### PR TITLE
fix(web-search): formatSearchSources 결함 수정 + 포맷터 통합 마무리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -513,7 +513,9 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # WEB_SEARCH_FETCH_TIMEOUT_MS=12000
 # 웹검색 도메인당 최대 결과 수 (소스 다양성 보호, 0=무제한, 기본 5)
 # SEARCH_MAX_PER_DOMAIN=5
-# 검색 결과 LLM 주입 캡 — 수집은 넉넉히(maxResults 12)하되 LLM 컨텍스트엔 상위 N개만 주입해
+# 검색 수집(랭킹 풀) 폭 — performWebSearch 가 모을 결과 수. 주입 캡보다 크게 잡아 디랭크 여지 확보 (최소 1, 기본 12)
+# WEB_SEARCH_COLLECT_MAX_RESULTS=12
+# 검색 결과 LLM 주입 캡 — 수집은 넉넉히(COLLECT_MAX_RESULTS)하되 LLM 컨텍스트엔 상위 N개만 주입해
 # TTFT(첫 토큰 지연)와 grounding 균형 조정. 0/비정수 = 무제한(가드 적용, 빈 슬라이스 방지).
 # WEB_SEARCH_INJECT_MAX_RESULTS=6
 # 주입 결과당 snippet 최대 글자 수 (0/비정수 = 무제한, 기본 300)

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -425,6 +425,8 @@ function parseInjectLimit(raw: string | undefined, def: number): number {
 }
 
 export const WEB_SEARCH_INJECTION = {
+    /** 검색 수집(랭킹 풀) 폭 — performWebSearch 가 모을 결과 수. 주입 캡보다 크게 잡아 디랭크 여지 확보. 최소 1 */
+    COLLECT_MAX_RESULTS: Math.max(1, parseInjectLimit(process.env.WEB_SEARCH_COLLECT_MAX_RESULTS, 12)),
     /** LLM 컨텍스트에 주입할 상위 결과 수 (수집은 더 많이 하되 주입은 캡). 0 = 무제한 */
     MAX_RESULTS: parseInjectLimit(process.env.WEB_SEARCH_INJECT_MAX_RESULTS, 6),
     /** 결과당 주입 snippet 최대 글자 수 (초과 절단). 0 = 무제한(절단 안 함) */

--- a/apps/api/src/mcp/web-search/format-sources.ts
+++ b/apps/api/src/mcp/web-search/format-sources.ts
@@ -47,14 +47,17 @@ export function formatSearchSources(results: SourceLike[], opts: FormatSourcesOp
     const lines = limited.map((r, i) => {
         let snip = r.snippet || '';
         if (maxSnippetChars > 0 && snip.length > maxSnippetChars) {
-            snip = snip.slice(0, maxSnippetChars) + snippetSuffix;
+            // 코드포인트 단위로 잘라 surrogate pair(이모지·astral 문자) 중간 분할 방지
+            snip = [...snip].slice(0, maxSnippetChars).join('') + snippetSuffix;
         } else if (snip && snippetSuffix) {
             snip = snip + snippetSuffix;
         }
         const tag = labeled ? `[${sourceWord} ${i + 1}]` : `[${i + 1}]`;
         const urlLine = labeled ? `   URL: ${r.url}` : `   ${r.url}`;
+        // snippet 도 placeholder 도 없으면 내용 라인 자체를 생략 (빈 '내용: ' 라벨 누수 방지)
+        const content = snip || emptySnippet;
         const contentLine = labeled
-            ? `\n   ${contentWord}: ${snip || emptySnippet}`
+            ? (content ? `\n   ${contentWord}: ${content}` : '')
             : (snip ? `\n   ${snip}` : '');
         return `${tag} ${r.title}\n${urlLine}${contentLine}`;
     });

--- a/apps/api/src/mcp/web-search/search-orchestrator.ts
+++ b/apps/api/src/mcp/web-search/search-orchestrator.ts
@@ -20,7 +20,7 @@ import {
     searchSearxng
 } from './providers';
 import { createLogger } from '../../utils/logger';
-import { SEARCH_RELIABILITY, WEB_SEARCH_INJECTION } from '../../config/runtime-limits';
+import { SEARCH_RELIABILITY } from '../../config/runtime-limits';
 import { formatSearchSources } from './format-sources';
 
 const logger = createLogger('WebSearch');
@@ -269,10 +269,9 @@ function scoreSearchResult(result: SearchResult): number {
  * @returns 포맷팅된 사실 검증 프롬프트 문자열
  */
 export function createFactCheckPrompt(claim: string, searchResults: SearchResult[]): string {
-    const sources = formatSearchSources(searchResults, {
-        maxResults: WEB_SEARCH_INJECTION.MAX_RESULTS,
-        maxSnippetChars: WEB_SEARCH_INJECTION.MAX_SNIPPET_CHARS,
-    });
+    // 사실 검증은 grounding 정확도가 핵심이므로 캡 미적용 — 전체 결과 + full snippet 주입.
+    // (chat 주입의 TTFT 캡과 달리 결정적 근거가 잘려 누락되면 검증 품질이 떨어진다.)
+    const sources = formatSearchSources(searchResults);
 
     return `## Web Search Results (${new Date().toLocaleDateString()})
 ${sources || '검색 결과 없음'}

--- a/apps/api/src/services/chat-strategies/agent-loop-execute-tool.ts
+++ b/apps/api/src/services/chat-strategies/agent-loop-execute-tool.ts
@@ -12,6 +12,7 @@ import { getUnifiedMCPClient } from '../../mcp/unified-client';
 import { VISION_OCR_SYSTEM_PROMPT, VISION_ANALYSIS_SYSTEM_PROMPT, buildVisionOcrUserMessage } from '../../prompts/vision-system';
 import { LLM_TEMPERATURES } from '../../config/llm-parameters';
 import { TRUNCATION } from '../../config/runtime-limits';
+import { formatSearchSources } from '../../mcp/web-search/format-sources';
 import type { AgentLoopStrategyContext } from './types';
 import { createLogger } from '../../utils/logger';
 
@@ -54,9 +55,10 @@ export async function executeToolCall(context: AgentLoopStrategyContext, toolCal
             const response = await context.client.webSearch(query, maxResults);
 
             if (response.results && response.results.length > 0) {
-                const formatted = response.results.map((r, i) =>
-                    `[${i + 1}] ${r.title}\n    ${r.url}\n    ${r.content?.substring(0, TRUNCATION.WEB_SNIPPET_MAX) || ''}...`
-                ).join('\n\n');
+                const formatted = formatSearchSources(
+                    response.results.map(r => ({ title: r.title, url: r.url, snippet: r.content })),
+                    { maxSnippetChars: TRUNCATION.WEB_SNIPPET_MAX, snippetSuffix: '...' },
+                );
                 return `🔍 웹 검색 결과 (${response.results.length}개):\n\n${formatted}`;
             }
             return '검색 결과가 없습니다.';

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -147,9 +147,9 @@ export async function handleChatMessage(
         if (!userExplicitlyDisabledSearch && (userWebSearchEnabled || isCurrentEventsQuery)) {
             try {
                 const { performWebSearch } = await import('../mcp');
-                // 수집은 넉넉히(maxResults 12 — 랭킹 풀: SearXNG·위키 디랭크 포함)하되, LLM 주입은
+                // 수집은 넉넉히(COLLECT_MAX_RESULTS — 랭킹 풀: SearXNG·위키 디랭크 포함)하되, LLM 주입은
                 // WEB_SEARCH_INJECTION 캡(상위 MAX_RESULTS + snippet MAX_SNIPPET_CHARS, 각 0=무제한)으로 제어한다.
-                const searchResults = await performWebSearch(message, { maxResults: 12, language: userLang, preferRecent: isCurrentEventsQuery });
+                const searchResults = await performWebSearch(message, { maxResults: WEB_SEARCH_INJECTION.COLLECT_MAX_RESULTS, language: userLang, preferRecent: isCurrentEventsQuery });
                 if (searchResults.length > 0) {
                     const tpl = getLocalizedTemplate(WEB_SEARCH_TEMPLATES, userLang);
                     const body = formatSearchSources(searchResults, {


### PR DESCRIPTION
## 배경

`formatSearchSources` 통합 PR(#205 후속)에 대한 코드 리뷰(`/code-review high`, 에이전트 34개)에서 검증된 결함과 정리 항목을 반영합니다.

## 변경 사항

### CONFIRMED 결함 (2건)
- **빈 `내용:` 라벨 라인 누수** — labeled 모드에서 snippet·placeholder가 모두 비면 content 라인 자체를 생략. 이전엔 빈 `내용: ` 라인이 LLM 컨텍스트에 주입돼 "이 출처엔 내용 없음"으로 읽히며 grounding을 떨어뜨림. `emptySnippet`을 넘기는 호출부(fact_check 등)는 기존대로 placeholder 표시.
- **surrogate pair 분할** — snippet 절단을 `snip.slice()`(UTF-16) → `[...snip].slice()`(코드포인트)로 변경. 이모지/astral 문자 중간 분할로 깨진 글자(�)가 출력되던 결함 방지.

### 설계 판단 항목
- **#4 fact-check 캡 제거** — `createFactCheckPrompt`이 snippet을 300자로 자르고 결과 수도 캡하던 것을 제거. fact-check는 grounding 정확도가 핵심이라 결정적 근거가 잘려 누락되지 않도록 전체 결과 + full snippet 복원 (PR 이전 동작). orphan `WEB_SEARCH_INJECTION` import 정리.
- **#6 agent-loop 포맷터 통합** — `agent-loop-execute-tool.ts`의 인라인 `[N]` 포맷터를 `formatSearchSources`로 통합(content→snippet 매핑, `WEB_SNIPPET_MAX` 캡 유지). PR의 단일 포맷터 일원화 목표 완성.
- **#7 수집 폭 외부화** — `ws-chat-handler.ts`의 하드코딩 `maxResults: 12`를 `WEB_SEARCH_INJECTION.COLLECT_MAX_RESULTS`(env `WEB_SEARCH_COLLECT_MAX_RESULTS`, 최소 1)로 외부화. No-Hardcoding 정책 정합.

### 현행 유지 (리뷰 후 확정)
- **#3** MCP `web_search` 빈 snippet 2줄 출력 — 무의미한 `...` 라인 제거가 더 깔끔, 의도된 개선으로 유지.
- **#5** `0=unlimited` 센티넬 — `.env.example`/JSDoc에 명시된 문서 의존 시맨틱이며 코드 결함 아님, 유지.

## 검증
- `tsc -p apps/api --noEmit` 통과
- `format-sources.test.ts` 9/9 통과 (회귀 테스트 2건 신규: 빈 라벨 라인 생략 / surrogate 비분할)

> 참고: `__tests__/`는 프로젝트 관행상 git-ignored(로컬 보관)이라 테스트 파일은 커밋에 미포함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)