### PR TITLE
feat(login): 회원가입 약관 동의 + Policy modal — GDPR Phase A Fix 3+4 (frontend)

### DIFF
--- a/frontend/web/public/login.html
+++ b/frontend/web/public/login.html
@@ -455,10 +455,37 @@
                         <input type="password" id="registerPasswordConfirm" class="form-input" placeholder="••••••••"
                             required>
                     </div>
+                    <!-- GDPR Phase A Fix 4 — 약관 동의 -->
+                    <div class="form-group" style="display: flex; flex-direction: column; gap: 6px;">
+                        <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+                            <input type="checkbox" id="agreePrivacy" required>
+                            <span><a href="#" onclick="event.preventDefault(); showPolicyModal('privacy')">개인정보 처리방침</a>에 동의합니다 (필수)</span>
+                        </label>
+                        <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+                            <input type="checkbox" id="agreeTerms" required>
+                            <span><a href="#" onclick="event.preventDefault(); showPolicyModal('terms')">이용약관</a>에 동의합니다 (필수)</span>
+                        </label>
+                    </div>
                     <button type="submit" class="btn btn-primary" id="registerBtn">
                         가입하기
                     </button>
                 </form>
+            </div>
+
+            <!-- GDPR Phase A Fix 3 — Policy modal -->
+            <div id="policyModal" class="modal-overlay" style="display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.5); z-index: 1000; align-items: center; justify-content: center;">
+                <div style="background: var(--surface, #fff); max-width: 720px; width: 90%; max-height: 80vh; border-radius: 8px; display: flex; flex-direction: column; box-shadow: 0 8px 24px rgba(0,0,0,0.2);">
+                    <div style="padding: 16px 20px; border-bottom: 1px solid var(--border, #e5e5e5); display: flex; justify-content: space-between; align-items: center;">
+                        <h3 id="policyModalTitle" style="margin: 0;">정책 문서</h3>
+                        <button type="button" onclick="closePolicyModal()" style="background: none; border: none; font-size: 24px; cursor: pointer; line-height: 1;">×</button>
+                    </div>
+                    <div id="policyModalBody" style="padding: 20px; overflow-y: auto; flex: 1;">
+                        <p>로딩 중...</p>
+                    </div>
+                    <div style="padding: 12px 20px; border-top: 1px solid var(--border, #e5e5e5); text-align: right;">
+                        <button type="button" class="btn btn-secondary" onclick="closePolicyModal()">닫기</button>
+                    </div>
+                </div>
             </div>
 
             <!-- 구분선 -->
@@ -713,13 +740,28 @@
                 return;
             }
 
+            // GDPR Phase A Fix 4 — 약관 동의 검증 (HTML required 가 1차, defensive 2차)
+            const agreedToPrivacy = document.getElementById('agreePrivacy').checked;
+            const agreedToTerms = document.getElementById('agreeTerms').checked;
+            if (!agreedToPrivacy || !agreedToTerms) {
+                showError('개인정보 처리방침과 이용약관에 모두 동의해주세요');
+                return;
+            }
+
             setLoading('registerBtn', true);
 
             try {
                 const res = await fetch(`${API_BASE}/api/auth/register`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ username, email, password })
+                    body: JSON.stringify({
+                        username,
+                        email,
+                        password,
+                        agreedToTerms,
+                        agreedToPrivacy,
+                        consentLocale: (navigator.language || 'ko').split('-')[0],
+                    })
                 });
 
                 const data = await res.json();
@@ -739,6 +781,38 @@
             } finally {
                 setLoading('registerBtn', false);
             }
+        }
+
+        // GDPR Phase A Fix 3 — Policy modal: backend route 에서 markdown 조회 + marked.js 렌더링
+        async function showPolicyModal(type) {
+            const modal = document.getElementById('policyModal');
+            const title = document.getElementById('policyModalTitle');
+            const body = document.getElementById('policyModalBody');
+            title.textContent = type === 'privacy' ? '개인정보 처리방침' : '이용약관';
+            body.innerHTML = '<p>로딩 중...</p>';
+            modal.style.display = 'flex';
+            try {
+                const locale = (navigator.language || 'ko').split('-')[0];
+                const res = await fetch(`${API_BASE}/api/policies/${type}/${locale}`);
+                const data = await res.json();
+                if (!res.ok || !data.success) {
+                    body.innerHTML = `<p style="color: var(--danger, #d00);">정책 문서를 불러오지 못했습니다. (${(data.error && data.error.message) || res.status})</p>`;
+                    return;
+                }
+                // marked.js 가 전역으로 loaded 되어 있다면 사용, 아니면 plain text 표시
+                const md = data.data.content || '';
+                if (window.marked && typeof window.marked.parse === 'function') {
+                    body.innerHTML = window.marked.parse(md);
+                } else {
+                    body.innerHTML = `<pre style="white-space: pre-wrap; font-family: inherit;">${md.replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]))}</pre>`;
+                }
+            } catch (e) {
+                body.innerHTML = `<p style="color: var(--danger, #d00);">정책 문서 조회 실패: ${e.message}</p>`;
+            }
+        }
+
+        function closePolicyModal() {
+            document.getElementById('policyModal').style.display = 'none';
         }
 
         function continueAsGuest() {


### PR DESCRIPTION
## Summary
- PR #70 (backend) 의 frontend UI 통합 — 회원가입 폼에 약관 동의 체크박스 2개 + Policy 본문 modal
- Phase A 1+2+3+4 의 마지막 PR — Phase A 완료

## 변경 파일
- \`frontend/web/public/login.html\` (1 file, +75/-1)

## 변경 내용
- 회원가입 폼 (line 433-461): 체크박스 2개 추가 (HTML \`required\` + 링크 클릭 → modal)
- 신규 Policy modal HTML (inline 스타일, login.html 의 기존 패턴 따름)
- \`handleRegister()\`:
  - defensive 동의 검증 (HTML required 1차 + JS 2차)
  - submit body: \`agreedToTerms\`, \`agreedToPrivacy\`, \`consentLocale\` 포함
  - consentLocale: \`navigator.language.split('-')[0]\` (예: 'ko')
- \`showPolicyModal(type)\`: GET /api/policies/:type/:locale → marked.js 렌더링
  - marked 미loaded 시 plain text 폴백 + XSS escape
- \`closePolicyModal()\`

## Phase A 완료 요약 (PR #68-#70 + 본 PR)
| PR | 내용 | 완료 |
|----|------|------|
| #68 | manifest is_public 강제 false on user deletion (backend) | ✅ |
| #69 | admin 삭제 GDPR 영향 안내 modal (frontend) | ✅ |
| #70 | consent_logs + Privacy/Terms 다국어 서빙 (backend) | ✅ |
| 본 PR | 회원가입 약관 동의 + Policy modal (frontend) | (이 PR) |

## Test plan
- [x] frontend validate-modules 5/5 통과
- [ ] **운영자 manual UI verify**:
  1. 회원가입 폼 → 체크박스 미체크 시 submit 차단
  2. "개인정보 처리방침" 링크 → modal 본문 (markdown 렌더링) 확인
  3. "이용약관" 링크 → modal 본문 확인
  4. 두 체크박스 + 정상 정보 입력 → 가입 성공
  5. DB \`SELECT consent_logs WHERE user_id = '<신규>'\` → 2 row 확인 (privacy + terms)

## 후속 (Phase B/C, 별도 plan)
- Skill manifest 생성 UI 에 "탈퇴 후 동작" 명시
- 데이터 export 완전화 (manifest, agents, memories 포함)
- 동의 철회 UI (settings 페이지)
- i18n Policy 다국어 (en, ja, ...)
- 정책 재동의 prompt (version bump 시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)