### PR TITLE
feat(composer): 토론·Thinking·에이전트 토글 연결 + 에이전트 작업 인라인 진행

### DIFF
--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -42,7 +42,7 @@ function readFileText(file: File): Promise<string> {
 }
 
 export function Composer() {
-  const { sendChat, abort } = useChatSocket();
+  const { sendChat, abort, startAgentTask } = useChatSocket();
   const [text, setText] = useState("");
   const [files, setFiles] = useState<WsAttachedFile[]>([]);
   // 모드 시트(모바일 최적화) — 7개 토글을 가로스크롤 칩 대신 '도구' 버튼 + 시트로 수납
@@ -118,7 +118,12 @@ export function Composer() {
 
   const submit = () => {
     if ((!text.trim() && files.length === 0) || isGenerating) return;
-    sendChat(text.trim(), undefined, files.length ? files : undefined);
+    if (agentTaskMode) {
+      // 에이전트 토글 ON — 메시지를 목표로 자율 에이전트 작업 실행 (REST). 첨부는 미지원.
+      void startAgentTask(text.trim());
+    } else {
+      sendChat(text.trim(), undefined, files.length ? files : undefined);
+    }
     setText("");
     setFiles([]);
     if (taRef.current) taRef.current.style.height = "auto";

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -12,6 +12,8 @@ import type {
 export interface ChatMessage extends Pick<SharedChatMessage, "role" | "content" | "images"> {
   /** 스트리밍 진행 중 여부 (assistant 메시지) */
   streaming?: boolean;
+  /** 에이전트 작업 메시지 — agent_task_progress 로 라이브 업데이트되는 메시지 식별자 */
+  taskId?: string;
 }
 
 export type { ChatRole };

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -121,7 +121,7 @@ export const useAppStore = create<AppState>((set) => ({
   activeArtifactId: null,
   artifactPanelOpen: false,
 
-  thinkingEnabled: true,
+  thinkingEnabled: false, // opt-in — ON 시 매 응답 thinking(지연·비용↑). 사용자가 필요할 때 켬
   discussionMode: false,
   deepResearchMode: false,
   webSearchEnabled: false,

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { WsChatRequest, WsServerEvent, WsAttachedFile } from "@openmake/shared-types";
 import { useAppStore } from "./store";
+import { ApiClient } from "./api-client";
 import { CLIENT_TIMING } from "./config";
 
 /**
@@ -155,6 +156,8 @@ export function useChatSocket() {
         files: files ?? [],
         webSearch: s.webSearchEnabled,
         deepResearchMode: s.deepResearchMode,
+        discussionMode: s.discussionMode,
+        thinkingMode: s.thinkingEnabled,
         imageMode: s.imageMode,
         artifactMode: s.artifactMode,
         enabledTools: s.mcpToolsEnabled,
@@ -168,5 +171,38 @@ export function useChatSocket() {
     wsRef.current?.send(JSON.stringify({ type: "abort" }));
   }, []);
 
-  return { connected, sendChat, abort };
+  // 에이전트 토글 ON: 메시지를 목표(goal)로 자율 에이전트 작업을 생성·실행한다.
+  // (채팅 WS 가 아니라 REST POST /api/agent-tasks + /execute — 진행상황은 '에이전트 작업' 페이지)
+  const startAgentTask = useCallback(
+    async (message: string) => {
+      const goal = message.trim();
+      const s = useAppStore.getState();
+      if (!goal || s.isGenerating) return;
+      appendMessage({ role: "user", content: goal });
+      try {
+        const created = await ApiClient.post<{ data: { task: { id: string } } }>(
+          "/api/agent-tasks",
+          { goal },
+        );
+        const taskId = created?.data?.task?.id;
+        if (!taskId) throw new Error("작업 생성 응답에 taskId 가 없습니다");
+        await ApiClient.post(`/api/agent-tasks/${taskId}/execute`);
+        appendMessage({
+          role: "assistant",
+          content:
+            "🤖 **에이전트 작업을 시작했습니다.**\n\n" +
+            `**목표:** ${goal}\n\n` +
+            "자율 에이전트가 백그라운드에서 작업을 수행합니다. 진행 상황과 결과는 **에이전트 작업** 페이지에서 확인하세요.",
+        });
+      } catch (e) {
+        appendMessage({
+          role: "assistant",
+          content: `에이전트 작업을 시작하지 못했습니다: ${e instanceof Error ? e.message : String(e)}`,
+        });
+      }
+    },
+    [appendMessage],
+  );
+
+  return { connected, sendChat, abort, startAgentTask };
 }

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -28,13 +28,39 @@ function resolveWsUrl(): string {
   return `${proto}//${location.host}`;
 }
 
+/** 에이전트 작업 메시지 마크다운 — 상태에 따라 진행바/완료/실패를 렌더. */
+function renderAgentTaskMessage(
+  goal: string,
+  status: string,
+  currentTurn: number,
+  progress: number,
+  result?: string,
+): string {
+  const head = `🤖 **에이전트 작업**${goal ? `\n\n**목표:** ${goal}` : ""}`;
+  if (status === "completed") {
+    return `${head}\n\n✅ **완료**\n\n---\n\n${result?.trim() || "_(결과 본문 없음)_"}`;
+  }
+  if (status === "failed" || status === "cancelled") {
+    const label = status === "failed" ? "실패" : "취소됨";
+    return `${head}\n\n❌ **${label}**${result?.trim() ? `\n\n---\n\n${result.trim()}` : ""}`;
+  }
+  // pending / running
+  const pct = Math.max(0, Math.min(100, Math.round(progress || 0)));
+  const filled = Math.round(pct / 10);
+  const bar = "▓".repeat(filled) + "░".repeat(10 - filled);
+  return `${head}\n\n⏳ \`${bar}\` ${pct}% · 턴 ${currentTurn ?? 0}`;
+}
+
 export function useChatSocket() {
   const wsRef = useRef<WebSocket | null>(null);
   const [connected, setConnected] = useState(false);
   const reconnectRef = useRef(0);
+  // 에이전트 작업 taskId → 목표(goal) — agent_task_progress 렌더에 사용
+  const agentGoalsRef = useRef<Map<string, string>>(new Map());
 
   const {
     appendMessage,
+    setChatHistory,
     appendToken,
     setStreaming,
     setCurrentSessionId,
@@ -100,6 +126,43 @@ export function useChatSocket() {
         case "artifact_end":
           endArtifact(data.id);
           break;
+        case "agent_task_progress": {
+          // 에이전트 작업 진행상황을 해당 메시지에 라이브 반영. 완료/실패 시 결과 본문 조회.
+          const { taskId, status, progress, currentTurn } = data;
+          const goal = agentGoalsRef.current.get(taskId) ?? "";
+          const terminal =
+            status === "completed" || status === "failed" || status === "cancelled";
+          if (terminal) {
+            void (async () => {
+              let result = "";
+              try {
+                const r = await ApiClient.get<{ data: { task: { result?: string } } }>(
+                  `/api/agent-tasks/${taskId}`,
+                );
+                result = r?.data?.task?.result ?? "";
+              } catch {
+                /* 결과 조회 실패 — 상태만 표시 */
+              }
+              setChatHistory((prev) =>
+                prev.map((m) =>
+                  m.taskId === taskId
+                    ? { ...m, content: renderAgentTaskMessage(goal, status, currentTurn, progress, result) }
+                    : m,
+                ),
+              );
+              agentGoalsRef.current.delete(taskId);
+            })();
+          } else {
+            setChatHistory((prev) =>
+              prev.map((m) =>
+                m.taskId === taskId
+                  ? { ...m, content: renderAgentTaskMessage(goal, status, currentTurn, progress) }
+                  : m,
+              ),
+            );
+          }
+          break;
+        }
         default:
           break; // init / research_progress / token_warning 등은 추후
       }
@@ -186,14 +249,14 @@ export function useChatSocket() {
         );
         const taskId = created?.data?.task?.id;
         if (!taskId) throw new Error("작업 생성 응답에 taskId 가 없습니다");
-        await ApiClient.post(`/api/agent-tasks/${taskId}/execute`);
+        // 진행상황 메시지 — agent_task_progress 이벤트로 taskId 로 식별해 라이브 업데이트.
+        agentGoalsRef.current.set(taskId, goal);
         appendMessage({
           role: "assistant",
-          content:
-            "🤖 **에이전트 작업을 시작했습니다.**\n\n" +
-            `**목표:** ${goal}\n\n` +
-            "자율 에이전트가 백그라운드에서 작업을 수행합니다. 진행 상황과 결과는 **에이전트 작업** 페이지에서 확인하세요.",
+          taskId,
+          content: renderAgentTaskMessage(goal, "pending", 0, 0),
         });
+        await ApiClient.post(`/api/agent-tasks/${taskId}/execute`);
       } catch (e) {
         appendMessage({
           role: "assistant",

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -133,7 +133,15 @@ export type WsServerEvent =
   // 아티팩트 스트리밍 (백엔드 ws-chat-handler.ts 송출)
   | { type: "artifact_start"; artifact: ArtifactMeta; messageId?: string }
   | { type: "artifact_chunk"; id: string; delta: string; messageId?: string }
-  | { type: "artifact_end"; id: string; messageId?: string };
+  | { type: "artifact_end"; id: string; messageId?: string }
+  // 에이전트 작업 진행상황 (백엔드 sockets/handler.ts agent_task_progress relay)
+  | {
+      type: "agent_task_progress";
+      taskId: string;
+      status: string;
+      progress: number;
+      currentTurn: number;
+    };
 
 /* ── 응답 페이로드 헬퍼 타입 ─────────────────────────────────────────── */
 export interface SessionsPayload {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -92,6 +92,10 @@ export interface WsChatRequest {
   files?: WsAttachedFile[];
   webSearch?: boolean;
   deepResearchMode?: boolean;
+  /** 멀티 에이전트 토론 모드 */
+  discussionMode?: boolean;
+  /** Sequential Thinking 모드 (UI thinkingEnabled 토글) */
+  thinkingMode?: boolean;
   /** 이미지 생성 모드 — ON 이면 메시지를 프롬프트로 이미지를 직접 생성 */
   imageMode?: boolean;
   /** 아티팩트 모드 — ON 이면 모델이 <artifact> 산출물을 생성하도록 유도 */


### PR DESCRIPTION
## 문제
채팅 컴포저의 7개 토글 중 **토론·Thinking·에이전트** 3개가 UI에만 있고 `use-chat-socket` payload에 빠져 있어 켜도 백엔드로 전송되지 않아 **무동작**(장식)이었음. (딥리서치·웹·이미지·아티팩트 4개는 정상)

## 해결
- **토론(discussionMode)·Thinking(thinkingMode)**: `WsChatRequest` + payload에 추가. 백엔드(ws-handler·message-pipeline·request-handler)는 이미 처리 준비돼 있어 **전송만으로 동작**.
- **에이전트(agentTaskMode)**: 채팅 WS가 아니라 REST로 연결 — submit 시 `POST /api/agent-tasks`(goal=메시지) + `/execute`로 자율 에이전트 작업 생성·실행 후 채팅에 확인 메시지. 진행상황은 '에이전트 작업' 페이지(`startAgentTask`).
- **Thinking 기본값 true→false**: 연결 시 ON이면 매 응답 thinking으로 지연·비용↑ → opt-in 전환(컴포저도 기본 활성칩 없이 깔끔). 필요 시 사용자가 켬.

## 검증 (Playwright E2E)
- WS 페이로드에 `discussionMode:true, thinkingMode:true` 전송 확인
- 백엔드 로그: 토론 엔진 5에이전트 실행, 에이전트 `POST create+execute` + taskId 구동, 확인 메시지 렌더
- apps/api tsc 0 / apps/web build 통과 (백엔드 무변경 — 프론트만 재빌드)

🤖 Generated with [Claude Code](https://claude.com/claude-code)