### PR TITLE
fix(mcp): docker 샌드박스 런타임 이미지 동작 수정 (node 유저 + 캐시 권한)

### DIFF
--- a/apps/api/src/mcp/sandbox-docker.ts
+++ b/apps/api/src/mcp/sandbox-docker.ts
@@ -112,13 +112,13 @@ export function buildDockerArgs(input: SandboxInput, cfg: SandboxConfig): string
     a.push('--cap-drop', 'ALL', '--security-opt', 'no-new-privileges');
     a.push('--pids-limit', String(cfg.pidsLimit), '--memory', cfg.memory);
     a.push('--user', cfg.user);
-    a.push('-v', `${cfg.cacheVolume}:/home/mcp/.cache`);
+    a.push('-v', `${cfg.cacheVolume}:/home/node/.cache`);
     // host.docker.internal 매핑 (Linux 호환 — Docker Desktop 은 기본 제공이나 무해)
     a.push('--add-host', 'host.docker.internal:host-gateway');
-    a.push('-w', '/home/mcp');
-    a.push('-e', 'HOME=/home/mcp');
-    a.push('-e', 'NPM_CONFIG_CACHE=/home/mcp/.cache/npm');
-    a.push('-e', 'UV_CACHE_DIR=/home/mcp/.cache/uv');
+    a.push('-w', '/home/node');
+    a.push('-e', 'HOME=/home/node');
+    a.push('-e', 'NPM_CONFIG_CACHE=/home/node/.cache/npm');
+    a.push('-e', 'UV_CACHE_DIR=/home/node/.cache/uv');
     // 서버 config.env 만 컨테이너에 주입 (호스트 env 미상속)
     for (const [k, v] of Object.entries(input.env ?? {})) {
         a.push('-e', `${k}=${rewriteLoopback(String(v))}`);

--- a/infra/mcp-runtime/Dockerfile
+++ b/infra/mcp-runtime/Dockerfile
@@ -8,7 +8,7 @@
 #   docker build -t openmake-mcp-runtime:latest infra/mcp-runtime
 #
 # 캐시 볼륨(npx/uvx 재다운로드 방지)은 sandbox-docker.ts 가 런타임에 자동 마운트:
-#   -v openmake-mcp-cache:/home/mcp/.cache   (named volume, 자동 생성)
+#   -v openmake-mcp-cache:/home/node/.cache   (named volume, 자동 생성)
 FROM node:22-slim
 
 # uv (uvx) + python — uvx 계열 MCP 서버용. uv 는 /usr/local/bin 에 설치(비-root 도 사용 가능).
@@ -18,13 +18,17 @@ RUN apt-get update \
     && apt-get purge -y curl \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# 비-root 실행 사용자 (sandbox-docker 의 --user 1000:1000 과 일치)
-RUN useradd --create-home --uid 1000 mcp
-USER mcp
-WORKDIR /home/mcp
-ENV HOME=/home/mcp \
-    NPM_CONFIG_CACHE=/home/mcp/.cache/npm \
-    UV_CACHE_DIR=/home/mcp/.cache/uv
+# node:22 이미지 기본 제공 'node' 유저(uid 1000) 사용 — sandbox-docker 의 --user 1000:1000 과 일치.
+# (useradd 로 새 uid 1000 생성하면 node 와 충돌해 실패하므로 기존 유저 재사용)
+USER node
+WORKDIR /home/node
+ENV HOME=/home/node \
+    NPM_CONFIG_CACHE=/home/node/.cache/npm \
+    UV_CACHE_DIR=/home/node/.cache/uv
+# .cache 를 node 소유로 미리 생성 — named volume(openmake-mcp-cache)이 빈 채로 처음
+# 마운트될 때 이 디렉토리의 소유권(node:1000)을 상속해 uid 1000 이 캐시를 쓸 수 있게 함.
+# (생성 안 하면 볼륨이 root 소유로 만들어져 npx/uvx 캐시 쓰기가 실패)
+RUN mkdir -p /home/node/.cache/npm /home/node/.cache/uv
 
 # 진입점 없음 — sandbox-docker 가 `docker run ... <image> <command> <args>` 로
 # 실행할 MCP command(npx/uvx/바이너리)를 직접 지정한다.


### PR DESCRIPTION
#157(bwrap→docker 전환)을 **실 환경에서 활성화·검증**하던 중 발견한 런타임 이미지 차단 2건 수정.

## 수정
1. **Dockerfile `useradd uid 1000` 충돌** — `node:22-slim` 이 이미 `node` 유저(uid 1000)를 제공 → `useradd --uid 1000 mcp` 가 exit 4 로 실패. 기존 `node` 유저 재사용으로 변경.
2. **npx/uvx 캐시 쓰기 실패** — named volume(`openmake-mcp-cache`)이 root 소유로 생성돼 `--user 1000` 이 못 씀 → 이미지에 `/home/node/.cache` 를 node 소유로 미리 생성해 빈 볼륨 첫 마운트 시 소유권(1000) 상속.
3. 컨테이너 경로 `/home/mcp` → `/home/node` 통일 (`sandbox-docker.ts`).

## 실 검증 (호스트 docker)
- 이미지 빌드 성공, `sequential-thinking` 서버가 컨테이너에서 **MCP initialize 정상 응답**.
- 운영 재기동 후 **표준 npx/uvx 서버 10개가 컨테이너로 격리·연결** (github 26 tools, firecrawl, filesystem 14, memory 9, playwright 23, duckduckgo 등) — `docker ps` 10개 실행 중.
- **PostgreSQL MCP**: `host.docker.internal` 치환으로 호스트 DB 연결 성공.
- **Python REPL**: `net=none` 격리 적용 확인.

## 알려진 한계 (후속)
`open-design`·`Python REPL`·`noapi-google-search` 는 호스트 설치 바이너리(`/Users`·`/Volumes` 경로)에 의존 → generic 런타임 이미지에서 미동작. per-server sandbox opt-out 또는 전용 이미지 필요. (`mcp-fetch` 는 npm E404 — 기존 잘못된 등록 데이터, docker 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)