### PR TITLE
chore(hardcode): Step 1 (A) — 기존 config 우회 4건 정리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -443,6 +443,7 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # SCRAPE_ABORT_BUFFER_MS=1000
 # Deep Research 루프당 최대 스크래핑 소스 수 (기본 15 — 상향 시 스크래핑 시간·합성 입력 토큰 비례 증가)
 # DEEP_RESEARCH_MAX_SCRAPE_PER_LOOP=15
+# RESEARCH_SEARCH_CONCURRENCY=5            # 딥리서치 검색 fan-out 동시실행 수
 # Deep Research(채팅 deep 모드) 최대 전체 소스 수 (기본 50 — 상향 시 합성·보고서 생성 시간 비례 증가)
 # DEEP_RESEARCH_MAX_TOTAL_SOURCES=50
 
@@ -727,3 +728,4 @@ VAPID_SUBJECT=mailto:admin@openmake.ai
 IMAGE_GEN_MODEL=flux2-klein
 # 이미지 생성 타임아웃 ms (기본 180000)
 IMAGE_GEN_TIMEOUT_MS=180000
+# MAX_TOOL_RESULT_CHARS=8000               # 도구 결과를 LLM 컨텍스트로 주입 시 단일 결과 최대 문자수

--- a/apps/api/src/chat/prompt-templates.ts
+++ b/apps/api/src/chat/prompt-templates.ts
@@ -12,6 +12,7 @@
  */
 
 import { resolvePromptLocale } from './language-policy';
+import promptTypePatternsData from '../config/data/prompt-type-patterns.json';
 import type { PromptLocaleCode } from './language-policy';
 
 // ============================================================
@@ -501,163 +502,56 @@ export class PromptCache {
  * @param question - 사용자 질문 텍스트
  * @returns 감지된 프롬프트 역할 유형
  */
+// 분류 테이블을 모듈 로드 시 1회 컴파일 (config/data/prompt-type-patterns.json).
+const PROMPT_TYPE_CONFIGS: { type: PromptType; priority: number; keywords: { pattern: RegExp; weight: number }[] }[] =
+    promptTypePatternsData.agentConfigs.map((c) => ({
+        type: c.type as PromptType,
+        priority: c.priority,
+        keywords: c.keywords.map((k) => ({ pattern: new RegExp(k.source, k.flags), weight: k.weight })),
+    }));
+const PROMPT_TYPE_BONUSES: { type: PromptType; pattern: RegExp; bonus: number }[] =
+    promptTypePatternsData.specialBonuses.map((b) => ({
+        type: b.type as PromptType,
+        pattern: new RegExp(b.source, b.flags),
+        bonus: b.bonus,
+    }));
+const PROMPT_TYPE_MIN_SCORE = promptTypePatternsData.minScore;
+const PROMPT_TYPE_SECURITY_SCORE = promptTypePatternsData.securityPriorityScore;
+
 export function detectPromptType(question: string): PromptType {
     const lowerQ = question.toLowerCase();
 
-    // ============================================
-    // 가중치 기반 스코어링 알고리즘 (Weighted Scoring)
-    // ============================================
-
-    interface AgentKeyword {
-        pattern: RegExp;
-        weight: number;
-    }
-
-    interface AgentConfig {
-        keywords: AgentKeyword[];
-        priority: number; // 동점 시 우선순위
-    }
-
-    const agentConfigs: Record<PromptType, AgentConfig> = {
-        security: {
-            keywords: [
-                { pattern: /보안|security/i, weight: 3 },
-                { pattern: /취약점|vulnerability|hack|해킹/i, weight: 3 },
-                { pattern: /injection|xss|csrf|owasp/i, weight: 4 },
-                { pattern: /인증|인가|auth|permission/i, weight: 2 },
-                { pattern: /encrypt|개인정보|privacy|firewall/i, weight: 2 }
-            ],
-            priority: 10 // 보안은 최우선
-        },
-        coder: {
-            keywords: [
-                { pattern: /코드|code|프로그래밍|programming/i, weight: 2 },
-                { pattern: /typescript|javascript|python|go|rust|java|swift/i, weight: 3 },
-                { pattern: /함수|function|클래스|class|변수|variable/i, weight: 2 },
-                { pattern: /debug|fix|버그|에러|error/i, weight: 2 },
-                { pattern: /api|rest|graphql/i, weight: 2 }
-            ],
-            priority: 8
-        },
-        generator: {
-            keywords: [
-                { pattern: /프로젝트.*만들|create.*project|build.*app/i, weight: 4 },
-                { pattern: /scaffold|boilerplate|템플릿|template/i, weight: 3 },
-                { pattern: /아키텍처|architecture|설계|구조/i, weight: 2 }
-            ],
-            priority: 7
-        },
-        reviewer: {
-            keywords: [
-                { pattern: /리뷰|review|코드.*검토/i, weight: 4 },
-                { pattern: /refactor|리팩토링|개선|최적화/i, weight: 2 },
-                { pattern: /audit|점검|검사/i, weight: 2 }
-            ],
-            priority: 7
-        },
-        reasoning: {
-            keywords: [
-                { pattern: /계산|수학|math|숫자/i, weight: 3 },
-                { pattern: /왜.*인가|why|어떻게|how/i, weight: 2 },
-                { pattern: /분석|analyze|추론|reason|논리|logic/i, weight: 3 },
-                { pattern: /증명|prove|비교|크다|작다/i, weight: 2 }
-            ],
-            priority: 6
-        },
-        translator: {
-            keywords: [
-                { pattern: /번역|translate/i, weight: 4 },
-                { pattern: /영어.*로|한국어.*로|일본어|중국어/i, weight: 3 },
-                { pattern: /뜻|meaning|expression/i, weight: 2 }
-            ],
-            priority: 5
-        },
-        writer: {
-            keywords: [
-                { pattern: /작성|글써|write/i, weight: 2 },
-                { pattern: /블로그|포스트|이메일|mail|essay/i, weight: 3 },
-                { pattern: /시|소설|대본|script|content/i, weight: 2 }
-            ],
-            priority: 5
-        },
-        researcher: {
-            keywords: [
-                { pattern: /리서치|research|조사|investigate/i, weight: 3 },
-                { pattern: /데이터|data|통계|statistics/i, weight: 2 },
-                { pattern: /뉴스|news|정보|info/i, weight: 1 }
-            ],
-            priority: 4
-        },
-        consultant: {
-            keywords: [
-                { pattern: /조언|추천|advice|recommend/i, weight: 2 },
-                { pattern: /전략|strategy|계획|plan|roadmap/i, weight: 3 },
-                { pattern: /상담|consult|해결/i, weight: 2 }
-            ],
-            priority: 4
-        },
-        explainer: {
-            keywords: [
-                { pattern: /설명|explain|알려|tell me/i, weight: 2 },
-                { pattern: /뭐야|무엇|what is/i, weight: 2 },
-                { pattern: /원리|정의|개념|concept/i, weight: 2 }
-            ],
-            priority: 3
-        },
-        agent: {
-            keywords: [
-                { pattern: /검색|search|찾아|find/i, weight: 2 },
-                { pattern: /도구|tool|실행|execute|run/i, weight: 3 },
-                { pattern: /날씨|쇼핑|예약|booking/i, weight: 2 }
-            ],
-            priority: 2
-        },
-        assistant: {
-            keywords: [], // 기본값, 스코어 0
-            priority: 1
-        }
-    };
-
-    // 각 에이전트별 스코어 계산
+    // 가중치 기반 스코어링 — 분류 테이블은 config/data/prompt-type-patterns.json 에서 로드
+    // (No-Hardcoding: regex/weight/priority 인라인 금지, query-patterns.json 과 동일 패턴).
     const scores: { type: PromptType; score: number; priority: number }[] = [];
-
-    for (const [agentType, config] of Object.entries(agentConfigs)) {
+    for (const config of PROMPT_TYPE_CONFIGS) {
         let score = 0;
         for (const kw of config.keywords) {
-            if (kw.pattern.test(lowerQ)) {
-                score += kw.weight;
-            }
+            if (kw.pattern.test(lowerQ)) score += kw.weight;
         }
-
-        // 특별 가중치: 도구 사용 의도가 명확한 경우
-        if (agentType === 'coder' && /api|lib|module|github|이슈|pr/i.test(lowerQ)) score += 2;
-        if (agentType === 'researcher' && /최신|뉴스|검색|사례|exa/i.test(lowerQ)) score += 2;
-        if (agentType === 'security' && /취약점|해킹|보안|vulnerability/i.test(lowerQ)) score += 2;
-
-        scores.push({
-            type: agentType as PromptType,
-            score,
-            priority: config.priority
-        });
+        scores.push({ type: config.type, score, priority: config.priority });
     }
 
-    // 스코어 내림차순 정렬 (동점 시 priority로)
-    scores.sort((a, b) => {
-        if (b.score !== a.score) return b.score - a.score;
-        return b.priority - a.priority;
-    });
+    // 특별 가중치 (도구 사용 의도가 명확한 경우 등)
+    for (const bonus of PROMPT_TYPE_BONUSES) {
+        if (bonus.pattern.test(lowerQ)) {
+            const s = scores.find(x => x.type === bonus.type);
+            if (s) s.score += bonus.bonus;
+        }
+    }
 
-    // 최고 스코어가 2점 미만이면 기본 assistant (더 엄격한 기준)
-    if (scores[0].score < 2) {
+    // 스코어 내림차순 정렬 (동점 시 priority로). Array.sort 는 안정 정렬이라
+    // 동점·동priority 는 PROMPT_TYPE_CONFIGS(=JSON) 순서가 유지된다.
+    scores.sort((a, b) => (b.score !== a.score ? b.score - a.score : b.priority - a.priority));
+
+    if (scores[0].score < PROMPT_TYPE_MIN_SCORE) {
         return 'assistant';
     }
-
-    // 보안 질문은 스코어가 조금이라도 있으면 우선 순위 대폭 상승
+    // 보안 질문은 스코어가 임계 이상이면 우선
     const securityScore = scores.find(s => s.type === 'security');
-    if (securityScore && securityScore.score >= 3) {
+    if (securityScore && securityScore.score >= PROMPT_TYPE_SECURITY_SCORE) {
         return 'security';
     }
-
     return scores[0].type;
 }
 

--- a/apps/api/src/config/data/prompt-type-patterns.json
+++ b/apps/api/src/config/data/prompt-type-patterns.json
@@ -1,0 +1,73 @@
+{
+  "_comment": "detectPromptType 가중치 분류 테이블 (No-Hardcoding: query-patterns.json 과 동일 패턴으로 외부화). 모든 pattern 은 source+flags 로 RegExp 컴파일. agentConfigs 순서는 동점 priority tiebreak 안정성을 위해 의미 있음(변경 주의).",
+  "minScore": 2,
+  "securityPriorityScore": 3,
+  "agentConfigs": [
+    { "type": "security", "priority": 10, "keywords": [
+      { "source": "보안|security", "flags": "i", "weight": 3 },
+      { "source": "취약점|vulnerability|hack|해킹", "flags": "i", "weight": 3 },
+      { "source": "injection|xss|csrf|owasp", "flags": "i", "weight": 4 },
+      { "source": "인증|인가|auth|permission", "flags": "i", "weight": 2 },
+      { "source": "encrypt|개인정보|privacy|firewall", "flags": "i", "weight": 2 }
+    ]},
+    { "type": "coder", "priority": 8, "keywords": [
+      { "source": "코드|code|프로그래밍|programming", "flags": "i", "weight": 2 },
+      { "source": "typescript|javascript|python|go|rust|java|swift", "flags": "i", "weight": 3 },
+      { "source": "함수|function|클래스|class|변수|variable", "flags": "i", "weight": 2 },
+      { "source": "debug|fix|버그|에러|error", "flags": "i", "weight": 2 },
+      { "source": "api|rest|graphql", "flags": "i", "weight": 2 }
+    ]},
+    { "type": "generator", "priority": 7, "keywords": [
+      { "source": "프로젝트.*만들|create.*project|build.*app", "flags": "i", "weight": 4 },
+      { "source": "scaffold|boilerplate|템플릿|template", "flags": "i", "weight": 3 },
+      { "source": "아키텍처|architecture|설계|구조", "flags": "i", "weight": 2 }
+    ]},
+    { "type": "reviewer", "priority": 7, "keywords": [
+      { "source": "리뷰|review|코드.*검토", "flags": "i", "weight": 4 },
+      { "source": "refactor|리팩토링|개선|최적화", "flags": "i", "weight": 2 },
+      { "source": "audit|점검|검사", "flags": "i", "weight": 2 }
+    ]},
+    { "type": "reasoning", "priority": 6, "keywords": [
+      { "source": "계산|수학|math|숫자", "flags": "i", "weight": 3 },
+      { "source": "왜.*인가|why|어떻게|how", "flags": "i", "weight": 2 },
+      { "source": "분석|analyze|추론|reason|논리|logic", "flags": "i", "weight": 3 },
+      { "source": "증명|prove|비교|크다|작다", "flags": "i", "weight": 2 }
+    ]},
+    { "type": "translator", "priority": 5, "keywords": [
+      { "source": "번역|translate", "flags": "i", "weight": 4 },
+      { "source": "영어.*로|한국어.*로|일본어|중국어", "flags": "i", "weight": 3 },
+      { "source": "뜻|meaning|expression", "flags": "i", "weight": 2 }
+    ]},
+    { "type": "writer", "priority": 5, "keywords": [
+      { "source": "작성|글써|write", "flags": "i", "weight": 2 },
+      { "source": "블로그|포스트|이메일|mail|essay", "flags": "i", "weight": 3 },
+      { "source": "시|소설|대본|script|content", "flags": "i", "weight": 2 }
+    ]},
+    { "type": "researcher", "priority": 4, "keywords": [
+      { "source": "리서치|research|조사|investigate", "flags": "i", "weight": 3 },
+      { "source": "데이터|data|통계|statistics", "flags": "i", "weight": 2 },
+      { "source": "뉴스|news|정보|info", "flags": "i", "weight": 1 }
+    ]},
+    { "type": "consultant", "priority": 4, "keywords": [
+      { "source": "조언|추천|advice|recommend", "flags": "i", "weight": 2 },
+      { "source": "전략|strategy|계획|plan|roadmap", "flags": "i", "weight": 3 },
+      { "source": "상담|consult|해결", "flags": "i", "weight": 2 }
+    ]},
+    { "type": "explainer", "priority": 3, "keywords": [
+      { "source": "설명|explain|알려|tell me", "flags": "i", "weight": 2 },
+      { "source": "뭐야|무엇|what is", "flags": "i", "weight": 2 },
+      { "source": "원리|정의|개념|concept", "flags": "i", "weight": 2 }
+    ]},
+    { "type": "agent", "priority": 2, "keywords": [
+      { "source": "검색|search|찾아|find", "flags": "i", "weight": 2 },
+      { "source": "도구|tool|실행|execute|run", "flags": "i", "weight": 3 },
+      { "source": "날씨|쇼핑|예약|booking", "flags": "i", "weight": 2 }
+    ]},
+    { "type": "assistant", "priority": 1, "keywords": [] }
+  ],
+  "specialBonuses": [
+    { "type": "coder", "source": "api|lib|module|github|이슈|pr", "flags": "i", "bonus": 2 },
+    { "type": "researcher", "source": "최신|뉴스|검색|사례|exa", "flags": "i", "bonus": 2 },
+    { "type": "security", "source": "취약점|해킹|보안|vulnerability", "flags": "i", "bonus": 2 }
+  ]
+}

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -173,6 +173,8 @@ export const RESEARCH_DEFAULTS = {
     SCRAPE_BATCH_SIZE: 3,
     /** 청크 크기 (소스 개수 기준) */
     CHUNK_SIZE: 6,
+    /** 검색 fan-out 동시실행 수 (env: RESEARCH_SEARCH_CONCURRENCY) */
+    SEARCH_CONCURRENCY: parseInt(process.env.RESEARCH_SEARCH_CONCURRENCY || '5', 10),
     /** 합성 병렬 동시실행 수 */
     SYNTHESIS_CONCURRENCY: 5,
     /** 전체 합성을 실행하기 위한 최소 콘텐츠 길이 (문자). 이 미만이면 경량 합성 */
@@ -596,6 +598,9 @@ export const TOOL_RESULT_COMPACTION = {
     /** 의미론적 요약 대상 최소 길이 (이보다 짧으면 단순 절단) */
     SEMANTIC_THRESHOLD_CHARS: 500,
 } as const;
+
+/** 도구 결과를 LLM 컨텍스트로 주입할 때 단일 결과 최대 문자 수 (외부 provider · agent task 공용). */
+export const MAX_TOOL_RESULT_CHARS = parseInt(process.env.MAX_TOOL_RESULT_CHARS || '8000', 10);
 
 // ============================================
 // GV 품질 측정

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -19,7 +19,7 @@ import type { ChatMessage, ToolDefinition } from '../llm/types';
 import { getModelForRole } from '../config/model-roles';
 import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { getUnifiedDatabase } from '../data/models/unified-database';
-import { AGENT_TASK_LIMITS } from '../config/runtime-limits';
+import { AGENT_TASK_LIMITS, MAX_TOOL_RESULT_CHARS } from '../config/runtime-limits';
 import { emitAgentTaskProgress } from '../utils/event-bus';
 import { getAgentTaskSystemPrompt, getAgentTaskDeliverableNudge } from '../prompts/agent-task-prompt';
 import { extractAndStripArtifacts, type ExtractedArtifact } from '../llm/artifact-parser';
@@ -388,7 +388,7 @@ export class AgentTaskService {
         try {
             const r = await mcp.executeToolWithContext(name, args, userCtx);
             const text =
-                typeof r.content === 'string' ? r.content : JSON.stringify(r.content).slice(0, 8000);
+                typeof r.content === 'string' ? r.content : JSON.stringify(r.content).slice(0, MAX_TOOL_RESULT_CHARS);
             return r.isError ? `Error: ${text}` : text;
         } catch (e) {
             const msg = e instanceof Error ? e.message : String(e);

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -13,7 +13,7 @@
  * @module services/chat-service/external-provider
  */
 import { createLogger } from '../../utils/logger';
-import { EXTERNAL_LLM_TOOL_BLACKLIST, LOOP_DETECTION, AGENT_LOOP_LIMITS } from '../../config/runtime-limits';
+import { EXTERNAL_LLM_TOOL_BLACKLIST, LOOP_DETECTION, AGENT_LOOP_LIMITS, MAX_TOOL_RESULT_CHARS } from '../../config/runtime-limits';
 import { getUnifiedMCPClient } from '../../mcp/unified-client';
 import { isPersistableUserId } from '../../utils/user-id-validation';
 import { getExternalProviderSystemGuards } from '../../chat/prompt';
@@ -332,7 +332,7 @@ export async function executeExternalTool(
             return `Error: ${typeof result.content === 'string' ? result.content : JSON.stringify(result.content)}`;
         }
         if (typeof result.content === 'string') return result.content;
-        return JSON.stringify(result.content).slice(0, 8000);
+        return JSON.stringify(result.content).slice(0, MAX_TOOL_RESULT_CHARS);
     } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         logger.warn(`외부 LLM 도구 실행 실패 (${toolName}): ${msg}`);

--- a/apps/api/src/services/chat-strategies/discussion-strategy.ts
+++ b/apps/api/src/services/chat-strategies/discussion-strategy.ts
@@ -19,7 +19,7 @@ import type { ChatMessage } from '../../llm';
 import type { ChatStrategy, ChatResult, DiscussionStrategyContext } from './types';
 import { createLogger } from '../../utils/logger';
 import { sanitizePromptInput } from '../../utils/input-sanitizer';
-import { DISCUSSION_TOKEN_BUDGET, MODEL_CONTEXT_DEFAULTS, DISCUSSION_STREAM_ABORT_CHECK_INTERVAL } from '../../config/runtime-limits';
+import { DISCUSSION_TOKEN_BUDGET, MODEL_CONTEXT_DEFAULTS, DISCUSSION_STREAM_ABORT_CHECK_INTERVAL, DISCUSSION_CONCURRENCY } from '../../config/runtime-limits';
 import { LLM_TEMPERATURES } from '../../config/llm-parameters';
 import { resolvePromptLocale, type PromptLocaleCode } from '../../chat/language-policy';
 import { withSpan } from '../../observability/otel';
@@ -351,7 +351,7 @@ export class DiscussionStrategy implements ChatStrategy<DiscussionStrategyContex
         const discussionEngine = createDiscussionEngine(
             generateResponse,
             {
-                maxAgents: 5,
+                maxAgents: DISCUSSION_CONCURRENCY.MAX_PARALLEL_AGENTS,
                 enableCrossReview: true,
                 enableDeepThinking: true,
                 userLanguage: userLanguagePreference,

--- a/apps/api/src/services/deep-research/source-searcher.ts
+++ b/apps/api/src/services/deep-research/source-searcher.ts
@@ -119,7 +119,7 @@ export async function searchSubTopics(params: {
             }
         },
         {
-            concurrency: 5,
+            concurrency: RESEARCH_DEFAULTS.SEARCH_CONCURRENCY,
             signal: abortSignal
         }
     );


### PR DESCRIPTION
하드코딩 검토 중 **이미 존재하는 config를 우회**한 명확한 위반 정리.

## 변경
- **#1 [카테고리 6]** `chat/prompt-templates.ts` `detectPromptType`의 12역할 regex+weight+priority 테이블 → `config/data/prompt-type-patterns.json` 외부화(`query-patterns.json` 동일 패턴, 모듈 로드 1회 컴파일). **동작 100% 동일 검증** — 옛 로직 전사 비교 522 케이스 0 불일치
- **#2 [카테고리 4]** `discussion-strategy.ts` `maxAgents: 5` → `DISCUSSION_CONCURRENCY.MAX_PARALLEL_AGENTS`(config 이미 존재)
- **#3 [카테고리 4]** `source-searcher.ts` `concurrency: 5` → `RESEARCH_DEFAULTS.SEARCH_CONCURRENCY`(신규, env)
- **#4 [카테고리 4]** 도구결과 캡 `.slice(0, 8000)` 중복 2곳 → `MAX_TOOL_RESULT_CHARS` config(env)
- `.env.example`: 신규 env 2개 문서화

## 검증
백엔드 `tsc` 0, `build` OK, `detectPromptType` 동작 보존(522 케이스 동일).

🤖 Generated with [Claude Code](https://claude.com/claude-code)