### PR TITLE
refactor(repo): skill-repository → assignment + row-mapper 분리

### DIFF
--- a/backend/api/src/data/repositories/skill-assignment-repository.ts
+++ b/backend/api/src/data/repositories/skill-assignment-repository.ts
@@ -1,0 +1,138 @@
+/**
+ * SkillAssignmentRepository — 에이전트/사용자 ↔ 스킬 binding 관리.
+ *
+ * skill-repository.ts 에서 추출 (max-lines 정책 + 책임 분리).
+ * `agent_skill_assignments` 테이블 전용. agent_id 가 '__global__' 또는
+ * 'user:{userId}' 패턴인 경우도 같은 테이블로 표현.
+ *
+ * @module data/repositories/skill-assignment-repository
+ */
+import { BaseRepository, type QueryParam } from './base-repository';
+import type { AgentSkill } from './skill-repository';
+import { rowToSkill } from './skill-row-mapper';
+
+interface SkillIdRow {
+    skill_id: string;
+}
+
+export class SkillAssignmentRepository extends BaseRepository {
+    /** agent ↔ skill 명시 binding (priority 정렬 키) */
+    async assignSkillToAgent(agentId: string, skillId: string, priority: number = 0): Promise<void> {
+        await this.query(
+            `INSERT INTO agent_skill_assignments (agent_id, skill_id, priority, created_at)
+             VALUES ($1, $2, $3, NOW())
+             ON CONFLICT (agent_id, skill_id) DO UPDATE
+             SET priority = EXCLUDED.priority`,
+            [agentId, skillId, priority]
+        );
+    }
+
+    async removeSkillFromAgent(agentId: string, skillId: string): Promise<void> {
+        await this.query(
+            'DELETE FROM agent_skill_assignments WHERE agent_id = $1 AND skill_id = $2',
+            [agentId, skillId]
+        );
+    }
+
+    /**
+     * 에이전트에 연결된 스킬 목록 반환.
+     *   - 에이전트 고유 스킬 + '__global__' 가상 에이전트 스킬
+     *   - userId 가 주어지면 'user:{userId}' 개인 스킬도 포함 (카테고리 일치 시)
+     *   - status='active' 만 (draft/archived 는 prompt 주입 경로에서 차단)
+     */
+    async getSkillsForAgent(agentId: string, userId?: string, agentCategory?: string): Promise<AgentSkill[]> {
+        const conditions: string[] = ['a.agent_id = $1', "a.agent_id = '__global__'"];
+        const params: QueryParam[] = [agentId];
+
+        if (userId) {
+            if (agentCategory) {
+                conditions.push(`(a.agent_id = $${params.length + 1} AND s.category = $${params.length + 2})`);
+                params.push(`user:${userId}`, agentCategory);
+            } else {
+                conditions.push(`a.agent_id = $${params.length + 1}`);
+                params.push(`user:${userId}`);
+            }
+        }
+
+        const whereClause = conditions.join(' OR ');
+        const result = await this.query(
+            `SELECT s.id, s.name, s.description, s.content, s.category, s.is_public,
+                    s.created_by, s.created_at, s.updated_at, s.source_repo, s.source_path,
+                    s.status, s.manifest_meta,
+                    MIN(a.priority) AS priority
+             FROM agent_skills s
+             JOIN agent_skill_assignments a ON s.id = a.skill_id
+             WHERE (${whereClause}) AND s.status = 'active'
+             GROUP BY s.id, s.name, s.description, s.content, s.category, s.is_public,
+                      s.created_by, s.created_at, s.updated_at, s.source_repo, s.source_path,
+                      s.status, s.manifest_meta
+             ORDER BY MIN(a.priority) ASC, s.name ASC
+             LIMIT $${params.length + 1}`,
+            [...params, 15]
+        );
+        return result.rows.map((row) => rowToSkill(row));
+    }
+
+    /** 에이전트에 연결된 skill ID 목록 (__global__ 포함, userId 개인 스킬 포함) */
+    async getSkillIdsForAgent(agentId: string, userId?: string): Promise<string[]> {
+        const conditions: string[] = ['agent_id = $1', "agent_id = '__global__'"];
+        const params: QueryParam[] = [agentId];
+
+        if (userId) {
+            conditions.push('agent_id = $2');
+            params.push(`user:${userId}`);
+        }
+
+        const whereClause = conditions.join(' OR ');
+        const result = await this.query<SkillIdRow>(
+            `SELECT DISTINCT skill_id
+             FROM agent_skill_assignments
+             WHERE ${whereClause}`,
+            params
+        );
+        return result.rows.map((row) => row.skill_id);
+    }
+
+    /** 사용자 개인 스킬 할당 ('user:{userId}' 가상 에이전트 ID 패턴) */
+    async assignSkillToUser(userId: string, skillId: string, priority: number = 0): Promise<void> {
+        await this.query(
+            `INSERT INTO agent_skill_assignments (agent_id, skill_id, priority, created_at)
+             VALUES ($1, $2, $3, NOW())
+             ON CONFLICT (agent_id, skill_id) DO UPDATE
+             SET priority = EXCLUDED.priority`,
+            [`user:${userId}`, skillId, priority]
+        );
+    }
+
+    async removeSkillFromUser(userId: string, skillId: string): Promise<void> {
+        await this.query(
+            'DELETE FROM agent_skill_assignments WHERE agent_id = $1 AND skill_id = $2',
+            [`user:${userId}`, skillId]
+        );
+    }
+
+    async getUserSkillIds(userId: string): Promise<string[]> {
+        const result = await this.query<SkillIdRow>(
+            `SELECT skill_id FROM agent_skill_assignments WHERE agent_id = $1`,
+            [`user:${userId}`]
+        );
+        return result.rows.map((row) => row.skill_id);
+    }
+
+    /**
+     * 사용자 개인 할당 스킬 전체 목록 (status='active' 만 — draft/archived 제외).
+     */
+    async getUserSkills(userId: string): Promise<AgentSkill[]> {
+        const result = await this.query(
+            `SELECT s.id, s.name, s.description, s.content, s.category, s.is_public,
+                    s.created_by, s.created_at, s.updated_at, s.source_repo, s.source_path,
+                    s.status, s.manifest_meta
+             FROM agent_skills s
+             JOIN agent_skill_assignments a ON s.id = a.skill_id
+             WHERE a.agent_id = $1 AND s.status = 'active'
+             ORDER BY a.priority ASC, s.name ASC`,
+            [`user:${userId}`]
+        );
+        return result.rows.map((row) => rowToSkill(row));
+    }
+}

--- a/backend/api/src/data/repositories/skill-repository.ts
+++ b/backend/api/src/data/repositories/skill-repository.ts
@@ -11,6 +11,8 @@
 
 import { BaseRepository, QueryParam } from './base-repository';
 import { assertResourceOwnerOrAdmin } from '../../auth/ownership';
+import { rowToSkill } from './skill-row-mapper';
+import { SkillAssignmentRepository } from './skill-assignment-repository';
 
 export interface AgentSkill {
     id: string;
@@ -93,9 +95,6 @@ interface CountRow {
     total: string;
 }
 
-interface SkillIdRow {
-    skill_id: string;
-}
 
 interface SkillOwnerRow {
     created_by: string | null;
@@ -223,7 +222,7 @@ export class SkillRepository extends BaseRepository {
             return null;
         }
 
-        return this.rowToSkill(result.rows[0]);
+        return rowToSkill(result.rows[0]);
     }
 
     async searchSkills(options: SkillSearchOptions): Promise<SkillSearchResult> {
@@ -298,7 +297,7 @@ export class SkillRepository extends BaseRepository {
         );
 
         return {
-            skills: dataResult.rows.map((row) => this.rowToSkill(row)),
+            skills: dataResult.rows.map((row) => rowToSkill(row)),
             total: parseInt(countResult.rows[0]?.total ?? '0', 10),
             limit,
             offset,
@@ -356,7 +355,7 @@ export class SkillRepository extends BaseRepository {
             ]
         );
         if (result.rows.length > 0) {
-            return this.rowToSkill(result.rows[0]);
+            return rowToSkill(result.rows[0]);
         }
         // fallback (should not normally happen)
         return {
@@ -371,140 +370,36 @@ export class SkillRepository extends BaseRepository {
         };
     }
 
+    // ────────────────────────────────────────────────────────────
+    // Assignment facade — 실제 구현은 SkillAssignmentRepository.
+    // 기존 호출자가 SkillRepository 하나만 사용해 둘 다 호출 가능.
+    // ────────────────────────────────────────────────────────────
+    private get assignments(): SkillAssignmentRepository {
+        return new SkillAssignmentRepository(this.pool);
+    }
     async assignSkillToAgent(agentId: string, skillId: string, priority: number = 0): Promise<void> {
-        await this.query(
-            `INSERT INTO agent_skill_assignments (agent_id, skill_id, priority, created_at)
-             VALUES ($1, $2, $3, NOW())
-             ON CONFLICT (agent_id, skill_id) DO UPDATE
-             SET priority = EXCLUDED.priority`,
-            [agentId, skillId, priority]
-        );
+        return this.assignments.assignSkillToAgent(agentId, skillId, priority);
     }
-
     async removeSkillFromAgent(agentId: string, skillId: string): Promise<void> {
-        await this.query(
-            'DELETE FROM agent_skill_assignments WHERE agent_id = $1 AND skill_id = $2',
-            [agentId, skillId]
-        );
+        return this.assignments.removeSkillFromAgent(agentId, skillId);
     }
-
-    /**
-     * 에이전트에 연결된 스킬 목록 반환
-     * 특정 에이전트 스킬 + '__global__' 가상 에이전트에 할당된 스킬 모두 포함.
-     * userId가 주어지면 'user:{userId}' 패턴의 개인 스킬도 포함.
-     * 중복 방지: 같은 스킬이 여러 곳에 할당된 경우 낙은 priority 우선.
-     */
     async getSkillsForAgent(agentId: string, userId?: string, agentCategory?: string): Promise<AgentSkill[]> {
-        // 1. 에이전트 고유 스킬 + __global__ 스킬 (제한 없음)
-        const conditions: string[] = ['a.agent_id = $1', "a.agent_id = '__global__'"];
-        const params: QueryParam[] = [agentId];
-
-        // 2. 개인 스킬: 에이전트 카테고리와 일치하는 스킬만 포함 (최대 10개)
-        //    카테고리 불일치 스킬은 프롬프트 오염 방지를 위해 제외
-        if (userId) {
-            if (agentCategory) {
-                // 카테고리 매칭: 개인 스킬 중 에이전트 카테고리와 동일한 것만
-                conditions.push(`(a.agent_id = $${params.length + 1} AND s.category = $${params.length + 2})`);
-                params.push(`user:${userId}`, agentCategory);
-            } else {
-                // 카테고리 불명 시 개인 스킬 포함하되 10개 제한은 ORDER/LIMIT으로 처리
-                conditions.push(`a.agent_id = $${params.length + 1}`);
-                params.push(`user:${userId}`);
-            }
-        }
-
-        const whereClause = conditions.join(' OR ');
-        // status='active' 필터: 채팅 시스템 프롬프트 주입 경로에 draft/archived 가 섞이지 않도록 차단
-        const result = await this.query(
-            `SELECT s.id, s.name, s.description, s.content, s.category, s.is_public,
-                    s.created_by, s.created_at, s.updated_at, s.source_repo, s.source_path,
-                    s.status, s.manifest_meta,
-                    MIN(a.priority) AS priority
-             FROM agent_skills s
-             JOIN agent_skill_assignments a ON s.id = a.skill_id
-             WHERE (${whereClause}) AND s.status = 'active'
-             GROUP BY s.id, s.name, s.description, s.content, s.category, s.is_public,
-                      s.created_by, s.created_at, s.updated_at, s.source_repo, s.source_path,
-                      s.status, s.manifest_meta
-             ORDER BY MIN(a.priority) ASC, s.name ASC
-             LIMIT $${params.length + 1}`,
-            [...params, 15]
-        );
-        return result.rows.map((row) => this.rowToSkill(row));
+        return this.assignments.getSkillsForAgent(agentId, userId, agentCategory);
     }
-
-    /**
-     * 에이전트에 연결된 스킬 ID 목록 반환 (__global__ 포함, userId 개인 스킬 포함)
-     */
     async getSkillIdsForAgent(agentId: string, userId?: string): Promise<string[]> {
-        const conditions: string[] = ['agent_id = $1', "agent_id = '__global__'"];
-        const params: QueryParam[] = [agentId];
-
-        if (userId) {
-            conditions.push('agent_id = $2');
-            params.push(`user:${userId}`);
-        }
-
-        const whereClause = conditions.join(' OR ');
-        const result = await this.query<SkillIdRow>(
-            `SELECT DISTINCT skill_id
-             FROM agent_skill_assignments
-             WHERE ${whereClause}`,
-            params
-        );
-        return result.rows.map((row) => row.skill_id);
+        return this.assignments.getSkillIdsForAgent(agentId, userId);
     }
-
-    /**
-     * 사용자 개인 스킬 할당 (user:{userId} 가상 에이전트 ID 패턴)
-     */
     async assignSkillToUser(userId: string, skillId: string, priority: number = 0): Promise<void> {
-        await this.query(
-            `INSERT INTO agent_skill_assignments (agent_id, skill_id, priority, created_at)
-             VALUES ($1, $2, $3, NOW())
-             ON CONFLICT (agent_id, skill_id) DO UPDATE
-             SET priority = EXCLUDED.priority`,
-            [`user:${userId}`, skillId, priority]
-        );
+        return this.assignments.assignSkillToUser(userId, skillId, priority);
     }
-
-    /**
-     * 사용자 개인 스킬 할당 해제
-     */
     async removeSkillFromUser(userId: string, skillId: string): Promise<void> {
-        await this.query(
-            'DELETE FROM agent_skill_assignments WHERE agent_id = $1 AND skill_id = $2',
-            [`user:${userId}`, skillId]
-        );
+        return this.assignments.removeSkillFromUser(userId, skillId);
     }
-
-    /**
-     * 사용자 개인 할당 스킬 ID 목록 반환
-     */
     async getUserSkillIds(userId: string): Promise<string[]> {
-        const result = await this.query<SkillIdRow>(
-            `SELECT skill_id FROM agent_skill_assignments WHERE agent_id = $1`,
-            [`user:${userId}`]
-        );
-        return result.rows.map((row) => row.skill_id);
+        return this.assignments.getUserSkillIds(userId);
     }
-
-    /**
-     * 사용자 개인 할당 스킬 전체 목록 반환.
-     * draft/archived 는 의도적으로 제외 — 사용자 할당 목록은 활성 스킬만 표시.
-     */
     async getUserSkills(userId: string): Promise<AgentSkill[]> {
-        const result = await this.query(
-            `SELECT s.id, s.name, s.description, s.content, s.category, s.is_public,
-                    s.created_by, s.created_at, s.updated_at, s.source_repo, s.source_path,
-                    s.status, s.manifest_meta
-             FROM agent_skills s
-             JOIN agent_skill_assignments a ON s.id = a.skill_id
-             WHERE a.agent_id = $1 AND s.status = 'active'
-             ORDER BY a.priority ASC, s.name ASC`,
-            [`user:${userId}`]
-        );
-        return result.rows.map((row) => this.rowToSkill(row));
+        return this.assignments.getUserSkills(userId);
     }
 
     /**
@@ -576,7 +471,7 @@ export class SkillRepository extends BaseRepository {
         );
 
         return {
-            drafts: dataResult.rows.map((row) => this.rowToSkill(row)),
+            drafts: dataResult.rows.map((row) => rowToSkill(row)),
             total: parseInt(countResult.rows[0]?.total ?? '0', 10),
             limit,
             offset,
@@ -598,55 +493,7 @@ export class SkillRepository extends BaseRepository {
         return result.rows[0].created_by;
     }
 
-    private rowToSkill(row: Record<string, unknown>): AgentSkill {
-        const createdBy = row.created_by;
-        const sourceRepo = row.source_repo;
-        const sourcePath = row.source_path;
-        const status = row.status;
-        const manifestMeta = row.manifest_meta;
-
-        return {
-            id: this.toStringValue(row.id),
-            name: this.toStringValue(row.name),
-            description: this.toStringValue(row.description, ''),
-            content: this.toStringValue(row.content),
-            category: this.toStringValue(row.category, 'general'),
-            isPublic: this.toBooleanValue(row.is_public, false),
-            createdBy: typeof createdBy === 'string' ? createdBy : undefined,
-            createdAt: this.toDateValue(row.created_at),
-            updatedAt: this.toDateValue(row.updated_at),
-            sourceRepo: typeof sourceRepo === 'string' ? sourceRepo : undefined,
-            sourcePath: typeof sourcePath === 'string' ? sourcePath : undefined,
-            status: status === 'draft' || status === 'active' || status === 'archived' ? status : undefined,
-            manifestMeta: manifestMeta && typeof manifestMeta === 'object' ? manifestMeta as Record<string, unknown> : undefined,
-        };
-    }
-
     private escapeILike(str: string): string {
         return str.replace(/[%_]/g, '\\$&');
-    }
-
-    private toStringValue(value: unknown, fallback: string = ''): string {
-        if (typeof value === 'string') {
-            return value;
-        }
-        return fallback;
-    }
-
-    private toBooleanValue(value: unknown, fallback: boolean): boolean {
-        if (typeof value === 'boolean') {
-            return value;
-        }
-        return fallback;
-    }
-
-    private toDateValue(value: unknown): Date {
-        if (value instanceof Date) {
-            return value;
-        }
-        if (typeof value === 'string' || typeof value === 'number') {
-            return new Date(value);
-        }
-        return new Date(0);
     }
 }

--- a/backend/api/src/data/repositories/skill-row-mapper.ts
+++ b/backend/api/src/data/repositories/skill-row-mapper.ts
@@ -1,0 +1,49 @@
+/**
+ * AgentSkill row → object 매퍼 (skill-repository / skill-assignment-repository 공용).
+ *
+ * SkillRepository 의 private 메서드에서 추출 — 두 repo 가 같은 row shape 을
+ * 다루므로 module-level helper 로 통합.
+ *
+ * @module data/repositories/skill-row-mapper
+ */
+import type { AgentSkill } from './skill-repository';
+
+export function toStringValue(value: unknown, fallback: string = ''): string {
+    if (typeof value === 'string') return value;
+    return fallback;
+}
+
+export function toBooleanValue(value: unknown, fallback: boolean): boolean {
+    if (typeof value === 'boolean') return value;
+    return fallback;
+}
+
+export function toDateValue(value: unknown): Date {
+    if (value instanceof Date) return value;
+    if (typeof value === 'string' || typeof value === 'number') return new Date(value);
+    return new Date(0);
+}
+
+export function rowToSkill(row: Record<string, unknown>): AgentSkill {
+    const createdBy = row.created_by;
+    const sourceRepo = row.source_repo;
+    const sourcePath = row.source_path;
+    const status = row.status;
+    const manifestMeta = row.manifest_meta;
+
+    return {
+        id: toStringValue(row.id),
+        name: toStringValue(row.name),
+        description: toStringValue(row.description, ''),
+        content: toStringValue(row.content),
+        category: toStringValue(row.category, 'general'),
+        isPublic: toBooleanValue(row.is_public, false),
+        createdBy: typeof createdBy === 'string' ? createdBy : undefined,
+        createdAt: toDateValue(row.created_at),
+        updatedAt: toDateValue(row.updated_at),
+        sourceRepo: typeof sourceRepo === 'string' ? sourceRepo : undefined,
+        sourcePath: typeof sourcePath === 'string' ? sourcePath : undefined,
+        status: status === 'draft' || status === 'active' || status === 'archived' ? status : undefined,
+        manifestMeta: manifestMeta && typeof manifestMeta === 'object' ? manifestMeta as Record<string, unknown> : undefined,
+    };
+}


### PR DESCRIPTION
## Summary

PR #44/#45 의 자연 follow-up. `skill-repository.ts` (528 lines, max-lines warning) 의 assignment 영역을 분리 + 공용 helper 추출.

## 동기
- max-lines warning 해소 (528 → 499 lines)
- 3-way 분리:
  - `SkillRepository` (499): skill CRUD + 검색 + draft + status + 시스템 upsert
  - `SkillAssignmentRepository` (138): `agent_skill_assignments` 테이블 전용 (8 method)
  - `skill-row-mapper.ts` (49): rowToSkill + 3개 type coercion helper (공용)

## Breaking change 0 — facade 패턴
- `SkillRepository` 에 8 assignment 메서드 thin facade 유지: `private get assignments() { return new SkillAssignmentRepository(this.pool); }`
- 기존 5 사용처 (skill-seeder / system-prompt / skill-manager / agents.routes / skills.routes) 호출 코드 영향 0
- 신규 코드는 직접 `SkillAssignmentRepository` import 권장

## Test plan
- [x] tsc 0 errors / lint 0 errors / **0 warnings (모든 repositories file)**
- [x] 전체 회귀: 97 suites / 1604 tests / 0 failed
- [x] repository 디렉토리 max-lines warning 완전 해소

🤖 Generated with [Claude Code](https://claude.com/claude-code)