### PR TITLE
feat(web/artifact): 아티팩트 가시화 + 샌드박스 iframe 라이브 렌더 (Phase 1)

### DIFF
--- a/apps/web/app/(workspace)/page.tsx
+++ b/apps/web/app/(workspace)/page.tsx
@@ -1,26 +1,35 @@
 import { MessageList } from "@/components/chat/message-list";
 import { ActiveContext } from "@/components/chat/active-context";
 import { Composer } from "@/components/chat/composer";
+import { ArtifactPanel } from "@/components/chat/artifact-panel";
+import { ArtifactToggle } from "@/components/chat/artifact-toggle";
 
 export default function ChatPage() {
   return (
-    <>
-      <header className="flex h-14 items-center justify-between border-b border-border px-5">
-        <div className="min-w-0">
-          <h1 className="truncate text-sm font-semibold text-fg">새 대화</h1>
-          <p className="truncate text-xs text-faint">워크스페이스 · 채팅</p>
-        </div>
-        <span className="shrink-0 rounded-md bg-surface-2 px-2 py-1 font-mono text-xs text-muted">
-          Lumen
-        </span>
-      </header>
+    <div className="flex min-h-0 flex-1">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="flex h-14 items-center justify-between border-b border-border px-5">
+          <div className="min-w-0">
+            <h1 className="truncate text-sm font-semibold text-fg">새 대화</h1>
+            <p className="truncate text-xs text-faint">워크스페이스 · 채팅</p>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <ArtifactToggle />
+            <span className="rounded-md bg-surface-2 px-2 py-1 font-mono text-xs text-muted">
+              Lumen
+            </span>
+          </div>
+        </header>
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        <MessageList />
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <MessageList />
+        </div>
+
+        <ActiveContext />
+        <Composer />
       </div>
 
-      <ActiveContext />
-      <Composer />
-    </>
+      <ArtifactPanel />
+    </div>
   );
 }

--- a/apps/web/components/chat/artifact-frame.tsx
+++ b/apps/web/components/chat/artifact-frame.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+/**
+ * 아티팩트 라이브 렌더용 샌드박스 iframe.
+ *
+ * 🔒 sandbox="allow-scripts" 만 부여하고 allow-same-origin 은 **절대** 부여하지 않는다.
+ *    → iframe 은 null(opaque) origin 으로 격리되어 앱 쿠키/localStorage/부모 DOM 에
+ *      접근할 수 없다. (둘을 동시에 주면 샌드박스가 무력화되어 세션 탈취가 가능해진다.)
+ */
+export function ArtifactFrame({ srcDoc, title }: { srcDoc: string; title?: string }) {
+  return (
+    <iframe
+      title={title ?? "아티팩트 미리보기"}
+      sandbox="allow-scripts allow-popups allow-modals"
+      srcDoc={srcDoc}
+      className="h-full w-full border-0 bg-white"
+      referrerPolicy="no-referrer"
+    />
+  );
+}

--- a/apps/web/components/chat/artifact-panel.tsx
+++ b/apps/web/components/chat/artifact-panel.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { X, Code2, Eye, Copy, Check } from "lucide-react";
+import { useAppStore } from "@/lib/store";
+import type { Artifact } from "@/lib/store";
+import { ApiClient } from "@/lib/api-client";
+import { isIframeKind, buildArtifactSrcDoc } from "@/lib/artifact-render";
+import { ArtifactFrame } from "./artifact-frame";
+import { Markdown } from "./markdown";
+import { cn } from "@/lib/utils";
+
+/** 영속 아티팩트 행(REST) → store Artifact 매핑. */
+interface PersistedArtifact {
+  artifact_id: string;
+  kind: string;
+  title: string | null;
+  language: string | null;
+  content: string;
+}
+
+function CsvTable({ content }: { content: string }) {
+  const rows = content
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => line.split(","));
+  if (rows.length === 0) return null;
+  const [head, ...body] = rows;
+  return (
+    <div className="overflow-auto p-3">
+      <table className="w-full border-collapse text-sm">
+        <thead>
+          <tr>
+            {head.map((h, i) => (
+              <th key={i} className="border border-border bg-surface-2 px-2.5 py-1.5 text-left font-medium text-fg">
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {body.map((r, i) => (
+            <tr key={i}>
+              {r.map((c, j) => (
+                <td key={j} className="border border-border px-2.5 py-1.5 text-fg-2">
+                  {c}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ArtifactBody({ artifact, view }: { artifact: Artifact; view: "preview" | "code" }) {
+  const { kind, lang, content, streaming } = artifact;
+
+  // 스트리밍 중이거나 코드 뷰 선택 시 → 원본 표시
+  if (view === "code" || streaming) {
+    return (
+      <div className="h-full overflow-auto px-3">
+        <Markdown content={"```" + (lang ?? kind) + "\n" + content + "\n```"} />
+      </div>
+    );
+  }
+  if (kind === "markdown") {
+    return (
+      <div className="h-full overflow-auto p-4">
+        <Markdown content={content} />
+      </div>
+    );
+  }
+  if (kind === "csv") return <CsvTable content={content} />;
+  if (kind === "code") {
+    return (
+      <div className="h-full overflow-auto px-3">
+        <Markdown content={"```" + (lang ?? "") + "\n" + content + "\n```"} />
+      </div>
+    );
+  }
+  if (isIframeKind(kind)) {
+    return <ArtifactFrame srcDoc={buildArtifactSrcDoc(kind, content)} title={artifact.title} />;
+  }
+  // 미지원 kind → 코드 폴백
+  return (
+    <div className="h-full overflow-auto px-3">
+      <Markdown content={"```\n" + content + "\n```"} />
+    </div>
+  );
+}
+
+export function ArtifactPanel() {
+  const artifacts = useAppStore((s) => s.artifacts);
+  const activeArtifactId = useAppStore((s) => s.activeArtifactId);
+  const open = useAppStore((s) => s.artifactPanelOpen);
+  const currentSessionId = useAppStore((s) => s.currentSessionId);
+  const setActiveArtifact = useAppStore((s) => s.setActiveArtifact);
+  const setArtifactPanelOpen = useAppStore((s) => s.setArtifactPanelOpen);
+  const setArtifacts = useAppStore((s) => s.setArtifacts);
+
+  const [view, setView] = useState<"preview" | "code">("preview");
+  const [copied, setCopied] = useState(false);
+
+  // 세션 진입 시 영속 아티팩트 복원 (메모리에 없을 때만 — 라이브 스트림 보호)
+  useEffect(() => {
+    if (!currentSessionId) return;
+    if (useAppStore.getState().artifacts.length > 0) return;
+    let alive = true;
+    (async () => {
+      try {
+        const res = await ApiClient.get<{ data?: { artifacts?: PersistedArtifact[] } }>(
+          `/api/sessions/${currentSessionId}/artifacts`,
+        );
+        if (!alive) return;
+        const rows = res.data?.artifacts ?? [];
+        if (rows.length > 0) {
+          setArtifacts(
+            rows.map((r) => ({
+              id: r.artifact_id,
+              kind: r.kind,
+              title: r.title ?? r.artifact_id,
+              lang: r.language,
+              content: r.content,
+              streaming: false,
+            })),
+          );
+        }
+      } catch {
+        /* 미인증/없음 → 무시 */
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [currentSessionId, setArtifacts]);
+
+  const active = artifacts.find((a) => a.id === activeArtifactId) ?? artifacts[artifacts.length - 1];
+
+  if (!open || !active) return null;
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(active.content);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard 불가 무시 */
+    }
+  };
+
+  const canToggle = isIframeKind(active.kind) && !active.streaming;
+
+  return (
+    <aside className="fixed inset-0 z-40 flex w-full flex-col border-border bg-surface lg:static lg:inset-auto lg:z-auto lg:w-[44%] lg:max-w-[560px] lg:border-l">
+      <div className="flex items-center gap-2 border-b border-border px-3 py-2.5">
+        <span className="rounded bg-surface-2 px-1.5 py-0.5 font-mono text-[11px] text-muted">
+          {active.kind}
+          {active.lang ? `·${active.lang}` : ""}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-sm font-medium text-fg">{active.title}</span>
+        {active.streaming && <span className="text-[11px] text-faint">생성 중…</span>}
+        {canToggle && (
+          <button
+            type="button"
+            onClick={() => setView((v) => (v === "preview" ? "code" : "preview"))}
+            aria-label={view === "preview" ? "코드 보기" : "미리보기"}
+            className="grid h-7 w-7 place-items-center rounded text-muted transition hover:bg-surface-3 hover:text-fg"
+          >
+            {view === "preview" ? <Code2 className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={copy}
+          aria-label="복사"
+          className="grid h-7 w-7 place-items-center rounded text-muted transition hover:bg-surface-3 hover:text-fg"
+        >
+          {copied ? <Check className="h-4 w-4 text-accent" /> : <Copy className="h-4 w-4" />}
+        </button>
+        <button
+          type="button"
+          onClick={() => setArtifactPanelOpen(false)}
+          aria-label="패널 닫기"
+          className="grid h-7 w-7 place-items-center rounded text-muted transition hover:bg-surface-3 hover:text-fg"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {artifacts.length > 1 && (
+        <div className="flex gap-1 overflow-x-auto border-b border-border px-2 py-1.5">
+          {artifacts.map((a) => (
+            <button
+              key={a.id}
+              type="button"
+              onClick={() => setActiveArtifact(a.id)}
+              className={cn(
+                "shrink-0 truncate rounded px-2 py-1 text-xs transition",
+                a.id === active.id ? "bg-accent text-accent-fg" : "text-muted hover:bg-surface-3 hover:text-fg",
+              )}
+            >
+              {a.title}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <ArtifactBody artifact={active} view={canToggle ? view : "preview"} />
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/components/chat/artifact-toggle.tsx
+++ b/apps/web/components/chat/artifact-toggle.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { FileCode2 } from "lucide-react";
+import { useAppStore } from "@/lib/store";
+
+/** 아티팩트가 있고 패널이 닫혀 있을 때만 노출 — 클릭 시 패널 재오픈. */
+export function ArtifactToggle() {
+  const count = useAppStore((s) => s.artifacts.length);
+  const open = useAppStore((s) => s.artifactPanelOpen);
+  const setOpen = useAppStore((s) => s.setArtifactPanelOpen);
+
+  if (count === 0 || open) return null;
+  return (
+    <button
+      type="button"
+      onClick={() => setOpen(true)}
+      className="flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-surface-2 px-2.5 py-1 text-xs font-medium text-fg-2 transition hover:bg-surface-3 hover:text-fg"
+    >
+      <FileCode2 className="h-3.5 w-3.5" />
+      아티팩트 {count}
+    </button>
+  );
+}

--- a/apps/web/lib/artifact-render.ts
+++ b/apps/web/lib/artifact-render.ts
@@ -1,0 +1,89 @@
+/**
+ * 아티팩트 kind → 렌더 전략. 브라우저에서 실행되는 종류(html/svg/mermaid/chart/react)는
+ * 샌드박스 iframe srcdoc 문서를 빌드하고, 나머지(code/markdown/csv 등)는 앱 트리에서 렌더한다.
+ *
+ * 보안: iframe 은 sandbox="allow-scripts" (allow-same-origin 미부여) → null(opaque) origin.
+ * 따라서 iframe 내부 스크립트는 앱 쿠키/localStorage/부모 DOM 에 접근할 수 없다(세션 격리).
+ * 여기서 빌드하는 문서 문자열은 그 iframe 의 srcdoc 으로만 사용된다.
+ */
+
+/** 라이브러리 CDN — iframe 내부에서만 로드 (앱 번들과 분리). */
+const CDN = {
+  mermaid: "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js",
+  chart: "https://cdn.jsdelivr.net/npm/chart.js@4",
+  react: "https://unpkg.com/react@18/umd/react.production.min.js",
+  reactDom: "https://unpkg.com/react-dom@18/umd/react-dom.production.min.js",
+  babel: "https://unpkg.com/@babel/standalone/babel.min.js",
+} as const;
+
+/** iframe 으로 라이브 렌더하는 kind 집합. 그 외는 앱 트리(code/표/markdown)에서 렌더. */
+const IFRAME_KINDS = new Set(["html", "svg", "mermaid", "chart", "react"]);
+
+export function isIframeKind(kind: string): boolean {
+  return IFRAME_KINDS.has(kind);
+}
+
+/** HTML 텍스트 노드 이스케이프 (mermaid 소스 등 텍스트를 안전하게 삽입). */
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** </script> 조기 종료 방지 — JS/JSON 문자열을 <script> 본문에 삽입할 때. */
+function escapeScript(s: string): string {
+  return s.replace(/<\/script/gi, "<\\/script");
+}
+
+const VIEWPORT = '<meta name="viewport" content="width=device-width, initial-scale=1">';
+const BASE_STYLE =
+  "<style>html,body{margin:0;padding:0}body{font-family:system-ui,-apple-system,sans-serif;padding:12px;color:#111;background:#fff}</style>";
+
+/** 라이브러리 doc 공통 셸. */
+function doc(head: string, body: string): string {
+  return `<!doctype html><html><head><meta charset="utf-8">${VIEWPORT}${head}</head><body>${body}</body></html>`;
+}
+
+/**
+ * kind 별 iframe srcdoc 문서 문자열을 만든다. isIframeKind(kind) 가 true 인 경우에만 호출.
+ */
+export function buildArtifactSrcDoc(kind: string, content: string): string {
+  switch (kind) {
+    case "html": {
+      // LLM 이 전체 HTML 문서를 생성(artifact-guide). 문서면 그대로, 조각이면 셸로 감싼다.
+      const looksFullDoc = /<html[\s>]|<!doctype/i.test(content);
+      return looksFullDoc ? content : doc(BASE_STYLE, content);
+    }
+    case "svg": {
+      return doc(
+        BASE_STYLE + "<style>body{display:grid;place-items:center;min-height:100vh}svg{max-width:100%;height:auto}</style>",
+        content,
+      );
+    }
+    case "mermaid": {
+      return doc(
+        `<script src="${CDN.mermaid}"></script>${BASE_STYLE}`,
+        `<pre class="mermaid">${escapeHtml(content)}</pre>` +
+          `<script>mermaid.initialize({startOnLoad:true,securityLevel:'strict'});</script>`,
+      );
+    }
+    case "chart": {
+      return doc(
+        `<script src="${CDN.chart}"></script>${BASE_STYLE}`,
+        `<canvas id="c"></canvas><script>try{new Chart(document.getElementById('c'),${escapeScript(content)});}catch(e){document.body.innerHTML='<pre>차트 오류: '+e.message+'</pre>';}</script>`,
+      );
+    }
+    case "react": {
+      // export default 제거 → Babel(text/babel) 은 ES module export 미지원. App 정의 후 렌더.
+      const code = escapeScript(content.replace(/export\s+default\s+/g, ""));
+      return doc(
+        `<script src="${CDN.react}"></script><script src="${CDN.reactDom}"></script><script src="${CDN.babel}"></script>${BASE_STYLE}`,
+        `<div id="root"></div><script type="text/babel" data-presets="react,typescript">
+${code}
+try{ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));}
+catch(e){document.getElementById('root').innerHTML='<pre>렌더 오류: '+e.message+'</pre>';}
+</script>`,
+      );
+    }
+    default:
+      return doc(BASE_STYLE, `<pre>${escapeHtml(content)}</pre>`);
+  }
+}

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -16,6 +16,20 @@ export interface ChatMessage extends Pick<SharedChatMessage, "role" | "content" 
 
 export type { ChatRole };
 
+/**
+ * 아티팩트 (claude.ai-style 산출물). 백엔드 ws artifact_* 스트림으로 누적되거나
+ * REST GET /api/sessions/:sid/artifacts 로 복원된다.
+ */
+export interface Artifact {
+  id: string;
+  kind: string;
+  title: string;
+  lang: string | null;
+  content: string;
+  /** 스트리밍 진행 중 (artifact_start ~ artifact_end) */
+  streaming?: boolean;
+}
+
 export type ChatStyle = "concise" | "default" | "verbose";
 
 /** store 인증 사용자 — shared-types User 의 표시용 부분집합 (name 은 username 매핑). */
@@ -36,6 +50,11 @@ interface AppState {
   /** 현재 응답에 선택된 에이전트 + 활성 스킬 (ws agent_selected / skills_activated) */
   activeAgent: { name: string; emoji?: string } | null;
   activeSkills: string[];
+
+  // 아티팩트
+  artifacts: Artifact[];
+  activeArtifactId: string | null;
+  artifactPanelOpen: boolean;
 
   // 모드 토글 (기존 state.js)
   thinkingEnabled: boolean;
@@ -63,6 +82,14 @@ interface AppState {
   setActiveSkills: (s: string[]) => void;
   clearChat: () => void;
 
+  // 아티팩트 actions
+  startArtifact: (meta: Omit<Artifact, "content" | "streaming">) => void;
+  appendArtifactDelta: (id: string, delta: string) => void;
+  endArtifact: (id: string) => void;
+  setActiveArtifact: (id: string | null) => void;
+  setArtifactPanelOpen: (v: boolean) => void;
+  setArtifacts: (list: Artifact[]) => void;
+
   toggle: (
     key:
       | "thinkingEnabled"
@@ -85,6 +112,10 @@ export const useAppStore = create<AppState>((set) => ({
   inputDraft: "",
   activeAgent: null,
   activeSkills: [],
+
+  artifacts: [],
+  activeArtifactId: null,
+  artifactPanelOpen: false,
 
   thinkingEnabled: true,
   discussionMode: false,
@@ -125,7 +156,43 @@ export const useAppStore = create<AppState>((set) => ({
   setActiveAgent: (a) => set({ activeAgent: a }),
   setActiveSkills: (s) => set({ activeSkills: s }),
   clearChat: () =>
-    set({ chatHistory: [], currentSessionId: null, activeAgent: null, activeSkills: [] }),
+    set({
+      chatHistory: [],
+      currentSessionId: null,
+      activeAgent: null,
+      activeSkills: [],
+      artifacts: [],
+      activeArtifactId: null,
+      artifactPanelOpen: false,
+    }),
+
+  startArtifact: (meta) =>
+    set((s) => {
+      const existing = s.artifacts.findIndex((a) => a.id === meta.id);
+      const next: Artifact = { ...meta, content: "", streaming: true };
+      const artifacts =
+        existing >= 0
+          ? s.artifacts.map((a, i) => (i === existing ? next : a))
+          : [...s.artifacts, next];
+      return { artifacts, activeArtifactId: meta.id, artifactPanelOpen: true };
+    }),
+  appendArtifactDelta: (id, delta) =>
+    set((s) => ({
+      artifacts: s.artifacts.map((a) =>
+        a.id === id ? { ...a, content: a.content + delta } : a,
+      ),
+    })),
+  endArtifact: (id) =>
+    set((s) => ({
+      artifacts: s.artifacts.map((a) => (a.id === id ? { ...a, streaming: false } : a)),
+    })),
+  setActiveArtifact: (id) => set({ activeArtifactId: id }),
+  setArtifactPanelOpen: (v) => set({ artifactPanelOpen: v }),
+  setArtifacts: (list) =>
+    set((s) => ({
+      artifacts: list,
+      activeArtifactId: list.length > 0 ? (s.activeArtifactId ?? list[list.length - 1].id) : null,
+    })),
 
   toggle: (key) => set((s) => ({ [key]: !s[key] }) as Partial<AppState>),
   setSelectedModel: (m) => set({ selectedModel: m }),

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -38,6 +38,9 @@ export function useChatSocket() {
     setCurrentSessionId,
     setActiveAgent,
     setActiveSkills,
+    startArtifact,
+    appendArtifactDelta,
+    endArtifact,
   } = useAppStore();
 
   const connect = useCallback(() => {
@@ -85,6 +88,15 @@ export function useChatSocket() {
           break;
         case "skills_activated":
           setActiveSkills(data.skillNames);
+          break;
+        case "artifact_start":
+          startArtifact(data.artifact);
+          break;
+        case "artifact_chunk":
+          appendArtifactDelta(data.id, data.delta);
+          break;
+        case "artifact_end":
+          endArtifact(data.id);
           break;
         default:
           break; // init / research_progress / token_warning 등은 추후

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -28,6 +28,22 @@ const nextConfig: NextConfig = {
       { source: "/api/:path*", destination: `${API_PROXY_TARGET}/api/:path*` },
     ];
   },
+  // 보안 헤더 (전역). 아티팩트 라이브 렌더는 sandbox iframe(null-origin)이 1차 경계이고,
+  // 여기 헤더는 앱 자체 보호(클릭재킹·MIME 스니핑·레퍼러). 전체 script-src CSP 는 Next 의
+  // 인라인 hydration 때문에 nonce 배선이 필요해 별도 하드닝 단계로 분리한다.
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "X-Frame-Options", value: "SAMEORIGIN" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          { key: "Content-Security-Policy", value: "frame-ancestors 'self'" },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -105,6 +105,14 @@ export interface WsChatRequest {
   enabledTools?: Record<string, boolean>;
 }
 
+/** 아티팩트 메타 — 백엔드 llm/artifact-parser.ts ArtifactInfo 와 동일 계약. */
+export interface ArtifactMeta {
+  id: string;
+  kind: string;
+  title: string;
+  lang: string | null;
+}
+
 export type WsServerEvent =
   | { type: "token"; token: string }
   | { type: "session_created"; sessionId: string }
@@ -123,7 +131,11 @@ export type WsServerEvent =
         confidence?: number;
       };
     }
-  | { type: "skills_activated"; skillNames: string[] };
+  | { type: "skills_activated"; skillNames: string[] }
+  // 아티팩트 스트리밍 (백엔드 ws-chat-handler.ts 송출)
+  | { type: "artifact_start"; artifact: ArtifactMeta; messageId?: string }
+  | { type: "artifact_chunk"; id: string; delta: string; messageId?: string }
+  | { type: "artifact_end"; id: string; messageId?: string };
 
 /* ── 응답 페이로드 헬퍼 타입 ─────────────────────────────────────────── */
 export interface SessionsPayload {


### PR DESCRIPTION
## 배경
점검 결과, 백엔드는 아티팩트 파이프라인(LLM `<artifact>` 생성 → ws 스트리밍 → 구문검증 → DB 영속 + JSON read API)이 **완비·활성**인데, apps/web 재구축 때 **렌더가 누락**돼 생성된 아티팩트가 화면에 안 떴음(파일첨부 누락과 동일 패턴). 즉 "샌드박스 고도화"는 강화가 아니라 **안전한 렌더 (재)구축**.

## Phase 1 (이 PR) — 가시화 + 클라이언트 샌드박스 렌더
- **shared-types**: `WsServerEvent` 에 `artifact_start/chunk/end` + `ArtifactMeta`
- **store**: 아티팩트 슬라이스(누적·활성·패널 open) + actions
- **use-chat-socket**: artifact_* 이벤트 수신 배선(기존엔 폐기)
- **artifact-render**: kind별 srcdoc 빌더 — html/svg/mermaid/chart/react=iframe, code/markdown/csv=인트리. `</script>` 이스케이프 등 안전 삽입
- **artifact-frame**: 🔒 `sandbox="allow-scripts"` (**allow-same-origin 미부여 = null origin**) → iframe 스크립트가 앱 쿠키/localStorage/부모 DOM 접근 불가
- **artifact-panel**: 우측 split(모바일 오버레이) + 코드/미리보기 토글 + 복사 + 다중 선택 + 세션 진입 REST 복원
- **artifact-toggle**: 헤더 재오픈 버튼
- **next.config**: 보안 헤더(X-Frame-Options/nosniff/Referrer/`frame-ancestors`)

## 검증 (Playwright, 인증 쿠키 주입, 공개 Funnel)
- SVG 아티팩트 요청 → 패널 자동 오픈 + `sandbox="allow-scripts allow-popups allow-modals"`(**allow-same-origin 없음**) + 빨간 원 라이브 렌더
- 보안 헤더 4종 Funnel 응답 확인
- `next build` OK

## 후속 (Phase 2)
`POST /api/artifacts/execute` — code 아티팩트를 Docker 컨테이너(network none·timeout·limit·audit)에서 실행 → 결과 표시. (별도 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)