### PR TITLE
feat(agent-task): semantic 메모리를 Agent Task 에 배선 (#3 3-tier)

### DIFF
--- a/apps/api/src/services/agent-task/skill-block.ts
+++ b/apps/api/src/services/agent-task/skill-block.ts
@@ -6,6 +6,7 @@ import { getSkillManager } from '../../agents/skill-manager';
 import { getAgentTaskSystemPrompt } from '../../prompts/agent-task-prompt';
 import { buildLearningBlock } from './task-learning';
 import { buildProceduralSkillBlock } from './procedural-skill';
+import { buildUserMemoryBlock } from '../chat-service/user-context-blocks';
 import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('AgentTaskService');
@@ -33,11 +34,14 @@ export async function buildSkillPromptBlock(userId: string): Promise<string> {
 }
 
 /**
- * 신규 task 의 system 메시지 콘텐츠 조립 — 기본 프롬프트 + 스킬 지식 + 크로스-task 학습 +
- * 재사용 가능 절차(#1). 각 블록은 실패 시 '' 라 조립을 막지 않는다. (resume 은 old system 유지)
+ * 신규 task 의 system 메시지 콘텐츠 조립 — 기본 프롬프트 + 3-tier 메모리:
+ * semantic(user_memories, #3) · procedural(스킬 지식·재사용 절차 #1) · episodic(크로스-task 학습).
+ * 각 블록은 실패 시 '' 라 조립을 막지 않는다. (resume 은 old system 유지)
  */
 export async function buildAgentTaskSystemContent(userId: string, goal: string, taskId: string): Promise<string> {
+    const memory = userId && userId !== 'guest' ? await buildUserMemoryBlock(userId) : '';
     return getAgentTaskSystemPrompt()
+        + memory
         + (await buildSkillPromptBlock(userId))
         + (await buildLearningBlock(userId, goal, taskId))
         + (await buildProceduralSkillBlock(userId, goal));

--- a/apps/api/src/services/chat-service/user-context-blocks.ts
+++ b/apps/api/src/services/chat-service/user-context-blocks.ts
@@ -11,6 +11,39 @@ import { USER_CONTEXT_LIMITS } from '../../config/runtime-limits';
 
 const logger = createLogger('UserContextBlocks');
 
+/**
+ * Semantic tier — 사용자 cross-conversation 메모리 블록('' 이면 미주입). 토큰 cap 적용.
+ * 채팅(buildUserContextBlocks)과 Agent Task(system 조립) 양쪽에서 재사용(#3 3-tier 배선).
+ * 실패 시 '' graceful. 인증 사용자만(guest 는 호출부에서 걸러짐).
+ */
+export async function buildUserMemoryBlock(userId: string): Promise<string> {
+    try {
+        const { UserMemoryRepository } = await import('../../data/repositories/user-memory-repository');
+        const { getPool } = await import('../../data/models/unified-database');
+        const memRepo = new UserMemoryRepository(getPool());
+        const memories = await memRepo.listActiveByUser(userId, 50);
+        if (memories.length === 0) return '';
+        const maxMem = USER_CONTEXT_LIMITS.MAX_MEMORY_TOKENS;
+        const kept: typeof memories = [];
+        let usedTokens = 0;
+        for (const m of memories) {
+            const t = estimateTokens(m.content) + 4;
+            if (usedTokens + t > maxMem && kept.length > 0) break;
+            kept.push(m);
+            usedTokens += t;
+        }
+        if (kept.length < memories.length) {
+            logger.info(`user_memories 토큰 cap 적용 (${kept.length}/${memories.length}, >${maxMem} tok)`);
+        }
+        const lines = kept.map((m, i) => `${i + 1}. ${m.content}`).join('\n');
+        void memRepo.touchAccessed(kept.map((m) => m.id)).catch((e) => logger.warn('memory touch 실패 (무시):', e));
+        return `## 🧠 User Memory (cross-conversation)\n${lines}\n\n---\n\n`;
+    } catch (e) {
+        logger.warn('user_memories 조회 실패 (계속 진행):', e);
+        return '';
+    }
+}
+
 export async function buildUserContextBlocks(
     userId: string | undefined,
     includeMemory = true,
@@ -39,34 +72,8 @@ export async function buildUserContextBlocks(
         }
 
         // includeMemory=false (설정 "장기 기억" 토글 OFF) → 저장된 메모리를 대화에 주입하지 않음.
-        try {
-            if (includeMemory) {
-                const { UserMemoryRepository } = await import('../../data/repositories/user-memory-repository');
-                const { getPool } = await import('../../data/models/unified-database');
-                const memRepo = new UserMemoryRepository(getPool());
-                const memories = await memRepo.listActiveByUser(userId, 50);
-                if (memories.length > 0) {
-                    const maxMem = USER_CONTEXT_LIMITS.MAX_MEMORY_TOKENS;
-                    const kept: typeof memories = [];
-                    let usedTokens = 0;
-                    for (const m of memories) {
-                        const t = estimateTokens(m.content) + 4;
-                        if (usedTokens + t > maxMem && kept.length > 0) break;
-                        kept.push(m);
-                        usedTokens += t;
-                    }
-                    if (kept.length < memories.length) {
-                        logger.info(`user_memories 토큰 cap 적용 (${kept.length}/${memories.length}, >${maxMem} tok)`);
-                    }
-                    const lines = kept.map((m, i) => `${i + 1}. ${m.content}`).join('\n');
-                    memoryBlock = `## 🧠 User Memory (cross-conversation)\n${lines}\n\n---\n\n`;
-                    void memRepo.touchAccessed(kept.map(m => m.id)).catch(e =>
-                        logger.warn('memory touch 실패 (무시):', e),
-                    );
-                }
-            }
-        } catch (e) {
-            logger.warn('user_memories 조회 실패 (계속 진행):', e);
+        if (includeMemory) {
+            memoryBlock = await buildUserMemoryBlock(userId);
         }
     }
     return { memoryBlock, customInstructionsBlock };


### PR DESCRIPTION
## 배경 (Memory 3-tier #3, 1단계)

semantic tier(`user_memories`, cross-conversation)가 **채팅에만 주입**되고 Agent Task엔 빠져 있어, 에이전트가 사용자의 저장된 선호/사실(예: "한국어로 응답")을 몰랐습니다. 이제 task에도 주입 → **episodic**(크로스-task 학습)·**procedural**(스킬·절차 #1)·**semantic**(user_memories) 3-tier가 task 컨텍스트에서 모두 활성.

## 수정 (기존 자산 배선·저위험)

- `buildUserMemoryBlock(userId)` 추출(`user-context-blocks`) — 채팅/task 공용, 토큰 cap 재사용. `buildUserContextBlocks`는 이 함수 호출로 리팩터(**동작 동일**).
- `buildAgentTaskSystemContent`가 semantic 블록을 맨 앞에 조립(guest 제외).

## 검증

라이브(dist+실DB): task system에 메모리 주입 확인, guest 미주입. tsc 0, **jest 159 pass**(채팅 회귀 없음), 파일 크기 여유.

## 메모
- 메모리 관리 **UI는 이미 존재**(`components/settings/memory-section.tsx`) — CLAUDE.md "UI 미연결" 표기는 낡음.
- #3 남은 것 = **자동 기억형성**(`source='candidate'`) — LLM 추출 비용 결정 필요(별도).

🤖 Generated with [Claude Code](https://claude.com/claude-code)