### PR TITLE
feat(llm-pool): routing 통계 모니터 — admin dashboard 신규 sub-tab

### DIFF
--- a/backend/api/src/controllers/admin.controller.ts
+++ b/backend/api/src/controllers/admin.controller.ts
@@ -61,6 +61,8 @@ export class AdminController {
         this.router.get('/alerts/export', this.exportAlertHistoryCsv.bind(this));
         // alert_history 통계 (대시보드 요약 카드용)
         this.router.get('/alerts/stats', this.getAlertStats.bind(this));
+        // LLM Model Pool routing 통계 (PR #98 follow-up)
+        this.router.get('/llm-pool/stats', this.getLlmPoolStats.bind(this));
         // alert_history acknowledge (확인 처리) — 운영자 ID/시간 기록
         this.router.post('/alerts/:id/acknowledge', this.acknowledgeAlert.bind(this));
 
@@ -564,6 +566,76 @@ export class AdminController {
         } catch (error) {
             log.error('[Admin AlertHistory] 오류:', error);
             res.status(500).json(internalError('알림 이력 조회 실패'));
+        }
+    }
+
+    /**
+     * GET /api/admin/llm-pool/stats — Model Pool routing 통계 (PR #98 follow-up).
+     *
+     * 응답:
+     *   - byModel: { 'qwen3.6-35b-a3b': N, 'qwen3.6-35b-a3b-1m': N, ... }
+     *   - bySource: { auto: N, auto_trimmed: N, auto_trimmed_reduced: N, manual: N, pool_disabled: N }
+     *   - largeModelRatioPct: 1M routing 비율 (%) — 30% 초과 시 margin 조정 검토
+     *   - last7Days: [{ date, default, large, total }] × 7
+     *
+     * 모두 지난 7일 데이터. 운영자가 LLM_POOL_DEFAULT_MARGIN_PCT 조정 의사결정용.
+     */
+    private async getLlmPoolStats(_req: Request, res: Response): Promise<void> {
+        try {
+            const { getPool } = await import('../data/models/unified-database');
+            const pool = getPool();
+
+            const [byModelRes, bySourceRes, trendRes] = await Promise.all([
+                pool.query<{ model: string; count: string }>(
+                    `SELECT model, COUNT(*)::text AS count FROM model_pool_metrics
+                     WHERE created_at >= NOW() - INTERVAL '7 days' GROUP BY model`,
+                ),
+                pool.query<{ source: string; count: string }>(
+                    `SELECT source, COUNT(*)::text AS count FROM model_pool_metrics
+                     WHERE created_at >= NOW() - INTERVAL '7 days' GROUP BY source`,
+                ),
+                pool.query<{ date: string; total: string; default_count: string; large_count: string }>(
+                    `SELECT to_char(date_trunc('day', d), 'YYYY-MM-DD') AS date,
+                            COUNT(m.*)::text AS total,
+                            COUNT(*) FILTER (WHERE m.model NOT LIKE '%-1m')::text AS default_count,
+                            COUNT(*) FILTER (WHERE m.model LIKE '%-1m')::text AS large_count
+                     FROM generate_series(date_trunc('day', NOW()) - INTERVAL '6 days',
+                                          date_trunc('day', NOW()), INTERVAL '1 day') AS d
+                     LEFT JOIN model_pool_metrics m ON date_trunc('day', m.created_at) = d
+                     GROUP BY d ORDER BY d ASC`,
+                ),
+            ]);
+
+            const byModel: Record<string, number> = {};
+            let totalCount = 0;
+            let largeCount = 0;
+            for (const r of byModelRes.rows) {
+                const n = parseInt(r.count, 10);
+                byModel[r.model] = n;
+                totalCount += n;
+                if (r.model.endsWith('-1m')) largeCount += n;
+            }
+
+            const bySource: Record<string, number> = {};
+            for (const r of bySourceRes.rows) {
+                bySource[r.source] = parseInt(r.count, 10);
+            }
+
+            res.json(success({
+                byModel,
+                bySource,
+                totalCount,
+                largeModelRatioPct: totalCount > 0 ? Math.round((largeCount / totalCount) * 1000) / 10 : 0,
+                last7Days: trendRes.rows.map(r => ({
+                    date: r.date,
+                    total: parseInt(r.total, 10),
+                    default: parseInt(r.default_count, 10),
+                    large: parseInt(r.large_count, 10),
+                })),
+            }));
+        } catch (error) {
+            log.error('[Admin LlmPoolStats] 오류:', error);
+            res.status(500).json(internalError('LLM pool 통계 조회 실패'));
         }
     }
 

--- a/backend/api/src/llm/client.ts
+++ b/backend/api/src/llm/client.ts
@@ -131,6 +131,26 @@ export class LLMClient {
             );
         }
 
+        // 통계 영속화 — fire-and-forget (운영자 모니터링용, audit 패턴).
+        // 실패해도 chat 자체는 계속 진행.
+        void (async () => {
+            try {
+                const { getPool } = await import('../data/models/unified-database');
+                await getPool().query(
+                    `INSERT INTO model_pool_metrics (model, source, input_tokens, dropped_messages)
+                     VALUES ($1, $2, $3, $4)`,
+                    [
+                        poolDecision.model,
+                        poolDecision.source,
+                        poolDecision.inputTokens ?? null,
+                        poolDecision.droppedMessages ?? null,
+                    ],
+                );
+            } catch (err) {
+                logger.warn(`[ModelPool] metric INSERT 실패 (continue):`, err);
+            }
+        })();
+
         const effectiveMessages = poolDecision.adjustedMessages ?? messages;
         const effectiveOptions: ModelOptions | undefined = poolDecision.adjustedMaxTokens !== undefined
             ? { ...(options ?? {}), num_predict: poolDecision.adjustedMaxTokens }

--- a/frontend/web/public/js/modules/pages/audit.js
+++ b/frontend/web/public/js/modules/pages/audit.js
@@ -71,6 +71,7 @@
                 <div class="filter-bar" style="margin-bottom: 0; border-bottom: 0; border-bottom-left-radius: 0; border-bottom-right-radius: 0; padding-bottom: 8px;">
                     <button class="btn-primary subtab-btn" data-subtab="logs" onclick="switchAuditSubTab('logs')">📋 감사 로그</button>
                     <button class="btn-secondary subtab-btn" data-subtab="alerts" onclick="switchAuditSubTab('alerts')" style="background: var(--bg-tertiary); color: var(--text-primary); border: 1px solid var(--border-light);">🔔 알림 이력</button>
+                    <button class="btn-secondary subtab-btn" data-subtab="pool" onclick="switchAuditSubTab('pool')" style="background: var(--bg-tertiary); color: var(--text-primary); border: 1px solid var(--border-light);">🤖 LLM Pool</button>
                 </div>
 
                 <!-- audit_logs panel -->
@@ -121,6 +122,12 @@
                         </table>
                     </div>
                     <div id="alertPagination" style="margin-top: 16px; display: flex; justify-content: center; gap: 8px;"></div>
+                </div>
+
+                <!-- LLM Pool panel (PR #98 follow-up) -->
+                <div id="llmPoolPanel" style="display: none;">
+                    <div id="llmPoolStatsRow" class="stats-row" style="display:none;"></div>
+                    <div class="log-count">지난 7일 LLM Model Pool routing 통계. 1M 비율 30% 초과 시 LLM_POOL_DEFAULT_MARGIN_PCT 조정 검토.</div>
                 </div>`;
                 }
 
@@ -136,7 +143,11 @@
                     });
                     document.getElementById('auditLogsPanel').style.display = tab === 'logs' ? '' : 'none';
                     document.getElementById('alertHistoryPanel').style.display = tab === 'alerts' ? '' : 'none';
-                    if (tab === 'alerts' && !window.__alertHistoryLoaded) {
+                    const poolPanel = document.getElementById('llmPoolPanel');
+                    if (poolPanel) poolPanel.style.display = tab === 'pool' ? '' : 'none';
+                    if (tab === 'pool') {
+                        loadLlmPoolStats();
+                    } else if (tab === 'alerts' && !window.__alertHistoryLoaded) {
                         loadAlertHistory(1);
                         loadAlertStats();
                         window.__alertHistoryLoaded = true;
@@ -319,6 +330,52 @@
                     }
                 }
 
+                async function loadLlmPoolStats() {
+                    const row = document.getElementById('llmPoolStatsRow');
+                    if (!row) return;
+                    try {
+                        const res = await authFetch('/api/admin/llm-pool/stats');
+                        const s = res.data || res;
+                        const trend = s.last7Days || [];
+                        const bySource = s.bySource || {};
+                        const trendMax = Math.max(1, ...trend.map(d => d.total || 0));
+                        const trendBars = trend.map(d => {
+                            const h = Math.max(2, Math.round(((d.total || 0) / trendMax) * 32));
+                            const cls = (d.large || 0) > (d.default || 0) ? 'bar critical' : 'bar';
+                            return `<div class="${cls}" style="height:${h}px" title="${d.date}: total ${d.total} (1m ${d.large}, default ${d.default})"></div>`;
+                        }).join('');
+                        const ratio = s.largeModelRatioPct || 0;
+                        const ratioCls = ratio > 30 ? 'danger' : (ratio > 15 ? 'warning' : 'muted');
+                        const total = s.totalCount || 0;
+                        const trimmedCount = (bySource.auto_trimmed || 0) + (bySource.auto_trimmed_reduced || 0);
+                        row.innerHTML = `
+                            <div class="stat-card">
+                                <div class="stat-card-label">7일 1M routing 비율</div>
+                                <div class="stat-card-value ${ratioCls}">${ratio}%</div>
+                                <div class="stat-card-sub">${total} 호출 중 ${total > 0 ? Math.round(ratio * total / 100) : 0}건</div>
+                            </div>
+                            <div class="stat-card">
+                                <div class="stat-card-label">7일 truncate 발동</div>
+                                <div class="stat-card-value ${trimmedCount > 0 ? 'warning' : 'muted'}">${trimmedCount}</div>
+                                <div class="stat-card-sub">input truncate + max_tokens 축소 합계</div>
+                            </div>
+                            <div class="stat-card">
+                                <div class="stat-card-label">7일 trend (1m=red)</div>
+                                <div class="stat-card-value muted" style="font-size:18px">총 ${total}건</div>
+                                <div class="stat-bars">${trendBars}</div>
+                            </div>
+                            <div class="stat-card">
+                                <div class="stat-card-label">source 분포</div>
+                                <div class="stat-card-sub">auto ${bySource.auto || 0} / trimmed ${bySource.auto_trimmed || 0} / reduced ${bySource.auto_trimmed_reduced || 0} / manual ${bySource.manual || 0}</div>
+                            </div>
+                        `;
+                        row.style.display = 'grid';
+                    } catch (e) {
+                        console.error('[Audit] llm-pool stats 로드 실패:', e);
+                        row.style.display = 'none';
+                    }
+                }
+
                 async function loadAlertStats() {
                     const row = document.getElementById('alertStatsRow');
                     if (!row) return;
@@ -443,6 +500,7 @@
                 if (typeof acknowledgeAlert === 'function') window.acknowledgeAlert = acknowledgeAlert;
                 if (typeof exportAlertsCsv === 'function') window.exportAlertsCsv = exportAlertsCsv;
                 if (typeof loadAlertStats === 'function') window.loadAlertStats = loadAlertStats;
+                if (typeof loadLlmPoolStats === 'function') window.loadLlmPoolStats = loadLlmPoolStats;
             } catch (e) {
                 console.error('[PageModule:audit] init error:', e);
             }
@@ -463,6 +521,7 @@
             try { delete window.acknowledgeAlert; } catch (e) { }
             try { delete window.exportAlertsCsv; } catch (e) { }
             try { delete window.loadAlertStats; } catch (e) { }
+            try { delete window.loadLlmPoolStats; } catch (e) { }
             try { delete window.__alertHistoryLoaded; } catch (e) { }
         }
     };

--- a/services/database/migrations/031_model_pool_metrics.sql
+++ b/services/database/migrations/031_model_pool_metrics.sql
@@ -1,0 +1,23 @@
+-- Migration 031 — Model Pool routing 통계 영속화
+--
+-- LLMClient.chat() 의 capacity-based routing 결정 (PR #98) 을 DB 에 영속화.
+-- admin dashboard 의 1주일 routing 비율 모니터링 + LLM_POOL_DEFAULT_MARGIN_PCT
+-- 조정 의사결정 근거 제공.
+--
+-- 행 INSERT 빈도: 매 chat 호출 마다 1행 — 운영 부담 적음 (PR #92 의 alert_history
+-- 와 동급 빈도). PII 없음 (input_tokens 수치만, content 제외).
+
+CREATE TABLE IF NOT EXISTS model_pool_metrics (
+    id          SERIAL PRIMARY KEY,
+    model       TEXT NOT NULL,
+    source      TEXT NOT NULL CHECK (source IN ('auto', 'auto_trimmed', 'auto_trimmed_reduced', 'manual', 'pool_disabled')),
+    input_tokens     INTEGER,
+    dropped_messages INTEGER,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+-- 주의: finish_reason='length' (truncation) 발생은 stream-parser.ts 의 logger.warn
+-- + (future) alert_history 별도 책임. 본 테이블은 routing decision 만 추적.
+
+CREATE INDEX IF NOT EXISTS idx_model_pool_metrics_created ON model_pool_metrics(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_model_pool_metrics_model ON model_pool_metrics(model);
+CREATE INDEX IF NOT EXISTS idx_model_pool_metrics_source ON model_pool_metrics(source);


### PR DESCRIPTION
## Summary

PR #98 의 follow-up. ModelPool routing 결정을 DB 영속화 + admin dashboard 통계
위젯. 운영자가 1주일 1M routing 비율 모니터링 → \`LLM_POOL_DEFAULT_MARGIN_PCT\`
조정 의사결정 근거.

## Changes

| 파일 | 종류 | 변경 |
|---|---|---|
| \`services/database/migrations/031_model_pool_metrics.sql\` | 신규 | model/source/input_tokens/dropped/created_at, 인덱스 3개. PII 없음 |
| \`backend/api/src/llm/client.ts\` | 수정 | chat() routing 결정 후 fire-and-forget INSERT (audit 패턴) |
| \`backend/api/src/controllers/admin.controller.ts\` | 수정 | GET /api/admin/llm-pool/stats — 3 query 병렬 (byModel/bySource/last7Days) |
| \`frontend/web/public/js/modules/pages/audit.js\` | 수정 | 신규 sub-tab \"🤖 LLM Pool\" + loadLlmPoolStats() + 4 카드 |

## Stats endpoint 응답

```json
{
  \"byModel\": { \"qwen3.6-35b-a3b\": 142, \"qwen3.6-35b-a3b-1m\": 8 },
  \"bySource\": { \"auto\": 145, \"auto_trimmed\": 3, \"manual\": 2 },
  \"totalCount\": 150,
  \"largeModelRatioPct\": 5.3,
  \"last7Days\": [{ \"date\": \"...\", \"total\": ..., \"default\": ..., \"large\": ... }]
}
```

## Frontend 4 카드

1. **7일 1M routing 비율** — >30% red / >15% warning / else muted
2. **7일 truncate 발동** — auto_trimmed + auto_trimmed_reduced 합계 (>0 warning)
3. **7일 trend mini chart** — CSS flex bar, 1M 우세 날 red
4. **source 분포** — auto / trimmed / reduced / manual 카운트

## Test plan
- [x] tsc 0 / eslint 0
- [x] frontend validate-modules 통과
- [x] migration 적용 확인 (model_pool_metrics 테이블 생성)
- [ ] (운영자 manual): PM2 reload 후 chat 호출 → \`SELECT * FROM model_pool_metrics LIMIT 5\` 확인 → admin → 감사 로그 → 🤖 LLM Pool tab 진입

## Follow-up

- truncate 별도 통계 (alert_history 의 'model.truncated' alert type)
- 운영자 자동 알림 (1M 비율 임계 초과 webhook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)