### PR TITLE
feat(agent-task): Computer Use — a11y 브라우저 폴백 + Stage 0 계측

### DIFF
--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1158,6 +1158,10 @@ export const AGENT_TASK_LIMITS = {
     PROCEDURAL_SKILLS_ENABLED: process.env.AGENT_TASK_PROCEDURAL_SKILLS === 'true',
     /** 재사용 후보로 system 에 제안할 절차 스킬 최대 건수(기본 3). */
     PROCEDURAL_MAX_SUGGEST: parseInt(process.env.AGENT_TASK_PROCEDURAL_MAX_SUGGEST || '3', 10),
+    /** Computer Use Stage 0: browser 액션 계측(browser_action_metrics 079)을 기록한다.
+     *  a11y 폴백 실효 + canvas 신호(selector·a11y 동시 실패)를 주-단위로 집계해 Stage 1
+     *  분기(State block vs Vision)를 데이터로 결정. 측정이 목적이라 기본 ON — 끄려면 =false. */
+    BROWSER_METRICS_ENABLED: process.env.AGENT_TASK_BROWSER_METRICS !== 'false',
     /** 산출물 검증 모드(Phase 5-3): 'syntax'(기본 — py_compile·node --check) | 'run'(샌드박스에서
      *  실제 실행 후 exit code 검사 — network none·자원캡 격리라 안전하나 부작용 있는 코드는 실행됨). */
     VERIFY_MODE: (process.env.AGENT_TASK_VERIFY_MODE === 'run' ? 'run' : 'syntax') as 'syntax' | 'run',

--- a/apps/api/src/services/task-sandbox/browser-metrics.ts
+++ b/apps/api/src/services/task-sandbox/browser-metrics.ts
@@ -1,0 +1,70 @@
+/**
+ * Agent Task 브라우저 액션 계측 (Computer Use Stage 0).
+ *
+ * browser-runner.mjs 의 결과 JSON(results[])을 집계해 browser_action_metrics(079)에 영속.
+ * 목적: a11y 폴백 실효 검증 + DOM/a11y 한계(canvas 신호) 실수요 측정 → Stage 1 분기 결정.
+ * 순수 파서(parseBrowserMetric)와 영속(recordBrowserMetric)을 분리해 파서만 단위 테스트한다.
+ *
+ * @module services/task-sandbox/browser-metrics
+ */
+import { getPool } from '../../data/models/unified-database';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('BrowserMetrics');
+
+/** CSS 셀렉터 액션(실패 시 a11y 폴백 대상). */
+const SELECTOR_TYPES = new Set(['click', 'fill']);
+/** a11y 폴백 액션(방금 배포한 snapshot/smartClick/smartFill). */
+const A11Y_TYPES = new Set(['snapshot', 'smartClick', 'smartFill']);
+/** a11y 조작 액션(발동만이 아니라 성패를 따지는 대상 — snapshot 은 발견이라 제외). */
+const A11Y_ACT_TYPES = new Set(['smartClick', 'smartFill']);
+
+export interface BrowserMetricSignal {
+    totalActions: number;
+    selectorActions: number;
+    selectorFail: number;
+    a11yAttempt: number;
+    a11yFail: number;
+    overallOk: boolean;
+}
+
+/** browser-runner stdout(JSON) → 집계 신호. 파싱 불가/결과 없음이면 null(잡음 미기록). */
+export function parseBrowserMetric(stdout: string): BrowserMetricSignal | null {
+    let obj: unknown;
+    try { obj = JSON.parse(stdout); } catch { return null; }
+    if (!obj || typeof obj !== 'object') return null;
+    const results = (obj as { results?: unknown }).results;
+    if (!Array.isArray(results)) return null;
+
+    let selectorActions = 0, selectorFail = 0, a11yAttempt = 0, a11yFail = 0;
+    for (const r of results) {
+        if (!r || typeof r !== 'object') continue;
+        const type = String((r as { type?: unknown }).type ?? '');
+        const ok = (r as { ok?: unknown }).ok === true;
+        if (SELECTOR_TYPES.has(type)) { selectorActions++; if (!ok) selectorFail++; }
+        if (A11Y_TYPES.has(type)) a11yAttempt++;
+        if (A11Y_ACT_TYPES.has(type) && !ok) a11yFail++;
+    }
+    return {
+        totalActions: results.length,
+        selectorActions,
+        selectorFail,
+        a11yAttempt,
+        a11yFail,
+        overallOk: (obj as { ok?: unknown }).ok === true,
+    };
+}
+
+/** stdout 파싱 후 browser_action_metrics 에 1행 INSERT (fire-and-forget, fail-open). */
+export function recordBrowserMetric(taskId: string, userId: string, stdout: string): void {
+    const s = parseBrowserMetric(stdout);
+    if (!s) return;
+    getPool()
+        .query(
+            `INSERT INTO browser_action_metrics
+                (task_id, user_id, total_actions, selector_actions, selector_fail, a11y_attempt, a11y_fail, overall_ok)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+            [taskId, userId, s.totalActions, s.selectorActions, s.selectorFail, s.a11yAttempt, s.a11yFail, s.overallOk],
+        )
+        .catch((e) => logger.warn(`browser 계측 기록 실패(무시): ${e instanceof Error ? e.message : String(e)}`));
+}

--- a/apps/api/src/services/task-sandbox/runtime.ts
+++ b/apps/api/src/services/task-sandbox/runtime.ts
@@ -13,6 +13,7 @@ import type { MCPToolDefinition } from '../../mcp/types';
 import { getTaskSandboxConfig, type TaskSandboxConfig } from '../../config/task-sandbox';
 import { TaskSandbox, type ExecResult } from './sandbox';
 import { createTaskTools, type DelegateFn, type SpawnFn, type ProceduralHooks } from './tools';
+import { recordBrowserMetric } from './browser-metrics';
 import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
 import { saveProceduralSkill, resolveProceduralSpec } from '../agent-task/procedural-skill';
 import { TaskPlan, type PlanStep } from './planning';
@@ -76,7 +77,11 @@ export class TaskRuntime {
                 load: (id) => resolveProceduralSpec(this.userId, id),
             }
             : undefined;
-        this.defs = createTaskTools(this.sandbox, this.plan, delegate, spawn, procedural);
+        // Computer Use Stage 0: browser 액션 계측을 taskId/userId 로 바인딩해 주입(fire-and-forget).
+        const browserMetrics = AGENT_TASK_LIMITS.BROWSER_METRICS_ENABLED
+            ? (stdout: string) => recordBrowserMetric(this.taskId, this.userId, stdout)
+            : undefined;
+        this.defs = createTaskTools(this.sandbox, this.plan, delegate, spawn, procedural, browserMetrics);
         for (const d of this.defs) this.handlers.set(d.tool.name, d.handler);
     }
 

--- a/apps/api/src/services/task-sandbox/tools.ts
+++ b/apps/api/src/services/task-sandbox/tools.ts
@@ -222,6 +222,8 @@ export function createTaskTools(
             description: '영속 컨테이너 내 chromium 으로 웹 브라우저를 자동화합니다(G2). actions 배열을 순서대로 실행: ' +
                 'goto{url} · click{selector} · fill{selector,text} · press{key} · wait{ms} · waitFor{selector} · ' +
                 'screenshot{path?} · extractText{selector?} · extractHtml{selector?}. 결과를 JSON 으로 반환합니다. ' +
+                'CSS 셀렉터(click/fill)가 실패하면 snapshot 으로 상호작용 요소를 {role,name,index} 목록으로 얻은 뒤 ' +
+                'smartClick{role,name,nth?}·smartFill{role,name,text,nth?} 로 재시도하세요(CSS 변동에 견고). ' +
                 '네트워크는 샌드박스 정책(none/restricted)에 따라 제한됩니다.',
             inputSchema: {
                 type: 'object',

--- a/apps/api/src/services/task-sandbox/tools.ts
+++ b/apps/api/src/services/task-sandbox/tools.ts
@@ -81,6 +81,7 @@ export function createTaskTools(
     delegate?: DelegateFn,
     spawn?: SpawnFn,
     procedural?: ProceduralHooks,
+    browserMetrics?: (stdout: string) => void,
 ): MCPToolDefinition[] {
     const bash: MCPToolDefinition = {
         tool: {
@@ -259,7 +260,9 @@ export function createTaskTools(
                 return textResult(`액션 파일 쓰기 실패: ${e instanceof Error ? e.message : String(e)}`, true);
             }
             // 메인 샌드박스(network none)가 아닌 별도 일회성 컨테이너에서 실행.
-            return formatExec(await sandbox.runBrowser('.browser-actions.json'));
+            const r = await sandbox.runBrowser('.browser-actions.json');
+            browserMetrics?.(r.stdout); // Stage 0 계측(fail-open)
+            return formatExec(r);
         },
     };
 
@@ -459,7 +462,9 @@ export function createTaskTools(
                         ...(sandbox.browserStatePath ? { statePath: sandbox.browserStatePath } : {}),
                     };
                     await sandbox.writeFile('.browser-actions.json', JSON.stringify(specOut));
-                    return formatExec(await sandbox.runBrowser('.browser-actions.json'));
+                    const r = await sandbox.runBrowser('.browser-actions.json');
+                    browserMetrics?.(r.stdout); // Stage 0 계측(fail-open)
+                    return formatExec(r);
                 }
                 // kind === 'script'
                 const code = sub(spec.code ?? '');

--- a/db/migrations/079_browser_action_metrics.sql
+++ b/db/migrations/079_browser_action_metrics.sql
@@ -1,0 +1,26 @@
+-- Migration 079 — Agent Task 브라우저 액션 계측 (Computer Use Stage 0)
+--
+-- browser 도구 호출마다 액션 결과를 집계해 영속화한다. 목적은 두 가지 의사결정 게이트:
+--   ① 방금 배포한 a11y 폴백(snapshot/smartClick/smartFill)이 실제로 발동·구원하는가
+--      (배포 실효 검증)
+--   ② DOM/a11y 셀렉터 경로의 한계(canvas/비표준 UI = selector_fail>0 AND a11y_fail>0)가
+--      실사용에서 얼마나 발생하는가 → State block(경로 A) vs Vision+좌표클릭(경로 B) 실수요 판정.
+--
+-- model_pool_metrics(031) 와 동일 성격: browser 호출당 1행(빈도 낮음), PII 없음(수치만).
+-- 주-단위 집계로 Stage 1 분기를 데이터로 결정한다(measure-first).
+
+CREATE TABLE IF NOT EXISTS browser_action_metrics (
+    id               SERIAL PRIMARY KEY,
+    task_id          TEXT NOT NULL,
+    user_id          TEXT NOT NULL,
+    total_actions    INTEGER NOT NULL,
+    selector_actions INTEGER NOT NULL,  -- CSS 셀렉터 액션(click/fill) 수
+    selector_fail    INTEGER NOT NULL,  -- 그중 실패 수 → CSS 실패율 분자
+    a11y_attempt     INTEGER NOT NULL,  -- a11y 폴백(snapshot/smartClick/smartFill) 사용 수
+    a11y_fail        INTEGER NOT NULL,  -- smartClick/smartFill 실패 수
+    overall_ok       BOOLEAN NOT NULL,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_browser_action_metrics_created ON browser_action_metrics(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_browser_action_metrics_task ON browser_action_metrics(task_id);

--- a/infra/task-runtime/browser-runner.mjs
+++ b/infra/task-runtime/browser-runner.mjs
@@ -17,6 +17,25 @@ const WORKSPACE = '/workspace';
 const MAX_ACTIONS = 40;
 const DEFAULT_TIMEOUT = 20000;
 
+// #2 Part B — a11y 폴백: CSS 셀렉터가 실패하는 페이지에서 상호작용 요소를
+// {role,name} 으로 재해석한다. role/name 은 fresh page 에서도 안정적으로 재해석되므로
+// 일회성 컨테이너(호출 간 page 소멸) 제약과 자연히 양립한다(ref 캐시 불필요).
+const INTERACTIVE_ROLES = new Set([
+    'button', 'link', 'textbox', 'checkbox', 'radio', 'combobox', 'menuitem',
+    'tab', 'switch', 'searchbox', 'slider', 'spinbutton', 'option',
+]);
+
+/** ariaSnapshot() YAML(줄당 `- role "name" [attrs]`)에서 상호작용 요소만 {role,name} 으로 추출.
+ *  (playwright 1.61 은 page.accessibility 를 제거 — ariaSnapshot 이 현행 a11y 조회 API.) */
+function parseAriaSnapshot(yaml) {
+    const acc = [];
+    for (const line of String(yaml).split('\n')) {
+        const m = line.match(/^\s*-\s+([a-z]+)\s+"([^"]*)"/);
+        if (m && INTERACTIVE_ROLES.has(m[1])) acc.push({ role: m[1], name: m[2].slice(0, 120) });
+    }
+    return acc;
+}
+
 function out(obj) { process.stdout.write(JSON.stringify(obj)); }
 
 const argPath = process.argv[2];
@@ -84,6 +103,21 @@ try {
                     results.push({ i, type: a.type, ok: true }); break;
                 case 'fill':
                     await page.fill(a.selector, String(a.text ?? ''), { timeout });
+                    results.push({ i, type: a.type, ok: true }); break;
+                case 'snapshot': {
+                    // 2단 폴백 발견: 상호작용 요소를 {role,name,index} 목록으로 반환 →
+                    // 에이전트가 CSS 대신 안정적인 role/name 으로 smartClick/smartFill 지정.
+                    const yaml = await page.locator('body').ariaSnapshot();
+                    const elements = parseAriaSnapshot(yaml).slice(0, 100).map((e, idx) => ({ index: idx, ...e }));
+                    results.push({ i, type: a.type, ok: true, elements }); break;
+                }
+                case 'smartClick':
+                    // role/name 으로 요소 재해석 후 클릭(CSS 무관). nth 로 동명 요소 구분.
+                    await page.getByRole(a.role, { name: a.name }).nth(Number(a.nth) || 0).click({ timeout });
+                    results.push({ i, type: a.type, ok: true }); break;
+                case 'smartFill':
+                    await page.getByRole(a.role, { name: a.name }).nth(Number(a.nth) || 0)
+                        .fill(String(a.text ?? ''), { timeout });
                     results.push({ i, type: a.type, ok: true }); break;
                 case 'press':
                     await page.keyboard.press(a.key);


### PR DESCRIPTION
## 개요
Computer Use 관점의 2가지 증분. 실코드 감사 기반으로 **measure-first** 원칙에 맞춰 구현.

### 1. a11y 브라우저 폴백 (#2 Part B 2단) — `62c95ab2`
CSS 셀렉터가 실패하는 페이지(구조변동·canvas·비표준 UI)를 role/name 으로 재해석하는 폴백.
- `browser-runner.mjs`: `snapshot`(ariaSnapshot YAML→`{role,name,index}`) + `smartClick{role,name,nth?}` + `smartFill{role,name,text,nth?}`
- role/name 은 fresh page 에서 재해석되므로 일회성 컨테이너(호출 간 page 소멸)와 양립 — ref 캐시 불필요
- `tools.ts` browser 도구 설명에 "CSS 실패→snapshot→smartClick/smartFill" 가이드 추가
- ⚠️ Playwright 1.61 은 `page.accessibility` 제거 → `ariaSnapshot()` 사용

### 2. Stage 0 브라우저 액션 계측 — `64cef94d`
a11y 폴백 실효 + DOM/a11y 한계(canvas 신호)를 주-단위로 집계해 다음 단계(State block vs Vision)를 **데이터로** 결정하기 위한 계측.
- `079_browser_action_metrics`: browser 호출당 1행 (model_pool_metrics 선례, PII 없음)
- `browser-metrics.ts`: 순수 파서 `parseBrowserMetric`(선택자/a11y 성패 집계) + fail-open `recordBrowserMetric`
- `createTaskTools` 에 `browserMetrics` 훅 추가(delegate/spawn/procedural 패턴) — browser 핸들러 + skill_run 재생 2곳
- 플래그 `AGENT_TASK_BROWSER_METRICS` (측정이 목적이라 기본 ON)

## 검증
- ✅ 타입체크 · 유닛테스트(파서 3케이스 + 기존 24) · lint 0 errors
- ✅ **a11y 폴백 라이브 검증**: 실 task-runtime 이미지 chromium 1.61.1, `--network none`, file:// 픽스처 — snapshot 3요소 추출 + smartFill/smartClick 후 DOM 조작 입증
- ✅ **Stage 0 E2E 스모크**: 실 API 로 브라우저 태스크 1건 구동(승인게이트 통과) → `browser_action_metrics` 행 기록 확인(합성 행은 정리)

## 운영 반영 (완료)
- task-runtime 이미지 재빌드 ✅ (browser-runner 는 빌드타임 COPY)
- 마이그레이션 079 적용 ✅
- apps/api 배포(pm2 `openmake-llm` 재시작) ✅

## 신규 테이블/마이그레이션
- `browser_action_metrics` (079) — 수동 적용 완료

## 다음 단계
2~4주 데이터 축적 후 canvas 신호/태스크당 호출수로 Stage 1(State block vs Vision) 결정 (measure-first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)