### PR TITLE
fix(web): 외부 공개 시 hydration·로그인·WS 정상화 (Caddy HMR WS 분리)

### DIFF
--- a/apps/api/src/controllers/auth-oauth.controller.ts
+++ b/apps/api/src/controllers/auth-oauth.controller.ts
@@ -229,6 +229,23 @@ function buildRedirectUri(req: Request, provider: 'google' | 'github', serverPor
 }
 
 /**
+ * OAuth 로그인 성공 후 리다이렉트 (Set-Cookie 동반).
+ *
+ * 302 redirect 대신 200 HTML(meta refresh)로 응답한다 — Next.js dev rewrites(프록시)가
+ * 3xx 응답의 Set-Cookie 헤더를 브라우저로 전파하지 못해 외부 접속 시 로그인 세션이
+ * 게스트로 떨어지던 문제를 우회한다. 200 응답의 Set-Cookie 는 정상 전파됨.
+ * path 는 내부 고정 경로만 전달 (open redirect / XSS 불가).
+ */
+function sendOAuthSuccessRedirect(res: Response, path: string): void {
+    res.status(200).type('html').send(
+        '<!DOCTYPE html><html lang="ko"><head><meta charset="utf-8">' +
+        `<meta http-equiv="refresh" content="0;url=${path}">` +
+        '<title>로그인 완료</title></head>' +
+        `<body style="font-family:sans-serif">로그인 완료. 이동 중…<br><a href="${path}">계속하기</a></body></html>`,
+    );
+}
+
+/**
  * OAuth 인증 관련 API 컨트롤러
  *
  * @class AuthOAuthController
@@ -385,7 +402,7 @@ export class AuthOAuthController {
 
             setTokenCookie(res, result.token);
             setRefreshTokenCookie(res, generateRefreshToken(result.user));
-            res.redirect('/?auth=callback');
+            sendOAuthSuccessRedirect(res, '/?auth=callback');
         } catch (error) {
             log.error('[OAuth Google Callback] 오류:', error);
             res.redirect('/login.html?error=oauth_failed');
@@ -480,7 +497,7 @@ export class AuthOAuthController {
 
             setTokenCookie(res, result.token);
             setRefreshTokenCookie(res, generateRefreshToken(result.user));
-            res.redirect('/?auth=callback');
+            sendOAuthSuccessRedirect(res, '/?auth=callback');
         } catch (error) {
             log.error('[OAuth GitHub Callback] 오류:', error);
             res.redirect('/login.html?error=oauth_failed');

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -17,6 +17,12 @@ function resolveWsUrl(): string {
   const env = process.env.NEXT_PUBLIC_WS_URL;
   if (env) return env;
   const proto = location.protocol === "https:" ? "wss:" : "ws:";
+  // Next dev 직접(:3000, Caddy 미경유)일 때만 백엔드 WS 포트(:52416)로 직접 연결.
+  // 그 외(Caddy 경유 :33000 — 로컬 테스트/외부 공개)는 same-origin → Caddy 가 WS upgrade 를
+  // 백엔드로 프록시한다. (Next.js rewrites 는 WS 를 프록시하지 못하므로 프록시 계층이 필수.)
+  if (location.port === "3000") {
+    return `${proto}//${location.hostname}:52416`;
+  }
   return `${proto}//${location.host}`;
 }
 

--- a/scripts/caddy/Caddyfile
+++ b/scripts/caddy/Caddyfile
@@ -1,0 +1,45 @@
+# ============================================================
+# OpenMake LLM — 외부 공개용 리버스 프록시 (Caddy)
+# ============================================================
+# 목적: 외부(rasplay.tplinkdns.com:33000)에서 프론트 + REST + WebSocket 을
+#       단일 origin 으로 접근. 백엔드(52416)는 외부에 직접 노출하지 않는다.
+#
+# 토폴로지:
+#   [외부 브라우저 rasplay.tplinkdns.com:33000]
+#        → [라우터 포트포워딩 33000 → 이 Mac:33000]
+#        → [Caddy :33000]  ──┬─ WS upgrade ─→ 백엔드 Express WS (localhost:52416)
+#                            ├─ /api/*      ─→ 백엔드 REST       (localhost:52416)
+#                            └─ 그 외        ─→ Next.js 페이지/정적 (localhost:3000)
+#
+# 실행:
+#   brew install caddy
+#   caddy run --config /Volumes/MAC_APP/openmake_llm/scripts/caddy/Caddyfile
+#   # 또는 백그라운드: brew services 로 등록하거나 `caddy start`
+#
+# 라우터 설정:
+#   외부 33000 → 이 Mac 의 LAN IP:33000 (기존 33000→3000 을 33000→33000 으로 변경)
+#
+# 주의:
+#   - Caddy reverse_proxy 는 X-Forwarded-Host/Proto/For 를 자동 전달 →
+#     백엔드 buildRedirectUri(OAuth) 가 rasplay:33000 을 올바르게 인식한다.
+#   - WS origin(http://rasplay.tplinkdns.com:33000)은 백엔드 CORS_ORIGINS 에 등록되어 있어야 한다(완료).
+#   - HTTP 운영(HTTPS 아님)이므로 `:33000` 으로 명시 — Caddy 자동 HTTPS 비활성.
+#     추후 도메인+TLS 도입 시 `rasplay.tplinkdns.com` 블록 + `tls` 로 전환 권장.
+
+:33000 {
+	# ── 채팅 WebSocket upgrade → 백엔드 Express WS ──
+	# 단, Next.js dev 의 HMR WebSocket(/_next/*)은 제외해야 한다 — 이를 백엔드로 보내면
+	# 클라이언트 HMR 연결이 깨져 hydration/Fast Refresh 가 동작하지 않는다(앱 인터랙션 전체 정지).
+	@chatws {
+		header Connection *Upgrade*
+		header Upgrade    websocket
+		not path /_next/*
+	}
+	reverse_proxy @chatws localhost:52416
+
+	# ── REST API → 백엔드 직접 (same-origin, x-forwarded-host 전달) ──
+	reverse_proxy /api/* localhost:52416
+
+	# ── 그 외(Next.js 페이지·정적 자산·HMR) ──
+	reverse_proxy localhost:3000
+}


### PR DESCRIPTION
## 배경
외부(rasplay.tplinkdns.com:33000)에서 구글 로그인 후 **게스트로 표시**되고 실시간 채팅이 안 되는 문제. Playwright로 전 경로를 검증하며 근본 원인을 추적.

## 발견·수정 (3건)

### 1. 🔴 (핵심) Caddy가 Next HMR WS를 가로채 hydration 붕괴
`@websockets` 매처가 **모든 WS upgrade를 백엔드(52416)로** 보내, Next.js dev의 HMR WebSocket(`/_next/webpack-hmr`)까지 백엔드로 잘못 라우팅 → **클라이언트 hydration 전체가 죽음** → `AuthSync` useEffect 미실행 → 인증 쿠키가 있어도 게스트. (입력·테마토글 등 모든 인터랙션 정지)
- **수정**: Caddyfile `@chatws`에 `not path /_next/*` — HMR은 Next(3000), 채팅 WS만 백엔드(52416).

### 2. resolveWsUrl 포트 기반 정정
localhost hostname 분기라 Caddy(:33000) 경유에서도 :52416 직접 연결(프록시 우회) + origin 불일치. → `port==='3000'`(Next dev 직접)만 :52416, 그 외 same-origin.

### 3. OAuth callback 302→200 (쿠키 손실 우회)
Next.js rewrites가 3xx 응답의 Set-Cookie를 손실 → callback을 `200 HTML(meta refresh)+Set-Cookie`로.

## 검증 (Playwright, Caddy 경유 localhost:33000)
- 로그인: 사이드바 `riskpw@gmail.com · admin` ✅
- hydration: 전송버튼 활성화 ✅
- 채팅 WS: `ws://.../`(채팅)·`ws://.../_next/webpack-hmr`(HMR) 분리 + LLM "2" 응답 ✅

> 운영 `.env`(CORS에 localhost:33000 추가)와 `apps/web/.env.local`은 gitignore라 제외. Caddyfile은 `/opt/homebrew/etc/Caddyfile` 심링크로 brew services 운영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)