### PR TITLE
feat(web): 채팅창 모델 셀렉터 숨김 (모델 선택은 설정)

### DIFF
--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import {
   ArrowUp,
   Globe,
-  KeyRound,
   MessagesSquare,
   Sparkles,
   Square,
@@ -29,8 +27,6 @@ export function Composer() {
     queryFn: fetchModels,
     staleTime: 60_000,
   });
-  const models = modelsData?.models ?? [];
-
   const {
     isGenerating,
     thinkingEnabled,
@@ -127,32 +123,8 @@ export function Composer() {
           className="block w-full resize-none bg-transparent px-4 pt-2.5 text-sm text-fg outline-none placeholder:text-faint"
         />
 
-        {/* 하단: 모델 셀렉터(로컬 + 외부 LLM) + 키 관리 + 스타일 + 전송 */}
+        {/* 하단: 스타일 + 전송 (모델 선택은 설정 → 기본 모델에서, 채팅창엔 모델명 비표시) */}
         <div className="flex items-center gap-1.5 px-2.5 pb-2.5 pt-1">
-          <select
-            value={selectedModel}
-            onChange={(e) => setSelectedModel(e.target.value)}
-            title="모델 선택 (로컬 + 등록한 외부 LLM)"
-            className="max-w-[40%] truncate rounded-md border border-border bg-surface-2 px-2 py-1.5 text-xs font-medium text-fg outline-none"
-          >
-            {models.length === 0 && <option value="">모델 로딩…</option>}
-            {models.map((m) => (
-              <option key={m.modelId} value={m.modelId}>
-                {m.name}
-                {m.isFree ? " · 무료" : ""}
-                {m.available === false ? " (불가)" : ""}
-              </option>
-            ))}
-          </select>
-
-          <Link
-            href="/api-keys"
-            title="외부 LLM(OpenRouter 등) 키 등록·관리"
-            className="grid h-8 w-8 shrink-0 place-items-center rounded-md text-muted transition hover:bg-surface-2 hover:text-fg"
-          >
-            <KeyRound className="h-4 w-4" />
-          </Link>
-
           <button
             onClick={cycleStyle}
             className="rounded-md px-2 py-1.5 text-xs font-medium capitalize text-muted hover:bg-surface-2 hover:text-fg"


### PR DESCRIPTION
## 요청
채팅창에서 모델명(Qwen 3.6 등)이 안 보이게.

## 변경
- composer 하단의 **모델 셀렉터 + 외부키(🔑) 아이콘 제거** → 스타일·전송만
- 모델 선택은 **설정 → "모델 & 응답" → 기본 모델**(동적, 로컬+외부 LLM)에서 유지
- `selectedModel`은 store에 유지되고 useEffect로 defaultModel 동기화(sendChat 정상)

## 검증
- `next build` exit 0
- 채팅창 하단에 모델명 비표시 확인(스크린샷)

🤖 Generated with [Claude Code](https://claude.com/claude-code)