### PR TITLE
fix(web-search): 검색결과 주입 캡 하드닝 — NaN/0 가드 + 포맷터 단일화 (PR #204 코드리뷰 P1~P5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -510,6 +510,11 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # WEB_SEARCH_FETCH_TIMEOUT_MS=12000
 # 웹검색 도메인당 최대 결과 수 (소스 다양성 보호, 0=무제한, 기본 5)
 # SEARCH_MAX_PER_DOMAIN=5
+# 검색 결과 LLM 주입 캡 — 수집은 넉넉히(maxResults 12)하되 LLM 컨텍스트엔 상위 N개만 주입해
+# TTFT(첫 토큰 지연)와 grounding 균형 조정. 0/비정수 = 무제한(가드 적용, 빈 슬라이스 방지).
+# WEB_SEARCH_INJECT_MAX_RESULTS=6
+# 주입 결과당 snippet 최대 글자 수 (0/비정수 = 무제한, 기본 300)
+# WEB_SEARCH_INJECT_MAX_SNIPPET=300
 
 # *******************************************************
 # OAuth state (CSRF 방어) — controllers/auth-oauth.controller

--- a/.env.example
+++ b/.env.example
@@ -285,6 +285,9 @@ DATABASE_URL=postgresql://openmake:your_password@localhost:5432/openmake_llm  # 
 # POSTGRES_DB=openmake_llm
 # POSTGRES_PORT=5432
 # REDIS_PORT=6379
+# docker compose 파일 경로. openmake_llm.sh / docker compose 가 -f 로 참조 (머신별 절대경로).
+# 미설정 시 docker 기본 탐색(cwd 의 docker-compose.yml). 데이터 위치 정책: /Volumes/MAC_APP/docker/<name>/
+# COMPOSE_FILE=/Volumes/MAC_APP/docker/openmake_llm/docker-compose.yml
 
 # 프론트 단일화(3000↔52416 분기 제거): 설정 시 백엔드(52416)로 직접 온 페이지(HTML) 요청을
 # 이 주소로 302 리다이렉트한다. /api·/ws·정적자산은 제외. dev 에서 Next(3000) 단일 진입점용.

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -415,11 +415,20 @@ export const ATTACH_CACHE_LIMITS = {
  *
  * sockets/ws-chat-handler.ts 에서 참조
  */
+/**
+ * 주입 캡 env 파싱 — 음수·NaN(잘못된 값)은 기본값으로, 0 은 "무제한"(캡 미적용) sentinel.
+ * 가드 없는 parseInt 는 0/NaN 시 snippet 을 전부 비워 grounding 을 무너뜨릴 수 있어 명시 정규화한다.
+ */
+function parseInjectLimit(raw: string | undefined, def: number): number {
+    const n = parseInt(raw ?? '', 10);
+    return Number.isFinite(n) && n >= 0 ? n : def;
+}
+
 export const WEB_SEARCH_INJECTION = {
-    /** LLM 컨텍스트에 주입할 상위 결과 수 (수집은 더 많이 하되 주입은 캡) */
-    MAX_RESULTS: parseInt(process.env.WEB_SEARCH_INJECT_MAX_RESULTS || '6', 10),
-    /** 결과당 주입 snippet 최대 글자 수 (초과 절단) */
-    MAX_SNIPPET_CHARS: parseInt(process.env.WEB_SEARCH_INJECT_MAX_SNIPPET || '300', 10),
+    /** LLM 컨텍스트에 주입할 상위 결과 수 (수집은 더 많이 하되 주입은 캡). 0 = 무제한 */
+    MAX_RESULTS: parseInjectLimit(process.env.WEB_SEARCH_INJECT_MAX_RESULTS, 6),
+    /** 결과당 주입 snippet 최대 글자 수 (초과 절단). 0 = 무제한(절단 안 함) */
+    MAX_SNIPPET_CHARS: parseInjectLimit(process.env.WEB_SEARCH_INJECT_MAX_SNIPPET, 300),
 } as const;
 
 /**

--- a/apps/api/src/mcp/web-search/format-sources.ts
+++ b/apps/api/src/mcp/web-search/format-sources.ts
@@ -1,0 +1,62 @@
+/**
+ * 검색 결과 → LLM 컨텍스트/프롬프트 주입용 문자열 포맷터 (단일 지점).
+ *
+ * 기존에 ws-chat-handler · web-search.routes · createFactCheckPrompt · tools 4곳에
+ * 동일한 `[N] title/URL/snippet` 포맷이 중복돼, 주입 캡(결과 수·snippet 길이)이 한 곳에만
+ * 적용되는 불일치가 있었다. 이 헬퍼로 포맷과 캡 정책을 한 곳에서 관리한다.
+ *
+ * @module mcp/web-search/format-sources
+ */
+import type { SearchResult } from './types';
+
+export interface FormatSourcesOptions {
+    /** 주입할 상위 결과 수 (0/미지정 = 무제한) */
+    maxResults?: number;
+    /** 결과당 snippet 최대 글자 수 (0/미지정 = 무제한) */
+    maxSnippetChars?: number;
+    /** true: `[출처 N] … URL: … 내용: …` 라벨형 / false: `[N] … url … snippet` 간결형 */
+    labeled?: boolean;
+    /** 라벨형의 출처 단어 (기본 '출처', 다국어 라벨 전달용) */
+    sourceWord?: string;
+    /** 라벨형의 내용 단어 (기본 '내용', 다국어 라벨 전달용) */
+    contentWord?: string;
+    /** 항목 구분자 (기본 '\n\n') */
+    separator?: string;
+    /** snippet 이 빈 경우 표시 텍스트 (기본 '') */
+    emptySnippet?: string;
+    /** 간결형에서 snippet 뒤에 붙일 접미사 (예: '...') */
+    snippetSuffix?: string;
+}
+
+type SourceLike = Pick<SearchResult, 'title' | 'url' | 'snippet'>;
+
+/** 검색 결과 배열을 주입용 문자열로 포맷 (결과 수·snippet 길이 캡 적용). */
+export function formatSearchSources(results: SourceLike[], opts: FormatSourcesOptions = {}): string {
+    const {
+        maxResults = 0,
+        maxSnippetChars = 0,
+        labeled = false,
+        sourceWord = '출처',
+        contentWord = '내용',
+        separator = '\n\n',
+        emptySnippet = '',
+        snippetSuffix = '',
+    } = opts;
+
+    const limited = maxResults > 0 ? results.slice(0, maxResults) : results;
+    const lines = limited.map((r, i) => {
+        let snip = r.snippet || '';
+        if (maxSnippetChars > 0 && snip.length > maxSnippetChars) {
+            snip = snip.slice(0, maxSnippetChars) + snippetSuffix;
+        } else if (snip && snippetSuffix) {
+            snip = snip + snippetSuffix;
+        }
+        const tag = labeled ? `[${sourceWord} ${i + 1}]` : `[${i + 1}]`;
+        const urlLine = labeled ? `   URL: ${r.url}` : `   ${r.url}`;
+        const contentLine = labeled
+            ? `\n   ${contentWord}: ${snip || emptySnippet}`
+            : (snip ? `\n   ${snip}` : '');
+        return `${tag} ${r.title}\n${urlLine}${contentLine}`;
+    });
+    return lines.join(separator);
+}

--- a/apps/api/src/mcp/web-search/search-orchestrator.ts
+++ b/apps/api/src/mcp/web-search/search-orchestrator.ts
@@ -20,7 +20,8 @@ import {
     searchSearxng
 } from './providers';
 import { createLogger } from '../../utils/logger';
-import { SEARCH_RELIABILITY } from '../../config/runtime-limits';
+import { SEARCH_RELIABILITY, WEB_SEARCH_INJECTION } from '../../config/runtime-limits';
+import { formatSearchSources } from './format-sources';
 
 const logger = createLogger('WebSearch');
 
@@ -268,9 +269,10 @@ function scoreSearchResult(result: SearchResult): number {
  * @returns 포맷팅된 사실 검증 프롬프트 문자열
  */
 export function createFactCheckPrompt(claim: string, searchResults: SearchResult[]): string {
-    const sources = searchResults.map((r, i) =>
-        `[${i + 1}] ${r.title}\n   ${r.url}\n   ${r.snippet}`
-    ).join('\n\n');
+    const sources = formatSearchSources(searchResults, {
+        maxResults: WEB_SEARCH_INJECTION.MAX_RESULTS,
+        maxSnippetChars: WEB_SEARCH_INJECTION.MAX_SNIPPET_CHARS,
+    });
 
     return `## Web Search Results (${new Date().toLocaleDateString()})
 ${sources || '검색 결과 없음'}

--- a/apps/api/src/mcp/web-search/tools.ts
+++ b/apps/api/src/mcp/web-search/tools.ts
@@ -11,6 +11,7 @@ import { MCPToolDefinition, MCPToolResult } from '../types';
 import { TRUNCATION } from '../../config/runtime-limits';
 import { safeFetch } from '../../security/ssrf-guard';
 import { performWebSearch } from './search-orchestrator';
+import { formatSearchSources } from './format-sources';
 
 /**
  * 웹 검색 MCP 도구 (web_search)
@@ -40,11 +41,9 @@ export const webSearchTool: MCPToolDefinition = {
             return { content: [{ type: 'text', text: `검색 결과 없음: "${query}"` }] };
         }
 
-        let output = `검색 결과 (${results.length}개)\n\n`;
-        for (let i = 0; i < results.length; i++) {
-            const r = results[i];
-            output += `[${i + 1}] ${r.title}\n   ${r.url}\n   ${r.snippet?.substring(0, 100) || ''}...\n\n`;
-        }
+        // MCP 도구 출력(사용자 직접 표시) — 주입 캡 미적용, snippet 100자 요약만 유지
+        const output = `검색 결과 (${results.length}개)\n\n` +
+            formatSearchSources(results, { maxSnippetChars: 100, snippetSuffix: '...' });
 
         return { content: [{ type: 'text', text: output }] };
     }

--- a/apps/api/src/routes/web-search.routes.ts
+++ b/apps/api/src/routes/web-search.routes.ts
@@ -27,9 +27,10 @@ import { buildExecutionPlan } from '../chat/profile-resolver';
 import { requireAuth } from '../auth';
 import { validate } from '../middlewares/validation';
 import { webSearchSchema } from '../schemas/web-search.schema';
-import { CAPACITY } from '../config/runtime-limits';
+import { CAPACITY, WEB_SEARCH_INJECTION } from '../config/runtime-limits';
 import { LLM_TEMPERATURES } from '../config/llm-parameters';
 import { buildWebSearchPrompt } from '../prompts/web-search-system';
+import { formatSearchSources } from '../mcp/web-search/format-sources';
 
 const logger = createLogger('WebSearchRoutes');
 
@@ -91,11 +92,14 @@ router.post('/web-search', requireAuth, validate(webSearchSchema), asyncHandler(
           return;
       }
 
-     // 2. 검색 결과를 기반으로 LLM에 사실 검증 요청
+     // 2. 검색 결과를 기반으로 LLM에 사실 검증 요청 (주입 캡: format-sources 단일 지점)
      const sourcesContext = searchResults.length > 0
-         ? searchResults.map((r: { title?: string; url?: string; snippet?: string }, i: number) =>
-             `[출처 ${i + 1}] ${r.title}\n   URL: ${r.url}\n   내용: ${r.snippet || '(내용 없음)'}`
-         ).join('\n\n')
+         ? formatSearchSources(searchResults, {
+             maxResults: WEB_SEARCH_INJECTION.MAX_RESULTS,
+             maxSnippetChars: WEB_SEARCH_INJECTION.MAX_SNIPPET_CHARS,
+             labeled: true,
+             emptySnippet: '(내용 없음)',
+         })
          : '(검색 결과 없음)';
 
      const searchPrompt = buildWebSearchPrompt(query, sourcesContext, new Date().toLocaleDateString());

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -23,6 +23,7 @@ import { WS_LIMITS } from '../config/timeouts';
 import { ArtifactStreamParser, type ArtifactInfo } from '../llm/artifact-parser';
 import { buildFileContext, buildUrlContext, getCachedAttachContext, appendCachedAttachContext } from '../services/chat-service/attach-context';
 import { WEB_SEARCH_INJECTION } from '../config/runtime-limits';
+import { formatSearchSources } from '../mcp/web-search/format-sources';
 
 /**
  * AI 채팅 메시지를 처리합니다.
@@ -146,19 +147,21 @@ export async function handleChatMessage(
         if (!userExplicitlyDisabledSearch && (userWebSearchEnabled || isCurrentEventsQuery)) {
             try {
                 const { performWebSearch } = await import('../mcp');
-                // maxResults 8: 신뢰도 정렬상 Wikipedia 가 상위를 점유해 최신 뉴스가 5개 cut 에서
-                // 누락되던 문제 완화 — 상위 8개로 늘려 News/Naver(최신 시사)가 LLM 컨텍스트에 포함되게 한다.
+                // 수집은 넉넉히(maxResults 12 — 랭킹 풀: SearXNG·위키 디랭크 포함)하되, LLM 주입은
+                // WEB_SEARCH_INJECTION 캡(상위 MAX_RESULTS + snippet MAX_SNIPPET_CHARS, 각 0=무제한)으로 제어한다.
                 const searchResults = await performWebSearch(message, { maxResults: 12, language: userLang, preferRecent: isCurrentEventsQuery });
                 if (searchResults.length > 0) {
                     const tpl = getLocalizedTemplate(WEB_SEARCH_TEMPLATES, userLang);
-                    // TTFT \uAC1C\uC120: \uC218\uC9D1\uC740 \uB109\uB109\uD788(\uB7AD\uD0B9 \uD480), LLM \uC8FC\uC785\uC740 \uC0C1\uC704 N + snippet \uAE38\uC774 \uCEA1.
-                    const injected = searchResults.slice(0, WEB_SEARCH_INJECTION.MAX_RESULTS);
+                    const body = formatSearchSources(searchResults, {
+                        maxResults: WEB_SEARCH_INJECTION.MAX_RESULTS,
+                        maxSnippetChars: WEB_SEARCH_INJECTION.MAX_SNIPPET_CHARS,
+                        labeled: true,
+                        sourceWord: tpl.sourceLabel,
+                        contentWord: tpl.contentLabel,
+                        separator: '\n',
+                    });
                     webSearchContext = `\n\n## \uD83D\uDD0D ${tpl.header} (${new Date().toLocaleDateString(tpl.locale)} )\n` +
-                        `${tpl.instruction}\n\n` +
-                        injected.map((r: { title?: string; url?: string; snippet?: string }, i: number) => {
-                            const snip = (r.snippet || '').slice(0, WEB_SEARCH_INJECTION.MAX_SNIPPET_CHARS);
-                            return `[${tpl.sourceLabel} ${i + 1}] ${r.title}\n   URL: ${r.url}\n${snip ? `   ${tpl.contentLabel}: ${snip}\n` : ''}`;
-                        }).join('\n') + '\n';
+                        `${tpl.instruction}\n\n${body}\n`;
                 }
             } catch (e) {
                 log.error('[Chat] 웹 검색 실패:', e);


### PR DESCRIPTION
## 배경
PR #204(시점 민감 쿼리 최신성 랭킹) 머지 후 `/code-review` 가 검색결과 LLM 주입 캡에서 확정한 findings P1~P5 일괄 수정.

## 수정 내역
| # | 심각도 | 내용 |
|---|---|---|
| **P1** | 🔴 CONFIRMED | `MAX_SNIPPET_CHARS` 가 `0`/NaN 이면 `slice(0,0)` 로 **모든 snippet 이 사라져** 제목·URL만 주입 → grounding 붕괴(의도와 정반대). `parseInjectLimit` 가드로 `0/비정수 = 무제한` sentinel 보장 |
| **P5** | 🟠 PLAUSIBLE | snippet 300자 절단이 후반 사실을 누락 → P1 의 `0=무제한` 으로 운영자가 해제 가능 |
| **P2** | 🟡 CONFIRMED | 신규 env `WEB_SEARCH_INJECT_MAX_RESULTS`/`WEB_SEARCH_INJECT_MAX_SNIPPET` 를 `.env.example` 에 문서화 |
| **P3** | 🟡 CONFIRMED | ws-chat-handler stale 주석(maxResults 8/상위 8개)을 실제 코드(수집 12·주입 캡)에 맞게 정정 |
| **P4** | 🟡 CONFIRMED | `[N] title/URL/snippet` 포맷 4곳 중복 → `formatSearchSources` 단일 헬퍼로 통합, 주입 캡 일관 적용 |

## P4 헬퍼 적용 경로
- **LLM 주입(캡 적용)**: `ws-chat-handler`, `web-search.routes`, `createFactCheckPrompt`
- **MCP 도구 출력(캡 미적용)**: `mcp/web-search/tools` — 사용자 직접 표시라 100자 요약만 유지

## 검증
- [x] `tsc --noEmit` 통과 (0 error)
- [x] `eslint` 통과 (0 error; ws-handler max-lines 경고는 기존, 본 변경이 오히려 단축)
- [x] `format-sources.test.ts` 7/7 통과 — P1 회귀(0→빈 슬라이스 금지)·캡·라벨/간결형·다국어 라벨 커버 (테스트 디렉토리는 프로젝트 관행상 git-ignored, 로컬 검증)

## 동작 영향
- 기본값(MAX_RESULTS 6, MAX_SNIPPET 300) 무변경 — 기존 TTFT 개선 유지
- env 미설정/오설정(`0`·빈값·문자) 시에도 안전: 무제한 또는 기본값으로 폴백, snippet 전멸 불가

🤖 Generated with [Claude Code](https://claude.com/claude-code)