### PR TITLE
feat(chat): 자동 기억형성 (#3 b — semantic tier auto-formation)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -795,6 +795,12 @@ AGENT_TASK_TIMEOUT_MS=600000
 # AGENT_TASK_PROCEDURAL_SKILLS=true
 # AGENT_TASK_PROCEDURAL_MAX_SUGGEST=3
 
+# 자동 기억형성(#3 b) — 대화에서 user_memories 를 자동 추출→저장(추출 즉시 active, 자동 주입).
+#   휴리스틱(무-LLM, 명시적 "기억해줘"류): vLLM 부하 0. LLM 추출: 메시지당 1콜(vLLM 부하). 둘 다 기본 OFF.
+# USER_MEMORY_AUTO_EXTRACT=true      # 휴리스틱 추출
+# USER_MEMORY_LLM_EXTRACT=true       # LLM 추출(대화당 1콜 — vLLM 부하 발생)
+# USER_MEMORY_MAX_COUNT=50           # 사용자별 메모리 상한(수동 저장과 공유)
+
 # Agent Task — 산출물 검증 모드: syntax(기본, 문법만) | run(샌드박스 실행 후 exit code 검사).
 # AGENT_TASK_VERIFY_MODE=syntax
 

--- a/apps/api/src/config/memory-extraction.ts
+++ b/apps/api/src/config/memory-extraction.ts
@@ -1,0 +1,42 @@
+/**
+ * 자동 기억형성(#3 b) 설정 — 패턴·임계값·프롬프트 외부화(no-hardcoding).
+ * ① 휴리스틱(무-LLM): 명시적 저장 의도 문장. ② LLM 추출: 대화당 1콜(vLLM 부하).
+ * 둘 다 기본 OFF. 추출된 메모리는 즉시 active(자동 주입) — 사용자는 삭제로만 제거.
+ *
+ * @module config/memory-extraction
+ */
+export const MEMORY_EXTRACTION = {
+    /** 휴리스틱(무-LLM) 추출 활성 — vLLM 부하 0. USER_MEMORY_AUTO_EXTRACT=true. 기본 OFF. */
+    heuristicEnabled: process.env.USER_MEMORY_AUTO_EXTRACT === 'true',
+    /** LLM 추출 활성 — 사용자 메시지당 1콜(vLLM 부하). USER_MEMORY_LLM_EXTRACT=true. 기본 OFF. */
+    llmEnabled: process.env.USER_MEMORY_LLM_EXTRACT === 'true',
+    /** 사용자별 메모리 최대 개수(수동 저장과 공유 — 초과 시 자동형성 스킵). 컨트롤러와 동일 env. */
+    maxCount: Number(process.env.USER_MEMORY_MAX_COUNT || '50'),
+    /** 저장 콘텐츠 최소/최대 길이. */
+    minLen: 4,
+    maxLen: 300,
+    /** LLM 추출이 한 메시지에서 만들 최대 메모리 수(폭주 방지). */
+    llmMaxPerMessage: 3,
+    /**
+     * 휴리스틱 패턴 — 명시적 저장 의도. group>0 이면 그 캡처를 저장 콘텐츠로 사용.
+     * (인라인 정규식 금지 정책 → 여기 config 로 외부화)
+     */
+    heuristicPatterns: [
+        { re: /(.{4,200}?)\s*(?:을|를|은|는|이|가)?\s*(?:좀\s*)?기억\s*(?:해\s*(?:둬|줘|주세요|두세요)|하고\s*있어|해\s*두)/u, group: 1 },
+        { re: /(.{4,200}?)\s*(?:을|를)?\s*잊지\s*(?:마|말아|말아줘|마세요)/u, group: 1 },
+        { re: /(내\s*이름은\s*[^.?!\n]{1,80})/u, group: 1 },
+        { re: /(나는\s*[^.?!\n]{2,120}?(?:를|을)\s*(?:선호|좋아)해)/u, group: 1 },
+    ] as ReadonlyArray<{ re: RegExp; group: number }>,
+};
+
+/** LLM 추출 프롬프트 — 지속적 사용자 사실만 짧은 줄로, 없으면 정확히 NONE. */
+export function getMemoryExtractionMessages(text: string): { system: string; user: string } {
+    return {
+        system:
+            '너는 대화에서 "다음 대화에도 계속 유용한 사용자 고유 사실"만 뽑는 추출기다. '
+            + '이름·선호·직업·언어·프로젝트·반복 요청 같은 지속적 사실만 추출한다. '
+            + '일회성 질문·잡담·시간의존 정보는 제외한다. 각 사실을 한 줄로, 최대 3개, 한국어로 간결히 출력한다. '
+            + '추출할 게 없으면 정확히 NONE 만 출력한다. 설명·번호·따옴표 없이 사실 문장만.',
+        user: text.slice(0, 2000),
+    };
+}

--- a/apps/api/src/services/chat-service/memory-extraction.ts
+++ b/apps/api/src/services/chat-service/memory-extraction.ts
@@ -1,0 +1,100 @@
+/**
+ * 자동 기억형성(#3 b) — 대화에서 사용자 메모리를 자동 추출해 user_memories 에 저장.
+ * ① 휴리스틱(무-LLM): 명시적 저장 의도 패턴. ② LLM 추출: 지속적 사실(플래그·대화당 1콜).
+ * 추출 즉시 active(자동 주입). dedup + 개수 cap. fire-and-forget — 절대 throw 하지 않음(응답 무영향).
+ *
+ * @module services/chat-service/memory-extraction
+ */
+import { randomUUID } from 'node:crypto';
+import { MEMORY_EXTRACTION, getMemoryExtractionMessages } from '../../config/memory-extraction';
+import type { LLMClient } from '../../llm/client';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('MemoryExtraction');
+
+/** PURE: 휴리스틱 추출 — 명시적 저장 의도 문장에서 메모리 콘텐츠 후보(중복 제거). */
+export function extractHeuristicMemories(text: string): string[] {
+    const t = (text || '').trim();
+    if (!t) return [];
+    const found: string[] = [];
+    for (const p of MEMORY_EXTRACTION.heuristicPatterns) {
+        const m = t.match(p.re);
+        if (!m) continue;
+        const c = (m[p.group] || m[0] || '').trim().replace(/\s+/g, ' ');
+        if (c.length >= MEMORY_EXTRACTION.minLen) found.push(c.slice(0, MEMORY_EXTRACTION.maxLen));
+    }
+    return [...new Set(found)];
+}
+
+/** LLM 추출 — user 메시지에서 지속적 사실. 실패/빈 결과 시 []. */
+export async function extractLLMMemories(client: LLMClient, text: string): Promise<string[]> {
+    try {
+        const { system, user } = getMemoryExtractionMessages(text);
+        const r = await client.chat(
+            [{ role: 'system', content: system }, { role: 'user', content: user }],
+            { temperature: 0 }, undefined, { think: false },
+        );
+        const raw = (r.content ?? '').trim();
+        if (!raw || /^none$/im.test(raw)) return [];
+        return raw
+            .split('\n')
+            .map((l) => l.replace(/^[-*\d.)\s"']+/, '').trim())
+            .filter((l) => l.length >= MEMORY_EXTRACTION.minLen && !/^none$/i.test(l))
+            .slice(0, MEMORY_EXTRACTION.llmMaxPerMessage)
+            .map((l) => l.slice(0, MEMORY_EXTRACTION.maxLen));
+    } catch (e) {
+        logger.debug(`LLM 추출 실패 — 스킵: ${e instanceof Error ? e.message : e}`);
+        return [];
+    }
+}
+
+/** PURE: 정규화 문자열. */
+function norm(s: string): string {
+    return s.toLowerCase().replace(/[.,!?~]/g, '').replace(/\s+/g, ' ').trim();
+}
+
+/** PURE: 기존 메모리와 근접 중복인지(정규화 exact 또는 부분포함). */
+export function isDuplicateMemory(content: string, existing: string[]): boolean {
+    const n = norm(content);
+    if (!n) return true;
+    return existing.some((e) => {
+        const ne = norm(e);
+        return ne === n || ne.includes(n) || n.includes(ne);
+    });
+}
+
+/**
+ * 오케스트레이터 — user 메시지에서 자동 기억형성. 비차단·비throw(fire-and-forget 로 호출).
+ * 플래그 OFF·guest·후보 없음·cap 초과 시 no-op.
+ */
+export async function autoFormMemories(params: { userId?: string; message: string; client?: LLMClient }): Promise<void> {
+    const { userId, message, client } = params;
+    if (!userId || userId === 'guest') return;
+    if (!MEMORY_EXTRACTION.heuristicEnabled && !MEMORY_EXTRACTION.llmEnabled) return;
+    try {
+        const heur = MEMORY_EXTRACTION.heuristicEnabled ? extractHeuristicMemories(message) : [];
+        const llm = MEMORY_EXTRACTION.llmEnabled && client ? await extractLLMMemories(client, message) : [];
+        const candidates = [...new Set([...heur, ...llm])];
+        if (candidates.length === 0) return;
+
+        const { UserMemoryRepository } = await import('../../data/repositories/user-memory-repository');
+        const { getPool } = await import('../../data/models/unified-database');
+        const repo = new UserMemoryRepository(getPool());
+        const existing = await repo.listActiveByUser(userId, MEMORY_EXTRACTION.maxCount);
+        const contents = existing.map((m) => m.content);
+        let count = existing.length;
+        let saved = 0;
+        for (const c of candidates) {
+            if (count >= MEMORY_EXTRACTION.maxCount) break;
+            if (isDuplicateMemory(c, contents)) continue;
+            const source = heur.includes(c) ? 'candidate' : 'batch';
+            await repo.create(randomUUID(), userId, c, source);
+            contents.push(c);
+            count += 1;
+            saved += 1;
+        }
+        if (saved > 0) logger.info(`[MemoryExtract] 자동 저장 ${saved}건 (user ${userId}, heur ${heur.length}/llm ${llm.length})`);
+    } catch (e) {
+        logger.debug(`[MemoryExtract] 실패 — 무시: ${e instanceof Error ? e.message : e}`);
+    }
+}

--- a/apps/api/src/services/chat-service/message-pipeline.ts
+++ b/apps/api/src/services/chat-service/message-pipeline.ts
@@ -31,6 +31,7 @@ import { buildNotebookContextPrefix } from '../../prompts/notebook-context';
 import { applyAgentModelOverride } from './agent-model-override';
 import { resolveModeExternalClient } from './mode-external-client';
 import { buildUserContextBlocks } from './user-context-blocks';
+import { autoFormMemories } from './memory-extraction';
 import type { RequestContext } from './request-context';
 
 const logger = createLogger('MessagePipeline');
@@ -290,6 +291,9 @@ export async function runMessagePipeline(svc: ChatService,
     // Memory + Custom Instructions 주입 (claude.ai Memory/CI 동등).
     const { memoryBlock: extMemoryBlock, customInstructionsBlock: extCustomInstructionsBlock } =
         await buildUserContextBlocks(userId, req.memoryLearning !== false);
+
+    // 자동 기억형성(#3 b) — user 메시지에서 지속적 사실 추출→저장. fire-and-forget(응답 무영향, 플래그 OFF 면 no-op).
+    void autoFormMemories({ userId, message: req.message, client: svc.client });
 
     // Custom Agent (user_agents) 활성 시 산업 agent 라우팅 우회 + allowedSkills 주입.
     // 전체 build() 대신 loadUserAgent 단독 호출 — provider 가 자체 model 처리하므로


### PR DESCRIPTION
## 배경 (Memory 3-tier #3, 2단계)

`user_memories`가 **수동 저장만** 가능하던 것을, 대화에서 **자동 추출→저장**. Letta/ChatGPT Memory 방향.
사용자 결정: **추출=둘 다(플래그)**, **주입=자동 활성**(즉시 active → 다음 대화 주입, 삭제로만 제거).

## 수정

- **① 휴리스틱(무-LLM)**: 명시적 저장 의도 패턴("~ 기억해줘"·"내 이름은 X"·"나는 X 선호"·"잊지 마")에서 콘텐츠 추출. **vLLM 부하 0**. `USER_MEMORY_AUTO_EXTRACT`(기본 OFF).
- **② LLM 추출**: user 메시지에서 지속적 사실 1콜 추출(NONE이면 스킵). `USER_MEMORY_LLM_EXTRACT`(기본 OFF).
- **dedup**(정규화 exact+부분포함) + **개수 cap**(`USER_MEMORY_MAX_COUNT`=50, 수동과 공유) + **guest 제외**.
- `message-pipeline`에서 **fire-and-forget**(void) — 응답 무영향, 절대 throw 안 함.
- 패턴·임계값·프롬프트는 `config/memory-extraction`로 **외부화**(no-hardcoding).

## 검증

라이브(dist+실DB, 휴리스틱 ON): "내 별명은 X 기억해줘"→저장(source=candidate), **중복 호출 dedup**(1건), **guest 무시**. 순수함수 유닛 9 pass, tsc 0, lint 0 error.
⚠️ LLM 추출 경로는 플래그 OFF·라이브 미검증(활성 시 검증 예정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)