### PR TITLE
fix(agent-task): #222 후속 정리 — web_search 화이트리스트 + degrade 시 화이트리스트-only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -748,7 +748,7 @@ TASK_SANDBOX_ENABLED=false
 # TASK_SANDBOX_WORKSPACE_TTL_MS=86400000              # 완료 task workspace 보존 TTL(스윕 삭제). 기본 24h
 # TASK_SANDBOX_APPROVAL_POLICY=all                     # all(전부 승인·기본) | high-risk(bash·삭제만) | none(자동)
 # TASK_SANDBOX_APPROVAL_TIMEOUT_MS=1800000             # 승인 대기 timeout(초과 시 자동 거절). 기본 30분
-# TASK_SANDBOX_EXTRA_TOOLS=generate_image              # 샌드박스 도구와 함께 노출할 내장 도구 화이트리스트(쉼표). 비면 샌드박스 도구만. ⚠️ HITL 승인 우회 — 생성·조회류만
+# TASK_SANDBOX_EXTRA_TOOLS=generate_image,web_search   # 샌드박스 도구와 함께 노출할 내장 도구 화이트리스트(쉼표). 비면 샌드박스 도구만. ⚠️ 호스트 실행 — FS/셸 변경 없는 생성·조회류만 (승인 게이트는 적용됨)
 # AGENT_MAX_TOTAL_TOKENS=1000000                       # agent task 누적 토큰 상한(멀티턴 누적). 기본 1M
 
 MCP_SANDBOX_ENABLED=false

--- a/apps/api/src/config/task-sandbox.ts
+++ b/apps/api/src/config/task-sandbox.ts
@@ -85,7 +85,7 @@ export interface TaskSandboxConfig {
      * 샌드박스 활성 시 샌드박스 도구와 함께 LLM 에 노출할 비-샌드박스(내장 MCP) 도구 화이트리스트(이름).
      * 전체 MCP 카탈로그(~150 도구)는 vLLM 문법 컴파일 폭주를 유발하므로 제외하되,
      * 샌드박스로 대체 불가한 소수 고가치 도구(예: generate_image)만 선별 노출.
-     * 비면 샌드박스 도구만 노출(순수 Manus). 기본 generate_image.
+     * 비면 샌드박스 도구만 노출(순수 Manus). 기본 generate_image,web_search.
      * ⚠️ 이 도구들은 task 도구가 아니라 HITL 승인 게이트를 우회해 직접 실행된다 —
      * FS/셸 변경이 없는 생성·조회류(generate_image 등)만 등록할 것. 위험 도구 금지.
      */
@@ -125,7 +125,7 @@ export function getTaskSandboxConfig(): TaskSandboxConfig {
         egressNetwork: process.env.TASK_SANDBOX_EGRESS_NETWORK || 'omk-egress-internal',
         egressProxyContainer: process.env.TASK_SANDBOX_EGRESS_PROXY_CONTAINER || 'omk-egress-proxy',
         egressProxyPort: intEnv(process.env.TASK_SANDBOX_EGRESS_PROXY_PORT, 8888),
-        extraTools: (process.env.TASK_SANDBOX_EXTRA_TOOLS ?? 'generate_image')
+        extraTools: (process.env.TASK_SANDBOX_EXTRA_TOOLS ?? 'generate_image,web_search')
             .split(',').map((s) => s.trim()).filter(Boolean),
     };
 }

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -228,14 +228,11 @@ export class AgentTaskService {
             // 전체 MCP 카탈로그(~150 도구)를 함께 넘기면 도구 스키마 union 이 수백 KB 로 부풀어
             // vLLM guided-decoding 문법 컴파일이 100s+ 로 폭주 → LLM_TIMEOUT 초과(Connection error).
             // Manus 모델에선 에이전트가 컨테이너 셸/브라우저로 작업하므로 외부 MCP 카탈로그가 불필요.
-            // 단, 샌드박스로 대체 불가한 소수 고가치 내장 도구(extraTools 화이트리스트, 예: generate_image)는
-            // mcpTools 에서 이름으로 선별해 합류 — 도구 수가 적어 문법 컴파일 폭주를 유발하지 않는다.
-            // 샌드박스 OFF(legacy) 경로는 기존대로 전체 MCP 도구 사용.
+            // 단, 샌드박스로 대체 불가한 소수 고가치 내장 도구(extraTools 화이트리스트, 예: generate_image,
+            // web_search)는 mcpTools 에서 이름으로 선별해 합류 — 도구 수가 적어 문법 컴파일 폭주가 없다.
             // extraTools 로 노출된 비-task 도구 이름 집합 — 디스패치에서 호스트 실행 전 승인 게이트 적용에 사용.
             const extraToolNames = new Set<string>();
-            let tools = mcpTools;
-            if (taskRuntime) {
-                const sandboxToolNames = new Set(taskRuntime.getLLMTools().map((t) => t.function.name));
+            const buildExtra = (sandboxToolNames: Set<string>): typeof mcpTools => {
                 const extra: typeof mcpTools = [];
                 for (const name of sandboxCfg.extraTools) {
                     // 샌드박스 도구와 이름 충돌 시 제외(중복 function.name 으로 인한 요청 거부·섀도잉 방지).
@@ -252,7 +249,20 @@ export class AgentTaskService {
                     extra.push(tool);
                     extraToolNames.add(name);
                 }
-                tools = [...extra, ...taskRuntime.getLLMTools()];
+                return extra;
+            };
+            let tools: typeof mcpTools;
+            if (taskRuntime) {
+                const sandboxTools = taskRuntime.getLLMTools();
+                tools = [...buildExtra(new Set(sandboxTools.map((t) => t.function.name))), ...sandboxTools];
+            } else if (sandboxCfg.enabled) {
+                // 샌드박스 ENABLED 인데 생성 실패(degrade): 전체 카탈로그(~150)는 hang 을 유발하므로
+                // 화이트리스트 도구만으로 진행 — 셸 작업은 불가하나 검색·이미지·작성 작업은 계속 가능.
+                tools = buildExtra(new Set<string>());
+                logger.warn(`[AgentTask] 샌드박스 미가용 — extraTools(${extraToolNames.size}개)만으로 진행 (전체 카탈로그 미전달)`);
+            } else {
+                // 샌드박스 OFF(legacy) 경로 — 기존대로 전체 MCP 도구 사용.
+                tools = mcpTools;
             }
 
             for (let turn = startTurn; turn < turnCeiling; turn++) {
@@ -390,9 +400,10 @@ export class AgentTaskService {
                             terminated = true;
                             terminateSummary = String(args.summary ?? '');
                         }
-                    } else if (taskRuntime && extraToolNames.has(name)) {
+                    } else if (extraToolNames.has(name)) {
                         // extra(화이트리스트) 도구 — 샌드박스 밖 호스트에서 실행되지만 HITL 승인은 task 도구와 동일 적용.
                         // (이 도구들은 격리 컨테이너가 아니라 API 프로세스에서 실행되므로 승인 우회를 닫는다.)
+                        // extraToolNames 는 샌드박스 ENABLED(활성·degrade) 일 때만 채워지므로 legacy OFF 경로엔 영향 없음.
                         const decision = requiresApproval(sandboxCfg.approvalPolicy, name, args)
                             ? await getApprovalRegistry().request(
                                 { taskId, userId, toolName: name, args },


### PR DESCRIPTION
## 배경

[#222](https://github.com/openmake/openmake_llm/pull/222)(샌드박스 도구 한정) → [#223](https://github.com/openmake/openmake_llm/pull/223)(extraTools 화이트리스트)의 **남은 후속 과제**를 정리한다. 코드리뷰 워크플로우가 식별한 잔여 항목 중 제품 결정이 필요했던 것을 사용자 승인 하에 처리.

## 변경

### 1. `web_search` 기본 화이트리스트 추가 (B·C·D 동시 해소)
`extraTools` 기본값 `generate_image` → `generate_image,web_search`. 한 번의 추가로 세 항목 정리:

| 항목 | 해소 |
|---|---|
| **C. web/research 도구 상실** | 샌드박스 작업이 랭킹된 `web_search` 재사용 (browser-goto 대체 탈피) |
| **B. 검색 throttle no-op** | `web_search`는 `isSearchTool` 매칭 → `MAX_SEARCH_CALLS` throttle 복원 |
| **D. 프롬프트 불일치** | "search tools" 안내가 다시 유효(도구-프롬프트 정합) |

`web_search`도 #223 승인 게이트 적용 — 호출 전 HITL 승인.

### 2. degrade 시 화이트리스트-only (A 해소)
샌드박스 생성 실패(docker 장애 등)로 `taskRuntime=null` 이 되면, 이전엔 전체 ~150 카탈로그를 전달 → **2.5분 hang 후 Connection error**.

이제 **ENABLED 인데 생성 실패면 extraTools 만 노출** → hang 없이 검색·이미지·작성 작업은 계속 가능(셸 작업만 불가). 샌드박스 OFF(legacy, `ENABLED=false`) 경로는 **기존대로 전체 MCP 도구 유지**(무변경).

- extra 빌드 로직을 `buildExtra()` 헬퍼로 추출(활성/degrade 공용)
- 디스패치 승인 게이트 조건을 `extraToolNames` 기준으로 단순화 (legacy OFF 엔 빈 집합 → 무영향)

## 검증

- `npm run lint`(Gate 4) 통과, `build:backend` 통과, Gate 3(563<600) 통과
- **라이브 E2E**: 샌드박스 작업이 `web_search` 호출 → 승인 대기(**게이트 적용 확인**) → 승인 → 검색 17건 → 완료(2025 노벨물리학상 수상자 요약)
- degrade 경로(A)는 docker 실패 재현이 필요해 코드/빌드로 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)