### PR TITLE
feat(chat): AI 응답 아바타를 OpenMake 로고로 변경

### DIFF
--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -158,9 +158,7 @@ function ThinkingIndicator({
       : "분석 중";
   return (
     <div className="flex gap-3">
-      <div className="mt-0.5 grid h-7 w-7 shrink-0 place-items-center rounded-md bg-accent text-xs font-bold text-accent-fg">
-        AI
-      </div>
+      <Image src="/logo.png" alt="OpenMake" width={28} height={28} className="mt-0.5 h-7 w-7 shrink-0 rounded-md object-contain" />
       <div className="min-w-0 flex-1">
         <p className="mb-1 text-xs font-medium text-muted">OpenMake</p>
         <div className="flex items-center gap-2 text-sm text-muted">
@@ -368,9 +366,7 @@ export function MessageList() {
           </div>
         ) : (
           <div key={i} className="flex gap-3">
-            <div className="mt-0.5 grid h-7 w-7 shrink-0 place-items-center rounded-md bg-accent text-xs font-bold text-accent-fg">
-              AI
-            </div>
+            <Image src="/logo.png" alt="OpenMake" width={28} height={28} className="mt-0.5 h-7 w-7 shrink-0 rounded-md object-contain" />
             <div className="min-w-0 flex-1">
               <p className="mb-1 text-xs font-medium text-muted">OpenMake</p>
               {m.reasoning && (


### PR DESCRIPTION
## 요청
AI 응답 시 네모난 "AI" 아바타를 로고로 변경

## 수정
`message-list.tsx`의 AI 아바타 2곳(분석 중 / 응답 메시지)을 `bg-accent` 사각형 + "AI" 텍스트에서 **sidebar와 동일한 `/logo.png`(next/image)** 로 교체 (28×28, rounded-md, object-contain).

## 검증 (라이브)
- 응답 아바타 `src=/logo.png alt=OpenMake`, "AI" 텍스트 아바타 제거 확인
- 스크린샷: OpenMake 로고가 응답 옆에 정상 렌더

🤖 Generated with [Claude Code](https://claude.com/claude-code)