### PR TITLE
fix(web): next dev 외부 origin HMR 허용 (allowedDevOrigins)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -19,6 +19,10 @@ const nextConfig: NextConfig = {
     "@openmake/api-client",
     "@openmake/config",
   ],
+  // Next 16 dev: 외부 origin(rasplay) 에서 /_next/* (HMR 등) 접근을 기본 차단 → HMR WS 실패로
+  // 클라이언트 hydration 이 죽어 게스트로 표시됨. 외부 공개 dev 접속을 허용한다.
+  // (운영은 next build + next start 권장 — production 은 HMR 자체가 없어 이 문제 무관.)
+  allowedDevOrigins: ["rasplay.tplinkdns.com", "localhost", "127.0.0.1"],
   async rewrites() {
     return [
       { source: "/api/:path*", destination: `${API_PROXY_TARGET}/api/:path*` },


### PR DESCRIPTION
## 원인
실제 외부(rasplay:33000)에서 구글 로그인해도 게스트, 채팅 입력해도 전송버튼 비활성. next dev 로그에 명시:
```
⚠ Blocked cross-origin request to Next.js dev resource /_next/webpack-hmr from "rasplay.tplinkdns.com".
```
Next.js 16 dev 가 외부 origin HMR 을 차단 → HMR WS 실패 → **hydration 전체 죽음** → AuthSync 미실행 → 게스트.

## 수정
`next.config.ts` 에 `allowedDevOrigins: ['rasplay.tplinkdns.com','localhost','127.0.0.1']`.

## 검증
node WS 로 `ws://localhost:3000/_next/webpack-hmr` 에 **Origin=rasplay** 연결 → **open(허용)** 확인. localhost:33000 hydration 회귀 없음.

## 참고
외부 공개 운영은 `next build + next start`(production) 권장 — production 은 HMR 이 없어 이 문제 자체가 발생하지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)