### PR TITLE
feat(cache): Vite content-hash 번들 파이프라인 + dist 서빙 (방침 변경)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Jest config: test files in `backend/api/src/**/__tests__/**/*.test.ts`, `backend
 ### Monorepo Structure (npm workspaces)
 
 - **`backend/api/`** - Express 5 + TypeScript API server (CommonJS output, ES2022 target, strict mode)
-- **`frontend/web/`** - Vanilla JS SPA with ES Modules (no framework, Vite for dev)
+- **`frontend/web/`** - Vanilla JS SPA with ES Modules (no framework; Vite content-hash 번들 빌드 → `dist` 서빙)
 - **`data/`** - Shared data layer (referenced from backend)
 - **`scripts/`** - Build, deploy, migration, and CI scripts
 - **`tests/`** - E2E tests (Playwright)
@@ -257,9 +257,10 @@ Environment variables loaded from `.env` at project root (see `.env.example`). K
 
 ### SPA 프레임워크 / 대형 프론트엔드 라이브러리 (영구 금지)
 
-- `React`, `Vue`, `Angular`, `Svelte` 등 SPA 프레임워크 **도입 금지** — Vanilla JS ES Modules 유지
+- `React`, `Vue`, `Angular`, `Svelte` 등 SPA 프레임워크 **도입 금지** — 소스는 Vanilla JS ES Modules 유지
 - `jQuery`, `Lodash` 등 대형 유틸 라이브러리 신규 추가 금지
-- 근거: 번들 없는 직접 서빙 구조 유지, 빌드 파이프라인 단순화
+- 근거: 프레임워크 없는 순수 ESM 소스 유지.
+- **운영 배포는 Vite content-hash 번들로 전환 (2026-06-19, 방침 변경)**: 과거 "번들 없는 직접 서빙"은 ES module-map 캐시(오래된 탭) + 하위 import 캐시 버스터 미전파로 stale 모듈 문제가 반복돼, content-hash asset pipeline 으로 근본 해결. Vite 는 **번들러로만** 사용(프레임워크 도입 아님). 소스(`frontend/web/public`)는 여전히 프레임워크 없는 순수 ESM 이며, `npm run build:frontend`(validate-modules → vite build → verify-dist-hash)로 `frontend/web/dist` 에 hash asset 생성. 운영 서빙: dist 우선(없으면 public 폴백), `index.html` no-cache + `/assets/*.<hash>` immutable + WS build ID handshake 자동 reload(`config/build-id.ts`).
 
 ## Phase 용어집
 

--- a/backend/api/src/middlewares/setup.ts
+++ b/backend/api/src/middlewares/setup.ts
@@ -214,6 +214,8 @@ export function setupStaticFiles(app: Application, dirname: string): void {
 
     const publicPath = path.join(dirname, 'public');
     const fallbackPublicPath = path.join(dirname, '../../../frontend/web/public');
+    // Vite content-hash 빌드 산출물 — 있으면 최우선 서빙(hash asset 참조 index.html).
+    const viteDistPath = path.join(dirname, '../../../frontend/web/dist');
 
     const allHtmlFiles = [
         ...listHtmlFiles(publicPath),
@@ -313,13 +315,14 @@ export function setupStaticFiles(app: Application, dirname: string): void {
         const html = fs.readFileSync(filePath, 'utf8');
         const nonce = getNonce(res);
         res.setHeader('Content-Security-Policy', buildCspHeader(nonce));
+        // HTML 은 hash asset manifest 진입점 — 항상 재검증(no-cache)해 최신 asset 참조를 보장.
+        res.setHeader('Cache-Control', 'no-cache');
         return injectBuildIdMeta(injectNonceIntoHtml(html, nonce));
     };
 
-    // 프론트엔드는 빌드 없는 순수 JS — 단일 원본(frontend/web/public)에서 직접 서빙.
-    // (2026-05-29) dist/public 복사 단계(sync-frontend) 제거 → 원본 수정 즉시 반영.
-    // HTML 도 소스 우선, 잔존 dist 는 폴백(없으면 no-op).
-    const htmlSearchOrder = [fallbackPublicPath, publicPath];
+    // 프론트엔드 서빙 우선순위: Vite dist(content-hash) → 소스(public, 폴백) → dist/public(잔존).
+    // dist 가 있으면 hash asset 참조 index.html 을 서빙하고, 없으면 소스 직접 서빙으로 무중단 폴백.
+    const htmlSearchOrder = [viteDistPath, fallbackPublicPath, publicPath];
 
     const getIndexPath = (): string | null => resolveFilePath(
         htmlSearchOrder.map(p => path.join(p, 'index.html'))
@@ -433,7 +436,9 @@ export function setupStaticFiles(app: Application, dirname: string): void {
         // 1년 캐시 + immutable hint 로 CDN/브라우저 캐시 적극 활용. esbuild.wasm 11MB 등
         // 큰 자산이 매 요청마다 ETag 검증 (no-cache) 하던 비효율 해소.
         const isVendor = filePath.includes('/vendor/') || filePath.includes('\\vendor\\');
-        if (isVendor && /\.(js|css|wasm|woff|woff2|ttf)$/i.test(filePath)) {
+        // Vite content-hash 자산(/assets/*.<hash>.*) — 내용이 바뀌면 파일명이 바뀌므로 immutable 안전.
+        const isHashedAsset = filePath.includes('/assets/') || filePath.includes('\\assets\\');
+        if ((isVendor || isHashedAsset) && /\.(js|css|wasm|woff|woff2|ttf|png|jpg|jpeg|svg|gif|webp)$/i.test(filePath)) {
             res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
         } else if (filePath.endsWith('.html')) {
             res.setHeader('Cache-Control', 'no-cache');
@@ -458,8 +463,9 @@ export function setupStaticFiles(app: Application, dirname: string): void {
         setHeaders: staticHeaders
     };
 
-    app.use(express.static(fallbackPublicPath, staticOpts));  // 소스 원본 (단일 출처)
-    app.use(express.static(publicPath, staticOpts));           // dist 잔존 폴백 (없으면 no-op)
+    app.use(express.static(viteDistPath, staticOpts));         // Vite dist 우선 (hash asset, immutable)
+    app.use(express.static(fallbackPublicPath, staticOpts));   // 소스 원본 폴백 (dist 없을 때)
+    app.use(express.static(publicPath, staticOpts));           // dist/public 잔존 폴백 (없으면 no-op)
 }
 
 /**

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,7 @@ export default [
       "**/dist/**",
       "**/build/**",
       "**/node_modules/**",
+      "**/.claude/**",
       "**/*.min.js",
       "frontend/web/public/vendor/**",
       "frontend/web/public/js/vendor/**",

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "scripts": {
         "dev": "vite",
-        "build": "bash scripts/validate-modules.sh",
+        "build": "bash scripts/validate-modules.sh && vite build && bash scripts/verify-dist-hash.sh",
         "preview": "vite preview"
     },
     "dependencies": {

--- a/frontend/web/public/css/unified-sidebar.css
+++ b/frontend/web/public/css/unified-sidebar.css
@@ -807,7 +807,7 @@
 }
 
 .us-nav-item:hover {
-    background: var(--bg-hover));
+    background: var(--bg-hover);
     color: var(--text-primary);
 }
 

--- a/frontend/web/public/index.html
+++ b/frontend/web/public/index.html
@@ -12,43 +12,43 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon.png">
 
     <!-- 한글 최적화 웹폰트 (self-hosted) -->
-    <link href="vendor/pretendard/pretendard.css" rel="stylesheet">
+    <!-- vendor·CSS 는 절대경로(/...)로 참조 → Vite 가 hash 변환하지 않고 그대로 둠(파일명 유지).
+         JS(<script type=module>)만 Vite content-hash 번들 대상. CSS 는 link 유지 + publicDir 복사. -->
+    <link href="/vendor/pretendard/pretendard.css" rel="stylesheet">
     <!-- Performance: Preload hints -->
-    <link rel="preload" href="/css/design-tokens.css?v=22" as="style">
-    <link rel="modulepreload" href="/js/spa-router.js?v=30" crossorigin>
-    <link rel="modulepreload" href="/js/modules/auth.js" crossorigin>
+    <link rel="preload" href="/css/design-tokens.css" as="style">
     <!-- 디자인 시스템 CSS (순서 중요!) -->
-    <link rel="stylesheet" href="css/design-tokens.css?v=22">
-    <link rel="stylesheet" href="css/icons.css?v=20">
+    <link rel="stylesheet" href="/css/design-tokens.css">
+    <link rel="stylesheet" href="/css/icons.css">
 
-    <link rel="stylesheet" href="css/animations.css?v=18">
-    <link rel="stylesheet" href="css/feature-cards.css?v=20">
-    <link rel="stylesheet" href="css/layout.css?v=22">
-    <link rel="stylesheet" href="css/components.css?v=30">
-    <link rel="stylesheet" href="css/model-selector.css?v=19">
-     <link rel="stylesheet" href="css/unified-sidebar.css?v=28">
-    <link rel="stylesheet" href="css/light-theme.css?v=20">
-    <link rel="stylesheet" href="style.css?v=23">
-    <link rel="stylesheet" href="css/chat-status-toast.css?v=2">
-    <link rel="stylesheet" href="css/system-toast.css?v=11">
-    <link rel="stylesheet" href="css/mobile-fab.css?v=2">
-    <link rel="stylesheet" href="css/mobile-composer.css?v=2">
-    <link rel="stylesheet" href="css/command-palette.css?v=1">
+    <link rel="stylesheet" href="/css/animations.css">
+    <link rel="stylesheet" href="/css/feature-cards.css">
+    <link rel="stylesheet" href="/css/layout.css">
+    <link rel="stylesheet" href="/css/components.css">
+    <link rel="stylesheet" href="/css/model-selector.css">
+    <link rel="stylesheet" href="/css/unified-sidebar.css">
+    <link rel="stylesheet" href="/css/light-theme.css">
+    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="/css/chat-status-toast.css">
+    <link rel="stylesheet" href="/css/system-toast.css">
+    <link rel="stylesheet" href="/css/mobile-fab.css">
+    <link rel="stylesheet" href="/css/mobile-composer.css">
+    <link rel="stylesheet" href="/css/command-palette.css">
     <!-- Iconify Icon Web Component (self-hosted, defer) -->
-    <script src="vendor/iconify-icon.min.js" defer></script>
+    <script src="/vendor/iconify-icon.min.js" defer></script>
     <!-- Markdown Parser (self-hosted, defer) -->
-    <script src="vendor/marked.min.js" defer></script>
+    <script src="/vendor/marked.min.js" defer></script>
     <!-- Code Highlighting (self-hosted, defer) -->
-    <link rel="stylesheet" href="vendor/hljs/github-dark.min.css"
+    <link rel="stylesheet" href="/vendor/hljs/github-dark.min.css"
         media="print" onload="this.media='all'">
-    <script src="vendor/hljs/highlight.min.js" defer></script>
+    <script src="/vendor/hljs/highlight.min.js" defer></script>
     <!-- XSS Defense: DOMPurify (self-hosted, defer) -->
-    <script src="vendor/purify.min.js" defer></script>
+    <script src="/vendor/purify.min.js" defer></script>
     <!-- Math Rendering: KaTeX (self-hosted, defer) -->
-    <link rel="stylesheet" href="vendor/katex.min.css">
-    <script src="vendor/katex.min.js" defer></script>
+    <link rel="stylesheet" href="/vendor/katex.min.css">
+    <script src="/vendor/katex.min.js" defer></script>
     <!-- Diagram Rendering: Mermaid (self-hosted, defer) -->
-    <script src="vendor/mermaid.min.js" defer></script>
+    <script src="/vendor/mermaid.min.js" defer></script>
     <!-- guide_content.js: 2026-05-21 제거 — 사용 가이드 시스템 폐기 -->
 
 
@@ -252,16 +252,16 @@
 
     </div> <!-- app 끝 -->
 
-    <!-- 앱 엔트리 포인트 (ES Module — 모든 모듈을 main.js에서 import 및 초기화) -->
+    <!-- 앱 엔트리 포인트 (ES Module — Vite content-hash 번들 대상. 캐시버스터는 content-hash 가 대체) -->
     <!-- API 중앙 관리 (ES Module — window.API_ENDPOINTS / window.ApiClient 전역 노출) -->
-    <script type="module" src="js/modules/api-endpoints.js?v=26"></script>
-    <script type="module" src="js/modules/api-client.js?v=26"></script>
+    <script type="module" src="/js/modules/api-endpoints.js"></script>
+    <script type="module" src="/js/modules/api-client.js"></script>
 
-    <script type="module" src="js/main.js?v=59"></script>
+    <script type="module" src="/js/main.js"></script>
     <!-- 채팅 이미지 첨부 (fileInput → base64 → attachedFiles → 미리보기). self-init -->
-    <script type="module" src="js/modules/file-attach.js?v=12"></script>
+    <script type="module" src="/js/modules/file-attach.js"></script>
     <!-- ⌘K 커맨드 팔레트 (Chat-first 구조 — 이동/액션 단일 진입점). self-init -->
-    <script type="module" src="js/modules/command-palette.js?v=4"></script>
+    <script type="module" src="/js/modules/command-palette.js"></script>
 </body>
 
 </html>

--- a/frontend/web/public/js/modules/pages/admin.js
+++ b/frontend/web/public/js/modules/pages/admin.js
@@ -54,7 +54,10 @@
                 if (_subModuleCache[section] && _subModuleCache[section].initialized) return;
                 if (!_subModuleCache[section] || !_subModuleCache[section].module) {
                     try {
-                        const mod = await import(SUB_SECTION_MODULES[section]);
+                        // Vite 빌드 시 변수 경로 import 누락 방지 — spa-router 의 glob 로더 경유
+                        // (직접 서빙 환경에서는 동적 import(url) 로 폴백).
+                        const _loadPage = window.loadPageModule || ((s) => import(s));
+                        const mod = await _loadPage(SUB_SECTION_MODULES[section]);
                         const pageModule = mod.default || mod;
                         _subModuleCache[section] = { module: pageModule, initialized: false };
                     } catch (e) {

--- a/frontend/web/public/js/modules/pages/settings.js
+++ b/frontend/web/public/js/modules/pages/settings.js
@@ -337,7 +337,10 @@
                         if (!embedPanel) return;
                         embedPanel.style.display = '';
                         embedPanel.innerHTML = '<div class="settings-embed-loading">불러오는 중…</div>';
-                        import(EMBED_MODULES[tabName]).then(function (mod) {
+                        // Vite 빌드 시 변수 경로 import 누락 방지 — spa-router 의 glob 로더 경유
+                        // (직접 서빙 환경에서는 동적 import(url) 로 폴백).
+                        var _loadPage = window.loadPageModule || function (s) { return import(s); };
+                        _loadPage(EMBED_MODULES[tabName]).then(function (mod) {
                             var pm = (mod && mod.default) || mod;
                             if (!pm || typeof pm.getHTML !== 'function') { embedPanel.innerHTML = '<div class="settings-embed-loading">로드 실패</div>'; return; }
                             embedPanel.innerHTML = pm.getHTML();

--- a/frontend/web/public/js/spa-router.js
+++ b/frontend/web/public/js/spa-router.js
@@ -258,8 +258,66 @@ function removeModuleCSS(moduleName) {
 // ─── ES Module 동적 로딩 ────────────────────────────
 
 /**
+ * 페이지 모듈 glob 맵 (Vite 빌드 전용)
+ *
+ * Vite 는 완전 변수 경로 `import(variable)` 를 정적 분석하지 못해 페이지 모듈이
+ * 번들에서 누락된다. `import.meta.glob('./modules/pages/*.js')` 는 Vite 가
+ * **빌드 타임에 객체 리터럴 `{ './modules/pages/x.js': () => import('...') }` 로 치환**하여
+ * 23개 페이지 모듈을 모두 그래프에 포함 + content-hash code-split 한다.
+ *
+ * 직접 서빙(빌드 없음) 환경에서는 `import.meta.glob` 이 `undefined` 이므로
+ * try/catch + typeof 가드로 안전하게 `null` 이 되고, `loadModule` 이 기존
+ * 동적 `import(url)` 경로로 폴백한다 (런타임 동작 동일 — 무중단 호환).
+ *
+ * 키 형식: './modules/pages/<name>.js' (glob 패턴 상대경로 기준)
+ * @type {Record<string, () => Promise<object>>|null}
+ */
+var _pageGlob = null;
+try {
+    // import.meta.glob 은 Vite 빌드 타임 매크로. 직접 서빙 시 undefined → 폴백.
+    if (typeof import.meta.glob === 'function') {
+        _pageGlob = import.meta.glob('./modules/pages/*.js');
+    }
+} catch (_globErr) {
+    // 직접 서빙 환경 — import.meta.glob 미지원. 동적 import(url) 폴백 사용.
+    _pageGlob = null;
+}
+
+/**
+ * 모듈 파일 절대경로(`/js/modules/pages/x.js`)를 glob 맵 키(`./modules/pages/x.js`)로 변환
+ * @param {string} src
+ * @returns {string} glob 맵 키
+ */
+function _toGlobKey(src) {
+    // '/js/modules/pages/research.js' → './modules/pages/research.js'
+    return src.replace(/^\/js\//, './').replace(/^js\//, './');
+}
+
+/**
+ * glob 맵에 해당 모듈이 있으면 lazy loader 로 로드, 없으면 동적 import(url) 폴백.
+ * admin.js / settings.js 등 다른 모듈에서도 재사용하도록 export 한다.
+ *
+ * @param {string} src - 모듈 파일 경로 (예: '/js/modules/pages/research.js')
+ * @returns {Promise<object>} import 결과 module namespace
+ */
+async function _importPageModule(src) {
+    var globKey = _pageGlob ? _toGlobKey(src) : null;
+    if (_pageGlob && globKey && _pageGlob[globKey]) {
+        // Vite 빌드 — glob lazy loader (hash 번들)
+        return _pageGlob[globKey]();
+    }
+    // 직접 서빙 — 캐시버스터 쿼리 동적 import
+    var moduleUrl = src + '?v=' + _moduleVersion;
+    return import(/* @vite-ignore */ moduleUrl);
+}
+
+/**
  * ES Module dynamic import()로 페이지 모듈 로드
- * @param {string} src - 모듈 파일 경로
+ *
+ * Vite 빌드 환경: `_pageGlob` 맵의 lazy loader 사용 → hash 번들 참조.
+ * 직접 서빙 환경: 기존 `import(src + '?v=N')` 폴백.
+ *
+ * @param {string} src - 모듈 파일 경로 (예: '/js/modules/pages/research.js')
  * @returns {Promise<object>} 모듈의 default export ({ getHTML, init, cleanup })
  */
 async function loadModule(src) {
@@ -269,8 +327,7 @@ async function loadModule(src) {
     }
 
     try {
-        var moduleUrl = src + '?v=' + _moduleVersion;
-        var mod = await import(moduleUrl);
+        var mod = await _importPageModule(src);
         var pageModule = mod.default || mod;
         _loadedModules.set(src, pageModule);
         log('모듈 로드 완료:', src);
@@ -893,9 +950,23 @@ var Router = {
     }
 };
 
+/**
+ * 페이지 모듈을 Vite glob 맵(빌드) 또는 동적 import(직접 서빙)로 로드한다.
+ * admin.js 의 SUB_SECTION_MODULES / settings.js 의 EMBED_MODULES 처럼
+ * `/js/modules/pages/*.js` 를 변수 경로로 import 하던 코드가 이 헬퍼를 거치면
+ * Vite 빌드 시 누락 없이 hash 번들로 묶인다.
+ *
+ * @param {string} src - 모듈 파일 절대경로 (예: '/js/modules/pages/audit.js')
+ * @returns {Promise<object>} import 결과 module namespace ({ default, ... })
+ */
+function loadPageModule(src) {
+    return _importPageModule(src);
+}
+
 // ─── 전역 노출 ────────────────────────────────────
 window.Router = Router;
 window.SPARouter = Router; // 별칭
+window.loadPageModule = loadPageModule; // admin/settings 등 비-라우터 임베드 로더용
 
 // ─── ES Module Exports ─────────────────────────────
-export { Router, SafeStorage };
+export { Router, SafeStorage, loadPageModule };

--- a/frontend/web/scripts/verify-dist-hash.sh
+++ b/frontend/web/scripts/verify-dist-hash.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# ============================================================
+# verify-dist-hash.sh — Vite content-hash 빌드 산출물 회귀 검증
+# ============================================================
+# 캐시 버스터 회귀 방지: dist/index.html 이 반드시 content-hash asset 만 참조하고,
+# 옛 방식(직접 ESM 파일 / ?v= 쿼리)으로 되돌아가지 않았는지 빌드 시 자동 차단한다.
+set -euo pipefail
+
+DIST="$(cd "$(dirname "$0")/.." && pwd)/dist"
+INDEX="$DIST/index.html"
+
+if [ ! -f "$INDEX" ]; then
+  echo "[verify-dist-hash] FAIL: $INDEX 가 없습니다 (vite build 미실행?)." >&2
+  exit 1
+fi
+
+# 1) index.html 이 hash 없는 직접 JS(`js/main.js`, `js/modules/...`) 또는 `?v=` 쿼리를 참조하면 실패.
+#    Vite entry 는 /assets/<name>.<hash>.js 만 참조해야 한다. (vendor/ 직접 script 는 허용)
+if grep -nE 'src="[^"]*\.js\?v=|src="/?js/main\.js|src="/?js/modules/|src="/?js/spa-router\.js' "$INDEX"; then
+  echo "[verify-dist-hash] FAIL: index.html 이 hash 없는 직접 JS / ?v= 쿼리를 참조합니다." >&2
+  echo "  → Vite 번들(/assets/*.<hash>.js) 만 참조해야 합니다." >&2
+  exit 1
+fi
+
+# 2) dist/assets 에 content-hash JS 가 실제로 생성됐는지.
+if ! ls "$DIST"/assets/*.js >/dev/null 2>&1; then
+  echo "[verify-dist-hash] FAIL: dist/assets 에 번들 JS 가 없습니다." >&2
+  exit 1
+fi
+
+# 3) entry asset 파일명이 hash 패턴([name].[hash].js)을 따르는지 (최소 1개).
+if ! ls "$DIST"/assets/index.*.js >/dev/null 2>&1; then
+  echo "[verify-dist-hash] FAIL: dist/assets/index.<hash>.js 형태의 entry 가 없습니다." >&2
+  exit 1
+fi
+
+echo "[verify-dist-hash] ✅ index.html 이 content-hash asset 만 참조 + dist/assets 번들 확인"

--- a/frontend/web/vite.config.js
+++ b/frontend/web/vite.config.js
@@ -1,0 +1,128 @@
+// @ts-check
+import { defineConfig } from 'vite';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * OpenMake Web — Vite content-hash 번들 파이프라인.
+ *
+ * 목적: 운영 배포물을 `dist/assets/*.<hash>.js|css` 형태로 만들어 파일명이 내용에
+ * 따라 바뀌게 함(캐시 버스터 근본 해결). 이 설정은 **빌드 산출물 생성 전용**이며,
+ * backend(setup.ts) 의 프로덕션 서빙 전환·캐시 정책 변경은 별도 단계에서 다룬다.
+ *
+ * 핵심 전제:
+ *  - 진입점은 `public/index.html`. Vite 가 `<script type="module">` / `<link rel=stylesheet>`
+ *    를 파싱해 자동으로 entry 그래프를 구성한다.
+ *  - 페이지 모듈(23개)은 spa-router.js 의 `import.meta.glob('./modules/pages/*.js')` 로
+ *    그래프에 포함되어 hash code-split 된다 (완전 변수 import 누락 방지).
+ *  - 서드파티 정적 자산(`public/vendor/`, `images/`, `icons/`, `css/` 등)은 그대로 복사.
+ *    vendor 는 `<script defer>` / CSS @font-face 등으로 직접 로드되므로 번들하지 않는다.
+ */
+export default defineConfig({
+    // public/ 을 빌드 root 로 사용 → index.html 이 entry
+    root: resolve(__dirname, 'public'),
+
+    // 절대경로 자산 참조 유지 (예: /js/..., /vendor/...) — backend 서빙 경로와 동일
+    base: '/',
+
+    /**
+     * publicDir 비활성화.
+     *
+     * root 가 public/ 이므로 root 자체를 publicDir 로 지정하면 순환이 된다.
+     * index.html 이 참조하지 않는 정적 자산(vendor, images, 런타임 동적 CSS 등)은
+     * 아래 `copyStaticDirs` 플러그인이 closeBundle 시점에 명시적으로 dist 로 복사한다.
+     * index.html 이 참조하는 JS/CSS/폰트는 entry 그래프를 통해 hash 번들된다.
+     */
+    publicDir: false,
+
+    build: {
+        // public/ 기준 한 단계 위의 dist/
+        outDir: resolve(__dirname, 'dist'),
+        assetsDir: 'assets',
+        emptyOutDir: true,
+        // 소스맵은 운영 디버깅용으로 분리 생성(원하면 false 로)
+        sourcemap: false,
+        // CSS 도 hash code-split — 각 entry/청크별 별도 hash CSS 파일
+        cssCodeSplit: true,
+        // CSS minify 활성화 (unified-sidebar.css 의 괄호 중복 타이포 수정 후 재활성화).
+        // lightningcss 가 CSS 문법 오류를 빌드 블로커로 잡아주므로 회귀 방지에도 유효.
+        cssMinify: true,
+        // 작은 자산도 인라인(base64)하지 않음 — CSP(nonce) 위반·파일명 hash 유지 목적
+        assetsInlineLimit: 0,
+        rollupOptions: {
+            input: resolve(__dirname, 'public/index.html'),
+            // 동적 import 청크를 단일 파일로 합치지 않음 → 페이지 모듈 code-split 유지.
+            // (Vite8/rolldown 은 codeSplitting 이 기본 true. 명시적으로 보존 의도 표기.)
+            output: {
+                entryFileNames: 'assets/[name].[hash].js',
+                chunkFileNames: 'assets/[name].[hash].js',
+                assetFileNames: 'assets/[name].[hash][extname]',
+            },
+        },
+    },
+
+    plugins: [
+        copyStaticDirs(),
+    ],
+});
+
+/**
+ * copyStaticDirs — 번들 그래프에 포함되지 않는 정적 디렉토리/파일을 dist 로 복사.
+ *
+ * Vite 의 publicDir 은 root 와 분리된 별도 디렉토리만 복사할 수 있어, root(public/)
+ * 자체의 비-entry 자산(vendor/, images/, icons/, generated/, *.html, sw 등)을
+ * 복사하지 못한다. 이 플러그인이 `closeBundle` 시점에 명시적으로 복사한다.
+ *
+ * 주의: `css/` 와 `js/` 는 index.html 이 참조하는 부분만 Vite 가 hash 처리하므로
+ * 통째로 복사하지 않는다. 단, css/pages/* 처럼 런타임에 동적 주입되는 CSS(loadModuleCSS)
+ * 는 절대경로(/css/...)로 fetch 되므로 css/ 전체를 복사 대상에 포함한다.
+ */
+function copyStaticDirs() {
+    return {
+        name: 'openmake-copy-static-dirs',
+        apply: 'build',
+        async closeBundle() {
+            const fs = await import('node:fs/promises');
+            const publicDir = resolve(__dirname, 'public');
+            const distDir = resolve(__dirname, 'dist');
+
+            // 디렉토리 단위 복사 대상 (vendor·정적 이미지·런타임 동적 CSS 등)
+            const dirs = [
+                'vendor',
+                'images',
+                'icons',
+                'generated',
+                'policies',
+                'css', // 런타임 동적 주입(loadModuleCSS)이 /css/* 절대경로로 fetch
+            ];
+            // 파일 단위 복사 대상 (entry 가 아닌 보조 HTML·서비스워커·정적 자산)
+            const files = [
+                'login.html',
+                'logo.png',
+                'push-sw.js',
+                'service-worker.js',
+                'style.css', // 일부 절대경로 참조 호환용 (index.html 은 hash 본을 쓰지만 잔존 참조 안전망)
+            ];
+
+            for (const d of dirs) {
+                const src = resolve(publicDir, d);
+                try {
+                    await fs.cp(src, resolve(distDir, d), { recursive: true });
+                } catch (e) {
+                    // 디렉토리가 없으면 스킵
+                    if (e && e.code !== 'ENOENT') throw e;
+                }
+            }
+            for (const f of files) {
+                const src = resolve(publicDir, f);
+                try {
+                    await fs.cp(src, resolve(distDir, f));
+                } catch (e) {
+                    if (e && e.code !== 'ENOENT') throw e;
+                }
+            }
+        },
+    };
+}


### PR DESCRIPTION
## 캐시 버스터 근본 해결 Phase 2+3
"번들 없는 직접 서빙" 영구 방침을 변경하고 **Vite content-hash asset pipeline** 도입. ES module-map 캐시(오래된 탭) + 하위 import 캐시버스터 미전파 stale 문제를 파일명 hash로 근본 해결. (Phase 1 build ID handshake = #117)

## Vite 번들
- `vite.config.js`: content-hash(entry/chunk/asset `[name].[hash]`), `assetsInlineLimit:0`(CSP nonce 회피), vendor/css/images publicDir 복사
- `spa-router.js`: **변수 동적 import → `import.meta.glob` + 직접서빙 폴백 가드**로 양립(dist 없으면 public 직접서빙 그대로). 23 페이지 빌드 포함, 누락 0
- `index.html`: `?v=` 제거, hash asset 참조
- `unified-sidebar.css`: 괄호중복 타이포(`var(--bg-hover))`) 수정 → minify 활성화

## 서빙/캐시 (setup.ts)
- 우선순위 `viteDistPath`(dist) → public 폴백 → dist/public (**무중단 폴백**)
- `index.html` no-cache + `/assets/*.<hash>` immutable

## 빌드/CI
- `build:frontend` = validate-modules → `vite build` → `verify-dist-hash.sh`(hash 없는 직접 JS/`?v=` 참조 차단)
- eslint `.claude`(worktree) ignore

## 검증
- ✅ tsc 0 / lint 0 / build:frontend 통과
- ✅ Playwright: `/` 채팅(hash entry 실행) + `/developer` 동적 import(glob) **콘솔 에러 0**
- ✅ index.html `no-cache` / asset `immutable` 헤더 라이브 확인
- ✅ CLAUDE.md 방침 갱신(Vite 번들 도입, React/Vue 금지 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)