### PR TITLE
feat(model-roles): 역할 배정 모델 목록 필터 (사용가능·역할수행가능·20B초과)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -461,6 +461,16 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # BYOK 키로 호출, 실패 시 전역 env → 로컬 default 로 fail-open 폴백.
 # USER_MODEL_ROLES_ENABLED=false
 
+# 역할 배정 드롭다운(설정>역할 모델, 커스텀 에이전트 model) 필터 (컴포저/기본모델 제외).
+# - 최소 파라미터 (B, 십억) — 이 값 이하 모델은 목록에서 제외 (기본 20). 파싱 불가한
+#   프론티어 모델(gpt/claude/deepseek-v3 등)은 유지.
+# ROLE_MODEL_MIN_PARAMS_B=20
+# - 채팅 불가(임베딩/이미지/음성) 모델 제외 패턴 (쉼표 구분, id substring). 미설정 시 기본 목록.
+# ROLE_MODEL_EXCLUDE_PATTERNS=bge,embed,rerank,flux,sdxl,whisper,tts
+# - 배정 시점 실호출 probe 타임아웃 (ms) — 카탈로그엔 있으나 계정별 404/403 인 모델을
+#   실제로 거부하기 위한 1-토큰 probe (기본 20000).
+# MODEL_ASSIGNMENT_PROBE_TIMEOUT_MS=20000
+
 # *******************************************************
 # Thinking / 토큰 예산 (chat/request-handler, services/ChatService)
 # *******************************************************

--- a/apps/api/src/config/role-model-filter.ts
+++ b/apps/api/src/config/role-model-filter.ts
@@ -1,0 +1,64 @@
+/**
+ * @module config/role-model-filter
+ * @description 역할별 모델 배정 드롭다운에 노출할 모델 필터 (No-Hardcoding L2).
+ *
+ * 역할 배정(설정 > 역할 모델, 커스텀 에이전트 model)에서 실제로 역할을 수행할 수
+ * 있는 모델만 노출하기 위한 필터. 컴포저/기본 모델 선택에는 적용하지 않는다.
+ *
+ * 필터 3축:
+ *   ① 채팅 불가 모델 제외 — 임베딩/이미지/음성 등 (id 패턴, ROLE_MODEL_EXCLUDE_PATTERNS)
+ *   ② 파라미터 20B 이하 제외 — id/name 에서 `<N>b` 파싱 (ROLE_MODEL_MIN_PARAMS_B),
+ *      파싱 불가(프론티어 모델 gpt/claude/deepseek-v3 등)는 대형으로 간주해 유지
+ *   ③ (등록 키 사용 가능 + 실제 호출 가능 여부는 model.routes 목록 소스와
+ *      assignment 시점 probe 가 담당 — 이 파일은 정적 필터만)
+ */
+
+/** 역할 배정 허용 최소 파라미터 (B, 십억). env override. */
+export const ROLE_MODEL_MIN_PARAMS_B = Number(process.env.ROLE_MODEL_MIN_PARAMS_B) || 20;
+
+/**
+ * 채팅/역할 수행이 불가능한 모델 id 패턴 (소문자 substring 매칭).
+ * 임베딩·이미지·음성·리랭커 등 — 어떤 역할도 수행 불가.
+ */
+export const ROLE_MODEL_EXCLUDE_PATTERNS: readonly string[] = (
+    process.env.ROLE_MODEL_EXCLUDE_PATTERNS
+        ? process.env.ROLE_MODEL_EXCLUDE_PATTERNS.split(',').map((s) => s.trim().toLowerCase()).filter(Boolean)
+        : ['bge', 'embed', 'embedding', 'rerank', 'flux', 'sdxl', 'stable-diffusion',
+           'dall-e', 'dalle', 'whisper', 'tts', 'clip', 'nemoretriever', 'nv-embed']
+);
+
+/**
+ * 모델 id/name 에서 파라미터 수(B, 십억)를 파싱. 없으면 null.
+ * `<숫자>b` 패턴을 모두 찾아 최댓값 반환 — 예: 'qwen3.6-35b-a3b' → 35 (총 파라미터 우선).
+ * 버전 번호(3.1, 5.2 등 'b' 미접미)는 매칭되지 않는다.
+ */
+export function parseModelParamsB(idOrName: string): number | null {
+    const matches = idOrName.toLowerCase().matchAll(/(\d+(?:\.\d+)?)\s*b\b/g);
+    let max: number | null = null;
+    for (const m of matches) {
+        const n = parseFloat(m[1]);
+        if (Number.isFinite(n) && (max === null || n > max)) max = n;
+    }
+    return max;
+}
+
+/**
+ * 역할 배정에 노출할 모델인지 판정.
+ * @param model modelId(fullId)·name·capabilities 를 가진 목록 항목
+ */
+export function isRoleAssignableModel(model: {
+    modelId: string;
+    name?: string;
+    capabilities?: { streaming?: boolean; toolCalling?: boolean; vision?: boolean };
+}): boolean {
+    const hay = `${model.modelId} ${model.name ?? ''}`.toLowerCase();
+
+    // ① 채팅 불가 모델(임베딩/이미지/음성 등) 제외
+    if (ROLE_MODEL_EXCLUDE_PATTERNS.some((p) => hay.includes(p))) return false;
+
+    // ② 20B 이하 제외 (파싱 불가 = 대형 프론티어 모델로 간주해 유지)
+    const params = parseModelParamsB(hay);
+    if (params !== null && params <= ROLE_MODEL_MIN_PARAMS_B) return false;
+
+    return true;
+}

--- a/apps/api/src/routes/model.routes.ts
+++ b/apps/api/src/routes/model.routes.ts
@@ -27,6 +27,7 @@ import { getPool } from '../data/models/unified-database';
 import { OpenAICompatProvider } from '../providers/openai-compat-provider';
 import { buildFullModelId } from '../providers/i-provider';
 import { getProviderCatalogEntry } from '../config/external-providers';
+import { isRoleAssignableModel } from '../config/role-model-filter';
 
 const router = Router();
 const logger = createLogger('ModelRoutes');
@@ -229,9 +230,15 @@ router.get('/models', optionalAuth, asyncHandler(async (req: Request, res: Respo
     // UI 는 이 값으로 "이미지 생성 가능" 표시만 한다 (채팅 셀렉터 옵션 아님). 미설정 시 null.
     const imageModel = process.env.IMAGE_GEN_MODEL?.trim() || null;
 
+    // 역할 배정 드롭다운 전용 필터 — 채팅 불가(임베딩/이미지) + 20B 이하 제외.
+    // (컴포저/기본 모델 선택은 이 파라미터 없이 호출 → 전체 노출)
+    const outModels = req.query.forRoleAssignment === '1'
+        ? models.filter((m) => isRoleAssignableModel({ modelId: m.modelId, name: m.name, capabilities: m.capabilities as { streaming?: boolean; toolCalling?: boolean; vision?: boolean } }))
+        : models;
+
     res.json(success({
         defaultModel: buildFullModelId('local-llm', defaultChat),
-        models,
+        models: outModels,
         imageModel,
     }));
 }));

--- a/apps/api/src/services/model-assignment-validation.ts
+++ b/apps/api/src/services/model-assignment-validation.ts
@@ -17,6 +17,9 @@ import { createLogger } from '../utils/logger';
 
 const logger = createLogger('ModelAssignmentValidation');
 
+/** 배정 시점 실호출 probe 타임아웃 (ms) — env override */
+const ASSIGNMENT_PROBE_TIMEOUT_MS = Number(process.env.MODEL_ASSIGNMENT_PROBE_TIMEOUT_MS) || 20000;
+
 async function validateExternalAssignment(userId: string, fullId: string): Promise<string | null> {
     const idx = fullId.indexOf(':');
     const providerId = fullId.slice(0, idx);
@@ -33,6 +36,21 @@ async function validateExternalAssignment(userId: string, fullId: string): Promi
     const keyRow = await keysRepo.getByUserAndProvider(userId, providerId);
     if (!keyRow) return `'${providerId}' API 키를 먼저 등록하세요`;
     if (!keyRow.isActive) return `'${providerId}' API 키가 비활성 상태입니다`;
+
+    // 실호출 probe — /models 카탈로그에 있어도 계정별로 추론이 404/403 인 모델이 있다
+    // (NVIDIA 무료티어 등). 실제 역할 수행 불가 모델을 배정 시점에 거부한다.
+    const plaintextKey = await keysRepo.decryptKey(userId, providerId);
+    if (!plaintextKey) return `'${providerId}' 키 복호화 실패`;
+    const baseUrl = keyRow.baseUrl || entry.defaultBaseUrl;
+    try {
+        const client = createClient({ baseUrl, apiKey: plaintextKey, model: modelId, userId });
+        await client.derive({ timeout: ASSIGNMENT_PROBE_TIMEOUT_MS })
+            .chat([{ role: 'user', content: 'ping' }], { num_predict: 1 }, undefined, { think: false });
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.warn(`모델 배정 probe 실패 (${fullId}): ${msg}`);
+        return `'${fullId}' 모델은 현재 이 API 키로 응답하지 않습니다 (역할 수행 불가): ${msg.slice(0, 80)}`;
+    }
     return null;
 }
 

--- a/apps/web/app/(workspace)/custom-agents/page.tsx
+++ b/apps/web/app/(workspace)/custom-agents/page.tsx
@@ -140,7 +140,7 @@ function AgentForm({
   const isEdit = !!initial;
 
   useEffect(() => {
-    void fetchModels().then((p) => setModels(p.models)).catch(() => setModels([]));
+    void fetchModels({ forRoleAssignment: true }).then((p) => setModels(p.models)).catch(() => setModels([]));
   }, []);
 
   async function handleSubmit() {

--- a/apps/web/app/(workspace)/settings/page.tsx
+++ b/apps/web/app/(workspace)/settings/page.tsx
@@ -201,7 +201,7 @@ export default function SettingsPage() {
   const isGuest = !useAppStore((s) => s.auth.currentUser);
   const { data: modelsData } = useQuery({
     queryKey: ["models"],
-    queryFn: fetchModels,
+    queryFn: () => fetchModels(),
     staleTime: 60_000,
   });
   // 기본 모델은 2단계 선택(provider → model)으로 노출 — components/model-picker.tsx 공용

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -163,7 +163,7 @@ export function Composer() {
   // 로컬 vLLM + 등록된 외부 LLM(OpenRouter 등) 통합 모델 목록
   const { data: modelsData } = useQuery({
     queryKey: ["models"],
-    queryFn: fetchModels,
+    queryFn: () => fetchModels(),
     staleTime: 60_000,
   });
   const {

--- a/apps/web/components/settings/model-roles-section.tsx
+++ b/apps/web/components/settings/model-roles-section.tsx
@@ -51,7 +51,7 @@ export function ModelRolesSection() {
     try {
       const [rolesRes, modelsRes] = await Promise.all([
         ApiClient.get<ApiSuccess<ModelRolesPayload>>("/api/users/me/model-roles"),
-        fetchModels(),
+        fetchModels({ forRoleAssignment: true }),
       ]);
       setMappings(rolesRes?.data?.mappings ?? []);
       setRoles(rolesRes?.data?.assignableRoles ?? []);

--- a/apps/web/lib/models-api.ts
+++ b/apps/web/lib/models-api.ts
@@ -22,9 +22,11 @@ export interface ModelsPayload {
  * GET /api/models — 로컬 vLLM 모델 + 인증 사용자가 등록한 외부 LLM(OpenRouter 등 openai-compatible)
  * provider 의 모델을 합산한 통합 목록. (legacy models-api.js 대응)
  */
-export async function fetchModels(): Promise<ModelsPayload> {
+export async function fetchModels(opts?: { forRoleAssignment?: boolean }): Promise<ModelsPayload> {
+  // 역할/에이전트 모델 배정용 목록은 서버가 채팅 불가(임베딩/이미지)·20B 이하 모델을 제외한다.
+  const qs = opts?.forRoleAssignment ? "?forRoleAssignment=1" : "";
   const res = await ApiClient.get<{ success: boolean; data: ModelsPayload }>(
-    "/api/models",
+    `/api/models${qs}`,
   );
   return res?.data ?? { defaultModel: "", models: [] };
 }


### PR DESCRIPTION
## 개요
역할별 모델 배정 드롭다운(설정>역할 모델, 커스텀 에이전트 model)에 **실제로 역할을 수행할 수 있는 모델만** 노출. 컴포저·기본 모델 선택에는 미적용.

## 3축 필터
1. **등록 키 사용 가능 모델만** — 기존 `/api/models` 로그인 사용자 카탈로그(로컬+BYOK) 유지
2. **역할 수행 불가 모델 제외**
   - 채팅 불가(임베딩/이미지/음성) id 패턴 제외 — `config/role-model-filter.ROLE_MODEL_EXCLUDE_PATTERNS`
   - **배정 시점 실호출 probe** — `/models` 카탈로그엔 있어도 계정별 추론이 404/403 인 모델(직전 점검에서 발견한 NVIDIA 무료티어 `nemotron-ultra-253b` 등)을 1-토큰 probe 로 거부하고 "역할 수행 불가" 명시 에러 반환
3. **20B 이하 제외** — id/name 의 `<N>b` 파싱(총 파라미터 우선), 최소 `ROLE_MODEL_MIN_PARAMS_B`(기본 20). 파싱 불가한 프론티어 모델(gpt/claude/deepseek-v3 등)은 유지

## 구현
- `GET /api/models?forRoleAssignment=1` 필터, `fetchModels({forRoleAssignment})` 배선(role-section·custom-agents만; composer·settings 기본모델은 미적용)
- 신규 config(No-Hardcoding L2, env override) + 배정 probe

## 검증
- [x] tsc(api/web) / eslint / 필터 파서 unit 8건 / 전체 backend suite (circuit-breaker 1건은 전체 실행 중 타이밍 flaky — 격리 재실행 34/34)
- [ ] live: 배포 후 forRoleAssignment 목록에서 임베딩/이미지·소형 모델 제외 + nemotron-ultra 배정 거부 확인 (merge 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)