### PR TITLE
feat(chat): 응답 진행상황 가시화 (분석중 인디케이터 + thinking 표시)

### DIFF
--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, type ReactNode } from "react";
 import Image from "next/image";
-import { MessagesSquare, Telescope, Brain, Sparkles, FileCode2 } from "lucide-react";
+import { MessagesSquare, Telescope, Brain, Sparkles, FileCode2, ChevronRight } from "lucide-react";
 import { useAppStore } from "@/lib/store";
 import { Markdown } from "./markdown";
 import { cn } from "@/lib/utils";
@@ -84,6 +84,42 @@ function AssistantContent({ content, streaming }: { content: string; streaming?:
   return <>{nodes}</>;
 }
 
+/**
+ * 질문 전송 후 첫 토큰이 오기 전까지(LLM 분석/생각 중) 표시하는 진행 인디케이터.
+ * 선택된 에이전트·활성 스킬이 있으면 함께 노출해 어떤 상태인지 인지시킨다.
+ */
+function ThinkingIndicator({
+  agent,
+  skills,
+}: {
+  agent: { name: string; emoji?: string } | null;
+  skills: string[];
+}) {
+  const label = agent
+    ? `${agent.emoji ? agent.emoji + " " : ""}${agent.name}가 분석 중`
+    : skills.length > 0
+      ? `${skills.join(", ")} 적용 중`
+      : "분석 중";
+  return (
+    <div className="flex gap-3">
+      <div className="mt-0.5 grid h-7 w-7 shrink-0 place-items-center rounded-md bg-accent text-xs font-bold text-accent-fg">
+        AI
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="mb-1 text-xs font-medium text-muted">OpenMake</p>
+        <div className="flex items-center gap-2 text-sm text-muted">
+          <span className="flex gap-1" aria-hidden>
+            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-muted [animation-delay:0ms]" />
+            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-muted [animation-delay:150ms]" />
+            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-muted [animation-delay:300ms]" />
+          </span>
+          <span>{label}…</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 const QUICK_STARTS = [
   { icon: MessagesSquare, label: "요약하기", prompt: "다음 내용을 요약해 줘:\n\n" },
   { icon: Telescope, label: "리서치", prompt: "다음 주제를 깊이 리서치해 줘:\n\n" },
@@ -94,11 +130,19 @@ const QUICK_STARTS = [
 export function MessageList() {
   const chatHistory = useAppStore((s) => s.chatHistory);
   const setInputDraft = useAppStore((s) => s.setInputDraft);
+  const isGenerating = useAppStore((s) => s.isGenerating);
+  const activeAgent = useAppStore((s) => s.activeAgent);
+  const activeSkills = useAppStore((s) => s.activeSkills);
   const bottomRef = useRef<HTMLDivElement>(null);
+
+  // 응답이 진행 중인데 아직 스트리밍 중인 assistant 메시지가 없으면(첫 토큰 전) "분석 중" 표시
+  const last = chatHistory[chatHistory.length - 1];
+  const showThinking =
+    isGenerating && !(last?.role === "assistant" && last?.streaming);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [chatHistory]);
+  }, [chatHistory, showThinking]);
 
   if (chatHistory.length === 0) {
     return (
@@ -154,6 +198,18 @@ export function MessageList() {
             </div>
             <div className="min-w-0 flex-1">
               <p className="mb-1 text-xs font-medium text-muted">OpenMake</p>
+              {m.reasoning && (
+                <details className="group mb-2 rounded-lg border border-border bg-surface-2/60 text-xs">
+                  <summary className="flex cursor-pointer select-none items-center gap-1.5 px-3 py-1.5 font-medium text-muted list-none [&::-webkit-details-marker]:hidden">
+                    <ChevronRight className="h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-90" />
+                    <Brain className="h-3.5 w-3.5 text-accent" />
+                    생각 과정
+                  </summary>
+                  <div className="whitespace-pre-wrap px-3 pb-2.5 pt-1 leading-relaxed text-muted">
+                    {m.reasoning}
+                  </div>
+                </details>
+              )}
               <div className="text-sm leading-relaxed text-fg">
                 <AssistantContent content={m.content} streaming={m.streaming} />
                 {m.streaming && (
@@ -164,6 +220,7 @@ export function MessageList() {
           </div>
         ),
       )}
+      {showThinking && <ThinkingIndicator agent={activeAgent} skills={activeSkills} />}
       <div ref={bottomRef} className={cn("h-px")} />
     </div>
   );

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -14,6 +14,8 @@ export interface ChatMessage extends Pick<SharedChatMessage, "role" | "content" 
   streaming?: boolean;
   /** 에이전트 작업 메시지 — agent_task_progress 로 라이브 업데이트되는 메시지 식별자 */
   taskId?: string;
+  /** 추론(thinking) 내용 — ws thinking 이벤트로 누적, 화면에 접이식 블록으로 표시 */
+  reasoning?: string;
 }
 
 export type { ChatRole };
@@ -79,6 +81,7 @@ interface AppState {
   setChatHistory: (fn: (prev: ChatMessage[]) => ChatMessage[]) => void;
   appendMessage: (m: ChatMessage) => void;
   appendToken: (token: string) => void;
+  appendThinking: (token: string) => void;
   setStreaming: (v: boolean) => void;
   setCurrentSessionId: (id: string | null) => void;
   setInputDraft: (t: string) => void;
@@ -123,7 +126,7 @@ export const useAppStore = create<AppState>((set) => ({
   activeArtifactId: null,
   artifactPanelOpen: false,
 
-  thinkingEnabled: false, // opt-in — ON 시 매 응답 thinking(지연·비용↑). 사용자가 필요할 때 켬
+  thinkingEnabled: true, // 기본 ON — tool calling 중 추론(thinking) 과정을 화면에 노출
   discussionMode: false,
   deepResearchMode: false,
   webSearchEnabled: false,
@@ -147,6 +150,18 @@ export const useAppStore = create<AppState>((set) => ({
         hist[hist.length - 1] = { ...last, content: last.content + token };
       } else {
         hist.push({ role: "assistant", content: token, streaming: true });
+      }
+      return { chatHistory: hist };
+    }),
+  appendThinking: (token) =>
+    set((s) => {
+      const hist = [...s.chatHistory];
+      const last = hist[hist.length - 1];
+      if (last && last.role === "assistant" && last.streaming) {
+        hist[hist.length - 1] = { ...last, reasoning: (last.reasoning || "") + token };
+      } else {
+        // thinking 은 보통 답변 토큰보다 먼저 도착 — assistant placeholder 를 생성해 누적
+        hist.push({ role: "assistant", content: "", reasoning: token, streaming: true });
       }
       return { chatHistory: hist };
     }),

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -62,6 +62,7 @@ export function useChatSocket() {
     appendMessage,
     setChatHistory,
     appendToken,
+    appendThinking,
     setStreaming,
     setCurrentSessionId,
     setActiveAgent,
@@ -93,6 +94,9 @@ export function useChatSocket() {
       switch (data.type) {
         case "token":
           if (data.token) appendToken(data.token);
+          break;
+        case "thinking":
+          if (data.token) appendThinking(data.token);
           break;
         case "session_created":
           if (data.sessionId) setCurrentSessionId(data.sessionId);

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -115,6 +115,7 @@ export interface ArtifactMeta {
 
 export type WsServerEvent =
   | { type: "token"; token: string }
+  | { type: "thinking"; token: string; messageId?: string }
   | { type: "session_created"; sessionId: string }
   | { type: "done"; sessionId?: string; totalTokens?: number }
   | { type: "aborted"; message?: string }


### PR DESCRIPTION
## 요약
질문 전송 후 **첫 토큰이 오기 전** 화면이 비어 사용자가 진행 여부를 알 수 없던 문제를 개선한다.

## 변경
- **분석 중 인디케이터**: 첫 토큰 전 AI 아바타 + bounce 점 애니메이션 + 선택된 에이전트/스킬 표시
- **Thinking 기본 ON**: tool calling 중 추론 노출 (`thinkingEnabled` 기본 true)
- **생각 과정 표시**: ws `thinking` 이벤트 → `reasoning` 누적 → **접이식 블록(기본 접힘, 클릭 펼침, ChevronRight 회전)**
  - 백엔드는 이미 `thinking` 이벤트(`onThinking`)를 발행 중 → **프론트 연결만**
- `WsServerEvent`에 `thinking` 타입, store `appendThinking`/`reasoning` 필드 추가

## 검증 (Playwright)
- 전송 즉시 "분석 중" 인디케이터(점3 애니메이션) 표시 ✅
- Thinking 토글 기본 활성 ✅
- 생각 과정 기본 접힘 → 클릭 시 펼쳐 실제 추론 내용 표시 ✅
- 답변 스트리밍 정상 ✅

파일: `message-list.tsx`, `store.ts`, `use-chat-socket.ts`, `packages/shared-types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)