### PR TITLE
feat(chat): 스킬 자동 호출 (LLM self-select) — load_skill 도구 + 카탈로그

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -658,6 +658,13 @@ CODE_REVIEW_MAX_FINDINGS=30
 # 비슬래시/미매칭은 무영향. 기본 ON(사용자가 '/' 입력해야만 동작).
 SLASH_COMMANDS_ENABLED=true
 SLASH_SKILL_CONTENT_MAX=8000
+# 스킬 자동 호출 (LLM self-select) — active 스킬 카탈로그를 load_skill 도구 description 에
+# 주입하면 모델이 질문에 맞는 스킬을 스스로 골라 불러온다(progressive disclosure).
+# 기본 OFF — 단계적 롤아웃(검증 후 true). '/' 슬래시 명시 호출과 독립.
+SKILL_AUTO_SELECT_ENABLED=false
+SKILL_AUTO_SELECT_TOP_K=3
+SKILL_CATALOG_MAX_ITEMS=200
+SKILL_CATALOG_DESC_MAX=120
 # fs_read_file 완전성 고지(P-6) — 이 바이트 초과 시 앞부분만 반환하고 잘림을 고지.
 FS_READ_MAX_BYTES=100000
 # WebSocket 메시지 최대 페이로드(bytes). **미설정/0 = 무제한**(파일·이미지 업로드 용량 제한 없음).

--- a/apps/api/src/agents/skill-manager.ts
+++ b/apps/api/src/agents/skill-manager.ts
@@ -46,6 +46,7 @@ import type {
     DraftListOptions,
     DraftListResult,
 } from '../data/repositories/skill-repository';
+import { slugify } from '../chat/slash-command';
 
 const logger = createLogger('SkillManager');
 
@@ -58,6 +59,11 @@ const MAX_SKILL_CONTENT_LENGTH = 10_000;
  */
 const SKILL_OVERLOAD_MAX_ACTIVE = Number(process.env.SKILL_OVERLOAD_MAX_ACTIVE) || 12;
 const SKILL_OVERLOAD_MAX_TOTAL_CHARS = Number(process.env.SKILL_OVERLOAD_MAX_TOTAL_CHARS) || 50_000;
+
+/** 스킬 자동 호출(LLM self-select) 카탈로그/선택 상한 — env override (No-Hardcoding). */
+const SKILL_CATALOG_MAX_ITEMS = Number(process.env.SKILL_CATALOG_MAX_ITEMS) || 200;
+const SKILL_CATALOG_DESC_MAX = Number(process.env.SKILL_CATALOG_DESC_MAX) || 120;
+const SKILL_AUTO_SELECT_TOP_K = Number(process.env.SKILL_AUTO_SELECT_TOP_K) || 3;
 
 /**
  * 한 에이전트에 주입될 스킬 묶음의 과포화 여부를 평가합니다 (순수 함수).
@@ -288,10 +294,11 @@ export class SkillManager {
                 try {
                     const s = await repo.getSkillById(id);
                     if (!s) return null;
-                    // \uad8c\ud55c \uac80\uc99d \u2014 public \ub610\ub294 \ubcf8\uc778 \uc18c\uc720\ub9cc (manifest \uad8c\ud55c \uccb4\uacc4\ub294 \ubbf8\uc138\ud654 \uac00\ub2a5)
-                    const meta = s as AgentSkill & { is_public?: boolean; created_by?: string };
-                    const isPublic = meta.is_public !== false;
-                    const isOwner = userId !== undefined && meta.created_by === userId;
+                    // \uad8c\ud55c \uac80\uc99d \u2014 public \ub610\ub294 \ubcf8\uc778 \uc18c\uc720\ub9cc (manifest \uad8c\ud55c \uccb4\uacc4\ub294 \ubbf8\uc138\ud654 \uac00\ub2a5).
+                    // rowToSkill \uc740 camelCase \ub9e4\ud551(isPublic \uae30\ubcf8 false)\uc774\ubbc0\ub85c snake_case \ub85c \uc77d\uc73c\uba74
+                    // \ud56d\uc0c1 undefined\u2192\uacf5\uac1c\ub85c \uc624\ud310\ud574 \ube44\uacf5\uac1c \uc2a4\ud0ac\uc774 \ub178\ucd9c\ub41c\ub2e4(2026-06-22 \uc218\uc815).
+                    const isPublic = s.isPublic === true;
+                    const isOwner = userId !== undefined && s.createdBy === userId;
                     if (!isPublic && !isOwner) return null;
                     return s;
                 } catch {
@@ -301,6 +308,57 @@ export class SkillManager {
         );
         const validSkills = skills.filter((s): s is AgentSkill => s !== null);
         return this.formatSkillsAsPrompt(validSkills);
+    }
+
+    /**
+     * active \uc2a4\ud0ac\uc744 "\uc774\ub984: \uc124\uba85" \ud55c \uc904 \uce74\ud0c8\ub85c\uadf8\ub85c \uc9c1\ub82c\ud654 (LLM self-select \uc6a9).
+     * load_skill \ub3c4\uad6c description \uc5d0 \uc2e4\ub824 \ubaa8\ub378\uc774 \uad00\ub828 \uc2a4\ud0ac\uc744 \uc2a4\uc2a4\ub85c \uace0\ub974\uac8c \ud55c\ub2e4.
+     *
+     * @param opts.excludeIds \uc774\ubbf8 \uc8fc\uc785\ub41c \ubc14\uc778\ub529 \uc2a4\ud0ac \u2014 \uc774\uc911 \ub178\ucd9c \ubc29\uc9c0(dedup)
+     */
+    async buildSkillCatalog(opts: { excludeIds?: ReadonlySet<string> } = {}): Promise<{ catalog: string; count: number }> {
+        const repo = await this.ensureInitialized();
+        const result = await repo.searchSkills({ status: 'active', sortBy: 'name', limit: SKILL_CATALOG_MAX_ITEMS });
+        const lines: string[] = [];
+        for (const s of result.skills) {
+            if (opts.excludeIds?.has(s.id)) continue;
+            const safeName = s.name.replace(/[<>"&]/g, '');
+            const desc = (s.description ?? '').replace(/\s+/g, ' ').trim().slice(0, SKILL_CATALOG_DESC_MAX);
+            lines.push(desc ? `- ${safeName}: ${desc}` : `- ${safeName}`);
+        }
+        return { catalog: lines.join('\n'), count: lines.length };
+    }
+
+    /**
+     * \uc2a4\ud0ac \uc774\ub984 \ubaa9\ub85d \u2192 \uc804\uccb4 content \uc8fc\uc785 \ud504\ub86c\ud504\ud2b8. load_skill \ub3c4\uad6c \ud578\ub4e4\ub7ec\uc6a9.
+     * \uc774\ub984\uc740 \uce74\ud0c8\ub85c\uadf8\uc758 \uc815\ud655\ud55c \uc774\ub984(\ub300\uc18c\ubb38\uc790 \ubb34\uad00) \ub610\ub294 slug \uc640 \ub9e4\uce6d. topK \ub85c \uc0c1\ud55c.
+     * \uad8c\ud55c: public \ub610\ub294 \ubcf8\uc778 \uc18c\uc720 \uc2a4\ud0ac\ub9cc \ub178\ucd9c(buildSkillPromptForIds \uc640 \ub3d9\uc77c \uaddc\uce59).
+     */
+    async buildSkillPromptForNames(
+        names: string[], userId?: string, topK: number = SKILL_AUTO_SELECT_TOP_K,
+    ): Promise<{ prompt: string; matched: string[] }> {
+        if (!Array.isArray(names) || names.length === 0) return { prompt: '', matched: [] };
+        const repo = await this.ensureInitialized();
+        const result = await repo.searchSkills({ status: 'active', limit: SKILL_CATALOG_MAX_ITEMS });
+        const wanted = names.slice(0, Math.max(1, topK)).map((n) => String(n).toLowerCase().trim()).filter(Boolean);
+        const seen = new Set<string>();
+        const picked: AgentSkill[] = [];
+        for (const w of wanted) {
+            // slug 매칭은 slug 가 비지 않을 때만 — 순수 한글 이름은 slugify 가 '' 라
+            // ''==='' 로 서로 오매칭되므로(예: '전기 엔지니어' vs '보고서') 정확 이름 매칭으로 폴백.
+            const wSlug = slugify(w);
+            const hit = result.skills.find((s) =>
+                !seen.has(s.id) && (
+                    s.name.toLowerCase() === w ||
+                    (wSlug.length > 0 && slugify(s.name) === wSlug)
+                ));
+            if (hit) { seen.add(hit.id); picked.push(hit); }
+        }
+        // 권한: public(isPublic) 또는 본인 소유(createdBy). rowToSkill 은 camelCase 매핑이며
+        // isPublic 기본 false 이므로 명시적 true 만 공개로 취급.
+        const visible = picked.filter((s) =>
+            s.isPublic === true || (userId !== undefined && s.createdBy === userId));
+        return { prompt: this.formatSkillsAsPrompt(visible), matched: visible.map((s) => s.name) };
     }
 
     /**

--- a/apps/api/src/mcp/load-skill-tool.ts
+++ b/apps/api/src/mcp/load-skill-tool.ts
@@ -1,0 +1,71 @@
+/**
+ * ============================================================
+ * MCP Tool: load_skill — 스킬 자동 호출 (LLM self-select)
+ * ============================================================
+ *
+ * 채팅 중 모델이 호출하는 도구. 시스템이 이 도구의 description 에 active 스킬
+ * 카탈로그("## Skill Library")를 주입하면(ChatService.getAllowedTools), 모델이
+ * 질문과 관련된 스킬 이름을 골라 호출한다. 핸들러는 이름 → 전체 content 를
+ * 조회해 반환하고, 다음 턴에서 모델이 그 지침으로 답한다(progressive disclosure).
+ *
+ * 안전 원칙:
+ * - 카탈로그 주입/노출은 SKILL_AUTO_SELECT_ENABLED 플래그로 게이팅(getAllowedTools).
+ * - 미매칭/오류는 throw 하지 않고 안내 텍스트 반환(채팅 흐름 무중단).
+ *
+ * @module mcp/load-skill-tool
+ */
+import type { MCPToolDefinition, MCPToolResult } from './types';
+import type { UserContext } from './user-sandbox';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('LoadSkillTool');
+
+export const LOAD_SKILL_TOOL_NAME = 'load_skill';
+
+interface LoadSkillArgs extends Record<string, unknown> {
+    skill_names: string[];
+}
+
+export const loadSkillTool: MCPToolDefinition<LoadSkillArgs> = {
+    tool: {
+        name: LOAD_SKILL_TOOL_NAME,
+        description:
+            '스킬 라이브러리에서 현재 질문에 직접 관련된 전문 스킬을 불러온다. ' +
+            '사용 가능한 스킬은 이 설명 하단의 "## Skill Library" 카탈로그에 있다. ' +
+            '질문과 직접 관련된 스킬이 있을 때만 그 정확한 이름을 skill_names 에 넣어 호출하라. ' +
+            '가장 관련된 1~3개만 고르고, 관련 스킬이 없으면 이 도구를 호출하지 마라.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                skill_names: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description: '불러올 스킬 이름들 — Skill Library 카탈로그의 정확한 이름. 가장 관련된 1~3개만.',
+                },
+            },
+            required: ['skill_names'],
+        },
+    },
+    handler: async (args, context?: UserContext): Promise<MCPToolResult> => {
+        const names = Array.isArray(args.skill_names)
+            ? args.skill_names.filter((n): n is string => typeof n === 'string')
+            : [];
+        if (names.length === 0) {
+            return { content: [{ type: 'text', text: '불러올 스킬 이름이 없습니다.' }] };
+        }
+        const userId = context?.userId !== undefined ? String(context.userId) : undefined;
+        try {
+            const { getSkillManager } = await import('../agents/skill-manager');
+            const { prompt, matched } = await getSkillManager().buildSkillPromptForNames(names, userId);
+            if (!prompt || matched.length === 0) {
+                return { content: [{ type: 'text', text: `요청한 스킬을 찾지 못했습니다: ${names.join(', ')}` }] };
+            }
+            logger.info(`load_skill: ${matched.join(', ')} (user=${userId ?? 'guest'})`);
+            return { content: [{ type: 'text', text: prompt }] };
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            logger.warn(`load_skill 실패: ${msg}`);
+            return { content: [{ type: 'text', text: `스킬 로드 실패: ${msg}` }], isError: true };
+        }
+    },
+};

--- a/apps/api/src/mcp/tools.ts
+++ b/apps/api/src/mcp/tools.ts
@@ -134,6 +134,8 @@ import { securityReviewTool } from './security-review-tool';
 import { createPlanTool } from './plan-tool';
 // 코드 리뷰 (P-1) — 다각도 코드 검토 (읽기 전용)
 import { codeReviewTool } from './code-review-tool';
+// 스킬 자동 호출 (LLM self-select) — 카탈로그는 getAllowedTools 가 description 에 주입
+import { loadSkillTool } from './load-skill-tool';
 
 /**
  * 전체 내장 도구 배열
@@ -162,4 +164,5 @@ export const builtInTools: MCPToolDefinition[] = [
     securityReviewTool,
     createPlanTool,
     codeReviewTool,
+    loadSkillTool as MCPToolDefinition,
 ];

--- a/apps/api/src/services/ChatService.ts
+++ b/apps/api/src/services/ChatService.ts
@@ -26,6 +26,7 @@ import type { ExecutionPlan } from '../chat/profile-resolver';
 import type { UserContext } from '../mcp/user-sandbox';
 import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { CHAT_ALWAYS_ON_TOOL_NAMES } from '../mcp/agent-task-tools';
+import { LOAD_SKILL_TOOL_NAME } from '../mcp/load-skill-tool';
 import { LLMClient } from '../llm';
 import { type ChatMessage, type ToolDefinition, type ModelOptions } from '../llm';
 import type { ResearchProgress } from './DeepResearchService';
@@ -163,7 +164,7 @@ export class ChatService {
             : await toolRouter.getLLMTools() as ToolDefinition[];
 
         // enabledTools가 없으면 레거시 호환: 전체 허용 (API 클라이언트 등). skill binding 적용도 skip.
-        if (reqCtx.enabledTools === undefined) return allTools;
+        if (reqCtx.enabledTools === undefined) return this.applySkillCatalog(allTools, allTools, reqCtx);
 
         // 사용자가 명시적으로 활성화한 도구만 추출
         const userToggled = allTools.filter(t => reqCtx.enabledTools![t.function.name] === true);
@@ -195,7 +196,48 @@ export class ChatService {
             `profileRequired=${profileRequiredNames.length}, skillBindings=${reqCtx.skillBindings.length}, ` +
             `merged=${merged.length}, alwaysOn=${alwaysOn.length}`,
         );
-        return [...merged, ...alwaysOn];
+        return this.applySkillCatalog([...merged, ...alwaysOn], allTools, reqCtx);
+    }
+
+    /**
+     * 스킬 자동 호출(LLM self-select) — load_skill 도구에 active 스킬 카탈로그를 주입한다.
+     *
+     * - SKILL_AUTO_SELECT_ENABLED!='true' (기본): load_skill 을 노출 목록에서 제거(기능 OFF).
+     * - ON: active 스킬을 "이름: 설명" 카탈로그로 만들어 load_skill description 에 붙여
+     *   request-scoped 로 교체. 모델이 카탈로그에서 관련 스킬을 골라 load_skill 호출.
+     * - 이미 주입된 바인딩 스킬(reqCtx.skillBindings)은 카탈로그에서 제외(dedup).
+     * - 카탈로그가 비거나 오류면 load_skill 제거(graceful) — 채팅 흐름 무영향.
+     *
+     * @param tools   노출 후보 도구 목록(merge 결과)
+     * @param allTools toolRouter 전체 도구 — load_skill 기본 정의(파라미터 스키마) 확보용
+     */
+    private async applySkillCatalog(
+        tools: ToolDefinition[], allTools: ToolDefinition[], reqCtx: RequestContext,
+    ): Promise<ToolDefinition[]> {
+        const without = tools.filter((t) => t.function.name !== LOAD_SKILL_TOOL_NAME);
+        if (process.env.SKILL_AUTO_SELECT_ENABLED !== 'true') return without;
+
+        const base = allTools.find((t) => t.function.name === LOAD_SKILL_TOOL_NAME);
+        if (!base) return without; // load_skill 미등록 — 노출 안 함
+
+        try {
+            const excludeIds = new Set(reqCtx.skillBindings.map((b) => b.skill_id));
+            const { catalog, count } = await getSkillManager().buildSkillCatalog({ excludeIds });
+            if (count === 0) return without;
+
+            const augmented: ToolDefinition = {
+                type: 'function',
+                function: {
+                    name: LOAD_SKILL_TOOL_NAME,
+                    description: `${base.function.description}\n\n## Skill Library (${count})\n${catalog}`,
+                    parameters: base.function.parameters,
+                },
+            };
+            return [...without, augmented];
+        } catch (e) {
+            logger.warn('스킬 카탈로그 주입 실패 (load_skill 제외):', e);
+            return without;
+        }
     }
 
     /**


### PR DESCRIPTION
## 요약
질문 내용에 따라 등록된 스킬을 `/` 명시 호출 없이 **자동 적용**한다. active 스킬 카탈로그(name+desc)를 `load_skill` 도구 description 에 주입 → 모델이 관련 스킬을 스스로 골라 호출(progressive disclosure) → 핸들러가 전체 content 주입. 기존 5턴 tool 루프 재사용, **별도 LLM classifier 호출 없음**.

**기본 OFF** (`SKILL_AUTO_SELECT_ENABLED=false`) — 운영 동작 무변화, 단계적 롤아웃.

## 변경
- `skill-manager.ts`: `buildSkillCatalog()` + `buildSkillPromptForNames()` (순수 한글 이름 `slugify`='' 오매칭 가드)
- `mcp/load-skill-tool.ts` (신규): `load_skill` 도구 — 이름→content, 권한 검증
- `mcp/tools.ts`: `builtInTools` 등록
- `ChatService.applySkillCatalog()`: `getAllowedTools` 양 반환점에서 카탈로그 주입(ON)/제거(OFF), 바인딩 스킬 dedup, top-K 캡
- `.env.example`: `SKILL_AUTO_SELECT_ENABLED`(false)·`_TOP_K`·`CATALOG_MAX_ITEMS`·`CATALOG_DESC_MAX`

## 검증 근거
| 방식 | 정확도 |
|---|---|
| 키워드 매칭 | top-1 82% (2건 실패) |
| **LLM self-select (실 qwen)** | **10/10** (키워드 실패 2건 교정, OOD 무선택) |

- 카탈로그 143개 ≈ 2K 토큰, `tool_choice:'auto'` 파싱 10/10
- 전제 확인: 로컬 tool calling 동작 + `qwen3.6-35b-a3b` preset `toolCalling:true` 게이트 통과

## 부수 수정 (보안)
`buildSkillPromptForIds` 권한필터가 `is_public`/`created_by`(snake_case)를 읽어, camelCase 런타임 객체(`isPublic`/`createdBy`, rowToSkill 매핑)에서 항상 `undefined`→공개로 오판해 **비공개 스킬이 노출**되던 버그 교정.

## 테스트
- 유닛 11 (카탈로그·매칭·dedup·topK·권한·camelCase 회귀) + 인접 회귀 46 통과
- `tsc` 0 / `eslint` 0
- ⚠️ 스트리밍 환경 tool 파싱은 운영 활성화 시 1회 실호출 확인 권장 (프로토타입은 non-stream)

## 활성화 절차 (운영, 수동)
`.env` `SKILL_AUTO_SELECT_ENABLED=true` → 빌드·재기동 → 실채팅 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)