### PR TITLE
fix(mcp): sandbox_network 컬럼 미선택으로 host 바이패스 유실 수정

### DIFF
--- a/apps/api/src/data/repositories/mcp-catalog-repository.ts
+++ b/apps/api/src/data/repositories/mcp-catalog-repository.ts
@@ -75,7 +75,7 @@ export class McpCatalogRepository {
     async listUserServers(userId: string): Promise<UserMcpServerRow[]> {
         const result = await this.pool.query<UserMcpServerRow>(
             `SELECT id, user_id, name, transport_type, command, args, env, url,
-                    visibility, catalog_template_id, auto_spawn, enabled,
+                    visibility, catalog_template_id, auto_spawn, enabled, sandbox_network,
                     created_at::text, updated_at::text
              FROM mcp_servers
              WHERE user_id = $1 OR visibility = 'global'
@@ -136,7 +136,7 @@ export class McpCatalogRepository {
     async getServerById(serverId: string): Promise<UserMcpServerRow | null> {
         const result = await this.pool.query<UserMcpServerRow>(
             `SELECT id, user_id, name, transport_type, command, args, env, url,
-                    visibility, catalog_template_id, auto_spawn, enabled,
+                    visibility, catalog_template_id, auto_spawn, enabled, sandbox_network,
                     created_at::text, updated_at::text
              FROM mcp_servers WHERE id = $1`,
             [serverId],


### PR DESCRIPTION
## 증상
open-design MCP 가 `Connection closed` 로 연결 실패. `mcp_servers` 행은 `sandbox_network='host'` 인데도 docker 샌드박스로 spawn 돼, 컨테이너에 없는 호스트 절대 경로(darwin node 바이너리·cli.js·`.od`)를 exec 하다 즉시 종료.

## 근본 원인
`getServerById` / `listUserServers` 의 SELECT 가 `sandbox_network` 컬럼을 **조회하지 않아** (`UserMcpServerRow` 에 필드는 있으나 미선택) `safeSpawn` 에서 값이 `undefined` → 기본 `'full'`(docker) 로 처리. 즉 `'host'`(비격리 호스트 실행)·`'none'`(네트워크 격리) 설정이 **전부 무시**되던 결함.

## 수정
두 SELECT 에 `sandbox_network` 추가 → 값이 safeSpawn 까지 전달.

## 검증
- open-design 연결 성공(`18 tools discovered`)
- 채팅에서 `list_projects` 호출 → 실제 데몬 프로젝트 **10개 반환**("OpenMake LLM — New Design 2026" 등, 환각 불가)
- darwin node 바이너리는 linux 컨테이너에서 실행 불가 → host 바이패스가 유일한 해법, 정상 복구
- tsc 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)