### PR TITLE
feat(design): Graphite & Ember II 내부 페이지 전파 — 4-아키타입 시안 적용

### DIFF
--- a/frontend/web/public/css/components.css
+++ b/frontend/web/public/css/components.css
@@ -125,6 +125,7 @@
 
 .card:hover {
     border-color: var(--border-medium);
+    box-shadow: var(--shadow-md);
 }
 
 .card-interactive:hover {
@@ -166,31 +167,33 @@
 
 /* Stat Card */
 .stat-card {
-    text-align: center;
+    text-align: left;
     min-width: 120px;
 }
 
 .stat-value {
     font-family: var(--font-serif); /* Fraunces — editorial 수치 (Latin-safe) */
-    font-size: var(--font-size-4xl);
-    font-weight: var(--font-weight-semibold);
+    font-size: var(--font-size-2xl);
+    font-weight: var(--font-weight-medium);
     letter-spacing: -0.02em;
-    color: var(--accent-primary);
-    line-height: 1.2;
+    color: var(--text-primary);
+    line-height: 1;
+    margin-top: var(--space-2);
 }
 
 .stat-label {
     font-family: var(--font-mono); /* technical 마이크로 라벨 */
-    font-size: var(--font-size-xs);
+    font-size: 10px;
     color: var(--text-muted);
-    margin-top: var(--space-1);
+    margin-top: 0;
     text-transform: uppercase;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.06em;
 }
 
 .stat-change {
-    font-size: var(--font-size-xs);
-    margin-top: var(--space-2);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    margin-top: var(--space-1);
 }
 
 .stat-change.positive {
@@ -356,37 +359,44 @@
 .badge {
     display: inline-flex;
     align-items: center;
-    padding: var(--space-1) var(--space-2);
+    gap: 4px;
+    padding: 3px 8px;
+    font-family: var(--font-mono);
     font-size: var(--font-size-xs);
     font-weight: var(--font-weight-bold);
-    border-radius: var(--radius-sm);
+    border-radius: var(--radius-full);
     line-height: 1;
     border: 1px solid currentColor;
 }
 
 .badge-primary {
-    background: var(--accent-primary-light);
-    color: var(--accent-primary);
+    background: var(--ember-soft);
+    color: var(--accent-primary-hover);
+    border-color: var(--ember-line);
 }
 
 .badge-success {
     background: var(--success-light);
     color: var(--success);
+    border-color: rgba(95, 185, 125, 0.3);
 }
 
 .badge-warning {
     background: var(--warning-light);
     color: var(--warning);
+    border-color: rgba(232, 176, 75, 0.3);
 }
 
 .badge-danger {
     background: var(--danger-light);
     color: var(--danger);
+    border-color: rgba(229, 84, 78, 0.3);
 }
 
 .badge-info {
     background: var(--info-light);
     color: var(--info);
+    border-color: rgba(107, 165, 201, 0.3);
 }
 
 /* ==========================================
@@ -468,16 +478,17 @@
 
 .table th {
     background: var(--bg-secondary);
+    font-family: var(--font-mono);
     font-size: var(--font-size-xs);
-    font-weight: var(--font-weight-bold);
+    font-weight: var(--font-weight-medium);
     color: var(--text-muted);
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: 0.07em;
     border-bottom: var(--border-width) solid var(--border-light);
 }
 
 .table tr:hover td {
-    background: var(--bg-hover);
+    background: var(--bg-tertiary);
 }
 
 .table tr:last-child td {

--- a/frontend/web/public/css/design-tokens.css
+++ b/frontend/web/public/css/design-tokens.css
@@ -60,6 +60,19 @@
     --info: #6ba5c9;
     --info-light: rgba(107, 165, 201, 0.15);
 
+    /* ------- Semantic Soft Aliases (시안 -soft suffix 정렬) ------- */
+    --positive-soft: var(--success-light);
+    --warning-soft: var(--warning-light);
+    --danger-soft: var(--danger-light);
+    --info-soft: var(--info-light);
+
+    /* ------- Data Visualization Palette (시안 --viz-1~5) ------- */
+    --viz-1: #ff6a3d;
+    --viz-2: #f2994a;
+    --viz-3: #e8b04b;
+    --viz-4: #9bb06a;
+    --viz-5: #5fb97d;
+
     /* ------- Semantic Aliases (호환성) ------- */
     --accent-success: var(--success);        /* success 색상 alias */
     --error: var(--danger);                  /* error/danger 색상 alias */
@@ -106,6 +119,7 @@
     --shadow-md: 0 6px 22px -8px rgba(0, 0, 0, 0.55), 0 2px 6px -2px rgba(0, 0, 0, 0.4); /* 시안 --sh-md */
     --shadow-lg: 0 24px 60px -18px rgba(0, 0, 0, 0.7);                                  /* 시안 --sh-lg */
     --shadow-xl: 0 28px 70px -16px rgba(0, 0, 0, 0.75), 0 10px 24px -10px rgba(0, 0, 0, 0.55);
+    --shadow-ember: 0 8px 28px -8px rgba(255, 106, 61, 0.4);
 
     /* ------- Shadow Aliases (brutal → soft) ------- */
     --shadow-brutal-sm: var(--shadow-sm);

--- a/frontend/web/public/css/layout.css
+++ b/frontend/web/public/css/layout.css
@@ -131,8 +131,9 @@
 
 .grid-stats {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: var(--space-4);
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: var(--s3);
+    margin-bottom: var(--s3);
 }
 
 .grid-2 {
@@ -177,8 +178,8 @@
 .section-title {
     font-family: var(--font-serif); /* editorial 섹션 타이틀 */
     font-size: var(--font-size-xl);
-    font-weight: 600;
-    letter-spacing: -0.01em;
+    font-weight: var(--font-weight-medium);
+    letter-spacing: -0.02em;
     color: var(--text-primary);
 }
 
@@ -222,9 +223,9 @@
 .search-input {
     width: 100%;
     padding: var(--space-3) var(--space-4) var(--space-3) var(--space-10);
-    background: var(--bg-tertiary);
-    border: var(--border-width, 2px) solid var(--border-medium);
-    border-radius: var(--radius-md);
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border-medium);
+    border-radius: var(--r-sm);
     color: var(--text-primary);
     font-size: var(--font-size-sm);
     transition: all var(--transition-fast);
@@ -257,11 +258,18 @@
     box-shadow: var(--shadow-sm);
 }
 
-.filter-btn:hover,
+.filter-btn:hover {
+    background: var(--bg-tertiary);
+    border-color: var(--border-strong);
+    color: var(--text-primary);
+    transform: translate(-2px, -2px);
+    box-shadow: var(--shadow-md);
+}
+
 .filter-btn.active {
-    background: var(--accent-primary);
-    border-color: #000;
-    color: white;
+    background: var(--ember-soft);
+    border-color: var(--ember-line);
+    color: var(--accent-primary-hover);
     transform: translate(-2px, -2px);
     box-shadow: var(--shadow-md);
 }

--- a/frontend/web/public/css/light-theme.css
+++ b/frontend/web/public/css/light-theme.css
@@ -334,3 +334,27 @@
 .theme-light .status-dot.stop {
     background: var(--danger);
 }
+
+/* ========================================
+   G&E II 신규 토큰 — 라이트 테마 대응값
+   (design-tokens.css 에 추가된 토큰 오버라이드)
+   ======================================== */
+
+[data-theme="light"],
+.theme-light {
+    /* ------- Semantic Soft Aliases (라이트: opacity 살짝 낮춤) ------- */
+    --positive-soft: rgba(63, 158, 99, 0.12);
+    --warning-soft: rgba(201, 138, 30, 0.12);
+    --danger-soft: rgba(200, 57, 47, 0.12);
+    --info-soft: rgba(80, 130, 160, 0.12);
+
+    /* ------- Data Visualization Palette (라이트: 채도 유지, 명도 약간 낮춤) ------- */
+    --viz-1: #e0512a;
+    --viz-2: #c97c1e;
+    --viz-3: #c09030;
+    --viz-4: #5a8040;
+    --viz-5: #3f9e63;
+
+    /* ------- Shadow Ember (라이트: rgba opacity 낮춤) ------- */
+    --shadow-ember: 0 8px 28px -8px rgba(224, 81, 42, 0.28);
+}

--- a/frontend/web/public/css/settings.css
+++ b/frontend/web/public/css/settings.css
@@ -101,7 +101,8 @@
     left: var(--space-6);
     right: var(--space-6);
     height: 1px;
-    background: var(--accent-primary);
+    background: var(--ember-line);
+    opacity: 0.6;
 }
 
 .s-card-icon {
@@ -445,22 +446,22 @@
     gap: var(--space-2);
     margin: 0 0 var(--space-5);
     padding: var(--space-2);
-    background: var(--bg-card);
+    background: var(--bg-sidebar);
     border: 1px solid var(--border-light);
-    border-radius: var(--radius-lg);
+    border-radius: var(--r-lg);
 }
 .settings-tab {
     flex: 1;
     min-width: 120px;
     padding: var(--space-3) var(--space-4);
     background: transparent;
-    border: none;
-    border-radius: var(--radius-md);
+    border: 1px solid transparent;
+    border-radius: var(--r-md);
     color: var(--text-secondary);
     font-size: var(--font-size-sm);
     font-weight: var(--font-weight-medium);
     cursor: pointer;
-    transition: background .15s, color .15s;
+    transition: background .15s, color .15s, border-color .15s;
     text-align: center;
 }
 .settings-tab:hover {
@@ -468,8 +469,9 @@
     color: var(--text-primary);
 }
 .settings-tab.active {
-    background: var(--accent-primary);
-    color: #fff;
+    background: var(--ember-soft);
+    color: var(--accent-primary-hover);
+    border: 1px solid var(--ember-line);
     font-weight: var(--font-weight-semibold);
 }
 @media (max-width: 640px) {

--- a/frontend/web/public/css/skill-library.css
+++ b/frontend/web/public/css/skill-library.css
@@ -48,8 +48,8 @@
 }
 .sl-tab:hover { color: var(--text-primary, #fff); }
 .sl-tab.active {
-    color: var(--accent-primary, #3b82f6);
-    border-bottom-color: var(--accent-primary, #3b82f6);
+    color: var(--accent-primary-hover);
+    border-bottom-color: var(--accent-primary);
 }
 
 /* Tab panes */
@@ -152,8 +152,8 @@
     overflow: hidden;
 }
 .skill-row:hover {
-    border-color: var(--accent-primary);
-    background-color: var(--bg-hover, rgba(255,255,255,0.02));
+    border-color: var(--ember-line);
+    background-color: var(--bg-hover);
 }
 /* 영역 공통: padding + 영역 사이 좌측 divider (첫 영역 제외) */
 .skill-row > * {
@@ -169,10 +169,11 @@
 .skill-row-header {
     background-color: var(--bg-secondary);
     color: var(--text-muted);
-    font-size: var(--font-size-xs);
-    font-weight: var(--font-weight-semibold, 600);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: var(--font-weight-medium);
     text-transform: uppercase;
-    letter-spacing: 0.04em;
+    letter-spacing: 0.07em;
     margin-bottom: 0.5rem;
     cursor: default;
 }
@@ -242,17 +243,18 @@
 
 /* Legacy card classes (다른 곳 호환) */
 .skill-card {
-    background-color: var(--bg-card, #1e293b);
-    border: 1px solid var(--border-color, #334155);
-    border-radius: 0.5rem;
-    padding: 1.25rem;
-    transition: border-color 0.2s, transform 0.2s;
+    background-color: var(--bg-card);
+    border: 1px solid var(--border-light);
+    border-radius: var(--r-lg);
+    padding: var(--s4);
+    gap: var(--s2);
+    transition: border-color 0.2s, box-shadow 0.2s;
     display: flex;
     flex-direction: column;
 }
 .skill-card:hover {
-    border-color: var(--accent-primary, #3b82f6);
-    transform: translateY(-2px);
+    border-color: var(--ember-line);
+    box-shadow: var(--shadow-md);
 }
 .skill-card-top {
     display: flex;
@@ -261,13 +263,15 @@
     margin-bottom: 0.5rem;
 }
 .skill-card-badge {
-    font-size: var(--font-size-xs);
-    padding: 0.2rem 0.5rem;
-    border-radius: 1rem;
-    background: rgba(59,130,246,0.1);
-    color: var(--accent-primary, #3b82f6);
-    border: 1px solid rgba(59,130,246,0.2);
-    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    padding: 2px 7px;
+    border-radius: var(--r-full);
+    background: var(--ember-soft);
+    color: var(--accent-primary-hover);
+    border: 1px solid var(--ember-line);
+    display: inline-flex;
+    align-items: center;
 }
 .skill-card-menu {
     position: relative;
@@ -336,8 +340,9 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    border-top: 1px solid var(--border-color, #334155);
-    padding-top: 0.75rem;
+    gap: var(--s2);
+    border-top: 1px solid var(--border-light);
+    padding-top: var(--s2);
     margin-top: auto;
 }
 .skill-card-footer small { color: var(--text-muted, #64748b); font-size: var(--font-size-xs); }
@@ -347,8 +352,8 @@
     border-radius: 1rem;
     border: 1px solid;
 }
-.sl-badge-success { background: rgba(34,197,94,0.1); color: var(--success, #4ade80); border-color: rgba(34,197,94,0.25); }
-.sl-badge-secondary { background: rgba(148,163,184,0.1); color: var(--text-secondary, #94a3b8); border-color: rgba(148,163,184,0.2); }
+.sl-badge-success { background: var(--success-light); color: var(--success); border-color: rgba(95, 185, 125, 0.3); }
+.sl-badge-secondary { background: var(--bg-tertiary); color: var(--text-secondary); border-color: var(--border-medium); }
 
 /* MP search toolbar */
 .sl-mp-search {


### PR DESCRIPTION
## 개요
chat 화면(#124)에 이어, **내부 19개 페이지**의 공유 컴포넌트를 open-design `pages-redesign` **4-아키타입 시안**(A 대시보드·B 리스트/관리·C 위저드·D 레퍼런스)에 정렬. **CSS만 수정 / 마크업 무변경** — 14개 페이지 모듈이 표준 컴포넌트 클래스를 공유하므로 자동 전파.

## 변경 (CSS 6파일, dist 는 gitignored → 배포 시 build:frontend 재생성)
| 파일 | 내용 |
|---|---|
| `design-tokens.css` | 신규 시맨틱 토큰 `--positive/warning/danger/info-soft`, `--viz-1~5`(차트), `--shadow-ember` (기존 success/danger 재사용) |
| `components.css` | `.stat-value` serif 수치, `.stat-label` mono, `.badge-*` soft variant, `.table th` mono uppercase, `tr:hover` surface-2, `.card` hover shadow |
| `layout.css` | `grid-stats` minmax, `.filter-btn.active` ember-soft, `.search-input` surface-inset |
| `settings.css` | `.settings-tab.active` ember-soft + ember-line |
| `skill-library.css` | `.skill-card` ember 아이콘칩, mono badge, hover ember border |
| `light-theme.css` | 신규 시맨틱 토큰 Bone Paper 대응값 |

## 전파 대상 (표준 클래스 사용 확인)
admin·analytics·usage·admin-metrics·alerts·audit·skill-library·mcp-servers·agent-tasks·research·developer·custom-agents·api-keys (14 모듈)

## 검증
- [x] `npm run build:frontend` 통과 (validate-modules → vite build → verify-dist-hash)
- [x] `npm run lint` 통과 (새 에러 0)
- [x] 배포 후 서버 번들에 `--viz-1`·`--shadow-ember`·`--positive-soft` 반영 확인
- [x] 다크/라이트 양쪽 토큰 정합

## 후속 (마크업 추가 필요 — CSS만으론 불가)
- 위저드 `.step/.flow` 스텝 표시기 (딥리서치 페이지)
- 문서 `.toc` 사이드 목차 (API문서 페이지)
- tier 뱃지는 구독/tier 전면 제거(2026-06-19)로 적용 불필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)