### PR TITLE
fix(web): MCP 카탈로그 설치 실패 수정 (from-catalog 라우트)

### DIFF
--- a/apps/web/app/(workspace)/mcp-catalog/page.tsx
+++ b/apps/web/app/(workspace)/mcp-catalog/page.tsx
@@ -136,11 +136,11 @@ export default function McpCatalogPage() {
     setInstalling((prev) => ({ ...prev, [e.id]: true }));
     setInstallError((prev) => ({ ...prev, [e.id]: "" }));
     try {
-      await ApiClient.post("/api/mcp/servers", {
-        name: e.name,
-        transport_type: "stdio",
-        catalog_template_id: e.id,
-        visibility: "global",
+      // 카탈로그 설치 전용 라우트 — 백엔드가 template_id 로 command/args/env 를 채운다.
+      // (일반 POST /servers 는 stdio 시 command 필수라 400 — from-catalog 가 정답)
+      await ApiClient.post("/api/mcp/servers/from-catalog", {
+        template_id: e.id,
+        name: e.id.replace(/[^a-zA-Z0-9_-]/g, "-"), // name 은 영숫자/_/- 만 허용
       });
       setEntries((prev) =>
         prev.map((item) =>


### PR DESCRIPTION
## 문제
MCP 카탈로그에서 Brave Search / DuckDuckGo / Fetch 등 설치 시 **"설치 실패. 다시 시도해 주세요."**(백엔드 400 반복).

## 원인
프론트 `handleInstall`이 **`POST /api/mcp/servers`**(일반 서버 등록)를 호출. 이 스키마는 `transport_type='stdio'`면 **command 필수**(`mcpServerCreateSchema` refine)인데, 카탈로그 응답(`ApiCatalogTemplate`)엔 command가 없어 항상 400.

## 수정
올바른 전용 라우트 **`POST /api/mcp/servers/from-catalog`**로 교정 — 백엔드가 `template_id`로 `createFromCatalog`를 실행해 카탈로그의 `command_template`/`args_schema`/`env_schema`를 채워 서버를 생성. payload `{ template_id, name(영숫자/_/- 으로 sanitize) }`.

## 검증
- 실측: Brave Search 설치 → **201 Created** (`command: "npx"`, `args: ["-y","@modelcontextprotocol/server-brave-search"]` 자동 채워짐)
- `tsc --noEmit` 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)