### PR TITLE
chore(deadcode): Step 3 — 데드 DB 테이블 제거

### DIFF
--- a/apps/api/src/data/db-retention.ts
+++ b/apps/api/src/data/db-retention.ts
@@ -5,7 +5,6 @@
  *
  * 만료된 DB 레코드를 주기적으로 정리합니다.
  * 대상 테이블:
- * - uploaded_documents              : expires_at 기준 만료 문서 삭제
  * - token_blacklist                 : expires_at(ms epoch) 기준 만료 토큰 삭제
  * - oauth_states                    : 10분 이상 경과한 OAuth state 삭제
  * - external_provider_usage         : EXTERNAL_USAGE_RETENTION_DAYS(기본 90일) 보존
@@ -35,15 +34,7 @@ async function runRetention(): Promise<void> {
         const db = getUnifiedDatabase();
         const pool = db.getPool();
 
-        // 1. 만료된 업로드 문서 삭제
-        const docResult = await pool.query(
-            `DELETE FROM uploaded_documents WHERE expires_at < NOW()`
-        );
-        if ((docResult.rowCount ?? 0) > 0) {
-            logger.info(`[DbRetention] 만료 문서 ${docResult.rowCount}건 삭제 완료`);
-        }
-
-        // 2. 만료된 토큰 블랙리스트 항목 삭제 (expires_at은 ms epoch)
+        // 만료된 토큰 블랙리스트 항목 삭제 (expires_at은 ms epoch)
         const now = Date.now();
         const tokenResult = await pool.query(
             `DELETE FROM token_blacklist WHERE expires_at < $1`,

--- a/apps/api/src/data/models/legacy-schema.ts
+++ b/apps/api/src/data/models/legacy-schema.ts
@@ -121,14 +121,6 @@ CREATE TABLE IF NOT EXISTS api_key_failures (
     updated_at TIMESTAMPTZ DEFAULT NOW()
 );
 
-CREATE TABLE IF NOT EXISTS uploaded_documents (
-    doc_id TEXT PRIMARY KEY,
-    document JSONB NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    last_accessed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    expires_at TIMESTAMPTZ NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_uploaded_documents_expires ON uploaded_documents(expires_at);
 
 -- [P3 UNUSED] token_daily_stats: 미사용 테이블. ApiUsageTracker가 현재 인메모리 전용으로 동작. 미래 DB 용 write-through 시 활성화 예정.
 CREATE TABLE IF NOT EXISTS token_daily_stats (
@@ -264,13 +256,6 @@ CREATE TABLE IF NOT EXISTS user_memories (
     updated_at TIMESTAMPTZ DEFAULT NOW(),
     expires_at TIMESTAMPTZ,
     UNIQUE(user_id, category, key)
-);
-
-CREATE TABLE IF NOT EXISTS memory_tags (
-    id SERIAL PRIMARY KEY,
-    memory_id TEXT NOT NULL REFERENCES user_memories(id) ON DELETE CASCADE,
-    tag TEXT NOT NULL,
-    UNIQUE(memory_id, tag)
 );
 
 CREATE TABLE IF NOT EXISTS research_sessions (
@@ -426,7 +411,6 @@ CREATE INDEX IF NOT EXISTS idx_memories_user ON user_memories(user_id);
 CREATE INDEX IF NOT EXISTS idx_memories_category ON user_memories(category);
 CREATE INDEX IF NOT EXISTS idx_memories_importance ON user_memories(importance DESC);
 CREATE INDEX IF NOT EXISTS idx_memories_user_category ON user_memories(user_id, category);
-CREATE INDEX IF NOT EXISTS idx_memory_tags_memory ON memory_tags(memory_id);
 
 CREATE INDEX IF NOT EXISTS idx_research_user ON research_sessions(user_id);
 CREATE INDEX IF NOT EXISTS idx_research_status ON research_sessions(status);

--- a/db/migrations/046_drop_dead_tables.sql
+++ b/db/migrations/046_drop_dead_tables.sql
@@ -1,0 +1,10 @@
+-- 046: 데드 테이블 제거 (RAG/MemoryService 폐기 잔재)
+-- 1단계(코드 참조 제거: legacy-schema CREATE + db-retention 정리)는 같은 PR 에서 완료.
+-- 이 DROP 은 코드 배포 후 수동 적용: `npx ts-node apps/api/src/data/migrations/cli.ts migrate`
+-- (migrations/ 는 부팅 자동적용 아님)
+--
+-- uploaded_documents: RAG/문서처리 폐기로 writer 0 (항상 0행). retention 참조 제거됨.
+-- memory_tags: MemoryService 폐기로 코드 참조 0 (고아 데이터). user_memories 로의 FK 측이라
+--              DROP 이 user_memories(live) 에 영향 없음.
+DROP TABLE IF EXISTS memory_tags CASCADE;
+DROP TABLE IF EXISTS uploaded_documents CASCADE;


### PR DESCRIPTION
RAG/MemoryService 폐기 잔재 테이블 2개 제거 (2단계 배포 1단계 + DROP 마이그레이션 동봉).

## 변경
- **legacy-schema.ts**: `uploaded_documents`·`memory_tags` CREATE TABLE/INDEX 제거 (부팅 재생성 방지)
- **db-retention.ts**: `uploaded_documents` 만료정리 블록·주석 제거 (writer 0·항상 0행)
- **db/migrations/046_drop_dead_tables.sql**: `DROP memory_tags, uploaded_documents` — 코드 배포 후 **수동 적용**

## 근거
- `uploaded_documents`: RAG/문서처리 폐기 → writer 0, DB 0행
- `memory_tags`: MemoryService 폐기 → 코드참조 0 (고아 17행). FK는 `user_memories`(live) 측이라 DROP이 영향 없음

## 검증
백엔드 `tsc` 0, `build` OK, 코드 잔여참조 0.

## ⚠️ 후속 (수동, 코드 배포 후)
`npx ts-node apps/api/src/data/migrations/cli.ts migrate` — 046 적용 시 테이블 영구 삭제.

🤖 Generated with [Claude Code](https://claude.com/claude-code)