### PR TITLE
feat(chat): 슬래시(/) 스킬 호출 드롭다운 구현

### DIFF
--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -22,7 +22,12 @@ import type { WsAttachedFile } from "@openmake/shared-types";
 import { useAppStore } from "@/lib/store";
 import { useChatSocket } from "@/lib/use-chat-socket";
 import { fetchModels } from "@/lib/models-api";
+import { fetchSkills, skillSlug, type SkillSummary } from "@/lib/skills-api";
+import { SlashSkillMenu } from "@/components/chat/slash-skill-menu";
 import { cn } from "@/lib/utils";
+
+// 슬래시 스킬 호출: "/" + 공백없는 단일 토큰일 때만 드롭다운 표시.
+const SLASH_PATTERN = /^\/(\S*)$/;
 
 // 클라이언트 첨부 캡 — 백엔드 FILE_ATTACH_LIMITS 기본값과 일치(서버가 재절단하므로 advisory).
 const MAX_FILES = 50;
@@ -86,6 +91,7 @@ export function Composer() {
   const [modeSheetOpen, setModeSheetOpen] = useState(false);
   const taRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
 
   // 선택/드롭한 파일들을 타입별로 분기해 첨부 목록에 추가.
   // 이미지 → base64 vision, 그 외 → 텍스트(캡 적용). 모든 파일 타입 허용.
@@ -167,6 +173,60 @@ export function Composer() {
     setInputDraft,
   } = useAppStore();
 
+  // ── 슬래시(/) 스킬 호출 드롭다운 ──
+  const [slashActiveIndex, setSlashActiveIndex] = useState(0);
+  const [slashDismissed, setSlashDismissed] = useState(false);
+  const slashMatch = SLASH_PATTERN.exec(text);
+  // 후보 조건: "/토큰" 패턴 + Esc/외부클릭으로 닫지 않음 + 생성중 아님
+  const slashCandidate = !!slashMatch && !slashDismissed && !isGenerating;
+  const slashQuery = slashMatch?.[1] ?? "";
+  // 디바운스된 검색어 (입력 폭주 시 과도한 요청 방지)
+  const [slashDebounced, setSlashDebounced] = useState("");
+  useEffect(() => {
+    if (!slashCandidate) return;
+    const t = setTimeout(() => setSlashDebounced(slashQuery), 150);
+    return () => clearTimeout(t);
+  }, [slashQuery, slashCandidate]);
+
+  const { data: slashSkillsData, isLoading: slashLoading } = useQuery({
+    queryKey: ["skills", slashDebounced],
+    queryFn: () => fetchSkills(slashDebounced),
+    enabled: slashCandidate,
+    staleTime: 30_000,
+  });
+  const slashSkills: SkillSummary[] = slashCandidate ? slashSkillsData ?? [] : [];
+  // 메뉴 표시: 후보 상태이며 로딩 중이거나 결과가 있을 때
+  const slashMenuOpen = slashCandidate && (slashLoading || slashSkills.length > 0);
+
+  // 검색 결과가 바뀌면 활성 인덱스 초기화
+  useEffect(() => {
+    setSlashActiveIndex(0);
+  }, [slashDebounced, slashSkillsData]);
+
+  // 외부 클릭 시 닫기
+  useEffect(() => {
+    if (!slashMenuOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setSlashDismissed(true);
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [slashMenuOpen]);
+
+  // 스킬 선택 → 텍스트를 "/<slug> " 로 채우고 포커스 유지 (이후 메시지 이어쓰기)
+  const selectSlashSkill = (skill: SkillSummary) => {
+    setText(`/${skillSlug(skill.name)} `);
+    setSlashActiveIndex(0);
+    const ta = taRef.current;
+    if (ta) {
+      ta.focus();
+      ta.style.height = "auto";
+      ta.style.height = Math.min(ta.scrollHeight, 200) + "px";
+    }
+  };
+
   // 모델 목록 로드 시 현재 selectedModel 이 목록에 없으면 defaultModel 로 동기화
   useEffect(() => {
     if (!modelsData) return;
@@ -236,6 +296,7 @@ export function Composer() {
   return (
     <div className="mx-auto w-full max-w-3xl px-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
       <div
+        ref={rootRef}
         className={cn(
           "relative rounded-xl border bg-surface shadow-2 transition-colors",
           dragging ? "border-accent ring-2 ring-accent/40" : "border-border",
@@ -376,15 +437,58 @@ export function Composer() {
           </div>
         )}
 
+        {slashMenuOpen && (
+          <SlashSkillMenu
+            skills={slashSkills}
+            activeIndex={slashActiveIndex}
+            loading={slashLoading}
+            onSelect={selectSlashSkill}
+            onHover={setSlashActiveIndex}
+          />
+        )}
+
         <textarea
           ref={taRef}
           value={text}
           onChange={(e) => {
             setText(e.target.value);
+            // 사용자가 다시 입력하면 Esc/외부클릭으로 닫았던 메뉴 후보를 재활성화
+            if (slashDismissed) setSlashDismissed(false);
             e.target.style.height = "auto";
             e.target.style.height = Math.min(e.target.scrollHeight, 200) + "px";
           }}
           onKeyDown={(e) => {
+            // 슬래시 메뉴가 열려 있으면 네비게이션/선택 우선 처리
+            if (slashMenuOpen) {
+              if (e.key === "ArrowDown") {
+                e.preventDefault();
+                setSlashActiveIndex((i) =>
+                  slashSkills.length ? (i + 1) % slashSkills.length : 0,
+                );
+                return;
+              }
+              if (e.key === "ArrowUp") {
+                e.preventDefault();
+                setSlashActiveIndex((i) =>
+                  slashSkills.length ? (i - 1 + slashSkills.length) % slashSkills.length : 0,
+                );
+                return;
+              }
+              if (e.key === "Escape") {
+                e.preventDefault();
+                setSlashDismissed(true);
+                return;
+              }
+              // Enter: 선택 가능한 항목이 있으면 스킬 선택, 없으면 아래 submit 으로 fall-through
+              if (e.key === "Enter" && !e.shiftKey) {
+                const sel = slashSkills[slashActiveIndex];
+                if (sel) {
+                  e.preventDefault();
+                  selectSlashSkill(sel);
+                  return;
+                }
+              }
+            }
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();
               submit();

--- a/apps/web/components/chat/slash-skill-menu.tsx
+++ b/apps/web/components/chat/slash-skill-menu.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Sparkles } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { skillSlug, type SkillSummary } from "@/lib/skills-api";
+
+interface SlashSkillMenuProps {
+  /** 표시할 스킬 목록 (이미 검색 필터링된 결과) */
+  skills: SkillSummary[];
+  /** 키보드 네비게이션 활성 인덱스 */
+  activeIndex: number;
+  /** 검색 로딩 중 여부 */
+  loading: boolean;
+  /** 항목 클릭/Enter 선택 */
+  onSelect: (skill: SkillSummary) => void;
+  /** 마우스 hover 로 활성 인덱스 변경 */
+  onHover: (index: number) => void;
+}
+
+/**
+ * 채팅 입력창 슬래시(/) 스킬 호출 드롭다운.
+ * 컴포저 위로 떠오르는 패널(모드 시트와 동일 스타일)로, 선택 시 텍스트를
+ * `/<slug> ` 로 채워 백엔드 slash-command 매칭을 유도한다.
+ * 키보드 네비게이션/Enter 충돌 처리는 부모(Composer)가 담당한다.
+ */
+export function SlashSkillMenu({
+  skills,
+  activeIndex,
+  loading,
+  onSelect,
+  onHover,
+}: SlashSkillMenuProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // 활성 항목이 보이도록 스크롤
+  useEffect(() => {
+    const el = listRef.current?.querySelector<HTMLElement>(`[data-idx="${activeIndex}"]`);
+    el?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex]);
+
+  return (
+    <div className="absolute bottom-full left-0 right-0 z-40 mb-2 overflow-hidden rounded-xl border border-border bg-surface-2 shadow-lg">
+      <p className="border-b border-border px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-faint">
+        스킬 호출
+      </p>
+      {skills.length === 0 ? (
+        <p className="px-3 py-3 text-sm text-muted">
+          {loading ? "스킬을 불러오는 중…" : "일치하는 스킬이 없습니다"}
+        </p>
+      ) : (
+        <div ref={listRef} className="max-h-64 overflow-y-auto p-1">
+          {skills.map((skill, i) => (
+            <button
+              key={skill.id}
+              type="button"
+              data-idx={i}
+              // 마우스다운(blur 전)에 선택 — 텍스트영역 포커스 유지
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onSelect(skill);
+              }}
+              onMouseEnter={() => onHover(i)}
+              className={cn(
+                "flex w-full items-start gap-2.5 rounded-md px-2.5 py-2 text-left transition",
+                i === activeIndex ? "bg-surface-3" : "hover:bg-surface-3",
+              )}
+            >
+              <Sparkles
+                className={cn(
+                  "mt-0.5 h-4 w-4 shrink-0",
+                  i === activeIndex ? "text-accent" : "text-muted",
+                )}
+              />
+              <span className="min-w-0 flex-1">
+                <span className="flex items-baseline gap-2">
+                  <span className="truncate text-sm font-medium text-fg">{skill.name}</span>
+                  <span className="shrink-0 font-mono text-[11px] text-faint">
+                    /{skillSlug(skill.name)}
+                  </span>
+                </span>
+                {skill.description && (
+                  <span className="mt-0.5 block truncate text-xs text-muted">
+                    {skill.description}
+                  </span>
+                )}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/skills-api.ts
+++ b/apps/web/lib/skills-api.ts
@@ -1,0 +1,42 @@
+import { ApiClient } from "@/lib/api-client";
+
+/** /api/agents/skills 의 스킬 1건 (메뉴 표시에 필요한 필드만 사용). */
+export interface SkillSummary {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+}
+
+interface SkillSearchResponse {
+  skills: SkillSummary[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+/**
+ * 스킬 이름 → slash 명령 slug.
+ * 백엔드 `chat/slash-command.ts` 의 slugify 와 정확히 동일해야 매칭된다.
+ * (소문자, 연속 비영숫자 → '-', 양끝 '-' 제거)
+ */
+export function skillSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * GET /api/agents/skills — active 스킬 검색/목록 (슬래시 드롭다운용).
+ * `{ success, data: { skills, ... } }` 응답을 언래핑해 스킬 배열만 반환한다.
+ */
+export async function fetchSkills(search?: string): Promise<SkillSummary[]> {
+  const params = new URLSearchParams({ sortBy: "name", limit: "20" });
+  if (search) params.set("search", search);
+  const res = await ApiClient.get<{ success: boolean; data: SkillSearchResponse }>(
+    `/api/agents/skills?${params.toString()}`,
+  );
+  return res?.data?.skills ?? [];
+}


### PR DESCRIPTION
## 배경
Playwright 라이브 점검(brand alias 폐기 검증) 중 발견한 **미구현 기능**. composer placeholder 에 "/ 로 스킬을 호출하세요" 안내가 있으나 실제 "/" 입력 시 스킬 선택 UI 가 없었습니다(백엔드 `slash-command.ts` 매칭 + `GET /api/agents/skills` 는 준비됨).

## 구현
- **lib/skills-api.ts**: `fetchSkills(search)` → `GET /api/agents/skills`, `skillSlug()` (백엔드 `slugify` 와 동일 로직으로 매칭 정합성 보장)
- **components/chat/slash-skill-menu.tsx**: 떠오르는 스킬 선택 패널 (스킬명 + `/slug` + 설명, 활성 하이라이트, 로딩/빈 상태)
- **composer.tsx**: `/^\/(\S*)$/` 패턴 감지 → 150ms 디바운스 `useQuery`, ↑↓/Enter/Esc 키보드 네비게이션, 외부클릭 닫기, 선택 시 `/<slug> ` 삽입
  - **Enter 충돌 처리**: 메뉴 열림 + 선택 가능 항목 있을 때만 Enter 가로채 스킬 선택, 그 외엔 기존 submit 으로 fall-through

기존 composer 기능(첨부/모드/스타일/전송) 무변경.

## 검증
- tsc 신규 에러 0 (기존 stale validator 에러는 무관)
- **라이브**: 프론트 빌드+재시작 후 Playwright 로 "/" 입력 → 스킬 목록 패널 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)