### PR TITLE
feat(gdpr): 사용자 전체 데이터 export — Phase B Fix 6 (B6, PR-B)

### DIFF
--- a/backend/api/src/config/rate-limits.ts
+++ b/backend/api/src/config/rate-limits.ts
@@ -201,6 +201,23 @@ export const RL_ADMIN = {
     userLimit: Number(process.env.RL_ADMIN_USER) || 150,
 } as const;
 
+/**
+ * GDPR Article 20 데이터 export 레이트 리밋.
+ *
+ * 적용: GET /api/users/me/export
+ * 비용: 5개 카테고리 SELECT 병렬 + JSON 직렬화 (사용자 데이터 ~MB 단위)
+ * 정책: 시간당 사용자별 N회 — 정상 사용 충분, 악용/실수 반복 방어
+ */
+export const RL_GDPR_EXPORT = {
+    windowMs: 60 * 60 * 1000,  // 1시간
+    limits: {
+        free: Number(process.env.RL_EXPORT_FREE) || 2,
+        pro: Number(process.env.RL_EXPORT_PRO) || 5,
+        enterprise: Number(process.env.RL_EXPORT_ENTERPRISE) || 10,
+        admin: Number(process.env.RL_EXPORT_ADMIN) || 100,
+    },
+} as const;
+
 // ============================================
 // 32-bit signed int invariant (module-load 검증)
 // ============================================
@@ -229,6 +246,7 @@ const _windowMsInvariant = [
     { name: 'RL_MCP_INGEST', cfg: RL_MCP_INGEST },
     { name: 'RL_PUSH', cfg: RL_PUSH },
     { name: 'RL_ADMIN', cfg: RL_ADMIN },
+    { name: 'RL_GDPR_EXPORT', cfg: RL_GDPR_EXPORT },
 ];
 for (const { name, cfg } of _windowMsInvariant) {
     if (cfg.windowMs > SAFE_32BIT_MS) {

--- a/backend/api/src/controllers/export.controller.ts
+++ b/backend/api/src/controllers/export.controller.ts
@@ -1,0 +1,167 @@
+/**
+ * ============================================================
+ * Export Controller — GDPR Phase B Fix 6 (B6)
+ * ============================================================
+ *
+ * GDPR Article 20 (right to data portability) — 사용자가 본인의 모든 데이터를
+ * 단일 JSON 으로 export.
+ *
+ * 5개 카테고리 병렬 조회:
+ *   1. conversation_sessions + 그 안의 messages
+ *   2. skill_manifests (created_by 본인)
+ *   3. agent_skills (legacy, created_by 본인)
+ *   4. custom_agents (created_by 본인)
+ *   5. user_memories (user_id 본인)
+ *
+ * Rate limit: RL_GDPR_EXPORT (시간당 사용자별 N회).
+ *
+ * @module controllers/export
+ */
+import { Router, Request, Response } from 'express';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+import { requireAuth } from '../auth/middleware';
+import { getPool } from '../data/models/unified-database';
+import { RL_GDPR_EXPORT } from '../config/rate-limits';
+import { createLogger } from '../utils/logger';
+import { internalError, badRequest } from '../utils/api-response';
+import type { QueryResultRow } from 'pg';
+
+const log = createLogger('ExportController');
+
+type UserTier = 'free' | 'pro' | 'enterprise' | 'admin';
+
+function getUserId(req: Request): string | null {
+    if (!req.user) return null;
+    if ('userId' in req.user && typeof (req.user as { userId?: unknown }).userId === 'string') {
+        return (req.user as { userId: string }).userId;
+    }
+    if ('id' in req.user) {
+        return String(req.user.id);
+    }
+    return null;
+}
+
+function resolveTier(req: Request): UserTier {
+    if (!req.user) return 'free';
+    const role = ('role' in req.user ? (req.user as { role?: string }).role : undefined);
+    if (role === 'admin') return 'admin';
+    const tier = (req.user && 'tier' in req.user ? (req.user as { tier?: string }).tier : undefined) ?? 'free';
+    return (tier === 'pro' || tier === 'enterprise') ? tier : 'free';
+}
+
+function exportKeyGen(req: Request): string {
+    const uid = getUserId(req);
+    return uid ? `export:user:${uid}` : `export:ip:${ipKeyGenerator(req.ip || 'unknown')}`;
+}
+
+const exportLimiter = rateLimit({
+    windowMs: RL_GDPR_EXPORT.windowMs,
+    limit: (req: Request): number => RL_GDPR_EXPORT.limits[resolveTier(req)],
+    keyGenerator: exportKeyGen,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (_req: Request, res: Response): void => {
+        res.status(429).json({
+            success: false,
+            error: { code: 'RATE_LIMITED', message: '데이터 export 시간당 한도를 초과했습니다. 잠시 후 다시 시도하세요.' },
+        });
+    },
+});
+
+/**
+ * 5개 카테고리 병렬 조회. 각 query 실패는 개별 catch 로 빈 배열 반환 (export 자체는
+ * 계속 — 사용자가 부분 데이터라도 받을 수 있게).
+ */
+async function collectUserData(userId: string): Promise<Record<string, unknown>> {
+    const pool = getPool();
+
+    const safeQuery = async <T extends QueryResultRow>(label: string, sql: string, params: unknown[]): Promise<T[]> => {
+        try {
+            const r = await pool.query<T>(sql, params);
+            return r.rows;
+        } catch (err) {
+            log.warn(`[Export] ${label} 조회 실패 (continue):`, err);
+            return [];
+        }
+    };
+
+    const [user, sessions, manifests, agentSkills, customAgents, memories] = await Promise.all([
+        safeQuery<Record<string, unknown>>('user', `SELECT id, username, email, role, created_at FROM users WHERE id = $1`, [userId]),
+        safeQuery<Record<string, unknown>>('conversation_sessions',
+            `SELECT s.id, s.title, s.created_at, s.updated_at,
+                COALESCE(
+                    (SELECT json_agg(m ORDER BY m.created_at)
+                     FROM conversation_messages m WHERE m.session_id = s.id),
+                    '[]'::json
+                ) AS messages
+             FROM conversation_sessions s WHERE s.user_id = $1 ORDER BY s.created_at DESC LIMIT 500`,
+            [userId]),
+        safeQuery<Record<string, unknown>>('skill_manifests',
+            `SELECT id, version, manifest_yaml, prompt_md, checksum, is_public, created_by, created_at, updated_at
+             FROM skill_manifests WHERE created_by = $1 ORDER BY created_at DESC`,
+            [userId]),
+        safeQuery<Record<string, unknown>>('agent_skills',
+            `SELECT id, name, description, content, category, is_public, created_by, created_at, updated_at
+             FROM agent_skills WHERE created_by = $1 ORDER BY created_at DESC`,
+            [userId]),
+        safeQuery<Record<string, unknown>>('custom_agents',
+            `SELECT id, name, description, system_prompt, model, temperature, max_tokens, created_by, status, created_at, updated_at
+             FROM custom_agents WHERE created_by = $1 ORDER BY created_at DESC`,
+            [userId]),
+        safeQuery<Record<string, unknown>>('user_memories',
+            `SELECT id, user_id, category, key, value, importance, created_at, updated_at
+             FROM user_memories WHERE user_id = $1 ORDER BY created_at DESC`,
+            [userId]),
+    ]);
+
+    return {
+        timestamp: new Date().toISOString(),
+        version: '1.0',
+        user: user[0] || null,
+        conversationSessions: sessions,
+        skillManifests: manifests,
+        agentSkills,
+        customAgents,
+        userMemories: memories,
+        _meta: {
+            counts: {
+                conversationSessions: sessions.length,
+                skillManifests: manifests.length,
+                agentSkills: agentSkills.length,
+                customAgents: customAgents.length,
+                userMemories: memories.length,
+            },
+            note: 'GDPR Article 20 right to data portability. consent_logs, api_keys (암호화) 는 보안상 미포함.',
+        },
+    };
+}
+
+export function createExportController(): Router {
+    const router = Router();
+
+    /**
+     * GET /api/users/me/export — 사용자 전체 데이터 JSON export.
+     */
+    router.get('/', requireAuth, exportLimiter, async (req: Request, res: Response): Promise<void> => {
+        try {
+            const userId = getUserId(req);
+            if (!userId) {
+                res.status(400).json(badRequest('user id 추출 실패'));
+                return;
+            }
+            const data = await collectUserData(userId);
+            log.info(`[Export] user=${userId} sessions=${(data._meta as { counts: { conversationSessions: number } }).counts.conversationSessions}`);
+
+            // Content-Disposition 으로 즉시 download. JSON response 가 아닌 attachment 로 처리.
+            const date = new Date().toISOString().slice(0, 10);
+            res.setHeader('Content-Type', 'application/json; charset=utf-8');
+            res.setHeader('Content-Disposition', `attachment; filename="openmake_full_export_${date}.json"`);
+            res.send(JSON.stringify(data, null, 2));
+        } catch (err) {
+            log.error('[Export] error:', err);
+            res.status(500).json(internalError('데이터 export 실패'));
+        }
+    });
+
+    return router;
+}

--- a/backend/api/src/routes/setup.ts
+++ b/backend/api/src/routes/setup.ts
@@ -17,6 +17,7 @@ import v1Router from './v1';
 import { tokenMonitoringRouter } from './token-monitoring.routes';
 import { createPoliciesRouter } from './policies.routes';
 import { createConsentController } from '../controllers/consent.controller';
+import { createExportController } from '../controllers/export.controller';
 import debugQueueRouter from './debug-queue.routes';
 import { default as chatRouter, setClusterManager as setChatCluster } from './chat.routes';
 import { setClusterManager as setOpenAICompatCluster } from './openai-compat.routes';
@@ -195,6 +196,8 @@ export function setupApiRoutes(
     app.use('/api/policies', createPoliciesRouter());
     // GDPR Phase B Fix 6 (B7) — 동의 조회/철회 API
     app.use('/api/users/me/consent', createConsentController());
+    // GDPR Phase B Fix 6 (B6) — 사용자 전체 데이터 export (Article 20)
+    app.use('/api/users/me/export', createExportController());
 
     // 클러스터 의존성 주입
     setChatCluster(cluster);

--- a/frontend/web/public/js/modules/api-endpoints.js
+++ b/frontend/web/public/js/modules/api-endpoints.js
@@ -120,6 +120,8 @@ const API_ENDPOINTS = Object.freeze({
     // ── GDPR Consent (Phase B Fix 6/7) ───────────
     USER_CONSENT: '/api/users/me/consent',
     USER_CONSENT_WITHDRAW: '/api/users/me/consent/withdraw',
+    // ── GDPR Data Export (Phase B Fix 6 / B6) ────
+    USER_EXPORT: '/api/users/me/export',
 });
 
 // Expose globally for IIFE page modules

--- a/frontend/web/public/js/modules/pages/settings.js
+++ b/frontend/web/public/js/modules/pages/settings.js
@@ -377,26 +377,30 @@
                 function resetSettings() { if (confirm('모든 설정을 초기화하시겠습니까?')) { safeStorage.removeItem(SK.THEME || 'theme'); safeStorage.removeItem(SK.SELECTED_MODEL || 'selectedModel'); safeStorage.removeItem(SK.MCP_SETTINGS || 'mcpSettings'); safeStorage.removeItem(SK.GENERAL_SETTINGS || 'generalSettings'); location.reload(); } }
 
                 async function exportData() {
+                    // GDPR Phase B Fix 6 (B6) — Article 20 right to data portability.
+                    // 전체 사용자 데이터 (conversations + manifests + agents + memories) JSON export.
+                    // 백엔드가 Content-Disposition attachment 로 즉시 다운로드 응답.
                     try {
-                        var res = await fetch(API_ENDPOINTS.CHAT_SESSIONS + '?limit=500', { credentials: 'include' });
-                        if (!res.ok) throw new Error('서버 응답 오류: ' + res.status);
-                        var data = await res.json();
-                        var payload = data.data || data;
-                        var sessions = payload.sessions || [];
-                        if (sessions.length === 0) {
-                            (typeof showToast === 'function' ? showToast('내보낼 대화 기록이 없습니다.', 'warning') : console.warn('내보낼 대화 기록이 없습니다.'));
+                        var res = await fetch(API_ENDPOINTS.USER_EXPORT, { credentials: 'include' });
+                        if (res.status === 429) {
+                            var rateData = await res.json().catch(function () { return null; });
+                            var rateMsg = (rateData && rateData.error && rateData.error.message) || '데이터 export 시간당 한도를 초과했습니다.';
+                            (typeof showToast === 'function' ? showToast(rateMsg, 'warning') : console.warn(rateMsg));
                             return;
                         }
-                        var blob = new Blob([JSON.stringify(sessions, null, 2)], { type: 'application/json' });
+                        if (!res.ok) throw new Error('서버 응답 오류: ' + res.status);
+                        // Content-Disposition 헤더로 다운로드 처리 — blob 받아서 anchor 클릭
+                        var blob = await res.blob();
                         var url = URL.createObjectURL(blob);
                         var a = document.createElement('a');
                         a.href = url;
-                        a.download = 'openmake_chat_export_' + new Date().toISOString().slice(0, 10) + '.json';
+                        // 백엔드가 filename 헤더 명시했지만 anchor download 속성도 fallback 으로 설정
+                        a.download = 'openmake_full_export_' + new Date().toISOString().slice(0, 10) + '.json';
                         document.body.appendChild(a);
                         a.click();
                         a.remove();
                         URL.revokeObjectURL(url);
-                        (typeof showToast === 'function' ? showToast(sessions.length + '개 대화가 내보내기되었습니다.', 'success') : console.log('Export complete'));
+                        (typeof showToast === 'function' ? showToast('전체 데이터를 내보냈습니다.', 'success') : console.log('Export complete'));
                     } catch (e) {
                         console.error('데이터 내보내기 실패:', e);
                         (typeof showToast === 'function' ? showToast('데이터 내보내기에 실패했습니다.', 'error') : console.error('데이터 내보내기 실패'));


### PR DESCRIPTION
## Summary
- GDPR Article 20 right to data portability — 기존 대화 세션만 export 하던 것을 5개 카테고리 완전화
- Phase B/C 마지막 PR — Phase A+B/C 9개 작업 전체 완료

## 신규 / 변경 파일
- **신규**: \`backend/api/src/controllers/export.controller.ts\` (~170줄)
- **변경**:
  - \`backend/api/src/config/rate-limits.ts\` (RL_GDPR_EXPORT 추가 + invariant 등록)
  - \`backend/api/src/routes/setup.ts\` (router 등록)
  - \`frontend/web/public/js/modules/api-endpoints.js\` (USER_EXPORT)
  - \`frontend/web/public/js/modules/pages/settings.js\` (exportData() 함수)

## 5개 카테고리 (Promise.all + safeQuery 부분 실패 격리)
1. \`conversation_sessions\` + messages (json_agg)
2. \`skill_manifests\` (created_by)
3. \`agent_skills\` legacy (created_by)
4. \`custom_agents\` (created_by)
5. \`user_memories\` (user_id)

## 응답 형식
- Content-Disposition: \`attachment; filename="openmake_full_export_YYYY-MM-DD.json"\`
- schema: \`{ timestamp, version, user, conversationSessions, skillManifests, agentSkills, customAgents, userMemories, _meta }\`
- \`_meta.counts\` 로 사용자가 export 결과 확인

## Rate limit (RL_GDPR_EXPORT)
- 시간당: free=2, pro=5, enterprise=10, admin=100
- invariant 자동 검증 통과 (PR #67 의 jest)

## 미포함 (의도)
- \`consent_logs\`: PII (IP/UA) 포함 — 별도 API 가 필요시 제공
- \`api_keys\`: AES-256-GCM 암호화 — 복호화 후 export 는 키 노출 위험

## Test plan
- [x] tsc 0 / eslint 0 / frontend validate-modules 통과
- [x] 회귀 53/53 (auth|consent|user-manager|rate-limits|export)
- [x] rate-limits invariant 자동 검증 통과
- [ ] **운영자**:
  - 로그인 → settings → "데이터 내보내기" → JSON 다운로드
  - 5개 카테고리 모두 포함 확인 (\`_meta.counts\`)
  - 1시간 내 3회 호출 → 3번째 429 확인

## GDPR Phase A+B/C 전체 완료
| PR | 내용 |
|----|------|
| #68-#69 | Phase A 1+2 (manifest deletion 보호 + admin UI) |
| #70-#71 | Phase A 3+4 (consent_logs + 회원가입 동의 UI) |
| #72-#74 | Phase B Core (영어 정책 + 동의 철회 + 재동의 prompt) |
| #75 | SSoT refactor (CURRENT_POLICY_VERSION) |
| #76 | Phase B/C 잔여 (skill UI 안내 + consent PII retention) |
| 본 PR | Phase B Fix 6 (데이터 export 완전화) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)