### PR TITLE
feat(models): selector UI 가용성 표시 (dimmed + reason badge)

### DIFF
--- a/backend/api/src/config/local-models.ts
+++ b/backend/api/src/config/local-models.ts
@@ -39,8 +39,10 @@ export interface LocalModelEntry {
     role: LocalModelRole;
     /** context window (tokens) — UI 표시 + selector 우선순위 보조 */
     contextLength?: number;
-    /** 선택적 — false 면 selector 에서 hidden (가용성 동적 체크 후속) */
+    /** 가용성 — false 면 selector 에서 dimmed (probe 결과 또는 explicit) */
     available?: boolean;
+    /** 가용성 실패 사유 — UI tooltip 표시용 */
+    unavailableReason?: string;
 }
 
 /**
@@ -119,17 +121,27 @@ export function getLocalModels(): LocalModelEntry[] {
 }
 
 /**
- * chat 역할 모델만 반환 — selector 표시용.
+ * chat 역할 모델 반환.
+ * @param opts.includeUnavailable true 면 available=false 모델도 포함 (UI dimmed 표시용)
  */
-export function getLocalChatModels(): LocalModelEntry[] {
-    return getLocalModels().filter(m => m.role === 'chat' && m.available !== false);
+export function getLocalChatModels(opts: { includeUnavailable?: boolean } = {}): LocalModelEntry[] {
+    return getLocalModels().filter(m => {
+        if (m.role !== 'chat') return false;
+        if (opts.includeUnavailable) return true;
+        return m.available !== false;
+    });
 }
 
 /**
- * embedding 역할 모델만 반환 — embed() 호출용.
+ * embedding 역할 모델 반환 — embed() 호출용.
+ * @param opts.includeUnavailable true 면 available=false 모델도 포함
  */
-export function getLocalEmbeddingModels(): LocalModelEntry[] {
-    return getLocalModels().filter(m => m.role === 'embedding' && m.available !== false);
+export function getLocalEmbeddingModels(opts: { includeUnavailable?: boolean } = {}): LocalModelEntry[] {
+    return getLocalModels().filter(m => {
+        if (m.role !== 'embedding') return false;
+        if (opts.includeUnavailable) return true;
+        return m.available !== false;
+    });
 }
 
 /**
@@ -275,6 +287,7 @@ export async function probeLocalModelAvailability(
     const pingTargets: LocalModelEntry[] = [];
     for (const m of list) {
         if (m.available === false) {
+            if (!m.unavailableReason) m.unavailableReason = 'explicit disabled';
             skipped.push(m.id);
             continue;
         }
@@ -282,6 +295,7 @@ export async function probeLocalModelAvailability(
             || Array.from(proxyIds).some(pid => pid.split(':')[0] === m.id);
         if (!inProxy) {
             m.available = false;
+            m.unavailableReason = 'proxy 카탈로그 미등록';
             skipped.push(m.id);
             continue;
         }
@@ -300,9 +314,11 @@ export async function probeLocalModelAvailability(
     for (const { model, result } of pingResults) {
         if (result.ok) {
             model.available = true;
+            model.unavailableReason = undefined;
             available.push(model.id);
         } else {
             model.available = false;
+            model.unavailableReason = result.reason || 'unknown';
             missing.push(`${model.id} (${result.reason})`);
         }
     }

--- a/backend/api/src/routes/model.routes.ts
+++ b/backend/api/src/routes/model.routes.ts
@@ -86,6 +86,10 @@ router.get('/models', optionalAuth, asyncHandler(async (req: Request, res: Respo
             toolCalling: boolean;
             streaming: boolean;
         };
+        /** 가용성 — 로컬 모델 startup probe 결과. false 면 UI 에서 dimmed. */
+        available?: boolean;
+        /** 비가용 사유 — UI tooltip. */
+        unavailableReason?: string;
         isFree?: boolean;
         pricing?: { input: number; output: number };
     };
@@ -106,8 +110,9 @@ router.get('/models', optionalAuth, asyncHandler(async (req: Request, res: Respo
 
     // Local models catalog — config/local-models.ts (서버 proxy 가 model 명으로 라우팅)
     // 기본 chat 모델 (OMK_CHAT_MODEL 또는 LLM_DEFAULT_MODEL) 을 첫 entry 로 (UI 정렬 호환).
+    // includeUnavailable=true: probe 결과 unavailable 모델도 응답에 포함 (UI dimmed 표시).
     const defaultChat = getModelForRole('chat');
-    const chatModels = getLocalChatModels();
+    const chatModels = getLocalChatModels({ includeUnavailable: true });
     const ordered = [
         ...chatModels.filter(m => m.id === defaultChat),
         ...chatModels.filter(m => m.id !== defaultChat),
@@ -118,7 +123,7 @@ router.get('/models', optionalAuth, asyncHandler(async (req: Request, res: Respo
         const ctxNote = m.contextLength
             ? ` · ${(m.contextLength / 1024).toFixed(0)}K`
             : '';
-        return {
+        const entry: ModelEntry = {
             name: m.displayName || m.id,
             modelId: buildFullModelId('local-llm', m.id),
             description: `${m.description}${ctxNote}`,
@@ -132,6 +137,11 @@ router.get('/models', optionalAuth, asyncHandler(async (req: Request, res: Respo
                 streaming: caps.streaming,
             },
         };
+        if (m.available === false) {
+            entry.available = false;
+            entry.unavailableReason = m.unavailableReason || 'unavailable';
+        }
+        return entry;
     });
 
     // 인증된 사용자는 외부 provider 키 등록분도 추가.

--- a/frontend/web/public/js/modules/components/model-selector.js
+++ b/frontend/web/public/js/modules/components/model-selector.js
@@ -262,13 +262,28 @@ function renderDropdown() {
             for (const m of groups[pid]) {
                 const isActive = m.modelId === selected;
                 const isOllama = pid === 'ollama';
-                const disabled = isOllama && !_isAdmin && !isActive;
+                // 가용성 — backend 가 available: false 면 서버 backend 미가동/장애.
+                // 클릭 차단 + dimmed + tooltip 으로 사유 표시.
+                const unavailable = m.available === false;
+                const disabledByRole = isOllama && !_isAdmin && !isActive;
+                const disabled = disabledByRole || unavailable;
+                const reason = unavailable
+                    ? (m.unavailableReason || 'unavailable')
+                    : '';
+                const badge = unavailable
+                    ? ' <span style="opacity:0.6;font-size:0.8em;">🔴 ' + escText(reason) + '</span>'
+                    : '';
+                const tooltip = unavailable
+                    ? ' title="현재 사용 불가: ' + escAttr(reason) + '"'
+                    : '';
                 html +=
                     '<div class="model-selector-option' +
                     (isActive ? ' active' : '') +
                     (disabled ? ' disabled' : '') +
-                    '" data-model-id="' + escAttr(m.modelId) + '" data-provider="' + escAttr(pid) + '">' +
-                    '<span>' + (isActive ? '<span class="check">✓ </span>' : '') + escText(m.name) + '</span>' +
+                    (unavailable ? ' unavailable' : '') +
+                    '" data-model-id="' + escAttr(m.modelId) + '" data-provider="' + escAttr(pid) + '"' +
+                    tooltip + '>' +
+                    '<span>' + (isActive ? '<span class="check">✓ </span>' : '') + escText(m.name) + badge + '</span>' +
                     '</div>';
             }
         }


### PR DESCRIPTION
## Summary

PR #58 의 후속. probe 결과 unavailable 모델을 selector dropdown 에 dimmed + reason badge 로 표시. 사용자가 모델 존재 인지 + 가용 상태 동시 확인 가능.

### 변경 (3 files / +53 / -12)
- `config/local-models.ts`
  - `LocalModelEntry.unavailableReason?: string` 추가
  - `getLocalChatModels({ includeUnavailable })` 옵션
  - probe demote 시 reason 저장 (`HTTP 500` / `proxy 카탈로그 미등록` / `explicit disabled`)
- `routes/model.routes.ts`: `/api/models` 응답에 `available + unavailableReason` + unavailable 모델도 포함
- `frontend/model-selector.js`:
  - `m.available === false` → `disabled` class (기존 click handler 자동 차단)
  - 🔴 reason badge + tooltip 표시
  - 기존 `.disabled` CSS (text-muted + not-allowed) 재활용

### UX
- 사용자: 모델 존재 확인 + 사유 확인 + 호출 실패 차단
- 운영자: probe 결과 시각적 피드백 (어느 backend 가 down 인지 명확)
- 자가 치유 (runtime polling) 없이도 startup probe 만으로 정확한 상태

## Test plan
- [x] `/api/models` 응답에 available + unavailableReason 포함
- [x] `getLocalChatModels({ includeUnavailable: true })` 가 1m 도 반환
- [x] tsc 0 / lint 0 / validate-modules ✓
- [x] 전체 회귀: 97 suites / 1604 tests / 0 failed
- [ ] 수동: dev server + selector dropdown → 1m 이 dimmed + 🔴 badge 표시 확인

## 후속 (선택)
- runtime polling (health-monitor) — startup 이후 backend 장애 감지
- runtime 호출 실패 시 즉시 demote + fallback 재시도

🤖 Generated with [Claude Code](https://claude.com/claude-code)