### PR TITLE
feat(gdpr): English Privacy/Terms 정책 draft — Phase B/C C8 (PR-5)

### DIFF
--- a/frontend/web/public/policies/privacy.en.md
+++ b/frontend/web/public/policies/privacy.en.md
@@ -1,0 +1,109 @@
+---
+version: "1.0"
+effective_date: "2026-05-24"
+locale: en
+---
+
+# Privacy Policy (Draft)
+
+> ⚠️ **This document is a Claude-generated draft.** Legal review required before production publication. Operators must obtain legal counsel prior to live deployment.
+
+OpenMake LLM ("the Service") processes personal data as follows.
+
+## 1. Personal Data Collected
+
+During account registration and service use, the following data is collected.
+
+| Item | Collection Point | Required |
+|------|------------------|----------|
+| Username | Registration | Required |
+| Email address | Registration | Required |
+| Password (one-way hash) | Registration | Required |
+| IP address, User-Agent | Registration, login, consent events | Auto-collected |
+| Conversation content, uploaded files | Service use | User-provided |
+| External LLM API keys (user-registered) | User settings | Optional |
+
+## 2. Purpose of Processing
+
+- **Account identification and authentication**: username, email, password hash
+- **Service provision**: conversation session management, model routing, per-user settings
+- **Security and audit**: IP/User-Agent, `audit_logs` (admin action trail), `consent_logs` (GDPR Article 7 consent demonstrability)
+- **Abuse prevention**: anomalous traffic blocking, rate limiting
+
+## 3. Retention Period
+
+- **Active account**: indefinite (deletion available upon user request)
+- **Account deletion**: applies per "Data Handling on User Deletion" policy below
+- **`audit_logs` / `message_feedback`**: user identifier anonymized; audit trail retained (separate retention period applies)
+- **`consent_logs`**: deleted together with user (CASCADE)
+
+## 4. Data Handling on User Deletion
+
+The service classifies user data into three categories upon account deletion.
+
+### (A) Immediately Deleted (CASCADE)
+- Custom agents (`custom_agents`)
+- Personal skills (`agent_skills`)
+- Conversation sessions (`conversation_sessions`)
+- User memories (`user_memories`)
+- External API keys, OAuth connections (`external_connections`, `user_api_keys`)
+- MCP server instances/registrations
+- Push subscriptions (`push_subscriptions`)
+- Consent history (`consent_logs`)
+
+### (B) Author Anonymized, Content Retained (SET NULL)
+- **Audit logs (`audit_logs`)** — required for admin action traceability
+- **Message feedback (`message_feedback`)** — model evaluation data
+- **Skill manifests (`skill_manifests`)** — the manifest itself is retained, but `created_by` is set to NULL and `is_public` is automatically set to false, ensuring **the manifest is no longer exposed to other users** (GDPR Phase A Fix 1 protection)
+
+### (C) Reference-Protected (NO ACTION)
+The following data is linked to other users' activities and requires separate cleanup before deletion.
+- `agent_feedback`, `agent_installations`, `agent_marketplace.author_id`
+- `agent_reviews`, `agent_usage_logs`, `canvas_documents`
+
+If data remains in this category, account deletion may be temporarily blocked, and administrators will provide cleanup guidance.
+
+## 5. Data Subject Rights (GDPR Articles 15–22)
+
+Users may exercise the following rights.
+
+- **Right of access (Article 15)**: view personal data held — Settings page "Data Export" (currently exports conversation sessions only; manifest/agents/memories inclusion planned)
+- **Right to rectification (Article 16)**: edit email/username via Settings
+- **Right to erasure (Article 17)**: account deletion — processed per §4 categories above
+- **Right to restriction (Article 18)**: separate inquiry
+- **Right to portability (Article 20)**: data export in JSON format
+- **Right to object (Article 21)**: separate inquiry
+- **Right not to be subject to automated decision-making (Article 22)**: no automated decision-making currently used
+
+## 6. Consent (GDPR Article 7)
+
+Explicit consent for this Policy and the Terms of Service is collected at registration. Consent records are retained with the following metadata:
+
+- Consent timestamp
+- Policy version (e.g., 1.0)
+- User locale at consent time
+- IP address, User-Agent
+
+Withdrawal of consent is currently handled via separate inquiry (a self-service withdrawal feature in Settings is planned).
+
+## 7. Third-Party Disclosure
+
+Personal data is not disclosed to third parties as a rule, with the following exceptions:
+
+- **LLM service calls**: User input is forwarded through LiteLLM proxy to the self-hosted vLLM backend. Calls to external LLM providers (Anthropic, OpenAI, Gemini, etc.) only occur when the user has registered their own API key; such calls are subject to the respective provider's policy.
+- **Legal requirement**: lawful warrant or order from law enforcement / court
+
+## 8. Security
+
+- Password: bcrypt one-way hash
+- Session: HttpOnly JWT cookies
+- External API keys: AES-256-GCM encrypted at rest (`token-crypto.ts`)
+- HTTPS recommended (operator infrastructure dependent)
+
+## 9. Contact
+
+For inquiries regarding this Policy, please contact the service administrator.
+
+---
+
+**Last updated**: 2026-05-24 (version 1.0)

--- a/frontend/web/public/policies/terms.en.md
+++ b/frontend/web/public/policies/terms.en.md
@@ -1,0 +1,76 @@
+---
+version: "1.0"
+effective_date: "2026-05-24"
+locale: en
+---
+
+# Terms of Service (Draft)
+
+> ⚠️ **This document is a Claude-generated draft.** Legal review required before production publication.
+
+## 1. Service Overview
+
+OpenMake LLM ("the Service") is a self-hosted AI assistant platform that provides multi-LLM model routing and user-defined agent/skill capabilities.
+
+## 2. Accounts and Registration
+
+- Provide accurate email and username at registration.
+- Passwords must be at least 8 characters and include uppercase, lowercase, digit, and special character.
+- You are responsible for safekeeping your account credentials.
+- Account hijacking, automated bulk registration, and similar abuse are prohibited.
+
+## 3. Use of Service
+
+### 3.1 Permitted Use
+- AI conversations for personal study, research, or work
+- Creation and use of custom agents/skills
+- External model calls using your own registered LLM API keys
+
+### 3.2 Prohibited Use
+- Generation of illegal content (child sexual abuse material, incitement to violence, defamation, etc.)
+- Infringement of others' rights (copyright, trademark, privacy, etc.)
+- Unauthorized system intrusion, abuse, or excessive traffic generation
+- Use of automation tools for high-volume calls (rate limit evasion)
+- Exploitation of security vulnerabilities
+
+Violations may result in account suspension or termination without prior notice.
+
+## 4. Rate Limits and Usage Quotas
+
+The service applies the following limits for stable operation:
+
+- Chat requests: hourly/weekly token quotas (`LLM_HOURLY_TOKEN_LIMIT`, `LLM_WEEKLY_TOKEN_LIMIT`)
+- Separate quotas for management actions (API key management, MCP server registration, skill creation, etc.)
+- Automatic reset after the quota window expires
+
+## 5. Content Ownership
+
+- Copyright in your prompts, uploaded files, and custom agents/skills belongs to you.
+- Skill manifests that you explicitly mark as public (`is_public=true`) may be shared with other users.
+- Upon account deletion, manifests you authored are automatically set to non-public and are no longer shared (see Privacy Policy §4).
+- You are responsible for your use of AI-generated outputs (independent verification of accuracy/legality required).
+
+## 6. Disclaimers
+
+- The Service is provided "as is" without warranty of fitness for a particular purpose.
+- No warranty is given as to the accuracy, completeness, or legality of AI responses.
+- Operator is not liable for service interruptions caused by external LLM providers (Anthropic, OpenAI, Gemini, etc.).
+- Operator is not liable for service outages, data loss, or abuse-related damages absent willful misconduct or gross negligence.
+
+## 7. Changes to Terms
+
+- The operator may modify these Terms in response to legal or operational changes.
+- Material changes will be notified to users; if you do not consent within the notified period, account closure may be initiated.
+
+## 8. Dispute Resolution
+
+- These Terms are governed by the law of the operator's jurisdiction.
+- In the event of a dispute, the court of the operator's jurisdiction shall serve as the court of first instance.
+
+## 9. Contact
+
+For inquiries regarding these Terms, please contact the service administrator.
+
+---
+
+**Last updated**: 2026-05-24 (version 1.0)


### PR DESCRIPTION
## Summary
- Phase A 의 ko 정책 (PR #70) 의 영어 번역 + GDPR 영문 용어 사용
- \`policies.routes.ts\` 가 \`{type}.{locale}.md\` 패턴 자동 인식 — 코드 변경 0
- Phase B/C Core 3개 중 첫 번째 (C8)

## 신규 파일
- \`frontend/web/public/policies/privacy.en.md\` (Claude draft)
- \`frontend/web/public/policies/terms.en.md\` (Claude draft)

## 번역 결정
- GDPR 공식 영문 용어: \`data subject\`, \`data controller\`, \`right of access/rectification/erasure/restriction/portability/object\`
- ko 의 구체 시맨틱 보존: CASCADE/SET NULL/NO ACTION 카테고리, skill_manifests \`is_public\` 자동 false (Phase A Fix 1 효과)
- "초안" warning 동일 (legal review 대상)

## Test plan
- [x] frontend validate-modules 통과
- [ ] **운영자**: 배포 후 \`curl /api/policies/privacy/en\` → 200 + content 확인
- [ ] **운영자**: native speaker 영문 정확성 review + 법적 표현 확인

## 후속 (Phase B/C Core 의 다음)
- PR-6 (B7 동의 철회 UI)
- PR-7 (재동의 prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)