### PR TITLE
feat(alerts): severity 별 cooldown 차등 — info/warning/critical 정책 분리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -168,6 +168,15 @@ EXTERNAL_USAGE_RETENTION_DAYS=90
 # 미설정 시 console 채널만 (PM2 logs 에서 확인).
 # OPERATOR_WEBHOOK_URL=https://hooks.slack.com/services/XXX/YYY/ZZZ
 
+# Severity 별 알림 쿨다운 (분). 동일 type+severity 키의 중복 알림 spam 방지.
+# - info: 60분 default — 빈도 높은 register/login_failed/consent_granted spam 회피
+# - warning: 15분 default — 일반 critical event
+# - critical: 1분 default — user_deleted/role_changed 등 즉시 통보
+# console 채널은 cooldown 영향 받음 (webhook 만 spam 방어가 아님)
+# ALERT_COOLDOWN_INFO_MIN=60
+# ALERT_COOLDOWN_WARNING_MIN=15
+# ALERT_COOLDOWN_CRITICAL_MIN=1
+
 # OpenRouter API 호출 타임아웃 (ms, 기본 2분)
 EXTERNAL_PROVIDER_REQUEST_TIMEOUT_MS=120000
 

--- a/backend/api/src/monitoring/alerts.ts
+++ b/backend/api/src/monitoring/alerts.ts
@@ -102,8 +102,15 @@ interface AlertConfig {
         /** 에러율 임계값 (%, 기본 10%) */
         errorRatePercent: number;
     };
-    /** 중복 알림 방지 쿨다운 시간 (분, 기본 15분) */
+    /** 중복 알림 방지 쿨다운 시간 (분, 기본 15분). severity 별 차등 사용 시 무시. */
     cooldownMinutes: number;
+    /**
+     * Severity 별 차등 쿨다운 (분). env 자동 활성:
+     *   - ALERT_COOLDOWN_INFO_MIN (default 60) — 빈도 높은 register/login_failed 등
+     *   - ALERT_COOLDOWN_WARNING_MIN (default 15) — 기본
+     *   - ALERT_COOLDOWN_CRITICAL_MIN (default 1) — user_deleted 등 즉시 알림
+     */
+    cooldownBySeverity?: { info: number; warning: number; critical: number };
 }
 
 /**
@@ -153,7 +160,12 @@ export class AlertSystem {
             },
             cooldownMinutes: config?.cooldownMinutes ?? 15,
             emailConfig: config?.emailConfig,
-            webhookUrl: config?.webhookUrl ?? envWebhookUrl
+            webhookUrl: config?.webhookUrl ?? envWebhookUrl,
+            cooldownBySeverity: config?.cooldownBySeverity ?? {
+                info: parseInt(process.env.ALERT_COOLDOWN_INFO_MIN ?? '60', 10),
+                warning: parseInt(process.env.ALERT_COOLDOWN_WARNING_MIN ?? '15', 10),
+                critical: parseInt(process.env.ALERT_COOLDOWN_CRITICAL_MIN ?? '1', 10),
+            }
         };
 
         // 이메일 전송기 설정
@@ -200,13 +212,14 @@ export class AlertSystem {
     ): Promise<void> {
         if (!this.config.enabled) return;
 
-        // 쿨다운 체크
+        // 쿨다운 체크 — severity 별 차등 cooldown (cooldownBySeverity 우선, fallback cooldownMinutes)
+        const cooldownMin = this.config.cooldownBySeverity?.[severity] ?? this.config.cooldownMinutes;
         const alertKey = `${type}:${severity}`;
         const lastAlert = this.lastAlerts.get(alertKey);
         if (lastAlert) {
             const elapsed = (Date.now() - lastAlert.getTime()) / 1000 / 60;
-            if (elapsed < this.config.cooldownMinutes) {
-                logger.debug(`알림 쿨다운 중: ${alertKey} (${this.config.cooldownMinutes - elapsed}분 남음)`);
+            if (elapsed < cooldownMin) {
+                logger.debug(`알림 쿨다운 중: ${alertKey} severity=${severity} (${(cooldownMin - elapsed).toFixed(1)}분 남음, cooldown=${cooldownMin}분)`);
                 return;
             }
         }


### PR DESCRIPTION
## Summary
- PR #84 의 critical event 알림 spam 방어 — info 빈도 높은 event 가 매 15분마다 webhook 보내는 문제 해결
- AlertSystem 의 cooldown 을 severity 별 차등 (info=60min / warning=15min / critical=1min)

## 변경 파일
- \`backend/api/src/monitoring/alerts.ts\` — \`cooldownBySeverity\` config + sendAlert 분기
- \`.env.example\` — 3개 env 문서화

## Default 정책
| Severity | Cooldown | 의도 |
|----------|----------|------|
| info | 60min | 빈도 높은 event (register, login_failed, consent_granted) spam 회피 |
| warning | 15min | 기존 default — 일반 critical event |
| critical | 1min | user_deleted/role_changed 즉시 통보 |

## env override
- \`ALERT_COOLDOWN_INFO_MIN=60\`
- \`ALERT_COOLDOWN_WARNING_MIN=15\`
- \`ALERT_COOLDOWN_CRITICAL_MIN=1\`

## 설계
- AlertSystem channels (console + webhook + email) 영향 0 — cooldown 만 차등
- console 채널도 cooldown 영향 받음 (PM2 logs spam 도 함께 줄어듦)
- backwards compat: \`cooldownMinutes\` (단일값) 도 유지 — cooldownBySeverity 미설정 시 fallback

## Test plan
- [x] tsc 0 / eslint 0 / jest 71/71 (auth|consent|alert 회귀)
- [ ] **운영자 manual**:
  - PM2 reload
  - critical event 빠른 연속 발생 → 첫 번째만 webhook, 두 번째 cooldown 로그
  - info event 1회 발생 후 30분 내 두 번째 → cooldown 로그 확인
  - log 메시지: \`쿨다운 중: ... severity=info ... 60.0 - X.X 분 남음\`

## 후속
- alert sender (actor) 트래킹
- Slack channel 별 severity 라우팅 (info → #ops-info, critical → #ops-alerts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)