### PR TITLE
feat(web): AI 응답 마크다운 가독성 — prose-chat typography 정의

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -207,3 +207,97 @@ body {
 .hljs-name {
   color: var(--m-vision);
 }
+
+/* =========================================================================
+   AI 응답 마크다운 typography — Tailwind preflight reset 보완.
+   (LLM 은 제목/리스트/강조 markdown 을 잘 생성하나 preflight 가 제목 크기·단락
+    여백·리스트 불릿을 모두 제거해 "글자만 나열"되던 가독성 문제 해결.)
+   ========================================================================= */
+.prose-chat {
+  font-size: 0.9375rem;
+  line-height: 1.7;
+  color: var(--fg);
+}
+.prose-chat > :first-child {
+  margin-top: 0;
+}
+.prose-chat > :last-child {
+  margin-bottom: 0;
+}
+.prose-chat p {
+  margin: 0.7em 0;
+}
+.prose-chat h1 {
+  font-size: 1.45em;
+  font-weight: 700;
+  line-height: 1.3;
+  margin: 1.3em 0 0.5em;
+}
+.prose-chat h2 {
+  font-size: 1.25em;
+  font-weight: 700;
+  line-height: 1.35;
+  margin: 1.2em 0 0.45em;
+  padding-bottom: 0.2em;
+  border-bottom: 1px solid var(--border);
+}
+.prose-chat h3 {
+  font-size: 1.1em;
+  font-weight: 600;
+  line-height: 1.4;
+  margin: 1.1em 0 0.35em;
+}
+.prose-chat h4 {
+  font-size: 1em;
+  font-weight: 600;
+  margin: 1em 0 0.3em;
+}
+.prose-chat ul {
+  list-style: disc;
+  padding-left: 1.45em;
+  margin: 0.6em 0;
+}
+.prose-chat ol {
+  list-style: decimal;
+  padding-left: 1.5em;
+  margin: 0.6em 0;
+}
+.prose-chat li {
+  margin: 0.35em 0;
+  padding-left: 0.15em;
+}
+.prose-chat li::marker {
+  color: var(--muted);
+}
+.prose-chat li > ul,
+.prose-chat li > ol {
+  margin: 0.3em 0;
+}
+.prose-chat strong {
+  font-weight: 700;
+  color: var(--fg);
+}
+.prose-chat em {
+  font-style: italic;
+}
+.prose-chat blockquote {
+  border-left: 3px solid var(--border-strong);
+  padding: 0.1em 0 0.1em 1em;
+  margin: 0.8em 0;
+  color: var(--muted);
+}
+.prose-chat hr {
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: 1.4em 0;
+}
+.prose-chat table th,
+.prose-chat table td {
+  border: 1px solid var(--border);
+  padding: 0.4em 0.7em;
+  text-align: left;
+}
+.prose-chat table th {
+  background: var(--surface-2);
+  font-weight: 600;
+}


### PR DESCRIPTION
## 문제
AI 응답이 "글자만 나열"되어 가독성이 떨어짐.

## 원인
`markdown.tsx`는 `.prose-chat` 컨테이너로 렌더하는데 **globals.css에 정의가 0개**이고 **Tailwind typography 플러그인도 미사용**. Tailwind preflight reset이 제목 크기·단락 여백·리스트 불릿을 모두 제거 → LLM이 제목/표/리스트 markdown을 잘 내도 평이하게 렌더됨.

라이브 진단(이전):
- 제목 h3: `14px / weight 400 / margin 0` (본문과 동일)
- 리스트 ul: `list-style:none / padding:0`
- 단락 p: `margin:0`

## 수정
`globals.css`에 `.prose-chat` typography 정의:
- 제목 위계 (h1~h4 크기/굵기/여백, h2 하단 구분선)
- 단락 간격 + line-height 1.7
- 리스트 불릿/번호/들여쓰기/마커 색
- 강조(strong), blockquote, hr, 표(보더/헤더 배경)
- 모두 Lumen 토큰 기반 → 라이트/다크 자동 대응

## 검증 (라이브)
개선 후: 제목 H2 `18.75px/700/상단여백 22.5px`, ul `disc/들여쓰기 21.75px`, 단락 `하단 10.5px`. 스크린샷상 제목/표/리스트/강조가 시각적으로 구조화됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)