### PR TITLE
docs(readme): 프로젝트 구조의 scripts/ 설명 정정 + 런타임 필수 범위 명시

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,12 +248,17 @@ openmake_llm/
 │   ├── web/          # Next.js + React frontend (the operating UI)
 │   ├── discord-bot/  # Optional Discord gateway bot (relays to /api/v1/chat/completions)
 │   └── legacy-web/   # Static asset host (e.g. /generated) — legacy SPA retired
-├── db/               # init schema + migrations (+ rollbacks/)
+├── db/               # init schema + migrations (+ rollbacks/) — read at runtime
 ├── packages/         # shared-types, config, api-client (shared workspaces)
 ├── infra/            # Dockerfiles & compose (mcp-runtime, task-runtime, artifact-viewer, egress-proxy)
-├── scripts/          # build, deploy, migration, CI scripts
+├── scripts/          # host setup for the LLM backend — vLLM/LiteLLM systemd units,
+│                     # serve scripts, litellm.config.yaml, Caddyfile, diagnostics
 └── tests/            # Playwright E2E
 ```
+
+**What the running server actually needs:** the built `apps/api/dist` + `apps/web/.next`, `db/` (the boot path applies `db/init/`, and the migration CLI resolves `db/migrations/` from the working directory), and `infra/` for the Docker-isolated sandboxes. `scripts/` and `tests/` are *not* loaded by any runtime code — but `scripts/vllm/` and `scripts/caddy/` are the deployment artifacts you copy onto the GPU host when standing up or rebuilding the inference backend, so keep them with the repo.
+
+Build, migration, and CI entry points live elsewhere: build in each workspace's `package.json`, migrations in `apps/api/src/data/migrations/cli.ts`, CI in `.github/workflows/`.
 
 ---
 


### PR DESCRIPTION
## 문제

`scripts/` 를 "build, deploy, migration, CI scripts" 로 설명했지만 실제 내용물에는 넷 중 아무것도 없습니다.

실제 `scripts/` 내용:
- `vllm/` — systemd 유닛 3종(qwen·bge·litellm), serve 스크립트, `litellm.config.yaml`
- `caddy/Caddyfile` — 외부 공개 리버스 프록시 설정
- `llm-droprate-probe.sh`, `mcp/measure-mcp-sandbox.js`, `tail-shadow-report.sql` — 진단·측정

실제 위치: build = 각 workspace `package.json`, migration = `apps/api/src/data/migrations/cli.ts`, CI = `.github/workflows/`

## 변경

- `scripts/` 설명을 실제 내용(LLM 백엔드 호스트 셋업 산출물)으로 교체
- 서버 운용 시 필요한 범위를 문단으로 명시 — `db/` 는 런타임 의존(부팅 시 `db/init/` 적용, runner 가 cwd 기준 `db/migrations/` 탐색), `scripts/`·`tests/` 는 런타임 코드 미참조이나 `scripts/vllm/`·`scripts/caddy/` 는 GPU 호스트 재구축 시 필요

검증: `apps/api/src`·`ecosystem.config.js` 에서 root `scripts/` 참조 0건(node_modules 오탐 제외), `runner.ts:169` 의 `db/migrations` cwd 해석 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)