### PR TITLE
feat(agent-task): browser 도구 전용 호출 cap — 무제한 탐색 폭주 차단

### DIFF
--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1131,6 +1131,11 @@ export const AGENT_TASK_LIMITS = {
     MAX_SEARCH_CALLS: parseInt(process.env.AGENT_MAX_SEARCH_CALLS || '5', 10),
     /** 검색/정보수집 도구 식별 키워드 (tool name 에 포함되면 검색류로 카운트) */
     SEARCH_TOOL_KEYWORDS: ['search', 'visit_page', 'research', 'firecrawl', 'scrape', 'crawl', 'fetch'] as readonly string[],
+    /** 샌드박스 browser 도구 호출 횟수 하드 상한 — browser 는 SEARCH_TOOL_KEYWORDS 에 안 잡혀
+     *  검색 throttle 로 제어되지 않으므로 별도 cap. 초과 시 다음 턴부터 browser 도구를 제거해
+     *  강제 종합. 탐색·추출이 여러 호출로 나뉘므로 검색보다 넉넉히(기본 10).
+     *  AGENT_MAX_BROWSER_CALLS 로 오버라이드. */
+    MAX_BROWSER_CALLS: parseInt(process.env.AGENT_MAX_BROWSER_CALLS || '10', 10),
     /** stuck 감지 — 동일 assistant 응답이 이 횟수만큼 연속되면 전략변경 프롬프트 주입(무한루프 방지).
      *  OpenManus BaseAgent.is_stuck 패턴. AGENT_STUCK_THRESHOLD 로 오버라이드(기본 3). */
     STUCK_THRESHOLD: parseInt(process.env.AGENT_STUCK_THRESHOLD || '3', 10),

--- a/apps/api/src/prompts/agent-task-prompt.ts
+++ b/apps/api/src/prompts/agent-task-prompt.ts
@@ -83,3 +83,8 @@ export function getTaskSandboxGuidance(): string {
 export function getAgentTaskStuckNudge(): string {
     return '같은 시도를 반복하고 있습니다. 접근 방식을 바꾸세요: 다른 도구나 다른 입력을 시도하거나, 막혔다면 지금까지의 결과로 작업을 마무리(terminate)하거나 사용자에게 도움을 요청(ask_human)하세요.';
 }
+
+/** browser 도구 호출 한도 도달 시 주입 — 더 이상 탐색하지 말고 수집한 정보로 종합·작성 유도. */
+export function getAgentTaskBrowserLimitNudge(): string {
+    return '브라우저 탐색 횟수 한도에 도달했습니다. 더 이상 웹을 탐색하지 말고, 지금까지 수집한 정보만으로 최종 결과물을 완성해 작성하세요.';
+}

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -21,7 +21,7 @@ import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { getUnifiedDatabase } from '../data/models/unified-database';
 import { AGENT_TASK_LIMITS, MAX_TOOL_RESULT_CHARS } from '../config/runtime-limits';
 import { emitAgentTaskProgress } from '../utils/event-bus';
-import { getAgentTaskSystemPrompt, getAgentTaskDeliverableNudge, getAgentTaskStuckNudge, getTaskSandboxGuidance } from '../prompts/agent-task-prompt';
+import { getAgentTaskSystemPrompt, getAgentTaskDeliverableNudge, getAgentTaskStuckNudge, getAgentTaskBrowserLimitNudge, getTaskSandboxGuidance } from '../prompts/agent-task-prompt';
 import { extractAndStripArtifacts, type ExtractedArtifact } from '../llm/artifact-parser';
 import { getPushService } from './PushService';
 import { createLogger } from '../utils/logger';
@@ -134,6 +134,8 @@ export class AgentTaskService {
         let totalTokens = 0;
         let searchCalls = 0;
         let searchLimitNotified = false;
+        let browserCalls = 0;
+        let browserLimitNotified = false;
         let curStatus = 'pending';
         let curProgress = 0;
         let curTurn = 0;
@@ -273,11 +275,18 @@ export class AgentTaskService {
                     progress: Math.min(95, 5 + Math.round((turn / turnCeiling) * 90)),
                 });
 
-                // 검색류 도구 호출이 한도를 넘으면 검색 도구를 제거해 강제로 종합/작성 단계로 유도.
-                // 프롬프트 지시를 LLM 이 무시하더라도 도구 자체가 사라지므로 검색 폭주가 끊긴다.
+                // 검색류/브라우저 도구 호출이 한도를 넘으면 해당 도구를 제거해 강제로 종합/작성 단계로 유도.
+                // 프롬프트 지시를 LLM 이 무시하더라도 도구 자체가 사라지므로 탐색 폭주가 끊긴다.
+                // browser 는 SEARCH_TOOL_KEYWORDS 에 안 잡혀 검색 throttle 로 제어 불가하므로 별도 cap.
                 const overSearchLimit = searchCalls >= AGENT_TASK_LIMITS.MAX_SEARCH_CALLS;
-                const effectiveTools = overSearchLimit
-                    ? tools.filter((t) => !isSearchTool(t.function.name))
+                const overBrowserLimit = browserCalls >= AGENT_TASK_LIMITS.MAX_BROWSER_CALLS;
+                const effectiveTools = (overSearchLimit || overBrowserLimit)
+                    ? tools.filter((t) => {
+                        const n = t.function.name;
+                        if (overSearchLimit && isSearchTool(n)) return false;
+                        if (overBrowserLimit && n === 'browser') return false;
+                        return true;
+                    })
                     : tools;
                 if (overSearchLimit && !searchLimitNotified) {
                     conversation.push({
@@ -285,6 +294,10 @@ export class AgentTaskService {
                         content: '검색 횟수 한도에 도달했습니다. 더 이상 검색하지 말고, 지금까지 수집한 정보만으로 최종 결과물(예: 블로그 초안)을 완성해 작성하세요.',
                     });
                     searchLimitNotified = true;
+                }
+                if (overBrowserLimit && !browserLimitNotified) {
+                    conversation.push({ role: 'user', content: getAgentTaskBrowserLimitNudge() });
+                    browserLimitNotified = true;
                 }
 
                 // per-call abort: 작업 잔여 예산을 호출에도 바인딩 — 응답이 hang 되면
@@ -387,6 +400,7 @@ export class AgentTaskService {
                     if (signal.aborted) throw new AgentTaskAbort('aborted');
                     const name = tc.function.name;
                     if (isSearchTool(name)) searchCalls++;
+                    if (name === 'browser') browserCalls++;
                     const args = (tc.function.arguments ?? {}) as Record<string, unknown>;
                     let toolResult: string;
                     if (taskRuntime?.isTaskTool(name)) {


### PR DESCRIPTION
## 배경

[#224](https://github.com/openmake/openmake_llm/pull/224)의 잔여 항목. `browser` 도구는 `SEARCH_TOOL_KEYWORDS`에 잡히지 않아 검색 throttle(`MAX_SEARCH_CALLS`)로 제어되지 않았다. 따라서 샌드박스 작업이 `browser`를 **turn ceiling·토큰·타임아웃에 닿을 때까지 무제한 호출**할 수 있었다. 검색 throttle와 대칭으로 browser 전용 cap을 추가한다.

## 변경

- **`runtime-limits`**: `AGENT_TASK_LIMITS.MAX_BROWSER_CALLS` (env `AGENT_MAX_BROWSER_CALLS`, 기본 **10** — 탐색·추출이 여러 호출로 나뉘므로 검색 5보다 넉넉히).
- **`AgentTaskService`**: `browserCalls` 카운터(`name==='browser'` 시 증가) + `overBrowserLimit` 시 다음 턴부터 `effectiveTools`에서 browser 제거 + 1회 nudge 주입(종합·작성 유도). 검색 throttle와 동일 메커니즘으로 `effectiveTools` 필터를 일반화.
- **`agent-task-prompt`**: `getAgentTaskBrowserLimitNudge()` 외부화(기존 nudge 패턴 일치).

## 검증

- `npm run lint`(Gate 4) 통과, `build:backend` 통과, Gate 3(577<600) 통과
- **라이브 E2E** (`AGENT_MAX_BROWSER_CALLS=1`): `browser`로 3개 사이트를 요청한 작업이 **browser를 정확히 1회만 호출**(cap 발동 후 도구 제거로 추가 호출 불가)했고, 도구별 호출 집계 `{plan_update:6, plan_create:2, browser:1}`로 확인. 테스트 후 기본 cap=10으로 복귀.

이로써 #222 → #223 → #224 → 본 PR 로 에이전트 작업 도구 제어가 마무리된다(검색·브라우저 양쪽 cap + 화이트리스트 + 승인 게이트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)