### PR TITLE
refactor(gdpr): CURRENT_POLICY_VERSION 단일 export 통합 — SSoT

### DIFF
--- a/backend/api/src/config/policy.ts
+++ b/backend/api/src/config/policy.ts
@@ -1,0 +1,27 @@
+/**
+ * ============================================================
+ * Policy version SSoT — GDPR Phase B follow-up
+ * ============================================================
+ *
+ * Privacy Policy / Terms of Service 의 현재 운영 버전.
+ *
+ * 사용처:
+ *   - AuthService.recordConsents() — 회원가입 시 consent_logs INSERT
+ *   - ConsentController.GET /status — 사용자 latest 동의 version vs 현재 비교
+ *   - ConsentController.POST / — 재동의 INSERT (frontend 가 정책 file frontmatter
+ *     version 을 직접 보내지만, server 검증 또는 default 로 사용 가능)
+ *
+ * Markdown 파일의 frontmatter `version: "1.0"` 과 **동기 유지 필수**.
+ * 신규 정책 publish 시:
+ *   1. `frontend/web/public/policies/{type}.{locale}.md` frontmatter version bump
+ *   2. 본 상수 bump
+ *   3. PM2 reload — 기존 사용자가 다음 로그인 시 재동의 prompt 자동 표시 (Phase B Fix 7)
+ *
+ * @module config/policy
+ */
+
+/**
+ * 현재 운영 중인 Privacy Policy + Terms of Service 의 버전.
+ * Markdown frontmatter 와 동기 유지 (`frontend/web/public/policies/*.md`).
+ */
+export const CURRENT_POLICY_VERSION = '1.0';

--- a/backend/api/src/controllers/consent.controller.ts
+++ b/backend/api/src/controllers/consent.controller.ts
@@ -23,6 +23,7 @@ import { validate } from '../middlewares/validation';
 import { getPool } from '../data/models/unified-database';
 import { createLogger } from '../utils/logger';
 import { success, internalError, badRequest } from '../utils/api-response';
+import { CURRENT_POLICY_VERSION } from '../config/policy';
 
 const log = createLogger('ConsentController');
 
@@ -38,12 +39,6 @@ const grantSchema = z.object({
     version: z.string().min(1).max(20),
     locale: z.string().min(2).max(10).optional().default('ko'),
 });
-
-/**
- * Phase A 의 CURRENT_POLICY_VERSION 과 동기 — Phase A AuthService.ts:22
- * Single source of truth 로 별도 export 모듈 분리는 후속 (현재 const 동기 유지).
- */
-const CURRENT_POLICY_VERSION = '1.0';
 
 interface ConsentStatus {
     type: ConsentType;

--- a/backend/api/src/services/AuthService.ts
+++ b/backend/api/src/services/AuthService.ts
@@ -12,14 +12,9 @@ import { createLogger } from '../utils/logger';
 import { getConfig } from '../config/env';
 import { PASSWORD_POLICY } from '../config/runtime-limits';
 import { getPool } from '../data/models/unified-database';
+import { CURRENT_POLICY_VERSION } from '../config/policy';
 
 const log = createLogger('AuthService');
-
-/**
- * 현재 정책 버전 — 정책 markdown frontmatter 와 동기 유지.
- * 신규 정책 publish 시 bump (Phase B 의 재동의 prompt 와 연동 예정).
- */
-const CURRENT_POLICY_VERSION = '1.0';
 
 /**
  * GDPR Phase A Fix 4 helper — 회원가입 시 privacy_policy + terms_of_service


### PR DESCRIPTION
## Summary
- Phase A+B PR (#70, #74) 에서 \`AuthService.ts\` + \`consent.controller.ts\` 에 동일 const '1.0' 중복 정의
- 정책 버전 bump 시 한쪽 누락 위험 → 단일 export 모듈로 통합
- 운영자 잔여 항목 ("CURRENT_POLICY_VERSION SSoT 분리") 해소

## 변경
- **신규**: \`backend/api/src/config/policy.ts\` — \`export const CURRENT_POLICY_VERSION\`
- **변경**: \`AuthService.ts\`, \`consent.controller.ts\` — const 제거 + import

## 운영 절차 (JSDoc 에 명시)
정책 publish 시:
1. \`frontend/web/public/policies/{type}.{locale}.md\` frontmatter version bump
2. \`backend/api/src/config/policy.ts\` 의 const bump
3. PM2 reload → 기존 사용자 다음 로그인 시 자동 재동의 prompt (Phase B Fix 7)

## Test plan
- [x] tsc 0 / eslint 0 / jest 43/43 (auth|consent)
- [x] 런타임 동작 무변경 (단순 import 통합)

## 후속 (별도)
- markdown frontmatter ↔ TS const 동기 검증 boot invariant (rate-limits invariant 패턴 적용 가능)

🤖 Generated with [Claude Code](https://claude.com/claude-code)