### PR TITLE
feat(web): 채팅 활성 에이전트·스킬 표시 복원

### DIFF
--- a/apps/web/app/(workspace)/page.tsx
+++ b/apps/web/app/(workspace)/page.tsx
@@ -1,4 +1,5 @@
 import { MessageList } from "@/components/chat/message-list";
+import { ActiveContext } from "@/components/chat/active-context";
 import { Composer } from "@/components/chat/composer";
 
 export default function ChatPage() {
@@ -18,6 +19,7 @@ export default function ChatPage() {
         <MessageList />
       </div>
 
+      <ActiveContext />
       <Composer />
     </>
   );

--- a/apps/web/components/chat/active-context.tsx
+++ b/apps/web/components/chat/active-context.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useAppStore } from "@/lib/store";
+
+/**
+ * 채팅창(컴포저) 위에 표시되는 활성 컨텍스트 바.
+ * 백엔드 ws 의 agent_selected / skills_activated 로 채워진 store 의 activeAgent·activeSkills 를 보여준다.
+ * (사용자 질문에 답할 때 라우팅된 에이전트 + 주입된 스킬)
+ */
+export function ActiveContext() {
+  const activeAgent = useAppStore((s) => s.activeAgent);
+  const activeSkills = useAppStore((s) => s.activeSkills);
+
+  if (!activeAgent && activeSkills.length === 0) return null;
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-wrap items-center gap-1.5 px-4 pb-2 text-xs">
+      {activeAgent && (
+        <span className="inline-flex items-center gap-1 rounded-full bg-accent-soft px-2.5 py-0.5 font-medium text-accent">
+          <span>{activeAgent.emoji || "🤖"}</span>
+          {activeAgent.name}
+        </span>
+      )}
+      {activeSkills.map((s) => (
+        <span
+          key={s}
+          className="inline-flex items-center gap-1 rounded-full bg-surface-2 px-2.5 py-0.5 font-medium text-muted"
+        >
+          <span>🛠</span>
+          {s}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -33,6 +33,9 @@ interface AppState {
   isGenerating: boolean;
   /** empty state 빠른 시작 카드 → composer prefill 용 드래프트 */
   inputDraft: string;
+  /** 현재 응답에 선택된 에이전트 + 활성 스킬 (ws agent_selected / skills_activated) */
+  activeAgent: { name: string; emoji?: string } | null;
+  activeSkills: string[];
 
   // 모드 토글 (기존 state.js)
   thinkingEnabled: boolean;
@@ -56,6 +59,8 @@ interface AppState {
   setStreaming: (v: boolean) => void;
   setCurrentSessionId: (id: string | null) => void;
   setInputDraft: (t: string) => void;
+  setActiveAgent: (a: { name: string; emoji?: string } | null) => void;
+  setActiveSkills: (s: string[]) => void;
   clearChat: () => void;
 
   toggle: (
@@ -78,6 +83,8 @@ export const useAppStore = create<AppState>((set) => ({
   currentSessionId: null,
   isGenerating: false,
   inputDraft: "",
+  activeAgent: null,
+  activeSkills: [],
 
   thinkingEnabled: true,
   discussionMode: false,
@@ -115,7 +122,10 @@ export const useAppStore = create<AppState>((set) => ({
     }),
   setCurrentSessionId: (id) => set({ currentSessionId: id }),
   setInputDraft: (t) => set({ inputDraft: t }),
-  clearChat: () => set({ chatHistory: [], currentSessionId: null }),
+  setActiveAgent: (a) => set({ activeAgent: a }),
+  setActiveSkills: (s) => set({ activeSkills: s }),
+  clearChat: () =>
+    set({ chatHistory: [], currentSessionId: null, activeAgent: null, activeSkills: [] }),
 
   toggle: (key) => set((s) => ({ [key]: !s[key] }) as Partial<AppState>),
   setSelectedModel: (m) => set({ selectedModel: m }),

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -30,6 +30,8 @@ export function useChatSocket() {
     appendToken,
     setStreaming,
     setCurrentSessionId,
+    setActiveAgent,
+    setActiveSkills,
   } = useAppStore();
 
   const connect = useCallback(() => {
@@ -72,8 +74,14 @@ export function useChatSocket() {
           });
           setStreaming(false);
           break;
+        case "agent_selected":
+          setActiveAgent({ name: data.agent.name, emoji: data.agent.emoji });
+          break;
+        case "skills_activated":
+          setActiveSkills(data.skillNames);
+          break;
         default:
-          break; // init / research_progress / agent_selected / token_warning 등은 추후
+          break; // init / research_progress / token_warning 등은 추후
       }
     };
 
@@ -106,6 +114,8 @@ export function useChatSocket() {
       if (!message.trim() || s.isGenerating) return;
 
       appendMessage({ role: "user", content: message, images });
+      setActiveAgent(null); // 새 질문 — 이전 에이전트/스킬 표시 초기화
+      setActiveSkills([]);
       setStreaming(true); // assistant placeholder 는 첫 token 에서 생성, isGenerating=true
 
       const payload: WsChatRequest = {
@@ -121,7 +131,7 @@ export function useChatSocket() {
       };
       wsRef.current?.send(JSON.stringify(payload));
     },
-    [appendMessage, setStreaming],
+    [appendMessage, setStreaming, setActiveAgent, setActiveSkills],
   );
 
   const abort = useCallback(() => {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -97,7 +97,19 @@ export type WsServerEvent =
   | { type: "done"; sessionId?: string; totalTokens?: number }
   | { type: "aborted"; message?: string }
   | { type: "error"; message: string }
-  | { type: "init"; data?: unknown };
+  | { type: "init"; data?: unknown }
+  | {
+      type: "agent_selected";
+      agent: {
+        type: string;
+        name: string;
+        emoji?: string;
+        phase?: string;
+        reason?: string;
+        confidence?: number;
+      };
+    }
+  | { type: "skills_activated"; skillNames: string[] };
 
 /* ── 응답 페이로드 헬퍼 타입 ─────────────────────────────────────────── */
 export interface SessionsPayload {


### PR DESCRIPTION
## 문제
사용자 질문에 답할 때 **라우팅된 에이전트 + 주입된 스킬**이 채팅창 위에 표시되던 기능이 사라짐.

## 원인
백엔드 `ws-chat-handler`는 `agent_selected`(에이전트 `{type,name,emoji,...}`)와 `skills_activated`(`skillNames[]`)를 보내는데, apps/web `use-chat-socket`이 `default: break // …추후`로 **무시**하고 있었습니다.

## 복원
- `shared-types` WsServerEvent에 `agent_selected`/`skills_activated` 타입 추가
- `store`: `activeAgent`/`activeSkills` 상태 + 새 질문 시 reset
- `use-chat-socket`: 두 이벤트 case 처리
- `ActiveContext` 컴포넌트: composer 위에 에이전트(🤖)·스킬(🛠) 칩 표시

## 검증
- `next build` exit 0 (shared-types transpile + 컴포넌트)
- 실제 표시는 산업/전문 질문 시 백엔드가 에이전트를 라우팅하면 채팅창 위에 칩으로 나타남

🤖 Generated with [Claude Code](https://claude.com/claude-code)