### PR TITLE
feat: 브라우저 egress 프록시 — 네트워크 레벨 도메인 allowlist (하드닝)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -726,8 +726,17 @@ TASK_SANDBOX_ENABLED=false
 #   none 권장 — bash/python 은 인터넷 미접근. browser 는 아래 별도 컨테이너에서만 인터넷 사용.
 # 브라우저 전용 격리(웹 필요 기능만 분리 — 메인은 none 유지):
 # TASK_SANDBOX_BROWSER_ENABLED=true                    # browser 도구 활성(false 면 인터넷 완전 차단)
-# TASK_SANDBOX_BROWSER_NETWORK=bridge                  # browser 일회성 컨테이너 네트워크. 외부 출시 전 egress 프록시로 교체 예정.
+# TASK_SANDBOX_BROWSER_NETWORK=bridge                  # browser 일회성 컨테이너 네트워크(egress 프록시 OFF 시).
 #   browser 는 page.route 도메인 allowlist 로 제한. 메인 샌드박스와 분리돼 bash/python 인터넷 미접근 보장.
+# 브라우저 egress 프록시(외부 출시 전 권장 — 네트워크 레벨 도메인 allowlist, 이중방어):
+#   선행: 이미지 빌드 — `docker build -t openmake-egress-proxy:latest infra/egress-proxy`
+#   ON 시 브라우저는 internal 망(인터넷 직접 차단)에만 연결되고 프록시 통해서만 allowlist 도메인 도달.
+# TASK_SANDBOX_EGRESS_PROXY_ENABLED=false              # true 면 네트워크 레벨 egress allowlist 적용
+# TASK_SANDBOX_EGRESS_ALLOWLIST=                       # 허용 도메인(쉼표). 비면 전부 거부(fail-safe). 예: example.com,github.com
+# TASK_SANDBOX_EGRESS_PROXY_IMAGE=openmake-egress-proxy:latest
+# TASK_SANDBOX_EGRESS_NETWORK=omk-egress-internal      # internal Docker 네트워크 이름
+# TASK_SANDBOX_EGRESS_PROXY_CONTAINER=omk-egress-proxy
+# TASK_SANDBOX_EGRESS_PROXY_PORT=8888
 # TASK_SANDBOX_NETWORK_ALLOWLIST=                      # restricted 시 egress 허용 도메인(쉼표)
 # TASK_SANDBOX_MEMORY=1g                               # 컨테이너 메모리 상한
 # TASK_SANDBOX_CPUS=1.0                                # CPU 상한

--- a/apps/api/src/config/task-sandbox.ts
+++ b/apps/api/src/config/task-sandbox.ts
@@ -63,8 +63,24 @@ export interface TaskSandboxConfig {
      * browser 만 별도 일회성 컨테이너(browserNetwork)에서 실행 — bash/python 은 인터넷 미접근.
      */
     browserEnabled: boolean;
-    /** 브라우저 전용 일회성 컨테이너의 네트워크(기본 bridge — 브라우저는 인터넷 필요). egress 프록시 도입 시 교체. */
+    /** 브라우저 전용 일회성 컨테이너의 네트워크(기본 bridge — 브라우저는 인터넷 필요). egress 프록시 ON 시 무시. */
     browserNetwork: string;
+    /**
+     * 브라우저 egress 프록시(네트워크 레벨 도메인 allowlist) 활성 여부(기본 false).
+     * ON 시 브라우저 컨테이너는 internal 망(인터넷 차단)에만 연결되고 프록시 통해서만 allowlist 도메인에 도달.
+     * 외부 출시 전 권장. bash/python 은 network=none 이라 무관.
+     */
+    egressProxyEnabled: boolean;
+    /** egress 프록시 허용 도메인(쉼표/배열). 비면 전부 거부(fail-safe). */
+    egressAllowlist: string[];
+    /** egress 프록시 이미지(infra/egress-proxy). */
+    egressProxyImage: string;
+    /** internal Docker 네트워크 이름(브라우저 컨테이너 인터넷 차단망). */
+    egressNetwork: string;
+    /** egress 프록시 컨테이너 이름. */
+    egressProxyContainer: string;
+    /** egress 프록시 포트. */
+    egressProxyPort: number;
 }
 
 export function getTaskSandboxConfig(): TaskSandboxConfig {
@@ -93,5 +109,12 @@ export function getTaskSandboxConfig(): TaskSandboxConfig {
         workspaceTtlMs: intEnv(process.env.TASK_SANDBOX_WORKSPACE_TTL_MS, 24 * 60 * 60_000),
         browserEnabled: process.env.TASK_SANDBOX_BROWSER_ENABLED !== 'false',
         browserNetwork: process.env.TASK_SANDBOX_BROWSER_NETWORK || 'bridge',
+        egressProxyEnabled: process.env.TASK_SANDBOX_EGRESS_PROXY_ENABLED === 'true',
+        egressAllowlist: (process.env.TASK_SANDBOX_EGRESS_ALLOWLIST || '')
+            .split(',').map((s) => s.trim()).filter(Boolean),
+        egressProxyImage: process.env.TASK_SANDBOX_EGRESS_PROXY_IMAGE || 'openmake-egress-proxy:latest',
+        egressNetwork: process.env.TASK_SANDBOX_EGRESS_NETWORK || 'omk-egress-internal',
+        egressProxyContainer: process.env.TASK_SANDBOX_EGRESS_PROXY_CONTAINER || 'omk-egress-proxy',
+        egressProxyPort: intEnv(process.env.TASK_SANDBOX_EGRESS_PROXY_PORT, 8888),
     };
 }

--- a/apps/api/src/services/task-sandbox/egress-proxy.ts
+++ b/apps/api/src/services/task-sandbox/egress-proxy.ts
@@ -1,0 +1,70 @@
+/**
+ * ============================================================
+ * Egress Proxy 수명주기 — 브라우저 네트워크 레벨 도메인 allowlist (Manus 하드닝)
+ * ============================================================
+ *
+ * 브라우저 전용 task 컨테이너를 internal Docker 네트워크(인터넷 차단)에만 연결하고, 양쪽
+ * (internal + bridge)에 붙은 egress 프록시를 통해서만 allowlist 도메인에 도달하게 한다.
+ * ensureEgressProxy 가 internal 네트워크 + 프록시 컨테이너를 멱등 생성한다.
+ *
+ * @module services/task-sandbox/egress-proxy
+ */
+import { spawn } from 'child_process';
+import type { TaskSandboxConfig } from '../../config/task-sandbox';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('EgressProxy');
+
+function run(docker: string, args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+    return new Promise((resolve) => {
+        const child = spawn(docker, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+        let stdout = ''; let stderr = '';
+        child.stdout.on('data', (b) => { stdout += b.toString('utf8', 0, 8192); });
+        child.stderr.on('data', (b) => { stderr += b.toString('utf8', 0, 8192); });
+        child.on('close', (code) => resolve({ code: code ?? -1, stdout: stdout.trim(), stderr: stderr.trim() }));
+        child.on('error', (e) => resolve({ code: -1, stdout: '', stderr: String(e) }));
+    });
+}
+
+/** internal 네트워크 + 프록시 컨테이너를 보장하고 프록시 base URL 을 반환. 멱등. */
+export async function ensureEgressProxy(cfg: TaskSandboxConfig): Promise<string> {
+    const d = cfg.dockerPath;
+    // 1) internal 네트워크 (외부 연결 없음) — 없으면 생성.
+    const netExists = await run(d, ['network', 'inspect', cfg.egressNetwork]);
+    if (netExists.code !== 0) {
+        const c = await run(d, ['network', 'create', '--internal', cfg.egressNetwork]);
+        if (c.code !== 0 && !/already exists/i.test(c.stderr)) {
+            throw new Error(`egress internal 네트워크 생성 실패: ${c.stderr}`);
+        }
+        logger.info(`internal 네트워크 생성: ${cfg.egressNetwork}`);
+    }
+
+    // 2) 프록시 컨테이너 — 실행 중이면 재사용, 아니면 생성.
+    const running = await run(d, ['inspect', '-f', '{{.State.Running}}', cfg.egressProxyContainer]);
+    if (running.stdout !== 'true') {
+        await run(d, ['rm', '-f', cfg.egressProxyContainer]); // 잔존 제거
+        const create = await run(d, [
+            'run', '-d', '--name', cfg.egressProxyContainer,
+            '--network', cfg.egressNetwork,
+            '--cap-drop', 'ALL', '--security-opt', 'no-new-privileges', '--read-only',
+            '-e', `EGRESS_ALLOWLIST=${cfg.egressAllowlist.join(',')}`,
+            '-e', `EGRESS_PROXY_PORT=${cfg.egressProxyPort}`,
+            cfg.egressProxyImage,
+        ]);
+        if (create.code !== 0) throw new Error(`egress 프록시 컨테이너 생성 실패: ${create.stderr}`);
+        // 프록시는 bridge 에도 연결 — 외부(allowlist 도메인) 도달용.
+        const connect = await run(d, ['network', 'connect', 'bridge', cfg.egressProxyContainer]);
+        if (connect.code !== 0 && !/already exists|endpoint/i.test(connect.stderr)) {
+            logger.warn(`egress 프록시 bridge 연결 경고: ${connect.stderr}`);
+        }
+        logger.info(`egress 프록시 기동 (${cfg.egressProxyContainer}, allowlist=${cfg.egressAllowlist.length}개)`);
+    }
+    return `http://${cfg.egressProxyContainer}:${cfg.egressProxyPort}`;
+}
+
+/** 프록시/네트워크 정리(운영 도구·테스트용). */
+export async function teardownEgressProxy(cfg: TaskSandboxConfig): Promise<void> {
+    const d = cfg.dockerPath;
+    await run(d, ['rm', '-f', cfg.egressProxyContainer]);
+    await run(d, ['network', 'rm', cfg.egressNetwork]);
+}

--- a/apps/api/src/services/task-sandbox/sandbox.ts
+++ b/apps/api/src/services/task-sandbox/sandbox.ts
@@ -62,15 +62,18 @@ export function buildBrowserRunArgs(
     hostWorkdir: string,
     actionsRelPath: string,
     cfg: TaskSandboxConfig,
+    proxyUrl?: string,
 ): string[] {
     const a: string[] = ['run', '--rm', '--init'];
-    a.push('--network', cfg.browserNetwork || 'bridge');
+    // egress 프록시 ON: internal 망(인터넷 직접 차단) + 프록시 env. OFF: browserNetwork(bridge).
+    a.push('--network', proxyUrl ? cfg.egressNetwork : (cfg.browserNetwork || 'bridge'));
     a.push('--cap-drop', 'ALL', '--security-opt', 'no-new-privileges');
     a.push('--pids-limit', String(cfg.pidsLimit), '--memory', cfg.memory, '--cpus', cfg.cpus);
     a.push('--user', cfg.user);
     a.push('--read-only', '--tmpfs', '/tmp:rw,exec', '--tmpfs', '/run:rw');
     a.push('-v', `${hostWorkdir}:${WORKSPACE}:rw`);
     a.push('-w', WORKSPACE);
+    if (proxyUrl) a.push('-e', `BROWSER_PROXY=${proxyUrl}`);
     a.push(cfg.image, 'node', '/opt/browser/browser-runner.mjs', actionsRelPath);
     return a;
 }
@@ -206,7 +209,13 @@ export class TaskSandbox {
      */
     async runBrowser(actionsRelPath: string): Promise<ExecResult> {
         this.assertCreated();
-        const args = buildBrowserRunArgs(this.hostWorkdir, actionsRelPath, this.cfg);
+        // egress 프록시 ON: internal 망 + 프록시 보장 후 그 URL 을 브라우저에 주입.
+        let proxyUrl: string | undefined;
+        if (this.cfg.egressProxyEnabled) {
+            const { ensureEgressProxy } = await import('./egress-proxy');
+            proxyUrl = await ensureEgressProxy(this.cfg);
+        }
+        const args = buildBrowserRunArgs(this.hostWorkdir, actionsRelPath, this.cfg, proxyUrl);
         return runProcess(this.cfg.dockerPath, args, {
             timeoutMs: Math.max(this.cfg.execTimeoutMs, 90_000),
             outputCap: this.cfg.outputCap,

--- a/infra/egress-proxy/Dockerfile
+++ b/infra/egress-proxy/Dockerfile
@@ -1,0 +1,15 @@
+# OpenMake Egress Proxy — 브라우저 컨테이너 네트워크 레벨 도메인 allowlist (Manus 하드닝).
+#
+# 브라우저 전용 task 컨테이너는 internal Docker 네트워크(인터넷 차단)에만 연결되고, 이 프록시를
+# 통해서만 외부로 나간다. 프록시는 양쪽(internal + bridge)에 연결돼 allowlist 통과 트래픽만 포워딩.
+#
+# 빌드 (사용자 직접 — 1회):
+#   docker build -t openmake-egress-proxy:latest infra/egress-proxy
+#
+# 실행은 services/task-sandbox/egress-proxy.ts 가 런타임에 관리(ensureEgressProxy).
+FROM node:22-slim
+USER node
+WORKDIR /app
+COPY proxy.mjs /app/proxy.mjs
+EXPOSE 8888
+CMD ["node", "/app/proxy.mjs"]

--- a/infra/egress-proxy/proxy.mjs
+++ b/infra/egress-proxy/proxy.mjs
@@ -1,0 +1,54 @@
+/**
+ * Egress 포워드 프록시 — 브라우저 컨테이너의 네트워크 레벨 도메인 allowlist (Manus 하드닝).
+ *
+ * 브라우저 전용 task 컨테이너는 internal Docker 네트워크(인터넷 차단)에만 연결되고, 이 프록시를
+ * 통해서만 외부로 나간다. 프록시는 HTTPS CONNECT 의 대상 호스트를 allowlist 와 대조해
+ * 허용 도메인만 터널을 연다(네트워크 레벨 — 브라우저 page.route 앱-레벨 allowlist 위의 이중방어).
+ *
+ * EGRESS_ALLOWLIST=쉼표목록 (비면 전부 거부 = fail-safe). 하위도메인 매칭.
+ * 포트 8888.
+ */
+import net from 'node:net';
+import http from 'node:http';
+
+const PORT = Number(process.env.EGRESS_PROXY_PORT) || 8888;
+const ALLOW = (process.env.EGRESS_ALLOWLIST || '')
+    .split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
+
+function allowed(host) {
+    if (!host) return false;
+    const h = host.toLowerCase();
+    // fail-safe: allowlist 비면 전부 거부.
+    return ALLOW.some((d) => h === d || h.endsWith('.' + d));
+}
+
+function log(msg) { process.stdout.write(`[egress-proxy] ${msg}\n`); }
+
+// 일반 HTTP 프록시 요청은 미지원(브라우저 HTTPS 는 CONNECT 사용) — 405.
+const server = http.createServer((_req, res) => {
+    res.writeHead(405, { 'content-type': 'text/plain' });
+    res.end('egress-proxy: HTTPS CONNECT only');
+});
+
+// HTTPS 터널 — CONNECT host:port. allowlist 통과 시에만 TCP 터널 연결.
+server.on('connect', (req, clientSocket, head) => {
+    const [host, portRaw] = String(req.url).split(':');
+    const port = Number(portRaw) || 443;
+    if (!allowed(host)) {
+        log(`DENY ${host}:${port}`);
+        clientSocket.write('HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n');
+        clientSocket.destroy();
+        return;
+    }
+    const upstream = net.connect(port, host, () => {
+        clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+        if (head && head.length) upstream.write(head);
+        upstream.pipe(clientSocket);
+        clientSocket.pipe(upstream);
+    });
+    upstream.on('error', () => clientSocket.destroy());
+    clientSocket.on('error', () => upstream.destroy());
+});
+
+server.on('clientError', (_e, socket) => { try { socket.destroy(); } catch { /* */ } });
+server.listen(PORT, () => log(`listening :${PORT} allowlist=[${ALLOW.join(',') || '(empty=deny-all)'}]`));

--- a/infra/task-runtime/browser-runner.mjs
+++ b/infra/task-runtime/browser-runner.mjs
@@ -47,7 +47,13 @@ const results = [];
 let finalUrl = '';
 let browser;
 try {
-    browser = await chromium.launch({ headless: spec.headless !== false });
+    // egress 프록시(BROWSER_PROXY) 가 주입되면 chromium 의 모든 트래픽을 프록시 경유 — 프록시가
+    // 네트워크 레벨 도메인 allowlist 를 강제(page.route 앱-레벨 위의 이중방어).
+    const proxyServer = process.env.BROWSER_PROXY || spec.proxy;
+    browser = await chromium.launch({
+        headless: spec.headless !== false,
+        ...(proxyServer ? { proxy: { server: proxyServer } } : {}),
+    });
     const context = await browser.newContext();
     context.setDefaultTimeout(timeout);
     if (allowlist) {


### PR DESCRIPTION
## 배경
운영 정책 4번(외부 출시 전 egress 프록시) 구현. 메인 샌드박스(bash/python)는 이미 `network=none`(인터넷 0)이라 대상이 아니고, **브라우저 컨테이너 한정** 네트워크 레벨 도메인 allowlist를 추가한다.

기존 브라우저는 `bridge`(전체 인터넷) + `page.route` 앱-레벨 allowlist. 이제 **internal 망(인터넷 직접 차단) + CONNECT 포워드 프록시**로 네트워크 레벨에서도 allowlist를 강제(이중방어).

## 구현
- `infra/egress-proxy/`: 경량 node CONNECT 포워드 프록시(도메인 allowlist, 비면 fail-safe deny) + Dockerfile.
- `services/task-sandbox/egress-proxy.ts`: `ensureEgressProxy` — internal 망 + 프록시 컨테이너 멱등 생성, 프록시를 bridge에도 연결(외부 도달).
- `sandbox.ts`: `runBrowser`가 프록시 ON 시 `ensureEgressProxy` → 브라우저를 internal 망에 + `BROWSER_PROXY` 주입.
- `browser-runner.mjs`: `BROWSER_PROXY` → `chromium.launch({ proxy })`.
- `config`: `TASK_SANDBOX_EGRESS_PROXY_ENABLED`(기본 false)/`ALLOWLIST`/`IMAGE`/`NETWORK` 외부화.

## 동작
- 브라우저 컨테이너: internal 망(직접 인터넷 0) → 프록시 경유만 가능
- 프록시: CONNECT 대상 호스트를 allowlist 대조 → 허용시 터널, 거부시 403
- 결과: 허용 도메인만 도달, 그 외 `ERR_TUNNEL_CONNECTION_FAILED`

## 검증
- [x] tsc 0 / eslint 0 / build / 유닛 50 pass
- [x] **인프라 결정적 검증**: allowlist=example.com → example.com "Example Domain" 성공 / **example.org → net::ERR_TUNNEL_CONNECTION_FAILED 차단**

## 운영
- 기본 **OFF**(prod 무변경). 활성화: 이미지 빌드(`infra/egress-proxy`) + `TASK_SANDBOX_EGRESS_PROXY_ENABLED=true` + `TASK_SANDBOX_EGRESS_ALLOWLIST=...`.
- 외부 출시 시점에 활성화 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)