### PR TITLE
feat(web/nav): 사이드 네비 역할 기반 게이팅

### DIFF
--- a/apps/web/components/mobile-sidebar.tsx
+++ b/apps/web/components/mobile-sidebar.tsx
@@ -6,19 +6,22 @@ import Link from "next/link";
 import { MessageSquare, Telescope, Sparkles, Menu, X, LogIn } from "lucide-react";
 import { Sidebar } from "./sidebar";
 import { useAppStore } from "@/lib/store";
+import { NAV_ROLE_RANK, type NavRole } from "@/lib/nav";
 import { cn } from "@/lib/utils";
 
 /** OD lumen 모바일 시안: 하단 탭바(44px+ 터치 타깃) + "메뉴" 탭으로 전체 드로어. 데스크탑(lg)은 고정 사이드바. */
-const TABS = [
-  { label: "채팅", href: "/", icon: MessageSquare },
-  { label: "리서치", href: "/research", icon: Telescope },
-  { label: "에이전트", href: "/agent-tasks", icon: Sparkles },
+const TABS: { label: string; href: string; icon: typeof MessageSquare; minRole: NavRole }[] = [
+  { label: "채팅", href: "/", icon: MessageSquare, minRole: "guest" },
+  { label: "리서치", href: "/research", icon: Telescope, minRole: "user" },
+  { label: "에이전트", href: "/agent-tasks", icon: Sparkles, minRole: "user" },
 ];
 
 export function MobileSidebar() {
   const [open, setOpen] = useState(false);
   const pathname = usePathname();
   const user = useAppStore((s) => s.auth.currentUser);
+  const roleRank = NAV_ROLE_RANK[user?.role ?? "guest"];
+  const tabs = TABS.filter((t) => roleRank >= NAV_ROLE_RANK[t.minRole]);
 
   // 라우트 이동 시 드로어 자동 닫기
   useEffect(() => setOpen(false), [pathname]);
@@ -50,7 +53,7 @@ export function MobileSidebar() {
 
       {/* 하단 탭바 (모바일 전용) */}
       <nav className="fixed inset-x-0 bottom-0 z-30 flex items-stretch border-t border-border bg-surface pb-[env(safe-area-inset-bottom)] lg:hidden">
-        {TABS.map((t) => (
+        {tabs.map((t) => (
           <Link
             key={t.href}
             href={t.href}

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -7,7 +7,7 @@ import { useQuery } from "@tanstack/react-query";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { useAppStore } from "@/lib/store";
 import type { ChatRole } from "@/lib/store";
-import { NAV_GROUPS } from "@/lib/nav";
+import { visibleNavGroups } from "@/lib/nav";
 import { ApiClient } from "@/lib/api-client";
 import Image from "next/image";
 import { ThemeToggle } from "./theme-toggle";
@@ -108,7 +108,7 @@ export function Sidebar() {
       </div>
 
       <nav className="mt-3 flex-1 overflow-y-auto px-3 pb-3">
-        {NAV_GROUPS.map((group) => (
+        {visibleNavGroups(user?.role ?? "guest").map((group) => (
           <div key={group.title} className="pt-3">
             <p className="px-1 pb-1 text-[11px] font-medium uppercase tracking-wider text-faint">
               {group.title}

--- a/apps/web/lib/nav.ts
+++ b/apps/web/lib/nav.ts
@@ -20,15 +20,23 @@ import {
   type LucideIcon,
 } from "lucide-react";
 
+/** 최소 가시 역할 — 백엔드 권한과 정합 (guest<user<admin). 항목>그룹>기본('user') 순 우선. */
+export type NavRole = "guest" | "user" | "admin";
+export const NAV_ROLE_RANK: Record<NavRole, number> = { guest: 0, user: 1, admin: 2 };
+
 export interface NavItem {
   label: string;
   href: string;
   icon: LucideIcon;
+  /** 이 항목을 보려면 필요한 최소 역할. 미지정 시 그룹값, 그것도 없으면 'user'. */
+  minRole?: NavRole;
 }
 
 export interface NavGroup {
   title: string;
   items: NavItem[];
+  /** 그룹 전체의 최소 역할 (항목별 minRole 이 우선). */
+  minRole?: NavRole;
 }
 
 /** 사이드바 네비게이션 — 기존 nav-items.js + pages 모듈에 대응. */
@@ -36,7 +44,7 @@ export const NAV_GROUPS: NavGroup[] = [
   {
     title: "워크스페이스",
     items: [
-      { label: "채팅", href: "/", icon: MessageSquare },
+      { label: "채팅", href: "/", icon: MessageSquare, minRole: "guest" },
       { label: "딥 리서치", href: "/research", icon: Telescope },
       { label: "에이전트 작업", href: "/agent-tasks", icon: Sparkles },
       { label: "커스텀 에이전트", href: "/custom-agents", icon: Bot },
@@ -64,6 +72,7 @@ export const NAV_GROUPS: NavGroup[] = [
   },
   {
     title: "관리자",
+    minRole: "admin",
     items: [
       { label: "관리자", href: "/admin", icon: Shield },
       { label: "애널리틱스", href: "/admin/analytics", icon: LineChart },
@@ -74,3 +83,15 @@ export const NAV_GROUPS: NavGroup[] = [
     ],
   },
 ];
+
+/**
+ * 역할로 nav 그룹/항목을 필터한다. 항목별 minRole(없으면 그룹 minRole, 그것도 없으면 'user')을
+ * 충족하는 항목만 남기고, 항목이 모두 가려진 그룹은 제외한다. role 미지정/미로그인 = 'guest'.
+ */
+export function visibleNavGroups(role: NavRole = "guest"): NavGroup[] {
+  const rank = NAV_ROLE_RANK[role];
+  return NAV_GROUPS.map((g) => ({
+    ...g,
+    items: g.items.filter((it) => rank >= NAV_ROLE_RANK[it.minRole ?? g.minRole ?? "user"]),
+  })).filter((g) => g.items.length > 0);
+}


### PR DESCRIPTION
## 배경
사이드바에 role 필터가 없어 **게스트·일반 사용자도 관리자 메뉴까지 전부 노출**됐음. 백엔드 권한과 정합하도록 nav 가시성 게이팅 추가.

## 역할 모델 (사용자 승인 "표준 3단계")
| 역할 | 보이는 메뉴 |
|---|---|
| **guest** | 채팅 |
| **user** | 채팅 + 워크스페이스(딥리서치·에이전트작업·커스텀에이전트·스킬·히스토리) + 통합(MCP·에이전트학습) + 계정(설정·API키·사용량·개발자) |
| **admin** | user 전체 + 관리자 메뉴(애널리틱스·감사·메트릭·알림·MCP카탈로그관리) |

백엔드 권한 정합: 채팅=guest, 그 외 워크스페이스/통합/계정=`requireAuth`, 관리자=`requireAuth+requireAdmin`.

## 변경
- `nav.ts`: `NavItem/NavGroup.minRole` + `visibleNavGroups(role)` 헬퍼(항목>그룹>기본'user', 빈 그룹 제외)
- `sidebar.tsx`: `visibleNavGroups(user?.role ?? 'guest')`
- `mobile-sidebar.tsx`: 하단 탭바도 역할 필터

**가시성만** 게이팅 — 백엔드 `requireAuth`/`requireAdmin`이 실제 접근 enforce(이중 방어).

## 검증 (Playwright)
- 게스트=채팅 1개 / 관리자=전체 20개(관리자 메뉴 포함)
- user 역할 로직=워크스페이스+통합+계정(관리자 제외) 단위 확인
- `next build` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)