### PR TITLE
feat(design): Graphite & Ember II 리파인 — open-design 시안 전면 적용

### DIFF
--- a/frontend/web/public/css/components.css
+++ b/frontend/web/public/css/components.css
@@ -757,7 +757,7 @@
     display: inline-flex;
     align-items: center;
     padding: 2px 8px;
-    background: var(--accent-primary-light, rgba(99,102,241,0.08));
+    background: var(--accent-primary-light, rgba(255,106,61,0.12));
     border: 1.5px solid var(--accent-primary);
     border-radius: 10px;
     font-size: var(--font-size-xs);

--- a/frontend/web/public/css/design-tokens.css
+++ b/frontend/web/public/css/design-tokens.css
@@ -23,8 +23,8 @@
 :root {
     /* ------- Primary Accent (Ember 시그니처) ------- */
     --accent-primary: #ff6a3d;
-    --accent-primary-hover: #ff855c;
-    --accent-primary-light: rgba(255, 106, 61, 0.13);
+    --accent-primary-hover: #ff8b63;        /* 시안 --ember-hi */
+    --accent-primary-light: rgba(255, 106, 61, 0.12);
 
     /* ------- Secondary Accents (warm + cool 보조) ------- */
     --accent-purple: #f2994a;   /* 레거시 이름 유지, 값은 warm amber */
@@ -41,8 +41,14 @@
     --glass-blur: none;
 
     /* ------- Soft Glow (ember) ------- */
-    --glow-primary: 0 8px 28px -8px rgba(255, 106, 61, 0.4);
-    --glow-input-focus: 0 0 0 3px rgba(255, 106, 61, 0.2);
+    --glow-primary: 0 8px 30px -10px rgba(255, 106, 61, 0.45);
+    --glow-input-focus: 0 0 0 3px rgba(255, 106, 61, 0.12);
+
+    /* ------- Ember System (시안 "Graphite & Ember II" 신규 토큰) ------- */
+    --ember-ink: #1a0d06;                          /* ember fill 위 텍스트(다크 잉크) */
+    --ember-soft: rgba(255, 106, 61, 0.12);        /* ember 연한 배경(active/on 상태) */
+    --ember-line: rgba(255, 106, 61, 0.30);        /* ember 보더(active/focus ring) */
+    --ember-glow: 0 8px 30px -10px rgba(255, 106, 61, 0.45);  /* ember 부유 그림자 */
 
     /* ------- Semantic Colors (액센트와 분리) ------- */
     --success: #5fb97d;
@@ -66,37 +72,40 @@
     --accent-indigo: #6ba5c9;                /* model-selector 보조 톤 */
     --danger-bright: #e5544e;                /* destructive action 강조 */
 
-    /* ------- Background Colors (Dark — Warm Graphite) ------- */
-    --bg-app: #131210;
-    --bg-main: #131210;
-    --bg-sidebar: #100f0d;
-    --bg-secondary: #1a1815;
-    --bg-card: #1a1815;
-    --bg-tertiary: #221f1b;
+    /* ------- Background Colors (Dark — Warm Graphite, 시안 매핑) ------- */
+    --bg-app: #100f0d;          /* 시안 --canvas */
+    --bg-main: #100f0d;         /* 시안 --canvas */
+    --bg-sidebar: #0c0b09;      /* 시안 --surface-inset (사이드바=inset) */
+    --bg-secondary: #171511;    /* 시안 --surface-1 */
+    --bg-card: #171511;         /* 시안 --surface-1 */
+    --bg-tertiary: #1d1b16;     /* 시안 --surface-2 */
+    --bg-surface-3: #26231d;    /* 시안 --surface-3 (가장 떠있는 표면) */
+    --bg-elevated: #1a1813;     /* 시안 --elevated */
     --bg-hover: rgba(245, 238, 225, 0.05);
-    --bg-active: rgba(255, 106, 61, 0.13);
+    --bg-active: rgba(255, 106, 61, 0.12);
     --bg-overlay: rgba(10, 9, 8, 0.9);
 
-    /* ------- Text Colors (Warm Bone) ------- */
-    --text-primary: #f3ede1;
-    --text-secondary: #b9b1a2;
-    --text-muted: #867d6e;
+    /* ------- Text Colors (Warm Bone, 시안 매핑) ------- */
+    --text-primary: #f4eee2;    /* 시안 --tx-1 */
+    --text-secondary: #b6ad9d;  /* 시안 --tx-2 */
+    --text-muted: #857c6d;      /* 시안 --tx-3 */
+    --text-faint: #5a5349;      /* 시안 --tx-4 (라벨/메타 최하위 톤) */
     --text-inverse: #1a0f08;
 
-    /* ------- Border Colors (Hairline) ------- */
-    --border-light: rgba(245, 238, 225, 0.08);
-    --border-medium: rgba(245, 238, 225, 0.12);
-    --border-strong: rgba(245, 238, 225, 0.18);
+    /* ------- Border Colors (Hairline, 시안 매핑) ------- */
+    --border-light: rgba(245, 238, 225, 0.07);   /* 시안 --line */
+    --border-medium: rgba(245, 238, 225, 0.12);  /* 시안 --line-2 */
+    --border-strong: rgba(245, 238, 225, 0.18);  /* 시안 --line-3 */
 
     /* ------- Border System (Hairline) ------- */
     --border-width: 1px;
     --border-color: rgba(245, 238, 225, 0.10);
 
-    /* ------- Shadow (Soft Layered) ------- */
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.35);
-    --shadow-md: 0 4px 16px -4px rgba(0, 0, 0, 0.45), 0 2px 6px -2px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 18px 50px -12px rgba(0, 0, 0, 0.65), 0 6px 18px -8px rgba(0, 0, 0, 0.5);
-    --shadow-xl: 0 28px 70px -16px rgba(0, 0, 0, 0.7), 0 10px 24px -10px rgba(0, 0, 0, 0.55);
+    /* ------- Shadow (Soft Layered, 시안 매핑 — no glow) ------- */
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);                                          /* 시안 --sh-sm */
+    --shadow-md: 0 6px 22px -8px rgba(0, 0, 0, 0.55), 0 2px 6px -2px rgba(0, 0, 0, 0.4); /* 시안 --sh-md */
+    --shadow-lg: 0 24px 60px -18px rgba(0, 0, 0, 0.7);                                  /* 시안 --sh-lg */
+    --shadow-xl: 0 28px 70px -16px rgba(0, 0, 0, 0.75), 0 10px 24px -10px rgba(0, 0, 0, 0.55);
 
     /* ------- Shadow Aliases (brutal → soft) ------- */
     --shadow-brutal-sm: var(--shadow-sm);
@@ -157,12 +166,31 @@
     --space-16: 4rem;
     /* 64px */
 
-    /* ------- Border Radius (Restrained) ------- */
+    /* ------- Spacing ramp · 4px base (시안 --s1~--s9, 기존 --space-* 와 공존) ------- */
+    --s1: 4px;
+    --s2: 8px;
+    --s3: 12px;
+    --s4: 16px;
+    --s5: 20px;
+    --s6: 24px;
+    --s7: 32px;
+    --s8: 48px;
+    --s9: 64px;
+
+    /* ------- Border Radius (Restrained, 시안 매핑) ------- */
     --radius-sm: 6px;
     --radius-md: 8px;
     --radius-lg: 12px;
     --radius-xl: 16px;
     --radius-full: 9999px;
+
+    /* ------- Radii ramp (시안 --r-xs~--r-full) ------- */
+    --r-xs: 6px;
+    --r-sm: 9px;
+    --r-md: 12px;
+    --r-lg: 16px;
+    --r-xl: 22px;
+    --r-full: 999px;
 
     /* ------- Sidebar ------- */
     --sidebar-width: 260px;
@@ -195,56 +223,65 @@
 .theme-light {
     /* ===== "BONE" — LIGHT THEME ===== */
 
-    /* ------- Accent Colors (Deep Ember) ------- */
+    /* ------- Accent Colors (Deep Ember, 시안 매핑) ------- */
     --accent-primary: #e0512a;
-    --accent-primary-hover: #c8431f;
+    --accent-primary-hover: #c8431f;        /* 시안 light --ember-hi */
     --accent-primary-light: rgba(224, 81, 42, 0.10);
 
     /* ------- Accent Fill ------- */
     --gradient-primary: #e0512a;
 
-    /* ------- Background Colors (Warm Bone Paper) ------- */
-    --bg-app: #f6f1e8;
-    --bg-main: #f6f1e8;
-    --bg-sidebar: #efe8db;
-    --bg-secondary: #efe9de;
-    --bg-card: #ffffff;
-    --bg-tertiary: #e7ded0;
-    --bg-hover: rgba(40, 30, 20, 0.04);
-    --bg-active: rgba(224, 81, 42, 0.10);
-    --bg-overlay: rgba(246, 241, 232, 0.95);
+    /* ------- Ember System (시안 light 매핑) ------- */
+    --ember-ink: #ffffff;
+    --ember-soft: rgba(224, 81, 42, 0.10);
+    --ember-line: rgba(224, 81, 42, 0.28);
+    --ember-glow: 0 8px 26px -12px rgba(224, 81, 42, 0.4);
 
-    /* ------- Text Colors (Warm Ink) ------- */
-    --text-primary: #241f17;
-    --text-secondary: #5c5347;
-    --text-muted: #8a7f6c;
+    /* ------- Background Colors (Warm Bone Paper, 시안 매핑) ------- */
+    --bg-app: #f3eee4;          /* 시안 light --canvas */
+    --bg-main: #f3eee4;         /* 시안 light --canvas */
+    --bg-sidebar: #ece5d7;      /* 시안 light --surface-inset */
+    --bg-secondary: #fbf8f1;    /* 시안 light --surface-1 */
+    --bg-card: #fbf8f1;         /* 시안 light --surface-1 */
+    --bg-tertiary: #efe9dc;     /* 시안 light --surface-3 */
+    --bg-surface-3: #efe9dc;    /* 시안 light --surface-3 */
+    --bg-elevated: #fffdf8;     /* 시안 light --elevated/--surface-2 */
+    --bg-hover: rgba(60, 48, 32, 0.05);
+    --bg-active: rgba(224, 81, 42, 0.10);
+    --bg-overlay: rgba(243, 238, 228, 0.95);
+
+    /* ------- Text Colors (Warm Ink, 시안 매핑) ------- */
+    --text-primary: #231d14;    /* 시안 light --tx-1 */
+    --text-secondary: #5f5749;  /* 시안 light --tx-2 */
+    --text-muted: #8a7f6c;      /* 시안 light --tx-3 */
+    --text-faint: #aaa08c;      /* 시안 light --tx-4 */
     --text-inverse: #ffffff;
 
-    /* ------- Border Colors (Hairline) ------- */
-    --border-light: rgba(40, 30, 20, 0.10);
-    --border-medium: rgba(40, 30, 20, 0.14);
-    --border-strong: rgba(40, 30, 20, 0.20);
-    --border-color: rgba(40, 30, 20, 0.12);
-    --border-dark: rgba(40, 30, 20, 0.14);
+    /* ------- Border Colors (Hairline, 시안 매핑) ------- */
+    --border-light: rgba(60, 48, 32, 0.10);   /* 시안 light --line */
+    --border-medium: rgba(60, 48, 32, 0.16);  /* 시안 light --line-2 */
+    --border-strong: rgba(60, 48, 32, 0.24);  /* 시안 light --line-3 */
+    --border-color: rgba(60, 48, 32, 0.12);
+    --border-dark: rgba(60, 48, 32, 0.16);
 
     /* ------- Surface (Solid) ------- */
     --glass-bg: #ffffff;
     --glass-bg-hover: #f3ede1;
     --glass-border: rgba(40, 30, 20, 0.12);
 
-    /* ------- Shadow (Soft Layered — Warm) ------- */
-    --shadow-sm: 0 1px 2px rgba(60, 45, 30, 0.12);
-    --shadow-md: 0 4px 16px -4px rgba(60, 45, 30, 0.16), 0 2px 6px -2px rgba(60, 45, 30, 0.12);
-    --shadow-lg: 0 18px 50px -12px rgba(60, 45, 30, 0.22), 0 6px 18px -8px rgba(60, 45, 30, 0.16);
-    --shadow-xl: 0 28px 70px -16px rgba(60, 45, 30, 0.26), 0 10px 24px -10px rgba(60, 45, 30, 0.18);
+    /* ------- Shadow (Soft Layered — Warm, 시안 light 매핑) ------- */
+    --shadow-sm: 0 1px 2px rgba(80, 60, 40, 0.08);                                       /* 시안 light --sh-sm */
+    --shadow-md: 0 8px 24px -10px rgba(80, 60, 40, 0.18), 0 2px 6px -2px rgba(80, 60, 40, 0.1); /* 시안 light --sh-md */
+    --shadow-lg: 0 24px 60px -18px rgba(80, 60, 40, 0.22);                               /* 시안 light --sh-lg */
+    --shadow-xl: 0 28px 70px -16px rgba(80, 60, 40, 0.26), 0 10px 24px -10px rgba(80, 60, 40, 0.18);
     --shadow-brutal: var(--shadow-md);
     --shadow-brutal-sm: var(--shadow-sm);
     --shadow-brutal-lg: var(--shadow-lg);
     --shadow-brutal-active: var(--shadow-sm);
 
     /* ------- Soft Glow (ember) ------- */
-    --glow-primary: 0 8px 28px -8px rgba(224, 81, 42, 0.35);
-    --glow-input-focus: 0 0 0 3px rgba(224, 81, 42, 0.15);
+    --glow-primary: 0 8px 26px -12px rgba(224, 81, 42, 0.4);
+    --glow-input-focus: 0 0 0 3px rgba(224, 81, 42, 0.10);
 
     /* ------- Bright Semantic (light 톤 보정) ------- */
     --success-bright: #3f9e63;
@@ -306,11 +343,11 @@ body::before {
     inset: 0;
     pointer-events: none;
     z-index: 9998;
-    opacity: 0.022;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    opacity: 0.02;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.85' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
 }
 [data-theme="light"] body::before,
-.theme-light body::before { opacity: 0.018; }
+.theme-light body::before { opacity: 0.015; }
 
 /* ==========================================
    유틸리티 클래스
@@ -625,10 +662,10 @@ body::before {
     background: var(--border-strong);
 }
 
-/* Selection */
+/* Selection (시안: ember-soft 배경 + ember-hi 텍스트) */
 ::selection {
-    background: var(--accent-primary-light);
-    color: var(--text-primary);
+    background: var(--ember-soft);
+    color: var(--accent-primary-hover);
 }
 
 /* Focus Ring */

--- a/frontend/web/public/css/feature-cards.css
+++ b/frontend/web/public/css/feature-cards.css
@@ -23,29 +23,32 @@
 }
 
 .feature-card {
-    background: var(--bg-card);
+    background: var(--bg-secondary);
     border: var(--border-width) solid var(--border-light);
-    border-radius: var(--radius-lg);
+    border-radius: var(--r-lg);
     padding: 20px 16px;
     text-align: center;
     cursor: pointer;
-    transition: all 0.2s cubic-bezier(0.2, 0, 0, 1);
-    box-shadow: var(--shadow-sm);
+    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+                box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+                border-color 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow: none;
 }
 
 .feature-card:hover {
-    transform: translate(-2px, -2px);
-    box-shadow: var(--shadow-lg);
-    border-color: var(--accent-primary);
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+    border-color: var(--border-strong);
 }
 
 .feature-icon {
     width: 64px;
     height: 64px;
     margin: 0 auto 12px;
-    background: var(--bg-secondary);
-    border: 1px solid var(--border-light);
-    border-radius: var(--radius-md);
+    background: var(--ember-soft);
+    border: 1px solid var(--ember-line);
+    border-radius: var(--r-md);
+    color: var(--accent-primary-hover);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -86,10 +89,10 @@
 
 .feature-btn:hover {
     background: var(--accent-primary);
-    color: white;
-    border-color: var(--border-strong);
+    color: var(--ember-ink);
+    border-color: transparent;
     box-shadow: var(--shadow-md);
-    transform: translate(-2px, -2px);
+    transform: translateY(-1px);
 }
 
 /* 모바일 반응형 */
@@ -154,21 +157,21 @@
 .theme-light .send-btn:hover {
     background: var(--accent-primary-hover);
     box-shadow: var(--shadow-md);
-    transform: translate(-2px, -2px);
+    transform: translateY(-1px);
 }
 
 /* 라이트 테마 카드 스타일 */
 [data-theme="light"] .feature-card,
 .theme-light .feature-card {
-    background: var(--bg-card);
+    background: var(--bg-secondary);
     border: var(--border-width) solid var(--border-light);
-    box-shadow: var(--shadow-sm);
+    box-shadow: none;
 }
 
 [data-theme="light"] .feature-card:hover,
 .theme-light .feature-card:hover {
-    box-shadow: var(--shadow-lg);
-    transform: translate(-2px, -2px);
+    box-shadow: var(--shadow-md);
+    transform: translateY(-2px);
     border-color: var(--border-strong);
 }
 
@@ -177,24 +180,24 @@
    ======================================== */
 [data-theme="dark"] .feature-card,
 .theme-dark .feature-card {
-    background: var(--bg-card);
+    background: var(--bg-secondary);
     border: var(--border-width) solid var(--border-light);
-    border-radius: 16px;
-    box-shadow: var(--shadow-sm);
+    border-radius: var(--r-lg);
+    box-shadow: none;
 }
 
 [data-theme="dark"] .feature-card:hover,
 .theme-dark .feature-card:hover {
-    border-color: var(--accent-primary);
-    box-shadow: var(--shadow-lg);
-    transform: translate(-2px, -2px);
+    border-color: var(--border-strong);
+    box-shadow: var(--shadow-md);
+    transform: translateY(-2px);
 }
 
-/* 다크 모드 - 아이콘 배경 */
+/* 다크 모드 - 아이콘 배경 (ember-soft) */
 [data-theme="dark"] .feature-icon,
 .theme-dark .feature-icon {
-    background: var(--bg-secondary) !important;
-    border: 1px solid var(--border-light);
+    background: var(--ember-soft) !important;
+    border: 1px solid var(--ember-line);
 }
 
 [data-theme="dark"] .feature-icon img,
@@ -227,20 +230,20 @@
 [data-theme="dark"] .feature-btn:hover,
 .theme-dark .feature-btn:hover {
     background: var(--accent-primary);
-    color: #FFFFFF !important;
-    border-color: var(--border-strong);
+    color: var(--ember-ink) !important;
+    border-color: transparent;
     box-shadow: var(--shadow-md);
-    transform: translate(-2px, -2px);
+    transform: translateY(-1px);
 }
 
 /* ========================================
    라이트 모드 기능 카드 스타일 (투명 아이콘 제거)
    ======================================== */
-/* 라이트 모드 - 아이콘 배경 */
+/* 라이트 모드 - 아이콘 배경 (ember-soft) */
 [data-theme="light"] .feature-icon,
 .theme-light .feature-icon {
-    background: var(--bg-secondary) !important;
-    border: 1px solid var(--border-light);
+    background: var(--ember-soft) !important;
+    border: 1px solid var(--ember-line);
 }
 
 [data-theme="light"] .feature-icon img,
@@ -271,8 +274,8 @@
 [data-theme="light"] .feature-btn:hover,
 .theme-light .feature-btn:hover {
     background: var(--accent-primary);
-    color: #FFFFFF;
-    border-color: var(--border-strong);
+    color: var(--ember-ink);
+    border-color: transparent;
     box-shadow: var(--shadow-md);
-    transform: translate(-2px, -2px);
+    transform: translateY(-1px);
 }

--- a/frontend/web/public/css/light-theme.css
+++ b/frontend/web/public/css/light-theme.css
@@ -15,11 +15,9 @@
 
 [data-theme="light"] .history-item:hover,
 .theme-light .history-item:hover {
-    background: var(--bg-card);
-    border-color: var(--border-strong);
+    background: var(--bg-tertiary);
+    border-color: transparent;
     color: var(--text-primary);
-    box-shadow: var(--shadow-sm);
-    transform: translate(-2px, -2px);
 }
 
 /* 테마 토글 - 라이트 */
@@ -36,11 +34,9 @@
 
 [data-theme="light"] .theme-toggle:hover,
 .theme-light .theme-toggle:hover {
-    background: var(--bg-card);
-    border-color: var(--border-strong);
+    background: var(--bg-tertiary);
+    border-color: transparent;
     color: var(--text-primary);
-    box-shadow: var(--shadow-sm);
-    transform: translate(-2px, -2px);
 }
 
 /* ========================================
@@ -91,16 +87,15 @@
    ======================================== */
 [data-theme="light"] .chat-input-container,
 .theme-light .chat-input-container {
-    background: var(--bg-card);
-    border: 1px solid var(--border-color);
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-medium);
     box-shadow: var(--shadow-md);
 }
 
 [data-theme="light"] .chat-input-container:focus-within,
 .theme-light .chat-input-container:focus-within {
-    border-color: var(--accent-primary);
-    box-shadow: var(--glow-input-focus);
-    transform: translate(-2px, -2px);
+    border-color: var(--ember-line);
+    box-shadow: 0 0 0 3px var(--ember-soft), var(--shadow-md);
 }
 
 /* 라이트 테마 - 채팅 드래그 앤 드롭 오버레이 */
@@ -147,20 +142,19 @@
     color: var(--text-muted);
 }
 
-/* 전송 버튼 - 파란색 -> 보라색 */
+/* 전송 버튼 - ember fill */
 [data-theme="light"] .send-btn,
 .theme-light .send-btn {
     background: var(--accent-primary);
-    color: var(--bg-card);
-    border: 1px solid var(--border-color);
-    box-shadow: var(--shadow-sm);
+    color: var(--ember-ink);
+    border: 1px solid transparent;
+    box-shadow: var(--ember-glow);
 }
 
 [data-theme="light"] .send-btn:hover,
 .theme-light .send-btn:hover {
     background: var(--accent-primary-hover);
-    transform: translate(-2px, -2px);
-    box-shadow: var(--shadow-md);
+    transform: translateY(-1px);
 }
 
 [data-theme="light"] .send-btn.abort-mode,
@@ -182,19 +176,16 @@
 
 [data-theme="light"] .action-btn:hover,
 .theme-light .action-btn:hover {
-    background: var(--bg-card);
-    border-color: var(--border-strong);
+    background: var(--bg-surface-3);
+    border-color: transparent;
     color: var(--text-primary);
-    box-shadow: var(--shadow-sm);
-    transform: translate(-2px, -2px);
 }
 
 [data-theme="light"] .action-btn.active,
 .theme-light .action-btn.active {
-    color: var(--accent-primary);
-    background: var(--accent-primary-light);
-    border-color: var(--accent-primary);
-    box-shadow: var(--shadow-sm);
+    color: var(--accent-primary-hover);
+    background: var(--ember-soft);
+    border-color: var(--ember-line);
 }
 
 /* ========================================

--- a/frontend/web/public/css/unified-sidebar.css
+++ b/frontend/web/public/css/unified-sidebar.css
@@ -194,16 +194,13 @@
 .us-toggle-btn:hover,
 .us-theme-btn:hover {
     background: var(--bg-tertiary);
-    border-color: var(--border-light);
+    border-color: transparent;
     color: var(--text-primary);
-    transform: translate(-2px, -2px);
-    box-shadow: var(--shadow-sm);
 }
 
 .us-toggle-btn:active,
 .us-theme-btn:active {
-    transform: translate(0, 0);
-    box-shadow: none;
+    background: var(--bg-surface-3);
 }
 
 /* ─── Logo ─────────────────────────────────── */
@@ -242,31 +239,29 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    padding: 10px 16px;
+    padding: 11px 14px;
     margin: 4px 12px 8px;
-    background: var(--bg-card);
-    border: var(--border-width) solid var(--border-light);
-    color: var(--text-primary);
-    border-radius: var(--radius-md);
+    background: var(--accent-primary);
+    border: var(--border-width) solid transparent;
+    color: var(--ember-ink);
+    border-radius: var(--r-md);
     font-size: var(--font-size-sm);
     font-weight: 600;
+    letter-spacing: -0.01em;
     font-family: var(--font-sans);
     cursor: pointer;
     transition: all 200ms ease;
     flex-shrink: 0;
-    box-shadow: var(--shadow-sm);
+    box-shadow: var(--ember-glow);
 }
 
 .us-new-chat:hover {
-    background: var(--bg-tertiary);
-    border-color: var(--border-medium);
-    transform: translate(-2px, -2px);
-    box-shadow: var(--shadow-md);
+    background: var(--accent-primary-hover);
+    transform: translateY(-1px);
 }
 
 .us-new-chat:active {
-    transform: translate(1px, 1px);
-    box-shadow: none;
+    transform: translateY(0);
 }
 
 .us-new-chat svg {
@@ -312,11 +307,16 @@
     gap: 8px;
     margin: 0 12px 8px;
     padding: 8px 12px;
-    background: var(--bg-tertiary);
-    border: var(--border-width) solid var(--border-light);
-    border-radius: var(--radius-sm);
+    background: var(--bg-sidebar);
+    border: var(--border-width) solid var(--border-medium);
+    border-radius: var(--r-sm);
     flex-shrink: 0;
-    box-shadow: var(--shadow-sm);
+    transition: border-color 200ms ease, box-shadow 200ms ease;
+}
+
+.us-search:focus-within {
+    border-color: var(--ember-line);
+    box-shadow: 0 0 0 3px var(--ember-soft);
 }
 
 .us-search svg {
@@ -354,12 +354,13 @@
 }
 
 .us-group-label {
-    padding: 8px 12px 4px;
-    font-size: var(--font-size-xs);
-    font-weight: 700;
-    color: var(--text-muted);
+    padding: 8px 12px 6px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--text-faint);
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: 0.12em;
 }
 
 .us-conv-item {
@@ -367,24 +368,30 @@
     align-items: center;
     padding: 9px 12px;
     margin: 1px 4px;
-    border-radius: var(--radius-sm);
+    border-radius: var(--r-sm);
     cursor: pointer;
-    transition: all 150ms ease;
+    transition: background 150ms ease, color 150ms ease;
     overflow: hidden;
-    border: var(--border-width) solid transparent;
+    position: relative;
 }
 
 .us-conv-item:hover {
-    background: var(--bg-card);
-    border-color: var(--border-light);
-    transform: translate(-2px, -2px);
-    box-shadow: var(--shadow-sm);
+    background: var(--bg-tertiary);
 }
 
 .us-conv-item.active {
-    background: var(--bg-active);
-    border-color: var(--border-light);
-    border-left: 4px solid var(--accent-primary);
+    background: var(--bg-tertiary);
+}
+
+.us-conv-item.active::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 8px;
+    bottom: 8px;
+    width: 2px;
+    border-radius: 2px;
+    background: var(--accent-primary);
 }
 
 .us-conv-item.active .us-conv-title {
@@ -505,22 +512,22 @@
 
 /* Light Theme Adjustments */
 [data-theme="light"] .us-user-menu {
-    background: #ffffff;
-    border-color: #000;
+    background: var(--bg-elevated);
+    border-color: var(--border-medium);
     box-shadow: var(--shadow-md);
 }
 
 [data-theme="light"] .us-menu-header {
-    border-bottom-color: #000;
+    border-bottom-color: var(--border-light);
 }
 
 [data-theme="light"] .us-menu-item:hover {
-    background: #f0f0f0;
-    color: #000;
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
 }
 
 [data-theme="light"] .us-menu-item.logout:hover {
-    background: #ff4d4d;
+    background: var(--danger);
     color: #fff;
 }
 
@@ -566,10 +573,8 @@
 
 .us-settings-btn:hover {
     background: var(--bg-tertiary);
-    border-color: var(--border-light);
+    border-color: transparent;
     color: var(--text-primary);
-    transform: translate(-2px, -2px);
-    box-shadow: var(--shadow-sm);
 }
 
 /* ─── Empty State ──────────────────────────── */
@@ -630,106 +635,98 @@
 
 /* ─── Light Theme ──────────────────────────── */
 [data-theme="light"] .unified-sidebar {
-    background: #fdfbf7;
-    border-right-color: #000;
+    background: var(--bg-sidebar);
+    border-right-color: var(--border-light);
 }
 
 [data-theme="light"] .unified-sidebar.us-hover-expanded {
-    background: #fdfbf7;
+    background: var(--bg-sidebar);
     box-shadow: var(--shadow-lg);
-    border-right-color: #000;
+    border-right-color: var(--border-light);
 }
 
 [data-theme="light"] .us-toggle-btn,
 [data-theme="light"] .us-theme-btn {
-    color: #000;
+    color: var(--text-secondary);
 }
 
 [data-theme="light"] .us-toggle-btn:hover,
 [data-theme="light"] .us-theme-btn:hover {
-    background: #fff;
-    border-color: #000;
-    color: #000;
-    box-shadow: var(--shadow-sm);
+    background: var(--bg-tertiary);
+    border-color: transparent;
+    color: var(--text-primary);
 }
 
 [data-theme="light"] .us-brand-text {
-    color: #000;
+    color: var(--text-primary);
 }
 
 [data-theme="light"] .us-new-chat {
-    background: #fff;
-    border-color: #000;
-    color: #000;
-    box-shadow: var(--shadow-sm);
+    background: var(--accent-primary);
+    border-color: transparent;
+    color: var(--ember-ink);
+    box-shadow: var(--ember-glow);
 }
 
 [data-theme="light"] .us-new-chat:hover {
-    background: #eee;
-    box-shadow: var(--shadow-md);
+    background: var(--accent-primary-hover);
 }
 
 [data-theme="light"] .us-doc-link {
-    color: #555;
+    color: var(--text-secondary);
 }
 
 [data-theme="light"] .us-doc-link:hover {
-    color: #000;
-    background: #eee;
+    color: var(--text-primary);
+    background: var(--bg-tertiary);
 }
 
 [data-theme="light"] .us-search {
-    background: #fff;
-    border-color: #000;
-    box-shadow: var(--shadow-sm);
+    background: var(--bg-elevated);
+    border-color: var(--border-medium);
 }
 
 [data-theme="light"] .us-search-input {
-    color: #000;
+    color: var(--text-primary);
 }
 
 [data-theme="light"] .us-conv-item:hover {
-    background: #fff;
-    border-color: #000;
-    box-shadow: var(--shadow-sm);
+    background: var(--bg-tertiary);
 }
 
 [data-theme="light"] .us-conv-item.active {
-    background: #f0f0f0;
-    border-color: #000;
-    border-left-color: var(--accent-primary);
+    background: var(--bg-tertiary);
 }
 
 [data-theme="light"] .us-conv-title {
-    color: #333;
+    color: var(--text-secondary);
 }
 
 [data-theme="light"] .us-conv-item.active .us-conv-title {
-    color: #000;
+    color: var(--text-primary);
 }
 
 [data-theme="light"] .us-user-section {
-    background: #fdfbf7;
-    border-top-color: #000;
+    background: var(--bg-sidebar);
+    border-top-color: var(--border-light);
 }
 
 [data-theme="light"] .us-user-name {
-    color: #000;
+    color: var(--text-primary);
 }
 
 [data-theme="light"] .us-settings-btn {
-    color: #000;
+    color: var(--text-secondary);
 }
 
 [data-theme="light"] .us-settings-btn:hover {
-    background: #fff;
-    border-color: #000;
-    color: #000;
-    box-shadow: var(--shadow-sm);
+    background: var(--bg-tertiary);
+    border-color: transparent;
+    color: var(--text-primary);
 }
 
 [data-theme="light"] .us-conversations::-webkit-scrollbar-thumb {
-    background: #000;
+    background: var(--border-strong);
 }
 
 [data-theme="light"] .us-conversations::-webkit-scrollbar-thumb:hover {
@@ -791,29 +788,31 @@
 .us-nav-item {
     display: flex;
     align-items: center;
-    gap: 10px;
-    padding: 7px 10px;
-    border-radius: var(--radius-md);
+    gap: 11px;
+    padding: 9px 10px;
+    border-radius: var(--r-sm);
     cursor: pointer;
     text-decoration: none;
     color: var(--text-secondary);
     font-size: var(--font-size-sm);
     font-weight: 500;
-    transition: background 0.15s, color 0.15s;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
     white-space: nowrap;
     overflow: hidden;
     min-height: 34px;
     flex-shrink: 0;
+    border: var(--border-width) solid transparent;
 }
 
 .us-nav-item:hover {
-    background: var(--bg-hover);
+    background: var(--bg-tertiary);
     color: var(--text-primary);
 }
 
 .us-nav-item.active {
-    background: rgba(99, 102, 241, 0.15);
-    color: var(--accent-primary);
+    background: var(--ember-soft);
+    color: var(--accent-primary-hover);
+    border-color: var(--ember-line);
 }
 
 .us-nav-icon {
@@ -834,12 +833,12 @@
 
 .us-nav-section-label {
     font-family: var(--font-mono); /* technical 마이크로 라벨 */
-    font-size: var(--font-size-xs);
-    font-weight: 600;
+    font-size: 10px;
+    font-weight: 500;
     text-transform: uppercase;
-    letter-spacing: 0.14em;
-    color: var(--text-muted);
-    padding: 8px 10px 2px;
+    letter-spacing: 0.16em;
+    color: var(--text-faint);
+    padding: 8px 10px 4px;
     flex-shrink: 0;
 }
 
@@ -894,9 +893,10 @@
 .unified-sidebar.us-hover-expanded .us-nav-section-label { display: inline; }
 /* active 페이지 nav — ember (고 specificity 로 상태 규칙 우선) */
 .unified-sidebar .us-page-nav .us-nav-link.active {
-    background: var(--accent-primary-light);
-    color: var(--accent-primary);
+    background: var(--ember-soft);
+    color: var(--accent-primary-hover);
     font-weight: 600;
+    box-shadow: inset 0 0 0 1px var(--ember-line);
 }
 
 .us-nav-divider {

--- a/frontend/web/public/index.html
+++ b/frontend/web/public/index.html
@@ -85,7 +85,7 @@
                             <img src="/images/avatar/character-avatar.png" alt="OpenMake AI" class="avatar-img">
                         </div>
                         <h1 class="welcome-title animate-fadeInUp" style="animation-delay: 0.1s;">오늘도 화이팅!<br>무엇을
-                            도와드릴까요? 😊
+                            <span class="accent">도와드릴까요?</span> 😊
                         </h1>
                         <p class="welcome-subtitle animate-fadeInUp" style="animation-delay: 0.2s;">AI 어시스턴트가 질문에
                             답변하고,<br>문서를 분석하고, 코드를 작성합니다.</p>

--- a/frontend/web/public/style.css
+++ b/frontend/web/public/style.css
@@ -39,16 +39,13 @@ body {
 }
 
 .theme-toggle:hover {
-    background: var(--bg-hover);
-    border-color: var(--border-light);
-    color: var(--accent-primary);
-    box-shadow: var(--shadow-sm);
-    transform: translate(-2px, -2px);
+    background: var(--bg-tertiary);
+    border-color: transparent;
+    color: var(--text-primary);
 }
 
 .theme-toggle:active {
-    transform: translate(0, 0);
-    box-shadow: none;
+    background: var(--bg-surface-3);
 }
 
 /* Main Content Area */
@@ -58,10 +55,9 @@ body {
     display: flex;
     flex-direction: column;
     height: 100%;
-    /* 무드 연출 — 코너 소프트 글로우 (다크 캔버스 깊이감) */
+    /* 무드 연출 — ember 코너 aura (시안: 우상단 미묘한 radial) */
     background:
-        radial-gradient(1100px 600px at 100% -10%, rgba(255, 106, 61, 0.05), transparent 60%),
-        radial-gradient(820px 480px at -8% 4%, rgba(107, 165, 201, 0.035), transparent 55%),
+        radial-gradient(900px 460px at 78% -8%, var(--ember-soft), transparent 62%),
         var(--bg-main);
     position: relative;
     overflow: hidden;
@@ -127,18 +123,27 @@ body {
 
 .welcome-title {
     font-family: var(--font-serif); /* Fraunces+Noto Serif KR — editorial 히어로 */
-    font-size: 3rem;
-    font-weight: 600;
+    font-size: clamp(34px, 4vw, 46px);
+    font-weight: 500;
+    line-height: 1.06;
     margin-bottom: 16px;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.025em;
     color: var(--text-primary);
     background: none;
     -webkit-text-fill-color: initial;
 }
 
+/* 시안 greeting accent — 일부 단어를 italic ember 로 강조 (라틴/한글 모두 안전) */
+.welcome-title .accent,
+.welcome-title em {
+    font-style: italic;
+    color: var(--accent-primary);
+}
+
 .welcome-subtitle {
     color: var(--text-secondary);
-    font-size: 1.15rem;
+    font-size: 1.05rem;
+    line-height: 1.6;
     margin-bottom: 48px;
     max-width: 500px;
     font-weight: 500;
@@ -163,10 +168,8 @@ body {
 
 .model-selector:hover,
 .model-selector:focus {
-    border-color: var(--accent-primary);
+    border-color: var(--border-strong);
     color: var(--text-primary);
-    transform: translate(-2px, -2px);
-    box-shadow: var(--shadow-md);
 }
 
 /* Chat Input Container */
@@ -179,18 +182,17 @@ body {
 }
 
 .chat-input-container {
-    background: var(--bg-card);
+    background: var(--bg-secondary);
     border: var(--border-width) solid var(--border-medium);
-    border-radius: var(--radius-xl);
+    border-radius: var(--r-xl);
     padding: 8px 16px;
     box-shadow: var(--shadow-md);
-    transition: all 0.2s;
+    transition: border-color 0.2s, box-shadow 0.2s;
 }
 
 .chat-input-container:focus-within {
-    border-color: var(--accent-primary);
-    box-shadow: var(--shadow-lg);
-    transform: translate(-1px, -1px);
+    border-color: var(--ember-line);
+    box-shadow: 0 0 0 3px var(--ember-soft), var(--shadow-md);
 }
 
 .input-wrapper textarea {
@@ -283,42 +285,37 @@ body {
 }
 
 .action-btn:hover {
-    background: var(--bg-hover);
+    background: var(--bg-surface-3);
     color: var(--text-primary);
-    border-color: var(--border-light);
-    box-shadow: var(--shadow-sm);
-    transform: translate(-2px, -2px);
+    border-color: transparent;
 }
 
 .action-btn:active {
-    transform: translate(0, 0);
-    box-shadow: none;
+    background: var(--bg-tertiary);
 }
 
 .action-btn.active {
-    color: var(--accent-primary);
-    background: var(--bg-tertiary);
-    border-color: var(--accent-primary);
+    color: var(--accent-primary-hover);
+    background: var(--ember-soft);
+    border-color: var(--ember-line);
 }
 
 .send-btn {
     background: var(--accent-primary);
-    color: #ffffff;
+    color: var(--ember-ink);
     padding: 10px;
-    border: var(--border-width) solid var(--border-dark);
-    box-shadow: var(--shadow-sm);
-    transition: all 0.2s ease;
+    border: var(--border-width) solid transparent;
+    box-shadow: var(--ember-glow);
+    transition: background 0.2s ease, transform 0.2s ease;
 }
 
 .send-btn:hover {
-    transform: translate(-2px, -2px);
-    box-shadow: var(--shadow-md);
-    background: var(--accent-glow);
+    transform: translateY(-1px);
+    background: var(--accent-primary-hover);
 }
 
 .send-btn:active {
-    transform: translate(1px, 1px);
-    box-shadow: none;
+    transform: translateY(0);
 }
 
 /* Abort mode */


### PR DESCRIPTION
## 개요
open-design MCP 가 생성한 **"Graphite & Ember II · refined edition"** 시안을 현재 토큰 시스템(`design-tokens.css` var() 23 페이지 구동)에 전면 반영. 프레임워크 도입 없이 기존 CSS 변수 토큰만 정교화·확장.

## 변경 (소스 7파일, dist 는 gitignored → 배포 시 `build:frontend` 재생성)
| 파일 | 내용 |
|---|---|
| `css/design-tokens.css` | 다크 캔버스/표면 3-tier·텍스트 4-tier 정교화, 신규 토큰(`--bg-surface-3/-elevated`, `--text-faint`, `--ember-ink/-soft/-line/-glow`, spacing `--s1~--s9`, radii `--r-xs~--r-full`) |
| `css/light-theme.css` | Bone Paper(#f3eee4) 정교화 + brutal translate 제거 |
| `css/unified-sidebar.css` | nav active = ember-soft+ember-line, 대화 current 좌측 2px ember bar, 그룹 라벨 mono 대문자, 새 대화 ember fill+glow |
| `css/feature-cards.css` | hover translateY+soft shadow, 아이콘 ember 칩 |
| `style.css` | welcome serif + ember italic accent, 코너 ember aura, composer focus ring, brutal 제거 |
| `css/components.css` | attribution-chip indigo→ember (1줄) |
| `index.html` | welcome accent CSP-safe `<span class="accent">` 래핑 |

## 검증
- [x] Playwright 시각 검증 — 다크(Graphite) + 라이트(Bone Paper) 양쪽 시안 일치
- [x] `npm run build:frontend` (validate-modules → vite build → verify-dist-hash) 통과
- [x] `npm run lint` 통과 (0 errors)
- [x] 백엔드 무변경 / CSP 정합(인라인 style·onclick 없음)

## 잔여(후속 PR 후보)
composer 도구 pill row·persona dropdown 신규 마크업, 일부 모달 brutal translate 잔존, grain texture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)