### PR TITLE
fix(artifact): artifact-guide를 external(로컬 기본) 경로에 주입 — 디자인시스템 적용

### DIFF
--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -48,6 +48,8 @@ export interface StreamFromExternalContext {
     memoryBlock?: string;
     /** Custom Instructions 블록 (사용자 영구 지시). 시스템 프롬프트 앞쪽에 prepend. */
     customInstructionsBlock?: string;
+    /** Artifacts guide (디자인시스템·<artifact> 형식 지시). 가드/페르소나 뒤에 append. */
+    artifactGuideBlock?: string;
 }
 
 /**
@@ -83,6 +85,12 @@ export async function streamFromExternalProvider(
 
     if (ctx.agentSystemMessage) {
         systemPromptParts.push(ctx.agentSystemMessage);
+    }
+
+    // Artifacts guide (디자인시스템·<artifact> 형식). strategy 경로의 combinedSystemPrompt
+    // 끝(... + artifactGuideBlock)과 동일하게 마지막에 append.
+    if (ctx.artifactGuideBlock) {
+        systemPromptParts.push(ctx.artifactGuideBlock.trim());
     }
 
     const langCode = ctx.resolvedLanguage || req.userLanguagePreference;

--- a/apps/api/src/services/chat-service/message-pipeline.ts
+++ b/apps/api/src/services/chat-service/message-pipeline.ts
@@ -99,7 +99,31 @@ async function buildUserContextBlocks(
     return { memoryBlock, customInstructionsBlock };
 }
 
-export async function runMessagePipeline(svc: ChatService, 
+/**
+ * Artifacts guide 블록 빌드 (사용자 artifacts_enabled 토글 반영, 기본 활성).
+ * ⚠️ external(local 기본) 경로와 strategy 경로 양쪽에서 호출 — 한쪽만 넣으면
+ * 로컬 채팅 LLM 이 가이드를 못 받아 <artifact> 태그/디자인시스템을 무시한다
+ * ([[외부 경로 skill/memory 누락]] 와 동일 클래스의 누락 방지).
+ */
+async function buildArtifactGuideBlock(userId: string | undefined, language: string): Promise<string> {
+    try {
+        let enabled = true;
+        if (userId && userId !== 'guest') {
+            const { UserRepository } = await import('../../data/repositories/user-repository');
+            const { getPool } = await import('../../data/models/unified-database');
+            enabled = await new UserRepository(getPool()).getArtifactsEnabled(userId);
+        }
+        if (!enabled) return '';
+        const { getArtifactGuide } = await import('../../prompts/artifact-guide');
+        return getArtifactGuide(language);
+    } catch (e) {
+        logger.warn('artifacts_enabled 조회 실패 (기본 활성으로 진행):', e);
+        const { getArtifactGuide } = await import('../../prompts/artifact-guide');
+        return getArtifactGuide(language);
+    }
+}
+
+export async function runMessagePipeline(svc: ChatService,
     req: ChatMessageRequest,
     onToken: (token: string) => void,
     onAgentSelected?: (agent: { type: string; name: string; emoji?: string; phase?: string; reason?: string; confidence?: number }) => void,
@@ -358,12 +382,16 @@ export async function runMessagePipeline(svc: ChatService,
             }
         }
 
+        // ⚠️ artifact-guide 를 external(로컬 기본) 경로에도 주입 — 안 그러면 로컬 채팅 LLM 이
+        //    가이드(디자인시스템·<artifact> 형식)를 못 받아 fence-fallback 으로만 동작.
+        const extArtifactGuide = await buildArtifactGuideBlock(userId, languagePolicy?.resolvedLanguage || 'en');
         return await svc.streamFromExternalProvider(externalResolved, req, streamToken, {
             agentSystemMessage: agentSysMsgForExternal,
             enhancedMessage: finalEnhancedMessage,
             resolvedLanguage: languagePolicy?.resolvedLanguage,
             memoryBlock: extMemoryBlock,
             customInstructionsBlock: extCustomInstructionsBlock,
+            artifactGuideBlock: extArtifactGuide,
         }, reqCtx);
     }
 
@@ -481,24 +509,7 @@ export async function runMessagePipeline(svc: ChatService,
     // Artifacts guide (2026-05-26 Phase 1.C): self-contained 산출물 wrap 지시.
     // 사용자별 on/off 토글 (Anthropic Settings > Capabilities 동등). 기본 true.
     // guest 세션은 사용자 설정이 없으므로 기본 활성 (안전한 기본값).
-    let artifactGuideBlock = '';
-    try {
-        let enabled = true;
-        if (userId && userId !== 'guest') {
-            const { UserRepository } = await import('../../data/repositories/user-repository');
-            const { getPool } = await import('../../data/models/unified-database');
-            const userRepo = new UserRepository(getPool());
-            enabled = await userRepo.getArtifactsEnabled(userId);
-        }
-        if (enabled) {
-            const { getArtifactGuide } = await import('../../prompts/artifact-guide');
-            artifactGuideBlock = getArtifactGuide(languagePolicy?.resolvedLanguage || 'en');
-        }
-    } catch (e) {
-        logger.warn('artifacts_enabled 조회 실패 (기본 활성으로 진행):', e);
-        const { getArtifactGuide } = await import('../../prompts/artifact-guide');
-        artifactGuideBlock = getArtifactGuide(languagePolicy?.resolvedLanguage || 'en');
-    }
+    const artifactGuideBlock = await buildArtifactGuideBlock(userId, languagePolicy?.resolvedLanguage || 'en');
 
     const combinedSystemPrompt = memoryBlock + customInstructionsBlock + thinkingGuidance + styledBase + artifactGuideBlock;
 


### PR DESCRIPTION
## 근본 원인 (회귀 버그)
`artifactGuideBlock`은 `message-pipeline` **strategy 경로에서만** 빌드되는데, 로컬 채팅은 `LOCAL_STRATEGY_PATH_ENABLED=off`라 **external 분기에서 조기 return** → **artifact-guide가 로컬 채팅 LLM에 주입된 적이 없음**. (외부 경로 skill/memory 누락과 동일 클래스.)

**증상**: 최근 아티팩트 12개 중 10개가 fence-fallback(`auto-*`) — LLM이 `<artifact>` 태그를 자발적으로 안 씀. PR #190의 디자인시스템·충실도 강화가 **LLM에 도달조차 못 함** → "open-design 디자인이 안 먹는" 진짜 이유.

## 수정
`buildArtifactGuideBlock()` 헬퍼로 추출 → strategy + external 양쪽에서 호출. `external-provider`가 `ctx.artifactGuideBlock`을 systemPromptParts 마지막에 append.

## 검증 (Playwright 실채팅)
"To-do 앱 html 아티팩트":
| | 이전 | 이후 |
|---|---|---|
| 아티팩트 | fence-fallback `auto-*` | **명시적 `<artifact id="todo-app">`** |
| 디자인 | generic 녹색 | **#2F6BFF 액센트 + Pretendard + 전체 :root 토큰** |

→ open-design에서 추출한 OpenMake 디자인 시스템이 **web/html 산출물에 기본 적용**됨. (사용자 요청 "웹디자인은 open-design 기본 이용"의 핵심 해결.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)