### PR TITLE
refactor(apikey): unify rate-limit to single limit — tier 차등 제거

### DIFF
--- a/backend/api/src/data/models/legacy-schema.ts
+++ b/backend/api/src/data/models/legacy-schema.ts
@@ -382,7 +382,6 @@ CREATE TABLE IF NOT EXISTS user_api_keys (
     description TEXT,
     scopes JSONB DEFAULT '["*"]',
     allowed_models JSONB DEFAULT '["*"]',
-    rate_limit_tier TEXT NOT NULL DEFAULT 'free' CHECK(rate_limit_tier IN ('free', 'starter', 'standard', 'enterprise')),
     is_active BOOLEAN DEFAULT TRUE,
     last_used_at TIMESTAMPTZ,
     expires_at TIMESTAMPTZ,
@@ -452,7 +451,6 @@ CREATE INDEX IF NOT EXISTS idx_mcp_servers_enabled ON mcp_servers(enabled);
 CREATE INDEX IF NOT EXISTS idx_api_keys_user ON user_api_keys(user_id);
 CREATE INDEX IF NOT EXISTS idx_api_keys_hash ON user_api_keys(key_hash);
 CREATE INDEX IF NOT EXISTS idx_api_keys_active ON user_api_keys(user_id, is_active);
-CREATE INDEX IF NOT EXISTS idx_api_keys_tier ON user_api_keys(rate_limit_tier);
 
 CREATE INDEX IF NOT EXISTS idx_oauth_states_created ON oauth_states(created_at);
 

--- a/backend/api/src/data/models/unified-database.ts
+++ b/backend/api/src/data/models/unified-database.ts
@@ -51,14 +51,13 @@ import type {
     ExternalConnection,
     ExternalFile,
     MCPServerRow,
-    ApiKeyTier,
     UserApiKey,
     UserApiKeyPublic,
     AgentTask,
     AgentTaskStatus,
     AgentTaskStep,
 } from './unified-database.types';
-import { API_KEY_TIER_LIMITS as _API_KEY_TIER_LIMITS } from './unified-database.types';
+import { API_KEY_LIMITS as _API_KEY_LIMITS } from './unified-database.types';
 
 export type {
     User,
@@ -75,11 +74,10 @@ export type {
     ExternalConnection,
     ExternalFile,
     MCPServerRow,
-    ApiKeyTier,
     UserApiKey,
     UserApiKeyPublic,
 };
-export { _API_KEY_TIER_LIMITS as API_KEY_TIER_LIMITS };
+export { _API_KEY_LIMITS as API_KEY_LIMITS };
 
 /**
  * 통합 데이터베이스 클래스 (PostgreSQL)
@@ -492,7 +490,6 @@ export class UnifiedDatabase {
         description?: string;
         scopes?: string[];
         allowedModels?: string[];
-        rateLimitTier?: ApiKeyTier;
         expiresAt?: string;
     }): Promise<UserApiKey> {
         return this.apiKeyRepository.createApiKey(params);
@@ -519,7 +516,6 @@ export class UnifiedDatabase {
         description?: string;
         scopes?: string[];
         allowedModels?: string[];
-        rateLimitTier?: ApiKeyTier;
         isActive?: boolean;
         expiresAt?: string | null;
     }): Promise<UserApiKey | undefined> {

--- a/backend/api/src/data/models/unified-database.types.ts
+++ b/backend/api/src/data/models/unified-database.types.ts
@@ -248,8 +248,6 @@ export interface MCPServerRow {
 // API Key 관리 인터페이스
 // ============================================
 
-export type ApiKeyTier = 'free' | 'starter' | 'standard' | 'enterprise';
-
 /**
  * 사용자 API Key 엔티티
  * 외부 개발자 API 접근을 위한 키 정보
@@ -274,8 +272,6 @@ export interface UserApiKey {
     scopes: string[];
     /** 접근 허용된 모델 목록 */
     allowed_models: string[];
-    /** Rate Limit 등급 (free/starter/standard/enterprise) */
-    rate_limit_tier: ApiKeyTier;
     /** 키 활성화 상태 */
     is_active: boolean;
     /** 마지막 사용 일시 */
@@ -302,7 +298,6 @@ export interface UserApiKeyPublic {
     description?: string;
     scopes: string[];
     allowed_models: string[];
-    rate_limit_tier: ApiKeyTier;
     is_active: boolean;
     last_used_at?: string;
     expires_at?: string;
@@ -312,15 +307,21 @@ export interface UserApiKeyPublic {
     total_tokens: number;
 }
 
-/** Rate limit tier 설정 */
-export const API_KEY_TIER_LIMITS: Record<ApiKeyTier, {
+/**
+ * 모든 API Key 에 공통 적용되는 단일 Rate Limit 한도.
+ *
+ * tier(free/starter/standard/enterprise) 차등은 제거됐다 — 모든 키가 동일한 한도를 공유한다.
+ * 순간 폭주(DoS)·비용 폭주 방지용으로 RPM/TPM 상한만 유지하고,
+ * 일·월 누적 요청 수는 무제한(-1)이다.
+ */
+export const API_KEY_LIMITS: {
     rpm: number;
     tpm: number;
     dailyRequests: number;
     monthlyRequests: number;
-}> = {
-    free: { rpm: 10, tpm: 10_000, dailyRequests: 100, monthlyRequests: 1_000 },
-    starter: { rpm: 30, tpm: 50_000, dailyRequests: 500, monthlyRequests: 10_000 },
-    standard: { rpm: 60, tpm: 100_000, dailyRequests: 3_000, monthlyRequests: 100_000 },
-    enterprise: { rpm: 300, tpm: 1_000_000, dailyRequests: -1, monthlyRequests: -1 }, // -1 = unlimited
+} = {
+    rpm: 300,
+    tpm: 1_000_000,
+    dailyRequests: -1, // -1 = unlimited
+    monthlyRequests: -1, // -1 = unlimited
 };

--- a/backend/api/src/data/repositories/api-key-repository.ts
+++ b/backend/api/src/data/repositories/api-key-repository.ts
@@ -8,7 +8,7 @@
  * - 키 해시 기반 인증 조회, 사용자별 키 목록
  */
 import { BaseRepository, QueryParam } from './base-repository';
-import type { ApiKeyTier, UserApiKey } from '../models/unified-database.types';
+import type { UserApiKey } from '../models/unified-database.types';
 
 export class ApiKeyRepository extends BaseRepository {
     async recordApiUsage(date: string, apiKeyId: string, requests: number, tokens: number, errors: number, avgResponseTime: number, models: Record<string, unknown>) {
@@ -48,13 +48,12 @@ export class ApiKeyRepository extends BaseRepository {
         description?: string;
         scopes?: string[];
         allowedModels?: string[];
-        rateLimitTier?: ApiKeyTier;
         expiresAt?: string;
     }): Promise<UserApiKey> {
         const result = await this.query<UserApiKey>(
-            `INSERT INTO user_api_keys 
-            (id, user_id, key_hash, key_prefix, last_4, name, description, scopes, allowed_models, rate_limit_tier, expires_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            `INSERT INTO user_api_keys
+            (id, user_id, key_hash, key_prefix, last_4, name, description, scopes, allowed_models, expires_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
             RETURNING *`,
             [
                 params.id,
@@ -66,7 +65,6 @@ export class ApiKeyRepository extends BaseRepository {
                 params.description || null,
                 JSON.stringify(params.scopes || ['*']),
                 JSON.stringify(params.allowedModels || ['*']),
-                params.rateLimitTier || 'free',
                 params.expiresAt || null
             ]
         );
@@ -146,7 +144,6 @@ export class ApiKeyRepository extends BaseRepository {
         description?: string;
         scopes?: string[];
         allowedModels?: string[];
-        rateLimitTier?: ApiKeyTier;
         isActive?: boolean;
         expiresAt?: string | null;
     }): Promise<UserApiKey | undefined> {
@@ -169,10 +166,6 @@ export class ApiKeyRepository extends BaseRepository {
         if (updates.allowedModels !== undefined) {
             sets.push(`allowed_models = $${paramIdx++}`);
             params.push(JSON.stringify(updates.allowedModels));
-        }
-        if (updates.rateLimitTier !== undefined) {
-            sets.push(`rate_limit_tier = $${paramIdx++}`);
-            params.push(updates.rateLimitTier);
         }
         if (updates.isActive !== undefined) {
             sets.push(`is_active = $${paramIdx++}`);

--- a/backend/api/src/middlewares/api-key-limiter.ts
+++ b/backend/api/src/middlewares/api-key-limiter.ts
@@ -11,35 +11,20 @@
 
 import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import { Request, Response, NextFunction } from 'express';
-import { API_KEY_TIER_LIMITS, ApiKeyTier } from '../data/models/unified-database';
+import { API_KEY_LIMITS } from '../data/models/unified-database';
 import { error as apiError, ErrorCodes } from '../utils/api-response';
 import { isTPMExceeded } from './rate-limit-headers';
 
 /**
- * Tier별 RPM 한도 조회
- */
-function getTierLimit(tier: ApiKeyTier | undefined): number {
-    const resolved = tier || 'free';
-    return API_KEY_TIER_LIMITS[resolved].rpm;
-}
-
-/**
  * API Key 인증 요청에 대한 RPM Rate Limiter
- * 
+ *
  * - keyGenerator: API Key ID 기반 (인증된 경우) / IP 기반 (미인증)
- * - limit: Tier별 동적 한도
+ * - limit: 모든 키 공통 단일 한도 (tier 차등 제거)
  * - windowMs: 1분 (RPM)
  */
 export const apiKeyRateLimiter = rateLimit({
     windowMs: 60 * 1000, // 1분
-    limit: (req: Request): number => {
-        // API Key 인증이 되어있으면 tier에 따른 한도 적용
-        if (req.apiKeyRecord) {
-            return getTierLimit(req.apiKeyRecord.rate_limit_tier);
-        }
-        // 미인증 요청은 최소 한도
-        return API_KEY_TIER_LIMITS.free.rpm;
-    },
+    limit: (): number => API_KEY_LIMITS.rpm,
 
     // API Key ID 기반 분리 (키마다 독립적 카운터)
     keyGenerator: (req: Request): string => {
@@ -83,16 +68,13 @@ export function apiKeyTPMLimiter(req: Request, res: Response, next: NextFunction
         return;
     }
 
-    const tier: ApiKeyTier = req.apiKeyRecord.rate_limit_tier || 'free';
-
-    if (isTPMExceeded(req.apiKeyId, tier)) {
-        const limits = API_KEY_TIER_LIMITS[tier];
+    if (isTPMExceeded(req.apiKeyId)) {
         res.status(429).json(apiError(
             ErrorCodes.RATE_LIMITED,
-            `Token rate limit exceeded. Maximum ${limits.tpm.toLocaleString()} tokens per minute for ${tier} tier.`,
+            `Token rate limit exceeded. Maximum ${API_KEY_LIMITS.tpm.toLocaleString()} tokens per minute.`,
             {
                 type: 'tokens_per_minute',
-                limit: limits.tpm,
+                limit: API_KEY_LIMITS.tpm,
                 retry_after_seconds: 60,
                 documentation_url: '/developer#rate-limits'
             }

--- a/backend/api/src/middlewares/rate-limit-headers.ts
+++ b/backend/api/src/middlewares/rate-limit-headers.ts
@@ -14,7 +14,7 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
-import { API_KEY_TIER_LIMITS, ApiKeyTier } from '../data/models/unified-database';
+import { API_KEY_LIMITS } from '../data/models/unified-database';
 
 /** 인메모리 TPM 카운터 (키 ID → { tokens, windowStart }) */
 const tpmCounters: Map<string, { tokens: number; windowStart: number }> = new Map();
@@ -57,8 +57,7 @@ export function rateLimitHeaders(req: Request, res: Response, next: NextFunction
         return;
     }
 
-    const tier: ApiKeyTier = req.apiKeyRecord.rate_limit_tier || 'free';
-    const limits = API_KEY_TIER_LIMITS[tier];
+    const limits = API_KEY_LIMITS;
     const keyId = req.apiKeyId;
     const now = Date.now();
 
@@ -112,11 +111,10 @@ export function recordTokenUsage(keyId: string, tokens: number): void {
  * TPM 한도 초과 여부 확인
  * 
  * @param keyId - API Key ID
- * @param tier - API Key 등급
  * @returns true이면 한도 초과
  */
-export function isTPMExceeded(keyId: string, tier: ApiKeyTier): boolean {
-    const limits = API_KEY_TIER_LIMITS[tier];
+export function isTPMExceeded(keyId: string): boolean {
+    const limits = API_KEY_LIMITS;
     const now = Date.now();
     const tpmCounter = getOrResetCounter(tpmCounters, keyId, () => ({
         tokens: 0,

--- a/backend/api/src/routes/api-keys.routes.ts
+++ b/backend/api/src/routes/api-keys.routes.ts
@@ -34,7 +34,6 @@ import { validate } from '../middlewares/validation';
 import { asyncHandler } from '../utils/error-handler';
 import { success, notFound, badRequest, unauthorized, rateLimited } from '../utils/api-response';
 import { getApiKeyService, ApiKeyError } from '../services/ApiKeyService';
-import type { ApiKeyTier } from '../data/models/unified-database';
 
 const router = Router();
 
@@ -46,7 +45,6 @@ const router = Router();
  * @property {string} [description] - 키 설명 (최대 500자)
  * @property {string[]} [scopes] - 접근 범위 목록
  * @property {string[]} [allowed_models] - 허용 모델 목록
- * @property {string} [rate_limit_tier] - Rate Limit 등급 (free/starter/standard/enterprise)
  * @property {string} [expires_at] - 만료 일시 (ISO 8601 datetime)
  */
 const createApiKeySchema = z.object({
@@ -54,7 +52,6 @@ const createApiKeySchema = z.object({
     description: z.string().max(500).optional(),
     scopes: z.array(z.string()).optional(),
     allowed_models: z.array(z.string()).optional(),
-    rate_limit_tier: z.enum(['free', 'starter', 'standard', 'enterprise']).optional(),
     expires_at: z.string().datetime().optional(),
 });
 
@@ -64,7 +61,6 @@ const createApiKeySchema = z.object({
  * @property {string} [description] - 키 설명 (최대 500자)
  * @property {string[]} [scopes] - 접근 범위 목록
  * @property {string[]} [allowed_models] - 허용 모델 목록
- * @property {string} [rate_limit_tier] - Rate Limit 등급
  * @property {boolean} [is_active] - 활성화 상태
  * @property {string|null} [expires_at] - 만료 일시 (null = 무기한)
  */
@@ -73,7 +69,6 @@ const updateApiKeySchema = z.object({
     description: z.string().max(500).optional(),
     scopes: z.array(z.string()).optional(),
     allowed_models: z.array(z.string()).optional(),
-    rate_limit_tier: z.enum(['free', 'starter', 'standard', 'enterprise']).optional(),
     is_active: z.boolean().optional(),
     expires_at: z.string().datetime().nullable().optional(),
 });
@@ -120,7 +115,6 @@ router.post('/',
                 description: req.body.description,
                 scopes: req.body.scopes,
                 allowedModels: req.body.allowed_models,
-                rateLimitTier: req.body.rate_limit_tier as ApiKeyTier | undefined,
                 expiresAt: req.body.expires_at,
             });
 
@@ -211,7 +205,6 @@ router.patch('/:id',
             description: req.body.description,
             scopes: req.body.scopes,
             allowedModels: req.body.allowed_models,
-            rateLimitTier: req.body.rate_limit_tier as ApiKeyTier | undefined,
             isActive: req.body.is_active,
             expiresAt: req.body.expires_at,
         });

--- a/backend/api/src/routes/v1/index.ts
+++ b/backend/api/src/routes/v1/index.ts
@@ -19,6 +19,7 @@
  * @requires apiKeyTPMLimiter - TPM(Tokens Per Minute) 이중 제한
  */
 import { Router } from 'express';
+import { API_KEY_LIMITS } from '../../data/models/unified-database';
 
 // Import existing routers
 import chatRouter from '../chat.routes';
@@ -83,7 +84,10 @@ v1Router.get('/usage', requireApiKey, asyncHandler(async (req, res) => {
             last_used_at: stats?.lastUsedAt ?? null,
         },
         limits: {
-            tier: keyRecord.rate_limit_tier || 'free',
+            rpm: API_KEY_LIMITS.rpm,
+            tpm: API_KEY_LIMITS.tpm,
+            daily_requests: API_KEY_LIMITS.dailyRequests,
+            monthly_requests: API_KEY_LIMITS.monthlyRequests,
         },
     }));
 }));
@@ -114,7 +118,10 @@ v1Router.get('/usage/daily', requireApiKey, asyncHandler(async (req, res) => {
             last_used_at: stats?.lastUsedAt ?? null,
         },
         limits: {
-            tier: keyRecord.rate_limit_tier || 'free',
+            rpm: API_KEY_LIMITS.rpm,
+            tpm: API_KEY_LIMITS.tpm,
+            daily_requests: API_KEY_LIMITS.dailyRequests,
+            monthly_requests: API_KEY_LIMITS.monthlyRequests,
         },
     }));
 }));

--- a/backend/api/src/services/ApiKeyService.ts
+++ b/backend/api/src/services/ApiKeyService.ts
@@ -8,7 +8,7 @@
  */
 
 import crypto from 'node:crypto';
-import { getUnifiedDatabase, UserApiKey, UserApiKeyPublic, ApiKeyTier } from '../data/models/unified-database';
+import { getUnifiedDatabase, UserApiKey, UserApiKeyPublic } from '../data/models/unified-database';
 import { generateApiKey, hashApiKey, extractLast4, API_KEY_PREFIX } from '../auth/api-key-utils';
 import { getConfig } from '../config/env';
 import { createLogger } from '../utils/logger';
@@ -22,7 +22,6 @@ export interface CreateApiKeyParams {
     description?: string;
     scopes?: string[];
     allowedModels?: string[];
-    rateLimitTier?: ApiKeyTier;
     expiresAt?: string;
 }
 
@@ -40,7 +39,6 @@ export interface UpdateApiKeyParams {
     description?: string;
     scopes?: string[];
     allowedModels?: string[];
-    rateLimitTier?: ApiKeyTier;
     isActive?: boolean;
     expiresAt?: string | null;
 }
@@ -58,7 +56,6 @@ function toPublic(key: UserApiKey): UserApiKeyPublic {
         description: key.description,
         scopes: key.scopes,
         allowed_models: key.allowed_models,
-        rate_limit_tier: key.rate_limit_tier,
         is_active: key.is_active,
         last_used_at: key.last_used_at,
         expires_at: key.expires_at,
@@ -110,15 +107,7 @@ export class ApiKeyService {
         const last4 = extractLast4(plainKey);
         const keyId = crypto.randomUUID();
 
-        // §7 Security: Free tier 30일 자동 만료 강제
-        let expiresAt = params.expiresAt;
-        const tier = params.rateLimitTier || 'free';
-        if (tier === 'free' && !expiresAt) {
-            const thirtyDaysFromNow = new Date();
-            thirtyDaysFromNow.setDate(thirtyDaysFromNow.getDate() + 30);
-            expiresAt = thirtyDaysFromNow.toISOString();
-            logger.info(`Free tier 키 자동 만료 설정: ${expiresAt}`);
-        }
+        const expiresAt = params.expiresAt;
 
         const created = await db.createApiKey({
             id: keyId,
@@ -130,7 +119,6 @@ export class ApiKeyService {
             description: params.description,
             scopes: params.scopes,
             allowedModels: params.allowedModels,
-            rateLimitTier: params.rateLimitTier,
             expiresAt,
         });
 
@@ -138,7 +126,6 @@ export class ApiKeyService {
 
         await this.audit('create', params.userId, keyId, {
             name: params.name,
-            tier: params.rateLimitTier || 'free',
             scopes: params.scopes,
         });
 
@@ -192,7 +179,6 @@ export class ApiKeyService {
             description: updates.description,
             scopes: updates.scopes,
             allowedModels: updates.allowedModels,
-            rateLimitTier: updates.rateLimitTier,
             isActive: updates.isActive,
             expiresAt: updates.expiresAt,
         });

--- a/backend/api/src/swagger/paths-platform.ts
+++ b/backend/api/src/swagger/paths-platform.ts
@@ -341,7 +341,6 @@ export const platformPaths = {
                                 description: { type: 'string', maxLength: 500 },
                                 scopes: { type: 'array', items: { type: 'string' }, default: ['*'] },
                                 allowed_models: { type: 'array', items: { type: 'string' }, default: ['*'] },
-                                rate_limit_tier: { type: 'string', enum: ['free', 'starter', 'standard', 'enterprise'] },
                                 expires_at: { type: 'string', format: 'date-time' }
                             }
                         }
@@ -388,8 +387,7 @@ export const platformPaths = {
                             properties: {
                                 name: { type: 'string' },
                                 description: { type: 'string' },
-                                is_active: { type: 'boolean' },
-                                rate_limit_tier: { type: 'string', enum: ['free', 'starter', 'standard', 'enterprise'] }
+                                is_active: { type: 'boolean' }
                             }
                         }
                     }

--- a/frontend/web/public/js/modules/pages/developer-sections.js
+++ b/frontend/web/public/js/modules/pages/developer-sections.js
@@ -626,22 +626,22 @@ export function renderApiKeysSection() {
 
         '<h3 id="update-key" style="margin-top:60px;">Update Key</h3>' +
         '<p><span class="endpoint-badge badge-patch">PATCH</span> <code>/api-keys/:id</code></p>' +
-        '<p>Update key metadata such as name, description, scopes, allowed models, rate limit tier, or active status.</p>' +
+        '<p>Update key metadata such as name, description, scopes, allowed models, or active status.</p>' +
         getCodeBlock(
             'curl',
             'curl -X PATCH ' + window.location.origin + '/api/api-keys/<key_id> \\\n' +
             '  -H "Authorization: Bearer <jwt_token>" \\\n' +
             '  -H "Content-Type: application/json" \\\n' +
-            '  -d \'{"name": "Updated Name", "rate_limit_tier": "standard"}\'',
+            '  -d \'{"name": "Updated Name", "is_active": true}\'',
             'python',
             'requests.patch("' + window.location.origin + '/api/api-keys/<key_id>",\n' +
             '    headers={"Authorization": "Bearer <jwt_token>"},\n' +
-            '    json={"name": "Updated Name", "rate_limit_tier": "standard"})',
+            '    json={"name": "Updated Name", "is_active": True})',
             'typescript',
             'await fetch("' + window.location.origin + '/api/api-keys/<key_id>", {\n' +
             '  method: "PATCH",\n' +
             '  headers: {"Authorization": "Bearer <jwt_token>", "Content-Type": "application/json"},\n' +
-            '  body: JSON.stringify({name: "Updated Name", rate_limit_tier: "standard"})\n' +
+            '  body: JSON.stringify({name: "Updated Name", is_active: true})\n' +
             '})'
         ) +
         '<h4>Request Body Parameters</h4>' +
@@ -650,7 +650,6 @@ export function renderApiKeysSection() {
         '<tr><td><code>description</code></td><td>string</td><td>Key description (max 500 chars)</td></tr>' +
         '<tr><td><code>scopes</code></td><td>string[]</td><td>Access scopes</td></tr>' +
         '<tr><td><code>allowed_models</code></td><td>string[]</td><td>Allowed model names</td></tr>' +
-        '<tr><td><code>rate_limit_tier</code></td><td>string</td><td>One of: free, starter, standard, enterprise</td></tr>' +
         '<tr><td><code>is_active</code></td><td>boolean</td><td>Enable or disable the key</td></tr>' +
         '<tr><td><code>expires_at</code></td><td>string|null</td><td>ISO 8601 datetime or null for no expiry</td></tr>' +
         '</tbody></table>' +
@@ -726,7 +725,10 @@ export function renderUsageSection() {
             '      "last_used_at": "2026-03-07T12:00:00.000Z"\n' +
             '    },\n' +
             '    "limits": {\n' +
-            '      "tier": "free"\n' +
+            '      "rpm": 300,\n' +
+            '      "tpm": 1000000,\n' +
+            '      "daily_requests": -1,\n' +
+            '      "monthly_requests": -1\n' +
             '    }\n' +
             '  }\n' +
             '}',
@@ -736,7 +738,7 @@ export function renderUsageSection() {
             '  "success": true,\n' +
             '  "data": {\n' +
             '    "usage": { "total_requests": 1234, "total_tokens": 567890, ... },\n' +
-            '    "limits": { "tier": "free" }\n' +
+            '    "limits": { "rpm": 300, "tpm": 1000000, "daily_requests": -1, "monthly_requests": -1 }\n' +
             '  }\n' +
             '}',
             'typescript',
@@ -745,7 +747,7 @@ export function renderUsageSection() {
             '  success: true,\n' +
             '  data: {\n' +
             '    usage: { total_requests: 1234, total_tokens: 567890, last_used_at: "..." },\n' +
-            '    limits: { tier: "free" }\n' +
+            '    limits: { rpm: 300, tpm: 1000000, daily_requests: -1, monthly_requests: -1 }\n' +
             '  }\n' +
             '}'
         ) +
@@ -769,14 +771,11 @@ export function renderUsageSection() {
 export function renderRateLimitsSection() {
     return '<section id="rate-limits" class="dev-section">' +
         '<h2>Rate Limits</h2>' +
-        '<p>API access is rate-limited based on your subscription tier.</p>' +
+        '<p>All API keys share a single rate limit (no tiers). Per-minute caps prevent abuse; daily and monthly request counts are unlimited.</p>' +
         '<table class="rate-table">' +
-        '<thead><tr><th>Tier</th><th>RPM</th><th>TPM</th><th>Daily Requests</th><th>Monthly Requests</th></tr></thead>' +
+        '<thead><tr><th>RPM</th><th>TPM</th><th>Daily Requests</th><th>Monthly Requests</th></tr></thead>' +
         '<tbody>' +
-        '<tr><td>Free (Tier 0)</td><td>10</td><td>10,000</td><td>100</td><td>1,000</td></tr>' +
-        '<tr><td>Starter (Tier 1)</td><td>30</td><td>50,000</td><td>500</td><td>10,000</td></tr>' +
-        '<tr><td>Standard (Tier 2)</td><td>60</td><td>100,000</td><td>3,000</td><td>100,000</td></tr>' +
-        '<tr><td>Enterprise (Tier 3)</td><td>300</td><td>1,000,000</td><td>Unlimited</td><td>Unlimited</td></tr>' +
+        '<tr><td>300</td><td>1,000,000</td><td>Unlimited</td><td>Unlimited</td></tr>' +
         '</tbody></table>' +
         '<h3>Rate Limit Headers</h3>' +
         '<p>Every response includes headers describing your current rate limit status:</p>' +

--- a/services/database/init/002-schema.sql
+++ b/services/database/init/002-schema.sql
@@ -368,7 +368,6 @@ CREATE TABLE IF NOT EXISTS user_api_keys (
     description TEXT,
     scopes JSONB DEFAULT '["*"]',
     allowed_models JSONB DEFAULT '["*"]',
-    rate_limit_tier TEXT NOT NULL DEFAULT 'free' CHECK(rate_limit_tier IN ('free', 'starter', 'standard', 'enterprise')),
     is_active BOOLEAN DEFAULT TRUE,
     last_used_at TIMESTAMPTZ,
     expires_at TIMESTAMPTZ,
@@ -410,7 +409,6 @@ CREATE INDEX IF NOT EXISTS idx_mcp_servers_enabled ON mcp_servers(enabled);
 CREATE INDEX IF NOT EXISTS idx_api_keys_user ON user_api_keys(user_id);
 CREATE INDEX IF NOT EXISTS idx_api_keys_hash ON user_api_keys(key_hash);
 CREATE INDEX IF NOT EXISTS idx_api_keys_active ON user_api_keys(user_id, is_active);
-CREATE INDEX IF NOT EXISTS idx_api_keys_tier ON user_api_keys(rate_limit_tier);
 
 -- Session & Audit indexes (from unified-database.ts)
 -- Remove duplicate anon_session_id rows before creating unique index (keep the most recent row per value)

--- a/services/database/migrations/040_drop_apikey_rate_limit_tier.sql
+++ b/services/database/migrations/040_drop_apikey_rate_limit_tier.sql
@@ -1,0 +1,15 @@
+-- 040_drop_apikey_rate_limit_tier.sql
+-- 개발자 API Key rate-limit 의 tier 차등(free/starter/standard/enterprise) 제거 —
+-- 모든 API 키가 동일한 단일 한도(API_KEY_LIMITS: rpm 300 / tpm 1,000,000 / 일·월 무제한)를 공유한다.
+--
+-- 구독 플랜 tier 전면 제거(039)의 후속. rate_limit_tier 는 남용 방지 도메인이라 039 에서
+-- 보존했으나, 이제 등급 차등 자체를 없애 단일 한도로 통일하므로 컬럼을 제거한다.
+-- 멱등(idempotent): DROP INDEX/COLUMN IF EXISTS 로 재실행 안전.
+--
+-- 자동 적용되지 않음(수동 CLI): npx ts-node backend/api/src/data/migrations/cli.ts migrate
+
+-- tier 기반 인덱스 먼저 제거 (DROP COLUMN 이 의존 인덱스를 자동 제거하지만 멱등 명시)
+DROP INDEX IF EXISTS idx_api_keys_tier;
+
+-- rate_limit_tier 컬럼 제거 (limiter 는 이제 단일 API_KEY_LIMITS 적용)
+ALTER TABLE user_api_keys DROP COLUMN IF EXISTS rate_limit_tier;


### PR DESCRIPTION
## 목표
개발자 API Key rate-limit의 tier 차등(free/starter/standard/enterprise)을 제거하고 **모든 키에 단일 한도** 적용. 구독 플랜 전면 제거(#112)의 후속 — 외부 API 도메인도 등급 차별 없이 동일 한도를 공유.

**단일 한도** (`API_KEY_LIMITS`): rpm 300 / tpm 1,000,000 / 일·월 무제한. 순간 폭주(DoS)·비용 방지용 RPM/TPM 상한만 유지하고 등급·일·월 한도는 제거.

## 변경
- `API_KEY_TIER_LIMITS`(4등급 맵) → `API_KEY_LIMITS`(단일 상수), `ApiKeyTier` 타입 제거
- `api-key-limiter.ts`/`rate-limit-headers.ts`: tier 조회 제거, 단일 한도 적용(`isTPMExceeded` tier 파라미터 제거)
- `ApiKeyService.ts`: `rateLimitTier` 파라미터 제거, **free tier 30일 자동 만료 로직 제거**(tier 개념 소멸)
- `api-keys.routes.ts`/swagger: `rate_limit_tier` 입력 필드·검증 제거
- `routes/v1/index.ts`: usage 응답 `limits`를 단일 한도(rpm/tpm/daily/monthly)로 표기
- **DB**: `040_drop_apikey_rate_limit_tier.sql`(`user_api_keys.rate_limit_tier` DROP, 멱등). init/002-schema.sql·legacy-schema.ts 컬럼/인덱스 제거. ⚠️ 수동 CLI 적용
- 프론트 `developer-sections.js`: rate-limit tier 표·예시 → 단일 한도 안내로 교체
- 테스트: tier 자동 만료 테스트 → 단일 한도/expiresAt 동작 검증으로 재작성

## 검증
- ✅ tsc 0 / lint 0 / build:backend·build:frontend 통과
- ✅ ApiKey 43 passed, rate-limit 미들웨어 10 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)