### PR TITLE
feat(skill-creator): SKILL_AUTHOR_MOCK env seam for E2E (closes #26)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -356,3 +356,9 @@ SKILL_DRAFT_TTL_DAYS=30
 
 # 사용자 1인당 누적 draft 상한. 초과 시 DRAFT_LIMIT_EXCEEDED.
 SKILL_AUTO_CREATE_MAX_DRAFTS_PER_USER=50
+
+# E2E 테스트 전용 — true 면 LLM 호출 우회하고 결정론적 mock 매니페스트 반환.
+# 운영 환경에서는 절대 true 설정 금지 (보안 + 데이터 무결성).
+# CI 의 playwright 또는 jest e2e 테스트에서만 사용:
+#   SKILL_AUTHOR_MOCK=true PORT=52417 npm run dev:api
+SKILL_AUTHOR_MOCK=false

--- a/backend/api/src/agents/skill-creator.ts
+++ b/backend/api/src/agents/skill-creator.ts
@@ -209,6 +209,25 @@ export class SkillCreatorService {
         tokensUsed: number;
         modelTier: 'system' | 'user-fallback';
     }> {
+        // E2E test seam — SKILL_AUTHOR_MOCK=true 면 LLM 호출 우회 + 결정론적 매니페스트.
+        // 운영 환경에서는 반드시 false (기본값). CI/E2E 전용.
+        if (process.env.SKILL_AUTHOR_MOCK === 'true') {
+            const purposeSlug = (input.purpose || 'mock-skill').slice(0, 30).replace(/[<>"&]/g, '');
+            return {
+                manifest: {
+                    name: `Mock Skill: ${purposeSlug}`,
+                    description: `결정론적 mock 응답 — purpose 첫 30자 echo. 실제 LLM 호출 없음 (SKILL_AUTHOR_MOCK=true).`,
+                    category: (input.category as LlmSkillManifest['category']) || 'general',
+                    content: `## Mock Skill Content\n\nThis is a deterministic mock manifest for E2E testing.\n\nUser purpose: ${input.purpose}\n\n${'A'.repeat(300)}`,
+                    triggers: ['mock', 'test', 'e2e'],
+                    tags: ['mock-skill', 'e2e-fixture'],
+                },
+                modelUsed: 'mock',
+                tokensUsed: 0,
+                modelTier: 'system',
+            };
+        }
+
         const userPrompt = this.buildUserPrompt(input);
         const fallbackEnabled = process.env.SKILL_AUTHOR_FALLBACK === 'true';
         let modelTier: 'system' | 'user-fallback' = 'system';

--- a/backend/api/src/config/constants.ts
+++ b/backend/api/src/config/constants.ts
@@ -125,6 +125,9 @@ export const SKILL_CREATOR = {
     authorFallback: process.env.SKILL_AUTHOR_FALLBACK === 'true',
     draftTtlDays: parseInt(process.env.SKILL_DRAFT_TTL_DAYS || '30', 10),
     maxDraftsPerUser: parseInt(process.env.SKILL_AUTO_CREATE_MAX_DRAFTS_PER_USER || '50', 10),
+    // E2E test seam — true 면 LLM 호출 우회, 결정론적 mock 매니페스트 반환.
+    // 운영 환경에서는 절대 true 설정 금지 (보안 + 데이터 무결성).
+    authorMock: process.env.SKILL_AUTHOR_MOCK === 'true',
 } as const;
 
 // ============================================


### PR DESCRIPTION
## Summary

GitHub [issue #26](https://github.com/openmake/openmake_llm/issues/26) 해결. Playwright happy path E2E 가 LLM 호출 의존성 없이 결정론적으로 실행되도록 test seam 1개 추가.

## 핵심 변경

### Backend: `skill-creator.ts` `generateManifest`
- 첫 줄에 `if (process.env.SKILL_AUTHOR_MOCK === 'true')` 분기
- 활성 시 LLM 호출 우회, purpose 첫 30자 echo 한 결정론적 매니페스트 반환
- `modelUsed='mock'`, `tokensUsed=0`, `modelTier='system'`
- zod schema 통과하는 최소 content 길이 충족

### Config: `constants.ts` + `.env.example`
- `SKILL_CREATOR.authorMock` 노출 (디버깅 보조)
- `.env.example` 에 `SKILL_AUTHOR_MOCK=false` + **운영 환경 절대 true 금지 경고**

### E2E spec (tests/e2e/skill-creator.spec.ts — gitignored)
신규 happy path describe 블록, 4 tests:
- admin fixture 생성 + mock 활성 감지 (응답시간 < 5s 휴리스틱)
- 전체 흐름: auto-create → drafts → approve → library 노출
- reject 흐름: draft → archived + 라이브러리 미노출
- dedupe: 동일 promptHash → 200 + same skillId + deduped:true

기존 7개 (인증/Schema/라우팅) + 신규 4개 = **11 tests**.

## 효과

| 항목 | 변경 전 | 변경 후 |
|---|---|---|
| E2E 1회 실행 시간 | 60~120s+ per LLM call | **1.5s 전체** |
| LLM API 비용 | 매 실행 발생 | **0** |
| vLLM 서버 의존성 | 필수 | **없음** |
| 응답 결정성 | LLM varies | **결정적** |

## Test plan

- [x] `tsc --noEmit` EXIT 0
- [x] `SKILL_AUTHOR_MOCK=true PORT=52417 npm run dev:api` 로 mock dev 서버 기동
- [x] `PW_TEST_BASE_URL=http://localhost:52417 npx playwright test` → 11/11 PASS in chromium (1.5s)
- [x] 운영 서버 :52416 영향 없음 (mock seam 1줄 분기, 정상 path 무변경)
- [x] 임시 admin fixture user/skill cleanup (afterAll + FK CASCADE)

## Operational notes

- **운영 환경에서 `SKILL_AUTHOR_MOCK=true` 설정 금지** — 모든 사용자 호출이 mock 매니페스트 반환됨. `.env.example` 주석에 명시.
- CI/CD 에서는 dedicated test 환경에서만 활성화
- Rollback: 1줄 if 분기 제거하면 즉시 기존 동작 복귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)