### PR TITLE
fix: 소스 점검 LOW 5건 — OAuth·리미터·토큰비교·CSRF·죽은 env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -338,10 +338,6 @@ DATABASE_URL=postgresql://openmake:your_password@localhost:5432/openmake_llm  # 
 # 운영은 Nginx 가 / → Next 를 라우팅하므로 보통 미설정(주석).
 # FRONTEND_REDIRECT_URL=http://localhost:3000
 
-# 캐시 설정
-CACHE_MAX_SIZE=1000
-CACHE_TTL=1800000
-
 # CORS 허용 Origin (쉼표 구분, REST/WS 공통 allowlist).
 # credentials(쿠키) 인증 환경이라 와일드카드('*') 금지 — 운영(NODE_ENV=production)에서 '*' 설정 시 부팅 중단.
 # 허용 목록에 정확히 일치하는 Origin 만 reflect 되고, 그 외는 REST/WS 모두 거부된다.

--- a/apps/api/src/controllers/auth-oauth.controller.ts
+++ b/apps/api/src/controllers/auth-oauth.controller.ts
@@ -181,6 +181,10 @@ export class AuthOAuthController {
 
             const userInfo = await userInfoRes.json() as GoogleUserInfo;
             if (!userInfo.email) throw new Error('이메일 정보를 가져올 수 없습니다');
+            // 계정 병합은 이메일 소유권을 신뢰하는 행위 — Google 이 명시적으로 미검증(email_verified===false)
+            // 이라 표시한 이메일은 거부해 크로스-프로바이더 계정 병합 탈취를 막는다(카카오 콜백과 대칭).
+            // (Google 은 통상 검증된 이메일만 릴리스하지만 방어적 하드닝.)
+            if (userInfo.email_verified === false) throw new Error('이메일이 인증되지 않았습니다');
 
             const authService = getAuthService();
             const result = await authService.findOrCreateOAuthUser(userInfo.email, 'google');

--- a/apps/api/src/middlewares/setup.ts
+++ b/apps/api/src/middlewares/setup.ts
@@ -136,7 +136,7 @@ export function setupParsersAndLimiting(app: Application): void {
     app.use('/api/research', researchLimiter);
     app.use('/api/upload', uploadLimiter);
     app.use('/api/web-search', webSearchLimiter);
-    app.use('/api/memory', memoryLimiter);
+    app.use('/api/users/me/memories', memoryLimiter);
     app.use('/api/mcp', mcpLimiter);
     app.use('/api/api-keys', apiKeyManagementLimiter);
     app.use('/api/push', pushLimiter);
@@ -144,7 +144,7 @@ export function setupParsersAndLimiting(app: Application): void {
     // generalLimiter는 전용 리미터가 없는 경로에만 적용 (이중 카운팅 방지)
     const dedicatedLimiterPrefixes = [
         '/api/auth/', '/api/chat', '/api/research', '/api/upload',
-        '/api/web-search', '/api/memory', '/api/mcp',
+        '/api/web-search', '/api/users/me/memories', '/api/mcp',
         '/api/api-keys', '/api/push', '/api/admin', '/api/monitoring', '/api/metrics',
     ];
     app.use('/api/', (req, res, next) => {

--- a/apps/api/src/routes/artifact-publication.routes.ts
+++ b/apps/api/src/routes/artifact-publication.routes.ts
@@ -11,6 +11,7 @@
  */
 
 import { Router, Request, Response } from 'express';
+import { timingSafeEqual } from 'crypto';
 import { ArtifactRepository } from '../data/repositories/artifact-repository';
 import {
     ArtifactPublicationRepository,
@@ -36,6 +37,14 @@ import { getAuditService } from '../services/AuditService';
 const router = Router();
 
 const VALID_VISIBILITY: ArtifactVisibility[] = ['private', 'authenticated', 'link'];
+
+/** 공유 링크 토큰 상수시간 비교 — 평문 !== 비교의 타이밍 사이드채널 제거(뷰어 authorizeViewer 와 대칭). */
+function safeTokenEqual(provided: string, expected: string | null | undefined): boolean {
+    if (!expected) return false;
+    const a = Buffer.from(provided);
+    const b = Buffer.from(expected);
+    return a.length === b.length && timingSafeEqual(a, b);
+}
 
 /**
  * POST /api/sessions/:sid/artifacts/:aid/publish
@@ -264,7 +273,7 @@ router.get('/published/:pubId', optionalAuth, asyncHandler(async (req: Request, 
         if (pub.visibility === 'authenticated') {
             if (!userId) { res.status(401).json({ error: 'UNAUTHENTICATED', detail: '로그인이 필요합니다' }); return; }
         } else if (pub.visibility === 'link') {
-            if (!token || token !== pub.share_token) { res.status(403).json({ error: 'FORBIDDEN', detail: 'invalid token' }); return; }
+            if (!token || !safeTokenEqual(token, pub.share_token)) { res.status(403).json({ error: 'FORBIDDEN', detail: 'invalid token' }); return; }
         } else {
             res.status(403).json({ error: 'FORBIDDEN', detail: 'private' });
             return;

--- a/apps/web/app/(workspace)/custom-agents/page.tsx
+++ b/apps/web/app/(workspace)/custom-agents/page.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/primitives";
 import { AgentsTabs } from "@/components/hub-tabs";
 import type { ApiSuccess } from "@openmake/shared-types";
-import { ApiClient } from "@/lib/api-client";
+import { ApiClient, csrfHeaders } from "@/lib/api-client";
 import { fetchModels, type ModelEntry } from "@/lib/models-api";
 import { useAppStore } from "@/lib/store";
 
@@ -263,7 +263,7 @@ function AgentGitIngestForm({
     try {
       const resp = await fetch("/api/agents/custom/import-from-git", {
         method: "POST",
-        headers: { "Content-Type": "application/json", "Accept": "text/event-stream" },
+        headers: { "Content-Type": "application/json", "Accept": "text/event-stream", ...(await csrfHeaders()) },
         credentials: "include",
         body: JSON.stringify({
           gitUrl: gitUrl.trim(),

--- a/apps/web/app/(workspace)/skill-library/page.tsx
+++ b/apps/web/app/(workspace)/skill-library/page.tsx
@@ -26,7 +26,7 @@ import {
 import { AgentsTabs } from "@/components/hub-tabs";
 import { cn } from "@/lib/utils";
 import type { ApiSuccess } from "@openmake/shared-types";
-import { ApiClient } from "@/lib/api-client";
+import { ApiClient, csrfHeaders } from "@/lib/api-client";
 
 /* ── 카테고리 라벨 (id → i18n 키) ──────────────────────────── */
 const CATEGORY_KEYS: Record<string, string> = {
@@ -324,7 +324,7 @@ function AutoCreateForm({
     try {
       const resp = await fetch("/api/agents/skills/auto-create", {
         method: "POST",
-        headers: { "Content-Type": "application/json", "Accept": "text/event-stream" },
+        headers: { "Content-Type": "application/json", "Accept": "text/event-stream", ...(await csrfHeaders()) },
         credentials: "include",
         body: JSON.stringify({ purpose: purpose.trim(), target: target.trim() || undefined, category }),
       });
@@ -457,7 +457,7 @@ function GitIngestForm({
     try {
       const resp = await fetch("/api/agents/skills/import-from-git", {
         method: "POST",
-        headers: { "Content-Type": "application/json", "Accept": "text/event-stream" },
+        headers: { "Content-Type": "application/json", "Accept": "text/event-stream", ...(await csrfHeaders()) },
         credentials: "include",
         body: JSON.stringify({
           gitUrl: gitUrl.trim(),

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -6,3 +6,5 @@
  * 응답 타입은 @openmake/shared-types 의 ApiResponse 등으로 강제할 수 있다.
  */
 export { ApiClient, ApiError } from "@openmake/api-client";
+// SSE 등 ApiClient 로 처리 못 하는 직접 fetch 에서 CSRF 헤더 주입용(enforce 모드 대비).
+export { csrfHeaders } from "@openmake/api-client";

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -28,6 +28,15 @@ async function ensureCsrf(): Promise<string | null> {
   return t;
 }
 
+/**
+ * mutating 직접 fetch(예: SSE 스트림 — ApiClient 로는 못 다룸)에서 CSRF 헤더를 붙일 때 사용.
+ * ApiClient 를 우회하는 fetch 도 CSRF_PROTECTION=enforce 에서 403 되지 않도록 하는 공용 헬퍼.
+ */
+export async function csrfHeaders(): Promise<Record<string, string>> {
+  const token = await ensureCsrf();
+  return token ? { [CSRF.HEADER_NAME]: token } : {};
+}
+
 export class ApiError extends Error {
   constructor(public status: number, message: string, public body?: unknown) {
     super(message);


### PR DESCRIPTION
## 배경
소스 전 기능 점검에서 발견된 **LOW 심각도** 하드닝 5건. HIGH #337·MEDIUM #338 머지 후 재구성(구 #339는 stacked base 삭제로 자동 close → main 위에 cherry-pick, auth-oauth 는 카카오(#337)+Google 둘 다 살려 auto-merge).

## 수정 (5건)
1. **Google email_verified 하드닝** — `email_verified===false` 이메일 거부(카카오 #337 과 대칭).
2. **memoryLimiter 경로 교정** — 죽은 `/api/memory` → 실제 `/api/users/me/memories`(+generalLimiter 제외 목록 동기화).
3. **공유 링크 토큰 상수시간 비교** — 평문 `!==` → `timingSafeEqual`.
4. **SSE 직접 fetch CSRF** — ApiClient 우회 SSE 3곳에 `csrfHeaders()` 주입(enforce 시 403 방지).
5. **죽은 env 키 제거** — `CACHE_MAX_SIZE`/`CACHE_TTL`.

## 제외 (별도 처리 권장)
- **Discussion/DeepResearch 메모리·CI 주입** — 전략 내부 프롬프트 조립 단계 설계 판단 필요.
- **자동기억 abortSignal** — message-pipeline signal 배관 부재로 인프라 선행 필요.
- **stale 주석** — 코드 동작 무관 문서 드리프트.

## 검증
- 백엔드 `tsc` 0 · 유닛 테스트 2,094 통과 · 프론트 `tsc`/`eslint` 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)