### PR TITLE
feat(agents): Phase C — 커스텀 에이전트 전용 모델 + spawn agentId

### DIFF
--- a/apps/api/src/chat/execution-plan-builder.ts
+++ b/apps/api/src/chat/execution-plan-builder.ts
@@ -69,6 +69,10 @@ export class ExecutionPlanBuilder {
     async loadUserAgent(
         userAgentId: string | undefined,
         userId: string | undefined,
+        opts?: {
+            /** false = usage_count 미증가 — 모델 배정 조회 등 보조 로드용 (기본 true) */
+            countUsage?: boolean;
+        },
     ): Promise<ResolvedUserAgent | null> {
         if (!userAgentId || !userId || userId === 'guest') return null;
         try {
@@ -78,9 +82,11 @@ export class ExecutionPlanBuilder {
             const agent = await repo.getByIdForUser(userAgentId, userId);
             if (!agent || !agent.is_active) return null;
             // usage_count 증가는 fire-and-forget — chat 흐름 차단 금지
-            void repo.incrementUsage(agent.id).catch(e =>
-                logger.warn('user_agent usage_count 증가 실패 (무시):', e),
-            );
+            if (opts?.countUsage !== false) {
+                void repo.incrementUsage(agent.id).catch(e =>
+                    logger.warn('user_agent usage_count 증가 실패 (무시):', e),
+                );
+            }
             return {
                 id: agent.id,
                 name: agent.name,
@@ -88,6 +94,7 @@ export class ExecutionPlanBuilder {
                 allowedTools: Array.isArray(agent.allowed_tools) ? agent.allowed_tools : [],
                 allowedSkills: Array.isArray(agent.allowed_skills) ? agent.allowed_skills : [],
                 icon: agent.icon,
+                model: agent.model ?? null,
             };
         } catch (e) {
             logger.warn('user_agent 조회 실패 (silent fallback):', e);

--- a/apps/api/src/chat/execution-plan-types.ts
+++ b/apps/api/src/chat/execution-plan-types.ts
@@ -63,4 +63,6 @@ export interface ResolvedUserAgent {
     allowedTools: string[];
     allowedSkills: string[];
     icon: string | null;
+    /** 에이전트 전용 모델 fullId (null=상속) — 요청 model 이 자동일 때만 적용 (Phase C) */
+    model: string | null;
 }

--- a/apps/api/src/controllers/user-agents.controller.ts
+++ b/apps/api/src/controllers/user-agents.controller.ts
@@ -27,6 +27,7 @@ import { requireAuth } from '../auth/middleware';
 import { validate } from '../middlewares/validation';
 import { getPool } from '../data/models/unified-database';
 import { UserAgentRepository } from '../data/repositories/user-agent-repository';
+import { validateModelAssignment } from '../services/model-assignment-validation';
 import { createLogger } from '../utils/logger';
 import { success, internalError, unauthorized, notFound, badRequest } from '../utils/api-response';
 
@@ -41,6 +42,7 @@ const createSchema = z.object({
     allowedTools: z.array(z.string().max(100)).max(50).optional(),
     allowedSkills: z.array(z.string().max(100)).max(50).optional(),
     icon: z.string().min(1).max(8).nullish(),
+    model: z.string().min(1).max(200).nullish(),
 });
 
 const updateSchema = z.object({
@@ -50,6 +52,7 @@ const updateSchema = z.object({
     allowedTools: z.array(z.string().max(100)).max(50).optional(),
     allowedSkills: z.array(z.string().max(100)).max(50).optional(),
     icon: z.string().min(1).max(8).nullish(),
+    model: z.string().min(1).max(200).nullish(),
 });
 
 function getUserId(req: Request): string | null {
@@ -96,6 +99,10 @@ export function createUserAgentsController(): Router {
         if (!userId) { res.status(401).json(unauthorized()); return; }
         try {
             const body = req.body as z.infer<typeof createSchema>;
+            if (body.model) {
+                const reason = await validateModelAssignment(userId, body.model.trim());
+                if (reason) { res.status(400).json(badRequest(reason)); return; }
+            }
             const repo = new UserAgentRepository(getPool());
             const agent = await repo.create({
                 id: uuidv4(),
@@ -106,6 +113,7 @@ export function createUserAgentsController(): Router {
                 allowedTools: body.allowedTools ?? [],
                 allowedSkills: body.allowedSkills ?? [],
                 icon: body.icon ?? null,
+                model: body.model?.trim() ?? null,
             });
             log.info(`agent 생성: userId=${userId} id=${agent.id} name=${agent.name}`);
             res.json(success({ agent }));
@@ -125,6 +133,10 @@ export function createUserAgentsController(): Router {
         if (!userId) { res.status(401).json(unauthorized()); return; }
         try {
             const body = req.body as z.infer<typeof updateSchema>;
+            if (body.model) {
+                const reason = await validateModelAssignment(userId, body.model.trim());
+                if (reason) { res.status(400).json(badRequest(reason)); return; }
+            }
             const repo = new UserAgentRepository(getPool());
             const agent = await repo.update(req.params.id, userId, {
                 name: body.name,
@@ -133,6 +145,7 @@ export function createUserAgentsController(): Router {
                 allowedTools: body.allowedTools,
                 allowedSkills: body.allowedSkills,
                 icon: body.icon === undefined ? undefined : (body.icon ?? null),
+                model: body.model === undefined ? undefined : (body.model?.trim() ?? null),
             });
             if (!agent) { res.status(404).json(notFound('agent 없음')); return; }
             res.json(success({ agent }));

--- a/apps/api/src/controllers/user-model-roles.controller.ts
+++ b/apps/api/src/controllers/user-model-roles.controller.ts
@@ -23,15 +23,8 @@ import { requireAuth } from '../auth/middleware';
 import { validate } from '../middlewares/validation';
 import { getPool } from '../data/models/unified-database';
 import { UserModelRolesRepository } from '../data/repositories/user-model-roles-repo';
-import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
-import {
-    ModelRole,
-    USER_ASSIGNABLE_MODEL_ROLES,
-    isExternalFullId,
-    toLocalModelTag,
-} from '../config/model-roles';
-import { EXTERNAL_PROVIDER_CATALOG } from '../config/external-providers';
-import { createClient } from '../llm';
+import { ModelRole, USER_ASSIGNABLE_MODEL_ROLES } from '../config/model-roles';
+import { validateModelAssignment } from '../services/model-assignment-validation';
 import { createLogger } from '../utils/logger';
 import { success, internalError, unauthorized, badRequest, notFound } from '../utils/api-response';
 
@@ -56,40 +49,6 @@ function parseAssignableRole(value: string): ModelRole | null {
     return (USER_ASSIGNABLE_MODEL_ROLES as readonly string[]).includes(value)
         ? (value as ModelRole)
         : null;
-}
-
-/** 외부 fullId 배정 검증 — 실패 사유 문자열 반환 (통과 시 null) */
-async function validateExternalAssignment(userId: string, fullId: string): Promise<string | null> {
-    const idx = fullId.indexOf(':');
-    const providerId = fullId.slice(0, idx);
-    const modelId = fullId.slice(idx + 1);
-    if (!modelId) return `모델 id 가 비어 있습니다: '${fullId}'`;
-
-    const entry = EXTERNAL_PROVIDER_CATALOG.find((p) => p.id === providerId);
-    if (!entry) return `카탈로그에 없는 provider: '${providerId}'`;
-    if (entry.sdkType !== 'openai-compatible') {
-        return `provider '${providerId}' (sdkType=${entry.sdkType}) 는 역할 배정을 지원하지 않습니다`;
-    }
-
-    const keysRepo = new ExternalKeysRepository(getPool());
-    const keyRow = await keysRepo.getByUserAndProvider(userId, providerId);
-    if (!keyRow) return `'${providerId}' API 키를 먼저 등록하세요`;
-    if (!keyRow.isActive) return `'${providerId}' API 키가 비활성 상태입니다`;
-    return null;
-}
-
-/** 로컬 태그 배정 검증 — LLM 서버 무응답 시 fail-open (null 반환) */
-async function validateLocalAssignment(tag: string): Promise<string | null> {
-    try {
-        const client = createClient();
-        const { models } = await client.listModels();
-        if (models.length > 0 && !models.some((m) => m.name === tag)) {
-            return `LLM 서버에 없는 로컬 모델: '${tag}' (사용 가능: ${models.map((m) => m.name).join(', ')})`;
-        }
-    } catch (err) {
-        log.warn(`로컬 모델 검증 스킵 (LLM 서버 무응답): ${err instanceof Error ? err.message : String(err)}`);
-    }
-    return null;
 }
 
 export function createUserModelRolesController(): Router {
@@ -125,13 +84,7 @@ export function createUserModelRolesController(): Router {
             const { model } = req.body as z.infer<typeof putSchema>;
             const fullId = model.trim();
 
-            let reason: string | null;
-            if (isExternalFullId(fullId)) {
-                reason = await validateExternalAssignment(userId, fullId);
-            } else {
-                const tag = toLocalModelTag(fullId);
-                reason = tag ? await validateLocalAssignment(tag) : `해석 불가한 모델 id: '${fullId}'`;
-            }
+            const reason = await validateModelAssignment(userId, fullId);
             if (reason) {
                 res.status(400).json(badRequest(reason));
                 return;

--- a/apps/api/src/data/repositories/user-agent-repository.ts
+++ b/apps/api/src/data/repositories/user-agent-repository.ts
@@ -18,6 +18,8 @@ export interface UserAgent {
     allowed_tools: string[];
     allowed_skills: string[];
     icon: string | null;
+    /** 에이전트 전용 모델 fullId (NULL=상속 — 요청 model 자동일 때만 적용, Phase C) */
+    model: string | null;
     is_active: boolean;
     usage_count: number;
     created_at: string;
@@ -33,6 +35,7 @@ export interface UserAgentCreate {
     allowedTools?: string[];
     allowedSkills?: string[];
     icon?: string | null;
+    model?: string | null;
 }
 
 export interface UserAgentUpdate {
@@ -42,6 +45,7 @@ export interface UserAgentUpdate {
     allowedTools?: string[];
     allowedSkills?: string[];
     icon?: string | null;
+    model?: string | null;
 }
 
 export class UserAgentRepository extends BaseRepository {
@@ -49,8 +53,8 @@ export class UserAgentRepository extends BaseRepository {
         const result = await this.query<UserAgent>(
             `INSERT INTO user_agents (
                 id, user_id, name, description, system_prompt,
-                allowed_tools, allowed_skills, icon
-            ) VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8)
+                allowed_tools, allowed_skills, icon, model
+            ) VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8, $9)
              RETURNING *`,
             [
                 params.id,
@@ -61,6 +65,7 @@ export class UserAgentRepository extends BaseRepository {
                 JSON.stringify(params.allowedTools ?? []),
                 JSON.stringify(params.allowedSkills ?? []),
                 params.icon ?? null,
+                params.model ?? null,
             ],
         );
         return result.rows[0] as UserAgent;
@@ -95,6 +100,7 @@ export class UserAgentRepository extends BaseRepository {
         if (patch.allowedTools !== undefined) { sets.push(`allowed_tools = $${i++}::jsonb`); values.push(JSON.stringify(patch.allowedTools)); }
         if (patch.allowedSkills !== undefined){ sets.push(`allowed_skills = $${i++}::jsonb`); values.push(JSON.stringify(patch.allowedSkills)); }
         if (patch.icon !== undefined)         { sets.push(`icon = $${i++}`); values.push(patch.icon); }
+        if (patch.model !== undefined)        { sets.push(`model = $${i++}`); values.push(patch.model); }
         if (sets.length === 0) return this.getByIdForUser(id, userId);
         sets.push(`updated_at = NOW()`);
         values.push(id, userId);

--- a/apps/api/src/services/agent-spawn/spawn-agents.ts
+++ b/apps/api/src/services/agent-spawn/spawn-agents.ts
@@ -49,6 +49,8 @@ export const spawnAgentsArgsSchema = z.object({
     tasks: z.array(z.object({
         prompt: z.string().trim().min(1),
         role: z.string().trim().min(1).optional(),
+        /** 사용자 Custom Agent id — 지정 시 그 에이전트의 페르소나+model 로 실행 (Phase C) */
+        agentId: z.string().trim().min(1).optional(),
     })).min(1),
 });
 
@@ -76,6 +78,7 @@ export const SPAWN_AGENTS_PARAMETERS_SCHEMA: {
                 properties: {
                     prompt: { type: 'string', description: '하위 작업의 자기완결적 지시문' },
                     role: { type: 'string', description: '원하는 전문 분야(선택, 예: finance/legal/engineering)' },
+                    agentId: { type: 'string', description: '사용자가 명시적으로 특정 커스텀 에이전트로 수행을 요청한 경우에만 그 에이전트 id (선택 — 임의 추측 금지)' },
                 },
                 required: ['prompt'],
             },
@@ -143,6 +146,40 @@ async function resolvePersona(task: SpawnTask, userId: string): Promise<string> 
 }
 
 /**
+ * 태스크별 실행 구성 — agentId(Custom Agent) 지정 시 그 에이전트의 페르소나와
+ * model(있으면, BYOK 해석)로 실행. 미지정/실패는 기존 role 페르소나 + 부모 client.
+ * 모델 선택권은 사용자가 정의한 에이전트에만 있음 — LLM 에 자유 model 필드를 열지 않는다.
+ */
+async function resolveTaskExecution(
+    task: SpawnTask,
+    userId: string,
+    parentClient: LLMClient,
+): Promise<{ persona: string; client: LLMClient; modelNote?: string }> {
+    if (task.agentId) {
+        try {
+            const { UserAgentRepository } = await import('../../data/repositories/user-agent-repository');
+            const { getPool } = await import('../../data/models/unified-database');
+            const agent = await new UserAgentRepository(getPool()).getByIdForUser(task.agentId, userId);
+            if (agent) {
+                let client = parentClient;
+                let modelNote: string | undefined;
+                if (agent.model) {
+                    const { resolveAssignedModelClient } = await import('../model-role-resolver');
+                    const resolved = await resolveAssignedModelClient(agent.model, userId);
+                    client = resolved.client;
+                    modelNote = resolved.degraded ? `${agent.model} (폴백: 로컬)` : agent.model;
+                }
+                return { persona: agent.system_prompt, client, modelNote };
+            }
+            logger.debug(`[AgentSpawn] agentId '${task.agentId}' 조회 실패/권한 없음 — role 페르소나 폴백`);
+        } catch (e) {
+            logger.warn(`[AgentSpawn] custom agent 해석 실패 — 폴백:`, e);
+        }
+    }
+    return { persona: await resolvePersona(task, userId), client: parentClient };
+}
+
+/**
  * spawn_agents 실행 — tasks 를 MAX_PARALLEL 동시성으로 병렬 수행하고 태스크별 결과를
  * 도구 결과 텍스트로 조립해 반환. 실패는 문자열로 흡수(호출 루프를 죽이지 않음).
  */
@@ -166,10 +203,13 @@ export async function runSpawnAgents(p: SpawnAgentsParams): Promise<string> {
             tasks,
             async (task, idx) => {
                 try {
-                    const personaPrompt = await resolvePersona(task, userId);
+                    const exec = await resolveTaskExecution(task, userId, p.client);
+                    if (exec.modelNote) {
+                        logger.info(`[AgentSpawn] 태스크 ${idx + 1} custom agent 모델: ${exec.modelNote}`);
+                    }
                     return await runSubagent({
-                        client: p.client,
-                        personaPrompt,
+                        client: exec.client,
+                        personaPrompt: exec.persona,
                         subgoal: task.prompt,
                         tools: subTools,
                         userCtx: p.userCtx,

--- a/apps/api/src/services/chat-service/agent-model-override.ts
+++ b/apps/api/src/services/chat-service/agent-model-override.ts
@@ -1,0 +1,34 @@
+/**
+ * Custom Agent 모델 배정 (Phase C) — message-pipeline 에서 분리 (파일 크기 가드).
+ *
+ * 요청 model 이 자동('default'/빈값)일 때만 에이전트 정의의 model 로 대체 —
+ * 사용자의 명시적 모델 선택이 항상 우선. provider-gate 이전 단일 지점에서
+ * 호출되어 로컬/외부 분기 대칭을 보장한다.
+ * countUsage:false — usage_count 는 외부 분기의 본 로드에서만 1회 증가.
+ *
+ * @module services/chat-service/agent-model-override
+ */
+import { getExecutionPlanBuilder } from '../../chat/execution-plan-builder';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('AgentModelOverride');
+
+export async function applyAgentModelOverride(
+    requestedModel: string | undefined,
+    userAgentId: string | undefined,
+    userId: string | number | undefined,
+): Promise<string | undefined> {
+    if (!userAgentId || !userId || String(userId) === 'guest') return requestedModel;
+    if (requestedModel && requestedModel !== 'default') return requestedModel;
+    try {
+        const preAgent = await getExecutionPlanBuilder()
+            .loadUserAgent(userAgentId, String(userId), { countUsage: false });
+        if (preAgent?.model) {
+            logger.info(`[UserAgent] 에이전트 모델 배정 적용: ${preAgent.model} (agent=${preAgent.name})`);
+            return preAgent.model;
+        }
+    } catch (e) {
+        logger.warn('[UserAgent] 에이전트 모델 조회 실패 (silent — 기본 모델 사용):', e);
+    }
+    return requestedModel;
+}

--- a/apps/api/src/services/chat-service/message-pipeline.ts
+++ b/apps/api/src/services/chat-service/message-pipeline.ts
@@ -30,6 +30,7 @@ import type { UnifiedExecutionPlan } from '../../chat/execution-plan-types';
 import { applyStyle, normalizeStyle } from '../../chat/style';
 import { resolveAnswerFormatProfile, applyAnswerFormat, getAnswerFormatGuard } from '../../chat/answer-format';
 import { runProviderGate } from './provider-gate';
+import { applyAgentModelOverride } from './agent-model-override';
 import type { RequestContext } from './request-context';
 import { buildChatOptions, assembleHistoryWithSummary } from './options-and-history';
 import { estimateTokens } from '../../llm/model-pool';
@@ -165,23 +166,10 @@ export async function runMessagePipeline(svc: ChatService,
     const localStrategyPathEnabled = (await import('../../config/env')).getConfig().localStrategyPathEnabled;
     let externalResolved: import('../../providers/provider-router').ResolvedProvider | null = null;
 
-    // Custom Agent 모델 배정 (Phase C): 요청 model 이 자동('default'/빈값)일 때만
-    // 에이전트 정의의 model 로 대체. 게이트 이전 단일 지점 — 로컬/외부 분기 대칭.
-    // countUsage:false — usage_count 는 아래 외부 분기의 본 로드에서만 1회 증가.
-    let gateRequestedModel = executionPlan?.requestedModel;
-    if (req.userAgentId && req.userId && String(req.userId) !== 'guest'
-        && (!gateRequestedModel || gateRequestedModel === 'default')) {
-        try {
-            const preAgent = await getExecutionPlanBuilder()
-                .loadUserAgent(req.userAgentId, String(req.userId), { countUsage: false });
-            if (preAgent?.model) {
-                gateRequestedModel = preAgent.model;
-                logger.info(`[UserAgent] 에이전트 모델 배정 적용: ${preAgent.model} (agent=${preAgent.name})`);
-            }
-        } catch (e) {
-            logger.warn('[UserAgent] 에이전트 모델 조회 실패 (silent — 기본 모델 사용):', e);
-        }
-    }
+    // Custom Agent 모델 배정 (Phase C) — 상세는 agent-model-override (요청 model 자동일 때만 적용)
+    const gateRequestedModel = await applyAgentModelOverride(
+        executionPlan?.requestedModel, req.userAgentId, req.userId,
+    );
 
     if (svc.providerRouter) {
         const resolved = await runProviderGate(svc.providerRouter, {

--- a/apps/api/src/services/chat-service/message-pipeline.ts
+++ b/apps/api/src/services/chat-service/message-pipeline.ts
@@ -164,9 +164,28 @@ export async function runMessagePipeline(svc: ChatService,
     //      ON: strategy 경로 (ThinkingStrategy/GV/AgentLoop/ExecutionPlanBuilder).
     const localStrategyPathEnabled = (await import('../../config/env')).getConfig().localStrategyPathEnabled;
     let externalResolved: import('../../providers/provider-router').ResolvedProvider | null = null;
+
+    // Custom Agent 모델 배정 (Phase C): 요청 model 이 자동('default'/빈값)일 때만
+    // 에이전트 정의의 model 로 대체. 게이트 이전 단일 지점 — 로컬/외부 분기 대칭.
+    // countUsage:false — usage_count 는 아래 외부 분기의 본 로드에서만 1회 증가.
+    let gateRequestedModel = executionPlan?.requestedModel;
+    if (req.userAgentId && req.userId && String(req.userId) !== 'guest'
+        && (!gateRequestedModel || gateRequestedModel === 'default')) {
+        try {
+            const preAgent = await getExecutionPlanBuilder()
+                .loadUserAgent(req.userAgentId, String(req.userId), { countUsage: false });
+            if (preAgent?.model) {
+                gateRequestedModel = preAgent.model;
+                logger.info(`[UserAgent] 에이전트 모델 배정 적용: ${preAgent.model} (agent=${preAgent.name})`);
+            }
+        } catch (e) {
+            logger.warn('[UserAgent] 에이전트 모델 조회 실패 (silent — 기본 모델 사용):', e);
+        }
+    }
+
     if (svc.providerRouter) {
         const resolved = await runProviderGate(svc.providerRouter, {
-            requestedModel: executionPlan?.requestedModel,
+            requestedModel: gateRequestedModel,
             fallbackModel: svc.client.model,
             ctx: { userId: req.userId, userRole: req.userRole },
         });

--- a/apps/api/src/services/model-assignment-validation.ts
+++ b/apps/api/src/services/model-assignment-validation.ts
@@ -1,0 +1,59 @@
+/**
+ * @module services/model-assignment-validation
+ * @description 모델 배정 값(fullId) 검증 — 사용자 역할 매핑·Custom Agent 모델 공용 규칙.
+ *
+ * 규칙 (user-model-roles PUT 과 동일):
+ *   - 외부 fullId: 카탈로그 존재 + openai-compatible + 그 사용자의 BYOK 키 등록·활성 필수
+ *   - 로컬 태그: LiteLLM /v1/models 대조 (서버 무응답 시 fail-open — 저장 유지 정책)
+ *
+ * @returns 실패 사유 문자열, 통과 시 null
+ */
+import { getPool } from '../data/models/unified-database';
+import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
+import { EXTERNAL_PROVIDER_CATALOG } from '../config/external-providers';
+import { isExternalFullId, toLocalModelTag } from '../config/model-roles';
+import { createClient } from '../llm';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('ModelAssignmentValidation');
+
+async function validateExternalAssignment(userId: string, fullId: string): Promise<string | null> {
+    const idx = fullId.indexOf(':');
+    const providerId = fullId.slice(0, idx);
+    const modelId = fullId.slice(idx + 1);
+    if (!modelId) return `모델 id 가 비어 있습니다: '${fullId}'`;
+
+    const entry = EXTERNAL_PROVIDER_CATALOG.find((p) => p.id === providerId);
+    if (!entry) return `카탈로그에 없는 provider: '${providerId}'`;
+    if (entry.sdkType !== 'openai-compatible') {
+        return `provider '${providerId}' (sdkType=${entry.sdkType}) 는 모델 배정을 지원하지 않습니다`;
+    }
+
+    const keysRepo = new ExternalKeysRepository(getPool());
+    const keyRow = await keysRepo.getByUserAndProvider(userId, providerId);
+    if (!keyRow) return `'${providerId}' API 키를 먼저 등록하세요`;
+    if (!keyRow.isActive) return `'${providerId}' API 키가 비활성 상태입니다`;
+    return null;
+}
+
+async function validateLocalAssignment(tag: string): Promise<string | null> {
+    try {
+        const client = createClient();
+        const { models } = await client.listModels();
+        if (models.length > 0 && !models.some((m) => m.name === tag)) {
+            return `LLM 서버에 없는 로컬 모델: '${tag}' (사용 가능: ${models.map((m) => m.name).join(', ')})`;
+        }
+    } catch (err) {
+        logger.warn(`로컬 모델 검증 스킵 (LLM 서버 무응답): ${err instanceof Error ? err.message : String(err)}`);
+    }
+    return null;
+}
+
+/** fullId 배정 검증 단일 진입점 — 실패 사유 문자열 또는 null(통과) */
+export async function validateModelAssignment(userId: string, fullId: string): Promise<string | null> {
+    if (isExternalFullId(fullId)) {
+        return validateExternalAssignment(userId, fullId);
+    }
+    const tag = toLocalModelTag(fullId);
+    return tag ? validateLocalAssignment(tag) : `해석 불가한 모델 id: '${fullId}'`;
+}

--- a/apps/api/src/services/model-role-resolver.ts
+++ b/apps/api/src/services/model-role-resolver.ts
@@ -345,6 +345,41 @@ export async function resolveRoleClient(
 }
 
 /**
+ * 배정된 모델 fullId 를 실행 클라이언트로 해석 — Custom Agent 모델(user_agents.model)
+ * 등 "role 이 아닌 정의 단위" 배정용. 외부 fullId 는 그 사용자의 BYOK 키로 실행,
+ * 실패는 로컬 default 로 fail-open (degraded 사유 반환).
+ */
+export async function resolveAssignedModelClient(
+    fullId: string,
+    userId: string,
+): Promise<{ client: LLMClient; fullId: string; degraded?: string }> {
+    const cfg = getConfig();
+    const localFallback = (degraded: string) => {
+        logger.warn(`배정 모델 '${fullId}' 해석 폴백 (user=${userId}): ${degraded}`);
+        return {
+            client: createClient({ model: cfg.llmDefaultModel, userId }),
+            fullId: `local-llm:${cfg.llmDefaultModel}`,
+            degraded,
+        };
+    };
+
+    if (isExternalFullId(fullId)) {
+        try {
+            const repo = new ExternalKeysRepository(getPool());
+            const result = await tryBuildExternalResolution('spawn', fullId, userId, repo);
+            if (typeof result !== 'string') {
+                return { client: result.client, fullId };
+            }
+            return localFallback(result);
+        } catch (err) {
+            return localFallback(`외부 클라이언트 구성 실패: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    const tag = toLocalModelTag(fullId) ?? cfg.llmDefaultModel;
+    return { client: createClient({ model: tag, userId }), fullId: `local-llm:${tag}` };
+}
+
+/**
  * 소비처 편의 진입점 — 사용자 매핑/외부 키 repo 를 DB pool 로 자동 구성해
  * resolveRoleClient 를 호출한다. 플래그 OFF·userId 없음·pool 미초기화(부팅 초기)
  * 는 전역/기본 티어로 자연 폴백 (fail-open).

--- a/apps/web/app/(workspace)/custom-agents/page.tsx
+++ b/apps/web/app/(workspace)/custom-agents/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/primitives";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { ApiClient } from "@/lib/api-client";
+import { fetchModels, type ModelEntry } from "@/lib/models-api";
 import { useAppStore } from "@/lib/store";
 
 /* ── 타입 ────────────────────────────────────────────────── */
@@ -21,6 +22,8 @@ interface CustomAgent {
   name: string;
   description: string;
   systemPrompt: string;
+  /** 에이전트 전용 모델 fullId (null=상속) */
+  model: string | null;
   source: "git" | "custom";
 }
 
@@ -30,6 +33,7 @@ interface ApiUserAgent {
   description: string | null;
   system_prompt: string;
   icon: string | null;
+  model: string | null;
 }
 
 type UserAgentsResponse = ApiSuccess<{ agents: ApiUserAgent[] }>;
@@ -51,6 +55,7 @@ function mapAgent(a: ApiUserAgent): CustomAgent {
     name: a.name,
     description: a.description || "",
     systemPrompt: a.system_prompt,
+    model: a.model ?? null,
     source: "custom",
   };
 }
@@ -127,10 +132,16 @@ function AgentForm({
   const [description, setDescription] = useState(initial?.description ?? "");
   const [systemPrompt, setSystemPrompt] = useState(initial?.systemPrompt ?? "");
   const [icon, setIcon] = useState(initial?.emoji ?? "🤖");
+  const [model, setModel] = useState(initial?.model ?? "");
+  const [models, setModels] = useState<ModelEntry[]>([]);
   const [saving, setSaving] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
   const isEdit = !!initial;
+
+  useEffect(() => {
+    void fetchModels().then((p) => setModels(p.models)).catch(() => setModels([]));
+  }, []);
 
   async function handleSubmit() {
     if (!name.trim()) { setFormError(t("nameRequired")); return; }
@@ -144,6 +155,7 @@ function AgentForm({
           description: description.trim() || null,
           systemPrompt: systemPrompt.trim(),
           icon: icon.trim() || null,
+          model: model || null,
         });
       } else {
         await ApiClient.post("/api/users/me/agents", {
@@ -151,6 +163,7 @@ function AgentForm({
           description: description.trim() || null,
           systemPrompt: systemPrompt.trim(),
           icon: icon.trim() || null,
+          model: model || null,
         });
       }
       await onSaved();
@@ -181,6 +194,19 @@ function AgentForm({
         <input value={description} onChange={(e) => setDescription(e.target.value)}
           placeholder={t("descriptionPlaceholder")}
           className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg outline-none focus:border-accent" />
+      </label>
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-fg-2">{t("modelLabel")}</span>
+        <select value={model} onChange={(e) => setModel(e.target.value)}
+          className="h-9 w-full rounded-md border border-border bg-surface px-2 text-sm text-fg outline-none focus:border-accent">
+          <option value="">{t("modelInherit")}</option>
+          {models.map((m) => (
+            <option key={m.modelId} value={m.modelId}>
+              {m.name}{m.provider !== "local-llm" ? ` (${m.provider})` : ""}
+            </option>
+          ))}
+        </select>
+        <span className="text-xs text-faint">{t("modelHelp")}</span>
       </label>
       <label className="block">
         <span className="mb-1 block text-xs font-medium text-fg-2">{t("systemPromptLabel")}</span>
@@ -436,6 +462,7 @@ export default function CustomAgentsPage() {
       name: t(m.nameKey),
       description: t(m.descKey),
       systemPrompt: t(m.promptKey),
+      model: null,
       source: m.source,
     })),
   );

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -779,7 +779,10 @@
     },
     "useInChat": "Use in chat",
     "inUseDeselect": "In use · Deselect",
-    "deselect": "Deselect agent"
+    "deselect": "Deselect agent",
+    "modelLabel": "Model",
+    "modelInherit": "Inherit (request model/default)",
+    "modelHelp": "When set, chats with this agent use this model (an explicit model choice in chat still wins). External models require a registered API key."
   },
   "research": {
     "pageTitle": "Deep Research History",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -779,7 +779,10 @@
     },
     "useInChat": "チャットで使用",
     "inUseDeselect": "使用中 · 解除",
-    "deselect": "エージェント解除"
+    "deselect": "エージェント解除",
+    "modelLabel": "モデル",
+    "modelInherit": "継承(リクエストモデル/既定)",
+    "modelHelp": "指定すると、このエージェントとの会話は常にこのモデルを使用します(チャットで明示的に選んだモデルが優先)。外部モデルにはAPIキー登録が必要です。"
   },
   "research": {
     "pageTitle": "ディープリサーチ履歴",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -779,7 +779,10 @@
     },
     "useInChat": "채팅에서 사용",
     "inUseDeselect": "사용 중 · 해제",
-    "deselect": "에이전트 해제"
+    "deselect": "에이전트 해제",
+    "modelLabel": "모델",
+    "modelInherit": "상속(요청 모델/기본값)",
+    "modelHelp": "지정 시 이 에이전트 대화는 항상 이 모델을 사용합니다(채팅에서 다른 모델을 직접 고르면 그 선택이 우선). 외부 모델은 API 키 등록이 필요합니다."
   },
   "research": {
     "pageTitle": "딥 리서치 히스토리",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -779,7 +779,10 @@
     },
     "useInChat": "在对话中使用",
     "inUseDeselect": "使用中 · 取消",
-    "deselect": "取消智能体"
+    "deselect": "取消智能体",
+    "modelLabel": "模型",
+    "modelInherit": "继承(请求模型/默认)",
+    "modelHelp": "设置后,该智能体的对话将始终使用此模型(聊天中明确选择的模型优先)。外部模型需要注册API密钥。"
   },
   "research": {
     "pageTitle": "深度研究历史",

--- a/db/migrations/072_user_agents_model.sql
+++ b/db/migrations/072_user_agents_model.sql
@@ -1,0 +1,12 @@
+-- Migration 072 — user_agents.model (에이전트 정의 단위 모델 배정)
+--
+-- Role-based Orchestration 2차 Phase C (2026-07-15).
+-- Custom Agent 가 자체 모델(fullId)을 가질 수 있다 (OpenCode 의 per-agent model 패턴).
+-- NULL = 상속(요청 모델/기본 모델). 적용 규칙: 요청 model 이 자동('default'/빈값)일 때만
+-- 에이전트 model 로 대체 — 사용자의 명시적 모델 선택이 항상 우선.
+-- 외부 fullId 는 그 소유자의 BYOK 키(user_external_api_keys)로 실행된다.
+
+ALTER TABLE user_agents ADD COLUMN IF NOT EXISTS model TEXT;
+
+COMMENT ON COLUMN user_agents.model IS
+    '에이전트 전용 모델 fullId (NULL=상속). 요청 model 이 자동일 때만 적용, 외부 모델은 소유자 BYOK 키 필요.';


### PR DESCRIPTION
## 개요
Role-based Orchestration 2차 Phase C. 에이전트 정의 단위 모델 배정 — "Planner 는 GPT, Coder 는 Claude" 시나리오의 실체.

## 변경
- 072 `user_agents.model` — 수동 적용 필요
- 채팅: 요청 model 자동('default')일 때만 agent.model 적용 (명시 선택 우선) — provider-gate 이전 단일 지점, BYOK 경유
- spawn_agents `agentId`: 커스텀 에이전트의 페르소나+model 로 서브에이전트 실행 (LLM 임의 지정 금지 설명 포함)
- 배정 검증 공용 모듈 추출 (`model-assignment-validation`) — 역할 매핑과 동일 규칙
- 에이전트 편집 UI 모델 select + i18n

## 검증
- [x] tsc(api/web) / eslint / 전체 backend unit 2143 통과
- [ ] live: 072 적용 → 외부 모델 에이전트 채팅이 해당 모델로 응답 (merge 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)