### PR TITLE
fix(artifact): react 렌더러 — 이름 무관 export default 캡처

### DIFF
--- a/apps/api/src/services/artifact-viewer-service.ts
+++ b/apps/api/src/services/artifact-viewer-service.ts
@@ -82,7 +82,7 @@ function chromeBar(input: BuildInput): string {
  * bootstrap.js(우리 코드)는 변경되므로 캐시버스팅 버전 부여 — /vendor 가 immutable 캐시라
  * 버전 없이는 갱신이 전파되지 않는다. bootstrap.js 수정 시 BOOTSTRAP_VERSION 을 올린다.
  */
-const BOOTSTRAP_VERSION = '5';
+const BOOTSTRAP_VERSION = '6';
 const VENDOR = {
     bootstrap: `/vendor/bootstrap.js?v=${BOOTSTRAP_VERSION}`,
 };

--- a/apps/web/lib/artifact-render.ts
+++ b/apps/web/lib/artifact-render.ts
@@ -101,8 +101,9 @@ export function buildArtifactSrcDoc(kind: string, content: string): string {
       // 브라우저 단일파일 — ES import/export 불가. ① export default·import 제거(regex 는 여기서 처리)
       // ② Babel JS API + classic JSX runtime(React.createElement) — automatic 은 jsx-runtime import 를
       //    삽입해 "Cannot use import statement" 로 깨짐 ③ 훅을 전역 React 에서 별칭.
+      // export default 를 변수로 캡처(컴포넌트 이름 무관) + import 제거.
       const stripped = content
-        .replace(/export\s+default\s+/g, "")
+        .replace(/export\s+default\s+/g, "\n__artifactDefault = ")
         .replace(/^[ \t]*import\s+[^\n;]+;?[ \t]*$/gm, "");
       const codeJson = escapeScript(JSON.stringify(stripped));
       return doc(
@@ -110,11 +111,11 @@ export function buildArtifactSrcDoc(kind: string, content: string): string {
         `<div id="root"></div><script>
 (function(){
   try{
-    var prelude="const {useState,useEffect,useRef,useMemo,useCallback,useContext,useReducer,useLayoutEffect,Fragment,createElement}=React;\\n";
+    var prelude="var __artifactDefault;const {useState,useEffect,useRef,useMemo,useCallback,useContext,useReducer,useLayoutEffect,Fragment,createElement}=React;\\n";
     var out=Babel.transform(prelude+${codeJson},{presets:[["react",{runtime:"classic"}],"typescript"],filename:"a.tsx"}).code;
-    var App=new Function("React","ReactDOM",out+"\\n;return typeof App!=='undefined'?App:null;")(React,ReactDOM);
-    if(!App){document.getElementById('root').innerHTML='<pre>App 컴포넌트를 찾을 수 없음 (export default function App 필요)</pre>';return;}
-    ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));
+    var Comp=new Function("React","ReactDOM",out+"\\n;return __artifactDefault||(typeof App!=='undefined'?App:null);")(React,ReactDOM);
+    if(!Comp){document.getElementById('root').innerHTML='<pre>컴포넌트를 찾을 수 없음 (export default 필요)</pre>';return;}
+    ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(Comp));
   }catch(e){document.getElementById('root').innerHTML='<pre>렌더 오류: '+e.message+'</pre>';}
 })();
 </script>`,

--- a/infra/artifact-viewer/vendor/bootstrap.js
+++ b/infra/artifact-viewer/vendor/bootstrap.js
@@ -99,18 +99,18 @@
           /* global Babel, React, ReactDOM */
           // 브라우저 단일파일 — ES import 불가. ① 사용자 import 제거 ② 훅을 전역 React 에서 별칭
           // ③ classic JSX runtime(React.createElement) 강제 — automatic 은 jsx-runtime import 를 삽입해 깨짐.
-          var src = content.replace(/export\s+default\s+/g, "");
+          // export default 를 변수로 캡처(컴포넌트 이름 무관) + import 제거.
+          var src = content.replace(/export\s+default\s+/g, "\n__artifactDefault = ");
           src = src.replace(/^[ \t]*import\s+[^\n;]+;?[ \t]*$/gm, "");
-          var prelude = "const {useState,useEffect,useRef,useMemo,useCallback,useContext,useReducer,useLayoutEffect,Fragment,createElement}=React;\n";
+          var prelude = "var __artifactDefault;const {useState,useEffect,useRef,useMemo,useCallback,useContext,useReducer,useLayoutEffect,Fragment,createElement}=React;\n";
           var out = Babel.transform(prelude + src, {
             presets: [["react", { runtime: "classic" }], "typescript"],
             filename: "artifact.tsx",
           }).code;
-          // App 컴포넌트를 정의/반환 (react 종류만 meta CSP 에 'unsafe-eval' 부여)
-          var factory = new Function("React", "ReactDOM", out + "\n;return typeof App!=='undefined'?App:null;");
-          var App = factory(React, ReactDOM);
-          if (!App) return fail("react: App 컴포넌트를 찾을 수 없음 (export default function App 필요)");
-          ReactDOM.createRoot(mount).render(React.createElement(App));
+          var factory = new Function("React", "ReactDOM", out + "\n;return __artifactDefault||(typeof App!=='undefined'?App:null);");
+          var Comp = factory(React, ReactDOM);
+          if (!Comp) return fail("react: 컴포넌트를 찾을 수 없음 (export default 필요)");
+          ReactDOM.createRoot(mount).render(React.createElement(Comp));
         }).catch(function (e) { fail("react: " + e.message); });
         break;
       }


### PR DESCRIPTION
## 개요
채팅창 라이브 테스트(Playwright)에서 발견. classic runtime 적용(PR #185/#186) 후에도 "App 컴포넌트를 찾을 수 없음" 에러 — LLM 이 컴포넌트를 `App` 이 아닌 이름(`Counter` 등)으로 `export default` 하는데 렌더러가 `App` 만 찾았음.

## 수정
`export default ` → `__artifactDefault = ` 로 치환해 **컴포넌트 이름과 무관하게** default export 값을 캡처 → `return __artifactDefault || App`. 공유 뷰어(`bootstrap.js`) + in-app(`artifact-render.ts`) 양쪽 동일 적용.

## 검증 (실채팅 Playwright MCP)
"React 카운터 컴포넌트를 아티팩트로 만들어줘" → `code/jsx` 아티팩트 생성 → 인앱 패널에 **카운터(증가/초기화 버튼) 정상 렌더** 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)