### PR TITLE
fix(chat): 외부 LLM 에 웹검색 결과 + 언어 system prompt 전달 — 오답 fix

### DIFF
--- a/backend/api/src/services/ChatService.ts
+++ b/backend/api/src/services/ChatService.ts
@@ -820,6 +820,28 @@ export class ChatService {
     ): Promise<string> {
         const messages: ChatMessage[] = [];
 
+        // System prompt — 외부 모델도 일관된 페르소나/언어 유지
+        const systemPromptParts: string[] = [];
+        const langCode = req.userLanguagePreference;
+        if (langCode) {
+            const langMap: Record<string, string> = {
+                ko: '한국어', en: 'English', ja: '日本語', zh: '中文',
+                es: 'Español', fr: 'Français', de: 'Deutsch',
+            };
+            const langName = langMap[langCode] || langCode;
+            systemPromptParts.push(`Respond in ${langName}.`);
+        }
+        // 외부 모델은 strategies 우회이므로 webSearchContext 를 system 으로 주입 — 검색 결과 활용 보장
+        if (req.webSearchContext) {
+            systemPromptParts.push(
+                '아래 웹검색 결과를 바탕으로 정확한 답변을 제공하세요. 결과에 없는 정보는 추측하지 말고 모른다고 답하세요.\n\n' +
+                req.webSearchContext,
+            );
+        }
+        if (systemPromptParts.length > 0) {
+            messages.push({ role: 'system', content: systemPromptParts.join('\n\n') });
+        }
+
         for (const h of req.history ?? []) {
             const role = h.role === 'user' || h.role === 'assistant' || h.role === 'system'
                 ? h.role


### PR DESCRIPTION
## Summary
사용자 보고 — '웹검색 MCP 활성화하고 질문했는데 외부 모델이 오답'.

## 원인
ChatService.streamFromExternalProvider (PR #7 P3.6) 가 \`req.webSearchContext\` 를 누락하고 있어 외부 LLM 이 internal knowledge 로만 응답.

## Fix
- 외부 dispatch 직전 system 메시지 조립
- userLanguagePreference → '한국어/English/日本語/中文/...' 응답 언어 명시
- webSearchContext 있으면 system 에 '아래 검색 결과를 바탕으로 정확한 답변, 결과에 없는 정보는 추측 금지' 와 함께 주입

ws-chat-handler 의 pre-chat 웹검색 결과 (사용자 우커밋 변경) 가 이제 외부 모델에도 정상 전달됨.

## 회귀
1747 PASS / 11 사전 FAIL 동일.

🤖 Generated with [Claude Code](https://claude.com/claude-code)