### PR TITLE
fix(web): 역할 라벨 줄바꿈 방지

### DIFF
--- a/apps/web/components/settings/model-roles-section.tsx
+++ b/apps/web/components/settings/model-roles-section.tsx
@@ -128,7 +128,7 @@ export function ModelRolesSection() {
                 >
                   <div className="min-w-0">
                     <div className="flex items-center gap-2">
-                      <span className="text-sm font-medium">
+                      <span className="whitespace-nowrap text-sm font-medium">
                         {t(`roles.${role}.label`)}
                       </span>
                       {current !== DEFAULT_VALUE && (


### PR DESCRIPTION
라이브 스크린샷 재검증에서 role 라벨('목표 판정')이 좁은 flex 안에서 세로로 줄바꿈 — whitespace-nowrap 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)