### PR TITLE
fix(ui): 통합 모델 셀렉트 사후 안정화 — 위치/이벤트/모달/모델 fallback

### DIFF
--- a/backend/api/src/routes/model.routes.ts
+++ b/backend/api/src/routes/model.routes.ts
@@ -32,6 +32,57 @@ const router = Router();
 const logger = createLogger('ModelRoutes');
 
 /**
+ * Provider 별 fallback 모델 목록 — `/v1/models` API 호출 실패 또는 빈 배열 반환 시
+ * 사용자가 채팅을 시작할 수 있도록 제공하는 known 모델 카탈로그.
+ *
+ * Gemini OpenAI 호환 endpoint 등 일부 provider 가 `/v1/models` 미구현인 경우 대응.
+ */
+function getProviderFallbackModels(
+    providerId: string,
+): Array<{ id: string; fullId: string; displayName: string; capabilities: Record<string, boolean> }> {
+    const KNOWN_MODELS: Record<string, Array<{ id: string; displayName: string; capabilities: Record<string, boolean> }>> = {
+        gemini: [
+            { id: 'gemini-2.5-pro',           displayName: 'Gemini 2.5 Pro',           capabilities: { streaming: true, toolCalling: true, vision: true, thinking: false, embedding: false } },
+            { id: 'gemini-2.5-flash',         displayName: 'Gemini 2.5 Flash',         capabilities: { streaming: true, toolCalling: true, vision: true, thinking: false, embedding: false } },
+            { id: 'gemini-2.0-flash-exp',     displayName: 'Gemini 2.0 Flash (Exp)',   capabilities: { streaming: true, toolCalling: true, vision: true, thinking: false, embedding: false } },
+        ],
+        openrouter: [
+            { id: 'openai/gpt-5',                    displayName: 'GPT-5',                       capabilities: { streaming: true, toolCalling: true, vision: true, thinking: false, embedding: false } },
+            { id: 'anthropic/claude-opus-4.5',       displayName: 'Claude Opus 4.5',             capabilities: { streaming: true, toolCalling: true, vision: true, thinking: true, embedding: false } },
+            { id: 'anthropic/claude-sonnet-4.6',     displayName: 'Claude Sonnet 4.6',           capabilities: { streaming: true, toolCalling: true, vision: true, thinking: true, embedding: false } },
+            { id: 'google/gemini-2.5-pro',           displayName: 'Gemini 2.5 Pro (via OR)',     capabilities: { streaming: true, toolCalling: true, vision: true, thinking: false, embedding: false } },
+            { id: 'meta-llama/llama-3.3-70b-instruct', displayName: 'Llama 3.3 70B',             capabilities: { streaming: true, toolCalling: true, vision: false, thinking: false, embedding: false } },
+            { id: 'deepseek/deepseek-r1',            displayName: 'DeepSeek R1',                 capabilities: { streaming: true, toolCalling: true, vision: false, thinking: true, embedding: false } },
+        ],
+        groq: [
+            { id: 'llama-3.3-70b-versatile',  displayName: 'Llama 3.3 70B (Versatile)',  capabilities: { streaming: true, toolCalling: true, vision: false, thinking: false, embedding: false } },
+            { id: 'llama-3.1-8b-instant',     displayName: 'Llama 3.1 8B (Instant)',     capabilities: { streaming: true, toolCalling: true, vision: false, thinking: false, embedding: false } },
+        ],
+        together: [
+            { id: 'meta-llama/Llama-3.3-70B-Instruct-Turbo',  displayName: 'Llama 3.3 70B Turbo',  capabilities: { streaming: true, toolCalling: true, vision: false, thinking: false, embedding: false } },
+            { id: 'Qwen/Qwen2.5-72B-Instruct-Turbo',           displayName: 'Qwen 2.5 72B Turbo',   capabilities: { streaming: true, toolCalling: true, vision: false, thinking: false, embedding: false } },
+        ],
+        mistral: [
+            { id: 'mistral-large-latest',     displayName: 'Mistral Large',     capabilities: { streaming: true, toolCalling: true, vision: false, thinking: false, embedding: false } },
+            { id: 'mistral-medium-latest',    displayName: 'Mistral Medium',    capabilities: { streaming: true, toolCalling: true, vision: false, thinking: false, embedding: false } },
+            { id: 'codestral-latest',         displayName: 'Codestral',         capabilities: { streaming: true, toolCalling: true, vision: false, thinking: false, embedding: false } },
+        ],
+        cohere: [
+            { id: 'command-r-plus',           displayName: 'Command R+',        capabilities: { streaming: true, toolCalling: false, vision: false, thinking: false, embedding: false } },
+            { id: 'command-r',                displayName: 'Command R',         capabilities: { streaming: true, toolCalling: false, vision: false, thinking: false, embedding: false } },
+        ],
+    };
+    const known = KNOWN_MODELS[providerId];
+    if (!known) return [];
+    return known.map(m => ({
+        id: m.id,
+        fullId: buildFullModelId(providerId, m.id),
+        displayName: m.displayName,
+        capabilities: m.capabilities,
+    }));
+}
+
+/**
  * GET /model
  * 현재 모델 정보 API (프론트엔드 settings.js 호출용)
  * model-roles 레지스트리의 chat 역할 모델을 반환합니다.
@@ -136,7 +187,7 @@ router.get('/models', asyncHandler(async (req: Request, res: Response) => {
                         const cached = await repo.getCachedModels(userId, keyRow.providerId, cacheTtlMs);
                         let list: CachedModel[] | null = cached as CachedModel[] | null;
 
-                        if (!list) {
+                        if (!list || list.length === 0) {
                             const plaintextKey = await repo.decryptKey(userId, keyRow.providerId);
                             if (!plaintextKey) continue;
                             const provider = new OpenAICompatProvider({
@@ -145,17 +196,25 @@ router.get('/models', asyncHandler(async (req: Request, res: Response) => {
                                 baseUrl: keyRow.baseUrl,
                             });
                             const fresh = await provider.listModels();
-                            // ProviderModel[] 을 캐시-친화 형태로 직렬화
                             list = fresh.map((m) => ({
                                 id: m.id,
                                 fullId: m.fullId,
                                 displayName: m.displayName,
                                 capabilities: m.capabilities as unknown as Record<string, boolean>,
                             }));
-                            await repo.putCachedModels(userId, keyRow.providerId, list);
+                            // 빈 배열은 캐싱 안 함 (stale 영구화 방지) + provider별 fallback 모델 보강
+                            if (list.length === 0) {
+                                list = getProviderFallbackModels(keyRow.providerId);
+                                if (list.length > 0) {
+                                    logger.warn(`${keyRow.providerId} /v1/models 빈 배열 — fallback ${list.length}개 사용 (캐싱 skip)`);
+                                }
+                            } else {
+                                await repo.putCachedModels(userId, keyRow.providerId, list);
+                            }
                         }
 
                         const catalogDisplay = getProviderCatalogEntry(keyRow.providerId)?.displayName ?? keyRow.providerId;
+                        if (!list) continue;
                         for (const m of list) {
                             const caps = m.capabilities;
                             models.push({

--- a/frontend/web/public/css/model-selector.css
+++ b/frontend/web/public/css/model-selector.css
@@ -31,7 +31,7 @@
 .model-selector-dropdown {
     position: absolute;
     bottom: calc(100% + 4px);
-    left: 0;
+    right: 0;
     min-width: 320px;
     max-width: 480px;
     max-height: 420px;

--- a/frontend/web/public/css/model-selector.css
+++ b/frontend/web/public/css/model-selector.css
@@ -102,3 +102,80 @@
     color: var(--text-primary);
 }
 .model-action-menu .menu-item:hover { background: var(--bg-tertiary); }
+
+/* AddKeyModal / UsageModal 내부 box — CSP 호환 (inline style 회피) */
+.ek-modal-box {
+    max-width: 480px;
+    width: 100%;
+    background: var(--bg-card);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-lg);
+    padding: 0;
+    box-shadow: var(--shadow-lg);
+    color: var(--text-primary);
+}
+.ek-modal-box.wide { max-width: 720px; }
+.ek-modal-box-header {
+    padding: var(--space-4) var(--space-5);
+    border-bottom: 1px solid var(--border-light);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.ek-modal-box-header h3 { margin: 0; font-size: var(--font-size-lg); }
+.ek-modal-box-close {
+    background: none;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+    color: var(--text-muted);
+    padding: 0 8px;
+}
+.ek-modal-box-body {
+    padding: var(--space-5);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+}
+.ek-modal-box-body.scrollable { max-height: 60vh; overflow-y: auto; }
+.ek-modal-box-body label {
+    font-size: var(--font-size-sm);
+    color: var(--text-secondary);
+    display: block;
+}
+.ek-modal-box-body input[type="text"],
+.ek-modal-box-body input[type="password"] {
+    width: 100%;
+    padding: var(--space-2) var(--space-3);
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-md);
+    color: var(--text-primary);
+    box-sizing: border-box;
+    margin-top: 4px;
+}
+.ek-modal-box-body input[type="password"] { font-family: monospace; }
+.ek-modal-box-footer {
+    padding: var(--space-4) var(--space-5);
+    border-top: 1px solid var(--border-light);
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-2);
+}
+.ek-modal-btn-primary {
+    padding: var(--space-2) var(--space-4);
+    background: var(--accent-primary);
+    border: none;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    color: #fff;
+    font-weight: var(--font-weight-semibold);
+}
+.ek-modal-btn-secondary {
+    padding: var(--space-2) var(--space-4);
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    color: var(--text-primary);
+}

--- a/frontend/web/public/index.html
+++ b/frontend/web/public/index.html
@@ -25,7 +25,7 @@
     <link rel="stylesheet" href="css/feature-cards.css?v=8">
     <link rel="stylesheet" href="css/layout.css?v=8">
     <link rel="stylesheet" href="css/components.css?v=8">
-    <link rel="stylesheet" href="css/model-selector.css?v=1">
+    <link rel="stylesheet" href="css/model-selector.css?v=2">
      <link rel="stylesheet" href="css/unified-sidebar.css?v=9">
     <link rel="stylesheet" href="css/light-theme.css?v=8">
     <link rel="stylesheet" href="style.css?v=9">
@@ -136,7 +136,6 @@
                                 aria-label="메시지 입력" onkeydown="handleKeyDown(event)"></textarea>
                             <div class="input-actions">
                                 <div class="left-actions">
-                                    <div id="modelSelectorMount" style="margin-right:8px"></div>
                                     <button class="action-btn" onclick="newChat()" title="새 대화 (+)">
                                         <svg width="20" height="20" viewBox="0 0 24 24" fill="none"
                                             stroke="currentColor" stroke-width="2">
@@ -178,6 +177,7 @@
                                         <span class="status-dot"></span>
                                         <span class="status-text">연결됨</span>
                                     </div>
+                                    <div id="modelSelectorMount" style="margin-right:8px"></div>
                                     <button class="send-btn" id="sendBtn" title="전송 (Enter)">
                                         <svg width="20" height="20" viewBox="0 0 24 24" fill="none"
                                             stroke="currentColor" stroke-width="2">

--- a/frontend/web/public/index.html
+++ b/frontend/web/public/index.html
@@ -25,7 +25,7 @@
     <link rel="stylesheet" href="css/feature-cards.css?v=8">
     <link rel="stylesheet" href="css/layout.css?v=8">
     <link rel="stylesheet" href="css/components.css?v=8">
-    <link rel="stylesheet" href="css/model-selector.css?v=2">
+    <link rel="stylesheet" href="css/model-selector.css?v=3">
      <link rel="stylesheet" href="css/unified-sidebar.css?v=9">
     <link rel="stylesheet" href="css/light-theme.css?v=8">
     <link rel="stylesheet" href="style.css?v=9">

--- a/frontend/web/public/js/main.js
+++ b/frontend/web/public/js/main.js
@@ -690,7 +690,10 @@ window._appInitialized = true;
 // ============================================
 async function _mountModelSelector() {
     const target = document.getElementById('modelSelectorMount');
-    if (!target) return;
+    if (!target) {
+        console.warn('[main] #modelSelectorMount 미발견 — ModelSelector 미마운트');
+        return;
+    }
     try {
         // 보조 컴포넌트 사전 로드 (window.* 글로벌 노출)
         await Promise.all([
@@ -698,11 +701,14 @@ async function _mountModelSelector() {
             import('./modules/components/usage-modal.js'),
             import('./modules/components/model-action-menu.js'),
         ]);
+        console.info('[main] AddKeyModal/UsageModal/ModelActionMenu 로드 완료');
         const mod = await import('./modules/components/model-selector.js');
         await mod.default.mount(target);
         window.ModelSelector = mod.default;
+        console.info('[main] ModelSelector 마운트 완료',
+            { hasAddKeyModal: !!window.AddKeyModal, hasUsageModal: !!window.UsageModal, hasModelActionMenu: !!window.ModelActionMenu });
     } catch (e) {
-        console.warn('[main] ModelSelector mount 실패:', e);
+        console.error('[main] ModelSelector mount 실패:', e);
     }
 }
 if (document.readyState === 'loading') {

--- a/frontend/web/public/js/modules/components/add-key-modal.js
+++ b/frontend/web/public/js/modules/components/add-key-modal.js
@@ -31,15 +31,15 @@ async function authFetch(url, opts) {
 function ensure() {
     if (_modal) return _modal;
     _modal = document.createElement('div');
+    // 본 프로젝트 modal 시스템 호환 — components.css의 .modal-overlay.active 패턴 따름
     _modal.className = 'modal-overlay';
     _modal.id = 'addKeyModalOverlay';
-    _modal.style.cssText = 'display:none;position:fixed;inset:0;background:rgba(0,0,0,0.5);z-index:1000;align-items:center;justify-content:center';
     document.body.appendChild(_modal);
     return _modal;
 }
 
 export function close() {
-    if (_modal) _modal.style.display = 'none';
+    if (_modal) _modal.classList.remove('active');
     if (_clickHandler && _modal) {
         _modal.removeEventListener('click', _clickHandler);
         _clickHandler = null;
@@ -85,7 +85,7 @@ function render(provider) {
         '</div>' +
         '</div>';
 
-    _modal.style.display = 'flex';
+    _modal.classList.add('active');
 
     _clickHandler = function (ev) {
         const action = ev.target.closest('[data-action]');
@@ -134,12 +134,27 @@ async function save() {
     }
 }
 
+function logDbg(msg) {
+    try {
+        const panel = document.getElementById('ms-debug-panel');
+        if (panel) {
+            const line = document.createElement('div');
+            line.textContent = '[' + new Date().toLocaleTimeString() + '] [AddKeyModal] ' + msg;
+            panel.appendChild(line);
+            panel.scrollTop = panel.scrollHeight;
+        }
+    } catch (_) {}
+    try { console.info('[AddKeyModal]', msg); } catch (_) {}
+}
+
 export async function open(opts) {
     ensure();
+    logDbg('open(' + opts.providerId + ') 시작');
     _currentProvider = null;
     _onSuccess = opts.onSuccess || null;
     const res = await authFetch('/api/external-keys');
     if (!res.ok) {
+        logDbg('  ✗ /api/external-keys ' + res.status + ' — 로그인 필요');
         if (window.showToast) window.showToast('카탈로그 로드 실패 (로그인 필요)', 'error');
         return;
     }
@@ -147,10 +162,13 @@ export async function open(opts) {
     const providers = (json.data && json.data.providers) || [];
     _currentProvider = providers.find(p => p.provider_id === opts.providerId);
     if (!_currentProvider) {
+        logDbg('  ✗ providers 에 ' + opts.providerId + ' 미발견 (' + providers.length + ' 개)');
         if (window.showToast) window.showToast('Provider 미발견: ' + opts.providerId, 'error');
         return;
     }
+    logDbg('  ✓ provider 매치, render() 호출');
     render(_currentProvider);
+    logDbg('  ✓ modal active 적용 (display=' + getComputedStyle(_modal).display + ')');
 }
 
 window.AddKeyModal = { open, close };

--- a/frontend/web/public/js/modules/components/add-key-modal.js
+++ b/frontend/web/public/js/modules/components/add-key-modal.js
@@ -53,35 +53,31 @@ function render(provider) {
     const supportsOAuth = (provider.auth_methods || ['api_key']).includes('oauth');
 
     _modal.innerHTML =
-        '<div class="modal" style="max-width:480px;background:var(--bg-card);border-radius:var(--radius-lg);padding:0;box-shadow:var(--shadow-lg)">' +
-        '<div class="modal-header" style="padding:var(--space-4) var(--space-5);border-bottom:1px solid var(--border-light);display:flex;justify-content:space-between;align-items:center">' +
-        '<h3 style="margin:0;font-size:var(--font-size-lg)">' + escText(provider.display_name) + ' 키 등록</h3>' +
-        '<button data-action="close" style="background:none;border:none;font-size:24px;cursor:pointer;color:var(--text-muted)">&times;</button>' +
+        '<div class="ek-modal-box">' +
+        '<div class="ek-modal-box-header">' +
+        '<h3>' + escText(provider.display_name) + ' 키 등록</h3>' +
+        '<button type="button" class="ek-modal-box-close" data-action="close">&times;</button>' +
         '</div>' +
-        '<div class="modal-body" style="padding:var(--space-5);display:flex;flex-direction:column;gap:var(--space-3)">' +
+        '<div class="ek-modal-box-body">' +
         (supportsOAuth
-            ? '<div style="font-size:var(--font-size-sm)">인증 방식:<br>' +
-              '<label style="margin-right:12px"><input type="radio" name="authMethod" value="api_key" checked> API Key 직접 입력</label>' +
+            ? '<div>인증 방식:<br>' +
+              '<label><input type="radio" name="authMethod" value="api_key" checked> API Key 직접 입력</label> ' +
               '<label style="color:var(--text-muted)"><input type="radio" name="authMethod" value="oauth" disabled> OAuth (Phase 2 예정)</label>' +
               '</div>'
             : '') +
-        '<label style="font-size:var(--font-size-sm);color:var(--text-secondary)">표시 이름' +
-        '<input type="text" id="ek-name" value="' + escAttr(provider.display_name) +
-        '" style="width:100%;padding:var(--space-2) var(--space-3);background:var(--bg-tertiary);border:1px solid var(--border-light);border-radius:var(--radius-md);color:var(--text-primary);box-sizing:border-box;margin-top:4px" /></label>' +
+        '<label>표시 이름' +
+        '<input type="text" id="ek-name" value="' + escAttr(provider.display_name) + '" /></label>' +
         (isOpenAICompat
-            ? '<label style="font-size:var(--font-size-sm);color:var(--text-secondary)">Base URL' +
-              '<input type="text" id="ek-baseurl" value="' + escAttr(provider.default_base_url) +
-              '" style="width:100%;padding:var(--space-2) var(--space-3);background:var(--bg-tertiary);border:1px solid var(--border-light);border-radius:var(--radius-md);color:var(--text-primary);box-sizing:border-box;margin-top:4px" /></label>'
+            ? '<label>Base URL<input type="text" id="ek-baseurl" value="' + escAttr(provider.default_base_url) + '" /></label>'
             : '') +
-        '<label style="font-size:var(--font-size-sm);color:var(--text-secondary)">API Key' +
-        '<input type="password" id="ek-key" placeholder="' + escAttr(provider.key_prefix_pattern || '키 입력') +
-        '" autocomplete="off" style="width:100%;padding:var(--space-2) var(--space-3);background:var(--bg-tertiary);border:1px solid var(--border-light);border-radius:var(--radius-md);color:var(--text-primary);box-sizing:border-box;margin-top:4px;font-family:monospace" /></label>' +
+        '<label>API Key' +
+        '<input type="password" id="ek-key" placeholder="' + escAttr(provider.key_prefix_pattern || '키 입력') + '" autocomplete="off" /></label>' +
         '<div style="font-size:11px;color:var(--text-muted)">' + escText(provider.help_text || '') + '</div>' +
         '<div style="font-size:11px;color:var(--text-muted)">※ 사용량은 본 서비스가 아닌 ' + escText(provider.display_name) + ' 계정으로 청구됩니다.</div>' +
         '</div>' +
-        '<div class="modal-footer" style="padding:var(--space-4) var(--space-5);border-top:1px solid var(--border-light);display:flex;justify-content:flex-end;gap:var(--space-2)">' +
-        '<button data-action="close" style="padding:var(--space-2) var(--space-4);background:var(--bg-tertiary);border:1px solid var(--border-light);border-radius:var(--radius-md);cursor:pointer;color:var(--text-primary)">취소</button>' +
-        '<button data-action="save" style="padding:var(--space-2) var(--space-4);background:var(--accent-primary);border:none;border-radius:var(--radius-md);cursor:pointer;color:#fff;font-weight:var(--font-weight-semibold)">등록</button>' +
+        '<div class="ek-modal-box-footer">' +
+        '<button type="button" class="ek-modal-btn-secondary" data-action="close">취소</button>' +
+        '<button type="button" class="ek-modal-btn-primary" data-action="save">등록</button>' +
         '</div>' +
         '</div>';
 
@@ -168,7 +164,15 @@ export async function open(opts) {
     }
     logDbg('  ✓ provider 매치, render() 호출');
     render(_currentProvider);
-    logDbg('  ✓ modal active 적용 (display=' + getComputedStyle(_modal).display + ')');
+    const overlayStyle = getComputedStyle(_modal);
+    const innerBox = _modal.querySelector('.ek-modal-box');
+    const innerRect = innerBox ? innerBox.getBoundingClientRect() : null;
+    const innerStyle = innerBox ? getComputedStyle(innerBox) : null;
+    logDbg('  ✓ overlay display=' + overlayStyle.display +
+        ' z=' + overlayStyle.zIndex + ' bg=' + overlayStyle.backgroundColor.slice(0, 30));
+    logDbg('  ✓ inner box: ' + (innerBox ? 'exists' : 'NULL') +
+        (innerRect ? ' rect=' + Math.round(innerRect.width) + 'x' + Math.round(innerRect.height) : '') +
+        (innerStyle ? ' bg=' + innerStyle.backgroundColor.slice(0, 30) : ''));
 }
 
 window.AddKeyModal = { open, close };

--- a/frontend/web/public/js/modules/components/model-selector.js
+++ b/frontend/web/public/js/modules/components/model-selector.js
@@ -387,7 +387,11 @@ export async function mount(targetElement) {
 }
 
 export function refresh() {
+    logDebug('refresh 호출');
     return loadData().then(() => {
+        const grouped = groupModelsByProvider();
+        const summary = Object.keys(grouped).map(p => p + '=' + grouped[p].length).join(', ');
+        logDebug('refresh 완료 — models=' + _models.length + ' (' + summary + ')');
         renderTrigger();
         if (_isOpen) renderDropdown();
     });

--- a/frontend/web/public/js/modules/components/model-selector.js
+++ b/frontend/web/public/js/modules/components/model-selector.js
@@ -14,6 +14,45 @@
 
 const STORAGE_KEY = 'selectedModel';
 
+// ============================================
+// Debug overlay — 임시 진단용 (운영 안정 후 제거)
+// 사용자가 콘솔 못 보는 환경에서 화면 우상단에 모든 ModelSelector 이벤트 표시.
+// localStorage.setItem('MS_DEBUG_OFF', '1') 하면 비활성.
+// ============================================
+function logDebug(msg) {
+    try { console.info('[ModelSelector]', msg); } catch (_) {}
+    if (localStorage.getItem('MS_DEBUG_OFF') === '1') return;
+    let panel = document.getElementById('ms-debug-panel');
+    if (!panel) {
+        panel = document.createElement('div');
+        panel.id = 'ms-debug-panel';
+        panel.style.cssText =
+            'position:fixed;top:8px;right:8px;background:rgba(0,0,0,0.85);color:#0f0;' +
+            'padding:8px 12px;font-size:11px;font-family:monospace;border-radius:6px;' +
+            'z-index:99999;max-width:420px;max-height:60vh;overflow-y:auto;line-height:1.4;' +
+            'box-shadow:0 4px 12px rgba(0,0,0,0.5)';
+        const closeBtn = document.createElement('button');
+        closeBtn.textContent = '✕ close';
+        closeBtn.style.cssText = 'position:absolute;top:4px;right:4px;background:#333;color:#fff;border:none;cursor:pointer;font-size:10px;padding:2px 6px;border-radius:3px';
+        closeBtn.onclick = function () {
+            panel.remove();
+            try { localStorage.setItem('MS_DEBUG_OFF', '1'); } catch (_) {}
+        };
+        const title = document.createElement('div');
+        title.textContent = '🔍 ModelSelector 진단 (close=비활성)';
+        title.style.cssText = 'color:#ff0;margin-bottom:4px;font-weight:bold';
+        panel.appendChild(closeBtn);
+        panel.appendChild(title);
+        document.body.appendChild(panel);
+    }
+    const line = document.createElement('div');
+    const ts = new Date().toLocaleTimeString();
+    line.textContent = '[' + ts + '] ' + msg;
+    panel.appendChild(line);
+    while (panel.children.length > 25) panel.removeChild(panel.children[2]);
+    panel.scrollTop = panel.scrollHeight;
+}
+
 const PROVIDER_LABELS = {
     ollama: '🖥️ Ollama 로컬',
     anthropic: '🧠 Anthropic Claude',
@@ -196,6 +235,11 @@ function renderDropdown() {
  * 이벤트 위임이 실패하는 환경(레이어 z-index, 부모 핸들러 중복 등) 회피.
  */
 function bindDropdownHandlers(dropdown) {
+    const optionCount = dropdown.querySelectorAll('.model-selector-option').length;
+    const addCount = dropdown.querySelectorAll('[data-action="add-key"]').length;
+    const menuCount = dropdown.querySelectorAll('[data-action="open-menu"]').length;
+    logDebug('dropdown 렌더 — opt=' + optionCount + ', +추가=' + addCount + ', ⋮=' + menuCount);
+
     // 모델 옵션 클릭 — 모델 변경
     dropdown.querySelectorAll('.model-selector-option').forEach((el) => {
         if (el.classList.contains('disabled')) return;
@@ -205,10 +249,12 @@ function bindDropdownHandlers(dropdown) {
             ev.preventDefault();
             ev.stopPropagation();
             const modelId = el.dataset.modelId;
-            console.info('[ModelSelector] 옵션 클릭:', modelId);
+            logDebug('✓ 옵션 클릭: ' + modelId);
             if (modelId) {
                 setSelectedModel(modelId);
                 closeDropdown();
+            } else {
+                logDebug('  ✗ modelId 비어있음 — dataset 누락');
             }
         });
     });
@@ -220,11 +266,11 @@ function bindDropdownHandlers(dropdown) {
             ev.stopPropagation();
             const providerId = el.dataset.provider;
             const modelId = el.dataset.modelId;
-            console.info('[ModelSelector] ⋮ 메뉴 클릭:', providerId);
+            logDebug('⋮ 메뉴 클릭: ' + providerId);
             if (window.ModelActionMenu) {
                 window.ModelActionMenu.open(el, { providerId, modelId });
             } else {
-                console.warn('[ModelSelector] window.ModelActionMenu 미정의');
+                logDebug('  ✗ window.ModelActionMenu 미정의');
             }
         });
     });
@@ -235,11 +281,11 @@ function bindDropdownHandlers(dropdown) {
             ev.preventDefault();
             ev.stopPropagation();
             const providerId = el.dataset.provider;
-            console.info('[ModelSelector] + 추가 클릭:', providerId);
+            logDebug('+ 추가 클릭: ' + providerId);
             if (window.AddKeyModal) {
                 window.AddKeyModal.open({ providerId, onSuccess: refresh });
             } else {
-                console.warn('[ModelSelector] window.AddKeyModal 미정의 — 모듈 로드 실패');
+                logDebug('  ✗ window.AddKeyModal 미정의');
                 if (window.showToast) window.showToast('등록 모달 로드 실패 — 페이지 새로고침 필요', 'error');
             }
             closeDropdown();
@@ -249,6 +295,7 @@ function bindDropdownHandlers(dropdown) {
 
 function toggleDropdown() {
     _isOpen = !_isOpen;
+    logDebug('toggle → ' + (_isOpen ? '열림' : '닫힘'));
     const dropdown = _container.querySelector('.model-selector-dropdown');
     if (dropdown) dropdown.classList.toggle('open', _isOpen);
     if (_isOpen) renderDropdown();
@@ -261,6 +308,7 @@ function closeDropdown() {
 }
 
 export async function mount(targetElement) {
+    logDebug('mount 시작');
     _container = document.createElement('div');
     _container.className = 'model-selector';
     _container.innerHTML =
@@ -327,6 +375,11 @@ export async function mount(targetElement) {
 
     await loadData();
     renderTrigger();
+    logDebug('mount 완료 — models=' + _models.length + ' / providers=' + _providers.length +
+        ' / auth=' + _isAuthenticated + ' / admin=' + _isAdmin +
+        ' / globals: AddKey=' + !!window.AddKeyModal +
+        ', Usage=' + !!window.UsageModal +
+        ', Menu=' + !!window.ModelActionMenu);
 
     if (location.search.includes('openModelSelector=1')) {
         toggleDropdown();

--- a/frontend/web/public/js/modules/components/model-selector.js
+++ b/frontend/web/public/js/modules/components/model-selector.js
@@ -89,12 +89,23 @@ function getSelectedModel() {
 }
 
 function setSelectedModel(modelId) {
-    localStorage.setItem(STORAGE_KEY, modelId);
+    try {
+        localStorage.setItem(STORAGE_KEY, modelId);
+    } catch (e) {
+        console.warn('[ModelSelector] localStorage 쓰기 실패 (incognito?):', e);
+    }
     renderTrigger();
     if (window.showToast) window.showToast('🤖 모델 변경됨: ' + modelId);
     if (typeof window.applyModelCapabilityToggles === 'function') {
-        window.applyModelCapabilityToggles(modelId);
+        try {
+            window.applyModelCapabilityToggles(modelId);
+        } catch (e) {
+            console.warn('[ModelSelector] applyModelCapabilityToggles 오류:', e);
+        }
     }
+    // chat.js 등이 settings select#modelSelect 를 읽는 경우 호환성 — 동일 값 동기화
+    const legacySel = document.getElementById('modelSelect');
+    if (legacySel) legacySel.value = modelId;
 }
 
 function renderTrigger() {
@@ -203,44 +214,58 @@ export async function mount(targetElement) {
     targetElement.appendChild(_container);
 
     _container.addEventListener('click', function (ev) {
-        const toggleBtn = ev.target.closest('[data-action="toggle"]');
-        if (toggleBtn) {
-            ev.stopPropagation();
-            toggleDropdown();
-            return;
-        }
-        const menuTrigger = ev.target.closest('[data-action="open-menu"]');
-        if (menuTrigger) {
-            ev.stopPropagation();
-            const providerId = menuTrigger.dataset.provider;
-            const modelId = menuTrigger.dataset.modelId;
-            if (window.ModelActionMenu) {
-                window.ModelActionMenu.open(menuTrigger, { providerId, modelId });
+        try {
+            const toggleBtn = ev.target.closest('[data-action="toggle"]');
+            if (toggleBtn) {
+                ev.preventDefault();
+                ev.stopPropagation();
+                toggleDropdown();
+                return;
             }
-            return;
-        }
-        const addOption = ev.target.closest('[data-action="add-key"]');
-        if (addOption) {
-            ev.stopPropagation();
-            const providerId = addOption.dataset.provider;
-            if (window.AddKeyModal) {
-                window.AddKeyModal.open({ providerId, onSuccess: refresh });
+            const menuTrigger = ev.target.closest('[data-action="open-menu"]');
+            if (menuTrigger) {
+                ev.preventDefault();
+                ev.stopPropagation();
+                const providerId = menuTrigger.dataset.provider;
+                const modelId = menuTrigger.dataset.modelId;
+                if (window.ModelActionMenu) {
+                    window.ModelActionMenu.open(menuTrigger, { providerId, modelId });
+                } else {
+                    console.warn('[ModelSelector] window.ModelActionMenu 미정의 — 모듈 로드 실패');
+                }
+                return;
             }
-            closeDropdown();
-            return;
-        }
-        const option = ev.target.closest('.model-selector-option');
-        if (option && !option.classList.contains('disabled')) {
-            const modelId = option.dataset.modelId;
-            if (modelId) {
-                setSelectedModel(modelId);
+            const addOption = ev.target.closest('[data-action="add-key"]');
+            if (addOption) {
+                ev.preventDefault();
+                ev.stopPropagation();
+                const providerId = addOption.dataset.provider;
+                if (window.AddKeyModal) {
+                    window.AddKeyModal.open({ providerId, onSuccess: refresh });
+                } else {
+                    console.warn('[ModelSelector] window.AddKeyModal 미정의 — 모듈 로드 실패');
+                    if (window.showToast) window.showToast('등록 모달 로드 실패 — 페이지 새로고침 필요', 'error');
+                }
                 closeDropdown();
+                return;
             }
+            const option = ev.target.closest('.model-selector-option');
+            if (option && !option.classList.contains('disabled')) {
+                ev.preventDefault();
+                ev.stopPropagation();
+                const modelId = option.dataset.modelId;
+                if (modelId) {
+                    setSelectedModel(modelId);
+                    closeDropdown();
+                }
+            }
+        } catch (err) {
+            console.error('[ModelSelector] 클릭 핸들러 오류:', err);
         }
     });
 
     document.addEventListener('click', function (ev) {
-        if (_isOpen && !_container.contains(ev.target)) closeDropdown();
+        if (_isOpen && _container && !_container.contains(ev.target)) closeDropdown();
     });
 
     await loadData();

--- a/frontend/web/public/js/modules/components/model-selector.js
+++ b/frontend/web/public/js/modules/components/model-selector.js
@@ -160,7 +160,7 @@ function renderDropdown() {
                 '" data-model-id="' + escAttr(m.modelId) + '" data-provider="' + escAttr(pid) + '">' +
                 '<span>' + (isActive ? '<span class="check">✓ </span>' : '') + escText(m.name) + '</span>' +
                 (pid !== 'ollama' && _isAuthenticated
-                    ? '<button class="menu-trigger" data-action="open-menu" data-provider="' +
+                    ? '<button type="button" class="menu-trigger" data-action="open-menu" data-provider="' +
                       escAttr(pid) + '" data-model-id="' + escAttr(m.modelId) + '" title="메뉴">⋮</button>'
                     : '') +
                 '</div>';
@@ -188,6 +188,63 @@ function renderDropdown() {
     }
 
     dropdown.innerHTML = html;
+    bindDropdownHandlers(dropdown);
+}
+
+/**
+ * 렌더된 dropdown 의 각 인터랙티브 element 에 직접 핸들러 부착.
+ * 이벤트 위임이 실패하는 환경(레이어 z-index, 부모 핸들러 중복 등) 회피.
+ */
+function bindDropdownHandlers(dropdown) {
+    // 모델 옵션 클릭 — 모델 변경
+    dropdown.querySelectorAll('.model-selector-option').forEach((el) => {
+        if (el.classList.contains('disabled')) return;
+        el.addEventListener('click', function (ev) {
+            // ⋮ 메뉴 trigger 클릭은 별도 처리 — option 클릭과 분리
+            if (ev.target.closest('[data-action="open-menu"]')) return;
+            ev.preventDefault();
+            ev.stopPropagation();
+            const modelId = el.dataset.modelId;
+            console.info('[ModelSelector] 옵션 클릭:', modelId);
+            if (modelId) {
+                setSelectedModel(modelId);
+                closeDropdown();
+            }
+        });
+    });
+
+    // ⋮ 메뉴 trigger 클릭
+    dropdown.querySelectorAll('[data-action="open-menu"]').forEach((el) => {
+        el.addEventListener('click', function (ev) {
+            ev.preventDefault();
+            ev.stopPropagation();
+            const providerId = el.dataset.provider;
+            const modelId = el.dataset.modelId;
+            console.info('[ModelSelector] ⋮ 메뉴 클릭:', providerId);
+            if (window.ModelActionMenu) {
+                window.ModelActionMenu.open(el, { providerId, modelId });
+            } else {
+                console.warn('[ModelSelector] window.ModelActionMenu 미정의');
+            }
+        });
+    });
+
+    // "+ 새 LLM 키 등록" 클릭
+    dropdown.querySelectorAll('[data-action="add-key"]').forEach((el) => {
+        el.addEventListener('click', function (ev) {
+            ev.preventDefault();
+            ev.stopPropagation();
+            const providerId = el.dataset.provider;
+            console.info('[ModelSelector] + 추가 클릭:', providerId);
+            if (window.AddKeyModal) {
+                window.AddKeyModal.open({ providerId, onSuccess: refresh });
+            } else {
+                console.warn('[ModelSelector] window.AddKeyModal 미정의 — 모듈 로드 실패');
+                if (window.showToast) window.showToast('등록 모달 로드 실패 — 페이지 새로고침 필요', 'error');
+            }
+            closeDropdown();
+        });
+    });
 }
 
 function toggleDropdown() {
@@ -207,7 +264,7 @@ export async function mount(targetElement) {
     _container = document.createElement('div');
     _container.className = 'model-selector';
     _container.innerHTML =
-        '<button class="model-selector-trigger" data-action="toggle">' +
+        '<button type="button" class="model-selector-trigger" data-action="toggle">' +
         '<span class="icon">📋</span><span class="name">로딩 중...</span><span class="arrow">▾</span>' +
         '</button>' +
         '<div class="model-selector-dropdown"></div>';

--- a/frontend/web/public/js/modules/components/model-selector.js
+++ b/frontend/web/public/js/modules/components/model-selector.js
@@ -187,7 +187,12 @@ function renderDropdown() {
     for (const pid of PROVIDER_ORDER) {
         if (!groups[pid] || groups[pid].length === 0) continue;
         const label = PROVIDER_LABELS[pid] || pid;
-        html += '<div class="model-selector-optgroup-label">' + escText(label) + '</div>';
+        const count = groups[pid].length;
+        // OpenWork pattern (provider-auth-modal.tsx:42 modelCount) — 카탈로그 entry 옆에 모델 수 표시
+        html += '<div class="model-selector-optgroup-label">' +
+            escText(label) +
+            ' <span style="opacity:0.6;font-weight:normal">(' + count + ')</span>' +
+            '</div>';
         for (const m of groups[pid]) {
             const isActive = m.modelId === selected;
             const isOllama = pid === 'ollama';

--- a/frontend/web/public/js/modules/components/usage-modal.js
+++ b/frontend/web/public/js/modules/components/usage-modal.js
@@ -52,12 +52,12 @@ export async function open(opts) {
     opts = opts || {};
     ensure();
     _modal.innerHTML =
-        '<div class="modal" style="max-width:720px;width:90%;background:var(--bg-card);border-radius:var(--radius-lg);padding:0;box-shadow:var(--shadow-lg)">' +
-        '<div class="modal-header" style="padding:var(--space-4) var(--space-5);border-bottom:1px solid var(--border-light);display:flex;justify-content:space-between;align-items:center">' +
-        '<h3 style="margin:0;font-size:var(--font-size-lg)">📊 외부 LLM 사용량' +
-        (opts.providerId ? ' — ' + escText(opts.providerId) : '') +
-        '</h3><button data-action="close" style="background:none;border:none;font-size:24px;cursor:pointer;color:var(--text-muted)">&times;</button></div>' +
-        '<div class="modal-body" id="usage-modal-body" style="padding:var(--space-5);max-height:60vh;overflow-y:auto">' +
+        '<div class="ek-modal-box wide">' +
+        '<div class="ek-modal-box-header">' +
+        '<h3>📊 외부 LLM 사용량' + (opts.providerId ? ' — ' + escText(opts.providerId) : '') + '</h3>' +
+        '<button type="button" class="ek-modal-box-close" data-action="close">&times;</button>' +
+        '</div>' +
+        '<div class="ek-modal-box-body scrollable" id="usage-modal-body">' +
         '<div style="color:var(--text-muted)">불러오는 중...</div>' +
         '</div></div>';
     _modal.classList.add('active');

--- a/frontend/web/public/js/modules/components/usage-modal.js
+++ b/frontend/web/public/js/modules/components/usage-modal.js
@@ -36,13 +36,12 @@ function ensure() {
     _modal = document.createElement('div');
     _modal.className = 'modal-overlay';
     _modal.id = 'usageModalOverlay';
-    _modal.style.cssText = 'display:none;position:fixed;inset:0;background:rgba(0,0,0,0.5);z-index:1000;align-items:center;justify-content:center';
     document.body.appendChild(_modal);
     return _modal;
 }
 
 export function close() {
-    if (_modal) _modal.style.display = 'none';
+    if (_modal) _modal.classList.remove('active');
     if (_clickHandler && _modal) {
         _modal.removeEventListener('click', _clickHandler);
         _clickHandler = null;
@@ -61,7 +60,7 @@ export async function open(opts) {
         '<div class="modal-body" id="usage-modal-body" style="padding:var(--space-5);max-height:60vh;overflow-y:auto">' +
         '<div style="color:var(--text-muted)">불러오는 중...</div>' +
         '</div></div>';
-    _modal.style.display = 'flex';
+    _modal.classList.add('active');
 
     _clickHandler = function (ev) {
         if (ev.target.closest('[data-action="close"]')) close();


### PR DESCRIPTION
## Summary
PR #10 (통합 모델 셀렉트) 머지 후 사용자 라이브 테스트에서 발견된 4단계 이슈를 점진적으로 해결한 8개 commit 통합.

## 8 commits 분류

### 위치 조정
- ee087e8: ModelSelector 좌측 left-actions → 우측 끝 right-actions (send 버튼 직전), dropdown 정렬 right:0

### 이벤트/클릭 핸들링
- 69c031f: 클릭 핸들러 방어 + try/catch + console 진단 로그
- d88ca3f: 이벤트 위임 → 직접 addEventListener (각 옵션/⋮/+추가 element 별도 부착)

### 디버그 가시화
- 9f056ee: 페이지 우상단 visible debug overlay — 콘솔 안 봐도 mount/click/render 이벤트 timestamp + 메시지로 표시

### 모달 가시화 (2단계)
- c09a6aa: `.modal-overlay.active` 클래스 토글 (components.css 패턴 일관)
- ba34627: 내부 `.ek-modal-box*` 클래스 기반 스타일 (CSP 호환, inline style 회피)

### 모델 노출 (Gemini 등 빈 /v1/models 응답 대응)
- 573f659: fallback 모델 카탈로그 (Gemini 3 / OpenRouter 6 / Groq 2 / Together 2 / Mistral 3 / Cohere 2) + 빈 배열 캐싱 차단
- d5400a8: dropdown 옆 (N) 모델 수 표시 (OpenWork modelCount 패턴 차용)

## 디자인 결정 보존
- Q1~Q7 (PR #10 spec) 그대로 유지
- 권한 정책: BYO + admin Ollama 변경
- 4 컴포넌트 boundary: ModelSelector / AddKeyModal / UsageModal / ModelActionMenu

## 회귀
- 1747 PASS / 11 사전 FAIL 동일

## Debug Overlay
운영 환경에서 우상단 검정 박스 표시. 사용자가 [✕ close] 클릭 시 영구 비활성 (`localStorage.MS_DEBUG_OFF=1`). 안정화 확인 후 별도 cleanup PR 예정.

## OpenWork 검토 결과
별도 메모리 (`reference_openwork_oauth.md`)에 Phase 2 OAuth 활성화 시 차용할 view state machine + polling 패턴 영구 기록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)