### PR TITLE
feat(model-roles): PR3 — 소비처 role 배선 (agent/judge/research/spawn/review)

### DIFF
--- a/apps/api/src/config/model-roles.ts
+++ b/apps/api/src/config/model-roles.ts
@@ -44,6 +44,13 @@ export type ModelRole = 'chat' | 'agent' | 'judge' | 'research' | 'spawn' | 'rev
 /** 전체 role 목록 — Zod enum/검증 재사용용 SoT */
 export const MODEL_ROLES: ReadonlyArray<ModelRole> = ['chat', 'agent', 'judge', 'research', 'spawn', 'review', 'router'];
 
+/**
+ * 사용자별 매핑(user_model_roles) 배정을 허용하는 role.
+ * - chat 제외: 채팅은 요청별 모델 선택(ModelSelector)이 이미 존재 — 매핑과 중복/충돌
+ * - router 제외: agents/llm-router 는 전역 싱글톤 클라이언트 — 사용자별 배정 불가
+ */
+export const USER_ASSIGNABLE_MODEL_ROLES: ReadonlyArray<ModelRole> = ['agent', 'judge', 'research', 'spawn', 'review'];
+
 /** 역할별 env var 이름 매핑 — OMK_* 일관 (vLLM/LiteLLM 표준) */
 const ROLE_ENV_VAR: Record<ModelRole, string> = {
     chat:     'OMK_CHAT_MODEL',

--- a/apps/api/src/controllers/user-model-roles.controller.ts
+++ b/apps/api/src/controllers/user-model-roles.controller.ts
@@ -31,7 +31,7 @@ import {
     toLocalModelTag,
 } from '../config/model-roles';
 import { EXTERNAL_PROVIDER_CATALOG } from '../config/external-providers';
-import { createClient } from '../llm/client';
+import { createClient } from '../llm';
 import { createLogger } from '../utils/logger';
 import { success, internalError, unauthorized, badRequest, notFound } from '../utils/api-response';
 

--- a/apps/api/src/controllers/user-model-roles.controller.ts
+++ b/apps/api/src/controllers/user-model-roles.controller.ts
@@ -1,0 +1,171 @@
+/**
+ * @module controllers/user-model-roles
+ * @description 사용자별 역할→모델 매핑 CRUD (Role-based Multi-Agent Orchestration Phase 2).
+ *
+ * Endpoints (모두 requireAuth):
+ *   GET    /api/users/me/model-roles        — 본인 매핑 목록 + 배정 가능 role 카탈로그
+ *   PUT    /api/users/me/model-roles/:role  — 배정/변경 (body: { model })
+ *   DELETE /api/users/me/model-roles/:role  — 매핑 해제 (전역/기본 폴백으로 복귀)
+ *
+ * PUT 검증:
+ *   - role ∈ USER_ASSIGNABLE_MODEL_ROLES (agent/judge/research/spawn/review)
+ *   - 외부 fullId → 해당 provider BYOK 키 등록·활성 필수 (400)
+ *     + sdkType 은 openai-compatible 만 (role 실행 경로 제약)
+ *   - 로컬 태그 → LiteLLM /v1/models 대조 (LLM 서버 무응답 시 형식 검증만 — fail-open,
+ *     external-keys validate 와 동일한 저장-유지 정책)
+ *
+ * @see services/model-role-resolver — 해석(3단 폴백) 소비자
+ * @see db/migrations/069_user_model_roles.sql
+ */
+import { Router, Request } from 'express';
+import { z } from 'zod';
+import { requireAuth } from '../auth/middleware';
+import { validate } from '../middlewares/validation';
+import { getPool } from '../data/models/unified-database';
+import { UserModelRolesRepository } from '../data/repositories/user-model-roles-repo';
+import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
+import {
+    ModelRole,
+    USER_ASSIGNABLE_MODEL_ROLES,
+    isExternalFullId,
+    toLocalModelTag,
+} from '../config/model-roles';
+import { EXTERNAL_PROVIDER_CATALOG } from '../config/external-providers';
+import { createClient } from '../llm/client';
+import { createLogger } from '../utils/logger';
+import { success, internalError, unauthorized, badRequest, notFound } from '../utils/api-response';
+
+const log = createLogger('UserModelRolesController');
+
+const MAX_MODEL_ID_CHARS = 200;
+
+const putSchema = z.object({
+    model: z.string().min(1).max(MAX_MODEL_ID_CHARS),
+});
+
+function getUserId(req: Request): string | null {
+    if (!req.user) return null;
+    if ('userId' in req.user && typeof (req.user as { userId?: unknown }).userId === 'string') {
+        return (req.user as { userId: string }).userId;
+    }
+    if ('id' in req.user) return String(req.user.id);
+    return null;
+}
+
+function parseAssignableRole(value: string): ModelRole | null {
+    return (USER_ASSIGNABLE_MODEL_ROLES as readonly string[]).includes(value)
+        ? (value as ModelRole)
+        : null;
+}
+
+/** 외부 fullId 배정 검증 — 실패 사유 문자열 반환 (통과 시 null) */
+async function validateExternalAssignment(userId: string, fullId: string): Promise<string | null> {
+    const idx = fullId.indexOf(':');
+    const providerId = fullId.slice(0, idx);
+    const modelId = fullId.slice(idx + 1);
+    if (!modelId) return `모델 id 가 비어 있습니다: '${fullId}'`;
+
+    const entry = EXTERNAL_PROVIDER_CATALOG.find((p) => p.id === providerId);
+    if (!entry) return `카탈로그에 없는 provider: '${providerId}'`;
+    if (entry.sdkType !== 'openai-compatible') {
+        return `provider '${providerId}' (sdkType=${entry.sdkType}) 는 역할 배정을 지원하지 않습니다`;
+    }
+
+    const keysRepo = new ExternalKeysRepository(getPool());
+    const keyRow = await keysRepo.getByUserAndProvider(userId, providerId);
+    if (!keyRow) return `'${providerId}' API 키를 먼저 등록하세요`;
+    if (!keyRow.isActive) return `'${providerId}' API 키가 비활성 상태입니다`;
+    return null;
+}
+
+/** 로컬 태그 배정 검증 — LLM 서버 무응답 시 fail-open (null 반환) */
+async function validateLocalAssignment(tag: string): Promise<string | null> {
+    try {
+        const client = createClient();
+        const { models } = await client.listModels();
+        if (models.length > 0 && !models.some((m) => m.name === tag)) {
+            return `LLM 서버에 없는 로컬 모델: '${tag}' (사용 가능: ${models.map((m) => m.name).join(', ')})`;
+        }
+    } catch (err) {
+        log.warn(`로컬 모델 검증 스킵 (LLM 서버 무응답): ${err instanceof Error ? err.message : String(err)}`);
+    }
+    return null;
+}
+
+export function createUserModelRolesController(): Router {
+    const router = Router();
+
+    router.get('/', requireAuth, async (req, res) => {
+        const userId = getUserId(req);
+        if (!userId) { res.status(401).json(unauthorized()); return; }
+        try {
+            const repo = new UserModelRolesRepository(getPool());
+            const mappings = await repo.listByUser(userId);
+            res.json(success({
+                mappings,
+                assignableRoles: USER_ASSIGNABLE_MODEL_ROLES,
+            }));
+        } catch (err) {
+            log.error('list 실패:', err);
+            res.status(500).json(internalError('역할 매핑 목록 조회 실패'));
+        }
+    });
+
+    router.put('/:role', requireAuth, validate(putSchema), async (req, res) => {
+        const userId = getUserId(req);
+        if (!userId) { res.status(401).json(unauthorized()); return; }
+        const role = parseAssignableRole(req.params.role);
+        if (!role) {
+            res.status(400).json(badRequest(
+                `배정 불가 role: '${req.params.role}' (허용: ${USER_ASSIGNABLE_MODEL_ROLES.join(', ')})`,
+            ));
+            return;
+        }
+        try {
+            const { model } = req.body as z.infer<typeof putSchema>;
+            const fullId = model.trim();
+
+            let reason: string | null;
+            if (isExternalFullId(fullId)) {
+                reason = await validateExternalAssignment(userId, fullId);
+            } else {
+                const tag = toLocalModelTag(fullId);
+                reason = tag ? await validateLocalAssignment(tag) : `해석 불가한 모델 id: '${fullId}'`;
+            }
+            if (reason) {
+                res.status(400).json(badRequest(reason));
+                return;
+            }
+
+            const repo = new UserModelRolesRepository(getPool());
+            const mapping = await repo.upsert(userId, role, fullId);
+            log.info(`역할 매핑 저장: userId=${userId} role=${role} model=${fullId}`);
+            res.json(success({ mapping }));
+        } catch (err) {
+            log.error('upsert 실패:', err);
+            res.status(500).json(internalError('역할 매핑 저장 실패'));
+        }
+    });
+
+    router.delete('/:role', requireAuth, async (req, res) => {
+        const userId = getUserId(req);
+        if (!userId) { res.status(401).json(unauthorized()); return; }
+        const role = parseAssignableRole(req.params.role);
+        if (!role) {
+            res.status(400).json(badRequest(`배정 불가 role: '${req.params.role}'`));
+            return;
+        }
+        try {
+            const repo = new UserModelRolesRepository(getPool());
+            const deleted = await repo.delete(userId, role);
+            if (!deleted) { res.status(404).json(notFound('매핑 없음')); return; }
+            log.info(`역할 매핑 해제: userId=${userId} role=${role}`);
+            res.json(success({ deleted: true }));
+        } catch (err) {
+            log.error('delete 실패:', err);
+            res.status(500).json(internalError('역할 매핑 해제 실패'));
+        }
+    });
+
+    return router;
+}

--- a/apps/api/src/data/repositories/user-model-roles-repo.ts
+++ b/apps/api/src/data/repositories/user-model-roles-repo.ts
@@ -1,0 +1,77 @@
+/**
+ * @module data/repositories/user-model-roles-repo
+ * @description 사용자별 역할→모델 매핑 (user_model_roles) 저장소.
+ *
+ * Role-based Multi-Agent Orchestration Phase 2.
+ * services/model-role-resolver 의 UserModelRoleLookup 과 구조적으로 호환
+ * (getRoleModel) — 계층 방향(data→services 금지)상 명시적 implements 는 하지 않는다.
+ *
+ * @see db/migrations/069_user_model_roles.sql
+ */
+import { BaseRepository } from './base-repository';
+import type { ModelRole } from '../../config/model-roles';
+
+export interface UserModelRoleRow {
+    userId: string;
+    role: ModelRole;
+    fullModelId: string;
+    updatedAt: Date;
+}
+
+interface DbRow {
+    user_id: string;
+    role: ModelRole;
+    full_model_id: string;
+    updated_at: Date;
+    [key: string]: unknown;
+}
+
+function toRow(row: DbRow): UserModelRoleRow {
+    return {
+        userId: row.user_id,
+        role: row.role,
+        fullModelId: row.full_model_id,
+        updatedAt: row.updated_at,
+    };
+}
+
+export class UserModelRolesRepository extends BaseRepository {
+    /** resolver 폴백 1순위 조회 — 매핑 없으면 null */
+    async getRoleModel(userId: string, role: ModelRole): Promise<string | null> {
+        const result = await this.query<DbRow>(
+            `SELECT * FROM user_model_roles WHERE user_id = $1 AND role = $2`,
+            [userId, role],
+        );
+        return result.rows[0]?.full_model_id ?? null;
+    }
+
+    async listByUser(userId: string): Promise<UserModelRoleRow[]> {
+        const result = await this.query<DbRow>(
+            `SELECT * FROM user_model_roles WHERE user_id = $1 ORDER BY role`,
+            [userId],
+        );
+        return result.rows.map(toRow);
+    }
+
+    async upsert(userId: string, role: ModelRole, fullModelId: string): Promise<UserModelRoleRow> {
+        const result = await this.query<DbRow>(
+            `INSERT INTO user_model_roles (user_id, role, full_model_id)
+             VALUES ($1, $2, $3)
+             ON CONFLICT (user_id, role) DO UPDATE SET
+                full_model_id = EXCLUDED.full_model_id,
+                updated_at = now()
+             RETURNING *`,
+            [userId, role, fullModelId],
+        );
+        return toRow(result.rows[0]);
+    }
+
+    /** 매핑 해제 — 삭제 성공 여부 반환 */
+    async delete(userId: string, role: ModelRole): Promise<boolean> {
+        const result = await this.query(
+            `DELETE FROM user_model_roles WHERE user_id = $1 AND role = $2`,
+            [userId, role],
+        );
+        return (result.rowCount ?? 0) > 0;
+    }
+}

--- a/apps/api/src/llm/client.ts
+++ b/apps/api/src/llm/client.ts
@@ -75,6 +75,16 @@ export class LLMClient {
         return this.config.model;
     }
 
+    /**
+     * 현재 설정(baseUrl/apiKey/model/userId 포함)을 유지한 채 일부만 덮어쓴
+     * 파생 클라이언트를 만든다. role 해석된 외부 endpoint 클라이언트에
+     * 전용 timeout 만 바꿔 쓰는 용도 (report-generator, review 류) —
+     * createClient({ model: client.model }) 재파생은 외부 baseUrl 을 잃는다.
+     */
+    derive(overrides: Partial<LLMConfig>): LLMClient {
+        return new LLMClient({ ...this.config, ...overrides });
+    }
+
     setModel(model: string): void {
         this.config.model = model;
     }

--- a/apps/api/src/mcp/code-review-tool.ts
+++ b/apps/api/src/mcp/code-review-tool.ts
@@ -67,7 +67,10 @@ export const codeReviewTool: MCPToolDefinition = {
         const language = typeof args.language === 'string' ? args.language : undefined;
         const filename = typeof args.filename === 'string' ? args.filename : undefined;
 
-        const result = await reviewCode({ code, language, filename });
+        const result = await reviewCode({
+            code, language, filename,
+            userId: context?.userId ? String(context.userId) : undefined,
+        });
 
         void (async () => {
             try {

--- a/apps/api/src/mcp/plan-tool.ts
+++ b/apps/api/src/mcp/plan-tool.ts
@@ -75,7 +75,10 @@ export const createPlanTool: MCPToolDefinition = {
             ctx = ctx.slice(0, PLAN_MODE_CONFIG.maxContextBytes);
         }
 
-        const plan = await createPlan({ task, context: ctx });
+        const plan = await createPlan({
+            task, context: ctx,
+            userId: context?.userId ? String(context.userId) : undefined,
+        });
 
         void (async () => {
             try {

--- a/apps/api/src/mcp/security-review-tool.ts
+++ b/apps/api/src/mcp/security-review-tool.ts
@@ -68,7 +68,10 @@ export const securityReviewTool: MCPToolDefinition = {
         const language = typeof args.language === 'string' ? args.language : undefined;
         const filename = typeof args.filename === 'string' ? args.filename : undefined;
 
-        const result = await analyzeCode({ code, language, filename });
+        const result = await analyzeCode({
+            code, language, filename,
+            userId: context?.userId ? String(context.userId) : undefined,
+        });
 
         // audit (fire-and-forget, 실패해도 결과 반환)
         void (async () => {

--- a/apps/api/src/routes/research.routes.ts
+++ b/apps/api/src/routes/research.routes.ts
@@ -33,6 +33,7 @@ import { validate } from '../middlewares/validation';
 import { getUnifiedDatabase } from '../data/models/unified-database';
 import { v4 as uuidv4 } from 'uuid';
 import { createDeepResearchService } from '../services/DeepResearchService';
+import { resolveRoleClientForUser } from '../services/model-role-resolver';
 import { detectLanguage } from '../chat/language-policy';
 import { RESEARCH_DEPTH_LOOPS } from '../config/runtime-limits';
 import {
@@ -246,9 +247,11 @@ router.post('/sessions/:sessionId/execute', validate(executeResearchSchema), asy
     // depth에 따른 maxLoops 기본값 설정
     const loops = maxLoops || RESEARCH_DEPTH_LOOPS[session.depth] || RESEARCH_DEPTH_LOOPS.standard;
 
-    // 서비스 생성 및 비동기 실행
+    // 서비스 생성 및 비동기 실행 — 'research' role 해석 클라이언트 주입
+    // (사용자 매핑 → 전역 env → 로컬 default, 외부 매핑은 BYOK 키로 직결)
     const language = detectLanguage(session.topic).language;
-    const service = createDeepResearchService({ maxLoops: loops, language });
+    const resolved = await resolveRoleClientForUser('research', String(req.user!.id));
+    const service = createDeepResearchService({ maxLoops: loops, language }, resolved.client);
 
     // 백그라운드 실행 (응답은 즉시 반환)
     service.executeResearch(sessionId, session.topic).catch((error) => {

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -20,6 +20,7 @@ import { createExportController } from '../controllers/export.controller';
 import { createUserPreferencesController } from '../controllers/user-preferences.controller';
 import { createUserAgentsController } from '../controllers/user-agents.controller';
 import { createUserMemoriesController } from '../controllers/user-memories.controller';
+import { createUserModelRolesController } from '../controllers/user-model-roles.controller';
 import debugQueueRouter from './debug-queue.routes';
 import { default as chatRouter, setClusterManager as setChatCluster } from './chat.routes';
 import { setClusterManager as setOpenAICompatCluster } from './openai-compat.routes';
@@ -217,6 +218,7 @@ export function setupApiRoutes(
     // Cross-conversation Memory — REST 로 explicit 저장 (claude.ai/ChatGPT Memory 동등, 2026-05-26)
     // ⚠️ 채팅 `/remember` 슬래시는 미구현 — 저장은 이 엔드포인트(POST)로만.
     app.use('/api/users/me/memories', createUserMemoriesController());
+    app.use('/api/users/me/model-roles', createUserModelRolesController());
 
     // 클러스터 의존성 주입
     setChatCluster(cluster);

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -17,6 +17,7 @@
 import { createClient, type LLMClient } from '../llm';
 import type { ChatMessage, ToolDefinition } from '../llm/types';
 import { getModelForRole } from '../config/model-roles';
+import { resolveRoleClientForUser } from './model-role-resolver';
 import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { getUnifiedDatabase } from '../data/models/unified-database';
 import { AGENT_TASK_LIMITS, AGENT_SPAWN } from '../config/runtime-limits';
@@ -53,11 +54,17 @@ export class AgentTaskService {
     /** 실행 중 인스턴스 레지스트리 — detached 실행을 cancel 엔드포인트에서 중단하기 위함 */
     private static readonly running = new Map<string, AgentTaskService>();
 
-    private readonly client: LLMClient;
+    private client: LLMClient;
     private readonly abortController = new AbortController();
+    /** 생성자에서 model 명시 시 role 해석을 건너뛴다 (기존 계약 유지) */
+    private readonly explicitModel: boolean;
+    /** role 해석 결과가 외부 provider 인지 — tools 4xx 로컬 폴백 판단용 */
+    private roleClientExternal = false;
+    private roleFallbackDone = false;
 
     constructor(model?: string) {
-        this.client = createClient({ model: model || getModelForRole('chat') });
+        this.client = createClient({ model: model || getModelForRole('agent') });
+        this.explicitModel = !!model;
     }
 
     /**
@@ -89,6 +96,19 @@ export class AgentTaskService {
         const turnCeiling = Math.min(maxTurns, AGENT_TASK_LIMITS.MAX_TURNS_CEILING);
 
         const userCtx: UserContext = { userId, role: userRole };
+
+        // 'agent' role 해석 (사용자 매핑 → 전역 env → 로컬 default, fail-open).
+        // 생성자에서 model 이 명시된 경우는 기존 계약대로 그대로 사용.
+        if (!this.explicitModel) {
+            const resolved = await resolveRoleClientForUser('agent', String(userId));
+            this.client = resolved.client;
+            this.roleClientExternal = resolved.providerId !== 'local-llm';
+            if (resolved.degraded) {
+                logger.warn(`[AgentTask] ${taskId} agent role 폴백: ${resolved.degraded}`);
+            } else if (this.roleClientExternal) {
+                logger.info(`[AgentTask] ${taskId} agent role 외부 모델 사용: ${resolved.fullId}`);
+            }
+        }
 
         let stepNumber = input.resume?.fromStep ?? 0;
         let totalTokens = 0;
@@ -314,14 +334,33 @@ export class AgentTaskService {
                 );
                 const callSignal = AbortSignal.any([signal, AbortSignal.timeout(remainingMs)]);
 
-                const result = await this.client.chat(conversation, undefined, undefined, {
-                    tools: effectiveTools,
-                    signal: callSignal,
-                    // reasoning OFF — qwen3.6 가 디자인/장문 작업에서 수만 토큰의 thinking 을
-                    // 생성해 토큰 한도를 소진하고 deliverable 을 못 쓰는 폭주 차단.
-                    // 도구 루프의 단계별 reasoning 은 대화 구조 자체가 대신한다.
-                    think: false,
-                });
+                let result;
+                try {
+                    result = await this.client.chat(conversation, undefined, undefined, {
+                        tools: effectiveTools,
+                        signal: callSignal,
+                        // reasoning OFF — qwen3.6 가 디자인/장문 작업에서 수만 토큰의 thinking 을
+                        // 생성해 토큰 한도를 소진하고 deliverable 을 못 쓰는 폭주 차단.
+                        // 도구 루프의 단계별 reasoning 은 대화 구조 자체가 대신한다.
+                        think: false,
+                    });
+                } catch (chatErr) {
+                    // 외부 role 모델의 4xx(tools 미지원 등 — 예: NVIDIA 소형 모델 tools 400)
+                    // → 로컬 default 로 1회 강등 후 같은 턴 재시도. 재발/그 외 에러는 기존 경로.
+                    const status = (chatErr as { status?: number }).status;
+                    if (this.roleClientExternal && !this.roleFallbackDone
+                        && typeof status === 'number' && status >= 400 && status < 500) {
+                        this.roleFallbackDone = true;
+                        this.roleClientExternal = false;
+                        logger.warn(`[AgentTask] ${taskId} 외부 role 모델 ${status} — 로컬 폴백: ${chatErr instanceof Error ? chatErr.message : chatErr}`);
+                        this.client = createClient({ model: getModelForRole('agent'), userId: String(userId) });
+                        result = await this.client.chat(conversation, undefined, undefined, {
+                            tools: effectiveTools, signal: callSignal, think: false,
+                        });
+                    } else {
+                        throw chatErr;
+                    }
+                }
                 totalTokens +=
                     (result.metrics?.prompt_tokens ?? 0) + (result.metrics?.completion_tokens ?? 0);
                 // 토큰 상한을 호출 직후 즉시 검사 — 큰 도구 결과로 컨텍스트가 부풀어
@@ -401,7 +440,9 @@ export class AgentTaskService {
                     // 5-3(b): 실행 컨텍스트(사용 도구·턴수·계획 상태)를 함께 제공해 판정 정확도 보강.
                     if (extracted!.artifacts.length === 0 && AGENT_TASK_LIMITS.GOAL_JUDGE_ENABLED) {
                         const execCtx = buildJudgeExecutionContext(usedTools, turn + 1, taskRuntime?.getPlanSnapshot() ?? []);
-                        const achieved = await judgeGoalAchieved(this.client, goal, stepContent ?? '', callSignal, execCtx);
+                        // 'judge' role 별도 해석 — agent 실행 모델과 판정 모델을 분리 배정 가능.
+                        const judgeResolved = await resolveRoleClientForUser('judge', String(userId));
+                        const achieved = await judgeGoalAchieved(judgeResolved.client, goal, stepContent ?? '', callSignal, execCtx);
                         if (achieved === false) {
                             await update({
                                 status: 'failed',

--- a/apps/api/src/services/DeepResearchService.ts
+++ b/apps/api/src/services/DeepResearchService.ts
@@ -54,11 +54,18 @@ export class DeepResearchService {
     private config: ResearchConfig;
     private abortController: AbortController | null = null;
 
-    constructor(config?: Partial<ResearchConfig>) {
+    constructor(config?: Partial<ResearchConfig>, client?: LLMClient) {
         this.config = { ...globalConfig, ...config };
+        if (client) {
+            // 'research' role 해석 클라이언트 주입 (외부 BYOK endpoint 포함) — research.routes 경로
+            this.client = client;
+            this.config.llmModel = client.model;
+            return;
+        }
         // 기본 llmModel이 비어있으면 model-roles 레지스트리에서 resolve
+        // ('research' role — 채팅 진입 경로는 deep-research-strategy 가 채팅 모델을 명시 전달)
         if (!this.config.llmModel) {
-            this.config.llmModel = getModelForRole('chat');
+            this.config.llmModel = getModelForRole('research');
             logger.info(`[DeepResearch] llmModel 미지정 → ${this.config.llmModel}`);
         }
         this.client = createClient({ model: this.config.llmModel });
@@ -456,8 +463,8 @@ export function configureResearch(config: Partial<ResearchConfig>): ResearchConf
 /**
  * 서비스 인스턴스 생성
  */
-export function createDeepResearchService(config?: Partial<ResearchConfig>): DeepResearchService {
-    return new DeepResearchService(config);
+export function createDeepResearchService(config?: Partial<ResearchConfig>, client?: LLMClient): DeepResearchService {
+    return new DeepResearchService(config, client);
 }
 
 /**

--- a/apps/api/src/services/agent-spawn/spawn-agents.ts
+++ b/apps/api/src/services/agent-spawn/spawn-agents.ts
@@ -21,12 +21,12 @@
  * @module services/agent-spawn/spawn-agents
  */
 import { z } from 'zod';
-import { createClient, type LLMClient } from '../../llm';
+import { type LLMClient } from '../../llm';
 import type { ToolDefinition } from '../../llm/types';
 import type { UserContext } from '../../mcp/user-sandbox';
 import type { TaskSandboxConfig } from '../../config/task-sandbox';
 import { AGENT_SPAWN } from '../../config/runtime-limits';
-import { getModelForRole } from '../../config/model-roles';
+import { resolveRoleClientForUser } from '../model-role-resolver';
 import { parallelBatch } from '../../workflow/graph-engine';
 import { routeToAgent } from '../../agents/keyword-router';
 import { getAgentSystemMessage } from '../../agents/system-prompt';
@@ -212,7 +212,8 @@ export async function runSpawnAgents(p: SpawnAgentsParams): Promise<string> {
 }
 
 /**
- * 채팅 경로 편의 래퍼 — runChatDelegate 와 대칭. 서브 LLM 은 항상 로컬 모델,
+ * 채팅 경로 편의 래퍼 — runChatDelegate 와 대칭. 서브 LLM 은 'spawn' role 해석
+ * (사용자 매핑 → 전역 env → 로컬 default, 외부는 BYOK 키 필요 — fail-open 폴백),
  * 승인 정책 'none' 고정(채팅 도구는 원래 승인 없이 실행되는 모델과 정합).
  */
 export async function runChatSpawnAgents(params: {
@@ -222,9 +223,13 @@ export async function runChatSpawnAgents(params: {
     userCtx: UserContext;
     signal?: AbortSignal;
 }): Promise<string> {
+    const resolved = await resolveRoleClientForUser('spawn', String(params.userCtx.userId));
+    if (resolved.degraded) {
+        logger.warn(`[AgentSpawn] spawn role 폴백: ${resolved.degraded}`);
+    }
     return runSpawnAgents({
         args: params.args,
-        client: createClient({ model: getModelForRole('chat') }),
+        client: resolved.client,
         tools: filterChatSubTools(params.chatTools),
         userCtx: params.userCtx,
         taskId: '__chat__', // 정책 'none' 이라 승인 레지스트리 미사용 — 식별용 문자열일 뿐

--- a/apps/api/src/services/code-review/reviewer.ts
+++ b/apps/api/src/services/code-review/reviewer.ts
@@ -9,8 +9,8 @@
  * @module services/code-review/reviewer
  */
 
-import { createClient } from '../../llm';
 import { LLM_TIMEOUTS } from '../../config/timeouts';
+import { resolveRoleClientForUser } from '../model-role-resolver';
 import {
     CODE_REVIEW_CONFIG,
     REVIEW_DIMENSIONS,
@@ -128,6 +128,8 @@ export interface ReviewInput {
     code: string;
     language?: string;
     filename?: string;
+    /** 'review' role 사용자 매핑 해석용 (미지정 시 전역/기본 티어) */
+    userId?: string;
 }
 
 const EMPTY: CodeReviewResult = {
@@ -141,7 +143,9 @@ export async function reviewCode(input: ReviewInput): Promise<CodeReviewResult> 
     const system = buildCodeReviewSystemPrompt();
     const user = buildCodeReviewUserMessage(input.code, input.language, input.filename);
 
-    const client = createClient({ timeout: LLM_TIMEOUTS.REPORT_GENERATION_TIMEOUT_MS });
+    // 'review' role 해석 (사용자 매핑 → 전역 env → 로컬 default) + 전용 timeout 파생
+    const resolved = await resolveRoleClientForUser('review', input.userId);
+    const client = resolved.client.derive({ timeout: LLM_TIMEOUTS.REPORT_GENERATION_TIMEOUT_MS });
     let raw = '';
     try {
         const response = await client.chat(

--- a/apps/api/src/services/deep-research/report-generator.ts
+++ b/apps/api/src/services/deep-research/report-generator.ts
@@ -6,7 +6,7 @@
  * @module services/deep-research/report-generator
  */
 
-import { type LLMClient, createClient } from '../../llm';
+import { type LLMClient } from '../../llm';
 import type { SearchResult } from '../../mcp/web-search';
 import type { ResearchConfig, SubTopic } from '../deep-research-types';
 import { getUnifiedDatabase } from '../../data/models/unified-database';
@@ -165,9 +165,9 @@ export async function generateReport(params: {
     const prompt = getReportPrompt(config.language, topic, subTopicGuide, meaningfulFindings, sourceList);
 
     // 보고서 생성은 대형 프롬프트·장문 출력으로 전역 LLM_TIMEOUT(SDK)을 초과한다(라이브 검증 확인).
-    // → 전용 긴 타임아웃 클라이언트 사용. (기존 reportController.signal 은 chat 에 전달되지 않아 무효였음)
-    const reportClient = createClient({
-        model: client.model,
+    // → 전용 긴 타임아웃 파생 클라이언트. derive 는 baseUrl/apiKey 를 보존하므로
+    //   role 해석된 외부 endpoint 클라이언트에서도 안전 (createClient 재파생은 외부 baseUrl 상실).
+    const reportClient = client.derive({
         timeout: LLM_TIMEOUTS.REPORT_GENERATION_TIMEOUT_MS,
     });
 

--- a/apps/api/src/services/model-role-resolver.ts
+++ b/apps/api/src/services/model-role-resolver.ts
@@ -39,8 +39,10 @@ import {
     toLocalModelTag,
 } from '../config/model-roles';
 import { EXTERNAL_PROVIDER_CATALOG } from '../config/external-providers';
-import { createClient, LLMClient } from '../llm/client';
-import type { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
+import { createClient, LLMClient } from '../llm';
+import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
+import { UserModelRolesRepository } from '../data/repositories/user-model-roles-repo';
+import { getPool } from '../data/models/unified-database';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('ModelRoleResolver');
@@ -189,4 +191,29 @@ export async function resolveRoleClient(
         logger.warn(`role '${role}' 해석 폴백 (user=${opts.userId ?? '-'}): ${degraded}`);
     }
     return buildLocalResolution(role, tag, source, opts.userId, degraded);
+}
+
+/**
+ * 소비처 편의 진입점 — 사용자 매핑/외부 키 repo 를 DB pool 로 자동 구성해
+ * resolveRoleClient 를 호출한다. 플래그 OFF·userId 없음·pool 미초기화(부팅 초기)
+ * 는 전역/기본 티어로 자연 폴백 (fail-open).
+ */
+export async function resolveRoleClientForUser(
+    role: ModelRole,
+    userId?: string,
+): Promise<RoleClientResolution> {
+    if (!userId || !getConfig().userModelRolesEnabled) {
+        return resolveRoleClient(role, { userId });
+    }
+    try {
+        const pool = getPool();
+        return await resolveRoleClient(role, {
+            userId,
+            userMappingLookup: new UserModelRolesRepository(pool),
+            externalKeysRepo: new ExternalKeysRepository(pool),
+        });
+    } catch (err) {
+        logger.warn(`role '${role}' repo 구성 실패 — 전역 티어 폴백: ${err instanceof Error ? err.message : String(err)}`);
+        return resolveRoleClient(role, { userId });
+    }
 }

--- a/apps/api/src/services/plan-mode/planner.ts
+++ b/apps/api/src/services/plan-mode/planner.ts
@@ -9,8 +9,8 @@
  * @module services/plan-mode/planner
  */
 
-import { createClient } from '../../llm';
 import { LLM_TIMEOUTS } from '../../config/timeouts';
+import { resolveRoleClientForUser } from '../model-role-resolver';
 import { PLAN_MODE_CONFIG } from '../../config/plan-mode';
 import { buildPlanModeSystemPrompt, buildPlanModeUserMessage } from '../../prompts/plan-mode-system';
 import { createLogger } from '../../utils/logger';
@@ -102,6 +102,8 @@ export function normalizePlan(
 export interface PlanInput {
     task: string;
     context?: string;
+    /** 'review' role 사용자 매핑 해석용 (미지정 시 전역/기본 티어) */
+    userId?: string;
 }
 
 /** 빈 계획 (graceful fallback) */
@@ -116,7 +118,9 @@ export async function createPlan(input: PlanInput): Promise<ImplementationPlan> 
     const system = buildPlanModeSystemPrompt();
     const user = buildPlanModeUserMessage(input.task, input.context);
 
-    const client = createClient({ timeout: LLM_TIMEOUTS.REPORT_GENERATION_TIMEOUT_MS });
+    // 'review' role 해석 (사용자 매핑 → 전역 env → 로컬 default) + 전용 timeout 파생
+    const resolved = await resolveRoleClientForUser('review', input.userId);
+    const client = resolved.client.derive({ timeout: LLM_TIMEOUTS.REPORT_GENERATION_TIMEOUT_MS });
     let raw = '';
     try {
         const response = await client.chat(

--- a/apps/api/src/services/security-review/analyzer.ts
+++ b/apps/api/src/services/security-review/analyzer.ts
@@ -12,8 +12,8 @@
  * @module services/security-review/analyzer
  */
 
-import { createClient } from '../../llm';
 import { LLM_TIMEOUTS } from '../../config/timeouts';
+import { resolveRoleClientForUser } from '../model-role-resolver';
 import {
     SECURITY_REVIEW_CONFIG,
     VULN_CATEGORIES,
@@ -153,6 +153,8 @@ export interface AnalyzeInput {
     language?: string;
     filename?: string;
     categories?: string[];
+    /** 'review' role 사용자 매핑 해석용 (미지정 시 전역/기본 티어) */
+    userId?: string;
 }
 
 /**
@@ -170,7 +172,9 @@ export async function analyzeCode(input: AnalyzeInput): Promise<SecurityReviewRe
     const system = buildSecurityReviewSystemPrompt(categories);
     const user = buildSecurityReviewUserMessage(input.code, input.language, input.filename);
 
-    const client = createClient({ timeout: LLM_TIMEOUTS.REPORT_GENERATION_TIMEOUT_MS });
+    // 'review' role 해석 (사용자 매핑 → 전역 env → 로컬 default) + 전용 timeout 파생
+    const resolved = await resolveRoleClientForUser('review', input.userId);
+    const client = resolved.client.derive({ timeout: LLM_TIMEOUTS.REPORT_GENERATION_TIMEOUT_MS });
     let raw = '';
     try {
         const response = await client.chat(

--- a/db/migrations/069_user_model_roles.sql
+++ b/db/migrations/069_user_model_roles.sql
@@ -1,0 +1,26 @@
+-- Migration 069 — user_model_roles 테이블
+--
+-- Role-based Multi-Agent Orchestration Phase 2 (2026-07-15).
+-- 로그인 사용자가 자신이 등록한 모델(로컬 + BYOK 외부)을 역할별로 배정한다.
+-- 해석 우선순위: 이 테이블(사용자 매핑) → OMK_<ROLE>_MODEL env(전역, 로컬만)
+-- → LLM_DEFAULT_MODEL. USER_MODEL_ROLES_ENABLED 플래그로 게이트 (기본 OFF).
+--
+-- role CHECK 는 코드 SoT(config/model-roles.ts MODEL_ROLES)와 정합 유지할 것.
+-- API 계층(user-model-roles.controller)은 이 중 사용자 배정 가능 role
+-- (USER_ASSIGNABLE_MODEL_ROLES: agent/judge/research/spawn/review)만 허용한다.
+
+CREATE TABLE IF NOT EXISTS user_model_roles (
+    user_id        TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role           TEXT NOT NULL CHECK (role IN ('chat', 'agent', 'judge', 'research', 'spawn', 'review', 'router')),
+    full_model_id  TEXT NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, role)
+);
+
+COMMENT ON TABLE user_model_roles IS
+    '사용자별 역할→모델 매핑 (Role-based Multi-Agent Orchestration). 외부 모델은 그 사용자의 user_external_api_keys BYOK 키로 호출.';
+COMMENT ON COLUMN user_model_roles.role IS
+    'LLM 호출 역할 — config/model-roles.ts MODEL_ROLES 와 정합. API 는 agent/judge/research/spawn/review 만 배정 허용.';
+COMMENT ON COLUMN user_model_roles.full_model_id IS
+    '모델 fullId — ''local-llm:<tag>'' | ''<external_provider>:<model>'' | 로컬 태그. 해석은 services/model-role-resolver.';


### PR DESCRIPTION
## 개요
Role-based Multi-Agent Orchestration Phase 3. **PR2(#281) 위에 스택.**

## 변경
- `resolveRoleClientForUser(role, userId)` 편의 진입점 — user_model_roles/BYOK repo 자동 구성, 어떤 실패도 로컬 default 로 fail-open
- `LLMClient.derive(overrides)` — baseUrl/apiKey 보존 파생 (외부 endpoint + 전용 timeout 조합용)
- **agent**: AgentTaskService.execute 진입 시 작업 소유자 기준 해석. 외부 모델 tools 4xx → 로컬 1회 강등 재시도 (NVIDIA 소형 모델 tools 400 대비)
- **judge**: goal judge 별도 해석 — 실행 모델과 판정 모델 분리 배정 가능
- **spawn**: 채팅 경로 spawn_agents 서브에이전트
- **research**: REST 직접 경로 주입 (채팅 진입은 기존 채팅 모델 상속 유지), report-generator 는 derive 로 외부 endpoint 보존
- **review**: code-review/security-review/plan-mode 3종 (MCP `context.userId` 전달)

## 검증
- [x] `tsc --noEmit` / eslint 통과 (max-lines 는 기존 warn)
- [x] 전체 백엔드 unit 2136/2136 통과 (영향권 96개 포함, report-generator 스텁은 derive 계약으로 갱신 — 로컬 보관 테스트)
- [ ] 라이브 E2E (외부 role 배정 task / 키 삭제 폴백) — 플래그 ON + 마이그레이션 적용 후 수행 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)