### PR TITLE
feat(chat): thinking 헤드라인 동적 갱신 + 생각 과정 영속화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -443,6 +443,11 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # THINKING_SUMMARY_ENABLED=true
 # THINKING_SUMMARY_TIMEOUT_MS=15000
 # THINKING_SUMMARY_MAX_INPUT_CHARS=6000
+# 진행 중 헤드라인 동적 갱신 (긴 생각 한정) — 첫 중간 요약 시작 길이 / 다음 요약까지
+# 신규 생각 길이 / 최소 간격. 중간 요약은 현재진행형("~하는 중"), 최종은 과거형.
+# THINKING_SUMMARY_PROGRESS_MIN_CHARS=800
+# THINKING_SUMMARY_PROGRESS_STEP_CHARS=1500
+# THINKING_SUMMARY_PROGRESS_INTERVAL_MS=7000
 
 # 사용자별 역할→모델 매핑 (user_model_roles) 사용 토글 (기본 false).
 # true 면 로그인 사용자의 role 매핑을 1순위로 해석 — 외부 모델은 그 사용자의

--- a/apps/api/src/chat/request-handler-types.ts
+++ b/apps/api/src/chat/request-handler-types.ts
@@ -119,6 +119,8 @@ export interface ChatRequestParams {
     onToken: (token: string) => void;
     /** Thinking 토큰 콜백 (추론 과정 실시간 전달) */
     onThinking?: (thinking: string) => void;
+    /** 생각 요약 헤드라인 (중간·최종) — thinking-summarizer 발행, WS thinking_summary 로 전달 */
+    onThinkingSummary?: (summary: string) => void;
     /** 에이전트 선택 콜백 */
     onAgentSelected?: (agent: { type: string; name: string; emoji?: string; phase?: string; reason?: string; confidence?: number }) => void;
     /** 토론 진행 콜백 */

--- a/apps/api/src/chat/request-handler.ts
+++ b/apps/api/src/chat/request-handler.ts
@@ -41,6 +41,8 @@ import { extractAndStripArtifacts } from '../llm/artifact-parser';
 import { ArtifactRepository, ArtifactSizeError, type ArtifactKind } from '../data/repositories/artifact-repository';
 import { processExternalToolCalling } from './external-tool-calling';
 import { ensureSession, saveUserMessage, saveAssistantMessage } from './request-persistence';
+import { createThinkingSummarySession } from '../services/chat-service/thinking-summarizer';
+import { getConversationDB } from '../data/conversation-db';
 import type {
     ChatUserContext,
     ExecutionPlanResult,
@@ -370,15 +372,35 @@ export class ChatRequestHandler {
             format: params.format,
         };
 
+        // 생각 요약 세션 (클로드 웹식 헤드라인): 중간(진행형)·최종(과거형) 요약을
+        // onThinkingSummary 로 발행하고, 누적 원문은 저장 시 thinking 컬럼에 영속화.
+        const summarySession = createThinkingSummarySession(
+            message,
+            userContext.authenticatedUserId ?? undefined,
+            (summary) => params.onThinkingSummary?.(summary),
+        );
+        let sawFirstToken = false;
+        const onTokenWithSummary = (token: string) => {
+            if (!sawFirstToken) {
+                sawFirstToken = true;
+                void summarySession.startFinal(); // 첫 응답 토큰 = 생각 종료 → 최종 요약 시작
+            }
+            onToken(token);
+        };
+        const onThinkingWithSummary = (thinking: string) => {
+            summarySession.onThinking(thinking);
+            params.onThinking?.(thinking);
+        };
+
         const response = await chatService.processMessage(
             chatRequest,
-            onToken,
+            onTokenWithSummary,
             onAgentSelected,
             onDiscussionProgress,
             onResearchProgress,
             plan,
             onSkillsActivated,
-            params.onThinking,
+            onThinkingWithSummary,
             onSystemEvent,
             params.onMcpToolResult,
             params.onMcpToolStart,
@@ -436,14 +458,23 @@ export class ChatRequestHandler {
         }
 
         // 7. AI 응답 저장 — placeholder 적용된 cleanedResponse 사용
-        await saveAssistantMessage(
+        void summarySession.startFinal(); // 안전망: 응답 토큰 없이 종료된 경우에도 최종 요약
+        const savedMessageId = await saveAssistantMessage(
             currentSessionId,
             auditUserId,
             cleanedResponse,
             maskedModel,
             responseTime,
             persistContent,
+            summarySession.getThinking() || undefined,
         );
+        // 요약 헤드라인은 비동기 도착 — 저장된 메시지에 fire-and-forget UPDATE (재열람 표시용)
+        if (savedMessageId) {
+            void summarySession.startFinal().then((summary) => {
+                if (!summary) return;
+                return getConversationDB().updateMessageReasoningSummary(savedMessageId, summary);
+            }).catch((e) => log.warn(`reasoning_summary 영속화 실패 (무시): ${e instanceof Error ? e.message : e}`));
+        }
 
         // 8. 다음 턴을 위한 사전 요약 (백그라운드, fire-and-forget)
         // 새 history = 기존 + user message + cleanedResponse (placeholder 포함).

--- a/apps/api/src/chat/request-persistence.ts
+++ b/apps/api/src/chat/request-persistence.ts
@@ -139,7 +139,9 @@ export async function saveAssistantMessage(
     model?: string,
     responseTime?: number,
     saveHistory: boolean = true,
-): Promise<void> {
+    /** 생각(추론) 원문 — 재열람 타임라인용. 요약 헤드라인은 비동기 도착이라 별도 UPDATE. */
+    thinking?: string,
+): Promise<string | null> {
     // 1. 감사 로그 — 항상
     await recordAuditLog({
         sessionId,
@@ -151,13 +153,16 @@ export async function saveAssistantMessage(
         contentLength: response.length,
     });
 
-    // 2. 본문 저장 — saveHistory=true 일 때만
+    // 2. 본문 저장 — saveHistory=true 일 때만. 저장된 메시지 id 반환 (요약 헤드라인 후속 UPDATE 용)
     if (saveHistory) {
         const conversationDb = getConversationDB();
-        await conversationDb.addMessage(sessionId, 'assistant', response, {
+        const saved = await conversationDb.addMessage(sessionId, 'assistant', response, {
             model,
             responseTime,
             tokensUsed: estimateTokens(response),
+            ...(thinking ? { thinking } : {}),
         });
+        return saved?.id ?? null;
     }
+    return null;
 }

--- a/apps/api/src/data/conversation-db.ts
+++ b/apps/api/src/data/conversation-db.ts
@@ -78,6 +78,7 @@ class ConversationDB {
 
     getMessages = messages.getMessages;
     addMessage = messages.addMessage;
+    updateMessageReasoningSummary = messages.updateMessageReasoningSummary;
 
     // saveMessage 별칭 메서드 (server.ts 호환성)
     saveMessage = messages.addMessage;

--- a/apps/api/src/data/conversation-messages.ts
+++ b/apps/api/src/data/conversation-messages.ts
@@ -149,3 +149,15 @@ export async function addMessage(
         thinking: options?.thinking || undefined
     };
 }
+
+/**
+ * 메시지의 생각 요약 헤드라인 갱신 — 요약은 저장 후 비동기로 도착하므로 UPDATE 로 반영.
+ * (thinking-summarizer 최종 요약 → request-handler 가 fire-and-forget 호출)
+ */
+export async function updateMessageReasoningSummary(messageId: string, summary: string): Promise<void> {
+    const pool = getPool();
+    await withRetry(() => pool.query(
+        'UPDATE conversation_messages SET reasoning_summary = $1 WHERE id = $2',
+        [summary, parseInt(messageId, 10)]
+    ), { operation: 'updateMessageReasoningSummary' });
+}

--- a/apps/api/src/data/conversation-types.ts
+++ b/apps/api/src/data/conversation-types.ts
@@ -50,6 +50,8 @@ export interface ConversationMessage {
     model?: string;
     /** AI의 사고 과정 */
     thinking?: string;
+    /** 생각 요약 헤드라인 — summary role 모델 생성 (재열람 타임라인용) */
+    reasoningSummary?: string;
 }
 
 /**
@@ -61,6 +63,8 @@ export interface MessageOptions {
     model?: string;
     /** AI 사고 과정 텍스트 */
     thinking?: string;
+    /** 생각 요약 헤드라인 — summary role 모델 생성 (재열람 타임라인용) */
+    reasoningSummary?: string;
     /** 사용된 토큰 수 */
     tokensUsed?: number;
     /** 응답 생성 시간 (밀리초) */
@@ -86,6 +90,7 @@ export interface MessageRow {
     model: string | null;
     agent_id: string | null;
     thinking: string | null;
+    reasoning_summary: string | null;
     tokens: number | null;
     response_time_ms: number | null;
     created_at: string;
@@ -102,7 +107,8 @@ export function rowToMessage(row: MessageRow): ConversationMessage {
         content: row.content,
         timestamp: row.created_at,
         model: row.model || undefined,
-        thinking: row.thinking || undefined
+        thinking: row.thinking || undefined,
+        reasoningSummary: row.reasoning_summary || undefined
     };
 }
 

--- a/apps/api/src/prompts/thinking-summary.ts
+++ b/apps/api/src/prompts/thinking-summary.ts
@@ -10,13 +10,18 @@
 export function getThinkingSummaryMessages(
     userMessage: string,
     thinking: string,
+    /** progress = 생각 진행 중 (현재진행형 헤드라인), final = 생각 종료 (과거형) */
+    mode: 'progress' | 'final' = 'final',
 ): { system: string; user: string } {
+    const tense = mode === 'progress'
+        ? '- 현재진행형 서술 한 문장, 40자 이내 (예: "근거리 이동 수단 선택지를 비교하는 중입니다")'
+        : '- 정중한 과거형 서술 한 문장, 40자 이내 (예: "근거리 이동 수단 선택지를 비교 검토했습니다")';
     return {
         system: [
             '당신은 AI 의 내부 추론 과정을 한 줄 헤드라인으로 요약하는 도우미입니다.',
             '규칙:',
             '- 반드시 사용자 질문과 같은 언어로 작성',
-            '- 정중한 과거형 서술 한 문장, 40자 이내 (예: "근거리 이동 수단 선택지를 비교 검토했습니다")',
+            tense,
             '- 추론에서 실제로 수행한 검토/비교/분석 행위를 요약 — 결론 내용은 포함하지 않음',
             '- 따옴표, 접두어, 설명 없이 헤드라인 문장만 출력',
         ].join('\n'),

--- a/apps/api/src/services/chat-service/thinking-summarizer.ts
+++ b/apps/api/src/services/chat-service/thinking-summarizer.ts
@@ -39,6 +39,7 @@ export async function summarizeThinking(
     userMessage: string,
     thinking: string,
     userId?: string,
+    mode: 'progress' | 'final' = 'final',
 ): Promise<string | null> {
     if (!getConfig().thinkingSummaryEnabled) return null;
     if (!thinking || thinking.trim().length < 20) return null; // 한두 단어 생각은 요약 무의미
@@ -49,6 +50,7 @@ export async function summarizeThinking(
         const { system, user } = getThinkingSummaryMessages(
             userMessage.slice(0, MAX_USER_MSG_CHARS),
             truncateThinking(thinking),
+            mode,
         );
         const r = await client.chat(
             [{ role: 'system', content: system }, { role: 'user', content: user }],
@@ -63,4 +65,75 @@ export async function summarizeThinking(
         logger.warn(`thinking 요약 실패 (헤드라인 생략): ${e instanceof Error ? e.message : e}`);
         return null;
     }
+}
+
+/* ── 요약 세션 (동적 헤드라인 — 클로드 웹의 진행 중 갱신 대응) ──────────── */
+
+/** 진행 중 첫 중간 요약을 시작하는 생각 누적 길이 — 짧은 생각은 최종 요약만 */
+const PROGRESS_MIN_CHARS = parseInt(process.env.THINKING_SUMMARY_PROGRESS_MIN_CHARS || '800', 10);
+/** 다음 중간 요약까지 필요한 신규 생각 길이 */
+const PROGRESS_STEP_CHARS = parseInt(process.env.THINKING_SUMMARY_PROGRESS_STEP_CHARS || '1500', 10);
+/** 중간 요약 최소 간격 — 요약 호출 폭주 방지 */
+const PROGRESS_MIN_INTERVAL_MS = parseInt(process.env.THINKING_SUMMARY_PROGRESS_INTERVAL_MS || '7000', 10);
+
+export interface ThinkingSummarySession {
+    /** 생각 청크 누적 — 임계값 도달 시 진행형 중간 요약을 비동기 발행 */
+    onThinking(chunk: string): void;
+    /** 누적된 생각 원문 (영속화용) */
+    getThinking(): string;
+    /**
+     * 생각 종료(첫 응답 토큰) — 과거형 최종 요약 시작. 멱등(1회만 시작).
+     * @returns 최종 요약 promise (실패/비활성 시 null resolve)
+     */
+    startFinal(): Promise<string | null>;
+}
+
+/**
+ * 채팅 1건의 생각 요약 세션. 중간(진행형)·최종(과거형) 요약을 onSummary 로 발행 —
+ * 호출부(WS 등)는 도착 순서대로 헤드라인을 덮어쓰면 된다.
+ * in-flight 가드로 요약 호출은 항상 1개만 진행, 최종 시작 후 중간 요약은 중단.
+ */
+export function createThinkingSummarySession(
+    userMessage: string,
+    userId: string | undefined,
+    onSummary: (summary: string) => void,
+): ThinkingSummarySession {
+    let buffer = '';
+    let lastSummarizedLen = 0;
+    let lastSummarizedAt = 0;
+    let inFlight = false;
+    let finalPromise: Promise<string | null> | null = null;
+
+    const run = async (mode: 'progress' | 'final'): Promise<string | null> => {
+        const summary = await summarizeThinking(userMessage, buffer, userId, mode);
+        // 최종 요약이 이미 시작됐으면 늦게 도착한 중간 요약은 발행하지 않음 (역행 방지)
+        if (summary && (mode === 'final' || !finalPromise)) onSummary(summary);
+        return summary;
+    };
+
+    return {
+        onThinking(chunk: string): void {
+            buffer += chunk;
+            if (finalPromise || inFlight) return;
+            if (!getConfig().thinkingSummaryEnabled) return;
+            if (buffer.length < PROGRESS_MIN_CHARS) return;
+            if (lastSummarizedLen > 0 && buffer.length - lastSummarizedLen < PROGRESS_STEP_CHARS) return;
+            if (Date.now() - lastSummarizedAt < PROGRESS_MIN_INTERVAL_MS && lastSummarizedAt > 0) return;
+            inFlight = true;
+            lastSummarizedLen = buffer.length;
+            lastSummarizedAt = Date.now();
+            void run('progress').catch(() => null).finally(() => { inFlight = false; });
+        },
+        getThinking(): string {
+            return buffer;
+        },
+        startFinal(): Promise<string | null> {
+            if (!finalPromise) {
+                finalPromise = buffer.trim().length > 0
+                    ? run('final').catch(() => null)
+                    : Promise.resolve(null);
+            }
+            return finalPromise;
+        },
+    };
 }

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -224,26 +224,6 @@ export async function handleChatMessage(
             },
         });
 
-        // thinking 요약 헤드라인 (클로드 웹식): 생각 스트림을 누적했다가 첫 응답 토큰
-        // 도착(=생각 종료) 시 'summary' role 모델로 1회 요약 → thinking_summary 이벤트.
-        // fire-and-forget — 실패/지연은 헤드라인 생략일 뿐 채팅 스트림에 영향 없음.
-        let thinkingBuffer = '';
-        let thinkingSummaryFired = false;
-        const fireThinkingSummary = () => {
-            if (thinkingSummaryFired || thinkingBuffer.trim().length === 0) return;
-            thinkingSummaryFired = true;
-            const captured = thinkingBuffer;
-            void (async () => {
-                try {
-                    const { summarizeThinking } = await import('../services/chat-service/thinking-summarizer');
-                    const summary = await summarizeThinking(message, captured, String(userContext.userId));
-                    if (summary && ws.readyState === ws.OPEN) {
-                        ws.send(JSON.stringify({ type: 'thinking_summary', summary, messageId }));
-                    }
-                } catch { /* 헤드라인 생략 */ }
-            })();
-        };
-
         const tokenCallback = (token: string) => {
             if (abortController.signal.aborted) {
                 throw new Error('ABORTED');
@@ -253,7 +233,6 @@ export async function handleChatMessage(
                 firstTokenTime = Date.now();
                 const ttfb = firstTokenTime - generationStartTime;
                 log.debug(`[Chat] 첫 번째 토큰 생성됨 (TTFB: ${ttfb}ms)`);
-                fireThinkingSummary(); // 응답 시작 = 생각 종료 시점
             }
             tokenCount++;
             partialAssistantResponse += token;
@@ -296,8 +275,13 @@ export async function handleChatMessage(
             onToken: tokenCallback,
             onThinking: (thinking) => {
                 if (abortController.signal.aborted) throw new Error('ABORTED');
-                thinkingBuffer += thinking;
                 ws.send(JSON.stringify({ type: 'thinking', token: thinking, messageId }));
+            },
+            // 생각 요약 헤드라인 (중간·최종) — request-handler 의 요약 세션이 발행
+            onThinkingSummary: (summary) => {
+                if (ws.readyState === ws.OPEN) {
+                    ws.send(JSON.stringify({ type: 'thinking_summary', summary, messageId }));
+                }
             },
             format: msg.format as import('../llm').FormatOption,
             onAgentSelected: (agent) => ws.send(JSON.stringify({ type: 'agent_selected', agent })),
@@ -407,7 +391,6 @@ export async function handleChatMessage(
         const cleanedContent = (result.artifacts && result.artifacts.length > 0)
             ? result.response
             : undefined;
-        fireThinkingSummary(); // 안전망: 응답 토큰 없이 종료된 경우(도구 전용 등)에도 헤드라인 생성
         ws.send(JSON.stringify({
             type: 'done',
             messageId,

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -40,13 +40,20 @@ export function Sidebar() {
     setCurrentSessionId(sid);
     try {
       const res = await ApiClient.get<
-        ApiSuccess<{ messages?: Array<{ role: string; content: string; images?: string[] }> }>
+        ApiSuccess<{ messages?: Array<{ role: string; content: string; images?: string[]; thinking?: string; reasoningSummary?: string }> }>
       >(appendAnonSessionId(`/api/chat/sessions/${sid}/messages`));
       const msgs = res?.data?.messages ?? [];
       setChatHistory(() =>
         msgs
           .filter((m) => m.role === "user" || m.role === "assistant" || m.role === "system")
-          .map((m) => ({ role: m.role as ChatRole, content: m.content, images: m.images })),
+          .map((m) => ({
+            role: m.role as ChatRole,
+            content: m.content,
+            images: m.images,
+            // 영속화된 생각 과정 — 재열람 시 타임라인 표시 (접힘 상태)
+            reasoning: m.thinking || undefined,
+            reasoningSummary: m.reasoningSummary || undefined,
+          })),
       );
     } catch {
       /* 조회 실패 — 무시 */

--- a/db/migrations/074_message_reasoning_summary.sql
+++ b/db/migrations/074_message_reasoning_summary.sql
@@ -1,0 +1,12 @@
+-- Migration 074 — conversation_messages.reasoning_summary (생각 요약 헤드라인 영속화)
+--
+-- 클로드 웹식 thinking 표시 후속 (2026-07-15): 생각 과정(기존 thinking 컬럼 재사용)과
+-- 요약 헤드라인을 assistant 메시지에 저장해, 세션 재열람 시에도 타임라인을 표시한다.
+-- thinking 컬럼은 Ollama 시절부터 존재(미사용) — 이번에 실사용 재개.
+
+ALTER TABLE conversation_messages ADD COLUMN IF NOT EXISTS reasoning_summary TEXT;
+
+COMMENT ON COLUMN conversation_messages.reasoning_summary IS
+    '생각 요약 헤드라인 — summary role 모델 생성 (thinking-summarizer). NULL=요약 없음.';
+COMMENT ON COLUMN conversation_messages.thinking IS
+    '생각(추론) 원문 — thinkingMode 스트림 누적본. 재열람 시 타임라인 표시에 사용.';


### PR DESCRIPTION
## 개요
클로드 웹식 thinking 표시(#292)의 후속 2건 — ① 긴 생각 진행 중 헤드라인 실시간 갱신(현재진행형→과거형), ② 생각 과정·헤드라인 DB 영속화(재열람 시 타임라인 복원).

## 변경
- `createThinkingSummarySession` — 중간(진행형)/최종(과거형) 요약, 임계값·간격 env, in-flight 가드, 역행 방지
- 오케스트레이션 request-handler 이관 (WS 핸들러는 `onThinkingSummary` 이벤트 전송만) — 저장 지점과 동일 스코프라 영속화 배선 단순화
- 074 `conversation_messages.reasoning_summary` + 기존 `thinking` 컬럼 실사용 재개 (수동 적용 필요)
- 사이드바 세션 로드에 reasoning/reasoningSummary 매핑 — ThinkingTimeline 이 접힌 상태로 복원

## 검증
- [x] tsc(api/web) / eslint / backend unit **2151** 통과 (summarizer 세션 8 테스트 신규 — 임계·멱등·fail-open)
- [ ] live: 074 적용 후 채팅 → 재열람 복원 + 긴 생각 중간 요약 이벤트 확인 (merge 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)