### PR TITLE
feat(web): 대화 히스토리·사이드바 세션 삭제 UI 추가

### DIFF
--- a/apps/web/app/(workspace)/history/page.tsx
+++ b/apps/web/app/(workspace)/history/page.tsx
@@ -2,10 +2,12 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Clock, Search, MessageSquare } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Clock, Search, MessageSquare, Trash2 } from "lucide-react";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { Badge, PageHeader, Card } from "@/components/ui/primitives";
 import { ApiClient } from "@/lib/api-client";
+import { appendAnonSessionId } from "@/lib/anon-session";
 import { useAppStore } from "@/lib/store";
 import type { ChatRole } from "@/lib/store";
 
@@ -133,10 +135,38 @@ const GROUP_ORDER: DateGroup[] = ["today", "yesterday", "week", "older"];
 
 export default function HistoryPage() {
   const router = useRouter();
-  const { setChatHistory, setCurrentSessionId, setArtifacts } = useAppStore();
+  const queryClient = useQueryClient();
+  const { setChatHistory, setCurrentSessionId, setArtifacts, clearChat, auth } = useAppStore();
+  const currentSessionId = useAppStore((s) => s.currentSessionId);
   const [sessions, setSessions] = useState<Session[]>(SESSIONS);
   const [loading, setLoading] = useState(true);
   const [query, setQuery] = useState("");
+
+  // 세션 단건 삭제 — 백엔드 DELETE /api/chat/sessions/:sid (소유자/익명 소유 검증).
+  const deleteSession = async (s: Session) => {
+    if (!window.confirm(`"${s.title}" 대화를 삭제하시겠습니까?\n삭제된 대화는 복구할 수 없습니다.`)) return;
+    try {
+      await ApiClient.del(appendAnonSessionId(`/api/chat/sessions/${s.id}`));
+      setSessions((prev) => prev.filter((x) => x.id !== s.id));
+      if (s.id === currentSessionId) clearChat();
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+    } catch {
+      window.alert("대화 삭제에 실패했습니다.");
+    }
+  };
+
+  // 전체 삭제 — 백엔드 DELETE /api/chat/sessions (requireAuth, 로그인 사용자 전용).
+  const deleteAll = async () => {
+    if (!window.confirm(`대화 기록 ${sessions.length}개를 모두 삭제하시겠습니까?\n삭제된 대화는 복구할 수 없습니다.`)) return;
+    try {
+      await ApiClient.del("/api/chat/sessions");
+      setSessions([]);
+      clearChat();
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+    } catch {
+      window.alert("전체 삭제에 실패했습니다.");
+    }
+  };
 
   // 대화 클릭 → 해당 세션 메시지 로드 + 채팅 화면으로 전환 (sidebar openSession 과 동일 패턴).
   const openSession = async (sid: string) => {
@@ -202,15 +232,27 @@ export default function HistoryPage() {
       />
 
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
-        {/* 검색 */}
-        <div className="mb-5 flex items-center gap-2 rounded-md border border-border-strong bg-surface-2 px-3">
-          <Search className="h-4 w-4 text-faint" />
-          <input
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="대화 제목 검색..."
-            className="h-9 w-full bg-transparent text-sm text-fg outline-none placeholder:text-muted"
-          />
+        {/* 검색 + 전체 삭제 */}
+        <div className="mb-5 flex items-center gap-2">
+          <div className="flex flex-1 items-center gap-2 rounded-md border border-border-strong bg-surface-2 px-3">
+            <Search className="h-4 w-4 text-faint" />
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="대화 제목 검색..."
+              className="h-9 w-full bg-transparent text-sm text-fg outline-none placeholder:text-muted"
+            />
+          </div>
+          {auth.currentUser && !loading && sessions.length > 0 && (
+            <button
+              type="button"
+              onClick={() => void deleteAll()}
+              className="flex h-9 flex-shrink-0 items-center gap-1.5 rounded-md border border-border-strong bg-surface-2 px-3 text-sm text-muted transition hover:border-danger/40 hover:text-danger"
+            >
+              <Trash2 className="h-4 w-4" />
+              전체 삭제
+            </button>
+          )}
         </div>
 
         {loading ? (
@@ -240,7 +282,7 @@ export default function HistoryPage() {
                     <Card
                       key={s.id}
                       onClick={() => void openSession(s.id)}
-                      className="flex cursor-pointer items-start gap-3 p-4 transition hover:border-border-strong hover:shadow-2"
+                      className="group flex cursor-pointer items-start gap-3 p-4 transition hover:border-border-strong hover:shadow-2"
                     >
                       <div className="mt-0.5 grid h-8 w-8 flex-shrink-0 place-items-center rounded-md bg-surface-2 text-faint">
                         <MessageSquare className="h-4 w-4" />
@@ -263,6 +305,17 @@ export default function HistoryPage() {
                           </Badge>
                         </div>
                       </div>
+                      <button
+                        type="button"
+                        aria-label="대화 삭제"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void deleteSession(s);
+                        }}
+                        className="mt-0.5 grid h-8 w-8 flex-shrink-0 place-items-center rounded-md text-faint opacity-0 transition group-hover:opacity-100 hover:bg-surface-3 hover:text-danger"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
                     </Card>
                   ))}
                 </div>

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -2,13 +2,14 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { Plus, Search, LogOut } from "lucide-react";
-import { useQuery } from "@tanstack/react-query";
+import { Plus, Search, LogOut, Trash2 } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { useAppStore } from "@/lib/store";
 import type { ChatRole } from "@/lib/store";
 import { visibleNavGroups } from "@/lib/nav";
 import { ApiClient } from "@/lib/api-client";
+import { appendAnonSessionId } from "@/lib/anon-session";
 import Image from "next/image";
 import { ThemeToggle } from "./theme-toggle";
 import { cn } from "@/lib/utils";
@@ -23,6 +24,7 @@ interface SessionRow {
 export function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { clearChat, auth, setAuth, setChatHistory, setCurrentSessionId, setArtifacts } =
     useAppStore();
   const user = auth.currentUser;
@@ -47,6 +49,18 @@ export function Sidebar() {
       /* 조회 실패 — 무시 */
     }
     if (pathname !== "/") router.push("/");
+  };
+
+  // 최근 대화 삭제 — 백엔드 DELETE /api/chat/sessions/:sid (소유자/익명 소유 검증).
+  const deleteSession = async (sid: string, title: string) => {
+    if (!window.confirm(`"${title}" 대화를 삭제하시겠습니까?\n삭제된 대화는 복구할 수 없습니다.`)) return;
+    try {
+      await ApiClient.del(appendAnonSessionId(`/api/chat/sessions/${sid}`));
+      if (sid === currentSessionId) clearChat();
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+    } catch {
+      window.alert("대화 삭제에 실패했습니다.");
+    }
   };
 
   const logout = async () => {
@@ -143,20 +157,31 @@ export function Sidebar() {
               {sessions.slice(0, 20).map((s, i) => {
                 const sid = s.id ?? s.sessionId;
                 const active = !!sid && sid === currentSessionId;
+                const title = s.title ?? s.name ?? "제목 없는 대화";
                 return (
-                  <li key={sid ?? i}>
+                  <li key={sid ?? i} className="group relative">
                     <button
                       type="button"
                       onClick={() => openSession(sid)}
                       className={cn(
-                        "w-full truncate rounded-md px-2.5 py-1.5 text-left text-sm transition",
+                        "w-full truncate rounded-md px-2.5 py-1.5 text-left text-sm transition group-hover:pr-8",
                         active
                           ? "bg-accent-soft font-medium text-accent"
                           : "text-muted hover:bg-surface-3 hover:text-fg",
                       )}
                     >
-                      {s.title ?? s.name ?? "제목 없는 대화"}
+                      {title}
                     </button>
+                    {sid && (
+                      <button
+                        type="button"
+                        aria-label="대화 삭제"
+                        onClick={() => void deleteSession(sid, title)}
+                        className="absolute right-1 top-1/2 grid h-6 w-6 -translate-y-1/2 place-items-center rounded text-faint opacity-0 transition group-hover:opacity-100 hover:bg-surface-3 hover:text-danger"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    )}
                   </li>
                 );
               })}


### PR DESCRIPTION
## Summary
최근 대화(사이드바)·대화 히스토리 페이지에서 대화를 삭제하는 기능. **백엔드 삭제 API 는 이미 완비** (`DELETE /api/chat/sessions/:sid` 단건 — admin/소유자/익명 소유 검증 + history-summary cache invalidate, `DELETE /api/chat/sessions` 전체 — requireAuth) 상태였고 apps/web UI 만 누락되어 있었음 (Lumen 재구축 쓰기 액션 누락 패턴). 이번 PR 은 프론트 2개 파일만 수정.

- **history 페이지**: 카드 hover 시 휴지통 버튼 → `window.confirm` → 삭제 후 목록에서 제거. 로그인 사용자에겐 검색창 옆 "전체 삭제" 버튼. 삭제한 세션이 현재 열린 세션이면 `clearChat()`.
- **sidebar 최근 대화**: 행 hover 시 휴지통 버튼 (버튼 중첩(invalid HTML) 회피를 위해 형제 배치 + absolute).
- **게스트 호환**: `appendAnonSessionId` 로 단건 삭제에 익명 소유 검증 파라미터 전달.
- 두 곳 모두 react-query `["conversations"]` invalidate 로 목록 동기화.

## 검증 (라이브 E2E)
- next dev(:3999) + Playwright, 실재 admin(id=3) JWT 쿠키 주입 (가짜 userId 는 401 — 메모리 원칙 준수)
- 일회용 테스트 세션 2개 생성 후: ① 히스토리 카드 삭제 ② 사이드바 행 삭제 — 각각 UI 제거 + **DB 실삭제 확인** (`conversation_sessions` 0 rows, admin 은 404 도 200 으로 통과하므로 API 응답 아닌 DB 직접 검증)
- confirm 다이얼로그 문구·수락 흐름 정상, 콘솔 에러 0
- `npm run build:frontend-next` 통과 (전체 삭제 실행은 실계정 데이터 파괴라 렌더·confirm 까지만 검증 — endpoint 는 기존 백엔드)

🤖 Generated with [Claude Code](https://claude.com/claude-code)