### PR TITLE
fix(web): 역할 배정 뱃지 줄바꿈 방지

### DIFF
--- a/apps/web/components/settings/model-roles-section.tsx
+++ b/apps/web/components/settings/model-roles-section.tsx
@@ -132,7 +132,9 @@ export function ModelRolesSection() {
                         {t(`roles.${role}.label`)}
                       </span>
                       {current !== DEFAULT_VALUE && (
-                        <Badge tone="accent">{t("assignedBadge")}</Badge>
+                        <Badge tone="accent" className="shrink-0 whitespace-nowrap">
+                          {t("assignedBadge")}
+                        </Badge>
                       )}
                     </div>
                     <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
라이브 스크린샷 검증에서 '배정됨' 뱃지가 좁은 flex 안에서 세로로 줄바꿈되는 문제 — shrink-0 + whitespace-nowrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)