### PR TITLE
feat(chat): 채팅 서브에이전트 — delegate_expert 전문가 위임

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -760,6 +760,11 @@ AGENT_TASK_TIMEOUT_MS=600000
 # Agent Task — 턴 중간 체크포인트 (도구 결과 단위 저장 — write 도구 재실행 방지 강화). 기본 OFF.
 # AGENT_TASK_MIDTURN_CHECKPOINT=true
 
+# 채팅 서브에이전트 — 채팅 도구 루프에 delegate_expert(전문가 위임 depth=1 tool-loop) 노출. 기본 OFF.
+# 위임 1회 = 서브 LLM 최대 3턴이라 응답 지연 증가 — 발동률·지연 관찰 후 조정 권장.
+# CHAT_SUBAGENT_ENABLED=true
+# CHAT_SUBAGENT_MAX_CALLS=1
+
 # 첨부 이미지 캡 (에이전트 작업 REST 생성 경로 — composer MAX_IMAGES 와 페어)
 # FILE_ATTACH_MAX_IMAGES=20
 # FILE_ATTACH_MAX_IMAGE_DATAURL_CHARS=20000000   # dataURL 최대 글자 (base64 = 원본의 4/3)

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1316,3 +1316,11 @@ export const AGENT_TASK_LIMITS = {
     MIDTURN_CHECKPOINT_ENABLED: process.env.AGENT_TASK_MIDTURN_CHECKPOINT === 'true',
 } as const;
 
+/** 채팅 서브에이전트(delegate_expert) — 채팅 도구 루프에서 전문가 위임(depth=1 tool-loop). */
+export const CHAT_SUBAGENT = {
+    /** 기본 OFF — 지연(위임 1회 = 서브 LLM 최대 3턴) UX 영향을 관찰 후 조정. CHAT_SUBAGENT_ENABLED=true. */
+    ENABLED: process.env.CHAT_SUBAGENT_ENABLED === 'true',
+    /** 메시지당 위임 호출 캡(남용·지연 억제, 기본 1). CHAT_SUBAGENT_MAX_CALLS. */
+    MAX_CALLS: parseInt(process.env.CHAT_SUBAGENT_MAX_CALLS || '1', 10),
+} as const;
+

--- a/apps/api/src/services/agent-task/subagent.ts
+++ b/apps/api/src/services/agent-task/subagent.ts
@@ -34,8 +34,10 @@ export interface SubagentParams {
     /** 안전 도구 서브셋 — 부모의 호스트 화이트리스트(extraTools). delegate 류는 호출부가 제외. */
     tools: ToolDefinition[];
     userCtx: UserContext;
+    /** 승인 레지스트리 키(에이전트 작업 taskId). 채팅 경로는 정책 'none' 이라 실사용 안 됨. */
     taskId: string;
-    sandboxCfg: TaskSandboxConfig;
+    /** 승인 정책·대기 상한만 사용 — 채팅 경로는 {approvalPolicy:'none', approvalTimeoutMs:0} 전달. */
+    sandboxCfg: Pick<TaskSandboxConfig, 'approvalPolicy' | 'approvalTimeoutMs'>;
     signal?: AbortSignal;
     /** 서브 LLM 호출 토큰을 부모 누적에 합산. */
     onTokens?: (n: number) => void;

--- a/apps/api/src/services/chat-service/chat-delegate.ts
+++ b/apps/api/src/services/chat-service/chat-delegate.ts
@@ -1,0 +1,93 @@
+/**
+ * 채팅 서브에이전트 위임 (chat-subagent) — agent task 의 delegate(5-1)를 채팅 경로로 확장.
+ *
+ * 채팅 도구 루프(external-provider)에 `delegate_expert` 도구를 노출하고, 호출 시
+ * 전문가 페르소나 + **이 채팅에서 이미 활성화된 도구 서브셋**으로 depth=1 미니 tool-loop
+ * (agent-task/subagent 재사용)를 실행해 결과를 도구 결과로 반환한다.
+ *
+ * 안전 원칙:
+ *  - 서브 도구 = 부모 채팅이 이미 실행 가능한 도구만(자기 자신 제외) — 권한 증분 0.
+ *  - 승인 정책 'none' 고정 — 채팅 도구는 원래 승인 없이 실행되는 모델과 정합
+ *    (승인 레지스트리를 아예 타지 않음 → agent task HITL 과 간섭 없음).
+ *  - 메시지당 호출 캡(CHAT_SUBAGENT.MAX_CALLS, 기본 1) — 지연·남용 억제(호출부가 집계).
+ *  - 서브 LLM 은 항상 로컬 모델(createClient) — 외부 provider 채팅이어도 위임 비용은 로컬.
+ *
+ * @module services/chat-service/chat-delegate
+ */
+import { createClient } from '../../llm';
+import type { ToolDefinition } from '../../llm/types';
+import type { UserContext } from '../../mcp/user-sandbox';
+import { getModelForRole } from '../../config/model-roles';
+import { routeToAgent } from '../../agents/keyword-router';
+import { getAgentSystemMessage } from '../../agents/system-prompt';
+import { runSubagent } from '../agent-task/subagent';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('ChatDelegate');
+
+/** 채팅 위임 도구 이름 — agent task 샌드박스의 'delegate' 와 분리(카탈로그 충돌·혼동 방지). */
+export const CHAT_DELEGATE_TOOL_NAME = 'delegate_expert';
+
+/** PURE: 채팅 도구 루프에 노출할 delegate_expert 도구 정의. */
+export function buildChatDelegateTool(): ToolDefinition {
+    return {
+        type: 'function',
+        function: {
+            name: CHAT_DELEGATE_TOOL_NAME,
+            description: '전문 지식·판단이 필요한 하위 질의를 해당 분야 전문가(금융/법률/의료/엔지니어링 등)에게 '
+                + '위임합니다. 전문가는 필요한 도구(검색 등)를 직접 사용해 조사한 결과를 반환합니다. '
+                + '⚠️ 일반 상식·단순 질문에는 쓰지 말고 직접 답하세요 — 전문 검토가 답변 품질을 실제로 바꾸는 '
+                + '경우에만 사용합니다(응답 시간이 늘어납니다).',
+            parameters: {
+                type: 'object',
+                properties: {
+                    subgoal: { type: 'string', description: '전문가에게 위임할 구체적 하위 질의' },
+                    role: { type: 'string', description: '원하는 전문 분야(선택, 예: finance/legal/medical)' },
+                },
+                required: ['subgoal'],
+            },
+        },
+    };
+}
+
+/** PURE: 서브에이전트에 넘길 도구 서브셋 — 부모 채팅 활성 도구에서 자기 자신만 제외. */
+export function buildSubagentTools(chatTools: ToolDefinition[]): ToolDefinition[] {
+    return chatTools.filter((t) => t.function.name !== CHAT_DELEGATE_TOOL_NAME);
+}
+
+/**
+ * delegate_expert 실행 — 실패는 문자열로 흡수(채팅 루프를 죽이지 않음).
+ */
+export async function runChatDelegate(params: {
+    args: Record<string, unknown>;
+    /** 부모 채팅의 활성 도구(자기 자신 포함 가능 — 내부에서 제외). */
+    chatTools: ToolDefinition[];
+    userCtx: UserContext;
+    signal?: AbortSignal;
+}): Promise<string> {
+    const subgoal = String(params.args.subgoal ?? '').trim();
+    if (!subgoal) return 'Error: subgoal 이 필요합니다.';
+    const role = typeof params.args.role === 'string' ? params.args.role : undefined;
+    try {
+        const selection = await routeToAgent(role ? `[${role}] ${subgoal}` : subgoal);
+        const { prompt } = await getAgentSystemMessage(selection, String(params.userCtx.userId));
+        const started = Date.now();
+        const result = await runSubagent({
+            client: createClient({ model: getModelForRole('chat') }),
+            personaPrompt: prompt,
+            subgoal,
+            tools: buildSubagentTools(params.chatTools),
+            userCtx: params.userCtx,
+            taskId: '__chat__', // 정책 'none' 이라 승인 레지스트리 미사용 — 식별용 문자열일 뿐
+            sandboxCfg: { approvalPolicy: 'none', approvalTimeoutMs: 0 },
+            signal: params.signal,
+            onTokens: (n) => logger.debug(`[ChatDelegate] 서브 토큰 +${n}`),
+        });
+        logger.info(`[ChatDelegate] 위임 완료 (${Date.now() - started}ms): "${subgoal.slice(0, 40)}"`);
+        return result;
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        logger.warn(`[ChatDelegate] 위임 실패: ${msg}`);
+        return `Error: 전문가 위임 실패 — ${msg}. 직접 답변을 작성하세요.`;
+    }
+}

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -19,6 +19,8 @@ import { getUnifiedMCPClient } from '../../mcp/unified-client';
 import { isPersistableUserId } from '../../utils/user-id-validation';
 import { type Style } from '../../chat/style';
 import { buildExternalSystemPrompt } from './external-system-prompt';
+import { CHAT_DELEGATE_TOOL_NAME, buildChatDelegateTool, runChatDelegate } from './chat-delegate';
+import { CHAT_SUBAGENT } from '../../config/runtime-limits';
 import type { ChatMessage, ToolDefinition } from '../../llm';
 import type { ChatMessageRequest } from '../chat-service-types';
 import type { UserContext } from '../../mcp/user-sandbox';
@@ -128,6 +130,10 @@ export async function streamFromExternalProvider(
             && !(wantsArtifact && ARTIFACT_REQUEST_SUPPRESSED_TOOLS.includes(t.function.name))
             && !(wantsMap && t.function.name === 'generate_image'))
         : [];
+    // 채팅 서브에이전트(chat-delegate): 전문가 위임 도구 노출 — 스키마 +1 은 문법 컴파일 무해.
+    if (CHAT_SUBAGENT.ENABLED && caps.toolCalling) {
+        tools.push(buildChatDelegateTool());
+    }
     if (wantsArtifact && caps.toolCalling) {
         logger.info(`[Artifact] 명시적 아티팩트 요청 감지 — distractor 도구 억제 (잔여 도구 ${tools.length}종)`);
     }
@@ -162,6 +168,8 @@ export async function streamFromExternalProvider(
     let lastBatchSig: string | null = null;
     let repeatCount = 0;
     let suppressTools = false;
+    // 채팅 서브에이전트 호출 집계 — 메시지당 캡(CHAT_SUBAGENT.MAX_CALLS) 초과 시 위임 거부.
+    let delegateCalls = 0;
 
     // generate_image 결과의 이미지 마크다운 추적 — 일부 모델(qwen 등)이 도구 지시("마크다운
     // 그대로 포함")를 누락해 생성된 이미지가 채팅에 표시되지 않는 문제 보정용.
@@ -275,7 +283,22 @@ export async function streamFromExternalProvider(
             });
 
             for (const tc of result.toolCalls) {
-                const toolResult = await executeExternalTool(deps, tc.name, tc.args as Record<string, unknown>);
+                let toolResult: string;
+                if (tc.name === CHAT_DELEGATE_TOOL_NAME) {
+                    // 서브에이전트 위임 — 부모 채팅 활성 도구 서브셋으로 depth=1 tool-loop.
+                    deps.mcpToolStartCallback?.({ toolName: tc.name });
+                    delegateCalls++;
+                    toolResult = delegateCalls > CHAT_SUBAGENT.MAX_CALLS
+                        ? `Error: 이 메시지의 전문가 위임 한도(${CHAT_SUBAGENT.MAX_CALLS}회)에 도달했습니다. 지금까지의 정보로 직접 답변하세요.`
+                        : await runChatDelegate({
+                            args: tc.args as Record<string, unknown>,
+                            chatTools: tools,
+                            userCtx: deps.currentUserContext ?? { userId: 'guest', role: 'guest' },
+                            ...(req.abortSignal ? { signal: req.abortSignal } : {}),
+                        });
+                } else {
+                    toolResult = await executeExternalTool(deps, tc.name, tc.args as Record<string, unknown>);
+                }
                 if (tc.name === 'generate_image') {
                     const m = toolResult.match(/!\[[^\]]*\]\(\/generated\/[^)]+\)/);
                     if (m && !generatedImageMarkdowns.includes(m[0])) {


### PR DESCRIPTION
## 개요

**채팅창에서도 서브에이전트 동작** — agent task Phase 5-1의 `runSubagent`를 재사용해 채팅 도구 루프에 `delegate_expert`(전문가 위임)를 노출합니다. 플래그 기본 off, 라이브 검증 완료.

## 설계 (권고안 그대로)

| 축 | 내용 |
|---|---|
| 노출 | `external-provider` 도구 조립부에 정의 1개 push (스키마 +1 — 문법컴파일 무해) |
| 디스패치 | 도구 실행부에서 `delegate_expert` → `runChatDelegate` → `runSubagent`(depth=1 tool-loop) |
| 서브 도구 | **부모 채팅이 이미 실행 가능한 도구만**(자기 자신 제외) — 권한 증분 0 |
| 승인 | 정책 `none` 고정 — 채팅 무승인 모델과 정합, agent task HITL 레지스트리와 간섭 없음 (`subagent` 파라미터를 `Pick<approvalPolicy\|approvalTimeoutMs>`로 완화) |
| 가드 | 메시지당 캡(기본 1) + 기존 wall-clock 가드 공유 + 도구 설명에 남용 억제 문구 |
| 비용 | 서브 LLM은 항상 로컬 모델(외부 provider 채팅이어도 위임은 로컬) |
| UX | 기존 `mcp_tool_start` 인라인 표시 재사용 — 프론트 변경 없음 |

## 라이브 검증
- WS 채팅에서 유발 → 이벤트 `mcp_tool_start:delegate_expert` → 위임 완료 10.6s → **컷오프 밖 사실**(2025 노벨 화학상 Kitagawa/Robson/Yaghi)을 서브가 실검색으로 확보 → 정답 응답 ✅

## 검증
- 유닛 2 신규 · tsc 0 · lint 0 · external-provider 528줄(Gate 3 OK)
- 운영: `CHAT_SUBAGENT_ENABLED=true`로 활성해 발동률·지연 관찰 중(캡 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
