### PR TITLE
fix(chat): 최근 대화 목록에서 메시지 0개 세션 제외

### DIFF
--- a/apps/api/src/data/conversation-sessions.ts
+++ b/apps/api/src/data/conversation-sessions.ts
@@ -132,8 +132,13 @@ export async function getSession(id: string): Promise<ConversationSession | unde
  */
 export async function getSessionsByUserId(userId: string, limit: number = CONVERSATION_LIMITS.SESSION_LIST_DEFAULT): Promise<ConversationSession[]> {
     const pool = getPool();
+    // 메시지 0개 세션 제외 — saveHistory:false 요청은 세션 행만 만들고 본문을 저장하지 않아
+    // (멀티턴 continuation 위해 세션 자체는 유지) 최근 목록에 빈 껍데기로 뜨던 것을 차단.
     const result = await pool.query(
-        'SELECT * FROM conversation_sessions WHERE user_id = $1 ORDER BY updated_at DESC LIMIT $2',
+        `SELECT * FROM conversation_sessions cs
+         WHERE cs.user_id = $1
+           AND EXISTS (SELECT 1 FROM conversation_messages m WHERE m.session_id = cs.id)
+         ORDER BY cs.updated_at DESC LIMIT $2`,
         [userId, limit]
     );
 
@@ -148,7 +153,10 @@ export async function getSessionsByUserId(userId: string, limit: number = CONVER
 export async function getSessionsByAnonId(anonSessionId: string, limit: number = CONVERSATION_LIMITS.SESSION_LIST_DEFAULT): Promise<ConversationSession[]> {
     const pool = getPool();
     const result = await pool.query(
-        'SELECT * FROM conversation_sessions WHERE anon_session_id = $1 ORDER BY updated_at DESC LIMIT $2',
+        `SELECT * FROM conversation_sessions cs
+         WHERE cs.anon_session_id = $1
+           AND EXISTS (SELECT 1 FROM conversation_messages m WHERE m.session_id = cs.id)
+         ORDER BY cs.updated_at DESC LIMIT $2`,
         [anonSessionId, limit]
     );
 
@@ -163,7 +171,9 @@ export async function getSessionsByAnonId(anonSessionId: string, limit: number =
 export async function getAllSessions(limit: number = CONVERSATION_LIMITS.SESSION_LIST_ALL_DEFAULT): Promise<ConversationSession[]> {
     const pool = getPool();
     const result = await pool.query(
-        'SELECT * FROM conversation_sessions ORDER BY updated_at DESC LIMIT $1',
+        `SELECT * FROM conversation_sessions cs
+         WHERE EXISTS (SELECT 1 FROM conversation_messages m WHERE m.session_id = cs.id)
+         ORDER BY cs.updated_at DESC LIMIT $1`,
         [limit]
     );
 


### PR DESCRIPTION
## 개요
`saveHistory:false` 요청이 세션 행만 만들고 본문을 저장하지 않아, 최근 대화 목록에 열면 빈 채팅창인 껍데기 세션이 뜨던 문제(직전 데이터 정리에 이은 근본 수정).

## 원인
`ensureSession` 이 saveHistory 와 무관하게 세션을 먼저 생성. saveHistory:false 는 멀티턴 continuation(클라이언트가 history 전달) 위해 세션 id 는 유지돼야 하므로 세션 생성 자체는 막을 수 없음.

## 수정
목록 조회 쿼리 3개(`getSessionsByUserId`·`getSessionsByAnonId`·`getAllSessions`)에 `EXISTS(conversation_messages)` 조건 추가 — 메시지 0개 세션은 목록에서 제외. 세션 생성/이어하기 로직 무변경. `idx_messages_session` 인덱스로 효율적.

## 검증
- [x] tsc / eslint / conversation-db unit 16 통과
- [ ] live: 빈 세션(아티팩트 보유 보존분 포함)이 목록에서 제외되는지 확인 (merge 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)