### PR TITLE
feat(web/mobile): 미로그인 시 하단 탭바에 로그인 진입점 추가

### DIFF
--- a/apps/web/components/mobile-sidebar.tsx
+++ b/apps/web/components/mobile-sidebar.tsx
@@ -3,8 +3,9 @@
 import { useState, useEffect } from "react";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
-import { MessageSquare, Telescope, Sparkles, Menu, X } from "lucide-react";
+import { MessageSquare, Telescope, Sparkles, Menu, X, LogIn } from "lucide-react";
 import { Sidebar } from "./sidebar";
+import { useAppStore } from "@/lib/store";
 import { cn } from "@/lib/utils";
 
 /** OD lumen 모바일 시안: 하단 탭바(44px+ 터치 타깃) + "메뉴" 탭으로 전체 드로어. 데스크탑(lg)은 고정 사이드바. */
@@ -17,6 +18,7 @@ const TABS = [
 export function MobileSidebar() {
   const [open, setOpen] = useState(false);
   const pathname = usePathname();
+  const user = useAppStore((s) => s.auth.currentUser);
 
   // 라우트 이동 시 드로어 자동 닫기
   useEffect(() => setOpen(false), [pathname]);
@@ -61,6 +63,15 @@ export function MobileSidebar() {
             {t.label}
           </Link>
         ))}
+        {!user && (
+          <Link
+            href="/login"
+            className="flex min-h-[52px] flex-1 flex-col items-center justify-center gap-0.5 text-[11px] font-medium text-muted transition hover:text-fg"
+          >
+            <LogIn className="h-5 w-5" />
+            로그인
+          </Link>
+        )}
         <button
           onClick={() => setOpen(true)}
           aria-label="전체 메뉴"


### PR DESCRIPTION
## 배경
직전 PR #164 로 데스크톱 사이드바에 로고→홈/게스트→로그인 진입점을 추가했으나, 모바일은 하단 탭바(채팅·리서치·에이전트·메뉴)에 계정/로그인 UI 가 없어 게스트가 로그인 페이지로 직접 갈 수 없었음.

## 수정 (\`apps/web/components/mobile-sidebar.tsx\`)
- \`useAppStore\` 의 \`auth.currentUser\` 로 인증 상태 구독
- **미로그인 시에만** 하단 탭바에 "로그인" 탭(\`LogIn\` → \`/login\`) 추가
- 로그인 상태에선 미노출

## 검증 (Playwright, 모바일 390px 뷰포트, 공개 Funnel URL)
- 게스트: 하단 탭바 = 채팅·리서치·에이전트·**로그인**·메뉴
- 로그인 탭 클릭 → \`/login\` 이동 확인
- \`next build\` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)