### PR TITLE
fix(web-search): 검색 컨텍스트 주입 캡으로 TTFT 단축 (14.6→9.7초)

### DIFF
--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -408,6 +408,21 @@ export const ATTACH_CACHE_LIMITS = {
 } as const;
 
 /**
+ * 채팅 웹검색 결과의 LLM 컨텍스트 주입 한도 (2026-06-25 TTFT 개선)
+ * 검색은 다소스 수집(랭킹 풀)을 위해 넉넉히 하되, LLM 에 실제 주입하는 양은 캡한다.
+ * 큰 검색 컨텍스트가 prompt prefill 을 키워 TTFT(첫 토큰)를 늘리는 것을 막는다 —
+ * SearXNG·위키 디랭크로 상위 결과 품질이 좋아져 적은 수로도 정답을 유지한다.
+ *
+ * sockets/ws-chat-handler.ts 에서 참조
+ */
+export const WEB_SEARCH_INJECTION = {
+    /** LLM 컨텍스트에 주입할 상위 결과 수 (수집은 더 많이 하되 주입은 캡) */
+    MAX_RESULTS: parseInt(process.env.WEB_SEARCH_INJECT_MAX_RESULTS || '6', 10),
+    /** 결과당 주입 snippet 최대 글자 수 (초과 절단) */
+    MAX_SNIPPET_CHARS: parseInt(process.env.WEB_SEARCH_INJECT_MAX_SNIPPET || '300', 10),
+} as const;
+
+/**
  * LLM 라우터 신뢰도 기본값
  * agents/llm-router.ts에서 참조
  */

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -22,6 +22,7 @@ import { getStaleDataWarning } from '../config/stale-data-warning';
 import { WS_LIMITS } from '../config/timeouts';
 import { ArtifactStreamParser, type ArtifactInfo } from '../llm/artifact-parser';
 import { buildFileContext, buildUrlContext, getCachedAttachContext, appendCachedAttachContext } from '../services/chat-service/attach-context';
+import { WEB_SEARCH_INJECTION } from '../config/runtime-limits';
 
 /**
  * AI 채팅 메시지를 처리합니다.
@@ -150,9 +151,14 @@ export async function handleChatMessage(
                 const searchResults = await performWebSearch(message, { maxResults: 12, language: userLang, preferRecent: isCurrentEventsQuery });
                 if (searchResults.length > 0) {
                     const tpl = getLocalizedTemplate(WEB_SEARCH_TEMPLATES, userLang);
+                    // TTFT \uAC1C\uC120: \uC218\uC9D1\uC740 \uB109\uB109\uD788(\uB7AD\uD0B9 \uD480), LLM \uC8FC\uC785\uC740 \uC0C1\uC704 N + snippet \uAE38\uC774 \uCEA1.
+                    const injected = searchResults.slice(0, WEB_SEARCH_INJECTION.MAX_RESULTS);
                     webSearchContext = `\n\n## \uD83D\uDD0D ${tpl.header} (${new Date().toLocaleDateString(tpl.locale)} )\n` +
                         `${tpl.instruction}\n\n` +
-                        searchResults.map((r: { title?: string; url?: string; snippet?: string }, i: number) => `[${tpl.sourceLabel} ${i + 1}] ${r.title}\n   URL: ${r.url}\n${r.snippet ? `   ${tpl.contentLabel}: ${r.snippet}\n` : ''}`).join('\n') + '\n';
+                        injected.map((r: { title?: string; url?: string; snippet?: string }, i: number) => {
+                            const snip = (r.snippet || '').slice(0, WEB_SEARCH_INJECTION.MAX_SNIPPET_CHARS);
+                            return `[${tpl.sourceLabel} ${i + 1}] ${r.title}\n   URL: ${r.url}\n${snip ? `   ${tpl.contentLabel}: ${snip}\n` : ''}`;
+                        }).join('\n') + '\n';
                 }
             } catch (e) {
                 log.error('[Chat] 웹 검색 실패:', e);


### PR DESCRIPTION
## 문제
웹검색 시사질문의 **TTFT(첫 토큰까지) 14.6초**로 응답 체감이 느림. (생성 자체는 0.3초로 빠름)

## 진단 (P1 observability `chat_llm_call` 이벤트로 측정)
| 케이스 | TTFT |
|---|---|
| 검색 없는 질문 (baseline) | **5.2초** (모델 prefill, 안정) |
| 검색 O — 12개 주입 | 14.6초 (+9.4초) |

- **검색 컨텍스트 주입량이 주 변수** — 수집 결과 12개를 snippet 포함 전부 주입해 prompt가 커짐
- thinking·검색 다소스 수집은 주 병목 **아님** (reasoning 0 응답도 느림 확인)

## 수정
- `WEB_SEARCH_INJECTION`: 수집은 넉넉히(랭킹 풀 유지), **LLM 주입은 상위 6개 + snippet 300자 캡**
- SearXNG·위키 디랭크로 상위 결과 품질이 좋아져 적은 수로도 정답 유지

## 검증
| | TTFT | 정답 |
|---|---|---|
| 12개 주입 | 14.6초 | 이재명 |
| **6개 캡 (웜)** | **9.7초 (~33%↓)** | **이재명 유지** ✅ |

(22.3초 측정은 재시작 직후 콜드 노이즈)

## 잔존 (인프라 영역)
- baseline 5.2초는 모델/하드웨어 prefill — 애플리케이션 한계
- 콜드스타트 변동은 모델 워밍업 영역

🤖 Generated with [Claude Code](https://claude.com/claude-code)