### PR TITLE
feat: Manus화 Phase 1 — 영속 task 샌드박스 + 도구 + 승인 게이트 (C1+B)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -715,6 +715,23 @@ SKILL_CATALOG_DESC_MAX=120
 # 서버별 mcp_servers.sandbox_network: 'full'=bridge | 'none'=네트워크 차단 |
 #   'host'=비격리 호스트 직접 실행(호스트 설치 바이너리 의존 신뢰 서버 opt-out).
 # 컨테이너 내 127.0.0.1/localhost 는 host.docker.internal 로 자동 치환(내부 DB 접속 보정).
+# ── Task 샌드박스 (Manus화 Phase 1 — 영속 가상 컴퓨터) ──
+# 자율 에이전트가 task별 영속 컨테이너(셸+파일시스템)에서 작업. 기본 OFF(요청경로 미연결 상태로 머지).
+# 선행: 이미지 빌드 — `docker build -t openmake-task-runtime:latest infra/task-runtime`
+TASK_SANDBOX_ENABLED=false
+# TASK_SANDBOX_IMAGE=openmake-task-runtime:latest      # task 런타임 이미지(mcp-runtime + git/curl/ripgrep)
+# TASK_SANDBOX_ROOT=/tmp/openmake-task-workspaces      # 호스트 workspace 루트(task별 하위 디렉토리)
+# TASK_SANDBOX_MAX_CONCURRENT=8                        # 동시 활성 컨테이너 상한
+# TASK_SANDBOX_NETWORK=none                            # none | restricted(allowlist, fast-follow). full 미허용
+# TASK_SANDBOX_NETWORK_ALLOWLIST=                      # restricted 시 egress 허용 도메인(쉼표)
+# TASK_SANDBOX_MEMORY=1g                               # 컨테이너 메모리 상한
+# TASK_SANDBOX_CPUS=1.0                                # CPU 상한
+# TASK_SANDBOX_PIDS_LIMIT=512                          # PID 상한
+# TASK_SANDBOX_USER=1000:1000                          # 실행 uid:gid (non-root)
+# TASK_SANDBOX_EXEC_TIMEOUT_MS=120000                  # 단일 명령 timeout
+# TASK_SANDBOX_OUTPUT_CAP=262144                       # exec 출력 캡(byte)
+# TASK_SANDBOX_WORKSPACE_QUOTA=536870912               # workspace 디스크 쿼터(byte)
+
 MCP_SANDBOX_ENABLED=false
 # MCP_SANDBOX_DOCKER_PATH=docker                       # docker 바이너리(기본 PATH 탐색 + Desktop 경로)
 # MCP_SANDBOX_IMAGE=openmake-mcp-runtime:latest        # 런타임 이미지

--- a/.env.example
+++ b/.env.example
@@ -731,6 +731,8 @@ TASK_SANDBOX_ENABLED=false
 # TASK_SANDBOX_EXEC_TIMEOUT_MS=120000                  # 단일 명령 timeout
 # TASK_SANDBOX_OUTPUT_CAP=262144                       # exec 출력 캡(byte)
 # TASK_SANDBOX_WORKSPACE_QUOTA=536870912               # workspace 디스크 쿼터(byte)
+# TASK_SANDBOX_APPROVAL_POLICY=all                     # all(전부 승인·기본) | high-risk(bash·삭제만) | none(자동)
+# TASK_SANDBOX_APPROVAL_TIMEOUT_MS=1800000             # 승인 대기 timeout(초과 시 자동 거절). 기본 30분
 
 MCP_SANDBOX_ENABLED=false
 # MCP_SANDBOX_DOCKER_PATH=docker                       # docker 바이너리(기본 PATH 탐색 + Desktop 경로)

--- a/.env.example
+++ b/.env.example
@@ -733,6 +733,7 @@ TASK_SANDBOX_ENABLED=false
 # TASK_SANDBOX_WORKSPACE_QUOTA=536870912               # workspace 디스크 쿼터(byte)
 # TASK_SANDBOX_APPROVAL_POLICY=all                     # all(전부 승인·기본) | high-risk(bash·삭제만) | none(자동)
 # TASK_SANDBOX_APPROVAL_TIMEOUT_MS=1800000             # 승인 대기 timeout(초과 시 자동 거절). 기본 30분
+# AGENT_MAX_TOTAL_TOKENS=1000000                       # agent task 누적 토큰 상한(멀티턴 누적). 기본 1M
 
 MCP_SANDBOX_ENABLED=false
 # MCP_SANDBOX_DOCKER_PATH=docker                       # docker 바이너리(기본 PATH 탐색 + Desktop 경로)

--- a/.env.example
+++ b/.env.example
@@ -731,6 +731,7 @@ TASK_SANDBOX_ENABLED=false
 # TASK_SANDBOX_EXEC_TIMEOUT_MS=120000                  # 단일 명령 timeout
 # TASK_SANDBOX_OUTPUT_CAP=262144                       # exec 출력 캡(byte)
 # TASK_SANDBOX_WORKSPACE_QUOTA=536870912               # workspace 디스크 쿼터(byte)
+# TASK_SANDBOX_WORKSPACE_TTL_MS=86400000              # 완료 task workspace 보존 TTL(스윕 삭제). 기본 24h
 # TASK_SANDBOX_APPROVAL_POLICY=all                     # all(전부 승인·기본) | high-risk(bash·삭제만) | none(자동)
 # TASK_SANDBOX_APPROVAL_TIMEOUT_MS=1800000             # 승인 대기 timeout(초과 시 자동 거절). 기본 30분
 # AGENT_MAX_TOTAL_TOKENS=1000000                       # agent task 누적 토큰 상한(멀티턴 누적). 기본 1M

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1122,8 +1122,10 @@ export const AGENT_TASK_LIMITS = {
     /** 작업 전체 타임아웃 (ms) — AGENT_TASK_TIMEOUT_MS 환경변수로 오버라이드.
      *  기본 10분: HTML/디자인 등 장문 deliverable 생성은 단일 LLM 호출이 수 분 걸릴 수 있음. */
     TOTAL_TIMEOUT_MS: parseInt(process.env.AGENT_TASK_TIMEOUT_MS || '', 10) || 10 * 60 * 1000,
-    /** 누적 토큰 상한 (input + output) — runaway 토큰 폭주 방지. */
-    MAX_TOTAL_TOKENS: 200_000,
+    /** 누적 토큰 상한 (input + output) — runaway 토큰 폭주 방지. AGENT_MAX_TOTAL_TOKENS 로 오버라이드.
+     *  멀티턴 도구 작업은 매 턴 prompt_eval_count(전체 컨텍스트)를 누적 카운트하므로 200k 는
+     *  3턴 만에 소진됐다(샌드박스 도구 작업이 terminate 전에 실패). 기본 1M 으로 상향. */
+    MAX_TOTAL_TOKENS: parseInt(process.env.AGENT_MAX_TOTAL_TOKENS || '', 10) || 1_000_000,
     /** 검색류 도구 호출 횟수 하드 상한 — 초과 시 다음 턴부터 검색 도구를 제거해 강제 종합.
      *  AGENT_MAX_SEARCH_CALLS 환경변수로 오버라이드 가능 (기본 5). */
     MAX_SEARCH_CALLS: parseInt(process.env.AGENT_MAX_SEARCH_CALLS || '5', 10),

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1129,5 +1129,8 @@ export const AGENT_TASK_LIMITS = {
     MAX_SEARCH_CALLS: parseInt(process.env.AGENT_MAX_SEARCH_CALLS || '5', 10),
     /** 검색/정보수집 도구 식별 키워드 (tool name 에 포함되면 검색류로 카운트) */
     SEARCH_TOOL_KEYWORDS: ['search', 'visit_page', 'research', 'firecrawl', 'scrape', 'crawl', 'fetch'] as readonly string[],
+    /** stuck 감지 — 동일 assistant 응답이 이 횟수만큼 연속되면 전략변경 프롬프트 주입(무한루프 방지).
+     *  OpenManus BaseAgent.is_stuck 패턴. AGENT_STUCK_THRESHOLD 로 오버라이드(기본 3). */
+    STUCK_THRESHOLD: parseInt(process.env.AGENT_STUCK_THRESHOLD || '3', 10),
 } as const;
 

--- a/apps/api/src/config/task-sandbox.ts
+++ b/apps/api/src/config/task-sandbox.ts
@@ -10,6 +10,14 @@
 /** 컨테이너 네트워크 정책. C1 은 none 출발, restricted(allowlist) fast-follow. full 미허용. */
 export type TaskSandboxNetwork = 'none' | 'restricted';
 
+/**
+ * 도구 호출 승인 정책 (HITL 게이트).
+ * - all: 모든 도구 호출에 사용자 승인 필요 (가장 안전, 기본값).
+ * - high-risk: 고위험 도구(bash·file 삭제·network egress)만 승인.
+ * - none: 승인 없이 자동 실행 (빠름, 위험↑).
+ */
+export type TaskSandboxApprovalPolicy = 'all' | 'high-risk' | 'none';
+
 function intEnv(raw: string | undefined, def: number): number {
     const n = parseInt(raw ?? '', 10);
     return Number.isFinite(n) && n > 0 ? n : def;
@@ -44,10 +52,17 @@ export interface TaskSandboxConfig {
     outputCap: number;
     /** workspace 디스크 쿼터(byte) — 초과 시 정리/거절. */
     workspaceQuota: number;
+    /** 도구 호출 승인 정책 (기본 all — 전부 승인). */
+    approvalPolicy: TaskSandboxApprovalPolicy;
+    /** 승인 대기 timeout(ms) — 초과 시 자동 거절(작업 일시정지 해제). */
+    approvalTimeoutMs: number;
 }
 
 export function getTaskSandboxConfig(): TaskSandboxConfig {
     const net = process.env.TASK_SANDBOX_NETWORK === 'restricted' ? 'restricted' : 'none';
+    const policyRaw = process.env.TASK_SANDBOX_APPROVAL_POLICY;
+    const approvalPolicy: TaskSandboxApprovalPolicy =
+        policyRaw === 'none' || policyRaw === 'high-risk' ? policyRaw : 'all';
     return {
         enabled: process.env.TASK_SANDBOX_ENABLED === 'true',
         dockerPath: process.env.TASK_SANDBOX_DOCKER_PATH || 'docker',
@@ -64,5 +79,7 @@ export function getTaskSandboxConfig(): TaskSandboxConfig {
         execTimeoutMs: intEnv(process.env.TASK_SANDBOX_EXEC_TIMEOUT_MS, 120_000),
         outputCap: intEnv(process.env.TASK_SANDBOX_OUTPUT_CAP, 256 * 1024),
         workspaceQuota: intEnv(process.env.TASK_SANDBOX_WORKSPACE_QUOTA, 512 * 1024 * 1024),
+        approvalPolicy,
+        approvalTimeoutMs: intEnv(process.env.TASK_SANDBOX_APPROVAL_TIMEOUT_MS, 30 * 60_000),
     };
 }

--- a/apps/api/src/config/task-sandbox.ts
+++ b/apps/api/src/config/task-sandbox.ts
@@ -56,6 +56,8 @@ export interface TaskSandboxConfig {
     approvalPolicy: TaskSandboxApprovalPolicy;
     /** 승인 대기 timeout(ms) — 초과 시 자동 거절(작업 일시정지 해제). */
     approvalTimeoutMs: number;
+    /** 완료 task workspace 보존 TTL(ms) — 초과한 workspace 디렉토리는 정리 스윕이 삭제. */
+    workspaceTtlMs: number;
 }
 
 export function getTaskSandboxConfig(): TaskSandboxConfig {
@@ -81,5 +83,6 @@ export function getTaskSandboxConfig(): TaskSandboxConfig {
         workspaceQuota: intEnv(process.env.TASK_SANDBOX_WORKSPACE_QUOTA, 512 * 1024 * 1024),
         approvalPolicy,
         approvalTimeoutMs: intEnv(process.env.TASK_SANDBOX_APPROVAL_TIMEOUT_MS, 30 * 60_000),
+        workspaceTtlMs: intEnv(process.env.TASK_SANDBOX_WORKSPACE_TTL_MS, 24 * 60 * 60_000),
     };
 }

--- a/apps/api/src/config/task-sandbox.ts
+++ b/apps/api/src/config/task-sandbox.ts
@@ -1,0 +1,68 @@
+/**
+ * Task 샌드박스 설정 (Manus화 Phase 1 / C1) — No-Hardcoding L1/L2 외부화.
+ *
+ * 영속 task 샌드박스(services/task-sandbox)가 참조하는 모든 상수. 전부 env 오버라이드.
+ * ⚠️ TASK_SANDBOX_ENABLED 기본 OFF — 운영 활성화는 사용자 직접(요청경로 미연결 상태로 머지).
+ *
+ * @module config/task-sandbox
+ */
+
+/** 컨테이너 네트워크 정책. C1 은 none 출발, restricted(allowlist) fast-follow. full 미허용. */
+export type TaskSandboxNetwork = 'none' | 'restricted';
+
+function intEnv(raw: string | undefined, def: number): number {
+    const n = parseInt(raw ?? '', 10);
+    return Number.isFinite(n) && n > 0 ? n : def;
+}
+
+export interface TaskSandboxConfig {
+    /** 마스터 게이트 (기본 OFF). */
+    enabled: boolean;
+    /** docker 바이너리 경로(또는 'docker'). */
+    dockerPath: string;
+    /** task 런타임 이미지 (infra/task-runtime). */
+    image: string;
+    /** 호스트 workspace 루트 — task별 하위 디렉토리 생성. */
+    workspaceRoot: string;
+    /** 동시 활성 컨테이너 상한. */
+    maxConcurrent: number;
+    /** 네트워크 정책. */
+    network: TaskSandboxNetwork;
+    /** restricted 시 egress 허용 도메인(쉼표구분). */
+    networkAllowlist: string[];
+    /** 컨테이너 메모리 상한(docker --memory 표기). */
+    memory: string;
+    /** CPU 상한(docker --cpus). */
+    cpus: string;
+    /** pids 상한. */
+    pidsLimit: number;
+    /** 컨테이너 유저(uid:gid). */
+    user: string;
+    /** 단일 명령(exec) timeout(ms). */
+    execTimeoutMs: number;
+    /** exec stdout/stderr 캡처 상한(byte). */
+    outputCap: number;
+    /** workspace 디스크 쿼터(byte) — 초과 시 정리/거절. */
+    workspaceQuota: number;
+}
+
+export function getTaskSandboxConfig(): TaskSandboxConfig {
+    const net = process.env.TASK_SANDBOX_NETWORK === 'restricted' ? 'restricted' : 'none';
+    return {
+        enabled: process.env.TASK_SANDBOX_ENABLED === 'true',
+        dockerPath: process.env.TASK_SANDBOX_DOCKER_PATH || 'docker',
+        image: process.env.TASK_SANDBOX_IMAGE || 'openmake-task-runtime:latest',
+        workspaceRoot: process.env.TASK_SANDBOX_ROOT || '/tmp/openmake-task-workspaces',
+        maxConcurrent: intEnv(process.env.TASK_SANDBOX_MAX_CONCURRENT, 8),
+        network: net,
+        networkAllowlist: (process.env.TASK_SANDBOX_NETWORK_ALLOWLIST || '')
+            .split(',').map((s) => s.trim()).filter(Boolean),
+        memory: process.env.TASK_SANDBOX_MEMORY || '1g',
+        cpus: process.env.TASK_SANDBOX_CPUS || '1.0',
+        pidsLimit: intEnv(process.env.TASK_SANDBOX_PIDS_LIMIT, 512),
+        user: process.env.TASK_SANDBOX_USER || '1000:1000',
+        execTimeoutMs: intEnv(process.env.TASK_SANDBOX_EXEC_TIMEOUT_MS, 120_000),
+        outputCap: intEnv(process.env.TASK_SANDBOX_OUTPUT_CAP, 256 * 1024),
+        workspaceQuota: intEnv(process.env.TASK_SANDBOX_WORKSPACE_QUOTA, 512 * 1024 * 1024),
+    };
+}

--- a/apps/api/src/data/models/unified-database.ts
+++ b/apps/api/src/data/models/unified-database.ts
@@ -360,6 +360,8 @@ export class UnifiedDatabase {
         result?: string;
         error?: string;
         checkpoint?: unknown;
+        sandboxContainerId?: string;
+        workspacePath?: string;
     }): Promise<void> {
         return this.agentTaskRepository.updateAgentTask(taskId, updates);
     }

--- a/apps/api/src/data/models/unified-database.types.ts
+++ b/apps/api/src/data/models/unified-database.types.ts
@@ -162,7 +162,7 @@ export interface ResearchStep {
 // 자율 에이전트 작업 (Agent Task) 인터페이스
 // ============================================
 
-export type AgentTaskStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
+export type AgentTaskStatus = 'pending' | 'running' | 'paused' | 'completed' | 'failed' | 'cancelled';
 
 export interface AgentTask {
     id: string;

--- a/apps/api/src/data/repositories/agent-task-repository.ts
+++ b/apps/api/src/data/repositories/agent-task-repository.ts
@@ -39,6 +39,8 @@ export class AgentTaskRepository extends BaseRepository {
         result?: string;
         error?: string;
         checkpoint?: unknown;
+        sandboxContainerId?: string;
+        workspacePath?: string;
     }): Promise<void> {
         const sets: string[] = ['updated_at = NOW()'];
         const params: QueryParam[] = [];
@@ -70,6 +72,14 @@ export class AgentTaskRepository extends BaseRepository {
         if (updates.checkpoint !== undefined) {
             sets.push(`checkpoint = $${paramIdx++}`);
             params.push(JSON.stringify(updates.checkpoint));
+        }
+        if (updates.sandboxContainerId !== undefined) {
+            sets.push(`sandbox_container_id = $${paramIdx++}`);
+            params.push(updates.sandboxContainerId);
+        }
+        if (updates.workspacePath !== undefined) {
+            sets.push(`workspace_path = $${paramIdx++}`);
+            params.push(updates.workspacePath);
         }
 
         params.push(taskId);

--- a/apps/api/src/prompts/agent-task-prompt.ts
+++ b/apps/api/src/prompts/agent-task-prompt.ts
@@ -58,3 +58,8 @@ export function getAgentTaskSystemPrompt(): string {
 export function getAgentTaskDeliverableNudge(): string {
     return '계획은 확인했습니다. 이제 계획대로 완성된 최종 결과물 전문을 <artifact> 태그로 감싸 작성하세요. 결과물 설명이 아니라 결과물 자체를 작성해야 합니다.';
 }
+
+/** stuck(동일 응답 반복) 감지 시 주입 — 전략 변경 유도(OpenManus handle_stuck_state 패턴). */
+export function getAgentTaskStuckNudge(): string {
+    return '같은 시도를 반복하고 있습니다. 접근 방식을 바꾸세요: 다른 도구나 다른 입력을 시도하거나, 막혔다면 지금까지의 결과로 작업을 마무리(terminate)하거나 사용자에게 도움을 요청(ask_human)하세요.';
+}

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -30,6 +30,7 @@ import { AgentTaskService } from '../services/AgentTaskService';
 import type { ChatMessage } from '../llm/types';
 import { AGENT_TASK_LIMITS } from '../config/runtime-limits';
 import { createAgentTaskSchema } from '../schemas/agent-task.schema';
+import { getApprovalRegistry } from '../services/task-sandbox/approval-gate';
 
 const logger = createLogger('AgentTaskRoutes');
 const router = Router();
@@ -238,6 +239,34 @@ router.delete('/:taskId', asyncHandler(async (req: Request, res: Response) => {
     const db = getUnifiedDatabase();
     await db.deleteAgentTask(task.id);
     res.json(success({ message: '작업이 삭제되었습니다.', taskId: task.id }));
+}));
+
+/**
+ * GET /api/agent-tasks/approvals/pending
+ * 현재 사용자의 승인 대기 도구 호출 목록 (HITL 게이트 — 전부-승인 정책).
+ */
+router.get('/approvals/pending', asyncHandler(async (req: Request, res: Response) => {
+    const pending = getApprovalRegistry().list(String(req.user!.id));
+    res.json(success({ pending }));
+}));
+
+/**
+ * POST /api/agent-tasks/approvals/:approvalId/:decision  (decision = approve | reject)
+ * 대기 중인 도구 호출을 승인/거절 — 해당 approval 의 owner 만 가능.
+ */
+router.post('/approvals/:approvalId/:decision', asyncHandler(async (req: Request, res: Response) => {
+    const { approvalId, decision } = req.params;
+    if (decision !== 'approve' && decision !== 'reject') {
+        return res.status(400).json(badRequest("decision 은 approve | reject 여야 합니다."));
+    }
+    const registry = getApprovalRegistry();
+    const pending = registry.get(approvalId);
+    if (!pending) return res.status(404).json(notFound('대기 중인 승인 요청을 찾을 수 없습니다(만료 가능).'));
+    assertResourceOwnerOrAdmin(pending.userId, String(req.user!.id), req.user!.role || 'user');
+
+    const ok = decision === 'approve' ? registry.approve(approvalId) : registry.reject(approvalId);
+    if (!ok) return res.status(404).json(notFound('대기 중인 승인 요청을 찾을 수 없습니다(만료 가능).'));
+    res.json(success({ approvalId, decision }));
 }));
 
 export { router as agentTaskRouter };

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -31,6 +31,8 @@ import type { ChatMessage } from '../llm/types';
 import { AGENT_TASK_LIMITS } from '../config/runtime-limits';
 import { createAgentTaskSchema } from '../schemas/agent-task.schema';
 import { getApprovalRegistry } from '../services/task-sandbox/approval-gate';
+import { safeResolveWorkspacePath, listWorkspaceFilesAt } from '../services/task-sandbox/sandbox';
+import { basename } from 'path';
 
 const logger = createLogger('AgentTaskRoutes');
 const router = Router();
@@ -239,6 +241,40 @@ router.delete('/:taskId', asyncHandler(async (req: Request, res: Response) => {
     const db = getUnifiedDatabase();
     await db.deleteAgentTask(task.id);
     res.json(success({ message: '작업이 삭제되었습니다.', taskId: task.id }));
+}));
+
+/**
+ * GET /api/agent-tasks/:taskId/files
+ * 완료된 task 의 workspace 산출물 파일 목록 (상대경로). 완료 시 workspace 보존됨.
+ */
+router.get('/:taskId/files', asyncHandler(async (req: Request, res: Response) => {
+    const task = await loadOwnedTask(req, res, req.params.taskId);
+    if (!task) return;
+    const wp = (task as { workspace_path?: string }).workspace_path;
+    if (!wp) return res.json(success({ files: [] }));
+    const files = await listWorkspaceFilesAt(wp);
+    res.json(success({ files }));
+}));
+
+/**
+ * GET /api/agent-tasks/:taskId/files/download?path=relative/path
+ * workspace 내 단일 파일 다운로드. 경로 탈출 가드 + owner 검증.
+ */
+router.get('/:taskId/files/download', asyncHandler(async (req: Request, res: Response) => {
+    const task = await loadOwnedTask(req, res, req.params.taskId);
+    if (!task) return;
+    const wp = (task as { workspace_path?: string }).workspace_path;
+    const rel = String(req.query.path || '');
+    if (!wp || !rel) return res.status(400).json(badRequest('path 가 필요합니다.'));
+    let abs: string;
+    try {
+        abs = safeResolveWorkspacePath(wp, rel);
+    } catch {
+        return res.status(400).json(badRequest('잘못된 경로입니다.'));
+    }
+    res.download(abs, basename(rel), (err) => {
+        if (err && !res.headersSent) res.status(404).json(notFound('파일을 찾을 수 없습니다.'));
+    });
 }));
 
 /**

--- a/apps/api/src/schedulers/index.ts
+++ b/apps/api/src/schedulers/index.ts
@@ -59,16 +59,19 @@ export async function startAllSchedulers(): Promise<void> {
     // 7. 로컬 모델 가용성 polling — startup probe 이후 backend 장애 동적 감지
     startLocalModelProbeScheduler();
 
-    // 8. Task 샌드박스 고아 컨테이너 청소 (플래그 ON 시) — 비정상 종료로 남은 omk-task-* 회수.
+    // 8. Task 샌드박스 정리 (플래그 ON 시) — 고아 컨테이너(부팅 1회) + stale workspace(부팅 + 6h 주기).
     try {
         const { getTaskSandboxConfig } = await import('../config/task-sandbox');
         if (getTaskSandboxConfig().enabled) {
-            const { reapOrphanTaskSandboxes } = await import('../services/task-sandbox/sandbox');
+            const { reapOrphanTaskSandboxes, reapStaleWorkspaces } = await import('../services/task-sandbox/sandbox');
             await reapOrphanTaskSandboxes();
-            logger.debug('TaskSandbox 고아 컨테이너 청소 완료');
+            await reapStaleWorkspaces(Date.now());
+            const SIX_HOURS = 6 * 60 * 60 * 1000;
+            setInterval(() => { void reapStaleWorkspaces(Date.now()).catch(() => { /* noop */ }); }, SIX_HOURS).unref();
+            logger.debug('TaskSandbox 정리 스케줄 등록 완료');
         }
     } catch (err) {
-        logger.warn('TaskSandbox 고아 청소 실패(무시):', err);
+        logger.warn('TaskSandbox 정리 실패(무시):', err);
     }
 
     logger.info('모든 백그라운드 스케줄러 시작 완료');

--- a/apps/api/src/schedulers/index.ts
+++ b/apps/api/src/schedulers/index.ts
@@ -59,6 +59,18 @@ export async function startAllSchedulers(): Promise<void> {
     // 7. 로컬 모델 가용성 polling — startup probe 이후 backend 장애 동적 감지
     startLocalModelProbeScheduler();
 
+    // 8. Task 샌드박스 고아 컨테이너 청소 (플래그 ON 시) — 비정상 종료로 남은 omk-task-* 회수.
+    try {
+        const { getTaskSandboxConfig } = await import('../config/task-sandbox');
+        if (getTaskSandboxConfig().enabled) {
+            const { reapOrphanTaskSandboxes } = await import('../services/task-sandbox/sandbox');
+            await reapOrphanTaskSandboxes();
+            logger.debug('TaskSandbox 고아 컨테이너 청소 완료');
+        }
+    } catch (err) {
+        logger.warn('TaskSandbox 고아 청소 실패(무시):', err);
+    }
+
     logger.info('모든 백그라운드 스케줄러 시작 완료');
 }
 

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -21,7 +21,7 @@ import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { getUnifiedDatabase } from '../data/models/unified-database';
 import { AGENT_TASK_LIMITS, MAX_TOOL_RESULT_CHARS } from '../config/runtime-limits';
 import { emitAgentTaskProgress } from '../utils/event-bus';
-import { getAgentTaskSystemPrompt, getAgentTaskDeliverableNudge } from '../prompts/agent-task-prompt';
+import { getAgentTaskSystemPrompt, getAgentTaskDeliverableNudge, getAgentTaskStuckNudge } from '../prompts/agent-task-prompt';
 import { extractAndStripArtifacts, type ExtractedArtifact } from '../llm/artifact-parser';
 import { getPushService } from './PushService';
 import { createLogger } from '../utils/logger';
@@ -135,6 +135,8 @@ export class AgentTaskService {
         let curProgress = 0;
         let curTurn = 0;
         let taskRuntime: TaskRuntime | null = null;
+        const recentSignatures: string[] = [];
+        let stuckNotified = false;
 
         // DB 갱신 + 진행상황 발행(fire-and-forget). ws 계층이 구독해 owner user 에게 relay.
         // ws 를 직접 참조하지 않으므로 소켓 연결 여부와 무관하게 실행은 끝까지 진행된다.
@@ -256,6 +258,24 @@ export class AgentTaskService {
                     content: result.content,
                     ...(result.tool_calls && { tool_calls: result.tool_calls }),
                 });
+
+                // stuck 감지 — 동일 응답(내용+도구호출)이 STUCK_THRESHOLD 회 연속되면 전략변경 유도.
+                // (OpenManus BaseAgent.is_stuck → handle_stuck_state 패턴. 무한루프/제자리맴돔 방지.)
+                const sig = JSON.stringify({
+                    c: result.content ?? '',
+                    t: (result.tool_calls ?? []).map((x) => ({ n: x.function.name, a: x.function.arguments })),
+                });
+                recentSignatures.push(sig);
+                if (recentSignatures.length > AGENT_TASK_LIMITS.STUCK_THRESHOLD) recentSignatures.shift();
+                const stuck = recentSignatures.length >= AGENT_TASK_LIMITS.STUCK_THRESHOLD
+                    && recentSignatures.every((s) => s === sig);
+                if (stuck && !stuckNotified) {
+                    conversation.push({ role: 'user', content: getAgentTaskStuckNudge() });
+                    stuckNotified = true;
+                    logger.info(`[AgentTask] stuck 감지 → 전략변경 주입: ${taskId} (turn ${turn + 1})`);
+                } else if (!stuck) {
+                    stuckNotified = false;
+                }
 
                 const hasToolCalls = !!result.tool_calls && result.tool_calls.length > 0;
 

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -28,6 +28,9 @@ import { createLogger } from '../utils/logger';
 import type { UserContext } from '../mcp/user-sandbox';
 import { getSkillManager } from '../agents/skill-manager';
 import { mergeToolsWithSkills, type ActiveSkillBinding } from './chat-service/tool-merger';
+import { getTaskSandboxConfig } from '../config/task-sandbox';
+import { TaskRuntime } from './task-sandbox/runtime';
+import { TASK_TERMINATE_SENTINEL } from './task-sandbox/tools';
 
 const logger = createLogger('AgentTaskService');
 
@@ -131,6 +134,7 @@ export class AgentTaskService {
         let curStatus = 'pending';
         let curProgress = 0;
         let curTurn = 0;
+        let taskRuntime: TaskRuntime | null = null;
 
         // DB 갱신 + 진행상황 발행(fire-and-forget). ws 계층이 구독해 owner user 에게 relay.
         // ws 를 직접 참조하지 않으므로 소켓 연결 여부와 무관하게 실행은 끝까지 진행된다.
@@ -178,9 +182,28 @@ export class AgentTaskService {
                 skillBindings = skillBindings.filter((b) => allow.has(b.skill_id));
                 logger.debug(`[AgentTask] 스킬 범위 제한: ${before} → ${skillBindings.length} (allowedSkills=${allowedSkills.length})`);
             }
-            const tools = skillBindings.length > 0
+            const mcpTools = skillBindings.length > 0
                 ? mergeToolsWithSkills({ allTools, userToggled: allTools, profileRequired: [], skillBindings })
                 : allTools;
+
+            // 영속 샌드박스(Manus화) — 플래그 ON 일 때만. OFF 면 runtime=null 로 기존 동작 그대로.
+            // 생성 실패는 작업을 죽이지 않고 샌드박스 없이 진행(graceful degrade).
+            if (getTaskSandboxConfig().enabled) {
+                try {
+                    taskRuntime = new TaskRuntime(taskId, userId);
+                    await taskRuntime.create();
+                    await db.updateAgentTask(taskId, {
+                        sandboxContainerId: taskRuntime.containerName,
+                        workspacePath: taskRuntime.workspacePath,
+                    });
+                    logger.info(`[AgentTask] 샌드박스 활성 (${taskId}, ${taskRuntime.containerName})`);
+                } catch (e) {
+                    logger.warn(`[AgentTask] 샌드박스 생성 실패 — 미사용 진행: ${e instanceof Error ? e.message : e}`);
+                    taskRuntime = null;
+                }
+            }
+            // task 도구를 LLM 도구 목록에 합류 (샌드박스 ON 시에만).
+            const tools = taskRuntime ? [...mcpTools, ...taskRuntime.getLLMTools()] : mcpTools;
 
             for (let turn = startTurn; turn < turnCeiling; turn++) {
                 this.assertWithinLimits(signal, startedAt, totalTokens);
@@ -271,11 +294,35 @@ export class AgentTaskService {
                 }
 
                 // 도구 실행 + 체크포인트
+                let terminated = false;
+                let terminateSummary = '';
                 for (const tc of result.tool_calls!) {
                     if (signal.aborted) throw new AgentTaskAbort('aborted');
                     const name = tc.function.name;
                     if (isSearchTool(name)) searchCalls++;
-                    const toolResult = await this.runTool(mcp, name, tc.function.arguments ?? {}, userCtx);
+                    const args = (tc.function.arguments ?? {}) as Record<string, unknown>;
+                    let toolResult: string;
+                    if (taskRuntime?.isTaskTool(name)) {
+                        // task 도구 — 승인 게이트 통과 후 영속 샌드박스에서 실행.
+                        toolResult = await taskRuntime.executeTaskTool(name, args, {
+                            signal,
+                            onApprovalPending: (p) => {
+                                void update({ status: 'paused' }).catch(() => { /* noop */ });
+                                void getPushService().sendPush(userId, {
+                                    title: 'OpenMake 에이전트 — 승인 필요',
+                                    body: `도구 실행 승인을 기다립니다: ${p.toolName}`,
+                                    url: '/agent-tasks.html',
+                                }).catch(() => { /* noop */ });
+                            },
+                        });
+                        if (curStatus === 'paused') await update({ status: 'running' }).catch(() => { /* noop */ });
+                        if (toolResult.includes(TASK_TERMINATE_SENTINEL)) {
+                            terminated = true;
+                            terminateSummary = String(args.summary ?? '');
+                        }
+                    } else {
+                        toolResult = await this.runTool(mcp, name, args, userCtx);
+                    }
                     conversation.push({
                         role: 'tool',
                         content: toolResult,
@@ -289,6 +336,19 @@ export class AgentTaskService {
                         toolName: name,
                         content: toolResult,
                     });
+                }
+
+                // terminate 도구 호출 — 깔끔한 완료 시그널(max_turns 소진 아님).
+                if (terminated) {
+                    const ex = extractAndStripArtifacts(result.content ?? '');
+                    stepNumber = await this.persistArtifactSteps(taskId, ex.artifacts, stepNumber);
+                    await update({
+                        status: 'completed',
+                        progress: 100,
+                        result: terminateSummary || ex.cleanedContent || '작업을 완료했습니다.',
+                    });
+                    logger.info(`[AgentTask] terminate 완료: ${taskId} (${turn + 1} 턴)`);
+                    return;
                 }
 
                 // end-of-turn 체크포인트: tool 결과까지 포함된 완전한 conversation + 완료 턴 번호.
@@ -322,6 +382,10 @@ export class AgentTaskService {
             logger.warn(`[AgentTask] ${aborted ? '취소' : '실패'}: ${taskId} — ${kind}: ${msg}`);
         } finally {
             AgentTaskService.running.delete(taskId);
+            if (taskRuntime) {
+                await taskRuntime.cleanup().catch((e) =>
+                    logger.warn(`[AgentTask] 샌드박스 정리 실패: ${taskId} — ${e}`));
+            }
         }
     }
 

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -403,7 +403,9 @@ export class AgentTaskService {
         } finally {
             AgentTaskService.running.delete(taskId);
             if (taskRuntime) {
-                await taskRuntime.cleanup().catch((e) =>
+                // 완료 시 workspace 보존(산출물 다운로드용), 실패/취소 시 삭제. 컨테이너는 항상 제거.
+                const keepWorkspace = curStatus === 'completed';
+                await taskRuntime.cleanup(!keepWorkspace).catch((e) =>
                     logger.warn(`[AgentTask] 샌드박스 정리 실패: ${taskId} — ${e}`));
             }
         }

--- a/apps/api/src/services/task-sandbox/approval-gate.ts
+++ b/apps/api/src/services/task-sandbox/approval-gate.ts
@@ -1,0 +1,129 @@
+/**
+ * ============================================================
+ * Task Tool Approval Gate — HITL 승인 게이트 (Manus화 Phase 1 / C1)
+ * ============================================================
+ *
+ * 자율 에이전트가 영속 샌드박스 도구(셸/파일/네트워크)를 실행하기 전, 정책에 따라
+ * 사용자 승인을 요구한다. 정책 'all'(기본)은 모든 도구 호출을 승인 대기시킨다.
+ *
+ * `AgentTaskService.ts:296` 이 예고한 "write 도구 추가 시 gate 필요"를 충족한다.
+ * resume(이어하기)는 continuation 일 뿐 승인 게이트가 아니었으므로 신규 구축.
+ *
+ * 구조: in-loop 대기 — task 는 in-memory 장수 백그라운드 프로세스이므로, 도구 실행 직전
+ * Promise 로 승인을 await 한다(timeout/abort 시 자동 거절). 승인은 REST 가 resolve.
+ *
+ * @module services/task-sandbox/approval-gate
+ */
+import type { TaskSandboxApprovalPolicy } from '../../config/task-sandbox';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('TaskApprovalGate');
+
+/** 승인이 필요한 고위험 도구(high-risk 정책 시). */
+const HIGH_RISK_TOOLS = new Set(['bash']);
+/** 고위험으로 보는 file_ops 작업. */
+const HIGH_RISK_FILE_OPS = new Set(['delete']);
+
+/** PURE: 도구 호출이 승인을 요구하는지 정책에 따라 판정. */
+export function requiresApproval(
+    policy: TaskSandboxApprovalPolicy,
+    toolName: string,
+    args: Record<string, unknown>,
+): boolean {
+    if (policy === 'none') return false;
+    // 제어 시그널은 승인 불요(부작용 없음).
+    if (toolName === 'terminate' || toolName === 'ask_human') return false;
+    if (policy === 'all') return true;
+    // high-risk
+    if (HIGH_RISK_TOOLS.has(toolName)) return true;
+    if (toolName === 'file_ops' && HIGH_RISK_FILE_OPS.has(String(args.op))) return true;
+    return false;
+}
+
+export type ApprovalDecision = 'approved' | 'rejected';
+
+export interface PendingApproval {
+    approvalId: string;
+    taskId: string;
+    userId: string;
+    toolName: string;
+    args: Record<string, unknown>;
+    createdAt: number;
+}
+
+interface Waiter {
+    pending: PendingApproval;
+    resolve: (d: ApprovalDecision) => void;
+    timer: NodeJS.Timeout;
+}
+
+/**
+ * in-memory 대기 승인 레지스트리 (싱글톤). task 백그라운드 프로세스가 request() 로 대기하고
+ * REST(approve/reject)가 resolve 한다. 멀티프로세스 정합은 후속(현재 단일 워커 전제).
+ */
+export class ApprovalRegistry {
+    private waiters = new Map<string, Waiter>();
+    private seq = 0;
+
+    /** 대기 중인 승인 요청 — owner user 의 task 일시정지 UI/REST 가 조회. */
+    list(userId: string): PendingApproval[] {
+        return [...this.waiters.values()]
+            .map((w) => w.pending)
+            .filter((p) => p.userId === userId);
+    }
+
+    get(approvalId: string): PendingApproval | undefined {
+        return this.waiters.get(approvalId)?.pending;
+    }
+
+    /**
+     * 승인을 요청하고 결정(approved/rejected)을 await. timeout/abort 시 'rejected'.
+     * onPending 콜백으로 호출부가 알림(web-push/WS)·상태('paused')를 발행한다.
+     */
+    request(
+        input: { taskId: string; userId: string; toolName: string; args: Record<string, unknown> },
+        opts: { timeoutMs: number; signal?: AbortSignal; onPending?: (p: PendingApproval) => void },
+    ): Promise<ApprovalDecision> {
+        const approvalId = `apv_${input.taskId}_${this.seq++}`;
+        const pending: PendingApproval = { approvalId, ...input, createdAt: 0 };
+        return new Promise<ApprovalDecision>((resolvePromise) => {
+            const settle = (d: ApprovalDecision) => {
+                const w = this.waiters.get(approvalId);
+                if (!w) return;
+                clearTimeout(w.timer);
+                this.waiters.delete(approvalId);
+                if (d === 'rejected') logger.info(`[${input.taskId}] 승인 거절/만료: ${input.toolName}`);
+                resolvePromise(d);
+            };
+            const timer = setTimeout(() => settle('rejected'), opts.timeoutMs);
+            this.waiters.set(approvalId, { pending, resolve: settle, timer });
+            if (opts.signal) {
+                if (opts.signal.aborted) { settle('rejected'); return; }
+                opts.signal.addEventListener('abort', () => settle('rejected'), { once: true });
+            }
+            opts.onPending?.(pending);
+        });
+    }
+
+    /** REST 승인 — owner 검증은 호출부 책임. 성공 시 true. */
+    approve(approvalId: string): boolean {
+        const w = this.waiters.get(approvalId);
+        if (!w) return false;
+        w.resolve('approved');
+        return true;
+    }
+
+    /** REST 거절. */
+    reject(approvalId: string): boolean {
+        const w = this.waiters.get(approvalId);
+        if (!w) return false;
+        w.resolve('rejected');
+        return true;
+    }
+}
+
+let registry: ApprovalRegistry | null = null;
+export function getApprovalRegistry(): ApprovalRegistry {
+    if (!registry) registry = new ApprovalRegistry();
+    return registry;
+}

--- a/apps/api/src/services/task-sandbox/runtime.ts
+++ b/apps/api/src/services/task-sandbox/runtime.ts
@@ -62,7 +62,10 @@ export class TaskRuntime {
     get workspacePath(): string { return this.sandbox.hostWorkdir; }
 
     async create(): Promise<void> { await this.sandbox.create(); }
-    async cleanup(): Promise<void> { await this.sandbox.cleanup(); }
+    /** removeWorkspace=false 면 산출물 다운로드를 위해 workspace 보존(컨테이너만 제거). */
+    async cleanup(removeWorkspace = true): Promise<void> { await this.sandbox.cleanup(removeWorkspace); }
+    /** 산출물 회수용 — workspace 파일 목록(상대경로, 재귀). */
+    async listWorkspace(): Promise<string[]> { return this.sandbox.listWorkspaceFiles(); }
 
     /** task-scoped 도구를 LLM 형식으로. AgentTaskService 가 effectiveTools 에 합류. */
     getLLMTools(): ToolDefinition[] { return this.defs.map(toLLMTool); }

--- a/apps/api/src/services/task-sandbox/runtime.ts
+++ b/apps/api/src/services/task-sandbox/runtime.ts
@@ -1,0 +1,103 @@
+/**
+ * ============================================================
+ * Task Runtime — 샌드박스 + 도구 + 승인 게이트 통합 (Manus화 Phase 1 / C1)
+ * ============================================================
+ *
+ * AgentTaskService 가 task 시작 시 1개 생성한다. 영속 샌드박스 수명주기 +
+ * task-scoped 도구(LLM 형식) 노출 + 도구 실행 시 HITL 승인 게이트 적용을 캡슐화.
+ *
+ * @module services/task-sandbox/runtime
+ */
+import type { ToolDefinition } from '../../llm/types';
+import type { MCPToolDefinition } from '../../mcp/types';
+import { getTaskSandboxConfig, type TaskSandboxConfig } from '../../config/task-sandbox';
+import { TaskSandbox } from './sandbox';
+import { createTaskTools } from './tools';
+import { requiresApproval, getApprovalRegistry, type PendingApproval } from './approval-gate';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('TaskRuntime');
+
+/** MCPToolDefinition → LLM ToolDefinition 어댑터. */
+export function toLLMTool(def: MCPToolDefinition): ToolDefinition {
+    return {
+        type: 'function',
+        function: {
+            name: def.tool.name,
+            description: def.tool.description,
+            parameters: def.tool.inputSchema as ToolDefinition['function']['parameters'],
+        },
+    };
+}
+
+function resultToString(r: { content: Array<{ text?: string }>; isError?: boolean }, cap = 8000): string {
+    const text = r.content.map((c) => c.text ?? '').join('\n').slice(0, cap);
+    return r.isError ? `Error: ${text}` : text;
+}
+
+export interface ExecuteTaskToolOpts {
+    signal?: AbortSignal;
+    /** 승인 대기 진입 시 호출 — 호출부가 status='paused' + web-push/WS 발행. */
+    onApprovalPending?: (p: PendingApproval) => void;
+}
+
+export class TaskRuntime {
+    readonly taskId: string;
+    readonly userId: string;
+    private readonly cfg: TaskSandboxConfig;
+    private readonly sandbox: TaskSandbox;
+    private readonly handlers = new Map<string, MCPToolDefinition['handler']>();
+    private readonly defs: MCPToolDefinition[];
+
+    constructor(taskId: string, userId: string, cfg: TaskSandboxConfig = getTaskSandboxConfig()) {
+        this.taskId = taskId;
+        this.userId = userId;
+        this.cfg = cfg;
+        this.sandbox = new TaskSandbox(taskId, cfg);
+        this.defs = createTaskTools(this.sandbox);
+        for (const d of this.defs) this.handlers.set(d.tool.name, d.handler);
+    }
+
+    get containerName(): string { return this.sandbox.containerName; }
+    get workspacePath(): string { return this.sandbox.hostWorkdir; }
+
+    async create(): Promise<void> { await this.sandbox.create(); }
+    async cleanup(): Promise<void> { await this.sandbox.cleanup(); }
+
+    /** task-scoped 도구를 LLM 형식으로. AgentTaskService 가 effectiveTools 에 합류. */
+    getLLMTools(): ToolDefinition[] { return this.defs.map(toLLMTool); }
+
+    isTaskTool(name: string): boolean { return this.handlers.has(name); }
+
+    /**
+     * 도구 실행 — 승인 정책 적용 후 핸들러 실행. 거절 시 도구 결과로 거절 메시지 반환
+     * (루프는 정상 진행 — LLM 이 거절을 보고 대안을 모색).
+     */
+    async executeTaskTool(
+        name: string,
+        args: Record<string, unknown>,
+        opts: ExecuteTaskToolOpts = {},
+    ): Promise<string> {
+        const handler = this.handlers.get(name);
+        if (!handler) return `Error: 알 수 없는 task 도구 ${name}`;
+
+        if (requiresApproval(this.cfg.approvalPolicy, name, args)) {
+            const decision = await getApprovalRegistry().request(
+                { taskId: this.taskId, userId: this.userId, toolName: name, args },
+                { timeoutMs: this.cfg.approvalTimeoutMs, signal: opts.signal, onPending: opts.onApprovalPending },
+            );
+            if (decision !== 'approved') {
+                return `Error: 사용자가 도구 실행을 승인하지 않았습니다 (${name}). 다른 방법을 시도하거나 작업을 종료하세요.`;
+            }
+        }
+
+        try {
+            const r = await handler(args, { userId: this.userId, role: 'user' });
+            return resultToString(r as { content: Array<{ text?: string }>; isError?: boolean });
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            logger.warn(`[${this.taskId}] task 도구 실행 실패 (${name}): ${msg}`);
+            return `Error: ${msg}`;
+        }
+    }
+}

--- a/apps/api/src/services/task-sandbox/sandbox.ts
+++ b/apps/api/src/services/task-sandbox/sandbox.ts
@@ -194,6 +194,13 @@ export class TaskSandbox {
         return readdir(abs);
     }
 
+    /** workspace 내 파일/디렉토리 삭제. 경로 가드 적용. */
+    async deleteFile(relPath: string): Promise<void> {
+        const abs = safeResolveWorkspacePath(this.hostWorkdir, relPath);
+        if (abs === resolve(this.hostWorkdir)) throw new Error('workspace 루트는 삭제할 수 없습니다');
+        await rm(abs, { recursive: true, force: true });
+    }
+
     /** 컨테이너 + workspace 정리. 멱등. */
     async cleanup(): Promise<void> {
         await runProcess(this.cfg.dockerPath, ['stop', '-t', '5', this.containerName],

--- a/apps/api/src/services/task-sandbox/sandbox.ts
+++ b/apps/api/src/services/task-sandbox/sandbox.ts
@@ -1,0 +1,225 @@
+/**
+ * ============================================================
+ * Task Sandbox — Manus형 영속 가상 컴퓨터 (Phase 1 / C1)
+ * ============================================================
+ *
+ * task별 영속 Docker 컨테이너(`tail -f /dev/null`)를 생성하고, 에이전트가
+ * bash/python/파일 도구를 `docker exec` 로 반복 실행한다. workspace 볼륨이
+ * 단계 간 파일을 누적해 "가상 컴퓨터" 속성을 제공한다. (mcp/sandbox-docker.ts 의
+ * 일회성 격리와 별개 — 이쪽은 장수 컨테이너.)
+ *
+ * 보안: --cap-drop ALL · no-new-privileges · non-root · --read-only(루트) +
+ *   /workspace 볼륨만 rw · network none(기본) · mem/cpu/pids 한도 · exec timeout.
+ *   C0 PoC(9/9) 로 검증된 플래그 세트.
+ *
+ * @module services/task-sandbox/sandbox
+ */
+import { spawn } from 'child_process';
+import { mkdir, rm, writeFile as fsWriteFile, readFile as fsReadFile, readdir } from 'fs/promises';
+import { resolve, sep, join, dirname } from 'path';
+import { getTaskSandboxConfig, type TaskSandboxConfig } from '../../config/task-sandbox';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('TaskSandbox');
+
+const CONTAINER_PREFIX = 'omk-task-';
+const WORKSPACE = '/workspace';
+
+/** docker 식별자 안전화. */
+export function sanitizeId(id: string): string {
+    return id.replace(/[^A-Za-z0-9._-]/g, '_').slice(0, 64) || 'unknown';
+}
+
+/**
+ * PURE: 영속 컨테이너 `docker run` 인자 조립 (유닛테스트 대상).
+ * mcp/sandbox-docker buildDockerArgs 보안 플래그를 영속(-d + tail) 형태로 미러.
+ */
+export function buildRunArgs(
+    containerName: string,
+    hostWorkdir: string,
+    cfg: TaskSandboxConfig,
+): string[] {
+    // restricted 는 egress allowlist(proxy) 미구현 단계에서 호출부가 none 으로 다운그레이드함.
+    const net = cfg.network === 'restricted' ? 'bridge' : 'none';
+    const a: string[] = ['run', '-d', '--init', '--name', containerName];
+    a.push('--network', net);
+    a.push('--cap-drop', 'ALL', '--security-opt', 'no-new-privileges');
+    a.push('--pids-limit', String(cfg.pidsLimit), '--memory', cfg.memory, '--cpus', cfg.cpus);
+    a.push('--user', cfg.user);
+    a.push('--read-only', '--tmpfs', '/tmp:rw,exec', '--tmpfs', '/run:rw');
+    a.push('-v', `${hostWorkdir}:${WORKSPACE}:rw`);
+    a.push('-w', WORKSPACE);
+    a.push(cfg.image, 'tail', '-f', '/dev/null');
+    return a;
+}
+
+/**
+ * PURE: workspace 내부로만 해석되는 안전 경로 반환 (유닛테스트 대상).
+ * `..`/절대경로/심링크 표기로 workspace 를 탈출하려는 시도를 차단한다.
+ */
+export function safeResolveWorkspacePath(hostWorkdir: string, userPath: string): string {
+    const root = resolve(hostWorkdir);
+    const abs = resolve(root, userPath);
+    if (abs !== root && !abs.startsWith(root + sep)) {
+        throw new Error(`workspace 경로 탈출 차단: ${userPath}`);
+    }
+    return abs;
+}
+
+export interface ExecResult {
+    stdout: string;
+    stderr: string;
+    exitCode: number;
+    truncated: boolean;
+    timedOut: boolean;
+    durationMs: number;
+}
+
+/** 자식 프로세스를 실행하고 출력 캡/timeout 을 적용 (docker CLI 호출 공용). */
+function runProcess(
+    dockerPath: string,
+    args: string[],
+    opts: { timeoutMs: number; outputCap: number; input?: string },
+): Promise<ExecResult> {
+    return new Promise((resolvePromise) => {
+        const started = Date.now();
+        const child = spawn(dockerPath, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+        let stdout = '';
+        let stderr = '';
+        let truncated = false;
+        let timedOut = false;
+
+        const onData = (buf: Buffer, which: 'out' | 'err') => {
+            const cur = which === 'out' ? stdout.length : stderr.length;
+            if (cur >= opts.outputCap) { truncated = true; return; }
+            const chunk = buf.toString('utf8', 0, Math.max(0, opts.outputCap - cur));
+            if (which === 'out') stdout += chunk; else stderr += chunk;
+            if (cur + buf.length > opts.outputCap) truncated = true;
+        };
+        child.stdout.on('data', (b) => onData(b, 'out'));
+        child.stderr.on('data', (b) => onData(b, 'err'));
+
+        const timer = setTimeout(() => {
+            timedOut = true;
+            child.kill('SIGKILL');
+        }, opts.timeoutMs);
+
+        child.on('close', (code) => {
+            clearTimeout(timer);
+            resolvePromise({
+                stdout, stderr,
+                exitCode: code ?? -1,
+                truncated, timedOut,
+                durationMs: Date.now() - started,
+            });
+        });
+        child.on('error', (err) => {
+            clearTimeout(timer);
+            resolvePromise({
+                stdout, stderr: stderr + String(err),
+                exitCode: -1, truncated, timedOut,
+                durationMs: Date.now() - started,
+            });
+        });
+
+        if (opts.input !== undefined) { child.stdin.write(opts.input); }
+        child.stdin.end();
+    });
+}
+
+/**
+ * 단일 task 의 영속 샌드박스. create() → exec()/파일 I/O 반복 → cleanup().
+ * 파일 I/O 는 bind-mount 된 호스트 workdir 에 직접 수행(빠르고 docker cp 불요).
+ */
+export class TaskSandbox {
+    readonly taskId: string;
+    readonly containerName: string;
+    readonly hostWorkdir: string;
+    private readonly cfg: TaskSandboxConfig;
+    private created = false;
+
+    constructor(taskId: string, cfg: TaskSandboxConfig = getTaskSandboxConfig()) {
+        this.taskId = taskId;
+        this.cfg = cfg;
+        const safe = sanitizeId(taskId);
+        this.containerName = `${CONTAINER_PREFIX}${safe}`;
+        this.hostWorkdir = join(cfg.workspaceRoot, safe);
+    }
+
+    /** 영속 컨테이너 생성. workspace 디렉토리 준비 + docker run -d. */
+    async create(): Promise<void> {
+        if (this.created) return;
+        if (this.cfg.network === 'restricted' && this.cfg.networkAllowlist.length === 0) {
+            logger.warn(`[${this.taskId}] network=restricted 인데 allowlist 미설정 → fail-safe none 다운그레이드`);
+        }
+        await mkdir(this.hostWorkdir, { recursive: true, mode: 0o777 });
+        // 동명 잔존 컨테이너 제거(이전 비정상 종료 대비).
+        await runProcess(this.cfg.dockerPath, ['rm', '-f', this.containerName],
+            { timeoutMs: 10_000, outputCap: 4096 });
+        const args = buildRunArgs(this.containerName, this.hostWorkdir, this.cfg);
+        const r = await runProcess(this.cfg.dockerPath, args, { timeoutMs: 30_000, outputCap: 8192 });
+        if (r.exitCode !== 0) {
+            throw new Error(`task 샌드박스 생성 실패 (${this.taskId}): ${r.stderr || r.stdout}`);
+        }
+        this.created = true;
+        logger.info(`[${this.taskId}] 샌드박스 생성 (${this.containerName}, ${r.durationMs}ms)`);
+    }
+
+    /** 컨테이너 내부에서 셸 명령 실행 (bash 도구의 실행 백엔드). */
+    async exec(command: string): Promise<ExecResult> {
+        this.assertCreated();
+        return runProcess(
+            this.cfg.dockerPath,
+            ['exec', this.containerName, 'sh', '-c', command],
+            { timeoutMs: this.cfg.execTimeoutMs, outputCap: this.cfg.outputCap },
+        );
+    }
+
+    /** workspace 내 파일 쓰기 (호스트 bind-mount 직접). 경로 가드 적용. */
+    async writeFile(relPath: string, content: string): Promise<void> {
+        const abs = safeResolveWorkspacePath(this.hostWorkdir, relPath);
+        await mkdir(dirname(abs), { recursive: true });
+        await fsWriteFile(abs, content, 'utf8');
+    }
+
+    /** workspace 내 파일 읽기. 경로 가드 적용. */
+    async readFile(relPath: string): Promise<string> {
+        const abs = safeResolveWorkspacePath(this.hostWorkdir, relPath);
+        return fsReadFile(abs, 'utf8');
+    }
+
+    /** workspace 내 디렉토리 목록. 경로 가드 적용. */
+    async listDir(relPath = '.'): Promise<string[]> {
+        const abs = safeResolveWorkspacePath(this.hostWorkdir, relPath);
+        return readdir(abs);
+    }
+
+    /** 컨테이너 + workspace 정리. 멱등. */
+    async cleanup(): Promise<void> {
+        await runProcess(this.cfg.dockerPath, ['stop', '-t', '5', this.containerName],
+            { timeoutMs: 15_000, outputCap: 4096 });
+        await runProcess(this.cfg.dockerPath, ['rm', '-f', this.containerName],
+            { timeoutMs: 10_000, outputCap: 4096 });
+        try { await rm(this.hostWorkdir, { recursive: true, force: true }); } catch { /* best-effort */ }
+        this.created = false;
+        logger.info(`[${this.taskId}] 샌드박스 정리`);
+    }
+
+    private assertCreated(): void {
+        if (!this.created) throw new Error(`샌드박스 미생성 (${this.taskId}) — create() 선행 필요`);
+    }
+}
+
+/**
+ * 부팅 시 고아 task 컨테이너(omk-task-*) 청소 — 비정상 종료로 남은 컨테이너 회수.
+ */
+export async function reapOrphanTaskSandboxes(cfg: TaskSandboxConfig = getTaskSandboxConfig()): Promise<number> {
+    const list = await runProcess(cfg.dockerPath,
+        ['ps', '-aq', '--filter', `name=${CONTAINER_PREFIX}`], { timeoutMs: 10_000, outputCap: 65536 });
+    const ids = list.stdout.split('\n').map((s) => s.trim()).filter(Boolean);
+    for (const id of ids) {
+        await runProcess(cfg.dockerPath, ['rm', '-f', id], { timeoutMs: 10_000, outputCap: 4096 });
+    }
+    if (ids.length) logger.info(`고아 task 샌드박스 ${ids.length}개 청소`);
+    return ids.length;
+}

--- a/apps/api/src/services/task-sandbox/sandbox.ts
+++ b/apps/api/src/services/task-sandbox/sandbox.ts
@@ -16,7 +16,7 @@
  */
 import { spawn } from 'child_process';
 import { mkdir, rm, writeFile as fsWriteFile, readFile as fsReadFile, readdir } from 'fs/promises';
-import { resolve, sep, join, dirname } from 'path';
+import { resolve, sep, join, dirname, relative } from 'path';
 import { getTaskSandboxConfig, type TaskSandboxConfig } from '../../config/task-sandbox';
 import { createLogger } from '../../utils/logger';
 
@@ -194,6 +194,11 @@ export class TaskSandbox {
         return readdir(abs);
     }
 
+    /** 산출물 회수용 — workspace 전체 파일을 상대경로로 재귀 나열. */
+    async listWorkspaceFiles(): Promise<string[]> {
+        return listWorkspaceFilesAt(this.hostWorkdir);
+    }
+
     /** workspace 내 파일/디렉토리 삭제. 경로 가드 적용. */
     async deleteFile(relPath: string): Promise<void> {
         const abs = safeResolveWorkspacePath(this.hostWorkdir, relPath);
@@ -201,20 +206,46 @@ export class TaskSandbox {
         await rm(abs, { recursive: true, force: true });
     }
 
-    /** 컨테이너 + workspace 정리. 멱등. */
-    async cleanup(): Promise<void> {
+    /**
+     * 컨테이너 정리. 멱등. removeWorkspace=true(기본) 면 workspace 도 삭제,
+     * false 면 산출물 회수(다운로드)를 위해 workspace 를 보존하고 컨테이너만 제거한다.
+     */
+    async cleanup(removeWorkspace = true): Promise<void> {
         await runProcess(this.cfg.dockerPath, ['stop', '-t', '5', this.containerName],
             { timeoutMs: 15_000, outputCap: 4096 });
         await runProcess(this.cfg.dockerPath, ['rm', '-f', this.containerName],
             { timeoutMs: 10_000, outputCap: 4096 });
-        try { await rm(this.hostWorkdir, { recursive: true, force: true }); } catch { /* best-effort */ }
+        if (removeWorkspace) {
+            try { await rm(this.hostWorkdir, { recursive: true, force: true }); } catch { /* best-effort */ }
+        }
         this.created = false;
-        logger.info(`[${this.taskId}] 샌드박스 정리`);
+        logger.info(`[${this.taskId}] 샌드박스 정리 (workspace ${removeWorkspace ? '삭제' : '보존'})`);
     }
 
     private assertCreated(): void {
         if (!this.created) throw new Error(`샌드박스 미생성 (${this.taskId}) — create() 선행 필요`);
     }
+}
+
+/**
+ * 주어진 workspace 디렉토리의 전체 파일을 상대경로로 재귀 나열 (산출물 다운로드 엔드포인트용).
+ * 라이브 TaskSandbox 인스턴스 없이도 동작(task 완료 후 workspace_path 로 호출).
+ */
+export async function listWorkspaceFilesAt(root: string, maxFiles = 1000): Promise<string[]> {
+    const out: string[] = [];
+    async function walk(dir: string): Promise<void> {
+        if (out.length >= maxFiles) return;
+        let entries;
+        try { entries = await readdir(dir, { withFileTypes: true }); } catch { return; }
+        for (const e of entries) {
+            if (out.length >= maxFiles) return;
+            const full = join(dir, e.name);
+            if (e.isDirectory()) await walk(full);
+            else out.push(relative(root, full));
+        }
+    }
+    await walk(resolve(root));
+    return out.sort();
 }
 
 /**

--- a/apps/api/src/services/task-sandbox/sandbox.ts
+++ b/apps/api/src/services/task-sandbox/sandbox.ts
@@ -15,7 +15,7 @@
  * @module services/task-sandbox/sandbox
  */
 import { spawn } from 'child_process';
-import { mkdir, rm, writeFile as fsWriteFile, readFile as fsReadFile, readdir } from 'fs/promises';
+import { mkdir, rm, writeFile as fsWriteFile, readFile as fsReadFile, readdir, stat } from 'fs/promises';
 import { resolve, sep, join, dirname, relative } from 'path';
 import { getTaskSandboxConfig, type TaskSandboxConfig } from '../../config/task-sandbox';
 import { createLogger } from '../../utils/logger';
@@ -246,6 +246,32 @@ export async function listWorkspaceFilesAt(root: string, maxFiles = 1000): Promi
     }
     await walk(resolve(root));
     return out.sort();
+}
+
+/**
+ * workspace 보존 TTL 스윕 — workspaceRoot 하위에서 mtime 이 TTL 초과한 디렉토리를 삭제.
+ * 완료 task 의 산출물 workspace 가 무한 누적되는 것을 막는다(now 는 호출부가 주입 — 결정성).
+ */
+export async function reapStaleWorkspaces(
+    nowMs: number,
+    cfg: TaskSandboxConfig = getTaskSandboxConfig(),
+): Promise<number> {
+    let removed = 0;
+    let entries;
+    try { entries = await readdir(cfg.workspaceRoot, { withFileTypes: true }); } catch { return 0; }
+    for (const e of entries) {
+        if (!e.isDirectory()) continue;
+        const dir = join(cfg.workspaceRoot, e.name);
+        try {
+            const s = await stat(dir);
+            if (nowMs - s.mtimeMs > cfg.workspaceTtlMs) {
+                await rm(dir, { recursive: true, force: true });
+                removed++;
+            }
+        } catch { /* best-effort */ }
+    }
+    if (removed) logger.info(`stale workspace ${removed}개 정리(TTL ${cfg.workspaceTtlMs}ms)`);
+    return removed;
 }
 
 /**

--- a/apps/api/src/services/task-sandbox/tools.ts
+++ b/apps/api/src/services/task-sandbox/tools.ts
@@ -1,0 +1,205 @@
+/**
+ * ============================================================
+ * Task Sandbox Tools — 영속 샌드박스에서 동작하는 에이전트 도구 (Phase 1 / C1)
+ * ============================================================
+ *
+ * OpenManus ToolCollection[PythonExecute, BrowserUseTool, StrReplaceEditor,
+ * AskHuman, Terminate] 대응. task별 TaskSandbox 인스턴스를 클로저로 바인딩하는
+ * factory(createTaskTools) 로 제공한다 — 전역 builtInTools 가 아닌 task-scoped.
+ *
+ * B 흡수(루프 로버스트니스): terminate(완료 시그널) + ask_human(HITL pause).
+ * 두 도구는 sentinel 결과를 반환하고, 실제 루프 해석(종료/일시정지)은 AgentTaskService
+ * 배선 증분에서 처리한다(현재 미배선 — 운영 안전).
+ *
+ * @module services/task-sandbox/tools
+ */
+import type { MCPToolDefinition, MCPToolResult } from '../../mcp/types';
+import type { TaskSandbox, ExecResult } from './sandbox';
+
+/** 루프가 인식하는 제어 시그널 sentinel (도구 결과 텍스트 prefix). */
+export const TASK_TERMINATE_SENTINEL = '__TASK_TERMINATE__';
+export const TASK_ASK_HUMAN_SENTINEL = '__TASK_ASK_HUMAN__';
+
+function textResult(text: string, isError = false): MCPToolResult {
+    return { content: [{ type: 'text', text }], isError };
+}
+
+/** exec 결과를 LLM 친화 텍스트로 포맷. */
+function formatExec(r: ExecResult): MCPToolResult {
+    const parts: string[] = [];
+    if (r.stdout) parts.push(`[stdout]\n${r.stdout}`);
+    if (r.stderr) parts.push(`[stderr]\n${r.stderr}`);
+    parts.push(`[exit=${r.exitCode}${r.timedOut ? ' TIMEOUT' : ''}${r.truncated ? ' TRUNCATED' : ''} ${r.durationMs}ms]`);
+    return textResult(parts.join('\n'), r.exitCode !== 0 || r.timedOut);
+}
+
+function str(v: unknown): string { return typeof v === 'string' ? v : ''; }
+
+/**
+ * task별 도구 세트 생성. AgentTaskService 가 task 시작 시 TaskSandbox 와 함께 호출해
+ * effectiveTools 에 합류시킨다.
+ */
+export function createTaskTools(sandbox: TaskSandbox): MCPToolDefinition[] {
+    const bash: MCPToolDefinition = {
+        tool: {
+            name: 'bash',
+            description: '영속 작업 컨테이너(/workspace)에서 셸 명령을 실행합니다. 파일은 단계 간 유지됩니다. ' +
+                'git/curl/ripgrep/python3/node 사용 가능. 네트워크는 정책에 따라 제한될 수 있습니다.',
+            inputSchema: {
+                type: 'object',
+                properties: { command: { type: 'string', description: '실행할 셸 명령' } },
+                required: ['command'],
+            },
+        },
+        handler: async (args): Promise<MCPToolResult> => {
+            const command = str(args.command).trim();
+            if (!command) return textResult('command 가 필요합니다.', true);
+            return formatExec(await sandbox.exec(command));
+        },
+    };
+
+    const pythonExecute: MCPToolDefinition = {
+        tool: {
+            name: 'python_execute',
+            description: '/workspace 에 Python 코드를 파일로 저장하고 실행합니다. 결과(stdout/stderr)를 반환합니다.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    code: { type: 'string', description: '실행할 Python 코드' },
+                    filename: { type: 'string', description: '저장 파일명 (기본 _exec.py)' },
+                },
+                required: ['code'],
+            },
+        },
+        handler: async (args): Promise<MCPToolResult> => {
+            const code = str(args.code);
+            if (!code) return textResult('code 가 필요합니다.', true);
+            const filename = str(args.filename) || '_exec.py';
+            try {
+                await sandbox.writeFile(filename, code);
+            } catch (e) {
+                return textResult(`파일 쓰기 실패: ${e instanceof Error ? e.message : String(e)}`, true);
+            }
+            return formatExec(await sandbox.exec(`python3 ${filename}`));
+        },
+    };
+
+    const strReplaceEditor: MCPToolDefinition = {
+        tool: {
+            name: 'str_replace_editor',
+            description: '/workspace 파일을 보고/생성/편집합니다. command: view(보기) | create(생성) | ' +
+                'str_replace(문자열 치환) | insert(라인 삽입).',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    command: { type: 'string', description: 'view | create | str_replace | insert' },
+                    path: { type: 'string', description: 'workspace 상대 경로' },
+                    file_text: { type: 'string', description: 'create 시 전체 내용' },
+                    old_str: { type: 'string', description: 'str_replace 시 찾을 문자열(유일해야 함)' },
+                    new_str: { type: 'string', description: 'str_replace/insert 시 새 문자열' },
+                    insert_line: { type: 'number', description: 'insert 시 이 라인 뒤에 삽입(0=맨 앞)' },
+                },
+                required: ['command', 'path'],
+            },
+        },
+        handler: async (args): Promise<MCPToolResult> => {
+            const command = str(args.command);
+            const path = str(args.path);
+            if (!path) return textResult('path 가 필요합니다.', true);
+            try {
+                if (command === 'create') {
+                    await sandbox.writeFile(path, str(args.file_text));
+                    return textResult(`생성됨: ${path}`);
+                }
+                if (command === 'view') {
+                    const content = await sandbox.readFile(path);
+                    return textResult(content);
+                }
+                if (command === 'str_replace') {
+                    const oldStr = str(args.old_str);
+                    if (!oldStr) return textResult('old_str 가 필요합니다.', true);
+                    const content = await sandbox.readFile(path);
+                    const count = content.split(oldStr).length - 1;
+                    if (count === 0) return textResult(`old_str 를 찾을 수 없습니다: ${path}`, true);
+                    if (count > 1) return textResult(`old_str 가 ${count}회 중복 — 유일해야 합니다.`, true);
+                    await sandbox.writeFile(path, content.replace(oldStr, str(args.new_str)));
+                    return textResult(`치환 완료: ${path}`);
+                }
+                if (command === 'insert') {
+                    const content = await sandbox.readFile(path);
+                    const lines = content.split('\n');
+                    const at = Math.max(0, Math.min(lines.length, Number(args.insert_line) || 0));
+                    lines.splice(at, 0, str(args.new_str));
+                    await sandbox.writeFile(path, lines.join('\n'));
+                    return textResult(`삽입 완료: ${path}:${at}`);
+                }
+                return textResult(`알 수 없는 command: ${command}`, true);
+            } catch (e) {
+                return textResult(`편집 실패: ${e instanceof Error ? e.message : String(e)}`, true);
+            }
+        },
+    };
+
+    const fileOps: MCPToolDefinition = {
+        tool: {
+            name: 'file_ops',
+            description: '/workspace 파일 작업: op=read | write | list | delete.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    op: { type: 'string', description: 'read | write | list | delete' },
+                    path: { type: 'string', description: 'workspace 상대 경로 (list 는 기본 ".")' },
+                    content: { type: 'string', description: 'write 시 내용' },
+                },
+                required: ['op'],
+            },
+        },
+        handler: async (args): Promise<MCPToolResult> => {
+            const op = str(args.op);
+            const path = str(args.path);
+            try {
+                if (op === 'read') return textResult(await sandbox.readFile(path));
+                if (op === 'write') { await sandbox.writeFile(path, str(args.content)); return textResult(`기록됨: ${path}`); }
+                if (op === 'list') return textResult((await sandbox.listDir(path || '.')).join('\n') || '(빈 디렉토리)');
+                if (op === 'delete') { await sandbox.deleteFile(path); return textResult(`삭제됨: ${path}`); }
+                return textResult(`알 수 없는 op: ${op}`, true);
+            } catch (e) {
+                return textResult(`파일 작업 실패: ${e instanceof Error ? e.message : String(e)}`, true);
+            }
+        },
+    };
+
+    // ── B 흡수: 제어 시그널 도구 (sandbox 무관) ──
+    const terminate: MCPToolDefinition = {
+        tool: {
+            name: 'terminate',
+            description: '작업을 완료했거나 더 진행할 수 없을 때 호출해 task 를 종료합니다.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    status: { type: 'string', description: 'success | failure' },
+                    summary: { type: 'string', description: '결과 요약' },
+                },
+                required: ['status'],
+            },
+        },
+        handler: async (args): Promise<MCPToolResult> =>
+            textResult(`${TASK_TERMINATE_SENTINEL} ${str(args.status) || 'success'}: ${str(args.summary)}`),
+    };
+
+    const askHuman: MCPToolDefinition = {
+        tool: {
+            name: 'ask_human',
+            description: '진행에 사용자 입력/승인이 필요할 때 호출합니다. task 가 일시정지되고 사용자에게 알림이 갑니다.',
+            inputSchema: {
+                type: 'object',
+                properties: { question: { type: 'string', description: '사용자에게 물을 질문' } },
+                required: ['question'],
+            },
+        },
+        handler: async (args): Promise<MCPToolResult> =>
+            textResult(`${TASK_ASK_HUMAN_SENTINEL} ${str(args.question)}`),
+    };
+
+    return [bash, pythonExecute, strReplaceEditor, fileOps, terminate, askHuman];
+}

--- a/apps/web/app/(workspace)/agent-tasks/page.tsx
+++ b/apps/web/app/(workspace)/agent-tasks/page.tsx
@@ -29,7 +29,7 @@ import { ApiClient } from "@/lib/api-client";
 
 /* ── 타입 ────────────────────────────────────────────────── */
 type TaskStatus = "running" | "completed" | "pending";
-type ApiTaskStatus = "pending" | "running" | "completed" | "failed" | "cancelled";
+type ApiTaskStatus = "pending" | "running" | "paused" | "completed" | "failed" | "cancelled";
 
 interface ChecklistItem {
   label: string;
@@ -79,7 +79,7 @@ type AgentTaskDetailResponse = ApiSuccess<{ task: ApiAgentTask; steps: ApiTaskSt
 
 /* ── 유틸 ────────────────────────────────────────────────── */
 function mapStatus(s: ApiTaskStatus): TaskStatus {
-  if (s === "running") return "running";
+  if (s === "running" || s === "paused") return "running";
   if (s === "completed" || s === "failed" || s === "cancelled") return "completed";
   return "pending";
 }
@@ -363,6 +363,89 @@ function TaskDetailModal({
 }
 
 /* ── 메인 페이지 ──────────────────────────────────────────── */
+/* ── 승인 대기 패널 (HITL 게이트) ──────────────────────────── */
+interface PendingApproval {
+  approvalId: string;
+  taskId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+}
+type ApprovalsResponse = ApiSuccess<{ pending: PendingApproval[] }>;
+
+function ApprovalsPanel() {
+  const [pending, setPending] = useState<PendingApproval[]>([]);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await ApiClient.get<ApprovalsResponse>("/api/agent-tasks/approvals/pending");
+      setPending(res?.data?.pending ?? []);
+    } catch {
+      // 401·네트워크: 빈 목록 유지
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+    const id = setInterval(load, 4000);
+    return () => clearInterval(id);
+  }, [load]);
+
+  async function decide(approvalId: string, decision: "approve" | "reject") {
+    setBusy(approvalId);
+    try {
+      await ApiClient.post(`/api/agent-tasks/approvals/${approvalId}/${decision}`, {});
+      await load();
+    } catch (err) {
+      alert("처리 실패: " + (err instanceof Error ? err.message : "오류"));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (pending.length === 0) return null;
+
+  return (
+    <Card className="mb-4 p-4">
+      <p className="mb-3 text-sm font-medium text-fg-2">
+        승인 대기 중인 도구 실행 ({pending.length})
+      </p>
+      <div className="space-y-2">
+        {pending.map((p) => (
+          <div
+            key={p.approvalId}
+            className="flex items-center justify-between gap-3 rounded-md border border-line bg-bg-1 p-2"
+          >
+            <div className="min-w-0">
+              <span className="font-mono text-xs text-fg-2">{p.toolName}</span>
+              <span className="ml-2 break-all text-xs text-muted">
+                {JSON.stringify(p.args).slice(0, 100)}
+              </span>
+            </div>
+            <div className="flex shrink-0 gap-1">
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={busy === p.approvalId}
+                onClick={() => decide(p.approvalId, "reject")}
+              >
+                거절
+              </Button>
+              <Button
+                size="sm"
+                disabled={busy === p.approvalId}
+                onClick={() => decide(p.approvalId, "approve")}
+              >
+                승인
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
 export default function AgentTasksPage() {
   const [tasks, setTasks] = useState<AgentTask[]>(TASK_FALLBACK);
   const [loading, setLoading] = useState(true);
@@ -452,6 +535,7 @@ export default function AgentTasksPage() {
       />
 
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
+        <ApprovalsPanel />
         {loading ? (
           <div className="grid place-items-center py-24 text-center">
             <Sparkles className="mb-3 h-8 w-8 animate-pulse text-faint" />

--- a/db/migrations/048_agent_task_sandbox.sql
+++ b/db/migrations/048_agent_task_sandbox.sql
@@ -1,0 +1,11 @@
+-- 048: Agent Task 영속 샌드박스 추적 컬럼 (Manus화 Phase 1 / C1)
+--
+-- 자율 에이전트 task 가 사용하는 영속 Docker 컨테이너(services/task-sandbox)와
+-- 호스트 workspace 디렉토리를 추적한다. 비정상 종료 시 정리·복구(orphan reaping)에 사용.
+-- 멱등 작성 — 재실행 안전. (수동 적용: cli.ts migrate)
+
+ALTER TABLE agent_tasks ADD COLUMN IF NOT EXISTS sandbox_container_id TEXT;
+ALTER TABLE agent_tasks ADD COLUMN IF NOT EXISTS workspace_path TEXT;
+
+COMMENT ON COLUMN agent_tasks.sandbox_container_id IS 'task 영속 샌드박스 컨테이너 이름/ID (omk-task-*). 정리·복구용.';
+COMMENT ON COLUMN agent_tasks.workspace_path IS 'task 호스트 workspace 디렉토리 경로. 산출물 회수·정리용.';

--- a/db/migrations/049_agent_task_paused_status.sql
+++ b/db/migrations/049_agent_task_paused_status.sql
@@ -1,0 +1,9 @@
+-- 049: Agent Task 'paused' 상태 추가 (Manus화 Phase 1 / C1 — HITL 승인 게이트)
+--
+-- 도구 실행 승인 대기 중 task 를 'paused' 로 표시한다(ask_human / 전부-승인 정책).
+-- 기존 status CHECK 제약을 교체. 멱등 — 재실행 안전(DROP IF EXISTS 후 재생성).
+-- (수동 적용: cli.ts migrate)
+
+ALTER TABLE agent_tasks DROP CONSTRAINT IF EXISTS agent_tasks_status_check;
+ALTER TABLE agent_tasks ADD CONSTRAINT agent_tasks_status_check
+    CHECK (status IN ('pending', 'running', 'paused', 'completed', 'failed', 'cancelled'));

--- a/infra/task-runtime/Dockerfile
+++ b/infra/task-runtime/Dockerfile
@@ -1,0 +1,26 @@
+# OpenMake Task Runtime — Manus형 자율 에이전트의 영속 task 샌드박스 이미지
+#
+# 목적: services/task-sandbox 가 `docker run -d ... openmake-task-runtime tail -f /dev/null`
+#   로 task별 영속 컨테이너(가상 컴퓨터)를 띄우고, 에이전트가 bash/python/파일도구를
+#   `docker exec` 로 반복 실행한다. mcp-runtime(외부 MCP 격리, 일회성)과 별개.
+#
+# mcp-runtime 대비 차이: 실작업(repo clone·fetch·grep·build)이 상시 요구하는
+#   git / curl / ripgrep 를 영구 포함(mcp-runtime 은 curl 을 purge 함).
+#
+# 빌드 (사용자 직접 — 호스트에서 1회):
+#   docker build -t openmake-task-runtime:latest infra/task-runtime
+#
+# workspace 볼륨(/workspace)·캐시는 services/task-sandbox 가 런타임에 마운트.
+FROM openmake-mcp-runtime:latest
+
+# 실작업 상시 도구 — root 로 설치 후 비-root(node)로 복귀.
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git curl ca-certificates ripgrep \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# workspace 마운트 지점 — node(uid 1000) 소유로 미리 생성(빈 볼륨 첫 마운트 시 소유권 상속).
+RUN mkdir -p /workspace && chown node:node /workspace
+
+USER node
+WORKDIR /workspace


### PR DESCRIPTION
## 배경

OpenMake LLM 을 **Manus형 자율 에이전트**(목표를 주면 영속 가상 컴퓨터에서 스스로 실행)로 고도화하는 Phase 1. OpenManus(FoundationAgents) 4-레이어 아키텍처를 레퍼런스로, 기존 AgentTaskService(자율 루프)·MCP Docker 격리·web-push 위에 빠진 레이어를 구축.

전부 `TASK_SANDBOX_ENABLED=false` 게이트 → **OFF 시 기존 Agent Task 와 100% 동일**.

## 구현 (9 커밋)

### ③ 영속 샌드박스 (키스톤)
- `services/task-sandbox/sandbox.ts` — `TaskSandbox`: task별 장수 컨테이너(`tail -f /dev/null`) + workspace 볼륨으로 **단계 간 파일 누적**. create/exec/read/write/listDir/deleteFile/cleanup + orphan/TTL 청소.
- `infra/task-runtime/Dockerfile` — mcp-runtime + git/curl/ripgrep.
- 보안: cap-drop ALL·no-new-privileges·non-root·read-only 루트(+/workspace rw)·network none·mem/cpu/pids 한도·exec timeout·경로탈출 가드.

### ② 도구
- `bash` · `python_execute` · `str_replace_editor` · `file_ops` (task별 factory 바인딩).

### 🔐 승인 게이트 (신규 — `AgentTaskService.ts:296` 이 예고한 "write 도구 시 gate 필요" 충족)
- `approval-gate.ts` — 정책(all/high-risk/none, 기본 **all**) + ApprovalRegistry(in-loop 대기, timeout/abort→reject).
- 도구 호출 시 task `paused` → web-push 알림 → REST 승인 → `running`.

### ① 라이브 배선 + B 흡수
- AgentTaskService: 샌드박스 수명주기 + 도구 합류 + 승인 경유 실행 + terminate(완료)/finally cleanup.
- B(루프 로버스트니스): **terminate · ask_human · stuck 감지**(OpenManus is_stuck).

### 산출물 + UI + 후속
- 완료 시 workspace 보존 + 다운로드 REST(`/:taskId/files`, `/download`).
- apps/web `ApprovalsPanel`(폴링 승인/거절) + `paused` 상태.
- 누적 토큰 상한 env 외부화(200k→1M) — 멀티턴 완주.
- DB 마이그레이션 048(추적 컬럼)/049(paused 상태). workspace TTL 스윕.

## 검증

- [x] tsc 0 / eslint 0 / `build:backend` 성공
- [x] 유닛 38 + 실 docker 통합 8 + 기존 agent-task 5(회귀 없음)
- [x] **라이브 E2E 완주**: 샌드박스 생성→bash(승인 게이트 paused→approve→running)→`echo > out.txt`(exit0)→`cat`="hello manus sandbox"→terminate→**completed**, workspace 보존(out.txt="done") 확인

## 운영

- 활성화(수동): `docker build -t openmake-task-runtime:latest infra/task-runtime` → migrate 048/049 → `TASK_SANDBOX_ENABLED=true` → 재시작. **현재 운영 ON 상태.**
- 롤백: 플래그 `false` + 재시작.
- 환경변수: `.env.example` 의 `TASK_SANDBOX_*`, `AGENT_MAX_TOTAL_TOKENS`.

## 남은 페이즈
G2 브라우저 도구 · G3 플래닝 레이어 · G5 라이브 패널 (별도 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)