### PR TITLE
feat(ws): WebSocket/파일 업로드 페이로드 기본 무제한화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -638,6 +638,11 @@ SLASH_COMMANDS_ENABLED=true
 SLASH_SKILL_CONTENT_MAX=8000
 # fs_read_file 완전성 고지(P-6) — 이 바이트 초과 시 앞부분만 반환하고 잘림을 고지.
 FS_READ_MAX_BYTES=100000
+# WebSocket 메시지 최대 페이로드(bytes). **미설정/0 = 무제한**(파일·이미지 업로드 용량 제한 없음).
+# 무제한은 거대 프레임이 서버 메모리를 한 번에 점유할 수 있으므로(OOM/DoS 여지),
+# 운영 상한이 필요하면 바이트 수를 지정(예: 67108864=64MB). 상한 지정 시 프론트
+# chat.js WS_MAX_PAYLOAD_BYTES 도 그보다 약간 낮게 맞출 것.
+# WS_MAX_PAYLOAD_BYTES=
 
 # *******************************************************
 # 🔔 Web Push (VAPID) — 백그라운드 작업 완료 브라우저 알림

--- a/backend/api/src/config/timeouts.ts
+++ b/backend/api/src/config/timeouts.ts
@@ -172,6 +172,14 @@ export const WEBSOCKET_TIMEOUTS = {
  * sockets/handler.ts에서 참조
  */
 export const WS_LIMITS = {
+    /**
+     * WebSocket 프레임 최대 페이로드 (bytes). **0 = 무제한**(ws 는 maxPayload>0 일 때만 검사).
+     * 파일/이미지 업로드 용량 제한을 두지 않기 위해 기본 0(무제한). 단, 무제한은 거대 프레임이
+     * 서버 메모리를 한 번에 점유할 수 있으므로(OOM/DoS 여지), 운영상 상한이 필요하면
+     * 환경변수 WS_MAX_PAYLOAD_BYTES 에 바이트 수를 지정해 재설정한다(예: 67108864=64MB).
+     * 프론트 가드(chat.js WS_MAX_PAYLOAD_BYTES)도 0=무제한 sentinel 로 정합.
+     */
+    MAX_PAYLOAD_BYTES: process.env.WS_MAX_PAYLOAD_BYTES !== undefined ? Number(process.env.WS_MAX_PAYLOAD_BYTES) : 0,
     /** 사용자당 최대 동시 WebSocket 연결 수 */
     MAX_CONNECTIONS_PER_USER: Number(process.env.WS_MAX_CONNECTIONS_PER_USER) || 5,
     /** 연결 속도 제한 윈도우 (ms) — 기본 60초 */

--- a/backend/api/src/server.ts
+++ b/backend/api/src/server.ts
@@ -34,6 +34,7 @@ import { getAnalyticsSystem } from './monitoring/analytics';
 import { setupSecurity, setupStaticFiles, setupParsersAndLimiting, setupErrorHandling } from './middlewares/setup';
 import { setupApiRoutes } from './routes/setup';
 import { getConfig } from './config';
+import { WS_LIMITS } from './config/timeouts';
 import { validateModels } from './config/model-roles';
 import { probeLocalModelAvailability } from './config/local-models';
 import { startAllSchedulers, stopAllSchedulers } from './schedulers';
@@ -93,7 +94,9 @@ export class DashboardServer {
         this.server = createServer(this.app);
         this.wss = new WebSocketServer({
             server: this.server,
-            maxPayload: 1 * 1024 * 1024
+            // 파일/이미지 업로드 용량 무제한 — 기본 0(=ws 무제한). 상한이 필요하면
+            // env WS_MAX_PAYLOAD_BYTES 로 바이트 지정.
+            maxPayload: WS_LIMITS.MAX_PAYLOAD_BYTES
         });
 
         this.setupRoutes();

--- a/frontend/web/public/js/modules/chat.js
+++ b/frontend/web/public/js/modules/chat.js
@@ -24,8 +24,10 @@ const SS = window.SafeStorage;
 const SEND_ICON_SVG = `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 2L11 13M22 2L15 22L11 13L2 9L22 2Z"/></svg>`;
 const ABORT_ICON_SVG = `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>`;
 
-// 백엔드 server.ts WebSocketServer maxPayload 와 동일 — 초과 프레임은 서버가 연결을 끊으므로 전송 전 차단
-const WS_MAX_PAYLOAD_BYTES = 1024 * 1024;
+// 0 = 용량 제한 없음 (백엔드 WS_LIMITS.MAX_PAYLOAD_BYTES 도 기본 0=무제한과 정합).
+// 백엔드에 상한을 두면(env WS_MAX_PAYLOAD_BYTES) 그보다 약간 낮은 바이트로 설정해
+// 서버 1009 끊김 전에 클라이언트가 먼저 안내하도록 한다.
+const WS_MAX_PAYLOAD_BYTES = 0;
 
 /** 스크린 리더용 상태 공지 (P1-14 접근성) */
 function announceA11y(message) {
@@ -431,10 +433,14 @@ async function sendMessage() {
         if (parsedUser.role) payload.userRole = parsedUser.role;
         if (parsedUser.tier) payload.userTier = parsedUser.tier;
 
-        // WS maxPayload(1MB, 백엔드 server.ts) 보호 — 초과 프레임은 서버가 연결을 끊어(1009)
-        // 메시지가 안내 없이 유실되므로 전송 전에 차단한다 (첨부+히스토리 합산 대비 최종 백스톱)
-        if (new TextEncoder().encode(JSON.stringify(payload)).length > WS_MAX_PAYLOAD_BYTES) {
-            throw new Error('메시지가 전송 한도(1MB)를 초과했습니다. 첨부 파일을 줄이거나 내용을 나눠 보내주세요.');
+        // WS maxPayload 보호 — 초과 프레임은 서버가 연결을 끊어(1009) 메시지가 안내 없이
+        // 유실되므로 전송 전에 차단한다 (첨부+히스토리 합산 대비 최종 백스톱)
+        if (WS_MAX_PAYLOAD_BYTES > 0) {
+            const payloadBytes = new TextEncoder().encode(JSON.stringify(payload)).length;
+            if (payloadBytes > WS_MAX_PAYLOAD_BYTES) {
+                const limitMB = Math.floor(WS_MAX_PAYLOAD_BYTES / (1024 * 1024));
+                throw new Error(`메시지가 전송 한도(${limitMB}MB)를 초과했습니다. 첨부 이미지/파일을 줄이거나 내용을 나눠 보내주세요.`);
+            }
         }
 
         const sent = sendWsMessage(payload);

--- a/frontend/web/public/js/modules/file-attach.js
+++ b/frontend/web/public/js/modules/file-attach.js
@@ -14,7 +14,7 @@
  */
 import { getState, setState } from './state.js';
 
-const MAX_FILE_BYTES = 10 * 1024 * 1024; // 10MB
+const MAX_FILE_BYTES = 0; // 0 = 용량 제한 없음 (상한을 두려면 바이트 수로 설정)
 const IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/webp', 'image/gif'];
 // 백엔드 FILE_ATTACH_LIMITS 기본값과 동일한 클라이언트 전송 캡 (WS maxPayload 1MB 보호).
 // 백엔드 캡은 env 오버라이드 가능 — 여기 값은 전송량 상한이며 절단 시 truncated 플래그로 안내 보장.
@@ -64,8 +64,9 @@ async function handleFiles(fileList) {
             window.showError?.(`첨부는 최대 ${MAX_ATTACH_FILES}개까지 가능합니다: ${f.name} 제외됨`);
             continue;
         }
-        if (f.size > MAX_FILE_BYTES) {
-            window.showError?.(`파일이 너무 큽니다 (최대 10MB): ${f.name}`);
+        // 용량 제한 없음(MAX_FILE_BYTES=0). 상한을 두려면 MAX_FILE_BYTES 를 양수로 설정.
+        if (MAX_FILE_BYTES > 0 && f.size > MAX_FILE_BYTES) {
+            window.showError?.(`파일이 너무 큽니다 (최대 ${Math.floor(MAX_FILE_BYTES / (1024 * 1024))}MB): ${f.name}`);
             continue;
         }
         try {

--- a/frontend/web/public/js/modules/file-attach.js
+++ b/frontend/web/public/js/modules/file-attach.js
@@ -16,8 +16,9 @@ import { getState, setState } from './state.js';
 
 const MAX_FILE_BYTES = 0; // 0 = 용량 제한 없음 (상한을 두려면 바이트 수로 설정)
 const IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/webp', 'image/gif'];
-// 백엔드 FILE_ATTACH_LIMITS 기본값과 동일한 클라이언트 전송 캡 (WS maxPayload 1MB 보호).
+// 백엔드 FILE_ATTACH_LIMITS 기본값과 동일한 클라이언트 텍스트 전송 캡 (과도한 텍스트 첨부 방어).
 // 백엔드 캡은 env 오버라이드 가능 — 여기 값은 전송량 상한이며 절단 시 truncated 플래그로 안내 보장.
+// (이미지/파일 바이트 용량은 MAX_FILE_BYTES=0=무제한; WS maxPayload 도 기본 무제한과 정합.)
 const MAX_TEXT_CHARS = 100000;       // FILE_ATTACH_MAX_CHARS_PER_FILE 기본값
 const MAX_TOTAL_TEXT_CHARS = 300000; // FILE_ATTACH_MAX_TOTAL_CHARS 기본값
 const MAX_ATTACH_FILES = 10;         // FILE_ATTACH_MAX_FILES 기본값
@@ -82,7 +83,8 @@ async function handleFiles(fileList) {
                     next.push({ id: genId(), name: f.name, type: f.type || 'application/octet-stream', size: f.size, isImage: false });
                     continue;
                 }
-                // 합산 전송량 캡 — WS maxPayload(1MB) 초과로 소켓이 끊기는 것을 첨부 시점에 차단
+                // 합산 텍스트 전송량 캡(MAX_TOTAL_TEXT_CHARS) — 과도한 텍스트로 WS 프레임이
+                // 백엔드 maxPayload(상한 설정 시) 를 넘겨 소켓이 끊기는 것을 첨부 시점에 차단
                 let { text, truncated } = decoded;
                 const used = next.reduce((sum, x) => sum + (x.textContent ? x.textContent.length : 0), 0);
                 const remaining = MAX_TOTAL_TEXT_CHARS - used;


### PR DESCRIPTION
## 변경
파일·이미지 첨부 용량 제한을 기본 해제. 백엔드 WS `maxPayload`와 프론트 2개 클라이언트 가드를 **0 = 무제한 sentinel**로 정합.

| 파일 | 변경 |
|---|---|
| `server.ts` | `WebSocketServer` maxPayload `1MB` → `WS_LIMITS.MAX_PAYLOAD_BYTES` |
| `config/timeouts.ts` | `WS_LIMITS.MAX_PAYLOAD_BYTES` 추가 (env override, 기본 0) |
| `chat.js` | `WS_MAX_PAYLOAD_BYTES` 0=무제한, `>0`일 때만 전송 전 크기 가드 (한도 메시지 동적 MB 표기) |
| `file-attach.js` | `MAX_FILE_BYTES` 10MB → 0(무제한), `>0`일 때만 파일 크기 검사 |
| `.env.example` | `WS_MAX_PAYLOAD_BYTES` 문서화 |

## 운영 주의
무제한은 거대 프레임이 서버 메모리를 한 번에 점유할 수 있어(OOM/DoS 여지) 상한이 필요하면 env `WS_MAX_PAYLOAD_BYTES`(예: `67108864`=64MB)로 재설정. 백엔드에 상한을 두면 프론트 `chat.js`의 값도 그보다 약간 낮게 맞춰 서버 1009 끊김 전에 클라이언트가 먼저 안내하도록 함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)