### PR TITLE
fix(admin/analytics): cost 필드명 정합(modelCosts→costByModel) 렌더 크래시 수정

### DIFF
--- a/apps/web/app/(workspace)/admin/analytics/page.tsx
+++ b/apps/web/app/(workspace)/admin/analytics/page.tsx
@@ -92,7 +92,7 @@ interface CostData {
   dailyCost: number;
   weeklyCost: number;
   projectedMonthlyCost: number;
-  modelCosts: { model: string; cost: number; percentage: number }[];
+  costByModel: { model: string; cost: number; percentage: number }[];
 }
 interface BehaviorData {
   peakHours: { hour: number; requests: number }[];
@@ -333,7 +333,7 @@ export default function AdminAnalyticsPage() {
                 <StatCard label="주간 비용" value={fmtCost(costData.weeklyCost)} />
                 <StatCard label="월간 예상 비용" value={fmtCost(costData.projectedMonthlyCost)} />
               </div>
-              {costData.modelCosts.length > 0 && (
+              {costData.costByModel.length > 0 && (
                 <Table>
                   <thead>
                     <tr>
@@ -343,7 +343,7 @@ export default function AdminAnalyticsPage() {
                     </tr>
                   </thead>
                   <tbody>
-                    {costData.modelCosts.map((m) => (
+                    {costData.costByModel.map((m) => (
                       <tr key={m.model}>
                         <Td className="font-medium text-fg">{m.model}</Td>
                         <Td className="text-right font-mono text-fg-2">{fmtCost(m.cost)}</Td>


### PR DESCRIPTION
## 증상
관리자로 로그인 후 \`/admin/analytics\` 가 **"This page couldn't load"** 로 안 열림. 게스트는 정상.

## 근본 원인 (Playwright 인증 세션 실측으로 확정)
유효 admin 쿠키를 주입해 로드하니 **모든 API가 200**인데 페이지가 **클라이언트 렌더 크래시**:
\`\`\`
TypeError: Cannot read properties of undefined (reading 'length')
\`\`\`
- 페이지는 \`costData.modelCosts.length\` 를 읽지만, 백엔드 \`/api/metrics/analytics/cost\` 는 **\`costByModel\`** 로 응답 → \`modelCosts\` 가 undefined → \`.length\` 에서 크래시
- **게스트는** cost 가 401→catch 로 빈 데이터라 크래시 없이 빈 화면(=정상으로 보임), **관리자는** 200 실데이터를 렌더하다 크래시 → "게스트 정상/관리자 비정상" 과 정확히 일치

## 수정
페이지의 \`CostData.modelCosts\` → \`costByModel\` (3곳). 백엔드 \`AnalyticsSystem\` 응답 필드와 동일, 항목 모양 \`{model,cost,percentage}\` 동일.

## 검증
유효 admin 쿠키 주입 Playwright:
- 수정 전: "This page couldn't load", PAGE_ERROR(undefined.length)
- 수정 후: 페이지 정상 렌더(TITLE/본문 표시), 모든 API 200, **PAGE_ERROR 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)