### PR TITLE
docs(readme): 소스 현행화 — role 오케스트레이션·Discord 봇·thinking 표시

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 
 ## Overview
 
-**OpenMake LLM** is a self-hosted AI assistant you run on your own hardware. It serves a local model through **vLLM** behind a **LiteLLM proxy** (OpenAI-compatible) and routes the *same* abstraction to external providers (Anthropic, OpenAI-compatible, OpenRouter, Ollama) whenever you want them — so your data stays on your machine by default.
+**OpenMake LLM** is a self-hosted AI assistant you run on your own hardware. It serves a local model through **vLLM** behind a **LiteLLM proxy** (OpenAI-compatible) and routes the *same* abstraction to external providers you register with your own keys (**OpenRouter, NVIDIA NIM, Ollama** local/cloud — all OpenAI-compatible; an Anthropic adapter is also built in) — so your data stays on your machine by default.
 
-Every request flows through a lightweight, deterministic policy layer — **`ExecutionPlanBuilder`** (regex + fast-path classification) — that routes the single local model and assembles options *without* an extra LLM round-trip. Behavior is controlled by orthogonal axes only — **Model · Style · Mode toggles · Custom Agent** — instead of opaque presets. Beyond chat, it adds autonomous agents, a deep-research pipeline, and an MCP tool system — all behind JWT auth and role-based access control.
+Every request flows through a lightweight, deterministic policy layer — **`ExecutionPlanBuilder`** (regex + fast-path classification) — that routes the single local model and assembles options *without* an extra LLM round-trip. Behavior is controlled by orthogonal axes only — **Model · Style · Mode toggles · Custom Agent** — instead of opaque presets. Power users can go further with **role-based model orchestration** — assigning a different model (local or external) to each functional role (agent, judge, research, parallel sub-agents, review, thinking-summary). Beyond chat, it adds autonomous agents, a deep-research pipeline, and an MCP tool system — all behind JWT auth and role-based access control.
 
 > **Single-host design:** the application (API + web) runs under **PM2**, while stateful dependencies (PostgreSQL / Redis) and sandboxed agent / MCP / artifact processes run in **Docker** for isolation.
 
@@ -29,10 +29,12 @@ Every request flows through a lightweight, deterministic policy layer — **`Exe
 | | |
 |---|---|
 | 🧠 **1 local model, routed per request** | `qwen3.6-35b-a3b` served via vLLM + LiteLLM, with a 262K context-fit safety net |
+| 🎛️ **Role-based model orchestration** | Assign a different model (local or BYOK external) per functional role; per-user + admin-global mappings, server-shared keys with token budgets |
 | 🤖 **Autonomous agents** | Manus-style multi-turn agent in a persistent Docker sandbox (shell · Python · browser · files), with human-in-the-loop approval |
 | 🔬 **Deep research** | Fan-out web search → source fetch → claim verification → cited synthesis |
 | 🧩 **22 built-in MCP tools** + external MCP servers | Each external server isolated in Docker (`--cap-drop ALL`, non-root, network policy) |
-| 👤 **Custom agents & 140+ skills** | Project-scoped personas + an auto-selectable skill library |
+| 👤 **Custom agents & skills** | Project-scoped personas (with optional per-agent model) + an auto-selectable skill library + 18 industry agents (100 specialists) |
+| 💬 **Discord gateway bot** | Optional workspace relaying Discord messages to the OpenAI-compatible API, with role/mention access control |
 | 🌐 **4-language UI** | 한국어 · English · 日本語 · 简体中文 (`next-intl`, cookie locale, browser auto-detect) |
 | 🔒 **Security-first** | JWT (HttpOnly), Google OAuth 2.0, RBAC, per-route rate limiting, SSRF guard, Audit ↔ Alert |
 
@@ -84,7 +86,9 @@ OpenMake separates **policy** (deciding *how* to answer) from **execution** (act
 
 - **Context-fit safety net** — on entry, prompt tokens (images included) are estimated; if the effective **262K** window is exceeded, input is truncated → `max_tokens` reduced → in the extreme, a `ContextOverflowError` returns **HTTP 413** with an audit record and an automatic webhook alert.
 - **User customization (4 orthogonal axes)** — **Model** (selector) · **Style** (Concise / Default / Verbose) · **Mode** (Discussion / Thinking / Deep Research / Web / Agent Task) · **Custom Instructions & Agents**. System-prompt assembly order: `memory + custom-instructions + style`.
+- **Role-based model orchestration** — every LLM-calling subsystem resolves its model through a single role registry with a fail-open fallback chain: per-user mapping → admin-set global (DB) → global env → local default. External models per role run on the user's BYOK key, or on a server-shared operator key (with daily/monthly token budgets) for global roles. Custom agents can also pin their own model.
 - **Cross-conversation memory** — explicit long-term memories are injected into the system prompt; a privacy toggle lets a user exclude them per session.
+- **Thinking display (Claude-web style)** — when Thinking mode is on, the reasoning stream renders as a live timeline; a dedicated `summary`-role model generates a one-line headline (streaming interim → final), and both the reasoning and headline are persisted so re-opening a conversation restores the timeline.
 
 ---
 
@@ -93,18 +97,23 @@ OpenMake separates **policy** (deciding *how* to answer) from **execution** (act
 **▸ Models & routing**
 - Single local model routed per request by the `ExecutionPlanBuilder` policy layer; behavior controlled by orthogonal axes (Model · Style · Mode · Custom Agent).
 - Self-hosted vLLM + LiteLLM (default `qwen3.6-35b-a3b`) with a context-fit safety net that protects output tokens and degrades gracefully on overflow.
-- Bring-your-own external keys (Anthropic / OpenAI-compatible / OpenRouter / Ollama), AES-256-GCM encrypted at rest. **Guests use the default local model only** — external providers require sign-in.
+- Bring-your-own external keys — **OpenRouter, NVIDIA NIM, Ollama** (local + cloud), all OpenAI-compatible (an Anthropic adapter is built into the provider abstraction) — AES-256-GCM encrypted at rest. **Guests use the default local model only** — external providers require sign-in.
+- **Role-based model orchestration** — assign a different model (local or BYOK external) to each functional role (`agent`, `judge`, `research`, `spawn`, `review`, `summary`) via Settings; admins set org-wide defaults and register server-shared external keys with per-key token budgets in an admin console. Resolution is fail-open (falls back to the local default on any failure).
 
 **▸ Agents & research**
 - **Autonomous agent tasks** — a Manus-style agent pursues a goal across multiple tool-calling turns inside a **persistent Docker sandbox** (shell, Python, browser, file, planning tools) with human-in-the-loop approval. It records file attachments, injects images through a vision channel, produces deliverables including **Excel (.xlsx)** and **PDF** (with Korean/CJK fonts), and honestly reports non-achievement (`[GOAL_INCOMPLETE]` marker + goal judge) instead of falsely marking "done".
 - **Deep research** — fan-out web search → source fetch → claim verification → cited synthesis.
-- **Custom agents & skills** — project-scoped agents (claude.ai Projects equivalent) selectable directly from the composer, plus an auto-selectable skill library and 18 built-in industry agents.
+- **Custom agents & skills** — project-scoped agents (claude.ai Projects equivalent) selectable directly from the composer, each optionally pinned to its own model, plus an auto-selectable skill library and 18 built-in industry agents (100 specialists).
 
 **▸ Tools & extensibility**
 - **MCP tool system** — 22 built-in tools (web search, fact-check, web scrape/map/crawl, image analysis, agent-task control, skill/agent/MCP git-ingest, …) plus external MCP servers, each isolated in Docker (`--cap-drop ALL`, non-root, `--memory`+`--memory-swap`, network policy, realpath-guarded mounts).
 - **Artifacts** — live sandboxed iframe rendering, optional Docker code execution (Python / JS), a resizable side panel, and a separate-origin strict-CSP shared viewer for publishing.
 - **Memory & instructions** — persistent cross-conversation memory (with a per-session usage toggle) and always-on custom instructions.
+- **Thinking display** — Claude-web-style reasoning timeline with a live one-line headline (generated by a dedicated summary model), persisted and restored on re-open.
 - **Multilingual UI** — Korean, English, Japanese, and Simplified Chinese via `next-intl` (cookie-based locale, browser auto-detect, locale-aware date/number formatting).
+
+**▸ Integrations**
+- **Discord gateway bot** (`apps/discord-bot`) — an optional standalone workspace that relays Discord messages to `/api/v1/chat/completions`, with per-user session isolation (`/reset`), role/mention access control, and API-key auth. Runs as its own PM2 process.
 
 **▸ Security**
 - JWT in HttpOnly cookies, Google OAuth 2.0, RBAC, per-user & per-route rate limiting, SSRF guard, Helmet headers, and a unified Audit ↔ Alert pipeline.
@@ -121,8 +130,9 @@ OpenMake separates **policy** (deciding *how* to answer) from **execution** (act
 | **Realtime** | WebSocket (`ws`) streaming chat |
 | **LLM backend** | vLLM + LiteLLM (OpenAI-compatible); `@anthropic-ai/sdk`, `openai` for external providers |
 | **Agents / Tools** | Model Context Protocol (`@modelcontextprotocol/sdk`), Docker-isolated sandboxes |
+| **Integrations** | Discord gateway bot (`discord.js`) — optional standalone workspace |
 | **Auth / Security** | `jsonwebtoken`, Google OAuth 2.0, Helmet, AES-256-GCM |
-| **Infra** | PM2 (app) + Docker (PostgreSQL/Redis, MCP / agent / artifact sandboxes) |
+| **Infra** | PM2 (API · web · Discord bot) + Docker (PostgreSQL/Redis, MCP / agent / artifact sandboxes) |
 | **Testing / CI** | Jest/ts-jest, Playwright, ESLint, GitHub Actions (CI Gate) |
 
 ---
@@ -211,6 +221,7 @@ openmake_llm/
 │   │       ├── auth/ security/ middlewares/     # JWT/OAuth, SSRF guard, rate limiting
 │   │       └── data/                            # PostgreSQL (raw SQL), migrations, repositories
 │   ├── web/          # Next.js + React frontend (the operating UI)
+│   ├── discord-bot/  # Optional Discord gateway bot (relays to /api/v1/chat/completions)
 │   └── legacy-web/   # Static asset host (e.g. /generated) — legacy SPA retired
 ├── db/               # init schema + migrations (+ rollbacks/)
 ├── packages/         # shared-types, config, api-client (shared workspaces)


### PR DESCRIPTION
## 개요
README(7/10자)를 현재 소스와 대조 검토해 누락·오류를 정정. 최근 도입된 기능들이 문서에 반영되지 않아 업데이트.

## 정정 (오류)
- **외부 provider 목록**: "Anthropic / OpenAI-compatible / OpenRouter / Ollama" → 실제 BYOK 등록 카탈로그 **OpenRouter · NVIDIA NIM · Ollama(local+cloud)** (전부 OpenAI 호환, Anthropic 은 어댑터만 존재하고 카탈로그 미등록). Overview·Features 2곳.

## 추가 (누락된 최근 기능)
- **Role 기반 모델 오케스트레이션** — 역할별 모델 배정(agent/judge/research/spawn/review/summary), 사용자+관리자 전역 매핑, 서버 공용 키+토큰 예산, 4단 fail-open 폴백
- **클로드 웹식 thinking 표시** — reasoning 타임라인 + summary role 헤드라인 + 영속화
- **Discord 게이트웨이 봇** (`apps/discord-bot`) — Features/Tech Stack/Project Structure
- **커스텀 에이전트 per-agent 모델**

## 검증
- 버전(1.5.6)·Node(≥24<25)·Next 16·기본모델·262K·infra/·packages/·에이전트 18/100·docker-compose postgres 서비스 등 기존 서술은 소스와 일치 확인, 그대로 유지
- README.md=readme.md 동일 inode(대소문자 무시 FS) — 단일 파일

🤖 Generated with [Claude Code](https://claude.com/claude-code)