### PR TITLE
perf(deep-research): deep 모드 소스 80→50, 보고서 timeout 10→15분 튜닝

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -426,6 +426,8 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # SCRAPE_ABORT_BUFFER_MS=1000
 # Deep Research 루프당 최대 스크래핑 소스 수 (기본 15 — 상향 시 스크래핑 시간·합성 입력 토큰 비례 증가)
 # DEEP_RESEARCH_MAX_SCRAPE_PER_LOOP=15
+# Deep Research(채팅 deep 모드) 최대 전체 소스 수 (기본 50 — 상향 시 합성·보고서 생성 시간 비례 증가)
+# DEEP_RESEARCH_MAX_TOTAL_SOURCES=50
 
 # *******************************************************
 # 채팅 파일 첨부 한도 (config/runtime-limits FILE_ATTACH_LIMITS)
@@ -459,8 +461,8 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # ATTACH_CACHE_MAX_SESSIONS=500
 # 세션당 누적 컨텍스트 최대 글자 수 (기본 400000, 초과 시 오래된 블록부터 제거)
 # ATTACH_CACHE_MAX_CHARS=400000
-# Deep Research 보고서 생성 타임아웃 (ms, 기본 600000=10분 — 전역 LLM_TIMEOUT 독립)
-# DEEP_RESEARCH_REPORT_TIMEOUT_MS=600000
+# Deep Research 보고서 생성 타임아웃 (ms, 기본 900000=15분 — 전역 LLM_TIMEOUT 독립, 소스 축소와 함께 정식 보고서 완성 여유 확보)
+# DEEP_RESEARCH_REPORT_TIMEOUT_MS=900000
 # Deep Research 추가정보 필요 판단 LLM 호출 타임아웃 (ms, 기본 30000)
 # DEEP_RESEARCH_NEED_MORE_TIMEOUT_MS=30000
 # 웹 검색 프로바이더 개별 fetch 타임아웃 (ms, 기본 12000). 너무 낮으면 느린 정상 응답이

--- a/backend/api/src/config/runtime-limits.ts
+++ b/backend/api/src/config/runtime-limits.ts
@@ -247,8 +247,8 @@ export const RESEARCH_STRATEGY_PARAMS = {
     SEARCH_API: 'all' as const,
     /** 최대 검색 결과 수 */
     MAX_SEARCH_RESULTS: 360,
-    /** 최대 전체 소스 수 */
-    MAX_TOTAL_SOURCES: 80,
+    /** 최대 전체 소스 수 — 합성·보고서 입력 규모를 좌우(과다 시 보고서 생성 지연). env override 가능. */
+    MAX_TOTAL_SOURCES: Number(process.env.DEEP_RESEARCH_MAX_TOTAL_SOURCES) || 50,
     /** 전체 콘텐츠 스크래핑 활성화 */
     SCRAPE_FULL_CONTENT: true,
     /** 루프당 최대 스크래핑 수 */

--- a/backend/api/src/config/timeouts.ts
+++ b/backend/api/src/config/timeouts.ts
@@ -42,9 +42,10 @@ export const LLM_TIMEOUTS = {
      * Deep Research 최종 보고서 생성 타임아웃 (ms).
      * 대형 프롬프트(다수 소스)·장문 출력으로 전역 LLM_TIMEOUT보다 길어야 한다.
      * 보고서 생성 LLM 호출에 **전용 클라이언트의 SDK 타임아웃**으로 적용됨(report-generator).
-     * env override: DEEP_RESEARCH_REPORT_TIMEOUT_MS. 기본 600000(10분).
+     * env override: DEEP_RESEARCH_REPORT_TIMEOUT_MS. 기본 900000(15분) — 소스 축소(50)와 함께
+     * 정식 LLM 보고서가 timeout 으로 잘려 fallback 되지 않도록 여유 확보(평소엔 거의 미사용).
      */
-    REPORT_GENERATION_TIMEOUT_MS: Number(process.env.DEEP_RESEARCH_REPORT_TIMEOUT_MS) || 600000,
+    REPORT_GENERATION_TIMEOUT_MS: Number(process.env.DEEP_RESEARCH_REPORT_TIMEOUT_MS) || 900000,
 } as const;
 
 // ============================================


### PR DESCRIPTION
## 배경
라이브 점검에서 deep 모드 딥리서치가 **21분** 소요. 원인: 80 소스가 합성·보고서 입력을 무겁게 만들고, 보고서 생성이 10분 timeout을 넘겨 fallback.

## 변경
| 항목 | 변경 | 효과 |
|---|---|---|
| `MAX_TOTAL_SOURCES` | 80 → **50** (+env `DEEP_RESEARCH_MAX_TOTAL_SOURCES` 신설) | 합성·보고서 입력 축소 → 평소 속도↑ |
| `REPORT_GENERATION_TIMEOUT_MS` | 600000 → **900000(15분)** | 정식 LLM 보고서가 timeout으로 잘려 fallback되지 않게 여유 확보(평소 거의 미사용) |
| `.env.example` | 두 항목 문서화 | 운영 튜닝 가능 |

평균은 소스 축소로 빨라지고, 큰 보고서만 timeout 여유로 정식 완성됩니다. **#104(스트리밍 중단 시 completed 유지)와 시너지** — 결과 유실·실패 표시가 함께 해소됩니다.

## 검증
- [x] `tsc --noEmit` 통과
- [x] 백엔드 단위 테스트 전수 통과 (값 하드코딩하던 2개 테스트를 상수 참조로 수정 — 미래 튜닝에 안 깨짐)
- [x] ESLint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)