### PR TITLE
fix(chat): 응답 스타일(concise/verbose) 프론트→백엔드 배선 복구

### DIFF
--- a/apps/api/src/chat/answer-format.ts
+++ b/apps/api/src/chat/answer-format.ts
@@ -1,0 +1,89 @@
+/**
+ * ============================================================
+ * Answer Format — intent-gated 답변 구조 가드
+ * ============================================================
+ *
+ * 사용자 요청(2026-06-26): 답변 스타일 일관성 개선. 의사결정·비교·문제해결·
+ * 기술설계 같은 "구조적 답변이 적합한" 질문에 한해 결론-우선·문단 절제·표/실행
+ * 항목 분리 형식을 system prompt 로 강제한다.
+ *
+ * 설계 결정 — JSON 구조화 출력이 아닌 프롬프트 레이어:
+ *   채팅은 WebSocket 토큰 스트리밍이라 JSON Schema 강제는 (1) 응답 완료까지 빈
+ *   화면 = 스트리밍 UX 소실, (2) 로컬 qwen3.6 strict-JSON 불안정 문제가 있다.
+ *   따라서 LLM 이 자유 텍스트를 스트리밍하되 "뼈대"만 프롬프트로 고정한다.
+ *
+ * 게이트 (profile):
+ *   - style==='concise' → 'prose' (간결 스타일은 한두 줄 답변이 목적이므로 침범 금지)
+ *   - promptType 이 구조적 유형(reasoning/coder/consultant 등) → 'structured'
+ *   - 그 외(assistant/translator/agent = 일상·잡담·번역) → 'prose'
+ *   'prose' 일 때는 가드 미주입 → RESPONSE_DISCIPLINE_TEXTS 의 산문 기본값 유지.
+ *
+ * Style 축과의 관계: Style(concise/default/verbose)은 "분량", Answer Format 은
+ * "뼈대 구조" 를 통제하는 직교 축. 둘 다 default 경로에서 overhead 0.
+ *
+ * @module chat/answer-format
+ */
+
+import { resolvePromptLocale } from './language-policy';
+import { ANSWER_FORMAT_TEXTS } from './prompt-locales';
+import { detectPromptType } from './prompt-templates';
+import type { PromptType } from './prompt-templates';
+import type { Style } from './style';
+
+export type AnswerFormatProfile = 'structured' | 'prose';
+
+/**
+ * 구조적 답변이 적합한 PromptType 집합.
+ * 제외: assistant(일상 대화), translator(번역), agent(도구 실행 — 자체 형식).
+ */
+const STRUCTURED_PROMPT_TYPES: ReadonlySet<PromptType> = new Set<PromptType>([
+    'reasoning',
+    'coder',
+    'reviewer',
+    'explainer',
+    'generator',
+    'researcher',
+    'consultant',
+    'security',
+    'writer',
+]);
+
+/**
+ * 답변 형식 profile 결정. promptType 미제공 시 message 로부터 detectPromptType 재사용
+ * (신규 classifier 도입 금지 — 기존 regex 분류기 단일 사용).
+ */
+export function resolveAnswerFormatProfile(opts: {
+    style: Style;
+    promptType?: PromptType;
+    message?: string;
+}): AnswerFormatProfile {
+    // 간결 스타일은 형식 강제 대상에서 제외 (사용자 명시 의도 우선).
+    if (opts.style === 'concise') return 'prose';
+
+    const type = opts.promptType
+        ?? (opts.message ? detectPromptType(opts.message) : 'assistant');
+
+    return STRUCTURED_PROMPT_TYPES.has(type) ? 'structured' : 'prose';
+}
+
+/**
+ * profile 별 prepend 텍스트. 'prose' 는 빈 문자열(overhead 0).
+ */
+export function getAnswerFormatGuard(profile: AnswerFormatProfile, userLanguage: string): string {
+    if (profile === 'prose') return '';
+    const locale = resolvePromptLocale(userLanguage);
+    return locale === 'ko' ? ANSWER_FORMAT_TEXTS.ko : ANSWER_FORMAT_TEXTS.en;
+}
+
+/**
+ * systemPrompt 앞에 answer-format 가드를 prepend. style.ts 의 applyStyle 과 동일 규약.
+ * 'prose' 일 때는 그대로 반환.
+ */
+export function applyAnswerFormat(
+    systemPrompt: string,
+    profile: AnswerFormatProfile,
+    userLanguage: string,
+): string {
+    const guard = getAnswerFormatGuard(profile, userLanguage);
+    return guard ? `${guard}---\n\n${systemPrompt}` : systemPrompt;
+}

--- a/apps/api/src/chat/answer-planner.ts
+++ b/apps/api/src/chat/answer-planner.ts
@@ -1,0 +1,58 @@
+/**
+ * ============================================================
+ * Answer Planner — 답변 유형(AnswerIntent) 분류
+ * ============================================================
+ *
+ * 제안서(2026-06-26) 3절 "가장 먼저 넣어야 할 기능: Answer Planner".
+ * 사용자 질문을 받아 답변 유형을 먼저 분류한다. 분류 결과는 구조화 출력
+ * (StructuredAnswer.intent) 와 Response Formatter Layer 의 system prompt 조립에
+ * 사용된다.
+ *
+ * 구현: cross-cutting intent(decision/comparison/troubleshooting 등)는 키워드
+ * 가중치(config/data/answer-intent-patterns.json)로 우선 식별하고, 미달 시 기존
+ * detectPromptType(regex 분류기) 결과를 promptTypeFallback 으로 매핑한다.
+ * (No-Hardcoding: 패턴 인라인 금지 — JSON 외부화, prompt-type-patterns.json 과 동일 패턴.)
+ *
+ * @module chat/answer-planner
+ */
+import patternsData from '../config/data/answer-intent-patterns.json';
+import { detectPromptType } from './prompt-templates';
+import type { PromptType } from './prompt-templates';
+import type { AnswerIntent } from '../schemas/structured-answer.schema';
+
+interface IntentKeyword { pattern: RegExp; weight: number; }
+interface IntentConfig { intent: AnswerIntent; priority: number; keywords: IntentKeyword[]; }
+
+// 모듈 로드 시 1회 컴파일 (prompt-templates.ts 와 동일 패턴).
+const INTENT_CONFIGS: IntentConfig[] = patternsData.intentConfigs.map((c) => ({
+    intent: c.intent as AnswerIntent,
+    priority: c.priority,
+    keywords: c.keywords.map((k) => ({ pattern: new RegExp(k.source, k.flags), weight: k.weight })),
+}));
+const MIN_SCORE: number = patternsData.minScore;
+const PROMPT_TYPE_FALLBACK = patternsData.promptTypeFallback as Record<PromptType, AnswerIntent>;
+const DEFAULT_INTENT: AnswerIntent = 'explanation';
+
+/**
+ * 답변 유형 분류. 키워드 가중치 우선 → 미달 시 detectPromptType 매핑.
+ */
+export function classifyAnswerIntent(message: string): AnswerIntent {
+    const lowerQ = (message || '').toLowerCase();
+
+    const scored = INTENT_CONFIGS.map((c) => {
+        let score = 0;
+        for (const kw of c.keywords) {
+            if (kw.pattern.test(lowerQ)) score += kw.weight;
+        }
+        return { intent: c.intent, score, priority: c.priority };
+    });
+    scored.sort((a, b) => (b.score !== a.score ? b.score - a.score : b.priority - a.priority));
+
+    if (scored[0] && scored[0].score >= MIN_SCORE) {
+        return scored[0].intent;
+    }
+
+    // Fallback: 기존 regex 분류기 재사용 (신규 classifier 도입 금지).
+    const promptType = detectPromptType(message || '');
+    return PROMPT_TYPE_FALLBACK[promptType] ?? DEFAULT_INTENT;
+}

--- a/apps/api/src/chat/prompt-locales.ts
+++ b/apps/api/src/chat/prompt-locales.ts
@@ -397,3 +397,32 @@ export const RESPONSE_DISCIPLINE_TEXTS: Record<'ko' | 'en', string> = {
 
 `,
 };
+
+/**
+ * 답변 형식 가드 (ko/en) — 구조적 답변이 적합한 질문(의사결정·비교·문제해결·기술설계
+ * 등)에만 prepend 되는 형식 디렉티브. 일상 질문에는 주입되지 않아 RESPONSE_DISCIPLINE_TEXTS
+ * 의 산문 기본값을 침범하지 않는다 (chat/answer-format.ts 의 profile 게이트로 제어).
+ *
+ * 도입 (2026-06-26): 답변 스타일 일관성 개선 — 결론-우선·문단 절제·표/실행항목 분리.
+ * 스트리밍 보존을 위해 JSON 구조화 출력이 아닌 프롬프트 레이어로 구현.
+ */
+export const ANSWER_FORMAT_TEXTS: Record<'ko' | 'en', string> = {
+    ko: `## 📐 답변 형식
+이 질문은 구조적 답변이 적합합니다. 아래 형식을 따르되, 질문에 맞지 않는 항목은 억지로 적용하지 않습니다.
+- **결론을 가장 먼저** 한두 문장으로 제시한다. 사용자가 핵심 답을 즉시 확인할 수 있게 한다.
+- 한 문단은 3문장을 넘지 않는다. 같은 의미의 문장을 반복하지 않는다.
+- 선택지·항목을 비교할 때는 표로 정리한다.
+- 의사결정 질문이면 권고안 하나를 먼저 제시한 뒤 근거를 댄다.
+- 실행이 필요하면 마지막에 '다음 실행' 항목으로 분리한다.
+
+`,
+    en: `## 📐 Answer Format
+This question calls for a structured answer. Follow the format below, but skip any item that does not fit the question.
+- **State the conclusion first** in one or two sentences, so the user sees the core answer immediately.
+- Keep each paragraph to three sentences or fewer. Do not repeat the same point.
+- When comparing options or items, organize them in a table.
+- For decision questions, give one recommendation first, then the rationale.
+- If action is required, separate it into a "Next steps" list at the end.
+
+`,
+};

--- a/apps/api/src/config/data/answer-intent-patterns.json
+++ b/apps/api/src/config/data/answer-intent-patterns.json
@@ -1,0 +1,50 @@
+{
+  "_comment": "classifyAnswerIntent 가중치 분류 테이블 (No-Hardcoding: prompt-type-patterns.json 과 동일 패턴). intent 별 keyword 매칭으로 cross-cutting intent(decision/comparison/troubleshooting/summary/drafting)를 우선 식별. 미달 시 promptTypeFallback 으로 detectPromptType→intent 매핑. 순서는 동점 tiebreak 안정성에 의미 있음.",
+  "minScore": 2,
+  "intentConfigs": [
+    { "intent": "comparison", "priority": 9, "keywords": [
+      { "source": "비교|compare|comparison", "flags": "i", "weight": 3 },
+      { "source": "차이|difference|diff\\b", "flags": "i", "weight": 2 },
+      { "source": "\\bvs\\b|대비|어느.*것|어느.*게|중.*뭐|중.*어떤|중.*골라", "flags": "i", "weight": 3 },
+      { "source": "장단점|pros.*cons|trade.?off", "flags": "i", "weight": 2 }
+    ]},
+    { "intent": "troubleshooting", "priority": 8, "keywords": [
+      { "source": "에러|error|버그|bug|오류", "flags": "i", "weight": 3 },
+      { "source": "안.?돼|안.?되|동작.*안|작동.*안|not work|doesn.?t work|fail", "flags": "i", "weight": 3 },
+      { "source": "디버그|debug|고치|fix|해결.*안", "flags": "i", "weight": 2 },
+      { "source": "왜.*안|왜.*못|why.*not", "flags": "i", "weight": 2 }
+    ]},
+    { "intent": "decision", "priority": 7, "keywords": [
+      { "source": "결정|decide|decision|선택|choose", "flags": "i", "weight": 3 },
+      { "source": "해야.*할까|할까요|좋을까|나을까|추천.*해|should i|recommend", "flags": "i", "weight": 3 },
+      { "source": "도입.*할|적용.*할|채택", "flags": "i", "weight": 2 }
+    ]},
+    { "intent": "technical_design", "priority": 6, "keywords": [
+      { "source": "설계|design|아키텍처|architecture|구조", "flags": "i", "weight": 3 },
+      { "source": "어떻게.*구현|어떻게.*만들|how.*build|how.*implement", "flags": "i", "weight": 3 },
+      { "source": "어떻게.*해결|어떻게.*처리|approach", "flags": "i", "weight": 2 }
+    ]},
+    { "intent": "summary", "priority": 5, "keywords": [
+      { "source": "요약|정리.*해|summarize|summary|tl;?dr", "flags": "i", "weight": 3 },
+      { "source": "핵심.*만|간단히.*정리|brief", "flags": "i", "weight": 2 }
+    ]},
+    { "intent": "drafting", "priority": 5, "keywords": [
+      { "source": "작성.*해|써.?줘|초안|draft|작문", "flags": "i", "weight": 3 },
+      { "source": "이메일.*써|문서.*작성|글.*써|write.*a", "flags": "i", "weight": 2 }
+    ]}
+  ],
+  "promptTypeFallback": {
+    "reasoning": "decision",
+    "consultant": "decision",
+    "coder": "technical_design",
+    "generator": "technical_design",
+    "reviewer": "troubleshooting",
+    "security": "technical_design",
+    "explainer": "explanation",
+    "researcher": "summary",
+    "writer": "drafting",
+    "translator": "drafting",
+    "assistant": "explanation",
+    "agent": "explanation"
+  }
+}

--- a/apps/api/src/prompts/answer-composer-system.ts
+++ b/apps/api/src/prompts/answer-composer-system.ts
@@ -1,0 +1,58 @@
+/**
+ * ============================================================
+ * Answer Composer System Prompt — 구조화 출력 지시
+ * ============================================================
+ *
+ * 제안서(2026-06-26) 5절 Developer Prompt + 4절 JSON 구조화 출력 지시.
+ * Response Formatter Layer(services/answer-composer) 가 비스트리밍 LLM 호출 시
+ * 사용하는 system prompt. 모델이 StructuredAnswer JSON 스키마에 맞춰 답하도록 유도.
+ *
+ * 품질 기준(제안서 7.2): 결론 우선·문단 절제·표 활용·권고안 우선·실행항목 분리.
+ *
+ * @module prompts/answer-composer-system
+ */
+import type { AnswerIntent } from '../schemas/structured-answer.schema';
+
+const BODY: Record<'ko' | 'en', string> = {
+    ko: `당신은 답변을 JSON 구조로 작성하는 어시스턴트입니다. 반드시 주어진 JSON 스키마에 맞는 객체 하나만 출력하고, 그 외 텍스트(설명·마크다운 펜스)는 출력하지 않습니다.
+
+## 작성 품질 기준
+- conclusion(결론)을 가장 먼저, 한두 문장으로 명확히 제시한다.
+- 각 섹션 body 의 한 문단은 3문장을 넘지 않는다. 같은 의미를 반복하지 않는다.
+- 비교 가능한 항목은 sections[].table 로 정리한다(headers + rows).
+- 의사결정 질문이면 conclusion 에 권고안 하나를 먼저 제시한 뒤 근거를 sections 에 둔다.
+- 실행이 필요하면 action_items 로 분리한다. 위험·주의는 risks 로 분리한다.
+- confidence 는 근거의 확실성에 따라 high/medium/low 로 정직하게 표기한다.
+- title 은 질문을 요약하는 짧은 제목. 불확실한 사실은 추측하지 말고 confidence 를 낮춘다.`,
+    en: `You are an assistant that writes answers as a JSON object. Output exactly one object matching the given JSON schema and nothing else (no prose, no markdown fences).
+
+## Quality bar
+- Put the conclusion first, in one or two clear sentences.
+- Keep each paragraph in a section body to three sentences or fewer. Do not repeat points.
+- Put comparable items into sections[].table (headers + rows).
+- For decision questions, give one recommendation first in conclusion, with rationale in sections.
+- Separate actionable steps into action_items, and warnings into risks.
+- Set confidence honestly to high/medium/low based on the certainty of evidence.
+- title is a short summary of the question. Do not guess unverifiable facts; lower confidence instead.`,
+};
+
+const INTENT_HINT: Record<'ko' | 'en', string> = {
+    ko: '\n\n분류된 답변 유형(intent): ',
+    en: '\n\nClassified answer intent: ',
+};
+
+/**
+ * Answer Composer system prompt 빌드. 분류된 intent 를 모델에 힌트로 전달.
+ */
+export function buildAnswerComposerSystemPrompt(intent: AnswerIntent, userLanguage: string): string {
+    const lang = userLanguage.toLowerCase().startsWith('ko') ? 'ko' : 'en';
+    return `${BODY[lang]}${INTENT_HINT[lang]}${intent}`;
+}
+
+/** Validator 실패 시 1회 재시도에 덧붙이는 교정 지시. */
+export function getRepairHint(userLanguage: string): string {
+    const lang = userLanguage.toLowerCase().startsWith('ko') ? 'ko' : 'en';
+    return lang === 'ko'
+        ? '직전 출력이 JSON 스키마를 벗어났습니다. 마크다운 펜스 없이 스키마에 맞는 JSON 객체 하나만 다시 출력하세요.'
+        : 'The previous output did not match the JSON schema. Output exactly one schema-conformant JSON object again, with no markdown fences.';
+}

--- a/apps/api/src/routes/chat.routes.ts
+++ b/apps/api/src/routes/chat.routes.ts
@@ -27,6 +27,7 @@ import { validate } from '../middlewares/validation';
 import { chatRequestSchema } from '../schemas';
 import { ChatRequestHandler, ChatRequestError } from '../chat/request-handler';
 import { createClient } from '../llm/client';
+import { AppError } from '../utils/error-handler';
 import { parseFullModelId } from '../providers/i-provider';
 import { ProviderRouter } from '../providers/provider-router';
 import { ProviderError } from '../providers/provider-errors';
@@ -310,6 +311,9 @@ router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncH
         }));
     } catch (err) {
         settled = true;
+        // 이 엔드포인트는 항상 JSON 으로 응답한다 — 글로벌 핸들러/Express 기본(비-JSON "Internal Server Error")
+        // 으로 위임하지 않아, 프론트(ApiClient.JSON.parse)가 어떤 실패에도 파싱 가능한 본문을 받게 한다.
+        if (res.headersSent) return; // abort 등으로 이미 응답 시작 — 중복 전송 방지
         if (err instanceof ProviderError) {
             const statusByCode: Record<string, number> = {
                 GUEST_NOT_ALLOWED: 403,
@@ -325,7 +329,10 @@ router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncH
             res.status(statusByCode[err.code] ?? 502).json({ error: err.message, code: err.code });
             return;
         }
-        throw err;
+        // AppError(예: 422 스키마 검증 실패) 및 기타 — 직접 JSON 으로 매핑.
+        const status = err instanceof AppError ? err.statusCode : 500;
+        const code = err instanceof AppError && err.code ? err.code : 'STRUCTURED_ERROR';
+        res.status(status).json({ error: err instanceof Error ? err.message : '구조화 답변 생성 실패', code });
     }
 }));
 

--- a/apps/api/src/routes/chat.routes.ts
+++ b/apps/api/src/routes/chat.routes.ts
@@ -28,6 +28,11 @@ import { chatRequestSchema } from '../schemas';
 import { ChatRequestHandler, ChatRequestError } from '../chat/request-handler';
 import { createClient } from '../llm/client';
 import { parseFullModelId } from '../providers/i-provider';
+import { ProviderRouter } from '../providers/provider-router';
+import { ProviderError } from '../providers/provider-errors';
+import { LocalLLMProvider } from '../providers/local-llm-provider';
+import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
+import { getPool } from '../data/models/unified-database';
 import { composeStructuredAnswer, type StructuredChatFn } from '../services/answer-composer';
 import { getConversationDB } from '../data/conversation-db';
 import { createLogger } from '../utils/logger';
@@ -242,38 +247,86 @@ router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncH
 
     const userLanguage: string = req.body.userLanguage || 'ko';
 
-    // 모델명 정규화 — 프론트는 'local-llm:qwen3.6-35b-a3b' 같은 full id 를 보내므로
-    // provider prefix 를 벗겨 LiteLLM 카탈로그 이름으로 변환한다. 외부 provider 나
-    // 'default' 는 env 기본 모델(LLM_DEFAULT_MODEL)로 폴백(이 엔드포인트는 로컬 전용).
-    let model: string | undefined;
+    // 사용자 중단(abort) — 클라이언트가 fetch 를 취소하면 req 가 close 되어 upstream LLM 호출도 끊는다.
+    const abortController = new AbortController();
+    let settled = false;
+    req.on('close', () => { if (!settled) abortController.abort(); });
+
+    // 모델 full id 정규화 — 프론트는 'local-llm:qwen3.6-35b-a3b' / 'anthropic:claude-...' 형식을 보낸다.
+    // 'default'·미지정·prefix 없는 경우는 로컬 기본 모델로 폴백.
     const rawModel = req.body.model;
-    if (typeof rawModel === 'string' && rawModel && rawModel !== 'default') {
-        if (rawModel.includes(':')) {
-            const parsed = parseFullModelId(rawModel);
-            if (parsed.providerId === 'local-llm') model = parsed.modelId;
-        } else {
-            model = rawModel;
-        }
+    const fullId = (typeof rawModel === 'string' && rawModel && rawModel !== 'default')
+        ? (rawModel.includes(':') ? rawModel : `local-llm:${rawModel}`)
+        : null;
+
+    const ctxUserId = isPersistableUserId(userContext.userId) ? String(userContext.userId) : undefined;
+    const parsed = fullId ? parseFullModelId(fullId) : { providerId: 'local-llm', modelId: '' };
+
+    let chat: StructuredChatFn;
+    let usedModel: string;
+
+    try {
+    if (parsed.providerId === 'local-llm') {
+        // 로컬(LiteLLM) — json_schema strict 로 최고 신뢰성. (provider 추상화는 format 미지원)
+        const client = createClient({
+            ...(parsed.modelId ? { model: parsed.modelId } : {}),
+            ...(ctxUserId ? { userId: ctxUserId } : {}),
+        });
+        usedModel = client.model;
+        chat = async (messages, format) => {
+            const result = await client.chat(messages, undefined, undefined, {
+                format,
+                signal: abortController.signal,
+            });
+            return result.content ?? '';
+        };
+    } else {
+        // 외부 provider(Anthropic/OpenRouter 등) — provider 추상화는 json_schema 미지원이라
+        // streamChat 을 집계(비스트리밍)하고 JSON 은 프롬프트 + Validator/재시도로 받는다.
+        const localProvider = new LocalLLMProvider(createClient());
+        const providerRouter = new ProviderRouter({
+            localProvider,
+            externalKeysRepo: new ExternalKeysRepository(getPool()),
+        });
+        // 외부 키는 실제(영속) user id 로만 조회 — 게스트(anon)는 ctxUserId=undefined → GUEST_NOT_ALLOWED.
+        const resolved = await providerRouter.resolve(fullId as string, { userId: ctxUserId });
+        usedModel = resolved.fullId;
+        chat = async (messages) => {
+            const result = await resolved.provider.streamChat(
+                { messages, modelId: resolved.modelId, abortSignal: abortController.signal },
+                {}, // 토큰 콜백 불필요 — 누적 결과(content)만 사용
+            );
+            return result.content ?? '';
+        };
     }
 
-    const client = createClient({
-        ...(model ? { model } : {}),
-        ...(isPersistableUserId(userContext.userId) ? { userId: String(userContext.userId) } : {}),
-    });
-
-    // 주입되는 LLM 호출 — 비스트리밍(onToken 미전달) + json_schema strict.
-    const chat: StructuredChatFn = async (messages, format) => {
-        const result = await client.chat(messages, undefined, undefined, { format });
-        return result.content ?? '';
-    };
-
-    const composed = await composeStructuredAnswer({ message, userLanguage, chat });
-    res.json(success({
-        intent: composed.intent,
-        structured: composed.structured,
-        markdown: composed.markdown,
-        model: client.model,
-    }));
+        const composed = await composeStructuredAnswer({ message, userLanguage, chat });
+        settled = true;
+        res.json(success({
+            intent: composed.intent,
+            structured: composed.structured,
+            markdown: composed.markdown,
+            model: usedModel,
+        }));
+    } catch (err) {
+        settled = true;
+        if (err instanceof ProviderError) {
+            const statusByCode: Record<string, number> = {
+                GUEST_NOT_ALLOWED: 403,
+                MISSING_API_KEY: 400,
+                INVALID_API_KEY: 401,
+                QUOTA_EXCEEDED: 429,
+                INSUFFICIENT_CREDIT: 402,
+                MODEL_NOT_FOUND: 404,
+                INVALID_MODEL_ID: 400,
+                NOT_SUPPORTED: 400,
+                UPSTREAM_ERROR: 502,
+            };
+            res.status(statusByCode[err.code] ?? 502).json({ error: err.message, code: err.code });
+            return;
+        }
+        throw err;
+    }
 }));
 
 export default router;

--- a/apps/api/src/routes/chat.routes.ts
+++ b/apps/api/src/routes/chat.routes.ts
@@ -26,6 +26,9 @@ import { chatRateLimiter } from '../middlewares/chat-rate-limiter';
 import { validate } from '../middlewares/validation';
 import { chatRequestSchema } from '../schemas';
 import { ChatRequestHandler, ChatRequestError } from '../chat/request-handler';
+import { createClient } from '../llm/client';
+import { parseFullModelId } from '../providers/i-provider';
+import { composeStructuredAnswer, type StructuredChatFn } from '../services/answer-composer';
 import { getConversationDB } from '../data/conversation-db';
 import { createLogger } from '../utils/logger';
 
@@ -216,5 +219,61 @@ router.post('/stream', optionalApiKey, optionalAuth, chatRateLimiter, validate(c
         res.end();
     }
 });
+
+/**
+ * POST /api/chat/structured
+ * 구조화 답변 API (비스트리밍, opt-in) — Response Formatter Layer.
+ * Answer Planner → JSON Schema(strict) 출력 → Validator → formatAnswer 마크다운 조립.
+ * 스트리밍 기본 경로(/stream)와 별개 — 완성형 카드/리포트가 필요한 호출 전용.
+ * 응답: { intent, structured(StructuredAnswer JSON), markdown }.
+ */
+router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncHandler(async (req: Request, res: Response) => {
+    const { message } = req.body;
+    if (typeof message !== 'string' || !message.trim()) {
+        res.status(400).json({ error: 'message 는 필수입니다' });
+        return;
+    }
+
+    const userContext = ChatRequestHandler.resolveUserContextFromRequest(req);
+    if (!userContext) {
+        res.status(401).json(unauthorized('인증이 필요합니다'));
+        return;
+    }
+
+    const userLanguage: string = req.body.userLanguage || 'ko';
+
+    // 모델명 정규화 — 프론트는 'local-llm:qwen3.6-35b-a3b' 같은 full id 를 보내므로
+    // provider prefix 를 벗겨 LiteLLM 카탈로그 이름으로 변환한다. 외부 provider 나
+    // 'default' 는 env 기본 모델(LLM_DEFAULT_MODEL)로 폴백(이 엔드포인트는 로컬 전용).
+    let model: string | undefined;
+    const rawModel = req.body.model;
+    if (typeof rawModel === 'string' && rawModel && rawModel !== 'default') {
+        if (rawModel.includes(':')) {
+            const parsed = parseFullModelId(rawModel);
+            if (parsed.providerId === 'local-llm') model = parsed.modelId;
+        } else {
+            model = rawModel;
+        }
+    }
+
+    const client = createClient({
+        ...(model ? { model } : {}),
+        ...(isPersistableUserId(userContext.userId) ? { userId: String(userContext.userId) } : {}),
+    });
+
+    // 주입되는 LLM 호출 — 비스트리밍(onToken 미전달) + json_schema strict.
+    const chat: StructuredChatFn = async (messages, format) => {
+        const result = await client.chat(messages, undefined, undefined, { format });
+        return result.content ?? '';
+    };
+
+    const composed = await composeStructuredAnswer({ message, userLanguage, chat });
+    res.json(success({
+        intent: composed.intent,
+        structured: composed.structured,
+        markdown: composed.markdown,
+        model: client.model,
+    }));
+}));
 
 export default router;

--- a/apps/api/src/schemas/structured-answer.schema.ts
+++ b/apps/api/src/schemas/structured-answer.schema.ts
@@ -1,0 +1,99 @@
+/**
+ * ============================================================
+ * Structured Answer Schema — JSON Schema 구조화 출력 계약
+ * ============================================================
+ *
+ * 제안서(2026-06-26) 3·4절: LLM 이 자유 마크다운을 즉흥 작성하는 대신, 답변의
+ * "뼈대"(제목·결론·요약·섹션·표·리스크·실행항목)를 JSON 으로 받는다. 이 모듈은
+ * 그 계약 한 곳(SoT)이다.
+ *
+ *   - `AnswerIntent`            : 답변 유형 (answer-planner 가 분류)
+ *   - `StructuredAnswer`        : TS 타입
+ *   - `StructuredAnswerSchema`  : Zod 검증기 (Validator 단계)
+ *   - `STRUCTURED_ANSWER_FORMAT`: LLMClient `format` (vLLM json_schema, strict)
+ *
+ * 스트리밍 기본 경로(message-pipeline)는 이 스키마를 쓰지 않는다 — 그쪽은 토큰
+ * 스트리밍 보존을 위해 chat/answer-format.ts 의 프롬프트 레이어를 사용한다.
+ * 본 스키마는 opt-in 비스트리밍 Response Formatter Layer 전용.
+ *
+ * @module schemas/structured-answer.schema
+ */
+import { z } from 'zod';
+import type { FormatOption } from '../llm/types';
+
+export const ANSWER_INTENTS = [
+    'decision',
+    'explanation',
+    'comparison',
+    'troubleshooting',
+    'technical_design',
+    'summary',
+    'drafting',
+] as const;
+
+export type AnswerIntent = (typeof ANSWER_INTENTS)[number];
+
+const TableSchema = z.object({
+    headers: z.array(z.string()),
+    rows: z.array(z.array(z.string())),
+});
+
+const SectionSchema = z.object({
+    heading: z.string(),
+    body: z.string(),
+    bullets: z.array(z.string()).optional(),
+    table: TableSchema.optional(),
+});
+
+/**
+ * 구조화 답변 Zod 검증기 (Validator). LLM 출력 파싱 후 이걸 통과해야 formatAnswer 로 넘어간다.
+ */
+export const StructuredAnswerSchema = z.object({
+    intent: z.enum(ANSWER_INTENTS),
+    title: z.string(),
+    conclusion: z.string(),
+    summary: z.string().optional().default(''),
+    sections: z.array(SectionSchema),
+    risks: z.array(z.string()).optional(),
+    action_items: z.array(z.string()).optional(),
+    confidence: z.enum(['high', 'medium', 'low']),
+});
+
+export type StructuredAnswer = z.infer<typeof StructuredAnswerSchema>;
+
+/**
+ * LLMClient `advancedOptions.format` 으로 전달할 JSON Schema (vLLM json_schema, strict).
+ * stream-parser.toResponseFormat 가 { type:'json_schema', json_schema:{ schema:{ type:'object', properties, required } } } 로 변환.
+ */
+export const STRUCTURED_ANSWER_FORMAT: FormatOption = {
+    type: 'object',
+    properties: {
+        intent: { type: 'string', enum: [...ANSWER_INTENTS] },
+        title: { type: 'string' },
+        conclusion: { type: 'string' },
+        summary: { type: 'string' },
+        sections: {
+            type: 'array',
+            items: {
+                type: 'object',
+                properties: {
+                    heading: { type: 'string' },
+                    body: { type: 'string' },
+                    bullets: { type: 'array', items: { type: 'string' } },
+                    table: {
+                        type: 'object',
+                        properties: {
+                            headers: { type: 'array', items: { type: 'string' } },
+                            rows: { type: 'array', items: { type: 'array', items: { type: 'string' } } },
+                        },
+                    },
+                },
+                required: ['heading', 'body'],
+            },
+        },
+        risks: { type: 'array', items: { type: 'string' } },
+        action_items: { type: 'array', items: { type: 'string' } },
+        confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+    },
+    required: ['intent', 'title', 'conclusion', 'sections', 'confidence'],
+};

--- a/apps/api/src/services/answer-composer.ts
+++ b/apps/api/src/services/answer-composer.ts
@@ -1,0 +1,147 @@
+/**
+ * ============================================================
+ * Answer Composer — Response Formatter Layer (비스트리밍 구조화 출력)
+ * ============================================================
+ *
+ * 제안서(2026-06-26) 4·8·10절: LLM 출력을 자유 텍스트가 아니라 JSON Schema 기반
+ * 구조화 출력(StructuredAnswer)으로 받은 뒤, 백엔드에서 일정한 마크다운으로 조립한다.
+ *
+ * 파이프라인:
+ *   message → classifyAnswerIntent(Answer Planner)
+ *           → LLM(비스트리밍, json_schema strict)  [Generator]
+ *           → StructuredAnswerSchema.safeParse      [Validator] (실패 시 1회 재시도)
+ *           → formatAnswer()                        [Response Formatter]
+ *
+ * ⚠️ 스트리밍 기본 경로(message-pipeline)와 별개의 opt-in 레이어. 토큰 스트리밍이
+ * 필요 없는(=완성형 카드/리포트) 호출에만 쓴다. LLM 호출 함수는 주입(chat) 받아
+ * 순수 함수로 유지 — 테스트 가능.
+ *
+ * @module services/answer-composer
+ */
+import { AppError } from '../utils/error-handler';
+import { createLogger } from '../utils/logger';
+import {
+    StructuredAnswerSchema,
+    STRUCTURED_ANSWER_FORMAT,
+    type StructuredAnswer,
+    type AnswerIntent,
+} from '../schemas/structured-answer.schema';
+import { classifyAnswerIntent } from '../chat/answer-planner';
+import { buildAnswerComposerSystemPrompt, getRepairHint } from '../prompts/answer-composer-system';
+import type { ChatMessage, FormatOption } from '../llm/types';
+
+const logger = createLogger('AnswerComposer');
+
+/** 주입되는 LLM 호출 함수 — (messages, json_schema) → raw content. 비스트리밍. */
+export type StructuredChatFn = (messages: ChatMessage[], format: FormatOption) => Promise<string>;
+
+/**
+ * StructuredAnswer → 일정한 마크다운 (제안서 8절 formatAnswer 정확 구현).
+ * 결론 → 요약 → 본문 섹션(+표) → 주의할 점 → 다음 실행 순으로 항상 동일 구조.
+ */
+export function formatAnswer(answer: StructuredAnswer, lang: 'ko' | 'en' = 'ko'): string {
+    const L = lang === 'ko'
+        ? { conclusion: '결론', summary: '요약', risks: '주의할 점', actions: '다음 실행' }
+        : { conclusion: 'Conclusion', summary: 'Summary', risks: 'Risks', actions: 'Next steps' };
+
+    const parts: string[] = [];
+    parts.push(`# ${answer.title}`);
+    parts.push(`## ${L.conclusion}`);
+    parts.push(answer.conclusion);
+
+    if (answer.summary && answer.summary.trim()) {
+        parts.push(`## ${L.summary}`);
+        parts.push(answer.summary);
+    }
+
+    for (const section of answer.sections) {
+        parts.push(`## ${section.heading}`);
+        if (section.body && section.body.trim()) parts.push(section.body);
+        if (section.bullets?.length) {
+            parts.push(section.bullets.map((b) => `- ${b}`).join('\n'));
+        }
+        if (section.table && section.table.headers.length) {
+            parts.push(renderTable(section.table.headers, section.table.rows));
+        }
+    }
+
+    if (answer.risks?.length) {
+        parts.push(`## ${L.risks}`);
+        parts.push(answer.risks.map((r) => `- ${r}`).join('\n'));
+    }
+    if (answer.action_items?.length) {
+        parts.push(`## ${L.actions}`);
+        parts.push(answer.action_items.map((a) => `- ${a}`).join('\n'));
+    }
+
+    return parts.join('\n\n');
+}
+
+/** 마크다운 GFM 표 렌더 (셀의 파이프는 이스케이프). */
+function renderTable(headers: string[], rows: string[][]): string {
+    const esc = (s: string) => String(s).replace(/\|/g, '\\|').replace(/\n/g, ' ');
+    const head = `| ${headers.map(esc).join(' | ')} |`;
+    const sep = `| ${headers.map(() => '---').join(' | ')} |`;
+    const body = rows
+        .map((row) => `| ${headers.map((_, i) => esc(row[i] ?? '')).join(' | ')} |`)
+        .join('\n');
+    return [head, sep, body].filter(Boolean).join('\n');
+}
+
+/** json_schema 출력에서 객체를 안전 파싱 (혹시 모를 마크다운 펜스 제거). */
+function parseStructured(raw: string): unknown {
+    const trimmed = raw.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '');
+    return JSON.parse(trimmed);
+}
+
+export interface ComposeResult {
+    intent: AnswerIntent;
+    structured: StructuredAnswer;
+    markdown: string;
+}
+
+/**
+ * 구조화 답변 합성. Answer Planner → Generator → Validator → Response Formatter.
+ * Validator 실패 시 교정 힌트로 1회 재시도, 그래도 실패면 422.
+ */
+export async function composeStructuredAnswer(opts: {
+    message: string;
+    userLanguage?: string;
+    chat: StructuredChatFn;
+}): Promise<ComposeResult> {
+    const lang = (opts.userLanguage || 'ko').toLowerCase().startsWith('ko') ? 'ko' : 'en';
+    const intent = classifyAnswerIntent(opts.message);
+    const system = buildAnswerComposerSystemPrompt(intent, lang);
+
+    const messages: ChatMessage[] = [
+        { role: 'system', content: system },
+        { role: 'user', content: opts.message },
+    ];
+
+    const attempt = async (msgs: ChatMessage[]): Promise<StructuredAnswer | null> => {
+        const raw = await opts.chat(msgs, STRUCTURED_ANSWER_FORMAT);
+        let parsed: unknown;
+        try {
+            parsed = parseStructured(raw);
+        } catch {
+            logger.warn('구조화 출력 JSON 파싱 실패');
+            return null;
+        }
+        const result = StructuredAnswerSchema.safeParse(parsed);
+        return result.success ? result.data : null;
+    };
+
+    let structured = await attempt(messages);
+    if (!structured) {
+        // 1회 재시도 — 교정 힌트 추가.
+        structured = await attempt([
+            ...messages,
+            { role: 'system', content: getRepairHint(lang) },
+        ]);
+    }
+    if (!structured) {
+        throw new AppError('구조화 답변 검증 실패 (스키마 불일치)', 422, true, 'STRUCTURED_OUTPUT_INVALID');
+    }
+
+    return { intent, structured, markdown: formatAnswer(structured, lang) };
+}

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -17,6 +17,7 @@ import { EXTERNAL_LLM_TOOL_BLACKLIST, LOOP_DETECTION, AGENT_LOOP_LIMITS, MAX_TOO
 import { getUnifiedMCPClient } from '../../mcp/unified-client';
 import { isPersistableUserId } from '../../utils/user-id-validation';
 import { getExternalProviderSystemGuards } from '../../chat/prompt';
+import { getStyleGuard, normalizeStyle, type Style } from '../../chat/style';
 import type { ChatMessage, ToolDefinition } from '../../llm';
 import type { ChatMessageRequest } from '../chat-service-types';
 import type { UserContext } from '../../mcp/user-sandbox';
@@ -50,6 +51,8 @@ export interface StreamFromExternalContext {
     customInstructionsBlock?: string;
     /** Artifacts guide (디자인시스템·<artifact> 형식 지시). 가드/페르소나 뒤에 append. */
     artifactGuideBlock?: string;
+    /** 응답 스타일 (concise/default/verbose). 정적 prefix 맨 앞에 style guard prepend. default 면 overhead 0. */
+    style?: Style;
 }
 
 /**
@@ -73,6 +76,15 @@ export async function streamFromExternalProvider(
     // Phase 2026-05-26: 외부 provider 도 Identity Guard + Response Discipline 적용.
     // 본 가드 미적용 시 Gemini/GPT 가 "Here's a thinking process", 단계 1-N,
     // 자기 정체 노출 같은 verbose 형식을 그대로 출력 (사용자 보고 사례 해결).
+    // 응답 스타일 가드 (concise/verbose) — 정적 prefix 맨 앞에 prepend. default 면 빈 문자열(overhead 0).
+    // strategy 경로의 applyStyle 과 동일 정책: 외부 provider 도 사용자 선택 스타일을 반영한다.
+    const styleGuard = getStyleGuard(
+        normalizeStyle(ctx.style),
+        ctx.resolvedLanguage || req.userLanguagePreference || 'en',
+    );
+    if (styleGuard) {
+        systemPromptParts.push(styleGuard.trim());
+    }
     const guards = getExternalProviderSystemGuards(ctx.resolvedLanguage || req.userLanguagePreference || 'en');
     if (guards) {
         systemPromptParts.push(guards.trim());

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -53,6 +53,8 @@ export interface StreamFromExternalContext {
     artifactGuideBlock?: string;
     /** 응답 스타일 (concise/default/verbose). 정적 prefix 맨 앞에 style guard prepend. default 면 overhead 0. */
     style?: Style;
+    /** 답변 형식 가드 (구조적 질문에 결론-우선·표·실행항목 분리). prose/concise 면 빈 문자열. */
+    answerFormatBlock?: string;
 }
 
 /**
@@ -88,6 +90,10 @@ export async function streamFromExternalProvider(
     const guards = getExternalProviderSystemGuards(ctx.resolvedLanguage || req.userLanguagePreference || 'en');
     if (guards) {
         systemPromptParts.push(guards.trim());
+    }
+    // 답변 형식 가드 (구조적 질문) — 정적 prefix. prose/concise 면 빈 문자열이라 미주입.
+    if (ctx.answerFormatBlock) {
+        systemPromptParts.push(ctx.answerFormatBlock.trim());
     }
     // Artifacts guide (디자인시스템·<artifact> 형식) — 정적.
     if (ctx.artifactGuideBlock) {

--- a/apps/api/src/services/chat-service/message-pipeline.ts
+++ b/apps/api/src/services/chat-service/message-pipeline.ts
@@ -24,7 +24,8 @@ import { createRoutingLogEntry } from '../../chat/routing-logger';
 import type { ChatMessageRequest, SystemEventCallback } from '../chat-service-types';
 import { getExecutionPlanBuilder } from '../../chat/execution-plan-builder';
 import type { UnifiedExecutionPlan } from '../../chat/execution-plan-types';
-import { applyStyle } from '../../chat/style';
+import { applyStyle, normalizeStyle } from '../../chat/style';
+import { resolveAnswerFormatProfile, applyAnswerFormat, getAnswerFormatGuard } from '../../chat/answer-format';
 import { normalizeBrandAlias, logAliasHitIfAny } from '../../chat/brand-alias-normalizer';
 import { runProviderGate } from './provider-gate';
 import type { RequestContext } from './request-context';
@@ -399,6 +400,13 @@ export async function runMessagePipeline(svc: ChatService,
             const { getArtifactForceDirective } = await import('../../prompts/artifact-guide');
             extArtifactGuide += getArtifactForceDirective(extLang);
         }
+        // Answer Format 축 (2026-06-26): 외부/로컬(기본 경로) 모두 strategy 경로와 대칭.
+        // promptConfig 는 이 분기에 없으므로 message 로부터 detectPromptType 재사용.
+        const extAnswerFormatProfile = resolveAnswerFormatProfile({
+            style: normalizeStyle(req.style),
+            message: message || '',
+        });
+        const extAnswerFormatBlock = getAnswerFormatGuard(extAnswerFormatProfile, extLang);
         return await svc.streamFromExternalProvider(externalResolved, req, streamToken, {
             agentSystemMessage: agentSysMsgForExternal,
             enhancedMessage: finalEnhancedMessage,
@@ -406,6 +414,7 @@ export async function runMessagePipeline(svc: ChatService,
             memoryBlock: extMemoryBlock,
             customInstructionsBlock: extCustomInstructionsBlock,
             artifactGuideBlock: extArtifactGuide,
+            answerFormatBlock: extAnswerFormatBlock,
             style: req.style,
         }, reqCtx);
     }
@@ -515,6 +524,15 @@ export async function runMessagePipeline(svc: ChatService,
         : promptConfig.systemPrompt;
     // Phase A (2026-05-26): per-session Style 축 적용. default 일 때는 overhead 0.
     const styledBase = applyStyle(baseCombined, unifiedPlan.style, languagePolicy?.resolvedLanguage || 'en');
+    // Answer Format 축 (2026-06-26): 구조적 질문(reasoning/coder/consultant 등)에 결론-우선·
+    // 표·실행항목 분리 형식을 강제. style 과 직교 — concise 거나 일상 질문이면 prose(주입 0).
+    const answerFormatProfile = resolveAnswerFormatProfile({
+        style: unifiedPlan.style,
+        promptType: promptConfig.type,
+    });
+    const formattedBase = applyAnswerFormat(
+        styledBase, answerFormatProfile, languagePolicy?.resolvedLanguage || 'en',
+    );
     // 2026-05-26: thinkingMode 활성 시 system prompt 로 사고 강도 유도.
     // 기존 user-message wrap 방식 (Sequential Thinking) 은 vLLM/Gemini native
     // reasoning 과 중복 + 본문 형식 오염을 일으켜 폐기됨.
@@ -528,7 +546,7 @@ export async function runMessagePipeline(svc: ChatService,
 
     // Cache-aware 조립: 정적 헌법(styledBase·artifactGuide)을 prefix 앞에, 동적(thinking·memory·custom)을
     // DYNAMIC BOUNDARY 뒤에 두어 vLLM/OpenRouter prefix 캐시 hit 을 극대화한다. (external-provider 경로와 동일 정책)
-    const combinedSystemPrompt = [styledBase, artifactGuideBlock, thinkingGuidance, memoryBlock, customInstructionsBlock]
+    const combinedSystemPrompt = [formattedBase, artifactGuideBlock, thinkingGuidance, memoryBlock, customInstructionsBlock]
         .map((s) => s.trim()).filter(Boolean).join('\n\n');
 
     // history assembly + system prompt + budget hint + user message — helper module 위임

--- a/apps/api/src/services/chat-service/message-pipeline.ts
+++ b/apps/api/src/services/chat-service/message-pipeline.ts
@@ -406,6 +406,7 @@ export async function runMessagePipeline(svc: ChatService,
             memoryBlock: extMemoryBlock,
             customInstructionsBlock: extCustomInstructionsBlock,
             artifactGuideBlock: extArtifactGuide,
+            style: req.style,
         }, reqCtx);
     }
 

--- a/apps/web/app/(workspace)/settings/page.tsx
+++ b/apps/web/app/(workspace)/settings/page.tsx
@@ -160,6 +160,9 @@ export default function SettingsPage() {
   // 일반 / 모델
   const selectedModel = useAppStore((s) => s.selectedModel);
   const setSelectedModel = useAppStore((s) => s.setSelectedModel);
+  // 응답 스타일 — composer 사이클 버튼과 동일한 store.style 을 단일 소스로 사용(영속화됨).
+  const responseStyle = useAppStore((s) => s.style);
+  const setResponseStyle = useAppStore((s) => s.setStyle);
   const { data: modelsData } = useQuery({
     queryKey: ["models"],
     queryFn: fetchModels,
@@ -194,8 +197,6 @@ export default function SettingsPage() {
       : []),
     ...externalGroups,
   ];
-  const [responseStyle, setResponseStyle] =
-    useState<(typeof RESPONSE_STYLES)[number]["value"]>("default");
   const [language, setLanguage] = useState("");
   const [customInstructions, setCustomInstructions] = useState("");
 

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -12,6 +12,7 @@ import {
   Brain,
   Image as ImageIcon,
   FileCode2,
+  LayoutList,
   SlidersHorizontal,
   Check,
   Paperclip,
@@ -74,7 +75,7 @@ function readFileBase64(file: File): Promise<string> {
 }
 
 export function Composer() {
-  const { sendChat, abort, startAgentTask } = useChatSocket();
+  const { sendChat, abort, startAgentTask, sendStructured } = useChatSocket();
   const [text, setText] = useState("");
   const [files, setFiles] = useState<WsAttachedFile[]>([]);
   // 이미지 첨부 — base64 data URL 로 vision 채널 전송. 미리보기/제거를 위해 메타와 함께 보관.
@@ -156,6 +157,7 @@ export function Composer() {
     agentTaskMode,
     imageMode,
     artifactMode,
+    structuredMode,
     selectedModel,
     style,
     inputDraft,
@@ -180,6 +182,9 @@ export function Composer() {
     if (agentTaskMode) {
       // 에이전트 토글 ON — 메시지를 목표로 자율 에이전트 작업 실행 (REST). 첨부는 미지원.
       void startAgentTask(text.trim());
+    } else if (structuredMode) {
+      // 구조화 답변 토글 ON — REST /api/chat/structured (비스트리밍, 카드 렌더). 첨부는 미지원.
+      void sendStructured(text.trim());
     } else {
       sendChat(
         text.trim(),
@@ -224,6 +229,7 @@ export function Composer() {
     { key: "agentTaskMode" as const, on: agentTaskMode, icon: Sparkles, label: "에이전트" },
     { key: "imageMode" as const, on: imageMode, icon: ImageIcon, label: "이미지" },
     { key: "artifactMode" as const, on: artifactMode, icon: FileCode2, label: "아티팩트" },
+    { key: "structuredMode" as const, on: structuredMode, icon: LayoutList, label: "구조화 답변" },
   ];
   const activeModeCount = TOGGLES.filter((t) => t.on).length;
 

--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { MessagesSquare, Telescope, Brain, Sparkles, FileCode2, ChevronRight } from "lucide-react";
 import { useAppStore } from "@/lib/store";
 import { Markdown } from "./markdown";
+import { StructuredAnswer } from "./structured-answer";
 import { cn } from "@/lib/utils";
 
 const ARTIFACT_PLACEHOLDER = /\[\[artifact:([^\]]+)\]\]/g;
@@ -211,7 +212,11 @@ export function MessageList() {
                 </details>
               )}
               <div className="text-sm leading-relaxed text-fg">
-                <AssistantContent content={m.content} streaming={m.streaming} />
+                {m.structured ? (
+                  <StructuredAnswer data={m.structured} />
+                ) : (
+                  <AssistantContent content={m.content} streaming={m.streaming} />
+                )}
                 {m.streaming && (
                   <span className="ml-0.5 inline-block h-4 w-1.5 animate-pulse bg-accent align-text-bottom" />
                 )}

--- a/apps/web/components/chat/structured-answer.tsx
+++ b/apps/web/components/chat/structured-answer.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { AlertTriangle, CheckCircle2, ListChecks } from "lucide-react";
+import type { StructuredAnswerData } from "@/lib/store";
+import { Markdown } from "./markdown";
+import { cn } from "@/lib/utils";
+
+const CONFIDENCE_LABEL: Record<StructuredAnswerData["confidence"], string> = {
+  high: "확신 높음",
+  medium: "확신 보통",
+  low: "확신 낮음",
+};
+
+const CONFIDENCE_STYLE: Record<StructuredAnswerData["confidence"], string> = {
+  high: "border-accent bg-accent-soft text-accent",
+  medium: "border-border bg-surface-2 text-fg-2",
+  low: "border-border bg-surface-2 text-muted",
+};
+
+/** 구조화 표(headers/rows) → GFM 스타일 네이티브 테이블. */
+function StructuredTable({ headers, rows }: { headers: string[]; rows: string[][] }) {
+  return (
+    <div className="my-2 overflow-x-auto">
+      <table className="w-full border-collapse text-sm">
+        <thead>
+          <tr>
+            {headers.map((h, i) => (
+              <th
+                key={i}
+                className="border border-border bg-surface-2 px-3 py-1.5 text-left font-semibold text-fg"
+              >
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, ri) => (
+            <tr key={ri}>
+              {headers.map((_, ci) => (
+                <td key={ci} className="border border-border px-3 py-1.5 align-top text-fg-2">
+                  {row[ci] ?? ""}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/**
+ * 구조화 답변 카드 렌더러 — structuredMode(REST /api/chat/structured) 응답 전용.
+ * 결론을 먼저, 그 다음 요약·섹션(+표)·주의할 점·다음 실행 순으로 항상 일정한 구조로 표시한다.
+ */
+export function StructuredAnswer({ data }: { data: StructuredAnswerData }) {
+  return (
+    <div className="space-y-3">
+      {/* 제목 + confidence 배지 */}
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-base font-semibold text-fg">{data.title}</h3>
+        <span
+          className={cn(
+            "shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium",
+            CONFIDENCE_STYLE[data.confidence],
+          )}
+        >
+          {CONFIDENCE_LABEL[data.confidence]}
+        </span>
+      </div>
+
+      {/* 결론 — 강조 카드 (가장 먼저) */}
+      <div className="rounded-lg border border-accent bg-accent-soft px-3.5 py-3">
+        <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-accent">결론</p>
+        <div className="text-sm leading-relaxed text-fg">
+          <Markdown content={data.conclusion} />
+        </div>
+      </div>
+
+      {/* 요약 */}
+      {data.summary?.trim() ? (
+        <div className="text-sm leading-relaxed text-fg-2">
+          <Markdown content={data.summary} />
+        </div>
+      ) : null}
+
+      {/* 본문 섹션 */}
+      {data.sections.map((s, i) => (
+        <section key={i} className="space-y-1.5">
+          <h4 className="text-sm font-semibold text-fg">{s.heading}</h4>
+          {s.body?.trim() ? (
+            <div className="text-sm leading-relaxed text-fg-2">
+              <Markdown content={s.body} />
+            </div>
+          ) : null}
+          {s.bullets?.length ? (
+            <ul className="ml-4 list-disc space-y-0.5 text-sm text-fg-2 marker:text-accent">
+              {s.bullets.map((b, bi) => (
+                <li key={bi}>{b}</li>
+              ))}
+            </ul>
+          ) : null}
+          {s.table?.headers?.length ? (
+            <StructuredTable headers={s.table.headers} rows={s.table.rows ?? []} />
+          ) : null}
+        </section>
+      ))}
+
+      {/* 주의할 점 */}
+      {data.risks?.length ? (
+        <div className="rounded-lg border border-border bg-surface-2 px-3.5 py-2.5">
+          <p className="mb-1.5 flex items-center gap-1.5 text-xs font-semibold text-fg-2">
+            <AlertTriangle className="h-3.5 w-3.5 text-amber-500" /> 주의할 점
+          </p>
+          <ul className="ml-4 list-disc space-y-0.5 text-sm text-fg-2 marker:text-amber-500">
+            {data.risks.map((r, i) => (
+              <li key={i}>{r}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {/* 다음 실행 */}
+      {data.action_items?.length ? (
+        <div className="rounded-lg border border-border bg-surface-2 px-3.5 py-2.5">
+          <p className="mb-1.5 flex items-center gap-1.5 text-xs font-semibold text-fg-2">
+            <ListChecks className="h-3.5 w-3.5 text-accent" /> 다음 실행
+          </p>
+          <ul className="space-y-1 text-sm text-fg-2">
+            {data.action_items.map((a, i) => (
+              <li key={i} className="flex items-start gap-1.5">
+                <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-accent" />
+                <span>{a}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -17,6 +17,28 @@ export interface ChatMessage extends Pick<SharedChatMessage, "role" | "content" 
   taskId?: string;
   /** 추론(thinking) 내용 — ws thinking 이벤트로 누적, 화면에 접이식 블록으로 표시 */
   reasoning?: string;
+  /** 구조화 답변 데이터 (structuredMode=true 시 REST /api/chat/structured 응답). 있으면 카드 UI 로 렌더. */
+  structured?: StructuredAnswerData;
+}
+
+/**
+ * 구조화 답변 (백엔드 schemas/structured-answer.schema.ts StructuredAnswer 대응).
+ * structuredMode 에서 POST /api/chat/structured 가 반환. content 에는 동일 내용의 markdown 도 함께 저장된다.
+ */
+export interface StructuredAnswerData {
+  intent: string;
+  title: string;
+  conclusion: string;
+  summary?: string;
+  sections: {
+    heading: string;
+    body: string;
+    bullets?: string[];
+    table?: { headers: string[]; rows: string[][] };
+  }[];
+  risks?: string[];
+  action_items?: string[];
+  confidence: "high" | "medium" | "low";
 }
 
 export type { ChatRole };
@@ -69,6 +91,8 @@ interface AppState {
   agentTaskMode: boolean;
   imageMode: boolean;
   artifactMode: boolean;
+  /** 구조화 답변 모드 — ON 시 메시지를 REST /api/chat/structured 로 보내 카드 UI 로 렌더(비스트리밍). */
+  structuredMode: boolean;
   mcpToolsEnabled: Record<string, boolean>;
 
   // 모델 / 스타일
@@ -106,7 +130,8 @@ interface AppState {
       | "webSearchEnabled"
       | "agentTaskMode"
       | "imageMode"
-      | "artifactMode",
+      | "artifactMode"
+      | "structuredMode",
   ) => void;
   setSelectedModel: (m: string) => void;
   cycleStyle: () => void;
@@ -144,6 +169,7 @@ export const useAppStore = create<AppState>()(
   agentTaskMode: false,
   imageMode: false,
   artifactMode: false,
+  structuredMode: false,
   mcpToolsEnabled: {},
 
   selectedModel: "default",

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -110,6 +110,7 @@ interface AppState {
   ) => void;
   setSelectedModel: (m: string) => void;
   cycleStyle: () => void;
+  setStyle: (m: ChatStyle) => void;
   setAuth: (auth: AppState["auth"]) => void;
 }
 
@@ -233,6 +234,7 @@ export const useAppStore = create<AppState>()(
     set((s) => ({
       style: STYLE_ORDER[(STYLE_ORDER.indexOf(s.style) + 1) % STYLE_ORDER.length],
     })),
+  setStyle: (m) => set({ style: m }),
   setAuth: (auth) => set({ auth }),
     }),
     {

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -76,6 +76,8 @@ export function useChatSocket() {
   const reconnectRef = useRef(0);
   // 에이전트 작업 taskId → 목표(goal) — agent_task_progress 렌더에 사용
   const agentGoalsRef = useRef<Map<string, string>>(new Map());
+  // 구조화 답변(REST) 진행 중 AbortController — abort() 가 취소할 수 있게 보관
+  const structuredAbortRef = useRef<AbortController | null>(null);
 
   const {
     appendMessage,
@@ -256,6 +258,8 @@ export function useChatSocket() {
 
   const abort = useCallback(() => {
     wsRef.current?.send(JSON.stringify({ type: "abort" }));
+    // 구조화 답변(REST) 진행 중이면 fetch 도 취소
+    structuredAbortRef.current?.abort();
   }, []);
 
   // 에이전트 토글 ON: 메시지를 목표(goal)로 자율 에이전트 작업을 생성·실행한다.
@@ -301,14 +305,16 @@ export function useChatSocket() {
       if (!msg || s.isGenerating) return;
       appendMessage({ role: "user", content: msg });
       setStreaming(true);
+      const controller = new AbortController();
+      structuredAbortRef.current = controller;
       try {
         const res = await ApiClient.post<{
           data: { intent: string; structured: StructuredAnswerData; markdown: string };
-        }>("/api/chat/structured", {
-          message: msg,
-          model: s.selectedModel,
-          anonSessionId: getAnonSessionId(),
-        });
+        }>(
+          "/api/chat/structured",
+          { message: msg, model: s.selectedModel, anonSessionId: getAnonSessionId() },
+          { signal: controller.signal },
+        );
         const data = res?.data;
         appendMessage({
           role: "assistant",
@@ -316,11 +322,15 @@ export function useChatSocket() {
           structured: data?.structured,
         });
       } catch (e) {
+        const aborted = e instanceof DOMException && e.name === "AbortError";
         appendMessage({
           role: "assistant",
-          content: `구조화 답변을 생성하지 못했습니다: ${e instanceof Error ? e.message : String(e)}`,
+          content: aborted
+            ? "_(구조화 답변 생성을 중단했습니다.)_"
+            : `구조화 답변을 생성하지 못했습니다: ${e instanceof Error ? e.message : String(e)}`,
         });
       } finally {
+        structuredAbortRef.current = null;
         setStreaming(false);
       }
     },

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { WsChatRequest, WsServerEvent, WsAttachedFile } from "@openmake/shared-types";
-import { useAppStore } from "./store";
+import { useAppStore, type StructuredAnswerData } from "./store";
 import { ApiClient } from "./api-client";
 import { CLIENT_TIMING } from "./config";
 
@@ -26,6 +26,25 @@ function resolveWsUrl(): string {
     return `${proto}//${location.hostname}:52416`;
   }
   return `${proto}//${location.host}`;
+}
+
+/**
+ * 게스트(비로그인) REST 호출용 anon 세션 ID. localStorage 에 영속.
+ * 백엔드 resolveUserContextFromRequest 는 req.user 없고 anonSessionId 도 없으면 401 →
+ * ApiClient 401 핸들러가 로그인 리다이렉트를 트리거하므로, 게스트도 식별자를 보내 게스트 컨텍스트를 받게 한다.
+ */
+function getAnonSessionId(): string {
+  try {
+    const KEY = "omk_anon_session";
+    let id = localStorage.getItem(KEY);
+    if (!id) {
+      id = (crypto?.randomUUID?.() ?? `anon-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+      localStorage.setItem(KEY, id);
+    }
+    return id;
+  } catch {
+    return `anon-${Date.now()}`;
+  }
 }
 
 /** 에이전트 작업 메시지 마크다운 — 상태에 따라 진행바/완료/실패를 렌더. */
@@ -272,5 +291,41 @@ export function useChatSocket() {
     [appendMessage],
   );
 
-  return { connected, sendChat, abort, startAgentTask };
+  // 구조화 답변 모드 — WebSocket 스트리밍 대신 REST /api/chat/structured 호출(비스트리밍).
+  // 백엔드가 Answer Planner → JSON Schema → Validator → formatAnswer 파이프라인으로
+  // { intent, structured, markdown } 을 반환. structured 는 카드 UI(StructuredAnswer)로 렌더.
+  const sendStructured = useCallback(
+    async (message: string) => {
+      const msg = message.trim();
+      const s = useAppStore.getState();
+      if (!msg || s.isGenerating) return;
+      appendMessage({ role: "user", content: msg });
+      setStreaming(true);
+      try {
+        const res = await ApiClient.post<{
+          data: { intent: string; structured: StructuredAnswerData; markdown: string };
+        }>("/api/chat/structured", {
+          message: msg,
+          model: s.selectedModel,
+          anonSessionId: getAnonSessionId(),
+        });
+        const data = res?.data;
+        appendMessage({
+          role: "assistant",
+          content: data?.markdown ?? "",
+          structured: data?.structured,
+        });
+      } catch (e) {
+        appendMessage({
+          role: "assistant",
+          content: `구조화 답변을 생성하지 못했습니다: ${e instanceof Error ? e.message : String(e)}`,
+        });
+      } finally {
+        setStreaming(false);
+      }
+    },
+    [appendMessage, setStreaming],
+  );
+
+  return { connected, sendChat, abort, startAgentTask, sendStructured };
 }

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -227,6 +227,7 @@ export function useChatSocket() {
         thinkingMode: s.thinkingEnabled,
         imageMode: s.imageMode,
         artifactMode: s.artifactMode,
+        style: s.style,
         enabledTools: s.mcpToolsEnabled,
       };
       wsRef.current?.send(JSON.stringify(payload));

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -73,7 +73,16 @@ async function request<T>(endpoint: string, options: RequestInit = {}, _isRetry 
   }
   const res = await fetch(endpoint, { ...options, credentials: "include", headers });
   const text = await res.text();
-  const json = text ? (JSON.parse(text) as ApiResponse<T> | T) : null;
+  // 비-JSON 본문(예: 프록시/서버 기본 "Internal Server Error" 평문)에도 깨지지 않도록 방어.
+  // 파싱 실패 시 json=null 로 두고, 아래 에러 분기에서 status 기반 메시지로 폴백한다.
+  let json: ApiResponse<T> | T | null = null;
+  if (text) {
+    try {
+      json = JSON.parse(text) as ApiResponse<T> | T;
+    } catch {
+      json = null;
+    }
+  }
   if (!res.ok) {
     // 401 자동 refresh: 재시도 아니고, 건너뛸 endpoint 가 아닌 경우에만 1회 시도.
     if (

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -102,6 +102,8 @@ export interface WsChatRequest {
   imageMode?: boolean;
   /** 아티팩트 모드 — ON 이면 모델이 <artifact> 산출물을 생성하도록 유도 */
   artifactMode?: boolean;
+  /** 응답 스타일 — 백엔드 chat/style.ts 가 system prompt 앞에 style guard 를 prepend (concise=간결, verbose=상세) */
+  style?: "concise" | "default" | "verbose";
   enabledTools?: Record<string, boolean>;
 }
 


### PR DESCRIPTION
## 배경

설정 > 모델&응답 > **응답 스타일**(또는 composer 사이클 버튼)을 바꿔도 응답이 항상 default였습니다. 워크플로우를 단계별로 추적해 **2중 단절**을 확인하고 수정합니다.

> base 를 PR #208 브랜치로 둔 stacked PR.

## 진단 (단계별 + WS 프레임/로그)

| 단계 | 상태(before) |
|---|---|
| 설정 응답 스타일 Segment | ❌ 죽은 로컬 `useState` (store·백엔드 미연결, 영속화 TODO) |
| composer 스타일 버튼 | ⚠️ `store.style` 갱신·persist 되나 **WS payload 에 style 미포함** |
| WS 전송 | ❌ `WsChatRequest` 타입에 style 필드 부재 → 프레임에 style 키 없음 |
| 백엔드 수신/적용 | ⚠️ WSMessage.style 은 있으나 항상 undefined. **외부 provider 경로(openrouter)는 `applyStyle` 전에 early return** → style 영영 미적용 |
| 백엔드 style 로직 | ✅ `chat/style.ts` 정상 (테스트 12/12) — 단지 호출 안 됨 |

## 수정
- **shared-types** `WsChatRequest` 에 `style` 필드 추가, **use-chat-socket** payload 에 `style: s.style` 전송.
- **store** `setStyle` 액션 추가 + **설정 Segment** 를 `store.style` 단일 소스로 연결(죽은 로컬 state 제거 → composer 버튼과 정합).
- **external-provider** 가 `ctx.style` 로 `getStyleGuard` 를 정적 prefix 맨 앞에 prepend(default 면 overhead 0). **message-pipeline** 외부 분기가 `req.style` 전달.

## 검증 (실측 + 로그, 로컬 qwen, 동일 질문 "양자컴퓨터가 뭐야?")

| | concise | verbose |
|---|---|---|
| WS payload `style` | `concise` ✅ | `verbose` ✅ |
| 백엔드 출력 토큰 | `out=169` | `out=960` |
| 렌더 길이 | 191자 (3문장) | 1213자 (예시·맥락·요약) |

→ 약 **5.7배** 길이 차이. 응답 스타일이 프론트 선택 → WS 전송 → 백엔드 style guard 적용까지 end-to-end 동작 확인.

검증: `tsc --noEmit`(web/api) 통과, `style.test.ts` 12/12, 변경 파일 eslint 에러 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)