### PR TITLE
feat(chat): 슬래시 스킬 메뉴 카테고리 그룹핑 + 전체보기 링크

### DIFF
--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -18,11 +18,17 @@ import {
   Paperclip,
   X,
 } from "lucide-react";
+import { useRouter } from "next/navigation";
 import type { WsAttachedFile } from "@openmake/shared-types";
 import { useAppStore } from "@/lib/store";
 import { useChatSocket } from "@/lib/use-chat-socket";
 import { fetchModels } from "@/lib/models-api";
-import { fetchSkills, skillSlug, type SkillSummary } from "@/lib/skills-api";
+import {
+  fetchSkills,
+  groupSkillsByCategory,
+  skillSlug,
+  type SkillSummary,
+} from "@/lib/skills-api";
 import { SlashSkillMenu } from "@/components/chat/slash-skill-menu";
 import { cn } from "@/lib/utils";
 
@@ -81,6 +87,7 @@ function readFileBase64(file: File): Promise<string> {
 
 export function Composer() {
   const { sendChat, abort, startAgentTask, sendStructured } = useChatSocket();
+  const router = useRouter();
   const [text, setText] = useState("");
   const [files, setFiles] = useState<WsAttachedFile[]>([]);
   // 이미지 첨부 — base64 data URL 로 vision 채널 전송. 미리보기/제거를 위해 메타와 함께 보관.
@@ -194,14 +201,28 @@ export function Composer() {
     enabled: slashCandidate,
     staleTime: 30_000,
   });
-  const slashSkills: SkillSummary[] = slashCandidate ? slashSkillsData ?? [] : [];
+  // 검색어 없으면("/") 카테고리 그룹핑(전체), 있으면 평면 검색 목록
+  const slashGrouped = slashDebounced.trim() === "";
+  const rawSlashSkills: SkillSummary[] = slashCandidate ? slashSkillsData ?? [] : [];
+  const slashSkills: SkillSummary[] = slashGrouped
+    ? groupSkillsByCategory(rawSlashSkills)
+    : rawSlashSkills;
   // 메뉴 표시: 후보 상태이며 로딩 중이거나 결과가 있을 때
   const slashMenuOpen = slashCandidate && (slashLoading || slashSkills.length > 0);
+  // 키보드 순회 길이: 스킬 + "전체 보기" 1
+  const slashNavCount = slashSkills.length + 1;
+  const slashViewAllIndex = slashSkills.length;
 
   // 검색 결과가 바뀌면 활성 인덱스 초기화
   useEffect(() => {
     setSlashActiveIndex(0);
   }, [slashDebounced, slashSkillsData]);
+
+  // "전체 보기" → 스킬 라이브러리로 이동하고 메뉴 닫기
+  const goToSkillLibrary = () => {
+    setSlashDismissed(true);
+    router.push("/skill-library");
+  };
 
   // 외부 클릭 시 닫기
   useEffect(() => {
@@ -440,10 +461,12 @@ export function Composer() {
         {slashMenuOpen && (
           <SlashSkillMenu
             skills={slashSkills}
+            grouped={slashGrouped}
             activeIndex={slashActiveIndex}
             loading={slashLoading}
             onSelect={selectSlashSkill}
             onHover={setSlashActiveIndex}
+            onViewAll={goToSkillLibrary}
           />
         )}
 
@@ -458,20 +481,17 @@ export function Composer() {
             e.target.style.height = Math.min(e.target.scrollHeight, 200) + "px";
           }}
           onKeyDown={(e) => {
-            // 슬래시 메뉴가 열려 있으면 네비게이션/선택 우선 처리
+            // 슬래시 메뉴가 열려 있으면 네비게이션/선택 우선 처리.
+            // 활성 인덱스는 스킬(0..n-1) + "전체 보기"(n) 를 순회.
             if (slashMenuOpen) {
               if (e.key === "ArrowDown") {
                 e.preventDefault();
-                setSlashActiveIndex((i) =>
-                  slashSkills.length ? (i + 1) % slashSkills.length : 0,
-                );
+                setSlashActiveIndex((i) => (i + 1) % slashNavCount);
                 return;
               }
               if (e.key === "ArrowUp") {
                 e.preventDefault();
-                setSlashActiveIndex((i) =>
-                  slashSkills.length ? (i - 1 + slashSkills.length) % slashSkills.length : 0,
-                );
+                setSlashActiveIndex((i) => (i - 1 + slashNavCount) % slashNavCount);
                 return;
               }
               if (e.key === "Escape") {
@@ -479,8 +499,14 @@ export function Composer() {
                 setSlashDismissed(true);
                 return;
               }
-              // Enter: 선택 가능한 항목이 있으면 스킬 선택, 없으면 아래 submit 으로 fall-through
               if (e.key === "Enter" && !e.shiftKey) {
+                // "전체 보기" 활성 → 라이브러리 이동
+                if (slashActiveIndex === slashViewAllIndex) {
+                  e.preventDefault();
+                  goToSkillLibrary();
+                  return;
+                }
+                // 스킬 항목 활성 → 선택. 없으면 아래 submit 으로 fall-through
                 const sel = slashSkills[slashActiveIndex];
                 if (sel) {
                   e.preventDefault();

--- a/apps/web/components/chat/slash-skill-menu.tsx
+++ b/apps/web/components/chat/slash-skill-menu.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { Sparkles } from "lucide-react";
+import { Fragment, useEffect, useRef } from "react";
+import { Sparkles, ArrowRight } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { skillSlug, type SkillSummary } from "@/lib/skills-api";
+import { skillCategoryLabel, skillSlug, type SkillSummary } from "@/lib/skills-api";
 
 interface SlashSkillMenuProps {
-  /** 표시할 스킬 목록 (이미 검색 필터링된 결과) */
+  /** 표시할 스킬 목록 (검색 시 평면 / 미검색 시 카테고리순 정렬된 단일 배열) */
   skills: SkillSummary[];
-  /** 키보드 네비게이션 활성 인덱스 */
+  /** 카테고리 헤더 그룹핑 여부 (검색어 없을 때 true) */
+  grouped: boolean;
+  /** 키보드 네비게이션 활성 인덱스. skills.length === "전체 보기" 항목. */
   activeIndex: number;
   /** 검색 로딩 중 여부 */
   loading: boolean;
@@ -16,22 +18,31 @@ interface SlashSkillMenuProps {
   onSelect: (skill: SkillSummary) => void;
   /** 마우스 hover 로 활성 인덱스 변경 */
   onHover: (index: number) => void;
+  /** "전체 보기" 활성화 (스킬 라이브러리 이동) */
+  onViewAll: () => void;
 }
 
 /**
  * 채팅 입력창 슬래시(/) 스킬 호출 드롭다운.
  * 컴포저 위로 떠오르는 패널(모드 시트와 동일 스타일)로, 선택 시 텍스트를
  * `/<slug> ` 로 채워 백엔드 slash-command 매칭을 유도한다.
- * 키보드 네비게이션/Enter 충돌 처리는 부모(Composer)가 담당한다.
+ *
+ * - 미검색: `grouped` true — category 가 바뀌는 지점마다 헤더 삽입(부모가 카테고리순 정렬해 전달).
+ * - 검색: 평면 목록.
+ * 키보드 네비게이션/Enter 충돌 처리는 부모(Composer)가 담당하며, activeIndex 는
+ * skills 배열 인덱스(0..n-1) 와 "전체 보기"(n) 를 단일 진실로 가리킨다.
  */
 export function SlashSkillMenu({
   skills,
+  grouped,
   activeIndex,
   loading,
   onSelect,
   onHover,
+  onViewAll,
 }: SlashSkillMenuProps) {
   const listRef = useRef<HTMLDivElement>(null);
+  const viewAllIndex = skills.length;
 
   // 활성 항목이 보이도록 스크롤
   useEffect(() => {
@@ -39,56 +50,88 @@ export function SlashSkillMenu({
     el?.scrollIntoView({ block: "nearest" });
   }, [activeIndex]);
 
+  let prevCategory: string | null = null;
+
   return (
-    <div className="absolute bottom-full left-0 right-0 z-40 mb-2 overflow-hidden rounded-xl border border-border bg-surface-2 shadow-lg">
-      <p className="border-b border-border px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-faint">
+    <div className="absolute bottom-full left-0 right-0 z-40 mb-2 flex flex-col overflow-hidden rounded-xl border border-border bg-surface-2 shadow-lg">
+      <p className="shrink-0 border-b border-border px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-faint">
         스킬 호출
       </p>
+
       {skills.length === 0 ? (
         <p className="px-3 py-3 text-sm text-muted">
           {loading ? "스킬을 불러오는 중…" : "일치하는 스킬이 없습니다"}
         </p>
       ) : (
-        <div ref={listRef} className="max-h-64 overflow-y-auto p-1">
-          {skills.map((skill, i) => (
-            <button
-              key={skill.id}
-              type="button"
-              data-idx={i}
-              // 마우스다운(blur 전)에 선택 — 텍스트영역 포커스 유지
-              onMouseDown={(e) => {
-                e.preventDefault();
-                onSelect(skill);
-              }}
-              onMouseEnter={() => onHover(i)}
-              className={cn(
-                "flex w-full items-start gap-2.5 rounded-md px-2.5 py-2 text-left transition",
-                i === activeIndex ? "bg-surface-3" : "hover:bg-surface-3",
-              )}
-            >
-              <Sparkles
-                className={cn(
-                  "mt-0.5 h-4 w-4 shrink-0",
-                  i === activeIndex ? "text-accent" : "text-muted",
+        <div ref={listRef} className="max-h-72 overflow-y-auto p-1">
+          {skills.map((skill, i) => {
+            const cat = skillCategoryLabel(skill.category);
+            const showHeader = grouped && cat !== prevCategory;
+            prevCategory = cat;
+            return (
+              <Fragment key={skill.id}>
+                {showHeader && (
+                  <p className="px-2.5 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-wide text-faint">
+                    {cat}
+                  </p>
                 )}
-              />
-              <span className="min-w-0 flex-1">
-                <span className="flex items-baseline gap-2">
-                  <span className="truncate text-sm font-medium text-fg">{skill.name}</span>
-                  <span className="shrink-0 font-mono text-[11px] text-faint">
-                    /{skillSlug(skill.name)}
+                <button
+                  type="button"
+                  data-idx={i}
+                  // 마우스다운(blur 전)에 선택 — 텍스트영역 포커스 유지
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    onSelect(skill);
+                  }}
+                  onMouseEnter={() => onHover(i)}
+                  className={cn(
+                    "flex w-full items-start gap-2.5 rounded-md px-2.5 py-2 text-left transition",
+                    i === activeIndex ? "bg-surface-3" : "hover:bg-surface-3",
+                  )}
+                >
+                  <Sparkles
+                    className={cn(
+                      "mt-0.5 h-4 w-4 shrink-0",
+                      i === activeIndex ? "text-accent" : "text-muted",
+                    )}
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="flex items-baseline gap-2">
+                      <span className="truncate text-sm font-medium text-fg">{skill.name}</span>
+                      <span className="shrink-0 font-mono text-[11px] text-faint">
+                        /{skillSlug(skill.name)}
+                      </span>
+                    </span>
+                    {skill.description && (
+                      <span className="mt-0.5 block truncate text-xs text-muted">
+                        {skill.description}
+                      </span>
+                    )}
                   </span>
-                </span>
-                {skill.description && (
-                  <span className="mt-0.5 block truncate text-xs text-muted">
-                    {skill.description}
-                  </span>
-                )}
-              </span>
-            </button>
-          ))}
+                </button>
+              </Fragment>
+            );
+          })}
         </div>
       )}
+
+      {/* 전체 보기 — 스킬 라이브러리로 이동 (키보드 순회 마지막 인덱스) */}
+      <button
+        type="button"
+        data-idx={viewAllIndex}
+        onMouseDown={(e) => {
+          e.preventDefault();
+          onViewAll();
+        }}
+        onMouseEnter={() => onHover(viewAllIndex)}
+        className={cn(
+          "flex shrink-0 items-center justify-between gap-2 border-t border-border px-3 py-2 text-left text-xs font-medium transition",
+          activeIndex === viewAllIndex ? "bg-surface-3 text-fg" : "text-muted hover:bg-surface-3 hover:text-fg",
+        )}
+      >
+        <span>스킬 라이브러리에서 전체 보기</span>
+        <ArrowRight className="h-3.5 w-3.5 shrink-0" />
+      </button>
     </div>
   );
 }

--- a/apps/web/lib/skills-api.ts
+++ b/apps/web/lib/skills-api.ts
@@ -31,12 +31,44 @@ export function skillSlug(name: string): string {
 /**
  * GET /api/agents/skills — active 스킬 검색/목록 (슬래시 드롭다운용).
  * `{ success, data: { skills, ... } }` 응답을 언래핑해 스킬 배열만 반환한다.
+ *
+ * - 검색어 없음("/" 단독): 카테고리 그룹핑을 위해 전체(최대 200)를 가져온다.
+ * - 검색어 있음: 평면 필터 목록이므로 30개로 제한.
  */
 export async function fetchSkills(search?: string): Promise<SkillSummary[]> {
-  const params = new URLSearchParams({ sortBy: "name", limit: "20" });
+  const limit = search ? "30" : "200";
+  const params = new URLSearchParams({ sortBy: "name", limit });
   if (search) params.set("search", search);
   const res = await ApiClient.get<{ success: boolean; data: SkillSearchResponse }>(
     `/api/agents/skills?${params.toString()}`,
   );
   return res?.data?.skills ?? [];
+}
+
+/** 카테고리 표시 라벨 — 빈 값은 '기타'로 대체. */
+export function skillCategoryLabel(category: string): string {
+  return category && category.trim() ? category : "기타";
+}
+
+/**
+ * 스킬을 카테고리로 그룹핑해 평탄화한 단일 순서를 반환한다.
+ * 키보드 네비게이션 인덱스와 그룹 렌더 순서를 일치시키기 위해, 호출자는
+ * 반환된 `ordered` 배열(카테고리별로 인접 정렬)을 단일 진실로 사용한다.
+ * 렌더 측은 category 가 바뀌는 지점마다 헤더를 삽입하면 된다.
+ */
+export function groupSkillsByCategory(skills: SkillSummary[]): SkillSummary[] {
+  const byCat = new Map<string, SkillSummary[]>();
+  for (const s of skills) {
+    const label = skillCategoryLabel(s.category);
+    const arr = byCat.get(label);
+    if (arr) arr.push(s);
+    else byCat.set(label, [s]);
+  }
+  const ordered: SkillSummary[] = [];
+  for (const label of [...byCat.keys()].sort((a, b) => a.localeCompare(b))) {
+    const arr = byCat.get(label)!;
+    arr.sort((a, b) => a.name.localeCompare(b.name));
+    ordered.push(...arr);
+  }
+  return ordered;
 }


### PR DESCRIPTION
## 배경
슬래시 스킬 드롭다운(#234)이 `limit=20` 하드코딩이라 101개 스킬 중 일부만 보여 탐색이 어렵다는 피드백.

## 개선 (2+3)
- **카테고리 그룹핑**: 검색어 없을 때("/" 단독) 스킬을 ~18개 카테고리 헤더로 그룹핑 표시. 검색 시("/키워드")는 평면 필터.
- **limit 상향**: 검색어 없으면 `limit=200`(전체 커버), 검색 시 30. 드롭다운 `max-h-72 overflow-y-auto` 스크롤.
- **"전체 보기" 링크**: 하단 sticky 버튼 → `/skill-library` (useRouter, sidebar 패턴).

## 키보드 네비게이션
- ↑↓ 평탄 배열 인덱스 순회(카테고리 헤더는 배열 원소가 아니라 자연 스킵), 마지막 인덱스 = "전체 보기"
- Enter = 스킬 선택 / 전체보기 이동, 기존 Enter↔submit 충돌 처리 유지

## 검증
- tsc 신규 에러 0
- 라이브: "/" 입력 → AGRICULTURE·ANALYSIS 등 카테고리 헤더 + **144항목** 표시, "전체 보기" 링크 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)