### PR TITLE
fix(api-client): single-flight refresh 로 동시 401 토큰 회전 레이스 차단

### DIFF
--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -40,6 +40,26 @@ const MUTATING = new Set<string>(MUTATING_METHODS);
 /** 401 자동 refresh 를 건너뛸 endpoint 목록 (무한루프 방지). */
 const SKIP_REFRESH_ENDPOINTS = ["/api/auth/refresh", "/api/auth/login", "/api/auth/me"];
 
+/**
+ * Single-flight refresh: 동시에 401 이 난 여러 요청이 각자 /api/auth/refresh 를 호출하면
+ * 서버 토큰 로테이션이 경합(첫 호출이 회전·기존 토큰 블랙리스트 → 나머지는 블랙리스트된
+ * 토큰으로 401 → clearTokenCookie 로 세션 쿠키 wipe)해 세션이 죽는다.
+ * 진행 중인 refresh 가 있으면 그 Promise 를 공유해 /refresh 가 단 1회만 나가도록 한다.
+ */
+let refreshInFlight: Promise<boolean> | null = null;
+
+function refreshOnce(): Promise<boolean> {
+  if (!refreshInFlight) {
+    refreshInFlight = fetch("/api/auth/refresh", { method: "POST", credentials: "include" })
+      .then((r) => r.ok)
+      .catch(() => false)
+      .finally(() => {
+        refreshInFlight = null;
+      });
+  }
+  return refreshInFlight;
+}
+
 async function request<T>(endpoint: string, options: RequestInit = {}, _isRetry = false): Promise<T> {
   const method = (options.method || "GET").toUpperCase();
   const headers: Record<string, string> = {
@@ -61,11 +81,9 @@ async function request<T>(endpoint: string, options: RequestInit = {}, _isRetry 
       !_isRetry &&
       !SKIP_REFRESH_ENDPOINTS.some((ep) => endpoint === ep || endpoint.startsWith(ep + "?"))
     ) {
-      try {
-        await fetch("/api/auth/refresh", { method: "POST", credentials: "include" });
+      const refreshed = await refreshOnce();
+      if (refreshed) {
         return request<T>(endpoint, options, true);
-      } catch {
-        /* refresh 실패 → 아래 리다이렉트로 진행 */
       }
       if (typeof window !== "undefined" && window.location.pathname !== "/login") {
         window.location.href = "/login";


### PR DESCRIPTION
## 문제

admin/analytics 페이지가 "안 열림" 신고 → 진단 결과 **세션이 죽어** admin API가 전부 401로 막혀 빈 화면.

운영 로그:
\`\`\`
POST /refresh 401 ×3 (동시)
[Auth] 블랙리스트된 리프레시 토큰 사용 시도
GET /analytics/behavior 401, /analytics/agents 401, /analytics/cost 401 ...
\`\`\`

### 근본 원인 — 동시 refresh 레이스
1. analytics 페이지는 admin API ~7개를 **병렬** 호출
2. 액세스 토큰(15분) 만료 시 → 7개 동시 401 → 클라이언트가 **각자 독립적으로** \`/api/auth/refresh\` 호출
3. 서버는 refresh 시 토큰 회전하며 기존 토큰 블랙리스트 → 첫 호출만 성공, 나머지는 블랙리스트된 토큰으로 401
4. 그 401 응답들이 \`auth.controller.ts:281\` \`clearTokenCookie(res)\`로 **세션 쿠키 삭제** → Set-Cookie 도착순 경합 → 쿠키 비결정적 wipe → 완전 로그아웃

## 수정
\`packages/api-client/src/index.ts\` 에 **single-flight refresh** 적용 — 동시 401이 단 하나의 \`/refresh\`만 공유. 레이스 자체 제거. 서버 미변경.

- \`refreshOnce()\`: 진행 중 refresh Promise 공유
- refresh 응답 \`r.ok\` 실제 검사 → 진짜 실패 시에만 \`/login\` 리다이렉트 (기존엔 401이어도 무조건 재시도하던 버그)

## 검증
- eslint 통과
- 배포 후 재로그인 1회 필요 (이미 블랙리스트된 세션은 소생 불가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)