### PR TITLE
fix(agent-task): 샌드박스 작업에 샌드박스 도구만 전달 — MCP 카탈로그 폭주 Connection error 해소

### DIFF
--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -221,8 +221,12 @@ export class AgentTaskService {
                     taskRuntime = null;
                 }
             }
-            // task 도구를 LLM 도구 목록에 합류 (샌드박스 ON 시에만).
-            const tools = taskRuntime ? [...mcpTools, ...taskRuntime.getLLMTools()] : mcpTools;
+            // 샌드박스(Manus) 활성 시: LLM 에 샌드박스 도구만 노출(셸/파이썬/브라우저/파일/플랜).
+            // 전체 MCP 카탈로그(~150 도구)를 함께 넘기면 도구 스키마 union 이 수백 KB 로 부풀어
+            // vLLM guided-decoding 문법 컴파일이 100s+ 로 폭주 → LLM_TIMEOUT 초과(Connection error).
+            // Manus 모델에선 에이전트가 컨테이너 셸/브라우저로 작업하므로 외부 MCP 카탈로그가 불필요.
+            // 샌드박스 OFF(legacy) 경로는 기존대로 전체 MCP 도구 사용.
+            const tools = taskRuntime ? taskRuntime.getLLMTools() : mcpTools;
 
             for (let turn = startTurn; turn < turnCeiling; turn++) {
                 this.assertWithinLimits(signal, startedAt, totalTokens);


### PR DESCRIPTION
## 문제

채팅 인라인 에이전트 작업이 첫 LLM 호출에서 **~2.5분 hang 후 `failed: Connection error`** 로 100% 실패. 카드가 `턴 1 · 5%` 에서 멈춤.

## 진단

서버(LiteLLM/vLLM) 문제가 아님 — 직접 호출(raw fetch·openai SDK, streaming·tools·`enable_thinking:false`·max_tokens 없음 전부)은 2-3s 성공. 연결풀 stale 도 아님(백엔드 재시작해도 동일).

근본 원인은 백엔드 회귀였음. `AgentTaskService` 가 샌드박스 활성 시 **등록된 전체 MCP 도구 카탈로그(~150개)** 를 LLM 에 통째로 전달:

| 도구 스키마 | 첫 토큰까지 |
|---|---|
| 단순 150개 | 2.3s |
| **복잡·대형 150개 (786KB)** | **101s** |

vLLM tool-calling 의 guided-decoding 문법(xgrammar) 컴파일이 큰 스키마 union 에서 폭주 → 실제 요청은 `LLM_TIMEOUT(120s)` 초과 → upstream 연결 reset → openai SDK 가 `APIConnectionError`("Connection error")로 표면화.

## 수정

샌드박스(Manus) 활성 시 LLM 에 **샌드박스 도구 11개만** 노출 (bash / python_execute / str_replace_editor / file_ops / browser / plan_* / delegate / terminate / ask_human). 전체 MCP 카탈로그 제거.

- **근거**: Manus 모델에선 에이전트가 컨테이너 셸·브라우저로 작업하므로 외부 MCP 카탈로그가 불필요 (OpenManus ToolCollection 과 동일한 도구 구성).
- 샌드박스 OFF(legacy) 경로는 기존대로 전체 MCP 도구 사용 — 동작 변화 없음.

```diff
-const tools = taskRuntime ? [...mcpTools, ...taskRuntime.getLLMTools()] : mcpTools;
+const tools = taskRuntime ? taskRuntime.getLLMTools() : mcpTools;
```

## 검증

- `npx eslint` 통과, `npm run build:backend` 통과
- **REST E2E**: 생성 → execute → paused → approve → completed (hello.txt 생성)
- **실앱 Playwright E2E**: 인라인 카드 전체 생애주기 라이브 — 대기 → 승인 대기(InlineApprovals 거절/승인) → 완료 + 산출물 `report.txt` 다운로드 링크. Connection error 완전 소멸.

🤖 Generated with [Claude Code](https://claude.com/claude-code)