### PR TITLE
fix(web): 외부 키 등록/삭제 후 모델 목록 캐시 즉시 갱신

### DIFF
--- a/apps/web/components/settings/provider-keys-section.tsx
+++ b/apps/web/components/settings/provider-keys-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useLocale, useTranslations } from "next-intl";
 import {
   KeyRound,
@@ -69,6 +70,7 @@ function formatDate(iso: string | null | undefined, locale: string) {
 export function ProviderKeysSection() {
   const t = useTranslations("apiKeys");
   const locale = toBcp47(useLocale());
+  const queryClient = useQueryClient();
   const [providers, setProviders] = useState<ProviderEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -101,6 +103,8 @@ export function ProviderKeysSection() {
     try {
       await ApiClient.del(`/api/external-keys/${providerId}`);
       await load();
+      // 키 삭제로 해당 provider 모델이 목록에서 빠짐 — 기본 모델 picker/컴포저 즉시 반영
+      void queryClient.invalidateQueries({ queryKey: ["models"] });
     } catch (e) {
       window.alert(
         t("deleteFailed", {
@@ -121,6 +125,8 @@ export function ProviderKeysSection() {
           onSaved={async () => {
             setShowForm(false);
             await load();
+            // 키 등록 직후 새 provider 모델이 기본 모델 picker 에 바로 나타나도록
+            void queryClient.invalidateQueries({ queryKey: ["models"] });
           }}
         />
       )}


### PR DESCRIPTION
## 문제

설정 → 모델&응답에서 외부 LLM 키를 등록해도 같은 화면의 **기본 모델 드롭다운에 새 provider 가 나타나지 않음** (페이지 새로고침 필요). `provider-keys-section.tsx` 가 자체 키 목록만 reload 하고, 기본 모델 picker(`settings/page.tsx`)와 컴포저(`composer.tsx`)가 공유하는 react-query `["models"]` 캐시(staleTime 60s)를 invalidate 하지 않았기 때문.

## 수정

키 **등록 성공**(onSaved)·**삭제 성공**(handleDelete) 시 `queryClient.invalidateQueries({ queryKey: ["models"] })` 호출 추가. 삭제 경로를 함께 처리해 삭제된 키를 가리키는 stale 모델 선택으로 INVALID_API_KEY 가 나는 재발 경로도 차단.

## 검증

- `tsc --noEmit` 통과
- 라이브 E2E: 프로덕션 빌드 + pm2 재시작 후 관리자 계정으로
  - ollama-local 키 등록 → **새로고침 없이** 제공자 드롭다운에 '🌐 Ollama (Local)' 즉시 추가 확인
  - 해당 키 삭제 → **새로고침 없이** 드롭다운에서 즉시 제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)