### PR TITLE
feat(agent-task): diff 복사·.patch 다운로드

### DIFF
--- a/apps/web/components/chat/diff-view.tsx
+++ b/apps/web/components/chat/diff-view.tsx
@@ -7,7 +7,7 @@
  */
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { ChevronRight, ChevronDown } from "lucide-react";
+import { ChevronRight, ChevronDown, Copy, Check, Download } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export interface DiffFile {
@@ -85,16 +85,50 @@ function FileSection({ file, defaultOpen }: { file: DiffFile; defaultOpen: boole
 
 export function DiffView({ text }: { text: string }) {
   const t = useTranslations("chat");
+  const [copied, setCopied] = useState(false);
   const files = parseUnifiedDiff(text);
   if (files.length === 0) return null;
   const additions = files.reduce((s, f) => s + f.additions, 0);
   const deletions = files.reduce((s, f) => s + f.deletions, 0);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch { /* clipboard 미허용 환경 — 무시 */ }
+  };
+  const download = () => {
+    // 사용자가 자신의 repo 에 `git apply changes.patch` 로 적용할 수 있는 표준 패치.
+    const url = URL.createObjectURL(new Blob([text], { type: "text/x-patch" }));
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "changes.patch";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <div className="mt-1 space-y-1">
       <div className="flex items-center gap-2 text-[11px]">
         <span className="text-muted">{t("diff.files", { count: files.length })}</span>
         <span className="font-mono text-success">+{additions}</span>
         <span className="font-mono text-danger">−{deletions}</span>
+        <div className="ml-auto flex items-center gap-1">
+          <button
+            type="button" onClick={copy} title={t("diff.copy")}
+            className="flex items-center gap-1 rounded border border-border px-1.5 py-0.5 text-muted hover:bg-surface-2"
+          >
+            {copied ? <Check className="h-3 w-3 text-success" /> : <Copy className="h-3 w-3" />}
+            {copied ? t("diff.copied") : t("diff.copy")}
+          </button>
+          <button
+            type="button" onClick={download} title={t("diff.download")}
+            className="flex items-center gap-1 rounded border border-border px-1.5 py-0.5 text-muted hover:bg-surface-2"
+          >
+            <Download className="h-3 w-3" /> .patch
+          </button>
+        </div>
       </div>
       <div className="space-y-1">
         {files.map((f, i) => (

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -357,7 +357,10 @@
       "failed": "Failed to send instruction: {error}"
     },
     "diff": {
-      "files": "{count} files"
+      "files": "{count} files",
+      "copy": "Copy",
+      "copied": "Copied",
+      "download": "Download .patch"
     }
   },
   "artifacts": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -357,7 +357,10 @@
       "failed": "指示の送信に失敗しました: {error}"
     },
     "diff": {
-      "files": "{count} ファイル"
+      "files": "{count} ファイル",
+      "copy": "コピー",
+      "copied": "コピー済み",
+      "download": ".patch をダウンロード"
     }
   },
   "artifacts": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -357,7 +357,10 @@
       "failed": "지시 전송 실패: {error}"
     },
     "diff": {
-      "files": "파일 {count}개"
+      "files": "파일 {count}개",
+      "copy": "복사",
+      "copied": "복사됨",
+      "download": ".patch 다운로드"
     }
   },
   "artifacts": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -357,7 +357,10 @@
       "failed": "发送指令失败: {error}"
     },
     "diff": {
-      "files": "{count} 个文件"
+      "files": "{count} 个文件",
+      "copy": "复制",
+      "copied": "已复制",
+      "download": "下载 .patch"
     }
   },
   "artifacts": {


### PR DESCRIPTION
## 개요

openmake_code diff 뷰어에 **복사 + .patch 다운로드** 툴바를 추가. GitHub 연동 없이 사용자가 자신의 repo 에 `git apply changes.patch` 로 에이전트 변경분을 적용할 수 있게 review→추출 루프를 완성한다(앞서 정의한 "GitHub 없는 openmake_code" 출력 경로).

## 변경

- `components/chat/diff-view.tsx`: DiffView 요약행 우측에 복사(clipboard)·다운로드(`text/x-patch` Blob → `changes.patch`) 버튼
- i18n: `chat.diff.copy/copied/download` 4개 로케일

순수 프론트 — 백엔드/DB 무관. `tsc`·`lint`·`build:frontend-next` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)