### PR TITLE
feat(chat): 인라인 결과 카드 재디자인 — 이모지→벡터 아이콘 (Open Design/Lumen)

### DIFF
--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import Image from "next/image";
-import { MessagesSquare, Telescope, Brain, Sparkles, FileCode2, ChevronRight, LoaderCircle } from "lucide-react";
-import { useAppStore, type PendingApproval } from "@/lib/store";
+import { MessagesSquare, Telescope, Brain, Sparkles, FileCode2, ChevronRight, LoaderCircle, Pause, CircleCheck, CircleX, Download, FileText, ShieldCheck } from "lucide-react";
+import { useAppStore, type PendingApproval, type AgentTaskState } from "@/lib/store";
 import { ApiClient } from "@/lib/api-client";
 import { Markdown } from "./markdown";
 import { StructuredAnswer } from "./structured-answer";
@@ -37,8 +37,10 @@ function InlineApprovals({ approvals }: { approvals: PendingApproval[] }) {
   }
 
   return (
-    <div className="mt-2 space-y-2 rounded-lg border border-warning/40 bg-warning-soft/40 p-2.5">
-      <p className="text-xs font-medium text-fg-2">도구 실행 승인 필요</p>
+    <div className="mt-1 space-y-2 rounded-md border border-warning-soft bg-warning-soft/50 p-2.5">
+      <p className="flex items-center gap-1.5 text-xs font-semibold text-fg-2">
+        <ShieldCheck className="h-3.5 w-3.5 text-warning" /> 도구 실행 승인 필요
+      </p>
       {approvals.map((a) => (
         <div key={a.approvalId} className="flex items-center justify-between gap-2 rounded-md border border-border bg-surface-1 p-2">
           <div className="min-w-0">
@@ -181,6 +183,94 @@ const QUICK_STARTS = [
   { icon: Sparkles, label: "브레인스토밍", prompt: "다음에 대해 브레인스토밍하자:\n\n" },
 ];
 
+/** 에이전트 작업 인라인 카드 — 상태별 벡터 아이콘 + 진행바 + 결과/아티팩트/산출물 + 승인 (이모지 없음). */
+type TaskTone = "run" | "pause" | "ok" | "fail";
+const TASK_STATUS: Record<string, { Icon: typeof Pause; spin: boolean; tone: TaskTone; badge: string }> = {
+  pending: { Icon: LoaderCircle, spin: true, tone: "run", badge: "대기" },
+  running: { Icon: LoaderCircle, spin: true, tone: "run", badge: "실행 중" },
+  paused: { Icon: Pause, spin: false, tone: "pause", badge: "승인 대기" },
+  completed: { Icon: CircleCheck, spin: false, tone: "ok", badge: "완료" },
+  failed: { Icon: CircleX, spin: false, tone: "fail", badge: "실패" },
+  cancelled: { Icon: CircleX, spin: false, tone: "fail", badge: "취소됨" },
+};
+const TONE_ICON: Record<TaskTone, string> = {
+  run: "bg-accent-soft text-accent",
+  pause: "bg-warning-soft text-warning",
+  ok: "bg-success-soft text-success",
+  fail: "bg-danger-soft text-danger",
+};
+const TONE_BADGE: Record<TaskTone, string> = {
+  run: "bg-accent-soft text-accent",
+  pause: "bg-warning-soft text-warning",
+  ok: "bg-success-soft text-success",
+  fail: "bg-danger-soft text-danger",
+};
+
+function AgentTaskCard({ task, approvals, taskId }: { task: AgentTaskState; approvals?: PendingApproval[]; taskId?: string }) {
+  const cfg = TASK_STATUS[task.status] ?? TASK_STATUS.running;
+  const pct = Math.max(0, Math.min(100, Math.round(task.progress || 0)));
+  const Icon = cfg.Icon;
+  const showProgress = task.status === "pending" || task.status === "running" || task.status === "paused";
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-surface-1">
+      <div className="flex items-center gap-2.5 border-b border-border px-3.5 py-2.5">
+        <span className={cn("grid h-6 w-6 shrink-0 place-items-center rounded-md", TONE_ICON[cfg.tone])}>
+          <Icon className={cn("h-3.5 w-3.5", cfg.spin && "animate-spin")} />
+        </span>
+        <span className="text-[13px] font-semibold tracking-tight text-fg">에이전트 작업</span>
+        <span className={cn("ml-auto rounded-full px-2 py-0.5 font-mono text-[11px] font-semibold tabular-nums", TONE_BADGE[cfg.tone])}>
+          {cfg.badge}{cfg.tone !== "ok" && task.currentTurn > 0 ? ` · 턴 ${task.currentTurn}` : ""}
+        </span>
+      </div>
+      <div className="flex flex-col gap-2.5 px-3.5 py-3">
+        {task.goal && (
+          <p className="text-xs text-muted"><span className="font-semibold text-fg-2">목표</span>&nbsp; {task.goal}</p>
+        )}
+        {showProgress && (
+          <div className="flex items-center gap-2.5">
+            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-surface-3">
+              <div className="h-full rounded-full bg-accent transition-all" style={{ width: `${pct}%` }} />
+            </div>
+            <span className="shrink-0 font-mono text-[11px] tabular-nums text-faint">{pct}% · 턴 {task.currentTurn ?? 0}</span>
+          </div>
+        )}
+        {task.result && (task.status === "completed" || task.status === "failed") && (
+          <div className="border-t border-border pt-2.5 text-[13px] leading-relaxed text-fg-2">
+            {/* AssistantContent 가 [[artifact:id]] placeholder 를 클릭 칩으로 변환(일반 채팅과 동일). */}
+            <AssistantContent content={task.result} />
+          </div>
+        )}
+        {/* result placeholder 에 없는 잔여 아티팩트만 보강 칩으로(중복 방지). */}
+        {task.artifactIds && task.artifactIds.filter((id) => !(task.result ?? "").includes(`[[artifact:${id}]]`)).length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {task.artifactIds.filter((id) => !(task.result ?? "").includes(`[[artifact:${id}]]`)).map((id) => <ArtifactChip key={id} id={id} />)}
+          </div>
+        )}
+        {task.files && task.files.length > 0 && (
+          <div>
+            <div className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold text-muted">
+              <Download className="h-3 w-3" /> 산출물
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {task.files.map((f) => (
+                <a
+                  key={f}
+                  href={`/api/agent-tasks/${taskId ?? ""}/files/download?path=${encodeURIComponent(f)}`}
+                  target="_blank" rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 rounded-md border border-border bg-surface-2 px-2.5 py-1 text-xs font-medium text-fg-2 hover:bg-surface-3"
+                >
+                  <FileText className="h-3 w-3" /> {f}
+                </a>
+              ))}
+            </div>
+          </div>
+        )}
+        {approvals && approvals.length > 0 && <InlineApprovals approvals={approvals} />}
+      </div>
+    </div>
+  );
+}
+
 /** 딥리서치 진행 배너 — 스트리밍 중 단계/진행/루프를 라이브 표시. */
 function ResearchProgressBanner() {
   const rp = useAppStore((s) => s.researchProgress);
@@ -296,18 +386,17 @@ export function MessageList() {
                 </details>
               )}
               <div className="text-sm leading-relaxed text-fg">
-                {m.structured ? (
+                {m.agentTask ? (
+                  <AgentTaskCard task={m.agentTask} approvals={m.approvals} taskId={m.taskId} />
+                ) : m.structured ? (
                   <StructuredAnswer data={m.structured} />
                 ) : (
                   <AssistantContent content={m.content} streaming={m.streaming} />
                 )}
-                {m.streaming && (
+                {m.streaming && !m.agentTask && (
                   <span className="ml-0.5 inline-block h-4 w-1.5 animate-pulse bg-accent align-text-bottom" />
                 )}
               </div>
-              {m.approvals && m.approvals.length > 0 && (
-                <InlineApprovals approvals={m.approvals} />
-              )}
             </div>
           </div>
         ),

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -21,6 +21,22 @@ export interface ChatMessage extends Pick<SharedChatMessage, "role" | "content" 
   structured?: StructuredAnswerData;
   /** 에이전트 작업이 승인 대기(paused)일 때 표시할 대기 중 도구 호출 — 채팅 인라인 승인. */
   approvals?: PendingApproval[];
+  /** 에이전트 작업 구조화 상태 — 채팅 인라인 카드(AgentTaskCard)로 렌더(이모지 대신 벡터 아이콘). */
+  agentTask?: AgentTaskState;
+}
+
+/** 에이전트 작업 인라인 카드 상태. */
+export interface AgentTaskState {
+  goal: string;
+  status: string; // pending | running | paused | completed | failed | cancelled
+  currentTurn: number;
+  progress: number;
+  /** 완료 시 결과 본문(markdown). */
+  result?: string;
+  /** 완료 시 deliverable 아티팩트 id 목록(store 에 등록됨 → 칩 렌더). */
+  artifactIds?: string[];
+  /** 완료 시 workspace 산출물 파일 경로 목록. */
+  files?: string[];
 }
 
 /** 에이전트 작업 도구 호출 승인 대기 (백엔드 approval-gate PendingApproval 대응). */

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { WsChatRequest, WsServerEvent, WsAttachedFile } from "@openmake/shared-types";
-import { useAppStore, type StructuredAnswerData, type PendingApproval } from "./store";
+import { useAppStore, type StructuredAnswerData, type PendingApproval, type AgentTaskState } from "./store";
 import { ApiClient } from "./api-client";
 import { CLIENT_TIMING } from "./config";
 
@@ -47,38 +47,11 @@ function getAnonSessionId(): string {
   }
 }
 
-/** 에이전트 작업 메시지 마크다운 — 상태에 따라 진행바/완료/실패를 렌더. */
-function renderAgentTaskMessage(
-  goal: string,
-  status: string,
-  currentTurn: number,
-  progress: number,
-  result?: string,
-): string {
-  const head = `🤖 **에이전트 작업**${goal ? `\n\n**목표:** ${goal}` : ""}`;
-  if (status === "completed") {
-    return `${head}\n\n✅ **완료**\n\n---\n\n${result?.trim() || "_(결과 본문 없음)_"}`;
-  }
-  if (status === "failed" || status === "cancelled") {
-    const label = status === "failed" ? "실패" : "취소됨";
-    return `${head}\n\n❌ **${label}**${result?.trim() ? `\n\n---\n\n${result.trim()}` : ""}`;
-  }
-  if (status === "paused") {
-    return `${head}\n\n⏸️ **승인 대기 중** — 아래에서 도구 실행을 승인/거절하세요. · 턴 ${currentTurn ?? 0}`;
-  }
-  // pending / running
-  const pct = Math.max(0, Math.min(100, Math.round(progress || 0)));
-  const filled = Math.round(pct / 10);
-  const bar = "▓".repeat(filled) + "░".repeat(10 - filled);
-  return `${head}\n\n⏳ \`${bar}\` ${pct}% · 턴 ${currentTurn ?? 0}`;
-}
-
 export function useChatSocket() {
   const wsRef = useRef<WebSocket | null>(null);
   const [connected, setConnected] = useState(false);
   const reconnectRef = useRef(0);
   // 에이전트 작업 taskId → 목표(goal) — agent_task_progress 렌더에 사용
-  const agentGoalsRef = useRef<Map<string, string>>(new Map());
   // 구조화 답변(REST) 진행 중 AbortController — abort() 가 취소할 수 있게 보관
   const structuredAbortRef = useRef<AbortController | null>(null);
 
@@ -172,86 +145,68 @@ export function useChatSocket() {
           endArtifact(data.id);
           break;
         case "agent_task_progress": {
-          // 에이전트 작업 진행상황을 해당 메시지에 라이브 반영. 완료/실패 시 결과 본문 조회.
+          // 에이전트 작업 진행을 구조화 상태(agentTask)로 갱신 → AgentTaskCard 가 벡터 아이콘으로 렌더.
           const { taskId, status, progress, currentTurn } = data;
-          const goal = agentGoalsRef.current.get(taskId) ?? "";
           const terminal =
             status === "completed" || status === "failed" || status === "cancelled";
+          const merge = (extra: Partial<AgentTaskState>, approvals: PendingApproval[] | undefined) =>
+            setChatHistory((prev) =>
+              prev.map((m) =>
+                m.taskId === taskId
+                  ? {
+                      ...m,
+                      approvals,
+                      agentTask: {
+                        goal: m.agentTask?.goal ?? "",
+                        ...(m.agentTask ?? {}),
+                        status, currentTurn, progress,
+                        ...extra,
+                      } as AgentTaskState,
+                    }
+                  : m,
+              ),
+            );
+
           if (terminal) {
             void (async () => {
               let result = "";
-              const chips: string[] = [];
-              const fileLinks: string[] = [];
+              const artifactIds: string[] = [];
+              let files: string[] = [];
               try {
                 const r = await ApiClient.get<{
-                  data: {
-                    task: { result?: string };
-                    steps?: Array<{ step_type: string; content?: string }>;
-                  };
+                  data: { task: { result?: string }; steps?: Array<{ step_type: string; content?: string }> };
                 }>(`/api/agent-tasks/${taskId}`);
                 result = r?.data?.task?.result ?? "";
-                // deliverable 아티팩트 — store 등록 + [[artifact:id]] 칩 주입(일반 채팅과 동일 인라인).
+                // deliverable 아티팩트 — store 등록 후 카드가 칩으로 렌더.
                 const arts = (r?.data?.steps ?? [])
                   .filter((s) => s.step_type === "artifact")
                   .map((s) => { try { return JSON.parse(s.content ?? ""); } catch { return null; } })
                   .filter((a): a is { id: string; kind: string; title?: string; lang?: string | null; content?: string } => !!a?.id);
                 if (arts.length > 0) {
                   registerArtifacts(arts.map((a) => ({
-                    id: a.id, kind: a.kind, title: a.title ?? a.id, lang: a.lang ?? null,
-                    content: a.content ?? "", streaming: false,
+                    id: a.id, kind: a.kind, title: a.title ?? a.id, lang: a.lang ?? null, content: a.content ?? "", streaming: false,
                   })));
-                  for (const a of arts) chips.push(`[[artifact:${a.id}]]`);
+                  for (const a of arts) artifactIds.push(a.id);
                 }
-              } catch {
-                /* 결과 조회 실패 — 상태만 표시 */
-              }
-              // 산출물 파일(완료 시 workspace 보존) 다운로드 링크.
+              } catch { /* 결과 조회 실패 — 상태만 */ }
               try {
-                const f = await ApiClient.get<{ data: { files: string[] } }>(
-                  `/api/agent-tasks/${taskId}/files`,
-                );
-                for (const file of f?.data?.files ?? []) {
-                  fileLinks.push(`[${file}](/api/agent-tasks/${taskId}/files/download?path=${encodeURIComponent(file)})`);
-                }
+                const f = await ApiClient.get<{ data: { files: string[] } }>(`/api/agent-tasks/${taskId}/files`);
+                files = f?.data?.files ?? [];
               } catch { /* 파일 없음 */ }
-              const extras =
-                (chips.length ? `\n\n${chips.join(" ")}` : "") +
-                (fileLinks.length ? `\n\n**📎 산출물:** ${fileLinks.join(" · ")}` : "");
-              setChatHistory((prev) =>
-                prev.map((m) =>
-                  m.taskId === taskId
-                    ? { ...m, approvals: undefined, content: renderAgentTaskMessage(goal, status, currentTurn, progress, result) + extras }
-                    : m,
-                ),
-              );
-              agentGoalsRef.current.delete(taskId);
+              merge({ result, artifactIds, files }, undefined);
             })();
           } else if (status === "paused") {
-            // 승인 대기 — 해당 task 의 pending approval 을 조회해 채팅에 인라인 승인 버튼 노출.
+            // 승인 대기 — 해당 task 의 pending approval 조회 → 카드에 인라인 승인 버튼.
             void (async () => {
               let mine: PendingApproval[] = [];
               try {
-                const r = await ApiClient.get<{ data: { pending: PendingApproval[] } }>(
-                  `/api/agent-tasks/approvals/pending`,
-                );
+                const r = await ApiClient.get<{ data: { pending: PendingApproval[] } }>(`/api/agent-tasks/approvals/pending`);
                 mine = (r?.data?.pending ?? []).filter((p) => p.taskId === taskId);
               } catch { /* 조회 실패 — 상태만 */ }
-              setChatHistory((prev) =>
-                prev.map((m) =>
-                  m.taskId === taskId
-                    ? { ...m, approvals: mine, content: renderAgentTaskMessage(goal, status, currentTurn, progress) }
-                    : m,
-                ),
-              );
+              merge({}, mine);
             })();
           } else {
-            setChatHistory((prev) =>
-              prev.map((m) =>
-                m.taskId === taskId
-                  ? { ...m, approvals: undefined, content: renderAgentTaskMessage(goal, status, currentTurn, progress) }
-                  : m,
-              ),
-            );
+            merge({}, undefined);
           }
           break;
         }
@@ -295,7 +250,7 @@ export function useChatSocket() {
 
       // 첨부만 있고 본문이 비면 파일명을 표시용 본문으로 사용
       const displayContent =
-        message.trim() || (hasFiles ? `📎 ${files!.map((f) => f.name).join(", ")}` : "");
+        message.trim() || (hasFiles ? files!.map((f) => f.name).join(", ") : "");
       appendMessage({ role: "user", content: displayContent, images });
       setActiveAgent(null); // 새 질문 — 이전 에이전트/스킬 표시 초기화
       setActiveSkills([]);
@@ -344,12 +299,12 @@ export function useChatSocket() {
         );
         const taskId = created?.data?.task?.id;
         if (!taskId) throw new Error("작업 생성 응답에 taskId 가 없습니다");
-        // 진행상황 메시지 — agent_task_progress 이벤트로 taskId 로 식별해 라이브 업데이트.
-        agentGoalsRef.current.set(taskId, goal);
+        // 진행상황 카드 — agent_task_progress 이벤트로 taskId 로 식별해 라이브 업데이트.
         appendMessage({
           role: "assistant",
           taskId,
-          content: renderAgentTaskMessage(goal, "pending", 0, 0),
+          content: "",
+          agentTask: { goal, status: "pending", currentTurn: 0, progress: 0 },
         });
         await ApiClient.post(`/api/agent-tasks/${taskId}/execute`);
       } catch (e) {


### PR DESCRIPTION
## 배경
Open Design MCP 로 채팅 인라인 결과를 재디자인. 이모지를 전부 lucide 벡터 아이콘으로 교체하고, 에이전트 작업 결과를 마크다운 문자열에서 구조화 카드(AgentTaskCard)로 전환.

## Open Design
- `openmake-newdesign-2026` 프로젝트에 `chat-inline-results.html` 목업 생성 — Lumen 디자인 시스템(토큰·JetBrains Mono·semantic 컬러) + lucide SVG 아이콘으로 4개 상태(승인대기/실행중/완료/리서치) 디자인.

## 구현
- `store.ts`: `ChatMessage.agentTask` 구조화 상태(goal/status/turn/progress/result/artifactIds/files). 이모지 문자열 방식 폐기.
- `use-chat-socket.ts`: `renderAgentTaskMessage`(이모지) 제거 → 구조화 업데이트. 완료 시 result/artifactIds/files 채움.
- `message-list.tsx`: `AgentTaskCard` — 상태별 아이콘(LoaderCircle/Pause/CircleCheck/CircleX) + semantic 뱃지 + 진행바 + 결과(AssistantContent [[artifact:id]]→칩) + 산출물 파일 칩 + InlineApprovals(ShieldCheck). 이모지 0.

## 검증
- [x] tsc(api/web) 0, build(web) 성공
- [x] 채팅 관련 파일 이모지 0 (grep)
- [x] **Playwright E2E**(프로덕션 UI): 채팅 에이전트 작업 → 승인대기 카드(Pause 아이콘 + "승인 대기 · 턴 1" 뱃지 + ShieldCheck 승인패널) → 승인 → 완료 카드(CircleCheck + "완료" 뱃지 + 아티팩트 칩 + 산출물 파일 링크), **모든 상태 표시가 벡터 아이콘(이모지 0)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)