### PR TITLE
feat(artifact): code 아티팩트 Docker 샌드박스 실행 (Phase 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -688,6 +688,23 @@ MCP_SANDBOX_ENABLED=false
 #   도구를 노출하지 않음. 기본: Python REPL(임의코드)=admin, Playwright=user.
 #   (외부 공개 + open registration 환경에서 게스트의 arbitrary code 도달 차단)
 # MCP_RESTRICTED_SERVERS=Python REPL:admin,Playwright Browser:user
+#
+# 🔒 아티팩트 코드 실행 샌드박스 — code 아티팩트(python/js)를 Docker 컨테이너에서 one-shot 실행.
+#   MCP 샌드박스 런타임 이미지(openmake-mcp-runtime) 재사용. network none(외부 exfil 차단)
+#   + timeout(SIGKILL) + cap-drop/non-root/read-only + 자원상한 + per-user rate limit + audit.
+#   기본 OFF — 활성화 전 `docker build -t openmake-mcp-runtime:latest infra/mcp-runtime` 필요.
+ARTIFACT_EXEC_ENABLED=false
+# ARTIFACT_EXEC_IMAGE=openmake-mcp-runtime:latest      # 런타임 이미지(미설정 시 MCP_SANDBOX_IMAGE 폴백)
+# ARTIFACT_EXEC_DOCKER_PATH=docker                     # docker 바이너리
+# ARTIFACT_EXEC_TIMEOUT_MS=10000                       # 벽시계 실행 제한(초과 시 SIGKILL)
+# ARTIFACT_EXEC_MEMORY=256m                            # 컨테이너 메모리 상한
+# ARTIFACT_EXEC_CPUS=1.0                               # 컨테이너 CPU 상한
+# ARTIFACT_EXEC_PIDS=128                               # 컨테이너 PID 상한
+# ARTIFACT_EXEC_OUTPUT_MAX=262144                      # stdout/stderr 각 캡(bytes)
+# ARTIFACT_EXEC_CODE_MAX=102400                        # 입력 코드 최대(bytes)
+# ARTIFACT_EXEC_RATE_WINDOW_MS=60000                   # 레이트 윈도우
+# ARTIFACT_EXEC_RATE_USER=20                           # per-user 분당 실행 한도
+# ARTIFACT_EXEC_RATE_IP=30                             # per-IP 분당 실행 한도
 # fs_read_file 완전성 고지(P-6) — 이 바이트 초과 시 앞부분만 반환하고 잘림을 고지.
 FS_READ_MAX_BYTES=100000
 # WebSocket 메시지 최대 페이로드(bytes). **미설정/0 = 무제한**(파일·이미지 업로드 용량 제한 없음).

--- a/apps/api/src/config/artifact-exec.ts
+++ b/apps/api/src/config/artifact-exec.ts
@@ -1,0 +1,51 @@
+/**
+ * 아티팩트 코드 실행 샌드박스 설정 (No-Hardcoding — env override).
+ *
+ * code 아티팩트(python/js)를 Docker 컨테이너에서 one-shot 실행하는 데 쓰는 한계값.
+ * MCP 샌드박스(sandbox-docker.ts)와 동일 런타임 이미지를 재사용하되, 실행은 별도
+ * 게이트(ARTIFACT_EXEC_ENABLED)로 통제한다 — network none + timeout + 자원상한.
+ *
+ * @module config/artifact-exec
+ */
+
+function envNum(v: string | undefined, d: number): number {
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? n : d;
+}
+
+export const ARTIFACT_EXEC = {
+  /** 실행 기능 게이트 (기본 off — 운영 활성화는 사용자 직접). */
+  enabled: process.env.ARTIFACT_EXEC_ENABLED === 'true',
+  /** 런타임 이미지 — MCP 샌드박스 이미지(node22+python3+uv) 재사용. */
+  image: process.env.ARTIFACT_EXEC_IMAGE || process.env.MCP_SANDBOX_IMAGE || 'openmake-mcp-runtime:latest',
+  /** docker 바이너리 경로/이름 (resolveDocker 로 절대경로 해석). */
+  dockerPath: process.env.ARTIFACT_EXEC_DOCKER_PATH || process.env.MCP_SANDBOX_DOCKER_PATH || 'docker',
+  /** 벽시계 실행 제한 — 초과 시 SIGKILL. */
+  timeoutMs: envNum(process.env.ARTIFACT_EXEC_TIMEOUT_MS, 10_000),
+  memory: process.env.ARTIFACT_EXEC_MEMORY || '256m',
+  cpus: process.env.ARTIFACT_EXEC_CPUS || '1.0',
+  pidsLimit: envNum(process.env.ARTIFACT_EXEC_PIDS, 128),
+  /** stdout/stderr 각각 캡 (병리적 출력 방지). */
+  outputMaxBytes: envNum(process.env.ARTIFACT_EXEC_OUTPUT_MAX, 256 * 1024),
+  /** 입력 코드 최대 크기. */
+  codeMaxBytes: envNum(process.env.ARTIFACT_EXEC_CODE_MAX, 100 * 1024),
+  user: process.env.ARTIFACT_EXEC_USER || '1000:1000',
+  /** 레이트 리밋 (실행은 비용이 커 보수적). */
+  rateWindowMs: envNum(process.env.ARTIFACT_EXEC_RATE_WINDOW_MS, 60_000),
+  rateUserLimit: envNum(process.env.ARTIFACT_EXEC_RATE_USER, 20),
+  rateIpLimit: envNum(process.env.ARTIFACT_EXEC_RATE_IP, 30),
+} as const;
+
+/**
+ * lang(소문자) → 컨테이너 런타임 바이너리. 매핑에 없으면 미지원(실행 거부).
+ * Phase 2: python / js 만. network none 이라 외부 패키지 설치 불가 — 표준 라이브러리만.
+ */
+export const ARTIFACT_EXEC_RUNTIMES: Record<string, string> = {
+  python: 'python3',
+  py: 'python3',
+  python3: 'python3',
+  javascript: 'node',
+  js: 'node',
+  node: 'node',
+  nodejs: 'node',
+};

--- a/apps/api/src/mcp/sandbox-docker.ts
+++ b/apps/api/src/mcp/sandbox-docker.ts
@@ -65,8 +65,8 @@ export interface SandboxConfig {
 }
 
 let dockerCache: { key: string; value: string | null } | null = null;
-/** PATH 또는 절대경로에서 docker 바이너리 탐색 (memoize). */
-function resolveDocker(dockerPath: string): string | null {
+/** PATH 또는 절대경로에서 docker 바이너리 탐색 (memoize). 아티팩트 실행 서비스도 재사용. */
+export function resolveDocker(dockerPath: string): string | null {
     if (dockerCache && dockerCache.key === dockerPath) return dockerCache.value;
     let resolved: string | null = null;
     try {

--- a/apps/api/src/middlewares/rate-limiters.ts
+++ b/apps/api/src/middlewares/rate-limiters.ts
@@ -11,6 +11,7 @@ import {
 } from '../config/rate-limits';
 import { getKeyValueStore } from '../storage';
 import { STORAGE_POLICY, RATE_LIMIT_POLICY } from '../config/security';
+import { ARTIFACT_EXEC } from '../config/artifact-exec';
 
 // ================================================
 // 타입 정의
@@ -438,4 +439,14 @@ export const adminLimiter = createAdvancedRateLimiter({
     ipLimit: RL_ADMIN.ipLimit,
     userLimit: RL_ADMIN.userLimit,
     message: 'Admin API 요청이 너무 많습니다. 잠시 후 다시 시도하세요.',
+});
+
+/**
+ * 아티팩트 코드 실행 레이트 리미터 — 컨테이너 실행은 비용이 커 보수적으로 제한.
+ */
+export const artifactExecLimiter = createAdvancedRateLimiter({
+    windowMs: ARTIFACT_EXEC.rateWindowMs,
+    ipLimit: ARTIFACT_EXEC.rateIpLimit,
+    userLimit: ARTIFACT_EXEC.rateUserLimit,
+    message: '코드 실행 요청이 너무 많습니다. 잠시 후 다시 시도하세요.',
 });

--- a/apps/api/src/routes/artifacts.routes.ts
+++ b/apps/api/src/routes/artifacts.routes.ts
@@ -15,6 +15,10 @@ import { getPool } from '../data/models/unified-database';
 import { success, notFound } from '../utils/api-response';
 import { asyncHandler } from '../utils/error-handler';
 import { requireAuth } from '../auth';
+import { artifactExecLimiter } from '../middlewares/rate-limiters';
+import { executeArtifactCode, ArtifactExecError } from '../services/artifact-exec-service';
+import { ARTIFACT_EXEC } from '../config/artifact-exec';
+import { getAuditService } from '../services/AuditService';
 
 const router = Router();
 
@@ -205,6 +209,54 @@ router.delete('/sessions/:sid/artifacts/:aid', requireAuth, asyncHandler(async (
     }
     const deleted = await repo.deleteByArtifactId(sid, aid);
     res.json(success({ deleted }));
+}));
+
+/**
+ * POST /api/artifacts/execute
+ * code 아티팩트(python/js)를 Docker 컨테이너 샌드박스에서 one-shot 실행하고 출력을 반환.
+ * body: { lang, code } → { runtime, stdout, stderr, exitCode, durationMs, timedOut, truncated }
+ *
+ * 보안: requireAuth + per-user rate limit + network none 컨테이너 + timeout + 자원상한 + audit.
+ */
+router.post('/artifacts/execute', requireAuth, artifactExecLimiter, asyncHandler(async (req: Request, res: Response) => {
+    const body = req.body as { lang?: unknown; code?: unknown };
+    const lang = typeof body.lang === 'string' ? body.lang : '';
+    const code = typeof body.code === 'string' ? body.code : '';
+    if (!lang || !code) {
+        res.status(400).json({ error: 'INVALID_BODY', detail: 'lang, code (string) 필수' });
+        return;
+    }
+    if (Buffer.byteLength(code, 'utf8') > ARTIFACT_EXEC.codeMaxBytes) {
+        res.status(413).json({ error: 'CODE_TOO_LARGE', detail: `최대 ${ARTIFACT_EXEC.codeMaxBytes} bytes` });
+        return;
+    }
+
+    const userId = req.user && 'userId' in req.user ? (req.user as { userId: string }).userId : req.user?.id?.toString();
+    try {
+        const result = await executeArtifactCode(lang, code);
+        // 실행 audit (인증 사용자 — userId FK 안전)
+        void getAuditService().logAudit({
+            action: 'artifact_execute',
+            userId,
+            details: {
+                lang,
+                runtime: result.runtime,
+                exitCode: result.exitCode,
+                durationMs: result.durationMs,
+                timedOut: result.timedOut,
+                truncated: result.truncated,
+                codeBytes: Buffer.byteLength(code, 'utf8'),
+            },
+            actor: { email: req.user?.email, role: req.user?.role },
+        });
+        res.json(success(result));
+    } catch (e) {
+        if (e instanceof ArtifactExecError) {
+            res.status(e.statusCode).json({ error: e.code, detail: e.message });
+            return;
+        }
+        throw e;
+    }
 }));
 
 export default router;

--- a/apps/api/src/services/artifact-exec-service.ts
+++ b/apps/api/src/services/artifact-exec-service.ts
@@ -1,0 +1,145 @@
+/**
+ * 아티팩트 코드 실행 서비스 — code 아티팩트(python/js)를 Docker 컨테이너에서
+ * one-shot 실행하고 stdout/stderr 를 캡처한다.
+ *
+ * 보안: `docker run --rm -i --init --network none --cap-drop ALL
+ *   --security-opt no-new-privileges --pids-limit --memory --cpus --user 1000:1000
+ *   --read-only --tmpfs /tmp` 로 격리. 코드는 인자가 아닌 **stdin** 으로 전달(셸 인젝션
+ *   표면 최소화). network none → 외부 exfil 불가. timeout 초과 시 SIGKILL.
+ *
+ * @module services/artifact-exec-service
+ */
+import { spawn } from 'child_process';
+import { createLogger } from '../utils/logger';
+import { resolveDocker } from '../mcp/sandbox-docker';
+import { ARTIFACT_EXEC, ARTIFACT_EXEC_RUNTIMES } from '../config/artifact-exec';
+
+const log = createLogger('ArtifactExec');
+
+export interface ArtifactExecResult {
+  runtime: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  durationMs: number;
+  timedOut: boolean;
+  truncated: boolean;
+}
+
+/** lang → 런타임 바이너리 (미지원이면 null). */
+export function resolveRuntime(lang: string | null | undefined): string | null {
+  if (!lang) return null;
+  return ARTIFACT_EXEC_RUNTIMES[lang.toLowerCase().trim()] ?? null;
+}
+
+/** PURE: docker run 인자 조립 (유닛테스트 대상). */
+export function buildExecDockerArgs(runtime: string): string[] {
+  const c = ARTIFACT_EXEC;
+  return [
+    'run', '--rm', '-i', '--init',
+    '--network', 'none',
+    '--cap-drop', 'ALL',
+    '--security-opt', 'no-new-privileges',
+    '--pids-limit', String(c.pidsLimit),
+    '--memory', c.memory,
+    '--cpus', c.cpus,
+    '--user', c.user,
+    '--read-only', '--tmpfs', '/tmp:rw,exec,size=64m',
+    '-e', 'HOME=/tmp',
+    c.image, runtime,
+  ];
+}
+
+export interface ExecAvailability {
+  enabled: boolean;
+  dockerPath: string | null;
+}
+
+/** 실행 가능 여부 — 게이트 on + docker 바이너리 발견. */
+export function execAvailability(): ExecAvailability {
+  if (!ARTIFACT_EXEC.enabled) return { enabled: false, dockerPath: null };
+  return { enabled: true, dockerPath: resolveDocker(ARTIFACT_EXEC.dockerPath) };
+}
+
+function runOnce(dockerPath: string, runtime: string, code: string): Promise<ArtifactExecResult> {
+  return new Promise((resolve) => {
+    const args = buildExecDockerArgs(runtime);
+    const started = Date.now();
+    let stdout = '';
+    let stderr = '';
+    let outBytes = 0;
+    let errBytes = 0;
+    let truncated = false;
+    let timedOut = false;
+    const max = ARTIFACT_EXEC.outputMaxBytes;
+
+    const child = spawn(dockerPath, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL'); // docker run 종료 → --rm 컨테이너 정리
+    }, ARTIFACT_EXEC.timeoutMs);
+
+    child.stdout.on('data', (d: Buffer) => {
+      if (outBytes < max) {
+        outBytes += d.length;
+        stdout += d.toString('utf8');
+        if (outBytes >= max) { stdout = stdout.slice(0, max); truncated = true; }
+      }
+    });
+    child.stderr.on('data', (d: Buffer) => {
+      if (errBytes < max) {
+        errBytes += d.length;
+        stderr += d.toString('utf8');
+        if (errBytes >= max) { stderr = stderr.slice(0, max); truncated = true; }
+      }
+    });
+    child.on('error', (e) => {
+      clearTimeout(timer);
+      log.warn(`docker spawn 실패: ${e.message}`);
+      resolve({ runtime, stdout: '', stderr: `실행 환경 오류: ${e.message}`, exitCode: null, durationMs: Date.now() - started, timedOut, truncated });
+    });
+    child.on('close', (exitCode) => {
+      clearTimeout(timer);
+      resolve({
+        runtime,
+        stdout,
+        stderr: timedOut ? (stderr + `\n[시간 초과: ${ARTIFACT_EXEC.timeoutMs}ms 내 미완료, 강제 종료]`) : stderr,
+        exitCode,
+        durationMs: Date.now() - started,
+        timedOut,
+        truncated,
+      });
+    });
+
+    // 코드는 stdin 으로 — python3/node 는 파이프된 stdin 을 스크립트로 실행한다.
+    child.stdin.on('error', () => { /* EPIPE(조기종료) 무시 */ });
+    child.stdin.write(code);
+    child.stdin.end();
+  });
+}
+
+/**
+ * 코드 아티팩트를 컨테이너에서 실행. lang 미지원/게이트 off/docker 부재면 throw.
+ */
+export async function executeArtifactCode(lang: string, code: string): Promise<ArtifactExecResult> {
+  const runtime = resolveRuntime(lang);
+  if (!runtime) {
+    throw new ArtifactExecError(`지원하지 않는 언어: ${lang}`, 400, 'UNSUPPORTED_LANG');
+  }
+  const { enabled, dockerPath } = execAvailability();
+  if (!enabled) {
+    throw new ArtifactExecError('코드 실행 기능이 비활성화되어 있습니다', 503, 'EXEC_DISABLED');
+  }
+  if (!dockerPath) {
+    throw new ArtifactExecError('실행 런타임(docker)을 찾을 수 없습니다', 503, 'DOCKER_NOT_FOUND');
+  }
+  return runOnce(dockerPath, runtime, code);
+}
+
+export class ArtifactExecError extends Error {
+  constructor(message: string, public statusCode: number, public code: string) {
+    super(message);
+    this.name = 'ArtifactExecError';
+  }
+}

--- a/apps/web/components/chat/artifact-panel.tsx
+++ b/apps/web/components/chat/artifact-panel.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { X, Code2, Eye, Copy, Check } from "lucide-react";
+import { X, Code2, Eye, Copy, Check, Play, Loader2 } from "lucide-react";
 import { useAppStore } from "@/lib/store";
 import type { Artifact } from "@/lib/store";
-import { ApiClient } from "@/lib/api-client";
+import { ApiClient, ApiError } from "@/lib/api-client";
 import { isIframeKind, buildArtifactSrcDoc } from "@/lib/artifact-render";
 import { ArtifactFrame } from "./artifact-frame";
 import { Markdown } from "./markdown";
@@ -17,6 +17,102 @@ interface PersistedArtifact {
   title: string | null;
   language: string | null;
   content: string;
+}
+
+/** 컨테이너 실행 결과(POST /api/artifacts/execute). */
+interface ExecResult {
+  runtime: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  durationMs: number;
+  timedOut: boolean;
+  truncated: boolean;
+}
+
+/** 서버 실행 가능 언어 (백엔드 ARTIFACT_EXEC_RUNTIMES 와 정합). */
+const RUNNABLE_LANGS = new Set(["python", "py", "python3", "javascript", "js", "node", "nodejs"]);
+
+function CodeArtifactView({ artifact }: { artifact: Artifact }) {
+  const lang = (artifact.lang ?? "").toLowerCase().trim();
+  const runnable = RUNNABLE_LANGS.has(lang);
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<ExecResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async () => {
+    setRunning(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await ApiClient.post<{ data: ExecResult }>("/api/artifacts/execute", {
+        lang,
+        code: artifact.content,
+      });
+      setResult(res.data);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        if (e.status === 503) setError("코드 실행 기능이 비활성화되어 있습니다.");
+        else if (e.status === 429) setError("실행 요청이 너무 많습니다. 잠시 후 다시 시도하세요.");
+        else if (e.status === 400) setError("지원하지 않는 언어입니다.");
+        else if (e.status === 413) setError("코드가 너무 큽니다.");
+        else setError(e.message);
+      } else {
+        setError("실행에 실패했습니다.");
+      }
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      {runnable && (
+        <div className="flex items-center gap-2 border-b border-border px-3 py-1.5">
+          <button
+            type="button"
+            onClick={run}
+            disabled={running}
+            className="flex items-center gap-1.5 rounded-md bg-accent px-2.5 py-1 text-xs font-medium text-accent-fg transition hover:bg-accent-hover disabled:opacity-60"
+          >
+            {running ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
+            {running ? "실행 중…" : "실행"}
+          </button>
+          <span className="text-[11px] text-faint">샌드박스(네트워크 차단) · {lang}</span>
+        </div>
+      )}
+      <div className="min-h-0 flex-1 overflow-auto px-3">
+        <Markdown content={"```" + (lang || "") + "\n" + artifact.content + "\n```"} />
+        {error && (
+          <div className="mb-3 rounded-md border border-danger/40 bg-danger/10 px-3 py-2 text-xs text-danger">
+            {error}
+          </div>
+        )}
+        {result && (
+          <div className="mb-3 rounded-md border border-border bg-surface-2">
+            <div className="flex items-center gap-2 border-b border-border px-3 py-1.5 text-[11px] text-muted">
+              <span>출력</span>
+              <span className="font-mono">exit={result.exitCode ?? "—"}</span>
+              <span className="font-mono">{result.durationMs}ms</span>
+              {result.timedOut && <span className="text-danger">시간 초과</span>}
+              {result.truncated && <span className="text-faint">잘림</span>}
+            </div>
+            {result.stdout && (
+              <pre className="overflow-x-auto px-3 py-2 text-xs text-fg-2">{result.stdout}</pre>
+            )}
+            {result.stderr && (
+              <pre className="overflow-x-auto border-t border-border px-3 py-2 text-xs text-danger">
+                {result.stderr}
+              </pre>
+            )}
+            {!result.stdout && !result.stderr && (
+              <p className="px-3 py-2 text-xs text-faint">(출력 없음)</p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }
 
 function CsvTable({ content }: { content: string }) {
@@ -73,13 +169,7 @@ function ArtifactBody({ artifact, view }: { artifact: Artifact; view: "preview" 
     );
   }
   if (kind === "csv") return <CsvTable content={content} />;
-  if (kind === "code") {
-    return (
-      <div className="h-full overflow-auto px-3">
-        <Markdown content={"```" + (lang ?? "") + "\n" + content + "\n```"} />
-      </div>
-    );
-  }
+  if (kind === "code") return <CodeArtifactView artifact={artifact} />;
   if (isIframeKind(kind)) {
     return <ArtifactFrame srcDoc={buildArtifactSrcDoc(kind, content)} title={artifact.title} />;
   }


### PR DESCRIPTION
## Phase 2 — code 아티팩트를 프론트에서 실행
Phase 1(렌더)에 이어, code 아티팩트(python/js)를 **"실행" 버튼**으로 Docker 컨테이너에서 실행하고 출력을 패널에 표시. MCP 샌드박스 런타임 이미지/인프라 재사용.

### 보안 모델 (서버 실행)
`docker run --rm -i --init --network none --cap-drop ALL --security-opt no-new-privileges --pids-limit --memory --cpus --user 1000:1000 --read-only --tmpfs /tmp <image> <runtime>`
- **network none** → 외부 exfil 차단
- 코드는 인자가 아닌 **stdin** 전달 → 셸 인젝션 표면 최소
- **timeout SIGKILL** + 출력/코드 크기 캡 + 비-root + read-only
- **requireAuth + per-user rate limit + audit**(action=`artifact_execute`)

### 변경
- `config/artifact-exec`: 게이트·한계값 env 외부화(No-Hardcoding)
- `services/artifact-exec-service`: `buildExecDockerArgs`(순수) + 실행 래퍼. `resolveDocker`(sandbox-docker) 재사용
- `routes/artifacts`: `POST /api/artifacts/execute`
- `rate-limiters`: `artifactExecLimiter`
- `artifact-panel`: code 아티팩트 "실행" 버튼 + 출력/exit/시간 + 503/429/400 분기

기본 **OFF**(`ARTIFACT_EXEC_ENABLED`). 활성화 전 `docker build -t openmake-mcp-runtime:latest infra/mcp-runtime` 필요.

### 검증
- 엔드포인트 curl: python→`42`, js→`42`, **network none → NET_BLOCKED**, 무한루프→**timeout SIGKILL**(10s, exitCode null), 미지원 lang→400, 무인증→401, **audit 기록 확인**
- 프론트 e2e(store 주입): 실행 버튼→POST→stdout `49` 패널 출력 렌더(스크린샷)
- 유닛 3/3(buildExecDockerArgs 보안플래그·resolveRuntime), tsc 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)