### PR TITLE
fix(mcp): current_running 이 이력 누적을 세던 버그 — 최신 transition 기준 수정

### DIFF
--- a/backend/api/src/data/repositories/mcp-admin-monitoring-repository.ts
+++ b/backend/api/src/data/repositories/mcp-admin-monitoring-repository.ts
@@ -52,7 +52,11 @@ export class McpAdminMonitoringRepository {
             `SELECT
                 (SELECT COUNT(*)::text FROM mcp_servers) AS total_servers,
                 (SELECT COUNT(DISTINCT user_id)::text FROM mcp_server_instances) AS total_users,
-                COUNT(*) FILTER (WHERE status IN ('starting','running'))::text AS current_running,
+                (SELECT COUNT(*) FROM (
+                    SELECT DISTINCT ON (mcp_server_id, user_id) status
+                    FROM mcp_server_instances
+                    ORDER BY mcp_server_id, user_id, started_at DESC
+                ) cur WHERE cur.status = 'running')::text AS current_running,
                 COUNT(*)::text AS total_spawned,
                 COUNT(*) FILTER (WHERE status='crashed' AND started_at > NOW() - INTERVAL '24 hours')::text AS crashed_24h,
                 COUNT(*) FILTER (WHERE started_at > NOW() - INTERVAL '24 hours')::text AS spawned_24h

--- a/backend/api/src/data/repositories/mcp-catalog-repository.ts
+++ b/backend/api/src/data/repositories/mcp-catalog-repository.ts
@@ -188,7 +188,11 @@ export class McpCatalogRepository {
             last_error_message: string | null;
         }>(
             `SELECT
-                COUNT(*) FILTER (WHERE status IN ('starting','running'))::text AS current_running,
+                (CASE WHEN (
+                    SELECT status FROM mcp_server_instances
+                    WHERE mcp_server_id = $1 AND user_id = $2
+                    ORDER BY started_at DESC LIMIT 1
+                ) = 'running' THEN 1 ELSE 0 END)::text AS current_running,
                 COUNT(*)::text AS total_spawned,
                 COUNT(*) FILTER (WHERE status='crashed' AND started_at > NOW() - INTERVAL '24 hours')::text AS crashed_24h,
                 AVG(EXTRACT(EPOCH FROM (stopped_at - started_at)))


### PR DESCRIPTION
## 문제
`mcp_server_instances`는 `recordInstanceTransition`이 **매 전이마다 INSERT하는 append-only 이력 테이블**인데, `current_running`을 이렇게 계산하고 있었습니다:
```sql
COUNT(*) FILTER (WHERE status IN ('starting','running'))  -- 전체 이력 COUNT
```
→ 한 달 누적 전이(starting 122 + running 115 = **237**)를 "현재 실행 중"으로 표시. 시간이 갈수록 무한 증가하는 버그. (MCP 테스트 중 발견)

## 수정
- **mcp-admin-monitoring-repository** (global): `DISTINCT ON (server,user)`로 각 인스턴스의 최신 transition이 `'running'`인 것만 COUNT
- **mcp-catalog-repository** (per server+user): 최신 transition이 `'running'`이면 1
- metrics 테스트: currentRunning 기대값을 이력 누적(3) → 현재 인스턴스(1)로 정정 + 회귀 방지 주석 (※ `__tests__`는 git-ignored라 커밋엔 미포함, 로컬 검증)

## 검증
- 실제 DB 현재 running = **2** (구버그 237)
- admin MCP 모니터링 화면 **"현재 실행 중: 2"** 확인 (누적 spawn 243과 명확히 구분)
- metrics 테스트 **13/13 통과**, `tsc` 빌드 통과
- `total_spawned`(243)은 누적 의미가 맞아 변경 없음

## 후속 (별도)
`mcp_server_instances` 이력 **retention 정책 없음**(DELETE는 테스트 코드만) — 무한 증가하므로 오래된 transition 정리(스케줄러/마이그레이션) 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)