### PR TITLE
feat(model-roles): Phase A — 서버 공용 외부 키 + 사용량 귀속

### DIFF
--- a/apps/api/src/config/model-roles.ts
+++ b/apps/api/src/config/model-roles.ts
@@ -200,18 +200,17 @@ export async function validateModels(
 
     logger.info(`모델 역할 매핑: ${JSON.stringify(roleModels)}`);
 
-    // 전역 env 의 외부 fullId 거부 — 외부 모델은 사용자별 매핑(BYOK)에서만 허용
-    const externalMisconfigs = Object.entries(roleModels)
+    // 전역 env 의 외부 fullId — 서버 공용 키(server_external_api_keys) 등록이 전제.
+    // 부팅 시점엔 DB 접근 없이 경고만 남긴다 (config 계층 — data 의존 금지).
+    // 실제 강제는 런타임 resolver: 키 미등록/비활성/상한 초과면 로컬 default 로 강등.
+    const externalGlobals = Object.entries(roleModels)
         .filter(([, model]) => model && isExternalFullId(model));
-    if (externalMisconfigs.length > 0) {
-        const msg = `전역 role env 에 외부 provider fullId 는 사용할 수 없습니다 (서버 공용 키 없음): ` +
-            externalMisconfigs.map(([role, model]) => `${role}=${model}`).join(', ') +
-            `. 외부 모델은 사용자별 역할 매핑(BYOK)에서만 배정 가능합니다.`;
-        if (failFast) {
-            logger.error(msg);
-            throw new Error(msg);
-        }
-        logger.warn(msg);
+    if (externalGlobals.length > 0) {
+        logger.warn(
+            `전역 role 에 외부 provider fullId 설정됨: ` +
+            externalGlobals.map(([role, model]) => `${role}=${model}`).join(', ') +
+            `. 해당 provider 의 서버 공용 키가 등록·활성 상태여야 하며, 아니면 런타임에 로컬로 강등됩니다.`,
+        );
     }
 
     const uniqueModels = Array.from(new Set(

--- a/apps/api/src/data/repositories/server-external-keys-repo.ts
+++ b/apps/api/src/data/repositories/server-external-keys-repo.ts
@@ -1,0 +1,150 @@
+/**
+ * @module data/repositories/server-external-keys-repo
+ * @description 서버 공용(운영자 소유) 외부 LLM provider 키 저장소.
+ *
+ * Role-based Orchestration 2차 Phase A. 전역 role 매핑 전용 —
+ * 사용자별 매핑/채팅 명시 선택은 user_external_api_keys(BYOK)만 사용한다.
+ * 키 암호화는 utils/token-crypto SSoT (AES-256-GCM, TOKEN_ENCRYPTION_KEY) 재사용.
+ *
+ * @see db/migrations/070_server_external_api_keys.sql
+ */
+import { BaseRepository } from './base-repository';
+import { encryptToken, decryptToken } from '../../utils/token-crypto';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('ServerExternalKeysRepo');
+
+export interface ServerExternalKeyRow {
+    providerId: string;
+    baseUrl: string | null;
+    isActive: boolean;
+    dailyTokenLimit: number;
+    monthlyTokenLimit: number | null;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+interface DbRow {
+    provider_id: string;
+    encrypted_key: string;
+    base_url: string | null;
+    is_active: boolean;
+    daily_token_limit: string | number;
+    monthly_token_limit: string | number | null;
+    created_at: Date;
+    updated_at: Date;
+    [key: string]: unknown;
+}
+
+function toRow(row: DbRow): ServerExternalKeyRow {
+    return {
+        providerId: row.provider_id,
+        baseUrl: row.base_url,
+        isActive: row.is_active,
+        dailyTokenLimit: Number(row.daily_token_limit),
+        monthlyTokenLimit: row.monthly_token_limit === null ? null : Number(row.monthly_token_limit),
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+    };
+}
+
+export class ServerExternalKeysRepository extends BaseRepository {
+    async get(providerId: string): Promise<ServerExternalKeyRow | null> {
+        const result = await this.query<DbRow>(
+            `SELECT * FROM server_external_api_keys WHERE provider_id = $1`,
+            [providerId],
+        );
+        return result.rows[0] ? toRow(result.rows[0]) : null;
+    }
+
+    async list(): Promise<ServerExternalKeyRow[]> {
+        const result = await this.query<DbRow>(
+            `SELECT * FROM server_external_api_keys ORDER BY provider_id`,
+        );
+        return result.rows.map(toRow);
+    }
+
+    /** 평문 키 반환 — 복호화 실패 시 null (호출자가 폴백 처리) */
+    async decryptKey(providerId: string): Promise<string | null> {
+        const result = await this.query<DbRow>(
+            `SELECT encrypted_key FROM server_external_api_keys WHERE provider_id = $1`,
+            [providerId],
+        );
+        const enc = result.rows[0]?.encrypted_key;
+        if (!enc) return null;
+        try {
+            return decryptToken(enc);
+        } catch (err) {
+            logger.error(`서버 키 복호화 실패 (${providerId}):`, err);
+            return null;
+        }
+    }
+
+    /** 등록/갱신 — 평문 키는 즉시 암호화, daily 상한 필수 */
+    async upsert(input: {
+        providerId: string;
+        apiKey: string;
+        baseUrl?: string | null;
+        dailyTokenLimit: number;
+        monthlyTokenLimit?: number | null;
+    }): Promise<ServerExternalKeyRow> {
+        const encrypted = encryptToken(input.apiKey);
+        const result = await this.query<DbRow>(
+            `INSERT INTO server_external_api_keys
+                (provider_id, encrypted_key, base_url, daily_token_limit, monthly_token_limit)
+             VALUES ($1, $2, $3, $4, $5)
+             ON CONFLICT (provider_id) DO UPDATE SET
+                encrypted_key = EXCLUDED.encrypted_key,
+                base_url = EXCLUDED.base_url,
+                daily_token_limit = EXCLUDED.daily_token_limit,
+                monthly_token_limit = EXCLUDED.monthly_token_limit,
+                is_active = TRUE,
+                updated_at = now()
+             RETURNING *`,
+            [
+                input.providerId,
+                encrypted,
+                input.baseUrl ?? null,
+                input.dailyTokenLimit,
+                input.monthlyTokenLimit ?? null,
+            ],
+        );
+        return toRow(result.rows[0]);
+    }
+
+    async delete(providerId: string): Promise<boolean> {
+        const result = await this.query(
+            `DELETE FROM server_external_api_keys WHERE provider_id = $1`,
+            [providerId],
+        );
+        return (result.rowCount ?? 0) > 0;
+    }
+
+    /** 서버 키 호출별 사용량 기록 (fire-and-forget 호출 전제 — throw 안 함) */
+    async recordUsage(input: {
+        providerId: string;
+        modelId: string;
+        role?: string;
+        callerUserId?: string;
+        inputTokens: number;
+        outputTokens: number;
+    }): Promise<void> {
+        try {
+            await this.query(
+                `INSERT INTO server_external_key_usage
+                    (provider_id, model_id, role, caller_user_id, input_tokens, output_tokens)
+                 VALUES ($1, $2, $3, $4, $5, $6)`,
+                [
+                    input.providerId,
+                    input.modelId,
+                    input.role ?? null,
+                    input.callerUserId ?? null,
+                    input.inputTokens,
+                    input.outputTokens,
+                ],
+            );
+        } catch (err) {
+            logger.warn(`서버 키 사용량 기록 실패 (무시): ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+}

--- a/apps/api/src/llm/client.ts
+++ b/apps/api/src/llm/client.ts
@@ -184,6 +184,13 @@ export class LLMClient {
                 if (totalTokens > 0) {
                     getApiUsageTracker().record(totalTokens);  // 전역 aggregate (dashboard 관측용)
                     void recordUserUsage(this.config.userId, totalTokens, Date.now());  // per-user enforcement 누적
+                    try {
+                        this.config.onUsage?.({
+                            model: poolDecision.model,
+                            promptTokens: result.metrics?.prompt_tokens ?? 0,
+                            completionTokens: result.metrics?.completion_tokens ?? 0,
+                        });
+                    } catch { /* 관측 훅 실패는 호출 결과에 영향 없음 */ }
                 }
                 span.setAttribute('llm.prompt_tokens', result.metrics?.prompt_tokens ?? 0);
                 span.setAttribute('llm.completion_tokens', result.metrics?.completion_tokens ?? 0);

--- a/apps/api/src/llm/types.ts
+++ b/apps/api/src/llm/types.ts
@@ -25,6 +25,12 @@ export interface LLMConfig {
     timeout: number;
     /** 요청 사용자 ID — per-user 토큰 쿼터 enforcement 용 (미설정 시 enforcement skip) */
     userId?: string;
+    /**
+     * 호출별 usage 관측 훅 — role 해석된 외부 endpoint 클라이언트의 사용량 귀속용
+     * (BYOK → external_provider_usage, 서버 키 → server_external_key_usage).
+     * 예외는 client 가 삼킨다 (관측 실패가 호출을 죽이지 않음).
+     */
+    onUsage?: (usage: { model: string; promptTokens: number; completionTokens: number }) => void;
 }
 
 /**

--- a/apps/api/src/services/model-role-resolver.ts
+++ b/apps/api/src/services/model-role-resolver.ts
@@ -42,7 +42,9 @@ import { EXTERNAL_PROVIDER_CATALOG } from '../config/external-providers';
 import { createClient, LLMClient } from '../llm';
 import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
 import { UserModelRolesRepository } from '../data/repositories/user-model-roles-repo';
+import { ServerExternalKeysRepository } from '../data/repositories/server-external-keys-repo';
 import { getPool } from '../data/models/unified-database';
+import { checkServerKeyBudget, recordServerKeyUsage } from './server-key-quota';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('ModelRoleResolver');
@@ -73,6 +75,13 @@ export interface ResolveRoleClientOptions {
     userMappingLookup?: UserModelRoleLookup;
     /** 외부 BYOK 키 저장소 — 미주입 시 외부 모델 매핑은 폴백 처리 */
     externalKeysRepo?: ExternalKeysRepository;
+    /**
+     * 서버 공용 키 저장소 — 전역(env/DB) 티어의 외부 fullId 실행용.
+     * 미주입 시 전역 외부 fullId 는 종전대로 로컬 강등. (사용자 티어와 무관 —
+     * USER_MODEL_ROLES_ENABLED 플래그의 게이트 대상이 아님, 운영자 opt-in 2중:
+     * 전역 매핑 설정 + 서버 키 등록)
+     */
+    serverKeysRepo?: ServerExternalKeysRepository;
 }
 
 function catalogEntry(providerId: string) {
@@ -130,12 +139,73 @@ async function tryBuildExternalResolution(
 
     const baseUrl = keyRow.baseUrl || entry.defaultBaseUrl;
     return {
-        client: createClient({ baseUrl, apiKey: plaintextKey, model: modelId, userId }),
+        client: createClient({
+            baseUrl, apiKey: plaintextKey, model: modelId, userId,
+            // BYOK 사용량 귀속 — 비용 대시보드(external_provider_usage) 반영 (fire-and-forget)
+            onUsage: (u) => void externalKeysRepo.recordUsage({
+                userId, providerId, modelId: u.model,
+                inputTokens: u.promptTokens, outputTokens: u.completionTokens,
+            }).catch(() => { /* 관측 실패 무시 */ }),
+        }),
         role,
         fullId,
         providerId,
         modelId,
         source: 'user',
+    };
+}
+
+/**
+ * 전역 티어의 외부 fullId 를 서버 공용 키로 실행 클라이언트화.
+ * 실패 시 실패 사유 문자열 반환 (fail-open 폴백용). 상한(hard gate) 포함.
+ */
+async function tryBuildServerKeyResolution(
+    role: ModelRole,
+    fullId: string,
+    userId: string | undefined,
+    serverKeysRepo: ServerExternalKeysRepository,
+): Promise<RoleClientResolution | string> {
+    const idx = fullId.indexOf(':');
+    const providerId = fullId.slice(0, idx);
+    const modelId = fullId.slice(idx + 1);
+    if (!modelId) return `'${fullId}' 모델 id 누락`;
+
+    const entry = catalogEntry(providerId);
+    if (!entry) return `카탈로그에 없는 provider '${providerId}'`;
+    if (entry.sdkType !== 'openai-compatible') {
+        return `provider '${providerId}' sdkType '${entry.sdkType}' 은 role 실행 미지원`;
+    }
+
+    const row = await serverKeysRepo.get(providerId);
+    if (!row) return `서버 공용 키 미등록 ('${providerId}')`;
+    if (!row.isActive) return `서버 공용 키 비활성 ('${providerId}')`;
+
+    const budgetReason = await checkServerKeyBudget(
+        providerId, row.dailyTokenLimit, row.monthlyTokenLimit, Date.now(),
+    );
+    if (budgetReason) return budgetReason;
+
+    const plaintextKey = await serverKeysRepo.decryptKey(providerId);
+    if (!plaintextKey) return `서버 키 복호화 실패 ('${providerId}')`;
+
+    const baseUrl = row.baseUrl || entry.defaultBaseUrl;
+    return {
+        client: createClient({
+            baseUrl, apiKey: plaintextKey, model: modelId, userId,
+            // 서버 키 사용량 귀속(운영자 비용 뷰) + 상한 카운터 누적
+            onUsage: (u) => {
+                void serverKeysRepo.recordUsage({
+                    providerId, modelId: u.model, role, callerUserId: userId,
+                    inputTokens: u.promptTokens, outputTokens: u.completionTokens,
+                });
+                void recordServerKeyUsage(providerId, u.promptTokens + u.completionTokens, Date.now());
+            },
+        }),
+        role,
+        fullId,
+        providerId,
+        modelId,
+        source: 'global',
     };
 }
 
@@ -181,8 +251,18 @@ export async function resolveRoleClient(
     const source: RoleClientResolution['source'] = hasRoleEnvOverride(role) ? 'global' : 'default';
     let tag = toLocalModelTag(globalValue);
     if (!tag) {
-        // 전역 env 에 외부 fullId — 정책 위반 (validateModels 가 부팅 시 경고). 로컬 default 로 강등.
-        degradedReasons.push(`전역 role env 의 외부 fullId '${globalValue}' 는 무시됨 (로컬만 허용)`);
+        // 전역 티어의 외부 fullId — 서버 공용 키가 등록돼 있으면 그 키로 실행 (Phase A).
+        if (opts.serverKeysRepo) {
+            const result = await tryBuildServerKeyResolution(role, globalValue, opts.userId, opts.serverKeysRepo)
+                .catch((err) => `서버 키 해석 실패: ${err instanceof Error ? err.message : String(err)}`);
+            if (typeof result !== 'string') {
+                if (degradedReasons.length > 0) result.degraded = degradedReasons.join(' → ');
+                return result;
+            }
+            degradedReasons.push(result);
+        } else {
+            degradedReasons.push(`전역 role 의 외부 fullId '${globalValue}' — 서버 키 저장소 미주입`);
+        }
         tag = cfg.llmDefaultModel;
     }
 
@@ -215,18 +295,18 @@ export async function resolveRoleClientForUser(
     role: ModelRole,
     userId?: string,
 ): Promise<RoleClientResolution> {
-    if (!userId || !getConfig().userModelRolesEnabled) {
-        return resolveRoleClient(role, { userId });
-    }
+    const opts: ResolveRoleClientOptions = { userId };
     try {
         const pool = getPool();
-        return await resolveRoleClient(role, {
-            userId,
-            userMappingLookup: new UserModelRolesRepository(pool),
-            externalKeysRepo: new ExternalKeysRepository(pool),
-        });
+        // 서버 키 티어는 사용자 플래그와 무관 (운영자 opt-in — 전역 매핑 + 키 등록)
+        opts.serverKeysRepo = new ServerExternalKeysRepository(pool);
+        if (userId && getConfig().userModelRolesEnabled) {
+            opts.userMappingLookup = new UserModelRolesRepository(pool);
+            opts.externalKeysRepo = new ExternalKeysRepository(pool);
+        }
     } catch (err) {
+        // pool 미초기화(부팅 초기) 등 — 전역 env/default 티어만으로 진행 (fail-open)
         logger.warn(`role '${role}' repo 구성 실패 — 전역 티어 폴백: ${err instanceof Error ? err.message : String(err)}`);
-        return resolveRoleClient(role, { userId });
     }
+    return resolveRoleClient(role, opts);
 }

--- a/apps/api/src/services/server-key-quota.ts
+++ b/apps/api/src/services/server-key-quota.ts
@@ -1,0 +1,73 @@
+/**
+ * @module services/server-key-quota
+ * @description 서버 공용 외부 키 토큰 상한 — KVStore calendar-bucket (llm/user-quota 패턴).
+ *
+ * 비용 주체가 운영자이므로 상한은 hard gate: 초과 시 role 해석이 로컬로 강등된다.
+ * KVStore 장애 시 fail-open (가용성 우선 — user-quota 와 동일 정책).
+ * 멀티프로세스 정합엔 STORAGE_BACKEND=redis 필요 (user-quota 와 동일 제약).
+ */
+import { getKeyValueStore } from '../storage';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('ServerKeyQuota');
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+// 고정 30일 윈도우 (calendar-month 대신 — user-quota week 버킷과 동일한 race-free 방식)
+const MONTH_MS = 30 * DAY_MS;
+const DAY_TTL_MS = 2 * DAY_MS;
+const MONTH_TTL_MS = 2 * MONTH_MS;
+
+function dayKey(providerId: string, now: number): string {
+    return `srvkeyq:${providerId}:d:${Math.floor(now / DAY_MS)}`;
+}
+function monthKey(providerId: string, now: number): string {
+    return `srvkeyq:${providerId}:m:${Math.floor(now / MONTH_MS)}`;
+}
+
+/**
+ * 상한 검사 — 사용 가능하면 null, 불가면 사유 문자열 반환 (resolver 폴백 사유로 사용).
+ * daily=0 은 "사용 불가" 로 해석 (등록만 하고 잠근 상태).
+ */
+export async function checkServerKeyBudget(
+    providerId: string,
+    dailyLimit: number,
+    monthlyLimit: number | null,
+    now: number,
+): Promise<string | null> {
+    if (dailyLimit <= 0) return `서버 키 '${providerId}' 일 상한이 0 (잠금 상태)`;
+    try {
+        const store = getKeyValueStore();
+        const [dUsed, mUsed] = await Promise.all([
+            store.get<number>(dayKey(providerId, now)),
+            store.get<number>(monthKey(providerId, now)),
+        ]);
+        const daily = typeof dUsed === 'number' ? dUsed : 0;
+        const monthly = typeof mUsed === 'number' ? mUsed : 0;
+        if (daily >= dailyLimit) {
+            return `서버 키 '${providerId}' 일 토큰 상한 초과 (${daily}/${dailyLimit})`;
+        }
+        if (monthlyLimit !== null && monthlyLimit > 0 && monthly >= monthlyLimit) {
+            return `서버 키 '${providerId}' 월 토큰 상한 초과 (${monthly}/${monthlyLimit})`;
+        }
+        return null;
+    } catch (e) {
+        logger.warn('서버 키 상한 조회 실패 — fail-open:', e);
+        return null;
+    }
+}
+
+/** 사용량 누적 (fire-and-forget) */
+export async function recordServerKeyUsage(providerId: string, tokens: number, now: number): Promise<void> {
+    if (!Number.isFinite(tokens) || tokens <= 0) return;
+    try {
+        const store = getKeyValueStore();
+        const dk = dayKey(providerId, now);
+        const mk = monthKey(providerId, now);
+        await Promise.all([
+            store.incrBy(dk, tokens).then(() => store.expire(dk, DAY_TTL_MS)),
+            store.incrBy(mk, tokens).then(() => store.expire(mk, MONTH_TTL_MS)),
+        ]);
+    } catch (e) {
+        logger.warn('서버 키 사용량 누적 실패 (무시):', e);
+    }
+}

--- a/db/migrations/070_server_external_api_keys.sql
+++ b/db/migrations/070_server_external_api_keys.sql
@@ -1,0 +1,41 @@
+-- Migration 070 — 서버 공용 외부 키 + 서버 키 사용량
+--
+-- Role-based Orchestration 2차 Phase A (2026-07-15).
+-- 운영자가 서버 레벨 외부 provider 키를 등록해 "전역 role 매핑"에 외부 모델을
+-- 배정할 수 있게 한다 (사용자별 매핑·채팅 명시 선택은 계속 BYOK 전용 — 과금 통제).
+-- 상한(daily_token_limit)은 등록 시 필수 — 무제한 운영자 과금 방지.
+
+CREATE TABLE IF NOT EXISTS server_external_api_keys (
+    provider_id          TEXT PRIMARY KEY,
+    encrypted_key        TEXT NOT NULL,          -- token-crypto v1:iv:ct:tag (AES-256-GCM)
+    base_url             TEXT,                   -- NULL 이면 카탈로그 defaultBaseUrl
+    is_active            BOOLEAN NOT NULL DEFAULT TRUE,
+    daily_token_limit    BIGINT NOT NULL,        -- 필수 상한 (0 = 사용 불가로 해석)
+    monthly_token_limit  BIGINT,                 -- NULL = 월 상한 없음 (일 상한만)
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE server_external_api_keys IS
+    '서버 공용(운영자 소유) 외부 LLM provider 키 — 전역 role 매핑 전용. 사용자별 매핑/채팅은 BYOK 만 사용.';
+COMMENT ON COLUMN server_external_api_keys.daily_token_limit IS
+    '일 토큰 상한 (필수). 초과 시 role 해석이 로컬 default 로 fail-open 강등.';
+
+-- 서버 키 호출별 사용량 — external_provider_usage(사용자 BYOK 과금 뷰)와 분리.
+-- (사용자 테이블 FK 없음: 호출자는 참고용 텍스트 — 비용 주체는 운영자)
+CREATE TABLE IF NOT EXISTS server_external_key_usage (
+    id             BIGSERIAL PRIMARY KEY,
+    provider_id    TEXT NOT NULL,
+    model_id       TEXT NOT NULL,
+    role           TEXT,                        -- 해석된 ModelRole (관측용)
+    caller_user_id TEXT,                        -- 호출 사용자 (참고용, FK 없음)
+    occurred_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    input_tokens   INTEGER NOT NULL DEFAULT 0,
+    output_tokens  INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_server_key_usage_provider_date
+    ON server_external_key_usage (provider_id, occurred_at DESC);
+
+COMMENT ON TABLE server_external_key_usage IS
+    '서버 공용 키 호출별 사용량 — 운영자 비용 관측. 사용자 BYOK 사용량(external_provider_usage)과 분리.';


### PR DESCRIPTION
## 개요
Role-based Orchestration 2차 Phase A (계획: docs/superpowers/plans/2026-07-15-model-roles-phase2-roadmap.md, 로컬 보관). 서버 공용 키로 **전역 role 매핑에 외부 모델** 배정 가능 + 1차의 usage 관측 gap 해소.

## 변경
- 070 `server_external_api_keys`(daily 상한 필수) + `server_external_key_usage`(운영자 비용 뷰) — 수동 적용 필요
- resolver: 전역 티어 외부 fullId → 서버 키 실행(활성+상한 통과 시), 실패는 로컬 강등 fail-open. **적용 범위 = 전역 role 매핑 전용** (사용자 매핑/채팅은 BYOK 만 — 과금 통제)
- KVStore 일/30일 상한 hard gate (`server-key-quota`)
- `LLMConfig.onUsage` 훅 — BYOK role 호출 → `external_provider_usage`, 서버 키 호출 → `server_external_key_usage`
- `validateModels` 전역 외부 fullId 경고로 완화 (런타임 강제)

## 검증
- [x] tsc / eslint / 전체 unit 2140 통과 (resolver 27 — 서버 키 성공/미등록/잠금/플래그독립/BYOK우선 포함)
- [ ] live: 070 적용 → 서버 키 등록 → 전역 judge 외부 해석·호출·usage 행·상한 강등 확인 (merge 후 수행)

관리 API/UI 는 Phase B 에서 제공 (그 전까지 서버 키 등록은 repo/SQL 직접).

🤖 Generated with [Claude Code](https://claude.com/claude-code)