### PR TITLE
fix(web/chat): 지난 대화 클릭 시 메시지 로드 (내용 안 보이던 버그)

### DIFF
--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -1,11 +1,56 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 import Image from "next/image";
-import { MessagesSquare, Telescope, Brain, Sparkles } from "lucide-react";
+import { MessagesSquare, Telescope, Brain, Sparkles, FileCode2 } from "lucide-react";
 import { useAppStore } from "@/lib/store";
 import { Markdown } from "./markdown";
 import { cn } from "@/lib/utils";
+
+const ARTIFACT_PLACEHOLDER = /\[\[artifact:([^\]]+)\]\]/g;
+
+/** 영속화된 `[[artifact:id]]` placeholder 를 클릭 가능한 아티팩트 칩으로 렌더. */
+function ArtifactChip({ id }: { id: string }) {
+  const artifacts = useAppStore((s) => s.artifacts);
+  const setActiveArtifact = useAppStore((s) => s.setActiveArtifact);
+  const setArtifactPanelOpen = useAppStore((s) => s.setArtifactPanelOpen);
+  const title = artifacts.find((a) => a.id === id)?.title ?? "아티팩트";
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        setActiveArtifact(id);
+        setArtifactPanelOpen(true);
+      }}
+      className="my-1 inline-flex items-center gap-1.5 rounded-md border border-border bg-surface-2 px-2.5 py-1.5 text-sm font-medium text-fg-2 transition hover:bg-surface-3 hover:text-fg"
+    >
+      <FileCode2 className="h-4 w-4 text-accent" />
+      {title}
+    </button>
+  );
+}
+
+/** assistant 본문 — `[[artifact:id]]` placeholder 를 칩으로, 나머지는 Markdown 으로. */
+function AssistantContent({ content }: { content: string }) {
+  if (!content.includes("[[artifact:")) return <Markdown content={content} />;
+  const nodes: ReactNode[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  const re = new RegExp(ARTIFACT_PLACEHOLDER);
+  let idx = 0;
+  while ((m = re.exec(content)) !== null) {
+    if (m.index > last) {
+      const text = content.slice(last, m.index).trim();
+      if (text) nodes.push(<Markdown key={`t${idx}`} content={text} />);
+    }
+    nodes.push(<ArtifactChip key={`a${idx}`} id={m[1]} />);
+    last = m.index + m[0].length;
+    idx += 1;
+  }
+  const tail = content.slice(last).trim();
+  if (tail) nodes.push(<Markdown key="tail" content={tail} />);
+  return <>{nodes}</>;
+}
 
 const QUICK_STARTS = [
   { icon: MessagesSquare, label: "요약하기", prompt: "다음 내용을 요약해 줘:\n\n" },
@@ -78,7 +123,7 @@ export function MessageList() {
             <div className="min-w-0 flex-1">
               <p className="mb-1 text-xs font-medium text-muted">OpenMake</p>
               <div className="text-sm leading-relaxed text-fg">
-                <Markdown content={m.content} />
+                <AssistantContent content={m.content} />
                 {m.streaming && (
                   <span className="ml-0.5 inline-block h-4 w-1.5 animate-pulse bg-accent align-text-bottom" />
                 )}

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -6,6 +6,7 @@ import { Plus, Search, LogOut } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { useAppStore } from "@/lib/store";
+import type { ChatRole } from "@/lib/store";
 import { NAV_GROUPS } from "@/lib/nav";
 import { ApiClient } from "@/lib/api-client";
 import Image from "next/image";
@@ -22,8 +23,31 @@ interface SessionRow {
 export function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
-  const { clearChat, auth, setAuth } = useAppStore();
+  const { clearChat, auth, setAuth, setChatHistory, setCurrentSessionId, setArtifacts } =
+    useAppStore();
   const user = auth.currentUser;
+  const currentSessionId = useAppStore((s) => s.currentSessionId);
+
+  // 지난 대화 클릭 → 해당 세션 메시지 로드 + 채팅 화면으로 전환.
+  const openSession = async (sid?: string) => {
+    if (!sid) return;
+    setArtifacts([]); // 이전 세션 아티팩트 비움 → 패널이 새 세션 것 재복원
+    setCurrentSessionId(sid);
+    try {
+      const res = await ApiClient.get<
+        ApiSuccess<{ messages?: Array<{ role: string; content: string; images?: string[] }> }>
+      >(`/api/chat/sessions/${sid}/messages`);
+      const msgs = res?.data?.messages ?? [];
+      setChatHistory(() =>
+        msgs
+          .filter((m) => m.role === "user" || m.role === "assistant" || m.role === "system")
+          .map((m) => ({ role: m.role as ChatRole, content: m.content, images: m.images })),
+      );
+    } catch {
+      /* 조회 실패 — 무시 */
+    }
+    if (pathname !== "/") router.push("/");
+  };
 
   const logout = async () => {
     try {
@@ -116,13 +140,26 @@ export function Sidebar() {
               최근 대화
             </p>
             <ul className="space-y-0.5">
-              {sessions.slice(0, 20).map((s, i) => (
-                <li key={s.id ?? s.sessionId ?? i}>
-                  <button className="w-full truncate rounded-md px-2.5 py-1.5 text-left text-sm text-muted transition hover:bg-surface-3 hover:text-fg">
-                    {s.title ?? s.name ?? "제목 없는 대화"}
-                  </button>
-                </li>
-              ))}
+              {sessions.slice(0, 20).map((s, i) => {
+                const sid = s.id ?? s.sessionId;
+                const active = !!sid && sid === currentSessionId;
+                return (
+                  <li key={sid ?? i}>
+                    <button
+                      type="button"
+                      onClick={() => openSession(sid)}
+                      className={cn(
+                        "w-full truncate rounded-md px-2.5 py-1.5 text-left text-sm transition",
+                        active
+                          ? "bg-accent-soft font-medium text-accent"
+                          : "text-muted hover:bg-surface-3 hover:text-fg",
+                      )}
+                    >
+                      {s.title ?? s.name ?? "제목 없는 대화"}
+                    </button>
+                  </li>
+                );
+              })}
             </ul>
           </div>
         )}


### PR DESCRIPTION
## 버그
관리자(및 모든 사용자) 로그인 후 사이드바 **"최근 대화" 항목을 클릭해도 대화 내용이 안 보임**. 원인: 세션 목록 버튼에 **onClick 핸들러가 아예 없어서** 클릭이 무동작.

## 수정 (`Sidebar` 는 데스크톱 + 모바일 드로어 공유 → 둘 다 적용)
- **sidebar**: `openSession(sid)` 추가 — `GET /api/chat/sessions/:sid/messages` 로 메시지 로드 → store(`chatHistory`/`currentSessionId`) 갱신 + 아티팩트 비움(새 세션 재복원) + 채팅 화면 전환. 현재 세션 사이드바 하이라이트.
- **message-list**: 영속화 `[[artifact:id]]` placeholder 가 raw 텍스트로 노출되던 것을 **클릭 가능한 아티팩트 칩**(제목 + 클릭 시 패널 오픈)으로 렌더(`AssistantContent`/`ArtifactChip`).

## 검증 (Playwright, 인증 쿠키 주입, 공개 Funnel)
- 지난 대화 클릭 → `messages API 200` → 사용자/어시스턴트 메시지 표시
- 어시스턴트 본문의 placeholder → `bubble_sort` 아티팩트 칩으로 렌더(스크린샷)
- 아티팩트 패널("아티팩트 1") 자동 복원
- `next build` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)