### PR TITLE
test(validate): SPA_PAGES ↔ nav-items.js 동기화 자동 검증 추가

### DIFF
--- a/frontend/web/scripts/validate-modules.sh
+++ b/frontend/web/scripts/validate-modules.sh
@@ -75,7 +75,7 @@ done
 # ─── 4. NAV_ITEMS ↔ pages/*.js 동기화 검증 ───
 # nav-items.js 의 모든 href: '/<name>.html' entry 는 pages/<name>.js 모듈이 존재해야 함
 # (spa-router.js 가 자동으로 dynamic import 시도 — 누락 시 콘솔 에러)
-echo "  [4/5] NAV_ITEMS ↔ pages 모듈 동기화 검증..."
+echo "  [4/6] NAV_ITEMS ↔ pages 모듈 동기화 검증..."
 NAV_FILE="$PUBLIC_DIR/js/nav-items.js"
 NAV_ERRORS=0
 if [ -f "$NAV_FILE" ]; then
@@ -96,8 +96,38 @@ else
     echo -e "  ${YELLOW}⚠ nav-items.js 미발견 — 스킵${NC}"
 fi
 
-# ─── 5. ES Module 문법 검증: export/import가 있는 JS 파일의 모듈 파싱 ───
-echo "  [5/5] ES Module 문법 검증 (V8 파서)..."
+# ─── 5. NAV_ITEMS ↔ backend SPA_PAGES 동기화 검증 ───
+# nav-items.js 의 모든 href: '/<name>.html' 은 backend 의 SPA_PAGES Set 에도 등록되어야 함
+# (누락 시 backend 가 404 반환 — SPA fallback 미동작. PR #96 의 버그 재발 방지)
+echo "  [5/6] NAV_ITEMS ↔ backend SPA_PAGES 동기화 검증..."
+SETUP_FILE="$PROJECT_ROOT/../../backend/api/src/middlewares/setup.ts"
+SPA_ERRORS=0
+if [ -f "$NAV_FILE" ] && [ -f "$SETUP_FILE" ]; then
+    # nav-items.js 의 page name 추출 (.html 확장자 떼고)
+    nav_pages=$(grep -E "href: '/[a-z0-9-]+\.html'" "$NAV_FILE" \
+        | sed -E "s/^.*href: '\/([^']+)\.html'.*$/\1/" | sort -u)
+    # backend SPA_PAGES Set 블록 내 single-quoted 문자열 추출
+    spa_pages=$(awk '/const SPA_PAGES = new Set\(\[/,/\]\);/' "$SETUP_FILE" \
+        | grep -oE "'[a-z0-9-]+'" | tr -d "'" | sort -u)
+    # nav 에 있는데 SPA_PAGES 에 없는 entry 검사
+    missing=$(comm -23 <(echo "$nav_pages") <(echo "$spa_pages"))
+    if [ -n "$missing" ]; then
+        while IFS= read -r p; do
+            [ -z "$p" ] && continue
+            echo -e "  ${RED}✗ NAV entry '/$p.html' 가 backend SPA_PAGES 에 누락 — 404 발생${NC}"
+            echo -e "    ${RED}수정: backend/api/src/middlewares/setup.ts 의 SPA_PAGES Set 에 '$p' 추가${NC}"
+            SPA_ERRORS=$((SPA_ERRORS + 1))
+        done <<< "$missing"
+    fi
+    if [ $SPA_ERRORS -gt 0 ]; then
+        ERRORS=$((ERRORS + SPA_ERRORS))
+    fi
+else
+    [ ! -f "$SETUP_FILE" ] && echo -e "  ${YELLOW}⚠ backend setup.ts 미발견 — 스킵${NC}"
+fi
+
+# ─── 6. ES Module 문법 검증: export/import가 있는 JS 파일의 모듈 파싱 ───
+echo "  [6/6] ES Module 문법 검증 (V8 파서)..."
 MODULE_ERRORS=0
 for f in "$PUBLIC_DIR"/js/modules/*.js "$PUBLIC_DIR"/js/modules/pages/*.js "$PUBLIC_DIR"/js/components/*.js "$PUBLIC_DIR"/js/spa-router.js "$PUBLIC_DIR"/js/nav-items.js; do
     if [ -f "$f" ]; then


### PR DESCRIPTION
## Summary

PR #96 에서 발견된 버그 (nav 에 entry 추가됐는데 backend \`SPA_PAGES\` Set
누락 → 404) 재발 방지. \`validate-modules.sh\` 에 신규 step 5/6 추가.

## Changes

**\`frontend/web/scripts/validate-modules.sh\`**
- step 4/5 → 4/6, 5/5 → 6/6 numbering 갱신
- **신규 step 5/6** — NAV_ITEMS ↔ backend SPA_PAGES 동기화 검증:
  - nav-items.js 의 \`href: '/<name>.html'\` 추출 → nav_pages
  - backend setup.ts 의 SPA_PAGES Set 추출 (awk 블록 매칭 + single-quoted 문자열 grep) → spa_pages
  - \`comm -23 <(nav_pages) <(spa_pages)\` 로 missing 검출
  - missing entry 마다 \`수정: ... 추가\` 가이드 출력

## Design 결정

- **한쪽 방향만 검증** (nav → SPA_PAGES) — SPA_PAGES 에만 있고 nav 에 없는 entry 는 admin sub-tab 등 다른 진입점이 있을 수 있어 OK
- \`npm run build:frontend\` 가 본 script 호출 → CI/배포 전 자동 fail
- backend setup.ts 미발견 시 silent skip (frontend 단독 개발 환경 대응)

## Test plan
- [x] 정상 case (현재 main): 통과
- [x] 회귀 시뮬: SPA_PAGES 에서 \`admin-mcp-catalog\` 임시 제거 → step 5/6 fail + 가이드 출력 확인:
  ```
  ✗ NAV entry '/admin-mcp-catalog.html' 가 backend SPA_PAGES 에 누락 — 404 발생
    수정: backend/api/src/middlewares/setup.ts 의 SPA_PAGES Set 에 'admin-mcp-catalog' 추가
  ```
- [x] restore 후 재실행 → 통과

## Follow-up

- backend 단위 테스트 (jest) 로 보강 — shell script 의 grep 기반보다 AST 기반이 더 정확. 현재는 shell 로 충분 (SPA_PAGES Set 단순 구조)

🤖 Generated with [Claude Code](https://claude.com/claude-code)