### PR TITLE
fix(artifact): 다운로드 파일명이 UUID 로 저장되던 문제

### DIFF
--- a/apps/web/lib/artifact-download.ts
+++ b/apps/web/lib/artifact-download.ts
@@ -39,8 +39,14 @@ const LANG_EXT: Record<string, string> = {
   css: "css",
 };
 
+/** UUID(v4) 형태 문자열 — title 이 없어 artifact id(UUID)로 폴백된 경우 파일명으로 부적합. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 function safeName(title: string): string {
-  return (title || "artifact").replace(/[^\w가-힣.-]+/g, "_").slice(0, 60) || "artifact";
+  const t = (title || "").trim();
+  // 빈 값 또는 UUID(제목 없이 id 로 폴백된 케이스)면 사람이 못 알아보는 파일명이 되므로 'artifact' 로.
+  const base = !t || UUID_RE.test(t) ? "artifact" : t;
+  return base.replace(/[^\w가-힣.-]+/g, "_").slice(0, 60) || "artifact";
 }
 
 function extFor(kind: string, lang: string | null): string {


### PR DESCRIPTION
## 문제

사용자 보고: 채팅에서 아티팩트 **'파일로 받기'** 로 다운로드하면 파일명이 `cfd46a7a-9211-43a1-990f-9a75b9acf8f3` 같은 **UUID**로 저장돼, 확장자/이름이 이상해 Word 등에서 안 열리는 "이상한 파일"이 됨.

## 원인

`downloadArtifact` 가 파일명을 `${safeName(title)}.${ext}` 로 짓는데, 아티팩트 title 이 없어 **artifact id(UUID)로 폴백**된 케이스(`title: … ?? id`)에서 title=UUID → 파일명=UUID.ext.

## 수정

`safeName` 이 **빈 값·UUID(v4) 형태 title 을 'artifact' 로 대체** → 어느 경로든 사람이 알아보는 파일명(예: `artifact.html`). 정상 title 은 그대로.

- `lib/artifact-download.ts`: UUID 정규식 가드 + 빈 title 폴백
- 검증: UUID/빈 title → 'artifact', 정상 title 유지

## 남은 확인(사용자)

이 수정으로 **다운로드 파일명**은 정상화되지만, 만약 채팅의 **아티팩트 칩 이름 자체가 UUID로 표시**된다면 title 이 UUID로 세팅되는 소스 버그가 있는 것이라 그 근본도 잡을 예정. (하드 리프레시 후 재확인 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)