### PR TITLE
fix(provider-gate): empty requestedModel falls back to default model

### DIFF
--- a/apps/api/src/services/chat-service/provider-gate.ts
+++ b/apps/api/src/services/chat-service/provider-gate.ts
@@ -61,7 +61,9 @@ export function normalizeToFullId(
     requestedModel: string | undefined,
     fallbackModel: string,
 ): string {
-    const raw = (requestedModel ?? fallbackModel ?? '').trim();
+    // requestedModel 이 빈 문자열/공백이어도 fallbackModel 로 대체 (?? 는 '' 를 통과시켜
+    // model 미지정 REST 요청이 INVALID_MODEL_ID 로 떨어지던 문제 방지).
+    const raw = ((requestedModel ?? '').trim() || (fallbackModel ?? '').trim());
     if (!raw) {
         throw new ProviderError('INVALID_MODEL_ID', '모델 ID가 비어있습니다');
     }


### PR DESCRIPTION
## 배경
Playwright 라이브 점검(brand alias 폐기 검증) 중 발견한 **별개 기존 버그**.

`POST /api/chat` 에 `model` 필드를 생략하거나 빈 문자열로 보내면 HTTP 500 `"모델 ID가 비어있습니다"`(INVALID_MODEL_ID)로 실패합니다.

## 원인
`provider-gate.ts` `normalizeToFullId` 의 `requestedModel ?? fallbackModel` — `??` 는 빈 문자열 `""` 을 통과시켜 fallback 으로 대체하지 않습니다. 따라서 빈 model 이 그대로 빈 검사에 걸려 throw 됩니다.

```ts
// before
const raw = (requestedModel ?? fallbackModel ?? '').trim();
// after — 빈/공백이면 fallbackModel 사용
const raw = ((requestedModel ?? '').trim() || (fallbackModel ?? '').trim());
```

## brand alias 폐기(#231/#232)와의 관계
**무관**합니다. provider-gate 는 #231/#232 diff에 없고, message-pipeline 에서 provider-gate 가 (제거된) normalizeBrandAlias 보다 먼저 실행되므로 normalizer 가 이 경로에 개입한 적이 없습니다.

## 영향
- 프론트(WebSocket)는 항상 `model:"default"` 를 전송하므로 실사용 영향 없음
- REST/외부 클라이언트가 `model` 을 생략하는 경우의 안정성 개선

## 검증
- `normalizeToFullId` 회귀 테스트 6건 통과(빈/공백/undefined → fallback, 명시 우선, 둘 다 빈 → throw)
- tsc 0 / eslint 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)