### PR TITLE
fix: 외부/로컬 채팅 경로의 skill tool binding + memory/CI 주입 누락 수정

### DIFF
--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -44,6 +44,10 @@ export interface StreamFromExternalContext {
     agentSystemMessage?: string;
     enhancedMessage?: string;
     resolvedLanguage?: string;
+    /** Cross-conversation Memory 블록 (claude.ai Memory 동등). 시스템 프롬프트 앞쪽에 prepend. */
+    memoryBlock?: string;
+    /** Custom Instructions 블록 (사용자 영구 지시). 시스템 프롬프트 앞쪽에 prepend. */
+    customInstructionsBlock?: string;
 }
 
 /**
@@ -58,6 +62,16 @@ export async function streamFromExternalProvider(
 ): Promise<string> {
     const messages: ChatMessage[] = [];
     const systemPromptParts: string[] = [];
+
+    // Memory + Custom Instructions 를 시스템 프롬프트 앞쪽에 배치 (strategy 경로의
+    // combinedSystemPrompt = memoryBlock + customInstructionsBlock + ... 순서와 동일).
+    // claude.ai Memory/Custom Instructions 동등 — 사용자 맥락을 가드/페르소나보다 먼저 노출.
+    if (ctx.memoryBlock) {
+        systemPromptParts.push(ctx.memoryBlock.trim());
+    }
+    if (ctx.customInstructionsBlock) {
+        systemPromptParts.push(ctx.customInstructionsBlock.trim());
+    }
 
     // Phase 2026-05-26: 외부 provider 도 Identity Guard + Response Discipline 적용.
     // 본 가드 미적용 시 Gemini/GPT 가 "Here's a thinking process", 단계 1-N,

--- a/apps/api/src/services/chat-service/message-pipeline.ts
+++ b/apps/api/src/services/chat-service/message-pipeline.ts
@@ -249,7 +249,13 @@ export async function runMessagePipeline(svc: ChatService,
     // strategies 우회하지만 agent 페르소나 + buildContextForLLM 결과 + 언어 정책은 통합.
     // tool calling / thinking / discussion / deep research 는 여전히 미지원.
     if (externalResolved) {
-        const { agentSystemMessage: industryAgentSysMsg } = await agentPromise;
+        const { agentSystemMessage: industryAgentSysMsg, selectedAgent } = await agentPromise;
+
+        // skill tool_bindings 캐시 — 외부 provider 경로(LOCAL_STRATEGY_PATH OFF 기본이라 로컬 포함)도
+        // getAllowedTools() 동기 머지가 skill required/allowed/denied 를 반영하도록 한다.
+        // (회귀: loadSkillBindings 가 아래 strategy 경로(Step 5 합류 직후)에만 있어, 외부 분기는
+        //  skillBindings=[] 인 채 머지되어 skill 의 도구 바인딩이 전부 무시되던 버그.)
+        await svc.loadSkillBindings(selectedAgent.id, reqCtx);
 
         // 2026-05-26 옵션 B 통합 (외부 provider 경로):
         // Custom Agent (user_agents) 활성 시 산업 agent 라우팅 우회 + allowedSkills 주입.

--- a/apps/api/src/services/chat-service/message-pipeline.ts
+++ b/apps/api/src/services/chat-service/message-pipeline.ts
@@ -33,6 +33,72 @@ import { USER_CONTEXT_LIMITS, AGENT_LOOP_LIMITS } from '../../config/runtime-lim
 
 const logger = createLogger('MessagePipeline');
 
+/**
+ * Cross-conversation Memory(/remember) + Custom Instructions 블록을 조립한다.
+ * strategy 경로와 외부 provider 경로 양쪽에서 동일하게 호출 (claude.ai Memory/CI 동등).
+ * 인증 사용자(userId 명시)만 적용 — guest 미적용. 각 조회 실패 시 빈 블록(graceful fallback).
+ *
+ * 회귀 배경: 과거 strategy 경로에만 인라인되어 있어, 외부 provider 분기
+ * (LOCAL_STRATEGY_PATH OFF 기본이라 로컬 채팅 포함)에서 memory/custom instructions 가
+ * 전혀 주입되지 않던 버그를 헬퍼 추출로 양 경로 대칭화.
+ */
+async function buildUserContextBlocks(
+    userId: string | undefined,
+): Promise<{ memoryBlock: string; customInstructionsBlock: string }> {
+    let customInstructionsBlock = '';
+    let memoryBlock = '';
+    if (userId && userId !== 'guest') {
+        try {
+            const { UserRepository } = await import('../../data/repositories/user-repository');
+            const { getPool } = await import('../../data/models/unified-database');
+            const userRepo = new UserRepository(getPool());
+            const ci = await userRepo.getCustomInstructions(userId);
+            if (ci && ci.trim().length > 0) {
+                // 토큰 cap — 매 턴 고정 비용이므로 무제한 prepend 방지 (head 보존 truncate)
+                let ciText = ci.trim();
+                const maxCi = USER_CONTEXT_LIMITS.MAX_CUSTOM_INSTRUCTIONS_TOKENS;
+                if (estimateTokens(ciText) > maxCi) {
+                    const ratio = ciText.length / estimateTokens(ciText);
+                    ciText = ciText.slice(0, Math.floor(maxCi * ratio)).trimEnd() + ' …(생략됨)';
+                    logger.info(`custom_instructions 토큰 cap 적용 (>${maxCi})`);
+                }
+                customInstructionsBlock = `## 👤 User Custom Instructions\n${ciText}\n\n---\n\n`;
+            }
+        } catch (e) {
+            logger.warn('custom_instructions 조회 실패 (계속 진행):', e);
+        }
+
+        try {
+            const { UserMemoryRepository } = await import('../../data/repositories/user-memory-repository');
+            const { getPool } = await import('../../data/models/unified-database');
+            const memRepo = new UserMemoryRepository(getPool());
+            const memories = await memRepo.listActiveByUser(userId, 50);
+            if (memories.length > 0) {
+                const maxMem = USER_CONTEXT_LIMITS.MAX_MEMORY_TOKENS;
+                const kept: typeof memories = [];
+                let usedTokens = 0;
+                for (const m of memories) {
+                    const t = estimateTokens(m.content) + 4;
+                    if (usedTokens + t > maxMem && kept.length > 0) break;
+                    kept.push(m);
+                    usedTokens += t;
+                }
+                if (kept.length < memories.length) {
+                    logger.info(`user_memories 토큰 cap 적용 (${kept.length}/${memories.length}, >${maxMem} tok)`);
+                }
+                const lines = kept.map((m, i) => `${i + 1}. ${m.content}`).join('\n');
+                memoryBlock = `## 🧠 User Memory (cross-conversation)\n${lines}\n\n---\n\n`;
+                void memRepo.touchAccessed(kept.map(m => m.id)).catch(e =>
+                    logger.warn('memory touch 실패 (무시):', e),
+                );
+            }
+        } catch (e) {
+            logger.warn('user_memories 조회 실패 (계속 진행):', e);
+        }
+    }
+    return { memoryBlock, customInstructionsBlock };
+}
+
 export async function runMessagePipeline(svc: ChatService, 
     req: ChatMessageRequest,
     onToken: (token: string) => void,
@@ -257,6 +323,12 @@ export async function runMessagePipeline(svc: ChatService,
         //  skillBindings=[] 인 채 머지되어 skill 의 도구 바인딩이 전부 무시되던 버그.)
         await svc.loadSkillBindings(selectedAgent.id, reqCtx);
 
+        // Memory + Custom Instructions — strategy 경로와 동일하게 외부 provider 경로에도 주입.
+        // (회귀: 과거 외부 분기가 memory/CI 조립 코드(strategy 경로 하단)에 도달 못 해
+        //  /remember 메모리·커스텀 지시가 기본 채팅에서 전혀 적용되지 않던 버그.)
+        const { memoryBlock: extMemoryBlock, customInstructionsBlock: extCustomInstructionsBlock } =
+            await buildUserContextBlocks(userId);
+
         // 2026-05-26 옵션 B 통합 (외부 provider 경로):
         // Custom Agent (user_agents) 활성 시 산업 agent 라우팅 우회 + allowedSkills 주입.
         // 2026-05-26 cleanup: 전체 build() 대신 loadUserAgent 단독 호출 —
@@ -290,6 +362,8 @@ export async function runMessagePipeline(svc: ChatService,
             agentSystemMessage: agentSysMsgForExternal,
             enhancedMessage: finalEnhancedMessage,
             resolvedLanguage: languagePolicy?.resolvedLanguage,
+            memoryBlock: extMemoryBlock,
+            customInstructionsBlock: extCustomInstructionsBlock,
         }, reqCtx);
     }
 
@@ -366,66 +440,9 @@ export async function runMessagePipeline(svc: ChatService,
     // getAllowedTools() 의 동기 머지에서 사용. agentId 가 결정된 직후 호출.
     await svc.loadSkillBindings(selectedAgent.id, reqCtx);
 
-    // Custom Instructions prepend — 사용자별 영구 system prompt 지시문 (2026-05-26).
-    // T1~T9 분석의 inter-turn verbosity 해결책. NULL/빈 문자열은 자동 스킵.
-    // 인증된 사용자 (userId 명시) 에만 적용 — guest 세션은 미적용.
-    let customInstructionsBlock = '';
-    let memoryBlock = '';
-    if (userId && userId !== 'guest') {
-        try {
-            const { UserRepository } = await import('../../data/repositories/user-repository');
-            const { getPool } = await import('../../data/models/unified-database');
-            const userRepo = new UserRepository(getPool());
-            const ci = await userRepo.getCustomInstructions(userId);
-            if (ci && ci.trim().length > 0) {
-                // 토큰 cap — 매 턴 고정 비용이므로 무제한 prepend 방지 (head 보존 truncate)
-                let ciText = ci.trim();
-                const maxCi = USER_CONTEXT_LIMITS.MAX_CUSTOM_INSTRUCTIONS_TOKENS;
-                if (estimateTokens(ciText) > maxCi) {
-                    // 대략 토큰당 char 비율로 head 자르고 안내 부착 (정확 토큰 재확인 불필요 — 보수적)
-                    const ratio = ciText.length / estimateTokens(ciText);
-                    ciText = ciText.slice(0, Math.floor(maxCi * ratio)).trimEnd() + ' …(생략됨)';
-                    logger.info(`custom_instructions 토큰 cap 적용 (>${maxCi})`);
-                }
-                customInstructionsBlock = `## 👤 User Custom Instructions\n${ciText}\n\n---\n\n`;
-            }
-        } catch (e) {
-            logger.warn('custom_instructions 조회 실패 (계속 진행):', e);
-        }
-
-        // Cross-conversation Memory prepend (2026-05-26 Phase 3-A).
-        // /remember 로 저장된 explicit memory 를 최신 50개까지 prepend.
-        // claude.ai/ChatGPT Memory 동등. 조회 실패 시 silent fallback.
-        try {
-            const { UserMemoryRepository } = await import('../../data/repositories/user-memory-repository');
-            const { getPool } = await import('../../data/models/unified-database');
-            const memRepo = new UserMemoryRepository(getPool());
-            const memories = await memRepo.listActiveByUser(userId, 50);
-            if (memories.length > 0) {
-                // 토큰 budget 누적 — 최신순으로 cap 도달 전까지만 포함 (무제한 prepend 방지)
-                const maxMem = USER_CONTEXT_LIMITS.MAX_MEMORY_TOKENS;
-                const kept: typeof memories = [];
-                let usedTokens = 0;
-                for (const m of memories) {
-                    const t = estimateTokens(m.content) + 4;
-                    if (usedTokens + t > maxMem && kept.length > 0) break;
-                    kept.push(m);
-                    usedTokens += t;
-                }
-                if (kept.length < memories.length) {
-                    logger.info(`user_memories 토큰 cap 적용 (${kept.length}/${memories.length}, >${maxMem} tok)`);
-                }
-                const lines = kept.map((m, i) => `${i + 1}. ${m.content}`).join('\n');
-                memoryBlock = `## 🧠 User Memory (cross-conversation)\n${lines}\n\n---\n\n`;
-                // 접근 시점 갱신 — fire-and-forget (포함된 항목만)
-                void memRepo.touchAccessed(kept.map(m => m.id)).catch(e =>
-                    logger.warn('memory touch 실패 (무시):', e),
-                );
-            }
-        } catch (e) {
-            logger.warn('user_memories 조회 실패 (계속 진행):', e);
-        }
-    }
+    // Custom Instructions + Cross-conversation Memory prepend (2026-05-26).
+    // 헬퍼로 추출되어 외부 provider 분기와 동일 로직 사용 (claude.ai Memory/CI 동등).
+    const { memoryBlock, customInstructionsBlock } = await buildUserContextBlocks(userId);
 
     // Phase 2 Custom Agent (2026-05-26): user agent system prompt 가 있으면
     // 18 산업 agentSystemMessage 자리에 우선 적용 (사용자 명시 의도 존중).


### PR DESCRIPTION
## 배경
"하네스/컨텍스트 엔지니어링 최적화 + Agent skill·MCP 제대로 적용" 목표로 3영역(하네스·컨텍스트·skill/MCP)을 병렬 진단. 진단 결과 **확정 버그 2개**를 발견·수정.

> 핵심: `LOCAL_STRATEGY_PATH_ENABLED` OFF(기본)이라 **로컬 채팅도 외부 dispatch 경로**(`streamFromExternalProvider`)를 탄다. 이 경로는 `message-pipeline.ts:251`에서 조기 return 하는데, skill binding 로드와 memory/CI 조립이 **그 이후 strategy 경로에만** 있어 둘 다 누락됐다.

## 수정 1 — Skill tool binding 누락 (`fix(skill)`)
- 외부 분기가 `loadSkillBindings`를 호출하지 않아 `reqCtx.skillBindings=[]`로 머지 → skill의 required/allowed/denied tool binding이 전부 무시됨
- 외부 분기에서 `selectedAgent`를 받아 `loadSkillBindings` 선행 호출
- **운영 DB에 `skill_tool_bindings` 2건(required/allowed) 존재 — 실제 영향 확인됨**

## 수정 2 — Memory/Custom Instructions 누락 (`fix(context)`)
- 외부 경로가 strategy 경로 하단의 memory/CI 조립에 도달 못 해, `/remember` cross-conversation memory + custom instructions가 **기본 채팅에서 전혀 주입 안 됨** (claude.ai 동등 기능이 죽어 있던 회귀)
- memory/CI 조립을 `buildUserContextBlocks` 헬퍼로 추출 → 양 경로 대칭화
- external-provider가 시스템 프롬프트 앞쪽(memory→CI→guards, strategy 경로와 동일 순서)에 prepend

## 하네스 진단 결과 (변경 없음)
하네스는 이미 견고 — doom-loop 감지, 5턴 제한, `tool-error-classifier` 공통 적용(`tool-router.ts:155`), abort 처리. 진단에서 제기된 갭(컨텍스트 GC·wall-clock·GV tool)은 5턴 제한 / 비활성 경로(LOCAL_STRATEGY OFF)라 확정 버그가 아니어서 surgical 원칙에 따라 변경하지 않음.

## 검증
- tsc 0, eslint 0
- `selectedAgent`가 모든 분기(bypass=general, 일반=라우팅 agent)에서 유효함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)