### PR TITLE
refactor(chat-service): chat options + history assembly 분리 (-42 lines)

### DIFF
--- a/backend/api/src/services/ChatService.ts
+++ b/backend/api/src/services/ChatService.ts
@@ -22,18 +22,16 @@ import { createLogger } from '../utils/logger';
 import { AGENTS, getAgentById, type AgentSelection } from '../agents';
 import type { DiscussionProgress } from '../agents/discussion-engine';
 import { getPromptConfig } from '../chat/prompt';
-import { adjustOptionsForModel, checkModelCapability } from '../chat/model-selector';
-import { assessComplexity, GV_SKIP_THRESHOLD } from '../chat/complexity-assessor';
+import { checkModelCapability } from '../chat/model-selector';
+import { assessComplexity } from '../chat/complexity-assessor';
 import { detectFastPath } from '../chat/fast-path-detector';
-import { CONCISE_RESPONSE_DIRECTIVE, TOKEN_BUDGETS } from '../config/llm-parameters';
-import { BUDGET_HINTS, CAPACITY } from '../config/runtime-limits';
 import { withSpan } from '../observability/otel';
 import type { ExecutionPlan } from '../chat/profile-resolver';
 import type { UserTier } from '../data/user-manager';
 import type { UserContext } from '../mcp/user-sandbox';
 import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { LLMClient } from '../llm';
-import { getGptOssTaskPreset, type ChatMessage, type ToolDefinition, type ModelOptions } from '../llm';
+import { type ChatMessage, type ToolDefinition, type ModelOptions } from '../llm';
 import type { ResearchProgress } from './DeepResearchService';
 import { AgentLoopStrategy, DeepResearchStrategy, DirectStrategy, DiscussionStrategy, GenerateVerifyStrategy, ThinkingStrategy } from './chat-strategies';
 import { formatResearchResult, formatDiscussionResult } from './chat-service-formatters';
@@ -57,6 +55,10 @@ import {
     type ExternalProviderDeps,
     type StreamFromExternalContext,
 } from './chat-service/external-provider';
+import {
+    buildChatOptions,
+    assembleHistoryWithSummary,
+} from './chat-service/options-and-history';
 
 // Re-export all types so consumers importing from ChatService don't break
 export type {
@@ -535,35 +537,15 @@ export class ChatService {
         // P1-2: 복잡도 기반 토큰 예산을 routingLog에 기록
         routingLog.routeDecision.tokenBudget = preComplexity.recommendedTokenBudget;
 
-        let chatOptions = adjustOptionsForModel(
-            modelSelection.model,
-            { ...modelSelection.options, ...(promptConfig.options || {}) },
-            modelSelection.queryType,
-            preComplexity.score
-        );
-
-        if (docId) {
-            const docPreset = getGptOssTaskPreset('document');
-            chatOptions = { ...docPreset, ...chatOptions };
-        }
-
-        // Thinking ON 시 num_predict 최소 보장.
-        // 배경: Ollama /api/chat 응답은 message.content 와 message.thinking 이
-        //      같은 num_predict 토큰 풀을 공유. 작은 cap에서 thinking 모델이
-        //      사고에 토큰을 다 쓰면 실제 응답이 비어 나오는 잘림 발생.
-        //      (예: chat/korean → tokenBudget 512, thinking이 2000+ 토큰 소비
-        //       → message.content 빈 응답 → empty-response 에러)
-        if (thinkingMode === true) {
-            const minTokens = TOKEN_BUDGETS.THINKING_MIN_TOKENS;
-            const current = chatOptions.num_predict;
-            if (current === undefined || current === null || (current > 0 && current < minTokens)) {
-                logger.info(
-                    `[ChatService] Thinking 활성 — num_predict 보강: ${current ?? 'undefined'} → ${minTokens}`
-                );
-                chatOptions = { ...chatOptions, num_predict: minTokens };
-                routingLog.routeDecision.tokenBudget = minTokens;
-            }
-        }
+        // chat options 조립 — helper module 위임 (model+complexity+doc+thinking 보강)
+        const chatOptions = buildChatOptions({
+            modelSelection,
+            promptOptions: promptConfig.options,
+            preComplexityScore: preComplexity.score,
+            docId,
+            thinkingMode,
+            routingLog,
+        });
 
         const currentImages = [...(images || []), ...documentImages];
 
@@ -583,58 +565,20 @@ export class ChatService {
         // getAllowedTools() 의 동기 머지에서 사용. agentId 가 결정된 직후 호출.
         await this.loadSkillBindings(selectedAgent.id);
 
-        let currentHistory: ChatMessage[] = [];
-        let combinedSystemPrompt = agentSystemMessage
+        const combinedSystemPrompt = agentSystemMessage
             ? `${agentSystemMessage}\n\n---\n\n${promptConfig.systemPrompt}`
             : promptConfig.systemPrompt;
 
-        // P1-1: 저복잡도 쿼리에 간결한 응답 지시어 주입
-        if (preComplexity.score < GV_SKIP_THRESHOLD) {
-            combinedSystemPrompt += `\n\n${CONCISE_RESPONSE_DIRECTIVE}`;
-        }
-
-        if (history && history.length > 0) {
-            // 긴 히스토리 자동 요약 (토큰 비용 절감)
-            let effectiveHistory = history;
-            try {
-                const { summarizeHistory } = await import('../chat/history-summarizer');
-                const summarized = await summarizeHistory(history, modelSelection.model);
-                if (summarized.wasSummarized) {
-                    logger.info(`히스토리 요약 적용: ${summarized.originalCount}개 → ${summarized.summarizedCount}개`);
-                }
-                effectiveHistory = summarized.messages;
-            } catch (sumError) {
-                logger.warn('히스토리 요약 실패 (원본 유지):', sumError);
-            }
-
-            currentHistory = [
-                { role: 'system', content: combinedSystemPrompt },
-                ...effectiveHistory.map((h) => ({
-                    role: h.role as ChatMessage['role'],
-                    content: h.content,
-                    images: h.images,
-                })),
-            ];
-        } else {
-            currentHistory = [{ role: 'system', content: combinedSystemPrompt }];
-        }
-
-        // 동적 토큰 예산 프롬프트: 잔여 예산 부족 시 간결 지시 주입
-        // Anthropic 하네스 원칙: "토큰 예산 인식 프롬프트 제어"
-        if (preComplexity.recommendedTokenBudget > 0) {
-            const estimatedUsed = currentHistory.reduce((sum, m) => sum + (m.content?.length ?? 0), 0) / CAPACITY.TOKEN_TO_CHAR_RATIO;
-            const remaining = 1 - (estimatedUsed / preComplexity.recommendedTokenBudget);
-            if (remaining < BUDGET_HINTS.LOW_BUDGET_THRESHOLD && remaining > 0) {
-                const hint = (languagePolicy?.resolvedLanguage === 'ko') ? BUDGET_HINTS.HINT_KO : BUDGET_HINTS.HINT_EN;
-                currentHistory[0].content += `\n\n${hint}`;
-                logger.info(`💡 토큰 예산 부족 (잔여 ${(remaining * 100).toFixed(0)}%) → 간결 지시 주입`);
-            }
-        }
-
-        currentHistory.push({
-            role: 'user',
-            content: finalEnhancedMessage,
-            ...(currentImages.length > 0 && { images: currentImages }),
+        // history assembly + system prompt + budget hint + user message — helper module 위임
+        const { currentHistory } = await assembleHistoryWithSummary({
+            history,
+            combinedSystemPrompt,
+            preComplexityScore: preComplexity.score,
+            finalEnhancedMessage,
+            currentImages,
+            recommendedTokenBudget: preComplexity.recommendedTokenBudget,
+            languagePolicy,
+            model: modelSelection.model,
         });
 
         // ── Step 5: 전략 선택 및 실행 (GV → AgentLoop 폴백) ──

--- a/backend/api/src/services/chat-service/options-and-history.ts
+++ b/backend/api/src/services/chat-service/options-and-history.ts
@@ -1,0 +1,159 @@
+/**
+ * ============================================================
+ * Options & History Builder — chat option 조립 + 히스토리 assembly
+ * ============================================================
+ *
+ * ChatService.processMessageInternal 에서 추출.
+ *
+ * - buildChatOptions: modelSelection + complexity + promptConfig + thinkingMode
+ *   → adjustOptionsForModel + 문서 preset + thinking num_predict 보정 결과
+ * - assembleHistoryWithSummary: history 자동 요약 + system prompt 조립 +
+ *   토큰 예산 부족 시 간결 지시 주입 + user message 추가
+ *
+ * 양 함수 모두 ChatService state 의존성 0 (pure function + 인자 객체).
+ *
+ * @module services/chat-service/options-and-history
+ */
+import { createLogger } from '../../utils/logger';
+import { adjustOptionsForModel } from '../../chat/model-selector';
+import { GV_SKIP_THRESHOLD } from '../../chat/complexity-assessor';
+import { CONCISE_RESPONSE_DIRECTIVE, TOKEN_BUDGETS } from '../../config/llm-parameters';
+import { BUDGET_HINTS, CAPACITY } from '../../config/runtime-limits';
+import { getGptOssTaskPreset, type ChatMessage, type ModelOptions } from '../../llm';
+import type { ModelSelection } from '../../chat/model-selector';
+import type { ChatHistoryMessage } from '../chat-service-types';
+import type { LanguagePolicyDecision } from '../../chat/language-policy';
+import type { RoutingDecisionLog } from '../../chat/routing-logger';
+
+const logger = createLogger('ChatOptionsHistory');
+
+export interface BuildChatOptionsParams {
+    modelSelection: ModelSelection;
+    promptOptions?: ModelOptions;
+    preComplexityScore: number;
+    docId?: string;
+    thinkingMode?: boolean;
+    routingLog: RoutingDecisionLog;
+}
+
+/**
+ * chat options 조립.
+ *
+ * 1. adjustOptionsForModel (model + complexity)
+ * 2. docId 가 있으면 document preset overlay
+ * 3. thinkingMode=true 시 num_predict 최소값 보강 (잘림 방지)
+ *
+ * 부수효과: thinking 보강 시 routingLog.routeDecision.tokenBudget 업데이트
+ */
+export function buildChatOptions(p: BuildChatOptionsParams): ModelOptions {
+    let chatOptions = adjustOptionsForModel(
+        p.modelSelection.model,
+        { ...p.modelSelection.options, ...(p.promptOptions || {}) },
+        p.modelSelection.queryType,
+        p.preComplexityScore,
+    );
+
+    if (p.docId) {
+        const docPreset = getGptOssTaskPreset('document');
+        chatOptions = { ...docPreset, ...chatOptions };
+    }
+
+    // Thinking ON 시 num_predict 최소 보장 — Ollama 의 thinking/content 공유 풀에서
+    // 작은 cap 으로 thinking 이 토큰을 다 쓰면 message.content 빈 응답 잘림 발생.
+    if (p.thinkingMode === true) {
+        const minTokens = TOKEN_BUDGETS.THINKING_MIN_TOKENS;
+        const current = chatOptions.num_predict;
+        if (current === undefined || current === null || (current > 0 && current < minTokens)) {
+            logger.info(
+                `Thinking 활성 — num_predict 보강: ${current ?? 'undefined'} → ${minTokens}`,
+            );
+            chatOptions = { ...chatOptions, num_predict: minTokens };
+            p.routingLog.routeDecision.tokenBudget = minTokens;
+        }
+    }
+
+    return chatOptions;
+}
+
+type HistoryInput = ChatHistoryMessage | { role: string; content: string; images?: string[] };
+
+export interface AssembleHistoryParams {
+    history?: HistoryInput[];
+    combinedSystemPrompt: string;
+    preComplexityScore: number;
+    finalEnhancedMessage: string;
+    currentImages: string[];
+    recommendedTokenBudget: number;
+    languagePolicy?: LanguagePolicyDecision | null;
+    model: string;
+}
+
+export interface AssembleHistoryResult {
+    currentHistory: ChatMessage[];
+    /** combinedSystemPrompt + low-budget hint + concise directive 가 합쳐진 최종 system prompt */
+    finalSystemPrompt: string;
+}
+
+/**
+ * 히스토리 assembly + system prompt 조립.
+ *
+ * 1. preComplexity 가 낮으면 CONCISE_RESPONSE_DIRECTIVE 주입
+ * 2. history 가 있으면 자동 요약 시도 (history-summarizer)
+ * 3. 토큰 예산 부족 (잔여 < LOW_BUDGET_THRESHOLD) 시 budget hint 주입
+ * 4. user message 추가 (이미지 동봉)
+ */
+export async function assembleHistoryWithSummary(p: AssembleHistoryParams): Promise<AssembleHistoryResult> {
+    let combinedSystemPrompt = p.combinedSystemPrompt;
+
+    if (p.preComplexityScore < GV_SKIP_THRESHOLD) {
+        combinedSystemPrompt += `\n\n${CONCISE_RESPONSE_DIRECTIVE}`;
+    }
+
+    let currentHistory: ChatMessage[];
+    if (p.history && p.history.length > 0) {
+        let effectiveHistory: Array<{ role: string; content: string; images?: string[] }> = p.history;
+        try {
+            const { summarizeHistory } = await import('../../chat/history-summarizer');
+            const summarized = await summarizeHistory(p.history, p.model);
+            if (summarized.wasSummarized) {
+                logger.info(`히스토리 요약 적용: ${summarized.originalCount}개 → ${summarized.summarizedCount}개`);
+            }
+            effectiveHistory = summarized.messages;
+        } catch (sumError) {
+            logger.warn('히스토리 요약 실패 (원본 유지):', sumError);
+        }
+
+        currentHistory = [
+            { role: 'system', content: combinedSystemPrompt },
+            ...effectiveHistory.map((h) => ({
+                role: h.role as ChatMessage['role'],
+                content: h.content,
+                images: h.images,
+            })),
+        ];
+    } else {
+        currentHistory = [{ role: 'system', content: combinedSystemPrompt }];
+    }
+
+    // 동적 토큰 예산 프롬프트 — 잔여 예산 부족 시 간결 지시 주입
+    if (p.recommendedTokenBudget > 0) {
+        const estimatedUsed = currentHistory.reduce((sum, m) => sum + (m.content?.length ?? 0), 0) / CAPACITY.TOKEN_TO_CHAR_RATIO;
+        const remaining = 1 - (estimatedUsed / p.recommendedTokenBudget);
+        if (remaining < BUDGET_HINTS.LOW_BUDGET_THRESHOLD && remaining > 0) {
+            const hint = (p.languagePolicy?.resolvedLanguage === 'ko') ? BUDGET_HINTS.HINT_KO : BUDGET_HINTS.HINT_EN;
+            currentHistory[0].content += `\n\n${hint}`;
+            logger.info(`💡 토큰 예산 부족 (잔여 ${(remaining * 100).toFixed(0)}%) → 간결 지시 주입`);
+        }
+    }
+
+    currentHistory.push({
+        role: 'user',
+        content: p.finalEnhancedMessage,
+        ...(p.currentImages.length > 0 && { images: p.currentImages }),
+    });
+
+    return {
+        currentHistory,
+        finalSystemPrompt: currentHistory[0].content || combinedSystemPrompt,
+    };
+}


### PR DESCRIPTION
## Summary

PR #51 의 후속. ChatService.processMessageInternal 의 chat options 조립 + history assembly 영역 (~110 inline lines) 을 helper module 로 추출.

### 변경 (2 files / +186 / -83)
- `chat-service/options-and-history.ts` (신규, 159 lines)
  - `buildChatOptions(p)` — adjustOptionsForModel + doc preset + thinking num_predict 보강 (routingLog mutation 포함)
  - `assembleHistoryWithSummary(p)` — history-summarizer 호출 + system prompt 조립 + concise directive + budget hint + user message
- `ChatService.ts`
  - 두 helper 호출로 교체 (-~85 inline lines)
  - unused import 7건 정리

### 결과
- ChatService.ts (lint 기준): 560 → **518 lines** (-42)
- 누적 (PR #51 + #52): 774 → 518 lines (**-256, 33% 감소**)

## Test plan
- [x] tsc 0 / lint 0 errors
- [x] 전체 회귀: 97 suites / 1604 tests / 0 failed

## 후속 (별도 PR)
- ChatService max-lines warning 잔존 (518 > 400). routing log 초기화 + complexity assessment + agent parallel start 영역 후속 split 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)