### PR TITLE
feat(models): per-request fallback — chat 실패 즉시 demote + 다른 모델 재시도

### DIFF
--- a/backend/api/src/providers/local-llm-fallback.ts
+++ b/backend/api/src/providers/local-llm-fallback.ts
@@ -1,0 +1,99 @@
+/**
+ * ============================================================
+ * LocalLLMProvider Per-Request Fallback Helper
+ * ============================================================
+ *
+ * LocalLLMProvider.streamChat 호출이 backend connectivity 문제로
+ * 실패한 경우:
+ *   1. 카탈로그에서 실패 모델 demote (available=false + reason)
+ *   2. 같은 role (chat) 의 다른 가용 model 선택
+ *   3. provider 가 1회 retry — 본 helper 는 retry 자체는 안 하고
+ *      pure 함수로 "다음 모델 ID" 만 반환
+ *
+ * 운영 시나리오:
+ *   - startup probe 후 backend 가 down (vLLM OOM 등) — runtime polling
+ *     (5분 주기) 이 감지하기 전 사용자 호출 발생
+ *   - 본 fallback 이 즉시 다른 모델로 우회 + 카탈로그 갱신
+ *   - polling 이 다음 cycle 에서 추가 검증 (UP/DOWN 로깅)
+ *
+ * 위치 근거:
+ *   - getLocalModels (config) + helper 자체만 의존 — service layer 미참조
+ *   - LocalLLMProvider 가 dynamic import 로 catch 경로에서만 로드
+ *
+ * @module providers/local-llm-fallback
+ */
+import { createLogger } from '../utils/logger';
+import { getLocalModels, type LocalModelEntry } from '../config/local-models';
+
+const logger = createLogger('LocalLLMFallback');
+
+/**
+ * 호출 실패 패턴 — backend connectivity 문제로 fallback 시도할 가치 있는 에러.
+ * 사용자 의도적 abort / quota 초과 등은 fallback 안 함.
+ */
+function isFallbackableError(err: unknown): { ok: boolean; reason: string } {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/ECONNREFUSED|ECONNRESET|ETIMEDOUT|EHOSTUNREACH|fetch failed|UPSTREAM_ERROR/i.test(msg)) {
+        return { ok: true, reason: 'connection-error' };
+    }
+    if (/HTTP 5\d\d|status 5\d\d|InternalServerError|status: 500|status: 502|status: 503|status: 504/i.test(msg)) {
+        return { ok: true, reason: 'http-5xx' };
+    }
+    return { ok: false, reason: msg.slice(0, 80) };
+}
+
+/**
+ * 카탈로그에서 같은 role 의 다른 가용 model 1개 선택. exclude id 는 제외.
+ */
+function pickFallbackModel(role: 'chat' | 'embedding', excludeId: string): LocalModelEntry | null {
+    const candidates = getLocalModels().filter(
+        m => m.role === role && m.id !== excludeId && m.available !== false,
+    );
+    if (candidates.length === 0) return null;
+    return candidates[0];
+}
+
+/**
+ * 결과: fallback 가능 시 `{ fallbackModelId }`, 불가능 시 `null`.
+ *
+ * 부수효과:
+ *   - 실패 모델을 카탈로그에서 demote (available=false, unavailableReason 설정)
+ *   - logger.warn 으로 demote 사실 기록
+ *
+ * @param failedModelId 실패한 model id (provider 가 호출한 modelId)
+ * @param err           실패 원인 (Error 또는 임의 값)
+ * @returns             fallback 모델 정보 또는 null (재시도 안 함)
+ */
+export function tryFallbackAfterFailure(
+    failedModelId: string,
+    err: unknown,
+): { fallbackModelId: string } | null {
+    const check = isFallbackableError(err);
+    if (!check.ok) {
+        return null;  // 사용자 abort / quota / 알 수 없는 에러 — fallback 안 함
+    }
+
+    // 1) 카탈로그 demote
+    const catalog = getLocalModels();
+    const failedEntry = catalog.find(m => m.id === failedModelId);
+    if (failedEntry) {
+        failedEntry.available = false;
+        failedEntry.unavailableReason = `runtime: ${check.reason}`;
+        logger.warn(`demote ${failedModelId} — ${check.reason}`);
+    }
+
+    // 2) chat 외 (embedding) 은 dim 다를 위험 — fallback 안 함
+    const role = failedEntry?.role || 'chat';
+    if (role !== 'chat') {
+        return null;
+    }
+
+    // 3) 같은 role 다른 가용 model 찾기
+    const fallback = pickFallbackModel('chat', failedModelId);
+    if (!fallback) {
+        logger.warn(`${failedModelId} 실패, fallback 가용 모델 없음`);
+        return null;
+    }
+
+    return { fallbackModelId: fallback.id };
+}

--- a/backend/api/src/providers/local-llm-provider.ts
+++ b/backend/api/src/providers/local-llm-provider.ts
@@ -116,13 +116,28 @@ export class LocalLLMProvider implements IProvider {
         opts: ChatStreamOptions,
         callbacks: ChatStreamCallbacks,
     ): Promise<ChatStreamResult> {
-        // LLMClient 는 생성 시 config.model 이 고정된다.
-        // opts.modelId 가 다르면 회귀 방지를 위해 warning 만 남긴다.
+        return this.streamChatOnce(opts, callbacks, /* retried */ false);
+    }
+
+    /**
+     * 단일 호출 시도 + 실패 시 1회 fallback 재시도.
+     * retried=true 면 fallback 시도 자체 — 재진입 막음.
+     */
+    private async streamChatOnce(
+        opts: ChatStreamOptions,
+        callbacks: ChatStreamCallbacks,
+        retried: boolean,
+    ): Promise<ChatStreamResult> {
+        // opts.modelId 가 client.model 과 다르면 client.setModel 로 동기화 (fallback retry 시).
         if (opts.modelId !== this.client.model) {
-            logger.warn(
-                `[streamChat] modelId mismatch — requested='${opts.modelId}', client='${this.client.model}'. ` +
-                'client 모델로 진행합니다.',
-            );
+            if (retried) {
+                this.client.setModel(opts.modelId);
+            } else {
+                logger.warn(
+                    `[streamChat] modelId mismatch — requested='${opts.modelId}', client='${this.client.model}'. ` +
+                    'client 모델로 진행합니다.',
+                );
+            }
         }
 
         try {
@@ -175,14 +190,31 @@ export class LocalLLMProvider implements IProvider {
                         : 'stop',
             };
         } catch (err) {
+            // 사용자 abort 는 fallback 안 함 (즉시 throw)
+            if (opts.abortSignal?.aborted) {
+                const message = err instanceof Error ? err.message : String(err);
+                throw new ProviderError('UPSTREAM_ERROR', `LLM 호출이 중단되었습니다: ${message}`, err);
+            }
+
+            // Per-request fallback: backend connectivity 실패 시 같은 role 다른 모델로 1회 재시도.
+            // retried=true 면 이미 fallback 시도 — 무한 loop 방지 위해 throw.
+            if (!retried) {
+                const { tryFallbackAfterFailure } = await import('./local-llm-fallback');
+                const fallbackOpts = tryFallbackAfterFailure(opts.modelId, err);
+                if (fallbackOpts) {
+                    logger.warn(
+                        `[streamChat] ${opts.modelId} 실패 → fallback ${fallbackOpts.fallbackModelId} 재시도`,
+                    );
+                    return this.streamChatOnce(
+                        { ...opts, modelId: fallbackOpts.fallbackModelId },
+                        callbacks,
+                        true,
+                    );
+                }
+            }
+
             const message = err instanceof Error ? err.message : String(err);
-            throw new ProviderError(
-                'UPSTREAM_ERROR',
-                opts.abortSignal?.aborted
-                    ? `LLM 호출이 중단되었습니다: ${message}`
-                    : `LLM 호출 실패: ${message}`,
-                err,
-            );
+            throw new ProviderError('UPSTREAM_ERROR', `LLM 호출 실패: ${message}`, err);
         }
     }
 


### PR DESCRIPTION
## Summary
- LocalLLMProvider.streamChat 호출이 backend connectivity 문제로 실패 시 polling cycle(5분) 기다리지 않고 즉시 우회
- 실패 모델은 카탈로그에서 demote(available=false + runtime reason), 같은 role(chat) 의 다른 가용 모델로 1회 retry
- 신규 helper `providers/local-llm-fallback.ts` — provider 내부 dynamic import 로 catch 경로에서만 로드
- embedding 은 model 별 dim 불일치 위험으로 fallback 안 함, 사용자 abort 는 즉시 throw

## Self-Healing 진화
| PR | 단계 | 동작 |
|----|------|------|
| #57 | explicit hide | 기본 unavailable=true 인 모델 카탈로그에서 비표시 |
| #58 | startup probe | `/v1/models` + per-model 1-token ping (2-stage) |
| #59 | UI 표시 | dimmed display + reason badge + tooltip |
| #60 | runtime polling | 5분 주기 자동 갱신 + UP/DOWN 로깅 |
| **본 PR** | **per-request fallback** | **실시간 호출 실패 → demote + 다른 모델 retry** |

## 동작 흐름
1. `provider.streamChat(opts, cb)` 호출 → `streamChatOnce(opts, cb, retried=false)`
2. LLMClient.chat 호출 시 catch
3. `opts.abortSignal.aborted` → 즉시 throw (fallback 안 함)
4. `retried=false` 인 경우 `tryFallbackAfterFailure(modelId, err)` 호출
5. fallbackable error + 다른 가용 chat 모델 존재 → demote + retry
6. `retried=true` 호출에서 fallback 재진입 차단 (무한 loop 방지)

## Test plan
- [x] tsc 0 errors
- [x] eslint 0 errors (touched files)
- [x] 신규 단위 테스트 4건 통과 — fallbackable/non-fallbackable/no-candidate/embedding-role
- [x] 기존 provider/llm 테스트 회귀 통과 (1603 passed)
- [ ] 실서버 시나리오: qwen3.6-35b-a3b 살아있고 1m down 상태에서 1m 요청 → qwen3.6-35b-a3b 로 자동 우회 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)