### PR TITLE
docs(readme): CI 러너 표기(Jest→Bun) 및 docker compose 경로 정정

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Every request flows through a lightweight, deterministic policy layer — **`Exe
 | **Agents / Tools** | Model Context Protocol (`@modelcontextprotocol/sdk`), Docker-isolated sandboxes |
 | **Auth / Security** | `jsonwebtoken`, Google OAuth 2.0, Helmet, AES-256-GCM |
 | **Infra** | PM2 (app) + Docker (PostgreSQL/Redis, MCP & agent sandboxes) |
-| **Testing / CI** | Jest (ts-jest), Playwright, ESLint, GitHub Actions |
+| **Testing / CI** | Jest/ts-jest (local), Bun test (CI gate), Playwright, ESLint, GitHub Actions |
 
 > **Pipeline shape:** `ExecutionPlanBuilder.build` (policy, once per request) → strategy dispatch → `LLMClient.chat` (execution, per call) — a SQL planner/executor split; keep the two layers separate.
 
@@ -86,7 +86,7 @@ npm install
 cp .env.example .env      # then fill in the values below
 
 # 3. Start PostgreSQL (schema auto-generates on first launch)
-docker compose up -d postgres
+docker compose -f infra/docker-compose.yml up -d postgres
 ```
 
 Minimum `.env` values (see `.env.example` for the full list):


### PR DESCRIPTION
## 개요
README.md 와 실제 소스 간 불일치 2건 정정.

## 변경
1. **Tech Stack — CI 러너 표기**: `ci.yml` 의 Gate 1 은 실제로 `bun test` (per-file isolation) 를 사용하는데 README 는 `Jest (ts-jest)` 로만 표기되어 있었음. 로컬 `npm test`(Jest)는 그대로 유지하고 `Bun test (CI gate)` 를 명시.
2. **docker compose 경로**: compose 파일이 `infra/docker-compose.yml` 에만 존재하여, README 안내대로 루트에서 `docker compose up -d postgres` 실행 시 실패. `-f infra/docker-compose.yml` 로 경로 명시.

## 검증
- 버전(1.5.6)·Node(>=24<25)·Next16/React19/Zustand5/Tailwind4·Express5·MIT·마이그레이션 CLI 경로 등 나머지 항목은 소스와 일치 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)