### PR TITLE
test: OpenAI SDK abort signal behavior smoke test

### DIFF
--- a/backend/api/scripts/sdk-signal-smoke.ts
+++ b/backend/api/scripts/sdk-signal-smoke.ts
@@ -1,0 +1,64 @@
+/**
+ * OpenAI SDK signal abort 동작 smoke test.
+ *
+ * 검증: AbortController 로 mid-stream 호출 abort 시
+ *   (a) iterator 가 silent 하게 종료 vs (b) Error throw
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
+
+import OpenAI from 'openai';
+
+async function main(): Promise<void> {
+    const baseURL = process.env.LLM_BASE_URL!;
+    const apiKey = process.env.LLM_API_KEY!;
+    const openai = new OpenAI({ baseURL: baseURL + '/v1', apiKey });
+
+    const controller = new AbortController();
+
+    console.log('--- Test A: abort mid-stream ---');
+    setTimeout(() => {
+        console.log('[t=200ms] controller.abort()');
+        controller.abort();
+    }, 200);
+
+    try {
+        const stream = await openai.chat.completions.create({
+            model: 'qwen3.6-35b-a3b',
+            messages: [{ role: 'user', content: 'Write a 200 word essay slowly' }],
+            stream: true,
+            max_tokens: 300,
+        }, { signal: controller.signal });
+
+        let chunks = 0;
+        for await (const _chunk of stream) {
+            chunks++;
+        }
+        console.log(`[silent-end] iterator 완료, chunks=${chunks} (THROW 안 함)`);
+    } catch (err) {
+        const e = err as Error & { name?: string; code?: string };
+        console.log(`[THROW] name=${e.name} code=${e.code} message=${e.message?.slice(0, 80)}`);
+    }
+
+    console.log('\n--- Test B: pre-aborted signal ---');
+    const preAborted = new AbortController();
+    preAborted.abort();
+    try {
+        const stream = await openai.chat.completions.create({
+            model: 'qwen3.6-35b-a3b',
+            messages: [{ role: 'user', content: 'hi' }],
+            stream: true,
+            max_tokens: 5,
+        }, { signal: preAborted.signal });
+        for await (const _chunk of stream) { /* drain */ }
+        console.log('[silent-end] pre-aborted 도 silent 종료');
+    } catch (err) {
+        const e = err as Error & { name?: string };
+        console.log(`[THROW] name=${e.name} message=${e.message?.slice(0, 80)}`);
+    }
+
+    process.exit(0);
+}
+
+main().catch(e => { console.error('main error:', e); process.exit(1); });


### PR DESCRIPTION
## Summary
- OpenAI SDK 의 \`signal\` 옵션이 mid-stream 호출 시 어떻게 동작하는지 검증한 ad-hoc smoke test
- 본 세션 중 사용자가 직접 main 에 commit (7a6c911) — local-only 상태였던 것을 별도 branch + PR 로 정리

## Background
이 smoke test 의 발견 (silent-end behavior) 이 PR #63 (LLMClient signal 옵션) 의 설계에 직접 반영되었습니다:
- mid-stream abort → SDK 가 silent 종료 (throw 안 함)
- pre-aborted signal → throw
- 따라서 PR #63 은 Promise.race 패턴을 유지하면서 signal 은 orphan cleanup 전용으로 사용

## Files
- \`backend/api/scripts/sdk-signal-smoke.ts\` (신규, 64 lines)

## Test plan
- [x] 로컬 실행 검증 완료 (silent-end vs throw 분기 확인)
- [ ] merge 여부는 운영자 판단 — 일회성 검증이라면 archive 후 close 도 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)