### PR TITLE
feat(cache): build ID handshake — 오래된 탭 자동 reload

### DIFF
--- a/backend/api/src/config/build-id.ts
+++ b/backend/api/src/config/build-id.ts
@@ -1,0 +1,46 @@
+/**
+ * Build ID 유틸 — 서버 빌드 식별자(gitHash) 단일 진입점.
+ *
+ * 소스: `backend/api/dist/build-info.json` 의 `gitHash` (deploy 시 자동 생성).
+ * 부팅 시 1회 read 하여 메모리 캐시한다 — 매 요청마다 파일 read 금지.
+ * 파일이 없거나(개발 중) 파싱 실패 시 `'dev'` 를 반환한다.
+ *
+ * 용도: index.html `<meta name="build-id">` 주입 + WS 연결 시 build_id 전송 →
+ * 클라이언트가 자신의 build ID 와 비교해 구버전 탭 자동 reload.
+ *
+ * @module config/build-id
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const FALLBACK_BUILD_ID = 'dev';
+
+// dist 출력 기준: 컴파일된 파일(dist/config/build-id.js)에서 dist/build-info.json 으로 한 단계 상위.
+// health.controller.ts 의 build-info 경로 규칙과 동일.
+const buildInfoPath = path.resolve(__dirname, '../build-info.json');
+
+let _cachedBuildId: string | null = null;
+
+/**
+ * 서버 build ID(gitHash) 반환. 최초 호출 시 1회 파일 read 후 메모리 캐시.
+ * @returns {string} gitHash 또는 `'dev'`
+ */
+export function getBuildId(): string {
+    if (_cachedBuildId !== null) {
+        return _cachedBuildId;
+    }
+    try {
+        if (fs.existsSync(buildInfoPath)) {
+            const raw = fs.readFileSync(buildInfoPath, 'utf-8');
+            const parsed = JSON.parse(raw) as { gitHash?: unknown };
+            if (typeof parsed.gitHash === 'string' && parsed.gitHash.trim() !== '') {
+                _cachedBuildId = parsed.gitHash.trim();
+                return _cachedBuildId;
+            }
+        }
+    } catch {
+        /* fallback below */
+    }
+    _cachedBuildId = FALLBACK_BUILD_ID;
+    return _cachedBuildId;
+}

--- a/backend/api/src/middlewares/setup.ts
+++ b/backend/api/src/middlewares/setup.ts
@@ -37,6 +37,7 @@ import { requestIdMiddleware } from './request-id';
 import { errorHandler, notFoundHandler } from '../utils/error-handler';
 import { getConfig } from '../config';
 import { buildPermissionsPolicyHeader, HSTS_POLICY } from '../config/security';
+import { getBuildId } from '../config/build-id';
 
 interface CspLocals {
     cspNonce?: string;
@@ -293,11 +294,26 @@ export function setupStaticFiles(app: Application, dirname: string): void {
         ].join('; ');
     };
 
+    // 서버 build ID 를 <head> 에 meta 태그로 주입 — CSP 영향 없는 meta 만 사용(inline script 금지).
+    // 클라이언트(websocket.js)가 이 값을 자신의 build ID 로 삼아 서버 build_id 와 비교 → 구버전 탭 자동 reload.
+    const injectBuildIdMeta = (html: string): string => {
+        const buildId = getBuildId();
+        const escaped = buildId.replace(/"/g, '&quot;');
+        const metaTag = `<meta name="build-id" content="${escaped}">`;
+        if (html.includes('name="build-id"')) {
+            return html; // 이미 존재(예: 정적 빌드) — 중복 주입 방지
+        }
+        if (html.includes('</head>')) {
+            return html.replace('</head>', `    ${metaTag}\n</head>`);
+        }
+        return html;
+    };
+
     const readHtmlForResponse = (filePath: string, res: Response): string => {
         const html = fs.readFileSync(filePath, 'utf8');
         const nonce = getNonce(res);
         res.setHeader('Content-Security-Policy', buildCspHeader(nonce));
-        return injectNonceIntoHtml(html, nonce);
+        return injectBuildIdMeta(injectNonceIntoHtml(html, nonce));
     };
 
     // 프론트엔드는 빌드 없는 순수 JS — 단일 원본(frontend/web/public)에서 직접 서빙.

--- a/backend/api/src/sockets/handler.ts
+++ b/backend/api/src/sockets/handler.ts
@@ -43,6 +43,7 @@ import { WSMessage, ExtendedWebSocket } from './ws-types';
 import { authenticateWebSocket, refreshWebSocketAuthentication } from './ws-auth';
 import { WEBSOCKET_TIMEOUTS, WS_LIMITS } from '../config/timeouts';
 import { WS_SECURITY } from '../config/security';
+import { getBuildId } from '../config/build-id';
 import { handleChatMessage } from './ws-chat-handler';
 import { handleRequestAgents } from './ws-agents-handler';
 import { withSpan } from '../observability/otel';
@@ -199,6 +200,10 @@ export class WebSocketHandler {
             const mcpClient = getUnifiedMCPClient();
             const stats = mcpClient.getStats();
             ws.send(JSON.stringify({ type: 'stats', stats }));
+
+            // Build ID handshake — 클라이언트가 자신의 build ID(meta[name=build-id])와 비교해
+            // 구버전 탭이면 자동 reload. 새 메시지 타입만 추가(기존 핸들러 영향 없음).
+            ws.send(JSON.stringify({ type: 'build_id', buildId: getBuildId() }));
 
             ws.on('close', () => {
                 this.unregisterConnection(ws);

--- a/frontend/web/public/js/modules/websocket.js
+++ b/frontend/web/public/js/modules/websocket.js
@@ -188,6 +188,33 @@ const messageHandlers = {
             handleClusterEvent(data.event);
         }
     },
+    // Build ID handshake — 서버가 새로 배포되면 오래 켜둔 탭(SPA navigation 만 하고 F5 안 한 탭)이
+    // 구버전 JS 모듈을 계속 쓰는 문제를 차단. 자기 build ID(주입된 meta) 와 서버 buildId 가 다르면 자동 reload.
+    'build_id': (data) => {
+        try {
+            const serverBuildId = data && typeof data.buildId === 'string' ? data.buildId : '';
+            const myBuildId = document.querySelector('meta[name="build-id"]')?.content || '';
+            // 둘 다 truthy + 서로 다름 + 자기 것이 'dev'(개발 중) 가 아닐 때만 새 배포로 간주.
+            if (!serverBuildId || !myBuildId || myBuildId === serverBuildId || myBuildId === 'dev') {
+                return;
+            }
+            // 무한 reload 방지: 같은 serverBuildId 로 이미 reload 했다면 다시 reload 하지 않는다.
+            // (reload 후에도 meta 가 아직 구버전 HTML 캐시이면 또 트리거될 수 있으므로 sessionStorage 가드)
+            if (sessionStorage.getItem('reloadedForBuild') === serverBuildId) {
+                return;
+            }
+            sessionStorage.setItem('reloadedForBuild', serverBuildId);
+            if (typeof showSystemToast === 'function') {
+                showSystemToast({ type: 'info', message: '새 버전이 배포되어 새로고침합니다' });
+            } else {
+                console.info('[WebSocket] 새 버전 배포 감지 — 새로고침합니다');
+            }
+            // 토스트가 잠깐 보이도록 짧게 지연 후 reload.
+            setTimeout(() => location.reload(), 800);
+        } catch (e) {
+            console.warn('[WebSocket] build_id 처리 실패:', e);
+        }
+    },
     'token': (data) => {
         if (typeof appendToken === 'function') {
             appendToken(data.token);


### PR DESCRIPTION
## 목표 (캐시 근본 해결 Phase 1)
서버 재배포 시 **오래 켜둔 탭**(F5 없이 SPA navigation만)이 구버전 JS 모듈을 계속 쓰는 문제를 근본 차단. HTTP `no-cache`(2026-03-02 `29c22ef` 도입)는 F5/재방문만 커버하므로, 오래된 탭은 build ID handshake로 해결.

## 구현
- `config/build-id.ts`: `getBuildId()` — `dist/build-info.json` gitHash 부팅 1회 read·캐시(없으면 `'dev'`)
- `setup.ts`: index.html 서빙 시 `<meta name="build-id">` 주입 (**CSP 안전 — meta만, nonce 로직 무관**)
- `sockets/handler.ts`: WS 연결 시 `{ type:'build_id', buildId }` 전송
- `websocket.js`: `build_id` 핸들러 — meta vs 서버 buildId 비교

## 무한 reload 방지
1. serverBuildId·myBuildId 둘 다 truthy
2. 서로 다름
3. 내 것이 `'dev'` 아님
4. `sessionStorage('reloadedForBuild')` 가드 — 같은 buildId로 재reload 차단
→ 토스트("새 버전 배포") 후 800ms 지연 reload. try/catch 보호.

## 검증
- ✅ tsc 0 / build:frontend 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)