### PR TITLE
fix(api): 웹검색 결과 LLM 주입 5→8개 (시사 질문 최신성)

### DIFF
--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -135,7 +135,9 @@ export async function handleChatMessage(
         if (!userExplicitlyDisabledSearch && (userWebSearchEnabled || isCurrentEventsQuery)) {
             try {
                 const { performWebSearch } = await import('../mcp');
-                const searchResults = await performWebSearch(message, { maxResults: 5, language: userLang });
+                // maxResults 8: 신뢰도 정렬상 Wikipedia 가 상위를 점유해 최신 뉴스가 5개 cut 에서
+                // 누락되던 문제 완화 — 상위 8개로 늘려 News/Naver(최신 시사)가 LLM 컨텍스트에 포함되게 한다.
+                const searchResults = await performWebSearch(message, { maxResults: 8, language: userLang });
                 if (searchResults.length > 0) {
                     const tpl = getLocalizedTemplate(WEB_SEARCH_TEMPLATES, userLang);
                     webSearchContext = `\n\n## \uD83D\uDD0D ${tpl.header} (${new Date().toLocaleDateString(tpl.locale)} )\n` +


### PR DESCRIPTION
## 점검 결과
웹검색은 **정상 동작**합니다(로그상 '한국 대통령' 질의에 네이버/뉴스/위키 등 **30개 수집**). 문제는 LLM에 주입되는 상위 결과의 품질이었습니다.

## 원인
`search-orchestrator`는 News/Naver를 먼저 병합하지만, 이후 `scoreSearchResult` 신뢰도 정렬에서 **Wikipedia가 official 도메인 boost로 상위**를 점유 → `maxResults: 5` cut에서 **최신 뉴스(News/Naver)가 누락**. 로컬 qwen3.6이 오래된 배경 정보(위키)로 부정확하게 답변.

## 수정
ws-chat-handler의 `webSearchContext` 주입을 `maxResults: 5 → 8`로 늘려 최신 뉴스가 LLM 컨텍스트에 포함되게 함.

## 한계 / 권장
- 로컬 qwen3.6은 다중 검색 결과 종합·최신성 판단에 한계가 있습니다. **정확한 시사 답변에는 방금 복원한 외부 LLM(OpenRouter의 GPT/Claude)** 사용을 권장합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)