### PR TITLE
feat(retention): audit_logs/alert_history PII 익명화 — Article 5(1)(c)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -162,6 +162,16 @@ EXTERNAL_USAGE_RETENTION_DAYS=90
 # 0 또는 음수 시 비활성 (legacy/test 환경).
 # CONSENT_PII_RETENTION_DAYS=90
 
+# audit_logs PII 익명화 기간 (일, 기본 90일).
+# timestamp 기준 N일 후 ip_address/user_agent NULL + details.actor (email/role) 제거.
+# action/user_id/resource_* 는 보존 (Article 30 record of processing).
+# AUDIT_PII_RETENTION_DAYS=90
+
+# alert_history PII 익명화 기간 (일, 기본 90일).
+# created_at 기준 N일 후 data.actor/ipAddress/userAgent 제거 (JSONB minus).
+# type/severity/title/message/data.userId 는 보존.
+# ALERT_PII_RETENTION_DAYS=90
+
 # GDPR Phase D — 운영자 알림 (14세 미만 가입 대기 시 즉시 알림).
 # Slack/Discord incoming webhook URL. 설정 시 AlertSystem (monitoring/alerts.ts) 가
 # webhook 채널 자동 활성. type=minor_pending_registered 알림이 본 URL 에 POST 됨.

--- a/backend/api/src/data/db-retention.ts
+++ b/backend/api/src/data/db-retention.ts
@@ -10,6 +10,9 @@
  * - oauth_states                    : 10분 이상 경과한 OAuth state 삭제
  * - external_provider_usage         : EXTERNAL_USAGE_RETENTION_DAYS(기본 90일) 보존
  * - external_provider_models_cache  : 7일 이상 stale 항목 정리 (TTL 만료 후 누적 방지)
+ * - consent_logs                    : CONSENT_PII_RETENTION_DAYS(기본 90일) 초과 ip/ua NULL (GDPR Article 5(1)(c))
+ * - audit_logs                      : AUDIT_PII_RETENTION_DAYS(기본 90일) 초과 ip/ua NULL + details.actor 제거
+ * - alert_history                   : ALERT_PII_RETENTION_DAYS(기본 90일) 초과 data.actor/ipAddress/userAgent 제거
  *
  * @module data/db-retention
  */
@@ -101,6 +104,50 @@ async function runRetention(): Promise<void> {
             );
             if ((consentResult.rowCount ?? 0) > 0) {
                 logger.info(`[DbRetention] consent_logs PII 익명화 ${consentResult.rowCount}건 완료 (${consentRetentionDays}일 초과)`);
+            }
+        }
+
+        // 7. audit_logs PII 익명화 (Article 5(1)(c) data minimization)
+        // 보존: action / user_id / resource_* / timestamp (Article 30 record of processing)
+        // 제거: ip_address / user_agent column + details.actor (PR #87 의 email/role)
+        // 행 삭제 안 함 — audit 사실 자체는 영구 보존, PII 만 제거.
+        const auditRetentionDays = parseInt(
+            process.env.AUDIT_PII_RETENTION_DAYS ?? '90',
+            10,
+        );
+        if (Number.isFinite(auditRetentionDays) && auditRetentionDays > 0) {
+            const auditResult = await pool.query(
+                `UPDATE audit_logs
+                 SET ip_address = NULL,
+                     user_agent = NULL,
+                     details = COALESCE(details, '{}'::jsonb) - 'actor'
+                 WHERE timestamp < NOW() - ($1 || ' days')::interval
+                   AND (ip_address IS NOT NULL OR user_agent IS NOT NULL OR (details ? 'actor'))`,
+                [auditRetentionDays.toString()]
+            );
+            if ((auditResult.rowCount ?? 0) > 0) {
+                logger.info(`[DbRetention] audit_logs PII 익명화 ${auditResult.rowCount}건 완료 (${auditRetentionDays}일 초과)`);
+            }
+        }
+
+        // 8. alert_history PII 익명화 (Article 5(1)(c) data minimization)
+        // 보존: type / severity / title / message / created_at / acknowledged_*
+        // 제거: data.actor (email/role) + data.ipAddress + data.userAgent
+        // data.userId 는 audit 식별성에 필수라 보존.
+        const alertRetentionDays = parseInt(
+            process.env.ALERT_PII_RETENTION_DAYS ?? '90',
+            10,
+        );
+        if (Number.isFinite(alertRetentionDays) && alertRetentionDays > 0) {
+            const alertResult = await pool.query(
+                `UPDATE alert_history
+                 SET data = COALESCE(data, '{}'::jsonb) - 'actor' - 'ipAddress' - 'userAgent'
+                 WHERE created_at < NOW() - ($1 || ' days')::interval
+                   AND (data ? 'actor' OR data ? 'ipAddress' OR data ? 'userAgent')`,
+                [alertRetentionDays.toString()]
+            );
+            if ((alertResult.rowCount ?? 0) > 0) {
+                logger.info(`[DbRetention] alert_history PII 익명화 ${alertResult.rowCount}건 완료 (${alertRetentionDays}일 초과)`);
             }
         }
 


### PR DESCRIPTION
## Summary

PR #76 의 consent_logs PII 익명화 패턴 확장. audit_logs / alert_history 도
N일 (default 90) 초과 시 PII 자동 제거. 행 삭제 안 함 — Article 30
record of processing 정합.

## Changes

**\`backend/api/src/data/db-retention.ts\`**
- \`runRetention()\` step 7, 8 추가
- **audit_logs**:
  - \`ip_address\`/\`user_agent\` → NULL
  - \`details.actor\` (PR #87 의 email/role) → JSONB minus (\`-\`) 제거
  - 보존: action / user_id / resource_* / timestamp
  - env: \`AUDIT_PII_RETENTION_DAYS\` (default 90)
- **alert_history**:
  - \`data.actor\` + \`data.ipAddress\` + \`data.userAgent\` → JSONB minus
  - 보존: type / severity / title / message / data.userId (audit 식별성)
  - env: \`ALERT_PII_RETENTION_DAYS\` (default 90)
- 헤더 주석 대상 테이블 list 갱신

**\`.env.example\`** — 신규 env 2개 문서화

## Design 결정

- **행 삭제 안 함** — audit 사실 자체는 영구 보존 (Article 30). PII 만 제거
- **userId 보존** — internal ID 라 단독 식별 어려움, audit 식별성 필수
- **details.actor / data.actor 만 제거** (PR #87 추가 필드) — legacy log 영향 0
- **JSONB minus operator** \`-\` — top-level key 제거, nested 안 건드림
- \`COALESCE(details, '{}'::jsonb) - 'actor'\` — NULL details 안전 처리
- \`AND (...?'actor')\` — actor 없는 row 는 UPDATE 안 함 (불필요 write 회피)

## Test plan
- [x] tsc 0 / eslint 0
- [x] ad-hoc dry-run (SELECT):
  - SQL syntax valid
  - production 90일 초과 PII row: audit=0, alert=0
  - JSONB minus 동작: \`{actor, userId, ipAddress}\` → \`{userId}\`
- [ ] (운영자) PM2 reload 후 1시간 후 logger 확인 (DbRetention step 7/8)
- [ ] 90일 후 실제 익명화 발동 시 audit_logs/alert_history.details/data 결과 확인

## Follow-up
- audit_logs.details 안의 다른 PII 키 (workflow 별 custom field) 가 발견되면 minus key list 확장
- legal counsel review 시 retention period 조정 (현재 90일 일관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)