### PR TITLE
feat(chat): 도구 실행 중 진행 표시 (mcp_tool_start)

### DIFF
--- a/backend/api/src/chat/request-handler-types.ts
+++ b/backend/api/src/chat/request-handler-types.ts
@@ -128,6 +128,11 @@ export interface ChatRequestParams {
      */
     onMcpToolResult?: (event: { toolName: string; resources: Array<{ uri: string; mimeType?: string; text?: string }> }) => void;
     /**
+     * MCP tool 호출이 시작될 때 호출되는 콜백.
+     * frontend "🔍 {도구} 실행 중" 진행 표시를 트리거 ("생각 중..." 멈춤 혼선 해소).
+     */
+    onMcpToolStart?: (event: { toolName: string }) => void;
+    /**
      * Phase 3.4 (2026-05-26) 메시지 편집 분기:
      * 새 session 생성 시 부모 session 추적 (conversation_sessions.metadata.parentSessionId).
      * 분기된 대화의 "원본으로 돌아가기" 기능 + 사이드바 그룹화 등에 활용.

--- a/backend/api/src/chat/request-handler.ts
+++ b/backend/api/src/chat/request-handler.ts
@@ -368,6 +368,7 @@ export class ChatRequestHandler {
             params.onThinking,
             onSystemEvent,
             params.onMcpToolResult,
+            params.onMcpToolStart,
         );
 
         const endTime = Date.now();

--- a/backend/api/src/services/ChatService.ts
+++ b/backend/api/src/services/ChatService.ts
@@ -96,6 +96,13 @@ export class ChatService {
      */
     private currentMcpToolResultCallback?: (event: { toolName: string; resources: Array<{ uri: string; mimeType?: string; text?: string }> }) => void;
 
+    /**
+     * 현재 채팅의 MCP tool 시작 콜백.
+     * processMessage 진입 시 저장, executeExternalTool / agent-loop-strategy 가 공유.
+     * 도구 호출 직전 invoke → ws-chat-handler 가 frontend 로 `mcp_tool_start` emit ("실행 중" 진행 표시).
+     */
+    private currentMcpToolStartCallback?: (event: { toolName: string }) => void;
+
     /** 단일 LLM 직접 호출 전략 */
     private readonly directStrategy: DirectStrategy;
     /** Generate-Verify 생성-검증 전략 */
@@ -269,9 +276,12 @@ export class ChatService {
         onThinking?: (thinking: string) => void,
         onSystemEvent?: SystemEventCallback,
         onMcpToolResult?: (event: { toolName: string; resources: Array<{ uri: string; mimeType?: string; text?: string }> }) => void,
+        onMcpToolStart?: (event: { toolName: string }) => void,
     ): Promise<string> {
         // MCP tool resource content 콜백을 인스턴스 상태로 저장 — executeExternalTool 및 strategy 가 공유
         this.currentMcpToolResultCallback = onMcpToolResult;
+        // MCP tool 시작 콜백 — 도구 실행 직전 진행 표시용 (동일 경로 공유)
+        this.currentMcpToolStartCallback = onMcpToolStart;
         // 채팅 요청 전체를 root span으로 추적 (모든 LLM/도구 호출이 자식 span으로 자동 연결)
         return withSpan(
             'chat-service',
@@ -401,6 +411,7 @@ export class ChatService {
             currentUserContext: params.reqCtx.userContext,
             getAllowedTools: () => resolvedAllowedTools,
             onMcpToolResult: this.currentMcpToolResultCallback,
+            onMcpToolStart: this.currentMcpToolStartCallback,
         });
     }
 
@@ -508,6 +519,7 @@ export class ChatService {
             providerRouter: this.providerRouter,
             currentUserContext: reqCtx.userContext,
             mcpToolResultCallback: this.currentMcpToolResultCallback,
+            mcpToolStartCallback: this.currentMcpToolStartCallback,
             onUsage: (usage) => { this.lastProviderUsage = usage; },
             allowedTools: await this.getAllowedTools(reqCtx),
         };

--- a/backend/api/src/services/chat-service/external-provider.ts
+++ b/backend/api/src/services/chat-service/external-provider.ts
@@ -32,6 +32,8 @@ export interface ExternalProviderDeps {
     currentUserContext: UserContext | null;
     /** MCP tool 호출 결과 inline 카드 콜백 (frontend 표시용) */
     mcpToolResultCallback?: (data: { toolName: string; resources: Array<{ uri: string; mimeType?: string; text?: string }> }) => void;
+    /** MCP tool 호출 시작 콜백 (frontend "실행 중" 진행 표시용) */
+    mcpToolStartCallback?: (data: { toolName: string }) => void;
     /** Provider usage 누적 — ChatService.lastProviderUsage setter */
     onUsage?: (usage: import('../../llm').UsageMetrics) => void;
     /** Allowed tools (tier + agent 매칭 후) */
@@ -300,6 +302,13 @@ export async function executeExternalTool(
             tier: 'free' as const,
             role: 'guest' as const,
         };
+        // 도구 실행 시작 알림 — 권한 체크 통과 후, 실제 호출 직전.
+        // frontend 가 "🔍 {도구} 실행 중" 진행 표시로 "생각 중..." 멈춤 혼선 해소.
+        if (deps.mcpToolStartCallback) {
+            try { deps.mcpToolStartCallback({ toolName }); }
+            catch (e) { logger.warn(`onMcpToolStart 콜백 실패: ${e instanceof Error ? e.message : String(e)}`); }
+        }
+
         const result = await mcpClient.executeToolWithContext(toolName, toolArgs, userCtx);
 
         if (deps.mcpToolResultCallback && Array.isArray(result.content)) {

--- a/backend/api/src/services/chat-service/strategy-executor.ts
+++ b/backend/api/src/services/chat-service/strategy-executor.ts
@@ -66,6 +66,8 @@ export interface StrategyExecutorParams {
     getAllowedTools: () => ToolDefinition[];
     /** MCP tool resource content 콜백 (frontend 인라인 카드 표시용, 선택) */
     onMcpToolResult?: (event: { toolName: string; resources: Array<{ uri: string; mimeType?: string; text?: string }> }) => void;
+    /** MCP tool 시작 콜백 (frontend "실행 중" 진행 표시용, 선택) */
+    onMcpToolStart?: (event: { toolName: string }) => void;
 }
 
 /**
@@ -85,7 +87,7 @@ export async function selectAndExecuteStrategy(params: StrategyExecutorParams): 
         supportsTools, supportsThinking, thinkingMode, thinkingLevel,
         languagePolicy, streamToken, abortSignal, checkAborted, format,
         generateVerifyStrategy, agentLoopStrategy, thinkingStrategy,
-        client, currentUserContext, getAllowedTools, onMcpToolResult,
+        client, currentUserContext, getAllowedTools, onMcpToolResult, onMcpToolStart,
     } = params;
 
     // P3-A: 사후 검증용 추적 변수
@@ -228,6 +230,7 @@ export async function selectAndExecuteStrategy(params: StrategyExecutorParams): 
         executionPlan, currentUserContext, getAllowedTools,
         onToken: wrappedStreamToken, abortSignal, checkAborted, format,
         onMcpToolResult,
+        onMcpToolStart,
         executionState,
         fallbackHint,
     });

--- a/backend/api/src/services/chat-strategies/agent-loop-execute-tool.ts
+++ b/backend/api/src/services/chat-strategies/agent-loop-execute-tool.ts
@@ -204,6 +204,11 @@ export async function executeToolCall(context: AgentLoopStrategyContext, toolCal
     // 인자 sanitize(SQL/명령어 인젝션 차단)를 REST 경로와 동일하게 적용(defense-in-depth 정합).
     try {
         const mcpClient = getUnifiedMCPClient();
+        // 도구 실행 시작 알림 — 실제 호출 직전. frontend "🔍 {도구} 실행 중" 진행 표시.
+        if (context.onMcpToolStart) {
+            try { context.onMcpToolStart({ toolName }); }
+            catch (e) { logger.warn(`onMcpToolStart 콜백 실패: ${e instanceof Error ? e.message : String(e)}`); }
+        }
         const result = context.currentUserContext
             ? await mcpClient.executeToolWithContext(toolName, toolArgs, context.currentUserContext)
             : await mcpClient.getToolRouter().executeTool(toolName, toolArgs, undefined);

--- a/backend/api/src/services/chat-strategies/types.ts
+++ b/backend/api/src/services/chat-strategies/types.ts
@@ -44,6 +44,12 @@ export interface ChatContext {
         toolName: string;
         resources: Array<{ uri: string; mimeType?: string; text?: string }>;
     }) => void;
+    /**
+     * MCP tool 호출이 시작될 때 호출되는 콜백.
+     * ws-chat-handler 가 frontend 로 `mcp_tool_start` WS 메시지로 emit.
+     * "🔍 {도구} 실행 중" 진행 표시용 ("생각 중..." 멈춤 혼선 해소).
+     */
+    onMcpToolStart?: (event: { toolName: string }) => void;
 }
 
 /**

--- a/backend/api/src/sockets/ws-chat-handler.ts
+++ b/backend/api/src/sockets/ws-chat-handler.ts
@@ -305,6 +305,17 @@ export async function handleChatMessage(
                     }));
                 }
             },
+            // MCP tool 호출 시작 알림 — frontend "🔍 {도구} 실행 중" 진행 표시
+            // (도구 실행 중 "생각 중..." 이 멈춘 듯 보이는 혼선 해소)
+            onMcpToolStart: (event) => {
+                if (ws.readyState === ws.OPEN) {
+                    ws.send(JSON.stringify({
+                        type: 'mcp_tool_start',
+                        toolName: event.toolName,
+                        messageId,
+                    }));
+                }
+            },
             // 시스템 이벤트 (자동 토론 활성화 등 메타 알림) — UI 토스트 분리 표시
             onSystemEvent: (event) => {
                 if (ws.readyState === ws.OPEN) {

--- a/frontend/web/public/js/modules/chat-renderer.js
+++ b/frontend/web/public/js/modules/chat-renderer.js
@@ -174,6 +174,50 @@ function addChatMessage(role, content) {
 }
 
 /**
+ * MCP 도구명 → 사용자 친화 라벨 + iconify(lucide) 아이콘 매핑.
+ * 앱에 이미 쓰인 아이콘만 사용 (CDN fetch + CSP 제약).
+ * 미등록 도구는 toolName 을 그대로 노출하되 escape 처리.
+ */
+const TOOL_STATUS_LABELS = {
+    web_search: { label: '웹 검색', icon: 'lucide:search' },
+    web_scrape: { label: '웹 검색', icon: 'lucide:search' },
+    web_map: { label: '웹 검색', icon: 'lucide:search' },
+    web_crawl: { label: '웹 검색', icon: 'lucide:search' },
+    sequential_thinking: { label: '추론', icon: 'lucide:wrench' },
+};
+
+/**
+ * MCP 도구 실행 시작 진행 표시.
+ * 현재 스트리밍 중인 assistant 버블의 "생각 중..." 영역(.loading-spinner)을
+ * "🔍 {친화 라벨} 실행 중..." 으로 갱신한다. 다음 토큰(appendToken)이 도착하면
+ * 스피너가 제거되며 본문으로 자연 대체되므로 원복 불필요.
+ * 도구가 여러 번 호출되면 최신 도구명으로 갱신된다.
+ * @param {string} toolName - 서버에서 전달된 MCP 도구명
+ * @returns {void}
+ */
+function showToolStatus(toolName) {
+    const content = getState('currentAssistantMessageContent');
+    if (!content) return;
+
+    // 이미 본문 토큰이 들어오기 시작했으면(스피너 없음) 진행 표시 갱신 생략.
+    const spinner = content.querySelector('.loading-spinner');
+    if (!spinner) return;
+
+    const mapping = (typeof toolName === 'string' && TOOL_STATUS_LABELS[toolName]) || null;
+    // 라벨은 raw 값 — 출력 직전 한 번만 escape (이중 이스케이프 방지).
+    const label = mapping ? mapping.label : String(toolName || '도구');
+    const icon = mapping ? mapping.icon : 'lucide:wrench';
+
+    // .loading-spinner 영역을 통째로 갱신 — appendToken 이 .loading-spinner 를
+    // querySelector 로 찾아 제거하므로 클래스/구조를 유지해야 한다.
+    // toolName 은 서버 도구명이지만 방어적으로 escape (CSP·XSS).
+    content.innerHTML =
+        '<span class="loading-spinner"></span> ' +
+        '<iconify-icon icon="' + icon + '"></iconify-icon> ' +
+        escapeHtml(label) + ' 실행 중...';
+}
+
+/**
  * 스트리밍 토큰 추가
  * WebSocket에서 수신된 토큰을 현재 AI 메시지에 누적 합산합니다.
  * 생각 과정([N/M] 패턴) 감지 시 진행 상태를 표시하고,
@@ -464,5 +508,6 @@ export {
     appendToken,
     appendThinkingToken,
     finishAssistantMessage,
+    showToolStatus,
     setHideAbortButton
 };

--- a/frontend/web/public/js/modules/websocket.js
+++ b/frontend/web/public/js/modules/websocket.js
@@ -23,6 +23,7 @@ import {
     setToolEntry,
 } from '../components/artifact-panel.js';
 import { insertArtifactCard } from '../components/artifact-card.js';
+import { showToolStatus } from './chat-renderer.js';
 
 /**
  * 2026-05-26 Phase 3 — 분기된 세션 배너 표시.
@@ -354,6 +355,16 @@ const messageHandlers = {
      *
      * Payload: { type: 'mcp_tool_result', toolName, resources: [{ uri, mimeType?, text? }], messageId }
      */
+    /**
+     * MCP tool 호출 시작 — 진행 표시.
+     * 도구 실행 중 "생각 중..." 이 멈춘 듯 보이는 혼선 해소를 위해
+     * 현재 스트리밍 버블을 "🔍 {도구} 실행 중..." 으로 갱신.
+     * Payload: { type: 'mcp_tool_start', toolName, messageId }
+     */
+    'mcp_tool_start': (data) => {
+        if (!data || typeof data.toolName !== 'string') return;
+        try { showToolStatus(data.toolName); } catch (e) { /* 렌더 실패 무시 */ }
+    },
     'mcp_tool_result': async (data) => {
         if (!Array.isArray(data?.resources) || data.resources.length === 0) return;
         // 우측 컨텍스트 패널 '도구' 탭으로 미러 (인라인 카드 렌더는 그대로)


### PR DESCRIPTION
일반 채팅에서 도구 실행 중 '생각 중...'이 멈춘 듯 보이던 혼선 해소 — mcp_tool_result 체인을 미러링해 도구 호출 시작 시 '🔍 {도구} 실행 중'을 표시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)