### PR TITLE
fix(mcp): 설치한 user MCP 서버 도구를 채팅 LLM에 자동 통합

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -844,3 +844,6 @@ IMAGE_GEN_TIMEOUT_MS=180000
 # *******************************************************
 # docker compose (/Volumes/MAC_APP/docker/searxng/) 로 기동 후 URL 지정. 미설정 시 비활성.
 # SEARXNG_URL=http://127.0.0.1:8888
+
+# 채팅 자동 노출 user MCP 도구 상한 (설치=기본 ON, 로컬 qwen tool-bloat 방지)
+CHAT_USER_MCP_TOOL_CAP=12

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1086,6 +1086,19 @@ export const EXTERNAL_LLM_TOOL_BLACKLIST: readonly string[] = [
 ] as const;
 
 /**
+ * 채팅에서 자동 활성화(설치=기본 ON)되는 사용자 MCP 풀 도구 수 상한.
+ *
+ * 사용자가 설치한 MCP 서버 도구는 명시 토글 없이 채팅 LLM 에 노출되나, 다수 서버를
+ * 설치한 사용자의 경우 전체 도구 스키마가 과대해져 vLLM 첫 토큰 컴파일이 지연/hang
+ * 되는 것을 막기 위해(과거 ~150 도구 786KB → 첫토큰 101s 사례) 노출 수를 제한한다.
+ * 초과분은 drop 하고 로그로 알린다. picker 로 끈 도구는 cap 계산 전에 제외된다.
+ */
+export const CHAT_USER_MCP_TOOL_CAP = parseInt(
+    process.env.CHAT_USER_MCP_TOOL_CAP || '12',
+    10,
+);
+
+/**
  * 외부 provider 도구 루프 messages 토큰 예산 — external-provider 경로는 LLMClient.chat 의
  * model-pool context-fit 안전망을 우회(provider.streamChat 직접 호출)하므로, 큰 누적
  * 컨텍스트가 그대로 provider 로 전달돼 모델이 텍스트 없이 도구만 호출하고 끝나는 빈 응답을

--- a/apps/api/src/mcp/lifecycle-supervisor.ts
+++ b/apps/api/src/mcp/lifecycle-supervisor.ts
@@ -48,6 +48,7 @@ export interface LifecycleSupervisor {
     onUserLogin(userId: string): Promise<void>;
     onUserLogout(userId: string): Promise<void>;
     onChatStart(userId: string, chatId: string): Promise<void>;
+    ensureUserServers(userId: string, ctx?: string): Promise<void>;
     onChatEnd(userId: string, chatId: string): Promise<void>;
     spawnUserServer(userId: string, serverId: string): Promise<ExternalMCPClient>;
     killUserServer(userId: string, serverId: string): Promise<void>;
@@ -97,16 +98,29 @@ export class MCPLifecycleSupervisor implements LifecycleSupervisor {
 
     async onChatStart(userId: string, chatId: string): Promise<void> {
         this.chatOwners.set(chatId, userId);
+        await this.ensureUserServers(userId, `chat=${chatId}`);
+    }
+
+    /**
+     * 사용자의 auto_spawn(per_chat/per_session) MCP 서버를 풀에 ensure.
+     * per_chat 뿐 아니라 per_session(lifecycle 컬럼 부재 시 기본) 도 포함 — 세션 도중
+     * 카탈로그 설치/프로세스 재시작으로 풀이 비워졌을 때 재로그인 없이 도구를 복구한다.
+     * safeSpawn 멱등 가드로 이미 살아있는 클라이언트는 재spawn 하지 않는다. onChatEnd 는
+     * per_chat 만 kill 하므로 per_session 은 onUserLogout 까지 유지된다.
+     *
+     * onChatStart(채팅 시작) 외에 도구 picker 엔드포인트도 호출 — 목록 표시 전 풀 보장.
+     */
+    async ensureUserServers(userId: string, ctx = ''): Promise<void> {
         const servers = await this.repo.listUserServers(userId);
-        const targets = servers.filter(s =>
-            s.user_id === userId &&
-            (s as ServerWithLifecycle).lifecycle === 'per_chat' &&
-            s.auto_spawn === true &&
-            s.enabled === true,
-        );
-        logger.info(`onChatStart u=${userId} chat=${chatId}: per_chat 후보 ${targets.length}개`);
+        const targets = servers.filter(s => {
+            if (s.user_id !== userId || s.auto_spawn !== true || s.enabled !== true) return false;
+            const lc = (s as ServerWithLifecycle).lifecycle ?? 'per_session';
+            return lc === 'per_chat' || lc === 'per_session';
+        });
+        const perChat = targets.filter(s => ((s as ServerWithLifecycle).lifecycle ?? 'per_session') === 'per_chat').length;
+        logger.info(`ensureUserServers u=${userId} ${ctx}: spawn 후보 ${targets.length}개 (per_chat ${perChat})`);
         await Promise.all(targets.map(s => this.safeSpawn(userId, s.id).catch(e => {
-            logger.warn(`per_chat spawn 실패 s=${s.id}: ${e}`);
+            logger.warn(`ensureUserServers spawn 실패 s=${s.id}: ${e}`);
         })));
     }
 

--- a/apps/api/src/mcp/tool-router.ts
+++ b/apps/api/src/mcp/tool-router.ts
@@ -144,6 +144,15 @@ export class ToolRouter {
     }
 
     /**
+     * 사용자 풀(설치한 user MCP 서버) 도구의 네임스페이스 적용 이름 집합.
+     * 채팅에서 "설치=기본 ON" 자동 노출 판별에 사용 (global 외부 도구는 제외).
+     */
+    getUserPoolToolNames(userId: string): Set<string> {
+        if (!this.userPool) return new Set<string>();
+        return new Set(collectUserPoolTools(this.userPool, userId).map(e => e.tool.name));
+    }
+
+    /**
      * 도구 실행 — 내장이면 직접 handler, 외부면 ExternalMCPClient로 라우팅
      * 
      * ⚙️ Phase 3: UserContext 전달 추가 (2026-02-07)

--- a/apps/api/src/routes/mcp-catalog.routes.ts
+++ b/apps/api/src/routes/mcp-catalog.routes.ts
@@ -59,6 +59,21 @@ mcpCatalogRouter.post(
 
         const created = await repo.createFromCatalog(payload, template, actor.id);
         logger.info(`from-catalog 등록: ${created.id} (template=${template.id}, user=${actor.id})`);
+
+        // 설치 즉시 spawn — auto_spawn 서버를 바로 풀에 연결해 재로그인/다음 채팅을 기다리지 않고
+        // LLM 도구로 사용 가능하게 한다(완전 통합). best-effort: spawn 실패해도 등록은 유지되며
+        // 다음 onChatStart 가 멱등 재시도한다. createFromCatalog 는 enabled=TRUE 고정이라 auto_spawn 만 확인.
+        if (created.auto_spawn) {
+            const supervisor = getLifecycleSupervisor();
+            if (supervisor) {
+                try {
+                    await supervisor.spawnUserServer(actor.id, created.id);
+                    logger.info(`from-catalog 즉시 spawn 성공: ${created.id}`);
+                } catch (e) {
+                    logger.warn(`from-catalog 즉시 spawn 실패(등록 유지): ${created.id}: ${e instanceof Error ? e.message : String(e)}`);
+                }
+            }
+        }
         res.status(201).json(success({ server: created }));
     }),
 );

--- a/apps/api/src/services/ChatService.ts
+++ b/apps/api/src/services/ChatService.ts
@@ -26,6 +26,7 @@ import type { ExecutionPlan } from '../chat/profile-resolver';
 import type { UserContext } from '../mcp/user-sandbox';
 import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { CHAT_ALWAYS_ON_TOOL_NAMES } from '../mcp/agent-task-tools';
+import { CHAT_USER_MCP_TOOL_CAP } from '../config/runtime-limits';
 import { LOAD_SKILL_TOOL_NAME } from '../mcp/load-skill-tool';
 import { LLMClient } from '../llm';
 import { type ChatMessage, type ToolDefinition, type ModelOptions } from '../llm';
@@ -42,7 +43,7 @@ import { resolveAgent as resolveAgentFn } from './chat-service/agent-resolver';
 import { resolveLanguagePolicy as resolveLanguagePolicyFn } from './chat-service/language-resolver';
 import { recordMetricsAndVerify as recordMetricsAndVerifyFn } from './chat-service/metrics-recorder';
 import { ProviderRouter } from '../providers/provider-router';
-import { mergeToolsWithSkills } from './chat-service/tool-merger';
+import { mergeToolsWithSkills, selectUserMcpAutoOn } from './chat-service/tool-merger';
 import type { RequestContext } from './chat-service/request-context';
 import { runMessagePipeline } from './chat-service/message-pipeline';
 import { getSkillManager } from '../agents/skill-manager';
@@ -209,6 +210,11 @@ export class ChatService {
         // enabledTools가 없으면 레거시 호환: 전체 허용 (API 클라이언트 등). skill binding 적용도 skip.
         if (reqCtx.enabledTools === undefined) return this.applySkillCatalog(allTools, allTools, reqCtx);
 
+        // 설치한 user MCP 서버 도구는 "설치=기본 ON" — 채팅 토글 없이 자동 노출(cap 적용).
+        // global 외부 도구는 자동 노출 대상 아님(opt-in 유지). 끄려면 /mcp-servers 서버 disable.
+        const userPoolNames = userIdStr ? toolRouter.getUserPoolToolNames(userIdStr) : new Set<string>();
+        const userMcpAutoOn = selectUserMcpAutoOn(allTools, userPoolNames, reqCtx.enabledTools, CHAT_USER_MCP_TOOL_CAP);
+
         // 사용자가 명시적으로 활성화한 도구만 추출
         const userToggled = allTools.filter(t => reqCtx.enabledTools![t.function.name] === true);
 
@@ -234,12 +240,11 @@ export class ChatService {
             CHAT_ALWAYS_ON_TOOL_NAMES.includes(t.function.name) &&
             !merged.some(m => m.function.name === t.function.name));
 
-        logger.debug(
-            `MCP 도구 머지: all=${allTools.length}, userToggled=${userToggled.length}, ` +
-            `profileRequired=${profileRequiredNames.length}, skillBindings=${reqCtx.skillBindings.length}, ` +
-            `merged=${merged.length}, alwaysOn=${alwaysOn.length}`,
-        );
-        return this.applySkillCatalog([...merged, ...alwaysOn], allTools, reqCtx);
+        // merged ∪ alwaysOn ∪ userMcpAutoOn(자동 노출 user MCP) — 이름 기준 중복 제거.
+        const seen = new Set([...merged, ...alwaysOn].map(t => t.function.name));
+        const combined = [...merged, ...alwaysOn, ...userMcpAutoOn.filter(t => !seen.has(t.function.name))];
+        logger.debug(`MCP 도구 머지: all=${allTools.length} userToggled=${userToggled.length} merged=${merged.length} alwaysOn=${alwaysOn.length} userMcpAutoOn=${userMcpAutoOn.length}`);
+        return this.applySkillCatalog(combined, allTools, reqCtx);
     }
 
     /**

--- a/apps/api/src/services/chat-service/tool-merger.ts
+++ b/apps/api/src/services/chat-service/tool-merger.ts
@@ -7,6 +7,34 @@
  *
  */
 import type { ToolDefinition } from '../../llm/types';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('ToolMerger');
+
+/**
+ * 설치한 user MCP 서버 도구의 "설치=기본 ON" 자동 노출 목록 선정.
+ *
+ * - userPoolNames: 사용자 풀(설치 서버) 도구의 네임스페이스 이름 집합
+ * - enabledTools[name]===false 면 제외(명시 차단), 그 외 user 풀 도구는 기본 노출
+ * - tool-bloat(로컬 qwen 첫토큰 hang) 방지로 cap 개까지만 — 초과분 drop + 로그
+ */
+export function selectUserMcpAutoOn(
+    allTools: ToolDefinition[],
+    userPoolNames: Set<string>,
+    enabledTools: Record<string, boolean>,
+    cap: number,
+): ToolDefinition[] {
+    const eligible = allTools.filter(t =>
+        userPoolNames.has(t.function.name) && enabledTools[t.function.name] !== false);
+    const capped = eligible.slice(0, cap);
+    if (eligible.length > capped.length) {
+        logger.warn(
+            `user MCP 자동 노출 cap 적용: ${eligible.length}개 중 ${capped.length}개만 노출 ` +
+            `(cap=${cap}). 도구가 많으면 /mcp-servers 에서 일부 서버를 disable 하세요.`,
+        );
+    }
+    return capped;
+}
 
 export interface ActiveSkillBinding {
     skill_id: string;


### PR DESCRIPTION
## 문제

MCP 카탈로그로 설치한 user MCP 서버(streamable-http 등)의 도구가 채팅 LLM 에 전달되지 않아, LLM 이 "검색 도구가 연결되어 있지 않다"고 응답.

## 근본 원인 (2층 결함)

1. **spawn 누락** — `from-catalog` 설치가 spawn 을 트리거하지 않고, `onChatStart` 가 `lifecycle==='per_chat'` strict 매칭이라 lifecycle 컬럼 없는(=per_session 기본) 서버를 영원히 제외 → 풀에 연결 안 됨, 도구 discovery 안 됨(`per_chat 후보 0개`). `onUserLogin` 은 spawn 하나 실제 로그인 시에만 발동 → 세션 도중 설치엔 미발동.
2. **enabledTools 미배선** — `getAllowedTools` 는 명시 토글된 도구만 노출하는데 프론트는 항상 빈 객체 전송 → always-on 4개만 LLM 에 전달.

## 수정

- `onChatStart` → `ensureUserServers` 추출: per_chat + per_session(기본) 모두 채팅 시점에 ensure(`safeSpawn` 멱등). 설치 시 `auto_spawn` 이면 즉시 spawn(best-effort).
- `getAllowedTools`: 설치한 user MCP 도구를 **"설치=기본 ON"** 으로 자동 노출(`enabledTools[name]!==false`). global 외부 도구는 opt-in 유지.
- `CHAT_USER_MCP_TOOL_CAP`(기본 12): 로컬 qwen tool-bloat hang 방지 상한. 도구 과다 시 turn-2 첫토큰 컴파일이 지연/hang 되는 것을 차단(검증: cap 32→hang, cap 8→7초 완료).

설치 도구를 끄려면 `/mcp-servers` 에서 서버 disable(서버 단위). 채팅 토글 UI 는 두지 않음(상시 도구 로딩 오버헤드 회피).

## 검증

- 백엔드 `tsc` 0 · `eslint` clean · lifecycle-supervisor 테스트 6/6
- 프론트 `next build` 성공 (프론트 변경 없음 — 백엔드 전용)
- **라이브 E2E (Playwright, admin)**: 채팅 토글 없이 LLM 이 `searxng::searxng_web_search` 자동 호출 → 실제 결과 응답("OpenMake Software - Wikipedia" 등). `tools=12` hang 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)