### PR TITLE
chore(zod): v4 deprecation migration — z.url() + code:'custom'

### DIFF
--- a/backend/api/src/agents/git-ingest/mcp-server-manifest-validator.ts
+++ b/backend/api/src/agents/git-ingest/mcp-server-manifest-validator.ts
@@ -28,14 +28,14 @@ export const mcpServerManifestFrontmatterSchema = z.object({
     args: z.array(z.string().max(500)).max(50).optional(),
     env: z.record(z.string(), z.string().max(2000)).optional(),
     required_env: z.array(z.string().min(1).max(200)).max(50).optional(),
-    url: z.string().url().optional(),
+    url: z.url().optional(),
     version: z.string().regex(
         /^\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?(\+[A-Za-z0-9.-]+)?$/,
         'version 은 semver (예: 1.0.0) 형식이어야 합니다',
     ),
     author: z.string().max(200).optional(),
     license: z.string().max(100).optional(),
-    homepage: z.string().url().optional(),
+    homepage: z.url().optional(),
     required_capabilities: z.array(z.string().max(50)).max(20).optional(),
     security_metadata: z.object({
         network_access: z.boolean().optional(),
@@ -46,14 +46,14 @@ export const mcpServerManifestFrontmatterSchema = z.object({
 }).superRefine((data, ctx) => {
     if (data.transport_type === 'stdio' && !data.command) {
         ctx.addIssue({
-            code: z.ZodIssueCode.custom,
+            code: 'custom',
             message: 'stdio transport 는 command 필수',
             path: ['command'],
         });
     }
     if ((data.transport_type === 'sse' || data.transport_type === 'streamable-http') && !data.url) {
         ctx.addIssue({
-            code: z.ZodIssueCode.custom,
+            code: 'custom',
             message: `${data.transport_type} transport 는 url 필수`,
             path: ['url'],
         });
@@ -63,7 +63,7 @@ export const mcpServerManifestFrontmatterSchema = z.object({
         for (const key of data.required_env) {
             if (!envKeys.has(key)) {
                 ctx.addIssue({
-                    code: z.ZodIssueCode.custom,
+                    code: 'custom',
                     message: `required_env '${key}' 가 env 에 정의되지 않음 (placeholder 마커 필요)`,
                     path: ['required_env'],
                 });

--- a/backend/api/src/schemas/external.schema.ts
+++ b/backend/api/src/schemas/external.schema.ts
@@ -60,7 +60,7 @@ export const addExternalFileSchema = z.object({
     fileName: z.string().min(1, 'fileName은 필수입니다').max(500),
     fileType: z.string().max(100).optional(),
     fileSize: z.number().int().min(0).optional(),
-    webUrl: z.string().url().max(2000).optional(),
+    webUrl: z.url().max(2000).optional(),
     cachedContent: z.string().max(1_000_000).optional(),
 });
 

--- a/backend/api/src/schemas/mcp-catalog-admin.schema.ts
+++ b/backend/api/src/schemas/mcp-catalog-admin.schema.ts
@@ -34,14 +34,14 @@ export const createCatalogTemplateSchema = z.object({
 }).superRefine((data, ctx) => {
     if (data.transport_type === 'stdio' && !data.command_template) {
         ctx.addIssue({
-            code: z.ZodIssueCode.custom,
+            code: 'custom',
             message: 'stdio transport 는 command_template 필수',
             path: ['command_template'],
         });
     }
     if ((data.transport_type === 'sse' || data.transport_type === 'streamable-http') && !data.url_template) {
         ctx.addIssue({
-            code: z.ZodIssueCode.custom,
+            code: 'custom',
             message: `${data.transport_type} transport 는 url_template 필수`,
             path: ['url_template'],
         });

--- a/backend/api/src/schemas/mcp.schema.ts
+++ b/backend/api/src/schemas/mcp.schema.ts
@@ -37,19 +37,19 @@ export const mcpServerCreateSchema = z.object({
     command: secureOptionalTextSchema({ minLength: 1, maxLength: 1000, fieldName: 'command', allowNewLines: false, detectMaliciousPatterns: false, specialCharacterRatioLimit: 0.95 }),
     args: z.array(secureTextSchema({ maxLength: 500, fieldName: 'args', allowNewLines: false, detectMaliciousPatterns: false, specialCharacterRatioLimit: 0.95 })).max(50).optional(),
     env: z.record(z.string(), z.string()).optional(),
-    url: z.string().url('유효한 URL을 입력하세요').optional(),
+    url: z.url('유효한 URL을 입력하세요').optional(),
     enabled: z.boolean().optional().default(true)
 }).superRefine((data, ctx) => {
     if (data.transport_type === 'stdio' && !data.command) {
         ctx.addIssue({
-            code: z.ZodIssueCode.custom,
+            code: 'custom',
             message: 'stdio transport에는 command가 필요합니다',
             path: ['command']
         });
     }
     if ((data.transport_type === 'sse' || data.transport_type === 'streamable-http') && !data.url) {
         ctx.addIssue({
-            code: z.ZodIssueCode.custom,
+            code: 'custom',
             message: `${data.transport_type} transport에는 url이 필요합니다`,
             path: ['url']
         });

--- a/backend/api/src/schemas/research.schema.ts
+++ b/backend/api/src/schemas/research.schema.ts
@@ -35,7 +35,7 @@ export const addResearchStepSchema = z.object({
     stepType: z.enum(['search', 'analysis', 'synthesis']),
     query: secureOptionalTextSchema({ maxLength: 1000, fieldName: 'query', detectMaliciousPatterns: false }),
     result: secureOptionalTextSchema({ maxLength: 50000, fieldName: 'result', allowHtmlLikeContent: true, detectMaliciousPatterns: false }),
-    sources: z.array(z.string().url()).optional(),
+    sources: z.array(z.url()).optional(),
     status: z.enum(['pending', 'completed', 'failed']).optional().default('pending')
 });
 
@@ -47,7 +47,7 @@ export const updateResearchSessionSchema = z.object({
     progress: z.number().min(0).max(100).optional(),
     summary: secureOptionalTextSchema({ maxLength: 10000, fieldName: 'summary', allowHtmlLikeContent: true, detectMaliciousPatterns: false }),
     keyFindings: z.array(secureTextSchema({ maxLength: 1000, fieldName: 'keyFindings', detectMaliciousPatterns: false })).optional(),
-    sources: z.array(z.string().url()).optional()
+    sources: z.array(z.url()).optional()
 });
 
 /**

--- a/backend/api/src/schemas/security.schema.ts
+++ b/backend/api/src/schemas/security.schema.ts
@@ -125,7 +125,7 @@ export function secureTextSchema(options: SecureTextOptions = {}) {
 
                 if (detection.detected) {
                     ctx.addIssue({
-                        code: z.ZodIssueCode.custom,
+                        code: 'custom',
                         message: `${fieldName}에 허용되지 않는 보안 패턴이 감지되었습니다`,
                     });
                 }
@@ -133,14 +133,14 @@ export function secureTextSchema(options: SecureTextOptions = {}) {
 
             if (!allowHtmlLikeContent && /<[^>]+>/.test(value)) {
                 ctx.addIssue({
-                    code: z.ZodIssueCode.custom,
+                    code: 'custom',
                     message: `${fieldName}에 HTML 태그 형태의 입력은 허용되지 않습니다`,
                 });
             }
 
             if (hasExcessiveSpecialCharacters(value, specialCharacterRatioLimit)) {
                 ctx.addIssue({
-                    code: z.ZodIssueCode.custom,
+                    code: 'custom',
                     message: `${fieldName}에 비정상적으로 많은 특수문자가 포함되어 있습니다`,
                 });
             }

--- a/backend/api/src/schemas/skill-manifest.schema.ts
+++ b/backend/api/src/schemas/skill-manifest.schema.ts
@@ -23,7 +23,7 @@ const McpBundleSchema = z.object({
         command: z.string().optional(),
         args: z.array(z.string()).optional(),
         env: z.record(z.string(), z.string()).optional(),
-        url: z.string().url().optional(),
+        url: z.url().optional(),
     }),
     lifecycle: z.enum(['per_chat', 'per_session', 'long_lived']).default('per_chat'),
 });
@@ -36,7 +36,7 @@ export const SkillManifestFrontmatterSchema = z.object({
     is_public: z.boolean().default(false),
     tool_bindings: z.array(ToolBindingSchema).max(64).default([]),
     mcp_bundles: z.array(McpBundleSchema).max(8).default([]),
-    source_repo: z.string().url().optional(),
+    source_repo: z.url().optional(),
     source_path: z.string().max(256).optional(),
 });
 


### PR DESCRIPTION
## Summary

PR #38 (lint cleanup) 의 자연 follow-up. zod v4 의 deprecated API 7 파일 일괄 마이그레이션.

## 패턴
- \`z.string().url(...)\` → \`z.url(...)\` — v4 의 top-level string format
- \`z.ZodIssueCode.custom\` → \`'custom'\` (literal) — deprecated symbol 제거

## 대상 파일 (7)
| 파일 | 변경 |
|---|---|
| `agents/git-ingest/mcp-server-manifest-validator.ts` | url 2건 + ZodIssueCode 3건 |
| `schemas/external.schema.ts` | url 1건 |
| `schemas/mcp-catalog-admin.schema.ts` | ZodIssueCode 2건 |
| `schemas/mcp.schema.ts` | url 1건 + ZodIssueCode 2건 |
| `schemas/research.schema.ts` | url 2건 |
| `schemas/security.schema.ts` | ZodIssueCode 3건 |
| `schemas/skill-manifest.schema.ts` | url 2건 |

## zod v4 API 사전 검증
ts-node smoke test 로 확인:
- `z.url()` / `z.url().max(N)` / `z.url().optional()` / `z.url('msg')` / `z.url({ error: '...' })`
- `ctx.addIssue({ code: 'custom', ... })` literal 통과

## 검증
- [x] `tsc --noEmit` 0 errors
- [x] eslint Phase 4 schema 영역 0 errors / 0 warnings
- [x] jest targeted (validator + schemas + routes): 4 suites / 43 tests 통과
- [x] jest 전체 회귀: 95 suites / 1589 tests / 본 PR 회귀 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)