### PR TITLE
feat: 기본 모델에서 LocalLLM ↔ OpenRouter(외부 LLM) 선택 복원 (+ base_url 폴백 수정)

### DIFF
--- a/apps/api/src/routes/external-keys.routes.ts
+++ b/apps/api/src/routes/external-keys.routes.ts
@@ -145,12 +145,19 @@ router.post('/:providerId',
             }
         }
 
+        // base_url 미입력 시 catalog 기본 endpoint 로 폴백 — 빈 base_url 은 model.routes 의
+        // `&& keyRow.baseUrl` 게이트에서 스킵돼 등록한 외부 모델이 노출되지 않으므로 반드시 채운다.
+        const resolvedBaseUrl =
+            typeof req.body.base_url === 'string' && req.body.base_url.trim()
+                ? req.body.base_url.trim()
+                : (catalogEntry.defaultBaseUrl ?? null);
+
         const row = await getRepo().upsert({
             userId,
             providerId,
             sdkType: req.body.sdk_type,
             displayName: req.body.display_name,
-            baseUrl: req.body.base_url ?? null,
+            baseUrl: resolvedBaseUrl,
             apiKey: req.body.api_key,
         });
 

--- a/apps/web/app/(workspace)/settings/page.tsx
+++ b/apps/web/app/(workspace)/settings/page.tsx
@@ -83,14 +83,20 @@ function FieldRow({
   );
 }
 
+type SelectOption = { value: string; label: string };
+type SelectGroup = { label: string; options: SelectOption[] };
+
 function Select({
   value,
   onChange,
   options,
+  groups,
 }: {
   value: string;
   onChange: (v: string) => void;
-  options: { value: string; label: string }[];
+  options?: SelectOption[];
+  /** 제공 시 <optgroup> 으로 분류 렌더 (provider 별 구분 등). options 보다 우선. */
+  groups?: SelectGroup[];
 }) {
   return (
     <select
@@ -98,11 +104,21 @@ function Select({
       onChange={(e) => onChange(e.target.value)}
       className="h-9 w-full rounded-md border border-border-strong bg-surface px-3 text-sm text-fg outline-none transition focus:border-accent"
     >
-      {options.map((o) => (
-        <option key={o.value} value={o.value}>
-          {o.label}
-        </option>
-      ))}
+      {groups
+        ? groups.map((g) => (
+            <optgroup key={g.label} label={g.label}>
+              {g.options.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </optgroup>
+          ))
+        : (options ?? []).map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
     </select>
   );
 }
@@ -149,10 +165,30 @@ export default function SettingsPage() {
     queryFn: fetchModels,
     staleTime: 60_000,
   });
-  const modelOptions = (modelsData?.models ?? []).map((m) => ({
+  // 기본 모델을 provider 별 그룹으로 분류 — 🏠 로컬 vLLM vs 🌐 외부 LLM(OpenRouter 등 BYOK)
+  const allModels = modelsData?.models ?? [];
+  const localModels = allModels.filter((m) => m.provider === "local-llm");
+  const externalModels = allModels.filter((m) => m.provider !== "local-llm");
+  const toOption = (m: (typeof allModels)[number]) => ({
     value: m.modelId,
     label: m.name + (m.isFree ? " · 무료" : ""),
+  });
+  // provider id → 표시 라벨 (현재 openrouter 만 등록 가능, 그 외 provider 도 일반 처리)
+  const externalGroupLabel = (provider: string) =>
+    provider === "openrouter" ? "🌐 OpenRouter" : `🌐 ${provider}`;
+  const externalGroups = Array.from(
+    new Set(externalModels.map((m) => m.provider)),
+  ).map((provider) => ({
+    label: externalGroupLabel(provider),
+    options: externalModels.filter((m) => m.provider === provider).map(toOption),
   }));
+  const modelGroups = [
+    { label: "기본", options: [{ value: "default", label: "자동 (서버 기본값)" }] },
+    ...(localModels.length
+      ? [{ label: "🏠 로컬 vLLM", options: localModels.map(toOption) }]
+      : []),
+    ...externalGroups,
+  ];
   const [responseStyle, setResponseStyle] =
     useState<(typeof RESPONSE_STYLES)[number]["value"]>("default");
   const [language, setLanguage] = useState("");
@@ -406,17 +442,35 @@ export default function SettingsPage() {
                 <CardContent className="py-0">
                   <FieldRow
                     title="기본 모델"
-                    description="새 대화에 사용할 모델입니다. 로컬 vLLM + 등록한 외부 LLM(API 키 페이지)."
+                    description="새 대화에 사용할 모델입니다. 🏠 로컬 vLLM 과 🌐 외부 LLM(OpenRouter, BYOK) 중 선택합니다."
                   >
-                    <Select
-                      value={selectedModel}
-                      onChange={setSelectedModel}
-                      options={
-                        modelOptions.length
-                          ? modelOptions
-                          : [{ value: "", label: "모델 로딩…" }]
-                      }
-                    />
+                    {allModels.length ? (
+                      <div className="flex flex-col gap-1.5">
+                        <Select
+                          value={selectedModel}
+                          onChange={setSelectedModel}
+                          groups={modelGroups}
+                        />
+                        {externalModels.length === 0 && (
+                          <p className="text-xs text-muted">
+                            외부 LLM(OpenRouter)을 추가하려면{" "}
+                            <a
+                              href="/api-keys"
+                              className="text-accent underline underline-offset-2 hover:opacity-80"
+                            >
+                              API 키 페이지
+                            </a>
+                            에서 키를 등록하세요.
+                          </p>
+                        )}
+                      </div>
+                    ) : (
+                      <Select
+                        value=""
+                        onChange={setSelectedModel}
+                        options={[{ value: "", label: "모델 로딩…" }]}
+                      />
+                    )}
                   </FieldRow>
                   <FieldRow
                     title="이미지 생성"

--- a/apps/web/app/(workspace)/settings/page.tsx
+++ b/apps/web/app/(workspace)/settings/page.tsx
@@ -180,7 +180,12 @@ export default function SettingsPage() {
     new Set(externalModels.map((m) => m.provider)),
   ).map((provider) => ({
     label: externalGroupLabel(provider),
-    options: externalModels.filter((m) => m.provider === provider).map(toOption),
+    options: externalModels
+      .filter((m) => m.provider === provider)
+      // 무료(:free) 모델을 그룹 상위로 — 안정 정렬이라 그 외는 원래(API) 순서 유지
+      .slice()
+      .sort((a, b) => (b.isFree ? 1 : 0) - (a.isFree ? 1 : 0))
+      .map(toOption),
   }));
   const modelGroups = [
     { label: "기본", options: [{ value: "default", label: "자동 (서버 기본값)" }] },

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist, createJSONStorage, type StateStorage } from "zustand/middleware";
 import type {
   ChatMessage as SharedChatMessage,
   ChatRole,
@@ -114,7 +115,16 @@ interface AppState {
 
 const STYLE_ORDER: ChatStyle[] = ["default", "concise", "verbose"];
 
-export const useAppStore = create<AppState>((set) => ({
+/** SSR(서버 평가) 시 localStorage 부재로 인한 ReferenceError 방지 — 클라에서만 실제 저장소 사용. */
+const noopStorage: StateStorage = {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {},
+};
+
+export const useAppStore = create<AppState>()(
+  persist(
+    (set) => ({
   chatHistory: [],
   currentSessionId: null,
   isGenerating: false,
@@ -224,4 +234,14 @@ export const useAppStore = create<AppState>((set) => ({
       style: STYLE_ORDER[(STYLE_ORDER.indexOf(s.style) + 1) % STYLE_ORDER.length],
     })),
   setAuth: (auth) => set({ auth }),
-}));
+    }),
+    {
+      name: "openmake-prefs",
+      storage: createJSONStorage(() =>
+        typeof window !== "undefined" ? window.localStorage : noopStorage,
+      ),
+      // 사용자 환경설정만 영속화 — 채팅/아티팩트 등 휘발성 세션 상태는 제외
+      partialize: (s) => ({ selectedModel: s.selectedModel, style: s.style }),
+    },
+  ),
+);


### PR DESCRIPTION
## 배경

설정 > 모델 & 응답 > **기본 모델**에서 LocalLLM 과 OpenRouter(외부 LLM, BYOK)를 구분해 선택하는 기능이 apps/web(Next.js) 재구축 과정에서 단순 드롭다운으로 축소됐습니다. provider 구분 선택 + 영속화를 복원하고, 검증 중 발견한 등록 경로 버그도 함께 수정합니다.

## 변경 사항

### 프론트 (apps/web)
**`app/(workspace)/settings/page.tsx`**
- 기본 모델 `Select` 를 **🏠 로컬 vLLM / 🌐 OpenRouter(외부 LLM)** 그룹(`<optgroup>`)으로 분류 선택 + "자동(서버 기본값)" 옵션.
- 외부 모델이 0개(키 미등록)일 때 **API 키 페이지 등록 안내 링크** 노출.
- `Select` primitive 에 optional `groups` prop 추가 — 기존 `options` 사용처 호환.

**`lib/store.ts`**
- zustand `persist` 로 `selectedModel`·`style` 만 partialize 영속화 — 새로고침에도 기본 모델 유지(과거 `localStorage.selectedModel` 동작 복원). SSR-safe storage guard 포함.

### 백엔드 (apps/api)
**`routes/external-keys.routes.ts`** — `base_url` 미입력 시 `catalogEntry.defaultBaseUrl` 로 폴백.
- 기존: 프론트가 base_url 을 비우면 `null` 저장 → `model.routes` 의 `&& keyRow.baseUrl` 게이트가 빈 값을 스킵 → 등록한 OpenRouter 모델이 `/api/models` 에 전혀 노출되지 않음(fallback 모델조차 미적용).
- 수정 후: openrouter 키만 등록하면 `https://openrouter.ai/api/v1` 로 자동 채워져 모델이 노출됨.
- ⚠️ 기존에 빈 base_url 로 저장된 행은 데이터 보정 필요(운영 DB 에서 처리 완료).

## 검증 (Playwright, 실제 등록 키로 E2E)
- `/api/models`: 로컬 1 + **openrouter 339개** 반환(키 live `listModels` 정상).
- 설정 UI: 기본 모델 Select 가 **기본 / 🏠 로컬 vLLM(1) / 🌐 OpenRouter(339)** 3그룹 · 341옵션 렌더.
- OpenRouter 모델 선택 → `localStorage.openmake-prefs` 저장 → **새로고침 후에도 유지**(그룹 🌐 OpenRouter).
- `tsc --noEmit`(web/api) 통과, 변경 파일 eslint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)