### PR TITLE
fix(api): OAuth 로그인 시 last_login 갱신 누락 수정

### DIFF
--- a/apps/api/src/data/user-manager.ts
+++ b/apps/api/src/data/user-manager.ts
@@ -296,6 +296,12 @@ class UserManagerImpl {
         return this.rowToPublicUser(row);
     }
 
+    /** OAuth 등 authenticate 를 거치지 않는 로그인 경로에서 last_login 갱신용. */
+    async updateLastLogin(userId: string): Promise<void> {
+        const pool = getPool();
+        await pool.query('UPDATE users SET last_login = $1 WHERE id = $2', [new Date().toISOString(), userId]);
+    }
+
     async getUserById(id: string): Promise<PublicUser | null> {
         const pool = getPool();
         const result = await pool.query('SELECT * FROM users WHERE id = $1', [id]);

--- a/apps/api/src/services/AuthService.ts
+++ b/apps/api/src/services/AuthService.ts
@@ -329,6 +329,7 @@ export class AuthService {
             }
         }
 
+        await this.userManager.updateLastLogin(publicUser.id);
         const token = generateToken(publicUser);
         log.info(`[OAuth] ${provider} 로그인 성공: ${email}`);
 


### PR DESCRIPTION
## 문제
`findOrCreateOAuthUser`는 email 로그인 경로(`userManager.authenticate`, 여기서 `last_login` UPDATE)를 거치지 않아, **OAuth(Google/GitHub) 로그인 시 `last_login`이 갱신되지 않았다**. riskpw(OAuth)의 last_login이 오래된 값으로 남아있던 원인.

## 수정
`user-manager`에 `updateLastLogin(userId)` 메서드 추가 → `findOrCreateOAuthUser`에서 토큰 발급 전 호출.

## 검증
- apps/api `tsc` 통과
- 재시작 후 OAuth 로그인 → DB `last_login` 갱신 확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)