### PR TITLE
fix(research): 딥리서치 히스토리 안 보임 — 조회 rate limit 완화

### DIFF
--- a/backend/api/src/config/rate-limits.ts
+++ b/backend/api/src/config/rate-limits.ts
@@ -58,12 +58,17 @@ export const RL_CHAT = {
 } as const;
 
 /**
- * Research API 레이트 리밋 (LLM 멀티스텝 — 비용 높음)
+ * Research API 레이트 리밋.
+ *
+ * ipLimit/userLimit 은 endpointRules 에 안 걸리는 요청(주로 **GET 히스토리 조회** —
+ * 세션 목록/상세/스텝)의 기본 한도다. 조회는 빈번(페이지 진입·세션 클릭마다 호출)하므로
+ * 관대하게 둔다. 비용 높은 **실행(POST)** 은 researchLimit/deepLimit(endpointRules)로 별도 제한.
+ * (구 ip=10/user=15/15분은 조회까지 묶어, 세션 몇 번만 클릭해도 429 → 히스토리가 사라졌다.)
  */
 export const RL_RESEARCH = {
     windowMs: WINDOW_15M,
-    ipLimit: Number(process.env.RL_RESEARCH_IP) || 10,
-    userLimit: Number(process.env.RL_RESEARCH_USER) || 15,
+    ipLimit: Number(process.env.RL_RESEARCH_IP) || 60,
+    userLimit: Number(process.env.RL_RESEARCH_USER) || 120,
     researchLimit: Number(process.env.RL_RESEARCH_RESEARCH) || 10,
     deepLimit: Number(process.env.RL_RESEARCH_DEEP) || 6,
 } as const;


### PR DESCRIPTION
## 문제
딥리서치 히스토리(research 페이지 세션 목록)가 안 보임.

## 원인 (라이브 점검으로 규명)
- `GET /api/research/sessions`가 **429 (Too Many Requests)** 반환
- `researchLimiter`가 비용 높은 **실행(POST)**뿐 아니라 가벼운 **GET 조회**(세션 목록/상세/스텝)까지 `ipLimit 10 / userLimit 15` **per 15분**으로 묶음
- research 페이지 진입(1) + 세션 클릭(상세+스텝 2회씩) + 새로고침 → 15분 한도를 금방 초과 → 429 → 목록 사라짐

## 수정
- `RL_RESEARCH` **ipLimit 10→60, userLimit 15→120** (조회 빈도 수용)
- 실행(POST)은 `endpointRules`(researchLimit 10 / deepLimit 6)로 별도 제한 **유지** — 비용 보호 영향 없음
- `env override`(RL_RESEARCH_IP/USER) 그대로 운영 조정 가능

## 검증
- [x] `tsc --noEmit` 통과
- [x] ESLint 통과
- [x] 라이브: GET /sessions 429 재현 → 원인 확정

🤖 Generated with [Claude Code](https://claude.com/claude-code)