### PR TITLE
feat(web): 전체 메뉴 i18n — next-intl 도입, UI 표시 언어 ko/en/ja/zh (Phase 1)

### DIFF
--- a/apps/web/app/(workspace)/page.tsx
+++ b/apps/web/app/(workspace)/page.tsx
@@ -1,17 +1,21 @@
+import { getTranslations } from "next-intl/server";
 import { MessageList } from "@/components/chat/message-list";
 import { ActiveContext } from "@/components/chat/active-context";
 import { Composer } from "@/components/chat/composer";
 import { ArtifactPanel } from "@/components/chat/artifact-panel";
 import { ArtifactToggle } from "@/components/chat/artifact-toggle";
 
-export default function ChatPage() {
+export default async function ChatPage() {
+  const t = await getTranslations();
   return (
     <div className="flex min-h-0 flex-1">
       <div className="flex min-w-0 flex-1 flex-col">
         <header className="flex h-14 items-center justify-between border-b border-border px-5">
           <div className="min-w-0">
-            <h1 className="truncate text-sm font-semibold text-fg">새 대화</h1>
-            <p className="truncate text-xs text-faint">워크스페이스 · 채팅</p>
+            <h1 className="truncate text-sm font-semibold text-fg">{t("sidebar.newChat")}</h1>
+            <p className="truncate text-xs text-faint">
+              {t("nav.groups.workspace")} · {t("nav.items.chat")}
+            </p>
           </div>
           <div className="flex shrink-0 items-center gap-2">
             <ArtifactToggle />

--- a/apps/web/app/(workspace)/settings/page.tsx
+++ b/apps/web/app/(workspace)/settings/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import {
   Settings,
   Bot,
@@ -26,6 +28,7 @@ import { ApiClient, ApiError } from "@/lib/api-client";
 import { useAppStore } from "@/lib/store";
 import { fetchModels } from "@/lib/models-api";
 import { cn } from "@/lib/utils";
+import { LOCALE_COOKIE, LOCALE_COOKIE_MAX_AGE, isLocale } from "@/i18n/config";
 
 /* ── 탭 정의 ────────────────────────────────────────────── */
 type TabId = "general" | "model" | "interface" | "notifications" | "privacy" | "security";
@@ -52,8 +55,20 @@ const THEMES = [
   { value: "dark", label: "다크" },
 ];
 
+/** NEXT_LOCALE 쿠키 값 (미설정/미지원 값 = "" → 자동 감지). */
+function readLocaleCookie(): string {
+  const v = document.cookie
+    .split("; ")
+    .find((c) => c.startsWith(`${LOCALE_COOKIE}=`))
+    ?.split("=")[1];
+  return isLocale(v) ? v : "";
+}
+// 쿠키 변경은 changeLanguage → router.refresh() 재렌더로만 발생 — 별도 구독 불필요.
+const emptySubscribe = () => () => {};
+
+/** UI 표시 언어. 언어명은 각 언어의 자기 표기(native name)라 번역하지 않고, "자동 감지"만 t 로 치환. */
 const LANGUAGES = [
-  { value: "", label: "자동 감지" },
+  { value: "", label: "" }, // label 은 렌더 시 t("languageAuto") 로 채움
   { value: "ko", label: "한국어" },
   { value: "en", label: "English" },
   { value: "ja", label: "日本語" },
@@ -197,8 +212,26 @@ export default function SettingsPage() {
       : []),
     ...externalGroups,
   ];
-  const [language, setLanguage] = useState("");
+  // UI 표시 언어 — NEXT_LOCALE 쿠키가 SoT (i18n/request.ts 가 서버 렌더 시 읽음).
+  // 로컬 state 중복 없이 쿠키를 직접 구독: 서버 스냅샷 "" → hydration 후 클라 값으로 갱신.
+  const language = useSyncExternalStore(
+    emptySubscribe,
+    readLocaleCookie,
+    () => "",
+  );
   const [customInstructions, setCustomInstructions] = useState("");
+  const tSettings = useTranslations("settings");
+  const router = useRouter();
+
+  const changeLanguage = (v: string) => {
+    if (isLocale(v)) {
+      document.cookie = `${LOCALE_COOKIE}=${v}; path=/; max-age=${LOCALE_COOKIE_MAX_AGE}; samesite=lax`;
+    } else {
+      // "자동 감지" — 쿠키 제거 → Accept-Language 협상으로 복귀
+      document.cookie = `${LOCALE_COOKIE}=; path=/; max-age=0`;
+    }
+    router.refresh(); // 재렌더 → useSyncExternalStore 가 쿠키를 다시 읽음
+  };
 
   // 인터페이스
   const [theme, setTheme] = useState("system");
@@ -330,7 +363,7 @@ export default function SettingsPage() {
       await ApiClient.put("/api/users/me/custom-instructions", {
         customInstructions: trimmed.length > 0 ? trimmed : null,
       });
-      // TODO: API 연동 — defaultModel/responseStyle/language/theme/알림/개인정보 영속화
+      // TODO: API 연동 — defaultModel/responseStyle/theme/알림/개인정보 영속화 (language 는 NEXT_LOCALE 쿠키로 완료)
       setSavedAt(new Date().toLocaleTimeString("ko-KR"));
     } catch {
       setSavedAt(null);
@@ -422,12 +455,14 @@ export default function SettingsPage() {
                 <CardContent className="py-0">
                   <FieldRow
                     title="언어"
-                    description="AI 응답 언어. 자동 감지 시 사용자 메시지 언어로 응답합니다."
+                    description="인터페이스 표시 언어. 자동 감지 시 브라우저 언어를 따릅니다. (AI 응답은 메시지 언어를 따릅니다)"
                   >
                     <Select
                       value={language}
-                      onChange={setLanguage}
-                      options={LANGUAGES}
+                      onChange={changeLanguage}
+                      options={LANGUAGES.map((o) =>
+                        o.value === "" ? { ...o, label: tSettings("languageAuto") } : o,
+                      )}
                     />
                   </FieldRow>
                   <FieldRow

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { JetBrains_Mono } from "next/font/google";
+import { NextIntlClientProvider } from "next-intl";
+import { getLocale, getTranslations } from "next-intl/server";
 import "./globals.css";
 import { Providers } from "./providers";
 
@@ -9,10 +11,13 @@ const jetbrainsMono = JetBrains_Mono({
   display: "swap",
 });
 
-export const metadata: Metadata = {
-  title: "OpenMake.Ai",
-  description: "AI 기반 지능형 채팅 어시스턴트",
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("metadata");
+  return {
+    title: "OpenMake.Ai",
+    description: t("description"),
+  };
+}
 
 // 실제 모바일 디바이스 반응형의 핵심 — viewport meta 가 없으면 모바일 브라우저가
 // 데스크탑 너비로 렌더 후 축소해 레이아웃이 작게 뭉개진다.
@@ -22,19 +27,23 @@ export const viewport: Viewport = {
   viewportFit: "cover", // 노치/홈바 safe-area 대응
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // NEXT_LOCALE 쿠키 → Accept-Language → ko (i18n/request.ts 에서 결정)
+  const locale = await getLocale();
   return (
-    <html lang="ko" suppressHydrationWarning className={jetbrainsMono.variable}>
+    <html lang={locale} suppressHydrationWarning className={jetbrainsMono.variable}>
       <head>
         {/* Pretendard self-host (public/vendor/pretendard) */}
         <link rel="stylesheet" href="/vendor/pretendard/pretendard.css" />
       </head>
       <body className="min-h-dvh bg-app text-fg antialiased">
-        <Providers>{children}</Providers>
+        <NextIntlClientProvider>
+          <Providers>{children}</Providers>
+        </NextIntlClientProvider>
       </body>
     </html>
   );

--- a/apps/web/components/mobile-sidebar.tsx
+++ b/apps/web/components/mobile-sidebar.tsx
@@ -4,24 +4,26 @@ import { useState, useEffect } from "react";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { MessageSquare, Telescope, Sparkles, Menu, X, LogIn } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Sidebar } from "./sidebar";
 import { useAppStore } from "@/lib/store";
 import { NAV_ROLE_RANK, type NavRole } from "@/lib/nav";
 import { cn } from "@/lib/utils";
 
 /** OD lumen 모바일 시안: 하단 탭바(44px+ 터치 타깃) + "메뉴" 탭으로 전체 드로어. 데스크탑(lg)은 고정 사이드바. */
-const TABS: { label: string; href: string; icon: typeof MessageSquare; minRole: NavRole }[] = [
-  { label: "채팅", href: "/", icon: MessageSquare, minRole: "guest" },
-  { label: "리서치", href: "/research", icon: Telescope, minRole: "user" },
-  { label: "에이전트", href: "/agent-tasks", icon: Sparkles, minRole: "user" },
+const TABS: { labelKey: string; href: string; icon: typeof MessageSquare; minRole: NavRole }[] = [
+  { labelKey: "chat", href: "/", icon: MessageSquare, minRole: "guest" },
+  { labelKey: "research", href: "/research", icon: Telescope, minRole: "user" },
+  { labelKey: "agent", href: "/agent-tasks", icon: Sparkles, minRole: "user" },
 ];
 
 export function MobileSidebar() {
+  const t = useTranslations("mobileNav");
   const [open, setOpen] = useState(false);
   const pathname = usePathname();
   const user = useAppStore((s) => s.auth.currentUser);
   const roleRank = NAV_ROLE_RANK[user?.role ?? "guest"];
-  const tabs = TABS.filter((t) => roleRank >= NAV_ROLE_RANK[t.minRole]);
+  const tabs = TABS.filter((tab) => roleRank >= NAV_ROLE_RANK[tab.minRole]);
 
   // 라우트 이동 시 드로어 자동 닫기
   useEffect(() => setOpen(false), [pathname]);
@@ -42,7 +44,7 @@ export function MobileSidebar() {
             <Sidebar />
             <button
               onClick={() => setOpen(false)}
-              aria-label="메뉴 닫기"
+              aria-label={t("closeMenu")}
               className="absolute right-2 top-3 grid h-8 w-8 place-items-center rounded-md text-muted hover:bg-surface-3 hover:text-fg"
             >
               <X className="h-[18px] w-[18px]" />
@@ -53,17 +55,17 @@ export function MobileSidebar() {
 
       {/* 하단 탭바 (모바일 전용) */}
       <nav className="fixed inset-x-0 bottom-0 z-30 flex items-stretch border-t border-border bg-surface pb-[env(safe-area-inset-bottom)] lg:hidden">
-        {tabs.map((t) => (
+        {tabs.map((tab) => (
           <Link
-            key={t.href}
-            href={t.href}
+            key={tab.href}
+            href={tab.href}
             className={cn(
               "flex min-h-[52px] flex-1 flex-col items-center justify-center gap-0.5 text-[11px] font-medium transition",
-              isActive(t.href) ? "text-accent" : "text-muted hover:text-fg",
+              isActive(tab.href) ? "text-accent" : "text-muted hover:text-fg",
             )}
           >
-            <t.icon className="h-5 w-5" />
-            {t.label}
+            <tab.icon className="h-5 w-5" />
+            {t(tab.labelKey)}
           </Link>
         ))}
         {!user && (
@@ -72,16 +74,16 @@ export function MobileSidebar() {
             className="flex min-h-[52px] flex-1 flex-col items-center justify-center gap-0.5 text-[11px] font-medium text-muted transition hover:text-fg"
           >
             <LogIn className="h-5 w-5" />
-            로그인
+            {t("login")}
           </Link>
         )}
         <button
           onClick={() => setOpen(true)}
-          aria-label="전체 메뉴"
+          aria-label={t("openMenu")}
           className="flex min-h-[52px] flex-1 flex-col items-center justify-center gap-0.5 text-[11px] font-medium text-muted transition hover:text-fg"
         >
           <Menu className="h-5 w-5" />
-          메뉴
+          {t("menu")}
         </button>
       </nav>
     </>

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { Plus, Search, LogOut, Trash2 } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useTranslations } from "next-intl";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { useAppStore } from "@/lib/store";
 import type { ChatRole } from "@/lib/store";
@@ -22,6 +23,8 @@ interface SessionRow {
 }
 
 export function Sidebar() {
+  const t = useTranslations("sidebar");
+  const tNav = useTranslations("nav");
   const pathname = usePathname();
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -53,13 +56,13 @@ export function Sidebar() {
 
   // 최근 대화 삭제 — 백엔드 DELETE /api/chat/sessions/:sid (소유자/익명 소유 검증).
   const deleteSession = async (sid: string, title: string) => {
-    if (!window.confirm(`"${title}" 대화를 삭제하시겠습니까?\n삭제된 대화는 복구할 수 없습니다.`)) return;
+    if (!window.confirm(t("deleteConfirm", { title }))) return;
     try {
       await ApiClient.del(appendAnonSessionId(`/api/chat/sessions/${sid}`));
       if (sid === currentSessionId) clearChat();
       void queryClient.invalidateQueries({ queryKey: ["conversations"] });
     } catch {
-      window.alert("대화 삭제에 실패했습니다.");
+      window.alert(t("deleteFailed"));
     }
   };
 
@@ -107,7 +110,8 @@ export function Sidebar() {
           onClick={() => clearChat()}
           className="flex w-full items-center gap-2 rounded-md bg-accent px-3 py-2 text-sm font-medium text-accent-fg shadow-2 transition hover:bg-accent-hover active:bg-accent-press"
         >
-          <Plus className="h-4 w-4" />새 대화
+          <Plus className="h-4 w-4" />
+          {t("newChat")}
         </Link>
       </div>
 
@@ -115,7 +119,7 @@ export function Sidebar() {
         <div className="flex items-center gap-2 rounded-md border border-border bg-surface px-2.5 py-2">
           <Search className="h-4 w-4 text-faint" />
           <input
-            placeholder="검색..."
+            placeholder={t("searchPlaceholder")}
             className="w-full bg-transparent text-sm text-fg outline-none placeholder:text-muted"
           />
         </div>
@@ -123,9 +127,9 @@ export function Sidebar() {
 
       <nav className="mt-3 flex-1 overflow-y-auto px-3 pb-3">
         {visibleNavGroups(user?.role ?? "guest").map((group) => (
-          <div key={group.title} className="pt-3">
+          <div key={group.titleKey} className="pt-3">
             <p className="px-1 pb-1 text-[11px] font-medium uppercase tracking-wider text-faint">
-              {group.title}
+              {tNav(group.titleKey)}
             </p>
             <ul className="space-y-0.5">
               {group.items.map((item) => (
@@ -140,7 +144,7 @@ export function Sidebar() {
                     )}
                   >
                     <item.icon className="h-[18px] w-[18px]" />
-                    {item.label}
+                    {tNav(item.labelKey)}
                   </Link>
                 </li>
               ))}
@@ -151,13 +155,13 @@ export function Sidebar() {
         {sessions.length > 0 && (
           <div className="pt-3">
             <p className="px-1 pb-1 text-[11px] font-medium uppercase tracking-wider text-faint">
-              최근 대화
+              {t("recentChats")}
             </p>
             <ul className="space-y-0.5">
               {sessions.slice(0, 20).map((s, i) => {
                 const sid = s.id ?? s.sessionId;
                 const active = !!sid && sid === currentSessionId;
-                const title = s.title ?? s.name ?? "제목 없는 대화";
+                const title = s.title ?? s.name ?? t("untitledChat");
                 return (
                   <li key={sid ?? i} className="group relative">
                     <button
@@ -175,7 +179,7 @@ export function Sidebar() {
                     {sid && (
                       <button
                         type="button"
-                        aria-label="대화 삭제"
+                        aria-label={t("deleteChat")}
                         onClick={() => void deleteSession(sid, title)}
                         className="absolute right-1 top-1/2 grid h-6 w-6 -translate-y-1/2 place-items-center rounded text-faint opacity-0 transition group-hover:opacity-100 hover:bg-surface-3 hover:text-danger"
                       >
@@ -197,8 +201,8 @@ export function Sidebar() {
               {user.name?.[0] ?? "G"}
             </div>
             <div className="min-w-0 flex-1">
-              <p className="truncate text-sm font-medium text-fg">{user.name ?? "게스트"}</p>
-              <p className="truncate text-xs text-faint">{user.role} · 자가호스팅</p>
+              <p className="truncate text-sm font-medium text-fg">{user.name ?? t("guest")}</p>
+              <p className="truncate text-xs text-faint">{user.role} · {t("selfHosted")}</p>
             </div>
           </div>
         ) : (
@@ -210,8 +214,8 @@ export function Sidebar() {
               G
             </div>
             <div className="min-w-0 flex-1">
-              <p className="truncate text-sm font-medium text-fg">게스트</p>
-              <p className="truncate text-xs text-faint">로그인 안 됨</p>
+              <p className="truncate text-sm font-medium text-fg">{t("guest")}</p>
+              <p className="truncate text-xs text-faint">{t("notLoggedIn")}</p>
             </div>
           </Link>
         )}
@@ -220,7 +224,7 @@ export function Sidebar() {
           <button
             type="button"
             onClick={() => void logout()}
-            aria-label="로그아웃"
+            aria-label={t("logout")}
             className="grid h-8 w-8 place-items-center rounded-md text-muted transition hover:bg-surface-3 hover:text-danger"
           >
             <LogOut className="h-4 w-4" />

--- a/apps/web/i18n/config.ts
+++ b/apps/web/i18n/config.ts
@@ -1,0 +1,16 @@
+/**
+ * i18n 공통 상수 — 서버/클라이언트 양쪽에서 import 가능 (next/headers 의존 금지).
+ * locale SoT 는 NEXT_LOCALE 쿠키 하나: 서버(i18n/request.ts)가 읽어 렌더하고,
+ * 클라이언트(설정 페이지)가 쓴 뒤 router.refresh() 로 재렌더한다.
+ * 쿠키 없음 = "자동 감지" (Accept-Language 협상 → DEFAULT_LOCALE 폴백).
+ */
+export const LOCALES = ["ko", "en", "ja", "zh"] as const;
+export type Locale = (typeof LOCALES)[number];
+
+export const DEFAULT_LOCALE: Locale = "ko";
+export const LOCALE_COOKIE = "NEXT_LOCALE";
+export const LOCALE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1년
+
+export function isLocale(value: string | undefined | null): value is Locale {
+  return !!value && (LOCALES as readonly string[]).includes(value);
+}

--- a/apps/web/i18n/request.ts
+++ b/apps/web/i18n/request.ts
@@ -1,0 +1,26 @@
+import { cookies, headers } from "next/headers";
+import { getRequestConfig } from "next-intl/server";
+import { DEFAULT_LOCALE, LOCALE_COOKIE, isLocale, type Locale } from "./config";
+
+/** NEXT_LOCALE 쿠키 → Accept-Language 협상 → 기본(ko) 순으로 locale 을 결정한다. */
+async function resolveLocale(): Promise<Locale> {
+  const store = await cookies();
+  const fromCookie = store.get(LOCALE_COOKIE)?.value;
+  if (isLocale(fromCookie)) return fromCookie;
+
+  // 쿠키 없음 = "자동 감지" — Accept-Language 의 primary subtag 를 순서대로 매칭.
+  const acceptLanguage = (await headers()).get("accept-language") ?? "";
+  for (const part of acceptLanguage.split(",")) {
+    const lang = part.split(";")[0]?.trim().slice(0, 2).toLowerCase();
+    if (isLocale(lang)) return lang;
+  }
+  return DEFAULT_LOCALE;
+}
+
+export default getRequestConfig(async () => {
+  const locale = await resolveLocale();
+  return {
+    locale,
+    messages: (await import(`../messages/${locale}.json`)).default,
+  };
+});

--- a/apps/web/lib/nav.ts
+++ b/apps/web/lib/nav.ts
@@ -26,7 +26,8 @@ export type NavRole = "guest" | "user" | "admin";
 export const NAV_ROLE_RANK: Record<NavRole, number> = { guest: 0, user: 1, admin: 2 };
 
 export interface NavItem {
-  label: string;
+  /** messages/*.json 의 nav 네임스페이스 키 (예: 'items.chat') */
+  labelKey: string;
   href: string;
   icon: LucideIcon;
   /** 이 항목을 보려면 필요한 최소 역할. 미지정 시 그룹값, 그것도 없으면 'user'. */
@@ -34,7 +35,8 @@ export interface NavItem {
 }
 
 export interface NavGroup {
-  title: string;
+  /** messages/*.json 의 nav 네임스페이스 키 (예: 'groups.workspace') */
+  titleKey: string;
   items: NavItem[];
   /** 그룹 전체의 최소 역할 (항목별 minRole 이 우선). */
   minRole?: NavRole;
@@ -43,45 +45,45 @@ export interface NavGroup {
 /** 사이드바 네비게이션 — 기존 nav-items.js + pages 모듈에 대응. */
 export const NAV_GROUPS: NavGroup[] = [
   {
-    title: "워크스페이스",
+    titleKey: "groups.workspace",
     items: [
-      { label: "채팅", href: "/", icon: MessageSquare, minRole: "guest" },
-      { label: "딥 리서치", href: "/research", icon: Telescope },
-      { label: "에이전트 작업", href: "/agent-tasks", icon: Sparkles },
-      { label: "커스텀 에이전트", href: "/custom-agents", icon: Bot },
-      { label: "스킬 라이브러리", href: "/skill-library", icon: Library },
-      { label: "아티팩트", href: "/artifacts", icon: LayoutGrid },
-      { label: "히스토리", href: "/history", icon: Clock },
+      { labelKey: "items.chat", href: "/", icon: MessageSquare, minRole: "guest" },
+      { labelKey: "items.research", href: "/research", icon: Telescope },
+      { labelKey: "items.agentTasks", href: "/agent-tasks", icon: Sparkles },
+      { labelKey: "items.customAgents", href: "/custom-agents", icon: Bot },
+      { labelKey: "items.skillLibrary", href: "/skill-library", icon: Library },
+      { labelKey: "items.artifacts", href: "/artifacts", icon: LayoutGrid },
+      { labelKey: "items.history", href: "/history", icon: Clock },
     ],
   },
   {
-    title: "통합",
+    titleKey: "groups.integrations",
     items: [
-      { label: "MCP 서버", href: "/mcp-servers", icon: Server },
-      { label: "MCP 카탈로그", href: "/mcp-catalog", icon: Boxes },
-      { label: "MCP 모니터링", href: "/mcp-monitoring", icon: Activity },
-      { label: "에이전트 학습", href: "/agent-learning", icon: GraduationCap },
+      { labelKey: "items.mcpServers", href: "/mcp-servers", icon: Server },
+      { labelKey: "items.mcpCatalog", href: "/mcp-catalog", icon: Boxes },
+      { labelKey: "items.mcpMonitoring", href: "/mcp-monitoring", icon: Activity },
+      { labelKey: "items.agentLearning", href: "/agent-learning", icon: GraduationCap },
     ],
   },
   {
-    title: "계정",
+    titleKey: "groups.account",
     items: [
-      { label: "설정", href: "/settings", icon: Settings },
-      { label: "API 키", href: "/api-keys", icon: KeyRound },
-      { label: "사용량", href: "/usage", icon: BarChart3 },
-      { label: "개발자 문서", href: "/developer", icon: ScrollText },
+      { labelKey: "items.settings", href: "/settings", icon: Settings },
+      { labelKey: "items.apiKeys", href: "/api-keys", icon: KeyRound },
+      { labelKey: "items.usage", href: "/usage", icon: BarChart3 },
+      { labelKey: "items.developerDocs", href: "/developer", icon: ScrollText },
     ],
   },
   {
-    title: "관리자",
+    titleKey: "groups.admin",
     minRole: "admin",
     items: [
-      { label: "관리자", href: "/admin", icon: Shield },
-      { label: "애널리틱스", href: "/admin/analytics", icon: LineChart },
-      { label: "감사 로그", href: "/admin/audit", icon: ScrollText },
-      { label: "메트릭", href: "/admin/metrics", icon: Gauge },
-      { label: "알림", href: "/admin/alerts", icon: Bell },
-      { label: "MCP 카탈로그 관리", href: "/admin/mcp-catalog", icon: Boxes },
+      { labelKey: "items.admin", href: "/admin", icon: Shield },
+      { labelKey: "items.analytics", href: "/admin/analytics", icon: LineChart },
+      { labelKey: "items.auditLog", href: "/admin/audit", icon: ScrollText },
+      { labelKey: "items.metrics", href: "/admin/metrics", icon: Gauge },
+      { labelKey: "items.alerts", href: "/admin/alerts", icon: Bell },
+      { labelKey: "items.mcpCatalogAdmin", href: "/admin/mcp-catalog", icon: Boxes },
     ],
   },
 ];

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1,0 +1,61 @@
+{
+  "metadata": {
+    "description": "AI-powered intelligent chat assistant"
+  },
+  "nav": {
+    "groups": {
+      "workspace": "Workspace",
+      "integrations": "Integrations",
+      "account": "Account",
+      "admin": "Admin"
+    },
+    "items": {
+      "chat": "Chat",
+      "research": "Deep Research",
+      "agentTasks": "Agent Tasks",
+      "customAgents": "Custom Agents",
+      "skillLibrary": "Skill Library",
+      "artifacts": "Artifacts",
+      "history": "History",
+      "mcpServers": "MCP Servers",
+      "mcpCatalog": "MCP Catalog",
+      "mcpMonitoring": "MCP Monitoring",
+      "agentLearning": "Agent Learning",
+      "settings": "Settings",
+      "apiKeys": "API Keys",
+      "usage": "Usage",
+      "developerDocs": "Developer Docs",
+      "admin": "Admin",
+      "analytics": "Analytics",
+      "auditLog": "Audit Log",
+      "metrics": "Metrics",
+      "alerts": "Alerts",
+      "mcpCatalogAdmin": "MCP Catalog Admin"
+    }
+  },
+  "sidebar": {
+    "newChat": "New chat",
+    "searchPlaceholder": "Search...",
+    "recentChats": "Recent chats",
+    "untitledChat": "Untitled chat",
+    "deleteChat": "Delete chat",
+    "deleteConfirm": "Delete \"{title}\"?\nDeleted chats cannot be recovered.",
+    "deleteFailed": "Failed to delete the chat.",
+    "guest": "Guest",
+    "selfHosted": "Self-hosted",
+    "notLoggedIn": "Not signed in",
+    "logout": "Sign out"
+  },
+  "mobileNav": {
+    "chat": "Chat",
+    "research": "Research",
+    "agent": "Agents",
+    "login": "Sign in",
+    "menu": "Menu",
+    "openMenu": "Full menu",
+    "closeMenu": "Close menu"
+  },
+  "settings": {
+    "languageAuto": "Auto-detect"
+  }
+}

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1,0 +1,61 @@
+{
+  "metadata": {
+    "description": "AIベースのインテリジェントチャットアシスタント"
+  },
+  "nav": {
+    "groups": {
+      "workspace": "ワークスペース",
+      "integrations": "連携",
+      "account": "アカウント",
+      "admin": "管理者"
+    },
+    "items": {
+      "chat": "チャット",
+      "research": "ディープリサーチ",
+      "agentTasks": "エージェントタスク",
+      "customAgents": "カスタムエージェント",
+      "skillLibrary": "スキルライブラリ",
+      "artifacts": "アーティファクト",
+      "history": "履歴",
+      "mcpServers": "MCPサーバー",
+      "mcpCatalog": "MCPカタログ",
+      "mcpMonitoring": "MCPモニタリング",
+      "agentLearning": "エージェント学習",
+      "settings": "設定",
+      "apiKeys": "APIキー",
+      "usage": "使用量",
+      "developerDocs": "開発者ドキュメント",
+      "admin": "管理者",
+      "analytics": "アナリティクス",
+      "auditLog": "監査ログ",
+      "metrics": "メトリクス",
+      "alerts": "アラート",
+      "mcpCatalogAdmin": "MCPカタログ管理"
+    }
+  },
+  "sidebar": {
+    "newChat": "新しいチャット",
+    "searchPlaceholder": "検索...",
+    "recentChats": "最近のチャット",
+    "untitledChat": "無題のチャット",
+    "deleteChat": "チャットを削除",
+    "deleteConfirm": "「{title}」を削除しますか？\n削除したチャットは復元できません。",
+    "deleteFailed": "チャットの削除に失敗しました。",
+    "guest": "ゲスト",
+    "selfHosted": "セルフホスト",
+    "notLoggedIn": "未ログイン",
+    "logout": "ログアウト"
+  },
+  "mobileNav": {
+    "chat": "チャット",
+    "research": "リサーチ",
+    "agent": "エージェント",
+    "login": "ログイン",
+    "menu": "メニュー",
+    "openMenu": "全メニュー",
+    "closeMenu": "メニューを閉じる"
+  },
+  "settings": {
+    "languageAuto": "自動検出"
+  }
+}

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1,0 +1,61 @@
+{
+  "metadata": {
+    "description": "AI 기반 지능형 채팅 어시스턴트"
+  },
+  "nav": {
+    "groups": {
+      "workspace": "워크스페이스",
+      "integrations": "통합",
+      "account": "계정",
+      "admin": "관리자"
+    },
+    "items": {
+      "chat": "채팅",
+      "research": "딥 리서치",
+      "agentTasks": "에이전트 작업",
+      "customAgents": "커스텀 에이전트",
+      "skillLibrary": "스킬 라이브러리",
+      "artifacts": "아티팩트",
+      "history": "히스토리",
+      "mcpServers": "MCP 서버",
+      "mcpCatalog": "MCP 카탈로그",
+      "mcpMonitoring": "MCP 모니터링",
+      "agentLearning": "에이전트 학습",
+      "settings": "설정",
+      "apiKeys": "API 키",
+      "usage": "사용량",
+      "developerDocs": "개발자 문서",
+      "admin": "관리자",
+      "analytics": "애널리틱스",
+      "auditLog": "감사 로그",
+      "metrics": "메트릭",
+      "alerts": "알림",
+      "mcpCatalogAdmin": "MCP 카탈로그 관리"
+    }
+  },
+  "sidebar": {
+    "newChat": "새 대화",
+    "searchPlaceholder": "검색...",
+    "recentChats": "최근 대화",
+    "untitledChat": "제목 없는 대화",
+    "deleteChat": "대화 삭제",
+    "deleteConfirm": "\"{title}\" 대화를 삭제하시겠습니까?\n삭제된 대화는 복구할 수 없습니다.",
+    "deleteFailed": "대화 삭제에 실패했습니다.",
+    "guest": "게스트",
+    "selfHosted": "자가호스팅",
+    "notLoggedIn": "로그인 안 됨",
+    "logout": "로그아웃"
+  },
+  "mobileNav": {
+    "chat": "채팅",
+    "research": "리서치",
+    "agent": "에이전트",
+    "login": "로그인",
+    "menu": "메뉴",
+    "openMenu": "전체 메뉴",
+    "closeMenu": "메뉴 닫기"
+  },
+  "settings": {
+    "languageAuto": "자동 감지"
+  }
+}

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1,0 +1,61 @@
+{
+  "metadata": {
+    "description": "基于AI的智能聊天助手"
+  },
+  "nav": {
+    "groups": {
+      "workspace": "工作区",
+      "integrations": "集成",
+      "account": "账户",
+      "admin": "管理员"
+    },
+    "items": {
+      "chat": "聊天",
+      "research": "深度研究",
+      "agentTasks": "智能体任务",
+      "customAgents": "自定义智能体",
+      "skillLibrary": "技能库",
+      "artifacts": "工件",
+      "history": "历史记录",
+      "mcpServers": "MCP服务器",
+      "mcpCatalog": "MCP目录",
+      "mcpMonitoring": "MCP监控",
+      "agentLearning": "智能体学习",
+      "settings": "设置",
+      "apiKeys": "API密钥",
+      "usage": "使用量",
+      "developerDocs": "开发者文档",
+      "admin": "管理员",
+      "analytics": "分析",
+      "auditLog": "审计日志",
+      "metrics": "指标",
+      "alerts": "告警",
+      "mcpCatalogAdmin": "MCP目录管理"
+    }
+  },
+  "sidebar": {
+    "newChat": "新对话",
+    "searchPlaceholder": "搜索...",
+    "recentChats": "最近对话",
+    "untitledChat": "未命名对话",
+    "deleteChat": "删除对话",
+    "deleteConfirm": "确定删除\"{title}\"吗？\n删除后无法恢复。",
+    "deleteFailed": "删除对话失败。",
+    "guest": "访客",
+    "selfHosted": "自托管",
+    "notLoggedIn": "未登录",
+    "logout": "退出登录"
+  },
+  "mobileNav": {
+    "chat": "聊天",
+    "research": "研究",
+    "agent": "智能体",
+    "login": "登录",
+    "menu": "菜单",
+    "openMenu": "全部菜单",
+    "closeMenu": "关闭菜单"
+  },
+  "settings": {
+    "languageAuto": "自动检测"
+  }
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import createNextIntlPlugin from "next-intl/plugin";
 
 /**
  * 백엔드(Express + WS, 기본 :52416)와의 연동.
@@ -50,4 +51,6 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+// i18n — 요청 설정은 i18n/request.ts (플러그인 기본 경로), locale SoT 는 NEXT_LOCALE 쿠키.
+const withNextIntl = createNextIntlPlugin();
+export default withNextIntl(nextConfig);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "check:i18n": "node scripts/check-i18n-keys.mjs"
   },
   "dependencies": {
     "@openmake/api-client": "1.5.6",
@@ -17,6 +18,7 @@
     "katex": "^0.17.0",
     "lucide-react": "^1.21.0",
     "next": "16.2.9",
+    "next-intl": "^4.13.1",
     "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/apps/web/scripts/check-i18n-keys.mjs
+++ b/apps/web/scripts/check-i18n-keys.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * i18n 키 정합 가드 — messages/ko.json(원본) 대비 나머지 locale 파일의
+ * 키 세트가 완전히 일치하는지 검사한다. 누락/잉여 키가 있으면 exit 1.
+ * 사용: npm run check:i18n (apps/web)
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MESSAGES_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "messages");
+const SOURCE = "ko.json";
+
+function flattenKeys(obj, prefix = "") {
+  return Object.entries(obj).flatMap(([k, v]) =>
+    v && typeof v === "object" ? flattenKeys(v, `${prefix}${k}.`) : [`${prefix}${k}`],
+  );
+}
+
+const files = readdirSync(MESSAGES_DIR).filter((f) => f.endsWith(".json"));
+const sourceKeys = new Set(
+  flattenKeys(JSON.parse(readFileSync(join(MESSAGES_DIR, SOURCE), "utf8"))),
+);
+
+let failed = false;
+for (const file of files) {
+  if (file === SOURCE) continue;
+  const keys = new Set(flattenKeys(JSON.parse(readFileSync(join(MESSAGES_DIR, file), "utf8"))));
+  const missing = [...sourceKeys].filter((k) => !keys.has(k));
+  const extra = [...keys].filter((k) => !sourceKeys.has(k));
+  if (missing.length || extra.length) {
+    failed = true;
+    console.error(`✗ ${file}`);
+    for (const k of missing) console.error(`    missing: ${k}`);
+    for (const k of extra) console.error(`    extra:   ${k}`);
+  } else {
+    console.log(`✓ ${file} (${keys.size} keys)`);
+  }
+}
+
+if (failed) {
+  console.error(`\ni18n key mismatch — ${SOURCE} 기준으로 모든 locale 파일의 키를 맞춰주세요.`);
+  process.exit(1);
+}
+console.log(`i18n keys OK — ${files.length} locales, ${sourceKeys.size} keys each.`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -144,6 +144,7 @@
                 "katex": "^0.17.0",
                 "lucide-react": "^1.21.0",
                 "next": "16.2.9",
+                "next-intl": "^4.13.1",
                 "next-themes": "^0.4.6",
                 "react": "19.2.4",
                 "react-dom": "19.2.4",
@@ -1252,6 +1253,36 @@
                 "@noble/hashes": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@formatjs/fast-memoize": {
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.6.tgz",
+            "integrity": "sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ==",
+            "license": "MIT"
+        },
+        "node_modules/@formatjs/icu-messageformat-parser": {
+            "version": "3.5.12",
+            "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.12.tgz",
+            "integrity": "sha512-YyzzxVgYJ8DELmmkhn0Yr0rUj0dTJFf9Jp628K3S0ysInBWxLVDOS8i3RP91cCp4DMK4WYb4cVMhWA9i4knSJg==",
+            "license": "MIT",
+            "dependencies": {
+                "@formatjs/icu-skeleton-parser": "2.1.10"
+            }
+        },
+        "node_modules/@formatjs/icu-skeleton-parser": {
+            "version": "2.1.10",
+            "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.10.tgz",
+            "integrity": "sha512-XuSva+8ZGawk8VnD5VD6UeH8KarQ/Z022zgjHDoHmlNiAewstXuuzXc0Hk5pGFSdG+nNw5bfJKXqj1ZXHn9yUA==",
+            "license": "MIT"
+        },
+        "node_modules/@formatjs/intl-localematcher": {
+            "version": "0.8.10",
+            "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.10.tgz",
+            "integrity": "sha512-P/IC3qws3jH+1fEs+o0RIFgXKRaQlFehjS5W0FPAqdo6hgzawLl+eD0q0JjheQ3XtoOe5n8WSYfX06KQZI/QJA==",
+            "license": "MIT",
+            "dependencies": {
+                "@formatjs/fast-memoize": "3.1.6"
             }
         },
         "node_modules/@grpc/grpc-js": {
@@ -4075,6 +4106,331 @@
                 "@noble/hashes": "^1.1.5"
             }
         },
+        "node_modules/@parcel/watcher": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+            "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "detect-libc": "^2.0.3",
+                "is-glob": "^4.0.3",
+                "node-addon-api": "^7.0.0",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "@parcel/watcher-android-arm64": "2.5.6",
+                "@parcel/watcher-darwin-arm64": "2.5.6",
+                "@parcel/watcher-darwin-x64": "2.5.6",
+                "@parcel/watcher-freebsd-x64": "2.5.6",
+                "@parcel/watcher-linux-arm-glibc": "2.5.6",
+                "@parcel/watcher-linux-arm-musl": "2.5.6",
+                "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+                "@parcel/watcher-linux-arm64-musl": "2.5.6",
+                "@parcel/watcher-linux-x64-glibc": "2.5.6",
+                "@parcel/watcher-linux-x64-musl": "2.5.6",
+                "@parcel/watcher-win32-arm64": "2.5.6",
+                "@parcel/watcher-win32-ia32": "2.5.6",
+                "@parcel/watcher-win32-x64": "2.5.6"
+            }
+        },
+        "node_modules/@parcel/watcher-android-arm64": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+            "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-darwin-arm64": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+            "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-darwin-x64": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+            "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-freebsd-x64": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+            "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm-glibc": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+            "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+            "cpu": [
+                "arm"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm-musl": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+            "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+            "cpu": [
+                "arm"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm64-glibc": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+            "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm64-musl": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+            "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-x64-glibc": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+            "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-x64-musl": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+            "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-arm64": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+            "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-ia32": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+            "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-x64": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+            "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
             "dev": true,
@@ -4177,6 +4533,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@schummar/icu-type-parser": {
+            "version": "1.21.5",
+            "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+            "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+            "license": "MIT"
+        },
         "node_modules/@sinclair/typebox": {
             "version": "0.34.49",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
@@ -4217,6 +4579,222 @@
             "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
             "license": "MIT"
         },
+        "node_modules/@swc/core-darwin-arm64": {
+            "version": "1.15.43",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.43.tgz",
+            "integrity": "sha512-v1aVuvXdo/BHxJzco9V2xpHrvwWmhfS8t6gziY5wJxd+Z2h8AeJRnAwPD8itCDaGXVBwJ/CaKfxEzTkG0Va0OA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-darwin-x64": {
+            "version": "1.15.43",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.43.tgz",
+            "integrity": "sha512-lp3d4Lamc8dt5huYdGLSR+9hLxmfr1jb0l+4XXG2zPqZwYWRN9R0U2qYoTrggiU2RWW0oV9VbWM3kBnqIc2kdQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm-gnueabihf": {
+            "version": "1.15.43",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.43.tgz",
+            "integrity": "sha512-JWTQQELtsG5GgphDrr/XqqmM2pDN3cZqbMS0Mrg+iTiXL3F74sn/S2IyYE/5u4h2KLkTf9qQ7dXyxsbx7YzkeA==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm64-gnu": {
+            "version": "1.15.43",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.43.tgz",
+            "integrity": "sha512-B4otJRdPWIsmiSBf0uG7Z/+vMWmkufjz5MmYxubwKuZazDW14Zd3symga1N62QR4RT+kEFeHEgsXfZGyn/w0hw==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm64-musl": {
+            "version": "1.15.43",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.43.tgz",
+            "integrity": "sha512-6zB6OnpViBxYy4tgY3v2i6AZY9fwkcHZ032UOwtwUuW1d19sdT07qF0kZe6/3UR1tUaK6jjg2rmVcUIBCEYVjQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-ppc64-gnu": {
+            "version": "1.15.43",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.43.tgz",
+            "integrity": "sha512-coxE1ZWdB3uSDVNoEtYNrRi/1epvckZx9cTJ8ICUxTMTxGk+yvQ/Twacp3ruZSaMPGCriUjP86C37VhaT6nyRg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-s390x-gnu": {
+            "version": "1.15.43",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.43.tgz",
+            "integrity": "sha512-lXfLhs+LpBsD5inuYx+YDH5WsPPBQ95KPUiy8P5wq9ob9xKDZFqwNfU2QW6bGO8NqRO/H9JQomTSt5Yyh+FGfA==",
+            "cpu": [
+                "s390x"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-x64-gnu": {
+            "version": "1.15.43",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.43.tgz",
+            "integrity": "sha512-07XnKwTmKy8TGOZG3D9fRnLWGynxPjwQnZLVmBFbo6F+7vHYzBIOuwXEhemrChBWb6yDNZsVCcMWCPX6FDD2xg==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-x64-musl": {
+            "version": "1.15.43",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.43.tgz",
+            "integrity": "sha512-TJc+bsSIaBh+hZvZ5GRtW/K1bw66TJ9vsUwvVIsZdiWxU5ObLwZvfcnZ3UpgVfMnFibRes9uriJrQNBHEEogRQ==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-arm64-msvc": {
+            "version": "1.15.43",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.43.tgz",
+            "integrity": "sha512-jfd7s2/bUQYkOHLs+LWQNKZdmDa8+sufKLllhpWAhVQ2GDCwsHe3vR/j+OSiItZNtkzFuaawa3+SAKz9y5gYfw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-ia32-msvc": {
+            "version": "1.15.43",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.43.tgz",
+            "integrity": "sha512-rLAE8JvucqEW1ZGohxPQrQWPBQeJG4+ypKbWfdlU/qmKScvCkxf9/Jxnzki1dkUQCQ7P5Enp13RlvqOlvx/32g==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-x64-msvc": {
+            "version": "1.15.43",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.43.tgz",
+            "integrity": "sha512-h8MLDHZcfIukwQWj03rIJZx1I0E81AYj2X7J/nGErG4nz+QAv6G1Z+peotvinL3lqpbo32tLYSMFo32/ySzxKg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/counter": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+            "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+            "license": "Apache-2.0"
+        },
         "node_modules/@swc/helpers": {
             "version": "0.5.15",
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -4224,6 +4802,15 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.8.0"
+            }
+        },
+        "node_modules/@swc/types": {
+            "version": "0.1.27",
+            "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
+            "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@swc/counter": "^0.1.3"
             }
         },
         "node_modules/@tailwindcss/node": {
@@ -7254,7 +7841,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
             "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-            "devOptional": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=8"
@@ -9254,6 +9840,21 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/icu-minify": {
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.13.1.tgz",
+            "integrity": "sha512-nFYW2im0WJ3RUVZwabd71J8QTZRtkK1xxZBY7klg7a6KS/os17LZSj9q1VhbRSnk3S8Mv2I7F1izr/aEJ6cUsw==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/amannn"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@formatjs/icu-messageformat-parser": "^3.4.0"
+            }
+        },
         "node_modules/idb-keyval": {
             "version": "6.2.5",
             "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.5.tgz",
@@ -9424,6 +10025,16 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/intl-messageformat": {
+            "version": "11.2.9",
+            "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.9.tgz",
+            "integrity": "sha512-cGzymZerpDhVXRKjKLgXKda9gI29TU2o88L7gwNMHp3WZVxA/0c5tX52udXbW9JklDApolvMXZG6Dhhdz5eirA==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@formatjs/fast-memoize": "3.1.6",
+                "@formatjs/icu-messageformat-parser": "3.5.12"
             }
         },
         "node_modules/ioredis": {
@@ -9683,7 +10294,6 @@
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -9744,7 +10354,6 @@
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -12921,6 +13530,83 @@
                 }
             }
         },
+        "node_modules/next-intl": {
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.13.1.tgz",
+            "integrity": "sha512-aS8KTA+nNhSNJJBlIhxgvU135WzoObwzFwav4wTDti/Gmhxqe0fs/Q343igo8Z7HGqPB/xgmoagwySZAlHmIfA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/amannn"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@formatjs/intl-localematcher": "^0.8.1",
+                "@parcel/watcher": "^2.4.1",
+                "@swc/core": "^1.15.2",
+                "icu-minify": "^4.13.1",
+                "negotiator": "^1.0.0",
+                "next-intl-swc-plugin-extractor": "^4.13.1",
+                "po-parser": "^2.1.1",
+                "use-intl": "^4.13.1"
+            },
+            "peerDependencies": {
+                "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/next-intl-swc-plugin-extractor": {
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.13.1.tgz",
+            "integrity": "sha512-RhlH2DR1ViEXzcX7G3tDXAvzNrBL2Ph54Hq/q/9oP9eXQV/okh3UQpA/lx2k9U5Ck83CZOSgH0eFTNi5U+zyXw==",
+            "license": "MIT"
+        },
+        "node_modules/next-intl/node_modules/@swc/core": {
+            "version": "1.15.43",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.43.tgz",
+            "integrity": "sha512-1CuKjFkPxIgGdeHVuNbkxmBxkcbdc08u0aiI43pFq6yY1tTVKmXT9hFEooyyKs/sJ3xf1GPHyEwTtk9Xl8dvQw==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@swc/counter": "^0.1.3",
+                "@swc/types": "^0.1.27"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/swc"
+            },
+            "optionalDependencies": {
+                "@swc/core-darwin-arm64": "1.15.43",
+                "@swc/core-darwin-x64": "1.15.43",
+                "@swc/core-linux-arm-gnueabihf": "1.15.43",
+                "@swc/core-linux-arm64-gnu": "1.15.43",
+                "@swc/core-linux-arm64-musl": "1.15.43",
+                "@swc/core-linux-ppc64-gnu": "1.15.43",
+                "@swc/core-linux-s390x-gnu": "1.15.43",
+                "@swc/core-linux-x64-gnu": "1.15.43",
+                "@swc/core-linux-x64-musl": "1.15.43",
+                "@swc/core-win32-arm64-msvc": "1.15.43",
+                "@swc/core-win32-ia32-msvc": "1.15.43",
+                "@swc/core-win32-x64-msvc": "1.15.43"
+            },
+            "peerDependencies": {
+                "@swc/helpers": ">=0.5.17"
+            },
+            "peerDependenciesMeta": {
+                "@swc/helpers": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/next-themes": {
             "version": "0.4.6",
             "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -12958,6 +13644,12 @@
             "engines": {
                 "node": "^10 || ^12 || >=14"
             }
+        },
+        "node_modules/node-addon-api": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+            "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+            "license": "MIT"
         },
         "node_modules/node-exports-info": {
             "version": "1.6.0",
@@ -13917,6 +14609,12 @@
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
+        },
+        "node_modules/po-parser": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/po-parser/-/po-parser-2.1.1.tgz",
+            "integrity": "sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==",
+            "license": "MIT"
         },
         "node_modules/possible-typed-array-names": {
             "version": "1.1.0",
@@ -16390,6 +17088,27 @@
             "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/use-intl": {
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.13.1.tgz",
+            "integrity": "sha512-UU5C3zAC7yVg3m7rq5C8VF5J5jhAfvS19Wi9bPNCB9xB7jQYBsUcrqfdxs4Mxl9XR3x6BDB5K++iAw7/rcm3gg==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/amannn"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@formatjs/fast-memoize": "^3.1.0",
+                "@schummar/icu-type-parser": "1.21.5",
+                "icu-minify": "^4.13.1",
+                "intl-messageformat": "^11.1.0"
+            },
+            "peerDependencies": {
+                "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
             }
         },
         "node_modules/util-deprecate": {


### PR DESCRIPTION
## 개요

전체 UI 문자열 i18n 시리즈의 **PR 1 (인프라 + 전체 메뉴)**. next-intl 4.13.1 (Next 16 공식 지원, peerDep `^16.0.0`) 을 **URL 라우팅 없는 NEXT_LOCALE 쿠키 모드**로 도입하고, 사이드바/모바일 탭바의 전체 메뉴와 채팅 페이지 브레드크럼을 ko/en/ja/zh 4개 언어로 전환.

## 아키텍처

- **locale SoT = `NEXT_LOCALE` 쿠키 단일**: 서버(`i18n/request.ts`)가 읽어 렌더, 클라이언트(설정 페이지)가 쓰고 `router.refresh()`. Zustand 중복 저장 없음.
- locale 결정: 쿠키 → `Accept-Language` 협상 → `ko` 기본. 쿠키 없음 = "자동 감지".
- URL `[locale]` 세그먼트·proxy 파일 불필요 (인증 워크스페이스라 SEO 무관). 활성 locale 메시지만 서버에서 로드.
- **AI 응답 언어는 별개 축 유지** — 백엔드 메시지 내용 기반 감지 (`use-chat-socket.ts` 무변경). 설정 페이지 언어 필드를 "UI 표시 언어"로 재정의 (기존은 미배선 TODO placeholder 였음).

## 변경 사항

- `i18n/config.ts`(공용 상수) + `i18n/request.ts`(locale 결정·메시지 로드) + `next.config.ts` 플러그인 배선
- `messages/{ko,en,ja,zh}.json` — nav/sidebar/mobileNav/metadata/settings 네임스페이스, ko 가 원본
- `lib/nav.ts` `label`→`labelKey`·`title`→`titleKey` 키 전환, `sidebar.tsx`·`mobile-sidebar.tsx` 하드코딩 문자열 전부 `t()` 전환 (confirm/alert/aria-label 포함)
- `app/layout.tsx` — `<html lang>` 동적화, `generateMetadata`, `NextIntlClientProvider`
- 설정 페이지 언어 드롭다운 배선 — 쿠키 read 는 `useSyncExternalStore`(lint-clean, hydration-safe), 변경 즉시 적용
- `scripts/check-i18n-keys.mjs` — 4개 locale 키 세트 정합 가드 (`npm run check:i18n`, 현재 45키 × 4 통과)

## 검증

- `tsc --noEmit` 0 에러, 변경 파일 eslint 신규 에러 0 (잔존 4건은 기존 코드의 것)
- 격리 워크트리에서 `next build` 성공 (운영 `.next` 무접촉)
- 라이브 스모크 (`next start` + curl/Playwright, 실재 admin 토큰 로그인):
  - 쿠키 ko/en/ja/zh 각각 `<html lang>`·메뉴 라벨·metadata 전환 확인
  - Accept-Language `ja`→ja, `en-US`→en, 없음→ko 협상 확인
  - 설정 드롭다운 日本語 선택 → 전체 메뉴 즉시 전환 + 새로고침 후 유지, "자동 감지" 복귀 → 쿠키 삭제 확인
  - ja/zh CJK 글리프 시스템 폰트 폴백 렌더 정상 (스크린샷 확인)

## 후속 (별도 PR)

- PR 2~5: 23개 페이지 본문 문자열 추출 (이 PR 에서는 메뉴 외 본문은 한국어 유지 — 깨지지 않음)
- PR 6: `toLocaleString("ko-KR")` 하드코딩 12곳+ locale 파라미터화
- 운영 반영 시 `npm run build:frontend-next` + pm2 재기동 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)