### PR TITLE
feat(model-roles): Phase B — Admin 전역 매핑(L3) + 서버 키 관리 UI

### DIFF
--- a/apps/api/src/data/repositories/global-model-roles-repo.ts
+++ b/apps/api/src/data/repositories/global-model-roles-repo.ts
@@ -1,0 +1,51 @@
+/**
+ * @module data/repositories/global-model-roles-repo
+ * @description 전역 역할→모델 매핑 (Admin UI, L3) 저장소.
+ *
+ * 해석 우선순위에서 사용자 매핑 다음, env 전역 이전에 조회된다.
+ * @see db/migrations/071_global_model_roles.sql
+ */
+import { BaseRepository } from './base-repository';
+import type { ModelRole } from '../../config/model-roles';
+
+export interface GlobalModelRoleRow {
+    role: ModelRole;
+    fullModelId: string;
+    updatedAt: Date;
+}
+
+interface DbRow {
+    role: ModelRole;
+    full_model_id: string;
+    updated_at: Date;
+    [key: string]: unknown;
+}
+
+function toRow(row: DbRow): GlobalModelRoleRow {
+    return { role: row.role, fullModelId: row.full_model_id, updatedAt: row.updated_at };
+}
+
+export class GlobalModelRolesRepository extends BaseRepository {
+    async list(): Promise<GlobalModelRoleRow[]> {
+        const result = await this.query<DbRow>(`SELECT * FROM global_model_roles ORDER BY role`);
+        return result.rows.map(toRow);
+    }
+
+    async upsert(role: ModelRole, fullModelId: string): Promise<GlobalModelRoleRow> {
+        const result = await this.query<DbRow>(
+            `INSERT INTO global_model_roles (role, full_model_id)
+             VALUES ($1, $2)
+             ON CONFLICT (role) DO UPDATE SET
+                full_model_id = EXCLUDED.full_model_id,
+                updated_at = now()
+             RETURNING *`,
+            [role, fullModelId],
+        );
+        return toRow(result.rows[0]);
+    }
+
+    async delete(role: ModelRole): Promise<boolean> {
+        const result = await this.query(`DELETE FROM global_model_roles WHERE role = $1`, [role]);
+        return (result.rowCount ?? 0) > 0;
+    }
+}

--- a/apps/api/src/routes/admin-model-roles.routes.ts
+++ b/apps/api/src/routes/admin-model-roles.routes.ts
@@ -1,0 +1,183 @@
+/**
+ * @module routes/admin-model-roles
+ * @description 전역 역할→모델 매핑(L3) + 서버 공용 외부 키 관리 — admin 전용.
+ *
+ * Role-based Orchestration 2차 Phase B.
+ *
+ * 엔드포인트 (모두 requireAuth + requireAdmin):
+ *   GET    /api/admin/model-roles                     — 전역 DB 매핑 + env 폴백 현황
+ *   PUT    /api/admin/model-roles/:role               — 배정 (body: { model })
+ *   DELETE /api/admin/model-roles/:role               — 해제 (env/default 폴백 복귀)
+ *   GET    /api/admin/server-external-keys            — 서버 키 목록 (키 값 미노출)
+ *   PUT    /api/admin/server-external-keys/:providerId — 등록/갱신 (daily 상한 필수)
+ *   DELETE /api/admin/server-external-keys/:providerId
+ *
+ * 전역 매핑의 외부 fullId 는 해당 provider 의 서버 공용 키 등록·활성이 전제(400).
+ * 변경은 logAudit 기록. resolver 캐시(60s)는 같은 프로세스 변경 시 즉시 무효화.
+ */
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+import { requireAuth, requireAdmin } from '../auth';
+import { validate } from '../middlewares/validation';
+import { asyncHandler } from '../utils/error-handler';
+import { success, badRequest, notFound } from '../utils/api-response';
+import { getPool } from '../data/models/unified-database';
+import { GlobalModelRolesRepository } from '../data/repositories/global-model-roles-repo';
+import { ServerExternalKeysRepository } from '../data/repositories/server-external-keys-repo';
+import { clearGlobalRolesCache } from '../services/model-role-resolver';
+import {
+    ModelRole,
+    MODEL_ROLES,
+    getAllRoleModels,
+    isExternalFullId,
+    toLocalModelTag,
+} from '../config/model-roles';
+import { EXTERNAL_PROVIDER_CATALOG } from '../config/external-providers';
+import { getAuditService } from '../services/AuditService';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('AdminModelRolesRoutes');
+
+const MAX_MODEL_ID_CHARS = 200;
+
+const putRoleSchema = z.object({
+    model: z.string().min(1).max(MAX_MODEL_ID_CHARS),
+});
+
+const putServerKeySchema = z.object({
+    apiKey: z.string().min(8).max(500),
+    baseUrl: z.url().max(500).optional(),
+    dailyTokenLimit: z.number().int().min(0),
+    monthlyTokenLimit: z.number().int().min(0).nullable().optional(),
+});
+
+function parseRole(value: string): ModelRole | null {
+    return (MODEL_ROLES as readonly string[]).includes(value) ? (value as ModelRole) : null;
+}
+
+function adminUserId(req: Request): string | undefined {
+    return req.user?.id !== undefined ? String(req.user.id) : undefined;
+}
+
+function auditChange(req: Request, action: string, details: Record<string, unknown>): void {
+    void getAuditService().logAudit({
+        action,
+        userId: adminUserId(req),
+        resourceType: 'model_role',
+        details,
+    }).catch(() => { /* audit 실패는 응답에 영향 없음 */ });
+}
+
+export const adminModelRolesRouter = Router();
+adminModelRolesRouter.use(requireAuth, requireAdmin);
+
+/* ── 전역 역할 매핑 ─────────────────────────────────────── */
+
+adminModelRolesRouter.get('/model-roles', asyncHandler(async (_req: Request, res: Response) => {
+    const repo = new GlobalModelRolesRepository(getPool());
+    const mappings = await repo.list();
+    res.json(success({
+        mappings,
+        roles: MODEL_ROLES,
+        // env(L1)/default 폴백 현황 — DB 매핑이 없을 때 실제 적용되는 값
+        envFallback: getAllRoleModels(),
+    }));
+}));
+
+adminModelRolesRouter.put('/model-roles/:role', validate(putRoleSchema), asyncHandler(async (req: Request, res: Response) => {
+    const role = parseRole(req.params.role);
+    if (!role) {
+        res.status(400).json(badRequest(`알 수 없는 role: '${req.params.role}' (허용: ${MODEL_ROLES.join(', ')})`));
+        return;
+    }
+    const fullId = (req.body as z.infer<typeof putRoleSchema>).model.trim();
+
+    if (isExternalFullId(fullId)) {
+        const providerId = fullId.slice(0, fullId.indexOf(':'));
+        const entry = EXTERNAL_PROVIDER_CATALOG.find((p) => p.id === providerId);
+        if (!entry || entry.sdkType !== 'openai-compatible') {
+            res.status(400).json(badRequest(`provider '${providerId}' 는 역할 배정을 지원하지 않습니다`));
+            return;
+        }
+        const serverKey = await new ServerExternalKeysRepository(getPool()).get(providerId);
+        if (!serverKey || !serverKey.isActive) {
+            res.status(400).json(badRequest(`'${providerId}' 서버 공용 키를 먼저 등록하세요 (전역 매핑은 BYOK 가 아닌 서버 키로 실행됩니다)`));
+            return;
+        }
+    } else if (!toLocalModelTag(fullId)) {
+        res.status(400).json(badRequest(`해석 불가한 모델 id: '${fullId}'`));
+        return;
+    }
+
+    const repo = new GlobalModelRolesRepository(getPool());
+    const mapping = await repo.upsert(role, fullId);
+    clearGlobalRolesCache();
+    auditChange(req, 'admin_global_model_role_set', { role, model: fullId });
+    logger.info(`전역 역할 매핑 저장: role=${role} model=${fullId}`);
+    res.json(success({ mapping }));
+}));
+
+adminModelRolesRouter.delete('/model-roles/:role', asyncHandler(async (req: Request, res: Response) => {
+    const role = parseRole(req.params.role);
+    if (!role) {
+        res.status(400).json(badRequest(`알 수 없는 role: '${req.params.role}'`));
+        return;
+    }
+    const repo = new GlobalModelRolesRepository(getPool());
+    const deleted = await repo.delete(role);
+    if (!deleted) {
+        res.status(404).json(notFound('매핑 없음'));
+        return;
+    }
+    clearGlobalRolesCache();
+    auditChange(req, 'admin_global_model_role_unset', { role });
+    res.json(success({ deleted: true }));
+}));
+
+/* ── 서버 공용 외부 키 ──────────────────────────────────── */
+
+adminModelRolesRouter.get('/server-external-keys', asyncHandler(async (_req: Request, res: Response) => {
+    const repo = new ServerExternalKeysRepository(getPool());
+    const keys = await repo.list();
+    res.json(success({
+        keys,
+        // 등록 가능한 provider 카탈로그 (openai-compatible 만 role 실행 지원)
+        providers: EXTERNAL_PROVIDER_CATALOG
+            .filter((p) => p.sdkType === 'openai-compatible')
+            .map((p) => ({ id: p.id, displayName: p.displayName, defaultBaseUrl: p.defaultBaseUrl })),
+    }));
+}));
+
+adminModelRolesRouter.put('/server-external-keys/:providerId', validate(putServerKeySchema), asyncHandler(async (req: Request, res: Response) => {
+    const providerId = req.params.providerId;
+    const entry = EXTERNAL_PROVIDER_CATALOG.find((p) => p.id === providerId);
+    if (!entry || entry.sdkType !== 'openai-compatible') {
+        res.status(400).json(badRequest(`카탈로그에 없는 provider: '${providerId}' (openai-compatible 만 지원)`));
+        return;
+    }
+    const body = req.body as z.infer<typeof putServerKeySchema>;
+    const repo = new ServerExternalKeysRepository(getPool());
+    const row = await repo.upsert({
+        providerId,
+        apiKey: body.apiKey,
+        baseUrl: body.baseUrl ?? null,
+        dailyTokenLimit: body.dailyTokenLimit,
+        monthlyTokenLimit: body.monthlyTokenLimit ?? null,
+    });
+    auditChange(req, 'admin_server_external_key_set', {
+        providerId, dailyTokenLimit: body.dailyTokenLimit, monthlyTokenLimit: body.monthlyTokenLimit ?? null,
+    });
+    logger.info(`서버 공용 키 등록: provider=${providerId} daily=${body.dailyTokenLimit}`);
+    res.json(success({ key: row }));
+}));
+
+adminModelRolesRouter.delete('/server-external-keys/:providerId', asyncHandler(async (req: Request, res: Response) => {
+    const repo = new ServerExternalKeysRepository(getPool());
+    const deleted = await repo.delete(req.params.providerId);
+    if (!deleted) {
+        res.status(404).json(notFound('서버 키 없음'));
+        return;
+    }
+    auditChange(req, 'admin_server_external_key_delete', { providerId: req.params.providerId });
+    res.json(success({ deleted: true }));
+}));

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -18,6 +18,7 @@ export { mcpCatalogRouter } from './mcp-catalog.routes';
 export { mcpServerIngestRouter } from './mcp-server-ingest.routes';
 export { mcpCatalogAdminRouter } from './mcp-catalog-admin.routes';
 export { mcpAdminMonitoringRouter } from './mcp-admin-monitoring.routes';
+export { adminModelRolesRouter } from './admin-model-roles.routes';
 
 // 🆕 리팩토링된 라우트
 export { default as chatRouter, setClusterManager as setChatCluster } from './chat.routes';

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -35,6 +35,7 @@ import {
     mcpServerIngestRouter,
     mcpCatalogAdminRouter,
     mcpAdminMonitoringRouter,
+    adminModelRolesRouter,
     usageRouter,
     nodesRouter,
     setNodesCluster,
@@ -180,6 +181,7 @@ export function setupApiRoutes(
         llmClientFactory: (model: string) => new LLMClient(model ? { model } : {}),
     }));
     app.use('/api/admin/mcp', mcpCatalogAdminRouter);
+    app.use('/api/admin', adminModelRolesRouter);
     app.use('/api/admin/mcp', mcpAdminMonitoringRouter);
     // F2 자가개선 — 프롬프트 제안 검토/승인 (관리자)
     app.use('/api/admin/agent-suggestions', agentSuggestionsRouter);

--- a/apps/api/src/services/model-role-resolver.ts
+++ b/apps/api/src/services/model-role-resolver.ts
@@ -9,8 +9,10 @@
  *   ① 사용자별 매핑 (user_model_roles, USER_MODEL_ROLES_ENABLED=true + userId 필요)
  *      — 외부 provider fullId 허용. 그 사용자의 BYOK 키(user_external_api_keys)로
  *        OpenAI 호환 endpoint 에 직결한 LLMClient 를 생성.
- *   ② 전역 env (OMK_<ROLE>_MODEL — 로컬 모델만, config/model-roles 참조)
- *   ③ LLM_DEFAULT_MODEL (로컬 default)
+ *   ② 전역 DB 매핑 (global_model_roles — Admin UI, 60s 캐시. 외부 fullId 는
+ *      서버 공용 키(server_external_api_keys) 필요)
+ *   ③ 전역 env (OMK_<ROLE>_MODEL — 외부 fullId 는 서버 공용 키 필요)
+ *   ④ LLM_DEFAULT_MODEL (로컬 default)
  *
  * 폴백 정책 = fail-open: 상위 티어 해석 실패(키 삭제·만료·비활성, anthropic sdk,
  * lookup 오류 등)는 throw 하지 않고 사유를 degraded 에 기록한 뒤 다음 티어로
@@ -43,6 +45,7 @@ import { createClient, LLMClient } from '../llm';
 import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
 import { UserModelRolesRepository } from '../data/repositories/user-model-roles-repo';
 import { ServerExternalKeysRepository } from '../data/repositories/server-external-keys-repo';
+import { GlobalModelRolesRepository } from '../data/repositories/global-model-roles-repo';
 import { getPool } from '../data/models/unified-database';
 import { checkServerKeyBudget, recordServerKeyUsage } from './server-key-quota';
 import { createLogger } from '../utils/logger';
@@ -82,6 +85,34 @@ export interface ResolveRoleClientOptions {
      * 전역 매핑 설정 + 서버 키 등록)
      */
     serverKeysRepo?: ServerExternalKeysRepository;
+    /** 전역 DB 매핑(Admin UI, L3) 저장소 — 미주입 시 env 전역 티어로 직행 */
+    globalRolesRepo?: GlobalModelRolesRepository;
+}
+
+/**
+ * 전역 DB 매핑 캐시 — per-call DB 조회 방지. TTL 내 변경은 최대 TTL 만큼 지연 반영
+ * (같은 프로세스의 admin API 변경은 clearGlobalRolesCache 로 즉시 반영).
+ */
+const GLOBAL_ROLES_CACHE_TTL_MS = parseInt(process.env.GLOBAL_MODEL_ROLES_CACHE_TTL_MS || '60000', 10);
+let globalRolesCache: { map: Map<string, string>; fetchedAt: number } | null = null;
+
+export function clearGlobalRolesCache(): void {
+    globalRolesCache = null;
+}
+
+async function getGlobalDbRole(repo: GlobalModelRolesRepository, role: ModelRole): Promise<string | null> {
+    const now = Date.now();
+    if (!globalRolesCache || now - globalRolesCache.fetchedAt > GLOBAL_ROLES_CACHE_TTL_MS) {
+        try {
+            const rows = await repo.list();
+            globalRolesCache = { map: new Map(rows.map((r) => [r.role, r.fullModelId])), fetchedAt: now };
+        } catch (err) {
+            // DB 장애 — fail-open (env/default 티어로). 캐시가 있으면 stale 사용.
+            logger.warn(`전역 DB 매핑 조회 실패: ${err instanceof Error ? err.message : String(err)}`);
+            if (!globalRolesCache) return null;
+        }
+    }
+    return globalRolesCache.map.get(role) ?? null;
 }
 
 function catalogEntry(providerId: string) {
@@ -246,7 +277,34 @@ export async function resolveRoleClient(
         }
     }
 
-    // ② 전역 env / ③ 로컬 default — getModelForRole 이 두 티어를 합쳐 처리
+    // ② 전역 DB 매핑 (Admin UI, L3 — Phase B). env 전역보다 우선.
+    if (opts.globalRolesRepo) {
+        const dbGlobal = await getGlobalDbRole(opts.globalRolesRepo, role);
+        if (dbGlobal) {
+            if (isExternalFullId(dbGlobal)) {
+                if (opts.serverKeysRepo) {
+                    const result = await tryBuildServerKeyResolution(role, dbGlobal, opts.userId, opts.serverKeysRepo)
+                        .catch((err) => `서버 키 해석 실패: ${err instanceof Error ? err.message : String(err)}`);
+                    if (typeof result !== 'string') {
+                        if (degradedReasons.length > 0) result.degraded = degradedReasons.join(' → ');
+                        return result;
+                    }
+                    degradedReasons.push(result);
+                } else {
+                    degradedReasons.push(`전역 DB 매핑 외부 fullId '${dbGlobal}' — 서버 키 저장소 미주입`);
+                }
+            } else {
+                const dbTag = toLocalModelTag(dbGlobal);
+                if (dbTag) {
+                    const degraded = degradedReasons.length > 0 ? degradedReasons.join(' → ') : undefined;
+                    return buildLocalResolution(role, dbTag, 'global', opts.userId, degraded);
+                }
+                degradedReasons.push(`전역 DB 매핑 값 해석 불가: '${dbGlobal}'`);
+            }
+        }
+    }
+
+    // ③ 전역 env / ④ 로컬 default — getModelForRole 이 두 티어를 합쳐 처리
     const globalValue = getModelForRole(role);
     const source: RoleClientResolution['source'] = hasRoleEnvOverride(role) ? 'global' : 'default';
     let tag = toLocalModelTag(globalValue);
@@ -298,8 +356,9 @@ export async function resolveRoleClientForUser(
     const opts: ResolveRoleClientOptions = { userId };
     try {
         const pool = getPool();
-        // 서버 키 티어는 사용자 플래그와 무관 (운영자 opt-in — 전역 매핑 + 키 등록)
+        // 서버 키·전역 DB 매핑 티어는 사용자 플래그와 무관 (운영자 opt-in)
         opts.serverKeysRepo = new ServerExternalKeysRepository(pool);
+        opts.globalRolesRepo = new GlobalModelRolesRepository(pool);
         if (userId && getConfig().userModelRolesEnabled) {
             opts.userMappingLookup = new UserModelRolesRepository(pool);
             opts.externalKeysRepo = new ExternalKeysRepository(pool);

--- a/apps/web/app/(workspace)/admin/model-roles/page.tsx
+++ b/apps/web/app/(workspace)/admin/model-roles/page.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { UsersRound, KeyRound, Trash2, Save, Loader2 } from "lucide-react";
+import {
+  PageHeader,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  Badge,
+  Button,
+  Table,
+  Th,
+  Td,
+} from "@/components/ui/primitives";
+import type { ApiSuccess } from "@openmake/shared-types";
+import { ApiClient } from "@/lib/api-client";
+
+/* ── 타입 (백엔드 /api/admin/model-roles, /api/admin/server-external-keys) ── */
+interface GlobalMapping {
+  role: string;
+  fullModelId: string;
+  updatedAt: string;
+}
+interface RolesPayload {
+  mappings: GlobalMapping[];
+  roles: string[];
+  envFallback: Record<string, string>;
+}
+interface ServerKeyRow {
+  providerId: string;
+  baseUrl: string | null;
+  isActive: boolean;
+  dailyTokenLimit: number;
+  monthlyTokenLimit: number | null;
+  updatedAt: string;
+}
+interface ServerKeysPayload {
+  keys: ServerKeyRow[];
+  providers: { id: string; displayName: string; defaultBaseUrl: string }[];
+}
+
+const inputCls =
+  "h-9 w-full rounded-md border border-border bg-surface-2 px-3 text-sm text-fg placeholder:text-muted focus:border-accent focus:outline-none";
+const selectCls =
+  "h-9 rounded-md border border-border bg-surface-2 px-2 text-sm text-fg focus:border-accent focus:outline-none";
+
+/** 서버 공용 키 등록 폼 */
+function ServerKeyForm({ providers, onSaved }: {
+  providers: ServerKeysPayload["providers"];
+  onSaved: () => void;
+}) {
+  const t = useTranslations("adminModelRoles");
+  const [providerId, setProviderId] = useState(providers[0]?.id ?? "");
+  const [apiKey, setApiKey] = useState("");
+  const [dailyLimit, setDailyLimit] = useState("100000");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    try {
+      await ApiClient.put(`/api/admin/server-external-keys/${providerId}`, {
+        apiKey,
+        dailyTokenLimit: Number(dailyLimit),
+      });
+      setApiKey("");
+      onSaved();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("saveFailed"));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <select className={selectCls} value={providerId} onChange={(e) => setProviderId(e.target.value)} aria-label={t("keyForm.provider")}>
+          {providers.map((p) => (
+            <option key={p.id} value={p.id}>{p.displayName}</option>
+          ))}
+        </select>
+        <input
+          className={inputCls}
+          type="password"
+          placeholder={t("keyForm.apiKeyPlaceholder")}
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+        />
+        <input
+          className={`${inputCls} sm:w-40`}
+          type="number"
+          min={0}
+          title={t("keyForm.dailyLimit")}
+          value={dailyLimit}
+          onChange={(e) => setDailyLimit(e.target.value)}
+        />
+        <Button size="sm" disabled={saving || apiKey.length < 8} onClick={() => void handleSave()}>
+          {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> : <Save className="h-4 w-4" aria-hidden />}
+          {t("keyForm.save")}
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">{t("keyForm.dailyLimitHelp")}</p>
+      {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
+    </div>
+  );
+}
+
+/**
+ * 전역 역할→모델 매핑(L3) + 서버 공용 외부 키 관리 — admin 전용.
+ * 변경은 재시작 없이 최대 60초 내 반영(resolver 캐시).
+ */
+export default function AdminModelRolesPage() {
+  const t = useTranslations("adminModelRoles");
+  const [roles, setRoles] = useState<RolesPayload | null>(null);
+  const [serverKeys, setServerKeys] = useState<ServerKeysPayload | null>(null);
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [busyRole, setBusyRole] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const [r, k] = await Promise.all([
+        ApiClient.get<ApiSuccess<RolesPayload>>("/api/admin/model-roles"),
+        ApiClient.get<ApiSuccess<ServerKeysPayload>>("/api/admin/server-external-keys"),
+      ]);
+      setRoles(r?.data ?? null);
+      setServerKeys(k?.data ?? null);
+      const mapped: Record<string, string> = {};
+      for (const m of r?.data?.mappings ?? []) mapped[m.role] = m.fullModelId;
+      setDrafts(mapped);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("loadError"));
+    }
+  }, [t]);
+
+  useEffect(() => {
+    queueMicrotask(() => void load());
+  }, [load]);
+
+  async function saveRole(role: string) {
+    const model = (drafts[role] ?? "").trim();
+    setBusyRole(role);
+    setError(null);
+    try {
+      if (model) {
+        await ApiClient.put(`/api/admin/model-roles/${role}`, { model });
+      } else if (roles?.mappings.some((m) => m.role === role)) {
+        await ApiClient.del(`/api/admin/model-roles/${role}`);
+      }
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("saveFailed"));
+    } finally {
+      setBusyRole(null);
+    }
+  }
+
+  async function deleteKey(providerId: string) {
+    if (!window.confirm(t("keyDeleteConfirm", { provider: providerId }))) return;
+    try {
+      await ApiClient.del(`/api/admin/server-external-keys/${providerId}`);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("saveFailed"));
+    }
+  }
+
+  const mappedRoles = new Set((roles?.mappings ?? []).map((m) => m.role));
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title={t("title")} description={t("description")} />
+
+      {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <KeyRound className="h-4 w-4" aria-hidden />
+            {t("serverKeys.title")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">{t("serverKeys.description")}</p>
+          {serverKeys && serverKeys.keys.length > 0 && (
+            <Table>
+              <thead>
+                <tr>
+                  <Th>{t("serverKeys.provider")}</Th>
+                  <Th>{t("serverKeys.dailyLimit")}</Th>
+                  <Th>{t("serverKeys.status")}</Th>
+                  <Th>{t("serverKeys.actions")}</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {serverKeys.keys.map((k) => (
+                  <tr key={k.providerId}>
+                    <Td>{k.providerId}</Td>
+                    <Td>{k.dailyTokenLimit.toLocaleString()}</Td>
+                    <Td>
+                      <Badge tone={k.isActive ? "success" : "neutral"}>
+                        {k.isActive ? t("serverKeys.active") : t("serverKeys.inactive")}
+                      </Badge>
+                    </Td>
+                    <Td>
+                      <Button variant="ghost" size="sm" aria-label={t("serverKeys.delete")}
+                        onClick={() => void deleteKey(k.providerId)}>
+                        <Trash2 className="h-4 w-4" aria-hidden />
+                      </Button>
+                    </Td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          )}
+          {serverKeys && <ServerKeyForm providers={serverKeys.providers} onSaved={() => void load()} />}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <UsersRound className="h-4 w-4" aria-hidden />
+            {t("globalRoles.title")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">{t("globalRoles.description")}</p>
+          {(roles?.roles ?? []).map((role) => (
+            <div key={role} className="flex flex-col gap-2 rounded-lg border p-3 sm:flex-row sm:items-center">
+              <div className="flex min-w-36 items-center gap-2">
+                <span className="whitespace-nowrap text-sm font-medium">{role}</span>
+                {mappedRoles.has(role) && <Badge tone="accent" className="shrink-0 whitespace-nowrap">{t("globalRoles.assigned")}</Badge>}
+              </div>
+              <input
+                className={inputCls}
+                placeholder={t("globalRoles.placeholder", { fallback: roles?.envFallback[role] ?? "" })}
+                value={drafts[role] ?? ""}
+                onChange={(e) => setDrafts((d) => ({ ...d, [role]: e.target.value }))}
+              />
+              <Button size="sm" disabled={busyRole === role} onClick={() => void saveRole(role)}>
+                {busyRole === role
+                  ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                  : <Save className="h-4 w-4" aria-hidden />}
+                {t("globalRoles.save")}
+              </Button>
+            </div>
+          ))}
+          <p className="text-xs text-muted-foreground">{t("globalRoles.cacheNote")}</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/lib/nav.ts
+++ b/apps/web/lib/nav.ts
@@ -13,6 +13,7 @@ import {
   Sparkles,
   Telescope,
   Boxes,
+  UsersRound,
   Terminal,
   type LucideIcon,
 } from "lucide-react";
@@ -81,6 +82,7 @@ export const NAV_GROUPS: NavGroup[] = [
       { labelKey: "items.auditLog", href: "/admin/audit", icon: ScrollText },
       { labelKey: "items.alerts", href: "/admin/alerts", icon: Bell },
       { labelKey: "items.mcpCatalogAdmin", href: "/admin/mcp-catalog", icon: Boxes },
+      { labelKey: "items.modelRolesAdmin", href: "/admin/model-roles", icon: UsersRound },
     ],
   },
 ];

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -28,6 +28,7 @@
       "metrics": "Metrics",
       "alerts": "Alerts",
       "mcpCatalogAdmin": "MCP Catalog Admin",
+      "modelRolesAdmin": "Model Roles Admin",
       "mcp": "MCP",
       "developer": "Developer"
     }
@@ -1335,6 +1336,39 @@
         "label": "Code & Security Review",
         "description": "Model for code review, security analysis, and planning"
       }
+    }
+  },
+  "adminModelRoles": {
+    "title": "Model Roles Admin",
+    "description": "Manage global role→model mappings (defaults for all users) and server-shared external keys.",
+    "loadError": "Failed to load.",
+    "saveFailed": "Failed to save.",
+    "keyDeleteConfirm": "Delete the server key for '{provider}'? Global mappings for this provider will fall back to the local model.",
+    "serverKeys": {
+      "title": "Server-shared External Keys",
+      "description": "Operator-owned keys — used only by global role mappings (per-user mappings and chat use personal BYOK keys). Calls fall back to the local model when the daily token limit is exceeded.",
+      "provider": "Provider",
+      "dailyLimit": "Daily token limit",
+      "status": "Status",
+      "actions": "Actions",
+      "active": "Active",
+      "inactive": "Inactive",
+      "delete": "Delete"
+    },
+    "keyForm": {
+      "provider": "Provider",
+      "apiKeyPlaceholder": "API key (encrypted at rest)",
+      "dailyLimit": "Daily token limit",
+      "dailyLimitHelp": "A daily token limit is required — 0 locks the key.",
+      "save": "Register"
+    },
+    "globalRoles": {
+      "title": "Global Role Mappings",
+      "description": "Set the default model per role. Per-user mappings take precedence; leave empty to fall back to env/default. External models (provider:model) require a server-shared key.",
+      "assigned": "Assigned",
+      "save": "Save",
+      "placeholder": "Empty = fallback ({fallback})",
+      "cacheNote": "Changes take effect within 60 seconds without a restart."
     }
   },
   "usage": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -28,6 +28,7 @@
       "metrics": "メトリクス",
       "alerts": "アラート",
       "mcpCatalogAdmin": "MCPカタログ管理",
+      "modelRolesAdmin": "ロールモデル管理",
       "mcp": "MCP",
       "developer": "開発者"
     }
@@ -1335,6 +1336,39 @@
         "label": "コード・セキュリティレビュー",
         "description": "コードレビュー、セキュリティ分析、実装計画のモデル"
       }
+    }
+  },
+  "adminModelRoles": {
+    "title": "ロールモデル管理",
+    "description": "グローバルなロール→モデル割り当て(全ユーザーの既定値)とサーバー共有外部キーを管理します。",
+    "loadError": "読み込みに失敗しました。",
+    "saveFailed": "保存に失敗しました。",
+    "keyDeleteConfirm": "'{provider}' のサーバーキーを削除しますか?このプロバイダーのグローバル割り当てはローカルモデルにフォールバックします。",
+    "serverKeys": {
+      "title": "サーバー共有外部キー",
+      "description": "運用者所有のキー — グローバルロール割り当てでのみ使用されます(ユーザー別割り当てとチャットは個人のBYOKキーを使用)。日次トークン上限を超えるとローカルモデルへ自動フォールバックします。",
+      "provider": "プロバイダー",
+      "dailyLimit": "日次トークン上限",
+      "status": "状態",
+      "actions": "操作",
+      "active": "有効",
+      "inactive": "無効",
+      "delete": "削除"
+    },
+    "keyForm": {
+      "provider": "プロバイダー",
+      "apiKeyPlaceholder": "APIキー(登録時に暗号化)",
+      "dailyLimit": "日次トークン上限",
+      "dailyLimitHelp": "日次トークン上限は必須です — 0はロック(使用不可)状態。",
+      "save": "登録"
+    },
+    "globalRoles": {
+      "title": "グローバルロール割り当て",
+      "description": "ロールごとの既定モデルを指定します。ユーザー別割り当てが優先され、空にすると環境変数/既定モデルにフォールバックします。外部モデル(provider:model)にはサーバー共有キーが必要です。",
+      "assigned": "割り当て済み",
+      "save": "保存",
+      "placeholder": "空 = フォールバック ({fallback})",
+      "cacheNote": "変更は再起動なしで最大60秒以内に反映されます。"
     }
   },
   "usage": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -28,6 +28,7 @@
       "metrics": "메트릭",
       "alerts": "알림",
       "mcpCatalogAdmin": "MCP 카탈로그 관리",
+      "modelRolesAdmin": "역할 모델 관리",
       "mcp": "MCP",
       "developer": "개발자"
     }
@@ -1335,6 +1336,39 @@
         "label": "코드·보안 리뷰",
         "description": "코드 리뷰, 보안 분석, 구현 계획 모델"
       }
+    }
+  },
+  "adminModelRoles": {
+    "title": "역할 모델 관리",
+    "description": "전역 역할→모델 매핑(모든 사용자 기본값)과 서버 공용 외부 키를 관리합니다.",
+    "loadError": "불러오기에 실패했습니다.",
+    "saveFailed": "저장에 실패했습니다.",
+    "keyDeleteConfirm": "'{provider}' 서버 공용 키를 삭제할까요? 해당 provider 의 전역 매핑은 로컬 모델로 폴백됩니다.",
+    "serverKeys": {
+      "title": "서버 공용 외부 키",
+      "description": "운영자 소유 키 — 전역 역할 매핑에서만 사용됩니다(사용자별 매핑·채팅은 개인 BYOK 키 사용). 일 토큰 상한 초과 시 자동으로 로컬 모델로 폴백됩니다.",
+      "provider": "공급자",
+      "dailyLimit": "일 토큰 상한",
+      "status": "상태",
+      "actions": "작업",
+      "active": "활성",
+      "inactive": "비활성",
+      "delete": "삭제"
+    },
+    "keyForm": {
+      "provider": "공급자",
+      "apiKeyPlaceholder": "API 키 (등록 즉시 암호화)",
+      "dailyLimit": "일 토큰 상한",
+      "dailyLimitHelp": "일 토큰 상한은 필수입니다 — 0은 잠금(사용 불가) 상태.",
+      "save": "등록"
+    },
+    "globalRoles": {
+      "title": "전역 역할 매핑",
+      "description": "역할별 기본 모델을 지정합니다. 사용자별 매핑이 있으면 그것이 우선하고, 비우면 환경변수/기본 모델로 폴백됩니다. 외부 모델(provider:model)은 서버 공용 키가 필요합니다.",
+      "assigned": "배정됨",
+      "save": "저장",
+      "placeholder": "비움 = 폴백 ({fallback})",
+      "cacheNote": "변경은 재시작 없이 최대 60초 내에 반영됩니다."
     }
   },
   "usage": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -28,6 +28,7 @@
       "metrics": "指标",
       "alerts": "告警",
       "mcpCatalogAdmin": "MCP目录管理",
+      "modelRolesAdmin": "角色模型管理",
       "mcp": "MCP",
       "developer": "开发者"
     }
@@ -1335,6 +1336,39 @@
         "label": "代码与安全审查",
         "description": "代码审查、安全分析与实现计划的模型"
       }
+    }
+  },
+  "adminModelRoles": {
+    "title": "角色模型管理",
+    "description": "管理全局角色→模型映射(所有用户的默认值)和服务器共享外部密钥。",
+    "loadError": "加载失败。",
+    "saveFailed": "保存失败。",
+    "keyDeleteConfirm": "删除 '{provider}' 的服务器密钥?该提供商的全局映射将回退到本地模型。",
+    "serverKeys": {
+      "title": "服务器共享外部密钥",
+      "description": "运营者所有的密钥 — 仅用于全局角色映射(按用户映射与聊天使用个人BYOK密钥)。超过每日令牌上限时自动回退到本地模型。",
+      "provider": "提供商",
+      "dailyLimit": "每日令牌上限",
+      "status": "状态",
+      "actions": "操作",
+      "active": "已启用",
+      "inactive": "已停用",
+      "delete": "删除"
+    },
+    "keyForm": {
+      "provider": "提供商",
+      "apiKeyPlaceholder": "API密钥(注册时加密)",
+      "dailyLimit": "每日令牌上限",
+      "dailyLimitHelp": "每日令牌上限为必填 — 0表示锁定(不可用)。",
+      "save": "注册"
+    },
+    "globalRoles": {
+      "title": "全局角色映射",
+      "description": "设置每个角色的默认模型。按用户映射优先;留空则回退到环境变量/默认模型。外部模型(provider:model)需要服务器共享密钥。",
+      "assigned": "已分配",
+      "save": "保存",
+      "placeholder": "留空 = 回退 ({fallback})",
+      "cacheNote": "更改无需重启,最多60秒内生效。"
     }
   },
   "usage": {

--- a/db/migrations/071_global_model_roles.sql
+++ b/db/migrations/071_global_model_roles.sql
@@ -1,0 +1,16 @@
+-- Migration 071 — global_model_roles (전역 역할→모델 매핑, Admin UI L3)
+--
+-- Role-based Orchestration 2차 Phase B (2026-07-15).
+-- env(OMK_<ROLE>_MODEL, L1) 전역 매핑을 DB 로 승격 — 재시작 없이 운영자가 조정.
+-- 해석 우선순위: user_model_roles → global_model_roles(이 테이블) → env → LLM_DEFAULT_MODEL.
+-- 외부 fullId 는 서버 공용 키(server_external_api_keys, 070) 등록이 전제.
+-- role CHECK 는 config/model-roles.ts MODEL_ROLES 와 정합 유지할 것.
+
+CREATE TABLE IF NOT EXISTS global_model_roles (
+    role           TEXT PRIMARY KEY CHECK (role IN ('chat', 'agent', 'judge', 'research', 'spawn', 'review', 'router')),
+    full_model_id  TEXT NOT NULL,
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE global_model_roles IS
+    '전역 역할→모델 매핑 (Admin UI 관리, L3). resolver 는 60s 캐시로 조회 — 변경 후 최대 60초 내 반영.';


### PR DESCRIPTION
## 개요
Role-based Orchestration 2차 Phase B. env(L1) 전역 role 매핑을 DB(L3)+Admin UI 로 승격 — 재시작 없이 조정(60s 캐시). Phase A(#288)의 서버 공용 키 관리 화면 포함.

## 변경
- 071 `global_model_roles` — 수동 적용 필요
- resolver 4단 폴백: user → **전역 DB** → 전역 env → default (DB 외부 fullId 는 서버 키 실행)
- admin API 6종 (requireAdmin, 외부 fullId 는 서버 키 검증, logAudit, 캐시 무효화)
- `/admin/model-roles` 페이지 + 사이드바 + i18n 4개 언어

## 검증
- [x] tsc(api/web) / eslint / resolver unit 30/30 (DB 전역 우선순위·외부+서버키·fail-open 포함)
- [ ] live: 071 적용 → admin UI 로 전역 매핑 설정 → 60s 내 반영 확인 (merge 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)