### PR TITLE
fix(agent-task): 채팅 카드 PR 링크 지연 재조회

### DIFF
--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -191,10 +191,19 @@ export function useChatSocket() {
               let prUrl: string | undefined;
               try {
                 const r = await ApiClient.get<{
-                  data: { task: { result?: string; git_pr_url?: string }; steps?: Array<{ step_type: string; content?: string }> };
+                  data: { task: { result?: string; git_pr_url?: string; git_repo_url?: string }; steps?: Array<{ step_type: string; content?: string }> };
                 }>(`/api/agent-tasks/${taskId}`);
                 result = r?.data?.task?.result ?? "";
                 prUrl = r?.data?.task?.git_pr_url || undefined;
+                // Git 태스크 PR 은 완료 표시 직후(finally, ~수초) 생성된다 — 완료 시점 조회엔 아직
+                // 없을 수 있으므로, repo 태스크인데 PR 이 비면 한 번 지연 재조회해 링크를 채운다.
+                if (r?.data?.task?.git_repo_url && !prUrl) {
+                  setTimeout(() => {
+                    void ApiClient.get<{ data: { task: { git_pr_url?: string } } }>(`/api/agent-tasks/${taskId}`)
+                      .then((r2) => { const p = r2?.data?.task?.git_pr_url; if (p) merge({ prUrl: p }, undefined); })
+                      .catch(() => { /* noop */ });
+                  }, 10_000);
+                }
                 // 코드 작업 diff 스텝 — 채팅 카드에 DiffView 로 인라인 렌더(마지막 diff 사용).
                 diff = (r?.data?.steps ?? []).filter((s) => s.step_type === "diff").pop()?.content || undefined;
                 // deliverable 아티팩트 — store 등록 후 카드가 칩으로 렌더.


### PR DESCRIPTION
## 개요

Git 태스크(Phase 2c)의 PR은 완료 표시 직후(finally 블록, ~수초) 생성되므로, 'completed' WS 이벤트에서 상세를 조회하는 채팅 카드엔 아직 `git_pr_url`이 비어 **PR 링크가 즉시 안 뜰 수 있었다**(재로드 시 표시됨). repo 태스크인데 PR이 비면 10초 후 한 번 재조회해 링크를 채운다. (`/agent-tasks` 상세는 새로 로드하므로 이미 정상.)

라이브 검증(실제 PR 생성 — riskpw/omk-git-test에 pull/1 생성, 컨테이너 토큰 부재 실측, 이후 정리)에서 발견한 UX 레이스.

순수 프론트, `tsc`·`lint`·`build` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)