### PR TITLE
feat(models): runtime polling — backend 장애 동적 감지

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,12 +72,18 @@ LLM_TIMEOUT=120000                              # HTTP 요청 타임아웃 (ms)
 # LLM_LOCAL_MODELS_JSON=
 #
 # 가용성 처리:
-#   - startup probe (probeLocalModelAvailability) 가 proxy /v1/models 호출 → 카탈로그
-#     의 available 플래그 갱신 (demote-only — explicit `available: false` 는 보존)
+#   - startup probe (probeLocalModelAvailability) 가 proxy /v1/models 호출 + 모델 별
+#     1-token chat ping 으로 실제 backend connectivity 검증
+#   - runtime polling (startLocalModelProbeScheduler) 가 N분마다 재실행 — backend
+#     장애 동적 감지 + 카탈로그 자동 갱신 + selector UI 반영
+#   - 상태 전환 시 logger.warn ([LocalModelProbe] DOWN: ...) / info (UP)
 #   - 선택적 모델 (예: qwen3.6-35b-a3b-1m / 서버 PC 8004 가동 시에만) 은 카탈로그에서
 #     `available: false` 기본값 — 운영자가 8004 가동 후 활성화하려면:
 #       1. config/local-models.ts 의 entry 에서 `available: false` 제거 후 PM2 reload
 #       2. 또는 LLM_LOCAL_MODELS_JSON 으로 override (available: true 명시)
+#
+# Polling 인터벌 (default 5분 = 300000ms). 0 또는 음수 시 polling 비활성 (startup probe 만).
+# LLM_MODEL_PROBE_INTERVAL_MS=300000
 
 # 토큰 기반 시간/주간 한도 (LLM 사용량 quota)
 LLM_HOURLY_TOKEN_LIMIT=300000

--- a/backend/api/src/schedulers/index.ts
+++ b/backend/api/src/schedulers/index.ts
@@ -56,7 +56,66 @@ export async function startAllSchedulers(): Promise<void> {
     //    Cloud 모델 재도입 시 이 줄의 주석을 해제하여 즉시 복구 가능.
     // startModelHealthScheduler();
 
+    // 7. 로컬 모델 가용성 polling — startup probe 이후 backend 장애 동적 감지
+    startLocalModelProbeScheduler();
+
     logger.info('모든 백그라운드 스케줄러 시작 완료');
+}
+
+/**
+ * 로컬 모델 가용성 polling 스케줄러.
+ *
+ * 동작:
+ *   - 서버 startup probe (server.ts) 이후 N분마다 probeLocalModelAvailability 재실행
+ *   - 카탈로그의 `available` 플래그 자동 갱신
+ *   - 상태 전환 시 (up → down, down → up) info 로그
+ *
+ * 환경변수:
+ *   - LLM_MODEL_PROBE_INTERVAL_MS (default 5분)
+ *   - 0 또는 음수 시 스케줄러 비활성 (startup probe 만 사용)
+ */
+function startLocalModelProbeScheduler(): void {
+    const intervalMs = parseInt(process.env.LLM_MODEL_PROBE_INTERVAL_MS || '300000', 10);
+    if (!intervalMs || intervalMs <= 0) {
+        logger.debug('LocalModelProbeScheduler 비활성 (LLM_MODEL_PROBE_INTERVAL_MS <= 0)');
+        return;
+    }
+
+    // 상태 전환 감지 위한 직전 스냅샷
+    let prevAvailable: Set<string> | null = null;
+
+    const runProbe = async () => {
+        try {
+            const { probeLocalModelAvailability } = await import('../config/local-models');
+            const { getConfig } = await import('../config/env');
+            const cfg = getConfig();
+            const r = await probeLocalModelAvailability(cfg.llmBaseUrl, cfg.llmApiKey);
+            if (!r.probed) return;
+
+            const currentAvailable = new Set(r.available);
+            if (prevAvailable) {
+                const newlyDown = [...prevAvailable].filter(id => !currentAvailable.has(id));
+                const newlyUp = [...currentAvailable].filter(id => !prevAvailable!.has(id));
+                if (newlyDown.length > 0) {
+                    logger.warn(`[LocalModelProbe] DOWN: ${newlyDown.join(', ')}`);
+                }
+                if (newlyUp.length > 0) {
+                    logger.info(`[LocalModelProbe] UP: ${newlyUp.join(', ')}`);
+                }
+                if (newlyDown.length === 0 && newlyUp.length === 0) {
+                    logger.debug(`[LocalModelProbe] 변경 없음 (available=${r.available.length})`);
+                }
+            }
+            prevAvailable = currentAvailable;
+        } catch (err) {
+            logger.error('[LocalModelProbe] polling 실패:', err);
+        }
+    };
+
+    const timer = setInterval(runProbe, intervalMs);
+    timer.unref();
+    activeTimers.push(timer);
+    logger.debug(`LocalModelProbeScheduler 시작 완료 (주기 ${intervalMs / 1000}s)`);
 }
 
 /**


### PR DESCRIPTION
## Summary

PR #58 의 startup probe 후속. 운영 중 backend 장애 (8004 OOM dies / vLLM restart 등) 도 자동 감지. 자가 치유 foundation 완성.

### 변경 (2 files / +67 / -2)
- `schedulers/index.ts`: `startLocalModelProbeScheduler()` 신규
  - `LLM_MODEL_PROBE_INTERVAL_MS` (default 5분) 주기 polling
  - 상태 전환 감지: prevAvailable vs currentAvailable diff
    - DOWN → `logger.warn`
    - UP → `logger.info` (운영자가 backend 가동 알림)
    - 변경 없음 → debug only (log noise 방지)
  - `timer.unref()` + `activeTimers` 등록 (graceful shutdown 통합)
  - `intervalMs <= 0` 시 비활성 (startup probe 만 사용)
- `.env.example`: `LLM_MODEL_PROBE_INTERVAL_MS` 가이드

### 효과 (startup probe + runtime polling 결합)
- backend 가 startup 후 down → 5분 안에 감지 → 카탈로그 자동 demote → selector UI 자동 dimmed (PR #59)
- 운영자가 backend 복구 → 5분 안에 UP 로그 + 카탈로그 자동 promote

## Test plan
- [x] tsc 0
- [x] 전체 회귀: 97 suites / 1604 tests / 0 failed
- [ ] 수동: dev server 기동 후 5분 대기 → 1m 활성화/비활성 toggle 시 DOWN/UP 로그 확인

## 후속 (선택)
- runtime per-request 자가 치유: 호출 실패 시 즉시 demote + fallback 모델 재시도

🤖 Generated with [Claude Code](https://claude.com/claude-code)