### PR TITLE
feat(agent-task): composer repo 자동완성 (Git UX)

### DIFF
--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -33,6 +33,7 @@ import { createAgentTaskSchema, type CreateAgentTaskInput } from '../schemas/age
 import { extractAttachedDocuments } from '../services/chat-service/doc-extractor';
 import { getApprovalRegistry } from '../services/task-sandbox/approval-gate';
 import { getSteeringRegistry } from '../services/agent-task/steering';
+import { listUserRepos } from '../services/agent-task/git-ops';
 import { dispatchAgentTask, getAgentTaskQueue } from '../services/agent-task/task-queue';
 import { safeRealWorkspacePath, listWorkspaceFilesAt } from '../services/task-sandbox/sandbox';
 import { basename } from 'path';
@@ -129,6 +130,16 @@ router.get('/', asyncHandler(async (req: Request, res: Response) => {
     const db = getUnifiedDatabase();
     const tasks = await db.getUserAgentTasks(String(req.user!.id));
     res.json(success({ tasks: tasks.map(t => toPublicTask(t as unknown as Record<string, unknown>)), total: tasks.length }));
+}));
+
+/**
+ * GET /api/agent-tasks/github/repos
+ * 저장된 GitHub 토큰으로 사용자의 repo 목록(push 권한) 조회 — composer repo 자동완성용.
+ * 토큰 미연결이면 빈 배열. ⚠️ GET /:taskId 보다 먼저 등록(github 가 taskId 로 매칭되지 않게).
+ */
+router.get('/github/repos', asyncHandler(async (req: Request, res: Response) => {
+    const repos = await listUserRepos(String(req.user!.id));
+    res.json(success({ repos }));
 }));
 
 /**

--- a/apps/api/src/services/agent-task/git-ops.ts
+++ b/apps/api/src/services/agent-task/git-ops.ts
@@ -28,6 +28,29 @@ export interface RepoRef {
     cleanUrl: string;
 }
 
+/**
+ * 저장된 토큰으로 사용자의 GitHub repo 목록 조회(composer 자동완성용). push 권한 있는 것만
+ * (permissions.push) 필터 — clone→편집→PR 대상으로 의미 있는 repo. 실패 시 빈 배열(fail-open).
+ * 최근 업데이트순 최대 100개.
+ */
+export async function listUserRepos(userId: string): Promise<Array<{ fullName: string; url: string; private: boolean }>> {
+    const token = await getUserGithubToken(userId);
+    if (!token) return [];
+    try {
+        const r = await fetch('https://api.github.com/user/repos?per_page=100&sort=updated&affiliation=owner,collaborator,organization_member', {
+            headers: { Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json', 'User-Agent': 'openmake-llm' },
+        });
+        if (!r.ok) return [];
+        const repos = (await r.json()) as Array<{ full_name: string; html_url: string; private: boolean; permissions?: { push?: boolean } }>;
+        return (Array.isArray(repos) ? repos : [])
+            .filter((x) => x?.permissions?.push !== false)
+            .map((x) => ({ fullName: x.full_name, url: x.html_url, private: x.private }));
+    } catch (e) {
+        logger.warn(`repo 목록 조회 실패 (user ${userId}): ${e instanceof Error ? e.message : e}`);
+        return [];
+    }
+}
+
 /** repoUrl 파싱 — https://github.com/owner/repo(.git) 만 허용(ssh·타 호스트 거절). 아니면 null. */
 export function parseGithubRepo(repoUrl: string): RepoRef | null {
     const m = /^https:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?\/?$/.exec((repoUrl || '').trim());

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -27,6 +27,7 @@ import { useAppStore, INTERCEPT_MODE_KEYS } from "@/lib/store";
 import { NotebookPicker } from "./notebook-picker";
 import { useChatSocket } from "@/lib/use-chat-socket";
 import { fetchModels } from "@/lib/models-api";
+import { ApiClient } from "@/lib/api-client";
 import {
   fetchSkills,
   groupSkillsByCategory,
@@ -221,6 +222,14 @@ export function Composer() {
     enabled: slashCandidate,
     staleTime: 30_000,
   });
+  // Phase 2 Git: 에이전트 모드 시 사용자의 GitHub repo 목록(push 권한) 조회 → repo 입력 자동완성.
+  const { data: repoData } = useQuery({
+    queryKey: ["github-repos"],
+    queryFn: () => ApiClient.get<{ data: { repos: Array<{ fullName: string; url: string }> } }>("/api/agent-tasks/github/repos"),
+    enabled: agentTaskMode,
+    staleTime: 300_000,
+  });
+  const repoSuggestions = repoData?.data?.repos ?? [];
   // 검색어 없으면("/") 카테고리 그룹핑(전체), 있으면 평면 검색 목록
   const slashGrouped = slashDebounced.trim() === "";
   const rawSlashSkills: SkillSummary[] = slashCandidate ? slashSkillsData ?? [] : [];
@@ -522,8 +531,16 @@ export function Composer() {
               value={agentRepoUrl}
               onChange={(e) => setAgentRepoUrl(e.target.value)}
               placeholder="https://github.com/org/repo"
+              list="agent-repo-suggestions"
               className="min-w-0 flex-1 rounded-md border border-border bg-surface-2 px-2 py-1 font-mono text-xs text-fg-1"
             />
+            {repoSuggestions.length > 0 && (
+              <datalist id="agent-repo-suggestions">
+                {repoSuggestions.map((r) => (
+                  <option key={r.url} value={r.url}>{r.fullName}</option>
+                ))}
+              </datalist>
+            )}
           </div>
         )}
         {/* 승인 3모드(Manual/Auto/Skip) — 에이전트 작업 위임 시 이 실행의 도구 승인 정책 선택. */}


### PR DESCRIPTION
## 개요

Phase 2 Git 기능 UX 개선 — Git 태스크 위임 시 repo URL을 직접 붙여넣는 대신, 저장된 GitHub 토큰으로 **사용자의 repo 목록을 불러와 자동완성**한다. 오타·탐색 문제 해소.

## 변경

- `git-ops.ts`: `listUserRepos(userId)` — GET /user/repos(push 권한 필터, 최근 업데이트순 100). fail-open
- `routes`: `GET /api/agent-tasks/github/repos` (⚠️ GET /:taskId 보다 먼저 등록 — 'github'가 taskId로 매칭되지 않게). 토큰 미연결이면 빈 배열
- 프론트: composer 에이전트 모드 시 repo 목록 useQuery → repo 입력에 `<datalist>` 자동완성

토큰 미연결이면 빈 목록 → 기존 free-text 입력 그대로(무해). `tsc`·`lint`·`build` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)