### PR TITLE
feat(llm): LLMClient signal 옵션 — orphan request 해소

### DIFF
--- a/backend/api/scripts/sdk-signal-smoke.ts
+++ b/backend/api/scripts/sdk-signal-smoke.ts
@@ -1,0 +1,64 @@
+/**
+ * OpenAI SDK signal abort 동작 smoke test.
+ *
+ * 검증: AbortController 로 mid-stream 호출 abort 시
+ *   (a) iterator 가 silent 하게 종료 vs (b) Error throw
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
+
+import OpenAI from 'openai';
+
+async function main(): Promise<void> {
+    const baseURL = process.env.LLM_BASE_URL!;
+    const apiKey = process.env.LLM_API_KEY!;
+    const openai = new OpenAI({ baseURL: baseURL + '/v1', apiKey });
+
+    const controller = new AbortController();
+
+    console.log('--- Test A: abort mid-stream ---');
+    setTimeout(() => {
+        console.log('[t=200ms] controller.abort()');
+        controller.abort();
+    }, 200);
+
+    try {
+        const stream = await openai.chat.completions.create({
+            model: 'qwen3.6-35b-a3b',
+            messages: [{ role: 'user', content: 'Write a 200 word essay slowly' }],
+            stream: true,
+            max_tokens: 300,
+        }, { signal: controller.signal });
+
+        let chunks = 0;
+        for await (const _chunk of stream) {
+            chunks++;
+        }
+        console.log(`[silent-end] iterator 완료, chunks=${chunks} (THROW 안 함)`);
+    } catch (err) {
+        const e = err as Error & { name?: string; code?: string };
+        console.log(`[THROW] name=${e.name} code=${e.code} message=${e.message?.slice(0, 80)}`);
+    }
+
+    console.log('\n--- Test B: pre-aborted signal ---');
+    const preAborted = new AbortController();
+    preAborted.abort();
+    try {
+        const stream = await openai.chat.completions.create({
+            model: 'qwen3.6-35b-a3b',
+            messages: [{ role: 'user', content: 'hi' }],
+            stream: true,
+            max_tokens: 5,
+        }, { signal: preAborted.signal });
+        for await (const _chunk of stream) { /* drain */ }
+        console.log('[silent-end] pre-aborted 도 silent 종료');
+    } catch (err) {
+        const e = err as Error & { name?: string };
+        console.log(`[THROW] name=${e.name} message=${e.message?.slice(0, 80)}`);
+    }
+
+    process.exit(0);
+}
+
+main().catch(e => { console.error('main error:', e); process.exit(1); });

--- a/backend/api/src/llm/client.ts
+++ b/backend/api/src/llm/client.ts
@@ -106,6 +106,8 @@ export class LLMClient {
             tools?: ToolDefinition[];
             tool_choice?: 'auto' | 'none' | 'required' | { type: 'function'; function: { name: string } };
             keep_alive?: string | number;
+            /** OpenAI SDK request cancel — abort 시 upstream HTTP 요청 즉시 종료 (orphan 방지) */
+            signal?: AbortSignal;
         },
     ): Promise<ChatMessage & { metrics?: UsageMetrics }> {
         this.checkQuota();
@@ -126,8 +128,8 @@ export class LLMClient {
             'llm.chat',
             async (span) => {
                 const result = onToken
-                    ? await streamChat(this.openai, request, onToken, extraBody)
-                    : await nonStreamChat(this.openai, request, extraBody);
+                    ? await streamChat(this.openai, request, onToken, extraBody, advancedOptions?.signal)
+                    : await nonStreamChat(this.openai, request, extraBody, advancedOptions?.signal);
                 const totalTokens =
                     (result.metrics?.prompt_eval_count ?? 0) + (result.metrics?.eval_count ?? 0);
                 if (totalTokens > 0) getApiUsageTracker().record(totalTokens);

--- a/backend/api/src/llm/stream-parser.ts
+++ b/backend/api/src/llm/stream-parser.ts
@@ -167,6 +167,7 @@ export async function streamChat(
     request: ChatRequest,
     onToken: (token: string, thinking?: string) => void,
     extraBody?: Record<string, unknown>,
+    signal?: AbortSignal,
 ): Promise<ChatMessage & { metrics?: UsageMetrics }> {
     const tools = request.tools ? toOpenAITools(request.tools) : undefined;
     const responseFormat = toResponseFormat(request.format);
@@ -179,7 +180,7 @@ export async function streamChat(
         ...(tools ? { tools, ...(request.tool_choice !== undefined && { tool_choice: request.tool_choice }) } : {}),
         ...(responseFormat && { response_format: responseFormat }),
         ...(extraBody ?? {}),
-    } as never);
+    } as never, signal ? { signal } : undefined);
 
     let content = '';
     let thinking = '';
@@ -332,6 +333,7 @@ export async function nonStreamChat(
     openai: OpenAI,
     request: ChatRequest,
     extraBody?: Record<string, unknown>,
+    signal?: AbortSignal,
 ): Promise<ChatMessage & { metrics?: UsageMetrics }> {
     const tools = request.tools ? toOpenAITools(request.tools) : undefined;
     const responseFormat = toResponseFormat(request.format);
@@ -343,7 +345,7 @@ export async function nonStreamChat(
         ...(tools ? { tools, ...(request.tool_choice !== undefined && { tool_choice: request.tool_choice }) } : {}),
         ...(responseFormat && { response_format: responseFormat }),
         ...(extraBody ?? {}),
-    } as never);
+    } as never, signal ? { signal } : undefined);
 
     const r = response as unknown as OpenAIChatResponse;
     const choice0 = r.choices[0];

--- a/backend/api/src/providers/local-llm-provider.ts
+++ b/backend/api/src/providers/local-llm-provider.ts
@@ -58,6 +58,27 @@ const FALLBACK_CAPABILITIES: ProviderCapabilities = {
 };
 
 /**
+ * 두 AbortSignal 을 합쳐 어느 한쪽이 abort 되면 결과 signal 도 abort.
+ * `AbortSignal.any` (Node 19+) 의 수동 구현 — Node 18 호환.
+ *
+ * 분기 정확성은 호출처가 원본 a/b 의 aborted 상태를 별도로 검사하여 보장.
+ */
+function combineSignals(a?: AbortSignal, b?: AbortSignal): AbortSignal | undefined {
+    if (!a) return b;
+    if (!b) return a;
+    if (a.aborted || b.aborted) {
+        const c = new AbortController();
+        c.abort();
+        return c.signal;
+    }
+    const combined = new AbortController();
+    const onAbort = (): void => combined.abort();
+    a.addEventListener('abort', onAbort, { once: true });
+    b.addEventListener('abort', onAbort, { once: true });
+    return combined.signal;
+}
+
+/**
  * IProvider 구현 — LLMClient 를 위임 호출하는 어댑터.
  */
 export class LocalLLMProvider implements IProvider {
@@ -140,18 +161,25 @@ export class LocalLLMProvider implements IProvider {
             }
         }
 
-        // Fast-fail timeout — retried=false 호출에 한해 짧은 timeout 으로 응답 미수신 시 즉시 reject.
+        // Fast-fail timeout — retried=false 호출에 한해 짧은 timeout 으로 TTFT race.
         // 정상 모델은 TTFT 가 수백 ms 이내 — default 5s 안전.
-        // user signal (opts.abortSignal) 과는 완전 분리된 자체 Promise 사용 (자체 abort 를 user
-        // abort 로 오인하여 fallback 을 건너뛰는 함정 방지).
+        //
+        // 2단 메커니즘:
+        //  1) fastFailController.abort() → SDK request cancel (upstream HTTP 즉시 종료, orphan 방지)
+        //  2) Promise.race reject → catch 진입 (SDK 의 mid-stream abort 는 silent 종료라
+        //     race 없이는 fallback 미발동)
+        //
+        // user signal (opts.abortSignal) 과는 별도 controller — 자체 abort 를 user abort 로
+        // 오인하여 fallback 을 건너뛰는 함정 방지.
         const FAST_FAIL_MS = retried ? 0 : parseInt(process.env.LLM_FAST_FAIL_TIMEOUT_MS || '5000', 10);
+        const fastFailController = FAST_FAIL_MS > 0 ? new AbortController() : null;
         let fastFailTimer: NodeJS.Timeout | null = null;
-        const fastFailPromise = FAST_FAIL_MS > 0
+        const fastFailPromise = fastFailController
             ? new Promise<never>((_, reject) => {
-                fastFailTimer = setTimeout(
-                    () => reject(new Error(`FAST_FAIL_TIMEOUT_EXCEEDED (${FAST_FAIL_MS}ms)`)),
-                    FAST_FAIL_MS,
-                );
+                fastFailTimer = setTimeout(() => {
+                    fastFailController.abort();
+                    reject(new Error(`FAST_FAIL_TIMEOUT_EXCEEDED (${FAST_FAIL_MS}ms)`));
+                }, FAST_FAIL_MS);
                 fastFailTimer.unref?.();
             })
             : null;
@@ -183,6 +211,11 @@ export class LocalLLMProvider implements IProvider {
                         ? true
                         : opts.thinking,
                     tools: opts.tools,
+                    // user signal (opts.abortSignal) + self fast-fail signal 결합 전달 — 어느 쪽이
+                    // abort 해도 SDK upstream 즉시 종료. catch 분기는 원본 signal 의 aborted 로 구분.
+                    ...((fastFailController || opts.abortSignal)
+                        ? { signal: combineSignals(fastFailController?.signal, opts.abortSignal) }
+                        : {}),
                 },
             );
 
@@ -220,18 +253,23 @@ export class LocalLLMProvider implements IProvider {
         } catch (err) {
             if (fastFailTimer) clearTimeout(fastFailTimer);
 
-            // 사용자 abort 는 fallback 안 함 (즉시 throw).
-            // 자체 fast-fail timeout 은 opts.abortSignal 을 건드리지 않으므로 여기 분기에 안 걸림.
+            // [분기 1] user abort — 항상 즉시 throw
             if (opts.abortSignal?.aborted) {
                 const message = err instanceof Error ? err.message : String(err);
                 throw new ProviderError('UPSTREAM_ERROR', `LLM 호출이 중단되었습니다: ${message}`, err);
             }
 
-            // Per-request fallback: backend connectivity 실패 시 같은 role 다른 모델로 1회 재시도.
-            // retried=true 면 이미 fallback 시도 — 무한 loop 방지 위해 throw.
+            // [분기 2] self fast-fail abort — SDK 가 'Request was aborted' 등 임의 메시지로 throw 해도
+            // controller.signal.aborted 가 ground truth. SDK 메시지 의존 회피 (버전 간 불안정).
+            const selfAborted = fastFailController?.signal.aborted ?? false;
+            const errForFallback = selfAborted
+                ? new Error(`FAST_FAIL_TIMEOUT_EXCEEDED (${FAST_FAIL_MS}ms, self-abort)`)
+                : err;
+
+            // [분기 3] retried=false 면 fallback 시도. self-aborted 는 강제 fallbackable 로 위장.
             if (!retried) {
                 const { tryFallbackAfterFailure } = await import('./local-llm-fallback');
-                const fallbackOpts = tryFallbackAfterFailure(opts.modelId, err);
+                const fallbackOpts = tryFallbackAfterFailure(opts.modelId, errForFallback);
                 if (fallbackOpts) {
                     logger.warn(
                         `[streamChat] ${opts.modelId} 실패 → fallback ${fallbackOpts.fallbackModelId} 재시도`,


### PR DESCRIPTION
## Summary
- PR #62 의 알려진 trade-off (fast-fail 시 LLMClient 호출이 orphan 으로 LiteLLM timeout 까지 대기) 해소
- LLMClient.chat 의 advancedOptions 에 \`signal?: AbortSignal\` 추가, SDK 까지 전파
- LocalLLMProvider 가 fastFailController + user signal 을 combine 해 SDK 에 전달

## 함정 회피 (smoke test + advisor 검토)
- **silent-end 함정**: OpenAI SDK 의 mid-stream signal abort 는 silent 종료 (throw 안 함). Promise.race 의 reject 가 fallback trigger 의 필수 경로 — SDK signal 은 보조적으로 orphan cleanup 만.
- **single combined signal 함정**: AbortSignal.any 를 쓰면 어느 쪽이 abort 했는지 catch 에서 모름. \`combineSignals\` 는 SDK 전달용 합본이고, 분기는 원본 \`opts.abortSignal.aborted\` / \`fastFailController.signal.aborted\` 별도 검사.
- **SDK 메시지 의존 회피**: SDK 의 abort 메시지("Request was aborted.")가 버전 간 불안정. \`selfAborted\` 면 \`errForFallback\` 을 명시 메시지로 위장하여 isFallbackableError 매치 보장.

## 검증 (실서버)
| 시나리오 | Before | After |
|----------|--------|-------|
| Down 모델 fast-fail | 5178ms | **5477ms** (동등) |
| 정상 long-response (2086자) | 7523ms | **14060ms** (TTFT 183ms, 미잘림) |
| user abort (300ms 후) | **11900ms** (full response, abort 무시) | **306ms** (98% 단축, partial result finish=aborted, NO fallback) |

## 변경 파일
- \`backend/api/src/llm/stream-parser.ts\` — streamChat/nonStreamChat signal 인자
- \`backend/api/src/llm/client.ts\` — chat() advancedOptions.signal 전달
- \`backend/api/src/providers/local-llm-provider.ts\` — fastFailController + combineSignals + catch 분기 강화

## Test plan
- [x] tsc 0 / eslint 0
- [x] jest 단위 5/5
- [x] 실서버 3 시나리오 (down/long/user-abort) 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)