### PR TITLE
feat(web): 채팅 코어 i18n — composer/메시지/아티팩트/히스토리 4개 언어 (PR 2/6)

### DIFF
--- a/apps/web/app/(workspace)/artifacts/page.tsx
+++ b/apps/web/app/(workspace)/artifacts/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Boxes, Share2, ExternalLink, Lock, Globe, Link2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { PageHeader, Card, Badge } from "@/components/ui/primitives";
 import { ApiClient, ApiError } from "@/lib/api-client";
@@ -21,13 +22,14 @@ interface GalleryItem {
   icon: string | null;
 }
 
-const VIS_META: Record<string, { label: string; icon: typeof Lock }> = {
-  private: { label: "비공개", icon: Lock },
-  authenticated: { label: "인증 공개", icon: Globe },
-  link: { label: "링크 공개", icon: Link2 },
+const VIS_META: Record<string, { labelKey: string; icon: typeof Lock }> = {
+  private: { labelKey: "vis.private", icon: Lock },
+  authenticated: { labelKey: "vis.authenticated", icon: Globe },
+  link: { labelKey: "vis.link", icon: Link2 },
 };
 
 export default function ArtifactsGalleryPage() {
+  const t = useTranslations("artifacts.page");
   const [items, setItems] = useState<GalleryItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [share, setShare] = useState<{ sessionId: string; artifactId: string; icon: string | null } | null>(null);
@@ -53,25 +55,25 @@ export default function ArtifactsGalleryPage() {
       const res = await ApiClient.get<ApiSuccess<{ url: string }>>(`/api/artifacts/pub/${it.publicationId}/open`);
       window.open(res.data.url, "_blank", "noopener");
     } catch (e) {
-      alert(e instanceof ApiError ? e.message : "뷰어를 열 수 없습니다");
+      alert(e instanceof ApiError ? e.message : t("viewerOpenFailed"));
     }
   };
 
   return (
     <>
-      <PageHeader title="아티팩트" description="생성한 산출물을 모아보고, 별도 오리진 뷰어로 공유합니다." />
+      <PageHeader title={t("title")} description={t("description")} />
 
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
         {loading ? (
           <div className="grid place-items-center py-24 text-center">
             <Boxes className="mb-3 h-8 w-8 animate-pulse text-faint" />
-            <p className="text-sm text-muted">불러오는 중...</p>
+            <p className="text-sm text-muted">{t("loading")}</p>
           </div>
         ) : items.length === 0 ? (
           <div className="grid place-items-center py-24 text-center">
             <Boxes className="mb-3 h-8 w-8 text-faint" />
-            <p className="text-sm font-medium text-fg-2">아티팩트가 없습니다</p>
-            <p className="mt-1 text-sm text-muted">채팅에서 코드·HTML·차트 등 산출물을 만들면 여기에 모입니다.</p>
+            <p className="text-sm font-medium text-fg-2">{t("emptyTitle")}</p>
+            <p className="mt-1 text-sm text-muted">{t("emptyDesc")}</p>
           </div>
         ) : (
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
@@ -94,17 +96,17 @@ export default function ArtifactsGalleryPage() {
                   <div className="flex items-center justify-between">
                     {it.published && vis && VisIcon ? (
                       <span className="flex items-center gap-1 text-[11px] text-muted">
-                        <VisIcon className="h-3 w-3" /> {vis.label}
+                        <VisIcon className="h-3 w-3" /> {t(vis.labelKey)}
                       </span>
                     ) : (
-                      <span className="text-[11px] text-faint">미공유</span>
+                      <span className="text-[11px] text-faint">{t("notShared")}</span>
                     )}
                     <div className="flex gap-1">
                       {it.published && (
                         <button
                           type="button"
                           onClick={() => open(it)}
-                          aria-label="뷰어 열기"
+                          aria-label={t("openViewer")}
                           className="grid h-7 w-7 place-items-center rounded text-muted transition hover:bg-surface-3 hover:text-fg"
                         >
                           <ExternalLink className="h-4 w-4" />
@@ -113,7 +115,7 @@ export default function ArtifactsGalleryPage() {
                       <button
                         type="button"
                         onClick={() => setShare({ sessionId: it.sessionId, artifactId: it.artifactId, icon: it.icon })}
-                        aria-label="공유"
+                        aria-label={t("share")}
                         className="grid h-7 w-7 place-items-center rounded text-muted transition hover:bg-surface-3 hover:text-fg"
                       >
                         <Share2 className="h-4 w-4" />

--- a/apps/web/app/(workspace)/history/page.tsx
+++ b/apps/web/app/(workspace)/history/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { Clock, Search, MessageSquare, Trash2 } from "lucide-react";
@@ -37,6 +38,8 @@ interface ApiConversation {
 
 type ConversationsResponse = ApiSuccess<{ sessions: ApiConversation[] }>;
 
+type TFn = ReturnType<typeof useTranslations>;
+
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 function bucketByDate(iso?: string): DateGroup {
@@ -60,111 +63,73 @@ function formatTime(iso?: string): string {
   return d.toLocaleTimeString("ko-KR", { hour: "numeric", minute: "2-digit" });
 }
 
-function mapConversation(c: ApiConversation): Session {
+function mapConversation(c: ApiConversation, t: TFn): Session {
   const ts = c.updatedAt || c.createdAt;
   return {
     id: c.id,
-    title: c.title?.trim() || "제목 없는 대화",
-    preview: `메시지 ${c.messageCount ?? 0}개`,
+    title: c.title?.trim() || t("untitledConversation"),
+    preview: t("messageCount", { count: c.messageCount ?? 0 }),
     time: formatTime(ts),
     model: c.model || "Auto",
     group: bucketByDate(ts),
   };
 }
 
-/* ── 목업 데이터 — 미인증/네트워크 실패 시 폴백 ─────────────── */
-const SESSIONS: Session[] = [
-  {
-    id: "c1",
-    title: "Next.js 16 App Router 마이그레이션",
-    preview: "기존 pages 라우터에서 app 라우터로 옮길 때 주의할 점은...",
-    time: "오후 2:14",
-    model: "Pro",
-    group: "today",
-  },
-  {
-    id: "c2",
-    title: "PostgreSQL 인덱스 튜닝",
-    preview: "복합 인덱스 순서가 쿼리 플랜에 미치는 영향을 설명해줘",
-    time: "오전 11:02",
-    model: "Default",
-    group: "today",
-  },
-  {
-    id: "c3",
-    title: "마케팅 캠페인 카피 브레인스토밍",
-    preview: "20대 타겟의 SNS 광고 카피 5개 변형을 만들어줘",
-    time: "오후 6:47",
-    model: "Fast",
-    group: "yesterday",
-  },
-  {
-    id: "c4",
-    title: "리서치 보고서 구조 잡기",
-    preview: "엔터프라이즈 LLM 도입 보고서의 목차를 제안해줘",
-    time: "오후 3:20",
-    model: "Think",
-    group: "yesterday",
-  },
-  {
-    id: "c5",
-    title: "TypeScript 제네릭 타입 가드",
-    preview: "Discriminated union 을 안전하게 좁히는 방법은?",
-    time: "월요일",
-    model: "Code",
-    group: "week",
-  },
-  {
-    id: "c6",
-    title: "이미지 분석 프롬프트",
-    preview: "첨부한 차트에서 주요 트렌드를 읽어줘",
-    time: "일요일",
-    model: "Vision",
-    group: "week",
-  },
+/* ── 목업 데이터 — 미인증/네트워크 실패 시 폴백 (라벨은 t() 로 렌더 시 해석) ─── */
+const MOCK_META: Array<{ id: string; model: string; group: DateGroup }> = [
+  { id: "c1", model: "Pro", group: "today" },
+  { id: "c2", model: "Default", group: "today" },
+  { id: "c3", model: "Fast", group: "yesterday" },
+  { id: "c4", model: "Think", group: "yesterday" },
+  { id: "c5", model: "Code", group: "week" },
+  { id: "c6", model: "Vision", group: "week" },
 ];
-
-const GROUP_LABEL: Record<DateGroup, string> = {
-  today: "오늘",
-  yesterday: "어제",
-  week: "이번 주",
-  older: "이전",
-};
 
 const GROUP_ORDER: DateGroup[] = ["today", "yesterday", "week", "older"];
 
 export default function HistoryPage() {
+  const t = useTranslations("history");
   const router = useRouter();
   const queryClient = useQueryClient();
   const { setChatHistory, setCurrentSessionId, setArtifacts, clearChat, auth } = useAppStore();
   const currentSessionId = useAppStore((s) => s.currentSessionId);
-  const [sessions, setSessions] = useState<Session[]>(SESSIONS);
+  const mockSessions = useMemo<Session[]>(
+    () =>
+      MOCK_META.map((m) => ({
+        ...m,
+        title: t(`mock.${m.id}.title`),
+        preview: t(`mock.${m.id}.preview`),
+        time: t(`mock.${m.id}.time`),
+      })),
+    [t],
+  );
+  const [sessions, setSessions] = useState<Session[]>(mockSessions);
   const [loading, setLoading] = useState(true);
   const [query, setQuery] = useState("");
 
   // 세션 단건 삭제 — 백엔드 DELETE /api/chat/sessions/:sid (소유자/익명 소유 검증).
   const deleteSession = async (s: Session) => {
-    if (!window.confirm(`"${s.title}" 대화를 삭제하시겠습니까?\n삭제된 대화는 복구할 수 없습니다.`)) return;
+    if (!window.confirm(t("deleteConfirm", { title: s.title }))) return;
     try {
       await ApiClient.del(appendAnonSessionId(`/api/chat/sessions/${s.id}`));
       setSessions((prev) => prev.filter((x) => x.id !== s.id));
       if (s.id === currentSessionId) clearChat();
       void queryClient.invalidateQueries({ queryKey: ["conversations"] });
     } catch {
-      window.alert("대화 삭제에 실패했습니다.");
+      window.alert(t("deleteError"));
     }
   };
 
   // 전체 삭제 — 백엔드 DELETE /api/chat/sessions (requireAuth, 로그인 사용자 전용).
   const deleteAll = async () => {
-    if (!window.confirm(`대화 기록 ${sessions.length}개를 모두 삭제하시겠습니까?\n삭제된 대화는 복구할 수 없습니다.`)) return;
+    if (!window.confirm(t("deleteAllConfirm", { count: sessions.length }))) return;
     try {
       await ApiClient.del("/api/chat/sessions");
       setSessions([]);
       clearChat();
       void queryClient.invalidateQueries({ queryKey: ["conversations"] });
     } catch {
-      window.alert("전체 삭제에 실패했습니다.");
+      window.alert(t("deleteAllError"));
     }
   };
 
@@ -198,7 +163,7 @@ export default function HistoryPage() {
         if (cancelled) return;
         const list = res?.data?.sessions ?? [];
         // 실제 데이터가 오면 우선 표시 (빈 배열도 실제 상태로 존중)
-        setSessions(list.map(mapConversation));
+        setSessions(list.map((c) => mapConversation(c, t)));
       } catch {
         // 401·네트워크 실패: 목업 폴백 유지 (초기 state 그대로)
       } finally {
@@ -208,7 +173,8 @@ export default function HistoryPage() {
     return () => {
       cancelled = true;
     };
-  }, []);
+    // locale 변경(t) 시 라벨 재매핑 위해 재조회
+  }, [t]);
 
   const grouped = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -217,7 +183,6 @@ export default function HistoryPage() {
       : sessions;
     return GROUP_ORDER.map((g) => ({
       group: g,
-      label: GROUP_LABEL[g],
       items: filtered.filter((s) => s.group === g),
     })).filter((g) => g.items.length > 0);
   }, [sessions, query]);
@@ -227,8 +192,8 @@ export default function HistoryPage() {
   return (
     <>
       <PageHeader
-        title="대화 히스토리"
-        description="이전 대화를 검색하고 이어서 진행할 수 있습니다."
+        title={t("title")}
+        description={t("description")}
       />
 
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
@@ -239,7 +204,7 @@ export default function HistoryPage() {
             <input
               value={query}
               onChange={(e) => setQuery(e.target.value)}
-              placeholder="대화 제목 검색..."
+              placeholder={t("searchPlaceholder")}
               className="h-9 w-full bg-transparent text-sm text-fg outline-none placeholder:text-muted"
             />
           </div>
@@ -250,7 +215,7 @@ export default function HistoryPage() {
               className="flex h-9 flex-shrink-0 items-center gap-1.5 rounded-md border border-border-strong bg-surface-2 px-3 text-sm text-muted transition hover:border-danger/40 hover:text-danger"
             >
               <Trash2 className="h-4 w-4" />
-              전체 삭제
+              {t("deleteAllButton")}
             </button>
           )}
         </div>
@@ -258,16 +223,14 @@ export default function HistoryPage() {
         {loading ? (
           <div className="grid place-items-center py-24 text-center">
             <Clock className="mb-3 h-8 w-8 animate-pulse text-faint" />
-            <p className="text-sm text-muted">불러오는 중...</p>
+            <p className="text-sm text-muted">{t("loading")}</p>
           </div>
         ) : isEmpty ? (
           <div className="grid place-items-center py-24 text-center">
             <Clock className="mb-3 h-8 w-8 text-faint" />
-            <p className="text-sm font-medium text-fg-2">대화 기록이 없습니다</p>
+            <p className="text-sm font-medium text-fg-2">{t("emptyState.title")}</p>
             <p className="mt-1 text-sm text-muted">
-              {query
-                ? "검색 결과가 없습니다."
-                : "새 대화를 시작하면 여기에 표시됩니다."}
+              {query ? t("emptyState.noResults") : t("emptyState.hint")}
             </p>
           </div>
         ) : (
@@ -275,7 +238,7 @@ export default function HistoryPage() {
             {grouped.map((g) => (
               <div key={g.group}>
                 <h2 className="mb-2 font-mono text-xs uppercase tracking-wide text-faint">
-                  {g.label}
+                  {t(`group.${g.group}`)}
                 </h2>
                 <div className="space-y-2">
                   {g.items.map((s) => (
@@ -307,7 +270,7 @@ export default function HistoryPage() {
                       </div>
                       <button
                         type="button"
-                        aria-label="대화 삭제"
+                        aria-label={t("deleteAria")}
                         onClick={(e) => {
                           e.stopPropagation();
                           void deleteSession(s);

--- a/apps/web/components/chat/artifact-frame.tsx
+++ b/apps/web/components/chat/artifact-frame.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useTranslations } from "next-intl";
+
 /**
  * 아티팩트 라이브 렌더용 샌드박스 iframe.
  *
@@ -8,9 +10,10 @@
  *      접근할 수 없다. (둘을 동시에 주면 샌드박스가 무력화되어 세션 탈취가 가능해진다.)
  */
 export function ArtifactFrame({ srcDoc, title }: { srcDoc: string; title?: string }) {
+  const t = useTranslations("artifacts");
   return (
     <iframe
-      title={title ?? "아티팩트 미리보기"}
+      title={title ?? t("framePreviewTitle")}
       sandbox="allow-scripts allow-popups allow-modals"
       srcDoc={srcDoc}
       className="h-full w-full border-0 bg-white"

--- a/apps/web/components/chat/artifact-panel.tsx
+++ b/apps/web/components/chat/artifact-panel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { X, Code2, Eye, Copy, Check, Play, Loader2, Download, Share2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { useAppStore } from "@/lib/store";
 import type { Artifact } from "@/lib/store";
 import { ApiClient, ApiError } from "@/lib/api-client";
@@ -38,6 +39,7 @@ interface ExecResult {
 const RUNNABLE_LANGS = new Set(["python", "py", "python3", "javascript", "js", "node", "nodejs"]);
 
 function CodeArtifactView({ artifact }: { artifact: Artifact }) {
+  const t = useTranslations("artifacts");
   const lang = (artifact.lang ?? "").toLowerCase().trim();
   const runnable = RUNNABLE_LANGS.has(lang);
   const [running, setRunning] = useState(false);
@@ -56,13 +58,13 @@ function CodeArtifactView({ artifact }: { artifact: Artifact }) {
       setResult(res.data);
     } catch (e) {
       if (e instanceof ApiError) {
-        if (e.status === 503) setError("코드 실행 기능이 비활성화되어 있습니다.");
-        else if (e.status === 429) setError("실행 요청이 너무 많습니다. 잠시 후 다시 시도하세요.");
-        else if (e.status === 400) setError("지원하지 않는 언어입니다.");
-        else if (e.status === 413) setError("코드가 너무 큽니다.");
+        if (e.status === 503) setError(t("exec.disabled"));
+        else if (e.status === 429) setError(t("exec.rateLimited"));
+        else if (e.status === 400) setError(t("exec.unsupportedLang"));
+        else if (e.status === 413) setError(t("exec.tooLarge"));
         else setError(e.message);
       } else {
-        setError("실행에 실패했습니다.");
+        setError(t("exec.failed"));
       }
     } finally {
       setRunning(false);
@@ -80,9 +82,9 @@ function CodeArtifactView({ artifact }: { artifact: Artifact }) {
             className="flex items-center gap-1.5 rounded-md bg-accent px-2.5 py-1 text-xs font-medium text-accent-fg transition hover:bg-accent-hover disabled:opacity-60"
           >
             {running ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
-            {running ? "실행 중…" : "실행"}
+            {running ? t("run.running") : t("run.run")}
           </button>
-          <span className="text-[11px] text-faint">샌드박스(네트워크 차단) · {lang}</span>
+          <span className="text-[11px] text-faint">{t("run.sandbox", { lang })}</span>
         </div>
       )}
       <div className="min-h-0 flex-1 overflow-auto px-3">
@@ -95,11 +97,11 @@ function CodeArtifactView({ artifact }: { artifact: Artifact }) {
         {result && (
           <div className="mb-3 rounded-md border border-border bg-surface-2">
             <div className="flex items-center gap-2 border-b border-border px-3 py-1.5 text-[11px] text-muted">
-              <span>출력</span>
+              <span>{t("output.title")}</span>
               <span className="font-mono">exit={result.exitCode ?? "—"}</span>
               <span className="font-mono">{result.durationMs}ms</span>
-              {result.timedOut && <span className="text-danger">시간 초과</span>}
-              {result.truncated && <span className="text-faint">잘림</span>}
+              {result.timedOut && <span className="text-danger">{t("output.timedOut")}</span>}
+              {result.truncated && <span className="text-faint">{t("output.truncated")}</span>}
             </div>
             {result.stdout && (
               <pre className="overflow-x-auto px-3 py-2 text-xs text-fg-2">{result.stdout}</pre>
@@ -110,7 +112,7 @@ function CodeArtifactView({ artifact }: { artifact: Artifact }) {
               </pre>
             )}
             {!result.stdout && !result.stderr && (
-              <p className="px-3 py-2 text-xs text-faint">(출력 없음)</p>
+              <p className="px-3 py-2 text-xs text-faint">{t("output.empty")}</p>
             )}
           </div>
         )}
@@ -188,6 +190,7 @@ function ArtifactBody({ artifact, view }: { artifact: Artifact; view: "preview" 
 }
 
 export function ArtifactPanel() {
+  const t = useTranslations("artifacts");
   const artifacts = useAppStore((s) => s.artifacts);
   const activeArtifactId = useAppStore((s) => s.activeArtifactId);
   const open = useAppStore((s) => s.artifactPanelOpen);
@@ -305,17 +308,17 @@ export function ArtifactPanel() {
           {shown.lang ? `·${shown.lang}` : ""}
         </span>
         <span className="min-w-0 flex-1 truncate text-sm font-medium text-fg">{shown.title}</span>
-        {active.streaming && <span className="text-[11px] text-faint">생성 중…</span>}
+        {active.streaming && <span className="text-[11px] text-faint">{t("generating")}</span>}
         {versions.length > 1 && shownVersion != null && (
           <select
             value={shownVersion}
             onChange={(e) => selectVersion(Number(e.target.value))}
-            aria-label="버전 선택"
+            aria-label={t("versionSelect")}
             className="rounded border border-border bg-surface-2 px-1.5 py-1 text-[11px] text-muted"
           >
             {versions.map((v) => (
               <option key={v.version} value={v.version}>
-                v{v.version}{v.version === latestVersion ? " (최신)" : ""}
+                v{v.version}{v.version === latestVersion ? ` (${t("latest")})` : ""}
               </option>
             ))}
           </select>
@@ -324,7 +327,7 @@ export function ArtifactPanel() {
           <button
             type="button"
             onClick={() => setView((v) => (v === "preview" ? "code" : "preview"))}
-            aria-label={view === "preview" ? "코드 보기" : "미리보기"}
+            aria-label={view === "preview" ? t("viewCode") : t("viewPreview")}
             className="grid h-7 w-7 place-items-center rounded text-muted transition hover:bg-surface-3 hover:text-fg"
           >
             {view === "preview" ? <Code2 className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
@@ -333,7 +336,7 @@ export function ArtifactPanel() {
         <button
           type="button"
           onClick={() => downloadArtifact({ title: shown.title, kind: shown.kind, lang: shown.lang, content: shown.content })}
-          aria-label="다운로드"
+          aria-label={t("download")}
           className="grid h-7 w-7 place-items-center rounded text-muted transition hover:bg-surface-3 hover:text-fg"
         >
           <Download className="h-4 w-4" />
@@ -342,7 +345,7 @@ export function ArtifactPanel() {
           <button
             type="button"
             onClick={() => setShareOpen(true)}
-            aria-label="공유"
+            aria-label={t("shareLabel")}
             className="grid h-7 w-7 place-items-center rounded text-muted transition hover:bg-surface-3 hover:text-fg"
           >
             <Share2 className="h-4 w-4" />
@@ -351,7 +354,7 @@ export function ArtifactPanel() {
         <button
           type="button"
           onClick={copy}
-          aria-label="복사"
+          aria-label={t("copy")}
           className="grid h-7 w-7 place-items-center rounded text-muted transition hover:bg-surface-3 hover:text-fg"
         >
           {copied ? <Check className="h-4 w-4 text-accent" /> : <Copy className="h-4 w-4" />}
@@ -359,7 +362,7 @@ export function ArtifactPanel() {
         <button
           type="button"
           onClick={() => setArtifactPanelOpen(false)}
-          aria-label="패널 닫기"
+          aria-label={t("closePanel")}
           className="grid h-7 w-7 place-items-center rounded text-muted transition hover:bg-surface-3 hover:text-fg"
         >
           <X className="h-4 w-4" />

--- a/apps/web/components/chat/artifact-share-modal.tsx
+++ b/apps/web/components/chat/artifact-share-modal.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { X, Globe, Lock, Link2, Check, Copy, Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { ApiClient, ApiError } from "@/lib/api-client";
 import type { ApiSuccess } from "@openmake/shared-types";
 
@@ -15,10 +16,10 @@ interface PublishResp {
   viewerEnabled: boolean;
 }
 
-const OPTIONS: { value: Visibility; label: string; desc: string; icon: typeof Globe }[] = [
-  { value: "private", label: "비공개", desc: "나만 볼 수 있음", icon: Lock },
-  { value: "authenticated", label: "인증 사용자 전체", desc: "로그인한 모든 사용자에게 공개", icon: Globe },
-  { value: "link", label: "링크 공유", desc: "링크를 가진 누구나 (비로그인 포함)", icon: Link2 },
+const OPTIONS: { value: Visibility; icon: typeof Globe }[] = [
+  { value: "private", icon: Lock },
+  { value: "authenticated", icon: Globe },
+  { value: "link", icon: Link2 },
 ];
 
 /**
@@ -36,6 +37,7 @@ export function ArtifactShareModal({
   defaultIcon?: string | null;
   onCloseAction: () => void;
 }) {
+  const t = useTranslations("artifacts.share");
   const onClose = onCloseAction;
   const [visibility, setVisibility] = useState<Visibility>("link");
   const [icon, setIcon] = useState(defaultIcon ?? "");
@@ -59,7 +61,7 @@ export function ArtifactShareModal({
       const data = res.data;
       setPublished(true);
       if (!data.viewerEnabled) {
-        setErr("뷰어가 비활성화되어 있습니다(ARTIFACT_VIEWER_ENABLED). 관리자에게 문의하세요.");
+        setErr(t("viewerDisabled"));
         return;
       }
       if (data.shareUrl) {
@@ -72,7 +74,7 @@ export function ArtifactShareModal({
         setUrl(open.data.url);
       }
     } catch (e) {
-      setErr(e instanceof ApiError ? e.message : "공유에 실패했습니다");
+      setErr(e instanceof ApiError ? e.message : t("publishFailed"));
     } finally {
       setBusy(false);
     }
@@ -86,7 +88,7 @@ export function ArtifactShareModal({
       setPublished(false);
       setUrl(null);
     } catch (e) {
-      setErr(e instanceof ApiError ? e.message : "공유 중단에 실패했습니다");
+      setErr(e instanceof ApiError ? e.message : t("unpublishFailed"));
     } finally {
       setBusy(false);
     }
@@ -116,8 +118,8 @@ export function ArtifactShareModal({
         aria-modal="true"
       >
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-base font-semibold text-fg">아티팩트 공유</h2>
-          <button type="button" onClick={onClose} aria-label="닫기" className="grid h-7 w-7 place-items-center rounded text-muted hover:bg-surface-3 hover:text-fg">
+          <h2 className="text-base font-semibold text-fg">{t("title")}</h2>
+          <button type="button" onClick={onClose} aria-label={t("close")} className="grid h-7 w-7 place-items-center rounded text-muted hover:bg-surface-3 hover:text-fg">
             <X className="h-4 w-4" />
           </button>
         </div>
@@ -141,8 +143,8 @@ export function ArtifactShareModal({
                 />
                 <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted" />
                 <span className="min-w-0">
-                  <span className="block text-sm font-medium text-fg">{opt.label}</span>
-                  <span className="block text-xs text-muted">{opt.desc}</span>
+                  <span className="block text-sm font-medium text-fg">{t(`visibility.${opt.value}.label`)}</span>
+                  <span className="block text-xs text-muted">{t(`visibility.${opt.value}.desc`)}</span>
                 </span>
               </label>
             );
@@ -150,7 +152,7 @@ export function ArtifactShareModal({
         </fieldset>
 
         <div className="mt-3 flex items-center gap-2">
-          <label className="text-xs text-muted" htmlFor="art-icon">아이콘(이모지)</label>
+          <label className="text-xs text-muted" htmlFor="art-icon">{t("iconLabel")}</label>
           <input
             id="art-icon"
             value={icon}
@@ -165,7 +167,7 @@ export function ArtifactShareModal({
         {url && (
           <div className="mt-3 flex items-center gap-2 rounded-lg border border-border bg-surface-2 p-2">
             <input readOnly value={url} className="min-w-0 flex-1 bg-transparent text-xs text-fg outline-none" />
-            <button type="button" onClick={copy} className="grid h-7 w-7 shrink-0 place-items-center rounded text-muted hover:bg-surface-3 hover:text-fg" aria-label="링크 복사">
+            <button type="button" onClick={copy} className="grid h-7 w-7 shrink-0 place-items-center rounded text-muted hover:bg-surface-3 hover:text-fg" aria-label={t("copyLink")}>
               {copied ? <Check className="h-4 w-4 text-accent" /> : <Copy className="h-4 w-4" />}
             </button>
           </div>
@@ -174,7 +176,7 @@ export function ArtifactShareModal({
         <div className="mt-5 flex justify-between gap-2">
           {published ? (
             <button type="button" onClick={unpublish} disabled={busy} className="rounded-lg px-3 py-2 text-sm text-danger transition hover:bg-danger/10 disabled:opacity-50">
-              공유 중단
+              {t("unpublish")}
             </button>
           ) : <span />}
           <button
@@ -184,7 +186,7 @@ export function ArtifactShareModal({
             className="flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-fg transition hover:opacity-90 disabled:opacity-50"
           >
             {busy && <Loader2 className="h-4 w-4 animate-spin" />}
-            {published ? "공유 설정 갱신" : "공유하기"}
+            {published ? t("updateSettings") : t("publish")}
           </button>
         </div>
       </div>

--- a/apps/web/components/chat/artifact-toggle.tsx
+++ b/apps/web/components/chat/artifact-toggle.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { FileCode2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { useAppStore } from "@/lib/store";
 
 /** 아티팩트가 있고 패널이 닫혀 있을 때만 노출 — 클릭 시 패널 재오픈. */
 export function ArtifactToggle() {
+  const t = useTranslations("artifacts");
   const count = useAppStore((s) => s.artifacts.length);
   const open = useAppStore((s) => s.artifactPanelOpen);
   const setOpen = useAppStore((s) => s.setArtifactPanelOpen);
@@ -17,7 +19,7 @@ export function ArtifactToggle() {
       className="flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-surface-2 px-2.5 py-1 text-xs font-medium text-fg-2 transition hover:bg-surface-3 hover:text-fg"
     >
       <FileCode2 className="h-3.5 w-3.5" />
-      아티팩트 {count}
+      {t("artifactCount", { count })}
     </button>
   );
 }

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -19,6 +19,7 @@ import {
   X,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import type { WsAttachedFile } from "@openmake/shared-types";
 import { useAppStore } from "@/lib/store";
 import { useChatSocket } from "@/lib/use-chat-socket";
@@ -86,6 +87,7 @@ function readFileBase64(file: File): Promise<string> {
 }
 
 export function Composer() {
+  const t = useTranslations("composer");
   const { sendChat, abort, startAgentTask, sendStructured } = useChatSocket();
   const router = useRouter();
   const [text, setText] = useState("");
@@ -191,8 +193,8 @@ export function Composer() {
   const [slashDebounced, setSlashDebounced] = useState("");
   useEffect(() => {
     if (!slashCandidate) return;
-    const t = setTimeout(() => setSlashDebounced(slashQuery), 150);
-    return () => clearTimeout(t);
+    const timer = setTimeout(() => setSlashDebounced(slashQuery), 150);
+    return () => clearTimeout(timer);
   }, [slashQuery, slashCandidate]);
 
   const { data: slashSkillsData, isLoading: slashLoading } = useQuery({
@@ -303,16 +305,16 @@ export function Composer() {
   }, [modeSheetOpen]);
 
   const TOGGLES = [
-    { key: "discussionMode" as const, on: discussionMode, icon: MessagesSquare, label: "토론" },
-    { key: "thinkingEnabled" as const, on: thinkingEnabled, icon: Brain, label: "Thinking" },
-    { key: "deepResearchMode" as const, on: deepResearchMode, icon: Telescope, label: "딥 리서치" },
-    { key: "webSearchEnabled" as const, on: webSearchEnabled, icon: Globe, label: "웹" },
-    { key: "agentTaskMode" as const, on: agentTaskMode, icon: Sparkles, label: "에이전트" },
-    { key: "imageMode" as const, on: imageMode, icon: ImageIcon, label: "이미지" },
-    { key: "artifactMode" as const, on: artifactMode, icon: FileCode2, label: "아티팩트" },
-    { key: "structuredMode" as const, on: structuredMode, icon: LayoutList, label: "구조화 답변" },
+    { key: "discussionMode" as const, on: discussionMode, icon: MessagesSquare, label: t("toggle.discussion") },
+    { key: "thinkingEnabled" as const, on: thinkingEnabled, icon: Brain, label: t("toggle.thinking") },
+    { key: "deepResearchMode" as const, on: deepResearchMode, icon: Telescope, label: t("toggle.deepResearch") },
+    { key: "webSearchEnabled" as const, on: webSearchEnabled, icon: Globe, label: t("toggle.web") },
+    { key: "agentTaskMode" as const, on: agentTaskMode, icon: Sparkles, label: t("toggle.agent") },
+    { key: "imageMode" as const, on: imageMode, icon: ImageIcon, label: t("toggle.image") },
+    { key: "artifactMode" as const, on: artifactMode, icon: FileCode2, label: t("toggle.artifact") },
+    { key: "structuredMode" as const, on: structuredMode, icon: LayoutList, label: t("toggle.structured") },
   ];
-  const activeModeCount = TOGGLES.filter((t) => t.on).length;
+  const activeModeCount = TOGGLES.filter((m) => m.on).length;
 
   return (
     <div className="mx-auto w-full max-w-3xl px-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
@@ -341,7 +343,7 @@ export function Composer() {
           <div className="pointer-events-none absolute inset-0 z-50 grid place-items-center rounded-xl border-2 border-dashed border-accent bg-surface/85 backdrop-blur-sm">
             <div className="flex items-center gap-2 text-sm font-medium text-accent">
               <Paperclip className="h-4 w-4" />
-              여기에 파일을 놓아 첨부
+              {t("dropToAttach")}
             </div>
           </div>
         )}
@@ -357,21 +359,21 @@ export function Composer() {
             <div className="absolute bottom-full left-0 right-0 z-40 mb-2 rounded-xl border border-border bg-surface-2 p-1.5 shadow-lg">
               <div className="mx-auto mb-1.5 h-1 w-9 rounded-full bg-border-strong" aria-hidden />
               <p className="px-2 pb-1 text-[11px] font-medium uppercase tracking-wide text-faint">
-                모드
+                {t("modeHeading")}
               </p>
-              {TOGGLES.map((t) => (
+              {TOGGLES.map((m) => (
                 <button
-                  key={t.key}
+                  key={m.key}
                   type="button"
-                  onClick={() => toggle(t.key)}
+                  onClick={() => toggle(m.key)}
                   className={cn(
                     "flex min-h-[44px] w-full items-center gap-3 rounded-lg px-3 text-sm transition",
-                    t.on ? "text-accent" : "text-fg-2 hover:bg-surface-3",
+                    m.on ? "text-accent" : "text-fg-2 hover:bg-surface-3",
                   )}
                 >
-                  <t.icon className="h-[18px] w-[18px] shrink-0" />
-                  <span className="flex-1 text-left">{t.label}</span>
-                  {t.on && <Check className="h-4 w-4 shrink-0 text-accent" />}
+                  <m.icon className="h-[18px] w-[18px] shrink-0" />
+                  <span className="flex-1 text-left">{m.label}</span>
+                  {m.on && <Check className="h-4 w-4 shrink-0 text-accent" />}
                 </button>
               ))}
             </div>
@@ -384,7 +386,7 @@ export function Composer() {
             type="button"
             onClick={() => setModeSheetOpen((v) => !v)}
             aria-expanded={modeSheetOpen}
-            aria-label="모드 선택"
+            aria-label={t("modeSelect")}
             className={cn(
               "inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition",
               activeModeCount > 0
@@ -393,7 +395,7 @@ export function Composer() {
             )}
           >
             <SlidersHorizontal className="h-3.5 w-3.5" />
-            도구
+            {t("toolsButton")}
             {activeModeCount > 0 && (
               <span className="grid h-4 min-w-4 place-items-center rounded-full bg-accent px-1 text-[10px] font-bold text-accent-fg">
                 {activeModeCount}
@@ -401,16 +403,16 @@ export function Composer() {
             )}
           </button>
 
-          {TOGGLES.filter((t) => t.on).map((t) => (
+          {TOGGLES.filter((m) => m.on).map((m) => (
             <button
-              key={t.key}
+              key={m.key}
               type="button"
-              onClick={() => toggle(t.key)}
-              title={`${t.label} 끄기`}
+              onClick={() => toggle(m.key)}
+              title={t("toggleOff", { label: m.label })}
               className="inline-flex shrink-0 items-center gap-1 rounded-full border border-accent bg-accent-soft px-2.5 py-1 text-xs font-medium text-accent transition hover:opacity-80"
             >
-              <t.icon className="h-3.5 w-3.5" />
-              {t.label}
+              <m.icon className="h-3.5 w-3.5" />
+              {m.label}
               <X className="h-3 w-3 opacity-70" />
             </button>
           ))}
@@ -430,7 +432,7 @@ export function Composer() {
                 <img src={img.dataUrl} alt={img.name} className="h-full w-full object-cover" />
                 <button
                   onClick={() => removeImage(img.id)}
-                  aria-label={`${img.name} 첨부 제거`}
+                  aria-label={t("removeAttachment", { name: img.name })}
                   className="absolute right-0 top-0 grid h-4 w-4 place-items-center rounded-bl bg-bg/70 text-muted hover:text-fg"
                 >
                   <X className="h-3 w-3" />
@@ -440,7 +442,7 @@ export function Composer() {
             {files.map((f) => (
               <span
                 key={f.id}
-                title={f.truncated ? `${f.name} (길이 초과로 일부만 첨부)` : f.name}
+                title={f.truncated ? t("attachTruncated", { name: f.name }) : f.name}
                 className="inline-flex max-w-[12rem] items-center gap-1.5 rounded-md border border-border bg-surface-2 px-2 py-1 text-xs text-fg"
               >
                 <Paperclip className="h-3 w-3 shrink-0 text-muted" />
@@ -448,7 +450,7 @@ export function Composer() {
                 {f.truncated && <span className="shrink-0 text-faint">✂</span>}
                 <button
                   onClick={() => removeFile(f.id)}
-                  aria-label={`${f.name} 첨부 제거`}
+                  aria-label={t("removeAttachment", { name: f.name })}
                   className="shrink-0 text-muted hover:text-fg"
                 >
                   <X className="h-3 w-3" />
@@ -521,7 +523,7 @@ export function Composer() {
             }
           }}
           rows={1}
-          placeholder="메시지를 입력하거나 / 로 스킬을 호출하세요..."
+          placeholder={t("placeholder")}
           className="block w-full resize-none bg-transparent px-4 pt-2.5 text-sm text-fg outline-none placeholder:text-muted"
         />
 
@@ -541,8 +543,8 @@ export function Composer() {
           <button
             onClick={() => fileInputRef.current?.click()}
             className="grid h-8 w-8 place-items-center rounded-md text-muted transition hover:bg-surface-2 hover:text-fg disabled:opacity-40"
-            title="파일 첨부 (드래그앤드롭 지원 · 모든 형식)"
-            aria-label="파일 첨부"
+            title={t("attachFile")}
+            aria-label={t("attachFileLabel")}
           >
             <Paperclip className="h-4 w-4" />
           </button>
@@ -550,7 +552,7 @@ export function Composer() {
           <button
             onClick={cycleStyle}
             className="rounded-md px-2 py-1.5 text-xs font-medium capitalize text-muted hover:bg-surface-2 hover:text-fg"
-            title="응답 스타일"
+            title={t("responseStyle")}
           >
             {style}
           </button>
@@ -558,7 +560,7 @@ export function Composer() {
           {isGenerating ? (
             <button
               onClick={abort}
-              aria-label="중단"
+              aria-label={t("stop")}
               className="ml-auto grid h-8 w-8 place-items-center rounded-md bg-surface-3 text-fg transition hover:bg-border-strong"
             >
               <Square className="h-3.5 w-3.5 fill-current" />
@@ -567,7 +569,7 @@ export function Composer() {
             <button
               onClick={submit}
               disabled={!text.trim() && files.length === 0 && images.length === 0}
-              aria-label="전송"
+              aria-label={t("send")}
               className="ml-auto grid h-8 w-8 place-items-center rounded-md bg-accent text-accent-fg transition hover:bg-accent-hover disabled:opacity-40"
             >
               <ArrowUp className="h-4 w-4" />
@@ -576,7 +578,7 @@ export function Composer() {
         </div>
       </div>
       <p className="mt-2 text-center text-[11px] text-faint">
-        OpenMake 는 실수할 수 있습니다. 중요한 정보는 확인하세요.
+        {t("disclaimer")}
       </p>
     </div>
   );

--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import Image from "next/image";
+import { useTranslations } from "next-intl";
 import { MessagesSquare, Telescope, Brain, Sparkles, FileCode2, ChevronRight, LoaderCircle, Pause, CircleCheck, CircleX, Download, FileText, ShieldCheck } from "lucide-react";
 import { useAppStore, type PendingApproval, type AgentTaskState } from "@/lib/store";
 import { ApiClient } from "@/lib/api-client";
@@ -13,6 +14,7 @@ const ARTIFACT_PLACEHOLDER = /\[\[artifact:([^\]]+)\]\]/g;
 
 /** 에이전트 작업 승인 대기 — 채팅 인라인 승인/거절 버튼 (paused task). */
 function InlineApprovals({ approvals }: { approvals: PendingApproval[] }) {
+  const t = useTranslations("chat");
   const setChatHistory = useAppStore((s) => s.setChatHistory);
   const [busy, setBusy] = useState<string | null>(null);
   if (approvals.length === 0) return null;
@@ -30,7 +32,7 @@ function InlineApprovals({ approvals }: { approvals: PendingApproval[] }) {
         ),
       );
     } catch (e) {
-      alert("처리 실패: " + (e instanceof Error ? e.message : "오류"));
+      alert(t("approvals.processFailed", { error: e instanceof Error ? e.message : t("approvals.errorFallback") }));
     } finally {
       setBusy(null);
     }
@@ -39,7 +41,7 @@ function InlineApprovals({ approvals }: { approvals: PendingApproval[] }) {
   return (
     <div className="mt-1 space-y-2 rounded-md border border-warning-soft bg-warning-soft/50 p-2.5">
       <p className="flex items-center gap-1.5 text-xs font-semibold text-fg-2">
-        <ShieldCheck className="h-3.5 w-3.5 text-warning" /> 도구 실행 승인 필요
+        <ShieldCheck className="h-3.5 w-3.5 text-warning" /> {t("approvals.title")}
       </p>
       {approvals.map((a) => (
         <div key={a.approvalId} className="flex items-center justify-between gap-2 rounded-md border border-border bg-surface-1 p-2">
@@ -52,12 +54,12 @@ function InlineApprovals({ approvals }: { approvals: PendingApproval[] }) {
               disabled={busy === a.approvalId}
               onClick={() => decide(a, "reject")}
               className="rounded-md border border-border px-2.5 py-1 text-xs text-muted hover:bg-surface-2 disabled:opacity-50"
-            >거절</button>
+            >{t("approvals.reject")}</button>
             <button
               disabled={busy === a.approvalId}
               onClick={() => decide(a, "approve")}
               className="rounded-md bg-accent px-2.5 py-1 text-xs font-medium text-accent-fg hover:opacity-90 disabled:opacity-50"
-            >승인</button>
+            >{t("approvals.approve")}</button>
           </div>
         </div>
       ))}
@@ -67,10 +69,11 @@ function InlineApprovals({ approvals }: { approvals: PendingApproval[] }) {
 
 /** 영속화된 `[[artifact:id]]` placeholder 를 클릭 가능한 아티팩트 칩으로 렌더. */
 function ArtifactChip({ id }: { id: string }) {
+  const t = useTranslations("chat");
   const artifacts = useAppStore((s) => s.artifacts);
   const setActiveArtifact = useAppStore((s) => s.setActiveArtifact);
   const setArtifactPanelOpen = useAppStore((s) => s.setArtifactPanelOpen);
-  const title = artifacts.find((a) => a.id === id)?.title ?? "아티팩트";
+  const title = artifacts.find((a) => a.id === id)?.title ?? t("artifactFallback");
   return (
     <button
       type="button"
@@ -88,10 +91,11 @@ function ArtifactChip({ id }: { id: string }) {
 
 /** 스트리밍 중 길어지는 미완성 코드 펜스 → "아티팩트 생성 중" 표시 (완료 시 칩/패널로 대체). */
 function ArtifactBuilding() {
+  const t = useTranslations("chat");
   return (
     <span className="my-1 inline-flex items-center gap-1.5 rounded-md border border-border bg-surface-2 px-2.5 py-1.5 text-sm font-medium text-fg-2">
       <FileCode2 className="h-4 w-4 animate-pulse text-accent" />
-      아티팩트 생성 중…
+      {t("artifactBuilding")}
     </span>
   );
 }
@@ -151,11 +155,12 @@ function ThinkingIndicator({
   agent: { name: string; emoji?: string } | null;
   skills: string[];
 }) {
+  const t = useTranslations("chat");
   const label = agent
-    ? `${agent.emoji ? agent.emoji + " " : ""}${agent.name}가 분석 중`
+    ? t("thinking.agentAnalyzing", { agent: `${agent.emoji ? agent.emoji + " " : ""}${agent.name}` })
     : skills.length > 0
-      ? `${skills.join(", ")} 적용 중`
-      : "분석 중";
+      ? t("thinking.skillsApplying", { skills: skills.join(", ") })
+      : t("thinking.analyzing");
   return (
     <div className="flex gap-3">
       <Image src="/logo.png" alt="OpenMake" width={28} height={28} className="mt-0.5 h-7 w-7 shrink-0 rounded-md object-contain" />
@@ -175,21 +180,21 @@ function ThinkingIndicator({
 }
 
 const QUICK_STARTS = [
-  { icon: MessagesSquare, label: "요약하기", prompt: "다음 내용을 요약해 줘:\n\n" },
-  { icon: Telescope, label: "리서치", prompt: "다음 주제를 깊이 리서치해 줘:\n\n" },
-  { icon: Brain, label: "단계별 분석", prompt: "다음 문제를 단계별로 분석해 줘:\n\n" },
-  { icon: Sparkles, label: "브레인스토밍", prompt: "다음에 대해 브레인스토밍하자:\n\n" },
+  { icon: MessagesSquare, labelKey: "quickStarts.summarize.label", promptKey: "quickStarts.summarize.prompt" },
+  { icon: Telescope, labelKey: "quickStarts.research.label", promptKey: "quickStarts.research.prompt" },
+  { icon: Brain, labelKey: "quickStarts.analyze.label", promptKey: "quickStarts.analyze.prompt" },
+  { icon: Sparkles, labelKey: "quickStarts.brainstorm.label", promptKey: "quickStarts.brainstorm.prompt" },
 ];
 
 /** 에이전트 작업 인라인 카드 — 상태별 벡터 아이콘 + 진행바 + 결과/아티팩트/산출물 + 승인 (이모지 없음). */
 type TaskTone = "run" | "pause" | "ok" | "fail";
-const TASK_STATUS: Record<string, { Icon: typeof Pause; spin: boolean; tone: TaskTone; badge: string }> = {
-  pending: { Icon: LoaderCircle, spin: true, tone: "run", badge: "대기" },
-  running: { Icon: LoaderCircle, spin: true, tone: "run", badge: "실행 중" },
-  paused: { Icon: Pause, spin: false, tone: "pause", badge: "승인 대기" },
-  completed: { Icon: CircleCheck, spin: false, tone: "ok", badge: "완료" },
-  failed: { Icon: CircleX, spin: false, tone: "fail", badge: "실패" },
-  cancelled: { Icon: CircleX, spin: false, tone: "fail", badge: "취소됨" },
+const TASK_STATUS: Record<string, { Icon: typeof Pause; spin: boolean; tone: TaskTone; badgeKey: string }> = {
+  pending: { Icon: LoaderCircle, spin: true, tone: "run", badgeKey: "status.pending" },
+  running: { Icon: LoaderCircle, spin: true, tone: "run", badgeKey: "status.running" },
+  paused: { Icon: Pause, spin: false, tone: "pause", badgeKey: "status.paused" },
+  completed: { Icon: CircleCheck, spin: false, tone: "ok", badgeKey: "status.completed" },
+  failed: { Icon: CircleX, spin: false, tone: "fail", badgeKey: "status.failed" },
+  cancelled: { Icon: CircleX, spin: false, tone: "fail", badgeKey: "status.cancelled" },
 };
 const TONE_ICON: Record<TaskTone, string> = {
   run: "bg-accent-soft text-accent",
@@ -205,6 +210,7 @@ const TONE_BADGE: Record<TaskTone, string> = {
 };
 
 function AgentTaskCard({ task, approvals, taskId }: { task: AgentTaskState; approvals?: PendingApproval[]; taskId?: string }) {
+  const t = useTranslations("chat");
   const cfg = TASK_STATUS[task.status] ?? TASK_STATUS.running;
   const pct = Math.max(0, Math.min(100, Math.round(task.progress || 0)));
   const Icon = cfg.Icon;
@@ -215,21 +221,21 @@ function AgentTaskCard({ task, approvals, taskId }: { task: AgentTaskState; appr
         <span className={cn("grid h-6 w-6 shrink-0 place-items-center rounded-md", TONE_ICON[cfg.tone])}>
           <Icon className={cn("h-3.5 w-3.5", cfg.spin && "animate-spin")} />
         </span>
-        <span className="text-[13px] font-semibold tracking-tight text-fg">에이전트 작업</span>
+        <span className="text-[13px] font-semibold tracking-tight text-fg">{t("agentTask.title")}</span>
         <span className={cn("ml-auto rounded-full px-2 py-0.5 font-mono text-[11px] font-semibold tabular-nums", TONE_BADGE[cfg.tone])}>
-          {cfg.badge}{cfg.tone !== "ok" && task.currentTurn > 0 ? ` · 턴 ${task.currentTurn}` : ""}
+          {t(cfg.badgeKey)}{cfg.tone !== "ok" && task.currentTurn > 0 ? ` · ${t("agentTask.turn", { turn: task.currentTurn })}` : ""}
         </span>
       </div>
       <div className="flex flex-col gap-2.5 px-3.5 py-3">
         {task.goal && (
-          <p className="text-xs text-muted"><span className="font-semibold text-fg-2">목표</span>&nbsp; {task.goal}</p>
+          <p className="text-xs text-muted"><span className="font-semibold text-fg-2">{t("agentTask.goal")}</span>&nbsp; {task.goal}</p>
         )}
         {showProgress && (
           <div className="flex items-center gap-2.5">
             <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-surface-3">
               <div className="h-full rounded-full bg-accent transition-all" style={{ width: `${pct}%` }} />
             </div>
-            <span className="shrink-0 font-mono text-[11px] tabular-nums text-faint">{pct}% · 턴 {task.currentTurn ?? 0}</span>
+            <span className="shrink-0 font-mono text-[11px] tabular-nums text-faint">{pct}% · {t("agentTask.turn", { turn: task.currentTurn ?? 0 })}</span>
           </div>
         )}
         {task.result && (task.status === "completed" || task.status === "failed") && (
@@ -247,7 +253,7 @@ function AgentTaskCard({ task, approvals, taskId }: { task: AgentTaskState; appr
         {task.files && task.files.length > 0 && (
           <div>
             <div className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold text-muted">
-              <Download className="h-3 w-3" /> 산출물
+              <Download className="h-3 w-3" /> {t("agentTask.outputs")}
             </div>
             <div className="flex flex-wrap gap-2">
               {task.files.map((f) => (
@@ -271,6 +277,7 @@ function AgentTaskCard({ task, approvals, taskId }: { task: AgentTaskState; appr
 
 /** 딥리서치 진행 배너 — 스트리밍 중 단계/진행/루프를 라이브 표시. */
 function ResearchProgressBanner() {
+  const t = useTranslations("chat");
   const rp = useAppStore((s) => s.researchProgress);
   if (!rp) return null;
   const filled = Math.round(rp.progress / 10);
@@ -282,9 +289,9 @@ function ResearchProgressBanner() {
       <div className="min-w-0 flex-1 rounded-lg border border-border bg-surface-2/60 p-3">
         <div className="mb-1 flex items-center gap-2 text-xs font-medium text-fg-2">
           <LoaderCircle className="h-3.5 w-3.5 animate-spin text-accent" />
-          딥 리서치 진행 중
+          {t("research.inProgress")}
           {rp.totalLoops > 0 && (
-            <span className="text-faint">· 루프 {rp.currentLoop}/{rp.totalLoops}</span>
+            <span className="text-faint">· {t("research.loop", { current: rp.currentLoop, total: rp.totalLoops })}</span>
           )}
         </div>
         {rp.message && <p className="mb-1.5 text-xs text-muted">{rp.message}</p>}
@@ -300,6 +307,7 @@ function ResearchProgressBanner() {
 }
 
 export function MessageList() {
+  const t = useTranslations("chat");
   const chatHistory = useAppStore((s) => s.chatHistory);
   const setInputDraft = useAppStore((s) => s.setInputDraft);
   const isGenerating = useAppStore((s) => s.isGenerating);
@@ -327,21 +335,22 @@ export function MessageList() {
           height={56}
           className="h-14 w-14 rounded-2xl object-contain"
         />
-        <h2 className="mt-5 text-2xl font-bold text-fg">무엇을 도와드릴까요?</h2>
+        <h2 className="mt-5 text-2xl font-bold text-fg">{t("emptyState.title")}</h2>
         <p className="mt-2 max-w-md text-sm text-muted">
-          멀티모델 오케스트레이션 · MCP 도구 · 딥 리서치 · 자율 에이전트.
-          아래에 질문을 입력하거나 <span className="font-mono text-accent">/</span> 로 스킬을 호출하세요.
+          {t.rich("emptyState.description", {
+            slash: (chunks) => <span className="font-mono text-accent">{chunks}</span>,
+          })}
         </p>
 
         <div className="mt-7 grid w-full max-w-md grid-cols-2 gap-2.5">
           {QUICK_STARTS.map((q) => (
             <button
-              key={q.label}
-              onClick={() => setInputDraft(q.prompt)}
+              key={q.labelKey}
+              onClick={() => setInputDraft(t(q.promptKey))}
               className="flex items-center gap-2.5 rounded-xl border border-border bg-surface px-3.5 py-3 text-left text-sm font-medium text-fg transition hover:border-border-strong hover:bg-surface-2"
             >
               <q.icon className="h-4 w-4 shrink-0 text-accent" />
-              <span className="truncate">{q.label}</span>
+              <span className="truncate">{t(q.labelKey)}</span>
             </button>
           ))}
         </div>
@@ -374,7 +383,7 @@ export function MessageList() {
                   <summary className="flex cursor-pointer select-none items-center gap-1.5 px-3 py-1.5 font-medium text-muted list-none [&::-webkit-details-marker]:hidden">
                     <ChevronRight className="h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-90" />
                     <Brain className="h-3.5 w-3.5 text-accent" />
-                    생각 과정
+                    {t("reasoningLabel")}
                   </summary>
                   <div className="whitespace-pre-wrap px-3 pb-2.5 pt-1 leading-relaxed text-muted">
                     {m.reasoning}

--- a/apps/web/components/chat/slash-skill-menu.tsx
+++ b/apps/web/components/chat/slash-skill-menu.tsx
@@ -2,6 +2,7 @@
 
 import { Fragment, useEffect, useRef } from "react";
 import { Sparkles, ArrowRight } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import { skillCategoryLabel, skillSlug, type SkillSummary } from "@/lib/skills-api";
 
@@ -41,6 +42,7 @@ export function SlashSkillMenu({
   onHover,
   onViewAll,
 }: SlashSkillMenuProps) {
+  const t = useTranslations("composer");
   const listRef = useRef<HTMLDivElement>(null);
   const viewAllIndex = skills.length;
 
@@ -55,12 +57,12 @@ export function SlashSkillMenu({
   return (
     <div className="absolute bottom-full left-0 right-0 z-40 mb-2 flex flex-col overflow-hidden rounded-xl border border-border bg-surface-2 shadow-lg">
       <p className="shrink-0 border-b border-border px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-faint">
-        스킬 호출
+        {t("slashMenu.heading")}
       </p>
 
       {skills.length === 0 ? (
         <p className="px-3 py-3 text-sm text-muted">
-          {loading ? "스킬을 불러오는 중…" : "일치하는 스킬이 없습니다"}
+          {loading ? t("slashMenu.loading") : t("slashMenu.noResults")}
         </p>
       ) : (
         <div ref={listRef} className="max-h-72 overflow-y-auto p-1">
@@ -129,7 +131,7 @@ export function SlashSkillMenu({
           activeIndex === viewAllIndex ? "bg-surface-3 text-fg" : "text-muted hover:bg-surface-3 hover:text-fg",
         )}
       >
-        <span>스킬 라이브러리에서 전체 보기</span>
+        <span>{t("slashMenu.viewAll")}</span>
         <ArrowRight className="h-3.5 w-3.5 shrink-0" />
       </button>
     </div>

--- a/apps/web/components/chat/structured-answer.tsx
+++ b/apps/web/components/chat/structured-answer.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import { AlertTriangle, CheckCircle2, ListChecks } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { StructuredAnswerData } from "@/lib/store";
 import { Markdown } from "./markdown";
 import { cn } from "@/lib/utils";
 
-const CONFIDENCE_LABEL: Record<StructuredAnswerData["confidence"], string> = {
-  high: "확신 높음",
-  medium: "확신 보통",
-  low: "확신 낮음",
+const CONFIDENCE_KEY: Record<StructuredAnswerData["confidence"], string> = {
+  high: "structured.confidence.high",
+  medium: "structured.confidence.medium",
+  low: "structured.confidence.low",
 };
 
 const CONFIDENCE_STYLE: Record<StructuredAnswerData["confidence"], string> = {
@@ -55,6 +56,7 @@ function StructuredTable({ headers, rows }: { headers: string[]; rows: string[][
  * 결론을 먼저, 그 다음 요약·섹션(+표)·주의할 점·다음 실행 순으로 항상 일정한 구조로 표시한다.
  */
 export function StructuredAnswer({ data }: { data: StructuredAnswerData }) {
+  const t = useTranslations("chat");
   return (
     <div className="space-y-3">
       {/* 제목 + confidence 배지 */}
@@ -66,13 +68,13 @@ export function StructuredAnswer({ data }: { data: StructuredAnswerData }) {
             CONFIDENCE_STYLE[data.confidence],
           )}
         >
-          {CONFIDENCE_LABEL[data.confidence]}
+          {t(CONFIDENCE_KEY[data.confidence])}
         </span>
       </div>
 
       {/* 결론 — 강조 카드 (가장 먼저) */}
       <div className="rounded-lg border border-accent bg-accent-soft px-3.5 py-3">
-        <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-accent">결론</p>
+        <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-accent">{t("structured.conclusion")}</p>
         <div className="text-sm leading-relaxed text-fg">
           <Markdown content={data.conclusion} />
         </div>
@@ -111,7 +113,7 @@ export function StructuredAnswer({ data }: { data: StructuredAnswerData }) {
       {data.risks?.length ? (
         <div className="rounded-lg border border-border bg-surface-2 px-3.5 py-2.5">
           <p className="mb-1.5 flex items-center gap-1.5 text-xs font-semibold text-fg-2">
-            <AlertTriangle className="h-3.5 w-3.5 text-amber-500" /> 주의할 점
+            <AlertTriangle className="h-3.5 w-3.5 text-amber-500" /> {t("structured.risks")}
           </p>
           <ul className="ml-4 list-disc space-y-0.5 text-sm text-fg-2 marker:text-amber-500">
             {data.risks.map((r, i) => (
@@ -125,7 +127,7 @@ export function StructuredAnswer({ data }: { data: StructuredAnswerData }) {
       {data.action_items?.length ? (
         <div className="rounded-lg border border-border bg-surface-2 px-3.5 py-2.5">
           <p className="mb-1.5 flex items-center gap-1.5 text-xs font-semibold text-fg-2">
-            <ListChecks className="h-3.5 w-3.5 text-accent" /> 다음 실행
+            <ListChecks className="h-3.5 w-3.5 text-accent" /> {t("structured.actionItems")}
           </p>
           <ul className="space-y-1 text-sm text-fg-2">
             {data.action_items.map((a, i) => (

--- a/apps/web/components/theme-toggle.tsx
+++ b/apps/web/components/theme-toggle.tsx
@@ -3,8 +3,10 @@
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 import { Moon, Sun } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 export function ThemeToggle({ className }: { className?: string }) {
+  const t = useTranslations("sidebar");
   const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
@@ -12,7 +14,7 @@ export function ThemeToggle({ className }: { className?: string }) {
   return (
     <button
       type="button"
-      aria-label="테마 전환"
+      aria-label={t("themeToggle")}
       onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
       className={
         "inline-flex h-9 w-9 items-center justify-center rounded-md text-muted transition hover:bg-surface-2 hover:text-fg " +

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import type { WsChatRequest, WsServerEvent, WsAttachedFile } from "@openmake/shared-types";
 import { useAppStore, type StructuredAnswerData, type PendingApproval, type AgentTaskState } from "./store";
 import { ApiClient } from "./api-client";
@@ -30,6 +31,14 @@ function resolveWsUrl(): string {
 }
 
 export function useChatSocket() {
+  const t = useTranslations("chatSocket");
+  // 콜백들이 stale deps(useCallback([]) 등)로 메모이즈되어 t 가 클로저에 갇히므로
+  // ref 로 최신 t 를 참조한다(렌더 중 ref 쓰기 금지 규칙이라 effect 에서 갱신).
+  const tRef = useRef(t);
+  useEffect(() => {
+    tRef.current = t;
+  });
+
   const wsRef = useRef<WebSocket | null>(null);
   const [connected, setConnected] = useState(false);
   const reconnectRef = useRef(0);
@@ -94,7 +103,9 @@ export function useChatSocket() {
         case "error":
           appendMessage({
             role: "system",
-            content: `오류: ${data.message ?? "알 수 없는 오류"}`,
+            content: tRef.current("error", {
+              message: data.message ?? tRef.current("unknownError"),
+            }),
           });
           setStreaming(false);
           setResearchProgress(null);
@@ -281,7 +292,7 @@ export function useChatSocket() {
           { goal },
         );
         const taskId = created?.data?.task?.id;
-        if (!taskId) throw new Error("작업 생성 응답에 taskId 가 없습니다");
+        if (!taskId) throw new Error(tRef.current("taskIdMissing"));
         // 진행상황 카드 — agent_task_progress 이벤트로 taskId 로 식별해 라이브 업데이트.
         appendMessage({
           role: "assistant",
@@ -293,7 +304,9 @@ export function useChatSocket() {
       } catch (e) {
         appendMessage({
           role: "assistant",
-          content: `에이전트 작업을 시작하지 못했습니다: ${e instanceof Error ? e.message : String(e)}`,
+          content: tRef.current("agentTaskStartFailed", {
+            message: e instanceof Error ? e.message : String(e),
+          }),
         });
       }
     },
@@ -341,8 +354,10 @@ export function useChatSocket() {
         appendMessage({
           role: "assistant",
           content: aborted
-            ? "_(구조화 답변 생성을 중단했습니다.)_"
-            : `구조화 답변을 생성하지 못했습니다: ${e instanceof Error ? e.message : String(e)}`,
+            ? tRef.current("structuredAborted")
+            : tRef.current("structuredFailed", {
+                message: e instanceof Error ? e.message : String(e),
+              }),
         });
       } finally {
         structuredAbortRef.current = null;

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -44,7 +44,8 @@
     "guest": "Guest",
     "selfHosted": "Self-hosted",
     "notLoggedIn": "Not signed in",
-    "logout": "Sign out"
+    "logout": "Sign out",
+    "themeToggle": "Toggle theme"
   },
   "mobileNav": {
     "chat": "Chat",
@@ -57,5 +58,242 @@
   },
   "settings": {
     "languageAuto": "Auto-detect"
+  },
+  "composer": {
+    "dropToAttach": "Drop files here to attach",
+    "modeHeading": "Modes",
+    "modeSelect": "Select mode",
+    "toolsButton": "Tools",
+    "toggleOff": "Turn off {label}",
+    "removeAttachment": "Remove {name}",
+    "attachTruncated": "{name} (partially attached, length exceeded)",
+    "placeholder": "Type a message or invoke a skill with /...",
+    "attachFile": "Attach files (drag & drop supported · any format)",
+    "attachFileLabel": "Attach files",
+    "responseStyle": "Response style",
+    "stop": "Stop",
+    "send": "Send",
+    "disclaimer": "OpenMake can make mistakes. Verify important information.",
+    "toggle": {
+      "discussion": "Discussion",
+      "thinking": "Thinking",
+      "deepResearch": "Deep Research",
+      "web": "Web",
+      "agent": "Agent",
+      "image": "Image",
+      "artifact": "Artifact",
+      "structured": "Structured"
+    },
+    "slashMenu": {
+      "heading": "Invoke skill",
+      "loading": "Loading skills…",
+      "noResults": "No matching skills",
+      "viewAll": "View all in Skill Library"
+    }
+  },
+  "chat": {
+    "approvals": {
+      "title": "Tool execution approval required",
+      "approve": "Approve",
+      "reject": "Reject",
+      "processFailed": "Failed to process: {error}",
+      "errorFallback": "Error"
+    },
+    "artifactFallback": "Artifact",
+    "artifactBuilding": "Building artifact…",
+    "reasoningLabel": "Reasoning",
+    "thinking": {
+      "agentAnalyzing": "{agent} is analyzing",
+      "skillsApplying": "Applying {skills}",
+      "analyzing": "Analyzing"
+    },
+    "quickStarts": {
+      "summarize": {
+        "label": "Summarize",
+        "prompt": "Summarize the following:\n\n"
+      },
+      "research": {
+        "label": "Research",
+        "prompt": "Research the following topic in depth:\n\n"
+      },
+      "analyze": {
+        "label": "Step-by-step analysis",
+        "prompt": "Analyze the following problem step by step:\n\n"
+      },
+      "brainstorm": {
+        "label": "Brainstorm",
+        "prompt": "Let's brainstorm about the following:\n\n"
+      }
+    },
+    "status": {
+      "pending": "Pending",
+      "running": "Running",
+      "paused": "Awaiting approval",
+      "completed": "Completed",
+      "failed": "Failed",
+      "cancelled": "Cancelled"
+    },
+    "agentTask": {
+      "title": "Agent task",
+      "turn": "Turn {turn}",
+      "goal": "Goal",
+      "outputs": "Outputs"
+    },
+    "research": {
+      "inProgress": "Deep research in progress",
+      "loop": "Loop {current}/{total}"
+    },
+    "emptyState": {
+      "title": "How can I help you?",
+      "description": "Multi-model orchestration · MCP tools · deep research · autonomous agents. Type your question below, or press <slash>/</slash> to invoke a skill."
+    },
+    "structured": {
+      "confidence": {
+        "high": "High confidence",
+        "medium": "Medium confidence",
+        "low": "Low confidence"
+      },
+      "conclusion": "Conclusion",
+      "risks": "Points to note",
+      "actionItems": "Next actions"
+    }
+  },
+  "artifacts": {
+    "exec": {
+      "disabled": "Code execution is disabled.",
+      "rateLimited": "Too many execution requests. Please try again shortly.",
+      "unsupportedLang": "Unsupported language.",
+      "tooLarge": "The code is too large.",
+      "failed": "Execution failed."
+    },
+    "run": {
+      "running": "Running…",
+      "run": "Run",
+      "sandbox": "Sandbox (network blocked) · {lang}"
+    },
+    "output": {
+      "title": "Output",
+      "timedOut": "Timed out",
+      "truncated": "Truncated",
+      "empty": "(No output)"
+    },
+    "generating": "Generating…",
+    "versionSelect": "Select version",
+    "latest": "latest",
+    "viewCode": "View code",
+    "viewPreview": "Preview",
+    "download": "Download",
+    "shareLabel": "Share",
+    "copy": "Copy",
+    "closePanel": "Close panel",
+    "artifactCount": "Artifacts {count}",
+    "framePreviewTitle": "Artifact preview",
+    "share": {
+      "title": "Share artifact",
+      "close": "Close",
+      "viewerDisabled": "The viewer is disabled (ARTIFACT_VIEWER_ENABLED). Please contact your administrator.",
+      "publishFailed": "Failed to share",
+      "unpublishFailed": "Failed to stop sharing",
+      "visibility": {
+        "private": {
+          "label": "Private",
+          "desc": "Only you can view it"
+        },
+        "authenticated": {
+          "label": "All signed-in users",
+          "desc": "Visible to all signed-in users"
+        },
+        "link": {
+          "label": "Share via link",
+          "desc": "Anyone with the link (including signed-out users)"
+        }
+      },
+      "iconLabel": "Icon (emoji)",
+      "copyLink": "Copy link",
+      "unpublish": "Stop sharing",
+      "updateSettings": "Update share settings",
+      "publish": "Share"
+    },
+    "page": {
+      "viewerOpenFailed": "Unable to open the viewer",
+      "title": "Artifacts",
+      "description": "Browse the outputs you've created and share them via a separate-origin viewer.",
+      "loading": "Loading...",
+      "emptyTitle": "No artifacts yet",
+      "emptyDesc": "Create outputs like code, HTML, or charts in chat and they'll appear here.",
+      "notShared": "Not shared",
+      "openViewer": "Open viewer",
+      "share": "Share",
+      "vis": {
+        "private": "Private",
+        "authenticated": "Authenticated",
+        "link": "Link"
+      }
+    }
+  },
+  "history": {
+    "title": "Conversation history",
+    "description": "Search past conversations and pick up where you left off.",
+    "searchPlaceholder": "Search conversation titles...",
+    "deleteAllButton": "Delete all",
+    "loading": "Loading...",
+    "untitledConversation": "Untitled conversation",
+    "messageCount": "{count} messages",
+    "deleteConfirm": "Delete the conversation \"{title}\"?\nDeleted conversations cannot be recovered.",
+    "deleteError": "Failed to delete the conversation.",
+    "deleteAllConfirm": "Delete all {count} conversations?\nDeleted conversations cannot be recovered.",
+    "deleteAllError": "Failed to delete all conversations.",
+    "deleteAria": "Delete conversation",
+    "group": {
+      "today": "Today",
+      "yesterday": "Yesterday",
+      "week": "This week",
+      "older": "Older"
+    },
+    "emptyState": {
+      "title": "No conversation history",
+      "noResults": "No results found.",
+      "hint": "Start a new conversation and it will appear here."
+    },
+    "mock": {
+      "c1": {
+        "title": "Next.js 16 App Router migration",
+        "preview": "What should I watch out for when moving from the pages router to the app router...",
+        "time": "2:14 PM"
+      },
+      "c2": {
+        "title": "PostgreSQL index tuning",
+        "preview": "Explain how composite index order affects the query plan",
+        "time": "11:02 AM"
+      },
+      "c3": {
+        "title": "Marketing campaign copy brainstorming",
+        "preview": "Create 5 variations of social media ad copy targeting people in their 20s",
+        "time": "6:47 PM"
+      },
+      "c4": {
+        "title": "Structuring a research report",
+        "preview": "Suggest a table of contents for an enterprise LLM adoption report",
+        "time": "3:20 PM"
+      },
+      "c5": {
+        "title": "TypeScript generic type guards",
+        "preview": "How can I safely narrow a discriminated union?",
+        "time": "Monday"
+      },
+      "c6": {
+        "title": "Image analysis prompt",
+        "preview": "Read the key trends from the attached chart",
+        "time": "Sunday"
+      }
+    }
+  },
+  "chatSocket": {
+    "error": "Error: {message}",
+    "unknownError": "Unknown error",
+    "taskIdMissing": "No taskId in the task creation response",
+    "agentTaskStartFailed": "Failed to start the agent task: {message}",
+    "structuredAborted": "_(Structured answer generation was stopped.)_",
+    "structuredFailed": "Failed to generate a structured answer: {message}"
   }
 }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -44,7 +44,8 @@
     "guest": "ゲスト",
     "selfHosted": "セルフホスト",
     "notLoggedIn": "未ログイン",
-    "logout": "ログアウト"
+    "logout": "ログアウト",
+    "themeToggle": "テーマ切替"
   },
   "mobileNav": {
     "chat": "チャット",
@@ -57,5 +58,242 @@
   },
   "settings": {
     "languageAuto": "自動検出"
+  },
+  "composer": {
+    "dropToAttach": "ここにファイルをドロップして添付",
+    "modeHeading": "モード",
+    "modeSelect": "モードを選択",
+    "toolsButton": "ツール",
+    "toggleOff": "{label}をオフにする",
+    "removeAttachment": "{name}を削除",
+    "attachTruncated": "{name}（サイズ超過のため一部のみ添付）",
+    "placeholder": "メッセージを入力するか、/ でスキルを呼び出してください...",
+    "attachFile": "ファイルを添付（ドラッグ＆ドロップ対応・すべての形式）",
+    "attachFileLabel": "ファイルを添付",
+    "responseStyle": "応答スタイル",
+    "stop": "停止",
+    "send": "送信",
+    "disclaimer": "OpenMake は誤ることがあります。重要な情報は確認してください。",
+    "toggle": {
+      "discussion": "ディスカッション",
+      "thinking": "思考",
+      "deepResearch": "ディープリサーチ",
+      "web": "ウェブ",
+      "agent": "エージェント",
+      "image": "画像",
+      "artifact": "アーティファクト",
+      "structured": "構造化"
+    },
+    "slashMenu": {
+      "heading": "スキルを呼び出す",
+      "loading": "スキルを読み込み中…",
+      "noResults": "一致するスキルがありません",
+      "viewAll": "スキルライブラリですべて表示"
+    }
+  },
+  "chat": {
+    "approvals": {
+      "title": "ツール実行の承認が必要です",
+      "approve": "承認",
+      "reject": "拒否",
+      "processFailed": "処理に失敗しました: {error}",
+      "errorFallback": "エラー"
+    },
+    "artifactFallback": "アーティファクト",
+    "artifactBuilding": "アーティファクトを生成中…",
+    "reasoningLabel": "思考プロセス",
+    "thinking": {
+      "agentAnalyzing": "{agent} が分析中",
+      "skillsApplying": "{skills} を適用中",
+      "analyzing": "分析中"
+    },
+    "quickStarts": {
+      "summarize": {
+        "label": "要約",
+        "prompt": "次の内容を要約してください:\n\n"
+      },
+      "research": {
+        "label": "リサーチ",
+        "prompt": "次のトピックを深くリサーチしてください:\n\n"
+      },
+      "analyze": {
+        "label": "段階的分析",
+        "prompt": "次の問題を段階的に分析してください:\n\n"
+      },
+      "brainstorm": {
+        "label": "ブレインストーミング",
+        "prompt": "次についてブレインストーミングしましょう:\n\n"
+      }
+    },
+    "status": {
+      "pending": "待機中",
+      "running": "実行中",
+      "paused": "承認待ち",
+      "completed": "完了",
+      "failed": "失敗",
+      "cancelled": "キャンセル済み"
+    },
+    "agentTask": {
+      "title": "エージェントタスク",
+      "turn": "ターン {turn}",
+      "goal": "目標",
+      "outputs": "成果物"
+    },
+    "research": {
+      "inProgress": "ディープリサーチ実行中",
+      "loop": "ループ {current}/{total}"
+    },
+    "emptyState": {
+      "title": "何かお手伝いしましょうか？",
+      "description": "マルチモデルオーケストレーション · MCP ツール · ディープリサーチ · 自律エージェント。下に質問を入力するか、<slash>/</slash> でスキルを呼び出してください。"
+    },
+    "structured": {
+      "confidence": {
+        "high": "確信度：高",
+        "medium": "確信度：中",
+        "low": "確信度：低"
+      },
+      "conclusion": "結論",
+      "risks": "注意点",
+      "actionItems": "次のアクション"
+    }
+  },
+  "artifacts": {
+    "exec": {
+      "disabled": "コード実行機能は無効になっています。",
+      "rateLimited": "実行リクエストが多すぎます。しばらくしてから再度お試しください。",
+      "unsupportedLang": "サポートされていない言語です。",
+      "tooLarge": "コードが大きすぎます。",
+      "failed": "実行に失敗しました。"
+    },
+    "run": {
+      "running": "実行中…",
+      "run": "実行",
+      "sandbox": "サンドボックス（ネットワーク遮断） · {lang}"
+    },
+    "output": {
+      "title": "出力",
+      "timedOut": "タイムアウト",
+      "truncated": "切り捨て",
+      "empty": "（出力なし）"
+    },
+    "generating": "生成中…",
+    "versionSelect": "バージョンを選択",
+    "latest": "最新",
+    "viewCode": "コードを表示",
+    "viewPreview": "プレビュー",
+    "download": "ダウンロード",
+    "shareLabel": "共有",
+    "copy": "コピー",
+    "closePanel": "パネルを閉じる",
+    "artifactCount": "アーティファクト {count}",
+    "framePreviewTitle": "アーティファクトのプレビュー",
+    "share": {
+      "title": "アーティファクトを共有",
+      "close": "閉じる",
+      "viewerDisabled": "ビューアーが無効になっています（ARTIFACT_VIEWER_ENABLED）。管理者にお問い合わせください。",
+      "publishFailed": "共有に失敗しました",
+      "unpublishFailed": "共有の停止に失敗しました",
+      "visibility": {
+        "private": {
+          "label": "非公開",
+          "desc": "自分のみ閲覧可能"
+        },
+        "authenticated": {
+          "label": "認証済みユーザー全員",
+          "desc": "ログイン済みのすべてのユーザーに公開"
+        },
+        "link": {
+          "label": "リンクで共有",
+          "desc": "リンクを知っている全員（未ログインを含む）"
+        }
+      },
+      "iconLabel": "アイコン（絵文字）",
+      "copyLink": "リンクをコピー",
+      "unpublish": "共有を停止",
+      "updateSettings": "共有設定を更新",
+      "publish": "共有する"
+    },
+    "page": {
+      "viewerOpenFailed": "ビューアーを開けません",
+      "title": "アーティファクト",
+      "description": "作成した成果物をまとめて確認し、別オリジンのビューアーで共有します。",
+      "loading": "読み込み中...",
+      "emptyTitle": "アーティファクトがありません",
+      "emptyDesc": "チャットでコード・HTML・チャートなどの成果物を作成すると、ここにまとまります。",
+      "notShared": "未共有",
+      "openViewer": "ビューアーを開く",
+      "share": "共有",
+      "vis": {
+        "private": "非公開",
+        "authenticated": "認証公開",
+        "link": "リンク公開"
+      }
+    }
+  },
+  "history": {
+    "title": "会話履歴",
+    "description": "過去の会話を検索して続きから進められます。",
+    "searchPlaceholder": "会話タイトルを検索...",
+    "deleteAllButton": "すべて削除",
+    "loading": "読み込み中...",
+    "untitledConversation": "無題の会話",
+    "messageCount": "{count}件のメッセージ",
+    "deleteConfirm": "会話「{title}」を削除しますか？\n削除した会話は復元できません。",
+    "deleteError": "会話の削除に失敗しました。",
+    "deleteAllConfirm": "{count}件の会話履歴をすべて削除しますか？\n削除した会話は復元できません。",
+    "deleteAllError": "すべての削除に失敗しました。",
+    "deleteAria": "会話を削除",
+    "group": {
+      "today": "今日",
+      "yesterday": "昨日",
+      "week": "今週",
+      "older": "それ以前"
+    },
+    "emptyState": {
+      "title": "会話履歴がありません",
+      "noResults": "検索結果がありません。",
+      "hint": "新しい会話を始めるとここに表示されます。"
+    },
+    "mock": {
+      "c1": {
+        "title": "Next.js 16 App Router 移行",
+        "preview": "既存の pages ルーターから app ルーターへ移行する際の注意点は...",
+        "time": "午後2:14"
+      },
+      "c2": {
+        "title": "PostgreSQL インデックスチューニング",
+        "preview": "複合インデックスの順序がクエリプランに与える影響を説明して",
+        "time": "午前11:02"
+      },
+      "c3": {
+        "title": "マーケティングキャンペーンのコピー ブレインストーミング",
+        "preview": "20代向けのSNS広告コピーを5パターン作って",
+        "time": "午後6:47"
+      },
+      "c4": {
+        "title": "リサーチレポートの構成づくり",
+        "preview": "エンタープライズLLM導入レポートの目次を提案して",
+        "time": "午後3:20"
+      },
+      "c5": {
+        "title": "TypeScript ジェネリック型ガード",
+        "preview": "Discriminated union を安全に絞り込む方法は？",
+        "time": "月曜日"
+      },
+      "c6": {
+        "title": "画像分析プロンプト",
+        "preview": "添付したチャートから主要なトレンドを読み取って",
+        "time": "日曜日"
+      }
+    }
+  },
+  "chatSocket": {
+    "error": "エラー: {message}",
+    "unknownError": "不明なエラー",
+    "taskIdMissing": "タスク作成レスポンスに taskId がありません",
+    "agentTaskStartFailed": "エージェントタスクを開始できませんでした: {message}",
+    "structuredAborted": "_(構造化回答の生成を中止しました。)_",
+    "structuredFailed": "構造化回答を生成できませんでした: {message}"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -44,7 +44,8 @@
     "guest": "게스트",
     "selfHosted": "자가호스팅",
     "notLoggedIn": "로그인 안 됨",
-    "logout": "로그아웃"
+    "logout": "로그아웃",
+    "themeToggle": "테마 전환"
   },
   "mobileNav": {
     "chat": "채팅",
@@ -57,5 +58,242 @@
   },
   "settings": {
     "languageAuto": "자동 감지"
+  },
+  "composer": {
+    "dropToAttach": "여기에 파일을 놓아 첨부",
+    "modeHeading": "모드",
+    "modeSelect": "모드 선택",
+    "toolsButton": "도구",
+    "toggleOff": "{label} 끄기",
+    "removeAttachment": "{name} 첨부 제거",
+    "attachTruncated": "{name} (길이 초과로 일부만 첨부)",
+    "placeholder": "메시지를 입력하거나 / 로 스킬을 호출하세요...",
+    "attachFile": "파일 첨부 (드래그앤드롭 지원 · 모든 형식)",
+    "attachFileLabel": "파일 첨부",
+    "responseStyle": "응답 스타일",
+    "stop": "중단",
+    "send": "전송",
+    "disclaimer": "OpenMake 는 실수할 수 있습니다. 중요한 정보는 확인하세요.",
+    "toggle": {
+      "discussion": "토론",
+      "thinking": "Thinking",
+      "deepResearch": "딥 리서치",
+      "web": "웹",
+      "agent": "에이전트",
+      "image": "이미지",
+      "artifact": "아티팩트",
+      "structured": "구조화 답변"
+    },
+    "slashMenu": {
+      "heading": "스킬 호출",
+      "loading": "스킬을 불러오는 중…",
+      "noResults": "일치하는 스킬이 없습니다",
+      "viewAll": "스킬 라이브러리에서 전체 보기"
+    }
+  },
+  "chat": {
+    "approvals": {
+      "title": "도구 실행 승인 필요",
+      "approve": "승인",
+      "reject": "거절",
+      "processFailed": "처리 실패: {error}",
+      "errorFallback": "오류"
+    },
+    "artifactFallback": "아티팩트",
+    "artifactBuilding": "아티팩트 생성 중…",
+    "reasoningLabel": "생각 과정",
+    "thinking": {
+      "agentAnalyzing": "{agent}가 분석 중",
+      "skillsApplying": "{skills} 적용 중",
+      "analyzing": "분석 중"
+    },
+    "quickStarts": {
+      "summarize": {
+        "label": "요약하기",
+        "prompt": "다음 내용을 요약해 줘:\n\n"
+      },
+      "research": {
+        "label": "리서치",
+        "prompt": "다음 주제를 깊이 리서치해 줘:\n\n"
+      },
+      "analyze": {
+        "label": "단계별 분석",
+        "prompt": "다음 문제를 단계별로 분석해 줘:\n\n"
+      },
+      "brainstorm": {
+        "label": "브레인스토밍",
+        "prompt": "다음에 대해 브레인스토밍하자:\n\n"
+      }
+    },
+    "status": {
+      "pending": "대기",
+      "running": "실행 중",
+      "paused": "승인 대기",
+      "completed": "완료",
+      "failed": "실패",
+      "cancelled": "취소됨"
+    },
+    "agentTask": {
+      "title": "에이전트 작업",
+      "turn": "턴 {turn}",
+      "goal": "목표",
+      "outputs": "산출물"
+    },
+    "research": {
+      "inProgress": "딥 리서치 진행 중",
+      "loop": "루프 {current}/{total}"
+    },
+    "emptyState": {
+      "title": "무엇을 도와드릴까요?",
+      "description": "멀티모델 오케스트레이션 · MCP 도구 · 딥 리서치 · 자율 에이전트. 아래에 질문을 입력하거나 <slash>/</slash> 로 스킬을 호출하세요."
+    },
+    "structured": {
+      "confidence": {
+        "high": "확신 높음",
+        "medium": "확신 보통",
+        "low": "확신 낮음"
+      },
+      "conclusion": "결론",
+      "risks": "주의할 점",
+      "actionItems": "다음 실행"
+    }
+  },
+  "artifacts": {
+    "exec": {
+      "disabled": "코드 실행 기능이 비활성화되어 있습니다.",
+      "rateLimited": "실행 요청이 너무 많습니다. 잠시 후 다시 시도하세요.",
+      "unsupportedLang": "지원하지 않는 언어입니다.",
+      "tooLarge": "코드가 너무 큽니다.",
+      "failed": "실행에 실패했습니다."
+    },
+    "run": {
+      "running": "실행 중…",
+      "run": "실행",
+      "sandbox": "샌드박스(네트워크 차단) · {lang}"
+    },
+    "output": {
+      "title": "출력",
+      "timedOut": "시간 초과",
+      "truncated": "잘림",
+      "empty": "(출력 없음)"
+    },
+    "generating": "생성 중…",
+    "versionSelect": "버전 선택",
+    "latest": "최신",
+    "viewCode": "코드 보기",
+    "viewPreview": "미리보기",
+    "download": "다운로드",
+    "shareLabel": "공유",
+    "copy": "복사",
+    "closePanel": "패널 닫기",
+    "artifactCount": "아티팩트 {count}",
+    "framePreviewTitle": "아티팩트 미리보기",
+    "share": {
+      "title": "아티팩트 공유",
+      "close": "닫기",
+      "viewerDisabled": "뷰어가 비활성화되어 있습니다(ARTIFACT_VIEWER_ENABLED). 관리자에게 문의하세요.",
+      "publishFailed": "공유에 실패했습니다",
+      "unpublishFailed": "공유 중단에 실패했습니다",
+      "visibility": {
+        "private": {
+          "label": "비공개",
+          "desc": "나만 볼 수 있음"
+        },
+        "authenticated": {
+          "label": "인증 사용자 전체",
+          "desc": "로그인한 모든 사용자에게 공개"
+        },
+        "link": {
+          "label": "링크 공유",
+          "desc": "링크를 가진 누구나 (비로그인 포함)"
+        }
+      },
+      "iconLabel": "아이콘(이모지)",
+      "copyLink": "링크 복사",
+      "unpublish": "공유 중단",
+      "updateSettings": "공유 설정 갱신",
+      "publish": "공유하기"
+    },
+    "page": {
+      "viewerOpenFailed": "뷰어를 열 수 없습니다",
+      "title": "아티팩트",
+      "description": "생성한 산출물을 모아보고, 별도 오리진 뷰어로 공유합니다.",
+      "loading": "불러오는 중...",
+      "emptyTitle": "아티팩트가 없습니다",
+      "emptyDesc": "채팅에서 코드·HTML·차트 등 산출물을 만들면 여기에 모입니다.",
+      "notShared": "미공유",
+      "openViewer": "뷰어 열기",
+      "share": "공유",
+      "vis": {
+        "private": "비공개",
+        "authenticated": "인증 공개",
+        "link": "링크 공개"
+      }
+    }
+  },
+  "history": {
+    "title": "대화 히스토리",
+    "description": "이전 대화를 검색하고 이어서 진행할 수 있습니다.",
+    "searchPlaceholder": "대화 제목 검색...",
+    "deleteAllButton": "전체 삭제",
+    "loading": "불러오는 중...",
+    "untitledConversation": "제목 없는 대화",
+    "messageCount": "메시지 {count}개",
+    "deleteConfirm": "\"{title}\" 대화를 삭제하시겠습니까?\n삭제된 대화는 복구할 수 없습니다.",
+    "deleteError": "대화 삭제에 실패했습니다.",
+    "deleteAllConfirm": "대화 기록 {count}개를 모두 삭제하시겠습니까?\n삭제된 대화는 복구할 수 없습니다.",
+    "deleteAllError": "전체 삭제에 실패했습니다.",
+    "deleteAria": "대화 삭제",
+    "group": {
+      "today": "오늘",
+      "yesterday": "어제",
+      "week": "이번 주",
+      "older": "이전"
+    },
+    "emptyState": {
+      "title": "대화 기록이 없습니다",
+      "noResults": "검색 결과가 없습니다.",
+      "hint": "새 대화를 시작하면 여기에 표시됩니다."
+    },
+    "mock": {
+      "c1": {
+        "title": "Next.js 16 App Router 마이그레이션",
+        "preview": "기존 pages 라우터에서 app 라우터로 옮길 때 주의할 점은...",
+        "time": "오후 2:14"
+      },
+      "c2": {
+        "title": "PostgreSQL 인덱스 튜닝",
+        "preview": "복합 인덱스 순서가 쿼리 플랜에 미치는 영향을 설명해줘",
+        "time": "오전 11:02"
+      },
+      "c3": {
+        "title": "마케팅 캠페인 카피 브레인스토밍",
+        "preview": "20대 타겟의 SNS 광고 카피 5개 변형을 만들어줘",
+        "time": "오후 6:47"
+      },
+      "c4": {
+        "title": "리서치 보고서 구조 잡기",
+        "preview": "엔터프라이즈 LLM 도입 보고서의 목차를 제안해줘",
+        "time": "오후 3:20"
+      },
+      "c5": {
+        "title": "TypeScript 제네릭 타입 가드",
+        "preview": "Discriminated union 을 안전하게 좁히는 방법은?",
+        "time": "월요일"
+      },
+      "c6": {
+        "title": "이미지 분석 프롬프트",
+        "preview": "첨부한 차트에서 주요 트렌드를 읽어줘",
+        "time": "일요일"
+      }
+    }
+  },
+  "chatSocket": {
+    "error": "오류: {message}",
+    "unknownError": "알 수 없는 오류",
+    "taskIdMissing": "작업 생성 응답에 taskId 가 없습니다",
+    "agentTaskStartFailed": "에이전트 작업을 시작하지 못했습니다: {message}",
+    "structuredAborted": "_(구조화 답변 생성을 중단했습니다.)_",
+    "structuredFailed": "구조화 답변을 생성하지 못했습니다: {message}"
   }
 }

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -44,7 +44,8 @@
     "guest": "访客",
     "selfHosted": "自托管",
     "notLoggedIn": "未登录",
-    "logout": "退出登录"
+    "logout": "退出登录",
+    "themeToggle": "切换主题"
   },
   "mobileNav": {
     "chat": "聊天",
@@ -57,5 +58,242 @@
   },
   "settings": {
     "languageAuto": "自动检测"
+  },
+  "composer": {
+    "dropToAttach": "将文件拖放到此处以添加",
+    "modeHeading": "模式",
+    "modeSelect": "选择模式",
+    "toolsButton": "工具",
+    "toggleOff": "关闭{label}",
+    "removeAttachment": "移除{name}",
+    "attachTruncated": "{name}（超出长度，仅部分添加）",
+    "placeholder": "输入消息，或用 / 调用技能...",
+    "attachFile": "添加文件（支持拖放 · 任意格式）",
+    "attachFileLabel": "添加文件",
+    "responseStyle": "回复风格",
+    "stop": "停止",
+    "send": "发送",
+    "disclaimer": "OpenMake 可能会出错，请核实重要信息。",
+    "toggle": {
+      "discussion": "讨论",
+      "thinking": "思考",
+      "deepResearch": "深度研究",
+      "web": "网络",
+      "agent": "智能体",
+      "image": "图像",
+      "artifact": "工件",
+      "structured": "结构化"
+    },
+    "slashMenu": {
+      "heading": "调用技能",
+      "loading": "正在加载技能…",
+      "noResults": "没有匹配的技能",
+      "viewAll": "在技能库中查看全部"
+    }
+  },
+  "chat": {
+    "approvals": {
+      "title": "需要批准工具执行",
+      "approve": "批准",
+      "reject": "拒绝",
+      "processFailed": "处理失败：{error}",
+      "errorFallback": "错误"
+    },
+    "artifactFallback": "工件",
+    "artifactBuilding": "正在生成工件…",
+    "reasoningLabel": "思考过程",
+    "thinking": {
+      "agentAnalyzing": "{agent} 正在分析",
+      "skillsApplying": "正在应用 {skills}",
+      "analyzing": "分析中"
+    },
+    "quickStarts": {
+      "summarize": {
+        "label": "总结",
+        "prompt": "请总结以下内容：\n\n"
+      },
+      "research": {
+        "label": "研究",
+        "prompt": "请深入研究以下主题：\n\n"
+      },
+      "analyze": {
+        "label": "逐步分析",
+        "prompt": "请逐步分析以下问题：\n\n"
+      },
+      "brainstorm": {
+        "label": "头脑风暴",
+        "prompt": "让我们围绕以下内容进行头脑风暴：\n\n"
+      }
+    },
+    "status": {
+      "pending": "等待中",
+      "running": "运行中",
+      "paused": "等待批准",
+      "completed": "已完成",
+      "failed": "失败",
+      "cancelled": "已取消"
+    },
+    "agentTask": {
+      "title": "智能体任务",
+      "turn": "第 {turn} 轮",
+      "goal": "目标",
+      "outputs": "产出"
+    },
+    "research": {
+      "inProgress": "深度研究进行中",
+      "loop": "循环 {current}/{total}"
+    },
+    "emptyState": {
+      "title": "有什么可以帮您的？",
+      "description": "多模型编排 · MCP 工具 · 深度研究 · 自主智能体。在下方输入问题，或按 <slash>/</slash> 调用技能。"
+    },
+    "structured": {
+      "confidence": {
+        "high": "高置信度",
+        "medium": "中等置信度",
+        "low": "低置信度"
+      },
+      "conclusion": "结论",
+      "risks": "注意事项",
+      "actionItems": "后续行动"
+    }
+  },
+  "artifacts": {
+    "exec": {
+      "disabled": "代码执行功能已禁用。",
+      "rateLimited": "执行请求过多，请稍后再试。",
+      "unsupportedLang": "不支持的语言。",
+      "tooLarge": "代码过大。",
+      "failed": "执行失败。"
+    },
+    "run": {
+      "running": "执行中…",
+      "run": "执行",
+      "sandbox": "沙箱（网络已阻断） · {lang}"
+    },
+    "output": {
+      "title": "输出",
+      "timedOut": "超时",
+      "truncated": "已截断",
+      "empty": "（无输出）"
+    },
+    "generating": "生成中…",
+    "versionSelect": "选择版本",
+    "latest": "最新",
+    "viewCode": "查看代码",
+    "viewPreview": "预览",
+    "download": "下载",
+    "shareLabel": "分享",
+    "copy": "复制",
+    "closePanel": "关闭面板",
+    "artifactCount": "工件 {count}",
+    "framePreviewTitle": "工件预览",
+    "share": {
+      "title": "分享工件",
+      "close": "关闭",
+      "viewerDisabled": "查看器已禁用（ARTIFACT_VIEWER_ENABLED）。请联系管理员。",
+      "publishFailed": "分享失败",
+      "unpublishFailed": "停止分享失败",
+      "visibility": {
+        "private": {
+          "label": "私密",
+          "desc": "仅自己可见"
+        },
+        "authenticated": {
+          "label": "所有登录用户",
+          "desc": "对所有登录用户可见"
+        },
+        "link": {
+          "label": "通过链接分享",
+          "desc": "拥有链接的任何人（包括未登录用户）"
+        }
+      },
+      "iconLabel": "图标（表情符号）",
+      "copyLink": "复制链接",
+      "unpublish": "停止分享",
+      "updateSettings": "更新分享设置",
+      "publish": "分享"
+    },
+    "page": {
+      "viewerOpenFailed": "无法打开查看器",
+      "title": "工件",
+      "description": "汇总查看你创建的产出，并通过独立源查看器分享。",
+      "loading": "加载中...",
+      "emptyTitle": "暂无工件",
+      "emptyDesc": "在聊天中创建代码、HTML、图表等产出后，会汇总到这里。",
+      "notShared": "未分享",
+      "openViewer": "打开查看器",
+      "share": "分享",
+      "vis": {
+        "private": "私密",
+        "authenticated": "认证公开",
+        "link": "链接公开"
+      }
+    }
+  },
+  "history": {
+    "title": "对话历史",
+    "description": "搜索过往对话并继续进行。",
+    "searchPlaceholder": "搜索对话标题...",
+    "deleteAllButton": "全部删除",
+    "loading": "加载中...",
+    "untitledConversation": "无标题对话",
+    "messageCount": "{count} 条消息",
+    "deleteConfirm": "确定要删除对话「{title}」吗？\n删除的对话无法恢复。",
+    "deleteError": "删除对话失败。",
+    "deleteAllConfirm": "确定要删除全部 {count} 条对话记录吗？\n删除的对话无法恢复。",
+    "deleteAllError": "全部删除失败。",
+    "deleteAria": "删除对话",
+    "group": {
+      "today": "今天",
+      "yesterday": "昨天",
+      "week": "本周",
+      "older": "更早"
+    },
+    "emptyState": {
+      "title": "暂无对话记录",
+      "noResults": "没有搜索结果。",
+      "hint": "开始新对话后将显示在此处。"
+    },
+    "mock": {
+      "c1": {
+        "title": "Next.js 16 App Router 迁移",
+        "preview": "从现有的 pages 路由迁移到 app 路由时需要注意什么...",
+        "time": "下午2:14"
+      },
+      "c2": {
+        "title": "PostgreSQL 索引调优",
+        "preview": "解释复合索引的顺序对查询计划的影响",
+        "time": "上午11:02"
+      },
+      "c3": {
+        "title": "营销活动文案头脑风暴",
+        "preview": "为面向20多岁人群制作5个社交媒体广告文案变体",
+        "time": "下午6:47"
+      },
+      "c4": {
+        "title": "搭建研究报告结构",
+        "preview": "为企业 LLM 采用报告提议一个目录",
+        "time": "下午3:20"
+      },
+      "c5": {
+        "title": "TypeScript 泛型类型守卫",
+        "preview": "如何安全地收窄可辨识联合类型？",
+        "time": "周一"
+      },
+      "c6": {
+        "title": "图像分析提示词",
+        "preview": "从附加的图表中解读主要趋势",
+        "time": "周日"
+      }
+    }
+  },
+  "chatSocket": {
+    "error": "错误：{message}",
+    "unknownError": "未知错误",
+    "taskIdMissing": "任务创建响应中缺少 taskId",
+    "agentTaskStartFailed": "无法启动智能体任务：{message}",
+    "structuredAborted": "_(已停止生成结构化回答。)_",
+    "structuredFailed": "无法生成结构化回答：{message}"
   }
 }


### PR DESCRIPTION
## 개요

i18n 시리즈 PR 2/6 (베이스: #258 — 머지되면 자동 retarget). 채팅 코어 컴포넌트와 history·artifacts 페이지의 하드코딩 한국어 전부를 next-intl 키로 추출.

## 변경

- `components/chat/`: composer, slash-skill-menu, message-list, structured-answer, artifact-panel, artifact-share-modal, artifact-toggle, artifact-frame
- `lib/use-chat-socket.ts` — 채팅에 주입되는 에러/상태 문자열. 콜백 stale closure 방지용 latest-ref 패턴(t 를 effect 에서 ref 갱신)
- `app/(workspace)/history/page.tsx`, `app/(workspace)/artifacts/page.tsx`, `components/theme-toggle.tsx`
- messages 네임스페이스: `composer` `chat` `artifacts` `history` `chatSocket` — 4개 locale 205키 정합

## 검증

- `check:i18n` 통과 (205키 × 4 locale)
- 격리 워크트리에서 `tsc --noEmit` 0 + `next build` 성공
- eslint: 신규 문제 0 (에이전트 초안의 신규 2건 — 렌더 중 ref 쓰기, useEffect t 의존성 누락 — 수정 완료. 잔존은 기존 코드의 것)
- 시리즈 최종 PR 에서 전 페이지 라이브 스모크 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)