### PR TITLE
fix(agent-task): 산출물 목록에서 숨김 파일 제외 (.verify_* 등)

### DIFF
--- a/apps/api/src/services/task-sandbox/sandbox.ts
+++ b/apps/api/src/services/task-sandbox/sandbox.ts
@@ -367,7 +367,8 @@ export async function dirSizeBytes(root: string, cap = Number.MAX_SAFE_INTEGER):
 /**
  * 주어진 workspace 디렉토리의 전체 파일을 상대경로로 재귀 나열 (산출물 다운로드 엔드포인트용).
  * 라이브 TaskSandbox 인스턴스 없이도 동작(task 완료 후 workspace_path 로 호출).
- * `.git` 은 diff 캡처(code-diff)의 내부 메타데이터라 산출물 목록에서 제외한다.
+ * **숨김 파일/디렉토리(dotfile) 제외** — `.git`(diff 캡처 메타), `.verify_*.py`(코드검증 임시),
+ * 기타 시스템 dotfile 이 산출물 목록에 새어 "이상한 파일" 로 다운로드되던 것을 막는다.
  */
 export async function listWorkspaceFilesAt(root: string, maxFiles = 1000): Promise<string[]> {
     const out: string[] = [];
@@ -377,9 +378,10 @@ export async function listWorkspaceFilesAt(root: string, maxFiles = 1000): Promi
         try { entries = await readdir(dir, { withFileTypes: true }); } catch { return; }
         for (const e of entries) {
             if (out.length >= maxFiles) return;
+            if (e.name.startsWith('.')) continue; // 숨김 파일/디렉토리(.git·.verify_* 등) 제외
             const full = join(dir, e.name);
             if (e.isDirectory()) {
-                if (e.name !== '.git') await walk(full);
+                await walk(full);
             } else {
                 out.push(relative(root, full));
             }


### PR DESCRIPTION
## 개요

산출물 다운로드 목록이 `.git`만 제외해, **코드검증 임시파일 `.verify_*.py` 등 시스템 dotfile이 목록에 새어** 사용자가 "이상한 파일"로 받게 됐다. 숨김 파일/디렉토리(dotfile) 전체를 제외한다.

## 변경

- `listWorkspaceFilesAt`: `e.name.startsWith('.')` 제외(재귀 walk도 dotdir 스킵). `.git`·`.verify_*`·`.env` 등 모두 제외, 실제 산출물(비-dotfile)만 노출
- 테스트: `.verify_0.py`·`.env`·`.git` 제외 확인

## 참고 (별건 — 다운로드 파일 손상)

사용자가 보고한 "docx가 Word로 안 열림"은 **PR #320에서 이미 해결**됨(옛 `<a href>` 다운로드가 토큰 만료 시 401 에러 JSON을 파일로 저장 → ApiClient.download로 교체). 이번 진단에서 실측 확인:
- 다운로드 바이트가 :52416·:3000·외부 Caddy 전부 동일·유효(md5 일치, PK)
- 외부 UI에서 report.docx 다운로드 → 36,679 bytes, Microsoft OOXML, 기준선 바이트 동일 ✅

즉 손상은 전송/현재코드 문제가 아니라 옛 만료-토큰 경로였고 이미 fixed·외부 반영됨. 여전히 보이면 하드 리프레시(캐시된 옛 번들) 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)