### PR TITLE
feat: Manus화 G3 — 플래닝 레이어 (실행 계획 + step 상태 추적)

### DIFF
--- a/apps/api/src/prompts/agent-task-prompt.ts
+++ b/apps/api/src/prompts/agent-task-prompt.ts
@@ -59,6 +59,26 @@ export function getAgentTaskDeliverableNudge(): string {
     return '계획은 확인했습니다. 이제 계획대로 완성된 최종 결과물 전문을 <artifact> 태그로 감싸 작성하세요. 결과물 설명이 아니라 결과물 자체를 작성해야 합니다.';
 }
 
+/**
+ * 영속 샌드박스(Manus화) 활성 시 system 에 덧붙이는 안내 — 작업 환경(셸+파일시스템) 인지 +
+ * 구조화 플랜 도구 사용 유도(G3). 샌드박스 비활성 시 미주입.
+ */
+export function getTaskSandboxGuidance(): string {
+    return [
+        '',
+        '## 작업 환경 (영속 샌드박스)',
+        '- 당신에게는 격리된 가상 컴퓨터가 있습니다: 작업 디렉토리 /workspace + 셸(bash) + python + 브라우저.',
+        '- /workspace 의 파일은 단계 간 유지됩니다. 산출물 파일은 여기에 저장하세요.',
+        '- bash/python_execute/str_replace_editor/file_ops 로 파일을 만들고 실행하고 편집하세요.',
+        '- browser 도구로 웹을 탐색·조작할 수 있습니다(네트워크 정책에 따라 제한).',
+        '- 일부 도구는 실행 전 사용자 승인이 필요할 수 있습니다(승인 대기 시 작업이 일시정지됩니다).',
+        '## 계획 추적 (G3)',
+        '- 복잡한 작업은 plan_create 로 단계 계획을 세우고, 진행하며 plan_update 로 각 단계 상태를',
+        '  (in_progress/completed/blocked) 갱신해 진행 상황을 가시화하세요.',
+        '- 막혔거나 더 진행할 수 없으면 terminate(또는 ask_human)로 깔끔히 마무리하세요.',
+    ].join('\n');
+}
+
 /** stuck(동일 응답 반복) 감지 시 주입 — 전략 변경 유도(OpenManus handle_stuck_state 패턴). */
 export function getAgentTaskStuckNudge(): string {
     return '같은 시도를 반복하고 있습니다. 접근 방식을 바꾸세요: 다른 도구나 다른 입력을 시도하거나, 막혔다면 지금까지의 결과로 작업을 마무리(terminate)하거나 사용자에게 도움을 요청(ask_human)하세요.';

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -21,7 +21,7 @@ import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { getUnifiedDatabase } from '../data/models/unified-database';
 import { AGENT_TASK_LIMITS, MAX_TOOL_RESULT_CHARS } from '../config/runtime-limits';
 import { emitAgentTaskProgress } from '../utils/event-bus';
-import { getAgentTaskSystemPrompt, getAgentTaskDeliverableNudge, getAgentTaskStuckNudge } from '../prompts/agent-task-prompt';
+import { getAgentTaskSystemPrompt, getAgentTaskDeliverableNudge, getAgentTaskStuckNudge, getTaskSandboxGuidance } from '../prompts/agent-task-prompt';
 import { extractAndStripArtifacts, type ExtractedArtifact } from '../llm/artifact-parser';
 import { getPushService } from './PushService';
 import { createLogger } from '../utils/logger';
@@ -198,6 +198,11 @@ export class AgentTaskService {
                         sandboxContainerId: taskRuntime.containerName,
                         workspacePath: taskRuntime.workspacePath,
                     });
+                    // 새 대화면 system 에 작업환경(셸+FS)+플랜 도구 안내 주입(workspace-aware).
+                    // resume 는 기존 checkpoint system 유지(일관성).
+                    if (!input.resume && conversation[0]?.role === 'system') {
+                        conversation[0].content += getTaskSandboxGuidance();
+                    }
                     logger.info(`[AgentTask] 샌드박스 활성 (${taskId}, ${taskRuntime.containerName})`);
                 } catch (e) {
                     logger.warn(`[AgentTask] 샌드박스 생성 실패 — 미사용 진행: ${e instanceof Error ? e.message : e}`);

--- a/apps/api/src/services/task-sandbox/approval-gate.ts
+++ b/apps/api/src/services/task-sandbox/approval-gate.ts
@@ -21,6 +21,8 @@ const logger = createLogger('TaskApprovalGate');
 
 /** 승인이 필요한 고위험 도구(high-risk 정책 시). browser=네트워크 egress. */
 const HIGH_RISK_TOOLS = new Set(['bash', 'browser']);
+/** 부작용 없는 도구 — 승인 불요(제어 시그널 + 플래닝). */
+const NO_APPROVAL_TOOLS = new Set(['terminate', 'ask_human', 'plan_create', 'plan_update', 'plan_view']);
 /** 고위험으로 보는 file_ops 작업. */
 const HIGH_RISK_FILE_OPS = new Set(['delete']);
 
@@ -31,8 +33,8 @@ export function requiresApproval(
     args: Record<string, unknown>,
 ): boolean {
     if (policy === 'none') return false;
-    // 제어 시그널은 승인 불요(부작용 없음).
-    if (toolName === 'terminate' || toolName === 'ask_human') return false;
+    // 제어 시그널·플래닝은 승인 불요(부작용 없음).
+    if (NO_APPROVAL_TOOLS.has(toolName)) return false;
     if (policy === 'all') return true;
     // high-risk
     if (HIGH_RISK_TOOLS.has(toolName)) return true;

--- a/apps/api/src/services/task-sandbox/planning.ts
+++ b/apps/api/src/services/task-sandbox/planning.ts
@@ -1,0 +1,70 @@
+/**
+ * ============================================================
+ * Task Plan — 에이전트 실행 계획 + step 상태 추적 (Manus화 G3)
+ * ============================================================
+ *
+ * OpenManus PlanningFlow 대응(단일 에이전트 MVP — 멀티에이전트 executor 라우팅 G4 별도).
+ * 에이전트가 plan_create 로 단계를 세우고, 작업하며 plan_update 로 상태를 갱신한다.
+ * not_started → in_progress → completed | blocked. 진행 가시성(G5) + 구조적 실행.
+ *
+ * @module services/task-sandbox/planning
+ */
+
+export type PlanStepStatus = 'not_started' | 'in_progress' | 'completed' | 'blocked';
+
+export interface PlanStep {
+    text: string;
+    status: PlanStepStatus;
+    note?: string;
+}
+
+const STATUS_MARK: Record<PlanStepStatus, string> = {
+    not_started: '[ ]',
+    in_progress: '[~]',
+    completed: '[x]',
+    blocked: '[!]',
+};
+
+/** task 실행 계획. 단계 목록 + 상태. 순수 로직(유닛테스트 대상). */
+export class TaskPlan {
+    private steps: PlanStep[] = [];
+
+    /** 계획 생성/교체. 모든 단계 not_started. */
+    create(stepTexts: string[]): void {
+        this.steps = stepTexts
+            .map((t) => String(t).trim())
+            .filter(Boolean)
+            .map((text) => ({ text, status: 'not_started' as PlanStepStatus }));
+    }
+
+    /** 단계 상태 갱신(1-based index). 범위 밖이면 false. */
+    update(stepNumber: number, status: PlanStepStatus, note?: string): boolean {
+        const idx = stepNumber - 1;
+        if (idx < 0 || idx >= this.steps.length) return false;
+        this.steps[idx].status = status;
+        if (note !== undefined) this.steps[idx].note = note;
+        return true;
+    }
+
+    get length(): number { return this.steps.length; }
+
+    /** 첫 미완료 단계(1-based) 또는 0(없음). */
+    currentStep(): number {
+        const i = this.steps.findIndex((s) => s.status !== 'completed');
+        return i < 0 ? 0 : i + 1;
+    }
+
+    snapshot(): PlanStep[] {
+        return this.steps.map((s) => ({ ...s }));
+    }
+
+    /** LLM/사용자용 렌더. */
+    render(): string {
+        if (this.steps.length === 0) return '(계획 없음 — plan_create 로 단계를 세우세요)';
+        const done = this.steps.filter((s) => s.status === 'completed').length;
+        const lines = this.steps.map(
+            (s, i) => `${i + 1}. ${STATUS_MARK[s.status]} ${s.text}${s.note ? ` — ${s.note}` : ''}`,
+        );
+        return `## 계획 (${done}/${this.steps.length} 완료)\n${lines.join('\n')}`;
+    }
+}

--- a/apps/api/src/services/task-sandbox/runtime.ts
+++ b/apps/api/src/services/task-sandbox/runtime.ts
@@ -13,6 +13,7 @@ import type { MCPToolDefinition } from '../../mcp/types';
 import { getTaskSandboxConfig, type TaskSandboxConfig } from '../../config/task-sandbox';
 import { TaskSandbox } from './sandbox';
 import { createTaskTools } from './tools';
+import { TaskPlan, type PlanStep } from './planning';
 import { requiresApproval, getApprovalRegistry, type PendingApproval } from './approval-gate';
 import { createLogger } from '../../utils/logger';
 
@@ -46,6 +47,7 @@ export class TaskRuntime {
     readonly userId: string;
     private readonly cfg: TaskSandboxConfig;
     private readonly sandbox: TaskSandbox;
+    private readonly plan = new TaskPlan();
     private readonly handlers = new Map<string, MCPToolDefinition['handler']>();
     private readonly defs: MCPToolDefinition[];
 
@@ -54,9 +56,12 @@ export class TaskRuntime {
         this.userId = userId;
         this.cfg = cfg;
         this.sandbox = new TaskSandbox(taskId, cfg);
-        this.defs = createTaskTools(this.sandbox);
+        this.defs = createTaskTools(this.sandbox, this.plan);
         for (const d of this.defs) this.handlers.set(d.tool.name, d.handler);
     }
+
+    /** 현재 실행 계획 스냅샷 (진행 가시성·영속용). */
+    getPlanSnapshot(): PlanStep[] { return this.plan.snapshot(); }
 
     get containerName(): string { return this.sandbox.containerName; }
     get workspacePath(): string { return this.sandbox.hostWorkdir; }

--- a/apps/api/src/services/task-sandbox/tools.ts
+++ b/apps/api/src/services/task-sandbox/tools.ts
@@ -15,6 +15,7 @@
  */
 import type { MCPToolDefinition, MCPToolResult } from '../../mcp/types';
 import type { TaskSandbox, ExecResult } from './sandbox';
+import { TaskPlan, type PlanStepStatus } from './planning';
 
 /** 루프가 인식하는 제어 시그널 sentinel (도구 결과 텍스트 prefix). */
 export const TASK_TERMINATE_SENTINEL = '__TASK_TERMINATE__';
@@ -39,7 +40,7 @@ function str(v: unknown): string { return typeof v === 'string' ? v : ''; }
  * task별 도구 세트 생성. AgentTaskService 가 task 시작 시 TaskSandbox 와 함께 호출해
  * effectiveTools 에 합류시킨다.
  */
-export function createTaskTools(sandbox: TaskSandbox): MCPToolDefinition[] {
+export function createTaskTools(sandbox: TaskSandbox, plan: TaskPlan = new TaskPlan()): MCPToolDefinition[] {
     const bash: MCPToolDefinition = {
         tool: {
             name: 'bash',
@@ -209,6 +210,60 @@ export function createTaskTools(sandbox: TaskSandbox): MCPToolDefinition[] {
         },
     };
 
+    // ── G3 플래닝: 실행 계획 + step 상태 추적 ──
+    const VALID_STATUS = new Set(['not_started', 'in_progress', 'completed', 'blocked']);
+    const planCreate: MCPToolDefinition = {
+        tool: {
+            name: 'plan_create',
+            description: '작업을 시작할 때 단계별 실행 계획을 세웁니다. steps 문자열 배열을 받아 추적 가능한 계획을 만듭니다. ' +
+                '복잡한 작업은 먼저 이 도구로 계획하고, 진행하며 plan_update 로 상태를 갱신하세요.',
+            inputSchema: {
+                type: 'object',
+                properties: { steps: { type: 'array', description: '단계 설명 문자열 배열' } },
+                required: ['steps'],
+            },
+        },
+        handler: async (args): Promise<MCPToolResult> => {
+            if (!Array.isArray(args.steps) || args.steps.length === 0) {
+                return textResult('steps 배열이 필요합니다.', true);
+            }
+            plan.create(args.steps.map(String));
+            return textResult(plan.render());
+        },
+    };
+
+    const planUpdate: MCPToolDefinition = {
+        tool: {
+            name: 'plan_update',
+            description: '계획 단계의 상태를 갱신합니다. step(1-based) + status(not_started|in_progress|completed|blocked).',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    step: { type: 'number', description: '단계 번호(1부터)' },
+                    status: { type: 'string', description: 'not_started | in_progress | completed | blocked' },
+                    note: { type: 'string', description: '메모(선택)' },
+                },
+                required: ['step', 'status'],
+            },
+        },
+        handler: async (args): Promise<MCPToolResult> => {
+            const status = str(args.status);
+            if (!VALID_STATUS.has(status)) return textResult(`status 는 ${[...VALID_STATUS].join('|')} 여야 합니다.`, true);
+            const ok = plan.update(Number(args.step), status as PlanStepStatus, args.note !== undefined ? str(args.note) : undefined);
+            if (!ok) return textResult(`단계 ${args.step} 가 범위를 벗어났습니다(계획 ${plan.length}단계).`, true);
+            return textResult(plan.render());
+        },
+    };
+
+    const planView: MCPToolDefinition = {
+        tool: {
+            name: 'plan_view',
+            description: '현재 실행 계획과 각 단계 상태를 봅니다.',
+            inputSchema: { type: 'object', properties: {} },
+        },
+        handler: async (): Promise<MCPToolResult> => textResult(plan.render()),
+    };
+
     // ── B 흡수: 제어 시그널 도구 (sandbox 무관) ──
     const terminate: MCPToolDefinition = {
         tool: {
@@ -241,5 +296,5 @@ export function createTaskTools(sandbox: TaskSandbox): MCPToolDefinition[] {
             textResult(`${TASK_ASK_HUMAN_SENTINEL} ${str(args.question)}`),
     };
 
-    return [bash, pythonExecute, strReplaceEditor, fileOps, browser, terminate, askHuman];
+    return [bash, pythonExecute, strReplaceEditor, fileOps, browser, planCreate, planUpdate, planView, terminate, askHuman];
 }


### PR DESCRIPTION
## 배경
Phase 1(#213) + G2(#214) 위에 **G3 플래닝 레이어**. OpenManus PlanningFlow 대응 — 자율 에이전트가 실행 계획을 세우고 진행하며 step 상태를 갱신해 구조적 실행 + 진행 가시성을 제공(단일 에이전트 MVP, 멀티에이전트 executor 라우팅=G4 별도).

기존 `create_plan`(채팅용 일회성 읽기전용 Plan Mode)과 **다름** — 이쪽은 에이전트가 실행 중 갱신하는 추적형 플랜(중복 없음 확인).

## 구현
- `planning.ts`: `TaskPlan` — create/update(1-based)/currentStep/render/snapshot. 상태 not_started→in_progress→completed|blocked. 순수 로직.
- `tools.ts`: `plan_create`(steps[]) / `plan_update`(step,status,note) / `plan_view`. TaskRuntime 이 TaskPlan 주입.
- `approval-gate.ts`: 플래닝 도구는 부작용 없어 승인 면제(`NO_APPROVAL_TOOLS`).
- `runtime.ts`: TaskPlan 소유 + `getPlanSnapshot()`(G5 가시성용).
- `AgentTaskService`: 샌드박스 활성 새 대화에 **작업환경(셸+FS, workspace-aware) + 플랜 도구 안내** 주입(`getTaskSandboxGuidance`). 플랜 진행은 `tool_result` step 으로 영속·가시화.

## 검증
- [x] tsc 0 / eslint 0 / build:backend 성공
- [x] 유닛 51 pass (TaskPlan 6 케이스 + 도구/runtime/gate 갱신, 회귀 0)

## 남은 것
G5 라이브 패널(파일트리/터미널/스텝/플랜 스트리밍) · G4 멀티에이전트 executor 라우팅 · 실인터넷 browser agent E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)