### PR TITLE
chore: remove dead code — redactPII, recordMemoryExtractionFailure

### DIFF
--- a/backend/api/src/chat/security-hooks.ts
+++ b/backend/api/src/chat/security-hooks.ts
@@ -87,7 +87,7 @@ const JAILBREAK_PATTERNS: RegExp[] = [
  * PII(개인식별정보) 탐지 패턴
  *
  * 한국 특화 패턴 + 범용 패턴을 포함합니다.
- * 감지 시 warn 수준으로 처리하며, redactPII()로 마스킹 가능합니다.
+ * 감지 시 warn 수준으로 처리합니다.
  */
 const PII_PATTERNS: { pattern: RegExp; label: string }[] = [
     { pattern: /\d{6}-[1-4]\d{6}/, label: 'Korean resident registration number' },
@@ -238,37 +238,4 @@ export function postResponseCheck(
         passed: violations.length === 0,
         violations,
     };
-}
-
-/**
- * PII 마스킹 처리 (로깅 목적 전용)
- *
- * 텍스트에서 개인식별정보를 마스킹 문자열로 대체합니다.
- * 실제 데이터 저장/전송이 아닌 로그 기록 시 사용하세요.
- *
- * 마스킹 대상:
- * - 한국 주민등록번호 → [주민번호 마스킹]
- * - 신용카드 번호 → [카드번호 마스킹]
- * - 한국 휴대폰 번호 → [전화번호 마스킹]
- *
- * @param text - 마스킹할 원본 텍스트
- * @returns PII가 마스킹된 텍스트
- *
- * @example
- * const safe = redactPII('주민번호 880101-1234567');
- * // → '주민번호 [주민번호 마스킹]'
- */
-export function redactPII(text: string): string {
-    let redacted = text;
-
-    // 한국 주민등록번호 마스킹
-    redacted = redacted.replace(/\d{6}-[1-4]\d{6}/g, '[주민번호 마스킹]');
-
-    // 신용카드 번호 마스킹
-    redacted = redacted.replace(/\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}/g, '[카드번호 마스킹]');
-
-    // 한국 휴대폰 번호 마스킹
-    redacted = redacted.replace(/010-?\d{4}-?\d{4}/g, '[전화번호 마스킹]');
-
-    return redacted;
 }

--- a/backend/api/src/services/chat-service-metrics.ts
+++ b/backend/api/src/services/chat-service-metrics.ts
@@ -95,17 +95,3 @@ export function recordChatMetrics(params: {
         logger.error('모니터링 데이터 기록 실패:', e);
     }
 }
-
-/**
- * 메모리 추출 fire-and-forget 실패를 MetricsCollector에 기록합니다.
- * @param reason - 실패 이유 ('timeout' | 'llm_error' | 'db_error' | 'unknown')
- */
-export function recordMemoryExtractionFailure(reason: string): void {
-    try {
-        const { getMetrics } = require('../monitoring/metrics');
-        const metricsCollector = getMetrics();
-        metricsCollector.incrementCounter('memory_extraction_failures_total', 1, { reason });
-    } catch (e) {
-        logger.debug('memory extraction failure metric 기록 실패:', e);
-    }
-}


### PR DESCRIPTION
## 목표
전체 소스 데드코드 재점검(이전 #115/#116 후속).

## 삭제 (grep 검증 후 진짜 데드만)
- `chat/security-hooks.ts`: **`redactPII`** — JSDoc `@example`·상단 주석 외 호출 0
- `services/chat-service-metrics.ts`: **`recordMemoryExtractionFailure`** — test 외 프로덕션 호출 0 (MemoryService 폐기로 미사용). 관련 test describe도 정리(git-ignored 로컬)

## 보존 (false positive / 보고)
- ts-prune 35개 후보 중 라우터(`*Router`, 동적 마운트)·Zod 추론 타입(`*Input`)·`ChatService` 타입 export·web-search 호환 re-export = 이전 검증 보존
- `rate-limit-headers.ts` `rateLimitHeaders` — 미사용이나 같은 파일 `recordTokenUsage`/`isTPMExceeded` 활성 OpenAI 호환 rate-limit 인프라(v1 마운트 누락)라 보존
- 프론트 미사용 모듈 0 (3개 후보는 index.html 진입점, pages는 nav-items/glob 검증)

## 검증
- ✅ tsc 0 / lint 0 / 관련 test 58 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)