### PR TITLE
fix(web): 모바일 디바이스 viewport meta 누락 수정 + safe-area

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
@@ -12,6 +12,14 @@ const jetbrainsMono = JetBrains_Mono({
 export const metadata: Metadata = {
   title: "OpenMake.Ai",
   description: "AI 기반 지능형 채팅 어시스턴트",
+};
+
+// 실제 모바일 디바이스 반응형의 핵심 — viewport meta 가 없으면 모바일 브라우저가
+// 데스크탑 너비로 렌더 후 축소해 레이아웃이 작게 뭉개진다.
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover", // 노치/홈바 safe-area 대응
 };
 
 export default function RootLayout({

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -73,7 +73,7 @@ export function Composer() {
   ];
 
   return (
-    <div className="mx-auto w-full max-w-3xl px-4 pb-4">
+    <div className="mx-auto w-full max-w-3xl px-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
       <div className="rounded-xl border border-border bg-surface shadow-2">
         <textarea
           ref={taRef}

--- a/apps/web/components/mobile-sidebar.tsx
+++ b/apps/web/components/mobile-sidebar.tsx
@@ -18,7 +18,7 @@ export function MobileSidebar() {
       <button
         onClick={() => setOpen(true)}
         aria-label="메뉴 열기"
-        className="fixed left-3 top-3 z-30 grid h-9 w-9 place-items-center rounded-md border border-border bg-surface text-fg shadow-1 lg:hidden"
+        className="fixed left-3 top-[max(0.75rem,env(safe-area-inset-top))] z-30 grid h-9 w-9 place-items-center rounded-md border border-border bg-surface text-fg shadow-1 lg:hidden"
       >
         <Menu className="h-[18px] w-[18px]" />
       </button>


### PR DESCRIPTION
## 근본 원인
`apps/web/app/layout.tsx`에 **viewport export가 없어**, 실제 모바일 디바이스에서 브라우저가 페이지를 데스크탑 너비로 렌더한 뒤 축소 → 레이아웃이 작게 뭉개졌습니다. (이전 모바일 작업 PR #134/#135는 Playwright viewport resize 기준이라 이 문제가 안 드러났습니다 — 실제 디바이스에서만 발생.)

## 수정 (apps/web 단일 구조 — 별도 모바일 폴더 없음)
- `viewport` export 추가: `width=device-width, initialScale=1, viewportFit=cover`
- 노치/홈바 대응: `mobile-sidebar` 햄버거 `top` + `composer` 하단 `pb`에 `env(safe-area-inset-*)` 적용

## 검증
- `next build` exit 0, 빌드 HTML에 `width=device-width` meta 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)