### PR TITLE
feat(web): 딥리서치/에이전트 작업 페이지를 히스토리·관리 전용으로 축소

### DIFF
--- a/apps/web/app/(workspace)/agent-tasks/page.tsx
+++ b/apps/web/app/(workspace)/agent-tasks/page.tsx
@@ -1,16 +1,15 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import {
   Sparkles,
-  Plus,
   Check,
   LoaderCircle,
   Clock,
   Cpu,
   X,
   Trash2,
-  Play,
   RotateCcw,
   ChevronRight,
 } from "lucide-react";
@@ -19,9 +18,6 @@ import {
   Badge,
   PageHeader,
   Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
 } from "@/components/ui/primitives";
 import { cn } from "@/lib/utils";
 import type { ApiSuccess } from "@openmake/shared-types";
@@ -221,65 +217,6 @@ function Modal({
   );
 }
 
-/* ── 작업 생성 폼 ─────────────────────────────────────────── */
-function CreateTaskForm({
-  onClose,
-  onCreated,
-}: {
-  onClose: () => void;
-  onCreated: (taskId: string) => void | Promise<void>;
-}) {
-  const [goal, setGoal] = useState("");
-  const [maxTurns, setMaxTurns] = useState(8);
-  const [saving, setSaving] = useState(false);
-  const [formError, setFormError] = useState<string | null>(null);
-
-  async function handleSubmit() {
-    if (!goal.trim()) { setFormError("목표를 입력하세요."); return; }
-    setSaving(true);
-    setFormError(null);
-    try {
-      const res = await ApiClient.post<ApiSuccess<{ task: ApiAgentTask }>>("/api/agent-tasks", {
-        goal: goal.trim(),
-        maxTurns,
-      });
-      const taskId = res?.data?.task?.id;
-      if (!taskId) throw new Error("taskId가 응답에 없습니다");
-      await onCreated(taskId);
-    } catch (err) {
-      setFormError("생성 실패: " + (err instanceof Error ? err.message : "서버 오류"));
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  return (
-    <form onSubmit={(e) => { e.preventDefault(); void handleSubmit(); }} className="space-y-4">
-      <label className="block">
-        <span className="mb-1 block text-xs font-medium text-fg-2">에이전트 목표 *</span>
-        <textarea value={goal} onChange={(e) => setGoal(e.target.value)}
-          rows={4} autoFocus
-          placeholder="예: 최신 AI 에이전트 동향을 조사해서 요약 보고서를 작성해줘"
-          className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none focus:border-accent resize-none" />
-      </label>
-      <label className="block">
-        <span className="mb-1 block text-xs font-medium text-fg-2">최대 턴 수</span>
-        <input type="number" value={maxTurns} onChange={(e) => setMaxTurns(Number(e.target.value))}
-          min={1} max={50}
-          className="h-9 w-32 rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
-      </label>
-      {formError && <p className="text-xs text-danger">{formError}</p>}
-      <div className="flex justify-end gap-2 pt-1">
-        <Button type="button" variant="outline" onClick={onClose} disabled={saving}>취소</Button>
-        <Button type="submit" disabled={saving}>
-          {saving ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
-          생성 및 실행
-        </Button>
-      </div>
-    </form>
-  );
-}
-
 /* ── 작업 상세 모달 (스텝 타임라인) ─────────────────────── */
 const PLAN_MARK: Record<PlanStepStatus, string> = {
   not_started: "○",
@@ -290,10 +227,8 @@ const PLAN_MARK: Record<PlanStepStatus, string> = {
 
 function TaskDetailModal({
   taskId,
-  onClose,
 }: {
   taskId: string;
-  onClose: () => void;
 }) {
   const [detail, setDetail] = useState<{ task: ApiAgentTask; steps: ApiTaskStep[] } | null>(null);
   const [files, setFiles] = useState<string[]>([]);
@@ -534,9 +469,9 @@ function ApprovalsPanel() {
 }
 
 export default function AgentTasksPage() {
+  const router = useRouter();
   const [tasks, setTasks] = useState<AgentTask[]>(TASK_FALLBACK);
   const [loading, setLoading] = useState(true);
-  const [showCreate, setShowCreate] = useState(false);
   const [detailTaskId, setDetailTaskId] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null); // taskId being acted on
 
@@ -559,17 +494,6 @@ export default function AgentTasksPage() {
     })();
     return () => { cancelled = true; };
   }, [loadTasks]);
-
-  async function handleCreated(taskId: string) {
-    setShowCreate(false);
-    // 생성 후 즉시 실행
-    try {
-      await ApiClient.post(`/api/agent-tasks/${taskId}/execute`, {});
-    } catch {
-      // execute 실패해도 목록 새로고침
-    }
-    await loadTasks();
-  }
 
   async function handleCancel(task: AgentTask) {
     if (!window.confirm(`"${task.goal.slice(0, 40)}..." 작업을 취소하시겠습니까?`)) return;
@@ -612,16 +536,22 @@ export default function AgentTasksPage() {
   return (
     <>
       <PageHeader
-        title="에이전트 작업"
-        description="자율 에이전트가 목표 달성까지 다단계로 작업을 수행합니다."
-        actions={
-          <Button size="sm" onClick={() => setShowCreate(true)}>
-            <Plus className="h-4 w-4" />새 작업
-          </Button>
-        }
+        title="에이전트 작업 관리"
+        description="작업 목록·진행·승인을 관리합니다. 생성·실행은 채팅의 에이전트 모드에서 진행됩니다."
       />
 
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
+        {/* 실행 안내 배너 — 생성/실행은 채팅 인라인으로 일원화 */}
+        <Card className="mb-4 flex flex-wrap items-center justify-between gap-3 p-4">
+          <p className="text-sm text-muted">
+            에이전트 작업은 채팅 입력창의{" "}
+            <span className="font-medium text-fg-2">에이전트</span> 모드로
+            생성·실행하세요. 이 페이지에서는 작업 목록·진행·승인을 관리합니다.
+          </p>
+          <Button size="sm" variant="outline" onClick={() => router.push("/")}>
+            채팅으로 이동
+          </Button>
+        </Card>
         <ApprovalsPanel />
         {loading ? (
           <div className="grid place-items-center py-24 text-center">
@@ -632,9 +562,9 @@ export default function AgentTasksPage() {
           <div className="grid place-items-center py-24 text-center">
             <Sparkles className="mb-3 h-8 w-8 text-faint" />
             <p className="text-sm font-medium text-fg-2">작업이 없습니다</p>
-            <p className="mt-1 text-sm text-muted">목표를 입력하고 새 작업을 시작하세요.</p>
-            <Button size="sm" className="mt-4" onClick={() => setShowCreate(true)}>
-              <Plus className="h-4 w-4" />새 작업 만들기
+            <p className="mt-1 text-sm text-muted">채팅의 에이전트 모드에서 새 작업을 시작하세요.</p>
+            <Button size="sm" variant="outline" className="mt-4" onClick={() => router.push("/")}>
+              채팅으로 이동
             </Button>
           </div>
         ) : (
@@ -755,15 +685,10 @@ export default function AgentTasksPage() {
         )}
       </div>
 
-      {/* 새 작업 모달 */}
-      <Modal open={showCreate} onClose={() => setShowCreate(false)} title="새 에이전트 작업">
-        <CreateTaskForm onClose={() => setShowCreate(false)} onCreated={handleCreated} />
-      </Modal>
-
       {/* 작업 상세 모달 */}
       {detailTaskId && (
         <Modal open={!!detailTaskId} onClose={() => setDetailTaskId(null)} title="작업 상세">
-          <TaskDetailModal taskId={detailTaskId} onClose={() => setDetailTaskId(null)} />
+          <TaskDetailModal taskId={detailTaskId} />
         </Modal>
       )}
     </>

--- a/apps/web/app/(workspace)/research/page.tsx
+++ b/apps/web/app/(workspace)/research/page.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import {
-  Telescope,
-  Plus,
-  Search,
   CircleCheck,
   LoaderCircle,
   Circle,
@@ -186,13 +184,6 @@ const STAGE_ICON: Record<StageStatus, typeof Circle> = {
 };
 
 
-/** depth 백엔드 enum(basic/deep/comprehensive) ↔ UI 라벨. */
-const DEPTH_OPTIONS: { value: "basic" | "deep" | "comprehensive"; label: string }[] = [
-  { value: "basic", label: "빠른 검색" },
-  { value: "deep", label: "표준 (심층)" },
-  { value: "comprehensive", label: "종합 (최대)" },
-];
-
 const TERMINAL: ApiResearchStatus[] = ["completed", "failed", "cancelled"];
 
 const STATUS_LABEL: Record<ApiResearchStatus, string> = {
@@ -218,9 +209,7 @@ function fmtDate(iso?: string): string {
 }
 
 export default function ResearchPage() {
-  const [topic, setTopic] = useState("");
-  const [depth, setDepth] = useState<"basic" | "deep" | "comprehensive">("deep");
-  const [busy, setBusy] = useState(false);
+  const router = useRouter();
   const [sourcesOpen, setSourcesOpen] = useState(false);
   // 최신 세션이 있으면 그것으로 진행/소스/메트릭 표시. 없거나 실패 시 목업 폴백.
   const [stages, setStages] = useState<Stage[]>(STAGES);
@@ -302,100 +291,24 @@ export default function ResearchPage() {
 
   const isRunning = status === "running" || status === "pending";
 
-  // 리서치 시작 — 세션 생성 → 비동기 실행 → 폴링.
-  const startResearch = async () => {
-    const t = topic.trim();
-    if (!t || busy || isRunning) return;
-    setBusy(true);
-    try {
-      const created = await ApiClient.post<ApiSuccess<{ session: ApiResearchSession }>>(
-        "/api/research/sessions",
-        { topic: t, depth },
-      );
-      const session = created?.data?.session;
-      const sid = session?.id;
-      if (!sid) throw new Error("세션 생성 실패");
-      await ApiClient.post(`/api/research/sessions/${sid}/execute`, {});
-      if (session) {
-        setSessionList((prev) => [session, ...prev]); // 목록 맨 앞에 추가
-        setActiveSession(session);
-      }
-      setTopic("");
-      setStatus("running");
-      setStages(STAGES.map((s, i) => ({ ...s, status: i === 0 ? "running" : "pending" })));
-      if (pollRef.current) clearTimeout(pollRef.current);
-      poll(sid);
-    } catch {
-      /* 실패 — 상태 유지 */
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  // 새 리서치 — 폼/화면 초기화.
-  const newResearch = () => {
-    if (pollRef.current) clearTimeout(pollRef.current);
-    setTopic("");
-    setStatus(null);
-    setStages(STAGES);
-    setSources(SOURCES);
-    setMetrics(METRICS);
-  };
-
   return (
     <>
       <PageHeader
-        title="딥 리서치"
-        description="자율 다단계 리서치 에이전트가 질문 분해부터 인용 보고서까지 합성합니다."
-        actions={
-          <Button size="sm" onClick={newResearch}>
-            <Plus className="h-4 w-4" />새 리서치
-          </Button>
-        }
+        title="딥 리서치 히스토리"
+        description="지난 리서치 결과를 조회합니다. 실행은 채팅의 딥 리서치 모드에서 진행됩니다."
       />
 
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
-        {/* 새 리서치 입력 */}
-        <Card className="mb-6 p-4">
-          <div className="flex flex-wrap items-end gap-3">
-            <div className="min-w-[240px] flex-[3]">
-              <label className="mb-2 block text-xs font-medium text-fg-2">
-                연구 주제
-              </label>
-              <div className="flex items-center gap-2 rounded-md border border-border-strong bg-surface-2 px-3">
-                <Search className="h-4 w-4 text-faint" />
-                <input
-                  value={topic}
-                  onChange={(e) => setTopic(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") startResearch();
-                  }}
-                  placeholder="연구하고 싶은 주제를 입력하세요..."
-                  className="h-9 w-full bg-transparent text-sm text-fg outline-none placeholder:text-muted"
-                />
-              </div>
-            </div>
-            <div className="min-w-[120px] flex-1">
-              <label className="mb-2 block text-xs font-medium text-fg-2">
-                깊이
-              </label>
-              <select
-                value={depth}
-                onChange={(e) => setDepth(e.target.value as typeof depth)}
-                className="h-9 w-full rounded-md border border-border-strong bg-surface-2 px-3 text-sm text-fg outline-none"
-              >
-                {DEPTH_OPTIONS.map((d) => (
-                  <option key={d.value} value={d.value}>
-                    {d.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <Button size="md" disabled={!topic.trim() || busy || isRunning} onClick={startResearch}>
-              <Telescope className="h-4 w-4" />
-              {busy ? "시작 중…" : isRunning ? "진행 중…" : "리서치 시작"}
-            </Button>
-          </div>
+        {/* 실행 안내 배너 — 생성/실행은 채팅 인라인으로 일원화 */}
+        <Card className="mb-6 flex flex-wrap items-center justify-between gap-3 p-4">
+          <p className="text-sm text-muted">
+            딥 리서치는 채팅 입력창의{" "}
+            <span className="font-medium text-fg-2">딥 리서치</span> 모드로
+            실행하세요. 이 페이지에서는 지난 리서치 결과를 조회합니다.
+          </p>
+          <Button size="sm" variant="outline" onClick={() => router.push("/")}>
+            채팅으로 이동
+          </Button>
         </Card>
 
         {/* 보고서 중심 레이아웃: 좌측 지난 리서치 레일 + 메인(진행 stepper · 메트릭 · 보고서 · 소스) */}


### PR DESCRIPTION
## 배경
딥리서치·에이전트 작업이 **sidebar 전용 페이지**와 **채팅 인라인 모드** 두 경로로 실행돼 중복 인상. 실행을 채팅 인라인으로 일원화하고 페이지는 조회·관리 전용으로 축소.

## 변경
- **research/page.tsx**: 입력 폼·`startResearch`·`newResearch`·"새 리서치" 버튼 제거 → 안내 배너(+채팅 이동) 추가, 제목 "딥 리서치 히스토리". 조회·폴링·히스토리·보고서·소스 **유지**.
- **agent-tasks/page.tsx**: `CreateTaskForm`·생성 모달·"새 작업" 버튼 제거 → 안내 배너 추가, 제목 "에이전트 작업 관리". 작업 목록·상세·취소/재시도/삭제·**HITL 승인 패널 유지**.
- 미사용 import/param orphan 정리.

백엔드 및 채팅 인라인 모드(composer)는 **무변경** — 실행 경로는 그대로 동작.

## 검증
- tsc 신규 에러 0
- 라이브: 두 페이지 입력 폼 제거 + 안내 배너 + 목록/관리 유지 확인 (스크린샷)

🤖 Generated with [Claude Code](https://claude.com/claude-code)