### PR TITLE
feat(mcp): 채팅 도구 노출 depth 개선 — 의도 인식 + 진행적 공개 하이브리드

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -847,3 +847,6 @@ IMAGE_GEN_TIMEOUT_MS=180000
 
 # 채팅 자동 노출 user MCP 도구 상한 (설치=기본 ON, 로컬 qwen tool-bloat 방지)
 CHAT_USER_MCP_TOOL_CAP=12
+
+# MCP 진행적 공개 메타 도구(mcp_list_tools/mcp_call) — cap 밖 서버 도구 on-demand 접근. 기본 off
+MCP_PROGRESSIVE_DISCLOSURE_ENABLED=false

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1099,6 +1099,15 @@ export const CHAT_USER_MCP_TOOL_CAP = parseInt(
 );
 
 /**
+ * MCP 진행적 공개(progressive disclosure) — mcp_list_tools / mcp_call 메타 도구를 채팅에
+ * always-on 노출할지. ON 이면 다(多)서버 사용자가 cap 밖으로 밀린 서버 도구도 on-demand 로
+ * 발견·호출 가능(함수 스키마 슬롯 1~2개만 사용). 추가 턴이 들어 로컬 qwen 은 약간 느려질 수
+ * 있어 기본 OFF — 운영 활성화는 .env 로 opt-in.
+ */
+export const MCP_PROGRESSIVE_DISCLOSURE_ENABLED =
+    process.env.MCP_PROGRESSIVE_DISCLOSURE_ENABLED === 'true';
+
+/**
  * 외부 provider 도구 루프 messages 토큰 예산 — external-provider 경로는 LLMClient.chat 의
  * model-pool context-fit 안전망을 우회(provider.streamChat 직접 호출)하므로, 큰 누적
  * 컨텍스트가 그대로 provider 로 전달돼 모델이 텍스트 없이 도구만 호출하고 끝나는 빈 응답을

--- a/apps/api/src/mcp/mcp-meta-tools.ts
+++ b/apps/api/src/mcp/mcp-meta-tools.ts
@@ -1,0 +1,97 @@
+/**
+ * MCP 진행적 공개(progressive disclosure) 메타 도구 — 하이브리드 정책 B.
+ *
+ * 자동 노출(getAllowedTools)은 cap 으로 도구 수를 제한하므로, 다(多)서버 사용자는 특정
+ * 서버의 도구가 cap 밖으로 밀릴 수 있다. 이 메타 도구 2개로 LLM 이 on-demand 로 임의
+ * 서버의 도구를 발견(mcp_list_tools)하고 호출(mcp_call)할 수 있게 한다 — 함수 스키마
+ * 슬롯 1~2개만 쓰면서 무제한 서버 도구에 접근. MCP_PROGRESSIVE_DISCLOSURE_ENABLED 게이트.
+ *
+ * 의존(unified-client/user-pool)은 순환 import 회피를 위해 핸들러 내부 dynamic import.
+ */
+import type { MCPToolDefinition, MCPToolResult } from './types';
+import { MCP_NAMESPACE_SEPARATOR } from './types';
+
+export const MCP_META_TOOL_NAMES = ['mcp_list_tools', 'mcp_call'] as const;
+
+function text(t: string): MCPToolResult {
+    return { content: [{ type: 'text', text: t }] };
+}
+
+/** mcp- / mcp_ prefix 무시 + 소문자 정규화 (displayName 매칭). */
+function norm(s: string): string {
+    return s.toLowerCase().replace(/^mcp[-_]/, '');
+}
+
+export const mcpListToolsTool: MCPToolDefinition = {
+    tool: {
+        name: 'mcp_list_tools',
+        description: '설치한 MCP 서버의 도구 목록을 조회합니다. 쓰고 싶은 서버 도구가 현재 노출 목록에 없을 때, server 이름으로 그 서버의 전체 도구(이름·설명·입력 스키마)를 받은 뒤 mcp_call 로 호출하세요. server 를 비우면 설치된 서버 이름 목록만 반환합니다.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                server: { type: 'string', description: '조회할 MCP 서버 이름(displayName). 비우면 서버 목록 반환.' },
+            },
+            required: [],
+        },
+    },
+    handler: async (args, context): Promise<MCPToolResult> => {
+        const userId = context?.userId != null ? String(context.userId) : undefined;
+        if (!userId || userId === 'guest') return text('로그인 사용자만 MCP 서버 도구를 조회할 수 있습니다.');
+        const { getUnifiedMCPClient } = await import('./unified-client');
+        const router = getUnifiedMCPClient().getToolRouter();
+        const groups = router.getUserPoolToolGroups(userId);
+        if (groups.length === 0) return text('설치된 MCP 서버가 없습니다. MCP 카탈로그에서 설치하세요.');
+
+        const server = typeof args.server === 'string' ? args.server.trim() : '';
+        if (!server) return text('설치된 MCP 서버: ' + groups.map(g => g.displayName).join(', '));
+
+        const g = groups.find(x => norm(x.displayName) === norm(server) || x.displayName.toLowerCase() === server.toLowerCase());
+        if (!g) return text(`서버 '${server}' 를 찾을 수 없습니다. 설치된 서버: ${groups.map(x => x.displayName).join(', ')}`);
+
+        const { collectUserPoolTools } = await import('./user-pool-tools');
+        const { getUserMCPPool } = await import('./user-pool');
+        const detail = collectUserPoolTools(getUserMCPPool(), userId)
+            .filter(e => e.displayName === g.displayName)
+            .map(e => ({ tool: e.originalToolName, description: e.tool.description, inputSchema: e.tool.inputSchema }));
+        return text(
+            `'${g.displayName}' 서버 도구 — mcp_call 로 호출 시 server="${g.displayName}", tool=아래 이름, args=그 도구 입력:\n` +
+            JSON.stringify(detail, null, 2),
+        );
+    },
+};
+
+export const mcpCallTool: MCPToolDefinition = {
+    tool: {
+        name: 'mcp_call',
+        description: '설치한 MCP 서버의 도구를 이름으로 호출합니다. 현재 노출 목록에 없는 서버 도구를 쓸 때 사용하세요(먼저 mcp_list_tools 로 server·tool·인자 스키마 확인). server=서버 displayName, tool=도구 원본 이름, args=그 도구의 입력 객체.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                server: { type: 'string', description: 'MCP 서버 이름(displayName)' },
+                tool: { type: 'string', description: '호출할 도구 이름(원본 이름)' },
+                args: { type: 'object', description: '도구 입력 인자 객체' },
+            },
+            required: ['server', 'tool'],
+        },
+    },
+    handler: async (args, context): Promise<MCPToolResult> => {
+        const userId = context?.userId != null ? String(context.userId) : undefined;
+        if (!userId || userId === 'guest') return text('로그인 사용자만 MCP 도구를 호출할 수 있습니다.');
+        const server = typeof args.server === 'string' ? args.server.trim() : '';
+        const tool = typeof args.tool === 'string' ? args.tool.trim() : '';
+        if (!server || !tool) return text('server 와 tool 이 필요합니다.');
+        const toolArgs = (args.args && typeof args.args === 'object') ? args.args as Record<string, unknown> : {};
+
+        const { getUnifiedMCPClient } = await import('./unified-client');
+        const router = getUnifiedMCPClient().getToolRouter();
+        const g = router.getUserPoolToolGroups(userId)
+            .find(x => norm(x.displayName) === norm(server) || x.displayName.toLowerCase() === server.toLowerCase());
+        if (!g) return text(`서버 '${server}' 를 찾을 수 없습니다.`);
+
+        // 네임스페이스 이름으로 재구성 → executeTool 의 user-pool 해석 경로 재사용.
+        const namespaced = `${g.displayName}${MCP_NAMESPACE_SEPARATOR}${tool}`;
+        return router.executeTool(namespaced, toolArgs, context);
+    },
+};
+
+export const mcpMetaTools: MCPToolDefinition[] = [mcpListToolsTool, mcpCallTool];

--- a/apps/api/src/mcp/tool-router.ts
+++ b/apps/api/src/mcp/tool-router.ts
@@ -148,15 +148,17 @@ export class ToolRouter {
      * 채팅에서 "설치=기본 ON" 자동 노출 판별에 사용 (global 외부 도구는 제외).
      */
     /**
-     * 사용자 풀 도구를 서버별로 그룹화한 이름 배열(네임스페이스 적용). 채팅 자동 노출
-     * round-robin(서버별 균등 선정)에 사용 — 무거운 서버가 cap 슬롯을 독점하지 않게 한다.
+     * 사용자 풀 도구를 서버별로 그룹화 — displayName + 네임스페이스 도구이름 배열 + 도구
+     * short name 배열. 채팅 자동 노출 선정(round-robin breadth + 의도 인식 depth)에 사용.
+     * displayName/shortNames 는 사용자 메시지가 특정 서버를 언급했는지 매칭하는 데 쓴다.
      */
-    getUserPoolToolGroups(userId: string): string[][] {
+    getUserPoolToolGroups(userId: string): Array<{ displayName: string; tools: string[]; shortNames: string[] }> {
         if (!this.userPool) return [];
-        const groups = new Map<string, string[]>();
+        const groups = new Map<string, { displayName: string; tools: string[]; shortNames: string[] }>();
         for (const e of collectUserPoolTools(this.userPool, userId)) {
-            const g = groups.get(e.serverId) ?? [];
-            g.push(e.tool.name);
+            const g = groups.get(e.serverId) ?? { displayName: e.displayName, tools: [], shortNames: [] };
+            g.tools.push(e.tool.name);
+            g.shortNames.push(e.originalToolName);
             groups.set(e.serverId, g);
         }
         return [...groups.values()];

--- a/apps/api/src/mcp/tools.ts
+++ b/apps/api/src/mcp/tools.ts
@@ -136,6 +136,8 @@ import { createPlanTool } from './plan-tool';
 import { codeReviewTool } from './code-review-tool';
 // 스킬 자동 호출 (LLM self-select) — 카탈로그는 getAllowedTools 가 description 에 주입
 import { loadSkillTool } from './load-skill-tool';
+// MCP 진행적 공개 메타 도구 (B) — 노출은 getAllowedTools 가 플래그로 게이트, 등록은 실행 라우팅용
+import { mcpMetaTools } from './mcp-meta-tools';
 
 /**
  * 전체 내장 도구 배열
@@ -165,4 +167,5 @@ export const builtInTools: MCPToolDefinition[] = [
     createPlanTool,
     codeReviewTool,
     loadSkillTool as MCPToolDefinition,
+    ...mcpMetaTools,
 ];

--- a/apps/api/src/services/ChatService.ts
+++ b/apps/api/src/services/ChatService.ts
@@ -26,7 +26,8 @@ import type { ExecutionPlan } from '../chat/profile-resolver';
 import type { UserContext } from '../mcp/user-sandbox';
 import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { CHAT_ALWAYS_ON_TOOL_NAMES } from '../mcp/agent-task-tools';
-import { CHAT_USER_MCP_TOOL_CAP } from '../config/runtime-limits';
+import { MCP_META_TOOL_NAMES } from '../mcp/mcp-meta-tools';
+import { CHAT_USER_MCP_TOOL_CAP, MCP_PROGRESSIVE_DISCLOSURE_ENABLED } from '../config/runtime-limits';
 import { LOAD_SKILL_TOOL_NAME } from '../mcp/load-skill-tool';
 import { LLMClient } from '../llm';
 import { type ChatMessage, type ToolDefinition, type ModelOptions } from '../llm';
@@ -213,7 +214,7 @@ export class ChatService {
         // 설치한 user MCP 서버 도구는 "설치=기본 ON" — 채팅 토글 없이 자동 노출(cap 적용).
         // global 외부 도구는 자동 노출 대상 아님(opt-in 유지). 끄려면 /mcp-servers 서버 disable.
         const toolGroups = userIdStr ? toolRouter.getUserPoolToolGroups(userIdStr) : [];
-        const userMcpAutoOn = selectUserMcpAutoOn(allTools, toolGroups, reqCtx.enabledTools, CHAT_USER_MCP_TOOL_CAP);
+        const userMcpAutoOn = selectUserMcpAutoOn(allTools, toolGroups, reqCtx.enabledTools, CHAT_USER_MCP_TOOL_CAP, reqCtx.message);
 
         // 사용자가 명시적으로 활성화한 도구만 추출
         const userToggled = allTools.filter(t => reqCtx.enabledTools![t.function.name] === true);
@@ -234,16 +235,15 @@ export class ChatService {
             skillBindings: reqCtx.skillBindings,
         });
 
-        // 본인 데이터 읽기 전용 도구(에이전트 작업 조회)는 토글 없이 항상 제공 —
-        // "에이전트 작업 결과 보여줘" 같은 요청이 설정과 무관하게 동작해야 한다.
+        // 토글 없이 항상 제공: 에이전트 작업 조회 + (플래그 ON 시) MCP 진행적 공개 메타 도구.
+        const alwaysOnNames: string[] = MCP_PROGRESSIVE_DISCLOSURE_ENABLED
+            ? [...CHAT_ALWAYS_ON_TOOL_NAMES, ...MCP_META_TOOL_NAMES] : CHAT_ALWAYS_ON_TOOL_NAMES;
         const alwaysOn = allTools.filter(t =>
-            CHAT_ALWAYS_ON_TOOL_NAMES.includes(t.function.name) &&
-            !merged.some(m => m.function.name === t.function.name));
-
-        // merged ∪ alwaysOn ∪ userMcpAutoOn(자동 노출 user MCP) — 이름 기준 중복 제거.
+            alwaysOnNames.includes(t.function.name) && !merged.some(m => m.function.name === t.function.name));
+        // merged ∪ alwaysOn ∪ userMcpAutoOn — 이름 기준 중복 제거.
         const seen = new Set([...merged, ...alwaysOn].map(t => t.function.name));
         const combined = [...merged, ...alwaysOn, ...userMcpAutoOn.filter(t => !seen.has(t.function.name))];
-        logger.debug(`MCP 도구 머지: all=${allTools.length} userToggled=${userToggled.length} merged=${merged.length} alwaysOn=${alwaysOn.length} userMcpAutoOn=${userMcpAutoOn.length}`);
+        logger.debug(`MCP 도구 머지: all=${allTools.length} merged=${merged.length} alwaysOn=${alwaysOn.length} userMcpAutoOn=${userMcpAutoOn.length}`);
         return this.applySkillCatalog(combined, allTools, reqCtx);
     }
 

--- a/apps/api/src/services/chat-service/message-pipeline.ts
+++ b/apps/api/src/services/chat-service/message-pipeline.ts
@@ -154,16 +154,12 @@ export async function runMessagePipeline(svc: ChatService,
     } = req;
 
     // SSE 연결 종료 시 처리를 조기 중단하기 위한 헬퍼
-    const checkAborted = () => {
-        if (abortSignal?.aborted) {
-            throw new Error('ABORTED');
-        }
-    };
+    const checkAborted = () => { if (abortSignal?.aborted) throw new Error('ABORTED'); };
 
     const reqCtx: RequestContext = {
         userContext: svc.buildUserContext(userId || 'guest', userRole),
-        // API Key 요청에서 enabledTools 미전달 시 내장 MCP 도구 비활성화
-        // 외부 서비스(openmake 등)는 자체 도구 체계를 사용하므로 내장 도구 간섭 방지
+        message: req.message,
+        // API Key 요청에서 enabledTools 미전달 시 내장 MCP 도구 비활성화(외부 서비스는 자체 도구 체계 사용)
         enabledTools: req.apiKeyId && !enabledTools ? {} : enabledTools,
         executionPlan,
         skillBindings: [],

--- a/apps/api/src/services/chat-service/request-context.ts
+++ b/apps/api/src/services/chat-service/request-context.ts
@@ -18,6 +18,8 @@ import type { ActiveSkillBinding } from './tool-merger';
 export interface RequestContext {
     /** 사용자 컨텍스트 (도구 접근 권한 결정) */
     userContext: UserContext;
+    /** 사용자 원문 메시지 — 의도 인식 도구 노출(특정 MCP 서버 언급 시 depth 우선)용. */
+    message?: string;
     /** 사용자가 활성화한 MCP 도구 (undefined면 레거시 모드: 전체 허용) */
     enabledTools?: Record<string, boolean>;
     /** 실행 계획 (requiredTools 강제 포함) */

--- a/apps/api/src/services/chat-service/tool-merger.ts
+++ b/apps/api/src/services/chat-service/tool-merger.ts
@@ -11,40 +11,72 @@ import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('ToolMerger');
 
+export interface UserPoolToolGroup {
+    displayName: string;
+    tools: string[];      // 네임스페이스 적용 이름 (displayName::tool)
+    shortNames: string[]; // 원본 도구 이름 (의도 매칭용)
+}
+
 /**
- * 설치한 user MCP 서버 도구의 "설치=기본 ON" 자동 노출 목록 선정 (서버별 round-robin).
+ * 메시지가 특정 서버를 언급했는지 판정 — displayName(mcp- prefix 무시) 또는 도구 short name
+ * 이 메시지에 포함되면 그 서버를 "참조됨"으로 본다. 경량 substring 매칭(regex 철학).
+ */
+function isServerReferenced(group: UserPoolToolGroup, msg: string): boolean {
+    if (!msg) return false;
+    const m = msg.toLowerCase();
+    const dn = group.displayName.toLowerCase();
+    const dnCore = dn.replace(/^mcp[-_]/, ''); // "mcp-memory" → "memory"
+    if (dnCore.length >= 3 && m.includes(dnCore)) return true;
+    return group.shortNames.some(n => n.length >= 4 && m.includes(n.toLowerCase()));
+}
+
+/**
+ * 설치한 user MCP 서버 도구의 "설치=기본 ON" 자동 노출 목록 선정.
  *
- * - toolGroups: 서버별 도구 이름 배열의 배열(네임스페이스 적용)
- * - enabledTools[name]===false 면 제외(명시 차단), 그 외 user 풀 도구는 기본 노출
- * - tool-bloat(로컬 qwen 첫토큰 hang) 방지로 cap 개까지만 노출
- * - round-robin: 각 서버에서 1개씩 돌아가며 채워, 무거운 서버가 cap 슬롯을 독점해
- *   가벼운 서버(예: duckduckgo 2개)가 통째로 잘리는 것을 막는다(각 서버 최소 1개 대표).
+ * 하이브리드 정책 (tool-bloat hang 방지로 cap 개까지):
+ *   1. 의도 인식 depth — 메시지가 언급한 서버는 도구를 전부(cap 한도) 우선 노출.
+ *      → "memory MCP 의 search_nodes 로 ..." 같은 다중 도구 워크플로를 살린다.
+ *   2. round-robin breadth — 남은 슬롯을 비참조 서버에 1개씩 돌아가며 채워, 무거운 서버가
+ *      독점하지 않고 모든 서버가 최소 1개 대표되게 한다.
+ * enabledTools[name]===false 는 제외(명시 차단).
  */
 export function selectUserMcpAutoOn(
     allTools: ToolDefinition[],
-    toolGroups: string[][],
+    toolGroups: UserPoolToolGroup[],
     enabledTools: Record<string, boolean>,
     cap: number,
+    message = '',
 ): ToolDefinition[] {
     const lookup = new Map(allTools.map(t => [t.function.name, t]));
     const groups = toolGroups
-        .map(names => names.filter(n => enabledTools[n] !== false))
-        .filter(g => g.length > 0);
-    const totalEligible = groups.reduce((n, g) => n + g.length, 0);
-    const maxLen = groups.reduce((m, g) => Math.max(m, g.length), 0);
+        .map(g => ({ ...g, tools: g.tools.filter(n => enabledTools[n] !== false) }))
+        .filter(g => g.tools.length > 0);
+    const totalEligible = groups.reduce((n, g) => n + g.tools.length, 0);
 
     const picked: ToolDefinition[] = [];
+    const seen = new Set<string>();
+    const add = (name: string): void => {
+        if (picked.length >= cap || seen.has(name)) return;
+        const t = lookup.get(name);
+        if (t) { picked.push(t); seen.add(name); }
+    };
+
+    // 1. depth: 참조된 서버의 도구 전부 우선
+    const referenced = groups.filter(g => isServerReferenced(g, message));
+    for (const g of referenced) for (const n of g.tools) add(n);
+
+    // 2. breadth: 남은 서버 round-robin (참조 서버는 이미 소진)
+    const rest = groups.filter(g => !referenced.includes(g));
+    const maxLen = rest.reduce((m, g) => Math.max(m, g.tools.length), 0);
     for (let round = 0; round < maxLen && picked.length < cap; round++) {
-        for (const g of groups) {
-            if (round >= g.length || picked.length >= cap) continue;
-            const t = lookup.get(g[round]);
-            if (t) picked.push(t);
-        }
+        for (const g of rest) if (round < g.tools.length) add(g.tools[round]);
     }
+
     if (totalEligible > picked.length) {
+        const mode = referenced.length ? `의도 depth(${referenced.map(g => g.displayName).join(',')}) + round-robin` : 'round-robin';
         logger.warn(
-            `user MCP 자동 노출 cap: ${totalEligible}개 중 ${picked.length}개 노출 ` +
-            `(cap=${cap}, 서버별 round-robin — 각 서버 우선 1개). 더 줄이려면 /mcp-servers 서버 disable.`,
+            `user MCP 자동 노출 cap: ${totalEligible}개 중 ${picked.length}개 노출 (cap=${cap}, ${mode}). ` +
+            `더 줄이려면 /mcp-servers 서버 disable.`,
         );
     }
     return picked;


### PR DESCRIPTION
round-robin cap(PR #242)은 모든 서버를 1개씩 대표(breadth)하지만, 다(多)서버 사용자가 특정 서버를 깊게 쓰는 워크플로(memory 생성→검색)를 못 살렸습니다. **A+B 하이브리드**로 depth 한계를 개선합니다.

## A. 의도 인식 depth (항상 적용, 후방호환)
사용자 메시지가 특정 서버를 언급(displayName / 도구 short name 경량 substring 매칭)하면 그 서버 도구를 **cap 한도 내 전부 우선 노출(depth)**, 나머지는 round-robin(breadth). 일반 메시지는 기존 round-robin 그대로(무변경).
- `request-context` 에 message 추가, `getUserPoolToolGroups` 가 displayName/shortNames 반환, `selectUserMcpAutoOn` 하이브리드 재작성.

## B. 진행적 공개 메타 도구 (`MCP_PROGRESSIVE_DISCLOSURE_ENABLED`, 기본 off)
`mcp_list_tools(server)` + `mcp_call(server,tool,args)` 2개만 always-on 노출 → LLM이 cap 밖 임의 서버 도구를 on-demand 발견·호출. 함수 스키마 슬롯 1~2개로 무제한 서버 도구 접근. `mcp_call` 은 `executeTool` 의 user-pool 해석 경로 재사용.

## 검증 (라이브 E2E, 환각 불가 실데이터)
- **A**: "memory MCP의 search_nodes로..." → 로그 `의도 depth(mcp-memory)` 로 memory 9개 도구 노출(round-robin 단독이면 잘렸을 search_nodes 포함). **새 대화(fresh context)**에서 검색 → 다른 대화에서 심은 observation **`val-DELTA-5573`** 반환 = memory 실제 저장·조회 입증.
- **B**: `🔧 mcp_call` 메타 도구 → fetch 라우팅 → 로컬 토큰서버 값 **`METATOOL-VERIFY-9X2B7Q-BRAVO`** 반환 입증.
- tsc 0 · `npm run lint` exit 0 · lifecycle 테스트 6/6 · ChatService 600줄(Gate 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)