### PR TITLE
fix(web): 로그인 직후 사이드바 게스트 표시 — auth store 즉시 동기화

### DIFF
--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { ArrowRight, LoaderCircle } from "lucide-react";
 import Image from "next/image";
 import { ApiClient, ApiError } from "@/lib/api-client";
+import { syncAuthFromServer } from "@/lib/auth-sync";
 import { Button } from "@/components/ui/primitives";
 
 export default function LoginPage() {
@@ -20,6 +21,9 @@ export default function LoginPage() {
     setError(null);
     try {
       await ApiClient.post("/api/auth/login", { email, password });
+      // router.push 는 remount 가 없어 AuthSync(마운트 1회)가 다시 돌지 않는다 —
+      // 로그인 직후 store 동기화(+익명 세션 이관)를 직접 수행해야 사이드바가 즉시 반영.
+      await syncAuthFromServer();
       router.push("/");
     } catch (err) {
       setError(err instanceof ApiError ? err.message : "로그인에 실패했습니다.");

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -3,41 +3,18 @@
 import { ThemeProvider } from "next-themes";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
-import type { ApiSuccess, MePayload } from "@openmake/shared-types";
-import { ApiClient } from "@/lib/api-client";
-import { getAnonSessionId } from "@/lib/anon-session";
-import { useAppStore } from "@/lib/store";
+import { syncAuthFromServer } from "@/lib/auth-sync";
 import { CLIENT_TIMING } from "@/lib/config";
 
 /**
  * 앱 마운트 시 /api/auth/me 로 현재 로그인 사용자를 store 에 동기화.
  * 실패(401=비로그인)면 게스트 유지. 사이드바·인증 의존 UI 가 이 상태를 구독한다.
+ * 동기화 본체는 lib/auth-sync (login 페이지와 공유).
  */
 function AuthSync() {
-  const setAuth = useAppStore((s) => s.setAuth);
   useEffect(() => {
-    ApiClient.get<ApiSuccess<MePayload>>("/api/auth/me")
-      .then((res) => {
-        const u = res?.data?.user;
-        if (u) {
-          setAuth({
-            currentUser: {
-              id: String(u.id),
-              email: u.email,
-              name: u.username,
-              role: u.role ?? "user",
-            },
-            isGuestMode: false,
-          });
-          void ApiClient.post("/api/chat/sessions/claim", { anonSessionId: getAnonSessionId() }).catch(() => {
-            /* 익명 세션이 없거나 이미 이관됨 */
-          });
-        }
-      })
-      .catch(() => {
-        /* 비로그인 — 게스트 유지 */
-      });
-  }, [setAuth]);
+    void syncAuthFromServer();
+  }, []);
   return null;
 }
 

--- a/apps/web/lib/auth-sync.ts
+++ b/apps/web/lib/auth-sync.ts
@@ -1,0 +1,35 @@
+import type { ApiSuccess, MePayload } from "@openmake/shared-types";
+import { ApiClient } from "./api-client";
+import { getAnonSessionId } from "./anon-session";
+import { useAppStore } from "./store";
+
+/**
+ * /api/auth/me 로 현재 로그인 사용자를 store 에 동기화하고 익명 세션을 이관.
+ *
+ * 앱 마운트(providers AuthSync)와 로그인 성공 직후(login 페이지) 양쪽에서 호출 —
+ * router.push 는 remount 가 없어 마운트 시 1회 동기화만으로는 로그인 직후
+ * 사이드바가 게스트로 남는다. 로그인 여부를 반환한다.
+ */
+export async function syncAuthFromServer(): Promise<boolean> {
+  try {
+    const res = await ApiClient.get<ApiSuccess<MePayload>>("/api/auth/me");
+    const u = res?.data?.user;
+    if (!u) return false;
+    useAppStore.getState().setAuth({
+      currentUser: {
+        id: String(u.id),
+        email: u.email,
+        name: u.username,
+        role: u.role ?? "user",
+      },
+      isGuestMode: false,
+    });
+    void ApiClient.post("/api/chat/sessions/claim", { anonSessionId: getAnonSessionId() }).catch(() => {
+      /* 익명 세션이 없거나 이미 이관됨 */
+    });
+    return true;
+  } catch {
+    /* 비로그인(401) — 게스트 유지 */
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
회원가입/로그인 라이브 E2E 테스트 중 발견한 결함 수정: 로그인 성공 직후 사이드바가 새로고침 전까지 "게스트 · 로그인 안 됨"으로 표시됨.

- **원인**: `router.push("/")` 는 remount 가 없어 앱 마운트 시 1회만 실행되는 AuthSync(`/api/auth/me` → `setAuth`)가 재실행되지 않음.
- **수정**: providers 의 동기화 로직(+익명 세션 claim)을 `lib/auth-sync.ts` 로 추출하고 로그인 성공 직후에도 호출. 부수 효과로 익명 세션 이관도 로그인 시점에 즉시 수행됨 (기존엔 새로고침까지 지연 — 같은 근본 원인).

## 검증
- dev(:3998) + Playwright: 일회용 계정 생성 → UI 로그인 → **새로고침 없이** 사이드바 "E2E 로그인싱크 | user · 자가호스팅" 즉시 표시 확인 (수정 전 재현: 게스트로 남음)
- `npm run build:frontend-next` 통과, 테스트 계정 DB 정리 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)