### PR TITLE
feat(web/research): 지난 리서치 목록·보고서 + 가로 오버플로 수정

### DIFF
--- a/apps/web/app/(workspace)/research/page.tsx
+++ b/apps/web/app/(workspace)/research/page.tsx
@@ -204,6 +204,28 @@ const DEPTH_OPTIONS: { value: "basic" | "deep" | "comprehensive"; label: string 
 
 const TERMINAL: ApiResearchStatus[] = ["completed", "failed", "cancelled"];
 
+const STATUS_LABEL: Record<ApiResearchStatus, string> = {
+  pending: "대기",
+  running: "진행중",
+  completed: "완료",
+  failed: "실패",
+  cancelled: "취소",
+};
+const STATUS_TONE: Record<ApiResearchStatus, "success" | "accent" | "neutral" | "warn"> = {
+  pending: "neutral",
+  running: "accent",
+  completed: "success",
+  failed: "warn",
+  cancelled: "neutral",
+};
+
+function fmtDate(iso?: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return `${d.getMonth() + 1}/${d.getDate()} ${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
 export default function ResearchPage() {
   const [topic, setTopic] = useState("");
   const [depth, setDepth] = useState<"basic" | "deep" | "comprehensive">("deep");
@@ -213,21 +235,32 @@ export default function ResearchPage() {
   const [sources, setSources] = useState<Source[]>(SOURCES);
   const [metrics, setMetrics] = useState<Metric[]>(METRICS);
   const [status, setStatus] = useState<ApiResearchStatus | null>(null);
+  const [sessionList, setSessionList] = useState<ApiResearchSession[]>([]);
+  const [activeSession, setActiveSession] = useState<ApiResearchSession | null>(null);
   const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const aliveRef = useRef(true);
 
-  // 세션 → 화면 상태 반영 (초기 로드 + 폴링 공용).
+  // 세션 → 화면 상태 반영 (초기 로드 + 폴링 + 목록 선택 공용).
   const applySession = (s: ApiResearchSession) => {
     const srcUrls = s.sources ?? [];
     setStages(deriveStages(s));
     setSources(srcUrls.map(urlToSource));
     setStatus(s.status);
+    setActiveSession(s);
+    setSessionList((prev) => prev.map((p) => (p.id === s.id ? { ...p, ...s } : p)));
     setMetrics([
       { label: "분석 소스", value: String(srcUrls.length) },
       { label: "주요 발견", value: String(s.key_findings?.length ?? 0) },
       { label: "진행률", value: `${Math.round(s.progress)}%` },
       { label: "깊이", value: s.depth },
     ]);
+  };
+
+  // 지난 리서치 목록에서 선택 → 해당 세션 로드 (진행 중이면 폴링 재개).
+  const selectSession = (s: ApiResearchSession) => {
+    if (pollRef.current) clearTimeout(pollRef.current);
+    applySession(s);
+    if (!TERMINAL.includes(s.status)) poll(s.id);
   };
 
   // 진행 중인 세션을 폴링 — 완료/실패/취소면 중단.
@@ -257,8 +290,11 @@ export default function ResearchPage() {
         const res = await ApiClient.get<ResearchSessionsResponse>(
           "/api/research/sessions?limit=20",
         );
-        const latest = res?.data?.sessions?.[0];
-        if (!latest || !aliveRef.current) return;
+        const list = res?.data?.sessions ?? [];
+        if (!aliveRef.current) return;
+        setSessionList(list);
+        const latest = list[0];
+        if (!latest) return;
         applySession(latest);
         if (!TERMINAL.includes(latest.status)) poll(latest.id); // 진행 중이면 이어서 폴링
       } catch {
@@ -284,9 +320,15 @@ export default function ResearchPage() {
         "/api/research/sessions",
         { topic: t, depth },
       );
-      const sid = created?.data?.session?.id;
+      const session = created?.data?.session;
+      const sid = session?.id;
       if (!sid) throw new Error("세션 생성 실패");
       await ApiClient.post(`/api/research/sessions/${sid}/execute`, {});
+      if (session) {
+        setSessionList((prev) => [session, ...prev]); // 목록 맨 앞에 추가
+        setActiveSession(session);
+      }
+      setTopic("");
       setStatus("running");
       setStages(STAGES.map((s, i) => ({ ...s, status: i === 0 ? "running" : "pending" })));
       if (pollRef.current) clearTimeout(pollRef.current);
@@ -365,8 +407,9 @@ export default function ResearchPage() {
         </Card>
 
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_300px]">
-          {/* 좌측: 진행 단계 + 소스 */}
-          <div className="space-y-6">
+          {/* 좌측: 진행 단계 + 소스. min-w-0 — grid item 기본 min-width:auto 가 긴 URL 로
+              컬럼을 넓혀 truncate 무력화·가로 오버플로를 일으키는 것을 차단. */}
+          <div className="min-w-0 space-y-6">
             <Card>
               <CardHeader className="flex items-center justify-between">
                 <CardTitle>리서치 진행</CardTitle>
@@ -449,8 +492,8 @@ export default function ResearchPage() {
             </Card>
           </div>
 
-          {/* 우측: 메트릭 */}
-          <div className="space-y-3">
+          {/* 우측: 메트릭 + 보고서 + 지난 리서치 */}
+          <div className="min-w-0 space-y-3">
             <Card>
               <CardHeader>
                 <CardTitle>메트릭</CardTitle>
@@ -480,12 +523,76 @@ export default function ResearchPage() {
               </CardContent>
             </Card>
 
-            <Card className="p-4">
-              <div className="flex items-center gap-2 text-sm text-muted">
-                <FileText className="h-4 w-4 text-faint" />
-                보고서는 합성 완료 후 표시됩니다.
-              </div>
+            {/* 보고서 — 활성 세션의 요약 + 주요 발견 */}
+            <Card>
+              <CardHeader>
+                <CardTitle>보고서</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {activeSession?.summary || (activeSession?.key_findings?.length ?? 0) > 0 ? (
+                  <div className="space-y-3">
+                    {activeSession?.summary && (
+                      <p className="whitespace-pre-wrap break-words text-sm leading-relaxed text-fg-2">
+                        {activeSession.summary}
+                      </p>
+                    )}
+                    {(activeSession?.key_findings?.length ?? 0) > 0 && (
+                      <div className="space-y-1.5">
+                        <p className="text-xs font-medium text-fg-2">주요 발견</p>
+                        <ul className="space-y-1">
+                          {activeSession!.key_findings!.map((f, i) => (
+                            <li key={i} className="flex gap-2 text-xs text-muted">
+                              <CircleCheck className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-success" />
+                              <span className="break-words">{f}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2 text-sm text-muted">
+                    <FileText className="h-4 w-4 text-faint" />
+                    보고서는 합성 완료 후 표시됩니다.
+                  </div>
+                )}
+              </CardContent>
             </Card>
+
+            {/* 지난 리서치 — 클릭 시 해당 세션 로드 (에이전트 작업 목록과 동일 패턴) */}
+            {sessionList.length > 0 && (
+              <Card>
+                <CardHeader className="flex items-center justify-between">
+                  <CardTitle>지난 리서치</CardTitle>
+                  <span className="font-mono text-xs text-faint">{sessionList.length}건</span>
+                </CardHeader>
+                <CardContent className="space-y-1.5">
+                  {sessionList.map((s) => (
+                    <button
+                      key={s.id}
+                      type="button"
+                      onClick={() => selectSession(s)}
+                      className={cn(
+                        "w-full rounded-md border px-3 py-2 text-left transition",
+                        s.id === activeSession?.id
+                          ? "border-accent bg-accent-soft"
+                          : "border-border bg-surface-2 hover:bg-surface-3",
+                      )}
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className="min-w-0 flex-1 truncate text-sm text-fg">{s.topic}</span>
+                        <Badge tone={STATUS_TONE[s.status]}>{STATUS_LABEL[s.status]}</Badge>
+                      </div>
+                      <div className="mt-0.5 flex items-center gap-2 text-[11px] text-faint">
+                        <span>{fmtDate(s.created_at)}</span>
+                        <span>·</span>
+                        <span>{Math.round(s.progress)}%</span>
+                      </div>
+                    </button>
+                  ))}
+                </CardContent>
+              </Card>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 목표
딥 리서치도 에이전트 작업 구조처럼 **과거 리서치(명령)를 확인**할 수 있게.

## 변경 (`apps/web/.../research/page.tsx`)
- **지난 리서치 목록**: `GET /api/research/sessions` 전체를 우측 목록으로 렌더(주제·상태 배지·날짜·진행률). 클릭 → `selectSession`으로 해당 세션 로드(진행 중이면 폴링 재개), 활성 항목 하이라이트. 새 리서치 시작 시 목록 맨 앞에 추가.
- **보고서**: 활성 세션의 `summary` + `key_findings` 표시(기존 "합성 완료 후 표시" placeholder 대체).
- **🐛 가로 오버플로 수정**: CSS grid item 기본 `min-width:auto` 가 긴 소스 URL 로 `1fr` 컬럼을 컨테이너보다 넓혀 `truncate` 무력화 + 페이지 가로 넘침 → 좌우 컬럼에 `min-w-0`. (사용자가 보고한 모바일 가로 스크롤의 실제 원인 중 하나)

## 검증 (Playwright)
- 데스크톱(1280)·모바일(390) 모두 **overflow 없음**(scrollW=viewport)
- 지난 리서치 **15건** 렌더 + 항목 클릭 시 활성 세션 전환 + 보고서 요약 표시(스크린샷)
- `next build` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)