### PR TITLE
chore(lint): 잔존 lint noise 일괄 정리

### DIFF
--- a/backend/api/src/config/constants.ts
+++ b/backend/api/src/config/constants.ts
@@ -86,7 +86,6 @@ export const AUTH_CONFIG = {
 // 애플리케이션 메타 정보
 // ============================================
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const rootPkg = require('../../../../package.json') as { version: string };
 
 /**

--- a/backend/api/src/mcp/tools.ts
+++ b/backend/api/src/mcp/tools.ts
@@ -58,7 +58,7 @@ export const visionOcrTool: MCPToolDefinition = {
             required: []
         }
     },
-    handler: async (args): Promise<MCPToolResult> => {
+    handler: async (_args): Promise<MCPToolResult> => {
         // 실제 OCR은 ChatService에서 비전 모델을 통해 처리됨
         // 이 핸들러는 MCP 도구 형식 호환용으로만 사용
         return {
@@ -104,7 +104,7 @@ export const analyzeImageTool: MCPToolDefinition = {
             required: []
         }
     },
-    handler: async (args): Promise<MCPToolResult> => {
+    handler: async (_args): Promise<MCPToolResult> => {
         return {
             content: [{
                 type: 'text',

--- a/backend/api/src/routes/setup.ts
+++ b/backend/api/src/routes/setup.ts
@@ -61,12 +61,12 @@ import { MCP_INGEST } from '../config/constants';
  *
  * @param app - Express 애플리케이션 인스턴스
  * @param cluster - Ollama 클러스터 매니저
- * @param broadcast - WebSocket 브로드캐스트 함수
+ * @param _broadcast - WebSocket 브로드캐스트 함수 (현 라우터 셋업에서 미사용, 시그너처 호환용)
  */
 export function setupApiRoutes(
     app: Application,
     cluster: ClusterManager,
-    broadcast: (data: Record<string, unknown>) => void
+    _broadcast: (data: Record<string, unknown>) => void
 ): void {
     // Silence browser favicon / apple-touch-icon requests to avoid 404 log noise
     app.get('/favicon.ico', (_req: Request, res: Response) => res.status(204).end());

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,8 @@ export default [
         {
           argsIgnorePattern: "^_",
           varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
         },
       ],
       "max-lines": [
@@ -48,6 +50,15 @@ export default [
     },
     rules: {
       "no-undef": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+        },
+      ],
     },
   },
 ];

--- a/frontend/web/public/js/modules/websocket.js
+++ b/frontend/web/public/js/modules/websocket.js
@@ -37,7 +37,7 @@ function connectWebSocket() {
             existingWs.onerror = null;
             existingWs.onmessage = null;
             existingWs.close();
-        } catch (e) {
+        } catch {
             // 이미 닫힌 상태일 수 있음 — 무시
         }
         setState('ws', null);
@@ -71,7 +71,7 @@ function connectWebSocket() {
         setState('isSending', false);
         try {
             hideAbortButton();
-        } catch (e) {
+        } catch {
             // DOM 접근 에러 무시
         }
 


### PR DESCRIPTION
## Summary

Phase 4 series (PR #35/#36/#37) 진행 중 누적된 잔존 lint noise + ESLint config 약점 일괄 해결. 코드 행동 변경 없음 (semantic-preserving).

### 변경 (5 files / 17+ / 7-)
| 파일 | 변경 |
|---|---|
| `eslint.config.mjs` | `caughtErrorsIgnorePattern` + `destructuredArrayIgnorePattern` + frontend `.js` 블록에 `@typescript-eslint/no-unused-vars` 옵션 명시 |
| `backend/api/src/routes/setup.ts` | `broadcast` → `_broadcast` (시그너처 호환 미사용 param) |
| `backend/api/src/mcp/tools.ts` | visionOcr / analyzeImage handler 의 `args` → `_args` |
| `frontend/web/public/js/modules/websocket.js` | `catch (e)` 2건 → optional catch binding |
| `backend/api/src/config/constants.ts` | 불필요한 eslint-disable directive 제거 |

### Root cause
- `tseslint.configs.recommended` 의 default `@typescript-eslint/no-unused-vars` 가 frontend `.js` 블록에 적용되면서 `argsIgnorePattern: ^_` 등 옵션 미반영 → underscore prefix 도 errors 로 잡힘.
- `caughtErrorsIgnorePattern` 미설정 → `catch (_e)` 도 errors.
- ESLint 의 룰 override 가 file-pattern block 별 — frontend 블록에 명시 누락.

### 효과
- Phase 4 영역 lint **errors: 17 → 0**
- 미래 `catch (_e)` 패턴이 모든 코드에서 자동 통과
- frontend `.js` 의 unused-vars 검출이 underscore prefix convention 존중

## Test plan
- [x] `tsc --noEmit` 0 errors
- [x] Phase 4 영역 lint 0 errors (위 sweep)
- [x] jest 회귀: 95 suites passed / 1589 tests passed / 본 PR 회귀 0
- [x] 코드 행동 변경 없음 (param rename + catch syntax + eslint config 만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)