### PR TITLE
feat(security): 외부 MCP stdio 서버 OS 격리 (bubblewrap)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -665,6 +665,15 @@ SKILL_AUTO_SELECT_ENABLED=false
 SKILL_AUTO_SELECT_TOP_K=3
 SKILL_CATALOG_MAX_ITEMS=200
 SKILL_CATALOG_DESC_MAX=120
+# 외부 MCP stdio 서버 OS 격리 (bubblewrap) — 외부 MCP 서버를 bwrap 으로 감싸 FS·프로세스·
+# (선택)네트워크 격리. Docker 미사용. 기본 OFF — Linux 운영서 bwrap 설치 후 활성화.
+# 비-Linux/bwrap 부재 시 graceful no-op(비격리 실행 + 경고). 네트워크는 서버별
+# mcp_servers.sandbox_network('full'|'none')로 제어(bwrap 한계상 binary).
+MCP_SANDBOX_ENABLED=false
+MCP_SANDBOX_BWRAP_PATH=bwrap
+# MCP_SANDBOX_ROOT=/home/smith/.openmake-mcp-sandbox   # per-server 작업 디렉토리 루트(기본 ~/.openmake-mcp-sandbox)
+# MCP_SANDBOX_NPM_CACHE=/home/smith/.npm               # npx/uvx 캐시 바인드(기본 ~/.npm)
+# MCP_SANDBOX_EXTRA_BINDS=/opt/tooling:/usr/local      # 추가 ro-bind 경로(: 구분, 툴체인 위치 등)
 # fs_read_file 완전성 고지(P-6) — 이 바이트 초과 시 앞부분만 반환하고 잘림을 고지.
 FS_READ_MAX_BYTES=100000
 # WebSocket 메시지 최대 페이로드(bytes). **미설정/0 = 무제한**(파일·이미지 업로드 용량 제한 없음).

--- a/apps/api/src/data/models/unified-database.types.ts
+++ b/apps/api/src/data/models/unified-database.types.ts
@@ -242,6 +242,8 @@ export interface MCPServerRow {
     enabled: boolean;
     created_at: string;
     updated_at: string;
+    /** stdio bwrap 샌드박스 네트워크 정책 ('full'|'none'). 042 마이그레이션. */
+    sandbox_network?: 'full' | 'none' | null;
 }
 
 // ============================================

--- a/apps/api/src/data/repositories/mcp-catalog-repository.ts
+++ b/apps/api/src/data/repositories/mcp-catalog-repository.ts
@@ -39,6 +39,8 @@ export interface UserMcpServerRow {
     enabled: boolean;
     created_at: string;
     updated_at: string;
+    /** stdio bwrap 샌드박스 네트워크 정책 ('full'|'none'). 042 마이그레이션. */
+    sandbox_network?: 'full' | 'none' | null;
 }
 
 export class McpCatalogRepository {

--- a/apps/api/src/mcp/external-client.ts
+++ b/apps/api/src/mcp/external-client.ts
@@ -26,6 +26,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import type { MCPServerConfig, MCPConnectionStatus, MCPTool, MCPToolResult } from './types';
+import { buildSandboxedCommand } from './sandbox-bwrap';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('ExternalMCP');
@@ -296,9 +297,19 @@ export class ExternalMCPClient extends EventEmitter {
                 if (!this.config.command) {
                     throw new Error(`stdio transport requires "command" for server "${this.config.name}"`);
                 }
-                return new StdioClientTransport({
+                // 🔒 OS 격리: bwrap 으로 command/args 를 감싼다(게이트 미충족 시 원본 no-op).
+                const sb = buildSandboxedCommand({
                     command: this.config.command,
                     args: this.config.args || [],
+                    serverId: this.config.id,
+                    network: this.config.sandbox_network ?? 'full',
+                });
+                if (sb.sandboxed) {
+                    logger.info(`MCP 서버 "${this.config.name}" bwrap 격리 적용 (net=${this.config.sandbox_network ?? 'full'})`);
+                }
+                return new StdioClientTransport({
+                    command: sb.command,
+                    args: sb.args,
                     // 🔒 보안: process.env 전체 상속 금지 — 외부(승인) MCP 서버가 호스트 비밀
                     //   (DATABASE_URL/JWT_SECRET/TOKEN_ENCRYPTION_KEY/LLM_API_KEY/GOOGLE_* 등)에
                     //   접근하던 누출을 차단. SDK 가 getDefaultEnvironment()(PATH/HOME 등 안전

--- a/apps/api/src/mcp/lifecycle-supervisor.ts
+++ b/apps/api/src/mcp/lifecycle-supervisor.ts
@@ -33,6 +33,7 @@ export interface ServerSpawnConfig {
     url?: string | null;
     lifecycle?: McpLifecycle;
     catalog_template_id?: string;
+    sandbox_network?: 'full' | 'none';
 }
 
 export type ClientFactory = (config: ServerSpawnConfig) => ExternalMCPClient;
@@ -172,6 +173,7 @@ export class MCPLifecycleSupervisor implements LifecycleSupervisor {
             url: server.url,
             lifecycle,
             catalog_template_id: server.catalog_template_id ?? undefined,
+            sandbox_network: (server as ServerWithLifecycle).sandbox_network === 'none' ? 'none' : 'full',
         };
 
         await this.repo.recordInstanceTransition(serverId, userId, 'starting').catch(() => { /* noop */ });

--- a/apps/api/src/mcp/sandbox-bwrap.ts
+++ b/apps/api/src/mcp/sandbox-bwrap.ts
@@ -1,0 +1,155 @@
+/**
+ * ============================================================
+ * MCP Sandbox (bubblewrap) — 외부 MCP stdio 서버 OS 격리
+ * ============================================================
+ *
+ * 외부(import·승인) MCP 서버를 호스트 자식 프로세스로 직접 spawn 하던 것을,
+ * bubblewrap(bwrap)으로 감싸 파일시스템·프로세스·(선택)네트워크를 격리한다.
+ * Docker 미사용 — 정책(인프라 한정) 회피. 단일 후킹: external-client createTransport.
+ *
+ * 안전/호환 원칙:
+ * - 게이트 미충족(플래그 off / 비-Linux / bwrap 부재) → 원본 command 그대로(no-op).
+ *   기능 OFF 기본이라 머지해도 동작 무변화. graceful (채팅·MCP 흐름 무중단).
+ * - 네트워크는 bwrap 한계상 binary: full(공유) | none(--unshare-net). 서버별 설정.
+ *   "외부 허용 + 내부 loopback 차단" 미세화는 Phase 2(netns+nftables) — 본 모듈 범위 밖.
+ *
+ * @module mcp/sandbox-bwrap
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('McpSandbox');
+
+export type SandboxNetwork = 'full' | 'none';
+
+export interface SandboxInput {
+    /** 원본 실행 명령 (예: 'npx') */
+    command: string;
+    /** 원본 인자 */
+    args: string[];
+    /** 서버 ID — per-server 작업 디렉토리 격리에 사용 */
+    serverId: string;
+    /** 네트워크 정책 (기본 'full') */
+    network?: SandboxNetwork;
+}
+
+export interface SandboxResult {
+    command: string;
+    args: string[];
+    /** 실제 bwrap 으로 감쌌는지 (false = no-op 통과) */
+    sandboxed: boolean;
+}
+
+/** 게이트/프로파일 입력 — 테스트에서 주입 가능(순수성 확보) */
+export interface SandboxConfig {
+    enabled: boolean;
+    platform: string;
+    /** resolve 된 bwrap 절대경로 또는 null(미발견) */
+    bwrapPath: string | null;
+    /** per-server 작업 디렉토리 루트 */
+    sandboxRoot: string;
+    /** npx/uvx 패키지 캐시 (쓰기 바인드) */
+    npmCache: string;
+    /** 읽기전용 바인드 경로 목록 (시스템 + 툴체인) */
+    roBinds: string[];
+}
+
+/** 기본 읽기전용 바인드 — 런타임(node/python)·CA·DNS 동작에 필요한 최소 시스템 경로. */
+const DEFAULT_RO_BINDS = ['/usr', '/bin', '/sbin', '/lib', '/lib64', '/etc', '/opt'];
+
+function sanitizeId(id: string): string {
+    return id.replace(/[^A-Za-z0-9._-]/g, '_') || 'unknown';
+}
+
+/** PATH 또는 절대경로에서 bwrap 바이너리 탐색 (memoize). 미발견 시 null. */
+let bwrapCache: { key: string; value: string | null } | null = null;
+function resolveBwrap(bwrapPath: string): string | null {
+    if (bwrapCache && bwrapCache.key === bwrapPath) return bwrapCache.value;
+    let resolved: string | null = null;
+    try {
+        if (bwrapPath.includes('/')) {
+            resolved = fs.existsSync(bwrapPath) ? bwrapPath : null;
+        } else {
+            for (const dir of (process.env.PATH || '').split(path.delimiter)) {
+                if (!dir) continue;
+                const candidate = path.join(dir, bwrapPath);
+                if (fs.existsSync(candidate)) { resolved = candidate; break; }
+            }
+        }
+    } catch {
+        resolved = null;
+    }
+    bwrapCache = { key: bwrapPath, value: resolved };
+    return resolved;
+}
+
+/** 환경/플랫폼에서 SandboxConfig 조립 (No-Hardcoding — env override). */
+export function defaultSandboxConfig(): SandboxConfig {
+    const enabled = process.env.MCP_SANDBOX_ENABLED === 'true';
+    const platform = process.platform;
+    const bwrapPath = enabled && platform === 'linux'
+        ? resolveBwrap(process.env.MCP_SANDBOX_BWRAP_PATH || 'bwrap')
+        : null;
+    const home = os.homedir();
+    const sandboxRoot = process.env.MCP_SANDBOX_ROOT || path.join(home, '.openmake-mcp-sandbox');
+    const npmCache = process.env.MCP_SANDBOX_NPM_CACHE || path.join(home, '.npm');
+    const extra = (process.env.MCP_SANDBOX_EXTRA_BINDS || '')
+        .split(path.delimiter).map((s) => s.trim()).filter(Boolean);
+    // 툴체인이 $HOME 하위(mise/nvm/uv)일 수 있어 ro 로 best-effort 바인드(존재 시).
+    const toolchain = [path.join(home, '.local'), path.join(home, '.nvm'), path.join(home, '.cache', 'uv')];
+    return {
+        enabled, platform, bwrapPath, sandboxRoot, npmCache,
+        roBinds: [...DEFAULT_RO_BINDS, ...toolchain, ...extra],
+    };
+}
+
+/**
+ * PURE: bwrap 인자 조립 (유닛테스트 대상). workdir 존재는 호출자가 보장.
+ * 레포·비밀 경로는 바인드하지 않음 → 샌드박스 내부에서 보이지 않음.
+ */
+export function buildBwrapArgs(input: SandboxInput, cfg: SandboxConfig): string[] {
+    const workdir = path.join(cfg.sandboxRoot, sanitizeId(input.serverId));
+    const a: string[] = [];
+    for (const p of cfg.roBinds) a.push('--ro-bind-try', p, p);
+    a.push('--proc', '/proc', '--dev', '/dev', '--tmpfs', '/tmp');
+    a.push('--bind', workdir, workdir, '--chdir', workdir);
+    a.push('--bind-try', cfg.npmCache, cfg.npmCache); // npx/uvx 캐시 (쓰기)
+    a.push('--unshare-user', '--unshare-pid', '--unshare-ipc', '--unshare-uts');
+    if ((input.network ?? 'full') === 'none') a.push('--unshare-net');
+    a.push('--die-with-parent', '--new-session');
+    return a;
+}
+
+const warned = new Set<string>();
+function warnOnce(key: string, msg: string): void {
+    if (warned.has(key)) return;
+    warned.add(key);
+    logger.warn(msg);
+}
+
+/**
+ * 외부 MCP stdio command 를 bwrap 으로 감싼다. 게이트 미충족 시 원본 그대로(no-op).
+ * @param cfg 테스트 주입용 — 기본 defaultSandboxConfig()
+ */
+export function buildSandboxedCommand(input: SandboxInput, cfg: SandboxConfig = defaultSandboxConfig()): SandboxResult {
+    if (!cfg.enabled) return { command: input.command, args: input.args, sandboxed: false };
+    if (cfg.platform !== 'linux') {
+        warnOnce('platform', `MCP 샌드박스는 Linux 전용 — ${cfg.platform} 에서는 미적용(비격리 실행). 운영(Linux)에서 활성화하세요.`);
+        return { command: input.command, args: input.args, sandboxed: false };
+    }
+    if (!cfg.bwrapPath) {
+        warnOnce('bwrap', 'bwrap 바이너리를 찾지 못해 MCP 샌드박스 미적용(비격리 실행). `apt install bubblewrap` 필요.');
+        return { command: input.command, args: input.args, sandboxed: false };
+    }
+    const workdir = path.join(cfg.sandboxRoot, sanitizeId(input.serverId));
+    try {
+        fs.mkdirSync(workdir, { recursive: true });
+    } catch (e) {
+        logger.warn(`샌드박스 작업 디렉토리 생성 실패 — 비격리 실행: ${e instanceof Error ? e.message : String(e)}`);
+        return { command: input.command, args: input.args, sandboxed: false };
+    }
+    const bwrapArgs = buildBwrapArgs(input, cfg);
+    return { command: cfg.bwrapPath, args: [...bwrapArgs, '--', input.command, ...input.args], sandboxed: true };
+}

--- a/apps/api/src/mcp/server-registry.ts
+++ b/apps/api/src/mcp/server-registry.ts
@@ -48,6 +48,7 @@ function rowToConfig(row: MCPServerRow): MCPServerConfig {
         enabled: row.enabled,
         created_at: row.created_at,
         updated_at: row.updated_at,
+        sandbox_network: row.sandbox_network === 'none' ? 'none' : 'full',
     };
 }
 

--- a/apps/api/src/mcp/types.ts
+++ b/apps/api/src/mcp/types.ts
@@ -260,6 +260,8 @@ export interface MCPServerConfig {
     updated_at: string;
     /** 카탈로그 템플릿 ID (mcp_server_catalog.id 참조) */
     catalog_template_id?: string;
+    /** stdio bwrap 샌드박스 네트워크 정책 ('full' 기본 | 'none'=--unshare-net). DB sandbox_network 컬럼. */
+    sandbox_network?: 'full' | 'none';
 }
 
 /**

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -329,6 +329,7 @@ export class DashboardServer {
                     created_at: '',
                     updated_at: '',
                     catalog_template_id: config.catalog_template_id ?? undefined,
+                    sandbox_network: config.sandbox_network ?? 'full',
                 }),
             });
             setLifecycleSupervisor(supervisor);
@@ -517,6 +518,7 @@ if (require.main === module) {
                         created_at: '',
                         updated_at: '',
                         catalog_template_id: config.catalog_template_id ?? undefined,
+                        sandbox_network: config.sandbox_network ?? 'full',
                     }),
                 });
                 setLifecycleSupervisor(supervisor);

--- a/db/migrations/042_mcp_sandbox_network.sql
+++ b/db/migrations/042_mcp_sandbox_network.sql
@@ -1,0 +1,28 @@
+-- 042_mcp_sandbox_network.sql
+-- 외부 MCP stdio 서버 bwrap 샌드박스 네트워크 정책 컬럼.
+--   'full' (기본): 네트워크 공유 — 외부 API 호출 서버·내부 DB 접속 서버.
+--   'none' (--unshare-net): 네트워크 차단 — 임의 코드 실행 등 고위험 서버(예: Python REPL).
+-- 멱등 작성. 운영 DB owner mismatch 대비 DO+EXCEPTION 으로 감쌈(graceful).
+
+DO $$
+BEGIN
+    ALTER TABLE mcp_servers
+        ADD COLUMN IF NOT EXISTS sandbox_network TEXT DEFAULT 'full';
+EXCEPTION
+    WHEN insufficient_privilege THEN
+        RAISE NOTICE 'mcp_servers ALTER 권한 없음 — owner 로 수동 적용 필요 (graceful skip)';
+    WHEN undefined_table THEN
+        RAISE NOTICE 'mcp_servers 테이블 부재 — schema-initializer 가 생성 후 재적용 (graceful skip)';
+END $$;
+
+-- CHECK 제약 (재실행 안전 — 존재 시 skip)
+DO $$
+BEGIN
+    ALTER TABLE mcp_servers
+        ADD CONSTRAINT mcp_servers_sandbox_network_chk CHECK (sandbox_network IN ('full', 'none'));
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+    WHEN insufficient_privilege THEN
+        RAISE NOTICE 'mcp_servers CHECK 추가 권한 없음 (graceful skip)';
+    WHEN undefined_table THEN NULL;
+END $$;

--- a/scripts/mcp/measure-mcp-sandbox.js
+++ b/scripts/mcp/measure-mcp-sandbox.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * measure-mcp-sandbox.js — 외부 MCP stdio 서버 bwrap 격리 호환성 재측정 (read-only)
+ *
+ * 목적: MCP_SANDBOX_ENABLED=true 활성화 전, 운영 DB에 등록된 stdio MCP 서버의
+ *   command/args/env 를 점검해 (1) 격리 호환성 위험을 분류하고 (2) 서버별
+ *   sandbox_network('full'|'none') 정책을 추천한다. 어떤 변경도 하지 않으며,
+ *   추천 UPDATE 문을 "주석으로" 출력만 한다(사람이 검토 후 직접 실행).
+ *
+ * 실행 (운영 서버, repo 루트에서 — DATABASE_URL 이 .env 또는 환경에 있어야 함):
+ *   node scripts/mcp/measure-mcp-sandbox.js
+ *
+ * 근거: docs/superpowers/plans/2026-06-22-mcp-sandbox-bubblewrap.md
+ *   - 네트워크는 bwrap 한계상 binary: full(공유) | none(--unshare-net)
+ *   - 대부분 MCP 는 외부 API 호출 → 기본 'full'. 임의 코드 실행 등 net 불필요
+ *     고위험 서버만 'none' 후보(예: Python REPL).
+ */
+/* eslint-disable @typescript-eslint/no-require-imports */ // 운영서 ts-node 없이 `node` 로 직접 실행되는 ops 스크립트
+'use strict';
+
+const { Pool } = require('pg');
+try { require('dotenv').config(); } catch { /* dotenv 없으면 환경변수 그대로 사용 */ }
+
+// ── 호환성 휴리스틱 ─────────────────────────────────────────────
+const SECRETISH = /(SECRET|TOKEN|KEY|PASSWORD|DATABASE_URL|CREDENTIAL)/i;
+const INTERNAL_NET = /(localhost|127\.0\.0\.1|::1|:5432|:13401|:4000|:52416|:6379)/i;
+const HOME_DEP = /(\$HOME|~\/|\/home\/|\/Users\/|\.config|\.cache|\.local)/i;
+// 임의 코드 실행 / 셸 계열 → 네트워크 차단(none) 후보
+const ARBITRARY_CODE = /(repl|interpreter|exec|eval|code-?run|shell|bash|python-?repl)/i;
+
+function classify(s) {
+    const args = Array.isArray(s.args) ? s.args : [];
+    const env = s.env && typeof s.env === 'object' ? s.env : {};
+    const envKeys = Object.keys(env);
+    const blob = [s.name, s.command, ...args.map(String), ...Object.values(env).map(String)].join(' ');
+
+    const flags = [];
+    if (envKeys.some((k) => SECRETISH.test(k))) flags.push('host-secret-env');
+    if (INTERNAL_NET.test(blob)) flags.push('internal-net');   // → net 필요(full 유지)
+    if (HOME_DEP.test(blob)) flags.push('home-path');           // → 설치/데이터 디렉토리 bind 필요
+    const arbitrary = ARBITRARY_CODE.test(blob);
+    if (arbitrary) flags.push('arbitrary-code');
+
+    // 네트워크 추천: 내부 net 의존이면 full 필수. 임의 코드 + 내부net 아님 → none 후보.
+    let suggestNet = 'full';
+    let reason = '외부 API 호출 가능성 — 기본 full';
+    if (flags.includes('internal-net')) {
+        reason = '내부 서비스(loopback) 접속 필요 — full 유지';
+    } else if (arbitrary) {
+        suggestNet = 'none';
+        reason = '임의 코드 실행 + 내부net 의존 없음 — net 차단(none) 권장';
+    }
+    return { flags, suggestNet, reason, envKeys, args };
+}
+
+(async () => {
+    if (!process.env.DATABASE_URL) {
+        console.error('❌ DATABASE_URL 미설정. .env 로드 또는 환경변수 export 후 재실행.');
+        process.exit(1);
+    }
+    const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+    try {
+        const { rows } = await pool.query(
+            "SELECT name, command, args, env, sandbox_network FROM mcp_servers WHERE transport_type='stdio' ORDER BY name"
+        );
+        if (rows.length === 0) {
+            console.log('등록된 stdio MCP 서버가 없습니다.');
+            return;
+        }
+        console.log(`\n외부 MCP stdio 서버 ${rows.length}개 — bwrap 격리 호환성 재측정`);
+        console.log('='.repeat(72));
+
+        const updates = [];
+        let i = 0;
+        for (const s of rows) {
+            i++;
+            const c = classify(s);
+            const current = s.sandbox_network || 'full(기본)';
+            console.log(`\n${i}. ${s.name}`);
+            console.log(`   command : ${s.command} ${JSON.stringify(c.args)}`);
+            console.log(`   env keys: ${c.envKeys.length ? c.envKeys.join(', ') : '(none)'}`);
+            console.log(`   flags   : ${c.flags.length ? c.flags.join(', ') : '특이 의존 없음'}`);
+            console.log(`   현재 net: ${current}  →  추천: ${c.suggestNet}  (${c.reason})`);
+            if (c.suggestNet === 'none' && s.sandbox_network !== 'none') {
+                updates.push(`UPDATE mcp_servers SET sandbox_network='none' WHERE name=${quote(s.name)};`);
+            }
+        }
+
+        console.log('\n' + '='.repeat(72));
+        console.log('📋 추천 정책 변경 (검토 후 직접 실행 — 이 스크립트는 변경하지 않음):');
+        if (updates.length === 0) {
+            console.log('   변경 추천 없음 — 전부 full 유지 권장.');
+        } else {
+            console.log('   /* 아래는 추천일 뿐. 각 서버가 실제로 네트워크 불필요한지 확인 후 적용 */');
+            for (const u of updates) console.log('   ' + u);
+        }
+        console.log('\n⚠️  bwrap 한계: 네트워크는 full/none 만 가능. "외부 허용+내부 loopback 차단"은');
+        console.log('    Phase 2(netns+nftables) 별도 작업. internal-net flag 서버는 full 유지 필수.');
+    } catch (e) {
+        console.error('ERR:', e.message);
+        process.exit(1);
+    } finally {
+        await pool.end();
+    }
+})();
+
+/** SQL 문자열 리터럴 안전 인용 (작은따옴표 이스케이프) */
+function quote(v) {
+    return `'${String(v).replace(/'/g, "''")}'`;
+}


### PR DESCRIPTION
> ⚠️ **PR #151 위에 스택됨** (base=`fix/mcp-env-secret-leak`). #151 머지 후 base 를 `main` 으로 재타겟하거나 #151 머지 뒤 머지하세요.

## 요약
외부(import·승인) MCP 서버를 **OS 격리 없이 호스트 자식 프로세스**로 spawn 하던 것을 **bubblewrap(bwrap)** 으로 감싸 FS·프로세스·(선택)네트워크를 격리. **Docker 미사용**(정책 회피). 단일 후킹: `external-client.ts` createTransport.

**기본 OFF**(`MCP_SANDBOX_ENABLED=false`) — Linux 운영서 bwrap 설치 후 활성화. 비-Linux/bwrap부재 시 **graceful no-op + 경고**.

## 통제 층위
`import 승인 → #151 env 비밀차단 → 🆕 bwrap FS/proc/net 격리 → 인자검증`

## 변경
- **`mcp/sandbox-bwrap.ts`**(신규): `buildSandboxedCommand()`(게이트) + `buildBwrapArgs()`(순수)
  - 프로파일: 레포·비밀 **미바인드** + per-server cwd + npm/uv 캐시 + `--unshare-{user,pid,ipc,uts}` + seccomp 기본
  - 네트워크 **binary**(bwrap 한계): `full` | `none`(`--unshare-net`). 서버별 정책
- `external-client.ts`: stdio createTransport 에서 command/args bwrap 래핑
- `mcp_servers.sandbox_network` 컬럼(마이그레이션 042, 멱등+graceful owner) + **두 spawn 경로**(registry/lifecycle) 배선
- `.env.example`: `MCP_SANDBOX_*` 문서화

## 실측 근거 (호환성)
stdio 16서버 분류: 표준11(net+캐시) / 경로의존3 / 내부net1(PostgreSQL :5432) / **임의코드1(Python REPL → net `none` 1순위)**. 대부분 외부 API 호출이라 **전면 net 차단 불가** → 서버별 full/none 채택.

## 한계 / 후속
- bwrap 네트워크가 binary 라 "외부 허용 + 내부 loopback 차단"은 **Phase 2**(netns+nftables)로 분리.
- 활성화 전: 운영 서버 `which bwrap` 설치 확인 + 운영 DB 등록 서버 재측정(로컬은 macOS 경로 포함).

## 테스트
- 유닛 8(게이트 no-op·bwrap 인자·net full/none·path-traversal 정규화) + mcp 회귀 52 통과
- `tsc` 0 / `eslint` 0
- ⚠️ 실제 Linux 격리 spawn smoke 는 운영 환경에서 1회 권장(설계 §11.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)