### PR TITLE
chore(lint): max-lines 정책 — declarative data file 예외

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,4 +61,20 @@ export default [
       ],
     },
   },
+  // Declarative data file 예외 — locale / OpenAPI spec / test fixture 은
+  // 자연 크기가 큼. max-lines 룰은 logic file 가독성 정책이라 적용 부적합.
+  {
+    files: [
+      "**/__tests__/**/*.test.ts",
+      "**/*.test.ts",
+      "**/locales/**/*.ts",
+      "backend/api/src/**/*locales*.ts",
+      "backend/api/src/chat/language-policy.ts",
+      "backend/api/src/chat/prompt-templates.ts",
+      "backend/api/src/swagger/paths-*.ts",
+    ],
+    rules: {
+      "max-lines": "off",
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

max-lines 룰 (400) 은 logic file 가독성 정책. test fixture / locale data / OpenAPI spec 같은 declarative file 은 자연 크기가 커서 동일 limit 적용 부적합. ESLint flat config 의 file-pattern block 으로 룰 off.

### 예외 적용 패턴
- `**/__tests__/**/*.test.ts`, `**/*.test.ts` — test fixture
- `**/locales/**/*.ts`, `**/*locales*.ts` — 다국어 데이터
- `chat/language-policy.ts`, `chat/prompt-templates.ts` — declarative config
- `swagger/paths-*.ts` — OpenAPI spec

### 결과
backend lint warnings: **16 → 6** (10건 해소)

남은 6건은 진짜 logic file (별도 split 후보):
| file | lines |
|---|---|
| services/ChatService.ts | 774 |
| routes/skills.routes.ts | 502 |
| services/chat-strategies/agent-loop-strategy.ts | 498 |
| sockets/handler.ts | 489 |
| chat/request-handler.ts | 472 |
| data/models/unified-database.ts | 447 |

## Test plan
- [x] tsc 0 / 0 errors
- [x] 전체 회귀: 97 suites / 1604 tests / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)