### PR TITLE
fix(agent-task): 실패/취소한 코드 작업도 diff 캡처

### DIFF
--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -39,7 +39,7 @@ import { AgentTaskAbort, assertWithinLimits, type AgentTaskRunInput } from './ag
 import { writeInputFilesToWorkspace } from './agent-task/task-inputs';
 import { judgeGoalAchieved, buildJudgeExecutionContext } from './agent-task/goal-judge';
 import { persistArtifactSteps, runTool, isSearchTool } from './agent-task/task-steps';
-import { initWorkspaceBaseline, maybePersistCodeDiff } from './agent-task/code-diff';
+import { initWorkspaceBaseline, maybePersistCodeDiff, captureDiffOnCleanup } from './agent-task/code-diff';
 import { getSteeringRegistry, applyPendingSteering } from './agent-task/steering';
 import { assembleAgentTools } from './agent-task/tool-assembly';
 import { verifyCodeArtifacts } from './agent-task/deliverable-verify';
@@ -589,8 +589,9 @@ export class AgentTaskService {
             // 미소비 steering 정리 — 종료된 task 에 남은 지시가 다음 동명 실행에 새지 않게.
             getSteeringRegistry().clear(taskId);
             if (taskRuntime) {
-                // 완료 시 workspace 보존(산출물 다운로드용), 실패/취소 시 삭제. 컨테이너는 항상 제거.
+                // 완료 시 workspace 보존(다운로드용), 실패/취소 시 삭제 직전 코드 diff 캡처(실패한 코드 작업도 변경분 검토).
                 const keepWorkspace = curStatus === 'completed';
+                if (!keepWorkspace) await captureDiffOnCleanup(taskRuntime, taskId, stepNumber).catch(() => { /* fail-open */ });
                 await taskRuntime.cleanup(!keepWorkspace).catch((e) =>
                     logger.warn(`[AgentTask] 샌드박스 정리 실패: ${taskId} — ${e}`));
             }

--- a/apps/api/src/services/agent-task/code-diff.ts
+++ b/apps/api/src/services/agent-task/code-diff.ts
@@ -11,6 +11,7 @@
  * @module services/agent-task/code-diff
  */
 import { getUnifiedDatabase } from '../../data/models/unified-database';
+import { getTaskSandboxConfig } from '../../config/task-sandbox';
 import type { TaskRuntime } from '../task-sandbox/runtime';
 import { createLogger } from '../../utils/logger';
 
@@ -77,6 +78,18 @@ export async function maybePersistCodeDiff(
     const next = await persistDiffStep(taskId, diff, stepNumber);
     emit('diff', 'git_diff', diff);
     return next;
+}
+
+/**
+ * 실패/취소 종료 직전(workspace 삭제 전) diff 캡처 — 완료 경로는 maybePersistCodeDiff 로 이미
+ * 캡처되지만, goal_incomplete·에러·취소로 끝난 코드 작업은 workspace 가 삭제돼 변경분을 볼 수 없었다.
+ * diff 스텝은 DB 에 남으므로 workspace 삭제와 무관하게 실패한 작업의 변경분도 검토 가능해진다.
+ * AgentTaskService finally 에서 !keepWorkspace 일 때 호출(fail-open, WS emit 불요 — 종료 후 재조회).
+ */
+export async function captureDiffOnCleanup(runtime: TaskRuntime, taskId: string, stepNumber: number): Promise<void> {
+    if (!getTaskSandboxConfig().codeDiffEnabled) return;
+    const diff = await captureWorkspaceDiff(runtime);
+    if (diff) await persistDiffStep(taskId, diff, stepNumber);
 }
 
 /**


### PR DESCRIPTION
## 개요

openmake_code diff 캡처의 실패-경로 갭 수정. 기존엔 완료 3경로(최종답변/terminate/턴상한)에만 diff를 캡처해서, **goal_incomplete·에러·취소로 끝난 코드 작업은 workspace가 삭제되며 에이전트가 무엇을 바꿨는지 전혀 볼 수 없었다.** diff 스텝은 DB에 영속되므로, `finally`의 workspace 삭제 직전에 캡처하면 실패한 코드 작업도 변경분을 검토할 수 있다.

## 변경

- `code-diff.ts`: `captureDiffOnCleanup(runtime, taskId, stepNumber)` — `codeDiffEnabled` 게이트 + `captureWorkspaceDiff` + `persistDiffStep` 조합. fail-open
- `AgentTaskService` finally: `!keepWorkspace`(=실패/취소) 시 `cleanup` 직전 호출 → 모든 실패 경로(마커·judge·에러·취소)를 **단일 지점**으로 커버. 완료 경로는 기존 `maybePersistCodeDiff`로 이미 캡처되므로 `keepWorkspace=true`에서 skip(중복 없음)
- 테스트 3건(로컬 `__tests__`: 변경분 영속·게이트 off·빈 diff)

## 검증

- 백엔드 테스트 통과(code-diff 11건), `tsc` 0에러, `lint` 0에러, 파일 크기 가드 600줄 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)