### PR TITLE
feat(models): 기본 모델 선택 목록 사용가능 필터 + 외부 오류 로깅 개선

### DIFF
--- a/apps/api/src/routes/model.routes.ts
+++ b/apps/api/src/routes/model.routes.ts
@@ -230,9 +230,11 @@ router.get('/models', optionalAuth, asyncHandler(async (req: Request, res: Respo
     // UI 는 이 값으로 "이미지 생성 가능" 표시만 한다 (채팅 셀렉터 옵션 아님). 미설정 시 null.
     const imageModel = process.env.IMAGE_GEN_MODEL?.trim() || null;
 
-    // 역할 배정 드롭다운 전용 필터 — 채팅 불가(임베딩/이미지) + 20B 이하 제외.
-    // (컴포저/기본 모델 선택은 이 파라미터 없이 호출 → 전체 노출)
-    const outModels = req.query.forRoleAssignment === '1'
+    // 사용 가능 모델 필터 — 채팅 불가(임베딩/이미지) + 20B 이하 제외.
+    // 역할 배정 드롭다운·기본 모델 선택(설정/컴포저)에서 usableOnly=1 로 호출.
+    // (forRoleAssignment 는 하위호환 별칭)
+    const usableOnly = req.query.usableOnly === '1' || req.query.forRoleAssignment === '1';
+    const outModels = usableOnly
         ? models.filter((m) => isRoleAssignableModel({ modelId: m.modelId, name: m.name, capabilities: m.capabilities as { streaming?: boolean; toolCalling?: boolean; vision?: boolean } }))
         : models;
 

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -467,7 +467,10 @@ export async function handleChatMessage(
         } else if (error instanceof ProviderError) {
             // 외부 provider(Anthropic/OpenRouter) 에러 — 코드별 사용자 친화 메시지로 분류
             // raw upstream 메시지(error.message)는 stack/credential 누출 위험으로 노출하지 않음
-            log.warn(`[Chat] 외부 provider 에러 (${error.code}):`, error.message);
+            const causeDetail = error.cause instanceof Error
+                ? `${error.cause.message}${(error.cause as { status?: number }).status ? ` [status=${(error.cause as { status?: number }).status}]` : ''}`
+                : (error.cause ? JSON.stringify(error.cause).slice(0, 300) : '');
+            log.warn(`[Chat] 외부 provider 에러 (${error.code}): ${error.message} | cause: ${causeDetail}`);
             const localizedTable = getLocalizedTemplate(WS_PROVIDER_ERROR_MESSAGES, userLang);
             safeSend({
                 type: 'error',

--- a/apps/web/app/(workspace)/custom-agents/page.tsx
+++ b/apps/web/app/(workspace)/custom-agents/page.tsx
@@ -140,7 +140,7 @@ function AgentForm({
   const isEdit = !!initial;
 
   useEffect(() => {
-    void fetchModels({ forRoleAssignment: true }).then((p) => setModels(p.models)).catch(() => setModels([]));
+    void fetchModels({ usableOnly: true }).then((p) => setModels(p.models)).catch(() => setModels([]));
   }, []);
 
   async function handleSubmit() {

--- a/apps/web/app/(workspace)/settings/page.tsx
+++ b/apps/web/app/(workspace)/settings/page.tsx
@@ -201,7 +201,7 @@ export default function SettingsPage() {
   const isGuest = !useAppStore((s) => s.auth.currentUser);
   const { data: modelsData } = useQuery({
     queryKey: ["models"],
-    queryFn: () => fetchModels(),
+    queryFn: () => fetchModels({ usableOnly: true }),
     staleTime: 60_000,
   });
   // 기본 모델은 2단계 선택(provider → model)으로 노출 — components/model-picker.tsx 공용

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -163,7 +163,7 @@ export function Composer() {
   // 로컬 vLLM + 등록된 외부 LLM(OpenRouter 등) 통합 모델 목록
   const { data: modelsData } = useQuery({
     queryKey: ["models"],
-    queryFn: () => fetchModels(),
+    queryFn: () => fetchModels({ usableOnly: true }),
     staleTime: 60_000,
   });
   const {

--- a/apps/web/components/settings/model-roles-section.tsx
+++ b/apps/web/components/settings/model-roles-section.tsx
@@ -51,7 +51,7 @@ export function ModelRolesSection() {
     try {
       const [rolesRes, modelsRes] = await Promise.all([
         ApiClient.get<ApiSuccess<ModelRolesPayload>>("/api/users/me/model-roles"),
-        fetchModels({ forRoleAssignment: true }),
+        fetchModels({ usableOnly: true }),
       ]);
       setMappings(rolesRes?.data?.mappings ?? []);
       setRoles(rolesRes?.data?.assignableRoles ?? []);

--- a/apps/web/lib/models-api.ts
+++ b/apps/web/lib/models-api.ts
@@ -22,9 +22,10 @@ export interface ModelsPayload {
  * GET /api/models — 로컬 vLLM 모델 + 인증 사용자가 등록한 외부 LLM(OpenRouter 등 openai-compatible)
  * provider 의 모델을 합산한 통합 목록. (legacy models-api.js 대응)
  */
-export async function fetchModels(opts?: { forRoleAssignment?: boolean }): Promise<ModelsPayload> {
-  // 역할/에이전트 모델 배정용 목록은 서버가 채팅 불가(임베딩/이미지)·20B 이하 모델을 제외한다.
-  const qs = opts?.forRoleAssignment ? "?forRoleAssignment=1" : "";
+export async function fetchModels(opts?: { usableOnly?: boolean }): Promise<ModelsPayload> {
+  // usableOnly: 서버가 채팅 불가(임베딩/이미지)·20B 이하 모델을 제외한 목록을 반환.
+  // 기본 모델 선택·역할/에이전트 모델 배정 드롭다운에서 사용.
+  const qs = opts?.usableOnly ? "?usableOnly=1" : "";
   const res = await ApiClient.get<{ success: boolean; data: ModelsPayload }>(
     `/api/models${qs}`,
   );


### PR DESCRIPTION
## 개요
① 기본 모델 선택 목록(설정 > 모델&응답 > 기본 모델, 컴포저)에 **실제 사용 가능 모델만 + 20B 이하 제외** 필터 적용.
② 외부 provider 오류 로깅에 원문 cause 포함 (진단성 개선).

## 변경
- 역할 배정용 `forRoleAssignment` 필터를 범용 `usableOnly` 로 정리(하위호환 별칭 유지): `/api/models?usableOnly=1` — 채팅 불가(임베딩/이미지) + 20B 이하 제외
- `usableOnly` 배선: 기본 모델 셀렉터(설정·컴포저 공유 쿼리) + 역할 배정 + 커스텀 에이전트
- ws-chat-handler 외부 오류 로그에 `cause`(원문 메시지 + HTTP status) 포함 — 기존엔 `error.message` 만 찍혀 실제 원인(OpenRouter 500, 402 잔액 부족 등)이 로그에서 유실되던 문제 해소

## 검증
- [x] tsc(api/web) / eslint
- [ ] live: 기본 모델 목록에서 임베딩/이미지·20B이하 제외 확인 (merge 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)