### PR TITLE
feat(retention): mcp_server_instances 전이 이력 retention 추가 (#127 후속)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -187,6 +187,11 @@ EXTERNAL_USAGE_RETENTION_DAYS=90
 # type/severity/title/message/data.userId 는 보존.
 # ALERT_PII_RETENTION_DAYS=90
 
+# mcp_server_instances 전이 이력 보존 기간 (일, 기본 30일).
+# append-only lifecycle 전이 이력의 무한 증가 방지. started_at 기준 N일 초과 row 삭제하되
+# 각 (server,user)의 최신 transition 은 보존(current_running 정확성 유지).
+# MCP_INSTANCE_RETENTION_DAYS=30
+
 # audit_logs CSV export 최대 row 수 (admin 전용 GET /api/audit/export).
 # 무거운 query 방어 — 큰 export 는 paged 호출로 분할 권장.
 # AUDIT_CSV_MAX_ROWS=10000

--- a/backend/api/src/data/db-retention.ts
+++ b/backend/api/src/data/db-retention.ts
@@ -13,6 +13,7 @@
  * - consent_logs                    : CONSENT_PII_RETENTION_DAYS(기본 90일) 초과 ip/ua NULL (GDPR Article 5(1)(c))
  * - audit_logs                      : AUDIT_PII_RETENTION_DAYS(기본 90일) 초과 ip/ua NULL + details.actor 제거
  * - alert_history                   : ALERT_PII_RETENTION_DAYS(기본 90일) 초과 data.actor/ipAddress/userAgent 제거
+ * - mcp_server_instances            : MCP_INSTANCE_RETENTION_DAYS(기본 30일) 초과 transition 이력 삭제 (각 server·user 의 최신 transition 은 보존)
  *
  * @module data/db-retention
  */
@@ -148,6 +149,30 @@ async function runRetention(): Promise<void> {
             );
             if ((alertResult.rowCount ?? 0) > 0) {
                 logger.info(`[DbRetention] alert_history PII 익명화 ${alertResult.rowCount}건 완료 (${alertRetentionDays}일 초과)`);
+            }
+        }
+
+        // 9. mcp_server_instances 전이 이력 정리 — append-only 이력(매 lifecycle 전이마다 INSERT)이
+        // 무한 증가하는 것을 방지. 각 (mcp_server_id, user_id) 의 최신 transition row 는 무조건 보존하여
+        // current_running 계산(최신 transition 기준, PR #127)의 정확성을 유지하고,
+        // 그 외 N일(기본 30) 초과 이력만 삭제한다.
+        const mcpInstanceRetentionDays = parseInt(
+            process.env.MCP_INSTANCE_RETENTION_DAYS ?? '30',
+            10,
+        );
+        if (Number.isFinite(mcpInstanceRetentionDays) && mcpInstanceRetentionDays > 0) {
+            const mcpResult = await pool.query(
+                `DELETE FROM mcp_server_instances
+                 WHERE started_at < NOW() - ($1 || ' days')::interval
+                   AND id NOT IN (
+                       SELECT DISTINCT ON (mcp_server_id, user_id) id
+                       FROM mcp_server_instances
+                       ORDER BY mcp_server_id, user_id, started_at DESC
+                   )`,
+                [mcpInstanceRetentionDays.toString()]
+            );
+            if ((mcpResult.rowCount ?? 0) > 0) {
+                logger.info(`[DbRetention] MCP 인스턴스 이력 ${mcpResult.rowCount}건 정리 완료 (${mcpInstanceRetentionDays}일 초과, 최신 transition 보존)`);
             }
         }
 


### PR DESCRIPTION
## 배경
#127에서 밝혀진 대로 `mcp_server_instances`는 `recordInstanceTransition`이 **매 lifecycle 전이마다 INSERT하는 append-only 이력 테이블**입니다. 정리 로직이 없어 무한 증가했습니다(프로덕션 DELETE 부재).

## 변경
`db-retention.ts` 스케줄러(1시간 주기, 부팅 즉시 1회)에 항목 추가:
```sql
DELETE FROM mcp_server_instances
WHERE started_at < NOW() - (N || ' days')::interval
  AND id NOT IN (
      SELECT DISTINCT ON (mcp_server_id, user_id) id
      FROM mcp_server_instances
      ORDER BY mcp_server_id, user_id, started_at DESC
  )
```
- **각 (server,user)의 최신 transition은 무조건 보존** → `current_running` 계산(#127, 최신 transition 기준)의 정확성 유지
- 30일(기본) 초과 과거 이력만 삭제
- `MCP_INSTANCE_RETENTION_DAYS` env (기본 30) + `.env.example` 문서화
- 기존 `startDbRetention`에 통합 — 별도 스케줄러 등록 불필요

## 검증
- 배포 후 retention 즉시 실행: `[DbRetention] MCP 인스턴스 이력 1건 정리 완료 (30일 초과, 최신 transition 보존)`, DB **247→246**
- 사전 쿼리 검증: 삭제 대상에 최신 transition row **0개**(안전), current_running **2 불변**
- `tsc` 빌드 통과, lint 0 에러

## 참고 (1번 web_search Naver — 코드 변경 없음)
`searchNaverNews`/`searchNaverWeb`는 키 가드·403 처리·XML 정리 모두 정상. `Naver:0`은 `NAVER_CLIENT_ID/SECRET` 미설정 때문(`.env.example` placeholder 존재). 키 발급해 설정하면 한국어 뉴스/웹 검색 동작(한도 25,000회/일).

🤖 Generated with [Claude Code](https://claude.com/claude-code)