### PR TITLE
docs(script): openmake_llm.sh 를 현재 구조에 맞게 동기화 (Vite 번들)

### DIFF
--- a/openmake_llm.sh
+++ b/openmake_llm.sh
@@ -14,7 +14,7 @@
 #   ./openmake_llm.sh start      # 의존성 → 앱 순서로 기동 (빌드/마이그레이션 X)
 #   ./openmake_llm.sh stop       # 앱 → 의존성 역순으로 정지
 #   ./openmake_llm.sh restart    # PM2 앱만 재시작 (코드 반영 X — 환경변수 변경 등)
-#   ./openmake_llm.sh build      # npm run build (TypeScript + frontend sync)
+#   ./openmake_llm.sh build      # npm run build (backend tsc + frontend Vite content-hash 번들 → dist)
 #   ./openmake_llm.sh migrate    # DB 마이그레이션 적용 (status로 사전 확인 권장)
 #   ./openmake_llm.sh deploy     # build + migrate + restart (코드 변경 운영 반영)
 #                                # 옵션: --yes (확인 skip), --no-migrate (마이그 생략)
@@ -207,9 +207,11 @@ start_redis() {
 start_app() {
     log_step "Layer 3/3: OpenMake LLM (PM2)"
 
-    # build 산출물 확인 — 미빌드 시 안내
-    if [[ ! -f "$SCRIPT_DIR/backend/api/dist/cli.js" ]]; then
-        log_warn "빌드 산출물 없음 — 'npm run build' 먼저 실행 필요"
+    # build 산출물 확인 — 백엔드(dist/cli.js) + 프론트(Vite content-hash dist/assets) 둘 다 필요.
+    # 프론트 dist 가 없으면 setup.ts 의 public 폴백으로 동작은 하나 content-hash 캐시버스터가
+    # 미적용되므로(페이지 모듈이 소스 ?v= 서빙) 함께 빌드한다.
+    if [[ ! -f "$SCRIPT_DIR/backend/api/dist/cli.js" ]] || [[ ! -d "$SCRIPT_DIR/frontend/web/dist/assets" ]]; then
+        log_warn "빌드 산출물 없음(backend dist/cli.js 또는 frontend Vite dist/assets) — 'npm run build' 먼저 실행 필요"
         log_info "수행 중: cd $SCRIPT_DIR && npm run build"
         ( cd "$SCRIPT_DIR" && npm run build ) || {
             log_err "빌드 실패"
@@ -357,7 +359,7 @@ cmd_restart() {
 
 # ── build / migrate / deploy ───────────────────────────────────────────────────
 cmd_build() {
-    log_step "npm run build (TypeScript 컴파일 + frontend sync)"
+    log_step "npm run build (backend tsc + frontend Vite content-hash 번들 → frontend/web/dist)"
     if ! ( cd "$SCRIPT_DIR" && npm run build ); then
         log_err "빌드 실패 — 후속 작업 중단"
         return 2
@@ -474,7 +476,7 @@ OpenMake LLM 통합 서비스 매니저
   restart   PM2 앱만 재시작 (코드 반영 X — 환경변수 변경 등)
 
 코드 변경 반영:
-  build     npm run build (TypeScript + frontend sync)
+  build     npm run build (backend tsc + frontend Vite content-hash 번들)
   migrate   DB 마이그레이션 (status → migrate)
   deploy    build + migrate + restart 통합 (코드 변경 운영 반영)
             옵션: --yes (확인 프롬프트 skip), --no-migrate (마이그 생략)


### PR DESCRIPTION
## 목표
`openmake_llm.sh`(3계층 서비스 매니저)를 현재 시스템 구조에 맞게 점검·수정.

## 수정
- **"frontend sync" → "Vite content-hash 번들"** (헤더 17행 / cmd_build log_step / usage 3곳): sync-frontend는 2026-05-29 제거, 이제 `build:frontend` = validate-modules → vite build → verify-dist-hash
- **start_app 빌드 산출물 체크**: 백엔드 `dist/cli.js`만 보던 것에 frontend Vite `dist/assets`를 추가 — 미빌드 시 함께 빌드(없으면 content-hash 미적용→public 폴백 ?v=)

## 점검 후 유지 (현재 구조와 정합)
3계층 기동순서(PostgreSQL→Redis→PM2), 외부 vLLM/LiteLLM(Ollama 제거 반영), migrate(cli.ts status→migrate), deploy(build→migrate→restart), 변수(포트/formula), `/health` 엔드포인트

## 검증
- ✅ bash -n 문법 OK
- ✅ `status` 실행: PG/Redis/PM2 online
- ✅ `health` 실행: `/health`가 `build.gitHash:cf1eac6` 노출(getBuildInfo 단일 source, meta build-id와 일치)

🤖 Generated with [Claude Code](https://claude.com/claude-code)