### PR TITLE
feat(models): single-model re-probe — demote 직후 false-positive 회복 단축

### DIFF
--- a/backend/api/src/config/local-models.ts
+++ b/backend/api/src/config/local-models.ts
@@ -329,3 +329,65 @@ export async function probeLocalModelAvailability(
     );
     return { probed: true, available, missing, skipped };
 }
+
+/**
+ * 동일 model 의 동시 reprobe 방지용 in-flight 가드.
+ * N 개 concurrent fallback 이 같은 model 에 대해 N 개 reprobe 를 동시에
+ * 실행하는 것을 방지 (advisor 함정 1).
+ */
+const inflightReprobes = new Set<string>();
+
+/**
+ * 단일 모델 재검사 — fast-fail/connection-error 로 runtime demote 된 모델이
+ * 즉시 회복(예: 운영자가 backend 재기동) 했는지 확인 + 카탈로그 promote.
+ *
+ * 호출 의도: `tryFallbackAfterFailure` 에서 demote 직후 fire-and-forget.
+ * 다음 polling cycle (5분) 까지 stale 상태로 남는 것을 줄여, false positive
+ * (일시적 slow → fast-fail) 회복을 단축한다.
+ *
+ * Promotion 정책 (advisor 함정 3):
+ *   - `unavailableReason` 이 `"runtime:"` prefix 일 때만 promote 가능
+ *   - 그 외 (config 기본값 `available: false`, "explicit disabled",
+ *     "proxy 카탈로그 미등록", startup probe 의 "HTTP 5xx" 등) 는 운영자/probe
+ *     관할 — 단일 ping 성공만으로 운영자 의도를 뒤집지 않음
+ *
+ * 부수효과 (모두 동기 카탈로그 mutation):
+ *   - ping 성공 + runtime-demote → `available=true`, `unavailableReason=undefined`
+ *   - ping 실패 → `unavailableReason` 만 갱신 (이미 false)
+ *   - 가드 충돌 (이미 in-flight) / config-demote → no-op
+ */
+export async function reprobeSingleModel(
+    modelId: string,
+    baseUrl: string,
+    apiKey: string | undefined,
+    timeoutMs: number = 5000,
+): Promise<void> {
+    if (inflightReprobes.has(modelId)) return;
+
+    const entry = getLocalModels().find(m => m.id === modelId);
+    if (!entry) return;
+
+    // config-demote 또는 startup-probe-demote 는 promote 권한 없음 — early return
+    const reason = entry.unavailableReason ?? '';
+    if (entry.available === false && !reason.startsWith('runtime:')) {
+        return;
+    }
+
+    inflightReprobes.add(modelId);
+    try {
+        const r = entry.role === 'embedding'
+            ? await pingEmbeddingModel(baseUrl, apiKey, modelId, timeoutMs)
+            : await pingChatModel(baseUrl, apiKey, modelId, timeoutMs);
+        if (r.ok) {
+            entry.available = true;
+            entry.unavailableReason = undefined;
+            logger.info(`[Reprobe] ${modelId} UP — promote (was: ${reason || 'n/a'})`);
+        } else {
+            // 여전히 down — reason 만 갱신 (available 은 이미 false)
+            entry.unavailableReason = `runtime: ${r.reason || 'reprobe-failed'}`;
+            logger.debug(`[Reprobe] ${modelId} still DOWN — ${r.reason}`);
+        }
+    } finally {
+        inflightReprobes.delete(modelId);
+    }
+}

--- a/backend/api/src/providers/local-llm-fallback.ts
+++ b/backend/api/src/providers/local-llm-fallback.ts
@@ -23,7 +23,8 @@
  * @module providers/local-llm-fallback
  */
 import { createLogger } from '../utils/logger';
-import { getLocalModels, type LocalModelEntry } from '../config/local-models';
+import { getLocalModels, reprobeSingleModel, type LocalModelEntry } from '../config/local-models';
+import { getConfig } from '../config/env';
 
 const logger = createLogger('LocalLLMFallback');
 
@@ -83,6 +84,18 @@ export function tryFallbackAfterFailure(
         failedEntry.available = false;
         failedEntry.unavailableReason = `runtime: ${check.reason}`;
         logger.warn(`demote ${failedModelId} — ${check.reason}`);
+
+        // 1-a) Fire-and-forget single-model re-probe — backend 즉시 회복 케이스 (운영자 재기동,
+        //      일시적 slow 후 회복) 의 false-positive 회복을 polling cycle (5분) 보다 빨리 감지.
+        //      user-response 크리티컬 경로 영향 0 (await 안 함).
+        try {
+            const cfg = getConfig();
+            void reprobeSingleModel(failedModelId, cfg.llmBaseUrl, cfg.llmApiKey)
+                .catch(e => logger.debug(`[Reprobe ${failedModelId}] error: ${e instanceof Error ? e.message : e}`));
+        } catch (cfgErr) {
+            // getConfig 가 cold-init 미완 등으로 실패해도 fallback 자체는 진행
+            logger.debug(`[Reprobe] getConfig 실패 — reprobe skip: ${cfgErr instanceof Error ? cfgErr.message : cfgErr}`);
+        }
     }
 
     // 2) chat 외 (embedding) 은 dim 다를 위험 — fallback 안 함


### PR DESCRIPTION
## Summary
- \`tryFallbackAfterFailure\` 의 demote 직후 fire-and-forget 으로 단일 모델 re-probe 트리거
- backend 즉시 회복 (운영자 재기동, 일시적 slow 후 회복) 케이스 의 false-positive 회복을 polling cycle (5분) 보다 빨리 감지
- Self-healing 의 6번째 layer

## Self-healing layer 진화
| PR | 단계 | 시간 scale |
|----|------|------|
| #57 | explicit hide | 배포 |
| #58 | startup probe | 부팅 |
| #59 | UI dimming | UX 즉시 |
| #60 | runtime polling | 5분 |
| #61 | per-request fallback | 요청 즉시 |
| #62 | fast-fail timeout | TTFT 5초 |
| #63 | LLMClient signal | orphan 해소 |
| **본 PR** | **demote 직후 re-probe** | **0초 (fire-and-forget)** |

## 함정 회피 (advisor 권고 3개)
1. ✅ **in-flight 가드**: \`Set<string>\` 로 동일 model 동시 reprobe 막음. 단위 테스트 5 — 3 concurrent → fetch 1회
2. ✅ **fire-and-forget**: \`void\` 패턴 — user-response 크리티컬 경로 영향 0. 실서버: 5147ms (PR #62 와 동일)
3. ✅ **runtime-only promote**: \`unavailableReason\` 가 \`"runtime:"\` prefix 일 때만 promote. config 기본값 (\`available: false\` 1m 등) / startup probe demote (\"HTTP 500\") / \"explicit disabled\" 는 운영자/probe 관할 — 단일 ping 으로 뒤집지 않음

## Test plan
- [x] tsc 0 / eslint 0
- [x] jest 단위 11/11 (기존 5 + 신규 6)
- [x] 실서버 fire-and-forget latency 영향 0 확인
- [ ] (실서버 manual) 운영자가 1m backend 살린 직후 호출 → reprobe 가 promote → 다음 호출 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)