### PR TITLE
fix(routing): SPA_PAGES 누락 3개 entry 추가 — 404 fallback fix

### DIFF
--- a/backend/api/src/middlewares/setup.ts
+++ b/backend/api/src/middlewares/setup.ts
@@ -206,7 +206,8 @@ export function setupStaticFiles(app: Application, dirname: string): void {
         'agent-learning', 'usage', 'analytics', 'admin-metrics',
         'admin', 'audit', 'external', 'alerts', 'memory', 'settings',
         'password-change', 'history', 'developer', 'api-keys',
-        'skill-library'
+        'skill-library', 'projects',
+        'admin-mcp-catalog', 'admin-mcp-monitoring'
     ]);
 
     const publicPath = path.join(dirname, 'public');


### PR DESCRIPTION
## Summary

\`backend/api/src/middlewares/setup.ts\` 의 \`SPA_PAGES\` Set 이 \`nav-items.js\`
entry 와 동기화 안 됨. 누락된 3개 entry 진입 시 SPA fallback 대신 **404**.

## Bug

| URL | nav-items.js entry | 응답 |
|---|---|---|
| /admin-mcp-catalog.html | ✓ (admin 전용 catalog CRUD) | **404** |
| /admin-mcp-monitoring.html | ✓ (admin 전용 모니터링) | **404** |
| /projects.html | ✓ | **404** |

사용자가 사이드바 link 클릭 시 페이지 없는 것처럼 보임.

## Root cause

\`nav-items.js\` (frontend) 와 \`SPA_PAGES\` Set (backend) 가 **분리된 SoT** —
nav 에 entry 추가될 때 backend 도 동기화 필요했는데 3개 누락.

## Changes

**\`backend/api/src/middlewares/setup.ts:209-210\`**
- \`SPA_PAGES\` Set 에 \`'projects'\`, \`'admin-mcp-catalog'\`, \`'admin-mcp-monitoring'\` 추가

## Test plan
- [x] tsc 0
- [x] build:backend → PM2 reload 후 4 URL 200 확인:
  - admin-mcp-catalog.html: ✓
  - admin-mcp-monitoring.html: ✓
  - projects.html: ✓
  - 기존 mcp-servers.html: 회귀 없음

## Follow-up
- nav-items.js ↔ SPA_PAGES 정합성 자동 검증 (validate-modules 확장 또는 단위 테스트)
- 두 SoT 통합 — nav-items 가 backend 도 import 가능한 형태로 export

🤖 Generated with [Claude Code](https://claude.com/claude-code)