### PR TITLE
fix(chat): admin-gate debug pipeline_info + observe legacy model-id fallback

### DIFF
--- a/apps/api/src/routes/chat.routes.ts
+++ b/apps/api/src/routes/chat.routes.ts
@@ -101,8 +101,9 @@ router.post('/', optionalApiKey, optionalAuth, chatRateLimiter, validate(chatReq
             onThinking: (thinking: string) => { thinkingTrace += thinking; },
         });
 
-        // §9 디버그 정보 (x-omk-debug 헤더가 있을 때만 노출)
-        const debugRequested = req.headers['x-omk-debug'] === 'true';
+        // §9 디버그 정보 — 인증된 관리자 + x-omk-debug 헤더일 때만 노출.
+        // (게스트 허용 라우트라 내부 라우팅 정보가 미인증 호출자에게 새지 않도록 admin 게이트.)
+        const debugRequested = req.headers['x-omk-debug'] === 'true' && userContext.userRole === 'admin';
         const pipelineInfo = debugRequested ? {
             requestedModel: result.executionPlan.requestedModel,
             engine: result.executionPlan.resolvedEngine,

--- a/apps/api/src/services/chat-service/message-pipeline.ts
+++ b/apps/api/src/services/chat-service/message-pipeline.ts
@@ -218,6 +218,13 @@ export async function runMessagePipeline(svc: ChatService,
         req.userLanguagePreference = languagePolicy.resolvedLanguage;
     }
 
+    // 관측: 구 brand alias(openmake_llm_*) 입력 추적 — 동작 분기 없음(default fallback 됨),
+    // 레거시 외부 클라가 아직 alias 를 보내는지 운영 관측용 1줄 info. (alias 목록 의존 없이 prefix 패턴만.)
+    const reqModel = executionPlan?.requestedModel;
+    if (reqModel && /^openmake[-_]llm[-_]/i.test(reqModel)) {
+        logger.info(`[legacy-model-id] '${reqModel}' → default fallback (구 brand alias). 동작은 직교 축 토글로만 제어.`);
+    }
+
     // 동작은 직교 축(Discussion/Thinking 토글)으로만 제어 — 사용자 명시 토글만 신뢰.
     const effectiveDiscussionMode = discussionMode === true;
     const effectiveThinkingMode = req.thinkingMode === true;


### PR DESCRIPTION
PR #231(7 brand profile alias 폐기)에 대한 **high-effort 코드 리뷰 후속 수정**.

## 수정 항목

### #1 — debug pipeline_info 정보 노출 (CONFIRMED 보안 회귀)
`chat.routes.ts`의 §9 debug 블록이 `isBrandModel`(항상 false) 게이트 제거로 `x-omk-debug: true` 헤더만 있으면 항상 노출됐고, `POST /api/chat`은 `optionalAuth`(게스트 허용)라 **미인증 게스트도 내부 라우팅 정보**(requestedModel/resolvedEngine/executionStrategy/thinkingLevel/useDiscussion)를 받았습니다.
→ `userContext.userRole === 'admin'` 게이트 추가로 **인증된 관리자에게만** 노출.

### #2 — deprecation telemetry 손실 (CONFIRMED 관측)
`brand-alias-normalizer.ts` 삭제로 `logAliasHitIfAny` 관측 신호가 사라져 레거시 클라 추적이 불가했습니다.
→ `message-pipeline.ts`에 구 brand alias(`openmake_llm_*`) 입력 시 **1줄 info 로그** 추가. alias 목록 의존 없이 prefix 패턴만 사용, **동작 분기 없음**(default fallback 유지) — "완전 폐기" 취지와 양립.

## 리뷰 나머지
- #3 silent downgrade (PLAUSIBLE): 의도된 무중단 fallback 결정. #2 로그로 관측 가능해짐. 코드 변경 없음.
- #4 eval 미실행 (PLAUSIBLE): 본 PR과 함께 `eval:routing` 실행.

## 검증
- tsc 0 / eslint 0 / chat·message-pipeline 54 tests 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)