### PR TITLE
feat(deep-research): 보고서 생성 스트리밍 + 진행 표시 (85% 공백 해소)

### DIFF
--- a/backend/api/src/config/runtime-limits.ts
+++ b/backend/api/src/config/runtime-limits.ts
@@ -224,6 +224,8 @@ export const RESEARCH_DEFAULTS = {
     SYNTHESIS_CONCURRENCY: 5,
     /** 전체 합성을 실행하기 위한 최소 콘텐츠 길이 (문자). 이 미만이면 경량 합성 */
     MIN_CONTENT_FOR_FULL_SYNTHESIS: 1000,
+    /** 보고서 생성 진행률 추정용 예상 출력 글자 수 (라이브 관측 ~20K자 기준, progress 표시 전용) */
+    REPORT_EXPECTED_CHARS: 20000,
     /** 검색 쿼리 최대 단어 수 (초과 시 잘림) */
     SEARCH_QUERY_MAX_WORDS: 10,
     /** 계층적 병합 전환 임계값 (청크 요약 수가 이 값 초과 시 재귀 병합) */

--- a/backend/api/src/services/DeepResearchService.ts
+++ b/backend/api/src/services/DeepResearchService.ts
@@ -15,7 +15,7 @@
 import { LLMClient, createClient } from '../llm';
 import type { SearchResult } from '../mcp/web-search';
 import { getModelForRole } from '../config/model-roles';
-import { RESEARCH_DEPTH_LOOPS } from '../config/runtime-limits';
+import { RESEARCH_DEPTH_LOOPS, RESEARCH_DEFAULTS } from '../config/runtime-limits';
 import { getUnifiedDatabase } from '../data/models/unified-database';
 import { isPersistableUserId } from '../utils/user-id-validation';
 import { createLogger } from '../utils/logger';
@@ -296,6 +296,12 @@ export class DeepResearchService {
                 sources: finalSources,
                 subTopics,
                 sessionId,
+                // 보고서 생성 진행 표시 — 85~99% 구간을 누적 글자 수로 채워 report 단계 공백 제거
+                onReportProgress: (chars) => {
+                    const frac = Math.min(chars / RESEARCH_DEFAULTS.REPORT_EXPECTED_CHARS, 1);
+                    const prog = 85 + frac * 14;
+                    this.reportProgress(onProgress, sessionId, 'running', this.config.maxLoops, this.config.maxLoops, 'report', prog, getResearchMessage('reportWriting', this.config.language, { chars }));
+                },
                 throwIfAborted: () => this.throwIfAborted()
             });
 

--- a/backend/api/src/services/deep-research-prompts.ts
+++ b/backend/api/src/services/deep-research-prompts.ts
@@ -211,6 +211,15 @@ const RESEARCH_MESSAGES: Record<string, Record<string, string>> = {
         de: 'Abschlussbericht wird erstellt...',
         fr: 'Génération du rapport final en cours...',
     },
+    reportWriting: {
+        ko: '보고서 작성 중... ({chars}자)',
+        en: 'Writing report... ({chars} chars)',
+        ja: 'レポート作成中... ({chars}文字)',
+        zh: '正在撰写报告... ({chars}字)',
+        es: 'Redactando informe... ({chars} caracteres)',
+        de: 'Bericht wird verfasst... ({chars} Zeichen)',
+        fr: 'Rédaction du rapport... ({chars} caractères)',
+    },
     completed: {
         ko: '리서치 완료!',
         en: 'Research complete!',

--- a/backend/api/src/services/deep-research/report-generator.ts
+++ b/backend/api/src/services/deep-research/report-generator.ts
@@ -87,9 +87,11 @@ export async function generateReport(params: {
     sources: SearchResult[];
     subTopics: SubTopic[];
     sessionId: string;
+    /** 보고서 생성 진행 콜백 — 누적 생성 글자 수를 보고해 report 단계 progress 공백(체감 멈춤)을 제거 */
+    onReportProgress?: (charsGenerated: number) => void;
     throwIfAborted: () => void;
 }): Promise<{ summary: string; keyFindings: string[] }> {
-    const { client, config, topic, findings, sources, subTopics, sessionId, throwIfAborted } = params;
+    const { client, config, topic, findings, sources, subTopics, sessionId, onReportProgress, throwIfAborted } = params;
 
     throwIfAborted();
     const db = getUnifiedDatabase();
@@ -133,9 +135,17 @@ export async function generateReport(params: {
     });
 
     try {
-        const response = await reportClient.chat([
-            { role: 'user', content: prompt }
-        ], { temperature: LLM_TEMPERATURES.RESEARCH_SYNTHESIS });
+        // 스트리밍 호출 — 토큰이 흐르는 동안 진행을 보고(85% 공백 해소)하고, 누적 출력으로
+        // stall 여부를 가시화한다. onToken 모드에서도 client 는 최종 content 를 누적 반환한다.
+        let accumulatedChars = 0;
+        const response = await reportClient.chat(
+            [{ role: 'user', content: prompt }],
+            { temperature: LLM_TEMPERATURES.RESEARCH_SYNTHESIS },
+            (token) => {
+                accumulatedChars += token.length;
+                onReportProgress?.(accumulatedChars);
+            },
+        );
         throwIfAborted();
 
         const content = response.content;


### PR DESCRIPTION
## 배경
라이브 점검에서 `report` 단계가 **85%에서 15분간 progress 공백**(체감 멈춤)이 잔존하고, 보고서 생성이 timeout→fallback되던 문제. 합성 단계의 B-1(progress 세분화)을 보고서 단계로 확장.

## 변경
- **report-generator**: `reportClient.chat`을 스트리밍(onToken)으로 전환 + `onReportProgress` 콜백으로 누적 생성 글자 수 보고. 토큰이 흐르는 동안 진행이 가시화돼 stall 여부 확인 가능
- **DeepResearchService**: report 단계 85~99% 구간을 누적 글자 수(예상 20K자 기준)로 채워 "보고서 작성 중 (N자)"로 실시간 갱신
- **runtime-limits**: `REPORT_EXPECTED_CHARS` 진행률 추정 상수
- **deep-research-prompts**: `reportWriting` 다국어 메시지

## 효과
report 단계가 더 이상 85%에서 멈춘 듯 보이지 않고 글자 수로 진행이 보입니다. 채팅 인라인 카드(#103)와 합쳐져 보고서 작성 과정이 실시간 표시됩니다.

## 검증
- [x] `tsc --noEmit` 통과
- [x] 백엔드 단위 테스트 전수 통과
- [x] ESLint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)