### PR TITLE
feat(agent-task): 샌드박스 작업 내장 도구 화이트리스트(extraTools) — generate_image 복원 + 승인 게이트

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -748,6 +748,7 @@ TASK_SANDBOX_ENABLED=false
 # TASK_SANDBOX_WORKSPACE_TTL_MS=86400000              # 완료 task workspace 보존 TTL(스윕 삭제). 기본 24h
 # TASK_SANDBOX_APPROVAL_POLICY=all                     # all(전부 승인·기본) | high-risk(bash·삭제만) | none(자동)
 # TASK_SANDBOX_APPROVAL_TIMEOUT_MS=1800000             # 승인 대기 timeout(초과 시 자동 거절). 기본 30분
+# TASK_SANDBOX_EXTRA_TOOLS=generate_image              # 샌드박스 도구와 함께 노출할 내장 도구 화이트리스트(쉼표). 비면 샌드박스 도구만. ⚠️ HITL 승인 우회 — 생성·조회류만
 # AGENT_MAX_TOTAL_TOKENS=1000000                       # agent task 누적 토큰 상한(멀티턴 누적). 기본 1M
 
 MCP_SANDBOX_ENABLED=false

--- a/apps/api/src/config/task-sandbox.ts
+++ b/apps/api/src/config/task-sandbox.ts
@@ -81,6 +81,15 @@ export interface TaskSandboxConfig {
     egressProxyContainer: string;
     /** egress 프록시 포트. */
     egressProxyPort: number;
+    /**
+     * 샌드박스 활성 시 샌드박스 도구와 함께 LLM 에 노출할 비-샌드박스(내장 MCP) 도구 화이트리스트(이름).
+     * 전체 MCP 카탈로그(~150 도구)는 vLLM 문법 컴파일 폭주를 유발하므로 제외하되,
+     * 샌드박스로 대체 불가한 소수 고가치 도구(예: generate_image)만 선별 노출.
+     * 비면 샌드박스 도구만 노출(순수 Manus). 기본 generate_image.
+     * ⚠️ 이 도구들은 task 도구가 아니라 HITL 승인 게이트를 우회해 직접 실행된다 —
+     * FS/셸 변경이 없는 생성·조회류(generate_image 등)만 등록할 것. 위험 도구 금지.
+     */
+    extraTools: string[];
 }
 
 export function getTaskSandboxConfig(): TaskSandboxConfig {
@@ -116,5 +125,7 @@ export function getTaskSandboxConfig(): TaskSandboxConfig {
         egressNetwork: process.env.TASK_SANDBOX_EGRESS_NETWORK || 'omk-egress-internal',
         egressProxyContainer: process.env.TASK_SANDBOX_EGRESS_PROXY_CONTAINER || 'omk-egress-proxy',
         egressProxyPort: intEnv(process.env.TASK_SANDBOX_EGRESS_PROXY_PORT, 8888),
+        extraTools: (process.env.TASK_SANDBOX_EXTRA_TOOLS ?? 'generate_image')
+            .split(',').map((s) => s.trim()).filter(Boolean),
     };
 }

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -33,6 +33,7 @@ import { mergeToolsWithSkills, type ActiveSkillBinding } from './chat-service/to
 import { getTaskSandboxConfig } from '../config/task-sandbox';
 import { TaskRuntime } from './task-sandbox/runtime';
 import { TASK_TERMINATE_SENTINEL } from './task-sandbox/tools';
+import { requiresApproval, getApprovalRegistry } from './task-sandbox/approval-gate';
 
 const logger = createLogger('AgentTaskService');
 
@@ -192,7 +193,9 @@ export class AgentTaskService {
 
             // 영속 샌드박스(Manus화) — 플래그 ON 일 때만. OFF 면 runtime=null 로 기존 동작 그대로.
             // 생성 실패는 작업을 죽이지 않고 샌드박스 없이 진행(graceful degrade).
-            if (getTaskSandboxConfig().enabled) {
+            // 설정은 한 번만 읽어 enabled 게이트·런타임·extraTools·승인 정책이 동일 스냅샷을 공유.
+            const sandboxCfg = getTaskSandboxConfig();
+            if (sandboxCfg.enabled) {
                 try {
                     // G4 위임: subgoal 을 적합 산업 전문가 페르소나로 1회 자문(재귀 루프 없음).
                     const delegateFn = async (subgoal: string, role?: string): Promise<string> => {
@@ -204,7 +207,7 @@ export class AgentTaskService {
                         );
                         return r.content ?? '';
                     };
-                    taskRuntime = new TaskRuntime(taskId, userId, getTaskSandboxConfig(), delegateFn);
+                    taskRuntime = new TaskRuntime(taskId, userId, sandboxCfg, delegateFn);
                     await taskRuntime.create();
                     await db.updateAgentTask(taskId, {
                         sandboxContainerId: taskRuntime.containerName,
@@ -225,8 +228,32 @@ export class AgentTaskService {
             // 전체 MCP 카탈로그(~150 도구)를 함께 넘기면 도구 스키마 union 이 수백 KB 로 부풀어
             // vLLM guided-decoding 문법 컴파일이 100s+ 로 폭주 → LLM_TIMEOUT 초과(Connection error).
             // Manus 모델에선 에이전트가 컨테이너 셸/브라우저로 작업하므로 외부 MCP 카탈로그가 불필요.
+            // 단, 샌드박스로 대체 불가한 소수 고가치 내장 도구(extraTools 화이트리스트, 예: generate_image)는
+            // mcpTools 에서 이름으로 선별해 합류 — 도구 수가 적어 문법 컴파일 폭주를 유발하지 않는다.
             // 샌드박스 OFF(legacy) 경로는 기존대로 전체 MCP 도구 사용.
-            const tools = taskRuntime ? taskRuntime.getLLMTools() : mcpTools;
+            // extraTools 로 노출된 비-task 도구 이름 집합 — 디스패치에서 호스트 실행 전 승인 게이트 적용에 사용.
+            const extraToolNames = new Set<string>();
+            let tools = mcpTools;
+            if (taskRuntime) {
+                const sandboxToolNames = new Set(taskRuntime.getLLMTools().map((t) => t.function.name));
+                const extra: typeof mcpTools = [];
+                for (const name of sandboxCfg.extraTools) {
+                    // 샌드박스 도구와 이름 충돌 시 제외(중복 function.name 으로 인한 요청 거부·섀도잉 방지).
+                    if (sandboxToolNames.has(name)) {
+                        logger.warn(`[AgentTask] extraTools '${name}' 가 샌드박스 도구와 이름 충돌 — 무시`);
+                        continue;
+                    }
+                    const tool = mcpTools.find((t) => t.function.name === name);
+                    if (!tool) {
+                        // 오타·스킬 거부 등으로 카탈로그에 없으면 조용히 누락되지 않게 경고.
+                        logger.warn(`[AgentTask] extraTools '${name}' 를 도구 카탈로그에서 찾지 못함 — 노출 생략`);
+                        continue;
+                    }
+                    extra.push(tool);
+                    extraToolNames.add(name);
+                }
+                tools = [...extra, ...taskRuntime.getLLMTools()];
+            }
 
             for (let turn = startTurn; turn < turnCeiling; turn++) {
                 this.assertWithinLimits(signal, startedAt, totalTokens);
@@ -337,6 +364,15 @@ export class AgentTaskService {
                 // 도구 실행 + 체크포인트
                 let terminated = false;
                 let terminateSummary = '';
+                // 승인 대기 진입 콜백 — task 도구·extra 도구 공용(status='paused' + web-push).
+                const onApprovalPending = (toolName: string) => {
+                    void update({ status: 'paused' }).catch(() => { /* noop */ });
+                    void getPushService().sendPush(userId, {
+                        title: 'OpenMake 에이전트 — 승인 필요',
+                        body: `도구 실행 승인을 기다립니다: ${toolName}`,
+                        url: '/agent-tasks.html',
+                    }).catch(() => { /* noop */ });
+                };
                 for (const tc of result.tool_calls!) {
                     if (signal.aborted) throw new AgentTaskAbort('aborted');
                     const name = tc.function.name;
@@ -347,20 +383,26 @@ export class AgentTaskService {
                         // task 도구 — 승인 게이트 통과 후 영속 샌드박스에서 실행.
                         toolResult = await taskRuntime.executeTaskTool(name, args, {
                             signal,
-                            onApprovalPending: (p) => {
-                                void update({ status: 'paused' }).catch(() => { /* noop */ });
-                                void getPushService().sendPush(userId, {
-                                    title: 'OpenMake 에이전트 — 승인 필요',
-                                    body: `도구 실행 승인을 기다립니다: ${p.toolName}`,
-                                    url: '/agent-tasks.html',
-                                }).catch(() => { /* noop */ });
-                            },
+                            onApprovalPending: (p) => onApprovalPending(p.toolName),
                         });
                         if (curStatus === 'paused') await update({ status: 'running' }).catch(() => { /* noop */ });
                         if (toolResult.includes(TASK_TERMINATE_SENTINEL)) {
                             terminated = true;
                             terminateSummary = String(args.summary ?? '');
                         }
+                    } else if (taskRuntime && extraToolNames.has(name)) {
+                        // extra(화이트리스트) 도구 — 샌드박스 밖 호스트에서 실행되지만 HITL 승인은 task 도구와 동일 적용.
+                        // (이 도구들은 격리 컨테이너가 아니라 API 프로세스에서 실행되므로 승인 우회를 닫는다.)
+                        const decision = requiresApproval(sandboxCfg.approvalPolicy, name, args)
+                            ? await getApprovalRegistry().request(
+                                { taskId, userId, toolName: name, args },
+                                { timeoutMs: sandboxCfg.approvalTimeoutMs, signal, onPending: (p) => onApprovalPending(p.toolName) },
+                            )
+                            : 'approved';
+                        if (curStatus === 'paused') await update({ status: 'running' }).catch(() => { /* noop */ });
+                        toolResult = decision === 'approved'
+                            ? await this.runTool(mcp, name, args, userCtx)
+                            : `Error: 사용자가 도구 실행을 승인하지 않았습니다 (${name}). 다른 방법을 시도하거나 작업을 종료하세요.`;
                     } else {
                         toolResult = await this.runTool(mcp, name, args, userCtx);
                     }


### PR DESCRIPTION
## 배경

[#222](https://github.com/openmake/openmake_llm/pull/222)가 샌드박스 작업의 LLM 노출 도구를 샌드박스 11종으로 좁혀 "도구 스키마 폭주 → vLLM 문법 컴파일 타임아웃(Connection error)"을 해결했으나, 그 과정에서 `generate_image` 등 **샌드박스로 대체 불가한 내장 도구**를 잃었다. 전체 MCP 카탈로그(~150)를 되돌리면 폭주가 재발한다.

## 변경

소수 고가치 내장 도구만 선별 노출하는 **화이트리스트**를 도입.

- **config (`task-sandbox.ts`)**: `extraTools` 추가 — env `TASK_SANDBOX_EXTRA_TOOLS`(쉼표), 기본 `generate_image`. 비면 순수 샌드박스 도구만.
- **`AgentTaskService`**: 샌드박스 활성 시 `mcpTools`에서 화이트리스트 이름만 선별해 샌드박스 도구와 합류. 도구 수가 적어 문법 컴파일 폭주 미발생.

## 코드리뷰 워크플로우 반영

| 심각도 | 항목 | 처리 |
|---|---|---|
| 🔴 | extra 도구가 task 도구가 아니라 **호스트(API 프로세스)에서 실행되어 HITL 승인을 우회** | 디스패치에 동일 승인 게이트(`requiresApproval`+`ApprovalRegistry`) 적용 — `approvalPolicy:'all'` 기본에선 generate_image도 승인 필요 |
| 🟡 | 이름 충돌 시 중복 `function.name` | 샌드박스 도구명과 충돌하는 extraTools 제외 + 경고 로그 |
| 🟡 | 오타·스킬 거부로 조용히 누락 | 카탈로그에 없는 이름은 경고 로그로 가시화 |
| 🟢 | `getTaskSandboxConfig()` 3회 호출 | 1회 스냅샷으로 hoist |

> 리뷰의 나머지 항목(샌드박스 OFF 경로의 ~150 카탈로그 잔존, 검색 throttle no-op, web/research 도구 상실)은 이 PR 범위 밖의 #222 후속 과제로 별도 트래킹.

⚠️ extra 도구는 격리 컨테이너가 아닌 호스트에서 실행되므로 **FS/셸 변경 없는 생성·조회류만 등록**할 것(config 주석·`.env.example`에 명시).

## 검증

- `npm run lint`(Gate 4) 통과, `npm run build:backend` 통과, Gate 3(600줄) 통과(552줄)
- **실앱 Playwright E2E**: 에이전트 작업이 `generate_image` 호출 → 승인 대기(InlineApprovals, **우회 닫힘 확인**) → 승인 → 호스트 실행(`[ImageTools] 이미지 생성 완료 img 1024x1024`) → 완료. 도구 +1로 인한 문법 컴파일 폭주 재발 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)