### PR TITLE
fix(cache): code-review 후속 — Vite glob 가드 버그(CRITICAL) 외 6건

### DIFF
--- a/backend/api/src/config/build-id.ts
+++ b/backend/api/src/config/build-id.ts
@@ -1,46 +1,67 @@
 /**
- * Build ID 유틸 — 서버 빌드 식별자(gitHash) 단일 진입점.
+ * Build Info 유틸 — 서버 빌드 메타(gitHash/buildTime/gitDate) 단일 진입점.
  *
- * 소스: `backend/api/dist/build-info.json` 의 `gitHash` (deploy 시 자동 생성).
+ * 소스: `backend/api/dist/build-info.json` (deploy 시 build-info 스크립트가 자동 생성).
  * 부팅 시 1회 read 하여 메모리 캐시한다 — 매 요청마다 파일 read 금지.
- * 파일이 없거나(개발 중) 파싱 실패 시 `'dev'` 를 반환한다.
+ * 파일이 없거나(개발 중·ts-node) 파싱 실패 시 fallback(gitHash `'dev'`)을 반환한다.
  *
- * 용도: index.html `<meta name="build-id">` 주입 + WS 연결 시 build_id 전송 →
- * 클라이언트가 자신의 build ID 와 비교해 구버전 탭 자동 reload.
+ * build ID handshake(index.html `<meta name="build-id">` 주입 + WS 연결 시 build_id 전송)와
+ * `/health` 응답이 **같은 캐시를 공유**한다 — 별도 read 로 gitHash sentinel 이 갈리지 않게 단일화.
  *
  * @module config/build-id
  */
 import fs from 'node:fs';
 import path from 'node:path';
 
+export interface BuildInfo {
+    buildTime: string;
+    gitHash: string;
+    gitDate: string;
+}
+
 const FALLBACK_BUILD_ID = 'dev';
+const FALLBACK_BUILD_INFO: BuildInfo = {
+    buildTime: 'unknown',
+    gitHash: FALLBACK_BUILD_ID,
+    gitDate: 'unknown',
+};
 
 // dist 출력 기준: 컴파일된 파일(dist/config/build-id.js)에서 dist/build-info.json 으로 한 단계 상위.
-// health.controller.ts 의 build-info 경로 규칙과 동일.
 const buildInfoPath = path.resolve(__dirname, '../build-info.json');
 
-let _cachedBuildId: string | null = null;
+let _cached: BuildInfo | null = null;
 
 /**
- * 서버 build ID(gitHash) 반환. 최초 호출 시 1회 파일 read 후 메모리 캐시.
- * @returns {string} gitHash 또는 `'dev'`
+ * 서버 build-info 전체 반환. 최초 호출 시 1회 파일 read 후 메모리 캐시.
+ * @returns {BuildInfo} { buildTime, gitHash, gitDate } — 누락/파싱 실패 시 fallback
  */
-export function getBuildId(): string {
-    if (_cachedBuildId !== null) {
-        return _cachedBuildId;
+export function getBuildInfo(): BuildInfo {
+    if (_cached !== null) {
+        return _cached;
     }
     try {
         if (fs.existsSync(buildInfoPath)) {
-            const raw = fs.readFileSync(buildInfoPath, 'utf-8');
-            const parsed = JSON.parse(raw) as { gitHash?: unknown };
-            if (typeof parsed.gitHash === 'string' && parsed.gitHash.trim() !== '') {
-                _cachedBuildId = parsed.gitHash.trim();
-                return _cachedBuildId;
-            }
+            const parsed = JSON.parse(fs.readFileSync(buildInfoPath, 'utf-8')) as Partial<BuildInfo>;
+            _cached = {
+                buildTime: typeof parsed.buildTime === 'string' ? parsed.buildTime : FALLBACK_BUILD_INFO.buildTime,
+                gitHash: (typeof parsed.gitHash === 'string' && parsed.gitHash.trim() !== '')
+                    ? parsed.gitHash.trim()
+                    : FALLBACK_BUILD_ID,
+                gitDate: typeof parsed.gitDate === 'string' ? parsed.gitDate : FALLBACK_BUILD_INFO.gitDate,
+            };
+            return _cached;
         }
     } catch {
         /* fallback below */
     }
-    _cachedBuildId = FALLBACK_BUILD_ID;
-    return _cachedBuildId;
+    _cached = FALLBACK_BUILD_INFO;
+    return _cached;
+}
+
+/**
+ * 서버 build ID(gitHash) 반환 — getBuildInfo().gitHash (없으면 `'dev'`).
+ * @returns {string} gitHash 또는 `'dev'`
+ */
+export function getBuildId(): string {
+    return getBuildInfo().gitHash;
 }

--- a/backend/api/src/controllers/health.controller.ts
+++ b/backend/api/src/controllers/health.controller.ts
@@ -12,6 +12,7 @@ import { ClusterManager, getClusterManager } from '../cluster/manager';
 import { getPool } from '../data/models/unified-database';
 import { success } from '../utils/api-response';
 import { DB_POOL_TIMEOUTS } from '../config/timeouts';
+import { getBuildInfo } from '../config/build-id';
 
 // package.json에서 버전을 한 번만 읽어 캐시
 const pkgJsonPath = path.resolve(__dirname, '../../package.json');
@@ -19,19 +20,6 @@ let _cachedVersion = '1.0.0';
 try {
     const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
     _cachedVersion = pkg.version || '1.0.0';
-} catch { /* fallback */ }
-
-// 빌드 정보 파일 (deploy 시 자동 생성됨)
-const buildInfoPath = path.resolve(__dirname, '../build-info.json');
-let _buildInfo: { buildTime: string; gitHash: string; gitDate: string } = {
-    buildTime: new Date().toISOString(),
-    gitHash: 'unknown',
-    gitDate: 'unknown'
-};
-try {
-    if (fs.existsSync(buildInfoPath)) {
-        _buildInfo = JSON.parse(fs.readFileSync(buildInfoPath, 'utf-8'));
-    }
 } catch { /* fallback */ }
 
 /**
@@ -80,7 +68,7 @@ export class HealthController {
                 totalNodes: stats.totalNodes,
                 totalModels: stats.totalModels
             },
-            build: _buildInfo
+            build: getBuildInfo()
         }));
     }
 

--- a/backend/api/src/middlewares/setup.ts
+++ b/backend/api/src/middlewares/setup.ts
@@ -216,6 +216,17 @@ export function setupStaticFiles(app: Application, dirname: string): void {
     const fallbackPublicPath = path.join(dirname, '../../../frontend/web/public');
     // Vite content-hash 빌드 산출물 — 있으면 최우선 서빙(hash asset 참조 index.html).
     const viteDistPath = path.join(dirname, '../../../frontend/web/dist');
+    // dist 무결성 검사(부팅 1회): index.html + assets/*.js 가 모두 있어야 dist 를 우선한다.
+    // 부분/손상 빌드(index.html 만 있고 assets 누락)면 dist 를 건너뛰고 public 직접 서빙으로
+    // 폴백해 /assets/*.hash.js 404 blank(전체 페이지 깨짐)를 방지한다.
+    const viteDistValid = (() => {
+        try {
+            const assetsDir = path.join(viteDistPath, 'assets');
+            return fs.existsSync(path.join(viteDistPath, 'index.html'))
+                && fs.existsSync(assetsDir)
+                && fs.readdirSync(assetsDir).some(f => f.endsWith('.js'));
+        } catch { return false; }
+    })();
 
     const allHtmlFiles = [
         ...listHtmlFiles(publicPath),
@@ -322,7 +333,9 @@ export function setupStaticFiles(app: Application, dirname: string): void {
 
     // 프론트엔드 서빙 우선순위: Vite dist(content-hash) → 소스(public, 폴백) → dist/public(잔존).
     // dist 가 있으면 hash asset 참조 index.html 을 서빙하고, 없으면 소스 직접 서빙으로 무중단 폴백.
-    const htmlSearchOrder = [viteDistPath, fallbackPublicPath, publicPath];
+    const htmlSearchOrder = viteDistValid
+        ? [viteDistPath, fallbackPublicPath, publicPath]
+        : [fallbackPublicPath, publicPath];
 
     const getIndexPath = (): string | null => resolveFilePath(
         htmlSearchOrder.map(p => path.join(p, 'index.html'))
@@ -463,8 +476,10 @@ export function setupStaticFiles(app: Application, dirname: string): void {
         setHeaders: staticHeaders
     };
 
-    app.use(express.static(viteDistPath, staticOpts));         // Vite dist 우선 (hash asset, immutable)
-    app.use(express.static(fallbackPublicPath, staticOpts));   // 소스 원본 폴백 (dist 없을 때)
+    if (viteDistValid) {
+        app.use(express.static(viteDistPath, staticOpts));     // Vite dist 우선 (hash asset, immutable)
+    }
+    app.use(express.static(fallbackPublicPath, staticOpts));   // 소스 원본 폴백 (dist 없거나 부분빌드일 때)
     app.use(express.static(publicPath, staticOpts));           // dist/public 잔존 폴백 (없으면 no-op)
 }
 

--- a/frontend/web/public/js/modules/websocket.js
+++ b/frontend/web/public/js/modules/websocket.js
@@ -198,9 +198,17 @@ const messageHandlers = {
             if (!serverBuildId || !myBuildId || myBuildId === serverBuildId || myBuildId === 'dev') {
                 return;
             }
-            // 무한 reload 방지: 같은 serverBuildId 로 이미 reload 했다면 다시 reload 하지 않는다.
-            // (reload 후에도 meta 가 아직 구버전 HTML 캐시이면 또 트리거될 수 있으므로 sessionStorage 가드)
+            // 무한 reload 방지 + stale wedge 완화: 같은 serverBuildId 로 이미 reload 했는데 또
+            // 불일치면, HTML 이 stale 캐시(프록시/CDN 이 index.html no-cache 를 무시하는 등)라
+            // reload 를 반복해도 갱신되지 않는 상황이다. 자동 reload 를 멈추고 사용자에게 수동
+            // 하드 새로고침을 (build 당) 1회 안내해 영구 stale 고착을 푼다.
             if (sessionStorage.getItem('reloadedForBuild') === serverBuildId) {
+                if (sessionStorage.getItem('staleReloadWarned') !== serverBuildId) {
+                    sessionStorage.setItem('staleReloadWarned', serverBuildId);
+                    if (typeof showSystemToast === 'function') {
+                        showSystemToast({ type: 'warning', message: '새 버전이 있으나 캐시로 갱신되지 않았습니다. Ctrl+Shift+R(Mac: Cmd+Shift+R)로 강제 새로고침하세요.' });
+                    }
+                }
                 return;
             }
             sessionStorage.setItem('reloadedForBuild', serverBuildId);

--- a/frontend/web/public/js/spa-router.js
+++ b/frontend/web/public/js/spa-router.js
@@ -265,8 +265,8 @@ function removeModuleCSS(moduleName) {
  * **빌드 타임에 객체 리터럴 `{ './modules/pages/x.js': () => import('...') }` 로 치환**하여
  * 23개 페이지 모듈을 모두 그래프에 포함 + content-hash code-split 한다.
  *
- * 직접 서빙(빌드 없음) 환경에서는 `import.meta.glob` 이 `undefined` 이므로
- * try/catch + typeof 가드로 안전하게 `null` 이 되고, `loadModule` 이 기존
+ * 직접 서빙(빌드 없음) 환경에서는 `import.meta.glob` 이 `undefined` 이므로 호출 시
+ * TypeError 가 발생하고, try/catch 로 안전하게 `null` 이 되어 `loadModule` 이 기존
  * 동적 `import(url)` 경로로 폴백한다 (런타임 동작 동일 — 무중단 호환).
  *
  * 키 형식: './modules/pages/<name>.js' (glob 패턴 상대경로 기준)
@@ -274,12 +274,15 @@ function removeModuleCSS(moduleName) {
  */
 var _pageGlob = null;
 try {
-    // import.meta.glob 은 Vite 빌드 타임 매크로. 직접 서빙 시 undefined → 폴백.
-    if (typeof import.meta.glob === 'function') {
-        _pageGlob = import.meta.glob('./modules/pages/*.js');
-    }
+    // import.meta.glob 은 Vite 빌드 타임 매크로 — 빌드 시 객체 리터럴로 치환된다.
+    // ⚠️ `typeof import.meta.glob === 'function'` 가드를 쓰면 안 된다: Vite 는 glob() **호출**만
+    //   치환하고 bare `import.meta.glob` 참조는 그대로 두므로, 빌드 결과에서도 런타임 undefined →
+    //   가드 false → glob 미할당이 되어 페이지 청크가 전부 dead 가 된다(직접서빙 폴백으로 빠져
+    //   dist-only 배포 시 404, 또는 public 소스를 ?v= 로 서빙해 content-hash 가 무효화됨).
+    // 직접 서빙(non-Vite)에서는 import.meta.glob 이 undefined → 호출 시 TypeError → catch → null.
+    _pageGlob = import.meta.glob('./modules/pages/*.js');
 } catch (_globErr) {
-    // 직접 서빙 환경 — import.meta.glob 미지원. 동적 import(url) 폴백 사용.
+    // 직접 서빙 환경 — import.meta.glob 미지원(undefined 호출 → TypeError). 동적 import(url) 폴백.
     _pageGlob = null;
 }
 

--- a/frontend/web/scripts/verify-dist-hash.sh
+++ b/frontend/web/scripts/verify-dist-hash.sh
@@ -14,11 +14,12 @@ if [ ! -f "$INDEX" ]; then
   exit 1
 fi
 
-# 1) index.html 이 hash 없는 직접 JS(`js/main.js`, `js/modules/...`) 또는 `?v=` 쿼리를 참조하면 실패.
-#    Vite entry 는 /assets/<name>.<hash>.js 만 참조해야 한다. (vendor/ 직접 script 는 허용)
-if grep -nE 'src="[^"]*\.js\?v=|src="/?js/main\.js|src="/?js/modules/|src="/?js/spa-router\.js' "$INDEX"; then
-  echo "[verify-dist-hash] FAIL: index.html 이 hash 없는 직접 JS / ?v= 쿼리를 참조합니다." >&2
-  echo "  → Vite 번들(/assets/*.<hash>.js) 만 참조해야 합니다." >&2
+# 1) index.html 이 hash 없는 직접 JS/CSS(`js/main.js`, `js/modules/...`) 또는 `?v=` 캐시버스터
+#    쿼리를 script src / link href 어디서든 참조하면 실패. Vite entry 는 /assets/<name>.<hash>.*
+#    만 참조해야 한다. (vendor/ 직접 script·link 는 hash 없이 허용 — ?v= 만 없으면 OK)
+if grep -nE '(src|href)="[^"]*\?v=|src="/?js/main\.js|src="/?js/modules/|src="/?js/spa-router\.js' "$INDEX"; then
+  echo "[verify-dist-hash] FAIL: index.html 이 hash 없는 직접 JS / ?v= 캐시버스터 쿼리(script src 또는 link href)를 참조합니다." >&2
+  echo "  → Vite 번들(/assets/*.<hash>.{js,css}) 만 참조해야 합니다." >&2
   exit 1
 fi
 

--- a/frontend/web/vite.config.js
+++ b/frontend/web/vite.config.js
@@ -89,11 +89,13 @@ function copyStaticDirs() {
             const distDir = resolve(__dirname, 'dist');
 
             // 디렉토리 단위 복사 대상 (vendor·정적 이미지·런타임 동적 CSS 등)
+            // ⚠️ 'generated'(런타임 사용자 생성 이미지)는 제외 — 빌드 시점 스냅샷이 되면 dist 우선
+            //   서빙으로 배포 후 새 업로드가 shadow 되거나 이름충돌 시 stale 본을 준다. dist 에 없으면
+            //   setup.ts 의 public 폴백이 live source(public/generated)를 서빙한다.
             const dirs = [
                 'vendor',
                 'images',
                 'icons',
-                'generated',
                 'policies',
                 'css', // 런타임 동적 주입(loadModuleCSS)이 /css/* 절대경로로 fetch
             ];


### PR DESCRIPTION
## 배경
직전 캐시 파이프라인 작업(#117·#118)에 대한 코드리뷰(8 finder + 런타임 검증)에서 발견된 결함 수정.

## 🔴 CRITICAL — spa-router glob 가드
`typeof import.meta.glob === 'function'` 가드가 **빌드 결과에서도 런타임 false**(Vite는 `glob()` 호출만 객체로 치환하고 bare `import.meta.glob` 참조는 미치환→브라우저에서 `undefined`)라 `_pageGlob`이 null → 페이지 모듈이 dist hash 청크 대신 **public `?v=` 소스**로 서빙됨. dist/assets 페이지 청크 35개가 dead, **dist-only 배포 시 전체 페이지 404**.
- **수정**: typeof 가드 제거, `try { _pageGlob = import.meta.glob(...) } catch { null }`로 양립(직접서빙=TypeError→catch→폴백)
- **검증**: research 페이지가 `/assets/research.<hash>.js` 로드 확인(이전 `?v=22` 요청 0)

## 그 외 (6건)
| 파일 | 수정 |
|---|---|
| vite.config.js | `generated/`(런타임 이미지)를 dist 복사 제외 — shadow/stale 방지 |
| setup.ts | dist 무결성(index.html+assets/*.js) 부팅 검사 → 부분빌드 시 public 폴백 |
| websocket.js | build_id stale wedge 완화 — 무한 reload 대신 수동 새로고침 1회 안내 |
| verify-dist-hash.sh | `link href ?v=`도 차단(CSS 회귀 탐지) |
| build-id.ts + health.controller.ts | build-info.json 중복 read를 `getBuildInfo()` 단일 source로 통합 |

설계 trade-off(build_id가 backend gitHash·dev fallback·dist-first stale)는 항상 full `npm run build` 배포 전제로 수용. CSS `?v=` 완전 마이그레이션은 별도.

## 검증
- ✅ tsc 0 / lint 0 / build:frontend+verify 통과 / 관련 test 통과
- ✅ 런타임: 페이지 모듈 dist hash 청크 로드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)