### PR TITLE
feat(web): 관리자·계정 페이지 i18n — admin/API키/사용량/개발자 4개 언어 (PR 5/6)

### DIFF
--- a/apps/web/app/(workspace)/admin/alerts/page.tsx
+++ b/apps/web/app/(workspace)/admin/alerts/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Bell, Plus, AlertTriangle, AlertCircle, Info, Check } from "lucide-react";
 import {
   PageHeader,
@@ -18,8 +19,8 @@ type Severity = "critical" | "warning" | "info";
 
 interface AlertRule {
   id: string;
-  name: string;
-  condition: string;
+  nameKey: string;
+  conditionKey: string;
   channel: string[];
   enabled: boolean;
 }
@@ -36,10 +37,10 @@ const SEV_TONE: Record<Severity, "danger" | "warn" | "accent"> = {
   warning: "warn",
   info: "accent",
 };
-const SEV_LABEL: Record<Severity, string> = {
-  critical: "심각",
-  warning: "경고",
-  info: "정보",
+const SEV_LABEL_KEY: Record<Severity, string> = {
+  critical: "status.critical",
+  warning: "status.warning",
+  info: "status.info",
 };
 const SEV_ICON: Record<Severity, typeof Info> = {
   critical: AlertTriangle,
@@ -55,19 +56,19 @@ const SEV_ICON_CLR: Record<Severity, string> = {
 // 알림 규칙(rule) CRUD 백엔드 엔드포인트 없음 — AlertSystem 은 코드 내 config 로 규칙을
 // 관리하고 발생 이력만 alert_history 에 영속화. 따라서 규칙 목록은 목업 유지(토글도 로컬 전용).
 const RULES: AlertRule[] = [
-  { id: "r1", name: "CPU 사용률 임계", condition: "CPU > 85% · 5분 지속", channel: ["webhook", "email"], enabled: true },
-  { id: "r2", name: "LLM 컨텍스트 오버플로", condition: "ContextOverflowError 발생", channel: ["webhook"], enabled: true },
-  { id: "r3", name: "에러율 급증", condition: "5xx 비율 > 2%", channel: ["webhook", "slack"], enabled: true },
-  { id: "r4", name: "토큰 쿼터 소진", condition: "주간 쿼터 90% 초과", channel: ["email"], enabled: false },
-  { id: "r5", name: "관리자 권한 변경", condition: "user.role_change → admin", channel: ["webhook", "email"], enabled: true },
+  { id: "r1", nameKey: "rules.cpu.name", conditionKey: "rules.cpu.condition", channel: ["webhook", "email"], enabled: true },
+  { id: "r2", nameKey: "rules.contextOverflow.name", conditionKey: "rules.contextOverflow.condition", channel: ["webhook"], enabled: true },
+  { id: "r3", nameKey: "rules.errorRate.name", conditionKey: "rules.errorRate.condition", channel: ["webhook", "slack"], enabled: true },
+  { id: "r4", nameKey: "rules.tokenQuota.name", conditionKey: "rules.tokenQuota.condition", channel: ["email"], enabled: false },
+  { id: "r5", nameKey: "rules.roleChange.name", conditionKey: "rules.roleChange.condition", channel: ["webhook", "email"], enabled: true },
 ];
 
-const MOCK_EVENTS: AlertEvent[] = [
-  { id: "e1", severity: "critical", message: "관리자 권한 부여 감지 — u_1040 (devops@partner.co.kr 수행)", timestamp: "2026-06-21T03:40:22Z" },
-  { id: "e2", severity: "warning", message: "redis-kv 노드 부하 78% — rate-limit 정합 영향 가능", timestamp: "2026-06-21T03:12:00Z" },
-  { id: "e3", severity: "warning", message: "LLM 컨텍스트 오버플로 1건 — conv_88412 truncate 적용", timestamp: "2026-06-21T03:31:05Z" },
-  { id: "e4", severity: "info", message: "일일 백업 완료 — postgres-primary (2.1GB)", timestamp: "2026-06-21T02:00:00Z" },
-  { id: "e5", severity: "critical", message: "비정상 로그인 시도 12회 — 45.33.21.7 차단됨", timestamp: "2026-06-20T22:31:00Z" },
+const MOCK_EVENTS: { id: string; severity: Severity; messageKey: string; timestamp: string }[] = [
+  { id: "e1", severity: "critical", messageKey: "events.e1", timestamp: "2026-06-21T03:40:22Z" },
+  { id: "e2", severity: "warning", messageKey: "events.e2", timestamp: "2026-06-21T03:12:00Z" },
+  { id: "e3", severity: "warning", messageKey: "events.e3", timestamp: "2026-06-21T03:31:05Z" },
+  { id: "e4", severity: "info", messageKey: "events.e4", timestamp: "2026-06-21T02:00:00Z" },
+  { id: "e5", severity: "critical", messageKey: "events.e5", timestamp: "2026-06-20T22:31:00Z" },
 ];
 
 function fmt(s: string) {
@@ -90,8 +91,16 @@ interface ApiAlert {
 }
 
 export default function AdminAlertsPage() {
+  const t = useTranslations("adminAlerts");
   const [rules, setRules] = useState<AlertRule[]>(RULES);
-  const [events, setEvents] = useState<AlertEvent[]>(MOCK_EVENTS);
+  const [events, setEvents] = useState<AlertEvent[]>(() =>
+    MOCK_EVENTS.map((e) => ({
+      id: e.id,
+      severity: e.severity,
+      message: t(e.messageKey),
+      timestamp: e.timestamp,
+    })),
+  );
   const [acknowledged, setAcknowledged] = useState<Set<string>>(new Set());
   const [ackLoading, setAckLoading] = useState<Set<string>>(new Set());
 
@@ -142,11 +151,11 @@ export default function AdminAlertsPage() {
   return (
     <>
       <PageHeader
-        title="알림"
-        description="알림 규칙을 관리하고 최근 발생 이벤트를 확인합니다."
+        title={t("title")}
+        description={t("description")}
         actions={
           <Button size="sm">
-            <Plus className="h-3.5 w-3.5" /> 규칙 추가
+            <Plus className="h-3.5 w-3.5" /> {t("addRule")}
           </Button>
         }
       />
@@ -156,7 +165,7 @@ export default function AdminAlertsPage() {
           <Card>
             <CardHeader className="flex items-center gap-2">
               <Bell className="h-4 w-4 text-accent" />
-              <CardTitle>알림 규칙</CardTitle>
+              <CardTitle>{t("rulesTitle")}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">
               {rules.map((r) => (
@@ -165,8 +174,8 @@ export default function AdminAlertsPage() {
                   className="flex items-start justify-between gap-3 rounded-lg border border-border bg-surface-2 p-3"
                 >
                   <div className="min-w-0">
-                    <p className="text-sm font-medium text-fg">{r.name}</p>
-                    <p className="mt-0.5 text-xs text-muted">{r.condition}</p>
+                    <p className="text-sm font-medium text-fg">{t(r.nameKey)}</p>
+                    <p className="mt-0.5 text-xs text-muted">{t(r.conditionKey)}</p>
                     <div className="mt-2 flex flex-wrap gap-1">
                       {r.channel.map((c) => (
                         <span
@@ -178,9 +187,9 @@ export default function AdminAlertsPage() {
                       ))}
                     </div>
                   </div>
-                  <button onClick={() => toggle(r.id)} aria-label="규칙 활성 토글">
+                  <button onClick={() => toggle(r.id)} aria-label={t("toggleAria")}>
                     <Badge tone={r.enabled ? "success" : "neutral"}>
-                      {r.enabled ? "활성" : "비활성"}
+                      {r.enabled ? t("enabled") : t("disabled")}
                     </Badge>
                   </button>
                 </div>
@@ -190,7 +199,7 @@ export default function AdminAlertsPage() {
 
           <Card>
             <CardHeader>
-              <CardTitle>최근 발생 알림</CardTitle>
+              <CardTitle>{t("recentTitle")}</CardTitle>
             </CardHeader>
             <CardContent>
               <ol className="relative space-y-4 border-l border-border pl-5">
@@ -210,12 +219,12 @@ export default function AdminAlertsPage() {
                       </span>
                       <div className="flex items-center justify-between gap-2">
                         <div className="flex items-center gap-2">
-                          <Badge tone={SEV_TONE[e.severity]}>{SEV_LABEL[e.severity]}</Badge>
+                          <Badge tone={SEV_TONE[e.severity]}>{t(SEV_LABEL_KEY[e.severity])}</Badge>
                           <span className="font-mono text-[11px] text-faint">{fmt(e.timestamp)}</span>
                           {isAcked && (
                             <Badge tone="success">
                               <Check className="h-3 w-3" />
-                              확인됨
+                              {t("acknowledged")}
                             </Badge>
                           )}
                         </div>
@@ -226,7 +235,7 @@ export default function AdminAlertsPage() {
                             disabled={isAcking}
                             onClick={() => handleAcknowledge(e.id)}
                           >
-                            확인
+                            {t("acknowledge")}
                           </Button>
                         )}
                       </div>

--- a/apps/web/app/(workspace)/admin/analytics/page.tsx
+++ b/apps/web/app/(workspace)/admin/analytics/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import { LineChart } from "lucide-react";
 import {
   PageHeader,
@@ -17,10 +18,10 @@ import { cn } from "@/lib/utils";
 import { ApiClient } from "@/lib/api-client";
 
 type Period = "7d" | "30d" | "90d";
-const PERIODS: { key: Period; label: string }[] = [
-  { key: "7d", label: "7일" },
-  { key: "30d", label: "30일" },
-  { key: "90d", label: "90일" },
+const PERIODS: { key: Period; labelKey: string }[] = [
+  { key: "7d", labelKey: "period.7d" },
+  { key: "30d", labelKey: "period.30d" },
+  { key: "90d", labelKey: "period.90d" },
 ];
 
 // 일별 대화량/모델 비중 실데이터: /api/metrics/analytics/daily-conversations,
@@ -113,6 +114,7 @@ interface AgentRow {
 function fmtCost(n: number) { return `$${n.toFixed(4)}`; }
 
 export default function AdminAnalyticsPage() {
+  const t = useTranslations("adminAnalytics");
   const [period, setPeriod] = useState<Period>("7d");
   // 실데이터 오버레이 (가능한 지표만): null 이면 목업 SUMMARY 사용
   const [liveUsers, setLiveUsers] = useState<string | null>(null);
@@ -234,8 +236,8 @@ export default function AdminAnalyticsPage() {
   return (
     <>
       <PageHeader
-        title="애널리틱스"
-        description="대화량, 사용자, 토큰 소비 추세를 분석합니다."
+        title={t("title")}
+        description={t("description")}
         actions={
           <div className="flex items-center gap-1 rounded-pill border border-border bg-surface-2 p-1">
             {PERIODS.map((p) => (
@@ -249,7 +251,7 @@ export default function AdminAnalyticsPage() {
                     : "text-muted hover:text-fg",
                 )}
               >
-                {p.label}
+                {t(p.labelKey)}
               </button>
             ))}
           </div>
@@ -258,16 +260,16 @@ export default function AdminAnalyticsPage() {
 
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          <StatCard label="총 대화" value={sum.conv} delta="+8.1%" />
-          <StatCard label="활성 사용자" value={liveUsers ?? sum.users} delta="+3.4%" />
-          <StatCard label="소비 토큰" value={liveTokens ?? sum.tokens} delta="+12.7%" />
-          <StatCard label="평균 응답" value={sum.latency} delta="-0.06s" deltaTone="success" />
+          <StatCard label={t("stats.totalConversations")} value={sum.conv} delta="+8.1%" />
+          <StatCard label={t("stats.activeUsers")} value={liveUsers ?? sum.users} delta="+3.4%" />
+          <StatCard label={t("stats.consumedTokens")} value={liveTokens ?? sum.tokens} delta="+12.7%" />
+          <StatCard label={t("stats.avgResponse")} value={sum.latency} delta="-0.06s" deltaTone="success" />
         </div>
 
         <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
           <Card className="lg:col-span-2">
             <CardHeader>
-              <CardTitle>일별 대화량</CardTitle>
+              <CardTitle>{t("dailyConversations")}</CardTitle>
             </CardHeader>
             <CardContent>
               <div className="flex h-56 items-end gap-1.5">
@@ -289,7 +291,7 @@ export default function AdminAnalyticsPage() {
               </div>
               {period !== "7d" && (
                 <p className="mt-3 text-center text-[10px] text-faint">
-                  최근 {period === "30d" ? 30 : 90}일 · 일자별
+                  {t("recentDaysCaption", { days: period === "30d" ? 30 : 90 })}
                 </p>
               )}
             </CardContent>
@@ -298,7 +300,7 @@ export default function AdminAnalyticsPage() {
           <Card>
             <CardHeader className="flex items-center gap-2">
               <LineChart className="h-4 w-4 text-accent" />
-              <CardTitle>모델 프로파일 사용 비중</CardTitle>
+              <CardTitle>{t("modelUsageTitle")}</CardTitle>
             </CardHeader>
             <CardContent>
               <div className="space-y-3.5">
@@ -325,21 +327,21 @@ export default function AdminAnalyticsPage() {
         {costData && (
           <Card className="mt-6">
             <CardHeader>
-              <CardTitle>비용 분석</CardTitle>
+              <CardTitle>{t("costAnalysis")}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-                <StatCard label="일일 비용" value={fmtCost(costData.dailyCost)} />
-                <StatCard label="주간 비용" value={fmtCost(costData.weeklyCost)} />
-                <StatCard label="월간 예상 비용" value={fmtCost(costData.projectedMonthlyCost)} />
+                <StatCard label={t("dailyCost")} value={fmtCost(costData.dailyCost)} />
+                <StatCard label={t("weeklyCost")} value={fmtCost(costData.weeklyCost)} />
+                <StatCard label={t("projectedMonthlyCost")} value={fmtCost(costData.projectedMonthlyCost)} />
               </div>
               {costData.costByModel.length > 0 && (
                 <Table>
                   <thead>
                     <tr>
-                      <Th>모델</Th>
-                      <Th className="text-right">비용</Th>
-                      <Th className="text-right">비중</Th>
+                      <Th>{t("col.model")}</Th>
+                      <Th className="text-right">{t("col.cost")}</Th>
+                      <Th className="text-right">{t("col.share")}</Th>
                     </tr>
                   </thead>
                   <tbody>
@@ -361,29 +363,29 @@ export default function AdminAnalyticsPage() {
         {behaviorData && (
           <Card className="mt-6">
             <CardHeader>
-              <CardTitle>사용자 행동</CardTitle>
+              <CardTitle>{t("userBehavior")}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <StatCard
-                  label="평균 세션 길이"
-                  value={`${Math.round(behaviorData.avgSessionLength)}분`}
+                  label={t("avgSessionLength")}
+                  value={t("minutesSuffix", { value: Math.round(behaviorData.avgSessionLength) })}
                 />
                 <StatCard
-                  label="세션당 평균 쿼리"
+                  label={t("avgQueriesPerSession")}
                   value={behaviorData.avgQueriesPerSession.toFixed(1)}
                 />
               </div>
               {behaviorData.peakHours.length > 0 && (
                 <div>
-                  <p className="mb-2 text-xs font-medium text-fg-2">피크 시간대 Top 3</p>
+                  <p className="mb-2 text-xs font-medium text-fg-2">{t("peakHoursTop3")}</p>
                   <div className="flex flex-wrap gap-2">
                     {behaviorData.peakHours.slice(0, 3).map((h) => (
                       <span
                         key={h.hour}
                         className="rounded-md border border-border bg-surface-2 px-2.5 py-1 text-xs text-fg"
                       >
-                        {String(h.hour).padStart(2, "0")}시 · {h.requests.toLocaleString()} 요청
+                        {t("peakHourItem", { hour: String(h.hour).padStart(2, "0"), requests: h.requests.toLocaleString() })}
                       </span>
                     ))}
                   </div>
@@ -391,7 +393,7 @@ export default function AdminAnalyticsPage() {
               )}
               {behaviorData.topQueries.length > 0 && (
                 <div>
-                  <p className="mb-2 text-xs font-medium text-fg-2">자주 묻는 쿼리 Top 5</p>
+                  <p className="mb-2 text-xs font-medium text-fg-2">{t("topQueriesTop5")}</p>
                   <ol className="space-y-1">
                     {behaviorData.topQueries.slice(0, 5).map((q, i) => (
                       <li key={i} className="flex items-center gap-2 text-xs text-fg-2">
@@ -411,16 +413,16 @@ export default function AdminAnalyticsPage() {
         {agentsData && agentsData.length > 0 && (
           <Card className="mt-6">
             <CardHeader>
-              <CardTitle>에이전트 성능</CardTitle>
+              <CardTitle>{t("agentPerformance")}</CardTitle>
             </CardHeader>
             <CardContent className="p-0">
               <Table>
                 <thead>
                   <tr>
-                    <Th>에이전트</Th>
-                    <Th className="text-right">요청 수</Th>
-                    <Th className="text-right">성공률</Th>
-                    <Th className="text-right">평균 응답</Th>
+                    <Th>{t("col.agent")}</Th>
+                    <Th className="text-right">{t("col.requests")}</Th>
+                    <Th className="text-right">{t("col.successRate")}</Th>
+                    <Th className="text-right">{t("col.avgResponse")}</Th>
                   </tr>
                 </thead>
                 <tbody>

--- a/apps/web/app/(workspace)/admin/audit/page.tsx
+++ b/apps/web/app/(workspace)/admin/audit/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import { ScrollText, Download } from "lucide-react";
 import {
   PageHeader,
@@ -32,10 +33,10 @@ const SEV_TONE: Record<Severity, "danger" | "warn" | "neutral"> = {
   warn: "warn",
   info: "neutral",
 };
-const SEV_LABEL: Record<Severity, string> = {
-  critical: "심각",
-  warn: "경고",
-  info: "정보",
+const SEV_LABEL_KEY: Record<Severity, string> = {
+  critical: "status.critical",
+  warn: "status.warn",
+  info: "status.info",
 };
 
 // TODO: API 연동 (/api/audit) — 응답 실패 시 폴백 목업
@@ -50,14 +51,20 @@ const MOCK_LOGS: AuditLog[] = [
   { id: "a8", timestamp: "2026-06-20T22:30:55Z", actor: "system", action: "auth.failed_attempt", target: "unknown@spam.io", severity: "warn", ip: "45.33.21.7" },
 ];
 
-const ACTIONS = ["전체", "user.delete", "user.role_change", "apikey.create", "auth.login", "auth.failed_attempt", "mcp.server_register", "llm.context_overflow", "alert.dispatched"];
-const SEVERITIES: { key: "all" | Severity; label: string }[] = [
-  { key: "all", label: "전체 심각도" },
-  { key: "critical", label: "심각" },
-  { key: "warn", label: "경고" },
-  { key: "info", label: "정보" },
+const ALL_ACTIONS = "__all__";
+const ACTIONS = [ALL_ACTIONS, "user.delete", "user.role_change", "apikey.create", "auth.login", "auth.failed_attempt", "mcp.server_register", "llm.context_overflow", "alert.dispatched"];
+const SEVERITIES: { key: "all" | Severity; labelKey: string }[] = [
+  { key: "all", labelKey: "severity.all" },
+  { key: "critical", labelKey: "status.critical" },
+  { key: "warn", labelKey: "status.warn" },
+  { key: "info", labelKey: "status.info" },
 ];
-const PERIODS = ["오늘", "7일", "30일", "전체"];
+const PERIODS: { key: string; labelKey: string }[] = [
+  { key: "today", labelKey: "period.today" },
+  { key: "days7", labelKey: "period.days7" },
+  { key: "days30", labelKey: "period.days30" },
+  { key: "all", labelKey: "period.all" },
+];
 
 function fmt(s: string) {
   return new Date(s).toLocaleString("ko-KR", {
@@ -83,10 +90,11 @@ interface ApiAuditLog {
 }
 
 export default function AdminAuditPage() {
+  const t = useTranslations("adminAudit");
   const [logs, setLogs] = useState<AuditLog[]>(MOCK_LOGS);
-  const [action, setAction] = useState("전체");
+  const [action, setAction] = useState(ALL_ACTIONS);
   const [severity, setSeverity] = useState<"all" | Severity>("all");
-  const [period, setPeriod] = useState("7일");
+  const [period, setPeriod] = useState("days7");
 
   useEffect(() => {
     let alive = true;
@@ -122,7 +130,7 @@ export default function AdminAuditPage() {
     () =>
       logs.filter(
         (l) =>
-          (action === "전체" || l.action === action) &&
+          (action === ALL_ACTIONS || l.action === action) &&
           (severity === "all" || l.severity === severity),
       ),
     [logs, action, severity],
@@ -134,12 +142,12 @@ export default function AdminAuditPage() {
   return (
     <>
       <PageHeader
-        title="감사 로그"
-        description="시스템 전반의 보안·관리 활동 기록입니다."
+        title={t("title")}
+        description={t("description")}
         actions={
           <div className="flex items-center gap-2">
             <Badge tone="neutral">
-              <ScrollText className="h-3.5 w-3.5" /> {filtered.length}건
+              <ScrollText className="h-3.5 w-3.5" /> {t("countBadge", { count: filtered.length })}
             </Badge>
             <Button
               variant="outline"
@@ -147,7 +155,7 @@ export default function AdminAuditPage() {
               onClick={() => { window.location.href = "/api/audit/export"; }}
             >
               <Download className="h-4 w-4" />
-              CSV 내보내기
+              {t("exportCsv")}
             </Button>
           </div>
         }
@@ -158,7 +166,7 @@ export default function AdminAuditPage() {
           <select className={selectCls} value={action} onChange={(e) => setAction(e.target.value)}>
             {ACTIONS.map((a) => (
               <option key={a} value={a}>
-                {a === "전체" ? "전체 액션" : a}
+                {a === ALL_ACTIONS ? t("filter.allActions") : a}
               </option>
             ))}
           </select>
@@ -169,21 +177,21 @@ export default function AdminAuditPage() {
           >
             {SEVERITIES.map((s) => (
               <option key={s.key} value={s.key}>
-                {s.label}
+                {t(s.labelKey)}
               </option>
             ))}
           </select>
           <div className="flex items-center gap-1 rounded-pill border border-border bg-surface-2 p-1">
             {PERIODS.map((p) => (
               <button
-                key={p}
-                onClick={() => setPeriod(p)}
+                key={p.key}
+                onClick={() => setPeriod(p.key)}
                 className={cn(
                   "rounded-pill px-3 py-1 text-xs font-medium transition",
-                  period === p ? "bg-surface text-fg shadow-1" : "text-muted hover:text-fg",
+                  period === p.key ? "bg-surface text-fg shadow-1" : "text-muted hover:text-fg",
                 )}
               >
-                {p}
+                {t(p.labelKey)}
               </button>
             ))}
           </div>
@@ -194,11 +202,11 @@ export default function AdminAuditPage() {
             <Table>
               <thead>
                 <tr>
-                  <Th>시각</Th>
-                  <Th>액터</Th>
-                  <Th>액션</Th>
-                  <Th>대상</Th>
-                  <Th>심각도</Th>
+                  <Th>{t("th.time")}</Th>
+                  <Th>{t("th.actor")}</Th>
+                  <Th>{t("th.action")}</Th>
+                  <Th>{t("th.target")}</Th>
+                  <Th>{t("th.severity")}</Th>
                   <Th>IP</Th>
                 </tr>
               </thead>
@@ -206,7 +214,7 @@ export default function AdminAuditPage() {
                 {filtered.length === 0 ? (
                   <tr>
                     <Td className="py-8 text-center text-muted" colSpan={6}>
-                      조건에 맞는 로그가 없습니다.
+                      {t("empty")}
                     </Td>
                   </tr>
                 ) : (
@@ -217,7 +225,7 @@ export default function AdminAuditPage() {
                       <Td className="font-mono text-xs text-fg-2">{l.action}</Td>
                       <Td className="font-mono text-xs text-muted">{l.target}</Td>
                       <Td>
-                        <Badge tone={SEV_TONE[l.severity]}>{SEV_LABEL[l.severity]}</Badge>
+                        <Badge tone={SEV_TONE[l.severity]}>{t(SEV_LABEL_KEY[l.severity])}</Badge>
                       </Td>
                       <Td className="font-mono text-xs text-muted">{l.ip}</Td>
                     </tr>

--- a/apps/web/app/(workspace)/admin/mcp-catalog/page.tsx
+++ b/apps/web/app/(workspace)/admin/mcp-catalog/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Boxes, Plus, Pencil, Trash2, X, Loader2 } from "lucide-react";
 import {
   PageHeader,
@@ -42,6 +43,7 @@ const labelCls = "block text-xs font-medium text-fg-2 mb-1";
 
 /* ── 모달 공통 래퍼 ─────────────────────────────────────────── */
 function Modal({ onClose, children }: { onClose: () => void; children: React.ReactNode }) {
+  const t = useTranslations("adminMcpCatalog");
   return (
     <div
       role="dialog"
@@ -55,7 +57,7 @@ function Modal({ onClose, children }: { onClose: () => void; children: React.Rea
         <button
           onClick={onClose}
           className="absolute right-4 top-4 text-faint hover:text-fg"
-          aria-label="닫기"
+          aria-label={t("close")}
         >
           <X className="h-4 w-4" />
         </button>
@@ -73,6 +75,7 @@ interface TemplateFormProps {
 }
 
 function TemplateFormModal({ initial, onClose, onSaved }: TemplateFormProps) {
+  const t = useTranslations("adminMcpCatalog");
   const isEdit = Boolean(initial);
   const [id, setId] = useState(initial?.id ?? "");
   const [displayName, setDisplayName] = useState(initial?.display_name ?? "");
@@ -105,7 +108,7 @@ function TemplateFormModal({ initial, onClose, onSaved }: TemplateFormProps) {
       onSaved();
       onClose();
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "저장 실패. 다시 시도해 주세요.");
+      setError(e instanceof Error ? e.message : t("saveError"));
     } finally {
       setSubmitting(false);
     }
@@ -114,7 +117,7 @@ function TemplateFormModal({ initial, onClose, onSaved }: TemplateFormProps) {
   return (
     <Modal onClose={onClose}>
       <h2 className="mb-4 text-base font-semibold text-fg">
-        {isEdit ? "템플릿 편집" : "새 템플릿"}
+        {isEdit ? t("editTitle") : t("createTitle")}
       </h2>
       <form onSubmit={handleSubmit} className="space-y-3">
         {!isEdit && (
@@ -130,7 +133,7 @@ function TemplateFormModal({ initial, onClose, onSaved }: TemplateFormProps) {
           </div>
         )}
         <div>
-          <label className={labelCls}>표시 이름 *</label>
+          <label className={labelCls}>{t("displayNameLabel")} *</label>
           <input
             className={inputCls}
             required
@@ -140,17 +143,17 @@ function TemplateFormModal({ initial, onClose, onSaved }: TemplateFormProps) {
           />
         </div>
         <div>
-          <label className={labelCls}>설명</label>
+          <label className={labelCls}>{t("descriptionLabel")}</label>
           <textarea
             className={textareaCls}
             rows={2}
             value={description}
             onChange={(e) => setDescription(e.target.value)}
-            placeholder="서버에 대한 간략한 설명"
+            placeholder={t("descriptionPlaceholder")}
           />
         </div>
         <div>
-          <label className={labelCls}>유형 *</label>
+          <label className={labelCls}>{t("typeLabel")} *</label>
           <select
             className={selectCls}
             value={transportType}
@@ -163,7 +166,7 @@ function TemplateFormModal({ initial, onClose, onSaved }: TemplateFormProps) {
         </div>
         {transportType === "stdio" && (
           <div>
-            <label className={labelCls}>명령어</label>
+            <label className={labelCls}>{t("commandLabel")}</label>
             <input
               className={inputCls}
               value={command}
@@ -192,14 +195,14 @@ function TemplateFormModal({ initial, onClose, onSaved }: TemplateFormProps) {
             onChange={(e) => setIsEnabled(e.target.checked)}
             className="h-4 w-4 accent-accent"
           />
-          <label htmlFor="is_enabled" className="text-sm text-fg-2">활성화</label>
+          <label htmlFor="is_enabled" className="text-sm text-fg-2">{t("enabledLabel")}</label>
         </div>
         {error && <p className="text-xs text-danger">{error}</p>}
         <div className="flex justify-end gap-2 pt-2">
-          <Button type="button" variant="outline" size="sm" onClick={onClose}>취소</Button>
+          <Button type="button" variant="outline" size="sm" onClick={onClose}>{t("cancel")}</Button>
           <Button type="submit" size="sm" disabled={submitting}>
             {submitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-            {isEdit ? "저장" : "생성"}
+            {isEdit ? t("save") : t("create")}
           </Button>
         </div>
       </form>
@@ -217,6 +220,7 @@ function DeleteTemplateModal({
   onClose: () => void;
   onDeleted: () => void;
 }) {
+  const t = useTranslations("adminMcpCatalog");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
 
@@ -228,7 +232,7 @@ function DeleteTemplateModal({
       onDeleted();
       onClose();
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "삭제 실패. 다시 시도해 주세요.");
+      setError(e instanceof Error ? e.message : t("deleteError"));
     } finally {
       setSubmitting(false);
     }
@@ -236,15 +240,15 @@ function DeleteTemplateModal({
 
   return (
     <Modal onClose={onClose}>
-      <h2 className="mb-2 text-base font-semibold text-fg">템플릿 삭제</h2>
-      <p className="mb-1 text-sm text-fg-2">정말 삭제하시겠습니까?</p>
+      <h2 className="mb-2 text-base font-semibold text-fg">{t("deleteTitle")}</h2>
+      <p className="mb-1 text-sm text-fg-2">{t("deleteConfirm")}</p>
       <p className="mb-4 font-mono text-xs text-muted">{template.id}</p>
       {error && <p className="mb-3 text-xs text-danger">{error}</p>}
       <div className="flex justify-end gap-2">
-        <Button variant="outline" size="sm" onClick={onClose} disabled={submitting}>취소</Button>
+        <Button variant="outline" size="sm" onClick={onClose} disabled={submitting}>{t("cancel")}</Button>
         <Button variant="danger" size="sm" onClick={handleDelete} disabled={submitting}>
           {submitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-          삭제
+          {t("delete")}
         </Button>
       </div>
     </Modal>
@@ -253,6 +257,7 @@ function DeleteTemplateModal({
 
 /* ── 페이지 ─────────────────────────────────────────────────── */
 export default function AdminMcpCatalogPage() {
+  const t = useTranslations("adminMcpCatalog");
   const [templates, setTemplates] = useState<CatalogTemplate[]>([]);
   const [loading, setLoading] = useState(true);
   const [showCreate, setShowCreate] = useState(false);
@@ -279,12 +284,12 @@ export default function AdminMcpCatalogPage() {
   return (
     <>
       <PageHeader
-        title="MCP 카탈로그 관리"
-        description="사용자에게 제공되는 MCP 서버 템플릿을 관리합니다."
+        title={t("pageTitle")}
+        description={t("pageDescription")}
         actions={
           <Button size="sm" onClick={() => setShowCreate(true)}>
             <Plus className="h-4 w-4" />
-            템플릿 추가
+            {t("addTemplate")}
           </Button>
         }
       />
@@ -296,18 +301,18 @@ export default function AdminMcpCatalogPage() {
               <thead>
                 <tr>
                   <Th>ID</Th>
-                  <Th>이름</Th>
-                  <Th>설명</Th>
-                  <Th>유형</Th>
-                  <Th>활성여부</Th>
-                  <Th>액션</Th>
+                  <Th>{t("colName")}</Th>
+                  <Th>{t("colDescription")}</Th>
+                  <Th>{t("colType")}</Th>
+                  <Th>{t("colEnabled")}</Th>
+                  <Th>{t("colActions")}</Th>
                 </tr>
               </thead>
               <tbody>
                 {loading ? (
                   <tr>
                     <Td colSpan={6}>
-                      <div className="py-12 text-center text-muted">로딩 중…</div>
+                      <div className="py-12 text-center text-muted">{t("loading")}</div>
                     </Td>
                   </tr>
                 ) : templates.length === 0 ? (
@@ -315,24 +320,24 @@ export default function AdminMcpCatalogPage() {
                     <Td colSpan={6}>
                       <div className="flex flex-col items-center gap-3 py-12">
                         <Boxes className="h-8 w-8 text-faint" />
-                        <p className="text-sm text-muted">등록된 템플릿이 없습니다.</p>
+                        <p className="text-sm text-muted">{t("emptyState")}</p>
                       </div>
                     </Td>
                   </tr>
                 ) : (
-                  templates.map((t) => (
-                    <tr key={t.id} className="transition hover:bg-surface-2">
-                      <Td className="font-mono text-xs text-muted">{t.id}</Td>
-                      <Td className="font-medium text-fg">{t.display_name}</Td>
-                      <Td className="max-w-xs truncate text-xs text-fg-2">{t.description ?? "-"}</Td>
+                  templates.map((row) => (
+                    <tr key={row.id} className="transition hover:bg-surface-2">
+                      <Td className="font-mono text-xs text-muted">{row.id}</Td>
+                      <Td className="font-medium text-fg">{row.display_name}</Td>
+                      <Td className="max-w-xs truncate text-xs text-fg-2">{row.description ?? "-"}</Td>
                       <Td>
                         <Badge tone="neutral">
-                          <span className="font-mono">{TRANSPORT_LABEL[t.transport_type]}</span>
+                          <span className="font-mono">{TRANSPORT_LABEL[row.transport_type]}</span>
                         </Badge>
                       </Td>
                       <Td>
-                        <Badge tone={t.is_enabled ? "success" : "neutral"}>
-                          {t.is_enabled ? "활성" : "비활성"}
+                        <Badge tone={row.is_enabled ? "success" : "neutral"}>
+                          {row.is_enabled ? t("enabled") : t("disabled")}
                         </Badge>
                       </Td>
                       <Td>
@@ -340,16 +345,16 @@ export default function AdminMcpCatalogPage() {
                           <Button
                             variant="ghost"
                             size="icon"
-                            onClick={() => setEditTemplate(t)}
-                            aria-label="편집"
+                            onClick={() => setEditTemplate(row)}
+                            aria-label={t("editAction")}
                           >
                             <Pencil className="h-3.5 w-3.5" />
                           </Button>
                           <Button
                             variant="ghost"
                             size="icon"
-                            onClick={() => setDeleteTemplate(t)}
-                            aria-label="삭제"
+                            onClick={() => setDeleteTemplate(row)}
+                            aria-label={t("deleteAction")}
                             className="text-danger hover:text-danger"
                           >
                             <Trash2 className="h-3.5 w-3.5" />

--- a/apps/web/app/(workspace)/admin/metrics/page.tsx
+++ b/apps/web/app/(workspace)/admin/metrics/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Gauge, RefreshCw } from "lucide-react";
 import {
   PageHeader,
@@ -32,10 +33,10 @@ const STATUS_TONE: Record<NodeStatus, "success" | "warn" | "danger"> = {
   degraded: "warn",
   offline: "danger",
 };
-const STATUS_LABEL: Record<NodeStatus, string> = {
-  online: "정상",
-  degraded: "저하",
-  offline: "중단",
+const STATUS_LABEL_KEY: Record<NodeStatus, string> = {
+  online: "status.online",
+  degraded: "status.degraded",
+  offline: "status.offline",
 };
 
 // 클러스터 노드/CPU/메모리는 /api/metrics·/api/metrics/metrics 실데이터로 오버레이.
@@ -81,6 +82,7 @@ const STATUS_MAP: Record<string, NodeStatus> = {
 };
 
 export default function AdminMetricsPage() {
+  const t = useTranslations("adminMetrics");
   const [updated, setUpdated] = useState<string>("");
   const [nodes, setNodes] = useState<NodeRow[]>(NODES);
   const [cpu, setCpu] = useState<string | null>(null);
@@ -111,7 +113,7 @@ export default function AdminMetricsPage() {
           setNodes(
             list.map((n) => ({
               name: n.name ?? n.id ?? "node",
-              role: "LLM 노드",
+              role: t("nodeRoleLlm"),
               status: STATUS_MAP[String(n.status)] ?? "degraded",
               latency:
                 typeof n.latency === "number" ? `${n.latency}ms` : (n.latency ?? "-"),
@@ -131,7 +133,7 @@ export default function AdminMetricsPage() {
         if (sys.memory?.used != null && sys.memory?.total != null) {
           setMem({
             value: `${(sys.memory.used / 1024).toFixed(1)} GB`,
-            delta: `총 ${(sys.memory.total / 1024).toFixed(1)} GB 중`,
+            delta: t("memoryDelta", { total: (sys.memory.total / 1024).toFixed(1) }),
           });
         }
       }
@@ -152,7 +154,7 @@ export default function AdminMetricsPage() {
     } catch {
       /* 401/실패 시 목업 유지 */
     }
-  }, []);
+  }, [t]);
 
   useEffect(() => {
     void load();
@@ -166,42 +168,42 @@ export default function AdminMetricsPage() {
   return (
     <>
       <PageHeader
-        title="시스템 메트릭"
-        description={updated ? `마지막 갱신 ${updated}` : "시스템 상태 및 리소스 실시간 모니터링"}
+        title={t("title")}
+        description={updated ? t("lastUpdated", { time: updated }) : t("subtitle")}
         actions={
           <Button variant="outline" size="sm" onClick={onRefresh}>
-            <RefreshCw className="h-3.5 w-3.5" /> 새로고침
+            <RefreshCw className="h-3.5 w-3.5" /> {t("refresh")}
           </Button>
         }
       />
 
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          <StatCard label="CPU 사용률" value={cpu ?? "47%"} delta="load avg / cores" deltaTone="success" />
-          <StatCard label="메모리" value={mem?.value ?? "6.2 GB"} delta={mem?.delta ?? "총 16 GB 중"} />
-          <StatCard label="요청률" value="612/min" delta="+8.4%" />
-          <StatCard label="에러율" value="0.21%" delta="+0.04%" deltaTone="danger" />
+          <StatCard label={t("stat.cpu")} value={cpu ?? "47%"} delta="load avg / cores" deltaTone="success" />
+          <StatCard label={t("stat.memory")} value={mem?.value ?? "6.2 GB"} delta={mem?.delta ?? t("memoryDelta", { total: "16" })} />
+          <StatCard label={t("stat.requestRate")} value="612/min" delta="+8.4%" />
+          <StatCard label={t("stat.errorRate")} value="0.21%" delta="+0.04%" deltaTone="danger" />
         </div>
 
         <Card className="mt-6">
           <CardHeader className="flex items-center gap-2">
             <Gauge className="h-4 w-4 text-accent" />
-            <CardTitle>요청률 (최근 24시간 · req/min)</CardTitle>
+            <CardTitle>{t("requestChartTitle")}</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="flex h-48 items-end gap-1">
-              {TIMESERIES.map((t) => (
+              {TIMESERIES.map((bar) => (
                 <div
-                  key={t.hour}
+                  key={bar.hour}
                   className="group flex h-full flex-1 flex-col items-center justify-end gap-1"
-                  title={`${String(t.hour).padStart(2, "0")}시: ${t.value}/min`}
+                  title={t("barTooltip", { hour: String(bar.hour).padStart(2, "0"), value: bar.value })}
                 >
                   <div
                     className="w-full rounded-t bg-accent/70 transition group-hover:bg-accent"
-                    style={{ height: `${Math.max(4, (t.value / maxV) * 100)}%` }}
+                    style={{ height: `${Math.max(4, (bar.value / maxV) * 100)}%` }}
                   />
-                  {t.hour % 3 === 0 && (
-                    <span className="text-[9px] text-faint">{String(t.hour).padStart(2, "0")}</span>
+                  {bar.hour % 3 === 0 && (
+                    <span className="text-[9px] text-faint">{String(bar.hour).padStart(2, "0")}</span>
                   )}
                 </div>
               ))}
@@ -211,17 +213,17 @@ export default function AdminMetricsPage() {
 
         <Card className="mt-6">
           <CardHeader>
-            <CardTitle>노드 · 서비스 상태</CardTitle>
+            <CardTitle>{t("nodeStatusTitle")}</CardTitle>
           </CardHeader>
           <CardContent className="p-0">
             <Table>
               <thead>
                 <tr>
-                  <Th>노드</Th>
-                  <Th>역할</Th>
-                  <Th>상태</Th>
-                  <Th>지연</Th>
-                  <Th>부하</Th>
+                  <Th>{t("th.node")}</Th>
+                  <Th>{t("th.role")}</Th>
+                  <Th>{t("th.status")}</Th>
+                  <Th>{t("th.latency")}</Th>
+                  <Th>{t("th.load")}</Th>
                 </tr>
               </thead>
               <tbody>
@@ -230,7 +232,7 @@ export default function AdminMetricsPage() {
                     <Td className="font-mono text-xs text-fg">{n.name}</Td>
                     <Td className="text-muted">{n.role}</Td>
                     <Td>
-                      <Badge tone={STATUS_TONE[n.status]}>{STATUS_LABEL[n.status]}</Badge>
+                      <Badge tone={STATUS_TONE[n.status]}>{t(STATUS_LABEL_KEY[n.status])}</Badge>
                     </Td>
                     <Td className="font-mono text-xs text-fg-2">{n.latency}</Td>
                     <Td className="font-mono text-xs text-fg-2">{n.load}</Td>
@@ -244,25 +246,25 @@ export default function AdminMetricsPage() {
         {(agentSummary || (agentMetrics && agentMetrics.length > 0)) && (
           <Card className="mt-6">
             <CardHeader>
-              <CardTitle>에이전트 메트릭</CardTitle>
+              <CardTitle>{t("agentMetricsTitle")}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               {agentSummary && (
                 <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
                   <StatCard
-                    label="총 에이전트"
+                    label={t("agent.totalAgents")}
                     value={String(agentSummary.totalAgents)}
                   />
                   <StatCard
-                    label="총 요청"
+                    label={t("agent.totalRequests")}
                     value={agentSummary.totalRequests.toLocaleString()}
                   />
                   <StatCard
-                    label="평균 성공률"
+                    label={t("agent.avgSuccessRate")}
                     value={`${(agentSummary.avgSuccessRate * 100).toFixed(1)}%`}
                   />
                   <StatCard
-                    label="평균 응답시간"
+                    label={t("agent.avgResponseTime")}
                     value={`${Math.round(agentSummary.avgResponseTime)}ms`}
                   />
                 </div>
@@ -271,10 +273,10 @@ export default function AdminMetricsPage() {
                 <Table>
                   <thead>
                     <tr>
-                      <Th>에이전트 ID</Th>
-                      <Th className="text-right">요청 수</Th>
-                      <Th className="text-right">성공률</Th>
-                      <Th className="text-right">평균 응답시간</Th>
+                      <Th>{t("agentTh.id")}</Th>
+                      <Th className="text-right">{t("agentTh.requests")}</Th>
+                      <Th className="text-right">{t("agentTh.successRate")}</Th>
+                      <Th className="text-right">{t("agentTh.avgResponseTime")}</Th>
                     </tr>
                   </thead>
                   <tbody>

--- a/apps/web/app/(workspace)/admin/page.tsx
+++ b/apps/web/app/(workspace)/admin/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { Shield, Users, Boxes, Gauge, ArrowRight, Pencil, Trash2, Plus, X, Loader2 } from "lucide-react";
 import {
@@ -34,10 +35,10 @@ interface GuardianPending {
   created_at: string;
 }
 
-const ROLE_LABEL: Record<string, string> = {
-  admin: "관리자",
-  user: "사용자",
-  guest: "게스트",
+const ROLE_LABEL_KEY: Record<string, string> = {
+  admin: "roles.admin",
+  user: "roles.user",
+  guest: "roles.guest",
 };
 const ROLE_TONE: Record<string, "danger" | "success" | "neutral"> = {
   admin: "danger",
@@ -60,13 +61,14 @@ function fmtDate(s?: string | null) {
 }
 
 const QUICK_LINKS = [
-  { href: "/admin", title: "사용자 관리", desc: "계정 생성·권한·상태 관리", icon: Users },
-  { href: "/mcp-catalog", title: "모델 · MCP 설정", desc: "모델 프리셋과 도구 카탈로그", icon: Boxes },
-  { href: "/admin/metrics", title: "시스템 상태", desc: "노드·서비스 헬스 모니터링", icon: Gauge },
+  { href: "/admin", titleKey: "quickLinks.users.title", descKey: "quickLinks.users.desc", icon: Users },
+  { href: "/mcp-catalog", titleKey: "quickLinks.models.title", descKey: "quickLinks.models.desc", icon: Boxes },
+  { href: "/admin/metrics", titleKey: "quickLinks.system.title", descKey: "quickLinks.system.desc", icon: Gauge },
 ];
 
 /* ── 모달 공통 래퍼 ─────────────────────────────────────────── */
 function Modal({ onClose, children }: { onClose: () => void; children: React.ReactNode }) {
+  const t = useTranslations("admin");
   const backdropRef = useRef<HTMLDivElement>(null);
   return (
     <div
@@ -79,7 +81,7 @@ function Modal({ onClose, children }: { onClose: () => void; children: React.Rea
         <button
           onClick={onClose}
           className="absolute right-4 top-4 text-faint hover:text-fg"
-          aria-label="닫기"
+          aria-label={t("close")}
         >
           <X className="h-4 w-4" />
         </button>
@@ -101,6 +103,7 @@ function CreateUserModal({
   onClose: () => void;
   onCreated: () => void;
 }) {
+  const t = useTranslations("admin");
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [role, setRole] = useState<"admin" | "user" | "guest">("user");
@@ -117,7 +120,7 @@ function CreateUserModal({
       onCreated();
       onClose();
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "생성 실패. 다시 시도해 주세요.");
+      setError(e instanceof Error ? e.message : t("createError"));
     } finally {
       setSubmitting(false);
     }
@@ -125,34 +128,34 @@ function CreateUserModal({
 
   return (
     <Modal onClose={onClose}>
-      <h2 className="mb-4 text-base font-semibold text-fg">사용자 추가</h2>
+      <h2 className="mb-4 text-base font-semibold text-fg">{t("addUser")}</h2>
       <form onSubmit={handleSubmit} className="space-y-3">
         <div>
-          <label className={labelCls}>이름 (선택)</label>
-          <input className={inputCls} value={name} onChange={(e) => setName(e.target.value)} placeholder="홍길동" />
+          <label className={labelCls}>{t("nameLabel")}</label>
+          <input className={inputCls} value={name} onChange={(e) => setName(e.target.value)} placeholder={t("namePlaceholder")} />
         </div>
         <div>
-          <label className={labelCls}>이메일 *</label>
+          <label className={labelCls}>{t("emailRequired")}</label>
           <input className={inputCls} type="email" required value={email} onChange={(e) => setEmail(e.target.value)} placeholder="user@example.com" />
         </div>
         <div>
-          <label className={labelCls}>역할 *</label>
+          <label className={labelCls}>{t("roleRequired")}</label>
           <select className={selectCls} value={role} onChange={(e) => setRole(e.target.value as "admin" | "user" | "guest")}>
-            <option value="user">사용자</option>
-            <option value="admin">관리자</option>
-            <option value="guest">게스트</option>
+            <option value="user">{t("roles.user")}</option>
+            <option value="admin">{t("roles.admin")}</option>
+            <option value="guest">{t("roles.guest")}</option>
           </select>
         </div>
         <div>
-          <label className={labelCls}>비밀번호 *</label>
+          <label className={labelCls}>{t("passwordRequired")}</label>
           <input className={inputCls} type="password" required value={password} onChange={(e) => setPassword(e.target.value)} placeholder="••••••••" />
         </div>
         {error && <p className="text-xs text-danger">{error}</p>}
         <div className="flex justify-end gap-2 pt-2">
-          <Button type="button" variant="outline" size="sm" onClick={onClose}>취소</Button>
+          <Button type="button" variant="outline" size="sm" onClick={onClose}>{t("cancel")}</Button>
           <Button type="submit" size="sm" disabled={submitting}>
             {submitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-            생성
+            {t("create")}
           </Button>
         </div>
       </form>
@@ -170,6 +173,7 @@ function EditUserModal({
   onClose: () => void;
   onUpdated: () => void;
 }) {
+  const t = useTranslations("admin");
   const [role, setRole] = useState<"admin" | "user" | "guest">(user.role);
   const [isActive, setIsActive] = useState(user.is_active);
   const [password, setPassword] = useState("");
@@ -187,7 +191,7 @@ function EditUserModal({
       onUpdated();
       onClose();
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "수정 실패. 다시 시도해 주세요.");
+      setError(e instanceof Error ? e.message : t("updateError"));
     } finally {
       setSubmitting(false);
     }
@@ -195,34 +199,34 @@ function EditUserModal({
 
   return (
     <Modal onClose={onClose}>
-      <h2 className="mb-1 text-base font-semibold text-fg">사용자 편집</h2>
+      <h2 className="mb-1 text-base font-semibold text-fg">{t("editUser")}</h2>
       <p className="mb-4 text-xs text-muted">{user.email}</p>
       <form onSubmit={handleSubmit} className="space-y-3">
         <div>
-          <label className={labelCls}>역할</label>
+          <label className={labelCls}>{t("roleField")}</label>
           <select className={selectCls} value={role} onChange={(e) => setRole(e.target.value as "admin" | "user" | "guest")}>
-            <option value="user">사용자</option>
-            <option value="admin">관리자</option>
-            <option value="guest">게스트</option>
+            <option value="user">{t("roles.user")}</option>
+            <option value="admin">{t("roles.admin")}</option>
+            <option value="guest">{t("roles.guest")}</option>
           </select>
         </div>
         <div>
-          <label className={labelCls}>상태</label>
+          <label className={labelCls}>{t("statusField")}</label>
           <select className={selectCls} value={isActive ? "active" : "inactive"} onChange={(e) => setIsActive(e.target.value === "active")}>
-            <option value="active">활성</option>
-            <option value="inactive">비활성</option>
+            <option value="active">{t("active")}</option>
+            <option value="inactive">{t("inactive")}</option>
           </select>
         </div>
         <div>
-          <label className={labelCls}>새 비밀번호 (선택)</label>
-          <input className={inputCls} type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="변경하지 않으려면 비워두세요" />
+          <label className={labelCls}>{t("newPasswordLabel")}</label>
+          <input className={inputCls} type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder={t("newPasswordPlaceholder")} />
         </div>
         {error && <p className="text-xs text-danger">{error}</p>}
         <div className="flex justify-end gap-2 pt-2">
-          <Button type="button" variant="outline" size="sm" onClick={onClose}>취소</Button>
+          <Button type="button" variant="outline" size="sm" onClick={onClose}>{t("cancel")}</Button>
           <Button type="submit" size="sm" disabled={submitting}>
             {submitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-            저장
+            {t("save")}
           </Button>
         </div>
       </form>
@@ -240,6 +244,7 @@ function DeleteUserModal({
   onClose: () => void;
   onDeleted: () => void;
 }) {
+  const t = useTranslations("admin");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
 
@@ -251,7 +256,7 @@ function DeleteUserModal({
       onDeleted();
       onClose();
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "삭제 실패. 다시 시도해 주세요.");
+      setError(e instanceof Error ? e.message : t("deleteError"));
     } finally {
       setSubmitting(false);
     }
@@ -259,15 +264,15 @@ function DeleteUserModal({
 
   return (
     <Modal onClose={onClose}>
-      <h2 className="mb-2 text-base font-semibold text-fg">사용자 삭제</h2>
-      <p className="mb-1 text-sm text-fg-2">정말 삭제하시겠습니까?</p>
+      <h2 className="mb-2 text-base font-semibold text-fg">{t("deleteTitle")}</h2>
+      <p className="mb-1 text-sm text-fg-2">{t("deleteConfirm")}</p>
       <p className="mb-4 text-xs text-muted font-mono">{user.email}</p>
       {error && <p className="mb-3 text-xs text-danger">{error}</p>}
       <div className="flex justify-end gap-2">
-        <Button variant="outline" size="sm" onClick={onClose} disabled={submitting}>취소</Button>
+        <Button variant="outline" size="sm" onClick={onClose} disabled={submitting}>{t("cancel")}</Button>
         <Button variant="danger" size="sm" onClick={handleDelete} disabled={submitting}>
           {submitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-          삭제
+          {t("delete")}
         </Button>
       </div>
     </Modal>
@@ -275,8 +280,9 @@ function DeleteUserModal({
 }
 
 export default function AdminPage() {
+  const t = useTranslations("admin");
   const [users, setUsers] = useState<AdminUser[]>(MOCK_USERS);
-  const [stats, setStats] = useState({ total: 1042, active: 318, today: 4821, status: "정상" });
+  const [stats, setStats] = useState({ total: 1042, active: 318, today: 4821, status: t("statusNormal") });
   const [guardianPending, setGuardianPending] = useState<GuardianPending[]>([]);
   const [approvingIds, setApprovingIds] = useState<Set<string>>(new Set());
 
@@ -360,16 +366,16 @@ export default function AdminPage() {
   return (
     <>
       <PageHeader
-        title="관리자 대시보드"
-        description="사용자, 모델, 시스템 상태를 한 곳에서 관리합니다."
+        title={t("title")}
+        description={t("description")}
         actions={
           <div className="flex items-center gap-2">
             <Badge tone="danger">
-              <Shield className="h-3.5 w-3.5" /> 관리자 전용
+              <Shield className="h-3.5 w-3.5" /> {t("adminOnly")}
             </Badge>
             <Button size="sm" onClick={() => setShowCreate(true)}>
               <Plus className="h-4 w-4" />
-              사용자 추가
+              {t("addUser")}
             </Button>
           </div>
         }
@@ -377,16 +383,16 @@ export default function AdminPage() {
 
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          <StatCard label="총 사용자" value={stats.total.toLocaleString()} delta="+12 (지난 7일)" />
-          <StatCard label="활성 세션" value={stats.active.toLocaleString()} delta="+5.2%" />
-          <StatCard label="오늘 요청" value={stats.today.toLocaleString()} delta="+18.4%" />
-          <StatCard label="시스템 상태" value={stats.status} delta="모든 노드 정상" />
+          <StatCard label={t("stats.totalUsers")} value={stats.total.toLocaleString()} delta={t("stats.totalUsersDelta")} />
+          <StatCard label={t("stats.activeSessions")} value={stats.active.toLocaleString()} delta="+5.2%" />
+          <StatCard label={t("stats.todayRequests")} value={stats.today.toLocaleString()} delta="+18.4%" />
+          <StatCard label={t("stats.systemStatus")} value={stats.status} delta={t("stats.allNodesNormal")} />
         </div>
 
-        <h2 className="mt-8 mb-3 text-sm font-semibold text-fg-2">빠른 관리</h2>
+        <h2 className="mt-8 mb-3 text-sm font-semibold text-fg-2">{t("quickLinksHeading")}</h2>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {QUICK_LINKS.map((q) => (
-            <Link key={q.title + q.href} href={q.href} className="group">
+            <Link key={q.titleKey + q.href} href={q.href} className="group">
               <Card className="h-full p-5 transition hover:border-border-strong hover:shadow-2">
                 <div className="flex items-start justify-between">
                   <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-accent-soft text-accent">
@@ -394,8 +400,8 @@ export default function AdminPage() {
                   </span>
                   <ArrowRight className="h-4 w-4 text-faint transition group-hover:translate-x-0.5 group-hover:text-accent" />
                 </div>
-                <p className="mt-4 text-sm font-semibold text-fg">{q.title}</p>
-                <p className="mt-1 text-xs text-muted">{q.desc}</p>
+                <p className="mt-4 text-sm font-semibold text-fg">{t(q.titleKey)}</p>
+                <p className="mt-1 text-xs text-muted">{t(q.descKey)}</p>
               </Card>
             </Link>
           ))}
@@ -403,25 +409,25 @@ export default function AdminPage() {
 
         <Card className="mt-8">
           <CardHeader className="flex items-center justify-between">
-            <CardTitle>최근 가입 사용자</CardTitle>
+            <CardTitle>{t("recentUsers")}</CardTitle>
             <Link
               href="/admin"
               className="inline-flex h-8 items-center rounded-md border border-border-strong bg-surface px-3 text-xs font-medium text-fg hover:bg-surface-2"
             >
-              전체 보기
+              {t("viewAll")}
             </Link>
           </CardHeader>
           <CardContent className="p-0">
             <Table>
               <thead>
                 <tr>
-                  <Th>ID</Th>
-                  <Th>이메일</Th>
-                  <Th>역할</Th>
-                  <Th>상태</Th>
-                  <Th>가입일</Th>
-                  <Th>마지막 로그인</Th>
-                  <Th>액션</Th>
+                  <Th>{t("col.id")}</Th>
+                  <Th>{t("col.email")}</Th>
+                  <Th>{t("col.role")}</Th>
+                  <Th>{t("col.status")}</Th>
+                  <Th>{t("col.joinedAt")}</Th>
+                  <Th>{t("col.lastLogin")}</Th>
+                  <Th>{t("col.actions")}</Th>
                 </tr>
               </thead>
               <tbody>
@@ -430,10 +436,10 @@ export default function AdminPage() {
                     <Td className="font-mono text-xs text-muted">{u.id}</Td>
                     <Td className="text-fg">{u.email}</Td>
                     <Td>
-                      <Badge tone={ROLE_TONE[u.role] ?? "neutral"}>{ROLE_LABEL[u.role] ?? u.role}</Badge>
+                      <Badge tone={ROLE_TONE[u.role] ?? "neutral"}>{ROLE_LABEL_KEY[u.role] ? t(ROLE_LABEL_KEY[u.role]) : u.role}</Badge>
                     </Td>
                     <Td>
-                      <Badge tone={u.is_active ? "success" : "danger"}>{u.is_active ? "활성" : "비활성"}</Badge>
+                      <Badge tone={u.is_active ? "success" : "danger"}>{u.is_active ? t("active") : t("inactive")}</Badge>
                     </Td>
                     <Td>{fmtDate(u.created_at)}</Td>
                     <Td className="text-muted">{u.last_login ? fmtDate(u.last_login) : "-"}</Td>
@@ -443,7 +449,7 @@ export default function AdminPage() {
                           variant="ghost"
                           size="icon"
                           onClick={() => setEditUser(u)}
-                          aria-label="편집"
+                          aria-label={t("col.edit")}
                         >
                           <Pencil className="h-3.5 w-3.5" />
                         </Button>
@@ -451,7 +457,7 @@ export default function AdminPage() {
                           variant="ghost"
                           size="icon"
                           onClick={() => setDeleteUser(u)}
-                          aria-label="삭제"
+                          aria-label={t("col.delete")}
                           className="text-danger hover:text-danger"
                         >
                           <Trash2 className="h-3.5 w-3.5" />
@@ -469,15 +475,15 @@ export default function AdminPage() {
         {guardianPending.length > 0 && (
           <Card className="mt-6">
             <CardHeader>
-              <CardTitle>미성년자 동의 보류</CardTitle>
+              <CardTitle>{t("guardianPending")}</CardTitle>
             </CardHeader>
             <CardContent className="p-0">
               <Table>
                 <thead>
                   <tr>
-                    <Th>이메일</Th>
-                    <Th>가입일</Th>
-                    <Th>액션</Th>
+                    <Th>{t("col.email")}</Th>
+                    <Th>{t("col.joinedAt")}</Th>
+                    <Th>{t("col.actions")}</Th>
                   </tr>
                 </thead>
                 <tbody>
@@ -494,7 +500,7 @@ export default function AdminPage() {
                           {approvingIds.has(u.id) && (
                             <Loader2 className="h-3.5 w-3.5 animate-spin" />
                           )}
-                          승인
+                          {t("approve")}
                         </Button>
                       </Td>
                     </tr>

--- a/apps/web/app/(workspace)/api-keys/page.tsx
+++ b/apps/web/app/(workspace)/api-keys/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import {
   KeyRound,
   Plus,
@@ -46,9 +47,10 @@ interface ProviderEntry {
   user_key: UserKey | null;
 }
 
-const SDK_LABEL: Record<SdkType, string> = {
-  anthropic: "Anthropic",
-  "openai-compatible": "OpenAI 호환",
+/** SdkType → 번역 키 (렌더 시 t() 로 해석) */
+const SDK_LABEL_KEY: Record<SdkType, string> = {
+  anthropic: "sdkType.anthropic",
+  "openai-compatible": "sdkType.openaiCompatible",
 };
 
 function formatDate(iso?: string | null) {
@@ -61,6 +63,7 @@ function formatDate(iso?: string | null) {
 }
 
 export default function ApiKeysPage() {
+  const t = useTranslations("apiKeys");
   const [providers, setProviders] = useState<ProviderEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -76,9 +79,7 @@ export default function ApiKeysPage() {
       setProviders(res?.data?.providers ?? []);
     } catch (e) {
       // TODO: API 연동 — 비로그인/오류 시 목업 카탈로그 노출
-      setError(
-        e instanceof Error ? e.message : "키 목록을 불러오지 못했습니다.",
-      );
+      setError(e instanceof Error ? e.message : t("loadError"));
       setProviders([
         {
           provider_id: "anthropic",
@@ -86,7 +87,7 @@ export default function ApiKeysPage() {
           sdk_type: "anthropic",
           default_base_url: "https://api.anthropic.com",
           user_key: {
-            display_name: "프로덕션",
+            display_name: t("mock.productionName"),
             key_prefix: "sk-ant-",
             base_url: null,
             last_validation_ok: true,
@@ -105,25 +106,23 @@ export default function ApiKeysPage() {
     } finally {
       setLoading(false);
     }
-  }, []);
+    // locale 변경(t) 시 목업 폴백 라벨 재생성
+  }, [t]);
 
   useEffect(() => {
     queueMicrotask(() => void load());
   }, [load]);
 
   async function handleDelete(providerId: string, displayName: string) {
-    if (
-      !window.confirm(
-        `${displayName} 키를 삭제하시겠습니까?\n이 키를 사용하는 모델 호출이 중단됩니다.`,
-      )
-    )
-      return;
+    if (!window.confirm(t("deleteConfirm", { name: displayName }))) return;
     try {
       await ApiClient.del(`/api/external-keys/${providerId}`);
       await load();
     } catch (e) {
       window.alert(
-        "삭제 실패: " + (e instanceof Error ? e.message : "서버 오류"),
+        t("deleteFailed", {
+          error: e instanceof Error ? e.message : t("serverError"),
+        }),
       );
     }
   }
@@ -133,12 +132,12 @@ export default function ApiKeysPage() {
   return (
     <>
       <PageHeader
-        title="API 키"
-        description="외부 LLM 공급자(Anthropic / OpenAI 호환) 키를 등록하고 관리합니다."
+        title={t("title")}
+        description={t("description")}
         actions={
           <Button onClick={() => setShowForm((v) => !v)}>
             {showForm ? <X className="h-4 w-4" /> : <Plus className="h-4 w-4" />}
-            {showForm ? "닫기" : "새 키 추가"}
+            {showForm ? t("close") : t("addKey")}
           </Button>
         }
       />
@@ -158,11 +157,11 @@ export default function ApiKeysPage() {
 
           <Card>
             <CardHeader className="flex items-center justify-between">
-              <CardTitle>등록된 공급자 키</CardTitle>
+              <CardTitle>{t("registeredKeys")}</CardTitle>
               {error && (
                 <span className="inline-flex items-center gap-1 text-xs text-warn">
                   <AlertTriangle className="h-3.5 w-3.5" />
-                  목업 데이터 표시 중
+                  {t("mockDataShown")}
                 </span>
               )}
             </CardHeader>
@@ -170,28 +169,26 @@ export default function ApiKeysPage() {
               {loading ? (
                 <div className="flex items-center justify-center gap-2 py-12 text-sm text-muted">
                   <Loader2 className="h-4 w-4 animate-spin" />
-                  키 목록을 불러오는 중...
+                  {t("loading")}
                 </div>
               ) : registered.length === 0 ? (
                 <div className="flex flex-col items-center gap-2 py-12 text-center">
                   <KeyRound className="h-8 w-8 text-faint" />
                   <p className="text-sm font-medium text-fg">
-                    등록된 외부 키가 없습니다
+                    {t("emptyTitle")}
                   </p>
-                  <p className="text-xs text-muted">
-                    새 키를 추가하면 해당 공급자 모델을 사용할 수 있습니다.
-                  </p>
+                  <p className="text-xs text-muted">{t("emptyDesc")}</p>
                 </div>
               ) : (
                 <Table>
                   <thead>
                     <tr>
-                      <Th>공급자</Th>
-                      <Th>이름</Th>
-                      <Th>키</Th>
-                      <Th>생성일</Th>
-                      <Th>상태</Th>
-                      <Th className="text-right">작업</Th>
+                      <Th>{t("col.provider")}</Th>
+                      <Th>{t("col.name")}</Th>
+                      <Th>{t("col.key")}</Th>
+                      <Th>{t("col.createdAt")}</Th>
+                      <Th>{t("col.status")}</Th>
+                      <Th className="text-right">{t("col.actions")}</Th>
                     </tr>
                   </thead>
                   <tbody>
@@ -203,7 +200,7 @@ export default function ApiKeysPage() {
                           <Td className="text-fg">
                             <div className="font-medium">{p.display_name}</div>
                             <div className="text-xs text-faint">
-                              {SDK_LABEL[p.sdk_type]}
+                              {t(SDK_LABEL_KEY[p.sdk_type])}
                             </div>
                           </Td>
                           <Td>{k.display_name}</Td>
@@ -214,18 +211,22 @@ export default function ApiKeysPage() {
                           <Td>{formatDate(k.created_at)}</Td>
                           <Td>
                             {ok === false ? (
-                              <Badge tone="danger">검증 실패</Badge>
+                              <Badge tone="danger">
+                                {t("status.validationFailed")}
+                              </Badge>
                             ) : ok ? (
-                              <Badge tone="success">활성</Badge>
+                              <Badge tone="success">{t("status.active")}</Badge>
                             ) : (
-                              <Badge tone="neutral">미검증</Badge>
+                              <Badge tone="neutral">
+                                {t("status.unverified")}
+                              </Badge>
                             )}
                           </Td>
                           <Td className="text-right">
                             <Button
                               variant="ghost"
                               size="icon"
-                              aria-label="삭제"
+                              aria-label={t("deleteAria")}
                               onClick={() =>
                                 handleDelete(p.provider_id, p.display_name)
                               }
@@ -257,6 +258,7 @@ function AddKeyForm({
   onClose: () => void;
   onSaved: () => void | Promise<void>;
 }) {
+  const t = useTranslations("apiKeys");
   const [providerId, setProviderId] = useState(
     providers[0]?.provider_id ?? "anthropic",
   );
@@ -270,7 +272,7 @@ function AddKeyForm({
 
   async function handleSubmit() {
     if (!displayName.trim() || apiKey.trim().length < 8) {
-      setFormError("이름과 8자 이상의 API 키를 입력하세요.");
+      setFormError(t("validationError"));
       return;
     }
     setSaving(true);
@@ -285,7 +287,9 @@ function AddKeyForm({
       await onSaved();
     } catch (err) {
       setFormError(
-        "저장 실패: " + (err instanceof Error ? err.message : "서버 오류"),
+        t("saveFailed", {
+          error: err instanceof Error ? err.message : t("serverError"),
+        }),
       );
     } finally {
       setSaving(false);
@@ -295,8 +299,13 @@ function AddKeyForm({
   return (
     <Card>
       <CardHeader className="flex items-center justify-between">
-        <CardTitle>새 키 추가</CardTitle>
-        <Button variant="ghost" size="icon" aria-label="닫기" onClick={onClose}>
+        <CardTitle>{t("addKey")}</CardTitle>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label={t("close")}
+          onClick={onClose}
+        >
           <X className="h-4 w-4" />
         </Button>
       </CardHeader>
@@ -311,7 +320,7 @@ function AddKeyForm({
           <div className="grid gap-4 sm:grid-cols-2">
             <label className="block">
               <span className="mb-1 block text-xs font-medium text-fg-2">
-                공급자
+                {t("col.provider")}
               </span>
               <select
                 value={providerId}
@@ -320,26 +329,26 @@ function AddKeyForm({
               >
                 {providers.map((p) => (
                   <option key={p.provider_id} value={p.provider_id}>
-                    {p.display_name} ({SDK_LABEL[p.sdk_type]})
+                    {p.display_name} ({t(SDK_LABEL_KEY[p.sdk_type])})
                   </option>
                 ))}
               </select>
             </label>
             <label className="block">
               <span className="mb-1 block text-xs font-medium text-fg-2">
-                이름
+                {t("col.name")}
               </span>
               <input
                 value={displayName}
                 onChange={(e) => setDisplayName(e.target.value)}
-                placeholder="예: 프로덕션, 개발용"
+                placeholder={t("namePlaceholder")}
                 className="h-9 w-full rounded-md border border-border-strong bg-surface px-3 text-sm text-fg outline-none focus:border-accent"
               />
             </label>
           </div>
           <label className="block">
             <span className="mb-1 block text-xs font-medium text-fg-2">
-              API 키
+              {t("apiKeyLabel")}
             </span>
             <input
               type="password"
@@ -351,7 +360,7 @@ function AddKeyForm({
           </label>
           <label className="block">
             <span className="mb-1 block text-xs font-medium text-fg-2">
-              Base URL (선택)
+              {t("baseUrlLabel")}
             </span>
             <input
               value={baseUrl}
@@ -365,7 +374,7 @@ function AddKeyForm({
 
           <div className="flex justify-end gap-2 pt-1">
             <Button type="button" variant="outline" onClick={onClose}>
-              취소
+              {t("cancel")}
             </Button>
             <Button type="submit" disabled={saving}>
               {saving ? (
@@ -373,7 +382,7 @@ function AddKeyForm({
               ) : (
                 <Save className="h-4 w-4" />
               )}
-              저장
+              {t("save")}
             </Button>
           </div>
         </form>

--- a/apps/web/app/(workspace)/developer/page.tsx
+++ b/apps/web/app/(workspace)/developer/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { ScrollText, KeyRound, MessageSquare, Sparkles } from "lucide-react";
 import {
   PageHeader,
@@ -23,39 +24,47 @@ interface QuickStartData {
   baseUrl?: string;
 }
 
-const DEFAULT_STEPS: QuickStartStep[] = [
-  {
-    step: 1,
-    title: "API 키 발급",
-    description: "설정 > API 키 페이지에서 새 API 키를 생성합니다.",
-    code: `# API 키를 HTTP 헤더에 포함
+const STEP_CODES: Record<number, string> = {
+  1: `# API 키를 HTTP 헤더에 포함
 Authorization: Bearer <YOUR_API_KEY>`,
-  },
-  {
-    step: 2,
-    title: "채팅 완성 요청",
-    description: "OpenAI 호환 /v1/chat/completions 엔드포인트에 요청을 보냅니다.",
-    code: `curl -X POST https://your-instance/v1/chat/completions \\
+  2: `curl -X POST https://your-instance/v1/chat/completions \\
   -H "Authorization: Bearer <YOUR_API_KEY>" \\
   -H "Content-Type: application/json" \\
   -d '{
     "model": "default",
     "messages": [{"role": "user", "content": "안녕하세요!"}]
   }'`,
-  },
-  {
-    step: 3,
-    title: "스트리밍 응답",
-    description: "stream: true 를 추가하면 SSE 스트림으로 토큰을 실시간 수신합니다.",
-    code: `curl -X POST https://your-instance/v1/chat/completions \\
+  3: `curl -X POST https://your-instance/v1/chat/completions \\
   -H "Authorization: Bearer <YOUR_API_KEY>" \\
   -H "Content-Type: application/json" \\
   -d '{"model":"default","messages":[...],"stream":true}'`,
-  },
-];
+};
 
 export default function DeveloperPage() {
-  const [steps, setSteps] = useState<QuickStartStep[]>(DEFAULT_STEPS);
+  const t = useTranslations("developer");
+
+  const defaultSteps: QuickStartStep[] = [
+    {
+      step: 1,
+      title: t("steps.apiKey.title"),
+      description: t("steps.apiKey.description"),
+      code: STEP_CODES[1],
+    },
+    {
+      step: 2,
+      title: t("steps.chatCompletion.title"),
+      description: t("steps.chatCompletion.description"),
+      code: STEP_CODES[2],
+    },
+    {
+      step: 3,
+      title: t("steps.streaming.title"),
+      description: t("steps.streaming.description"),
+      code: STEP_CODES[3],
+    },
+  ];
+
+  const [steps, setSteps] = useState<QuickStartStep[]>(defaultSteps);
 
   useEffect(() => {
     let alive = true;
@@ -81,8 +90,8 @@ export default function DeveloperPage() {
   return (
     <>
       <PageHeader
-        title="개발자 문서"
-        description="OpenMake LLM API를 통합하고 자동화합니다."
+        title={t("pageTitle")}
+        description={t("pageDescription")}
       />
 
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
@@ -91,7 +100,7 @@ export default function DeveloperPage() {
           <Card>
             <CardHeader className="flex items-center gap-2">
               <ScrollText className="h-4 w-4 text-accent" />
-              <CardTitle>API 기본 정보</CardTitle>
+              <CardTitle>{t("apiInfo.title")}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div>
@@ -101,15 +110,19 @@ export default function DeveloperPage() {
                 </pre>
               </div>
               <div>
-                <p className="mb-1 text-xs font-medium text-fg-2">API 버전</p>
+                <p className="mb-1 text-xs font-medium text-fg-2">{t("apiInfo.apiVersionLabel")}</p>
                 <pre className="rounded-md bg-surface-2 p-3 text-xs text-fg-2 overflow-x-auto font-mono">
-                  {`/v1  — OpenAI 호환 엔드포인트\n/api — OpenMake 전용 엔드포인트`}
+                  {t("apiInfo.versionBlock")}
                 </pre>
               </div>
               <p className="text-sm text-fg-2">
-                OpenMake LLM API는 OpenAI Chat Completions API와 호환됩니다.
-                기존 OpenAI SDK를 <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-xs">baseURL</code>만
-                변경하여 바로 사용할 수 있습니다.
+                {t.rich("apiInfo.description", {
+                  code: (chunks) => (
+                    <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-xs">
+                      {chunks}
+                    </code>
+                  ),
+                })}
               </p>
             </CardContent>
           </Card>
@@ -118,23 +131,28 @@ export default function DeveloperPage() {
           <Card>
             <CardHeader className="flex items-center gap-2">
               <KeyRound className="h-4 w-4 text-accent" />
-              <CardTitle>인증 방식</CardTitle>
+              <CardTitle>{t("auth.title")}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div>
-                <p className="mb-2 text-sm font-medium text-fg">API Key 인증</p>
+                <p className="mb-2 text-sm font-medium text-fg">{t("auth.apiKeyTitle")}</p>
                 <p className="mb-2 text-sm text-fg-2">
-                  설정 {">"} API 키 페이지에서 발급한 키를 <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-xs">Authorization</code> 헤더에 전달합니다.
+                  {t.rich("auth.apiKeyDesc", {
+                    code: (chunks) => (
+                      <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-xs">
+                        {chunks}
+                      </code>
+                    ),
+                  })}
                 </p>
                 <pre className="rounded-md bg-surface-2 p-3 text-xs text-fg-2 overflow-x-auto font-mono">
                   {`Authorization: Bearer om_live_xxxxxxxxxxxxxxxx`}
                 </pre>
               </div>
               <div>
-                <p className="mb-2 text-sm font-medium text-fg">JWT 세션 인증</p>
+                <p className="mb-2 text-sm font-medium text-fg">{t("auth.jwtTitle")}</p>
                 <p className="mb-2 text-sm text-fg-2">
-                  브라우저 세션은 HttpOnly 쿠키에 저장된 JWT를 자동으로 사용합니다.
-                  API 직접 호출 시에는 API Key를 권장합니다.
+                  {t("auth.jwtDesc")}
                 </p>
               </div>
             </CardContent>
@@ -144,31 +162,36 @@ export default function DeveloperPage() {
           <Card>
             <CardHeader className="flex items-center gap-2">
               <Sparkles className="h-4 w-4 text-accent" />
-              <CardTitle>모델 목록</CardTitle>
+              <CardTitle>{t("models.title")}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">
               <p className="text-sm text-fg-2">
-                사용 가능한 모델 목록은 <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-xs">GET /api/models</code>로 조회하거나,
-                채팅 페이지의 모델 선택기를 참고하세요.
+                {t.rich("models.description", {
+                  code: (chunks) => (
+                    <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-xs">
+                      {chunks}
+                    </code>
+                  ),
+                })}
               </p>
               <pre className="rounded-md bg-surface-2 p-3 text-xs text-fg-2 overflow-x-auto font-mono">
                 {`curl https://your-instance/api/models \\
   -H "Authorization: Bearer <YOUR_API_KEY>"`}
               </pre>
               <div className="rounded-md border border-border bg-surface-2 p-3">
-                <p className="mb-2 text-xs font-medium text-fg-2">브랜드 모델 ID</p>
+                <p className="mb-2 text-xs font-medium text-fg-2">{t("models.brandIdLabel")}</p>
                 <div className="grid grid-cols-2 gap-1 text-xs font-mono text-muted">
                   {[
-                    ["default", "기본 모델"],
-                    ["pro", "고성능 모델"],
-                    ["fast", "빠른 응답"],
-                    ["think", "추론 모드"],
-                    ["code", "코드 특화"],
-                    ["vision", "이미지 지원"],
-                  ].map(([id, label]) => (
+                    ["default", "brandModels.default"],
+                    ["pro", "brandModels.pro"],
+                    ["fast", "brandModels.fast"],
+                    ["think", "brandModels.think"],
+                    ["code", "brandModels.code"],
+                    ["vision", "brandModels.vision"],
+                  ].map(([id, labelKey]) => (
                     <div key={id} className="flex gap-2">
                       <span className="text-accent">{id}</span>
-                      <span className="text-faint">{label}</span>
+                      <span className="text-faint">{t(labelKey)}</span>
                     </div>
                   ))}
                 </div>

--- a/apps/web/app/(workspace)/usage/page.tsx
+++ b/apps/web/app/(workspace)/usage/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { RefreshCw, Loader2 } from "lucide-react";
 import {
   Button,
@@ -100,6 +101,7 @@ interface MonitoringHourly {
 }
 
 function SystemTokenMonitor() {
+  const t = useTranslations("usage");
   const [costs, setCosts] = useState<MonitoringCosts | null>(null);
   const [daily, setDaily] = useState<MonitoringDaily | null>(null);
   const [hourly, setHourly] = useState<MonitoringHourly | null>(null);
@@ -140,26 +142,26 @@ function SystemTokenMonitor() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>시스템 토큰 모니터링</CardTitle>
+        <CardTitle>{t("systemMonitorTitle")}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
         {/* 비용 StatCard 4개 */}
         {costs && (
           <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
             <StatCard
-              label="오늘 비용"
+              label={t("stat.todayCost")}
               value={fmtCost(costs.today.totalCost)}
             />
             <StatCard
-              label="오늘 토큰"
+              label={t("stat.todayTokens")}
               value={fmtNum(costs.today.totalTokens)}
             />
             <StatCard
-              label="주간 토큰"
+              label={t("stat.weekTokens")}
               value={fmtNum(costs.weekly.totalTokens)}
             />
             <StatCard
-              label="주간 예상 비용"
+              label={t("stat.weekEstCost")}
               value={fmtCost(costs.weekly.estimatedCost)}
             />
           </div>
@@ -168,7 +170,7 @@ function SystemTokenMonitor() {
         {/* 일별 토큰 바 차트 */}
         {daily && daily.labels.length > 0 && (
           <div>
-            <p className="mb-3 text-xs font-medium text-fg-2">일별 토큰 (최근 7일)</p>
+            <p className="mb-3 text-xs font-medium text-fg-2">{t("dailyTokens7d")}</p>
             <div className="flex h-36 items-end gap-1.5">
               {daily.labels.map((label, i) => {
                 const tokens = daily.datasets.tokens[i] ?? 0;
@@ -177,7 +179,7 @@ function SystemTokenMonitor() {
                   <div
                     key={label}
                     className="group flex h-full flex-1 flex-col items-center justify-end gap-1"
-                    title={`${label} · ${fmtNum(tokens)} 토큰`}
+                    title={t("tokenTooltip", { date: label, count: fmtNum(tokens) })}
                   >
                     <span className="text-[10px] text-faint opacity-0 transition group-hover:opacity-100">
                       {fmtNum(tokens)}
@@ -199,7 +201,7 @@ function SystemTokenMonitor() {
         {/* 시간별 토큰 바 차트 */}
         {hourly && hourly.labels.length > 0 && (
           <div>
-            <p className="mb-3 text-xs font-medium text-fg-2">시간별 토큰</p>
+            <p className="mb-3 text-xs font-medium text-fg-2">{t("hourlyTokens")}</p>
             <div className="flex h-28 items-end gap-0.5">
               {hourly.labels.map((label, i) => {
                 const tokens = hourly.datasets.tokens[i] ?? 0;
@@ -208,7 +210,7 @@ function SystemTokenMonitor() {
                   <div
                     key={label}
                     className="group flex h-full flex-1 flex-col items-center justify-end gap-0.5"
-                    title={`${label} · ${fmtNum(tokens)} 토큰`}
+                    title={t("tokenTooltip", { date: label, count: fmtNum(tokens) })}
                   >
                     <div
                       className="w-full rounded-t bg-success-soft transition group-hover:bg-success"
@@ -248,6 +250,7 @@ function mockDaily(): DailyRow[] {
 }
 
 export default function UsagePage() {
+  const t = useTranslations("usage");
   const [summary, setSummary] = useState<UsageSummary | null>(null);
   const [daily, setDaily] = useState<DailyRow[]>([]);
   const [loading, setLoading] = useState(true);
@@ -306,16 +309,16 @@ export default function UsagePage() {
   return (
     <>
       <PageHeader
-        title="사용량"
-        description="내 계정 기준 토큰·요청 사용량입니다."
+        title={t("title")}
+        description={t("description")}
         actions={
           <div className="flex items-center gap-3">
             <span className="text-xs text-muted">
-              {usingMock ? "목업 데이터" : `갱신 ${updatedAt}`}
+              {usingMock ? t("mockData") : t("updatedAt", { time: updatedAt })}
             </span>
             <Button variant="outline" size="sm" onClick={() => void load()}>
               <RefreshCw className="h-4 w-4" />
-              새로고침
+              {t("refresh")}
             </Button>
           </div>
         }
@@ -326,25 +329,28 @@ export default function UsagePage() {
           {loading && !summary ? (
             <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted">
               <Loader2 className="h-4 w-4 animate-spin" />
-              불러오는 중...
+              {t("loading")}
             </div>
           ) : (
             <>
               {/* 상단 StatCard 4개 */}
               <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
                 <StatCard
-                  label="이번 달 토큰"
+                  label={t("stat.monthTokens")}
                   value={fmtNum(month?.totalTokens)}
                 />
-                <StatCard label="요청 수" value={fmtNum(month?.totalRequests)} />
                 <StatCard
-                  label="평균 지연"
+                  label={t("stat.requests")}
+                  value={fmtNum(month?.totalRequests)}
+                />
+                <StatCard
+                  label={t("stat.avgLatency")}
                   value={fmtMs(month?.avgResponseTime)}
                 />
                 <StatCard
-                  label="에러"
+                  label={t("stat.errors")}
                   value={fmtNum(month?.totalErrors)}
-                  delta={month?.totalErrors ? "주의" : "정상"}
+                  delta={month?.totalErrors ? t("delta.warning") : t("delta.normal")}
                   deltaTone={month?.totalErrors ? "danger" : "success"}
                 />
               </div>
@@ -352,12 +358,12 @@ export default function UsagePage() {
               {/* 일별 사용량 추이 (CSS 바 차트) */}
               <Card>
                 <CardHeader>
-                  <CardTitle>일별 토큰 사용량 (최근 14일)</CardTitle>
+                  <CardTitle>{t("dailyTitle")}</CardTitle>
                 </CardHeader>
                 <CardContent>
                   {daily.length === 0 ? (
                     <p className="py-8 text-center text-sm text-muted">
-                      데이터가 없습니다.
+                      {t("noData")}
                     </p>
                   ) : (
                     <div className="flex h-44 items-end gap-1.5">
@@ -371,7 +377,7 @@ export default function UsagePage() {
                           <div
                             key={d.date}
                             className="group flex h-full flex-1 flex-col items-center justify-end gap-1"
-                            title={`${d.date} · ${fmtNum(tokens)} 토큰`}
+                            title={t("tokenTooltip", { date: d.date, count: fmtNum(tokens) })}
                           >
                             <span className="text-[10px] text-faint opacity-0 transition group-hover:opacity-100">
                               {fmtNum(tokens)}
@@ -397,21 +403,21 @@ export default function UsagePage() {
               {/* 모델별 사용 비중 */}
               <Card>
                 <CardHeader>
-                  <CardTitle>모델별 사용 비중</CardTitle>
+                  <CardTitle>{t("modelUsageTitle")}</CardTitle>
                 </CardHeader>
                 <CardContent className="px-0 py-0">
                   {modelTotal === 0 ? (
                     <p className="py-8 text-center text-sm text-muted">
-                      모델별 사용 데이터가 없습니다.
+                      {t("noModelData")}
                     </p>
                   ) : (
                     <Table>
                       <thead>
                         <tr>
-                          <Th>모델</Th>
-                          <Th>토큰</Th>
-                          <Th>비중</Th>
-                          <Th className="w-1/3">분포</Th>
+                          <Th>{t("col.model")}</Th>
+                          <Th>{t("col.tokens")}</Th>
+                          <Th>{t("col.share")}</Th>
+                          <Th className="w-1/3">{t("col.distribution")}</Th>
                         </tr>
                       </thead>
                       <tbody>

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -838,5 +838,391 @@
       "agreementRequired": "You must agree to the Terms of Service and Privacy Policy.",
       "registerFailed": "Sign up failed."
     }
+  },
+  "admin": {
+    "title": "Admin Dashboard",
+    "description": "Manage users, models, and system status in one place.",
+    "adminOnly": "Admins only",
+    "addUser": "Add User",
+    "quickLinksHeading": "Quick Management",
+    "recentUsers": "Recently Joined Users",
+    "viewAll": "View All",
+    "guardianPending": "Minor Consent Pending",
+    "approve": "Approve",
+    "close": "Close",
+    "cancel": "Cancel",
+    "create": "Create",
+    "save": "Save",
+    "delete": "Delete",
+    "active": "Active",
+    "inactive": "Inactive",
+    "statusNormal": "Normal",
+    "editUser": "Edit User",
+    "deleteTitle": "Delete User",
+    "deleteConfirm": "Are you sure you want to delete?",
+    "nameLabel": "Name (optional)",
+    "namePlaceholder": "John Doe",
+    "emailRequired": "Email *",
+    "roleRequired": "Role *",
+    "passwordRequired": "Password *",
+    "roleField": "Role",
+    "statusField": "Status",
+    "newPasswordLabel": "New Password (optional)",
+    "newPasswordPlaceholder": "Leave blank to keep unchanged",
+    "createError": "Failed to create. Please try again.",
+    "updateError": "Failed to update. Please try again.",
+    "deleteError": "Failed to delete. Please try again.",
+    "roles": {
+      "admin": "Admin",
+      "user": "User",
+      "guest": "Guest"
+    },
+    "quickLinks": {
+      "users": {
+        "title": "User Management",
+        "desc": "Account creation, roles, and status"
+      },
+      "models": {
+        "title": "Model · MCP Settings",
+        "desc": "Model presets and tool catalog"
+      },
+      "system": {
+        "title": "System Status",
+        "desc": "Node and service health monitoring"
+      }
+    },
+    "stats": {
+      "totalUsers": "Total Users",
+      "totalUsersDelta": "+12 (last 7 days)",
+      "activeSessions": "Active Sessions",
+      "todayRequests": "Today's Requests",
+      "systemStatus": "System Status",
+      "allNodesNormal": "All nodes normal"
+    },
+    "col": {
+      "id": "ID",
+      "email": "Email",
+      "role": "Role",
+      "status": "Status",
+      "joinedAt": "Joined",
+      "lastLogin": "Last Login",
+      "actions": "Actions",
+      "edit": "Edit",
+      "delete": "Delete"
+    }
+  },
+  "adminAnalytics": {
+    "title": "Analytics",
+    "description": "Analyze trends in conversations, users, and token consumption.",
+    "dailyConversations": "Daily Conversations",
+    "recentDaysCaption": "Last {days} days · daily",
+    "modelUsageTitle": "Model Profile Usage",
+    "costAnalysis": "Cost Analysis",
+    "dailyCost": "Daily Cost",
+    "weeklyCost": "Weekly Cost",
+    "projectedMonthlyCost": "Projected Monthly Cost",
+    "userBehavior": "User Behavior",
+    "avgSessionLength": "Avg. Session Length",
+    "minutesSuffix": "{value} min",
+    "avgQueriesPerSession": "Avg. Queries per Session",
+    "peakHoursTop3": "Peak Hours Top 3",
+    "peakHourItem": "{hour}:00 · {requests} requests",
+    "topQueriesTop5": "Top 5 Queries",
+    "agentPerformance": "Agent Performance",
+    "period": {
+      "7d": "7 days",
+      "30d": "30 days",
+      "90d": "90 days"
+    },
+    "stats": {
+      "totalConversations": "Total Conversations",
+      "activeUsers": "Active Users",
+      "consumedTokens": "Tokens Consumed",
+      "avgResponse": "Avg. Response"
+    },
+    "col": {
+      "model": "Model",
+      "cost": "Cost",
+      "share": "Share",
+      "agent": "Agent",
+      "requests": "Requests",
+      "successRate": "Success Rate",
+      "avgResponse": "Avg. Response"
+    }
+  },
+  "adminAudit": {
+    "title": "Audit Log",
+    "description": "A record of security and administrative activity across the system.",
+    "countBadge": "{count} entries",
+    "exportCsv": "Export CSV",
+    "filter": {
+      "allActions": "All actions"
+    },
+    "severity": {
+      "all": "All severities"
+    },
+    "status": {
+      "critical": "Critical",
+      "warn": "Warning",
+      "info": "Info"
+    },
+    "period": {
+      "today": "Today",
+      "days7": "7 days",
+      "days30": "30 days",
+      "all": "All"
+    },
+    "th": {
+      "time": "Time",
+      "actor": "Actor",
+      "action": "Action",
+      "target": "Target",
+      "severity": "Severity"
+    },
+    "empty": "No logs match the filters."
+  },
+  "adminMetrics": {
+    "title": "System Metrics",
+    "lastUpdated": "Last updated {time}",
+    "subtitle": "Real-time monitoring of system status and resources",
+    "refresh": "Refresh",
+    "stat": {
+      "cpu": "CPU Usage",
+      "memory": "Memory",
+      "requestRate": "Request Rate",
+      "errorRate": "Error Rate"
+    },
+    "memoryDelta": "of {total} GB total",
+    "requestChartTitle": "Request Rate (last 24h · req/min)",
+    "barTooltip": "{hour}:00 · {value}/min",
+    "nodeStatusTitle": "Node · Service Status",
+    "nodeRoleLlm": "LLM Node",
+    "th": {
+      "node": "Node",
+      "role": "Role",
+      "status": "Status",
+      "latency": "Latency",
+      "load": "Load"
+    },
+    "status": {
+      "online": "Online",
+      "degraded": "Degraded",
+      "offline": "Offline"
+    },
+    "agentMetricsTitle": "Agent Metrics",
+    "agent": {
+      "totalAgents": "Total Agents",
+      "totalRequests": "Total Requests",
+      "avgSuccessRate": "Avg Success Rate",
+      "avgResponseTime": "Avg Response Time"
+    },
+    "agentTh": {
+      "id": "Agent ID",
+      "requests": "Requests",
+      "successRate": "Success Rate",
+      "avgResponseTime": "Avg Response Time"
+    }
+  },
+  "adminAlerts": {
+    "title": "Alerts",
+    "description": "Manage alert rules and review recent events.",
+    "addRule": "Add Rule",
+    "rulesTitle": "Alert Rules",
+    "toggleAria": "Toggle rule enabled",
+    "enabled": "Enabled",
+    "disabled": "Disabled",
+    "recentTitle": "Recent Alerts",
+    "acknowledged": "Acknowledged",
+    "acknowledge": "Acknowledge",
+    "status": {
+      "critical": "Critical",
+      "warning": "Warning",
+      "info": "Info"
+    },
+    "rules": {
+      "cpu": {
+        "name": "CPU Usage Threshold",
+        "condition": "CPU > 85% · sustained 5 min"
+      },
+      "contextOverflow": {
+        "name": "LLM Context Overflow",
+        "condition": "ContextOverflowError raised"
+      },
+      "errorRate": {
+        "name": "Error Rate Spike",
+        "condition": "5xx rate > 2%"
+      },
+      "tokenQuota": {
+        "name": "Token Quota Exhausted",
+        "condition": "Weekly quota over 90%"
+      },
+      "roleChange": {
+        "name": "Admin Role Change",
+        "condition": "user.role_change → admin"
+      }
+    },
+    "events": {
+      "e1": "Admin privilege grant detected — u_1040 (by devops@partner.co.kr)",
+      "e2": "redis-kv node load 78% — may affect rate-limit consistency",
+      "e3": "1 LLM context overflow — truncation applied to conv_88412",
+      "e4": "Daily backup complete — postgres-primary (2.1GB)",
+      "e5": "12 abnormal login attempts — 45.33.21.7 blocked"
+    }
+  },
+  "adminMcpCatalog": {
+    "close": "Close",
+    "editTitle": "Edit Template",
+    "createTitle": "New Template",
+    "saveError": "Save failed. Please try again.",
+    "displayNameLabel": "Display Name",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "A brief description of the server",
+    "typeLabel": "Type",
+    "commandLabel": "Command",
+    "enabledLabel": "Enabled",
+    "cancel": "Cancel",
+    "save": "Save",
+    "create": "Create",
+    "deleteTitle": "Delete Template",
+    "deleteConfirm": "Are you sure you want to delete this?",
+    "deleteError": "Delete failed. Please try again.",
+    "delete": "Delete",
+    "pageTitle": "MCP Catalog Management",
+    "pageDescription": "Manage MCP server templates offered to users.",
+    "addTemplate": "Add Template",
+    "colName": "Name",
+    "colDescription": "Description",
+    "colType": "Type",
+    "colEnabled": "Enabled",
+    "colActions": "Actions",
+    "loading": "Loading…",
+    "emptyState": "No templates registered.",
+    "enabled": "Enabled",
+    "disabled": "Disabled",
+    "editAction": "Edit",
+    "deleteAction": "Delete"
+  },
+  "apiKeys": {
+    "title": "API Keys",
+    "description": "Register and manage keys for external LLM providers (Anthropic / OpenAI-compatible).",
+    "addKey": "Add Key",
+    "close": "Close",
+    "cancel": "Cancel",
+    "save": "Save",
+    "registeredKeys": "Registered Provider Keys",
+    "mockDataShown": "Showing mock data",
+    "loading": "Loading key list...",
+    "emptyTitle": "No external keys registered",
+    "emptyDesc": "Add a key to use that provider's models.",
+    "loadError": "Failed to load the key list.",
+    "deleteConfirm": "Delete the {name} key?\nModel calls using this key will stop working.",
+    "deleteFailed": "Delete failed: {error}",
+    "saveFailed": "Save failed: {error}",
+    "serverError": "Server error",
+    "deleteAria": "Delete",
+    "validationError": "Enter a name and an API key of at least 8 characters.",
+    "namePlaceholder": "e.g. Production, Development",
+    "apiKeyLabel": "API Key",
+    "baseUrlLabel": "Base URL (optional)",
+    "col": {
+      "provider": "Provider",
+      "name": "Name",
+      "key": "Key",
+      "createdAt": "Created",
+      "status": "Status",
+      "actions": "Actions"
+    },
+    "status": {
+      "validationFailed": "Validation failed",
+      "active": "Active",
+      "unverified": "Unverified"
+    },
+    "sdkType": {
+      "anthropic": "Anthropic",
+      "openaiCompatible": "OpenAI-compatible"
+    },
+    "mock": {
+      "productionName": "Production"
+    }
+  },
+  "usage": {
+    "title": "Usage",
+    "description": "Token and request usage for your account.",
+    "mockData": "Mock data",
+    "updatedAt": "Updated {time}",
+    "refresh": "Refresh",
+    "loading": "Loading...",
+    "noData": "No data available.",
+    "dailyTitle": "Daily Token Usage (Last 14 Days)",
+    "tokenTooltip": "{date} · {count} tokens",
+    "systemMonitorTitle": "System Token Monitoring",
+    "dailyTokens7d": "Daily Tokens (Last 7 Days)",
+    "hourlyTokens": "Hourly Tokens",
+    "modelUsageTitle": "Usage by Model",
+    "noModelData": "No per-model usage data available.",
+    "stat": {
+      "monthTokens": "Tokens This Month",
+      "requests": "Requests",
+      "avgLatency": "Avg Latency",
+      "errors": "Errors",
+      "todayCost": "Today's Cost",
+      "todayTokens": "Today's Tokens",
+      "weekTokens": "Weekly Tokens",
+      "weekEstCost": "Weekly Est. Cost"
+    },
+    "delta": {
+      "warning": "Warning",
+      "normal": "Normal"
+    },
+    "col": {
+      "model": "Model",
+      "tokens": "Tokens",
+      "share": "Share",
+      "distribution": "Distribution"
+    }
+  },
+  "developer": {
+    "pageTitle": "Developer Docs",
+    "pageDescription": "Integrate and automate with the OpenMake LLM API.",
+    "apiInfo": {
+      "title": "API Basics",
+      "apiVersionLabel": "API Version",
+      "versionBlock": "/v1  — OpenAI-compatible endpoints\n/api — OpenMake-specific endpoints",
+      "description": "The OpenMake LLM API is compatible with the OpenAI Chat Completions API. You can use your existing OpenAI SDK right away by changing only the <code>baseURL</code>."
+    },
+    "auth": {
+      "title": "Authentication",
+      "apiKeyTitle": "API Key Authentication",
+      "apiKeyDesc": "Pass a key issued on the Settings > API Keys page in the <code>Authorization</code> header.",
+      "jwtTitle": "JWT Session Authentication",
+      "jwtDesc": "Browser sessions automatically use a JWT stored in an HttpOnly cookie. For direct API calls, an API key is recommended."
+    },
+    "models": {
+      "title": "Model List",
+      "description": "Retrieve the list of available models with <code>GET /api/models</code>, or check the model selector on the chat page.",
+      "brandIdLabel": "Brand Model IDs"
+    },
+    "brandModels": {
+      "default": "Default model",
+      "pro": "High-performance model",
+      "fast": "Fast response",
+      "think": "Reasoning mode",
+      "code": "Code-specialized",
+      "vision": "Image support"
+    },
+    "steps": {
+      "apiKey": {
+        "title": "Issue an API Key",
+        "description": "Create a new API key on the Settings > API Keys page."
+      },
+      "chatCompletion": {
+        "title": "Chat Completion Request",
+        "description": "Send a request to the OpenAI-compatible /v1/chat/completions endpoint."
+      },
+      "streaming": {
+        "title": "Streaming Responses",
+        "description": "Add stream: true to receive tokens in real time as an SSE stream."
+      }
+    }
   }
 }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -838,5 +838,391 @@
       "agreementRequired": "利用規約およびプライバシーポリシーに同意する必要があります。",
       "registerFailed": "新規登録に失敗しました。"
     }
+  },
+  "admin": {
+    "title": "管理者ダッシュボード",
+    "description": "ユーザー、モデル、システム状態を一元管理します。",
+    "adminOnly": "管理者専用",
+    "addUser": "ユーザー追加",
+    "quickLinksHeading": "クイック管理",
+    "recentUsers": "最近登録したユーザー",
+    "viewAll": "すべて表示",
+    "guardianPending": "未成年者同意の保留",
+    "approve": "承認",
+    "close": "閉じる",
+    "cancel": "キャンセル",
+    "create": "作成",
+    "save": "保存",
+    "delete": "削除",
+    "active": "有効",
+    "inactive": "無効",
+    "statusNormal": "正常",
+    "editUser": "ユーザー編集",
+    "deleteTitle": "ユーザー削除",
+    "deleteConfirm": "本当に削除しますか？",
+    "nameLabel": "名前（任意）",
+    "namePlaceholder": "山田太郎",
+    "emailRequired": "メール *",
+    "roleRequired": "ロール *",
+    "passwordRequired": "パスワード *",
+    "roleField": "ロール",
+    "statusField": "ステータス",
+    "newPasswordLabel": "新しいパスワード（任意）",
+    "newPasswordPlaceholder": "変更しない場合は空欄のままにしてください",
+    "createError": "作成に失敗しました。もう一度お試しください。",
+    "updateError": "更新に失敗しました。もう一度お試しください。",
+    "deleteError": "削除に失敗しました。もう一度お試しください。",
+    "roles": {
+      "admin": "管理者",
+      "user": "ユーザー",
+      "guest": "ゲスト"
+    },
+    "quickLinks": {
+      "users": {
+        "title": "ユーザー管理",
+        "desc": "アカウント作成・権限・ステータス管理"
+      },
+      "models": {
+        "title": "モデル・MCP 設定",
+        "desc": "モデルプリセットとツールカタログ"
+      },
+      "system": {
+        "title": "システム状態",
+        "desc": "ノード・サービスのヘルス監視"
+      }
+    },
+    "stats": {
+      "totalUsers": "総ユーザー数",
+      "totalUsersDelta": "+12（過去7日間）",
+      "activeSessions": "アクティブセッション",
+      "todayRequests": "本日のリクエスト",
+      "systemStatus": "システム状態",
+      "allNodesNormal": "すべてのノードが正常"
+    },
+    "col": {
+      "id": "ID",
+      "email": "メール",
+      "role": "ロール",
+      "status": "ステータス",
+      "joinedAt": "登録日",
+      "lastLogin": "最終ログイン",
+      "actions": "操作",
+      "edit": "編集",
+      "delete": "削除"
+    }
+  },
+  "adminAnalytics": {
+    "title": "アナリティクス",
+    "description": "会話量、ユーザー、トークン消費の傾向を分析します。",
+    "dailyConversations": "日別会話量",
+    "recentDaysCaption": "直近 {days} 日 · 日別",
+    "modelUsageTitle": "モデルプロファイル利用比率",
+    "costAnalysis": "コスト分析",
+    "dailyCost": "日次コスト",
+    "weeklyCost": "週次コスト",
+    "projectedMonthlyCost": "月間予想コスト",
+    "userBehavior": "ユーザー行動",
+    "avgSessionLength": "平均セッション時間",
+    "minutesSuffix": "{value}分",
+    "avgQueriesPerSession": "セッションあたり平均クエリ",
+    "peakHoursTop3": "ピーク時間帯 Top 3",
+    "peakHourItem": "{hour}時 · {requests} 件",
+    "topQueriesTop5": "よく聞かれるクエリ Top 5",
+    "agentPerformance": "エージェント性能",
+    "period": {
+      "7d": "7日",
+      "30d": "30日",
+      "90d": "90日"
+    },
+    "stats": {
+      "totalConversations": "総会話数",
+      "activeUsers": "アクティブユーザー",
+      "consumedTokens": "消費トークン",
+      "avgResponse": "平均応答"
+    },
+    "col": {
+      "model": "モデル",
+      "cost": "コスト",
+      "share": "比率",
+      "agent": "エージェント",
+      "requests": "リクエスト数",
+      "successRate": "成功率",
+      "avgResponse": "平均応答"
+    }
+  },
+  "adminAudit": {
+    "title": "監査ログ",
+    "description": "システム全体のセキュリティ・管理操作の記録です。",
+    "countBadge": "{count}件",
+    "exportCsv": "CSVエクスポート",
+    "filter": {
+      "allActions": "すべてのアクション"
+    },
+    "severity": {
+      "all": "すべての重大度"
+    },
+    "status": {
+      "critical": "重大",
+      "warn": "警告",
+      "info": "情報"
+    },
+    "period": {
+      "today": "今日",
+      "days7": "7日",
+      "days30": "30日",
+      "all": "すべて"
+    },
+    "th": {
+      "time": "時刻",
+      "actor": "実行者",
+      "action": "アクション",
+      "target": "対象",
+      "severity": "重大度"
+    },
+    "empty": "条件に一致するログはありません。"
+  },
+  "adminMetrics": {
+    "title": "システムメトリクス",
+    "lastUpdated": "最終更新 {time}",
+    "subtitle": "システム状態とリソースのリアルタイム監視",
+    "refresh": "更新",
+    "stat": {
+      "cpu": "CPU使用率",
+      "memory": "メモリ",
+      "requestRate": "リクエスト率",
+      "errorRate": "エラー率"
+    },
+    "memoryDelta": "全{total} GB中",
+    "requestChartTitle": "リクエスト率（過去24時間 · req/min）",
+    "barTooltip": "{hour}時: {value}/min",
+    "nodeStatusTitle": "ノード · サービス状態",
+    "nodeRoleLlm": "LLMノード",
+    "th": {
+      "node": "ノード",
+      "role": "役割",
+      "status": "状態",
+      "latency": "遅延",
+      "load": "負荷"
+    },
+    "status": {
+      "online": "正常",
+      "degraded": "低下",
+      "offline": "停止"
+    },
+    "agentMetricsTitle": "エージェントメトリクス",
+    "agent": {
+      "totalAgents": "総エージェント数",
+      "totalRequests": "総リクエスト数",
+      "avgSuccessRate": "平均成功率",
+      "avgResponseTime": "平均応答時間"
+    },
+    "agentTh": {
+      "id": "エージェントID",
+      "requests": "リクエスト数",
+      "successRate": "成功率",
+      "avgResponseTime": "平均応答時間"
+    }
+  },
+  "adminAlerts": {
+    "title": "アラート",
+    "description": "アラートルールを管理し、最近発生したイベントを確認します。",
+    "addRule": "ルールを追加",
+    "rulesTitle": "アラートルール",
+    "toggleAria": "ルールの有効切り替え",
+    "enabled": "有効",
+    "disabled": "無効",
+    "recentTitle": "最近のアラート",
+    "acknowledged": "確認済み",
+    "acknowledge": "確認",
+    "status": {
+      "critical": "重大",
+      "warning": "警告",
+      "info": "情報"
+    },
+    "rules": {
+      "cpu": {
+        "name": "CPU使用率のしきい値",
+        "condition": "CPU > 85% · 5分間継続"
+      },
+      "contextOverflow": {
+        "name": "LLMコンテキストオーバーフロー",
+        "condition": "ContextOverflowError発生"
+      },
+      "errorRate": {
+        "name": "エラー率の急増",
+        "condition": "5xx率 > 2%"
+      },
+      "tokenQuota": {
+        "name": "トークンクォータの枯渇",
+        "condition": "週間クォータ90%超過"
+      },
+      "roleChange": {
+        "name": "管理者権限の変更",
+        "condition": "user.role_change → admin"
+      }
+    },
+    "events": {
+      "e1": "管理者権限の付与を検知 — u_1040（devops@partner.co.kr が実行）",
+      "e2": "redis-kvノード負荷78% — rate-limit整合性に影響の可能性",
+      "e3": "LLMコンテキストオーバーフロー1件 — conv_88412にtruncate適用",
+      "e4": "日次バックアップ完了 — postgres-primary（2.1GB）",
+      "e5": "異常なログイン試行12回 — 45.33.21.7をブロック"
+    }
+  },
+  "adminMcpCatalog": {
+    "close": "閉じる",
+    "editTitle": "テンプレートを編集",
+    "createTitle": "新規テンプレート",
+    "saveError": "保存に失敗しました。もう一度お試しください。",
+    "displayNameLabel": "表示名",
+    "descriptionLabel": "説明",
+    "descriptionPlaceholder": "サーバーの簡単な説明",
+    "typeLabel": "種類",
+    "commandLabel": "コマンド",
+    "enabledLabel": "有効化",
+    "cancel": "キャンセル",
+    "save": "保存",
+    "create": "作成",
+    "deleteTitle": "テンプレートを削除",
+    "deleteConfirm": "本当に削除しますか？",
+    "deleteError": "削除に失敗しました。もう一度お試しください。",
+    "delete": "削除",
+    "pageTitle": "MCPカタログ管理",
+    "pageDescription": "ユーザーに提供するMCPサーバーテンプレートを管理します。",
+    "addTemplate": "テンプレートを追加",
+    "colName": "名前",
+    "colDescription": "説明",
+    "colType": "種類",
+    "colEnabled": "有効状態",
+    "colActions": "操作",
+    "loading": "読み込み中…",
+    "emptyState": "登録されたテンプレートはありません。",
+    "enabled": "有効",
+    "disabled": "無効",
+    "editAction": "編集",
+    "deleteAction": "削除"
+  },
+  "apiKeys": {
+    "title": "APIキー",
+    "description": "外部LLMプロバイダー(Anthropic / OpenAI互換)のキーを登録・管理します。",
+    "addKey": "新しいキーを追加",
+    "close": "閉じる",
+    "cancel": "キャンセル",
+    "save": "保存",
+    "registeredKeys": "登録済みプロバイダーキー",
+    "mockDataShown": "モックデータを表示中",
+    "loading": "キー一覧を読み込み中...",
+    "emptyTitle": "登録された外部キーがありません",
+    "emptyDesc": "キーを追加すると、そのプロバイダーのモデルを利用できます。",
+    "loadError": "キー一覧を読み込めませんでした。",
+    "deleteConfirm": "{name} キーを削除しますか?\nこのキーを使用するモデル呼び出しが停止します。",
+    "deleteFailed": "削除に失敗しました: {error}",
+    "saveFailed": "保存に失敗しました: {error}",
+    "serverError": "サーバーエラー",
+    "deleteAria": "削除",
+    "validationError": "名前と8文字以上のAPIキーを入力してください。",
+    "namePlaceholder": "例: 本番、開発用",
+    "apiKeyLabel": "APIキー",
+    "baseUrlLabel": "Base URL(任意)",
+    "col": {
+      "provider": "プロバイダー",
+      "name": "名前",
+      "key": "キー",
+      "createdAt": "作成日",
+      "status": "ステータス",
+      "actions": "操作"
+    },
+    "status": {
+      "validationFailed": "検証失敗",
+      "active": "有効",
+      "unverified": "未検証"
+    },
+    "sdkType": {
+      "anthropic": "Anthropic",
+      "openaiCompatible": "OpenAI互換"
+    },
+    "mock": {
+      "productionName": "本番"
+    }
+  },
+  "usage": {
+    "title": "使用量",
+    "description": "アカウント単位のトークン・リクエスト使用量です。",
+    "mockData": "モックデータ",
+    "updatedAt": "更新 {time}",
+    "refresh": "更新",
+    "loading": "読み込み中...",
+    "noData": "データがありません。",
+    "dailyTitle": "日別トークン使用量(直近14日)",
+    "tokenTooltip": "{date} · {count} トークン",
+    "systemMonitorTitle": "システムトークン監視",
+    "dailyTokens7d": "日別トークン(直近7日)",
+    "hourlyTokens": "時間別トークン",
+    "modelUsageTitle": "モデル別使用割合",
+    "noModelData": "モデル別の使用データがありません。",
+    "stat": {
+      "monthTokens": "今月のトークン",
+      "requests": "リクエスト数",
+      "avgLatency": "平均レイテンシ",
+      "errors": "エラー",
+      "todayCost": "本日のコスト",
+      "todayTokens": "本日のトークン",
+      "weekTokens": "週間トークン",
+      "weekEstCost": "週間予想コスト"
+    },
+    "delta": {
+      "warning": "注意",
+      "normal": "正常"
+    },
+    "col": {
+      "model": "モデル",
+      "tokens": "トークン",
+      "share": "割合",
+      "distribution": "分布"
+    }
+  },
+  "developer": {
+    "pageTitle": "開発者ドキュメント",
+    "pageDescription": "OpenMake LLM API を統合し、自動化します。",
+    "apiInfo": {
+      "title": "API 基本情報",
+      "apiVersionLabel": "API バージョン",
+      "versionBlock": "/v1  — OpenAI 互換エンドポイント\n/api — OpenMake 専用エンドポイント",
+      "description": "OpenMake LLM API は OpenAI Chat Completions API と互換性があります。既存の OpenAI SDK は <code>baseURL</code> を変更するだけですぐに利用できます。"
+    },
+    "auth": {
+      "title": "認証方式",
+      "apiKeyTitle": "API キー認証",
+      "apiKeyDesc": "設定 > API キーページで発行したキーを <code>Authorization</code> ヘッダーに渡します。",
+      "jwtTitle": "JWT セッション認証",
+      "jwtDesc": "ブラウザーセッションは HttpOnly クッキーに保存された JWT を自動的に使用します。API を直接呼び出す場合は API キーを推奨します。"
+    },
+    "models": {
+      "title": "モデル一覧",
+      "description": "利用可能なモデル一覧は <code>GET /api/models</code> で取得するか、チャットページのモデルセレクターを参照してください。",
+      "brandIdLabel": "ブランドモデル ID"
+    },
+    "brandModels": {
+      "default": "デフォルトモデル",
+      "pro": "高性能モデル",
+      "fast": "高速応答",
+      "think": "推論モード",
+      "code": "コード特化",
+      "vision": "画像対応"
+    },
+    "steps": {
+      "apiKey": {
+        "title": "API キーの発行",
+        "description": "設定 > API キーページで新しい API キーを作成します。"
+      },
+      "chatCompletion": {
+        "title": "チャット補完リクエスト",
+        "description": "OpenAI 互換の /v1/chat/completions エンドポイントにリクエストを送信します。"
+      },
+      "streaming": {
+        "title": "ストリーミング応答",
+        "description": "stream: true を追加すると、SSE ストリームでトークンをリアルタイムに受信します。"
+      }
+    }
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -838,5 +838,391 @@
       "agreementRequired": "서비스 이용약관 및 개인정보 처리방침에 동의해야 합니다.",
       "registerFailed": "회원가입에 실패했습니다."
     }
+  },
+  "admin": {
+    "title": "관리자 대시보드",
+    "description": "사용자, 모델, 시스템 상태를 한 곳에서 관리합니다.",
+    "adminOnly": "관리자 전용",
+    "addUser": "사용자 추가",
+    "quickLinksHeading": "빠른 관리",
+    "recentUsers": "최근 가입 사용자",
+    "viewAll": "전체 보기",
+    "guardianPending": "미성년자 동의 보류",
+    "approve": "승인",
+    "close": "닫기",
+    "cancel": "취소",
+    "create": "생성",
+    "save": "저장",
+    "delete": "삭제",
+    "active": "활성",
+    "inactive": "비활성",
+    "statusNormal": "정상",
+    "editUser": "사용자 편집",
+    "deleteTitle": "사용자 삭제",
+    "deleteConfirm": "정말 삭제하시겠습니까?",
+    "nameLabel": "이름 (선택)",
+    "namePlaceholder": "홍길동",
+    "emailRequired": "이메일 *",
+    "roleRequired": "역할 *",
+    "passwordRequired": "비밀번호 *",
+    "roleField": "역할",
+    "statusField": "상태",
+    "newPasswordLabel": "새 비밀번호 (선택)",
+    "newPasswordPlaceholder": "변경하지 않으려면 비워두세요",
+    "createError": "생성 실패. 다시 시도해 주세요.",
+    "updateError": "수정 실패. 다시 시도해 주세요.",
+    "deleteError": "삭제 실패. 다시 시도해 주세요.",
+    "roles": {
+      "admin": "관리자",
+      "user": "사용자",
+      "guest": "게스트"
+    },
+    "quickLinks": {
+      "users": {
+        "title": "사용자 관리",
+        "desc": "계정 생성·권한·상태 관리"
+      },
+      "models": {
+        "title": "모델 · MCP 설정",
+        "desc": "모델 프리셋과 도구 카탈로그"
+      },
+      "system": {
+        "title": "시스템 상태",
+        "desc": "노드·서비스 헬스 모니터링"
+      }
+    },
+    "stats": {
+      "totalUsers": "총 사용자",
+      "totalUsersDelta": "+12 (지난 7일)",
+      "activeSessions": "활성 세션",
+      "todayRequests": "오늘 요청",
+      "systemStatus": "시스템 상태",
+      "allNodesNormal": "모든 노드 정상"
+    },
+    "col": {
+      "id": "ID",
+      "email": "이메일",
+      "role": "역할",
+      "status": "상태",
+      "joinedAt": "가입일",
+      "lastLogin": "마지막 로그인",
+      "actions": "액션",
+      "edit": "편집",
+      "delete": "삭제"
+    }
+  },
+  "adminAnalytics": {
+    "title": "애널리틱스",
+    "description": "대화량, 사용자, 토큰 소비 추세를 분석합니다.",
+    "dailyConversations": "일별 대화량",
+    "recentDaysCaption": "최근 {days}일 · 일자별",
+    "modelUsageTitle": "모델 프로파일 사용 비중",
+    "costAnalysis": "비용 분석",
+    "dailyCost": "일일 비용",
+    "weeklyCost": "주간 비용",
+    "projectedMonthlyCost": "월간 예상 비용",
+    "userBehavior": "사용자 행동",
+    "avgSessionLength": "평균 세션 길이",
+    "minutesSuffix": "{value}분",
+    "avgQueriesPerSession": "세션당 평균 쿼리",
+    "peakHoursTop3": "피크 시간대 Top 3",
+    "peakHourItem": "{hour}시 · {requests} 요청",
+    "topQueriesTop5": "자주 묻는 쿼리 Top 5",
+    "agentPerformance": "에이전트 성능",
+    "period": {
+      "7d": "7일",
+      "30d": "30일",
+      "90d": "90일"
+    },
+    "stats": {
+      "totalConversations": "총 대화",
+      "activeUsers": "활성 사용자",
+      "consumedTokens": "소비 토큰",
+      "avgResponse": "평균 응답"
+    },
+    "col": {
+      "model": "모델",
+      "cost": "비용",
+      "share": "비중",
+      "agent": "에이전트",
+      "requests": "요청 수",
+      "successRate": "성공률",
+      "avgResponse": "평균 응답"
+    }
+  },
+  "adminAudit": {
+    "title": "감사 로그",
+    "description": "시스템 전반의 보안·관리 활동 기록입니다.",
+    "countBadge": "{count}건",
+    "exportCsv": "CSV 내보내기",
+    "filter": {
+      "allActions": "전체 액션"
+    },
+    "severity": {
+      "all": "전체 심각도"
+    },
+    "status": {
+      "critical": "심각",
+      "warn": "경고",
+      "info": "정보"
+    },
+    "period": {
+      "today": "오늘",
+      "days7": "7일",
+      "days30": "30일",
+      "all": "전체"
+    },
+    "th": {
+      "time": "시각",
+      "actor": "액터",
+      "action": "액션",
+      "target": "대상",
+      "severity": "심각도"
+    },
+    "empty": "조건에 맞는 로그가 없습니다."
+  },
+  "adminMetrics": {
+    "title": "시스템 메트릭",
+    "lastUpdated": "마지막 갱신 {time}",
+    "subtitle": "시스템 상태 및 리소스 실시간 모니터링",
+    "refresh": "새로고침",
+    "stat": {
+      "cpu": "CPU 사용률",
+      "memory": "메모리",
+      "requestRate": "요청률",
+      "errorRate": "에러율"
+    },
+    "memoryDelta": "총 {total} GB 중",
+    "requestChartTitle": "요청률 (최근 24시간 · req/min)",
+    "barTooltip": "{hour}시: {value}/min",
+    "nodeStatusTitle": "노드 · 서비스 상태",
+    "nodeRoleLlm": "LLM 노드",
+    "th": {
+      "node": "노드",
+      "role": "역할",
+      "status": "상태",
+      "latency": "지연",
+      "load": "부하"
+    },
+    "status": {
+      "online": "정상",
+      "degraded": "저하",
+      "offline": "중단"
+    },
+    "agentMetricsTitle": "에이전트 메트릭",
+    "agent": {
+      "totalAgents": "총 에이전트",
+      "totalRequests": "총 요청",
+      "avgSuccessRate": "평균 성공률",
+      "avgResponseTime": "평균 응답시간"
+    },
+    "agentTh": {
+      "id": "에이전트 ID",
+      "requests": "요청 수",
+      "successRate": "성공률",
+      "avgResponseTime": "평균 응답시간"
+    }
+  },
+  "adminAlerts": {
+    "title": "알림",
+    "description": "알림 규칙을 관리하고 최근 발생 이벤트를 확인합니다.",
+    "addRule": "규칙 추가",
+    "rulesTitle": "알림 규칙",
+    "toggleAria": "규칙 활성 토글",
+    "enabled": "활성",
+    "disabled": "비활성",
+    "recentTitle": "최근 발생 알림",
+    "acknowledged": "확인됨",
+    "acknowledge": "확인",
+    "status": {
+      "critical": "심각",
+      "warning": "경고",
+      "info": "정보"
+    },
+    "rules": {
+      "cpu": {
+        "name": "CPU 사용률 임계",
+        "condition": "CPU > 85% · 5분 지속"
+      },
+      "contextOverflow": {
+        "name": "LLM 컨텍스트 오버플로",
+        "condition": "ContextOverflowError 발생"
+      },
+      "errorRate": {
+        "name": "에러율 급증",
+        "condition": "5xx 비율 > 2%"
+      },
+      "tokenQuota": {
+        "name": "토큰 쿼터 소진",
+        "condition": "주간 쿼터 90% 초과"
+      },
+      "roleChange": {
+        "name": "관리자 권한 변경",
+        "condition": "user.role_change → admin"
+      }
+    },
+    "events": {
+      "e1": "관리자 권한 부여 감지 — u_1040 (devops@partner.co.kr 수행)",
+      "e2": "redis-kv 노드 부하 78% — rate-limit 정합 영향 가능",
+      "e3": "LLM 컨텍스트 오버플로 1건 — conv_88412 truncate 적용",
+      "e4": "일일 백업 완료 — postgres-primary (2.1GB)",
+      "e5": "비정상 로그인 시도 12회 — 45.33.21.7 차단됨"
+    }
+  },
+  "adminMcpCatalog": {
+    "close": "닫기",
+    "editTitle": "템플릿 편집",
+    "createTitle": "새 템플릿",
+    "saveError": "저장 실패. 다시 시도해 주세요.",
+    "displayNameLabel": "표시 이름",
+    "descriptionLabel": "설명",
+    "descriptionPlaceholder": "서버에 대한 간략한 설명",
+    "typeLabel": "유형",
+    "commandLabel": "명령어",
+    "enabledLabel": "활성화",
+    "cancel": "취소",
+    "save": "저장",
+    "create": "생성",
+    "deleteTitle": "템플릿 삭제",
+    "deleteConfirm": "정말 삭제하시겠습니까?",
+    "deleteError": "삭제 실패. 다시 시도해 주세요.",
+    "delete": "삭제",
+    "pageTitle": "MCP 카탈로그 관리",
+    "pageDescription": "사용자에게 제공되는 MCP 서버 템플릿을 관리합니다.",
+    "addTemplate": "템플릿 추가",
+    "colName": "이름",
+    "colDescription": "설명",
+    "colType": "유형",
+    "colEnabled": "활성여부",
+    "colActions": "액션",
+    "loading": "로딩 중…",
+    "emptyState": "등록된 템플릿이 없습니다.",
+    "enabled": "활성",
+    "disabled": "비활성",
+    "editAction": "편집",
+    "deleteAction": "삭제"
+  },
+  "apiKeys": {
+    "title": "API 키",
+    "description": "외부 LLM 공급자(Anthropic / OpenAI 호환) 키를 등록하고 관리합니다.",
+    "addKey": "새 키 추가",
+    "close": "닫기",
+    "cancel": "취소",
+    "save": "저장",
+    "registeredKeys": "등록된 공급자 키",
+    "mockDataShown": "목업 데이터 표시 중",
+    "loading": "키 목록을 불러오는 중...",
+    "emptyTitle": "등록된 외부 키가 없습니다",
+    "emptyDesc": "새 키를 추가하면 해당 공급자 모델을 사용할 수 있습니다.",
+    "loadError": "키 목록을 불러오지 못했습니다.",
+    "deleteConfirm": "{name} 키를 삭제하시겠습니까?\n이 키를 사용하는 모델 호출이 중단됩니다.",
+    "deleteFailed": "삭제 실패: {error}",
+    "saveFailed": "저장 실패: {error}",
+    "serverError": "서버 오류",
+    "deleteAria": "삭제",
+    "validationError": "이름과 8자 이상의 API 키를 입력하세요.",
+    "namePlaceholder": "예: 프로덕션, 개발용",
+    "apiKeyLabel": "API 키",
+    "baseUrlLabel": "Base URL (선택)",
+    "col": {
+      "provider": "공급자",
+      "name": "이름",
+      "key": "키",
+      "createdAt": "생성일",
+      "status": "상태",
+      "actions": "작업"
+    },
+    "status": {
+      "validationFailed": "검증 실패",
+      "active": "활성",
+      "unverified": "미검증"
+    },
+    "sdkType": {
+      "anthropic": "Anthropic",
+      "openaiCompatible": "OpenAI 호환"
+    },
+    "mock": {
+      "productionName": "프로덕션"
+    }
+  },
+  "usage": {
+    "title": "사용량",
+    "description": "내 계정 기준 토큰·요청 사용량입니다.",
+    "mockData": "목업 데이터",
+    "updatedAt": "갱신 {time}",
+    "refresh": "새로고침",
+    "loading": "불러오는 중...",
+    "noData": "데이터가 없습니다.",
+    "dailyTitle": "일별 토큰 사용량 (최근 14일)",
+    "tokenTooltip": "{date} · {count} 토큰",
+    "systemMonitorTitle": "시스템 토큰 모니터링",
+    "dailyTokens7d": "일별 토큰 (최근 7일)",
+    "hourlyTokens": "시간별 토큰",
+    "modelUsageTitle": "모델별 사용 비중",
+    "noModelData": "모델별 사용 데이터가 없습니다.",
+    "stat": {
+      "monthTokens": "이번 달 토큰",
+      "requests": "요청 수",
+      "avgLatency": "평균 지연",
+      "errors": "에러",
+      "todayCost": "오늘 비용",
+      "todayTokens": "오늘 토큰",
+      "weekTokens": "주간 토큰",
+      "weekEstCost": "주간 예상 비용"
+    },
+    "delta": {
+      "warning": "주의",
+      "normal": "정상"
+    },
+    "col": {
+      "model": "모델",
+      "tokens": "토큰",
+      "share": "비중",
+      "distribution": "분포"
+    }
+  },
+  "developer": {
+    "pageTitle": "개발자 문서",
+    "pageDescription": "OpenMake LLM API를 통합하고 자동화합니다.",
+    "apiInfo": {
+      "title": "API 기본 정보",
+      "apiVersionLabel": "API 버전",
+      "versionBlock": "/v1  — OpenAI 호환 엔드포인트\n/api — OpenMake 전용 엔드포인트",
+      "description": "OpenMake LLM API는 OpenAI Chat Completions API와 호환됩니다. 기존 OpenAI SDK를 <code>baseURL</code>만 변경하여 바로 사용할 수 있습니다."
+    },
+    "auth": {
+      "title": "인증 방식",
+      "apiKeyTitle": "API Key 인증",
+      "apiKeyDesc": "설정 > API 키 페이지에서 발급한 키를 <code>Authorization</code> 헤더에 전달합니다.",
+      "jwtTitle": "JWT 세션 인증",
+      "jwtDesc": "브라우저 세션은 HttpOnly 쿠키에 저장된 JWT를 자동으로 사용합니다. API 직접 호출 시에는 API Key를 권장합니다."
+    },
+    "models": {
+      "title": "모델 목록",
+      "description": "사용 가능한 모델 목록은 <code>GET /api/models</code>로 조회하거나, 채팅 페이지의 모델 선택기를 참고하세요.",
+      "brandIdLabel": "브랜드 모델 ID"
+    },
+    "brandModels": {
+      "default": "기본 모델",
+      "pro": "고성능 모델",
+      "fast": "빠른 응답",
+      "think": "추론 모드",
+      "code": "코드 특화",
+      "vision": "이미지 지원"
+    },
+    "steps": {
+      "apiKey": {
+        "title": "API 키 발급",
+        "description": "설정 > API 키 페이지에서 새 API 키를 생성합니다."
+      },
+      "chatCompletion": {
+        "title": "채팅 완성 요청",
+        "description": "OpenAI 호환 /v1/chat/completions 엔드포인트에 요청을 보냅니다."
+      },
+      "streaming": {
+        "title": "스트리밍 응답",
+        "description": "stream: true 를 추가하면 SSE 스트림으로 토큰을 실시간 수신합니다."
+      }
+    }
   }
 }

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -838,5 +838,391 @@
       "agreementRequired": "您必须同意服务条款和隐私政策。",
       "registerFailed": "注册失败。"
     }
+  },
+  "admin": {
+    "title": "管理员仪表盘",
+    "description": "在一处管理用户、模型和系统状态。",
+    "adminOnly": "仅限管理员",
+    "addUser": "添加用户",
+    "quickLinksHeading": "快速管理",
+    "recentUsers": "最近注册的用户",
+    "viewAll": "查看全部",
+    "guardianPending": "未成年人同意待审",
+    "approve": "批准",
+    "close": "关闭",
+    "cancel": "取消",
+    "create": "创建",
+    "save": "保存",
+    "delete": "删除",
+    "active": "启用",
+    "inactive": "停用",
+    "statusNormal": "正常",
+    "editUser": "编辑用户",
+    "deleteTitle": "删除用户",
+    "deleteConfirm": "确定要删除吗？",
+    "nameLabel": "姓名（可选）",
+    "namePlaceholder": "张三",
+    "emailRequired": "邮箱 *",
+    "roleRequired": "角色 *",
+    "passwordRequired": "密码 *",
+    "roleField": "角色",
+    "statusField": "状态",
+    "newPasswordLabel": "新密码（可选）",
+    "newPasswordPlaceholder": "如不更改请留空",
+    "createError": "创建失败。请重试。",
+    "updateError": "更新失败。请重试。",
+    "deleteError": "删除失败。请重试。",
+    "roles": {
+      "admin": "管理员",
+      "user": "用户",
+      "guest": "访客"
+    },
+    "quickLinks": {
+      "users": {
+        "title": "用户管理",
+        "desc": "账户创建、权限与状态管理"
+      },
+      "models": {
+        "title": "模型 · MCP 设置",
+        "desc": "模型预设与工具目录"
+      },
+      "system": {
+        "title": "系统状态",
+        "desc": "节点与服务健康监控"
+      }
+    },
+    "stats": {
+      "totalUsers": "总用户数",
+      "totalUsersDelta": "+12（过去 7 天）",
+      "activeSessions": "活跃会话",
+      "todayRequests": "今日请求",
+      "systemStatus": "系统状态",
+      "allNodesNormal": "所有节点正常"
+    },
+    "col": {
+      "id": "ID",
+      "email": "邮箱",
+      "role": "角色",
+      "status": "状态",
+      "joinedAt": "注册日期",
+      "lastLogin": "最后登录",
+      "actions": "操作",
+      "edit": "编辑",
+      "delete": "删除"
+    }
+  },
+  "adminAnalytics": {
+    "title": "分析",
+    "description": "分析对话量、用户和令牌消耗趋势。",
+    "dailyConversations": "每日对话量",
+    "recentDaysCaption": "最近 {days} 天 · 按日",
+    "modelUsageTitle": "模型配置使用占比",
+    "costAnalysis": "成本分析",
+    "dailyCost": "每日成本",
+    "weeklyCost": "每周成本",
+    "projectedMonthlyCost": "预计月度成本",
+    "userBehavior": "用户行为",
+    "avgSessionLength": "平均会话时长",
+    "minutesSuffix": "{value} 分钟",
+    "avgQueriesPerSession": "每会话平均查询",
+    "peakHoursTop3": "高峰时段 Top 3",
+    "peakHourItem": "{hour}时 · {requests} 次请求",
+    "topQueriesTop5": "常见查询 Top 5",
+    "agentPerformance": "智能体性能",
+    "period": {
+      "7d": "7 天",
+      "30d": "30 天",
+      "90d": "90 天"
+    },
+    "stats": {
+      "totalConversations": "总对话数",
+      "activeUsers": "活跃用户",
+      "consumedTokens": "消耗令牌",
+      "avgResponse": "平均响应"
+    },
+    "col": {
+      "model": "模型",
+      "cost": "成本",
+      "share": "占比",
+      "agent": "智能体",
+      "requests": "请求数",
+      "successRate": "成功率",
+      "avgResponse": "平均响应"
+    }
+  },
+  "adminAudit": {
+    "title": "审计日志",
+    "description": "系统范围内的安全与管理活动记录。",
+    "countBadge": "{count}条",
+    "exportCsv": "导出 CSV",
+    "filter": {
+      "allActions": "全部操作"
+    },
+    "severity": {
+      "all": "全部严重级别"
+    },
+    "status": {
+      "critical": "严重",
+      "warn": "警告",
+      "info": "信息"
+    },
+    "period": {
+      "today": "今天",
+      "days7": "7天",
+      "days30": "30天",
+      "all": "全部"
+    },
+    "th": {
+      "time": "时间",
+      "actor": "操作者",
+      "action": "操作",
+      "target": "目标",
+      "severity": "严重级别"
+    },
+    "empty": "没有符合条件的日志。"
+  },
+  "adminMetrics": {
+    "title": "系统指标",
+    "lastUpdated": "最后更新 {time}",
+    "subtitle": "系统状态与资源实时监控",
+    "refresh": "刷新",
+    "stat": {
+      "cpu": "CPU 使用率",
+      "memory": "内存",
+      "requestRate": "请求率",
+      "errorRate": "错误率"
+    },
+    "memoryDelta": "共 {total} GB 中",
+    "requestChartTitle": "请求率（最近 24 小时 · req/min）",
+    "barTooltip": "{hour}时: {value}/min",
+    "nodeStatusTitle": "节点 · 服务状态",
+    "nodeRoleLlm": "LLM 节点",
+    "th": {
+      "node": "节点",
+      "role": "角色",
+      "status": "状态",
+      "latency": "延迟",
+      "load": "负载"
+    },
+    "status": {
+      "online": "正常",
+      "degraded": "降级",
+      "offline": "离线"
+    },
+    "agentMetricsTitle": "智能体指标",
+    "agent": {
+      "totalAgents": "智能体总数",
+      "totalRequests": "请求总数",
+      "avgSuccessRate": "平均成功率",
+      "avgResponseTime": "平均响应时间"
+    },
+    "agentTh": {
+      "id": "智能体 ID",
+      "requests": "请求数",
+      "successRate": "成功率",
+      "avgResponseTime": "平均响应时间"
+    }
+  },
+  "adminAlerts": {
+    "title": "告警",
+    "description": "管理告警规则并查看最近发生的事件。",
+    "addRule": "添加规则",
+    "rulesTitle": "告警规则",
+    "toggleAria": "切换规则启用状态",
+    "enabled": "已启用",
+    "disabled": "已禁用",
+    "recentTitle": "最近告警",
+    "acknowledged": "已确认",
+    "acknowledge": "确认",
+    "status": {
+      "critical": "严重",
+      "warning": "警告",
+      "info": "信息"
+    },
+    "rules": {
+      "cpu": {
+        "name": "CPU 使用率阈值",
+        "condition": "CPU > 85% · 持续 5 分钟"
+      },
+      "contextOverflow": {
+        "name": "LLM 上下文溢出",
+        "condition": "发生 ContextOverflowError"
+      },
+      "errorRate": {
+        "name": "错误率激增",
+        "condition": "5xx 比例 > 2%"
+      },
+      "tokenQuota": {
+        "name": "令牌配额耗尽",
+        "condition": "周配额超过 90%"
+      },
+      "roleChange": {
+        "name": "管理员权限变更",
+        "condition": "user.role_change → admin"
+      }
+    },
+    "events": {
+      "e1": "检测到管理员权限授予 — u_1040（由 devops@partner.co.kr 执行）",
+      "e2": "redis-kv 节点负载 78% — 可能影响限流一致性",
+      "e3": "1 次 LLM 上下文溢出 — 已对 conv_88412 应用截断",
+      "e4": "每日备份完成 — postgres-primary（2.1GB）",
+      "e5": "12 次异常登录尝试 — 已封禁 45.33.21.7"
+    }
+  },
+  "adminMcpCatalog": {
+    "close": "关闭",
+    "editTitle": "编辑模板",
+    "createTitle": "新建模板",
+    "saveError": "保存失败。请重试。",
+    "displayNameLabel": "显示名称",
+    "descriptionLabel": "说明",
+    "descriptionPlaceholder": "服务器的简要说明",
+    "typeLabel": "类型",
+    "commandLabel": "命令",
+    "enabledLabel": "启用",
+    "cancel": "取消",
+    "save": "保存",
+    "create": "创建",
+    "deleteTitle": "删除模板",
+    "deleteConfirm": "确定要删除吗？",
+    "deleteError": "删除失败。请重试。",
+    "delete": "删除",
+    "pageTitle": "MCP 目录管理",
+    "pageDescription": "管理提供给用户的 MCP 服务器模板。",
+    "addTemplate": "添加模板",
+    "colName": "名称",
+    "colDescription": "说明",
+    "colType": "类型",
+    "colEnabled": "启用状态",
+    "colActions": "操作",
+    "loading": "加载中…",
+    "emptyState": "尚未注册模板。",
+    "enabled": "已启用",
+    "disabled": "已禁用",
+    "editAction": "编辑",
+    "deleteAction": "删除"
+  },
+  "apiKeys": {
+    "title": "API 密钥",
+    "description": "注册并管理外部 LLM 提供商(Anthropic / OpenAI 兼容)的密钥。",
+    "addKey": "添加密钥",
+    "close": "关闭",
+    "cancel": "取消",
+    "save": "保存",
+    "registeredKeys": "已注册的提供商密钥",
+    "mockDataShown": "正在显示模拟数据",
+    "loading": "正在加载密钥列表...",
+    "emptyTitle": "尚未注册外部密钥",
+    "emptyDesc": "添加密钥后即可使用该提供商的模型。",
+    "loadError": "无法加载密钥列表。",
+    "deleteConfirm": "确定要删除 {name} 密钥吗?\n使用此密钥的模型调用将中断。",
+    "deleteFailed": "删除失败: {error}",
+    "saveFailed": "保存失败: {error}",
+    "serverError": "服务器错误",
+    "deleteAria": "删除",
+    "validationError": "请输入名称和至少 8 个字符的 API 密钥。",
+    "namePlaceholder": "例如: 生产、开发",
+    "apiKeyLabel": "API 密钥",
+    "baseUrlLabel": "Base URL(可选)",
+    "col": {
+      "provider": "提供商",
+      "name": "名称",
+      "key": "密钥",
+      "createdAt": "创建日期",
+      "status": "状态",
+      "actions": "操作"
+    },
+    "status": {
+      "validationFailed": "验证失败",
+      "active": "已启用",
+      "unverified": "未验证"
+    },
+    "sdkType": {
+      "anthropic": "Anthropic",
+      "openaiCompatible": "OpenAI 兼容"
+    },
+    "mock": {
+      "productionName": "生产"
+    }
+  },
+  "usage": {
+    "title": "使用量",
+    "description": "按账户统计的令牌与请求使用量。",
+    "mockData": "模拟数据",
+    "updatedAt": "更新于 {time}",
+    "refresh": "刷新",
+    "loading": "加载中...",
+    "noData": "暂无数据。",
+    "dailyTitle": "每日令牌使用量(最近 14 天)",
+    "tokenTooltip": "{date} · {count} 令牌",
+    "systemMonitorTitle": "系统令牌监控",
+    "dailyTokens7d": "每日令牌(最近 7 天)",
+    "hourlyTokens": "每小时令牌",
+    "modelUsageTitle": "按模型使用占比",
+    "noModelData": "暂无按模型的使用数据。",
+    "stat": {
+      "monthTokens": "本月令牌",
+      "requests": "请求数",
+      "avgLatency": "平均延迟",
+      "errors": "错误",
+      "todayCost": "今日费用",
+      "todayTokens": "今日令牌",
+      "weekTokens": "每周令牌",
+      "weekEstCost": "每周预估费用"
+    },
+    "delta": {
+      "warning": "注意",
+      "normal": "正常"
+    },
+    "col": {
+      "model": "模型",
+      "tokens": "令牌",
+      "share": "占比",
+      "distribution": "分布"
+    }
+  },
+  "developer": {
+    "pageTitle": "开发者文档",
+    "pageDescription": "集成并自动化 OpenMake LLM API。",
+    "apiInfo": {
+      "title": "API 基本信息",
+      "apiVersionLabel": "API 版本",
+      "versionBlock": "/v1  — OpenAI 兼容端点\n/api — OpenMake 专用端点",
+      "description": "OpenMake LLM API 与 OpenAI Chat Completions API 兼容。只需更改 <code>baseURL</code>，即可直接使用现有的 OpenAI SDK。"
+    },
+    "auth": {
+      "title": "认证方式",
+      "apiKeyTitle": "API Key 认证",
+      "apiKeyDesc": "将在 设置 > API 密钥 页面签发的密钥传入 <code>Authorization</code> 请求头。",
+      "jwtTitle": "JWT 会话认证",
+      "jwtDesc": "浏览器会话会自动使用存储在 HttpOnly Cookie 中的 JWT。直接调用 API 时建议使用 API Key。"
+    },
+    "models": {
+      "title": "模型列表",
+      "description": "使用 <code>GET /api/models</code> 获取可用模型列表，或参考聊天页面的模型选择器。",
+      "brandIdLabel": "品牌模型 ID"
+    },
+    "brandModels": {
+      "default": "默认模型",
+      "pro": "高性能模型",
+      "fast": "快速响应",
+      "think": "推理模式",
+      "code": "代码专用",
+      "vision": "图像支持"
+    },
+    "steps": {
+      "apiKey": {
+        "title": "签发 API 密钥",
+        "description": "在 设置 > API 密钥 页面创建新的 API 密钥。"
+      },
+      "chatCompletion": {
+        "title": "聊天补全请求",
+        "description": "向 OpenAI 兼容的 /v1/chat/completions 端点发送请求。"
+      },
+      "streaming": {
+        "title": "流式响应",
+        "description": "添加 stream: true 即可通过 SSE 流实时接收 token。"
+      }
+    }
   }
 }


### PR DESCRIPTION
## 개요

i18n 시리즈 PR 5/6 (베이스: #261). 관리자 6개 페이지와 계정 관련 3개 페이지를 next-intl 키로 전환 — 이로써 전 페이지 문자열 추출 완료.

## 변경

- `admin`(메인) · `admin/analytics` · `admin/audit` · `admin/metrics` · `admin/alerts` · `admin/mcp-catalog`
- `api-keys` · `usage` · `developer`
- messages 네임스페이스 9개 — 누적 **914키 × 4 locale** 정합

## 검증

- `check:i18n` 통과 (914키 × 4) · 격리 워크트리 `tsc` 0 + `next build` 성공
- eslint: 에이전트 초안의 신규 warning 1건(api-keys useCallback t 의존성) 수정 — 신규 0 (기준 3건 = 기존 코드 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)