### PR TITLE
fix(chat): 구조화 답변 현재 날짜 주입 + 웹검색 수행 (2024 오인식 해결)

### DIFF
--- a/apps/api/src/mcp/web-search/build-search-context.ts
+++ b/apps/api/src/mcp/web-search/build-search-context.ts
@@ -1,0 +1,95 @@
+/**
+ * ============================================================
+ * Web Search Context Builder — 웹검색 → system 주입용 컨텍스트 문자열
+ * ============================================================
+ *
+ * ws-chat-handler 의 pre-chat 웹검색 블록을 공유 헬퍼로 추출. 동일 로직을 여러
+ * 경로(WS 채팅, REST /api/chat/structured)가 재사용해 "한 경로만 웹검색이 되고
+ * 다른 경로는 안 되는" 분기 누락 버그를 방지한다.
+ *
+ * 동작(원본과 동일):
+ *  1. 시사(current-events) 질의 감지 — 언어별 + 영어 키워드.
+ *  2. 사용자가 명시적으로 끄지 않았고 (webSearchEnabled || 시사질의) 이면 검색 수행.
+ *  3. 결과를 WEB_SEARCH_INJECTION 캡으로 포맷해 컨텍스트 문자열 생성.
+ *  4. 시사질의인데 외부 데이터 0건이면 환각 방지 안전망 문구 주입.
+ *
+ * @module mcp/web-search/build-search-context
+ */
+import { performWebSearch } from './search-orchestrator';
+import { cleanSearchQuery } from './query-cleaner';
+import { formatSearchSources } from './format-sources';
+import { WEB_SEARCH_INJECTION } from '../../config/runtime-limits';
+import { getStaleDataWarning } from '../../config/stale-data-warning';
+import {
+    CURRENT_EVENTS_KEYWORDS,
+    WEB_SEARCH_TEMPLATES,
+    getLocalizedTemplate,
+} from '../../sockets/ws-chat-locales';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('WebSearchContext');
+
+export interface BuildWebSearchContextResult {
+    /** system 채널에 주입할 웹검색 컨텍스트 문자열 (없으면 ''). */
+    webSearchContext: string;
+    /** 시사 질의로 감지되었는지 여부. */
+    isCurrentEventsQuery: boolean;
+}
+
+/**
+ * 웹검색을 수행하고 LLM 주입용 컨텍스트 문자열을 만든다.
+ */
+export async function buildWebSearchContext(opts: {
+    message: string;
+    userLang: string;
+    /** 사용자 웹검색 토글 (UI webSearch=true). */
+    webSearchEnabled: boolean;
+    /** enabledTools.web_search === false 처럼 명시적으로 끈 경우. */
+    explicitlyDisabled?: boolean;
+    signal?: AbortSignal;
+}): Promise<BuildWebSearchContextResult> {
+    const { message, userLang, webSearchEnabled, explicitlyDisabled = false, signal } = opts;
+
+    const langKeywords = getLocalizedTemplate(CURRENT_EVENTS_KEYWORDS, userLang);
+    const allKeywords = [...langKeywords, ...(CURRENT_EVENTS_KEYWORDS['en'] || [])];
+    const isCurrentEventsQuery = allKeywords.some(
+        (keyword) => message?.toLowerCase().includes(keyword.toLowerCase()),
+    );
+
+    let webSearchContext = '';
+
+    if (!explicitlyDisabled && (webSearchEnabled || isCurrentEventsQuery)) {
+        try {
+            const searchQuery = cleanSearchQuery(message);
+            const searchResults = await performWebSearch(searchQuery, {
+                maxResults: 12,
+                language: userLang,
+                preferRecent: isCurrentEventsQuery,
+                signal,
+            });
+            if (searchResults.length > 0) {
+                const tpl = getLocalizedTemplate(WEB_SEARCH_TEMPLATES, userLang);
+                const body = formatSearchSources(searchResults, {
+                    maxResults: WEB_SEARCH_INJECTION.MAX_RESULTS,
+                    maxSnippetChars: WEB_SEARCH_INJECTION.MAX_SNIPPET_CHARS,
+                    labeled: true,
+                    sourceWord: tpl.sourceLabel,
+                    contentWord: tpl.contentLabel,
+                    separator: '\n',
+                });
+                webSearchContext = `\n\n## 🔍 ${tpl.header} (${new Date().toLocaleDateString(tpl.locale)} )\n` +
+                    `${tpl.instruction}\n\n${body}\n`;
+            }
+        } catch (e) {
+            logger.error('웹 검색 실패:', e);
+        }
+    }
+
+    // 시사 질의인데 외부 데이터를 얻지 못한 경우 환각 방지 안전망 주입.
+    if (isCurrentEventsQuery && !webSearchContext) {
+        const warning = getStaleDataWarning(userLang);
+        webSearchContext = `\n\n## ⚠️ ${warning.header}\n${warning.instruction}\n`;
+    }
+
+    return { webSearchContext, isCurrentEventsQuery };
+}

--- a/apps/api/src/prompts/answer-composer-system.ts
+++ b/apps/api/src/prompts/answer-composer-system.ts
@@ -42,11 +42,24 @@ const INTENT_HINT: Record<'ko' | 'en', string> = {
 };
 
 /**
- * Answer Composer system prompt 빌드. 분류된 intent 를 모델에 힌트로 전달.
+ * 시간 컨텍스트 — 모델이 지식 컷오프(2024-12)를 "현재"로 착각하지 않도록 현재 날짜를 명시.
+ * (일반 파이프라인의 createDynamicMetadata + 지식 기준일 가드 동등. 구조화 경로는 base prompt 를
+ *  거치지 않아 이 가드가 누락되어 "현재가 2024년" 오인식이 발생했음.)
  */
-export function buildAnswerComposerSystemPrompt(intent: AnswerIntent, userLanguage: string): string {
+function temporalContext(lang: 'ko' | 'en', currentDate: string): string {
+    return lang === 'ko'
+        ? `\n\n## ⏱️ 시간 컨텍스트\n- 오늘 날짜는 ${currentDate} 입니다. "현재/올해/최근" 은 이 날짜를 기준으로 판단하세요.\n- 당신의 학습 지식 기준일은 2024년 12월입니다. 그 이후의 사건·인물·통계는 아래 제공된 검색 결과에 근거하고, 검색 결과가 없으면 추측하지 말고 confidence 를 낮추세요.\n- 검색 결과(웹 컨텍스트)가 제공되면 그것을 최신 사실의 근거로 우선하세요.`
+        : `\n\n## ⏱️ Temporal context\n- Today's date is ${currentDate}. Interpret "current/this year/recent" relative to this date.\n- Your training knowledge cutoff is December 2024. For events/people/statistics after that, rely on the search results provided below; if none are provided, do not guess — lower confidence instead.\n- When web context (search results) is provided, prefer it as the source of up-to-date facts.`;
+}
+
+/**
+ * Answer Composer system prompt 빌드. 분류된 intent + 현재 날짜를 모델에 전달.
+ * @param currentDate ISO date (YYYY-MM-DD). 미지정 시 호출 시점 날짜.
+ */
+export function buildAnswerComposerSystemPrompt(intent: AnswerIntent, userLanguage: string, currentDate?: string): string {
     const lang = userLanguage.toLowerCase().startsWith('ko') ? 'ko' : 'en';
-    return `${BODY[lang]}${INTENT_HINT[lang]}${intent}`;
+    const date = currentDate || new Date().toISOString().split('T')[0];
+    return `${BODY[lang]}${temporalContext(lang, date)}${INTENT_HINT[lang]}${intent}`;
 }
 
 /** Validator 실패 시 1회 재시도에 덧붙이는 교정 지시. */

--- a/apps/api/src/routes/chat.routes.ts
+++ b/apps/api/src/routes/chat.routes.ts
@@ -35,6 +35,7 @@ import { LocalLLMProvider } from '../providers/local-llm-provider';
 import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
 import { getPool } from '../data/models/unified-database';
 import { composeStructuredAnswer, type StructuredChatFn } from '../services/answer-composer';
+import { buildWebSearchContext } from '../mcp/web-search/build-search-context';
 import { getConversationDB } from '../data/conversation-db';
 import { createLogger } from '../utils/logger';
 
@@ -301,7 +302,23 @@ router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncH
         };
     }
 
-        const composed = await composeStructuredAnswer({ message, userLanguage, chat });
+        // 웹검색 — 일반 채팅(ws-handler)과 동일 정책. 사용자 토글(webSearch) 또는 시사 질의 자동 감지.
+        // (구조화 모드가 웹검색을 건너뛰어 2024 학습지식으로만 답하던 결함 수정.)
+        const { webSearchContext } = await buildWebSearchContext({
+            message,
+            userLang: userLanguage,
+            webSearchEnabled: req.body.webSearch === true,
+            explicitlyDisabled: req.body.enabledTools?.web_search === false,
+            signal: abortController.signal,
+        });
+
+        const composed = await composeStructuredAnswer({
+            message,
+            userLanguage,
+            chat,
+            webContext: webSearchContext || undefined,
+            currentDate: new Date().toISOString().split('T')[0],
+        });
         settled = true;
         res.json(success({
             intent: composed.intent,

--- a/apps/api/src/services/answer-composer.ts
+++ b/apps/api/src/services/answer-composer.ts
@@ -108,14 +108,23 @@ export async function composeStructuredAnswer(opts: {
     message: string;
     userLanguage?: string;
     chat: StructuredChatFn;
+    /** 웹검색 결과 컨텍스트 (있으면 user 메시지에 합류 — 최신 사실 근거). */
+    webContext?: string;
+    /** 현재 날짜(YYYY-MM-DD). 미지정 시 호출 시점. 모델의 2024 컷오프 오인식 방지. */
+    currentDate?: string;
 }): Promise<ComposeResult> {
     const lang = (opts.userLanguage || 'ko').toLowerCase().startsWith('ko') ? 'ko' : 'en';
     const intent = classifyAnswerIntent(opts.message);
-    const system = buildAnswerComposerSystemPrompt(intent, lang);
+    const system = buildAnswerComposerSystemPrompt(intent, lang, opts.currentDate);
+
+    // 웹검색 컨텍스트가 있으면 user 메시지에 합류 (buildContextForLLM 과 동일 정책).
+    const userContent = opts.webContext
+        ? `${opts.message}${opts.webContext}`
+        : opts.message;
 
     const messages: ChatMessage[] = [
         { role: 'system', content: system },
-        { role: 'user', content: opts.message },
+        { role: 'user', content: userContent },
     ];
 
     const attempt = async (msgs: ChatMessage[]): Promise<StructuredAnswer | null> => {

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -312,7 +312,15 @@ export function useChatSocket() {
           data: { intent: string; structured: StructuredAnswerData; markdown: string };
         }>(
           "/api/chat/structured",
-          { message: msg, model: s.selectedModel, anonSessionId: getAnonSessionId() },
+          {
+            message: msg,
+            model: s.selectedModel,
+            anonSessionId: getAnonSessionId(),
+            // 웹 기능 토글을 구조화 모드에도 전달 — 백엔드가 시사 질의 시 웹검색 수행.
+            webSearch: s.webSearchEnabled,
+            enabledTools: s.mcpToolsEnabled,
+            userLanguage: navigator?.language?.startsWith("ko") ? "ko" : "en",
+          },
           { signal: controller.signal },
         );
         const data = res?.data;


### PR DESCRIPTION
## 증상
구조화 답변(`/api/chat/structured`)과 웹 기능을 함께 사용해도 모델이 **"현재가 2024년"** 이라고 답함.

## 근본 원인 (2가지)
구조화 경로가 일반 채팅 파이프라인(message-pipeline)을 거치지 않아 누락된 것:
1. **현재 날짜 미주입** — 모델이 지식 컷오프(2024-12)를 "현재"로 착각.
2. **웹검색 미수행** — `/structured` 라우트에 웹검색 로직 자체가 없고, 프론트도 `webSearch` 플래그를 보내지 않아 시사 데이터가 전혀 주입되지 않음.

## 수정
| 파일 | 내용 |
|---|---|
| `prompts/answer-composer-system.ts` | `temporalContext` — 현재 날짜 + 지식 컷오프 + "검색 결과 우선" 가드 주입 |
| `mcp/web-search/build-search-context.ts` (신규) | ws-handler 웹검색 로직을 공유 헬퍼로 추출(시사 자동감지·비활성 게이트·환각 안전망) |
| `routes/chat.routes.ts` | `/structured` 가 웹검색 수행 후 composer 에 `webContext`+`currentDate` 전달 |
| `services/answer-composer.ts` | webContext→user 메시지 합류, currentDate→system prompt |
| `web/lib/use-chat-socket.ts` | `sendStructured` 가 webSearch/enabledTools/userLanguage 전송 |

## 검증
- 유닛 28/28, tsc 0 (backend·frontend)
- 실모델 격리 검증: HTTP 200 — **"올해는 2026년, 오늘 2026-06-26"** + 웹 그라운딩(서울 월세·암호화폐 동향 등)
- Caddy 무관 확인: 30초 끊김은 Next dev rewrites 프록시 타임아웃이며 운영(Caddy)은 `/api` 가 Next 미경유라 영향 없음

## 알려진 한계 (dev 한정)
- dev(localhost:3000)에서 웹+구조화가 **>30초** 생성 시 Next dev 프록시 30초 타임아웃으로 500(크래시 아님, graceful 에러). 일반 질의(3~13초)는 정상. 운영(Caddy)은 무관.
- 프록시 우회(백엔드 직접 호출)는 cross-origin 에서 HttpOnly 인증 쿠키 미전송 → 로그인 사용자 게스트 강등 회귀라 **미채택**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)