### PR TITLE
refactor(routes): skills user-assign sub-router (skills.routes max-lines 해소)

### DIFF
--- a/backend/api/src/routes/skills-user-assign.routes.ts
+++ b/backend/api/src/routes/skills-user-assign.routes.ts
@@ -1,0 +1,81 @@
+/**
+ * ============================================================
+ * Skills User Assignment Sub-Router — 사용자별 개인 스킬 할당
+ * ============================================================
+ *
+ * skills.routes.ts 에서 추출. mount path: `/api/agents/skills` 의 sub-router.
+ *
+ * 엔드포인트:
+ *   GET    /user-assigned          — 현재 사용자의 개인 할당 스킬 목록
+ *   POST   /:skillId/user-assign   — 개인 스킬 할당 (priority)
+ *   DELETE /:skillId/user-assign   — 개인 스킬 할당 해제
+ *
+ * @module routes/skills-user-assign.routes
+ */
+import { Router, type Request, type Response } from 'express';
+import { requireAuth } from '../auth';
+import { validate } from '../middlewares/validation';
+import { asyncHandler } from '../utils/error-handler';
+import { success, notFound, unauthorized } from '../utils/api-response';
+import { assignSkillSchema } from '../schemas/agents.schema';
+import { getSkillManager } from '../agents/skill-manager';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('SkillsUserAssignRoutes');
+
+const router = Router();
+
+function extractUserId(req: Request): string | undefined {
+    return (req.user && 'userId' in req.user
+        ? (req.user as { userId: string }).userId
+        : req.user?.id?.toString());
+}
+
+router.get('/user-assigned', requireAuth, asyncHandler(async (req: Request, res: Response) => {
+    const userId = extractUserId(req);
+    if (!userId) {
+        res.status(401).json(unauthorized('인증 필요'));
+        return;
+    }
+    const skills = await getSkillManager().getUserSkills(userId);
+    res.json(success(skills));
+}));
+
+router.post('/:skillId/user-assign', requireAuth, validate(assignSkillSchema), asyncHandler(async (req: Request, res: Response) => {
+    const { skillId } = req.params;
+    const userId = extractUserId(req);
+    if (!userId) {
+        res.status(401).json(unauthorized('인증 필요'));
+        return;
+    }
+
+    const skill = await getSkillManager().getSkillById(skillId);
+    if (!skill) {
+        res.status(404).json(notFound('스킬'));
+        return;
+    }
+    if (skill.status && skill.status !== 'active') {
+        res.status(409).json({ error: 'SKILL_NOT_ACTIVE', detail: `status=${skill.status} 인 스킬은 할당할 수 없습니다. 먼저 승인하세요.` });
+        return;
+    }
+
+    const priority: number = typeof req.body?.priority === 'number' ? req.body.priority : 0;
+    await getSkillManager().assignSkillToUser(userId, skillId, priority);
+    logger.info(`개인 스킬 할당: userId=${userId}, skillId=${skillId}`);
+    res.json(success({ assigned: true, skillId, userId }));
+}));
+
+router.delete('/:skillId/user-assign', requireAuth, asyncHandler(async (req: Request, res: Response) => {
+    const { skillId } = req.params;
+    const userId = extractUserId(req);
+    if (!userId) {
+        res.status(401).json(unauthorized('인증 필요'));
+        return;
+    }
+
+    await getSkillManager().removeSkillFromUser(userId, skillId);
+    logger.info(`개인 스킬 할당 해제: userId=${userId}, skillId=${skillId}`);
+    res.json(success({ unassigned: true, skillId, userId }));
+}));
+
+export default router;

--- a/backend/api/src/routes/skills.routes.ts
+++ b/backend/api/src/routes/skills.routes.ts
@@ -40,7 +40,6 @@ import {
     searchSkillsQuerySchema,
     autoCreateSkillSchema,
 } from '../schemas/skills.schema';
-import { assignSkillSchema } from '../schemas/agents.schema';
 import { SkillCreatorService } from '../agents/skill-creator';
 import { LLMClient } from '../llm/client';
 import { SKILL_CREATOR } from '../config/constants';
@@ -102,6 +101,10 @@ const router = Router();
 // Draft 워크플로 (GET /drafts, POST /:skillId/approve|reject) sub-router
 import skillsDraftsRouter from './skills-drafts.routes';
 router.use('/', skillsDraftsRouter);
+
+// 사용자 개인 스킬 할당 (GET /user-assigned, POST/DELETE /:skillId/user-assign)
+import skillsUserAssignRouter from './skills-user-assign.routes';
+router.use('/', skillsUserAssignRouter);
 
 // .SKILL 업로드 multer (memoryStorage, 256KB 제한, P5-D7)
 const skillUpload = multer({
@@ -437,71 +440,6 @@ function mapGitIngestErrorToStatus(code: string): number {
         default: return 500;
     }
 }
-
-
-// ================================================
-// 사용자 개인 스킬 할당
-// ================================================
-
-/**
- * GET /api/agents/skills/user-assigned
- * 현재 로그인 사용자의 개인 할당 스킬 목록
- */
-router.get('/user-assigned', requireAuth, asyncHandler(async (req: Request, res: Response) => {
-    const userId = (req.user && 'userId' in req.user ? (req.user as { userId: string }).userId : req.user?.id?.toString());
-    if (!userId) {
-        res.status(401).json(unauthorized('인증 필요'));
-        return;
-    }
-    const skills = await getSkillManager().getUserSkills(userId);
-    res.json(success(skills));
-}));
-
-/**
- * POST /api/agents/skills/:skillId/user-assign
- * 개인 스킬 할당 (사용자 스코프)
- */
-router.post('/:skillId/user-assign', requireAuth, validate(assignSkillSchema), asyncHandler(async (req: Request, res: Response) => {
-    const { skillId } = req.params;
-    const userId = (req.user && 'userId' in req.user ? (req.user as { userId: string }).userId : req.user?.id?.toString());
-    if (!userId) {
-        res.status(401).json(unauthorized('인증 필요'));
-        return;
-    }
-
-    const skill = await getSkillManager().getSkillById(skillId);
-    if (!skill) {
-        res.status(404).json(notFound('스킬'));
-        return;
-    }
-    if (skill.status && skill.status !== 'active') {
-        res.status(409).json({ error: 'SKILL_NOT_ACTIVE', detail: `status=${skill.status} 인 스킬은 할당할 수 없습니다. 먼저 승인하세요.` });
-        return;
-    }
-
-    const priority: number = typeof req.body?.priority === 'number' ? req.body.priority : 0;
-    await getSkillManager().assignSkillToUser(userId, skillId, priority);
-    logger.info(`개인 스킬 할당: userId=${userId}, skillId=${skillId}`);
-    res.json(success({ assigned: true, skillId, userId }));
-}));
-
-/**
- * DELETE /api/agents/skills/:skillId/user-assign
- * 개인 스킬 할당 해제
- */
-router.delete('/:skillId/user-assign', requireAuth, asyncHandler(async (req: Request, res: Response) => {
-    const { skillId } = req.params;
-    const userId = (req.user && 'userId' in req.user ? (req.user as { userId: string }).userId : req.user?.id?.toString());
-    if (!userId) {
-        res.status(401).json(unauthorized('인증 필요'));
-        return;
-    }
-
-    await getSkillManager().removeSkillFromUser(userId, skillId);
-    logger.info(`개인 스킬 할당 해제: userId=${userId}, skillId=${skillId}`);
-    res.json(success({ unassigned: true, skillId, userId }));
-}));
-
 /**
  * PUT /api/agents/skills/:skillId
  * 스킬 수정 (소유권 검증 포함)


### PR DESCRIPTION
## Summary

PR #53 의 후속. skills.routes.ts 의 user-assign 3 endpoints 분리.

### 변경 (2 files / +85 / -66)
- `routes/skills-user-assign.routes.ts` (신규, 81 lines)
  - GET /user-assigned, POST /:id/user-assign, DELETE /:id/user-assign
- `routes/skills.routes.ts`
  - 3 endpoint 본문 제거 (-66 lines)
  - assignSkillSchema import 제거 + sub-router mount

### 결과
- skills.routes.ts (lint 기준): **423 → 376 lines** (-47, **max 400 미만 통과** ✅)
- skills.routes max-lines warning **완전 해소**
- 전체 backend lint: 6 → **5 warnings**

## Test plan
- [x] tsc 0 / lint 0 errors / 0 warnings (skills.routes)
- [x] 전체 회귀: 97 suites / 1604 tests / 0 failed

## 후속 (별도 PR)
- agent-loop-strategy / sockets/handler / request-handler / unified-database / ChatService 추가 split

🤖 Generated with [Claude Code](https://claude.com/claude-code)