### PR TITLE
feat(alert-ui): acknowledge UI — 운영자 확인 처리 + cooldown 외 표시

### DIFF
--- a/backend/api/src/controllers/admin.controller.ts
+++ b/backend/api/src/controllers/admin.controller.ts
@@ -57,6 +57,8 @@ export class AdminController {
 
         // GDPR Phase D follow-up — alert_history 조회 (admin dashboard 용)
         this.router.get('/alerts/history', this.listAlertHistory.bind(this));
+        // alert_history acknowledge (확인 처리) — 운영자 ID/시간 기록
+        this.router.post('/alerts/:id/acknowledge', this.acknowledgeAlert.bind(this));
 
         // 관리자용 대화 목록 (모든 사용자 대화 조회)
         this.router.get('/stats', this.getStats.bind(this));
@@ -524,6 +526,8 @@ export class AdminController {
             const severity = req.query.severity ? String(req.query.severity) : null;
             const startDate = req.query.startDate ? String(req.query.startDate) : null;
             const endDate = req.query.endDate ? String(req.query.endDate) : null;
+            // acknowledged 필터: 'true'/'false' string, 미설정 시 전체
+            const ackParam = req.query.acknowledged !== undefined ? String(req.query.acknowledged) : null;
 
             const conditions: string[] = [];
             const params: unknown[] = [];
@@ -532,6 +536,8 @@ export class AdminController {
             if (severity) { conditions.push(`severity = $${idx++}`); params.push(severity); }
             if (startDate) { conditions.push(`created_at >= $${idx++}`); params.push(startDate); }
             if (endDate) { conditions.push(`created_at <= $${idx++}`); params.push(endDate); }
+            if (ackParam === 'true') { conditions.push(`acknowledged = TRUE`); }
+            else if (ackParam === 'false') { conditions.push(`acknowledged = FALSE`); }
             const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
 
             const { getPool } = await import('../data/models/unified-database');
@@ -543,7 +549,8 @@ export class AdminController {
             const total = parseInt(totalRes.rows[0]?.count ?? '0', 10);
 
             const dataRes = await pool.query(
-                `SELECT id, type, severity, title, message, data, created_at
+                `SELECT id, type, severity, title, message, data, created_at,
+                        acknowledged, acknowledged_by, acknowledged_at
                  FROM alert_history ${whereClause}
                  ORDER BY created_at DESC
                  LIMIT $${idx++} OFFSET $${idx++}`,
@@ -553,6 +560,76 @@ export class AdminController {
         } catch (error) {
             log.error('[Admin AlertHistory] 오류:', error);
             res.status(500).json(internalError('알림 이력 조회 실패'));
+        }
+    }
+
+    /**
+     * POST /api/admin/alerts/:id/acknowledge — alert_history 행 ack 처리.
+     * 이미 ack 된 row 는 idempotent (no-op, 기존 ack 정보 그대로 반환).
+     * 운영자 ID + 시간 기록으로 알림 처리 추적.
+     */
+    private async acknowledgeAlert(req: Request, res: Response): Promise<void> {
+        try {
+            const id = parseInt(req.params.id, 10);
+            if (!Number.isFinite(id) || id <= 0) {
+                res.status(400).json(badRequest('잘못된 alert id'));
+                return;
+            }
+            const userId = req.user && 'id' in req.user ? String((req.user as { id?: string | number }).id) : null;
+            if (!userId) {
+                res.status(401).json({ success: false, error: { code: 'UNAUTHORIZED', message: '인증 필요' } });
+                return;
+            }
+
+            const { getPool } = await import('../data/models/unified-database');
+            const pool = getPool();
+            // acknowledged=FALSE 인 row 만 UPDATE — 중복 ack 시 정보 덮어쓰기 방지
+            const r = await pool.query(
+                `UPDATE alert_history
+                 SET acknowledged = TRUE, acknowledged_by = $1, acknowledged_at = NOW()
+                 WHERE id = $2 AND acknowledged = FALSE
+                 RETURNING id, type, severity, title, acknowledged, acknowledged_by, acknowledged_at`,
+                [userId, id],
+            );
+            if (r.rowCount === 0) {
+                // 이미 ack 됐거나 id 없음 — 현재 상태 조회 후 반환 (idempotent)
+                const cur = await pool.query(
+                    `SELECT id, type, severity, title, acknowledged, acknowledged_by, acknowledged_at
+                     FROM alert_history WHERE id = $1`,
+                    [id],
+                );
+                if (cur.rowCount === 0) {
+                    res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: 'alert 없음' } });
+                    return;
+                }
+                res.json(success({ alert: cur.rows[0], alreadyAcknowledged: true }));
+                return;
+            }
+
+            // audit_logs INSERT — fire-and-forget (CRITICAL_ACTIONS whitelist 외라 alert 자체는 안 보냄)
+            void (async () => {
+                try {
+                    const { getAuditService } = await import('../services/AuditService');
+                    await getAuditService().logAudit({
+                        action: 'alert.acknowledged',
+                        userId,
+                        resourceType: 'alert',
+                        resourceId: String(id),
+                        details: { type: r.rows[0].type, severity: r.rows[0].severity },
+                        ipAddress: req.ip,
+                        userAgent: req.headers['user-agent'],
+                        actor: {
+                            email: req.user && 'email' in req.user ? (req.user as { email?: string }).email : undefined,
+                            role: req.user && 'role' in req.user ? (req.user as { role?: string }).role : undefined,
+                        },
+                    });
+                } catch (e) { log.warn('[audit] alert.acknowledged 기록 실패:', e); }
+            })();
+
+            res.json(success({ alert: r.rows[0], alreadyAcknowledged: false }));
+        } catch (error) {
+            log.error('[Admin AlertAck] 오류:', error);
+            res.status(500).json(internalError('알림 확인 처리 실패'));
         }
     }
 

--- a/frontend/web/public/js/modules/pages/audit.js
+++ b/frontend/web/public/js/modules/pages/audit.js
@@ -18,7 +18,7 @@
         getHTML: function () {
             return '<div class="page-audit">' +
                 '<style data-spa-style="audit">' +
-                ".filter-bar { display:flex; gap:var(--space-3); align-items:flex-end; flex-wrap:wrap; margin-bottom:var(--space-5); background:var(--bg-card); border:1px solid var(--border-light); border-radius:var(--radius-lg); padding:var(--space-4); }\n        .filter-bar .fg { display:flex; flex-direction:column; gap:var(--space-1); }\n        .filter-bar label { color:var(--text-muted); font-size:var(--font-size-sm); font-weight:var(--font-weight-semibold); }\n        .filter-bar select, .filter-bar input { padding:var(--space-2) var(--space-3); background:var(--bg-secondary); border:1px solid var(--border-light); border-radius:var(--radius-md); color:var(--text-primary); font-size:14px; }\n        .filter-bar .btn-primary { padding:var(--space-2) var(--space-4); background:var(--accent-primary); color:#fff; border:none; border-radius:var(--radius-md); cursor:pointer; font-weight:var(--font-weight-semibold); align-self:flex-end; }\n        .table-wrapper { overflow-x:auto; background:var(--bg-card); border:1px solid var(--border-light); border-radius:var(--radius-lg); }\n        .log-table { width:100%; border-collapse:collapse; min-width:700px; }\n        .log-table th { text-align:left; padding:var(--space-3); color:var(--text-muted); font-size:var(--font-size-sm); font-weight:var(--font-weight-semibold); border-bottom:2px solid var(--border-light); position:sticky; top:0; background:var(--bg-secondary); }\n        .log-table td { padding:var(--space-3); border-bottom:1px solid var(--border-light); color:var(--text-secondary); font-size:var(--font-size-sm); vertical-align:top; }\n        .log-table tr:hover { background:var(--bg-tertiary); cursor:pointer; }\n        .badge { display:inline-block; padding:2px 8px; border-radius:var(--radius-md); font-size:11px; font-weight:var(--font-weight-semibold); }\n        .badge-auth { background:var(--accent-primary); color:#fff; }\n        .badge-create { background:var(--success); color:#fff; }\n        .badge-delete { background:var(--danger); color:#fff; }\n        .badge-update { background:var(--warning); color:#000; }\n        .badge-default { background:var(--bg-tertiary); color:var(--text-secondary); }\n        .badge-severity-info { background:var(--info,#3b82f6); color:#fff; }\n        .badge-severity-warning { background:var(--warning,#f59e0b); color:#000; }\n        .badge-severity-critical { background:var(--danger,#ef4444); color:#fff; animation: badgePulse 1.5s ease-in-out infinite; }\n        @keyframes badgePulse { 0%,100% { box-shadow:0 0 0 0 rgba(239,68,68,.6); } 50% { box-shadow:0 0 0 4px rgba(239,68,68,0); } }\n        .detail-cell { max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--text-muted); }\n        .log-count { color:var(--text-muted); font-size:var(--font-size-sm); margin-bottom:var(--space-3); }\n        .empty-state { text-align:center; padding:var(--space-8); color:var(--text-muted); }\n        .empty-state h2 { color:var(--text-secondary); margin-bottom:var(--space-3); }\n\n        .modal-overlay { display:none; position:fixed; inset:0; background:rgba(0,0,0,.6); z-index:1000; justify-content:center; align-items:center; }\n        .modal-overlay.open { display:flex; }\n        .modal { background:var(--bg-card); border:1px solid var(--border-light); border-radius:var(--radius-lg); width:90%; max-width:650px; max-height:90vh; overflow-y:auto; padding:var(--space-6); }\n        .modal h2 { margin:0 0 var(--space-4); color:var(--text-primary); }\n        .detail-block { background:var(--bg-secondary); padding:var(--space-4); border-radius:var(--radius-md); overflow-x:auto; }\n        .detail-block pre { margin:0; color:var(--text-primary); font-size:var(--font-size-sm); white-space:pre-wrap; word-break:break-all; font-family:'Courier New',monospace; }\n        .detail-row { margin-bottom:var(--space-3); }\n        .detail-label { color:var(--text-muted); font-size:var(--font-size-sm); font-weight:var(--font-weight-semibold); margin-bottom:var(--space-1); }\n        .detail-value { color:var(--text-primary); }\n        .modal-actions { display:flex; gap:var(--space-3); justify-content:flex-end; margin-top:var(--space-5); }\n        .modal-actions button { padding:var(--space-2) var(--space-4); border:none; border-radius:var(--radius-md); cursor:pointer; font-weight:var(--font-weight-semibold); }\n        .btn-secondary { background:var(--bg-tertiary); color:var(--text-primary); border:1px solid var(--border-light) !important; }\n        .toast { position:fixed; bottom:20px; right:20px; padding:var(--space-3) var(--space-5); border-radius:var(--radius-md); color:#fff; z-index:2000; opacity:0; transition:opacity .3s; }\n        .toast.show { opacity:1; } .toast.success { background:var(--success); } .toast.error { background:var(--danger); }\n        .loading { text-align:center; padding:var(--space-6); color:var(--text-muted); }" +
+                ".filter-bar { display:flex; gap:var(--space-3); align-items:flex-end; flex-wrap:wrap; margin-bottom:var(--space-5); background:var(--bg-card); border:1px solid var(--border-light); border-radius:var(--radius-lg); padding:var(--space-4); }\n        .filter-bar .fg { display:flex; flex-direction:column; gap:var(--space-1); }\n        .filter-bar label { color:var(--text-muted); font-size:var(--font-size-sm); font-weight:var(--font-weight-semibold); }\n        .filter-bar select, .filter-bar input { padding:var(--space-2) var(--space-3); background:var(--bg-secondary); border:1px solid var(--border-light); border-radius:var(--radius-md); color:var(--text-primary); font-size:14px; }\n        .filter-bar .btn-primary { padding:var(--space-2) var(--space-4); background:var(--accent-primary); color:#fff; border:none; border-radius:var(--radius-md); cursor:pointer; font-weight:var(--font-weight-semibold); align-self:flex-end; }\n        .table-wrapper { overflow-x:auto; background:var(--bg-card); border:1px solid var(--border-light); border-radius:var(--radius-lg); }\n        .log-table { width:100%; border-collapse:collapse; min-width:700px; }\n        .log-table th { text-align:left; padding:var(--space-3); color:var(--text-muted); font-size:var(--font-size-sm); font-weight:var(--font-weight-semibold); border-bottom:2px solid var(--border-light); position:sticky; top:0; background:var(--bg-secondary); }\n        .log-table td { padding:var(--space-3); border-bottom:1px solid var(--border-light); color:var(--text-secondary); font-size:var(--font-size-sm); vertical-align:top; }\n        .log-table tr:hover { background:var(--bg-tertiary); cursor:pointer; }\n        .badge { display:inline-block; padding:2px 8px; border-radius:var(--radius-md); font-size:11px; font-weight:var(--font-weight-semibold); }\n        .badge-auth { background:var(--accent-primary); color:#fff; }\n        .badge-create { background:var(--success); color:#fff; }\n        .badge-delete { background:var(--danger); color:#fff; }\n        .badge-update { background:var(--warning); color:#000; }\n        .badge-default { background:var(--bg-tertiary); color:var(--text-secondary); }\n        .badge-severity-info { background:var(--info,#3b82f6); color:#fff; }\n        .badge-severity-warning { background:var(--warning,#f59e0b); color:#000; }\n        .badge-severity-critical { background:var(--danger,#ef4444); color:#fff; animation: badgePulse 1.5s ease-in-out infinite; }\n        @keyframes badgePulse { 0%,100% { box-shadow:0 0 0 0 rgba(239,68,68,.6); } 50% { box-shadow:0 0 0 4px rgba(239,68,68,0); } }\n        .ack-btn { padding:2px 8px; border:1px solid var(--accent-primary); background:transparent; color:var(--accent-primary); border-radius:var(--radius-md); cursor:pointer; font-size:11px; font-weight:var(--font-weight-semibold); }\n        .ack-btn:hover { background:var(--accent-primary); color:#fff; }\n        .alert-row-acked { opacity:0.55; }\n        .alert-row-acked td { color:var(--text-muted); }\n        .ack-info { font-size:11px; color:var(--text-muted); white-space:nowrap; }\n        .detail-cell { max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--text-muted); }\n        .log-count { color:var(--text-muted); font-size:var(--font-size-sm); margin-bottom:var(--space-3); }\n        .empty-state { text-align:center; padding:var(--space-8); color:var(--text-muted); }\n        .empty-state h2 { color:var(--text-secondary); margin-bottom:var(--space-3); }\n\n        .modal-overlay { display:none; position:fixed; inset:0; background:rgba(0,0,0,.6); z-index:1000; justify-content:center; align-items:center; }\n        .modal-overlay.open { display:flex; }\n        .modal { background:var(--bg-card); border:1px solid var(--border-light); border-radius:var(--radius-lg); width:90%; max-width:650px; max-height:90vh; overflow-y:auto; padding:var(--space-6); }\n        .modal h2 { margin:0 0 var(--space-4); color:var(--text-primary); }\n        .detail-block { background:var(--bg-secondary); padding:var(--space-4); border-radius:var(--radius-md); overflow-x:auto; }\n        .detail-block pre { margin:0; color:var(--text-primary); font-size:var(--font-size-sm); white-space:pre-wrap; word-break:break-all; font-family:'Courier New',monospace; }\n        .detail-row { margin-bottom:var(--space-3); }\n        .detail-label { color:var(--text-muted); font-size:var(--font-size-sm); font-weight:var(--font-weight-semibold); margin-bottom:var(--space-1); }\n        .detail-value { color:var(--text-primary); }\n        .modal-actions { display:flex; gap:var(--space-3); justify-content:flex-end; margin-top:var(--space-5); }\n        .modal-actions button { padding:var(--space-2) var(--space-4); border:none; border-radius:var(--radius-md); cursor:pointer; font-weight:var(--font-weight-semibold); }\n        .btn-secondary { background:var(--bg-tertiary); color:var(--text-primary); border:1px solid var(--border-light) !important; }\n        .toast { position:fixed; bottom:20px; right:20px; padding:var(--space-3) var(--space-5); border-radius:var(--radius-md); color:#fff; z-index:2000; opacity:0; transition:opacity .3s; }\n        .toast.show { opacity:1; } .toast.success { background:var(--success); } .toast.error { background:var(--danger); }\n        .loading { text-align:center; padding:var(--space-6); color:var(--text-muted); }" +
                 '<\/style>' +
                 "<header class=\"page-header\">\n                <button class=\"mobile-menu-btn\" onclick=\"toggleMobileSidebar(event)\">&#9776;</button>\n                <h1>감사 로그</h1>\n            </header>\n            <div class=\"content-area\" id=\"app\">\n                <div class=\"loading\">권한 확인 중...</div>\n            </div>\n<div class=\"modal-overlay\" id=\"detailModal\">\n        <div class=\"modal\">\n            <h2>로그 상세</h2>\n            <div id=\"detailContent\"></div>\n            <div class=\"modal-actions\"><button class=\"btn-secondary\" onclick=\"closeDetail()\">닫기</button></div>\n        </div>\n    </div>\n<div id=\"toast\" class=\"toast\"></div>" +
                 '<\/div>';
@@ -106,12 +106,15 @@
                         <div class="fg"><label for="filterAlertLimit">페이지 크기</label>
                             <select id="filterAlertLimit"><option value="50" selected>50개</option><option value="100">100개</option><option value="200">200개</option></select>
                         </div>
+                        <div class="fg"><label for="filterAlertAck">확인 상태</label>
+                            <select id="filterAlertAck"><option value="">전체</option><option value="false">미확인만</option><option value="true">확인됨만</option></select>
+                        </div>
                         <button class="btn-primary" onclick="loadAlertHistory(1)">조회</button>
                     </div>
                     <div id="alertCount" class="log-count"></div>
                     <div class="table-wrapper">
                         <table class="log-table">
-                            <thead><tr><th>시간</th><th>심각도</th><th>type</th><th>제목</th><th>메시지</th></tr></thead>
+                            <thead><tr><th>시간</th><th>심각도</th><th>type</th><th>제목</th><th>메시지</th><th>확인</th></tr></thead>
                             <tbody id="alertBody"></tbody>
                         </table>
                     </div>
@@ -268,13 +271,15 @@
                 async function loadAlertHistory(page = 1) {
                     const type = document.getElementById('filterAlertType').value.trim();
                     const severity = document.getElementById('filterAlertSeverity').value;
+                    const ack = document.getElementById('filterAlertAck').value;
                     const limit = parseInt(document.getElementById('filterAlertLimit').value, 10);
                     const offset = (page - 1) * limit;
                     let url = '/api/admin/alerts/history?limit=' + limit + '&offset=' + offset;
                     if (type) url += '&type=' + encodeURIComponent(type);
                     if (severity) url += '&severity=' + encodeURIComponent(severity);
+                    if (ack === 'true' || ack === 'false') url += '&acknowledged=' + ack;
                     const body = document.getElementById('alertBody');
-                    body.innerHTML = '<tr><td colspan="5"><div class="loading">불러오는 중...</div></td></tr>';
+                    body.innerHTML = '<tr><td colspan="6"><div class="loading">불러오는 중...</div></td></tr>';
                     try {
                         const res = await authFetch(url);
                         const payload = res.data || {};
@@ -283,22 +288,47 @@
                         document.getElementById('alertCount').textContent = '총 ' + total + '건 (현재 ' + history.length + '건 표시)';
                         renderPaginationInto('alertPagination', total, page, limit, (p) => loadAlertHistory(p));
                         if (!history.length) {
-                            body.innerHTML = '<tr><td colspan="5"><div class="empty-state"><h2>알림 이력이 없습니다</h2></div></td></tr>';
+                            body.innerHTML = '<tr><td colspan="6"><div class="empty-state"><h2>알림 이력이 없습니다</h2></div></td></tr>';
                             return;
                         }
                         const severityColor = { info: 'badge-severity-info', warning: 'badge-severity-warning', critical: 'badge-severity-critical' };
-                        body.innerHTML = history.map(a => `
-                            <tr>
+                        body.innerHTML = history.map(a => {
+                            const ackCell = a.acknowledged
+                                ? `<div class="ack-info">✓ by ${esc(a.acknowledged_by || '-')}<br>${a.acknowledged_at ? new Date(a.acknowledged_at).toLocaleString('ko') : ''}</div>`
+                                : `<button class="ack-btn" onclick="acknowledgeAlert(${a.id}, this)">✓ 확인</button>`;
+                            const rowClass = a.acknowledged ? 'alert-row-acked' : '';
+                            return `
+                            <tr class="${rowClass}">
                                 <td style="white-space:nowrap">${new Date(a.created_at).toLocaleString('ko')}</td>
                                 <td><span class="badge ${severityColor[a.severity] || 'badge-default'}">${esc(a.severity)}</span></td>
                                 <td>${esc(a.type)}</td>
                                 <td>${esc(a.title)}</td>
                                 <td class="detail-cell">${esc(a.message)}</td>
-                            </tr>
-                        `).join('');
+                                <td>${ackCell}</td>
+                            </tr>`;
+                        }).join('');
                     } catch (e) {
-                        body.innerHTML = '<tr><td colspan="5"><div class="empty-state"><h2>알림 이력 로드 실패</h2></div></td></tr>';
+                        body.innerHTML = '<tr><td colspan="6"><div class="empty-state"><h2>알림 이력 로드 실패</h2></div></td></tr>';
                         showToast('로드 실패', 'error');
+                    }
+                }
+
+                async function acknowledgeAlert(id, btn) {
+                    if (btn) { btn.disabled = true; btn.textContent = '...'; }
+                    try {
+                        const res = await authFetch('/api/admin/alerts/' + id + '/acknowledge', { method: 'POST' });
+                        if (res && (res.success !== false)) {
+                            showToast('확인 처리됨', 'success');
+                            // 현재 page 재로딩 — pagination 위치 유지를 위해 1 페이지로 단순 처리
+                            loadAlertHistory(1);
+                        } else {
+                            showToast('확인 실패', 'error');
+                            if (btn) { btn.disabled = false; btn.textContent = '✓ 확인'; }
+                        }
+                    } catch (e) {
+                        console.error('[Audit] ack 실패:', e);
+                        showToast('확인 실패', 'error');
+                        if (btn) { btn.disabled = false; btn.textContent = '✓ 확인'; }
                     }
                 }
 
@@ -318,6 +348,7 @@
                 if (typeof switchAuditSubTab === 'function') window.switchAuditSubTab = switchAuditSubTab;
                 if (typeof loadAlertHistory === 'function') window.loadAlertHistory = loadAlertHistory;
                 if (typeof exportLogsCsv === 'function') window.exportLogsCsv = exportLogsCsv;
+                if (typeof acknowledgeAlert === 'function') window.acknowledgeAlert = acknowledgeAlert;
             } catch (e) {
                 console.error('[PageModule:audit] init error:', e);
             }
@@ -335,6 +366,7 @@
             try { delete window.switchAuditSubTab; } catch (e) { }
             try { delete window.loadAlertHistory; } catch (e) { }
             try { delete window.exportLogsCsv; } catch (e) { }
+            try { delete window.acknowledgeAlert; } catch (e) { }
             try { delete window.__alertHistoryLoaded; } catch (e) { }
         }
     };


### PR DESCRIPTION
## Summary

PR #85 의 \`alert_history\` 의 미사용 컬럼 (\`acknowledged\`/\`acknowledged_by\`/
\`acknowledged_at\`) 활성화. 운영자가 webhook 도착한 알림을 admin 대시보드
에서 직접 \"확인\" 처리 → 처리 시점/ID 영구 기록.

## Changes

**\`backend/api/src/controllers/admin.controller.ts\`**
- 신규 \`POST /api/admin/alerts/:id/acknowledge\`
  - **idempotent** — 이미 ack 된 row 는 기존 정보 그대로 반환 (\`alreadyAcknowledged=true\`)
  - \`audit_logs\` INSERT (\`action='alert.acknowledged'\`) — \`CRITICAL_ACTIONS\` 외라 webhook 안 보냄 (PR #84 SoT 패턴)
  - actor 정보 (email/role) 포함 (PR #87 패턴)
- \`listAlertHistory\`:
  - SELECT 에 acknowledged 관련 3개 컬럼 추가
  - \`acknowledged=true/false\` filter 추가 (미확인만/확인됨만/전체)

**\`frontend/web/public/js/modules/pages/audit.js\`**
- alert_history thead 에 "확인" 컬럼 추가
- inline CSS: \`.ack-btn\` / \`.alert-row-acked\` / \`.ack-info\`
- filter bar 에 "확인 상태" select 추가
- tbody render:
  - 확인됨 → \`✓ by X (시간)\` 표시 + 행 opacity 0.55
  - 미확인 → \`✓ 확인\` 버튼
- \`acknowledgeAlert(id, btn)\` — POST 호출 + 토스트 + 재로딩

## Design 결정

- **idempotent UPDATE** — \`WHERE acknowledged=FALSE\` 로 중복 ack 시 기존 \`acknowledged_by\` 덮어쓰기 방지. 0 rowCount → 현재 상태 조회 후 반환
- **재로딩 단순화** — 1 페이지로 reload. pagination 위치 유지는 별도 작업
- **cooldown reset 미포함** — 본 PR scope 외. ack 가 cooldown 영향 안 줌 (별도 PR 후속 가능)
- **audit logging** — PR #84 의 \`logAudit\` + actor 패턴 따름

## Test plan
- [x] tsc 0 / eslint 0 errors
- [x] jest 47/47 통과 (admin/audit/alert 회귀)
- [x] frontend validate-modules 통과
- [ ] (운영자 manual): admin → 감사 로그 → 알림 이력 tab →
  - \`✓ 확인\` 클릭 → toast + row dim + \"by email\" 표시
  - \"확인 상태\" filter 로 미확인/확인됨 토글
  - \`audit_logs\` 에 \`alert.acknowledged\` row 생성 확인

## Follow-up
- ack 시 cooldown reset (재발생 시 즉시 통보) — 별도 PR
- 일괄 ack 버튼 (선택 row 모두 ack)
- ack 통계 (시간대별 미확인 비율)

🤖 Generated with [Claude Code](https://claude.com/claude-code)