### PR TITLE
fix(artifact): 공유 뷰어 react 렌더 + bootstrap 캐시버스팅

### DIFF
--- a/apps/api/src/services/artifact-viewer-service.ts
+++ b/apps/api/src/services/artifact-viewer-service.ts
@@ -77,15 +77,14 @@ function chromeBar(input: BuildInput): string {
 </div>`;
 }
 
-/** 뷰어 오리진에 self-host 된 라이브러리 경로. */
+/**
+ * 뷰어 오리진에 self-host 된 라이브러리 경로.
+ * bootstrap.js(우리 코드)는 변경되므로 캐시버스팅 버전 부여 — /vendor 가 immutable 캐시라
+ * 버전 없이는 갱신이 전파되지 않는다. bootstrap.js 수정 시 BOOTSTRAP_VERSION 을 올린다.
+ */
+const BOOTSTRAP_VERSION = '5';
 const VENDOR = {
-    mermaid: '/vendor/mermaid.min.js',
-    chart: '/vendor/chart.umd.min.js',
-    react: '/vendor/react.production.min.js',
-    reactDom: '/vendor/react-dom.production.min.js',
-    babel: '/vendor/babel.min.js',
-    marked: '/vendor/marked.min.js',
-    bootstrap: '/vendor/bootstrap.js',
+    bootstrap: `/vendor/bootstrap.js?v=${BOOTSTRAP_VERSION}`,
 };
 
 /**

--- a/infra/artifact-viewer/vendor/bootstrap.js
+++ b/infra/artifact-viewer/vendor/bootstrap.js
@@ -97,8 +97,15 @@
           return load("/vendor/babel.min.js");
         }).then(function () {
           /* global Babel, React, ReactDOM */
+          // 브라우저 단일파일 — ES import 불가. ① 사용자 import 제거 ② 훅을 전역 React 에서 별칭
+          // ③ classic JSX runtime(React.createElement) 강제 — automatic 은 jsx-runtime import 를 삽입해 깨짐.
           var src = content.replace(/export\s+default\s+/g, "");
-          var out = Babel.transform(src, { presets: ["react", "typescript"], filename: "artifact.tsx" }).code;
+          src = src.replace(/^[ \t]*import\s+[^\n;]+;?[ \t]*$/gm, "");
+          var prelude = "const {useState,useEffect,useRef,useMemo,useCallback,useContext,useReducer,useLayoutEffect,Fragment,createElement}=React;\n";
+          var out = Babel.transform(prelude + src, {
+            presets: [["react", { runtime: "classic" }], "typescript"],
+            filename: "artifact.tsx",
+          }).code;
           // App 컴포넌트를 정의/반환 (react 종류만 meta CSP 에 'unsafe-eval' 부여)
           var factory = new Function("React", "ReactDOM", out + "\n;return typeof App!=='undefined'?App:null;");
           var App = factory(React, ReactDOM);


### PR DESCRIPTION
## 개요
PR #184(공유 뷰어) 후속. Playwright MCP 라이브 검증 중 발견한 react 렌더 버그 수정 + bootstrap 캐시버스팅.

## 수정
- **react 렌더 실패**: Babel react preset 의 automatic JSX runtime 이 `import { jsx } from "react/jsx-runtime"` 를 자동 삽입 → 브라우저 단일파일 뷰어에서 `Cannot use import statement` 로 깨짐. **classic runtime**(`{runtime:'classic'}`) 강제 → `React.createElement` 출력으로 정상 렌더. 사용자 ES import 제거 + React 훅 전역 별칭(self-contained react 지원).
- **bootstrap 캐시버스팅**: `/vendor` 가 immutable 캐시라 bootstrap.js 갱신이 전파 안 됨 → `BOOTSTRAP_VERSION` 쿼리(`?v=N`). 수정 시 버전 올림.

## 검증 (Playwright MCP 직접)
| 종류 | 결과 |
|---|---|
| html | ✅ 풀 랜딩페이지 렌더 |
| svg | ✅ 도형 렌더 |
| chart | ✅ Chart.js 막대그래프 |
| mermaid | ✅ 플로차트 |
| react | ✅ 카운터 컴포넌트(수정 후) |

모두 strict CSP·별도 오리진·외부요청 0, 접근제어 403 deny 확인.

> 참고(별도 이슈): in-app 패널의 react 렌더러(`lib/artifact-render.ts`)도 동일하게 automatic runtime 을 쓰므로 같은 한계가 있을 수 있음 — 별도 추적.

🤖 Generated with [Claude Code](https://claude.com/claude-code)