### PR TITLE
refactor(agent-task): role 클라이언트 분리 — 600줄 가드 복구

### DIFF
--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -14,10 +14,9 @@
  *
  * @module services/AgentTaskService
  */
-import { createClient, type LLMClient } from '../llm';
+import { type LLMClient } from '../llm';
 import type { ChatMessage, ToolDefinition } from '../llm/types';
-import { getModelForRole } from '../config/model-roles';
-import { resolveRoleClientForUser } from './model-role-resolver';
+import { initAgentRoleState, chatTurnWithRoleFallback, judgeClientFor, defaultAgentClient } from './agent-task/role-client';
 import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { getUnifiedDatabase } from '../data/models/unified-database';
 import { AGENT_TASK_LIMITS, AGENT_SPAWN } from '../config/runtime-limits';
@@ -56,14 +55,10 @@ export class AgentTaskService {
 
     private client: LLMClient;
     private readonly abortController = new AbortController();
-    /** 생성자에서 model 명시 시 role 해석을 건너뛴다 (기존 계약 유지) */
-    private readonly explicitModel: boolean;
-    /** role 해석 결과가 외부 provider 인지 — tools 4xx 로컬 폴백 판단용 */
-    private roleClientExternal = false;
-    private roleFallbackDone = false;
+    private readonly explicitModel: boolean; // model 명시 시 role 해석 생략 (기존 계약 유지)
 
     constructor(model?: string) {
-        this.client = createClient({ model: model || getModelForRole('agent') });
+        this.client = defaultAgentClient(model);
         this.explicitModel = !!model;
     }
 
@@ -97,18 +92,9 @@ export class AgentTaskService {
 
         const userCtx: UserContext = { userId, role: userRole };
 
-        // 'agent' role 해석 (사용자 매핑 → 전역 env → 로컬 default, fail-open).
-        // 생성자에서 model 이 명시된 경우는 기존 계약대로 그대로 사용.
-        if (!this.explicitModel) {
-            const resolved = await resolveRoleClientForUser('agent', String(userId));
-            this.client = resolved.client;
-            this.roleClientExternal = resolved.providerId !== 'local-llm';
-            if (resolved.degraded) {
-                logger.warn(`[AgentTask] ${taskId} agent role 폴백: ${resolved.degraded}`);
-            } else if (this.roleClientExternal) {
-                logger.info(`[AgentTask] ${taskId} agent role 외부 모델 사용: ${resolved.fullId}`);
-            }
-        }
+        // 'agent' role 해석 — 상세는 agent-task/role-client (생성자 model 명시 시 그대로 사용)
+        const roleState = await initAgentRoleState(taskId, String(userId), this.explicitModel ? this.client : undefined);
+        this.client = roleState.client;
 
         let stepNumber = input.resume?.fromStep ?? 0;
         let totalTokens = 0;
@@ -334,33 +320,12 @@ export class AgentTaskService {
                 );
                 const callSignal = AbortSignal.any([signal, AbortSignal.timeout(remainingMs)]);
 
-                let result;
-                try {
-                    result = await this.client.chat(conversation, undefined, undefined, {
-                        tools: effectiveTools,
-                        signal: callSignal,
-                        // reasoning OFF — qwen3.6 가 디자인/장문 작업에서 수만 토큰의 thinking 을
-                        // 생성해 토큰 한도를 소진하고 deliverable 을 못 쓰는 폭주 차단.
-                        // 도구 루프의 단계별 reasoning 은 대화 구조 자체가 대신한다.
-                        think: false,
-                    });
-                } catch (chatErr) {
-                    // 외부 role 모델의 4xx(tools 미지원 등 — 예: NVIDIA 소형 모델 tools 400)
-                    // → 로컬 default 로 1회 강등 후 같은 턴 재시도. 재발/그 외 에러는 기존 경로.
-                    const status = (chatErr as { status?: number }).status;
-                    if (this.roleClientExternal && !this.roleFallbackDone
-                        && typeof status === 'number' && status >= 400 && status < 500) {
-                        this.roleFallbackDone = true;
-                        this.roleClientExternal = false;
-                        logger.warn(`[AgentTask] ${taskId} 외부 role 모델 ${status} — 로컬 폴백: ${chatErr instanceof Error ? chatErr.message : chatErr}`);
-                        this.client = createClient({ model: getModelForRole('agent'), userId: String(userId) });
-                        result = await this.client.chat(conversation, undefined, undefined, {
-                            tools: effectiveTools, signal: callSignal, think: false,
-                        });
-                    } else {
-                        throw chatErr;
-                    }
-                }
+                // reasoning OFF + 외부 role 모델 tools 4xx 로컬 폴백 — agent-task/role-client
+                const result = await chatTurnWithRoleFallback(roleState, {
+                    conversation, tools: effectiveTools, signal: callSignal,
+                    taskId, userId: String(userId),
+                });
+                this.client = roleState.client;
                 totalTokens +=
                     (result.metrics?.prompt_tokens ?? 0) + (result.metrics?.completion_tokens ?? 0);
                 // 토큰 상한을 호출 직후 즉시 검사 — 큰 도구 결과로 컨텍스트가 부풀어
@@ -440,9 +405,8 @@ export class AgentTaskService {
                     // 5-3(b): 실행 컨텍스트(사용 도구·턴수·계획 상태)를 함께 제공해 판정 정확도 보강.
                     if (extracted!.artifacts.length === 0 && AGENT_TASK_LIMITS.GOAL_JUDGE_ENABLED) {
                         const execCtx = buildJudgeExecutionContext(usedTools, turn + 1, taskRuntime?.getPlanSnapshot() ?? []);
-                        // 'judge' role 별도 해석 — agent 실행 모델과 판정 모델을 분리 배정 가능.
-                        const judgeResolved = await resolveRoleClientForUser('judge', String(userId));
-                        const achieved = await judgeGoalAchieved(judgeResolved.client, goal, stepContent ?? '', callSignal, execCtx);
+                        const achieved = await judgeGoalAchieved(
+                            await judgeClientFor(String(userId)), goal, stepContent ?? '', callSignal, execCtx);
                         if (achieved === false) {
                             await update({
                                 status: 'failed',

--- a/apps/api/src/services/agent-task/role-client.ts
+++ b/apps/api/src/services/agent-task/role-client.ts
@@ -1,0 +1,91 @@
+/**
+ * Agent Task 의 'agent'/'judge' role 클라이언트 해석 + 외부 모델 폴백 —
+ * AgentTaskService 에서 분리 (파일 크기 가드).
+ * @module services/agent-task/role-client
+ */
+import { createClient, type LLMClient } from '../../llm';
+import type { ChatMessage, ToolDefinition } from '../../llm/types';
+import { getModelForRole } from '../../config/model-roles';
+import { resolveRoleClientForUser } from '../model-role-resolver';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('AgentTaskService');
+
+/** 턴 루프가 들고 다니는 role 클라이언트 상태 — 폴백 시 client 가 교체된다. */
+export interface AgentRoleState {
+    client: LLMClient;
+    /** 외부 provider 해석 여부 — tools 4xx 로컬 폴백 판단용 */
+    external: boolean;
+    /** 폴백은 작업당 1회 — true 면 더 이상 강등하지 않음 */
+    fallbackDone: boolean;
+}
+
+/**
+ * 'agent' role 해석 (사용자 매핑 → 전역 env → 로컬 default, fail-open).
+ * explicitClient 가 주어지면(생성자 model 명시) 해석을 건너뛰고 그대로 사용.
+ */
+export async function initAgentRoleState(
+    taskId: string,
+    userId: string,
+    explicitClient?: LLMClient,
+): Promise<AgentRoleState> {
+    if (explicitClient) {
+        return { client: explicitClient, external: false, fallbackDone: true };
+    }
+    const resolved = await resolveRoleClientForUser('agent', userId);
+    const external = resolved.providerId !== 'local-llm';
+    if (resolved.degraded) {
+        logger.warn(`[AgentTask] ${taskId} agent role 폴백: ${resolved.degraded}`);
+    } else if (external) {
+        logger.info(`[AgentTask] ${taskId} agent role 외부 모델 사용: ${resolved.fullId}`);
+    }
+    return { client: resolved.client, external, fallbackDone: false };
+}
+
+/**
+ * 턴 1회 chat 호출. reasoning OFF — qwen3.6 가 디자인/장문 작업에서 수만 토큰의
+ * thinking 을 생성해 토큰 한도를 소진하고 deliverable 을 못 쓰는 폭주 차단.
+ * 도구 루프의 단계별 reasoning 은 대화 구조 자체가 대신한다.
+ *
+ * 외부 role 모델의 4xx(tools 미지원 등 — 예: NVIDIA 소형 모델 tools 400) 는
+ * 로컬 default 로 1회 강등 후 같은 턴을 재시도한다 (state.client 교체).
+ * 재발/그 외 에러는 기존 경로대로 throw.
+ */
+export async function chatTurnWithRoleFallback(
+    state: AgentRoleState,
+    p: {
+        conversation: ChatMessage[];
+        tools: ToolDefinition[];
+        signal: AbortSignal;
+        taskId: string;
+        userId: string;
+    },
+): Promise<Awaited<ReturnType<LLMClient['chat']>>> {
+    const call = () => state.client.chat(p.conversation, undefined, undefined, {
+        tools: p.tools, signal: p.signal, think: false,
+    });
+    try {
+        return await call();
+    } catch (chatErr) {
+        const status = (chatErr as { status?: number }).status;
+        if (state.external && !state.fallbackDone
+            && typeof status === 'number' && status >= 400 && status < 500) {
+            state.fallbackDone = true;
+            state.external = false;
+            logger.warn(`[AgentTask] ${p.taskId} 외부 role 모델 ${status} — 로컬 폴백: ${chatErr instanceof Error ? chatErr.message : chatErr}`);
+            state.client = createClient({ model: getModelForRole('agent'), userId: p.userId });
+            return await call();
+        }
+        throw chatErr;
+    }
+}
+
+/** 'judge' role 별도 해석 — agent 실행 모델과 판정 모델을 분리 배정 가능. */
+export async function judgeClientFor(userId: string): Promise<LLMClient> {
+    return (await resolveRoleClientForUser('judge', userId)).client;
+}
+
+/** 생성자 기본 클라이언트 — model 미지정 시 'agent' role 전역 티어. */
+export function defaultAgentClient(model?: string): LLMClient {
+    return createClient({ model: model || getModelForRole('agent') });
+}


### PR DESCRIPTION
## 개요
#282 머지로 main CI Gate 3(600줄 가드)가 AgentTaskService.ts(636줄)에서 실패 — role 배선 로직을 `services/agent-task/role-client.ts`로 추출해 600줄로 복구. 동작 무변경.

## 검증
- [x] tsc / eslint(0 errors) / agent-task·model-role unit 79/79
- [x] wc -l 600 (가드 `-gt 600` 통과) — ⚠️ 여유 0, 다음 수정 시 추가 분할 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)