### PR TITLE
feat(artifact): 스트리밍 중 '아티팩트 생성 중' 라이브 인디케이터

### DIFF
--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -30,8 +30,40 @@ function ArtifactChip({ id }: { id: string }) {
   );
 }
 
+/** 스트리밍 중 길어지는 미완성 코드 펜스 → "아티팩트 생성 중" 표시 (완료 시 칩/패널로 대체). */
+function ArtifactBuilding() {
+  return (
+    <span className="my-1 inline-flex items-center gap-1.5 rounded-md border border-border bg-surface-2 px-2.5 py-1.5 text-sm font-medium text-fg-2">
+      <FileCode2 className="h-4 w-4 animate-pulse text-accent" />
+      아티팩트 생성 중…
+    </span>
+  );
+}
+
 /** assistant 본문 — `[[artifact:id]]` placeholder 를 칩으로, 나머지는 Markdown 으로. */
-function AssistantContent({ content }: { content: string }) {
+function AssistantContent({ content, streaming }: { content: string; streaming?: boolean }) {
+  // 스트리밍 중 닫히지 않은(길어지는) 코드 펜스는 fence-fallback 으로 아티팩트가 될 가능성이 높다.
+  // 원시 코드를 71초간 흘리는 대신 "생성 중" 인디케이터로 즉시 피드백 (완료 시 칩/패널로 교체).
+  // 명시적 <artifact> 태그 경로는 ws 가 이미 라이브 패널을 열므로 여기 대상 아님.
+  if (streaming && !content.includes("[[artifact:")) {
+    const fenceCount = (content.match(/```/g) || []).length;
+    if (fenceCount % 2 === 1) {
+      const lastOpen = content.lastIndexOf("```");
+      const fenceOpen = content.slice(lastOpen, lastOpen + 24);
+      // 렌더 가능한 lang(html/svg/mermaid/chart/react)은 즉시, 일반 코드는 길어질 때(≥12줄) 표시.
+      const renderable = /```\s*(html|svg|mermaid|chart|jsx|tsx|react)/i.test(fenceOpen);
+      const openLines = content.slice(lastOpen).split("\n").length;
+      if (renderable || openLines >= 12) {
+        const before = content.slice(0, lastOpen).trim();
+        return (
+          <>
+            {before && <Markdown content={before} />}
+            <ArtifactBuilding />
+          </>
+        );
+      }
+    }
+  }
   if (!content.includes("[[artifact:")) return <Markdown content={content} />;
   const nodes: ReactNode[] = [];
   let last = 0;
@@ -123,7 +155,7 @@ export function MessageList() {
             <div className="min-w-0 flex-1">
               <p className="mb-1 text-xs font-medium text-muted">OpenMake</p>
               <div className="text-sm leading-relaxed text-fg">
-                <AssistantContent content={m.content} />
+                <AssistantContent content={m.content} streaming={m.streaming} />
                 {m.streaming && (
                   <span className="ml-0.5 inline-block h-4 w-1.5 animate-pulse bg-accent align-text-bottom" />
                 )}


### PR DESCRIPTION
## 문제 (실테스트 점검)
"세계지도를 3D로 아티팩트로 생성해줘" → 점검 결과 **아티팩트는 정상 생성·렌더되지만**(Three.js 3D 지구본), qwen 이 `<artifact>` 태그가 아니라 **```html 펜스**로 ~71초간 대용량 출력 → fence-fallback 은 **응답 완료 시점에야** 패널을 엶. 그 동안 화면엔 원시 코드만 흘러 사용자가 *"아무 일도 안 일어남"* 으로 인식.

## 수정 (프론트, 저위험)
스트리밍 중 닫히지 않은 **렌더 가능 펜스**(```html/svg/mermaid/chart/jsx/tsx, 일반 코드는 ≥12줄)를 감지하면 원시 코드 대신 **"아티팩트 생성 중…" 인디케이터** 표시. 완료 시 기존 칩/패널로 교체.

- 명시적 `<artifact>` 태그 경로는 ws 가 이미 라이브 패널을 여므로 대상 아님(중복 없음)
- **백엔드 스트리밍 파서는 무변경** (critical path 보호 — 리스크 큰 streaming-fence 미채택)

## 검증 (Playwright MCP 실채팅)
3D 세계지도 요청 → ① 생성 중 "아티팩트 생성 중…" 표시(원시 코드 숨김) → ② 완료 시 패널에 **Three.js 3D 지구본 렌더** 확인.

> 추가 점검 사실: 생성이 ~71초로 긴 이유는 (a) 3D 코드 자체가 대용량(4260 토큰) (b) `load_skill`(그래픽 디자이너 스킬) 자동 호출 1턴. 아티팩트 자체는 완전하게 생성되며 in-app 패널에서 정상 렌더됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)