### PR TITLE
feat(mcp): 자동 노출 도구 스키마 바이트 예산 (firecrawl 거대 스키마 대응)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -851,3 +851,6 @@ CHAT_USER_MCP_TOOL_CAP=12
 # MCP 진행적 공개 메타 도구(mcp_list_tools/mcp_call) — cap 밖 서버 도구 on-demand 접근. 기본 ON
 # 비활성화하려면 false 로 설정(opt-out)
 # MCP_PROGRESSIVE_DISCLOSURE_ENABLED=false
+
+# user MCP 자동 노출 도구의 누적 스키마 바이트 상한 (firecrawl 등 거대 스키마 서버가 로컬 모델 압도 방지). 기본 16000
+CHAT_USER_MCP_SCHEMA_BUDGET_BYTES=16000

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1099,6 +1099,19 @@ export const CHAT_USER_MCP_TOOL_CAP = parseInt(
 );
 
 /**
+ * 채팅 자동 노출 user MCP 도구의 누적 **스키마 바이트** 상한 (개수 cap 과 별개의 이중 상한).
+ *
+ * cap 은 도구 "개수"만 제한하므로, firecrawl 처럼 도구 1개의 파라미터 스키마가 거대한(수 KB)
+ * 서버는 개수가 적어도 총 바이트로 로컬 qwen 의 vLLM 도구-grammar 컴파일 예산을 초과해
+ * UPSTREAM_ERROR(첫 토큰 타임아웃)를 유발한다. 누적 스키마 바이트가 이 값을 넘으면 추가
+ * 노출을 중단한다(단 최소 1개는 노출). 외부 provider 는 영향 적으므로 로컬 보호용 기본값.
+ */
+export const CHAT_USER_MCP_SCHEMA_BUDGET_BYTES = parseInt(
+    process.env.CHAT_USER_MCP_SCHEMA_BUDGET_BYTES || '16000',
+    10,
+);
+
+/**
  * MCP 진행적 공개(progressive disclosure) — mcp_list_tools / mcp_call 메타 도구를 채팅에
  * always-on 노출할지. ON 이면 다(多)서버 사용자가 cap 밖으로 밀린 서버 도구도 on-demand 로
  * 발견·호출 가능(함수 스키마 슬롯 1~2개만 사용). **기본 ON** — 라이브 E2E 검증 완료로 운영

--- a/apps/api/src/services/ChatService.ts
+++ b/apps/api/src/services/ChatService.ts
@@ -27,7 +27,7 @@ import type { UserContext } from '../mcp/user-sandbox';
 import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { CHAT_ALWAYS_ON_TOOL_NAMES } from '../mcp/agent-task-tools';
 import { MCP_META_TOOL_NAMES } from '../mcp/mcp-meta-tools';
-import { CHAT_USER_MCP_TOOL_CAP, MCP_PROGRESSIVE_DISCLOSURE_ENABLED } from '../config/runtime-limits';
+import { CHAT_USER_MCP_TOOL_CAP, CHAT_USER_MCP_SCHEMA_BUDGET_BYTES, MCP_PROGRESSIVE_DISCLOSURE_ENABLED } from '../config/runtime-limits';
 import { LOAD_SKILL_TOOL_NAME } from '../mcp/load-skill-tool';
 import { LLMClient } from '../llm';
 import { type ChatMessage, type ToolDefinition, type ModelOptions } from '../llm';
@@ -214,7 +214,7 @@ export class ChatService {
         // 설치한 user MCP 서버 도구는 "설치=기본 ON" — 채팅 토글 없이 자동 노출(cap 적용).
         // global 외부 도구는 자동 노출 대상 아님(opt-in 유지). 끄려면 /mcp-servers 서버 disable.
         const toolGroups = userIdStr ? toolRouter.getUserPoolToolGroups(userIdStr) : [];
-        const userMcpAutoOn = selectUserMcpAutoOn(allTools, toolGroups, reqCtx.enabledTools, CHAT_USER_MCP_TOOL_CAP, reqCtx.message);
+        const userMcpAutoOn = selectUserMcpAutoOn(allTools, toolGroups, reqCtx.enabledTools, CHAT_USER_MCP_TOOL_CAP, CHAT_USER_MCP_SCHEMA_BUDGET_BYTES, reqCtx.message);
 
         // 사용자가 명시적으로 활성화한 도구만 추출
         const userToggled = allTools.filter(t => reqCtx.enabledTools![t.function.name] === true);

--- a/apps/api/src/services/chat-service/tool-merger.ts
+++ b/apps/api/src/services/chat-service/tool-merger.ts
@@ -33,18 +33,22 @@ function isServerReferenced(group: UserPoolToolGroup, msg: string): boolean {
 /**
  * 설치한 user MCP 서버 도구의 "설치=기본 ON" 자동 노출 목록 선정.
  *
- * 하이브리드 정책 (tool-bloat hang 방지로 cap 개까지):
+ * 하이브리드 정책 (tool-bloat hang 방지):
  *   1. 의도 인식 depth — 메시지가 언급한 서버는 도구를 전부(cap 한도) 우선 노출.
  *      → "memory MCP 의 search_nodes 로 ..." 같은 다중 도구 워크플로를 살린다.
  *   2. round-robin breadth — 남은 슬롯을 비참조 서버에 1개씩 돌아가며 채워, 무거운 서버가
  *      독점하지 않고 모든 서버가 최소 1개 대표되게 한다.
- * enabledTools[name]===false 는 제외(명시 차단).
+ * 이중 상한: ① 도구 **개수** cap ② 도구 스키마 **바이트** schemaBudget. firecrawl 처럼
+ * 도구 스키마가 거대한 서버는 개수는 적어도 바이트로 로컬 모델 vLLM 도구 컴파일을 압도해
+ * UPSTREAM_ERROR 를 유발하므로, 누적 스키마 바이트가 budget 을 넘으면 추가를 중단한다
+ * (단 최소 1개는 항상 노출). enabledTools[name]===false 는 제외(명시 차단).
  */
 export function selectUserMcpAutoOn(
     allTools: ToolDefinition[],
     toolGroups: UserPoolToolGroup[],
     enabledTools: Record<string, boolean>,
     cap: number,
+    schemaBudget: number,
     message = '',
 ): ToolDefinition[] {
     const lookup = new Map(allTools.map(t => [t.function.name, t]));
@@ -55,10 +59,16 @@ export function selectUserMcpAutoOn(
 
     const picked: ToolDefinition[] = [];
     const seen = new Set<string>();
+    let bytes = 0;
+    let budgetHit = false;
     const add = (name: string): void => {
         if (picked.length >= cap || seen.has(name)) return;
         const t = lookup.get(name);
-        if (t) { picked.push(t); seen.add(name); }
+        if (!t) return;
+        const sz = JSON.stringify(t).length;
+        // 최소 1개는 항상 허용, 그 외엔 누적 스키마 바이트가 budget 초과면 제외.
+        if (picked.length > 0 && bytes + sz > schemaBudget) { budgetHit = true; return; }
+        picked.push(t); seen.add(name); bytes += sz;
     };
 
     // 1. depth: 참조된 서버의 도구 전부 우선
@@ -74,9 +84,10 @@ export function selectUserMcpAutoOn(
 
     if (totalEligible > picked.length) {
         const mode = referenced.length ? `의도 depth(${referenced.map(g => g.displayName).join(',')}) + round-robin` : 'round-robin';
+        const limit = budgetHit ? `스키마 budget(${Math.round(schemaBudget / 1000)}KB)` : `cap=${cap}`;
         logger.warn(
-            `user MCP 자동 노출 cap: ${totalEligible}개 중 ${picked.length}개 노출 (cap=${cap}, ${mode}). ` +
-            `더 줄이려면 /mcp-servers 서버 disable.`,
+            `user MCP 자동 노출: ${totalEligible}개 중 ${picked.length}개(${Math.round(bytes / 1000)}KB) 노출 ` +
+            `(${limit}, ${mode}). 더 줄이려면 /mcp-servers 서버 disable.`,
         );
     }
     return picked;


### PR DESCRIPTION
## 문제
cap(`CHAT_USER_MCP_TOOL_CAP=12`)은 도구 **개수**만 제한합니다. firecrawl 처럼 도구 1개의 파라미터 스키마가 ~3KB 인 서버는 12개 노출 시 ~38KB 가 되어 **로컬 qwen 의 vLLM 도구-grammar 컴파일을 압도** → `UPSTREAM_ERROR`(첫 토큰 타임아웃). 도구가 호출조차 안 됐습니다(전수 검증에서 firecrawl만 실행 불가였던 원인).

## 수정
`selectUserMcpAutoOn` 에 누적 스키마 **바이트** 상한(개수 cap 과 독립한 이중 상한) 추가:
- `CHAT_USER_MCP_SCHEMA_BUDGET_BYTES`(기본 16000)
- 누적 schema bytes 가 budget 을 넘으면 추가 노출 중단(단 최소 1개는 항상 노출)
- 로그에 노출 도구 수 + KB + 어떤 상한이 걸렸는지(cap vs budget) 표기

## 검증 (라이브 E2E)
- **이전**: firecrawl 언급 → 12개 노출 → `UPSTREAM_ERROR`(호출 불가)
- **이후**: firecrawl 언급 → `127개 중 5개(16KB) 노출 (스키마 budget 16KB)` → UPSTREAM_ERROR 사라짐 → `mcp_call→firecrawl_scrape` 정상 실행 → example.com 스크랩 **"Example Domain"** 반환 ✅
- 소형 스키마 서버(memory/searxng/fetch 등)는 16KB 안에 모두 들어가 **영향 없음**
- tsc 0 · lint clean · ChatService 600줄(Gate 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)