### PR TITLE
feat(artifact): 공유 뷰어 CSP에 신뢰 CDN 화이트리스트 (안 B)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -712,6 +712,7 @@ ARTIFACT_VIEWER_ENABLED=false                          # publish 시 self-contai
 # ARTIFACT_VIEWER_DATA_DIR=/Volumes/MAC_APP/docker/openmake_llm/artifact-viewer/data  # 백엔드 export 경로(nginx read-only mount)
 # ARTIFACT_VIEWER_SIGNING_KEY=                         # authenticated/private 접근토큰 HMAC 키(미설정 시 JWT_SECRET)
 # ARTIFACT_VIEWER_TOKEN_TTL_SEC=3600                   # 접근토큰 TTL(초)
+# ARTIFACT_VIEWER_TRUSTED_CDNS=...                     # 신뢰 CDN(script/style/img/font 허용, connect-src는 none 유지). 기본 cdnjs/unpkg/jsdelivr
 # fs_read_file 완전성 고지(P-6) — 이 바이트 초과 시 앞부분만 반환하고 잘림을 고지.
 FS_READ_MAX_BYTES=100000
 # WebSocket 메시지 최대 페이로드(bytes). **미설정/0 = 무제한**(파일·이미지 업로드 용량 제한 없음).

--- a/apps/api/src/config/artifact-viewer.ts
+++ b/apps/api/src/config/artifact-viewer.ts
@@ -38,6 +38,16 @@ export const ARTIFACT_VIEWER = {
 
     /** react(JSX) 런타임 변환은 babel eval 필요 → 해당 종류만 'unsafe-eval' 완화. */
     reactNeedsUnsafeEval: true,
+
+    /**
+     * 신뢰 CDN 화이트리스트 (안 B) — script/style/img/font 소스로만 허용.
+     * connect-src 는 여전히 'none' (fetch/XHR/WebSocket 데이터 유출 차단) — 핵심 보호 유지.
+     * Three.js/D3/Chart 등 외부 라이브러리에 의존하는 아티팩트가 공유 뷰어에서도 렌더되도록.
+     * space 구분 env override.
+     */
+    trustedCdns: (process.env.ARTIFACT_VIEWER_TRUSTED_CDNS
+        || 'https://cdnjs.cloudflare.com https://unpkg.com https://cdn.jsdelivr.net')
+        .split(/\s+/).filter(Boolean),
 } as const;
 
 /** publish 한 artifact 의 뷰어 디렉토리 절대경로. */

--- a/apps/api/src/services/artifact-viewer-service.ts
+++ b/apps/api/src/services/artifact-viewer-service.ts
@@ -185,14 +185,19 @@ ${dataIsland}
     return { html, needsUnsafeEval };
 }
 
-/** strict CSP 본문 — scriptSrc 만 종류별로 다름. */
+/**
+ * strict CSP 본문 — scriptSrc 만 종류별로 다름.
+ * 신뢰 CDN(안 B)을 script/style/img/font 에 허용하되 connect-src 는 'none' 유지
+ * (데이터 유출·임의 호스트 fetch 차단). Three.js 등 CDN 라이브러리 렌더 가능.
+ */
 function cspContent(scriptSrc: string): string {
+    const cdn = ARTIFACT_VIEWER.trustedCdns.length ? ' ' + ARTIFACT_VIEWER.trustedCdns.join(' ') : '';
     return [
         "default-src 'none'",
-        `script-src ${scriptSrc}`,
-        "style-src 'self' 'unsafe-inline'",
-        "img-src 'self' data:",
-        "font-src 'self' data:",
+        `script-src ${scriptSrc}${cdn}`,
+        `style-src 'self' 'unsafe-inline'${cdn}`,
+        `img-src 'self' data:${cdn}`,
+        `font-src 'self' data:${cdn}`,
         "media-src data:",
         "connect-src 'none'",
         "object-src 'none'",


### PR DESCRIPTION
## 문제
Docker 공유 뷰어의 strict CSP(`script-src 'self'`)가 외부 CDN을 차단 → Three.js/D3 등 **CDN 라이브러리에 의존하는 아티팩트가 공유 뷰어에서 빈 화면**(in-app 패널은 CSP 없어 정상 렌더). 3D 세계지도 publish 시 `THREE is not defined`.

## 수정 (안 B)
신뢰 CDN(`cdnjs`/`unpkg`/`jsdelivr`)을 `script/style/img/font` 소스에 허용. **`connect-src 'none'` 유지** → fetch/XHR/WebSocket 데이터 유출·임의 호스트는 여전히 차단(핵심 보호 유지). `config/artifact-viewer.ts` `trustedCdns`(env override `ARTIFACT_VIEWER_TRUSTED_CDNS`).

```
script-src 'self' 'sha256-…' https://cdnjs.cloudflare.com https://unpkg.com https://cdn.jsdelivr.net
connect-src 'none'   ← 유지
```

## 검증 (Playwright MCP)
3D 세계지도 publish → Docker 뷰어에서 **Three.js(cdnjs) 로드 + WebGL 지구본 렌더 확인**. 콘솔 CSP 차단 에러 사라짐(3→1, frame-ancestors 경고만).

## 보안 트레이드오프
"외부요청 0" → "신뢰 CDN 3곳의 정적 리소스(script/style/img/font)만 허용". 데이터 유출 경로(`connect-src`)·임의 호스트는 차단 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)