### PR TITLE
chore(lint): unused caught error 10건 → optional catch binding

### DIFF
--- a/backend/api/src/auth/oauth-provider.ts
+++ b/backend/api/src/auth/oauth-provider.ts
@@ -360,7 +360,7 @@ export class OAuthManager {
                         });
                         const primaryEmail = emailResponse.data.find((e: { primary?: boolean; email?: string }) => e.primary);
                         email = primaryEmail?.email || '';
-                    } catch (e) {
+                    } catch {
                         logger.warn('GitHub 이메일 조회 실패');
                     }
                 }

--- a/backend/api/src/cli.ts
+++ b/backend/api/src/cli.ts
@@ -219,7 +219,7 @@ program
                     const size = (model.size / 1024 / 1024 / 1024).toFixed(1);
                     console.log(chalk.white(`   • ${model.name}`) + chalk.gray(` (${size} GB)`));
                 }
-            } catch (e) {
+            } catch {
                 console.log(chalk.yellow('\n⚠️ 모델 목록 조회 실패'));
             }
         } else {

--- a/backend/api/src/cluster/config.ts
+++ b/backend/api/src/cluster/config.ts
@@ -67,7 +67,7 @@ export function loadClusterConfig(): ClusterConfig {
                 name: 'primary'
             };
             return { ...DEFAULT_CONFIG, nodes: [node] };
-        } catch (e) {
+        } catch {
             // URL 파싱 실패
         }
     }
@@ -84,7 +84,7 @@ export function loadClusterConfig(): ClusterConfig {
                 name: 'llm-proxy',
             };
             return { ...DEFAULT_CONFIG, nodes: [node] };
-        } catch (e) {
+        } catch {
             // URL 파싱 실패 — DEFAULT_CONFIG (빈 nodes) 폴백
         }
     }

--- a/backend/api/src/cluster/multiClient.ts
+++ b/backend/api/src/cluster/multiClient.ts
@@ -64,7 +64,7 @@ export class MultiNodeClient {
                         allModels.set(model.name, model);
                     }
                 }
-            } catch (e) {
+            } catch {
                 // 노드 오류 무시
             }
         }
@@ -100,7 +100,7 @@ export class MultiNodeClient {
             try {
                 client.setModel(model);
                 return await client.generate(prompt, options, onToken);
-            } catch (e) {
+            } catch {
                 logger.warn(`노드 ${node.name} 오류, 재시도 중...`);
                 // 다음 노드 시도
             }
@@ -136,7 +136,7 @@ export class MultiNodeClient {
             try {
                 client.setModel(model);
                 return await client.chat(messages, options, onToken);
-            } catch (e) {
+            } catch {
                 logger.warn(`노드 ${node.name} 오류, 재시도 중...`);
             }
         }

--- a/backend/api/src/commands/generate.ts
+++ b/backend/api/src/commands/generate.ts
@@ -125,7 +125,7 @@ async function saveToFile(content: string, filename: string): Promise<void> {
         const absolutePath = path.resolve(filename);
         fs.writeFileSync(absolutePath, codeToSave.trim());
         console.log(chalk.green(`\n✅ 파일 저장됨: ${absolutePath}\n`));
-    } catch (error) {
+    } catch {
         console.log(chalk.red(`\n❌ 파일 저장 실패\n`));
     }
 }

--- a/backend/api/src/mcp/server.ts
+++ b/backend/api/src/mcp/server.ts
@@ -220,7 +220,7 @@ export class MCPServer {
                 const request: MCPRequest = JSON.parse(line);
                 const response = await this.handleRequest(request);
                 console.log(JSON.stringify(response));
-            } catch (error) {
+            } catch {
                 const errorResponse: MCPResponse = {
                     jsonrpc: '2.0',
                     id: 0,

--- a/backend/api/src/services/chat-strategies/discussion-strategy.ts
+++ b/backend/api/src/services/chat-strategies/discussion-strategy.ts
@@ -386,7 +386,7 @@ export class DiscussionStrategy implements ChatStrategy<DiscussionStrategyContex
             const { performWebSearch } = await import('../../mcp');
             webSearchFn = performWebSearch;
             logger.info('🔍 웹 검색 사실 검증 활성화');
-        } catch (e) {
+        } catch {
             logger.warn('웹 검색 모듈 로드 실패, 사실 검증 비활성화');
         }
 


### PR DESCRIPTION
## Summary

PR #47 의 후속. backend lint 의 unused caught error 10건을 ES2019+ optional catch binding 으로 정리.

### 변환 패턴
- \`} catch (e) {\` → \`} catch {\`
- \`} catch (error) {\` → \`} catch {\`

### 변경 (7 files / +10 / -10)
| 파일 | 줄 |
|---|---|
| auth/oauth-provider.ts | 363 |
| cli.ts | 222 |
| cluster/config.ts | 70, 87 |
| cluster/multiClient.ts | 67, 103, 139 |
| commands/generate.ts | 128 |
| mcp/server.ts | 223 |
| services/chat-strategies/discussion-strategy.ts | 389 |

### 안전성
- 각 file:line 은 ESLint 가 unused 로 명시한 정확한 위치만 sed 변환 — 사용 중인 catch 영향 0
- ES2019+ optional catch binding 은 표준 — Node 22 (engines 요구사항) 충족

## 결과
- backend lint warnings: **57 → 47** (caught errors 10건 모두 해소)
- 0 errors / 0 regression

## 잔여 47 warnings (별도 PR 후보)
- max-lines 11건 (file split 작업)
- unused imports/vars 36건 (logger / type imports / destructuring)

## Test plan
- [x] tsc 0
- [x] 전체 회귀: 97 suites / 1604 tests / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)