### PR TITLE
feat(models): 로컬 다중 모델 카탈로그 (qwen3.6 / gemma-4 / bge-m3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,11 +41,35 @@
 #   sudo systemctl daemon-reload
 #   sudo systemctl enable --now openmake-vllm-qwen openmake-vllm-exaone openmake-litellm
 
-LLM_BASE_URL=http://localhost:4000              # LiteLLM proxy endpoint
+LLM_BASE_URL=http://localhost:4000              # 서버 PC 의 vLLM/LiteLLM proxy endpoint
+                                                  # 운영 예: http://rockyhan.duckdns.org:13401
 LLM_API_KEY=sk-litellm-master-key               # LiteLLM master key (또는 vLLM --api-key)
-LLM_DEFAULT_MODEL=qwen2.5-7b                    # LiteLLM model alias (chat 용)
-# LLM_EMBEDDING_MODEL / LLM_EMBEDDING_BASE_URL: 2026-05-19 제거 (vector cache / semantic router 폐기)
+LLM_DEFAULT_MODEL=qwen3.6-35b-a3b               # proxy 가 라우팅하는 model 명 (chat 기본)
 LLM_TIMEOUT=120000                              # HTTP 요청 타임아웃 (ms)
+
+# ────────────────────────────────────────────────────────────
+# 로컬 모델 카탈로그 (서버 PC 의 vLLM proxy 가 노출하는 모델 목록)
+# ────────────────────────────────────────────────────────────
+# 기본 카탈로그는 backend/api/src/config/local-models.ts 에 하드코드.
+# 운영 환경에서 모델 추가/제거 시 본 환경변수로 override (JSON 배열):
+#
+#   LLM_LOCAL_MODELS_JSON='[
+#     {"id":"qwen3.6-35b-a3b","displayName":"Qwen 3.6","description":"기본","role":"chat","contextLength":262144},
+#     {"id":"qwen3.6-35b-a3b-1m","displayName":"Qwen 1M","description":"대용량","role":"chat","contextLength":1048576},
+#     {"id":"gemma-4-31b","displayName":"Gemma 4","description":"Vision","role":"chat","contextLength":32768},
+#     {"id":"gpt-3.5-turbo","displayName":"GPT-3.5 alias","description":"OpenAI 호환","role":"chat"},
+#     {"id":"bge-m3","displayName":"BGE-M3","description":"Embedding","role":"embedding"}
+#   ]'
+#
+# 새 모델 추가 절차 (클라이언트 PC 만 작업):
+#   1. 서버 PC 의 vLLM 에 모델 띄움 + proxy 카탈로그 등록 (서버 PC 운영자 작업)
+#   2. 본 환경변수 또는 config/local-models.ts 갱신
+#   3. PM2 reload (또는 서비스 재시작) — selector dropdown 에 즉시 반영
+#
+# 모델 capability 매핑은 backend/api/src/config/model-defaults.ts 의
+# MODEL_CAPABILITY_PRESETS prefix 매칭 (longest match). 새 model prefix 가 매칭 안 되면
+# 보수적 default (toolCalling: true / thinking: false / vision: false / streaming: true).
+# LLM_LOCAL_MODELS_JSON=
 
 # 토큰 기반 시간/주간 한도 (LLM 사용량 quota)
 LLM_HOURLY_TOKEN_LIMIT=300000

--- a/backend/api/src/config/local-models.ts
+++ b/backend/api/src/config/local-models.ts
@@ -1,0 +1,137 @@
+/**
+ * ============================================================
+ * Local Models Catalog — 서버 PC 의 vLLM/LiteLLM proxy 가 노출하는 모델
+ * ============================================================
+ *
+ * 운영 컨텍스트:
+ *   - LLM 은 외부 서버 PC 에서 vLLM/LiteLLM 으로 호스팅
+ *   - 클라이언트 PC 는 단일 proxy endpoint (LLM_BASE_URL) 로 호출
+ *   - proxy 가 model 명 기반으로 백엔드 라우팅 (server 의 8002/8003/8004/8005)
+ *
+ * 본 카탈로그는 클라이언트 PC 가 알아야 할 **모델 ID + role + 표시 정보** 만 정의.
+ * 실제 endpoint host:port 는 proxy 가 캡슐화 — 클라이언트는 model 명만 사용.
+ *
+ * 외부화 (No-Hardcoding L2):
+ *   - 본 파일이 기본 카탈로그 (개발자 튜닝)
+ *   - 환경변수 override: `LLM_LOCAL_MODELS_JSON` (runtime tweaking)
+ *
+ * 새 모델 추가 가이드:
+ *   1. 서버 PC 의 vLLM 에 모델 띄움
+ *   2. 본 카탈로그에 entry 추가 + 클라이언트 PC PM2 reload
+ *   3. (선택) MODEL_CAPABILITY_PRESETS (model-defaults.ts) 에 capability 추가
+ *
+ * @module config/local-models
+ */
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('LocalModels');
+
+export type LocalModelRole = 'chat' | 'embedding';
+
+export interface LocalModelEntry {
+    /** model ID — proxy 가 라우팅 key 로 사용 (LLM_BASE_URL 의 body.model 필드) */
+    id: string;
+    /** UI 표시 이름 (selector dropdown) */
+    displayName: string;
+    /** 짧은 설명 — selector 의 보조 텍스트 */
+    description: string;
+    /** chat: 일반 채팅 / embedding: /v1/embeddings 전용 (selector 에서 분리) */
+    role: LocalModelRole;
+    /** context window (tokens) — UI 표시 + selector 우선순위 보조 */
+    contextLength?: number;
+    /** 선택적 — false 면 selector 에서 hidden (가용성 동적 체크 후속) */
+    available?: boolean;
+}
+
+/**
+ * 기본 카탈로그 — 사용자 환경 (2026-05 기준):
+ *   - qwen3.6-35b-a3b      : 기본 채팅 (262K)
+ *   - qwen3.6-35b-a3b-1m   : 대용량 context (1M, 선택적)
+ *   - gemma-4-31b          : Vision + 32K
+ *   - gpt-3.5-turbo        : OpenAI 호환 alias (→ qwen3.6 라우팅)
+ *   - bge-m3               : embedding (multilingual, 1024-dim)
+ */
+const DEFAULT_LOCAL_MODELS: LocalModelEntry[] = [
+    {
+        id: 'qwen3.6-35b-a3b',
+        displayName: 'Qwen 3.6 (35B-A3B)',
+        description: '기본 채팅 — 262K context',
+        role: 'chat',
+        contextLength: 262144,
+    },
+    {
+        id: 'qwen3.6-35b-a3b-1m',
+        displayName: 'Qwen 3.6 (1M context)',
+        description: '대용량 문서/research — 1M context',
+        role: 'chat',
+        contextLength: 1048576,
+    },
+    {
+        id: 'gemma-4-31b',
+        displayName: 'Gemma 4 (31B)',
+        description: 'Vision + 32K context',
+        role: 'chat',
+        contextLength: 32768,
+    },
+    {
+        id: 'gpt-3.5-turbo',
+        displayName: 'GPT-3.5 (alias)',
+        description: 'OpenAI 호환 alias → Qwen 3.6 로 라우팅',
+        role: 'chat',
+    },
+    {
+        id: 'bge-m3',
+        displayName: 'BGE-M3',
+        description: 'Multilingual embedding (1024-dim)',
+        role: 'embedding',
+    },
+];
+
+let _cached: LocalModelEntry[] | null = null;
+
+/**
+ * 환경변수 `LLM_LOCAL_MODELS_JSON` 또는 default 카탈로그 반환.
+ * env 가 JSON 배열로 셋팅돼 있으면 그것을 사용 (default 덮어쓰기).
+ */
+export function getLocalModels(): LocalModelEntry[] {
+    if (_cached) return _cached;
+
+    const envJson = process.env.LLM_LOCAL_MODELS_JSON;
+    if (envJson) {
+        try {
+            const parsed = JSON.parse(envJson) as LocalModelEntry[];
+            if (Array.isArray(parsed) && parsed.every(m => m.id && m.role && m.displayName)) {
+                logger.info(`LLM_LOCAL_MODELS_JSON override: ${parsed.length} models`);
+                _cached = parsed;
+                return _cached;
+            }
+            logger.warn('LLM_LOCAL_MODELS_JSON 유효성 실패 — DEFAULT_LOCAL_MODELS 사용');
+        } catch (e) {
+            logger.warn(`LLM_LOCAL_MODELS_JSON parse 실패 — DEFAULT_LOCAL_MODELS 사용: ${e instanceof Error ? e.message : e}`);
+        }
+    }
+
+    _cached = DEFAULT_LOCAL_MODELS;
+    return _cached;
+}
+
+/**
+ * chat 역할 모델만 반환 — selector 표시용.
+ */
+export function getLocalChatModels(): LocalModelEntry[] {
+    return getLocalModels().filter(m => m.role === 'chat' && m.available !== false);
+}
+
+/**
+ * embedding 역할 모델만 반환 — embed() 호출용.
+ */
+export function getLocalEmbeddingModels(): LocalModelEntry[] {
+    return getLocalModels().filter(m => m.role === 'embedding' && m.available !== false);
+}
+
+/**
+ * 테스트 / 환경변수 핫 리로드용 — 캐시 초기화.
+ */
+export function resetLocalModelsCache(): void {
+    _cached = null;
+}

--- a/backend/api/src/config/model-defaults.ts
+++ b/backend/api/src/config/model-defaults.ts
@@ -56,4 +56,50 @@ export const MODEL_CAPABILITY_PRESETS: Readonly<Record<string, ModelCapabilities
         vision: true,
         streaming: true,
     },
+    /**
+     * Gemma 4 (Google DeepMind) — 31B.
+     * - vision: ✅, toolCalling: ✅, thinking: ✅, context: 32K
+     * 서버 PC 의 vLLM 8005 백엔드. proxy (LLM_BASE_URL) 가 model 명으로 라우팅.
+     */
+    'gemma-4': {
+        toolCalling: true,
+        thinking: true,
+        vision: true,
+        streaming: true,
+    },
+    /**
+     * Qwen 3.6 (Alibaba) — 35B-A3B MoE.
+     * - toolCalling: ✅ (vLLM `--tool-call-parser hermes` 호환)
+     * - thinking: ✅ (DeepSeek R1 style reasoning)
+     * - vision: ❌
+     * - context: 262K (기본), 1M (`qwen3.6-35b-a3b-1m` variant)
+     * 서버 PC 의 vLLM 8002 (기본) / 8004 (1m, 선택적) 백엔드.
+     */
+    'qwen3.6': {
+        toolCalling: true,
+        thinking: true,
+        vision: false,
+        streaming: true,
+    },
+    /**
+     * OpenAI 호환 alias — proxy 가 qwen3.6-35b-a3b 으로 라우팅.
+     * 외부 도구 / OpenAI SDK 호환 클라이언트가 표준 model ID 로 호출 가능.
+     */
+    'gpt-3.5-turbo': {
+        toolCalling: true,
+        thinking: true,
+        vision: false,
+        streaming: true,
+    },
+    /**
+     * BGE-M3 (BAAI) — multilingual embedding (1024-dim).
+     * embedding 전용 — chat 호출 대상 아님 (selector 에서 분리).
+     * 서버 PC 의 vLLM 8003 백엔드.
+     */
+    'bge-m3': {
+        toolCalling: false,
+        thinking: false,
+        vision: false,
+        streaming: false,
+    },
 } as const;

--- a/backend/api/src/routes/model.routes.ts
+++ b/backend/api/src/routes/model.routes.ts
@@ -19,6 +19,7 @@ import { asyncHandler } from '../utils/error-handler';
 import { createLogger } from '../utils/logger';
 import { getModelForRole } from '../config/model-roles';
 import { MODEL_CAPABILITY_PRESETS } from '../config/model-defaults';
+import { getLocalChatModels } from '../config/local-models';
 import { requireAuth, requireAdmin, optionalAuth } from '../auth';
 import { getModelHealthMonitor } from '../services/model-health-monitor';
 import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
@@ -72,19 +73,6 @@ router.get('/model', asyncHandler(async (_req: Request, res: Response) => {
  * capabilities 는 MODEL_CAPABILITY_PRESETS 의 가장 긴 prefix 매칭으로 조회합니다.
  */
 router.get('/models', optionalAuth, asyncHandler(async (req: Request, res: Response) => {
-    const chatModel = getModelForRole('chat');
-
-    // MODEL_CAPABILITY_PRESETS에서 가장 긴 prefix 매칭으로 capabilities 조회
-    const lower = chatModel.toLowerCase();
-    let caps = { toolCalling: true, thinking: false, vision: false, streaming: true };
-    let bestPrefix = '';
-    for (const [prefix, presetCaps] of Object.entries(MODEL_CAPABILITY_PRESETS)) {
-        if (lower.includes(prefix) && prefix.length > bestPrefix.length) {
-            bestPrefix = prefix;
-            caps = presetCaps;
-        }
-    }
-
     type ModelEntry = {
         name: string;
         modelId: string;
@@ -102,20 +90,49 @@ router.get('/models', optionalAuth, asyncHandler(async (req: Request, res: Respo
         pricing?: { input: number; output: number };
     };
 
-    const models: ModelEntry[] = [{
-        name: chatModel,
-        modelId: buildFullModelId('local-llm', chatModel),
-        description: `Local LLM model (${chatModel})`,
-        provider: 'local-llm',
-        capabilities: {
-            executionStrategy: 'single',
-            thinking: caps.thinking ? 'medium' : 'off',
-            discussion: false,
-            vision: caps.vision,
-            toolCalling: caps.toolCalling,
-            streaming: caps.streaming,
-        },
-    }];
+    /** model id → MODEL_CAPABILITY_PRESETS longest-prefix 매칭. */
+    function capsFor(modelId: string) {
+        const lower = modelId.toLowerCase();
+        let caps = { toolCalling: true, thinking: false, vision: false, streaming: true };
+        let bestPrefix = '';
+        for (const [prefix, presetCaps] of Object.entries(MODEL_CAPABILITY_PRESETS)) {
+            if (lower.includes(prefix) && prefix.length > bestPrefix.length) {
+                bestPrefix = prefix;
+                caps = presetCaps;
+            }
+        }
+        return caps;
+    }
+
+    // Local models catalog — config/local-models.ts (서버 proxy 가 model 명으로 라우팅)
+    // 기본 chat 모델 (OMK_CHAT_MODEL 또는 LLM_DEFAULT_MODEL) 을 첫 entry 로 (UI 정렬 호환).
+    const defaultChat = getModelForRole('chat');
+    const chatModels = getLocalChatModels();
+    const ordered = [
+        ...chatModels.filter(m => m.id === defaultChat),
+        ...chatModels.filter(m => m.id !== defaultChat),
+    ];
+
+    const models: ModelEntry[] = ordered.map((m): ModelEntry => {
+        const caps = capsFor(m.id);
+        const ctxNote = m.contextLength
+            ? ` · ${(m.contextLength / 1024).toFixed(0)}K`
+            : '';
+        return {
+            name: m.displayName || m.id,
+            modelId: buildFullModelId('local-llm', m.id),
+            description: `${m.description}${ctxNote}`,
+            provider: 'local-llm',
+            capabilities: {
+                executionStrategy: 'single',
+                thinking: caps.thinking ? 'medium' : 'off',
+                discussion: false,
+                vision: caps.vision,
+                toolCalling: caps.toolCalling,
+                streaming: caps.streaming,
+            },
+        };
+    });
 
     // 인증된 사용자는 외부 provider 키 등록분도 추가.
     // optionalAuth 가 PublicUser(id) 를 req.user 에 부착 — JWT payload(userId)가 아님.
@@ -208,7 +225,7 @@ router.get('/models', optionalAuth, asyncHandler(async (req: Request, res: Respo
     }
 
     res.json(success({
-        defaultModel: buildFullModelId('local-llm', chatModel),
+        defaultModel: buildFullModelId('local-llm', defaultChat),
         models,
     }));
 }));


### PR DESCRIPTION
## Summary

서버 PC 의 vLLM/LiteLLM proxy 에 호스팅된 4 chat + 1 embedding 모델을 클라이언트 PC selector 에 노출. 옵션 C (서버 proxy 단일 endpoint) 시나리오 — 클라이언트 코드 변경 최소.

### 변경 (4 files / +255 / -31)

| 파일 | 변경 |
|---|---|
| `config/local-models.ts` (신규) | 모델 카탈로그 외부화 (LocalModelEntry + env override) |
| `config/model-defaults.ts` | MODEL_CAPABILITY_PRESETS 에 5 prefix 추가 (gemma-4 / qwen3.6 / gpt-3.5-turbo / bge-m3) |
| `routes/model.routes.ts` | `/api/models` 가 다중 chat 모델 반환 (capability prefix 매칭) |
| `.env.example` | LLM_DEFAULT_MODEL → qwen3.6-35b-a3b, LLM_LOCAL_MODELS_JSON 가이드 |

### 신규 카탈로그
| ID | role | context | capability |
|---|---|---|---|
| `qwen3.6-35b-a3b` | chat | 262K | toolCalling + thinking |
| `qwen3.6-35b-a3b-1m` | chat | 1M | toolCalling + thinking |
| `gemma-4-31b` | chat | 32K | toolCalling + thinking + vision |
| `gpt-3.5-turbo` | chat (alias) | — | qwen3.6 라우팅 |
| `bge-m3` | embedding | — | embedding only |

### 외부 영향 0
- frontend `model-selector.js` 는 `/api/models` 응답 동적 렌더 → frontend 변경 없음
- 외부 LLM provider (anthropic / openai) 분기 미변경
- 단일 `LLM_BASE_URL` 그대로 유지 (proxy 가 model 명으로 라우팅)

## Test plan
- [x] tsc 0 / lint 0 errors
- [x] smoke test — getLocalChatModels() 4 model, getLocalEmbeddingModels() 1 model
- [x] 전체 회귀: 97 suites / 1604 tests / 0 failed
- [ ] 수동: dev server 기동 후 `/api/models` 응답 확인 + 채팅 페이지 selector 4 모델 표시

## 후속 (선택)
- 클라이언트 PC 운영 가이드 (docs/) — 새 클라이언트 등록 절차
- model-health-monitor 가 endpoint 별 ping (Phase L4 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)