### PR TITLE
feat(gdpr): 동의 조회 + 철회 UI — Phase B Fix 6 (B7, PR-6)

### DIFF
--- a/backend/api/src/controllers/consent.controller.ts
+++ b/backend/api/src/controllers/consent.controller.ts
@@ -1,0 +1,151 @@
+/**
+ * ============================================================
+ * Consent Controller — GDPR Phase B Fix 6 (B7) + Phase A Fix 4 follow-up
+ * ============================================================
+ *
+ * 동의 관리 API. Phase A 의 회원가입 동의 (consent_logs INSERT) 후
+ * 사용자가 본인 동의 상태를 조회 / 철회할 수 있는 인터페이스.
+ *
+ * Endpoints:
+ *   GET  /api/users/me/consent          — 현재 동의 상태 (privacy + terms)
+ *   POST /api/users/me/consent/withdraw — 동의 철회 (granted=false 새 row INSERT)
+ *
+ * (PR-7 에서 추가 예정: GET /api/users/me/consent/status — 재동의 필요 여부)
+ *
+ * Article 7(3) right to withdraw consent — 동의 철회가 동의 부여만큼 쉬워야 함.
+ *
+ * @module controllers/consent
+ */
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { requireAuth } from '../auth/middleware';
+import { validate } from '../middlewares/validation';
+import { getPool } from '../data/models/unified-database';
+import { createLogger } from '../utils/logger';
+import { success, internalError, badRequest } from '../utils/api-response';
+
+const log = createLogger('ConsentController');
+
+const VALID_CONSENT_TYPES = ['privacy_policy', 'terms_of_service'] as const;
+type ConsentType = typeof VALID_CONSENT_TYPES[number];
+
+const withdrawSchema = z.object({
+    type: z.enum(VALID_CONSENT_TYPES),
+});
+
+interface ConsentStatus {
+    type: ConsentType;
+    version: string | null;
+    locale: string | null;
+    granted: boolean;
+    granted_at: string | null;
+}
+
+/**
+ * req.user 에서 user id 추출 — controller 단계에서 requireAuth 통과 이후 호출.
+ */
+function getUserId(req: Request): string | null {
+    if (!req.user) return null;
+    if ('userId' in req.user && typeof (req.user as { userId?: unknown }).userId === 'string') {
+        return (req.user as { userId: string }).userId;
+    }
+    if ('id' in req.user) {
+        return String(req.user.id);
+    }
+    return null;
+}
+
+/**
+ * 각 type 의 latest row 반환. 사용자가 한 번도 해당 type 에 대해 동의/철회한
+ * 적이 없으면 `granted=false` 의 placeholder 반환 (안전 default).
+ */
+async function getCurrentConsents(userId: string): Promise<ConsentStatus[]> {
+    const pool = getPool();
+    const result = await pool.query<{
+        consent_type: ConsentType;
+        consent_version: string;
+        consent_locale: string;
+        granted: boolean;
+        granted_at: Date;
+    }>(
+        `SELECT DISTINCT ON (consent_type)
+            consent_type, consent_version, consent_locale, granted, granted_at
+         FROM consent_logs
+         WHERE user_id = $1
+         ORDER BY consent_type, granted_at DESC`,
+        [userId],
+    );
+    const latest = new Map<ConsentType, ConsentStatus>();
+    for (const row of result.rows) {
+        latest.set(row.consent_type, {
+            type: row.consent_type,
+            version: row.consent_version,
+            locale: row.consent_locale,
+            granted: row.granted,
+            granted_at: row.granted_at.toISOString(),
+        });
+    }
+    return VALID_CONSENT_TYPES.map(type => latest.get(type) ?? {
+        type,
+        version: null,
+        locale: null,
+        granted: false,
+        granted_at: null,
+    });
+}
+
+export function createConsentController(): Router {
+    const router = Router();
+
+    /**
+     * GET /api/users/me/consent — 현재 동의 상태 조회
+     */
+    router.get('/', requireAuth, async (req: Request, res: Response): Promise<void> => {
+        try {
+            const userId = getUserId(req);
+            if (!userId) {
+                res.status(400).json(badRequest('user id 추출 실패'));
+                return;
+            }
+            const consents = await getCurrentConsents(userId);
+            res.json(success({ consents }));
+        } catch (err) {
+            log.error('[Consent GET] error:', err);
+            res.status(500).json(internalError('동의 상태 조회 실패'));
+        }
+    });
+
+    /**
+     * POST /api/users/me/consent/withdraw — 동의 철회 (granted=false 새 row INSERT).
+     * 기존 동의 row 는 보존 (이력 추적). 최신 row 의 granted 가 현재 상태.
+     */
+    router.post('/withdraw', requireAuth, validate(withdrawSchema), async (req: Request, res: Response): Promise<void> => {
+        try {
+            const userId = getUserId(req);
+            if (!userId) {
+                res.status(400).json(badRequest('user id 추출 실패'));
+                return;
+            }
+            const { type } = req.body as { type: ConsentType };
+
+            // 사용자의 latest version/locale 가져오기 — 철회 row 의 version/locale 도 보존
+            const latest = (await getCurrentConsents(userId)).find(c => c.type === type);
+            const version = latest?.version || 'unknown';
+            const locale = latest?.locale || 'unknown';
+
+            const pool = getPool();
+            await pool.query(
+                `INSERT INTO consent_logs (user_id, consent_type, consent_version, consent_locale, granted, ip_address, user_agent)
+                 VALUES ($1, $2, $3, $4, FALSE, $5, $6)`,
+                [userId, type, version, locale, req.ip || null, req.headers['user-agent'] || null],
+            );
+            log.info(`[Consent withdraw] user=${userId} type=${type}`);
+            res.json(success({ withdrawn: true, type }));
+        } catch (err) {
+            log.error('[Consent withdraw] error:', err);
+            res.status(500).json(internalError('동의 철회 실패'));
+        }
+    });
+
+    return router;
+}

--- a/backend/api/src/routes/setup.ts
+++ b/backend/api/src/routes/setup.ts
@@ -16,6 +16,7 @@ import * as fs from 'fs';
 import v1Router from './v1';
 import { tokenMonitoringRouter } from './token-monitoring.routes';
 import { createPoliciesRouter } from './policies.routes';
+import { createConsentController } from '../controllers/consent.controller';
 import debugQueueRouter from './debug-queue.routes';
 import { default as chatRouter, setClusterManager as setChatCluster } from './chat.routes';
 import { setClusterManager as setOpenAICompatCluster } from './openai-compat.routes';
@@ -192,6 +193,8 @@ export function setupApiRoutes(
     app.use('/api/admin', createAdminController());
     // GDPR Phase A Fix 3 — Policy 문서 다국어 서빙
     app.use('/api/policies', createPoliciesRouter());
+    // GDPR Phase B Fix 6 (B7) — 동의 조회/철회 API
+    app.use('/api/users/me/consent', createConsentController());
 
     // 클러스터 의존성 주입
     setChatCluster(cluster);

--- a/frontend/web/public/js/modules/api-endpoints.js
+++ b/frontend/web/public/js/modules/api-endpoints.js
@@ -116,6 +116,10 @@ const API_ENDPOINTS = Object.freeze({
     V1_CHAT: '/api/v1/chat',
     V1_MODELS: '/api/v1/models',
     V1_USAGE: '/api/v1/usage',
+
+    // ── GDPR Consent (Phase B Fix 6/7) ───────────
+    USER_CONSENT: '/api/users/me/consent',
+    USER_CONSENT_WITHDRAW: '/api/users/me/consent/withdraw',
 });
 
 // Expose globally for IIFE page modules

--- a/frontend/web/public/js/modules/pages/settings.js
+++ b/frontend/web/public/js/modules/pages/settings.js
@@ -174,6 +174,14 @@
         '<a href="/password-change.html" class="s-btn s-btn-primary" style="text-decoration:none;">\uD83D\uDD11 \uBE44\uBC00\uBC88\uD638 \uBCC0\uACBD</a>' +
         '<a href="/admin.html" class="s-btn s-btn-secondary" id="adminLink" style="text-decoration:none;display:none;">\uD83D\uDC65 \uC0AC\uC6A9\uC790 \uAD00\uB9AC</a>' +
         '</div>' +
+        // GDPR Phase B Fix 6 (B7) \u2014 \uB3D9\uC758 \uAD00\uB9AC \uC139\uC158
+        '<div class="setting-row" style="margin-top: 16px; border-top: 1px solid var(--border, #e5e5e5); padding-top: 16px;">' +
+        '<div class="setting-info">' +
+        '<h4>\uB3D9\uC758 \uAD00\uB9AC <span style="font-size: 0.85em; color: var(--text-muted, #888);">(GDPR Article 7)</span></h4>' +
+        '<p>\uAC1C\uC778\uC815\uBCF4 \uCC98\uB9AC\uBC29\uCE68 / \uC774\uC6A9\uC57D\uAD00 \uB3D9\uC758 \uC0C1\uD0DC \uBC0F \uCCA0\uD68C</p>' +
+        '</div>' +
+        '</div>' +
+        '<div id="consentList" style="margin-top: 8px;">\uB85C\uB529 \uC911...</div>' +
         '</div>' +
         '</div>' +
 
@@ -419,8 +427,69 @@
                     if (loggedIn && accountCard) {
                         accountCard.style.display = '';
                         if (isAdmin() && adminLink) adminLink.style.display = '';
+                        loadConsents();
                     }
                 })();
+
+                // GDPR Phase B Fix 6 (B7) — 동의 상태 조회 + 철회 UI
+                async function loadConsents() {
+                    var listEl = document.getElementById('consentList');
+                    if (!listEl) return;
+                    try {
+                        var res = await window.authFetch(window.API_ENDPOINTS.USER_CONSENT);
+                        var data = await res.json();
+                        if (!res.ok || !data.success) {
+                            listEl.innerHTML = '<p style="color: var(--danger, #d00); font-size: 0.9em;">동의 상태 조회 실패</p>';
+                            return;
+                        }
+                        var consents = data.data.consents || [];
+                        listEl.innerHTML = consents.map(function (c) {
+                            var typeLabel = c.type === 'privacy_policy' ? '개인정보 처리방침' : '이용약관';
+                            var statusBadge = c.granted
+                                ? '<span style="color: var(--success, #2a8); font-weight: 600;">✓ 동의됨</span>'
+                                : '<span style="color: var(--text-muted, #888);">철회됨</span>';
+                            var versionInfo = c.version ? ' v' + esc(c.version) : '';
+                            var dateInfo = c.granted_at ? ' (' + new Date(c.granted_at).toLocaleString() + ')' : '';
+                            var withdrawBtn = c.granted
+                                ? '<button class="s-btn s-btn-secondary" style="margin-left: 8px; font-size: 0.85em; padding: 4px 10px;" data-consent-withdraw="' + esc(c.type) + '">철회</button>'
+                                : '';
+                            return '<div style="display: flex; align-items: center; justify-content: space-between; padding: 8px 0; border-bottom: 1px solid var(--border-subtle, #f0f0f0);">'
+                                + '<div><strong>' + typeLabel + '</strong>' + versionInfo + ' &nbsp;' + statusBadge + '<div style="font-size: 0.85em; color: var(--text-muted, #888);">' + dateInfo + '</div></div>'
+                                + '<div>' + withdrawBtn + '</div>'
+                                + '</div>';
+                        }).join('');
+                        // 철회 button event delegation
+                        listEl.querySelectorAll('[data-consent-withdraw]').forEach(function (btn) {
+                            btn.addEventListener('click', function () {
+                                withdrawConsent(btn.dataset.consentWithdraw);
+                            });
+                        });
+                    } catch (e) {
+                        listEl.innerHTML = '<p style="color: var(--danger, #d00); font-size: 0.9em;">동의 상태 조회 실패: ' + esc(String(e.message || e)) + '</p>';
+                    }
+                }
+
+                async function withdrawConsent(type) {
+                    var label = type === 'privacy_policy' ? '개인정보 처리방침' : '이용약관';
+                    if (!confirm(label + ' 동의를 철회하시겠습니까?\n\n다음 로그인 시 재동의가 필요할 수 있습니다.')) return;
+                    try {
+                        var res = await window.authFetch(window.API_ENDPOINTS.USER_CONSENT_WITHDRAW, {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ type: type }),
+                        });
+                        var data = await res.json();
+                        if (res.ok && data.success) {
+                            if (window.showToast) window.showToast(label + ' 동의가 철회되었습니다', 'success');
+                            loadConsents();  // refresh
+                        } else {
+                            var msg = (data.error && typeof data.error === 'object') ? data.error.message : data.error;
+                            if (window.showToast) window.showToast(msg || '철회 실패', 'error');
+                        }
+                    } catch (e) {
+                        if (window.showToast) window.showToast('철회 실패: ' + (e.message || e), 'error');
+                    }
+                }
 
                 // 사용자 등급(tier) 판별 — 백엔드 tool-tiers.ts의 getDefaultTierForRole 동기화
                 function getUserTier() {


### PR DESCRIPTION
## Summary
- GDPR Article 7(3) right to withdraw consent — 동의 철회가 동의 부여만큼 쉬워야 함
- Phase A 의 회원가입 동의 (PR #70 backend, PR #71 frontend) 후속
- 사용자가 settings 페이지에서 본인 동의 상태 조회 + 철회 가능

## 신규 / 변경 파일
- **신규**: \`backend/api/src/controllers/consent.controller.ts\` — 2 endpoint
- **변경**: \`backend/api/src/routes/setup.ts\` (router 등록)
- **변경**: \`frontend/web/public/js/modules/api-endpoints.js\` (USER_CONSENT, USER_CONSENT_WITHDRAW)
- **변경**: \`frontend/web/public/js/modules/pages/settings.js\` (동의 관리 섹션)

## API
- \`GET /api/users/me/consent\` — 현재 동의 상태 (privacy + terms)
- \`POST /api/users/me/consent/withdraw\` — granted=false 새 row INSERT

## 설계
- DISTINCT ON (consent_type) ORDER BY granted_at DESC — index \`idx_consent_logs_user\` 활용
- 기존 row 보존 (이력 추적), 최신 row 가 현재 상태
- IP/UA 캡처 (Phase A Fix 4 패턴 재사용)
- 철회 후 즉시 서비스 차단 안 함 — 사용자 경험 우선, 다음 로그인 시 재동의 prompt (PR-7) 가 처리
- 단순 confirm() 사용 (본인 데이터 통제 액션, modal 부담 회피)

## Test plan
- [x] tsc 0 / eslint 0
- [x] frontend validate-modules 통과
- [x] 회귀 47/47 (auth|consent|user-manager)
- [ ] **운영자 manual**: settings 페이지 → "동의 관리" 섹션 → 철회 버튼 → DB \`SELECT consent_logs WHERE user_id AND granted=FALSE\`

## 후속
- PR-7: 재동의 prompt (GET /api/users/me/consent/status + chat.js modal hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)