### PR TITLE
feat(chat): 딥리서치/에이전트 작업 채팅 인라인 완성 (진행·승인·결과)

### DIFF
--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -1,14 +1,67 @@
 "use client";
 
-import { useEffect, useRef, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import Image from "next/image";
-import { MessagesSquare, Telescope, Brain, Sparkles, FileCode2, ChevronRight } from "lucide-react";
-import { useAppStore } from "@/lib/store";
+import { MessagesSquare, Telescope, Brain, Sparkles, FileCode2, ChevronRight, LoaderCircle } from "lucide-react";
+import { useAppStore, type PendingApproval } from "@/lib/store";
+import { ApiClient } from "@/lib/api-client";
 import { Markdown } from "./markdown";
 import { StructuredAnswer } from "./structured-answer";
 import { cn } from "@/lib/utils";
 
 const ARTIFACT_PLACEHOLDER = /\[\[artifact:([^\]]+)\]\]/g;
+
+/** 에이전트 작업 승인 대기 — 채팅 인라인 승인/거절 버튼 (paused task). */
+function InlineApprovals({ approvals }: { approvals: PendingApproval[] }) {
+  const setChatHistory = useAppStore((s) => s.setChatHistory);
+  const [busy, setBusy] = useState<string | null>(null);
+  if (approvals.length === 0) return null;
+
+  async function decide(a: PendingApproval, decision: "approve" | "reject") {
+    setBusy(a.approvalId);
+    try {
+      await ApiClient.post(`/api/agent-tasks/approvals/${a.approvalId}/${decision}`, {});
+      // 낙관적 제거 — 해당 approval 을 메시지에서 뺀다(승인 시 agent_task_progress 가 곧 갱신).
+      setChatHistory((prev) =>
+        prev.map((m) =>
+          m.taskId === a.taskId
+            ? { ...m, approvals: (m.approvals ?? []).filter((x) => x.approvalId !== a.approvalId) }
+            : m,
+        ),
+      );
+    } catch (e) {
+      alert("처리 실패: " + (e instanceof Error ? e.message : "오류"));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="mt-2 space-y-2 rounded-lg border border-warning/40 bg-warning-soft/40 p-2.5">
+      <p className="text-xs font-medium text-fg-2">도구 실행 승인 필요</p>
+      {approvals.map((a) => (
+        <div key={a.approvalId} className="flex items-center justify-between gap-2 rounded-md border border-border bg-surface-1 p-2">
+          <div className="min-w-0">
+            <span className="font-mono text-xs text-fg-2">{a.toolName}</span>
+            <span className="ml-2 break-all text-xs text-muted">{JSON.stringify(a.args).slice(0, 90)}</span>
+          </div>
+          <div className="flex shrink-0 gap-1">
+            <button
+              disabled={busy === a.approvalId}
+              onClick={() => decide(a, "reject")}
+              className="rounded-md border border-border px-2.5 py-1 text-xs text-muted hover:bg-surface-2 disabled:opacity-50"
+            >거절</button>
+            <button
+              disabled={busy === a.approvalId}
+              onClick={() => decide(a, "approve")}
+              className="rounded-md bg-accent px-2.5 py-1 text-xs font-medium text-accent-fg hover:opacity-90 disabled:opacity-50"
+            >승인</button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 /** 영속화된 `[[artifact:id]]` placeholder 를 클릭 가능한 아티팩트 칩으로 렌더. */
 function ArtifactChip({ id }: { id: string }) {
@@ -128,12 +181,43 @@ const QUICK_STARTS = [
   { icon: Sparkles, label: "브레인스토밍", prompt: "다음에 대해 브레인스토밍하자:\n\n" },
 ];
 
+/** 딥리서치 진행 배너 — 스트리밍 중 단계/진행/루프를 라이브 표시. */
+function ResearchProgressBanner() {
+  const rp = useAppStore((s) => s.researchProgress);
+  if (!rp) return null;
+  const filled = Math.round(rp.progress / 10);
+  return (
+    <div className="flex gap-3">
+      <div className="mt-0.5 grid h-7 w-7 shrink-0 place-items-center rounded-md bg-accent-soft text-accent">
+        <Telescope className="h-4 w-4" />
+      </div>
+      <div className="min-w-0 flex-1 rounded-lg border border-border bg-surface-2/60 p-3">
+        <div className="mb-1 flex items-center gap-2 text-xs font-medium text-fg-2">
+          <LoaderCircle className="h-3.5 w-3.5 animate-spin text-accent" />
+          딥 리서치 진행 중
+          {rp.totalLoops > 0 && (
+            <span className="text-faint">· 루프 {rp.currentLoop}/{rp.totalLoops}</span>
+          )}
+        </div>
+        {rp.message && <p className="mb-1.5 text-xs text-muted">{rp.message}</p>}
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[11px] text-accent">
+            {"▓".repeat(filled)}{"░".repeat(10 - filled)}
+          </span>
+          <span className="text-[11px] text-faint">{rp.progress}%{rp.currentStep ? ` · ${rp.currentStep}` : ""}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function MessageList() {
   const chatHistory = useAppStore((s) => s.chatHistory);
   const setInputDraft = useAppStore((s) => s.setInputDraft);
   const isGenerating = useAppStore((s) => s.isGenerating);
   const activeAgent = useAppStore((s) => s.activeAgent);
   const activeSkills = useAppStore((s) => s.activeSkills);
+  const researchProgress = useAppStore((s) => s.researchProgress);
   const bottomRef = useRef<HTMLDivElement>(null);
 
   // 응답이 진행 중인데 아직 스트리밍 중인 assistant 메시지가 없으면(첫 토큰 전) "분석 중" 표시
@@ -221,10 +305,14 @@ export function MessageList() {
                   <span className="ml-0.5 inline-block h-4 w-1.5 animate-pulse bg-accent align-text-bottom" />
                 )}
               </div>
+              {m.approvals && m.approvals.length > 0 && (
+                <InlineApprovals approvals={m.approvals} />
+              )}
             </div>
           </div>
         ),
       )}
+      {researchProgress && <ResearchProgressBanner />}
       {showThinking && <ThinkingIndicator agent={activeAgent} skills={activeSkills} />}
       <div ref={bottomRef} className={cn("h-px")} />
     </div>

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -19,6 +19,25 @@ export interface ChatMessage extends Pick<SharedChatMessage, "role" | "content" 
   reasoning?: string;
   /** 구조화 답변 데이터 (structuredMode=true 시 REST /api/chat/structured 응답). 있으면 카드 UI 로 렌더. */
   structured?: StructuredAnswerData;
+  /** 에이전트 작업이 승인 대기(paused)일 때 표시할 대기 중 도구 호출 — 채팅 인라인 승인. */
+  approvals?: PendingApproval[];
+}
+
+/** 에이전트 작업 도구 호출 승인 대기 (백엔드 approval-gate PendingApproval 대응). */
+export interface PendingApproval {
+  approvalId: string;
+  taskId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+}
+
+/** 딥리서치 진행상황 (백엔드 research_progress 이벤트 — DeepResearch ResearchProgress 대응). */
+export interface ResearchProgressInfo {
+  currentStep: string;
+  progress: number;
+  message: string;
+  currentLoop: number;
+  totalLoops: number;
 }
 
 /**
@@ -77,6 +96,8 @@ interface AppState {
   /** 현재 응답에 선택된 에이전트 + 활성 스킬 (ws agent_selected / skills_activated) */
   activeAgent: { name: string; emoji?: string } | null;
   activeSkills: string[];
+  /** 딥리서치 진행상황 (ws research_progress) — 스트리밍 중 상태 배너로 표시, done 시 clear. */
+  researchProgress: ResearchProgressInfo | null;
 
   // 아티팩트
   artifacts: Artifact[];
@@ -112,6 +133,7 @@ interface AppState {
   setInputDraft: (t: string) => void;
   setActiveAgent: (a: { name: string; emoji?: string } | null) => void;
   setActiveSkills: (s: string[]) => void;
+  setResearchProgress: (p: ResearchProgressInfo | null) => void;
   clearChat: () => void;
 
   // 아티팩트 actions
@@ -121,6 +143,8 @@ interface AppState {
   setActiveArtifact: (id: string | null) => void;
   setArtifactPanelOpen: (v: boolean) => void;
   setArtifacts: (list: Artifact[]) => void;
+  /** 완료된 아티팩트들을 패널 자동 오픈 없이 store 에 등록(dedup by id) — 에이전트 작업 인라인용. */
+  registerArtifacts: (list: Artifact[]) => void;
 
   toggle: (
     key:
@@ -157,6 +181,7 @@ export const useAppStore = create<AppState>()(
   inputDraft: "",
   activeAgent: null,
   activeSkills: [],
+  researchProgress: null,
 
   artifacts: [],
   activeArtifactId: null,
@@ -215,12 +240,14 @@ export const useAppStore = create<AppState>()(
   setInputDraft: (t) => set({ inputDraft: t }),
   setActiveAgent: (a) => set({ activeAgent: a }),
   setActiveSkills: (s) => set({ activeSkills: s }),
+  setResearchProgress: (p) => set({ researchProgress: p }),
   clearChat: () =>
     set({
       chatHistory: [],
       currentSessionId: null,
       activeAgent: null,
       activeSkills: [],
+      researchProgress: null,
       artifacts: [],
       activeArtifactId: null,
       artifactPanelOpen: false,
@@ -253,6 +280,13 @@ export const useAppStore = create<AppState>()(
       artifacts: list,
       activeArtifactId: list.length > 0 ? (s.activeArtifactId ?? list[list.length - 1].id) : null,
     })),
+  registerArtifacts: (list) =>
+    set((s) => {
+      // 패널 자동 오픈 없이 append (dedup by id).
+      const ids = new Set(s.artifacts.map((a) => a.id));
+      const added = list.filter((a) => !ids.has(a.id));
+      return added.length > 0 ? { artifacts: [...s.artifacts, ...added] } : {};
+    }),
 
   toggle: (key) => set((s) => ({ [key]: !s[key] }) as Partial<AppState>),
   setSelectedModel: (m) => set({ selectedModel: m }),

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { WsChatRequest, WsServerEvent, WsAttachedFile } from "@openmake/shared-types";
-import { useAppStore, type StructuredAnswerData } from "./store";
+import { useAppStore, type StructuredAnswerData, type PendingApproval } from "./store";
 import { ApiClient } from "./api-client";
 import { CLIENT_TIMING } from "./config";
 
@@ -63,6 +63,9 @@ function renderAgentTaskMessage(
     const label = status === "failed" ? "실패" : "취소됨";
     return `${head}\n\n❌ **${label}**${result?.trim() ? `\n\n---\n\n${result.trim()}` : ""}`;
   }
+  if (status === "paused") {
+    return `${head}\n\n⏸️ **승인 대기 중** — 아래에서 도구 실행을 승인/거절하세요. · 턴 ${currentTurn ?? 0}`;
+  }
   // pending / running
   const pct = Math.max(0, Math.min(100, Math.round(progress || 0)));
   const filled = Math.round(pct / 10);
@@ -88,9 +91,11 @@ export function useChatSocket() {
     setCurrentSessionId,
     setActiveAgent,
     setActiveSkills,
+    setResearchProgress,
     startArtifact,
     appendArtifactDelta,
     endArtifact,
+    registerArtifacts,
   } = useAppStore();
 
   const connect = useCallback(() => {
@@ -125,9 +130,11 @@ export function useChatSocket() {
         case "done":
           if (data.sessionId) setCurrentSessionId(data.sessionId);
           setStreaming(false);
+          setResearchProgress(null);
           break;
         case "aborted":
           setStreaming(false);
+          setResearchProgress(null);
           break;
         case "error":
           appendMessage({
@@ -135,7 +142,20 @@ export function useChatSocket() {
             content: `오류: ${data.message ?? "알 수 없는 오류"}`,
           });
           setStreaming(false);
+          setResearchProgress(null);
           break;
+        case "research_progress": {
+          // 딥리서치 진행을 채팅 상태 배너로 라이브 표시(스트리밍 시작 전/중).
+          const p = data.progress ?? {};
+          setResearchProgress({
+            currentStep: p.currentStep ?? "",
+            progress: Math.max(0, Math.min(100, Math.round(p.progress ?? 0))),
+            message: p.message ?? "",
+            currentLoop: p.currentLoop ?? 0,
+            totalLoops: p.totalLoops ?? 0,
+          });
+          break;
+        }
         case "agent_selected":
           setActiveAgent({ name: data.agent.name, emoji: data.agent.emoji });
           break;
@@ -160,28 +180,75 @@ export function useChatSocket() {
           if (terminal) {
             void (async () => {
               let result = "";
+              const chips: string[] = [];
+              const fileLinks: string[] = [];
               try {
-                const r = await ApiClient.get<{ data: { task: { result?: string } } }>(
-                  `/api/agent-tasks/${taskId}`,
-                );
+                const r = await ApiClient.get<{
+                  data: {
+                    task: { result?: string };
+                    steps?: Array<{ step_type: string; content?: string }>;
+                  };
+                }>(`/api/agent-tasks/${taskId}`);
                 result = r?.data?.task?.result ?? "";
+                // deliverable 아티팩트 — store 등록 + [[artifact:id]] 칩 주입(일반 채팅과 동일 인라인).
+                const arts = (r?.data?.steps ?? [])
+                  .filter((s) => s.step_type === "artifact")
+                  .map((s) => { try { return JSON.parse(s.content ?? ""); } catch { return null; } })
+                  .filter((a): a is { id: string; kind: string; title?: string; lang?: string | null; content?: string } => !!a?.id);
+                if (arts.length > 0) {
+                  registerArtifacts(arts.map((a) => ({
+                    id: a.id, kind: a.kind, title: a.title ?? a.id, lang: a.lang ?? null,
+                    content: a.content ?? "", streaming: false,
+                  })));
+                  for (const a of arts) chips.push(`[[artifact:${a.id}]]`);
+                }
               } catch {
                 /* 결과 조회 실패 — 상태만 표시 */
               }
+              // 산출물 파일(완료 시 workspace 보존) 다운로드 링크.
+              try {
+                const f = await ApiClient.get<{ data: { files: string[] } }>(
+                  `/api/agent-tasks/${taskId}/files`,
+                );
+                for (const file of f?.data?.files ?? []) {
+                  fileLinks.push(`[${file}](/api/agent-tasks/${taskId}/files/download?path=${encodeURIComponent(file)})`);
+                }
+              } catch { /* 파일 없음 */ }
+              const extras =
+                (chips.length ? `\n\n${chips.join(" ")}` : "") +
+                (fileLinks.length ? `\n\n**📎 산출물:** ${fileLinks.join(" · ")}` : "");
               setChatHistory((prev) =>
                 prev.map((m) =>
                   m.taskId === taskId
-                    ? { ...m, content: renderAgentTaskMessage(goal, status, currentTurn, progress, result) }
+                    ? { ...m, approvals: undefined, content: renderAgentTaskMessage(goal, status, currentTurn, progress, result) + extras }
                     : m,
                 ),
               );
               agentGoalsRef.current.delete(taskId);
             })();
+          } else if (status === "paused") {
+            // 승인 대기 — 해당 task 의 pending approval 을 조회해 채팅에 인라인 승인 버튼 노출.
+            void (async () => {
+              let mine: PendingApproval[] = [];
+              try {
+                const r = await ApiClient.get<{ data: { pending: PendingApproval[] } }>(
+                  `/api/agent-tasks/approvals/pending`,
+                );
+                mine = (r?.data?.pending ?? []).filter((p) => p.taskId === taskId);
+              } catch { /* 조회 실패 — 상태만 */ }
+              setChatHistory((prev) =>
+                prev.map((m) =>
+                  m.taskId === taskId
+                    ? { ...m, approvals: mine, content: renderAgentTaskMessage(goal, status, currentTurn, progress) }
+                    : m,
+                ),
+              );
+            })();
           } else {
             setChatHistory((prev) =>
               prev.map((m) =>
                 m.taskId === taskId
-                  ? { ...m, content: renderAgentTaskMessage(goal, status, currentTurn, progress) }
+                  ? { ...m, approvals: undefined, content: renderAgentTaskMessage(goal, status, currentTurn, progress) }
                   : m,
               ),
             );
@@ -189,7 +256,7 @@ export function useChatSocket() {
           break;
         }
         default:
-          break; // init / research_progress / token_warning 등은 추후
+          break; // init / token_warning 등은 추후
       }
     };
 

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -146,6 +146,19 @@ export type WsServerEvent =
       status: string;
       progress: number;
       currentTurn: number;
+    }
+  // 딥리서치 진행상황 (백엔드 ws-chat-handler onResearchProgress)
+  | {
+      type: "research_progress";
+      progress: {
+        sessionId?: string;
+        status?: string;
+        currentLoop?: number;
+        totalLoops?: number;
+        currentStep?: string;
+        progress?: number;
+        message?: string;
+      };
     };
 
 /* ── 응답 페이로드 헬퍼 타입 ─────────────────────────────────────────── */


### PR DESCRIPTION
## 배경
전체 점검 결과, 딥리서치·에이전트 작업이 채팅에서 **인라인 실행**은 되나 **모니터링·승인·결과**가 불완전했다. 이를 단일 채팅 인라인 구조로 통합.

## 발견된 갭 → 수정
| 우선 | 갭 | 수정 |
|---|---|---|
| 🔴 | 에이전트 작업 **HITL 승인이 채팅에 없음** (채팅 작업이 paused 에서 멈춤 — 승인은 /agent-tasks 페이지에만) | `InlineApprovals` — paused 시 pending approval 조회 → 채팅 메시지에 승인/거절 버튼 |
| 🔴 | 에이전트 작업 **deliverable 아티팩트 인라인 누락** (result 에서 stripped, /agent-tasks 에만) | 완료 시 step_type='artifact' 조회 → `registerArtifacts` + `[[artifact:id]]` 칩 주입(기존 인프라 재사용) |
| 🟡 | 딥리서치 **진행 이벤트 무시** (백엔드는 research_progress 발행하나 프론트 default:break) | `case research_progress` → `ResearchProgressBanner`(루프/단계/%/메시지 라이브) |
| 🟡 | 에이전트 작업 **산출물 파일 인라인 누락** | /files 다운로드 링크 주입 |

## 구현
- `store.ts`: `ChatMessage.approvals`, `researchProgress` 슬라이스 + `setResearchProgress`, `registerArtifacts`(패널 자동오픈 없이 dedup append).
- `shared-types`: `WsServerEvent` 에 `research_progress` 추가.
- `use-chat-socket.ts`: research_progress 케이스 + done/error 시 clear, agent_task_progress 강화(paused→승인조회, completed→아티팩트등록+칩+파일링크).
- `message-list.tsx`: `InlineApprovals`(승인/거절) + `ResearchProgressBanner`.

## 검증
- [x] tsc(api/web) 0, build(api/web) 성공
- [x] **Playwright E2E 완주**(프로덕션 UI): 채팅 에이전트 작업 시작 → 인라인 승인(bash + str_replace 반복 승인) → 진행바 라이브(턴/%) → **완료 결과 + 아티팩트 칩(`chk.txt 내용`) + 파일 다운로드**(내용 `inline-approval-test`, HTTP 200) 인라인 / 딥리서치 **진행 배너**(루프 1/5 · 16% · synthesize)

🤖 Generated with [Claude Code](https://claude.com/claude-code)