### PR TITLE
feat(llm): model pool — 262K↔1M proactive capacity-based routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,20 @@ LLM_TIMEOUT=120000                              # HTTP 요청 타임아웃 (ms)
 LLM_HOURLY_TOKEN_LIMIT=300000
 LLM_WEEKLY_TOKEN_LIMIT=5000000
 
+# Model Pool — 두 chat 모델 (262K / 1M) capacity 기반 proactive routing.
+# 입력 + 예상 출력 합산이 default 모델 임계 초과 시 1M 으로 자동 전환.
+# 답변 잘림 방지 (output 보호 우선 안전망).
+# 자세한 정책: docs/superpowers/specs/2026-05-25-llm-model-pool-design.md
+# LLM_POOL_ENABLED=true                            # false 시 routing 비활성 (rollback)
+# LLM_POOL_DEFAULT_MODEL=qwen3.6-35b-a3b          # default (262K) model id
+# LLM_POOL_LARGE_MODEL=qwen3.6-35b-a3b-1m         # large (1M) model id
+# LLM_POOL_DEFAULT_CTX=262144                     # default 모델 nominal context
+# LLM_POOL_LARGE_CTX=1048576                      # large 모델 nominal context
+# LLM_POOL_DEFAULT_MARGIN_PCT=10                  # default 모델 safety margin %
+# LLM_POOL_LARGE_MARGIN_PCT=5                     # large 모델 safety margin %
+# LLM_POOL_ROUTING_MAX_TOKENS_DEFAULT=16384       # max_tokens 미지정 시 routing 계산용
+# LLM_POOL_MIN_OUTPUT_TOKENS=4096                 # 1M 안전망 최소 출력 보장
+
 # vLLM extra_body.reasoning_effort 전송 (opt-in, 기본 비활성).
 # 모델/서버가 reasoning 지원 시에만 'true' 로 활성화 — vLLM 서버 가동 시
 # `--reasoning-parser deepseek_r1|qwen3|granite|...` 옵션 함께 지정 필요.

--- a/backend/api/src/config/local-models.ts
+++ b/backend/api/src/config/local-models.ts
@@ -64,12 +64,13 @@ const DEFAULT_LOCAL_MODELS: LocalModelEntry[] = [
     {
         id: 'qwen3.6-35b-a3b-1m',
         displayName: 'Qwen 3.6 (1M context)',
-        description: '대용량 문서/research — 1M context (서버 PC 의 8004 가동 시에만)',
+        description: '대용량 문서/research — 1M context (LiteLLM gateway 가 항상 노출)',
         role: 'chat',
         contextLength: 1048576,
-        // 8004 백엔드가 선택적 — 기본 비활성. 운영자가 8004 가동 후 startup
-        // health check (probeLocalModelAvailability) 가 available=true 로 전환.
-        available: false,
+        // LiteLLM gateway 가 /v1/models 응답에 항상 포함 → 클라이언트는 always available 가정.
+        // 내부 8004 vLLM 다운 시는 LiteLLM router 가 에러 응답 (기존 LLMClient 에러 처리 cought).
+        // ModelPool routing 의 자동 1M 전환을 위해 available 보장 필요.
+        available: true,
     },
     {
         id: 'gemma-4-31b',

--- a/backend/api/src/config/model-pool.ts
+++ b/backend/api/src/config/model-pool.ts
@@ -1,0 +1,48 @@
+/**
+ * Model Pool Config — env-driven 상수 (No-Hardcoding L1).
+ *
+ * 모든 임계값은 env 로 운영 조정 가능. effective capacity 는 derived
+ * (nominal * (1 - margin/100)) — 운영자가 margin 만 조정해도 자동 반영.
+ *
+ * 자세한 정책: docs/superpowers/specs/2026-05-25-llm-model-pool-design.md
+ *
+ * @module config/model-pool
+ */
+
+function parseIntEnv(key: string, defaultValue: number): number {
+    const v = process.env[key];
+    if (v === undefined) return defaultValue;
+    const n = parseInt(v, 10);
+    return Number.isFinite(n) ? n : defaultValue;
+}
+
+function parseBoolEnv(key: string, defaultValue: boolean): boolean {
+    const v = process.env[key];
+    if (v === undefined) return defaultValue;
+    return v.toLowerCase() === 'true';
+}
+
+const enabled = parseBoolEnv('LLM_POOL_ENABLED', true);
+const defaultModel = process.env.LLM_POOL_DEFAULT_MODEL ?? 'qwen3.6-35b-a3b';
+const largeModel = process.env.LLM_POOL_LARGE_MODEL ?? 'qwen3.6-35b-a3b-1m';
+const defaultCtx = parseIntEnv('LLM_POOL_DEFAULT_CTX', 262144);
+const largeCtx = parseIntEnv('LLM_POOL_LARGE_CTX', 1048576);
+const defaultMarginPct = parseIntEnv('LLM_POOL_DEFAULT_MARGIN_PCT', 10);
+const largeMarginPct = parseIntEnv('LLM_POOL_LARGE_MARGIN_PCT', 5);
+const routingMaxTokensDefault = parseIntEnv('LLM_POOL_ROUTING_MAX_TOKENS_DEFAULT', 16384);
+const minOutputTokens = parseIntEnv('LLM_POOL_MIN_OUTPUT_TOKENS', 4096);
+
+export const MODEL_POOL_CONFIG = {
+    enabled,
+    defaultModel,
+    largeModel,
+    defaultCtx,
+    largeCtx,
+    defaultMarginPct,
+    largeMarginPct,
+    routingMaxTokensDefault,
+    minOutputTokens,
+    // derived effective capacity (nominal * (1 - margin/100))
+    effectiveDefault: Math.floor(defaultCtx * (1 - defaultMarginPct / 100)),
+    effectiveLarge: Math.floor(largeCtx * (1 - largeMarginPct / 100)),
+} as const;

--- a/backend/api/src/errors/context-overflow.error.ts
+++ b/backend/api/src/errors/context-overflow.error.ts
@@ -1,0 +1,17 @@
+/**
+ * ContextOverflowError — 입력이 모든 모델의 effective capacity 초과 시 throw.
+ *
+ * model-pool 의 1M 안전망 3단계 (system 단독 990K+ 초과) 에서 발생.
+ * 운영자 알림 대상이 아닌 사용자 입력 검증 에러 — HTTP 400 응답 권장.
+ */
+export class ContextOverflowError extends Error {
+    public readonly inputTokens: number;
+    public readonly limitTokens: number;
+
+    constructor(message: string, inputTokens: number, limitTokens: number) {
+        super(message);
+        this.name = 'ContextOverflowError';
+        this.inputTokens = inputTokens;
+        this.limitTokens = limitTokens;
+    }
+}

--- a/backend/api/src/llm/client.ts
+++ b/backend/api/src/llm/client.ts
@@ -25,6 +25,8 @@ import { QuotaExceededError } from '../errors/quota-exceeded.error';
 import { getApiUsageTracker } from './usage-tracker';
 import { streamChat, nonStreamChat } from './stream-parser';
 import { buildExtraBody } from './reasoning-adapter';
+import { selectModelByCapacity } from './model-pool';
+import { MODEL_POOL_CONFIG } from '../config/model-pool';
 import {
     webSearch as webSearchAdapter,
     webFetch as webFetchAdapter,
@@ -111,11 +113,34 @@ export class LLMClient {
         },
     ): Promise<ChatMessage & { metrics?: UsageMetrics }> {
         this.checkQuota();
+
+        // Model Pool routing — this.config.model 이 pool default 와 같을 때만 자동 선택.
+        // 다른 model 로 인스턴스화 됐으면 manual 우회 (사용자 명시 모델 존중).
+        const isDefaultModel = this.config.model === MODEL_POOL_CONFIG.defaultModel;
+        const poolDecision = isDefaultModel
+            ? selectModelByCapacity(messages, { num_predict: options?.num_predict })
+            : { model: this.config.model, source: 'manual' as const };
+
+        if (poolDecision.source !== 'manual') {
+            const droppedStr = poolDecision.droppedMessages
+                ? ` dropped=${poolDecision.droppedMessages}`
+                : '';
+            logger.info(
+                `[ModelPool] routed=${poolDecision.model} source=${poolDecision.source}` +
+                ` input=~${poolDecision.inputTokens ?? '?'}${droppedStr}`,
+            );
+        }
+
+        const effectiveMessages = poolDecision.adjustedMessages ?? messages;
+        const effectiveOptions: ModelOptions | undefined = poolDecision.adjustedMaxTokens !== undefined
+            ? { ...(options ?? {}), num_predict: poolDecision.adjustedMaxTokens }
+            : options;
+
         const request: ChatRequest = {
-            model: this.config.model,
-            messages,
+            model: poolDecision.model,
+            messages: effectiveMessages,
             stream: !!onToken,
-            options,
+            options: effectiveOptions,
             ...(advancedOptions?.think !== undefined && { think: advancedOptions.think }),
             ...(advancedOptions?.format && { format: advancedOptions.format }),
             ...(advancedOptions?.tools && { tools: advancedOptions.tools }),
@@ -140,8 +165,8 @@ export class LLMClient {
             },
             {
                 attributes: {
-                    'llm.model': this.config.model,
-                    'llm.message_count': messages.length,
+                    'llm.model': poolDecision.model,
+                    'llm.message_count': effectiveMessages.length,
                     'llm.stream': !!onToken,
                     'llm.has_tools': !!advancedOptions?.tools,
                     'llm.has_format': !!advancedOptions?.format,

--- a/backend/api/src/llm/model-pool.ts
+++ b/backend/api/src/llm/model-pool.ts
@@ -1,0 +1,204 @@
+/**
+ * Model Pool — capacity 기반 proactive model routing.
+ *
+ * 두 chat 모델 (qwen3.6-35b-a3b 262K / qwen3.6-35b-a3b-1m 1M) 사이에서
+ * 입력 + 예상 출력 합산을 추정하여 자동 선택. 1M 도 부족 시 안전망 (input
+ * truncate 우선, max_tokens 축소 fallback, 극단 시 에러).
+ *
+ * Pure Manual 호환: options.model 명시 시 routing 우회.
+ *
+ * 자세한 정책: docs/superpowers/specs/2026-05-25-llm-model-pool-design.md
+ *
+ * @module llm/model-pool
+ */
+import { MODEL_POOL_CONFIG } from '../config/model-pool';
+import { ContextOverflowError } from '../errors/context-overflow.error';
+import type { ChatMessage, ModelOptions } from './types';
+
+/** tokenizer overhead 안전 마진 — system prompt boilerplate 등 */
+const SAFETY_BUFFER = 256;
+
+export interface ModelPoolDecision {
+    /** 사용할 model ID (LLMClient.chat 에 body.model 로 전달) */
+    model: string;
+    /** routing 소스 */
+    source: 'auto' | 'auto_trimmed' | 'auto_trimmed_reduced' | 'manual' | 'pool_disabled';
+    /** truncate 적용 시 새 messages — 없으면 원본 사용 */
+    adjustedMessages?: ChatMessage[];
+    /** max_tokens 축소 적용 시 새 값 — 없으면 원본 사용 */
+    adjustedMaxTokens?: number;
+    /** truncate 로 drop 된 message 수 (운영자 로깅용) */
+    droppedMessages?: number;
+    /** routing 결정 입력 토큰 추정 (logger 용) */
+    inputTokens?: number;
+}
+
+/**
+ * char-based token 추정 — 한국어 안전 (CJK 1.0 / ASCII 0.25 / 전각 1.0 / 기타 0.5).
+ * +5% 보수적 보정.
+ */
+export function estimateTokens(text: string): number {
+    if (!text) return 0;
+    let tokens = 0;
+    for (const ch of text) {
+        const code = ch.codePointAt(0) ?? 0;
+        if ((code >= 0xAC00 && code <= 0xD7A3) ||  // 한글
+            (code >= 0x3040 && code <= 0x9FFF) ||  // 일본어 + 한자
+            (code >= 0xFF00 && code <= 0xFFEF)) {  // 전각
+            tokens += 1.0;
+        } else if (code < 0x80) {
+            tokens += 0.25;
+        } else {
+            tokens += 0.5;
+        }
+    }
+    return Math.ceil(tokens * 1.05);
+}
+
+/** 모든 message 의 content + role/separator overhead (+4) 합. */
+export function estimateMessageTokens(messages: ChatMessage[]): number {
+    return messages.reduce(
+        (sum, m) => sum + estimateTokens(m.content || '') + 4,
+        0,
+    );
+}
+
+/**
+ * Token budget 안에서 messages 를 자르되 system + 최근 user/assistant 는 보존.
+ *
+ * 알고리즘:
+ *   1. system message (index 0 인 경우만) 항상 유지
+ *   2. 나머지를 최근 → 오래된 순으로 budget 누적
+ *   3. 최소 보장: rest 가 있으면 최근 1개라도 포함 (대화 맥락)
+ */
+export function truncateMessagesPreservingSystem(
+    messages: ChatMessage[],
+    budgetTokens: number,
+): ChatMessage[] {
+    if (messages.length === 0) return [];
+
+    const hasSystem = messages[0].role === 'system';
+    const systemMsg = hasSystem ? messages[0] : null;
+    const rest = hasSystem ? messages.slice(1) : messages;
+
+    const systemTokens = systemMsg
+        ? estimateTokens(systemMsg.content || '') + 4
+        : 0;
+
+    const kept: ChatMessage[] = [];
+    let used = systemTokens;
+    for (let i = rest.length - 1; i >= 0; i--) {
+        const tokens = estimateTokens(rest[i].content || '') + 4;
+        if (used + tokens > budgetTokens && kept.length > 0) break;
+        kept.unshift(rest[i]);
+        used += tokens;
+    }
+
+    if (rest.length > 0 && kept.length === 0) {
+        kept.push(rest[rest.length - 1]);
+    }
+
+    return systemMsg ? [systemMsg, ...kept] : kept;
+}
+
+/**
+ * 1M 모델 안전망 — output 보호 우선 점진차:
+ *   1단계: input truncate (system + 최근 N 보존)
+ *   2단계: max_tokens 축소 (최소 MIN_OUTPUT_TOKENS 보장)
+ *   3단계: 극단 (system 단독 990K+) — ContextOverflowError throw
+ */
+export function reduceToFit1M(
+    messages: ChatMessage[],
+    options: Pick<ModelOptions, 'num_predict'>,
+    inputTokens: number,
+): ModelPoolDecision {
+    const requested = options.num_predict ?? MODEL_POOL_CONFIG.routingMaxTokensDefault;
+    const effectiveLarge = MODEL_POOL_CONFIG.effectiveLarge;
+    const minOutput = MODEL_POOL_CONFIG.minOutputTokens;
+
+    if (inputTokens + requested <= effectiveLarge) {
+        return {
+            model: MODEL_POOL_CONFIG.largeModel,
+            source: 'auto',
+            adjustedMessages: messages,
+            adjustedMaxTokens: requested,
+            inputTokens,
+        };
+    }
+
+    // 1단계: input truncate
+    const inputBudget = effectiveLarge - requested - SAFETY_BUFFER;
+    const trimmed = truncateMessagesPreservingSystem(messages, inputBudget);
+    const newInputTokens = estimateMessageTokens(trimmed);
+
+    if (newInputTokens + requested <= effectiveLarge) {
+        return {
+            model: MODEL_POOL_CONFIG.largeModel,
+            source: 'auto_trimmed',
+            adjustedMessages: trimmed,
+            adjustedMaxTokens: requested,
+            droppedMessages: messages.length - trimmed.length,
+            inputTokens: newInputTokens,
+        };
+    }
+
+    // 2단계: max_tokens 축소
+    const available = effectiveLarge - newInputTokens - SAFETY_BUFFER;
+    if (available >= minOutput) {
+        return {
+            model: MODEL_POOL_CONFIG.largeModel,
+            source: 'auto_trimmed_reduced',
+            adjustedMessages: trimmed,
+            adjustedMaxTokens: available,
+            droppedMessages: messages.length - trimmed.length,
+            inputTokens: newInputTokens,
+        };
+    }
+
+    // 3단계: 극단
+    throw new ContextOverflowError(
+        `메시지가 1M 토큰 한계 초과 (input=${newInputTokens}, limit=${effectiveLarge}). 입력을 줄여주세요.`,
+        newInputTokens,
+        effectiveLarge,
+    );
+}
+
+/**
+ * Main routing 함수 — LLMClient.chat() 진입에서 호출.
+ *
+ * 흐름:
+ *   1. options.model 명시 → manual (routing 우회)
+ *   2. LLM_POOL_ENABLED=false → pool_disabled (default 모델)
+ *   3. 자동 routing — inputTokens + estimatedOutput 합산 기반:
+ *      - effective 262K 이하 → default 모델
+ *      - 초과 → reduceToFit1M (1M + 안전망)
+ */
+export function selectModelByCapacity(
+    messages: ChatMessage[],
+    options: Pick<ModelOptions, 'num_predict'> & { model?: string },
+): ModelPoolDecision {
+    // 1. Pure Manual 우회
+    if (options.model) {
+        return { model: options.model, source: 'manual' };
+    }
+
+    // 2. Pool 비활성
+    if (!MODEL_POOL_CONFIG.enabled) {
+        return { model: MODEL_POOL_CONFIG.defaultModel, source: 'pool_disabled' };
+    }
+
+    // 3. 자동 routing
+    const inputTokens = estimateMessageTokens(messages);
+    const estimatedOutput = options.num_predict ?? MODEL_POOL_CONFIG.routingMaxTokensDefault;
+    const required = inputTokens + estimatedOutput;
+
+    if (required <= MODEL_POOL_CONFIG.effectiveDefault) {
+        return {
+            model: MODEL_POOL_CONFIG.defaultModel,
+            source: 'auto',
+            inputTokens,
+        };
+    }
+
+    return reduceToFit1M(messages, options, inputTokens);
+}

--- a/backend/api/src/llm/stream-parser.ts
+++ b/backend/api/src/llm/stream-parser.ts
@@ -23,6 +23,9 @@ import type {
 } from './types';
 import { buildImageDataUrl } from '../utils/image-mime';
 import { parseReasoningTags } from './reasoning-tag-parser';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('StreamParser');
 
 /**
  * Fallback 메시지: vLLM reasoning 모델(EXAONE/Qwen3 등) 이 reasoning 토큰만으로
@@ -316,6 +319,12 @@ export async function streamChat(
         }
     }
 
+    // 사후 안전망 — finish_reason='length' = max_tokens 도달로 응답 절단됨.
+    // ModelPool 의 proactive routing 이 max_tokens 충분히 확보 못한 신호.
+    if (finishReason === 'length') {
+        log.warn(`[ModelPool] response truncated at max_tokens — model=${request.model} completion_tokens=${completionTokens}`);
+    }
+
     return {
         role: 'assistant',
         content: finalContent,
@@ -381,6 +390,11 @@ export async function nonStreamChat(
         if (finishReason === 'length') {
             finalContent += '\n\n' + FALLBACK_REASONING_ONLY_NOTICE;
         }
+    }
+
+    // 사후 안전망 (nonStream) — Section 5.6
+    if (finishReason === 'length') {
+        log.warn(`[ModelPool] response truncated at max_tokens — model=${request.model} completion_tokens=${r.usage?.completion_tokens ?? '?'}`);
     }
 
     return {


### PR DESCRIPTION
## Summary

두 chat 모델 (`qwen3.6-35b-a3b` 262K / `qwen3.6-35b-a3b-1m` 1M) 을 capacity 기반으로
**proactive routing**. 입력 + 예상 출력 합산이 default 모델 임계 초과 시 1M 자동
전환. 1M 도 부족 시 안전망 (output 보호 우선 → input truncate → max_tokens 축소).

**Spec**: `docs/superpowers/specs/2026-05-25-llm-model-pool-design.md` (gitignored)
**Plan**: `docs/superpowers/plans/2026-05-25-llm-model-pool-implementation.md` (gitignored)

## Why

- 외부 vLLM/LiteLLM gateway 변경 (`rockyhan.duckdns.org:13401`) — 1M 모델 노출됐는데 미활용
- 사용자 요구: **"답변이 잘리지 않고 끝까지 출력되는 가장 안전한 방향"**
- 현재 Pure Manual 정책 (단일 default 모델) 으로는 긴 답변 케이스에서 `finish_reason='length'` 발생 위험

## Changes

| 파일 | 종류 | 변경 |
|---|---|---|
| `backend/api/src/errors/context-overflow.error.ts` | 신규 | `ContextOverflowError` (system 단독 1M 초과) |
| `backend/api/src/config/model-pool.ts` | 신규 | `MODEL_POOL_CONFIG` — 9 env + derived effective capacity |
| `backend/api/src/llm/model-pool.ts` | 신규 | `selectModelByCapacity` / `estimateTokens` / `estimateMessageTokens` / `truncateMessagesPreservingSystem` / `reduceToFit1M` |
| `backend/api/src/llm/client.ts` | 수정 | `chat()` 진입 routing hook (this.config.model === pool default 일 때만) |
| `backend/api/src/llm/stream-parser.ts` | 수정 | `finish_reason='length'` → `logger.warn` (사후 안전망) |
| `backend/api/src/config/local-models.ts` | 수정 | `qwen3.6-35b-a3b-1m.available: true` |
| `.env.example` | 수정 | `LLM_POOL_*` 9개 env 문서화 |

총: 신규 215줄 + 수정 4 파일

## Routing logic

```
selectModelByCapacity(messages, options):
  1. options.model 명시 → manual (우회)
  2. LLM_POOL_ENABLED=false → pool_disabled (default)
  3. inputTokens + estimatedOutput <= EFFECTIVE_262K (235K) → default
  4. else → reduceToFit1M:
     a. input truncate (system + 최근 N 보존) → 충분하면 OK
     b. 그래도 부족 → max_tokens 축소 (최소 4096 보장)
     c. system 단독 990K+ → ContextOverflowError
```

## Test plan
- [x] tsc 0 / eslint 0
- [x] jest **1649/1649 통과** (기존 회귀 0)
- [x] model-pool **23/23 통과** (5 group: config / estimator / truncate / reduce / select)
- [x] build:backend + PM2 reload — online
- [x] stream-parser `finish_reason='length'` warn 동작 production 확인
- [ ] (운영자 manual): 긴 메시지 (한글 250K+ char) 전송 → pm2 logs `[ModelPool] routed=qwen3.6-35b-a3b-1m source=auto`

## Test code (gitignored)

```typescript
// backend/api/src/__tests__/model-pool.test.ts — 5 group, 23 tests
// (위치: local 보관, memory project_test_dir_ignored 정책)
```

## Rollback (1초)

```bash
echo "LLM_POOL_ENABLED=false" >> .env
pm2 reload openmake-llm --update-env
```

## Follow-up

- vLLM `/tokenize` endpoint 호출 옵션 (정확 추정, +latency)
- `finish_reason='length'` 자동 continuation (별도 PR)
- 추가 모델 풀 통합 (gemma-4-31b 등)

🤖 Generated with [Claude Code](https://claude.com/claude-code)