### PR TITLE
fix(artifact): in-app react 렌더러 classic JSX runtime 적용

### DIFF
--- a/apps/web/lib/artifact-render.ts
+++ b/apps/web/lib/artifact-render.ts
@@ -98,14 +98,25 @@ export function buildArtifactSrcDoc(kind: string, content: string): string {
       );
     }
     case "react": {
-      // export default 제거 → Babel(text/babel) 은 ES module export 미지원. App 정의 후 렌더.
-      const code = escapeScript(content.replace(/export\s+default\s+/g, ""));
+      // 브라우저 단일파일 — ES import/export 불가. ① export default·import 제거(regex 는 여기서 처리)
+      // ② Babel JS API + classic JSX runtime(React.createElement) — automatic 은 jsx-runtime import 를
+      //    삽입해 "Cannot use import statement" 로 깨짐 ③ 훅을 전역 React 에서 별칭.
+      const stripped = content
+        .replace(/export\s+default\s+/g, "")
+        .replace(/^[ \t]*import\s+[^\n;]+;?[ \t]*$/gm, "");
+      const codeJson = escapeScript(JSON.stringify(stripped));
       return doc(
         `<script src="${CDN.react}"></script><script src="${CDN.reactDom}"></script><script src="${CDN.babel}"></script>${BASE_STYLE}`,
-        `<div id="root"></div><script type="text/babel" data-presets="react,typescript">
-${code}
-try{ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));}
-catch(e){document.getElementById('root').innerHTML='<pre>렌더 오류: '+e.message+'</pre>';}
+        `<div id="root"></div><script>
+(function(){
+  try{
+    var prelude="const {useState,useEffect,useRef,useMemo,useCallback,useContext,useReducer,useLayoutEffect,Fragment,createElement}=React;\\n";
+    var out=Babel.transform(prelude+${codeJson},{presets:[["react",{runtime:"classic"}],"typescript"],filename:"a.tsx"}).code;
+    var App=new Function("React","ReactDOM",out+"\\n;return typeof App!=='undefined'?App:null;")(React,ReactDOM);
+    if(!App){document.getElementById('root').innerHTML='<pre>App 컴포넌트를 찾을 수 없음 (export default function App 필요)</pre>';return;}
+    ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));
+  }catch(e){document.getElementById('root').innerHTML='<pre>렌더 오류: '+e.message+'</pre>';}
+})();
 </script>`,
       );
     }


### PR DESCRIPTION
## 개요
PR #185(공유 뷰어 react 수정) 후속. 채팅 패널의 react 아티팩트 렌더러(`lib/artifact-render.ts`)도 동일한 **automatic JSX runtime 버그**를 갖고 있어 같은 방식으로 수정.

## 문제
`<script type="text/babel" data-presets="react,typescript">` 자동변환이 automatic runtime 으로 동작 → `import { jsx } from "react/jsx-runtime"` 삽입 → 브라우저 단일파일(srcdoc iframe)에서 `Cannot use import statement` 로 react 아티팩트가 깨짐.

## 수정
`<script type="text/babel">` 자동변환 → **JS API + classic runtime** 으로 교체:
- `export default`·ES `import` 제거 (regex 는 TS 에서 처리 → 임베드 이스케이프 함정 회피)
- `Babel.transform({presets:[["react",{runtime:"classic"}],"typescript"]})` → `React.createElement` 출력(import 없음)
- React 훅 전역 별칭(self-contained react 지원)
- 콘텐츠는 `JSON.stringify` + `escapeScript` 로 안전 임베드

## 검증 (Playwright)
`buildArtifactSrcDoc("react", ...)` 출력의 import 잔여 0, 카운터 컴포넌트 정상 렌더 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)