### PR TITLE
feat: Manus화 G2 — 컨테이너 내 브라우저 자동화 도구 (playwright chromium)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -722,7 +722,10 @@ TASK_SANDBOX_ENABLED=false
 # TASK_SANDBOX_IMAGE=openmake-task-runtime:latest      # task 런타임 이미지(mcp-runtime + git/curl/ripgrep)
 # TASK_SANDBOX_ROOT=/tmp/openmake-task-workspaces      # 호스트 workspace 루트(task별 하위 디렉토리)
 # TASK_SANDBOX_MAX_CONCURRENT=8                        # 동시 활성 컨테이너 상한
-# TASK_SANDBOX_NETWORK=none                            # none | restricted(allowlist, fast-follow). full 미허용
+# TASK_SANDBOX_NETWORK=none                            # none | restricted. browser 도구(G2)는 restricted 필요.
+#   restricted=컨테이너 bridge 네트워크 + browser-runner page.route 도메인 allowlist(브라우저 egress 차단).
+#   주의: bridge 는 bash/python 에도 네트워크를 열어줌(allowlist 미적용) — 매 도구호출 승인(APPROVAL_POLICY=all)
+#   이 사람-게이트 역할. 완전한 bash/python egress 제한(프록시/방화벽)은 후속.
 # TASK_SANDBOX_NETWORK_ALLOWLIST=                      # restricted 시 egress 허용 도메인(쉼표)
 # TASK_SANDBOX_MEMORY=1g                               # 컨테이너 메모리 상한
 # TASK_SANDBOX_CPUS=1.0                                # CPU 상한

--- a/apps/api/src/services/task-sandbox/approval-gate.ts
+++ b/apps/api/src/services/task-sandbox/approval-gate.ts
@@ -19,8 +19,8 @@ import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('TaskApprovalGate');
 
-/** 승인이 필요한 고위험 도구(high-risk 정책 시). */
-const HIGH_RISK_TOOLS = new Set(['bash']);
+/** 승인이 필요한 고위험 도구(high-risk 정책 시). browser=네트워크 egress. */
+const HIGH_RISK_TOOLS = new Set(['bash', 'browser']);
 /** 고위험으로 보는 file_ops 작업. */
 const HIGH_RISK_FILE_OPS = new Set(['delete']);
 

--- a/apps/api/src/services/task-sandbox/tools.ts
+++ b/apps/api/src/services/task-sandbox/tools.ts
@@ -169,6 +169,46 @@ export function createTaskTools(sandbox: TaskSandbox): MCPToolDefinition[] {
         },
     };
 
+    const browser: MCPToolDefinition = {
+        tool: {
+            name: 'browser',
+            description: '영속 컨테이너 내 chromium 으로 웹 브라우저를 자동화합니다(G2). actions 배열을 순서대로 실행: ' +
+                'goto{url} · click{selector} · fill{selector,text} · press{key} · wait{ms} · waitFor{selector} · ' +
+                'screenshot{path?} · extractText{selector?} · extractHtml{selector?}. 결과를 JSON 으로 반환합니다. ' +
+                '네트워크는 샌드박스 정책(none/restricted)에 따라 제한됩니다.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    actions: {
+                        type: 'array',
+                        description: '액션 객체 배열. 예: [{"type":"goto","url":"https://example.com"},{"type":"extractText"}]',
+                    },
+                    allowlist: {
+                        type: 'array',
+                        description: '허용 도메인 목록(예 ["example.com"]). 비허용 호스트 요청은 차단됩니다.',
+                    },
+                },
+                required: ['actions'],
+            },
+        },
+        handler: async (args): Promise<MCPToolResult> => {
+            const actions = args.actions;
+            if (!Array.isArray(actions) || actions.length === 0) {
+                return textResult('actions 배열이 필요합니다.', true);
+            }
+            const spec = {
+                actions,
+                ...(Array.isArray(args.allowlist) ? { allowlist: args.allowlist } : {}),
+            };
+            try {
+                await sandbox.writeFile('.browser-actions.json', JSON.stringify(spec));
+            } catch (e) {
+                return textResult(`액션 파일 쓰기 실패: ${e instanceof Error ? e.message : String(e)}`, true);
+            }
+            return formatExec(await sandbox.exec('node /opt/browser/browser-runner.mjs .browser-actions.json'));
+        },
+    };
+
     // ── B 흡수: 제어 시그널 도구 (sandbox 무관) ──
     const terminate: MCPToolDefinition = {
         tool: {
@@ -201,5 +241,5 @@ export function createTaskTools(sandbox: TaskSandbox): MCPToolDefinition[] {
             textResult(`${TASK_ASK_HUMAN_SENTINEL} ${str(args.question)}`),
     };
 
-    return [bash, pythonExecute, strReplaceEditor, fileOps, terminate, askHuman];
+    return [bash, pythonExecute, strReplaceEditor, fileOps, browser, terminate, askHuman];
 }

--- a/infra/task-runtime/Dockerfile
+++ b/infra/task-runtime/Dockerfile
@@ -1,26 +1,34 @@
 # OpenMake Task Runtime — Manus형 자율 에이전트의 영속 task 샌드박스 이미지
 #
 # 목적: services/task-sandbox 가 `docker run -d ... openmake-task-runtime tail -f /dev/null`
-#   로 task별 영속 컨테이너(가상 컴퓨터)를 띄우고, 에이전트가 bash/python/파일도구를
-#   `docker exec` 로 반복 실행한다. mcp-runtime(외부 MCP 격리, 일회성)과 별개.
+#   로 task별 영속 컨테이너(가상 컴퓨터)를 띄우고, 에이전트가 bash/python/파일/브라우저
+#   도구를 `docker exec` 로 반복 실행한다. (mcp-runtime 의 일회성 격리와 별개.)
 #
-# mcp-runtime 대비 차이: 실작업(repo clone·fetch·grep·build)이 상시 요구하는
-#   git / curl / ripgrep 를 영구 포함(mcp-runtime 은 curl 을 purge 함).
+# mcp-runtime 대비 차이: 실작업 상시 도구(git/curl/ripgrep) + G2 브라우저 자동화용
+#   playwright chromium(컨테이너 내부 격리 실행).
 #
-# 빌드 (사용자 직접 — 호스트에서 1회):
+# 빌드 (사용자 직접 — 호스트에서 1회, chromium 다운로드로 수 분 소요):
 #   docker build -t openmake-task-runtime:latest infra/task-runtime
-#
-# workspace 볼륨(/workspace)·캐시는 services/task-sandbox 가 런타임에 마운트.
 FROM openmake-mcp-runtime:latest
 
-# 실작업 상시 도구 — root 로 설치 후 비-root(node)로 복귀.
 USER root
+# 브라우저는 /opt 에 self-contained 설치(node uid 1000 도 읽기 가능). 캐시 분리.
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
+
+# 실작업 상시 도구 + playwright chromium(+OS 의존성). root 설치 후 비-root 복귀.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git curl ca-certificates ripgrep \
+    && mkdir -p /workspace /opt/browser \
+    && chown node:node /workspace \
+    && cd /opt/browser && npm init -y >/dev/null 2>&1 \
+    && npm install playwright@1.49.0 \
+    && npx playwright install --with-deps chromium \
+    && chmod -R a+rX /opt/ms-playwright /opt/browser \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# workspace 마운트 지점 — node(uid 1000) 소유로 미리 생성(빈 볼륨 첫 마운트 시 소유권 상속).
-RUN mkdir -p /workspace && chown node:node /workspace
+# 브라우저 액션 러너 — `node /opt/browser/browser-runner.mjs <actions.json>`.
+COPY browser-runner.mjs /opt/browser/browser-runner.mjs
+RUN chmod a+r /opt/browser/browser-runner.mjs
 
 USER node
 WORKDIR /workspace

--- a/infra/task-runtime/browser-runner.mjs
+++ b/infra/task-runtime/browser-runner.mjs
@@ -1,0 +1,114 @@
+/**
+ * browser-runner — task 샌드박스 컨테이너 내부에서 playwright chromium 으로
+ * 액션 시퀀스를 실행한다(Manus화 G2). 호스트가 아닌 컨테이너 내 격리 실행.
+ *
+ * 사용: node /opt/browser/browser-runner.mjs <actionsJsonPath(/workspace 상대 또는 절대)>
+ * 입력 JSON: { actions: [...], allowlist?: ["example.com"], timeoutMs?: number, headless?: bool }
+ * 출력(stdout): { ok, finalUrl, results: [...], error? }
+ *
+ * egress 제어: allowlist 가 있으면 context.route 로 비허용 호스트 요청을 abort
+ *   (브라우저 레벨 도메인 화이트리스트 — 컨테이너 network=bridge 의 over-reach 를 좁힘).
+ */
+import { chromium } from 'playwright';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const WORKSPACE = '/workspace';
+const MAX_ACTIONS = 40;
+const DEFAULT_TIMEOUT = 20000;
+
+function out(obj) { process.stdout.write(JSON.stringify(obj)); }
+
+const argPath = process.argv[2];
+if (!argPath) { out({ ok: false, error: 'actions JSON 경로 인자 필요' }); process.exit(1); }
+
+let spec;
+try {
+    const abs = argPath.startsWith('/') ? argPath : resolve(WORKSPACE, argPath);
+    spec = JSON.parse(readFileSync(abs, 'utf8'));
+} catch (e) {
+    out({ ok: false, error: `actions JSON 읽기 실패: ${e.message}` });
+    process.exit(1);
+}
+
+const actions = Array.isArray(spec.actions) ? spec.actions.slice(0, MAX_ACTIONS) : [];
+const timeout = Number(spec.timeoutMs) > 0 ? Number(spec.timeoutMs) : DEFAULT_TIMEOUT;
+const allowlist = Array.isArray(spec.allowlist) ? spec.allowlist.map(String) : null;
+
+function hostAllowed(url) {
+    if (!allowlist) return true;
+    try {
+        const h = new URL(url).hostname;
+        return allowlist.some((d) => h === d || h.endsWith('.' + d));
+    } catch { return false; }
+}
+
+const results = [];
+let finalUrl = '';
+let browser;
+try {
+    browser = await chromium.launch({ headless: spec.headless !== false });
+    const context = await browser.newContext();
+    context.setDefaultTimeout(timeout);
+    if (allowlist) {
+        await context.route('**', (route) => {
+            hostAllowed(route.request().url()) ? route.continue() : route.abort();
+        });
+    }
+    const page = await context.newPage();
+
+    for (let i = 0; i < actions.length; i++) {
+        const a = actions[i];
+        try {
+            switch (a.type) {
+                case 'goto':
+                    if (!hostAllowed(a.url)) throw new Error(`allowlist 차단: ${a.url}`);
+                    await page.goto(a.url, { waitUntil: a.waitUntil || 'domcontentloaded', timeout });
+                    results.push({ i, type: a.type, ok: true, url: page.url() }); break;
+                case 'click':
+                    await page.click(a.selector, { timeout });
+                    results.push({ i, type: a.type, ok: true }); break;
+                case 'fill':
+                    await page.fill(a.selector, String(a.text ?? ''), { timeout });
+                    results.push({ i, type: a.type, ok: true }); break;
+                case 'press':
+                    await page.keyboard.press(a.key);
+                    results.push({ i, type: a.type, ok: true }); break;
+                case 'wait':
+                    await page.waitForTimeout(Math.min(Number(a.ms) || 0, 10000));
+                    results.push({ i, type: a.type, ok: true }); break;
+                case 'waitFor':
+                    await page.waitForSelector(a.selector, { timeout });
+                    results.push({ i, type: a.type, ok: true }); break;
+                case 'screenshot': {
+                    const p = (a.path || `screenshot-${i}.png`).replace(/[^A-Za-z0-9._-]/g, '_');
+                    await page.screenshot({ path: resolve(WORKSPACE, p), fullPage: !!a.fullPage });
+                    results.push({ i, type: a.type, ok: true, path: p }); break;
+                }
+                case 'extractText': {
+                    const text = a.selector
+                        ? await page.locator(a.selector).first().innerText({ timeout })
+                        : await page.evaluate(() => document.body.innerText);
+                    results.push({ i, type: a.type, ok: true, text: String(text).slice(0, 8000) }); break;
+                }
+                case 'extractHtml': {
+                    const html = a.selector
+                        ? await page.locator(a.selector).first().innerHTML({ timeout })
+                        : await page.content();
+                    results.push({ i, type: a.type, ok: true, html: String(html).slice(0, 8000) }); break;
+                }
+                default:
+                    results.push({ i, type: a.type, ok: false, error: '알 수 없는 action' });
+            }
+        } catch (e) {
+            results.push({ i, type: a?.type, ok: false, error: e.message });
+            break; // 액션 실패 시 중단
+        }
+    }
+    finalUrl = page.url();
+    out({ ok: results.every((r) => r.ok), finalUrl, results });
+} catch (e) {
+    out({ ok: false, error: e.message, results });
+} finally {
+    if (browser) await browser.close().catch(() => {});
+}

--- a/infra/task-runtime/browser-runner.mjs
+++ b/infra/task-runtime/browser-runner.mjs
@@ -52,7 +52,8 @@ try {
     context.setDefaultTimeout(timeout);
     if (allowlist) {
         await context.route('**', (route) => {
-            hostAllowed(route.request().url()) ? route.continue() : route.abort();
+            if (hostAllowed(route.request().url())) route.continue();
+            else route.abort();
         });
     }
     const page = await context.newPage();


### PR DESCRIPTION
## 배경
Manus화 Phase 1(PR #213) 위에 **G2 브라우저 도구**. 자율 에이전트가 영속 샌드박스 컨테이너 **내부에서** chromium 을 구동해 웹을 자동화(계획 결정 2: 호스트 재사용 금지, 완전 격리).

## 구현
- `infra/task-runtime/Dockerfile`: playwright@1.49 + chromium(`--with-deps`, `/opt` 설치로 uid1000 읽기) + `browser-runner.mjs`.
- `infra/task-runtime/browser-runner.mjs`: 액션 시퀀스 실행 — goto/click/fill/press/wait/waitFor/screenshot/extractText/extractHtml. `page.route` 도메인 allowlist 로 브라우저 egress 차단. 스크린샷 `/workspace` 저장.
- `services/task-sandbox/tools.ts`: `browser` 도구(7번째) — 액션 JSON 작성 → 컨테이너 내 러너 exec.
- `approval-gate.ts`: browser=고위험(네트워크 egress).

## 네트워크 정책
- browser 는 `TASK_SANDBOX_NETWORK=restricted`(bridge) 필요. **bridge 는 bash/python egress 도 열림**(allowlist 미적용) — `APPROVAL_POLICY=all`(매 도구호출 승인)이 사람-게이트. 완전한 bash/python egress 제한(프록시/방화벽)은 후속.
- 현 프로덕션은 `network=none` 유지 → browser 는 operator opt-in(restricted) 시 동작. 미설정 시 data/local URL 만.

## 검증
- [x] tsc 0 / eslint 0 / 유닛 40 pass(browser 도구 2 케이스 추가)
- [x] **이미지 빌드 성공**(chromium 포함)
- [x] **라이브 in-container 검증**: network none 격리 컨테이너(non-root·read-only)에서 chromium 구동 → data URL goto → extractText `#x`="sandbox works" → screenshot(11KB) `/workspace` 저장 ✅

## 남은 것
실인터넷 라이브 agent E2E(restricted 활성 후) · bash/python egress 프록시 · G3 플래닝 · G5 패널.

🤖 Generated with [Claude Code](https://claude.com/claude-code)