### PR TITLE
feat(web): 모바일 최적화 2차 (테이블 가로스크롤 + 빠른시작 카드)

### DIFF
--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   ArrowUp,
   Globe,
@@ -37,9 +37,11 @@ export function Composer() {
     agentTaskMode,
     selectedModel,
     style,
+    inputDraft,
     toggle,
     setSelectedModel,
     cycleStyle,
+    setInputDraft,
   } = useAppStore();
 
   const submit = () => {
@@ -48,6 +50,19 @@ export function Composer() {
     setText("");
     if (taRef.current) taRef.current.style.height = "auto";
   };
+
+  // 빠른 시작 카드(message-list)에서 설정한 draft 를 textarea 에 prefill 후 소비.
+  useEffect(() => {
+    if (!inputDraft) return;
+    setText(inputDraft);
+    setInputDraft("");
+    const ta = taRef.current;
+    if (ta) {
+      ta.focus();
+      ta.style.height = "auto";
+      ta.style.height = Math.min(ta.scrollHeight, 200) + "px";
+    }
+  }, [inputDraft, setInputDraft]);
 
   const TOGGLES = [
     { key: "discussionMode" as const, on: discussionMode, icon: MessagesSquare, label: "토론" },

--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -2,12 +2,21 @@
 
 import { useEffect, useRef } from "react";
 import Image from "next/image";
+import { MessagesSquare, Telescope, Brain, Sparkles } from "lucide-react";
 import { useAppStore } from "@/lib/store";
 import { Markdown } from "./markdown";
 import { cn } from "@/lib/utils";
 
+const QUICK_STARTS = [
+  { icon: MessagesSquare, label: "요약하기", prompt: "다음 내용을 요약해 줘:\n\n" },
+  { icon: Telescope, label: "리서치", prompt: "다음 주제를 깊이 리서치해 줘:\n\n" },
+  { icon: Brain, label: "단계별 분석", prompt: "다음 문제를 단계별로 분석해 줘:\n\n" },
+  { icon: Sparkles, label: "브레인스토밍", prompt: "다음에 대해 브레인스토밍하자:\n\n" },
+];
+
 export function MessageList() {
   const chatHistory = useAppStore((s) => s.chatHistory);
+  const setInputDraft = useAppStore((s) => s.setInputDraft);
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -29,6 +38,19 @@ export function MessageList() {
           멀티모델 오케스트레이션 · MCP 도구 · 딥 리서치 · 자율 에이전트.
           아래에 질문을 입력하거나 <span className="font-mono text-accent">/</span> 로 스킬을 호출하세요.
         </p>
+
+        <div className="mt-7 grid w-full max-w-md grid-cols-2 gap-2.5">
+          {QUICK_STARTS.map((q) => (
+            <button
+              key={q.label}
+              onClick={() => setInputDraft(q.prompt)}
+              className="flex items-center gap-2.5 rounded-xl border border-border bg-surface px-3.5 py-3 text-left text-sm font-medium text-fg transition hover:border-border-strong hover:bg-surface-2"
+            >
+              <q.icon className="h-4 w-4 shrink-0 text-accent" />
+              <span className="truncate">{q.label}</span>
+            </button>
+          ))}
+        </div>
       </div>
     );
   }

--- a/apps/web/components/ui/primitives.tsx
+++ b/apps/web/components/ui/primitives.tsx
@@ -49,7 +49,7 @@ export function Card({
   return (
     <div
       className={cn(
-        "rounded-lg border border-border bg-surface shadow-1",
+        "rounded-lg border border-border bg-surface shadow-1 overflow-hidden",
         className,
       )}
       {...props}
@@ -156,7 +156,7 @@ export function StatCard({
 export function Table({ children }: { children: React.ReactNode }) {
   return (
     <div className="overflow-x-auto">
-      <table className="w-full text-sm">{children}</table>
+      <table className="min-w-full text-sm">{children}</table>
     </div>
   );
 }

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -31,6 +31,8 @@ interface AppState {
   chatHistory: ChatMessage[];
   currentSessionId: string | null;
   isGenerating: boolean;
+  /** empty state 빠른 시작 카드 → composer prefill 용 드래프트 */
+  inputDraft: string;
 
   // 모드 토글 (기존 state.js)
   thinkingEnabled: boolean;
@@ -53,6 +55,7 @@ interface AppState {
   appendToken: (token: string) => void;
   setStreaming: (v: boolean) => void;
   setCurrentSessionId: (id: string | null) => void;
+  setInputDraft: (t: string) => void;
   clearChat: () => void;
 
   toggle: (
@@ -74,6 +77,7 @@ export const useAppStore = create<AppState>((set) => ({
   chatHistory: [],
   currentSessionId: null,
   isGenerating: false,
+  inputDraft: "",
 
   thinkingEnabled: true,
   discussionMode: false,
@@ -110,6 +114,7 @@ export const useAppStore = create<AppState>((set) => ({
       return { chatHistory: hist, isGenerating: v };
     }),
   setCurrentSessionId: (id) => set({ currentSessionId: id }),
+  setInputDraft: (t) => set({ inputDraft: t }),
   clearChat: () => set({ chatHistory: [], currentSessionId: null }),
 
   toggle: (key) => set((s) => ({ [key]: !s[key] }) as Partial<AppState>),


### PR DESCRIPTION
OD `openmake-mobile` 시안 기준 모바일 최적화 2차.

## 변경
- **데이터 테이블 reflow**: 공통 `Table` 컴포넌트에 `overflow-x-auto` + `min-w-full`(컬럼 압착·페이지 가로넘침 방지) + `Card overflow-hidden`. analytics·audit·metrics·usage·mcp-catalog·api-keys·mcp-servers·mcp-monitoring 8개 페이지 일괄.
- **채팅 빠른시작 카드**: empty state에 2×2 카드(요약/리서치/단계별분석/브레인스토밍). 클릭 시 `store.inputDraft` → composer textarea prefill(실측 확인).

## 검증
- apps/web `tsc --noEmit` 0, `next build` exit 0
- 모바일(390px) 브라우저: 카드 렌더 + 클릭 prefill 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)