### PR TITLE
feat(web): 외부 LLM 모델 셀렉터 복원 (brand 제거 + /api/models 동적)

### DIFF
--- a/apps/web/app/(workspace)/settings/page.tsx
+++ b/apps/web/app/(workspace)/settings/page.tsx
@@ -20,7 +20,10 @@ import {
   PageHeader,
 } from "@/components/ui/primitives";
 import type { ApiSuccess } from "@openmake/shared-types";
+import { useQuery } from "@tanstack/react-query";
 import { ApiClient, ApiError } from "@/lib/api-client";
+import { useAppStore } from "@/lib/store";
+import { fetchModels } from "@/lib/models-api";
 import { cn } from "@/lib/utils";
 
 /* ── 탭 정의 ────────────────────────────────────────────── */
@@ -35,14 +38,6 @@ const TABS: { id: TabId; label: string; icon: LucideIcon }[] = [
   { id: "security", label: "보안", icon: ShieldCheck },
 ];
 
-const MODEL_PROFILES = [
-  { value: "default", label: "Default (Auto)" },
-  { value: "pro", label: "Pro" },
-  { value: "fast", label: "Fast" },
-  { value: "think", label: "Think" },
-  { value: "code", label: "Code" },
-  { value: "vision", label: "Vision" },
-];
 
 const RESPONSE_STYLES = [
   { value: "concise", label: "간결" },
@@ -146,7 +141,17 @@ export default function SettingsPage() {
   const [tab, setTab] = useState<TabId>("general");
 
   // 일반 / 모델
-  const [defaultModel, setDefaultModel] = useState("default");
+  const selectedModel = useAppStore((s) => s.selectedModel);
+  const setSelectedModel = useAppStore((s) => s.setSelectedModel);
+  const { data: modelsData } = useQuery({
+    queryKey: ["models"],
+    queryFn: fetchModels,
+    staleTime: 60_000,
+  });
+  const modelOptions = (modelsData?.models ?? []).map((m) => ({
+    value: m.modelId,
+    label: m.name + (m.isFree ? " · 무료" : ""),
+  }));
   const [responseStyle, setResponseStyle] =
     useState<(typeof RESPONSE_STYLES)[number]["value"]>("default");
   const [language, setLanguage] = useState("");
@@ -399,13 +404,17 @@ export default function SettingsPage() {
                 </CardHeader>
                 <CardContent className="py-0">
                   <FieldRow
-                    title="기본 모델 프로파일"
-                    description="새 대화에 기본으로 사용할 모델 프로파일입니다."
+                    title="기본 모델"
+                    description="새 대화에 사용할 모델입니다. 로컬 vLLM + 등록한 외부 LLM(API 키 페이지)."
                   >
                     <Select
-                      value={defaultModel}
-                      onChange={setDefaultModel}
-                      options={MODEL_PROFILES}
+                      value={selectedModel}
+                      onChange={setSelectedModel}
+                      options={
+                        modelOptions.length
+                          ? modelOptions
+                          : [{ value: "", label: "모델 로딩…" }]
+                      }
                     />
                   </FieldRow>
                   <FieldRow

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
 import {
   ArrowUp,
   Globe,
+  KeyRound,
   MessagesSquare,
   Sparkles,
   Square,
@@ -12,21 +15,21 @@ import {
 } from "lucide-react";
 import { useAppStore } from "@/lib/store";
 import { useChatSocket } from "@/lib/use-chat-socket";
+import { fetchModels } from "@/lib/models-api";
 import { cn } from "@/lib/utils";
-
-const MODELS = [
-  { id: "default", label: "Auto" },
-  { id: "pro", label: "Pro" },
-  { id: "fast", label: "Fast" },
-  { id: "think", label: "Think" },
-  { id: "code", label: "Code" },
-  { id: "vision", label: "Vision" },
-];
 
 export function Composer() {
   const { sendChat, abort } = useChatSocket();
   const [text, setText] = useState("");
   const taRef = useRef<HTMLTextAreaElement>(null);
+
+  // 로컬 vLLM + 등록된 외부 LLM(OpenRouter 등) 통합 모델 목록
+  const { data: modelsData } = useQuery({
+    queryKey: ["models"],
+    queryFn: fetchModels,
+    staleTime: 60_000,
+  });
+  const models = modelsData?.models ?? [];
 
   const {
     isGenerating,
@@ -43,6 +46,16 @@ export function Composer() {
     cycleStyle,
     setInputDraft,
   } = useAppStore();
+
+  // 모델 목록 로드 시 현재 selectedModel 이 목록에 없으면 defaultModel 로 동기화
+  useEffect(() => {
+    if (!modelsData) return;
+    if (!modelsData.models.some((m) => m.modelId === selectedModel)) {
+      setSelectedModel(modelsData.defaultModel);
+    }
+    // selectedModel 변동마다 재실행 불필요 — 목록 로드 시점에만 보정
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [modelsData]);
 
   const submit = () => {
     if (!text.trim() || isGenerating) return;
@@ -114,19 +127,31 @@ export function Composer() {
           className="block w-full resize-none bg-transparent px-4 pt-2.5 text-sm text-fg outline-none placeholder:text-faint"
         />
 
-        {/* 하단: 모델 셀렉터 + 스타일 + 전송 */}
+        {/* 하단: 모델 셀렉터(로컬 + 외부 LLM) + 키 관리 + 스타일 + 전송 */}
         <div className="flex items-center gap-1.5 px-2.5 pb-2.5 pt-1">
           <select
             value={selectedModel}
             onChange={(e) => setSelectedModel(e.target.value)}
-            className="rounded-md border border-border bg-surface-2 px-2 py-1.5 text-xs font-medium text-fg outline-none"
+            title="모델 선택 (로컬 + 등록한 외부 LLM)"
+            className="max-w-[40%] truncate rounded-md border border-border bg-surface-2 px-2 py-1.5 text-xs font-medium text-fg outline-none"
           >
-            {MODELS.map((m) => (
-              <option key={m.id} value={m.id}>
-                {m.label}
+            {models.length === 0 && <option value="">모델 로딩…</option>}
+            {models.map((m) => (
+              <option key={m.modelId} value={m.modelId}>
+                {m.name}
+                {m.isFree ? " · 무료" : ""}
+                {m.available === false ? " (불가)" : ""}
               </option>
             ))}
           </select>
+
+          <Link
+            href="/api-keys"
+            title="외부 LLM(OpenRouter 등) 키 등록·관리"
+            className="grid h-8 w-8 shrink-0 place-items-center rounded-md text-muted transition hover:bg-surface-2 hover:text-fg"
+          >
+            <KeyRound className="h-4 w-4" />
+          </Link>
 
           <button
             onClick={cycleStyle}

--- a/apps/web/lib/models-api.ts
+++ b/apps/web/lib/models-api.ts
@@ -1,0 +1,28 @@
+import { ApiClient } from "@/lib/api-client";
+
+/** /api/models 의 모델 1건 (로컬 vLLM 또는 등록된 외부 LLM provider). */
+export interface ModelEntry {
+  name: string;
+  modelId: string;
+  description?: string;
+  provider: string; // 'local-llm' | providerId(외부, 예: 'openrouter')
+  isFree?: boolean;
+  available?: boolean;
+  capabilities?: Record<string, unknown>;
+}
+
+export interface ModelsPayload {
+  defaultModel: string;
+  models: ModelEntry[];
+}
+
+/**
+ * GET /api/models — 로컬 vLLM 모델 + 인증 사용자가 등록한 외부 LLM(OpenRouter 등 openai-compatible)
+ * provider 의 모델을 합산한 통합 목록. (legacy models-api.js 대응)
+ */
+export async function fetchModels(): Promise<ModelsPayload> {
+  const res = await ApiClient.get<{ success: boolean; data: ModelsPayload }>(
+    "/api/models",
+  );
+  return res?.data ?? { defaultModel: "", models: [] };
+}


### PR DESCRIPTION
## 문제
OpenRouter 등 **외부 LLM 모델 선택 기능이 사라짐**. 백엔드 `/api/models`는 로컬 vLLM + 인증 사용자의 등록 외부 키(openai-compatible)의 `/v1/models`를 **합산**(model.routes.ts:150)하는데, apps/web composer가 **brand profile(Default/Pro/Fast/Think/Code/Vision/Auto)을 하드코딩**해 이를 무시했습니다. (legacy `models-api.js`+`model-selector.js`의 동적 표시가 재구축 때 누락.)

## 복원
- `lib/models-api.ts`: `/api/models` 클라이언트(로컬+외부 통합)
- **composer**: brand 하드코딩 제거 → `useQuery` 동적 모델 셀렉터 + 외부 키 관리(`/api-keys`) 진입(KeyRound)
- **settings**: 기본 모델 프로파일 brand 제거 → 동적 모델(store `selectedModel` 연동)
- `selectedModel` = full modelId(`local-llm:..` / `openrouter:..`)

## 검증
- `tsc --noEmit` 0, `next build` 0
- composer 동적 모델 확인: `Qwen 3.6`, `GPT-3.5` (외부 키 등록 시 OpenRouter 모델 자동 합산)

🤖 Generated with [Claude Code](https://claude.com/claude-code)