### PR TITLE
feat(model-roles): Role-based Multi-Agent Orchestration — PR1 코어 (역할 레지스트리 + 3단 폴백 해석기)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -384,10 +384,6 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # *******************************************************
 # LLM 라우팅 설정 (선택적, 기본값 사용 권장)
 # *******************************************************
-# 쿼리 분류 모델 (기본값: LLM_DEFAULT_MODEL → ROLE_DEFAULTS, 단일 로컬 모델 환경)
-# 별도 모델로 분리하려면 명시 — model-roles 레지스트리가 자동 위임
-# OMK_CLASSIFIER_MODEL=gemma4:e4b
-
 # LLM 라우터 temperature - 낮을수록 결정적 응답 (기본값: 0.1)
 # OMK_ROUTER_TEMPERATURE=0.1
 
@@ -421,10 +417,28 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # OMK_EXPANDED_DAMPING=0.3
 
 # *******************************************************
-# 모델 역할 레지스트리 (model-roles.ts) — 단일 로컬 모델 환경
+# 모델 역할 레지스트리 (model-roles.ts) — Role-based Multi-Agent Orchestration
 # *******************************************************
-# OMK_CHAT_MODEL / OMK_CLASSIFIER_MODEL / OMK_ROUTER_MODEL 로 역할별 모델 override.
+# 역할별 전역 모델 override (미설정 시 LLM_DEFAULT_MODEL 로 자동 위임).
+# ⚠️ 전역 계층은 **로컬 모델만** 허용 — 외부 provider fullId('openrouter:...' 등)는
+#    서버 공용 키가 없어 validateModels 가 거부. 외부 모델 배정은 사용자별
+#    역할 매핑(user_model_roles, BYOK 키 필요)에서만 가능.
+# 역할: chat(채팅) / agent(에이전트 작업) / judge(목표 판정) / research(딥리서치)
+#       / spawn(병렬 서브에이전트) / review(코드·보안 리뷰) / router(에이전트 라우팅)
+# OMK_CLASSIFIER_MODEL: 2026-07-15 제거 (Phase B 로 LLM classifier 경로 폐기)
 # OMK_EMBEDDING_MODEL: 2026-05-19 제거 (vector cache / semantic router 폐기)
+# OMK_CHAT_MODEL=
+# OMK_AGENT_MODEL=
+# OMK_JUDGE_MODEL=
+# OMK_RESEARCH_MODEL=
+# OMK_SPAWN_MODEL=
+# OMK_REVIEW_MODEL=
+# OMK_ROUTER_MODEL=
+
+# 사용자별 역할→모델 매핑 (user_model_roles) 사용 토글 (기본 false).
+# true 면 로그인 사용자의 role 매핑을 1순위로 해석 — 외부 모델은 그 사용자의
+# BYOK 키로 호출, 실패 시 전역 env → 로컬 default 로 fail-open 폴백.
+# USER_MODEL_ROLES_ENABLED=false
 
 # *******************************************************
 # Thinking / 토큰 예산 (chat/request-handler, services/ChatService)

--- a/apps/api/src/agents/llm-router.ts
+++ b/apps/api/src/agents/llm-router.ts
@@ -20,6 +20,7 @@
  */
 
 import { LLMClient } from '../llm';
+import { getModelForRole } from '../config/model-roles';
 import { sanitizePromptInput, validatePromptInput } from '../utils/input-sanitizer';
 import { AgentCategory } from './types';
 import industryData from './industry-agents.json';
@@ -83,7 +84,8 @@ let routerClient: LLMClient | null = null;
  */
 function getRouterClient(): LLMClient {
     if (!routerClient) {
-        routerClient = new LLMClient();
+        // 'router' role 레지스트리 경유 (OMK_ROUTER_MODEL → legacy OMK_UIR_MODEL → LLM_DEFAULT_MODEL)
+        routerClient = new LLMClient({ model: getModelForRole('router') });
     }
     return routerClient;
 }

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -120,6 +120,13 @@ export const envSchema = z
          * 외부 provider(anthropic 등)는 이 값과 무관하게 항상 외부 dispatch.
          */
         LOCAL_STRATEGY_PATH_ENABLED: z.string().default('false'),
+        /**
+         * 사용자별 역할→모델 매핑 (Role-based Multi-Agent Orchestration) 토글.
+         * 'true' 면 로그인 사용자의 user_model_roles 매핑을 role 해석 1순위로 사용
+         * (외부 모델은 BYOK 키 필요, 실패 시 전역 env → 로컬 default 로 fail-open 폴백).
+         * 'false'(기본) 면 현행 동작과 동일 — 전역 env/default 만 사용.
+         */
+        USER_MODEL_ROLES_ENABLED: z.string().default('false'),
         /** Tail 라우팅 셰도우 모드 — 게이트 결정 계산/적재만, 실행 무변경 (기본 false). */
         TAIL_ROUTING_SHADOW_ENABLED: z.string().default('false'),
         SEARCH_SEMANTIC_RERANK_SHADOW: z.string().default('false'),

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -55,6 +55,8 @@ export interface EnvConfig {
     llmEnableReasoningEffort: boolean;
     /** 로컬(local-llm) 채팅을 strategy 계층으로 라우팅할지 토글 (기본 false=현행 외부 dispatch). */
     localStrategyPathEnabled: boolean;
+    /** 사용자별 역할→모델 매핑(user_model_roles) 사용 토글 (기본 false=전역 env/default 만). */
+    userModelRolesEnabled: boolean;
     /** Tail 라우팅 셰도우 모드 — 게이트 결정을 계산/적재만 하고 실행은 바꾸지 않음 (기본 false). */
     tailRoutingShadowEnabled: boolean;
     /** 웹검색 의미 리랭킹 셰도우 — bge-m3 임베딩 리랭킹 결과를 로깅만 하고 실행은 안 바꿈 (기본 false). */
@@ -174,6 +176,7 @@ const DEFAULT_CONFIG: EnvConfig = {
     llmWeeklyTokenLimit: 5000000,
     llmEnableReasoningEffort: false,
     localStrategyPathEnabled: false,
+    userModelRolesEnabled: false,
     tailRoutingShadowEnabled: false,
     searchSemanticRerankShadow: false,
     searchSemanticRerankEnabled: false,
@@ -389,6 +392,7 @@ export function loadConfig(): EnvConfig {
         LLM_WEEKLY_TOKEN_LIMIT: env('LLM_WEEKLY_TOKEN_LIMIT'),
         LLM_ENABLE_REASONING_EFFORT: env('LLM_ENABLE_REASONING_EFFORT'),
         LOCAL_STRATEGY_PATH_ENABLED: env('LOCAL_STRATEGY_PATH_ENABLED'),
+        USER_MODEL_ROLES_ENABLED: env('USER_MODEL_ROLES_ENABLED'),
         TAIL_ROUTING_SHADOW_ENABLED: env('TAIL_ROUTING_SHADOW_ENABLED'),
         SEARCH_SEMANTIC_RERANK_SHADOW: env('SEARCH_SEMANTIC_RERANK_SHADOW'),
         SEARCH_SEMANTIC_RERANK_ENABLED: env('SEARCH_SEMANTIC_RERANK_ENABLED'),
@@ -492,6 +496,7 @@ export function loadConfig(): EnvConfig {
         llmWeeklyTokenLimit: parsed.LLM_WEEKLY_TOKEN_LIMIT ?? DEFAULT_CONFIG.llmWeeklyTokenLimit,
         llmEnableReasoningEffort: (parsed.LLM_ENABLE_REASONING_EFFORT ?? 'false').toLowerCase() === 'true',
         localStrategyPathEnabled: (parsed.LOCAL_STRATEGY_PATH_ENABLED ?? 'false').toLowerCase() === 'true',
+        userModelRolesEnabled: (parsed.USER_MODEL_ROLES_ENABLED ?? 'false').toLowerCase() === 'true',
         tailRoutingShadowEnabled: (parsed.TAIL_ROUTING_SHADOW_ENABLED ?? 'false').toLowerCase() === 'true',
         searchSemanticRerankShadow: (parsed.SEARCH_SEMANTIC_RERANK_SHADOW ?? 'false').toLowerCase() === 'true',
         searchSemanticRerankEnabled: (parsed.SEARCH_SEMANTIC_RERANK_ENABLED ?? 'false').toLowerCase() === 'true',

--- a/apps/api/src/config/model-roles.ts
+++ b/apps/api/src/config/model-roles.ts
@@ -6,26 +6,53 @@
  * 모든 LLM 호출 경로의 모델 선택을 단일 진입점으로 통합합니다.
  * 새 sub-LLM 추가 시 ModelRole에 한 줄만 추가하면 됩니다.
  *
- * 환경변수 우선순위:
- *   1. 역할별 env var (OMK_CHAT_MODEL, OMK_CLASSIFIER_MODEL 등)
- *   2. LLM_DEFAULT_MODEL (메인 모델로 자동 위임, embedding 제외)
+ * 환경변수 우선순위 (전역 계층 — 사용자별 매핑은 services/model-role-resolver 참조):
+ *   1. 역할별 env var (OMK_CHAT_MODEL, OMK_AGENT_MODEL 등)
+ *   2. LLM_DEFAULT_MODEL (메인 모델로 자동 위임)
  *   3. ROLE_DEFAULTS 하드코딩 기본값
+ *
+ * ⚠️ 전역(env) 계층에는 **로컬 모델만** 허용합니다. 외부 provider fullId
+ * ('openrouter:...' 등)는 서버 공용 키가 없어 동작할 수 없으므로 validateModels
+ * 가 거부합니다. 외부 모델 배정은 사용자별 매핑(user_model_roles, BYOK 키 필요)
+ * 에서만 가능합니다.
  *
  * @module config/model-roles
  */
 
 import { createLogger } from '../utils/logger';
+import { EXTERNAL_PROVIDER_CATALOG } from './external-providers';
 
 const logger = createLogger('ModelRoles');
 
-/** LLM 호출 역할 (embedding role 은 2026-05-19 제거 — vector cache / semantic router 폐기) */
-export type ModelRole = 'chat' | 'classifier' | 'router';
+/**
+ * LLM 호출 역할.
+ *
+ * - chat:     기본 채팅 (ChatService/metrics/model.routes)
+ * - agent:    Agent Task 실행 루프 (AgentTaskService)
+ * - judge:    Agent Task 목표 판정 (goal-judge)
+ * - research: Deep Research 직접 호출 경로 (채팅 진입 시엔 채팅 모델 상속)
+ * - spawn:    spawn_agents 병렬 서브에이전트
+ * - review:   code-review / security-review / plan-mode
+ * - router:   산업 에이전트 라우팅 (agents/llm-router)
+ *
+ * (2026-05-19 embedding 제거 — vector cache / semantic router 폐기.
+ *  2026-07-15 classifier 제거 — Phase B 로 LLM classifier 경로 자체가 사라져 dead.
+ *  동시에 role 목록을 실소비처 기준으로 확장 — Role-based Multi-Agent Orchestration)
+ */
+export type ModelRole = 'chat' | 'agent' | 'judge' | 'research' | 'spawn' | 'review' | 'router';
+
+/** 전체 role 목록 — Zod enum/검증 재사용용 SoT */
+export const MODEL_ROLES: ReadonlyArray<ModelRole> = ['chat', 'agent', 'judge', 'research', 'spawn', 'review', 'router'];
 
 /** 역할별 env var 이름 매핑 — OMK_* 일관 (vLLM/LiteLLM 표준) */
 const ROLE_ENV_VAR: Record<ModelRole, string> = {
-    chat:       'OMK_CHAT_MODEL',
-    classifier: 'OMK_CLASSIFIER_MODEL',
-    router:     'OMK_ROUTER_MODEL',
+    chat:     'OMK_CHAT_MODEL',
+    agent:    'OMK_AGENT_MODEL',
+    judge:    'OMK_JUDGE_MODEL',
+    research: 'OMK_RESEARCH_MODEL',
+    spawn:    'OMK_SPAWN_MODEL',
+    review:   'OMK_REVIEW_MODEL',
+    router:   'OMK_ROUTER_MODEL',
 };
 
 /**
@@ -44,6 +71,35 @@ const LEGACY_ROLE_ENV_VAR: Partial<Record<ModelRole, string>> = {
     router: 'OMK_UIR_MODEL',
 };
 
+/** 로컬 canonical provider prefix — 'local-llm:tag' 형태 허용 (tag 로 해석) */
+const LOCAL_PROVIDER_PREFIX = 'local-llm:';
+
+/**
+ * 값이 외부 provider fullId 인지 판정.
+ * 외부 prefix 는 EXTERNAL_PROVIDER_CATALOG 의 id 목록에서 파생 (SoT 재사용 —
+ * provider-gate 의 KNOWN_FULLID_PREFIXES 와 별도 하드코딩 금지).
+ * prefix 없는 값·미등록 prefix 는 채팅 경로 규칙과 동일하게 로컬 모델 태그로 간주.
+ */
+export function isExternalFullId(value: string): boolean {
+    const idx = value.indexOf(':');
+    if (idx <= 0) return false;
+    const prefix = value.slice(0, idx);
+    if (`${prefix}:` === LOCAL_PROVIDER_PREFIX) return false;
+    return EXTERNAL_PROVIDER_CATALOG.some((p) => p.id === prefix);
+}
+
+/**
+ * 값에서 로컬 모델 태그를 추출.
+ * - 'local-llm:tag' → 'tag'
+ * - 외부 fullId → null (로컬 태그 아님)
+ * - 그 외 → 값 그대로 (로컬 태그)
+ */
+export function toLocalModelTag(value: string): string | null {
+    if (isExternalFullId(value)) return null;
+    if (value.startsWith(LOCAL_PROVIDER_PREFIX)) return value.slice(LOCAL_PROVIDER_PREFIX.length);
+    return value;
+}
+
 /**
  * 역할별 fallback 모델 — env 미설정 시 사용하는 보수적 기본값.
  *
@@ -58,10 +114,25 @@ function roleFallback(_role: ModelRole): string {
 }
 
 /**
- * 주어진 역할에 사용할 모델명을 반환합니다.
+ * 해당 역할에 전역 env 오버라이드가 설정되어 있는지 여부.
+ * (resolver 가 폴백 출처를 'global' vs 'default' 로 라벨링할 때 사용)
+ */
+export function hasRoleEnvOverride(role: ModelRole): boolean {
+    const primary = process.env[ROLE_ENV_VAR[role]];
+    if (primary && primary.trim() !== '') return true;
+    const legacyEnvName = LEGACY_ROLE_ENV_VAR[role];
+    if (legacyEnvName) {
+        const legacyValue = process.env[legacyEnvName];
+        if (legacyValue && legacyValue.trim() !== '') return true;
+    }
+    return false;
+}
+
+/**
+ * 주어진 역할에 사용할 모델명을 반환합니다. (전역 계층)
  *
  * 우선순위:
- *   1. 역할별 env var (OMK_CHAT_MODEL, OMK_CLASSIFIER_MODEL, ...)
+ *   1. 역할별 env var (OMK_CHAT_MODEL, OMK_AGENT_MODEL, ...)
  *   2. Legacy env var (OMK_UIR_MODEL → router)
  *   3. LLM_DEFAULT_MODEL
  */
@@ -95,11 +166,10 @@ export function getModelForRole(role: ModelRole): string {
  * 시작 시 검증 및 디버깅용.
  */
 export function getAllRoleModels(): Record<ModelRole, string> {
-    return {
-        chat:       getModelForRole('chat'),
-        classifier: getModelForRole('classifier'),
-        router:     getModelForRole('router'),
-    };
+    return MODEL_ROLES.reduce((acc, role) => {
+        acc[role] = getModelForRole(role);
+        return acc;
+    }, {} as Record<ModelRole, string>);
 }
 
 /**
@@ -107,8 +177,10 @@ export function getAllRoleModels(): Record<ModelRole, string> {
  *
  * 기능:
  *   1. 모든 역할별 모델 식별 — 중복 제거 후 unique 모델 목록 생성
- *   2. OpenAI 호환 `/v1/models` (또는 `/models`) endpoint 로 ping — 미등록 모델 발견 시
- *      경고 또는 fail-fast. LiteLLM/vLLM 응답: `{ data: [{ id, ... }] }`.
+ *   2. 전역 env 에 외부 provider fullId 가 설정된 경우 거부 — 전역 계층은 서버
+ *      공용 키가 없어 외부 모델이 동작할 수 없다 (failFast 시 throw, 아니면 경고).
+ *   3. 로컬 모델을 OpenAI 호환 `/v1/models` (또는 `/models`) endpoint 로 ping —
+ *      미등록 모델 발견 시 경고 또는 fail-fast. LiteLLM/vLLM 응답: `{ data: [{ id, ... }] }`.
  *
  * @param llmBaseUrl LiteLLM/vLLM proxy base URL (예: http://host:13434)
  * @param failFast true=production 환경에서 미등록 모델 발견 시 throw
@@ -118,9 +190,28 @@ export async function validateModels(
     failFast: boolean = false,
 ): Promise<void> {
     const roleModels = getAllRoleModels();
-    const uniqueModels = Array.from(new Set(Object.values(roleModels))).filter(Boolean);
 
     logger.info(`모델 역할 매핑: ${JSON.stringify(roleModels)}`);
+
+    // 전역 env 의 외부 fullId 거부 — 외부 모델은 사용자별 매핑(BYOK)에서만 허용
+    const externalMisconfigs = Object.entries(roleModels)
+        .filter(([, model]) => model && isExternalFullId(model));
+    if (externalMisconfigs.length > 0) {
+        const msg = `전역 role env 에 외부 provider fullId 는 사용할 수 없습니다 (서버 공용 키 없음): ` +
+            externalMisconfigs.map(([role, model]) => `${role}=${model}`).join(', ') +
+            `. 외부 모델은 사용자별 역할 매핑(BYOK)에서만 배정 가능합니다.`;
+        if (failFast) {
+            logger.error(msg);
+            throw new Error(msg);
+        }
+        logger.warn(msg);
+    }
+
+    const uniqueModels = Array.from(new Set(
+        Object.values(roleModels)
+            .map((m) => (m ? toLocalModelTag(m) : null))
+            .filter((m): m is string => !!m),
+    ));
 
     if (uniqueModels.length === 0) {
         logger.warn('등록된 모델이 없습니다 — LLM_DEFAULT_MODEL 및 OMK_*_MODEL 환경변수를 확인하세요.');

--- a/apps/api/src/providers/provider-router.ts
+++ b/apps/api/src/providers/provider-router.ts
@@ -21,7 +21,6 @@ import { LocalLLMProvider } from './local-llm-provider';
 import { AnthropicProvider } from './anthropic-provider';
 import { OpenAICompatProvider } from './openai-compat-provider';
 import type { ExternalKeysRepository, ExternalApiKeyRow } from '../data/repositories/external-keys-repo';
-import type { ModelRole } from '../config/model-roles';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('ProviderRouter');
@@ -222,13 +221,5 @@ export class ProviderRouter {
         }
 
         return [...localModels, ...externalModels];
-    }
-
-    /**
-     * sub-LLM(classifier/router/embedding) 역할 → 항상 local (vLLM/LiteLLM) provider.
-     * 외부 provider 는 채팅 전용으로 한정 (사용자 키 비용/지연 회피).
-     */
-    resolveForRole(_role: ModelRole): IProvider {
-        return this.deps.localProvider;
     }
 }

--- a/apps/api/src/services/model-role-resolver.ts
+++ b/apps/api/src/services/model-role-resolver.ts
@@ -1,0 +1,192 @@
+/**
+ * ============================================================
+ * ModelRoleResolver — 역할(role)→실행 LLMClient 해석 (3단 폴백)
+ * ============================================================
+ *
+ * Role-based Multi-Agent Orchestration 의 정책 진입점.
+ * 역할별 모델을 아래 우선순위로 해석해 실행용 LLMClient 를 만든다.
+ *
+ *   ① 사용자별 매핑 (user_model_roles, USER_MODEL_ROLES_ENABLED=true + userId 필요)
+ *      — 외부 provider fullId 허용. 그 사용자의 BYOK 키(user_external_api_keys)로
+ *        OpenAI 호환 endpoint 에 직결한 LLMClient 를 생성.
+ *   ② 전역 env (OMK_<ROLE>_MODEL — 로컬 모델만, config/model-roles 참조)
+ *   ③ LLM_DEFAULT_MODEL (로컬 default)
+ *
+ * 폴백 정책 = fail-open: 상위 티어 해석 실패(키 삭제·만료·비활성, anthropic sdk,
+ * lookup 오류 등)는 throw 하지 않고 사유를 degraded 에 기록한 뒤 다음 티어로
+ * 내려간다. 역할 경유 호출은 백그라운드(부팅 복구·스케줄러)에서도 돌기 때문에
+ * 여기서 죽으면 안 된다. (사용자가 채팅에서 명시 선택한 모델의 실패는 기존
+ * provider-gate 경로가 에러를 노출 — 이 모듈과 무관.)
+ *
+ * 외부 provider 는 현 카탈로그 전부가 openai-compatible 이므로 LLMClient
+ * (OpenAI SDK thin wrapper) 를 baseUrl/apiKey 오버라이드로 재사용한다.
+ * anthropic sdkType 은 LLMClient 로 호출 불가 → 로컬 폴백 (카탈로그 복귀 시
+ * IProvider 어댑터 경로로 확장).
+ *
+ * 참고: LLMClient.chat() 의 model-pool(context-fit) 라우팅은 model 이
+ * MODEL_POOL_CONFIG.defaultModel 과 같을 때만 동작하므로 외부 모델엔 자동으로
+ * 적용되지 않는다 — 외부는 provider 자체 한도에 의존.
+ *
+ * @module services/model-role-resolver
+ */
+
+import { getConfig } from '../config';
+import {
+    ModelRole,
+    getModelForRole,
+    hasRoleEnvOverride,
+    isExternalFullId,
+    toLocalModelTag,
+} from '../config/model-roles';
+import { EXTERNAL_PROVIDER_CATALOG } from '../config/external-providers';
+import { createClient, LLMClient } from '../llm/client';
+import type { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('ModelRoleResolver');
+
+/** 사용자별 역할→모델 매핑 조회 인터페이스 (실구현: user-model-roles-repo) */
+export interface UserModelRoleLookup {
+    /** 매핑된 fullId ('local-llm:tag' | 'openrouter:model' | 로컬 태그) 또는 null */
+    getRoleModel(userId: string, role: ModelRole): Promise<string | null>;
+}
+
+export interface RoleClientResolution {
+    client: LLMClient;
+    role: ModelRole;
+    /** 해석된 모델 fullId (로컬은 'local-llm:<tag>' 로 정규화) */
+    fullId: string;
+    providerId: string;
+    modelId: string;
+    /** 어느 티어에서 해석됐는지 — user(사용자 매핑) / global(전역 env) / default */
+    source: 'user' | 'global' | 'default';
+    /** 상위 티어 해석 실패로 폴백이 발생한 경우 그 사유 (관측/audit 용) */
+    degraded?: string;
+}
+
+export interface ResolveRoleClientOptions {
+    /** 사용자별 매핑·BYOK 키 소유자. 미지정 시 전역/기본 티어만 사용. */
+    userId?: string;
+    /** 사용자별 매핑 조회 — 미주입 시 사용자 티어 스킵 (PR2 에서 실 repo 연결) */
+    userMappingLookup?: UserModelRoleLookup;
+    /** 외부 BYOK 키 저장소 — 미주입 시 외부 모델 매핑은 폴백 처리 */
+    externalKeysRepo?: ExternalKeysRepository;
+}
+
+function catalogEntry(providerId: string) {
+    return EXTERNAL_PROVIDER_CATALOG.find((p) => p.id === providerId);
+}
+
+/** 로컬 모델 태그로 실행 클라이언트 구성 (base config = LiteLLM proxy) */
+function buildLocalResolution(
+    role: ModelRole,
+    tag: string,
+    source: RoleClientResolution['source'],
+    userId: string | undefined,
+    degraded: string | undefined,
+): RoleClientResolution {
+    return {
+        client: createClient({ model: tag, userId }),
+        role,
+        fullId: `local-llm:${tag}`,
+        providerId: 'local-llm',
+        modelId: tag,
+        source,
+        degraded,
+    };
+}
+
+/**
+ * 사용자 매핑의 외부 fullId 를 BYOK 키로 실행 클라이언트화.
+ * 실패 시 throw 하지 않고 실패 사유 문자열을 반환한다 (fail-open 폴백용).
+ */
+async function tryBuildExternalResolution(
+    role: ModelRole,
+    fullId: string,
+    userId: string,
+    externalKeysRepo: ExternalKeysRepository | undefined,
+): Promise<RoleClientResolution | string> {
+    const idx = fullId.indexOf(':');
+    const providerId = fullId.slice(0, idx);
+    const modelId = fullId.slice(idx + 1);
+    if (!modelId) return `'${fullId}' 모델 id 누락`;
+
+    if (!externalKeysRepo) return `externalKeysRepo 미주입 — '${providerId}' 사용 불가`;
+
+    const entry = catalogEntry(providerId);
+    if (!entry) return `카탈로그에 없는 provider '${providerId}'`;
+    if (entry.sdkType !== 'openai-compatible') {
+        return `provider '${providerId}' sdkType '${entry.sdkType}' 은 role 실행 미지원 (openai-compatible 만)`;
+    }
+
+    const keyRow = await externalKeysRepo.getByUserAndProvider(userId, providerId);
+    if (!keyRow) return `'${providerId}' API 키 미등록`;
+    if (!keyRow.isActive) return `'${providerId}' API 키 비활성`;
+
+    const plaintextKey = await externalKeysRepo.decryptKey(userId, providerId);
+    if (!plaintextKey) return `'${providerId}' 키 복호화 실패`;
+
+    const baseUrl = keyRow.baseUrl || entry.defaultBaseUrl;
+    return {
+        client: createClient({ baseUrl, apiKey: plaintextKey, model: modelId, userId }),
+        role,
+        fullId,
+        providerId,
+        modelId,
+        source: 'user',
+    };
+}
+
+/**
+ * 역할에 대한 실행 LLMClient 를 3단 폴백으로 해석한다.
+ * 어떤 경우에도 throw 하지 않고 최소한 로컬 default 클라이언트를 반환한다
+ * (LLM_DEFAULT_MODEL 미설정 등 전역 설정 오류는 기존 경로와 동일하게
+ * 호출 시점 에러로 드러난다).
+ */
+export async function resolveRoleClient(
+    role: ModelRole,
+    opts: ResolveRoleClientOptions = {},
+): Promise<RoleClientResolution> {
+    const cfg = getConfig();
+    const degradedReasons: string[] = [];
+
+    // ① 사용자별 매핑
+    if (cfg.userModelRolesEnabled && opts.userId && opts.userMappingLookup) {
+        let mapped: string | null = null;
+        try {
+            mapped = await opts.userMappingLookup.getRoleModel(opts.userId, role);
+        } catch (err) {
+            degradedReasons.push(`사용자 매핑 조회 실패: ${err instanceof Error ? err.message : String(err)}`);
+        }
+        if (mapped) {
+            if (isExternalFullId(mapped)) {
+                const result = await tryBuildExternalResolution(role, mapped, opts.userId, opts.externalKeysRepo)
+                    .catch((err) => `외부 클라이언트 구성 실패: ${err instanceof Error ? err.message : String(err)}`);
+                if (typeof result !== 'string') return result;
+                degradedReasons.push(result);
+            } else {
+                const tag = toLocalModelTag(mapped);
+                if (tag) {
+                    return buildLocalResolution(role, tag, 'user', opts.userId, undefined);
+                }
+                degradedReasons.push(`사용자 매핑 값 해석 불가: '${mapped}'`);
+            }
+        }
+    }
+
+    // ② 전역 env / ③ 로컬 default — getModelForRole 이 두 티어를 합쳐 처리
+    const globalValue = getModelForRole(role);
+    const source: RoleClientResolution['source'] = hasRoleEnvOverride(role) ? 'global' : 'default';
+    let tag = toLocalModelTag(globalValue);
+    if (!tag) {
+        // 전역 env 에 외부 fullId — 정책 위반 (validateModels 가 부팅 시 경고). 로컬 default 로 강등.
+        degradedReasons.push(`전역 role env 의 외부 fullId '${globalValue}' 는 무시됨 (로컬만 허용)`);
+        tag = cfg.llmDefaultModel;
+    }
+
+    const degraded = degradedReasons.length > 0 ? degradedReasons.join(' → ') : undefined;
+    if (degraded) {
+        logger.warn(`role '${role}' 해석 폴백 (user=${opts.userId ?? '-'}): ${degraded}`);
+    }
+    return buildLocalResolution(role, tag, source, opts.userId, degraded);
+}


### PR DESCRIPTION
## 개요
Role-based Multi-Agent Orchestration Phase 1 (코어). 사용자별 역할→모델 매핑(PR2~)의 기반이 되는 role 해석 계층.
계획: `docs/superpowers/plans/2026-07-15-role-based-model-orchestration.md` (로컬 보관)

## 변경
- **ModelRole 재정의**: `chat / agent / judge / research / spawn / review / router` — 실소비처 기준. dead `classifier` 제거 (Phase B 로 LLM classifier 경로 자체가 폐기됨)
- **`services/model-role-resolver.ts` 신설**: 역할→실행 LLMClient 3단 fail-open 폴백
  ① 사용자 매핑(PR2 repo, 외부 fullId 는 그 사용자의 BYOK 키로 OpenAI 호환 endpoint 직결) → ② 전역 `OMK_<ROLE>_MODEL` env(로컬만) → ③ `LLM_DEFAULT_MODEL`
- **validateModels**: 전역 env 의 외부 fullId 거부(서버 공용 키 없음 정책), `local-llm:` prefix 태그 정규화
- **provider-router**: dead `resolveForRole`(항상 로컬 봉인, 호출처 0곳) 제거 — resolver 로 대체
- **agents/llm-router**: `'router'` role 레지스트리 배선 (기존 `new LLMClient()` 우회 제거, OMK_ROUTER_MODEL 미설정 시 동작 무변화)
- **`USER_MODEL_ROLES_ENABLED`** 플래그 (기본 OFF — OFF 시 현행 동작과 완전 동일)

## 검증
- [x] `tsc --noEmit` 통과
- [x] eslint 변경 파일 통과
- [x] unit 23/23 통과 (model-roles 14 + model-role-resolver 9 — 폴백 3단, 키 미등록/비활성/복호화 실패/lookup 예외 fail-open, 플래그 OFF 회귀, 전역 외부 fullId 거부) ※ 테스트 파일은 저장소 관행상 git-ignored(로컬 보관)
- [x] `.env.example` 갱신

🤖 Generated with [Claude Code](https://claude.com/claude-code)