### PR TITLE
feat(login): 14세 미만 셀프 동의 frontend — Phase D PR-B

### DIFF
--- a/backend/api/src/services/AuthService.ts
+++ b/backend/api/src/services/AuthService.ts
@@ -70,6 +70,8 @@ export interface AuthResult {
     error?: string;
     user?: PublicUser;
     token?: string;
+    // GDPR Phase D — 14세 미만 가입 시 활성화 대기 표시
+    pendingGuardianConsent?: boolean;
 }
 
 /**
@@ -135,6 +137,7 @@ export class AuthService {
         // GDPR Phase D — 14세 미만 셀프 동의 흐름.
         // birthDate 가 있으면 연령 계산 → locale 별 임계값 미달 시 guardianEmail 필수 +
         // is_active=false + minor_status='minor_pending' + guardian_consent_pending INSERT.
+        let pendingGuardianConsent = false;
         if (data.birthDate) {
             try {
                 const age = calculateAge(data.birthDate);
@@ -158,6 +161,7 @@ export class AuthService {
                         [user.id, data.guardianEmail],
                     );
                     log.info(`[GDPR-D] 14세 미만 가입 대기 user=${user.id} locale=${locale} age=${age} threshold=${threshold}`);
+                    pendingGuardianConsent = true;
                     // consent_logs 는 아래에서 동일 처리 — 동의 기록은 보존 (verify 후에도 reuse)
                 } else {
                     // 성인 — birth_date 만 저장 (minor_status='adult' 는 default)
@@ -191,8 +195,8 @@ export class AuthService {
             }
         }
 
-        log.info(`회원가입 완료: ${email}`);
-        return { success: true, user };
+        log.info(`회원가입 완료: ${email}${pendingGuardianConsent ? ' (guardian consent pending)' : ''}`);
+        return { success: true, user, ...(pendingGuardianConsent ? { pendingGuardianConsent: true } : {}) };
     }
 
     /**

--- a/frontend/web/public/login.html
+++ b/frontend/web/public/login.html
@@ -455,6 +455,17 @@
                         <input type="password" id="registerPasswordConfirm" class="form-input" placeholder="••••••••"
                             required>
                     </div>
+                    <!-- GDPR Phase D — 14세 미만 셀프 동의 (locale 별 임계값) -->
+                    <div class="form-group">
+                        <label class="form-label" for="registerBirthDate">생년월일</label>
+                        <input type="date" id="registerBirthDate" class="form-input" required>
+                        <span class="form-hint">정확한 생년월일을 입력하세요. 미성년자는 법정대리인 동의가 필요할 수 있습니다.</span>
+                    </div>
+                    <div class="form-group" id="guardianEmailGroup" style="display:none;">
+                        <label class="form-label" for="registerGuardianEmail">법정대리인 이메일</label>
+                        <input type="email" id="registerGuardianEmail" class="form-input" placeholder="parent@example.com">
+                        <span class="form-hint">법정대리인의 동의 확인을 위해 운영자가 별도 연락합니다. 가입 후 활성화 대기 상태가 됩니다.</span>
+                    </div>
                     <!-- GDPR Phase A Fix 4 — 약관 동의 -->
                     <div class="form-group" style="display: flex; flex-direction: column; gap: 6px;">
                         <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
@@ -704,6 +715,41 @@
             }
         }
 
+        // GDPR Phase D — locale 별 연령 임계값 (backend config/age-thresholds.ts 와 동기 유지)
+        const AGE_THRESHOLDS = {
+            ko: 14,
+            en: 16, de: 16, fr: 16, it: 16, es: 16, nl: 16, pt: 16,
+            sv: 16, da: 16, no: 16, fi: 16,
+            pl: 16, cs: 16, hu: 16, ro: 16, bg: 16, sk: 16, sl: 16, hr: 16,
+        };
+        const DEFAULT_AGE_THRESHOLD = 13;
+
+        function calculateAge(birthDateIso) {
+            const birth = new Date(birthDateIso + 'T00:00:00Z');
+            if (isNaN(birth.getTime())) return -1;
+            const now = new Date();
+            let age = now.getUTCFullYear() - birth.getUTCFullYear();
+            const m = now.getUTCMonth() - birth.getUTCMonth();
+            const d = now.getUTCDate() - birth.getUTCDate();
+            if (m < 0 || (m === 0 && d < 0)) age--;
+            return age;
+        }
+
+        // birthDate 입력 변화 시 guardianEmail input 동적 표시
+        function setupBirthDateListener() {
+            const bd = document.getElementById('registerBirthDate');
+            const guardianGroup = document.getElementById('guardianEmailGroup');
+            if (!bd || !guardianGroup) return;
+            bd.addEventListener('change', function () {
+                if (!bd.value) { guardianGroup.style.display = 'none'; return; }
+                const age = calculateAge(bd.value);
+                const locale = (navigator.language || 'ko').split('-')[0];
+                const threshold = AGE_THRESHOLDS[locale] || DEFAULT_AGE_THRESHOLD;
+                guardianGroup.style.display = age < threshold ? '' : 'none';
+            });
+        }
+        document.addEventListener('DOMContentLoaded', setupBirthDateListener);
+
         async function handleRegister(e) {
             e.preventDefault();
             hideMessages();
@@ -748,25 +794,49 @@
                 return;
             }
 
+            // GDPR Phase D — birthDate + locale 별 임계값 미달 시 guardianEmail 필수
+            const birthDate = document.getElementById('registerBirthDate').value;
+            if (!birthDate) {
+                showError('생년월일을 입력하세요');
+                return;
+            }
+            const consentLocale = (navigator.language || 'ko').split('-')[0];
+            const age = calculateAge(birthDate);
+            const threshold = AGE_THRESHOLDS[consentLocale] || DEFAULT_AGE_THRESHOLD;
+            const isMinor = age < threshold;
+            let guardianEmail;
+            if (isMinor) {
+                guardianEmail = document.getElementById('registerGuardianEmail').value.trim();
+                if (!guardianEmail) {
+                    showError(`${threshold}세 미만 가입 시 법정대리인 이메일이 필요합니다`);
+                    return;
+                }
+            }
+
             setLoading('registerBtn', true);
 
             try {
+                const body = {
+                    username, email, password,
+                    agreedToTerms, agreedToPrivacy, consentLocale,
+                    birthDate,
+                };
+                if (guardianEmail) body.guardianEmail = guardianEmail;
                 const res = await fetch(`${API_BASE}/api/auth/register`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        username,
-                        email,
-                        password,
-                        agreedToTerms,
-                        agreedToPrivacy,
-                        consentLocale: (navigator.language || 'ko').split('-')[0],
-                    })
+                    body: JSON.stringify(body)
                 });
 
                 const data = await res.json();
 
                 if (res.ok && data.success) {
+                    // GDPR Phase D — 14세 미만 가입 시 pendingGuardianConsent 응답
+                    if (data.data && data.data.pendingGuardianConsent) {
+                        showSuccess('회원가입이 접수되었습니다. 법정대리인 동의 확인 후 활성화됩니다. 운영자가 별도 연락 드립니다.');
+                        // login 자동 전환 안 함 (활성화 전에는 로그인 불가)
+                        return;
+                    }
                     showSuccess('회원가입 완료! 로그인해주세요.');
                     setTimeout(() => {
                         switchTab('login');


### PR DESCRIPTION
## Summary
- PR-A (#80) backend 의 UI 통합
- 회원가입 form 에 birthDate + 조건부 guardianEmail 동적 표시
- 미달 가입 시 pending 응답 처리 (login 자동 전환 안 함)

## 변경 파일
- \`frontend/web/public/login.html\` (+72/-10) — birthDate input, AGE_THRESHOLDS, handleRegister 분기, pendingGuardianConsent 응답 처리
- \`backend/api/src/services/AuthService.ts\` (+12/-3) — AuthResult.pendingGuardianConsent 추가

## 흐름
1. 사용자가 birthDate 입력
2. change 리스너: locale 별 임계값 미달 시 guardianEmail group 표시 (display:none → '')
3. submit:
   - 미달 + guardianEmail 누락 → 에러
   - 정상 → body 에 birthDate + (조건부) guardianEmail
4. 응답:
   - pendingGuardianConsent=true → "법정대리인 동의 확인 후 활성화" 안내 + login 자동 전환 안 함
   - 정상 → 기존 동작 (login 전환)

## AGE_THRESHOLDS (frontend ↔ backend 동기)
- ko: 14 / EU 회원국: 16 / 기타: 13 (DEFAULT_AGE_THRESHOLD)
- hardcoded — 후속에 dynamic API fetch 가능

## Test plan
- [x] tsc 0 / frontend validate-modules 통과
- [x] 회귀 43/43 (auth|consent)
- [ ] **운영자 manual**:
  - 회원가입 form → birthDate 2020-01-01 → guardianEmail input 자동 표시
  - 가입 → "법정대리인 확인 후 활성화" 토스트 + login 자동 전환 안 함
  - DB: \`SELECT * FROM guardian_consent_pending WHERE user_id=<신규>\` row 확인
  - POST /api/admin/users/<id>/guardian-verify { decision: 'verified' } → 사용자 로그인 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)