### PR TITLE
feat(web): 채팅 파일첨부 기능 복원

### DIFF
--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -10,16 +10,71 @@ import {
   Square,
   Telescope,
   Brain,
+  Paperclip,
+  X,
 } from "lucide-react";
+import type { WsAttachedFile } from "@openmake/shared-types";
 import { useAppStore } from "@/lib/store";
 import { useChatSocket } from "@/lib/use-chat-socket";
 import { fetchModels } from "@/lib/models-api";
 import { cn } from "@/lib/utils";
 
+// 클라이언트 첨부 캡 — 백엔드 FILE_ATTACH_LIMITS 기본값과 일치(서버가 재절단하므로 advisory).
+const MAX_FILES = 10;
+const MAX_CHARS_PER_FILE = 100_000;
+const MAX_TOTAL_CHARS = 300_000;
+// 텍스트로 읽을 수 있는 확장자(바이너리는 미전송 — 백엔드 계약). vision 이미지는 별도 채널.
+const TEXT_ACCEPT =
+  ".txt,.md,.markdown,.json,.csv,.tsv,.log,.xml,.yaml,.yml,.html,.htm,.css,.js,.jsx,.ts,.tsx,.py,.java,.go,.rs,.c,.cpp,.h,.sh,.sql,.env,.ini,.toml,text/*";
+
+/** 파일을 텍스트로 읽는다(바이너리는 깨질 수 있으나 백엔드가 처리). */
+function readFileText(file: File): Promise<string> {
+  return new Promise((resolve) => {
+    const r = new FileReader();
+    r.onload = () => resolve(typeof r.result === "string" ? r.result : "");
+    r.onerror = () => resolve("");
+    r.readAsText(file);
+  });
+}
+
 export function Composer() {
   const { sendChat, abort } = useChatSocket();
   const [text, setText] = useState("");
+  const [files, setFiles] = useState<WsAttachedFile[]>([]);
   const taRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // 선택한 파일들을 텍스트로 읽어 캡 적용 후 첨부 목록에 추가
+  const addFiles = async (list: FileList | null) => {
+    if (!list || list.length === 0) return;
+    const next = [...files];
+    let total = next.reduce((n, f) => n + (f.content?.length ?? 0), 0);
+    for (const file of Array.from(list)) {
+      if (next.length >= MAX_FILES || total >= MAX_TOTAL_CHARS) break;
+      let content = await readFileText(file);
+      let truncated = false;
+      if (content.length > MAX_CHARS_PER_FILE) {
+        content = content.slice(0, MAX_CHARS_PER_FILE);
+        truncated = true;
+      }
+      if (total + content.length > MAX_TOTAL_CHARS) {
+        content = content.slice(0, Math.max(0, MAX_TOTAL_CHARS - total));
+        truncated = true;
+      }
+      total += content.length;
+      next.push({
+        id: crypto.randomUUID(),
+        name: file.name.slice(0, 200),
+        type: file.type || "text/plain",
+        content,
+        size: file.size,
+        truncated,
+      });
+    }
+    setFiles(next);
+  };
+
+  const removeFile = (id: string) => setFiles((prev) => prev.filter((f) => f.id !== id));
 
   // 로컬 vLLM + 등록된 외부 LLM(OpenRouter 등) 통합 모델 목록
   const { data: modelsData } = useQuery({
@@ -54,9 +109,10 @@ export function Composer() {
   }, [modelsData]);
 
   const submit = () => {
-    if (!text.trim() || isGenerating) return;
-    sendChat(text.trim());
+    if ((!text.trim() && files.length === 0) || isGenerating) return;
+    sendChat(text.trim(), undefined, files.length ? files : undefined);
     setText("");
+    setFiles([]);
     if (taRef.current) taRef.current.style.height = "auto";
   };
 
@@ -104,6 +160,30 @@ export function Composer() {
           ))}
         </div>
 
+        {/* 첨부 파일 칩 */}
+        {files.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 px-3 pt-2">
+            {files.map((f) => (
+              <span
+                key={f.id}
+                title={f.truncated ? `${f.name} (길이 초과로 일부만 첨부)` : f.name}
+                className="inline-flex max-w-[12rem] items-center gap-1.5 rounded-md border border-border bg-surface-2 px-2 py-1 text-xs text-fg"
+              >
+                <Paperclip className="h-3 w-3 shrink-0 text-muted" />
+                <span className="truncate">{f.name}</span>
+                {f.truncated && <span className="shrink-0 text-faint">✂</span>}
+                <button
+                  onClick={() => removeFile(f.id)}
+                  aria-label={`${f.name} 첨부 제거`}
+                  className="shrink-0 text-muted hover:text-fg"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+
         <textarea
           ref={taRef}
           value={text}
@@ -125,6 +205,28 @@ export function Composer() {
 
         {/* 하단: 스타일 + 전송 (모델 선택은 설정 → 기본 모델에서, 채팅창엔 모델명 비표시) */}
         <div className="flex items-center gap-1.5 px-2.5 pb-2.5 pt-1">
+          {/* 파일 첨부 */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept={TEXT_ACCEPT}
+            className="hidden"
+            onChange={(e) => {
+              void addFiles(e.target.files);
+              e.target.value = ""; // 같은 파일 재선택 허용
+            }}
+          />
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            disabled={files.length >= MAX_FILES}
+            className="grid h-8 w-8 place-items-center rounded-md text-muted transition hover:bg-surface-2 hover:text-fg disabled:opacity-40"
+            title={files.length >= MAX_FILES ? `최대 ${MAX_FILES}개까지 첨부` : "파일 첨부 (텍스트)"}
+            aria-label="파일 첨부"
+          >
+            <Paperclip className="h-4 w-4" />
+          </button>
+
           <button
             onClick={cycleStyle}
             className="rounded-md px-2 py-1.5 text-xs font-medium capitalize text-muted hover:bg-surface-2 hover:text-fg"
@@ -144,7 +246,7 @@ export function Composer() {
           ) : (
             <button
               onClick={submit}
-              disabled={!text.trim()}
+              disabled={!text.trim() && files.length === 0}
               aria-label="전송"
               className="ml-auto grid h-8 w-8 place-items-center rounded-md bg-accent text-accent-fg transition hover:bg-accent-hover disabled:opacity-40"
             >

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { WsChatRequest, WsServerEvent } from "@openmake/shared-types";
+import type { WsChatRequest, WsServerEvent, WsAttachedFile } from "@openmake/shared-types";
 import { useAppStore } from "./store";
 
 /**
@@ -115,11 +115,16 @@ export function useChatSocket() {
   }, [connect]);
 
   const sendChat = useCallback(
-    (message: string, images?: string[]) => {
+    (message: string, images?: string[], files?: WsAttachedFile[]) => {
       const s = useAppStore.getState();
-      if (!message.trim() || s.isGenerating) return;
+      const hasFiles = Array.isArray(files) && files.length > 0;
+      // 텍스트가 비어도 첨부 파일만으로 전송 가능
+      if ((!message.trim() && !hasFiles) || s.isGenerating) return;
 
-      appendMessage({ role: "user", content: message, images });
+      // 첨부만 있고 본문이 비면 파일명을 표시용 본문으로 사용
+      const displayContent =
+        message.trim() || (hasFiles ? `📎 ${files!.map((f) => f.name).join(", ")}` : "");
+      appendMessage({ role: "user", content: displayContent, images });
       setActiveAgent(null); // 새 질문 — 이전 에이전트/스킬 표시 초기화
       setActiveSkills([]);
       setStreaming(true); // assistant placeholder 는 첫 token 에서 생성, isGenerating=true
@@ -131,6 +136,7 @@ export function useChatSocket() {
         history: s.chatHistory.map((m) => ({ role: m.role, content: m.content })),
         sessionId: s.currentSessionId,
         images: images ?? [],
+        files: files ?? [],
         webSearch: s.webSearchEnabled,
         deepResearchMode: s.deepResearchMode,
         enabledTools: s.mcpToolsEnabled,

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -79,6 +79,18 @@ export interface Project {
 }
 
 /* ── WebSocket 채팅 프로토콜 (sockets/ws-chat-handler 와 페어) ───────── */
+/** 첨부 텍스트 파일 (백엔드 ws-chat-handler files[] · attach-context AttachedFileInput 호환) */
+export interface WsAttachedFile {
+  id: string;
+  name: string;
+  type: string;
+  /** 텍스트 내용 (바이너리는 미전송). 클라이언트가 캡 초과 시 절단 */
+  content?: string;
+  size?: number;
+  /** 전송 전 캡으로 내용을 절단했음 */
+  truncated?: boolean;
+}
+
 export interface WsChatRequest {
   type: "chat";
   message: string;
@@ -86,6 +98,8 @@ export interface WsChatRequest {
   history?: Array<{ role: ChatRole; content: string }>;
   sessionId?: string | null;
   images?: string[];
+  /** 첨부 텍스트 파일 — 백엔드가 fileContext 채널로 LLM 에 주입 */
+  files?: WsAttachedFile[];
   webSearch?: boolean;
   deepResearchMode?: boolean;
   enabledTools?: Record<string, boolean>;


### PR DESCRIPTION
## 배경
백엔드(`ws-chat-handler` `buildFileContext`·`attach-context`, `files[]` 멀티턴 재주입)는 **이미 완비**돼 있었으나, apps/web Lumen 재구축 시 **composer 의 파일첨부 UI 가 누락**돼 기능이 동작하지 않던 것을 복원.

## 변경 (프론트만 — 백엔드 무변경)
- **`packages/shared-types`**: `WsAttachedFile` + `WsChatRequest.files` (백엔드 `ws-types.ts` `files[]` 형태와 호환)
- **`apps/web/lib/use-chat-socket`**: `sendChat(message, images?, files?)` — `files` 를 WS payload 에 포함. 본문이 비어도 첨부만으로 전송 가능(표시용 본문은 파일명).
- **`apps/web/components/chat/composer`**: 📎 첨부 버튼 + 숨김 `file input` + 첨부 칩(제거 X / 절단 ✂ 표시). 텍스트 파일을 `FileReader` 로 읽어 캡 적용.

## 캡 (백엔드 `FILE_ATTACH_LIMITS` 기본값과 일치)
| 항목 | 값 |
|---|---|
| 파일 수 | 10 |
| 파일당 글자 | 100,000 (초과 절단 + `truncated`) |
| 총 글자 | 300,000 |

- 바이너리는 미전송(백엔드 계약 — 텍스트만). 이미지(vision base64)는 별도 채널이라 본 복원 범위 밖.

## 검증
- `apps/web` `tsc` 통과 / 신규 lint 에러 0 (기존 eslint-config-next react-hooks 룰 violation만 잔존, root eslint 는 apps/web 무시)
- ⚠️ 라이브 E2E(파일 첨부→응답에 내용 반영)는 실행 스택(backend+next dev+WS)에서 1회 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)