### PR TITLE
feat: 브라우저 네트워크 격리 — 메인 샌드박스 none + 브라우저 별도 컨테이너

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -722,10 +722,12 @@ TASK_SANDBOX_ENABLED=false
 # TASK_SANDBOX_IMAGE=openmake-task-runtime:latest      # task 런타임 이미지(mcp-runtime + git/curl/ripgrep)
 # TASK_SANDBOX_ROOT=/tmp/openmake-task-workspaces      # 호스트 workspace 루트(task별 하위 디렉토리)
 # TASK_SANDBOX_MAX_CONCURRENT=8                        # 동시 활성 컨테이너 상한
-# TASK_SANDBOX_NETWORK=none                            # none | restricted. browser 도구(G2)는 restricted 필요.
-#   restricted=컨테이너 bridge 네트워크 + browser-runner page.route 도메인 allowlist(브라우저 egress 차단).
-#   주의: bridge 는 bash/python 에도 네트워크를 열어줌(allowlist 미적용) — 매 도구호출 승인(APPROVAL_POLICY=all)
-#   이 사람-게이트 역할. 완전한 bash/python egress 제한(프록시/방화벽)은 후속.
+# TASK_SANDBOX_NETWORK=none                            # 메인 샌드박스(bash/python) 네트워크. 기본 none(인터넷 차단·안전).
+#   none 권장 — bash/python 은 인터넷 미접근. browser 는 아래 별도 컨테이너에서만 인터넷 사용.
+# 브라우저 전용 격리(웹 필요 기능만 분리 — 메인은 none 유지):
+# TASK_SANDBOX_BROWSER_ENABLED=true                    # browser 도구 활성(false 면 인터넷 완전 차단)
+# TASK_SANDBOX_BROWSER_NETWORK=bridge                  # browser 일회성 컨테이너 네트워크. 외부 출시 전 egress 프록시로 교체 예정.
+#   browser 는 page.route 도메인 allowlist 로 제한. 메인 샌드박스와 분리돼 bash/python 인터넷 미접근 보장.
 # TASK_SANDBOX_NETWORK_ALLOWLIST=                      # restricted 시 egress 허용 도메인(쉼표)
 # TASK_SANDBOX_MEMORY=1g                               # 컨테이너 메모리 상한
 # TASK_SANDBOX_CPUS=1.0                                # CPU 상한

--- a/apps/api/src/config/task-sandbox.ts
+++ b/apps/api/src/config/task-sandbox.ts
@@ -58,6 +58,13 @@ export interface TaskSandboxConfig {
     approvalTimeoutMs: number;
     /** 완료 task workspace 보존 TTL(ms) — 초과한 workspace 디렉토리는 정리 스윕이 삭제. */
     workspaceTtlMs: number;
+    /**
+     * 브라우저 도구 활성 여부(기본 true). 메인 샌드박스는 항상 TASK_SANDBOX_NETWORK(기본 none)이고,
+     * browser 만 별도 일회성 컨테이너(browserNetwork)에서 실행 — bash/python 은 인터넷 미접근.
+     */
+    browserEnabled: boolean;
+    /** 브라우저 전용 일회성 컨테이너의 네트워크(기본 bridge — 브라우저는 인터넷 필요). egress 프록시 도입 시 교체. */
+    browserNetwork: string;
 }
 
 export function getTaskSandboxConfig(): TaskSandboxConfig {
@@ -84,5 +91,7 @@ export function getTaskSandboxConfig(): TaskSandboxConfig {
         approvalPolicy,
         approvalTimeoutMs: intEnv(process.env.TASK_SANDBOX_APPROVAL_TIMEOUT_MS, 30 * 60_000),
         workspaceTtlMs: intEnv(process.env.TASK_SANDBOX_WORKSPACE_TTL_MS, 24 * 60 * 60_000),
+        browserEnabled: process.env.TASK_SANDBOX_BROWSER_ENABLED !== 'false',
+        browserNetwork: process.env.TASK_SANDBOX_BROWSER_NETWORK || 'bridge',
     };
 }

--- a/apps/api/src/services/task-sandbox/sandbox.ts
+++ b/apps/api/src/services/task-sandbox/sandbox.ts
@@ -54,6 +54,28 @@ export function buildRunArgs(
 }
 
 /**
+ * PURE: 브라우저 전용 일회성 컨테이너 `docker run --rm` 인자 (유닛테스트 대상).
+ * 메인 샌드박스(network none)와 분리 — browser 만 browserNetwork(기본 bridge)에서 실행해
+ * bash/python 의 인터넷 미접근을 보장한다. workspace 는 공유(스크린샷·결과 저장).
+ */
+export function buildBrowserRunArgs(
+    hostWorkdir: string,
+    actionsRelPath: string,
+    cfg: TaskSandboxConfig,
+): string[] {
+    const a: string[] = ['run', '--rm', '--init'];
+    a.push('--network', cfg.browserNetwork || 'bridge');
+    a.push('--cap-drop', 'ALL', '--security-opt', 'no-new-privileges');
+    a.push('--pids-limit', String(cfg.pidsLimit), '--memory', cfg.memory, '--cpus', cfg.cpus);
+    a.push('--user', cfg.user);
+    a.push('--read-only', '--tmpfs', '/tmp:rw,exec', '--tmpfs', '/run:rw');
+    a.push('-v', `${hostWorkdir}:${WORKSPACE}:rw`);
+    a.push('-w', WORKSPACE);
+    a.push(cfg.image, 'node', '/opt/browser/browser-runner.mjs', actionsRelPath);
+    return a;
+}
+
+/**
  * PURE: workspace 내부로만 해석되는 안전 경로 반환 (유닛테스트 대상).
  * `..`/절대경로/심링크 표기로 workspace 를 탈출하려는 시도를 차단한다.
  */
@@ -173,6 +195,22 @@ export class TaskSandbox {
             ['exec', this.containerName, 'sh', '-c', command],
             { timeoutMs: this.cfg.execTimeoutMs, outputCap: this.cfg.outputCap },
         );
+    }
+
+    /** 브라우저 도구 활성 여부. */
+    get isBrowserEnabled(): boolean { return this.cfg.browserEnabled; }
+
+    /**
+     * 브라우저 액션을 별도 일회성 컨테이너(browserNetwork)에서 실행 — 메인 컨테이너(network none)와
+     * 분리해 bash/python 인터넷 미접근 보장. workspace 공유(스크린샷 저장). actionsRelPath 는 사전에 쓰여 있어야 함.
+     */
+    async runBrowser(actionsRelPath: string): Promise<ExecResult> {
+        this.assertCreated();
+        const args = buildBrowserRunArgs(this.hostWorkdir, actionsRelPath, this.cfg);
+        return runProcess(this.cfg.dockerPath, args, {
+            timeoutMs: Math.max(this.cfg.execTimeoutMs, 90_000),
+            outputCap: this.cfg.outputCap,
+        });
     }
 
     /** workspace 내 파일 쓰기 (호스트 bind-mount 직접). 경로 가드 적용. */

--- a/apps/api/src/services/task-sandbox/tools.ts
+++ b/apps/api/src/services/task-sandbox/tools.ts
@@ -200,6 +200,9 @@ export function createTaskTools(
             },
         },
         handler: async (args): Promise<MCPToolResult> => {
+            if (!sandbox.isBrowserEnabled) {
+                return textResult('브라우저 기능이 비활성화되어 있습니다 (TASK_SANDBOX_BROWSER_ENABLED=false).', true);
+            }
             const actions = args.actions;
             if (!Array.isArray(actions) || actions.length === 0) {
                 return textResult('actions 배열이 필요합니다.', true);
@@ -213,7 +216,8 @@ export function createTaskTools(
             } catch (e) {
                 return textResult(`액션 파일 쓰기 실패: ${e instanceof Error ? e.message : String(e)}`, true);
             }
-            return formatExec(await sandbox.exec('node /opt/browser/browser-runner.mjs .browser-actions.json'));
+            // 메인 샌드박스(network none)가 아닌 별도 일회성 컨테이너에서 실행.
+            return formatExec(await sandbox.runBrowser('.browser-actions.json'));
         },
     };
 


### PR DESCRIPTION
## 배경
운영 네트워크 정책 반영: **①기본 none ②웹 필요 기능만 인터넷 ③restricted 기능 별도 샌드박스 분리**.

기존엔 `TASK_SANDBOX_NETWORK=restricted` 시 컨테이너 전체가 bridge → bash/python 도 인터넷 개방(승인 게이트만 통제). 이제 **메인 샌드박스는 항상 none(커널 레벨 인터넷 차단)**, **browser 만 별도 일회성 컨테이너**에서 통제된 인터넷 사용.

## 구현
- `config`: `browserEnabled`(기본 true) + `browserNetwork`(기본 bridge).
- `sandbox.ts`: `buildBrowserRunArgs`(순수, `--rm` 일회성) + `runBrowser()` + `isBrowserEnabled`. workspace 공유(스크린샷 저장).
- `tools.ts`: browser 도구가 `sandbox.exec` → `sandbox.runBrowser`(별도 컨테이너). page.route 도메인 allowlist 유지.

## 검증
- [x] tsc 0 / eslint 0 / 유닛 54 pass
- [x] **인프라 결정적 검증**(LLM 무관): 메인 샌드박스(none)에서 bash python 소켓 → `Network is unreachable`(차단) / 브라우저 별도 컨테이너(bridge) → `example.com` extractText="Example Domain"(성공)

## 결과 (운영 포스처)
- bash/python: **인터넷 완전 차단**(네트워크 자체 부재 — 승인 게이트보다 강함)
- browser: 별도 throwaway 컨테이너 + 도메인 allowlist
- 남은: egress 프록시(외부 출시 전, browserNetwork 교체) — 부록 E 설계

🤖 Generated with [Claude Code](https://claude.com/claude-code)