### PR TITLE
feat: Manus화 G4 — 멀티에이전트 delegate 전문가 위임 도구

### DIFF
--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -27,6 +27,8 @@ import { getPushService } from './PushService';
 import { createLogger } from '../utils/logger';
 import type { UserContext } from '../mcp/user-sandbox';
 import { getSkillManager } from '../agents/skill-manager';
+import { routeToAgent } from '../agents/keyword-router';
+import { getAgentSystemMessage } from '../agents/system-prompt';
 import { mergeToolsWithSkills, type ActiveSkillBinding } from './chat-service/tool-merger';
 import { getTaskSandboxConfig } from '../config/task-sandbox';
 import { TaskRuntime } from './task-sandbox/runtime';
@@ -192,7 +194,17 @@ export class AgentTaskService {
             // 생성 실패는 작업을 죽이지 않고 샌드박스 없이 진행(graceful degrade).
             if (getTaskSandboxConfig().enabled) {
                 try {
-                    taskRuntime = new TaskRuntime(taskId, userId);
+                    // G4 위임: subgoal 을 적합 산업 전문가 페르소나로 1회 자문(재귀 루프 없음).
+                    const delegateFn = async (subgoal: string, role?: string): Promise<string> => {
+                        const selection = await routeToAgent(role ? `[${role}] ${subgoal}` : subgoal);
+                        const { prompt } = await getAgentSystemMessage(selection, userId);
+                        const r = await this.client.chat(
+                            [{ role: 'system', content: prompt }, { role: 'user', content: subgoal }],
+                            undefined, undefined, { think: false, signal },
+                        );
+                        return r.content ?? '';
+                    };
+                    taskRuntime = new TaskRuntime(taskId, userId, getTaskSandboxConfig(), delegateFn);
                     await taskRuntime.create();
                     await db.updateAgentTask(taskId, {
                         sandboxContainerId: taskRuntime.containerName,

--- a/apps/api/src/services/task-sandbox/approval-gate.ts
+++ b/apps/api/src/services/task-sandbox/approval-gate.ts
@@ -21,8 +21,8 @@ const logger = createLogger('TaskApprovalGate');
 
 /** 승인이 필요한 고위험 도구(high-risk 정책 시). browser=네트워크 egress. */
 const HIGH_RISK_TOOLS = new Set(['bash', 'browser']);
-/** 부작용 없는 도구 — 승인 불요(제어 시그널 + 플래닝). */
-const NO_APPROVAL_TOOLS = new Set(['terminate', 'ask_human', 'plan_create', 'plan_update', 'plan_view']);
+/** 부작용 없는 도구 — 승인 불요(제어 시그널 + 플래닝 + 전문가 자문). */
+const NO_APPROVAL_TOOLS = new Set(['terminate', 'ask_human', 'plan_create', 'plan_update', 'plan_view', 'delegate']);
 /** 고위험으로 보는 file_ops 작업. */
 const HIGH_RISK_FILE_OPS = new Set(['delete']);
 

--- a/apps/api/src/services/task-sandbox/runtime.ts
+++ b/apps/api/src/services/task-sandbox/runtime.ts
@@ -12,7 +12,7 @@ import type { ToolDefinition } from '../../llm/types';
 import type { MCPToolDefinition } from '../../mcp/types';
 import { getTaskSandboxConfig, type TaskSandboxConfig } from '../../config/task-sandbox';
 import { TaskSandbox } from './sandbox';
-import { createTaskTools } from './tools';
+import { createTaskTools, type DelegateFn } from './tools';
 import { TaskPlan, type PlanStep } from './planning';
 import { requiresApproval, getApprovalRegistry, type PendingApproval } from './approval-gate';
 import { createLogger } from '../../utils/logger';
@@ -51,12 +51,17 @@ export class TaskRuntime {
     private readonly handlers = new Map<string, MCPToolDefinition['handler']>();
     private readonly defs: MCPToolDefinition[];
 
-    constructor(taskId: string, userId: string, cfg: TaskSandboxConfig = getTaskSandboxConfig()) {
+    constructor(
+        taskId: string,
+        userId: string,
+        cfg: TaskSandboxConfig = getTaskSandboxConfig(),
+        delegate?: DelegateFn,
+    ) {
         this.taskId = taskId;
         this.userId = userId;
         this.cfg = cfg;
         this.sandbox = new TaskSandbox(taskId, cfg);
-        this.defs = createTaskTools(this.sandbox, this.plan);
+        this.defs = createTaskTools(this.sandbox, this.plan, delegate);
         for (const d of this.defs) this.handlers.set(d.tool.name, d.handler);
     }
 

--- a/apps/api/src/services/task-sandbox/tools.ts
+++ b/apps/api/src/services/task-sandbox/tools.ts
@@ -40,7 +40,14 @@ function str(v: unknown): string { return typeof v === 'string' ? v : ''; }
  * task별 도구 세트 생성. AgentTaskService 가 task 시작 시 TaskSandbox 와 함께 호출해
  * effectiveTools 에 합류시킨다.
  */
-export function createTaskTools(sandbox: TaskSandbox, plan: TaskPlan = new TaskPlan()): MCPToolDefinition[] {
+/** 전문가 자문 콜백 — subgoal 을 적합 산업 전문가(페르소나)에게 1회 위임해 응답을 받는다. */
+export type DelegateFn = (subgoal: string, role?: string) => Promise<string>;
+
+export function createTaskTools(
+    sandbox: TaskSandbox,
+    plan: TaskPlan = new TaskPlan(),
+    delegate?: DelegateFn,
+): MCPToolDefinition[] {
     const bash: MCPToolDefinition = {
         tool: {
             name: 'bash',
@@ -264,6 +271,35 @@ export function createTaskTools(sandbox: TaskSandbox, plan: TaskPlan = new TaskP
         handler: async (): Promise<MCPToolResult> => textResult(plan.render()),
     };
 
+    // ── G4 멀티에이전트: 전문가 위임(자문) ──
+    const delegateTool: MCPToolDefinition = {
+        tool: {
+            name: 'delegate',
+            description: '특정 하위 문제를 적합한 산업 전문가(금융/법률/엔지니어링/의료/과학 등)에게 위임해 ' +
+                '전문 자문을 받습니다. 자문 결과를 참고해 당신이 직접 다음 작업을 수행하세요. ' +
+                '전문 지식·검토·판단이 필요한 단계에서 사용하세요.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    subgoal: { type: 'string', description: '전문가에게 위임할 구체적 하위 문제/질문' },
+                    role: { type: 'string', description: '원하는 전문 분야(선택, 예: finance/legal/engineering)' },
+                },
+                required: ['subgoal'],
+            },
+        },
+        handler: async (args): Promise<MCPToolResult> => {
+            const subgoal = str(args.subgoal).trim();
+            if (!subgoal) return textResult('subgoal 이 필요합니다.', true);
+            if (!delegate) return textResult('위임 기능을 사용할 수 없습니다.', true);
+            try {
+                const advice = await delegate(subgoal, str(args.role) || undefined);
+                return textResult(advice);
+            } catch (e) {
+                return textResult(`전문가 위임 실패: ${e instanceof Error ? e.message : String(e)}`, true);
+            }
+        },
+    };
+
     // ── B 흡수: 제어 시그널 도구 (sandbox 무관) ──
     const terminate: MCPToolDefinition = {
         tool: {
@@ -296,5 +332,5 @@ export function createTaskTools(sandbox: TaskSandbox, plan: TaskPlan = new TaskP
             textResult(`${TASK_ASK_HUMAN_SENTINEL} ${str(args.question)}`),
     };
 
-    return [bash, pythonExecute, strReplaceEditor, fileOps, browser, planCreate, planUpdate, planView, terminate, askHuman];
+    return [bash, pythonExecute, strReplaceEditor, fileOps, browser, planCreate, planUpdate, planView, delegateTool, terminate, askHuman];
 }


### PR DESCRIPTION
## 배경
Manus 4-레이어(Phase 1·G2·G3·G5) 위에 **G4 멀티에이전트**. OpenManus PlanningFlow의 executor 라우팅(step→agent) 대응.

**저위험 설계**: 검증된 라이브 메인 루프를 재작성하지 않고 **agent-as-tool 단일 자문**으로 구현 — 메인 에이전트가 하위 문제를 적합 산업 전문가에게 1회 위임해 자문받고 직접 실행(재귀 sub-loop 없음).

## 구현
- `tools.ts`: `delegate`(subgoal, role?) 도구 + `DelegateFn` 타입 (11번째 task 도구).
- `runtime.ts`: TaskRuntime 이 delegate fn 주입.
- `approval-gate.ts`: delegate=부작용 없어 승인 면제.
- `AgentTaskService`: `routeToAgent`(subgoal→전문가 선택) + `getAgentSystemMessage`(페르소나 프롬프트) + `client.chat` 1회로 위임 fn 구성. 기존 18 산업 agent 활용.

## 검증
- [x] tsc 0 / eslint 0 / build:backend 성공
- [x] 유닛 53 pass (delegate 2 케이스 + 회귀 0)

## 비고
재귀 멀티-agent-loop(step별 풀 sub-agent 실행)는 메인 루프 안정성·토큰 예산 리스크로 보류 — 단일 자문이 specialist 가치를 저위험으로 제공. 풀 executor-per-step 은 후속 검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)