### PR TITLE
feat(agent-task): GitHub 연결 저장 (Phase 2a)

### DIFF
--- a/apps/api/src/services/github-token.ts
+++ b/apps/api/src/services/github-token.ts
@@ -1,0 +1,24 @@
+/**
+ * 저장된 사용자 GitHub 연결(external_connections, serviceType='github')에서 복호화된
+ * PAT 를 조회한다. Phase 2 Git 통합의 호스트측 clone/push/PR 이 이 토큰을 사용한다.
+ *
+ * ⚠️ 반환된 토큰은 **호스트 프로세스에서만** 사용하고 격리 컨테이너에는 절대 주입하지 않는다
+ * (프롬프트 인젝션 → 토큰 유출 차단 — 보안 아키텍처의 핵심).
+ *
+ * @module services/github-token
+ */
+import { getUnifiedDatabase } from '../data/models/unified-database';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('GithubToken');
+
+/** 사용자의 저장된 GitHub PAT(복호화됨). 미연결이면 null. 조회 실패는 null(fail-open). */
+export async function getUserGithubToken(userId: string): Promise<string | null> {
+    try {
+        const conn = await getUnifiedDatabase().getUserConnectionByService(userId, 'github');
+        return conn?.access_token ?? null;
+    } catch (e) {
+        logger.warn(`[${userId}] GitHub 토큰 조회 실패: ${e instanceof Error ? e.message : e}`);
+        return null;
+    }
+}

--- a/apps/web/app/(workspace)/settings/page.tsx
+++ b/apps/web/app/(workspace)/settings/page.tsx
@@ -34,6 +34,7 @@ import { LOCALE_COOKIE, LOCALE_COOKIE_MAX_AGE, isLocale, toBcp47 } from "@/i18n/
 import { ModelPicker } from "@/components/model-picker";
 import { MemorySection } from "@/components/settings/memory-section";
 import { ConnectorsSection } from "@/components/settings/connectors-section";
+import { GithubConnectSection } from "@/components/settings/github-connect-section";
 import { ProviderKeysSection } from "@/components/settings/provider-keys-section";
 import { ModelRolesSection } from "@/components/settings/model-roles-section";
 
@@ -755,7 +756,12 @@ export default function SettingsPage() {
 
             {tab === "memory" && <MemorySection />}
 
-            {tab === "connectors" && <ConnectorsSection />}
+            {tab === "connectors" && (
+              <div className="space-y-6">
+                <GithubConnectSection />
+                <ConnectorsSection />
+              </div>
+            )}
 
             {tab === "privacy" && (
               <Card>

--- a/apps/web/components/settings/github-connect-section.tsx
+++ b/apps/web/components/settings/github-connect-section.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+/**
+ * GitHub 연결 섹션 — 사용자가 Personal Access Token(PAT)을 저장/해제한다.
+ * Phase 2 Git 통합에서 에이전트 작업의 호스트측 clone/push/PR 인증에 사용된다.
+ * 저장은 기존 external_connections(serviceType='github', 암호화) 를 재사용.
+ * ⚠️ 토큰 원문은 응답에 노출되지 않으며(hasAccessToken 만), 격리 컨테이너에도 주입되지 않는다.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { GitBranch, Check, LoaderCircle } from "lucide-react";
+import { ApiClient } from "@/lib/api-client";
+import { cn } from "@/lib/utils";
+
+type Status = "loading" | "connected" | "disconnected";
+
+export function GithubConnectSection() {
+  const t = useTranslations("githubConnect");
+  const [status, setStatus] = useState<Status>("loading");
+  const [pat, setPat] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await ApiClient.get<{ data?: { hasAccessToken?: boolean } }>("/api/external/github");
+      setStatus(res?.data?.hasAccessToken ? "connected" : "disconnected");
+    } catch {
+      // 404 = 미연결 (그 외 오류도 미연결로 간주 — 저장 시도는 여전히 가능).
+      setStatus("disconnected");
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  async function save() {
+    const token = pat.trim();
+    if (!token || busy) return;
+    setBusy(true); setError(null);
+    try {
+      await ApiClient.post("/api/external", { serviceType: "github", accessToken: token });
+      setPat("");
+      setStatus("connected");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("saveFailed"));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function disconnect() {
+    if (busy || !window.confirm(t("disconnectConfirm"))) return;
+    setBusy(true); setError(null);
+    try {
+      await ApiClient.del("/api/external/github");
+      setStatus("disconnected");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("disconnectFailed"));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-surface-1 p-4">
+      <div className="mb-1 flex items-center gap-2">
+        <GitBranch className="h-4 w-4 text-fg-2" />
+        <h3 className="text-sm font-semibold text-fg">{t("title")}</h3>
+        {status === "connected" && (
+          <span className="ml-auto inline-flex items-center gap-1 rounded-full bg-success-soft px-2 py-0.5 text-[11px] font-medium text-success">
+            <Check className="h-3 w-3" /> {t("connected")}
+          </span>
+        )}
+      </div>
+      <p className="mb-3 text-xs text-muted">{t("description")}</p>
+
+      {status === "loading" ? (
+        <LoaderCircle className="h-4 w-4 animate-spin text-muted" />
+      ) : status === "connected" ? (
+        <button
+          type="button" disabled={busy} onClick={disconnect}
+          className="rounded-md border border-border px-3 py-1.5 text-xs text-muted hover:bg-surface-2 disabled:opacity-50"
+        >
+          {t("disconnect")}
+        </button>
+      ) : (
+        <div className="flex items-end gap-2">
+          <div className="min-w-0 flex-1">
+            <label className="mb-1 block text-[11px] text-muted">{t("patLabel")}</label>
+            <input
+              type="password"
+              value={pat}
+              onChange={(e) => setPat(e.target.value)}
+              placeholder="ghp_..."
+              disabled={busy}
+              className="w-full rounded-md border border-border bg-surface-2 px-2 py-1.5 font-mono text-xs text-fg-1 disabled:opacity-50"
+            />
+          </div>
+          <button
+            type="button" disabled={busy || !pat.trim()} onClick={save}
+            className={cn(
+              "shrink-0 rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-fg hover:opacity-90 disabled:opacity-50",
+            )}
+          >
+            {busy ? <LoaderCircle className="h-3.5 w-3.5 animate-spin" /> : t("save")}
+          </button>
+        </div>
+      )}
+      {error && <p className="mt-2 text-xs text-danger">{error}</p>}
+      <p className="mt-2 text-[11px] text-faint">{t("hint")}</p>
+    </div>
+  );
+}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1508,5 +1508,17 @@
     "dashboard": "Dashboard",
     "history": "Chat history",
     "research": "Deep research"
+  },
+  "githubConnect": {
+    "title": "GitHub",
+    "description": "Connect a Personal Access Token so agent tasks can clone repositories and open pull requests. The token is encrypted and never exposed to task sandboxes.",
+    "connected": "Connected",
+    "patLabel": "Personal Access Token",
+    "save": "Connect",
+    "disconnect": "Disconnect",
+    "disconnectConfirm": "Disconnect GitHub? Agent tasks will no longer be able to access your repositories.",
+    "hint": "Needs repo scope. Create at github.com → Settings → Developer settings → Personal access tokens.",
+    "saveFailed": "Failed to save token",
+    "disconnectFailed": "Failed to disconnect"
   }
 }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1508,5 +1508,17 @@
     "dashboard": "ダッシュボード",
     "history": "チャット履歴",
     "research": "ディープリサーチ"
+  },
+  "githubConnect": {
+    "title": "GitHub",
+    "description": "Personal Access Token を接続すると、エージェントタスクがリポジトリをクローンし PR を作成できます。トークンは暗号化され、タスクサンドボックスには公開されません。",
+    "connected": "接続済み",
+    "patLabel": "Personal Access Token",
+    "save": "接続",
+    "disconnect": "切断",
+    "disconnectConfirm": "GitHub を切断しますか？エージェントタスクはリポジトリにアクセスできなくなります。",
+    "hint": "repo スコープが必要です。github.com → Settings → Developer settings → Personal access tokens で作成。",
+    "saveFailed": "トークンの保存に失敗しました",
+    "disconnectFailed": "切断に失敗しました"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1508,5 +1508,17 @@
     "dashboard": "대시보드",
     "history": "대화 히스토리",
     "research": "딥 리서치"
+  },
+  "githubConnect": {
+    "title": "GitHub",
+    "description": "Personal Access Token을 연결하면 에이전트 작업이 저장소를 clone하고 PR을 생성할 수 있습니다. 토큰은 암호화되며 작업 샌드박스에 노출되지 않습니다.",
+    "connected": "연결됨",
+    "patLabel": "Personal Access Token",
+    "save": "연결",
+    "disconnect": "연결 해제",
+    "disconnectConfirm": "GitHub 연결을 해제할까요? 에이전트 작업이 더 이상 저장소에 접근할 수 없습니다.",
+    "hint": "repo 권한이 필요합니다. github.com → Settings → Developer settings → Personal access tokens 에서 생성.",
+    "saveFailed": "토큰 저장 실패",
+    "disconnectFailed": "연결 해제 실패"
   }
 }

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1508,5 +1508,17 @@
     "dashboard": "仪表盘",
     "history": "对话历史",
     "research": "深度研究"
+  },
+  "githubConnect": {
+    "title": "GitHub",
+    "description": "连接个人访问令牌(PAT)后，代理任务即可克隆仓库并创建 PR。令牌已加密，绝不暴露给任务沙箱。",
+    "connected": "已连接",
+    "patLabel": "个人访问令牌",
+    "save": "连接",
+    "disconnect": "断开",
+    "disconnectConfirm": "断开 GitHub？代理任务将无法访问你的仓库。",
+    "hint": "需要 repo 权限。在 github.com → Settings → Developer settings → Personal access tokens 创建。",
+    "saveFailed": "保存令牌失败",
+    "disconnectFailed": "断开失败"
   }
 }


### PR DESCRIPTION
## 개요

Phase 2 Git/PR 통합의 **foundation(2a)** — 사용자가 GitHub Personal Access Token(PAT)을 저장/해제하는 UI. 호스트측 clone/push/PR(2b·2c)의 인증 토큰 출처. git-ops 리스크 0(저장만).

## 변경

- `services/github-token.ts` (신규): `getUserGithubToken(userId)` — 복호화된 PAT 조회(2b·2c에서 사용). ⚠️ 호스트 전용, 격리 컨테이너 미주입(보안 아키텍처 전제)
- 프론트 `GithubConnectSection`: PAT 입력(password) → `POST /api/external`(serviceType='github'), 상태(연결됨/미연결) → `GET`, 해제 → `DELETE`. settings connectors 탭에 배선. 토큰 원문 미노출(`hasAccessToken`만)
- i18n `githubConnect` 4로케일

저장 인프라(`external_connections` 암호화 + `POST /api/external`)는 기존 것 재사용 — 신규는 조회 헬퍼 + 프론트 UI뿐.

## 검증

- `tsc`(api+web)·`lint`·`build:frontend-next` 통과
- 배포 후 라이브: settings에서 PAT 저장 → DB 암호화 확인 → 상태 표시 → 해제

🤖 Generated with [Claude Code](https://claude.com/claude-code)