### PR TITLE
docs(infra): docker-compose 주석의 구 경로 표기 정정

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,7 +1,7 @@
 # OpenMake LLM — 인프라 의존성(DB/Redis) Docker 분리 운영
 #
 # 목적: 호스트 brew(postgresql@16, redis) 대신 버전 고정·격리·이식 가능한 컨테이너로 운영.
-# 애플리케이션(backend/api, frontend)은 여전히 PM2 + 직접 배포 (이 compose 에 포함하지 않음).
+# 애플리케이션(apps/api, apps/web)은 여전히 PM2 + 직접 배포 (이 compose 에 포함하지 않음).
 #
 # 사용:
 #   docker compose up -d                 # DB+Redis 기동
@@ -13,9 +13,9 @@
 # 선행: .env 에 POSTGRES_PASSWORD 를 DATABASE_URL 의 비밀번호와 동일하게 설정.
 #   (DATABASE_URL=postgresql://openmake:<PW>@127.0.0.1:5432/openmake_llm ↔ POSTGRES_PASSWORD=<PW>)
 #
-# 초기화: 빈 볼륨 첫 기동 시 services/database/init/*.sql(001→002→003) 자동 실행.
-#   단 migrations/(033, 041 등)는 자동 적용 안 됨 → 기동 후:
-#     npx ts-node backend/api/src/data/migrations/cli.ts migrate
+# 초기화: 빈 볼륨 첫 기동 시 db/init/*.sql(001→002→003) 자동 실행.
+#   단 db/migrations/ 는 자동 적용 안 됨 → 기동 후:
+#     npx ts-node apps/api/src/data/migrations/cli.ts migrate
 
 services:
   postgres:


### PR DESCRIPTION
## Summary
2026-06-21 모노레포 재편 이후 `infra/docker-compose.yml` 주석에 남아 있던 구 경로 표기 3곳 정정 (주석만 변경, 동작 무영향):

- `backend/api, frontend` → `apps/api, apps/web`
- `services/database/init/*.sql` → `db/init/*.sql`
- `backend/api/src/data/migrations/cli.ts` → `apps/api/src/data/migrations/cli.ts`

실제 마운트 경로(`../db/init`)는 재편 때 이미 수정되어 있었음. `docker compose config` 문법 검증 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)