### PR TITLE
fix(web/sidebar): 로고→홈, 게스트 계정→로그인 네비게이션

### DIFF
--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -52,7 +52,7 @@ export function Sidebar() {
 
   return (
     <aside className="flex h-full w-[264px] flex-col border-r border-border bg-surface-2/60">
-      <div className="flex items-center gap-2 px-4 pt-4">
+      <Link href="/" className="flex items-center gap-2 px-4 pt-4 transition hover:opacity-80">
         <Image
           src="/logo.png"
           alt="OpenMake"
@@ -61,7 +61,7 @@ export function Sidebar() {
           className="h-7 w-7 rounded-md object-contain"
         />
         <span className="text-sm font-semibold text-fg">OpenMake</span>
-      </div>
+      </Link>
 
       <div className="px-3 pt-3">
         <Link
@@ -129,17 +129,30 @@ export function Sidebar() {
       </nav>
 
       <div className="flex items-center gap-2.5 border-t border-border px-3 py-3">
-        <div className="grid h-8 w-8 place-items-center rounded-full bg-m-pro/15 text-xs font-bold text-m-pro">
-          {user?.name?.[0] ?? "G"}
-        </div>
-        <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-medium text-fg">
-            {user?.name ?? "게스트"}
-          </p>
-          <p className="truncate text-xs text-faint">
-            {user ? `${user.role} · 자가호스팅` : "로그인 안 됨"}
-          </p>
-        </div>
+        {user ? (
+          <div className="flex min-w-0 flex-1 items-center gap-2.5">
+            <div className="grid h-8 w-8 place-items-center rounded-full bg-m-pro/15 text-xs font-bold text-m-pro">
+              {user.name?.[0] ?? "G"}
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium text-fg">{user.name ?? "게스트"}</p>
+              <p className="truncate text-xs text-faint">{user.role} · 자가호스팅</p>
+            </div>
+          </div>
+        ) : (
+          <Link
+            href="/login"
+            className="flex min-w-0 flex-1 items-center gap-2.5 rounded-md transition hover:opacity-80"
+          >
+            <div className="grid h-8 w-8 place-items-center rounded-full bg-m-pro/15 text-xs font-bold text-m-pro">
+              G
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium text-fg">게스트</p>
+              <p className="truncate text-xs text-faint">로그인 안 됨</p>
+            </div>
+          </Link>
+        )}
         <ThemeToggle />
         {user && (
           <button


### PR DESCRIPTION
## 문제
사이드바 로고(아이콘+OpenMake)가 클릭 불가한 \`<div>\` 라 클릭해도 홈 이동이 안 되고, 미로그인 시 계정 영역(게스트)에 로그인 진입점이 없어 사용자가 **주소창에 URL 을 수동 입력**해야 로그인 페이지로 갈 수 있었음.

## 수정 (\`apps/web/components/sidebar.tsx\`)
- 로고 \`<div>\` → \`<Link href="/">\` (홈)
- 미로그인 시 계정 영역 → \`<Link href="/login">\` (로그인)
- 로그인 상태에선 기존처럼 계정 정보만 표시(링크 없음)

## 검증 (Playwright, 공개 Funnel URL)
- 로고 \`href="/"\`, 게스트 영역 \`href="/login"\`
- 게스트 영역 클릭 → \`/login\` 이동 확인
- \`next build\` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)