### PR TITLE
feat(bootstrap): clone 후 즉시 구동 이식성 확보

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -305,9 +305,12 @@ NAVER_CLIENT_SECRET=your_naver_client_secret_here
 # *******************************************************
 # PostgreSQL 데이터베이스 — 운영 전 db + user + password 생성 필요
 # Setup: psql postgres -c "CREATE USER openmake WITH PASSWORD '<pw>'; CREATE DATABASE openmake_llm OWNER openmake;"
-# 스키마는 첫 실행 시 자동 생성 (services/database/init/002-schema.sql)
-# 마이그레이션 적용 (필요 시): npx ts-node backend/api/src/data/migrations/cli.ts migrate
+# 스키마는 첫 실행 시 자동 생성 (db/init/002-schema.sql = baseline) +
+# db/migrations/ 의 증분 스키마를 부팅 시 자동 적용 (advisory lock, 멱등). → clone 후 바로 완전한 스키마.
 DATABASE_URL=postgresql://openmake:your_password@localhost:5432/openmake_llm  # ⭐ 필수
+# 부팅 시 pending 마이그레이션 자동 적용 (기본 true). false 로 끄고 수동 CLI 만 사용 가능:
+#   npx ts-node apps/api/src/data/migrations/cli.ts migrate
+# DB_AUTO_MIGRATE=true
 
 # --- DB 를 Docker 로 분리 운영할 때 (docker-compose.yml) ---
 # DB_RUNTIME=docker 면 openmake_llm.sh 가 brew 대신 docker compose 로 PostgreSQL/Redis 기동.
@@ -318,9 +321,9 @@ DATABASE_URL=postgresql://openmake:your_password@localhost:5432/openmake_llm  # 
 # POSTGRES_DB=openmake_llm
 # POSTGRES_PORT=5432
 # REDIS_PORT=6379
-# docker compose 파일 경로. openmake_llm.sh / docker compose 가 -f 로 참조 (머신별 절대경로).
-# 미설정 시 docker 기본 탐색(cwd 의 docker-compose.yml). 데이터 위치 정책: /Volumes/MAC_APP/docker/<name>/
-# COMPOSE_FILE=/Volumes/MAC_APP/docker/openmake_llm/docker-compose.yml
+# docker compose 파일 경로. openmake_llm.sh / docker compose 가 -f 로 참조.
+# 미설정 시 레포의 infra/docker-compose.yml 사용 (openmake_llm.sh 기본값). 절대경로로 override 가능.
+# COMPOSE_FILE=/path/to/docker-compose.yml
 
 # 프론트 단일화(3000↔52416 분기 제거): 설정 시 백엔드(52416)로 직접 온 페이지(HTML) 요청을
 # 이 주소로 302 리다이렉트한다. /api·/ws·정적자산은 제외. dev 에서 Next(3000) 단일 진입점용.
@@ -972,7 +975,7 @@ ARTIFACT_EXEC_ENABLED=false
 # Artifact Viewer (C안 — 별도 오리진 엄격 CSP 공유 뷰어). infra/artifact-viewer/ 참고.
 ARTIFACT_VIEWER_ENABLED=false                          # publish 시 self-contained HTML export + 별도 오리진 서빙
 # ARTIFACT_VIEWER_ORIGIN=http://localhost:8088         # 뷰어 공개 origin(외부공개 시 Funnel :8443 URL)
-# ARTIFACT_VIEWER_DATA_DIR=/Volumes/MAC_APP/docker/openmake_llm/artifact-viewer/data  # 백엔드 export 경로(nginx read-only mount)
+# ARTIFACT_VIEWER_DATA_DIR=/path/to/artifact-viewer/data  # 백엔드 export 경로(nginx read-only mount). 미설정 시 <repo>/data/artifact-viewer
 # ARTIFACT_VIEWER_SIGNING_KEY=                         # authenticated/private 접근토큰 HMAC 키(미설정 시 JWT_SECRET)
 # ARTIFACT_VIEWER_TOKEN_TTL_SEC=3600                   # 접근토큰 TTL(초)
 # ARTIFACT_VIEWER_TRUSTED_CDNS=...                     # 신뢰 CDN(script/style/img/font 허용, connect-src는 none 유지). 기본 cdnjs/unpkg/jsdelivr
@@ -1031,7 +1034,7 @@ IMAGE_GEN_TIMEOUT_MS=180000
 # *******************************************************
 # SearXNG 자가호스팅 메타검색 (docker — key 불필요, Google CSE 무료 대체)
 # *******************************************************
-# docker compose (/Volumes/MAC_APP/docker/searxng/) 로 기동 후 URL 지정. 미설정 시 비활성.
+# docker compose 로 기동 후 URL 지정. 미설정 시 비활성.
 # SEARXNG_URL=http://127.0.0.1:8888
 
 # 채팅 자동 노출 user MCP 도구 상한 (설치=기본 ON, 로컬 qwen tool-bloat 방지)

--- a/apps/api/src/config/artifact-viewer.ts
+++ b/apps/api/src/config/artifact-viewer.ts
@@ -7,6 +7,7 @@
  *
  * 외부화 (No-Hardcoding L1): 모든 값 env override.
  */
+import * as path from 'path';
 
 /** 뷰어 공개 base URL (별도 오리진). 로컬: http://localhost:8088, 외부: Funnel :8443 URL. */
 const ORIGIN = process.env.ARTIFACT_VIEWER_ORIGIN || 'http://localhost:8088';
@@ -24,7 +25,7 @@ export const ARTIFACT_VIEWER = {
      * 구조: {dataDir}/a/{pubId}/index.html , {dataDir}/vendor/*.js
      */
     dataDir: process.env.ARTIFACT_VIEWER_DATA_DIR
-        || '/Volumes/MAC_APP/docker/openmake_llm/artifact-viewer/data',
+        || path.resolve(process.cwd(), 'data/artifact-viewer'),
 
     /**
      * 뷰어 접근토큰(authenticated/private) 서명 키 — HMAC-SHA256.

--- a/apps/api/src/data/migrations/runner.ts
+++ b/apps/api/src/data/migrations/runner.ts
@@ -182,3 +182,31 @@ export class MigrationRunner {
         );
     }
 }
+
+/** 마이그레이션 직렬화용 전역 advisory lock 키 (앱 전역 유일 고정값 — "omlm" 의 hex). */
+const MIGRATION_ADVISORY_LOCK_KEY = 0x6f6d6c6d;
+
+/**
+ * 부팅 시 pending 마이그레이션을 자동 적용한다 (advisory lock 으로 다중 인스턴스 직렬화).
+ *
+ * 부팅 init(002-schema.sql)은 baseline 테이블만 생성하므로, migrations/ 의 증분 스키마를
+ * 여기서 적용해야 artifacts/user_agents/mcp_server_catalog/skill_* 등이 완성된다.
+ * 여러 인스턴스가 동시에 부팅해도 pg_advisory_lock 으로 한 번에 하나만 실행하고,
+ * 나머지는 락 획득 시점에 이미 적용 완료 상태 → 전부 skip 된다. (마이그레이션은
+ * 전부 멱등 IF NOT EXISTS 이므로 락 없이 재실행돼도 안전하지만, 락으로 경합 로그를 줄인다.)
+ */
+export async function applyPendingWithLock(
+    pool: Pool
+): Promise<{ applied: string[]; skipped: string[] }> {
+    const lockClient = await pool.connect();
+    try {
+        await lockClient.query('SELECT pg_advisory_lock($1)', [MIGRATION_ADVISORY_LOCK_KEY]);
+        try {
+            return await new MigrationRunner(pool).applyPending();
+        } finally {
+            await lockClient.query('SELECT pg_advisory_unlock($1)', [MIGRATION_ADVISORY_LOCK_KEY]);
+        }
+    } finally {
+        lockClient.release();
+    }
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -204,6 +204,23 @@ export class DashboardServer {
             process.exit(1);
         }
 
+        // 부팅 시 pending 마이그레이션 자동 적용 (advisory lock 으로 다중 인스턴스 직렬화).
+        // 부팅 init(002-schema.sql)은 baseline 만 생성 → migrations/ 의 증분 스키마를 여기서
+        // 적용해야 artifacts/user_agents/mcp_server_catalog/skill_* 테이블이 완성된다.
+        // 외부 MCP·스킬 시더가 이 테이블들에 의존하므로 그보다 먼저 실행해야 한다.
+        // (DB_AUTO_MIGRATE=false 로 opt-out — 수동 CLI 운영 시)
+        if (process.env.DB_AUTO_MIGRATE !== 'false') {
+            try {
+                const { applyPendingWithLock } = await import('./data/migrations/runner');
+                const { getPool } = await import('./data/models/unified-database');
+                const { applied, skipped } = await applyPendingWithLock(getPool());
+                console.log(`[Server] 마이그레이션 자동 적용 완료 — 적용 ${applied.length}건, skip ${skipped.length}건`);
+            } catch (err) {
+                console.error('[Server] 마이그레이션 자동 적용 실패 — Fail-Fast:', err);
+                process.exit(1);
+            }
+        }
+
         // 외부 MCP 서버 초기화 (DB에서 설정 로드 → stdio 연결)
         try {
             const { getUnifiedMCPClient } = await import('./mcp');

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -18,6 +18,40 @@
  *   # /tmp/openmake-llm-*.log 가 10MB 도달 시 회전, 30일 보관, gzip 압축
  *   # 미설정 시 단일 로그 파일이 무한 증가 → 디스크 가득 위험
  */
+const { execSync } = require('child_process');
+const path = require('path');
+
+/**
+ * JVM 위치를 크로스플랫폼으로 탐지한다 (opendataloader-pdf 의 PDF 텍스트 추출에 필요).
+ * 우선순위: 명시적 JAVA_HOME > macOS /usr/libexec/java_home > PATH 의 java 역추적.
+ * 못 찾으면 '' 반환 → 라이브러리가 PATH 의 java 로 자체 탐색(있으면 동작, 없으면 PDF 만 비활성).
+ * (구 하드코딩 /opt/homebrew/opt/openjdk@17 은 Apple Silicon 전용이라 Intel/Linux 에서 부재였음)
+ */
+function resolveJavaHome() {
+    if (process.env.JAVA_HOME) return process.env.JAVA_HOME;
+    try {
+        if (process.platform === 'darwin') {
+            // macOS 내장 — 활성 JDK home 반환 (Intel/ARM 무관). JDK 없으면 exit 1 → catch.
+            return execSync('/usr/libexec/java_home', { stdio: ['ignore', 'pipe', 'ignore'] })
+                .toString().trim();
+        }
+        // Linux/기타 — PATH 의 java 실행파일에서 home 역추적 (…/bin/java → …).
+        const javaBin = execSync('command -v java', { stdio: ['ignore', 'pipe', 'ignore'] })
+            .toString().trim();
+        if (javaBin) {
+            const real = execSync(`readlink -f "${javaBin}"`, { stdio: ['ignore', 'pipe', 'ignore'] })
+                .toString().trim() || javaBin;
+            return path.dirname(path.dirname(real)); // …/bin/java → …
+        }
+    } catch {
+        // java 미설치 — PDF 추출만 비활성, 앱 부팅·기타 기능은 정상.
+    }
+    return '';
+}
+
+const JAVA_HOME = resolveJavaHome();
+const JAVA_PATH_PREFIX = JAVA_HOME ? path.join(JAVA_HOME, 'bin') + path.delimiter : '';
+
 module.exports = {
     apps: [{
         name: 'openmake-llm',
@@ -30,9 +64,9 @@ module.exports = {
             NODE_ENV: 'production',
             PORT: 52416,
             // 문서 첨부 추출(opendataloader-pdf)은 Java 11+ 가 필요하다.
-            // pm2 프로세스가 JVM 을 찾도록 JAVA_HOME 과 PATH 에 openjdk@17 을 주입.
-            JAVA_HOME: '/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home',
-            PATH: '/opt/homebrew/opt/openjdk@17/bin:' + (process.env.PATH || ''),
+            // pm2 프로세스가 JVM 을 찾도록 자동 탐지한 JAVA_HOME 과 PATH 를 주입 (크로스플랫폼).
+            ...(JAVA_HOME ? { JAVA_HOME } : {}),
+            PATH: JAVA_PATH_PREFIX + (process.env.PATH || ''),
         },
         
         // 프로세스 관리


### PR DESCRIPTION
## 배경

새 시스템에 `git clone` 후 바로 가동하려 할 때 걸리는 이식성 걸림돌을 제거한다. **품질 관련 의존성(Java/opendataloader PDF 추출)은 그대로 유지**하고, 머신 고유 경로와 수동 스텝만 없앤다.

## 변경 내용

### 1. DB 부팅 자동 마이그레이션 ⭐ (핵심)
- `server.ts` 부팅 시 `applyPendingWithLock()` 으로 `db/migrations/` 증분 스키마를 자동 적용 (advisory lock 으로 다중 인스턴스 직렬화).
- **문제**: 부팅 init(`db/init/002-schema.sql`)은 baseline 35개 테이블만 생성. 그간 마이그레이션 CLI 를 깜빡하면 `artifacts`·`user_agents`·`mcp_server_catalog`·`skill_*` 등 **~30개 테이블이 누락된 채 조용히 부팅**되고, 해당 기능 실행 시 `relation does not exist` 에러 발생.
- 스키마 init 완료 후 → 외부 MCP·스킬 시더 **전에** 실행 (시더가 마이그레이션 테이블에 의존).
- `DB_AUTO_MIGRATE=false` 로 opt-out (수동 CLI 운영 시). 실패 시 기존 DB init 과 동일하게 fail-fast.

### 2. JAVA_HOME 크로스플랫폼 자동 탐지
- `ecosystem.config.js` 의 하드코딩 `/opt/homebrew/opt/openjdk@17` (Apple Silicon 전용) 제거.
- `/usr/libexec/java_home`(macOS) / `command -v java`(Linux) 로 자동 탐지. Java 미설치 시 PDF 추출만 비활성, 앱 부팅은 정상.

### 3. artifact-viewer 경로 기본값 레포 상대화
- `/Volumes/MAC_APP/...` → `<repo>/data/artifact-viewer` (env override 우선, 기능 default-off).

### 4. `.env.example` 정리
- `DB_AUTO_MIGRATE` 문서화, 머신 절대경로 주석 일반화, stale 경로 수정(`backend/api`→`apps/api`, `services/database`→`db`).

## 검증
- ✅ `tsc --noEmit` 통과
- ✅ `eslint` 통과
- ✅ 마이그레이션 테스트 6개 통과
- ✅ `ecosystem.config.js` 평가 시 JAVA_HOME 실제 경로로 정상 resolve

## 남은 확인
- 라이브 DB 마이그레이션 실제 적용은 미실행 (운영 DB 는 이미 적용돼 있어 부팅 시 전부 skip 예상). 실제 부팅 검증은 배포 시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)