### PR TITLE
feat(alert-ui): alert_history CSV export — PR #91 패턴 동일 적용

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -176,6 +176,10 @@ EXTERNAL_USAGE_RETENTION_DAYS=90
 # 무거운 query 방어 — 큰 export 는 paged 호출로 분할 권장.
 # AUDIT_CSV_MAX_ROWS=10000
 
+# alert_history CSV export 최대 row 수 (admin 전용 GET /api/admin/alerts/export).
+# 동일 방어 정책. 알림 이력은 audit_logs 보다 빈도 낮아 default 충분.
+# ALERT_CSV_MAX_ROWS=10000
+
 # GDPR Phase D — 운영자 알림 (14세 미만 가입 대기 시 즉시 알림).
 # Slack/Discord incoming webhook URL. 설정 시 AlertSystem (monitoring/alerts.ts) 가
 # webhook 채널 자동 활성. type=minor_pending_registered 알림이 본 URL 에 POST 됨.

--- a/backend/api/src/controllers/admin.controller.ts
+++ b/backend/api/src/controllers/admin.controller.ts
@@ -57,6 +57,8 @@ export class AdminController {
 
         // GDPR Phase D follow-up — alert_history 조회 (admin dashboard 용)
         this.router.get('/alerts/history', this.listAlertHistory.bind(this));
+        // alert_history CSV export (운영자 reporting/compliance)
+        this.router.get('/alerts/export', this.exportAlertHistoryCsv.bind(this));
         // alert_history acknowledge (확인 처리) — 운영자 ID/시간 기록
         this.router.post('/alerts/:id/acknowledge', this.acknowledgeAlert.bind(this));
 
@@ -560,6 +562,76 @@ export class AdminController {
         } catch (error) {
             log.error('[Admin AlertHistory] 오류:', error);
             res.status(500).json(internalError('알림 이력 조회 실패'));
+        }
+    }
+
+    /**
+     * GET /api/admin/alerts/export — alert_history CSV download.
+     *
+     * 동일 filter (type/severity/acknowledged/startDate/endDate) 지원.
+     * 무거운 query 방어: ALERT_CSV_MAX_ROWS env (default 10000) 강제 limit.
+     * 출력: UTF-8 BOM + RFC 4180 escape — PR #91 의 audit export 와 동일 패턴.
+     */
+    private async exportAlertHistoryCsv(req: Request, res: Response): Promise<void> {
+        try {
+            const maxRows = parseInt(process.env.ALERT_CSV_MAX_ROWS ?? '10000', 10);
+            const type = req.query.type ? String(req.query.type) : null;
+            const severity = req.query.severity ? String(req.query.severity) : null;
+            const startDate = req.query.startDate ? String(req.query.startDate) : null;
+            const endDate = req.query.endDate ? String(req.query.endDate) : null;
+            const ackParam = req.query.acknowledged !== undefined ? String(req.query.acknowledged) : null;
+
+            const conditions: string[] = [];
+            const params: unknown[] = [];
+            let idx = 1;
+            if (type) { conditions.push(`type = $${idx++}`); params.push(type); }
+            if (severity) { conditions.push(`severity = $${idx++}`); params.push(severity); }
+            if (startDate) { conditions.push(`created_at >= $${idx++}`); params.push(startDate); }
+            if (endDate) { conditions.push(`created_at <= $${idx++}`); params.push(endDate); }
+            if (ackParam === 'true') { conditions.push(`acknowledged = TRUE`); }
+            else if (ackParam === 'false') { conditions.push(`acknowledged = FALSE`); }
+            const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+
+            const { getPool } = await import('../data/models/unified-database');
+            const pool = getPool();
+            const r = await pool.query(
+                `SELECT id, created_at, type, severity, title, message,
+                        acknowledged, acknowledged_by, acknowledged_at, data
+                 FROM alert_history ${whereClause}
+                 ORDER BY created_at DESC
+                 LIMIT $${idx}`,
+                [...params, maxRows],
+            );
+
+            // RFC 4180: 모든 필드를 "" 로 감싸고 내부 " 를 "" 로 escape
+            const esc = (v: unknown): string => {
+                if (v === null || v === undefined) return '""';
+                const s = typeof v === 'string' ? v : (v instanceof Date ? v.toISOString() : JSON.stringify(v));
+                return `"${s.replace(/"/g, '""')}"`;
+            };
+
+            const header = ['id', 'created_at', 'type', 'severity', 'title', 'message', 'acknowledged', 'acknowledged_by', 'acknowledged_at', 'data'].join(',');
+            const rows = (r.rows as Array<Record<string, unknown>>).map(row => [
+                esc(row.id),
+                esc(row.created_at),
+                esc(row.type),
+                esc(row.severity),
+                esc(row.title),
+                esc(row.message),
+                esc(row.acknowledged ? 'true' : 'false'),
+                esc(row.acknowledged_by),
+                esc(row.acknowledged_at),
+                esc(row.data),
+            ].join(','));
+            const csv = '﻿' + [header, ...rows].join('\n');
+
+            const date = new Date().toISOString().slice(0, 10);
+            res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+            res.setHeader('Content-Disposition', `attachment; filename="alert_history_${date}.csv"`);
+            res.send(csv);
+        } catch (error) {
+            log.error('[Admin AlertExport] 오류:', error);
+            res.status(500).json(internalError('알림 이력 CSV export 실패'));
         }
     }
 

--- a/frontend/web/public/js/modules/pages/audit.js
+++ b/frontend/web/public/js/modules/pages/audit.js
@@ -110,6 +110,7 @@
                             <select id="filterAlertAck"><option value="">전체</option><option value="false">미확인만</option><option value="true">확인됨만</option></select>
                         </div>
                         <button class="btn-primary" onclick="loadAlertHistory(1)">조회</button>
+                        <button class="btn-secondary" onclick="exportAlertsCsv()" title="현재 필터 조건으로 최대 10000건 CSV 다운로드">📥 CSV</button>
                     </div>
                     <div id="alertCount" class="log-count"></div>
                     <div class="table-wrapper">
@@ -313,6 +314,35 @@
                     }
                 }
 
+                async function exportAlertsCsv() {
+                    const type = document.getElementById('filterAlertType').value.trim();
+                    const severity = document.getElementById('filterAlertSeverity').value;
+                    const ack = document.getElementById('filterAlertAck').value;
+                    let url = '/api/admin/alerts/export';
+                    const params = [];
+                    if (type) params.push('type=' + encodeURIComponent(type));
+                    if (severity) params.push('severity=' + encodeURIComponent(severity));
+                    if (ack === 'true' || ack === 'false') params.push('acknowledged=' + ack);
+                    if (params.length) url += '?' + params.join('&');
+                    try {
+                        const res = await window.authFetch(url);
+                        if (!res.ok) { showToast('CSV export 실패: HTTP ' + res.status, 'error'); return; }
+                        const blob = await res.blob();
+                        const blobUrl = URL.createObjectURL(blob);
+                        const a = document.createElement('a');
+                        a.href = blobUrl;
+                        a.download = 'alert_history_' + new Date().toISOString().slice(0, 10) + '.csv';
+                        document.body.appendChild(a);
+                        a.click();
+                        document.body.removeChild(a);
+                        URL.revokeObjectURL(blobUrl);
+                        showToast('CSV 다운로드 완료', 'success');
+                    } catch (e) {
+                        console.error('[Audit] alert CSV export 실패:', e);
+                        showToast('CSV export 실패', 'error');
+                    }
+                }
+
                 async function acknowledgeAlert(id, btn) {
                     if (btn) { btn.disabled = true; btn.textContent = '...'; }
                     try {
@@ -349,6 +379,7 @@
                 if (typeof loadAlertHistory === 'function') window.loadAlertHistory = loadAlertHistory;
                 if (typeof exportLogsCsv === 'function') window.exportLogsCsv = exportLogsCsv;
                 if (typeof acknowledgeAlert === 'function') window.acknowledgeAlert = acknowledgeAlert;
+                if (typeof exportAlertsCsv === 'function') window.exportAlertsCsv = exportAlertsCsv;
             } catch (e) {
                 console.error('[PageModule:audit] init error:', e);
             }
@@ -367,6 +398,7 @@
             try { delete window.loadAlertHistory; } catch (e) { }
             try { delete window.exportLogsCsv; } catch (e) { }
             try { delete window.acknowledgeAlert; } catch (e) { }
+            try { delete window.exportAlertsCsv; } catch (e) { }
             try { delete window.__alertHistoryLoaded; } catch (e) { }
         }
     };


### PR DESCRIPTION
## Summary

PR #91 의 \`audit_logs\` CSV export 패턴을 \`alert_history\` 에도 적용. 운영자
incident reporting + compliance 추적 편의. ack 정보 (\`acknowledged_by\` /
\`acknowledged_at\`) 포함하여 처리 이력 함께 export.

## Changes

**\`backend/api/src/controllers/admin.controller.ts\`**
- 신규 \`GET /api/admin/alerts/export\` (admin 전용)
- 동일 filter (type/severity/acknowledged/startDate/endDate)
- 무거운 query 방어: \`ALERT_CSV_MAX_ROWS\` env (default 10000)
- 응답: UTF-8 BOM + RFC 4180 CSV escape
- columns 10: id / created_at / type / severity / title / message / **acknowledged** / **acknowledged_by** / **acknowledged_at** / data(JSON)

**\`frontend/web/public/js/modules/pages/audit.js\`**
- alert_history filter bar 에 \`📥 CSV\` 버튼
- 신규 \`exportAlertsCsv()\` — window.authFetch + blob 다운로드 패턴
- window 노출 + cleanup

**\`.env.example\`** — \`ALERT_CSV_MAX_ROWS\` 문서화

## Design 결정

- PR #91 의 esc / BOM / RFC 4180 패턴 그대로 — 별도 util 추출 안 함 (라인 양 작음, import 추가 비용 회피)
- **ack 정보 포함** — incident response 시 처리 이력 함께 확인 가능
- admin 전용 (requireAdmin 가드) — PII (data.actor) 포함 OK

## Test plan
- [x] tsc 0 / eslint 0 errors
- [x] frontend validate-modules 통과
- [ ] (운영자 manual): admin → 감사 로그 → 알림 이력 → \`📥 CSV\` → \`alert_history_YYYY-MM-DD.csv\` 다운로드 → ack 정보 컬럼 확인

## Follow-up
- audit + alert CSV 공통 util 추출 (3번째 CSV endpoint 추가 시점)
- streaming (cursor + Readable) — 100k+ row 대응

🤖 Generated with [Claude Code](https://claude.com/claude-code)