### PR TITLE
fix(llm): fast-fail 타임아웃 대형 프롬프트 prefill 보정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,13 @@ LLM_TIMEOUT=120000                              # HTTP 요청 타임아웃 (ms)
 # - 0 또는 음수 시 비활성.
 # LLM_FAST_FAIL_TIMEOUT_MS=30000
 
+# Fast-fail 대형 프롬프트 prefill 보정 (2026-07-14).
+# vLLM 은 prefill 완료 후에야 첫 SSE 청크를 보내므로, 고정 fast-fail 은 대형 첨부
+# (예: 엑셀 10개 ~55k 토큰) 의 정상 prefill 을 죽인다. 유효 타임아웃 =
+# min(BASE + 입력토큰추정/1000 × PER_1K, MAX). config/timeouts.ts LLM_TIMEOUTS 참조.
+# LLM_FAST_FAIL_PREFILL_MS_PER_1K_TOKENS=1000
+# LLM_FAST_FAIL_MAX_MS=120000
+
 # Server boot 시 모델 워밍업 timeout (default 10000ms). PR #66.
 # - LLM_TIMEOUT (chat 120s) 보다 짧음 — backend hang 으로 워밍업 무한 대기 방지.
 # - 워밍업 실패해도 boot 는 정상 진행 (첫 사용자 요청 시 cold-load 발생 가능).

--- a/apps/api/src/config/timeouts.ts
+++ b/apps/api/src/config/timeouts.ts
@@ -46,6 +46,14 @@ export const LLM_TIMEOUTS = {
      * 정식 LLM 보고서가 timeout 으로 잘려 fallback 되지 않도록 여유 확보(평소엔 거의 미사용).
      */
     REPORT_GENERATION_TIMEOUT_MS: Number(process.env.DEEP_RESEARCH_REPORT_TIMEOUT_MS) || 900000,
+    /**
+     * Fast-fail(TTFT race) 대형 프롬프트 prefill 보정: 입력 1k 토큰 추정치당 가산 시간 (ms).
+     * vLLM 은 prefill 완료 후에야 첫 SSE 청크를 보내므로, 고정 fast-fail 은 대형 첨부(수만 토큰)의
+     * 정상 prefill 을 죽인다. env override: LLM_FAST_FAIL_PREFILL_MS_PER_1K_TOKENS
+     */
+    FAST_FAIL_PREFILL_MS_PER_1K_TOKENS: Number(process.env.LLM_FAST_FAIL_PREFILL_MS_PER_1K_TOKENS) || 1000,
+    /** Fast-fail 유효 타임아웃 상한 (ms) — 전역 LLM_TIMEOUT(기본 120000)과 정렬. env override: LLM_FAST_FAIL_MAX_MS */
+    FAST_FAIL_MAX_MS: Number(process.env.LLM_FAST_FAIL_MAX_MS) || 120000,
 } as const;
 
 // ============================================

--- a/apps/api/src/providers/local-llm-provider.ts
+++ b/apps/api/src/providers/local-llm-provider.ts
@@ -34,6 +34,8 @@ import type { LLMClient } from '../llm';
 import type { ToolCall, UsageMetrics } from '../llm';
 import { matchCapabilityPreset, FALLBACK_CAPABILITIES } from '../config/model-defaults';
 import { LLM_ANTI_DEGENERATION_FREQUENCY_PENALTY } from '../config/llm-parameters';
+import { LLM_TIMEOUTS } from '../config/timeouts';
+import { estimateMessageTokens } from '../llm/model-pool';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('LocalLLMProvider');
@@ -133,6 +135,11 @@ export class LocalLLMProvider implements IProvider {
         // Fast-fail timeout — retried=false 호출에 한해 짧은 timeout 으로 TTFT race.
         // 정상 모델은 TTFT 가 수백 ms 이내 — default 5s 안전.
         //
+        // 대형 프롬프트 보정 (2026-07-14): vLLM 은 prefill 이 끝나야 첫 SSE 청크를 보내므로
+        // 고정 timeout 은 정상 prefill 중인 요청을 죽인다 (엑셀 10개 첨부 ~55k 토큰이 30s
+        // fast-fail 로 오판 demote → 사용자에겐 "파일을 읽을 수 없음"으로 보이던 회귀).
+        // 입력 토큰 추정치에 비례해 연장하고 FAST_FAIL_MAX_MS 로 상한을 둔다.
+        //
         // 2단 메커니즘:
         //  1) fastFailController.abort() → SDK request cancel (upstream HTTP 즉시 종료, orphan 방지)
         //  2) Promise.race reject → catch 진입 (SDK 의 mid-stream abort 는 silent 종료라
@@ -140,7 +147,13 @@ export class LocalLLMProvider implements IProvider {
         //
         // user signal (opts.abortSignal) 과는 별도 controller — 자체 abort 를 user abort 로
         // 오인하여 fallback 을 건너뛰는 함정 방지.
-        const FAST_FAIL_MS = retried ? 0 : parseInt(process.env.LLM_FAST_FAIL_TIMEOUT_MS || '5000', 10);
+        const FAST_FAIL_BASE_MS = retried ? 0 : parseInt(process.env.LLM_FAST_FAIL_TIMEOUT_MS || '5000', 10);
+        const prefillAllowanceMs = Math.round(
+            (estimateMessageTokens(opts.messages) / 1000) * LLM_TIMEOUTS.FAST_FAIL_PREFILL_MS_PER_1K_TOKENS,
+        );
+        const FAST_FAIL_MS = FAST_FAIL_BASE_MS > 0
+            ? Math.max(FAST_FAIL_BASE_MS, Math.min(FAST_FAIL_BASE_MS + prefillAllowanceMs, LLM_TIMEOUTS.FAST_FAIL_MAX_MS))
+            : 0;
         const fastFailController = FAST_FAIL_MS > 0 ? new AbortController() : null;
         let fastFailTimer: NodeJS.Timeout | null = null;
         const fastFailPromise = fastFailController


### PR DESCRIPTION
## 개요
이미 dist 로 빌드·운영 배포돼 돌고 있던 fast-fail prefill 보정의 **소스를 git 에 정합화** (source↔production drift 해소). 워킹트리에 미커밋 상태로 있던 WIP.

## 문제
vLLM 은 prefill(입력 처리) 완료 후에야 첫 SSE 청크를 보내므로, 고정 fast-fail 타임아웃(기본 5s)이 대형 첨부(예: 엑셀 10개 ~55k 토큰)의 **정상 prefill 중인 요청을 "응답 없음"으로 오판해 죽였다** → 사용자에겐 "파일을 읽을 수 없음"으로 보이던 회귀.

## 수정
유효 fast-fail = `min(BASE + 입력토큰추정/1000 × PER_1K, MAX)`. 입력 토큰 추정치(`estimateMessageTokens`)에 비례 연장, `FAST_FAIL_MAX_MS`(기본 120000, 전역 LLM_TIMEOUT 정렬) 상한. retried 호출은 종전대로 0(비활성).
- `config/timeouts.ts`: `FAST_FAIL_PREFILL_MS_PER_1K_TOKENS`·`FAST_FAIL_MAX_MS` 상수 (env override)
- `providers/local-llm-provider.ts`: `prefillAllowanceMs` 반영

## 검증
- [x] `tsc --noEmit` / eslint 통과
- [x] 이미 운영 dist 에 반영·가동 중 (이 PR 은 소스 정합화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)