### PR TITLE
feat(chat): 클로드 웹식 생각 과정 표시 — 요약 헤드라인 + 타임라인

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -425,6 +425,7 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 #    역할 매핑(user_model_roles, BYOK 키 필요)에서만 가능.
 # 역할: chat(채팅) / agent(에이전트 작업) / judge(목표 판정) / research(딥리서치)
 #       / spawn(병렬 서브에이전트) / review(코드·보안 리뷰) / router(에이전트 라우팅)
+#       / summary(생각 요약 헤드라인 — 클로드 웹식 thinking 표시)
 # OMK_CLASSIFIER_MODEL: 2026-07-15 제거 (Phase B 로 LLM classifier 경로 폐기)
 # OMK_EMBEDDING_MODEL: 2026-05-19 제거 (vector cache / semantic router 폐기)
 # OMK_CHAT_MODEL=
@@ -434,6 +435,14 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # OMK_SPAWN_MODEL=
 # OMK_REVIEW_MODEL=
 # OMK_ROUTER_MODEL=
+# OMK_SUMMARY_MODEL=
+
+# 생각(thinking) 요약 헤드라인 — 클로드 웹식 표시 (기본 true).
+# 생각 종료 시 'summary' role 모델이 한 줄 헤드라인 생성 → WS thinking_summary.
+# false 면 요약 LLM 호출 없이 타임라인 UI 만 표시.
+# THINKING_SUMMARY_ENABLED=true
+# THINKING_SUMMARY_TIMEOUT_MS=15000
+# THINKING_SUMMARY_MAX_INPUT_CHARS=6000
 
 # 사용자별 역할→모델 매핑 (user_model_roles) 사용 토글 (기본 false).
 # true 면 로그인 사용자의 role 매핑을 1순위로 해석 — 외부 모델은 그 사용자의

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -127,6 +127,12 @@ export const envSchema = z
          * 'false'(기본) 면 현행 동작과 동일 — 전역 env/default 만 사용.
          */
         USER_MODEL_ROLES_ENABLED: z.string().default('false'),
+        /**
+         * thinking 요약 헤드라인 (클로드 웹식) — 생각 종료 시 'summary' role 모델이
+         * 한 줄 요약을 생성해 WS thinking_summary 이벤트로 전송. 'false' 면 헤드라인 없이
+         * 타임라인 UI 만 표시 (요약 LLM 호출 없음).
+         */
+        THINKING_SUMMARY_ENABLED: z.string().default('true'),
         /** Tail 라우팅 셰도우 모드 — 게이트 결정 계산/적재만, 실행 무변경 (기본 false). */
         TAIL_ROUTING_SHADOW_ENABLED: z.string().default('false'),
         SEARCH_SEMANTIC_RERANK_SHADOW: z.string().default('false'),

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -57,6 +57,8 @@ export interface EnvConfig {
     localStrategyPathEnabled: boolean;
     /** 사용자별 역할→모델 매핑(user_model_roles) 사용 토글 (기본 false=전역 env/default 만). */
     userModelRolesEnabled: boolean;
+    /** thinking 요약 헤드라인 생성 토글 (기본 true — 'summary' role 모델 1회 호출). */
+    thinkingSummaryEnabled: boolean;
     /** Tail 라우팅 셰도우 모드 — 게이트 결정을 계산/적재만 하고 실행은 바꾸지 않음 (기본 false). */
     tailRoutingShadowEnabled: boolean;
     /** 웹검색 의미 리랭킹 셰도우 — bge-m3 임베딩 리랭킹 결과를 로깅만 하고 실행은 안 바꿈 (기본 false). */
@@ -177,6 +179,7 @@ const DEFAULT_CONFIG: EnvConfig = {
     llmEnableReasoningEffort: false,
     localStrategyPathEnabled: false,
     userModelRolesEnabled: false,
+    thinkingSummaryEnabled: true,
     tailRoutingShadowEnabled: false,
     searchSemanticRerankShadow: false,
     searchSemanticRerankEnabled: false,
@@ -393,6 +396,7 @@ export function loadConfig(): EnvConfig {
         LLM_ENABLE_REASONING_EFFORT: env('LLM_ENABLE_REASONING_EFFORT'),
         LOCAL_STRATEGY_PATH_ENABLED: env('LOCAL_STRATEGY_PATH_ENABLED'),
         USER_MODEL_ROLES_ENABLED: env('USER_MODEL_ROLES_ENABLED'),
+        THINKING_SUMMARY_ENABLED: env('THINKING_SUMMARY_ENABLED'),
         TAIL_ROUTING_SHADOW_ENABLED: env('TAIL_ROUTING_SHADOW_ENABLED'),
         SEARCH_SEMANTIC_RERANK_SHADOW: env('SEARCH_SEMANTIC_RERANK_SHADOW'),
         SEARCH_SEMANTIC_RERANK_ENABLED: env('SEARCH_SEMANTIC_RERANK_ENABLED'),
@@ -497,6 +501,7 @@ export function loadConfig(): EnvConfig {
         llmEnableReasoningEffort: (parsed.LLM_ENABLE_REASONING_EFFORT ?? 'false').toLowerCase() === 'true',
         localStrategyPathEnabled: (parsed.LOCAL_STRATEGY_PATH_ENABLED ?? 'false').toLowerCase() === 'true',
         userModelRolesEnabled: (parsed.USER_MODEL_ROLES_ENABLED ?? 'false').toLowerCase() === 'true',
+        thinkingSummaryEnabled: (parsed.THINKING_SUMMARY_ENABLED ?? 'true').toLowerCase() === 'true',
         tailRoutingShadowEnabled: (parsed.TAIL_ROUTING_SHADOW_ENABLED ?? 'false').toLowerCase() === 'true',
         searchSemanticRerankShadow: (parsed.SEARCH_SEMANTIC_RERANK_SHADOW ?? 'false').toLowerCase() === 'true',
         searchSemanticRerankEnabled: (parsed.SEARCH_SEMANTIC_RERANK_ENABLED ?? 'false').toLowerCase() === 'true',

--- a/apps/api/src/config/model-roles.ts
+++ b/apps/api/src/config/model-roles.ts
@@ -34,22 +34,23 @@ const logger = createLogger('ModelRoles');
  * - spawn:    spawn_agents 병렬 서브에이전트
  * - review:   code-review / security-review / plan-mode
  * - router:   산업 에이전트 라우팅 (agents/llm-router)
+ * - summary:  thinking 요약 헤드라인 (chat-service/thinking-summarizer — 클로드 웹식 표시)
  *
  * (2026-05-19 embedding 제거 — vector cache / semantic router 폐기.
  *  2026-07-15 classifier 제거 — Phase B 로 LLM classifier 경로 자체가 사라져 dead.
  *  동시에 role 목록을 실소비처 기준으로 확장 — Role-based Multi-Agent Orchestration)
  */
-export type ModelRole = 'chat' | 'agent' | 'judge' | 'research' | 'spawn' | 'review' | 'router';
+export type ModelRole = 'chat' | 'agent' | 'judge' | 'research' | 'spawn' | 'review' | 'router' | 'summary';
 
-/** 전체 role 목록 — Zod enum/검증 재사용용 SoT */
-export const MODEL_ROLES: ReadonlyArray<ModelRole> = ['chat', 'agent', 'judge', 'research', 'spawn', 'review', 'router'];
+/** 전체 role 목록 — Zod enum/검증 재사용용 SoT (DB CHECK 정합: 073) */
+export const MODEL_ROLES: ReadonlyArray<ModelRole> = ['chat', 'agent', 'judge', 'research', 'spawn', 'review', 'router', 'summary'];
 
 /**
  * 사용자별 매핑(user_model_roles) 배정을 허용하는 role.
  * - chat 제외: 채팅은 요청별 모델 선택(ModelSelector)이 이미 존재 — 매핑과 중복/충돌
  * - router 제외: agents/llm-router 는 전역 싱글톤 클라이언트 — 사용자별 배정 불가
  */
-export const USER_ASSIGNABLE_MODEL_ROLES: ReadonlyArray<ModelRole> = ['agent', 'judge', 'research', 'spawn', 'review'];
+export const USER_ASSIGNABLE_MODEL_ROLES: ReadonlyArray<ModelRole> = ['agent', 'judge', 'research', 'spawn', 'review', 'summary'];
 
 /** 역할별 env var 이름 매핑 — OMK_* 일관 (vLLM/LiteLLM 표준) */
 const ROLE_ENV_VAR: Record<ModelRole, string> = {
@@ -60,6 +61,7 @@ const ROLE_ENV_VAR: Record<ModelRole, string> = {
     spawn:    'OMK_SPAWN_MODEL',
     review:   'OMK_REVIEW_MODEL',
     router:   'OMK_ROUTER_MODEL',
+    summary:  'OMK_SUMMARY_MODEL',
 };
 
 /**

--- a/apps/api/src/prompts/thinking-summary.ts
+++ b/apps/api/src/prompts/thinking-summary.ts
@@ -1,0 +1,25 @@
+/**
+ * @module prompts/thinking-summary
+ * @description thinking 요약 헤드라인 프롬프트 — 클로드 웹식 표시.
+ *
+ * 생각(내부 추론) 원문을 받아 "무엇을 했는지" 한 문장 과거형 헤드라인을 만든다.
+ * 예: "근거리 이동 수단 선택지를 비교 검토했습니다"
+ * 사용자 질문과 같은 언어로 출력 (thinking 원문이 영어여도 헤드라인은 질문 언어).
+ */
+
+export function getThinkingSummaryMessages(
+    userMessage: string,
+    thinking: string,
+): { system: string; user: string } {
+    return {
+        system: [
+            '당신은 AI 의 내부 추론 과정을 한 줄 헤드라인으로 요약하는 도우미입니다.',
+            '규칙:',
+            '- 반드시 사용자 질문과 같은 언어로 작성',
+            '- 정중한 과거형 서술 한 문장, 40자 이내 (예: "근거리 이동 수단 선택지를 비교 검토했습니다")',
+            '- 추론에서 실제로 수행한 검토/비교/분석 행위를 요약 — 결론 내용은 포함하지 않음',
+            '- 따옴표, 접두어, 설명 없이 헤드라인 문장만 출력',
+        ].join('\n'),
+        user: `[사용자 질문]\n${userMessage}\n\n[AI 내부 추론]\n${thinking}\n\n위 추론 과정을 헤드라인 한 문장으로:`,
+    };
+}

--- a/apps/api/src/services/chat-service/thinking-summarizer.ts
+++ b/apps/api/src/services/chat-service/thinking-summarizer.ts
@@ -1,0 +1,66 @@
+/**
+ * @module services/chat-service/thinking-summarizer
+ * @description thinking 요약 헤드라인 생성 — 클로드 웹식 표시 (2026-07-15).
+ *
+ * 클로드 웹은 메인 모델의 추론과 별개로 헤드라인 전용 모델이 접힌 생각 블록
+ * 상단의 한 줄 요약을 생성한다. 동일 패턴: 생각 스트림이 끝나는 시점(첫 응답
+ * 토큰 도착)에 'summary' role 모델로 1회 요약 → WS 'thinking_summary' 이벤트.
+ *
+ * - 모델: resolveRoleClientForUser('summary', userId) — 사용자/전역 매핑으로
+ *   무료 외부 소형 모델 배정 가능, 미배정 시 로컬 default.
+ * - fail-open: 실패/타임아웃 시 null — 헤드라인 없이 타임라인만 표시.
+ * - THINKING_SUMMARY_ENABLED=false 로 전체 비활성 (요약 LLM 호출 없음).
+ */
+import { getConfig } from '../../config';
+import { resolveRoleClientForUser } from '../model-role-resolver';
+import { getThinkingSummaryMessages } from '../../prompts/thinking-summary';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('ThinkingSummarizer');
+
+/** 요약 입력 상한 — thinking 이 수만 토큰이어도 헤드라인엔 앞부분+뒷부분이면 충분 */
+const MAX_THINKING_CHARS = parseInt(process.env.THINKING_SUMMARY_MAX_INPUT_CHARS || '6000', 10);
+const MAX_USER_MSG_CHARS = 500;
+/** 헤드라인 1문장 호출 전용 타임아웃 — 채팅 스트림과 병행되므로 짧게 */
+const SUMMARY_TIMEOUT_MS = parseInt(process.env.THINKING_SUMMARY_TIMEOUT_MS || '15000', 10);
+const SUMMARY_MAX_CHARS = 120;
+
+function truncateThinking(thinking: string): string {
+    if (thinking.length <= MAX_THINKING_CHARS) return thinking;
+    const head = thinking.slice(0, Math.floor(MAX_THINKING_CHARS * 0.7));
+    const tail = thinking.slice(-Math.floor(MAX_THINKING_CHARS * 0.3));
+    return `${head}\n…(중략)…\n${tail}`;
+}
+
+/**
+ * 헤드라인 생성 — 실패 시 null (호출부는 이벤트 미전송으로 graceful degrade).
+ */
+export async function summarizeThinking(
+    userMessage: string,
+    thinking: string,
+    userId?: string,
+): Promise<string | null> {
+    if (!getConfig().thinkingSummaryEnabled) return null;
+    if (!thinking || thinking.trim().length < 20) return null; // 한두 단어 생각은 요약 무의미
+
+    try {
+        const resolved = await resolveRoleClientForUser('summary', userId);
+        const client = resolved.client.derive({ timeout: SUMMARY_TIMEOUT_MS });
+        const { system, user } = getThinkingSummaryMessages(
+            userMessage.slice(0, MAX_USER_MSG_CHARS),
+            truncateThinking(thinking),
+        );
+        const r = await client.chat(
+            [{ role: 'system', content: system }, { role: 'user', content: user }],
+            { num_predict: 80 },
+            undefined,
+            { think: false },
+        );
+        const summary = (r.content ?? '').trim().replace(/^["'「]|["'」]$/g, '').split('\n')[0].trim();
+        if (!summary) return null;
+        return summary.length > SUMMARY_MAX_CHARS ? `${summary.slice(0, SUMMARY_MAX_CHARS)}…` : summary;
+    } catch (e) {
+        logger.warn(`thinking 요약 실패 (헤드라인 생략): ${e instanceof Error ? e.message : e}`);
+        return null;
+    }
+}

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -224,6 +224,26 @@ export async function handleChatMessage(
             },
         });
 
+        // thinking 요약 헤드라인 (클로드 웹식): 생각 스트림을 누적했다가 첫 응답 토큰
+        // 도착(=생각 종료) 시 'summary' role 모델로 1회 요약 → thinking_summary 이벤트.
+        // fire-and-forget — 실패/지연은 헤드라인 생략일 뿐 채팅 스트림에 영향 없음.
+        let thinkingBuffer = '';
+        let thinkingSummaryFired = false;
+        const fireThinkingSummary = () => {
+            if (thinkingSummaryFired || thinkingBuffer.trim().length === 0) return;
+            thinkingSummaryFired = true;
+            const captured = thinkingBuffer;
+            void (async () => {
+                try {
+                    const { summarizeThinking } = await import('../services/chat-service/thinking-summarizer');
+                    const summary = await summarizeThinking(message, captured, String(userContext.userId));
+                    if (summary && ws.readyState === ws.OPEN) {
+                        ws.send(JSON.stringify({ type: 'thinking_summary', summary, messageId }));
+                    }
+                } catch { /* 헤드라인 생략 */ }
+            })();
+        };
+
         const tokenCallback = (token: string) => {
             if (abortController.signal.aborted) {
                 throw new Error('ABORTED');
@@ -233,6 +253,7 @@ export async function handleChatMessage(
                 firstTokenTime = Date.now();
                 const ttfb = firstTokenTime - generationStartTime;
                 log.debug(`[Chat] 첫 번째 토큰 생성됨 (TTFB: ${ttfb}ms)`);
+                fireThinkingSummary(); // 응답 시작 = 생각 종료 시점
             }
             tokenCount++;
             partialAssistantResponse += token;
@@ -275,6 +296,7 @@ export async function handleChatMessage(
             onToken: tokenCallback,
             onThinking: (thinking) => {
                 if (abortController.signal.aborted) throw new Error('ABORTED');
+                thinkingBuffer += thinking;
                 ws.send(JSON.stringify({ type: 'thinking', token: thinking, messageId }));
             },
             format: msg.format as import('../llm').FormatOption,
@@ -385,6 +407,7 @@ export async function handleChatMessage(
         const cleanedContent = (result.artifacts && result.artifacts.length > 0)
             ? result.response
             : undefined;
+        fireThinkingSummary(); // 안전망: 응답 토큰 없이 종료된 경우(도구 전용 등)에도 헤드라인 생성
         ws.send(JSON.stringify({
             type: 'done',
             messageId,

--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
-import { Bot, MessagesSquare, Telescope, Brain, Sparkles, FileCode2, ChevronRight, LoaderCircle, Pause, CircleCheck, CircleX, Download, FileText, ShieldCheck, ThumbsUp, ThumbsDown } from "lucide-react";
+import { Bot, MessagesSquare, Telescope, Brain, Sparkles, FileCode2, LoaderCircle, Pause, CircleCheck, CircleX, Download, FileText, ShieldCheck, ThumbsUp, ThumbsDown } from "lucide-react";
+import { ThinkingTimeline } from "@/components/chat/thinking-timeline";
 import { useAppStore, type PendingApproval, type AgentTaskState } from "@/lib/store";
 import { ApiClient } from "@/lib/api-client";
 import { Markdown } from "./markdown";
@@ -484,16 +485,12 @@ export function MessageList() {
             <div className="min-w-0 flex-1">
               <p className="mb-1 text-xs font-medium text-muted">OpenMake</p>
               {m.reasoning && (
-                <details className="group mb-2 rounded-lg border border-border bg-surface-2/60 text-xs">
-                  <summary className="flex cursor-pointer select-none items-center gap-1.5 px-3 py-1.5 font-medium text-muted list-none [&::-webkit-details-marker]:hidden">
-                    <ChevronRight className="h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-90" />
-                    <Brain className="h-3.5 w-3.5 text-accent" />
-                    {t("reasoningLabel")}
-                  </summary>
-                  <div className="whitespace-pre-wrap px-3 pb-2.5 pt-1 leading-relaxed text-muted">
-                    {m.reasoning}
-                  </div>
-                </details>
+                <ThinkingTimeline
+                  reasoning={m.reasoning}
+                  summary={m.reasoningSummary}
+                  thinkingActive={!!m.streaming && m.content.trim().length === 0}
+                  done={!m.streaming || m.content.trim().length > 0}
+                />
               )}
               <div className="text-sm leading-relaxed text-fg">
                 {m.agentTask ? (

--- a/apps/web/components/chat/thinking-timeline.tsx
+++ b/apps/web/components/chat/thinking-timeline.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import { ChevronRight, Clock, CircleCheck, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * 생각 과정 타임라인 (클로드 웹식) — 접힌 상태는 요약 헤드라인 한 줄,
+ * 펼치면 시계 아이콘 + 세로 연결선 + 생각 단락 + ✓ 완료 타임라인.
+ *
+ * 자동 동작: 생각 스트리밍 중엔 자동 펼침, 응답 본문이 시작되면 자동 접힘
+ * (사용자가 수동으로 토글하면 그 선택이 우선).
+ * 헤드라인은 백엔드 'summary' role 모델이 생각 종료 시 생성(thinking_summary 이벤트) —
+ * 도착 전/실패 시엔 기본 라벨로 표시.
+ */
+export function ThinkingTimeline({
+  reasoning,
+  summary,
+  thinkingActive,
+  done,
+}: {
+  reasoning: string;
+  /** 요약 헤드라인 (thinking_summary) — 없으면 기본 라벨 */
+  summary?: string;
+  /** 생각 스트리밍 진행 중 (응답 본문 시작 전) */
+  thinkingActive: boolean;
+  /** 생각 종료 여부 — ✓ 완료 노드 표시 */
+  done: boolean;
+}) {
+  const t = useTranslations("chat.thinkingTimeline");
+  // null = 자동(생각 중 펼침 / 본문 시작 시 접힘), true/false = 사용자 수동 토글
+  const [manualOpen, setManualOpen] = useState<boolean | null>(null);
+  const open = manualOpen ?? thinkingActive;
+
+  // 스트리밍 중 새 생각 단락이 뷰포트 밖으로 흐르지 않게 하단 고정 스크롤
+  const bodyRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (thinkingActive && open && bodyRef.current) {
+      bodyRef.current.scrollTop = bodyRef.current.scrollHeight;
+    }
+  }, [reasoning, thinkingActive, open]);
+
+  const paragraphs = reasoning
+    .split(/\n{2,}/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+
+  const headline = summary ?? (thinkingActive ? t("thinking") : t("fallbackLabel"));
+
+  return (
+    <div className="mb-2 text-xs">
+      {/* 헤드라인 (접기/펼치기 토글) */}
+      <button
+        type="button"
+        onClick={() => setManualOpen((v) => (v === null ? !open : !v))}
+        className="group flex w-full items-center gap-1.5 py-1 text-left text-muted transition-colors hover:text-fg-2"
+        aria-expanded={open}
+      >
+        <ChevronRight
+          className={cn("h-3.5 w-3.5 shrink-0 transition-transform", open && "rotate-90")}
+          aria-hidden
+        />
+        {thinkingActive ? (
+          <span className="flex items-center gap-1.5">
+            <span className="animate-pulse">{headline}…</span>
+          </span>
+        ) : (
+          <span>{headline}</span>
+        )}
+      </button>
+
+      {/* 타임라인 본문 */}
+      {open && paragraphs.length > 0 && (
+        <div
+          ref={bodyRef}
+          className={cn(
+            "mt-1 space-y-0 pl-1",
+            thinkingActive && "max-h-48 overflow-y-auto",
+          )}
+        >
+          {paragraphs.map((p, i) => {
+            const isLast = i === paragraphs.length - 1;
+            const activeNode = thinkingActive && isLast;
+            return (
+              <div key={i} className="relative flex gap-3 pb-4">
+                {/* 세로 연결선 — 마지막 노드 뒤엔 완료 노드까지 이어짐 */}
+                <span
+                  className="absolute left-[8px] top-5 bottom-0 w-px bg-border"
+                  aria-hidden
+                />
+                <span className="relative z-10 mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center text-muted">
+                  {activeNode
+                    ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+                    : <Clock className="h-3.5 w-3.5" aria-hidden />}
+                </span>
+                <p className="min-w-0 whitespace-pre-wrap leading-relaxed text-muted">{p}</p>
+              </div>
+            );
+          })}
+          {done && (
+            <div className="relative flex items-center gap-3">
+              <span className="relative z-10 flex h-4 w-4 shrink-0 items-center justify-center text-muted">
+                <CircleCheck className="h-3.5 w-3.5" aria-hidden />
+              </span>
+              <span className="font-medium text-muted">{t("done")}</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -17,8 +17,10 @@ export interface ChatMessage extends Pick<SharedChatMessage, "role" | "content" 
   streaming?: boolean;
   /** 에이전트 작업 메시지 — agent_task_progress 로 라이브 업데이트되는 메시지 식별자 */
   taskId?: string;
-  /** 추론(thinking) 내용 — ws thinking 이벤트로 누적, 화면에 접이식 블록으로 표시 */
+  /** 추론(thinking) 내용 — ws thinking 이벤트로 누적, 타임라인 블록으로 표시 */
   reasoning?: string;
+  /** 추론 요약 헤드라인 — 생각 종료 시 별도 모델이 생성 (ws thinking_summary, 클로드 웹식) */
+  reasoningSummary?: string;
   /** 구조화 답변 데이터 (structuredMode=true 시 REST /api/chat/structured 응답). 있으면 카드 UI 로 렌더. */
   structured?: StructuredAnswerData;
   /** 에이전트 작업이 승인 대기(paused)일 때 표시할 대기 중 도구 호출 — 채팅 인라인 승인. */
@@ -156,6 +158,7 @@ interface AppState {
   appendMessage: (m: ChatMessage) => void;
   appendToken: (token: string) => void;
   appendThinking: (token: string) => void;
+  setThinkingSummary: (summary: string) => void;
   setStreaming: (v: boolean) => void;
   setCurrentSessionId: (id: string | null) => void;
   setInputDraft: (t: string) => void;
@@ -295,6 +298,18 @@ export const useAppStore = create<AppState>()(
       } else {
         // thinking 은 보통 답변 토큰보다 먼저 도착 — assistant placeholder 를 생성해 누적
         hist.push({ role: "assistant", content: "", reasoning: token, streaming: true });
+      }
+      return { chatHistory: hist };
+    }),
+  setThinkingSummary: (summary) =>
+    set((s) => {
+      // 요약은 스트리밍 중(첫 토큰 직후) 또는 done 직후 도착 — 마지막 assistant 에 부착
+      const hist = [...s.chatHistory];
+      for (let i = hist.length - 1; i >= 0; i--) {
+        if (hist[i].role === "assistant") {
+          hist[i] = { ...hist[i], reasoningSummary: summary };
+          break;
+        }
       }
       return { chatHistory: hist };
     }),

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -57,6 +57,7 @@ export function useChatSocket() {
     setChatHistory,
     appendToken,
     appendThinking,
+    setThinkingSummary,
     setStreaming,
     setCurrentSessionId,
     setActiveAgent,
@@ -100,6 +101,9 @@ export function useChatSocket() {
           break;
         case "thinking":
           if (data.token) appendThinking(data.token);
+          break;
+        case "thinking_summary":
+          if (typeof data.summary === "string" && data.summary) setThinkingSummary(data.summary);
           break;
         case "session_created":
           if (data.sessionId) setCurrentSessionId(data.sessionId);

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -337,7 +337,12 @@
     },
     "feedbackUp": "Helpful",
     "feedbackDown": "Not helpful",
-    "feedbackThanks": "Thanks for your feedback"
+    "feedbackThanks": "Thanks for your feedback",
+    "thinkingTimeline": {
+      "thinking": "Thinking",
+      "fallbackLabel": "Thought process",
+      "done": "Done"
+    }
   },
   "artifacts": {
     "exec": {
@@ -1338,6 +1343,10 @@
       "review": {
         "label": "Code & Security Review",
         "description": "Model for code review, security analysis, and planning"
+      },
+      "summary": {
+        "label": "Thinking Summary",
+        "description": "Model that generates thinking headline summaries"
       }
     }
   },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -337,7 +337,12 @@
     },
     "feedbackUp": "役に立った",
     "feedbackDown": "いまいち",
-    "feedbackThanks": "フィードバックありがとうございます"
+    "feedbackThanks": "フィードバックありがとうございます",
+    "thinkingTimeline": {
+      "thinking": "思考中",
+      "fallbackLabel": "思考プロセス",
+      "done": "完了"
+    }
   },
   "artifacts": {
     "exec": {
@@ -1338,6 +1343,10 @@
       "review": {
         "label": "コード・セキュリティレビュー",
         "description": "コードレビュー、セキュリティ分析、実装計画のモデル"
+      },
+      "summary": {
+        "label": "思考要約",
+        "description": "思考プロセスのヘッドラインを生成するモデル"
       }
     }
   },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -337,7 +337,12 @@
     },
     "feedbackUp": "도움이 됐어요",
     "feedbackDown": "아쉬워요",
-    "feedbackThanks": "피드백 감사합니다"
+    "feedbackThanks": "피드백 감사합니다",
+    "thinkingTimeline": {
+      "thinking": "생각하는 중",
+      "fallbackLabel": "생각 과정",
+      "done": "완료"
+    }
   },
   "artifacts": {
     "exec": {
@@ -1338,6 +1343,10 @@
       "review": {
         "label": "코드·보안 리뷰",
         "description": "코드 리뷰, 보안 분석, 구현 계획 모델"
+      },
+      "summary": {
+        "label": "생각 요약",
+        "description": "생각 과정 헤드라인을 생성하는 모델"
       }
     }
   },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -337,7 +337,12 @@
     },
     "feedbackUp": "有帮助",
     "feedbackDown": "没帮助",
-    "feedbackThanks": "感谢您的反馈"
+    "feedbackThanks": "感谢您的反馈",
+    "thinkingTimeline": {
+      "thinking": "思考中",
+      "fallbackLabel": "思考过程",
+      "done": "完成"
+    }
   },
   "artifacts": {
     "exec": {
@@ -1338,6 +1343,10 @@
       "review": {
         "label": "代码与安全审查",
         "description": "代码审查、安全分析与实现计划的模型"
+      },
+      "summary": {
+        "label": "思考摘要",
+        "description": "生成思考过程标题摘要的模型"
       }
     }
   },

--- a/db/migrations/073_model_role_summary.sql
+++ b/db/migrations/073_model_role_summary.sql
@@ -1,0 +1,14 @@
+-- Migration 073 — 'summary' role 추가 (thinking 요약 헤드라인)
+--
+-- 클로드 웹식 생각 표시 (2026-07-15): 생각(thinking) 종료 시 별도 모델이
+-- 한 줄 헤드라인을 생성한다. 그 요약 모델을 role 시스템으로 배정 가능하게
+-- user_model_roles / global_model_roles 의 role CHECK 를 확장한다.
+-- 코드 SoT: config/model-roles.ts MODEL_ROLES (8종으로 확장).
+
+ALTER TABLE user_model_roles DROP CONSTRAINT IF EXISTS user_model_roles_role_check;
+ALTER TABLE user_model_roles ADD CONSTRAINT user_model_roles_role_check
+    CHECK (role IN ('chat', 'agent', 'judge', 'research', 'spawn', 'review', 'router', 'summary'));
+
+ALTER TABLE global_model_roles DROP CONSTRAINT IF EXISTS global_model_roles_role_check;
+ALTER TABLE global_model_roles ADD CONSTRAINT global_model_roles_role_check
+    CHECK (role IN ('chat', 'agent', 'judge', 'research', 'spawn', 'review', 'router', 'summary'));

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -126,6 +126,7 @@ export interface ArtifactMeta {
 export type WsServerEvent =
   | { type: "token"; token: string }
   | { type: "thinking"; token: string; messageId?: string }
+  | { type: "thinking_summary"; summary: string; messageId?: string }
   | { type: "session_created"; sessionId: string }
   | { type: "done"; sessionId?: string; totalTokens?: number; messageId?: string }
   | { type: "aborted"; message?: string }


### PR DESCRIPTION
## 개요
생각(thinking) 표시를 클로드 웹과 동일한 구조로 — 별도 'summary' role 모델이 생성하는 한 줄 헤드라인 + 시계/체크 아이콘 타임라인 + 자동 펼침/접힘.

## 변경
- **백엔드**: 'summary' role(073, role 8종) + `thinking-summarizer`(생각 종료 시 1회 요약, fail-open) + WS `thinking_summary` 이벤트. `THINKING_SUMMARY_ENABLED` 기본 true
- **프론트**: `ThinkingTimeline` — 헤드라인(접힘)/타임라인(펼침), 생각 중 자동 펼침 + 응답 시작 시 자동 접힘, ✓ 완료 노드
- shared-types WS 유니온에 thinking_summary 추가, i18n 4개 언어

## 검증
- [x] tsc(api/web) / eslint / backend unit 2143 통과 (role 테스트 8종 갱신)
- [ ] live: 073 적용 후 WS 채팅으로 thinking→thinking_summary 이벤트 수신 + UI 스크린샷 (merge 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)