### PR TITLE
feat(mcp): Python REPL 컨테이너 격리 (런타임 이미지 베이크, net=none)

### DIFF
--- a/infra/mcp-runtime/Dockerfile
+++ b/infra/mcp-runtime/Dockerfile
@@ -30,5 +30,12 @@ ENV HOME=/home/node \
 # (생성 안 하면 볼륨이 root 소유로 만들어져 npx/uvx 캐시 쓰기가 실패)
 RUN mkdir -p /home/node/.cache/npm /home/node/.cache/uv
 
+# net=none(네트워크 차단) 격리 대상 서버 사전설치 — Python REPL(arbitrary code 실행)을
+# 컨테이너로 격리하면 런타임 uvx 다운로드가 불가하므로 이미지에 미리 설치한다.
+# uv tool install 은 /home/node/.local 에 self-contained venv 로 설치 →
+# 런타임에 볼륨 마운트되는 /home/node/.cache 와 분리되어 net=none(오프라인)에도 동작.
+RUN uv tool install mcp-python-repl
+ENV PATH=/home/node/.local/bin:${PATH}
+
 # 진입점 없음 — sandbox-docker 가 `docker run ... <image> <command> <args>` 로
-# 실행할 MCP command(npx/uvx/바이너리)를 직접 지정한다.
+# 실행할 MCP command(npx/uvx/바이너리/사전설치 바이너리)를 직접 지정한다.


### PR DESCRIPTION
docker MCP 샌드박스 후속 — **arbitrary code 실행 Python REPL을 host 비격리 → 컨테이너(net=none) 격리** 로 전환.

## 배경
Python REPL은 호스트 venv 바이너리(`/Volumes/.../mcp-venv/bin/mcp-python-repl`) 의존 → generic 이미지에서 미동작 → #159에서 `sandbox_network='host'`(비격리)로 뒀음. 하지만 arbitrary code 실행이라 격리가 중요 → 패키지를 이미지에 베이크해 컨테이너 격리.

## 변경
- **Dockerfile**: `uv tool install mcp-python-repl` (PyPI 0.1.1) → `/home/node/.local` self-contained venv + PATH. 런타임 볼륨(`/home/node/.cache`)과 분리돼 **net=none(완전 오프라인)에도 동작**.
- **DB(운영)**: Python REPL `command` 를 호스트 절대경로 → `mcp-python-repl`(컨테이너 PATH), `sandbox_network` host→none. `REPL_*` env 유지.

## 검증 (실 docker)
- net=none 오프라인 컨테이너에서 MCP initialize 정상 응답 (serverInfo: python_repl_mcp)
- 운영 재기동 후 Python REPL이 **`--network none` 컨테이너로 격리·연결** (컨테이너 net 분포: 11 bridge + **1 none**)
- → arbitrary-code 서버가 **OS격리(컨테이너) + 네트워크차단(none)** 으로 보호

## 최종 운영 상태
14 서버 연결 = **12 docker 컨테이너 격리** (11 full/bridge + 1 none=Python REPL) + 2 host(open-design·noapi-google-search, PyPI 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)