### PR TITLE
fix: 소스 점검 MEDIUM 6건 — 기억형성 게이트·MCP 캡·SSRF·프론트 WS 이벤트

### DIFF
--- a/apps/api/src/mcp/tool-router.ts
+++ b/apps/api/src/mcp/tool-router.ts
@@ -229,6 +229,18 @@ export class ToolRouter {
                 }
                 return ok(result);
             };
+            // 외부 도구 출력 크기 제한(MAX_OUTPUT_SIZE, 1MB) — user-pool(1a)·전역(1b) 두 경로 공통.
+            // 누락 시 대용량 도구 결과가 통째로 LLM 컨텍스트에 주입돼 토큰 예산 폭주/context-fit 조기 발동.
+            const capOutput = (result: MCPToolResult): MCPToolResult => {
+                if (result?.content) {
+                    for (const item of result.content) {
+                        if ('text' in item && typeof item.text === 'string' && item.text.length > MCP_EXTERNAL_TOOL_LIMITS.MAX_OUTPUT_SIZE) {
+                            item.text = item.text.substring(0, MCP_EXTERNAL_TOOL_LIMITS.MAX_OUTPUT_SIZE) + '\n... (출력이 1MB를 초과하여 잘렸습니다)';
+                        }
+                    }
+                }
+                return result;
+            };
 
             // 1. 외부 도구 확인 (:: 네임스페이스)
             if (isExternal) {
@@ -252,7 +264,7 @@ export class ToolRouter {
                                     setTimeout(() => reject(new Error(`외부 도구 타임아웃: ${name} (${MCP_EXTERNAL_TOOL_LIMITS.EXECUTION_TIMEOUT_MS}ms 초과)`)), MCP_EXTERNAL_TOOL_LIMITS.EXECUTION_TIMEOUT_MS)
                                 ),
                             ]);
-                            return finalize(result);
+                            return finalize(capOutput(result));
                         } catch (e) {
                             const msg = e instanceof Error ? e.message : String(e);
                             return fail(`사용자 풀 도구 실행 실패 (${name}): ${msg}`);
@@ -280,16 +292,7 @@ export class ToolRouter {
                         )
                     ]);
 
-                    // 출력 크기 제한
-                    if (result.content) {
-                        for (const item of result.content) {
-                            if ('text' in item && typeof item.text === 'string' && item.text.length > MCP_EXTERNAL_TOOL_LIMITS.MAX_OUTPUT_SIZE) {
-                                item.text = item.text.substring(0, MCP_EXTERNAL_TOOL_LIMITS.MAX_OUTPUT_SIZE) + '\n... (출력이 1MB를 초과하여 잘렸습니다)';
-                            }
-                        }
-                    }
-
-                    return finalize(result);
+                    return finalize(capOutput(result));
                 } catch (error) {
                     const message = error instanceof Error ? error.message : '외부 도구 실행 실패';
                     return fail(message);

--- a/apps/api/src/services/chat-service/message-pipeline.ts
+++ b/apps/api/src/services/chat-service/message-pipeline.ts
@@ -293,7 +293,11 @@ export async function runMessagePipeline(svc: ChatService,
         await buildUserContextBlocks(userId, req.memoryLearning !== false);
 
     // 자동 기억형성(#3 b) — user 메시지에서 지속적 사실 추출→저장. fire-and-forget(응답 무영향, 플래그 OFF 면 no-op).
-    void autoFormMemories({ userId, message: req.message, client: svc.client });
+    // memoryLearning 토글은 "주입"(293행)뿐 아니라 "형성/저장"도 게이팅한다 — OFF 인데 저장이 계속되면
+    // 사용자가 끈 것과 반대로 동작하는 프라이버시 이슈.
+    if (req.memoryLearning !== false) {
+        void autoFormMemories({ userId, message: req.message, client: svc.client });
+    }
 
     // Custom Agent (user_agents) 활성 시 산업 agent 라우팅 우회 + allowedSkills 주입.
     // 전체 build() 대신 loadUserAgent 단독 호출 — provider 가 자체 model 처리하므로

--- a/apps/api/src/utils/web-scraper.ts
+++ b/apps/api/src/utils/web-scraper.ts
@@ -266,7 +266,26 @@ async function scrapeWithPlaywright(
     const browser = await chromium.launch({ headless: true });
     try {
         const page = await browser.newPage();
+        // SSRF 방어: Playwright 는 자체 네트워크 스택을 써서 safeFetch 의 redirect 재검증·DNS 핀을
+        // 우회한다. 문서 네비게이션(초기 goto + 서버 redirect)마다 validateOutboundUrl 로 재검증해
+        // 공격자 도메인이 내부/메타데이터 엔드포인트로 redirect 시키는 것을 차단한다. 리소스(img/css/
+        // script)는 본문 추출 대상이 아니라 성능 위해 통과.
+        await page.route('**/*', async (route) => {
+            const request = route.request();
+            if (request.isNavigationRequest()) {
+                try {
+                    await validateOutboundUrl(request.url());
+                } catch {
+                    logger.warn(`[${url}] Playwright 네비게이션 SSRF 차단: ${request.url()}`);
+                    await route.abort('blockedbyclient');
+                    return;
+                }
+            }
+            await route.continue();
+        });
         await page.goto(url, { waitUntil: 'networkidle', timeout: timeoutMs });
+        // 안전망: route 가 못 잡은 클라이언트측(JS/meta) redirect 대비 최종 URL 재검증.
+        await validateOutboundUrl(page.url());
         const html = await page.content();
         return parseHtmlToMarkdown(html, url, onlyMainContent);
     } finally {

--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -394,6 +394,53 @@ function ResearchProgressBanner() {
   );
 }
 
+/** 토론 모드 진행 배너 — research 배너와 대칭. phase/에이전트/라운드/진행률 라이브 표시. */
+function DiscussionProgressBanner() {
+  const t = useTranslations("chat");
+  const dp = useAppStore((s) => s.discussionProgress);
+  if (!dp) return null;
+  const filled = Math.round(dp.progress / 10);
+  return (
+    <div className="flex gap-3">
+      <div className="mt-0.5 grid h-7 w-7 shrink-0 place-items-center rounded-md bg-accent-soft text-accent">
+        <MessagesSquare className="h-4 w-4" />
+      </div>
+      <div className="min-w-0 flex-1 rounded-lg border border-border bg-surface-2/60 p-3">
+        <div className="mb-1 flex items-center gap-2 text-xs font-medium text-fg-2">
+          <LoaderCircle className="h-3.5 w-3.5 animate-spin text-accent" />
+          {t("discussion.inProgress")}
+          {dp.currentAgent && (
+            <span className="text-faint">· {dp.agentEmoji ? `${dp.agentEmoji} ` : ""}{dp.currentAgent}</span>
+          )}
+          {dp.totalRounds != null && dp.totalRounds > 0 && dp.roundNumber != null && (
+            <span className="text-faint">· {t("discussion.round", { current: dp.roundNumber, total: dp.totalRounds })}</span>
+          )}
+        </div>
+        {dp.message && <p className="mb-1.5 text-xs text-muted">{dp.message}</p>}
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[11px] text-accent">
+            {"▓".repeat(filled)}{"░".repeat(10 - filled)}
+          </span>
+          <span className="text-[11px] text-faint">{dp.progress}%</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** 도구 실행 인디케이터 — always-on tool loop 중 "실행 중" 표시(스트리밍 멈춘 듯한 혼선 해소). */
+function ToolIndicator() {
+  const t = useTranslations("chat");
+  const tool = useAppStore((s) => s.activeTool);
+  if (!tool) return null;
+  return (
+    <div className="flex items-center gap-2 text-xs text-muted">
+      <Wrench className="h-3.5 w-3.5 animate-pulse text-accent" />
+      {t("tool.running", { tool })}
+    </div>
+  );
+}
+
 /** 메시지 피드백(👍/👎) — 백엔드 /api/chat/feedback (thumbs_up/thumbs_down) 전송. */
 function FeedbackButtons({ messageId }: { messageId: string }) {
   const t = useTranslations("chat");
@@ -441,6 +488,8 @@ export function MessageList() {
   const activeAgent = useAppStore((s) => s.activeAgent);
   const activeSkills = useAppStore((s) => s.activeSkills);
   const researchProgress = useAppStore((s) => s.researchProgress);
+  const discussionProgress = useAppStore((s) => s.discussionProgress);
+  const activeTool = useAppStore((s) => s.activeTool);
   const bottomRef = useRef<HTMLDivElement>(null);
 
   // 응답이 진행 중인데 아직 스트리밍 중인 assistant 메시지가 없으면(첫 토큰 전) "분석 중" 표시
@@ -533,6 +582,8 @@ export function MessageList() {
         ),
       )}
       {researchProgress && <ResearchProgressBanner />}
+      {discussionProgress && <DiscussionProgressBanner />}
+      {activeTool && <ToolIndicator />}
       {showThinking && <ThinkingIndicator agent={activeAgent} skills={activeSkills} />}
       <div ref={bottomRef} className={cn("h-px")} />
     </div>

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -68,6 +68,17 @@ export interface ResearchProgressInfo {
   totalLoops: number;
 }
 
+/** 토론 모드 진행상황 (백엔드 discussion_progress 이벤트 — DiscussionProgress 대응). */
+export interface DiscussionProgressInfo {
+  phase: "selecting" | "discussing" | "reviewing" | "synthesizing" | "complete";
+  currentAgent?: string;
+  agentEmoji?: string;
+  message: string;
+  progress: number;
+  roundNumber?: number;
+  totalRounds?: number;
+}
+
 /**
  * 구조화 답변 (백엔드 schemas/structured-answer.schema.ts StructuredAnswer 대응).
  * structuredMode 에서 POST /api/chat/structured 가 반환. content 에는 동일 내용의 markdown 도 함께 저장된다.
@@ -130,6 +141,10 @@ interface AppState {
   notebookContext: { id: string; title: string } | null;
   /** 딥리서치 진행상황 (ws research_progress) — 스트리밍 중 상태 배너로 표시, done 시 clear. */
   researchProgress: ResearchProgressInfo | null;
+  /** 토론 모드 진행상황 (ws discussion_progress) — 스트리밍 중 배너로 표시, done 시 clear. */
+  discussionProgress: DiscussionProgressInfo | null;
+  /** 현재 실행 중인 MCP/내장 도구명 (ws mcp_tool_start→표시, mcp_tool_result/done→clear). */
+  activeTool: string | null;
 
   // 아티팩트
   artifacts: Artifact[];
@@ -177,9 +192,11 @@ interface AppState {
   setActiveUserAgent: (a: { id: string; name: string; icon?: string | null } | null) => void;
   setNotebookContext: (nb: { id: string; title: string } | null) => void;
   setResearchProgress: (p: ResearchProgressInfo | null) => void;
+  setDiscussionProgress: (p: DiscussionProgressInfo | null) => void;
+  setActiveTool: (t: string | null) => void;
   setPrivacyPrefs: (patch: { saveHistory?: boolean; memoryLearning?: boolean }) => void;
-  /** WS done 시 마지막 assistant 메시지에 서버 messageId 부여 — 피드백 전송용. */
-  finalizeLastAssistant: (messageId: string) => void;
+  /** WS done 시 마지막 assistant 메시지에 서버 messageId 부여(+cleanedContent 시 본문 reset) — 피드백 전송용. */
+  finalizeLastAssistant: (messageId: string, cleanedContent?: string) => void;
   clearChat: () => void;
 
   // 아티팩트 actions
@@ -255,6 +272,8 @@ export const useAppStore = create<AppState>()(
   activeUserAgent: null,
   notebookContext: null,
   researchProgress: null,
+  discussionProgress: null,
+  activeTool: null,
 
   artifacts: [],
   activeArtifactId: null,
@@ -281,12 +300,18 @@ export const useAppStore = create<AppState>()(
   auth: { currentUser: null, isGuestMode: true },
 
   setPrivacyPrefs: (patch) => set(() => ({ ...patch })),
-  finalizeLastAssistant: (messageId) =>
+  finalizeLastAssistant: (messageId, cleanedContent) =>
     set((s) => {
       const hist = [...s.chatHistory];
       for (let i = hist.length - 1; i >= 0; i--) {
         if (hist[i].role === "assistant") {
-          hist[i] = { ...hist[i], id: messageId };
+          // cleanedContent: 아티팩트 승격 시 raw 코드펜스가 placeholder 로 치환된 본문 —
+          // 클라가 token 단위로 누적한 원문을 이걸로 reset 해 펜스 원문+아티팩트 칩 이중 렌더를 막는다.
+          hist[i] = {
+            ...hist[i],
+            id: messageId,
+            ...(typeof cleanedContent === "string" ? { content: cleanedContent } : {}),
+          };
           break;
         }
       }
@@ -345,6 +370,8 @@ export const useAppStore = create<AppState>()(
   setActiveUserAgent: (a) => set({ activeUserAgent: a }),
   setNotebookContext: (nb) => set({ notebookContext: nb }),
   setResearchProgress: (p) => set({ researchProgress: p }),
+  setDiscussionProgress: (p) => set({ discussionProgress: p }),
+  setActiveTool: (t) => set({ activeTool: t }),
   clearChat: () =>
     set({
       chatHistory: [],
@@ -353,6 +380,8 @@ export const useAppStore = create<AppState>()(
       activeSkills: [],
       notebookContext: null,
       researchProgress: null,
+      discussionProgress: null,
+      activeTool: null,
       artifacts: [],
       activeArtifactId: null,
       artifactPanelOpen: false,

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -63,6 +63,8 @@ export function useChatSocket() {
     setActiveAgent,
     setActiveSkills,
     setResearchProgress,
+    setDiscussionProgress,
+    setActiveTool,
     finalizeLastAssistant,
     startArtifact,
     appendArtifactDelta,
@@ -109,14 +111,19 @@ export function useChatSocket() {
           if (data.sessionId) setCurrentSessionId(data.sessionId);
           break;
         case "done":
-          if (data.sessionId) setCurrentSessionId(data.sessionId);
-          if (data.messageId) finalizeLastAssistant(data.messageId);
+          // sessionId 는 session_created 이벤트가 담당(done 페이로드엔 없음).
+          // cleanedContent 가 있으면 누적 본문을 placeholder 치환본으로 reset(아티팩트 이중 렌더 방지).
+          if (data.messageId) finalizeLastAssistant(data.messageId, data.cleanedContent);
           setStreaming(false);
           setResearchProgress(null);
+          setDiscussionProgress(null);
+          setActiveTool(null);
           break;
         case "aborted":
           setStreaming(false);
           setResearchProgress(null);
+          setDiscussionProgress(null);
+          setActiveTool(null);
           break;
         case "error":
           appendMessage({
@@ -127,6 +134,8 @@ export function useChatSocket() {
           });
           setStreaming(false);
           setResearchProgress(null);
+          setDiscussionProgress(null);
+          setActiveTool(null);
           break;
         case "research_progress": {
           // 딥리서치 진행을 채팅 상태 배너로 라이브 표시(스트리밍 시작 전/중).
@@ -140,6 +149,28 @@ export function useChatSocket() {
           });
           break;
         }
+        case "discussion_progress": {
+          // 토론 모드 진행을 배너로 라이브 표시(research_progress 와 대칭).
+          const p = data.progress;
+          setDiscussionProgress({
+            phase: p.phase,
+            currentAgent: p.currentAgent,
+            agentEmoji: p.agentEmoji,
+            message: p.message ?? "",
+            progress: Math.max(0, Math.min(100, Math.round(p.progress ?? 0))),
+            roundNumber: p.roundNumber,
+            totalRounds: p.totalRounds,
+          });
+          break;
+        }
+        case "mcp_tool_start":
+          // 도구 실행 시작 — "🔍 {도구} 실행 중" 인디케이터(스트리밍 멈춘 듯한 혼선 해소).
+          setActiveTool(data.toolName);
+          break;
+        case "mcp_tool_result":
+          // 도구 결과 도착 — 인디케이터 해제(다음 도구 시작 시 다시 표시).
+          setActiveTool(null);
+          break;
         case "agent_selected":
           setActiveAgent({ name: data.agent.name, emoji: data.agent.emoji });
           break;

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -342,6 +342,13 @@
       "inProgress": "Deep research in progress",
       "loop": "Loop {current}/{total}"
     },
+    "discussion": {
+      "inProgress": "Discussion in progress",
+      "round": "Round {current}/{total}"
+    },
+    "tool": {
+      "running": "Running {tool}"
+    },
     "emptyState": {
       "title": "How can I help you?",
       "description": "Multi-model orchestration · MCP tools · deep research · autonomous agents. Type your question below, or press <slash>/</slash> to invoke a skill."

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -342,6 +342,13 @@
       "inProgress": "ディープリサーチ実行中",
       "loop": "ループ {current}/{total}"
     },
+    "discussion": {
+      "inProgress": "ディスカッション進行中",
+      "round": "ラウンド {current}/{total}"
+    },
+    "tool": {
+      "running": "{tool} を実行中"
+    },
     "emptyState": {
       "title": "何かお手伝いしましょうか？",
       "description": "マルチモデルオーケストレーション · MCP ツール · ディープリサーチ · 自律エージェント。下に質問を入力するか、<slash>/</slash> でスキルを呼び出してください。"

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -342,6 +342,13 @@
       "inProgress": "딥 리서치 진행 중",
       "loop": "루프 {current}/{total}"
     },
+    "discussion": {
+      "inProgress": "토론 진행 중",
+      "round": "라운드 {current}/{total}"
+    },
+    "tool": {
+      "running": "{tool} 실행 중"
+    },
     "emptyState": {
       "title": "무엇을 도와드릴까요?",
       "description": "멀티모델 오케스트레이션 · MCP 도구 · 딥 리서치 · 자율 에이전트. 아래에 질문을 입력하거나 <slash>/</slash> 로 스킬을 호출하세요."

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -342,6 +342,13 @@
       "inProgress": "深度研究进行中",
       "loop": "循环 {current}/{total}"
     },
+    "discussion": {
+      "inProgress": "讨论进行中",
+      "round": "第 {current}/{total} 轮"
+    },
+    "tool": {
+      "running": "正在运行 {tool}"
+    },
     "emptyState": {
       "title": "有什么可以帮您的？",
       "description": "多模型编排 · MCP 工具 · 深度研究 · 自主智能体。在下方输入问题，或按 <slash>/</slash> 调用技能。"

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -130,7 +130,14 @@ export type WsServerEvent =
   | { type: "thinking"; token: string; messageId?: string }
   | { type: "thinking_summary"; summary: string; messageId?: string }
   | { type: "session_created"; sessionId: string }
-  | { type: "done"; sessionId?: string; totalTokens?: number; messageId?: string }
+  | {
+      type: "done";
+      messageId?: string;
+      /** 백엔드 실제 페이로드(ws-chat-handler): 스트리밍 완료 시 토큰 메트릭. */
+      metrics?: { tokensPerSec: number; tokenCount: number };
+      /** 아티팩트가 있으면 raw 코드펜스가 placeholder 로 치환된 본문 — 클라가 누적 본문을 이걸로 reset. */
+      cleanedContent?: string;
+    }
   | { type: "aborted"; message?: string }
   | { type: "error"; message: string }
   | { type: "init"; data?: unknown }
@@ -146,6 +153,22 @@ export type WsServerEvent =
       };
     }
   | { type: "skills_activated"; skillNames: string[] }
+  // MCP 도구 호출 진행 (백엔드 ws-chat-handler onMcpToolStart/onMcpToolResult)
+  | { type: "mcp_tool_start"; toolName: string; messageId?: string }
+  | { type: "mcp_tool_result"; toolName: string; resources?: unknown; messageId?: string }
+  // 토론 모드 진행 (백엔드 ws-chat-handler onDiscussionProgress → DiscussionProgress)
+  | {
+      type: "discussion_progress";
+      progress: {
+        phase: "selecting" | "discussing" | "reviewing" | "synthesizing" | "complete";
+        currentAgent?: string;
+        agentEmoji?: string;
+        message: string;
+        progress: number;
+        roundNumber?: number;
+        totalRounds?: number;
+      };
+    }
   // 아티팩트 스트리밍 (백엔드 ws-chat-handler.ts 송출)
   | { type: "artifact_start"; artifact: ArtifactMeta; messageId?: string }
   | { type: "artifact_chunk"; id: string; delta: string; messageId?: string }


### PR DESCRIPTION
## 배경
소스 전 기능 점검(6개 영역 감사)에서 발견된 **MEDIUM 심각도 6건**을 수정합니다. HIGH 2건은 #337 참고.

## 백엔드 (3건)
1. **자동 기억형성 프라이버시** — `autoFormMemories` 가 `memoryLearning` 토글 OFF 를 무시하고 매 메시지마다 저장하던 갭. 토글이 "주입"뿐 아니라 "형성/저장"도 게이팅하도록 수정.
2. **MCP 도구 결과 1MB 캡 누락** — 전역 경로에만 있던 출력 캡이 실제 주 경로인 user-pool 에는 없어 대용량 결과가 통째로 컨텍스트 주입. `capOutput` 헬퍼로 두 경로 공통 적용.
3. **web_scrape Playwright SSRF** — 폴백 경로가 safeFetch 의 redirect 재검증·DNS 핀을 우회. navigation 요청마다 + goto 후 최종 URL 로 `validateOutboundUrl` 재검증 추가.

## 프론트 (3건, apps/web 이전 시 누락된 WS 이벤트)
4. **mcp_tool_start/result** — 도구 실행 인디케이터 미표시 → `activeTool` + `ToolIndicator`.
5. **discussion_progress** — 토론 진행 배너 미표시(research 와 비대칭) → `discussionProgress` + `DiscussionProgressBanner`.
6. **done.cleanedContent** — 아티팩트 승격 시 코드펜스 본문+칩 이중 렌더 → `finalizeLastAssistant` 확장.

부수: `shared-types` WsServerEvent 를 실제 백엔드 페이로드에 맞춰 정정(거짓 타입 제거), i18n 4언어 키 추가.

## 검증
- 백엔드: `tsc` 0 · `eslint` 0 · 유닛 테스트 **2,094 통과 / 실패 0**
- 프론트: `apps/web` `tsc --noEmit` 0 · `eslint` 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)