### PR TITLE
feat(web): 모바일 최적화 (헤더 겹침 해소 + composer 압축)

### DIFF
--- a/apps/web/app/(workspace)/page.tsx
+++ b/apps/web/app/(workspace)/page.tsx
@@ -4,12 +4,12 @@ import { Composer } from "@/components/chat/composer";
 export default function ChatPage() {
   return (
     <>
-      <header className="flex h-14 items-center justify-between border-b border-border px-5">
-        <div>
-          <h1 className="text-sm font-semibold text-fg">새 대화</h1>
-          <p className="text-xs text-faint">워크스페이스 · 채팅</p>
+      <header className="flex h-14 items-center justify-between border-b border-border pl-14 pr-4 lg:px-5">
+        <div className="min-w-0">
+          <h1 className="truncate text-sm font-semibold text-fg">새 대화</h1>
+          <p className="truncate text-xs text-faint">워크스페이스 · 채팅</p>
         </div>
-        <span className="rounded-md bg-surface-2 px-2 py-1 font-mono text-xs text-muted">
+        <span className="shrink-0 rounded-md bg-surface-2 px-2 py-1 font-mono text-xs text-muted">
           Lumen
         </span>
       </header>

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -99,6 +99,7 @@ export function Composer() {
               <button
                 key={t.key}
                 onClick={() => toggle(t.key)}
+                title={t.label}
                 className={cn(
                   "inline-flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs font-medium transition",
                   t.on
@@ -107,7 +108,7 @@ export function Composer() {
                 )}
               >
                 <t.icon className="h-3.5 w-3.5" />
-                {t.label}
+                <span className="hidden sm:inline">{t.label}</span>
               </button>
             ))}
           </div>

--- a/apps/web/components/ui/primitives.tsx
+++ b/apps/web/components/ui/primitives.tsx
@@ -112,12 +112,12 @@ export function PageHeader({
   actions?: React.ReactNode;
 }) {
   return (
-    <div className="flex items-start justify-between gap-4 border-b border-border px-6 py-5">
-      <div>
-        <h1 className="text-xl font-bold text-fg">{title}</h1>
-        {description && <p className="mt-1 text-sm text-muted">{description}</p>}
+    <div className="flex items-start justify-between gap-4 border-b border-border pl-14 pr-6 py-5 lg:px-6">
+      <div className="min-w-0">
+        <h1 className="truncate text-xl font-bold text-fg">{title}</h1>
+        {description && <p className="mt-1 truncate text-sm text-muted">{description}</p>}
       </div>
-      {actions && <div className="flex items-center gap-2">{actions}</div>}
+      {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
     </div>
   );
 }


### PR DESCRIPTION
OD `openmake-mobile` 시안 참고한 모바일 최적화.

## 변경
- **헤더 햄버거 겹침 해소**: `mobile-sidebar`의 `fixed left-3 top-3` 햄버거와 겹쳐 제목이 잘리던 문제 → 헤더에 모바일 `pl-14`(데스크탑 `lg:` 원복) + `min-w-0 truncate` + 우측 `shrink-0`. 공통 `PageHeader`(20페이지) + 채팅 헤더(page.tsx)에 적용.
- **composer 압축**: 모드 토글 5개 라벨을 모바일에서 숨김(`hidden sm:inline`) + `title` tooltip → 아이콘 위주로 밀집 완화.

## 검증
- apps/web `tsc --noEmit` 0, `next build` exit 0
- 모바일(390px) 브라우저에서 채팅·history 헤더 겹침 해소 + composer 압축 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)