### PR TITLE
fix(deploy): apps/web 외부 공개를 production(pm2 next start)으로

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -69,8 +69,9 @@ module.exports = {
         // 선행: `npm run build:frontend-next` 로 apps/web/.next 생성 필요.
         name: 'openmake-next',
         cwd: __dirname + '/apps/web',
-        script: 'npm',
-        args: 'start -- -p 3000',
+        // npm 을 fork 하면 pm2 ProcessContainerFork 가 crash → next 바이너리를 직접 node 로 실행.
+        script: './node_modules/next/dist/bin/next',
+        args: 'start -p 3000',
         env: {
             NODE_ENV: 'production',
             PORT: 3000,


### PR DESCRIPTION
## 배경
외부(rasplay:33000)에서 구글 로그인해도 게스트·전송버튼 비활성. 근본 원인은 **next dev 로 외부 공개** — Next 16 HMR 의 cross-origin 차단 + hairpin 환경 HMR WS 실패로 hydration 이 죽음.

## 해결
- apps/web 를 **production(next build + next start)** 로 운영 → HMR 자체가 없어 cross-origin·hairpin-HMR 문제 원천 제거. hydration(로그인·전송버튼)은 초기 JS 만으로 모든 환경에서 동작.
- ecosystem `openmake-next` script 를 `npm`→`./node_modules/next/dist/bin/next` 직접 실행으로 (npm fork 시 pm2 ProcessContainerFork crash 회피).

## 검증 (Playwright, Caddy 경유)
로그인(riskpw)·hydration(전송버튼 활성)·채팅 WS(LLM "12" 응답)·HMR WS 없음(production) 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)