### PR TITLE
chore(websearch): 리랭킹 셰도우 로그에 임베딩 지연(embMs) 계측 추가

### DIFF
--- a/apps/api/src/mcp/web-search/semantic-reranker.ts
+++ b/apps/api/src/mcp/web-search/semantic-reranker.ts
@@ -59,12 +59,15 @@ export async function logSemanticRerankShadow(query: string, results: SearchResu
     const texts = [query, ...top.map((r) => [...`${r.title} ${r.snippet || ''}`].slice(0, SHADOW_TEXT_CHARS).join(''))];
 
     let embs: number[][];
+    const embStart = Date.now();
     try {
         embs = await embedBatch(texts, cfg.searchRerankEmbedModel, cfg.llmBaseUrl, cfg.llmApiKey);
     } catch (e) {
         logger.warn(`임베딩 실패(셰도우 skip): ${e instanceof Error ? e.message : String(e)}`);
         return;
     }
+    // 활성화(ENABLED) 시 이 만큼이 웹검색 critical-path 에 더해진다 — 운영 셰도우로 실지연 관측용.
+    const embMs = Date.now() - embStart;
     if (embs.length !== texts.length) return;
 
     const qv = embs[0];
@@ -83,8 +86,8 @@ export async function logSemanticRerankShadow(query: string, results: SearchResu
     const demotedFromTop5 = top.slice(0, 5).filter((r) => !rerankSet.has(r.url)).length;
 
     logger.info(
-        `q="${query.slice(0, 30)}" orig5=[${origTop.join(', ')}] semantic5=[${semanticTop.join(', ')}] ` +
-        `sim=${simMin}~${simMax} lifted=${liftedIntoTop5} demoted=${demotedFromTop5}`,
+        `q="${query.slice(0, 30)}" embMs=${embMs} n=${top.length} orig5=[${origTop.join(', ')}] ` +
+        `semantic5=[${semanticTop.join(', ')}] sim=${simMin}~${simMax} lifted=${liftedIntoTop5} demoted=${demotedFromTop5}`,
     );
 }
 


### PR DESCRIPTION
리랭킹 활성화 시 critical-path 에 더해질 실지연을 운영 셰도우 로그로 관측하기 위해 `embMs`·`n` 필드 추가. 로컬 실측 warm ~75ms(cold 첫 1회 ~1.4s). 실사용 분포 관찰 후 `SEARCH_SEMANTIC_RERANK_ENABLED` 판단.

🤖 Generated with [Claude Code](https://claude.com/claude-code)