### PR TITLE
feat(alerts): ack 시 cooldown reset — 재발생 시 즉시 통보

### DIFF
--- a/backend/api/src/controllers/admin.controller.ts
+++ b/backend/api/src/controllers/admin.controller.ts
@@ -678,6 +678,13 @@ export class AdminController {
                 return;
             }
 
+            // ack 성공 시 해당 alert key 의 cooldown clear → 재발생 시 즉시 통보
+            // (incident 처리 후 같은 critical 재발 시 1분 cooldown 도 우회)
+            try {
+                const { getAlertSystem } = await import('../monitoring/alerts');
+                getAlertSystem().clearCooldown(r.rows[0].type as string, r.rows[0].severity as 'info' | 'warning' | 'critical');
+            } catch (e) { log.warn('[ack] cooldown clear 실패:', e); }
+
             // audit_logs INSERT — fire-and-forget (CRITICAL_ACTIONS whitelist 외라 alert 자체는 안 보냄)
             void (async () => {
                 try {

--- a/backend/api/src/monitoring/alerts.ts
+++ b/backend/api/src/monitoring/alerts.ts
@@ -212,6 +212,27 @@ export class AlertSystem {
     }
 
     /**
+     * 특정 alert key 의 cooldown 을 제거합니다.
+     *
+     * 운영자가 ack 처리한 경우 호출 — 동일 type+severity 의 다음 발생을 즉시 통보.
+     * 일반 cooldown 정책 (severity 별 60/15/1분) 우회. ack 후 incident 재발생 시
+     * 운영자가 바로 인지해야 하는 시나리오 (예: critical 가 1분 cooldown 이라도
+     * ack 한 직후 같은 critical 다시 발생하면 즉시 통보).
+     *
+     * @param type - 알림 이벤트 타입
+     * @param severity - 심각도 레벨 (key 형식: `${type}:${severity}`)
+     * @returns 제거된 cooldown 이 있었으면 true, 없었으면 false (이미 만료/미발동)
+     */
+    clearCooldown(type: AlertType | string, severity: AlertSeverity): boolean {
+        const alertKey = `${type}:${severity}`;
+        const had = this.lastAlerts.delete(alertKey);
+        if (had) {
+            logger.info(`[AlertSystem] cooldown cleared: ${alertKey}`);
+        }
+        return had;
+    }
+
+    /**
      * 알림을 발송합니다.
      *
      * 쿨다운 기간 내 동일 타입/심각도의 알림은 무시됩니다.


### PR DESCRIPTION
## Summary

PR #92 의 acknowledge UI follow-up. 운영자가 ack 처리한 alert key 의
cooldown 을 clear 하여 동일 type+severity 재발생 시 즉시 통보. incident
처리 후 같은 critical 재발 시 1분 cooldown 도 우회.

## Changes

**\`backend/api/src/monitoring/alerts.ts\`**
- 신규 \`AlertSystem.clearCooldown(type, severity): boolean\`
  - \`this.lastAlerts\` Map 에서 \`\${type}:\${severity}\` 키 제거
  - 제거 성공 시 \`logger.info\` (디버깅용)
  - 반환: 제거된 cooldown 이 있었으면 true

**\`backend/api/src/controllers/admin.controller.ts\`**
- \`acknowledgeAlert\` (PR #92) 내 UPDATE 성공 직후 \`clearCooldown\` 호출
- fire-and-forget try/catch — alert system 실패해도 ack 자체는 성공
- audit logging 호출보다 먼저 (cooldown clear 가 user-visible 동작)

## Design 결정

- **ack 성공 시에만 호출** — \`alreadyAcknowledged\` 인 경우 안 함 (이미 다른 운영자 처리, cooldown 영향 없음)
- **in-memory Map 만 조작** — DB 변경 없음. multi-instance 환경에서는 인스턴스 별 cooldown 따로 (PM2 single-fork 라 현재 무관)
- type cast: \`as 'info'|'warning'|'critical'\` — DB CHECK 제약으로 안전

## Test plan
- [x] tsc 0 / eslint 0 errors
- [x] jest 40/40 통과 (admin/alert 회귀)
- [ ] (운영자 manual):
  1. critical event 발생 → webhook 도착 (1분 cooldown 시작)
  2. 즉시 같은 type+critical 재발생 → cooldown 으로 webhook 안 옴
  3. admin → \`✓ 확인\` 클릭 → cooldown clear
  4. 다시 같은 critical 발생 → 즉시 webhook ✓

## Follow-up
- multi-instance 환경 (cluster mode) 대응: cooldown 을 Redis/DB 로
- bulk ack 시 cooldown 일괄 clear
- \"cooldown 유지 ack\" 옵션 (시각만 dim, 알림 spam 방어 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)