### PR TITLE
fix(artifacts): 유령 [[artifact:id]] placeholder 가드 + Discord 히스토리 치환본 저장

### DIFF
--- a/apps/api/src/chat/request-handler.ts
+++ b/apps/api/src/chat/request-handler.ts
@@ -38,7 +38,7 @@ import { LocalLLMProvider } from '../providers/local-llm-provider';
 import { ProviderRouter } from '../providers/provider-router';
 import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
 import { getPool } from '../data/models/unified-database';
-import { extractAndStripArtifacts } from '../llm/artifact-parser';
+import { extractAndStripArtifacts, findArtifactPlaceholderIds, stripArtifactPlaceholders } from '../llm/artifact-parser';
 import { ArtifactRepository, ArtifactSizeError, type ArtifactKind } from '../data/repositories/artifact-repository';
 import { processExternalToolCalling } from './external-tool-calling';
 import { ensureSession, saveUserMessage, saveAssistantMessage } from './request-persistence';
@@ -465,6 +465,31 @@ export class ChatRequestHandler {
             }
         } catch (e) {
             log.warn(`[Artifact] 후처리 실패 (continue): ${e instanceof Error ? e.message : e}`);
+        }
+
+        // 6.5 유령 placeholder 가드 (2026-07-21): 소형 모델이 히스토리의 [[artifact:id]]
+        // 표기를 모방해 실체 없는 placeholder 를 직접 출력하는 경우가 있다 (Discord 경로
+        // 실측 — 응답 전체가 placeholder 한 줄, artifacts 미생성). 이번 턴 추출분에도
+        // 세션 영속분에도 없는 id 는 본문에서 제거해 클라이언트 원문 노출을 막는다.
+        try {
+            const extractedIds = new Set(extractedArtifacts.map((a) => a.id));
+            const candidateIds = findArtifactPlaceholderIds(cleanedResponse)
+                .filter((id) => !extractedIds.has(id));
+            if (candidateIds.length > 0) {
+                const repo = new ArtifactRepository(getPool());
+                const ghostIds: string[] = [];
+                for (const id of candidateIds) {
+                    const versions = await repo.listVersionsByArtifactId(currentSessionId, id);
+                    if (versions.length === 0) ghostIds.push(id);
+                }
+                if (ghostIds.length > 0) {
+                    log.warn(`[Artifact] 유령 placeholder 제거 (모델 모방 출력): ${ghostIds.join(', ')}`);
+                    cleanedResponse = stripArtifactPlaceholders(cleanedResponse, ghostIds).trim()
+                        || '죄송합니다. 요청하신 산출물 생성에 실패했습니다. 다시 한번 요청해 주세요.';
+                }
+            }
+        } catch (e) {
+            log.warn(`[Artifact] 유령 placeholder 가드 실패 (continue): ${e instanceof Error ? e.message : e}`);
         }
 
         // 7. AI 응답 저장 — placeholder 적용된 cleanedResponse 사용

--- a/apps/api/src/llm/artifact-parser.ts
+++ b/apps/api/src/llm/artifact-parser.ts
@@ -227,6 +227,34 @@ export function extractAndStripArtifacts(raw: string): {
     return { cleanedContent: cleaned, artifacts };
 }
 
+// [[artifact:id]] / [[artifact:id:vN]] placeholder 스캔 — 시스템이 삽입하는 표기와 동일 grammar.
+const PLACEHOLDER_SCAN_PATTERN = /\[\[artifact:([^\]]+?)(?::v\d+)?\]\]/g;
+
+/**
+ * 본문에 등장하는 `[[artifact:id]]` placeholder 의 id 목록 (중복 제거, 등장 순서 유지).
+ *
+ * 유령 placeholder 가드용: 정상 placeholder 는 extractAndStripArtifacts 가 삽입한
+ * 것뿐이므로, 이 목록에서 이번 턴 추출분·세션 영속분에 없는 id 는 모델이
+ * 히스토리 표기를 모방(hallucination)한 것이다.
+ */
+export function findArtifactPlaceholderIds(content: string): string[] {
+    const ids: string[] = [];
+    for (const m of content.matchAll(PLACEHOLDER_SCAN_PATTERN)) {
+        if (!ids.includes(m[1])) ids.push(m[1]);
+    }
+    return ids;
+}
+
+/** 지정 id 들의 placeholder(`[[artifact:id]]`/`[[artifact:id:vN]]`)를 본문에서 제거. */
+export function stripArtifactPlaceholders(content: string, ids: readonly string[]): string {
+    let out = content;
+    for (const id of ids) {
+        const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        out = out.replace(new RegExp(`\\[\\[artifact:${escaped}(?::v\\d+)?\\]\\]`, 'g'), '');
+    }
+    return out;
+}
+
 function slug(s: string): string {
     return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 30) || 'code';
 }

--- a/apps/api/src/prompts/artifact-guide.ts
+++ b/apps/api/src/prompts/artifact-guide.ts
@@ -169,6 +169,8 @@ function App() {
 - ❌ \`\`\`python ... \`\`\` 만 출력 → ❌ artifact 패널에 안 들어감
 - ❌ <artifact id="..."> ... </artifact id> → ❌ 닫는 태그 형식 오류
 - ❌ \`<artifact>\` 외부에 같은 본문 중복 → ❌ 사용자 화면 중복 표시
+- ❌ \`[[artifact:id]]\` 표기를 직접 출력 → ❌ 이것은 시스템이 저장 후 삽입하는 내부 표기입니다.
+  대화 히스토리에 보이더라도 **절대 모방하지 마세요** — 산출물은 항상 \`<artifact>\` 태그로 본문 전체를 생성해야 합니다.
 - ✅ 위 예시처럼 \`<artifact id="..." kind="..." title="...">본문</artifact>\` 형식 정확히
 
 ## 🎨 html 디자인 최종 점검 — kind="html" 이면 코드 작성 직전에 반드시 적용
@@ -281,6 +283,11 @@ the finished design back via \`open-design::create_artifact\` or
 
 Outside the tag, write only a brief description/context. Do not duplicate
 the artifact body outside — the user will see it twice.
+
+⚠️ Never output the \`[[artifact:id]]\` notation yourself — it is an internal
+placeholder the system inserts after saving an artifact. Even if it appears in
+conversation history, do NOT imitate it; always produce the full content inside
+an \`<artifact>\` tag instead.
 
 ## 🎨 html design final check — apply right before writing kind="html" code
 Copy this token block **verbatim** at the top of your \`<style>\`:

--- a/apps/discord-bot/src/index.ts
+++ b/apps/discord-bot/src/index.ts
@@ -57,8 +57,9 @@ async function handleChat(message: Message, botUserId: string): Promise<void> {
         const answer = await requestChatCompletion(getHistory(key), content);
         // 생성 이미지·아티팩트 → 파일 첨부 + 뷰어 링크 (Discord 는 md 이미지/artifact 렌더 불가)
         const prepared = await prepareReply(answer.content, answer.artifacts);
-        // 아티팩트 전용 응답은 content 가 '' — 빈 assistant 턴이 세션 히스토리를 오염시키지 않게 치환본 저장
-        appendTurns(key, content, answer.content.trim() ? answer.content : prepared.content);
+        // 히스토리에는 항상 치환본(prepared.content) 저장 — 원문의 [[artifact:id]] placeholder 를
+        // 그대로 남기면 모델이 그 표기를 모방해 실체 없는 placeholder 만 출력한다 (2026-07-21 실측)
+        appendTurns(key, content, prepared.content);
         const chunks = splitForDiscord(prepared.content);
         try {
             await message.reply({


### PR DESCRIPTION
## 요약

Discord 질문 응답에 `[[artifact:kosu_prediction_report]]` 원문이 그대로 노출되던 문제 수정. 소형 모델(qwen)이 대화 히스토리에 남은 placeholder 표기를 모방해 실체 없는 placeholder 한 줄만 출력(out=8 tokens, artifacts 미생성)한 것이 원인.

## 변경 사항

- **request-handler**: 이번 턴 추출분·세션 영속분 어디에도 없는 placeholder 는 유령으로 판정해 제거, 전량 제거 시 안내 문구로 대체 (fail-open, WS/REST 공통)
- **artifact-parser**: `findArtifactPlaceholderIds` / `stripArtifactPlaceholders` 순수 헬퍼 분리 (+유닛 테스트 5건, 로컬 `__tests__`)
- **discord-bot**: 채널 히스토리에 원문 대신 치환본(`prepared.content`) 저장 — 모방의 원천 제거
- **artifact-guide(KO/EN)**: placeholder 는 시스템 내부 표기, 직접 출력 금지 명시

🤖 Generated with [Claude Code](https://claude.com/claude-code)