### PR TITLE
chore(hardcode): Step 2 (B) — 백엔드 매직넘버 config 외부화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -729,3 +729,26 @@ IMAGE_GEN_MODEL=flux2-klein
 # 이미지 생성 타임아웃 ms (기본 180000)
 IMAGE_GEN_TIMEOUT_MS=180000
 # MAX_TOOL_RESULT_CHARS=8000               # 도구 결과를 LLM 컨텍스트로 주입 시 단일 결과 최대 문자수
+
+# ────────────────────────────────────────────────────────────
+# 고급 튜닝 — 매직넘버 외부화(선택, 기본값 사용 권장)
+# ────────────────────────────────────────────────────────────
+# 클러스터 타이밍
+# CLUSTER_DISCOVERY_PORT=52415
+# CLUSTER_HEARTBEAT_INTERVAL_MS=5000
+# CLUSTER_NODE_TIMEOUT_MS=15000
+# WebSocket
+# WS_MAX_MESSAGE_CHARS=1048576            # 단일 메시지 문자열 상한(1MB chars)
+# WS_ARTIFACT_CHUNK_FLUSH_MS=50           # artifact_chunk throttle 윈도우
+# API 키 레이트
+# API_KEY_RATE_WINDOW_MS=60000            # RPM/TPM 윈도우(1분)
+# 대화 조회 limit
+# CONVERSATION_SESSION_DETAIL_MESSAGES=500
+# CONVERSATION_SESSION_LIST_DEFAULT=50
+# CONVERSATION_SESSION_LIST_ALL_DEFAULT=100
+# CONVERSATION_MESSAGES_DEFAULT=200
+# CONVERSATION_MESSAGES_MAX=1000
+# CONVERSATION_LIST_MESSAGES_PER_SESSION=50
+# DB 재시도/성능
+# DB_SLOW_QUERY_WARN_MS=1000              # 느린 쿼리 경고 임계
+# DB_RETRY_JITTER_MAX_MS=100              # 백오프 jitter 최대

--- a/apps/api/src/cluster/config.ts
+++ b/apps/api/src/cluster/config.ts
@@ -16,12 +16,13 @@ import { createLogger } from '../utils/logger';
 
 const logger = createLogger('ClusterConfig');
 
+// 매직넘버 금지 — env 오버라이드 지원(미설정 시 기본값).
 const DEFAULT_CONFIG: ClusterConfig = {
     name: 'llm-cluster',
-    discoveryPort: 52415,
+    discoveryPort: parseInt(process.env.CLUSTER_DISCOVERY_PORT || '52415', 10),
     dashboardPort: SERVER_CONFIG.DEFAULT_PORT,
-    heartbeatInterval: 5000,
-    nodeTimeout: 15000,
+    heartbeatInterval: parseInt(process.env.CLUSTER_HEARTBEAT_INTERVAL_MS || '5000', 10),
+    nodeTimeout: parseInt(process.env.CLUSTER_NODE_TIMEOUT_MS || '15000', 10),
     nodes: []
 };
 

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -447,6 +447,10 @@ export const RETRY_DEFAULTS = {
     BASE_DELAY_MS: 500,
     /** 최대 딜레이 (ms) */
     MAX_DELAY_MS: 5000,
+    /** 느린 쿼리 경고 임계값 (ms) — 초과 시 [Performance] warn 로그 */
+    SLOW_QUERY_WARN_MS: parseInt(process.env.DB_SLOW_QUERY_WARN_MS || '1000', 10),
+    /** 백오프 jitter 최대값 (ms) — thundering herd 완화 */
+    JITTER_MAX_MS: parseInt(process.env.DB_RETRY_JITTER_MAX_MS || '100', 10),
 } as const;
 
 // ============================================
@@ -601,6 +605,22 @@ export const TOOL_RESULT_COMPACTION = {
 
 /** 도구 결과를 LLM 컨텍스트로 주입할 때 단일 결과 최대 문자 수 (외부 provider · agent task 공용). */
 export const MAX_TOOL_RESULT_CHARS = parseInt(process.env.MAX_TOOL_RESULT_CHARS || '8000', 10);
+
+/** 대화 조회 limit (conversation-sessions / conversation-messages). */
+export const CONVERSATION_LIMITS = {
+    /** getSession() 단일 세션 상세의 메시지 로드 상한 */
+    SESSION_DETAIL_MESSAGES: parseInt(process.env.CONVERSATION_SESSION_DETAIL_MESSAGES || '500', 10),
+    /** 세션 목록 기본 조회 수 (user/anon) */
+    SESSION_LIST_DEFAULT: parseInt(process.env.CONVERSATION_SESSION_LIST_DEFAULT || '50', 10),
+    /** getMessages() 기본 조회 수 */
+    MESSAGES_DEFAULT: parseInt(process.env.CONVERSATION_MESSAGES_DEFAULT || '200', 10),
+    /** getMessages() 최대 조회 상한(cap) */
+    MESSAGES_MAX: parseInt(process.env.CONVERSATION_MESSAGES_MAX || '1000', 10),
+    /** 목록 view 에서 세션당 로드할 최근 메시지 수 (대용량 사용자 메모리 spike 방지) */
+    LIST_MESSAGES_PER_SESSION: parseInt(process.env.CONVERSATION_LIST_MESSAGES_PER_SESSION || '50', 10),
+    /** getAllSessions() 전체 세션 목록 기본 조회 수 */
+    SESSION_LIST_ALL_DEFAULT: parseInt(process.env.CONVERSATION_SESSION_LIST_ALL_DEFAULT || '100', 10),
+} as const;
 
 // ============================================
 // GV 품질 측정

--- a/apps/api/src/config/timeouts.ts
+++ b/apps/api/src/config/timeouts.ts
@@ -165,6 +165,11 @@ export const WS_LIMITS = {
      * 프론트 가드(chat.js WS_MAX_PAYLOAD_BYTES)도 0=무제한 sentinel 로 정합.
      */
     MAX_PAYLOAD_BYTES: process.env.WS_MAX_PAYLOAD_BYTES !== undefined ? Number(process.env.WS_MAX_PAYLOAD_BYTES) : 0,
+    /**
+     * 단일 메시지 문자열 최대 길이(chars). MAX_PAYLOAD_BYTES(0=무제한 sentinel)와 별개로,
+     * 메시지 핸들러가 raw.length 로 거대 텍스트 프레임을 즉시 거부하는 가드. 기본 1MB(chars).
+     */
+    MAX_MESSAGE_CHARS: parseInt(process.env.WS_MAX_MESSAGE_CHARS || String(1024 * 1024), 10),
     /** 사용자당 최대 동시 WebSocket 연결 수 */
     MAX_CONNECTIONS_PER_USER: Number(process.env.WS_MAX_CONNECTIONS_PER_USER) || 5,
     /** 연결 속도 제한 윈도우 (ms) — 기본 60초 */
@@ -192,6 +197,8 @@ export const WS_LIMITS = {
      * 기본 5회 — 일시적 네트워크 spike 는 허용, 만성적 stall 은 정리.
      */
     BROADCAST_BACKPRESSURE_TERMINATE_AFTER: Number(process.env.WS_BROADCAST_BACKPRESSURE_TERMINATE_AFTER) || 5,
+    /** artifact_chunk 스트리밍 throttle 윈도우(ms) — 토큰 단위 delta 를 합쳐 메시지 폭주 방지. */
+    ARTIFACT_CHUNK_FLUSH_MS: parseInt(process.env.WS_ARTIFACT_CHUNK_FLUSH_MS || '50', 10),
 } as const;
 
 // ============================================

--- a/apps/api/src/data/conversation-messages.ts
+++ b/apps/api/src/data/conversation-messages.ts
@@ -9,6 +9,7 @@
  */
 
 import { getPool } from './models/unified-database';
+import { CONVERSATION_LIMITS } from '../config/runtime-limits';
 import { withRetry, withTransaction } from './retry-wrapper';
 import {
     ConversationMessage,
@@ -82,8 +83,8 @@ export async function loadMessagesForSessions(
 /**
  * 세션의 메시지 목록 조회
  */
-export async function getMessages(sessionId: string, limit: number = 200): Promise<ConversationMessage[]> {
-    const safeLimit = Math.min(limit || 200, 1000);
+export async function getMessages(sessionId: string, limit: number = CONVERSATION_LIMITS.MESSAGES_DEFAULT): Promise<ConversationMessage[]> {
+    const safeLimit = Math.min(limit || CONVERSATION_LIMITS.MESSAGES_DEFAULT, CONVERSATION_LIMITS.MESSAGES_MAX);
     const pool = getPool();
     const result = await pool.query(
         'SELECT * FROM conversation_messages WHERE session_id = $1 ORDER BY created_at ASC LIMIT $2',

--- a/apps/api/src/data/conversation-sessions.ts
+++ b/apps/api/src/data/conversation-sessions.ts
@@ -23,6 +23,7 @@ import {
     rowToSession
 } from './conversation-types';
 import { loadMessagesForSessions } from './conversation-messages';
+import { CONVERSATION_LIMITS } from '../config/runtime-limits';
 
 const logger = createLogger('ConversationSessions');
 
@@ -110,7 +111,7 @@ export async function getSession(id: string): Promise<ConversationSession | unde
 
     const msgResult = await pool.query(
         'SELECT * FROM conversation_messages WHERE session_id = $1 ORDER BY created_at ASC LIMIT $2',
-        [id, 500]
+        [id, CONVERSATION_LIMITS.SESSION_DETAIL_MESSAGES]
     );
 
     const messages = (msgResult.rows as MessageRow[]).map(mr => rowToMessage(mr));
@@ -120,7 +121,7 @@ export async function getSession(id: string): Promise<ConversationSession | unde
 /**
  * 사용자 ID로 세션 목록 조회
  */
-export async function getSessionsByUserId(userId: string, limit: number = 50): Promise<ConversationSession[]> {
+export async function getSessionsByUserId(userId: string, limit: number = CONVERSATION_LIMITS.SESSION_LIST_DEFAULT): Promise<ConversationSession[]> {
     const pool = getPool();
     const result = await pool.query(
         'SELECT * FROM conversation_sessions WHERE user_id = $1 ORDER BY updated_at DESC LIMIT $2',
@@ -129,13 +130,13 @@ export async function getSessionsByUserId(userId: string, limit: number = 50): P
 
     // list view: 세션당 최근 50개만 — 5K+ 메시지 사용자의 메모리 spike 방지.
     // single-session detail 은 getSession() 의 LIMIT 500 으로 별도 로드.
-    return loadMessagesForSessions(result.rows as SessionRow[], { maxMessagesPerSession: 50 });
+    return loadMessagesForSessions(result.rows as SessionRow[], { maxMessagesPerSession: CONVERSATION_LIMITS.LIST_MESSAGES_PER_SESSION });
 }
 
 /**
  * 익명 세션 ID로 세션 목록 조회
  */
-export async function getSessionsByAnonId(anonSessionId: string, limit: number = 50): Promise<ConversationSession[]> {
+export async function getSessionsByAnonId(anonSessionId: string, limit: number = CONVERSATION_LIMITS.SESSION_LIST_DEFAULT): Promise<ConversationSession[]> {
     const pool = getPool();
     const result = await pool.query(
         'SELECT * FROM conversation_sessions WHERE anon_session_id = $1 ORDER BY updated_at DESC LIMIT $2',
@@ -144,13 +145,13 @@ export async function getSessionsByAnonId(anonSessionId: string, limit: number =
 
     // list view: 세션당 최근 50개만 — 5K+ 메시지 사용자의 메모리 spike 방지.
     // single-session detail 은 getSession() 의 LIMIT 500 으로 별도 로드.
-    return loadMessagesForSessions(result.rows as SessionRow[], { maxMessagesPerSession: 50 });
+    return loadMessagesForSessions(result.rows as SessionRow[], { maxMessagesPerSession: CONVERSATION_LIMITS.LIST_MESSAGES_PER_SESSION });
 }
 
 /**
  * 전체 세션 목록 조회
  */
-export async function getAllSessions(limit: number = 100): Promise<ConversationSession[]> {
+export async function getAllSessions(limit: number = CONVERSATION_LIMITS.SESSION_LIST_ALL_DEFAULT): Promise<ConversationSession[]> {
     const pool = getPool();
     const result = await pool.query(
         'SELECT * FROM conversation_sessions ORDER BY updated_at DESC LIMIT $1',
@@ -159,13 +160,13 @@ export async function getAllSessions(limit: number = 100): Promise<ConversationS
 
     // list view: 세션당 최근 50개만 — 5K+ 메시지 사용자의 메모리 spike 방지.
     // single-session detail 은 getSession() 의 LIMIT 500 으로 별도 로드.
-    return loadMessagesForSessions(result.rows as SessionRow[], { maxMessagesPerSession: 50 });
+    return loadMessagesForSessions(result.rows as SessionRow[], { maxMessagesPerSession: CONVERSATION_LIMITS.LIST_MESSAGES_PER_SESSION });
 }
 
 /**
  * 하위 호환성: guest이면 전체, 그 외는 사용자별 조회
  */
-export async function getSessions(userId: string, limit: number = 50): Promise<ConversationSession[]> {
+export async function getSessions(userId: string, limit: number = CONVERSATION_LIMITS.SESSION_LIST_DEFAULT): Promise<ConversationSession[]> {
     if (!isPersistableUserId(userId)) {
         return getAllSessions(limit);
     }

--- a/apps/api/src/data/models/unified-database.types.ts
+++ b/apps/api/src/data/models/unified-database.types.ts
@@ -319,11 +319,13 @@ export interface UserApiKeyPublic {
 export const API_KEY_LIMITS: {
     rpm: number;
     tpm: number;
+    windowMs: number;
     dailyRequests: number;
     monthlyRequests: number;
 } = {
     rpm: 300,
     tpm: 1_000_000,
+    windowMs: parseInt(process.env.API_KEY_RATE_WINDOW_MS || '60000', 10), // RPM/TPM 윈도우(기본 1분)
     dailyRequests: -1, // -1 = unlimited
     monthlyRequests: -1, // -1 = unlimited
 };

--- a/apps/api/src/data/retry-wrapper.ts
+++ b/apps/api/src/data/retry-wrapper.ts
@@ -98,7 +98,7 @@ export async function withRetry<T>(
             // 성공 로그 (첫 시도가 아닌 경우만 또는 특정 시간 초과 시 상세 로깅 가능)
             if (attempt > 0) {
                 logger.info(`[Retry] 쿼리 성공: ${operation} (시도: ${attempt + 1}/${maxRetries + 1}, 소요시간: ${duration}ms)`);
-            } else if (duration > 1000) {
+            } else if (duration > RETRY_DEFAULTS.SLOW_QUERY_WARN_MS) {
                 logger.warn(`[Performance] 느린 쿼리 감지: ${operation} (${duration}ms)`);
             } else {
                 logger.debug(`[Performance] 쿼리 완료: ${operation} (${duration}ms)`);
@@ -122,7 +122,7 @@ export async function withRetry<T>(
 
             // 지수 백오프 + jitter
             const delay = Math.min(
-                baseDelayMs * Math.pow(2, attempt) + Math.random() * 100,
+                baseDelayMs * Math.pow(2, attempt) + Math.random() * RETRY_DEFAULTS.JITTER_MAX_MS,
                 maxDelayMs
             );
 

--- a/apps/api/src/middlewares/api-key-limiter.ts
+++ b/apps/api/src/middlewares/api-key-limiter.ts
@@ -22,8 +22,11 @@ import { isTPMExceeded } from './rate-limit-headers';
  * - limit: 모든 키 공통 단일 한도 (tier 차등 제거)
  * - windowMs: 1분 (RPM)
  */
+/** retry-after(초) — RPM 윈도우에서 파생. */
+const API_KEY_RETRY_AFTER_SECONDS = Math.ceil(API_KEY_LIMITS.windowMs / 1000);
+
 export const apiKeyRateLimiter = rateLimit({
-    windowMs: 60 * 1000, // 1분
+    windowMs: API_KEY_LIMITS.windowMs,
     limit: (): number => API_KEY_LIMITS.rpm,
 
     // API Key ID 기반 분리 (키마다 독립적 카운터)
@@ -44,7 +47,7 @@ export const apiKeyRateLimiter = rateLimit({
             ErrorCodes.RATE_LIMITED,
             'Rate limit exceeded. Please wait before making more requests.',
             {
-                retry_after_seconds: 60,
+                retry_after_seconds: API_KEY_RETRY_AFTER_SECONDS,
                 documentation_url: '/developer#rate-limits'
             }
         ));
@@ -75,7 +78,7 @@ export function apiKeyTPMLimiter(req: Request, res: Response, next: NextFunction
             {
                 type: 'tokens_per_minute',
                 limit: API_KEY_LIMITS.tpm,
-                retry_after_seconds: 60,
+                retry_after_seconds: API_KEY_RETRY_AFTER_SECONDS,
                 documentation_url: '/developer#rate-limits'
             }
         ));

--- a/apps/api/src/sockets/handler.ts
+++ b/apps/api/src/sockets/handler.ts
@@ -238,7 +238,7 @@ export class WebSocketHandler {
                         }
 
                         const raw = data.toString();
-                        if (raw.length > 1024 * 1024) {
+                        if (raw.length > WS_LIMITS.MAX_MESSAGE_CHARS) {
                             ws.send(JSON.stringify({ type: 'error', message: '메시지가 너무 큽니다' }));
                             return;
                         }

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -19,6 +19,7 @@ import { CURRENT_EVENTS_KEYWORDS, WEB_SEARCH_TEMPLATES, WS_ERROR_MESSAGES, WS_PR
 import { detectLanguage, type SupportedLanguageCode } from '../chat/language-policy';
 import { applySlashCommand } from '../chat/slash-command';
 import { getStaleDataWarning } from '../config/stale-data-warning';
+import { WS_LIMITS } from '../config/timeouts';
 import { ArtifactStreamParser, type ArtifactInfo } from '../llm/artifact-parser';
 import { buildFileContext, buildUrlContext, getCachedAttachContext, appendCachedAttachContext } from '../services/chat-service/attach-context';
 
@@ -194,8 +195,8 @@ export async function handleChatMessage(
         // - tokenCallback (아래) 보다 먼저 선언 — TS use-before-declaration 안전.
         // - parser callbacks 가 ws.send 직접 발행 (token / artifact_start/chunk/end).
         // Phase 3 보완 B.3 (2026-05-26): artifact_chunk WS 메시지 폭주 방지 — 토큰 단위 1회/메시지를
-        // ID 별 50ms 윈도우로 buffer 후 합쳐서 1회 dispatch. 큰 artifact (~MB) 시 message rate 1/20.
-        const ARTIFACT_CHUNK_FLUSH_MS = 50;
+        // ID 별 throttle 윈도우(WS_LIMITS.ARTIFACT_CHUNK_FLUSH_MS)로 buffer 후 합쳐서 1회 dispatch.
+        const ARTIFACT_CHUNK_FLUSH_MS = WS_LIMITS.ARTIFACT_CHUNK_FLUSH_MS;
         const chunkBuffers = new Map<string, { delta: string; timer: ReturnType<typeof setTimeout> | null }>();
         const streamedArtifactIds = new Set<string>();
         const flushArtifactChunk = (id: string) => {


### PR DESCRIPTION
비즈니스 로직 인라인 매직넘버를 명명 config 상수(env 오버라이드)로 외부화. **값 기본값 동일 → 동작 무변경**.

## 변경
- `cluster/config.ts`: discoveryPort/heartbeatInterval/nodeTimeout → env
- `WS_LIMITS`: `MAX_MESSAGE_CHARS`(handler 1MB 가드) + `ARTIFACT_CHUNK_FLUSH_MS`(50ms throttle) 신규
- `api-key-limiter`: windowMs/retry_after → `API_KEY_LIMITS.windowMs` 파생
- `CONVERSATION_LIMITS` 신규: getSession 500 · 세션목록 50/100 · getMessages 200/cap 1000 · per-session 50
- `RETRY_DEFAULTS`: `SLOW_QUERY_WARN_MS`(1000) · `JITTER_MAX_MS`(100) 신규
- `.env.example`: 신규 env 14개 문서화

## 검증
백엔드 `tsc` 0, `build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)