### PR TITLE
fix(deep-research): 동작 중 멈춤 해결 — fetch·LLM 호출에 abort/timeout 전파

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -461,6 +461,11 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # ATTACH_CACHE_MAX_CHARS=400000
 # Deep Research 보고서 생성 타임아웃 (ms, 기본 600000=10분 — 전역 LLM_TIMEOUT 독립)
 # DEEP_RESEARCH_REPORT_TIMEOUT_MS=600000
+# Deep Research 추가정보 필요 판단 LLM 호출 타임아웃 (ms, 기본 30000)
+# DEEP_RESEARCH_NEED_MORE_TIMEOUT_MS=30000
+# 웹 검색 프로바이더 개별 fetch 타임아웃 (ms, 기본 12000). 너무 낮으면 느린 정상 응답이
+# 잘려 소스 누락, 너무 높으면 응답을 무는 서버가 검색 단계를 지연. prod latency 측정 후 조정.
+# WEB_SEARCH_FETCH_TIMEOUT_MS=12000
 # 웹검색 도메인당 최대 결과 수 (소스 다양성 보호, 0=무제한, 기본 5)
 # SEARCH_MAX_PER_DOMAIN=5
 

--- a/backend/api/src/config/timeouts.ts
+++ b/backend/api/src/config/timeouts.ts
@@ -30,6 +30,10 @@ export const LLM_TIMEOUTS = {
     MEMORY_EXTRACTION_TIMEOUT_MS: 30000,
     /** Deep Research 주제 분해 타임아웃 (ms) */
     RESEARCH_DECOMPOSE_TIMEOUT_MS: 60000,
+    /** Deep Research 추가정보 필요 판단 LLM 호출 타임아웃 (ms) */
+    RESEARCH_NEED_MORE_TIMEOUT_MS: 30000,
+    /** 웹 검색 프로바이더 개별 fetch 타임아웃 (ms) — timeout 부재 시 Promise.all 무한 hang 방지 */
+    WEB_SEARCH_FETCH_TIMEOUT_MS: Number(process.env.WEB_SEARCH_FETCH_TIMEOUT_MS) || 12000,
     /** Deep Research 청크 합성 개별 타임아웃 (ms) — 전역 LLM_TIMEOUT과 독립 */
     SYNTHESIS_PER_CHUNK_TIMEOUT_MS: 120000,
     /** Deep Research 청크 병합 타임아웃 (ms) */

--- a/backend/api/src/config/timeouts.ts
+++ b/backend/api/src/config/timeouts.ts
@@ -30,9 +30,9 @@ export const LLM_TIMEOUTS = {
     MEMORY_EXTRACTION_TIMEOUT_MS: 30000,
     /** Deep Research 주제 분해 타임아웃 (ms) */
     RESEARCH_DECOMPOSE_TIMEOUT_MS: 60000,
-    /** Deep Research 추가정보 필요 판단 LLM 호출 타임아웃 (ms) */
-    RESEARCH_NEED_MORE_TIMEOUT_MS: 30000,
-    /** 웹 검색 프로바이더 개별 fetch 타임아웃 (ms) — timeout 부재 시 Promise.all 무한 hang 방지 */
+    /** Deep Research 추가정보 필요 판단 LLM 호출 타임아웃 (ms). env override: DEEP_RESEARCH_NEED_MORE_TIMEOUT_MS */
+    RESEARCH_NEED_MORE_TIMEOUT_MS: Number(process.env.DEEP_RESEARCH_NEED_MORE_TIMEOUT_MS) || 30000,
+    /** 웹 검색 프로바이더 개별 fetch 타임아웃 (ms) — timeout 부재 시 Promise.all 무한 hang 방지. env override: WEB_SEARCH_FETCH_TIMEOUT_MS */
     WEB_SEARCH_FETCH_TIMEOUT_MS: Number(process.env.WEB_SEARCH_FETCH_TIMEOUT_MS) || 12000,
     /** Deep Research 청크 합성 개별 타임아웃 (ms) — 전역 LLM_TIMEOUT과 독립 */
     SYNTHESIS_PER_CHUNK_TIMEOUT_MS: 120000,

--- a/backend/api/src/mcp/web-search/providers.ts
+++ b/backend/api/src/mcp/web-search/providers.ts
@@ -11,6 +11,7 @@ import { SearchResult } from './types';
 import { getConfig } from '../../config/env';
 import { createLogger } from '../../utils/logger';
 import { CAPACITY } from '../../config/runtime-limits';
+import { LLM_TIMEOUTS } from '../../config/timeouts';
 import { getSearchLocale } from '../../i18n/search-locale';
 
 /** Google Custom Search API 키 */
@@ -28,6 +29,25 @@ const logger = createLogger('WebSearch');
 if (!GOOGLE_API_KEY || !GOOGLE_CSE_ID) {
     logger.warn('GOOGLE_API_KEY 또는 GOOGLE_CSE_ID가 설정되지 않았습니다.');
     logger.warn('Google 검색 기능이 비활성화됩니다. .env 파일에 설정하세요.');
+}
+
+/**
+ * 검색 프로바이더용 fetch — 개별 timeout 과 외부 abort signal 을 결합한다.
+ *
+ * provider fetch 에 timeout 이 없으면 응답을 물고 있는 검색 서버 하나가
+ * `performWebSearch` 의 `Promise.all` 을 무한정 멈추게 한다(Deep Research 멈춤 주원인).
+ * timeout(WEB_SEARCH_FETCH_TIMEOUT_MS) 또는 외부 중단 중 먼저 발생하는 쪽이 요청을 취소한다.
+ *
+ * @param url - 요청 URL
+ * @param externalSignal - 상위(연구 중단) abort signal (optional)
+ * @param init - 추가 fetch 옵션 (headers 등)
+ */
+function searchFetch(url: string, externalSignal?: AbortSignal, init?: RequestInit): Promise<Response> {
+    const timeoutSignal = AbortSignal.timeout(LLM_TIMEOUTS.WEB_SEARCH_FETCH_TIMEOUT_MS);
+    const signal = externalSignal
+        ? AbortSignal.any([externalSignal, timeoutSignal])
+        : timeoutSignal;
+    return fetch(url, { ...init, signal });
 }
 
 /**
@@ -59,7 +79,7 @@ function decodeXmlEntities(text: string): string {
  * @param language - 검색 언어 (기본값: 'en')
  * @returns SearchResult 배열 (API 키 미설정 또는 실패 시 빈 배열)
  */
-export async function searchGoogle(query: string, maxResults: number = 10, globalSearch: boolean = true, language: string = 'en'): Promise<SearchResult[]> {
+export async function searchGoogle(query: string, maxResults: number = 10, globalSearch: boolean = true, language: string = 'en', signal?: AbortSignal): Promise<SearchResult[]> {
     const results: SearchResult[] = [];
 
     if (!GOOGLE_API_KEY || !GOOGLE_CSE_ID) {
@@ -75,7 +95,7 @@ export async function searchGoogle(query: string, maxResults: number = 10, globa
             url += getSearchLocale(language).googleParams;
         }
 
-        const response = await fetch(url);
+        const response = await searchFetch(url, signal);
 
         if (!response.ok) {
             logger.error(`Google API 오류: ${response.status}`);
@@ -112,7 +132,7 @@ export async function searchGoogle(query: string, maxResults: number = 10, globa
  * @param language - 검색 언어 (기본값: 'en')
  * @returns SearchResult 배열 (실패 시 빈 배열)
  */
-export async function searchWikipedia(query: string, language: string = 'en'): Promise<SearchResult[]> {
+export async function searchWikipedia(query: string, language: string = 'en', signal?: AbortSignal): Promise<SearchResult[]> {
     const results: SearchResult[] = [];
 
     try {
@@ -120,7 +140,7 @@ export async function searchWikipedia(query: string, language: string = 'en'): P
         const wikiDomain = getSearchLocale(language).wikiDomain;
         const url = `https://${wikiDomain}.wikipedia.org/w/api.php?action=query&list=search&srsearch=${encodeURIComponent(query)}&format=json&srlimit=5&origin=*`;
 
-        const response = await fetch(url);
+        const response = await searchFetch(url, signal);
         if (!response.ok) return results;
 
         const data = await response.json() as {
@@ -159,7 +179,7 @@ export async function searchWikipedia(query: string, language: string = 'en'): P
  * @param language - 검색 언어 (기본값: 'en')
  * @returns SearchResult 배열 (실패 시 빈 배열)
  */
-export async function searchGoogleNews(query: string, language: string = 'en'): Promise<SearchResult[]> {
+export async function searchGoogleNews(query: string, language: string = 'en', signal?: AbortSignal): Promise<SearchResult[]> {
     const results: SearchResult[] = [];
 
     try {
@@ -167,7 +187,7 @@ export async function searchGoogleNews(query: string, language: string = 'en'): 
         const newsParams = getSearchLocale(language).newsParams;
         const url = `https://news.google.com/rss/search?q=${encodeURIComponent(query)}&${newsParams}`;
 
-        const response = await fetch(url);
+        const response = await searchFetch(url, signal);
         if (!response.ok) return results;
 
         const xml = (await response.text()).replace(/\u0000/g, '');
@@ -229,12 +249,12 @@ export async function searchGoogleNews(query: string, language: string = 'en'): 
  * @param query - 검색 쿼리
  * @returns SearchResult 배열 (실패 시 빈 배열)
  */
-export async function searchDuckDuckGoAPI(query: string): Promise<SearchResult[]> {
+export async function searchDuckDuckGoAPI(query: string, signal?: AbortSignal): Promise<SearchResult[]> {
     const results: SearchResult[] = [];
 
     try {
         const url = `https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_html=1&skip_disambig=1`;
-        const response = await fetch(url);
+        const response = await searchFetch(url, signal);
         if (!response.ok) return results;
 
         const data = await response.json() as {
@@ -292,7 +312,7 @@ export async function searchDuckDuckGoAPI(query: string): Promise<SearchResult[]
  * @param maxResults - 최대 결과 수 (기본값: 5, API 제한: 최대 100)
  * @returns SearchResult 배열 (키 미설정/실패 시 빈 배열)
  */
-export async function searchNaverNews(query: string, maxResults: number = 5): Promise<SearchResult[]> {
+export async function searchNaverNews(query: string, maxResults: number = 5, signal?: AbortSignal): Promise<SearchResult[]> {
     const results: SearchResult[] = [];
 
     if (!NAVER_CLIENT_ID || !NAVER_CLIENT_SECRET) {
@@ -303,7 +323,7 @@ export async function searchNaverNews(query: string, maxResults: number = 5): Pr
         const display = Math.min(Math.max(maxResults, 1), 100);
         const url = `https://openapi.naver.com/v1/search/news.json?query=${encodeURIComponent(query)}&display=${display}&sort=date`;
 
-        const response = await fetch(url, {
+        const response = await searchFetch(url, signal, {
             headers: {
                 'X-Naver-Client-Id': NAVER_CLIENT_ID,
                 'X-Naver-Client-Secret': NAVER_CLIENT_SECRET,
@@ -360,7 +380,7 @@ function stripNaverTags(text: string): string {
  * @param maxResults - 최대 결과 수 (기본값: 10, API 제한: 최대 100)
  * @returns SearchResult 배열 (키 미설정/실패 시 빈 배열)
  */
-export async function searchNaverWeb(query: string, maxResults: number = 10): Promise<SearchResult[]> {
+export async function searchNaverWeb(query: string, maxResults: number = 10, signal?: AbortSignal): Promise<SearchResult[]> {
     const results: SearchResult[] = [];
 
     if (!NAVER_CLIENT_ID || !NAVER_CLIENT_SECRET) {
@@ -371,7 +391,7 @@ export async function searchNaverWeb(query: string, maxResults: number = 10): Pr
         const display = Math.min(Math.max(maxResults, 1), 100);
         const url = `https://openapi.naver.com/v1/search/webkr.json?query=${encodeURIComponent(query)}&display=${display}`;
 
-        const response = await fetch(url, {
+        const response = await searchFetch(url, signal, {
             headers: {
                 'X-Naver-Client-Id': NAVER_CLIENT_ID,
                 'X-Naver-Client-Secret': NAVER_CLIENT_SECRET,

--- a/backend/api/src/mcp/web-search/providers.ts
+++ b/backend/api/src/mcp/web-search/providers.ts
@@ -51,6 +51,19 @@ function searchFetch(url: string, externalSignal?: AbortSignal, init?: RequestIn
 }
 
 /**
+ * 검색 fetch 에러를 사람이 읽을 수 있게 기술 — timeout/abort 를 일반 실패와 구분한다.
+ * (12초 fetch timeout 으로 정상 응답이 잘리는 경우를 silent 실패와 구분해 진단 가능하게 함)
+ */
+function describeFetchError(e: unknown): string {
+    if (e instanceof Error) {
+        if (e.name === 'TimeoutError') return `timeout(${LLM_TIMEOUTS.WEB_SEARCH_FETCH_TIMEOUT_MS}ms 초과)`;
+        if (e.name === 'AbortError') return '요청 중단(abort)';
+        return e.message;
+    }
+    return String(e);
+}
+
+/**
  * XML 엔티티를 일반 문자로 디코딩
  *
  * Google News RSS 파싱에서 XML 엔티티를 처리합니다.
@@ -116,7 +129,7 @@ export async function searchGoogle(query: string, maxResults: number = 10, globa
         }
         logger.info(`Google: ${results.length}개`);
     } catch (e) {
-        logger.error('Google 실패:', e instanceof Error ? e.message : String(e));
+        logger.error('Google 실패:', describeFetchError(e));
     }
 
     return results;
@@ -162,7 +175,7 @@ export async function searchWikipedia(query: string, language: string = 'en', si
 
         logger.info(`Wikipedia: ${results.length}개`);
     } catch (e) {
-        logger.error('Wikipedia 실패:', e instanceof Error ? e.message : String(e));
+        logger.error('Wikipedia 실패:', describeFetchError(e));
     }
 
     return results;
@@ -234,7 +247,7 @@ export async function searchGoogleNews(query: string, language: string = 'en', s
 
         logger.info(`Google News: ${results.length}개`);
     } catch (e) {
-        logger.error('Google News 실패:', e instanceof Error ? e.message : String(e));
+        logger.error('Google News 실패:', describeFetchError(e));
     }
 
     return results;
@@ -293,7 +306,7 @@ export async function searchDuckDuckGoAPI(query: string, signal?: AbortSignal): 
 
         logger.info(`DuckDuckGo API: ${results.length}개`);
     } catch (e) {
-        logger.error('DuckDuckGo API 실패:', e instanceof Error ? e.message : String(e));
+        logger.error('DuckDuckGo API 실패:', describeFetchError(e));
     }
 
     return results;
@@ -351,7 +364,7 @@ export async function searchNaverNews(query: string, maxResults: number = 5, sig
         }
         logger.info(`네이버 뉴스: ${results.length}개`);
     } catch (e) {
-        logger.error('네이버 뉴스 실패:', e instanceof Error ? e.message : String(e));
+        logger.error('네이버 뉴스 실패:', describeFetchError(e));
     }
 
     return results;
@@ -418,7 +431,7 @@ export async function searchNaverWeb(query: string, maxResults: number = 10, sig
         }
         logger.info(`네이버 웹문서: ${results.length}개`);
     } catch (e) {
-        logger.error('네이버 웹문서 실패:', e instanceof Error ? e.message : String(e));
+        logger.error('네이버 웹문서 실패:', describeFetchError(e));
     }
 
     return results;

--- a/backend/api/src/mcp/web-search/search-orchestrator.ts
+++ b/backend/api/src/mcp/web-search/search-orchestrator.ts
@@ -41,22 +41,23 @@ const logger = createLogger('WebSearch');
  *
  * 변경 이력: 2026-05-19 — Ollama Cloud /api/web_search 폐기로 useOllamaFirst/searchOllamaWebSearch 제거.
  */
-export async function performWebSearch(query: string, options: { maxResults?: number; globalSearch?: boolean; language?: string } = {}): Promise<SearchResult[]> {
-    const { maxResults = 30, globalSearch = true, language = 'en' } = options;
+export async function performWebSearch(query: string, options: { maxResults?: number; globalSearch?: boolean; language?: string; signal?: AbortSignal } = {}): Promise<SearchResult[]> {
+    const { maxResults = 30, globalSearch = true, language = 'en', signal } = options;
 
     // 고볼륨 모드: maxResults > 15이면 모든 소스에서 병렬 수집 (Deep Research 용)
     const highVolumeMode = maxResults > 15;
 
     logger.info(`쿼리: ${query} (maxResults: ${maxResults}, highVolume: ${highVolumeMode})`);
 
-    // 모든 소스에서 병렬 검색
+    // 모든 소스에서 병렬 검색 — 각 provider 는 자체 fetch timeout + 외부 abort signal 로
+    // hang 을 방지하므로 Promise.all 이 무한정 멈추지 않는다.
     const searchPromises: Promise<SearchResult[]>[] = [
-        searchGoogle(query, 10, globalSearch, language),
-        searchWikipedia(query, language),
-        searchGoogleNews(query, language),
-        searchDuckDuckGoAPI(query),
+        searchGoogle(query, 10, globalSearch, language, signal),
+        searchWikipedia(query, language, signal),
+        searchGoogleNews(query, language, signal),
+        searchDuckDuckGoAPI(query, signal),
         // 한국어 쿼리: 네이버 뉴스(모바일 스크래핑) + 웹문서(공식 검색 API) 병렬 수집
-        ...(language === 'ko' ? [searchNaverNews(query), searchNaverWeb(query)] : [])
+        ...(language === 'ko' ? [searchNaverNews(query, 5, signal), searchNaverWeb(query, 10, signal)] : [])
     ];
 
     const allSearchResults = await Promise.all(searchPromises);

--- a/backend/api/src/services/DeepResearchService.ts
+++ b/backend/api/src/services/DeepResearchService.ts
@@ -335,7 +335,12 @@ export class DeepResearchService {
                 duration
             };
         } catch (error) {
-            if (error instanceof Error && error.message === 'RESEARCH_ABORTED') {
+            // 중단 판별: 명시적 RESEARCH_ABORTED 외에도, 하위 레이어가 던지는 abort 계열
+            // (parallelBatch BATCH_ABORTED / graph WORKFLOW_ABORTED)을 cancelled 로 통합한다.
+            // signal.aborted 면 메시지와 무관하게 사용자 취소로 간주 (failed 오분류 방지).
+            const aborted = this.abortController?.signal.aborted
+                || (error instanceof Error && ['RESEARCH_ABORTED', 'BATCH_ABORTED', 'WORKFLOW_ABORTED'].includes(error.message));
+            if (aborted) {
                 await db.updateResearchSession(sessionId, {
                     status: 'cancelled',
                     summary: '리서치가 취소되었습니다.'

--- a/backend/api/src/services/DeepResearchService.ts
+++ b/backend/api/src/services/DeepResearchService.ts
@@ -102,6 +102,7 @@ export class DeepResearchService {
                 config: this.config,
                 topic,
                 sessionId,
+                abortSignal: this.abortController?.signal,
                 throwIfAborted: () => this.throwIfAborted()
             });
             await db.updateResearchSession(sessionId, { progress: 5 });
@@ -260,6 +261,7 @@ export class DeepResearchService {
                         topic,
                         currentFindings: allFindings,
                         sourceCount: sourcesAfterScrape.length,
+                        abortSignal: this.abortController?.signal,
                         throwIfAborted: () => this.throwIfAborted()
                     });
                     if (!needsMore) {

--- a/backend/api/src/services/deep-research/chat-with-timeout.ts
+++ b/backend/api/src/services/deep-research/chat-with-timeout.ts
@@ -1,0 +1,42 @@
+/**
+ * Deep Research - abort/timeout 결합 LLM 호출 헬퍼
+ *
+ * 각 단계(분해·합성·병합·판단)의 LLM 호출에서 반복되던
+ * `AbortController` + `setTimeout` + 리스너 등록/해제 boilerplate 를 단일 지점으로 수렴한다.
+ * repo 우세 관용구인 `AbortSignal.any` + `AbortSignal.timeout` 을 사용한다.
+ *
+ * @module services/deep-research/chat-with-timeout
+ */
+
+import type { LLMClient, ChatMessage, ModelOptions, UsageMetrics } from '../../llm';
+
+/**
+ * 외부 연구 abort signal 과 호출별 timeout 을 결합해 `client.chat` 을 실행한다.
+ *
+ * - timeout(ms) 또는 외부 중단 중 먼저 발생하는 쪽이 upstream HTTP 요청을 취소한다.
+ * - 외부 signal 이 이미 abort 면 즉시 `RESEARCH_ABORTED` 를 throw 해 불필요한 호출을 회피한다.
+ * - `AbortSignal.any` 의 dependent 는 source signal 을 약하게 참조하므로 별도 `removeEventListener`
+ *   정리가 필요 없고, `AbortSignal.timeout` 의 타이머는 unref 되어 프로세스 종료를 막지 않는다.
+ *
+ * @param client - LLM 클라이언트
+ * @param messages - chat 메시지
+ * @param options - 모델 옵션(temperature 등)
+ * @param timeoutMs - 이 호출 전용 timeout
+ * @param externalSignal - 상위(연구 중단) abort signal (optional)
+ */
+export async function chatWithAbortTimeout(
+    client: LLMClient,
+    messages: ChatMessage[],
+    options: ModelOptions,
+    timeoutMs: number,
+    externalSignal?: AbortSignal,
+): Promise<ChatMessage & { metrics?: UsageMetrics }> {
+    if (externalSignal?.aborted) {
+        throw new Error('RESEARCH_ABORTED');
+    }
+    const timeoutSignal = AbortSignal.timeout(timeoutMs);
+    const signal = externalSignal
+        ? AbortSignal.any([externalSignal, timeoutSignal])
+        : timeoutSignal;
+    return client.chat(messages, options, undefined, { signal });
+}

--- a/backend/api/src/services/deep-research/findings-synthesizer.ts
+++ b/backend/api/src/services/deep-research/findings-synthesizer.ts
@@ -117,9 +117,12 @@ export async function synthesizeFindings(params: {
             }
 
             try {
-                const response = await client.chat([
-                    { role: 'user', content: chunkPrompt }
-                ], { temperature: LLM_TEMPERATURES.RESEARCH_SYNTHESIS });
+                const response = await client.chat(
+                    [{ role: 'user', content: chunkPrompt }],
+                    { temperature: LLM_TEMPERATURES.RESEARCH_SYNTHESIS },
+                    undefined,
+                    { signal: chunkController.signal },
+                );
                 throwIfAborted();
                 return response.content.trim();
             } catch (error) {
@@ -259,9 +262,12 @@ async function singleMerge(params: {
     }
 
     try {
-        const response = await client.chat([
-            { role: 'user', content: mergedPrompt }
-        ], { temperature: LLM_TEMPERATURES.RESEARCH_REPORT });
+        const response = await client.chat(
+            [{ role: 'user', content: mergedPrompt }],
+            { temperature: LLM_TEMPERATURES.RESEARCH_REPORT },
+            undefined,
+            { signal: mergeController.signal },
+        );
         throwIfAborted();
         return response.content.trim();
     } catch (error) {
@@ -288,9 +294,10 @@ export async function checkNeedsMoreInfo(params: {
     topic: string;
     currentFindings: string[];
     sourceCount: number;
+    abortSignal?: AbortSignal;
     throwIfAborted: () => void;
 }): Promise<boolean> {
-    const { client, config, topic, currentFindings, sourceCount, throwIfAborted } = params;
+    const { client, config, topic, currentFindings, sourceCount, abortSignal, throwIfAborted } = params;
 
     throwIfAborted();
     if (sourceCount < RESEARCH_DEFAULTS.MAX_TOTAL_SOURCES * 0.6) {
@@ -299,15 +306,32 @@ export async function checkNeedsMoreInfo(params: {
 
     const prompt = getNeedMorePrompt(config.language, topic, currentFindings, sourceCount);
 
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(() => controller.abort(), LLM_TIMEOUTS.RESEARCH_NEED_MORE_TIMEOUT_MS);
+    const forwardAbort = () => controller.abort();
+    if (abortSignal) {
+        if (abortSignal.aborted) { clearTimeout(timeoutHandle); throw new Error('RESEARCH_ABORTED'); }
+        abortSignal.addEventListener('abort', forwardAbort);
+    }
+
     try {
-        const response = await client.chat([
-            { role: 'user', content: prompt }
-        ], { temperature: LLM_TEMPERATURES.RESEARCH_FACT_CHECK });
+        const response = await client.chat(
+            [{ role: 'user', content: prompt }],
+            { temperature: LLM_TEMPERATURES.RESEARCH_FACT_CHECK },
+            undefined,
+            { signal: controller.signal },
+        );
         throwIfAborted();
 
         return response.content.toLowerCase().includes('yes');
     } catch (error) {
+        throwIfAborted();
         logger.error(`[DeepResearch] 추가 정보 판단 실패: ${error instanceof Error ? error.message : String(error)}`);
         return sourceCount < config.maxTotalSources;
+    } finally {
+        clearTimeout(timeoutHandle);
+        if (abortSignal) {
+            abortSignal.removeEventListener('abort', forwardAbort);
+        }
     }
 }

--- a/backend/api/src/services/deep-research/findings-synthesizer.ts
+++ b/backend/api/src/services/deep-research/findings-synthesizer.ts
@@ -29,6 +29,7 @@ import {
     getResearchMessage
 } from '../deep-research-prompts';
 import { parallelBatch } from '../../workflow/graph-engine';
+import { chatWithAbortTimeout } from './chat-with-timeout';
 
 const logger = createLogger('DeepResearch:FindingsSynthesizer');
 
@@ -103,38 +104,20 @@ export async function synthesizeFindings(params: {
                 ? getLightweightChunkSummaryPrompt(config.language, topic, chunkIndex, chunks.length, chunkContext)
                 : getChunkSummaryPrompt(config.language, topic, chunkIndex, chunks.length, chunkContext);
 
-            // 개별 청크 타임아웃 적용
-            const chunkController = new AbortController();
-            const timeoutHandle = setTimeout(
-                () => chunkController.abort(),
-                LLM_TIMEOUTS.SYNTHESIS_PER_CHUNK_TIMEOUT_MS,
-            );
-            // 외부 abort signal 전파
-            const forwardAbort = () => chunkController.abort();
-            if (abortSignal) {
-                if (abortSignal.aborted) { clearTimeout(timeoutHandle); throw new Error('RESEARCH_ABORTED'); }
-                abortSignal.addEventListener('abort', forwardAbort);
-            }
-
             try {
-                const response = await client.chat(
+                const response = await chatWithAbortTimeout(
+                    client,
                     [{ role: 'user', content: chunkPrompt }],
                     { temperature: LLM_TEMPERATURES.RESEARCH_SYNTHESIS },
-                    undefined,
-                    { signal: chunkController.signal },
+                    LLM_TIMEOUTS.SYNTHESIS_PER_CHUNK_TIMEOUT_MS,
+                    abortSignal,
                 );
                 throwIfAborted();
                 return response.content.trim();
             } catch (error) {
-                const msg = error instanceof Error ? error.message : String(error);
-                if (msg === 'RESEARCH_ABORTED') throw error;
-                logger.error(`[DeepResearch] 청크 요약 실패 (${chunkIndex + 1}/${chunks.length}): ${msg}`);
+                throwIfAborted();  // 외부 중단이면 RESEARCH_ABORTED 전파, timeout/기타면 강등
+                logger.error(`[DeepResearch] 청크 요약 실패 (${chunkIndex + 1}/${chunks.length}): ${error instanceof Error ? error.message : String(error)}`);
                 return '청크 요약 실패';
-            } finally {
-                clearTimeout(timeoutHandle);
-                if (abortSignal) {
-                    abortSignal.removeEventListener('abort', forwardAbort);
-                }
             }
         },
         {
@@ -161,6 +144,7 @@ export async function synthesizeFindings(params: {
 
     const keyPoints = extractBulletLikeFindings(mergedSummary);
 
+    throwIfAborted();  // abort 시 합성 스텝을 completed 로 오기록하지 않음
     await db.addResearchStep({
         sessionId,
         stepNumber: loopNumber * 100 + 100,
@@ -250,38 +234,22 @@ async function singleMerge(params: {
 
     const mergedPrompt = getMergePrompt(config.language, topic, summaries);
 
-    const mergeController = new AbortController();
-    const mergeTimeout = setTimeout(
-        () => mergeController.abort(),
-        LLM_TIMEOUTS.SYNTHESIS_MERGE_TIMEOUT_MS,
-    );
-    const forwardMergeAbort = () => mergeController.abort();
-    if (abortSignal) {
-        if (abortSignal.aborted) { clearTimeout(mergeTimeout); throw new Error('RESEARCH_ABORTED'); }
-        abortSignal.addEventListener('abort', forwardMergeAbort);
-    }
-
     try {
-        const response = await client.chat(
+        const response = await chatWithAbortTimeout(
+            client,
             [{ role: 'user', content: mergedPrompt }],
             { temperature: LLM_TEMPERATURES.RESEARCH_REPORT },
-            undefined,
-            { signal: mergeController.signal },
+            LLM_TIMEOUTS.SYNTHESIS_MERGE_TIMEOUT_MS,
+            abortSignal,
         );
         throwIfAborted();
         return response.content.trim();
     } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        if (msg === 'RESEARCH_ABORTED') throw error;
-        logger.error(`[DeepResearch] 병합 실패: ${msg}`);
+        throwIfAborted();  // 외부 중단이면 RESEARCH_ABORTED 전파, timeout/기타면 폴백
+        logger.error(`[DeepResearch] 병합 실패: ${error instanceof Error ? error.message : String(error)}`);
         // 폴백: 청크 요약들을 합쳐서 반환
         const partialSummary = summaries.filter(s => s !== '청크 요약 실패').join('\n\n');
         return partialSummary || getResearchMessage('synthesisFailed', config.language);
-    } finally {
-        clearTimeout(mergeTimeout);
-        if (abortSignal) {
-            abortSignal.removeEventListener('abort', forwardMergeAbort);
-        }
     }
 }
 
@@ -306,32 +274,20 @@ export async function checkNeedsMoreInfo(params: {
 
     const prompt = getNeedMorePrompt(config.language, topic, currentFindings, sourceCount);
 
-    const controller = new AbortController();
-    const timeoutHandle = setTimeout(() => controller.abort(), LLM_TIMEOUTS.RESEARCH_NEED_MORE_TIMEOUT_MS);
-    const forwardAbort = () => controller.abort();
-    if (abortSignal) {
-        if (abortSignal.aborted) { clearTimeout(timeoutHandle); throw new Error('RESEARCH_ABORTED'); }
-        abortSignal.addEventListener('abort', forwardAbort);
-    }
-
     try {
-        const response = await client.chat(
+        const response = await chatWithAbortTimeout(
+            client,
             [{ role: 'user', content: prompt }],
             { temperature: LLM_TEMPERATURES.RESEARCH_FACT_CHECK },
-            undefined,
-            { signal: controller.signal },
+            LLM_TIMEOUTS.RESEARCH_NEED_MORE_TIMEOUT_MS,
+            abortSignal,
         );
         throwIfAborted();
 
         return response.content.toLowerCase().includes('yes');
     } catch (error) {
-        throwIfAborted();
+        throwIfAborted();  // 외부 중단이면 RESEARCH_ABORTED 전파, timeout/기타면 폴백
         logger.error(`[DeepResearch] 추가 정보 판단 실패: ${error instanceof Error ? error.message : String(error)}`);
         return sourceCount < config.maxTotalSources;
-    } finally {
-        clearTimeout(timeoutHandle);
-        if (abortSignal) {
-            abortSignal.removeEventListener('abort', forwardAbort);
-        }
     }
 }

--- a/backend/api/src/services/deep-research/source-searcher.ts
+++ b/backend/api/src/services/deep-research/source-searcher.ts
@@ -84,7 +84,8 @@ export async function searchSubTopics(params: {
             try {
                 const results = await performWebSearch(query, {
                     maxResults: resultsPerQuery,
-                    language: config.language
+                    language: config.language,
+                    signal: abortSignal
                 });
 
                 const uniqueForQuery: SearchResult[] = [];

--- a/backend/api/src/services/deep-research/source-searcher.ts
+++ b/backend/api/src/services/deep-research/source-searcher.ts
@@ -87,6 +87,9 @@ export async function searchSubTopics(params: {
                     language: config.language,
                     signal: abortSignal
                 });
+                // abort 시 performWebSearch 는 빈/부분 결과를 반환하므로, 검색 스텝을
+                // completed 로 오기록하지 않도록 결과 처리 전에 중단을 확인한다.
+                throwIfAborted();
 
                 const uniqueForQuery: SearchResult[] = [];
                 for (const result of results) {

--- a/backend/api/src/services/deep-research/topic-decomposer.ts
+++ b/backend/api/src/services/deep-research/topic-decomposer.ts
@@ -12,6 +12,7 @@ import { getUnifiedDatabase } from '../../data/models/unified-database';
 import { createLogger } from '../../utils/logger';
 import { CAPACITY } from '../../config/runtime-limits';
 import { LLM_TEMPERATURES } from '../../config/llm-parameters';
+import { LLM_TIMEOUTS } from '../../config/timeouts';
 import { clampImportance, buildFallbackSubTopics } from '../deep-research-utils';
 import { getDecomposePrompt, getResearchMessage } from '../deep-research-prompts';
 
@@ -25,17 +26,29 @@ export async function decomposeTopics(params: {
     config: ResearchConfig;
     topic: string;
     sessionId: string;
+    abortSignal?: AbortSignal;
     throwIfAborted: () => void;
 }): Promise<SubTopic[]> {
-    const { client, config, topic, sessionId, throwIfAborted } = params;
+    const { client, config, topic, sessionId, abortSignal, throwIfAborted } = params;
 
     throwIfAborted();
     const prompt = getDecomposePrompt(config.language, topic);
 
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(() => controller.abort(), LLM_TIMEOUTS.RESEARCH_DECOMPOSE_TIMEOUT_MS);
+    const forwardAbort = () => controller.abort();
+    if (abortSignal) {
+        if (abortSignal.aborted) { clearTimeout(timeoutHandle); throw new Error('RESEARCH_ABORTED'); }
+        abortSignal.addEventListener('abort', forwardAbort);
+    }
+
     try {
-        const response = await client.chat([
-            { role: 'user', content: prompt }
-        ], { temperature: LLM_TEMPERATURES.RESEARCH_PLAN });
+        const response = await client.chat(
+            [{ role: 'user', content: prompt }],
+            { temperature: LLM_TEMPERATURES.RESEARCH_PLAN },
+            undefined,
+            { signal: controller.signal },
+        );
         throwIfAborted();
 
         const jsonMatch = response.content.match(/\[[\s\S]*\]/);
@@ -85,7 +98,13 @@ export async function decomposeTopics(params: {
 
         return finalSubTopics;
     } catch (error) {
+        throwIfAborted();
         logger.error(`[DeepResearch] 주제 분해 실패: ${error instanceof Error ? error.message : String(error)}`);
         return buildFallbackSubTopics(topic);
+    } finally {
+        clearTimeout(timeoutHandle);
+        if (abortSignal) {
+            abortSignal.removeEventListener('abort', forwardAbort);
+        }
     }
 }

--- a/backend/api/src/services/deep-research/topic-decomposer.ts
+++ b/backend/api/src/services/deep-research/topic-decomposer.ts
@@ -15,6 +15,7 @@ import { LLM_TEMPERATURES } from '../../config/llm-parameters';
 import { LLM_TIMEOUTS } from '../../config/timeouts';
 import { clampImportance, buildFallbackSubTopics } from '../deep-research-utils';
 import { getDecomposePrompt, getResearchMessage } from '../deep-research-prompts';
+import { chatWithAbortTimeout } from './chat-with-timeout';
 
 const logger = createLogger('DeepResearch:TopicDecomposer');
 
@@ -34,20 +35,13 @@ export async function decomposeTopics(params: {
     throwIfAborted();
     const prompt = getDecomposePrompt(config.language, topic);
 
-    const controller = new AbortController();
-    const timeoutHandle = setTimeout(() => controller.abort(), LLM_TIMEOUTS.RESEARCH_DECOMPOSE_TIMEOUT_MS);
-    const forwardAbort = () => controller.abort();
-    if (abortSignal) {
-        if (abortSignal.aborted) { clearTimeout(timeoutHandle); throw new Error('RESEARCH_ABORTED'); }
-        abortSignal.addEventListener('abort', forwardAbort);
-    }
-
     try {
-        const response = await client.chat(
+        const response = await chatWithAbortTimeout(
+            client,
             [{ role: 'user', content: prompt }],
             { temperature: LLM_TEMPERATURES.RESEARCH_PLAN },
-            undefined,
-            { signal: controller.signal },
+            LLM_TIMEOUTS.RESEARCH_DECOMPOSE_TIMEOUT_MS,
+            abortSignal,
         );
         throwIfAborted();
 
@@ -98,13 +92,8 @@ export async function decomposeTopics(params: {
 
         return finalSubTopics;
     } catch (error) {
-        throwIfAborted();
+        throwIfAborted();  // 외부 중단이면 RESEARCH_ABORTED 전파, timeout/파싱 실패면 폴백
         logger.error(`[DeepResearch] 주제 분해 실패: ${error instanceof Error ? error.message : String(error)}`);
         return buildFallbackSubTopics(topic);
-    } finally {
-        clearTimeout(timeoutHandle);
-        if (abortSignal) {
-            abortSignal.removeEventListener('abort', forwardAbort);
-        }
     }
 }


### PR DESCRIPTION
## 문제
딥리서치가 동작 중 멈춘다는 보고. 근본 원인은 **중단 신호가 실제 I/O(fetch·LLM HTTP)까지 도달하지 못하는 것**.

## 진단된 3가지 구조적 결함
| # | 결함 | 멈춤 메커니즘 |
|---|---|---|
| 1 | 웹 검색 provider 6개 `fetch`에 timeout/abort 전무 | `performWebSearch`의 `Promise.all`이 모든 provider 완료를 대기 → 응답을 무는 검색 서버 하나가 검색 단계를 무한 정지 |
| 2 | 합성·병합 LLM 호출의 timeout이 dead code | `AbortController`+`setTimeout`(120s/180s)을 만들고도 signal을 `client.chat()`에 안 넘겨 무효 |
| 3 | `decomposeTopics`/`checkNeedsMoreInfo`는 timeout·signal 둘 다 없음 | 전역 `LLM_TIMEOUT`에만 의존 |

## 수정 (7개 파일)
- **`config/timeouts.ts`** — `WEB_SEARCH_FETCH_TIMEOUT_MS`(12s, env override), `RESEARCH_NEED_MORE_TIMEOUT_MS`(30s) 추가
- **`web-search/providers.ts`** — `searchFetch()` 헬퍼(`AbortSignal.any([외부신호, AbortSignal.timeout])`) 도입, 6개 provider에 signal 결합
- **`web-search/search-orchestrator.ts`** — `performWebSearch`에 `signal` 옵션 추가·전달
- **`source-searcher.ts`** — `performWebSearch` 호출에 연구 abort signal 전달
- **`findings-synthesizer.ts`** — 청크·병합 `chat()`에 signal 전달(dead code 활성화) + `checkNeedsMoreInfo` timeout/signal 추가
- **`topic-decomposer.ts`** — abort signal + 분해 timeout 추가
- **`DeepResearchService.ts`** — 두 호출에 `abortController.signal` 연결

## 효과
어떤 단계도 외부 의존성에 무한 hang하지 않고, 사용자 중단 시 진행 중인 fetch·LLM 요청까지 즉시 취소(orphan 방지). 보고서 단계가 이미 우회해 둔 패턴을 검색·합성·분해 전 단계로 일관 확장.

## 호환성
추가된 인자·옵션이 전부 optional이라 `performWebSearch`의 다른 호출부(채팅 웹검색, MCP 도구 등)는 영향 없음.

## 검증
- [x] `tsc --noEmit` 통과 (에러 0)
- [x] 백엔드 단위 테스트 전수 통과 (134 suites / 1813 passed / 0 failed)
- [x] 변경 파일 ESLint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)