### PR TITLE
feat(agent-task): 실행 중 중간 지시(steering)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -805,6 +805,11 @@ AGENT_TASK_TIMEOUT_MS=600000
 # Agent Task — 턴 중간 체크포인트 (도구 결과 단위 저장 — write 도구 재실행 방지 강화). 기본 OFF.
 # AGENT_TASK_MIDTURN_CHECKPOINT=true
 
+# Agent Task — 실행 중 중간 지시(steering). 실행 중 task 에 방향 지시 주입 → 다음 턴 경계에서 반영. 기본 ON.
+# AGENT_TASK_STEERING=false                            # 기능 비활성
+# AGENT_TASK_STEERING_MAX_CHARS=2000                   # 지시 1건 최대 글자 수
+# AGENT_TASK_STEERING_MAX_PENDING=10                   # task 당 미소비 지시 대기 상한(초과 429)
+
 # 채팅 서브에이전트 — 채팅 도구 루프에 delegate_expert(전문가 위임 depth=1 tool-loop) 노출. 기본 OFF.
 # 위임 1회 = 서브 LLM 최대 3턴이라 응답 지연 증가 — 발동률·지연 관찰 후 조정 권장.
 # CHAT_SUBAGENT_ENABLED=true

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1173,6 +1173,14 @@ export const AGENT_TASK_LIMITS = {
      *  대화가 크면 도구 호출마다 DB 쓰기가 늘어나므로 기본 OFF(opt-in).
      *  AGENT_TASK_MIDTURN_CHECKPOINT=true 로 활성. */
     MIDTURN_CHECKPOINT_ENABLED: process.env.AGENT_TASK_MIDTURN_CHECKPOINT === 'true',
+    /** 실행 중 중간 지시(steering) — 실행 중 task 에 사용자가 방향 지시를 주입하면 다음 턴 경계에서
+     *  conversation 에 user 메시지로 반영(취소·재시작 없이 교정). steering 은 사용자가 명시적으로
+     *  보낼 때만 동작하므로 기본 ON. AGENT_TASK_STEERING=false 로 비활성. */
+    STEERING_ENABLED: process.env.AGENT_TASK_STEERING !== 'false',
+    /** steering 메시지 1건 최대 글자 수. AGENT_TASK_STEERING_MAX_CHARS(기본 2000). */
+    STEERING_MAX_CHARS: parseInt(process.env.AGENT_TASK_STEERING_MAX_CHARS || '2000', 10),
+    /** task 당 미소비 steering 대기 상한 — 초과 시 429(플러딩 방지). AGENT_TASK_STEERING_MAX_PENDING(기본 10). */
+    STEERING_MAX_PENDING: parseInt(process.env.AGENT_TASK_STEERING_MAX_PENDING || '10', 10),
 } as const;
 
 /** 채팅 서브에이전트(delegate_expert) — 채팅 도구 루프에서 전문가 위임(depth=1 tool-loop). */

--- a/apps/api/src/prompts/agent-task-prompt.ts
+++ b/apps/api/src/prompts/agent-task-prompt.ts
@@ -146,6 +146,18 @@ export function getAgentTaskGoalJudgeMessages(
     };
 }
 
+/**
+ * 실행 중 사용자 중간 지시(steering) 주입 프레이밍 — 다음 턴 conversation 에 user 메시지로 들어간다.
+ * 진행 중 작업의 방향을 바꾸는 추가 지시임을 명시해, 모델이 기존 목표에 반영·조정하도록 유도한다.
+ */
+export function getAgentTaskSteeringInjection(text: string): string {
+    return [
+        '[사용자 추가 지시] 작업 진행 중 사용자가 다음 지시를 보냈습니다. 현재 작업에 이 지시를',
+        '즉시 반영해 방향을 조정하세요(기존 목표와 충돌하면 이 지시를 우선):',
+        text,
+    ].join('\n');
+}
+
 /** stuck(동일 응답 반복) 감지 시 주입 — 전략 변경 유도(OpenManus handle_stuck_state 패턴). */
 export function getAgentTaskStuckNudge(): string {
     return '같은 시도를 반복하고 있습니다. 접근 방식을 바꾸세요: 다른 도구나 다른 입력을 시도하거나, 막혔다면 지금까지의 결과로 작업을 마무리(terminate)하거나 사용자에게 도움을 요청(ask_human)하세요.';

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -32,6 +32,7 @@ import { AGENT_TASK_LIMITS } from '../config/runtime-limits';
 import { createAgentTaskSchema, type CreateAgentTaskInput } from '../schemas/agent-task.schema';
 import { extractAttachedDocuments } from '../services/chat-service/doc-extractor';
 import { getApprovalRegistry } from '../services/task-sandbox/approval-gate';
+import { getSteeringRegistry } from '../services/agent-task/steering';
 import { dispatchAgentTask, getAgentTaskQueue } from '../services/agent-task/task-queue';
 import { safeRealWorkspacePath, listWorkspaceFilesAt } from '../services/task-sandbox/sandbox';
 import { basename } from 'path';
@@ -295,6 +296,31 @@ router.delete('/:taskId', asyncHandler(async (req: Request, res: Response) => {
     const db = getUnifiedDatabase();
     await db.deleteAgentTask(task.id);
     res.json(success({ message: '작업이 삭제되었습니다.', taskId: task.id }));
+}));
+
+/**
+ * POST /api/agent-tasks/:taskId/steer  { message }
+ * 실행 중 중간 지시(steering) — 실행 중 task 에 방향 지시를 주입. 다음 턴 경계에서 conversation
+ * 에 user 메시지로 반영된다(취소·재시작 불요). running/paused/queued 상태에서만 유효. owner/admin 만.
+ */
+router.post('/:taskId/steer', asyncHandler(async (req: Request, res: Response) => {
+    const task = await loadOwnedTask(req, res, req.params.taskId);
+    if (!task) return;
+    if (!AGENT_TASK_LIMITS.STEERING_ENABLED) {
+        return res.status(400).json(badRequest('중간 지시 기능이 비활성화되어 있습니다.'));
+    }
+    if (task.status !== 'running' && task.status !== 'paused' && task.status !== 'queued') {
+        return res.status(400).json(badRequest('실행 중인 작업에만 지시를 보낼 수 있습니다.'));
+    }
+    const message = String((req.body as { message?: unknown })?.message ?? '').trim();
+    if (!message) return res.status(400).json(badRequest('message 가 필요합니다.'));
+    if (message.length > AGENT_TASK_LIMITS.STEERING_MAX_CHARS) {
+        return res.status(400).json(badRequest(`지시는 ${AGENT_TASK_LIMITS.STEERING_MAX_CHARS}자를 넘을 수 없습니다.`));
+    }
+    const ok = getSteeringRegistry().submit(task.id, message, AGENT_TASK_LIMITS.STEERING_MAX_PENDING);
+    if (!ok) return res.status(429).json(badRequest('대기 중인 지시가 너무 많습니다. 반영된 후 다시 시도하세요.'));
+    logger.info(`[AgentTaskRoutes] steering 접수: ${task.id} (user ${req.user!.id})`);
+    res.json(success({ taskId: task.id, queued: getSteeringRegistry().count(task.id) }));
 }));
 
 /**

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -40,6 +40,7 @@ import { writeInputFilesToWorkspace } from './agent-task/task-inputs';
 import { judgeGoalAchieved, buildJudgeExecutionContext } from './agent-task/goal-judge';
 import { persistArtifactSteps, runTool, isSearchTool } from './agent-task/task-steps';
 import { initWorkspaceBaseline, maybePersistCodeDiff } from './agent-task/code-diff';
+import { getSteeringRegistry, applyPendingSteering } from './agent-task/steering';
 import { assembleAgentTools } from './agent-task/tool-assembly';
 import { verifyCodeArtifacts } from './agent-task/deliverable-verify';
 import { buildLearningBlock } from './agent-task/task-learning';
@@ -314,6 +315,11 @@ export class AgentTaskService {
                     browserLimitNotified = true;
                 }
 
+                // 실행 중 사용자 중간 지시(steering) — 이 턴 경계에 도착한 지시를 conversation 에
+                // user 메시지로 주입해 방향을 조정한다. 턴 경계 소비라 tool_call_id 매칭이 유지되고
+                // 다음 checkpoint 에 자연 포함된다(resume 안전). 스텝으로 기록해 상세/카드에 노출.
+                stepNumber = await applyPendingSteering(taskId, turn, conversation, stepNumber, emitStep);
+
                 // per-call abort: 작업 잔여 예산을 호출에도 바인딩 — 응답이 hang 되면
                 // 턴 사이 assertWithinLimits 까지 도달하지 못하므로 호출 자체를 끊는다.
                 // 승인 대기 누적(pausedMs)은 예산에서 제외(4-1 pause-aware).
@@ -579,6 +585,8 @@ export class AgentTaskService {
             AgentTaskService.running.delete(taskId);
             // task 자동승인(4-2) 해제 — 종료된 task 의 플래그가 레지스트리에 잔존하지 않게.
             getApprovalRegistry().clearAutoApprove(taskId);
+            // 미소비 steering 정리 — 종료된 task 에 남은 지시가 다음 동명 실행에 새지 않게.
+            getSteeringRegistry().clear(taskId);
             if (taskRuntime) {
                 // 완료 시 workspace 보존(산출물 다운로드용), 실패/취소 시 삭제. 컨테이너는 항상 제거.
                 const keepWorkspace = curStatus === 'completed';

--- a/apps/api/src/services/agent-task/steering.ts
+++ b/apps/api/src/services/agent-task/steering.ts
@@ -1,0 +1,83 @@
+/**
+ * 실행 중 중간 지시(steering) 레지스트리 — 실행 중 task 에 사용자가 방향 지시를 주입하고,
+ * AgentTaskService 루프가 매 턴 경계에서 drain 해 conversation 에 user 메시지로 반영한다.
+ *
+ * 구조: in-memory 싱글톤(ApprovalRegistry 패턴). task 백그라운드 프로세스가 drain() 으로 소비하고
+ * REST(/steer)가 submit() 한다. 멀티프로세스 정합은 후속(현재 단일 워커 전제 — API instances:1).
+ * 종료 시 clear() 로 잔존 방지(AgentTaskService finally). 프로세스 재시작 시 미소비분은 유실된다
+ * (아직 conversation 에 반영되지 않았으므로 checkpoint 에도 없음 — 허용).
+ *
+ * @module services/agent-task/steering
+ */
+import type { ChatMessage } from '../../llm/types';
+import { getUnifiedDatabase } from '../../data/models/unified-database';
+import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
+import { getAgentTaskSteeringInjection } from '../../prompts/agent-task-prompt';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('AgentTaskSteering');
+
+/**
+ * task 별 미소비 steering 메시지 큐(FIFO). 도착 순서대로 다음 턴 경계에서 주입된다.
+ */
+export class SteeringRegistry {
+    private pending = new Map<string, string[]>();
+
+    /** 미소비 지시를 추가. maxPending 초과 시 false(호출부가 429 처리). */
+    submit(taskId: string, text: string, maxPending: number): boolean {
+        const q = this.pending.get(taskId) ?? [];
+        if (q.length >= maxPending) return false;
+        q.push(text);
+        this.pending.set(taskId, q);
+        logger.info(`[${taskId}] steering 접수 (대기 ${q.length})`);
+        return true;
+    }
+
+    /** 대기 중인 지시를 모두 반환하고 비운다(턴 경계 소비). 없으면 빈 배열. */
+    drain(taskId: string): string[] {
+        const q = this.pending.get(taskId);
+        if (!q || q.length === 0) return [];
+        this.pending.delete(taskId);
+        return q;
+    }
+
+    /** 현재 대기 건수. */
+    count(taskId: string): number {
+        return this.pending.get(taskId)?.length ?? 0;
+    }
+
+    /** task 종료 시 잔존 지시 정리. */
+    clear(taskId: string): void {
+        this.pending.delete(taskId);
+    }
+}
+
+let registry: SteeringRegistry | null = null;
+export function getSteeringRegistry(): SteeringRegistry {
+    if (!registry) registry = new SteeringRegistry();
+    return registry;
+}
+
+/**
+ * 턴 경계에서 대기 steering 을 소비 — conversation 에 user 메시지로 주입하고 step_type='steering'
+ * 스텝을 영속 + WS emit. AgentTaskService 루프가 매 턴 상단에서 호출한다(파일 크기 가드로 분리).
+ * 기능 OFF/대기 없음이면 stepNumber 그대로 반환. 스텝 기록 실패는 주입을 막지 않는다.
+ */
+export async function applyPendingSteering(
+    taskId: string,
+    turn: number,
+    conversation: ChatMessage[],
+    stepNumber: number,
+    emit: (stepType: string, toolName?: string, content?: string | null) => void,
+): Promise<number> {
+    if (!AGENT_TASK_LIMITS.STEERING_ENABLED) return stepNumber;
+    for (const text of getSteeringRegistry().drain(taskId)) {
+        conversation.push({ role: 'user', content: getAgentTaskSteeringInjection(text) });
+        await getUnifiedDatabase().addAgentTaskStep({
+            taskId, stepNumber: stepNumber++, stepType: 'steering', content: text,
+        }).catch(() => { /* 기록 실패는 주입을 막지 않음 */ });
+        emit('steering', undefined, text);
+        logger.info(`[${taskId}] steering 반영 (turn ${turn + 1})`);
+    }
+    return stepNumber;
+}

--- a/apps/web/app/(workspace)/agent-tasks/page.tsx
+++ b/apps/web/app/(workspace)/agent-tasks/page.tsx
@@ -27,6 +27,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { ApiClient } from "@/lib/api-client";
+import { SteeringInput } from "@/components/chat/steering-input";
 
 /* ── 타입 ────────────────────────────────────────────────── */
 type TaskStatus = "running" | "completed" | "pending";
@@ -308,6 +309,11 @@ function TaskDetailModal({
               <span>{t("turnLabel")} {detail.task.current_turn ?? 0}/{detail.task.max_turns ?? 0}</span>
             </div>
           </div>
+
+          {/* 실행 중/일시정지 시 방향 지시(steering) — 취소·재시작 없이 교정. */}
+          {(detail.task.status === "running" || detail.task.status === "paused") && (
+            <SteeringInput taskId={taskId} />
+          )}
 
           {/* 계획 패널 (G3 plan + G5 실시간 상태) */}
           {plan.length > 0 && (

--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { Bot, MessagesSquare, Telescope, Brain, Sparkles, FileCode2, LoaderCircle, Pause, CircleCheck, CircleX, Download, FileText, ShieldCheck, ThumbsUp, ThumbsDown } from "lucide-react";
 import { ThinkingTimeline } from "@/components/chat/thinking-timeline";
+import { SteeringInput } from "@/components/chat/steering-input";
 import { useAppStore, type PendingApproval, type AgentTaskState } from "@/lib/store";
 import { ApiClient } from "@/lib/api-client";
 import { Markdown } from "./markdown";
@@ -337,6 +338,8 @@ function AgentTaskCard({ task, approvals, taskId }: { task: AgentTaskState; appr
           </div>
         )}
         {approvals && approvals.length > 0 && <InlineApprovals approvals={approvals} />}
+        {/* 실행 중/일시정지 시 방향 지시(steering) 입력 — 취소·재시작 없이 교정. */}
+        {(task.status === "running" || task.status === "paused") && <SteeringInput taskId={taskId} />}
       </div>
     </div>
   );

--- a/apps/web/components/chat/steering-input.tsx
+++ b/apps/web/components/chat/steering-input.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+/**
+ * 실행 중 중간 지시(steering) 입력 — 실행 중/일시정지 task 에 방향 지시를 보낸다.
+ * 백엔드 POST /api/agent-tasks/:taskId/steer 로 전송, 다음 턴 경계에서 반영된다.
+ * 채팅 인라인 카드와 agent-tasks 상세 양쪽에서 공유한다.
+ */
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { Send } from "lucide-react";
+import { ApiClient } from "@/lib/api-client";
+import { cn } from "@/lib/utils";
+
+export function SteeringInput({ taskId }: { taskId?: string }) {
+  const t = useTranslations("chat");
+  const [text, setText] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  async function send() {
+    const message = text.trim();
+    if (!message || !taskId || busy) return;
+    setBusy(true);
+    try {
+      await ApiClient.post(`/api/agent-tasks/${taskId}/steer`, { message });
+      setText("");
+      setSent(true);
+      setTimeout(() => setSent(false), 2500);
+    } catch (e) {
+      alert(t("steering.failed", { error: e instanceof Error ? e.message : "error" }));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mt-1 rounded-md border border-border bg-surface-2/50 p-2">
+      <p className="mb-1 text-[11px] font-medium text-muted">{t("steering.label")}</p>
+      <div className="flex items-end gap-1.5">
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) { e.preventDefault(); void send(); }
+          }}
+          placeholder={t("steering.placeholder")}
+          rows={2}
+          disabled={busy}
+          maxLength={2000}
+          className="min-w-0 flex-1 resize-y rounded-md border border-border bg-surface-1 p-1.5 text-xs text-fg-1 disabled:opacity-50"
+        />
+        <button
+          type="button"
+          disabled={busy || !text.trim()}
+          onClick={() => void send()}
+          className={cn(
+            "shrink-0 rounded-md px-2.5 py-1.5 text-xs font-medium disabled:opacity-50",
+            sent ? "bg-success-soft text-success" : "bg-accent text-accent-fg hover:opacity-90",
+          )}
+        >
+          {sent ? t("steering.sent") : <Send className="h-3.5 w-3.5" />}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -349,6 +349,12 @@
       "thinking": "Thinking",
       "fallbackLabel": "Thought process",
       "done": "Done"
+    },
+    "steering": {
+      "label": "Steer this task",
+      "placeholder": "Send a new instruction to adjust direction… (Cmd/Ctrl+Enter)",
+      "sent": "Sent",
+      "failed": "Failed to send instruction: {error}"
     }
   },
   "artifacts": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -349,6 +349,12 @@
       "thinking": "思考中",
       "fallbackLabel": "思考プロセス",
       "done": "完了"
+    },
+    "steering": {
+      "label": "タスクへの指示",
+      "placeholder": "方向を調整する新しい指示を送信… (Cmd/Ctrl+Enter)",
+      "sent": "送信済み",
+      "failed": "指示の送信に失敗しました: {error}"
     }
   },
   "artifacts": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -349,6 +349,12 @@
       "thinking": "생각하는 중",
       "fallbackLabel": "생각 과정",
       "done": "완료"
+    },
+    "steering": {
+      "label": "작업 방향 지시",
+      "placeholder": "방향을 조정할 새 지시를 보내세요… (Cmd/Ctrl+Enter)",
+      "sent": "전송됨",
+      "failed": "지시 전송 실패: {error}"
     }
   },
   "artifacts": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -349,6 +349,12 @@
       "thinking": "思考中",
       "fallbackLabel": "思考过程",
       "done": "完成"
+    },
+    "steering": {
+      "label": "引导此任务",
+      "placeholder": "发送新指令以调整方向… (Cmd/Ctrl+Enter)",
+      "sent": "已发送",
+      "failed": "发送指令失败: {error}"
     }
   },
   "artifacts": {


### PR DESCRIPTION
## 개요

Cowork/Codex 도입 검토(2026-07-21) 로드맵 **Phase 1**의 핵심 항목. 실행 중인 에이전트 작업에 사용자가 방향 지시를 주입하면 **다음 턴 경계에서 conversation 에 user 메시지로 반영**된다 — 취소·재시작 없이 진행 중 작업을 교정. Cowork("중간 개입/방향 수정")·Codex("follow-up 지시")가 가진 위임 UX 갭을 메운다.

## 동기

실사용 태스크 이력상 232분·62분·35분씩 돌다 실패로 끝난 작업이 여럿 — 잘못 가는 걸 취소 후 처음부터 다시 하는 것 말고 손쓸 방법이 없었다. steering 은 도중에 "그거 말고 이렇게"를 넣는다.

## 설계

기존 루프가 이미 턴 경계에서 nudge(검색한도·stuck)를 `conversation.push({role:'user'})` 로 주입하는 패턴을 재사용 — 새 인프라 최소.

- **소비**: 턴 루프 상단 `applyPendingSteering` 이 registry drain → 각 지시를 `[사용자 추가 지시]` 프레이밍으로 push + `step_type='steering'` 스텝 영속 + WS emit. 턴 경계 소비라 tool_call_id 매칭 유지, 다음 checkpoint 에 자연 포함(resume 안전)
- **저장**: in-memory `SteeringRegistry`(ApprovalRegistry 패턴, 단일 프로세스 전제). 종료 시 finally clear
- **라우트**: `POST /:taskId/steer` — running/paused/queued 만, 길이/대기 cap(429), owner 검증
- **프론트**: `SteeringInput` 공유 컴포넌트 → 채팅 인라인 카드 + agent-tasks 상세(running/paused 시)

## 게이트

`AGENT_TASK_STEERING`(기본 ON — 사용자가 명시적으로 보낼 때만 동작), `_MAX_CHARS`(2000), `_MAX_PENDING`(10).

## 한계 (문서화)

- 마지막 턴에서 완료로 빠진 직후 도착한 지시는 소비 안 됨(턴 경계 race)
- 멀티프로세스는 Redis 필요(현재 API instances:1 전제)

## 체크리스트

- [x] `npm run lint` 통과 (에러 0)
- [x] 백엔드 유닛테스트 (신규 steering.test.ts 4케이스 포함, agent-task 관련 16 스위트 136개 통과 — 테스트 파일은 관행상 로컬 보관)
- [x] `tsc --noEmit` 백엔드/프론트 0 에러
- [x] `build:frontend-next` 성공 (i18n 4개 로케일 키 검증)
- [x] 환경변수 → `.env.example`
- [ ] UI 스크린샷 — 라이브 검증(실행 중 steer 주입)으로 대체, 아래 코멘트에 첨부 예정
- 라우팅/응답 eval 해당 없음, DB 스키마 변경 없음(step_type 자유 TEXT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)