### PR TITLE
refactor(routes): artifacts 세션 접근 헬퍼 추출 — CI Gate 3(600줄) 수정

### DIFF
--- a/apps/api/src/routes/artifact-session-access.ts
+++ b/apps/api/src/routes/artifact-session-access.ts
@@ -1,0 +1,68 @@
+/**
+ * ============================================================
+ * Artifact Session Access — 세션 접근 검증 헬퍼
+ * ============================================================
+ *
+ * artifacts.routes 에서 추출 (파일 크기 가드). 인증 사용자(user_id) 또는
+ * 게스트(anon_session_id) 의 conversation_sessions 접근 권한을 검증한다.
+ *
+ * @module routes/artifact-session-access
+ */
+
+import { Request, Response } from 'express';
+import { getPool } from '../data/models/unified-database';
+import { notFound, unauthorized, forbidden } from '../utils/api-response';
+
+/** 요청에서 userId 추출 (JWT userId 또는 id). 미인증이면 undefined. */
+export function resolveUserId(req: Request): string | undefined {
+    if (!req.user) return undefined;
+    return 'userId' in req.user ? (req.user as { userId: string }).userId : req.user.id?.toString();
+}
+
+export function resolveAnonSessionId(req: Request): string | undefined {
+    const raw = req.query.anonSessionId ?? req.body?.anonSessionId ?? req.get('x-anon-session-id');
+    return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+}
+
+export async function assertSessionAccess(req: Request, sessionId: string): Promise<void> {
+    if (req.user?.role === 'admin') return;
+
+    const pool = getPool();
+    const result = await pool.query<{ user_id: string | null; anon_session_id: string | null }>(
+        'SELECT user_id, anon_session_id FROM conversation_sessions WHERE id = $1',
+        [sessionId]
+    );
+    const session = result.rows[0];
+    if (!session) {
+        throw Object.assign(new Error('SESSION_NOT_FOUND'), { statusCode: 404 });
+    }
+
+    const userId = resolveUserId(req);
+    if (userId && session.user_id === userId) return;
+
+    const anonSessionId = resolveAnonSessionId(req);
+    if (anonSessionId && session.anon_session_id === anonSessionId) return;
+
+    throw Object.assign(new Error(userId || anonSessionId ? 'SESSION_FORBIDDEN' : 'SESSION_UNAUTHORIZED'), {
+        statusCode: userId || anonSessionId ? 403 : 401,
+    });
+}
+
+export function sendSessionAccessError(res: Response, error: unknown): boolean {
+    const statusCode = typeof error === 'object' && error !== null && 'statusCode' in error
+        ? Number((error as { statusCode?: unknown }).statusCode)
+        : 0;
+    if (statusCode === 404) {
+        res.status(404).json(notFound('session'));
+        return true;
+    }
+    if (statusCode === 401) {
+        res.status(401).json(unauthorized('인증이 필요합니다'));
+        return true;
+    }
+    if (statusCode === 403) {
+        res.status(403).json(forbidden('권한이 없습니다'));
+        return true;
+    }
+    return false;
+}

--- a/apps/api/src/routes/artifacts.routes.ts
+++ b/apps/api/src/routes/artifacts.routes.ts
@@ -17,8 +17,13 @@ import {
     type ArtifactPublicationRow,
 } from '../data/repositories/artifact-publication-repository';
 import { getPool } from '../data/models/unified-database';
-import { success, notFound, unauthorized, forbidden } from '../utils/api-response';
+import { success, notFound } from '../utils/api-response';
 import { asyncHandler } from '../utils/error-handler';
+import {
+    resolveUserId,
+    assertSessionAccess,
+    sendSessionAccessError,
+} from './artifact-session-access';
 import { requireAuth, optionalAuth } from '../auth';
 import { artifactExecLimiter } from '../middlewares/rate-limiters';
 import { executeArtifactCode, ArtifactExecError } from '../services/artifact-exec-service';
@@ -36,59 +41,8 @@ import { getAuditService } from '../services/AuditService';
 
 const router = Router();
 
-/** 요청에서 userId 추출 (JWT userId 또는 id). 미인증이면 undefined. */
-function resolveUserId(req: Request): string | undefined {
-    if (!req.user) return undefined;
-    return 'userId' in req.user ? (req.user as { userId: string }).userId : req.user.id?.toString();
-}
-
-function resolveAnonSessionId(req: Request): string | undefined {
-    const raw = req.query.anonSessionId ?? req.body?.anonSessionId ?? req.get('x-anon-session-id');
-    return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
-}
-
-async function assertSessionAccess(req: Request, sessionId: string): Promise<void> {
-    if (req.user?.role === 'admin') return;
-
-    const pool = getPool();
-    const result = await pool.query<{ user_id: string | null; anon_session_id: string | null }>(
-        'SELECT user_id, anon_session_id FROM conversation_sessions WHERE id = $1',
-        [sessionId]
-    );
-    const session = result.rows[0];
-    if (!session) {
-        throw Object.assign(new Error('SESSION_NOT_FOUND'), { statusCode: 404 });
-    }
-
-    const userId = resolveUserId(req);
-    if (userId && session.user_id === userId) return;
-
-    const anonSessionId = resolveAnonSessionId(req);
-    if (anonSessionId && session.anon_session_id === anonSessionId) return;
-
-    throw Object.assign(new Error(userId || anonSessionId ? 'SESSION_FORBIDDEN' : 'SESSION_UNAUTHORIZED'), {
-        statusCode: userId || anonSessionId ? 403 : 401,
-    });
-}
-
-function sendSessionAccessError(res: Response, error: unknown): boolean {
-    const statusCode = typeof error === 'object' && error !== null && 'statusCode' in error
-        ? Number((error as { statusCode?: unknown }).statusCode)
-        : 0;
-    if (statusCode === 404) {
-        res.status(404).json(notFound('session'));
-        return true;
-    }
-    if (statusCode === 401) {
-        res.status(401).json(unauthorized('인증이 필요합니다'));
-        return true;
-    }
-    if (statusCode === 403) {
-        res.status(403).json(forbidden('권한이 없습니다'));
-        return true;
-    }
-    return false;
-}
+// 세션 접근 검증 헬퍼(resolveUserId / assertSessionAccess / sendSessionAccessError)는
+// routes/artifact-session-access 로 추출 (파일 크기 가드).
 
 const VALID_VISIBILITY: ArtifactVisibility[] = ['private', 'authenticated', 'link'];
 


### PR DESCRIPTION
## Summary
- PR #252 머지 후 main CI 가 Gate 3 (File Size Guard) 에서 실패: `artifacts.routes.ts` 613줄 > 600줄 상한
- 기존 artifact-viewer-service 추출 전례와 동일 패턴으로 세션 접근 검증 헬퍼 4개를 `routes/artifact-session-access.ts` 로 이동 (동작 변경 없음, 613→567줄)

## 체크
- [x] `npm run build:backend` (tsc) 통과
- [x] `npm run lint` 통과 (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)