### PR TITLE
chore(hardcode): Step 2 (C) — convention-checker truncation 캡 외부화

### DIFF
--- a/apps/api/src/agents/git-ingest/convention-checker.ts
+++ b/apps/api/src/agents/git-ingest/convention-checker.ts
@@ -9,6 +9,7 @@
 import type { LLMClient } from '../../llm/client';
 import type { ChatMessage } from '../../llm/types';
 import { createLogger } from '../../utils/logger';
+import { CONVENTION_CHECK_LIMITS } from '../../config/runtime-limits';
 import { MCP_INGEST } from '../../config/constants';
 
 const logger = createLogger('ConventionChecker');
@@ -47,7 +48,7 @@ export class ConventionChecker {
     constructor(private llm: Pick<LLMClient, 'chat'>) {}
 
     async check(manifestYaml: string, promptBody: string): Promise<ConventionCheckResult> {
-        const userContent = `## YAML frontmatter\n\`\`\`yaml\n${manifestYaml.slice(0, 4000)}\n\`\`\`\n\n## Body\n${promptBody.slice(0, 8000)}`;
+        const userContent = `## YAML frontmatter\n\`\`\`yaml\n${manifestYaml.slice(0, CONVENTION_CHECK_LIMITS.MANIFEST_YAML_MAX_CHARS)}\n\`\`\`\n\n## Body\n${promptBody.slice(0, CONVENTION_CHECK_LIMITS.PROMPT_BODY_MAX_CHARS)}`;
         const messages: ChatMessage[] = [
             { role: 'system', content: SYSTEM_PROMPT },
             { role: 'user', content: userContent },

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -606,6 +606,12 @@ export const TOOL_RESULT_COMPACTION = {
 /** 도구 결과를 LLM 컨텍스트로 주입할 때 단일 결과 최대 문자 수 (외부 provider · agent task 공용). */
 export const MAX_TOOL_RESULT_CHARS = parseInt(process.env.MAX_TOOL_RESULT_CHARS || '8000', 10);
 
+/** Git-ingest 컨벤션 검사 시 LLM 입력 truncation 캡. */
+export const CONVENTION_CHECK_LIMITS = {
+    MANIFEST_YAML_MAX_CHARS: parseInt(process.env.CONVENTION_CHECK_YAML_MAX || '4000', 10),
+    PROMPT_BODY_MAX_CHARS: parseInt(process.env.CONVENTION_CHECK_BODY_MAX || '8000', 10),
+} as const;
+
 /** 대화 조회 limit (conversation-sessions / conversation-messages). */
 export const CONVERSATION_LIMITS = {
     /** getSession() 단일 세션 상세의 메시지 로드 상한 */


### PR DESCRIPTION
## 변경
git-ingest 컨벤션 검사의 LLM 입력 truncation 매직넘버 `4000`/`8000` → `CONVENTION_CHECK_LIMITS` config(env).
- `runtime-limits`: `CONVENTION_CHECK_LIMITS`(MANIFEST_YAML_MAX_CHARS/PROMPT_BODY_MAX_CHARS) 신규
- `convention-checker.ts`: `.slice(0, 4000/8000)` → config 참조

## 보류 (의도적)
`prompt.ts` identity/discipline 가드 · `discussion-engine` evaluationPrompt 인라인 프롬프트 외부화는 보류:
1. 이미 **프롬프트 전용 모듈**(prompt.ts/discussion-engine)에 위치 — 정책의 "비즈니스 로직에 인라인 금지" 취지 충족
2. 모든 **system prompt/토론에 주입**되는 문자열 → 재배치 시 trailing whitespace 한 글자 차이가 전 응답 동작에 영향 → **위험 > 일관성 이득**
3. `convention-checker` SYSTEM_PROMPT 도 모듈 top-level const라 양호(유지)

원하시면 byte-identity 검증(원문 바이트 추출 비교)과 함께 진행 가능.

## 검증
백엔드 `tsc` 0, `build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)