### PR TITLE
fix: 소스 점검 HIGH 2건 — 예약 task 완주 + 카카오 OAuth 이메일 검증

### DIFF
--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1141,6 +1141,16 @@ export const AGENT_TASK_LIMITS = {
     SCHEDULE_MIN_INTERVAL_SEC: parseInt(process.env.AGENT_TASK_SCHEDULE_MIN_INTERVAL_SEC || '300', 10),
     /** 연속 실패 이 횟수 도달 시 스케줄 자동 비활성(폭주 차단). AGENT_TASK_SCHEDULE_DISABLE_AFTER_FAILURES(기본 5). */
     SCHEDULE_DISABLE_AFTER_FAILURES: parseInt(process.env.AGENT_TASK_SCHEDULE_DISABLE_AFTER_FAILURES || '5', 10),
+    /** 예약 실행 승인정책 — 예약 task 는 무인(사람 승인 불가)이므로 기본 'none'(전부 자동).
+     *  전역 TASK_SANDBOX_APPROVAL_POLICY='all' 이면 예약 task 가 첫 도구서 pause 되어 멈추므로 분리한다.
+     *  AGENT_TASK_SCHEDULE_APPROVAL_POLICY(기본 'none' | 'high-risk' | 'all'). */
+    SCHEDULE_APPROVAL_POLICY: ((): 'all' | 'high-risk' | 'none' => {
+        const v = process.env.AGENT_TASK_SCHEDULE_APPROVAL_POLICY;
+        return v === 'all' || v === 'high-risk' || v === 'none' ? v : 'none';
+    })(),
+    /** 예약(무인) task 총 타임아웃(ms) — 리포트·디자인 등 무거운 생성 워크플로우는 대화형 기본
+     *  10분을 넘길 수 있어 분리(기본 20분). AGENT_TASK_SCHEDULE_TIMEOUT_MS. */
+    SCHEDULE_TOTAL_TIMEOUT_MS: parseInt(process.env.AGENT_TASK_SCHEDULE_TIMEOUT_MS || '', 10) || 20 * 60 * 1000,
     /** 크로스-task 학습(Phase 5-2) — 유저 과거 유사 작업의 결과·도구·실패사유를 새 task system 에
      *  주입(같은 실수 반복 방지). 무-LLM(키워드 유사도)·기존 테이블 파생. 기본 OFF.
      *  AGENT_TASK_LEARNING_ENABLED=true 로 활성. */

--- a/apps/api/src/controllers/auth-oauth.controller.ts
+++ b/apps/api/src/controllers/auth-oauth.controller.ts
@@ -376,11 +376,19 @@ export class AuthOAuthController {
             const kakaoUser = await userInfoRes.json() as KakaoUserInfo;
 
             // 비즈앱 전환으로 이메일(account_email) 필수 동의 활성화 → 실이메일로 식별한다(Google 등
-            // 타 provider 와 동일 이메일이면 계정 병합). 이메일이 없는 예외 케이스만 회원번호(id)
-            // 기반 합성 이메일로 폴백 — 회원번호는 '사용자 아이디 고정'(기본 ON)이라 안정적.
+            // 타 provider 와 동일 이메일이면 계정 병합). 단, 계정 병합은 이메일 소유권을 신뢰하는
+            // 행위이므로 카카오가 유효(is_email_valid)하고 인증(is_email_verified)했다고 확인한
+            // 이메일만 병합에 사용한다. 미검증/무효/미동의 이메일은 회원번호(id) 기반 합성 이메일로
+            // 격리 — 이렇게 하지 않으면 공격자가 피해자 이메일을 미검증 상태로 걸어 계정을 탈취할 수 있다.
+            // (회원번호는 '사용자 아이디 고정'(기본 ON)이라 안정적.)
             const kakaoId = kakaoUser.id;
             if (!kakaoId) throw new Error('카카오 사용자 정보를 가져올 수 없습니다');
-            const email = kakaoUser.kakao_account?.email || `kakao_${kakaoId}@kakao.local`;
+            const kakaoAccount = kakaoUser.kakao_account;
+            const hasVerifiedEmail =
+                !!kakaoAccount?.email &&
+                kakaoAccount.is_email_valid === true &&
+                kakaoAccount.is_email_verified === true;
+            const email = hasVerifiedEmail ? kakaoAccount!.email! : `kakao_${kakaoId}@kakao.local`;
 
             const authService = getAuthService();
             const result = await authService.findOrCreateOAuthUser(email, 'kakao');

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -91,6 +91,8 @@ export class AgentTaskService {
         const mcp = getUnifiedMCPClient();
         const signal = this.abortController.signal;
         const startedAt = Date.now();
+        // 총 타임아웃 예산 — 예약(무인) task 는 input.totalTimeoutMs 로 더 긴 예산을 받는다(기본 전역값).
+        const totalTimeoutMs = input.totalTimeoutMs ?? AGENT_TASK_LIMITS.TOTAL_TIMEOUT_MS;
         const turnCeiling = Math.min(maxTurns, AGENT_TASK_LIMITS.MAX_TURNS_CEILING);
 
         const userCtx: UserContext = { userId, role: userRole };
@@ -268,7 +270,7 @@ export class AgentTaskService {
             };
 
             for (let turn = startTurn; turn < turnCeiling; turn++) {
-                assertWithinLimits(signal, startedAt, pausedMs, totalTokens);
+                assertWithinLimits(signal, startedAt, pausedMs, totalTokens, totalTimeoutMs);
 
                 // 진행률: 에이전트가 plan 을 세웠으면 실제 단계 완료율(completed/total)을 진척으로 쓴다
                 // — "3/7 단계"처럼 실제 진행을 반영(1-C). plan 이 없으면(턴0·비플래닝 작업) 총 턴 수를
@@ -320,7 +322,7 @@ export class AgentTaskService {
                 // 승인 대기 누적(pausedMs)은 예산에서 제외(4-1 pause-aware).
                 const remainingMs = Math.max(
                     1_000,
-                    AGENT_TASK_LIMITS.TOTAL_TIMEOUT_MS - (Date.now() - startedAt - pausedMs)
+                    totalTimeoutMs - (Date.now() - startedAt - pausedMs)
                 );
                 const callSignal = AbortSignal.any([signal, AbortSignal.timeout(remainingMs)]);
 

--- a/apps/api/src/services/agent-task/role-client.ts
+++ b/apps/api/src/services/agent-task/role-client.ts
@@ -7,6 +7,7 @@ import { createClient, type LLMClient } from '../../llm';
 import type { ChatMessage, ToolDefinition } from '../../llm/types';
 import { getModelForRole } from '../../config/model-roles';
 import { resolveRoleClientForUser } from '../model-role-resolver';
+import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
 import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('AgentTaskService');
@@ -61,9 +62,14 @@ export async function chatTurnWithRoleFallback(
         userId: string;
     },
 ): Promise<Awaited<ReturnType<LLMClient['chat']>>> {
-    const call = () => state.client.chat(p.conversation, undefined, undefined, {
-        tools: p.tools, signal: p.signal, think: false,
-    });
+    // openai SDK 요청 타임아웃을 task 총 예산에 맞춰 늘린다(파생 클라이언트, baseUrl/model 유지).
+    // 기본 LLM_TIMEOUT(120s)은 채팅용이라, 리포트·디자인 등 장문 생성 턴이 단일 요청에서 120s 를
+    // 넘기면 "Request timed out" 으로 task 가 죽는다. 실제 한계는 p.signal(잔여 예산)이 governor.
+    // SDK 요청 타임아웃 상한은 최대 예산(예약)에 맞춘다 — 실제 한계는 p.signal(잔여 예산)이 governor.
+    const call = () => state.client.derive({ timeout: AGENT_TASK_LIMITS.SCHEDULE_TOTAL_TIMEOUT_MS })
+        .chat(p.conversation, undefined, undefined, {
+            tools: p.tools, signal: p.signal, think: false,
+        });
     try {
         return await call();
     } catch (chatErr) {

--- a/apps/api/src/services/agent-task/schedule-runner.ts
+++ b/apps/api/src/services/agent-task/schedule-runner.ts
@@ -48,6 +48,11 @@ async function fireSchedule(repo: AgentTaskScheduleRepository, s: AgentTaskSched
             userId: String(s.user_id),
             run: () => service.execute({
                 taskId, goal: s.goal, userId: String(s.user_id), userRole: role, maxTurns: s.max_turns,
+                // 예약 task 는 무인 실행 — 사람이 승인할 수 없으므로 승인정책을 분리(기본 none).
+                // 전역 approvalPolicy='all' 이면 첫 도구서 pause 되어 예약이 영영 멈추는 것을 방지.
+                approvalPolicy: AGENT_TASK_LIMITS.SCHEDULE_APPROVAL_POLICY,
+                // 무거운 리포트 생성은 대화형 10분을 넘길 수 있어 예약 전용 총 예산(기본 20분) 부여.
+                totalTimeoutMs: AGENT_TASK_LIMITS.SCHEDULE_TOTAL_TIMEOUT_MS,
             }),
         });
         await repo.markRun(s.id, nextRunAtMs, taskId);

--- a/apps/api/src/services/agent-task/types.ts
+++ b/apps/api/src/services/agent-task/types.ts
@@ -18,9 +18,12 @@ export class AgentTaskAbort extends Error {
 
 /** runaway 가드 — 한도 초과 시 종류별 AgentTaskAbort throw (AgentTaskService 에서 분리 — 파일 크기 가드).
  *  pausedMs(승인 대기 누적)는 활성 시간이 아니므로 타임아웃 예산에서 제외(4-1). */
-export function assertWithinLimits(signal: AbortSignal, startedAt: number, pausedMs: number, totalTokens: number): void {
+export function assertWithinLimits(
+    signal: AbortSignal, startedAt: number, pausedMs: number, totalTokens: number,
+    totalTimeoutMs: number = AGENT_TASK_LIMITS.TOTAL_TIMEOUT_MS,
+): void {
     if (signal.aborted) throw new AgentTaskAbort('aborted');
-    if (Date.now() - startedAt - pausedMs > AGENT_TASK_LIMITS.TOTAL_TIMEOUT_MS) {
+    if (Date.now() - startedAt - pausedMs > totalTimeoutMs) {
         throw new AgentTaskAbort('timeout');
     }
     if (totalTokens > AGENT_TASK_LIMITS.MAX_TOTAL_TOKENS) {
@@ -52,6 +55,9 @@ export interface AgentTaskRunInput {
     /** 승인 3모드(Manual/Auto/Skip) — 이 실행에 한해 전역 승인 정책을 override(비영속).
      *  all=전부 승인, high-risk=고위험만, none=전부 자동. 미지정 시 전역 TASK_SANDBOX_APPROVAL_POLICY. */
     approvalPolicy?: 'all' | 'high-risk' | 'none';
+    /** 이 실행의 총 타임아웃(ms) override — 미지정 시 전역 TOTAL_TIMEOUT_MS. 예약(무인) task 는
+     *  무거운 생성 워크플로우를 위해 더 긴 SCHEDULE_TOTAL_TIMEOUT_MS 를 넘긴다. */
+    totalTimeoutMs?: number;
     /** Phase 2 Git: 작업 대상 GitHub repo URL(https://github.com/org/repo). 있으면 실행 시
      *  호스트가 workspace 에 clone(토큰은 사용자 github 연결). 미지정이면 일반 샌드박스 작업. */
     gitRepoUrl?: string;


### PR DESCRIPTION
## 배경
소스 전 기능 영역 점검(6개 영역 병렬 감사)에서 발견된 **HIGH 심각도 2건**을 수정합니다.

## 수정 내용

### 1. 예약(무인) Agent Task 완주 불가 수정 (cherry-pick `cfec42ba`)
`fix/scheduled-task-unattended-execution` 브랜치에만 있고 main 미머지 상태였던 3중 결함:
- **승인 pause 영구정지**: `schedule-runner` 가 approvalPolicy 미전달 → 전역 `'all'` → 첫 도구서 pause → 무인이라 30분 후 거절. `SCHEDULE_APPROVAL_POLICY`(기본 none)로 분리.
- **per-call 120s 타임아웃**: 장문 리포트 턴 사망 → `client.derive({timeout})` 로 task 예산에 맞춰 상향.
- **총예산 10분 고정**: `SCHEDULE_TOTAL_TIMEOUT_MS`(기본 20분) 추가, `AgentTaskRunInput.totalTimeoutMs` 주입.

> 이 수정 없이는 "매일 7시 AI 트렌드 리포트" 등 예약 task 가 실제로 완주하지 못했음(문서는 완료로 기록돼 있어 라이브로 오인 중).

### 2. 카카오 OAuth 미검증 이메일 계정 병합 차단
- 카카오 콜백이 `kakao_account.email` 을 검증 없이 `findOrCreateOAuthUser` 에 넘겨, 이메일-only 병합으로 계정 탈취가 가능했음.
- `is_email_valid === true && is_email_verified === true` 인 이메일만 병합에 사용, 미검증/무효/미동의는 회원번호 합성 이메일로 격리.

## 검증
- `tsc --noEmit` 통과 (타입 에러 0)
- `eslint` 변경 파일 에러 0
- 전체 유닛 테스트 **2,094 통과 / 실패 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)