### PR TITLE
feat(scraper): 공개 API/RSS 폴백 + 브라우저 UA + 차단우회(옵트인)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -470,6 +470,28 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # URL_ANALYZE_TIMEOUT_MS=8000
 
 # *******************************************************
+# 웹 스크래퍼 폴백·차단우회 (config/web-scraper SCRAPER_CONFIG)
+# *******************************************************
+# 외부 요청 User-Agent (기본: 현실적 Chrome UA — 봇 차단 통과용)
+# SCRAPER_USER_AGENT=
+# 구조화 소스 핸들러(YouTube oEmbed·HN Algolia) on/off (기본 on)
+# SCRAPER_STRUCTURED_ENABLED=true
+# RSS 폴백(본문 0일 때) on/off (기본 on)
+# SCRAPER_RSS_FALLBACK_ENABLED=true
+# --- 차단 우회 (curl_cffi TLS 임퍼소네이션) — 기본 OFF, 옵트인 ---
+# 활성화 전 서버에 `pip install curl_cffi` 필요. ToS 회색지대·유지보수 부담 유의.
+# SCRAPER_IMPERSONATE_ENABLED=false
+# 차단우회 허용 도메인 화이트리스트 (SSRF·남용 방지)
+# SCRAPER_IMPERSONATE_WHITELIST=reddit.com,www.reddit.com,old.reddit.com,oauth.reddit.com
+# curl_cffi 임퍼소네이션 브라우저 프로필
+# SCRAPER_IMPERSONATE_TARGET=chrome120
+# 차단우회 응답 최대 바이트 / 타임아웃 ms
+# SCRAPER_IMPERSONATE_MAX_BYTES=5000000
+# SCRAPER_IMPERSONATE_TIMEOUT_MS=15000
+# python3 실행 경로 (curl_cffi 호출용)
+# SCRAPER_PYTHON_BIN=python3
+
+# *******************************************************
 # 첨부 컨텍스트 세션 캐시 (config/runtime-limits ATTACH_CACHE_LIMITS)
 # 첨부 파일/URL 분석 내용을 세션 메모리에 보관해 후속 턴에 재주입 (DB 미저장)
 # *******************************************************

--- a/apps/api/src/config/web-scraper.ts
+++ b/apps/api/src/config/web-scraper.ts
@@ -1,0 +1,67 @@
+/**
+ * ============================================================
+ * Web Scraper Config (L2) — UA · 구조화 소스 · 차단우회 정책
+ * ============================================================
+ * CLAUDE.md No-Hardcoding Policy 에 따라 스크래퍼 정책을 명명 상수로 외부화.
+ * utils/web-scraper.ts · utils/web-scraper-handlers.ts · utils/impersonate-fetch.ts 에서 참조.
+ *
+ * @module config/web-scraper
+ */
+
+export const SCRAPER_CONFIG = {
+    /**
+     * 외부 요청 User-Agent. 봇임을 명시하던 'OpenMakeBot/1.0' 대신 현실적 브라우저 UA 로
+     * UA 기반 약한 봇 차단을 통과한다. (TLS fingerprint 차단은 impersonate 경로 담당)
+     */
+    USER_AGENT: process.env.SCRAPER_USER_AGENT
+        || 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+
+    /** 구조화 소스 핸들러(YouTube oEmbed · HN Algolia) 사용 (기본 on) */
+    STRUCTURED_SOURCE_ENABLED: process.env.SCRAPER_STRUCTURED_ENABLED !== 'false',
+
+    /** RSS 폴백(본문 0일 때) 사용 (기본 on) */
+    RSS_FALLBACK_ENABLED: process.env.SCRAPER_RSS_FALLBACK_ENABLED !== 'false',
+
+    /**
+     * 차단 우회(curl_cffi TLS 임퍼소네이션) — **기본 OFF**.
+     * 운영 활성화: 서버에 `pip install curl_cffi` 후 SCRAPER_IMPERSONATE_ENABLED=true.
+     * ToS 회색지대·유지보수 부담이 있어 옵트인.
+     */
+    IMPERSONATE_ENABLED: process.env.SCRAPER_IMPERSONATE_ENABLED === 'true',
+
+    /** 차단 우회 허용 도메인 화이트리스트 (SSRF·남용 방지 — 명시 소셜 사이트만) */
+    IMPERSONATE_WHITELIST: (process.env.SCRAPER_IMPERSONATE_WHITELIST
+        || 'reddit.com,www.reddit.com,old.reddit.com,oauth.reddit.com')
+        .split(',').map((s) => s.trim().toLowerCase()).filter(Boolean),
+
+    /** curl_cffi 임퍼소네이션 브라우저 프로필 */
+    IMPERSONATE_TARGET: process.env.SCRAPER_IMPERSONATE_TARGET || 'chrome120',
+
+    /** 차단 우회 응답 최대 바이트 (메모리 보호) */
+    IMPERSONATE_MAX_BYTES: parseInt(process.env.SCRAPER_IMPERSONATE_MAX_BYTES || '5000000', 10),
+
+    /** 차단 우회 타임아웃 (ms) */
+    IMPERSONATE_TIMEOUT_MS: parseInt(process.env.SCRAPER_IMPERSONATE_TIMEOUT_MS || '15000', 10),
+
+    /** python3 실행 경로 (curl_cffi 호출용) */
+    PYTHON_BIN: process.env.SCRAPER_PYTHON_BIN || 'python3',
+} as const;
+
+/**
+ * 브라우저 유사 헤더 세트 (UA + Sec-CH-UA + Accept).
+ * safeFetch 의 일반 경로에서 사용해 봇 식별 표면을 줄인다.
+ */
+export function browserHeaders(): Record<string, string> {
+    return {
+        'User-Agent': SCRAPER_CONFIG.USER_AGENT,
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+        'Accept-Language': 'ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7',
+        'Sec-CH-UA': '"Chromium";v="120", "Not(A:Brand";v="24", "Google Chrome";v="120"',
+        'Sec-CH-UA-Mobile': '?0',
+        'Sec-CH-UA-Platform': '"macOS"',
+        'Sec-Fetch-Dest': 'document',
+        'Sec-Fetch-Mode': 'navigate',
+        'Sec-Fetch-Site': 'none',
+        'Upgrade-Insecure-Requests': '1',
+    };
+}

--- a/apps/api/src/utils/impersonate-fetch.ts
+++ b/apps/api/src/utils/impersonate-fetch.ts
@@ -1,0 +1,134 @@
+/**
+ * ============================================================
+ * Impersonate Fetch — TLS fingerprint 임퍼소네이션 (차단 우회, 2단계)
+ * ============================================================
+ * Reddit 등 TLS(JA3) fingerprint 로 봇을 차단하는 사이트는 Node fetch/undici 로
+ * 우회 불가하다. Python `curl_cffi`(브라우저 TLS 임퍼소네이션)를 child_process 로
+ * 호출해 공개 엔드포인트(.json 등)에 접근한다. (doc-extractor 의 child_process 패턴 동형)
+ *
+ * **보안(SSRF) 정합** — curl_cffi 는 별도 프로세스라 safeFetch 의 SSRF 가드를 우회하므로:
+ *   1. 도메인 화이트리스트(SCRAPER_CONFIG.IMPERSONATE_WHITELIST)에만 허용
+ *   2. DNS resolve 후 차단 IP 대역(isBlockedIP) 거부
+ *   3. resolve 한 공인 IP 를 curl `--resolve` 로 고정 → DNS rebinding 차단
+ *   4. allow_redirects=False → 단일 hop (리다이렉트로 내부망 우회 방지)
+ *
+ * 기본 OFF(SCRAPER_CONFIG.IMPERSONATE_ENABLED). curl_cffi 미설치 시 graceful null.
+ *
+ * @module utils/impersonate-fetch
+ */
+import { execFile } from 'child_process';
+import dns from 'node:dns/promises';
+import { isBlockedIP } from '../security/ssrf-guard';
+import { SCRAPER_CONFIG } from '../config/web-scraper';
+import { createLogger } from './logger';
+
+const logger = createLogger('ImpersonateFetch');
+
+/** python 스크립트를 stdin 으로 payload 를 넘겨 실행하고 stdout 을 반환 (execFile 은 input 옵션 미지원). */
+function runPython(payload: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const child = execFile(
+            SCRAPER_CONFIG.PYTHON_BIN,
+            ['-c', PY_SCRIPT],
+            {
+                timeout: SCRAPER_CONFIG.IMPERSONATE_TIMEOUT_MS + 5000,
+                maxBuffer: SCRAPER_CONFIG.IMPERSONATE_MAX_BYTES + 1_000_000,
+            },
+            (err, stdout) => {
+                if (err) reject(err);
+                else resolve(stdout);
+            },
+        );
+        child.stdin?.end(payload);
+    });
+}
+
+/** stdin 으로 받은 설정으로 curl_cffi GET 을 수행하는 파이썬 스크립트 (인자는 stdin JSON — 셸 인젝션 차단) */
+const PY_SCRIPT = `
+import sys, json
+data = json.load(sys.stdin)
+try:
+    from curl_cffi import requests
+except Exception:
+    print(json.dumps({"error": "curl_cffi_not_installed"})); sys.exit(0)
+try:
+    r = requests.get(
+        data["url"],
+        impersonate=data["target"],
+        allow_redirects=False,
+        timeout=data["timeout"],
+        resolve=[data["resolve"]],
+        headers={"Accept-Language": "en-US,en;q=0.9"},
+    )
+    body = r.text
+    if len(body) > data["maxBytes"]:
+        body = body[: data["maxBytes"]]
+    print(json.dumps({"status": r.status_code, "body": body}))
+except Exception as e:
+    print(json.dumps({"error": str(e)[:300]}))
+`;
+
+export interface ImpersonateResult {
+    status: number;
+    body: string;
+}
+
+/**
+ * curl_cffi 로 차단 우회 GET. 비활성/비화이트리스트/차단IP/미설치 시 null (graceful).
+ */
+export async function impersonateFetch(rawUrl: string): Promise<ImpersonateResult | null> {
+    if (!SCRAPER_CONFIG.IMPERSONATE_ENABLED) return null;
+
+    let u: URL;
+    try {
+        u = new URL(rawUrl);
+    } catch {
+        return null;
+    }
+    if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+
+    // 1. 화이트리스트 도메인만
+    if (!SCRAPER_CONFIG.IMPERSONATE_WHITELIST.includes(u.hostname.toLowerCase())) {
+        logger.warn(`[impersonate] 비화이트리스트 도메인 거부: ${u.hostname}`);
+        return null;
+    }
+
+    // 2. DNS resolve + 차단 IP 거부, 3. 고정 IP 확보
+    let address: string;
+    try {
+        ({ address } = await dns.lookup(u.hostname));
+    } catch {
+        return null;
+    }
+    if (isBlockedIP(address)) {
+        logger.warn(`[impersonate] 차단 IP 대역 거부: ${u.hostname} → ${address}`);
+        return null;
+    }
+    const port = u.port || (u.protocol === 'https:' ? '443' : '80');
+
+    const payload = JSON.stringify({
+        url: rawUrl,
+        target: SCRAPER_CONFIG.IMPERSONATE_TARGET,
+        timeout: Math.ceil(SCRAPER_CONFIG.IMPERSONATE_TIMEOUT_MS / 1000),
+        maxBytes: SCRAPER_CONFIG.IMPERSONATE_MAX_BYTES,
+        // curl --resolve host:port:ip 로 DNS rebinding 차단 (검증한 IP 로만 연결)
+        resolve: `${u.hostname}:${port}:${address}`,
+    });
+
+    try {
+        const stdout = await runPython(payload);
+        const out = JSON.parse(stdout.trim());
+        if (out.error) {
+            if (out.error === 'curl_cffi_not_installed') {
+                logger.warn('[impersonate] curl_cffi 미설치 — `pip install curl_cffi` 필요');
+            } else {
+                logger.warn(`[impersonate] 실패: ${out.error}`);
+            }
+            return null;
+        }
+        return { status: out.status, body: out.body };
+    } catch (e) {
+        logger.warn(`[impersonate] child_process 실패: ${e instanceof Error ? e.message : e}`);
+        return null;
+    }
+}

--- a/apps/api/src/utils/web-scraper-handlers.ts
+++ b/apps/api/src/utils/web-scraper-handlers.ts
@@ -1,0 +1,259 @@
+/**
+ * ============================================================
+ * Web Scraper Handlers — 구조화 소스 · 차단우회 · RSS 폴백
+ * ============================================================
+ * scrapePage 의 보조 경로:
+ *  - resolveStructuredSource: YouTube oEmbed · HN Algolia (공개 API, safeFetch)
+ *  - resolveBlockedSource: Reddit (curl_cffi 임퍼소네이션, 플래그 OFF 기본)
+ *  - tryRssFallback: 본문 0일 때 RSS 피드 탐지·파싱
+ *
+ * 모든 일반 외부 호출은 safeFetch(SSRF guard) 경유. 차단우회는 impersonateFetch 가
+ * 자체 SSRF 정합(화이트리스트+고정IP+no-redirect)을 수행한다.
+ *
+ * @module utils/web-scraper-handlers
+ */
+import { JSDOM } from 'jsdom';
+import { safeFetch } from '../security/ssrf-guard';
+import { impersonateFetch } from './impersonate-fetch';
+import { SCRAPER_CONFIG, browserHeaders } from '../config/web-scraper';
+import { createLogger } from './logger';
+import type { ScrapeResult } from './web-scraper';
+
+const logger = createLogger('ScraperHandlers');
+
+// ============================================
+// 구조화 소스 핸들러 (공개 API)
+// ============================================
+
+/** YouTube → oEmbed 메타(제목·채널). 자막은 불안정해 미포함(best-effort 메타만). */
+async function youtubeHandler(url: string): Promise<ScrapeResult | null> {
+    const oembed = `https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`;
+    const res = await safeFetch(oembed, { headers: browserHeaders() });
+    if (!res.ok) return null;
+    const j = await res.json() as { title?: string; author_name?: string; author_url?: string; thumbnail_url?: string };
+    if (!j.title) return null;
+    const markdown = `# ${j.title}\n\n` +
+        (j.author_name ? `**채널:** ${j.author_name}\n\n` : '') +
+        (j.thumbnail_url ? `![thumbnail](${j.thumbnail_url})\n\n` : '') +
+        `원본 영상: ${url}\n\n` +
+        `(YouTube 메타데이터 — 영상 자막/본문은 포함되지 않음)`;
+    return { markdown, title: j.title, links: [j.author_url, url].filter((x): x is string => !!x) };
+}
+
+interface HnItem {
+    title?: string;
+    text?: string;
+    url?: string;
+    author?: string;
+    points?: number;
+    children?: HnItem[];
+}
+
+/** HN 댓글 트리를 들여쓰기 markdown 으로 (깊이·개수 제한). */
+function renderHnComments(items: HnItem[] | undefined, depth: number, budget: { left: number }): string {
+    if (!items || depth > 4 || budget.left <= 0) return '';
+    let out = '';
+    for (const c of items) {
+        if (budget.left <= 0) break;
+        if (!c.text) continue;
+        budget.left -= 1;
+        const indent = '  '.repeat(depth);
+        const text = c.text.replace(/<[^>]+>/g, '').slice(0, 800);
+        out += `${indent}- **${c.author || '익명'}:** ${text}\n`;
+        out += renderHnComments(c.children, depth + 1, budget);
+    }
+    return out;
+}
+
+/** Hacker News → Algolia items API (제목·본문·상위 댓글). */
+async function hnHandler(url: string): Promise<ScrapeResult | null> {
+    const m = url.match(/item\?id=(\d+)/);
+    if (!m) return null;
+    const res = await safeFetch(`https://hn.algolia.com/api/v1/items/${m[1]}`, { headers: browserHeaders() });
+    if (!res.ok) return null;
+    const item = await res.json() as HnItem;
+    if (!item.title) return null;
+    const body = (item.text || '').replace(/<[^>]+>/g, '');
+    const comments = renderHnComments(item.children, 0, { left: 30 });
+    const markdown = `# ${item.title}\n\n` +
+        (item.url ? `링크: ${item.url}\n\n` : '') +
+        (body ? `${body}\n\n` : '') +
+        (comments ? `## 댓글\n\n${comments}` : '');
+    return { markdown, title: item.title, links: item.url ? [item.url] : [] };
+}
+
+// ============================================
+// 차단 우회 핸들러 (impersonate)
+// ============================================
+
+interface RedditThing { data?: Record<string, unknown>; kind?: string }
+interface RedditListing { data?: { children?: RedditThing[] } }
+
+/** Reddit → .json (curl_cffi 임퍼소네이션). 게시글 본문 + 상위 댓글. */
+async function redditHandler(url: string): Promise<ScrapeResult | null> {
+    // 쿼리/해시 제거 후 .json 부착
+    const u = new URL(url);
+    const jsonUrl = `${u.origin}${u.pathname.replace(/\/$/, '')}.json`;
+    const res = await impersonateFetch(jsonUrl);
+    if (!res || res.status !== 200) return null;
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(res.body);
+    } catch {
+        return null;
+    }
+    if (!Array.isArray(parsed) || parsed.length < 1) return null;
+
+    const postListing = parsed[0] as RedditListing;
+    const post = postListing.data?.children?.[0]?.data as Record<string, string> | undefined;
+    if (!post) return null;
+    const title = String(post.title || '');
+    const selftext = String(post.selftext || '');
+
+    let comments = '';
+    if (parsed.length >= 2) {
+        const commentListing = parsed[1] as RedditListing;
+        const children = commentListing.data?.children || [];
+        let count = 0;
+        for (const c of children) {
+            if (count >= 20) break;
+            const body = c.data?.body as string | undefined;
+            const author = c.data?.author as string | undefined;
+            if (!body) continue;
+            count += 1;
+            comments += `- **${author || '익명'}:** ${body.slice(0, 800)}\n`;
+        }
+    }
+    const markdown = `# ${title}\n\n` +
+        (selftext ? `${selftext}\n\n` : '') +
+        (comments ? `## 댓글\n\n${comments}` : '');
+    return { markdown, title, links: [] };
+}
+
+// ============================================
+// 레지스트리
+// ============================================
+
+const STRUCTURED_HANDLERS: Array<{ match: (u: URL) => boolean; handler: (url: string) => Promise<ScrapeResult | null> }> = [
+    { match: (u) => /(?:^|\.)youtube\.com$/.test(u.hostname) && u.pathname === '/watch', handler: youtubeHandler },
+    { match: (u) => u.hostname === 'youtu.be', handler: youtubeHandler },
+    { match: (u) => u.hostname === 'news.ycombinator.com' && u.pathname === '/item', handler: hnHandler },
+];
+
+const BLOCKED_HANDLERS: Array<{ match: (u: URL) => boolean; handler: (url: string) => Promise<ScrapeResult | null> }> = [
+    { match: (u) => /(?:^|\.)reddit\.com$/.test(u.hostname), handler: redditHandler },
+];
+
+function safeUrl(url: string): URL | null {
+    try { return new URL(url); } catch { return null; }
+}
+
+/** YouTube/HN 등 공개 구조화 소스 — 매칭+성공 시 ScrapeResult, 아니면 null. */
+export async function resolveStructuredSource(url: string): Promise<ScrapeResult | null> {
+    if (!SCRAPER_CONFIG.STRUCTURED_SOURCE_ENABLED) return null;
+    const u = safeUrl(url);
+    if (!u) return null;
+    for (const h of STRUCTURED_HANDLERS) {
+        if (h.match(u)) {
+            try {
+                return await h.handler(url);
+            } catch (e) {
+                logger.warn(`[structured] ${u.hostname} 핸들러 실패: ${e instanceof Error ? e.message : e}`);
+                return null;
+            }
+        }
+    }
+    return null;
+}
+
+/** Reddit 등 차단 사이트 — impersonate 활성 시에만. 매칭+성공 시 ScrapeResult. */
+export async function resolveBlockedSource(url: string): Promise<ScrapeResult | null> {
+    if (!SCRAPER_CONFIG.IMPERSONATE_ENABLED) return null;
+    const u = safeUrl(url);
+    if (!u) return null;
+    for (const h of BLOCKED_HANDLERS) {
+        if (h.match(u)) {
+            try {
+                return await h.handler(url);
+            } catch (e) {
+                logger.warn(`[blocked] ${u.hostname} 핸들러 실패: ${e instanceof Error ? e.message : e}`);
+                return null;
+            }
+        }
+    }
+    return null;
+}
+
+// ============================================
+// RSS 폴백
+// ============================================
+
+/** HTML 에서 RSS/Atom 피드 URL 후보를 찾는다. */
+function findFeedCandidates(html: string, origin: string): string[] {
+    const candidates: string[] = [];
+    try {
+        const doc = new JSDOM(html).window.document;
+        doc.querySelectorAll('link[rel="alternate"]').forEach((l) => {
+            const type = (l.getAttribute('type') || '').toLowerCase();
+            const href = l.getAttribute('href');
+            if (href && (type.includes('rss') || type.includes('atom') || type.includes('xml'))) {
+                try { candidates.push(new URL(href, origin).toString()); } catch { /* skip */ }
+            }
+        });
+    } catch { /* skip */ }
+    // 관례적 경로 폴백
+    candidates.push(`${origin}/feed`, `${origin}/rss`, `${origin}/atom.xml`, `${origin}/feed.xml`);
+    return [...new Set(candidates)];
+}
+
+/** RSS/Atom XML → 항목 제목·요약 markdown. */
+function parseFeed(xml: string): ScrapeResult | null {
+    let doc: Document;
+    try {
+        doc = new JSDOM(xml, { contentType: 'text/xml' }).window.document;
+    } catch {
+        return null;
+    }
+    const channelTitle = doc.querySelector('channel > title, feed > title')?.textContent?.trim() || '피드';
+    const items = Array.from(doc.querySelectorAll('item, entry')).slice(0, 20);
+    if (items.length === 0) return null;
+    let markdown = `# ${channelTitle}\n\n`;
+    for (const it of items) {
+        const t = it.querySelector('title')?.textContent?.trim() || '(제목 없음)';
+        const link = it.querySelector('link')?.textContent?.trim()
+            || it.querySelector('link')?.getAttribute('href') || '';
+        const desc = (it.querySelector('description, summary, content')?.textContent || '')
+            .replace(/<[^>]+>/g, '').trim().slice(0, 300);
+        markdown += `## ${t}\n${link ? link + '\n' : ''}${desc ? desc + '\n' : ''}\n`;
+    }
+    return { markdown, title: channelTitle, links: [] };
+}
+
+/** 본문 추출 실패 시 RSS 피드로 폴백. */
+export async function tryRssFallback(url: string): Promise<ScrapeResult | null> {
+    if (!SCRAPER_CONFIG.RSS_FALLBACK_ENABLED) return null;
+    const u = safeUrl(url);
+    if (!u) return null;
+    // 원 페이지 HTML 에서 피드 링크 탐지 (실패해도 관례 경로 시도)
+    let html = '';
+    try {
+        const res = await safeFetch(url, { headers: browserHeaders() });
+        if (res.ok) html = await res.text();
+    } catch { /* 관례 경로로 진행 */ }
+
+    for (const feedUrl of findFeedCandidates(html, u.origin)) {
+        try {
+            const res = await safeFetch(feedUrl, { headers: browserHeaders() });
+            if (!res.ok) continue;
+            const xml = await res.text();
+            if (!/<(rss|feed|channel)\b/i.test(xml)) continue;
+            const parsed = parseFeed(xml);
+            if (parsed && parsed.markdown.trim().length > 0) {
+                logger.info(`[rss] 폴백 성공: ${feedUrl}`);
+                return parsed;
+            }
+        } catch { /* 다음 후보 */ }
+    }
+    return null;
+}

--- a/apps/api/src/utils/web-scraper.ts
+++ b/apps/api/src/utils/web-scraper.ts
@@ -18,6 +18,8 @@ import { gfm } from 'turndown-plugin-gfm';
 import { safeFetch, validateOutboundUrl } from '../security/ssrf-guard';
 import { createLogger } from './logger';
 import { LLM_TIMEOUTS } from '../config/timeouts';
+import { SCRAPER_CONFIG, browserHeaders } from '../config/web-scraper';
+import { resolveStructuredSource, resolveBlockedSource, tryRssFallback } from './web-scraper-handlers';
 
 const logger = createLogger('WebScraper');
 
@@ -142,6 +144,28 @@ export async function scrapePage(url: string, options: ScrapeOptions = {}): Prom
     const timeoutMs = options.timeoutMs ?? LLM_TIMEOUTS.WEB_SCRAPE_TIMEOUT_MS;
     const onlyMainContent = options.onlyMainContent !== false;
 
+    // 0단계: 구조화 공개 소스 (YouTube oEmbed · HN Algolia) — 매칭 시 우선 사용
+    try {
+        const structured = await resolveStructuredSource(url);
+        if (structured && structured.markdown.trim().length > 0) {
+            recordSuccess();
+            return structured;
+        }
+    } catch (error) {
+        logger.warn(`[${url}] 구조화 소스 실패: ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    // 0b단계: 차단 사이트 우회 (Reddit 등 — impersonate 활성 시에만, 기본 OFF)
+    try {
+        const blocked = await resolveBlockedSource(url);
+        if (blocked && blocked.markdown.trim().length > 0) {
+            recordSuccess();
+            return blocked;
+        }
+    } catch (error) {
+        logger.warn(`[${url}] 차단우회 실패: ${error instanceof Error ? error.message : String(error)}`);
+    }
+
     // 1단계: safeFetch + Readability
     try {
         const result = await scrapeWithFetch(url, timeoutMs, onlyMainContent, options.signal);
@@ -162,14 +186,28 @@ export async function scrapePage(url: string, options: ScrapeOptions = {}): Prom
     }
     try {
         const result = await scrapeWithPlaywright(url, timeoutMs, onlyMainContent);
-        recordSuccess();
-        return result;
+        if (result.markdown.trim().length > 0) {
+            recordSuccess();
+            return result;
+        }
+        logger.info(`[${url}] Playwright 결과 비어있음 → RSS 폴백`);
     } catch (error) {
-        recordFailure();
-        throw new Error(
-            `스크래핑 실패 (${url}): ${error instanceof Error ? error.message : String(error)}`
-        );
+        logger.warn(`[${url}] Playwright 실패: ${error instanceof Error ? error.message : String(error)}`);
     }
+
+    // 3단계: RSS 폴백 (본문 추출 전부 실패/빈 결과)
+    try {
+        const rss = await tryRssFallback(url);
+        if (rss && rss.markdown.trim().length > 0) {
+            recordSuccess();
+            return rss;
+        }
+    } catch (error) {
+        logger.warn(`[${url}] RSS 폴백 실패: ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    recordFailure();
+    throw new Error(`스크래핑 실패 (${url}): 모든 단계(구조화·차단우회·fetch·playwright·rss) 실패`);
 }
 
 // ============================================
@@ -193,11 +231,7 @@ async function scrapeWithFetch(
 
     try {
         const response = await safeFetch(url, {
-            headers: {
-                'User-Agent': 'Mozilla/5.0 (compatible; OpenMakeBot/1.0)',
-                'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-                'Accept-Language': 'ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7',
-            },
+            headers: browserHeaders(),
             signal: controller.signal,
         });
 
@@ -308,7 +342,7 @@ export async function mapSiteUrls(url: string, options: MapOptions = {}): Promis
     try {
         const sitemapUrl = `${baseOrigin}/sitemap.xml`;
         const response = await safeFetch(sitemapUrl, {
-            headers: { 'User-Agent': 'Mozilla/5.0 (compatible; OpenMakeBot/1.0)' },
+            headers: { 'User-Agent': SCRAPER_CONFIG.USER_AGENT },
         });
 
         if (response.ok) {
@@ -330,7 +364,7 @@ export async function mapSiteUrls(url: string, options: MapOptions = {}): Promis
     if (urls.size < limit) {
         try {
             const response = await safeFetch(url, {
-                headers: { 'User-Agent': 'Mozilla/5.0 (compatible; OpenMakeBot/1.0)' },
+                headers: { 'User-Agent': SCRAPER_CONFIG.USER_AGENT },
             });
 
             if (response.ok) {


### PR DESCRIPTION
## 요약
`web-scraper.ts` 폴백을 강화해 **web_scrape MCP·딥리서치·URL 자동분석 3곳**의 소스 품질을 높인다. (insane-search 플러그인의 기법을 자체 구현 — 코드 차용 아님)

## 1단계 (활성)
- **브라우저 UA**: `OpenMakeBot/1.0`(봇 명시) → 현실적 Chrome UA + Sec-CH-UA (config 외부화)
- **구조화 소스 핸들러**: YouTube oEmbed(제목·채널), HN Algolia(제목·본문·댓글 트리)
- **RSS 폴백**: 본문 0일 때 `<link rel=alternate>`·관례경로 탐지 → jsdom 파싱

## 2단계 (코드 포함, **기본 OFF**)
- **Reddit 차단우회**: Python `curl_cffi`(TLS 임퍼소네이션) child_process — Node fetch로 못 뚫는 JA3 fingerprint 차단 대응
- **SSRF 정합**(서버 제품 필수): 도메인 화이트리스트 + DNS resolve 후 차단IP 거부 + `--resolve` 고정IP(rebinding 차단) + no-redirect
- `SCRAPER_IMPERSONATE_ENABLED` 기본 false, `curl_cffi` 미설치 시 graceful null

## 설계 판단
- **X 제외**: oEmbed 폐기로 무동작
- **YouTube 자막 제외**: 불안정 → oEmbed 메타만
- **추가 npm 의존성 0** (jsdom 재사용)

## scrapePage 흐름
```
구조화(YouTube/HN) → 차단우회(Reddit, OFF) → fetch(브라우저UA) → playwright → RSS 폴백
```

## 검증 (실측)
- HN item → 제목·링크·댓글 구조화 ✅
- YouTube → 제목·채널 ✅
- example.com 회귀 없음 ✅
- Reddit(플래그 OFF) → graceful `null` ✅
- 타입체크 통과(순환참조 없음), 백엔드 재시작 api=200

## 운영 활성화 (2단계, 선택)
`pip install curl_cffi` → `SCRAPER_IMPERSONATE_ENABLED=true`

신규: `config/web-scraper.ts`, `utils/impersonate-fetch.ts`, `utils/web-scraper-handlers.ts` / 수정: `web-scraper.ts`, `.env.example`

🤖 Generated with [Claude Code](https://claude.com/claude-code)