### PR TITLE
feat(security): MCP 보안 하드닝 — 접근통제·audit·컨테이너 강화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -678,7 +678,16 @@ MCP_SANDBOX_ENABLED=false
 # MCP_SANDBOX_CACHE_VOLUME=openmake-mcp-cache          # npx/uvx 캐시 named volume
 # MCP_SANDBOX_MEMORY=512m                              # 컨테이너 메모리 상한
 # MCP_SANDBOX_PIDS_LIMIT=256                           # 컨테이너 PID 상한
+# MCP_SANDBOX_CPUS=1.0                                 # 컨테이너 CPU 상한(CPU DoS 방어)
 # MCP_SANDBOX_USER=1000:1000                           # 컨테이너 실행 uid:gid (이미지 mcp 유저)
+# MCP_SANDBOX_READONLY=false                           # read-only rootfs + tmpfs(opt-in, 일부 서버 호환성 주의)
+# 캐시 볼륨은 서버별로 분리됨(openmake-mcp-cache-<serverId>) — 컨테이너 간 캐시 오염 차단.
+# add-host(host.docker.internal)는 127.0.0.1/localhost 참조 서버에만 부여(내부 서비스 over-grant 차단).
+#
+# 🔒 고위험 MCP 도구 접근통제 — "서버명:최소역할" 콤마목록. 역할 미달 사용자에겐 해당 서버
+#   도구를 노출하지 않음. 기본: Python REPL(임의코드)=admin, Playwright=user.
+#   (외부 공개 + open registration 환경에서 게스트의 arbitrary code 도달 차단)
+# MCP_RESTRICTED_SERVERS=Python REPL:admin,Playwright Browser:user
 # fs_read_file 완전성 고지(P-6) — 이 바이트 초과 시 앞부분만 반환하고 잘림을 고지.
 FS_READ_MAX_BYTES=100000
 # WebSocket 메시지 최대 페이로드(bytes). **미설정/0 = 무제한**(파일·이미지 업로드 용량 제한 없음).

--- a/apps/api/src/mcp/sandbox-docker.ts
+++ b/apps/api/src/mcp/sandbox-docker.ts
@@ -53,10 +53,15 @@ export interface SandboxConfig {
     /** resolve 된 docker 절대경로 또는 null(미발견) */
     dockerPath: string | null;
     image: string;
+    /** per-server 캐시 볼륨 prefix — 실제 볼륨은 `${cacheVolume}-${serverId}` (상호 오염 차단) */
     cacheVolume: string;
     memory: string;
     pidsLimit: number;
+    /** CPU 상한 (CPU DoS 방어) */
+    cpus: string;
     user: string;
+    /** read-only rootfs + tmpfs (opt-in — 일부 서버가 home 외 쓰기 시 깨질 수 있어 기본 off) */
+    readonly: boolean;
 }
 
 let dockerCache: { key: string; value: string | null } | null = null;
@@ -95,12 +100,21 @@ export function defaultSandboxConfig(): SandboxConfig {
         cacheVolume: process.env.MCP_SANDBOX_CACHE_VOLUME || 'openmake-mcp-cache',
         memory: process.env.MCP_SANDBOX_MEMORY || '512m',
         pidsLimit: Number(process.env.MCP_SANDBOX_PIDS_LIMIT) || 256,
+        cpus: process.env.MCP_SANDBOX_CPUS || '1.0',
         user: process.env.MCP_SANDBOX_USER || '1000:1000',
+        readonly: process.env.MCP_SANDBOX_READONLY === 'true',
     };
+}
+
+/** docker 볼륨/식별자 안전화. */
+function sanitizeId(id: string): string {
+    return id.replace(/[^A-Za-z0-9._-]/g, '_') || 'unknown';
 }
 
 /** 컨테이너 내 127.0.0.1/localhost → host.docker.internal (내부 서비스 접속 보정). */
 const LOOPBACK_RE = /\b(?:127\.0\.0\.1|localhost)\b/g;
+/** loopback 참조 여부 검사용 (non-global — .test() 상태 누적 방지). */
+const LOOPBACK_TEST = /(?:127\.0\.0\.1|localhost)/;
 export function rewriteLoopback(s: string): string {
     return s.replace(LOOPBACK_RE, 'host.docker.internal');
 }
@@ -108,14 +122,21 @@ export function rewriteLoopback(s: string): string {
 /** PURE: docker run 인자 조립 (유닛테스트 대상). */
 export function buildDockerArgs(input: SandboxInput, cfg: SandboxConfig): string[] {
     const net = (input.network ?? 'full') === 'none' ? 'none' : 'bridge';
+    // per-server 캐시 볼륨 — 컨테이너 간 캐시(공급망) 상호 오염 차단.
+    const cacheVol = `${cfg.cacheVolume}-${sanitizeId(input.serverId)}`;
+    // 내부 서비스(127.0.0.1/localhost) 를 참조하는 서버에만 host.docker.internal 부여 —
+    // 그 외 서버가 호스트 내부 서비스에 도달하는 over-grant 차단.
+    const referencesLoopback = LOOPBACK_TEST.test(
+        [input.command, ...input.args.map(String), ...Object.values(input.env ?? {}).map(String)].join(' '),
+    );
     const a: string[] = ['run', '--rm', '-i', '--init'];
     a.push('--network', net);
     a.push('--cap-drop', 'ALL', '--security-opt', 'no-new-privileges');
-    a.push('--pids-limit', String(cfg.pidsLimit), '--memory', cfg.memory);
+    a.push('--pids-limit', String(cfg.pidsLimit), '--memory', cfg.memory, '--cpus', cfg.cpus);
     a.push('--user', cfg.user);
-    a.push('-v', `${cfg.cacheVolume}:/home/node/.cache`);
-    // host.docker.internal 매핑 (Linux 호환 — Docker Desktop 은 기본 제공이나 무해)
-    a.push('--add-host', 'host.docker.internal:host-gateway');
+    if (cfg.readonly) a.push('--read-only', '--tmpfs', '/tmp:rw,exec', '--tmpfs', '/run:rw');
+    a.push('-v', `${cacheVol}:/home/node/.cache`);
+    if (referencesLoopback) a.push('--add-host', 'host.docker.internal:host-gateway');
     a.push('-w', '/home/node');
     a.push('-e', 'HOME=/home/node');
     a.push('-e', 'NPM_CONFIG_CACHE=/home/node/.cache/npm');

--- a/apps/api/src/mcp/unified-client.ts
+++ b/apps/api/src/mcp/unified-client.ts
@@ -204,7 +204,37 @@ export class UnifiedMCPClient {
         // toolRouter 직접 호출 — JSON-RPC 래퍼(executeTool)는 context 채널이 없어
         // 사용자 스코프 내장 도구(agent_task_* 등)와 user-pool 외부 도구에 userId 가
         // 전달되지 않는다. 에이전트 루프(runTool)와 동일한 canonical 경로.
-        return this.toolRouter.executeTool(toolName, sandboxedArgs, context);
+        const startedAt = Date.now();
+        const result = await this.toolRouter.executeTool(toolName, sandboxedArgs, context);
+        // tool call 감사 영속화 (fire-and-forget·비차단). 공개 운영 포렌식용.
+        void this.auditToolCall(toolName, context, result, Date.now() - startedAt);
+        return result;
+    }
+
+    /** MCP tool call 을 audit_logs 에 영속화. action='mcp_tool_call' 은 CRITICAL_ACTIONS 미포함 → 알림 없음. */
+    private async auditToolCall(
+        toolName: string, context: UserContext, result: MCPToolResult, durationMs: number,
+    ): Promise<void> {
+        try {
+            const { getAuditService } = await import('../services/AuditService');
+            const isExternal = toolName.includes('::');
+            const rawUid = context.userId !== undefined && context.userId !== null ? String(context.userId) : undefined;
+            // audit_logs.user_id 는 users FK — 게스트('guest')는 user_id=null 로 넣고 details 에 표시(FK 위반 방지).
+            const isRealUser = rawUid !== undefined && rawUid !== 'guest';
+            await getAuditService().logAudit({
+                action: 'mcp_tool_call',
+                userId: isRealUser ? rawUid : undefined,
+                resourceType: isExternal ? 'mcp_external_tool' : 'mcp_builtin_tool',
+                resourceId: toolName,
+                details: {
+                    isError: result?.isError === true,
+                    durationMs,
+                    server: isExternal ? toolName.split('::')[0] : 'builtin',
+                    role: context.role,
+                    actorId: rawUid ?? 'guest',
+                },
+            });
+        } catch (e) { logger.debug(`audit 기록 실패(무시): ${e instanceof Error ? e.message : String(e)}`); }
     }
 
     // ============================================

--- a/apps/api/src/services/ChatService.ts
+++ b/apps/api/src/services/ChatService.ts
@@ -66,6 +66,45 @@ export type {
 
 const logger = createLogger('ChatService');
 
+/** 역할 레벨 (게스트<일반<관리자). */
+function roleLevel(role?: string): number {
+    return role === 'admin' ? 2 : role === 'user' ? 1 : 0;
+}
+
+/**
+ * 고위험 MCP 서버별 최소 역할 파싱 — env `MCP_RESTRICTED_SERVERS` ("서버명:역할,..").
+ * 기본: Python REPL(임의코드)=admin, Playwright Browser=user. (open registration 이라
+ * authenticated 는 약해 arbitrary code 는 admin 기본.)
+ */
+function parseRestrictedServers(): Map<string, number> {
+    const raw = process.env.MCP_RESTRICTED_SERVERS ?? 'Python REPL:admin,Playwright Browser:user';
+    const m = new Map<string, number>();
+    for (const part of raw.split(',')) {
+        const idx = part.lastIndexOf(':');
+        if (idx <= 0) continue;
+        const name = part.slice(0, idx).trim();
+        const role = part.slice(idx + 1).trim();
+        if (name) m.set(name, roleLevel(role));
+    }
+    return m;
+}
+
+/**
+ * 고위험 서버 도구(네임스페이스 "서버명::도구")를 역할 미달 사용자에게서 제거.
+ * 외부 공개 인스턴스에서 게스트·저권한 사용자의 위험도구 과노출 차단.
+ */
+function filterRestrictedTools(tools: ToolDefinition[], role?: string): ToolDefinition[] {
+    const restricted = parseRestrictedServers();
+    if (restricted.size === 0) return tools;
+    const userLevel = roleLevel(role);
+    return tools.filter((t) => {
+        for (const [serverName, minLevel] of restricted) {
+            if (t.function.name.startsWith(`${serverName}::`) && userLevel < minLevel) return false;
+        }
+        return true;
+    });
+}
+
 /**
  * 중앙 채팅 오케스트레이션 서비스
  *
@@ -159,9 +198,13 @@ export class ChatService {
         const toolRouter = getUnifiedMCPClient().getToolRouter();
         const rawUserId = reqCtx.userContext.userId;
         const userIdStr = rawUserId !== undefined && rawUserId !== null ? String(rawUserId) : undefined;
-        const allTools = userIdStr
+        const rawTools = userIdStr
             ? await toolRouter.getLLMTools({ userId: userIdStr }) as ToolDefinition[]
             : await toolRouter.getLLMTools() as ToolDefinition[];
+
+        // 🔒 고위험 도구 접근통제 — Python REPL(임의코드)·Playwright 등 위험 서버의 도구는
+        //   역할 미달(게스트 등) 사용자에게 노출하지 않는다(공개 인스턴스 과노출 차단).
+        const allTools = filterRestrictedTools(rawTools, reqCtx.userContext.role);
 
         // enabledTools가 없으면 레거시 호환: 전체 허용 (API 클라이언트 등). skill binding 적용도 skip.
         if (reqCtx.enabledTools === undefined) return this.applySkillCatalog(allTools, allTools, reqCtx);


### PR DESCRIPTION
MCP 보안 검토에서 식별된 보완점을 일괄 처리(중간 발견 문제 반영).

## P0 — 고위험 도구 접근통제
외부 공개(Tailscale Funnel)+open registration+게스트 환경에서 **Python REPL(임의코드)·Playwright가 global 노출**(익명 도달 가능)이던 것을 차단.
- `ChatService.getAllowedTools`에 **서버별 min-role 게이트** — env `MCP_RESTRICTED_SERVERS`("서버명:역할,..", 기본 `Python REPL:admin,Playwright Browser:user`). 역할 미달 사용자에겐 도구 미노출.
- **검증**: 게스트가 Python REPL을 `enabledTools`로 명시 활성화 + 코드실행 요청해도 **repl_run_code 0회 실행**.

## audit 영속화
- 모든 MCP tool call → `audit_logs(action='mcp_tool_call')` fire-and-forget 기록 (공개 운영 포렌식).
- ⚠️ **발견·수정**: `audit_logs.user_id`가 users FK → 게스트 `'guest'`가 FK 위반(23503)으로 INSERT 실패하던 것을, 게스트는 `user_id=null` + `details.actorId='guest'`로 기록.

## 컨테이너 하드닝 (sandbox-docker)
- `--cpus`(CPU DoS 방어), read-only rootfs **opt-in**(`MCP_SANDBOX_READONLY`)
- **per-server 캐시 볼륨**(`openmake-mcp-cache-<serverId>`) — 컨테이너 간 캐시(공급망) 상호 오염 차단
- `--add-host`(host.docker.internal)를 **127.0.0.1/localhost 참조 서버에만** 부여(내부 서비스 over-grant 차단)

## 검증 (실 운영 재기동)
- cpus 적용(NanoCpus=1e9), per-server 캐시 볼륨 생성, add-host는 loopback 참조 1개 컨테이너만
- audit 기록 확인(`load_skill | user_id=null | actorId=guest`)
- P0 게이트 게스트 차단 확인
- `tsc` 0 / `eslint` 0 / mcp 59 통과

## 미적용 (의도적)
- npx/uvx **버전 핀**: 14서버 blind 변경은 breakage 위험 → 운영 catalog 작업으로 위임(캐시 격리로 상호오염은 차단)
- **gateway/executor 분리·microVM**: Linux 호스트 이전 또는 사용자 코드업로드 기능 도입 시 과제(현 규모 과투자)

🤖 Generated with [Claude Code](https://claude.com/claude-code)