### PR TITLE
feat(web): 채팅 empty state 중앙 로고 적용

### DIFF
--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import Image from "next/image";
 import { useAppStore } from "@/lib/store";
 import { Markdown } from "./markdown";
 import { cn } from "@/lib/utils";
@@ -16,9 +17,13 @@ export function MessageList() {
   if (chatHistory.length === 0) {
     return (
       <div className="flex h-full flex-col items-center justify-center px-6 text-center">
-        <div className="grid h-14 w-14 place-items-center rounded-2xl bg-accent text-2xl font-bold text-accent-fg shadow-2">
-          O
-        </div>
+        <Image
+          src="/logo.png"
+          alt="OpenMake"
+          width={56}
+          height={56}
+          className="h-14 w-14 rounded-2xl object-contain"
+        />
         <h2 className="mt-5 text-2xl font-bold text-fg">무엇을 도와드릴까요?</h2>
         <p className="mt-2 max-w-md text-sm text-muted">
           멀티모델 오케스트레이션 · MCP 도구 · 딥 리서치 · 자율 에이전트.


### PR DESCRIPTION
채팅 빈 화면 중앙의 "O" 텍스트 placeholder를 OpenMake 브랜드 로고(`logo.png`, next/image)로 교체. 사이드바·login·favicon(PR #131)에 이어 마지막 남은 "O"를 통일.

## 검증
- apps/web `tsc --noEmit` 0, `next build` exit 0
- dev 브라우저 채팅 메인에서 로고 렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)