### PR TITLE
fix(agent-task): 산출물 다운로드 토큰 만료 시 실패 수정

### DIFF
--- a/apps/web/app/(workspace)/agent-tasks/page.tsx
+++ b/apps/web/app/(workspace)/agent-tasks/page.tsx
@@ -362,13 +362,16 @@ function TaskDetailModal({
               <ul className="space-y-1">
                 {files.map((f) => (
                   <li key={f} className="text-xs">
-                    <a
-                      href={`/api/agent-tasks/${taskId}/files/download?path=${encodeURIComponent(f)}`}
+                    <button
+                      type="button"
+                      onClick={() => void ApiClient.download(
+                        `/api/agent-tasks/${taskId}/files/download?path=${encodeURIComponent(f)}`,
+                        f.split("/").pop() || f,
+                      ).catch((e) => alert(t("downloadFailed", { error: e instanceof Error ? e.message : "error" })))}
                       className="font-mono text-accent hover:underline"
-                      target="_blank" rel="noopener noreferrer"
                     >
                       {f}
-                    </a>
+                    </button>
                   </li>
                 ))}
               </ul>

--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -326,14 +326,18 @@ function AgentTaskCard({ task, approvals, taskId }: { task: AgentTaskState; appr
             </div>
             <div className="flex flex-wrap gap-2">
               {task.files.map((f) => (
-                <a
+                <button
                   key={f}
-                  href={`/api/agent-tasks/${taskId ?? ""}/files/download?path=${encodeURIComponent(f)}`}
-                  target="_blank" rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 rounded-md border border-border bg-surface-2 px-2.5 py-1 text-xs font-medium text-fg-2 hover:bg-surface-3"
+                  type="button"
+                  disabled={!taskId}
+                  onClick={() => void ApiClient.download(
+                    `/api/agent-tasks/${taskId ?? ""}/files/download?path=${encodeURIComponent(f)}`,
+                    f.split("/").pop() || f,
+                  ).catch((e) => alert(t("agentTask.downloadFailed", { error: e instanceof Error ? e.message : "error" })))}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-border bg-surface-2 px-2.5 py-1 text-xs font-medium text-fg-2 hover:bg-surface-3 disabled:opacity-50"
                 >
                   <FileText className="h-3 w-3" /> {f}
-                </a>
+                </button>
               ))}
             </div>
           </div>

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -335,7 +335,8 @@
       "turn": "Turn {turn}",
       "goal": "Goal",
       "outputs": "Outputs",
-      "viewPr": "View PR"
+      "viewPr": "View PR",
+      "downloadFailed": "Download failed: {error}"
     },
     "research": {
       "inProgress": "Deep research in progress",
@@ -744,7 +745,8 @@
       "delete": "Delete",
       "started": "Task started from template."
     },
-    "viewPr": "View PR"
+    "viewPr": "View PR",
+    "downloadFailed": "Download failed: {error}"
   },
   "customAgents": {
     "pageTitle": "Custom Agents",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -335,7 +335,8 @@
       "turn": "ターン {turn}",
       "goal": "目標",
       "outputs": "成果物",
-      "viewPr": "PR を表示"
+      "viewPr": "PR を表示",
+      "downloadFailed": "ダウンロードに失敗しました: {error}"
     },
     "research": {
       "inProgress": "ディープリサーチ実行中",
@@ -744,7 +745,8 @@
       "delete": "削除",
       "started": "テンプレートからタスクを開始しました。"
     },
-    "viewPr": "PR を表示"
+    "viewPr": "PR を表示",
+    "downloadFailed": "ダウンロードに失敗しました: {error}"
   },
   "customAgents": {
     "pageTitle": "カスタムエージェント",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -335,7 +335,8 @@
       "turn": "턴 {turn}",
       "goal": "목표",
       "outputs": "산출물",
-      "viewPr": "PR 보기"
+      "viewPr": "PR 보기",
+      "downloadFailed": "다운로드 실패: {error}"
     },
     "research": {
       "inProgress": "딥 리서치 진행 중",
@@ -744,7 +745,8 @@
       "delete": "삭제",
       "started": "템플릿으로 작업을 시작했습니다."
     },
-    "viewPr": "PR 보기"
+    "viewPr": "PR 보기",
+    "downloadFailed": "다운로드 실패: {error}"
   },
   "customAgents": {
     "pageTitle": "커스텀 에이전트",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -335,7 +335,8 @@
       "turn": "第 {turn} 轮",
       "goal": "目标",
       "outputs": "产出",
-      "viewPr": "查看 PR"
+      "viewPr": "查看 PR",
+      "downloadFailed": "下载失败: {error}"
     },
     "research": {
       "inProgress": "深度研究进行中",
@@ -744,7 +745,8 @@
       "delete": "删除",
       "started": "已从模板启动任务。"
     },
-    "viewPr": "查看 PR"
+    "viewPr": "查看 PR",
+    "downloadFailed": "下载失败: {error}"
   },
   "customAgents": {
     "pageTitle": "自定义智能体",

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -112,9 +112,44 @@ async function request<T>(endpoint: string, options: ApiRequestOptions = {}, _is
   return json as T;
 }
 
+/**
+ * 인증(401 자동 refresh) 포함 바이너리 fetch — 파일 다운로드용. plain <a href> 다운로드는
+ * ApiClient 를 안 거쳐 15분 만료 시 refresh 없이 401 로 실패한다(사용자 "다운로드 안 됨" 결함).
+ */
+async function requestBlob(endpoint: string, _isRetry = false): Promise<Blob> {
+  const res = await fetch(endpoint, { credentials: "include" });
+  if (!res.ok) {
+    if (
+      res.status === 401 &&
+      !_isRetry &&
+      !SKIP_REFRESH_ENDPOINTS.some((ep) => endpoint === ep || endpoint.startsWith(ep + "?"))
+    ) {
+      const refreshed = await refreshOnce();
+      if (refreshed) return requestBlob(endpoint, true);
+      if (typeof window !== "undefined" && window.location.pathname !== "/login") {
+        window.location.href = "/login";
+      }
+    }
+    throw new ApiError(res.status, `다운로드 실패 (${res.status})`, null);
+  }
+  return res.blob();
+}
+
 export const ApiClient = {
   get: <T>(endpoint: string, options: ApiRequestOptions = {}) =>
     request<T>(endpoint, { ...options, method: "GET" }),
+  /** 인증 포함 파일 다운로드 — 만료 시 자동 refresh 후 blob 저장(plain <a> 대비 15분 만료 무관). */
+  download: async (endpoint: string, filename: string): Promise<void> => {
+    const blob = await requestBlob(endpoint);
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 10_000);
+  },
   post: <T>(endpoint: string, body?: unknown, options: ApiRequestOptions = {}) =>
     request<T>(endpoint, {
       ...options,


### PR DESCRIPTION
## 문제

사용자 보고: 파일이 생성돼도 다운로드가 안 되는 경우가 있음.

## 원인

산출물 다운로드 링크가 **plain `<a href target="_blank">`** 라 ApiClient를 안 거침. `auth_token` 쿠키는 **15분 수명**이고, ApiClient 호출은 401 시 자동 refresh(single-flight)하지만 **링크 네비게이션은 refresh를 못 타서 만료 후 401로 실패**한다. → 페이지/카드를 열어두고 나중에 클릭하면 다운로드 실패("자동 로그아웃" 결함과 동일 계열, api-client 주석에 명시). `target="_blank"` 팝업 플레이키함도 동반.

(다운로드 라우트·헤더·프록시·CORS는 정상 — 앞서 fresh 토큰으로 다 확인됨. 문제는 만료 토큰 경로.)

## 수정

- `packages/api-client`: `requestBlob`(401 자동 refresh 재시도 포함) + **`ApiClient.download(endpoint, filename)`** — 인증·갱신 후 blob을 받아 프로그램 다운로드(`a.download`)
- 프론트: 채팅 카드·agent-tasks 상세의 `<a href>` → `<button onClick={ApiClient.download(...)}>`. 파일명은 basename, 실패 시 alert
- i18n `downloadFailed`

## 검증

- `tsc`·`lint`·`build` 통과
- 배포 후 라이브: **만료된 토큰으로 다운로드 → 자동 refresh 후 성공** 확인(아래 코멘트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)