### PR TITLE
fix(artifact): 아티팩트 미리보기 실패 2원인 수정 (생성 가로챔 + 렌더러 미분기)

### DIFF
--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1007,6 +1007,31 @@ export const EXTERNAL_LLM_TOOL_BLACKLIST: readonly string[] = [
 ] as const;
 
 /**
+ * 명시적 아티팩트 생성 요청 턴에서 억제할 always-on 도구.
+ *
+ * 측정 근거 (2026-06-23 통제실험): "아티팩트로 html5 ... 작성해" 요청에서 qwen3.6 이
+ * `<artifact>` 산출물을 쓰는 대신 always-on 도구(generate_image / agent_task_list /
+ * agent_task_get)를 간헐 호출(~33%)해 아티팩트 생성이 실패(빈 응답). 동일 프롬프트로
+ * 도구를 제거하면 3/3 정상 생성됨. artifact-guide 시스템 프롬프트(주입돼 있음)로는 막지
+ * 못함 → 도구 레벨 조정. 이 도구들은 아티팩트 "생성"에 불필요하므로 명시적 아티팩트
+ * 요청 턴에서만 제외한다(이미지/에이전트 작업 조회 등 비-아티팩트 요청은 무영향).
+ *
+ * 값은 mcp/agent-task-tools.ts CHAT_ALWAYS_ON_TOOL_NAMES 와 일치 — always-on 으로
+ * 무조건 주입되는 도구들이 곧 distractor 이기 때문.
+ */
+export const ARTIFACT_REQUEST_SUPPRESSED_TOOLS: readonly string[] = [
+    'generate_image',
+    'agent_task_list',
+    'agent_task_get',
+] as const;
+
+/** 사용자 메시지가 명시적 아티팩트 생성 요청인지 판정하는 키워드 패턴. */
+export const ARTIFACT_INTENT_PATTERNS: readonly RegExp[] = [
+    /아티팩트/i,
+    /\bartifact\b/i,
+] as const;
+
+/**
  * 자율 에이전트 작업 (AgentTaskService) runaway 가드 한계.
  * 백그라운드 detached 실행이라 사람이 지켜보지 않으므로 토큰/시간 폭주 방지가 필수.
  */

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -13,7 +13,7 @@
  * @module services/chat-service/external-provider
  */
 import { createLogger } from '../../utils/logger';
-import { EXTERNAL_LLM_TOOL_BLACKLIST, LOOP_DETECTION, AGENT_LOOP_LIMITS, MAX_TOOL_RESULT_CHARS } from '../../config/runtime-limits';
+import { EXTERNAL_LLM_TOOL_BLACKLIST, LOOP_DETECTION, AGENT_LOOP_LIMITS, MAX_TOOL_RESULT_CHARS, ARTIFACT_REQUEST_SUPPRESSED_TOOLS, ARTIFACT_INTENT_PATTERNS } from '../../config/runtime-limits';
 import { getUnifiedMCPClient } from '../../mcp/unified-client';
 import { isPersistableUserId } from '../../utils/user-id-validation';
 import { getExternalProviderSystemGuards } from '../../chat/prompt';
@@ -151,9 +151,17 @@ export async function streamFromExternalProvider(
         throw err;
     }
 
+    // 명시적 아티팩트 생성 요청이면 distractor always-on 도구(generate_image 등)를 제외해
+    // 모델이 도구 호출 대신 <artifact> 산출물을 쓰도록 유도 (2026-06-23 통제실험 근거).
+    const wantsArtifact = ARTIFACT_INTENT_PATTERNS.some((re) => re.test(req.message ?? ''));
     const tools = caps.toolCalling
-        ? deps.allowedTools.filter((t) => !EXTERNAL_LLM_TOOL_BLACKLIST.includes(t.function.name))
+        ? deps.allowedTools.filter((t) =>
+            !EXTERNAL_LLM_TOOL_BLACKLIST.includes(t.function.name)
+            && !(wantsArtifact && ARTIFACT_REQUEST_SUPPRESSED_TOOLS.includes(t.function.name)))
         : [];
+    if (wantsArtifact && caps.toolCalling) {
+        logger.info(`[Artifact] 명시적 아티팩트 요청 감지 — distractor 도구 억제 (잔여 도구 ${tools.length}종)`);
+    }
 
     const startedAt = Date.now();
     let errorCode: string | null = null;

--- a/apps/web/components/chat/artifact-panel.tsx
+++ b/apps/web/components/chat/artifact-panel.tsx
@@ -5,7 +5,7 @@ import { X, Code2, Eye, Copy, Check, Play, Loader2 } from "lucide-react";
 import { useAppStore } from "@/lib/store";
 import type { Artifact } from "@/lib/store";
 import { ApiClient, ApiError } from "@/lib/api-client";
-import { isIframeKind, buildArtifactSrcDoc } from "@/lib/artifact-render";
+import { buildArtifactSrcDoc, previewKindFor } from "@/lib/artifact-render";
 import { ArtifactFrame } from "./artifact-frame";
 import { Markdown } from "./markdown";
 import { cn } from "@/lib/utils";
@@ -169,10 +169,12 @@ function ArtifactBody({ artifact, view }: { artifact: Artifact; view: "preview" 
     );
   }
   if (kind === "csv") return <CsvTable content={content} />;
-  if (kind === "code") return <CodeArtifactView artifact={artifact} />;
-  if (isIframeKind(kind)) {
-    return <ArtifactFrame srcDoc={buildArtifactSrcDoc(kind, content)} title={artifact.title} />;
+  // 미리보기 가능(html/svg/mermaid/chart/react) — kind=code+웹 lang(예: ```html 펜스) 포함
+  const previewKind = previewKindFor(kind, lang);
+  if (previewKind) {
+    return <ArtifactFrame srcDoc={buildArtifactSrcDoc(previewKind, content)} title={artifact.title} />;
   }
+  if (kind === "code") return <CodeArtifactView artifact={artifact} />;
   // 미지원 kind → 코드 폴백
   return (
     <div className="h-full overflow-auto px-3">
@@ -240,7 +242,7 @@ export function ArtifactPanel() {
     }
   };
 
-  const canToggle = isIframeKind(active.kind) && !active.streaming;
+  const canToggle = previewKindFor(active.kind, active.lang) !== null && !active.streaming;
 
   return (
     <aside className="fixed inset-0 z-40 flex w-full flex-col border-border bg-surface lg:static lg:inset-auto lg:z-auto lg:w-[44%] lg:max-w-[560px] lg:border-l">

--- a/apps/web/lib/artifact-render.ts
+++ b/apps/web/lib/artifact-render.ts
@@ -23,6 +23,32 @@ export function isIframeKind(kind: string): boolean {
   return IFRAME_KINDS.has(kind);
 }
 
+/**
+ * code 아티팩트의 lang → 미리보기 렌더 kind 매핑.
+ * LLM 이 ```html 같은 마크다운 펜스를 쓰면 backend fence-fallback 이 kind="code"+lang 으로
+ * 저장하므로(예: kind=code lang=html), 그 경우에도 미리보기 iframe 으로 렌더하기 위함.
+ */
+const CODE_LANG_PREVIEW: Record<string, string> = {
+  html: "html",
+  htm: "html",
+  svg: "svg",
+  mermaid: "mermaid",
+  mmd: "mermaid",
+  jsx: "react",
+  tsx: "react",
+};
+
+/**
+ * 이 아티팩트를 미리보기 iframe 으로 렌더할 kind 를 반환(없으면 null).
+ * - isIframeKind(kind) 면 그 kind
+ * - kind="code" 인데 lang 이 웹 렌더 가능(html/svg/mermaid/jsx/tsx)이면 매핑 kind
+ */
+export function previewKindFor(kind: string, lang: string | null | undefined): string | null {
+  if (isIframeKind(kind)) return kind;
+  if (kind === "code" && lang) return CODE_LANG_PREVIEW[lang.toLowerCase().trim()] ?? null;
+  return null;
+}
+
 /** HTML 텍스트 노드 이스케이프 (mermaid 소스 등 텍스트를 안전하게 삽입). */
 function escapeHtml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");


### PR DESCRIPTION
## 문제
채팅에서 아티팩트를 요청해도 미리보기가 안 됨. Playwright 라이브 재현 + LiteLLM 통제실험으로 **2개 원인**으로 격리.

## 진단 (경험적 격리)
**라이브 재현**: "html5 버튼 페이지 작성해" → frontend-developer 에이전트 자동배정 → LLM이 `<artifact>` 대신 `agent_task_list`→`generate_image` 도구 호출 → 빈 응답.

**통제실험** (LiteLLM 직접, artifact-guide 동일 주입, ×6):
| 조건 | 결과 |
|---|---|
| 도구 없음 ×3 | **3/3 `<artifact>` 정상 생성** ✅ |
| 도구 3종 있음 ×3 | 2/3 성공, **1/3 generate_image 호출 실패** ❌ |

→ `CHAT_ALWAYS_ON_TOOL_NAMES`(generate_image/agent_task_list/agent_task_get)가 토글 무관 모든 채팅에 주입돼 qwen3.6이 간헐 derail. **artifact-guide(6회 다 주입)로는 못 막음** → 도구 레벨 조정.

## 수정
**원인 B (지배적)** — `config/runtime-limits.ts` `ARTIFACT_REQUEST_SUPPRESSED_TOOLS`+`ARTIFACT_INTENT_PATTERNS`, `external-provider.ts`에서 명시적 아티팩트 요청(`req.message` 가 `/아티팩트|artifact/`) 시 distractor 도구 제외. 이미지/일반 채팅 무영향.

**원인 A (부수)** — `lib/artifact-render.ts` `previewKindFor(kind, lang)` 추가: `kind=code`+웹 lang(html/svg/mermaid)이면 미리보기 iframe 렌더. `artifact-panel.tsx` 분기·`canToggle` 교체. 과거 저장된 `code/html` 도 함께 복구.

## 검증
라이브 배포 후 동일 프롬프트:
- WS `artifact_start → chunk → end` 정상 ✅
- 미리보기 iframe 내부 `<button>` 실제 렌더 확인 ✅
- 콘솔 에러 없음

## 체크리스트
- [x] 백엔드 tsc 0 에러 / 프론트 build 성공
- [x] 라이브 배포 + Playwright 검증 완료
- [ ] No-Hardcoding: distractor 목록·의도 패턴 모두 config(L2)로 외부화

🤖 Generated with [Claude Code](https://claude.com/claude-code)