### PR TITLE
feat(discord-bot): Discord gateway 봇 워크스페이스 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1008,3 +1008,34 @@ CHAT_USER_MCP_SCHEMA_BUDGET_BYTES=16000
 # 죽은 LAN IP 등에서 등록 응답이 hang 되지 않도록 상한. 검증 실패해도 저장은 유지(fail-open).
 # EXTERNAL_KEY_VALIDATION_TIMEOUT_MS=8000
 
+
+
+
+# *******************************************************
+# Discord Gateway Bot (apps/discord-bot — hermes-agent 동일 체계)
+# *******************************************************
+# Discord Developer Portal 봇 토큰. 필수 Intents: Server Members + Message Content
+# DISCORD_BOT_TOKEN=
+# openmake_llm API Key (설정 > API 키 발급, omk_live_...) — /api/v1/chat/completions 인증
+# DISCORD_BOT_API_KEY=
+# 백엔드 origin (기본 http://127.0.0.1:52416)
+# DISCORD_BOT_API_BASE_URL=http://127.0.0.1:52416
+# 사용할 모델 id (미설정 시 GET /api/v1/models 첫 항목 자동 선택)
+# DISCORD_BOT_MODEL=
+# DISCORD_BOT_REQUEST_TIMEOUT_MS=120000
+
+# ── 접근 제어 (기본: 전원 거부 — 아래 중 하나는 반드시 설정) ──
+# 허용 사용자 ID 목록 (쉼표 구분)
+# DISCORD_ALLOWED_USERS=
+# 허용 역할 ID 목록 (쉼표 구분)
+# DISCORD_ALLOWED_ROLES=
+# 전원 허용 (신뢰 서버 전용, 명시적 opt-in)
+# DISCORD_ALLOW_ALL_USERS=false
+# 서버 채널에서 @멘션 필수 여부 (기본 true, DM 은 항상 응답)
+# DISCORD_REQUIRE_MENTION=true
+# 멘션 없이 응답하는 자유응답 채널 ID 목록 (쉼표 구분)
+# DISCORD_FREE_RESPONSE_CHANNELS=
+
+# ── 세션 (사용자별 격리, /reset 슬래시 명령으로 초기화) ──
+# 세션당 보관 최대 대화 턴 수
+# DISCORD_SESSION_MAX_TURNS=20

--- a/apps/discord-bot/package.json
+++ b/apps/discord-bot/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "openmake-discord-bot",
+    "version": "1.5.6",
+    "description": "OpenMake LLM Discord gateway bot — Discord 메시지를 /api/v1/chat/completions 로 중계",
+    "main": "dist/index.js",
+    "scripts": {
+        "build": "tsc",
+        "dev": "ts-node src/index.ts",
+        "start": "node dist/index.js"
+    },
+    "engines": {
+        "node": ">=24 <25"
+    },
+    "dependencies": {
+        "discord.js": "^14.16.3",
+        "dotenv": "^16.4.5"
+    },
+    "devDependencies": {
+        "ts-node": "^10.9.2",
+        "typescript": "^5.3.2"
+    }
+}

--- a/apps/discord-bot/src/access-control.ts
+++ b/apps/discord-bot/src/access-control.ts
@@ -1,0 +1,32 @@
+/**
+ * hermes-agent 동일 의미론의 접근 제어:
+ *   allow-all 명시 → 전원 허용
+ *   그 외 → 허용 사용자 목록 또는 허용 역할 보유자만 (기본 전원 거부)
+ */
+import { Message } from 'discord.js';
+import { config } from './config';
+
+export function isUserAllowed(message: Message): boolean {
+    if (config.allowAllUsers) return true;
+    if (config.allowedUsers.includes(message.author.id)) return true;
+    if (config.allowedRoles.length > 0 && message.member) {
+        return message.member.roles.cache.some((role) => config.allowedRoles.includes(role.id));
+    }
+    return false;
+}
+
+/**
+ * 이 메시지에 응답해야 하는가 (멘션/채널 규칙).
+ * DM → 항상 응답. 서버 채널 → 자유응답 채널이거나, 멘션 필수 설정 시 봇 멘션 포함일 때만.
+ */
+export function shouldRespond(message: Message, botUserId: string): boolean {
+    if (!message.guild) return true; // DM
+    if (config.freeResponseChannels.includes(message.channelId)) return true;
+    if (!config.requireMention) return true;
+    return message.mentions.users.has(botUserId);
+}
+
+/** 봇 멘션 토큰(<@id>, <@!id>)을 본문에서 제거 */
+export function stripBotMention(content: string, botUserId: string): string {
+    return content.replace(new RegExp(`<@!?${botUserId}>`, 'g'), '').trim();
+}

--- a/apps/discord-bot/src/config.ts
+++ b/apps/discord-bot/src/config.ts
@@ -1,0 +1,69 @@
+/**
+ * Discord gateway bot 설정 — 전부 환경변수에서 로드 (No-Hardcoding 정책 L1/L2).
+ * 접근 제어 키 체계는 hermes-agent Discord gateway 와 동일한 의미론:
+ *   DISCORD_ALLOWED_USERS / DISCORD_ALLOWED_ROLES / DISCORD_ALLOW_ALL_USERS
+ *   DISCORD_REQUIRE_MENTION / DISCORD_FREE_RESPONSE_CHANNELS
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+
+// apps/api/src/server.ts 와 동일하게 레포 루트 .env 를 로드
+dotenv.config({ path: path.resolve(__dirname, '../../../.env'), quiet: true } as dotenv.DotenvConfigOptions);
+
+function parseList(value: string | undefined): string[] {
+    return (value || '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+}
+
+function parseBool(value: string | undefined, defaultValue: boolean): boolean {
+    if (value === undefined || value === '') return defaultValue;
+    return value.toLowerCase() === 'true';
+}
+
+function parseIntEnv(value: string | undefined, defaultValue: number): number {
+    const n = parseInt(value || '', 10);
+    return Number.isFinite(n) && n > 0 ? n : defaultValue;
+}
+
+export const config = {
+    /** Discord Developer Portal 에서 발급한 bot token (필수) */
+    botToken: process.env.DISCORD_BOT_TOKEN || '',
+
+    /** openmake_llm 백엔드 (OpenAI 호환 v1 경로의 origin) */
+    apiBaseUrl: process.env.DISCORD_BOT_API_BASE_URL || 'http://127.0.0.1:52416',
+    /** openmake_llm API Key (omk_live_...) — /api/v1/* 인증 (필수) */
+    apiKey: process.env.DISCORD_BOT_API_KEY || '',
+    /** 사용할 모델 id. 미설정 시 GET /api/v1/models 첫 항목 사용 */
+    model: process.env.DISCORD_BOT_MODEL || '',
+    requestTimeoutMs: parseIntEnv(process.env.DISCORD_BOT_REQUEST_TIMEOUT_MS, 120_000),
+
+    // ── 접근 제어 (hermes-parity) ─────────────────────────────
+    allowAllUsers: parseBool(process.env.DISCORD_ALLOW_ALL_USERS, false),
+    allowedUsers: parseList(process.env.DISCORD_ALLOWED_USERS),
+    allowedRoles: parseList(process.env.DISCORD_ALLOWED_ROLES),
+    requireMention: parseBool(process.env.DISCORD_REQUIRE_MENTION, true),
+    freeResponseChannels: parseList(process.env.DISCORD_FREE_RESPONSE_CHANNELS),
+
+    // ── 세션 (사용자별 격리, /reset 까지 유지) ─────────────────
+    /** 세션당 보관할 최대 대화 턴 수 (user+assistant 쌍) */
+    sessionMaxTurns: parseIntEnv(process.env.DISCORD_SESSION_MAX_TURNS, 20),
+} as const;
+
+/** Discord 메시지 하드 리밋(2000자) 아래 분할 여유치 */
+export const DISCORD_CHUNK_LIMIT = 1900;
+
+/** 설정 오류로 기동 불가 시 종료 코드 — PM2 stop_exit_codes 와 페어 (재시작 루프 방지) */
+export const EXIT_CODE_CONFIG = 78; // EX_CONFIG
+
+/** 필수 설정 검증. 문제 목록을 반환 (빈 배열 = OK) */
+export function validateConfig(): string[] {
+    const problems: string[] = [];
+    if (!config.botToken) problems.push('DISCORD_BOT_TOKEN 이 설정되지 않았습니다.');
+    if (!config.apiKey) problems.push('DISCORD_BOT_API_KEY (omk_live_...) 가 설정되지 않았습니다.');
+    if (!config.allowAllUsers && config.allowedUsers.length === 0 && config.allowedRoles.length === 0) {
+        problems.push('접근 제어가 비어 있습니다 — DISCORD_ALLOWED_USERS / DISCORD_ALLOWED_ROLES 를 설정하거나 DISCORD_ALLOW_ALL_USERS=true 로 명시하세요.');
+    }
+    return problems;
+}

--- a/apps/discord-bot/src/index.ts
+++ b/apps/discord-bot/src/index.ts
@@ -1,0 +1,126 @@
+/**
+ * OpenMake LLM Discord gateway bot 엔트리포인트.
+ * 구조 (hermes-agent gateway 동일 계열):
+ *   Discord Gateway(WS, 아웃바운드) 상시 접속 → 메시지 수신 → 접근 제어/멘션 규칙
+ *   → 사용자별 세션 이력 → POST /api/v1/chat/completions → Discord 회신.
+ */
+import {
+    ChatInputCommandInteraction,
+    Client,
+    GatewayIntentBits,
+    Message,
+    Partials,
+    SlashCommandBuilder,
+} from 'discord.js';
+import { config, EXIT_CODE_CONFIG, validateConfig } from './config';
+import { isUserAllowed, shouldRespond, stripBotMention } from './access-control';
+import { appendTurns, getHistory, resetSession, sessionKey } from './session-store';
+import { requestChatCompletion, resolveModel } from './openmake-client';
+import { splitForDiscord } from './message-utils';
+
+const problems = validateConfig();
+if (problems.length > 0) {
+    console.error('[discord-bot] 설정 오류로 기동하지 않습니다:');
+    for (const p of problems) console.error(`  - ${p}`);
+    console.error('[discord-bot] 루트 .env 에 값을 설정한 뒤 pm2 start openmake-discord 로 재기동하세요.');
+    process.exit(EXIT_CODE_CONFIG);
+}
+
+const client = new Client({
+    intents: [
+        GatewayIntentBits.Guilds,
+        GatewayIntentBits.GuildMessages,
+        GatewayIntentBits.GuildMembers,
+        GatewayIntentBits.MessageContent,
+        GatewayIntentBits.DirectMessages,
+    ],
+    // DM 채널은 partial 로 도착하므로 필수
+    partials: [Partials.Channel, Partials.Message],
+});
+
+const TYPING_REFRESH_MS = 8_000; // Discord typing 표시는 ~10초 후 소멸 → 주기 갱신
+
+async function handleChat(message: Message, botUserId: string): Promise<void> {
+    const content = stripBotMention(message.content, botUserId);
+    if (!content) return;
+
+    const key = sessionKey(message.channelId, message.author.id);
+    const channel = message.channel;
+    const canType = 'sendTyping' in channel;
+    if (canType) void channel.sendTyping().catch(() => {});
+    const typingTimer = canType
+        ? setInterval(() => void channel.sendTyping().catch(() => {}), TYPING_REFRESH_MS)
+        : null;
+
+    try {
+        const answer = await requestChatCompletion(getHistory(key), content);
+        appendTurns(key, content, answer);
+        const chunks = splitForDiscord(answer);
+        await message.reply({ content: chunks[0], allowedMentions: { repliedUser: true, parse: [] } });
+        for (const chunk of chunks.slice(1)) {
+            if ('send' in channel) {
+                await channel.send({ content: chunk, allowedMentions: { parse: [] } });
+            }
+        }
+    } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        console.error(`[discord-bot] 응답 실패 (${key}):`, reason);
+        await message
+            .reply({ content: `⚠️ 답변 생성에 실패했습니다: ${reason}`, allowedMentions: { parse: [] } })
+            .catch(() => {});
+    } finally {
+        if (typingTimer) clearInterval(typingTimer);
+    }
+}
+
+async function handleReset(interaction: ChatInputCommandInteraction): Promise<void> {
+    const key = sessionKey(interaction.channelId, interaction.user.id);
+    const existed = resetSession(key);
+    await interaction.reply({
+        content: existed ? '🔄 이 채널의 대화 세션을 초기화했습니다.' : 'ℹ️ 초기화할 세션이 없습니다.',
+        ephemeral: true,
+    });
+}
+
+client.once('clientReady', async () => {
+    const user = client.user;
+    if (!user) return;
+    try {
+        const model = await resolveModel();
+        console.log(`[discord-bot] 로그인: ${user.tag}, 모델: ${model}, 백엔드: ${config.apiBaseUrl}`);
+    } catch (err) {
+        console.error('[discord-bot] 백엔드 모델 확인 실패 (기동은 계속):', err instanceof Error ? err.message : err);
+    }
+    // commands.set 은 전역 명령 전체를 교체해 같은 봇 앱을 공유하는 다른 gateway(hermes 등)의
+    // 명령을 지워버림 — 기존 명령을 보존하고 /reset 만 없을 때 추가한다.
+    const app = client.application;
+    if (app) {
+        const existing = await app.commands.fetch();
+        if (!existing.some((cmd) => cmd.name === 'reset')) {
+            await app.commands.create(
+                new SlashCommandBuilder().setName('reset').setDescription('이 채널의 내 대화 세션을 초기화합니다').toJSON(),
+            );
+        }
+    }
+});
+
+client.on('messageCreate', async (message) => {
+    if (message.author.bot) return;
+    const botUserId = client.user?.id;
+    if (!botUserId) return;
+    if (!isUserAllowed(message)) return;
+    if (!shouldRespond(message, botUserId)) return;
+    await handleChat(message, botUserId);
+});
+
+client.on('interactionCreate', async (interaction) => {
+    if (!interaction.isChatInputCommand()) return;
+    if (interaction.commandName === 'reset') {
+        await handleReset(interaction).catch((err) => console.error('[discord-bot] /reset 실패:', err));
+    }
+});
+
+client.login(config.botToken).catch((err) => {
+    console.error('[discord-bot] Discord 로그인 실패:', err instanceof Error ? err.message : err);
+    process.exit(1);
+});

--- a/apps/discord-bot/src/message-utils.ts
+++ b/apps/discord-bot/src/message-utils.ts
@@ -1,0 +1,18 @@
+import { DISCORD_CHUNK_LIMIT } from './config';
+
+/**
+ * Discord 2000자 제한 대응 분할 — 줄바꿈 경계 우선, 초과 시 하드 분할.
+ */
+export function splitForDiscord(content: string, limit: number = DISCORD_CHUNK_LIMIT): string[] {
+    if (content.length <= limit) return [content];
+    const chunks: string[] = [];
+    let remaining = content;
+    while (remaining.length > limit) {
+        let cut = remaining.lastIndexOf('\n', limit);
+        if (cut <= 0) cut = limit;
+        chunks.push(remaining.slice(0, cut));
+        remaining = remaining.slice(cut).replace(/^\n/, '');
+    }
+    if (remaining.length > 0) chunks.push(remaining);
+    return chunks;
+}

--- a/apps/discord-bot/src/openmake-client.ts
+++ b/apps/discord-bot/src/openmake-client.ts
@@ -1,0 +1,66 @@
+/**
+ * openmake_llm 백엔드 호출 — OpenAI 호환 REST (POST /api/v1/chat/completions).
+ * API Key 인증, 비스트리밍 (Discord 는 deferred reply 패턴이라 스트리밍 불필요).
+ */
+import { config } from './config';
+import { ChatTurn } from './session-store';
+
+interface ModelListResponse {
+    data?: Array<{ id: string }>;
+}
+
+interface ChatCompletionResponse {
+    choices?: Array<{ message?: { content?: string } }>;
+    error?: { message?: string };
+}
+
+let resolvedModel = config.model;
+
+/** DISCORD_BOT_MODEL 미설정 시 백엔드 모델 목록의 첫 항목으로 결정 */
+export async function resolveModel(): Promise<string> {
+    if (resolvedModel) return resolvedModel;
+    const res = await fetch(`${config.apiBaseUrl}/api/v1/models`, {
+        headers: { Authorization: `Bearer ${config.apiKey}` },
+    });
+    if (!res.ok) {
+        throw new Error(`모델 목록 조회 실패: HTTP ${res.status}`);
+    }
+    const body = (await res.json()) as ModelListResponse;
+    const first = body.data?.[0]?.id;
+    if (!first) {
+        throw new Error('백엔드 모델 목록이 비어 있습니다 (GET /api/v1/models).');
+    }
+    resolvedModel = first;
+    return resolvedModel;
+}
+
+export async function requestChatCompletion(history: ChatTurn[], userContent: string): Promise<string> {
+    const model = await resolveModel();
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), config.requestTimeoutMs);
+    try {
+        const res = await fetch(`${config.apiBaseUrl}/api/v1/chat/completions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${config.apiKey}`,
+            },
+            body: JSON.stringify({
+                model,
+                messages: [...history, { role: 'user', content: userContent }],
+            }),
+            signal: controller.signal,
+        });
+        const body = (await res.json()) as ChatCompletionResponse;
+        if (!res.ok) {
+            throw new Error(body.error?.message || `백엔드 오류: HTTP ${res.status}`);
+        }
+        const content = body.choices?.[0]?.message?.content;
+        if (!content) {
+            throw new Error('백엔드 응답에 content 가 없습니다.');
+        }
+        return content;
+    } finally {
+        clearTimeout(timer);
+    }
+}

--- a/apps/discord-bot/src/session-store.ts
+++ b/apps/discord-bot/src/session-store.ts
@@ -1,0 +1,36 @@
+/**
+ * 사용자별 세션 격리 (hermes group_sessions_per_user 동일):
+ * 키 = 채널 ID + 사용자 ID. /reset 슬래시 명령까지 유지, 턴 수 상한으로 트림.
+ * v1 은 인메모리 — 프로세스 재시작 시 초기화됨 (영속화는 후속 과제).
+ */
+import { config } from './config';
+
+export interface ChatTurn {
+    role: 'user' | 'assistant';
+    content: string;
+}
+
+const sessions = new Map<string, ChatTurn[]>();
+
+export function sessionKey(channelId: string, userId: string): string {
+    return `${channelId}:${userId}`;
+}
+
+export function getHistory(key: string): ChatTurn[] {
+    return sessions.get(key) || [];
+}
+
+export function appendTurns(key: string, userContent: string, assistantContent: string): void {
+    const history = sessions.get(key) || [];
+    history.push({ role: 'user', content: userContent }, { role: 'assistant', content: assistantContent });
+    const maxMessages = config.sessionMaxTurns * 2;
+    if (history.length > maxMessages) {
+        history.splice(0, history.length - maxMessages);
+    }
+    sessions.set(key, history);
+}
+
+/** 세션 초기화. 기존 세션이 있었으면 true */
+export function resetSession(key: string): boolean {
+    return sessions.delete(key);
+}

--- a/apps/discord-bot/tsconfig.json
+++ b/apps/discord-bot/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "outDir": "dist",
+        "rootDir": "src",
+        "strict": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "resolveJsonModule": true
+    },
+    "include": ["src/**/*.ts"]
+}

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -93,5 +93,29 @@ module.exports = {
         out_file: '/tmp/openmake-next-out.log',
         merge_logs: true,
         log_date_format: 'YYYY-MM-DD HH:mm:ss',
+    }, {
+        // ── Discord Gateway Bot ─────────────────────────────────
+        // Discord 메시지를 /api/v1/chat/completions 로 중계하는 독립 gateway 프로세스.
+        // 선행: 루트 .env 에 DISCORD_BOT_TOKEN·DISCORD_BOT_API_KEY + 접근 제어 설정,
+        //       `npm run build:discord-bot` 으로 dist 생성.
+        // 설정 미비 시 exit 78 로 스스로 내려가며 stop_exit_codes 가 재시작 루프를 막는다.
+        name: 'openmake-discord',
+        script: 'apps/discord-bot/dist/index.js',
+        cwd: __dirname,
+        env: {
+            NODE_ENV: 'production',
+        },
+        instances: 1,
+        exec_mode: 'fork',
+        autorestart: true,
+        stop_exit_codes: [78],          // EX_CONFIG — 설정 미비 정상 정지
+        max_restarts: 10,
+        min_uptime: '10s',
+        restart_delay: 3000,
+        max_memory_restart: '300M',
+        error_file: '/tmp/openmake-discord-error.log',
+        out_file: '/tmp/openmake-discord-out.log',
+        merge_logs: true,
+        log_date_format: 'YYYY-MM-DD HH:mm:ss',
     }],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "workspaces": [
                 "apps/api",
                 "apps/web",
+                "apps/discord-bot",
                 "packages/*"
             ],
             "dependencies": {
@@ -120,16 +121,31 @@
                 "node": ">=12"
             }
         },
-        "apps/legacy-web": {
-            "name": "openmake-web",
+        "apps/discord-bot": {
+            "name": "openmake-discord-bot",
             "version": "1.5.6",
-            "extraneous": true,
             "dependencies": {
-                "axios": "^1.13.2"
+                "discord.js": "^14.16.3",
+                "dotenv": "^16.4.5"
             },
             "devDependencies": {
-                "typescript": "^5.3.2",
-                "vite": "^8.0.16"
+                "ts-node": "^10.9.2",
+                "typescript": "^5.3.2"
+            },
+            "engines": {
+                "node": ">=24 <25"
+            }
+        },
+        "apps/discord-bot/node_modules/dotenv": {
+            "version": "16.6.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+            "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
             }
         },
         "apps/web": {
@@ -175,184 +191,6 @@
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
-            }
-        },
-        "backend/api": {
-            "name": "openmake-api",
-            "version": "1.5.6",
-            "extraneous": true,
-            "dependencies": {
-                "@anthropic-ai/sdk": "^0.95.1",
-                "@modelcontextprotocol/sdk": "^1.25.3",
-                "@mozilla/readability": "^0.6.0",
-                "@opentelemetry/api": "^1.9.1",
-                "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
-                "@opentelemetry/instrumentation-express": "^0.67.0",
-                "@opentelemetry/instrumentation-http": "^0.219.0",
-                "@opentelemetry/resources": "^2.8.0",
-                "@opentelemetry/sdk-node": "^0.219.0",
-                "@opentelemetry/sdk-trace-node": "^2.8.0",
-                "@opentelemetry/semantic-conventions": "^1.41.1",
-                "@types/pg": "^8.16.0",
-                "axios": "^1.13.2",
-                "babel-jest": "^30.4.1",
-                "bcryptjs": "^3.0.3",
-                "chalk": "^4.1.2",
-                "cli-highlight": "^2.1.11",
-                "commander": "^14.0.3",
-                "cookie-parser": "^1.4.7",
-                "dotenv": "^17.2.3",
-                "express": "^5.2.1",
-                "express-rate-limit": "^8.2.1",
-                "helmet": "^8.1.0",
-                "inquirer": "^13.2.2",
-                "ioredis": "^5.10.1",
-                "js-yaml": "^4.1.1",
-                "jsdom": "^29.0.1",
-                "jsonwebtoken": "^9.0.3",
-                "lru-cache": "^7.18.3",
-                "multer": "^2.0.2",
-                "nodemailer": "^9.0.0",
-                "openai": "^6.37.0",
-                "ora": "^9.2.0",
-                "pdf-parse": "^2.4.5",
-                "pg": "^8.18.0",
-                "tesseract.js": "^7.0.0",
-                "turndown": "^7.2.2",
-                "turndown-plugin-gfm": "^1.0.2",
-                "undici": "^7.24.5",
-                "uuid": "^13.0.0",
-                "web-push": "^3.6.7",
-                "winston": "^3.19.0",
-                "ws": "^8.18.3",
-                "zod": "^4.3.6"
-            },
-            "devDependencies": {
-                "@types/bcryptjs": "^2.4.6",
-                "@types/cookie-parser": "^1.4.7",
-                "@types/cors": "^2.8.17",
-                "@types/express": "^5.0.6",
-                "@types/inquirer": "^9.0.9",
-                "@types/jest": "^30.0.0",
-                "@types/js-yaml": "^4.0.9",
-                "@types/jsdom": "^28.0.1",
-                "@types/jsonwebtoken": "^9.0.10",
-                "@types/multer": "^2.0.0",
-                "@types/node": "^24.0.0",
-                "@types/pdf-parse": "^1.1.5",
-                "@types/turndown": "^5.0.6",
-                "@types/web-push": "^3.6.4",
-                "@types/ws": "^8.18.1",
-                "ts-jest": "^29.4.11",
-                "ts-node": "^10.9.2",
-                "typescript": "^5.3.2"
-            }
-        },
-        "backend/core": {
-            "name": "openmake-core",
-            "version": "1.0.0",
-            "extraneous": true,
-            "dependencies": {
-                "@modelcontextprotocol/sdk": "^1.25.1",
-                "axios": "^1.6.0",
-                "bcryptjs": "^3.0.3",
-                "better-sqlite3": "^12.5.0",
-                "bull": "^4.16.5",
-                "chalk": "^4.1.2",
-                "cli-highlight": "^2.1.11",
-                "commander": "^11.1.0",
-                "dotenv": "^17.2.3",
-                "exceljs": "^4.4.0",
-                "inquirer": "^8.2.6",
-                "jsonwebtoken": "^9.0.3",
-                "lru-cache": "^11.2.4",
-                "nodemailer": "^7.0.12",
-                "ora": "^5.4.1",
-                "pdf-parse": "^2.4.5",
-                "pdfjs-dist": "^5.4.449",
-                "pino": "^10.1.0",
-                "tesseract.js": "^7.0.0",
-                "uuid": "^13.0.0",
-                "winston": "^3.19.0",
-                "zod": "^4.2.1"
-            },
-            "devDependencies": {
-                "@types/bcryptjs": "^2.4.6",
-                "@types/inquirer": "^9.0.7",
-                "@types/jsonwebtoken": "^9.0.10",
-                "@types/node": "^20.10.0",
-                "@types/nodemailer": "^7.0.4",
-                "@types/uuid": "^10.0.0",
-                "typescript": "^5.3.2"
-            }
-        },
-        "backend/workers": {
-            "name": "openmake-workers",
-            "version": "1.0.0",
-            "extraneous": true
-        },
-        "database": {
-            "name": "openmake-database",
-            "version": "1.0.0",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/pg": "^8.16.0",
-                "bcryptjs": "^3.0.3",
-                "better-sqlite3": "^12.5.0",
-                "pg": "^8.18.0",
-                "uuid": "^13.0.0"
-            },
-            "devDependencies": {
-                "@types/bcryptjs": "^2.4.6",
-                "@types/better-sqlite3": "^7.6.13",
-                "@types/node": "^20.10.0",
-                "@types/uuid": "^10.0.0",
-                "typescript": "^5.3.2"
-            }
-        },
-        "frontend/nextjs": {
-            "name": "@openmake/nextjs",
-            "version": "0.1.0",
-            "extraneous": true,
-            "dependencies": {
-                "@tanstack/react-query": "^5.101.0",
-                "clsx": "^2.1.1",
-                "katex": "^0.17.0",
-                "lucide-react": "^1.21.0",
-                "next": "16.2.9",
-                "next-themes": "^0.4.6",
-                "react": "19.2.4",
-                "react-dom": "19.2.4",
-                "react-markdown": "^10.1.0",
-                "rehype-highlight": "^7.0.2",
-                "rehype-katex": "^7.0.1",
-                "rehype-sanitize": "^6.0.0",
-                "remark-gfm": "^4.0.1",
-                "tailwind-merge": "^3.6.0",
-                "zustand": "^5.0.14"
-            },
-            "devDependencies": {
-                "@tailwindcss/postcss": "^4",
-                "@types/node": "^20",
-                "@types/react": "^19",
-                "@types/react-dom": "^19",
-                "eslint": "^9",
-                "eslint-config-next": "16.2.9",
-                "tailwindcss": "^4",
-                "typescript": "^5"
-            }
-        },
-        "frontend/web": {
-            "name": "openmake-web",
-            "version": "1.5.6",
-            "extraneous": true,
-            "dependencies": {
-                "axios": "^1.13.2"
-            },
-            "devDependencies": {
-                "typescript": "^5.3.2",
-                "vite": "^8.0.16"
             }
         },
         "node_modules/@alloc/quick-lru": {
@@ -1076,6 +914,155 @@
                 "@so-ric/colorspace": "^1.1.6",
                 "enabled": "2.0.x",
                 "kuler": "^2.0.0"
+            }
+        },
+        "node_modules/@discordjs/builders": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.14.1.tgz",
+            "integrity": "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@discordjs/formatters": "^0.6.2",
+                "@discordjs/util": "^1.2.0",
+                "@sapphire/shapeshift": "^4.0.0",
+                "discord-api-types": "^0.38.40",
+                "fast-deep-equal": "^3.1.3",
+                "ts-mixer": "^6.0.4",
+                "tslib": "^2.6.3"
+            },
+            "engines": {
+                "node": ">=16.11.0"
+            },
+            "funding": {
+                "url": "https://github.com/discordjs/discord.js?sponsor"
+            }
+        },
+        "node_modules/@discordjs/collection": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+            "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=16.11.0"
+            }
+        },
+        "node_modules/@discordjs/formatters": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+            "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "discord-api-types": "^0.38.33"
+            },
+            "engines": {
+                "node": ">=16.11.0"
+            },
+            "funding": {
+                "url": "https://github.com/discordjs/discord.js?sponsor"
+            }
+        },
+        "node_modules/@discordjs/rest": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
+            "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@discordjs/collection": "^2.1.1",
+                "@discordjs/util": "^1.2.0",
+                "@sapphire/async-queue": "^1.5.3",
+                "@sapphire/snowflake": "^3.5.5",
+                "@vladfrangu/async_event_emitter": "^2.4.6",
+                "discord-api-types": "^0.38.40",
+                "magic-bytes.js": "^1.13.0",
+                "tslib": "^2.6.3",
+                "undici": "6.24.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/discordjs/discord.js?sponsor"
+            }
+        },
+        "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+            "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/discordjs/discord.js?sponsor"
+            }
+        },
+        "node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
+            "version": "3.5.5",
+            "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+            "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=v14.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/@discordjs/rest/node_modules/undici": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+            "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.17"
+            }
+        },
+        "node_modules/@discordjs/util": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+            "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "discord-api-types": "^0.38.33"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/discordjs/discord.js?sponsor"
+            }
+        },
+        "node_modules/@discordjs/ws": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+            "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@discordjs/collection": "^2.1.0",
+                "@discordjs/rest": "^2.5.1",
+                "@discordjs/util": "^1.1.0",
+                "@sapphire/async-queue": "^1.5.2",
+                "@types/ws": "^8.5.10",
+                "@vladfrangu/async_event_emitter": "^2.2.4",
+                "discord-api-types": "^0.38.1",
+                "tslib": "^2.6.2",
+                "ws": "^8.17.0"
+            },
+            "engines": {
+                "node": ">=16.11.0"
+            },
+            "funding": {
+                "url": "https://github.com/discordjs/discord.js?sponsor"
+            }
+        },
+        "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+            "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/discordjs/discord.js?sponsor"
             }
         },
         "node_modules/@emnapi/core": {
@@ -4533,6 +4520,39 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@sapphire/async-queue": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+            "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=v14.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/@sapphire/shapeshift": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+            "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "lodash": "^4.17.21"
+            },
+            "engines": {
+                "node": ">=v16"
+            }
+        },
+        "node_modules/@sapphire/snowflake": {
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+            "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=v14.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
         "node_modules/@schummar/icu-type-parser": {
             "version": "1.21.5",
             "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
@@ -5621,7 +5641,6 @@
         },
         "node_modules/@types/ws": {
             "version": "8.18.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
@@ -6281,6 +6300,16 @@
             "os": [
                 "win32"
             ]
+        },
+        "node_modules/@vladfrangu/async_event_emitter": {
+            "version": "2.4.7",
+            "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+            "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=v14.0.0",
+                "npm": ">=7.0.0"
+            }
         },
         "node_modules/@xmldom/xmldom": {
             "version": "0.9.10",
@@ -7886,6 +7915,51 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
+            }
+        },
+        "node_modules/discord-api-types": {
+            "version": "0.38.49",
+            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.49.tgz",
+            "integrity": "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg==",
+            "license": "MIT",
+            "workspaces": [
+                "scripts/actions/documentation"
+            ]
+        },
+        "node_modules/discord.js": {
+            "version": "14.26.5",
+            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.5.tgz",
+            "integrity": "sha512-SGYgjiAs0o8ZzMC97XmFXKONyairJ9YzVda+LvoSKs9YYh2gPtQhY+liaV6H/w72jxYbu9ggiSqAXoF3FLOH4A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@discordjs/builders": "^1.14.1",
+                "@discordjs/collection": "1.5.3",
+                "@discordjs/formatters": "^0.6.2",
+                "@discordjs/rest": "^2.6.1",
+                "@discordjs/util": "^1.2.0",
+                "@discordjs/ws": "^1.2.3",
+                "@sapphire/snowflake": "3.5.3",
+                "discord-api-types": "^0.38.48",
+                "fast-deep-equal": "3.1.3",
+                "lodash.snakecase": "4.1.1",
+                "magic-bytes.js": "^1.13.0",
+                "tslib": "^2.6.3",
+                "undici": "6.24.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/discordjs/discord.js?sponsor"
+            }
+        },
+        "node_modules/discord.js/node_modules/undici": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+            "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.17"
             }
         },
         "node_modules/doctrine": {
@@ -12125,7 +12199,6 @@
             "version": "4.18.1",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
             "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.camelcase": {
@@ -12198,6 +12271,12 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.snakecase": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+            "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
             "license": "MIT"
         },
         "node_modules/logform": {
@@ -12285,6 +12364,12 @@
             "peerDependencies": {
                 "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
+        },
+        "node_modules/magic-bytes.js": {
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+            "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+            "license": "MIT"
         },
         "node_modules/magic-string": {
             "version": "0.30.21",
@@ -13955,6 +14040,10 @@
         },
         "node_modules/openmake-api": {
             "resolved": "apps/api",
+            "link": true
+        },
+        "node_modules/openmake-discord-bot": {
+            "resolved": "apps/discord-bot",
             "link": true
         },
         "node_modules/optionator": {
@@ -16546,6 +16635,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/ts-mixer": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+            "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+            "license": "MIT"
         },
         "node_modules/ts-node": {
             "version": "10.9.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "test:e2e:ui": "npx playwright test --ui",
         "lint": "eslint .",
         "clean": "rm -rf */dist **/dist",
-        "version": "node -e \"const v=require('./package.json').version;const fs=require('fs');['apps/api/package.json','apps/web/package.json'].forEach(f=>{const p=JSON.parse(fs.readFileSync(f,'utf8'));p.version=v;fs.writeFileSync(f,JSON.stringify(p,null,4)+'\\n')});console.log('✅ 모든 workspace 버전 동기화 완료:',v)\" && git add apps/api/package.json apps/web/package.json"
+        "version": "node -e \"const v=require('./package.json').version;const fs=require('fs');['apps/api/package.json','apps/web/package.json'].forEach(f=>{const p=JSON.parse(fs.readFileSync(f,'utf8'));p.version=v;fs.writeFileSync(f,JSON.stringify(p,null,4)+'\\n')});console.log('✅ 모든 workspace 버전 동기화 완료:',v)\" && git add apps/api/package.json apps/web/package.json",
+        "build:discord-bot": "cd apps/discord-bot && npm run build"
     },
     "keywords": [
         "ai",
@@ -37,6 +38,7 @@
     "workspaces": [
         "apps/api",
         "apps/web",
+        "apps/discord-bot",
         "packages/*"
     ],
     "devDependencies": {


### PR DESCRIPTION
## 개요
Discord 메시지를 openmake_llm 백엔드(`/api/v1/chat/completions`)로 중계하는 독립 gateway 봇. hermes-agent Discord gateway 동일 계열. 세션 시작 전부터 워킹트리에 있던 WIP를 정리·검증 후 커밋.

## 변경
- **`apps/discord-bot`** 신규 워크스페이스 (소스 6 + package.json/tsconfig): Gateway WS 상시 접속 → 접근 제어/멘션 규칙 → 사용자별 세션 이력(인메모리, `/reset`) → OpenAI 호환 REST → Discord 회신 (2000자 분할)
- **접근 제어** hermes-parity: `DISCORD_ALLOWED_USERS/ROLES/ALLOW_ALL`, `REQUIRE_MENTION`, `FREE_RESPONSE_CHANNELS` (기본 전원 거부)
- 설정 미비 시 **exit 78(EX_CONFIG)** 자진 정지 + pm2 `stop_exit_codes` 재시작 루프 차단
- 루트 `workspaces` + `build:discord-bot` 스크립트, ecosystem `openmake-discord` 프로세스, `.env.example` DISCORD_* 문서
- No-Hardcoding(전부 env), API Key 인증

## 범위 외 (의도적 제외)
- 워킹트리의 fast-fail prefill 보정(`timeouts.ts`·`local-llm-provider.ts`)은 **별개 관심사**라 이 커밋에 미포함 — 그대로 남김

## 검증
- [x] `npm run build:discord-bot` (tsc) 통과
- [x] `eslint apps/discord-bot/src` 통과
- [x] 메인 `build`(backend+frontend)·CI 파일크기 가드·테스트는 apps/api 한정 → 새 워크스페이스 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)