### PR TITLE
feat+perf: env schema 통합 + 페이지네이션 + WS backpressure

### DIFF
--- a/backend/api/src/config/env.schema.ts
+++ b/backend/api/src/config/env.schema.ts
@@ -17,7 +17,13 @@ const supportedLanguageSchema = z.enum([
     'hi', 'it', 'nl', 'sv', 'da', 'no', 'fi', 'th', 'vi', 'tr'
 ]);
 
-const nodeEnvSchema = z.enum(['development', 'test', 'production']);
+// dev/test 외 모든 환경 (production, staging, uat, qa, ...) 은 시크릿 강제 — token-crypto.ts SAFE_TO_SKIP_ENVS 와 일관.
+// staging/uat/qa 가 누락된 white-list 였던 기존 enum 은 deploy 시 silent token plaintext 위험을 만들었음.
+const nodeEnvSchema = z.enum(['development', 'test', 'production', 'staging', 'uat', 'qa']);
+const SAFE_ENVS_FOR_MISSING_SECRETS = new Set(['development', 'test']);
+function isUnsafeEnv(env: string | undefined): boolean {
+    return !SAFE_ENVS_FOR_MISSING_SECRETS.has(env ?? '');
+}
 const logLevelSchema = z.enum(['debug', 'info', 'warn', 'error']);
 const geminiThinkLevelSchema = z.enum(['low', 'medium', 'high']);
 
@@ -59,6 +65,9 @@ export const envSchema = z
         ADMIN_EMAILS: z.string().default(''),
         API_KEY_PEPPER: z.string().default(''),
         API_KEY_MAX_PER_USER: positiveIntWithDefault(5),
+        // OAuth 토큰 AES-256-GCM 키 — 64자리 hex (openssl rand -hex 32).
+        // dev/test 외 모든 환경 (production, staging, uat, qa) 에서 필수 — superRefine 검증.
+        TOKEN_ENCRYPTION_KEY: z.string().default(''),
 
         // Security — Blacklist Policy (additive; default 'open' preserves legacy behavior)
         BLACKLIST_FAIL_MODE: z.enum(['open', 'safe']).default('open'),
@@ -172,7 +181,9 @@ export const envSchema = z
         OMK_DISABLE_LLM_CLASSIFIER: z.string().optional(),
     })
     .superRefine((data, ctx) => {
-        if (data.NODE_ENV !== 'production') {
+        // dev/test 가 아닌 모든 환경 (production, staging, uat, qa, ...) 에서 시크릿 강제.
+        // 화이트리스트 (production 만 검사) 패턴은 staging silent fallback 위험을 만들어 사용 안 함.
+        if (!isUnsafeEnv(data.NODE_ENV)) {
             return;
         }
 
@@ -180,7 +191,7 @@ export const envSchema = z
             ctx.addIssue({
                 code: 'custom',
                 path: ['JWT_SECRET'],
-                message: 'JWT_SECRET must be at least 32 characters in production',
+                message: `JWT_SECRET must be at least 32 characters in ${data.NODE_ENV} environment`,
             });
         }
 
@@ -188,7 +199,23 @@ export const envSchema = z
             ctx.addIssue({
                 code: 'custom',
                 path: ['API_KEY_PEPPER'],
-                message: 'API_KEY_PEPPER is required in production for API key hashing security',
+                message: `API_KEY_PEPPER is required in ${data.NODE_ENV} environment for API key hashing security`,
+            });
+        }
+
+        // TOKEN_ENCRYPTION_KEY: 누락 시 OAuth 토큰 평문 저장 → DB 백업 노출 시 자격증명 유출.
+        // token-crypto.ts assertTokenEncryptionKeyForProduction 와 동일 규칙 — 부팅 더 빠른 시점에서 검출.
+        if (!data.TOKEN_ENCRYPTION_KEY || data.TOKEN_ENCRYPTION_KEY.length === 0) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['TOKEN_ENCRYPTION_KEY'],
+                message: `TOKEN_ENCRYPTION_KEY is required in ${data.NODE_ENV} environment (openssl rand -hex 32). OAuth tokens are stored plaintext without it.`,
+            });
+        } else if (data.TOKEN_ENCRYPTION_KEY.length !== 64) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['TOKEN_ENCRYPTION_KEY'],
+                message: `TOKEN_ENCRYPTION_KEY must be exactly 64 hex characters (32 bytes). Current length: ${data.TOKEN_ENCRYPTION_KEY.length}`,
             });
         }
     });

--- a/backend/api/src/config/env.ts
+++ b/backend/api/src/config/env.ts
@@ -105,6 +105,8 @@ export interface EnvConfig {
     // API Key Service
     apiKeyPepper: string;
     apiKeyMaxPerUser: number;
+    /** OAuth 토큰 AES-256-GCM 키 (64자리 hex). dev/test 외 환경에서 필수 — env.schema.ts superRefine 검증. */
+    tokenEncryptionKey: string;
 
     // Cookie Security (HTTPS 없이 production 운영 시 false로 설정)
     cookieSecure: boolean;
@@ -225,6 +227,7 @@ const DEFAULT_CONFIG: EnvConfig = {
     // API Key Service
     apiKeyPepper: '',
     apiKeyMaxPerUser: 5,
+    tokenEncryptionKey: '',
 
     // Cookie Security
     cookieSecure: false,
@@ -418,6 +421,7 @@ export function loadConfig(): EnvConfig {
         SWAGGER_BASE_URL: env('SWAGGER_BASE_URL'),
         API_KEY_PEPPER: env('API_KEY_PEPPER'),
         API_KEY_MAX_PER_USER: env('API_KEY_MAX_PER_USER'),
+        TOKEN_ENCRYPTION_KEY: env('TOKEN_ENCRYPTION_KEY'),
 
         // P2: Cost Tier & Domain Routing
         OMK_COST_TIER_DEFAULT: env('OMK_COST_TIER_DEFAULT'),
@@ -554,6 +558,7 @@ export function loadConfig(): EnvConfig {
         // API Key Service
         apiKeyPepper: parsed.API_KEY_PEPPER ?? DEFAULT_CONFIG.apiKeyPepper,
         apiKeyMaxPerUser: parsed.API_KEY_MAX_PER_USER ?? DEFAULT_CONFIG.apiKeyMaxPerUser,
+        tokenEncryptionKey: parsed.TOKEN_ENCRYPTION_KEY ?? DEFAULT_CONFIG.tokenEncryptionKey,
 
         // Pipeline Profile — Cost Tier & Domain Routing (P2)
         omkCostTierDefault: parsed.OMK_COST_TIER_DEFAULT ?? DEFAULT_CONFIG.omkCostTierDefault,

--- a/backend/api/src/config/timeouts.ts
+++ b/backend/api/src/config/timeouts.ts
@@ -185,6 +185,17 @@ export const WS_LIMITS = {
     MESSAGE_RATE_WINDOW_MS: Number(process.env.WS_MESSAGE_RATE_WINDOW_MS) || 10 * 1000,
     /** 윈도우 내 최대 메시지 수 — 기본 30개 */
     MESSAGE_RATE_MAX_PER_WINDOW: Number(process.env.WS_MESSAGE_RATE_MAX_PER_WINDOW) || 30,
+    /**
+     * Backpressure 임계 (bytes). bufferedAmount 가 이 값을 초과한 클라이언트는
+     * broadcast 시 skip 됨 — 슬로우 클라이언트가 이벤트 루프/메모리 점유 방지.
+     * 기본 1MB — 일반 cluster_event 메시지 (~수 KB) 수십 개가 큐에 쌓인 수준.
+     */
+    BROADCAST_BACKPRESSURE_THRESHOLD_BYTES: Number(process.env.WS_BROADCAST_BACKPRESSURE_THRESHOLD_BYTES) || 1 * 1024 * 1024,
+    /**
+     * 위 임계를 N회 연속 초과한 클라이언트는 강제 종료 (terminate). 0 = 종료 안 함.
+     * 기본 5회 — 일시적 네트워크 spike 는 허용, 만성적 stall 은 정리.
+     */
+    BROADCAST_BACKPRESSURE_TERMINATE_AFTER: Number(process.env.WS_BROADCAST_BACKPRESSURE_TERMINATE_AFTER) || 5,
 } as const;
 
 // ============================================

--- a/backend/api/src/data/conversation-messages.ts
+++ b/backend/api/src/data/conversation-messages.ts
@@ -22,19 +22,47 @@ import {
 
 /**
  * 세션 목록에 대한 메시지 배치 로딩 (N+1 방지)
+ *
+ * @param rows - 세션 row 목록
+ * @param options.maxMessagesPerSession - 세션당 최근 N 메시지로 제한 (기본 미지정: 모든 메시지).
+ *   list view 에서는 50 등 작은 값을 전달해 5K+ 메시지 보유 사용자의 메모리 spike 방지.
+ *   single-session detail 은 getSession() 의 LIMIT 500 패턴을 사용하므로 본 함수 미사용.
  */
-export async function loadMessagesForSessions(rows: SessionRow[]): Promise<ConversationSession[]> {
+export async function loadMessagesForSessions(
+    rows: SessionRow[],
+    options?: { maxMessagesPerSession?: number }
+): Promise<ConversationSession[]> {
     if (rows.length === 0) return [];
 
     const pool = getPool();
     const ids = rows.map(r => r.id);
     const placeholders = ids.map((_, i) => `$${i + 1}`).join(',');
+    const maxPerSession = options?.maxMessagesPerSession;
 
-    const msgResult = await pool.query(
-        `SELECT * FROM conversation_messages WHERE session_id IN (${placeholders}) ORDER BY created_at ASC`,
-        ids
-    );
-    const msgRows = msgResult.rows as MessageRow[];
+    let msgRows: MessageRow[];
+    if (maxPerSession === undefined || maxPerSession <= 0) {
+        // 기존 동작 (하위 호환): 세션당 메시지 무제한
+        const msgResult = await pool.query(
+            `SELECT * FROM conversation_messages WHERE session_id IN (${placeholders}) ORDER BY created_at ASC`,
+            ids
+        );
+        msgRows = msgResult.rows as MessageRow[];
+    } else {
+        // window function 으로 세션당 최근 N 메시지만 — list view 페이로드 비대화 방지.
+        // ROW_NUMBER() PARTITION BY session_id ORDER BY created_at DESC 로 최신 N 추출 후
+        // 외부에서 created_at ASC 로 재정렬 (기존 동작과 동일 순서 보장).
+        const msgResult = await pool.query(
+            `SELECT * FROM (
+                SELECT *, ROW_NUMBER() OVER (
+                    PARTITION BY session_id ORDER BY created_at DESC
+                ) AS rn
+                FROM conversation_messages WHERE session_id IN (${placeholders})
+            ) ranked WHERE rn <= $${ids.length + 1}
+            ORDER BY session_id, created_at ASC`,
+            [...ids, maxPerSession]
+        );
+        msgRows = msgResult.rows as MessageRow[];
+    }
 
     // Group messages by session_id
     const msgMap = new Map<string, ConversationMessage[]>();

--- a/backend/api/src/data/conversation-sessions.ts
+++ b/backend/api/src/data/conversation-sessions.ts
@@ -126,7 +126,9 @@ export async function getSessionsByUserId(userId: string, limit: number = 50): P
         [userId, limit]
     );
 
-    return loadMessagesForSessions(result.rows as SessionRow[]);
+    // list view: 세션당 최근 50개만 — 5K+ 메시지 사용자의 메모리 spike 방지.
+    // single-session detail 은 getSession() 의 LIMIT 500 으로 별도 로드.
+    return loadMessagesForSessions(result.rows as SessionRow[], { maxMessagesPerSession: 50 });
 }
 
 /**
@@ -139,7 +141,9 @@ export async function getSessionsByAnonId(anonSessionId: string, limit: number =
         [anonSessionId, limit]
     );
 
-    return loadMessagesForSessions(result.rows as SessionRow[]);
+    // list view: 세션당 최근 50개만 — 5K+ 메시지 사용자의 메모리 spike 방지.
+    // single-session detail 은 getSession() 의 LIMIT 500 으로 별도 로드.
+    return loadMessagesForSessions(result.rows as SessionRow[], { maxMessagesPerSession: 50 });
 }
 
 /**
@@ -152,7 +156,9 @@ export async function getAllSessions(limit: number = 100): Promise<ConversationS
         [limit]
     );
 
-    return loadMessagesForSessions(result.rows as SessionRow[]);
+    // list view: 세션당 최근 50개만 — 5K+ 메시지 사용자의 메모리 spike 방지.
+    // single-session detail 은 getSession() 의 LIMIT 500 으로 별도 로드.
+    return loadMessagesForSessions(result.rows as SessionRow[], { maxMessagesPerSession: 50 });
 }
 
 /**

--- a/backend/api/src/sockets/handler.ts
+++ b/backend/api/src/sockets/handler.ts
@@ -61,6 +61,8 @@ export class WebSocketHandler {
     private wss: WebSocketServer;
     private cluster: ClusterManager;
     private clients: Set<WebSocket> = new Set();
+    /** broadcast 시 backpressure 임계 초과 횟수 — terminate 임계 도달 시 강제 종료 */
+    private slowClientCounters: WeakMap<WebSocket, number> = new WeakMap();
     private userConnections: Map<string, Set<WebSocket>> = new Map();
     private ipConnectionAttempts: Map<string, number[]> = new Map();
     private userConnectionAttempts: Map<string, number[]> = new Map();
@@ -637,15 +639,56 @@ export class WebSocketHandler {
 
     /**
      * 모든 연결된 클라이언트에 메시지를 브로드캐스트합니다.
-     * OPEN 상태인 클라이언트에만 전송합니다.
+     * OPEN 상태이며 backpressure 임계 미만인 클라이언트에만 전송합니다.
+     *
+     * Backpressure 정책:
+     *  - bufferedAmount > THRESHOLD_BYTES: 송신 skip + slowClient 카운터 증가
+     *  - 카운터가 TERMINATE_AFTER 초과: ws.terminate() 로 강제 종료
+     *    (heartbeat 가 없는 dead connection 정리)
+     *  - 정상 송신 시 카운터 리셋
+     *
+     * 이전 동작 (await/콜백 없는 단순 send) 은 슬로우 클라이언트가
+     * 이벤트 루프와 Node 메모리를 점유하여 fast 클라이언트의 latency 까지 끌어올렸음.
+     *
      * @param data - 전송할 JSON 직렬화 가능 데이터
      */
     public broadcast(data: Record<string, unknown>): void {
         const message = JSON.stringify(data);
+        const threshold = WS_LIMITS.BROADCAST_BACKPRESSURE_THRESHOLD_BYTES;
+        const terminateAfter = WS_LIMITS.BROADCAST_BACKPRESSURE_TERMINATE_AFTER;
+        let skipped = 0;
+        let terminated = 0;
+
         for (const client of this.clients) {
-            if (client.readyState === WebSocket.OPEN) {
-                client.send(message);
+            if (client.readyState !== WebSocket.OPEN) continue;
+
+            // 슬로우 클라이언트 감지 — bufferedAmount 가 임계 초과
+            if (client.bufferedAmount > threshold) {
+                const count = (this.slowClientCounters.get(client) ?? 0) + 1;
+                this.slowClientCounters.set(client, count);
+                skipped++;
+
+                if (terminateAfter > 0 && count >= terminateAfter) {
+                    // 만성적 stall — 강제 종료 (close 핸들러가 cleanup 처리)
+                    client.terminate();
+                    this.slowClientCounters.delete(client);
+                    terminated++;
+                }
+                continue;
             }
+
+            // 정상 송신 — slow 카운터 리셋
+            if (this.slowClientCounters.has(client)) {
+                this.slowClientCounters.delete(client);
+            }
+            client.send(message);
+        }
+
+        if (skipped > 0 || terminated > 0) {
+            log.warn(
+                `broadcast backpressure: skipped=${skipped}, terminated=${terminated} ` +
+                `(threshold=${threshold}B, terminateAfter=${terminateAfter})`
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

리뷰 follow-up 작업 3건 통합 (PR #22 머지 후 후속 patch).

- **feat(security)**: `TOKEN_ENCRYPTION_KEY` env.schema 등록 + production-only 화이트리스트 → dev/test 외 모든 환경 (production/staging/uat/qa) 블랙리스트로 반전. Zod superRefine 검증 통합.
- **perf(db)**: `loadMessagesForSessions` 에 `maxMessagesPerSession` 옵션 추가, list view 함수 (`getAllSessions/getSessionsByUserId/getSessionsByAnonId`) 가 세션당 최근 50개만 로드. 5K+ 메시지 사용자 메모리 spike 방지.
- **perf(ws)**: `WebSocketHandler.broadcast()` 에 backpressure 정책 도입. `bufferedAmount > 1MB` 클라이언트는 skip, 5회 연속 초과 시 `ws.terminate()` 로 강제 종료.

## 변경 파일

| 파일 | 종류 | 효과 |
|---|---|---|
| `backend/api/src/config/env.schema.ts` | feat | NODE_ENV enum 확장 + TOKEN_ENCRYPTION_KEY 검증 |
| `backend/api/src/config/env.ts` | feat | tokenEncryptionKey config field |
| `backend/api/src/config/timeouts.ts` | feat | WS broadcast backpressure 임계 2개 추가 |
| `backend/api/src/data/conversation-messages.ts` | perf | window function 페이지네이션 |
| `backend/api/src/data/conversation-sessions.ts` | perf | list 함수에 maxMessagesPerSession=50 적용 |
| `backend/api/src/sockets/handler.ts` | perf | broadcast backpressure + slow client terminate |

## 비포함

- 사전 존재 테스트 실패 2건 fix (`AuthService.test.ts`, `csp-hash-enforcement.test.ts`) — `**/__tests__/` 가 gitignored 라 로컬 보관만. CI 영향 없으므로 commit 불필요.
- git history rewrite (#4) — destructive, 본 PR 머지 후 별도 진행.

## Test plan

- [x] `tsc --noEmit` 통과 (silent)
- [x] `npx jest` 관련 테스트 통과 — token-crypto 8/8, env/cookie 14/14, conversation 16/16, ws 8/8
- [x] 회귀 검증: 기본 동작 (loadMessagesForSessions 옵션 미지정) 유지
- [ ] **production/staging 배포 전**: `TOKEN_ENCRYPTION_KEY=$(openssl rand -hex 32)` 환경변수 사전 설정 필수 — 누락 시 부팅 실패 (의도된 fail-fast)
- [ ] WS backpressure smoke test: 1000+ 동시 연결에서 cluster_event 발송 시 latency 분포 측정

## 관련

- Follows up PR #22 (https://github.com/openmake/openmake_llm/pull/22)
- 관련 리포트: `docs/REVIEW-2026-05-16.md`, `docs/REVIEW-2026-05-16-GEMINI.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)