### PR TITLE
fix(chat): Discussion·Deep Research 모드도 선택한 외부 모델 사용

### DIFF
--- a/apps/api/src/services/ChatService.ts
+++ b/apps/api/src/services/ChatService.ts
@@ -494,7 +494,9 @@ export class ChatService {
     async processMessageWithDiscussion(
         req: ChatMessageRequest,
         onToken: (token: string) => void,
-        onProgress?: (progress: DiscussionProgress) => void
+        onProgress?: (progress: DiscussionProgress) => void,
+        /** 외부 모델 선택 시 해석된 LLMClient — 미지정 시 로컬 this.client */
+        externalClient?: LLMClient,
     ): Promise<string> {
         const abortSignal = req.abortSignal;
         const checkAborted = () => {
@@ -504,7 +506,7 @@ export class ChatService {
         };
         const result = await this.discussionStrategy.execute({
             req,
-            client: this.client,
+            client: externalClient ?? this.client,
             onProgress,
             formatDiscussionResult: (discussionResult) => formatDiscussionResult(discussionResult),
             onToken,
@@ -529,11 +531,13 @@ export class ChatService {
     async processMessageWithDeepResearch(
         req: ChatMessageRequest,
         onToken: (token: string) => void,
-        onProgress?: (progress: ResearchProgress) => void
+        onProgress?: (progress: ResearchProgress) => void,
+        /** 외부 모델 선택 시 해석된 LLMClient — 미지정 시 로컬 this.client */
+        externalClient?: LLMClient,
     ): Promise<string> {
         const result = await this.deepResearchStrategy.execute({
             req,
-            client: this.client,
+            client: externalClient ?? this.client,
             onProgress,
             formatResearchResult: (researchResult) => formatResearchResult(researchResult),
             onToken,

--- a/apps/api/src/services/chat-service/message-pipeline.ts
+++ b/apps/api/src/services/chat-service/message-pipeline.ts
@@ -224,13 +224,33 @@ export async function runMessagePipeline(svc: ChatService,
         return generateImageInline((req.message ?? '').trim(), onToken);
     }
 
+    // Discussion / Deep Research 모드에 외부 모델 선택을 반영 — externalResolved 가
+    // 있으면(외부 provider 선택) 그 모델의 LLMClient 를 해석해 두 모드의 전략에 주입한다.
+    // (미주입 시 로컬 svc.client 사용 — 기존 동작). 해석 실패는 fail-open 로 로컬 폴백.
+    let modeExternalClient: import('../../llm').LLMClient | undefined;
+    if (externalResolved && req.userId && String(req.userId) !== 'guest'
+        && (effectiveDiscussionMode || deepResearchMode)) {
+        try {
+            const { resolveAssignedModelClient } = await import('../model-role-resolver');
+            const resolved = await resolveAssignedModelClient(externalResolved.fullId, String(req.userId));
+            modeExternalClient = resolved.client;
+            if (resolved.degraded) {
+                logger.warn(`[Mode] 외부 모델 해석 폴백 (${externalResolved.fullId}): ${resolved.degraded}`);
+            } else {
+                logger.info(`[Mode] ${effectiveDiscussionMode ? 'Discussion' : 'DeepResearch'} 외부 모델 사용: ${externalResolved.fullId}`);
+            }
+        } catch (e) {
+            logger.warn('[Mode] 외부 모델 해석 실패 (로컬 폴백):', e);
+        }
+    }
+
     // 토론 모드: 사용자 명시 토글.
     if (effectiveDiscussionMode) {
-        return svc.processMessageWithDiscussion(req, onToken, onDiscussionProgress);
+        return svc.processMessageWithDiscussion(req, onToken, onDiscussionProgress, modeExternalClient);
     }
 
     if (deepResearchMode) {
-        return svc.processMessageWithDeepResearch(req, onToken, onResearchProgress);
+        return svc.processMessageWithDeepResearch(req, onToken, onResearchProgress, modeExternalClient);
     }
 
     const startTime = Date.now();

--- a/apps/api/src/services/chat-service/message-pipeline.ts
+++ b/apps/api/src/services/chat-service/message-pipeline.ts
@@ -31,82 +31,14 @@ import { applyStyle, normalizeStyle } from '../../chat/style';
 import { resolveAnswerFormatProfile, applyAnswerFormat, getAnswerFormatGuard } from '../../chat/answer-format';
 import { runProviderGate } from './provider-gate';
 import { applyAgentModelOverride } from './agent-model-override';
+import { resolveModeExternalClient } from './mode-external-client';
+import { buildUserContextBlocks } from './user-context-blocks';
 import type { RequestContext } from './request-context';
 import { buildChatOptions, assembleHistoryWithSummary } from './options-and-history';
-import { estimateTokens } from '../../llm/model-pool';
-import { USER_CONTEXT_LIMITS, AGENT_LOOP_LIMITS } from '../../config/runtime-limits';
+import { AGENT_LOOP_LIMITS } from '../../config/runtime-limits';
 
 const logger = createLogger('MessagePipeline');
 
-/**
- * Cross-conversation Memory(/remember) + Custom Instructions 블록을 조립한다.
- * strategy 경로와 외부 provider 경로 양쪽에서 동일하게 호출 (claude.ai Memory/CI 동등).
- * 인증 사용자(userId 명시)만 적용 — guest 미적용. 각 조회 실패 시 빈 블록(graceful fallback).
- *
- * 회귀 배경: 과거 strategy 경로에만 인라인되어 있어, 외부 provider 분기
- * (LOCAL_STRATEGY_PATH OFF 기본이라 로컬 채팅 포함)에서 memory/custom instructions 가
- * 전혀 주입되지 않던 버그를 헬퍼 추출로 양 경로 대칭화.
- */
-async function buildUserContextBlocks(
-    userId: string | undefined,
-    includeMemory = true,
-): Promise<{ memoryBlock: string; customInstructionsBlock: string }> {
-    let customInstructionsBlock = '';
-    let memoryBlock = '';
-    if (userId && userId !== 'guest') {
-        try {
-            const { UserRepository } = await import('../../data/repositories/user-repository');
-            const { getPool } = await import('../../data/models/unified-database');
-            const userRepo = new UserRepository(getPool());
-            const ci = await userRepo.getCustomInstructions(userId);
-            if (ci && ci.trim().length > 0) {
-                // 토큰 cap — 매 턴 고정 비용이므로 무제한 prepend 방지 (head 보존 truncate)
-                let ciText = ci.trim();
-                const maxCi = USER_CONTEXT_LIMITS.MAX_CUSTOM_INSTRUCTIONS_TOKENS;
-                if (estimateTokens(ciText) > maxCi) {
-                    const ratio = ciText.length / estimateTokens(ciText);
-                    ciText = ciText.slice(0, Math.floor(maxCi * ratio)).trimEnd() + ' …(생략됨)';
-                    logger.info(`custom_instructions 토큰 cap 적용 (>${maxCi})`);
-                }
-                customInstructionsBlock = `## 👤 User Custom Instructions\n${ciText}\n\n---\n\n`;
-            }
-        } catch (e) {
-            logger.warn('custom_instructions 조회 실패 (계속 진행):', e);
-        }
-
-        // includeMemory=false (설정 "장기 기억" 토글 OFF) → 저장된 메모리를 대화에 주입하지 않음.
-        try {
-            if (includeMemory) {
-            const { UserMemoryRepository } = await import('../../data/repositories/user-memory-repository');
-            const { getPool } = await import('../../data/models/unified-database');
-            const memRepo = new UserMemoryRepository(getPool());
-            const memories = await memRepo.listActiveByUser(userId, 50);
-            if (memories.length > 0) {
-                const maxMem = USER_CONTEXT_LIMITS.MAX_MEMORY_TOKENS;
-                const kept: typeof memories = [];
-                let usedTokens = 0;
-                for (const m of memories) {
-                    const t = estimateTokens(m.content) + 4;
-                    if (usedTokens + t > maxMem && kept.length > 0) break;
-                    kept.push(m);
-                    usedTokens += t;
-                }
-                if (kept.length < memories.length) {
-                    logger.info(`user_memories 토큰 cap 적용 (${kept.length}/${memories.length}, >${maxMem} tok)`);
-                }
-                const lines = kept.map((m, i) => `${i + 1}. ${m.content}`).join('\n');
-                memoryBlock = `## 🧠 User Memory (cross-conversation)\n${lines}\n\n---\n\n`;
-                void memRepo.touchAccessed(kept.map(m => m.id)).catch(e =>
-                    logger.warn('memory touch 실패 (무시):', e),
-                );
-            }
-            }
-        } catch (e) {
-            logger.warn('user_memories 조회 실패 (계속 진행):', e);
-        }
-    }
-    return { memoryBlock, customInstructionsBlock };
-}
 
 /**
  * Artifacts guide 블록 빌드 (사용자 artifacts_enabled 토글 반영, 기본 활성).
@@ -224,25 +156,11 @@ export async function runMessagePipeline(svc: ChatService,
         return generateImageInline((req.message ?? '').trim(), onToken);
     }
 
-    // Discussion / Deep Research 모드에 외부 모델 선택을 반영 — externalResolved 가
-    // 있으면(외부 provider 선택) 그 모델의 LLMClient 를 해석해 두 모드의 전략에 주입한다.
-    // (미주입 시 로컬 svc.client 사용 — 기존 동작). 해석 실패는 fail-open 로 로컬 폴백.
-    let modeExternalClient: import('../../llm').LLMClient | undefined;
-    if (externalResolved && req.userId && String(req.userId) !== 'guest'
-        && (effectiveDiscussionMode || deepResearchMode)) {
-        try {
-            const { resolveAssignedModelClient } = await import('../model-role-resolver');
-            const resolved = await resolveAssignedModelClient(externalResolved.fullId, String(req.userId));
-            modeExternalClient = resolved.client;
-            if (resolved.degraded) {
-                logger.warn(`[Mode] 외부 모델 해석 폴백 (${externalResolved.fullId}): ${resolved.degraded}`);
-            } else {
-                logger.info(`[Mode] ${effectiveDiscussionMode ? 'Discussion' : 'DeepResearch'} 외부 모델 사용: ${externalResolved.fullId}`);
-            }
-        } catch (e) {
-            logger.warn('[Mode] 외부 모델 해석 실패 (로컬 폴백):', e);
-        }
-    }
+    // Discussion / Deep Research 모드에 외부 모델 선택 반영 — 상세는 mode-external-client
+    // (외부 선택 시 그 모델 LLMClient 를 두 모드 전략에 주입, 미주입/실패 시 로컬 svc.client).
+    const modeExternalClient = (effectiveDiscussionMode || deepResearchMode)
+        ? await resolveModeExternalClient(externalResolved, req.userId, effectiveDiscussionMode ? 'Discussion' : 'DeepResearch')
+        : undefined;
 
     // 토론 모드: 사용자 명시 토글.
     if (effectiveDiscussionMode) {

--- a/apps/api/src/services/chat-service/mode-external-client.ts
+++ b/apps/api/src/services/chat-service/mode-external-client.ts
@@ -1,0 +1,36 @@
+/**
+ * Discussion·Deep Research 모드의 외부 모델 클라이언트 해석 —
+ * message-pipeline 에서 분리 (파일 크기 가드).
+ *
+ * 외부 provider 선택(externalResolved) 시 그 모델의 LLMClient 를 해석해
+ * 두 모드 전략에 주입할 수 있게 한다. 해석 실패는 undefined 반환(호출부가
+ * 로컬 svc.client 로 fail-open).
+ *
+ * @module services/chat-service/mode-external-client
+ */
+import type { ResolvedProvider } from '../../providers/provider-router';
+import type { LLMClient } from '../../llm';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('ModeExternalClient');
+
+export async function resolveModeExternalClient(
+    externalResolved: ResolvedProvider | null,
+    userId: string | number | undefined,
+    modeLabel: 'Discussion' | 'DeepResearch',
+): Promise<LLMClient | undefined> {
+    if (!externalResolved || !userId || String(userId) === 'guest') return undefined;
+    try {
+        const { resolveAssignedModelClient } = await import('../model-role-resolver');
+        const resolved = await resolveAssignedModelClient(externalResolved.fullId, String(userId));
+        if (resolved.degraded) {
+            logger.warn(`[Mode] 외부 모델 해석 폴백 (${externalResolved.fullId}): ${resolved.degraded}`);
+        } else {
+            logger.info(`[Mode] ${modeLabel} 외부 모델 사용: ${externalResolved.fullId}`);
+        }
+        return resolved.client;
+    } catch (e) {
+        logger.warn('[Mode] 외부 모델 해석 실패 (로컬 폴백):', e);
+        return undefined;
+    }
+}

--- a/apps/api/src/services/chat-service/user-context-blocks.ts
+++ b/apps/api/src/services/chat-service/user-context-blocks.ts
@@ -1,0 +1,73 @@
+/**
+ * Cross-conversation Memory(/remember) + Custom Instructions 블록 조립 —
+ * message-pipeline 에서 분리 (파일 크기 가드).
+ * strategy 경로·외부 provider 경로 양쪽에서 동일 호출 (claude.ai Memory/CI 동등).
+ * 인증 사용자만 적용(guest 미적용), 각 조회 실패는 빈 블록 graceful fallback.
+ * @module services/chat-service/user-context-blocks
+ */
+import { createLogger } from '../../utils/logger';
+import { estimateTokens } from '../../llm/model-pool';
+import { USER_CONTEXT_LIMITS } from '../../config/runtime-limits';
+
+const logger = createLogger('UserContextBlocks');
+
+export async function buildUserContextBlocks(
+    userId: string | undefined,
+    includeMemory = true,
+): Promise<{ memoryBlock: string; customInstructionsBlock: string }> {
+    let customInstructionsBlock = '';
+    let memoryBlock = '';
+    if (userId && userId !== 'guest') {
+        try {
+            const { UserRepository } = await import('../../data/repositories/user-repository');
+            const { getPool } = await import('../../data/models/unified-database');
+            const userRepo = new UserRepository(getPool());
+            const ci = await userRepo.getCustomInstructions(userId);
+            if (ci && ci.trim().length > 0) {
+                // 토큰 cap — 매 턴 고정 비용이므로 무제한 prepend 방지 (head 보존 truncate)
+                let ciText = ci.trim();
+                const maxCi = USER_CONTEXT_LIMITS.MAX_CUSTOM_INSTRUCTIONS_TOKENS;
+                if (estimateTokens(ciText) > maxCi) {
+                    const ratio = ciText.length / estimateTokens(ciText);
+                    ciText = ciText.slice(0, Math.floor(maxCi * ratio)).trimEnd() + ' …(생략됨)';
+                    logger.info(`custom_instructions 토큰 cap 적용 (>${maxCi})`);
+                }
+                customInstructionsBlock = `## 👤 User Custom Instructions\n${ciText}\n\n---\n\n`;
+            }
+        } catch (e) {
+            logger.warn('custom_instructions 조회 실패 (계속 진행):', e);
+        }
+
+        // includeMemory=false (설정 "장기 기억" 토글 OFF) → 저장된 메모리를 대화에 주입하지 않음.
+        try {
+            if (includeMemory) {
+                const { UserMemoryRepository } = await import('../../data/repositories/user-memory-repository');
+                const { getPool } = await import('../../data/models/unified-database');
+                const memRepo = new UserMemoryRepository(getPool());
+                const memories = await memRepo.listActiveByUser(userId, 50);
+                if (memories.length > 0) {
+                    const maxMem = USER_CONTEXT_LIMITS.MAX_MEMORY_TOKENS;
+                    const kept: typeof memories = [];
+                    let usedTokens = 0;
+                    for (const m of memories) {
+                        const t = estimateTokens(m.content) + 4;
+                        if (usedTokens + t > maxMem && kept.length > 0) break;
+                        kept.push(m);
+                        usedTokens += t;
+                    }
+                    if (kept.length < memories.length) {
+                        logger.info(`user_memories 토큰 cap 적용 (${kept.length}/${memories.length}, >${maxMem} tok)`);
+                    }
+                    const lines = kept.map((m, i) => `${i + 1}. ${m.content}`).join('\n');
+                    memoryBlock = `## 🧠 User Memory (cross-conversation)\n${lines}\n\n---\n\n`;
+                    void memRepo.touchAccessed(kept.map(m => m.id)).catch(e =>
+                        logger.warn('memory touch 실패 (무시):', e),
+                    );
+                }
+            }
+        } catch (e) {
+            logger.warn('user_memories 조회 실패 (계속 진행):', e);
+        }
+    }
+    return { memoryBlock, customInstructionsBlock };
+}

--- a/apps/api/src/services/chat-strategies/deep-research-strategy.ts
+++ b/apps/api/src/services/chat-strategies/deep-research-strategy.ts
@@ -54,10 +54,12 @@ export class DeepResearchStrategy implements ChatStrategy<DeepResearchStrategyCo
 
         logger.info('🔬 Deep Research 모드 시작');
 
-        // 사용자 메시지에서 언어 감지 후 연구 서비스 생성
+        // 사용자 메시지에서 언어 감지 후 연구 서비스 생성.
+        // context.client 를 직접 주입 — 외부 모델 선택 시 그 BYOK 클라이언트로 리서치 전 단계
+        // 수행(로컬은 svc.client 로 기존과 동일). 모델명만 넘기면 내부에서 로컬 client 를
+        // 재생성해 외부 모델이 로컬 endpoint 로 404 나던 문제 해소.
         const researchService = new DeepResearchService({
             maxLoops: RESEARCH_STRATEGY_PARAMS.MAX_LOOPS,
-            llmModel: context.client.model,
             searchApi: RESEARCH_STRATEGY_PARAMS.SEARCH_API,
             maxSearchResults: RESEARCH_STRATEGY_PARAMS.MAX_SEARCH_RESULTS,
             language: detectLanguage(message).language,
@@ -66,7 +68,7 @@ export class DeepResearchStrategy implements ChatStrategy<DeepResearchStrategyCo
             maxScrapePerLoop: RESEARCH_STRATEGY_PARAMS.MAX_SCRAPE_PER_LOOP,
             scrapeTimeoutMs: LLM_TIMEOUTS.SCRAPE_TIMEOUT_MS,
             chunkSize: RESEARCH_STRATEGY_PARAMS.CHUNK_SIZE,
-        });
+        }, context.client);
 
         // 연구 세션 ID 생성 및 DB 저장 (추후 조회/이어하기용)
         const sessionId = uuidv4();


### PR DESCRIPTION
## 개요
직전 점검에서 확인된 문제 해결 — 외부 모델 선택 시 **Discussion·Deep Research 채팅 모드가 외부 모델을 무시하고 로컬로 실행**되던 것을, 선택한 외부 모델을 쓰도록 수정.

## 원인
message-pipeline 에서 두 모드가 provider gate(externalResolved 계산)보다 뒤이지만 external dispatch 이전에 조기 return 하며 `svc.client`(로컬)를 전략에 넘김. Deep Research 는 추가로 전략이 `llmModel`(모델명)만 넘겨 `DeepResearchService` 내부에서 로컬 client 를 재생성 → 외부 모델 id 로 로컬 LiteLLM 호출 → 404.

## 수정
- **message-pipeline**: `externalResolved` 있으면 `resolveAssignedModelClient` 로 외부 LLMClient 해석 → 두 모드 핸들러에 주입 (해석 실패는 로컬 fail-open)
- **ChatService**: 두 핸들러에 `externalClient` 옵션 추가, 전략 client = `externalClient ?? this.client`
- **deep-research-strategy**: `DeepResearchService(config, context.client)` 로 client 직접 주입 (로컬 동작 불변)

discussion-engine 은 주입 콜백만 사용해 자체 client 미생성 확인.

## 검증
- [x] tsc / eslint / 전체 backend unit 2159 통과 (deep-research-strategy 테스트를 client 주입 계약으로 갱신)
- [ ] live: 외부 모델 + Discussion/DeepResearch → external_provider_usage 기록 확인 (merge 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)