### PR TITLE
feat(gdpr): 14세 미만 셀프 동의 backend — Phase D PR-A

### DIFF
--- a/backend/api/src/config/age-thresholds.ts
+++ b/backend/api/src/config/age-thresholds.ts
@@ -1,0 +1,61 @@
+/**
+ * ============================================================
+ * Age Thresholds — GDPR Phase D (14세 미만 셀프 동의)
+ * ============================================================
+ *
+ * Locale 별 디지털 동의 연령 임계값. 미달 시 법정대리인 동의 필수.
+ *
+ * 법적 근거:
+ *   - 한국 (ko): 정보통신망법 §31 + 개인정보 보호법 §39-3 — 14세 미만
+ *   - EU (de/fr/it/...): GDPR Article 8 — default 16세, member state 13세 lower 가능
+ *     (본 구현은 보수적 16세 일괄 적용)
+ *   - 기타 (default): US COPPA 13세 + 보수적 default
+ *
+ * @module config/age-thresholds
+ */
+
+/**
+ * Locale → 디지털 동의 연령 임계값 (만 나이).
+ * 명시되지 않은 locale 은 DEFAULT_AGE_THRESHOLD 사용.
+ */
+export const AGE_THRESHOLDS: Readonly<Record<string, number>> = Object.freeze({
+    // 한국 (정통망법 §31, 개보법 §39-3)
+    ko: 14,
+    // EU 회원국 — GDPR Article 8 default 16 (member state 13세 lower 가능, 보수적으로 16)
+    en: 16,  // 영어권 기본 — EU 사용자 가능성 + 미국 13 보다 보수적
+    de: 16, fr: 16, it: 16, es: 16, nl: 16, pt: 16,
+    sv: 16, da: 16, no: 16, fi: 16,
+    pl: 16, cs: 16, hu: 16, ro: 16, bg: 16, sk: 16, sl: 16, hr: 16,
+    // 명시 안 된 기타 locale → DEFAULT_AGE_THRESHOLD
+});
+
+/**
+ * 명시되지 않은 locale 의 기본 임계값. US COPPA (13) 기준.
+ */
+export const DEFAULT_AGE_THRESHOLD = 13;
+
+/**
+ * locale 의 임계값 반환. 명시 안 된 locale 은 DEFAULT_AGE_THRESHOLD.
+ * locale 은 BCP-47 (예: 'ko', 'ko-KR', 'en-US') — '-' 앞 prefix 만 사용.
+ */
+export function getAgeThreshold(locale: string | undefined | null): number {
+    if (!locale) return DEFAULT_AGE_THRESHOLD;
+    const prefix = locale.toLowerCase().split('-')[0];
+    return AGE_THRESHOLDS[prefix] ?? DEFAULT_AGE_THRESHOLD;
+}
+
+/**
+ * 만 나이 계산 (ISO YYYY-MM-DD birthDate vs NOW).
+ * 생일 안 지났으면 -1 한 값 반환.
+ */
+export function calculateAge(birthDateIso: string, now: Date = new Date()): number {
+    const birth = new Date(birthDateIso + 'T00:00:00Z');
+    if (Number.isNaN(birth.getTime())) {
+        throw new Error(`Invalid birthDate: ${birthDateIso}`);
+    }
+    let age = now.getUTCFullYear() - birth.getUTCFullYear();
+    const monthDiff = now.getUTCMonth() - birth.getUTCMonth();
+    const dayDiff = now.getUTCDate() - birth.getUTCDate();
+    if (monthDiff < 0 || (monthDiff === 0 && dayDiff < 0)) age--;
+    return age;
+}

--- a/backend/api/src/controllers/admin.controller.ts
+++ b/backend/api/src/controllers/admin.controller.ts
@@ -51,6 +51,10 @@ export class AdminController {
         this.router.put('/users/:id/tier', this.changeUserTier.bind(this));
         this.router.delete('/users/:id', this.deleteUser.bind(this));
 
+        // GDPR Phase D — 14세 미만 셀프 동의 admin endpoint
+        this.router.get('/guardian-consent-pending', this.listGuardianPending.bind(this));
+        this.router.post('/users/:id/guardian-verify', this.verifyGuardianConsent.bind(this));
+
         // 관리자용 대화 목록 (모든 사용자 대화 조회)
         this.router.get('/stats', this.getStats.bind(this));
         this.router.get('/conversations/export', this.exportConversations.bind(this));
@@ -399,6 +403,71 @@ export class AdminController {
         } catch (error) {
             log.error('[Admin Delete User] 오류:', error);
             res.status(500).json(internalError('사용자 삭제 실패'));
+        }
+    }
+
+    /**
+     * GET /api/admin/guardian-consent-pending — 14세 미만 가입 대기 list (GDPR Phase D)
+     */
+    private async listGuardianPending(_req: Request, res: Response): Promise<void> {
+        try {
+            const { getPool } = await import('../data/models/unified-database');
+            const r = await getPool().query(
+                `SELECT g.id, g.user_id, g.guardian_email, g.status, g.created_at,
+                        u.username, u.email AS user_email, u.birth_date
+                 FROM guardian_consent_pending g
+                 JOIN users u ON u.id = g.user_id
+                 WHERE g.status = 'pending'
+                 ORDER BY g.created_at ASC
+                 LIMIT 200`,
+            );
+            res.json(success({ pending: r.rows }));
+        } catch (error) {
+            log.error('[Admin Guardian List] 오류:', error);
+            res.status(500).json(internalError('보류 list 조회 실패'));
+        }
+    }
+
+    /**
+     * POST /api/admin/users/:id/guardian-verify — 14세 미만 동의 verify (GDPR Phase D)
+     * body: { decision: 'verified' | 'rejected', reason?: string }
+     */
+    private async verifyGuardianConsent(req: Request, res: Response): Promise<void> {
+        try {
+            const userId = req.params.id;
+            const { decision, reason } = req.body as { decision?: string; reason?: string };
+            if (decision !== 'verified' && decision !== 'rejected') {
+                res.status(400).json(badRequest('decision 은 verified 또는 rejected 여야 합니다'));
+                return;
+            }
+            const adminId = String('userId' in req.user! ? req.user!.userId : req.user!.id);
+            const { getPool } = await import('../data/models/unified-database');
+            const pool = getPool();
+
+            const upd = await pool.query(
+                `UPDATE guardian_consent_pending
+                 SET status = $2, reason = $3, verified_at = NOW(), verified_by_admin_id = $4
+                 WHERE user_id = $1 AND status = 'pending'
+                 RETURNING id`,
+                [userId, decision, reason || null, adminId],
+            );
+            if (upd.rowCount === 0) {
+                res.status(404).json(badRequest('보류 row 없음 또는 이미 처리됨'));
+                return;
+            }
+
+            await pool.query(
+                `UPDATE users
+                 SET minor_status = $2, is_active = $3
+                 WHERE id = $1`,
+                [userId, decision === 'verified' ? 'minor_verified' : 'minor_rejected', decision === 'verified'],
+            );
+
+            log.info(`[GDPR-D] guardian verify user=${userId} decision=${decision} admin=${adminId}`);
+            res.json(success({ user_id: userId, decision }));
+        } catch (error) {
+            log.error('[Admin Guardian Verify] 오류:', error);
+            res.status(500).json(internalError('동의 verify 실패'));
         }
     }
 

--- a/backend/api/src/schemas/auth.schema.ts
+++ b/backend/api/src/schemas/auth.schema.ts
@@ -38,6 +38,10 @@ export const registerSchema = z.object({
     agreedToPrivacy: z.literal(true, { message: '개인정보 처리방침에 동의해야 합니다' }),
     // 동의 시점의 사용자 locale (consent_logs 저장용). 미지정 시 'ko' 폴백.
     consentLocale: z.string().min(2).max(10).optional().default('ko'),
+    // GDPR Phase D — 14세 미만 셀프 동의 흐름. 필수.
+    birthDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, '생년월일은 YYYY-MM-DD 형식이어야 합니다'),
+    // 14세 미만 시 server-side enforce — locale 별 임계값 미달 시 필수.
+    guardianEmail: z.string().email().optional(),
 });
 
 /**

--- a/backend/api/src/services/AuthService.ts
+++ b/backend/api/src/services/AuthService.ts
@@ -13,6 +13,7 @@ import { getConfig } from '../config/env';
 import { PASSWORD_POLICY } from '../config/runtime-limits';
 import { getPool } from '../data/models/unified-database';
 import { CURRENT_POLICY_VERSION } from '../config/policy';
+import { getAgeThreshold, calculateAge } from '../config/age-thresholds';
 
 const log = createLogger('AuthService');
 
@@ -47,6 +48,9 @@ export interface RegisterRequest {
     // controller 가 req.ip / req.headers['user-agent'] 캡처 후 전달 (consent_logs 저장)
     consentIp?: string;
     consentUserAgent?: string;
+    // GDPR Phase D — 14세 미만 셀프 동의
+    birthDate?: string;       // ISO YYYY-MM-DD
+    guardianEmail?: string;   // 미달 연령 시 필수
 }
 
 export interface LoginRequest {
@@ -126,6 +130,47 @@ export class AuthService {
 
         if (!user) {
             return { success: false, error: '이미 등록된 이메일입니다' };
+        }
+
+        // GDPR Phase D — 14세 미만 셀프 동의 흐름.
+        // birthDate 가 있으면 연령 계산 → locale 별 임계값 미달 시 guardianEmail 필수 +
+        // is_active=false + minor_status='minor_pending' + guardian_consent_pending INSERT.
+        if (data.birthDate) {
+            try {
+                const age = calculateAge(data.birthDate);
+                const locale = data.consentLocale || 'ko';
+                const threshold = getAgeThreshold(locale);
+
+                if (age < threshold) {
+                    if (!data.guardianEmail) {
+                        // user 는 이미 생성 — 정리 후 fail
+                        await this.userManager.deleteUser(user.id);
+                        return { success: false, error: `${threshold}세 미만 가입 시 법정대리인 이메일이 필요합니다` };
+                    }
+                    const pool = getPool();
+                    await pool.query(
+                        `UPDATE users SET birth_date = $2, minor_status = 'minor_pending', is_active = FALSE WHERE id = $1`,
+                        [user.id, data.birthDate],
+                    );
+                    await pool.query(
+                        `INSERT INTO guardian_consent_pending (user_id, guardian_email, status)
+                         VALUES ($1, $2, 'pending')`,
+                        [user.id, data.guardianEmail],
+                    );
+                    log.info(`[GDPR-D] 14세 미만 가입 대기 user=${user.id} locale=${locale} age=${age} threshold=${threshold}`);
+                    // consent_logs 는 아래에서 동일 처리 — 동의 기록은 보존 (verify 후에도 reuse)
+                } else {
+                    // 성인 — birth_date 만 저장 (minor_status='adult' 는 default)
+                    const pool = getPool();
+                    await pool.query(
+                        `UPDATE users SET birth_date = $2 WHERE id = $1`,
+                        [user.id, data.birthDate],
+                    );
+                }
+            } catch (ageErr) {
+                log.error(`[GDPR-D] 연령 처리 실패 (user_id=${user.id}):`, ageErr);
+                // 연령 처리 실패해도 가입 자체는 진행 (사용자 영향 최소화). 단 운영자가 audit 필요.
+            }
         }
 
         // GDPR Phase A Fix 4 — consent_logs INSERT.

--- a/services/database/migrations/030_guardian_consent.sql
+++ b/services/database/migrations/030_guardian_consent.sql
@@ -1,0 +1,38 @@
+-- ============================================================
+-- 030_guardian_consent.sql — GDPR Phase D (14세 미만 셀프 동의)
+-- ============================================================
+--
+-- 정통망법 §31 + 개보법 §39-3 (한국 14세 미만) / GDPR Article 8
+-- (EU 16세, member state 13세 lower) 의 법정대리인 동의 의무 구현.
+--
+-- 정책: Option 3 (이메일 캐프쳐 + 운영자 수동 verify)
+--   - 회원가입 시 birthDate 수집
+--   - locale 별 임계값 미달 시 guardian_email 추가 수집
+--   - users.minor_status='minor_pending' + is_active=false
+--   - 운영자가 admin endpoint 로 verify → is_active=true
+--
+-- ============================================================
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS birth_date DATE;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS minor_status TEXT
+    NOT NULL DEFAULT 'adult'
+    CHECK (minor_status IN ('adult', 'minor_pending', 'minor_verified', 'minor_rejected'));
+
+CREATE TABLE IF NOT EXISTS guardian_consent_pending (
+    id                   SERIAL PRIMARY KEY,
+    user_id              TEXT NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+    guardian_email       TEXT NOT NULL,
+    status               TEXT NOT NULL DEFAULT 'pending'
+                            CHECK (status IN ('pending', 'verified', 'rejected', 'expired')),
+    reason               TEXT,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    verified_at          TIMESTAMPTZ,
+    verified_by_admin_id TEXT REFERENCES users(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_guardian_pending_status
+    ON guardian_consent_pending(status)
+    WHERE status = 'pending';
+
+COMMENT ON TABLE guardian_consent_pending IS '14세 미만 가입 시 법정대리인 동의 보류 큐 — 정통망법 §31, GDPR Article 8';
+COMMENT ON COLUMN users.minor_status IS 'adult | minor_pending (대기) | minor_verified (운영자 승인) | minor_rejected (운영자 거부)';


### PR DESCRIPTION
## Summary
- Option 3 (이메일 캐프쳐 + 운영자 수동 verify) — 이메일 발송 인프라 부담 0
- locale 별 임계값 (ko=14 정통망법, EU=16 GDPR Article 8, 기타=13 US COPPA)
- Phase D PR-A (backend), PR-B (frontend) 는 후속

## 신규 / 변경 파일
- **신규**: \`services/database/migrations/030_guardian_consent.sql\`
- **신규**: \`backend/api/src/config/age-thresholds.ts\`
- **변경**: \`backend/api/src/schemas/auth.schema.ts\` (birthDate + guardianEmail)
- **변경**: \`backend/api/src/services/AuthService.ts\` (register 분기)
- **변경**: \`backend/api/src/controllers/admin.controller.ts\` (2 endpoint 신규)

## API
- \`GET /api/admin/guardian-consent-pending\` — 보류 list
- \`POST /api/admin/users/:id/guardian-verify\` — body \`{ decision, reason }\`

## 흐름
1. 회원가입 (birthDate + 조건부 guardianEmail) → AuthService.register
2. 연령 계산 + locale 별 임계값 비교
3. 미달 시:
   - guardianEmail 누락 → 400 + user cleanup
   - 정상 → users.is_active=false, minor_status='minor_pending' + guardian_consent_pending INSERT
4. 운영자 → POST guardian-verify → users.is_active=true (decision='verified') 또는 minor_rejected

## Trade-off
- birthDate 진위 검증 불가 — 정통망법/GDPR 모두 "합리적 조치" 만 요구. self-report + admin verify 가 baseline
- 14세 미만 user row 는 생성 (FK 위해), 단 is_active=false 로 사용 차단
- 운영자 알림: audit_logs 만 (별도 이메일/Slack 알림은 후속)

## Test plan
- [x] tsc 0 / eslint 0 / jest 47/47 (auth|consent|user-manager 회귀)
- [ ] **운영자**: migration 030 적용 → curl register (birthDate 2020-01-01 + guardianEmail=parent@example.com) → \`SELECT * FROM guardian_consent_pending\` 확인
- [ ] **운영자**: POST /api/admin/users/<id>/guardian-verify { decision: 'verified' } → users.is_active=true 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)