### PR TITLE
feat(web): apps/web 누락 기능 전수 복구 (인증·skill·agent·mcp·admin·developer)

### DIFF
--- a/apps/web/app/(workspace)/admin/alerts/page.tsx
+++ b/apps/web/app/(workspace)/admin/alerts/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Bell, Plus, AlertTriangle, AlertCircle, Info } from "lucide-react";
+import { Bell, Plus, AlertTriangle, AlertCircle, Info, Check } from "lucide-react";
 import {
   PageHeader,
   Card,
@@ -92,6 +92,24 @@ interface ApiAlert {
 export default function AdminAlertsPage() {
   const [rules, setRules] = useState<AlertRule[]>(RULES);
   const [events, setEvents] = useState<AlertEvent[]>(MOCK_EVENTS);
+  const [acknowledged, setAcknowledged] = useState<Set<string>>(new Set());
+  const [ackLoading, setAckLoading] = useState<Set<string>>(new Set());
+
+  async function handleAcknowledge(id: string) {
+    setAckLoading((prev) => new Set(prev).add(id));
+    try {
+      await ApiClient.post(`/api/admin/alerts/${id}/acknowledge`, {});
+      setAcknowledged((prev) => new Set(prev).add(id));
+    } catch {
+      /* 실패 시 현상 유지 */
+    } finally {
+      setAckLoading((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+  }
 
   useEffect(() => {
     let alive = true;
@@ -178,8 +196,10 @@ export default function AdminAlertsPage() {
               <ol className="relative space-y-4 border-l border-border pl-5">
                 {events.map((e) => {
                   const Icon = SEV_ICON[e.severity];
+                  const isAcked = acknowledged.has(e.id);
+                  const isAcking = ackLoading.has(e.id);
                   return (
-                    <li key={e.id} className="relative">
+                    <li key={e.id} className={cn("relative", isAcked && "opacity-50")}>
                       <span
                         className={cn(
                           "absolute -left-[27px] flex h-5 w-5 items-center justify-center rounded-full bg-surface",
@@ -188,9 +208,27 @@ export default function AdminAlertsPage() {
                       >
                         <Icon className="h-3.5 w-3.5" />
                       </span>
-                      <div className="flex items-center gap-2">
-                        <Badge tone={SEV_TONE[e.severity]}>{SEV_LABEL[e.severity]}</Badge>
-                        <span className="font-mono text-[11px] text-faint">{fmt(e.timestamp)}</span>
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="flex items-center gap-2">
+                          <Badge tone={SEV_TONE[e.severity]}>{SEV_LABEL[e.severity]}</Badge>
+                          <span className="font-mono text-[11px] text-faint">{fmt(e.timestamp)}</span>
+                          {isAcked && (
+                            <Badge tone="success">
+                              <Check className="h-3 w-3" />
+                              확인됨
+                            </Badge>
+                          )}
+                        </div>
+                        {!isAcked && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={isAcking}
+                            onClick={() => handleAcknowledge(e.id)}
+                          >
+                            확인
+                          </Button>
+                        )}
                       </div>
                       <p className="mt-1 text-sm leading-relaxed text-fg-2">{e.message}</p>
                     </li>

--- a/apps/web/app/(workspace)/admin/analytics/page.tsx
+++ b/apps/web/app/(workspace)/admin/analytics/page.tsx
@@ -9,6 +9,9 @@ import {
   CardHeader,
   CardTitle,
   CardContent,
+  Table,
+  Th,
+  Td,
 } from "@/components/ui/primitives";
 import { cn } from "@/lib/utils";
 import { ApiClient } from "@/lib/api-client";
@@ -84,6 +87,31 @@ function fmtTokens(n: number): string {
 const PERIOD_DAYS: Record<Period, number> = { "7d": 7, "30d": 30, "90d": 90 };
 const WEEKDAY = ["일", "월", "화", "수", "목", "금", "토"];
 
+/* ── 비용/행동/에이전트 섹션 타입 ──────────────────────────── */
+interface CostData {
+  dailyCost: number;
+  weeklyCost: number;
+  projectedMonthlyCost: number;
+  modelCosts: { model: string; cost: number; percentage: number }[];
+}
+interface BehaviorData {
+  peakHours: { hour: number; requests: number }[];
+  avgSessionLength: number;
+  topQueries: { query: string; count: number }[];
+  avgQueriesPerSession: number;
+}
+interface AgentRow {
+  agentId: string;
+  agentName: string;
+  totalRequests: number;
+  avgResponseTime: number;
+  successRate: number;
+  avgTokens: number;
+  popularity: number;
+}
+
+function fmtCost(n: number) { return `$${n.toFixed(4)}`; }
+
 export default function AdminAnalyticsPage() {
   const [period, setPeriod] = useState<Period>("7d");
   // 실데이터 오버레이 (가능한 지표만): null 이면 목업 SUMMARY 사용
@@ -92,6 +120,10 @@ export default function AdminAnalyticsPage() {
   // 실데이터 차트: null 이면 목업 DAILY / MODEL_USAGE 사용
   const [liveDaily, setLiveDaily] = useState<{ label: string; value: number }[] | null>(null);
   const [liveModels, setLiveModels] = useState<{ name: string; pct: number; color: string }[] | null>(null);
+  // 추가 섹션 데이터
+  const [costData, setCostData] = useState<CostData | null>(null);
+  const [behaviorData, setBehaviorData] = useState<BehaviorData | null>(null);
+  const [agentsData, setAgentsData] = useState<AgentRow[] | null>(null);
 
   const daily = liveDaily ?? DAILY[period];
   const sum = SUMMARY[period];
@@ -122,6 +154,23 @@ export default function AdminAnalyticsPage() {
     return () => {
       alive = false;
     };
+  }, []);
+
+  // 비용/행동/에이전트 데이터 로드 (마운트 1회)
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      const [costRes, behaviorRes, agentsRes] = await Promise.allSettled([
+        ApiClient.get<{ data: CostData }>("/api/metrics/analytics/cost"),
+        ApiClient.get<{ data: BehaviorData }>("/api/metrics/analytics/behavior"),
+        ApiClient.get<{ data: AgentRow[] }>("/api/metrics/analytics/agents"),
+      ]);
+      if (!alive) return;
+      if (costRes.status === "fulfilled") setCostData(costRes.value?.data ?? null);
+      if (behaviorRes.status === "fulfilled") setBehaviorData(behaviorRes.value?.data ?? null);
+      if (agentsRes.status === "fulfilled") setAgentsData(agentsRes.value?.data ?? null);
+    })();
+    return () => { alive = false; };
   }, []);
 
   // 기간별 일별 대화량 + 모델 비중 실데이터 로드
@@ -271,6 +320,129 @@ export default function AdminAnalyticsPage() {
             </CardContent>
           </Card>
         </div>
+
+        {/* 비용 분석 */}
+        {costData && (
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle>비용 분석</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                <StatCard label="일일 비용" value={fmtCost(costData.dailyCost)} />
+                <StatCard label="주간 비용" value={fmtCost(costData.weeklyCost)} />
+                <StatCard label="월간 예상 비용" value={fmtCost(costData.projectedMonthlyCost)} />
+              </div>
+              {costData.modelCosts.length > 0 && (
+                <Table>
+                  <thead>
+                    <tr>
+                      <Th>모델</Th>
+                      <Th className="text-right">비용</Th>
+                      <Th className="text-right">비중</Th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {costData.modelCosts.map((m) => (
+                      <tr key={m.model}>
+                        <Td className="font-medium text-fg">{m.model}</Td>
+                        <Td className="text-right font-mono text-fg-2">{fmtCost(m.cost)}</Td>
+                        <Td className="text-right font-mono text-muted">{m.percentage.toFixed(1)}%</Td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* 사용자 행동 */}
+        {behaviorData && (
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle>사용자 행동</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <StatCard
+                  label="평균 세션 길이"
+                  value={`${Math.round(behaviorData.avgSessionLength)}분`}
+                />
+                <StatCard
+                  label="세션당 평균 쿼리"
+                  value={behaviorData.avgQueriesPerSession.toFixed(1)}
+                />
+              </div>
+              {behaviorData.peakHours.length > 0 && (
+                <div>
+                  <p className="mb-2 text-xs font-medium text-fg-2">피크 시간대 Top 3</p>
+                  <div className="flex flex-wrap gap-2">
+                    {behaviorData.peakHours.slice(0, 3).map((h) => (
+                      <span
+                        key={h.hour}
+                        className="rounded-md border border-border bg-surface-2 px-2.5 py-1 text-xs text-fg"
+                      >
+                        {String(h.hour).padStart(2, "0")}시 · {h.requests.toLocaleString()} 요청
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {behaviorData.topQueries.length > 0 && (
+                <div>
+                  <p className="mb-2 text-xs font-medium text-fg-2">자주 묻는 쿼리 Top 5</p>
+                  <ol className="space-y-1">
+                    {behaviorData.topQueries.slice(0, 5).map((q, i) => (
+                      <li key={i} className="flex items-center gap-2 text-xs text-fg-2">
+                        <span className="w-4 shrink-0 font-mono text-faint">{i + 1}.</span>
+                        <span className="truncate">{q.query}</span>
+                        <span className="ml-auto shrink-0 font-mono text-muted">{q.count}</span>
+                      </li>
+                    ))}
+                  </ol>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* 에이전트 성능 */}
+        {agentsData && agentsData.length > 0 && (
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle>에이전트 성능</CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              <Table>
+                <thead>
+                  <tr>
+                    <Th>에이전트</Th>
+                    <Th className="text-right">요청 수</Th>
+                    <Th className="text-right">성공률</Th>
+                    <Th className="text-right">평균 응답</Th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {agentsData.map((a) => (
+                    <tr key={a.agentId}>
+                      <Td className="font-medium text-fg">{a.agentName}</Td>
+                      <Td className="text-right font-mono text-fg-2">
+                        {a.totalRequests.toLocaleString()}
+                      </Td>
+                      <Td className="text-right font-mono text-fg-2">
+                        {(a.successRate * 100).toFixed(1)}%
+                      </Td>
+                      <Td className="text-right font-mono text-fg-2">
+                        {Math.round(a.avgResponseTime)}ms
+                      </Td>
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+            </CardContent>
+          </Card>
+        )}
       </div>
     </>
   );

--- a/apps/web/app/(workspace)/admin/audit/page.tsx
+++ b/apps/web/app/(workspace)/admin/audit/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { ScrollText } from "lucide-react";
+import { ScrollText, Download } from "lucide-react";
 import {
   PageHeader,
   Card,
   CardContent,
   Badge,
+  Button,
   Table,
   Th,
   Td,
@@ -136,9 +137,19 @@ export default function AdminAuditPage() {
         title="감사 로그"
         description="시스템 전반의 보안·관리 활동 기록입니다."
         actions={
-          <Badge tone="neutral">
-            <ScrollText className="h-3.5 w-3.5" /> {filtered.length}건
-          </Badge>
+          <div className="flex items-center gap-2">
+            <Badge tone="neutral">
+              <ScrollText className="h-3.5 w-3.5" /> {filtered.length}건
+            </Badge>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => { window.location.href = "/api/audit/export"; }}
+            >
+              <Download className="h-4 w-4" />
+              CSV 내보내기
+            </Button>
+          </div>
         }
       />
 

--- a/apps/web/app/(workspace)/admin/mcp-catalog/page.tsx
+++ b/apps/web/app/(workspace)/admin/mcp-catalog/page.tsx
@@ -1,0 +1,390 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Boxes, Plus, Pencil, Trash2, X, Loader2 } from "lucide-react";
+import {
+  PageHeader,
+  Card,
+  CardContent,
+  Badge,
+  Button,
+  Table,
+  Th,
+  Td,
+} from "@/components/ui/primitives";
+import type { ApiSuccess as ApiEnvelope } from "@openmake/shared-types";
+import { ApiClient } from "@/lib/api-client";
+
+type TransportType = "stdio" | "sse" | "streamable-http";
+
+interface CatalogTemplate {
+  id: string;
+  display_name: string;
+  description?: string;
+  transport_type: TransportType;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  is_enabled: boolean;
+}
+
+const TRANSPORT_LABEL: Record<TransportType, string> = {
+  stdio: "stdio",
+  sse: "SSE",
+  "streamable-http": "HTTP",
+};
+
+const inputCls = "h-9 w-full rounded-md border border-border bg-surface-2 px-3 text-sm text-fg placeholder:text-faint focus:border-accent focus:outline-none";
+const selectCls = "h-9 w-full rounded-md border border-border bg-surface-2 px-3 text-sm text-fg focus:border-accent focus:outline-none";
+const textareaCls = "w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-fg placeholder:text-faint focus:border-accent focus:outline-none resize-none";
+const labelCls = "block text-xs font-medium text-fg-2 mb-1";
+
+/* ── 모달 공통 래퍼 ─────────────────────────────────────────── */
+function Modal({ onClose, children }: { onClose: () => void; children: React.ReactNode }) {
+  return (
+    <div
+      role="dialog"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onClick={(ev) => { if (ev.currentTarget === ev.target) onClose(); }}
+    >
+      <div
+        className="relative mx-4 w-full max-w-lg rounded-lg bg-surface p-6 shadow-xl max-h-[90vh] overflow-y-auto"
+        onClick={(ev) => ev.stopPropagation()}
+      >
+        <button
+          onClick={onClose}
+          className="absolute right-4 top-4 text-faint hover:text-fg"
+          aria-label="닫기"
+        >
+          <X className="h-4 w-4" />
+        </button>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/* ── 생성/편집 폼 ─────────────────────────────────────────────── */
+interface TemplateFormProps {
+  initial?: CatalogTemplate;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+function TemplateFormModal({ initial, onClose, onSaved }: TemplateFormProps) {
+  const isEdit = Boolean(initial);
+  const [id, setId] = useState(initial?.id ?? "");
+  const [displayName, setDisplayName] = useState(initial?.display_name ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [transportType, setTransportType] = useState<TransportType>(initial?.transport_type ?? "stdio");
+  const [command, setCommand] = useState(initial?.command ?? "");
+  const [url, setUrl] = useState(initial?.url ?? "");
+  const [isEnabled, setIsEnabled] = useState(initial?.is_enabled ?? true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(ev: React.FormEvent) {
+    ev.preventDefault();
+    setSubmitting(true);
+    setError("");
+    try {
+      const body: Record<string, unknown> = {
+        display_name: displayName,
+        description: description || undefined,
+        transport_type: transportType,
+        command: command || undefined,
+        url: url || undefined,
+        is_enabled: isEnabled,
+      };
+      if (isEdit && initial) {
+        await ApiClient.put(`/api/admin/mcp/catalog/${initial.id}`, body);
+      } else {
+        await ApiClient.post("/api/admin/mcp/catalog", { id, ...body });
+      }
+      onSaved();
+      onClose();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "저장 실패. 다시 시도해 주세요.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal onClose={onClose}>
+      <h2 className="mb-4 text-base font-semibold text-fg">
+        {isEdit ? "템플릿 편집" : "새 템플릿"}
+      </h2>
+      <form onSubmit={handleSubmit} className="space-y-3">
+        {!isEdit && (
+          <div>
+            <label className={labelCls}>ID *</label>
+            <input
+              className={inputCls}
+              required
+              value={id}
+              onChange={(e) => setId(e.target.value)}
+              placeholder="mcp-my-server"
+            />
+          </div>
+        )}
+        <div>
+          <label className={labelCls}>표시 이름 *</label>
+          <input
+            className={inputCls}
+            required
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="My MCP Server"
+          />
+        </div>
+        <div>
+          <label className={labelCls}>설명</label>
+          <textarea
+            className={textareaCls}
+            rows={2}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="서버에 대한 간략한 설명"
+          />
+        </div>
+        <div>
+          <label className={labelCls}>유형 *</label>
+          <select
+            className={selectCls}
+            value={transportType}
+            onChange={(e) => setTransportType(e.target.value as TransportType)}
+          >
+            <option value="stdio">stdio</option>
+            <option value="sse">SSE</option>
+            <option value="streamable-http">streamable-http</option>
+          </select>
+        </div>
+        {transportType === "stdio" && (
+          <div>
+            <label className={labelCls}>명령어</label>
+            <input
+              className={inputCls}
+              value={command}
+              onChange={(e) => setCommand(e.target.value)}
+              placeholder="npx -y @modelcontextprotocol/server-…"
+            />
+          </div>
+        )}
+        {(transportType === "sse" || transportType === "streamable-http") && (
+          <div>
+            <label className={labelCls}>URL</label>
+            <input
+              className={inputCls}
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://example.com/mcp"
+            />
+          </div>
+        )}
+        <div className="flex items-center gap-2">
+          <input
+            id="is_enabled"
+            type="checkbox"
+            checked={isEnabled}
+            onChange={(e) => setIsEnabled(e.target.checked)}
+            className="h-4 w-4 accent-accent"
+          />
+          <label htmlFor="is_enabled" className="text-sm text-fg-2">활성화</label>
+        </div>
+        {error && <p className="text-xs text-danger">{error}</p>}
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="outline" size="sm" onClick={onClose}>취소</Button>
+          <Button type="submit" size="sm" disabled={submitting}>
+            {submitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            {isEdit ? "저장" : "생성"}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+/* ── 삭제 확인 모달 ─────────────────────────────────────────── */
+function DeleteTemplateModal({
+  template,
+  onClose,
+  onDeleted,
+}: {
+  template: CatalogTemplate;
+  onClose: () => void;
+  onDeleted: () => void;
+}) {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleDelete() {
+    setSubmitting(true);
+    setError("");
+    try {
+      await ApiClient.del(`/api/admin/mcp/catalog/${template.id}`);
+      onDeleted();
+      onClose();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "삭제 실패. 다시 시도해 주세요.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal onClose={onClose}>
+      <h2 className="mb-2 text-base font-semibold text-fg">템플릿 삭제</h2>
+      <p className="mb-1 text-sm text-fg-2">정말 삭제하시겠습니까?</p>
+      <p className="mb-4 font-mono text-xs text-muted">{template.id}</p>
+      {error && <p className="mb-3 text-xs text-danger">{error}</p>}
+      <div className="flex justify-end gap-2">
+        <Button variant="outline" size="sm" onClick={onClose} disabled={submitting}>취소</Button>
+        <Button variant="danger" size="sm" onClick={handleDelete} disabled={submitting}>
+          {submitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+          삭제
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+/* ── 페이지 ─────────────────────────────────────────────────── */
+export default function AdminMcpCatalogPage() {
+  const [templates, setTemplates] = useState<CatalogTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showCreate, setShowCreate] = useState(false);
+  const [editTemplate, setEditTemplate] = useState<CatalogTemplate | null>(null);
+  const [deleteTemplate, setDeleteTemplate] = useState<CatalogTemplate | null>(null);
+
+  async function loadTemplates() {
+    try {
+      const res = await ApiClient.get<ApiEnvelope<{ templates: CatalogTemplate[]; total: number }>>(
+        "/api/admin/mcp/catalog",
+      );
+      setTemplates(res?.data?.templates ?? []);
+    } catch {
+      /* 401/실패 시 빈 목록 유지 */
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadTemplates();
+  }, []);
+
+  return (
+    <>
+      <PageHeader
+        title="MCP 카탈로그 관리"
+        description="사용자에게 제공되는 MCP 서버 템플릿을 관리합니다."
+        actions={
+          <Button size="sm" onClick={() => setShowCreate(true)}>
+            <Plus className="h-4 w-4" />
+            템플릿 추가
+          </Button>
+        }
+      />
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-6">
+        <Card className="overflow-hidden">
+          <CardContent className="p-0">
+            <Table>
+              <thead>
+                <tr>
+                  <Th>ID</Th>
+                  <Th>이름</Th>
+                  <Th>설명</Th>
+                  <Th>유형</Th>
+                  <Th>활성여부</Th>
+                  <Th>액션</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading ? (
+                  <tr>
+                    <Td colSpan={6}>
+                      <div className="py-12 text-center text-muted">로딩 중…</div>
+                    </Td>
+                  </tr>
+                ) : templates.length === 0 ? (
+                  <tr>
+                    <Td colSpan={6}>
+                      <div className="flex flex-col items-center gap-3 py-12">
+                        <Boxes className="h-8 w-8 text-faint" />
+                        <p className="text-sm text-muted">등록된 템플릿이 없습니다.</p>
+                      </div>
+                    </Td>
+                  </tr>
+                ) : (
+                  templates.map((t) => (
+                    <tr key={t.id} className="transition hover:bg-surface-2">
+                      <Td className="font-mono text-xs text-muted">{t.id}</Td>
+                      <Td className="font-medium text-fg">{t.display_name}</Td>
+                      <Td className="max-w-xs truncate text-xs text-fg-2">{t.description ?? "-"}</Td>
+                      <Td>
+                        <Badge tone="neutral">
+                          <span className="font-mono">{TRANSPORT_LABEL[t.transport_type]}</span>
+                        </Badge>
+                      </Td>
+                      <Td>
+                        <Badge tone={t.is_enabled ? "success" : "neutral"}>
+                          {t.is_enabled ? "활성" : "비활성"}
+                        </Badge>
+                      </Td>
+                      <Td>
+                        <div className="flex items-center gap-1">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => setEditTemplate(t)}
+                            aria-label="편집"
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => setDeleteTemplate(t)}
+                            aria-label="삭제"
+                            className="text-danger hover:text-danger"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        </div>
+                      </Td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+
+      {showCreate && (
+        <TemplateFormModal
+          onClose={() => setShowCreate(false)}
+          onSaved={loadTemplates}
+        />
+      )}
+      {editTemplate && (
+        <TemplateFormModal
+          initial={editTemplate}
+          onClose={() => setEditTemplate(null)}
+          onSaved={loadTemplates}
+        />
+      )}
+      {deleteTemplate && (
+        <DeleteTemplateModal
+          template={deleteTemplate}
+          onClose={() => setDeleteTemplate(null)}
+          onDeleted={loadTemplates}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/app/(workspace)/admin/metrics/page.tsx
+++ b/apps/web/app/(workspace)/admin/metrics/page.tsx
@@ -57,6 +57,22 @@ const TIMESERIES = Array.from({ length: 24 }, (_, h) => ({
 
 type Cat = { id?: string; name?: string; status?: string; latency?: number | string };
 
+/* ── 에이전트 메트릭 타입 ───────────────────────────────────── */
+interface AgentMetric {
+  agentId: string;
+  requests: number;
+  successCount: number;
+  totalResponseTime: number;
+  totalTokens: number;
+}
+interface AgentSummary {
+  totalAgents: number;
+  totalRequests: number;
+  avgSuccessRate: number;
+  avgResponseTime: number;
+  mostUsedAgent: string | null;
+}
+
 const STATUS_MAP: Record<string, NodeStatus> = {
   online: "online",
   offline: "offline",
@@ -69,6 +85,8 @@ export default function AdminMetricsPage() {
   const [nodes, setNodes] = useState<NodeRow[]>(NODES);
   const [cpu, setCpu] = useState<string | null>(null);
   const [mem, setMem] = useState<{ value: string; delta: string } | null>(null);
+  const [agentSummary, setAgentSummary] = useState<AgentSummary | null>(null);
+  const [agentMetrics, setAgentMetrics] = useState<AgentMetric[] | null>(null);
   const maxV = Math.max(...TIMESERIES.map((t) => t.value));
 
   const load = useCallback(async () => {
@@ -115,6 +133,20 @@ export default function AdminMetricsPage() {
             value: `${(sys.memory.used / 1024).toFixed(1)} GB`,
             delta: `총 ${(sys.memory.total / 1024).toFixed(1)} GB 중`,
           });
+        }
+      }
+      // 에이전트 메트릭 로드
+      const [agentSummaryRes, agentMetricsRes] = await Promise.allSettled([
+        ApiClient.get<{ data: { summary: AgentSummary } }>("/api/agents-monitoring/summary"),
+        ApiClient.get<{ data: { metrics: Record<string, AgentMetric> } }>("/api/agents-monitoring/metrics"),
+      ]);
+      if (agentSummaryRes.status === "fulfilled") {
+        setAgentSummary(agentSummaryRes.value?.data?.summary ?? null);
+      }
+      if (agentMetricsRes.status === "fulfilled") {
+        const raw = agentMetricsRes.value?.data?.metrics;
+        if (raw) {
+          setAgentMetrics(Object.values(raw));
         }
       }
     } catch {
@@ -208,6 +240,74 @@ export default function AdminMetricsPage() {
             </Table>
           </CardContent>
         </Card>
+        {/* 에이전트 메트릭 */}
+        {(agentSummary || (agentMetrics && agentMetrics.length > 0)) && (
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle>에이전트 메트릭</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {agentSummary && (
+                <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+                  <StatCard
+                    label="총 에이전트"
+                    value={String(agentSummary.totalAgents)}
+                  />
+                  <StatCard
+                    label="총 요청"
+                    value={agentSummary.totalRequests.toLocaleString()}
+                  />
+                  <StatCard
+                    label="평균 성공률"
+                    value={`${(agentSummary.avgSuccessRate * 100).toFixed(1)}%`}
+                  />
+                  <StatCard
+                    label="평균 응답시간"
+                    value={`${Math.round(agentSummary.avgResponseTime)}ms`}
+                  />
+                </div>
+              )}
+              {agentMetrics && agentMetrics.length > 0 && (
+                <Table>
+                  <thead>
+                    <tr>
+                      <Th>에이전트 ID</Th>
+                      <Th className="text-right">요청 수</Th>
+                      <Th className="text-right">성공률</Th>
+                      <Th className="text-right">평균 응답시간</Th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {agentMetrics.map((m) => {
+                      const successRate =
+                        m.requests > 0
+                          ? Math.round((m.successCount / m.requests) * 100)
+                          : 0;
+                      const avgRt =
+                        m.requests > 0
+                          ? Math.round(m.totalResponseTime / m.requests)
+                          : 0;
+                      return (
+                        <tr key={m.agentId}>
+                          <Td className="font-mono text-xs text-fg">{m.agentId}</Td>
+                          <Td className="text-right font-mono text-fg-2">
+                            {m.requests.toLocaleString()}
+                          </Td>
+                          <Td className="text-right font-mono text-fg-2">
+                            {successRate}%
+                          </Td>
+                          <Td className="text-right font-mono text-fg-2">
+                            {avgRt}ms
+                          </Td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+        )}
       </div>
     </>
   );

--- a/apps/web/app/(workspace)/admin/page.tsx
+++ b/apps/web/app/(workspace)/admin/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { Shield, Users, Boxes, Gauge, ArrowRight } from "lucide-react";
+import { Shield, Users, Boxes, Gauge, ArrowRight, Pencil, Trash2, Plus, X, Loader2 } from "lucide-react";
 import {
   PageHeader,
   StatCard,
@@ -11,6 +11,7 @@ import {
   CardTitle,
   CardContent,
   Badge,
+  Button,
   Table,
   Th,
   Td,
@@ -20,10 +21,17 @@ import { ApiClient } from "@/lib/api-client";
 interface AdminUser {
   id: string;
   email: string;
+  name?: string;
   role: "admin" | "user" | "guest";
   is_active: boolean;
   created_at: string;
   last_login?: string | null;
+}
+
+interface GuardianPending {
+  id: string;
+  email: string;
+  created_at: string;
 }
 
 const ROLE_LABEL: Record<string, string> = {
@@ -37,7 +45,6 @@ const ROLE_TONE: Record<string, "danger" | "success" | "neutral"> = {
   guest: "neutral",
 };
 
-// /api/admin/users·/users/stats·/stats 실데이터로 교체, 401/실패 시 폴백 목업.
 const MOCK_USERS: AdminUser[] = [
   { id: "u_1042", email: "minji.kim@openmake.io", role: "user", is_active: true, created_at: "2026-06-19T09:12:00Z", last_login: "2026-06-21T02:30:00Z" },
   { id: "u_1041", email: "devops@partner.co.kr", role: "admin", is_active: true, created_at: "2026-06-18T15:40:00Z", last_login: "2026-06-20T22:05:00Z" },
@@ -58,9 +65,261 @@ const QUICK_LINKS = [
   { href: "/admin/metrics", title: "시스템 상태", desc: "노드·서비스 헬스 모니터링", icon: Gauge },
 ];
 
+/* ── 모달 공통 래퍼 ─────────────────────────────────────────── */
+function Modal({ onClose, children }: { onClose: () => void; children: React.ReactNode }) {
+  const backdropRef = useRef<HTMLDivElement>(null);
+  return (
+    <div
+      role="dialog"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      ref={backdropRef}
+      onClick={(ev) => { if (ev.target === backdropRef.current) onClose(); }}
+    >
+      <div className="relative mx-4 w-full max-w-md rounded-lg bg-surface p-6 shadow-xl">
+        <button
+          onClick={onClose}
+          className="absolute right-4 top-4 text-faint hover:text-fg"
+          aria-label="닫기"
+        >
+          <X className="h-4 w-4" />
+        </button>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+const inputCls = "h-9 w-full rounded-md border border-border bg-surface-2 px-3 text-sm text-fg placeholder:text-faint focus:border-accent focus:outline-none";
+const selectCls = "h-9 w-full rounded-md border border-border bg-surface-2 px-3 text-sm text-fg focus:border-accent focus:outline-none";
+const labelCls = "block text-xs font-medium text-fg-2 mb-1";
+
+/* ── 생성 모달 ───────────────────────────────────────────────── */
+function CreateUserModal({
+  onClose,
+  onCreated,
+}: {
+  onClose: () => void;
+  onCreated: () => void;
+}) {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<"admin" | "user" | "guest">("user");
+  const [password, setPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(ev: React.FormEvent) {
+    ev.preventDefault();
+    setSubmitting(true);
+    setError("");
+    try {
+      await ApiClient.post("/api/admin/users", { name: name || undefined, email, role, password });
+      onCreated();
+      onClose();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "생성 실패. 다시 시도해 주세요.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal onClose={onClose}>
+      <h2 className="mb-4 text-base font-semibold text-fg">사용자 추가</h2>
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <div>
+          <label className={labelCls}>이름 (선택)</label>
+          <input className={inputCls} value={name} onChange={(e) => setName(e.target.value)} placeholder="홍길동" />
+        </div>
+        <div>
+          <label className={labelCls}>이메일 *</label>
+          <input className={inputCls} type="email" required value={email} onChange={(e) => setEmail(e.target.value)} placeholder="user@example.com" />
+        </div>
+        <div>
+          <label className={labelCls}>역할 *</label>
+          <select className={selectCls} value={role} onChange={(e) => setRole(e.target.value as "admin" | "user" | "guest")}>
+            <option value="user">사용자</option>
+            <option value="admin">관리자</option>
+            <option value="guest">게스트</option>
+          </select>
+        </div>
+        <div>
+          <label className={labelCls}>비밀번호 *</label>
+          <input className={inputCls} type="password" required value={password} onChange={(e) => setPassword(e.target.value)} placeholder="••••••••" />
+        </div>
+        {error && <p className="text-xs text-danger">{error}</p>}
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="outline" size="sm" onClick={onClose}>취소</Button>
+          <Button type="submit" size="sm" disabled={submitting}>
+            {submitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            생성
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+/* ── 편집 모달 ───────────────────────────────────────────────── */
+function EditUserModal({
+  user,
+  onClose,
+  onUpdated,
+}: {
+  user: AdminUser;
+  onClose: () => void;
+  onUpdated: () => void;
+}) {
+  const [role, setRole] = useState<"admin" | "user" | "guest">(user.role);
+  const [isActive, setIsActive] = useState(user.is_active);
+  const [password, setPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(ev: React.FormEvent) {
+    ev.preventDefault();
+    setSubmitting(true);
+    setError("");
+    try {
+      const body: Record<string, unknown> = { role, is_active: isActive };
+      if (password) body.password = password;
+      await ApiClient.put(`/api/admin/users/${user.id}`, body);
+      onUpdated();
+      onClose();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "수정 실패. 다시 시도해 주세요.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal onClose={onClose}>
+      <h2 className="mb-1 text-base font-semibold text-fg">사용자 편집</h2>
+      <p className="mb-4 text-xs text-muted">{user.email}</p>
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <div>
+          <label className={labelCls}>역할</label>
+          <select className={selectCls} value={role} onChange={(e) => setRole(e.target.value as "admin" | "user" | "guest")}>
+            <option value="user">사용자</option>
+            <option value="admin">관리자</option>
+            <option value="guest">게스트</option>
+          </select>
+        </div>
+        <div>
+          <label className={labelCls}>상태</label>
+          <select className={selectCls} value={isActive ? "active" : "inactive"} onChange={(e) => setIsActive(e.target.value === "active")}>
+            <option value="active">활성</option>
+            <option value="inactive">비활성</option>
+          </select>
+        </div>
+        <div>
+          <label className={labelCls}>새 비밀번호 (선택)</label>
+          <input className={inputCls} type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="변경하지 않으려면 비워두세요" />
+        </div>
+        {error && <p className="text-xs text-danger">{error}</p>}
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="outline" size="sm" onClick={onClose}>취소</Button>
+          <Button type="submit" size="sm" disabled={submitting}>
+            {submitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            저장
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+/* ── 삭제 확인 모달 ─────────────────────────────────────────── */
+function DeleteUserModal({
+  user,
+  onClose,
+  onDeleted,
+}: {
+  user: AdminUser;
+  onClose: () => void;
+  onDeleted: () => void;
+}) {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleDelete() {
+    setSubmitting(true);
+    setError("");
+    try {
+      await ApiClient.del(`/api/admin/users/${user.id}`);
+      onDeleted();
+      onClose();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "삭제 실패. 다시 시도해 주세요.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal onClose={onClose}>
+      <h2 className="mb-2 text-base font-semibold text-fg">사용자 삭제</h2>
+      <p className="mb-1 text-sm text-fg-2">정말 삭제하시겠습니까?</p>
+      <p className="mb-4 text-xs text-muted font-mono">{user.email}</p>
+      {error && <p className="mb-3 text-xs text-danger">{error}</p>}
+      <div className="flex justify-end gap-2">
+        <Button variant="outline" size="sm" onClick={onClose} disabled={submitting}>취소</Button>
+        <Button variant="danger" size="sm" onClick={handleDelete} disabled={submitting}>
+          {submitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+          삭제
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
 export default function AdminPage() {
   const [users, setUsers] = useState<AdminUser[]>(MOCK_USERS);
   const [stats, setStats] = useState({ total: 1042, active: 318, today: 4821, status: "정상" });
+  const [guardianPending, setGuardianPending] = useState<GuardianPending[]>([]);
+  const [approvingIds, setApprovingIds] = useState<Set<string>>(new Set());
+
+  // Modal state
+  const [showCreate, setShowCreate] = useState(false);
+  const [editUser, setEditUser] = useState<AdminUser | null>(null);
+  const [deleteUser, setDeleteUser] = useState<AdminUser | null>(null);
+
+  async function loadUsers() {
+    try {
+      const res = await ApiClient.get<{ data?: { users?: AdminUser[] }; users?: AdminUser[] }>("/api/admin/users?limit=8");
+      const list = (res.data?.users || (res as { users?: AdminUser[] }).users) ?? [];
+      if (list.length) setUsers(list);
+    } catch {
+      /* 목업 유지 */
+    }
+  }
+
+  async function loadGuardianPending() {
+    try {
+      const res = await ApiClient.get<{ data?: { users?: GuardianPending[] }; users?: GuardianPending[] }>("/api/admin/guardian-consent-pending");
+      const list = (res.data?.users || (res as { users?: GuardianPending[] }).users) ?? [];
+      setGuardianPending(list);
+    } catch {
+      /* 미표시 */
+    }
+  }
+
+  async function approveGuardian(id: string) {
+    setApprovingIds((prev) => new Set(prev).add(id));
+    try {
+      await ApiClient.post(`/api/admin/users/${id}/guardian-verify`, {});
+      setGuardianPending((prev) => prev.filter((u) => u.id !== id));
+    } catch {
+      /* 실패 시 목록 유지 */
+    } finally {
+      setApprovingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+  }
 
   useEffect(() => {
     let alive = true;
@@ -73,15 +332,15 @@ export default function AdminPage() {
         ]);
         if (!alive) return;
         if (u.status === "fulfilled") {
-          const list = (u.value.data?.users || u.value.users) ?? [];
+          const list = (u.value.data?.users || (u.value as { users?: AdminUser[] }).users) ?? [];
           if (list.length) setUsers(list);
         }
         if (us.status === "fulfilled") {
           const p = us.value.data ?? (us.value as Record<string, number>);
           setStats((s) => ({
             ...s,
-            total: p.totalUsers ?? s.total,
-            active: p.activeUsers ?? s.active,
+            total: (p as Record<string, number>).totalUsers ?? s.total,
+            active: (p as Record<string, number>).activeUsers ?? s.active,
           }));
         }
         if (st.status === "fulfilled") {
@@ -92,6 +351,7 @@ export default function AdminPage() {
         /* 목업 유지 */
       }
     })();
+    void loadGuardianPending();
     return () => {
       alive = false;
     };
@@ -103,9 +363,15 @@ export default function AdminPage() {
         title="관리자 대시보드"
         description="사용자, 모델, 시스템 상태를 한 곳에서 관리합니다."
         actions={
-          <Badge tone="danger">
-            <Shield className="h-3.5 w-3.5" /> 관리자 전용
-          </Badge>
+          <div className="flex items-center gap-2">
+            <Badge tone="danger">
+              <Shield className="h-3.5 w-3.5" /> 관리자 전용
+            </Badge>
+            <Button size="sm" onClick={() => setShowCreate(true)}>
+              <Plus className="h-4 w-4" />
+              사용자 추가
+            </Button>
+          </div>
         }
       />
 
@@ -155,6 +421,7 @@ export default function AdminPage() {
                   <Th>상태</Th>
                   <Th>가입일</Th>
                   <Th>마지막 로그인</Th>
+                  <Th>액션</Th>
                 </tr>
               </thead>
               <tbody>
@@ -170,13 +437,95 @@ export default function AdminPage() {
                     </Td>
                     <Td>{fmtDate(u.created_at)}</Td>
                     <Td className="text-muted">{u.last_login ? fmtDate(u.last_login) : "-"}</Td>
+                    <Td>
+                      <div className="flex items-center gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => setEditUser(u)}
+                          aria-label="편집"
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => setDeleteUser(u)}
+                          aria-label="삭제"
+                          className="text-danger hover:text-danger"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    </Td>
                   </tr>
                 ))}
               </tbody>
             </Table>
           </CardContent>
         </Card>
+
+        {/* M8: 미성년자 동의 보류 섹션 */}
+        {guardianPending.length > 0 && (
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle>미성년자 동의 보류</CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              <Table>
+                <thead>
+                  <tr>
+                    <Th>이메일</Th>
+                    <Th>가입일</Th>
+                    <Th>액션</Th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {guardianPending.map((u) => (
+                    <tr key={u.id}>
+                      <Td className="text-fg">{u.email}</Td>
+                      <Td className="text-muted">{fmtDate(u.created_at)}</Td>
+                      <Td>
+                        <Button
+                          size="sm"
+                          disabled={approvingIds.has(u.id)}
+                          onClick={() => approveGuardian(u.id)}
+                        >
+                          {approvingIds.has(u.id) && (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                          )}
+                          승인
+                        </Button>
+                      </Td>
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+            </CardContent>
+          </Card>
+        )}
       </div>
+
+      {showCreate && (
+        <CreateUserModal
+          onClose={() => setShowCreate(false)}
+          onCreated={loadUsers}
+        />
+      )}
+      {editUser && (
+        <EditUserModal
+          user={editUser}
+          onClose={() => setEditUser(null)}
+          onUpdated={loadUsers}
+        />
+      )}
+      {deleteUser && (
+        <DeleteUserModal
+          user={deleteUser}
+          onClose={() => setDeleteUser(null)}
+          onDeleted={loadUsers}
+        />
+      )}
     </>
   );
 }

--- a/apps/web/app/(workspace)/agent-learning/page.tsx
+++ b/apps/web/app/(workspace)/agent-learning/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { GraduationCap, ThumbsUp, ThumbsDown } from "lucide-react";
+import { GraduationCap, ThumbsUp, ThumbsDown, Loader2 } from "lucide-react";
 import {
   Badge,
   PageHeader,
@@ -14,12 +14,39 @@ import {
 import type { ApiSuccess as ApiEnvelope } from "@openmake/shared-types";
 import { ApiClient } from "@/lib/api-client";
 
-/* ── 백엔드 응답 타입 (GET /api/agents/feedback/stats) ─────── */
+/* ── 백엔드 응답 타입 ────────────────────────────────────── */
 interface ApiFeedbackStats {
   totalFeedbacks: number;
   avgRating: number;
   topAgents?: { agentId: string; score: number }[];
   worstAgents?: { agentId: string; score: number }[];
+}
+
+interface ApiQualityScore {
+  agentId: string;
+  score?: number;
+  totalFeedbacks?: number;
+  avgRating?: number;
+  [key: string]: unknown;
+}
+
+interface ApiFailurePattern {
+  pattern?: string;
+  count?: number;
+  [key: string]: unknown;
+}
+
+interface ApiImprovement {
+  suggestion?: string;
+  priority?: string;
+  [key: string]: unknown;
+}
+
+interface ApiSystemAgent {
+  id: string;
+  name: string;
+  emoji?: string;
+  category?: string;
 }
 
 /* ── 타입 ────────────────────────────────────────────────── */
@@ -33,96 +60,182 @@ interface LearningItem {
   status: LearningStatus;
 }
 
-/* ── 목업 데이터 ──────────────────────────────────────────
- * "수집 피드백" StatCard 는 GET /api/agents/feedback/stats 의 totalFeedbacks
- * 로 실연동. "반영 개선"·"대기" 는 백엔드에 해당 집계가 없어 목업 유지.
- * 하단 "학습 항목" 리스트(topic+👍/👎+상태)도 백엔드에 동등 엔드포인트가
- * 없어 목업 유지. (stats 는 topAgents/worstAgents 만 제공 — 형태 불일치)
- */
-const SUMMARY = {
-  collected: "1,284",
-  applied: "37",
-  pending: "12",
-};
-
-const ITEMS: LearningItem[] = [
-  {
-    id: 1,
-    topic: "코드 리뷰 응답의 근거 인용 강화",
-    positive: 142,
-    negative: 18,
-    status: "applied",
-  },
-  {
-    id: 2,
-    topic: "한국어 존댓말 일관성 유지",
-    positive: 98,
-    negative: 7,
-    status: "applied",
-  },
-  {
-    id: 3,
-    topic: "딥 리서치 출처 신뢰도 표기",
-    positive: 64,
-    negative: 21,
-    status: "reviewing",
-  },
-  {
-    id: 4,
-    topic: "장문 요약 시 핵심 누락 감소",
-    positive: 51,
-    negative: 33,
-    status: "reviewing",
-  },
-  {
-    id: 5,
-    topic: "도구 호출 실패 시 사용자 안내 개선",
-    positive: 29,
-    negative: 44,
-    status: "pending",
-  },
-  {
-    id: 6,
-    topic: "수치 계산 검산 단계 추가",
-    positive: 18,
-    negative: 12,
-    status: "pending",
-  },
+/* ── 목업 데이터 ──────────────────────────────────────────── */
+const ITEMS_FALLBACK: LearningItem[] = [
+  { id: 1, topic: "코드 리뷰 응답의 근거 인용 강화", positive: 142, negative: 18, status: "applied" },
+  { id: 2, topic: "한국어 존댓말 일관성 유지", positive: 98, negative: 7, status: "applied" },
+  { id: 3, topic: "딥 리서치 출처 신뢰도 표기", positive: 64, negative: 21, status: "reviewing" },
+  { id: 4, topic: "장문 요약 시 핵심 누락 감소", positive: 51, negative: 33, status: "reviewing" },
+  { id: 5, topic: "도구 호출 실패 시 사용자 안내 개선", positive: 29, negative: 44, status: "pending" },
+  { id: 6, topic: "수치 계산 검산 단계 추가", positive: 18, negative: 12, status: "pending" },
 ];
 
-const STATUS_META: Record<
-  LearningStatus,
-  { label: string; tone: "success" | "warn" | "neutral" }
-> = {
+const STATUS_META: Record<LearningStatus, { label: string; tone: "success" | "warn" | "neutral" }> = {
   applied: { label: "반영됨", tone: "success" },
   reviewing: { label: "검토 중", tone: "warn" },
   pending: { label: "대기", tone: "neutral" },
 };
 
+/* ── 에이전트별 품질 패널 ─────────────────────────────────── */
+function AgentDetailPanel({ agentId }: { agentId: string }) {
+  const [quality, setQuality] = useState<ApiQualityScore | null>(null);
+  const [failures, setFailures] = useState<ApiFailurePattern[]>([]);
+  const [improvements, setImprovements] = useState<ApiImprovement[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!agentId) return;
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      try {
+        const [qRes, fRes, iRes] = await Promise.allSettled([
+          ApiClient.get<ApiEnvelope<ApiQualityScore>>(`/api/agents/${agentId}/quality`),
+          ApiClient.get<ApiEnvelope<ApiFailurePattern[]>>(`/api/agents/${agentId}/failures`),
+          ApiClient.get<ApiEnvelope<ApiImprovement[]>>(`/api/agents/${agentId}/improvements`),
+        ]);
+        if (cancelled) return;
+        if (qRes.status === "fulfilled") setQuality(qRes.value?.data ?? null);
+        if (fRes.status === "fulfilled") {
+          const d = fRes.value?.data;
+          setFailures(Array.isArray(d) ? d : []);
+        }
+        if (iRes.status === "fulfilled") {
+          const d = iRes.value?.data;
+          setImprovements(Array.isArray(d) ? d : []);
+        }
+      } catch {
+        // 실패 시 빈 상태 유지
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [agentId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        에이전트 데이터 불러오는 중...
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-3">
+      {/* 품질 점수 */}
+      <Card>
+        <CardHeader><CardTitle>품질 점수</CardTitle></CardHeader>
+        <CardContent>
+          {quality ? (
+            <div className="space-y-2">
+              {typeof quality.score === "number" && (
+                <div className="flex items-end gap-1">
+                  <span className="text-3xl font-bold text-fg">{quality.score.toFixed(1)}</span>
+                  <span className="mb-1 text-xs text-muted">/10</span>
+                </div>
+              )}
+              {typeof quality.totalFeedbacks === "number" && (
+                <p className="text-xs text-muted">총 피드백 {quality.totalFeedbacks}건</p>
+              )}
+              {typeof quality.avgRating === "number" && (
+                <p className="text-xs text-muted">평균 평점 {quality.avgRating.toFixed(2)}</p>
+              )}
+              {typeof quality.score !== "number" && typeof quality.totalFeedbacks !== "number" && (
+                <p className="text-xs text-muted">품질 데이터 없음</p>
+              )}
+            </div>
+          ) : (
+            <p className="text-xs text-muted">데이터 없음</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* 실패 패턴 */}
+      <Card>
+        <CardHeader><CardTitle>실패 패턴</CardTitle></CardHeader>
+        <CardContent>
+          {failures.length === 0 ? (
+            <p className="text-xs text-muted">기록된 실패 패턴 없음</p>
+          ) : (
+            <ul className="space-y-2">
+              {failures.slice(0, 4).map((f, i) => (
+                <li key={i} className="text-xs text-fg-2">
+                  {f.pattern ? (
+                    <span>{f.pattern}{f.count != null && <span className="ml-1 text-faint">({f.count}회)</span>}</span>
+                  ) : (
+                    <span className="text-faint font-mono">{JSON.stringify(f)}</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* 개선 제안 */}
+      <Card>
+        <CardHeader><CardTitle>개선 제안</CardTitle></CardHeader>
+        <CardContent>
+          {improvements.length === 0 ? (
+            <p className="text-xs text-muted">개선 제안 없음</p>
+          ) : (
+            <ul className="space-y-2">
+              {improvements.slice(0, 4).map((item, i) => (
+                <li key={i} className="flex items-start gap-2 text-xs">
+                  {item.priority && (
+                    <Badge tone={item.priority === "high" ? "danger" : item.priority === "medium" ? "warn" : "neutral"}>
+                      {item.priority}
+                    </Badge>
+                  )}
+                  <span className="text-fg-2">{item.suggestion ?? JSON.stringify(item)}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
 export default function AgentLearningPage() {
-  const [items] = useState<LearningItem[]>(ITEMS);
-  const [collected, setCollected] = useState<string>(SUMMARY.collected);
+  const [items] = useState<LearningItem[]>(ITEMS_FALLBACK);
+  const [collected, setCollected] = useState("1,284");
+  const [agents, setAgents] = useState<ApiSystemAgent[]>([]);
+  const [selectedAgentId, setSelectedAgentId] = useState<string>("");
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        const res = await ApiClient.get<ApiEnvelope<ApiFeedbackStats>>(
-          "/api/agents/feedback/stats",
-        );
+        // 피드백 통계
+        const statsRes = await ApiClient.get<ApiEnvelope<ApiFeedbackStats>>("/api/agents/feedback/stats");
         if (cancelled) return;
-        const stats = res?.data;
+        const stats = statsRes?.data;
         if (stats && typeof stats.totalFeedbacks === "number") {
           setCollected(stats.totalFeedbacks.toLocaleString("ko-KR"));
         }
       } catch {
-        // 401·실패 → 목업 값 유지 (데모)
+        // 목업 값 유지
+      }
+
+      try {
+        // 시스템 에이전트 목록 (드롭다운용)
+        const agentsRes = await ApiClient.get<ApiEnvelope<{ agents: ApiSystemAgent[] }>>("/api/agents");
+        if (cancelled) return;
+        const list = agentsRes?.data?.agents ?? [];
+        setAgents(list);
+        if (list.length > 0 && !selectedAgentId) {
+          setSelectedAgentId(list[0].id);
+        }
+      } catch {
+        // 드롭다운 없이 진행
       }
     })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    return () => { cancelled = true; };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <>
@@ -132,17 +245,35 @@ export default function AgentLearningPage() {
       />
 
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
+        {/* 요약 통계 */}
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-          <StatCard
-            label="수집 피드백"
-            value={collected}
-            delta="+126 이번 주"
-            deltaTone="success"
-          />
-          <StatCard label="반영 개선" value={SUMMARY.applied} />
-          <StatCard label="대기" value={SUMMARY.pending} />
+          <StatCard label="수집 피드백" value={collected} delta="+126 이번 주" deltaTone="success" />
+          <StatCard label="반영 개선" value="37" />
+          <StatCard label="대기" value="12" />
         </div>
 
+        {/* 에이전트별 품질 패널 */}
+        {agents.length > 0 && (
+          <div className="mt-6">
+            <div className="mb-4 flex items-center gap-3">
+              <h2 className="text-sm font-semibold text-fg">에이전트 상세 분석</h2>
+              <select
+                value={selectedAgentId}
+                onChange={(e) => setSelectedAgentId(e.target.value)}
+                className="h-8 rounded-md border border-border bg-surface px-2 text-xs text-fg outline-none focus:border-accent"
+              >
+                {agents.map((a) => (
+                  <option key={a.id} value={a.id}>
+                    {a.emoji ? `${a.emoji} ` : ""}{a.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            {selectedAgentId && <AgentDetailPanel agentId={selectedAgentId} />}
+          </div>
+        )}
+
+        {/* 학습 항목 리스트 */}
         <Card className="mt-6">
           <CardHeader>
             <CardTitle>학습 항목</CardTitle>
@@ -167,9 +298,7 @@ export default function AgentLearningPage() {
                         <GraduationCap className="h-4 w-4" />
                       </span>
                       <div className="min-w-0">
-                        <p className="truncate text-sm font-medium text-fg">
-                          {it.topic}
-                        </p>
+                        <p className="truncate text-sm font-medium text-fg">{it.topic}</p>
                         <div className="mt-1 flex items-center gap-3 text-xs">
                           <span className="inline-flex items-center gap-1 text-success">
                             <ThumbsUp className="h-3 w-3" />

--- a/apps/web/app/(workspace)/agent-tasks/page.tsx
+++ b/apps/web/app/(workspace)/agent-tasks/page.tsx
@@ -1,12 +1,27 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Sparkles, Plus, Check, LoaderCircle, Clock, Cpu } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import {
+  Sparkles,
+  Plus,
+  Check,
+  LoaderCircle,
+  Clock,
+  Cpu,
+  X,
+  Trash2,
+  Play,
+  RotateCcw,
+  ChevronRight,
+} from "lucide-react";
 import {
   Button,
   Badge,
   PageHeader,
   Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
 } from "@/components/ui/primitives";
 import { cn } from "@/lib/utils";
 import type { ApiSuccess } from "@openmake/shared-types";
@@ -14,6 +29,7 @@ import { ApiClient } from "@/lib/api-client";
 
 /* ── 타입 ────────────────────────────────────────────────── */
 type TaskStatus = "running" | "completed" | "pending";
+type ApiTaskStatus = "pending" | "running" | "completed" | "failed" | "cancelled";
 
 interface ChecklistItem {
   label: string;
@@ -24,34 +40,45 @@ interface AgentTask {
   id: string;
   goal: string;
   status: TaskStatus;
+  rawStatus: ApiTaskStatus;
   model: string;
   elapsed: string;
   currentTurn: number;
   maxTurns: number;
-  progress: number; // 0~100. 체크리스트가 없을 때(실데이터) 진행률 표시용
+  progress: number;
   checklist: ChecklistItem[];
+  resumable?: boolean;
 }
 
-/* ── 백엔드 응답 타입 (GET /api/agent-tasks → res.data.tasks) ── */
 interface ApiAgentTask {
   id: string;
   goal: string;
-  status: "pending" | "running" | "completed" | "failed" | "cancelled";
+  status: ApiTaskStatus;
   progress?: number;
   current_turn?: number;
   max_turns?: number;
   model?: string;
   created_at?: string;
   completed_at?: string;
+  resumable?: boolean;
 }
 
-type AgentTasksResponse = ApiSuccess<{
-  tasks: ApiAgentTask[];
-  total: number;
-}>;
+interface ApiTaskStep {
+  id: string;
+  turn: number;
+  type?: string;
+  content?: string;
+  tool_name?: string;
+  tool_input?: Record<string, unknown>;
+  tool_output?: string;
+  created_at?: string;
+}
 
-/** failed/cancelled 은 UI 의 3-상태(running/completed/pending)로 축약 — 완료(종료) 취급 */
-function mapStatus(s: ApiAgentTask["status"]): TaskStatus {
+type AgentTasksResponse = ApiSuccess<{ tasks: ApiAgentTask[]; total: number }>;
+type AgentTaskDetailResponse = ApiSuccess<{ task: ApiAgentTask; steps: ApiTaskStep[] }>;
+
+/* ── 유틸 ────────────────────────────────────────────────── */
+function mapStatus(s: ApiTaskStatus): TaskStatus {
   if (s === "running") return "running";
   if (s === "completed" || s === "failed" || s === "cancelled") return "completed";
   return "pending";
@@ -80,22 +107,24 @@ function mapTask(t: ApiAgentTask): AgentTask {
     id: t.id,
     goal: t.goal,
     status,
+    rawStatus: t.status,
     model: t.model || "Auto",
     elapsed: formatElapsed(t.created_at, t.completed_at),
     currentTurn: t.current_turn ?? 0,
     maxTurns: t.max_turns ?? 0,
     progress,
-    // 목록 엔드포인트는 스텝(체크리스트)을 포함하지 않음 — 상세(GET /:taskId/steps)에서만 제공.
     checklist: [],
+    resumable: t.resumable,
   };
 }
 
-/* ── 목업 데이터 — 미인증/네트워크 실패 시 폴백 ─────────────── */
-const TASKS: AgentTask[] = [
+/* ── 목업 폴백 ─────────────────────────────────────────────── */
+const TASK_FALLBACK: AgentTask[] = [
   {
     id: "t1",
     goal: "최신 AI 에이전트 동향을 조사해서 요약 보고서를 작성",
     status: "running",
+    rawStatus: "running",
     model: "Pro",
     elapsed: "2분 41초",
     currentTurn: 3,
@@ -113,6 +142,7 @@ const TASKS: AgentTask[] = [
     id: "t2",
     goal: "사내 위키 문서를 정리하고 누락된 섹션 목록 생성",
     status: "completed",
+    rawStatus: "completed",
     model: "Default",
     elapsed: "5분 08초",
     currentTurn: 6,
@@ -129,49 +159,285 @@ const TASKS: AgentTask[] = [
     id: "t3",
     goal: "경쟁사 가격 정책을 수집해 비교표로 정리",
     status: "pending",
+    rawStatus: "pending",
     model: "Fast",
     elapsed: "—",
     currentTurn: 0,
     maxTurns: 5,
     progress: 0,
-    checklist: [
-      { label: "대상 경쟁사 선정", done: false },
-      { label: "가격 데이터 수집", done: false },
-      { label: "비교표 구성", done: false },
-    ],
+    checklist: [],
   },
 ];
 
-const STATUS_META: Record<
-  TaskStatus,
-  { label: string; tone: "accent" | "success" | "neutral" }
-> = {
+const STATUS_META: Record<TaskStatus, { label: string; tone: "accent" | "success" | "neutral" }> = {
   running: { label: "진행중", tone: "accent" },
   completed: { label: "완료", tone: "success" },
   pending: { label: "대기", tone: "neutral" },
 };
 
-export default function AgentTasksPage() {
-  const [tasks, setTasks] = useState<AgentTask[]>(TASKS);
+/* ── 오버레이 모달 ────────────────────────────────────────── */
+function Modal({
+  open,
+  onClose,
+  title,
+  children,
+}: {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: React.ReactNode;
+}) {
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
+      <div className="relative z-10 w-full max-w-xl max-h-[90vh] overflow-y-auto mx-4 rounded-lg border border-border bg-app shadow-xl">
+        <div className="flex items-center justify-between border-b border-border px-5 py-4">
+          <h2 className="text-sm font-semibold text-fg">{title}</h2>
+          <button onClick={onClose} className="text-muted hover:text-fg">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="p-5">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+/* ── 작업 생성 폼 ─────────────────────────────────────────── */
+function CreateTaskForm({
+  onClose,
+  onCreated,
+}: {
+  onClose: () => void;
+  onCreated: (taskId: string) => void | Promise<void>;
+}) {
+  const [goal, setGoal] = useState("");
+  const [maxTurns, setMaxTurns] = useState(8);
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  async function handleSubmit() {
+    if (!goal.trim()) { setFormError("목표를 입력하세요."); return; }
+    setSaving(true);
+    setFormError(null);
+    try {
+      const res = await ApiClient.post<ApiSuccess<{ task: ApiAgentTask }>>("/api/agent-tasks", {
+        goal: goal.trim(),
+        maxTurns,
+      });
+      const taskId = res?.data?.task?.id;
+      if (!taskId) throw new Error("taskId가 응답에 없습니다");
+      await onCreated(taskId);
+    } catch (err) {
+      setFormError("생성 실패: " + (err instanceof Error ? err.message : "서버 오류"));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={(e) => { e.preventDefault(); void handleSubmit(); }} className="space-y-4">
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-fg-2">에이전트 목표 *</span>
+        <textarea value={goal} onChange={(e) => setGoal(e.target.value)}
+          rows={4} autoFocus
+          placeholder="예: 최신 AI 에이전트 동향을 조사해서 요약 보고서를 작성해줘"
+          className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none focus:border-accent resize-none" />
+      </label>
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-fg-2">최대 턴 수</span>
+        <input type="number" value={maxTurns} onChange={(e) => setMaxTurns(Number(e.target.value))}
+          min={1} max={50}
+          className="h-9 w-32 rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
+      </label>
+      {formError && <p className="text-xs text-danger">{formError}</p>}
+      <div className="flex justify-end gap-2 pt-1">
+        <Button type="button" variant="outline" onClick={onClose} disabled={saving}>취소</Button>
+        <Button type="submit" disabled={saving}>
+          {saving ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+          생성 및 실행
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+/* ── 작업 상세 모달 (스텝 타임라인) ─────────────────────── */
+function TaskDetailModal({
+  taskId,
+  onClose,
+}: {
+  taskId: string;
+  onClose: () => void;
+}) {
+  const [detail, setDetail] = useState<{ task: ApiAgentTask; steps: ApiTaskStep[] } | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        const res = await ApiClient.get<AgentTasksResponse>("/api/agent-tasks");
-        if (cancelled) return;
-        setTasks((res?.data?.tasks ?? []).map(mapTask));
+        const res = await ApiClient.get<AgentTaskDetailResponse>(`/api/agent-tasks/${taskId}`);
+        if (!cancelled) setDetail(res?.data ?? null);
       } catch {
-        // 401·네트워크 실패: 목업 폴백 유지
+        // 오류 시 detail = null
       } finally {
         if (!cancelled) setLoading(false);
       }
     })();
-    return () => {
-      cancelled = true;
-    };
+    return () => { cancelled = true; };
+  }, [taskId]);
+
+  return (
+    <div className="space-y-4">
+      {loading ? (
+        <div className="flex items-center gap-2 py-8 justify-center text-muted text-sm">
+          <LoaderCircle className="h-4 w-4 animate-spin" />
+          불러오는 중...
+        </div>
+      ) : !detail ? (
+        <p className="text-sm text-danger py-8 text-center">작업 정보를 불러오지 못했습니다.</p>
+      ) : (
+        <>
+          <div className="rounded-md border border-border bg-surface-2 p-4">
+            <p className="mb-1 text-xs font-medium text-muted">목표</p>
+            <p className="text-sm text-fg">{detail.task.goal}</p>
+            <div className="mt-2 flex gap-3 text-xs text-faint">
+              <span>상태: {detail.task.status}</span>
+              <span>턴: {detail.task.current_turn ?? 0}/{detail.task.max_turns ?? 0}</span>
+            </div>
+          </div>
+
+          {detail.steps.length === 0 ? (
+            <p className="text-sm text-muted text-center py-4">스텝 기록이 없습니다.</p>
+          ) : (
+            <div className="space-y-2">
+              <p className="text-xs font-medium text-fg-2">실행 스텝 ({detail.steps.length})</p>
+              <div className="max-h-80 overflow-y-auto space-y-2 pr-1">
+                {detail.steps.map((step, i) => (
+                  <div key={step.id} className="flex gap-3">
+                    <div className="flex flex-col items-center">
+                      <div className={cn(
+                        "flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-xs font-mono",
+                        "border-border bg-surface-2 text-faint",
+                      )}>
+                        {i + 1}
+                      </div>
+                      {i < detail.steps.length - 1 && (
+                        <div className="w-px flex-1 bg-border mt-1" />
+                      )}
+                    </div>
+                    <div className="pb-3 min-w-0 flex-1">
+                      <div className="flex items-center gap-2 text-xs text-muted mb-0.5">
+                        <Badge tone="neutral">{step.type ?? "step"}</Badge>
+                        {step.tool_name && <span className="font-mono">{step.tool_name}</span>}
+                      </div>
+                      {step.content && (
+                        <p className="text-xs text-fg-2 line-clamp-3 leading-relaxed">
+                          {step.content}
+                        </p>
+                      )}
+                      {step.tool_output && (
+                        <p className="mt-1 text-xs text-muted font-mono line-clamp-2 bg-surface-2 rounded px-2 py-1">
+                          {step.tool_output}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+/* ── 메인 페이지 ──────────────────────────────────────────── */
+export default function AgentTasksPage() {
+  const [tasks, setTasks] = useState<AgentTask[]>(TASK_FALLBACK);
+  const [loading, setLoading] = useState(true);
+  const [showCreate, setShowCreate] = useState(false);
+  const [detailTaskId, setDetailTaskId] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState<string | null>(null); // taskId being acted on
+
+  const loadTasks = useCallback(async () => {
+    try {
+      const res = await ApiClient.get<AgentTasksResponse>("/api/agent-tasks");
+      setTasks((res?.data?.tasks ?? []).map(mapTask));
+    } catch {
+      // 401·네트워크 실패: 목업 폴백 유지
+    } finally {
+      setLoading(false);
+    }
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      await loadTasks();
+      if (cancelled) return;
+    })();
+    return () => { cancelled = true; };
+  }, [loadTasks]);
+
+  async function handleCreated(taskId: string) {
+    setShowCreate(false);
+    // 생성 후 즉시 실행
+    try {
+      await ApiClient.post(`/api/agent-tasks/${taskId}/execute`, {});
+    } catch {
+      // execute 실패해도 목록 새로고침
+    }
+    await loadTasks();
+  }
+
+  async function handleCancel(task: AgentTask) {
+    if (!window.confirm(`"${task.goal.slice(0, 40)}..." 작업을 취소하시겠습니까?`)) return;
+    setActionLoading(task.id);
+    try {
+      await ApiClient.post(`/api/agent-tasks/${task.id}/cancel`, {});
+      await loadTasks();
+    } catch (err) {
+      alert("취소 실패: " + (err instanceof Error ? err.message : "오류"));
+    } finally {
+      setActionLoading(null);
+    }
+  }
+
+  async function handleResume(task: AgentTask) {
+    setActionLoading(task.id);
+    try {
+      await ApiClient.post(`/api/agent-tasks/${task.id}/resume`, {});
+      await loadTasks();
+    } catch (err) {
+      alert("이어하기 실패: " + (err instanceof Error ? err.message : "오류"));
+    } finally {
+      setActionLoading(null);
+    }
+  }
+
+  async function handleDelete(task: AgentTask) {
+    if (!window.confirm(`"${task.goal.slice(0, 40)}..." 작업을 삭제하시겠습니까?`)) return;
+    setActionLoading(task.id);
+    try {
+      await ApiClient.del(`/api/agent-tasks/${task.id}`);
+      await loadTasks();
+    } catch (err) {
+      alert("삭제 실패: " + (err instanceof Error ? err.message : "오류"));
+    } finally {
+      setActionLoading(null);
+    }
+  }
 
   return (
     <>
@@ -179,7 +445,7 @@ export default function AgentTasksPage() {
         title="에이전트 작업"
         description="자율 에이전트가 목표 달성까지 다단계로 작업을 수행합니다."
         actions={
-          <Button size="sm">
+          <Button size="sm" onClick={() => setShowCreate(true)}>
             <Plus className="h-4 w-4" />새 작업
           </Button>
         }
@@ -195,9 +461,10 @@ export default function AgentTasksPage() {
           <div className="grid place-items-center py-24 text-center">
             <Sparkles className="mb-3 h-8 w-8 text-faint" />
             <p className="text-sm font-medium text-fg-2">작업이 없습니다</p>
-            <p className="mt-1 text-sm text-muted">
-              목표를 입력하고 새 작업을 시작하세요.
-            </p>
+            <p className="mt-1 text-sm text-muted">목표를 입력하고 새 작업을 시작하세요.</p>
+            <Button size="sm" className="mt-4" onClick={() => setShowCreate(true)}>
+              <Plus className="h-4 w-4" />새 작업 만들기
+            </Button>
           </div>
         ) : (
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
@@ -205,10 +472,9 @@ export default function AgentTasksPage() {
               const meta = STATUS_META[task.status];
               const total = task.checklist.length;
               const completed = task.checklist.filter((c) => c.done).length;
-              // 체크리스트가 있으면(목업) 그 비율, 없으면(실데이터) progress 사용
-              const pct = total
-                ? Math.round((completed / total) * 100)
-                : task.progress;
+              const pct = total ? Math.round((completed / total) * 100) : task.progress;
+              const isActing = actionLoading === task.id;
+
               return (
                 <Card key={task.id} className="flex flex-col p-5">
                   <div className="mb-3 flex items-start justify-between gap-2">
@@ -217,41 +483,32 @@ export default function AgentTasksPage() {
                         <LoaderCircle className="h-3 w-3 animate-spin" />
                       )}
                       {meta.label}
+                      {task.rawStatus === "failed" && " (실패)"}
+                      {task.rawStatus === "cancelled" && " (취소됨)"}
                     </Badge>
                     <span className="font-mono text-xs text-faint">
                       턴 {task.currentTurn}/{task.maxTurns}
                     </span>
                   </div>
 
-                  <h3 className="mb-4 line-clamp-2 text-sm font-semibold leading-snug text-fg">
+                  <h3
+                    className="mb-4 line-clamp-2 cursor-pointer text-sm font-semibold leading-snug text-fg hover:underline"
+                    onClick={() => setDetailTaskId(task.id)}
+                  >
                     {task.goal}
                   </h3>
 
-                  {/* 진행 체크리스트 (목업/상세에만 존재 — 목록 실데이터는 비어 있음) */}
                   {total > 0 ? (
                     <ul className="mb-4 flex-1 space-y-1.5">
                       {task.checklist.map((item, i) => (
-                        <li
-                          key={i}
-                          className="flex items-center gap-2 text-xs"
-                        >
-                          <span
-                            className={cn(
-                              "grid h-4 w-4 flex-shrink-0 place-items-center rounded-full border",
-                              item.done
-                                ? "border-success bg-success-soft text-success"
-                                : "border-border text-faint",
-                            )}
-                          >
+                        <li key={i} className="flex items-center gap-2 text-xs">
+                          <span className={cn(
+                            "grid h-4 w-4 flex-shrink-0 place-items-center rounded-full border",
+                            item.done ? "border-success bg-success-soft text-success" : "border-border text-faint",
+                          )}>
                             {item.done && <Check className="h-2.5 w-2.5" />}
                           </span>
-                          <span
-                            className={cn(
-                              item.done
-                                ? "text-fg-2 line-through decoration-faint"
-                                : "text-muted",
-                            )}
-                          >
+                          <span className={cn(item.done ? "text-fg-2 line-through decoration-faint" : "text-muted")}>
                             {item.label}
                           </span>
                         </li>
@@ -261,30 +518,64 @@ export default function AgentTasksPage() {
                     <div className="flex-1" />
                   )}
 
-                  {/* 프로그레스 바 */}
+                  {/* 진행률 */}
                   <div className="mb-3">
                     <div className="mb-1 flex items-center justify-between text-xs">
                       <span className="text-faint">진행률</span>
                       <span className="font-mono text-fg-2">{pct}%</span>
                     </div>
                     <div className="h-1.5 overflow-hidden rounded-pill bg-surface-3">
-                      <div
-                        className="h-full rounded-pill bg-accent transition-all"
-                        style={{ width: `${pct}%` }}
-                      />
+                      <div className="h-full rounded-pill bg-accent transition-all" style={{ width: `${pct}%` }} />
                     </div>
                   </div>
 
-                  {/* 메타 */}
-                  <div className="flex items-center justify-between border-t border-border pt-3 text-xs text-faint">
-                    <span className="flex items-center gap-1">
-                      <Clock className="h-3.5 w-3.5" />
-                      {task.elapsed}
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <Cpu className="h-3.5 w-3.5" />
-                      {task.model}
-                    </span>
+                  {/* 메타 + 액션 버튼 */}
+                  <div className="flex items-center justify-between border-t border-border pt-3">
+                    <div className="flex items-center gap-3 text-xs text-faint">
+                      <span className="flex items-center gap-1">
+                        <Clock className="h-3.5 w-3.5" />{task.elapsed}
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <Cpu className="h-3.5 w-3.5" />{task.model}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      {/* 상세 보기 */}
+                      <button
+                        onClick={() => setDetailTaskId(task.id)}
+                        title="상세 보기"
+                        className="flex h-7 w-7 items-center justify-center rounded-md text-faint transition hover:bg-surface-2 hover:text-fg">
+                        <ChevronRight className="h-3.5 w-3.5" />
+                      </button>
+                      {/* Resume (failed + resumable) */}
+                      {task.rawStatus === "failed" && task.resumable && (
+                        <button
+                          onClick={() => void handleResume(task)}
+                          disabled={isActing}
+                          title="이어하기"
+                          className="flex h-7 w-7 items-center justify-center rounded-md text-faint transition hover:bg-accent-soft hover:text-accent disabled:opacity-40">
+                          <RotateCcw className="h-3.5 w-3.5" />
+                        </button>
+                      )}
+                      {/* Cancel (running/pending) */}
+                      {(task.status === "running" || task.rawStatus === "pending") && (
+                        <button
+                          onClick={() => void handleCancel(task)}
+                          disabled={isActing}
+                          title="취소"
+                          className="flex h-7 w-7 items-center justify-center rounded-md text-faint transition hover:bg-danger-soft hover:text-danger disabled:opacity-40">
+                          <X className="h-3.5 w-3.5" />
+                        </button>
+                      )}
+                      {/* Delete */}
+                      <button
+                        onClick={() => void handleDelete(task)}
+                        disabled={isActing}
+                        title="삭제"
+                        className="flex h-7 w-7 items-center justify-center rounded-md text-faint transition hover:bg-danger-soft hover:text-danger disabled:opacity-40">
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
                   </div>
                 </Card>
               );
@@ -292,6 +583,18 @@ export default function AgentTasksPage() {
           </div>
         )}
       </div>
+
+      {/* 새 작업 모달 */}
+      <Modal open={showCreate} onClose={() => setShowCreate(false)} title="새 에이전트 작업">
+        <CreateTaskForm onClose={() => setShowCreate(false)} onCreated={handleCreated} />
+      </Modal>
+
+      {/* 작업 상세 모달 */}
+      {detailTaskId && (
+        <Modal open={!!detailTaskId} onClose={() => setDetailTaskId(null)} title="작업 상세">
+          <TaskDetailModal taskId={detailTaskId} onClose={() => setDetailTaskId(null)} />
+        </Modal>
+      )}
     </>
   );
 }

--- a/apps/web/app/(workspace)/custom-agents/page.tsx
+++ b/apps/web/app/(workspace)/custom-agents/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Bot, Plus, Pencil, Trash, GitBranch } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Bot, Plus, Pencil, Trash2, GitBranch, X, Loader2, Check } from "lucide-react";
 import {
   Button,
   Badge,
@@ -21,7 +21,6 @@ interface CustomAgent {
   source: "git" | "custom";
 }
 
-/* ── 백엔드 응답 타입 (GET /api/users/me/agents → res.data.agents) ── */
 interface ApiUserAgent {
   id: string;
   name: string;
@@ -32,6 +31,16 @@ interface ApiUserAgent {
 
 type UserAgentsResponse = ApiSuccess<{ agents: ApiUserAgent[] }>;
 
+interface ApiCustomAgentDraft {
+  id: string;
+  name: string;
+  description: string | null;
+  system_prompt?: string;
+  status?: string;
+}
+
+type DraftAgentsResponse = ApiSuccess<{ drafts: ApiCustomAgentDraft[]; total: number }>;
+
 function mapAgent(a: ApiUserAgent): CustomAgent {
   return {
     id: a.id,
@@ -39,65 +48,419 @@ function mapAgent(a: ApiUserAgent): CustomAgent {
     name: a.name,
     description: a.description || "설명이 없습니다.",
     systemPrompt: a.system_prompt,
-    // 백엔드 user_agents 에는 git/custom 출처 구분 컬럼이 없음 — 모두 custom 으로 표기
     source: "custom",
   };
 }
 
-/* ── 목업 데이터 — 미인증/네트워크 실패 시 폴백 ─────────────── */
-const AGENTS: CustomAgent[] = [
+/* ── 목업 폴백 ─────────────────────────────────────────────── */
+const AGENTS_FALLBACK: CustomAgent[] = [
   {
-    id: "a1",
-    emoji: "📐",
-    name: "기술 문서 작성가",
+    id: "a1", emoji: "📐", name: "기술 문서 작성가",
     description: "API 레퍼런스와 아키텍처 문서를 일관된 톤으로 작성합니다.",
-    systemPrompt:
-      "당신은 시니어 테크니컬 라이터입니다. 명료하고 구조적인 한국어 문서를 작성하며, 코드 예시를 적극 포함합니다...",
-    source: "custom",
+    systemPrompt: "당신은 시니어 테크니컬 라이터입니다...", source: "custom",
   },
   {
-    id: "a2",
-    emoji: "🧪",
-    name: "코드 리뷰어",
+    id: "a2", emoji: "🧪", name: "코드 리뷰어",
     description: "변경된 코드의 버그와 단순화 기회를 집어냅니다.",
-    systemPrompt:
-      "당신은 까다로운 코드 리뷰어입니다. 정확성 버그를 우선하고, 재사용/단순화 개선점을 신뢰도 순으로 제시합니다...",
-    source: "git",
-  },
-  {
-    id: "a3",
-    emoji: "📊",
-    name: "데이터 분석가",
-    description: "데이터셋을 해석하고 인사이트를 도출합니다.",
-    systemPrompt:
-      "당신은 데이터 분석 전문가입니다. 통계적으로 타당한 해석을 제공하며, 시각화 제안을 함께 합니다...",
-    source: "custom",
+    systemPrompt: "당신은 까다로운 코드 리뷰어입니다...", source: "git",
   },
 ];
 
-export default function CustomAgentsPage() {
-  const [agents, setAgents] = useState<CustomAgent[]>(AGENTS);
+const TAB_ACTIVE = "active";
+const TAB_DRAFT = "draft";
+
+/* ── 오버레이 모달 ────────────────────────────────────────── */
+function Modal({
+  open,
+  onClose,
+  title,
+  children,
+}: {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: React.ReactNode;
+}) {
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
+      <div className="relative z-10 w-full max-w-lg max-h-[90vh] overflow-y-auto mx-4 rounded-lg border border-border bg-app shadow-xl">
+        <div className="flex items-center justify-between border-b border-border px-5 py-4">
+          <h2 className="text-sm font-semibold text-fg">{title}</h2>
+          <button onClick={onClose} className="text-muted hover:text-fg">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="p-5">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+/* ── 에이전트 생성/편집 폼 ────────────────────────────────── */
+function AgentForm({
+  initial,
+  onClose,
+  onSaved,
+}: {
+  initial?: CustomAgent;
+  onClose: () => void;
+  onSaved: () => void | Promise<void>;
+}) {
+  const [name, setName] = useState(initial?.name ?? "");
+  const [description, setDescription] = useState(initial?.description === "설명이 없습니다." ? "" : (initial?.description ?? ""));
+  const [systemPrompt, setSystemPrompt] = useState(initial?.systemPrompt ?? "");
+  const [icon, setIcon] = useState(initial?.emoji ?? "🤖");
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const isEdit = !!initial;
+
+  async function handleSubmit() {
+    if (!name.trim()) { setFormError("에이전트 이름을 입력하세요."); return; }
+    if (!systemPrompt.trim()) { setFormError("시스템 프롬프트를 입력하세요."); return; }
+    setSaving(true);
+    setFormError(null);
+    try {
+      if (isEdit) {
+        await ApiClient.put(`/api/users/me/agents/${initial.id}`, {
+          name: name.trim(),
+          description: description.trim() || null,
+          systemPrompt: systemPrompt.trim(),
+          icon: icon.trim() || null,
+        });
+      } else {
+        await ApiClient.post("/api/users/me/agents", {
+          name: name.trim(),
+          description: description.trim() || null,
+          systemPrompt: systemPrompt.trim(),
+          icon: icon.trim() || null,
+        });
+      }
+      await onSaved();
+    } catch (err) {
+      setFormError("저장 실패: " + (err instanceof Error ? err.message : "서버 오류"));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={(e) => { e.preventDefault(); void handleSubmit(); }} className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-[auto_1fr]">
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-fg-2">아이콘</span>
+          <input value={icon} onChange={(e) => setIcon(e.target.value)} maxLength={4}
+            className="h-9 w-16 rounded-md border border-border bg-surface px-2 text-center text-lg outline-none focus:border-accent" />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-fg-2">에이전트 이름 *</span>
+          <input value={name} onChange={(e) => setName(e.target.value)}
+            placeholder="예: 기술 문서 작성가" autoFocus
+            className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
+        </label>
+      </div>
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-fg-2">설명</span>
+        <input value={description} onChange={(e) => setDescription(e.target.value)}
+          placeholder="이 에이전트가 하는 일을 간단히 설명하세요"
+          className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
+      </label>
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-fg-2">시스템 프롬프트 *</span>
+        <textarea value={systemPrompt} onChange={(e) => setSystemPrompt(e.target.value)}
+          rows={6}
+          placeholder="당신은 ... 전문가입니다. ..."
+          className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none focus:border-accent resize-none" />
+        <span className="text-xs text-faint">{systemPrompt.length}/8000</span>
+      </label>
+      {formError && <p className="text-xs text-danger">{formError}</p>}
+      <div className="flex justify-end gap-2 pt-1">
+        <Button type="button" variant="outline" onClick={onClose} disabled={saving}>취소</Button>
+        <Button type="submit" disabled={saving}>
+          {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+          {isEdit ? "저장" : "생성"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+/* ── Git Ingest 폼 (Agent용) ──────────────────────────────── */
+function AgentGitIngestForm({
+  onClose,
+  onSaved,
+}: {
+  onClose: () => void;
+  onSaved: () => void | Promise<void>;
+}) {
+  const [gitUrl, setGitUrl] = useState("");
+  const [gitRef, setGitRef] = useState("");
+  const [gitPath, setGitPath] = useState("");
+  const [accessToken, setAccessToken] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [progress, setProgress] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  async function handleImport() {
+    if (!gitUrl.trim()) { setFormError("GitHub URL을 입력하세요."); return; }
+    setLoading(true);
+    setFormError(null);
+    setProgress("저장소 가져오는 중...");
+
+    try {
+      const resp = await fetch("/api/agents/custom/import-from-git", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "Accept": "text/event-stream" },
+        credentials: "include",
+        body: JSON.stringify({
+          gitUrl: gitUrl.trim(),
+          gitRef: gitRef.trim() || undefined,
+          gitPath: gitPath.trim() || undefined,
+          accessToken: accessToken.trim() || undefined,
+        }),
+      });
+
+      if (!resp.ok || !resp.body) {
+        const errText = await resp.text().catch(() => "서버 오류");
+        setFormError(`실패 (${resp.status}): ${errText}`);
+        setLoading(false);
+        setProgress(null);
+        return;
+      }
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const parts = buffer.split("\n\n");
+        buffer = parts.pop() ?? "";
+
+        for (const part of parts) {
+          const eventLine = part.split("\n").find((l) => l.startsWith("event:"));
+          const dataLine = part.split("\n").find((l) => l.startsWith("data:"));
+          if (!dataLine) continue;
+          const eventName = eventLine ? eventLine.replace("event:", "").trim() : "message";
+          const data = dataLine.replace("data:", "").trim();
+
+          try {
+            const parsed = JSON.parse(data) as Record<string, unknown>;
+            if (eventName === "progress") {
+              setProgress("매니페스트 처리 중...");
+            } else if (eventName === "result") {
+              setProgress("완료!");
+              setLoading(false);
+              await onSaved();
+              return;
+            } else if (eventName === "error") {
+              const errMsg = ((parsed as { error?: { message?: string } }).error?.message) || "가져오기 실패";
+              setFormError(errMsg);
+              setLoading(false);
+              setProgress(null);
+              return;
+            }
+          } catch {
+            // 무시
+          }
+        }
+      }
+      await onSaved();
+    } catch (err) {
+      setFormError("요청 실패: " + (err instanceof Error ? err.message : "네트워크 오류"));
+    } finally {
+      setLoading(false);
+      setProgress(null);
+    }
+  }
+
+  return (
+    <form onSubmit={(e) => { e.preventDefault(); void handleImport(); }} className="space-y-4">
+      <p className="text-sm text-muted">GitHub 저장소의 AGENT.md 매니페스트를 가져와 draft로 저장합니다.</p>
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-fg-2">GitHub URL *</span>
+        <input value={gitUrl} onChange={(e) => setGitUrl(e.target.value)} autoFocus
+          placeholder="https://github.com/owner/repo"
+          className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
+      </label>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-fg-2">브랜치/태그 (선택)</span>
+          <input value={gitRef} onChange={(e) => setGitRef(e.target.value)} placeholder="main"
+            className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-fg-2">파일 경로 (선택)</span>
+          <input value={gitPath} onChange={(e) => setGitPath(e.target.value)} placeholder="AGENT.md"
+            className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
+        </label>
+      </div>
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-fg-2">Access Token (비공개 저장소)</span>
+        <input type="password" value={accessToken} onChange={(e) => setAccessToken(e.target.value)} placeholder="ghp_..."
+          className="h-9 w-full rounded-md border border-border bg-surface px-3 font-mono text-sm text-fg outline-none focus:border-accent" />
+      </label>
+      {progress && (
+        <div className="flex items-center gap-2 text-xs text-accent">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          {progress}
+        </div>
+      )}
+      {formError && <p className="text-xs text-danger">{formError}</p>}
+      <div className="flex justify-end gap-2 pt-1">
+        <Button type="button" variant="outline" onClick={onClose} disabled={loading}>취소</Button>
+        <Button type="submit" disabled={loading}>
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <GitBranch className="h-4 w-4" />}
+          가져오기
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+/* ── Draft 탭 (에이전트용) ──────────────────────────────────── */
+function AgentDraftTab({ onRefresh }: { onRefresh: () => void }) {
+  const [drafts, setDrafts] = useState<ApiCustomAgentDraft[]>([]);
   const [loading, setLoading] = useState(true);
+
+  const loadDrafts = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await ApiClient.get<DraftAgentsResponse>("/api/agents/custom/drafts?target=user");
+      setDrafts(res?.data?.drafts ?? []);
+    } catch {
+      setDrafts([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void loadDrafts(); }, [loadDrafts]);
+
+  async function handleApprove(agentId: string) {
+    try {
+      await ApiClient.post(`/api/agents/custom/${agentId}/approve`, {});
+      await loadDrafts();
+      onRefresh();
+    } catch (err) {
+      alert("승인 실패: " + (err instanceof Error ? err.message : "오류"));
+    }
+  }
+
+  async function handleReject(agentId: string) {
+    if (!window.confirm("이 draft 에이전트를 거부(보관)하시겠습니까?")) return;
+    try {
+      await ApiClient.post(`/api/agents/custom/${agentId}/reject`, {});
+      await loadDrafts();
+    } catch (err) {
+      alert("거부 실패: " + (err instanceof Error ? err.message : "오류"));
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="grid place-items-center py-16 text-center">
+        <Loader2 className="mb-3 h-6 w-6 animate-spin text-faint" />
+        <p className="text-sm text-muted">Draft 불러오는 중...</p>
+      </div>
+    );
+  }
+
+  if (drafts.length === 0) {
+    return (
+      <div className="grid place-items-center py-16 text-center">
+        <Bot className="mb-3 h-8 w-8 text-faint" />
+        <p className="text-sm font-medium text-fg-2">승인 대기 중인 Draft가 없습니다</p>
+        <p className="mt-1 text-sm text-muted">Git URL 가져오기로 생성된 에이전트가 여기 나타납니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {drafts.map((d) => (
+        <Card key={d.id} className="p-4">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex-1 min-w-0">
+              <div className="mb-1 flex items-center gap-2">
+                <Badge tone="warn">Draft</Badge>
+              </div>
+              <h3 className="text-sm font-semibold text-fg">{d.name}</h3>
+              {d.description && (
+                <p className="mt-1 text-xs text-muted line-clamp-2">{d.description}</p>
+              )}
+            </div>
+            <div className="flex gap-2 shrink-0">
+              <Button size="sm" onClick={() => void handleApprove(d.id)}>
+                <Check className="h-3.5 w-3.5" />승인
+              </Button>
+              <Button variant="outline" size="sm" onClick={() => void handleReject(d.id)}>
+                <X className="h-3.5 w-3.5" />거부
+              </Button>
+            </div>
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+/* ── 메인 페이지 ──────────────────────────────────────────── */
+export default function CustomAgentsPage() {
+  const [agents, setAgents] = useState<CustomAgent[]>(AGENTS_FALLBACK);
+  const [loading, setLoading] = useState(true);
+  const [tab, setTab] = useState<string>(TAB_ACTIVE);
+  const [showCreate, setShowCreate] = useState(false);
+  const [showGitIngest, setShowGitIngest] = useState(false);
+  const [editingAgent, setEditingAgent] = useState<CustomAgent | null>(null);
+
+  const loadAgents = useCallback(async () => {
+    try {
+      const res = await ApiClient.get<UserAgentsResponse>("/api/users/me/agents");
+      setAgents((res?.data?.agents ?? []).map(mapAgent));
+    } catch {
+      // 401·네트워크 실패: 목업 폴백 유지
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      try {
-        const res = await ApiClient.get<UserAgentsResponse>(
-          "/api/users/me/agents",
-        );
-        if (cancelled) return;
-        setAgents((res?.data?.agents ?? []).map(mapAgent));
-      } catch {
-        // 401·네트워크 실패: 목업 폴백 유지
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
+      await loadAgents();
+      if (cancelled) return;
     })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    return () => { cancelled = true; };
+  }, [loadAgents]);
+
+  async function handleDelete(agent: CustomAgent) {
+    if (!window.confirm(`"${agent.name}" 에이전트를 삭제하시겠습니까?`)) return;
+    try {
+      await ApiClient.del(`/api/users/me/agents/${agent.id}`);
+      await loadAgents();
+    } catch (err) {
+      alert("삭제 실패: " + (err instanceof Error ? err.message : "오류"));
+    }
+  }
+
+  async function afterSave() {
+    setShowCreate(false);
+    setShowGitIngest(false);
+    setEditingAgent(null);
+    await loadAgents();
+  }
 
   return (
     <>
@@ -106,19 +469,31 @@ export default function CustomAgentsPage() {
         description="나만의 시스템 프롬프트로 특화된 에이전트를 정의합니다."
         actions={
           <>
-            <Button variant="outline" size="sm">
+            <Button variant="outline" size="sm" onClick={() => setShowGitIngest(true)}>
               <GitBranch className="h-4 w-4" />
               Git URL 에서 가져오기
             </Button>
-            <Button size="sm">
+            <Button size="sm" onClick={() => setShowCreate(true)}>
               <Plus className="h-4 w-4" />새 에이전트
             </Button>
           </>
         }
       />
 
+      {/* 탭 */}
+      <div className="flex gap-4 border-b border-border px-6 pt-3">
+        {[{ id: TAB_ACTIVE, label: "활성 에이전트" }, { id: TAB_DRAFT, label: "Draft 검토" }].map((t) => (
+          <button key={t.id} onClick={() => setTab(t.id)}
+            className={`pb-2 text-sm font-medium transition border-b-2 ${tab === t.id ? "border-accent text-accent" : "border-transparent text-muted hover:text-fg"}`}>
+            {t.label}
+          </button>
+        ))}
+      </div>
+
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
-        {loading ? (
+        {tab === TAB_DRAFT ? (
+          <AgentDraftTab onRefresh={loadAgents} />
+        ) : loading ? (
           <div className="grid place-items-center py-24 text-center">
             <Bot className="mb-3 h-8 w-8 animate-pulse text-faint" />
             <p className="text-sm text-muted">불러오는 중...</p>
@@ -126,13 +501,11 @@ export default function CustomAgentsPage() {
         ) : agents.length === 0 ? (
           <div className="grid place-items-center py-24 text-center">
             <Bot className="mb-3 h-8 w-8 text-faint" />
-            <p className="text-sm font-medium text-fg-2">
-              아직 커스텀 에이전트가 없습니다
-            </p>
+            <p className="text-sm font-medium text-fg-2">아직 커스텀 에이전트가 없습니다</p>
             <p className="mt-1 max-w-sm text-sm text-muted">
               직접 만들거나 Git URL 에서 가져와 특화된 에이전트를 추가하세요.
             </p>
-            <Button size="sm" className="mt-4">
+            <Button size="sm" className="mt-4" onClick={() => setShowCreate(true)}>
               <Plus className="h-4 w-4" />새 에이전트 만들기
             </Button>
           </div>
@@ -152,9 +525,7 @@ export default function CustomAgentsPage() {
                   )}
                 </div>
 
-                <h3 className="mb-1 text-sm font-semibold text-fg">
-                  {agent.name}
-                </h3>
+                <h3 className="mb-1 text-sm font-semibold text-fg">{agent.name}</h3>
                 <p className="mb-3 line-clamp-2 text-xs leading-relaxed text-muted">
                   {agent.description}
                 </p>
@@ -169,12 +540,12 @@ export default function CustomAgentsPage() {
                 </div>
 
                 <div className="flex gap-2">
-                  <Button variant="outline" size="sm" className="flex-1">
+                  <Button variant="outline" size="sm" className="flex-1" onClick={() => setEditingAgent(agent)}>
                     <Pencil className="h-3.5 w-3.5" />
                     편집
                   </Button>
-                  <Button variant="ghost" size="icon" aria-label="삭제">
-                    <Trash className="h-4 w-4" />
+                  <Button variant="ghost" size="icon" aria-label="삭제" onClick={() => void handleDelete(agent)}>
+                    <Trash2 className="h-4 w-4 text-danger" />
                   </Button>
                 </div>
               </Card>
@@ -182,6 +553,21 @@ export default function CustomAgentsPage() {
           </div>
         )}
       </div>
+
+      {/* 모달들 */}
+      <Modal open={showCreate} onClose={() => setShowCreate(false)} title="새 에이전트 생성">
+        <AgentForm onClose={() => setShowCreate(false)} onSaved={afterSave} />
+      </Modal>
+
+      <Modal open={!!editingAgent} onClose={() => setEditingAgent(null)} title="에이전트 편집">
+        {editingAgent && (
+          <AgentForm initial={editingAgent} onClose={() => setEditingAgent(null)} onSaved={afterSave} />
+        )}
+      </Modal>
+
+      <Modal open={showGitIngest} onClose={() => setShowGitIngest(false)} title="Git URL에서 에이전트 가져오기">
+        <AgentGitIngestForm onClose={() => setShowGitIngest(false)} onSaved={afterSave} />
+      </Modal>
     </>
   );
 }

--- a/apps/web/app/(workspace)/developer/page.tsx
+++ b/apps/web/app/(workspace)/developer/page.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ScrollText, KeyRound, MessageSquare, Sparkles } from "lucide-react";
+import {
+  PageHeader,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+} from "@/components/ui/primitives";
+import { ApiClient } from "@/lib/api-client";
+
+interface QuickStartStep {
+  step: number;
+  title: string;
+  description: string;
+  code?: string;
+}
+
+interface QuickStartData {
+  steps?: QuickStartStep[];
+  baseUrl?: string;
+}
+
+const DEFAULT_STEPS: QuickStartStep[] = [
+  {
+    step: 1,
+    title: "API 키 발급",
+    description: "설정 > API 키 페이지에서 새 API 키를 생성합니다.",
+    code: `# API 키를 HTTP 헤더에 포함
+Authorization: Bearer <YOUR_API_KEY>`,
+  },
+  {
+    step: 2,
+    title: "채팅 완성 요청",
+    description: "OpenAI 호환 /v1/chat/completions 엔드포인트에 요청을 보냅니다.",
+    code: `curl -X POST https://your-instance/v1/chat/completions \\
+  -H "Authorization: Bearer <YOUR_API_KEY>" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "안녕하세요!"}]
+  }'`,
+  },
+  {
+    step: 3,
+    title: "스트리밍 응답",
+    description: "stream: true 를 추가하면 SSE 스트림으로 토큰을 실시간 수신합니다.",
+    code: `curl -X POST https://your-instance/v1/chat/completions \\
+  -H "Authorization: Bearer <YOUR_API_KEY>" \\
+  -H "Content-Type: application/json" \\
+  -d '{"model":"default","messages":[...],"stream":true}'`,
+  },
+];
+
+export default function DeveloperPage() {
+  const [steps, setSteps] = useState<QuickStartStep[]>(DEFAULT_STEPS);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const res = await ApiClient.get<{ data?: QuickStartData } & QuickStartData>(
+          "/api/docs/quickstart",
+        );
+        const payload: QuickStartData = res.data ?? res;
+        if (!alive) return;
+        if (payload.steps && payload.steps.length > 0) {
+          setSteps(payload.steps);
+        }
+      } catch {
+        /* 기본 목업 유지 */
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return (
+    <>
+      <PageHeader
+        title="개발자 문서"
+        description="OpenMake LLM API를 통합하고 자동화합니다."
+      />
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-6">
+        <div className="mx-auto max-w-3xl space-y-6">
+          {/* API 기본 정보 */}
+          <Card>
+            <CardHeader className="flex items-center gap-2">
+              <ScrollText className="h-4 w-4 text-accent" />
+              <CardTitle>API 기본 정보</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <p className="mb-1 text-xs font-medium text-fg-2">Base URL</p>
+                <pre className="rounded-md bg-surface-2 p-3 text-xs text-fg-2 overflow-x-auto font-mono">
+                  {`https://your-instance.example.com`}
+                </pre>
+              </div>
+              <div>
+                <p className="mb-1 text-xs font-medium text-fg-2">API 버전</p>
+                <pre className="rounded-md bg-surface-2 p-3 text-xs text-fg-2 overflow-x-auto font-mono">
+                  {`/v1  — OpenAI 호환 엔드포인트\n/api — OpenMake 전용 엔드포인트`}
+                </pre>
+              </div>
+              <p className="text-sm text-fg-2">
+                OpenMake LLM API는 OpenAI Chat Completions API와 호환됩니다.
+                기존 OpenAI SDK를 <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-xs">baseURL</code>만
+                변경하여 바로 사용할 수 있습니다.
+              </p>
+            </CardContent>
+          </Card>
+
+          {/* 인증 방식 */}
+          <Card>
+            <CardHeader className="flex items-center gap-2">
+              <KeyRound className="h-4 w-4 text-accent" />
+              <CardTitle>인증 방식</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <p className="mb-2 text-sm font-medium text-fg">API Key 인증</p>
+                <p className="mb-2 text-sm text-fg-2">
+                  설정 {">"} API 키 페이지에서 발급한 키를 <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-xs">Authorization</code> 헤더에 전달합니다.
+                </p>
+                <pre className="rounded-md bg-surface-2 p-3 text-xs text-fg-2 overflow-x-auto font-mono">
+                  {`Authorization: Bearer om_live_xxxxxxxxxxxxxxxx`}
+                </pre>
+              </div>
+              <div>
+                <p className="mb-2 text-sm font-medium text-fg">JWT 세션 인증</p>
+                <p className="mb-2 text-sm text-fg-2">
+                  브라우저 세션은 HttpOnly 쿠키에 저장된 JWT를 자동으로 사용합니다.
+                  API 직접 호출 시에는 API Key를 권장합니다.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* 모델 목록 */}
+          <Card>
+            <CardHeader className="flex items-center gap-2">
+              <Sparkles className="h-4 w-4 text-accent" />
+              <CardTitle>모델 목록</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <p className="text-sm text-fg-2">
+                사용 가능한 모델 목록은 <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-xs">GET /api/models</code>로 조회하거나,
+                채팅 페이지의 모델 선택기를 참고하세요.
+              </p>
+              <pre className="rounded-md bg-surface-2 p-3 text-xs text-fg-2 overflow-x-auto font-mono">
+                {`curl https://your-instance/api/models \\
+  -H "Authorization: Bearer <YOUR_API_KEY>"`}
+              </pre>
+              <div className="rounded-md border border-border bg-surface-2 p-3">
+                <p className="mb-2 text-xs font-medium text-fg-2">브랜드 모델 ID</p>
+                <div className="grid grid-cols-2 gap-1 text-xs font-mono text-muted">
+                  {[
+                    ["default", "기본 모델"],
+                    ["pro", "고성능 모델"],
+                    ["fast", "빠른 응답"],
+                    ["think", "추론 모드"],
+                    ["code", "코드 특화"],
+                    ["vision", "이미지 지원"],
+                  ].map(([id, label]) => (
+                    <div key={id} className="flex gap-2">
+                      <span className="text-accent">{id}</span>
+                      <span className="text-faint">{label}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Quick Start */}
+          <Card>
+            <CardHeader className="flex items-center gap-2">
+              <MessageSquare className="h-4 w-4 text-accent" />
+              <CardTitle>Quick Start</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {steps.map((s) => (
+                <div key={s.step}>
+                  <div className="mb-2 flex items-center gap-2">
+                    <span className="flex h-5 w-5 items-center justify-center rounded-full bg-accent-soft text-xs font-bold text-accent">
+                      {s.step}
+                    </span>
+                    <p className="text-sm font-semibold text-fg">{s.title}</p>
+                  </div>
+                  <p className="mb-2 text-sm text-fg-2">{s.description}</p>
+                  {s.code && (
+                    <pre className="rounded-md bg-surface-2 p-3 text-xs text-fg-2 overflow-x-auto font-mono">
+                      {s.code}
+                    </pre>
+                  )}
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/app/(workspace)/mcp-catalog/page.tsx
+++ b/apps/web/app/(workspace)/mcp-catalog/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Search, Boxes, Download } from "lucide-react";
+import { Search, Boxes, Download, Loader2 } from "lucide-react";
 import {
   Button,
   Badge,
@@ -106,6 +106,8 @@ export default function McpCatalogPage() {
   const [loading, setLoading] = useState(true);
   // 실데이터는 toolCount 를 제공하지 않으므로 도구 수 배지를 숨긴다.
   const [showToolCount, setShowToolCount] = useState(true);
+  const [installing, setInstalling] = useState<Record<string, boolean>>({});
+  const [installError, setInstallError] = useState<Record<string, string>>({});
 
   useEffect(() => {
     let cancelled = false;
@@ -129,6 +131,31 @@ export default function McpCatalogPage() {
       cancelled = true;
     };
   }, []);
+
+  async function handleInstall(e: CatalogEntry) {
+    setInstalling((prev) => ({ ...prev, [e.id]: true }));
+    setInstallError((prev) => ({ ...prev, [e.id]: "" }));
+    try {
+      await ApiClient.post("/api/mcp/servers", {
+        name: e.name,
+        transport_type: "stdio",
+        catalog_template_id: e.id,
+        visibility: "global",
+      });
+      setEntries((prev) =>
+        prev.map((item) =>
+          item.id === e.id ? { ...item, installed: true } : item,
+        ),
+      );
+    } catch {
+      setInstallError((prev) => ({
+        ...prev,
+        [e.id]: "설치 실패. 다시 시도해 주세요.",
+      }));
+    } finally {
+      setInstalling((prev) => ({ ...prev, [e.id]: false }));
+    }
+  }
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -192,23 +219,36 @@ export default function McpCatalogPage() {
                     {e.description}
                   </p>
 
-                  <div className="flex items-center justify-between border-t border-border pt-3">
-                    {showToolCount ? (
-                      <Badge tone="neutral">도구 {e.toolCount}개</Badge>
-                    ) : (
-                      <Badge tone="neutral">
-                        <span className="font-mono">{e.provider}</span>
-                      </Badge>
-                    )}
-                    {e.installed ? (
-                      <Button variant="outline" size="sm" disabled>
-                        설치됨
-                      </Button>
-                    ) : (
-                      <Button size="sm">
-                        <Download className="h-4 w-4" />
-                        설치
-                      </Button>
+                  <div className="flex flex-col gap-2 border-t border-border pt-3">
+                    <div className="flex items-center justify-between">
+                      {showToolCount ? (
+                        <Badge tone="neutral">도구 {e.toolCount}개</Badge>
+                      ) : (
+                        <Badge tone="neutral">
+                          <span className="font-mono">{e.provider}</span>
+                        </Badge>
+                      )}
+                      {e.installed ? (
+                        <Button variant="outline" size="sm" disabled>
+                          설치됨
+                        </Button>
+                      ) : (
+                        <Button
+                          size="sm"
+                          disabled={installing[e.id]}
+                          onClick={() => handleInstall(e)}
+                        >
+                          {installing[e.id] ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <Download className="h-4 w-4" />
+                          )}
+                          설치
+                        </Button>
+                      )}
+                    </div>
+                    {installError[e.id] && (
+                      <p className="text-xs text-danger">{installError[e.id]}</p>
                     )}
                   </div>
                 </CardContent>

--- a/apps/web/app/(workspace)/mcp-monitoring/page.tsx
+++ b/apps/web/app/(workspace)/mcp-monitoring/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { RefreshCw } from "lucide-react";
+import { RefreshCw, AlertTriangle } from "lucide-react";
 import {
   Button,
   Badge,
@@ -33,6 +33,19 @@ interface SummaryView {
   totalCalls: string;
   avgLatency: string;
   errorRate: string;
+}
+
+/* ── 추가 타입 ───────────────────────────────────────────── */
+interface TopCrashedItem {
+  server_name: string;
+  crash_count: number;
+  last_crash_at: string;
+}
+
+interface CrashTrendItem {
+  hour: string;
+  spawned: number;
+  crashed: number;
 }
 
 /* ── 타입 ────────────────────────────────────────────────── */
@@ -152,10 +165,30 @@ async function fetchSummaryView(): Promise<SummaryView | null> {
 
 export default function McpMonitoringPage() {
   const [summary, setSummary] = useState<SummaryView>(SUMMARY);
+  const [topCrashed, setTopCrashed] = useState<TopCrashedItem[]>([]);
+  const [crashTrend, setCrashTrend] = useState<CrashTrendItem[]>([]);
+
+  async function loadExtraStats() {
+    try {
+      const [tc, ct] = await Promise.allSettled([
+        ApiClient.get<ApiEnvelope<{ items: TopCrashedItem[]; limit: number }>>(
+          "/api/admin/mcp/monitoring/top-crashed?limit=10",
+        ),
+        ApiClient.get<ApiEnvelope<{ timeline: CrashTrendItem[] }>>(
+          "/api/admin/mcp/monitoring/crash-trend",
+        ),
+      ]);
+      if (tc.status === "fulfilled") setTopCrashed(tc.value?.data?.items ?? []);
+      if (ct.status === "fulfilled") setCrashTrend(ct.value?.data?.timeline ?? []);
+    } catch {
+      /* 비관리자/실패 시 빈 상태 유지 */
+    }
+  }
 
   const refresh = useCallback(async () => {
     const view = await fetchSummaryView();
     if (view) setSummary(view);
+    await loadExtraStats();
   }, []);
 
   useEffect(() => {
@@ -165,6 +198,7 @@ export default function McpMonitoringPage() {
       if (!cancelled && view) setSummary(view);
     };
     void tick();
+    void loadExtraStats();
     const id = setInterval(() => void tick(), 30_000);
     return () => {
       cancelled = true;
@@ -285,6 +319,92 @@ export default function McpMonitoringPage() {
                   ))}
                 </tbody>
               </Table>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* M5: Top 크래시 서버 + 크래시 추이 */}
+        <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>Top 크래시 서버</CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              {topCrashed.length === 0 ? (
+                <p className="px-5 py-8 text-center text-sm text-muted">데이터 없음</p>
+              ) : (
+                <Table>
+                  <thead>
+                    <tr>
+                      <Th>서버</Th>
+                      <Th className="text-right">크래시</Th>
+                      <Th>마지막 크래시</Th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {topCrashed.map((item) => (
+                      <tr key={item.server_name} className="transition hover:bg-surface-2">
+                        <Td>
+                          <div className="flex items-center gap-2">
+                            <AlertTriangle className="h-3.5 w-3.5 text-warn" />
+                            <span className="font-mono text-xs text-fg-2">{item.server_name}</span>
+                          </div>
+                        </Td>
+                        <Td className="text-right font-mono text-danger">{item.crash_count}</Td>
+                        <Td className="text-xs text-muted">
+                          {item.last_crash_at
+                            ? new Date(item.last_crash_at).toLocaleString("ko-KR", { month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" })
+                            : "—"}
+                        </Td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>크래시 추이 (24h)</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {crashTrend.length === 0 ? (
+                <p className="py-8 text-center text-sm text-muted">데이터 없음</p>
+              ) : (
+                <div className="space-y-2">
+                  {crashTrend.map((item) => {
+                    const maxVal = Math.max(...crashTrend.map((t) => t.spawned), 1);
+                    const spawnedPct = (item.spawned / maxVal) * 100;
+                    const crashedPct = item.spawned > 0 ? (item.crashed / item.spawned) * 100 : 0;
+                    return (
+                      <div key={item.hour}>
+                        <div className="mb-0.5 flex items-center justify-between text-[11px]">
+                          <span className="font-mono text-muted">{item.hour}</span>
+                          <span className="text-faint">
+                            spawn {item.spawned} ·{" "}
+                            <span className={item.crashed > 0 ? "text-danger" : "text-muted"}>
+                              crash {item.crashed}
+                            </span>
+                          </span>
+                        </div>
+                        <div className="relative h-2 overflow-hidden rounded-pill bg-surface-2">
+                          <div
+                            className="absolute inset-y-0 left-0 rounded-pill bg-accent opacity-60"
+                            style={{ width: `${spawnedPct}%` }}
+                          />
+                          {item.crashed > 0 && (
+                            <div
+                              className="absolute inset-y-0 left-0 rounded-pill bg-danger"
+                              style={{ width: `${crashedPct * spawnedPct / 100}%` }}
+                            />
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
             </CardContent>
           </Card>
         </div>

--- a/apps/web/app/(workspace)/mcp-servers/page.tsx
+++ b/apps/web/app/(workspace)/mcp-servers/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Server, Boxes, Plus } from "lucide-react";
+import { Server, Boxes, Plus, Loader2, X } from "lucide-react";
 import {
   Button,
   Badge,
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/primitives";
 import type { ApiSuccess as ApiEnvelope } from "@openmake/shared-types";
 import { ApiClient } from "@/lib/api-client";
+import { cn } from "@/lib/utils";
 
 /* ── 타입 ────────────────────────────────────────────────── */
 type Transport = "stdio" | "SSE" | "HTTP";
@@ -72,6 +73,113 @@ function mapServer(s: ApiMcpServer): McpServer {
     latencyMs: null,
     lastChecked: relativeTime(s.lastPing),
   };
+}
+
+/* ── Draft 타입 ─────────────────────────────────────────────── */
+interface DraftServer {
+  id: string;
+  name?: string;
+  git_url?: string;
+  status: string;
+  manifest_meta?: {
+    conventionFindings?: { severity: string }[];
+  };
+}
+
+/* ── Git URL 등록 모달 ──────────────────────────────────────── */
+function GitImportModal({
+  open,
+  onClose,
+  onSuccess,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}) {
+  const [gitUrl, setGitUrl] = useState("");
+  const [accessToken, setAccessToken] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      await ApiClient.post("/api/mcp/servers/import-from-git", {
+        gitUrl,
+        ...(accessToken ? { accessToken } : {}),
+      });
+      setGitUrl("");
+      setAccessToken("");
+      onClose();
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "등록에 실패했습니다.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="w-full max-w-md rounded-xl border border-border bg-surface p-6 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-base font-semibold text-fg">Git URL로 MCP 서버 등록</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 text-muted hover:bg-surface-2 hover:text-fg"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+          <div>
+            <label className="mb-1 block text-xs font-medium text-fg-2">
+              Git URL <span className="text-danger">*</span>
+            </label>
+            <input
+              type="url"
+              required
+              value={gitUrl}
+              onChange={(e) => setGitUrl(e.target.value)}
+              placeholder="https://github.com/org/repo"
+              className="h-9 w-full rounded-md border border-border-strong bg-app px-3 text-sm text-fg outline-none transition focus:border-accent"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-fg-2">
+              액세스 토큰 (선택)
+            </label>
+            <input
+              type="password"
+              value={accessToken}
+              onChange={(e) => setAccessToken(e.target.value)}
+              placeholder="ghp_xxxx"
+              className="h-9 w-full rounded-md border border-border-strong bg-app px-3 text-sm text-fg outline-none transition focus:border-accent"
+            />
+          </div>
+          {error && (
+            <p className="rounded-md bg-danger-soft px-3 py-2 text-xs text-danger">
+              {error}
+            </p>
+          )}
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" size="sm" onClick={onClose}>
+              취소
+            </Button>
+            <Button type="submit" size="sm" disabled={submitting || !gitUrl}>
+              {submitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+              등록
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
 }
 
 /* ── 목업 데이터 — TODO: API 연동 (GET /api/mcp/servers) ──── */
@@ -138,9 +246,83 @@ const TRANSPORT_TONE: Record<Transport, "accent" | "neutral"> = {
   HTTP: "accent",
 };
 
+type TabId = "servers" | "drafts";
+
 export default function McpServersPage() {
+  const [tab, setTab] = useState<TabId>("servers");
+  const [modalOpen, setModalOpen] = useState(false);
   const [servers, setServers] = useState<McpServer[]>(MOCK_SERVERS);
   const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState<Record<string, boolean>>({});
+  const [drafts, setDrafts] = useState<DraftServer[]>([]);
+  const [draftsLoading, setDraftsLoading] = useState(false);
+  const [draftActionLoading, setDraftActionLoading] = useState<Record<string, boolean>>({});
+
+  async function loadDrafts() {
+    setDraftsLoading(true);
+    try {
+      const res = await ApiClient.get<{ success: boolean; data: DraftServer[] }>(
+        "/api/mcp/servers/drafts",
+      );
+      setDrafts(res?.data ?? []);
+    } catch {
+      /* 실패 시 빈 목록 유지 */
+    } finally {
+      setDraftsLoading(false);
+    }
+  }
+
+  async function handleApproveDraft(id: string) {
+    setDraftActionLoading((prev) => ({ ...prev, [id]: true }));
+    try {
+      await ApiClient.post(`/api/mcp/servers/${id}/approve`, {});
+      await loadDrafts();
+    } catch {
+      /* 실패 시 현상 유지 */
+    } finally {
+      setDraftActionLoading((prev) => ({ ...prev, [id]: false }));
+    }
+  }
+
+  async function handleRejectDraft(id: string) {
+    setDraftActionLoading((prev) => ({ ...prev, [id]: true }));
+    try {
+      await ApiClient.post(`/api/mcp/servers/${id}/reject`, {});
+      await loadDrafts();
+    } catch {
+      /* 실패 시 현상 유지 */
+    } finally {
+      setDraftActionLoading((prev) => ({ ...prev, [id]: false }));
+    }
+  }
+
+  async function handleConnect(id: string) {
+    setActionLoading((prev) => ({ ...prev, [id]: true }));
+    try {
+      await ApiClient.post<ApiEnvelope<{ status: string }>>(`/api/mcp/servers/${id}/connect`, {});
+      setServers((prev) =>
+        prev.map((s) => (s.id === id ? { ...s, status: "connected" } : s)),
+      );
+    } catch {
+      /* 실패 시 현상 유지 */
+    } finally {
+      setActionLoading((prev) => ({ ...prev, [id]: false }));
+    }
+  }
+
+  async function handleDisconnect(id: string) {
+    setActionLoading((prev) => ({ ...prev, [id]: true }));
+    try {
+      await ApiClient.post<ApiEnvelope<{ disconnected: boolean }>>(`/api/mcp/servers/${id}/disconnect`, {});
+      setServers((prev) =>
+        prev.map((s) => (s.id === id ? { ...s, status: "disconnected" } : s)),
+      );
+    } catch {
+      /* 실패 시 현상 유지 */
+    } finally {
+      setActionLoading((prev) => ({ ...prev, [id]: false }));
+    }
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -163,8 +345,23 @@ export default function McpServersPage() {
     };
   }, []);
 
+  useEffect(() => {
+    if (tab === "drafts") {
+      void loadDrafts();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab]);
+
   return (
     <>
+      <GitImportModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSuccess={() => {
+          setTab("drafts");
+          void loadDrafts();
+        }}
+      />
       <PageHeader
         title="MCP 서버"
         description="로컬 도구를 LLM 이 사용할 수 있도록 연결합니다."
@@ -174,7 +371,7 @@ export default function McpServersPage() {
               <Boxes className="h-4 w-4" />
               카탈로그
             </Button>
-            <Button size="sm">
+            <Button size="sm" onClick={() => setModalOpen(true)}>
               <Plus className="h-4 w-4" />
               서버 추가
             </Button>
@@ -183,6 +380,27 @@ export default function McpServersPage() {
       />
 
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
+        {/* 탭 */}
+        <div className="mb-4 inline-flex rounded-pill border border-border bg-surface-2 p-1">
+          {(["servers", "drafts"] as TabId[]).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setTab(t)}
+              className={cn(
+                "rounded-pill px-4 py-1.5 text-xs font-medium transition",
+                tab === t
+                  ? "bg-surface text-fg shadow-1"
+                  : "text-muted hover:text-fg",
+              )}
+            >
+              {t === "servers" ? "서버 목록" : "Draft"}
+            </button>
+          ))}
+        </div>
+
+        {/* 서버 목록 탭 */}
+        {tab === "servers" && (
         <Card className="overflow-hidden">
           <Table>
             <thead>
@@ -193,18 +411,19 @@ export default function McpServersPage() {
                 <Th>상태</Th>
                 <Th className="text-right">지연</Th>
                 <Th>마지막 확인</Th>
+                <Th>액션</Th>
               </tr>
             </thead>
             <tbody>
               {loading ? (
                 <tr>
-                  <Td colSpan={6}>
+                  <Td colSpan={7}>
                     <div className="py-12 text-center text-muted">로딩 중…</div>
                   </Td>
                 </tr>
               ) : servers.length === 0 ? (
                 <tr>
-                  <Td colSpan={6}>
+                  <Td colSpan={7}>
                     <div className="py-12 text-center text-muted">
                       연결된 MCP 서버가 없습니다. 카탈로그에서 추가하세요.
                     </div>
@@ -213,6 +432,7 @@ export default function McpServersPage() {
               ) : (
                 servers.map((s) => {
                   const meta = STATUS_META[s.status];
+                  const isActing = actionLoading[s.id] ?? false;
                   return (
                     <tr key={s.id} className="transition hover:bg-surface-2">
                       <Td>
@@ -246,6 +466,49 @@ export default function McpServersPage() {
                         )}
                       </Td>
                       <Td className="text-faint">{s.lastChecked}</Td>
+                      <Td>
+                        <div className="flex items-center gap-1">
+                          {s.status === "connected" ? (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              disabled={isActing}
+                              onClick={() => handleDisconnect(s.id)}
+                            >
+                              {isActing && <Loader2 className="h-3 w-3 animate-spin" />}
+                              연결해제
+                            </Button>
+                          ) : s.status === "degraded" ? (
+                            <>
+                              <Button
+                                size="sm"
+                                disabled={isActing}
+                                onClick={() => handleConnect(s.id)}
+                              >
+                                {isActing && <Loader2 className="h-3 w-3 animate-spin" />}
+                                재연결
+                              </Button>
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                disabled={isActing}
+                                onClick={() => handleDisconnect(s.id)}
+                              >
+                                연결해제
+                              </Button>
+                            </>
+                          ) : (
+                            <Button
+                              size="sm"
+                              disabled={isActing}
+                              onClick={() => handleConnect(s.id)}
+                            >
+                              {isActing && <Loader2 className="h-3 w-3 animate-spin" />}
+                              연결
+                            </Button>
+                          )}
+                        </div>
+                      </Td>
                     </tr>
                   );
                 })
@@ -253,6 +516,96 @@ export default function McpServersPage() {
             </tbody>
           </Table>
         </Card>
+        )}
+
+        {/* Draft 탭 */}
+        {tab === "drafts" && (
+          <Card className="overflow-hidden">
+            <Table>
+              <thead>
+                <tr>
+                  <Th>ID</Th>
+                  <Th>Git URL</Th>
+                  <Th>이름</Th>
+                  <Th>상태</Th>
+                  <Th>위험</Th>
+                  <Th>액션</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {draftsLoading ? (
+                  <tr>
+                    <Td colSpan={6}>
+                      <div className="py-12 text-center text-muted">로딩 중…</div>
+                    </Td>
+                  </tr>
+                ) : drafts.length === 0 ? (
+                  <tr>
+                    <Td colSpan={6}>
+                      <div className="py-12 text-center text-muted">
+                        Draft가 없습니다. Git URL로 서버를 등록하세요.
+                      </div>
+                    </Td>
+                  </tr>
+                ) : (
+                  drafts.map((d) => {
+                    const hasError = d.manifest_meta?.conventionFindings?.some(
+                      (f) => f.severity === "error",
+                    );
+                    const isActing = draftActionLoading[d.id] ?? false;
+                    return (
+                      <tr key={d.id} className="transition hover:bg-surface-2">
+                        <Td className="font-mono text-xs text-fg-2">
+                          {d.id.slice(0, 8)}
+                        </Td>
+                        <Td className="max-w-xs truncate text-xs text-fg-2">
+                          {d.git_url ?? "—"}
+                        </Td>
+                        <Td className="text-sm text-fg">{d.name ?? "—"}</Td>
+                        <Td>
+                          <Badge tone={d.status === "approved" ? "success" : d.status === "rejected" ? "danger" : "neutral"}>
+                            {d.status}
+                          </Badge>
+                        </Td>
+                        <Td>
+                          {hasError ? (
+                            <span className="text-sm text-danger">⚠️ 위험</span>
+                          ) : (
+                            <span className="text-faint">—</span>
+                          )}
+                        </Td>
+                        <Td>
+                          {d.status === "pending" && (
+                            <div className="flex items-center gap-1">
+                              <Button
+                                size="sm"
+                                disabled={isActing}
+                                onClick={() => void handleApproveDraft(d.id)}
+                              >
+                                {isActing && (
+                                  <Loader2 className="h-3 w-3 animate-spin" />
+                                )}
+                                승인
+                              </Button>
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                disabled={isActing}
+                                onClick={() => void handleRejectDraft(d.id)}
+                              >
+                                거부
+                              </Button>
+                            </div>
+                          )}
+                        </Td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </Table>
+          </Card>
+        )}
       </div>
     </>
   );

--- a/apps/web/app/(workspace)/settings/page.tsx
+++ b/apps/web/app/(workspace)/settings/page.tsx
@@ -20,11 +20,11 @@ import {
   PageHeader,
 } from "@/components/ui/primitives";
 import type { ApiSuccess } from "@openmake/shared-types";
-import { ApiClient } from "@/lib/api-client";
+import { ApiClient, ApiError } from "@/lib/api-client";
 import { cn } from "@/lib/utils";
 
 /* ── 탭 정의 ────────────────────────────────────────────── */
-type TabId = "general" | "model" | "interface" | "notifications" | "privacy";
+type TabId = "general" | "model" | "interface" | "notifications" | "privacy" | "security";
 
 const TABS: { id: TabId; label: string; icon: LucideIcon }[] = [
   { id: "general", label: "일반", icon: Settings },
@@ -32,6 +32,7 @@ const TABS: { id: TabId; label: string; icon: LucideIcon }[] = [
   { id: "interface", label: "인터페이스", icon: Palette },
   { id: "notifications", label: "알림", icon: Bell },
   { id: "privacy", label: "개인정보", icon: ShieldCheck },
+  { id: "security", label: "보안", icon: ShieldCheck },
 ];
 
 const MODEL_PROFILES = [
@@ -157,14 +158,101 @@ export default function SettingsPage() {
   // 알림
   const [emailAlerts, setEmailAlerts] = useState(true);
   const [pushAlerts, setPushAlerts] = useState(false);
+  const [pushSupported, setPushSupported] = useState<boolean | null>(null);
+  const [pushSwReady, setPushSwReady] = useState(false);
+  const [pushLoading, setPushLoading] = useState(false);
 
   // 개인정보
   const [saveHistory, setSaveHistory] = useState(true);
   const [memoryLearning, setMemoryLearning] = useState(true);
 
+  // 보안 — 비밀번호 변경
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [pwSaving, setPwSaving] = useState(false);
+  const [pwMessage, setPwMessage] = useState<{ text: string; ok: boolean } | null>(null);
+
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  // 푸시 지원 여부 및 현재 구독 상태 초기화
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const supported =
+      "serviceWorker" in navigator && "PushManager" in window;
+    setPushSupported(supported);
+    if (!supported) return;
+
+    navigator.serviceWorker.ready
+      .then((reg) => {
+        setPushSwReady(true);
+        return reg.pushManager.getSubscription();
+      })
+      .then((sub) => {
+        if (sub) setPushAlerts(true);
+      })
+      .catch(() => {
+        // SW 등록 안 됨
+      });
+  }, []);
+
+  function urlBase64ToUint8Array(base64String: string): ArrayBuffer {
+    const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+    const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+    const rawData = atob(base64);
+    const arr = new Uint8Array(rawData.length);
+    for (let i = 0; i < rawData.length; i++) {
+      arr[i] = rawData.charCodeAt(i);
+    }
+    return arr.buffer;
+  }
+
+  async function handlePushToggle(on: boolean) {
+    if (typeof window === "undefined") return;
+    setPushLoading(true);
+    try {
+      if (on) {
+        const permission = await Notification.requestPermission();
+        if (permission !== "granted") {
+          setPushLoading(false);
+          return;
+        }
+        const reg = await navigator.serviceWorker.ready;
+        let sub = await reg.pushManager.getSubscription();
+        if (!sub) {
+          const vapidRes = await ApiClient.get<{ data: { publicKey: string } }>(
+            "/api/push/vapid-key",
+          );
+          const key = vapidRes?.data?.publicKey;
+          if (!key) throw new Error("VAPID key 없음");
+          sub = await reg.pushManager.subscribe({
+            userVisibleOnly: true,
+            applicationServerKey: urlBase64ToUint8Array(key),
+          });
+        }
+        const json = sub.toJSON();
+        await ApiClient.post("/api/push/subscribe", {
+          endpoint: sub.endpoint,
+          keys: json.keys,
+        });
+        setPushAlerts(true);
+      } else {
+        const reg = await navigator.serviceWorker.ready;
+        const sub = await reg.pushManager.getSubscription();
+        if (sub) {
+          await sub.unsubscribe();
+          await ApiClient.post("/api/push/unsubscribe", { endpoint: sub.endpoint });
+        }
+        setPushAlerts(false);
+      }
+    } catch (err) {
+      console.error("push toggle error", err);
+    } finally {
+      setPushLoading(false);
+    }
+  }
 
   // custom-instructions 만 실제 API 연동 (나머지는 로컬/목업)
   useEffect(() => {
@@ -200,6 +288,31 @@ export default function SettingsPage() {
       setSavedAt(null);
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function handlePasswordChange() {
+    if (newPassword !== confirmPassword) {
+      setPwMessage({ text: "새 비밀번호가 일치하지 않습니다.", ok: false });
+      return;
+    }
+    if (newPassword.length < 8) {
+      setPwMessage({ text: "새 비밀번호는 8자 이상이어야 합니다.", ok: false });
+      return;
+    }
+    setPwSaving(true);
+    setPwMessage(null);
+    try {
+      await ApiClient.put("/api/auth/password", { currentPassword, newPassword });
+      setPwMessage({ text: "비밀번호가 변경되었습니다.", ok: true });
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : "비밀번호 변경에 실패했습니다.";
+      setPwMessage({ text: msg, ok: false });
+    } finally {
+      setPwSaving(false);
     }
   }
 
@@ -363,7 +476,25 @@ export default function SettingsPage() {
                     title="푸시 알림"
                     description="브라우저 푸시로 실시간 알림을 받습니다."
                   >
-                    <Toggle checked={pushAlerts} onChange={setPushAlerts} />
+                    {pushSupported === false ? (
+                      <p className="text-xs text-muted">
+                        이 브라우저는 푸시 알림을 지원하지 않습니다.
+                      </p>
+                    ) : pushSupported === true && !pushSwReady ? (
+                      <p className="text-xs text-muted">
+                        서비스 워커가 등록되지 않아 푸시 알림을 사용할 수 없습니다.
+                      </p>
+                    ) : (
+                      <div className="flex items-center gap-2">
+                        <Toggle
+                          checked={pushAlerts}
+                          onChange={(v) => void handlePushToggle(v)}
+                        />
+                        {pushLoading && (
+                          <Loader2 className="h-4 w-4 animate-spin text-muted" />
+                        )}
+                      </div>
+                    )}
                   </FieldRow>
                 </CardContent>
               </Card>
@@ -390,6 +521,68 @@ export default function SettingsPage() {
                   >
                     <Toggle checked={saveHistory} onChange={setSaveHistory} />
                   </FieldRow>
+                </CardContent>
+              </Card>
+            )}
+
+            {tab === "security" && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>비밀번호 변경</CardTitle>
+                </CardHeader>
+                <CardContent className="py-0">
+                  {pwMessage && (
+                    <div
+                      className={cn(
+                        "my-4 rounded-md px-3 py-2 text-xs",
+                        pwMessage.ok
+                          ? "bg-success-soft text-success"
+                          : "bg-danger-soft text-danger",
+                      )}
+                    >
+                      {pwMessage.text}
+                    </div>
+                  )}
+                  <FieldRow title="현재 비밀번호">
+                    <input
+                      type="password"
+                      value={currentPassword}
+                      onChange={(e) => setCurrentPassword(e.target.value)}
+                      placeholder="••••••••"
+                      className="h-9 w-full rounded-md border border-border-strong bg-surface px-3 text-sm text-fg outline-none transition focus:border-accent"
+                    />
+                  </FieldRow>
+                  <FieldRow title="새 비밀번호" description="8자 이상">
+                    <input
+                      type="password"
+                      value={newPassword}
+                      onChange={(e) => setNewPassword(e.target.value)}
+                      placeholder="••••••••"
+                      className="h-9 w-full rounded-md border border-border-strong bg-surface px-3 text-sm text-fg outline-none transition focus:border-accent"
+                    />
+                  </FieldRow>
+                  <FieldRow title="새 비밀번호 확인">
+                    <input
+                      type="password"
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                      placeholder="••••••••"
+                      className="h-9 w-full rounded-md border border-border-strong bg-surface px-3 text-sm text-fg outline-none transition focus:border-accent"
+                    />
+                  </FieldRow>
+                  <div className="py-4">
+                    <Button
+                      onClick={() => void handlePasswordChange()}
+                      disabled={pwSaving || !currentPassword || !newPassword || !confirmPassword}
+                    >
+                      {pwSaving ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Save className="h-4 w-4" />
+                      )}
+                      비밀번호 변경
+                    </Button>
+                  </div>
                 </CardContent>
               </Card>
             )}

--- a/apps/web/app/(workspace)/skill-library/page.tsx
+++ b/apps/web/app/(workspace)/skill-library/page.tsx
@@ -1,18 +1,35 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { Library, Plus, Package, Upload } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Library,
+  Plus,
+  Package,
+  Upload,
+  Pencil,
+  Trash2,
+  X,
+  Star,
+  GitBranch,
+  Cpu,
+  Loader2,
+  Check,
+  Download,
+} from "lucide-react";
 import {
   Button,
   Badge,
   PageHeader,
   Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
 } from "@/components/ui/primitives";
 import { cn } from "@/lib/utils";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { ApiClient } from "@/lib/api-client";
 
-/* ── 카테고리 라벨 (apps/legacy-web skill-library.js CATEGORY_LABELS 미러) ── */
+/* ── 카테고리 라벨 ─────────────────────────────────────────── */
 const CATEGORY_LABELS: Record<string, string> = {
   productivity: "생산성",
   technology: "기술/IT",
@@ -24,21 +41,25 @@ const CATEGORY_LABELS: Record<string, string> = {
   education: "교육/학습",
 };
 
-/* ── 타입 ────────────────────────────────────────────────── */
+/* ── 타입 ─────────────────────────────────────────────────── */
 interface Skill {
   id: string;
   name: string;
   category: string;
   description: string;
   isSystem: boolean;
+  status?: string;
+  content?: string;
+  createdBy?: string | null;
 }
 
-/* ── 백엔드 응답 타입 (GET /api/agents/skills → res.data = SkillSearchResult) ── */
 interface ApiSkill {
   id: string;
   name: string;
   description: string;
   category: string;
+  status?: string;
+  content?: string;
   createdBy?: string | null;
 }
 
@@ -49,120 +70,745 @@ type SkillsResponse = ApiSuccess<{
   offset: number;
 }>;
 
+type DraftsResponse = ApiSuccess<{
+  drafts: ApiSkill[];
+  total: number;
+}>;
+
+/* ── 목업 폴백 ─────────────────────────────────────────────── */
+const SKILL_FALLBACK: Skill[] = [
+  { id: "s1", name: "PDF 요약", category: "productivity", description: "긴 PDF 문서를 핵심 요점으로 압축합니다.", isSystem: true },
+  { id: "s2", name: "SQL 쿼리 작성", category: "technology", description: "자연어 요구사항을 파라미터화된 SQL 로 변환합니다.", isSystem: true },
+  { id: "s3", name: "광고 카피라이팅", category: "creative", description: "타겟 세그먼트에 맞춘 마케팅 카피를 생성합니다.", isSystem: false },
+  { id: "s4", name: "재무 보고서 해석", category: "finance", description: "손익계산서와 대차대조표의 핵심 지표를 해석합니다.", isSystem: false },
+];
+
 function mapSkill(s: ApiSkill): Skill {
   return {
     id: s.id,
     name: s.name,
     category: s.category || "general",
     description: s.description || "",
-    // 시스템 스킬 = createdBy 없음(null), 사용자 스킬 = createdBy 존재
     isSystem: !s.createdBy,
+    status: s.status,
+    content: s.content,
+    createdBy: s.createdBy,
   };
 }
-
-/* ── 목업 데이터 — 미인증/네트워크 실패 시 폴백 ─────────────── */
-const SKILLS: Skill[] = [
-  {
-    id: "s1",
-    name: "PDF 요약",
-    category: "productivity",
-    description: "긴 PDF 문서를 핵심 요점으로 압축합니다.",
-    isSystem: true,
-  },
-  {
-    id: "s2",
-    name: "SQL 쿼리 작성",
-    category: "technology",
-    description: "자연어 요구사항을 파라미터화된 SQL 로 변환합니다.",
-    isSystem: true,
-  },
-  {
-    id: "s3",
-    name: "광고 카피라이팅",
-    category: "creative",
-    description: "타겟 세그먼트에 맞춘 마케팅 카피를 생성합니다.",
-    isSystem: false,
-  },
-  {
-    id: "s4",
-    name: "재무 보고서 해석",
-    category: "finance",
-    description: "손익계산서와 대차대조표의 핵심 지표를 해석합니다.",
-    isSystem: false,
-  },
-  {
-    id: "s5",
-    name: "논문 리뷰",
-    category: "science",
-    description: "학술 논문의 방법론과 한계를 비판적으로 검토합니다.",
-    isSystem: true,
-  },
-  {
-    id: "s6",
-    name: "이메일 초안 작성",
-    category: "communication",
-    description: "상황과 톤에 맞는 비즈니스 이메일을 작성합니다.",
-    isSystem: false,
-  },
-  {
-    id: "s7",
-    name: "회의록 정리",
-    category: "productivity",
-    description: "대화 기록을 구조화된 회의록과 액션 아이템으로 정리합니다.",
-    isSystem: false,
-  },
-  {
-    id: "s8",
-    name: "코드 리팩터링 제안",
-    category: "technology",
-    description: "코드의 단순화·재사용 기회를 식별해 제안합니다.",
-    isSystem: true,
-  },
-];
-
-const ALL = "all";
 
 function categoryLabel(id: string) {
   return CATEGORY_LABELS[id] || id || "일반";
 }
 
+const ALL = "all";
+const TAB_ACTIVE = "active";
+const TAB_DRAFT = "draft";
+
+/* ── 오버레이 모달 컴포넌트 ──────────────────────────────── */
+function Modal({
+  open,
+  onClose,
+  title,
+  children,
+}: {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: React.ReactNode;
+}) {
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <div className="relative z-10 w-full max-w-lg max-h-[90vh] overflow-y-auto mx-4 rounded-lg border border-border bg-app shadow-xl">
+        <div className="flex items-center justify-between border-b border-border px-5 py-4">
+          <h2 className="text-sm font-semibold text-fg">{title}</h2>
+          <button onClick={onClose} className="text-muted hover:text-fg">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="p-5">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+/* ── 스킬 생성/편집 폼 ───────────────────────────────────── */
+function SkillForm({
+  initial,
+  onClose,
+  onSaved,
+}: {
+  initial?: Skill;
+  onClose: () => void;
+  onSaved: () => void | Promise<void>;
+}) {
+  const [name, setName] = useState(initial?.name ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [content, setContent] = useState(initial?.content ?? "");
+  const [category, setCategory] = useState(initial?.category ?? "productivity");
+  const [isPublic, setIsPublic] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const isEdit = !!initial;
+
+  async function handleSubmit() {
+    if (!name.trim()) { setFormError("스킬 이름을 입력하세요."); return; }
+    if (!content.trim()) { setFormError("스킬 내용(Instructions)을 입력하세요."); return; }
+    setSaving(true);
+    setFormError(null);
+    try {
+      if (isEdit) {
+        await ApiClient.put(`/api/agents/skills/${initial.id}`, { name: name.trim(), description: description.trim(), content: content.trim(), category, isPublic });
+      } else {
+        await ApiClient.post("/api/agents/skills", { name: name.trim(), description: description.trim(), content: content.trim(), category, isPublic });
+      }
+      await onSaved();
+    } catch (err) {
+      setFormError("저장 실패: " + (err instanceof Error ? err.message : "서버 오류"));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={(e) => { e.preventDefault(); void handleSubmit(); }} className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="block sm:col-span-2">
+          <span className="mb-1 block text-xs font-medium text-fg-2">스킬 이름 *</span>
+          <input value={name} onChange={(e) => setName(e.target.value)}
+            placeholder="예: PDF 요약" autoFocus
+            className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-fg-2">카테고리</span>
+          <select value={category} onChange={(e) => setCategory(e.target.value)}
+            className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent">
+            {Object.entries(CATEGORY_LABELS).map(([k, v]) => (
+              <option key={k} value={k}>{v}</option>
+            ))}
+          </select>
+        </label>
+        <label className="flex cursor-pointer items-center gap-2 self-end">
+          <input type="checkbox" checked={isPublic} onChange={(e) => setIsPublic(e.target.checked)}
+            className="h-4 w-4 rounded border-border accent-accent" />
+          <span className="text-xs text-fg-2">공개 스킬</span>
+        </label>
+      </div>
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-fg-2">설명</span>
+        <input value={description} onChange={(e) => setDescription(e.target.value)}
+          placeholder="이 스킬이 하는 일을 간단히 설명하세요"
+          className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
+      </label>
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-fg-2">Instructions (스킬 내용) *</span>
+        <textarea value={content} onChange={(e) => setContent(e.target.value)}
+          rows={5} placeholder="이 스킬이 수행할 작업을 상세히 기술하세요..."
+          className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none focus:border-accent resize-none" />
+      </label>
+      {formError && <p className="text-xs text-danger">{formError}</p>}
+      <div className="flex justify-end gap-2 pt-1">
+        <Button type="button" variant="outline" onClick={onClose}>취소</Button>
+        <Button type="submit" disabled={saving}>
+          {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+          {isEdit ? "저장" : "생성"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+/* ── 파일 업로드 폼 ──────────────────────────────────────── */
+function UploadForm({
+  onClose,
+  onSaved,
+}: {
+  onClose: () => void;
+  onSaved: () => void | Promise<void>;
+}) {
+  const [file, setFile] = useState<File | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  async function handleUpload() {
+    if (!file) { setFormError("파일을 선택하세요."); return; }
+    setUploading(true);
+    setFormError(null);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const res = await ApiClient.post<ApiSuccess<{ skill_id: string; version: string; inserted: boolean }>>("/api/agents/skills/upload", fd);
+      const d = res?.data;
+      setResult(d ? `업로드 완료: ${d.skill_id} v${d.version}` : "업로드 완료");
+      await onSaved();
+    } catch (err) {
+      setFormError("업로드 실패: " + (err instanceof Error ? err.message : "서버 오류"));
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted">.SKILL 또는 .md YAML frontmatter 파일을 업로드합니다. (최대 256KB)</p>
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-fg-2">파일 선택</span>
+        <input type="file" accept=".skill,.md"
+          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+          className="text-sm text-fg-2 file:mr-3 file:rounded-md file:border-0 file:bg-surface-2 file:px-3 file:py-1.5 file:text-xs file:font-medium file:text-fg hover:file:bg-surface-3" />
+      </label>
+      {result && <p className="text-xs text-success">{result}</p>}
+      {formError && <p className="text-xs text-danger">{formError}</p>}
+      <div className="flex justify-end gap-2">
+        <Button variant="outline" onClick={onClose}>취소</Button>
+        <Button onClick={() => void handleUpload()} disabled={!file || uploading}>
+          {uploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
+          업로드
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/* ── AI 자동 생성 폼 ─────────────────────────────────────── */
+function AutoCreateForm({
+  onClose,
+  onSaved,
+}: {
+  onClose: () => void;
+  onSaved: () => void | Promise<void>;
+}) {
+  const [purpose, setPurpose] = useState("");
+  const [target, setTarget] = useState("");
+  const [category, setCategory] = useState("productivity");
+  const [generating, setGenerating] = useState(false);
+  const [progress, setProgress] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const esRef = useRef<EventSource | null>(null);
+
+  function cleanup() {
+    esRef.current?.close();
+    esRef.current = null;
+  }
+
+  useEffect(() => () => cleanup(), []);
+
+  async function handleGenerate() {
+    if (!purpose.trim()) { setFormError("목적을 입력하세요."); return; }
+    setGenerating(true);
+    setFormError(null);
+    setProgress("생성 요청 중...");
+
+    // SSE 방식: fetch + ReadableStream 로 파싱
+    try {
+      const resp = await fetch("/api/agents/skills/auto-create", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "Accept": "text/event-stream" },
+        credentials: "include",
+        body: JSON.stringify({ purpose: purpose.trim(), target: target.trim() || undefined, category }),
+      });
+
+      if (!resp.ok || !resp.body) {
+        const errText = await resp.text().catch(() => "서버 오류");
+        setFormError(`실패 (${resp.status}): ${errText}`);
+        setGenerating(false);
+        setProgress(null);
+        return;
+      }
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const parts = buffer.split("\n\n");
+        buffer = parts.pop() ?? "";
+
+        for (const part of parts) {
+          const eventLine = part.split("\n").find((l) => l.startsWith("event:"));
+          const dataLine = part.split("\n").find((l) => l.startsWith("data:"));
+          if (!dataLine) continue;
+          const eventName = eventLine ? eventLine.replace("event:", "").trim() : "message";
+          const data = dataLine.replace("data:", "").trim();
+
+          try {
+            const parsed = JSON.parse(data) as Record<string, unknown>;
+            if (eventName === "progress") {
+              const phase = (parsed as { phase?: string }).phase;
+              setProgress(phase === "llm_call_started" ? "LLM 생성 중..." : "처리 중...");
+            } else if (eventName === "result") {
+              setProgress("생성 완료!");
+              cleanup();
+              await onSaved();
+              return;
+            } else if (eventName === "error") {
+              const errMsg = ((parsed as { error?: { message?: string } }).error?.message) || "생성 실패";
+              setFormError(errMsg);
+              cleanup();
+              setGenerating(false);
+              setProgress(null);
+              return;
+            }
+          } catch {
+            // JSON 파싱 실패 무시
+          }
+        }
+      }
+      await onSaved();
+    } catch (err) {
+      setFormError("요청 실패: " + (err instanceof Error ? err.message : "네트워크 오류"));
+    } finally {
+      setGenerating(false);
+      setProgress(null);
+    }
+  }
+
+  return (
+    <form onSubmit={(e) => { e.preventDefault(); void handleGenerate(); }} className="space-y-4">
+      <p className="text-sm text-muted">자연어 목적을 입력하면 LLM이 스킬 매니페스트를 자동 생성합니다.</p>
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-fg-2">스킬 목적 *</span>
+        <textarea value={purpose} onChange={(e) => setPurpose(e.target.value)}
+          rows={3} autoFocus placeholder="예: PDF 문서를 업로드하면 핵심 내용을 3줄로 요약하는 스킬"
+          className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none focus:border-accent resize-none" />
+      </label>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-fg-2">대상 사용자 (선택)</span>
+          <input value={target} onChange={(e) => setTarget(e.target.value)}
+            placeholder="예: 연구자, 마케터"
+            className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-fg-2">카테고리</span>
+          <select value={category} onChange={(e) => setCategory(e.target.value)}
+            className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent">
+            {Object.entries(CATEGORY_LABELS).map(([k, v]) => (
+              <option key={k} value={k}>{v}</option>
+            ))}
+          </select>
+        </label>
+      </div>
+      {progress && (
+        <div className="flex items-center gap-2 text-xs text-accent">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          {progress}
+        </div>
+      )}
+      {formError && <p className="text-xs text-danger">{formError}</p>}
+      <div className="flex justify-end gap-2 pt-1">
+        <Button type="button" variant="outline" onClick={onClose} disabled={generating}>취소</Button>
+        <Button type="submit" disabled={generating}>
+          {generating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Cpu className="h-4 w-4" />}
+          AI 생성
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+/* ── Git URL Ingest 폼 ───────────────────────────────────── */
+function GitIngestForm({
+  onClose,
+  onSaved,
+}: {
+  onClose: () => void;
+  onSaved: () => void | Promise<void>;
+}) {
+  const [gitUrl, setGitUrl] = useState("");
+  const [gitRef, setGitRef] = useState("");
+  const [gitPath, setGitPath] = useState("");
+  const [accessToken, setAccessToken] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [progress, setProgress] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  async function handleImport() {
+    if (!gitUrl.trim()) { setFormError("GitHub URL을 입력하세요."); return; }
+    setLoading(true);
+    setFormError(null);
+    setProgress("저장소 가져오는 중...");
+
+    try {
+      const resp = await fetch("/api/agents/skills/import-from-git", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "Accept": "text/event-stream" },
+        credentials: "include",
+        body: JSON.stringify({
+          gitUrl: gitUrl.trim(),
+          gitRef: gitRef.trim() || undefined,
+          gitPath: gitPath.trim() || undefined,
+          accessToken: accessToken.trim() || undefined,
+        }),
+      });
+
+      if (!resp.ok || !resp.body) {
+        const errText = await resp.text().catch(() => "서버 오류");
+        setFormError(`실패 (${resp.status}): ${errText}`);
+        setLoading(false);
+        setProgress(null);
+        return;
+      }
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const parts = buffer.split("\n\n");
+        buffer = parts.pop() ?? "";
+
+        for (const part of parts) {
+          const eventLine = part.split("\n").find((l) => l.startsWith("event:"));
+          const dataLine = part.split("\n").find((l) => l.startsWith("data:"));
+          if (!dataLine) continue;
+          const eventName = eventLine ? eventLine.replace("event:", "").trim() : "message";
+          const data = dataLine.replace("data:", "").trim();
+
+          try {
+            const parsed = JSON.parse(data) as Record<string, unknown>;
+            if (eventName === "progress") {
+              setProgress("매니페스트 검증 중...");
+            } else if (eventName === "result") {
+              setProgress("완료!");
+              setLoading(false);
+              await onSaved();
+              return;
+            } else if (eventName === "error") {
+              const errMsg = ((parsed as { error?: { message?: string } }).error?.message) || "가져오기 실패";
+              setFormError(errMsg);
+              setLoading(false);
+              setProgress(null);
+              return;
+            }
+          } catch {
+            // 무시
+          }
+        }
+      }
+      await onSaved();
+    } catch (err) {
+      setFormError("요청 실패: " + (err instanceof Error ? err.message : "네트워크 오류"));
+    } finally {
+      setLoading(false);
+      setProgress(null);
+    }
+  }
+
+  return (
+    <form onSubmit={(e) => { e.preventDefault(); void handleImport(); }} className="space-y-4">
+      <p className="text-sm text-muted">GitHub 저장소의 SKILL.md 매니페스트를 가져와 draft로 저장합니다.</p>
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-fg-2">GitHub URL *</span>
+        <input value={gitUrl} onChange={(e) => setGitUrl(e.target.value)} autoFocus
+          placeholder="https://github.com/owner/repo"
+          className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
+      </label>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-fg-2">브랜치/태그 (선택)</span>
+          <input value={gitRef} onChange={(e) => setGitRef(e.target.value)}
+            placeholder="main"
+            className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-fg-2">파일 경로 (선택)</span>
+          <input value={gitPath} onChange={(e) => setGitPath(e.target.value)}
+            placeholder="SKILL.md"
+            className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
+        </label>
+      </div>
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-fg-2">Access Token (비공개 저장소)</span>
+        <input type="password" value={accessToken} onChange={(e) => setAccessToken(e.target.value)}
+          placeholder="ghp_..."
+          className="h-9 w-full rounded-md border border-border bg-surface px-3 font-mono text-sm text-fg outline-none focus:border-accent" />
+      </label>
+      {progress && (
+        <div className="flex items-center gap-2 text-xs text-accent">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          {progress}
+        </div>
+      )}
+      {formError && <p className="text-xs text-danger">{formError}</p>}
+      <div className="flex justify-end gap-2 pt-1">
+        <Button type="button" variant="outline" onClick={onClose} disabled={loading}>취소</Button>
+        <Button type="submit" disabled={loading}>
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <GitBranch className="h-4 w-4" />}
+          가져오기
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+/* ── 필터 칩 ──────────────────────────────────────────────── */
+function FilterChip({ label, count, active, onClick }: { label: string; count: number; active: boolean; onClick: () => void }) {
+  return (
+    <button onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-pill border px-3 py-1 text-xs font-medium transition",
+        active ? "border-accent bg-accent-soft text-accent" : "border-border bg-surface text-fg-2 hover:bg-surface-2",
+      )}>
+      {label}
+      <span className={cn("font-mono", active ? "text-accent" : "text-faint")}>{count}</span>
+    </button>
+  );
+}
+
+/* ── 스킬 카드 ────────────────────────────────────────────── */
+function SkillCard({
+  skill,
+  assigned,
+  onEdit,
+  onDelete,
+  onToggleAssign,
+  onExport,
+}: {
+  skill: Skill;
+  assigned: boolean;
+  onEdit: (s: Skill) => void;
+  onDelete: (s: Skill) => void;
+  onToggleAssign: (s: Skill, assigned: boolean) => void;
+  onExport: (s: Skill) => void;
+}) {
+  return (
+    <Card className="flex flex-col p-5">
+      <div className="mb-3 flex items-center gap-2">
+        <div className="grid h-9 w-9 place-items-center rounded-md bg-accent-soft text-accent">
+          <Package className="h-4 w-4" />
+        </div>
+        <Badge tone="neutral">{categoryLabel(skill.category)}</Badge>
+        {skill.isSystem ? <Badge tone="accent">시스템</Badge> : <Badge tone="neutral">사용자</Badge>}
+      </div>
+      <h3 className="mb-1 text-sm font-semibold text-fg">{skill.name}</h3>
+      <p className="mb-3 line-clamp-2 flex-1 text-xs leading-relaxed text-muted">{skill.description}</p>
+      <div className="flex items-center gap-1.5 border-t border-border pt-3">
+        <button
+          onClick={() => onToggleAssign(skill, assigned)}
+          title={assigned ? "개인 스킬 해제" : "개인 스킬로 추가"}
+          className={cn(
+            "flex h-7 w-7 items-center justify-center rounded-md transition",
+            assigned ? "text-accent hover:bg-accent-soft" : "text-faint hover:bg-surface-2 hover:text-fg",
+          )}>
+          <Star className="h-3.5 w-3.5" fill={assigned ? "currentColor" : "none"} />
+        </button>
+        <button
+          onClick={() => onExport(skill)}
+          title=".SKILL.md 내보내기"
+          className="flex h-7 w-7 items-center justify-center rounded-md text-faint transition hover:bg-surface-2 hover:text-fg">
+          <Download className="h-3.5 w-3.5" />
+        </button>
+        <div className="flex-1" />
+        <button
+          onClick={() => onEdit(skill)}
+          className="flex h-7 items-center gap-1 rounded-md px-2 text-xs text-fg-2 transition hover:bg-surface-2">
+          <Pencil className="h-3 w-3" />편집
+        </button>
+        <button
+          onClick={() => onDelete(skill)}
+          className="flex h-7 w-7 items-center justify-center rounded-md text-faint transition hover:bg-danger-soft hover:text-danger">
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </Card>
+  );
+}
+
+/* ── Draft 탭 ─────────────────────────────────────────────── */
+function DraftTab({ onRefresh }: { onRefresh: () => void }) {
+  const [drafts, setDrafts] = useState<Skill[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadDrafts = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await ApiClient.get<DraftsResponse>("/api/agents/skills/drafts?target=user");
+      setDrafts((res?.data?.drafts ?? []).map(mapSkill));
+    } catch {
+      setDrafts([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void loadDrafts(); }, [loadDrafts]);
+
+  async function handleApprove(skillId: string) {
+    try {
+      await ApiClient.post(`/api/agents/skills/${skillId}/approve`, {});
+      await loadDrafts();
+      onRefresh();
+    } catch (err) {
+      alert("승인 실패: " + (err instanceof Error ? err.message : "오류"));
+    }
+  }
+
+  async function handleReject(skillId: string) {
+    if (!window.confirm("이 draft를 거부(보관)하시겠습니까?")) return;
+    try {
+      await ApiClient.post(`/api/agents/skills/${skillId}/reject`, {});
+      await loadDrafts();
+    } catch (err) {
+      alert("거부 실패: " + (err instanceof Error ? err.message : "오류"));
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="grid place-items-center py-16 text-center">
+        <Loader2 className="mb-3 h-6 w-6 animate-spin text-faint" />
+        <p className="text-sm text-muted">Draft 불러오는 중...</p>
+      </div>
+    );
+  }
+
+  if (drafts.length === 0) {
+    return (
+      <div className="grid place-items-center py-16 text-center">
+        <Library className="mb-3 h-8 w-8 text-faint" />
+        <p className="text-sm font-medium text-fg-2">승인 대기 중인 Draft가 없습니다</p>
+        <p className="mt-1 text-sm text-muted">AI 자동생성 또는 Git 가져오기로 생성된 스킬이 여기 나타납니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {drafts.map((d) => (
+        <Card key={d.id} className="p-4">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex-1 min-w-0">
+              <div className="mb-1 flex items-center gap-2">
+                <Badge tone="warn">Draft</Badge>
+                <Badge tone="neutral">{categoryLabel(d.category)}</Badge>
+              </div>
+              <h3 className="text-sm font-semibold text-fg">{d.name}</h3>
+              <p className="mt-1 text-xs text-muted line-clamp-2">{d.description}</p>
+            </div>
+            <div className="flex gap-2 shrink-0">
+              <Button size="sm" onClick={() => void handleApprove(d.id)}>
+                <Check className="h-3.5 w-3.5" />승인
+              </Button>
+              <Button variant="outline" size="sm" onClick={() => void handleReject(d.id)}>
+                <X className="h-3.5 w-3.5" />거부
+              </Button>
+            </div>
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+/* ── 메인 페이지 ──────────────────────────────────────────── */
 export default function SkillLibraryPage() {
-  const [skills, setSkills] = useState<Skill[]>(SKILLS);
+  const [skills, setSkills] = useState<Skill[]>(SKILL_FALLBACK);
   const [loading, setLoading] = useState(true);
   const [active, setActive] = useState<string>(ALL);
+  const [tab, setTab] = useState<string>(TAB_ACTIVE);
+  const [assignedIds, setAssignedIds] = useState<Set<string>>(new Set());
+
+  // 모달 상태
+  const [showCreate, setShowCreate] = useState(false);
+  const [showUpload, setShowUpload] = useState(false);
+  const [showAutoCreate, setShowAutoCreate] = useState(false);
+  const [showGitIngest, setShowGitIngest] = useState(false);
+  const [editingSkill, setEditingSkill] = useState<Skill | null>(null);
+
+  const loadSkills = useCallback(async () => {
+    try {
+      const res = await ApiClient.get<SkillsResponse>("/api/agents/skills?limit=200");
+      setSkills((res?.data?.skills ?? []).map(mapSkill));
+    } catch {
+      // 401·네트워크 실패: 목업 폴백 유지
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const loadAssigned = useCallback(async () => {
+    try {
+      const res = await ApiClient.get<ApiSuccess<ApiSkill[]>>("/api/agents/skills/user-assigned");
+      const list = Array.isArray(res?.data) ? res.data : [];
+      setAssignedIds(new Set(list.map((s) => s.id)));
+    } catch {
+      // 무시
+    }
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      try {
-        const res = await ApiClient.get<SkillsResponse>(
-          "/api/agents/skills?limit=200",
-        );
-        if (cancelled) return;
-        setSkills((res?.data?.skills ?? []).map(mapSkill));
-      } catch {
-        // 401·네트워크 실패: 목업 폴백 유지
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
+      await Promise.all([loadSkills(), loadAssigned()]);
+      if (cancelled) return;
     })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    return () => { cancelled = true; };
+  }, [loadSkills, loadAssigned]);
 
   const categories = useMemo(() => {
     const counts = new Map<string, number>();
     for (const s of skills) counts.set(s.category, (counts.get(s.category) || 0) + 1);
-    return Array.from(counts.entries()).map(([id, count]) => ({
-      id,
-      label: categoryLabel(id),
-      count,
-    }));
+    return Array.from(counts.entries()).map(([id, count]) => ({ id, label: categoryLabel(id), count }));
   }, [skills]);
 
-  const filtered =
-    active === ALL ? skills : skills.filter((s) => s.category === active);
+  const filtered = active === ALL ? skills : skills.filter((s) => s.category === active);
+
+  async function handleDelete(skill: Skill) {
+    if (!window.confirm(`"${skill.name}" 스킬을 삭제하시겠습니까?`)) return;
+    try {
+      await ApiClient.del(`/api/agents/skills/${skill.id}`);
+      await loadSkills();
+    } catch (err) {
+      alert("삭제 실패: " + (err instanceof Error ? err.message : "오류"));
+    }
+  }
+
+  async function handleToggleAssign(skill: Skill, currently: boolean) {
+    try {
+      if (currently) {
+        await ApiClient.del(`/api/agents/skills/${skill.id}/user-assign`);
+        setAssignedIds((prev) => { const n = new Set(prev); n.delete(skill.id); return n; });
+      } else {
+        await ApiClient.post(`/api/agents/skills/${skill.id}/user-assign`, {});
+        setAssignedIds((prev) => new Set(prev).add(skill.id));
+      }
+    } catch (err) {
+      alert("할당 변경 실패: " + (err instanceof Error ? err.message : "오류"));
+    }
+  }
+
+  function handleExport(skill: Skill) {
+    window.open(`/api/agents/skills/${skill.id}/export`, "_blank");
+  }
+
+  async function afterSave() {
+    setShowCreate(false);
+    setShowUpload(false);
+    setShowAutoCreate(false);
+    setShowGitIngest(false);
+    setEditingSkill(null);
+    await loadSkills();
+  }
 
   return (
     <>
@@ -171,108 +817,102 @@ export default function SkillLibraryPage() {
         description="재사용 가능한 매니페스트와 도구 바인딩을 관리합니다."
         actions={
           <>
-            <Button variant="outline" size="sm">
-              <Upload className="h-4 w-4" />
-              .SKILL 업로드
+            <Button variant="outline" size="sm" onClick={() => setShowUpload(true)}>
+              <Upload className="h-4 w-4" />.SKILL 업로드
             </Button>
-            <Button size="sm">
+            <Button variant="outline" size="sm" onClick={() => setShowGitIngest(true)}>
+              <GitBranch className="h-4 w-4" />Git 가져오기
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => setShowAutoCreate(true)}>
+              <Cpu className="h-4 w-4" />AI 자동생성
+            </Button>
+            <Button size="sm" onClick={() => setShowCreate(true)}>
               <Plus className="h-4 w-4" />새 스킬
             </Button>
           </>
         }
       />
 
-      <div className="min-h-0 flex-1 overflow-y-auto p-6">
-        {/* 카테고리 필터 */}
-        <div className="mb-5 flex flex-wrap gap-2">
-          <FilterChip
-            label="전체"
-            count={skills.length}
-            active={active === ALL}
-            onClick={() => setActive(ALL)}
-          />
-          {categories.map((c) => (
-            <FilterChip
-              key={c.id}
-              label={c.label}
-              count={c.count}
-              active={active === c.id}
-              onClick={() => setActive(c.id)}
-            />
-          ))}
-        </div>
+      {/* 탭 */}
+      <div className="flex gap-4 border-b border-border px-6 pt-3">
+        {[{ id: TAB_ACTIVE, label: "활성 스킬" }, { id: TAB_DRAFT, label: "Draft 검토" }].map((t) => (
+          <button key={t.id} onClick={() => setTab(t.id)}
+            className={cn(
+              "pb-2 text-sm font-medium transition border-b-2",
+              tab === t.id
+                ? "border-accent text-accent"
+                : "border-transparent text-muted hover:text-fg",
+            )}>
+            {t.label}
+          </button>
+        ))}
+      </div>
 
-        {loading ? (
-          <div className="grid place-items-center py-24 text-center">
-            <Library className="mb-3 h-8 w-8 animate-pulse text-faint" />
-            <p className="text-sm text-muted">불러오는 중...</p>
-          </div>
-        ) : filtered.length === 0 ? (
-          <div className="grid place-items-center py-24 text-center">
-            <Library className="mb-3 h-8 w-8 text-faint" />
-            <p className="text-sm font-medium text-fg-2">스킬이 없습니다</p>
-            <p className="mt-1 text-sm text-muted">
-              다른 카테고리를 선택하거나 새 스킬을 추가하세요.
-            </p>
-          </div>
+      <div className="min-h-0 flex-1 overflow-y-auto p-6">
+        {tab === TAB_DRAFT ? (
+          <DraftTab onRefresh={loadSkills} />
         ) : (
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-            {filtered.map((s) => (
-              <Card key={s.id} className="flex flex-col p-5">
-                <div className="mb-3 flex items-center gap-2">
-                  <div className="grid h-9 w-9 place-items-center rounded-md bg-accent-soft text-accent">
-                    <Package className="h-4 w-4" />
-                  </div>
-                  <Badge tone="neutral">{categoryLabel(s.category)}</Badge>
-                  {s.isSystem ? (
-                    <Badge tone="accent">시스템</Badge>
-                  ) : (
-                    <Badge tone="neutral">사용자</Badge>
-                  )}
-                </div>
-                <h3 className="mb-1 text-sm font-semibold text-fg">{s.name}</h3>
-                <p className="line-clamp-2 text-xs leading-relaxed text-muted">
-                  {s.description}
-                </p>
-              </Card>
-            ))}
-          </div>
+          <>
+            {/* 카테고리 필터 */}
+            <div className="mb-5 flex flex-wrap gap-2">
+              <FilterChip label="전체" count={skills.length} active={active === ALL} onClick={() => setActive(ALL)} />
+              {categories.map((c) => (
+                <FilterChip key={c.id} label={c.label} count={c.count} active={active === c.id} onClick={() => setActive(c.id)} />
+              ))}
+            </div>
+
+            {loading ? (
+              <div className="grid place-items-center py-24 text-center">
+                <Library className="mb-3 h-8 w-8 animate-pulse text-faint" />
+                <p className="text-sm text-muted">불러오는 중...</p>
+              </div>
+            ) : filtered.length === 0 ? (
+              <div className="grid place-items-center py-24 text-center">
+                <Library className="mb-3 h-8 w-8 text-faint" />
+                <p className="text-sm font-medium text-fg-2">스킬이 없습니다</p>
+                <p className="mt-1 text-sm text-muted">다른 카테고리를 선택하거나 새 스킬을 추가하세요.</p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                {filtered.map((s) => (
+                  <SkillCard
+                    key={s.id}
+                    skill={s}
+                    assigned={assignedIds.has(s.id)}
+                    onEdit={setEditingSkill}
+                    onDelete={handleDelete}
+                    onToggleAssign={handleToggleAssign}
+                    onExport={handleExport}
+                  />
+                ))}
+              </div>
+            )}
+          </>
         )}
       </div>
-    </>
-  );
-}
 
-function FilterChip({
-  label,
-  count,
-  active,
-  onClick,
-}: {
-  label: string;
-  count: number;
-  active: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className={cn(
-        "inline-flex items-center gap-1.5 rounded-pill border px-3 py-1 text-xs font-medium transition",
-        active
-          ? "border-accent bg-accent-soft text-accent"
-          : "border-border bg-surface text-fg-2 hover:bg-surface-2",
-      )}
-    >
-      {label}
-      <span
-        className={cn(
-          "font-mono",
-          active ? "text-accent" : "text-faint",
+      {/* 모달들 */}
+      <Modal open={showCreate} onClose={() => setShowCreate(false)} title="새 스킬 생성">
+        <SkillForm onClose={() => setShowCreate(false)} onSaved={afterSave} />
+      </Modal>
+
+      <Modal open={!!editingSkill} onClose={() => setEditingSkill(null)} title="스킬 편집">
+        {editingSkill && (
+          <SkillForm initial={editingSkill} onClose={() => setEditingSkill(null)} onSaved={afterSave} />
         )}
-      >
-        {count}
-      </span>
-    </button>
+      </Modal>
+
+      <Modal open={showUpload} onClose={() => setShowUpload(false)} title=".SKILL 파일 업로드">
+        <UploadForm onClose={() => setShowUpload(false)} onSaved={afterSave} />
+      </Modal>
+
+      <Modal open={showAutoCreate} onClose={() => setShowAutoCreate(false)} title="AI 스킬 자동 생성">
+        <AutoCreateForm onClose={() => setShowAutoCreate(false)} onSaved={afterSave} />
+      </Modal>
+
+      <Modal open={showGitIngest} onClose={() => setShowGitIngest(false)} title="Git URL에서 스킬 가져오기">
+        <GitIngestForm onClose={() => setShowGitIngest(false)} onSaved={afterSave} />
+      </Modal>
+    </>
   );
 }

--- a/apps/web/app/(workspace)/usage/page.tsx
+++ b/apps/web/app/(workspace)/usage/page.tsx
@@ -63,6 +63,172 @@ function modelBar(name: string): string {
 const fmtNum = (n?: number) =>
   n != null ? Number(n).toLocaleString("ko-KR") : "-";
 const fmtMs = (n?: number) => (n != null && n > 0 ? `${Math.round(n)}ms` : "-");
+const fmtCost = (n?: number) =>
+  n != null ? `$${n.toFixed(4)}` : "-";
+
+/* ── 시스템 토큰 모니터링 섹션 (관리자 전용) ────────────────── */
+interface MonitoringCosts {
+  today: {
+    totalCost: number;
+    byModel: Record<string, number>;
+    totalTokens: number;
+    totalRequests: number;
+  };
+  weekly: {
+    totalTokens: number;
+    totalRequests: number;
+    estimatedCost: number;
+  };
+  priceTable: Record<string, { input: number; output: number }>;
+}
+
+interface MonitoringDailyDatasets {
+  requests: number[];
+  tokens: number[];
+  errors: number[];
+  avgResponseTime: number[];
+}
+
+interface MonitoringDaily {
+  labels: string[];
+  datasets: MonitoringDailyDatasets;
+}
+
+interface MonitoringHourly {
+  labels: string[];
+  datasets: { requests: number[]; tokens: number[] };
+}
+
+function SystemTokenMonitor() {
+  const [costs, setCosts] = useState<MonitoringCosts | null>(null);
+  const [daily, setDaily] = useState<MonitoringDaily | null>(null);
+  const [hourly, setHourly] = useState<MonitoringHourly | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const [costsRes, dailyRes, hourlyRes] = await Promise.all([
+          ApiClient.get<{ data: MonitoringCosts }>("/api/monitoring/costs"),
+          ApiClient.get<{ data: MonitoringDaily }>("/api/monitoring/usage/daily?days=7"),
+          ApiClient.get<{ data: MonitoringHourly }>("/api/monitoring/usage/hourly"),
+        ]);
+        if (!alive) return;
+        setCosts(costsRes?.data ?? null);
+        setDaily(dailyRes?.data ?? null);
+        setHourly(hourlyRes?.data ?? null);
+        setVisible(true);
+      } catch {
+        // 401/비관리자 → 섹션 숨김
+      }
+    })();
+    return () => { alive = false; };
+  }, []);
+
+  if (!visible) return null;
+
+  const maxDailyTokens = Math.max(
+    1,
+    ...(daily?.datasets.tokens ?? []),
+  );
+  const maxHourlyTokens = Math.max(
+    1,
+    ...(hourly?.datasets.tokens ?? []),
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>시스템 토큰 모니터링</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* 비용 StatCard 4개 */}
+        {costs && (
+          <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+            <StatCard
+              label="오늘 비용"
+              value={fmtCost(costs.today.totalCost)}
+            />
+            <StatCard
+              label="오늘 토큰"
+              value={fmtNum(costs.today.totalTokens)}
+            />
+            <StatCard
+              label="주간 토큰"
+              value={fmtNum(costs.weekly.totalTokens)}
+            />
+            <StatCard
+              label="주간 예상 비용"
+              value={fmtCost(costs.weekly.estimatedCost)}
+            />
+          </div>
+        )}
+
+        {/* 일별 토큰 바 차트 */}
+        {daily && daily.labels.length > 0 && (
+          <div>
+            <p className="mb-3 text-xs font-medium text-fg-2">일별 토큰 (최근 7일)</p>
+            <div className="flex h-36 items-end gap-1.5">
+              {daily.labels.map((label, i) => {
+                const tokens = daily.datasets.tokens[i] ?? 0;
+                const pct = Math.max(2, Math.round((tokens / maxDailyTokens) * 100));
+                return (
+                  <div
+                    key={label}
+                    className="group flex h-full flex-1 flex-col items-center justify-end gap-1"
+                    title={`${label} · ${fmtNum(tokens)} 토큰`}
+                  >
+                    <span className="text-[10px] text-faint opacity-0 transition group-hover:opacity-100">
+                      {fmtNum(tokens)}
+                    </span>
+                    <div
+                      className="w-full rounded-t bg-accent-soft transition group-hover:bg-accent"
+                      style={{ height: `${pct}%` }}
+                    />
+                    <span className="font-mono text-[9px] text-faint">
+                      {label.slice(-5)}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* 시간별 토큰 바 차트 */}
+        {hourly && hourly.labels.length > 0 && (
+          <div>
+            <p className="mb-3 text-xs font-medium text-fg-2">시간별 토큰</p>
+            <div className="flex h-28 items-end gap-0.5">
+              {hourly.labels.map((label, i) => {
+                const tokens = hourly.datasets.tokens[i] ?? 0;
+                const pct = Math.max(2, Math.round((tokens / maxHourlyTokens) * 100));
+                return (
+                  <div
+                    key={label}
+                    className="group flex h-full flex-1 flex-col items-center justify-end gap-0.5"
+                    title={`${label} · ${fmtNum(tokens)} 토큰`}
+                  >
+                    <div
+                      className="w-full rounded-t bg-success-soft transition group-hover:bg-success"
+                      style={{ height: `${pct}%` }}
+                    />
+                    {i % 4 === 0 && (
+                      <span className="font-mono text-[8px] text-faint">
+                        {label}
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
 
 /* ── 목업 (비로그인/오류 폴백) ──────────────────────────── */
 function mockDaily(): DailyRow[] {
@@ -224,6 +390,9 @@ export default function UsagePage() {
                   )}
                 </CardContent>
               </Card>
+
+              {/* 시스템 토큰 모니터링 */}
+              <SystemTokenMonitor />
 
               {/* 모델별 사용 비중 */}
               <Card>

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ArrowRight, LoaderCircle } from "lucide-react";
 import { ApiClient, ApiError } from "@/lib/api-client";
@@ -122,6 +123,13 @@ export default function LoginPage() {
           >
             게스트로 계속하기
           </button>
+
+          <p className="mt-4 text-center text-xs text-muted">
+            계정이 없으신가요?{" "}
+            <Link href="/register" className="font-medium text-accent hover:underline">
+              회원가입
+            </Link>
+          </p>
         </form>
       </div>
     </div>

--- a/apps/web/app/register/page.tsx
+++ b/apps/web/app/register/page.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ArrowRight, LoaderCircle } from "lucide-react";
+import { ApiClient, ApiError } from "@/lib/api-client";
+import { Button } from "@/components/ui/primitives";
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [birthDate, setBirthDate] = useState("");
+  const [agreedToTerms, setAgreedToTerms] = useState(false);
+  const [agreedToPrivacy, setAgreedToPrivacy] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    if (!agreedToTerms || !agreedToPrivacy) {
+      setError("서비스 이용약관 및 개인정보 처리방침에 동의해야 합니다.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      await ApiClient.post("/api/auth/register", {
+        username,
+        email,
+        password,
+        birthDate,
+        agreedToTerms: true,
+        agreedToPrivacy: true,
+      });
+      router.push("/login");
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "회원가입에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="grid min-h-dvh place-items-center bg-app px-4">
+      <div className="w-full max-w-sm">
+        <div className="mb-7 flex flex-col items-center text-center">
+          <div className="grid h-12 w-12 place-items-center rounded-xl bg-accent text-xl font-bold text-accent-fg shadow-2">
+            O
+          </div>
+          <h1 className="mt-4 text-2xl font-bold text-fg">OpenMake.Ai</h1>
+          <p className="mt-1 text-sm text-muted">계정을 만들고 시작하세요</p>
+        </div>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            void submit();
+          }}
+          className="rounded-xl border border-border bg-surface p-6 shadow-2"
+        >
+          {error && (
+            <div className="mb-4 rounded-md bg-danger-soft px-3 py-2 text-xs text-danger">
+              {error}
+            </div>
+          )}
+
+          <label className="block text-xs font-medium text-fg-2">이름</label>
+          <input
+            type="text"
+            required
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="홍길동"
+            className="mt-1.5 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none transition placeholder:text-faint focus:border-accent focus:ring-2 focus:ring-[var(--accent-ring)]"
+          />
+
+          <label className="mt-4 block text-xs font-medium text-fg-2">이메일</label>
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@example.com"
+            className="mt-1.5 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none transition placeholder:text-faint focus:border-accent focus:ring-2 focus:ring-[var(--accent-ring)]"
+          />
+
+          <label className="mt-4 block text-xs font-medium text-fg-2">비밀번호</label>
+          <input
+            type="password"
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="••••••••"
+            className="mt-1.5 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none transition placeholder:text-faint focus:border-accent focus:ring-2 focus:ring-[var(--accent-ring)]"
+          />
+
+          <label className="mt-4 block text-xs font-medium text-fg-2">생년월일</label>
+          <input
+            type="date"
+            required
+            value={birthDate}
+            onChange={(e) => setBirthDate(e.target.value)}
+            className="mt-1.5 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none transition focus:border-accent focus:ring-2 focus:ring-[var(--accent-ring)]"
+          />
+
+          <div className="mt-4 space-y-2.5">
+            <label className="flex items-start gap-2.5 text-xs text-fg-2">
+              <input
+                type="checkbox"
+                checked={agreedToTerms}
+                onChange={(e) => setAgreedToTerms(e.target.checked)}
+                className="mt-0.5 shrink-0 accent-[var(--accent)]"
+              />
+              <span>
+                <span className="font-medium text-fg">서비스 이용약관</span>에 동의합니다{" "}
+                <span className="text-danger">*</span>
+              </span>
+            </label>
+            <label className="flex items-start gap-2.5 text-xs text-fg-2">
+              <input
+                type="checkbox"
+                checked={agreedToPrivacy}
+                onChange={(e) => setAgreedToPrivacy(e.target.checked)}
+                className="mt-0.5 shrink-0 accent-[var(--accent)]"
+              />
+              <span>
+                <span className="font-medium text-fg">개인정보 처리방침</span>에 동의합니다{" "}
+                <span className="text-danger">*</span>
+              </span>
+            </label>
+          </div>
+
+          <Button type="submit" disabled={loading} className="mt-5 w-full">
+            {loading ? (
+              <LoaderCircle className="h-4 w-4 animate-spin" />
+            ) : (
+              <>
+                회원가입 <ArrowRight className="h-4 w-4" />
+              </>
+            )}
+          </Button>
+
+          <p className="mt-4 text-center text-xs text-muted">
+            이미 계정이 있으신가요?{" "}
+            <Link href="/login" className="font-medium text-accent hover:underline">
+              로그인
+            </Link>
+          </p>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { Plus, Search } from "lucide-react";
+import { usePathname, useRouter } from "next/navigation";
+import { Plus, Search, LogOut } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { useAppStore } from "@/lib/store";
@@ -20,8 +20,19 @@ interface SessionRow {
 
 export function Sidebar() {
   const pathname = usePathname();
-  const { clearChat, auth } = useAppStore();
+  const router = useRouter();
+  const { clearChat, auth, setAuth } = useAppStore();
   const user = auth.currentUser;
+
+  const logout = async () => {
+    try {
+      await ApiClient.post("/api/auth/logout");
+    } catch {
+      /* 실패해도 진행 */
+    }
+    setAuth({ currentUser: null, isGuestMode: true });
+    router.push("/login");
+  };
 
   // 최근 대화 — /api/chat/conversations ({data:{sessions:[]}}). 실패/빈이면 목록 숨김.
   const { data: sessions = [] } = useQuery<SessionRow[]>({
@@ -125,6 +136,16 @@ export function Sidebar() {
           </p>
         </div>
         <ThemeToggle />
+        {user && (
+          <button
+            type="button"
+            onClick={() => void logout()}
+            aria-label="로그아웃"
+            className="grid h-8 w-8 place-items-center rounded-md text-muted transition hover:bg-surface-3 hover:text-danger"
+          >
+            <LogOut className="h-4 w-4" />
+          </button>
+        )}
       </div>
     </aside>
   );

--- a/apps/web/lib/nav.ts
+++ b/apps/web/lib/nav.ts
@@ -61,6 +61,7 @@ export const NAV_GROUPS: NavGroup[] = [
       { label: "설정", href: "/settings", icon: Settings },
       { label: "API 키", href: "/api-keys", icon: KeyRound },
       { label: "사용량", href: "/usage", icon: BarChart3 },
+      { label: "개발자 문서", href: "/developer", icon: ScrollText },
     ],
   },
   {
@@ -71,6 +72,7 @@ export const NAV_GROUPS: NavGroup[] = [
       { label: "감사 로그", href: "/admin/audit", icon: ScrollText },
       { label: "메트릭", href: "/admin/metrics", icon: Gauge },
       { label: "알림", href: "/admin/alerts", icon: Bell },
+      { label: "MCP 카탈로그 관리", href: "/admin/mcp-catalog", icon: Boxes },
     ],
   },
 ];

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -37,7 +37,10 @@ export class ApiError extends Error {
 
 const MUTATING = new Set<string>(MUTATING_METHODS);
 
-async function request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+/** 401 자동 refresh 를 건너뛸 endpoint 목록 (무한루프 방지). */
+const SKIP_REFRESH_ENDPOINTS = ["/api/auth/refresh", "/api/auth/login", "/api/auth/me"];
+
+async function request<T>(endpoint: string, options: RequestInit = {}, _isRetry = false): Promise<T> {
   const method = (options.method || "GET").toUpperCase();
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -52,6 +55,22 @@ async function request<T>(endpoint: string, options: RequestInit = {}): Promise<
   const text = await res.text();
   const json = text ? (JSON.parse(text) as ApiResponse<T> | T) : null;
   if (!res.ok) {
+    // 401 자동 refresh: 재시도 아니고, 건너뛸 endpoint 가 아닌 경우에만 1회 시도.
+    if (
+      res.status === 401 &&
+      !_isRetry &&
+      !SKIP_REFRESH_ENDPOINTS.some((ep) => endpoint === ep || endpoint.startsWith(ep + "?"))
+    ) {
+      try {
+        await fetch("/api/auth/refresh", { method: "POST", credentials: "include" });
+        return request<T>(endpoint, options, true);
+      } catch {
+        /* refresh 실패 → 아래 리다이렉트로 진행 */
+      }
+      if (typeof window !== "undefined" && window.location.pathname !== "/login") {
+        window.location.href = "/login";
+      }
+    }
     const body = json as { error?: { message?: string }; message?: string } | null;
     throw new ApiError(res.status, body?.error?.message || body?.message || `요청 실패 (${res.status})`, json);
   }


### PR DESCRIPTION
## 요약
Lumen 재구축 시 apps/web 23페이지가 **목록 조회만 되고 쓰기/액션 핸들러가 없던 "읽기 골격"** 상태였던 것을, backend 엔드포인트(이미 존재)에 맞춰 전수 복구.

## 복구 도메인
- **인증**: api-client 401→refresh→/login, 로그아웃, 회원가입(`/register`), 비밀번호 변경(보안 탭)
- **skill/agent**: 생성·편집·삭제·업로드·AI자동생성(SSE)·Git ingest·Draft·개인할당, custom-agents CRUD, agent-tasks 실행·상세모달·취소/resume, agent-learning 3패널 실연동
- **mcp/admin**: 카탈로그 설치, 사용자 CRUD, `/admin/mcp-catalog` 신규, connect/disconnect, crash-trend, guardian, audit/alerts export, 토큰/agent 모니터링, analytics 확장
- **신규 페이지**: `/register`, `/developer`, `/admin/mcp-catalog`

## 검증
- `apps/web` `tsc --noEmit`: **0**
- `next build`: **0** (26페이지 정적 생성)

## 주의·미완
- mcp start/stop: backend 라우트 부재 → connect/disconnect로 대체
- push 구독: service worker(`/sw.js`) 등록 전제
- 런타임 실연동은 빌드/타입까지만 검증(브라우저 실동작은 배포 후 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)