### PR TITLE
feat(web): 대형 페이지 i18n — 스킬/설정/에이전트/리서치 4개 언어 (PR 3/6)

### DIFF
--- a/apps/web/app/(workspace)/agent-tasks/page.tsx
+++ b/apps/web/app/(workspace)/agent-tasks/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import {
   Sparkles,
   Check,
@@ -175,10 +176,10 @@ const TASK_FALLBACK: AgentTask[] = [
   },
 ];
 
-const STATUS_META: Record<TaskStatus, { label: string; tone: "accent" | "success" | "neutral" }> = {
-  running: { label: "진행중", tone: "accent" },
-  completed: { label: "완료", tone: "success" },
-  pending: { label: "대기", tone: "neutral" },
+const STATUS_META: Record<TaskStatus, { labelKey: string; tone: "accent" | "success" | "neutral" }> = {
+  running: { labelKey: "status.running", tone: "accent" },
+  completed: { labelKey: "status.completed", tone: "success" },
+  pending: { labelKey: "status.pending", tone: "neutral" },
 };
 
 /* ── 오버레이 모달 ────────────────────────────────────────── */
@@ -230,6 +231,7 @@ function TaskDetailModal({
 }: {
   taskId: string;
 }) {
+  const t = useTranslations("agentTasks");
   const [detail, setDetail] = useState<{ task: ApiAgentTask; steps: ApiTaskStep[] } | null>(null);
   const [files, setFiles] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
@@ -272,23 +274,23 @@ function TaskDetailModal({
       {loading && !detail ? (
         <div className="flex items-center gap-2 py-8 justify-center text-muted text-sm">
           <LoaderCircle className="h-4 w-4 animate-spin" />
-          불러오는 중...
+          {t("loading")}
         </div>
       ) : !detail ? (
-        <p className="text-sm text-danger py-8 text-center">작업 정보를 불러오지 못했습니다.</p>
+        <p className="text-sm text-danger py-8 text-center">{t("detailLoadError")}</p>
       ) : (
         <>
           <div className="rounded-md border border-border bg-surface-2 p-4">
-            <p className="mb-1 text-xs font-medium text-muted">목표</p>
+            <p className="mb-1 text-xs font-medium text-muted">{t("goalLabel")}</p>
             <p className="text-sm text-fg">{detail.task.goal}</p>
             <div className="mt-2 flex items-center gap-3 text-xs text-faint">
               <span className="flex items-center gap-1">
-                상태: {detail.task.status}
+                {t("stateLabel")} {detail.task.status}
                 {(detail.task.status === "running" || detail.task.status === "paused") && (
                   <LoaderCircle className="h-3 w-3 animate-spin" />
                 )}
               </span>
-              <span>턴: {detail.task.current_turn ?? 0}/{detail.task.max_turns ?? 0}</span>
+              <span>{t("turnLabel")} {detail.task.current_turn ?? 0}/{detail.task.max_turns ?? 0}</span>
             </div>
           </div>
 
@@ -296,7 +298,7 @@ function TaskDetailModal({
           {plan.length > 0 && (
             <div className="rounded-md border border-border bg-surface-1 p-3">
               <p className="mb-2 text-xs font-medium text-fg-2">
-                계획 ({plan.filter((s) => s.status === "completed").length}/{plan.length})
+                {t("planLabel", { completed: plan.filter((s) => s.status === "completed").length, total: plan.length })}
               </p>
               <ul className="space-y-1">
                 {plan.map((s, i) => (
@@ -323,7 +325,7 @@ function TaskDetailModal({
           {/* 산출물 파일 (완료 시 workspace 보존) */}
           {files.length > 0 && (
             <div className="rounded-md border border-border bg-surface-1 p-3">
-              <p className="mb-2 text-xs font-medium text-fg-2">산출물 ({files.length})</p>
+              <p className="mb-2 text-xs font-medium text-fg-2">{t("outputsLabel", { count: files.length })}</p>
               <ul className="space-y-1">
                 {files.map((f) => (
                   <li key={f} className="text-xs">
@@ -342,10 +344,10 @@ function TaskDetailModal({
 
           {/* 실행 스텝 — 터미널 스타일(도구 출력 전문) */}
           {detail.steps.length === 0 ? (
-            <p className="text-sm text-muted text-center py-4">스텝 기록이 없습니다.</p>
+            <p className="text-sm text-muted text-center py-4">{t("noSteps")}</p>
           ) : (
             <div className="space-y-2">
-              <p className="text-xs font-medium text-fg-2">실행 스텝 ({detail.steps.length})</p>
+              <p className="text-xs font-medium text-fg-2">{t("stepsLabel", { count: detail.steps.length })}</p>
               <div className="max-h-96 overflow-y-auto space-y-2 pr-1">
                 {detail.steps.map((step, i) => {
                   const body = step.tool_output || step.content || "";
@@ -395,6 +397,7 @@ interface PendingApproval {
 type ApprovalsResponse = ApiSuccess<{ pending: PendingApproval[] }>;
 
 function ApprovalsPanel() {
+  const t = useTranslations("agentTasks");
   const [pending, setPending] = useState<PendingApproval[]>([]);
   const [busy, setBusy] = useState<string | null>(null);
 
@@ -419,7 +422,7 @@ function ApprovalsPanel() {
       await ApiClient.post(`/api/agent-tasks/approvals/${approvalId}/${decision}`, {});
       await load();
     } catch (err) {
-      alert("처리 실패: " + (err instanceof Error ? err.message : "오류"));
+      alert(t("processFailed", { message: err instanceof Error ? err.message : t("error") }));
     } finally {
       setBusy(null);
     }
@@ -430,7 +433,7 @@ function ApprovalsPanel() {
   return (
     <Card className="mb-4 p-4">
       <p className="mb-3 text-sm font-medium text-fg-2">
-        승인 대기 중인 도구 실행 ({pending.length})
+        {t("approvalsTitle", { count: pending.length })}
       </p>
       <div className="space-y-2">
         {pending.map((p) => (
@@ -451,14 +454,14 @@ function ApprovalsPanel() {
                 disabled={busy === p.approvalId}
                 onClick={() => decide(p.approvalId, "reject")}
               >
-                거절
+                {t("reject")}
               </Button>
               <Button
                 size="sm"
                 disabled={busy === p.approvalId}
                 onClick={() => decide(p.approvalId, "approve")}
               >
-                승인
+                {t("approve")}
               </Button>
             </div>
           </div>
@@ -469,6 +472,7 @@ function ApprovalsPanel() {
 }
 
 export default function AgentTasksPage() {
+  const t = useTranslations("agentTasks");
   const router = useRouter();
   const [tasks, setTasks] = useState<AgentTask[]>(TASK_FALLBACK);
   const [loading, setLoading] = useState(true);
@@ -496,13 +500,13 @@ export default function AgentTasksPage() {
   }, [loadTasks]);
 
   async function handleCancel(task: AgentTask) {
-    if (!window.confirm(`"${task.goal.slice(0, 40)}..." 작업을 취소하시겠습니까?`)) return;
+    if (!window.confirm(t("cancelConfirm", { goal: task.goal.slice(0, 40) }))) return;
     setActionLoading(task.id);
     try {
       await ApiClient.post(`/api/agent-tasks/${task.id}/cancel`, {});
       await loadTasks();
     } catch (err) {
-      alert("취소 실패: " + (err instanceof Error ? err.message : "오류"));
+      alert(t("cancelFailed", { message: err instanceof Error ? err.message : t("error") }));
     } finally {
       setActionLoading(null);
     }
@@ -514,20 +518,20 @@ export default function AgentTasksPage() {
       await ApiClient.post(`/api/agent-tasks/${task.id}/resume`, {});
       await loadTasks();
     } catch (err) {
-      alert("이어하기 실패: " + (err instanceof Error ? err.message : "오류"));
+      alert(t("resumeFailed", { message: err instanceof Error ? err.message : t("error") }));
     } finally {
       setActionLoading(null);
     }
   }
 
   async function handleDelete(task: AgentTask) {
-    if (!window.confirm(`"${task.goal.slice(0, 40)}..." 작업을 삭제하시겠습니까?`)) return;
+    if (!window.confirm(t("deleteConfirm", { goal: task.goal.slice(0, 40) }))) return;
     setActionLoading(task.id);
     try {
       await ApiClient.del(`/api/agent-tasks/${task.id}`);
       await loadTasks();
     } catch (err) {
-      alert("삭제 실패: " + (err instanceof Error ? err.message : "오류"));
+      alert(t("deleteFailed", { message: err instanceof Error ? err.message : t("error") }));
     } finally {
       setActionLoading(null);
     }
@@ -536,35 +540,35 @@ export default function AgentTasksPage() {
   return (
     <>
       <PageHeader
-        title="에이전트 작업 관리"
-        description="작업 목록·진행·승인을 관리합니다. 생성·실행은 채팅의 에이전트 모드에서 진행됩니다."
+        title={t("pageTitle")}
+        description={t("pageDescription")}
       />
 
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
         {/* 실행 안내 배너 — 생성/실행은 채팅 인라인으로 일원화 */}
         <Card className="mb-4 flex flex-wrap items-center justify-between gap-3 p-4">
           <p className="text-sm text-muted">
-            에이전트 작업은 채팅 입력창의{" "}
-            <span className="font-medium text-fg-2">에이전트</span> 모드로
-            생성·실행하세요. 이 페이지에서는 작업 목록·진행·승인을 관리합니다.
+            {t.rich("banner", {
+              b: (chunks) => <span className="font-medium text-fg-2">{chunks}</span>,
+            })}
           </p>
           <Button size="sm" variant="outline" onClick={() => router.push("/")}>
-            채팅으로 이동
+            {t("chatCta")}
           </Button>
         </Card>
         <ApprovalsPanel />
         {loading ? (
           <div className="grid place-items-center py-24 text-center">
             <Sparkles className="mb-3 h-8 w-8 animate-pulse text-faint" />
-            <p className="text-sm text-muted">불러오는 중...</p>
+            <p className="text-sm text-muted">{t("loading")}</p>
           </div>
         ) : tasks.length === 0 ? (
           <div className="grid place-items-center py-24 text-center">
             <Sparkles className="mb-3 h-8 w-8 text-faint" />
-            <p className="text-sm font-medium text-fg-2">작업이 없습니다</p>
-            <p className="mt-1 text-sm text-muted">채팅의 에이전트 모드에서 새 작업을 시작하세요.</p>
+            <p className="text-sm font-medium text-fg-2">{t("emptyTitle")}</p>
+            <p className="mt-1 text-sm text-muted">{t("emptyDescription")}</p>
             <Button size="sm" variant="outline" className="mt-4" onClick={() => router.push("/")}>
-              채팅으로 이동
+              {t("chatCta")}
             </Button>
           </div>
         ) : (
@@ -583,12 +587,12 @@ export default function AgentTasksPage() {
                       {task.status === "running" && (
                         <LoaderCircle className="h-3 w-3 animate-spin" />
                       )}
-                      {meta.label}
-                      {task.rawStatus === "failed" && " (실패)"}
-                      {task.rawStatus === "cancelled" && " (취소됨)"}
+                      {t(meta.labelKey)}
+                      {task.rawStatus === "failed" && ` (${t("failedTag")})`}
+                      {task.rawStatus === "cancelled" && ` (${t("cancelledTag")})`}
                     </Badge>
                     <span className="font-mono text-xs text-faint">
-                      턴 {task.currentTurn}/{task.maxTurns}
+                      {t("turnShort", { current: task.currentTurn, max: task.maxTurns })}
                     </span>
                   </div>
 
@@ -622,7 +626,7 @@ export default function AgentTasksPage() {
                   {/* 진행률 */}
                   <div className="mb-3">
                     <div className="mb-1 flex items-center justify-between text-xs">
-                      <span className="text-faint">진행률</span>
+                      <span className="text-faint">{t("progressLabel")}</span>
                       <span className="font-mono text-fg-2">{pct}%</span>
                     </div>
                     <div className="h-1.5 overflow-hidden rounded-pill bg-surface-3">
@@ -644,7 +648,7 @@ export default function AgentTasksPage() {
                       {/* 상세 보기 */}
                       <button
                         onClick={() => setDetailTaskId(task.id)}
-                        title="상세 보기"
+                        title={t("detailTitle")}
                         className="flex h-7 w-7 items-center justify-center rounded-md text-faint transition hover:bg-surface-2 hover:text-fg">
                         <ChevronRight className="h-3.5 w-3.5" />
                       </button>
@@ -653,7 +657,7 @@ export default function AgentTasksPage() {
                         <button
                           onClick={() => void handleResume(task)}
                           disabled={isActing}
-                          title="이어하기"
+                          title={t("resumeTitle")}
                           className="flex h-7 w-7 items-center justify-center rounded-md text-faint transition hover:bg-accent-soft hover:text-accent disabled:opacity-40">
                           <RotateCcw className="h-3.5 w-3.5" />
                         </button>
@@ -663,7 +667,7 @@ export default function AgentTasksPage() {
                         <button
                           onClick={() => void handleCancel(task)}
                           disabled={isActing}
-                          title="취소"
+                          title={t("cancelTitle")}
                           className="flex h-7 w-7 items-center justify-center rounded-md text-faint transition hover:bg-danger-soft hover:text-danger disabled:opacity-40">
                           <X className="h-3.5 w-3.5" />
                         </button>
@@ -672,7 +676,7 @@ export default function AgentTasksPage() {
                       <button
                         onClick={() => void handleDelete(task)}
                         disabled={isActing}
-                        title="삭제"
+                        title={t("deleteTitle")}
                         className="flex h-7 w-7 items-center justify-center rounded-md text-faint transition hover:bg-danger-soft hover:text-danger disabled:opacity-40">
                         <Trash2 className="h-3.5 w-3.5" />
                       </button>
@@ -687,7 +691,7 @@ export default function AgentTasksPage() {
 
       {/* 작업 상세 모달 */}
       {detailTaskId && (
-        <Modal open={!!detailTaskId} onClose={() => setDetailTaskId(null)} title="작업 상세">
+        <Modal open={!!detailTaskId} onClose={() => setDetailTaskId(null)} title={t("modalTitle")}>
           <TaskDetailModal taskId={detailTaskId} />
         </Modal>
       )}

--- a/apps/web/app/(workspace)/custom-agents/page.tsx
+++ b/apps/web/app/(workspace)/custom-agents/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Bot, Plus, Pencil, Trash2, GitBranch, X, Loader2, Check } from "lucide-react";
 import {
   Button,
@@ -46,23 +47,27 @@ function mapAgent(a: ApiUserAgent): CustomAgent {
     id: a.id,
     emoji: a.icon || "🤖",
     name: a.name,
-    description: a.description || "설명이 없습니다.",
+    description: a.description || "",
     systemPrompt: a.system_prompt,
     source: "custom",
   };
 }
 
 /* ── 목업 폴백 ─────────────────────────────────────────────── */
-const AGENTS_FALLBACK: CustomAgent[] = [
+const AGENTS_FALLBACK_META: {
+  id: string; emoji: string; nameKey: string; descKey: string; promptKey: string; source: "git" | "custom";
+}[] = [
   {
-    id: "a1", emoji: "📐", name: "기술 문서 작성가",
-    description: "API 레퍼런스와 아키텍처 문서를 일관된 톤으로 작성합니다.",
-    systemPrompt: "당신은 시니어 테크니컬 라이터입니다...", source: "custom",
+    id: "a1", emoji: "📐",
+    nameKey: "fallback.techWriter.name",
+    descKey: "fallback.techWriter.description",
+    promptKey: "fallback.techWriter.systemPrompt", source: "custom",
   },
   {
-    id: "a2", emoji: "🧪", name: "코드 리뷰어",
-    description: "변경된 코드의 버그와 단순화 기회를 집어냅니다.",
-    systemPrompt: "당신은 까다로운 코드 리뷰어입니다...", source: "git",
+    id: "a2", emoji: "🧪",
+    nameKey: "fallback.reviewer.name",
+    descKey: "fallback.reviewer.description",
+    promptKey: "fallback.reviewer.systemPrompt", source: "git",
   },
 ];
 
@@ -115,8 +120,9 @@ function AgentForm({
   onClose: () => void;
   onSaved: () => void | Promise<void>;
 }) {
+  const t = useTranslations("customAgents");
   const [name, setName] = useState(initial?.name ?? "");
-  const [description, setDescription] = useState(initial?.description === "설명이 없습니다." ? "" : (initial?.description ?? ""));
+  const [description, setDescription] = useState(initial?.description ?? "");
   const [systemPrompt, setSystemPrompt] = useState(initial?.systemPrompt ?? "");
   const [icon, setIcon] = useState(initial?.emoji ?? "🤖");
   const [saving, setSaving] = useState(false);
@@ -125,8 +131,8 @@ function AgentForm({
   const isEdit = !!initial;
 
   async function handleSubmit() {
-    if (!name.trim()) { setFormError("에이전트 이름을 입력하세요."); return; }
-    if (!systemPrompt.trim()) { setFormError("시스템 프롬프트를 입력하세요."); return; }
+    if (!name.trim()) { setFormError(t("nameRequired")); return; }
+    if (!systemPrompt.trim()) { setFormError(t("systemPromptRequired")); return; }
     setSaving(true);
     setFormError(null);
     try {
@@ -147,7 +153,7 @@ function AgentForm({
       }
       await onSaved();
     } catch (err) {
-      setFormError("저장 실패: " + (err instanceof Error ? err.message : "서버 오류"));
+      setFormError(t("saveFailed", { error: err instanceof Error ? err.message : t("serverError") }));
     } finally {
       setSaving(false);
     }
@@ -157,37 +163,37 @@ function AgentForm({
     <form onSubmit={(e) => { e.preventDefault(); void handleSubmit(); }} className="space-y-4">
       <div className="grid gap-4 sm:grid-cols-[auto_1fr]">
         <label className="block">
-          <span className="mb-1 block text-xs font-medium text-fg-2">아이콘</span>
+          <span className="mb-1 block text-xs font-medium text-fg-2">{t("iconLabel")}</span>
           <input value={icon} onChange={(e) => setIcon(e.target.value)} maxLength={4}
             className="h-9 w-16 rounded-md border border-border bg-surface px-2 text-center text-lg outline-none focus:border-accent" />
         </label>
         <label className="block">
-          <span className="mb-1 block text-xs font-medium text-fg-2">에이전트 이름 *</span>
+          <span className="mb-1 block text-xs font-medium text-fg-2">{t("nameLabel")}</span>
           <input value={name} onChange={(e) => setName(e.target.value)}
-            placeholder="예: 기술 문서 작성가" autoFocus
+            placeholder={t("namePlaceholder")} autoFocus
             className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
         </label>
       </div>
       <label className="block">
-        <span className="mb-1 block text-xs font-medium text-fg-2">설명</span>
+        <span className="mb-1 block text-xs font-medium text-fg-2">{t("descriptionLabel")}</span>
         <input value={description} onChange={(e) => setDescription(e.target.value)}
-          placeholder="이 에이전트가 하는 일을 간단히 설명하세요"
+          placeholder={t("descriptionPlaceholder")}
           className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
       </label>
       <label className="block">
-        <span className="mb-1 block text-xs font-medium text-fg-2">시스템 프롬프트 *</span>
+        <span className="mb-1 block text-xs font-medium text-fg-2">{t("systemPromptLabel")}</span>
         <textarea value={systemPrompt} onChange={(e) => setSystemPrompt(e.target.value)}
           rows={6}
-          placeholder="당신은 ... 전문가입니다. ..."
+          placeholder={t("systemPromptPlaceholder")}
           className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none focus:border-accent resize-none" />
         <span className="text-xs text-faint">{systemPrompt.length}/8000</span>
       </label>
       {formError && <p className="text-xs text-danger">{formError}</p>}
       <div className="flex justify-end gap-2 pt-1">
-        <Button type="button" variant="outline" onClick={onClose} disabled={saving}>취소</Button>
+        <Button type="button" variant="outline" onClick={onClose} disabled={saving}>{t("cancel")}</Button>
         <Button type="submit" disabled={saving}>
           {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-          {isEdit ? "저장" : "생성"}
+          {isEdit ? t("save") : t("create")}
         </Button>
       </div>
     </form>
@@ -202,6 +208,7 @@ function AgentGitIngestForm({
   onClose: () => void;
   onSaved: () => void | Promise<void>;
 }) {
+  const t = useTranslations("customAgents");
   const [gitUrl, setGitUrl] = useState("");
   const [gitRef, setGitRef] = useState("");
   const [gitPath, setGitPath] = useState("");
@@ -211,10 +218,10 @@ function AgentGitIngestForm({
   const [formError, setFormError] = useState<string | null>(null);
 
   async function handleImport() {
-    if (!gitUrl.trim()) { setFormError("GitHub URL을 입력하세요."); return; }
+    if (!gitUrl.trim()) { setFormError(t("gitUrlRequired")); return; }
     setLoading(true);
     setFormError(null);
-    setProgress("저장소 가져오는 중...");
+    setProgress(t("fetchingRepo"));
 
     try {
       const resp = await fetch("/api/agents/custom/import-from-git", {
@@ -230,8 +237,8 @@ function AgentGitIngestForm({
       });
 
       if (!resp.ok || !resp.body) {
-        const errText = await resp.text().catch(() => "서버 오류");
-        setFormError(`실패 (${resp.status}): ${errText}`);
+        const errText = await resp.text().catch(() => t("serverError"));
+        setFormError(t("importFailedStatus", { status: resp.status, error: errText }));
         setLoading(false);
         setProgress(null);
         return;
@@ -258,14 +265,14 @@ function AgentGitIngestForm({
           try {
             const parsed = JSON.parse(data) as Record<string, unknown>;
             if (eventName === "progress") {
-              setProgress("매니페스트 처리 중...");
+              setProgress(t("processingManifest"));
             } else if (eventName === "result") {
-              setProgress("완료!");
+              setProgress(t("done"));
               setLoading(false);
               await onSaved();
               return;
             } else if (eventName === "error") {
-              const errMsg = ((parsed as { error?: { message?: string } }).error?.message) || "가져오기 실패";
+              const errMsg = ((parsed as { error?: { message?: string } }).error?.message) || t("importFailed");
               setFormError(errMsg);
               setLoading(false);
               setProgress(null);
@@ -278,7 +285,7 @@ function AgentGitIngestForm({
       }
       await onSaved();
     } catch (err) {
-      setFormError("요청 실패: " + (err instanceof Error ? err.message : "네트워크 오류"));
+      setFormError(t("requestFailed", { error: err instanceof Error ? err.message : t("networkError") }));
     } finally {
       setLoading(false);
       setProgress(null);
@@ -287,27 +294,27 @@ function AgentGitIngestForm({
 
   return (
     <form onSubmit={(e) => { e.preventDefault(); void handleImport(); }} className="space-y-4">
-      <p className="text-sm text-muted">GitHub 저장소의 AGENT.md 매니페스트를 가져와 draft로 저장합니다.</p>
+      <p className="text-sm text-muted">{t("gitIngestDescription")}</p>
       <label className="block">
-        <span className="mb-1 block text-xs font-medium text-fg-2">GitHub URL *</span>
+        <span className="mb-1 block text-xs font-medium text-fg-2">{t("gitUrlLabel")}</span>
         <input value={gitUrl} onChange={(e) => setGitUrl(e.target.value)} autoFocus
           placeholder="https://github.com/owner/repo"
           className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
       </label>
       <div className="grid gap-3 sm:grid-cols-2">
         <label className="block">
-          <span className="mb-1 block text-xs font-medium text-fg-2">브랜치/태그 (선택)</span>
+          <span className="mb-1 block text-xs font-medium text-fg-2">{t("branchTagLabel")}</span>
           <input value={gitRef} onChange={(e) => setGitRef(e.target.value)} placeholder="main"
             className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
         </label>
         <label className="block">
-          <span className="mb-1 block text-xs font-medium text-fg-2">파일 경로 (선택)</span>
+          <span className="mb-1 block text-xs font-medium text-fg-2">{t("filePathLabel")}</span>
           <input value={gitPath} onChange={(e) => setGitPath(e.target.value)} placeholder="AGENT.md"
             className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
         </label>
       </div>
       <label className="block">
-        <span className="mb-1 block text-xs font-medium text-fg-2">Access Token (비공개 저장소)</span>
+        <span className="mb-1 block text-xs font-medium text-fg-2">{t("accessTokenLabel")}</span>
         <input type="password" value={accessToken} onChange={(e) => setAccessToken(e.target.value)} placeholder="ghp_..."
           className="h-9 w-full rounded-md border border-border bg-surface px-3 font-mono text-sm text-fg outline-none focus:border-accent" />
       </label>
@@ -319,10 +326,10 @@ function AgentGitIngestForm({
       )}
       {formError && <p className="text-xs text-danger">{formError}</p>}
       <div className="flex justify-end gap-2 pt-1">
-        <Button type="button" variant="outline" onClick={onClose} disabled={loading}>취소</Button>
+        <Button type="button" variant="outline" onClick={onClose} disabled={loading}>{t("cancel")}</Button>
         <Button type="submit" disabled={loading}>
           {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <GitBranch className="h-4 w-4" />}
-          가져오기
+          {t("importButton")}
         </Button>
       </div>
     </form>
@@ -331,6 +338,7 @@ function AgentGitIngestForm({
 
 /* ── Draft 탭 (에이전트용) ──────────────────────────────────── */
 function AgentDraftTab({ onRefresh }: { onRefresh: () => void }) {
+  const t = useTranslations("customAgents");
   const [drafts, setDrafts] = useState<ApiCustomAgentDraft[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -354,17 +362,17 @@ function AgentDraftTab({ onRefresh }: { onRefresh: () => void }) {
       await loadDrafts();
       onRefresh();
     } catch (err) {
-      alert("승인 실패: " + (err instanceof Error ? err.message : "오류"));
+      alert(t("approveFailed", { error: err instanceof Error ? err.message : t("genericError") }));
     }
   }
 
   async function handleReject(agentId: string) {
-    if (!window.confirm("이 draft 에이전트를 거부(보관)하시겠습니까?")) return;
+    if (!window.confirm(t("rejectConfirm"))) return;
     try {
       await ApiClient.post(`/api/agents/custom/${agentId}/reject`, {});
       await loadDrafts();
     } catch (err) {
-      alert("거부 실패: " + (err instanceof Error ? err.message : "오류"));
+      alert(t("rejectFailed", { error: err instanceof Error ? err.message : t("genericError") }));
     }
   }
 
@@ -372,7 +380,7 @@ function AgentDraftTab({ onRefresh }: { onRefresh: () => void }) {
     return (
       <div className="grid place-items-center py-16 text-center">
         <Loader2 className="mb-3 h-6 w-6 animate-spin text-faint" />
-        <p className="text-sm text-muted">Draft 불러오는 중...</p>
+        <p className="text-sm text-muted">{t("loadingDrafts")}</p>
       </div>
     );
   }
@@ -381,8 +389,8 @@ function AgentDraftTab({ onRefresh }: { onRefresh: () => void }) {
     return (
       <div className="grid place-items-center py-16 text-center">
         <Bot className="mb-3 h-8 w-8 text-faint" />
-        <p className="text-sm font-medium text-fg-2">승인 대기 중인 Draft가 없습니다</p>
-        <p className="mt-1 text-sm text-muted">Git URL 가져오기로 생성된 에이전트가 여기 나타납니다.</p>
+        <p className="text-sm font-medium text-fg-2">{t("noDraftsTitle")}</p>
+        <p className="mt-1 text-sm text-muted">{t("noDraftsDescription")}</p>
       </div>
     );
   }
@@ -403,10 +411,10 @@ function AgentDraftTab({ onRefresh }: { onRefresh: () => void }) {
             </div>
             <div className="flex gap-2 shrink-0">
               <Button size="sm" onClick={() => void handleApprove(d.id)}>
-                <Check className="h-3.5 w-3.5" />승인
+                <Check className="h-3.5 w-3.5" />{t("approve")}
               </Button>
               <Button variant="outline" size="sm" onClick={() => void handleReject(d.id)}>
-                <X className="h-3.5 w-3.5" />거부
+                <X className="h-3.5 w-3.5" />{t("reject")}
               </Button>
             </div>
           </div>
@@ -418,7 +426,17 @@ function AgentDraftTab({ onRefresh }: { onRefresh: () => void }) {
 
 /* ── 메인 페이지 ──────────────────────────────────────────── */
 export default function CustomAgentsPage() {
-  const [agents, setAgents] = useState<CustomAgent[]>(AGENTS_FALLBACK);
+  const t = useTranslations("customAgents");
+  const [agents, setAgents] = useState<CustomAgent[]>(() =>
+    AGENTS_FALLBACK_META.map((m) => ({
+      id: m.id,
+      emoji: m.emoji,
+      name: t(m.nameKey),
+      description: t(m.descKey),
+      systemPrompt: t(m.promptKey),
+      source: m.source,
+    })),
+  );
   const [loading, setLoading] = useState(true);
   const [tab, setTab] = useState<string>(TAB_ACTIVE);
   const [showCreate, setShowCreate] = useState(false);
@@ -446,12 +464,12 @@ export default function CustomAgentsPage() {
   }, [loadAgents]);
 
   async function handleDelete(agent: CustomAgent) {
-    if (!window.confirm(`"${agent.name}" 에이전트를 삭제하시겠습니까?`)) return;
+    if (!window.confirm(t("deleteConfirm", { name: agent.name }))) return;
     try {
       await ApiClient.del(`/api/users/me/agents/${agent.id}`);
       await loadAgents();
     } catch (err) {
-      alert("삭제 실패: " + (err instanceof Error ? err.message : "오류"));
+      alert(t("deleteFailed", { error: err instanceof Error ? err.message : t("genericError") }));
     }
   }
 
@@ -465,16 +483,16 @@ export default function CustomAgentsPage() {
   return (
     <>
       <PageHeader
-        title="커스텀 에이전트"
-        description="나만의 시스템 프롬프트로 특화된 에이전트를 정의합니다."
+        title={t("pageTitle")}
+        description={t("pageDescription")}
         actions={
           <>
             <Button variant="outline" size="sm" onClick={() => setShowGitIngest(true)}>
               <GitBranch className="h-4 w-4" />
-              Git URL 에서 가져오기
+              {t("importFromGit")}
             </Button>
             <Button size="sm" onClick={() => setShowCreate(true)}>
-              <Plus className="h-4 w-4" />새 에이전트
+              <Plus className="h-4 w-4" />{t("newAgent")}
             </Button>
           </>
         }
@@ -482,10 +500,10 @@ export default function CustomAgentsPage() {
 
       {/* 탭 */}
       <div className="flex gap-4 border-b border-border px-6 pt-3">
-        {[{ id: TAB_ACTIVE, label: "활성 에이전트" }, { id: TAB_DRAFT, label: "Draft 검토" }].map((t) => (
-          <button key={t.id} onClick={() => setTab(t.id)}
-            className={`pb-2 text-sm font-medium transition border-b-2 ${tab === t.id ? "border-accent text-accent" : "border-transparent text-muted hover:text-fg"}`}>
-            {t.label}
+        {[{ id: TAB_ACTIVE, labelKey: "tabActive" }, { id: TAB_DRAFT, labelKey: "tabDraft" }].map((tabItem) => (
+          <button key={tabItem.id} onClick={() => setTab(tabItem.id)}
+            className={`pb-2 text-sm font-medium transition border-b-2 ${tab === tabItem.id ? "border-accent text-accent" : "border-transparent text-muted hover:text-fg"}`}>
+            {t(tabItem.labelKey)}
           </button>
         ))}
       </div>
@@ -496,17 +514,17 @@ export default function CustomAgentsPage() {
         ) : loading ? (
           <div className="grid place-items-center py-24 text-center">
             <Bot className="mb-3 h-8 w-8 animate-pulse text-faint" />
-            <p className="text-sm text-muted">불러오는 중...</p>
+            <p className="text-sm text-muted">{t("loading")}</p>
           </div>
         ) : agents.length === 0 ? (
           <div className="grid place-items-center py-24 text-center">
             <Bot className="mb-3 h-8 w-8 text-faint" />
-            <p className="text-sm font-medium text-fg-2">아직 커스텀 에이전트가 없습니다</p>
+            <p className="text-sm font-medium text-fg-2">{t("emptyTitle")}</p>
             <p className="mt-1 max-w-sm text-sm text-muted">
-              직접 만들거나 Git URL 에서 가져와 특화된 에이전트를 추가하세요.
+              {t("emptyDescription")}
             </p>
             <Button size="sm" className="mt-4" onClick={() => setShowCreate(true)}>
-              <Plus className="h-4 w-4" />새 에이전트 만들기
+              <Plus className="h-4 w-4" />{t("createNewAgent")}
             </Button>
           </div>
         ) : (
@@ -527,12 +545,12 @@ export default function CustomAgentsPage() {
 
                 <h3 className="mb-1 text-sm font-semibold text-fg">{agent.name}</h3>
                 <p className="mb-3 line-clamp-2 text-xs leading-relaxed text-muted">
-                  {agent.description}
+                  {agent.description || t("noDescription")}
                 </p>
 
                 <div className="mb-4 flex-1 rounded-md border border-border bg-surface-2 p-3">
                   <p className="mb-1 font-mono text-[10px] uppercase tracking-wide text-faint">
-                    시스템 프롬프트
+                    {t("systemPromptHeading")}
                   </p>
                   <p className="line-clamp-3 text-xs leading-relaxed text-fg-2">
                     {agent.systemPrompt}
@@ -542,9 +560,9 @@ export default function CustomAgentsPage() {
                 <div className="flex gap-2">
                   <Button variant="outline" size="sm" className="flex-1" onClick={() => setEditingAgent(agent)}>
                     <Pencil className="h-3.5 w-3.5" />
-                    편집
+                    {t("edit")}
                   </Button>
-                  <Button variant="ghost" size="icon" aria-label="삭제" onClick={() => void handleDelete(agent)}>
+                  <Button variant="ghost" size="icon" aria-label={t("deleteAria")} onClick={() => void handleDelete(agent)}>
                     <Trash2 className="h-4 w-4 text-danger" />
                   </Button>
                 </div>
@@ -555,17 +573,17 @@ export default function CustomAgentsPage() {
       </div>
 
       {/* 모달들 */}
-      <Modal open={showCreate} onClose={() => setShowCreate(false)} title="새 에이전트 생성">
+      <Modal open={showCreate} onClose={() => setShowCreate(false)} title={t("createModalTitle")}>
         <AgentForm onClose={() => setShowCreate(false)} onSaved={afterSave} />
       </Modal>
 
-      <Modal open={!!editingAgent} onClose={() => setEditingAgent(null)} title="에이전트 편집">
+      <Modal open={!!editingAgent} onClose={() => setEditingAgent(null)} title={t("editModalTitle")}>
         {editingAgent && (
           <AgentForm initial={editingAgent} onClose={() => setEditingAgent(null)} onSaved={afterSave} />
         )}
       </Modal>
 
-      <Modal open={showGitIngest} onClose={() => setShowGitIngest(false)} title="Git URL에서 에이전트 가져오기">
+      <Modal open={showGitIngest} onClose={() => setShowGitIngest(false)} title={t("gitImportModalTitle")}>
         <AgentGitIngestForm onClose={() => setShowGitIngest(false)} onSaved={afterSave} />
       </Modal>
     </>

--- a/apps/web/app/(workspace)/research/page.tsx
+++ b/apps/web/app/(workspace)/research/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import {
   CircleCheck,
   LoaderCircle,
@@ -30,21 +31,23 @@ type StageStatus = "done" | "running" | "pending";
 
 interface Stage {
   key: string;
-  label: string;
-  desc: string;
+  labelKey: string;
+  descKey: string;
   status: StageStatus;
 }
 
 interface Source {
   id: string;
   title: string;
+  titleKey?: string;
   domain: string;
   verified: boolean;
 }
 
 interface Metric {
-  label: string;
+  labelKey: string;
   value: string;
+  valueKey?: string;
   tone?: "default" | "warn";
 }
 
@@ -76,10 +79,10 @@ type ResearchSessionsResponse = ApiSuccess<{
 /** progress(0~100) 기준으로 4단계 파이프라인 상태를 파생. completed 면 전부 done. */
 function deriveStages(session: ApiResearchSession): Stage[] {
   const base: Omit<Stage, "status">[] = [
-    { key: "decompose", label: "질문 분해", desc: "핵심 질문을 검증 가능한 하위 질문으로 분해" },
-    { key: "collect", label: "소스 수집", desc: "웹 검색 fan-out 및 신뢰도 기반 소스 선별" },
-    { key: "verify", label: "교차 검증", desc: "주장별 적대적 검증 및 상충 탐지" },
-    { key: "synthesize", label: "보고서 합성", desc: "인용 포함 최종 보고서 생성" },
+    { key: "decompose", labelKey: "stages.decompose.label", descKey: "stages.decompose.desc" },
+    { key: "collect", labelKey: "stages.collect.label", descKey: "stages.collect.desc" },
+    { key: "verify", labelKey: "stages.verify.label", descKey: "stages.verify.desc" },
+    { key: "synthesize", labelKey: "stages.synthesize.label", descKey: "stages.synthesize.desc" },
   ];
   if (session.status === "completed") {
     return base.map((s) => ({ ...s, status: "done" as StageStatus }));
@@ -112,26 +115,26 @@ function urlToSource(raw: string, idx: number): Source {
 const STAGES: Stage[] = [
   {
     key: "decompose",
-    label: "질문 분해",
-    desc: "핵심 질문을 검증 가능한 하위 질문으로 분해",
+    labelKey: "stages.decompose.label",
+    descKey: "stages.decompose.desc",
     status: "done",
   },
   {
     key: "collect",
-    label: "소스 수집",
-    desc: "웹 검색 fan-out 및 신뢰도 기반 소스 선별",
+    labelKey: "stages.collect.label",
+    descKey: "stages.collect.desc",
     status: "done",
   },
   {
     key: "verify",
-    label: "교차 검증",
-    desc: "주장별 적대적 검증 및 상충 탐지",
+    labelKey: "stages.verify.label",
+    descKey: "stages.verify.desc",
     status: "running",
   },
   {
     key: "synthesize",
-    label: "보고서 합성",
-    desc: "인용 포함 최종 보고서 생성",
+    labelKey: "stages.synthesize.label",
+    descKey: "stages.synthesize.desc",
     status: "pending",
   },
 ];
@@ -139,42 +142,47 @@ const STAGES: Stage[] = [
 const SOURCES: Source[] = [
   {
     id: "1",
-    title: "2026 AI 에이전트 시장 동향 보고서",
+    title: "",
+    titleKey: "mock.source1",
     domain: "research.example.com",
     verified: true,
   },
   {
     id: "2",
-    title: "멀티 에이전트 오케스트레이션 아키텍처 분석",
+    title: "",
+    titleKey: "mock.source2",
     domain: "arxiv.org",
     verified: true,
   },
   {
     id: "3",
-    title: "엔터프라이즈 LLM 도입 사례 연구",
+    title: "",
+    titleKey: "mock.source3",
     domain: "techblog.example.io",
     verified: true,
   },
   {
     id: "4",
-    title: "자율 에이전트 안전성 가이드라인",
+    title: "",
+    titleKey: "mock.source4",
     domain: "safety.example.org",
     verified: false,
   },
   {
     id: "5",
-    title: "RAG vs 장기 컨텍스트 비교 벤치마크",
+    title: "",
+    titleKey: "mock.source5",
     domain: "benchmark.example.dev",
     verified: true,
   },
 ];
 
 const METRICS: Metric[] = [
-  { label: "분석 소스", value: "5" },
-  { label: "검증 주장", value: "23" },
-  { label: "상충 발견", value: "2", tone: "warn" },
-  { label: "사용 토큰", value: "48.2K" },
-  { label: "경과 시간", value: "3분 12초" },
+  { labelKey: "metrics.sources", value: "5" },
+  { labelKey: "mock.verifiedClaims", value: "23" },
+  { labelKey: "mock.conflicts", value: "2", tone: "warn" },
+  { labelKey: "mock.tokensUsed", value: "48.2K" },
+  { labelKey: "mock.elapsed", value: "", valueKey: "mock.elapsedValue" },
 ];
 
 const STAGE_ICON: Record<StageStatus, typeof Circle> = {
@@ -186,12 +194,12 @@ const STAGE_ICON: Record<StageStatus, typeof Circle> = {
 
 const TERMINAL: ApiResearchStatus[] = ["completed", "failed", "cancelled"];
 
-const STATUS_LABEL: Record<ApiResearchStatus, string> = {
-  pending: "대기",
-  running: "진행중",
-  completed: "완료",
-  failed: "실패",
-  cancelled: "취소",
+const STATUS_LABEL_KEY: Record<ApiResearchStatus, string> = {
+  pending: "status.pending",
+  running: "status.running",
+  completed: "status.completed",
+  failed: "status.failed",
+  cancelled: "status.cancelled",
 };
 const STATUS_TONE: Record<ApiResearchStatus, "success" | "accent" | "neutral" | "warn"> = {
   pending: "neutral",
@@ -209,6 +217,7 @@ function fmtDate(iso?: string): string {
 }
 
 export default function ResearchPage() {
+  const t = useTranslations("research");
   const router = useRouter();
   const [sourcesOpen, setSourcesOpen] = useState(false);
   // 최신 세션이 있으면 그것으로 진행/소스/메트릭 표시. 없거나 실패 시 목업 폴백.
@@ -230,10 +239,10 @@ export default function ResearchPage() {
     setActiveSession(s);
     setSessionList((prev) => prev.map((p) => (p.id === s.id ? { ...p, ...s } : p)));
     setMetrics([
-      { label: "분석 소스", value: String(srcUrls.length) },
-      { label: "주요 발견", value: String(s.key_findings?.length ?? 0) },
-      { label: "진행률", value: `${Math.round(s.progress)}%` },
-      { label: "깊이", value: s.depth },
+      { labelKey: "metrics.sources", value: String(srcUrls.length) },
+      { labelKey: "metrics.keyFindings", value: String(s.key_findings?.length ?? 0) },
+      { labelKey: "metrics.progress", value: `${Math.round(s.progress)}%` },
+      { labelKey: "metrics.depth", value: s.depth },
     ]);
   };
 
@@ -294,20 +303,22 @@ export default function ResearchPage() {
   return (
     <>
       <PageHeader
-        title="딥 리서치 히스토리"
-        description="지난 리서치 결과를 조회합니다. 실행은 채팅의 딥 리서치 모드에서 진행됩니다."
+        title={t("pageTitle")}
+        description={t("pageDescription")}
       />
 
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
         {/* 실행 안내 배너 — 생성/실행은 채팅 인라인으로 일원화 */}
         <Card className="mb-6 flex flex-wrap items-center justify-between gap-3 p-4">
           <p className="text-sm text-muted">
-            딥 리서치는 채팅 입력창의{" "}
-            <span className="font-medium text-fg-2">딥 리서치</span> 모드로
-            실행하세요. 이 페이지에서는 지난 리서치 결과를 조회합니다.
+            {t.rich("runBanner", {
+              mode: (chunks) => (
+                <span className="font-medium text-fg-2">{chunks}</span>
+              ),
+            })}
           </p>
           <Button size="sm" variant="outline" onClick={() => router.push("/")}>
-            채팅으로 이동
+            {t("goToChat")}
           </Button>
         </Card>
 
@@ -317,12 +328,12 @@ export default function ResearchPage() {
           <div className="min-w-0">
             <Card className="lg:sticky lg:top-0">
               <CardHeader className="flex items-center justify-between">
-                <CardTitle>지난 리서치</CardTitle>
+                <CardTitle>{t("pastResearch")}</CardTitle>
                 <span className="font-mono text-xs text-faint">{sessionList.length}</span>
               </CardHeader>
               <CardContent className="max-h-[60vh] space-y-1.5 overflow-y-auto">
                 {sessionList.length === 0 ? (
-                  <p className="py-4 text-center text-xs text-muted">아직 리서치가 없습니다.</p>
+                  <p className="py-4 text-center text-xs text-muted">{t("sessionEmpty")}</p>
                 ) : (
                   sessionList.map((s) => (
                     <button
@@ -338,7 +349,7 @@ export default function ResearchPage() {
                     >
                       <div className="flex items-center gap-2">
                         <span className="min-w-0 flex-1 truncate text-sm text-fg">{s.topic}</span>
-                        <Badge tone={STATUS_TONE[s.status]}>{STATUS_LABEL[s.status]}</Badge>
+                        <Badge tone={STATUS_TONE[s.status]}>{t(STATUS_LABEL_KEY[s.status])}</Badge>
                       </div>
                       <div className="mt-0.5 flex items-center gap-2 text-[11px] text-faint">
                         <span>{fmtDate(s.created_at)}</span>
@@ -368,10 +379,10 @@ export default function ResearchPage() {
                           stage.status === "running" && "bg-accent-soft text-accent",
                           stage.status === "pending" && "bg-surface-2 text-faint",
                         )}
-                        title={stage.desc}
+                        title={t(stage.descKey)}
                       >
                         <Icon className={cn("h-3.5 w-3.5", stage.status === "running" && "animate-spin")} />
-                        {stage.label}
+                        {t(stage.labelKey)}
                       </span>
                       {i < stages.length - 1 && (
                         <span className="hidden h-px w-5 bg-border sm:block" />
@@ -385,10 +396,10 @@ export default function ResearchPage() {
             {/* 메트릭 — 가로 인라인 stat strip */}
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
               {metrics.map((m) => (
-                <Card key={m.label} className="p-3">
+                <Card key={m.labelKey} className="p-3">
                   <p className="flex items-center gap-1 text-[11px] text-muted">
                     {m.tone === "warn" && <TriangleAlert className="h-3 w-3 text-warn" />}
-                    {m.label}
+                    {t(m.labelKey)}
                   </p>
                   <p
                     className={cn(
@@ -396,7 +407,7 @@ export default function ResearchPage() {
                       m.tone === "warn" ? "text-warn" : "text-fg",
                     )}
                   >
-                    {m.value}
+                    {m.valueKey ? t(m.valueKey) : m.value}
                   </p>
                 </Card>
               ))}
@@ -405,10 +416,10 @@ export default function ResearchPage() {
             {/* 보고서 — 메인 산출물, 넓게 */}
             <Card>
               <CardHeader className="flex items-center justify-between">
-                <CardTitle>보고서</CardTitle>
+                <CardTitle>{t("report")}</CardTitle>
                 {activeSession && (
                   <Badge tone={STATUS_TONE[activeSession.status]}>
-                    {STATUS_LABEL[activeSession.status]}
+                    {t(STATUS_LABEL_KEY[activeSession.status])}
                   </Badge>
                 )}
               </CardHeader>
@@ -422,7 +433,7 @@ export default function ResearchPage() {
                     )}
                     {(activeSession?.key_findings?.length ?? 0) > 0 && (
                       <div className="space-y-2 border-t border-border pt-3">
-                        <p className="text-xs font-semibold text-fg-2">주요 발견</p>
+                        <p className="text-xs font-semibold text-fg-2">{t("keyFindings")}</p>
                         <ul className="space-y-1.5">
                           {activeSession!.key_findings!.map((f, i) => (
                             <li key={i} className="flex gap-2 text-sm text-fg-2">
@@ -437,7 +448,7 @@ export default function ResearchPage() {
                 ) : (
                   <div className="flex items-center gap-2 py-6 text-sm text-muted">
                     <FileText className="h-4 w-4 text-faint" />
-                    {isRunning ? "리서치 진행 중 — 합성 완료 후 보고서가 표시됩니다." : "보고서는 합성 완료 후 표시됩니다."}
+                    {isRunning ? t("reportPendingRunning") : t("reportPending")}
                   </div>
                 )}
               </CardContent>
@@ -451,8 +462,10 @@ export default function ResearchPage() {
                 className="flex w-full items-center justify-between px-5 py-4"
               >
                 <span className="flex items-center gap-2 text-sm font-semibold text-fg">
-                  수집 소스
-                  <span className="font-mono text-xs text-faint">{sources.length}건</span>
+                  {t("collectedSources")}
+                  <span className="font-mono text-xs text-faint">
+                    {t("sourceCount", { count: sources.length })}
+                  </span>
                 </span>
                 <ChevronDown
                   className={cn(
@@ -470,13 +483,13 @@ export default function ResearchPage() {
                     >
                       <Link className="mt-0.5 h-4 w-4 flex-shrink-0 text-faint" />
                       <div className="min-w-0 flex-1">
-                        <p className="truncate text-sm text-fg">{s.title}</p>
+                        <p className="truncate text-sm text-fg">{s.titleKey ? t(s.titleKey) : s.title}</p>
                         <p className="truncate font-mono text-xs text-faint">{s.domain}</p>
                       </div>
                       {s.verified ? (
-                        <Badge tone="success">검증됨</Badge>
+                        <Badge tone="success">{t("verified")}</Badge>
                       ) : (
-                        <Badge tone="warn">미검증</Badge>
+                        <Badge tone="warn">{t("unverified")}</Badge>
                       )}
                     </div>
                   ))}

--- a/apps/web/app/(workspace)/settings/page.tsx
+++ b/apps/web/app/(workspace)/settings/page.tsx
@@ -33,26 +33,26 @@ import { LOCALE_COOKIE, LOCALE_COOKIE_MAX_AGE, isLocale } from "@/i18n/config";
 /* ── 탭 정의 ────────────────────────────────────────────── */
 type TabId = "general" | "model" | "interface" | "notifications" | "privacy" | "security";
 
-const TABS: { id: TabId; label: string; icon: LucideIcon }[] = [
-  { id: "general", label: "일반", icon: Settings },
-  { id: "model", label: "모델 & 응답", icon: Bot },
-  { id: "interface", label: "인터페이스", icon: Palette },
-  { id: "notifications", label: "알림", icon: Bell },
-  { id: "privacy", label: "개인정보", icon: ShieldCheck },
-  { id: "security", label: "보안", icon: ShieldCheck },
+const TABS: { id: TabId; labelKey: string; icon: LucideIcon }[] = [
+  { id: "general", labelKey: "tabs.general", icon: Settings },
+  { id: "model", labelKey: "tabs.model", icon: Bot },
+  { id: "interface", labelKey: "tabs.interface", icon: Palette },
+  { id: "notifications", labelKey: "tabs.notifications", icon: Bell },
+  { id: "privacy", labelKey: "tabs.privacy", icon: ShieldCheck },
+  { id: "security", labelKey: "tabs.security", icon: ShieldCheck },
 ];
 
 
 const RESPONSE_STYLES = [
-  { value: "concise", label: "간결" },
-  { value: "default", label: "기본" },
-  { value: "verbose", label: "상세" },
+  { value: "concise", labelKey: "responseStyles.concise" },
+  { value: "default", labelKey: "responseStyles.default" },
+  { value: "verbose", labelKey: "responseStyles.verbose" },
 ] as const;
 
 const THEMES = [
-  { value: "system", label: "시스템 설정" },
-  { value: "light", label: "라이트" },
-  { value: "dark", label: "다크" },
+  { value: "system", labelKey: "themes.system" },
+  { value: "light", labelKey: "themes.light" },
+  { value: "dark", labelKey: "themes.dark" },
 ];
 
 /** NEXT_LOCALE 쿠키 값 (미설정/미지원 값 = "" → 자동 감지). */
@@ -170,6 +170,7 @@ function Segment<T extends string>({
 
 /* ── 페이지 ─────────────────────────────────────────────── */
 export default function SettingsPage() {
+  const tSettings = useTranslations("settings");
   const [tab, setTab] = useState<TabId>("general");
 
   // 일반 / 모델
@@ -189,7 +190,7 @@ export default function SettingsPage() {
   const externalModels = allModels.filter((m) => m.provider !== "local-llm");
   const toOption = (m: (typeof allModels)[number]) => ({
     value: m.modelId,
-    label: m.name + (m.isFree ? " · 무료" : ""),
+    label: m.name + (m.isFree ? tSettings("freeSuffix") : ""),
   });
   // provider id → 표시 라벨 (현재 openrouter 만 등록 가능, 그 외 provider 도 일반 처리)
   const externalGroupLabel = (provider: string) =>
@@ -206,9 +207,9 @@ export default function SettingsPage() {
       .map(toOption),
   }));
   const modelGroups = [
-    { label: "기본", options: [{ value: "default", label: "자동 (서버 기본값)" }] },
+    { label: tSettings("modelGroup.default"), options: [{ value: "default", label: tSettings("modelGroup.auto") }] },
     ...(localModels.length
-      ? [{ label: "🏠 로컬 vLLM", options: localModels.map(toOption) }]
+      ? [{ label: tSettings("modelGroup.local"), options: localModels.map(toOption) }]
       : []),
     ...externalGroups,
   ];
@@ -220,7 +221,6 @@ export default function SettingsPage() {
     () => "",
   );
   const [customInstructions, setCustomInstructions] = useState("");
-  const tSettings = useTranslations("settings");
   const router = useRouter();
 
   const changeLanguage = (v: string) => {
@@ -374,23 +374,23 @@ export default function SettingsPage() {
 
   async function handlePasswordChange() {
     if (newPassword !== confirmPassword) {
-      setPwMessage({ text: "새 비밀번호가 일치하지 않습니다.", ok: false });
+      setPwMessage({ text: tSettings("password.mismatch"), ok: false });
       return;
     }
     if (newPassword.length < 8) {
-      setPwMessage({ text: "새 비밀번호는 8자 이상이어야 합니다.", ok: false });
+      setPwMessage({ text: tSettings("password.tooShort"), ok: false });
       return;
     }
     setPwSaving(true);
     setPwMessage(null);
     try {
       await ApiClient.put("/api/auth/password", { currentPassword, newPassword });
-      setPwMessage({ text: "비밀번호가 변경되었습니다.", ok: true });
+      setPwMessage({ text: tSettings("password.changed"), ok: true });
       setCurrentPassword("");
       setNewPassword("");
       setConfirmPassword("");
     } catch (err) {
-      const msg = err instanceof ApiError ? err.message : "비밀번호 변경에 실패했습니다.";
+      const msg = err instanceof ApiError ? err.message : tSettings("password.changeFailed");
       setPwMessage({ text: msg, ok: false });
     } finally {
       setPwSaving(false);
@@ -400,12 +400,12 @@ export default function SettingsPage() {
   return (
     <>
       <PageHeader
-        title="설정"
-        description="앱 환경과 AI 모델 동작을 구성합니다."
+        title={tSettings("pageTitle")}
+        description={tSettings("pageDescription")}
         actions={
           <div className="flex items-center gap-3">
             {savedAt && (
-              <span className="text-xs text-muted">{savedAt} 저장됨</span>
+              <span className="text-xs text-muted">{tSettings("savedAt", { time: savedAt })}</span>
             )}
             <Button onClick={handleSave} disabled={saving || loading}>
               {saving ? (
@@ -413,7 +413,7 @@ export default function SettingsPage() {
               ) : (
                 <Save className="h-4 w-4" />
               )}
-              설정 저장
+              {tSettings("saveButton")}
             </Button>
           </div>
         }
@@ -439,7 +439,7 @@ export default function SettingsPage() {
                   )}
                 >
                   <Icon className="h-4 w-4" />
-                  {t.label}
+                  {tSettings(t.labelKey)}
                 </button>
               );
             })}
@@ -450,12 +450,12 @@ export default function SettingsPage() {
             {tab === "general" && (
               <Card>
                 <CardHeader>
-                  <CardTitle>일반</CardTitle>
+                  <CardTitle>{tSettings("tabs.general")}</CardTitle>
                 </CardHeader>
                 <CardContent className="py-0">
                   <FieldRow
-                    title="언어"
-                    description="인터페이스 표시 언어. 자동 감지 시 브라우저 언어를 따릅니다. (AI 응답은 메시지 언어를 따릅니다)"
+                    title={tSettings("language.title")}
+                    description={tSettings("language.description")}
                   >
                     <Select
                       value={language}
@@ -466,8 +466,8 @@ export default function SettingsPage() {
                     />
                   </FieldRow>
                   <FieldRow
-                    title="대화 본문 저장"
-                    description="대화 내용을 서버 DB에 저장합니다. 끄면 익명 사용량 메타만 기록됩니다."
+                    title={tSettings("saveHistory.title")}
+                    description={tSettings("saveHistory.descriptionGeneral")}
                   >
                     <Toggle checked={saveHistory} onChange={setSaveHistory} />
                   </FieldRow>
@@ -478,12 +478,12 @@ export default function SettingsPage() {
             {tab === "model" && (
               <Card>
                 <CardHeader>
-                  <CardTitle>모델 & 응답</CardTitle>
+                  <CardTitle>{tSettings("tabs.model")}</CardTitle>
                 </CardHeader>
                 <CardContent className="py-0">
                   <FieldRow
-                    title="기본 모델"
-                    description="새 대화에 사용할 모델입니다. 🏠 로컬 vLLM 과 🌐 외부 LLM(OpenRouter, BYOK) 중 선택합니다."
+                    title={tSettings("defaultModel.title")}
+                    description={tSettings("defaultModel.description")}
                   >
                     {allModels.length ? (
                       <div className="flex flex-col gap-1.5">
@@ -494,14 +494,14 @@ export default function SettingsPage() {
                         />
                         {externalModels.length === 0 && (
                           <p className="text-xs text-muted">
-                            외부 LLM(OpenRouter)을 추가하려면{" "}
+                            {tSettings("externalLlmHint.prefix")}{" "}
                             <a
                               href="/api-keys"
                               className="text-accent underline underline-offset-2 hover:opacity-80"
                             >
-                              API 키 페이지
+                              {tSettings("externalLlmHint.link")}
                             </a>
-                            에서 키를 등록하세요.
+                            {tSettings("externalLlmHint.suffix")}
                           </p>
                         )}
                       </div>
@@ -509,38 +509,41 @@ export default function SettingsPage() {
                       <Select
                         value=""
                         onChange={setSelectedModel}
-                        options={[{ value: "", label: "모델 로딩…" }]}
+                        options={[{ value: "", label: tSettings("modelLoading") }]}
                       />
                     )}
                   </FieldRow>
                   <FieldRow
-                    title="이미지 생성"
-                    description="채팅에서 그림/이미지를 요청하면 자동으로 사용됩니다. 별도 선택은 필요 없습니다."
+                    title={tSettings("imageGeneration.title")}
+                    description={tSettings("imageGeneration.description")}
                   >
                     {modelsData?.imageModel ? (
                       <Badge tone="neutral">
                         <span className="font-mono">{modelsData.imageModel}</span>
                       </Badge>
                     ) : (
-                      <span className="text-sm text-muted">미설정</span>
+                      <span className="text-sm text-muted">{tSettings("notConfigured")}</span>
                     )}
                   </FieldRow>
                   <FieldRow
-                    title="응답 스타일"
-                    description="응답의 자세함 정도를 조절합니다."
+                    title={tSettings("responseStyle.title")}
+                    description={tSettings("responseStyle.description")}
                   >
                     <Segment
                       value={responseStyle}
                       onChange={setResponseStyle}
-                      options={RESPONSE_STYLES}
+                      options={RESPONSE_STYLES.map((s) => ({
+                        value: s.value,
+                        label: tSettings(s.labelKey),
+                      }))}
                     />
                   </FieldRow>
                   <div className="py-4">
                     <h4 className="text-sm font-medium text-fg">
-                      사용자 지시문 (Custom Instructions)
+                      {tSettings("customInstructions.title")}
                     </h4>
                     <p className="mt-0.5 text-xs text-muted">
-                      모든 대화에 영구 적용되는 system prompt 추가 지시문입니다.
+                      {tSettings("customInstructions.description")}
                     </p>
                     <textarea
                       value={customInstructions}
@@ -550,11 +553,14 @@ export default function SettingsPage() {
                         )
                       }
                       rows={6}
-                      placeholder="예: 사용자가 명시적으로 요청하지 않은 부가 정보는 출력하지 않는다."
+                      placeholder={tSettings("customInstructions.placeholder")}
                       className="mt-3 w-full resize-y rounded-md border border-border-strong bg-surface px-3 py-2 text-sm text-fg outline-none transition focus:border-accent"
                     />
                     <p className="mt-1 text-right text-xs text-faint">
-                      {customInstructions.length} / {CUSTOM_INSTRUCTIONS_MAX} 자
+                      {tSettings("customInstructions.charCount", {
+                        count: customInstructions.length,
+                        max: CUSTOM_INSTRUCTIONS_MAX,
+                      })}
                     </p>
                   </div>
                 </CardContent>
@@ -564,14 +570,21 @@ export default function SettingsPage() {
             {tab === "interface" && (
               <Card>
                 <CardHeader>
-                  <CardTitle>인터페이스</CardTitle>
+                  <CardTitle>{tSettings("tabs.interface")}</CardTitle>
                 </CardHeader>
                 <CardContent className="py-0">
                   <FieldRow
-                    title="테마"
-                    description="앱의 색상 테마를 선택합니다."
+                    title={tSettings("theme.title")}
+                    description={tSettings("theme.description")}
                   >
-                    <Select value={theme} onChange={setTheme} options={THEMES} />
+                    <Select
+                      value={theme}
+                      onChange={setTheme}
+                      options={THEMES.map((th) => ({
+                        value: th.value,
+                        label: tSettings(th.labelKey),
+                      }))}
+                    />
                   </FieldRow>
                 </CardContent>
               </Card>
@@ -580,26 +593,26 @@ export default function SettingsPage() {
             {tab === "notifications" && (
               <Card>
                 <CardHeader>
-                  <CardTitle>알림</CardTitle>
+                  <CardTitle>{tSettings("tabs.notifications")}</CardTitle>
                 </CardHeader>
                 <CardContent className="py-0">
                   <FieldRow
-                    title="이메일 알림"
-                    description="에이전트 작업 완료 및 보안 이벤트를 이메일로 받습니다."
+                    title={tSettings("emailAlerts.title")}
+                    description={tSettings("emailAlerts.description")}
                   >
                     <Toggle checked={emailAlerts} onChange={setEmailAlerts} />
                   </FieldRow>
                   <FieldRow
-                    title="푸시 알림"
-                    description="브라우저 푸시로 실시간 알림을 받습니다."
+                    title={tSettings("pushAlerts.title")}
+                    description={tSettings("pushAlerts.description")}
                   >
                     {pushSupported === false ? (
                       <p className="text-xs text-muted">
-                        이 브라우저는 푸시 알림을 지원하지 않습니다.
+                        {tSettings("pushNotSupported")}
                       </p>
                     ) : pushSupported === true && !pushSwReady ? (
                       <p className="text-xs text-muted">
-                        서비스 워커가 등록되지 않아 푸시 알림을 사용할 수 없습니다.
+                        {tSettings("pushSwNotReady")}
                       </p>
                     ) : (
                       <div className="flex items-center gap-2">
@@ -620,12 +633,12 @@ export default function SettingsPage() {
             {tab === "privacy" && (
               <Card>
                 <CardHeader>
-                  <CardTitle>개인정보</CardTitle>
+                  <CardTitle>{tSettings("tabs.privacy")}</CardTitle>
                 </CardHeader>
                 <CardContent className="py-0">
                   <FieldRow
-                    title="장기 기억 학습"
-                    description="대화에서 이름·직업·선호 같은 사실을 추출하여 저장합니다."
+                    title={tSettings("memoryLearning.title")}
+                    description={tSettings("memoryLearning.description")}
                   >
                     <Toggle
                       checked={memoryLearning}
@@ -633,8 +646,8 @@ export default function SettingsPage() {
                     />
                   </FieldRow>
                   <FieldRow
-                    title="대화 본문 저장"
-                    description="끄면 대화 본문은 서버에 저장되지 않습니다."
+                    title={tSettings("saveHistory.title")}
+                    description={tSettings("saveHistory.descriptionPrivacy")}
                   >
                     <Toggle checked={saveHistory} onChange={setSaveHistory} />
                   </FieldRow>
@@ -645,7 +658,7 @@ export default function SettingsPage() {
             {tab === "security" && (
               <Card>
                 <CardHeader>
-                  <CardTitle>비밀번호 변경</CardTitle>
+                  <CardTitle>{tSettings("passwordChange.title")}</CardTitle>
                 </CardHeader>
                 <CardContent className="py-0">
                   {pwMessage && (
@@ -660,7 +673,7 @@ export default function SettingsPage() {
                       {pwMessage.text}
                     </div>
                   )}
-                  <FieldRow title="현재 비밀번호">
+                  <FieldRow title={tSettings("password.current")}>
                     <input
                       type="password"
                       value={currentPassword}
@@ -669,7 +682,7 @@ export default function SettingsPage() {
                       className="h-9 w-full rounded-md border border-border-strong bg-surface px-3 text-sm text-fg outline-none transition focus:border-accent"
                     />
                   </FieldRow>
-                  <FieldRow title="새 비밀번호" description="8자 이상">
+                  <FieldRow title={tSettings("password.new")} description={tSettings("password.newHint")}>
                     <input
                       type="password"
                       value={newPassword}
@@ -678,7 +691,7 @@ export default function SettingsPage() {
                       className="h-9 w-full rounded-md border border-border-strong bg-surface px-3 text-sm text-fg outline-none transition focus:border-accent"
                     />
                   </FieldRow>
-                  <FieldRow title="새 비밀번호 확인">
+                  <FieldRow title={tSettings("password.confirm")}>
                     <input
                       type="password"
                       value={confirmPassword}
@@ -697,7 +710,7 @@ export default function SettingsPage() {
                       ) : (
                         <Save className="h-4 w-4" />
                       )}
-                      비밀번호 변경
+                      {tSettings("passwordChange.title")}
                     </Button>
                   </div>
                 </CardContent>

--- a/apps/web/app/(workspace)/skill-library/page.tsx
+++ b/apps/web/app/(workspace)/skill-library/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import {
   Library,
   Plus,
@@ -29,16 +30,16 @@ import { cn } from "@/lib/utils";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { ApiClient } from "@/lib/api-client";
 
-/* ── 카테고리 라벨 ─────────────────────────────────────────── */
-const CATEGORY_LABELS: Record<string, string> = {
-  productivity: "생산성",
-  technology: "기술/IT",
-  creative: "창작/디자인",
-  business: "비즈니스",
-  science: "과학/연구",
-  communication: "커뮤니케이션",
-  finance: "금융/투자",
-  education: "교육/학습",
+/* ── 카테고리 라벨 (id → i18n 키) ──────────────────────────── */
+const CATEGORY_KEYS: Record<string, string> = {
+  productivity: "categories.productivity",
+  technology: "categories.technology",
+  creative: "categories.creative",
+  business: "categories.business",
+  science: "categories.science",
+  communication: "categories.communication",
+  finance: "categories.finance",
+  education: "categories.education",
 };
 
 /* ── 타입 ─────────────────────────────────────────────────── */
@@ -76,12 +77,16 @@ type DraftsResponse = ApiSuccess<{
 }>;
 
 /* ── 목업 폴백 ─────────────────────────────────────────────── */
-const SKILL_FALLBACK: Skill[] = [
-  { id: "s1", name: "PDF 요약", category: "productivity", description: "긴 PDF 문서를 핵심 요점으로 압축합니다.", isSystem: true },
-  { id: "s2", name: "SQL 쿼리 작성", category: "technology", description: "자연어 요구사항을 파라미터화된 SQL 로 변환합니다.", isSystem: true },
-  { id: "s3", name: "광고 카피라이팅", category: "creative", description: "타겟 세그먼트에 맞춘 마케팅 카피를 생성합니다.", isSystem: false },
-  { id: "s4", name: "재무 보고서 해석", category: "finance", description: "손익계산서와 대차대조표의 핵심 지표를 해석합니다.", isSystem: false },
-];
+type Translate = (key: string) => string;
+
+function buildFallback(t: Translate): Skill[] {
+  return [
+    { id: "s1", name: t("fallback.pdfSummary.name"), category: "productivity", description: t("fallback.pdfSummary.description"), isSystem: true },
+    { id: "s2", name: t("fallback.sqlQuery.name"), category: "technology", description: t("fallback.sqlQuery.description"), isSystem: true },
+    { id: "s3", name: t("fallback.adCopy.name"), category: "creative", description: t("fallback.adCopy.description"), isSystem: false },
+    { id: "s4", name: t("fallback.financialReport.name"), category: "finance", description: t("fallback.financialReport.description"), isSystem: false },
+  ];
+}
 
 function mapSkill(s: ApiSkill): Skill {
   return {
@@ -96,8 +101,10 @@ function mapSkill(s: ApiSkill): Skill {
   };
 }
 
-function categoryLabel(id: string) {
-  return CATEGORY_LABELS[id] || id || "일반";
+function categoryLabel(t: Translate, id: string): string {
+  const key = CATEGORY_KEYS[id];
+  if (key) return t(key);
+  return id || t("categoryGeneral");
 }
 
 const ALL = "all";
@@ -153,6 +160,7 @@ function SkillForm({
   onClose: () => void;
   onSaved: () => void | Promise<void>;
 }) {
+  const t = useTranslations("skillLibrary");
   const [name, setName] = useState(initial?.name ?? "");
   const [description, setDescription] = useState(initial?.description ?? "");
   const [content, setContent] = useState(initial?.content ?? "");
@@ -164,8 +172,8 @@ function SkillForm({
   const isEdit = !!initial;
 
   async function handleSubmit() {
-    if (!name.trim()) { setFormError("스킬 이름을 입력하세요."); return; }
-    if (!content.trim()) { setFormError("스킬 내용(Instructions)을 입력하세요."); return; }
+    if (!name.trim()) { setFormError(t("form.nameRequired")); return; }
+    if (!content.trim()) { setFormError(t("form.contentRequired")); return; }
     setSaving(true);
     setFormError(null);
     try {
@@ -176,7 +184,7 @@ function SkillForm({
       }
       await onSaved();
     } catch (err) {
-      setFormError("저장 실패: " + (err instanceof Error ? err.message : "서버 오류"));
+      setFormError(t("form.saveFailed", { error: err instanceof Error ? err.message : t("serverError") }));
     } finally {
       setSaving(false);
     }
@@ -186,44 +194,44 @@ function SkillForm({
     <form onSubmit={(e) => { e.preventDefault(); void handleSubmit(); }} className="space-y-4">
       <div className="grid gap-4 sm:grid-cols-2">
         <label className="block sm:col-span-2">
-          <span className="mb-1 block text-xs font-medium text-fg-2">스킬 이름 *</span>
+          <span className="mb-1 block text-xs font-medium text-fg-2">{t("form.nameLabel")}</span>
           <input value={name} onChange={(e) => setName(e.target.value)}
-            placeholder="예: PDF 요약" autoFocus
+            placeholder={t("form.namePlaceholder")} autoFocus
             className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
         </label>
         <label className="block">
-          <span className="mb-1 block text-xs font-medium text-fg-2">카테고리</span>
+          <span className="mb-1 block text-xs font-medium text-fg-2">{t("form.categoryLabel")}</span>
           <select value={category} onChange={(e) => setCategory(e.target.value)}
             className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent">
-            {Object.entries(CATEGORY_LABELS).map(([k, v]) => (
-              <option key={k} value={k}>{v}</option>
+            {Object.entries(CATEGORY_KEYS).map(([k, key]) => (
+              <option key={k} value={k}>{t(key)}</option>
             ))}
           </select>
         </label>
         <label className="flex cursor-pointer items-center gap-2 self-end">
           <input type="checkbox" checked={isPublic} onChange={(e) => setIsPublic(e.target.checked)}
             className="h-4 w-4 rounded border-border accent-accent" />
-          <span className="text-xs text-fg-2">공개 스킬</span>
+          <span className="text-xs text-fg-2">{t("form.publicLabel")}</span>
         </label>
       </div>
       <label className="block">
-        <span className="mb-1 block text-xs font-medium text-fg-2">설명</span>
+        <span className="mb-1 block text-xs font-medium text-fg-2">{t("form.descriptionLabel")}</span>
         <input value={description} onChange={(e) => setDescription(e.target.value)}
-          placeholder="이 스킬이 하는 일을 간단히 설명하세요"
+          placeholder={t("form.descriptionPlaceholder")}
           className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
       </label>
       <label className="block">
-        <span className="mb-1 block text-xs font-medium text-fg-2">Instructions (스킬 내용) *</span>
+        <span className="mb-1 block text-xs font-medium text-fg-2">{t("form.instructionsLabel")}</span>
         <textarea value={content} onChange={(e) => setContent(e.target.value)}
-          rows={5} placeholder="이 스킬이 수행할 작업을 상세히 기술하세요..."
+          rows={5} placeholder={t("form.instructionsPlaceholder")}
           className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none focus:border-accent resize-none" />
       </label>
       {formError && <p className="text-xs text-danger">{formError}</p>}
       <div className="flex justify-end gap-2 pt-1">
-        <Button type="button" variant="outline" onClick={onClose}>취소</Button>
+        <Button type="button" variant="outline" onClick={onClose}>{t("cancel")}</Button>
         <Button type="submit" disabled={saving}>
           {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-          {isEdit ? "저장" : "생성"}
+          {isEdit ? t("save") : t("create")}
         </Button>
       </div>
     </form>
@@ -238,13 +246,14 @@ function UploadForm({
   onClose: () => void;
   onSaved: () => void | Promise<void>;
 }) {
+  const t = useTranslations("skillLibrary");
   const [file, setFile] = useState<File | null>(null);
   const [uploading, setUploading] = useState(false);
   const [result, setResult] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
 
   async function handleUpload() {
-    if (!file) { setFormError("파일을 선택하세요."); return; }
+    if (!file) { setFormError(t("upload.fileRequired")); return; }
     setUploading(true);
     setFormError(null);
     try {
@@ -252,10 +261,10 @@ function UploadForm({
       fd.append("file", file);
       const res = await ApiClient.post<ApiSuccess<{ skill_id: string; version: string; inserted: boolean }>>("/api/agents/skills/upload", fd);
       const d = res?.data;
-      setResult(d ? `업로드 완료: ${d.skill_id} v${d.version}` : "업로드 완료");
+      setResult(d ? t("upload.successDetail", { id: d.skill_id, version: d.version }) : t("upload.success"));
       await onSaved();
     } catch (err) {
-      setFormError("업로드 실패: " + (err instanceof Error ? err.message : "서버 오류"));
+      setFormError(t("upload.failed", { error: err instanceof Error ? err.message : t("serverError") }));
     } finally {
       setUploading(false);
     }
@@ -263,9 +272,9 @@ function UploadForm({
 
   return (
     <div className="space-y-4">
-      <p className="text-sm text-muted">.SKILL 또는 .md YAML frontmatter 파일을 업로드합니다. (최대 256KB)</p>
+      <p className="text-sm text-muted">{t("upload.hint")}</p>
       <label className="block">
-        <span className="mb-1 block text-xs font-medium text-fg-2">파일 선택</span>
+        <span className="mb-1 block text-xs font-medium text-fg-2">{t("upload.fileLabel")}</span>
         <input type="file" accept=".skill,.md"
           onChange={(e) => setFile(e.target.files?.[0] ?? null)}
           className="text-sm text-fg-2 file:mr-3 file:rounded-md file:border-0 file:bg-surface-2 file:px-3 file:py-1.5 file:text-xs file:font-medium file:text-fg hover:file:bg-surface-3" />
@@ -273,10 +282,10 @@ function UploadForm({
       {result && <p className="text-xs text-success">{result}</p>}
       {formError && <p className="text-xs text-danger">{formError}</p>}
       <div className="flex justify-end gap-2">
-        <Button variant="outline" onClick={onClose}>취소</Button>
+        <Button variant="outline" onClick={onClose}>{t("cancel")}</Button>
         <Button onClick={() => void handleUpload()} disabled={!file || uploading}>
           {uploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
-          업로드
+          {t("upload.submit")}
         </Button>
       </div>
     </div>
@@ -291,6 +300,7 @@ function AutoCreateForm({
   onClose: () => void;
   onSaved: () => void | Promise<void>;
 }) {
+  const t = useTranslations("skillLibrary");
   const [purpose, setPurpose] = useState("");
   const [target, setTarget] = useState("");
   const [category, setCategory] = useState("productivity");
@@ -307,10 +317,10 @@ function AutoCreateForm({
   useEffect(() => () => cleanup(), []);
 
   async function handleGenerate() {
-    if (!purpose.trim()) { setFormError("목적을 입력하세요."); return; }
+    if (!purpose.trim()) { setFormError(t("auto.purposeRequired")); return; }
     setGenerating(true);
     setFormError(null);
-    setProgress("생성 요청 중...");
+    setProgress(t("auto.requesting"));
 
     // SSE 방식: fetch + ReadableStream 로 파싱
     try {
@@ -322,8 +332,8 @@ function AutoCreateForm({
       });
 
       if (!resp.ok || !resp.body) {
-        const errText = await resp.text().catch(() => "서버 오류");
-        setFormError(`실패 (${resp.status}): ${errText}`);
+        const errText = await resp.text().catch(() => t("serverError"));
+        setFormError(t("failedStatus", { status: resp.status, error: errText }));
         setGenerating(false);
         setProgress(null);
         return;
@@ -351,14 +361,14 @@ function AutoCreateForm({
             const parsed = JSON.parse(data) as Record<string, unknown>;
             if (eventName === "progress") {
               const phase = (parsed as { phase?: string }).phase;
-              setProgress(phase === "llm_call_started" ? "LLM 생성 중..." : "처리 중...");
+              setProgress(phase === "llm_call_started" ? t("auto.generating") : t("auto.processing"));
             } else if (eventName === "result") {
-              setProgress("생성 완료!");
+              setProgress(t("auto.done"));
               cleanup();
               await onSaved();
               return;
             } else if (eventName === "error") {
-              const errMsg = ((parsed as { error?: { message?: string } }).error?.message) || "생성 실패";
+              const errMsg = ((parsed as { error?: { message?: string } }).error?.message) || t("auto.generateFailed");
               setFormError(errMsg);
               cleanup();
               setGenerating(false);
@@ -372,7 +382,7 @@ function AutoCreateForm({
       }
       await onSaved();
     } catch (err) {
-      setFormError("요청 실패: " + (err instanceof Error ? err.message : "네트워크 오류"));
+      setFormError(t("requestFailed", { error: err instanceof Error ? err.message : t("networkError") }));
     } finally {
       setGenerating(false);
       setProgress(null);
@@ -381,26 +391,26 @@ function AutoCreateForm({
 
   return (
     <form onSubmit={(e) => { e.preventDefault(); void handleGenerate(); }} className="space-y-4">
-      <p className="text-sm text-muted">자연어 목적을 입력하면 LLM이 스킬 매니페스트를 자동 생성합니다.</p>
+      <p className="text-sm text-muted">{t("auto.hint")}</p>
       <label className="block">
-        <span className="mb-1 block text-xs font-medium text-fg-2">스킬 목적 *</span>
+        <span className="mb-1 block text-xs font-medium text-fg-2">{t("auto.purposeLabel")}</span>
         <textarea value={purpose} onChange={(e) => setPurpose(e.target.value)}
-          rows={3} autoFocus placeholder="예: PDF 문서를 업로드하면 핵심 내용을 3줄로 요약하는 스킬"
+          rows={3} autoFocus placeholder={t("auto.purposePlaceholder")}
           className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none focus:border-accent resize-none" />
       </label>
       <div className="grid gap-3 sm:grid-cols-2">
         <label className="block">
-          <span className="mb-1 block text-xs font-medium text-fg-2">대상 사용자 (선택)</span>
+          <span className="mb-1 block text-xs font-medium text-fg-2">{t("auto.targetLabel")}</span>
           <input value={target} onChange={(e) => setTarget(e.target.value)}
-            placeholder="예: 연구자, 마케터"
+            placeholder={t("auto.targetPlaceholder")}
             className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
         </label>
         <label className="block">
-          <span className="mb-1 block text-xs font-medium text-fg-2">카테고리</span>
+          <span className="mb-1 block text-xs font-medium text-fg-2">{t("form.categoryLabel")}</span>
           <select value={category} onChange={(e) => setCategory(e.target.value)}
             className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent">
-            {Object.entries(CATEGORY_LABELS).map(([k, v]) => (
-              <option key={k} value={k}>{v}</option>
+            {Object.entries(CATEGORY_KEYS).map(([k, key]) => (
+              <option key={k} value={k}>{t(key)}</option>
             ))}
           </select>
         </label>
@@ -413,10 +423,10 @@ function AutoCreateForm({
       )}
       {formError && <p className="text-xs text-danger">{formError}</p>}
       <div className="flex justify-end gap-2 pt-1">
-        <Button type="button" variant="outline" onClick={onClose} disabled={generating}>취소</Button>
+        <Button type="button" variant="outline" onClick={onClose} disabled={generating}>{t("cancel")}</Button>
         <Button type="submit" disabled={generating}>
           {generating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Cpu className="h-4 w-4" />}
-          AI 생성
+          {t("auto.submit")}
         </Button>
       </div>
     </form>
@@ -431,6 +441,7 @@ function GitIngestForm({
   onClose: () => void;
   onSaved: () => void | Promise<void>;
 }) {
+  const t = useTranslations("skillLibrary");
   const [gitUrl, setGitUrl] = useState("");
   const [gitRef, setGitRef] = useState("");
   const [gitPath, setGitPath] = useState("");
@@ -440,10 +451,10 @@ function GitIngestForm({
   const [formError, setFormError] = useState<string | null>(null);
 
   async function handleImport() {
-    if (!gitUrl.trim()) { setFormError("GitHub URL을 입력하세요."); return; }
+    if (!gitUrl.trim()) { setFormError(t("git.urlRequired")); return; }
     setLoading(true);
     setFormError(null);
-    setProgress("저장소 가져오는 중...");
+    setProgress(t("git.fetching"));
 
     try {
       const resp = await fetch("/api/agents/skills/import-from-git", {
@@ -459,8 +470,8 @@ function GitIngestForm({
       });
 
       if (!resp.ok || !resp.body) {
-        const errText = await resp.text().catch(() => "서버 오류");
-        setFormError(`실패 (${resp.status}): ${errText}`);
+        const errText = await resp.text().catch(() => t("serverError"));
+        setFormError(t("failedStatus", { status: resp.status, error: errText }));
         setLoading(false);
         setProgress(null);
         return;
@@ -487,14 +498,14 @@ function GitIngestForm({
           try {
             const parsed = JSON.parse(data) as Record<string, unknown>;
             if (eventName === "progress") {
-              setProgress("매니페스트 검증 중...");
+              setProgress(t("git.validating"));
             } else if (eventName === "result") {
-              setProgress("완료!");
+              setProgress(t("git.done"));
               setLoading(false);
               await onSaved();
               return;
             } else if (eventName === "error") {
-              const errMsg = ((parsed as { error?: { message?: string } }).error?.message) || "가져오기 실패";
+              const errMsg = ((parsed as { error?: { message?: string } }).error?.message) || t("git.importFailed");
               setFormError(errMsg);
               setLoading(false);
               setProgress(null);
@@ -507,7 +518,7 @@ function GitIngestForm({
       }
       await onSaved();
     } catch (err) {
-      setFormError("요청 실패: " + (err instanceof Error ? err.message : "네트워크 오류"));
+      setFormError(t("requestFailed", { error: err instanceof Error ? err.message : t("networkError") }));
     } finally {
       setLoading(false);
       setProgress(null);
@@ -516,29 +527,29 @@ function GitIngestForm({
 
   return (
     <form onSubmit={(e) => { e.preventDefault(); void handleImport(); }} className="space-y-4">
-      <p className="text-sm text-muted">GitHub 저장소의 SKILL.md 매니페스트를 가져와 draft로 저장합니다.</p>
+      <p className="text-sm text-muted">{t("git.hint")}</p>
       <label className="block">
-        <span className="mb-1 block text-xs font-medium text-fg-2">GitHub URL *</span>
+        <span className="mb-1 block text-xs font-medium text-fg-2">{t("git.urlLabel")}</span>
         <input value={gitUrl} onChange={(e) => setGitUrl(e.target.value)} autoFocus
           placeholder="https://github.com/owner/repo"
           className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
       </label>
       <div className="grid gap-3 sm:grid-cols-2">
         <label className="block">
-          <span className="mb-1 block text-xs font-medium text-fg-2">브랜치/태그 (선택)</span>
+          <span className="mb-1 block text-xs font-medium text-fg-2">{t("git.refLabel")}</span>
           <input value={gitRef} onChange={(e) => setGitRef(e.target.value)}
             placeholder="main"
             className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
         </label>
         <label className="block">
-          <span className="mb-1 block text-xs font-medium text-fg-2">파일 경로 (선택)</span>
+          <span className="mb-1 block text-xs font-medium text-fg-2">{t("git.pathLabel")}</span>
           <input value={gitPath} onChange={(e) => setGitPath(e.target.value)}
             placeholder="SKILL.md"
             className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
         </label>
       </div>
       <label className="block">
-        <span className="mb-1 block text-xs font-medium text-fg-2">Access Token (비공개 저장소)</span>
+        <span className="mb-1 block text-xs font-medium text-fg-2">{t("git.tokenLabel")}</span>
         <input type="password" value={accessToken} onChange={(e) => setAccessToken(e.target.value)}
           placeholder="ghp_..."
           className="h-9 w-full rounded-md border border-border bg-surface px-3 font-mono text-sm text-fg outline-none focus:border-accent" />
@@ -551,10 +562,10 @@ function GitIngestForm({
       )}
       {formError && <p className="text-xs text-danger">{formError}</p>}
       <div className="flex justify-end gap-2 pt-1">
-        <Button type="button" variant="outline" onClick={onClose} disabled={loading}>취소</Button>
+        <Button type="button" variant="outline" onClick={onClose} disabled={loading}>{t("cancel")}</Button>
         <Button type="submit" disabled={loading}>
           {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <GitBranch className="h-4 w-4" />}
-          가져오기
+          {t("git.submit")}
         </Button>
       </div>
     </form>
@@ -591,21 +602,22 @@ function SkillCard({
   onToggleAssign: (s: Skill, assigned: boolean) => void;
   onExport: (s: Skill) => void;
 }) {
+  const t = useTranslations("skillLibrary");
   return (
     <Card className="flex flex-col p-5">
       <div className="mb-3 flex items-center gap-2">
         <div className="grid h-9 w-9 place-items-center rounded-md bg-accent-soft text-accent">
           <Package className="h-4 w-4" />
         </div>
-        <Badge tone="neutral">{categoryLabel(skill.category)}</Badge>
-        {skill.isSystem ? <Badge tone="accent">시스템</Badge> : <Badge tone="neutral">사용자</Badge>}
+        <Badge tone="neutral">{categoryLabel(t, skill.category)}</Badge>
+        {skill.isSystem ? <Badge tone="accent">{t("systemBadge")}</Badge> : <Badge tone="neutral">{t("userBadge")}</Badge>}
       </div>
       <h3 className="mb-1 text-sm font-semibold text-fg">{skill.name}</h3>
       <p className="mb-3 line-clamp-2 flex-1 text-xs leading-relaxed text-muted">{skill.description}</p>
       <div className="flex items-center gap-1.5 border-t border-border pt-3">
         <button
           onClick={() => onToggleAssign(skill, assigned)}
-          title={assigned ? "개인 스킬 해제" : "개인 스킬로 추가"}
+          title={assigned ? t("card.unassignTitle") : t("card.assignTitle")}
           className={cn(
             "flex h-7 w-7 items-center justify-center rounded-md transition",
             assigned ? "text-accent hover:bg-accent-soft" : "text-faint hover:bg-surface-2 hover:text-fg",
@@ -614,7 +626,7 @@ function SkillCard({
         </button>
         <button
           onClick={() => onExport(skill)}
-          title=".SKILL.md 내보내기"
+          title={t("card.exportTitle")}
           className="flex h-7 w-7 items-center justify-center rounded-md text-faint transition hover:bg-surface-2 hover:text-fg">
           <Download className="h-3.5 w-3.5" />
         </button>
@@ -622,7 +634,7 @@ function SkillCard({
         <button
           onClick={() => onEdit(skill)}
           className="flex h-7 items-center gap-1 rounded-md px-2 text-xs text-fg-2 transition hover:bg-surface-2">
-          <Pencil className="h-3 w-3" />편집
+          <Pencil className="h-3 w-3" />{t("edit")}
         </button>
         <button
           onClick={() => onDelete(skill)}
@@ -636,6 +648,7 @@ function SkillCard({
 
 /* ── Draft 탭 ─────────────────────────────────────────────── */
 function DraftTab({ onRefresh }: { onRefresh: () => void }) {
+  const t = useTranslations("skillLibrary");
   const [drafts, setDrafts] = useState<Skill[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -659,17 +672,17 @@ function DraftTab({ onRefresh }: { onRefresh: () => void }) {
       await loadDrafts();
       onRefresh();
     } catch (err) {
-      alert("승인 실패: " + (err instanceof Error ? err.message : "오류"));
+      alert(t("draft.approveFailed", { error: err instanceof Error ? err.message : t("genericError") }));
     }
   }
 
   async function handleReject(skillId: string) {
-    if (!window.confirm("이 draft를 거부(보관)하시겠습니까?")) return;
+    if (!window.confirm(t("draft.rejectConfirm"))) return;
     try {
       await ApiClient.post(`/api/agents/skills/${skillId}/reject`, {});
       await loadDrafts();
     } catch (err) {
-      alert("거부 실패: " + (err instanceof Error ? err.message : "오류"));
+      alert(t("draft.rejectFailed", { error: err instanceof Error ? err.message : t("genericError") }));
     }
   }
 
@@ -677,7 +690,7 @@ function DraftTab({ onRefresh }: { onRefresh: () => void }) {
     return (
       <div className="grid place-items-center py-16 text-center">
         <Loader2 className="mb-3 h-6 w-6 animate-spin text-faint" />
-        <p className="text-sm text-muted">Draft 불러오는 중...</p>
+        <p className="text-sm text-muted">{t("draft.loading")}</p>
       </div>
     );
   }
@@ -686,8 +699,8 @@ function DraftTab({ onRefresh }: { onRefresh: () => void }) {
     return (
       <div className="grid place-items-center py-16 text-center">
         <Library className="mb-3 h-8 w-8 text-faint" />
-        <p className="text-sm font-medium text-fg-2">승인 대기 중인 Draft가 없습니다</p>
-        <p className="mt-1 text-sm text-muted">AI 자동생성 또는 Git 가져오기로 생성된 스킬이 여기 나타납니다.</p>
+        <p className="text-sm font-medium text-fg-2">{t("draft.emptyTitle")}</p>
+        <p className="mt-1 text-sm text-muted">{t("draft.emptyDesc")}</p>
       </div>
     );
   }
@@ -700,17 +713,17 @@ function DraftTab({ onRefresh }: { onRefresh: () => void }) {
             <div className="flex-1 min-w-0">
               <div className="mb-1 flex items-center gap-2">
                 <Badge tone="warn">Draft</Badge>
-                <Badge tone="neutral">{categoryLabel(d.category)}</Badge>
+                <Badge tone="neutral">{categoryLabel(t, d.category)}</Badge>
               </div>
               <h3 className="text-sm font-semibold text-fg">{d.name}</h3>
               <p className="mt-1 text-xs text-muted line-clamp-2">{d.description}</p>
             </div>
             <div className="flex gap-2 shrink-0">
               <Button size="sm" onClick={() => void handleApprove(d.id)}>
-                <Check className="h-3.5 w-3.5" />승인
+                <Check className="h-3.5 w-3.5" />{t("draft.approve")}
               </Button>
               <Button variant="outline" size="sm" onClick={() => void handleReject(d.id)}>
-                <X className="h-3.5 w-3.5" />거부
+                <X className="h-3.5 w-3.5" />{t("draft.reject")}
               </Button>
             </div>
           </div>
@@ -722,7 +735,8 @@ function DraftTab({ onRefresh }: { onRefresh: () => void }) {
 
 /* ── 메인 페이지 ──────────────────────────────────────────── */
 export default function SkillLibraryPage() {
-  const [skills, setSkills] = useState<Skill[]>(SKILL_FALLBACK);
+  const t = useTranslations("skillLibrary");
+  const [skills, setSkills] = useState<Skill[]>(() => buildFallback(t));
   const [loading, setLoading] = useState(true);
   const [active, setActive] = useState<string>(ALL);
   const [tab, setTab] = useState<string>(TAB_ACTIVE);
@@ -768,18 +782,18 @@ export default function SkillLibraryPage() {
   const categories = useMemo(() => {
     const counts = new Map<string, number>();
     for (const s of skills) counts.set(s.category, (counts.get(s.category) || 0) + 1);
-    return Array.from(counts.entries()).map(([id, count]) => ({ id, label: categoryLabel(id), count }));
-  }, [skills]);
+    return Array.from(counts.entries()).map(([id, count]) => ({ id, label: categoryLabel(t, id), count }));
+  }, [skills, t]);
 
   const filtered = active === ALL ? skills : skills.filter((s) => s.category === active);
 
   async function handleDelete(skill: Skill) {
-    if (!window.confirm(`"${skill.name}" 스킬을 삭제하시겠습니까?`)) return;
+    if (!window.confirm(t("deleteConfirm", { name: skill.name }))) return;
     try {
       await ApiClient.del(`/api/agents/skills/${skill.id}`);
       await loadSkills();
     } catch (err) {
-      alert("삭제 실패: " + (err instanceof Error ? err.message : "오류"));
+      alert(t("deleteFailed", { error: err instanceof Error ? err.message : t("genericError") }));
     }
   }
 
@@ -793,7 +807,7 @@ export default function SkillLibraryPage() {
         setAssignedIds((prev) => new Set(prev).add(skill.id));
       }
     } catch (err) {
-      alert("할당 변경 실패: " + (err instanceof Error ? err.message : "오류"));
+      alert(t("assignFailed", { error: err instanceof Error ? err.message : t("genericError") }));
     }
   }
 
@@ -813,21 +827,21 @@ export default function SkillLibraryPage() {
   return (
     <>
       <PageHeader
-        title="스킬 라이브러리"
-        description="재사용 가능한 매니페스트와 도구 바인딩을 관리합니다."
+        title={t("pageTitle")}
+        description={t("pageDescription")}
         actions={
           <>
             <Button variant="outline" size="sm" onClick={() => setShowUpload(true)}>
-              <Upload className="h-4 w-4" />.SKILL 업로드
+              <Upload className="h-4 w-4" />{t("uploadButton")}
             </Button>
             <Button variant="outline" size="sm" onClick={() => setShowGitIngest(true)}>
-              <GitBranch className="h-4 w-4" />Git 가져오기
+              <GitBranch className="h-4 w-4" />{t("gitButton")}
             </Button>
             <Button variant="outline" size="sm" onClick={() => setShowAutoCreate(true)}>
-              <Cpu className="h-4 w-4" />AI 자동생성
+              <Cpu className="h-4 w-4" />{t("autoButton")}
             </Button>
             <Button size="sm" onClick={() => setShowCreate(true)}>
-              <Plus className="h-4 w-4" />새 스킬
+              <Plus className="h-4 w-4" />{t("newButton")}
             </Button>
           </>
         }
@@ -835,15 +849,15 @@ export default function SkillLibraryPage() {
 
       {/* 탭 */}
       <div className="flex gap-4 border-b border-border px-6 pt-3">
-        {[{ id: TAB_ACTIVE, label: "활성 스킬" }, { id: TAB_DRAFT, label: "Draft 검토" }].map((t) => (
-          <button key={t.id} onClick={() => setTab(t.id)}
+        {[{ id: TAB_ACTIVE, label: t("tabs.active") }, { id: TAB_DRAFT, label: t("tabs.draft") }].map((tabItem) => (
+          <button key={tabItem.id} onClick={() => setTab(tabItem.id)}
             className={cn(
               "pb-2 text-sm font-medium transition border-b-2",
-              tab === t.id
+              tab === tabItem.id
                 ? "border-accent text-accent"
                 : "border-transparent text-muted hover:text-fg",
             )}>
-            {t.label}
+            {tabItem.label}
           </button>
         ))}
       </div>
@@ -855,7 +869,7 @@ export default function SkillLibraryPage() {
           <>
             {/* 카테고리 필터 */}
             <div className="mb-5 flex flex-wrap gap-2">
-              <FilterChip label="전체" count={skills.length} active={active === ALL} onClick={() => setActive(ALL)} />
+              <FilterChip label={t("filterAll")} count={skills.length} active={active === ALL} onClick={() => setActive(ALL)} />
               {categories.map((c) => (
                 <FilterChip key={c.id} label={c.label} count={c.count} active={active === c.id} onClick={() => setActive(c.id)} />
               ))}
@@ -864,13 +878,13 @@ export default function SkillLibraryPage() {
             {loading ? (
               <div className="grid place-items-center py-24 text-center">
                 <Library className="mb-3 h-8 w-8 animate-pulse text-faint" />
-                <p className="text-sm text-muted">불러오는 중...</p>
+                <p className="text-sm text-muted">{t("loading")}</p>
               </div>
             ) : filtered.length === 0 ? (
               <div className="grid place-items-center py-24 text-center">
                 <Library className="mb-3 h-8 w-8 text-faint" />
-                <p className="text-sm font-medium text-fg-2">스킬이 없습니다</p>
-                <p className="mt-1 text-sm text-muted">다른 카테고리를 선택하거나 새 스킬을 추가하세요.</p>
+                <p className="text-sm font-medium text-fg-2">{t("emptyTitle")}</p>
+                <p className="mt-1 text-sm text-muted">{t("emptyDesc")}</p>
               </div>
             ) : (
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
@@ -892,25 +906,25 @@ export default function SkillLibraryPage() {
       </div>
 
       {/* 모달들 */}
-      <Modal open={showCreate} onClose={() => setShowCreate(false)} title="새 스킬 생성">
+      <Modal open={showCreate} onClose={() => setShowCreate(false)} title={t("modal.create")}>
         <SkillForm onClose={() => setShowCreate(false)} onSaved={afterSave} />
       </Modal>
 
-      <Modal open={!!editingSkill} onClose={() => setEditingSkill(null)} title="스킬 편집">
+      <Modal open={!!editingSkill} onClose={() => setEditingSkill(null)} title={t("modal.edit")}>
         {editingSkill && (
           <SkillForm initial={editingSkill} onClose={() => setEditingSkill(null)} onSaved={afterSave} />
         )}
       </Modal>
 
-      <Modal open={showUpload} onClose={() => setShowUpload(false)} title=".SKILL 파일 업로드">
+      <Modal open={showUpload} onClose={() => setShowUpload(false)} title={t("modal.upload")}>
         <UploadForm onClose={() => setShowUpload(false)} onSaved={afterSave} />
       </Modal>
 
-      <Modal open={showAutoCreate} onClose={() => setShowAutoCreate(false)} title="AI 스킬 자동 생성">
+      <Modal open={showAutoCreate} onClose={() => setShowAutoCreate(false)} title={t("modal.autoCreate")}>
         <AutoCreateForm onClose={() => setShowAutoCreate(false)} onSaved={afterSave} />
       </Modal>
 
-      <Modal open={showGitIngest} onClose={() => setShowGitIngest(false)} title="Git URL에서 스킬 가져오기">
+      <Modal open={showGitIngest} onClose={() => setShowGitIngest(false)} title={t("modal.gitIngest")}>
         <GitIngestForm onClose={() => setShowGitIngest(false)} onSaved={afterSave} />
       </Modal>
     </>

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -57,7 +57,100 @@
     "closeMenu": "Close menu"
   },
   "settings": {
-    "languageAuto": "Auto-detect"
+    "languageAuto": "Auto-detect",
+    "pageTitle": "Settings",
+    "pageDescription": "Configure app preferences and AI model behavior.",
+    "saveButton": "Save settings",
+    "savedAt": "Saved at {time}",
+    "freeSuffix": " · Free",
+    "notConfigured": "Not set",
+    "modelLoading": "Loading models…",
+    "tabs": {
+      "general": "General",
+      "model": "Model & Response",
+      "interface": "Interface",
+      "notifications": "Notifications",
+      "privacy": "Privacy",
+      "security": "Security"
+    },
+    "responseStyles": {
+      "concise": "Concise",
+      "default": "Default",
+      "verbose": "Verbose"
+    },
+    "themes": {
+      "system": "System",
+      "light": "Light",
+      "dark": "Dark"
+    },
+    "modelGroup": {
+      "default": "Default",
+      "auto": "Auto (server default)",
+      "local": "🏠 Local vLLM"
+    },
+    "language": {
+      "title": "Language",
+      "description": "Interface display language. Auto-detect follows your browser language. (AI responses follow the message language.)"
+    },
+    "saveHistory": {
+      "title": "Save conversation content",
+      "descriptionGeneral": "Store conversation content in the server database. When off, only anonymous usage metadata is recorded.",
+      "descriptionPrivacy": "When off, conversation content is not stored on the server."
+    },
+    "defaultModel": {
+      "title": "Default model",
+      "description": "The model used for new conversations. Choose between 🏠 local vLLM and 🌐 external LLMs (OpenRouter, BYOK)."
+    },
+    "externalLlmHint": {
+      "prefix": "To add an external LLM (OpenRouter),",
+      "link": "the API keys page",
+      "suffix": "is where you register your key."
+    },
+    "imageGeneration": {
+      "title": "Image generation",
+      "description": "Used automatically when you request a drawing or image in chat. No separate selection needed."
+    },
+    "responseStyle": {
+      "title": "Response style",
+      "description": "Adjust how detailed responses are."
+    },
+    "customInstructions": {
+      "title": "Custom Instructions",
+      "description": "Additional system prompt instructions applied permanently to every conversation.",
+      "placeholder": "e.g. Do not output extra information the user did not explicitly request.",
+      "charCount": "{count} / {max} chars"
+    },
+    "theme": {
+      "title": "Theme",
+      "description": "Choose the app color theme."
+    },
+    "emailAlerts": {
+      "title": "Email alerts",
+      "description": "Receive agent task completions and security events by email."
+    },
+    "pushAlerts": {
+      "title": "Push notifications",
+      "description": "Receive real-time notifications via browser push."
+    },
+    "pushNotSupported": "This browser does not support push notifications.",
+    "pushSwNotReady": "The service worker is not registered, so push notifications are unavailable.",
+    "memoryLearning": {
+      "title": "Long-term memory learning",
+      "description": "Extract and store facts such as name, occupation, and preferences from conversations."
+    },
+    "passwordChange": {
+      "title": "Change password"
+    },
+    "password": {
+      "current": "Current password",
+      "new": "New password",
+      "newHint": "8 characters or more",
+      "confirm": "Confirm new password",
+      "mismatch": "The new passwords do not match.",
+      "tooShort": "The new password must be at least 8 characters.",
+      "changed": "Password changed.",
+      "changeFailed": "Failed to change password."
+    }
   },
   "composer": {
     "dropToAttach": "Drop files here to attach",
@@ -295,5 +388,305 @@
     "agentTaskStartFailed": "Failed to start the agent task: {message}",
     "structuredAborted": "_(Structured answer generation was stopped.)_",
     "structuredFailed": "Failed to generate a structured answer: {message}"
+  },
+  "skillLibrary": {
+    "cancel": "Cancel",
+    "save": "Save",
+    "create": "Create",
+    "edit": "Edit",
+    "serverError": "Server error",
+    "networkError": "Network error",
+    "genericError": "Error",
+    "requestFailed": "Request failed: {error}",
+    "failedStatus": "Failed ({status}): {error}",
+    "systemBadge": "System",
+    "userBadge": "User",
+    "filterAll": "All",
+    "loading": "Loading...",
+    "emptyTitle": "No skills",
+    "emptyDesc": "Select another category or add a new skill.",
+    "deleteConfirm": "Delete the \"{name}\" skill?",
+    "deleteFailed": "Delete failed: {error}",
+    "assignFailed": "Failed to update assignment: {error}",
+    "pageTitle": "Skill Library",
+    "pageDescription": "Manage reusable manifests and tool bindings.",
+    "uploadButton": "Upload .SKILL",
+    "gitButton": "Import from Git",
+    "autoButton": "AI Generate",
+    "newButton": "New Skill",
+    "categoryGeneral": "General",
+    "categories": {
+      "productivity": "Productivity",
+      "technology": "Technology/IT",
+      "creative": "Creative/Design",
+      "business": "Business",
+      "science": "Science/Research",
+      "communication": "Communication",
+      "finance": "Finance/Investing",
+      "education": "Education/Learning"
+    },
+    "tabs": {
+      "active": "Active Skills",
+      "draft": "Draft Review"
+    },
+    "modal": {
+      "create": "Create New Skill",
+      "edit": "Edit Skill",
+      "upload": "Upload .SKILL File",
+      "autoCreate": "AI Skill Generation",
+      "gitIngest": "Import Skill from Git URL"
+    },
+    "fallback": {
+      "pdfSummary": {
+        "name": "PDF Summary",
+        "description": "Condenses long PDF documents into key points."
+      },
+      "sqlQuery": {
+        "name": "SQL Query Writer",
+        "description": "Converts natural-language requirements into parameterized SQL."
+      },
+      "adCopy": {
+        "name": "Ad Copywriting",
+        "description": "Generates marketing copy tailored to a target segment."
+      },
+      "financialReport": {
+        "name": "Financial Report Analysis",
+        "description": "Interprets key metrics from income statements and balance sheets."
+      }
+    },
+    "form": {
+      "nameRequired": "Enter a skill name.",
+      "contentRequired": "Enter the skill content (Instructions).",
+      "saveFailed": "Save failed: {error}",
+      "nameLabel": "Skill Name *",
+      "namePlaceholder": "e.g. PDF Summary",
+      "categoryLabel": "Category",
+      "publicLabel": "Public skill",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Briefly describe what this skill does",
+      "instructionsLabel": "Instructions (skill content) *",
+      "instructionsPlaceholder": "Describe in detail what this skill should do..."
+    },
+    "upload": {
+      "fileRequired": "Select a file.",
+      "successDetail": "Upload complete: {id} v{version}",
+      "success": "Upload complete",
+      "failed": "Upload failed: {error}",
+      "hint": "Upload a .SKILL or .md YAML frontmatter file. (max 256KB)",
+      "fileLabel": "Select file",
+      "submit": "Upload"
+    },
+    "auto": {
+      "purposeRequired": "Enter a purpose.",
+      "requesting": "Sending request...",
+      "generating": "Generating with LLM...",
+      "processing": "Processing...",
+      "done": "Generation complete!",
+      "generateFailed": "Generation failed",
+      "hint": "Enter a natural-language purpose and the LLM will auto-generate a skill manifest.",
+      "purposeLabel": "Skill Purpose *",
+      "purposePlaceholder": "e.g. A skill that summarizes uploaded PDF documents into three key lines",
+      "targetLabel": "Target users (optional)",
+      "targetPlaceholder": "e.g. researchers, marketers",
+      "submit": "AI Generate"
+    },
+    "git": {
+      "urlRequired": "Enter a GitHub URL.",
+      "fetching": "Fetching repository...",
+      "validating": "Validating manifest...",
+      "done": "Done!",
+      "importFailed": "Import failed",
+      "hint": "Import a SKILL.md manifest from a GitHub repository and save it as a draft.",
+      "urlLabel": "GitHub URL *",
+      "refLabel": "Branch/tag (optional)",
+      "pathLabel": "File path (optional)",
+      "tokenLabel": "Access Token (private repository)",
+      "submit": "Import"
+    },
+    "card": {
+      "assignTitle": "Add as personal skill",
+      "unassignTitle": "Remove personal skill",
+      "exportTitle": "Export .SKILL.md"
+    },
+    "draft": {
+      "approveFailed": "Approval failed: {error}",
+      "rejectConfirm": "Reject (archive) this draft?",
+      "rejectFailed": "Rejection failed: {error}",
+      "loading": "Loading drafts...",
+      "emptyTitle": "No drafts awaiting approval",
+      "emptyDesc": "Skills created via AI generation or Git import appear here.",
+      "approve": "Approve",
+      "reject": "Reject"
+    }
+  },
+  "agentTasks": {
+    "loading": "Loading...",
+    "error": "Error",
+    "chatCta": "Go to chat",
+    "pageTitle": "Agent task management",
+    "pageDescription": "Manage the task list, progress, and approvals. Creation and execution happen in the chat's agent mode.",
+    "banner": "Create and run agent tasks in the <b>Agent</b> mode of the chat input. This page manages the task list, progress, and approvals.",
+    "emptyTitle": "No tasks",
+    "emptyDescription": "Start a new task in the chat's agent mode.",
+    "status": {
+      "running": "In progress",
+      "completed": "Completed",
+      "pending": "Pending"
+    },
+    "failedTag": "Failed",
+    "cancelledTag": "Cancelled",
+    "turnShort": "Turn {current}/{max}",
+    "progressLabel": "Progress",
+    "detailTitle": "View details",
+    "resumeTitle": "Resume",
+    "cancelTitle": "Cancel",
+    "deleteTitle": "Delete",
+    "modalTitle": "Task details",
+    "detailLoadError": "Failed to load task information.",
+    "goalLabel": "Goal",
+    "stateLabel": "Status:",
+    "turnLabel": "Turn:",
+    "planLabel": "Plan ({completed}/{total})",
+    "outputsLabel": "Outputs ({count})",
+    "noSteps": "No step records.",
+    "stepsLabel": "Steps ({count})",
+    "approvalsTitle": "Tool executions awaiting approval ({count})",
+    "reject": "Reject",
+    "approve": "Approve",
+    "cancelConfirm": "Cancel the task \"{goal}...\"?",
+    "deleteConfirm": "Delete the task \"{goal}...\"?",
+    "processFailed": "Processing failed: {message}",
+    "cancelFailed": "Cancellation failed: {message}",
+    "resumeFailed": "Resume failed: {message}",
+    "deleteFailed": "Deletion failed: {message}"
+  },
+  "customAgents": {
+    "pageTitle": "Custom Agents",
+    "pageDescription": "Define specialized agents with your own system prompts.",
+    "importFromGit": "Import from Git URL",
+    "newAgent": "New Agent",
+    "tabActive": "Active Agents",
+    "tabDraft": "Draft Review",
+    "loading": "Loading...",
+    "emptyTitle": "No custom agents yet",
+    "emptyDescription": "Create one yourself or import from a Git URL to add a specialized agent.",
+    "createNewAgent": "Create New Agent",
+    "systemPromptHeading": "System Prompt",
+    "edit": "Edit",
+    "deleteAria": "Delete",
+    "deleteConfirm": "Delete the \"{name}\" agent?",
+    "deleteFailed": "Delete failed: {error}",
+    "noDescription": "No description.",
+    "genericError": "Error",
+    "createModalTitle": "Create New Agent",
+    "editModalTitle": "Edit Agent",
+    "gitImportModalTitle": "Import Agent from Git URL",
+    "iconLabel": "Icon",
+    "nameLabel": "Agent Name *",
+    "namePlaceholder": "e.g. Technical Writer",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "Briefly describe what this agent does",
+    "systemPromptLabel": "System Prompt *",
+    "systemPromptPlaceholder": "You are a ... expert. ...",
+    "cancel": "Cancel",
+    "save": "Save",
+    "create": "Create",
+    "nameRequired": "Please enter an agent name.",
+    "systemPromptRequired": "Please enter a system prompt.",
+    "saveFailed": "Save failed: {error}",
+    "serverError": "Server error",
+    "gitIngestDescription": "Imports the AGENT.md manifest from a GitHub repository and saves it as a draft.",
+    "gitUrlLabel": "GitHub URL *",
+    "branchTagLabel": "Branch/Tag (optional)",
+    "filePathLabel": "File Path (optional)",
+    "accessTokenLabel": "Access Token (private repository)",
+    "importButton": "Import",
+    "gitUrlRequired": "Please enter a GitHub URL.",
+    "fetchingRepo": "Fetching repository...",
+    "processingManifest": "Processing manifest...",
+    "done": "Done!",
+    "importFailed": "Import failed",
+    "importFailedStatus": "Failed ({status}): {error}",
+    "requestFailed": "Request failed: {error}",
+    "networkError": "Network error",
+    "loadingDrafts": "Loading drafts...",
+    "noDraftsTitle": "No drafts awaiting approval",
+    "noDraftsDescription": "Agents created via Git URL import will appear here.",
+    "approve": "Approve",
+    "reject": "Reject",
+    "approveFailed": "Approval failed: {error}",
+    "rejectFailed": "Rejection failed: {error}",
+    "rejectConfirm": "Reject (archive) this draft agent?",
+    "fallback": {
+      "techWriter": {
+        "name": "Technical Writer",
+        "description": "Writes API references and architecture docs in a consistent tone.",
+        "systemPrompt": "You are a senior technical writer..."
+      },
+      "reviewer": {
+        "name": "Code Reviewer",
+        "description": "Catches bugs and simplification opportunities in changed code.",
+        "systemPrompt": "You are a meticulous code reviewer..."
+      }
+    }
+  },
+  "research": {
+    "pageTitle": "Deep Research History",
+    "pageDescription": "Browse your past research results. Runs are started from Deep Research mode in the chat.",
+    "runBanner": "Run Deep Research from the <mode>Deep Research</mode> mode in the chat input. This page shows your past research results.",
+    "goToChat": "Go to Chat",
+    "pastResearch": "Past Research",
+    "sessionEmpty": "No research yet.",
+    "report": "Report",
+    "keyFindings": "Key Findings",
+    "reportPendingRunning": "Research in progress — the report will appear after synthesis completes.",
+    "reportPending": "The report will appear after synthesis completes.",
+    "collectedSources": "Collected Sources",
+    "sourceCount": "{count, plural, one {# item} other {# items}}",
+    "verified": "Verified",
+    "unverified": "Unverified",
+    "status": {
+      "pending": "Pending",
+      "running": "Running",
+      "completed": "Completed",
+      "failed": "Failed",
+      "cancelled": "Cancelled"
+    },
+    "stages": {
+      "decompose": {
+        "label": "Decompose Question",
+        "desc": "Break the core question into verifiable sub-questions"
+      },
+      "collect": {
+        "label": "Collect Sources",
+        "desc": "Fan out web searches and select sources by credibility"
+      },
+      "verify": {
+        "label": "Cross-Verify",
+        "desc": "Adversarially verify each claim and detect conflicts"
+      },
+      "synthesize": {
+        "label": "Synthesize Report",
+        "desc": "Generate the final report with citations"
+      }
+    },
+    "metrics": {
+      "sources": "Sources Analyzed",
+      "keyFindings": "Key Findings",
+      "progress": "Progress",
+      "depth": "Depth"
+    },
+    "mock": {
+      "verifiedClaims": "Claims Verified",
+      "conflicts": "Conflicts Found",
+      "tokensUsed": "Tokens Used",
+      "elapsed": "Elapsed Time",
+      "elapsedValue": "3m 12s",
+      "source1": "2026 AI Agent Market Trends Report",
+      "source2": "Multi-Agent Orchestration Architecture Analysis",
+      "source3": "Enterprise LLM Adoption Case Study",
+      "source4": "Autonomous Agent Safety Guidelines",
+      "source5": "RAG vs Long-Context Comparison Benchmark"
+    }
   }
 }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -57,7 +57,100 @@
     "closeMenu": "メニューを閉じる"
   },
   "settings": {
-    "languageAuto": "自動検出"
+    "languageAuto": "自動検出",
+    "pageTitle": "設定",
+    "pageDescription": "アプリ環境とAIモデルの動作を構成します。",
+    "saveButton": "設定を保存",
+    "savedAt": "{time} に保存しました",
+    "freeSuffix": " · 無料",
+    "notConfigured": "未設定",
+    "modelLoading": "モデルを読み込み中…",
+    "tabs": {
+      "general": "一般",
+      "model": "モデルと応答",
+      "interface": "インターフェース",
+      "notifications": "通知",
+      "privacy": "プライバシー",
+      "security": "セキュリティ"
+    },
+    "responseStyles": {
+      "concise": "簡潔",
+      "default": "標準",
+      "verbose": "詳細"
+    },
+    "themes": {
+      "system": "システム設定",
+      "light": "ライト",
+      "dark": "ダーク"
+    },
+    "modelGroup": {
+      "default": "デフォルト",
+      "auto": "自動（サーバー既定値）",
+      "local": "🏠 ローカル vLLM"
+    },
+    "language": {
+      "title": "言語",
+      "description": "インターフェースの表示言語です。自動検出時はブラウザの言語に従います。（AIの応答はメッセージの言語に従います）"
+    },
+    "saveHistory": {
+      "title": "会話本文の保存",
+      "descriptionGeneral": "会話内容をサーバーのデータベースに保存します。オフにすると匿名の利用メタデータのみが記録されます。",
+      "descriptionPrivacy": "オフにすると会話本文はサーバーに保存されません。"
+    },
+    "defaultModel": {
+      "title": "デフォルトモデル",
+      "description": "新しい会話で使用するモデルです。🏠 ローカル vLLM と 🌐 外部LLM（OpenRouter、BYOK）から選択します。"
+    },
+    "externalLlmHint": {
+      "prefix": "外部LLM（OpenRouter）を追加するには、",
+      "link": "APIキーページ",
+      "suffix": "でキーを登録してください。"
+    },
+    "imageGeneration": {
+      "title": "画像生成",
+      "description": "チャットで絵や画像を要求すると自動的に使用されます。個別の選択は不要です。"
+    },
+    "responseStyle": {
+      "title": "応答スタイル",
+      "description": "応答の詳しさを調整します。"
+    },
+    "customInstructions": {
+      "title": "カスタム指示（Custom Instructions）",
+      "description": "すべての会話に永続的に適用されるシステムプロンプトの追加指示です。",
+      "placeholder": "例: ユーザーが明示的に要求していない付加情報は出力しない。",
+      "charCount": "{count} / {max} 文字"
+    },
+    "theme": {
+      "title": "テーマ",
+      "description": "アプリのカラーテーマを選択します。"
+    },
+    "emailAlerts": {
+      "title": "メール通知",
+      "description": "エージェント作業の完了やセキュリティイベントをメールで受け取ります。"
+    },
+    "pushAlerts": {
+      "title": "プッシュ通知",
+      "description": "ブラウザのプッシュでリアルタイム通知を受け取ります。"
+    },
+    "pushNotSupported": "このブラウザはプッシュ通知に対応していません。",
+    "pushSwNotReady": "サービスワーカーが登録されていないため、プッシュ通知を利用できません。",
+    "memoryLearning": {
+      "title": "長期記憶の学習",
+      "description": "会話から名前・職業・好みなどの事実を抽出して保存します。"
+    },
+    "passwordChange": {
+      "title": "パスワード変更"
+    },
+    "password": {
+      "current": "現在のパスワード",
+      "new": "新しいパスワード",
+      "newHint": "8文字以上",
+      "confirm": "新しいパスワードの確認",
+      "mismatch": "新しいパスワードが一致しません。",
+      "tooShort": "新しいパスワードは8文字以上にしてください。",
+      "changed": "パスワードを変更しました。",
+      "changeFailed": "パスワードの変更に失敗しました。"
+    }
   },
   "composer": {
     "dropToAttach": "ここにファイルをドロップして添付",
@@ -295,5 +388,305 @@
     "agentTaskStartFailed": "エージェントタスクを開始できませんでした: {message}",
     "structuredAborted": "_(構造化回答の生成を中止しました。)_",
     "structuredFailed": "構造化回答を生成できませんでした: {message}"
+  },
+  "skillLibrary": {
+    "cancel": "キャンセル",
+    "save": "保存",
+    "create": "作成",
+    "edit": "編集",
+    "serverError": "サーバーエラー",
+    "networkError": "ネットワークエラー",
+    "genericError": "エラー",
+    "requestFailed": "リクエスト失敗: {error}",
+    "failedStatus": "失敗 ({status}): {error}",
+    "systemBadge": "システム",
+    "userBadge": "ユーザー",
+    "filterAll": "すべて",
+    "loading": "読み込み中...",
+    "emptyTitle": "スキルがありません",
+    "emptyDesc": "別のカテゴリを選択するか、新しいスキルを追加してください。",
+    "deleteConfirm": "「{name}」スキルを削除しますか？",
+    "deleteFailed": "削除失敗: {error}",
+    "assignFailed": "割り当ての変更に失敗しました: {error}",
+    "pageTitle": "スキルライブラリ",
+    "pageDescription": "再利用可能なマニフェストとツールバインディングを管理します。",
+    "uploadButton": ".SKILL アップロード",
+    "gitButton": "Git インポート",
+    "autoButton": "AI 自動生成",
+    "newButton": "新規スキル",
+    "categoryGeneral": "一般",
+    "categories": {
+      "productivity": "生産性",
+      "technology": "技術/IT",
+      "creative": "クリエイティブ/デザイン",
+      "business": "ビジネス",
+      "science": "科学/研究",
+      "communication": "コミュニケーション",
+      "finance": "金融/投資",
+      "education": "教育/学習"
+    },
+    "tabs": {
+      "active": "アクティブスキル",
+      "draft": "Draft レビュー"
+    },
+    "modal": {
+      "create": "新規スキル作成",
+      "edit": "スキル編集",
+      "upload": ".SKILL ファイルのアップロード",
+      "autoCreate": "AI スキル自動生成",
+      "gitIngest": "Git URL からスキルをインポート"
+    },
+    "fallback": {
+      "pdfSummary": {
+        "name": "PDF 要約",
+        "description": "長い PDF 文書を要点に凝縮します。"
+      },
+      "sqlQuery": {
+        "name": "SQL クエリ作成",
+        "description": "自然言語の要件をパラメータ化された SQL に変換します。"
+      },
+      "adCopy": {
+        "name": "広告コピーライティング",
+        "description": "ターゲットセグメントに合わせたマーケティングコピーを生成します。"
+      },
+      "financialReport": {
+        "name": "財務レポート解釈",
+        "description": "損益計算書と貸借対照表の主要指標を解釈します。"
+      }
+    },
+    "form": {
+      "nameRequired": "スキル名を入力してください。",
+      "contentRequired": "スキル内容（Instructions）を入力してください。",
+      "saveFailed": "保存失敗: {error}",
+      "nameLabel": "スキル名 *",
+      "namePlaceholder": "例: PDF 要約",
+      "categoryLabel": "カテゴリ",
+      "publicLabel": "公開スキル",
+      "descriptionLabel": "説明",
+      "descriptionPlaceholder": "このスキルが行うことを簡単に説明してください",
+      "instructionsLabel": "Instructions（スキル内容）*",
+      "instructionsPlaceholder": "このスキルが実行する作業を詳しく記述してください..."
+    },
+    "upload": {
+      "fileRequired": "ファイルを選択してください。",
+      "successDetail": "アップロード完了: {id} v{version}",
+      "success": "アップロード完了",
+      "failed": "アップロード失敗: {error}",
+      "hint": ".SKILL または .md YAML frontmatter ファイルをアップロードします。（最大 256KB）",
+      "fileLabel": "ファイル選択",
+      "submit": "アップロード"
+    },
+    "auto": {
+      "purposeRequired": "目的を入力してください。",
+      "requesting": "リクエスト送信中...",
+      "generating": "LLM 生成中...",
+      "processing": "処理中...",
+      "done": "生成完了！",
+      "generateFailed": "生成失敗",
+      "hint": "自然言語で目的を入力すると、LLM がスキルマニフェストを自動生成します。",
+      "purposeLabel": "スキルの目的 *",
+      "purposePlaceholder": "例: PDF 文書をアップロードすると要点を3行に要約するスキル",
+      "targetLabel": "対象ユーザー（任意）",
+      "targetPlaceholder": "例: 研究者、マーケター",
+      "submit": "AI 生成"
+    },
+    "git": {
+      "urlRequired": "GitHub URL を入力してください。",
+      "fetching": "リポジトリを取得中...",
+      "validating": "マニフェストを検証中...",
+      "done": "完了！",
+      "importFailed": "インポート失敗",
+      "hint": "GitHub リポジトリの SKILL.md マニフェストを取得し、draft として保存します。",
+      "urlLabel": "GitHub URL *",
+      "refLabel": "ブランチ/タグ（任意）",
+      "pathLabel": "ファイルパス（任意）",
+      "tokenLabel": "Access Token（非公開リポジトリ）",
+      "submit": "インポート"
+    },
+    "card": {
+      "assignTitle": "個人スキルに追加",
+      "unassignTitle": "個人スキルを解除",
+      "exportTitle": ".SKILL.md をエクスポート"
+    },
+    "draft": {
+      "approveFailed": "承認失敗: {error}",
+      "rejectConfirm": "この draft を拒否（保管）しますか？",
+      "rejectFailed": "拒否失敗: {error}",
+      "loading": "Draft を読み込み中...",
+      "emptyTitle": "承認待ちの Draft がありません",
+      "emptyDesc": "AI 自動生成または Git インポートで作成されたスキルがここに表示されます。",
+      "approve": "承認",
+      "reject": "拒否"
+    }
+  },
+  "agentTasks": {
+    "loading": "読み込み中...",
+    "error": "エラー",
+    "chatCta": "チャットへ移動",
+    "pageTitle": "エージェントタスク管理",
+    "pageDescription": "タスク一覧・進捗・承認を管理します。作成・実行はチャットのエージェントモードで行います。",
+    "banner": "エージェントタスクはチャット入力欄の<b>エージェント</b>モードで作成・実行してください。このページではタスク一覧・進捗・承認を管理します。",
+    "emptyTitle": "タスクがありません",
+    "emptyDescription": "チャットのエージェントモードで新しいタスクを開始してください。",
+    "status": {
+      "running": "実行中",
+      "completed": "完了",
+      "pending": "待機"
+    },
+    "failedTag": "失敗",
+    "cancelledTag": "キャンセル済み",
+    "turnShort": "ターン {current}/{max}",
+    "progressLabel": "進捗",
+    "detailTitle": "詳細を見る",
+    "resumeTitle": "再開",
+    "cancelTitle": "キャンセル",
+    "deleteTitle": "削除",
+    "modalTitle": "タスク詳細",
+    "detailLoadError": "タスク情報を読み込めませんでした。",
+    "goalLabel": "目標",
+    "stateLabel": "ステータス:",
+    "turnLabel": "ターン:",
+    "planLabel": "計画 ({completed}/{total})",
+    "outputsLabel": "成果物 ({count})",
+    "noSteps": "ステップ記録がありません。",
+    "stepsLabel": "実行ステップ ({count})",
+    "approvalsTitle": "承認待ちのツール実行 ({count})",
+    "reject": "却下",
+    "approve": "承認",
+    "cancelConfirm": "「{goal}...」のタスクをキャンセルしますか？",
+    "deleteConfirm": "「{goal}...」のタスクを削除しますか？",
+    "processFailed": "処理に失敗しました: {message}",
+    "cancelFailed": "キャンセルに失敗しました: {message}",
+    "resumeFailed": "再開に失敗しました: {message}",
+    "deleteFailed": "削除に失敗しました: {message}"
+  },
+  "customAgents": {
+    "pageTitle": "カスタムエージェント",
+    "pageDescription": "独自のシステムプロンプトで特化したエージェントを定義します。",
+    "importFromGit": "Git URL から取り込む",
+    "newAgent": "新規エージェント",
+    "tabActive": "有効なエージェント",
+    "tabDraft": "ドラフト確認",
+    "loading": "読み込み中...",
+    "emptyTitle": "カスタムエージェントはまだありません",
+    "emptyDescription": "自分で作成するか、Git URL から取り込んで特化したエージェントを追加してください。",
+    "createNewAgent": "新規エージェントを作成",
+    "systemPromptHeading": "システムプロンプト",
+    "edit": "編集",
+    "deleteAria": "削除",
+    "deleteConfirm": "「{name}」エージェントを削除しますか？",
+    "deleteFailed": "削除に失敗しました: {error}",
+    "noDescription": "説明はありません。",
+    "genericError": "エラー",
+    "createModalTitle": "新規エージェントの作成",
+    "editModalTitle": "エージェントの編集",
+    "gitImportModalTitle": "Git URL からエージェントを取り込む",
+    "iconLabel": "アイコン",
+    "nameLabel": "エージェント名 *",
+    "namePlaceholder": "例: テクニカルライター",
+    "descriptionLabel": "説明",
+    "descriptionPlaceholder": "このエージェントの役割を簡潔に説明してください",
+    "systemPromptLabel": "システムプロンプト *",
+    "systemPromptPlaceholder": "あなたは ... の専門家です。...",
+    "cancel": "キャンセル",
+    "save": "保存",
+    "create": "作成",
+    "nameRequired": "エージェント名を入力してください。",
+    "systemPromptRequired": "システムプロンプトを入力してください。",
+    "saveFailed": "保存に失敗しました: {error}",
+    "serverError": "サーバーエラー",
+    "gitIngestDescription": "GitHub リポジトリの AGENT.md マニフェストを取り込み、ドラフトとして保存します。",
+    "gitUrlLabel": "GitHub URL *",
+    "branchTagLabel": "ブランチ/タグ (任意)",
+    "filePathLabel": "ファイルパス (任意)",
+    "accessTokenLabel": "Access Token (非公開リポジトリ)",
+    "importButton": "取り込む",
+    "gitUrlRequired": "GitHub URL を入力してください。",
+    "fetchingRepo": "リポジトリを取得中...",
+    "processingManifest": "マニフェストを処理中...",
+    "done": "完了！",
+    "importFailed": "取り込みに失敗しました",
+    "importFailedStatus": "失敗 ({status}): {error}",
+    "requestFailed": "リクエストに失敗しました: {error}",
+    "networkError": "ネットワークエラー",
+    "loadingDrafts": "ドラフトを読み込み中...",
+    "noDraftsTitle": "承認待ちのドラフトはありません",
+    "noDraftsDescription": "Git URL の取り込みで作成されたエージェントがここに表示されます。",
+    "approve": "承認",
+    "reject": "却下",
+    "approveFailed": "承認に失敗しました: {error}",
+    "rejectFailed": "却下に失敗しました: {error}",
+    "rejectConfirm": "このドラフトエージェントを却下(保管)しますか？",
+    "fallback": {
+      "techWriter": {
+        "name": "テクニカルライター",
+        "description": "API リファレンスやアーキテクチャ文書を一貫したトーンで作成します。",
+        "systemPrompt": "あなたはシニアテクニカルライターです..."
+      },
+      "reviewer": {
+        "name": "コードレビュアー",
+        "description": "変更されたコードのバグや簡素化の余地を指摘します。",
+        "systemPrompt": "あなたは厳格なコードレビュアーです..."
+      }
+    }
+  },
+  "research": {
+    "pageTitle": "ディープリサーチ履歴",
+    "pageDescription": "過去のリサーチ結果を確認できます。実行はチャットのディープリサーチモードで行います。",
+    "runBanner": "ディープリサーチはチャット入力欄の<mode>ディープリサーチ</mode>モードで実行してください。このページでは過去のリサーチ結果を確認できます。",
+    "goToChat": "チャットへ移動",
+    "pastResearch": "過去のリサーチ",
+    "sessionEmpty": "まだリサーチがありません。",
+    "report": "レポート",
+    "keyFindings": "主な発見",
+    "reportPendingRunning": "リサーチ実行中 — 合成が完了するとレポートが表示されます。",
+    "reportPending": "レポートは合成完了後に表示されます。",
+    "collectedSources": "収集ソース",
+    "sourceCount": "{count}件",
+    "verified": "検証済み",
+    "unverified": "未検証",
+    "status": {
+      "pending": "待機",
+      "running": "実行中",
+      "completed": "完了",
+      "failed": "失敗",
+      "cancelled": "キャンセル"
+    },
+    "stages": {
+      "decompose": {
+        "label": "質問の分解",
+        "desc": "核心的な質問を検証可能なサブ質問に分解します"
+      },
+      "collect": {
+        "label": "ソース収集",
+        "desc": "ウェブ検索をファンアウトし、信頼度に基づいてソースを選別します"
+      },
+      "verify": {
+        "label": "クロス検証",
+        "desc": "主張ごとに敵対的検証を行い、矛盾を検出します"
+      },
+      "synthesize": {
+        "label": "レポート合成",
+        "desc": "引用を含む最終レポートを生成します"
+      }
+    },
+    "metrics": {
+      "sources": "分析ソース",
+      "keyFindings": "主な発見",
+      "progress": "進捗率",
+      "depth": "深さ"
+    },
+    "mock": {
+      "verifiedClaims": "検証済みの主張",
+      "conflicts": "検出された矛盾",
+      "tokensUsed": "使用トークン",
+      "elapsed": "経過時間",
+      "elapsedValue": "3分12秒",
+      "source1": "2026年AIエージェント市場動向レポート",
+      "source2": "マルチエージェントオーケストレーションアーキテクチャ分析",
+      "source3": "エンタープライズLLM導入事例研究",
+      "source4": "自律エージェント安全性ガイドライン",
+      "source5": "RAG対ロングコンテキスト比較ベンチマーク"
+    }
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -57,7 +57,100 @@
     "closeMenu": "메뉴 닫기"
   },
   "settings": {
-    "languageAuto": "자동 감지"
+    "languageAuto": "자동 감지",
+    "pageTitle": "설정",
+    "pageDescription": "앱 환경과 AI 모델 동작을 구성합니다.",
+    "saveButton": "설정 저장",
+    "savedAt": "{time} 저장됨",
+    "freeSuffix": " · 무료",
+    "notConfigured": "미설정",
+    "modelLoading": "모델 로딩…",
+    "tabs": {
+      "general": "일반",
+      "model": "모델 & 응답",
+      "interface": "인터페이스",
+      "notifications": "알림",
+      "privacy": "개인정보",
+      "security": "보안"
+    },
+    "responseStyles": {
+      "concise": "간결",
+      "default": "기본",
+      "verbose": "상세"
+    },
+    "themes": {
+      "system": "시스템 설정",
+      "light": "라이트",
+      "dark": "다크"
+    },
+    "modelGroup": {
+      "default": "기본",
+      "auto": "자동 (서버 기본값)",
+      "local": "🏠 로컬 vLLM"
+    },
+    "language": {
+      "title": "언어",
+      "description": "인터페이스 표시 언어. 자동 감지 시 브라우저 언어를 따릅니다. (AI 응답은 메시지 언어를 따릅니다)"
+    },
+    "saveHistory": {
+      "title": "대화 본문 저장",
+      "descriptionGeneral": "대화 내용을 서버 DB에 저장합니다. 끄면 익명 사용량 메타만 기록됩니다.",
+      "descriptionPrivacy": "끄면 대화 본문은 서버에 저장되지 않습니다."
+    },
+    "defaultModel": {
+      "title": "기본 모델",
+      "description": "새 대화에 사용할 모델입니다. 🏠 로컬 vLLM 과 🌐 외부 LLM(OpenRouter, BYOK) 중 선택합니다."
+    },
+    "externalLlmHint": {
+      "prefix": "외부 LLM(OpenRouter)을 추가하려면",
+      "link": "API 키 페이지",
+      "suffix": "에서 키를 등록하세요."
+    },
+    "imageGeneration": {
+      "title": "이미지 생성",
+      "description": "채팅에서 그림/이미지를 요청하면 자동으로 사용됩니다. 별도 선택은 필요 없습니다."
+    },
+    "responseStyle": {
+      "title": "응답 스타일",
+      "description": "응답의 자세함 정도를 조절합니다."
+    },
+    "customInstructions": {
+      "title": "사용자 지시문 (Custom Instructions)",
+      "description": "모든 대화에 영구 적용되는 system prompt 추가 지시문입니다.",
+      "placeholder": "예: 사용자가 명시적으로 요청하지 않은 부가 정보는 출력하지 않는다.",
+      "charCount": "{count} / {max} 자"
+    },
+    "theme": {
+      "title": "테마",
+      "description": "앱의 색상 테마를 선택합니다."
+    },
+    "emailAlerts": {
+      "title": "이메일 알림",
+      "description": "에이전트 작업 완료 및 보안 이벤트를 이메일로 받습니다."
+    },
+    "pushAlerts": {
+      "title": "푸시 알림",
+      "description": "브라우저 푸시로 실시간 알림을 받습니다."
+    },
+    "pushNotSupported": "이 브라우저는 푸시 알림을 지원하지 않습니다.",
+    "pushSwNotReady": "서비스 워커가 등록되지 않아 푸시 알림을 사용할 수 없습니다.",
+    "memoryLearning": {
+      "title": "장기 기억 학습",
+      "description": "대화에서 이름·직업·선호 같은 사실을 추출하여 저장합니다."
+    },
+    "passwordChange": {
+      "title": "비밀번호 변경"
+    },
+    "password": {
+      "current": "현재 비밀번호",
+      "new": "새 비밀번호",
+      "newHint": "8자 이상",
+      "confirm": "새 비밀번호 확인",
+      "mismatch": "새 비밀번호가 일치하지 않습니다.",
+      "tooShort": "새 비밀번호는 8자 이상이어야 합니다.",
+      "changed": "비밀번호가 변경되었습니다.",
+      "changeFailed": "비밀번호 변경에 실패했습니다."
+    }
   },
   "composer": {
     "dropToAttach": "여기에 파일을 놓아 첨부",
@@ -295,5 +388,305 @@
     "agentTaskStartFailed": "에이전트 작업을 시작하지 못했습니다: {message}",
     "structuredAborted": "_(구조화 답변 생성을 중단했습니다.)_",
     "structuredFailed": "구조화 답변을 생성하지 못했습니다: {message}"
+  },
+  "skillLibrary": {
+    "cancel": "취소",
+    "save": "저장",
+    "create": "생성",
+    "edit": "편집",
+    "serverError": "서버 오류",
+    "networkError": "네트워크 오류",
+    "genericError": "오류",
+    "requestFailed": "요청 실패: {error}",
+    "failedStatus": "실패 ({status}): {error}",
+    "systemBadge": "시스템",
+    "userBadge": "사용자",
+    "filterAll": "전체",
+    "loading": "불러오는 중...",
+    "emptyTitle": "스킬이 없습니다",
+    "emptyDesc": "다른 카테고리를 선택하거나 새 스킬을 추가하세요.",
+    "deleteConfirm": "\"{name}\" 스킬을 삭제하시겠습니까?",
+    "deleteFailed": "삭제 실패: {error}",
+    "assignFailed": "할당 변경 실패: {error}",
+    "pageTitle": "스킬 라이브러리",
+    "pageDescription": "재사용 가능한 매니페스트와 도구 바인딩을 관리합니다.",
+    "uploadButton": ".SKILL 업로드",
+    "gitButton": "Git 가져오기",
+    "autoButton": "AI 자동생성",
+    "newButton": "새 스킬",
+    "categoryGeneral": "일반",
+    "categories": {
+      "productivity": "생산성",
+      "technology": "기술/IT",
+      "creative": "창작/디자인",
+      "business": "비즈니스",
+      "science": "과학/연구",
+      "communication": "커뮤니케이션",
+      "finance": "금융/투자",
+      "education": "교육/학습"
+    },
+    "tabs": {
+      "active": "활성 스킬",
+      "draft": "Draft 검토"
+    },
+    "modal": {
+      "create": "새 스킬 생성",
+      "edit": "스킬 편집",
+      "upload": ".SKILL 파일 업로드",
+      "autoCreate": "AI 스킬 자동 생성",
+      "gitIngest": "Git URL에서 스킬 가져오기"
+    },
+    "fallback": {
+      "pdfSummary": {
+        "name": "PDF 요약",
+        "description": "긴 PDF 문서를 핵심 요점으로 압축합니다."
+      },
+      "sqlQuery": {
+        "name": "SQL 쿼리 작성",
+        "description": "자연어 요구사항을 파라미터화된 SQL 로 변환합니다."
+      },
+      "adCopy": {
+        "name": "광고 카피라이팅",
+        "description": "타겟 세그먼트에 맞춘 마케팅 카피를 생성합니다."
+      },
+      "financialReport": {
+        "name": "재무 보고서 해석",
+        "description": "손익계산서와 대차대조표의 핵심 지표를 해석합니다."
+      }
+    },
+    "form": {
+      "nameRequired": "스킬 이름을 입력하세요.",
+      "contentRequired": "스킬 내용(Instructions)을 입력하세요.",
+      "saveFailed": "저장 실패: {error}",
+      "nameLabel": "스킬 이름 *",
+      "namePlaceholder": "예: PDF 요약",
+      "categoryLabel": "카테고리",
+      "publicLabel": "공개 스킬",
+      "descriptionLabel": "설명",
+      "descriptionPlaceholder": "이 스킬이 하는 일을 간단히 설명하세요",
+      "instructionsLabel": "Instructions (스킬 내용) *",
+      "instructionsPlaceholder": "이 스킬이 수행할 작업을 상세히 기술하세요..."
+    },
+    "upload": {
+      "fileRequired": "파일을 선택하세요.",
+      "successDetail": "업로드 완료: {id} v{version}",
+      "success": "업로드 완료",
+      "failed": "업로드 실패: {error}",
+      "hint": ".SKILL 또는 .md YAML frontmatter 파일을 업로드합니다. (최대 256KB)",
+      "fileLabel": "파일 선택",
+      "submit": "업로드"
+    },
+    "auto": {
+      "purposeRequired": "목적을 입력하세요.",
+      "requesting": "생성 요청 중...",
+      "generating": "LLM 생성 중...",
+      "processing": "처리 중...",
+      "done": "생성 완료!",
+      "generateFailed": "생성 실패",
+      "hint": "자연어 목적을 입력하면 LLM이 스킬 매니페스트를 자동 생성합니다.",
+      "purposeLabel": "스킬 목적 *",
+      "purposePlaceholder": "예: PDF 문서를 업로드하면 핵심 내용을 3줄로 요약하는 스킬",
+      "targetLabel": "대상 사용자 (선택)",
+      "targetPlaceholder": "예: 연구자, 마케터",
+      "submit": "AI 생성"
+    },
+    "git": {
+      "urlRequired": "GitHub URL을 입력하세요.",
+      "fetching": "저장소 가져오는 중...",
+      "validating": "매니페스트 검증 중...",
+      "done": "완료!",
+      "importFailed": "가져오기 실패",
+      "hint": "GitHub 저장소의 SKILL.md 매니페스트를 가져와 draft로 저장합니다.",
+      "urlLabel": "GitHub URL *",
+      "refLabel": "브랜치/태그 (선택)",
+      "pathLabel": "파일 경로 (선택)",
+      "tokenLabel": "Access Token (비공개 저장소)",
+      "submit": "가져오기"
+    },
+    "card": {
+      "assignTitle": "개인 스킬로 추가",
+      "unassignTitle": "개인 스킬 해제",
+      "exportTitle": ".SKILL.md 내보내기"
+    },
+    "draft": {
+      "approveFailed": "승인 실패: {error}",
+      "rejectConfirm": "이 draft를 거부(보관)하시겠습니까?",
+      "rejectFailed": "거부 실패: {error}",
+      "loading": "Draft 불러오는 중...",
+      "emptyTitle": "승인 대기 중인 Draft가 없습니다",
+      "emptyDesc": "AI 자동생성 또는 Git 가져오기로 생성된 스킬이 여기 나타납니다.",
+      "approve": "승인",
+      "reject": "거부"
+    }
+  },
+  "agentTasks": {
+    "loading": "불러오는 중...",
+    "error": "오류",
+    "chatCta": "채팅으로 이동",
+    "pageTitle": "에이전트 작업 관리",
+    "pageDescription": "작업 목록·진행·승인을 관리합니다. 생성·실행은 채팅의 에이전트 모드에서 진행됩니다.",
+    "banner": "에이전트 작업은 채팅 입력창의 <b>에이전트</b> 모드로 생성·실행하세요. 이 페이지에서는 작업 목록·진행·승인을 관리합니다.",
+    "emptyTitle": "작업이 없습니다",
+    "emptyDescription": "채팅의 에이전트 모드에서 새 작업을 시작하세요.",
+    "status": {
+      "running": "진행중",
+      "completed": "완료",
+      "pending": "대기"
+    },
+    "failedTag": "실패",
+    "cancelledTag": "취소됨",
+    "turnShort": "턴 {current}/{max}",
+    "progressLabel": "진행률",
+    "detailTitle": "상세 보기",
+    "resumeTitle": "이어하기",
+    "cancelTitle": "취소",
+    "deleteTitle": "삭제",
+    "modalTitle": "작업 상세",
+    "detailLoadError": "작업 정보를 불러오지 못했습니다.",
+    "goalLabel": "목표",
+    "stateLabel": "상태:",
+    "turnLabel": "턴:",
+    "planLabel": "계획 ({completed}/{total})",
+    "outputsLabel": "산출물 ({count})",
+    "noSteps": "스텝 기록이 없습니다.",
+    "stepsLabel": "실행 스텝 ({count})",
+    "approvalsTitle": "승인 대기 중인 도구 실행 ({count})",
+    "reject": "거절",
+    "approve": "승인",
+    "cancelConfirm": "\"{goal}...\" 작업을 취소하시겠습니까?",
+    "deleteConfirm": "\"{goal}...\" 작업을 삭제하시겠습니까?",
+    "processFailed": "처리 실패: {message}",
+    "cancelFailed": "취소 실패: {message}",
+    "resumeFailed": "이어하기 실패: {message}",
+    "deleteFailed": "삭제 실패: {message}"
+  },
+  "customAgents": {
+    "pageTitle": "커스텀 에이전트",
+    "pageDescription": "나만의 시스템 프롬프트로 특화된 에이전트를 정의합니다.",
+    "importFromGit": "Git URL 에서 가져오기",
+    "newAgent": "새 에이전트",
+    "tabActive": "활성 에이전트",
+    "tabDraft": "Draft 검토",
+    "loading": "불러오는 중...",
+    "emptyTitle": "아직 커스텀 에이전트가 없습니다",
+    "emptyDescription": "직접 만들거나 Git URL 에서 가져와 특화된 에이전트를 추가하세요.",
+    "createNewAgent": "새 에이전트 만들기",
+    "systemPromptHeading": "시스템 프롬프트",
+    "edit": "편집",
+    "deleteAria": "삭제",
+    "deleteConfirm": "\"{name}\" 에이전트를 삭제하시겠습니까?",
+    "deleteFailed": "삭제 실패: {error}",
+    "noDescription": "설명이 없습니다.",
+    "genericError": "오류",
+    "createModalTitle": "새 에이전트 생성",
+    "editModalTitle": "에이전트 편집",
+    "gitImportModalTitle": "Git URL에서 에이전트 가져오기",
+    "iconLabel": "아이콘",
+    "nameLabel": "에이전트 이름 *",
+    "namePlaceholder": "예: 기술 문서 작성가",
+    "descriptionLabel": "설명",
+    "descriptionPlaceholder": "이 에이전트가 하는 일을 간단히 설명하세요",
+    "systemPromptLabel": "시스템 프롬프트 *",
+    "systemPromptPlaceholder": "당신은 ... 전문가입니다. ...",
+    "cancel": "취소",
+    "save": "저장",
+    "create": "생성",
+    "nameRequired": "에이전트 이름을 입력하세요.",
+    "systemPromptRequired": "시스템 프롬프트를 입력하세요.",
+    "saveFailed": "저장 실패: {error}",
+    "serverError": "서버 오류",
+    "gitIngestDescription": "GitHub 저장소의 AGENT.md 매니페스트를 가져와 draft로 저장합니다.",
+    "gitUrlLabel": "GitHub URL *",
+    "branchTagLabel": "브랜치/태그 (선택)",
+    "filePathLabel": "파일 경로 (선택)",
+    "accessTokenLabel": "Access Token (비공개 저장소)",
+    "importButton": "가져오기",
+    "gitUrlRequired": "GitHub URL을 입력하세요.",
+    "fetchingRepo": "저장소 가져오는 중...",
+    "processingManifest": "매니페스트 처리 중...",
+    "done": "완료!",
+    "importFailed": "가져오기 실패",
+    "importFailedStatus": "실패 ({status}): {error}",
+    "requestFailed": "요청 실패: {error}",
+    "networkError": "네트워크 오류",
+    "loadingDrafts": "Draft 불러오는 중...",
+    "noDraftsTitle": "승인 대기 중인 Draft가 없습니다",
+    "noDraftsDescription": "Git URL 가져오기로 생성된 에이전트가 여기 나타납니다.",
+    "approve": "승인",
+    "reject": "거부",
+    "approveFailed": "승인 실패: {error}",
+    "rejectFailed": "거부 실패: {error}",
+    "rejectConfirm": "이 draft 에이전트를 거부(보관)하시겠습니까?",
+    "fallback": {
+      "techWriter": {
+        "name": "기술 문서 작성가",
+        "description": "API 레퍼런스와 아키텍처 문서를 일관된 톤으로 작성합니다.",
+        "systemPrompt": "당신은 시니어 테크니컬 라이터입니다..."
+      },
+      "reviewer": {
+        "name": "코드 리뷰어",
+        "description": "변경된 코드의 버그와 단순화 기회를 집어냅니다.",
+        "systemPrompt": "당신은 까다로운 코드 리뷰어입니다..."
+      }
+    }
+  },
+  "research": {
+    "pageTitle": "딥 리서치 히스토리",
+    "pageDescription": "지난 리서치 결과를 조회합니다. 실행은 채팅의 딥 리서치 모드에서 진행됩니다.",
+    "runBanner": "딥 리서치는 채팅 입력창의 <mode>딥 리서치</mode> 모드로 실행하세요. 이 페이지에서는 지난 리서치 결과를 조회합니다.",
+    "goToChat": "채팅으로 이동",
+    "pastResearch": "지난 리서치",
+    "sessionEmpty": "아직 리서치가 없습니다.",
+    "report": "보고서",
+    "keyFindings": "주요 발견",
+    "reportPendingRunning": "리서치 진행 중 — 합성 완료 후 보고서가 표시됩니다.",
+    "reportPending": "보고서는 합성 완료 후 표시됩니다.",
+    "collectedSources": "수집 소스",
+    "sourceCount": "{count}건",
+    "verified": "검증됨",
+    "unverified": "미검증",
+    "status": {
+      "pending": "대기",
+      "running": "진행중",
+      "completed": "완료",
+      "failed": "실패",
+      "cancelled": "취소"
+    },
+    "stages": {
+      "decompose": {
+        "label": "질문 분해",
+        "desc": "핵심 질문을 검증 가능한 하위 질문으로 분해"
+      },
+      "collect": {
+        "label": "소스 수집",
+        "desc": "웹 검색 fan-out 및 신뢰도 기반 소스 선별"
+      },
+      "verify": {
+        "label": "교차 검증",
+        "desc": "주장별 적대적 검증 및 상충 탐지"
+      },
+      "synthesize": {
+        "label": "보고서 합성",
+        "desc": "인용 포함 최종 보고서 생성"
+      }
+    },
+    "metrics": {
+      "sources": "분석 소스",
+      "keyFindings": "주요 발견",
+      "progress": "진행률",
+      "depth": "깊이"
+    },
+    "mock": {
+      "verifiedClaims": "검증 주장",
+      "conflicts": "상충 발견",
+      "tokensUsed": "사용 토큰",
+      "elapsed": "경과 시간",
+      "elapsedValue": "3분 12초",
+      "source1": "2026 AI 에이전트 시장 동향 보고서",
+      "source2": "멀티 에이전트 오케스트레이션 아키텍처 분석",
+      "source3": "엔터프라이즈 LLM 도입 사례 연구",
+      "source4": "자율 에이전트 안전성 가이드라인",
+      "source5": "RAG vs 장기 컨텍스트 비교 벤치마크"
+    }
   }
 }

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -57,7 +57,100 @@
     "closeMenu": "关闭菜单"
   },
   "settings": {
-    "languageAuto": "自动检测"
+    "languageAuto": "自动检测",
+    "pageTitle": "设置",
+    "pageDescription": "配置应用环境和 AI 模型行为。",
+    "saveButton": "保存设置",
+    "savedAt": "已于 {time} 保存",
+    "freeSuffix": " · 免费",
+    "notConfigured": "未设置",
+    "modelLoading": "正在加载模型…",
+    "tabs": {
+      "general": "常规",
+      "model": "模型与响应",
+      "interface": "界面",
+      "notifications": "通知",
+      "privacy": "隐私",
+      "security": "安全"
+    },
+    "responseStyles": {
+      "concise": "简洁",
+      "default": "默认",
+      "verbose": "详细"
+    },
+    "themes": {
+      "system": "跟随系统",
+      "light": "浅色",
+      "dark": "深色"
+    },
+    "modelGroup": {
+      "default": "默认",
+      "auto": "自动（服务器默认）",
+      "local": "🏠 本地 vLLM"
+    },
+    "language": {
+      "title": "语言",
+      "description": "界面显示语言。自动检测时跟随浏览器语言。（AI 响应跟随消息语言）"
+    },
+    "saveHistory": {
+      "title": "保存对话内容",
+      "descriptionGeneral": "将对话内容保存到服务器数据库。关闭后仅记录匿名使用元数据。",
+      "descriptionPrivacy": "关闭后对话内容不会保存到服务器。"
+    },
+    "defaultModel": {
+      "title": "默认模型",
+      "description": "用于新对话的模型。可在 🏠 本地 vLLM 和 🌐 外部 LLM（OpenRouter、BYOK）之间选择。"
+    },
+    "externalLlmHint": {
+      "prefix": "若要添加外部 LLM（OpenRouter），请在",
+      "link": "API 密钥页面",
+      "suffix": "注册密钥。"
+    },
+    "imageGeneration": {
+      "title": "图像生成",
+      "description": "在聊天中请求绘图或图像时会自动使用，无需单独选择。"
+    },
+    "responseStyle": {
+      "title": "响应风格",
+      "description": "调整响应的详细程度。"
+    },
+    "customInstructions": {
+      "title": "自定义指令（Custom Instructions）",
+      "description": "永久应用于所有对话的系统提示附加指令。",
+      "placeholder": "例如：不输出用户未明确请求的附加信息。",
+      "charCount": "{count} / {max} 字"
+    },
+    "theme": {
+      "title": "主题",
+      "description": "选择应用的配色主题。"
+    },
+    "emailAlerts": {
+      "title": "邮件提醒",
+      "description": "通过邮件接收代理任务完成和安全事件通知。"
+    },
+    "pushAlerts": {
+      "title": "推送通知",
+      "description": "通过浏览器推送接收实时通知。"
+    },
+    "pushNotSupported": "此浏览器不支持推送通知。",
+    "pushSwNotReady": "服务工作线程未注册，无法使用推送通知。",
+    "memoryLearning": {
+      "title": "长期记忆学习",
+      "description": "从对话中提取并保存姓名、职业、偏好等事实。"
+    },
+    "passwordChange": {
+      "title": "修改密码"
+    },
+    "password": {
+      "current": "当前密码",
+      "new": "新密码",
+      "newHint": "至少 8 个字符",
+      "confirm": "确认新密码",
+      "mismatch": "两次输入的新密码不一致。",
+      "tooShort": "新密码至少需要 8 个字符。",
+      "changed": "密码已修改。",
+      "changeFailed": "修改密码失败。"
+    }
   },
   "composer": {
     "dropToAttach": "将文件拖放到此处以添加",
@@ -295,5 +388,305 @@
     "agentTaskStartFailed": "无法启动智能体任务：{message}",
     "structuredAborted": "_(已停止生成结构化回答。)_",
     "structuredFailed": "无法生成结构化回答：{message}"
+  },
+  "skillLibrary": {
+    "cancel": "取消",
+    "save": "保存",
+    "create": "创建",
+    "edit": "编辑",
+    "serverError": "服务器错误",
+    "networkError": "网络错误",
+    "genericError": "错误",
+    "requestFailed": "请求失败：{error}",
+    "failedStatus": "失败（{status}）：{error}",
+    "systemBadge": "系统",
+    "userBadge": "用户",
+    "filterAll": "全部",
+    "loading": "加载中...",
+    "emptyTitle": "暂无技能",
+    "emptyDesc": "请选择其他分类或添加新技能。",
+    "deleteConfirm": "确定删除“{name}”技能吗？",
+    "deleteFailed": "删除失败：{error}",
+    "assignFailed": "更新分配失败：{error}",
+    "pageTitle": "技能库",
+    "pageDescription": "管理可复用的清单和工具绑定。",
+    "uploadButton": "上传 .SKILL",
+    "gitButton": "从 Git 导入",
+    "autoButton": "AI 自动生成",
+    "newButton": "新建技能",
+    "categoryGeneral": "通用",
+    "categories": {
+      "productivity": "生产力",
+      "technology": "技术/IT",
+      "creative": "创意/设计",
+      "business": "商业",
+      "science": "科学/研究",
+      "communication": "沟通",
+      "finance": "金融/投资",
+      "education": "教育/学习"
+    },
+    "tabs": {
+      "active": "活跃技能",
+      "draft": "Draft 审核"
+    },
+    "modal": {
+      "create": "创建新技能",
+      "edit": "编辑技能",
+      "upload": "上传 .SKILL 文件",
+      "autoCreate": "AI 技能自动生成",
+      "gitIngest": "从 Git URL 导入技能"
+    },
+    "fallback": {
+      "pdfSummary": {
+        "name": "PDF 摘要",
+        "description": "将长 PDF 文档压缩为核心要点。"
+      },
+      "sqlQuery": {
+        "name": "SQL 查询编写",
+        "description": "将自然语言需求转换为参数化 SQL。"
+      },
+      "adCopy": {
+        "name": "广告文案",
+        "description": "生成针对目标细分群体的营销文案。"
+      },
+      "financialReport": {
+        "name": "财务报表解读",
+        "description": "解读损益表和资产负债表的关键指标。"
+      }
+    },
+    "form": {
+      "nameRequired": "请输入技能名称。",
+      "contentRequired": "请输入技能内容（Instructions）。",
+      "saveFailed": "保存失败：{error}",
+      "nameLabel": "技能名称 *",
+      "namePlaceholder": "例如：PDF 摘要",
+      "categoryLabel": "分类",
+      "publicLabel": "公开技能",
+      "descriptionLabel": "描述",
+      "descriptionPlaceholder": "简要描述该技能的功能",
+      "instructionsLabel": "Instructions（技能内容）*",
+      "instructionsPlaceholder": "详细描述该技能要执行的操作..."
+    },
+    "upload": {
+      "fileRequired": "请选择文件。",
+      "successDetail": "上传完成：{id} v{version}",
+      "success": "上传完成",
+      "failed": "上传失败：{error}",
+      "hint": "上传 .SKILL 或 .md YAML frontmatter 文件。（最大 256KB）",
+      "fileLabel": "选择文件",
+      "submit": "上传"
+    },
+    "auto": {
+      "purposeRequired": "请输入目的。",
+      "requesting": "正在发送请求...",
+      "generating": "LLM 生成中...",
+      "processing": "处理中...",
+      "done": "生成完成！",
+      "generateFailed": "生成失败",
+      "hint": "输入自然语言目的，LLM 将自动生成技能清单。",
+      "purposeLabel": "技能目的 *",
+      "purposePlaceholder": "例如：上传 PDF 文档后将核心内容总结为三行的技能",
+      "targetLabel": "目标用户（可选）",
+      "targetPlaceholder": "例如：研究人员、营销人员",
+      "submit": "AI 生成"
+    },
+    "git": {
+      "urlRequired": "请输入 GitHub URL。",
+      "fetching": "正在获取仓库...",
+      "validating": "正在验证清单...",
+      "done": "完成！",
+      "importFailed": "导入失败",
+      "hint": "从 GitHub 仓库获取 SKILL.md 清单并保存为 draft。",
+      "urlLabel": "GitHub URL *",
+      "refLabel": "分支/标签（可选）",
+      "pathLabel": "文件路径（可选）",
+      "tokenLabel": "Access Token（私有仓库）",
+      "submit": "导入"
+    },
+    "card": {
+      "assignTitle": "添加为个人技能",
+      "unassignTitle": "移除个人技能",
+      "exportTitle": "导出 .SKILL.md"
+    },
+    "draft": {
+      "approveFailed": "审批失败：{error}",
+      "rejectConfirm": "拒绝（归档）此 draft 吗？",
+      "rejectFailed": "拒绝失败：{error}",
+      "loading": "正在加载 Draft...",
+      "emptyTitle": "没有待审批的 Draft",
+      "emptyDesc": "通过 AI 自动生成或 Git 导入创建的技能会显示在这里。",
+      "approve": "审批",
+      "reject": "拒绝"
+    }
+  },
+  "agentTasks": {
+    "loading": "加载中...",
+    "error": "错误",
+    "chatCta": "前往聊天",
+    "pageTitle": "智能体任务管理",
+    "pageDescription": "管理任务列表、进度和批准。创建和执行在聊天的智能体模式中进行。",
+    "banner": "请在聊天输入框的<b>智能体</b>模式中创建和运行智能体任务。此页面用于管理任务列表、进度和批准。",
+    "emptyTitle": "暂无任务",
+    "emptyDescription": "在聊天的智能体模式中开始新任务。",
+    "status": {
+      "running": "进行中",
+      "completed": "已完成",
+      "pending": "待处理"
+    },
+    "failedTag": "失败",
+    "cancelledTag": "已取消",
+    "turnShort": "回合 {current}/{max}",
+    "progressLabel": "进度",
+    "detailTitle": "查看详情",
+    "resumeTitle": "继续",
+    "cancelTitle": "取消",
+    "deleteTitle": "删除",
+    "modalTitle": "任务详情",
+    "detailLoadError": "无法加载任务信息。",
+    "goalLabel": "目标",
+    "stateLabel": "状态:",
+    "turnLabel": "回合:",
+    "planLabel": "计划 ({completed}/{total})",
+    "outputsLabel": "产出物 ({count})",
+    "noSteps": "暂无步骤记录。",
+    "stepsLabel": "执行步骤 ({count})",
+    "approvalsTitle": "等待批准的工具执行 ({count})",
+    "reject": "拒绝",
+    "approve": "批准",
+    "cancelConfirm": "要取消任务“{goal}...”吗？",
+    "deleteConfirm": "要删除任务“{goal}...”吗？",
+    "processFailed": "处理失败：{message}",
+    "cancelFailed": "取消失败：{message}",
+    "resumeFailed": "继续失败：{message}",
+    "deleteFailed": "删除失败：{message}"
+  },
+  "customAgents": {
+    "pageTitle": "自定义智能体",
+    "pageDescription": "用你自己的系统提示词定义专用智能体。",
+    "importFromGit": "从 Git URL 导入",
+    "newAgent": "新建智能体",
+    "tabActive": "启用的智能体",
+    "tabDraft": "草稿审核",
+    "loading": "加载中...",
+    "emptyTitle": "还没有自定义智能体",
+    "emptyDescription": "自行创建或从 Git URL 导入以添加专用智能体。",
+    "createNewAgent": "创建新智能体",
+    "systemPromptHeading": "系统提示词",
+    "edit": "编辑",
+    "deleteAria": "删除",
+    "deleteConfirm": "确定要删除“{name}”智能体吗？",
+    "deleteFailed": "删除失败：{error}",
+    "noDescription": "暂无描述。",
+    "genericError": "错误",
+    "createModalTitle": "创建新智能体",
+    "editModalTitle": "编辑智能体",
+    "gitImportModalTitle": "从 Git URL 导入智能体",
+    "iconLabel": "图标",
+    "nameLabel": "智能体名称 *",
+    "namePlaceholder": "例如：技术文档写作者",
+    "descriptionLabel": "描述",
+    "descriptionPlaceholder": "简要描述该智能体的用途",
+    "systemPromptLabel": "系统提示词 *",
+    "systemPromptPlaceholder": "你是一名……专家。……",
+    "cancel": "取消",
+    "save": "保存",
+    "create": "创建",
+    "nameRequired": "请输入智能体名称。",
+    "systemPromptRequired": "请输入系统提示词。",
+    "saveFailed": "保存失败：{error}",
+    "serverError": "服务器错误",
+    "gitIngestDescription": "从 GitHub 仓库导入 AGENT.md 清单并保存为草稿。",
+    "gitUrlLabel": "GitHub URL *",
+    "branchTagLabel": "分支/标签（可选）",
+    "filePathLabel": "文件路径（可选）",
+    "accessTokenLabel": "Access Token（私有仓库）",
+    "importButton": "导入",
+    "gitUrlRequired": "请输入 GitHub URL。",
+    "fetchingRepo": "正在获取仓库...",
+    "processingManifest": "正在处理清单...",
+    "done": "完成！",
+    "importFailed": "导入失败",
+    "importFailedStatus": "失败（{status}）：{error}",
+    "requestFailed": "请求失败：{error}",
+    "networkError": "网络错误",
+    "loadingDrafts": "正在加载草稿...",
+    "noDraftsTitle": "没有待审核的草稿",
+    "noDraftsDescription": "通过 Git URL 导入创建的智能体将显示在这里。",
+    "approve": "批准",
+    "reject": "拒绝",
+    "approveFailed": "批准失败：{error}",
+    "rejectFailed": "拒绝失败：{error}",
+    "rejectConfirm": "确定要拒绝（归档）此草稿智能体吗？",
+    "fallback": {
+      "techWriter": {
+        "name": "技术文档写作者",
+        "description": "以一致的语气撰写 API 参考和架构文档。",
+        "systemPrompt": "你是一名资深技术文档写作者……"
+      },
+      "reviewer": {
+        "name": "代码审查者",
+        "description": "找出变更代码中的缺陷和可简化之处。",
+        "systemPrompt": "你是一名严格的代码审查者……"
+      }
+    }
+  },
+  "research": {
+    "pageTitle": "深度研究历史",
+    "pageDescription": "查看过往的研究结果。运行请在聊天的深度研究模式中进行。",
+    "runBanner": "请在聊天输入框的<mode>深度研究</mode>模式中运行深度研究。此页面用于查看过往的研究结果。",
+    "goToChat": "前往聊天",
+    "pastResearch": "过往研究",
+    "sessionEmpty": "暂无研究。",
+    "report": "报告",
+    "keyFindings": "关键发现",
+    "reportPendingRunning": "研究进行中 — 合成完成后将显示报告。",
+    "reportPending": "报告将在合成完成后显示。",
+    "collectedSources": "收集的来源",
+    "sourceCount": "{count} 条",
+    "verified": "已验证",
+    "unverified": "未验证",
+    "status": {
+      "pending": "待处理",
+      "running": "进行中",
+      "completed": "已完成",
+      "failed": "失败",
+      "cancelled": "已取消"
+    },
+    "stages": {
+      "decompose": {
+        "label": "问题拆解",
+        "desc": "将核心问题拆解为可验证的子问题"
+      },
+      "collect": {
+        "label": "来源收集",
+        "desc": "扇出网络搜索并按可信度筛选来源"
+      },
+      "verify": {
+        "label": "交叉验证",
+        "desc": "对每项主张进行对抗性验证并检测冲突"
+      },
+      "synthesize": {
+        "label": "报告合成",
+        "desc": "生成包含引用的最终报告"
+      }
+    },
+    "metrics": {
+      "sources": "分析来源",
+      "keyFindings": "关键发现",
+      "progress": "进度",
+      "depth": "深度"
+    },
+    "mock": {
+      "verifiedClaims": "已验证主张",
+      "conflicts": "发现的冲突",
+      "tokensUsed": "已用令牌",
+      "elapsed": "耗时",
+      "elapsedValue": "3分12秒",
+      "source1": "2026 AI 智能体市场趋势报告",
+      "source2": "多智能体编排架构分析",
+      "source3": "企业级 LLM 采用案例研究",
+      "source4": "自主智能体安全指南",
+      "source5": "RAG 与长上下文对比基准"
+    }
   }
 }


### PR DESCRIPTION
## 개요

i18n 시리즈 PR 3/6 (베이스: #259). 한글 문자열이 가장 많은 대형 페이지 5개를 next-intl 키로 전환.

## 변경

- `skill-library`(94줄) · `settings`(68줄) · `agent-tasks`(55줄) · `custom-agents`(59줄) · `research`(47줄) 페이지
- messages 네임스페이스: `skillLibrary` `settings` `agentTasks` `customAgents` `research` — 누적 504키 × 4 locale 정합
- settings 는 PR 1 의 언어 드롭다운 배선(`languageAuto` 키·`useSyncExternalStore`) 위에 나머지 문자열 전량 추출

## 검증

- `check:i18n` 통과 (504키 × 4)
- 격리 워크트리 `tsc --noEmit` 0 + `next build` 성공
- eslint: 대상 파일 신규 문제 0 (기준 7건 = 기존 코드, 변동 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)