### PR TITLE
docs(gdpr): Privacy/Terms en v2 draft — GDPR + EU + 한국 통합 보강

### DIFF
--- a/frontend/web/public/policies/privacy.en.md
+++ b/frontend/web/public/policies/privacy.en.md
@@ -4,11 +4,11 @@ effective_date: "2026-05-24"
 locale: en
 ---
 
-# Privacy Policy (Draft)
+# Privacy Policy (v2 Draft)
 
-> ⚠️ **This document is a Claude-generated draft.** Legal review required before production publication. Operators must obtain legal counsel prior to live deployment.
+> ⚠️ **This document is a Claude-generated v2 draft.** Legal review required before production publication. Operators must obtain qualified legal counsel covering both GDPR (EU) and Republic of Korea data protection law prior to live deployment.
 
-OpenMake LLM ("the Service") processes personal data as follows.
+OpenMake LLM ("the Service") processes personal data in accordance with the EU General Data Protection Regulation (GDPR), the ePrivacy Directive, and applicable national data protection law (including the Republic of Korea Personal Information Protection Act where applicable).
 
 ## 1. Personal Data Collected
 
@@ -20,22 +20,31 @@ During account registration and service use, the following data is collected.
 | Email address | Registration | Required |
 | Password (one-way hash) | Registration | Required |
 | IP address, User-Agent | Registration, login, consent events | Auto-collected |
+| Authentication cookie (HttpOnly JWT `auth_token`) | Post-login | Auto-generated |
 | Conversation content, uploaded files | Service use | User-provided |
 | External LLM API keys (user-registered) | User settings | Optional |
 
-## 2. Purpose of Processing
+### 1-a. Automated Collection Devices (Cookies) and Refusal
 
-- **Account identification and authentication**: username, email, password hash
+- The Service uses an HttpOnly authentication cookie (`auth_token`) solely for session maintenance.
+- No analytics, advertising, or tracking cookies are used.
+- Refusal: Cookies can be blocked via browser settings. Blocking the authentication cookie will prevent logged-in use.
+- Compliance: ePrivacy Directive — strictly necessary cookies do not require prior consent; analytics/tracking cookies, if introduced in the future, will require explicit opt-in.
+
+## 2. Purposes of Processing
+
+- **Account identification and authentication**: username, email, password hash, authentication cookie
 - **Service provision**: conversation session management, model routing, per-user settings
 - **Security and audit**: IP/User-Agent, `audit_logs` (admin action trail), `consent_logs` (GDPR Article 7 consent demonstrability)
 - **Abuse prevention**: anomalous traffic blocking, rate limiting
 
-## 3. Retention Period
+## 3. Retention Periods
 
-- **Active account**: indefinite (deletion available upon user request)
-- **Account deletion**: applies per "Data Handling on User Deletion" policy below
-- **`audit_logs` / `message_feedback`**: user identifier anonymized; audit trail retained (separate retention period applies)
-- **`consent_logs`**: deleted together with user (CASCADE)
+- **Active account**: retained until user-initiated deletion request
+- **Inactive account isolation**: where applicable national law (e.g., Republic of Korea Information and Communications Network Act §29) requires, accounts inactive for one (1) year may be moved to separated storage (operational policy, subsequent implementation)
+- **Account deletion**: handled per "Data Handling on User Deletion" policy below
+- **`audit_logs` / `message_feedback`**: user identifier anonymized (`user_id → NULL`); content retained for audit obligations (default retention period subject to operator policy)
+- **`consent_logs`**: deleted together with user account (CASCADE); PII (IP/User-Agent) automatically anonymized after 90 days (Phase C Fix 9)
 
 ## 4. Data Handling on User Deletion
 
@@ -54,56 +63,111 @@ The service classifies user data into three categories upon account deletion.
 ### (B) Author Anonymized, Content Retained (SET NULL)
 - **Audit logs (`audit_logs`)** — required for admin action traceability
 - **Message feedback (`message_feedback`)** — model evaluation data
-- **Skill manifests (`skill_manifests`)** — the manifest itself is retained, but `created_by` is set to NULL and `is_public` is automatically set to false, ensuring **the manifest is no longer exposed to other users** (GDPR Phase A Fix 1 protection)
+- **Skill manifests (`skill_manifests`)** — the manifest itself is retained, but `created_by` is set to NULL and `is_public` is automatically set to false, ensuring **the manifest is no longer exposed to other users** (Phase A Fix 1 protection)
 
-### (C) Reference-Protected (NO ACTION)
-The following data is linked to other users' activities and requires separate cleanup before deletion.
-- `agent_feedback`, `agent_installations`, `agent_marketplace.author_id`
-- `agent_reviews`, `agent_usage_logs`, `canvas_documents`
+### (C) Reference-Protected (Manual Cleanup Required)
+Data linked to other users' activities (reviews, marketplace listings, etc.) may require separate cleanup before deletion. If such data remains, account deletion may be temporarily blocked, and administrators will provide cleanup guidance.
 
-If data remains in this category, account deletion may be temporarily blocked, and administrators will provide cleanup guidance.
+## 5. Data Subject Rights
 
-## 5. Data Subject Rights (GDPR Articles 15–22)
+Users may exercise the following rights (GDPR Articles 15–22 + Korea PIPA §35-39 where applicable).
 
-Users may exercise the following rights.
+### How to Exercise
+- **Online**: Settings page (`/settings.html`) provides direct exercise for:
+  - Data export (access + portability) — "Export Data" button
+  - Withdrawal of consent — "Consent Management" section
+  - Email/username modification — Account settings
+  - Account deletion request — separate inquiry (admin-handled at present; self-service deletion planned)
+- **Email inquiry**: §11 Complaints Department or §10 Data Protection Officer (DPO)
 
-- **Right of access (Article 15)**: view personal data held — Settings page "Data Export" (currently exports conversation sessions only; manifest/agents/memories inclusion planned)
-- **Right to rectification (Article 16)**: edit email/username via Settings
-- **Right to erasure (Article 17)**: account deletion — processed per §4 categories above
-- **Right to restriction (Article 18)**: separate inquiry
-- **Right to portability (Article 20)**: data export in JSON format
+### Rights Overview
+- **Right of access (Article 15)**: view personal data held
+- **Right to rectification (Article 16)**: correct inaccurate data
+- **Right to erasure (Article 17)**: account deletion processed per §4 above
+- **Right to restriction of processing (Article 18)**: separate inquiry
+- **Right to data portability (Article 20)**: JSON export
 - **Right to object (Article 21)**: separate inquiry
 - **Right not to be subject to automated decision-making (Article 22)**: no automated decision-making currently used
+- **Right to lodge a complaint with a supervisory authority (Article 77)**: see §11-a below
 
 ## 6. Consent (GDPR Article 7)
 
-Explicit consent for this Policy and the Terms of Service is collected at registration. Consent records are retained with the following metadata:
+Explicit consent for this Policy and the Terms of Service is collected at registration.
 
-- Consent timestamp
-- Policy version (e.g., 1.0)
-- User locale at consent time
-- IP address, User-Agent
+- **Right to refuse**: Acceptance of the Policy and Terms is mandatory for registration — **refusal precludes account creation** (guest mode with limited features may be available separately).
+- **Consequences of refusal**: personalized features (saved conversations, skill registration, etc.) are unavailable without an account.
+- **Consent record metadata**: timestamp, policy version, locale, IP address, User-Agent.
+- **Withdrawal**: available at any time via Settings → "Consent Management". Upon withdrawal, re-consent will be requested at next login.
+- **Granular consent**: consent for the Privacy Policy and Terms of Service is recorded separately, allowing withdrawal of one without affecting the other.
 
-Withdrawal of consent is currently handled via separate inquiry (a self-service withdrawal feature in Settings is planned).
+## 7. Third-Party Disclosure and Processor Engagement
 
-## 7. Third-Party Disclosure
-
+### 7-1. Third-Party Disclosure
 Personal data is not disclosed to third parties as a rule, with the following exceptions:
+- **Legal requirement**: lawful warrant or order from law enforcement / court of competent jurisdiction
 
-- **LLM service calls**: User input is forwarded through LiteLLM proxy to the self-hosted vLLM backend. Calls to external LLM providers (Anthropic, OpenAI, Gemini, etc.) only occur when the user has registered their own API key; such calls are subject to the respective provider's policy.
-- **Legal requirement**: lawful warrant or order from law enforcement / court
+### 7-2. Processor Engagement (GDPR Article 28)
+The Service engages the following data processors (notified to users at consent collection):
+
+| Processor | Processing Activity | Data Transferred |
+|-----------|---------------------|------------------|
+| External LLM providers (Anthropic, OpenAI, Google Gemini, etc.) | LLM inference for user-registered API keys | User input prompts (only when user explicitly registers external provider API keys) |
+| Self-hosted vLLM / LiteLLM | Default LLM inference | User input prompts processed within operator infrastructure; no external transfer |
+
+When external LLM providers are used, users should review the respective provider's privacy policy. International data transfers (if any) shall comply with GDPR Chapter V (e.g., Standard Contractual Clauses, adequacy decisions where applicable).
 
 ## 8. Security
 
 - Password: bcrypt one-way hash
-- Session: HttpOnly JWT cookies
+- Session: HttpOnly JWT cookies (SameSite, Secure attributes — HTTPS required in production)
 - External API keys: AES-256-GCM encrypted at rest (`token-crypto.ts`)
-- HTTPS recommended (operator infrastructure dependent)
+- HTTPS: mandatory in production environments (e.g., via Caddy, Cloudflare Tunnel)
+- Rate Limiting: per-IP and per-user request quotas
 
-## 9. Contact
+## 9. Changes to This Policy
 
-For inquiries regarding this Policy, please contact the service administrator.
+Material changes (collection items, processing purposes, retention periods, or any change affecting data subject rights) will be:
+
+- **Notified** via in-app modal (re-consent prompt) on first entry and via email (auxiliary)
+- **Effective**: at least **30 days after notification** (consistent with EU consumer protection norms and Korea Electronic Commerce Act §15 where applicable)
+- **Right to object**: users may terminate the account or request retention of the prior version (subject to negotiation) within the notification period
+
+## 10. Data Controller and Data Protection Officer (DPO)
+
+### 10-a. Data Controller
+- **Legal entity name**: [Operator to provide — e.g., OpenMake Inc.]
+- **Address**: [Operator to provide — registered business address]
+- **Contact (email)**: [Operator to provide]
+- **EU Representative (if applicable under GDPR Article 27)**: [Operator to provide if processing targets EU data subjects without establishment in the EU]
+
+### 10-b. Data Protection Officer (DPO)
+Designated under GDPR Article 37 (where required) and Korea PIPA §31:
+- **Name**: [Operator to provide — actual value before publication]
+- **Title**: [Operator to provide]
+- **Contact (email)**: [Operator to provide — e.g., dpo@openmake.example]
+- **Contact (phone)**: [Optional]
+
+## 11. Complaints Department
+
+For privacy-related complaints, exercise of data subject rights, or breach reports, contact:
+
+- **Department**: [Operator to provide — e.g., OpenMake Privacy Team]
+- **Email**: [Operator to provide]
+- **Hours**: [Operator to provide — e.g., Monday-Friday 09:00-18:00 KST]
+
+### 11-a. Supervisory Authorities (Right to Lodge a Complaint — GDPR Article 77)
+
+Users have the right to lodge a complaint with a competent supervisory authority. Examples:
+
+| Authority | Jurisdiction | Contact |
+|-----------|--------------|---------|
+| Personal Information Protection Commission (PIPC) | Republic of Korea | privacy.go.kr / 182 (toll-free) |
+| Korea Internet & Security Agency (KISA) | Republic of Korea | privacy.kisa.or.kr / 118 (toll-free) |
+| EU member state Data Protection Authorities | European Union | See edpb.europa.eu/about-edpb/about-edpb/members_en |
+| (Other applicable national authority) | User's habitual residence | Per local law |
+
+Users in the EU may lodge complaints with the Data Protection Authority of their member state of habitual residence, place of work, or where the alleged infringement occurred (Article 77 §1).
 
 ---
 
-**Last updated**: 2026-05-24 (version 1.0)
+**Last updated**: 2026-05-24 (version 1.0, v2 draft)

--- a/frontend/web/public/policies/terms.en.md
+++ b/frontend/web/public/policies/terms.en.md
@@ -4,13 +4,13 @@ effective_date: "2026-05-24"
 locale: en
 ---
 
-# Terms of Service (Draft)
+# Terms of Service (v2 Draft)
 
-> ⚠️ **This document is a Claude-generated draft.** Legal review required before production publication.
+> ⚠️ **This document is a Claude-generated v2 draft.** Legal review required before production publication.
 
 ## 1. Service Overview
 
-OpenMake LLM ("the Service") is a self-hosted AI assistant platform that provides multi-LLM model routing and user-defined agent/skill capabilities.
+OpenMake LLM ("the Service") is a self-hosted AI assistant platform providing multi-LLM model routing and user-defined agent/skill capabilities.
 
 ## 2. Accounts and Registration
 
@@ -19,58 +19,103 @@ OpenMake LLM ("the Service") is a self-hosted AI assistant platform that provide
 - You are responsible for safekeeping your account credentials.
 - Account hijacking, automated bulk registration, and similar abuse are prohibited.
 
+### 2-a. Minors (GDPR Article 8 + applicable national law)
+
+- The Service does not knowingly permit registration by children below the applicable age of digital consent without verified parental authorization.
+- **EU/EEA**: Under GDPR Article 8, the default age is 16; EU member states may lower this to 13 by national law. Users below the applicable age require verifiable parental consent.
+- **Republic of Korea**: Under the Information and Communications Network Act §31 and PIPA §39-3, children under 14 require verifiable legal guardian consent.
+- A self-service guardian consent flow is planned for future implementation; in the interim, please contact the operator for assisted registration.
+- The operator must implement reasonable measures to verify users meet the applicable age threshold.
+
 ## 3. Use of Service
 
 ### 3.1 Permitted Use
 - AI conversations for personal study, research, or work
 - Creation and use of custom agents/skills
-- External model calls using your own registered LLM API keys
+- External model calls using user-registered LLM API keys
 
 ### 3.2 Prohibited Use
-- Generation of illegal content (child sexual abuse material, incitement to violence, defamation, etc.)
-- Infringement of others' rights (copyright, trademark, privacy, etc.)
+
+The following are strictly prohibited (including but not limited to content prohibited under Republic of Korea Information and Communications Network Act §44-7 and equivalent EU/national prohibitions):
+
+- Child sexual abuse material (CSAM) — zero tolerance, reported per applicable mandatory disclosure law
+- Sexually explicit material involving non-consenting individuals
+- Non-consensual intimate imagery (NCII) — creation, distribution, or facilitation
+- Defamation, harassment, stalking, threats
+- Content facilitating fraud, gambling, illicit drugs, or other criminal activity per applicable law
+- Disclosure of state secrets or unauthorized classified information
+- Content advocating violent extremism or terrorism
+- Infringement of intellectual property rights (copyright, trademark, patent, design)
+- Violation of others' rights (privacy, image, name, etc.)
 - Unauthorized system intrusion, abuse, or excessive traffic generation
 - Use of automation tools for high-volume calls (rate limit evasion)
 - Exploitation of security vulnerabilities
+- Discrimination or hateful content (gender, race, religion, origin, disability, etc.)
+- Deliberate dissemination of disinformation
+- Other content violating applicable law or public order and morals
 
-Violations may result in account suspension or termination without prior notice.
+Violations may result in account suspension or termination without prior notice, and the operator may comply with mandatory reporting obligations under applicable law.
 
 ## 4. Rate Limits and Usage Quotas
 
-The service applies the following limits for stable operation:
+The Service applies the following limits for stable operation:
 
 - Chat requests: hourly/weekly token quotas (`LLM_HOURLY_TOKEN_LIMIT`, `LLM_WEEKLY_TOKEN_LIMIT`)
 - Separate quotas for management actions (API key management, MCP server registration, skill creation, etc.)
+- Data export: per-user hourly limit, tiered by subscription (Free/Pro/Enterprise)
 - Automatic reset after the quota window expires
 
-## 5. Content Ownership
+## 5. Content Ownership and Intellectual Property
 
-- Copyright in your prompts, uploaded files, and custom agents/skills belongs to you.
-- Skill manifests that you explicitly mark as public (`is_public=true`) may be shared with other users.
-- Upon account deletion, manifests you authored are automatically set to non-public and are no longer shared (see Privacy Policy §4).
-- You are responsible for your use of AI-generated outputs (independent verification of accuracy/legality required).
+### 5-1. User Content
+- Copyright in your prompts, uploaded files, and custom agents/skills **belongs to you**.
+- Skill manifests you explicitly mark as public (`is_public=true`) may be shared with other users.
+- Upon account deletion, manifests you authored are automatically set to non-public and are no longer shared (Privacy Policy §4).
+
+### 5-2. AI-Generated Outputs
+The copyright status of AI-generated outputs is **legally uncertain in many jurisdictions**; users should consider the following:
+- Under Republic of Korea Copyright Act, copyright protection requires human authorship; pure AI outputs may not qualify for protection.
+- Under U.S. Copyright Office guidance (March 2023), AI-only outputs are not eligible for copyright; user creative contribution (prompting, editing) may qualify.
+- EU and other jurisdictions: positions vary; consult local counsel for commercial use.
+- The operator makes no warranty as to the accuracy, completeness, or legality of AI outputs.
+- Users are responsible for independent verification before use (distribution, commercial exploitation, etc.).
 
 ## 6. Disclaimers
 
-- The Service is provided "as is" without warranty of fitness for a particular purpose.
+- The Service is provided **"as is"** without warranty of fitness for a particular purpose.
 - No warranty is given as to the accuracy, completeness, or legality of AI responses.
-- Operator is not liable for service interruptions caused by external LLM providers (Anthropic, OpenAI, Gemini, etc.).
-- Operator is not liable for service outages, data loss, or abuse-related damages absent willful misconduct or gross negligence.
+- The operator is not liable for service interruptions caused by external LLM providers (Anthropic, OpenAI, Gemini, etc.).
+- The operator is not liable for service outages, data loss, or abuse-related damages absent willful misconduct or gross negligence.
+
+### 6-a. Mandatory Rights Take Precedence
+The following mandatory rights under applicable consumer protection law are not waived by this Agreement:
+
+- **EU/EEA**: Mandatory rights under the EU Consumer Rights Directive (2011/83/EU), the Unfair Contract Terms Directive (93/13/EEC), and the Digital Services Act (2022/2065) — including, where applicable, the right of withdrawal, statutory warranties, and prohibition of unfair contract terms.
+- **Republic of Korea**: Mandatory rights under the Consumer Fundamental Act, the Act on Standard Terms of Contract, the Electronic Commerce Act, and the Information and Communications Network Act.
+- The operator's liability for willful misconduct or gross negligence cannot be excluded.
+- Any clause of this Agreement found contrary to mandatory law is severable and shall be deemed unenforceable to the extent of such conflict; the remaining provisions remain in effect.
 
 ## 7. Changes to Terms
 
 - The operator may modify these Terms in response to legal or operational changes.
-- Material changes will be notified to users; if you do not consent within the notified period, account closure may be initiated.
+- **Material changes** (adverse changes to user rights or obligations) will be **notified at least 30 days in advance** of effective date (Republic of Korea Electronic Commerce Act §15; equivalent EU consumer protection norms apply).
+- **Minor changes** will be notified upon effect.
+- Notification method: in-app modal on first entry (re-consent prompt) + email (auxiliary).
+- Continued use of the Service after the notification period without objection constitutes acceptance. Users may terminate the account during the notification period if they do not consent.
 
-## 8. Dispute Resolution
+## 8. Governing Law and Dispute Resolution
 
-- These Terms are governed by the law of the operator's jurisdiction.
-- In the event of a dispute, the court of the operator's jurisdiction shall serve as the court of first instance.
+- These Terms are governed by the laws of the **Republic of Korea**, without prejudice to applicable mandatory consumer protection law of the user's jurisdiction.
+- In the event of a dispute, users are encouraged first to contact the operator's complaints department (Privacy Policy §11) for amicable resolution.
+- If amicable resolution fails:
+  - **Republic of Korea consumers**: Korea Consumer Agency Consumer Dispute Mediation Committee (ccn.go.kr / 1372) or Korea Internet & Security Agency Electronic Transaction Dispute Mediation Committee (ecmc.or.kr).
+  - **EU consumers**: ODR Platform (ec.europa.eu/consumers/odr) — Online Dispute Resolution.
+- Unresolved disputes shall be submitted to the **competent court of the operator's principal place of business in the Republic of Korea**; consumers may also bring claims in their own court of habitual residence where applicable mandatory law (e.g., EU Regulation 1215/2012 Brussels I bis Article 18; Republic of Korea Civil Procedure Act §8) so provides.
 
 ## 9. Contact
 
-For inquiries regarding these Terms, please contact the service administrator.
+For inquiries regarding these Terms, please contact the operator's complaints department (Privacy Policy §11).
 
 ---
 
-**Last updated**: 2026-05-24 (version 1.0)
+**Last updated**: 2026-05-24 (version 1.0, v2 draft)


### PR DESCRIPTION
## Summary
- ko v2 (PR #78) 와 동일 구조로 en draft v2
- 한국법 + GDPR + EU Consumer Rights 통합 — EU 사용자 + 한국 사용자 양쪽 baseline
- version 유지 (1.0) — draft 개선만, publish 전 단계

## 변경 파일
- \`frontend/web/public/policies/privacy.en.md\` (+119/-37)
- \`frontend/web/public/policies/terms.en.md\` (+50/-23)

## privacy.en v2 핵심 추가
| 섹션 | 내용 |
|------|------|
| §1-a | Cookie + ePrivacy Directive (strictly necessary 예외) |
| §6 | Right to refuse + consequences (Article 7 ①) |
| §7-2 | Processor Engagement (Article 28) + Chapter V (SCCs) |
| §9 | 30일 전 통지 |
| **§10** | **Data Controller (Article 13 ①.a-b) + EU Representative (Article 27) + DPO (Article 37)** |
| **§11-a** | **Supervisory Authorities (Article 77) — PIPC/KISA + EU member state DPAs** |

## terms.en v2 핵심 추가
| 섹션 | 내용 |
|------|------|
| **§2-a** | **Minors — GDPR Article 8 (EU 16, member state 13 가능) + 한국 14세** |
| §3.2 | CSAM zero tolerance + NCII + §44-7 equivalent |
| §5-2 | AI 저작권 — 한국 + USCO 2023 + EU 차이 |
| **§6-a** | **Mandatory Rights — EU Consumer Rights Directive + Unfair Contract Terms + DSA** |
| §8 | 한국 분쟁조정위 + EU ODR Platform + Brussels I bis Article 18 |

## ⚠️ 운영자 critical
publish 전 placeholder 모두 입력:
- privacy.en.md §10-a: Data Controller 4개 (legal entity, address, contact email, EU Representative)
- privacy.en.md §10-b: DPO 3개 (name, title, contact)
- privacy.en.md §11: 부서/이메일/응대 시간 3개

## Test plan
- [x] frontend validate-modules 통과
- [ ] **운영자**: native English speaker review (영어 표현)
- [ ] **운영자**: GDPR 전문 변호사 자문 (특히 EU Representative 필요 여부 — Article 27)
- [ ] **운영자**: GET /api/policies/privacy/en + terms/en → v2 content 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)