### PR TITLE
feat(gdpr): audit_logs whitelist + critical event 자동 알림 — PR #83 확장

### DIFF
--- a/backend/api/src/controllers/admin.controller.ts
+++ b/backend/api/src/controllers/admin.controller.ts
@@ -339,6 +339,22 @@ export class AdminController {
             }
 
             log.info(`사용자 역할 변경: ${user.email} -> ${role}`);
+            // user.role_changed audit (critical, AlertSystem 자동) — admin 권한 변화 가시성
+            void (async () => {
+                try {
+                    const adminId = String('userId' in req.user! ? req.user!.userId : req.user!.id);
+                    const { getAuditService } = await import('../services/AuditService');
+                    await getAuditService().logAudit({
+                        action: 'user.role_changed',
+                        userId: adminId,
+                        resourceType: 'user',
+                        resourceId: userId,
+                        details: { newRole: role, targetEmail: user.email },
+                        ipAddress: req.ip,
+                        userAgent: req.headers['user-agent'],
+                    });
+                } catch (e) { log.warn('[audit] user.role_changed 기록 실패:', e); }
+            })();
             res.json(success({ user }));
         } catch (error) {
             log.error('[Admin Change Role] 오류:', error);
@@ -399,6 +415,20 @@ export class AdminController {
             }
 
             log.info(`사용자 삭제: ID ${userId}`);
+            // GDPR Article 17 — user.deleted audit (critical, AlertSystem 자동)
+            void (async () => {
+                try {
+                    const { getAuditService } = await import('../services/AuditService');
+                    await getAuditService().logAudit({
+                        action: 'user.deleted',
+                        userId: currentUserId,  // admin actor
+                        resourceType: 'user',
+                        resourceId: userId,
+                        ipAddress: req.ip,
+                        userAgent: req.headers['user-agent'],
+                    });
+                } catch (e) { log.warn('[audit] user.deleted 기록 실패:', e); }
+            })();
             res.json(success({ deleted: true }));
         } catch (error) {
             log.error('[Admin Delete User] 오류:', error);

--- a/backend/api/src/controllers/auth.controller.ts
+++ b/backend/api/src/controllers/auth.controller.ts
@@ -91,6 +91,24 @@ export class AuthController {
                 return;
             }
 
+            // GDPR follow-up — user.register audit
+            void (async () => {
+                try {
+                    const { getAuditService } = await import('../services/AuditService');
+                    await getAuditService().logAudit({
+                        action: 'user.register',
+                        userId: result.user?.id,
+                        resourceType: 'user',
+                        resourceId: result.user?.id,
+                        details: {
+                            email: result.user?.email,
+                            pendingGuardianConsent: result.pendingGuardianConsent || false,
+                        },
+                        ipAddress: req.ip,
+                        userAgent: req.headers['user-agent'],
+                    });
+                } catch (e) { log.warn('[audit] user.register 기록 실패:', e); }
+            })();
             res.json(success(result));
         } catch (error) {
             log.error('[Register] 오류:', error);
@@ -108,6 +126,19 @@ export class AuthController {
             const result = await authService.login(req.body);
 
             if (!result.success) {
+                // GDPR follow-up — login.failed audit + brute-force 감지
+                void (async () => {
+                    try {
+                        const { getAuditService } = await import('../services/AuditService');
+                        await getAuditService().logAudit({
+                            action: 'login.failed',
+                            resourceType: 'auth',
+                            details: { email: req.body?.email, reason: result.error },
+                            ipAddress: req.ip,
+                            userAgent: req.headers['user-agent'],
+                        });
+                    } catch (e) { log.warn('[audit] login.failed 기록 실패:', e); }
+                })();
                 res.status(401).json(unauthorized(result.error || '로그인에 실패했습니다'));
                 return;
             }
@@ -203,6 +234,20 @@ export class AuthController {
                 return;
             }
 
+            // GDPR follow-up — password.changed audit (warning severity, AlertSystem 자동)
+            void (async () => {
+                try {
+                    const { getAuditService } = await import('../services/AuditService');
+                    await getAuditService().logAudit({
+                        action: 'password.changed',
+                        userId: String(user.id),
+                        resourceType: 'user',
+                        resourceId: String(user.id),
+                        ipAddress: req.ip,
+                        userAgent: req.headers['user-agent'],
+                    });
+                } catch (e) { log.warn('[audit] password.changed 기록 실패:', e); }
+            })();
             res.json(success(result));
         } catch (error) {
             log.error('[ChangePassword] 오류:', error);

--- a/backend/api/src/controllers/consent.controller.ts
+++ b/backend/api/src/controllers/consent.controller.ts
@@ -147,6 +147,20 @@ export function createConsentController(): Router {
                 [userId, type, version, locale, req.ip || null, req.headers['user-agent'] || null],
             );
             log.info(`[Consent withdraw] user=${userId} type=${type}`);
+            // GDPR Article 7(3) — consent.withdrawn audit (warning, AlertSystem 자동)
+            void (async () => {
+                try {
+                    const { getAuditService } = await import('../services/AuditService');
+                    await getAuditService().logAudit({
+                        action: 'consent.withdrawn',
+                        userId,
+                        resourceType: 'consent',
+                        resourceId: type,
+                        ipAddress: req.ip,
+                        userAgent: req.headers['user-agent'],
+                    });
+                } catch (e) { log.warn('[audit] consent.withdrawn 기록 실패:', e); }
+            })();
             res.json(success({ withdrawn: true, type }));
         } catch (err) {
             log.error('[Consent withdraw] error:', err);
@@ -203,6 +217,21 @@ export function createConsentController(): Router {
                 [userId, type, version, locale, req.ip || null, req.headers['user-agent'] || null],
             );
             log.info(`[Consent grant] user=${userId} type=${type} version=${version}`);
+            // consent.granted audit (info, console 만 — webhook 안 보냄)
+            void (async () => {
+                try {
+                    const { getAuditService } = await import('../services/AuditService');
+                    await getAuditService().logAudit({
+                        action: 'consent.granted',
+                        userId,
+                        resourceType: 'consent',
+                        resourceId: type,
+                        details: { version, locale },
+                        ipAddress: req.ip,
+                        userAgent: req.headers['user-agent'],
+                    });
+                } catch (e) { log.warn('[audit] consent.granted 기록 실패:', e); }
+            })();
             res.json(success({ granted: true, type, version }));
         } catch (err) {
             log.error('[Consent grant] error:', err);

--- a/backend/api/src/controllers/export.controller.ts
+++ b/backend/api/src/controllers/export.controller.ts
@@ -151,6 +151,21 @@ export function createExportController(): Router {
             }
             const data = await collectUserData(userId);
             log.info(`[Export] user=${userId} sessions=${(data._meta as { counts: { conversationSessions: number } }).counts.conversationSessions}`);
+            // GDPR Article 20 — export.requested audit (warning, AlertSystem 자동)
+            void (async () => {
+                try {
+                    const { getAuditService } = await import('../services/AuditService');
+                    await getAuditService().logAudit({
+                        action: 'export.requested',
+                        userId,
+                        resourceType: 'user_data_export',
+                        resourceId: userId,
+                        details: (data._meta as { counts?: unknown })?.counts as Record<string, unknown> | undefined,
+                        ipAddress: req.ip,
+                        userAgent: req.headers['user-agent'],
+                    });
+                } catch (e) { log.warn('[audit] export.requested 기록 실패:', e); }
+            })();
 
             // Content-Disposition 으로 즉시 download. JSON response 가 아닌 attachment 로 처리.
             const date = new Date().toISOString().slice(0, 10);

--- a/backend/api/src/services/AuditService.ts
+++ b/backend/api/src/services/AuditService.ts
@@ -127,6 +127,68 @@ export class AuditService {
             logger.error('Failed to create audit log:', error);
             throw error;
         }
+
+        // GDPR Phase D follow-up — critical event 시 fire-and-forget AlertSystem.
+        // whitelist 만 alert 발송 (chat 등 빈도 높은 event 는 skip).
+        const severity = CRITICAL_ACTIONS[input.action];
+        if (severity) {
+            void sendAlertForAction(input, severity);
+        }
+    }
+}
+
+/**
+ * Critical event whitelist — audit_logs INSERT 시 자동 AlertSystem 호출 대상.
+ * severity 별로 channel 영향: info 는 console 만 (spam 방어), warning+ 는 webhook 도 발송.
+ */
+const CRITICAL_ACTIONS: Record<string, 'info' | 'warning' | 'critical'> = {
+    // GDPR Article 17 (right to erasure) — admin 의 사용자 삭제
+    'user.deleted': 'critical',
+    // 권한 변화 — admin 승격/박탈
+    'user.role_changed': 'critical',
+    // 보안 변화
+    'password.changed': 'warning',
+    // GDPR Article 7(3) — 동의 철회
+    'consent.withdrawn': 'warning',
+    // GDPR Article 20 — 데이터 export 요청 (operator 인지용)
+    'export.requested': 'warning',
+    // 기존 ApiKeyService 패턴 정합
+    'api_key.revoked': 'warning',
+    // info 는 audit 만 (alert webhook 안 보냄)
+    'api_key.created': 'info',
+    'user.register': 'info',
+    'consent.granted': 'info',
+    'login.failed': 'info',
+};
+
+/**
+ * AlertSystem 으로 critical event 알림. info 는 webhook 안 보내고 console 만.
+ * warning+ 는 channel 전체 (console + webhook + email if configured).
+ */
+async function sendAlertForAction(
+    input: CreateAuditLogInput,
+    severity: 'info' | 'warning' | 'critical',
+): Promise<void> {
+    try {
+        const { getAlertSystem } = await import('../monitoring/alerts');
+        // alert type 은 AlertType enum 에 등록된 것만 valid — 동적이라 string cast.
+        // AuditService 의 whitelist 가 SoT.
+        await getAlertSystem().sendAlert(
+            input.action.replace(/\./g, '_') as never,
+            severity,
+            `[audit] ${input.action} by ${input.userId || 'system'}`,
+            `Resource: ${input.resourceType ?? '-'}/${input.resourceId ?? '-'}`,
+            {
+                userId: input.userId,
+                resourceType: input.resourceType,
+                resourceId: input.resourceId,
+                ipAddress: input.ipAddress,
+                userAgent: input.userAgent,
+                ...(input.details ?? {}),
+            },
+        );
+    } catch (err) {
+        logger.error(`[AuditAlert] sendAlert 실패 (action=${input.action}):`, err);
     }
 }
 


### PR DESCRIPTION
## Summary
- PR #83 의 minor_pending webhook 패턴을 8개 critical event 로 일반화
- AuditService.logAudit 안에서 CRITICAL_ACTIONS whitelist hit 시 자동 AlertSystem 트리거
- 신규 8개 호출처에 logAudit INSERT 추가

## 대상 Event (8개 + 기존 api_key.* + minor_pending = 11)
| Action | Severity | 사유 |
|--------|----------|------|
| user.register | info | 신규 가입 가시성 |
| user.deleted | critical | GDPR Article 17 — admin 의 사용자 삭제 |
| user.role_changed | critical | admin 승격/박탈 |
| password.changed | warning | 보안 변화 |
| login.failed | info | brute force 감지 |
| consent.withdrawn | warning | GDPR Article 7(3) |
| consent.granted | info | version bump 추적 |
| export.requested | warning | GDPR Article 20 (data portability) |

## 변경 파일 (5)
- \`backend/api/src/services/AuditService.ts\` — CRITICAL_ACTIONS map + sendAlertForAction
- \`backend/api/src/controllers/auth.controller.ts\` — register/login.failed/changePassword
- \`backend/api/src/controllers/admin.controller.ts\` — deleteUser/changeUserRole
- \`backend/api/src/controllers/consent.controller.ts\` — withdraw/grant
- \`backend/api/src/controllers/export.controller.ts\` — GET /

## 설계
- **Fire-and-forget**: 모든 logAudit + sendAlert 가 사용자 응답 지연 영향 0
- **controller-level audit**: actor 정보 (admin id, IP, UA) 가 controller 에 있음. service signature 변경 회피.
- **15분 cooldown**: AlertSystem 기본 — 동일 type+severity 다발 시 한 번만
- **fail-safe**: logAudit 실패 시 log.warn 만, 사용자 동작 영향 0

## Test plan
- [x] tsc 0 / eslint 0 / jest 54/54 (auth|consent|user-manager|AuditService)
- [ ] **운영자 manual**:
  - 14세 미만 가입 → DB audit_logs (action=user.register) + Slack webhook (info 도 보냄)
  - admin role 변경 → DB + Slack (critical)
  - 사용자 삭제 → DB + Slack (critical)
  - 동의 철회 → DB + Slack (warning)
  - export 요청 → DB + Slack (warning)
  - login 실패 → DB + (warning 이상만 webhook 인 경우 안 옴)

## 후속 (별도)
- audit_logs UI 대시보드 (admin 페이지)
- severity 별 cooldown 차등 (info=skip, warning=15m, critical=즉시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)