### PR TITLE
fix(agent-task): 절차 스킬 skill_run 퍼지 해석 (라이브 E2E 갭)

### DIFF
--- a/apps/api/src/services/agent-task/procedural-skill.ts
+++ b/apps/api/src/services/agent-task/procedural-skill.ts
@@ -111,6 +111,36 @@ export async function loadProceduralSpec(userId: string, skillId: string): Promi
     return parseSpec(skill.content);
 }
 
+/**
+ * id 우선 해석 — 정확한 skill_id 미스 시, 본인 절차 스킬 중 name/goal 퍼지 매칭으로 해석.
+ * 라이브 관찰: 모델이 주입된 exact skill_id 대신 의미 이름("square" 등)을 지어내 호출 →
+ * 퍼지 폴백이 없으면 재생이 전부 실패한다.
+ */
+export async function resolveProceduralSpec(userId: string, idOrName: string): Promise<ProceduralSpec | null> {
+    const exact = await loadProceduralSpec(userId, idOrName);
+    if (exact) return exact;
+    const res = await getRepo()
+        .searchSkills({ userId, category: PROCEDURAL_CATEGORY, status: 'active', limit: 50 })
+        .catch(() => null);
+    if (!res || res.skills.length === 0) return null;
+    const q = idOrName.toLowerCase().replace(/[_-]/g, ' ').trim();
+    const words = q.split(/\s+/).filter((w) => w.length > 2);
+    let best: ProceduralSpec | null = null;
+    let bestScore = 0;
+    for (const s of res.skills) {
+        const spec = parseSpec(s.content);
+        if (!spec) continue;
+        const hay = `${s.name} ${spec.goal ?? ''}`.toLowerCase();
+        const hayWords = hay.split(/\s+/).filter((w) => w.length > 2);
+        // 부분일치 또는 형태변형(접두 5자 공유: square↔squaring) 매칭.
+        const contains = hay.includes(q) || words.some((w) =>
+            hay.includes(w) || hayWords.some((hw) => hw.slice(0, 5) === w.slice(0, 5) && w.length >= 5));
+        const score = Math.max(goalSimilarity(idOrName, spec.goal ?? s.name), contains ? 0.5 : 0);
+        if (score > bestScore) { bestScore = score; best = spec; }
+    }
+    return bestScore >= 0.3 ? best : null;
+}
+
 /** goal 유사 절차 스킬 상위 N(임계 이상). */
 export async function findMatchingSkills(userId: string, goal: string): Promise<MatchedSkill[]> {
     const res = await getRepo()
@@ -153,7 +183,8 @@ export async function buildProceduralSkillBlock(userId: string, goal: string): P
             '',
             '### 지금 재사용 가능한 절차 (skill_run 으로 즉시 재생)',
             '아래는 과거에 성공해 저장된 실행 절차입니다. 목표에 부합하면 처음부터 다시 추론하지 말고',
-            'skill_run 을 skill_id 와 params 로 호출해 그대로 재생하세요. 재생 결과가 목표와 다르면 수동으로 진행하세요.',
+            'skill_run 을 아래 정확한 skill_id(권장) 또는 스킬 이름과 params 로 호출해 그대로 재생하세요.',
+            '재생 결과가 목표와 다르면 수동으로 진행하세요.',
             ...lines,
         ].join('\n');
     } catch (e) {

--- a/apps/api/src/services/task-sandbox/runtime.ts
+++ b/apps/api/src/services/task-sandbox/runtime.ts
@@ -14,7 +14,7 @@ import { getTaskSandboxConfig, type TaskSandboxConfig } from '../../config/task-
 import { TaskSandbox, type ExecResult } from './sandbox';
 import { createTaskTools, type DelegateFn, type SpawnFn, type ProceduralHooks } from './tools';
 import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
-import { saveProceduralSkill, loadProceduralSpec } from '../agent-task/procedural-skill';
+import { saveProceduralSkill, resolveProceduralSpec } from '../agent-task/procedural-skill';
 import { TaskPlan, type PlanStep } from './planning';
 import { requiresApproval, getApprovalRegistry, type PendingApproval } from './approval-gate';
 import { createLogger } from '../../utils/logger';
@@ -73,7 +73,7 @@ export class TaskRuntime {
                     kind: i.kind, goal: i.description, params: i.params,
                     actions: i.actions, allowlist: i.allowlist, lang: i.lang, code: i.code,
                 }),
-                load: (id) => loadProceduralSpec(this.userId, id),
+                load: (id) => resolveProceduralSpec(this.userId, id),
             }
             : undefined;
         this.defs = createTaskTools(this.sandbox, this.plan, delegate, spawn, procedural);

--- a/apps/api/src/services/task-sandbox/tools.ts
+++ b/apps/api/src/services/task-sandbox/tools.ts
@@ -419,7 +419,7 @@ export function createTaskTools(
             inputSchema: {
                 type: 'object',
                 properties: {
-                    skill_id: { type: 'string', description: '재생할 절차 스킬 id' },
+                    skill_id: { type: 'string', description: '재생할 절차 스킬 id(정확한 skill_id 권장). 미스 시 스킬 이름/설명으로도 매칭됩니다.' },
                     params: { type: 'object', description: '{{param}} 치환값 (예: {"city":"부산","year":"2026"})' },
                 },
                 required: ['skill_id'],


### PR DESCRIPTION
## 라이브 E2E 발견

#1 배포 후 실제 에이전트 루프 E2E에서: 모델(qwen)이 system에 주입된 **exact skill_id 대신 의미 이름**("square"·"squaring"·"square_number"...)을 지어내 `skill_run` 호출 → 6회 전부 "스킬 못 찾음" → task `goal_incomplete`.

메커니즘(정확 id 재생)은 결정적 검증 통과였으나, 에이전트가 id를 안 쓰는 **실사용 갭**.

## 수정

- `resolveProceduralSpec`: exact id 미스 시 본인 절차 스킬을 **name/goal 퍼지 해석**(부분일치 + 접두 5자 공유로 형태변형 square↔squaring 흡수 + goalSimilarity, 임계 0.3). 무관한 이름은 미해석(오재생 방지).
- runtime `load` 훅을 `resolveProceduralSpec`로 교체.
- `skill_run` 설명·주입 블록에 "이름으로도 매칭" 명시(exact id 여전히 권장).

## 검증 (배포 dist 라이브)

qwen이 실제로 지어냈던 이름 `square`/`squaring`/`square_number`/`calculate_square` **전부 해석 성공**, 무관 `multiply` 정확 거부, exact id 유지. jest 81 pass, tsc 0, lint 0 error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)