### PR TITLE
refactor(db): unified-database schema initializer 분리 (warning 해소)

### DIFF
--- a/backend/api/src/data/models/schema-initializer.ts
+++ b/backend/api/src/data/models/schema-initializer.ts
@@ -1,0 +1,92 @@
+/**
+ * ============================================================
+ * Schema Initializer — PostgreSQL 스키마 자동 초기화
+ * ============================================================
+ *
+ * unified-database.ts 에서 추출. 서버 시작 시 1회 실행:
+ *   1. 002-schema.sql 파일 탐색 → 없으면 LEGACY_SCHEMA fallback
+ *   2. 전체 스키마 적용 (CREATE TABLE IF NOT EXISTS)
+ *   3. agent_usage_logs FK migration (ON DELETE SET NULL)
+ *   4. pg_trgm 트라이그램 인덱스 생성 (확장 미지원 시 skip)
+ *
+ * @module data/models/schema-initializer
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Pool } from 'pg';
+import { withRetry } from '../retry-wrapper';
+import { createLogger } from '../../utils/logger';
+import { LEGACY_SCHEMA } from './legacy-schema';
+
+const logger = createLogger('SchemaInitializer');
+
+const SCHEMA_FILE_RELATIVE_PATH = 'services/database/init/002-schema.sql';
+
+/**
+ * 002-schema.sql 파일 탐색 (cwd / __dirname 상대 경로 모두 시도).
+ * 발견 실패 시 LEGACY_SCHEMA (inline) fallback.
+ */
+export function getSchemaSql(): { schema: string; source: string } {
+    const candidatePaths = [
+        path.resolve(process.cwd(), SCHEMA_FILE_RELATIVE_PATH),
+        path.resolve(__dirname, '../../../../../services/database/init/002-schema.sql'),
+        path.resolve(__dirname, '../../../../services/database/init/002-schema.sql'),
+    ];
+
+    for (const filePath of candidatePaths) {
+        try {
+            const schema = fs.readFileSync(filePath, 'utf8');
+            return { schema, source: `file:${filePath}` };
+        } catch (error: unknown) {
+            const err = error as NodeJS.ErrnoException;
+            if (err.code !== 'ENOENT') {
+                logger.warn(`Failed reading schema file at ${filePath}:`, err);
+            }
+        }
+    }
+
+    logger.warn('Schema SQL file not found; falling back to LEGACY_SCHEMA');
+    return { schema: LEGACY_SCHEMA, source: 'inline:LEGACY_SCHEMA' };
+}
+
+/**
+ * 스키마 초기화 전체 시퀀스 — pool 받아서 1회 실행.
+ *
+ * 1. schema SQL 적용 (idempotent — IF NOT EXISTS)
+ * 2. agent_usage_logs FK 보정 (ON DELETE SET NULL)
+ * 3. pg_trgm 확장 + GIN 인덱스 (user_memories.key/value)
+ *
+ * 멱등 — 재실행 안전.
+ */
+export async function initSchema(pool: Pool): Promise<void> {
+    const { schema, source } = getSchemaSql();
+    logger.info(`Initializing schema from ${source}`);
+    await withRetry(
+        () => pool.query(schema),
+        { operation: 'initialize schema from SQL source' },
+    );
+
+    // Migration: agent_usage_logs FK to use SET NULL on delete
+    try {
+        await withRetry(
+            () => pool.query(`
+                ALTER TABLE agent_usage_logs DROP CONSTRAINT IF EXISTS agent_usage_logs_session_id_fkey;
+                ALTER TABLE agent_usage_logs ADD CONSTRAINT agent_usage_logs_session_id_fkey
+                    FOREIGN KEY (session_id) REFERENCES conversation_sessions(id) ON DELETE SET NULL;
+            `),
+            { operation: 'agent_usage_logs FK migration' },
+        );
+    } catch {
+        // Constraint may already be correct — ignore
+    }
+
+    // pg_trgm GIN 인덱스 (확장 미지원 환경에서는 skip)
+    try {
+        await pool.query(`CREATE EXTENSION IF NOT EXISTS pg_trgm`);
+        await pool.query(`CREATE INDEX IF NOT EXISTS idx_memories_key_trgm ON user_memories USING gin (key gin_trgm_ops)`);
+        await pool.query(`CREATE INDEX IF NOT EXISTS idx_memories_value_trgm ON user_memories USING gin (value gin_trgm_ops)`);
+        logger.info('pg_trgm 트라이그램 인덱스 생성 완료');
+    } catch {
+        logger.info('pg_trgm 인덱스 생성 건너뜀 (확장 미지원 환경)');
+    }
+}

--- a/backend/api/src/data/models/unified-database.ts
+++ b/backend/api/src/data/models/unified-database.ts
@@ -15,10 +15,7 @@
  * - 싱글톤 접근: getUnifiedDatabase(), getPool()
  */
 
-import { Pool, QueryResult, type PoolConfig } from 'pg';
-import * as fs from 'fs';
-import * as path from 'path';
-import { withRetry } from '../retry-wrapper';
+import { Pool, type PoolConfig } from 'pg';
 import { getConfig } from '../../config/env';
 import { DB_POOL_TIMEOUTS } from '../../config/timeouts';
 import { createLogger } from '../../utils/logger';
@@ -30,43 +27,10 @@ import {
     ResearchRepository,
     UserRepository
 } from '../repositories';
-import { LEGACY_SCHEMA } from './legacy-schema';
+import { initSchema as initSchemaFn } from './schema-initializer';
 
 const logger = createLogger('UnifiedDB');
 
-type SpanLike = {
-    setAttribute: (key: string, value: string | number | boolean) => SpanLike;
-};
-
-type WithSpanLike = <T>(
-    tracerName: string,
-    spanName: string,
-    fn: (span: SpanLike) => Promise<T>,
-    options?: { kind?: number; attributes?: Record<string, string | number | boolean> }
-) => Promise<T>;
-
-let cachedWithSpan: WithSpanLike | null | undefined;
-
-function getWithSpan(): WithSpanLike | null {
-    if (cachedWithSpan !== undefined) {
-        return cachedWithSpan;
-    }
-
-    try {
-        const otelModule = require('../../observability/otel') as { withSpan?: WithSpanLike };
-        cachedWithSpan = typeof otelModule.withSpan === 'function' ? otelModule.withSpan : null;
-    } catch (err) {
-        logger.debug('[UnifiedDB] OTel withSpan load skipped', err);
-        cachedWithSpan = null;
-    }
-
-    return cachedWithSpan;
-}
-
-/** SQL 쿼리 파라미터 타입 - $1, $2 등의 플레이스홀더에 바인딩되는 값 */
-type QueryParam = string | number | boolean | null | undefined;
-
-const SCHEMA_FILE_RELATIVE_PATH = 'services/database/init/002-schema.sql';
 
 // ============================================
 // 엔티티 타입 (unified-database.types.ts에서 import + re-export)
@@ -169,7 +133,7 @@ export class UnifiedDatabase {
         });
 
         // 스키마 초기화 — Promise를 보관하여 초기 쿼리가 스키마 완료를 대기할 수 있도록 함
-        this.schemaReady = this.initSchema().catch(err => {
+        this.schemaReady = initSchemaFn(this.pool).catch((err: unknown) => {
             logger.error('[UnifiedDB] Schema init failed:', err);
         }) as Promise<void>;
 
@@ -183,57 +147,7 @@ export class UnifiedDatabase {
         logger.info('[UnifiedDB] PostgreSQL Pool initialized');
     }
 
-    private async initSchema(): Promise<void> {
-        const { schema, source } = this.getSchemaSql();
-        logger.info(`[UnifiedDB] Initializing schema from ${source}`);
-        await withRetry(
-            () => this.pool.query(schema),
-            { operation: 'initialize schema from SQL source' }
-        );
-        // Migration: fix agent_usage_logs FK to use SET NULL on delete
-        try {
-            await this.retryQuery(`
-                ALTER TABLE agent_usage_logs DROP CONSTRAINT IF EXISTS agent_usage_logs_session_id_fkey;
-                ALTER TABLE agent_usage_logs ADD CONSTRAINT agent_usage_logs_session_id_fkey
-                    FOREIGN KEY (session_id) REFERENCES conversation_sessions(id) ON DELETE SET NULL;
-            `);
-        } catch (_e: unknown) {
-            // Constraint may already be correct — ignore
-        }
-
-        // pg_trgm GIN 인덱스 생성 시도 (LEGACY_SCHEMA 폴백 시에도 적용)
-        try {
-            await this.pool.query(`CREATE EXTENSION IF NOT EXISTS pg_trgm`);
-            await this.pool.query(`CREATE INDEX IF NOT EXISTS idx_memories_key_trgm ON user_memories USING gin (key gin_trgm_ops)`);
-            await this.pool.query(`CREATE INDEX IF NOT EXISTS idx_memories_value_trgm ON user_memories USING gin (value gin_trgm_ops)`);
-            logger.info('[UnifiedDB] pg_trgm 트라이그램 인덱스 생성 완료');
-        } catch (_e: unknown) {
-            logger.info('[UnifiedDB] pg_trgm 인덱스 생성 건너뜀 (확장 미지원 환경)');
-        }
-    }
-
-    private getSchemaSql(): { schema: string; source: string } {
-        const candidatePaths = [
-            path.resolve(process.cwd(), SCHEMA_FILE_RELATIVE_PATH),
-            path.resolve(__dirname, '../../../../../services/database/init/002-schema.sql'),
-            path.resolve(__dirname, '../../../../services/database/init/002-schema.sql')
-        ];
-
-        for (const filePath of candidatePaths) {
-            try {
-                const schema = fs.readFileSync(filePath, 'utf8');
-                return { schema, source: `file:${filePath}` };
-            } catch (error: unknown) {
-                const err = error as NodeJS.ErrnoException;
-                if (err.code !== 'ENOENT') {
-                    logger.warn(`[UnifiedDB] Failed reading schema file at ${filePath}:`, err);
-                }
-            }
-        }
-
-        logger.warn('[UnifiedDB] Schema SQL file not found; falling back to LEGACY_SCHEMA');
-        return { schema: LEGACY_SCHEMA, source: 'inline:LEGACY_SCHEMA' };
-    }
+    // initSchema / getSchemaSql 은 data/models/schema-initializer.ts 로 분리.
 
     /**
      * 스키마 초기화 완료를 보장하는 헬퍼
@@ -250,33 +164,8 @@ export class UnifiedDatabase {
         return this.pool;
     }
 
-    /**
-     * 재시도 가능한 쿼리 래퍼
-     * 일시적 연결 오류 시 자동 재시도 (지수 백오프)
-     */
-    private retryQuery(text: string, params?: QueryParam[]): Promise<QueryResult<Record<string, unknown>>> {
-        const withSpan = getWithSpan();
-
-        if (!withSpan) {
-            return withRetry(
-                () => this.pool.query(text, params),
-                { operation: text.substring(0, 50) }
-            );
-        }
-
-        return withSpan('UnifiedDB', 'db.query', async (span) => {
-            span.setAttribute('db.system', 'postgresql');
-            span.setAttribute('db.statement', text.substring(0, 200));
-
-            const result = await withRetry(
-                () => this.pool.query(text, params),
-                { operation: text.substring(0, 50) }
-            );
-
-            span.setAttribute('db.rows_affected', result.rowCount ?? 0);
-            return result;
-        });
-    }
+    // retryQuery 는 모든 사용처가 repository 위임으로 이행되어 dead code — 제거.
+    // base-repository.ts 의 query() 가 동일한 withRetry 패턴 제공.
 
     // ===== 사용자 관리 =====
 


### PR DESCRIPTION
## Summary

unified-database.ts (lint 기준 447 lines) max-lines warning 해소.

### 변경 (2 files / +98 / -117)
- `data/models/schema-initializer.ts` (신규, 92 lines)
  - `getSchemaSql()`: 002-schema.sql 파일 탐색 + LEGACY_SCHEMA fallback
  - `initSchema(pool)`: 스키마 적용 + agent_usage_logs FK migration + pg_trgm GIN 인덱스
- `data/models/unified-database.ts`
  - `initSchema` / `getSchemaSql` 제거 (helper 위임)
  - `retryQuery` 제거 — 모든 사용처가 repository 위임으로 이행 후 dead code
  - 관련 dead utilities 정리: SpanLike / WithSpanLike / cachedWithSpan / getWithSpan / QueryParam
  - unused imports 정리 (fs / path / LEGACY_SCHEMA / QueryResult / withRetry / SCHEMA_FILE_RELATIVE_PATH)

### 결과
- unified-database.ts: 645 → **532 lines** (raw, -113)
- max-lines warning **완전 해소** ✅
- 전체 backend lint: 5 → **4 warnings**

## Test plan
- [x] tsc 0 / lint 0 errors / 0 warnings (unified-database)
- [x] 전체 회귀: 97 suites / 1604 tests / 0 failed

## 후속 (별도 PR)
- ChatService (518), agent-loop-strategy (498), sockets/handler (489), request-handler (472)

🤖 Generated with [Claude Code](https://claude.com/claude-code)