### PR TITLE
feat(gdpr): 정책 재동의 prompt — Phase B Fix 7 (PR-7)

### DIFF
--- a/backend/api/src/controllers/consent.controller.ts
+++ b/backend/api/src/controllers/consent.controller.ts
@@ -33,6 +33,18 @@ const withdrawSchema = z.object({
     type: z.enum(VALID_CONSENT_TYPES),
 });
 
+const grantSchema = z.object({
+    type: z.enum(VALID_CONSENT_TYPES),
+    version: z.string().min(1).max(20),
+    locale: z.string().min(2).max(10).optional().default('ko'),
+});
+
+/**
+ * Phase A 의 CURRENT_POLICY_VERSION 과 동기 — Phase A AuthService.ts:22
+ * Single source of truth 로 별도 export 모듈 분리는 후속 (현재 const 동기 유지).
+ */
+const CURRENT_POLICY_VERSION = '1.0';
+
 interface ConsentStatus {
     type: ConsentType;
     version: string | null;
@@ -144,6 +156,62 @@ export function createConsentController(): Router {
         } catch (err) {
             log.error('[Consent withdraw] error:', err);
             res.status(500).json(internalError('동의 철회 실패'));
+        }
+    });
+
+    /**
+     * GET /api/users/me/consent/status — 재동의 필요 여부 (Phase B Fix 7).
+     * 사용자의 latest granted=true row 의 version 과 CURRENT_POLICY_VERSION 비교.
+     * 사용자가 한 번도 동의 안 했거나 (Phase A 이전 가입), 버전 불일치, 또는 철회
+     * 상태면 needsConsent=true + 해당 type 들 반환.
+     */
+    router.get('/status', requireAuth, async (req: Request, res: Response): Promise<void> => {
+        try {
+            const userId = getUserId(req);
+            if (!userId) {
+                res.status(400).json(badRequest('user id 추출 실패'));
+                return;
+            }
+            const consents = await getCurrentConsents(userId);
+            const pendingTypes: ConsentType[] = consents
+                .filter(c => !c.granted || c.version !== CURRENT_POLICY_VERSION)
+                .map(c => c.type);
+            res.json(success({
+                needsConsent: pendingTypes.length > 0,
+                currentVersion: CURRENT_POLICY_VERSION,
+                pendingTypes,
+                consents,  // 현재 상태도 함께 반환 (UI 가 details 표시)
+            }));
+        } catch (err) {
+            log.error('[Consent status] error:', err);
+            res.status(500).json(internalError('동의 상태 확인 실패'));
+        }
+    });
+
+    /**
+     * POST /api/users/me/consent — 재동의 (granted=true 새 row INSERT).
+     * 재동의 prompt 에서 호출. PR-3 의 회원가입 INSERT 와 동일 형식.
+     */
+    router.post('/', requireAuth, validate(grantSchema), async (req: Request, res: Response): Promise<void> => {
+        try {
+            const userId = getUserId(req);
+            if (!userId) {
+                res.status(400).json(badRequest('user id 추출 실패'));
+                return;
+            }
+            const { type, version, locale } = req.body as { type: ConsentType; version: string; locale: string };
+
+            const pool = getPool();
+            await pool.query(
+                `INSERT INTO consent_logs (user_id, consent_type, consent_version, consent_locale, granted, ip_address, user_agent)
+                 VALUES ($1, $2, $3, $4, TRUE, $5, $6)`,
+                [userId, type, version, locale, req.ip || null, req.headers['user-agent'] || null],
+            );
+            log.info(`[Consent grant] user=${userId} type=${type} version=${version}`);
+            res.json(success({ granted: true, type, version }));
+        } catch (err) {
+            log.error('[Consent grant] error:', err);
+            res.status(500).json(internalError('동의 기록 실패'));
         }
     });
 

--- a/frontend/web/public/js/main.js
+++ b/frontend/web/public/js/main.js
@@ -130,6 +130,7 @@ import { UnifiedSidebar } from './components/unified-sidebar.js?v=7';
 
 // 1-18. 모바일 FAB 메뉴
 import { init as initMobileFab } from './modules/mobile-fab.js';
+import { checkReconsent } from './modules/consent-prompt.js';
 
 
 
@@ -481,6 +482,10 @@ async function initApp() {
 
     // 12. SPA 라우터 시작
     Router.start();
+
+    // 12-a. GDPR Phase B Fix 7 — 재동의 prompt 체크 (auth 완료 후, 비차단).
+    // 로그인 안 한 경우 / 동의 필요 없는 경우 즉시 return (no-op).
+    checkReconsent().catch(function (e) { console.warn('[App] reconsent check failed:', e); });
 
     // 라우터 네비게이션 시 사이드바 활성 대화 업데이트
     Router.onAfterNavigate(function (info) {

--- a/frontend/web/public/js/modules/consent-prompt.js
+++ b/frontend/web/public/js/modules/consent-prompt.js
@@ -1,0 +1,153 @@
+/**
+ * ============================================================
+ * Consent Prompt — GDPR Phase B Fix 7 (PR-7)
+ * ============================================================
+ *
+ * 로그인 후 첫 진입 시 사용자의 정책 동의 상태 확인 → 재동의 필요 시
+ * modal 표시. CURRENT_POLICY_VERSION bump (예: 1.0 → 1.1) 또는 사용자가
+ * 동의 철회 후 재로그인 한 케이스 처리.
+ *
+ * 동작:
+ *   1. GET /api/users/me/consent/status — needsConsent 확인
+ *   2. needsConsent=true → 각 pendingTypes 의 정책 본문 fetch (login.html
+ *      의 showPolicyModal 동일 패턴 — marked.js 렌더링)
+ *   3. 사용자가 동의 클릭 → POST /api/users/me/consent (각 type)
+ *   4. 모든 type 동의 완료 → modal close
+ *
+ * 거부 (cancel) 옵션은 본 PR 에서 제외 — Phase B 추가 (Article 7 우선,
+ * 거부 시 logout/grace period 결정은 별도 plan).
+ *
+ * @module modules/consent-prompt
+ */
+
+const API = '/api';
+
+let _modalEl = null;
+
+function ensureModal() {
+    if (_modalEl) return _modalEl;
+    const el = document.createElement('div');
+    el.id = 'reconsentModal';
+    el.style.cssText = 'display:none; position:fixed; inset:0; background:rgba(0,0,0,0.5); z-index:9999; align-items:center; justify-content:center;';
+    el.innerHTML = `
+        <div style="background: var(--surface, #fff); color: var(--text, #000); max-width: 720px; width: 90%; max-height: 80vh; border-radius: 8px; display: flex; flex-direction: column; box-shadow: 0 8px 24px rgba(0,0,0,0.3);">
+            <div style="padding: 16px 20px; border-bottom: 1px solid var(--border, #e5e5e5);">
+                <h3 style="margin: 0;">📋 정책 업데이트 — 재동의 필요</h3>
+                <p style="margin: 6px 0 0 0; color: var(--text-muted, #888); font-size: 0.9em;">
+                    아래 정책에 동의가 필요합니다. 서비스 사용을 계속하려면 동의해 주세요.
+                </p>
+            </div>
+            <div id="reconsentBody" style="padding: 16px 20px; overflow-y: auto; flex: 1;">
+                로딩 중...
+            </div>
+            <div id="reconsentFooter" style="padding: 12px 20px; border-top: 1px solid var(--border, #e5e5e5); text-align: right;">
+                <!-- 동적 버튼 -->
+            </div>
+        </div>
+    `;
+    document.body.appendChild(el);
+    _modalEl = el;
+    return el;
+}
+
+function showModal() { ensureModal().style.display = 'flex'; }
+function hideModal() { if (_modalEl) _modalEl.style.display = 'none'; }
+
+async function fetchPolicy(type, locale) {
+    const res = await fetch(`${API}/policies/${type}/${locale}`, { credentials: 'include' });
+    if (!res.ok) throw new Error(`policy fetch failed (${res.status})`);
+    const data = await res.json();
+    return data.data;  // { type, locale, version, content }
+}
+
+async function grantConsent(type, version, locale) {
+    const res = await fetch(`${API}/users/me/consent`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type, version, locale }),
+    });
+    if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error((data.error && data.error.message) || `grant failed (${res.status})`);
+    }
+}
+
+function renderContent(md) {
+    if (window.marked && typeof window.marked.parse === 'function') {
+        return window.marked.parse(md);
+    }
+    return `<pre style="white-space: pre-wrap; font-family: inherit;">${md.replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]))}</pre>`;
+}
+
+/**
+ * 메인 entry — main.js 의 initApp 끝부분에서 호출.
+ * 로그인 안 한 경우 / 동의 필요 없는 경우 즉시 return (no-op).
+ */
+export async function checkReconsent() {
+    try {
+        const statusRes = await fetch(`${API}/users/me/consent/status`, { credentials: 'include' });
+        if (statusRes.status === 401 || statusRes.status === 403) return;  // 로그인 안 함
+        if (!statusRes.ok) return;
+        const statusData = await statusRes.json();
+        if (!statusData.success || !statusData.data.needsConsent) return;
+
+        const pendingTypes = statusData.data.pendingTypes;
+        const currentVersion = statusData.data.currentVersion;
+        const locale = (navigator.language || 'ko').split('-')[0];
+
+        // 각 pending type 의 정책 본문 fetch 후 sequential 동의 처리
+        const policies = await Promise.all(pendingTypes.map(t => fetchPolicy(t, locale).catch(() => null)));
+
+        ensureModal();
+        const body = document.getElementById('reconsentBody');
+        const footer = document.getElementById('reconsentFooter');
+
+        let idx = 0;
+        function renderNext() {
+            if (idx >= pendingTypes.length) {
+                hideModal();
+                // 새로고침으로 상태 동기화 (settings 의 loadConsents 등)
+                if (window.location.pathname === '/' || window.location.pathname === '/index.html') {
+                    return;  // chat 페이지면 그대로 진행
+                }
+                return;
+            }
+            const type = pendingTypes[idx];
+            const policy = policies[idx];
+            const typeLabel = type === 'privacy_policy' ? '개인정보 처리방침' : '이용약관';
+            const version = (policy && policy.version) || currentVersion;
+            const policyLocale = (policy && policy.locale) || locale;
+
+            body.innerHTML = `
+                <h4>${typeLabel} <span style="font-size: 0.85em; color: var(--text-muted, #888);">(v${version})</span></h4>
+                <div style="margin-top: 12px; padding: 12px; background: var(--surface-secondary, #f7f7f7); border-radius: 6px; max-height: 50vh; overflow-y: auto;">
+                    ${policy ? renderContent(policy.content) : '<p style="color: var(--danger, #d00);">정책 본문 로드 실패</p>'}
+                </div>
+            `;
+            footer.innerHTML = `
+                <span style="margin-right: 12px; color: var(--text-muted, #888);">${idx + 1} / ${pendingTypes.length}</span>
+                <button class="btn btn-primary" id="reconsentAgreeBtn">동의하고 계속</button>
+            `;
+            const btn = document.getElementById('reconsentAgreeBtn');
+            btn.addEventListener('click', async () => {
+                btn.disabled = true;
+                btn.textContent = '처리 중...';
+                try {
+                    await grantConsent(type, version, policyLocale);
+                    idx++;
+                    renderNext();
+                } catch (e) {
+                    btn.disabled = false;
+                    btn.textContent = '동의하고 계속';
+                    alert('동의 처리 실패: ' + (e.message || e));
+                }
+            });
+        }
+        renderNext();
+        showModal();
+    } catch (err) {
+        // network/parse 에러 — 로깅만, 사용자 차단 안 함
+        console.warn('[ConsentPrompt] check failed:', err);
+    }
+}


### PR DESCRIPTION
## Summary
- CURRENT_POLICY_VERSION bump 또는 사용자 동의 철회 후 재로그인 시 자동 재동의 modal
- Phase A Article 7 affirmative consent 의 ongoing 유지
- Phase B/C Core 3개 의 마지막 (PR-5 영어 + PR-6 철회 + 본 PR)

## Backend (consent.controller.ts 확장)
- \`GET /api/users/me/consent/status\` — needsConsent 판단 + pendingTypes 반환
- \`POST /api/users/me/consent\` — 재동의 INSERT (granted=true 새 row)

## Frontend
- 신규 module: \`js/modules/consent-prompt.js\` (160줄)
  - \`checkReconsent()\` entry — main.js 가 호출
  - 로그인 안 한 경우 / 동의 필요 없는 경우 즉시 return
  - modal 동적 생성 + injection (CSS 의존 0, inline 스타일)
  - 각 pendingTypes sequential 처리 (정책 본문 fetch → 동의 → 다음)
  - marked.js 렌더링 (PR #71 showPolicyModal 패턴 재사용)
- \`main.js\`:
  - import { checkReconsent } from './modules/consent-prompt.js'
  - initApp 의 Router.start 직후 비차단 호출 (12-a 단계)

## 설계
- "거부" 옵션 미제공 — Article 7 우선. 거부 = modal 닫기 → 다음 로그인 시 다시 prompt
- chat 페이지 (main.js) 만 hook — settings/admin 직접 진입은 일반적으로 chat 경유 흐름 (trade-off 수용)
- 동의 후 grace period (예: 7일 후 재차단) 같은 운영 정책은 별도 plan

## Test plan
- [x] tsc 0 / eslint 0 / frontend validate-modules 통과
- [x] 회귀 47/47 (auth|consent|user-manager)
- [ ] **운영자 manual**:
  1. \`CURRENT_POLICY_VERSION\` 임시 bump (consent.controller.ts:35 + AuthService.ts:22)
  2. PM2 reload → 기존 사용자 로그인 → modal 자동 표시
  3. 동의 클릭 → \`SELECT consent_logs WHERE granted=TRUE ORDER BY granted_at DESC LIMIT 5\` 확인
  4. version revert

## Phase A+B/C Core 완료
| PR | 내용 | 상태 |
|----|------|------|
| #68 | manifest is_public deletion 보호 | ✅ |
| #69 | admin 삭제 영향 안내 modal | ✅ |
| #70 | consent_logs + Policy 다국어 서빙 (backend) | ✅ |
| #71 | 회원가입 약관 동의 + Policy modal (frontend) | ✅ |
| #72 | English Privacy/Terms draft | ✅ |
| #73 | 동의 조회 + 철회 UI | ✅ |
| 본 PR | 재동의 prompt | (이 PR) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)