### PR TITLE
docs(readme): 아키텍처 다이어그램 가로 스크롤 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ OpenMake separates **policy** (deciding *how* to answer) from **execution** (act
                     ┌─────────────▼─────────────┐
                     │ streamFromExternalProvider│  single path — local & external alike
                     │   (always-on tool loop)   │  · 5 tool turns max
-                    └─────────────┬─────────────┘  · Discussion / Deep Research intercept earlier
+                    └─────────────┬─────────────┘  · special modes intercept earlier
                                   │
                     ┌─────────────▼─────────────┐
                     │       LLMClient.chat      │  execution — per call


### PR DESCRIPTION
렌더링 확인 후속 수정입니다. 다이어그램의 가장 긴 주석(97자)이 GitHub 코드블록 폭을 넘겨 가로 스크롤바가 생기고 문구 끝(`intercept earli…`)이 잘렸습니다. 해당 주석을 줄여 최대 87자로 맞췄습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)