### PR TITLE
fix(chat): external-provider history의 system 메시지 제외 (400 위치 위반 수정)

### DIFF
--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -152,7 +152,12 @@ export async function streamFromExternalProvider(
     }
 
     for (const h of req.history ?? []) {
-        const role = h.role === 'user' || h.role === 'assistant' || h.role === 'system'
+        // history 에 섞인 system 메시지는 제외한다. external-provider 는 위(151)에서 자체
+        // system 을 맨 앞에 조립하므로, history 의 system 을 그대로 두면 두 번째 system 이
+        // 중간 위치에 들어가 vLLM/qwen 템플릿이 "System message must be at the beginning"
+        // (400 BadRequest) 으로 거부한다.
+        if (h.role === 'system') continue;
+        const role = h.role === 'user' || h.role === 'assistant'
             ? h.role
             : 'user';
         messages.push({


### PR DESCRIPTION
## 문제
웹 채팅에서 질문 시 `UPSTREAM_ERROR`("A temporary error occurred at the external LLM provider")가 발생.

라이브 진단(서버 로그 raw 캡처)으로 확인한 실제 upstream 에러:
```
400 litellm.BadRequestError: OpenAIException - System message must be at the beginning.
```

## 원인
`streamFromExternalProvider`는 자체 system 프롬프트(guards·agent·memory·custom instructions 등)를 `messages` **맨 앞**에 조립한다. 그런데 history 루프가 `req.history`의 `role: 'system'` 항목을 **그대로 push**하여, 두 번째 system 이 **중간 위치**에 들어갔다. vLLM/qwen 챗 템플릿은 system 이 맨 앞에만 오도록 강제하므로 400 으로 거부 → 외부 dispatch 경로(기본 OFF 의 로컬 `local-llm` 포함) 채팅이 전부 실패.

## 수정
history 루프에서 `h.role === 'system'` 항목을 `continue` 로 건너뜀. external-provider 는 system 을 자체 조립하므로 history 의 system 은 중복이라 제외해도 정보 손실 없음.

```diff
  for (const h of req.history ?? []) {
+     if (h.role === 'system') continue;
-     const role = h.role === 'user' || h.role === 'assistant' || h.role === 'system'
+     const role = h.role === 'user' || h.role === 'assistant'
          ? h.role : 'user';
      messages.push({ role, content: h.content, ... });
  }
```

## 검증
- 라이브 진단(임시 dist 패치)으로 messages role 시퀀스 캡처 → 수정 후 `roles=["system","user","assistant"]` 로 system 1개 맨 앞 유지 확인
- 빌드 후 실제 웹 채팅 정상 응답 확인: `content.len=900 finishReason=stop`, `out=443 tokens`
- 프론트(`apps/web`) 영향 없음 — 백엔드 내부 messages 조립 로직

> 참고: 동시에 발생했던 vLLM 엔진 다운(별도 GPU 서버 재기동으로 해결)은 본 PR 범위 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)