### PR TITLE
refactor(routes): skills drafts workflow sub-router 분리 (-79 lines)

### DIFF
--- a/backend/api/src/routes/skills-drafts.routes.ts
+++ b/backend/api/src/routes/skills-drafts.routes.ts
@@ -1,0 +1,133 @@
+/**
+ * ============================================================
+ * Skills Drafts Sub-Router — draft 목록 + approve + reject
+ * ============================================================
+ *
+ * skills.routes.ts 에서 추출. mount path: `/api/agents/skills` 의 sub-router.
+ *
+ * 엔드포인트:
+ *   GET  /drafts                — target=user/system/all 별 draft 목록
+ *   POST /:skillId/approve      — draft → active (소유자/admin)
+ *   POST /:skillId/reject       — draft → archived (소유자/admin)
+ *
+ * @module routes/skills-drafts.routes
+ */
+import { Router, type Request, type Response } from 'express';
+import { requireAuth } from '../auth';
+import { validateQuery } from '../middlewares/validation';
+import { asyncHandler } from '../utils/error-handler';
+import { success, notFound, unauthorized } from '../utils/api-response';
+import { draftsQuerySchema } from '../schemas/skills.schema';
+import { getSkillManager } from '../agents/skill-manager';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('SkillsDraftsRoutes');
+
+const router = Router();
+
+/** 호출자 userId 추출 (PublicUser/AuthUser 양쪽 호환) */
+function extractUserId(req: Request): string | undefined {
+    return (req.user && 'userId' in req.user
+        ? (req.user as { userId: string }).userId
+        : req.user?.id?.toString());
+}
+
+router.get('/drafts', requireAuth, validateQuery(draftsQuerySchema), asyncHandler(async (req: Request, res: Response) => {
+    const userId = extractUserId(req);
+    if (!userId) {
+        res.status(401).json(unauthorized('인증 필요'));
+        return;
+    }
+    const isAdmin = req.user?.role === 'admin';
+    const target = String(req.query.target ?? 'user') as 'user' | 'system' | 'all';
+
+    if ((target === 'system' || target === 'all') && !isAdmin) {
+        res.status(403).json({ error: 'ADMIN_REQUIRED', detail: `target=${target} 는 관리자 전용` });
+        return;
+    }
+
+    const result = await getSkillManager().listDrafts({
+        target,
+        userId: target === 'user' ? userId : undefined,
+        limit: req.query.limit != null ? Number(req.query.limit) : undefined,
+        offset: req.query.offset != null ? Number(req.query.offset) : undefined,
+    });
+    res.json(success(result));
+}));
+
+/**
+ * POST /api/agents/skills/:skillId/approve
+ * draft → active 전환. 소유자 또는 admin 만 가능. 시스템 스킬(createdBy=null) 은 admin 만.
+ */
+router.post('/:skillId/approve', requireAuth, asyncHandler(async (req: Request, res: Response) => {
+    const { skillId } = req.params;
+    const userId = extractUserId(req);
+    if (!userId) {
+        res.status(401).json(unauthorized('인증 필요'));
+        return;
+    }
+
+    const existing = await getSkillManager().getSkillById(skillId);
+    if (!existing) {
+        res.status(404).json(notFound('스킬'));
+        return;
+    }
+    if (existing.status !== 'draft') {
+        res.status(409).json({ error: 'NOT_DRAFT', detail: `현재 status=${existing.status ?? 'unknown'}` });
+        return;
+    }
+
+    try {
+        const actor = { userId: String(userId), userRole: req.user?.role || 'user' };
+        const updated = await getSkillManager().updateStatus(skillId, 'active', actor);
+        logger.info(`draft approved: ${skillId} by ${userId}`);
+        res.json(success(updated));
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        if (msg.includes('ADMIN_REQUIRED') || msg.includes('소유자')) {
+            res.status(403).json({ error: 'FORBIDDEN', detail: msg });
+            return;
+        }
+        res.status(500).json({ error: msg });
+    }
+}));
+
+/**
+ * POST /api/agents/skills/:skillId/reject
+ * draft → archived 전환 (보존, 삭제 아님 — manifest_meta 감사용).
+ * 소유자 또는 admin.
+ */
+router.post('/:skillId/reject', requireAuth, asyncHandler(async (req: Request, res: Response) => {
+    const { skillId } = req.params;
+    const userId = extractUserId(req);
+    if (!userId) {
+        res.status(401).json(unauthorized('인증 필요'));
+        return;
+    }
+
+    const existing = await getSkillManager().getSkillById(skillId);
+    if (!existing) {
+        res.status(404).json(notFound('스킬'));
+        return;
+    }
+    if (existing.status !== 'draft') {
+        res.status(409).json({ error: 'NOT_DRAFT', detail: `현재 status=${existing.status ?? 'unknown'}` });
+        return;
+    }
+
+    try {
+        const actor = { userId: String(userId), userRole: req.user?.role || 'user' };
+        const updated = await getSkillManager().updateStatus(skillId, 'archived', actor);
+        logger.info(`draft rejected: ${skillId} by ${userId}`);
+        res.json(success(updated));
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        if (msg.includes('ADMIN_REQUIRED') || msg.includes('소유자')) {
+            res.status(403).json({ error: 'FORBIDDEN', detail: msg });
+            return;
+        }
+        res.status(500).json({ error: msg });
+    }
+}));
+
+export default router;

--- a/backend/api/src/routes/skills.routes.ts
+++ b/backend/api/src/routes/skills.routes.ts
@@ -39,7 +39,6 @@ import {
     updateSkillSchema,
     searchSkillsQuerySchema,
     autoCreateSkillSchema,
-    draftsQuerySchema,
 } from '../schemas/skills.schema';
 import { assignSkillSchema } from '../schemas/agents.schema';
 import { SkillCreatorService } from '../agents/skill-creator';
@@ -99,6 +98,10 @@ const skillCreateBurstLimiter = rateLimit({
 
 const logger = createLogger('SkillsRoutes');
 const router = Router();
+
+// Draft 워크플로 (GET /drafts, POST /:skillId/approve|reject) sub-router
+import skillsDraftsRouter from './skills-drafts.routes';
+router.use('/', skillsDraftsRouter);
 
 // .SKILL 업로드 multer (memoryStorage, 256KB 제한, P5-D7)
 const skillUpload = multer({
@@ -435,107 +438,6 @@ function mapGitIngestErrorToStatus(code: string): number {
     }
 }
 
-/**
- * GET /api/agents/skills/drafts
- * draft 상태 스킬 목록. target='user' (기본, 본인 것), 'system' (admin only), 'all' (admin only).
- */
-router.get('/drafts', requireAuth, validateQuery(draftsQuerySchema), asyncHandler(async (req: Request, res: Response) => {
-    const userId = (req.user && 'userId' in req.user ? (req.user as { userId: string }).userId : req.user?.id?.toString());
-    if (!userId) {
-        res.status(401).json(unauthorized('인증 필요'));
-        return;
-    }
-    const isAdmin = req.user?.role === 'admin';
-    const target = String(req.query.target ?? 'user') as 'user' | 'system' | 'all';
-
-    if ((target === 'system' || target === 'all') && !isAdmin) {
-        res.status(403).json({ error: 'ADMIN_REQUIRED', detail: `target=${target} 는 관리자 전용` });
-        return;
-    }
-
-    const result = await getSkillManager().listDrafts({
-        target,
-        userId: target === 'user' ? userId : undefined,
-        limit: req.query.limit != null ? Number(req.query.limit) : undefined,
-        offset: req.query.offset != null ? Number(req.query.offset) : undefined,
-    });
-    res.json(success(result));
-}));
-
-/**
- * POST /api/agents/skills/:skillId/approve
- * draft → active 전환. 소유자 또는 admin 만 가능. 시스템 스킬(createdBy=null) 은 admin 만.
- */
-router.post('/:skillId/approve', requireAuth, asyncHandler(async (req: Request, res: Response) => {
-    const { skillId } = req.params;
-    const userId = (req.user && 'userId' in req.user ? (req.user as { userId: string }).userId : req.user?.id?.toString());
-    if (!userId) {
-        res.status(401).json(unauthorized('인증 필요'));
-        return;
-    }
-
-    const existing = await getSkillManager().getSkillById(skillId);
-    if (!existing) {
-        res.status(404).json(notFound('스킬'));
-        return;
-    }
-    if (existing.status !== 'draft') {
-        res.status(409).json({ error: 'NOT_DRAFT', detail: `현재 status=${existing.status ?? 'unknown'}` });
-        return;
-    }
-
-    try {
-        const actor = { userId: String(userId), userRole: req.user?.role || 'user' };
-        const updated = await getSkillManager().updateStatus(skillId, 'active', actor);
-        logger.info(`draft approved: ${skillId} by ${userId}`);
-        res.json(success(updated));
-    } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        if (msg.includes('ADMIN_REQUIRED') || msg.includes('소유자')) {
-            res.status(403).json({ error: 'FORBIDDEN', detail: msg });
-            return;
-        }
-        res.status(500).json({ error: msg });
-    }
-}));
-
-/**
- * POST /api/agents/skills/:skillId/reject
- * draft → archived 전환 (보존, 삭제 아님 — manifest_meta 감사용).
- * 소유자 또는 admin.
- */
-router.post('/:skillId/reject', requireAuth, asyncHandler(async (req: Request, res: Response) => {
-    const { skillId } = req.params;
-    const userId = (req.user && 'userId' in req.user ? (req.user as { userId: string }).userId : req.user?.id?.toString());
-    if (!userId) {
-        res.status(401).json(unauthorized('인증 필요'));
-        return;
-    }
-
-    const existing = await getSkillManager().getSkillById(skillId);
-    if (!existing) {
-        res.status(404).json(notFound('스킬'));
-        return;
-    }
-    if (existing.status !== 'draft') {
-        res.status(409).json({ error: 'NOT_DRAFT', detail: `현재 status=${existing.status ?? 'unknown'}` });
-        return;
-    }
-
-    try {
-        const actor = { userId: String(userId), userRole: req.user?.role || 'user' };
-        const updated = await getSkillManager().updateStatus(skillId, 'archived', actor);
-        logger.info(`draft rejected: ${skillId} by ${userId}`);
-        res.json(success(updated));
-    } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        if (msg.includes('ADMIN_REQUIRED') || msg.includes('소유자')) {
-            res.status(403).json({ error: 'FORBIDDEN', detail: msg });
-            return;
-        }
-        res.status(500).json({ error: msg });
-    }
-}));
 
 // ================================================
 // 사용자 개인 스킬 할당


### PR DESCRIPTION
## Summary

skills.routes.ts (lint 기준 502 lines) max-lines warning 해소 시리즈의 1차. drafts workflow 3 endpoints 가 가장 self-contained → 첫 split.

### 변경 (2 files / +137 / -102)
- `routes/skills-drafts.routes.ts` (신규, 133 lines) — GET /drafts + POST /:id/approve|reject
- `routes/skills.routes.ts` (-101 lines)
  - 3 endpoint 본문 제거
  - sub-router mount: `router.use('/', skillsDraftsRouter)`
  - `draftsQuerySchema` import 제거 (sub-router 직접 import)

### 결과
- skills.routes.ts (lint 기준): **502 → 423 lines** (-79)
- 외부 호출 URL 영향 0 (sub-router mount path 동일)

## Test plan
- [x] tsc 0 / lint 0 errors
- [x] 전체 회귀: 97 suites / 1604 tests / 0 failed

## 후속 (별도 PR)
- skills.routes 추가 split: create flow (4 endpoints) + user-assign (3 endpoints)
- max-lines 후보: agent-loop-strategy / sockets/handler / request-handler / unified-database

🤖 Generated with [Claude Code](https://claude.com/claude-code)