### PR TITLE
feat(skill-creator): Phase 1 Plan-Driven Completion — wiring + cleanup + keystone

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -329,3 +329,30 @@ OMK_APP_CATEGORIES=ai-platform
 # 환경에서는 브라우저가 헤더를 무시하며 매 요청마다 경고 로그 발생.
 # Caddy/Cloudflare Tunnel 등으로 HTTPS 도입 후 true 로 설정.
 OMK_COOP_ENABLED=false
+
+
+# ── Skill Creator (Phase 1) ───────────────────────────────────────────
+# 자연어 prompt 로 LLM 이 SKILL 매니페스트를 작성해 draft 로 저장하는 기능.
+# REST: POST /api/agents/skills/auto-create
+# MCP tool: create_skill
+# 검토 UX: 채팅 inline 카드 + 스킬 라이브러리 "AI 자동 생성" 탭
+
+# 전체 기능 ON/OFF. false 면 /auto-create 가 503 + FEATURE_DISABLED 응답.
+SKILL_CREATOR_ENABLED=true
+
+# false 면 admin 만 호출 가능 (일반 user 는 503 + FEATURE_ADMIN_ONLY).
+SKILL_CREATOR_USER_TIER_ENABLED=true
+
+# LLM 호출 시 사용할 모델. 비어있으면 사용자의 채팅 fallback 모델 사용 (modelTier='user-fallback').
+# 예: exaone4.5-33b-awq, claude-haiku-4-5-20251001
+SKILL_AUTHOR_MODEL=
+
+# system 모델이 schema 검증을 두 번 실패하면 user fallback 모델로 재시도할지.
+# true=재시도 / false=즉시 LLM_PARSE_FAIL 반환.
+SKILL_AUTHOR_FALLBACK=true
+
+# draft 상태로 보존하는 기간 (일). 이후 정리 스크립트가 archived 로 전환.
+SKILL_DRAFT_TTL_DAYS=30
+
+# 사용자 1인당 누적 draft 상한. 초과 시 DRAFT_LIMIT_EXCEEDED.
+SKILL_AUTO_CREATE_MAX_DRAFTS_PER_USER=50

--- a/backend/api/src/agents/skill-manager.ts
+++ b/backend/api/src/agents/skill-manager.ts
@@ -11,7 +11,8 @@
  *
  * @module agents/skill-manager
  * @description
- * - CRUD: createSkill(), updateSkill(), deleteSkill(), getAllSkills()
+ * - CRUD: createSkill(), updateSkill(), deleteSkill(), searchSkills()
+ * - Status workflow: updateStatus(), listDrafts()
  * - 연결: assignSkillToAgent(), removeSkillFromAgent(), getSkillsForAgent()
  * - 주입: buildSkillPrompt() - 에이전트 시스템 프롬프트에 스킬 내용 삽입
  * - 소유권: getSkillOwner() - 스킬 소유자 확인
@@ -30,6 +31,9 @@ export type {
     UpdateSkillInput,
     SkillSearchOptions,
     SkillSearchResult,
+    SkillStatus,
+    DraftListOptions,
+    DraftListResult,
 } from '../data/repositories/skill-repository';
 
 import type {
@@ -38,6 +42,9 @@ import type {
     UpdateSkillInput,
     SkillSearchOptions,
     SkillSearchResult,
+    SkillStatus,
+    DraftListOptions,
+    DraftListResult,
 } from '../data/repositories/skill-repository';
 
 const logger = createLogger('SkillManager');
@@ -113,11 +120,6 @@ export class SkillManager {
         return repo.getSkillById(id);
     }
 
-    async getAllSkills(userId?: string): Promise<AgentSkill[]> {
-        const repo = await this.ensureInitialized();
-        return repo.getAllSkills(userId);
-    }
-
     async searchSkills(options: SkillSearchOptions): Promise<SkillSearchResult> {
         const repo = await this.ensureInitialized();
         return repo.searchSkills(options);
@@ -130,6 +132,22 @@ export class SkillManager {
     async getSkillOwner(skillId: string): Promise<string | null> {
         const repo = await this.ensureInitialized();
         return repo.getSkillOwner(skillId);
+    }
+
+    // ------------------------------------------------
+    // Status workflow (draft → active → archived)
+    // ------------------------------------------------
+
+    async updateStatus(id: string, status: SkillStatus, actor?: { userId: string; userRole: string }): Promise<AgentSkill | null> {
+        const repo = await this.ensureInitialized();
+        const updated = await repo.updateStatus(id, status, actor);
+        if (updated) logger.info(`스킬 status 변경: ${id} → ${status} (by ${actor?.userId ?? 'system'})`);
+        return updated;
+    }
+
+    async listDrafts(options: DraftListOptions): Promise<DraftListResult> {
+        const repo = await this.ensureInitialized();
+        return repo.listDrafts(options);
     }
 
     // ------------------------------------------------

--- a/backend/api/src/chat/request-handler.ts
+++ b/backend/api/src/chat/request-handler.ts
@@ -153,6 +153,11 @@ export interface ChatRequestParams {
     onSkillsActivated?: (skillNames: string[]) => void;
     /** 시스템 이벤트 콜백 - 자동 토론 활성화 등 메타 알림 (UI에서 토스트로 표시) */
     onSystemEvent?: SystemEventCallback;
+    /**
+     * MCP tool 호출이 resource content 를 반환했을 때 호출되는 콜백.
+     * frontend 인라인 카드 UI (예: skill-draft) 렌더링을 트리거.
+     */
+    onMcpToolResult?: (event: { toolName: string; resources: Array<{ uri: string; mimeType?: string; text?: string }> }) => void;
 }
 
 /**
@@ -588,6 +593,7 @@ export class ChatRequestHandler {
             onSkillsActivated,
             params.onThinking,
             onSystemEvent,
+            params.onMcpToolResult,
         );
 
         const endTime = Date.now();

--- a/backend/api/src/config/constants.ts
+++ b/backend/api/src/config/constants.ts
@@ -106,6 +106,28 @@ export const APP_VERSION: string = rootPkg.version;
 export const APP_USER_AGENT = 'OpenMake-AI';
 
 // ============================================
+// Skill Creator (Phase 1) feature flags
+// ============================================
+
+/**
+ * Skill Creator (Phase 1) — 자연어 prompt → LLM → SKILL 매니페스트 → draft 워크플로
+ * 의 런타임 설정 객체. `.env` 의 SKILL_* 변수를 named constant 로 외부화.
+ *
+ * 사용 위치:
+ *   - skills.routes.ts: /auto-create 진입 가드 (enabled, userTierEnabled)
+ *   - skill-creator.ts: LLM 모델 / fallback / draft 상한 (authorModel/authorFallback/maxDraftsPerUser)
+ *   - cleanup 스크립트 (예정): draftTtlDays
+ */
+export const SKILL_CREATOR = {
+    enabled: process.env.SKILL_CREATOR_ENABLED !== 'false',
+    userTierEnabled: process.env.SKILL_CREATOR_USER_TIER_ENABLED !== 'false',
+    authorModel: process.env.SKILL_AUTHOR_MODEL || '',
+    authorFallback: process.env.SKILL_AUTHOR_FALLBACK === 'true',
+    draftTtlDays: parseInt(process.env.SKILL_DRAFT_TTL_DAYS || '30', 10),
+    maxDraftsPerUser: parseInt(process.env.SKILL_AUTO_CREATE_MAX_DRAFTS_PER_USER || '50', 10),
+} as const;
+
+// ============================================
 // 모델 선택
 // ============================================
 

--- a/backend/api/src/config/rate-limits.ts
+++ b/backend/api/src/config/rate-limits.ts
@@ -125,8 +125,11 @@ export const RL_MCP = {
  *
  * 적용: POST /api/agents/skills/auto-create
  */
+// 주의: express-rate-limit MemoryStore 는 windowMs <= 2^31-1 (≈24.85일) 만 허용.
+// 30일 windowMs 는 setTimeout 32-bit overflow 발생 → 보수적으로 20일로 설정.
+// (월간 quota 의미는 그대로 보존, limits 도 동일).
 export const RL_SKILL_CREATE = {
-    windowMs: 30 * 24 * 60 * 60 * 1000,  // 30일
+    windowMs: 20 * 24 * 60 * 60 * 1000,  // 20일 (max 24.85일 미만)
     limits: {
         free: Number(process.env.RL_SKILL_CREATE_FREE) || 10,
         pro: Number(process.env.RL_SKILL_CREATE_PRO) || 50,

--- a/backend/api/src/config/rate-limits.ts
+++ b/backend/api/src/config/rate-limits.ts
@@ -181,3 +181,41 @@ export const RL_ADMIN = {
     ipLimit: Number(process.env.RL_ADMIN_IP) || 100,
     userLimit: Number(process.env.RL_ADMIN_USER) || 150,
 } as const;
+
+// ============================================
+// 32-bit signed int invariant (module-load 검증)
+// ============================================
+// express-rate-limit MemoryStore + Node.js setTimeout 은 32-bit signed int (2^31-1 ≈ 24.85일)
+// 까지의 windowMs 만 안전하게 처리. 초과 시 setTimeout 이 1ms 로 truncate 되어 rate limit
+// 가 비정상 동작 (TimeoutOverflowWarning + ValidationError).
+//
+// 본 단언은 module import 시점에 실행되어 deploy 단계 회귀 (2026-05-22 windowMs=30일 사고)
+// 의 재발을 차단. dev/prod/test 환경 모두에서 boot 시점에 즉시 throw 하므로 운영 서버
+// 첫 로그 라인 전에 발견 가능.
+//
+// 새 RL_* config 추가 시 아래 배열에 포함시키면 자동 검증됨.
+const SAFE_32BIT_MS = 2_147_483_647;
+const _windowMsInvariant = [
+    { name: 'RL_GENERAL', cfg: RL_GENERAL },
+    { name: 'RL_AUTH', cfg: RL_AUTH },
+    { name: 'RL_CHAT', cfg: RL_CHAT },
+    { name: 'RL_RESEARCH', cfg: RL_RESEARCH },
+    { name: 'RL_UPLOAD', cfg: RL_UPLOAD },
+    { name: 'RL_WEB_SEARCH', cfg: RL_WEB_SEARCH },
+    { name: 'RL_MEMORY', cfg: RL_MEMORY },
+    { name: 'RL_MCP', cfg: RL_MCP },
+    { name: 'RL_API_KEY_MGMT', cfg: RL_API_KEY_MGMT },
+    { name: 'RL_SKILL_CREATE', cfg: RL_SKILL_CREATE },
+    { name: 'RL_SKILL_CREATE_SHORT', cfg: RL_SKILL_CREATE_SHORT },
+    { name: 'RL_PUSH', cfg: RL_PUSH },
+    { name: 'RL_ADMIN', cfg: RL_ADMIN },
+];
+for (const { name, cfg } of _windowMsInvariant) {
+    if (cfg.windowMs > SAFE_32BIT_MS) {
+        throw new Error(
+            `[rate-limits invariant] ${name}.windowMs=${cfg.windowMs} > 2^31-1 (${SAFE_32BIT_MS}). ` +
+            `express-rate-limit MemoryStore + setTimeout 의 32-bit signed int 제약 초과. ` +
+            `windowMs 를 24일 이하로 조정하거나 Redis store 로 교체하세요.`
+        );
+    }
+}

--- a/backend/api/src/config/rate-limits.ts
+++ b/backend/api/src/config/rate-limits.ts
@@ -114,6 +114,38 @@ export const RL_MCP = {
 } as const;
 
 /**
+ * Skill Creator (Phase 1) 레이트 리밋
+ *
+ * LLM 호출은 비용 높음 + draft 상한이 50/user 라 도배 자체는 불가능하지만
+ * 단시간 burst 차단을 위한 이중 제한 (월간 quota + 시간당 burst).
+ *
+ * Tier 별 차등:
+ *   - free / pro / enterprise / admin 순으로 점진 완화
+ *   - 미들웨어가 req.user.tier 보고 동적으로 결정
+ *
+ * 적용: POST /api/agents/skills/auto-create
+ */
+export const RL_SKILL_CREATE = {
+    windowMs: 30 * 24 * 60 * 60 * 1000,  // 30일
+    limits: {
+        free: Number(process.env.RL_SKILL_CREATE_FREE) || 10,
+        pro: Number(process.env.RL_SKILL_CREATE_PRO) || 50,
+        enterprise: Number(process.env.RL_SKILL_CREATE_ENTERPRISE) || 1000,
+        admin: Number(process.env.RL_SKILL_CREATE_ADMIN) || 1000,
+    },
+} as const;
+
+export const RL_SKILL_CREATE_SHORT = {
+    windowMs: 60 * 60 * 1000,  // 1시간 burst 방어
+    limits: {
+        free: Number(process.env.RL_SKILL_CREATE_SHORT_FREE) || 5,
+        pro: Number(process.env.RL_SKILL_CREATE_SHORT_PRO) || 10,
+        enterprise: Number(process.env.RL_SKILL_CREATE_SHORT_ENTERPRISE) || 50,
+        admin: Number(process.env.RL_SKILL_CREATE_SHORT_ADMIN) || 50,
+    },
+} as const;
+
+/**
  * API 키 관리 레이트 리밋
  */
 export const RL_API_KEY_MGMT = {

--- a/backend/api/src/data/repositories/skill-repository.ts
+++ b/backend/api/src/data/repositories/skill-repository.ts
@@ -24,6 +24,24 @@ export interface AgentSkill {
     updatedAt: Date;
     sourceRepo?: string;
     sourcePath?: string;
+    status?: 'draft' | 'active' | 'archived';
+    manifestMeta?: Record<string, unknown>;
+}
+
+export type SkillStatus = 'draft' | 'active' | 'archived';
+
+export interface DraftListOptions {
+    target?: 'user' | 'system' | 'all';
+    userId?: string;
+    limit?: number;
+    offset?: number;
+}
+
+export interface DraftListResult {
+    drafts: AgentSkill[];
+    total: number;
+    limit: number;
+    offset: number;
 }
 
 export interface AgentSkillAssignment {
@@ -60,6 +78,8 @@ export interface SkillSearchOptions {
     sortBy?: 'newest' | 'name' | 'category' | 'updated';
     limit?: number;
     offset?: number;
+    /** 'draft' | 'active' | 'all'. 기본값 'active' — 일반 라이브러리에는 draft 노출 금지. */
+    status?: 'draft' | 'active' | 'all';
 }
 
 export interface SkillSearchResult {
@@ -193,7 +213,7 @@ export class SkillRepository extends BaseRepository {
 
     async getSkillById(id: string): Promise<AgentSkill | null> {
         const result = await this.query(
-            `SELECT id, name, description, content, category, is_public, created_by, created_at, updated_at, source_repo, source_path
+            `SELECT id, name, description, content, category, is_public, created_by, created_at, updated_at, source_repo, source_path, status, manifest_meta
              FROM agent_skills
              WHERE id = $1`,
             [id]
@@ -204,24 +224,6 @@ export class SkillRepository extends BaseRepository {
         }
 
         return this.rowToSkill(result.rows[0]);
-    }
-
-    async getAllSkills(userId?: string): Promise<AgentSkill[]> {
-        let sql = `SELECT id, name, description, content, category, is_public, created_by, created_at, updated_at, source_repo, source_path
-                   FROM agent_skills`;
-        const params: QueryParam[] = [];
-
-        if (userId) {
-            sql += ' WHERE created_by = $1 OR is_public = TRUE';
-            params.push(userId);
-        } else {
-            sql += ' WHERE is_public = TRUE';
-        }
-
-        sql += ' ORDER BY created_at DESC, id ASC';
-
-        const result = await this.query(sql, params);
-        return result.rows.map((row) => this.rowToSkill(row));
     }
 
     async searchSkills(options: SkillSearchOptions): Promise<SkillSearchResult> {
@@ -255,6 +257,14 @@ export class SkillRepository extends BaseRepository {
             paramIdx += 1;
         }
 
+        // status 필터: 기본 'active'. 'all' 이면 필터 없음, 'draft' 면 draft 만.
+        const statusFilter = options.status ?? 'active';
+        if (statusFilter !== 'all') {
+            conditions.push(`status = $${paramIdx}`);
+            params.push(statusFilter);
+            paramIdx += 1;
+        }
+
         const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
         const sortMap: Record<NonNullable<SkillSearchOptions['sortBy']>, string> = {
@@ -279,7 +289,7 @@ export class SkillRepository extends BaseRepository {
 
         const dataParams: QueryParam[] = [...params, limit, offset];
         const dataResult = await this.query(
-            `SELECT id, name, description, content, category, is_public, created_by, created_at, updated_at, source_repo, source_path
+            `SELECT id, name, description, content, category, is_public, created_by, created_at, updated_at, source_repo, source_path, status, manifest_meta
              FROM agent_skills
              ${whereClause}
              ORDER BY ${orderBy}
@@ -316,9 +326,11 @@ export class SkillRepository extends BaseRepository {
      */
     async upsertSystemSkill(id: string, input: CreateSkillInput): Promise<AgentSkill> {
         const nowIso = new Date().toISOString();
+        // 시스템 스킬 재시드 = active 강제. 누군가 system skill 을 archived 로 바꿔도
+        // 부트스트랩 재실행 시 자동 복구됨 (시스템 스킬은 늘 active 가 invariant).
         const result = await this.query(
-            `INSERT INTO agent_skills (id, name, description, content, category, is_public, created_by, created_at, updated_at, source_repo, source_path)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            `INSERT INTO agent_skills (id, name, description, content, category, is_public, created_by, created_at, updated_at, source_repo, source_path, status)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'active')
              ON CONFLICT (id) DO UPDATE
              SET name = EXCLUDED.name,
                  description = EXCLUDED.description,
@@ -326,8 +338,9 @@ export class SkillRepository extends BaseRepository {
                  category = EXCLUDED.category,
                  is_public = EXCLUDED.is_public,
                  updated_at = EXCLUDED.updated_at,
-                 source_path = EXCLUDED.source_path
-             RETURNING id, name, description, content, category, is_public, created_by, created_at, updated_at, source_repo, source_path`,
+                 source_path = EXCLUDED.source_path,
+                 status = 'active'
+             RETURNING id, name, description, content, category, is_public, created_by, created_at, updated_at, source_repo, source_path, status, manifest_meta`,
             [
                 id,
                 input.name,
@@ -401,15 +414,18 @@ export class SkillRepository extends BaseRepository {
         }
 
         const whereClause = conditions.join(' OR ');
+        // status='active' 필터: 채팅 시스템 프롬프트 주입 경로에 draft/archived 가 섞이지 않도록 차단
         const result = await this.query(
             `SELECT s.id, s.name, s.description, s.content, s.category, s.is_public,
                     s.created_by, s.created_at, s.updated_at, s.source_repo, s.source_path,
+                    s.status, s.manifest_meta,
                     MIN(a.priority) AS priority
              FROM agent_skills s
              JOIN agent_skill_assignments a ON s.id = a.skill_id
-             WHERE ${whereClause}
+             WHERE (${whereClause}) AND s.status = 'active'
              GROUP BY s.id, s.name, s.description, s.content, s.category, s.is_public,
-                      s.created_by, s.created_at, s.updated_at, s.source_repo, s.source_path
+                      s.created_by, s.created_at, s.updated_at, s.source_repo, s.source_path,
+                      s.status, s.manifest_meta
              ORDER BY MIN(a.priority) ASC, s.name ASC
              LIMIT $${params.length + 1}`,
             [...params, 15]
@@ -474,19 +490,97 @@ export class SkillRepository extends BaseRepository {
     }
 
     /**
-     * 사용자 개인 할당 스킬 전체 목록 반환
+     * 사용자 개인 할당 스킬 전체 목록 반환.
+     * draft/archived 는 의도적으로 제외 — 사용자 할당 목록은 활성 스킬만 표시.
      */
     async getUserSkills(userId: string): Promise<AgentSkill[]> {
         const result = await this.query(
             `SELECT s.id, s.name, s.description, s.content, s.category, s.is_public,
-                    s.created_by, s.created_at, s.updated_at, s.source_repo, s.source_path
+                    s.created_by, s.created_at, s.updated_at, s.source_repo, s.source_path,
+                    s.status, s.manifest_meta
              FROM agent_skills s
              JOIN agent_skill_assignments a ON s.id = a.skill_id
-             WHERE a.agent_id = $1
+             WHERE a.agent_id = $1 AND s.status = 'active'
              ORDER BY a.priority ASC, s.name ASC`,
             [`user:${userId}`]
         );
         return result.rows.map((row) => this.rowToSkill(row));
+    }
+
+    /**
+     * 스킬 status 를 변경합니다 (draft → active 승인, draft → archived 거절 등).
+     * actor 가 주어지면 소유권을 검증합니다. 시스템 스킬(createdBy=null) 은 admin 만 변경 가능.
+     */
+    async updateStatus(id: string, status: SkillStatus, actor?: ActorContext): Promise<AgentSkill | null> {
+        const existing = await this.getSkillById(id);
+        if (!existing) {
+            return null;
+        }
+
+        if (actor) {
+            if (existing.createdBy) {
+                assertResourceOwnerOrAdmin(existing.createdBy, actor.userId, actor.userRole);
+            } else if (actor.userRole !== 'admin') {
+                throw new Error('ADMIN_REQUIRED: 시스템 스킬 status 변경은 관리자만 가능합니다');
+            }
+        }
+
+        const nowIso = new Date().toISOString();
+        await this.query(
+            `UPDATE agent_skills SET status = $1, updated_at = $2 WHERE id = $3`,
+            [status, nowIso, id]
+        );
+        return this.getSkillById(id);
+    }
+
+    /**
+     * draft 상태 스킬 목록 (페이지네이션).
+     * target='user' → 본인 draft 만. 'system' → admin 이 본 system draft (createdBy IS NULL).
+     * 'all' → admin 이 전체 draft (소유자 무관).
+     */
+    async listDrafts(options: DraftListOptions): Promise<DraftListResult> {
+        const conditions: string[] = [`status = 'draft'`];
+        const params: QueryParam[] = [];
+        let paramIdx = 1;
+
+        const target = options.target ?? 'user';
+        if (target === 'user') {
+            if (!options.userId) {
+                throw new Error('listDrafts: target=user 는 userId 필수');
+            }
+            conditions.push(`created_by = $${paramIdx}`);
+            params.push(options.userId);
+            paramIdx += 1;
+        } else if (target === 'system') {
+            conditions.push(`created_by IS NULL`);
+        }
+        // target === 'all' → 추가 조건 없음
+
+        const whereClause = `WHERE ${conditions.join(' AND ')}`;
+        const limit = Math.min(options.limit ?? 50, 100);
+        const offset = Math.max(0, options.offset ?? 0);
+
+        const countResult = await this.query<CountRow>(
+            `SELECT COUNT(*) AS total FROM agent_skills ${whereClause}`,
+            params
+        );
+
+        const dataParams: QueryParam[] = [...params, limit, offset];
+        const dataResult = await this.query(
+            `SELECT id, name, description, content, category, is_public, created_by, created_at, updated_at, source_repo, source_path, status, manifest_meta
+             FROM agent_skills
+             ${whereClause}
+             ORDER BY created_at DESC, id ASC
+             LIMIT $${paramIdx} OFFSET $${paramIdx + 1}`,
+            dataParams
+        );
+
+        return {
+            drafts: dataResult.rows.map((row) => this.rowToSkill(row)),
+            total: parseInt(countResult.rows[0]?.total ?? '0', 10),
+            limit,
+            offset,
+        };
     }
 
     async getSkillOwner(skillId: string): Promise<string | null> {
@@ -508,6 +602,8 @@ export class SkillRepository extends BaseRepository {
         const createdBy = row.created_by;
         const sourceRepo = row.source_repo;
         const sourcePath = row.source_path;
+        const status = row.status;
+        const manifestMeta = row.manifest_meta;
 
         return {
             id: this.toStringValue(row.id),
@@ -521,6 +617,8 @@ export class SkillRepository extends BaseRepository {
             updatedAt: this.toDateValue(row.updated_at),
             sourceRepo: typeof sourceRepo === 'string' ? sourceRepo : undefined,
             sourcePath: typeof sourcePath === 'string' ? sourcePath : undefined,
+            status: status === 'draft' || status === 'active' || status === 'archived' ? status : undefined,
+            manifestMeta: manifestMeta && typeof manifestMeta === 'object' ? manifestMeta as Record<string, unknown> : undefined,
         };
     }
 

--- a/backend/api/src/mcp/skill-creator-tool.ts
+++ b/backend/api/src/mcp/skill-creator-tool.ts
@@ -1,0 +1,117 @@
+/**
+ * ============================================================
+ * MCP Tool: create_skill - LLM 자동 스킬 생성 (Phase 1)
+ * ============================================================
+ *
+ * 채팅 중 LLM 이 호출 가능한 도구. 자연어 purpose 를 받아 SkillCreatorService
+ * 를 통해 매니페스트를 생성하고 status='draft' 로 저장합니다.
+ *
+ * UserContext 의 userId/role 로 소유권을 결정. dedupe, draft 상한 같은
+ * 안전장치는 SkillCreatorService 내부에서 처리.
+ *
+ * @module mcp/skill-creator-tool
+ */
+import type { MCPToolDefinition, MCPToolResult } from './types';
+import type { UserContext } from './user-sandbox';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('CreateSkillTool');
+
+interface CreateSkillArgs extends Record<string, unknown> {
+    purpose: string;
+    target?: 'user' | 'system';
+    category?: string;
+    examples?: string[];
+    hints?: string;
+}
+
+export const createSkillTool: MCPToolDefinition<CreateSkillArgs> = {
+    tool: {
+        name: 'create_skill',
+        description: '자연어 purpose 를 받아 SKILL 매니페스트를 LLM 으로 생성하고 draft 상태로 저장합니다. 사용자가 명시적으로 "스킬을 만들어줘", "이런 스킬이 있으면 좋겠다" 같은 요청을 했을 때만 호출하세요.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                purpose: {
+                    type: 'string',
+                    description: '만들고자 하는 스킬의 목적/역할 (5-500자). 예: "한국 의료법 자문 스킬"',
+                },
+                target: {
+                    type: 'string',
+                    enum: ['user', 'system'],
+                    description: '"user" = 본인 전용, "system" = 전역 공개 (admin 만 가능, 비-admin 은 user 로 강제). 기본 user',
+                },
+                category: {
+                    type: 'string',
+                    description: '카테고리 ID (예: legal, healthcare, coding, business). 생략 시 LLM 이 결정',
+                },
+                examples: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description: '스킬이 처리해야 할 예시 질문/작업 (최대 5개, 각 500자)',
+                },
+                hints: {
+                    type: 'string',
+                    description: '추가 지침/제약 (선택, 1000자)',
+                },
+            },
+            required: ['purpose'],
+        },
+    },
+    handler: async (args, context?: UserContext): Promise<MCPToolResult> => {
+        if (!context?.userId) {
+            return {
+                content: [{ type: 'text', text: '인증 컨텍스트가 없어 스킬을 생성할 수 없습니다.' }],
+                isError: true,
+            };
+        }
+        const userId = String(context.userId);
+        const isAdmin = context.role === 'admin';
+
+        try {
+            const { SkillCreatorService } = await import('../agents/skill-creator');
+            const { LLMClient } = await import('../llm/client');
+            const { getUnifiedDatabase } = await import('../data/models/unified-database');
+
+            const service = new SkillCreatorService({
+                pool: getUnifiedDatabase().getPool(),
+                llmClientFactory: (model: string) => new LLMClient(model ? { model } : {}),
+            });
+
+            const result = await service.create({
+                userId,
+                isAdmin,
+                purpose: args.purpose,
+                target: args.target,
+                category: args.category,
+                examples: args.examples,
+                hints: args.hints,
+            });
+
+            const summary = [
+                `스킬 draft 생성 완료${result.deduped ? ' (24시간 내 동일 요청 — 기존 draft 재사용)' : ''}`,
+                ``,
+                `- ID: ${result.skillId}`,
+                `- 이름: ${result.name}`,
+                `- 설명: ${result.description}`,
+                `- 카테고리: ${result.category}`,
+                `- 대상: ${result.target}${result.warnings.includes('ADMIN_REQUIRED') ? ' (관리자 권한 없음 → user 로 변경됨)' : ''}`,
+                `- 상태: draft (승인 필요)`,
+                `- 트리거: ${result.triggers.join(', ') || '(없음)'}`,
+                `- 미리보기: ${result.contentPreview}${result.contentPreview.length >= 300 ? '...' : ''}`,
+                ``,
+                `검토 후 /api/agents/skills/${result.skillId}/approve 로 활성화하세요.`,
+            ].join('\n');
+
+            logger.info(`MCP create_skill: ${result.skillId} (user=${userId}, deduped=${result.deduped})`);
+            return { content: [{ type: 'text', text: summary }] };
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            logger.warn(`MCP create_skill 실패: ${msg}`);
+            return {
+                content: [{ type: 'text', text: `스킬 생성 실패: ${msg}` }],
+                isError: true,
+            };
+        }
+    },
+};

--- a/backend/api/src/mcp/skill-creator-tool.ts
+++ b/backend/api/src/mcp/skill-creator-tool.ts
@@ -88,23 +88,46 @@ export const createSkillTool: MCPToolDefinition<CreateSkillArgs> = {
                 hints: args.hints,
             });
 
-            const summary = [
-                `스킬 draft 생성 완료${result.deduped ? ' (24시간 내 동일 요청 — 기존 draft 재사용)' : ''}`,
-                ``,
-                `- ID: ${result.skillId}`,
-                `- 이름: ${result.name}`,
-                `- 설명: ${result.description}`,
-                `- 카테고리: ${result.category}`,
-                `- 대상: ${result.target}${result.warnings.includes('ADMIN_REQUIRED') ? ' (관리자 권한 없음 → user 로 변경됨)' : ''}`,
-                `- 상태: draft (승인 필요)`,
-                `- 트리거: ${result.triggers.join(', ') || '(없음)'}`,
-                `- 미리보기: ${result.contentPreview}${result.contentPreview.length >= 300 ? '...' : ''}`,
-                ``,
-                `검토 후 /api/agents/skills/${result.skillId}/approve 로 활성화하세요.`,
-            ].join('\n');
+            // Frontend (chat.js) 가 인라인 카드로 렌더링할 수 있도록 resource content 동봉.
+            // URI prefix `openmake://skill-draft/` 가 frontend 의 감지 패턴.
+            const previewCard = {
+                kind: 'skill-draft' as const,
+                skillId: result.skillId,
+                name: result.name,
+                description: result.description,
+                category: result.category,
+                target: result.target,
+                contentPreview: result.contentPreview,
+                triggers: result.triggers,
+                createdAt: result.manifestMeta.createdAt,
+                modelUsed: result.modelUsed,
+                tokensUsed: result.tokensUsed,
+                deduped: result.deduped,
+            };
+            const assistantText = result.deduped
+                ? `24시간 내 동일 요청이라 기존 draft "${result.name}" 를 재사용했습니다. 아래 카드에서 검토·승인하세요.`
+                : `"${result.name}" draft 를 생성했습니다 (status=draft). 아래 카드에서 검토·승인하세요.`;
+            const warningSuffix = result.warnings.includes('ADMIN_REQUIRED')
+                ? '\n\n⚠ 관리자 권한이 없어 target=user 로 변경되었습니다.'
+                : '';
+
+            // LLM 이 다음 turn 의 context 로 받는 텍스트 (간결한 fallback)
+            const llmText = `Created skill draft ${result.skillId} (name="${result.name}", category=${result.category}, status=draft).`;
 
             logger.info(`MCP create_skill: ${result.skillId} (user=${userId}, deduped=${result.deduped})`);
-            return { content: [{ type: 'text', text: summary }] };
+            return {
+                content: [
+                    { type: 'text', text: llmText },
+                    {
+                        type: 'resource',
+                        resource: {
+                            uri: `openmake://skill-draft/${result.skillId}`,
+                            mimeType: 'application/json',
+                            text: JSON.stringify({ previewCard, assistantText: assistantText + warningSuffix }),
+                        },
+                    },
+                ],
+            };
         } catch (e) {
             const msg = e instanceof Error ? e.message : String(e);
             logger.warn(`MCP create_skill 실패: ${msg}`);

--- a/backend/api/src/mcp/tool-tiers.ts
+++ b/backend/api/src/mcp/tool-tiers.ts
@@ -42,12 +42,14 @@ export const TOOL_TIERS: Record<UserTier, string[]> = {
         'web_search',           // 웹 검색
         'vision_ocr',           // 이미지 OCR
         'analyze_image',        // 이미지 분석
+        'create_skill',         // 자연어 → 스킬 draft 생성 (서비스 내부에 50 drafts/user + 24h dedupe 안전장치)
         'noapi-google-search::*', // 외부: Google 검색
     ],
     pro: [
         'web_search',
         'vision_ocr',
         'analyze_image',
+        'create_skill',         // 자연어 → 스킬 draft 생성
         'web_scrape',           // 웹 스크래핑
         'web_map',              // URL 매핑
         'web_crawl',            // 웹 크롤링

--- a/backend/api/src/mcp/tools.ts
+++ b/backend/api/src/mcp/tools.ts
@@ -118,6 +118,8 @@ export const analyzeImageTool: MCPToolDefinition = {
 import { webSearchTools } from './web-search';
 // 웹 스크래핑 MCP 도구 가져오기 (Firecrawl 대체 — API 키 불필요, 항상 활성)
 import { webScraperTools } from './web-scraper-tools';
+// Skill Creator 도구 (Phase 1) — 자연어 purpose → LLM 매니페스트 → draft
+import { createSkillTool } from './skill-creator-tool';
 
 /**
  * 전체 내장 도구 배열
@@ -137,4 +139,5 @@ export const builtInTools: MCPToolDefinition[] = [
     analyzeImageTool,
     ...webSearchTools,
     ...webScraperTools,
+    createSkillTool as MCPToolDefinition,
 ];

--- a/backend/api/src/mcp/types.ts
+++ b/backend/api/src/mcp/types.ts
@@ -134,6 +134,13 @@ export interface MCPToolResult {
         data?: string;
         /** MIME 타입 (type='image' 또는 'resource'일 때) */
         mimeType?: string;
+        /** 리소스 참조 (type='resource'일 때) — URI + 직렬화 payload */
+        resource?: {
+            uri: string;
+            mimeType?: string;
+            text?: string;
+            blob?: string;
+        };
     }>;
     /** 에러 발생 여부 (true이면 content에 에러 메시지 포함) */
     isError?: boolean;

--- a/backend/api/src/routes/agents.routes.ts
+++ b/backend/api/src/routes/agents.routes.ts
@@ -305,6 +305,16 @@ router.get('/:agentId/skills', requireAuth, asyncHandler(async (req: Request, re
  */
 router.post('/:agentId/skills/:skillId', requireAuth, validate(assignSkillSchema), asyncHandler(async (req: Request, res: Response) => {
     const { agentId, skillId } = req.params;
+    // status 가드: 활성 스킬만 할당 허용 (draft/archived 차단)
+    const skill = await getSkillManager().getSkillById(skillId);
+    if (!skill) {
+        res.status(404).json(notFound('스킬'));
+        return;
+    }
+    if (skill.status && skill.status !== 'active') {
+        res.status(409).json({ error: 'SKILL_NOT_ACTIVE', detail: `status=${skill.status} 인 스킬은 할당할 수 없습니다.` });
+        return;
+    }
     const priority = Number(req.body.priority ?? 0);
     await getSkillManager().assignSkillToAgent(agentId, skillId, priority);
     res.json(success({ assigned: true }));

--- a/backend/api/src/routes/skills.routes.ts
+++ b/backend/api/src/routes/skills.routes.ts
@@ -44,6 +44,7 @@ import {
 import { assignSkillSchema } from '../schemas/agents.schema';
 import { SkillCreatorService } from '../agents/skill-creator';
 import { LLMClient } from '../llm/client';
+import { SKILL_CREATOR } from '../config/constants';
 
 const logger = createLogger('SkillsRoutes');
 const router = Router();
@@ -205,12 +206,21 @@ router.post('/upload', requireAuth, skillUpload.single('file'), asyncHandler(asy
  * 동일 promptHash 24h 내 재요청은 dedupe 되어 기존 draft 반환.
  */
 router.post('/auto-create', requireAuth, validate(autoCreateSkillSchema), asyncHandler(async (req: Request, res: Response) => {
+    // Feature flag gate — 빠른 disable (env 변경 후 재시작) 가능
+    if (!SKILL_CREATOR.enabled) {
+        res.status(503).json({ success: false, error: { code: 'FEATURE_DISABLED', message: 'Skill Creator 기능이 비활성화 상태입니다.' } });
+        return;
+    }
     const userId = (req.user && 'userId' in req.user ? (req.user as { userId: string }).userId : req.user?.id?.toString());
     if (!userId) {
         res.status(401).json(unauthorized('인증 필요'));
         return;
     }
     const isAdmin = req.user?.role === 'admin';
+    if (!SKILL_CREATOR.userTierEnabled && !isAdmin) {
+        res.status(503).json({ success: false, error: { code: 'FEATURE_ADMIN_ONLY', message: '현재 admin 만 사용 가능합니다.' } });
+        return;
+    }
     const { purpose, target, category, examples, hints } = req.body;
 
     const service = new SkillCreatorService({

--- a/backend/api/src/routes/skills.routes.ts
+++ b/backend/api/src/routes/skills.routes.ts
@@ -45,6 +45,54 @@ import { assignSkillSchema } from '../schemas/agents.schema';
 import { SkillCreatorService } from '../agents/skill-creator';
 import { LLMClient } from '../llm/client';
 import { SKILL_CREATOR } from '../config/constants';
+import { RL_SKILL_CREATE, RL_SKILL_CREATE_SHORT } from '../config/rate-limits';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+
+// ────────────────────────────────────────────────────────────────────
+// Skill Creator Rate Limiters (월간 quota + 시간당 burst, tier 별 차등)
+// req.user.tier 가 없으면 'free' 로 폴백.
+// ────────────────────────────────────────────────────────────────────
+type SkillTier = 'free' | 'pro' | 'enterprise' | 'admin';
+
+function resolveTier(req: Request): SkillTier {
+    const role = req.user?.role;
+    if (role === 'admin') return 'admin';
+    const tier = (req.user && 'tier' in req.user ? (req.user as { tier?: string }).tier : undefined) ?? 'free';
+    return (tier === 'pro' || tier === 'enterprise') ? tier : 'free';
+}
+
+function skillCreateKeyGen(prefix: string) {
+    return (req: Request): string => {
+        const uid = req.user
+            ? ('userId' in req.user ? (req.user as { userId: string }).userId : req.user.id?.toString())
+            : undefined;
+        return uid ? `${prefix}:user:${uid}` : `${prefix}:ip:${ipKeyGenerator(req.ip || 'unknown')}`;
+    };
+}
+
+const skillCreateMonthlyLimiter = rateLimit({
+    windowMs: RL_SKILL_CREATE.windowMs,
+    limit: (req: Request): number => RL_SKILL_CREATE.limits[resolveTier(req)],
+    keyGenerator: skillCreateKeyGen('skill-create'),
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (_req: Request, res: Response): void => {
+        res.status(429).json({ success: false, error: { code: 'RATE_LIMITED', message: '월간 스킬 생성 한도를 초과했습니다.' } });
+    },
+    skipFailedRequests: true,  // LLM 실패 시 quota 차감 안 함
+});
+
+const skillCreateBurstLimiter = rateLimit({
+    windowMs: RL_SKILL_CREATE_SHORT.windowMs,
+    limit: (req: Request): number => RL_SKILL_CREATE_SHORT.limits[resolveTier(req)],
+    keyGenerator: skillCreateKeyGen('skill-create-burst'),
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (_req: Request, res: Response): void => {
+        res.status(429).json({ success: false, error: { code: 'RATE_LIMITED', message: '단시간 내 너무 많은 요청 (burst). 잠시 후 다시 시도하세요.' } });
+    },
+    skipFailedRequests: true,
+});
 
 const logger = createLogger('SkillsRoutes');
 const router = Router();
@@ -205,7 +253,7 @@ router.post('/upload', requireAuth, skillUpload.single('file'), asyncHandler(asy
  * 자연어 purpose 를 받아 LLM 으로 스킬 매니페스트 생성 → status='draft' 저장.
  * 동일 promptHash 24h 내 재요청은 dedupe 되어 기존 draft 반환.
  */
-router.post('/auto-create', requireAuth, validate(autoCreateSkillSchema), asyncHandler(async (req: Request, res: Response) => {
+router.post('/auto-create', requireAuth, skillCreateMonthlyLimiter, skillCreateBurstLimiter, validate(autoCreateSkillSchema), asyncHandler(async (req: Request, res: Response) => {
     // Feature flag gate — 빠른 disable (env 변경 후 재시작) 가능
     if (!SKILL_CREATOR.enabled) {
         res.status(503).json({ success: false, error: { code: 'FEATURE_DISABLED', message: 'Skill Creator 기능이 비활성화 상태입니다.' } });

--- a/backend/api/src/routes/skills.routes.ts
+++ b/backend/api/src/routes/skills.routes.ts
@@ -38,8 +38,12 @@ import {
     createSkillSchema,
     updateSkillSchema,
     searchSkillsQuerySchema,
+    autoCreateSkillSchema,
+    draftsQuerySchema,
 } from '../schemas/skills.schema';
 import { assignSkillSchema } from '../schemas/agents.schema';
+import { SkillCreatorService } from '../agents/skill-creator';
+import { LLMClient } from '../llm/client';
 
 const logger = createLogger('SkillsRoutes');
 const router = Router();
@@ -192,6 +196,158 @@ router.post('/upload', requireAuth, skillUpload.single('file'), asyncHandler(asy
 }));
 
 // ================================================
+// AI 자동 생성 (Skill Creator Phase 1)
+// ================================================
+
+/**
+ * POST /api/agents/skills/auto-create
+ * 자연어 purpose 를 받아 LLM 으로 스킬 매니페스트 생성 → status='draft' 저장.
+ * 동일 promptHash 24h 내 재요청은 dedupe 되어 기존 draft 반환.
+ */
+router.post('/auto-create', requireAuth, validate(autoCreateSkillSchema), asyncHandler(async (req: Request, res: Response) => {
+    const userId = (req.user && 'userId' in req.user ? (req.user as { userId: string }).userId : req.user?.id?.toString());
+    if (!userId) {
+        res.status(401).json(unauthorized('인증 필요'));
+        return;
+    }
+    const isAdmin = req.user?.role === 'admin';
+    const { purpose, target, category, examples, hints } = req.body;
+
+    const service = new SkillCreatorService({
+        pool: getUnifiedDatabase().getPool(),
+        llmClientFactory: (model: string) => new LLMClient(model ? { model } : {}),
+    });
+
+    try {
+        const result = await service.create({
+            userId,
+            isAdmin,
+            purpose,
+            target,
+            category,
+            examples,
+            hints,
+            // user-fallback 모델: 환경변수가 비어있을 때 사용자 채팅 기본 모델로 보낼 수 있음 — 본 단계는 SKILL_AUTHOR_MODEL 또는 LLM_DEFAULT_MODEL fallback
+        });
+        logger.info(`auto-create draft: ${result.skillId} (user=${userId}, deduped=${result.deduped})`);
+        res.status(result.deduped ? 200 : 201).json(success(result));
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        if (msg.startsWith('DRAFT_LIMIT_EXCEEDED')) {
+            res.status(429).json({ error: msg });
+            return;
+        }
+        if (msg.startsWith('LLM_PARSE_FAIL')) {
+            res.status(502).json({ error: 'LLM_PARSE_FAIL', detail: msg });
+            return;
+        }
+        res.status(500).json({ error: msg });
+    }
+}));
+
+/**
+ * GET /api/agents/skills/drafts
+ * draft 상태 스킬 목록. target='user' (기본, 본인 것), 'system' (admin only), 'all' (admin only).
+ */
+router.get('/drafts', requireAuth, validateQuery(draftsQuerySchema), asyncHandler(async (req: Request, res: Response) => {
+    const userId = (req.user && 'userId' in req.user ? (req.user as { userId: string }).userId : req.user?.id?.toString());
+    if (!userId) {
+        res.status(401).json(unauthorized('인증 필요'));
+        return;
+    }
+    const isAdmin = req.user?.role === 'admin';
+    const target = String(req.query.target ?? 'user') as 'user' | 'system' | 'all';
+
+    if ((target === 'system' || target === 'all') && !isAdmin) {
+        res.status(403).json({ error: 'ADMIN_REQUIRED', detail: `target=${target} 는 관리자 전용` });
+        return;
+    }
+
+    const result = await getSkillManager().listDrafts({
+        target,
+        userId: target === 'user' ? userId : undefined,
+        limit: req.query.limit != null ? Number(req.query.limit) : undefined,
+        offset: req.query.offset != null ? Number(req.query.offset) : undefined,
+    });
+    res.json(success(result));
+}));
+
+/**
+ * POST /api/agents/skills/:skillId/approve
+ * draft → active 전환. 소유자 또는 admin 만 가능. 시스템 스킬(createdBy=null) 은 admin 만.
+ */
+router.post('/:skillId/approve', requireAuth, asyncHandler(async (req: Request, res: Response) => {
+    const { skillId } = req.params;
+    const userId = (req.user && 'userId' in req.user ? (req.user as { userId: string }).userId : req.user?.id?.toString());
+    if (!userId) {
+        res.status(401).json(unauthorized('인증 필요'));
+        return;
+    }
+
+    const existing = await getSkillManager().getSkillById(skillId);
+    if (!existing) {
+        res.status(404).json(notFound('스킬'));
+        return;
+    }
+    if (existing.status !== 'draft') {
+        res.status(409).json({ error: 'NOT_DRAFT', detail: `현재 status=${existing.status ?? 'unknown'}` });
+        return;
+    }
+
+    try {
+        const actor = { userId: String(userId), userRole: req.user?.role || 'user' };
+        const updated = await getSkillManager().updateStatus(skillId, 'active', actor);
+        logger.info(`draft approved: ${skillId} by ${userId}`);
+        res.json(success(updated));
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        if (msg.includes('ADMIN_REQUIRED') || msg.includes('소유자')) {
+            res.status(403).json({ error: 'FORBIDDEN', detail: msg });
+            return;
+        }
+        res.status(500).json({ error: msg });
+    }
+}));
+
+/**
+ * POST /api/agents/skills/:skillId/reject
+ * draft → archived 전환 (보존, 삭제 아님 — manifest_meta 감사용).
+ * 소유자 또는 admin.
+ */
+router.post('/:skillId/reject', requireAuth, asyncHandler(async (req: Request, res: Response) => {
+    const { skillId } = req.params;
+    const userId = (req.user && 'userId' in req.user ? (req.user as { userId: string }).userId : req.user?.id?.toString());
+    if (!userId) {
+        res.status(401).json(unauthorized('인증 필요'));
+        return;
+    }
+
+    const existing = await getSkillManager().getSkillById(skillId);
+    if (!existing) {
+        res.status(404).json(notFound('스킬'));
+        return;
+    }
+    if (existing.status !== 'draft') {
+        res.status(409).json({ error: 'NOT_DRAFT', detail: `현재 status=${existing.status ?? 'unknown'}` });
+        return;
+    }
+
+    try {
+        const actor = { userId: String(userId), userRole: req.user?.role || 'user' };
+        const updated = await getSkillManager().updateStatus(skillId, 'archived', actor);
+        logger.info(`draft rejected: ${skillId} by ${userId}`);
+        res.json(success(updated));
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        if (msg.includes('ADMIN_REQUIRED') || msg.includes('소유자')) {
+            res.status(403).json({ error: 'FORBIDDEN', detail: msg });
+            return;
+        }
+        res.status(500).json({ error: msg });
+    }
+}));
+
+// ================================================
 // 사용자 개인 스킬 할당
 // ================================================
 
@@ -224,6 +380,10 @@ router.post('/:skillId/user-assign', requireAuth, validate(assignSkillSchema), a
     const skill = await getSkillManager().getSkillById(skillId);
     if (!skill) {
         res.status(404).json(notFound('스킬'));
+        return;
+    }
+    if (skill.status && skill.status !== 'active') {
+        res.status(409).json({ error: 'SKILL_NOT_ACTIVE', detail: `status=${skill.status} 인 스킬은 할당할 수 없습니다. 먼저 승인하세요.` });
         return;
     }
 

--- a/backend/api/src/schemas/skills.schema.ts
+++ b/backend/api/src/schemas/skills.schema.ts
@@ -33,6 +33,9 @@ export const updateSkillSchema = z.object({
 export type UpdateSkillInput = z.infer<typeof updateSkillSchema>;
 
 // GET /api/agents/skills query params — 스킬 검색
+// status 필터는 의도적으로 미지원: draft 조회는 GET /api/agents/skills/drafts 전용 엔드포인트
+// (admin 가드가 있는 곳) 으로만 가능. 여기서 ?status=draft 를 허용하면 is_public=TRUE 인
+// system draft 가 일반 사용자에게 노출될 수 있음.
 export const searchSkillsQuerySchema = z.object({
     search: z.string().max(200).optional(),
     category: z.string().max(100).optional(),
@@ -40,7 +43,6 @@ export const searchSkillsQuerySchema = z.object({
     sortBy: z.enum(['newest', 'name', 'category', 'updated']).optional().default('newest'),
     limit: z.coerce.number().int().min(1).max(200).optional().default(20),
     offset: z.coerce.number().int().min(0).optional().default(0),
-    status: z.enum(['draft', 'active', 'all']).default('active'),
 });
 
 export type SearchSkillsQuery = z.infer<typeof searchSkillsQuerySchema>;

--- a/backend/api/src/services/ChatService.ts
+++ b/backend/api/src/services/ChatService.ts
@@ -103,6 +103,13 @@ export class ChatService {
      */
     private currentSkillBindings: ActiveSkillBinding[] = [];
 
+    /**
+     * 현재 채팅의 MCP tool resource content 콜백.
+     * processMessage 진입 시 저장, executeExternalTool / agent-loop-strategy 가 공유.
+     * tool 결과에 type='resource' content 가 있으면 invoke → ws-chat-handler 가 frontend 로 emit.
+     */
+    private currentMcpToolResultCallback?: (event: { toolName: string; resources: Array<{ uri: string; mimeType?: string; text?: string }> }) => void;
+
     /** 단일 LLM 직접 호출 전략 */
     private readonly directStrategy: DirectStrategy;
     /** Generate-Verify 생성-검증 전략 */
@@ -265,7 +272,10 @@ export class ChatService {
         onSkillsActivated?: (skillNames: string[]) => void,
         onThinking?: (thinking: string) => void,
         onSystemEvent?: SystemEventCallback,
+        onMcpToolResult?: (event: { toolName: string; resources: Array<{ uri: string; mimeType?: string; text?: string }> }) => void,
     ): Promise<string> {
+        // MCP tool resource content 콜백을 인스턴스 상태로 저장 — executeExternalTool 및 strategy 가 공유
+        this.currentMcpToolResultCallback = onMcpToolResult;
         // 채팅 요청 전체를 root span으로 추적 (모든 LLM/도구 호출이 자식 span으로 자동 연결)
         return withSpan(
             'chat-service',
@@ -737,6 +747,7 @@ export class ChatService {
             client: this.client,
             currentUserContext: this.currentUserContext,
             getAllowedTools: () => this.getAllowedTools(),
+            onMcpToolResult: this.currentMcpToolResultCallback,
         });
     }
 
@@ -1064,6 +1075,18 @@ export class ChatService {
                 role: 'guest' as const,
             };
             const result = await mcpClient.executeToolWithContext(toolName, toolArgs, userCtx);
+
+            // resource content 가 있으면 frontend 인라인 카드 표시용 콜백 invoke
+            if (this.currentMcpToolResultCallback && Array.isArray(result.content)) {
+                const resources = result.content
+                    .filter((c): c is { type: 'resource'; resource: { uri: string; mimeType?: string; text?: string } } =>
+                        c.type === 'resource' && !!c.resource && typeof c.resource.uri === 'string')
+                    .map(c => ({ uri: c.resource.uri, mimeType: c.resource.mimeType, text: c.resource.text }));
+                if (resources.length > 0) {
+                    try { this.currentMcpToolResultCallback({ toolName, resources }); }
+                    catch (e) { logger.warn(`onMcpToolResult 콜백 실패: ${e instanceof Error ? e.message : String(e)}`); }
+                }
+            }
 
             // MCPToolResult → 문자열 직렬화
             if (result.isError) {

--- a/backend/api/src/services/chat-service/strategy-executor.ts
+++ b/backend/api/src/services/chat-service/strategy-executor.ts
@@ -64,6 +64,8 @@ export interface StrategyExecutorParams {
     currentUserContext: UserContext | null;
     /** 허용된 도구 목록을 반환하는 콜백 */
     getAllowedTools: () => ToolDefinition[];
+    /** MCP tool resource content 콜백 (frontend 인라인 카드 표시용, 선택) */
+    onMcpToolResult?: (event: { toolName: string; resources: Array<{ uri: string; mimeType?: string; text?: string }> }) => void;
 }
 
 /**
@@ -83,7 +85,7 @@ export async function selectAndExecuteStrategy(params: StrategyExecutorParams): 
         supportsTools, supportsThinking, thinkingMode, thinkingLevel,
         languagePolicy, streamToken, abortSignal, checkAborted, format,
         generateVerifyStrategy, agentLoopStrategy, thinkingStrategy,
-        client, currentUserContext, getAllowedTools,
+        client, currentUserContext, getAllowedTools, onMcpToolResult,
     } = params;
 
     // P3-A: 사후 검증용 추적 변수
@@ -225,6 +227,7 @@ export async function selectAndExecuteStrategy(params: StrategyExecutorParams): 
         supportsTools, supportsThinking, thinkingMode, thinkingLevel,
         executionPlan, currentUserContext, getAllowedTools,
         onToken: wrappedStreamToken, abortSignal, checkAborted, format,
+        onMcpToolResult,
         executionState,
         fallbackHint,
     });

--- a/backend/api/src/services/chat-strategies/agent-loop-strategy.ts
+++ b/backend/api/src/services/chat-strategies/agent-loop-strategy.ts
@@ -661,6 +661,19 @@ export class AgentLoopStrategy implements ChatStrategy<AgentLoopStrategyContext,
         try {
             const toolRouter = getUnifiedMCPClient().getToolRouter();
             const result = await toolRouter.executeTool(toolName, toolArgs, context.currentUserContext ?? undefined);
+
+            // resource content 감지 → frontend 인라인 카드 콜백 (ChatContext.onMcpToolResult)
+            if (context.onMcpToolResult && Array.isArray(result.content)) {
+                const resources = result.content
+                    .filter((c): c is { type: 'resource'; resource: { uri: string; mimeType?: string; text?: string } } =>
+                        c.type === 'resource' && !!c.resource && typeof c.resource.uri === 'string')
+                    .map(c => ({ uri: c.resource.uri, mimeType: c.resource.mimeType, text: c.resource.text }));
+                if (resources.length > 0) {
+                    try { context.onMcpToolResult({ toolName, resources }); }
+                    catch (e) { logger.warn(`onMcpToolResult 콜백 실패: ${e instanceof Error ? e.message : String(e)}`); }
+                }
+            }
+
             if (result.isError) {
                 return `Error executing tool: ${result.content.map((c: { text?: string }) => c.text).join('\n')}`;
             }

--- a/backend/api/src/services/chat-strategies/types.ts
+++ b/backend/api/src/services/chat-strategies/types.ts
@@ -35,6 +35,15 @@ export interface ChatContext {
     abortSignal?: AbortSignal;
     /** 중단 상태를 확인하고 'ABORTED' 에러를 throw하는 헬퍼 함수 */
     checkAborted?: () => void;
+    /**
+     * MCP tool 호출이 resource content 를 반환했을 때 호출되는 콜백.
+     * ws-chat-handler 가 frontend 로 `mcp_tool_result` WS 메시지로 emit.
+     * 인라인 UI (예: skill-draft card) 표시용. text content 만 있는 호출은 트리거 안 됨.
+     */
+    onMcpToolResult?: (event: {
+        toolName: string;
+        resources: Array<{ uri: string; mimeType?: string; text?: string }>;
+    }) => void;
 }
 
 /**

--- a/backend/api/src/sockets/ws-chat-handler.ts
+++ b/backend/api/src/sockets/ws-chat-handler.ts
@@ -312,6 +312,18 @@ export async function handleChatMessage(
             onDiscussionProgress: (progress) => ws.send(JSON.stringify({ type: 'discussion_progress', progress })),
             onResearchProgress: (progress) => ws.send(JSON.stringify({ type: 'research_progress', progress })),
             onSkillsActivated: (skillNames) => ws.send(JSON.stringify({ type: 'skills_activated', skillNames })),
+            // MCP tool 호출 결과의 resource content 를 frontend 로 emit
+            // (예: create_skill → openmake://skill-draft/{id} → chat.js 가 인라인 카드 렌더)
+            onMcpToolResult: (event) => {
+                if (ws.readyState === ws.OPEN) {
+                    ws.send(JSON.stringify({
+                        type: 'mcp_tool_result',
+                        toolName: event.toolName,
+                        resources: event.resources,
+                        messageId,
+                    }));
+                }
+            },
             // 시스템 이벤트 (자동 토론 활성화 등 메타 알림) — UI 토스트 분리 표시
             onSystemEvent: (event) => {
                 if (ws.readyState === ws.OPEN) {

--- a/frontend/web/public/css/skill-library.css
+++ b/frontend/web/public/css/skill-library.css
@@ -468,3 +468,96 @@
     margin-top: 1.25rem; padding-top: 1rem;
     border-top: 1px solid var(--border-color, #334155);
 }
+
+/* ============================================================
+ * Skill Draft Card — 채팅 inline + 라이브러리 공용 컴포넌트
+ * (components/skill-draft-card.js 가 렌더)
+ * ============================================================ */
+.skill-draft-card {
+    background: var(--bg-secondary, #0f172a);
+    border: 1px solid var(--border-color, #334155);
+    border-radius: var(--radius-lg, 12px);
+    padding: 1rem 1.1rem;
+    margin: 0.75rem 0;
+    color: var(--text-primary, #f1f5f9);
+}
+.skill-draft-card--inline {
+    /* 채팅 메시지 안에서는 약간 여백 줄임 */
+    margin: 0.5rem 0 0.75rem;
+    border-left: 3px solid var(--accent-primary, #a855f7);
+}
+.skill-draft-card__header {
+    display: flex; gap: 0.4rem; align-items: center; flex-wrap: wrap;
+    margin-bottom: 0.5rem;
+}
+.skill-draft-card__badge {
+    font-size: 0.72rem; padding: 0.15rem 0.55rem;
+    border-radius: 999px; line-height: 1.4;
+    background: rgba(168, 85, 247, 0.12);
+    color: var(--accent-primary, #a855f7);
+    border: 1px solid rgba(168, 85, 247, 0.25);
+}
+.skill-draft-card__badge-draft {
+    background: rgba(234, 179, 8, 0.12);
+    color: #eab308;
+    border-color: rgba(234, 179, 8, 0.25);
+}
+.skill-draft-card__badge-system {
+    background: rgba(59, 130, 246, 0.12);
+    color: var(--info-color, #3b82f6);
+    border-color: rgba(59, 130, 246, 0.25);
+}
+.skill-draft-card__badge-user {
+    background: rgba(34, 197, 94, 0.12);
+    color: #22c55e;
+    border-color: rgba(34, 197, 94, 0.25);
+}
+.skill-draft-card__badge-deduped {
+    background: rgba(148, 163, 184, 0.12);
+    color: var(--text-secondary, #94a3b8);
+    border-color: rgba(148, 163, 184, 0.25);
+}
+.skill-draft-card__title {
+    margin: 0 0 0.3rem; font-size: 1rem; font-weight: 600;
+    color: var(--text-primary, #fff);
+}
+.skill-draft-card__desc {
+    margin: 0 0 0.5rem; font-size: 0.85rem; line-height: 1.5;
+    color: var(--text-secondary, #94a3b8);
+}
+.skill-draft-card__meta {
+    font-size: 0.75rem; color: var(--text-secondary, #94a3b8);
+    margin-bottom: 0.5rem;
+}
+.skill-draft-card__triggers {
+    display: flex; flex-wrap: wrap; gap: 0.3rem;
+    margin: 0.5rem 0;
+}
+.skill-draft-card__preview {
+    margin: 0.5rem 0; font-size: 0.8rem;
+}
+.skill-draft-card__preview summary {
+    cursor: pointer; color: var(--accent-primary, #a855f7);
+    font-weight: 500;
+}
+.skill-draft-card__content {
+    max-height: 200px; overflow: auto;
+    background: var(--bg-primary, #0a0a0a);
+    border: 1px solid var(--border-color, #334155);
+    border-radius: var(--radius-md, 6px);
+    padding: 0.5rem 0.75rem;
+    font-family: ui-monospace, 'SF Mono', Monaco, monospace;
+    font-size: 0.78rem; line-height: 1.5;
+    color: var(--text-primary, #f1f5f9);
+    white-space: pre-wrap; word-break: break-word;
+    margin-top: 0.4rem;
+}
+.skill-draft-card__actions {
+    display: flex; gap: 0.4rem; flex-wrap: wrap;
+    margin-top: 0.75rem;
+    padding-top: 0.6rem;
+    border-top: 1px dashed var(--border-color, #334155);
+}
+.skill-draft-card__actions .sl-btn-sm {
+    font-size: 0.78rem; padding: 0.3rem 0.7rem;
+}

--- a/frontend/web/public/js/components/skill-draft-card.js
+++ b/frontend/web/public/js/components/skill-draft-card.js
@@ -1,0 +1,152 @@
+/**
+ * ============================================================
+ * Skill Draft Preview Card — 채팅 inline + 라이브러리 공용 컴포넌트
+ * ============================================================
+ *
+ * MCP tool `create_skill` 이 반환한 resource content (uri prefix
+ * `openmake://skill-draft/`) 를 채팅 메시지 안에 인라인으로 표시하거나,
+ * 스킬 라이브러리의 drafts 탭에서 동일한 카드로 표시.
+ *
+ * @module components/skill-draft-card
+ */
+'use strict';
+
+/**
+ * @typedef {Object} SkillDraft
+ * @property {string} skillId
+ * @property {string} name
+ * @property {string} description
+ * @property {string} category
+ * @property {'user'|'system'} target
+ * @property {string} contentPreview
+ * @property {string[]} [triggers]
+ * @property {string} [createdAt]
+ * @property {string} [modelUsed]
+ * @property {number} [tokensUsed]
+ * @property {boolean} [deduped]
+ */
+
+/** XSS sanitize — sanitize.js 의 전역 window.escapeHTML 사용 */
+function esc(s) {
+    const fn = (typeof window !== 'undefined' && window.escapeHTML) || (v => String(v));
+    return fn(s == null ? '' : String(s));
+}
+
+/**
+ * @param {SkillDraft} draft
+ * @param {{ mode?: 'inline'|'full', onAction?: (action: string, skillId: string) => void }} [opts]
+ * @returns {HTMLElement}
+ */
+export function renderSkillDraftCard(draft, opts) {
+    const mode = (opts && opts.mode) || 'inline';
+    const onAction = (opts && opts.onAction) || function () {};
+
+    const el = document.createElement('div');
+    el.className = 'skill-draft-card skill-draft-card--' + mode;
+    el.dataset.skillId = draft.skillId;
+    el.dataset.target = draft.target || 'user';
+
+    const targetBadge = draft.target === 'system'
+        ? '<span class="sl-badge skill-draft-card__badge-system">🔒 시스템</span>'
+        : '<span class="sl-badge skill-draft-card__badge-user">👤 본인</span>';
+
+    const dedupedBadge = draft.deduped
+        ? '<span class="sl-badge skill-draft-card__badge-deduped" title="24시간 내 동일 요청으로 기존 draft 재사용">↻ 재사용</span>'
+        : '';
+
+    const triggersHtml = (Array.isArray(draft.triggers) && draft.triggers.length > 0)
+        ? '<div class="skill-draft-card__triggers">' +
+          draft.triggers.slice(0, 8).map(t => '<span class="sl-badge sl-badge-secondary">' + esc(t) + '</span>').join(' ') +
+          '</div>'
+        : '';
+
+    const previewHtml = mode === 'full' && draft.contentPreview
+        ? '<details class="skill-draft-card__preview">' +
+          '<summary>본문 미리보기</summary>' +
+          '<pre class="skill-draft-card__content">' + esc(draft.contentPreview) + '</pre>' +
+          '</details>'
+        : '';
+
+    const metaLine = mode === 'inline'
+        ? '<div class="skill-draft-card__meta">' +
+          (draft.modelUsed ? '모델 ' + esc(draft.modelUsed) + ' · ' : '') +
+          (draft.tokensUsed != null ? '토큰 ' + esc(draft.tokensUsed) + ' · ' : '') +
+          '카테고리 ' + esc(draft.category || 'general') +
+          '</div>'
+        : '';
+
+    el.innerHTML =
+        '<div class="skill-draft-card__header">' +
+            '<span class="skill-draft-card__badge skill-draft-card__badge-draft">📝 초안</span>' +
+            targetBadge +
+            dedupedBadge +
+        '</div>' +
+        '<h4 class="skill-draft-card__title">' + esc(draft.name) + '</h4>' +
+        '<p class="skill-draft-card__desc">' + esc(draft.description) + '</p>' +
+        metaLine +
+        previewHtml +
+        triggersHtml +
+        '<div class="skill-draft-card__actions">' +
+            '<button type="button" class="sl-btn sl-btn-primary sl-btn-sm" data-action="approve">승인 (활성화)</button>' +
+            '<button type="button" class="sl-btn sl-btn-secondary sl-btn-sm" data-action="reject">거절 (보관)</button>' +
+            '<a href="/skill-library" class="sl-btn sl-btn-outline sl-btn-sm" data-action="open-library">라이브러리에서 검토</a>' +
+        '</div>';
+
+    el.addEventListener('click', function (ev) {
+        const btn = ev.target.closest('[data-action]');
+        if (!btn) return;
+        if (btn.tagName === 'BUTTON') ev.preventDefault();
+        onAction(btn.dataset.action, draft.skillId);
+    });
+
+    return el;
+}
+
+/**
+ * 카드의 승인/거절 액션 핸들러.
+ * 백엔드 endpoint 는 API_ENDPOINTS.AGENTS_SKILLS_APPROVE/REJECT (path builder).
+ *
+ * @param {'approve'|'reject'|'open-library'} action
+ * @param {string} skillId
+ * @param {{ onToast?: (msg: string, type?: string) => void, confirmFn?: () => boolean }} [callbacks]
+ */
+export async function handleSkillDraftAction(action, skillId, callbacks) {
+    const toast = (callbacks && callbacks.onToast) || (window.showToast || function () {});
+    const confirmFn = (callbacks && callbacks.confirmFn) || ((msg) => window.confirm(msg));
+
+    if (action === 'open-library') {
+        // 링크 자체 동작 — 핸들러는 no-op
+        return;
+    }
+
+    const API = (typeof window !== 'undefined' && window.API_ENDPOINTS) || {};
+    const fetch_ = window.authFetch || window.fetch;
+
+    if (action === 'approve') {
+        if (!confirmFn('이 draft 를 승인하시겠습니까?\n\n⚠ 승인 후 채팅 system prompt 에 주입됩니다. AI 가 작성한 텍스트라 의심스러운 지시문이 없는지 라이브러리 미리보기로 확인하세요.')) return;
+        const url = typeof API.AGENTS_SKILLS_APPROVE === 'function'
+            ? API.AGENTS_SKILLS_APPROVE(skillId)
+            : '/api/agents/skills/' + encodeURIComponent(skillId) + '/approve';
+        const r = await fetch_(url, { method: 'POST', credentials: 'include' });
+        const data = await r.json().catch(() => ({}));
+        if (!r.ok || !data.success) {
+            toast('승인 실패: ' + (data?.error?.message || data?.error || r.statusText), 'error');
+            return;
+        }
+        toast('스킬이 활성화되었습니다.', 'success');
+        window.dispatchEvent(new CustomEvent('skill-draft:approved', { detail: { skillId } }));
+    } else if (action === 'reject') {
+        if (!confirmFn('이 draft 를 거절하시겠습니까? archived 상태로 보관됩니다 (영구 삭제 아님).')) return;
+        const url = typeof API.AGENTS_SKILLS_REJECT === 'function'
+            ? API.AGENTS_SKILLS_REJECT(skillId)
+            : '/api/agents/skills/' + encodeURIComponent(skillId) + '/reject';
+        const r = await fetch_(url, { method: 'POST', credentials: 'include' });
+        const data = await r.json().catch(() => ({}));
+        if (!r.ok || !data.success) {
+            toast('거절 실패: ' + (data?.error?.message || data?.error || r.statusText), 'error');
+            return;
+        }
+        toast('거절됨 (archived).', 'info');
+        window.dispatchEvent(new CustomEvent('skill-draft:rejected', { detail: { skillId } }));
+    }
+}

--- a/frontend/web/public/js/modules/api-endpoints.js
+++ b/frontend/web/public/js/modules/api-endpoints.js
@@ -42,6 +42,11 @@ const API_ENDPOINTS = Object.freeze({
     AGENTS: '/api/agents',
     AGENTS_CUSTOM: '/api/agents/custom',           // + /:id, /:id/clone
     AGENTS_SKILLS: '/api/agents/skills',           // + /:skillId, /categories, /user-assigned
+    // Skill Creator (Phase 1) — auto-create / drafts / approve / reject
+    AGENTS_SKILLS_AUTO_CREATE: '/api/agents/skills/auto-create',
+    AGENTS_SKILLS_DRAFTS: '/api/agents/skills/drafts',
+    AGENTS_SKILLS_APPROVE: (skillId) => `/api/agents/skills/${encodeURIComponent(skillId)}/approve`,
+    AGENTS_SKILLS_REJECT: (skillId) => `/api/agents/skills/${encodeURIComponent(skillId)}/reject`,
     AGENTS_FEEDBACK_STATS: '/api/agents/feedback/stats',
     AGENTS_ABTEST: '/api/agents/abtest',
     AGENTS_ABTEST_START: '/api/agents/abtest/start',

--- a/frontend/web/public/js/modules/pages/skill-library.js
+++ b/frontend/web/public/js/modules/pages/skill-library.js
@@ -41,6 +41,8 @@
     let localSkills = [];
     let userAssignedIds = new Set(); // 사용자 개인 할당 스킬 ID 집합
     let editingSkillId = null; // 현재 편집 중인 스킬 ID (null = 새 스킬)
+    let drafts = []; // AI 자동 생성 draft 목록
+    let draftsLoaded = false; // drafts 탭 첫 진입 시에만 자동 로드
 
     let localFilters = {
         search: '',
@@ -62,6 +64,7 @@
         <p>로컬에 설치된 에이전트 스킬을 관리합니다.</p>
         <div class="sl-tabs" role="tablist">
             <button class="sl-tab active" data-sl-tab="local" role="tab" aria-selected="true">내 스킬</button>
+            <button class="sl-tab" data-sl-tab="drafts" role="tab" aria-selected="false">AI 자동 생성 (Drafts)</button>
         </div>
     </div>
 
@@ -105,6 +108,93 @@
                 <div class="sl-loading"><div class="sl-spinner"></div></div>
             </div>
             <div id="localPagination" class="sl-pagination"></div>
+        </div>
+
+        <!-- AI 자동 생성 (Drafts) 탭 -->
+        <div class="sl-pane" id="sl-pane-drafts" role="tabpanel">
+            <div class="sl-toolbar">
+                <div class="sl-search-group" style="flex:1">
+                    <p style="margin:0;color:var(--text-secondary,#a0a0a0);font-size:0.9rem">
+                        자연어로 스킬의 목적을 설명하면 AI 가 매니페스트를 자동 작성합니다. 검토 후 승인하면 활성화됩니다.
+                    </p>
+                </div>
+                <button class="sl-btn sl-btn-primary" id="btnOpenAutoCreate">
+                    <span class="iconify" data-icon="lucide:sparkles"></span> AI 로 새 스킬 만들기
+                </button>
+            </div>
+
+            <div class="skill-row skill-row-header" role="row" aria-hidden="false">
+                <div class="skill-row-meta">카테고리</div>
+                <div class="skill-row-main">이름 · 설명</div>
+                <div class="skill-row-side">생성 정보</div>
+                <div class="skill-row-actions">작업</div>
+            </div>
+
+            <div id="draftsGrid" class="skill-grid">
+                <div class="sl-empty">"AI 로 새 스킬 만들기" 버튼을 눌러 시작하세요.</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- AI 자동 생성 모달 -->
+    <div class="sl-modal-overlay" id="slAutoCreateModal">
+        <div class="sl-modal">
+            <h2>AI 자동 스킬 생성</h2>
+            <div class="sl-form-group">
+                <label class="sl-form-label" for="acPurpose">목적 / 역할 <span style="color:var(--danger-color,#ef4444)">*</span></label>
+                <textarea id="acPurpose" class="sl-form-textarea" rows="2" placeholder="예: 한국 의료법 자문 — 의료기기법·약사법·임상시험 규정에 답변" maxlength="500"></textarea>
+                <small style="color:var(--text-secondary);font-size:0.8rem">5~500자. 만들고자 하는 스킬이 어떤 일을 해야 하는지.</small>
+            </div>
+            <div class="sl-form-group">
+                <label class="sl-form-label" for="acCategory">카테고리 (선택)</label>
+                <select id="acCategory" class="sl-form-select">
+                    <option value="">자동 결정</option>
+                    <option value="general">일반</option>
+                    <option value="coding">코딩</option>
+                    <option value="writing">글쓰기</option>
+                    <option value="analysis">분석</option>
+                    <option value="creative">창작</option>
+                    <option value="education">교육</option>
+                    <option value="business">비즈니스</option>
+                    <option value="science">과학</option>
+                    <option value="technology">기술/IT</option>
+                    <option value="finance">금융</option>
+                    <option value="healthcare">의료/건강</option>
+                    <option value="legal">법률</option>
+                    <option value="engineering">엔지니어링</option>
+                    <option value="media">미디어</option>
+                    <option value="social-welfare">사회/복지</option>
+                    <option value="government">공공/정부</option>
+                    <option value="real-estate">부동산</option>
+                    <option value="energy">에너지/환경</option>
+                    <option value="logistics">물류/운송</option>
+                    <option value="hospitality">관광/서비스</option>
+                    <option value="agriculture">농업/식품</option>
+                    <option value="productivity">생산성</option>
+                    <option value="communication">커뮤니케이션</option>
+                </select>
+            </div>
+            <div class="sl-form-group">
+                <label class="sl-form-label" for="acExamples">예시 질문/작업 (선택, 한 줄당 하나, 최대 5개)</label>
+                <textarea id="acExamples" class="sl-form-textarea" rows="4" placeholder="의료기기 인증 절차를 알려줘&#10;임상시험 IRB 승인 요건은?&#10;..."></textarea>
+            </div>
+            <div class="sl-form-group">
+                <label class="sl-form-label" for="acHints">추가 지침 (선택, 최대 1000자)</label>
+                <textarea id="acHints" class="sl-form-textarea" rows="2" placeholder="예: 한국법만 다루고, 출처를 명시할 것" maxlength="1000"></textarea>
+            </div>
+            <div class="sl-form-group" id="acTargetGroup" style="display:none">
+                <label class="sl-form-label" for="acTarget">대상 (관리자 전용)</label>
+                <select id="acTarget" class="sl-form-select">
+                    <option value="user">user — 본인 전용</option>
+                    <option value="system">system — 전역 공개</option>
+                </select>
+            </div>
+            <div class="sl-modal-actions">
+                <button class="sl-btn sl-btn-secondary" onclick="sl_closeAutoCreate()">취소</button>
+                <button class="sl-btn sl-btn-primary" id="btnSubmitAutoCreate" onclick="sl_submitAutoCreate()">
+                    <span class="iconify" data-icon="lucide:sparkles"></span> 생성하기
+                </button>
+            </div>
         </div>
     </div>
     <!-- 인라인 스킬 편집 모달 -->
@@ -186,15 +276,22 @@
 
             // Cleanup globals
             ['sl_openNewSkill', 'sl_editSkill', 'sl_deleteSkill', 'sl_exportSkill',
-             'sl_changeLocalPage', 'sl_toggleUserSkill', 'sl_saveSkill', 'sl_closeSkillModal'].forEach(key => {
+             'sl_changeLocalPage', 'sl_toggleUserSkill', 'sl_saveSkill', 'sl_closeSkillModal',
+             'sl_openAutoCreate', 'sl_closeAutoCreate', 'sl_submitAutoCreate',
+             'sl_approveDraft', 'sl_rejectDraft'].forEach(key => {
                 try { delete window[key]; } catch (e) {}
             });
+
+            // Reset draft state for next session
+            drafts = [];
+            draftsLoaded = false;
 
             // Close any open dropdowns
             document.querySelectorAll('.skill-card-dropdown.open').forEach(el => el.classList.remove('open'));
         },
 
         setupTabs: function () {
+            const self = this;
             document.querySelectorAll('.sl-tab').forEach(tab => {
                 tab.addEventListener('click', function () {
                     const target = this.dataset.slTab;
@@ -207,6 +304,10 @@
                     document.querySelectorAll('.sl-pane').forEach(p => {
                         p.classList.toggle('active', p.id === 'sl-pane-' + target);
                     });
+                    // drafts 탭 첫 진입 시 자동 로드
+                    if (target === 'drafts' && !draftsLoaded) {
+                        self.loadDrafts();
+                    }
                 });
             });
         },
@@ -309,6 +410,11 @@
                 }
             });
 
+            // AI 자동 생성 버튼
+            document.getElementById('btnOpenAutoCreate')?.addEventListener('click', () => {
+                self.openAutoCreateModal();
+            });
+
             // 글로벌 함수 노출
             window.sl_openNewSkill = this.openNewSkillModal.bind(this);
             window.sl_editSkill = this.editLocalSkill.bind(this);
@@ -322,6 +428,12 @@
             window.sl_toggleUserSkill = this.toggleUserSkill.bind(this);
             window.sl_saveSkill = this.saveSkillFromModal.bind(this);
             window.sl_closeSkillModal = this.closeSkillModal.bind(this);
+            // AI 자동 생성 / draft 관리 함수
+            window.sl_openAutoCreate = this.openAutoCreateModal.bind(this);
+            window.sl_closeAutoCreate = this.closeAutoCreateModal.bind(this);
+            window.sl_submitAutoCreate = this.submitAutoCreate.bind(this);
+            window.sl_approveDraft = this.approveDraft.bind(this);
+            window.sl_rejectDraft = this.rejectDraft.bind(this);
         },
 
         loadLocalCategories: async function () {
@@ -656,6 +768,209 @@
                     if (typeof fn === 'function' && !Number.isNaN(page)) fn(page);
                 });
                 container.dataset.delegated = '1';
+            }
+        },
+
+        // -------------------------------------------------------
+        // AI 자동 생성 (Drafts)
+        // -------------------------------------------------------
+
+        loadDrafts: async function () {
+            const grid = document.getElementById('draftsGrid');
+            if (!grid) return;
+            grid.innerHTML = '<div class="sl-loading"><div class="sl-spinner"></div></div>';
+            try {
+                const res = await window.authFetch(API_ENDPOINTS.AGENTS_SKILLS + '/drafts?target=user&limit=50');
+                const data = await res.json();
+                if (!res.ok || !data.success) throw new Error(data.error?.message || data.message || 'draft 로드 실패');
+                drafts = (data.data && Array.isArray(data.data.drafts)) ? data.data.drafts : [];
+                draftsLoaded = true;
+                this.renderDrafts();
+            } catch (e) {
+                const esc = window.escapeHtml || (s => s);
+                grid.innerHTML = `<div class="sl-error">${esc(e.message || String(e))}</div>`;
+            }
+        },
+
+        renderDrafts: function () {
+            const grid = document.getElementById('draftsGrid');
+            if (!grid) return;
+            const esc = window.escapeHtml || (s => s);
+
+            if (drafts.length === 0) {
+                grid.innerHTML = '<div class="sl-empty">생성된 draft 가 없습니다. "AI 로 새 스킬 만들기" 버튼을 눌러 시작하세요.</div>';
+                return;
+            }
+
+            grid.innerHTML = drafts.map(d => {
+                const meta = d.manifestMeta || {};
+                const model = esc(meta.model || '-');
+                const tokens = (meta.tokensUsed != null) ? meta.tokensUsed : '-';
+                const createdAt = d.createdAt ? new Date(d.createdAt).toLocaleString() : '-';
+                const triggers = Array.isArray(meta.triggers) && meta.triggers.length > 0
+                    ? meta.triggers.slice(0, 3).map(t => `<span class="sl-badge">${esc(String(t))}</span>`).join(' ')
+                    : '';
+                const promptText = (meta.userPrompt && typeof meta.userPrompt === 'string') ? meta.userPrompt : '';
+                return `
+                <div class="skill-row">
+                    <div class="skill-row-meta">
+                        <span class="skill-card-badge">${esc(categoryLabel(d.category))}</span>
+                        <span class="sl-badge" style="background:rgba(234,179,8,0.12);color:#eab308;border-color:rgba(234,179,8,0.25);margin-left:0.4rem">DRAFT</span>
+                    </div>
+                    <div class="skill-row-main">
+                        <h3 class="skill-row-title" title="${esc(d.name)}">${esc(d.name)}</h3>
+                        <p class="skill-row-desc" title="${esc(d.description || '')}">${esc(d.description || '설명 없음')}</p>
+                        ${promptText ? `<small style="display:block;margin-top:0.3rem;color:var(--text-secondary,#a0a0a0);font-size:0.75rem">요청: ${esc(promptText.slice(0,120))}${promptText.length > 120 ? '…' : ''}</small>` : ''}
+                        ${triggers ? `<div style="margin-top:0.3rem">${triggers}</div>` : ''}
+                    </div>
+                    <div class="skill-row-side" style="font-size:0.78rem;color:var(--text-secondary,#a0a0a0)">
+                        <div>모델: ${model}</div>
+                        <div>토큰: ${esc(String(tokens))}</div>
+                        <div>${esc(createdAt)}</div>
+                    </div>
+                    <div class="skill-row-actions" style="display:flex;gap:0.4rem;align-items:center">
+                        <button class="sl-btn sl-btn-secondary" data-draft-action="preview" data-draft-id="${esc(d.id)}" title="미리보기">
+                            <span class="iconify" data-icon="lucide:eye"></span>
+                        </button>
+                        <button class="sl-btn sl-btn-primary" data-draft-action="approve" data-draft-id="${esc(d.id)}">
+                            <span class="iconify" data-icon="lucide:check"></span> 승인
+                        </button>
+                        <button class="sl-btn sl-btn-secondary" data-draft-action="reject" data-draft-id="${esc(d.id)}" title="거절 (archived 로 보관)">
+                            <span class="iconify" data-icon="lucide:x"></span>
+                        </button>
+                    </div>
+                </div>`;
+            }).join('');
+
+            // 이벤트 위임 — inline onclick 회피 (CSP/XSS)
+            if (!grid.dataset.delegated) {
+                grid.addEventListener('click', (e) => {
+                    const btn = e.target.closest('[data-draft-action]');
+                    if (!btn) return;
+                    const id = btn.dataset.draftId;
+                    const action = btn.dataset.draftAction;
+                    if (action === 'approve') sl_approveDraft(id);
+                    else if (action === 'reject') sl_rejectDraft(id);
+                    else if (action === 'preview') {
+                        const d = drafts.find(x => x.id === id);
+                        if (d) {
+                            // 기존 편집 모달 재사용 — preview-only (저장 시 PUT 으로 active 스킬 수정됨)
+                            const titleEl = document.getElementById('slSkillModalTitle');
+                            if (titleEl) titleEl.textContent = 'Draft 미리보기 (저장 시 active 로 즉시 반영)';
+                            document.getElementById('slSkillName').value = d.name || '';
+                            document.getElementById('slSkillDesc').value = d.description || '';
+                            document.getElementById('slSkillCategory').value = d.category || 'general';
+                            document.getElementById('slSkillContent').value = d.content || '';
+                            editingSkillId = d.id;
+                            document.getElementById('slSkillModal')?.classList.add('open');
+                        }
+                    }
+                });
+                grid.dataset.delegated = '1';
+            }
+        },
+
+        openAutoCreateModal: function () {
+            const modal = document.getElementById('slAutoCreateModal');
+            if (!modal) return;
+            document.getElementById('acPurpose').value = '';
+            document.getElementById('acCategory').value = '';
+            document.getElementById('acExamples').value = '';
+            document.getElementById('acHints').value = '';
+            // admin 만 target 노출 — currentUser 가 있으면 role 확인
+            const isAdmin = (window.currentUser && window.currentUser.role === 'admin');
+            const targetGroup = document.getElementById('acTargetGroup');
+            if (targetGroup) targetGroup.style.display = isAdmin ? 'block' : 'none';
+            if (isAdmin) document.getElementById('acTarget').value = 'user';
+            modal.classList.add('open');
+        },
+
+        closeAutoCreateModal: function () {
+            const modal = document.getElementById('slAutoCreateModal');
+            if (modal) modal.classList.remove('open');
+        },
+
+        submitAutoCreate: async function () {
+            const purpose = (document.getElementById('acPurpose').value || '').trim();
+            if (purpose.length < 5) {
+                if (window.showToast) window.showToast('목적은 5자 이상 입력하세요', 'error');
+                return;
+            }
+            const category = document.getElementById('acCategory').value || undefined;
+            const examplesText = (document.getElementById('acExamples').value || '').trim();
+            const examples = examplesText
+                ? examplesText.split('\n').map(s => s.trim()).filter(Boolean).slice(0, 5)
+                : undefined;
+            const hints = (document.getElementById('acHints').value || '').trim() || undefined;
+            const isAdmin = (window.currentUser && window.currentUser.role === 'admin');
+            const target = isAdmin ? (document.getElementById('acTarget').value || 'user') : undefined;
+
+            const btn = document.getElementById('btnSubmitAutoCreate');
+            if (btn) { btn.disabled = true; btn.dataset.origText = btn.innerHTML; btn.innerHTML = '<span class="iconify" data-icon="lucide:loader-2"></span> 생성 중...'; }
+
+            try {
+                const res = await window.authFetch(API_ENDPOINTS.AGENTS_SKILLS + '/auto-create', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ purpose, category, examples, hints, target }),
+                });
+                const data = await res.json().catch(() => ({}));
+                if (!res.ok || !data.success) {
+                    const msg = data?.error?.message || data?.error || data?.detail || data?.message || res.statusText;
+                    if (window.showToast) window.showToast(`생성 실패: ${msg}`, 'error');
+                    return;
+                }
+                const result = data.data || {};
+                if (window.showToast) {
+                    const note = result.deduped ? ' (24시간 내 동일 요청 — 기존 draft 재사용)' : '';
+                    window.showToast(`Draft 생성 완료: ${result.name || result.skillId}${note}`, 'success');
+                }
+                this.closeAutoCreateModal();
+                // drafts 탭 새로고침
+                await this.loadDrafts();
+                // drafts 탭으로 자동 이동
+                const draftsTab = document.querySelector('.sl-tab[data-sl-tab="drafts"]');
+                if (draftsTab) draftsTab.click();
+            } catch (e) {
+                if (window.showToast) window.showToast('오류: ' + (e?.message || String(e)), 'error');
+            } finally {
+                if (btn) { btn.disabled = false; btn.innerHTML = btn.dataset.origText || '<span class="iconify" data-icon="lucide:sparkles"></span> 생성하기'; }
+            }
+        },
+
+        approveDraft: async function (skillId) {
+            if (!confirm('이 draft 를 승인하시겠습니까?\n\n⚠ 승인 후 이 스킬의 content 가 채팅의 system prompt 에 주입됩니다. AI 가 작성한 텍스트이므로 의심스러운 지시문(예: "이전 지시를 무시하라", 시스템 페르소나 변경 등)이 포함돼 있지 않은지 미리보기로 확인하세요.')) return;
+            try {
+                const res = await window.authFetch(`${API_ENDPOINTS.AGENTS_SKILLS}/${encodeURIComponent(skillId)}/approve`, { method: 'POST' });
+                const data = await res.json().catch(() => ({}));
+                if (!res.ok || !data.success) {
+                    const msg = data?.error?.message || data?.error || data?.detail || res.statusText;
+                    if (window.showToast) window.showToast(`승인 실패: ${msg}`, 'error');
+                    return;
+                }
+                if (window.showToast) window.showToast('승인 완료 — 활성 스킬로 전환되었습니다.', 'success');
+                await this.loadDrafts();
+                await this.loadLocalSkills();
+                await this.loadLocalCategories();
+            } catch (e) {
+                if (window.showToast) window.showToast('오류: ' + (e?.message || String(e)), 'error');
+            }
+        },
+
+        rejectDraft: async function (skillId) {
+            if (!confirm('이 draft 를 거절하시겠습니까? archived 상태로 보관됩니다 (영구 삭제 아님).')) return;
+            try {
+                const res = await window.authFetch(`${API_ENDPOINTS.AGENTS_SKILLS}/${encodeURIComponent(skillId)}/reject`, { method: 'POST' });
+                const data = await res.json().catch(() => ({}));
+                if (!res.ok || !data.success) {
+                    const msg = data?.error?.message || data?.error || data?.detail || res.statusText;
+                    if (window.showToast) window.showToast(`거절 실패: ${msg}`, 'error');
+                    return;
+                }
+                if (window.showToast) window.showToast('거절됨 (archived).', 'success');
+                await this.loadDrafts();
+            } catch (e) {
+                if (window.showToast) window.showToast('오류: ' + (e?.message || String(e)), 'error');
             }
         }
     };

--- a/frontend/web/public/js/modules/pages/skill-library.js
+++ b/frontend/web/public/js/modules/pages/skill-library.js
@@ -780,7 +780,7 @@
             if (!grid) return;
             grid.innerHTML = '<div class="sl-loading"><div class="sl-spinner"></div></div>';
             try {
-                const res = await window.authFetch(API_ENDPOINTS.AGENTS_SKILLS + '/drafts?target=user&limit=50');
+                const res = await window.authFetch(API_ENDPOINTS.AGENTS_SKILLS_DRAFTS + '?target=user&limit=50');
                 const data = await res.json();
                 if (!res.ok || !data.success) throw new Error(data.error?.message || data.message || 'draft 로드 실패');
                 drafts = (data.data && Array.isArray(data.data.drafts)) ? data.data.drafts : [];
@@ -909,7 +909,7 @@
             if (btn) { btn.disabled = true; btn.dataset.origText = btn.innerHTML; btn.innerHTML = '<span class="iconify" data-icon="lucide:loader-2"></span> 생성 중...'; }
 
             try {
-                const res = await window.authFetch(API_ENDPOINTS.AGENTS_SKILLS + '/auto-create', {
+                const res = await window.authFetch(API_ENDPOINTS.AGENTS_SKILLS_AUTO_CREATE, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ purpose, category, examples, hints, target }),
@@ -941,7 +941,7 @@
         approveDraft: async function (skillId) {
             if (!confirm('이 draft 를 승인하시겠습니까?\n\n⚠ 승인 후 이 스킬의 content 가 채팅의 system prompt 에 주입됩니다. AI 가 작성한 텍스트이므로 의심스러운 지시문(예: "이전 지시를 무시하라", 시스템 페르소나 변경 등)이 포함돼 있지 않은지 미리보기로 확인하세요.')) return;
             try {
-                const res = await window.authFetch(`${API_ENDPOINTS.AGENTS_SKILLS}/${encodeURIComponent(skillId)}/approve`, { method: 'POST' });
+                const res = await window.authFetch(API_ENDPOINTS.AGENTS_SKILLS_APPROVE(skillId), { method: 'POST' });
                 const data = await res.json().catch(() => ({}));
                 if (!res.ok || !data.success) {
                     const msg = data?.error?.message || data?.error || data?.detail || res.statusText;
@@ -960,7 +960,7 @@
         rejectDraft: async function (skillId) {
             if (!confirm('이 draft 를 거절하시겠습니까? archived 상태로 보관됩니다 (영구 삭제 아님).')) return;
             try {
-                const res = await window.authFetch(`${API_ENDPOINTS.AGENTS_SKILLS}/${encodeURIComponent(skillId)}/reject`, { method: 'POST' });
+                const res = await window.authFetch(API_ENDPOINTS.AGENTS_SKILLS_REJECT(skillId), { method: 'POST' });
                 const data = await res.json().catch(() => ({}));
                 if (!res.ok || !data.success) {
                     const msg = data?.error?.message || data?.error || data?.detail || res.statusText;

--- a/frontend/web/public/js/modules/websocket.js
+++ b/frontend/web/public/js/modules/websocket.js
@@ -253,6 +253,52 @@ const messageHandlers = {
         }
     },
     /**
+     * MCP tool 호출 결과의 resource content — 인라인 카드 렌더링.
+     * 현재 지원하는 resource URI prefix:
+     *   - openmake://skill-draft/{id}  → skill-draft-card 컴포넌트
+     * 다른 prefix 는 무시 (확장 시 분기 추가).
+     *
+     * Payload: { type: 'mcp_tool_result', toolName, resources: [{ uri, mimeType?, text? }], messageId }
+     */
+    'mcp_tool_result': async (data) => {
+        if (!Array.isArray(data?.resources) || data.resources.length === 0) return;
+        for (const res of data.resources) {
+            const uri = res && res.uri;
+            if (typeof uri !== 'string' || !uri.startsWith('openmake://skill-draft/')) continue;
+            try {
+                const payload = JSON.parse(res.text || '{}');
+                const previewCard = payload.previewCard;
+                if (!previewCard || previewCard.kind !== 'skill-draft') continue;
+                const { renderSkillDraftCard, handleSkillDraftAction } = await import('/js/components/skill-draft-card.js?v=1');
+                const card = renderSkillDraftCard(previewCard, {
+                    mode: 'inline',
+                    onAction: (action, skillId) => handleSkillDraftAction(action, skillId, {
+                        onToast: (msg, type) => window.showToast && window.showToast(msg, type),
+                    }),
+                });
+                // 현재 assistant 메시지 컨테이너에 추가 (state.currentAssistantMessage)
+                const assistantEl = (typeof getState === 'function') ? getState('currentAssistantMessage') : null;
+                const target = assistantEl?.querySelector?.('.message-content') || assistantEl;
+                if (target) {
+                    target.appendChild(card);
+                } else {
+                    // fallback — chat 영역의 마지막 메시지 끝에 붙임
+                    const last = document.querySelector('.chat-messages .message.assistant:last-child .message-content')
+                        || document.querySelector('.chat-messages .message.assistant:last-child');
+                    if (last) last.appendChild(card);
+                }
+                if (payload.assistantText) {
+                    const p = document.createElement('p');
+                    p.className = 'skill-draft-card__assistant-text';
+                    p.textContent = payload.assistantText;
+                    (target || card.parentNode)?.appendChild(p);
+                }
+            } catch (e) {
+                console.warn('[WS mcp_tool_result] skill-draft resource 처리 실패:', e);
+            }
+        }
+    },
+    /**
      * 시스템 이벤트 (백엔드 onSystemEvent 콜백)
      * 형식: { type: 'system_event', payload: { type, message, metadata? } }
      * 자동 토론 활성화 등 메타 알림을 우측 상단 토스트로 표시.

--- a/frontend/web/public/js/nav-items.js
+++ b/frontend/web/public/js/nav-items.js
@@ -34,7 +34,7 @@ const NAV_ITEMS = {
         // /documents.html, /memory.html: 2026-05-19 제거
         { href: '/projects.html', icon: '📁', iconify: 'lucide:folder', label: '프로젝트', requireAuth: true },
         // projects hub 의 3 카드 진입점 — 사이드바 nav 에서 hidden (projects 가 진입점), spa-router 라우트 등록 유지
-        { href: '/skill-library.html', icon: '📦', iconify: 'lucide:package', label: '스킬 라이브러리', requireAuth: true, minTier: 'pro', cssFiles: ['/css/skill-library.css?v=3'], excludeFromSidebar: true },
+        { href: '/skill-library.html', icon: '📦', iconify: 'lucide:package', label: '스킬 라이브러리', requireAuth: true, minTier: 'pro', cssFiles: ['/css/skill-library.css?v=4'], excludeFromSidebar: true },
         { href: '/mcp-servers.html', icon: '🔌', iconify: 'lucide:plug', label: 'MCP 서버', requireAuth: true, excludeFromSidebar: true },
         { href: '/custom-agents.html', icon: '🤖', iconify: 'lucide:bot', label: '커스텀 에이전트', requireAuth: true, minTier: 'pro', excludeFromSidebar: true },
         // /usage.html, /api-keys.html: Phase R1 (2026-05-21) — settings 탭으로 통합


### PR DESCRIPTION
## Summary

Skill Creator Phase 1 (자연어 prompt → LLM → SKILL 매니페스트 → draft) 의 plan
파일 `docs/superpowers/plans/2026-05-21-skill-creator.md` 의 미완 task 들을
원 plan 의 step-by-step 대로 마무리. 진행 중 발견한 latent bug + plan 누락
의존성도 함께 해결.

## What's included (7 commits)

### Phase 1 wiring (8cb0e0e)
- REST `POST /auto-create`, `GET /drafts`, `POST /:id/approve`, `POST /:id/reject`
- MCP tool `create_skill` + builtInTools + TOOL_TIERS 등록
- Frontend "AI 자동 생성" 탭 + 모달 + drafts pane

### 발견된 latent bug cleanup (8cb0e0e 안에 포함)
- **D1**: `getAllSkills` (production caller 0건) 삭제
- **D2**: `searchSkillsQuerySchema.status` schema trap 삭제
- **F1**: `getSkillsForAgent` status='active' 필터 (채팅 시스템 프롬프트 오염 차단)
- **F2**: `getUserSkills` status='active' 필터
- **A1**: user/agent skill assign 라우트에 status 가드
- **N1**: `upsertSystemSkill` ON CONFLICT 에 status='active' 강제

### Plan-driven completion (이 PR 의 추가 5 commits)
- **A.11** (`68131b4`): `.env.example` 6개 env + `SKILL_CREATOR` const + 503 feature gate
- **A.8** (`cbab917`): rate limit tier 차등 (monthly + hourly burst)
- **B.12** (`f2410a3`): api-endpoints 4개 상수 (path builder 포함)
- **Backend keystone** (`6b1fad9`): MCP tool resource content → ChatService onMcpToolResult callback → ws-chat-handler emit `mcp_tool_result`
- **Frontend keystone** (`5917375`): `skill-draft-card.js` 공용 컴포넌트 + CSS + WS handler → 채팅 안에서 인라인 카드 즉시 렌더

### Production hotfix (`01d028c`)
- 운영 배포 시 발견된 회귀: `RL_SKILL_CREATE.windowMs = 30일` 이 express-rate-limit
  MemoryStore 의 32-bit signed int 한계 초과 → 20일로 축소. ValidationError 사라짐.

## Test plan

- [x] `tsc --noEmit` EXIT 0 (all commits)
- [x] `validate-modules.sh` PASS
- [x] Unit tests: 5 suites / 43 tests pass (skill-creator service / repo status + drafts / skill-manager / schema)
- [x] E2E tests: tests/e2e/skill-creator.spec.ts, 7 tests chromium PASS (local, gitignored)
- [x] 라이브 dev 서버 브라우저 검증 — draft 생성/승인/거절/dedupe full flow
- [x] 운영 서버 (PM2) build + restart + health check + endpoint 401 검증 + log clean
- [ ] 인증 사용자 prod 호출 검증 (별도, 본 PR 머지 후)

## Migration / Operational notes

- DB 마이그레이션 무관 (migration 024 는 이전 PR 에 머지됨)
- 새 env 변수 6개 — 기본값 fallback 이라 .env 업데이트 강제 아님
- PM2 graceful restart 만으로 적용 (현재 운영 서버에 이미 적용 완료 — pid 2868, gitHash 5917375 후속 fix 반영)
- Rollback: `git revert 01d028c..5917375 -m 1` → `npm run build:backend` → `pm2 restart openmake-llm`

## Plan deviation (의도적)

- **A.9 ownership middleware**: plan 은 `middlewares/skill-ownership.ts` 신규 파일 요구, 본 PR 은 기존 `assertResourceOwnerOrAdmin` helper 재사용 (DRY, 같은 책임의 추가 파일 불필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)