### PR TITLE
feat(agent-task): diff 뷰어 고도화 — 파일별 접기 + 통계

### DIFF
--- a/apps/web/app/(workspace)/agent-tasks/page.tsx
+++ b/apps/web/app/(workspace)/agent-tasks/page.tsx
@@ -28,6 +28,7 @@ import { cn } from "@/lib/utils";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { ApiClient } from "@/lib/api-client";
 import { SteeringInput } from "@/components/chat/steering-input";
+import { DiffView } from "@/components/chat/diff-view";
 
 /* ── 타입 ────────────────────────────────────────────────── */
 type TaskStatus = "running" | "completed" | "pending";
@@ -389,7 +390,7 @@ function TaskDetailModal({
                           {step.tool_name && <span className="font-mono">{step.tool_name}</span>}
                         </div>
                         {body && (isDiff ? (
-                          <DiffBlock text={body.slice(0, 20000)} />
+                          <DiffView text={body.slice(0, 20000)} />
                         ) : (
                           <pre className={cn(
                             "mt-1 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded px-2 py-1 text-xs leading-relaxed",
@@ -408,33 +409,6 @@ function TaskDetailModal({
         </>
       )}
     </div>
-  );
-}
-
-/* ── diff 스텝 렌더 (openmake_code v1) — git diff 를 +/− 라인 색상으로 표시 ── */
-function DiffBlock({ text }: { text: string }) {
-  return (
-    <pre className="mt-1 max-h-80 overflow-auto rounded bg-surface-2 px-2 py-1 font-mono text-xs leading-relaxed">
-      {text.split("\n").map((line, i) => (
-        <div
-          key={i}
-          className={cn(
-            "whitespace-pre-wrap break-words",
-            line.startsWith("+") && !line.startsWith("+++")
-              ? "bg-success-soft text-success"
-              : line.startsWith("-") && !line.startsWith("---")
-                ? "bg-danger-soft text-danger"
-                : line.startsWith("@@")
-                  ? "text-accent"
-                  : line.startsWith("diff ")
-                    ? "font-semibold text-fg-2"
-                    : "text-muted",
-          )}
-        >
-          {line || " "}
-        </div>
-      ))}
-    </pre>
   );
 }
 

--- a/apps/web/components/chat/diff-view.tsx
+++ b/apps/web/components/chat/diff-view.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+/**
+ * git diff 뷰어 — 통합 diff 를 파일별로 그룹핑해 접기/펼치기 + 파일별 +/− 통계 + 총합 요약으로
+ * 렌더한다. agent-task 코드 작업(openmake_code)의 step_type='diff' 스텝 표시에 사용.
+ * parseUnifiedDiff 는 순수 함수(파일 경계 `diff --git` 기준 분할 + 라인 카운트).
+ */
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { ChevronRight, ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface DiffFile {
+  path: string;
+  additions: number;
+  deletions: number;
+  /** 파일 헤더(diff/index/---/+++)를 제외한 본문 라인(@@ 헝크 헤더 + 내용). */
+  body: string[];
+}
+
+/** 통합 git diff 를 파일 단위로 파싱. `diff --git a/x b/x` 경계로 분할하고 +/− 라인을 센다. */
+export function parseUnifiedDiff(text: string): DiffFile[] {
+  const files: DiffFile[] = [];
+  let cur: DiffFile | null = null;
+  const isMeta = (l: string) =>
+    l.startsWith("diff --git ") || l.startsWith("index ") ||
+    l.startsWith("--- ") || l.startsWith("+++ ") ||
+    l.startsWith("new file mode ") || l.startsWith("deleted file mode ") ||
+    l.startsWith("similarity index ") || l.startsWith("rename ");
+  const push = () => { if (cur) files.push(cur); };
+
+  for (const line of text.split("\n")) {
+    if (line.startsWith("diff --git ")) {
+      push();
+      const m = line.match(/ b\/(.+)$/);
+      cur = { path: m ? m[1] : line.slice("diff --git ".length), additions: 0, deletions: 0, body: [] };
+      continue;
+    }
+    if (!cur) {
+      // 'diff --git' 헤더 없이 시작하는 diff(단일 파일 등) — 합성 버킷.
+      cur = { path: "", additions: 0, deletions: 0, body: [] };
+    }
+    if (line.startsWith("+") && !line.startsWith("+++")) cur.additions++;
+    else if (line.startsWith("-") && !line.startsWith("---")) cur.deletions++;
+    if (!isMeta(line)) cur.body.push(line);
+  }
+  push();
+  return files.filter((f) => f.body.length > 0 || f.additions > 0 || f.deletions > 0);
+}
+
+function lineClass(line: string): string {
+  if (line.startsWith("+") && !line.startsWith("+++")) return "bg-success-soft text-success";
+  if (line.startsWith("-") && !line.startsWith("---")) return "bg-danger-soft text-danger";
+  if (line.startsWith("@@")) return "text-accent";
+  return "text-muted";
+}
+
+function FileSection({ file, defaultOpen }: { file: DiffFile; defaultOpen: boolean }) {
+  const [open, setOpen] = useState(defaultOpen);
+  const Chevron = open ? ChevronDown : ChevronRight;
+  return (
+    <div className="overflow-hidden rounded border border-border">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center gap-2 bg-surface-2 px-2 py-1 text-left hover:bg-surface-3"
+      >
+        <Chevron className="h-3.5 w-3.5 shrink-0 text-faint" />
+        <span className="min-w-0 flex-1 truncate font-mono text-xs text-fg-2">{file.path || "diff"}</span>
+        <span className="shrink-0 font-mono text-[11px] text-success">+{file.additions}</span>
+        <span className="shrink-0 font-mono text-[11px] text-danger">−{file.deletions}</span>
+      </button>
+      {open && (
+        <pre className="max-h-80 overflow-auto bg-surface-1 px-2 py-1 font-mono text-xs leading-relaxed">
+          {file.body.map((line, i) => (
+            <div key={i} className={cn("whitespace-pre-wrap break-words", lineClass(line))}>
+              {line || " "}
+            </div>
+          ))}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+export function DiffView({ text }: { text: string }) {
+  const t = useTranslations("chat");
+  const files = parseUnifiedDiff(text);
+  if (files.length === 0) return null;
+  const additions = files.reduce((s, f) => s + f.additions, 0);
+  const deletions = files.reduce((s, f) => s + f.deletions, 0);
+  return (
+    <div className="mt-1 space-y-1">
+      <div className="flex items-center gap-2 text-[11px]">
+        <span className="text-muted">{t("diff.files", { count: files.length })}</span>
+        <span className="font-mono text-success">+{additions}</span>
+        <span className="font-mono text-danger">−{deletions}</span>
+      </div>
+      <div className="space-y-1">
+        {files.map((f, i) => (
+          <FileSection key={i} file={f} defaultOpen={files.length === 1} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -355,6 +355,9 @@
       "placeholder": "Send a new instruction to adjust direction… (Cmd/Ctrl+Enter)",
       "sent": "Sent",
       "failed": "Failed to send instruction: {error}"
+    },
+    "diff": {
+      "files": "{count} files"
     }
   },
   "artifacts": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -355,6 +355,9 @@
       "placeholder": "方向を調整する新しい指示を送信… (Cmd/Ctrl+Enter)",
       "sent": "送信済み",
       "failed": "指示の送信に失敗しました: {error}"
+    },
+    "diff": {
+      "files": "{count} ファイル"
     }
   },
   "artifacts": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -355,6 +355,9 @@
       "placeholder": "방향을 조정할 새 지시를 보내세요… (Cmd/Ctrl+Enter)",
       "sent": "전송됨",
       "failed": "지시 전송 실패: {error}"
+    },
+    "diff": {
+      "files": "파일 {count}개"
     }
   },
   "artifacts": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -355,6 +355,9 @@
       "placeholder": "发送新指令以调整方向… (Cmd/Ctrl+Enter)",
       "sent": "已发送",
       "failed": "发送指令失败: {error}"
+    },
+    "diff": {
+      "files": "{count} 个文件"
     }
   },
   "artifacts": {


### PR DESCRIPTION
## 개요

openmake_code(코드 작업 diff 캡처)의 diff 스텝 렌더를 고도화. 기존은 전체 diff 를 한 덩어리 `<pre>` 로 색칠만 했는데, 파일 단위 그룹핑 + 접기/펼치기 + 파일별 +/− 통계 + 상단 총합 요약으로 개선(Codex/GitHub diff UX 정렬).

## 변경

- `components/chat/diff-view.tsx` (신규):
  - `parseUnifiedDiff(text)` 순수 함수 — `diff --git` 경계로 파일 분할, +/− 라인 카운트, 메타라인(index/---/+++/new file mode 등) 본문 제외
  - `DiffView` — 상단 요약(`파일 N개 · +A −D`) + 파일별 `FileSection`(접기 버튼 + 파일명 + `+N −M` 배지). 단일 파일은 기본 펼침, 다중은 접힘
- `agent-tasks/page.tsx`: 인라인 `DiffBlock` → `DiffView` 교체
- i18n: `chat.diff.files` 4개 로케일

## 검증

- 파서 로직 단일/다중 파일 검증 PASS(경로 추출·+/− 카운트·메타라인 제외)
- `tsc --noEmit` 0 에러, `lint` 0 에러, `build:frontend-next` 성공
- 배포 후 Playwright 시각 검증 예정(아래 코멘트)

순수 프론트 변경 — 백엔드/DB/라우팅 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)