### PR TITLE
fix(security): 외부 MCP 서버 spawn 시 호스트 비밀 env 누출 차단

### DIFF
--- a/apps/api/src/mcp/external-client.ts
+++ b/apps/api/src/mcp/external-client.ts
@@ -299,8 +299,13 @@ export class ExternalMCPClient extends EventEmitter {
                 return new StdioClientTransport({
                     command: this.config.command,
                     args: this.config.args || [],
+                    // 🔒 보안: process.env 전체 상속 금지 — 외부(승인) MCP 서버가 호스트 비밀
+                    //   (DATABASE_URL/JWT_SECRET/TOKEN_ENCRYPTION_KEY/LLM_API_KEY/GOOGLE_* 등)에
+                    //   접근하던 누출을 차단. SDK 가 getDefaultEnvironment()(PATH/HOME 등 안전
+                    //   부분집합)를 base 로 병합하므로, 서버가 명시 설정한 env 만 추가 전달한다.
+                    //   (host env 가 필요한 서버는 config.env 에 해당 키를 명시해야 함 — 명시적 opt-in)
                     env: this.config.env
-                        ? { ...process.env, ...this.config.env } as Record<string, string>
+                        ? { ...this.config.env } as Record<string, string>
                         : undefined,
                     stderr: 'pipe',
                 });


### PR DESCRIPTION
## 문제
`ExternalMCPClient` 의 stdio transport 가 외부(import·승인) MCP 서버를 spawn 할 때 `env: { ...process.env, ...config.env }` 로 **호스트 프로세스 환경 전체를 상속**시켰다. 즉 승인된 MCP 서버 프로세스가 다음 비밀에 모두 접근 가능했다:
- `DATABASE_URL`, `JWT_SECRET`, `TOKEN_ENCRYPTION_KEY`, `LLM_API_KEY`, `GOOGLE_CLIENT_SECRET` 등

`external-client.ts:299` (수정 전):
```js
env: this.config.env ? { ...process.env, ...this.config.env } : undefined,
```

## 수정
MCP SDK 의 `StdioClientTransport.start()` 는 spawn 시 항상 `getDefaultEnvironment()`(PATH/HOME/SHELL/TERM/USER 등 **안전 부분집합**)를 base 로 병합한다(`@modelcontextprotocol/sdk` stdio.js). 따라서 우리 코드가 `...process.env` 를 스프레드할 필요가 없다 — `config.env`(서버가 명시 설정한 값)만 전달.

```js
env: this.config.env ? { ...this.config.env } : undefined,
```

## 영향 (의도된 동작 변경)
호스트 env 를 **암묵적으로** 상속하던 외부 MCP 서버는, 필요한 키를 `config.env` 에 **명시(explicit opt-in)** 해야 동작한다. 보안상 올바른 방향.

## 검증
- 단일 누출 지점 확인: `...process.env` 스프레드는 src 전체에서 이 한 곳뿐, 다른 spawn 경로 없음
- `tsc` 0 / `eslint` 0

## 배경
외부 MCP 서버는 현재 호스트 자식 프로세스로 **OS 격리 없이** 실행된다(별도 샌드박스 재검토 진행 중). 본 PR 은 그 중 **즉시 surgical 하게 닫을 수 있는 비밀 누출**만 우선 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)