### PR TITLE
feat(gdpr): 운영자 알림 — minor_pending 등록 시 webhook 즉시 통보

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -162,6 +162,12 @@ EXTERNAL_USAGE_RETENTION_DAYS=90
 # 0 또는 음수 시 비활성 (legacy/test 환경).
 # CONSENT_PII_RETENTION_DAYS=90
 
+# GDPR Phase D — 운영자 알림 (14세 미만 가입 대기 시 즉시 알림).
+# Slack/Discord incoming webhook URL. 설정 시 AlertSystem (monitoring/alerts.ts) 가
+# webhook 채널 자동 활성. type=minor_pending_registered 알림이 본 URL 에 POST 됨.
+# 미설정 시 console 채널만 (PM2 logs 에서 확인).
+# OPERATOR_WEBHOOK_URL=https://hooks.slack.com/services/XXX/YYY/ZZZ
+
 # OpenRouter API 호출 타임아웃 (ms, 기본 2분)
 EXTERNAL_PROVIDER_REQUEST_TIMEOUT_MS=120000
 

--- a/backend/api/src/monitoring/alerts.ts
+++ b/backend/api/src/monitoring/alerts.ts
@@ -38,7 +38,8 @@ type AlertType =
     | 'system_overload'
     | 'key_exhausted'
     | 'response_time_spike'
-    | 'error_rate_spike';
+    | 'error_rate_spike'
+    | 'minor_pending_registered';  // GDPR Phase D — 14세 미만 가입 대기
 
 /**
  * 알림 메시지 인터페이스
@@ -135,9 +136,15 @@ export class AlertSystem {
      * @param config - 알림 설정 (부분 지정 가능, 미지정 항목은 기본값 사용)
      */
     constructor(config?: Partial<AlertConfig>) {
+        // env-driven defaults — config 미지정 시 환경변수로 자동 활성.
+        // OPERATOR_WEBHOOK_URL (Slack/Discord incoming webhook) 가 있으면 webhook 채널 자동 추가.
+        const envWebhookUrl = process.env.OPERATOR_WEBHOOK_URL?.trim();
+        const defaultChannels: ('console' | 'email' | 'webhook')[] = ['console'];
+        if (envWebhookUrl) defaultChannels.push('webhook');
+
         this.config = {
             enabled: config?.enabled ?? true,
-            channels: config?.channels ?? ['console'],
+            channels: config?.channels ?? defaultChannels,
             thresholds: {
                 quotaWarningPercent: config?.thresholds?.quotaWarningPercent ?? 70,
                 quotaCriticalPercent: config?.thresholds?.quotaCriticalPercent ?? 90,
@@ -146,7 +153,7 @@ export class AlertSystem {
             },
             cooldownMinutes: config?.cooldownMinutes ?? 15,
             emailConfig: config?.emailConfig,
-            webhookUrl: config?.webhookUrl
+            webhookUrl: config?.webhookUrl ?? envWebhookUrl
         };
 
         // 이메일 전송기 설정

--- a/backend/api/src/services/AuthService.ts
+++ b/backend/api/src/services/AuthService.ts
@@ -162,6 +162,30 @@ export class AuthService {
                     );
                     log.info(`[GDPR-D] 14세 미만 가입 대기 user=${user.id} locale=${locale} age=${age} threshold=${threshold}`);
                     pendingGuardianConsent = true;
+                    // 운영자 알림 — AlertSystem (webhook/email/console 채널, env 자동 활성).
+                    // fire-and-forget: 사용자 응답 지연 방지.
+                    void (async () => {
+                        try {
+                            const { getAlertSystem } = await import('../monitoring/alerts');
+                            await getAlertSystem().sendAlert(
+                                'minor_pending_registered',
+                                'warning',
+                                '14세 미만 가입 대기 (Guardian Verify 필요)',
+                                `사용자 ${user.email} (${user.username || 'no-username'}) — locale=${locale}, age=${age} < ${threshold}. ` +
+                                `법정대리인 이메일: ${data.guardianEmail}. admin 페이지 "🛡️ 14세 미만 동의 보류" 에서 verify 필요.`,
+                                {
+                                    user_id: user.id,
+                                    user_email: user.email,
+                                    locale,
+                                    age,
+                                    threshold,
+                                    guardian_email: data.guardianEmail,
+                                },
+                            );
+                        } catch (alertErr) {
+                            log.error(`[GDPR-D] AlertSystem 호출 실패 (user=${user.id}):`, alertErr);
+                        }
+                    })();
                     // consent_logs 는 아래에서 동일 처리 — 동의 기록은 보존 (verify 후에도 reuse)
                 } else {
                     // 성인 — birth_date 만 저장 (minor_status='adult' 는 default)


### PR DESCRIPTION
## Summary
- GDPR Phase D 의 14세 미만 가입 시 운영자가 신속히 guardian verify 하도록 webhook 알림
- 기존 AlertSystem (monitoring/alerts.ts) 의 webhook 채널 재사용 — 신규 인프라 0
- OPERATOR_WEBHOOK_URL env (Slack/Discord) 만 설정하면 자동 활성

## 변경 파일
- \`backend/api/src/monitoring/alerts.ts\` — AlertType enum 확장 + constructor env 자동 활성
- \`backend/api/src/services/AuthService.ts\` — minor_pending 분기에 sendAlert() 호출
- \`.env.example\` — OPERATOR_WEBHOOK_URL 문서화

## 흐름
1. 14세 미만 가입 → AuthService.register 분기 → guardian_consent_pending INSERT
2. fire-and-forget 으로 \`getAlertSystem().sendAlert('minor_pending_registered', 'warning', ...)\`
3. AlertSystem 이 channels (console + webhook) 별 발송
4. webhook payload: \`{ type, severity, title, message, data: { user_id, user_email, locale, age, threshold, guardian_email }, timestamp }\`

## 설계
- env-driven 자동 활성: OPERATOR_WEBHOOK_URL 만 설정 → 즉시 동작
- 쿨다운 (15분) — 동일 type+severity 중복 방지 (spam 방어)
- 알림 실패 시 가입 자체는 성공 (try/catch + log.error)
- console 채널 항상 포함 — webhook 미설정 환경에서도 PM2 logs 확인 가능

## Test plan
- [x] tsc 0 / eslint 0 / jest 43/43 (auth|consent)
- [ ] **운영자**:
  - Slack incoming webhook URL 발급
  - \`.env\` 에 \`OPERATOR_WEBHOOK_URL=https://hooks.slack.com/...\` 추가
  - PM2 reload --update-env
  - 14세 미만 가입 (test) → Slack 즉시 알림 확인
  - 쿨다운 검증: 15분 내 두번째 가입은 알림 안 옴 (정상)

## 후속 (별도)
- audit_logs INSERT trigger 와 AlertSystem 연동 (더 일반화된 알림)
- 보안 critical event (admin role 변경, 대량 삭제) 알림 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)