### PR TITLE
fix(external-provider): 큰 컨텍스트 빈 응답 방지 (context-fit + 빈응답 재시도)

### DIFF
--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1086,6 +1086,18 @@ export const EXTERNAL_LLM_TOOL_BLACKLIST: readonly string[] = [
 ] as const;
 
 /**
+ * 외부 provider 도구 루프 messages 토큰 예산 — external-provider 경로는 LLMClient.chat 의
+ * model-pool context-fit 안전망을 우회(provider.streamChat 직접 호출)하므로, 큰 누적
+ * 컨텍스트가 그대로 provider 로 전달돼 모델이 텍스트 없이 도구만 호출하고 끝나는 빈 응답을
+ * 유발한다. 이 예산을 넘으면 system 보존 + 최근 메시지 우선으로 truncate 한다.
+ * (262K 모델 기준 안전 마진. env 로 조정 가능.)
+ */
+export const EXTERNAL_LLM_INPUT_TOKEN_BUDGET = parseInt(
+    process.env.EXTERNAL_LLM_INPUT_TOKEN_BUDGET || '220000',
+    10,
+);
+
+/**
  * 명시적 아티팩트 생성 요청 턴에서 억제할 always-on 도구.
  *
  * 측정 근거 (2026-06-23 통제실험): "아티팩트로 html5 ... 작성해" 요청에서 qwen3.6 이

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -13,7 +13,8 @@
  * @module services/chat-service/external-provider
  */
 import { createLogger } from '../../utils/logger';
-import { EXTERNAL_LLM_TOOL_BLACKLIST, LOOP_DETECTION, AGENT_LOOP_LIMITS, MAX_TOOL_RESULT_CHARS, ARTIFACT_REQUEST_SUPPRESSED_TOOLS, ARTIFACT_INTENT_PATTERNS } from '../../config/runtime-limits';
+import { EXTERNAL_LLM_TOOL_BLACKLIST, LOOP_DETECTION, AGENT_LOOP_LIMITS, MAX_TOOL_RESULT_CHARS, ARTIFACT_REQUEST_SUPPRESSED_TOOLS, ARTIFACT_INTENT_PATTERNS, EXTERNAL_LLM_INPUT_TOKEN_BUDGET } from '../../config/runtime-limits';
+import { estimateMessageTokens, truncateMessagesPreservingSystem } from '../../llm/model-pool';
 import { getUnifiedMCPClient } from '../../mcp/unified-client';
 import { isPersistableUserId } from '../../utils/user-id-validation';
 import { getExternalProviderSystemGuards } from '../../chat/prompt';
@@ -228,9 +229,15 @@ export async function streamFromExternalProvider(
                 });
             }
             const turnTools = suppressTools ? [] : tools;
+            // A. context-fit 안전망: external 경로는 LLMClient.chat 의 model-pool truncate 를
+            // 우회하므로, 도구 루프로 누적된 messages 가 예산을 넘으면 system 보존 + 최근 우선
+            // 으로 절단한다(큰 컨텍스트가 그대로 전달돼 모델이 빈 응답을 내는 회귀의 극단 방어).
+            const fittedMessages = estimateMessageTokens(messages) > EXTERNAL_LLM_INPUT_TOKEN_BUDGET
+                ? truncateMessagesPreservingSystem(messages, EXTERNAL_LLM_INPUT_TOKEN_BUDGET)
+                : messages;
             result = await resolved.provider.streamChat(
                 {
-                    messages,
+                    messages: fittedMessages,
                     modelId: resolved.modelId,
                     thinking: req.thinkingMode === true,
                     ...(turnTools.length > 0 ? { tools: turnTools } : {}),
@@ -251,6 +258,20 @@ export async function streamFromExternalProvider(
             );
 
             if (suppressTools || !result.toolCalls || result.toolCalls.length === 0) {
+                // B. 빈 응답 방어: 도구를 아직 끄지 않았는데 모델이 도구 호출도 텍스트도 없이
+                // 종료하면(큰 컨텍스트에서 관측된 회귀 — 텍스트 스트리밍 0) 도구를 끈 최종 턴으로
+                // 한 번 더 유도해 답변 본문을 강제한다. (재시도는 1회 — suppressTools 진입 후 break)
+                const noText = !(result.content && result.content.trim());
+                const noTools = !result.toolCalls || result.toolCalls.length === 0;
+                if (!suppressTools && noText && noTools) {
+                    logger.warn('⚠️ 외부 LLM 빈 응답(텍스트·도구 모두 없음) — 도구 비활성 최종 턴으로 답변 강제');
+                    suppressTools = true;
+                    messages.push({
+                        role: 'user',
+                        content: '답변 본문이 비어 있습니다. 추가 도구 호출 없이 사용자 요청에 대한 답변(필요 시 <artifact> 산출물 포함)을 반드시 작성하세요.',
+                    });
+                    continue;
+                }
                 break;
             }
 


### PR DESCRIPTION
## 배경
Playwright 라이브 점검(brand alias 폐기 검증) 중 발견한 **별개 기존 이슈**. 누적 대화(`in=73197`)에서 아티팩트 요청 시 모델이 텍스트 없이 도구만 호출하고 종료(`ttfb=-1ms, tokens=0`)하여 **화면에 빈 응답**이 표시됨. 새 대화(`in=8448`)에선 정상.

## 근본 원인
`external-provider` 경로는 `LLMClient.chat` 의 model-pool context-fit 안전망을 **우회**(`provider.streamChat` 직접 호출)합니다. 따라서 도구 루프로 누적된 큰 컨텍스트가 그대로 provider 로 전달되고, 큰 컨텍스트에서 모델이 텍스트 스트리밍 0 으로 종료해도 방어가 없습니다.

## 수정 (A+B)
- **A. context-fit**: 도구 루프 `streamChat` 직전, messages 가 `EXTERNAL_LLM_INPUT_TOKEN_BUDGET`(기본 220K, env 조정) 초과 시 `truncateMessagesPreservingSystem`(system 보존 + 최근 우선)으로 절단 — 극단 컨텍스트 방어
- **B. 빈응답 방어**: 도구 호출도 텍스트도 없이 종료하면 도구 비활성 최종 턴으로 한 번 더 유도해 답변 본문 강제. 기존 doom-loop/wall-clock 의 `suppressTools + continue` **검증된 패턴 재사용**

## 검증
- tsc 0
- **⚠️ 라이브 73K 재현 미완**: 컨텍스트 구축(여러 긴 메시지 누적) + 모드 토글 + 응답 진행 중 전송 타이밍이 환경적으로 불안정해, 빈 응답을 결정적으로 재현하지 못함. B 로직은 기존 검증된 패턴 재사용이라 신뢰하나, 운영 배포 후 **`외부 LLM 빈 응답` warn 로그로 발동 빈도 모니터링 권장**.

## brand alias 폐기와의 관계
무관한 별개 기존 이슈 (external-provider 컨텍스트 관리).

🤖 Generated with [Claude Code](https://claude.com/claude-code)