### PR TITLE
feat(providers): NVIDIA NIM 외부 provider 추가

### DIFF
--- a/apps/api/src/config/external-providers.ts
+++ b/apps/api/src/config/external-providers.ts
@@ -145,6 +145,28 @@ export const EXTERNAL_PROVIDER_CATALOG: ReadonlyArray<ExternalProviderCatalogEnt
             { id: 'qwen3-coder:480b-cloud',   displayName: 'Qwen3 Coder 480B (Cloud)',   isFree: false, capabilities: { streaming: true, toolCalling: true, vision: false, thinking: false } },
         ],
     },
+    {
+        id: 'nvidia',
+        displayName: 'NVIDIA NIM',
+        sdkType: 'openai-compatible',
+        defaultBaseUrl: 'https://integrate.api.nvidia.com/v1',
+        keyPrefixPattern: 'nvapi-',
+        validatePath: '/models',
+        enabled: true,
+        sortOrder: 50,
+        helpText:
+            'NVIDIA NIM (https://build.nvidia.com) 의 API 키(nvapi- 로 시작)를 입력하세요. ' +
+            'NVIDIA GPU 클라우드가 서빙하는 오픈소스 모델(Llama, Qwen, Nemotron 등)을 ' +
+            'OpenAI 호환 API 로 사용합니다. 모델 ID 는 "meta/llama-3.3-70b-instruct" 형식입니다. ' +
+            '주의: NVIDIA 의 모델 목록 API 는 인증이 없어 키 유효성은 첫 채팅에서 확인됩니다.',
+        authMethods: ['api_key'] as const,
+        fallbackModels: [
+            { id: 'meta/llama-3.3-70b-instruct',             displayName: 'Llama 3.3 70B',        isFree: false, capabilities: { streaming: true, toolCalling: true, vision: false, thinking: false } },
+            { id: 'meta/llama-4-maverick-17b-128e-instruct', displayName: 'Llama 4 Maverick 17B', isFree: false, capabilities: { streaming: true, toolCalling: true, vision: true,  thinking: false } },
+            { id: 'qwen/qwen3-next-80b-a3b-instruct',        displayName: 'Qwen3 Next 80B A3B',   isFree: false, capabilities: { streaming: true, toolCalling: true, vision: false, thinking: false } },
+            { id: 'mistralai/mistral-nemotron',              displayName: 'Mistral Nemotron',     isFree: false, capabilities: { streaming: true, toolCalling: true, vision: false, thinking: false } },
+        ],
+    },
 ] as const;
 
 /**

--- a/apps/api/src/services/chat-service/provider-gate.ts
+++ b/apps/api/src/services/chat-service/provider-gate.ts
@@ -41,6 +41,7 @@ const KNOWN_FULLID_PREFIXES: readonly string[] = [
     'openrouter',
     'ollama-local',
     'ollama-cloud',
+    'nvidia',
 ];
 
 export interface ProviderGateInput {

--- a/apps/web/components/model-picker.tsx
+++ b/apps/web/components/model-picker.tsx
@@ -26,6 +26,7 @@ const EXTERNAL_PROVIDER_LABELS: Record<string, string> = {
   openrouter: "🌐 OpenRouter",
   "ollama-local": "🌐 Ollama (Local)",
   "ollama-cloud": "🌐 Ollama Cloud",
+  nvidia: "🌐 NVIDIA NIM",
 };
 
 export function ModelPicker({


### PR DESCRIPTION
## 요약
- NVIDIA NIM (https://integrate.api.nvidia.com/v1, OpenAI 호환)을 설정 → 모델&응답 → API 키에서 등록 가능한 BYO Key 외부 provider 로 추가
- 기존 `openai-compatible` 인프라(OpenAICompatProvider·외부 dispatch·모델 캐시) 전부 재사용 — 신규 provider 클래스·DB 마이그레이션 없음
- 변경 3파일: 카탈로그 entry(`external-providers.ts`) + fullId prefix(`provider-gate.ts`) + picker 라벨(`model-picker.tsx`)

## 라이브 E2E 검증 (운영 반영 완료)
- [x] admin 계정 `nvapi-` 키 등록 → `validated: true`
- [x] 메인 모델 API에 NVIDIA 모델 121개 노출 (`nvidia:` prefix)
- [x] WS 스트리밍 채팅: `nvidia:qwen/qwen3-next-80b-a3b-instruct` 응답 정상 수신 (첫 토큰 ~34s, NVIDIA 무료 티어 큐)
- [x] 잘못된 키 → 채팅 시 403 → `INVALID_API_KEY` 매핑 확인

## NVIDIA 무료 티어 특이사항 (실측)
- `GET /v1/models` 가 무인증 공개 → 등록 시 키 검증이 사실상 통과됨. 키 유효성은 첫 채팅에서 확인 — helpText 에 안내 명시
- 인기 모델(llama-3.3-70b 등)은 포화 시 에러 대신 무기한 대기, 한산한 모델은 즉시 응답
- 카탈로그에 있어도 계정별 404 인 모델 존재(nemotron-70b) → fallbackModels 는 라이브 검증된 모델만 수록
- 소형 모델(gemma-2b 등)은 `tools` 파라미터를 400 거부 — 도구 지원 모델 사용 필요

## 체크리스트
- [x] `npx tsc --noEmit` 통과
- [x] provider 관련 유닛 테스트 54개 통과
- [x] eslint 통과
- [x] 스키마/환경변수 변경 없음 (BYOK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)