### PR TITLE
feat(web): OD lumen 모바일 시안 1:1 정합 (하단 탭바 + 칩 토글)

### DIFF
--- a/apps/web/app/(workspace)/layout.tsx
+++ b/apps/web/app/(workspace)/layout.tsx
@@ -12,7 +12,7 @@ export default function WorkspaceLayout({
         <Sidebar />
       </div>
       <MobileSidebar />
-      <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
+      <main className="flex min-w-0 flex-1 flex-col overflow-hidden pb-[calc(3.25rem+env(safe-area-inset-bottom))] lg:pb-0">
         {children}
       </main>
     </div>

--- a/apps/web/app/(workspace)/page.tsx
+++ b/apps/web/app/(workspace)/page.tsx
@@ -4,7 +4,7 @@ import { Composer } from "@/components/chat/composer";
 export default function ChatPage() {
   return (
     <>
-      <header className="flex h-14 items-center justify-between border-b border-border pl-14 pr-4 lg:px-5">
+      <header className="flex h-14 items-center justify-between border-b border-border px-5">
         <div className="min-w-0">
           <h1 className="truncate text-sm font-semibold text-fg">새 대화</h1>
           <p className="truncate text-xs text-faint">워크스페이스 · 채팅</p>

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -75,6 +75,26 @@ export function Composer() {
   return (
     <div className="mx-auto w-full max-w-3xl px-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
       <div className="rounded-xl border border-border bg-surface shadow-2">
+        {/* 모드 토글 — 가로 스크롤 칩 (OD lumen 모바일 시안: 컴포저 상단) */}
+        <div className="flex items-center gap-1.5 overflow-x-auto px-3 pt-2.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {TOGGLES.map((t) => (
+            <button
+              key={t.key}
+              onClick={() => toggle(t.key)}
+              title={t.label}
+              className={cn(
+                "inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition",
+                t.on
+                  ? "border-accent bg-accent-soft text-accent"
+                  : "border-border text-muted hover:bg-surface-2 hover:text-fg",
+              )}
+            >
+              <t.icon className="h-3.5 w-3.5" />
+              {t.label}
+            </button>
+          ))}
+        </div>
+
         <textarea
           ref={taRef}
           value={text}
@@ -91,11 +111,11 @@ export function Composer() {
           }}
           rows={1}
           placeholder="메시지를 입력하거나 / 로 스킬을 호출하세요..."
-          className="block w-full resize-none bg-transparent px-4 pt-3.5 text-sm text-fg outline-none placeholder:text-faint"
+          className="block w-full resize-none bg-transparent px-4 pt-2.5 text-sm text-fg outline-none placeholder:text-faint"
         />
 
+        {/* 하단: 모델 셀렉터 + 스타일 + 전송 */}
         <div className="flex items-center gap-1.5 px-2.5 pb-2.5 pt-1">
-          {/* 모델 셀렉터 */}
           <select
             value={selectedModel}
             onChange={(e) => setSelectedModel(e.target.value)}
@@ -108,41 +128,19 @@ export function Composer() {
             ))}
           </select>
 
-          {/* 모드 토글 */}
-          <div className="flex flex-wrap items-center gap-1">
-            {TOGGLES.map((t) => (
-              <button
-                key={t.key}
-                onClick={() => toggle(t.key)}
-                title={t.label}
-                className={cn(
-                  "inline-flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs font-medium transition",
-                  t.on
-                    ? "bg-accent-soft text-accent"
-                    : "text-muted hover:bg-surface-2 hover:text-fg",
-                )}
-              >
-                <t.icon className="h-3.5 w-3.5" />
-                <span className="hidden sm:inline">{t.label}</span>
-              </button>
-            ))}
-          </div>
-
-          {/* 스타일 cycle */}
           <button
             onClick={cycleStyle}
-            className="ml-auto rounded-md px-2 py-1.5 text-xs font-medium capitalize text-muted hover:bg-surface-2 hover:text-fg"
+            className="rounded-md px-2 py-1.5 text-xs font-medium capitalize text-muted hover:bg-surface-2 hover:text-fg"
             title="응답 스타일"
           >
             {style}
           </button>
 
-          {/* 전송 / 중단 */}
           {isGenerating ? (
             <button
               onClick={abort}
               aria-label="중단"
-              className="grid h-8 w-8 place-items-center rounded-md bg-surface-3 text-fg transition hover:bg-border-strong"
+              className="ml-auto grid h-8 w-8 place-items-center rounded-md bg-surface-3 text-fg transition hover:bg-border-strong"
             >
               <Square className="h-3.5 w-3.5 fill-current" />
             </button>
@@ -151,7 +149,7 @@ export function Composer() {
               onClick={submit}
               disabled={!text.trim()}
               aria-label="전송"
-              className="grid h-8 w-8 place-items-center rounded-md bg-accent text-accent-fg transition hover:bg-accent-hover disabled:opacity-40"
+              className="ml-auto grid h-8 w-8 place-items-center rounded-md bg-accent text-accent-fg transition hover:bg-accent-hover disabled:opacity-40"
             >
               <ArrowUp className="h-4 w-4" />
             </button>

--- a/apps/web/components/mobile-sidebar.tsx
+++ b/apps/web/components/mobile-sidebar.tsx
@@ -2,29 +2,33 @@
 
 import { useState, useEffect } from "react";
 import { usePathname } from "next/navigation";
-import { Menu, X } from "lucide-react";
+import Link from "next/link";
+import { MessageSquare, Telescope, Sparkles, Menu, X } from "lucide-react";
 import { Sidebar } from "./sidebar";
+import { cn } from "@/lib/utils";
 
-/** 모바일(<lg) 사이드바 드로어 + 햄버거 토글. 데스크탑은 layout 의 고정 사이드바 사용. */
+/** OD lumen 모바일 시안: 하단 탭바(44px+ 터치 타깃) + "메뉴" 탭으로 전체 드로어. 데스크탑(lg)은 고정 사이드바. */
+const TABS = [
+  { label: "채팅", href: "/", icon: MessageSquare },
+  { label: "리서치", href: "/research", icon: Telescope },
+  { label: "에이전트", href: "/agent-tasks", icon: Sparkles },
+];
+
 export function MobileSidebar() {
   const [open, setOpen] = useState(false);
   const pathname = usePathname();
 
-  // 라우트 이동 시 자동 닫기
+  // 라우트 이동 시 드로어 자동 닫기
   useEffect(() => setOpen(false), [pathname]);
+
+  const isActive = (href: string) =>
+    href === "/" ? pathname === "/" : pathname.startsWith(href);
 
   return (
     <>
-      <button
-        onClick={() => setOpen(true)}
-        aria-label="메뉴 열기"
-        className="fixed left-3 top-[max(0.75rem,env(safe-area-inset-top))] z-30 grid h-9 w-9 place-items-center rounded-md border border-border bg-surface text-fg shadow-1 lg:hidden"
-      >
-        <Menu className="h-[18px] w-[18px]" />
-      </button>
-
+      {/* 전체 메뉴 드로어 ("메뉴" 탭으로 열림) */}
       {open && (
-        <div className="fixed inset-0 z-40 lg:hidden">
+        <div className="fixed inset-0 z-50 lg:hidden">
           <div
             className="absolute inset-0 bg-black/40"
             onClick={() => setOpen(false)}
@@ -41,6 +45,31 @@ export function MobileSidebar() {
           </div>
         </div>
       )}
+
+      {/* 하단 탭바 (모바일 전용) */}
+      <nav className="fixed inset-x-0 bottom-0 z-30 flex items-stretch border-t border-border bg-surface pb-[env(safe-area-inset-bottom)] lg:hidden">
+        {TABS.map((t) => (
+          <Link
+            key={t.href}
+            href={t.href}
+            className={cn(
+              "flex min-h-[52px] flex-1 flex-col items-center justify-center gap-0.5 text-[11px] font-medium transition",
+              isActive(t.href) ? "text-accent" : "text-muted hover:text-fg",
+            )}
+          >
+            <t.icon className="h-5 w-5" />
+            {t.label}
+          </Link>
+        ))}
+        <button
+          onClick={() => setOpen(true)}
+          aria-label="전체 메뉴"
+          className="flex min-h-[52px] flex-1 flex-col items-center justify-center gap-0.5 text-[11px] font-medium text-muted transition hover:text-fg"
+        >
+          <Menu className="h-5 w-5" />
+          메뉴
+        </button>
+      </nav>
     </>
   );
 }

--- a/apps/web/components/ui/primitives.tsx
+++ b/apps/web/components/ui/primitives.tsx
@@ -112,7 +112,7 @@ export function PageHeader({
   actions?: React.ReactNode;
 }) {
   return (
-    <div className="flex items-start justify-between gap-4 border-b border-border pl-14 pr-6 py-5 lg:px-6">
+    <div className="flex items-start justify-between gap-4 border-b border-border px-6 py-5">
       <div className="min-w-0">
         <h1 className="truncate text-xl font-bold text-fg">{title}</h1>
         {description && <p className="mt-1 truncate text-sm text-muted">{description}</p>}


### PR DESCRIPTION
OD `openmake-newdesign-2026`의 **"04 — Mobile"** 시안("컴포저 우선 설계. 모드 토글은 가로 스크롤 칩으로, 하단 탭바는 44px+ 터치 타깃")과 불일치하던 모바일 UI를 1:1 정합.

## 변경
- **하단 탭바**: 햄버거 드로어 → 하단 탭바(채팅/리서치/에이전트/메뉴, `min-h-[52px]` 44px+ 터치, safe-area). "메뉴" 탭이 전체 드로어.
- **모드 토글 칩**: 아이콘 압축 → 가로 스크롤 `rounded-full` 칩, composer 상단.
- **composer 레이아웃**: 칩(위) + 입력 + 하단(모델/스타일/전송) — OD 시안 순서.
- 햄버거 제거 → 헤더 `pl-14` 원복(PageHeader + 채팅), `main`에 탭바 공간 `pb` + safe-area.

## 검증
- `next build` exit 0
- 모바일(390px) 채팅·history 화면이 OD lumen 시안과 정합 확인(하단 탭바·칩 토글)

🤖 Generated with [Claude Code](https://claude.com/claude-code)