### PR TITLE
fix(web): 기본 다크모드 + 라이트모드 보조 텍스트 대비 보강

### DIFF
--- a/apps/web/app/(workspace)/admin/mcp-catalog/page.tsx
+++ b/apps/web/app/(workspace)/admin/mcp-catalog/page.tsx
@@ -35,9 +35,9 @@ const TRANSPORT_LABEL: Record<TransportType, string> = {
   "streamable-http": "HTTP",
 };
 
-const inputCls = "h-9 w-full rounded-md border border-border bg-surface-2 px-3 text-sm text-fg placeholder:text-faint focus:border-accent focus:outline-none";
+const inputCls = "h-9 w-full rounded-md border border-border bg-surface-2 px-3 text-sm text-fg placeholder:text-muted focus:border-accent focus:outline-none";
 const selectCls = "h-9 w-full rounded-md border border-border bg-surface-2 px-3 text-sm text-fg focus:border-accent focus:outline-none";
-const textareaCls = "w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-fg placeholder:text-faint focus:border-accent focus:outline-none resize-none";
+const textareaCls = "w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-fg placeholder:text-muted focus:border-accent focus:outline-none resize-none";
 const labelCls = "block text-xs font-medium text-fg-2 mb-1";
 
 /* ── 모달 공통 래퍼 ─────────────────────────────────────────── */

--- a/apps/web/app/(workspace)/admin/page.tsx
+++ b/apps/web/app/(workspace)/admin/page.tsx
@@ -89,7 +89,7 @@ function Modal({ onClose, children }: { onClose: () => void; children: React.Rea
   );
 }
 
-const inputCls = "h-9 w-full rounded-md border border-border bg-surface-2 px-3 text-sm text-fg placeholder:text-faint focus:border-accent focus:outline-none";
+const inputCls = "h-9 w-full rounded-md border border-border bg-surface-2 px-3 text-sm text-fg placeholder:text-muted focus:border-accent focus:outline-none";
 const selectCls = "h-9 w-full rounded-md border border-border bg-surface-2 px-3 text-sm text-fg focus:border-accent focus:outline-none";
 const labelCls = "block text-xs font-medium text-fg-2 mb-1";
 

--- a/apps/web/app/(workspace)/history/page.tsx
+++ b/apps/web/app/(workspace)/history/page.tsx
@@ -209,7 +209,7 @@ export default function HistoryPage() {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="대화 제목 검색..."
-            className="h-9 w-full bg-transparent text-sm text-fg outline-none placeholder:text-faint"
+            className="h-9 w-full bg-transparent text-sm text-fg outline-none placeholder:text-muted"
           />
         </div>
 

--- a/apps/web/app/(workspace)/mcp-catalog/page.tsx
+++ b/apps/web/app/(workspace)/mcp-catalog/page.tsx
@@ -183,7 +183,7 @@ export default function McpCatalogPage() {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="이름, 제공자, 설명으로 검색…"
-            className="h-9 w-full rounded-md border border-border bg-surface pl-9 pr-3 text-sm text-fg placeholder:text-faint focus:border-accent focus:outline-none"
+            className="h-9 w-full rounded-md border border-border bg-surface pl-9 pr-3 text-sm text-fg placeholder:text-muted focus:border-accent focus:outline-none"
           />
         </div>
 

--- a/apps/web/app/(workspace)/research/page.tsx
+++ b/apps/web/app/(workspace)/research/page.tsx
@@ -371,7 +371,7 @@ export default function ResearchPage() {
                     if (e.key === "Enter") startResearch();
                   }}
                   placeholder="연구하고 싶은 주제를 입력하세요..."
-                  className="h-9 w-full bg-transparent text-sm text-fg outline-none placeholder:text-faint"
+                  className="h-9 w-full bg-transparent text-sm text-fg outline-none placeholder:text-muted"
                 />
               </div>
             </div>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -13,8 +13,8 @@
   --surface-3: #e9ecf1;
   --fg: #14161c;
   --fg-2: #3a3f4a;
-  --muted: #626b7a;
-  --faint: #8a93a1;
+  --muted: #5b6472;
+  --faint: #6e7686;
   --border: #e4e7ec;
   --border-strong: #cfd4dc;
 

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -75,7 +75,7 @@ export default function LoginPage() {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder="you@example.com"
-            className="mt-1.5 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none transition placeholder:text-faint focus:border-accent focus:ring-2 focus:ring-[var(--accent-ring)]"
+            className="mt-1.5 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none transition placeholder:text-muted focus:border-accent focus:ring-2 focus:ring-[var(--accent-ring)]"
           />
 
           <label className="mt-4 block text-xs font-medium text-fg-2">
@@ -87,7 +87,7 @@ export default function LoginPage() {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="••••••••"
-            className="mt-1.5 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none transition placeholder:text-faint focus:border-accent focus:ring-2 focus:ring-[var(--accent-ring)]"
+            className="mt-1.5 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none transition placeholder:text-muted focus:border-accent focus:ring-2 focus:ring-[var(--accent-ring)]"
           />
 
           <Button type="submit" disabled={loading} className="mt-5 w-full">

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -49,7 +49,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
     <QueryClientProvider client={queryClient}>
       <ThemeProvider
         attribute="data-theme"
-        defaultTheme="light"
+        defaultTheme="dark"
         enableSystem={false}
         disableTransitionOnChange
       >

--- a/apps/web/app/register/page.tsx
+++ b/apps/web/app/register/page.tsx
@@ -73,7 +73,7 @@ export default function RegisterPage() {
             value={username}
             onChange={(e) => setUsername(e.target.value)}
             placeholder="홍길동"
-            className="mt-1.5 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none transition placeholder:text-faint focus:border-accent focus:ring-2 focus:ring-[var(--accent-ring)]"
+            className="mt-1.5 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none transition placeholder:text-muted focus:border-accent focus:ring-2 focus:ring-[var(--accent-ring)]"
           />
 
           <label className="mt-4 block text-xs font-medium text-fg-2">이메일</label>
@@ -83,7 +83,7 @@ export default function RegisterPage() {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder="you@example.com"
-            className="mt-1.5 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none transition placeholder:text-faint focus:border-accent focus:ring-2 focus:ring-[var(--accent-ring)]"
+            className="mt-1.5 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none transition placeholder:text-muted focus:border-accent focus:ring-2 focus:ring-[var(--accent-ring)]"
           />
 
           <label className="mt-4 block text-xs font-medium text-fg-2">비밀번호</label>
@@ -93,7 +93,7 @@ export default function RegisterPage() {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="••••••••"
-            className="mt-1.5 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none transition placeholder:text-faint focus:border-accent focus:ring-2 focus:ring-[var(--accent-ring)]"
+            className="mt-1.5 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none transition placeholder:text-muted focus:border-accent focus:ring-2 focus:ring-[var(--accent-ring)]"
           />
 
           <label className="mt-4 block text-xs font-medium text-fg-2">생년월일</label>

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -522,7 +522,7 @@ export function Composer() {
           }}
           rows={1}
           placeholder="메시지를 입력하거나 / 로 스킬을 호출하세요..."
-          className="block w-full resize-none bg-transparent px-4 pt-2.5 text-sm text-fg outline-none placeholder:text-faint"
+          className="block w-full resize-none bg-transparent px-4 pt-2.5 text-sm text-fg outline-none placeholder:text-muted"
         />
 
         {/* 하단: 스타일 + 전송 (모델 선택은 설정 → 기본 모델에서, 채팅창엔 모델명 비표시) */}

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -102,7 +102,7 @@ export function Sidebar() {
           <Search className="h-4 w-4 text-faint" />
           <input
             placeholder="검색..."
-            className="w-full bg-transparent text-sm text-fg outline-none placeholder:text-faint"
+            className="w-full bg-transparent text-sm text-fg outline-none placeholder:text-muted"
           />
         </div>
       </div>


### PR DESCRIPTION
## 요청
1. 사용자 접속 시 기본을 **다크모드**로
2. **라이트모드에서 글씨가 거의 안 보이는 현상** 해결 (OD MCP 함께 검토)

## 진단 (Playwright + Open Design MCP)
- 라이트모드 **핵심 화면(메인/채팅/사이드바)은 정상** — 전수 저대비 스캔 결과 실질 0개, 본문/코드블록 모두 대비 충분
- 현재 globals.css 토큰은 OD 시안 `openmake-newdesign-2026`과 **100% 일치** (잘못된 토큰 아님)
- 다만 `--faint #8a93a1` on `#f7f8fa` ≈ **대비 2.9:1로 WCAG AA 미달** → eyebrow/meta/label 등 흐린 보조 텍스트가 일부 안 보일 수 있음

## 수정
- **기본 다크모드**: `providers.tsx` next-themes `defaultTheme="light"` → `"dark"` (신규/localStorage 미설정 사용자)
- **라이트 보조색 대비 보강**: `--muted #626b7a→#5b6472`, `--faint #8a93a1→#6e7686` (OD 시안 대조 후 보조색만 조정, 본문 토큰은 유지)

## 검증 (라이브)
- 신규 접속(localStorage clear) → `data-theme="dark"` ✅, 다크 렌더 글씨 정상
- 라이트 토큰 보강 적용 확인 (`--faint:#6e7686`, `--muted:#5b6472`)

## 참고
사용자가 본 "거의 안 보임"이 특정 페이지/모달일 가능성도 있어, 추가로 어느 화면이었는지 알려주시면 그 영역을 집중 점검하겠습니다. 기본 다크모드 전환으로 라이트 사용 빈도 자체가 줄어 주 불편은 해소됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)