### PR TITLE
fix(mcp): user MCP 도구 실행 라우팅 수정 + cap round-robin + postgres 템플릿

### DIFF
--- a/apps/api/src/mcp/lifecycle-supervisor.ts
+++ b/apps/api/src/mcp/lifecycle-supervisor.ts
@@ -58,6 +58,18 @@ export interface LifecycleSupervisor {
 
 type ServerWithLifecycle = UserMcpServerRow & { lifecycle?: McpLifecycle };
 
+/**
+ * command/args 의 `{{env.KEY}}` placeholder 를 복호화된 env 값으로 치환.
+ *
+ * secret(connection string·토큰 등)을 env_schema(암호화 저장)로 받되, 위치 인자로
+ * 전달해야 하는 MCP 서버(예: @modelcontextprotocol/server-postgres 는 URL 을 argv 로
+ * 받음)를 지원한다 — 평문을 args(미암호화) 에 저장하지 않고 spawn 시점에만 주입.
+ */
+const ENV_PLACEHOLDER_RE = /\{\{env\.(\w+)\}\}/g;
+function substituteEnvPlaceholders(value: string, env: Record<string, string>): string {
+    return value.replace(ENV_PLACEHOLDER_RE, (_m, key: string) => env[key] ?? '');
+}
+
 export class MCPLifecycleSupervisor implements LifecycleSupervisor {
     private readonly userPool: UserMCPPool;
     private readonly repo: SupervisorDeps['repo'];
@@ -181,8 +193,11 @@ export class MCPLifecycleSupervisor implements LifecycleSupervisor {
             user_id: userId,
             name: server.name,
             transport_type: server.transport_type,
-            command: server.command,
-            args: server.args,
+            // {{env.KEY}} placeholder 를 복호화 env 로 치환 (위치 인자 secret 주입 지원).
+            command: server.command ? substituteEnvPlaceholders(server.command, env) : server.command,
+            args: Array.isArray(server.args)
+                ? server.args.map(a => typeof a === 'string' ? substituteEnvPlaceholders(a, env) : a)
+                : server.args,
             env,
             url: server.url,
             lifecycle,

--- a/apps/api/src/mcp/tool-router.ts
+++ b/apps/api/src/mcp/tool-router.ts
@@ -147,9 +147,19 @@ export class ToolRouter {
      * 사용자 풀(설치한 user MCP 서버) 도구의 네임스페이스 적용 이름 집합.
      * 채팅에서 "설치=기본 ON" 자동 노출 판별에 사용 (global 외부 도구는 제외).
      */
-    getUserPoolToolNames(userId: string): Set<string> {
-        if (!this.userPool) return new Set<string>();
-        return new Set(collectUserPoolTools(this.userPool, userId).map(e => e.tool.name));
+    /**
+     * 사용자 풀 도구를 서버별로 그룹화한 이름 배열(네임스페이스 적용). 채팅 자동 노출
+     * round-robin(서버별 균등 선정)에 사용 — 무거운 서버가 cap 슬롯을 독점하지 않게 한다.
+     */
+    getUserPoolToolGroups(userId: string): string[][] {
+        if (!this.userPool) return [];
+        const groups = new Map<string, string[]>();
+        for (const e of collectUserPoolTools(this.userPool, userId)) {
+            const g = groups.get(e.serverId) ?? [];
+            g.push(e.tool.name);
+            groups.set(e.serverId, g);
+        }
+        return [...groups.values()];
     }
 
     /**
@@ -199,23 +209,27 @@ export class ToolRouter {
                 // 1a. 사용자별 풀 우선 검색 (Phase 7 LifecycleSupervisor 가 채운 인스턴스)
                 //     context.userId 가 있으면 user_private/user_shared 서버는 사용자 풀에서만 접근.
                 if (context?.userId) {
-                    const [serverId, toolName] = name.split(MCP_NAMESPACE_SEPARATOR, 2);
-                    if (serverId && toolName) {
-                        const { getUserMCPPool } = await import('./user-pool');
-                        const userClient = getUserMCPPool().get(String(context.userId), serverId);
-                        if (userClient) {
-                            try {
-                                const result = await Promise.race([
-                                    userClient.callTool(toolName, args),
-                                    new Promise<never>((_, reject) =>
-                                        setTimeout(() => reject(new Error(`외부 도구 타임아웃: ${name} (${MCP_EXTERNAL_TOOL_LIMITS.EXECUTION_TIMEOUT_MS}ms 초과)`)), MCP_EXTERNAL_TOOL_LIMITS.EXECUTION_TIMEOUT_MS)
-                                    ),
-                                ]);
-                                return finalize(result);
-                            } catch (e) {
-                                const msg = e instanceof Error ? e.message : String(e);
-                                return fail(`사용자 풀 도구 실행 실패 (${name}): ${msg}`);
-                            }
+                    // 네임스페이스 이름은 `displayName::tool` 인데 풀은 serverId(mcp_*) 로 키된다.
+                    // split[0](displayName) 직접 조회는 항상 실패하므로(서버명 충돌 시 suffix 도
+                    // 붙음), collectUserPoolTools 로 전체 네임스페이스 이름을 매칭해 entry 의
+                    // 실제 serverId + originalToolName 으로 호출한다.
+                    const { getUserMCPPool } = await import('./user-pool');
+                    const pool = getUserMCPPool();
+                    const entry = collectUserPoolTools(pool, String(context.userId))
+                        .find(e => e.tool.name === name);
+                    const userClient = entry ? pool.get(String(context.userId), entry.serverId) : undefined;
+                    if (entry && userClient) {
+                        try {
+                            const result = await Promise.race([
+                                userClient.callTool(entry.originalToolName, args),
+                                new Promise<never>((_, reject) =>
+                                    setTimeout(() => reject(new Error(`외부 도구 타임아웃: ${name} (${MCP_EXTERNAL_TOOL_LIMITS.EXECUTION_TIMEOUT_MS}ms 초과)`)), MCP_EXTERNAL_TOOL_LIMITS.EXECUTION_TIMEOUT_MS)
+                                ),
+                            ]);
+                            return finalize(result);
+                        } catch (e) {
+                            const msg = e instanceof Error ? e.message : String(e);
+                            return fail(`사용자 풀 도구 실행 실패 (${name}): ${msg}`);
                         }
                     }
                 }

--- a/apps/api/src/services/ChatService.ts
+++ b/apps/api/src/services/ChatService.ts
@@ -212,8 +212,8 @@ export class ChatService {
 
         // 설치한 user MCP 서버 도구는 "설치=기본 ON" — 채팅 토글 없이 자동 노출(cap 적용).
         // global 외부 도구는 자동 노출 대상 아님(opt-in 유지). 끄려면 /mcp-servers 서버 disable.
-        const userPoolNames = userIdStr ? toolRouter.getUserPoolToolNames(userIdStr) : new Set<string>();
-        const userMcpAutoOn = selectUserMcpAutoOn(allTools, userPoolNames, reqCtx.enabledTools, CHAT_USER_MCP_TOOL_CAP);
+        const toolGroups = userIdStr ? toolRouter.getUserPoolToolGroups(userIdStr) : [];
+        const userMcpAutoOn = selectUserMcpAutoOn(allTools, toolGroups, reqCtx.enabledTools, CHAT_USER_MCP_TOOL_CAP);
 
         // 사용자가 명시적으로 활성화한 도구만 추출
         const userToggled = allTools.filter(t => reqCtx.enabledTools![t.function.name] === true);

--- a/apps/api/src/services/chat-service/tool-merger.ts
+++ b/apps/api/src/services/chat-service/tool-merger.ts
@@ -12,28 +12,42 @@ import { createLogger } from '../../utils/logger';
 const logger = createLogger('ToolMerger');
 
 /**
- * 설치한 user MCP 서버 도구의 "설치=기본 ON" 자동 노출 목록 선정.
+ * 설치한 user MCP 서버 도구의 "설치=기본 ON" 자동 노출 목록 선정 (서버별 round-robin).
  *
- * - userPoolNames: 사용자 풀(설치 서버) 도구의 네임스페이스 이름 집합
+ * - toolGroups: 서버별 도구 이름 배열의 배열(네임스페이스 적용)
  * - enabledTools[name]===false 면 제외(명시 차단), 그 외 user 풀 도구는 기본 노출
- * - tool-bloat(로컬 qwen 첫토큰 hang) 방지로 cap 개까지만 — 초과분 drop + 로그
+ * - tool-bloat(로컬 qwen 첫토큰 hang) 방지로 cap 개까지만 노출
+ * - round-robin: 각 서버에서 1개씩 돌아가며 채워, 무거운 서버가 cap 슬롯을 독점해
+ *   가벼운 서버(예: duckduckgo 2개)가 통째로 잘리는 것을 막는다(각 서버 최소 1개 대표).
  */
 export function selectUserMcpAutoOn(
     allTools: ToolDefinition[],
-    userPoolNames: Set<string>,
+    toolGroups: string[][],
     enabledTools: Record<string, boolean>,
     cap: number,
 ): ToolDefinition[] {
-    const eligible = allTools.filter(t =>
-        userPoolNames.has(t.function.name) && enabledTools[t.function.name] !== false);
-    const capped = eligible.slice(0, cap);
-    if (eligible.length > capped.length) {
+    const lookup = new Map(allTools.map(t => [t.function.name, t]));
+    const groups = toolGroups
+        .map(names => names.filter(n => enabledTools[n] !== false))
+        .filter(g => g.length > 0);
+    const totalEligible = groups.reduce((n, g) => n + g.length, 0);
+    const maxLen = groups.reduce((m, g) => Math.max(m, g.length), 0);
+
+    const picked: ToolDefinition[] = [];
+    for (let round = 0; round < maxLen && picked.length < cap; round++) {
+        for (const g of groups) {
+            if (round >= g.length || picked.length >= cap) continue;
+            const t = lookup.get(g[round]);
+            if (t) picked.push(t);
+        }
+    }
+    if (totalEligible > picked.length) {
         logger.warn(
-            `user MCP 자동 노출 cap 적용: ${eligible.length}개 중 ${capped.length}개만 노출 ` +
-            `(cap=${cap}). 도구가 많으면 /mcp-servers 에서 일부 서버를 disable 하세요.`,
+            `user MCP 자동 노출 cap: ${totalEligible}개 중 ${picked.length}개 노출 ` +
+            `(cap=${cap}, 서버별 round-robin — 각 서버 우선 1개). 더 줄이려면 /mcp-servers 서버 disable.`,
         );
     }
-    return capped;
+    return picked;
 }
 
 export interface ActiveSkillBinding {

--- a/db/migrations/028_mcp_catalog_seed.sql
+++ b/db/migrations/028_mcp_catalog_seed.sql
@@ -57,7 +57,9 @@ INSERT INTO mcp_server_catalog (
     'PostgreSQL',
     'PostgreSQL DB 읽기 전용 쿼리. 스키마 조회 + SELECT 실행.',
     'stdio',
-    'npx -y @modelcontextprotocol/server-postgres',
+    -- server-postgres 는 DB URL 을 위치 인자로 받음 — {{env.DATABASE_URL}} placeholder 를
+    -- safeSpawn 이 복호화 env 로 치환(051 마이그레이션과 동일). env_schema 로 암호화 저장.
+    'npx -y @modelcontextprotocol/server-postgres {{env.DATABASE_URL}}',
     '{}'::jsonb,
     '{"type": "object", "required": ["DATABASE_URL"], "properties": {"DATABASE_URL": {"type": "string", "title": "PostgreSQL URL", "secret": true, "description": "postgresql://user:pass@host:port/db (read-only 권장)"}}}'::jsonb,
     'pro',

--- a/db/migrations/051_fix_mcp_postgres_catalog_arg.sql
+++ b/db/migrations/051_fix_mcp_postgres_catalog_arg.sql
@@ -1,0 +1,16 @@
+-- 051: mcp-postgres 카탈로그 템플릿 — connection string 을 위치 인자로 전달하도록 수정.
+--
+-- 문제: @modelcontextprotocol/server-postgres (deprecated v0.6.2) 는 DB URL 을
+--       위치 인자(argv[2]) 로 받는데, 028 seed 는 env(DATABASE_URL) 로 설정해
+--       "Please provide a database URL as a command-line argument" 로 spawn 실패했다.
+--
+-- 수정: command_template 에 {{env.DATABASE_URL}} placeholder 추가. lifecycle-supervisor
+--       safeSpawn 이 spawn 시점에 복호화된 env 값으로 치환한다(secret 은 여전히
+--       env_schema 로 암호화 저장 — args 평문 저장 없음). env_schema 는 그대로 유지.
+--
+-- 멱등: 동일 command_template 이면 no-op.
+
+UPDATE mcp_server_catalog
+   SET command_template = 'npx -y @modelcontextprotocol/server-postgres {{env.DATABASE_URL}}'
+ WHERE id = 'mcp-postgres'
+   AND command_template = 'npx -y @modelcontextprotocol/server-postgres';


### PR DESCRIPTION
설치한 user MCP 도구의 채팅 통합을 실제 동작까지 완성. 세 가지 수정 (모두 라이브 E2E 검증).

## 1) user pool 도구 실행 버그 (선재 결함, 치명적)
`executeTool` 가 네임스페이스 이름(`displayName::tool`)을 `split` 해 **displayName 을 serverId 로** 풀 조회했으나, 풀은 **실제 serverId(`mcp_*`)로 키**된다 → 모든 user MCP 도구 실행이 `tool not found` 로 실패.
- searxng 는 LLM 이 결과를 **환각**해 성공처럼 보였고(OpenMake=실존 엔티티), postgres 처럼 실데이터가 필요한 도구에서 드러남.
- → `collectUserPoolTools` 로 전체 네임스페이스 이름을 매칭해 entry 의 실제 `serverId` + `originalToolName` 으로 호출.

## 2) cap 선정 round-robin (가벼운 도구 truncation 방지)
기존 `slice(0,cap)` 은 spawn 완료 순서로 앞 N개만 노출 → 무거운 서버(firecrawl 26개 등)가 슬롯 독점, 가벼운 서버(duckduckgo 2개)가 통째로 잘림.
- → 서버별 round-robin(각 서버 우선 1개씩) → 모든 설치 서버 대표. `getUserPoolToolGroups` + `selectUserMcpAutoOn` 재작성.

## 3) mcp-postgres 카탈로그 템플릿 (env→위치 인자)
`@modelcontextprotocol/server-postgres` 는 DB URL 을 argv 로 받는데 seed 는 env 로 설정해 spawn 실패.
- → `command_template` 에 `{{env.DATABASE_URL}}` placeholder + `safeSpawn` 이 복호화 env 로 치환(secret 은 env_schema 암호화 저장 유지, args 평문 저장 없음). 028 seed 갱신 + 051 마이그레이션(기존 DB UPDATE).

## 검증
- postgres MCP 설치 → 채팅 "SELECT count(*) FROM mcp_servers" → **실제 DB 값 16 반환**(환각 아님)
- round-robin 으로 duckduckgo/postgres 등 가벼운 서버 도구 노출 확인
- tsc 0 · eslint clean · lifecycle-supervisor 테스트 6/6 · ChatService 600줄(Gate 3)

## 운영 주의
051 마이그레이션 적용 필요: `npx ts-node apps/api/src/data/migrations/cli.ts migrate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)