### PR TITLE
feat(agent-task): Git 태스크 commit→push→PR (Phase 2c)

### DIFF
--- a/apps/api/src/data/models/unified-database.ts
+++ b/apps/api/src/data/models/unified-database.ts
@@ -364,7 +364,7 @@ export class UnifiedDatabase {
         sandboxContainerId?: string;
         workspacePath?: string;
         plan?: unknown;
-        totalTokens?: number;
+        totalTokens?: number; gitPrUrl?: string; gitPushedBranch?: string;
     }): Promise<void> {
         return this.agentTaskRepository.updateAgentTask(taskId, updates);
     }

--- a/apps/api/src/data/models/unified-database.types.ts
+++ b/apps/api/src/data/models/unified-database.types.ts
@@ -184,6 +184,10 @@ export interface AgentTask {
     git_repo_url?: string;
     /** Phase 2 Git: clone 할 base 브랜치(077) */
     git_branch?: string;
+    /** Phase 2c Git: 완료 시 생성된 PR URL(078) — 카드/상세에 링크 노출 */
+    git_pr_url?: string;
+    /** Phase 2c Git: push 된 작업 브랜치명(078) */
+    git_pushed_branch?: string;
     /** 누적 LLM 토큰(prompt+completion) — terminal 전이 시 기록(066), resume 은 통산 */
     total_tokens?: number;
     created_at: string;

--- a/apps/api/src/data/repositories/agent-task-repository.ts
+++ b/apps/api/src/data/repositories/agent-task-repository.ts
@@ -71,6 +71,8 @@ export class AgentTaskRepository extends BaseRepository {
         workspacePath?: string;
         plan?: unknown;
         totalTokens?: number;
+        gitPrUrl?: string;
+        gitPushedBranch?: string;
     }): Promise<void> {
         const sets: string[] = ['updated_at = NOW()'];
         const params: QueryParam[] = [];
@@ -119,6 +121,14 @@ export class AgentTaskRepository extends BaseRepository {
         if (updates.totalTokens !== undefined) {
             sets.push(`total_tokens = $${paramIdx++}`);
             params.push(updates.totalTokens);
+        }
+        if (updates.gitPrUrl !== undefined) {
+            sets.push(`git_pr_url = $${paramIdx++}`);
+            params.push(updates.gitPrUrl);
+        }
+        if (updates.gitPushedBranch !== undefined) {
+            sets.push(`git_pushed_branch = $${paramIdx++}`);
+            params.push(updates.gitPushedBranch);
         }
 
         params.push(taskId);

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -41,7 +41,7 @@ import { judgeGoalAchieved, buildJudgeExecutionContext } from './agent-task/goal
 import { persistArtifactSteps, runTool, isSearchTool } from './agent-task/task-steps';
 import { initWorkspaceBaseline, maybePersistCodeDiff, captureDiffOnCleanup } from './agent-task/code-diff';
 import { getSteeringRegistry, applyPendingSteering } from './agent-task/steering';
-import { setupTaskRepo } from './agent-task/git-ops';
+import { setupTaskRepo, maybePushAndOpenPR } from './agent-task/git-ops';
 import { assembleAgentTools } from './agent-task/tool-assembly';
 import { verifyCodeArtifacts } from './agent-task/deliverable-verify';
 import { buildLearningBlock } from './agent-task/task-learning';
@@ -591,6 +591,7 @@ export class AgentTaskService {
                 // 완료 시 workspace 보존(다운로드용), 실패/취소 시 삭제 직전 코드 diff 캡처(실패한 코드 작업도 변경분 검토).
                 const keepWorkspace = curStatus === 'completed';
                 if (!keepWorkspace) await captureDiffOnCleanup(taskRuntime, taskId, stepNumber).catch(() => { /* fail-open */ });
+                else if (input.gitRepoUrl) await maybePushAndOpenPR(taskRuntime, input, userId, taskId, goal); // 완료+repo: 새 브랜치 push+PR
                 await taskRuntime.cleanup(!keepWorkspace).catch((e) =>
                     logger.warn(`[AgentTask] 샌드박스 정리 실패: ${taskId} — ${e}`));
             }

--- a/apps/api/src/services/agent-task/git-ops.ts
+++ b/apps/api/src/services/agent-task/git-ops.ts
@@ -11,6 +11,7 @@
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { getUserGithubToken } from '../github-token';
+import { getUnifiedDatabase } from '../../data/models/unified-database';
 import { getAgentTaskGitRepoGuidance } from '../../prompts/agent-task-prompt';
 import { createLogger } from '../../utils/logger';
 
@@ -71,6 +72,86 @@ export async function cloneRepoToWorkspace(
     } catch (e) {
         logger.warn(`clone 실패 ${ref.owner}/${ref.repo}: ${scrub(e instanceof Error ? e.message : String(e), token)}`);
         return null;
+    }
+}
+
+const GIT_PUSH_TIMEOUT_MS = 120_000;
+
+/** git -C <cwd> <args> 실행(shell 미경유). */
+async function gitC(cwd: string, args: string[], timeoutMs = GIT_CMD_TIMEOUT_MS): Promise<string> {
+    const { stdout } = await execFileAsync('git', ['-C', cwd, ...args], { timeout: timeoutMs });
+    return stdout;
+}
+
+export interface PrResult { prUrl: string; branch: string; }
+
+/** GitHub REST 로 PR 생성. base 미지정 시 repo 기본 브랜치 조회. */
+async function createPullRequest(
+    ref: RepoRef, head: string, base: string | undefined, token: string, goal: string,
+): Promise<string> {
+    const headers: Record<string, string> = {
+        Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json', 'User-Agent': 'openmake-llm',
+    };
+    let baseBranch = base;
+    if (!baseBranch) {
+        const rr = await fetch(`https://api.github.com/repos/${ref.owner}/${ref.repo}`, { headers });
+        baseBranch = ((await rr.json()) as { default_branch?: string }).default_branch || 'main';
+    }
+    const title = `openmake: ${goal.slice(0, 72)}`;
+    const r = await fetch(`https://api.github.com/repos/${ref.owner}/${ref.repo}/pulls`, {
+        method: 'POST', headers: { ...headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, head, base: baseBranch, body: `자동 생성 — openmake 에이전트 작업.\n\n**목표**: ${goal}` }),
+    });
+    const j = (await r.json()) as { html_url?: string; message?: string };
+    if (!r.ok || !j.html_url) throw new Error(`PR API ${r.status}: ${j.message ?? 'unknown'}`);
+    return j.html_url;
+}
+
+/**
+ * 완료된 코드 작업의 변경분을 새 브랜치로 commit+push 하고 PR 을 생성한다(호스트측, 컨테이너 종료 후).
+ * 변경 없음/토큰 없음/repo 아님이면 null(fail-open — 작업은 이미 완료). **default 브랜치 직접 push 금지**:
+ * 항상 새 브랜치(openmake/task-<id>) → PR. 토큰은 push URL·PR 헤더에만 순간 사용(미영속).
+ */
+export async function commitPushAndOpenPR(
+    hostWorkdir: string, ref: RepoRef, baseBranch: string | undefined, token: string, taskId: string, goal: string,
+): Promise<PrResult | null> {
+    const branch = `openmake/task-${taskId.slice(0, 8)}`;
+    try {
+        const status = await gitC(hostWorkdir, ['status', '--porcelain']);
+        if (!status.trim()) { logger.info(`push 생략(변경 없음): ${ref.owner}/${ref.repo}`); return null; }
+        await gitC(hostWorkdir, ['checkout', '-b', branch]);
+        await gitC(hostWorkdir, ['add', '-A']);
+        await gitC(hostWorkdir, ['-c', 'user.email=agent@openmake.local', '-c', 'user.name=openmake-agent',
+            'commit', '-m', `openmake: ${goal.slice(0, 72)}`]);
+        const authUrl = `https://x-access-token:${token}@github.com/${ref.owner}/${ref.repo}`;
+        await gitC(hostWorkdir, ['push', authUrl, `${branch}:${branch}`], GIT_PUSH_TIMEOUT_MS);
+        const prUrl = await createPullRequest(ref, branch, baseBranch, token, goal);
+        logger.info(`PR 생성: ${prUrl}`);
+        return { prUrl, branch };
+    } catch (e) {
+        logger.warn(`push/PR 실패 ${ref.owner}/${ref.repo}: ${scrub(e instanceof Error ? e.message : String(e), token)}`);
+        return null;
+    }
+}
+
+/**
+ * 완료 시 push+PR 헬퍼(AgentTaskService 배선 1줄화). gitRepoUrl/토큰 없으면 no-op.
+ * 성공 시 PR URL·브랜치를 task row 에 직접 저장. 전 과정 fail-open(작업은 이미 완료).
+ */
+export async function maybePushAndOpenPR(
+    runtime: { workspacePath: string } | null,
+    input: { gitRepoUrl?: string; gitBranch?: string },
+    userId: string, taskId: string, goal: string,
+): Promise<void> {
+    if (!runtime || !input.gitRepoUrl) return;
+    const ref = parseGithubRepo(input.gitRepoUrl);
+    if (!ref) return;
+    const token = await getUserGithubToken(userId);
+    if (!token) { logger.info(`push 생략(github 토큰 없음): ${ref.owner}/${ref.repo}`); return; }
+    const pr = await commitPushAndOpenPR(runtime.workspacePath, ref, input.gitBranch, token, taskId, goal);
+    if (pr) {
+        await getUnifiedDatabase().updateAgentTask(taskId, { gitPrUrl: pr.prUrl, gitPushedBranch: pr.branch })
+            .catch((e) => logger.warn(`PR URL 저장 실패 ${taskId}: ${e instanceof Error ? e.message : e}`));
     }
 }
 

--- a/apps/web/app/(workspace)/agent-tasks/page.tsx
+++ b/apps/web/app/(workspace)/agent-tasks/page.tsx
@@ -75,6 +75,7 @@ interface ApiAgentTask {
   resumable?: boolean;
   plan?: PlanStep[] | null;
   total_tokens?: number | null;
+  git_pr_url?: string | null;
 }
 
 type TaskFilesResponse = ApiSuccess<{ files: string[] }>;
@@ -342,6 +343,16 @@ function TaskDetailModal({
                 ))}
               </ul>
             </div>
+          )}
+
+          {/* Phase 2c Git: 생성된 PR 링크 */}
+          {detail.task.git_pr_url && (
+            <a
+              href={detail.task.git_pr_url} target="_blank" rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-md border border-accent bg-accent-soft px-3 py-1.5 text-xs font-medium text-accent hover:opacity-90"
+            >
+              {t("viewPr")}
+            </a>
           )}
 
           {/* 산출물 파일 (완료 시 workspace 보존) */}

--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
-import { Bot, MessagesSquare, Telescope, Brain, Sparkles, FileCode2, LoaderCircle, Pause, CircleCheck, CircleX, Download, FileText, ShieldCheck, ThumbsUp, ThumbsDown } from "lucide-react";
+import { Bot, MessagesSquare, Telescope, Brain, Sparkles, FileCode2, LoaderCircle, Pause, CircleCheck, CircleX, Download, FileText, ShieldCheck, ThumbsUp, ThumbsDown, GitPullRequest } from "lucide-react";
 import { ThinkingTimeline } from "@/components/chat/thinking-timeline";
 import { SteeringInput } from "@/components/chat/steering-input";
 import { DiffView } from "@/components/chat/diff-view";
@@ -340,6 +340,15 @@ function AgentTaskCard({ task, approvals, taskId }: { task: AgentTaskState; appr
         )}
         {/* 코드 작업(openmake_code) diff — 채팅에서 위임한 코드 변경을 인라인으로 검토·다운로드. */}
         {task.diff && <DiffView text={task.diff} />}
+        {/* Phase 2c Git: 생성된 PR 링크. */}
+        {task.prUrl && (
+          <a
+            href={task.prUrl} target="_blank" rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-md border border-accent bg-accent-soft px-2.5 py-1 text-xs font-medium text-accent hover:opacity-90"
+          >
+            <GitPullRequest className="h-3.5 w-3.5" /> {t("agentTask.viewPr")}
+          </a>
+        )}
         {approvals && approvals.length > 0 && <InlineApprovals approvals={approvals} />}
         {/* 실행 중/일시정지 시 방향 지시(steering) 입력 — 취소·재시작 없이 교정. */}
         {(task.status === "running" || task.status === "paused") && <SteeringInput taskId={taskId} />}

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -45,6 +45,8 @@ export interface AgentTaskState {
   files?: string[];
   /** 완료 시 코드 작업(openmake_code) git diff — 있으면 카드에 DiffView 로 렌더. */
   diff?: string;
+  /** Phase 2c Git: 완료 시 생성된 PR URL — 있으면 카드에 "PR 보기" 링크. */
+  prUrl?: string;
   /** 방금 실행된 스텝 요약(4-5 실시간 스트림) — "현재 단계" 라인 표시. */
   lastStep?: { stepType: string; toolName?: string; preview?: string };
 }

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -188,11 +188,13 @@ export function useChatSocket() {
               const artifactIds: string[] = [];
               let files: string[] = [];
               let diff: string | undefined;
+              let prUrl: string | undefined;
               try {
                 const r = await ApiClient.get<{
-                  data: { task: { result?: string }; steps?: Array<{ step_type: string; content?: string }> };
+                  data: { task: { result?: string; git_pr_url?: string }; steps?: Array<{ step_type: string; content?: string }> };
                 }>(`/api/agent-tasks/${taskId}`);
                 result = r?.data?.task?.result ?? "";
+                prUrl = r?.data?.task?.git_pr_url || undefined;
                 // 코드 작업 diff 스텝 — 채팅 카드에 DiffView 로 인라인 렌더(마지막 diff 사용).
                 diff = (r?.data?.steps ?? []).filter((s) => s.step_type === "diff").pop()?.content || undefined;
                 // deliverable 아티팩트 — store 등록 후 카드가 칩으로 렌더.
@@ -211,7 +213,7 @@ export function useChatSocket() {
                 const f = await ApiClient.get<{ data: { files: string[] } }>(`/api/agent-tasks/${taskId}/files`);
                 files = f?.data?.files ?? [];
               } catch { /* 파일 없음 */ }
-              merge({ result, artifactIds, files, diff, lastStep: undefined }, undefined);
+              merge({ result, artifactIds, files, diff, prUrl, lastStep: undefined }, undefined);
             })();
           } else if (status === "paused") {
             // 승인 대기 — 해당 task 의 pending approval 조회 → 카드에 인라인 승인 버튼.

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -334,7 +334,8 @@
       "title": "Agent task",
       "turn": "Turn {turn}",
       "goal": "Goal",
-      "outputs": "Outputs"
+      "outputs": "Outputs",
+      "viewPr": "View PR"
     },
     "research": {
       "inProgress": "Deep research in progress",
@@ -742,7 +743,8 @@
       "run": "Run from this template",
       "delete": "Delete",
       "started": "Task started from template."
-    }
+    },
+    "viewPr": "View PR"
   },
   "customAgents": {
     "pageTitle": "Custom Agents",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -334,7 +334,8 @@
       "title": "エージェントタスク",
       "turn": "ターン {turn}",
       "goal": "目標",
-      "outputs": "成果物"
+      "outputs": "成果物",
+      "viewPr": "PR を表示"
     },
     "research": {
       "inProgress": "ディープリサーチ実行中",
@@ -742,7 +743,8 @@
       "run": "このテンプレートで実行",
       "delete": "削除",
       "started": "テンプレートからタスクを開始しました。"
-    }
+    },
+    "viewPr": "PR を表示"
   },
   "customAgents": {
     "pageTitle": "カスタムエージェント",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -334,7 +334,8 @@
       "title": "에이전트 작업",
       "turn": "턴 {turn}",
       "goal": "목표",
-      "outputs": "산출물"
+      "outputs": "산출물",
+      "viewPr": "PR 보기"
     },
     "research": {
       "inProgress": "딥 리서치 진행 중",
@@ -742,7 +743,8 @@
       "run": "이 템플릿으로 실행",
       "delete": "삭제",
       "started": "템플릿으로 작업을 시작했습니다."
-    }
+    },
+    "viewPr": "PR 보기"
   },
   "customAgents": {
     "pageTitle": "커스텀 에이전트",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -334,7 +334,8 @@
       "title": "智能体任务",
       "turn": "第 {turn} 轮",
       "goal": "目标",
-      "outputs": "产出"
+      "outputs": "产出",
+      "viewPr": "查看 PR"
     },
     "research": {
       "inProgress": "深度研究进行中",
@@ -742,7 +743,8 @@
       "run": "使用此模板运行",
       "delete": "删除",
       "started": "已从模板启动任务。"
-    }
+    },
+    "viewPr": "查看 PR"
   },
   "customAgents": {
     "pageTitle": "自定义智能体",

--- a/db/migrations/078_agent_task_pr.sql
+++ b/db/migrations/078_agent_task_pr.sql
@@ -1,0 +1,11 @@
+-- 078: Agent Task Git PR (Phase 2c) — 완료된 코드 작업의 PR 결과
+--
+-- Git 태스크(077 repo)가 완료되면 호스트가 변경분을 새 브랜치로 push 하고 PR 을 생성한다.
+-- 생성된 PR URL·브랜치명을 보관해 채팅 카드/상세에서 "PR 보기" 링크로 노출한다.
+-- 멱등(ADD COLUMN IF NOT EXISTS). 수동 적용(cli.ts migrate).
+
+ALTER TABLE agent_tasks ADD COLUMN IF NOT EXISTS git_pr_url TEXT;
+ALTER TABLE agent_tasks ADD COLUMN IF NOT EXISTS git_pushed_branch TEXT;
+
+COMMENT ON COLUMN agent_tasks.git_pr_url IS 'Phase 2c: 완료 시 생성된 Pull Request URL(있으면 카드에 링크).';
+COMMENT ON COLUMN agent_tasks.git_pushed_branch IS 'Phase 2c: push 된 작업 브랜치명(openmake/task-<id>).';


### PR DESCRIPTION
## 개요

Phase 2c(마무리) — Git 태스크(repo clone)가 완료되면 호스트가 변경분을 **새 브랜치로 commit+push하고 GitHub PR을 생성**. 위임→수정→diff→**PR** 루프 완결.

## 보안 (토큰 비주입 아키텍처, 계속)

commit/push/PR은 **호스트 전용**(컨테이너 종료 후 finally). 토큰은 push URL·PR API 헤더에만 순간 사용(미영속). **default 브랜치 직접 push 금지 — 항상 새 브랜치(`openmake/task-<id>`) → PR**(Codex 패턴). 에러 로깅 토큰 스크럽.

## 변경

- `db/migrations/078`: `agent_tasks.git_pr_url/git_pushed_branch` (⚠️ 수동 적용)
- `git-ops.ts`: `commitPushAndOpenPR`(status→새 브랜치→commit→push→PR)·`createPullRequest`(base 미지정 시 default_branch 조회, GitHub REST)·`maybePushAndOpenPR`(가드+PR URL 저장). 전 과정 fail-open(작업은 이미 완료)
- `AgentTaskService` finally: 완료+repo 시 `maybePushAndOpenPR`(1줄, workspace 삭제 전, 600줄 가드 내)
- `updateAgentTask` gitPrUrl/gitPushedBranch(repository+wrapper), AgentTask 타입 git_pr_url
- 프론트: `AgentTaskState.prUrl` + use-chat-socket 추출 + **채팅 카드/agent-tasks 상세 "PR 보기" 링크**
- 테스트 git-ops 가드, i18n viewPr

## 검증

- 백엔드 테스트(77개)·`tsc`(api+web)·`lint`·`build` 통과
- ⚠️ **배포 전 마이그레이션 078 수동 적용**
- 배포 후 라이브: 쓰기 권한 repo로 태스크→실제 PR 생성 + 토큰 부재 실측(아래 코멘트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)