### PR TITLE
feat(doc-extract): 스캔본 PDF OCR 폴백 (sips + tesseract.js)

### DIFF
--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -362,6 +362,14 @@ export const DOC_EXTRACT_LIMITS = {
     PDF_EXTS: ['pdf'] as readonly string[],
     /** officeparser 로 처리할 확장자 */
     OFFICE_EXTS: ['docx', 'xlsx', 'pptx', 'odt', 'odp', 'ods', 'rtf'] as readonly string[],
+    /** 스캔본 PDF OCR 폴백 on/off (기본 on — opendataloader 가 텍스트를 못 뽑으면 officeparser+tesseract 로 재시도) */
+    OCR_ENABLED: process.env.DOC_EXTRACT_OCR_ENABLED !== 'false',
+    /** opendataloader 추출 텍스트가 이 글자 수 미만이면 스캔본(이미지 PDF)으로 보고 OCR 폴백 */
+    PDF_MIN_TEXT_CHARS: parseInt(process.env.DOC_EXTRACT_PDF_MIN_TEXT_CHARS || '16', 10),
+    /** OCR(tesseract) 타임아웃 (ms) — 페이지 렌더+인식이 느리므로 길게 */
+    OCR_TIMEOUT_MS: parseInt(process.env.DOC_EXTRACT_OCR_TIMEOUT_MS || '120000', 10),
+    /** OCR 언어 (tesseract 코드, '+' 로 다중 — 기본 영어+한국어) */
+    OCR_LANGS: process.env.DOC_EXTRACT_OCR_LANGS || 'eng+kor',
 } as const;
 
 /**

--- a/apps/api/src/services/chat-service/doc-extractor.ts
+++ b/apps/api/src/services/chat-service/doc-extractor.ts
@@ -12,12 +12,15 @@ import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 import * as crypto from 'crypto';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import { createLogger } from '../../utils/logger';
 import { DOC_EXTRACT_LIMITS, FILE_ATTACH_LIMITS } from '../../config/runtime-limits';
 import type { AttachedFileInput } from './attach-context';
 import type { SupportedFileType } from 'officeparser';
 
 const logger = createLogger('DocExtractor');
+const execFileAsync = promisify(execFile);
 
 /** 파일명에서 소문자 확장자 추출 ('' = 확장자 없음) */
 function extOf(name: string): string {
@@ -50,9 +53,58 @@ async function extractPdf(buf: Buffer): Promise<string> {
             DOC_EXTRACT_LIMITS.PDF_TIMEOUT_MS,
             'PDF',
         );
-        return typeof out === 'string' ? out : '';
+        const text = typeof out === 'string' ? out : '';
+        // 텍스트 레이어가 충분하면 그대로 사용. 추출량이 매우 적으면 스캔본(이미지 PDF)으로
+        // 보고 OCR 폴백 — opendataloader 는 OCR 미지원이므로 officeparser+tesseract 로 재시도.
+        if (text.trim().length >= DOC_EXTRACT_LIMITS.PDF_MIN_TEXT_CHARS || !DOC_EXTRACT_LIMITS.OCR_ENABLED) {
+            return text;
+        }
+        logger.info(`[DocExtract] PDF 텍스트 레이어 부족(${text.trim().length}자) — 스캔본 의심, OCR 폴백 시도`);
+        try {
+            const ocrText = await extractPdfOcr(buf);
+            return ocrText.trim().length > text.trim().length ? ocrText : text;
+        } catch (e) {
+            logger.warn(`[DocExtract] PDF OCR 폴백 실패: ${e instanceof Error ? e.message : e}`);
+            return text;
+        }
     } finally {
         await fs.unlink(tmp).catch(() => { /* noop */ });
+    }
+}
+
+/**
+ * 스캔본 PDF → text (sips 로 페이지 래스터화 후 tesseract.js OCR).
+ * officeparser 의 PDF OCR 은 페이지를 통째로 래스터화하지 않아(임베드 이미지 객체만 처리)
+ * 스캔본을 못 읽으므로, macOS 내장 sips 로 PDF→PNG 변환 후 tesseract 로 직접 인식한다.
+ * (운영 서버가 macOS 확정 — opendataloader JVM 과 동일하게 환경 종속. 다중 페이지 PDF 는
+ * sips 가 첫 페이지만 변환하므로 첫 페이지 위주로 인식된다.)
+ */
+async function extractPdfOcr(buf: Buffer): Promise<string> {
+    const id = crypto.randomUUID();
+    const tmpPdf = path.join(os.tmpdir(), `om-ocr-${id}.pdf`);
+    const tmpPng = path.join(os.tmpdir(), `om-ocr-${id}.png`);
+    await fs.writeFile(tmpPdf, buf);
+    try {
+        // PDF → PNG 래스터화 (macOS sips)
+        await execFileAsync('sips', ['-s', 'format', 'png', tmpPdf, '--out', tmpPng], {
+            timeout: DOC_EXTRACT_LIMITS.PDF_TIMEOUT_MS,
+        });
+        // tesseract.js OCR (officeparser 의 트랜지티브 의존 — 별도 설치 불필요)
+        const { createWorker } = await import('tesseract.js');
+        const worker = await createWorker(DOC_EXTRACT_LIMITS.OCR_LANGS);
+        try {
+            const { data } = await withTimeout(
+                worker.recognize(tmpPng),
+                DOC_EXTRACT_LIMITS.OCR_TIMEOUT_MS,
+                'PDF OCR',
+            );
+            return data.text || '';
+        } finally {
+            await worker.terminate();
+        }
+    } finally {
+        await fs.unlink(tmpPdf).catch(() => { /* noop */ });
+        await fs.unlink(tmpPng).catch(() => { /* noop */ });
     }
 }
 


### PR DESCRIPTION
## 요약
텍스트 레이어가 없는 **스캔본(이미지) PDF**의 본문을 OCR로 추출하는 폴백을 추가한다.
opendataloader-pdf는 텍스트 레이어만 추출하므로 스캔본은 0자로 나오던 문제를 보완.

## 동작
1. `extractPdf`가 opendataloader 추출 결과를 확인
2. 텍스트가 `PDF_MIN_TEXT_CHARS`(기본 16자) 미만이면 **스캔본으로 판단 → OCR 폴백**
3. `extractPdfOcr`: macOS **sips로 PDF→PNG 래스터화** 후 **tesseract.js OCR**

## 왜 sips + tesseract 직접인가
- tesseract 엔진 자체는 정상(PNG 직접 OCR로 확인)
- 그러나 officeparser의 PDF OCR은 페이지를 통째로 래스터화하지 않고 "임베드 이미지 객체"만 처리 → 스캔본 페이지를 못 읽음(metadata만 반환)
- 따라서 PDF→이미지 단계를 sips로 직접 수행 (운영 서버 macOS 확정 — opendataloader JVM과 동일하게 환경 종속)

## 설정 (`DOC_EXTRACT_LIMITS`)
- `OCR_ENABLED`(기본 on) / `PDF_MIN_TEXT_CHARS`(16) / `OCR_TIMEOUT_MS`(120s) / `OCR_LANGS`(eng+kor)

## 검증 (E2E)
- 텍스트 레이어 0인 스캔본 PDF 첨부
- 로그: "텍스트 레이어 부족(0자) → 스캔본 의심 → OCR 폴백" → "60자 추출"
- LLM 응답: **secret code/codename 정확 인식** ✅
- 기존 텍스트 PDF·Office·이미지 vision 경로 회귀 없음

## 한계
- 다중 페이지 PDF는 sips가 첫 페이지만 변환 → 첫 페이지 위주 인식
- macOS 전용(sips). Linux 이식 시 PDF 래스터화 방식 교체 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)