### PR TITLE
chore(lint): backend lint errors 4→0

### DIFF
--- a/backend/api/src/agents/learning.ts
+++ b/backend/api/src/agents/learning.ts
@@ -88,7 +88,7 @@ export class AgentLearningSystem {
         logger.info('에이전트 학습 시스템 초기화됨');
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
+     
     private getPool(): import('pg').Pool {
         const { getPool } = require('../data/models/unified-database') as { getPool: () => import('pg').Pool };
         return getPool();

--- a/backend/api/src/auth/middleware.ts
+++ b/backend/api/src/auth/middleware.ts
@@ -59,7 +59,9 @@ export interface AuthUser {
 
 // Request 타입 확장
 // user는 PublicUser (DB 조회) 또는 AuthUser (JWT 직접 추출) 가능
+// declaration merging 위한 namespace 사용 — ES module syntax 로 대체 불가.
 declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
     namespace Express {
         interface Request {
             /** 인증된 사용자 정보 - PublicUser(DB) 또는 AuthUser(JWT) */

--- a/backend/api/src/evaluation/router-evaluator.ts
+++ b/backend/api/src/evaluation/router-evaluator.ts
@@ -169,7 +169,7 @@ function computePassRateByCategory(results: CaseResult[]): EvaluationSummary['pa
  */
 function defaultAgentCategoryLookup(agentId: string): string | undefined {
     // require로 lazy load — circular import 방지 + 테스트 시 쉽게 mock 가능
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
+     
     const { AGENTS } = require('../agents');
     return AGENTS[agentId]?.category;
 }

--- a/backend/api/src/evaluation/run-response-evaluation.ts
+++ b/backend/api/src/evaluation/run-response-evaluation.ts
@@ -167,7 +167,7 @@ async function main() {
     if (useReal) {
         // Lazy load: ChatService/LLMClient 등 LLM 의존성은 --real 모드에서만 필요
         // (mock 모드 회귀 시 web-scraper 등 무관한 모듈이 컴파일되는 비용 회피)
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
+         
         const { createRealResponseGenerator } = require('./real-response-generator') as
             typeof import('./real-response-generator');
         generator = createRealResponseGenerator({

--- a/backend/api/src/monitoring/analytics.ts
+++ b/backend/api/src/monitoring/analytics.ts
@@ -414,7 +414,7 @@ export class AnalyticsSystem {
 
         // 모델별 비용 (에이전트 통계에서 추정)
         const modelCosts: { model: string; cost: number; percentage: number }[] = [];
-        let totalCost = weeklyCost || 1;
+        const totalCost = weeklyCost || 1;
 
         const todayModels = summary.today.modelUsage || {};
         for (const [model, count] of Object.entries(todayModels)) {

--- a/backend/api/src/services/AuthService.ts
+++ b/backend/api/src/services/AuthService.ts
@@ -155,7 +155,7 @@ export class AuthService {
      * OAuth 사용자 생성 또는 반환
      */
     async findOrCreateOAuthUser(email: string, provider: 'google' | 'github'): Promise<AuthResult> {
-        let user = await this.userManager.getUserByEmail(email);
+        const user = await this.userManager.getUserByEmail(email);
         let publicUser = user ? await this.userManager.getUserById(user.id) : null;
 
         if (!publicUser) {

--- a/backend/api/src/utils/web-scraper.ts
+++ b/backend/api/src/utils/web-scraper.ts
@@ -258,7 +258,7 @@ function parseHtmlToMarkdown(html: string, url: string, onlyMainContent: boolean
 
     if (onlyMainContent) {
         // Readability로 메인 콘텐츠 추출
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+         
         const reader = new Readability(document as any);
         const article = reader.parse();
 


### PR DESCRIPTION
## Summary

`backend/api/src/` 의 모든 lint errors 해결. 누적 cleanup 의 자연 follow-up.

### 변경 (7 files / +8 / -6)
- `eslint --fix` 자동 적용 (prefer-const 등 3건)
- `auth/middleware.ts`: `declare global { namespace Express }` 는 Express request 확장의 **declaration merging 필수 패턴** — ES module syntax 로 대체 불가. inline `// eslint-disable-next-line @typescript-eslint/no-namespace` 로 의도 명시.

### 결과
- backend lint: **4 errors → 0 errors**
- warnings 65 → 57

### 남은 warnings (별도 PR 후보)
- max-lines 11건 (여러 file split 필요)
- unused vars 46건 (대다수 `_` prefix 또는 catch optional binding 으로 정리 가능)

## Test plan
- [x] tsc 0
- [x] 전체 회귀: 97 suites / 1604 tests / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)