### PR TITLE
feat(mcp): per-server 샌드박스 opt-out (sandbox_network='host') + mcp-fetch 정정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -669,7 +669,8 @@ SKILL_CATALOG_DESC_MAX=120
 # 호스트 FS·비밀·네트워크 접근 차단. macOS(Docker Desktop) 포함 docker 있는 모든 호스트에서 동작.
 # 기본 OFF. docker 부재 시 graceful no-op(비격리 실행 + 경고).
 # 선행: 런타임 이미지 빌드 — `docker build -t openmake-mcp-runtime:latest infra/mcp-runtime`
-# 네트워크는 서버별 mcp_servers.sandbox_network('full'=bridge | 'none'=차단)로 제어.
+# 서버별 mcp_servers.sandbox_network: 'full'=bridge | 'none'=네트워크 차단 |
+#   'host'=비격리 호스트 직접 실행(호스트 설치 바이너리 의존 신뢰 서버 opt-out).
 # 컨테이너 내 127.0.0.1/localhost 는 host.docker.internal 로 자동 치환(내부 DB 접속 보정).
 MCP_SANDBOX_ENABLED=false
 # MCP_SANDBOX_DOCKER_PATH=docker                       # docker 바이너리(기본 PATH 탐색 + Desktop 경로)

--- a/apps/api/src/data/models/unified-database.types.ts
+++ b/apps/api/src/data/models/unified-database.types.ts
@@ -243,7 +243,7 @@ export interface MCPServerRow {
     created_at: string;
     updated_at: string;
     /** stdio docker 샌드박스 네트워크 정책 ('full'|'none'). 042 마이그레이션. */
-    sandbox_network?: 'full' | 'none' | null;
+    sandbox_network?: 'full' | 'none' | 'host' | null;
 }
 
 // ============================================

--- a/apps/api/src/data/repositories/mcp-catalog-repository.ts
+++ b/apps/api/src/data/repositories/mcp-catalog-repository.ts
@@ -40,7 +40,7 @@ export interface UserMcpServerRow {
     created_at: string;
     updated_at: string;
     /** stdio docker 샌드박스 네트워크 정책 ('full'|'none'). 042 마이그레이션. */
-    sandbox_network?: 'full' | 'none' | null;
+    sandbox_network?: 'full' | 'none' | 'host' | null;
 }
 
 export class McpCatalogRepository {

--- a/apps/api/src/mcp/lifecycle-supervisor.ts
+++ b/apps/api/src/mcp/lifecycle-supervisor.ts
@@ -33,7 +33,7 @@ export interface ServerSpawnConfig {
     url?: string | null;
     lifecycle?: McpLifecycle;
     catalog_template_id?: string;
-    sandbox_network?: 'full' | 'none';
+    sandbox_network?: 'full' | 'none' | 'host';
 }
 
 export type ClientFactory = (config: ServerSpawnConfig) => ExternalMCPClient;
@@ -173,7 +173,7 @@ export class MCPLifecycleSupervisor implements LifecycleSupervisor {
             url: server.url,
             lifecycle,
             catalog_template_id: server.catalog_template_id ?? undefined,
-            sandbox_network: (server as ServerWithLifecycle).sandbox_network === 'none' ? 'none' : 'full',
+            sandbox_network: (() => { const n = (server as ServerWithLifecycle).sandbox_network; return n === 'none' || n === 'host' ? n : 'full'; })(),
         };
 
         await this.repo.recordInstanceTransition(serverId, userId, 'starting').catch(() => { /* noop */ });

--- a/apps/api/src/mcp/sandbox-docker.ts
+++ b/apps/api/src/mcp/sandbox-docker.ts
@@ -28,7 +28,8 @@ import { createLogger } from '../utils/logger';
 
 const logger = createLogger('McpSandbox');
 
-export type SandboxNetwork = 'full' | 'none';
+/** 'full'=bridge, 'none'=--network none, 'host'=컨테이너 없이 호스트 직접 실행(opt-out) */
+export type SandboxNetwork = 'full' | 'none' | 'host';
 
 export interface SandboxInput {
     command: string;
@@ -140,6 +141,9 @@ function warnOnce(key: string, msg: string): void {
  * sandboxed=true 이면 env 는 args(-e)에 baked 되므로 호출자는 StdioClientTransport env 를 비워야 한다.
  */
 export function buildSandboxedCommand(input: SandboxInput, cfg: SandboxConfig = defaultSandboxConfig()): SandboxResult {
+    // per-server opt-out — 호스트 설치 바이너리 의존 등으로 컨테이너 미동작인 신뢰 서버는
+    // sandbox_network='host' 로 비격리 호스트 실행 (플래그 ON 여부와 무관).
+    if (input.network === 'host') return { command: input.command, args: input.args, sandboxed: false };
     if (!cfg.enabled) return { command: input.command, args: input.args, sandboxed: false };
     if (!cfg.dockerPath) {
         warnOnce('docker', 'docker 바이너리를 찾지 못해 MCP 샌드박스 미적용(비격리 실행). Docker 설치/실행 확인 필요.');

--- a/apps/api/src/mcp/server-registry.ts
+++ b/apps/api/src/mcp/server-registry.ts
@@ -48,7 +48,7 @@ function rowToConfig(row: MCPServerRow): MCPServerConfig {
         enabled: row.enabled,
         created_at: row.created_at,
         updated_at: row.updated_at,
-        sandbox_network: row.sandbox_network === 'none' ? 'none' : 'full',
+        sandbox_network: row.sandbox_network === 'none' || row.sandbox_network === 'host' ? row.sandbox_network : 'full',
     };
 }
 

--- a/apps/api/src/mcp/types.ts
+++ b/apps/api/src/mcp/types.ts
@@ -260,8 +260,8 @@ export interface MCPServerConfig {
     updated_at: string;
     /** 카탈로그 템플릿 ID (mcp_server_catalog.id 참조) */
     catalog_template_id?: string;
-    /** stdio docker 샌드박스 네트워크 정책 ('full'=bridge | 'none'=--network none). DB sandbox_network 컬럼. */
-    sandbox_network?: 'full' | 'none';
+    /** stdio docker 샌드박스 정책 ('full'=bridge | 'none'=--network none | 'host'=비격리 호스트 실행). DB sandbox_network 컬럼. */
+    sandbox_network?: 'full' | 'none' | 'host';
 }
 
 /**

--- a/db/migrations/044_mcp_sandbox_host_optout.sql
+++ b/db/migrations/044_mcp_sandbox_host_optout.sql
@@ -1,0 +1,18 @@
+-- 044_mcp_sandbox_host_optout.sql
+-- 외부 MCP 서버 per-server 샌드박스 opt-out 값 'host' 추가.
+--   sandbox_network: 'full'(bridge) | 'none'(--network none) | 'host'(컨테이너 없이 호스트 직접 실행).
+-- 'host' = 호스트 설치 바이너리(/Users·/Volumes 경로 등)에 의존해 generic 런타임 이미지에서
+--   동작 불가한 신뢰 로컬 서버(open-design·Python REPL·noapi-google-search 등)를 비격리 실행.
+-- 042 의 CHECK 제약을 'host' 포함으로 교체. 멱등 + graceful owner.
+
+DO $$
+BEGIN
+    ALTER TABLE mcp_servers DROP CONSTRAINT IF EXISTS mcp_servers_sandbox_network_chk;
+    ALTER TABLE mcp_servers
+        ADD CONSTRAINT mcp_servers_sandbox_network_chk CHECK (sandbox_network IN ('full', 'none', 'host'));
+EXCEPTION
+    WHEN insufficient_privilege THEN
+        RAISE NOTICE 'mcp_servers CHECK 교체 권한 없음 — owner 로 수동 적용 필요 (graceful skip)';
+    WHEN undefined_table THEN
+        RAISE NOTICE 'mcp_servers 테이블 부재 (graceful skip)';
+END $$;


### PR DESCRIPTION
docker MCP 샌드박스 활성화 후속 — 호스트 경로 의존 서버 opt-out + 잘못된 등록 정리.

## A. per-server opt-out (`sandbox_network='host'`)
호스트 설치 바이너리(`/Users`·`/Volumes` 경로)에 의존해 generic 런타임 이미지에서 동작 불가한 **신뢰 로컬 서버**를 비격리 호스트 실행.
- `sandbox_network`: `full`(bridge) | `none`(--network none) | **`host`**(컨테이너 없이 호스트 직접 실행)
- `buildSandboxedCommand`: `network==='host'` → no-op (플래그 ON 무관)
- 마이그레이션 **044**: CHECK 를 `('full','none','host')` 로 교체 (멱등+graceful owner)
- 타입 union 5곳 + `rowToConfig`/lifecycle 패스스루

## B. mcp-fetch 정정
잘못된 `npx @modelcontextprotocol/server-fetch`(npm **E404**, 호스트에서도 미동작) → 올바른 `uvx mcp-server-fetch`(Python) 로 정정 → 컨테이너에서 정상 동작.

## 운영 적용 (DB)
- `open-design`·`Python REPL`·`noapi-google-search` → `sandbox_network='host'`
- `mcp-fetch` command/args 정정

## 검증 (실 운영 재기동)
- **14개 서버 연결**: 11개 docker 컨테이너 격리 + 3개 host 비격리
- 3개 host 서버는 "docker 격리 적용" 로그에 없음(호스트 실행 확인), mcp-fetch 컨테이너 격리 연결
- `tsc` 0 / `eslint` 0 / docker 유닛 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)