### PR TITLE
feat(audit-ui): CSV export — 운영자 reporting/compliance 편의

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -172,6 +172,10 @@ EXTERNAL_USAGE_RETENTION_DAYS=90
 # type/severity/title/message/data.userId 는 보존.
 # ALERT_PII_RETENTION_DAYS=90
 
+# audit_logs CSV export 최대 row 수 (admin 전용 GET /api/audit/export).
+# 무거운 query 방어 — 큰 export 는 paged 호출로 분할 권장.
+# AUDIT_CSV_MAX_ROWS=10000
+
 # GDPR Phase D — 운영자 알림 (14세 미만 가입 대기 시 즉시 알림).
 # Slack/Discord incoming webhook URL. 설정 시 AlertSystem (monitoring/alerts.ts) 가
 # webhook 채널 자동 활성. type=minor_pending_registered 알림이 본 URL 에 POST 됨.

--- a/backend/api/src/routes/audit.routes.ts
+++ b/backend/api/src/routes/audit.routes.ts
@@ -10,6 +10,7 @@
  * @module routes/audit.routes
  * @description
  * - GET  /api/audit               - 감사 로그 목록 조회 (필터: action, userId, limit)
+ * - GET  /api/audit/export        - 감사 로그 CSV download (동일 filter)
  * - GET  /api/audit/actions       - 감사 로그 액션 타입 목록
  * - GET  /api/audit/user/:userId  - 특정 사용자 감사 로그 조회
  * - POST /api/audit               - 감사 로그 엔트리 생성
@@ -58,6 +59,57 @@ router.get('/', asyncHandler(async (req: Request, res: Response) => {
          offset,
      });
      res.json(success({ logs, total }));
+}));
+
+/**
+ * GET /api/audit/export
+ * 감사 로그 CSV download (관리자 전용)
+ *
+ * 현재 GET / 와 동일 filter (startDate/endDate/action/userId) 지원.
+ * 무거운 query 방어: limit 강제 max AUDIT_CSV_MAX_ROWS (default 10000).
+ * 출력 형식: UTF-8 BOM + CSV (Excel 한글 호환, RFC 4180 escape).
+ */
+router.get('/export', asyncHandler(async (req: Request, res: Response) => {
+    const maxRows = parseInt(process.env.AUDIT_CSV_MAX_ROWS ?? '10000', 10);
+    const startDate = req.query.startDate as string | undefined;
+    const endDate = req.query.endDate as string | undefined;
+    const action = req.query.action as string | undefined;
+    const userId = req.query.userId as string | undefined;
+
+    const { logs } = await auditService.getAuditLogs({
+        startDate,
+        endDate,
+        action,
+        userId,
+        limit: maxRows,
+        offset: 0,
+    });
+
+    // RFC 4180: 큰따옴표는 "" 로 escape, 모든 필드를 "" 로 감쌈
+    const esc = (v: unknown): string => {
+        if (v === null || v === undefined) return '""';
+        const s = typeof v === 'string' ? v : JSON.stringify(v);
+        return `"${s.replace(/"/g, '""')}"`;
+    };
+
+    const header = ['id', 'timestamp', 'action', 'user_id', 'resource_type', 'resource_id', 'ip_address', 'user_agent', 'details'].join(',');
+    const rows = (logs as Array<Record<string, unknown>>).map(row => [
+        esc(row.id),
+        esc(row.timestamp instanceof Date ? row.timestamp.toISOString() : row.timestamp),
+        esc(row.action),
+        esc(row.user_id),
+        esc(row.resource_type),
+        esc(row.resource_id),
+        esc(row.ip_address),
+        esc(row.user_agent),
+        esc(row.details),
+    ].join(','));
+    const csv = '﻿' + [header, ...rows].join('\n');  // UTF-8 BOM
+
+    const date = new Date().toISOString().slice(0, 10);
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename="audit_logs_${date}.csv"`);
+    res.send(csv);
 }));
 
 /**

--- a/frontend/web/public/js/modules/pages/audit.js
+++ b/frontend/web/public/js/modules/pages/audit.js
@@ -82,6 +82,7 @@
                             <select id="filterLimit"><option value="50" selected>50개</option><option value="100">100개</option><option value="200">200개</option></select>
                         </div>
                         <button class="btn-primary" onclick="loadLogs(1)">조회</button>
+                        <button class="btn-secondary" onclick="exportLogsCsv()" title="현재 필터 조건으로 최대 10000건 CSV 다운로드">📥 CSV</button>
                     </div>
                     <div id="logCount" class="log-count"></div>
                     <div class="table-wrapper">
@@ -219,6 +220,34 @@
                     }
                 }
 
+                async function exportLogsCsv() {
+                    const action = document.getElementById('filterAction').value;
+                    const userId = document.getElementById('filterUser').value.trim();
+                    let url = API_ENDPOINTS.AUDIT + '/export';
+                    const params = [];
+                    if (action) params.push('action=' + encodeURIComponent(action));
+                    if (userId) params.push('userId=' + encodeURIComponent(userId));
+                    if (params.length) url += '?' + params.join('&');
+                    try {
+                        // window.authFetch 직접 사용 — 본 module 의 authFetch wrapper 는 항상 JSON.parse 라 binary 부적합
+                        const res = await window.authFetch(url);
+                        if (!res.ok) { showToast('CSV export 실패: HTTP ' + res.status, 'error'); return; }
+                        const blob = await res.blob();
+                        const blobUrl = URL.createObjectURL(blob);
+                        const a = document.createElement('a');
+                        a.href = blobUrl;
+                        a.download = 'audit_logs_' + new Date().toISOString().slice(0, 10) + '.csv';
+                        document.body.appendChild(a);
+                        a.click();
+                        document.body.removeChild(a);
+                        URL.revokeObjectURL(blobUrl);
+                        showToast('CSV 다운로드 완료', 'success');
+                    } catch (e) {
+                        console.error('[Audit] CSV export 실패:', e);
+                        showToast('CSV export 실패', 'error');
+                    }
+                }
+
                 function openDetail(idx) {
                     const l = logs[idx];
                     if (!l) return;
@@ -288,6 +317,7 @@
                 if (typeof openDetail === 'function') window.openDetail = openDetail;
                 if (typeof switchAuditSubTab === 'function') window.switchAuditSubTab = switchAuditSubTab;
                 if (typeof loadAlertHistory === 'function') window.loadAlertHistory = loadAlertHistory;
+                if (typeof exportLogsCsv === 'function') window.exportLogsCsv = exportLogsCsv;
             } catch (e) {
                 console.error('[PageModule:audit] init error:', e);
             }
@@ -304,6 +334,7 @@
             try { delete window.openDetail; } catch (e) { }
             try { delete window.switchAuditSubTab; } catch (e) { }
             try { delete window.loadAlertHistory; } catch (e) { }
+            try { delete window.exportLogsCsv; } catch (e) { }
             try { delete window.__alertHistoryLoaded; } catch (e) { }
         }
     };


### PR DESCRIPTION
## Summary

PR #85 의 audit dashboard 후속. audit_logs 의 현재 filter 조건으로 CSV
다운로드 — legal compliance 및 운영자 reporting 편의.

## Changes

**\`backend/api/src/routes/audit.routes.ts\`**
- 신규 \`GET /api/audit/export\` (admin 전용, 기존 \`requireAuth+requireAdmin\` 공통 미들웨어)
- 동일 filter (startDate/endDate/action/userId)
- 무거운 query 방어: \`AUDIT_CSV_MAX_ROWS\` env (default 10000) 강제 limit
- 응답: **UTF-8 BOM** + RFC 4180 CSV escape
- columns: id / timestamp / action / user_id / resource_type / resource_id / ip_address / user_agent / details(JSON)
- \`Content-Disposition\` attachment + date suffix

**\`frontend/web/public/js/modules/pages/audit.js\`**
- audit_logs panel 의 filter bar 에 \`📥 CSV\` 버튼
- 신규 \`exportLogsCsv()\` — \`window.authFetch\` 직접 사용 (module wrapper 는 JSON.parse 라 binary 부적합)
- blob → \`URL.createObjectURL\` → anchor click 다운로드 패턴
- window 노출 + cleanup 추가

**\`.env.example\`** — \`AUDIT_CSV_MAX_ROWS\` 문서화

## Design 결정

- **admin 전용** — routes 최상위 \`requireAdmin\` 가드. PII (actor/ip/ua) 포함 OK
- **BOM** — Excel 한글 깨짐 방지 (UTF-8 BOM 표준)
- **RFC 4180** — details JSONB 의 쌍따옴표/줄바꿈 안전 처리
- **Max rows env** — 큰 dataset 운영 시 paged export 권장. 더 큰 export 필요 시 운영자가 env 조정
- **별도 rate limit 미적용** — admin 전용이라 abuse risk 낮음, 추후 필요 시 추가

## Test plan
- [x] tsc 0 / eslint 0
- [x] frontend validate-modules 통과
- [ ] (운영자 manual): admin → 감사 로그 → \`📥 CSV\` 클릭 → \`audit_logs_YYYY-MM-DD.csv\` 다운로드 → Excel/Numbers 에서 한글/JSON 정상 표시

## Follow-up
- rate limit (시간당 N회) 추가 검토
- alert_history CSV export (별도 PR — 동일 패턴)
- 큰 export 의 streaming (PostgreSQL cursor + Node Readable) — 100k+ row

🤖 Generated with [Claude Code](https://claude.com/claude-code)