### PR TITLE
fix(web): 내비 통폐합 코드리뷰 후속 — 목업 키 제거·관리자 탭 가드·설정 URL 동기화·i18n 정리

### DIFF
--- a/apps/web/app/(workspace)/settings/page.tsx
+++ b/apps/web/app/(workspace)/settings/page.tsx
@@ -183,6 +183,11 @@ export default function SettingsPage() {
   const [tab, setTab] = useState<TabId>(
     TABS.some((t) => t.id === tabParam) ? (tabParam as TabId) : "general",
   );
+  // 뒤로가기/앞으로가기로 ?tab= 이 바뀌면 상태 동기화 (탭 클릭은 selectTab 이 URL 에 반영)
+  useEffect(() => {
+    const p = searchParams.get("tab");
+    if (p && TABS.some((t) => t.id === p)) setTab(p as TabId);
+  }, [searchParams]);
 
   // 일반 / 모델
   const selectedModel = useAppStore((s) => s.selectedModel);
@@ -530,7 +535,11 @@ export default function SettingsPage() {
                 <button
                   key={t.id}
                   type="button"
-                  onClick={() => setTab(t.id)}
+                  onClick={() => {
+                    setTab(t.id);
+                    // URL 동기화 — 새로고침/뒤로가기가 딥링크 탭으로 되돌리지 않게
+                    router.replace(`/settings?tab=${t.id}`, { scroll: false });
+                  }}
                   className={cn(
                     "flex items-center gap-2 whitespace-nowrap rounded-md px-3 py-2 text-sm font-medium transition",
                     active

--- a/apps/web/components/chat/slash-skill-menu.tsx
+++ b/apps/web/components/chat/slash-skill-menu.tsx
@@ -52,9 +52,11 @@ export function SlashSkillMenu({
     el?.scrollIntoView({ block: "nearest" });
   }, [activeIndex]);
 
-  // 카테고리 헤더: 이전 항목과 비교해 바뀌는 지점에만 표시 (렌더 스코프 변수 재할당 없이 파생)
-  const categoryOf = (idx: number) =>
-    skillCategoryLabel(skills[idx].category) || t("slashMenu.categoryEtc");
+  // 카테고리 헤더: 이전 항목과 비교해 바뀌는 지점에만 표시 (렌더 스코프 변수 재할당 없이 파생).
+  // 항목당 1회만 계산해 두고 행 렌더에서 조회한다.
+  const categories = skills.map(
+    (s) => skillCategoryLabel(s.category) || t("slashMenu.categoryEtc"),
+  );
 
   return (
     <div className="absolute bottom-full left-0 right-0 z-40 mb-2 flex flex-col overflow-hidden rounded-xl border border-border bg-surface-2 shadow-lg">
@@ -69,8 +71,8 @@ export function SlashSkillMenu({
       ) : (
         <div ref={listRef} className="max-h-72 overflow-y-auto p-1">
           {skills.map((skill, i) => {
-            const cat = categoryOf(i);
-            const showHeader = grouped && (i === 0 || categoryOf(i - 1) !== cat);
+            const cat = categories[i];
+            const showHeader = grouped && (i === 0 || categories[i - 1] !== cat);
             return (
               <Fragment key={skill.id}>
                 {showHeader && (

--- a/apps/web/components/hub-tabs.tsx
+++ b/apps/web/components/hub-tabs.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { PageTabs } from "@/components/ui/page-tabs";
+import { useAppStore } from "@/lib/store";
 
 /**
  * 사이드바 통폐합(2026-07-11)으로 묶인 허브별 탭 정의.
@@ -21,30 +22,38 @@ export function McpTabs() {
   );
 }
 
-/** 개발자 허브 — 문서 | API 액세스 */
+/** 개발자 허브 — 문서 | API 액세스 (기존 nav.items 라벨 재사용 — 중복 키 방지) */
 export function DeveloperTabs() {
   const t = useTranslations("pageTabs");
+  const tNav = useTranslations("nav");
   return (
     <PageTabs
       tabs={[
         { href: "/developer", label: t("docs") },
-        { href: "/api-access", label: t("apiAccess") },
+        { href: "/api-access", label: tNav("items.apiAccess") },
       ]}
     />
   );
 }
 
-/** 관리자 관측 허브 — 대시보드 | 애널리틱스 | 메트릭 | MCP 모니터링 | 에이전트 학습 */
+/**
+ * 관리자 관측 허브 — 대시보드 | 애널리틱스 | 메트릭 | MCP 모니터링 | 에이전트 학습.
+ * /mcp-monitoring·/agent-learning 은 라우트 가드가 없어 비관리자도 URL 로 도달할 수 있다 —
+ * 그 경우 /admin 계열 링크를 노출하지 않도록 admin 역할에서만 렌더.
+ */
 export function AdminObservabilityTabs() {
   const t = useTranslations("pageTabs");
+  const tNav = useTranslations("nav");
+  const role = useAppStore((s) => s.auth.currentUser?.role);
+  if (role !== "admin") return null;
   return (
     <PageTabs
       tabs={[
         { href: "/admin", label: t("dashboard") },
-        { href: "/admin/analytics", label: t("analytics") },
-        { href: "/admin/metrics", label: t("metrics") },
-        { href: "/mcp-monitoring", label: t("mcpMonitoring") },
-        { href: "/agent-learning", label: t("agentLearning") },
+        { href: "/admin/analytics", label: tNav("items.analytics") },
+        { href: "/admin/metrics", label: tNav("items.metrics") },
+        { href: "/mcp-monitoring", label: tNav("items.mcpMonitoring") },
+        { href: "/agent-learning", label: tNav("items.agentLearning") },
       ]}
     />
   );

--- a/apps/web/components/settings/provider-keys-section.tsx
+++ b/apps/web/components/settings/provider-keys-section.tsx
@@ -83,31 +83,9 @@ export function ProviderKeysSection() {
       );
       setProviders(res?.data?.providers ?? []);
     } catch (e) {
-      // TODO: API 연동 — 비로그인/오류 시 목업 카탈로그 노출
+      // 비로그인/오류 — 목업 주입 금지(가짜 '활성' 키가 실제 등록으로 오인됨). 빈 목록 + 에러 표시.
       setError(e instanceof Error ? e.message : t("loadError"));
-      setProviders([
-        {
-          provider_id: "anthropic",
-          display_name: "Anthropic",
-          sdk_type: "anthropic",
-          default_base_url: "https://api.anthropic.com",
-          user_key: {
-            display_name: t("mock.productionName"),
-            key_prefix: "sk-ant-",
-            base_url: null,
-            last_validation_ok: true,
-            last_used_at: "2026-06-18T08:21:00Z",
-            created_at: "2026-05-30T02:10:00Z",
-          },
-        },
-        {
-          provider_id: "openrouter",
-          display_name: "OpenRouter",
-          sdk_type: "openai-compatible",
-          default_base_url: "https://openrouter.ai/api/v1",
-          user_key: null,
-        },
-      ]);
+      setProviders([]);
     } finally {
       setLoading(false);
     }
@@ -157,7 +135,7 @@ export function ProviderKeysSection() {
             {error && (
               <span className="inline-flex items-center gap-1 text-xs text-warn">
                 <AlertTriangle className="h-3.5 w-3.5" />
-                {t("mockDataShown")}
+                {t("loadError")}
               </span>
             )}
             <Button size="sm" onClick={() => setShowForm((v) => !v)}>

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -18,21 +18,16 @@
       "skillLibrary": "Skill Library",
       "artifacts": "Artifacts",
       "history": "History",
-      "mcpServers": "MCP Servers",
-      "mcpCatalog": "MCP Catalog",
       "mcpMonitoring": "MCP Monitoring",
       "agentLearning": "Agent Learning",
       "settings": "Settings",
-      "apiKeys": "API Keys",
       "usage": "Usage",
-      "developerDocs": "Developer Docs",
       "admin": "Admin",
       "analytics": "Analytics",
       "auditLog": "Audit Log",
       "metrics": "Metrics",
       "alerts": "Alerts",
       "mcpCatalogAdmin": "MCP Catalog Admin",
-      "memory": "Memory",
       "mcp": "MCP",
       "developer": "Developer"
     }
@@ -1276,7 +1271,6 @@
     "cancel": "Cancel",
     "save": "Save",
     "registeredKeys": "Registered Provider Keys",
-    "mockDataShown": "Showing mock data",
     "loading": "Loading key list...",
     "emptyTitle": "No external keys registered",
     "emptyDesc": "Add a key to use that provider's models.",
@@ -1306,9 +1300,6 @@
     "sdkType": {
       "anthropic": "Anthropic",
       "openaiCompatible": "OpenAI-compatible"
-    },
-    "mock": {
-      "productionName": "Production"
     },
     "validationWarning": "Key saved, but endpoint validation failed: {error} — check the URL/key and save again."
   },
@@ -1407,11 +1398,6 @@
     "myServers": "My Servers",
     "catalog": "Catalog",
     "docs": "Docs",
-    "apiAccess": "API Access",
-    "dashboard": "Dashboard",
-    "analytics": "Analytics",
-    "metrics": "Metrics",
-    "mcpMonitoring": "MCP Monitoring",
-    "agentLearning": "Agent Learning"
+    "dashboard": "Dashboard"
   }
 }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -18,21 +18,16 @@
       "skillLibrary": "スキルライブラリ",
       "artifacts": "アーティファクト",
       "history": "履歴",
-      "mcpServers": "MCPサーバー",
-      "mcpCatalog": "MCPカタログ",
       "mcpMonitoring": "MCPモニタリング",
       "agentLearning": "エージェント学習",
       "settings": "設定",
-      "apiKeys": "APIキー",
       "usage": "使用量",
-      "developerDocs": "開発者ドキュメント",
       "admin": "管理者",
       "analytics": "アナリティクス",
       "auditLog": "監査ログ",
       "metrics": "メトリクス",
       "alerts": "アラート",
       "mcpCatalogAdmin": "MCPカタログ管理",
-      "memory": "メモリ",
       "mcp": "MCP",
       "developer": "開発者"
     }
@@ -1276,7 +1271,6 @@
     "cancel": "キャンセル",
     "save": "保存",
     "registeredKeys": "登録済みプロバイダーキー",
-    "mockDataShown": "モックデータを表示中",
     "loading": "キー一覧を読み込み中...",
     "emptyTitle": "登録された外部キーがありません",
     "emptyDesc": "キーを追加すると、そのプロバイダーのモデルを利用できます。",
@@ -1306,9 +1300,6 @@
     "sdkType": {
       "anthropic": "Anthropic",
       "openaiCompatible": "OpenAI互換"
-    },
-    "mock": {
-      "productionName": "本番"
     },
     "validationWarning": "キーは保存されましたが、endpoint の検証に失敗しました: {error} — URL/キーを確認して再保存してください。"
   },
@@ -1407,11 +1398,6 @@
     "myServers": "マイサーバー",
     "catalog": "カタログ",
     "docs": "ドキュメント",
-    "apiAccess": "API アクセス",
-    "dashboard": "ダッシュボード",
-    "analytics": "アナリティクス",
-    "metrics": "メトリクス",
-    "mcpMonitoring": "MCPモニタリング",
-    "agentLearning": "エージェント学習"
+    "dashboard": "ダッシュボード"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -18,21 +18,16 @@
       "skillLibrary": "스킬 라이브러리",
       "artifacts": "아티팩트",
       "history": "히스토리",
-      "mcpServers": "MCP 서버",
-      "mcpCatalog": "MCP 카탈로그",
       "mcpMonitoring": "MCP 모니터링",
       "agentLearning": "에이전트 학습",
       "settings": "설정",
-      "apiKeys": "API 키",
       "usage": "사용량",
-      "developerDocs": "개발자 문서",
       "admin": "관리자",
       "analytics": "애널리틱스",
       "auditLog": "감사 로그",
       "metrics": "메트릭",
       "alerts": "알림",
       "mcpCatalogAdmin": "MCP 카탈로그 관리",
-      "memory": "메모리",
       "mcp": "MCP",
       "developer": "개발자"
     }
@@ -1276,7 +1271,6 @@
     "cancel": "취소",
     "save": "저장",
     "registeredKeys": "등록된 공급자 키",
-    "mockDataShown": "목업 데이터 표시 중",
     "loading": "키 목록을 불러오는 중...",
     "emptyTitle": "등록된 외부 키가 없습니다",
     "emptyDesc": "새 키를 추가하면 해당 공급자 모델을 사용할 수 있습니다.",
@@ -1306,9 +1300,6 @@
     "sdkType": {
       "anthropic": "Anthropic",
       "openaiCompatible": "OpenAI 호환"
-    },
-    "mock": {
-      "productionName": "프로덕션"
     },
     "validationWarning": "키는 저장됐지만 endpoint 검증에 실패했습니다: {error} — 주소/키를 확인 후 다시 저장하세요."
   },
@@ -1407,11 +1398,6 @@
     "myServers": "내 서버",
     "catalog": "카탈로그",
     "docs": "문서",
-    "apiAccess": "API 액세스",
-    "dashboard": "대시보드",
-    "analytics": "애널리틱스",
-    "metrics": "메트릭",
-    "mcpMonitoring": "MCP 모니터링",
-    "agentLearning": "에이전트 학습"
+    "dashboard": "대시보드"
   }
 }

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -18,21 +18,16 @@
       "skillLibrary": "技能库",
       "artifacts": "工件",
       "history": "历史记录",
-      "mcpServers": "MCP服务器",
-      "mcpCatalog": "MCP目录",
       "mcpMonitoring": "MCP监控",
       "agentLearning": "智能体学习",
       "settings": "设置",
-      "apiKeys": "API密钥",
       "usage": "使用量",
-      "developerDocs": "开发者文档",
       "admin": "管理员",
       "analytics": "分析",
       "auditLog": "审计日志",
       "metrics": "指标",
       "alerts": "告警",
       "mcpCatalogAdmin": "MCP目录管理",
-      "memory": "记忆",
       "mcp": "MCP",
       "developer": "开发者"
     }
@@ -1276,7 +1271,6 @@
     "cancel": "取消",
     "save": "保存",
     "registeredKeys": "已注册的提供商密钥",
-    "mockDataShown": "正在显示模拟数据",
     "loading": "正在加载密钥列表...",
     "emptyTitle": "尚未注册外部密钥",
     "emptyDesc": "添加密钥后即可使用该提供商的模型。",
@@ -1306,9 +1300,6 @@
     "sdkType": {
       "anthropic": "Anthropic",
       "openaiCompatible": "OpenAI 兼容"
-    },
-    "mock": {
-      "productionName": "生产"
     },
     "validationWarning": "密钥已保存，但 endpoint 验证失败：{error} — 请检查地址/密钥后重新保存。"
   },
@@ -1407,11 +1398,6 @@
     "myServers": "我的服务器",
     "catalog": "目录",
     "docs": "文档",
-    "apiAccess": "API 访问",
-    "dashboard": "仪表盘",
-    "analytics": "分析",
-    "metrics": "指标",
-    "mcpMonitoring": "MCP监控",
-    "agentLearning": "智能体学习"
+    "dashboard": "仪表盘"
   }
 }


### PR DESCRIPTION
## 요약

PR #274 머지 후 실행한 `/code-review`(high, 멀티에이전트 워크플로우) 검증 통과 발견 7건의 후속 수정. **에이전트 학습은 관리자 관측 허브 소속 유지(ⓐ)**로 결정.

## 수정 내역

| # | 심각도 | 수정 |
|---|---|---|
| 1 | correctness | **가짜 '활성' 키 목업 제거** — 외부 키 조회 실패 시 catch가 `last_validation_ok:true`인 Anthropic 목업을 주입해 실제 등록 키로 오인시키던 것을 빈 목록+에러 라벨로 대체 |
| 2 | correctness | **AdminObservabilityTabs role 가드** — admin이 아니면 렌더하지 않음. 라우트 가드 없는 /agent-learning·/mcp-monitoring에서 비관리자에게 /admin 계열 링크가 노출되던 표면 차단 |
| 3 | cleanup | **설정 탭 ↔ URL 동기화** — 탭 클릭 시 `router.replace('?tab=')` + popstate 시 상태 동기화. 새로고침/뒤로가기가 딥링크 탭으로 스냅백하던 문제 해소 |
| 4 | cleanup | **i18n 정리** — 고아 nav.items 5키·pageTabs 중복 5키·apiKeys.mock 계열 × 4언어 삭제, 허브 탭은 기존 nav.items 라벨 재사용. 잔여 nav.items 20키 = 사이드바 15 + 탭 재사용 5 정합 |
| 5 | cleanup | **slash-skill-menu** — 카테고리 라벨 행당 2회 계산 → 항목당 1회 사전 계산 |

## 검증

- [x] `tsc --noEmit` 0 / `eslint` 0 / `next build` 성공
- [x] Playwright (임시 :3106): 게스트 /agent-learning에서 관리자 탭 **미노출**, 관리자에겐 5탭 정상(재사용 라벨 렌더 확인), 설정 탭 클릭 시 URL `?tab=` 갱신 확인
- [ ] 운영 반영: 머지 후 build + pm2 재시작

🤖 Generated with [Claude Code](https://claude.com/claude-code)