### PR TITLE
chore(mcp): 진행적 공개 메타 도구 기본 ON (opt-out)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -848,5 +848,6 @@ IMAGE_GEN_TIMEOUT_MS=180000
 # 채팅 자동 노출 user MCP 도구 상한 (설치=기본 ON, 로컬 qwen tool-bloat 방지)
 CHAT_USER_MCP_TOOL_CAP=12
 
-# MCP 진행적 공개 메타 도구(mcp_list_tools/mcp_call) — cap 밖 서버 도구 on-demand 접근. 기본 off
-MCP_PROGRESSIVE_DISCLOSURE_ENABLED=false
+# MCP 진행적 공개 메타 도구(mcp_list_tools/mcp_call) — cap 밖 서버 도구 on-demand 접근. 기본 ON
+# 비활성화하려면 false 로 설정(opt-out)
+# MCP_PROGRESSIVE_DISCLOSURE_ENABLED=false

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1101,11 +1101,11 @@ export const CHAT_USER_MCP_TOOL_CAP = parseInt(
 /**
  * MCP 진행적 공개(progressive disclosure) — mcp_list_tools / mcp_call 메타 도구를 채팅에
  * always-on 노출할지. ON 이면 다(多)서버 사용자가 cap 밖으로 밀린 서버 도구도 on-demand 로
- * 발견·호출 가능(함수 스키마 슬롯 1~2개만 사용). 추가 턴이 들어 로컬 qwen 은 약간 느려질 수
- * 있어 기본 OFF — 운영 활성화는 .env 로 opt-in.
+ * 발견·호출 가능(함수 스키마 슬롯 1~2개만 사용). **기본 ON** — 라이브 E2E 검증 완료로 운영
+ * 기본값 채택. 비활성화하려면 .env 에 `MCP_PROGRESSIVE_DISCLOSURE_ENABLED=false` (opt-out).
  */
 export const MCP_PROGRESSIVE_DISCLOSURE_ENABLED =
-    process.env.MCP_PROGRESSIVE_DISCLOSURE_ENABLED === 'true';
+    process.env.MCP_PROGRESSIVE_DISCLOSURE_ENABLED !== 'false';
 
 /**
  * 외부 provider 도구 루프 messages 토큰 예산 — external-provider 경로는 LLMClient.chat 의


### PR DESCRIPTION
`MCP_PROGRESSIVE_DISCLOSURE_ENABLED` 기본값을 **ON** 으로 전환합니다. `mcp_list_tools`/`mcp_call` 메타 도구가 채팅에 기본 노출되어, 다(多)서버 사용자가 cap 밖으로 밀린 서버 도구도 on-demand 발견·호출할 수 있습니다.

- 근거: PR #243 라이브 E2E 검증 완료 (mcp_call → fetch → 실데이터 토큰 반환, 환각 불가).
- 코드: `process.env.X === 'true'` → `!== 'false'` (기본 ON, opt-out 시맨틱).
- `.env.example`: 기본 ON 문서화 + 비활성화(`=false`) 안내.

🤖 Generated with [Claude Code](https://claude.com/claude-code)