### PR TITLE
feat(memory): 과거 대화 데이터 백필 (#3 c)

### DIFF
--- a/apps/api/src/cli.ts
+++ b/apps/api/src/cli.ts
@@ -359,6 +359,34 @@ program
         }
     });
 
+// backfill-memories 명령어 — 과거 대화(#3 c)에서 사용자 메모리 일회성 추출/저장
+program
+    .command('backfill-memories <userId>')
+    .description('과거 대화에서 사용자 메모리를 LLM 추출해 저장(#3 c). --dry-run 으로 저장 없이 미리보기.')
+    .option('--dry-run', '저장하지 않고 추출 후보만 출력')
+    .option('--max-sessions <n>', '분석할 최근 세션 수', '30')
+    .action(async (userId, options) => {
+        const { backfillUserMemories } = await import('./services/chat-service/memory-backfill');
+        const dryRun = !!options.dryRun;
+        console.log(chalk.cyan(`\n🧠 메모리 백필 ${dryRun ? '(dry-run)' : ''} — user ${userId}\n`));
+        const spinner = createSpinner('과거 세션 분석 중...');
+        spinner.start();
+        try {
+            const r = await backfillUserMemories(userId, { dryRun, maxSessions: parseInt(options.maxSessions, 10) });
+            spinner.succeed(`세션 ${r.sessionsProcessed} 처리 · 후보 ${r.candidateCount} · 신규 ${r.fresh.length} · 저장 ${r.saved} · 중복 ${r.skippedDup}`);
+            if (r.fresh.length > 0) {
+                console.log(chalk.cyan(`\n${dryRun ? '추출 후보(미저장)' : '저장된 메모리'}:`));
+                r.fresh.forEach((m, i) => console.log(chalk.white(`  ${i + 1}. ${m}`)));
+            }
+            console.log('');
+        } catch (e) {
+            spinner.fail('백필 실패');
+            console.log(chalk.red(`\n❌ ${e instanceof Error ? e.message : String(e)}\n`));
+            process.exit(1);
+        }
+        process.exit(0);
+    });
+
 // 기본 명령 (인수 없이 실행 시)
 program
     .action(async () => {

--- a/apps/api/src/services/chat-service/memory-backfill.ts
+++ b/apps/api/src/services/chat-service/memory-backfill.ts
@@ -1,0 +1,82 @@
+/**
+ * 과거 대화 데이터 백필(#3 c) — 기존 conversation_messages 에서 사용자 메모리를 일회성 추출.
+ * 사용자별 과거 세션의 user 메시지를 LLM 으로 분석해 지속적 사실을 뽑아 source='batch' 로 저장.
+ * #3(b)의 추출·dedup·cap 을 그대로 재사용. dryRun 지원(대량 기록 전 품질 확인).
+ * 세션 단위 병렬(제한 동시성) — 개별 세션 실패는 스킵.
+ *
+ * @module services/chat-service/memory-backfill
+ */
+import { getPool } from '../../data/models/unified-database';
+import { UserMemoryRepository } from '../../data/repositories/user-memory-repository';
+import { createClient } from '../../llm/client';
+import { extractLLMMemories, isDuplicateMemory } from './memory-extraction';
+import { MEMORY_EXTRACTION } from '../../config/memory-extraction';
+import { parallelBatch } from '../../workflow/graph-engine';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('MemoryBackfill');
+
+export interface BackfillResult {
+    sessionsProcessed: number;
+    candidateCount: number;
+    fresh: string[];
+    saved: number;
+    skippedDup: number;
+    dryRun: boolean;
+}
+
+/**
+ * 사용자 과거 대화에서 메모리 백필. dryRun=true 면 저장 없이 추출 후보만 반환.
+ */
+export async function backfillUserMemories(
+    userId: string,
+    opts: { dryRun?: boolean; maxSessions?: number; minChars?: number; concurrency?: number } = {},
+): Promise<BackfillResult> {
+    const { dryRun = false, maxSessions = 30, minChars = 40, concurrency = 3 } = opts;
+    const pool = getPool();
+
+    // 사용자 과거 세션의 user 메시지 병합(최근 우선).
+    const rows = (await pool.query(
+        `SELECT s.id, string_agg(m.content, E'\n' ORDER BY m.created_at) AS user_text
+         FROM conversation_sessions s
+         JOIN conversation_messages m ON m.session_id = s.id
+         WHERE s.user_id = $1 AND m.role = 'user'
+         GROUP BY s.id
+         ORDER BY max(m.created_at) DESC
+         LIMIT $2`,
+        [userId, maxSessions],
+    )).rows as Array<{ id: string; user_text: string }>;
+    const sessions = rows.filter((r) => (r.user_text || '').length >= minChars);
+
+    const client = createClient();
+    const perSession = await parallelBatch(
+        sessions,
+        async (s) => extractLLMMemories(client, s.user_text),
+        { concurrency },
+    );
+    const candidates = [...new Set((perSession.flat().filter(Boolean) as string[]))];
+
+    const repo = new UserMemoryRepository(pool);
+    const existing = (await repo.listActiveByUser(userId, MEMORY_EXTRACTION.maxCount)).map((m) => m.content);
+    const fresh: string[] = [];
+    let skippedDup = 0;
+    for (const c of candidates) {
+        if (isDuplicateMemory(c, [...existing, ...fresh])) { skippedDup += 1; continue; }
+        fresh.push(c);
+    }
+
+    let saved = 0;
+    if (!dryRun && fresh.length > 0) {
+        const { randomUUID } = await import('node:crypto');
+        let count = existing.length;
+        for (const c of fresh) {
+            if (count >= MEMORY_EXTRACTION.maxCount) break;
+            await repo.create(randomUUID(), userId, c, 'batch');
+            count += 1;
+            saved += 1;
+        }
+        logger.info(`[Backfill] user ${userId}: ${saved} 저장 (세션 ${sessions.length}, 후보 ${candidates.length}, 중복 ${skippedDup})`);
+    }
+
+    return { sessionsProcessed: sessions.length, candidateCount: candidates.length, fresh, saved, skippedDup, dryRun };
+}


### PR DESCRIPTION
## 배경

"기존에 쌓인 데이터를 활용할 수 없나?"에 대한 답 — #3(b) 자동형성이 **앞으로의 대화**만 처리하던 것을, `conversation_messages`에 쌓인 **과거 대화까지 소급 추출**.

## 수정

- `services/chat-service/memory-backfill.ts`: `backfillUserMemories(userId, {dryRun, maxSessions})` — 사용자 과거 세션의 user 메시지를 세션 단위 LLM 추출(#3b `extractLLMMemories` **재사용**), dedup+cap 후 `source='batch'` 저장. **dryRun**으로 대량 기록 전 품질 확인. 세션 병렬(concurrency 3).
- `cli.ts`: `backfill-memories <userId> [--dry-run] [--max-sessions n]` 커맨드(admin 일회성 운용).

## 검증

- 추출 경로 정상: 개인 사실 메시지 → "서울 거주 백엔드 개발자"·"파이썬/Go 사용"·"등산 취미" 추출 / 작업 질의 → NONE
- CLI dry-run 동작 확인. tsc 0, lint 0 error, cli 397줄

## ⚠️ 관찰 (중요)

현 배포 실데이터(관리자/테스트 계정 3·11)는 **전부 작업성 질의**("html로 작성", "코스피 예측", "이미지 그려줘")라 backfill **yield≈0** — 결함이 아니라 **데이터 성격**. 대화체로 쓰는 실사용자에게는 유효. 대량 실행은 개별 판단(프라이버시).

🤖 Generated with [Claude Code](https://claude.com/claude-code)