### PR TITLE
fix(chat): 구조화 답변 KST 날짜 + 언어 메시지 감지 (코드리뷰 회귀 수정)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,13 @@ LLM_BASE_URL=http://localhost:4000              # 서버 PC 의 vLLM/LiteLLM pro
 LLM_API_KEY=sk-litellm-master-key               # LiteLLM master key (또는 vLLM --api-key)
 LLM_DEFAULT_MODEL=qwen3.6-35b-a3b               # proxy 가 라우팅하는 model 명 (chat 기본)
 LLM_TIMEOUT=120000                              # HTTP 요청 타임아웃 (ms)
+# 모델 학습 지식 컷오프 라벨 — 프롬프트 "학습 기준일" 명시용. 기본 모델/외부 provider 교체 시 조정.
+# LLM_KNOWLEDGE_CUTOFF_KO=2024년 12월
+# LLM_KNOWLEDGE_CUTOFF_EN=December 2024
+
+# 앱 기준 타임존 (IANA) — 프롬프트에 주입하는 "오늘 날짜" 계산 기준. 기본 Asia/Seoul.
+# UTC 로 계산하면 KST 사용자가 자정~오전 9시 사이 전날 날짜를 받는 버그가 생긴다.
+# APP_TIMEZONE=Asia/Seoul
 
 # ────────────────────────────────────────────────────────────
 # 로컬 모델 카탈로그 (서버 PC 의 vLLM proxy 가 노출하는 모델 목록)
@@ -513,7 +520,9 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # WEB_SEARCH_FETCH_TIMEOUT_MS=12000
 # 웹검색 도메인당 최대 결과 수 (소스 다양성 보호, 0=무제한, 기본 5)
 # SEARCH_MAX_PER_DOMAIN=5
-# 검색 결과 LLM 주입 캡 — 수집은 넉넉히(maxResults 12)하되 LLM 컨텍스트엔 상위 N개만 주입해
+# 웹검색 수집(랭킹 풀) 결과 수 — SearXNG·위키 디랭크 포함 넉넉히 수집한 뒤 INJECT 캡으로 주입 제한. 기본 12.
+# WEB_SEARCH_COLLECT_MAX_RESULTS=12
+# 검색 결과 LLM 주입 캡 — 수집은 넉넉히(COLLECT_MAX_RESULTS)하되 LLM 컨텍스트엔 상위 N개만 주입해
 # TTFT(첫 토큰 지연)와 grounding 균형 조정. 0/비정수 = 무제한(가드 적용, 빈 슬라이스 방지).
 # 6→10: 시사 쿼리에서 정답 포함 결과가 하위로 밀려 top-6 컷오프에 잘리던 누락 방지.
 # WEB_SEARCH_INJECT_MAX_RESULTS=10

--- a/apps/api/src/config/knowledge-cutoff.ts
+++ b/apps/api/src/config/knowledge-cutoff.ts
@@ -1,0 +1,15 @@
+/**
+ * 모델 학습 지식 컷오프 — 프롬프트에 명시할 "학습 기준일" 라벨.
+ *
+ * 컷오프는 LLM_DEFAULT_MODEL(qwen3.6 등)·외부 provider 에 종속된 모델별 사실이므로,
+ * 프롬프트 문자열에 인라인 하드코딩하지 않고 여기서 단일 소스로 관리한다(No-Hardcoding L2).
+ * 기본 모델/외부 provider 교체 시 LLM_KNOWLEDGE_CUTOFF_* env 로 배포 없이 조정.
+ *
+ * @module config/knowledge-cutoff
+ */
+
+/** 언어별 학습 컷오프 표기 (프롬프트 본문 삽입용 자연어 라벨). */
+export const KNOWLEDGE_CUTOFF: Record<'ko' | 'en', string> = {
+    ko: process.env.LLM_KNOWLEDGE_CUTOFF_KO || '2024년 12월',
+    en: process.env.LLM_KNOWLEDGE_CUTOFF_EN || 'December 2024',
+};

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -426,6 +426,11 @@ function parseInjectLimit(raw: string | undefined, def: number): number {
 
 export const WEB_SEARCH_INJECTION = {
     /**
+     * 검색 수집(랭킹 풀) 결과 수 — SearXNG·위키 디랭크 포함 넉넉히 수집한 뒤 MAX_RESULTS 로 주입 캡.
+     * WS 채팅·구조화(/structured) 경로가 공유한다.
+     */
+    COLLECT_MAX_RESULTS: parseInjectLimit(process.env.WEB_SEARCH_COLLECT_MAX_RESULTS, 12),
+    /**
      * LLM 컨텍스트에 주입할 상위 결과 수 (수집은 더 많이 하되 주입은 캡). 0 = 무제한.
      * 6 → 10: 시사 쿼리에서 정답 포함 결과가 랭킹 하위(예: namu.wiki 현직 인물)로 밀려
      * top-6 컷오프에 잘리던 그라운딩 누락을 줄인다(수집 풀 12 의 대부분 주입).

--- a/apps/api/src/mcp/web-search/build-search-context.ts
+++ b/apps/api/src/mcp/web-search/build-search-context.ts
@@ -52,8 +52,9 @@ export async function buildWebSearchContext(opts: {
 
     const langKeywords = getLocalizedTemplate(CURRENT_EVENTS_KEYWORDS, userLang);
     const allKeywords = [...langKeywords, ...(CURRENT_EVENTS_KEYWORDS['en'] || [])];
+    const lowerMessage = message?.toLowerCase() ?? '';
     const isCurrentEventsQuery = allKeywords.some(
-        (keyword) => message?.toLowerCase().includes(keyword.toLowerCase()),
+        (keyword) => lowerMessage.includes(keyword.toLowerCase()),
     );
 
     let webSearchContext = '';
@@ -62,7 +63,7 @@ export async function buildWebSearchContext(opts: {
         try {
             const searchQuery = cleanSearchQuery(message);
             const searchResults = await performWebSearch(searchQuery, {
-                maxResults: 12,
+                maxResults: WEB_SEARCH_INJECTION.COLLECT_MAX_RESULTS,
                 language: userLang,
                 preferRecent: isCurrentEventsQuery,
                 signal,
@@ -81,6 +82,9 @@ export async function buildWebSearchContext(opts: {
                     `${tpl.instruction}\n\n${body}\n`;
             }
         } catch (e) {
+            // 클라이언트 중단(abort)은 삼키지 않고 전파 — 이미 끊긴 signal 로 LLM 을 호출해
+            // 헛된 upstream 요청·spurious 500 을 내는 것을 막는다. (호출부가 깔끔히 취소 처리)
+            if (signal?.aborted || (e instanceof Error && e.name === 'AbortError')) throw e;
             logger.error('웹 검색 실패:', e);
         }
     }

--- a/apps/api/src/prompts/answer-composer-system.ts
+++ b/apps/api/src/prompts/answer-composer-system.ts
@@ -12,6 +12,8 @@
  * @module prompts/answer-composer-system
  */
 import type { AnswerIntent } from '../schemas/structured-answer.schema';
+import { getCurrentDate } from '../utils/datetime';
+import { KNOWLEDGE_CUTOFF } from '../config/knowledge-cutoff';
 
 const BODY: Record<'ko' | 'en', string> = {
     ko: `당신은 답변을 JSON 구조로 작성하는 어시스턴트입니다. 반드시 주어진 JSON 스키마에 맞는 객체 하나만 출력하고, 그 외 텍스트(설명·마크다운 펜스)는 출력하지 않습니다.
@@ -48,8 +50,8 @@ const INTENT_HINT: Record<'ko' | 'en', string> = {
  */
 function temporalContext(lang: 'ko' | 'en', currentDate: string): string {
     return lang === 'ko'
-        ? `\n\n## ⏱️ 시간 컨텍스트\n- 오늘 날짜는 ${currentDate} 입니다. "현재/올해/최근" 은 이 날짜를 기준으로 판단하세요.\n- 당신의 학습 지식 기준일은 2024년 12월입니다. 그 이후의 사건·인물·통계는 아래 제공된 검색 결과에 근거하고, 검색 결과가 없으면 추측하지 말고 confidence 를 낮추세요.\n- 검색 결과(웹 컨텍스트)가 제공되면 그것을 최신 사실의 근거로 우선하세요.`
-        : `\n\n## ⏱️ Temporal context\n- Today's date is ${currentDate}. Interpret "current/this year/recent" relative to this date.\n- Your training knowledge cutoff is December 2024. For events/people/statistics after that, rely on the search results provided below; if none are provided, do not guess — lower confidence instead.\n- When web context (search results) is provided, prefer it as the source of up-to-date facts.`;
+        ? `\n\n## ⏱️ 시간 컨텍스트\n- 오늘 날짜는 ${currentDate} 입니다. "현재/올해/최근" 은 이 날짜를 기준으로 판단하세요.\n- 당신의 학습 지식 기준일은 ${KNOWLEDGE_CUTOFF.ko}입니다. 그 이후의 사건·인물·통계는 아래 제공된 검색 결과에 근거하고, 검색 결과가 없으면 추측하지 말고 confidence 를 낮추세요.\n- 검색 결과(웹 컨텍스트)가 제공되면 그것을 최신 사실의 근거로 우선하세요.`
+        : `\n\n## ⏱️ Temporal context\n- Today's date is ${currentDate}. Interpret "current/this year/recent" relative to this date.\n- Your training knowledge cutoff is ${KNOWLEDGE_CUTOFF.en}. For events/people/statistics after that, rely on the search results provided below; if none are provided, do not guess — lower confidence instead.\n- When web context (search results) is provided, prefer it as the source of up-to-date facts.`;
 }
 
 /**
@@ -58,7 +60,7 @@ function temporalContext(lang: 'ko' | 'en', currentDate: string): string {
  */
 export function buildAnswerComposerSystemPrompt(intent: AnswerIntent, userLanguage: string, currentDate?: string): string {
     const lang = userLanguage.toLowerCase().startsWith('ko') ? 'ko' : 'en';
-    const date = currentDate || new Date().toISOString().split('T')[0];
+    const date = currentDate || getCurrentDate();
     return `${BODY[lang]}${temporalContext(lang, date)}${INTENT_HINT[lang]}${intent}`;
 }
 

--- a/apps/api/src/routes/chat.routes.ts
+++ b/apps/api/src/routes/chat.routes.ts
@@ -36,6 +36,8 @@ import { ExternalKeysRepository } from '../data/repositories/external-keys-repo'
 import { getPool } from '../data/models/unified-database';
 import { composeStructuredAnswer, type StructuredChatFn } from '../services/answer-composer';
 import { buildWebSearchContext } from '../mcp/web-search/build-search-context';
+import { detectLanguage } from '../chat/language-policy';
+import { getCurrentDate } from '../utils/datetime';
 import { getConversationDB } from '../data/conversation-db';
 import { createLogger } from '../utils/logger';
 
@@ -247,7 +249,10 @@ router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncH
         return;
     }
 
-    const userLanguage: string = req.body.userLanguage || 'ko';
+    // 출력 언어: 명시적 선호(userLanguage) 우선, 없으면 메시지 내용으로 감지.
+    // (WS 채팅 경로와 동일 정책 — 브라우저 로케일에 의존하지 않아 en-* 브라우저의
+    //  한국어 사용자가 영어 답변을 받던 비대칭을 제거.)
+    const userLanguage: string = req.body.userLanguage || detectLanguage(message).language;
 
     // 사용자 중단(abort) — 클라이언트가 fetch 를 취소하면 req 가 close 되어 upstream LLM 호출도 끊는다.
     const abortController = new AbortController();
@@ -317,7 +322,7 @@ router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncH
             userLanguage,
             chat,
             webContext: webSearchContext || undefined,
-            currentDate: new Date().toISOString().split('T')[0],
+            currentDate: getCurrentDate(),
         });
         settled = true;
         res.json(success({
@@ -331,6 +336,7 @@ router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncH
         // 이 엔드포인트는 항상 JSON 으로 응답한다 — 글로벌 핸들러/Express 기본(비-JSON "Internal Server Error")
         // 으로 위임하지 않아, 프론트(ApiClient.JSON.parse)가 어떤 실패에도 파싱 가능한 본문을 받게 한다.
         if (res.headersSent) return; // abort 등으로 이미 응답 시작 — 중복 전송 방지
+        if (abortController.signal.aborted) return; // 클라이언트 중단 — 끊긴 연결에 에러 응답 불필요(spurious 500 방지)
         if (err instanceof ProviderError) {
             const statusByCode: Record<string, number> = {
                 GUEST_NOT_ALLOWED: 403,

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -15,16 +15,13 @@ import { ProviderError } from '../providers/provider-errors';
 import { checkChatRateLimit } from '../middlewares/chat-rate-limiter';
 import { createLogger } from '../utils/logger';
 import { WSMessage, ExtendedWebSocket } from './ws-types';
-import { CURRENT_EVENTS_KEYWORDS, WEB_SEARCH_TEMPLATES, WS_ERROR_MESSAGES, WS_PROVIDER_ERROR_MESSAGES, getLocalizedTemplate } from './ws-chat-locales';
+import { WS_ERROR_MESSAGES, WS_PROVIDER_ERROR_MESSAGES, getLocalizedTemplate } from './ws-chat-locales';
 import { detectLanguage, type SupportedLanguageCode } from '../chat/language-policy';
 import { applySlashCommand } from '../chat/slash-command';
-import { getStaleDataWarning } from '../config/stale-data-warning';
 import { WS_LIMITS } from '../config/timeouts';
 import { ArtifactStreamParser, type ArtifactInfo } from '../llm/artifact-parser';
 import { buildFileContext, buildUrlContext, getCachedAttachContext, appendCachedAttachContext } from '../services/chat-service/attach-context';
-import { WEB_SEARCH_INJECTION } from '../config/runtime-limits';
-import { formatSearchSources } from '../mcp/web-search/format-sources';
-import { cleanSearchQuery } from '../mcp/web-search/query-cleaner';
+import { buildWebSearchContext } from '../mcp/web-search/build-search-context';
 
 /**
  * AI 채팅 메시지를 처리합니다.
@@ -135,50 +132,15 @@ export async function handleChatMessage(
             ? Promise.resolve('')
             : buildUrlContext(message);
 
-        // 웹 검색: 사용자가 명시적으로 활성화했거나, 시사 관련 질문이 감지된 경우 수행
-        const langKeywords = getLocalizedTemplate(CURRENT_EVENTS_KEYWORDS, userLang);
-        const allKeywords = [...langKeywords, ...(CURRENT_EVENTS_KEYWORDS['en'] || [])];
-        const isCurrentEventsQuery = allKeywords.some(keyword => message?.toLowerCase().includes(keyword.toLowerCase()));
-        const userWebSearchEnabled = msg.webSearch === true;
-        let webSearchContext = '';
-
-        // pre-chat 웹 검색 게이트: 사용자가 명시적으로 web_search=false를 송신한 경우만 차단.
-        // 빈 객체 {} 또는 미지정(undefined)은 허용 — 시사 키워드 자동 검색이 기본 동작이어야 함.
-        const userExplicitlyDisabledSearch = msg.enabledTools?.web_search === false;
-        if (!userExplicitlyDisabledSearch && (userWebSearchEnabled || isCurrentEventsQuery)) {
-            try {
-                const { performWebSearch } = await import('../mcp');
-                // 대화체 메시지를 검색 키워드로 정제 — 장황한 지시문("…웹 검색 결과를 바탕으로 한 문장으로
-                // 알려줘")이 쿼리에 섞이면 뉴스 API 가 0건을 반환해 시의성 사실(현직 인물 등)을 놓친다.
-                const searchQuery = cleanSearchQuery(message);
-                // 수집은 넉넉히(maxResults 12 — 랭킹 풀: SearXNG·위키 디랭크 포함)하되, LLM 주입은
-                // WEB_SEARCH_INJECTION 캡(상위 MAX_RESULTS + snippet MAX_SNIPPET_CHARS, 각 0=무제한)으로 제어한다.
-                const searchResults = await performWebSearch(searchQuery, { maxResults: 12, language: userLang, preferRecent: isCurrentEventsQuery });
-                if (searchResults.length > 0) {
-                    const tpl = getLocalizedTemplate(WEB_SEARCH_TEMPLATES, userLang);
-                    const body = formatSearchSources(searchResults, {
-                        maxResults: WEB_SEARCH_INJECTION.MAX_RESULTS,
-                        maxSnippetChars: WEB_SEARCH_INJECTION.MAX_SNIPPET_CHARS,
-                        labeled: true,
-                        sourceWord: tpl.sourceLabel,
-                        contentWord: tpl.contentLabel,
-                        separator: '\n',
-                    });
-                    webSearchContext = `\n\n## \uD83D\uDD0D ${tpl.header} (${new Date().toLocaleDateString(tpl.locale)} )\n` +
-                        `${tpl.instruction}\n\n${body}\n`;
-                }
-            } catch (e) {
-                log.error('[Chat] 웹 검색 실패:', e);
-            }
-        }
-
-        // 시사 질의인데 외부 데이터를 얻지 못한 경우(검색 차단·결과 0건·검색 실패 모두 포함)
-        // 환각 방지 안전망 메시지를 system prompt 채널(webSearchContext)로 주입.
-        if (isCurrentEventsQuery && !webSearchContext) {
-            const warning = getStaleDataWarning(userLang);
-            webSearchContext = `\n\n## ⚠️ ${warning.header}\n${warning.instruction}\n`;
-            log.info(`[Chat] 시사 질의 + 외부 데이터 부재 → 환각 방지 안전망 주입 (lang=${userLang}, explicitlyDisabled=${userExplicitlyDisabledSearch})`);
-        }
+        // 웹 검색: 사용자가 명시적으로 활성화했거나, 시사 관련 질문이 감지된 경우 수행.
+        // 구조화(/structured) 경로와 동일 헬퍼를 공유해 "한 경로만 검색되는" 분기 누락·로직 드리프트를 방지한다.
+        // (WS 는 기존 동작 보존을 위해 signal 미전달 — 중단 시 진행 중 검색은 메인 LLM 루프에서 정리.)
+        const { webSearchContext } = await buildWebSearchContext({
+            message,
+            userLang,
+            webSearchEnabled: msg.webSearch === true,
+            explicitlyDisabled: msg.enabledTools?.web_search === false,
+        });
 
         // URL 사전 분석 결과 합류 (위에서 웹검색과 병렬 시작) — 본문을 fileContext 채널에 합류.
         const urlContext = await urlContextPromise;

--- a/apps/api/src/utils/datetime.ts
+++ b/apps/api/src/utils/datetime.ts
@@ -1,0 +1,20 @@
+/**
+ * 날짜/시간 유틸 — 앱 타임존 기준 현재 날짜.
+ *
+ * `new Date().toISOString()` 은 UTC 라, KST(UTC+9) 사용자에게 자정~오전 9시 사이에는
+ * 전날(연초엔 전년) 날짜를 주입해 "현재가 2024년" 류의 stale-year 오인식을 유발한다.
+ * 앱 타임존(APP_TIMEZONE, 기본 Asia/Seoul) 기준으로 YYYY-MM-DD 를 산출해 이를 방지한다.
+ *
+ * @module utils/datetime
+ */
+
+/** 앱 기준 타임존 (IANA). 배포 지역에 맞춰 APP_TIMEZONE 으로 오버라이드. */
+export const APP_TIMEZONE = process.env.APP_TIMEZONE || 'Asia/Seoul';
+
+/**
+ * 지정 타임존(기본 APP_TIMEZONE) 기준 현재 날짜를 YYYY-MM-DD 로 반환.
+ * en-CA 로케일은 ISO 8601 형식(YYYY-MM-DD)을 보장한다.
+ */
+export function getCurrentDate(timeZone: string = APP_TIMEZONE): string {
+    return new Date().toLocaleDateString('en-CA', { timeZone });
+}

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -319,7 +319,9 @@ export function useChatSocket() {
             // 웹 기능 토글을 구조화 모드에도 전달 — 백엔드가 시사 질의 시 웹검색 수행.
             webSearch: s.webSearchEnabled,
             enabledTools: s.mcpToolsEnabled,
-            userLanguage: navigator?.language?.startsWith("ko") ? "ko" : "en",
+            // userLanguage 는 보내지 않는다 — 백엔드가 메시지 내용으로 언어를 감지(WS 채팅과 동일).
+            // navigator.language(브라우저 로케일)에 의존하면 en-* 브라우저의 한국어 사용자가
+            // 한국어 질문에도 영어 답변을 받는 회귀가 발생했다.
           },
           { signal: controller.signal },
         );


### PR DESCRIPTION
## 배경

직전 머지(#211, 구조화 답변에 현재 날짜 주입 + 웹검색)에 대한 멀티에이전트 코드리뷰(high)에서 확정된 **사용자 영향 회귀 2건 + 유지보수 결함 5건**을 수정합니다.

## 🔴 사용자 영향 회귀 수정

1. **날짜 UTC → 앱 타임존(Asia/Seoul)** — `new Date().toISOString()` 이 KST 사용자에게 자정~오전 9시 사이 **전날**(연초엔 **전년**) 날짜를 주입해, 이 PR이 고치려던 stale-year("현재가 2024년") 오인식을 재현하던 회귀.
   - `utils/datetime.ts` 신규 (`getCurrentDate`, `APP_TIMEZONE`). 경계 케이스 실증: `2025-12-31T23:30Z` → UTC `2025-12-31`(구버그) vs KST `2026-01-01`(수정).
2. **출력 언어 회귀** — 프론트가 `navigator.language` 로 `userLanguage` 를 도출해, **en-\* 브라우저의 한국어 사용자가 한국어 질문에도 영어 답변**을 받던 회귀 + WS 채팅 경로와의 비대칭.
   - 프론트 `navigator.language` 라인 제거 + 백엔드 `userLanguage || detectLanguage(message).language` 폴백 (WS 경로와 대칭).

## 🟡 유지보수성 / No-Hardcoding

3. **웹검색 헬퍼 단일화** — `ws-chat-handler` 의 인라인 40줄을 `buildWebSearchContext` 호출로 마이그레이션(중복·드리프트 제거, orphan import 6개 정리). WS 는 기존 동작 보존 위해 `signal` 미전달.
4. **지식 컷오프 외부화** — `config/knowledge-cutoff.ts` 신규, env 오버라이드 지원.
5. **검색 수집 캡 외부화** — `maxResults: 12` → `WEB_SEARCH_INJECTION.COLLECT_MAX_RESULTS` (양 경로 공유).

## 🟢 기타

- **abort 처리** — 웹검색 중단 시 끊긴 signal 로 LLM 을 호출하던 spurious 500 방지 (헬퍼 abort 재throw + 라우트 catch guard).
- `toLowerCase()` 키워드 루프 hoist (micro-perf).

### 의도적 보류 (리뷰 findings 중)
- **순차 await 병렬화**: 외부 provider 한정 + resolve 는 인덱스 DB 단건(~ms)이라 실익 미미, 복잡도 ↑ → 보류.
- **구조화 전 동기 웹검색**: 이 PR의 의도된 기능(버그 아님).
- **재시도 시 webContext 재전송**: 빼면 교정 품질 저하 → 현행 유지.

## 검증
- [x] `tsc -p apps/api --noEmit` → exit 0
- [x] `eslint` (변경 백엔드 파일 전체) → exit 0
- [x] 유닛 테스트 **87개 전부 통과** (answer-composer 25 + web-search/deep-research 62)
- [x] 빌드(backend + next) 성공
- [x] 운영 pm2 재배포 후 health 200, `/api/chat/structured` 정상 응답

## 환경변수 추가 (`.env.example` 반영됨)
- `APP_TIMEZONE` (기본 `Asia/Seoul`)
- `LLM_KNOWLEDGE_CUTOFF_KO` / `LLM_KNOWLEDGE_CUTOFF_EN`
- `WEB_SEARCH_COLLECT_MAX_RESULTS` (기본 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)