### PR TITLE
feat(usage): 일별 사용량 집계 endpoint + UsageModal 30일 누계 표시

### DIFF
--- a/backend/api/src/data/repositories/external-keys-repo.ts
+++ b/backend/api/src/data/repositories/external-keys-repo.ts
@@ -364,6 +364,55 @@ export class ExternalKeysRepository extends BaseRepository {
     }
 
     /**
+     * 사용자별 일별 사용량 집계 — UsageModal 차트 / 비용 추이용.
+     *
+     * @param days 조회 일수 (기본 30일)
+     * @returns 날짜별 + provider별 토큰/비용 합산
+     */
+    async listDailyUsage(
+        userId: string,
+        days: number = 30,
+    ): Promise<Array<{
+        day: string;
+        providerId: string;
+        callCount: number;
+        inputTokens: number;
+        outputTokens: number;
+        costUsdMicros: number;
+    }>> {
+        const result = await this.query<{
+            day: string;
+            provider_id: string;
+            call_count: string;
+            input_tokens: string;
+            output_tokens: string;
+            cost_usd_micros: string;
+        }>(
+            `SELECT
+                to_char(occurred_at AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS day,
+                provider_id,
+                COUNT(*)::text AS call_count,
+                SUM(input_tokens)::text AS input_tokens,
+                SUM(output_tokens)::text AS output_tokens,
+                SUM(cost_usd_micros)::text AS cost_usd_micros
+             FROM external_provider_usage
+             WHERE user_id = $1
+               AND occurred_at > NOW() - ($2 || ' days')::interval
+             GROUP BY day, provider_id
+             ORDER BY day DESC, provider_id ASC`,
+            [userId, days.toString()],
+        );
+        return result.rows.map((r) => ({
+            day: r.day,
+            providerId: r.provider_id,
+            callCount: Number(r.call_count),
+            inputTokens: Number(r.input_tokens),
+            outputTokens: Number(r.output_tokens),
+            costUsdMicros: Number(r.cost_usd_micros),
+        }));
+    }
+
+    /**
      * 키 삭제 (소프트 비활성화) — DB row는 audit를 위해 보존하고 is_active=false 처리.
      */
     async deactivate(userId: string, providerId: string): Promise<boolean> {

--- a/backend/api/src/routes/external-keys.routes.ts
+++ b/backend/api/src/routes/external-keys.routes.ts
@@ -218,6 +218,48 @@ router.get('/usage/recent',
     }),
 );
 
+router.get('/usage/summary',
+    requireAuth,
+    asyncHandler(async (req: Request, res: Response) => {
+        const userId = getUserId(req);
+        if (!userId) {
+            res.status(401).json(unauthorized('User ID not found.'));
+            return;
+        }
+        const days = Math.min(parseInt(req.query.days as string, 10) || 30, 90);
+        const rows = await getRepo().listDailyUsage(userId, days);
+
+        // provider별 누계
+        const totalsByProvider: Record<string, { calls: number; inTokens: number; outTokens: number; costMicros: number }> = {};
+        for (const r of rows) {
+            const t = totalsByProvider[r.providerId] = totalsByProvider[r.providerId] || { calls: 0, inTokens: 0, outTokens: 0, costMicros: 0 };
+            t.calls += r.callCount;
+            t.inTokens += r.inputTokens;
+            t.outTokens += r.outputTokens;
+            t.costMicros += r.costUsdMicros;
+        }
+
+        res.json(success({
+            days,
+            daily: rows.map(r => ({
+                day: r.day,
+                provider_id: r.providerId,
+                call_count: r.callCount,
+                input_tokens: r.inputTokens,
+                output_tokens: r.outputTokens,
+                cost_usd_micros: r.costUsdMicros,
+            })),
+            totals_by_provider: Object.entries(totalsByProvider).map(([providerId, t]) => ({
+                provider_id: providerId,
+                call_count: t.calls,
+                input_tokens: t.inTokens,
+                output_tokens: t.outTokens,
+                cost_usd_micros: t.costMicros,
+            })),
+        }));
+    }),
+);
+
 router.post('/:providerId/validate',
     requireAuth,
     asyncHandler(async (req: Request, res: Response) => {

--- a/frontend/web/public/js/modules/components/usage-modal.js
+++ b/frontend/web/public/js/modules/components/usage-modal.js
@@ -85,11 +85,36 @@ export async function open(opts) {
     const totalOut = rows.reduce((s, r) => s + (r.output_tokens || 0), 0);
     const totalCost = rows.reduce((s, r) => s + (r.cost_usd_micros || 0), 0);
 
-    body.innerHTML =
+    // 30일 daily summary 시도 (실패해도 raw 표는 그대로 표시)
+    let summaryHtml = '';
+    try {
+        const sumRes = await authFetch('/api/external-keys/usage/summary?days=30');
+        if (sumRes.ok) {
+            const sumJson = await sumRes.json();
+            const totalsByProvider = (sumJson.data && sumJson.data.totals_by_provider) || [];
+            if (totalsByProvider.length > 0) {
+                summaryHtml =
+                    '<div style="margin-bottom:12px;padding:8px 12px;background:var(--bg-tertiary);border-radius:6px;font-size:12px">' +
+                    '<div style="color:var(--text-muted);margin-bottom:6px">📅 최근 30일 provider별 누계</div>' +
+                    '<table style="width:100%;font-size:12px"><tbody>' +
+                    totalsByProvider.map((t) =>
+                        '<tr>' +
+                        '<td style="padding:2px 0">' + escText(t.provider_id) + '</td>' +
+                        '<td style="text-align:right;color:var(--text-muted)">호출 ' + t.call_count.toLocaleString() + '</td>' +
+                        '<td style="text-align:right;color:var(--text-muted)">' + (t.input_tokens + t.output_tokens).toLocaleString() + ' tok</td>' +
+                        '<td style="text-align:right;color:var(--accent-primary)">' + escText(fmtUsd(t.cost_usd_micros)) + '</td>' +
+                        '</tr>'
+                    ).join('') +
+                    '</tbody></table></div>';
+            }
+        }
+    } catch (_) { /* summary 실패 → 기본 표만 */ }
+
+    body.innerHTML = summaryHtml +
         '<div style="margin-bottom:12px;color:var(--text-secondary);font-size:var(--font-size-sm)">' +
-        rows.length + '건 — 입력 ' + totalIn.toLocaleString() + ' / 출력 ' + totalOut.toLocaleString() +
-        ' 토큰, 비용 누계 <b>' + escText(fmtUsd(totalCost)) +
-        '</b> <span style="color:var(--text-muted);font-size:11px">(추정 — 정확한 청구는 각 provider 콘솔 참조)</span></div>' +
+        '🕒 직전 ' + rows.length + '건 — 입력 ' + totalIn.toLocaleString() + ' / 출력 ' + totalOut.toLocaleString() +
+        ' 토큰, 비용 <b>' + escText(fmtUsd(totalCost)) +
+        '</b> <span style="color:var(--text-muted);font-size:11px">(추정 — 정확한 청구는 각 provider 콘솔)</span></div>' +
         '<table style="width:100%;border-collapse:collapse;font-size:13px">' +
         '<thead><tr style="text-align:left;color:var(--text-muted);border-bottom:1px solid var(--border-light)">' +
         '<th style="padding:6px 0">시각</th><th>Provider</th><th>모델</th>' +


### PR DESCRIPTION
## Summary
외부 LLM 사용량 가시성 강화 — provider 별 30일 누계를 한눈에.

## 신규
- \`ExternalKeysRepository.listDailyUsage(userId, days=30)\`: SQL date 그룹화 + provider별 합산
- \`GET /api/external-keys/usage/summary?days=N\` (max 90): { daily, totals_by_provider }

## UsageModal 강화
직전 50건 raw 표 위에 '📅 최근 30일 provider별 누계' 박스 추가:
- provider별 호출수 / 누계 토큰 / 누계 비용 USD
- summary fetch 실패 시 raw 표만 그대로 (graceful degrade)

## 회귀
1747 PASS / 11 사전 FAIL 동일.

🤖 Generated with [Claude Code](https://claude.com/claude-code)