### PR TITLE
feat(agent-task): 재생 가능 절차 스킬 (#1 Procedural Skill)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -789,6 +789,12 @@ AGENT_TASK_TIMEOUT_MS=600000
 # AGENT_TASK_LEARNING_MAX_LESSONS=3
 # AGENT_TASK_LEARNING_MIN_SIMILARITY=0.2
 
+# Agent Task — 재생 가능 절차 스킬(#1 Procedural Skill). 성공한 액션 시퀀스를 skill_save 로 저장하고
+# 유사 goal 에서 skill_run 으로 LLM 재추론 없이 재생. agent_skills(category='procedural') 재사용, 신규 테이블 없음.
+# skill_run 은 코드/브라우저 실행이라 승인 게이트상 high-risk. 기본 OFF.
+# AGENT_TASK_PROCEDURAL_SKILLS=true
+# AGENT_TASK_PROCEDURAL_MAX_SUGGEST=3
+
 # Agent Task — 산출물 검증 모드: syntax(기본, 문법만) | run(샌드박스 실행 후 exit code 검사).
 # AGENT_TASK_VERIFY_MODE=syntax
 

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1151,6 +1151,13 @@ export const AGENT_TASK_LIMITS = {
     LEARNING_MAX_LESSONS: parseInt(process.env.AGENT_TASK_LEARNING_MAX_LESSONS || '3', 10),
     /** goal 유사도(자카드) 임계 — 미만은 무관 작업으로 간주(기본 0.2). */
     LEARNING_MIN_SIMILARITY: parseFloat(process.env.AGENT_TASK_LEARNING_MIN_SIMILARITY || '0.2'),
+    /** 재생 가능 절차 스킬(#1 Procedural Skill) — 성공한 액션 시퀀스를 저장(skill_save)하고
+     *  유사 goal 에서 LLM 재추론 없이 재생(skill_run). agent_skills(category='procedural') 재사용,
+     *  신규 테이블 없음. skill_run 은 코드/브라우저를 실행하므로 승인 게이트상 high-risk. 기본 OFF.
+     *  AGENT_TASK_PROCEDURAL_SKILLS=true 로 활성. */
+    PROCEDURAL_SKILLS_ENABLED: process.env.AGENT_TASK_PROCEDURAL_SKILLS === 'true',
+    /** 재사용 후보로 system 에 제안할 절차 스킬 최대 건수(기본 3). */
+    PROCEDURAL_MAX_SUGGEST: parseInt(process.env.AGENT_TASK_PROCEDURAL_MAX_SUGGEST || '3', 10),
     /** 산출물 검증 모드(Phase 5-3): 'syntax'(기본 — py_compile·node --check) | 'run'(샌드박스에서
      *  실제 실행 후 exit code 검사 — network none·자원캡 격리라 안전하나 부작용 있는 코드는 실행됨). */
     VERIFY_MODE: (process.env.AGENT_TASK_VERIFY_MODE === 'run' ? 'run' : 'syntax') as 'syntax' | 'run',

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -21,7 +21,7 @@ import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { getUnifiedDatabase } from '../data/models/unified-database';
 import { AGENT_TASK_LIMITS, AGENT_SPAWN } from '../config/runtime-limits';
 import { emitAgentTaskProgress } from '../utils/event-bus';
-import { getAgentTaskSystemPrompt, getAgentTaskDeliverableNudge, getAgentTaskStuckNudge, getAgentTaskBrowserLimitNudge, getTaskSandboxGuidance, getAgentTaskUploadedFilesNote, getAgentTaskVerifyFailedNudge, AGENT_TASK_INCOMPLETE_MARKER } from '../prompts/agent-task-prompt';
+import { getAgentTaskDeliverableNudge, getAgentTaskStuckNudge, getAgentTaskBrowserLimitNudge, getTaskSandboxGuidance, getAgentTaskUploadedFilesNote, getAgentTaskVerifyFailedNudge, AGENT_TASK_INCOMPLETE_MARKER } from '../prompts/agent-task-prompt';
 import { extractAndStripArtifacts } from '../llm/artifact-parser';
 import { getPushService } from './PushService';
 import { createLogger } from '../utils/logger';
@@ -45,9 +45,7 @@ import { setupTaskRepo, maybePushAndOpenPR } from './agent-task/git-ops';
 import { recoverTextToolCalls } from './agent-task/text-tool-calls';
 import { assembleAgentTools } from './agent-task/tool-assembly';
 import { verifyCodeArtifacts } from './agent-task/deliverable-verify';
-import { buildLearningBlock } from './agent-task/task-learning';
-import { buildProceduralSkillBlock } from './agent-task/procedural-skill';
-import { buildSkillPromptBlock, AGENT_TASK_SKILL_AGENT_ID } from './agent-task/skill-block';
+import { buildAgentTaskSystemContent, AGENT_TASK_SKILL_AGENT_ID } from './agent-task/skill-block';
 
 // 기존 import 호환 재노출 — 타입/에러는 services/agent-task/types 로 분리 (파일 크기 가드).
 export { AgentTaskAbort, type AgentTaskRunInput, type AgentTaskInputFile } from './agent-task/types';
@@ -162,10 +160,7 @@ export class AgentTaskService {
                 : [
                     {
                         role: 'system',
-                        content: getAgentTaskSystemPrompt()
-                            + (await buildSkillPromptBlock(userId))
-                            + (await buildLearningBlock(userId, goal, taskId))
-                            + (await buildProceduralSkillBlock(userId, goal)),
+                        content: await buildAgentTaskSystemContent(userId, goal, taskId),
                     },
                     { role: 'user', content: goal },
                 ];

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -46,6 +46,7 @@ import { recoverTextToolCalls } from './agent-task/text-tool-calls';
 import { assembleAgentTools } from './agent-task/tool-assembly';
 import { verifyCodeArtifacts } from './agent-task/deliverable-verify';
 import { buildLearningBlock } from './agent-task/task-learning';
+import { buildProceduralSkillBlock } from './agent-task/procedural-skill';
 import { buildSkillPromptBlock, AGENT_TASK_SKILL_AGENT_ID } from './agent-task/skill-block';
 
 // 기존 import 호환 재노출 — 타입/에러는 services/agent-task/types 로 분리 (파일 크기 가드).
@@ -163,7 +164,8 @@ export class AgentTaskService {
                         role: 'system',
                         content: getAgentTaskSystemPrompt()
                             + (await buildSkillPromptBlock(userId))
-                            + (await buildLearningBlock(userId, goal, taskId)),
+                            + (await buildLearningBlock(userId, goal, taskId))
+                            + (await buildProceduralSkillBlock(userId, goal)),
                     },
                     { role: 'user', content: goal },
                 ];

--- a/apps/api/src/services/agent-task/procedural-skill.ts
+++ b/apps/api/src/services/agent-task/procedural-skill.ts
@@ -1,0 +1,163 @@
+/**
+ * Procedural Skill (재생 가능 절차 스킬) — #1 워크플로 학습.
+ *
+ * 성공한 task 의 실행 절차(브라우저 액션 시퀀스 / 스크립트)를 파라미터화해 저장(skill_save)하고,
+ * 유사 goal 의 새 task 에서 LLM 재추론 없이 재생(skill_run)한다. 선언형 프롬프트 스킬과 같은
+ * `agent_skills` 테이블에 category='procedural' 로 공존한다 — 신규 테이블·마이그레이션 없음.
+ *
+ * 설계 원칙(task-learning 과 동일):
+ *  - 무-LLM·결정적: 매칭은 goalSimilarity(키워드 자카드) 재사용.
+ *  - 절대 throw 하지 않음(블록 생성): 실패 시 '' 반환(작업 시작을 막지 않음).
+ *  - 소유자 격리: 재생은 본인 소유 스킬만.
+ *
+ * @module services/agent-task/procedural-skill
+ */
+import { SkillRepository } from '../../data/repositories/skill-repository';
+import { getPool } from '../../data/models/unified-database';
+import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
+import { goalSimilarity } from './task-learning';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('ProceduralSkill');
+
+/** 절차 스킬을 선언형 스킬과 구분하는 카테고리. */
+export const PROCEDURAL_CATEGORY = 'procedural';
+
+/** 재생 가능 절차 스펙 — agent_skills.content 에 JSON 으로 저장. */
+export interface ProceduralSpec {
+    kind: 'browser' | 'script';
+    /** 이 절차가 달성하는 목표(원문) — 향후 매칭 기준. */
+    goal: string;
+    /** 재생 시 {{name}} 치환에 쓰는 파라미터 이름 목록. */
+    params?: string[];
+    /** kind='browser': browser 도구와 동일한 액션 배열 + 허용 도메인. */
+    actions?: unknown[];
+    allowlist?: string[];
+    /** kind='script': 언어 + 코드. */
+    lang?: 'bash' | 'python';
+    code?: string;
+}
+
+interface MatchedSkill {
+    id: string;
+    name: string;
+    goal: string;
+    params: string[];
+    sim: number;
+}
+
+function getRepo(): SkillRepository {
+    return new SkillRepository(getPool());
+}
+
+/** PURE: 텍스트 내 {{name}} 를 params 로 치환. 미정의 키는 원문 보존. */
+export function applyParams(text: string, params: Record<string, string>): string {
+    return text.replace(/\{\{\s*([\w.-]+)\s*\}\}/g, (m, k) => (k in params ? params[k] : m));
+}
+
+/** PURE: 문자열 리프에만 재귀 치환(JSON 구조 보존 — 값에 따옴표가 있어도 안전). */
+export function deepApplyParams<T>(v: T, params: Record<string, string>): T {
+    if (typeof v === 'string') return applyParams(v, params) as unknown as T;
+    if (Array.isArray(v)) return v.map((x) => deepApplyParams(x, params)) as unknown as T;
+    if (v && typeof v === 'object') {
+        const o: Record<string, unknown> = {};
+        for (const k of Object.keys(v as Record<string, unknown>)) {
+            o[k] = deepApplyParams((v as Record<string, unknown>)[k], params);
+        }
+        return o as unknown as T;
+    }
+    return v;
+}
+
+/** PURE: content(JSON) 안전 파싱. 형식 불충족 시 null. */
+export function parseSpec(content: string): ProceduralSpec | null {
+    try {
+        const o = JSON.parse(content) as ProceduralSpec;
+        if (!o || (o.kind !== 'browser' && o.kind !== 'script')) return null;
+        if (o.kind === 'browser' && !Array.isArray(o.actions)) return null;
+        if (o.kind === 'script' && typeof o.code !== 'string') return null;
+        return o;
+    } catch {
+        return null;
+    }
+}
+
+/** 절차 스킬 저장 → skill id. spec.goal 미지정 시 description 으로 채운다. */
+export async function saveProceduralSkill(
+    userId: string,
+    name: string,
+    description: string,
+    spec: ProceduralSpec,
+): Promise<string> {
+    const desc = (description || spec.goal || name).slice(0, 500);
+    const stored: ProceduralSpec = { ...spec, goal: spec.goal || desc };
+    const skill = await getRepo().createSkill({
+        name: name.slice(0, 120),
+        description: desc,
+        content: JSON.stringify(stored),
+        category: PROCEDURAL_CATEGORY,
+        isPublic: false,
+        createdBy: userId,
+    });
+    logger.info(`[Procedural] 저장: "${skill.name}" (user ${userId}, kind ${spec.kind}, id ${skill.id})`);
+    return skill.id;
+}
+
+/** id 로 절차 스펙 로드 — 본인 소유(또는 public) 이고 category='procedural' 인 경우만. */
+export async function loadProceduralSpec(userId: string, skillId: string): Promise<ProceduralSpec | null> {
+    const skill = await getRepo().getSkillById(skillId).catch(() => null);
+    if (!skill || skill.category !== PROCEDURAL_CATEGORY) return null;
+    if (skill.createdBy && skill.createdBy !== userId && !skill.isPublic) return null;
+    return parseSpec(skill.content);
+}
+
+/** goal 유사 절차 스킬 상위 N(임계 이상). */
+export async function findMatchingSkills(userId: string, goal: string): Promise<MatchedSkill[]> {
+    const res = await getRepo()
+        .searchSkills({ userId, category: PROCEDURAL_CATEGORY, status: 'active', limit: 50 })
+        .catch(() => null);
+    if (!res) return [];
+    return res.skills
+        .map((s) => {
+            const spec = parseSpec(s.content);
+            const g = spec?.goal || s.description || s.name;
+            return { id: s.id, name: s.name, goal: g, params: spec?.params ?? [], sim: goalSimilarity(goal, g) };
+        })
+        .filter((m) => m.sim >= AGENT_TASK_LIMITS.LEARNING_MIN_SIMILARITY)
+        .sort((a, b) => b.sim - a.sim)
+        .slice(0, AGENT_TASK_LIMITS.PROCEDURAL_MAX_SUGGEST);
+}
+
+/**
+ * system 프롬프트에 덧붙일 "재사용 가능한 절차" 블록('' 이면 미주입).
+ * 유사 절차가 있으면 모델이 skill_run 으로 재추론 없이 재생하도록 유도한다.
+ */
+export async function buildProceduralSkillBlock(userId: string, goal: string): Promise<string> {
+    if (!AGENT_TASK_LIMITS.PROCEDURAL_SKILLS_ENABLED) return '';
+    // 저장 유도(항상) — 반복 가능한 절차를 완료하면 skill_save 로 저장해 다음에 재사용하게 한다.
+    const saveHint = [
+        '',
+        '## 절차 재사용 (Procedural Skill)',
+        '브라우저/스크립트로 반복 가능한 작업을 성공적으로 마쳤다면, 그 액션 시퀀스를 skill_save 로 저장하세요',
+        '(반복되는 값은 {{param}} 로 일반화). 다음에 유사 작업에서 skill_run 으로 재추론 없이 재생할 수 있습니다.',
+    ];
+    try {
+        const matches = await findMatchingSkills(userId, goal);
+        if (matches.length === 0) return saveHint.join('\n');
+        logger.info(`[Procedural] 재사용 후보 ${matches.length}건 주입 (user ${userId})`);
+        const lines = matches.map(
+            (m) => `- skill_id=${m.id} "${m.name}"${m.params.length ? ` (params: ${m.params.join(', ')})` : ''}`,
+        );
+        return [
+            ...saveHint,
+            '',
+            '### 지금 재사용 가능한 절차 (skill_run 으로 즉시 재생)',
+            '아래는 과거에 성공해 저장된 실행 절차입니다. 목표에 부합하면 처음부터 다시 추론하지 말고',
+            'skill_run 을 skill_id 와 params 로 호출해 그대로 재생하세요. 재생 결과가 목표와 다르면 수동으로 진행하세요.',
+            ...lines,
+        ].join('\n');
+    } catch (e) {
+        logger.debug(`[Procedural] 매칭 조회 실패 — 저장 힌트만 주입: ${e instanceof Error ? e.message : e}`);
+        return saveHint.join('\n');
+    }
+}

--- a/apps/api/src/services/agent-task/skill-block.ts
+++ b/apps/api/src/services/agent-task/skill-block.ts
@@ -3,6 +3,9 @@
  * @module services/agent-task/skill-block
  */
 import { getSkillManager } from '../../agents/skill-manager';
+import { getAgentTaskSystemPrompt } from '../../prompts/agent-task-prompt';
+import { buildLearningBlock } from './task-learning';
+import { buildProceduralSkillBlock } from './procedural-skill';
 import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('AgentTaskService');
@@ -27,4 +30,15 @@ export async function buildSkillPromptBlock(userId: string): Promise<string> {
         logger.debug('[AgentTask] 스킬 프롬프트 주입 실패 — 무시', e);
         return '';
     }
+}
+
+/**
+ * 신규 task 의 system 메시지 콘텐츠 조립 — 기본 프롬프트 + 스킬 지식 + 크로스-task 학습 +
+ * 재사용 가능 절차(#1). 각 블록은 실패 시 '' 라 조립을 막지 않는다. (resume 은 old system 유지)
+ */
+export async function buildAgentTaskSystemContent(userId: string, goal: string, taskId: string): Promise<string> {
+    return getAgentTaskSystemPrompt()
+        + (await buildSkillPromptBlock(userId))
+        + (await buildLearningBlock(userId, goal, taskId))
+        + (await buildProceduralSkillBlock(userId, goal));
 }

--- a/apps/api/src/services/task-sandbox/approval-gate.ts
+++ b/apps/api/src/services/task-sandbox/approval-gate.ts
@@ -20,8 +20,9 @@ import { createLogger } from '../../utils/logger';
 const logger = createLogger('TaskApprovalGate');
 
 /** 승인이 필요한 고위험 도구(high-risk 정책 시). browser=네트워크 egress.
- *  python_execute 는 임의 코드 실행이라 bash 와 동급 — 제외하면 정책 우회가 된다. */
-const HIGH_RISK_TOOLS = new Set(['bash', 'browser', 'python_execute']);
+ *  python_execute 는 임의 코드 실행이라 bash 와 동급 — 제외하면 정책 우회가 된다.
+ *  skill_run 은 저장된 브라우저/스크립트 절차를 그대로 실행하므로 bash/browser 와 동급(제외 시 우회). */
+const HIGH_RISK_TOOLS = new Set(['bash', 'browser', 'python_execute', 'skill_run']);
 /** 부작용 없는 도구 — 승인 불요(제어 시그널 + 플래닝 + 전문가 자문·병렬 위임).
  *  ask_human 은 이 게이트와 무관하게 TaskRuntime 이 직접 승인 레지스트리로 대기시킨다.
  *  spawn_agents 는 서브 도구를 승인 불요 도구로만 선별(buildTaskSpawnFn)하므로 delegate 와 동급. */

--- a/apps/api/src/services/task-sandbox/runtime.ts
+++ b/apps/api/src/services/task-sandbox/runtime.ts
@@ -12,7 +12,9 @@ import type { ToolDefinition } from '../../llm/types';
 import type { MCPToolDefinition } from '../../mcp/types';
 import { getTaskSandboxConfig, type TaskSandboxConfig } from '../../config/task-sandbox';
 import { TaskSandbox, type ExecResult } from './sandbox';
-import { createTaskTools, type DelegateFn, type SpawnFn } from './tools';
+import { createTaskTools, type DelegateFn, type SpawnFn, type ProceduralHooks } from './tools';
+import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
+import { saveProceduralSkill, loadProceduralSpec } from '../agent-task/procedural-skill';
 import { TaskPlan, type PlanStep } from './planning';
 import { requiresApproval, getApprovalRegistry, type PendingApproval } from './approval-gate';
 import { createLogger } from '../../utils/logger';
@@ -64,7 +66,17 @@ export class TaskRuntime {
         this.userId = userId;
         this.cfg = cfg;
         this.sandbox = new TaskSandbox(taskId, cfg);
-        this.defs = createTaskTools(this.sandbox, this.plan, delegate, spawn);
+        // #1 절차 스킬: 저장/조회 훅을 userId 로 바인딩(재생 실행은 tools.ts 가 sandbox 로 수행). 플래그 OFF 면 미노출.
+        const procedural: ProceduralHooks | undefined = AGENT_TASK_LIMITS.PROCEDURAL_SKILLS_ENABLED
+            ? {
+                save: (i) => saveProceduralSkill(this.userId, i.name, i.description, {
+                    kind: i.kind, goal: i.description, params: i.params,
+                    actions: i.actions, allowlist: i.allowlist, lang: i.lang, code: i.code,
+                }),
+                load: (id) => loadProceduralSpec(this.userId, id),
+            }
+            : undefined;
+        this.defs = createTaskTools(this.sandbox, this.plan, delegate, spawn, procedural);
         for (const d of this.defs) this.handlers.set(d.tool.name, d.handler);
     }
 

--- a/apps/api/src/services/task-sandbox/tools.ts
+++ b/apps/api/src/services/task-sandbox/tools.ts
@@ -51,11 +51,36 @@ function str(v: unknown): string { return typeof v === 'string' ? v : ''; }
 /** 전문가 자문 콜백 — subgoal 을 적합 산업 전문가(페르소나)에게 1회 위임해 응답을 받는다. */
 export type DelegateFn = (subgoal: string, role?: string) => Promise<string>;
 
+/** 절차 스킬(save/load) 훅 — userId·repo 를 아는 TaskRuntime 이 바인딩한다.
+ *  재생(실행)은 sandbox 를 가진 tools.ts 가 수행하므로 여기선 저장/조회만 노출한다. */
+export interface ProceduralHooks {
+    /** 성공한 절차를 저장 → skill id. */
+    save: (input: {
+        name: string;
+        description: string;
+        kind: 'browser' | 'script';
+        actions?: unknown[];
+        allowlist?: string[];
+        lang?: 'bash' | 'python';
+        code?: string;
+        params?: string[];
+    }) => Promise<string>;
+    /** id 로 저장된 절차 스펙 조회(소유자 격리는 훅 내부에서 적용). */
+    load: (skillId: string) => Promise<{
+        kind: 'browser' | 'script';
+        actions?: unknown[];
+        allowlist?: string[];
+        lang?: 'bash' | 'python';
+        code?: string;
+    } | null>;
+}
+
 export function createTaskTools(
     sandbox: TaskSandbox,
     plan: TaskPlan = new TaskPlan(),
     delegate?: DelegateFn,
     spawn?: SpawnFn,
+    procedural?: ProceduralHooks,
 ): MCPToolDefinition[] {
     const bash: MCPToolDefinition = {
         tool: {
@@ -336,6 +361,113 @@ export function createTaskTools(
         },
     };
 
+    // ── #1 절차 스킬: 성공한 실행 절차를 저장(save)하고 LLM 재추론 없이 재생(run) ──
+    const skillSave: MCPToolDefinition = {
+        tool: {
+            name: 'skill_save',
+            description: '성공한 실행 절차를 재사용 가능한 스킬로 저장합니다. 같은 유형의 작업을 나중에 skill_run 으로 ' +
+                'LLM 재추론 없이 재생할 수 있습니다. kind=browser 면 actions(browser 도구와 동일한 액션 배열), ' +
+                'kind=script 면 lang+code 를 저장합니다. 반복되는 값(도시·기간 등)은 {{param}} 로 두고 params 에 이름을 나열하세요.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    name: { type: 'string', description: '스킬 이름(짧게)' },
+                    description: { type: 'string', description: '이 절차가 달성하는 목표(매칭에 사용)' },
+                    kind: { type: 'string', description: 'browser | script' },
+                    actions: { type: 'array', description: 'kind=browser: browser 도구와 동일한 액션 배열' },
+                    allowlist: { type: 'array', description: 'kind=browser: 허용 도메인 목록' },
+                    lang: { type: 'string', description: 'kind=script: bash | python' },
+                    code: { type: 'string', description: 'kind=script: 실행 코드({{param}} 치환 지원)' },
+                    params: { type: 'array', description: '치환 파라미터 이름 목록(예: ["city","year"])' },
+                },
+                required: ['name', 'kind'],
+            },
+        },
+        handler: async (args): Promise<MCPToolResult> => {
+            if (!procedural) return textResult('절차 스킬 저장이 비활성화되어 있습니다 (AGENT_TASK_PROCEDURAL_SKILLS=false).', true);
+            const name = str(args.name).trim();
+            const kind = str(args.kind);
+            if (!name) return textResult('name 이 필요합니다.', true);
+            if (kind !== 'browser' && kind !== 'script') return textResult('kind 는 browser | script 여야 합니다.', true);
+            if (kind === 'browser' && !Array.isArray(args.actions)) return textResult('kind=browser 는 actions 배열이 필요합니다.', true);
+            if (kind === 'script' && !str(args.code)) return textResult('kind=script 는 code 가 필요합니다.', true);
+            const lang = args.lang === 'python' ? 'python' : args.lang === 'bash' ? 'bash' : undefined;
+            try {
+                const id = await procedural.save({
+                    name,
+                    description: str(args.description),
+                    kind,
+                    actions: Array.isArray(args.actions) ? args.actions : undefined,
+                    allowlist: Array.isArray(args.allowlist) ? (args.allowlist as unknown[]).filter((d): d is string => typeof d === 'string') : undefined,
+                    lang,
+                    code: str(args.code) || undefined,
+                    params: Array.isArray(args.params) ? (args.params as unknown[]).filter((p): p is string => typeof p === 'string') : undefined,
+                });
+                return textResult(`절차 스킬 저장됨: skill_id=${id}. 다음에 skill_run 으로 재생하세요.`);
+            } catch (e) {
+                return textResult(`스킬 저장 실패: ${e instanceof Error ? e.message : String(e)}`, true);
+            }
+        },
+    };
+
+    const skillRun: MCPToolDefinition = {
+        tool: {
+            name: 'skill_run',
+            description: '저장된 절차 스킬을 skill_id 로 즉시 재생합니다(LLM 재추론 없이 전체 시퀀스 1회 실행). ' +
+                'params 로 {{param}} 를 치환합니다. kind=browser 는 브라우저 액션을, kind=script 는 저장된 코드를 실행하고 결과를 반환합니다. ' +
+                '재생 결과가 목표와 다르면 수동으로 진행하세요.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    skill_id: { type: 'string', description: '재생할 절차 스킬 id' },
+                    params: { type: 'object', description: '{{param}} 치환값 (예: {"city":"부산","year":"2026"})' },
+                },
+                required: ['skill_id'],
+            },
+        },
+        handler: async (args): Promise<MCPToolResult> => {
+            if (!procedural) return textResult('절차 스킬 재생이 비활성화되어 있습니다 (AGENT_TASK_PROCEDURAL_SKILLS=false).', true);
+            const skillId = str(args.skill_id).trim();
+            if (!skillId) return textResult('skill_id 가 필요합니다.', true);
+            const spec = await procedural.load(skillId).catch(() => null);
+            if (!spec) return textResult(`절차 스킬을 찾지 못했습니다(또는 접근 불가): ${skillId}`, true);
+            const params: Record<string, string> = {};
+            if (args.params && typeof args.params === 'object') {
+                for (const [k, v] of Object.entries(args.params as Record<string, unknown>)) params[k] = String(v);
+            }
+            const sub = (t: string): string => t.replace(/\{\{\s*([\w.-]+)\s*\}\}/g, (m, k) => (k in params ? params[k] : m));
+            const deepSub = (v: unknown): unknown => {
+                if (typeof v === 'string') return sub(v);
+                if (Array.isArray(v)) return v.map(deepSub);
+                if (v && typeof v === 'object') {
+                    const o: Record<string, unknown> = {};
+                    for (const k of Object.keys(v as Record<string, unknown>)) o[k] = deepSub((v as Record<string, unknown>)[k]);
+                    return o;
+                }
+                return v;
+            };
+            try {
+                if (spec.kind === 'browser') {
+                    if (!sandbox.isBrowserEnabled) return textResult('브라우저 기능이 비활성화되어 있습니다 (TASK_SANDBOX_BROWSER_ENABLED=false).', true);
+                    const renderedActions = deepSub(spec.actions ?? []);
+                    const specOut = { actions: renderedActions, ...(Array.isArray(spec.allowlist) ? { allowlist: deepSub(spec.allowlist) } : {}) };
+                    await sandbox.writeFile('.browser-actions.json', JSON.stringify(specOut));
+                    return formatExec(await sandbox.runBrowser('.browser-actions.json'));
+                }
+                // kind === 'script'
+                const code = sub(spec.code ?? '');
+                if (!code) return textResult('재생할 코드가 비어 있습니다.', true);
+                if (spec.lang === 'python') {
+                    await sandbox.writeFile('.skill-run.py', code);
+                    return formatExec(await sandbox.exec('python3 .skill-run.py'));
+                }
+                return formatExec(await sandbox.exec(code));
+            } catch (e) {
+                return textResult(`스킬 재생 실패: ${e instanceof Error ? e.message : String(e)}`, true);
+            }
+        },
+    };
+
     // ── B 흡수: 제어 시그널 도구 (sandbox 무관) ──
     const terminate: MCPToolDefinition = {
         tool: {
@@ -369,5 +501,5 @@ export function createTaskTools(
             textResult(`${TASK_ASK_HUMAN_SENTINEL} ${str(args.question)}`),
     };
 
-    return [bash, pythonExecute, strReplaceEditor, fileOps, browser, planCreate, planUpdate, planView, delegateTool, ...(spawn ? [spawnAgentsTool] : []), terminate, askHuman];
+    return [bash, pythonExecute, strReplaceEditor, fileOps, browser, planCreate, planUpdate, planView, delegateTool, ...(spawn ? [spawnAgentsTool] : []), ...(procedural ? [skillSave, skillRun] : []), terminate, askHuman];
 }


### PR DESCRIPTION
## 배경 (Computer-Use / AGI 방향 #1)

Agentic AI 트렌드의 **절차적 기억(Procedural Memory)** 갭 직격 — "매번 재추론" 대신 검증된 절차를 재사용. openmake의 기존 스킬 인프라(`agent_skills`·`skill-manager`·`task-learning`) 위에서 "선언형 프롬프트 스킬 → 실행형 절차 스킬"로 확장.

## 무엇을

- **skill_save**: 성공한 실행 절차(브라우저 액션 시퀀스 / bash·python 스크립트)를 `{{param}}` 로 일반화해 저장
- **skill_run**: 저장된 절차를 `skill_id`+`params`로 **LLM 재추론 없이 1회 재생**(치환 후 `runBrowser`/`exec`)
- **system 주입**: `buildProceduralSkillBlock` — 저장 유도(항상) + 유사 goal 매칭 절차 재생 안내(`goalSimilarity` 재사용)

## 설계 — 코어 무변경, 전부 additive

- `agent_skills(category='procedural')` 재사용 → **신규 테이블·마이그레이션 0건**. content=JSON 스펙.
- 저장/조회 훅은 userId 를 아는 `TaskRuntime`이 바인딩(**소유자 격리**), 실행은 sandbox 보유한 `tools.ts`.
- 플래그 `AGENT_TASK_PROCEDURAL_SKILLS`(**기본 OFF**) — OFF면 도구 미노출 + 블록 `''` → 기존 동작 완전 불변.

## 보안

`skill_run`을 approval-gate `HIGH_RISK_TOOLS`에 추가(bash/browser와 동급 — 저장된 코드/브라우저를 그대로 실행하므로 제외 시 승인 우회). `skill_save`는 저장만이라 non-execution.

## 검증

- tsc 0 · lint 0 error(400줄 max-lines 경고만, CI Gate 600 미만)
- 순수함수 유닛테스트(applyParams/deepApplyParams/parseSpec) + task-sandbox·agent-task 스위트 **88 pass 회귀 없음**

## 파일
`procedural-skill.ts`(신규) · `tools.ts`(도구 2개) · `runtime.ts`(훅) · `approval-gate.ts`(high-risk) · `AgentTaskService.ts`(주입) · `runtime-limits`/`.env.example`(플래그)

🤖 Generated with [Claude Code](https://claude.com/claude-code)