### PR TITLE
feat(alerts): alert sender tracking — actor 정보로 webhook payload 풍부화

### DIFF
--- a/backend/api/src/controllers/admin.controller.ts
+++ b/backend/api/src/controllers/admin.controller.ts
@@ -355,6 +355,10 @@ export class AdminController {
                         details: { newRole: role, targetEmail: user.email },
                         ipAddress: req.ip,
                         userAgent: req.headers['user-agent'],
+                        actor: {
+                            email: 'email' in req.user! ? (req.user as { email?: string }).email : undefined,
+                            role: 'role' in req.user! ? (req.user as { role?: string }).role : undefined,
+                        },
                     });
                 } catch (e) { log.warn('[audit] user.role_changed 기록 실패:', e); }
             })();
@@ -429,6 +433,10 @@ export class AdminController {
                         resourceId: userId,
                         ipAddress: req.ip,
                         userAgent: req.headers['user-agent'],
+                        actor: {
+                            email: 'email' in req.user! ? (req.user as { email?: string }).email : undefined,
+                            role: 'role' in req.user! ? (req.user as { role?: string }).role : undefined,
+                        },
                     });
                 } catch (e) { log.warn('[audit] user.deleted 기록 실패:', e); }
             })();

--- a/backend/api/src/controllers/auth.controller.ts
+++ b/backend/api/src/controllers/auth.controller.ts
@@ -106,6 +106,8 @@ export class AuthController {
                         },
                         ipAddress: req.ip,
                         userAgent: req.headers['user-agent'],
+                        // 신규 가입자 본인 = actor (admin 아님)
+                        actor: { email: result.user?.email, role: result.user?.role },
                     });
                 } catch (e) { log.warn('[audit] user.register 기록 실패:', e); }
             })();
@@ -136,6 +138,8 @@ export class AuthController {
                             details: { email: req.body?.email, reason: result.error },
                             ipAddress: req.ip,
                             userAgent: req.headers['user-agent'],
+                            // 실패 — req.user 없음. 시도한 email 만 actor 로 표시.
+                            actor: { email: req.body?.email },
                         });
                     } catch (e) { log.warn('[audit] login.failed 기록 실패:', e); }
                 })();
@@ -245,6 +249,10 @@ export class AuthController {
                         resourceId: String(user.id),
                         ipAddress: req.ip,
                         userAgent: req.headers['user-agent'],
+                        actor: {
+                            email: user.email,
+                            role: 'role' in user ? (user as { role?: string }).role : undefined,
+                        },
                     });
                 } catch (e) { log.warn('[audit] password.changed 기록 실패:', e); }
             })();

--- a/backend/api/src/controllers/consent.controller.ts
+++ b/backend/api/src/controllers/consent.controller.ts
@@ -158,6 +158,10 @@ export function createConsentController(): Router {
                         resourceId: type,
                         ipAddress: req.ip,
                         userAgent: req.headers['user-agent'],
+                        actor: {
+                            email: req.user && 'email' in req.user ? (req.user as { email?: string }).email : undefined,
+                            role: req.user && 'role' in req.user ? (req.user as { role?: string }).role : undefined,
+                        },
                     });
                 } catch (e) { log.warn('[audit] consent.withdrawn 기록 실패:', e); }
             })();
@@ -229,6 +233,10 @@ export function createConsentController(): Router {
                         details: { version, locale },
                         ipAddress: req.ip,
                         userAgent: req.headers['user-agent'],
+                        actor: {
+                            email: req.user && 'email' in req.user ? (req.user as { email?: string }).email : undefined,
+                            role: req.user && 'role' in req.user ? (req.user as { role?: string }).role : undefined,
+                        },
                     });
                 } catch (e) { log.warn('[audit] consent.granted 기록 실패:', e); }
             })();

--- a/backend/api/src/controllers/export.controller.ts
+++ b/backend/api/src/controllers/export.controller.ts
@@ -163,6 +163,10 @@ export function createExportController(): Router {
                         details: (data._meta as { counts?: unknown })?.counts as Record<string, unknown> | undefined,
                         ipAddress: req.ip,
                         userAgent: req.headers['user-agent'],
+                        actor: {
+                            email: req.user && 'email' in req.user ? (req.user as { email?: string }).email : undefined,
+                            role: req.user && 'role' in req.user ? (req.user as { role?: string }).role : undefined,
+                        },
                     });
                 } catch (e) { log.warn('[audit] export.requested 기록 실패:', e); }
             })();

--- a/backend/api/src/services/AuditService.ts
+++ b/backend/api/src/services/AuditService.ts
@@ -27,6 +27,15 @@ export interface CreateAuditLogInput {
     details?: Record<string, unknown>;
     ipAddress?: string;
     userAgent?: string;
+    /**
+     * Alert sender tracking (PR follow-up) — actor 의 풍부한 정보. sendAlertForAction 에서
+     * webhook payload 의 title/message 가독성 향상에 사용. DB INSERT 시 details 에 자동 병합.
+     */
+    actor?: {
+        email?: string;
+        username?: string;
+        role?: string;
+    };
 }
 
 export class AuditService {
@@ -114,12 +123,16 @@ export class AuditService {
     async logAudit(input: CreateAuditLogInput): Promise<void> {
         const db = getUnifiedDatabase();
         try {
+            // actor 정보를 details 에 병합 (DB 영속화 — webhook 외 audit 조회 시도 표시)
+            const mergedDetails = input.actor
+                ? { ...(input.details ?? {}), actor: input.actor }
+                : input.details;
             await db.logAudit({
                 action: input.action,
                 userId: input.userId,
                 resourceType: input.resourceType,
                 resourceId: input.resourceId,
-                details: input.details,
+                details: mergedDetails,
                 ipAddress: input.ipAddress,
                 userAgent: input.userAgent,
             });
@@ -173,12 +186,19 @@ async function sendAlertForAction(
         const { getAlertSystem } = await import('../monitoring/alerts');
         // alert type 은 AlertType enum 에 등록된 것만 valid — 동적이라 string cast.
         // AuditService 의 whitelist 가 SoT.
+        // Actor 정보 풍부화 — email > username > userId 우선순위로 표시명 + role 명시.
+        const actorDisplay = input.actor?.email
+            || input.actor?.username
+            || input.userId
+            || 'system';
+        const roleSuffix = input.actor?.role ? ` (${input.actor.role})` : '';
         await getAlertSystem().sendAlert(
             input.action.replace(/\./g, '_') as never,
             severity,
-            `[audit] ${input.action} by ${input.userId || 'system'}`,
-            `Resource: ${input.resourceType ?? '-'}/${input.resourceId ?? '-'}`,
+            `[audit] ${input.action} by ${actorDisplay}${roleSuffix}`,
+            `Resource: ${input.resourceType ?? '-'}/${input.resourceId ?? '-'} | IP: ${input.ipAddress ?? '-'}`,
             {
+                actor: input.actor,
                 userId: input.userId,
                 resourceType: input.resourceType,
                 resourceId: input.resourceId,


### PR DESCRIPTION
## Summary

PR #84 의 alert payload 에 actor 의 email/role 추가. 운영자가 webhook 받을 때
\`by user-3\` 같은 ID 만 보는 대신 \`by alice@example.com (admin)\` 즉시 확인.

## Changes

**Core (AuditService.ts)**
- \`CreateAuditLogInput\` 에 \`actor?: { email?, username?, role? }\` 옵션 추가
- \`logAudit()\` 가 actor 를 details 에 자동 병합 → DB audit_logs.details.actor 영속화 (admin 대시보드도 조회 가능)
- \`sendAlertForAction()\` title/message 풍부화:
  - title: \`[audit] {action} by {email|username|userId} ({role})\`
  - message: Resource + IP 정보
  - data payload 에 actor 객체 그대로 포함

**Controllers (8개 logAudit 호출 패턴 통일)**
- \`admin.controller.ts\` — user.deleted, user.role_changed (관리자 actor)
- \`auth.controller.ts\` — user.register (가입자 본인), login.failed (req.body.email), password.changed
- \`consent.controller.ts\` — consent.withdrawn, consent.granted
- \`export.controller.ts\` — export.requested

## Design

- actor 가 details 에 병합되어 DB 에 영속화 — 운영자가 admin 대시보드 (PR #85) 에서도 actor 정보 확인 가능
- DB query 추가 없음 — controller 가 보유한 \`req.user\` 만 사용
- type guard \`'email' in req.user\` 로 type 안전성 유지

## Test plan
- [x] tsc 0 / eslint 0 (기존 1 warning)
- [x] jest 75/75 통과 (auth/consent/alert/user-manager 회귀)
- [ ] (운영자 manual): admin 사용자 삭제 → Slack webhook title 변화 확인
  - 이전: \`[audit] user.deleted by user-3\`
  - 이후: \`[audit] user.deleted by admin@example.com (admin)\`

## Follow-up
- Slack channel 별 severity 라우팅 (별도 plan)
- actor IP geolocation (별도)

🤖 Generated with [Claude Code](https://claude.com/claude-code)