### PR TITLE
feat(mcp-ingest): Phase 4.5 — import_mcp_server_from_git MCP tool

### DIFF
--- a/backend/api/src/mcp/mcp-server-ingest-tool.ts
+++ b/backend/api/src/mcp/mcp-server-ingest-tool.ts
@@ -1,0 +1,176 @@
+/**
+ * ============================================================
+ * MCP Tool: import_mcp_server_from_git - Git URL → MCP server draft (Phase 4.5)
+ * ============================================================
+ *
+ * 채팅 중 LLM 이 호출 가능한 도구. GitHub URL 을 받아 McpServerIngestService
+ * 통해 MCPSERVER.md 매니페스트를 가져와 status='draft' + enabled=false +
+ * visibility='user_private' 3중 잠금으로 저장합니다.
+ *
+ * Phase 3.5 의 `import_agent_from_git` (agent-ingest-tool.ts) 패턴 100% 차용 —
+ * text 응답 (LLM next-turn) + resource content (frontend inline card) 듀얼 반환.
+ *
+ * @module mcp/mcp-server-ingest-tool
+ */
+import type { MCPToolDefinition, MCPToolResult } from './types';
+import type { UserContext } from './user-sandbox';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('McpServerIngestTool');
+
+interface ImportMcpServerFromGitArgs extends Record<string, unknown> {
+    gitUrl: string;
+    gitRef?: string;
+    gitPath?: string;
+    accessToken?: string;
+}
+
+export const importMcpServerFromGitTool: MCPToolDefinition<ImportMcpServerFromGitArgs> = {
+    tool: {
+        name: 'import_mcp_server_from_git',
+        description: 'GitHub URL 에서 MCPSERVER.md 매니페스트를 가져와 MCP server draft 로 저장합니다. 사용자가 명시적으로 "이 git url 의 MCP server 가져와줘", "이 저장소를 MCP 서버로 import 해줘" 같은 요청을 했을 때만 호출하세요. 저장된 draft 는 status=draft + enabled=false + visibility=user_private 3중 잠금이라 사용자가 카드에서 검토 후 승인해야 활성화됩니다. tree 에 MCPSERVER.md 가 여러 개면 후보 목록만 반환 (재호출에서 gitPath 명시 필요). 위험 명령 패턴 (curl|sh, rm -rf, base64 exec 등) 이 감지되면 자동 승인이 차단됩니다.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                gitUrl: {
+                    type: 'string',
+                    description: 'GitHub 저장소 URL. 형식: "https://github.com/owner/repo" 또는 단축 "owner/repo".',
+                },
+                gitRef: {
+                    type: 'string',
+                    description: '브랜치/태그/SHA (선택). 기본 HEAD.',
+                },
+                gitPath: {
+                    type: 'string',
+                    description: '명시적 단일 파일 경로 (선택). 미지정 시 자동 스캔 (root MCPSERVER.md → *.mcpserver.md → *.mcp-server.md → mcp-servers/*.md). multi-candidate 응답을 받았다면 이 인자로 재호출.',
+                },
+                accessToken: {
+                    type: 'string',
+                    description: 'GitHub access token (선택). private repo / rate limit 우회. 요청 한정 — DB 미저장.',
+                },
+            },
+            required: ['gitUrl'],
+        },
+    },
+    handler: async (args, context?: UserContext): Promise<MCPToolResult> => {
+        if (!context?.userId) {
+            return {
+                content: [{ type: 'text', text: '인증 컨텍스트가 없어 MCP server 를 가져올 수 없습니다.' }],
+                isError: true,
+            };
+        }
+        const userId = String(context.userId);
+        const isAdmin = context.role === 'admin';
+
+        try {
+            const { McpServerIngestService } = await import('../agents/git-ingest/mcp-server-ingest-service');
+            const { GitFetcher } = await import('../agents/git-ingest/git-fetcher');
+            const { LLMClient } = await import('../llm/client');
+            const { getUnifiedDatabase } = await import('../data/models/unified-database');
+            const { MCP_INGEST } = await import('../config/constants');
+
+            if (!MCP_INGEST.enabled) {
+                return {
+                    content: [{ type: 'text', text: 'MCP server ingest 기능이 비활성화 상태입니다. 관리자에게 MCP_INGEST_ENABLED 환경변수 확인 요청하세요.' }],
+                    isError: true,
+                };
+            }
+
+            const service = new McpServerIngestService({
+                pool: getUnifiedDatabase().getPool(),
+                llmClientFactory: (model: string) => new LLMClient(model ? { model } : {}),
+                fetcherFactory: (opts) => new GitFetcher({
+                    accessToken: opts.accessToken,
+                    timeoutMs: MCP_INGEST.gitFetchTimeoutMs,
+                }),
+            });
+
+            const result = await service.import({
+                userId,
+                isAdmin,
+                gitUrl: args.gitUrl,
+                gitRef: args.gitRef,
+                gitPath: args.gitPath,
+                accessToken: args.accessToken,
+            });
+
+            // multi-candidate 응답 — text 만
+            if ('selectionRequired' in result && result.selectionRequired) {
+                const list = result.candidates.map((c, i) => `  ${i + 1}. ${c.path} (${c.size} bytes)`).join('\n');
+                const text = `MCPSERVER.md 후보 ${result.totalCandidates}개 발견 — 가져올 파일 경로를 \`gitPath\` 인자로 명시해 재호출하세요:\n\n${list}\n\n예: \`import_mcp_server_from_git({ gitUrl: "${args.gitUrl}", gitPath: "${result.candidates[0].path}" })\``;
+                logger.info(`MCP import_mcp_server_from_git multi-candidate: ${result.candidates.length} (user=${userId}, gitUrl=${args.gitUrl})`);
+                return { content: [{ type: 'text', text }] };
+            }
+
+            // Single result — frontend 가 인라인 카드로 렌더할 resource content 동봉
+            const previewCard = {
+                kind: 'mcp-server-draft' as const,
+                serverId: result.serverId,
+                name: result.name,
+                description: result.description,
+                category: result.category,
+                transportType: result.transportType,
+                transport_type: result.transportType,
+                command: result.command,
+                args: result.args,
+                env: result.env,
+                url: result.url,
+                requiredEnv: result.requiredEnv,
+                manifest_meta: {
+                    gitUrl: result.gitUrl,
+                    gitRef: result.gitRef,
+                    gitPath: result.gitPath,
+                    description: result.description,
+                    category: result.category,
+                    requiredEnv: result.requiredEnv,
+                    conventionFindings: result.conventionFindings,
+                    blockedByConvention: result.blockedByConvention,
+                },
+                conventionFindings: result.conventionFindings,
+                blockedByConvention: result.blockedByConvention,
+                tokensUsed: result.tokensUsed,
+                deduped: result.deduped,
+            };
+
+            const assistantText = result.deduped
+                ? `24시간 내 동일 git ref/path 라 기존 MCP server draft "${result.name}" 를 재사용했습니다. 아래 카드에서 검토·승인하세요.`
+                : `Git URL 에서 "${result.name}" MCP server 를 가져왔습니다 (status=draft, enabled=false). 아래 카드에서 검토·승인하세요.`;
+            const blockedSuffix = result.blockedByConvention
+                ? '\n\n⚠ 위험 명령 패턴이 감지되어 승인이 차단됩니다. command/args 를 검토하세요.'
+                : '';
+            const requiredEnvSuffix = result.requiredEnv.length > 0
+                ? `\n\nℹ 필수 환경변수 ${result.requiredEnv.length}개 (${result.requiredEnv.join(', ')}) — 승인 시 실제 값으로 채워야 합니다.`
+                : '';
+            const convSuffix = !result.blockedByConvention && result.conventionFindings.length > 0
+                ? `\n\nℹ ConventionChecker 가 ${result.conventionFindings.length}건 발견 — 승인 전 검토하세요.`
+                : '';
+
+            const llmText = `Imported MCP server draft ${result.serverId} from ${result.gitUrl}@${result.gitRef.slice(0, 7)}:${result.gitPath} (name="${result.name}", category=${result.category}, transport=${result.transportType}, status=draft, blockedByConvention=${result.blockedByConvention}, requiredEnv=${result.requiredEnv.length}).`;
+
+            logger.info(`MCP import_mcp_server_from_git: ${result.serverId} (user=${userId}, gitUrl=${args.gitUrl}, deduped=${result.deduped}, blocked=${result.blockedByConvention})`);
+            return {
+                content: [
+                    { type: 'text', text: llmText },
+                    {
+                        type: 'resource',
+                        resource: {
+                            uri: `openmake://mcp-server-draft/${result.serverId}`,
+                            mimeType: 'application/json',
+                            text: JSON.stringify({
+                                previewCard,
+                                assistantText: assistantText + blockedSuffix + requiredEnvSuffix + convSuffix,
+                            }),
+                        },
+                    },
+                ],
+            };
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            logger.warn(`MCP import_mcp_server_from_git 실패: ${msg}`);
+            return {
+                content: [{ type: 'text', text: `Git URL 에서 MCP server 가져오기 실패: ${msg}` }],
+                isError: true,
+            };
+        }
+    },
+};

--- a/backend/api/src/mcp/tool-tiers.ts
+++ b/backend/api/src/mcp/tool-tiers.ts
@@ -45,6 +45,7 @@ export const TOOL_TIERS: Record<UserTier, string[]> = {
         'create_skill',         // 자연어 → 스킬 draft 생성 (서비스 내부에 50 drafts/user + 24h dedupe 안전장치)
         'import_skill_from_git', // Git URL → 스킬 draft (rate limiter + draft 상한 공유)
         'import_agent_from_git', // Git URL → agent draft (chained skill ingest 포함, 20 drafts/user)
+        'import_mcp_server_from_git', // Git URL → MCP server draft (3중 잠금, RL_MCP_INGEST 5/hr free)
         'noapi-google-search::*', // 외부: Google 검색
     ],
     pro: [
@@ -54,6 +55,7 @@ export const TOOL_TIERS: Record<UserTier, string[]> = {
         'create_skill',         // 자연어 → 스킬 draft 생성
         'import_skill_from_git', // Git URL → 스킬 draft
         'import_agent_from_git', // Git URL → agent draft
+        'import_mcp_server_from_git', // Git URL → MCP server draft
         'web_scrape',           // 웹 스크래핑
         'web_map',              // URL 매핑
         'web_crawl',            // 웹 크롤링

--- a/backend/api/src/mcp/tools.ts
+++ b/backend/api/src/mcp/tools.ts
@@ -124,6 +124,8 @@ import { createSkillTool } from './skill-creator-tool';
 import { importSkillFromGitTool } from './git-ingest-tool';
 // Git URL → Agent 매니페스트 ingest (Phase 3.5) — chained skill ingest 포함
 import { importAgentFromGitTool } from './agent-ingest-tool';
+// Git URL → MCP server 매니페스트 ingest (Phase 4.5) — 3중 잠금 draft + 위험 명령 차단
+import { importMcpServerFromGitTool } from './mcp-server-ingest-tool';
 
 /**
  * 전체 내장 도구 배열
@@ -146,4 +148,5 @@ export const builtInTools: MCPToolDefinition[] = [
     createSkillTool as MCPToolDefinition,
     importSkillFromGitTool as MCPToolDefinition,
     importAgentFromGitTool as MCPToolDefinition,
+    importMcpServerFromGitTool as MCPToolDefinition,
 ];

--- a/frontend/web/public/js/modules/websocket.js
+++ b/frontend/web/public/js/modules/websocket.js
@@ -255,8 +255,9 @@ const messageHandlers = {
     /**
      * MCP tool 호출 결과의 resource content — 인라인 카드 렌더링.
      * 현재 지원하는 resource URI prefix:
-     *   - openmake://skill-draft/{id}  → skill-draft-card 컴포넌트 (Phase 1.5/2.5)
-     *   - openmake://agent-draft/{id}  → agent-draft-card 컴포넌트 (Phase 3.5)
+     *   - openmake://skill-draft/{id}       → skill-draft-card 컴포넌트 (Phase 1.5/2.5)
+     *   - openmake://agent-draft/{id}       → agent-draft-card 컴포넌트 (Phase 3.5)
+     *   - openmake://mcp-server-draft/{id}  → mcp-server-draft-card 컴포넌트 (Phase 4.5)
      * 다른 prefix 는 무시 (확장 시 분기 추가).
      *
      * Payload: { type: 'mcp_tool_result', toolName, resources: [{ uri, mimeType?, text? }], messageId }
@@ -269,7 +270,8 @@ const messageHandlers = {
 
             const isSkillDraft = uri.startsWith('openmake://skill-draft/');
             const isAgentDraft = uri.startsWith('openmake://agent-draft/');
-            if (!isSkillDraft && !isAgentDraft) continue;
+            const isMcpServerDraft = uri.startsWith('openmake://mcp-server-draft/');
+            if (!isSkillDraft && !isAgentDraft && !isMcpServerDraft) continue;
 
             try {
                 const payload = JSON.parse(res.text || '{}');
@@ -292,6 +294,29 @@ const messageHandlers = {
                         onAction: (action, agentId) => handleAgentDraftAction(action, agentId, {
                             onToast: (msg, type) => window.showToast && window.showToast(msg, type),
                         }),
+                    });
+                } else if (isMcpServerDraft && previewCard.kind === 'mcp-server-draft') {
+                    const { renderMcpServerDraftCard, handleMcpServerDraftAction } = await import('/js/components/mcp-server-draft-card.js?v=1');
+                    card = renderMcpServerDraftCard(previewCard, {
+                        mode: 'inline',
+                        onAction: (action, serverId, ctx) => {
+                            // 채팅 인라인에서는 envOverrides UI 가 어려움 — required_env 있으면 mcp-servers 페이지로 안내
+                            const augCtx = Object.assign({}, ctx);
+                            if (action === 'approve' && Array.isArray(ctx.requiredEnv) && ctx.requiredEnv.length > 0) {
+                                const overrides = {};
+                                for (const key of ctx.requiredEnv) {
+                                    const cur = (ctx.draft.env || {})[key];
+                                    if (cur && !/^\$\{.+\}$/.test(String(cur))) continue;
+                                    const v = window.prompt(`required_env: ${key}\n실제 값을 입력하세요 (취소하면 승인 중단)`, '');
+                                    if (v == null) return;
+                                    if (v) overrides[key] = v;
+                                }
+                                augCtx.envOverrides = overrides;
+                            }
+                            handleMcpServerDraftAction(action, serverId, augCtx, {
+                                onToast: (msg, type) => window.showToast && window.showToast(msg, type),
+                            });
+                        },
                     });
                 } else {
                     continue;


### PR DESCRIPTION
## Summary

Phase 4 (REST endpoint) 에 이어 MCP tool 로 동일 기능 노출. 사용자가 채팅에서 자연어로 \"이 저장소 MCP 서버로 가져와줘\" 같은 요청을 하면 LLM 이 본 tool 을 자동 호출 → 인라인 mcp-server-draft 카드 렌더.

Phase 3.5 (`import_agent_from_git`, db24cf5) 패턴 100% 차용.

### 변경 파일 (4)
| 파일 | 변경 |
|---|---|
| `backend/api/src/mcp/mcp-server-ingest-tool.ts` | 신규 — `importMcpServerFromGitTool` 정의 + handler (176 lines) |
| `backend/api/src/mcp/tools.ts` | `builtInTools` 배열에 추가 |
| `backend/api/src/mcp/tool-tiers.ts` | `TOOL_TIERS.free` / `pro` 에 `'import_mcp_server_from_git'` |
| `frontend/web/public/js/modules/websocket.js` | `openmake://mcp-server-draft/` prefix 분기 추가 (3번째 draft 종류) |

### 동작 흐름
\`\`\`
사용자 (채팅): \"이 저장소 MCP 서버로 가져와줘: https://github.com/foo/bar\"
  ↓ LLM tool_use
  ↓ import_mcp_server_from_git({ gitUrl })
  ↓ Phase 4 service: fetch → scan → Zod validate → ConventionCheck →
    dedupe → INSERT mcp_servers (status='draft' + enabled=false +
    visibility='user_private' 3중 잠금)
  ↓ tool returns { content: [text, resource] }
  ↓ ws-chat-handler emit mcp_tool_result
  ↓ frontend websocket.js → mcp-server-draft prefix 감지 →
    renderMcpServerDraftCard
  ↓ 사용자 required_env 값 입력 prompt → \"승인\" 버튼 →
    POST /api/mcp/servers/:id/approve → enabled=true
\`\`\`

### Tool description (LLM 가이드)
- \"사용자가 명시적으로 요청했을 때만\" 호출하도록 안내
- multi-candidate 시 `gitPath` 재호출 예시 제공
- 위험 명령 패턴 자동 차단 (CONVENTION_BLOCKED)
- 3중 잠금 정책 (status/enabled/visibility) 설명

## Test plan

### 자동 검증 통과 (이미 완료)
- [x] `tsc --noEmit` 0 errors
- [x] `npm run lint` Phase 4.5 파일 0 errors
- [x] `validate-modules.sh` 통과
- [x] `npm run build:backend` 통과
- [x] backend jest 회귀: 본 PR 변경 회귀 0 (token-crypto 2 fail + routes 3 fail 은 기존 환경 의존 이슈 — Phase 4 종료 시점에 알려진 패턴)

### 수동 검증 권장
- [ ] dev server 기동 후 채팅에서 \"이 git url MCP 서버로 가져와줘: https://github.com/foo/bar\" 입력 → tool 호출 + 카드 렌더 확인
- [ ] 카드의 approve 버튼 → required_env prompt → 활성화 흐름 확인
- [ ] 위험 명령 패턴 매니페스트 (`MCP_INGEST_E2E_MOCK=true` + `malicious` repo) → approve disabled 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)