### PR TITLE
fix(auth): OAuth 실패 리디렉트 죽은 /login.html(404) → /login 교정

### DIFF
--- a/apps/api/src/controllers/auth-oauth.controller.ts
+++ b/apps/api/src/controllers/auth-oauth.controller.ts
@@ -344,7 +344,7 @@ export class AuthOAuthController {
         const { code, error: oauthError, state } = req.query;
 
         if (oauthError) {
-            res.redirect(`/login.html?error=${encodeURIComponent(String(oauthError))}`);
+            res.redirect(`/login?error=${encodeURIComponent(String(oauthError))}`);
             return;
         }
 
@@ -357,12 +357,12 @@ export class AuthOAuthController {
         // 🔒 Phase 2 CSRF 방어: state 검증 (Phase 3: DB 기반 비동기)
         if (!await validateAndConsumeState(state, 'google')) {
             log.error('[OAuth] Google callback: Invalid or expired state');
-            res.redirect('/login.html?error=invalid_state');
+            res.redirect('/login?error=invalid_state');
             return;
         }
 
         if (!code) {
-            res.redirect('/login.html?error=no_code');
+            res.redirect('/login?error=no_code');
             return;
         }
 
@@ -405,7 +405,7 @@ export class AuthOAuthController {
             sendOAuthSuccessRedirect(res, '/?auth=callback');
         } catch (error) {
             log.error('[OAuth Google Callback] 오류:', error);
-            res.redirect('/login.html?error=oauth_failed');
+            res.redirect('/login?error=oauth_failed');
         }
     }
 
@@ -416,7 +416,7 @@ export class AuthOAuthController {
         const { code, error: oauthError, state } = req.query;
 
         if (oauthError) {
-            res.redirect(`/login.html?error=${encodeURIComponent(String(oauthError))}`);
+            res.redirect(`/login?error=${encodeURIComponent(String(oauthError))}`);
             return;
         }
 
@@ -429,12 +429,12 @@ export class AuthOAuthController {
         // 🔒 Phase 2 CSRF 방어: state 검증 (Phase 3: DB 기반 비동기)
         if (!await validateAndConsumeState(state, 'github')) {
             log.error('[OAuth] GitHub callback: Invalid or expired state');
-            res.redirect('/login.html?error=invalid_state');
+            res.redirect('/login?error=invalid_state');
             return;
         }
 
         if (!code) {
-            res.redirect('/login.html?error=no_code');
+            res.redirect('/login?error=no_code');
             return;
         }
 
@@ -484,7 +484,7 @@ export class AuthOAuthController {
                 // primary 이메일이 없으면 OAuth 프로필에서 public 이메일 사용, 그것도 없으면 거부
                 if (!primaryEmail?.email) {
                     log.warn(`[OAuth GitHub] 이메일 비공개 사용자 로그인 거부: login=${githubUser.login}`);
-                    res.redirect('/login.html?error=email_required');
+                    res.redirect('/login?error=email_required');
                     return;
                 }
                 email = primaryEmail.email;
@@ -500,7 +500,7 @@ export class AuthOAuthController {
             sendOAuthSuccessRedirect(res, '/?auth=callback');
         } catch (error) {
             log.error('[OAuth GitHub Callback] 오류:', error);
-            res.redirect('/login.html?error=oauth_failed');
+            res.redirect('/login?error=oauth_failed');
         }
     }
 


### PR DESCRIPTION
## 문제
구글 로그인 "인증 안됨" 점검 중 발견. OAuth 콜백 에러 리디렉트 9곳이 legacy `/login.html` 을 가리키는데, Next.js(`apps/web`) 이전 후 이 경로는 **404**. 결과적으로 state 만료(TTL 5분)·`no_code`·`oauth_failed` 등 사소한 실패라도 사용자가 **404 막다른 페이지**에 떨어져 재로그인 경로조차 없이 "인증이 안 된다" 로 나타남.

## 수정
`auth-oauth.controller.ts` 의 `/login.html?error=` → `/login?error=` 9곳 일괄 교정 (유효 경로 200).

## 검증 (라이브, openmake.cc)
- bad state 콜백 → `302 /login?error=invalid_state` → 그 페이지 **200** (이전 404)
- 로그인 시작 정상 경로 `302` 유지 — 회귀 없음
- 백엔드 빌드 통과, `openmake-llm` 재시작 반영 완료

## 범위 밖 (후속)
- openmake.cc 외 도메인(ts.net/rasplay)은 동적 redirect_uri 가 `http://` 로 생성돼 구글 `redirect_uri_mismatch` — 별도 정책 결정 후 처리
- `/login` 페이지가 URL `?error=` 파라미터를 아직 표시하지 않음(재시도는 가능)

🤖 Generated with [Claude Code](https://claude.com/claude-code)