### PR TITLE
fix(web/chat): 모바일 가로 오버플로 방어 (표/긴 문자열)

### DIFF
--- a/apps/web/components/chat/markdown.tsx
+++ b/apps/web/components/chat/markdown.tsx
@@ -11,7 +11,7 @@ import rehypeHighlight from "rehype-highlight";
  */
 export function Markdown({ content }: { content: string }) {
   return (
-    <div className="prose-chat">
+    <div className="prose-chat break-words">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeHighlight]}
@@ -21,8 +21,14 @@ export function Markdown({ content }: { content: string }) {
               {...props}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-accent underline underline-offset-2 hover:text-accent-hover"
+              className="break-all text-accent underline underline-offset-2 hover:text-accent-hover"
             />
+          ),
+          // 넓은 표는 가로 스크롤 컨테이너로 감싸 모바일에서 페이지 전체가 넘치지 않게 한다.
+          table: ({ children }) => (
+            <div className="my-3 overflow-x-auto">
+              <table className="w-full border-collapse text-sm">{children}</table>
+            </div>
           ),
           code: ({ className, children, ...props }) => {
             const isBlock = /language-/.test(className ?? "");

--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -105,7 +105,7 @@ export function MessageList() {
       {chatHistory.map((m, i) =>
         m.role === "user" ? (
           <div key={i} className="flex justify-end">
-            <div className="max-w-[80%] rounded-2xl rounded-tr-sm bg-accent-soft px-4 py-2.5 text-sm text-fg">
+            <div className="max-w-[80%] whitespace-pre-wrap break-words rounded-2xl rounded-tr-sm bg-accent-soft px-4 py-2.5 text-sm text-fg">
               {m.content}
             </div>
           </div>


### PR DESCRIPTION
## 증상
모바일 접속 시 페이지가 가로로 넓어 옆으로 스크롤해야 내용이 보이는 문제 신고.

## 점검
- viewport meta 정상 서빙(`width=device-width...`), 20+ 페이지 320~390px 에뮬레이션에서 문서 오버플로 미재현. 단 **markdown 에 `table` 렌더러가 없어** 넓은 표(LLM 응답에 흔함)가 오버플로 래퍼 없이 렌더되고, 긴 미분할 문자열(URL/토큰)이 줄바꿈 안 되는 실기기 오버플로 원인 발견.

## 수정
- **markdown**: `table` → `overflow-x-auto` 컨테이너 래핑(넓은 표는 페이지가 아니라 표 안에서 가로 스크롤). 컨테이너 `break-words` + 링크 `break-all`.
- **message-list**: 사용자 버블 `whitespace-pre-wrap break-words`.

## 검증 (Playwright, 390px 모바일)
컬럼 많은 표 응답 → 표 `overflow-x-auto` 안에서 렌더(`tableInScroll=true`), 문서 `scrollWidth=390=viewport`, **오버플로 없음**. `next build` OK.

⚠️ 에뮬레이션에서 문서레벨 오버플로는 재현 안 돼, 실기기 특정 페이지/요소가 더 있으면 스크린샷 공유 부탁.

🤖 Generated with [Claude Code](https://claude.com/claude-code)