### PR TITLE
feat(model-roles): PR2 — user_model_roles DB + 역할 매핑 REST API

### DIFF
--- a/apps/api/src/config/model-roles.ts
+++ b/apps/api/src/config/model-roles.ts
@@ -44,6 +44,13 @@ export type ModelRole = 'chat' | 'agent' | 'judge' | 'research' | 'spawn' | 'rev
 /** 전체 role 목록 — Zod enum/검증 재사용용 SoT */
 export const MODEL_ROLES: ReadonlyArray<ModelRole> = ['chat', 'agent', 'judge', 'research', 'spawn', 'review', 'router'];
 
+/**
+ * 사용자별 매핑(user_model_roles) 배정을 허용하는 role.
+ * - chat 제외: 채팅은 요청별 모델 선택(ModelSelector)이 이미 존재 — 매핑과 중복/충돌
+ * - router 제외: agents/llm-router 는 전역 싱글톤 클라이언트 — 사용자별 배정 불가
+ */
+export const USER_ASSIGNABLE_MODEL_ROLES: ReadonlyArray<ModelRole> = ['agent', 'judge', 'research', 'spawn', 'review'];
+
 /** 역할별 env var 이름 매핑 — OMK_* 일관 (vLLM/LiteLLM 표준) */
 const ROLE_ENV_VAR: Record<ModelRole, string> = {
     chat:     'OMK_CHAT_MODEL',

--- a/apps/api/src/controllers/user-model-roles.controller.ts
+++ b/apps/api/src/controllers/user-model-roles.controller.ts
@@ -1,0 +1,171 @@
+/**
+ * @module controllers/user-model-roles
+ * @description 사용자별 역할→모델 매핑 CRUD (Role-based Multi-Agent Orchestration Phase 2).
+ *
+ * Endpoints (모두 requireAuth):
+ *   GET    /api/users/me/model-roles        — 본인 매핑 목록 + 배정 가능 role 카탈로그
+ *   PUT    /api/users/me/model-roles/:role  — 배정/변경 (body: { model })
+ *   DELETE /api/users/me/model-roles/:role  — 매핑 해제 (전역/기본 폴백으로 복귀)
+ *
+ * PUT 검증:
+ *   - role ∈ USER_ASSIGNABLE_MODEL_ROLES (agent/judge/research/spawn/review)
+ *   - 외부 fullId → 해당 provider BYOK 키 등록·활성 필수 (400)
+ *     + sdkType 은 openai-compatible 만 (role 실행 경로 제약)
+ *   - 로컬 태그 → LiteLLM /v1/models 대조 (LLM 서버 무응답 시 형식 검증만 — fail-open,
+ *     external-keys validate 와 동일한 저장-유지 정책)
+ *
+ * @see services/model-role-resolver — 해석(3단 폴백) 소비자
+ * @see db/migrations/069_user_model_roles.sql
+ */
+import { Router, Request } from 'express';
+import { z } from 'zod';
+import { requireAuth } from '../auth/middleware';
+import { validate } from '../middlewares/validation';
+import { getPool } from '../data/models/unified-database';
+import { UserModelRolesRepository } from '../data/repositories/user-model-roles-repo';
+import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
+import {
+    ModelRole,
+    USER_ASSIGNABLE_MODEL_ROLES,
+    isExternalFullId,
+    toLocalModelTag,
+} from '../config/model-roles';
+import { EXTERNAL_PROVIDER_CATALOG } from '../config/external-providers';
+import { createClient } from '../llm/client';
+import { createLogger } from '../utils/logger';
+import { success, internalError, unauthorized, badRequest, notFound } from '../utils/api-response';
+
+const log = createLogger('UserModelRolesController');
+
+const MAX_MODEL_ID_CHARS = 200;
+
+const putSchema = z.object({
+    model: z.string().min(1).max(MAX_MODEL_ID_CHARS),
+});
+
+function getUserId(req: Request): string | null {
+    if (!req.user) return null;
+    if ('userId' in req.user && typeof (req.user as { userId?: unknown }).userId === 'string') {
+        return (req.user as { userId: string }).userId;
+    }
+    if ('id' in req.user) return String(req.user.id);
+    return null;
+}
+
+function parseAssignableRole(value: string): ModelRole | null {
+    return (USER_ASSIGNABLE_MODEL_ROLES as readonly string[]).includes(value)
+        ? (value as ModelRole)
+        : null;
+}
+
+/** 외부 fullId 배정 검증 — 실패 사유 문자열 반환 (통과 시 null) */
+async function validateExternalAssignment(userId: string, fullId: string): Promise<string | null> {
+    const idx = fullId.indexOf(':');
+    const providerId = fullId.slice(0, idx);
+    const modelId = fullId.slice(idx + 1);
+    if (!modelId) return `모델 id 가 비어 있습니다: '${fullId}'`;
+
+    const entry = EXTERNAL_PROVIDER_CATALOG.find((p) => p.id === providerId);
+    if (!entry) return `카탈로그에 없는 provider: '${providerId}'`;
+    if (entry.sdkType !== 'openai-compatible') {
+        return `provider '${providerId}' (sdkType=${entry.sdkType}) 는 역할 배정을 지원하지 않습니다`;
+    }
+
+    const keysRepo = new ExternalKeysRepository(getPool());
+    const keyRow = await keysRepo.getByUserAndProvider(userId, providerId);
+    if (!keyRow) return `'${providerId}' API 키를 먼저 등록하세요`;
+    if (!keyRow.isActive) return `'${providerId}' API 키가 비활성 상태입니다`;
+    return null;
+}
+
+/** 로컬 태그 배정 검증 — LLM 서버 무응답 시 fail-open (null 반환) */
+async function validateLocalAssignment(tag: string): Promise<string | null> {
+    try {
+        const client = createClient();
+        const { models } = await client.listModels();
+        if (models.length > 0 && !models.some((m) => m.name === tag)) {
+            return `LLM 서버에 없는 로컬 모델: '${tag}' (사용 가능: ${models.map((m) => m.name).join(', ')})`;
+        }
+    } catch (err) {
+        log.warn(`로컬 모델 검증 스킵 (LLM 서버 무응답): ${err instanceof Error ? err.message : String(err)}`);
+    }
+    return null;
+}
+
+export function createUserModelRolesController(): Router {
+    const router = Router();
+
+    router.get('/', requireAuth, async (req, res) => {
+        const userId = getUserId(req);
+        if (!userId) { res.status(401).json(unauthorized()); return; }
+        try {
+            const repo = new UserModelRolesRepository(getPool());
+            const mappings = await repo.listByUser(userId);
+            res.json(success({
+                mappings,
+                assignableRoles: USER_ASSIGNABLE_MODEL_ROLES,
+            }));
+        } catch (err) {
+            log.error('list 실패:', err);
+            res.status(500).json(internalError('역할 매핑 목록 조회 실패'));
+        }
+    });
+
+    router.put('/:role', requireAuth, validate(putSchema), async (req, res) => {
+        const userId = getUserId(req);
+        if (!userId) { res.status(401).json(unauthorized()); return; }
+        const role = parseAssignableRole(req.params.role);
+        if (!role) {
+            res.status(400).json(badRequest(
+                `배정 불가 role: '${req.params.role}' (허용: ${USER_ASSIGNABLE_MODEL_ROLES.join(', ')})`,
+            ));
+            return;
+        }
+        try {
+            const { model } = req.body as z.infer<typeof putSchema>;
+            const fullId = model.trim();
+
+            let reason: string | null;
+            if (isExternalFullId(fullId)) {
+                reason = await validateExternalAssignment(userId, fullId);
+            } else {
+                const tag = toLocalModelTag(fullId);
+                reason = tag ? await validateLocalAssignment(tag) : `해석 불가한 모델 id: '${fullId}'`;
+            }
+            if (reason) {
+                res.status(400).json(badRequest(reason));
+                return;
+            }
+
+            const repo = new UserModelRolesRepository(getPool());
+            const mapping = await repo.upsert(userId, role, fullId);
+            log.info(`역할 매핑 저장: userId=${userId} role=${role} model=${fullId}`);
+            res.json(success({ mapping }));
+        } catch (err) {
+            log.error('upsert 실패:', err);
+            res.status(500).json(internalError('역할 매핑 저장 실패'));
+        }
+    });
+
+    router.delete('/:role', requireAuth, async (req, res) => {
+        const userId = getUserId(req);
+        if (!userId) { res.status(401).json(unauthorized()); return; }
+        const role = parseAssignableRole(req.params.role);
+        if (!role) {
+            res.status(400).json(badRequest(`배정 불가 role: '${req.params.role}'`));
+            return;
+        }
+        try {
+            const repo = new UserModelRolesRepository(getPool());
+            const deleted = await repo.delete(userId, role);
+            if (!deleted) { res.status(404).json(notFound('매핑 없음')); return; }
+            log.info(`역할 매핑 해제: userId=${userId} role=${role}`);
+            res.json(success({ deleted: true }));
+        } catch (err) {
+            log.error('delete 실패:', err);
+            res.status(500).json(internalError('역할 매핑 해제 실패'));
+        }
+    });
+
+    return router;
+}

--- a/apps/api/src/data/repositories/user-model-roles-repo.ts
+++ b/apps/api/src/data/repositories/user-model-roles-repo.ts
@@ -1,0 +1,77 @@
+/**
+ * @module data/repositories/user-model-roles-repo
+ * @description 사용자별 역할→모델 매핑 (user_model_roles) 저장소.
+ *
+ * Role-based Multi-Agent Orchestration Phase 2.
+ * services/model-role-resolver 의 UserModelRoleLookup 과 구조적으로 호환
+ * (getRoleModel) — 계층 방향(data→services 금지)상 명시적 implements 는 하지 않는다.
+ *
+ * @see db/migrations/069_user_model_roles.sql
+ */
+import { BaseRepository } from './base-repository';
+import type { ModelRole } from '../../config/model-roles';
+
+export interface UserModelRoleRow {
+    userId: string;
+    role: ModelRole;
+    fullModelId: string;
+    updatedAt: Date;
+}
+
+interface DbRow {
+    user_id: string;
+    role: ModelRole;
+    full_model_id: string;
+    updated_at: Date;
+    [key: string]: unknown;
+}
+
+function toRow(row: DbRow): UserModelRoleRow {
+    return {
+        userId: row.user_id,
+        role: row.role,
+        fullModelId: row.full_model_id,
+        updatedAt: row.updated_at,
+    };
+}
+
+export class UserModelRolesRepository extends BaseRepository {
+    /** resolver 폴백 1순위 조회 — 매핑 없으면 null */
+    async getRoleModel(userId: string, role: ModelRole): Promise<string | null> {
+        const result = await this.query<DbRow>(
+            `SELECT * FROM user_model_roles WHERE user_id = $1 AND role = $2`,
+            [userId, role],
+        );
+        return result.rows[0]?.full_model_id ?? null;
+    }
+
+    async listByUser(userId: string): Promise<UserModelRoleRow[]> {
+        const result = await this.query<DbRow>(
+            `SELECT * FROM user_model_roles WHERE user_id = $1 ORDER BY role`,
+            [userId],
+        );
+        return result.rows.map(toRow);
+    }
+
+    async upsert(userId: string, role: ModelRole, fullModelId: string): Promise<UserModelRoleRow> {
+        const result = await this.query<DbRow>(
+            `INSERT INTO user_model_roles (user_id, role, full_model_id)
+             VALUES ($1, $2, $3)
+             ON CONFLICT (user_id, role) DO UPDATE SET
+                full_model_id = EXCLUDED.full_model_id,
+                updated_at = now()
+             RETURNING *`,
+            [userId, role, fullModelId],
+        );
+        return toRow(result.rows[0]);
+    }
+
+    /** 매핑 해제 — 삭제 성공 여부 반환 */
+    async delete(userId: string, role: ModelRole): Promise<boolean> {
+        const result = await this.query(
+            `DELETE FROM user_model_roles WHERE user_id = $1 AND role = $2`,
+            [userId, role],
+        );
+        return (result.rowCount ?? 0) > 0;
+    }
+}

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -20,6 +20,7 @@ import { createExportController } from '../controllers/export.controller';
 import { createUserPreferencesController } from '../controllers/user-preferences.controller';
 import { createUserAgentsController } from '../controllers/user-agents.controller';
 import { createUserMemoriesController } from '../controllers/user-memories.controller';
+import { createUserModelRolesController } from '../controllers/user-model-roles.controller';
 import debugQueueRouter from './debug-queue.routes';
 import { default as chatRouter, setClusterManager as setChatCluster } from './chat.routes';
 import { setClusterManager as setOpenAICompatCluster } from './openai-compat.routes';
@@ -217,6 +218,7 @@ export function setupApiRoutes(
     // Cross-conversation Memory — REST 로 explicit 저장 (claude.ai/ChatGPT Memory 동등, 2026-05-26)
     // ⚠️ 채팅 `/remember` 슬래시는 미구현 — 저장은 이 엔드포인트(POST)로만.
     app.use('/api/users/me/memories', createUserMemoriesController());
+    app.use('/api/users/me/model-roles', createUserModelRolesController());
 
     // 클러스터 의존성 주입
     setChatCluster(cluster);

--- a/db/migrations/069_user_model_roles.sql
+++ b/db/migrations/069_user_model_roles.sql
@@ -1,0 +1,26 @@
+-- Migration 069 — user_model_roles 테이블
+--
+-- Role-based Multi-Agent Orchestration Phase 2 (2026-07-15).
+-- 로그인 사용자가 자신이 등록한 모델(로컬 + BYOK 외부)을 역할별로 배정한다.
+-- 해석 우선순위: 이 테이블(사용자 매핑) → OMK_<ROLE>_MODEL env(전역, 로컬만)
+-- → LLM_DEFAULT_MODEL. USER_MODEL_ROLES_ENABLED 플래그로 게이트 (기본 OFF).
+--
+-- role CHECK 는 코드 SoT(config/model-roles.ts MODEL_ROLES)와 정합 유지할 것.
+-- API 계층(user-model-roles.controller)은 이 중 사용자 배정 가능 role
+-- (USER_ASSIGNABLE_MODEL_ROLES: agent/judge/research/spawn/review)만 허용한다.
+
+CREATE TABLE IF NOT EXISTS user_model_roles (
+    user_id        TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role           TEXT NOT NULL CHECK (role IN ('chat', 'agent', 'judge', 'research', 'spawn', 'review', 'router')),
+    full_model_id  TEXT NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, role)
+);
+
+COMMENT ON TABLE user_model_roles IS
+    '사용자별 역할→모델 매핑 (Role-based Multi-Agent Orchestration). 외부 모델은 그 사용자의 user_external_api_keys BYOK 키로 호출.';
+COMMENT ON COLUMN user_model_roles.role IS
+    'LLM 호출 역할 — config/model-roles.ts MODEL_ROLES 와 정합. API 는 agent/judge/research/spawn/review 만 배정 허용.';
+COMMENT ON COLUMN user_model_roles.full_model_id IS
+    '모델 fullId — ''local-llm:<tag>'' | ''<external_provider>:<model>'' | 로컬 태그. 해석은 services/model-role-resolver.';


### PR DESCRIPTION
## 개요
Role-based Multi-Agent Orchestration Phase 2. **PR1(#280) 위에 스택** — base 를 feat/model-role-orchestration 으로 설정, PR1 머지 후 자동 retarget.

## 변경
- 마이그레이션 069: `user_model_roles(user_id TEXT FK CASCADE, role CHECK, full_model_id, PK(user_id, role))` — 수동 적용 필요 (`npx ts-node apps/api/src/data/migrations/cli.ts migrate`)
- `UserModelRolesRepository` — resolver 의 `UserModelRoleLookup` 구조 호환
- `GET/PUT/DELETE /api/users/me/model-roles(/:role)` — requireAuth, Zod, 배정 role 은 `USER_ASSIGNABLE_MODEL_ROLES`(agent/judge/research/spawn/review)로 제한
- PUT 검증: 외부 fullId → BYOK 키 등록·활성 + openai-compatible sdkType 필수 / 로컬 태그 → LiteLLM `/v1/models` 대조(무응답 시 fail-open)

## 검증
- [x] `tsc --noEmit` / eslint 통과
- [ ] 마이그레이션 적용 + 관리자 계정 live API 왕복 — 운영 DB 변경이라 merge 후 수동 실행 (안내 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)