### PR TITLE
feat(server): LLM_WARMUP_TIMEOUT_MS env knob — 워밍업 hang 방지

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,6 +91,11 @@ LLM_TIMEOUT=120000                              # HTTP 요청 타임아웃 (ms)
 # - 정상 모델 TTFT 는 보통 수백 ms — 5초면 thinking 모델도 안전. 0 또는 음수 시 비활성.
 # LLM_FAST_FAIL_TIMEOUT_MS=5000
 
+# Server boot 시 모델 워밍업 timeout (default 10000ms). PR #66.
+# - LLM_TIMEOUT (chat 120s) 보다 짧음 — backend hang 으로 워밍업 무한 대기 방지.
+# - 워밍업 실패해도 boot 는 정상 진행 (첫 사용자 요청 시 cold-load 발생 가능).
+# LLM_WARMUP_TIMEOUT_MS=10000
+
 # 토큰 기반 시간/주간 한도 (LLM 사용량 quota)
 LLM_HOURLY_TOKEN_LIMIT=300000
 LLM_WEEKLY_TOKEN_LIMIT=5000000

--- a/backend/api/src/config/env.schema.ts
+++ b/backend/api/src/config/env.schema.ts
@@ -100,6 +100,9 @@ export const envSchema = z
         LLM_TIMEOUT: positiveIntWithDefault(120000).refine((value) => value <= 600000, {
             message: 'LLM_TIMEOUT must be between 1 and 600000 milliseconds',
         }),
+        LLM_WARMUP_TIMEOUT_MS: positiveIntWithDefault(10000).refine((value) => value <= 60000, {
+            message: 'LLM_WARMUP_TIMEOUT_MS must be between 1 and 60000 milliseconds',
+        }),
         LLM_HOURLY_TOKEN_LIMIT: nonNegativeIntWithDefault(300000),
         LLM_WEEKLY_TOKEN_LIMIT: nonNegativeIntWithDefault(5000000),
         /**

--- a/backend/api/src/config/env.ts
+++ b/backend/api/src/config/env.ts
@@ -48,6 +48,7 @@ export interface EnvConfig {
     llmApiKey: string;
     llmDefaultModel: string;
     llmTimeout: number;
+    llmWarmupTimeoutMs: number;
     llmHourlyTokenLimit: number;
     llmWeeklyTokenLimit: number;
     /** vLLM `--reasoning-parser` 미설정 환경 등에서 extra_body.reasoning_effort 거절 방지 토글. */
@@ -171,6 +172,7 @@ const DEFAULT_CONFIG: EnvConfig = {
     llmApiKey: 'sk-no-key',
     llmDefaultModel: 'qwen2.5-7b',
     llmTimeout: 120000,
+    llmWarmupTimeoutMs: 10000,
     llmHourlyTokenLimit: 300000,
     llmWeeklyTokenLimit: 5000000,
     llmEnableReasoningEffort: false,
@@ -380,6 +382,7 @@ export function loadConfig(): EnvConfig {
         LLM_API_KEY: env('LLM_API_KEY'),
         LLM_DEFAULT_MODEL: env('LLM_DEFAULT_MODEL'),
         LLM_TIMEOUT: env('LLM_TIMEOUT'),
+        LLM_WARMUP_TIMEOUT_MS: env('LLM_WARMUP_TIMEOUT_MS'),
         LLM_HOURLY_TOKEN_LIMIT: env('LLM_HOURLY_TOKEN_LIMIT'),
         LLM_WEEKLY_TOKEN_LIMIT: env('LLM_WEEKLY_TOKEN_LIMIT'),
         LLM_ENABLE_REASONING_EFFORT: env('LLM_ENABLE_REASONING_EFFORT'),
@@ -484,6 +487,7 @@ export function loadConfig(): EnvConfig {
         llmApiKey: parsed.LLM_API_KEY ?? DEFAULT_CONFIG.llmApiKey,
         llmDefaultModel: parsed.LLM_DEFAULT_MODEL ?? DEFAULT_CONFIG.llmDefaultModel,
         llmTimeout: parsed.LLM_TIMEOUT ?? DEFAULT_CONFIG.llmTimeout,
+        llmWarmupTimeoutMs: parsed.LLM_WARMUP_TIMEOUT_MS ?? DEFAULT_CONFIG.llmWarmupTimeoutMs,
         llmHourlyTokenLimit: parsed.LLM_HOURLY_TOKEN_LIMIT ?? DEFAULT_CONFIG.llmHourlyTokenLimit,
         llmWeeklyTokenLimit: parsed.LLM_WEEKLY_TOKEN_LIMIT ?? DEFAULT_CONFIG.llmWeeklyTokenLimit,
         llmEnableReasoningEffort: (parsed.LLM_ENABLE_REASONING_EFFORT ?? 'false').toLowerCase() === 'true',

--- a/backend/api/src/llm/client.ts
+++ b/backend/api/src/llm/client.ts
@@ -169,6 +169,8 @@ export class LLMClient {
             format?: FormatOption;
             system?: string;
             keep_alive?: string | number;
+            /** chat() 와 동일 — fast-fail / warmup timeout 등 caller abort 전달 경로 */
+            signal?: AbortSignal;
         },
     ): Promise<{ response: string; metrics?: UsageMetrics }> {
         const messages: ChatMessage[] = [];
@@ -187,6 +189,7 @@ export class LLMClient {
             {
                 ...(advancedOptions?.think !== undefined && { think: advancedOptions.think }),
                 ...(advancedOptions?.format && { format: advancedOptions.format }),
+                ...(advancedOptions?.signal && { signal: advancedOptions.signal }),
             },
         );
         return { response: result.content, metrics: result.metrics };

--- a/backend/api/src/server.ts
+++ b/backend/api/src/server.ts
@@ -252,18 +252,31 @@ export class DashboardServer {
 
         // 모델 워밍업: LiteLLM 헬스체크 + 첫 토큰 호출로 vLLM 캐시 워밍.
         // 비동기, 실패해도 서버 시작은 계속.
+        //
+        // Fast-fail: LLM_WARMUP_TIMEOUT_MS (default 10s) 내 미수신 시 abort.
+        // LLMClient 의 LLM_TIMEOUT (default 120s) 보다 짧음 — 워밍업 hang 시 boot 지연 방지.
+        // 정상 cold-load 는 80-81ms (실측), 10s 는 ~120 배 여유.
         (async () => {
+            const { LLMClient } = await import('./llm');
+            const cfg = getConfig();
+            const warmupClient = new LLMClient({ model: cfg.llmDefaultModel });
+            const controller = new AbortController();
+            const warmupTimer = setTimeout(() => controller.abort(), cfg.llmWarmupTimeoutMs);
+            warmupTimer.unref?.();
+            const t0 = Date.now();
             try {
-                const { LLMClient } = await import('./llm');
-                const cfg = getConfig();
-                const warmupClient = new LLMClient({ model: cfg.llmDefaultModel });
-                const t0 = Date.now();
-                await warmupClient.generate(' ', { num_predict: 1 });
+                await warmupClient.generate(' ', { num_predict: 1 }, undefined, undefined, {
+                    signal: controller.signal,
+                });
                 const elapsed = Date.now() - t0;
                 console.log(`[Server] 모델 워밍업 완료 — ${cfg.llmDefaultModel} (${elapsed}ms)`);
             } catch (err) {
-                const message = err instanceof Error ? err.message : String(err);
-                console.warn('[Server] 모델 워밍업 실패 (무시, 첫 사용자 요청 시 콜드 로딩 발생 가능):', message);
+                const elapsed = Date.now() - t0;
+                const aborted = controller.signal.aborted;
+                const reason = aborted ? `timeout ${cfg.llmWarmupTimeoutMs}ms` : (err instanceof Error ? err.message : String(err));
+                console.warn(`[Server] 모델 워밍업 실패 (무시, 첫 사용자 요청 시 콜드 로딩 발생 가능) — ${reason} (${elapsed}ms)`);
+            } finally {
+                clearTimeout(warmupTimer);
             }
         })();
 


### PR DESCRIPTION
## Summary
- Server boot 의 모델 워밍업 호출에 별도 짧은 timeout (default 10s) 적용
- LLMClient 의 LLM_TIMEOUT (120s) 보다 짧음 — backend hang 시 boot 무한 대기 방지
- 5/21 사고 (워밍업 timeout 후 무시 처리, 실제로는 LiteLLM 자체 timeout 까지 hang) 재발 방어

## Why
본 세션 PM2 로그 분석에서 5/21 07:07, 07:19 워밍업 fail 발견 (5/23 측정 79-81ms 정상 대비 outlier). 원인: LiteLLM upstream 의 backend 일시 slow + LLMClient 가 120s timeout 까지 대기 → boot 지연. 짧은 워밍업 전용 timeout 으로 fail-fast.

## 변경 파일
- \`backend/api/src/config/env.ts\` + \`env.schema.ts\`: \`LLM_WARMUP_TIMEOUT_MS\` 추가 (default 10000)
- \`backend/api/src/llm/client.ts\`: \`generate()\` advancedOptions.signal 추가 (chat() pass-through)
- \`backend/api/src/server.ts\`: warmup 호출에 AbortController + setTimeout
- \`.env.example\`: 문서화

## 기본값 근거
| 측정 | 값 |
|------|-----|
| 정상 cold-load 실측 (5/23 ×3회) | 79-81ms |
| 본 PR default (LLM_WARMUP_TIMEOUT_MS) | 10000ms (~120 배 여유) |
| LLMClient default (LLM_TIMEOUT) | 120000ms (1/12) |

## Test plan
- [x] tsc 0 / eslint 0 / jest 5/5 (local-llm 회귀)
- [x] 실서버 reload: 워밍업 79ms 정상 (LLM_WARMUP_TIMEOUT_MS=10000 무영향)
- [ ] (운영자 옵션) LLM_WARMUP_TIMEOUT_MS=100 임시 적용 → "timeout" 로그 후 자동 복구 (production 위험, dry-run 만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)