### PR TITLE
feat(alerts): ContextOverflowError → 413 + audit + 자동 webhook

### DIFF
--- a/backend/api/src/services/AuditService.ts
+++ b/backend/api/src/services/AuditService.ts
@@ -165,6 +165,8 @@ const CRITICAL_ACTIONS: Record<string, 'info' | 'warning' | 'critical'> = {
     'consent.withdrawn': 'warning',
     // GDPR Article 20 — 데이터 export 요청 (operator 인지용)
     'export.requested': 'warning',
+    // PR #98 model-pool 안전망 3단계 — 1M 도 초과 (드물지만 즉시 인지)
+    'chat.context_overflow': 'warning',
     // 기존 ApiKeyService 패턴 정합
     'api_key.revoked': 'warning',
     // info 는 audit 만 (alert webhook 안 보냄)

--- a/backend/api/src/utils/error-handler.ts
+++ b/backend/api/src/utils/error-handler.ts
@@ -23,6 +23,7 @@ import { createLogger } from './logger';
 import { error as apiError, badRequest as apiBadRequest, ErrorCodes, ApiErrorResponse } from './api-response';
 import { QuotaExceededError } from '../errors/quota-exceeded.error';
 import { KeyExhaustionError } from '../errors/key-exhaustion.error';
+import { ContextOverflowError } from '../errors/context-overflow.error';
 
 const logger = createLogger('ErrorHandler');
 
@@ -189,6 +190,34 @@ export function errorHandler(
             resetTime: err.resetTime.toISOString(),
             totalKeys: err.totalKeys,
             keysInCooldown: err.keysInCooldown,
+        }));
+        return;
+    }
+
+    // ── ContextOverflowError → 413 (PR #98 model-pool 안전망 3단계) ──
+    if (err instanceof ContextOverflowError) {
+        logger.warn(`Context overflow: input=${err.inputTokens} limit=${err.limitTokens}`, { path: req.path });
+        // Audit + 자동 alert (CRITICAL_ACTIONS whitelist 매칭 — PR #84 패턴)
+        void (async () => {
+            try {
+                const { getAuditService } = await import('../services/AuditService');
+                await getAuditService().logAudit({
+                    action: 'chat.context_overflow',
+                    userId: req.user && 'id' in req.user ? String((req.user as { id?: string | number }).id) : undefined,
+                    resourceType: 'chat',
+                    details: { inputTokens: err.inputTokens, limitTokens: err.limitTokens, path: req.path },
+                    ipAddress: req.ip,
+                    userAgent: req.headers['user-agent'],
+                    actor: {
+                        email: req.user && 'email' in req.user ? (req.user as { email?: string }).email : undefined,
+                        role: req.user && 'role' in req.user ? (req.user as { role?: string }).role : undefined,
+                    },
+                });
+            } catch (e) { logger.warn('[audit] chat.context_overflow 기록 실패:', e); }
+        })();
+        res.status(413).json(apiError(ErrorCodes.PAYLOAD_TOO_LARGE, err.message, {
+            inputTokens: err.inputTokens,
+            limitTokens: err.limitTokens,
         }));
         return;
     }


### PR DESCRIPTION
## Summary

PR #98 model-pool 안전망 3단계 (system 단독 1M 초과) 에서 발생하는
\`ContextOverflowError\` 에 대한 일관된 처리.

## Changes

**\`backend/api/src/utils/error-handler.ts\`**
- \`ContextOverflowError\` instanceof 분기 추가 (QuotaExceededError 패턴)
- HTTP **413 PAYLOAD_TOO_LARGE** 응답 (RFC 7231)
- 응답 body: \`{ inputTokens, limitTokens }\` — 사용자가 얼마나 줄여야 하는지 명시
- fire-and-forget \`AuditService.logAudit\` (action='chat.context_overflow', actor)

**\`backend/api/src/services/AuditService.ts\`**
- \`CRITICAL_ACTIONS\` whitelist 에 \`'chat.context_overflow': 'warning'\` 등록
- 자동 webhook 발송 (PR #84 SoT 패턴) — 운영자 즉시 인지
- 드문 event 라 15분 cooldown spam 방어

## Design 결정

- **HTTP 413** — 입력 크기 초과 표준 (Multer LIMIT_FILE_SIZE 와 동급)
- 한국어 에러 메시지 (ContextOverflowError.message)
- audit logging fire-and-forget — error 응답 latency 영향 0
- **warning severity** — 사용자 입력 검증 에러지만 운영자 인지 가치 있음

## Test plan
- [x] tsc 0 / eslint 0
- [x] jest 58/58 통과 (audit/alert/model-pool/error-handler 회귀 0)
- [ ] (운영자 manual): 1M 초과 메시지 전송 시 HTTP 413 + admin webhook 도착 확인

## Follow-up

- HTTP 413 응답 시 frontend toast 친절한 가이드 (별도 PR)
- ContextOverflowError 빈도 통계 (LLM Pool dashboard 카드 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)