### PR TITLE
feat(skill-creator): /auto-create SSE 지원 — long-running LLM timeout 방어 (closes #25)

### DIFF
--- a/backend/api/src/routes/skills.routes.ts
+++ b/backend/api/src/routes/skills.routes.ts
@@ -250,8 +250,15 @@ router.post('/upload', requireAuth, skillUpload.single('file'), asyncHandler(asy
 
 /**
  * POST /api/agents/skills/auto-create
+ *
  * 자연어 purpose 를 받아 LLM 으로 스킬 매니페스트 생성 → status='draft' 저장.
  * 동일 promptHash 24h 내 재요청은 dedupe 되어 기존 draft 반환.
+ *
+ * 응답 형식 — Accept 헤더로 분기:
+ *   - `Accept: text/event-stream` → SSE 스트림 (heartbeat + 최종 result event)
+ *       LLM 호출이 60~120s 걸리는 동안 proxy idle timeout 방어. 클라이언트는
+ *       progress 이벤트로 UX 표시 가능.
+ *   - 그 외 (default JSON) → 기존 blocking REST 응답 (호환 유지)
  */
 router.post('/auto-create', requireAuth, skillCreateMonthlyLimiter, skillCreateBurstLimiter, validate(autoCreateSkillSchema), asyncHandler(async (req: Request, res: Response) => {
     // Feature flag gate — 빠른 disable (env 변경 후 재시작) 가능
@@ -276,6 +283,43 @@ router.post('/auto-create', requireAuth, skillCreateMonthlyLimiter, skillCreateB
         llmClientFactory: (model: string) => new LLMClient(model ? { model } : {}),
     });
 
+    const wantsSSE = (req.headers.accept || '').includes('text/event-stream');
+
+    if (wantsSSE) {
+        // SSE 모드: heartbeat 로 connection 유지 + 최종 결과는 'result' event
+        res.setHeader('Content-Type', 'text/event-stream');
+        res.setHeader('Cache-Control', 'no-cache, no-transform');
+        res.setHeader('Connection', 'keep-alive');
+        res.setHeader('X-Accel-Buffering', 'no');  // nginx 버퍼링 비활성
+        res.flushHeaders?.();
+
+        // 5s 마다 SSE 주석 라인 (heartbeat) — proxy idle timeout 차단
+        const heartbeat = setInterval(() => {
+            try { res.write(`: heartbeat ${Date.now()}\n\n`); } catch { /* noop */ }
+        }, 5_000);
+        // 시작 이벤트 — frontend 가 "생성 중..." UX 띄울 수 있게
+        res.write(`event: progress\ndata: ${JSON.stringify({ phase: 'llm_call_started', ts: Date.now() })}\n\n`);
+
+        try {
+            const result = await service.create({ userId, isAdmin, purpose, target, category, examples, hints });
+            clearInterval(heartbeat);
+            logger.info(`auto-create draft (SSE): ${result.skillId} (user=${userId}, deduped=${result.deduped})`);
+            res.write(`event: result\ndata: ${JSON.stringify({ success: true, status: result.deduped ? 200 : 201, data: result })}\n\n`);
+            res.end();
+        } catch (e) {
+            clearInterval(heartbeat);
+            const msg = e instanceof Error ? e.message : String(e);
+            const code = msg.startsWith('DRAFT_LIMIT_EXCEEDED') ? 'DRAFT_LIMIT_EXCEEDED'
+                : msg.startsWith('LLM_PARSE_FAIL') ? 'LLM_PARSE_FAIL'
+                : 'INTERNAL_ERROR';
+            const httpStatus = code === 'DRAFT_LIMIT_EXCEEDED' ? 429 : code === 'LLM_PARSE_FAIL' ? 502 : 500;
+            res.write(`event: error\ndata: ${JSON.stringify({ success: false, status: httpStatus, error: { code, message: msg } })}\n\n`);
+            res.end();
+        }
+        return;
+    }
+
+    // JSON 모드 (기존 동작 — 호환 유지)
     try {
         const result = await service.create({
             userId,

--- a/frontend/web/public/js/modules/pages/skill-library.js
+++ b/frontend/web/public/js/modules/pages/skill-library.js
@@ -908,27 +908,81 @@
             const btn = document.getElementById('btnSubmitAutoCreate');
             if (btn) { btn.disabled = true; btn.dataset.origText = btn.innerHTML; btn.innerHTML = '<span class="iconify" data-icon="lucide:loader-2"></span> 생성 중...'; }
 
+            // SSE 모드 — backend 의 long-running LLM 호출 (60~120s) 동안 proxy idle drop 방어 + 진행 UX
             try {
                 const res = await window.authFetch(API_ENDPOINTS.AGENTS_SKILLS_AUTO_CREATE, {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', 'Accept': 'text/event-stream' },
                     body: JSON.stringify({ purpose, category, examples, hints, target }),
                 });
-                const data = await res.json().catch(() => ({}));
-                if (!res.ok || !data.success) {
-                    const msg = data?.error?.message || data?.error || data?.detail || data?.message || res.statusText;
+                if (!res.ok) {
+                    const errData = await res.json().catch(() => ({}));
+                    const msg = errData?.error?.message || errData?.error || errData?.detail || res.statusText;
                     if (window.showToast) window.showToast(`생성 실패: ${msg}`, 'error');
                     return;
                 }
-                const result = data.data || {};
+
+                // Content-Type 분기: SSE 면 stream 파싱, 아니면 기존 JSON 호환
+                const ct = (res.headers.get('Content-Type') || '').toLowerCase();
+                let result = null;
+                let errorPayload = null;
+
+                if (ct.includes('text/event-stream')) {
+                    // SSE reader — 'event: <name>\ndata: <json>\n\n' 청크 파싱
+                    const reader = res.body.getReader();
+                    const decoder = new TextDecoder();
+                    let buffer = '';
+                    while (true) {
+                        const { value, done } = await reader.read();
+                        if (done) break;
+                        buffer += decoder.decode(value, { stream: true });
+                        const events = buffer.split('\n\n');
+                        buffer = events.pop() || '';
+                        for (const raw of events) {
+                            const lines = raw.split('\n');
+                            let evName = 'message';
+                            let dataStr = '';
+                            for (const ln of lines) {
+                                if (ln.startsWith(':')) continue; // 주석 (heartbeat)
+                                if (ln.startsWith('event:')) evName = ln.slice(6).trim();
+                                else if (ln.startsWith('data:')) dataStr += ln.slice(5).trim();
+                            }
+                            if (!dataStr) continue;
+                            try {
+                                const payload = JSON.parse(dataStr);
+                                if (evName === 'progress') {
+                                    // 진행 표시 — 버튼 라벨 갱신
+                                    if (btn) btn.innerHTML = '<span class="iconify" data-icon="lucide:loader-2"></span> LLM 호출 중...';
+                                } else if (evName === 'result') {
+                                    result = payload.data;
+                                } else if (evName === 'error') {
+                                    errorPayload = payload.error || { message: '알 수 없는 오류' };
+                                }
+                            } catch (_e) { /* malformed event chunk — 무시 */ }
+                        }
+                    }
+                } else {
+                    // Fallback: JSON 응답 (구버전 backend 호환)
+                    const data = await res.json().catch(() => ({}));
+                    if (data.success) result = data.data;
+                    else errorPayload = data.error;
+                }
+
+                if (errorPayload) {
+                    if (window.showToast) window.showToast(`생성 실패: ${errorPayload.message || JSON.stringify(errorPayload)}`, 'error');
+                    return;
+                }
+                if (!result) {
+                    if (window.showToast) window.showToast('응답을 받았으나 result 가 비어있습니다', 'error');
+                    return;
+                }
+
                 if (window.showToast) {
                     const note = result.deduped ? ' (24시간 내 동일 요청 — 기존 draft 재사용)' : '';
                     window.showToast(`Draft 생성 완료: ${result.name || result.skillId}${note}`, 'success');
                 }
                 this.closeAutoCreateModal();
-                // drafts 탭 새로고침
                 await this.loadDrafts();
-                // drafts 탭으로 자동 이동
                 const draftsTab = document.querySelector('.sl-tab[data-sl-tab="drafts"]');
                 if (draftsTab) draftsTab.click();
             } catch (e) {


### PR DESCRIPTION
## Summary

GitHub [issue #25](https://github.com/openmake/openmake_llm/issues/25) 해결. LLM 호출 60~120s 동안 proxy/client idle timeout 으로 응답을 받지 못하는 문제를 SSE 로 해결.

## 핵심 변경

### Backend: skills.routes.ts `/auto-create`
- Accept 헤더 분기: `text/event-stream` 이면 SSE 응답, 아니면 기존 JSON
- SSE 모드: heartbeat (5s 주기) + progress 이벤트 + result/error 이벤트
- nginx 등 proxy 의 stream 모드 진입을 위한 X-Accel-Buffering: no 헤더
- SkillCreatorService 자체 변경 없음 — surgical refactor

### Frontend: skill-library.js `submitAutoCreate`
- Accept: text/event-stream 으로 요청
- `res.body.getReader()` + TextDecoder 로 SSE 청크 파싱
- 'progress' 이벤트로 버튼 라벨 "LLM 호출 중..." 갱신 (UX 개선)
- Content-Type 이 SSE 아니면 fallback JSON 파싱 (구버전 backend 호환)

## 옵션 분석 (issue #25 에 명시)

| 옵션 | 채택? | 이유 |
|---|---|---|
| A. SSE | ✅ | 같은 endpoint, header 분기. 기존 호환 유지. SkillCreatorService 무변경 |
| B. Async Job + Polling | ❌ | jobs 테이블 + GET endpoint 추가, 인프라 ↑ |
| C. WS 일관성 | ❌ | user WS session 없을 때 fallback 필요, 라이브러리 모달은 WS 미연결 |

## Test plan

- [x] `tsc --noEmit` EXIT 0
- [x] `validate-modules.sh` PASS
- [x] 기존 7 e2e tests 영향 없음 (Accept 미명시 → JSON path)
- [ ] Prod 배포 후 라이브 검증 (Accept: text/event-stream 으로 actual LLM 호출, heartbeat 수신 확인)

## Operational notes

- Rollback: SSE 코드 블록만 제거하면 기존 JSON path 그대로 동작
- nginx 등 reverse proxy 사용 시 `proxy_buffering off;` 또는 `X-Accel-Buffering: no` 헤더 (백엔드가 이미 설정) 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)