### PR TITLE
feat(search): 백과 소스 보장 포함 + 웹검색 전달량 확대

### DIFF
--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -661,6 +661,15 @@ export const SEARCH_RELIABILITY = {
      * 0 이하면 비활성(무제한). env override: SEARCH_MAX_PER_DOMAIN. 기본 5.
      */
     MAX_PER_DOMAIN: Number(process.env.SEARCH_MAX_PER_DOMAIN) || 5,
+    /**
+     * 백과/레퍼런스 도메인 (사실성 보강 대상).
+     * 랭킹은 수집 순서(relevance) 가중이 커서 백과가 뉴스 가십에 밀려 컷오프되는 문제가 있다.
+     * 현직 인물·직책 같은 사실 질문에서 백과 본문(예: "제21대 대선 이재명 당선")이 LLM 입력에서
+     * 누락되지 않도록, 최종 결과에 최소 MIN_REFERENCE_RESULTS 개를 보장 포함한다.
+     */
+    REFERENCE_DOMAINS: ['wikipedia.org', 'namu.wiki', 'britannica.com'] as readonly string[],
+    /** 최종 결과에 보장 포함할 백과/레퍼런스 최소 개수. 0 이하면 비활성. env: SEARCH_MIN_REFERENCE. 기본 4. */
+    MIN_REFERENCE_RESULTS: Number(process.env.SEARCH_MIN_REFERENCE ?? 4),
 } as const;
 
 // ============================================

--- a/apps/api/src/mcp/web-search/search-orchestrator.ts
+++ b/apps/api/src/mcp/web-search/search-orchestrator.ts
@@ -101,11 +101,56 @@ export async function performWebSearch(query: string, options: { maxResults?: nu
 
     scored.sort((a, b) => b.combinedScore - a.combinedScore);
 
-    return applyPerDomainCap(
-        scored.map(s => s.result),
+    const sortedResults = scored.map(s => s.result);
+    const ranked = applyPerDomainCap(
+        sortedResults,
         maxResults,
         SEARCH_RELIABILITY.MAX_PER_DOMAIN,
     );
+
+    // 사실성 보강: 백과/레퍼런스 소스가 컷오프에서 누락되면 보장 포함 (현직 인물·직책 등 사실 질문 정확도)
+    return ensureReferenceResults(ranked, sortedResults, maxResults);
+}
+
+/**
+ * 백과/레퍼런스 소스(REFERENCE_DOMAINS)를 최종 결과에 최소 개수 보장한다.
+ *
+ * relevance 가 수집 순서 기반이라 백과 결과가 뉴스 가십에 밀려 top-N 컷오프에서 잘리는 문제를
+ * 보정한다. 부족분만큼 점수 상위 백과 결과를 **앞쪽**에 삽입(LLM 우선 노출)하고,
+ * maxResults 한도를 유지하기 위해 비-레퍼런스 결과를 뒤에서 밀어낸다.
+ *
+ * @param ranked - applyPerDomainCap 적용 후 최종 후보 (점수 내림차순)
+ * @param sortedResults - 점수 내림차순 전체 결과 풀
+ * @param maxResults - 최종 최대 개수
+ */
+export function ensureReferenceResults(
+    ranked: SearchResult[],
+    sortedResults: SearchResult[],
+    maxResults: number,
+): SearchResult[] {
+    const min = SEARCH_RELIABILITY.MIN_REFERENCE_RESULTS;
+    if (min <= 0) return ranked;
+
+    const isReference = (r: SearchResult): boolean => {
+        try {
+            const host = new URL(r.url).hostname.toLowerCase();
+            return SEARCH_RELIABILITY.REFERENCE_DOMAINS.some(d => host.includes(d));
+        } catch {
+            return false;
+        }
+    };
+
+    const have = ranked.filter(isReference).length;
+    if (have >= min) return ranked;
+
+    const inRanked = new Set(ranked.map(r => r.url));
+    const additions = sortedResults
+        .filter(r => isReference(r) && !inRanked.has(r.url))
+        .slice(0, min - have);
+    if (additions.length === 0) return ranked;
+
+    // 백과를 앞에 배치 → 비-레퍼런스 결과는 뒤에서 밀려남 (maxResults 유지)
+    return [...additions, ...ranked].slice(0, maxResults);
 }
 
 /**

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -137,7 +137,7 @@ export async function handleChatMessage(
                 const { performWebSearch } = await import('../mcp');
                 // maxResults 8: 신뢰도 정렬상 Wikipedia 가 상위를 점유해 최신 뉴스가 5개 cut 에서
                 // 누락되던 문제 완화 — 상위 8개로 늘려 News/Naver(최신 시사)가 LLM 컨텍스트에 포함되게 한다.
-                const searchResults = await performWebSearch(message, { maxResults: 8, language: userLang });
+                const searchResults = await performWebSearch(message, { maxResults: 12, language: userLang });
                 if (searchResults.length > 0) {
                     const tpl = getLocalizedTemplate(WEB_SEARCH_TEMPLATES, userLang);
                     webSearchContext = `\n\n## \uD83D\uDD0D ${tpl.header} (${new Date().toLocaleDateString(tpl.locale)} )\n` +


### PR DESCRIPTION
## 배경
"한국 대통령이 누구야" 질문에 계속 전직(윤석열)으로 답하는 문제 진단.

## 근본 원인
- 랭킹의 `relevance`가 **질문 관련성이 아니라 수집 순서**(`1-index/total`) 기반 → 늦게 수집되는 Wikipedia가 영원히 밀림
- `RELEVANCE_WEIGHT(0.6) > RELIABILITY_WEIGHT(0.4)` → 수집 순서가 권위를 압도
- "이재명 당선"을 명시한 위키 문서가 top8 컷오프에서 잘리고, AI 오답 가십 뉴스가 상위 독점

## 변경
- `ensureReferenceResults`: 백과/레퍼런스(위키·나무위키·브리태니커) 소스를 최종 결과에 **최소 4개 보장 포함**, 누락 시 앞쪽 보강
- `REFERENCE_DOMAINS` / `MIN_REFERENCE_RESULTS` config (env override)
- 웹검색 LLM 전달량 8→12

## 한계
구어체 질문(의문사 "누구야")이 검색 소스 전반에서 전직 콘텐츠를 끌어오는 건 이 변경으로 완전히 해결되지 않음 → 후속 LLM 쿼리 재작성 검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)