### PR TITLE
feat(gdpr): skill UI 탈퇴 안내 + consent_logs PII retention — Phase B/C 잔여 (PR-A)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -156,6 +156,12 @@ EXTERNAL_MODELS_CACHE_TTL_MS=3600000
 # db-retention 스케줄러가 cron 으로 자동 정리 (services/db-retention.ts)
 EXTERNAL_USAGE_RETENTION_DAYS=90
 
+# GDPR Phase C Fix 9 — consent_logs PII (IP/User-Agent) 익명화 기간 (일, 기본 90일).
+# granted_at 기준 N일 후 ip_address/user_agent 를 NULL 로 UPDATE (row 보존, PII 만 제거).
+# Article 5(1)(c) data minimization + 7(1) demonstrability 동시 충족.
+# 0 또는 음수 시 비활성 (legacy/test 환경).
+# CONSENT_PII_RETENTION_DAYS=90
+
 # OpenRouter API 호출 타임아웃 (ms, 기본 2분)
 EXTERNAL_PROVIDER_REQUEST_TIMEOUT_MS=120000
 

--- a/backend/api/src/data/db-retention.ts
+++ b/backend/api/src/data/db-retention.ts
@@ -83,6 +83,27 @@ async function runRetention(): Promise<void> {
             logger.info(`[DbRetention] 외부 모델 캐시 stale ${cacheResult.rowCount}건 정리 완료`);
         }
 
+        // 6. GDPR Phase C Fix 9 — consent_logs PII 익명화 (Article 5(1)(c) data minimization)
+        // granted/version/granted_at 은 보존 (Article 7(1) consent demonstrability 유지),
+        // ip_address/user_agent 만 NULL 처리. row 삭제 안 함 — 동의 이력 사실 자체는 영구 보존,
+        // CASCADE 는 사용자 탈퇴 시에만 적용.
+        const consentRetentionDays = parseInt(
+            process.env.CONSENT_PII_RETENTION_DAYS ?? '90',
+            10,
+        );
+        if (Number.isFinite(consentRetentionDays) && consentRetentionDays > 0) {
+            const consentResult = await pool.query(
+                `UPDATE consent_logs
+                 SET ip_address = NULL, user_agent = NULL
+                 WHERE granted_at < NOW() - ($1 || ' days')::interval
+                   AND (ip_address IS NOT NULL OR user_agent IS NOT NULL)`,
+                [consentRetentionDays.toString()]
+            );
+            if ((consentResult.rowCount ?? 0) > 0) {
+                logger.info(`[DbRetention] consent_logs PII 익명화 ${consentResult.rowCount}건 완료 (${consentRetentionDays}일 초과)`);
+            }
+        }
+
     } catch (err) {
         logger.error('[DbRetention] 정리 작업 중 오류 발생:', err);
     }

--- a/frontend/web/public/js/modules/pages/skill-library.js
+++ b/frontend/web/public/js/modules/pages/skill-library.js
@@ -210,6 +210,10 @@
                     <option value="system">system — 전역 공개</option>
                 </select>
             </div>
+            <!-- GDPR Phase B Fix 5 — 탈퇴 시 manifest 처리 안내 -->
+            <div class="sl-form-group" style="background: var(--surface-secondary, #f7f7f7); padding: 10px 12px; border-radius: 6px; font-size: 0.85em; color: var(--text-muted, #666); line-height: 1.5;">
+                💡 <strong>탈퇴 시 안내</strong>: 본인 manifest 는 계정 삭제 시 <code>is_public</code> 이 자동으로 false 처리되어 다른 사용자에게 노출되지 않습니다 (Phase A Fix 1). 운영자가 system manifest 로 publish 한 경우에만 영구 공개됩니다.
+            </div>
             <div class="sl-modal-actions">
                 <button class="sl-btn sl-btn-secondary" onclick="sl_closeAutoCreate()">취소</button>
                 <button class="sl-btn sl-btn-primary" id="btnSubmitAutoCreate" onclick="sl_submitAutoCreate()">


### PR DESCRIPTION
## Summary
- **B5**: skill manifest 생성 UI 에 탈퇴 시 처리 안내 (Phase A Fix 1 효과 명시)
- **C9**: consent_logs PII (IP/UA) 90일 후 자동 익명화 — Option B (Article 5(1)(c) + 7(1) 동시 충족)
- Phase B/C 6개 중 2개 (잔여 B6 는 PR-B 단독)

## 변경 파일
- \`frontend/web/public/js/modules/pages/skill-library.js\` (B5 안내 텍스트, inline 스타일)
- \`backend/api/src/data/db-retention.ts\` (C9 UPDATE 25줄)
- \`.env.example\` (C9 env 문서화)

## C9 선택 근거 (Option B vs C)
| 항목 | Option B (PII 익명화) | Option C (row 삭제) |
|------|--------------------|--------------------|
| Article 5(1)(c) minimization | ✓ | ✓ |
| Article 5(1)(e) storage limitation | △ (row 보존) | ✓ |
| Article 7(1) demonstrability | ✓ | ❌ (이력 손실) |
| EU 사실상 표준 | ✓ | △ |

→ Option B: demonstrability 우선, PII 만 minimize.

## Test plan
- [x] tsc 0 / eslint 0 / frontend validate-modules 통과
- [x] 회귀 47/47 (auth|consent|user-manager|db-retention)
- [ ] **운영자**:
  - skill-library 페이지 → "탈퇴 시 안내" 텍스트 확인
  - \`CONSENT_PII_RETENTION_DAYS=0\` 임시 → PM2 reload → 즉시 모든 row 익명화 verify → revert (default 90)
  - 또는 1시간 후 로그 \`[DbRetention] consent_logs PII 익명화 N건\` 확인

## 후속
- PR-B: B6 (데이터 export 완전화) — 별도 단독 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)