### PR TITLE
feat(agent-task): Phase 6 제품화 — 템플릿·스케줄 이력/알림·턴중간 체크포인트

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -757,6 +757,9 @@ AGENT_TASK_TIMEOUT_MS=600000
 # AGENT_TASK_DYNAMIC_TOOLS_EMBED_MIN_SIM=0.35
 # AGENT_TASK_DYNAMIC_TOOLS_EMBED_TIMEOUT_MS=3000
 
+# Agent Task — 턴 중간 체크포인트 (도구 결과 단위 저장 — write 도구 재실행 방지 강화). 기본 OFF.
+# AGENT_TASK_MIDTURN_CHECKPOINT=true
+
 # 첨부 이미지 캡 (에이전트 작업 REST 생성 경로 — composer MAX_IMAGES 와 페어)
 # FILE_ATTACH_MAX_IMAGES=20
 # FILE_ATTACH_MAX_IMAGE_DATAURL_CHARS=20000000   # dataURL 최대 글자 (base64 = 원본의 4/3)

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1309,5 +1309,10 @@ export const AGENT_TASK_LIMITS = {
     DYNAMIC_TOOLS_EMBED_MIN_SIM: parseFloat(process.env.AGENT_TASK_DYNAMIC_TOOLS_EMBED_MIN_SIM || '0.35'),
     /** 임베딩 선별 전체 타임아웃(ms) — 초과 시 키워드 폴백(기본 3000). */
     DYNAMIC_TOOLS_EMBED_TIMEOUT_MS: parseInt(process.env.AGENT_TASK_DYNAMIC_TOOLS_EMBED_TIMEOUT_MS || '3000', 10),
+    /** 턴 중간 체크포인트(Phase 6-4) — 도구 결과 단위로도 checkpoint 저장. 재시작이 턴 중간에
+     *  일어나도 이미 실행된 도구를 재실행하지 않고 재개한다(write 도구 재실행 방지 강화).
+     *  대화가 크면 도구 호출마다 DB 쓰기가 늘어나므로 기본 OFF(opt-in).
+     *  AGENT_TASK_MIDTURN_CHECKPOINT=true 로 활성. */
+    MIDTURN_CHECKPOINT_ENABLED: process.env.AGENT_TASK_MIDTURN_CHECKPOINT === 'true',
 } as const;
 

--- a/apps/api/src/data/repositories/agent-task-schedule-repository.ts
+++ b/apps/api/src/data/repositories/agent-task-schedule-repository.ts
@@ -120,5 +120,29 @@ export class AgentTaskScheduleRepository extends BaseRepository {
 
     async delete(id: string): Promise<void> {
         await this.query('DELETE FROM agent_task_schedules WHERE id = $1', [id]);
+        // 이력도 정리(068 은 FK 없이 append-only — 스케줄 삭제 시 함께 비운다).
+        await this.query('DELETE FROM agent_task_schedule_runs WHERE schedule_id = $1', [id])
+            .catch(() => { /* 068 미적용 배포 호환 */ });
+    }
+
+    /** 발화 이력 기록(6-2) — tick 1회 발화당 1행. 기록 실패는 발화를 막지 않는다(호출부 catch). */
+    async recordRun(p: { scheduleId: string; userId?: string; taskId?: string; outcome: 'fired' | 'error'; error?: string }): Promise<void> {
+        await this.query(
+            `INSERT INTO agent_task_schedule_runs (schedule_id, user_id, task_id, outcome, error)
+             VALUES ($1, $2, $3, $4, $5)`,
+            [p.scheduleId, p.userId ?? null, p.taskId ?? null, p.outcome, p.error ?? null],
+        );
+    }
+
+    /** 발화 이력 조회(최신순, 6-2). */
+    async listRuns(scheduleId: string, limit = 20): Promise<Array<{
+        id: number; schedule_id: string; task_id?: string | null; outcome: string; error?: string | null; created_at: string;
+    }>> {
+        const r = await this.query<{ id: number; schedule_id: string; task_id?: string | null; outcome: string; error?: string | null; created_at: string }>(
+            `SELECT id, schedule_id, task_id, outcome, error, created_at
+             FROM agent_task_schedule_runs WHERE schedule_id = $1 ORDER BY created_at DESC LIMIT $2`,
+            [scheduleId, limit],
+        );
+        return r.rows;
     }
 }

--- a/apps/api/src/data/repositories/agent-task-template-repository.ts
+++ b/apps/api/src/data/repositories/agent-task-template-repository.ts
@@ -1,0 +1,84 @@
+/**
+ * @module data/repositories/agent-task-template-repository
+ * @description `agent_task_templates` 테이블 데이터 접근 (Phase 6-1 작업 템플릿).
+ *
+ * goal 템플릿({{param}} 치환) CRUD. schedule-repository 처럼 unified-database facade 없이
+ * 직접 사용(getPool() 주입 — facade 팽창 회피).
+ */
+import { BaseRepository } from './base-repository';
+
+export interface TemplateParamDef {
+    name: string;
+    description?: string;
+    default?: string;
+}
+
+export interface AgentTaskTemplate {
+    id: string;
+    user_id?: string;
+    name: string;
+    goal_template: string;
+    params?: TemplateParamDef[] | null;
+    max_turns: number;
+    created_at: string;
+    updated_at: string;
+}
+
+export class AgentTaskTemplateRepository extends BaseRepository {
+    async create(p: {
+        id: string; userId: string; name: string; goalTemplate: string;
+        params?: TemplateParamDef[]; maxTurns: number;
+    }): Promise<void> {
+        await this.query(
+            `INSERT INTO agent_task_templates (id, user_id, name, goal_template, params, max_turns)
+             VALUES ($1, $2, $3, $4, $5, $6)`,
+            [p.id, p.userId, p.name, p.goalTemplate, p.params ? JSON.stringify(p.params) : null, p.maxTurns],
+        );
+    }
+
+    async get(id: string): Promise<AgentTaskTemplate | undefined> {
+        const r = await this.query<AgentTaskTemplate>('SELECT * FROM agent_task_templates WHERE id = $1', [id]);
+        return r.rows[0];
+    }
+
+    async listByUser(userId: string): Promise<AgentTaskTemplate[]> {
+        const r = await this.query<AgentTaskTemplate>(
+            'SELECT * FROM agent_task_templates WHERE user_id = $1 ORDER BY updated_at DESC', [userId]);
+        return r.rows;
+    }
+
+    async update(id: string, u: {
+        name?: string; goalTemplate?: string; params?: TemplateParamDef[] | null; maxTurns?: number;
+    }): Promise<void> {
+        const sets: string[] = ['updated_at = NOW()'];
+        const vals: unknown[] = [];
+        let i = 1;
+        if (u.name !== undefined) { sets.push(`name = $${i++}`); vals.push(u.name); }
+        if (u.goalTemplate !== undefined) { sets.push(`goal_template = $${i++}`); vals.push(u.goalTemplate); }
+        if (u.params !== undefined) { sets.push(`params = $${i++}`); vals.push(u.params ? JSON.stringify(u.params) : null); }
+        if (u.maxTurns !== undefined) { sets.push(`max_turns = $${i++}`); vals.push(u.maxTurns); }
+        vals.push(id);
+        await this.query(`UPDATE agent_task_templates SET ${sets.join(', ')} WHERE id = $${i}`, vals as never[]);
+    }
+
+    async delete(id: string): Promise<void> {
+        await this.query('DELETE FROM agent_task_templates WHERE id = $1', [id]);
+    }
+}
+
+/**
+ * PURE: goal 템플릿의 {{name}} 자리를 값으로 치환. 정의 파라미터만 치환하고
+ * 값 미제공 시 default → 그것도 없으면 빈 문자열. 미정의 {{...}} 는 그대로 둔다(오탈자 가시화).
+ */
+export function instantiateGoal(
+    goalTemplate: string,
+    paramDefs: TemplateParamDef[] | null | undefined,
+    values: Record<string, string>,
+): string {
+    let out = goalTemplate;
+    for (const def of paramDefs ?? []) {
+        const v = values[def.name] ?? def.default ?? '';
+        out = out.split(`{{${def.name}}}`).join(v);
+    }
+    return out;
+}

--- a/apps/api/src/routes/agent-task-schedule.routes.ts
+++ b/apps/api/src/routes/agent-task-schedule.routes.ts
@@ -98,6 +98,14 @@ router.patch('/:id', validate(updateAgentTaskScheduleSchema), asyncHandler(async
     res.json(success({ schedule: await repo().get(s.id) }));
 }));
 
+/** GET /:id/runs — 발화 이력(6-2, 최신순 최대 20건). */
+router.get('/:id/runs', asyncHandler(async (req: Request, res: Response) => {
+    const s = await loadOwned(req, res, req.params.id);
+    if (!s) return;
+    const runs = await repo().listRuns(s.id);
+    res.json(success({ runs, total: runs.length }));
+}));
+
 /** DELETE /:id — 스케줄 삭제. */
 router.delete('/:id', asyncHandler(async (req: Request, res: Response) => {
     const s = await loadOwned(req, res, req.params.id);

--- a/apps/api/src/routes/agent-task-template.routes.ts
+++ b/apps/api/src/routes/agent-task-template.routes.ts
@@ -1,0 +1,112 @@
+/**
+ * ============================================================
+ * Agent Task Template Routes — 작업 템플릿 관리 API (Phase 6-1)
+ * ============================================================
+ *
+ * 반복 사용하는 goal 을 파라미터({{name}})와 함께 템플릿으로 저장하고,
+ * instantiate 로 치환해 task 를 생성(기본: 즉시 실행 — 큐 3-B 경유)한다.
+ *
+ * @module routes/agent-task-template.routes
+ * @description
+ * - POST   /api/agent-task-templates                 - 템플릿 생성
+ * - GET    /api/agent-task-templates                 - 내 템플릿 목록
+ * - PATCH  /api/agent-task-templates/:id             - 수정
+ * - DELETE /api/agent-task-templates/:id             - 삭제
+ * - POST   /api/agent-task-templates/:id/instantiate - task 생성(+기본 즉시 실행)
+ */
+import { Router, Request, Response } from 'express';
+import { createLogger } from '../utils/logger';
+import { success, notFound } from '../utils/api-response';
+import { asyncHandler } from '../utils/error-handler';
+import { requireAuth } from '../auth';
+import { assertResourceOwnerOrAdmin } from '../auth/ownership';
+import { validate } from '../middlewares/validation';
+import { getPool, getUnifiedDatabase } from '../data/models/unified-database';
+import { v4 as uuidv4 } from 'uuid';
+import { AgentTaskTemplateRepository, instantiateGoal } from '../data/repositories/agent-task-template-repository';
+import {
+    createAgentTaskTemplateSchema, updateAgentTaskTemplateSchema, instantiateTemplateSchema,
+    type CreateAgentTaskTemplateInput, type UpdateAgentTaskTemplateInput, type InstantiateTemplateInput,
+} from '../schemas/agent-task.schema';
+import { AGENT_TASK_LIMITS } from '../config/runtime-limits';
+import { AgentTaskService } from '../services/AgentTaskService';
+import { dispatchAgentTask } from '../services/agent-task/task-queue';
+
+const logger = createLogger('AgentTaskTemplateRoutes');
+const router = Router();
+router.use(requireAuth);
+
+function repo() { return new AgentTaskTemplateRepository(getPool()); }
+
+async function loadOwned(req: Request, res: Response, id: string) {
+    const t = await repo().get(id);
+    if (!t) { res.status(404).json(notFound('템플릿을 찾을 수 없습니다.')); return undefined; }
+    assertResourceOwnerOrAdmin(String(t.user_id), String(req.user!.id), req.user!.role || 'user');
+    return t;
+}
+
+/** POST / — 템플릿 생성. */
+router.post('/', validate(createAgentTaskTemplateSchema), asyncHandler(async (req: Request, res: Response) => {
+    const { name, goalTemplate, params, maxTurns } = req.body as CreateAgentTaskTemplateInput;
+    const id = uuidv4();
+    await repo().create({
+        id, userId: String(req.user!.id), name, goalTemplate,
+        params, maxTurns: maxTurns ?? AGENT_TASK_LIMITS.DEFAULT_MAX_TURNS,
+    });
+    logger.info(`[Template] 생성: ${id} (user ${req.user!.id})`);
+    res.status(201).json(success({ template: await repo().get(id) }));
+}));
+
+/** GET / — 내 템플릿 목록. */
+router.get('/', asyncHandler(async (req: Request, res: Response) => {
+    const templates = await repo().listByUser(String(req.user!.id));
+    res.json(success({ templates, total: templates.length }));
+}));
+
+/** PATCH /:id — 수정. */
+router.patch('/:id', validate(updateAgentTaskTemplateSchema), asyncHandler(async (req: Request, res: Response) => {
+    const t = await loadOwned(req, res, req.params.id);
+    if (!t) return;
+    const b = req.body as UpdateAgentTaskTemplateInput;
+    await repo().update(t.id, { name: b.name, goalTemplate: b.goalTemplate, params: b.params, maxTurns: b.maxTurns });
+    res.json(success({ template: await repo().get(t.id) }));
+}));
+
+/** DELETE /:id — 삭제. */
+router.delete('/:id', asyncHandler(async (req: Request, res: Response) => {
+    const t = await loadOwned(req, res, req.params.id);
+    if (!t) return;
+    await repo().delete(t.id);
+    res.json(success({ message: '템플릿이 삭제되었습니다.', id: t.id }));
+}));
+
+/**
+ * POST /:id/instantiate — 파라미터 치환으로 task 생성. execute!==false 면 즉시 실행(큐 3-B 경유).
+ */
+router.post('/:id/instantiate', validate(instantiateTemplateSchema), asyncHandler(async (req: Request, res: Response) => {
+    const t = await loadOwned(req, res, req.params.id);
+    if (!t) return;
+    const { values, execute } = req.body as InstantiateTemplateInput;
+    const goal = instantiateGoal(t.goal_template, t.params, values ?? {});
+
+    const db = getUnifiedDatabase();
+    const taskId = uuidv4();
+    const userId = String(req.user!.id);
+    await db.createAgentTask({ id: taskId, userId, goal, maxTurns: t.max_turns });
+
+    let queued = false;
+    if (execute !== false) {
+        const role = (req.user!.role as 'admin' | 'user' | 'guest') || 'user';
+        const service = new AgentTaskService();
+        const outcome = await dispatchAgentTask({
+            taskId, userId,
+            run: () => service.execute({ taskId, goal, userId, userRole: role, maxTurns: t.max_turns }),
+        });
+        queued = outcome === 'queued';
+    }
+    logger.info(`[Template] instantiate: ${t.id} → task ${taskId} (execute=${execute !== false})`);
+    res.status(201).json(success({ taskId, goal, queued, executed: execute !== false }));
+}));
+
+export { router as agentTaskTemplateRouter };
+export default router;

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -35,6 +35,7 @@ export { default as auditRouter } from './audit.routes';
 export { default as researchRouter } from './research.routes';
 export { default as agentTaskRouter } from './agent-task.routes';
 export { default as agentTaskScheduleRouter } from './agent-task-schedule.routes';
+export { default as agentTaskTemplateRouter } from './agent-task-template.routes';
 export { default as agentSuggestionsRouter } from './agent-suggestions.routes';
 export { default as externalRouter } from './external.routes';
 // 🆕 Artifacts (2026-05-26 Phase 1): claude.ai-style 산출물 영속화

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -42,6 +42,7 @@ import {
     researchRouter,
     agentTaskRouter,
     agentTaskScheduleRouter,
+    agentTaskTemplateRouter,
     agentSuggestionsRouter,
     externalRouter,
     pushRouter,
@@ -243,6 +244,7 @@ export function setupApiRoutes(
     app.use('/api/research', researchRouter);
     app.use('/api/agent-tasks', agentTaskRouter);
     app.use('/api/agent-task-schedules', agentTaskScheduleRouter);
+    app.use('/api/agent-task-templates', agentTaskTemplateRouter);
     app.use('/api/external', externalRouter);
     app.use('/api/push', pushRouter);
     app.use('/api/docs', developerDocsRouter);

--- a/apps/api/src/schemas/agent-task.schema.ts
+++ b/apps/api/src/schemas/agent-task.schema.ts
@@ -69,3 +69,31 @@ export const updateAgentTaskScheduleSchema = z.object({
 
 export type CreateAgentTaskScheduleInput = z.infer<typeof createAgentTaskScheduleSchema>;
 export type UpdateAgentTaskScheduleInput = z.infer<typeof updateAgentTaskScheduleSchema>;
+
+/** 템플릿 파라미터 정의(6-1) — {{name}} 자리 치환. */
+const templateParamSchema = z.object({
+    name: z.string().min(1).max(50).regex(/^[A-Za-z0-9_가-힣-]+$/, '파라미터 이름은 영숫자·한글·_·- 만 허용'),
+    description: z.string().max(200).optional(),
+    default: z.string().max(500).optional(),
+});
+
+/** 작업 템플릿 생성 스키마(6-1). goal_template 은 secureText(HTML 태그 금지 등) 적용. */
+export const createAgentTaskTemplateSchema = z.object({
+    name: z.string().min(1).max(100),
+    goalTemplate: secureTextSchema({ minLength: 1, maxLength: 2000, fieldName: 'goalTemplate', detectMaliciousPatterns: false }),
+    params: z.array(templateParamSchema).max(10).optional(),
+    maxTurns: z.number().int().min(1).max(AGENT_TASK_LIMITS.MAX_TURNS_CEILING).optional(),
+});
+
+export const updateAgentTaskTemplateSchema = createAgentTaskTemplateSchema.partial();
+
+/** 템플릿 instantiate 입력 — 파라미터 값 맵. */
+export const instantiateTemplateSchema = z.object({
+    values: z.record(z.string(), z.string().max(2000)).optional(),
+    /** true(기본): 생성 즉시 실행(큐 경유). false: 생성만. */
+    execute: z.boolean().optional(),
+});
+
+export type CreateAgentTaskTemplateInput = z.infer<typeof createAgentTaskTemplateSchema>;
+export type UpdateAgentTaskTemplateInput = z.infer<typeof updateAgentTaskTemplateSchema>;
+export type InstantiateTemplateInput = z.infer<typeof instantiateTemplateSchema>;

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -41,18 +41,12 @@ import { persistArtifactSteps, runTool, isSearchTool } from './agent-task/task-s
 import { assembleAgentTools } from './agent-task/tool-assembly';
 import { verifyCodeArtifacts } from './agent-task/deliverable-verify';
 import { buildLearningBlock } from './agent-task/task-learning';
+import { buildSkillPromptBlock, AGENT_TASK_SKILL_AGENT_ID } from './agent-task/skill-block';
 
 // 기존 import 호환 재노출 — 타입/에러는 services/agent-task/types 로 분리 (파일 크기 가드).
 export { AgentTaskAbort, type AgentTaskRunInput, type AgentTaskInputFile } from './agent-task/types';
 
 const logger = createLogger('AgentTaskService');
-
-/**
- * Agent Task 는 페르소나/산업 agent 를 우회하므로 고유 agentId 가 없다.
- * 스킬 스코프 조회 시 어떤 실제 agent_id(산업 agent id · uuid · __global__ · user:*)
- * 와도 겹치지 않는 sentinel 을 넘겨, __global__ + user:{userId} 스킬만 매칭시킨다.
- */
-const AGENT_TASK_SKILL_AGENT_ID = '__agent_task__';
 
 export class AgentTaskService {
     /** 실행 중 인스턴스 레지스트리 — detached 실행을 cancel 엔드포인트에서 중단하기 위함 */
@@ -160,7 +154,7 @@ export class AgentTaskService {
                     {
                         role: 'system',
                         content: getAgentTaskSystemPrompt()
-                            + (await this.buildSkillPromptBlock(userId))
+                            + (await buildSkillPromptBlock(userId))
                             + (await buildLearningBlock(userId, goal, taskId)),
                     },
                     { role: 'user', content: goal },
@@ -503,6 +497,14 @@ export class AgentTaskService {
                         content: toolResult,
                     });
                     emitStep('tool_result', name, toolResult);
+                    // 턴 중간 체크포인트(6-4, opt-in): 도구 결과 단위로 저장 — 이 시점 conversation 은
+                    // assistant(tool_calls)+실행된 tool 결과들로 유효하며, resume 이 같은 턴(fromTurn=turn)
+                    // 에서 LLM 호출로 자연 이어져 이미 실행된 도구(특히 write)를 재실행하지 않는다.
+                    if (AGENT_TASK_LIMITS.MIDTURN_CHECKPOINT_ENABLED) {
+                        await db.updateAgentTask(taskId, {
+                            checkpoint: { conversation, completedTurn: turn - 1 },
+                        }).catch(() => { /* checkpoint 실패는 실행을 막지 않음 */ });
+                    }
                 }
 
                 // terminate 도구 호출 — 깔끔한 완료 시그널(max_turns 소진 아님).
@@ -578,21 +580,6 @@ export class AgentTaskService {
         }
         if (totalTokens > AGENT_TASK_LIMITS.MAX_TOTAL_TOKENS) {
             throw new AgentTaskAbort('token_limit');
-        }
-    }
-
-    /**
-     * 활성 스킬(global + user)의 prompt_md 지식 블록을 만든다.
-     * execute 의 status 머신(try)이 켜지기 전에 호출되므로 절대 throw 하지 않는다 —
-     * 실패/부재 시 '' 를 반환해 task row 가 stuck 되지 않게 한다.
-     */
-    private async buildSkillPromptBlock(userId: string): Promise<string> {
-        try {
-            const block = await getSkillManager().buildManifestPrompt(AGENT_TASK_SKILL_AGENT_ID, userId);
-            return block ?? '';
-        } catch (e) {
-            logger.debug('[AgentTask] 스킬 프롬프트 주입 실패 — 무시', e);
-            return '';
         }
     }
 

--- a/apps/api/src/services/agent-task/schedule-runner.ts
+++ b/apps/api/src/services/agent-task/schedule-runner.ts
@@ -13,6 +13,7 @@ import { AgentTaskScheduleRepository, type AgentTaskSchedule } from '../../data/
 import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
 import { createLogger } from '../../utils/logger';
 import { AgentTaskService } from '../AgentTaskService';
+import { getPushService } from '../PushService';
 import { dispatchAgentTask } from './task-queue';
 import { computeNextRun } from './schedule-cron';
 import type { AgentTaskUserRole } from './types';
@@ -50,12 +51,25 @@ async function fireSchedule(repo: AgentTaskScheduleRepository, s: AgentTaskSched
             }),
         });
         await repo.markRun(s.id, nextRunAtMs, taskId);
+        // 발화 이력(6-2) — 실패해도 발화 자체를 막지 않음.
+        await repo.recordRun({ scheduleId: s.id, userId: s.user_id, taskId, outcome: 'fired' }).catch(() => { /* noop */ });
         logger.info(`[Schedule] 실행: ${s.id} → task ${taskId} (next=${nextRunAtMs ? new Date(nextRunAtMs).toISOString() : '비활성'})`);
     } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
         // 실패 시 next_run_at 을 앞으로 밀어 무한 재시도 방지 + 연속실패 집계.
         await repo.markFailure(s.id, nextRunAtMs, AGENT_TASK_LIMITS.SCHEDULE_DISABLE_AFTER_FAILURES)
             .catch(() => { /* noop */ });
-        logger.warn(`[Schedule] 실행 실패: ${s.id} — ${e instanceof Error ? e.message : e}`);
+        await repo.recordRun({ scheduleId: s.id, userId: s.user_id, outcome: 'error', error: msg.slice(0, 500) }).catch(() => { /* noop */ });
+        // 실패 알림(6-2) — 스케줄은 사용자가 안 보는 새 도는 백그라운드라 push 로 인지시킨다.
+        // 연속실패 임계 도달(자동 비활성) 여부를 함께 알린다. fire-and-forget.
+        const failures = (s.consecutive_failures ?? 0) + 1;
+        const disabled = failures >= AGENT_TASK_LIMITS.SCHEDULE_DISABLE_AFTER_FAILURES;
+        void getPushService().sendPush(String(s.user_id), {
+            title: 'OpenMake 예약 작업 실패',
+            body: `예약 실행이 실패했습니다(연속 ${failures}회${disabled ? ' — 예약 자동 비활성됨' : ''}): ${s.goal.slice(0, 50)}`,
+            url: '/agent-tasks',
+        }).catch(() => { /* noop */ });
+        logger.warn(`[Schedule] 실행 실패: ${s.id} — ${msg}`);
     }
 }
 

--- a/apps/api/src/services/agent-task/skill-block.ts
+++ b/apps/api/src/services/agent-task/skill-block.ts
@@ -1,0 +1,30 @@
+/**
+ * Agent Task 스킬 프롬프트 블록 — AgentTaskService 에서 분리 (파일 크기 가드).
+ * @module services/agent-task/skill-block
+ */
+import { getSkillManager } from '../../agents/skill-manager';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('AgentTaskService');
+
+/**
+ * Agent Task 는 페르소나/산업 agent 를 우회하므로 고유 agentId 가 없다.
+ * 스킬 스코프 조회 시 어떤 실제 agent_id(산업 agent id · uuid · __global__ · user:*)
+ * 와도 겹치지 않는 sentinel 을 넘겨, __global__ + user:{userId} 스킬만 매칭시킨다.
+ */
+export const AGENT_TASK_SKILL_AGENT_ID = '__agent_task__';
+
+/**
+ * 활성 스킬(global + user)의 prompt_md 지식 블록을 만든다.
+ * execute 의 status 머신(try)이 켜지기 전에 호출되므로 절대 throw 하지 않는다 —
+ * 실패/부재 시 '' 를 반환해 task row 가 stuck 되지 않게 한다.
+ */
+export async function buildSkillPromptBlock(userId: string): Promise<string> {
+    try {
+        const block = await getSkillManager().buildManifestPrompt(AGENT_TASK_SKILL_AGENT_ID, userId);
+        return block ?? '';
+    } catch (e) {
+        logger.debug('[AgentTask] 스킬 프롬프트 주입 실패 — 무시', e);
+        return '';
+    }
+}

--- a/apps/web/app/(workspace)/agent-tasks/page.tsx
+++ b/apps/web/app/(workspace)/agent-tasks/page.tsx
@@ -16,6 +16,7 @@ import {
   CalendarClock,
   Plus,
   Play,
+  FileStack,
 } from "lucide-react";
 import {
   Button,
@@ -690,6 +691,107 @@ function SchedulesPanel() {
   );
 }
 
+/* ── 작업 템플릿 패널 (Phase 6-1) ───────────────────────────── */
+interface ApiTemplate {
+  id: string;
+  name: string;
+  goal_template: string;
+  params?: Array<{ name: string; description?: string; default?: string }> | null;
+  max_turns: number;
+}
+type TemplatesResponse = ApiSuccess<{ templates: ApiTemplate[]; total: number }>;
+
+function TemplatesPanel() {
+  const t = useTranslations("agentTasks");
+  const [templates, setTemplates] = useState<ApiTemplate[]>([]);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [goal, setGoal] = useState("");
+
+  const load = useCallback(async () => {
+    try {
+      const r = await ApiClient.get<TemplatesResponse>("/api/agent-task-templates");
+      setTemplates(r?.data?.templates ?? []);
+    } catch { /* 401·미배포: 빈 목록 */ }
+  }, []);
+  useEffect(() => { load(); }, [load]);
+
+  async function run(id: string, fn: () => Promise<unknown>) {
+    setBusy(id);
+    try { await fn(); await load(); }
+    catch (err) { alert(t("processFailed", { message: err instanceof Error ? err.message : t("error") })); }
+    finally { setBusy(null); }
+  }
+
+  const create = () => run("new", async () => {
+    await ApiClient.post("/api/agent-task-templates", { name, goalTemplate: goal });
+    setName(""); setGoal(""); setOpen(false);
+  });
+  const instantiate = (tp: ApiTemplate) => run(tp.id, async () => {
+    await ApiClient.post(`/api/agent-task-templates/${tp.id}/instantiate`, {});
+    alert(t("templates.started"));
+  });
+  const remove = (tp: ApiTemplate) => run(tp.id, () => ApiClient.del(`/api/agent-task-templates/${tp.id}`));
+
+  return (
+    <Card className="mb-4 p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <p className="flex items-center gap-1.5 text-sm font-medium text-fg-2">
+          <FileStack className="h-4 w-4 text-accent" /> {t("templates.title")}
+        </p>
+        <Button size="sm" variant="outline" onClick={() => setOpen((v) => !v)}>
+          <Plus className="h-3.5 w-3.5" /> {t("templates.create")}
+        </Button>
+      </div>
+      {open && (
+        <div className="mb-3 space-y-2 rounded-md border border-line bg-bg-1 p-3">
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder={t("templates.namePlaceholder")}
+            className="w-full rounded-md border border-line bg-bg-2 px-2 py-1.5 text-sm text-fg-1"
+          />
+          <textarea
+            value={goal}
+            onChange={(e) => setGoal(e.target.value)}
+            placeholder={t("templates.goalPlaceholder")}
+            rows={2}
+            className="w-full resize-y rounded-md border border-line bg-bg-2 p-2 text-sm text-fg-1"
+          />
+          <div className="flex justify-end">
+            <Button size="sm" disabled={busy === "new" || !name.trim() || !goal.trim()} onClick={create}>
+              {t("templates.add")}
+            </Button>
+          </div>
+        </div>
+      )}
+      {templates.length === 0 ? (
+        <p className="text-xs text-muted">{t("templates.empty")}</p>
+      ) : (
+        <div className="space-y-2">
+          {templates.map((tp) => (
+            <div key={tp.id} className="flex items-center justify-between gap-3 rounded-md border border-line bg-bg-1 p-2">
+              <div className="min-w-0">
+                <p className="truncate text-xs font-medium text-fg-1">{tp.name}</p>
+                <p className="truncate text-xs text-muted">{tp.goal_template}</p>
+              </div>
+              <div className="flex shrink-0 gap-1">
+                <Button size="sm" variant="outline" disabled={busy === tp.id} onClick={() => instantiate(tp)} title={t("templates.run")}>
+                  <Play className="h-3.5 w-3.5" />
+                </Button>
+                <Button size="sm" variant="outline" disabled={busy === tp.id} onClick={() => remove(tp)} title={t("templates.delete")}>
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}
+
 export default function AgentTasksPage() {
   const t = useTranslations("agentTasks");
   const router = useRouter();
@@ -777,6 +879,7 @@ export default function AgentTasksPage() {
         </Card>
         <ApprovalsPanel />
         <SchedulesPanel />
+        <TemplatesPanel />
         {loading ? (
           <div className="grid place-items-center py-24 text-center">
             <Sparkles className="mb-3 h-8 w-8 animate-pulse text-faint" />

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -696,7 +696,18 @@
     "autoApprove": "Approve rest",
     "autoApproveHint": "Run remaining tool calls of this task without approval (questions excluded)",
     "tokensUsed": "{count} tokens",
-    "tokensUsedHint": "Total LLM tokens used by this task"
+    "tokensUsedHint": "Total LLM tokens used by this task",
+    "templates": {
+      "title": "Task templates",
+      "create": "New template",
+      "namePlaceholder": "Template name",
+      "goalPlaceholder": "Goal template… ({{param}} supported)",
+      "add": "Add",
+      "empty": "No templates yet.",
+      "run": "Run from this template",
+      "delete": "Delete",
+      "started": "Task started from template."
+    }
   },
   "customAgents": {
     "pageTitle": "Custom Agents",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -696,7 +696,18 @@
     "autoApprove": "残りをすべて承認",
     "autoApproveHint": "このタスクの以降のツール実行を承認なしで進めます（質問は除く）",
     "tokensUsed": "{count} トークン",
-    "tokensUsedHint": "このタスクが使用した累計LLMトークン"
+    "tokensUsedHint": "このタスクが使用した累計LLMトークン",
+    "templates": {
+      "title": "タスクテンプレート",
+      "create": "新規テンプレート",
+      "namePlaceholder": "テンプレート名",
+      "goalPlaceholder": "目標テンプレート… ({{パラメータ}} 使用可)",
+      "add": "追加",
+      "empty": "テンプレートはありません。",
+      "run": "このテンプレートで実行",
+      "delete": "削除",
+      "started": "テンプレートからタスクを開始しました。"
+    }
   },
   "customAgents": {
     "pageTitle": "カスタムエージェント",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -696,7 +696,18 @@
     "autoApprove": "나머지 모두 승인",
     "autoApproveHint": "이 작업의 이후 도구 실행을 승인 없이 진행합니다 (질문 제외)",
     "tokensUsed": "{count} 토큰",
-    "tokensUsedHint": "이 작업이 사용한 누적 LLM 토큰"
+    "tokensUsedHint": "이 작업이 사용한 누적 LLM 토큰",
+    "templates": {
+      "title": "작업 템플릿",
+      "create": "새 템플릿",
+      "namePlaceholder": "템플릿 이름",
+      "goalPlaceholder": "작업 목표 템플릿… ({{파라미터}} 사용 가능)",
+      "add": "추가",
+      "empty": "등록된 템플릿이 없습니다.",
+      "run": "이 템플릿으로 실행",
+      "delete": "삭제",
+      "started": "템플릿으로 작업을 시작했습니다."
+    }
   },
   "customAgents": {
     "pageTitle": "커스텀 에이전트",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -696,7 +696,18 @@
     "autoApprove": "批准其余全部",
     "autoApproveHint": "此任务后续的工具调用将无需批准直接执行（提问除外）",
     "tokensUsed": "{count} 令牌",
-    "tokensUsedHint": "此任务累计使用的LLM令牌"
+    "tokensUsedHint": "此任务累计使用的LLM令牌",
+    "templates": {
+      "title": "任务模板",
+      "create": "新建模板",
+      "namePlaceholder": "模板名称",
+      "goalPlaceholder": "目标模板…（支持 {{参数}}）",
+      "add": "添加",
+      "empty": "暂无模板。",
+      "run": "使用此模板运行",
+      "delete": "删除",
+      "started": "已从模板启动任务。"
+    }
   },
   "customAgents": {
     "pageTitle": "自定义智能体",

--- a/db/migrations/067_agent_task_templates.sql
+++ b/db/migrations/067_agent_task_templates.sql
@@ -1,0 +1,22 @@
+-- 067: Agent Task 템플릿 (Phase 6-1)
+--
+-- 반복 사용하는 작업 goal 을 파라미터({{name}})와 함께 템플릿으로 저장하고,
+-- instantiate 로 파라미터를 치환해 task 를 생성한다. 스케줄과 별개(스케줄은 확정 goal 보관).
+-- 멱등(IF NOT EXISTS). 수동 적용(cli.ts migrate).
+
+CREATE TABLE IF NOT EXISTS agent_task_templates (
+    id TEXT PRIMARY KEY,
+    user_id TEXT REFERENCES users(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    -- goal 본문. {{param}} 자리는 instantiate 시 치환.
+    goal_template TEXT NOT NULL,
+    -- 파라미터 정의 [{name, description?, default?}] — UI 폼 렌더·기본값 채움용.
+    params JSONB,
+    max_turns INTEGER DEFAULT 10,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_task_templates_user ON agent_task_templates(user_id);
+
+COMMENT ON TABLE agent_task_templates IS 'Agent Task goal 템플릿({{param}} 치환) — instantiate 로 task 생성.';

--- a/db/migrations/068_agent_task_schedule_runs.sql
+++ b/db/migrations/068_agent_task_schedule_runs.sql
@@ -1,0 +1,21 @@
+-- 068: Agent Task 스케줄 실행 이력 (Phase 6-2)
+--
+-- 스케줄 tick 이 발화할 때마다 1행 기록 — "언제 돌았고 어떤 task 가 만들어졌고 성공/실패였나"를
+-- 스케줄 단위로 추적한다(기존엔 last_task_id 1개만 남아 이력 소실). 실패 시 web push 알림과 페어.
+-- 멱등(IF NOT EXISTS). 수동 적용(cli.ts migrate).
+
+CREATE TABLE IF NOT EXISTS agent_task_schedule_runs (
+    id SERIAL PRIMARY KEY,
+    schedule_id TEXT NOT NULL,
+    user_id TEXT,
+    -- 발화가 만든 task (생성 실패 시 NULL + error 기록)
+    task_id TEXT,
+    -- fired: task 생성·큐 제출 성공 / error: 생성·제출 실패
+    outcome TEXT NOT NULL CHECK (outcome IN ('fired', 'error')),
+    error TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_schedule_runs_schedule ON agent_task_schedule_runs(schedule_id, created_at DESC);
+
+COMMENT ON TABLE agent_task_schedule_runs IS '스케줄 발화 이력 — tick 1회 발화당 1행(fired/error).';


### PR DESCRIPTION
## 개요

Agent Task **Phase 6 — 제품화**. 라이브 검증 완료, 신규 플래그는 opt-in.

## 변경 내용

### 6-1 작업 템플릿 (마이그 067)
- goal 템플릿(`{{param}}` 치환, default 지원) 저장 → `POST /:id/instantiate`로 task 생성(+기본 즉시 실행, 큐 3-B 경유)
- CRUD API + agent-tasks 페이지 **템플릿 패널**(생성·실행·삭제), i18n 4로케일
- **라이브**: `{{city}}`→"부산" 치환 → task 완주 → 정리

### 6-2 스케줄 실행 이력 + 실패 알림 (마이그 068)
- 발화당 1행(`fired`/`error`) 기록 — `last_task_id` 1개만 남아 이력 소실되던 문제 해소. `GET /:id/runs`
- 발화 실패 시 **web push**(연속실패 횟수·자동 비활성 여부 포함)
- **라이브**: /run → `outcome=fired`+task_id → 스케줄발 task 완주

### 6-4 턴 중간 체크포인트 (`AGENT_TASK_MIDTURN_CHECKPOINT`, 기본 off)
- 도구 결과 단위로도 checkpoint 저장 — 턴 중간 재시작 시 이미 실행된 도구(특히 write) 재실행 방지
- **라이브**: 플래그 ON 무회귀 완주

### 6-3 산출물 자동 게시 — 의도적 보류
게시는 외부 공개 행위라 **명시적 사용자 액션**(기존 수동 공유 뷰어 경로)을 유지하는 것이 안전하다고 판단.

### 기타
- 파일 크기 가드: skill-block 추출(AgentTaskService 586줄)
- `.env.example` 보충

## 검증
- ✅ 라이브(6-1 치환·완주 / 6-2 이력·push 배선 / 6-4 무회귀), 플래그·테스트 데이터 원복/정리
- ✅ 유닛 108 pass · api/web tsc 0 · lint 0 error · Gate 3 통과

## 배포 시
```bash
npx ts-node apps/api/src/data/migrations/cli.ts migrate   # 067, 068 (이 서버엔 적용됨)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
