### PR TITLE
feat(agent-task): 채팅 카드에 코드 diff 인라인 렌더

### DIFF
--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from "next-intl";
 import { Bot, MessagesSquare, Telescope, Brain, Sparkles, FileCode2, LoaderCircle, Pause, CircleCheck, CircleX, Download, FileText, ShieldCheck, ThumbsUp, ThumbsDown } from "lucide-react";
 import { ThinkingTimeline } from "@/components/chat/thinking-timeline";
 import { SteeringInput } from "@/components/chat/steering-input";
+import { DiffView } from "@/components/chat/diff-view";
 import { useAppStore, type PendingApproval, type AgentTaskState } from "@/lib/store";
 import { ApiClient } from "@/lib/api-client";
 import { Markdown } from "./markdown";
@@ -337,6 +338,8 @@ function AgentTaskCard({ task, approvals, taskId }: { task: AgentTaskState; appr
             </div>
           </div>
         )}
+        {/* 코드 작업(openmake_code) diff — 채팅에서 위임한 코드 변경을 인라인으로 검토·다운로드. */}
+        {task.diff && <DiffView text={task.diff} />}
         {approvals && approvals.length > 0 && <InlineApprovals approvals={approvals} />}
         {/* 실행 중/일시정지 시 방향 지시(steering) 입력 — 취소·재시작 없이 교정. */}
         {(task.status === "running" || task.status === "paused") && <SteeringInput taskId={taskId} />}

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -43,6 +43,8 @@ export interface AgentTaskState {
   artifactIds?: string[];
   /** 완료 시 workspace 산출물 파일 경로 목록. */
   files?: string[];
+  /** 완료 시 코드 작업(openmake_code) git diff — 있으면 카드에 DiffView 로 렌더. */
+  diff?: string;
   /** 방금 실행된 스텝 요약(4-5 실시간 스트림) — "현재 단계" 라인 표시. */
   lastStep?: { stepType: string; toolName?: string; preview?: string };
 }

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -187,11 +187,14 @@ export function useChatSocket() {
               let result = "";
               const artifactIds: string[] = [];
               let files: string[] = [];
+              let diff: string | undefined;
               try {
                 const r = await ApiClient.get<{
                   data: { task: { result?: string }; steps?: Array<{ step_type: string; content?: string }> };
                 }>(`/api/agent-tasks/${taskId}`);
                 result = r?.data?.task?.result ?? "";
+                // 코드 작업 diff 스텝 — 채팅 카드에 DiffView 로 인라인 렌더(마지막 diff 사용).
+                diff = (r?.data?.steps ?? []).filter((s) => s.step_type === "diff").pop()?.content || undefined;
                 // deliverable 아티팩트 — store 등록 후 카드가 칩으로 렌더.
                 const arts = (r?.data?.steps ?? [])
                   .filter((s) => s.step_type === "artifact")
@@ -208,7 +211,7 @@ export function useChatSocket() {
                 const f = await ApiClient.get<{ data: { files: string[] } }>(`/api/agent-tasks/${taskId}/files`);
                 files = f?.data?.files ?? [];
               } catch { /* 파일 없음 */ }
-              merge({ result, artifactIds, files, lastStep: undefined }, undefined);
+              merge({ result, artifactIds, files, diff, lastStep: undefined }, undefined);
             })();
           } else if (status === "paused") {
             // 승인 대기 — 해당 task 의 pending approval 조회 → 카드에 인라인 승인 버튼.


### PR DESCRIPTION
## 개요

채팅 composer에서 위임한 코드 작업(openmake_code)의 diff를 **완료 후 채팅 카드에서 바로** 볼 수 있게 한다. 기존엔 `/agent-tasks` 페이지로 이동해야만 diff를 확인할 수 있어, 위임(chat) ↔ 결과 확인(page)이 분리돼 있었다. 이제 위임과 검토가 채팅 한 곳에서 완결된다.

## 변경 (프론트 전용, 백엔드 무관)

- terminal 시 **이미 fetch 하는 steps 응답**에서 `step_type='diff'` content 추출 → `AgentTaskState.diff`
- `AgentTaskCard` 가 기존 `DiffView`(파일별 접기·+/− 통계·복사·.patch 다운로드)로 렌더
- 새 WS 이벤트·백엔드 변경 없음 — 기존 완료-핸들러 재사용

`tsc`·`lint`·`build:frontend-next` 통과. 배포 후 채팅 코드 태스크로 시각 검증 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)