### PR TITLE
feat(alert-ui): dashboard 통계 위젯 — 4 카드 요약 + 7일 trend

### DIFF
--- a/backend/api/src/controllers/admin.controller.ts
+++ b/backend/api/src/controllers/admin.controller.ts
@@ -59,6 +59,8 @@ export class AdminController {
         this.router.get('/alerts/history', this.listAlertHistory.bind(this));
         // alert_history CSV export (운영자 reporting/compliance)
         this.router.get('/alerts/export', this.exportAlertHistoryCsv.bind(this));
+        // alert_history 통계 (대시보드 요약 카드용)
+        this.router.get('/alerts/stats', this.getAlertStats.bind(this));
         // alert_history acknowledge (확인 처리) — 운영자 ID/시간 기록
         this.router.post('/alerts/:id/acknowledge', this.acknowledgeAlert.bind(this));
 
@@ -562,6 +564,73 @@ export class AdminController {
         } catch (error) {
             log.error('[Admin AlertHistory] 오류:', error);
             res.status(500).json(internalError('알림 이력 조회 실패'));
+        }
+    }
+
+    /**
+     * GET /api/admin/alerts/stats — alert_history 대시보드 요약 통계.
+     *
+     * 응답 schema:
+     *   - todayCriticalCount: 오늘 0시 이후 critical 개수
+     *   - pendingAckCount: 전체 acknowledged=false 개수 (모든 severity)
+     *   - last7Days: [{ date: 'YYYY-MM-DD', total, info, warning, critical }] × 7
+     *   - severityTotals: { info, warning, critical } — 지난 7일 합계
+     *
+     * 4 query 병렬 실행. 운영자 dashboard 진입 시 초당 호출 가능 — 가벼움 우선.
+     */
+    private async getAlertStats(_req: Request, res: Response): Promise<void> {
+        try {
+            const { getPool } = await import('../data/models/unified-database');
+            const pool = getPool();
+
+            const [todayCrit, pendingAck, trend, severityTotals] = await Promise.all([
+                pool.query<{ count: string }>(
+                    `SELECT COUNT(*)::text AS count FROM alert_history
+                     WHERE severity = 'critical' AND created_at >= date_trunc('day', NOW())`,
+                ),
+                pool.query<{ count: string }>(
+                    `SELECT COUNT(*)::text AS count FROM alert_history WHERE acknowledged = FALSE`,
+                ),
+                pool.query<{ date: string; total: string; info: string; warning: string; critical: string }>(
+                    `SELECT to_char(date_trunc('day', d), 'YYYY-MM-DD') AS date,
+                            COUNT(a.*)::text AS total,
+                            COUNT(*) FILTER (WHERE a.severity = 'info')::text AS info,
+                            COUNT(*) FILTER (WHERE a.severity = 'warning')::text AS warning,
+                            COUNT(*) FILTER (WHERE a.severity = 'critical')::text AS critical
+                     FROM generate_series(date_trunc('day', NOW()) - INTERVAL '6 days',
+                                          date_trunc('day', NOW()), INTERVAL '1 day') AS d
+                     LEFT JOIN alert_history a
+                       ON date_trunc('day', a.created_at) = d
+                     GROUP BY d
+                     ORDER BY d ASC`,
+                ),
+                pool.query<{ severity: string; count: string }>(
+                    `SELECT severity, COUNT(*)::text AS count FROM alert_history
+                     WHERE created_at >= NOW() - INTERVAL '7 days'
+                     GROUP BY severity`,
+                ),
+            ]);
+
+            const severityMap: Record<string, number> = { info: 0, warning: 0, critical: 0 };
+            for (const r of severityTotals.rows) {
+                severityMap[r.severity] = parseInt(r.count, 10);
+            }
+
+            res.json(success({
+                todayCriticalCount: parseInt(todayCrit.rows[0]?.count ?? '0', 10),
+                pendingAckCount: parseInt(pendingAck.rows[0]?.count ?? '0', 10),
+                last7Days: trend.rows.map(r => ({
+                    date: r.date,
+                    total: parseInt(r.total, 10),
+                    info: parseInt(r.info, 10),
+                    warning: parseInt(r.warning, 10),
+                    critical: parseInt(r.critical, 10),
+                })),
+                severityTotals: severityMap,
+            }));
+        } catch (error) {
+            log.error('[Admin AlertStats] 오류:', error);
+            res.status(500).json(internalError('알림 통계 조회 실패'));
         }
     }
 

--- a/frontend/web/public/js/modules/pages/audit.js
+++ b/frontend/web/public/js/modules/pages/audit.js
@@ -18,7 +18,7 @@
         getHTML: function () {
             return '<div class="page-audit">' +
                 '<style data-spa-style="audit">' +
-                ".filter-bar { display:flex; gap:var(--space-3); align-items:flex-end; flex-wrap:wrap; margin-bottom:var(--space-5); background:var(--bg-card); border:1px solid var(--border-light); border-radius:var(--radius-lg); padding:var(--space-4); }\n        .filter-bar .fg { display:flex; flex-direction:column; gap:var(--space-1); }\n        .filter-bar label { color:var(--text-muted); font-size:var(--font-size-sm); font-weight:var(--font-weight-semibold); }\n        .filter-bar select, .filter-bar input { padding:var(--space-2) var(--space-3); background:var(--bg-secondary); border:1px solid var(--border-light); border-radius:var(--radius-md); color:var(--text-primary); font-size:14px; }\n        .filter-bar .btn-primary { padding:var(--space-2) var(--space-4); background:var(--accent-primary); color:#fff; border:none; border-radius:var(--radius-md); cursor:pointer; font-weight:var(--font-weight-semibold); align-self:flex-end; }\n        .table-wrapper { overflow-x:auto; background:var(--bg-card); border:1px solid var(--border-light); border-radius:var(--radius-lg); }\n        .log-table { width:100%; border-collapse:collapse; min-width:700px; }\n        .log-table th { text-align:left; padding:var(--space-3); color:var(--text-muted); font-size:var(--font-size-sm); font-weight:var(--font-weight-semibold); border-bottom:2px solid var(--border-light); position:sticky; top:0; background:var(--bg-secondary); }\n        .log-table td { padding:var(--space-3); border-bottom:1px solid var(--border-light); color:var(--text-secondary); font-size:var(--font-size-sm); vertical-align:top; }\n        .log-table tr:hover { background:var(--bg-tertiary); cursor:pointer; }\n        .badge { display:inline-block; padding:2px 8px; border-radius:var(--radius-md); font-size:11px; font-weight:var(--font-weight-semibold); }\n        .badge-auth { background:var(--accent-primary); color:#fff; }\n        .badge-create { background:var(--success); color:#fff; }\n        .badge-delete { background:var(--danger); color:#fff; }\n        .badge-update { background:var(--warning); color:#000; }\n        .badge-default { background:var(--bg-tertiary); color:var(--text-secondary); }\n        .badge-severity-info { background:var(--info,#3b82f6); color:#fff; }\n        .badge-severity-warning { background:var(--warning,#f59e0b); color:#000; }\n        .badge-severity-critical { background:var(--danger,#ef4444); color:#fff; animation: badgePulse 1.5s ease-in-out infinite; }\n        @keyframes badgePulse { 0%,100% { box-shadow:0 0 0 0 rgba(239,68,68,.6); } 50% { box-shadow:0 0 0 4px rgba(239,68,68,0); } }\n        .ack-btn { padding:2px 8px; border:1px solid var(--accent-primary); background:transparent; color:var(--accent-primary); border-radius:var(--radius-md); cursor:pointer; font-size:11px; font-weight:var(--font-weight-semibold); }\n        .ack-btn:hover { background:var(--accent-primary); color:#fff; }\n        .alert-row-acked { opacity:0.55; }\n        .alert-row-acked td { color:var(--text-muted); }\n        .ack-info { font-size:11px; color:var(--text-muted); white-space:nowrap; }\n        .detail-cell { max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--text-muted); }\n        .log-count { color:var(--text-muted); font-size:var(--font-size-sm); margin-bottom:var(--space-3); }\n        .empty-state { text-align:center; padding:var(--space-8); color:var(--text-muted); }\n        .empty-state h2 { color:var(--text-secondary); margin-bottom:var(--space-3); }\n\n        .modal-overlay { display:none; position:fixed; inset:0; background:rgba(0,0,0,.6); z-index:1000; justify-content:center; align-items:center; }\n        .modal-overlay.open { display:flex; }\n        .modal { background:var(--bg-card); border:1px solid var(--border-light); border-radius:var(--radius-lg); width:90%; max-width:650px; max-height:90vh; overflow-y:auto; padding:var(--space-6); }\n        .modal h2 { margin:0 0 var(--space-4); color:var(--text-primary); }\n        .detail-block { background:var(--bg-secondary); padding:var(--space-4); border-radius:var(--radius-md); overflow-x:auto; }\n        .detail-block pre { margin:0; color:var(--text-primary); font-size:var(--font-size-sm); white-space:pre-wrap; word-break:break-all; font-family:'Courier New',monospace; }\n        .detail-row { margin-bottom:var(--space-3); }\n        .detail-label { color:var(--text-muted); font-size:var(--font-size-sm); font-weight:var(--font-weight-semibold); margin-bottom:var(--space-1); }\n        .detail-value { color:var(--text-primary); }\n        .modal-actions { display:flex; gap:var(--space-3); justify-content:flex-end; margin-top:var(--space-5); }\n        .modal-actions button { padding:var(--space-2) var(--space-4); border:none; border-radius:var(--radius-md); cursor:pointer; font-weight:var(--font-weight-semibold); }\n        .btn-secondary { background:var(--bg-tertiary); color:var(--text-primary); border:1px solid var(--border-light) !important; }\n        .toast { position:fixed; bottom:20px; right:20px; padding:var(--space-3) var(--space-5); border-radius:var(--radius-md); color:#fff; z-index:2000; opacity:0; transition:opacity .3s; }\n        .toast.show { opacity:1; } .toast.success { background:var(--success); } .toast.error { background:var(--danger); }\n        .loading { text-align:center; padding:var(--space-6); color:var(--text-muted); }" +
+                ".filter-bar { display:flex; gap:var(--space-3); align-items:flex-end; flex-wrap:wrap; margin-bottom:var(--space-5); background:var(--bg-card); border:1px solid var(--border-light); border-radius:var(--radius-lg); padding:var(--space-4); }\n        .filter-bar .fg { display:flex; flex-direction:column; gap:var(--space-1); }\n        .filter-bar label { color:var(--text-muted); font-size:var(--font-size-sm); font-weight:var(--font-weight-semibold); }\n        .filter-bar select, .filter-bar input { padding:var(--space-2) var(--space-3); background:var(--bg-secondary); border:1px solid var(--border-light); border-radius:var(--radius-md); color:var(--text-primary); font-size:14px; }\n        .filter-bar .btn-primary { padding:var(--space-2) var(--space-4); background:var(--accent-primary); color:#fff; border:none; border-radius:var(--radius-md); cursor:pointer; font-weight:var(--font-weight-semibold); align-self:flex-end; }\n        .table-wrapper { overflow-x:auto; background:var(--bg-card); border:1px solid var(--border-light); border-radius:var(--radius-lg); }\n        .log-table { width:100%; border-collapse:collapse; min-width:700px; }\n        .log-table th { text-align:left; padding:var(--space-3); color:var(--text-muted); font-size:var(--font-size-sm); font-weight:var(--font-weight-semibold); border-bottom:2px solid var(--border-light); position:sticky; top:0; background:var(--bg-secondary); }\n        .log-table td { padding:var(--space-3); border-bottom:1px solid var(--border-light); color:var(--text-secondary); font-size:var(--font-size-sm); vertical-align:top; }\n        .log-table tr:hover { background:var(--bg-tertiary); cursor:pointer; }\n        .badge { display:inline-block; padding:2px 8px; border-radius:var(--radius-md); font-size:11px; font-weight:var(--font-weight-semibold); }\n        .badge-auth { background:var(--accent-primary); color:#fff; }\n        .badge-create { background:var(--success); color:#fff; }\n        .badge-delete { background:var(--danger); color:#fff; }\n        .badge-update { background:var(--warning); color:#000; }\n        .badge-default { background:var(--bg-tertiary); color:var(--text-secondary); }\n        .badge-severity-info { background:var(--info,#3b82f6); color:#fff; }\n        .badge-severity-warning { background:var(--warning,#f59e0b); color:#000; }\n        .badge-severity-critical { background:var(--danger,#ef4444); color:#fff; animation: badgePulse 1.5s ease-in-out infinite; }\n        @keyframes badgePulse { 0%,100% { box-shadow:0 0 0 0 rgba(239,68,68,.6); } 50% { box-shadow:0 0 0 4px rgba(239,68,68,0); } }\n        .ack-btn { padding:2px 8px; border:1px solid var(--accent-primary); background:transparent; color:var(--accent-primary); border-radius:var(--radius-md); cursor:pointer; font-size:11px; font-weight:var(--font-weight-semibold); }\n        .ack-btn:hover { background:var(--accent-primary); color:#fff; }\n        .alert-row-acked { opacity:0.55; }\n        .alert-row-acked td { color:var(--text-muted); }\n        .ack-info { font-size:11px; color:var(--text-muted); white-space:nowrap; }\n        .stats-row { display:grid; grid-template-columns:repeat(auto-fit, minmax(200px, 1fr)); gap:var(--space-3); margin-bottom:var(--space-4); }\n        .stat-card { background:var(--bg-card); border:1px solid var(--border-light); border-radius:var(--radius-lg); padding:var(--space-4); display:flex; flex-direction:column; gap:var(--space-2); }\n        .stat-card-label { font-size:var(--font-size-sm); color:var(--text-muted); font-weight:var(--font-weight-semibold); }\n        .stat-card-value { font-size:28px; font-weight:var(--font-weight-bold); color:var(--text-primary); line-height:1; }\n        .stat-card-value.danger { color:var(--danger,#ef4444); }\n        .stat-card-value.warning { color:var(--warning,#f59e0b); }\n        .stat-card-value.muted { color:var(--text-muted); }\n        .stat-card-sub { font-size:11px; color:var(--text-muted); }\n        .stat-bars { display:flex; align-items:flex-end; gap:2px; height:32px; margin-top:4px; }\n        .stat-bars .bar { flex:1; background:var(--accent-primary); border-radius:2px 2px 0 0; min-height:2px; transition:opacity 0.2s; }\n        .stat-bars .bar:hover { opacity:0.7; }\n        .stat-bars .bar.critical { background:var(--danger,#ef4444); }\n        .stat-distribution { display:flex; gap:4px; height:8px; border-radius:4px; overflow:hidden; background:var(--bg-tertiary); }\n        .stat-distribution > div { transition:flex 0.3s; }\n        .detail-cell { max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--text-muted); }\n        .log-count { color:var(--text-muted); font-size:var(--font-size-sm); margin-bottom:var(--space-3); }\n        .empty-state { text-align:center; padding:var(--space-8); color:var(--text-muted); }\n        .empty-state h2 { color:var(--text-secondary); margin-bottom:var(--space-3); }\n\n        .modal-overlay { display:none; position:fixed; inset:0; background:rgba(0,0,0,.6); z-index:1000; justify-content:center; align-items:center; }\n        .modal-overlay.open { display:flex; }\n        .modal { background:var(--bg-card); border:1px solid var(--border-light); border-radius:var(--radius-lg); width:90%; max-width:650px; max-height:90vh; overflow-y:auto; padding:var(--space-6); }\n        .modal h2 { margin:0 0 var(--space-4); color:var(--text-primary); }\n        .detail-block { background:var(--bg-secondary); padding:var(--space-4); border-radius:var(--radius-md); overflow-x:auto; }\n        .detail-block pre { margin:0; color:var(--text-primary); font-size:var(--font-size-sm); white-space:pre-wrap; word-break:break-all; font-family:'Courier New',monospace; }\n        .detail-row { margin-bottom:var(--space-3); }\n        .detail-label { color:var(--text-muted); font-size:var(--font-size-sm); font-weight:var(--font-weight-semibold); margin-bottom:var(--space-1); }\n        .detail-value { color:var(--text-primary); }\n        .modal-actions { display:flex; gap:var(--space-3); justify-content:flex-end; margin-top:var(--space-5); }\n        .modal-actions button { padding:var(--space-2) var(--space-4); border:none; border-radius:var(--radius-md); cursor:pointer; font-weight:var(--font-weight-semibold); }\n        .btn-secondary { background:var(--bg-tertiary); color:var(--text-primary); border:1px solid var(--border-light) !important; }\n        .toast { position:fixed; bottom:20px; right:20px; padding:var(--space-3) var(--space-5); border-radius:var(--radius-md); color:#fff; z-index:2000; opacity:0; transition:opacity .3s; }\n        .toast.show { opacity:1; } .toast.success { background:var(--success); } .toast.error { background:var(--danger); }\n        .loading { text-align:center; padding:var(--space-6); color:var(--text-muted); }" +
                 '<\/style>' +
                 "<header class=\"page-header\">\n                <button class=\"mobile-menu-btn\" onclick=\"toggleMobileSidebar(event)\">&#9776;</button>\n                <h1>감사 로그</h1>\n            </header>\n            <div class=\"content-area\" id=\"app\">\n                <div class=\"loading\">권한 확인 중...</div>\n            </div>\n<div class=\"modal-overlay\" id=\"detailModal\">\n        <div class=\"modal\">\n            <h2>로그 상세</h2>\n            <div id=\"detailContent\"></div>\n            <div class=\"modal-actions\"><button class=\"btn-secondary\" onclick=\"closeDetail()\">닫기</button></div>\n        </div>\n    </div>\n<div id=\"toast\" class=\"toast\"></div>" +
                 '<\/div>';
@@ -96,6 +96,7 @@
 
                 <!-- alert_history panel -->
                 <div id="alertHistoryPanel" style="display: none;">
+                    <div id="alertStatsRow" class="stats-row" style="display:none;"></div>
                     <div class="filter-bar">
                         <div class="fg"><label for="filterAlertType">type</label><input type="text" id="filterAlertType" placeholder="예: user_deleted"></div>
                         <div class="fg"><label for="filterAlertSeverity">심각도</label>
@@ -137,7 +138,11 @@
                     document.getElementById('alertHistoryPanel').style.display = tab === 'alerts' ? '' : 'none';
                     if (tab === 'alerts' && !window.__alertHistoryLoaded) {
                         loadAlertHistory(1);
+                        loadAlertStats();
                         window.__alertHistoryLoaded = true;
+                    } else if (tab === 'alerts') {
+                        // 재진입 시 stats 만 새로고침 (저렴, 사용자 인지 시점 반영)
+                        loadAlertStats();
                     }
                 }
 
@@ -314,6 +319,62 @@
                     }
                 }
 
+                async function loadAlertStats() {
+                    const row = document.getElementById('alertStatsRow');
+                    if (!row) return;
+                    try {
+                        const res = await authFetch('/api/admin/alerts/stats');
+                        const s = res.data || res;
+                        const trend = s.last7Days || [];
+                        const sev = s.severityTotals || { info: 0, warning: 0, critical: 0 };
+                        const totals7d = (sev.info || 0) + (sev.warning || 0) + (sev.critical || 0);
+                        // 7일 trend max — bar height 정규화
+                        const trendMax = Math.max(1, ...trend.map(d => d.total || 0));
+                        const trendBars = trend.map(d => {
+                            const h = Math.max(2, Math.round(((d.total || 0) / trendMax) * 32));
+                            const cls = (d.critical || 0) > 0 ? 'bar critical' : 'bar';
+                            return `<div class="${cls}" style="height:${h}px" title="${d.date}: total ${d.total} (critical ${d.critical}, warning ${d.warning}, info ${d.info})"></div>`;
+                        }).join('');
+                        // severity 분포 막대 (총합 0 이면 회색 빈 막대)
+                        const distSum = totals7d || 1;
+                        const distBars = `
+                            <div style="background:var(--info,#3b82f6); flex:${sev.info};" title="info ${sev.info}"></div>
+                            <div style="background:var(--warning,#f59e0b); flex:${sev.warning};" title="warning ${sev.warning}"></div>
+                            <div style="background:var(--danger,#ef4444); flex:${sev.critical};" title="critical ${sev.critical}"></div>
+                        `;
+                        const critToday = s.todayCriticalCount || 0;
+                        const pending = s.pendingAckCount || 0;
+                        row.innerHTML = `
+                            <div class="stat-card">
+                                <div class="stat-card-label">오늘 critical</div>
+                                <div class="stat-card-value ${critToday > 0 ? 'danger' : 'muted'}">${critToday}</div>
+                                <div class="stat-card-sub">오늘 0시 이후</div>
+                            </div>
+                            <div class="stat-card">
+                                <div class="stat-card-label">미확인 알림</div>
+                                <div class="stat-card-value ${pending > 0 ? 'warning' : 'muted'}">${pending}</div>
+                                <div class="stat-card-sub">전체 severity, ack 대기</div>
+                            </div>
+                            <div class="stat-card">
+                                <div class="stat-card-label">지난 7일 추이</div>
+                                <div class="stat-card-value muted" style="font-size:18px">총 ${totals7d}건</div>
+                                <div class="stat-bars">${trendBars}</div>
+                            </div>
+                            <div class="stat-card">
+                                <div class="stat-card-label">severity 분포 (7일)</div>
+                                <div class="stat-card-sub">info ${sev.info} / warning ${sev.warning} / critical ${sev.critical}</div>
+                                <div class="stat-distribution" style="display:${distSum > 0 ? 'flex' : 'none'}">${distBars}</div>
+                                ${distSum === 0 ? '<div class="stat-card-sub" style="margin-top:8px">데이터 없음</div>' : ''}
+                            </div>
+                        `;
+                        row.style.display = 'grid';
+                    } catch (e) {
+                        console.error('[Audit] stats 로드 실패:', e);
+                        // 통계 실패해도 alert_history 자체는 정상 동작 — row 숨김
+                        row.style.display = 'none';
+                    }
+                }
+
                 async function exportAlertsCsv() {
                     const type = document.getElementById('filterAlertType').value.trim();
                     const severity = document.getElementById('filterAlertSeverity').value;
@@ -351,6 +412,7 @@
                             showToast('확인 처리됨', 'success');
                             // 현재 page 재로딩 — pagination 위치 유지를 위해 1 페이지로 단순 처리
                             loadAlertHistory(1);
+                            loadAlertStats();
                         } else {
                             showToast('확인 실패', 'error');
                             if (btn) { btn.disabled = false; btn.textContent = '✓ 확인'; }
@@ -380,6 +442,7 @@
                 if (typeof exportLogsCsv === 'function') window.exportLogsCsv = exportLogsCsv;
                 if (typeof acknowledgeAlert === 'function') window.acknowledgeAlert = acknowledgeAlert;
                 if (typeof exportAlertsCsv === 'function') window.exportAlertsCsv = exportAlertsCsv;
+                if (typeof loadAlertStats === 'function') window.loadAlertStats = loadAlertStats;
             } catch (e) {
                 console.error('[PageModule:audit] init error:', e);
             }
@@ -399,6 +462,7 @@
             try { delete window.exportLogsCsv; } catch (e) { }
             try { delete window.acknowledgeAlert; } catch (e) { }
             try { delete window.exportAlertsCsv; } catch (e) { }
+            try { delete window.loadAlertStats; } catch (e) { }
             try { delete window.__alertHistoryLoaded; } catch (e) { }
         }
     };


### PR DESCRIPTION
## Summary

PR #85 의 audit dashboard 가시성 강화. alert tab 진입 시 **오늘 critical
/ 미확인 / 7일 trend / severity 분포** 4개 카드 표시. 운영자가 incident
현황을 한눈에 파악.

## Changes

**\`backend/api/src/controllers/admin.controller.ts\`**
- 신규 \`GET /api/admin/alerts/stats\` (admin 전용)
- 4 query Promise.all 병렬:
  - \`todayCriticalCount\` — 오늘 0시 이후 critical
  - \`pendingAckCount\` — 전체 acknowledged=false
  - \`last7Days\` — generate_series + LEFT JOIN (데이터 0 날도 row 채움)
  - \`severityTotals\` — 지난 7일 severity 별
- \`COUNT(*) FILTER WHERE\` — severity 별 카운트 single query

**\`frontend/web/public/js/modules/pages/audit.js\`**
- \`alertHistoryPanel\` 상단에 \`alertStatsRow\` grid container
- inline CSS 신규 ~10 클래스: \`.stats-row\` / \`.stat-card\` / \`.stat-bars\` / \`.stat-distribution\`
- 신규 \`loadAlertStats()\` — 4 카드 렌더링:
  1. 오늘 critical (>0 빨강, 0 muted)
  2. 미확인 알림 (>0 노랑, 0 muted)
  3. 7일 trend mini bar chart (CSS flex, critical 있는 날 빨강)
  4. severity 분포 (가로 막대 3색 비율)
- \`switchAuditSubTab\` → alert tab 진입 시 자동 호출
- \`acknowledgeAlert\` → ack 성공 시 stats 도 새로고침 (pending 즉시 반영)

## Design 결정

- **CSS flex mini bar chart** — SVG/Chart.js 의존성 0, 모든 브라우저 호환
- **title hover tooltip** — browser native, 별도 JS 없이
- **통계 실패 시 row 숨김** — alert_history 자체는 정상 동작
- **alert tab 진입마다 stats 호출** — 가벼움 (indexed query), 운영자 인지 시점 = 호출 시점

## Test plan
- [x] tsc 0 / eslint 0 errors
- [x] frontend validate-modules 통과
- [x] ad-hoc SQL dry-run: trend 7 rows 반환 (generate_series 정상)
- [ ] (운영자 manual): admin → 감사 로그 → 알림 이력 tab →
  - 상단 4 카드 표시
  - critical 있는 날 빨강 bar / severity 막대 비율
  - ack 누르면 미확인 카운트 즉시 감소

## Follow-up
- 일별 type 별 hot list (가장 많이 발동된 alert type)
- 시간대 별 heatmap
- 운영자 별 ack 처리 시간 평균

🤖 Generated with [Claude Code](https://claude.com/claude-code)