### PR TITLE
feat(agent-task): Phase 5 지능 확장 — 서브에이전트·크로스task학습·검증확장·임베딩 동적도구

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -738,6 +738,25 @@ AGENT_TASK_TIMEOUT_MS=600000
 # AGENT_TASK_SCHEDULE_MIN_INTERVAL_SEC=300
 # AGENT_TASK_SCHEDULE_DISABLE_AFTER_FAILURES=5
 
+# Agent Task — 크로스-task 학습 (과거 유사 작업의 결과·도구·실패사유를 system 에 주입). 기본 OFF.
+# AGENT_TASK_LEARNING_ENABLED=true
+# AGENT_TASK_LEARNING_LOOKBACK=30
+# AGENT_TASK_LEARNING_MAX_LESSONS=3
+# AGENT_TASK_LEARNING_MIN_SIMILARITY=0.2
+
+# Agent Task — 산출물 검증 모드: syntax(기본, 문법만) | run(샌드박스 실행 후 exit code 검사).
+# AGENT_TASK_VERIFY_MODE=syntax
+
+# Agent Task — 서브에이전트 위임 (delegate 를 depth=1 미니 tool-loop 로 승격). 기본 OFF.
+# AGENT_TASK_SUBAGENT_ENABLED=true
+# AGENT_TASK_SUBAGENT_MAX_TURNS=3
+# AGENT_TASK_SUBAGENT_MAX_TOKENS=100000
+
+# Agent Task — 동적 도구 선별 방식: keyword(기본) | embedding(bge-m3 코사인, 실패 시 키워드 폴백).
+# AGENT_TASK_DYNAMIC_TOOLS_MODE=keyword
+# AGENT_TASK_DYNAMIC_TOOLS_EMBED_MIN_SIM=0.35
+# AGENT_TASK_DYNAMIC_TOOLS_EMBED_TIMEOUT_MS=3000
+
 # 첨부 이미지 캡 (에이전트 작업 REST 생성 경로 — composer MAX_IMAGES 와 페어)
 # FILE_ATTACH_MAX_IMAGES=20
 # FILE_ATTACH_MAX_IMAGE_DATAURL_CHARS=20000000   # dataURL 최대 글자 (base64 = 원본의 4/3)

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1282,5 +1282,32 @@ export const AGENT_TASK_LIMITS = {
     SCHEDULE_MIN_INTERVAL_SEC: parseInt(process.env.AGENT_TASK_SCHEDULE_MIN_INTERVAL_SEC || '300', 10),
     /** 연속 실패 이 횟수 도달 시 스케줄 자동 비활성(폭주 차단). AGENT_TASK_SCHEDULE_DISABLE_AFTER_FAILURES(기본 5). */
     SCHEDULE_DISABLE_AFTER_FAILURES: parseInt(process.env.AGENT_TASK_SCHEDULE_DISABLE_AFTER_FAILURES || '5', 10),
+    /** 크로스-task 학습(Phase 5-2) — 유저 과거 유사 작업의 결과·도구·실패사유를 새 task system 에
+     *  주입(같은 실수 반복 방지). 무-LLM(키워드 유사도)·기존 테이블 파생. 기본 OFF.
+     *  AGENT_TASK_LEARNING_ENABLED=true 로 활성. */
+    LEARNING_ENABLED: process.env.AGENT_TASK_LEARNING_ENABLED === 'true',
+    /** 학습 조회 대상 — 유저 최근 terminal task 수(기본 30). */
+    LEARNING_LOOKBACK: parseInt(process.env.AGENT_TASK_LEARNING_LOOKBACK || '30', 10),
+    /** 주입할 교훈 최대 건수(기본 3). */
+    LEARNING_MAX_LESSONS: parseInt(process.env.AGENT_TASK_LEARNING_MAX_LESSONS || '3', 10),
+    /** goal 유사도(자카드) 임계 — 미만은 무관 작업으로 간주(기본 0.2). */
+    LEARNING_MIN_SIMILARITY: parseFloat(process.env.AGENT_TASK_LEARNING_MIN_SIMILARITY || '0.2'),
+    /** 산출물 검증 모드(Phase 5-3): 'syntax'(기본 — py_compile·node --check) | 'run'(샌드박스에서
+     *  실제 실행 후 exit code 검사 — network none·자원캡 격리라 안전하나 부작용 있는 코드는 실행됨). */
+    VERIFY_MODE: (process.env.AGENT_TASK_VERIFY_MODE === 'run' ? 'run' : 'syntax') as 'syntax' | 'run',
+    /** 서브에이전트 위임(Phase 5-1) — delegate 를 1-shot 자문에서 depth=1 미니 tool-loop 로 승격.
+     *  기본 OFF(기존 1-shot 유지). AGENT_TASK_SUBAGENT_ENABLED=true 로 활성. */
+    SUBAGENT_ENABLED: process.env.AGENT_TASK_SUBAGENT_ENABLED === 'true',
+    /** 서브에이전트 턴 상한(작게 — 재귀·폭주 방지, 기본 3). */
+    SUBAGENT_MAX_TURNS: parseInt(process.env.AGENT_TASK_SUBAGENT_MAX_TURNS || '3', 10),
+    /** 서브에이전트 1회 위임당 토큰 상한 — 부모 누적에 합산되어 부모 한도도 함께 적용(기본 100k). */
+    SUBAGENT_MAX_TOKENS: parseInt(process.env.AGENT_TASK_SUBAGENT_MAX_TOKENS || '100000', 10),
+    /** 동적 도구 선별 방식(Phase 5-4): 'keyword'(기본 — 무-LLM 오버랩) | 'embedding'(bge-m3 코사인,
+     *  어휘가 달라도 의미 매칭. 실패 시 키워드 폴백). AGENT_TASK_DYNAMIC_TOOLS_MODE. */
+    DYNAMIC_TOOLS_MODE: (process.env.AGENT_TASK_DYNAMIC_TOOLS_MODE === 'embedding' ? 'embedding' : 'keyword') as 'keyword' | 'embedding',
+    /** 임베딩 모드 유사도 임계 — 미만은 예산이 남아도 제외(무관 도구 미주입, 기본 0.35). */
+    DYNAMIC_TOOLS_EMBED_MIN_SIM: parseFloat(process.env.AGENT_TASK_DYNAMIC_TOOLS_EMBED_MIN_SIM || '0.35'),
+    /** 임베딩 선별 전체 타임아웃(ms) — 초과 시 키워드 폴백(기본 3000). */
+    DYNAMIC_TOOLS_EMBED_TIMEOUT_MS: parseInt(process.env.AGENT_TASK_DYNAMIC_TOOLS_EMBED_TIMEOUT_MS || '3000', 10),
 } as const;
 

--- a/apps/api/src/data/repositories/agent-task-repository.ts
+++ b/apps/api/src/data/repositories/agent-task-repository.ts
@@ -159,6 +159,29 @@ export class AgentTaskRepository extends BaseRepository {
         return result.rows;
     }
 
+    /** 크로스-task 학습(5-2)용 — 유저 최근 terminal task 의 경량 메타만 조회(checkpoint 등 대형 컬럼 제외). */
+    async getRecentTerminalTaskMetas(userId: string, limit: number): Promise<Array<
+        Pick<AgentTask, 'id' | 'goal' | 'status' | 'error' | 'current_turn'>
+    >> {
+        const result = await this.query<Pick<AgentTask, 'id' | 'goal' | 'status' | 'error' | 'current_turn'>>(
+            `SELECT id, goal, status, error, current_turn FROM agent_tasks
+             WHERE user_id = $1 AND status IN ('completed', 'failed', 'cancelled')
+             ORDER BY created_at DESC LIMIT $2`,
+            [userId, limit]
+        );
+        return result.rows;
+    }
+
+    /** 크로스-task 학습(5-2)용 — task 가 실제 사용한 도구 이름 목록(distinct). */
+    async getTaskToolNames(taskId: string): Promise<string[]> {
+        const result = await this.query<{ tool_name: string }>(
+            `SELECT DISTINCT tool_name FROM agent_task_steps
+             WHERE task_id = $1 AND tool_name IS NOT NULL AND step_type = 'tool_result'`,
+            [taskId]
+        );
+        return result.rows.map((r) => r.tool_name);
+    }
+
     /**
      * 부팅 복구 대상 조회 — 재시작으로 in-process 루프가 소멸한 task.
      * schema-initializer 가 부팅 시 running/paused 를 failed('server restarted') 로 먼저 마킹하므로

--- a/apps/api/src/prompts/agent-task-prompt.ts
+++ b/apps/api/src/prompts/agent-task-prompt.ts
@@ -119,18 +119,27 @@ export function getAgentTaskUploadedFilesNote(fileLines: string[]): string {
  * 보수적 기준: 답변이 "수행하지 못했음"(입력 부재·불가·되묻기만)을 드러낼 때만 미달성.
  * 품질 평가가 아니다 — 부실해도 목표를 수행한 답변은 달성으로 본다(오탐 방지).
  */
-export function getAgentTaskGoalJudgeMessages(goal: string, answer: string): { system: string; user: string } {
+export function getAgentTaskGoalJudgeMessages(
+    goal: string,
+    answer: string,
+    /** 5-3(b): 실행 컨텍스트(계획 상태·사용 도구·턴수) — 판정 정확도 보강. 없으면 기존 동작. */
+    executionContext?: string,
+): { system: string; user: string } {
     return {
         system: [
             '당신은 자율 에이전트 작업의 결과 심사자입니다.',
             '목표(GOAL)와 에이전트의 최종 답변(ANSWER)을 보고, 답변이 목표 수행의 결과물인지 판정하세요.',
             '- 미달성(achieved=false)은 답변이 목표를 수행하지 못했음을 드러낼 때만: 필요한 입력/자료가 없다고 함,',
             '  할 수 없다고 함, 사용자에게 되묻기만 함, 목표와 무관한 내용만 있음.',
+            '- 실행 기록(EXECUTION)이 주어지면 참고하세요: 목표에 필요한 작업(예: 파일 생성·검색·실행)을',
+            '  실제로 수행한 흔적이 전혀 없는데 수행했다고 주장하면 미달성입니다.',
             '- 품질은 평가하지 마세요 — 내용이 부실하더라도 목표를 수행한 답변이면 달성(achieved=true)입니다.',
             '- 확신이 없으면 달성(true)으로 판정하세요.',
             '다른 설명 없이 JSON 한 줄만 출력: {"achieved": true|false, "reason": "한 문장 근거"}',
         ].join('\n'),
-        user: `## GOAL\n${goal}\n\n## ANSWER\n${answer}\n\n판정 JSON 을 출력하세요.`,
+        user: `## GOAL\n${goal}\n\n## ANSWER\n${answer}`
+            + (executionContext ? `\n\n## EXECUTION\n${executionContext}` : '')
+            + '\n\n판정 JSON 을 출력하세요.',
     };
 }
 

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -27,8 +27,7 @@ import { getPushService } from './PushService';
 import { createLogger } from '../utils/logger';
 import type { UserContext } from '../mcp/user-sandbox';
 import { getSkillManager } from '../agents/skill-manager';
-import { routeToAgent } from '../agents/keyword-router';
-import { getAgentSystemMessage } from '../agents/system-prompt';
+import { buildDelegateFn } from './agent-task/delegate';
 import { mergeToolsWithSkills, type ActiveSkillBinding } from './chat-service/tool-merger';
 import { getTaskSandboxConfig } from '../config/task-sandbox';
 import { TaskRuntime } from './task-sandbox/runtime';
@@ -37,10 +36,11 @@ import { requiresApproval, getApprovalRegistry } from './task-sandbox/approval-g
 import { buildFileContext } from './chat-service/attach-context';
 import { AgentTaskAbort, type AgentTaskRunInput } from './agent-task/types';
 import { writeInputFilesToWorkspace } from './agent-task/task-inputs';
-import { judgeGoalAchieved } from './agent-task/goal-judge';
-import { persistArtifactSteps, runTool } from './agent-task/task-steps';
+import { judgeGoalAchieved, buildJudgeExecutionContext } from './agent-task/goal-judge';
+import { persistArtifactSteps, runTool, isSearchTool } from './agent-task/task-steps';
 import { assembleAgentTools } from './agent-task/tool-assembly';
 import { verifyCodeArtifacts } from './agent-task/deliverable-verify';
+import { buildLearningBlock } from './agent-task/task-learning';
 
 // 기존 import 호환 재노출 — 타입/에러는 services/agent-task/types 로 분리 (파일 크기 가드).
 export { AgentTaskAbort, type AgentTaskRunInput, type AgentTaskInputFile } from './agent-task/types';
@@ -53,12 +53,6 @@ const logger = createLogger('AgentTaskService');
  * 와도 겹치지 않는 sentinel 을 넘겨, __global__ + user:{userId} 스킬만 매칭시킨다.
  */
 const AGENT_TASK_SKILL_AGENT_ID = '__agent_task__';
-
-/** tool name 이 검색/정보수집류인지 (키워드 포함 여부) — 검색 폭주 하드 제한용 */
-function isSearchTool(name: string): boolean {
-    const n = name.toLowerCase();
-    return AGENT_TASK_LIMITS.SEARCH_TOOL_KEYWORDS.some((k) => n.includes(k));
-}
 
 export class AgentTaskService {
     /** 실행 중 인스턴스 레지스트리 — detached 실행을 cancel 엔드포인트에서 중단하기 위함 */
@@ -118,6 +112,8 @@ export class AgentTaskService {
         const recentSignatures: string[] = [];
         let stuckNotified = false;
         let verifyRetries = 0;
+        // 5-3(b): 실제 사용한 도구 추적 — goal judge 의 실행 컨텍스트(수행 흔적)로 전달.
+        const usedTools = new Set<string>();
 
         // DB 갱신 + 진행상황 발행(fire-and-forget). ws 계층이 구독해 owner user 에게 relay.
         // ws 를 직접 참조하지 않으므로 소켓 연결 여부와 무관하게 실행은 끝까지 진행된다.
@@ -157,10 +153,16 @@ export class AgentTaskService {
             // 새 시작 시 system 프롬프트에 활성 스킬(global+user)의 지식(prompt_md)을 주입한다.
             // resume 의 system 은 old checkpoint 그대로이므로, 작업 중 스킬이 바뀌면 지식(system)과
             // 도구 바인딩(매 실행 fresh)이 갈릴 수 있다 — 무해, 재개 일관성을 위한 의도된 동작.
+            // 크로스-task 학습(5-2): 과거 유사 작업 교훈 블록 — 플래그 OFF/실패 시 ''(미주입).
             const conversation: ChatMessage[] = input.resume
                 ? [...input.resume.conversation]
                 : [
-                    { role: 'system', content: getAgentTaskSystemPrompt() + (await this.buildSkillPromptBlock(userId)) },
+                    {
+                        role: 'system',
+                        content: getAgentTaskSystemPrompt()
+                            + (await this.buildSkillPromptBlock(userId))
+                            + (await buildLearningBlock(userId, goal, taskId)),
+                    },
                     { role: 'user', content: goal },
                 ];
             const startTurn = input.resume?.fromTurn ?? 0;
@@ -202,16 +204,13 @@ export class AgentTaskService {
             const sandboxCfg = getTaskSandboxConfig();
             if (sandboxCfg.enabled) {
                 try {
-                    // G4 위임: subgoal 을 적합 산업 전문가 페르소나로 1회 자문(재귀 루프 없음).
-                    const delegateFn = async (subgoal: string, role?: string): Promise<string> => {
-                        const selection = await routeToAgent(role ? `[${role}] ${subgoal}` : subgoal);
-                        const { prompt } = await getAgentSystemMessage(selection, userId);
-                        const r = await this.client.chat(
-                            [{ role: 'system', content: prompt }, { role: 'user', content: subgoal }],
-                            undefined, undefined, { think: false, signal },
-                        );
-                        return r.content ?? '';
-                    };
+                    // G4 위임 — 상세는 agent-task/delegate (SUBAGENT_ENABLED 시 depth=1 tool-loop 승격,
+                    // 토큰·승인대기는 부모 누적에 합산되어 runaway 가드·pause-aware 타임아웃 공유).
+                    const delegateFn = buildDelegateFn({
+                        client: this.client, userId, taskId, userCtx, sandboxCfg, mcpTools, signal,
+                        onTokens: (n) => { totalTokens += n; },
+                        onPausedMs: (ms) => { pausedMs += ms; },
+                    });
                     taskRuntime = new TaskRuntime(taskId, userId, sandboxCfg, delegateFn);
                     await taskRuntime.create();
                     await db.updateAgentTask(taskId, {
@@ -250,7 +249,7 @@ export class AgentTaskService {
 
             // LLM 에 전달할 도구 세트 조립(샌드박스 도구 + extraTools + 2-A 동적 도구). 상세는
             // agent-task/tool-assembly. extraToolNames = 호스트 실행 도구(디스패치 승인 게이트 대상).
-            const { tools, extraToolNames } = assembleAgentTools({ mcpTools, taskRuntime, sandboxCfg, goal });
+            const { tools, extraToolNames } = await assembleAgentTools({ mcpTools, taskRuntime, sandboxCfg, goal });
 
             // 스텝 실시간 발행(4-5) — DB 기록 직후 요약을 WS 로 브로드캐스트(채팅 인라인 카드의 "현재 단계").
             const emitStep = (stepType: string, toolName?: string, content?: string | null): void => {
@@ -396,8 +395,10 @@ export class AgentTaskService {
                     // 목표 달성 judge (마커 미준수 보완): 아티팩트 없는 최종 답변만 판정 전용
                     // LLM 1회 호출로 검증 — deliverable 아티팩트가 실재하면 생략(호출 절약).
                     // 판정 실패/파싱 불가는 fail-open(완료 유지), 미달성 확정 시에만 실패 처리.
+                    // 5-3(b): 실행 컨텍스트(사용 도구·턴수·계획 상태)를 함께 제공해 판정 정확도 보강.
                     if (extracted!.artifacts.length === 0 && AGENT_TASK_LIMITS.GOAL_JUDGE_ENABLED) {
-                        const achieved = await judgeGoalAchieved(this.client, goal, stepContent ?? '', callSignal);
+                        const execCtx = buildJudgeExecutionContext(usedTools, turn + 1, taskRuntime?.getPlanSnapshot() ?? []);
+                        const achieved = await judgeGoalAchieved(this.client, goal, stepContent ?? '', callSignal, execCtx);
                         if (achieved === false) {
                             await update({
                                 status: 'failed',
@@ -450,6 +451,7 @@ export class AgentTaskService {
                 for (const tc of result.tool_calls!) {
                     if (signal.aborted) throw new AgentTaskAbort('aborted');
                     const name = tc.function.name;
+                    usedTools.add(name);
                     if (isSearchTool(name)) searchCalls++;
                     if (name === 'browser') browserCalls++;
                     const args = (tc.function.arguments ?? {}) as Record<string, unknown>;

--- a/apps/api/src/services/agent-task/delegate.ts
+++ b/apps/api/src/services/agent-task/delegate.ts
@@ -1,0 +1,59 @@
+/**
+ * Agent Task delegate 팩토리 — AgentTaskService 에서 분리 (파일 크기 가드).
+ *
+ * G4 위임: subgoal 을 적합 산업 전문가 페르소나에게 위임.
+ *  - 기본(1-shot 자문): 재귀 루프 없이 텍스트 자문만.
+ *  - SUBAGENT_ENABLED(5-1): depth=1 미니 tool-loop 로 승격 — 안전 도구 서브셋
+ *    (호스트 화이트리스트, delegate 재귀 구조적 불가)으로 하위 목표를 실제 수행.
+ *
+ * @module services/agent-task/delegate
+ */
+import type { LLMClient } from '../../llm';
+import type { ToolDefinition } from '../../llm/types';
+import type { UserContext } from '../../mcp/user-sandbox';
+import type { TaskSandboxConfig } from '../../config/task-sandbox';
+import type { DelegateFn } from '../task-sandbox/tools';
+import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
+import { routeToAgent } from '../../agents/keyword-router';
+import { getAgentSystemMessage } from '../../agents/system-prompt';
+import { runSubagent } from './subagent';
+
+export interface DelegateFactoryParams {
+    client: LLMClient;
+    userId: string;
+    taskId: string;
+    userCtx: UserContext;
+    sandboxCfg: TaskSandboxConfig;
+    /** 전체 MCP 카탈로그 — 서브에이전트 도구(extraTools 이름)를 여기서 선별. */
+    mcpTools: ToolDefinition[];
+    signal: AbortSignal;
+    /** 서브 LLM 토큰을 부모 누적에 합산(부모 runaway 가드 공유). */
+    onTokens: (n: number) => void;
+    /** 승인 대기 시간을 부모 pausedMs 에 합산(4-1 pause-aware 일관). */
+    onPausedMs: (ms: number) => void;
+}
+
+/** delegate 도구 핸들러 생성 — TaskRuntime 에 주입. */
+export function buildDelegateFn(p: DelegateFactoryParams): DelegateFn {
+    return async (subgoal: string, role?: string): Promise<string> => {
+        const selection = await routeToAgent(role ? `[${role}] ${subgoal}` : subgoal);
+        const { prompt } = await getAgentSystemMessage(selection, p.userId);
+        if (AGENT_TASK_LIMITS.SUBAGENT_ENABLED) {
+            // 서브 도구 = 부모 호스트 화이트리스트(extraTools)와 동일 선별(샌드박스 쓰기 도구 제외).
+            const subTools = p.sandboxCfg.extraTools
+                .map((n) => p.mcpTools.find((t) => t.function.name === n))
+                .filter((t): t is ToolDefinition => !!t);
+            return runSubagent({
+                client: p.client, personaPrompt: prompt, subgoal,
+                tools: subTools, userCtx: p.userCtx, taskId: p.taskId,
+                sandboxCfg: p.sandboxCfg, signal: p.signal,
+                onTokens: p.onTokens, onPausedMs: p.onPausedMs,
+            });
+        }
+        const r = await p.client.chat(
+            [{ role: 'system', content: prompt }, { role: 'user', content: subgoal }],
+            undefined, undefined, { think: false, signal: p.signal },
+        );
+        return r.content ?? '';
+    };
+}

--- a/apps/api/src/services/agent-task/deliverable-verify.ts
+++ b/apps/api/src/services/agent-task/deliverable-verify.ts
@@ -5,7 +5,10 @@
  * **문법/컴파일 검사**해 명백한 오류를 잡는다. 실측 근거: 실행 grounding 은 self-critique 보다
  * 값싸고 정확하다(틀린 코드를 "PASS"로 통과시키는 자기평가의 맹점을 실제 컴파일러가 막는다).
  *
- * 코드를 **실행하지 않고 컴파일/문법만** 검사한다(py_compile · node --check) — 부작용·hang 없음.
+ * 검사 모드(5-3, AGENT_TASK_VERIFY_MODE):
+ *  - 'syntax'(기본): 컴파일/문법만(py_compile · node --check) — 부작용·hang 없음.
+ *  - 'run': 샌드박스에서 실제 실행 후 exit code 검사 — 런타임 오류까지 잡는다.
+ *    (network none·자원캡 격리라 안전하나 부작용 있는 코드는 실행됨 — opt-in.)
  * 검사 불가 언어(ts/html/sql 등)나 코드가 아닌 산출물은 통과(ok=true)로 취급. 검사 자체 실패는
  * fail-open(ok=true) — 검증 인프라 문제로 정상 산출물을 막지 않는다.
  *
@@ -13,21 +16,19 @@
  */
 import type { TaskRuntime } from '../task-sandbox/runtime';
 import type { ExtractedArtifact } from '../../llm/artifact-parser';
+import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
 import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('AgentTaskVerify');
 
-/** 언어별 문법/컴파일 검사 — 파일 확장자 + 검사 명령. 코드를 실행하지 않는 것만 등록. */
-interface LangCheck { ext: string; cmd: (file: string) => string; }
+/** 언어별 검사 — cmd=문법/컴파일(코드 미실행) · runCmd=실제 실행(run 모드). */
+interface LangCheck { ext: string; cmd: (file: string) => string; runCmd: (file: string) => string; }
+const PY: LangCheck = { ext: 'py', cmd: (f) => `python3 -m py_compile ${f}`, runCmd: (f) => `python3 ${f}` };
+const jsCheck = (ext: string): LangCheck => ({ ext, cmd: (f) => `node --check ${f}`, runCmd: (f) => `node ${f}` });
 const LANG_CHECKS: Record<string, LangCheck> = {
-    python: { ext: 'py', cmd: (f) => `python3 -m py_compile ${f}` },
-    python3: { ext: 'py', cmd: (f) => `python3 -m py_compile ${f}` },
-    py: { ext: 'py', cmd: (f) => `python3 -m py_compile ${f}` },
-    javascript: { ext: 'js', cmd: (f) => `node --check ${f}` },
-    js: { ext: 'js', cmd: (f) => `node --check ${f}` },
-    node: { ext: 'js', cmd: (f) => `node --check ${f}` },
-    mjs: { ext: 'mjs', cmd: (f) => `node --check ${f}` },
-    cjs: { ext: 'cjs', cmd: (f) => `node --check ${f}` },
+    python: PY, python3: PY, py: PY,
+    javascript: jsCheck('js'), js: jsCheck('js'), node: jsCheck('js'),
+    mjs: jsCheck('mjs'), cjs: jsCheck('cjs'),
 };
 
 export interface VerifyResult {
@@ -55,17 +56,18 @@ export async function verifyCodeArtifacts(
             .filter((x): x is { a: ExtractedArtifact; i: number; check: LangCheck } => !!x.check);
         if (targets.length === 0) return { ok: true, report: '' };
 
+        const mode = AGENT_TASK_LIMITS.VERIFY_MODE;
         const failures: string[] = [];
         for (const { a, i, check } of targets) {
             if (signal?.aborted) break;
             const file = `.verify_${i}.${check.ext}`;
             try {
                 await runtime.writeWorkspaceFile(file, a.content ?? '');
-                const r = await runtime.execRaw(check.cmd(file));
+                const r = await runtime.execRaw(mode === 'run' ? check.runCmd(file) : check.cmd(file));
                 if (r.exitCode !== 0 || r.timedOut) {
                     const err = (r.stderr || r.stdout || '(no output)').trim().slice(0, MAX_REPORT_CHARS);
                     failures.push(`### ${a.title || a.id} (${a.lang})\n${err}`);
-                    logger.info(`[Verify] 산출물 문법 검사 실패: ${a.id} (${a.lang})`);
+                    logger.info(`[Verify] 산출물 ${mode === 'run' ? '실행' : '문법'} 검사 실패: ${a.id} (${a.lang})`);
                 }
             } catch (e) {
                 // 개별 산출물 검사 실패는 통과 취급(fail-open) — 인프라 문제로 완료를 막지 않음.

--- a/apps/api/src/services/agent-task/goal-judge.ts
+++ b/apps/api/src/services/agent-task/goal-judge.ts
@@ -9,6 +9,21 @@ import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('AgentTaskService');
 
+/** 5-3(b): judge 에 제공할 실행 컨텍스트(수행 흔적) 렌더 — 사용 도구·턴수·계획 상태. */
+export function buildJudgeExecutionContext(
+    usedTools: ReadonlySet<string>,
+    turnCount: number,
+    planSteps: ReadonlyArray<{ status: string }>,
+): string {
+    return [
+        `사용 도구: ${usedTools.size > 0 ? [...usedTools].join(', ') : '(없음 — 도구 미사용)'}`,
+        `턴 수: ${turnCount}`,
+        ...(planSteps.length > 0
+            ? [`계획: ${planSteps.filter((s) => s.status === 'completed').length}/${planSteps.length} 단계 완료`]
+            : []),
+    ].join('\n');
+}
+
 /**
  * 목표 달성 judge — 판정 전용 LLM 1회 호출. true=달성, false=미달성,
  * null=판정 불가(호출 실패/파싱 실패) → 호출자가 fail-open(완료 유지) 처리.
@@ -18,11 +33,14 @@ export async function judgeGoalAchieved(
     goal: string,
     answer: string,
     signal: AbortSignal,
+    /** 5-3(b): 실행 컨텍스트(계획 상태·사용 도구·턴수) — 판정 정확도 보강. */
+    executionContext?: string,
 ): Promise<boolean | null> {
     try {
         const { system, user } = getAgentTaskGoalJudgeMessages(
             goal,
             answer.slice(0, AGENT_TASK_LIMITS.GOAL_JUDGE_MAX_ANSWER_CHARS),
+            executionContext,
         );
         const r = await client.chat(
             [{ role: 'system', content: system }, { role: 'user', content: user }],

--- a/apps/api/src/services/agent-task/subagent.ts
+++ b/apps/api/src/services/agent-task/subagent.ts
@@ -1,0 +1,121 @@
+/**
+ * Agent Task 서브에이전트 위임 (Phase 5-1).
+ *
+ * delegate 도구를 1-shot 자문에서 **depth=1 미니 tool-loop** 로 승격한다 — 서브에이전트가
+ * 전문가 페르소나 + 안전 도구 서브셋(호스트 화이트리스트, 예: web_search)으로 하위 목표를
+ * 실제 수행하고 결과를 반환한다. (SUBAGENT_ENABLED off 면 기존 1-shot 유지.)
+ *
+ * 폭주 가드(설계 원칙 — 재귀·비용 차단):
+ *  - depth 1 고정: 서브에이전트 도구 목록에 delegate 없음(재위임 구조적 불가).
+ *  - 턴 상한 SUBAGENT_MAX_TURNS(기본 3) · 위임당 토큰 상한 SUBAGENT_MAX_TOKENS.
+ *  - 토큰은 onTokens 로 부모 totalTokens 에 합산 — 부모 runaway 가드도 함께 적용.
+ *  - 도구는 부모와 동일한 HITL 승인 게이트 경유(정책 우회 없음) — 자동승인 task 면 즉시.
+ *  - 샌드박스(쓰기) 도구는 제외 — 부모 컨테이너 상태를 서브가 변경하지 못함.
+ *
+ * @module services/agent-task/subagent
+ */
+import type { LLMClient } from '../../llm';
+import type { ChatMessage, ToolDefinition } from '../../llm/types';
+import { getUnifiedMCPClient } from '../../mcp/unified-client';
+import type { UserContext } from '../../mcp/user-sandbox';
+import type { TaskSandboxConfig } from '../../config/task-sandbox';
+import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
+import { requiresApproval, getApprovalRegistry } from '../task-sandbox/approval-gate';
+import { runTool } from './task-steps';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('AgentTaskSubagent');
+
+export interface SubagentParams {
+    client: LLMClient;
+    /** 전문가 페르소나 system prompt (keyword-router 가 고른 산업 agent). */
+    personaPrompt: string;
+    subgoal: string;
+    /** 안전 도구 서브셋 — 부모의 호스트 화이트리스트(extraTools). delegate 류는 호출부가 제외. */
+    tools: ToolDefinition[];
+    userCtx: UserContext;
+    taskId: string;
+    sandboxCfg: TaskSandboxConfig;
+    signal?: AbortSignal;
+    /** 서브 LLM 호출 토큰을 부모 누적에 합산. */
+    onTokens?: (n: number) => void;
+    /** 승인 대기 시간을 부모 pausedMs 에 합산(4-1 pause-aware 일관). */
+    onPausedMs?: (ms: number) => void;
+}
+
+/**
+ * depth=1 미니 tool-loop 실행 — 최종 텍스트 반환. 실패는 문자열로 흡수(부모 luoop 를 죽이지 않음).
+ */
+export async function runSubagent(p: SubagentParams): Promise<string> {
+    const maxTurns = AGENT_TASK_LIMITS.SUBAGENT_MAX_TURNS;
+    const mcp = getUnifiedMCPClient();
+    let tokens = 0;
+
+    const conversation: ChatMessage[] = [
+        {
+            role: 'system',
+            content: p.personaPrompt + '\n\n' + [
+                '당신은 상위 자율 에이전트로부터 하위 목표를 위임받은 서브에이전트입니다.',
+                `- 최대 ${maxTurns}턴 안에 끝내세요. 필요한 경우에만 도구를 쓰고, 즉시 답할 수 있으면 바로 답하세요.`,
+                '- 다른 에이전트에게 재위임할 수 없습니다.',
+                '- 최종 응답은 상위 에이전트가 그대로 활용할 간결·구체적인 결과여야 합니다.',
+            ].join('\n'),
+        },
+        { role: 'user', content: p.subgoal },
+    ];
+
+    try {
+        for (let turn = 0; turn < maxTurns; turn++) {
+            if (p.signal?.aborted) return 'Error: 상위 작업이 중단되었습니다.';
+            // 마지막 턴엔 도구를 제거해 최종 답변을 강제(도구 호출로 끝나 결과가 없는 상황 방지).
+            const lastTurn = turn === maxTurns - 1;
+            const result = await p.client.chat(conversation, undefined, undefined, {
+                tools: lastTurn || p.tools.length === 0 ? undefined : p.tools,
+                signal: p.signal,
+                think: false,
+            });
+            const used = (result.metrics?.prompt_tokens ?? 0) + (result.metrics?.completion_tokens ?? 0);
+            tokens += used;
+            p.onTokens?.(used);
+            if (tokens > AGENT_TASK_LIMITS.SUBAGENT_MAX_TOKENS) {
+                logger.warn(`[Subagent] 토큰 상한 초과 — 조기 종료 (${tokens})`);
+                return result.content || '(서브에이전트 토큰 상한 도달 — 부분 결과 없음)';
+            }
+
+            conversation.push({
+                role: 'assistant',
+                content: result.content,
+                ...(result.tool_calls && { tool_calls: result.tool_calls }),
+            });
+            if (!result.tool_calls || result.tool_calls.length === 0) {
+                return result.content || '(서브에이전트가 빈 응답을 반환했습니다)';
+            }
+
+            for (const tc of result.tool_calls) {
+                const name = tc.function.name;
+                const args = (tc.function.arguments ?? {}) as Record<string, unknown>;
+                // 부모와 동일한 승인 게이트 — 정책 우회 없음(자동승인 task 면 즉시 approved).
+                let approved = true;
+                if (requiresApproval(p.sandboxCfg.approvalPolicy, name, args)) {
+                    const r = await getApprovalRegistry().request(
+                        { taskId: p.taskId, userId: String(p.userCtx.userId), toolName: name, args },
+                        { timeoutMs: p.sandboxCfg.approvalTimeoutMs, signal: p.signal },
+                    );
+                    p.onPausedMs?.(r.waitedMs);
+                    approved = r.decision === 'approved';
+                }
+                const toolResult = approved
+                    ? await runTool(mcp, name, args, p.userCtx)
+                    : `Error: 사용자가 도구 실행을 승인하지 않았습니다 (${name}).`;
+                conversation.push({ role: 'tool', content: toolResult, tool_name: name, tool_call_id: tc.id });
+            }
+        }
+        // 턴 소진 — 마지막 assistant 내용 반환.
+        const last = [...conversation].reverse().find((m) => m.role === 'assistant');
+        return (last?.content as string) || '(서브에이전트가 턴 상한에 도달했습니다)';
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        logger.warn(`[Subagent] 실행 실패: ${msg}`);
+        return `Error: 서브에이전트 실행 실패 — ${msg}`;
+    }
+}

--- a/apps/api/src/services/agent-task/task-learning.ts
+++ b/apps/api/src/services/agent-task/task-learning.ts
@@ -1,0 +1,84 @@
+/**
+ * Agent Task 크로스-task 학습 주입 (Phase 5-2).
+ *
+ * 같은 사용자의 과거 유사 작업(성공/실패·사용 도구·실패 사유)을 새 task 의 system 프롬프트에
+ * 압축 블록으로 주입한다 — 같은 실수(예: browser 상태 미보존, 도구 오선택)를 반복하지 않게.
+ *
+ * 설계 원칙:
+ *  - 신규 테이블 없음: agent_tasks(결과) + agent_task_steps(도구 사용)에서 파생.
+ *  - 무-LLM·결정적: 유사도는 tool-selector 의 키워드 토큰 오버랩 재사용(추가 지연·비용 0).
+ *  - 절대 throw 하지 않음: 실패 시 '' 반환(작업 시작을 막지 않음).
+ *
+ * @module services/agent-task/task-learning
+ */
+import { getPool } from '../../data/models/unified-database';
+import { AgentTaskRepository } from '../../data/repositories/agent-task-repository';
+import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
+import { tokenizeGoal } from './tool-selector';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('AgentTaskLearning');
+
+/** PURE: goal 간 키워드 오버랩 점수(자카드 유사). 0~1. */
+export function goalSimilarity(a: string, b: string): number {
+    const ta = new Set(tokenizeGoal(a));
+    const tb = new Set(tokenizeGoal(b));
+    if (ta.size === 0 || tb.size === 0) return 0;
+    let inter = 0;
+    for (const t of ta) if (tb.has(t)) inter++;
+    return inter / (ta.size + tb.size - inter);
+}
+
+interface LessonSource {
+    goal: string;
+    status: string;
+    error?: string | null;
+    current_turn: number;
+    tools: string[];
+}
+
+/** PURE: 교훈 1줄 렌더 — 결과·사유·도구·턴수를 압축. */
+export function renderLesson(s: LessonSource): string {
+    const outcome = s.status === 'completed'
+        ? '성공'
+        : s.status === 'failed' ? `실패(${s.error || '원인 미상'})` : '취소됨';
+    const goal = s.goal.length > 80 ? s.goal.slice(0, 80) + '…' : s.goal;
+    const tools = s.tools.length > 0 ? ` — 도구: ${s.tools.slice(0, 6).join(', ')}` : '';
+    return `- [${outcome}] "${goal}" (${s.current_turn}턴${tools})`;
+}
+
+/**
+ * 과거 유사 작업 교훈 블록 생성 — system 프롬프트에 덧붙일 텍스트('' 이면 미주입).
+ * 유저 최근 terminal task 중 goal 유사도 상위 N 건(임계 이상, 자기 자신 제외).
+ */
+export async function buildLearningBlock(userId: string, goal: string, excludeTaskId?: string): Promise<string> {
+    if (!AGENT_TASK_LIMITS.LEARNING_ENABLED) return '';
+    try {
+        const repo = new AgentTaskRepository(getPool());
+        const recent = await repo.getRecentTerminalTaskMetas(userId, AGENT_TASK_LIMITS.LEARNING_LOOKBACK);
+        const scored = recent
+            .filter((t) => t.id !== excludeTaskId)
+            .map((t) => ({ t, sim: goalSimilarity(goal, t.goal) }))
+            .filter((x) => x.sim >= AGENT_TASK_LIMITS.LEARNING_MIN_SIMILARITY)
+            .sort((a, b) => b.sim - a.sim)
+            .slice(0, AGENT_TASK_LIMITS.LEARNING_MAX_LESSONS);
+        if (scored.length === 0) return '';
+
+        const lessons: string[] = [];
+        for (const { t } of scored) {
+            const tools = await repo.getTaskToolNames(t.id).catch(() => [] as string[]);
+            lessons.push(renderLesson({ ...t, tools }));
+        }
+        logger.info(`[Learning] 유사 과거 작업 ${lessons.length}건 주입 (user ${userId})`);
+        return [
+            '',
+            '## 과거 유사 작업 기록 (참고)',
+            '이 사용자의 이전 작업 결과입니다. 성공 사례의 도구 선택을 참고하고,',
+            '실패 사례와 같은 실수(원인 참조)를 반복하지 마세요.',
+            ...lessons,
+        ].join('\n');
+    } catch (e) {
+        logger.debug(`[Learning] 교훈 블록 생성 실패 — 미주입: ${e instanceof Error ? e.message : e}`);
+        return '';
+    }
+}

--- a/apps/api/src/services/agent-task/task-steps.ts
+++ b/apps/api/src/services/agent-task/task-steps.ts
@@ -6,10 +6,16 @@ import { getUnifiedDatabase } from '../../data/models/unified-database';
 import { getUnifiedMCPClient } from '../../mcp/unified-client';
 import type { UserContext } from '../../mcp/user-sandbox';
 import type { ExtractedArtifact } from '../../llm/artifact-parser';
-import { MAX_TOOL_RESULT_CHARS } from '../../config/runtime-limits';
+import { MAX_TOOL_RESULT_CHARS, AGENT_TASK_LIMITS } from '../../config/runtime-limits';
 import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('AgentTaskService');
+
+/** tool name 이 검색/정보수집류인지 (키워드 포함 여부) — 검색 폭주 하드 제한용 */
+export function isSearchTool(name: string): boolean {
+    const n = name.toLowerCase();
+    return AGENT_TASK_LIMITS.SEARCH_TOOL_KEYWORDS.some((k) => n.includes(k));
+}
 
 /**
  * 최종 답변에서 추출한 deliverable 아티팩트를 step_type='artifact' 행으로 영속화.

--- a/apps/api/src/services/agent-task/tool-assembly.ts
+++ b/apps/api/src/services/agent-task/tool-assembly.ts
@@ -12,6 +12,7 @@ import type { TaskRuntime } from '../task-sandbox/runtime';
 import type { TaskSandboxConfig } from '../../config/task-sandbox';
 import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
 import { selectRelevantTools } from './tool-selector';
+import { selectRelevantToolsEmbedding } from './tool-selector-embedding';
 import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('AgentTaskService');
@@ -24,13 +25,14 @@ export interface AssembledTools {
 
 /**
  * LLM 에 전달할 도구 세트를 조립. taskRuntime 유무·샌드박스 enabled 여부로 3분기.
+ * (5-4: 임베딩 선별 모드가 비동기라 async — keyword 모드는 즉시 resolve.)
  */
-export function assembleAgentTools(params: {
+export async function assembleAgentTools(params: {
     mcpTools: ToolDefinition[];
     taskRuntime: TaskRuntime | null;
     sandboxCfg: TaskSandboxConfig;
     goal: string;
-}): AssembledTools {
+}): Promise<AssembledTools> {
     const { mcpTools, taskRuntime, sandboxCfg, goal } = params;
     const extraToolNames = new Set<string>();
 
@@ -58,19 +60,19 @@ export function assembleAgentTools(params: {
         const sandboxTools = taskRuntime.getLLMTools();
         const sandboxNames = new Set(sandboxTools.map((t) => t.function.name));
         const staticExtra = buildExtra(sandboxNames);
-        // 2-A 동적 도구: 목표 관련성 top-K MCP 도구를 예산 내에서 합류. 호스트 실행이므로
+        // 2-A/5-4 동적 도구: 목표 관련성 top-K MCP 도구를 예산 내에서 합류. 호스트 실행이므로
         // extraToolNames 에 등록해 디스패치가 extra 도구와 동일하게 HITL 승인 게이트를 적용한다.
-        // 관련성 0 도구는 selectRelevantTools 가 제외 → 문법 컴파일 폭주 재유발 없음.
+        // 관련성/유사도 임계 미만은 제외 → 문법 컴파일 폭주 재유발 없음.
         let dynamicExtra: ToolDefinition[] = [];
         if (AGENT_TASK_LIMITS.DYNAMIC_TOOLS_ENABLED) {
             const budget = AGENT_TASK_LIMITS.DYNAMIC_TOOLS_BUDGET - sandboxTools.length - staticExtra.length;
-            dynamicExtra = selectRelevantTools(goal, mcpTools, {
-                budget,
-                exclude: new Set<string>([...sandboxNames, ...extraToolNames]),
-            });
+            const selectOpts = { budget, exclude: new Set<string>([...sandboxNames, ...extraToolNames]) };
+            dynamicExtra = AGENT_TASK_LIMITS.DYNAMIC_TOOLS_MODE === 'embedding'
+                ? await selectRelevantToolsEmbedding(goal, mcpTools, selectOpts) // 실패 시 내부 키워드 폴백
+                : selectRelevantTools(goal, mcpTools, selectOpts);
             for (const t of dynamicExtra) extraToolNames.add(t.function.name);
             if (dynamicExtra.length > 0) {
-                logger.info(`[AgentTask] 동적 도구 ${dynamicExtra.length}개 합류 (예산 ${budget}, 총 ${sandboxTools.length + staticExtra.length + dynamicExtra.length})`);
+                logger.info(`[AgentTask] 동적 도구 ${dynamicExtra.length}개 합류 (${AGENT_TASK_LIMITS.DYNAMIC_TOOLS_MODE}, 예산 ${budget}, 총 ${sandboxTools.length + staticExtra.length + dynamicExtra.length})`);
             }
         }
         return { tools: [...staticExtra, ...dynamicExtra, ...sandboxTools], extraToolNames };

--- a/apps/api/src/services/agent-task/tool-selector-embedding.ts
+++ b/apps/api/src/services/agent-task/tool-selector-embedding.ts
@@ -1,0 +1,82 @@
+/**
+ * Agent Task 동적 도구 서브셋팅 — 임베딩 모드 (Phase 5-4).
+ *
+ * 키워드 오버랩(2-A) 대신 bge-m3 임베딩 코사인 유사도로 목표 관련 도구를 선별한다.
+ * 어휘가 달라도 의미가 통하는 도구(예: "일정 잡아줘" → calendar 도구)를 잡는 것이 목적.
+ *
+ * 비용 설계: 도구 텍스트(name+description) 벡터는 **모듈 레벨 캐시**(설명 불변 전제, 변경 시
+ * 재임베딩) — 첫 task 만 카탈로그 임베딩 비용을 내고 이후는 goal 1건만 임베딩한다(로컬 bge-m3).
+ * 실패/타임아웃은 키워드 모드로 폴백(절대 throw 하지 않음).
+ *
+ * @module services/agent-task/tool-selector-embedding
+ */
+import OpenAI from 'openai';
+import type { ToolDefinition } from '../../llm/types';
+import { getConfig } from '../../config/env';
+import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
+import { selectRelevantTools, type SelectToolsOptions } from './tool-selector';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('AgentTaskToolEmbed');
+
+/** 도구 벡터 캐시 — name → {desc(무효화 키), vec}. 카탈로그 설명은 사실상 불변. */
+const vecCache = new Map<string, { desc: string; vec: number[] }>();
+
+async function embedBatch(texts: string[]): Promise<number[][]> {
+    const cfg = getConfig();
+    const client = new OpenAI({ baseURL: cfg.llmBaseUrl, apiKey: cfg.llmApiKey });
+    const res = await client.embeddings.create({ model: cfg.searchRerankEmbedModel, input: texts });
+    return res.data.map((d) => d.embedding as number[]);
+}
+
+function cosine(a: number[], b: number[]): number {
+    let dot = 0, na = 0, nb = 0;
+    for (let i = 0; i < a.length; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+    const denom = Math.sqrt(na) * Math.sqrt(nb);
+    return denom === 0 ? 0 : dot / denom;
+}
+
+function toolText(t: ToolDefinition): string {
+    return `${t.function.name}: ${(t.function.description ?? '').slice(0, 300)}`;
+}
+
+/**
+ * 임베딩 기반 top-K 도구 선별. 유사도 임계 미만은 예산이 남아도 제외(무관 도구 미주입 원칙 유지).
+ * 임베딩 실패/타임아웃 시 키워드 모드(selectRelevantTools)로 폴백.
+ */
+export async function selectRelevantToolsEmbedding(
+    goal: string,
+    catalog: ToolDefinition[],
+    opts: SelectToolsOptions,
+): Promise<ToolDefinition[]> {
+    if (opts.budget <= 0) return [];
+    const exclude = opts.exclude ?? new Set<string>();
+    const candidates = catalog.filter((t) => !exclude.has(t.function.name));
+    if (candidates.length === 0) return [];
+
+    try {
+        const deadline = AGENT_TASK_LIMITS.DYNAMIC_TOOLS_EMBED_TIMEOUT_MS;
+        const work = (async () => {
+            // 캐시 미스 도구만 배치 임베딩(설명 변경 시 재임베딩).
+            const misses = candidates.filter((t) => vecCache.get(t.function.name)?.desc !== toolText(t));
+            for (let i = 0; i < misses.length; i += 64) {
+                const batch = misses.slice(i, i + 64);
+                const vecs = await embedBatch(batch.map(toolText));
+                batch.forEach((t, j) => vecCache.set(t.function.name, { desc: toolText(t), vec: vecs[j] }));
+            }
+            const [goalVec] = await embedBatch([goal.slice(0, 512)]);
+            return candidates
+                .map((t) => ({ t, sim: cosine(goalVec, vecCache.get(t.function.name)!.vec) }))
+                .filter((x) => x.sim >= AGENT_TASK_LIMITS.DYNAMIC_TOOLS_EMBED_MIN_SIM)
+                .sort((a, b) => b.sim - a.sim || a.t.function.name.localeCompare(b.t.function.name))
+                .slice(0, opts.budget)
+                .map((x) => x.t);
+        })();
+        const timeout = new Promise<never>((_, rej) =>
+            setTimeout(() => rej(new Error(`임베딩 선별 타임아웃(${deadline}ms)`)), deadline).unref());
+        return await Promise.race([work, timeout]);
+    } catch (e) {
+        logger.warn(`[ToolEmbed] 임베딩 선별 실패 — 키워드 폴백: ${e instanceof Error ? e.message : e}`);
+        return selectRelevantTools(goal, catalog, opts);
+    }
+}


### PR DESCRIPTION
## 개요

Agent Task **Phase 5 — 지능 확장**. 전부 플래그 게이트(기본 동작 무변경), 실 서버 **라이브 검증 4/4** 완료.

## 변경 내용

### 5-1 서브에이전트 위임 (`AGENT_TASK_SUBAGENT_ENABLED`, 기본 off)
`delegate`를 1-shot 자문 → **depth=1 미니 tool-loop**로 승격. 전문가 페르소나 + 안전 도구 서브셋(호스트 화이트리스트)으로 하위 목표를 실제 수행.
**폭주 가드**: 재위임 구조적 불가(도구 목록에 delegate 없음) · 턴캡(3) · 위임당 토큰캡(100k) · 부모 토큰/pause 누적 합산(runaway 가드 공유) · 동일 HITL 승인 게이트.
**라이브**: 모델 컷오프 밖 사실(2025 노벨물리학상 수상자)을 서브가 **실제 웹 검색**으로 확보 → 부모가 정리·완료.

### 5-2 크로스-task 학습 (`AGENT_TASK_LEARNING_ENABLED`, 기본 off)
과거 유사 작업(결과·사용 도구·실패 사유)을 새 task system에 압축 주입 — 같은 실수 반복 방지. **신규 테이블 없음**(agent_tasks/steps 파생) · 무-LLM(자카드 유사도, 임계 0.2).
**라이브**: `유사 과거 작업 1건 주입` 로그 + 완주.

### 5-3 검증 확장
- (a) `AGENT_TASK_VERIFY_MODE=run`: 샌드박스에서 **실제 실행**해 런타임 오류까지 검출(기본 syntax 유지). **라이브**: ZeroDivisionError 검출 → 자가수정 유도 → 재시도 상한 후 완료(무한루프 방지 설계대로).
- (b) goal judge에 실행 컨텍스트(사용 도구·턴수·계획 상태) 제공 — "수행 흔적 없는 주장" 미달성 판정 근거.

### 5-4 임베딩 동적도구 (`AGENT_TASK_DYNAMIC_TOOLS_MODE=embedding`, 기본 keyword)
bge-m3 코사인 유사도 top-K — 어휘가 달라도 의미 매칭. 도구 벡터는 모듈 캐시(첫 task만 카탈로그 임베딩), 실패/타임아웃 시 키워드 폴백.
**라이브**: `동적 도구 17개 합류 (embedding)` · 30도구 무-hang 완주.

### 기타
- 파일 크기 가드: delegateFn→`agent-task/delegate`, execCtx→`goal-judge`, isSearchTool→`task-steps` 추출(AgentTaskService 599줄)
- `.env.example` Phase 5 env 보충

## 검증
- ✅ 라이브 4/4 (실 서버, 플래그 임시 활성 후 원복)
- ✅ 유닛 103 pass · tsc 0 · lint 0 · Gate 3 통과
- ✅ 검증용 테스트 task·플래그 전부 정리/원복

🤖 Generated with [Claude Code](https://claude.com/claude-code)
