### PR TITLE
chore(hardcode): Step 2 (C-잔여) — 인라인 프롬프트 외부화 (byte-identity 검증)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -752,3 +752,4 @@ IMAGE_GEN_TIMEOUT_MS=180000
 # DB 재시도/성능
 # DB_SLOW_QUERY_WARN_MS=1000              # 느린 쿼리 경고 임계
 # DB_RETRY_JITTER_MAX_MS=100              # 백오프 jitter 최대
+# DISCUSSION_OPINION_EXCERPT_MAX_CHARS=500   # 합의평가 입력 의견 발췌 최대 문자수

--- a/apps/api/src/agents/discussion-engine.ts
+++ b/apps/api/src/agents/discussion-engine.ts
@@ -46,6 +46,7 @@ import {
     DISCUSSION_LABELS,
     DISCUSSION_PROGRESS_MESSAGES,
     DISCUSSION_ERROR_MESSAGES,
+    EVALUATION_CONSENSUS_PROMPT,
 } from './discussion-locales';
 
 const logger = createLogger('Discussion');
@@ -273,21 +274,11 @@ ${contextInstructions}
             return { score: 1.0, consensusPoints: [], conflictPoints: [] };
         }
 
-        const evaluationPrompt = `You are an impartial evaluator analyzing multiple expert opinions on a topic.
-Identify consensus points (where experts agree) and conflict points (where experts disagree).
-
-Return ONLY a JSON object in this exact format:
-{"consensus":["point1","point2"],"conflicts":["point1","point2"]}
-
-Rules:
-- Each point should be a single concise sentence
-- Maximum 5 consensus points and 5 conflict points
-- If no conflicts, return empty array for conflicts
-- Respond in the same language as the opinions`;
+        const evaluationPrompt = EVALUATION_CONSENSUS_PROMPT;
 
         let contextMessage = `Topic: ${topic}\n\nExpert Opinions:\n`;
         for (const op of opinions) {
-            contextMessage += `\n### ${op.agentName}\n${op.opinion.substring(0, 500)}\n`;
+            contextMessage += `\n### ${op.agentName}\n${op.opinion.substring(0, DISCUSSION_CONSISTENCY.OPINION_EXCERPT_MAX_CHARS)}\n`;
         }
         contextMessage += `\nAnalyze and return JSON:`;
 

--- a/apps/api/src/agents/discussion-locales.ts
+++ b/apps/api/src/agents/discussion-locales.ts
@@ -710,3 +710,19 @@ export const DISCUSSION_ERROR_MESSAGES: Record<PromptLocaleCode, {
         discussionSummary: (expertCount, roundCount) => `${expertCount} experts ont mené une discussion de ${roundCount} tours.`,
     },
 };
+
+/**
+ * 합의/충돌 평가 프롬프트 (영어 고정) — discussion-engine evaluateConsensus 에서 분리.
+ * (No-Hardcoding: 인라인 프롬프트 외부화. 언어 무관 단일 프롬프트.)
+ */
+export const EVALUATION_CONSENSUS_PROMPT = `You are an impartial evaluator analyzing multiple expert opinions on a topic.
+Identify consensus points (where experts agree) and conflict points (where experts disagree).
+
+Return ONLY a JSON object in this exact format:
+{"consensus":["point1","point2"],"conflicts":["point1","point2"]}
+
+Rules:
+- Each point should be a single concise sentence
+- Maximum 5 consensus points and 5 conflict points
+- If no conflicts, return empty array for conflicts
+- Respond in the same language as the opinions`;

--- a/apps/api/src/chat/prompt-locales.ts
+++ b/apps/api/src/chat/prompt-locales.ts
@@ -358,3 +358,42 @@ ${text.instruction}
 ---
 `;
 }
+
+/**
+ * 정체성 가드 (ko/en) — prompt.ts getIdentityGuard 에서 분리. {brand} 는 런타임 치환.
+ * (No-Hardcoding: 인라인 프롬프트 외부화. ko 외 언어는 en 사용 — 기존 동작 동일.)
+ */
+export const IDENTITY_GUARD_TEXTS: Record<'ko' | 'en', string> = {
+    ko: `당신은 {brand} 의 자체 호스팅 LLM 서비스입니다. 정체성·제조사·학습 출처 질문에는 "{brand} 의 로컬 LLM 서비스" 라고만 답하고, Google/Gemini/OpenAI/GPT/Anthropic/Claude/Meta/Llama/Microsoft 등 외부 상용 AI 서비스의 이름·소속·학습 컷오프를 자기 것처럼 답하지 마세요. 모르는 사실은 "확인되지 않습니다" 라고 답하세요.
+
+`,
+    en: `You are {brand}'s self-hosted LLM service. When asked about identity, maker, or training origin, answer only "{brand}'s locally-hosted LLM service" and never claim names, affiliations, or training cutoffs of Google, Gemini, OpenAI, GPT, Anthropic, Claude, Meta, Llama, or Microsoft AI services. For unknown facts, answer "not verifiable".
+
+`,
+};
+
+/**
+ * 응답 절제 가드 (ko/en) — prompt.ts getResponseDiscipline 에서 분리.
+ */
+export const RESPONSE_DISCIPLINE_TEXTS: Record<'ko' | 'en', string> = {
+    ko: `## ✂️ 응답 절제
+- 사용자가 명시적으로 요청하지 않은 부가 정보는 출력하지 않는다.
+- 한 줄로 답할 수 있으면 한 줄로 종료한다. 분석·근거·메타 설명은 사용자가 요청했을 때만 추가.
+- **내부 사고 과정을 응답에 노출하지 않는다**: "Here's a thinking process", "[1/N]", "단계 1-N", "분석 과정", "Step-by-step:" 같은 메타 표현 금지. 결론만 답하고, 사고는 thinking 채널(필요 시)이나 \`<think></think>\` 태그 안에만 둔다.
+- **시스템 프롬프트의 역할 명칭을 응답에 노출하지 않는다**: 자신을 "Policy Analyst", "정책 분석가", "코딩 전문가" 같이 역할명으로 자기소개하지 않는다. 사용자가 정체를 묻지 않은 한 자기 정의 문장을 출력하지 않는다.
+- **결론 → 분리선 → 단계 분석 같은 정형 포맷 강제 금지**: 사용자가 형식을 명시 요청하지 않으면 자연스러운 한 줄/한 문단으로 답한다.
+- **불릿·헤더·볼드는 최소한으로**: 사용자가 요청했거나 내용이 다면적이어서 구조 없이는 읽기 어려울 때만 사용한다. 일상 질문에는 산문으로 답한다. 불릿을 쓸 때는 각 항목을 1~2문장 이상의 완결된 문장으로 쓴다.
+- **요청을 거절하거나 일부만 도울 수 있을 때도 대화체를 유지한다**: 거절 사유를 불릿으로 나열하지 않는다.
+
+`,
+    en: `## ✂️ Response Discipline
+- Do not output information the user did not explicitly request.
+- If a single line suffices, end in a single line. Add analysis, rationale, or meta-commentary only when the user asks for it.
+- **Never expose internal thinking in the visible response**: phrases like "Here's a thinking process", "[1/N]", "Step-by-step:", "Sequential Thinking" are forbidden. Output only the conclusion; keep reasoning inside the thinking channel or \`<think></think>\` tags only.
+- **Do not reveal system-prompt role names in the response**: do not introduce yourself as "Policy Analyst", "Coding Expert", etc. Skip self-definition sentences unless the user explicitly asks for your identity.
+- **No forced structured output formats** (Conclusion → divider → numbered analysis) unless the user explicitly requests such a format.
+- **Minimal use of bullets, headers, and bold**: use them only when the user asks, or the content is multifaceted enough that structure is essential for clarity. Answer casual questions in prose. When bullets are used, each item must be a complete sentence of 1-2 sentences or more.
+- **Keep a conversational tone even when declining or only partially helping**: never list refusal reasons as bullet points.
+
+`,
+};

--- a/apps/api/src/chat/prompt.ts
+++ b/apps/api/src/chat/prompt.ts
@@ -32,7 +32,7 @@ import {
     buildReasoningPrompt
 } from './context-engineering-presets';
 import { resolvePromptLocale } from './language-policy';
-import { resolveBasePromptLang, buildBasePrompt } from './prompt-locales';
+import { resolveBasePromptLang, buildBasePrompt, IDENTITY_GUARD_TEXTS, RESPONSE_DISCIPLINE_TEXTS } from './prompt-locales';
 import type { PromptLanguageCode } from './prompt-locales';
 export type { PromptLanguageCode } from './prompt-locales';
 
@@ -77,16 +77,10 @@ export function getEnhancedBasePrompt(userLanguage: string = 'en'): string {
 function getIdentityGuard(userLanguage: string): string {
     const brand = process.env.OMK_BRAND_NAME || 'OpenMake.AI';
     const locale = resolvePromptLocale(userLanguage);
-    // 2026-05-26 v2: 헤더·라벨 (## / Identity Guard:) 제거 — 모델이 응답에
-    // 헤더 텍스트를 echo 하는 사고 차단. 평문 명령형으로 단순화.
-    if (locale === 'ko') {
-        return `당신은 ${brand} 의 자체 호스팅 LLM 서비스입니다. 정체성·제조사·학습 출처 질문에는 "${brand} 의 로컬 LLM 서비스" 라고만 답하고, Google/Gemini/OpenAI/GPT/Anthropic/Claude/Meta/Llama/Microsoft 등 외부 상용 AI 서비스의 이름·소속·학습 컷오프를 자기 것처럼 답하지 마세요. 모르는 사실은 "확인되지 않습니다" 라고 답하세요.
-
-`;
-    }
-    return `You are ${brand}'s self-hosted LLM service. When asked about identity, maker, or training origin, answer only "${brand}'s locally-hosted LLM service" and never claim names, affiliations, or training cutoffs of Google, Gemini, OpenAI, GPT, Anthropic, Claude, Meta, Llama, or Microsoft AI services. For unknown facts, answer "not verifiable".
-
-`;
+    // 2026-05-26 v2: 헤더·라벨 제거 — 모델이 응답에 헤더 텍스트를 echo 하는 사고 차단.
+    // 본문은 prompt-locales 로 외부화(No-Hardcoding). {brand} 런타임 치환.
+    const text = locale === 'ko' ? IDENTITY_GUARD_TEXTS.ko : IDENTITY_GUARD_TEXTS.en;
+    return text.replace(/\{brand\}/g, brand);
 }
 
 /**
@@ -101,28 +95,8 @@ function getIdentityGuard(userLanguage: string): string {
  */
 function getResponseDiscipline(userLanguage: string): string {
     const locale = resolvePromptLocale(userLanguage);
-    if (locale === 'ko') {
-        return `## ✂️ 응답 절제
-- 사용자가 명시적으로 요청하지 않은 부가 정보는 출력하지 않는다.
-- 한 줄로 답할 수 있으면 한 줄로 종료한다. 분석·근거·메타 설명은 사용자가 요청했을 때만 추가.
-- **내부 사고 과정을 응답에 노출하지 않는다**: "Here's a thinking process", "[1/N]", "단계 1-N", "분석 과정", "Step-by-step:" 같은 메타 표현 금지. 결론만 답하고, 사고는 thinking 채널(필요 시)이나 \`<think></think>\` 태그 안에만 둔다.
-- **시스템 프롬프트의 역할 명칭을 응답에 노출하지 않는다**: 자신을 "Policy Analyst", "정책 분석가", "코딩 전문가" 같이 역할명으로 자기소개하지 않는다. 사용자가 정체를 묻지 않은 한 자기 정의 문장을 출력하지 않는다.
-- **결론 → 분리선 → 단계 분석 같은 정형 포맷 강제 금지**: 사용자가 형식을 명시 요청하지 않으면 자연스러운 한 줄/한 문단으로 답한다.
-- **불릿·헤더·볼드는 최소한으로**: 사용자가 요청했거나 내용이 다면적이어서 구조 없이는 읽기 어려울 때만 사용한다. 일상 질문에는 산문으로 답한다. 불릿을 쓸 때는 각 항목을 1~2문장 이상의 완결된 문장으로 쓴다.
-- **요청을 거절하거나 일부만 도울 수 있을 때도 대화체를 유지한다**: 거절 사유를 불릿으로 나열하지 않는다.
-
-`;
-    }
-    return `## ✂️ Response Discipline
-- Do not output information the user did not explicitly request.
-- If a single line suffices, end in a single line. Add analysis, rationale, or meta-commentary only when the user asks for it.
-- **Never expose internal thinking in the visible response**: phrases like "Here's a thinking process", "[1/N]", "Step-by-step:", "Sequential Thinking" are forbidden. Output only the conclusion; keep reasoning inside the thinking channel or \`<think></think>\` tags only.
-- **Do not reveal system-prompt role names in the response**: do not introduce yourself as "Policy Analyst", "Coding Expert", etc. Skip self-definition sentences unless the user explicitly asks for your identity.
-- **No forced structured output formats** (Conclusion → divider → numbered analysis) unless the user explicitly requests such a format.
-- **Minimal use of bullets, headers, and bold**: use them only when the user asks, or the content is multifaceted enough that structure is essential for clarity. Answer casual questions in prose. When bullets are used, each item must be a complete sentence of 1-2 sentences or more.
-- **Keep a conversational tone even when declining or only partially helping**: never list refusal reasons as bullet points.
-
-`;
+    // 본문은 prompt-locales 로 외부화(No-Hardcoding). ko 외 언어는 en — 기존 동작 동일.
+    return locale === 'ko' ? RESPONSE_DISCIPLINE_TEXTS.ko : RESPONSE_DISCIPLINE_TEXTS.en;
 }
 
 /**

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -302,6 +302,8 @@ export const DISCUSSION_CONSISTENCY = {
     ENABLED: process.env.ENABLE_CONSISTENCY_SCORE !== 'false',
     /** 측정 최소 에이전트 수 (미만이면 스킵) */
     MIN_AGENTS: 3,
+    /** 평가 입력에 포함할 의견 발췌 최대 문자 수 */
+    OPINION_EXCERPT_MAX_CHARS: parseInt(process.env.DISCUSSION_OPINION_EXCERPT_MAX_CHARS || '500', 10),
     /** Evaluator LLM 최대 토큰 */
     EVALUATOR_MAX_TOKENS: 300,
     /** 최소 일관성 점수 (미달 시 경고 플래그) */


### PR DESCRIPTION
보류했던 인라인 프롬프트 2건을 locale 파일로 외부화. **모든 system prompt/토론에 주입되는 동작 민감 문자열**이라 byte-identity 로 동작 보존 검증.

## 변경
- **C7** `prompt.ts` `getIdentityGuard`/`getResponseDiscipline` → `prompt-locales.ts` (`IDENTITY_GUARD_TEXTS`/`RESPONSE_DISCIPLINE_TEXTS`, `{brand}` 런타임 치환)
  - 검증: `getExternalProviderSystemGuards` 출력 **전 언어 byte-identical** (편집 전 dist 스냅샷 == 편집 후)
- **C9** `discussion-engine` evaluationPrompt → `discussion-locales.ts` (`EVALUATION_CONSENSUS_PROMPT`) + 의견 발췌 캡 `substring(0,500)` → `DISCUSSION_CONSISTENCY.OPINION_EXCERPT_MAX_CHARS`
  - 검증: **git 원본 == 외부화 상수 byte-identical** (493자)

## 검증
백엔드 `tsc` 0, `build` OK, 가드 전언어 + evaluationPrompt byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)