### PR TITLE
chore(hardcode): Step 3 (D) — apps/web 클라이언트 타이밍 상수 모듈

### DIFF
--- a/apps/web/app/(workspace)/mcp-monitoring/page.tsx
+++ b/apps/web/app/(workspace)/mcp-monitoring/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { RefreshCw, AlertTriangle } from "lucide-react";
+import { CLIENT_TIMING } from "@/lib/config";
 import {
   Button,
   Badge,
@@ -199,7 +200,7 @@ export default function McpMonitoringPage() {
     };
     void tick();
     void loadExtraStats();
-    const id = setInterval(() => void tick(), 30_000);
+    const id = setInterval(() => void tick(), CLIENT_TIMING.MCP_MONITORING_REFRESH_MS);
     return () => {
       cancelled = true;
       clearInterval(id);

--- a/apps/web/app/(workspace)/research/page.tsx
+++ b/apps/web/app/(workspace)/research/page.tsx
@@ -25,6 +25,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { ApiClient } from "@/lib/api-client";
+import { CLIENT_TIMING } from "@/lib/config";
 
 /* ── 타입 ────────────────────────────────────────────────── */
 type StageStatus = "done" | "running" | "pending";
@@ -265,12 +266,12 @@ export default function ResearchPage() {
       if (s && aliveRef.current) {
         applySession(s);
         if (!TERMINAL.includes(s.status)) {
-          pollRef.current = setTimeout(() => poll(sid), 2500);
+          pollRef.current = setTimeout(() => poll(sid), CLIENT_TIMING.RESEARCH_POLL_MS);
         }
       }
     } catch {
       /* 일시 실패 — 다음 틱에 재시도 */
-      if (aliveRef.current) pollRef.current = setTimeout(() => poll(sid), 4000);
+      if (aliveRef.current) pollRef.current = setTimeout(() => poll(sid), CLIENT_TIMING.RESEARCH_POLL_RETRY_MS);
     }
   };
 

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import type { ApiSuccess, MePayload } from "@openmake/shared-types";
 import { ApiClient } from "@/lib/api-client";
 import { useAppStore } from "@/lib/store";
+import { CLIENT_TIMING } from "@/lib/config";
 
 /**
  * 앱 마운트 시 /api/auth/me 로 현재 로그인 사용자를 store 에 동기화.
@@ -40,7 +41,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
     () =>
       new QueryClient({
-        defaultOptions: { queries: { staleTime: 30_000, retry: 1 } },
+        defaultOptions: { queries: { staleTime: CLIENT_TIMING.QUERY_STALE_MS, retry: 1 } },
       }),
   );
 

--- a/apps/web/lib/config.ts
+++ b/apps/web/lib/config.ts
@@ -1,0 +1,28 @@
+/**
+ * 클라이언트 타이밍/한계 상수 (No-Hardcoding 정책).
+ *
+ * 폴링 간격·타임아웃·backoff 등 매직넘버를 한 곳에 명명 상수로 모은다.
+ * NEXT_PUBLIC_* 환경변수로 빌드타임 오버라이드 가능(미설정 시 기본값).
+ *
+ * @module lib/config
+ */
+
+function envNum(v: string | undefined, d: number): number {
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? n : d;
+}
+
+export const CLIENT_TIMING = {
+  /** 딥리서치 진행 폴링 간격(ms) */
+  RESEARCH_POLL_MS: envNum(process.env.NEXT_PUBLIC_RESEARCH_POLL_MS, 2500),
+  /** 딥리서치 폴링 일시 실패 시 재시도 간격(ms) */
+  RESEARCH_POLL_RETRY_MS: envNum(process.env.NEXT_PUBLIC_RESEARCH_POLL_RETRY_MS, 4000),
+  /** MCP 모니터링 자동 새로고침 간격(ms) */
+  MCP_MONITORING_REFRESH_MS: envNum(process.env.NEXT_PUBLIC_MCP_MONITORING_REFRESH_MS, 30_000),
+  /** WebSocket 재연결 backoff 기본값(ms) — 실제 지연 = base * 2^attempt (MAX 상한) */
+  WS_RECONNECT_BASE_MS: envNum(process.env.NEXT_PUBLIC_WS_RECONNECT_BASE_MS, 1000),
+  /** WebSocket 재연결 backoff 상한(ms) */
+  WS_RECONNECT_MAX_MS: envNum(process.env.NEXT_PUBLIC_WS_RECONNECT_MAX_MS, 10_000),
+  /** react-query staleTime(ms) */
+  QUERY_STALE_MS: envNum(process.env.NEXT_PUBLIC_QUERY_STALE_MS, 30_000),
+} as const;

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { WsChatRequest, WsServerEvent, WsAttachedFile } from "@openmake/shared-types";
 import { useAppStore } from "./store";
+import { CLIENT_TIMING } from "./config";
 
 /**
  * 채팅 WebSocket hook — 백엔드 sockets/ws-chat-handler.ts 프로토콜.
@@ -108,7 +109,10 @@ export function useChatSocket() {
       setStreaming(false);
       // 지수 백오프 재연결 (최대 10회)
       if (reconnectRef.current < 10) {
-        const delay = Math.min(1000 * 2 ** reconnectRef.current, 10000);
+        const delay = Math.min(
+          CLIENT_TIMING.WS_RECONNECT_BASE_MS * 2 ** reconnectRef.current,
+          CLIENT_TIMING.WS_RECONNECT_MAX_MS,
+        );
         reconnectRef.current += 1;
         setTimeout(connect, delay);
       }


### PR DESCRIPTION
apps/web 의 폴링/타임아웃/backoff 매직넘버를 `lib/config.ts`의 명명 상수(`CLIENT_TIMING`, `NEXT_PUBLIC_*` env 오버라이드)로 통합. **값 기본값 동일 → 동작 무변경**.

## 변경
- **`lib/config.ts` 신규**: RESEARCH_POLL_MS·RESEARCH_POLL_RETRY_MS·MCP_MONITORING_REFRESH_MS·WS_RECONNECT_BASE_MS·WS_RECONNECT_MAX_MS·QUERY_STALE_MS
- `use-chat-socket.ts`: WS 재연결 backoff(1000/10000) → 상수
- `research/page.tsx`: 폴링(2500/4000) → 상수
- `mcp-monitoring/page.tsx`: 새로고침(30000) → 상수
- `providers.tsx`: react-query staleTime(30000) → 상수

## 검증
`next build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)