### PR TITLE
feat(attach): 드래그앤드롭·이미지 vision·문서 본문 추출 지원

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,10 +21,11 @@
         "eval:all": "npm run eval:routing && npm run eval:response && npm run eval:citation"
     },
     "dependencies": {
-        "@openmake/shared-types": "1.5.6",
         "@anthropic-ai/sdk": "^0.95.1",
         "@modelcontextprotocol/sdk": "^1.25.3",
         "@mozilla/readability": "^0.6.0",
+        "@opendataloader/pdf": "^2.4.7",
+        "@openmake/shared-types": "1.5.6",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
         "@opentelemetry/instrumentation-express": "^0.67.0",
@@ -53,6 +54,7 @@
         "lru-cache": "^7.18.3",
         "multer": "^2.0.2",
         "nodemailer": "^9.0.0",
+        "officeparser": "^7.2.1",
         "openai": "^6.37.0",
         "ora": "^9.2.0",
         "pg": "^8.18.0",

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -332,13 +332,36 @@ export const DISCUSSION_CONCURRENCY = {
  */
 export const FILE_ATTACH_LIMITS = {
     /** 메시지당 첨부 파일 최대 개수 */
-    MAX_FILES: parseInt(process.env.FILE_ATTACH_MAX_FILES || '10', 10),
+    MAX_FILES: parseInt(process.env.FILE_ATTACH_MAX_FILES || '50', 10),
     /** 파일당 주입 텍스트 최대 글자 수 (초과분 절단) */
-    MAX_CHARS_PER_FILE: parseInt(process.env.FILE_ATTACH_MAX_CHARS_PER_FILE || '100000', 10),
-    /** 전체 첨부 합산 주입 텍스트 최대 글자 수 */
-    MAX_TOTAL_CHARS: parseInt(process.env.FILE_ATTACH_MAX_TOTAL_CHARS || '300000', 10),
+    MAX_CHARS_PER_FILE: parseInt(process.env.FILE_ATTACH_MAX_CHARS_PER_FILE || '2000000', 10),
+    /** 전체 첨부 합산 주입 텍스트 최대 글자 수 (최종 컨텍스트 적합화는 LLMClient context-fit 안전망이 담당) */
+    MAX_TOTAL_CHARS: parseInt(process.env.FILE_ATTACH_MAX_TOTAL_CHARS || '10000000', 10),
     /** 파일명 표시 최대 길이 (프롬프트 주입 시 절단) */
     MAX_NAME_LENGTH: 200,
+} as const;
+
+/**
+ * 문서 첨부 텍스트 추출 한도 (2026-06-24)
+ * PDF 는 opendataloader-pdf(Java CLI, JVM spawn), 그 외 office 포맷(docx/xlsx/pptx/odt 등)은
+ * officeparser(순수 Node) 로 base64 원본을 텍스트로 추출해 fileContext 채널에 주입한다.
+ * JVM spawn 은 느리므로 PDF 는 별도 타임아웃을 둔다.
+ *
+ * services/chat-service/doc-extractor.ts 에서 참조
+ */
+export const DOC_EXTRACT_LIMITS = {
+    /** 기능 on/off (기본 on — 'false' 명시 시에만 비활성) */
+    ENABLED: process.env.DOC_EXTRACT_ENABLED !== 'false',
+    /** 추출 입력 1개 최대 바이트 (base64 디코드 후 원본 크기). 초과 시 추출 생략 → 메타만 */
+    MAX_BYTES_PER_FILE: parseInt(process.env.DOC_EXTRACT_MAX_BYTES_PER_FILE || String(30 * 1024 * 1024), 10),
+    /** PDF(opendataloader, JVM) 추출 타임아웃 (ms) */
+    PDF_TIMEOUT_MS: parseInt(process.env.DOC_EXTRACT_PDF_TIMEOUT_MS || '60000', 10),
+    /** office(officeparser) 추출 타임아웃 (ms) */
+    OFFICE_TIMEOUT_MS: parseInt(process.env.DOC_EXTRACT_OFFICE_TIMEOUT_MS || '30000', 10),
+    /** opendataloader 로 처리할 확장자 (PDF 전용 — 고품질 레이아웃 인식) */
+    PDF_EXTS: ['pdf'] as readonly string[],
+    /** officeparser 로 처리할 확장자 */
+    OFFICE_EXTS: ['docx', 'xlsx', 'pptx', 'odt', 'odp', 'ods', 'rtf'] as readonly string[],
 } as const;
 
 /**

--- a/apps/api/src/config/timeouts.ts
+++ b/apps/api/src/config/timeouts.ts
@@ -167,9 +167,12 @@ export const WS_LIMITS = {
     MAX_PAYLOAD_BYTES: process.env.WS_MAX_PAYLOAD_BYTES !== undefined ? Number(process.env.WS_MAX_PAYLOAD_BYTES) : 0,
     /**
      * 단일 메시지 문자열 최대 길이(chars). MAX_PAYLOAD_BYTES(0=무제한 sentinel)와 별개로,
-     * 메시지 핸들러가 raw.length 로 거대 텍스트 프레임을 즉시 거부하는 가드. 기본 1MB(chars).
+     * 메시지 핸들러가 raw.length 로 거대 텍스트 프레임을 즉시 거부하는 가드.
+     * 주의: raw 는 message+files+images(base64) 전체 JSON payload 이므로, 파일/이미지 첨부
+     * 용량이 이 값에 합산된다. 첨부 제한 완화를 위해 기본 64MB(chars). base64 이미지 수 MB·
+     * 대용량 텍스트 첨부를 수용한다(최종 컨텍스트 적합화는 LLMClient context-fit 안전망이 담당).
      */
-    MAX_MESSAGE_CHARS: parseInt(process.env.WS_MAX_MESSAGE_CHARS || String(1024 * 1024), 10),
+    MAX_MESSAGE_CHARS: parseInt(process.env.WS_MAX_MESSAGE_CHARS || String(64 * 1024 * 1024), 10),
     /** 사용자당 최대 동시 WebSocket 연결 수 */
     MAX_CONNECTIONS_PER_USER: Number(process.env.WS_MAX_CONNECTIONS_PER_USER) || 5,
     /** 연결 속도 제한 윈도우 (ms) — 기본 60초 */

--- a/apps/api/src/services/chat-service/attach-context.ts
+++ b/apps/api/src/services/chat-service/attach-context.ts
@@ -115,7 +115,10 @@ export function buildFileContext(files: AttachedFileInput[] | undefined): string
 
     if (parts.length === 0) return '';
     const skipped = files.length - limited.length;
-    return `\n\n## 📎 첨부 파일\n사용자가 첨부한 파일입니다. 답변 시 아래 내용을 참고하세요.\n\n${parts.join('\n\n')}` +
+    // 헤더는 단정적으로 — PDF/문서는 이미 텍스트로 추출·디코드되어 아래에 그대로 들어있다.
+    // 모델이 "원본을 도구로 읽어야 한다"고 오해해 "파일을 읽을 수 없다/도구가 없다"는 사족을
+    // 붙이는 것을 방지한다 (추출 텍스트를 최종 내용으로 신뢰하도록 명시).
+    return `\n\n## 📎 첨부 파일\n아래는 사용자가 첨부한 파일의 내용입니다. PDF·오피스 문서·텍스트가 이미 추출·디코드되어 그대로 제공됩니다 — 이 내용을 직접 읽고 답변에 사용하세요. 파일을 열기 위한 별도 도구 호출은 필요 없으며, "파일을 읽을 수 없다"거나 분석 도구 부재를 언급하지 마세요.\n\n${parts.join('\n\n')}` +
         (skipped > 0 ? `\n\n(첨부 ${files.length}개 중 ${FILE_ATTACH_LIMITS.MAX_FILES}개만 포함 — ${skipped}개 생략)` : '') + '\n';
 }
 

--- a/apps/api/src/services/chat-service/attach-context.ts
+++ b/apps/api/src/services/chat-service/attach-context.ts
@@ -23,6 +23,8 @@ export interface AttachedFileInput {
     type?: string;
     /** 텍스트 파일 내용 (바이너리는 미전송). 빈 문자열은 빈 파일로 취급 */
     content?: string;
+    /** 추출 대상 바이너리 문서의 base64 원본. doc-extractor 가 content 로 추출 후 제거 */
+    data?: string;
     size?: number;
     /** 클라이언트가 전송 전 캡으로 내용을 절단했음 (절단 안내문 부착용) */
     truncated?: boolean;

--- a/apps/api/src/services/chat-service/doc-extractor.ts
+++ b/apps/api/src/services/chat-service/doc-extractor.ts
@@ -1,0 +1,121 @@
+/**
+ * 문서 첨부 텍스트 추출 (2026-06-24)
+ *
+ * PDF → opendataloader-pdf(Java/JVM, 고품질 마크다운), office → officeparser(순수 Node).
+ * 클라이언트가 보낸 base64 원본(file.data)을 텍스트로 추출해 file.content 를 채운다.
+ * 추출 성공/실패와 무관하게 data 는 제거(중복 전송·메모리 방지). 실패 시 content 미설정
+ * → buildFileContext 가 바이너리 메타만 주입(환각 방지). 전송 계층(WS/REST) 무관.
+ *
+ * @module services/chat-service/doc-extractor
+ */
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as crypto from 'crypto';
+import { createLogger } from '../../utils/logger';
+import { DOC_EXTRACT_LIMITS, FILE_ATTACH_LIMITS } from '../../config/runtime-limits';
+import type { AttachedFileInput } from './attach-context';
+import type { SupportedFileType } from 'officeparser';
+
+const logger = createLogger('DocExtractor');
+
+/** 파일명에서 소문자 확장자 추출 ('' = 확장자 없음) */
+function extOf(name: string): string {
+    const i = name.lastIndexOf('.');
+    return i >= 0 ? name.slice(i + 1).toLowerCase() : '';
+}
+
+/**
+ * Promise 에 타임아웃을 건다. 초과 시 reject (원 작업은 백그라운드에 남을 수 있으나 호출자가 graceful 처리).
+ * PDF 는 JVM child process 라 강제 종료가 어려워, 과대 파일은 MAX_BYTES_PER_FILE 로 사전 차단한다.
+ */
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(`${label} 추출 타임아웃 (${ms}ms)`)), ms);
+        p.then(
+            (v) => { clearTimeout(timer); resolve(v); },
+            (e) => { clearTimeout(timer); reject(e); },
+        );
+    });
+}
+
+/** PDF → markdown (opendataloader-pdf, JVM). 입력은 파일 경로만 받으므로 임시파일 경유. */
+async function extractPdf(buf: Buffer): Promise<string> {
+    const { convert } = await import('@opendataloader/pdf');
+    const tmp = path.join(os.tmpdir(), `om-pdf-${crypto.randomUUID()}.pdf`);
+    await fs.writeFile(tmp, buf);
+    try {
+        const out = await withTimeout(
+            convert(tmp, { format: 'markdown', toStdout: true, quiet: true }),
+            DOC_EXTRACT_LIMITS.PDF_TIMEOUT_MS,
+            'PDF',
+        );
+        return typeof out === 'string' ? out : '';
+    } finally {
+        await fs.unlink(tmp).catch(() => { /* noop */ });
+    }
+}
+
+/** office 포맷(docx/xlsx/pptx/odt/...) → plain text (officeparser, 순수 Node). buffer 직접 처리. */
+async function extractOffice(buf: Buffer, ext: string): Promise<string> {
+    const { parseOffice } = await import('officeparser');
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), DOC_EXTRACT_LIMITS.OFFICE_TIMEOUT_MS);
+    try {
+        // buffer 입력 시 magic byte 외에 확장자 힌트 제공 (officeparser 권장).
+        // ext 는 호출 전 OFFICE_EXTS 화이트리스트로 검증됨 → SupportedFileType 캐스팅 안전.
+        const ast = await parseOffice(buf, {
+            fileType: ext as SupportedFileType,
+            abortSignal: controller.signal,
+        });
+        // toText() 는 deprecated → to('md') 로 구조 보존 마크다운 추출
+        return (await ast.to('md')).value;
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+/**
+ * files[] 의 data(base64 문서)를 텍스트로 추출해 content 를 채운다 (in-place mutate).
+ * - 이미 content 가 있으면 추출 생략
+ * - 추출 대상 아닌 확장자/과대 파일/추출 실패 → content 미설정(메타 처리)
+ * - 성공 시 FILE_ATTACH_LIMITS.MAX_CHARS_PER_FILE 로 절단
+ */
+export async function extractAttachedDocuments(files: AttachedFileInput[] | undefined): Promise<void> {
+    if (!DOC_EXTRACT_LIMITS.ENABLED || !Array.isArray(files)) return;
+
+    for (const f of files) {
+        if (!f || typeof f.data !== 'string' || f.data.length === 0) continue;
+        // 이미 텍스트 내용이 있으면 추출 불필요
+        if (typeof f.content === 'string') { delete f.data; continue; }
+
+        const ext = extOf(typeof f.name === 'string' ? f.name : '');
+        const isPdf = DOC_EXTRACT_LIMITS.PDF_EXTS.includes(ext);
+        const isOffice = DOC_EXTRACT_LIMITS.OFFICE_EXTS.includes(ext);
+        if (!isPdf && !isOffice) { delete f.data; continue; }
+
+        const buf = Buffer.from(f.data, 'base64');
+        if (buf.length === 0 || buf.length > DOC_EXTRACT_LIMITS.MAX_BYTES_PER_FILE) {
+            logger.warn(`[DocExtract] ${f.name}: 크기 초과/빈 파일 (${buf.length}B) — 추출 생략`);
+            delete f.data;
+            continue;
+        }
+
+        try {
+            const text = isPdf ? await extractPdf(buf) : await extractOffice(buf, ext);
+            const trimmed = (text || '').trim();
+            if (trimmed.length > 0) {
+                f.content = trimmed.slice(0, FILE_ATTACH_LIMITS.MAX_CHARS_PER_FILE);
+                if (trimmed.length > FILE_ATTACH_LIMITS.MAX_CHARS_PER_FILE) f.truncated = true;
+                logger.info(`[DocExtract] ${f.name} (${ext}) → ${f.content.length}자 추출`);
+            } else {
+                logger.info(`[DocExtract] ${f.name} (${ext}): 추출 텍스트 없음(스캔본/이미지 가능) — 메타만`);
+            }
+        } catch (e) {
+            logger.warn(`[DocExtract] ${f.name} 추출 실패: ${e instanceof Error ? e.message : e}`);
+            // content 미설정 → buildFileContext 가 바이너리 메타로 처리
+        } finally {
+            delete f.data;
+        }
+    }
+}

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -107,6 +107,12 @@ export async function handleChatMessage(
 
         // 첨부 파일(이미지 외) → LLM 주입용 컨텍스트 (transient — DB 미저장, webSearchContext 와 동급 채널)
         // 레이트 리밋 통과 후 조립 — 거부될 요청에 최대 300k 자 문자열 조립 비용을 쓰지 않는다.
+        // 바이너리 문서(PDF/docx/xlsx/pptx 등)는 base64(data)를 텍스트로 추출해 content 를 채운다.
+        // (무거운 파서는 첨부가 있을 때만 lazy 로딩)
+        if (hasFiles) {
+            const { extractAttachedDocuments } = await import('../services/chat-service/doc-extractor');
+            await extractAttachedDocuments(msg.files);
+        }
         const fileContext = buildFileContext(msg.files);
 
         // 딥 리서치 파이프라인은 fileContext 를 소비하지 않음 (research 전략은 message 만 사용).

--- a/apps/api/src/sockets/ws-types.ts
+++ b/apps/api/src/sockets/ws-types.ts
@@ -46,11 +46,12 @@ export interface WSMessage {
     /**
      * 첨부 파일 목록 (2026-06-12 전체 파일 타입 허용).
      * 텍스트 파일은 content 에 UTF-8 디코드 내용 포함 (fileContext 주입용),
-     * 바이너리는 content 없이 name/type/size 메타만 전달.
+     * 문서 바이너리(PDF/docx/xlsx/pptx 등)는 data 에 base64 원본 포함 → 백엔드 doc-extractor 가 content 로 추출,
+     * 그 외 바이너리는 content/data 없이 name/type/size 메타만 전달.
      * 이미지는 content 없이 images(base64 vision) 경로로 별도 전송.
      * truncated: 클라이언트가 전송 전 캡으로 내용을 절단했음 (절단 안내문 부착용).
      */
-    files?: Array<{ id: string; name: string; type: string; content?: string; size?: number; truncated?: boolean }>;
+    files?: Array<{ id: string; name: string; type: string; content?: string; data?: string; size?: number; truncated?: boolean }>;
     userRole?: string;
     /** 사용자 선호 언어 (설정 페이지에서 선택) */
     language?: string;

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -24,12 +24,20 @@ import { fetchModels } from "@/lib/models-api";
 import { cn } from "@/lib/utils";
 
 // 클라이언트 첨부 캡 — 백엔드 FILE_ATTACH_LIMITS 기본값과 일치(서버가 재절단하므로 advisory).
-const MAX_FILES = 10;
-const MAX_CHARS_PER_FILE = 100_000;
-const MAX_TOTAL_CHARS = 300_000;
-// 텍스트로 읽을 수 있는 확장자(바이너리는 미전송 — 백엔드 계약). vision 이미지는 별도 채널.
-const TEXT_ACCEPT =
-  ".txt,.md,.markdown,.json,.csv,.tsv,.log,.xml,.yaml,.yml,.html,.htm,.css,.js,.jsx,.ts,.tsx,.py,.java,.go,.rs,.c,.cpp,.h,.sh,.sql,.env,.ini,.toml,text/*";
+const MAX_FILES = 50;
+const MAX_IMAGES = 20;
+const MAX_CHARS_PER_FILE = 2_000_000;
+const MAX_TOTAL_CHARS = 10_000_000;
+// 모든 파일 타입 허용(accept 미지정). 처리 분기:
+//  - 이미지(image/*) → base64 data URL → vision 채널(images)
+//  - 문서(EXTRACT_EXTS: PDF/Word/Excel/PowerPoint 등) → base64 원본(data) → 백엔드가 텍스트 추출
+//  - 그 외 → 텍스트로 읽어 content (바이너리는 깨질 수 있으나 백엔드가 메타로 처리)
+const EXTRACT_EXTS = ["pdf", "docx", "xlsx", "pptx", "odt", "odp", "ods", "rtf"];
+
+const extOf = (name: string): string => {
+  const i = name.lastIndexOf(".");
+  return i >= 0 ? name.slice(i + 1).toLowerCase() : "";
+};
 
 /** 파일을 텍스트로 읽는다(바이너리는 깨질 수 있으나 백엔드가 처리). */
 function readFileText(file: File): Promise<string> {
@@ -41,46 +49,97 @@ function readFileText(file: File): Promise<string> {
   });
 }
 
+/** 이미지를 base64 data URL 로 읽는다(vision 채널 전송용). */
+function readFileDataURL(file: File): Promise<string> {
+  return new Promise((resolve) => {
+    const r = new FileReader();
+    r.onload = () => resolve(typeof r.result === "string" ? r.result : "");
+    r.onerror = () => resolve("");
+    r.readAsDataURL(file);
+  });
+}
+
+/** 문서 바이너리를 순수 base64(data URL prefix 제외)로 읽는다(백엔드 추출용). */
+function readFileBase64(file: File): Promise<string> {
+  return new Promise((resolve) => {
+    const r = new FileReader();
+    r.onload = () => {
+      const s = typeof r.result === "string" ? r.result : "";
+      const comma = s.indexOf(",");
+      resolve(comma >= 0 ? s.slice(comma + 1) : "");
+    };
+    r.onerror = () => resolve("");
+    r.readAsDataURL(file);
+  });
+}
+
 export function Composer() {
   const { sendChat, abort, startAgentTask } = useChatSocket();
   const [text, setText] = useState("");
   const [files, setFiles] = useState<WsAttachedFile[]>([]);
+  // 이미지 첨부 — base64 data URL 로 vision 채널 전송. 미리보기/제거를 위해 메타와 함께 보관.
+  const [images, setImages] = useState<{ id: string; name: string; dataUrl: string }[]>([]);
+  // 드래그앤드롭 오버레이 표시 상태
+  const [dragging, setDragging] = useState(false);
   // 모드 시트(모바일 최적화) — 7개 토글을 가로스크롤 칩 대신 '도구' 버튼 + 시트로 수납
   const [modeSheetOpen, setModeSheetOpen] = useState(false);
   const taRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // 선택한 파일들을 텍스트로 읽어 캡 적용 후 첨부 목록에 추가
+  // 선택/드롭한 파일들을 타입별로 분기해 첨부 목록에 추가.
+  // 이미지 → base64 vision, 그 외 → 텍스트(캡 적용). 모든 파일 타입 허용.
   const addFiles = async (list: FileList | null) => {
     if (!list || list.length === 0) return;
-    const next = [...files];
-    let total = next.reduce((n, f) => n + (f.content?.length ?? 0), 0);
+    const nextFiles = [...files];
+    const nextImages = [...images];
+    let total = nextFiles.reduce((n, f) => n + (f.content?.length ?? 0), 0);
     for (const file of Array.from(list)) {
-      if (next.length >= MAX_FILES || total >= MAX_TOTAL_CHARS) break;
-      let content = await readFileText(file);
-      let truncated = false;
-      if (content.length > MAX_CHARS_PER_FILE) {
-        content = content.slice(0, MAX_CHARS_PER_FILE);
-        truncated = true;
+      if (file.type.startsWith("image/")) {
+        if (nextImages.length >= MAX_IMAGES) continue;
+        const dataUrl = await readFileDataURL(file);
+        if (!dataUrl) continue;
+        nextImages.push({ id: crypto.randomUUID(), name: file.name.slice(0, 200), dataUrl });
+      } else if (EXTRACT_EXTS.includes(extOf(file.name))) {
+        // 문서(PDF/Word/Excel/PPT 등) → base64 원본 전송, 백엔드가 텍스트 추출
+        if (nextFiles.length >= MAX_FILES) continue;
+        const data = await readFileBase64(file);
+        if (!data) continue;
+        nextFiles.push({
+          id: crypto.randomUUID(),
+          name: file.name.slice(0, 200),
+          type: file.type || "application/octet-stream",
+          data,
+          size: file.size,
+        });
+      } else {
+        if (nextFiles.length >= MAX_FILES || total >= MAX_TOTAL_CHARS) continue;
+        let content = await readFileText(file);
+        let truncated = false;
+        if (content.length > MAX_CHARS_PER_FILE) {
+          content = content.slice(0, MAX_CHARS_PER_FILE);
+          truncated = true;
+        }
+        if (total + content.length > MAX_TOTAL_CHARS) {
+          content = content.slice(0, Math.max(0, MAX_TOTAL_CHARS - total));
+          truncated = true;
+        }
+        total += content.length;
+        nextFiles.push({
+          id: crypto.randomUUID(),
+          name: file.name.slice(0, 200),
+          type: file.type || "text/plain",
+          content,
+          size: file.size,
+          truncated,
+        });
       }
-      if (total + content.length > MAX_TOTAL_CHARS) {
-        content = content.slice(0, Math.max(0, MAX_TOTAL_CHARS - total));
-        truncated = true;
-      }
-      total += content.length;
-      next.push({
-        id: crypto.randomUUID(),
-        name: file.name.slice(0, 200),
-        type: file.type || "text/plain",
-        content,
-        size: file.size,
-        truncated,
-      });
     }
-    setFiles(next);
+    setFiles(nextFiles);
+    setImages(nextImages);
   };
 
   const removeFile = (id: string) => setFiles((prev) => prev.filter((f) => f.id !== id));
+  const removeImage = (id: string) => setImages((prev) => prev.filter((i) => i.id !== id));
 
   // 로컬 vLLM + 등록된 외부 LLM(OpenRouter 등) 통합 모델 목록
   const { data: modelsData } = useQuery({
@@ -117,15 +176,20 @@ export function Composer() {
   }, [modelsData]);
 
   const submit = () => {
-    if ((!text.trim() && files.length === 0) || isGenerating) return;
+    if ((!text.trim() && files.length === 0 && images.length === 0) || isGenerating) return;
     if (agentTaskMode) {
       // 에이전트 토글 ON — 메시지를 목표로 자율 에이전트 작업 실행 (REST). 첨부는 미지원.
       void startAgentTask(text.trim());
     } else {
-      sendChat(text.trim(), undefined, files.length ? files : undefined);
+      sendChat(
+        text.trim(),
+        images.length ? images.map((i) => i.dataUrl) : undefined,
+        files.length ? files : undefined,
+      );
     }
     setText("");
     setFiles([]);
+    setImages([]);
     if (taRef.current) taRef.current.style.height = "auto";
   };
 
@@ -165,7 +229,34 @@ export function Composer() {
 
   return (
     <div className="mx-auto w-full max-w-3xl px-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
-      <div className="relative rounded-xl border border-border bg-surface shadow-2">
+      <div
+        className={cn(
+          "relative rounded-xl border bg-surface shadow-2 transition-colors",
+          dragging ? "border-accent ring-2 ring-accent/40" : "border-border",
+        )}
+        onDragOver={(e) => {
+          e.preventDefault();
+          if (!dragging) setDragging(true);
+        }}
+        onDragLeave={(e) => {
+          // 자식으로의 dragleave 무시 — 컴포저 경계를 실제로 벗어날 때만 해제
+          if (e.currentTarget.contains(e.relatedTarget as Node)) return;
+          setDragging(false);
+        }}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDragging(false);
+          void addFiles(e.dataTransfer.files);
+        }}
+      >
+        {dragging && (
+          <div className="pointer-events-none absolute inset-0 z-50 grid place-items-center rounded-xl border-2 border-dashed border-accent bg-surface/85 backdrop-blur-sm">
+            <div className="flex items-center gap-2 text-sm font-medium text-accent">
+              <Paperclip className="h-4 w-4" />
+              여기에 파일을 놓아 첨부
+            </div>
+          </div>
+        )}
         {/* 모드 시트 — 컴포저 위로 떠오르는 바텀시트(모바일 최적화). 7개 모드를 세로 리스트로
             수납해 바가 가로 스크롤/넘침 없이 동작한다. (OD openmake-mobile '+' 시트 패턴) */}
         {modeSheetOpen && (
@@ -237,9 +328,27 @@ export function Composer() {
           ))}
         </div>
 
-        {/* 첨부 파일 칩 */}
-        {files.length > 0 && (
+        {/* 첨부 칩 — 이미지 썸네일 + 텍스트/파일 칩 */}
+        {(files.length > 0 || images.length > 0) && (
           <div className="flex flex-wrap gap-1.5 px-3 pt-2">
+            {images.map((img) => (
+              <span
+                key={img.id}
+                title={img.name}
+                className="relative inline-flex h-12 w-12 shrink-0 overflow-hidden rounded-md border border-border bg-surface-2"
+              >
+                {/* data URL 미리보기 — next/image 비대상(로컬 base64). eslint-disable 의도적. */}
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={img.dataUrl} alt={img.name} className="h-full w-full object-cover" />
+                <button
+                  onClick={() => removeImage(img.id)}
+                  aria-label={`${img.name} 첨부 제거`}
+                  className="absolute right-0 top-0 grid h-4 w-4 place-items-center rounded-bl bg-bg/70 text-muted hover:text-fg"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            ))}
             {files.map((f) => (
               <span
                 key={f.id}
@@ -287,7 +396,6 @@ export function Composer() {
             ref={fileInputRef}
             type="file"
             multiple
-            accept={TEXT_ACCEPT}
             className="hidden"
             onChange={(e) => {
               void addFiles(e.target.files);
@@ -296,9 +404,8 @@ export function Composer() {
           />
           <button
             onClick={() => fileInputRef.current?.click()}
-            disabled={files.length >= MAX_FILES}
             className="grid h-8 w-8 place-items-center rounded-md text-muted transition hover:bg-surface-2 hover:text-fg disabled:opacity-40"
-            title={files.length >= MAX_FILES ? `최대 ${MAX_FILES}개까지 첨부` : "파일 첨부 (텍스트)"}
+            title="파일 첨부 (드래그앤드롭 지원 · 모든 형식)"
             aria-label="파일 첨부"
           >
             <Paperclip className="h-4 w-4" />
@@ -323,7 +430,7 @@ export function Composer() {
           ) : (
             <button
               onClick={submit}
-              disabled={!text.trim() && files.length === 0}
+              disabled={!text.trim() && files.length === 0 && images.length === 0}
               aria-label="전송"
               className="ml-auto grid h-8 w-8 place-items-center rounded-md bg-accent text-accent-fg transition hover:bg-accent-hover disabled:opacity-40"
             >

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -29,6 +29,10 @@ module.exports = {
         env: {
             NODE_ENV: 'production',
             PORT: 52416,
+            // 문서 첨부 추출(opendataloader-pdf)은 Java 11+ 가 필요하다.
+            // pm2 프로세스가 JVM 을 찾도록 JAVA_HOME 과 PATH 에 openjdk@17 을 주입.
+            JAVA_HOME: '/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home',
+            PATH: '/opt/homebrew/opt/openjdk@17/bin:' + (process.env.PATH || ''),
         },
         
         // 프로세스 관리

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
                 "@anthropic-ai/sdk": "^0.95.1",
                 "@modelcontextprotocol/sdk": "^1.25.3",
                 "@mozilla/readability": "^0.6.0",
+                "@opendataloader/pdf": "^2.4.7",
                 "@openmake/shared-types": "1.5.6",
                 "@opentelemetry/api": "^1.9.1",
                 "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
@@ -77,6 +78,7 @@
                 "lru-cache": "^7.18.3",
                 "multer": "^2.0.2",
                 "nodemailer": "^9.0.0",
+                "officeparser": "^7.2.1",
                 "openai": "^6.37.0",
                 "ora": "^9.2.0",
                 "pg": "^8.18.0",
@@ -882,6 +884,16 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@borewit/text-codec": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+            "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
         },
         "node_modules/@bramus/specificity": {
             "version": "2.4.2",
@@ -2972,6 +2984,271 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@napi-rs/canvas": {
+            "version": "0.1.100",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+            "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+            "license": "MIT",
+            "optional": true,
+            "workspaces": [
+                "e2e/*"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "optionalDependencies": {
+                "@napi-rs/canvas-android-arm64": "0.1.100",
+                "@napi-rs/canvas-darwin-arm64": "0.1.100",
+                "@napi-rs/canvas-darwin-x64": "0.1.100",
+                "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+                "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+                "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+                "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+                "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+                "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+                "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+                "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+            }
+        },
+        "node_modules/@napi-rs/canvas-android-arm64": {
+            "version": "0.1.100",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+            "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-darwin-arm64": {
+            "version": "0.1.100",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+            "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-darwin-x64": {
+            "version": "0.1.100",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+            "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+            "version": "0.1.100",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+            "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+            "version": "0.1.100",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+            "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+            "version": "0.1.100",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+            "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+            "version": "0.1.100",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+            "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+            "version": "0.1.100",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+            "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-linux-x64-musl": {
+            "version": "0.1.100",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+            "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+            "version": "0.1.100",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+            "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+            "version": "0.1.100",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+            "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
         "node_modules/@napi-rs/wasm-runtime": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
@@ -3206,6 +3483,21 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12.4.0"
+            }
+        },
+        "node_modules/@opendataloader/pdf": {
+            "version": "2.4.7",
+            "resolved": "https://registry.npmjs.org/@opendataloader/pdf/-/pdf-2.4.7.tgz",
+            "integrity": "sha512-gVkweTbNKKWGHxOWzDmCuWfwvU+ierBrRIDi5ux8MLG0JOeYnzXOt1gojuEbVsQvSIUhE0QIkTshp/iru3cX0w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "commander": "^14.0.3"
+            },
+            "bin": {
+                "opendataloader-pdf": "dist/cli.js"
+            },
+            "engines": {
+                "node": ">=20.19.0"
             }
         },
         "node_modules/@openmake/api-client": {
@@ -4242,6 +4534,29 @@
             "peerDependencies": {
                 "react": "^18 || ^19"
             }
+        },
+        "node_modules/@tokenizer/inflate": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+            "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "token-types": "^6.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
+        "node_modules/@tokenizer/token": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+            "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+            "license": "MIT"
         },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.12",
@@ -5380,6 +5695,15 @@
                 "win32"
             ]
         },
+        "node_modules/@xmldom/xmldom": {
+            "version": "0.9.10",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+            "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.6"
+            }
+        },
         "node_modules/accepts": {
             "version": "2.0.0",
             "license": "MIT",
@@ -5978,6 +6302,12 @@
             "dependencies": {
                 "require-from-string": "^2.0.2"
             }
+        },
+        "node_modules/bmp-js": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+            "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+            "license": "MIT"
         },
         "node_modules/bn.js": {
             "version": "4.12.3",
@@ -7991,6 +8321,12 @@
             "version": "4.2.3",
             "license": "MIT"
         },
+        "node_modules/fflate": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+            "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+            "license": "MIT"
+        },
         "node_modules/file-entry-cache": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -8002,6 +8338,24 @@
             },
             "engines": {
                 "node": ">=16.0.0"
+            }
+        },
+        "node_modules/file-type": {
+            "version": "22.0.1",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-22.0.1.tgz",
+            "integrity": "sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==",
+            "license": "MIT",
+            "dependencies": {
+                "@tokenizer/inflate": "^0.4.1",
+                "strtok3": "^10.3.5",
+                "token-types": "^6.1.2",
+                "uint8array-extras": "^1.5.0"
+            },
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/file-type?sponsor=1"
             }
         },
         "node_modules/fill-range": {
@@ -8900,6 +9254,32 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/idb-keyval": {
+            "version": "6.2.5",
+            "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.5.tgz",
+            "integrity": "sha512-eKQkTnS0relYsSOYomx8ozIbmdsQCKUdhyuIaQ2DZgKuaxtyQQMkyD/wlnQN32pO3yutN1b1L8uqwcDKaJd7/Q==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -9566,6 +9946,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/is-url": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+            "license": "MIT"
         },
         "node_modules/is-weakmap": {
             "version": "2.0.2",
@@ -12592,9 +12978,36 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/node-int64": {
             "version": "0.4.0",
             "license": "MIT"
+        },
+        "node_modules/node-readable-to-web-readable-stream": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
+            "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/node-releases": {
             "version": "2.0.47",
@@ -12751,6 +13164,33 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/officeparser": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/officeparser/-/officeparser-7.2.1.tgz",
+            "integrity": "sha512-l9v4ygeUAZGjNlmXhQNIOaPpxAbLNHzcN32Mwyad/HfGOxLcMGrz8aXMVCGICxtE0s8Mq5MwAEkO9gdliK7hZw==",
+            "license": "MIT",
+            "dependencies": {
+                "@xmldom/xmldom": "^0.9.10",
+                "fflate": "^0.8.2",
+                "file-type": "^22.0.1",
+                "pdfjs-dist": "5.6.205",
+                "tesseract.js": "^7.0.0"
+            },
+            "bin": {
+                "officeparser": "dist/cli.js"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/harshankur"
+            },
+            "peerDependenciesMeta": {
+                "puppeteer": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/on-finished": {
             "version": "2.4.1",
             "license": "MIT",
@@ -12810,6 +13250,15 @@
                 "zod": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/opencollective-postinstall": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+            "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+            "license": "MIT",
+            "bin": {
+                "opencollective-postinstall": "index.js"
             }
         },
         "node_modules/openmake-api": {
@@ -13220,6 +13669,19 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/pdfjs-dist": {
+            "version": "5.6.205",
+            "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.6.205.tgz",
+            "integrity": "sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=20.19.0 || >=22.13.0 || >=24"
+            },
+            "optionalDependencies": {
+                "@napi-rs/canvas": "^0.1.96",
+                "node-readable-to-web-readable-stream": "^0.4.2"
             }
         },
         "node_modules/pg": {
@@ -13842,6 +14304,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/regenerator-runtime": {
+            "version": "0.13.11",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+            "license": "MIT"
         },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.4",
@@ -14889,6 +15357,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strtok3": {
+            "version": "10.3.5",
+            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+            "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+            "license": "MIT",
+            "dependencies": {
+                "@tokenizer/token": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
         "node_modules/style-to-js": {
             "version": "1.1.21",
             "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -15045,6 +15529,30 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/tesseract.js": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-7.0.0.tgz",
+            "integrity": "sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bmp-js": "^0.1.0",
+                "idb-keyval": "^6.2.0",
+                "is-url": "^1.2.4",
+                "node-fetch": "^2.6.9",
+                "opencollective-postinstall": "^2.0.3",
+                "regenerator-runtime": "^0.13.3",
+                "tesseract.js-core": "^7.0.0",
+                "wasm-feature-detect": "^1.8.0",
+                "zlibjs": "^0.3.1"
+            }
+        },
+        "node_modules/tesseract.js-core": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-7.0.0.tgz",
+            "integrity": "sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==",
+            "license": "Apache-2.0"
+        },
         "node_modules/test-exclude": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -15172,6 +15680,24 @@
                 "node": ">=0.6"
             }
         },
+        "node_modules/token-types": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+            "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+            "license": "MIT",
+            "dependencies": {
+                "@borewit/text-codec": "^0.2.1",
+                "@tokenizer/token": "^0.3.0",
+                "ieee754": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
         "node_modules/tough-cookie": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
@@ -15183,6 +15709,12 @@
             "engines": {
                 "node": ">=16"
             }
+        },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "license": "MIT"
         },
         "node_modules/tree-kill": {
             "version": "1.2.2",
@@ -15613,6 +16145,18 @@
                 "node": ">=0.8.0"
             }
         },
+        "node_modules/uint8array-extras": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+            "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/unbox-primitive": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -15953,6 +16497,12 @@
                 "makeerror": "1.0.12"
             }
         },
+        "node_modules/wasm-feature-detect": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+            "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+            "license": "Apache-2.0"
+        },
         "node_modules/web-namespaces": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -15982,6 +16532,12 @@
                 "node": ">= 16"
             }
         },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "license": "BSD-2-Clause"
+        },
         "node_modules/whatwg-mimetype": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
@@ -15989,6 +16545,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/which": {
@@ -16324,6 +16890,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zlibjs": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+            "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/zod": {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -76,6 +76,8 @@ export interface WsAttachedFile {
   type: string;
   /** 텍스트 내용 (바이너리는 미전송). 클라이언트가 캡 초과 시 절단 */
   content?: string;
+  /** 추출 대상 바이너리 문서(PDF/docx/xlsx/pptx 등)의 base64 원본. 백엔드가 텍스트로 추출해 content 를 채운다 */
+  data?: string;
   size?: number;
   /** 전송 전 캡으로 내용을 절단했음 */
   truncated?: boolean;


### PR DESCRIPTION
## 요약
채팅 첨부 기능을 강화한다. ① 드래그앤드롭 첨부, ② 업로드 타입/크기 제한 해제, ③ 이미지 vision 분석, ④ PDF·Office 문서 **본문 추출**까지 지원한다.

## 변경 내용

### UI / 전송 (`apps/web/components/chat/composer.tsx`)
- 채팅창 **드래그앤드롭** 첨부 + 드롭 오버레이/테두리 강조
- `accept` 타입 필터 제거 → **모든 파일 형식** 선택·드롭 가능
- 이미지(`image/*`)는 base64 data URL → **vision 채널**, 썸네일 칩 미리보기
- 문서(pdf/docx/xlsx/pptx/odt 등)는 base64 원본(`data`)으로 전송

### 업로드 제한 해제 (config)
- `FILE_ATTACH_LIMITS`: 10→**50개**, 100k→**2M자**(파일), 300k→**10M자**(합산)
- `WS_MAX_MESSAGE_CHARS`: 1MB→**64MB** (전체 payload, base64 첨부 수용)

### 문서 본문 추출 (백엔드 `doc-extractor.ts` 신규)
- **PDF** = `@opendataloader/pdf` (Java 11+, markdown 추출)
- **Office** = `officeparser` (순수 Node — docx/xlsx/pptx/odt/rtf 등)
- 프론트 base64(`data`) → 텍스트 추출 → **기존 `fileContext` 채널 재사용**
- 실패/스캔본은 메타만 주입(환각 방지), 타임아웃·크기 가드(`DOC_EXTRACT_LIMITS`)
- `WsAttachedFile.data` 필드 추가
- `ecosystem.config.js`: 백엔드 pm2 env에 `JAVA_HOME`/`PATH`(openjdk@17) 주입

## 사전 준비 (운영 서버)
- openjdk@17 시스템 심링크 완료(`/Library/Java/JavaVirtualMachines`)
- pm2 백엔드는 env 변경 반영 위해 `delete→start` 필요

## 검증 (Playwright E2E)
- ✅ 드래그앤드롭 → 첨부 칩 생성 + 오버레이 표시
- ✅ accept 제한 해제 확인
- ✅ 이미지 vision: 빨강/파랑 PNG 색 정확 인식
- ✅ DOCX 추출(officeparser): 비밀코드 인식
- ✅ PDF 추출(opendataloader/Java): 비밀코드 + 코드네임 인식
- ✅ **PDF+DOCX+이미지 동시 첨부** → 3채널 동시 정확 인식
- ✅ 백엔드/프론트 타입체크 통과

## 한계 / 후속
- 스캔본 PDF(이미지)는 텍스트 레이어 없어 추출 0 → 메타만. 필요 시 OCR(tesseract) 폴백 추가 가능
- PDF 답변 시 모델이 "도구 없다"는 사족을 붙이는 경우 있음(추출은 정상) → 시스템 프롬프트 문구 개선 여지

🤖 Generated with [Claude Code](https://claude.com/claude-code)