### PR TITLE
feat(agent-task): 승인 3모드 (Manual/Auto/Skip)

### DIFF
--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -179,6 +179,11 @@ router.post('/:taskId/execute', asyncHandler(async (req: Request, res: Response)
         ? rawSkills.filter((s): s is string => typeof s === 'string' && s.length > 0 && s.length <= 200).slice(0, 50)
         : undefined;
 
+    // 승인 3모드(Manual/Auto/Skip) — 이 실행에만 적용할 승인 정책(옵션). 유효 enum 만 수용.
+    const rawPolicy = (req.body as { approvalPolicy?: unknown })?.approvalPolicy;
+    const approvalPolicy = rawPolicy === 'all' || rawPolicy === 'high-risk' || rawPolicy === 'none'
+        ? rawPolicy : undefined;
+
     // 백그라운드 detached 실행 (응답은 즉시 반환). AgentTaskService 가 자체
     // AbortController 를 소유하므로 ws.close 와 무관하게 끝까지 진행한다.
     // 큐(3-B) 활성 시 동시 실행 상한을 넘으면 'queued' 로 대기 후 슬롯이 비면 실행된다.
@@ -193,6 +198,7 @@ router.post('/:taskId/execute', asyncHandler(async (req: Request, res: Response)
             userRole: role,
             maxTurns: task.max_turns,
             allowedSkills,
+            approvalPolicy,
             files: Array.isArray(task.input_files) ? task.input_files as AgentTaskInputFile[] : undefined,
             images: Array.isArray(task.input_images) ? task.input_images as string[] : undefined,
         }),

--- a/apps/api/src/schemas/agent-task.schema.ts
+++ b/apps/api/src/schemas/agent-task.schema.ts
@@ -45,6 +45,15 @@ export const createAgentTaskSchema = z.object({
 export type CreateAgentTaskInput = z.infer<typeof createAgentTaskSchema>;
 
 /**
+ * 에이전트 작업 실행(execute) 요청 스키마 — 승인 3모드(Manual/Auto/Skip)를 이 실행에 한해 지정.
+ * all=Manual(전부 승인·기본), high-risk=Auto(고위험만), none=Skip(전부 자동). 미지정 시 전역 정책.
+ */
+export const executeAgentTaskSchema = z.object({
+    approvalPolicy: z.enum(['all', 'high-risk', 'none']).optional(),
+});
+export type ExecuteAgentTaskInput = z.infer<typeof executeAgentTaskSchema>;
+
+/**
  * 스케줄(반복 트리거) 생성 스키마 (Phase 3-A).
  * cron 또는 intervalSeconds 중 정확히 하나만 지정. interval 은 최소 간격 강제(남용 방지).
  * cron 표현식 유효성은 라우트에서 parseCron 으로 추가 검증.

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -204,7 +204,13 @@ export class AgentTaskService {
             // 영속 샌드박스(Manus화) — 플래그 ON 일 때만. OFF 면 runtime=null 로 기존 동작 그대로.
             // 생성 실패는 작업을 죽이지 않고 샌드박스 없이 진행(graceful degrade).
             // 설정은 한 번만 읽어 enabled 게이트·런타임·extraTools·승인 정책이 동일 스냅샷을 공유.
-            const sandboxCfg = getTaskSandboxConfig();
+            // 승인 3모드(Manual/Auto/Skip): input.approvalPolicy 가 있으면 이 실행에 한해 전역 정책을
+            // override(비영속 — resume/부팅복구는 전역 기본값 폴백). requiresApproval 호출부(TaskRuntime
+            // 구성 + extra-tool 게이트)가 모두 이 cfg.approvalPolicy 를 읽으므로 단일 지점 주입으로 충분.
+            const baseCfg = getTaskSandboxConfig();
+            const sandboxCfg = input.approvalPolicy
+                ? { ...baseCfg, approvalPolicy: input.approvalPolicy }
+                : baseCfg;
             if (sandboxCfg.enabled) {
                 try {
                     // G4 위임 — 상세는 agent-task/delegate (SUBAGENT_ENABLED 시 depth=1 tool-loop 승격,

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -201,16 +201,11 @@ export class AgentTaskService {
                 ? mergeToolsWithSkills({ allTools, userToggled: allTools, profileRequired: [], skillBindings })
                 : allTools;
 
-            // 영속 샌드박스(Manus화) — 플래그 ON 일 때만. OFF 면 runtime=null 로 기존 동작 그대로.
-            // 생성 실패는 작업을 죽이지 않고 샌드박스 없이 진행(graceful degrade).
-            // 설정은 한 번만 읽어 enabled 게이트·런타임·extraTools·승인 정책이 동일 스냅샷을 공유.
-            // 승인 3모드(Manual/Auto/Skip): input.approvalPolicy 가 있으면 이 실행에 한해 전역 정책을
-            // override(비영속 — resume/부팅복구는 전역 기본값 폴백). requiresApproval 호출부(TaskRuntime
-            // 구성 + extra-tool 게이트)가 모두 이 cfg.approvalPolicy 를 읽으므로 단일 지점 주입으로 충분.
-            const baseCfg = getTaskSandboxConfig();
+            // 영속 샌드박스(Manus화, 플래그 ON 시만). 생성 실패는 샌드박스 없이 진행(graceful degrade).
+            // 설정은 한 번만 읽어 스냅샷 공유. 승인 3모드는 input.approvalPolicy 로 이 실행에만 override
+            // (비영속, resume은 전역 폴백; requiresApproval 호출부 2곳이 이 cfg 를 읽어 단일 지점 주입).
             const sandboxCfg = input.approvalPolicy
-                ? { ...baseCfg, approvalPolicy: input.approvalPolicy }
-                : baseCfg;
+                ? { ...getTaskSandboxConfig(), approvalPolicy: input.approvalPolicy } : getTaskSandboxConfig();
             if (sandboxCfg.enabled) {
                 try {
                     // G4 위임 — 상세는 agent-task/delegate (SUBAGENT_ENABLED 시 depth=1 tool-loop 승격,

--- a/apps/api/src/services/agent-task/types.ts
+++ b/apps/api/src/services/agent-task/types.ts
@@ -49,6 +49,9 @@ export interface AgentTaskRunInput {
     /** 입력 첨부 이미지(dataURL) — goal 메시지 vision 채널로 주입(신규 시작에 한함),
      *  샌드박스 ON 이면 uploads/ 에 원본 바이트로도 기록. */
     images?: string[];
+    /** 승인 3모드(Manual/Auto/Skip) — 이 실행에 한해 전역 승인 정책을 override(비영속).
+     *  all=전부 승인, high-risk=고위험만, none=전부 자동. 미지정 시 전역 TASK_SANDBOX_APPROVAL_POLICY. */
+    approvalPolicy?: 'all' | 'high-risk' | 'none';
     /** resume(이어하기): 기존 end-of-turn checkpoint 에서 복원 */
     resume?: {
         conversation: ChatMessage[];

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -181,6 +181,7 @@ export function Composer() {
     deepResearchMode,
     webSearchEnabled,
     agentTaskMode,
+    agentApprovalMode,
     imageMode,
     artifactMode,
     structuredMode,
@@ -189,6 +190,7 @@ export function Composer() {
     inputDraft,
     toggle,
     setSelectedModel,
+    setAgentApprovalMode,
     cycleStyle,
     setInputDraft,
     auth,
@@ -285,6 +287,7 @@ export function Composer() {
         text.trim(),
         files.length ? files : undefined,
         images.length ? images.map((i) => i.dataUrl) : undefined,
+        agentApprovalMode,
       );
     } else if (structuredMode) {
       // 구조화 답변 토글 ON — REST /api/chat/structured (비스트리밍, 카드 렌더). 첨부는 미지원.
@@ -340,6 +343,13 @@ export function Composer() {
     { key: "structuredMode" as const, on: structuredMode, icon: LayoutList, label: t("toggle.structured") },
   ];
   const activeModeCount = TOGGLES.filter((m) => m.on).length;
+
+  // 승인 3모드 세그먼트 — all=Manual, high-risk=Auto, none=Skip (에이전트 작업 위임 시 노출).
+  const APPROVAL_MODES = [
+    { v: "all" as const, label: t("approvalMode.manual"), hint: t("approvalMode.manualHint") },
+    { v: "high-risk" as const, label: t("approvalMode.auto"), hint: t("approvalMode.autoHint") },
+    { v: "none" as const, label: t("approvalMode.skip"), hint: t("approvalMode.skipHint") },
+  ];
 
   // 가로채기(bypass) 모드: 켜지면 백엔드가 웹·아티팩트 modifier 를 무시(전용 파이프라인).
   const INTERCEPT_KEYS = new Set<string>(INTERCEPT_MODE_KEYS);
@@ -499,6 +509,31 @@ export function Composer() {
             );
           })}
         </div>
+
+        {/* 승인 3모드(Manual/Auto/Skip) — 에이전트 작업 위임 시 이 실행의 도구 승인 정책 선택. */}
+        {agentTaskMode && (
+          <div className="flex items-center gap-2 px-3 pt-2 text-xs">
+            <span className="text-muted">{t("approvalMode.label")}</span>
+            <div className="inline-flex overflow-hidden rounded-md border border-border">
+              {APPROVAL_MODES.map((m) => (
+                <button
+                  key={m.v}
+                  type="button"
+                  onClick={() => setAgentApprovalMode(m.v)}
+                  title={m.hint}
+                  className={cn(
+                    "px-2 py-0.5 font-medium transition",
+                    agentApprovalMode === m.v
+                      ? "bg-accent text-accent-fg"
+                      : "text-muted hover:bg-surface-2",
+                  )}
+                >
+                  {m.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* 첨부 칩 — 이미지 썸네일 + 텍스트/파일 칩 */}
         {(files.length > 0 || images.length > 0) && (

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -138,6 +138,8 @@ interface AppState {
   deepResearchMode: boolean;
   webSearchEnabled: boolean;
   agentTaskMode: boolean;
+  /** 에이전트 작업 승인 3모드 — all=Manual(전부 승인·기본)·high-risk=Auto(고위험만)·none=Skip(전부 자동). */
+  agentApprovalMode: "all" | "high-risk" | "none";
   imageMode: boolean;
   artifactMode: boolean;
   /** 구조화 답변 모드 — ON 시 메시지를 REST /api/chat/structured 로 보내 카드 UI 로 렌더(비스트리밍). */
@@ -196,6 +198,7 @@ interface AppState {
       | "structuredMode",
   ) => void;
   setSelectedModel: (m: string) => void;
+  setAgentApprovalMode: (m: "all" | "high-risk" | "none") => void;
   cycleStyle: () => void;
   setStyle: (m: ChatStyle) => void;
   setAuth: (auth: AppState["auth"]) => void;
@@ -255,6 +258,7 @@ export const useAppStore = create<AppState>()(
   deepResearchMode: false,
   webSearchEnabled: false,
   agentTaskMode: false,
+  agentApprovalMode: "all",
   imageMode: false,
   artifactMode: false,
   structuredMode: false,
@@ -397,6 +401,7 @@ export const useAppStore = create<AppState>()(
       return { [key]: next } as Partial<AppState>;
     }),
   setSelectedModel: (m) => set({ selectedModel: m }),
+  setAgentApprovalMode: (m) => set({ agentApprovalMode: m }),
   cycleStyle: () =>
     set((s) => ({
       style: STYLE_ORDER[(STYLE_ORDER.indexOf(s.style) + 1) % STYLE_ORDER.length],

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -339,7 +339,12 @@ export function useChatSocket() {
   // 첨부 files 는 백엔드가 텍스트 추출 후 작업 샌드박스 workspace 에 주입,
   // images(dataURL)는 goal 메시지의 vision 채널로 전달된다.
   const startAgentTask = useCallback(
-    async (message: string, files?: WsAttachedFile[], images?: string[]) => {
+    async (
+      message: string,
+      files?: WsAttachedFile[],
+      images?: string[],
+      approvalPolicy?: "all" | "high-risk" | "none",
+    ) => {
       const goal = message.trim();
       const s = useAppStore.getState();
       if (!goal || s.isGenerating) return;
@@ -362,7 +367,11 @@ export function useChatSocket() {
           content: "",
           agentTask: { goal, status: "pending", currentTurn: 0, progress: 0 },
         });
-        await ApiClient.post(`/api/agent-tasks/${taskId}/execute`);
+        // 승인 3모드 — all(기본)이면 전역 정책이므로 미전송, 그 외만 이 실행에 override 전달.
+        await ApiClient.post(
+          `/api/agent-tasks/${taskId}/execute`,
+          approvalPolicy && approvalPolicy !== "all" ? { approvalPolicy } : {},
+        );
       } catch (e) {
         appendMessage({
           role: "assistant",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -361,6 +361,15 @@
       "copy": "Copy",
       "copied": "Copied",
       "download": "Download .patch"
+    },
+    "approvalMode": {
+      "label": "Approval:",
+      "manual": "Manual",
+      "auto": "Auto",
+      "skip": "Skip",
+      "manualHint": "Approve every tool call",
+      "autoHint": "Approve only high-risk tools (shell/python/browser/delete)",
+      "skipHint": "Run all tools automatically"
     }
   },
   "artifacts": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -361,6 +361,15 @@
       "copy": "コピー",
       "copied": "コピー済み",
       "download": ".patch をダウンロード"
+    },
+    "approvalMode": {
+      "label": "承認:",
+      "manual": "手動",
+      "auto": "自動",
+      "skip": "スキップ",
+      "manualHint": "すべてのツール呼び出しを承認",
+      "autoHint": "高リスクツールのみ承認 (シェル/python/ブラウザ/削除)",
+      "skipHint": "すべてのツールを自動実行"
     }
   },
   "artifacts": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -361,6 +361,15 @@
       "copy": "복사",
       "copied": "복사됨",
       "download": ".patch 다운로드"
+    },
+    "approvalMode": {
+      "label": "승인:",
+      "manual": "수동",
+      "auto": "자동",
+      "skip": "건너뜀",
+      "manualHint": "모든 도구 호출을 승인",
+      "autoHint": "고위험 도구만 승인 (셸/파이썬/브라우저/삭제)",
+      "skipHint": "모든 도구를 자동 실행"
     }
   },
   "artifacts": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -361,6 +361,15 @@
       "copy": "复制",
       "copied": "已复制",
       "download": "下载 .patch"
+    },
+    "approvalMode": {
+      "label": "审批:",
+      "manual": "手动",
+      "auto": "自动",
+      "skip": "跳过",
+      "manualHint": "批准每次工具调用",
+      "autoHint": "仅批准高风险工具 (shell/python/浏览器/删除)",
+      "skipHint": "自动运行所有工具"
     }
   },
   "artifacts": {


### PR DESCRIPTION
## 개요

에이전트 작업 위임 시 도구 승인 정책을 **per-task 선택**(Cowork의 Manual/Auto/Skip 병행). **마이그레이션 없이** execute 요청 본문으로 `approvalPolicy` 를 전달해 이 실행에만 override — 기존 auto-approve 토글과 동일한 비영속 패턴(resume/부팅복구는 전역 기본값 폴백).

- **Manual** = `all` (모든 도구 승인, 현 기본)
- **Auto** = `high-risk` (bash/python/browser/파일삭제만 승인, 나머지 자동)
- **Skip** = `none` (전부 자동 — 기존 auto-approve 토글과 동등)

## 변경

- `schemas/agent-task.schema`: `executeAgentTaskSchema { approvalPolicy? }`
- `AgentTaskService`: `input.approvalPolicy` 있으면 `{...cfg, approvalPolicy}` override. `requiresApproval` 호출부 2곳(TaskRuntime 구성 → runtime.ts:124 task 도구, AgentTaskService:495 extra 도구)이 모두 이 cfg 를 읽으므로 **단일 지점 주입**으로 충분
- `routes` execute: 본문 `approvalPolicy`(enum) 파싱 → service 전달. resume 라우트는 미전달(=전역 기본)
- 프론트: store `agentApprovalMode` + composer 3-way 세그먼트(agentTaskMode ON 시 노출) + `startAgentTask`→execute 본문(`all`은 전역이라 미전송)
- i18n: `chat.approvalMode.*` 4개 로케일

## 검증

- 백엔드 유닛테스트 16 스위트 136개 통과, `tsc`(api/web)·`lint`·`build:frontend-next` 통과
- 배포 후 라이브 E2E 예정: Auto 모드 태스크에서 안전도구 자동·bash만 승인 대기 확인(아래 코멘트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)