### PR TITLE
feat(admin): 관리자용 전체 에이전트 작업 스케줄 조회

### DIFF
--- a/apps/api/src/data/repositories/agent-task-schedule-repository.ts
+++ b/apps/api/src/data/repositories/agent-task-schedule-repository.ts
@@ -54,6 +54,26 @@ export class AgentTaskScheduleRepository extends BaseRepository {
         return r.rows;
     }
 
+    /** 전체 스케줄 목록 (admin 조회) — 소유자 이메일·최근 task 상태 포함. */
+    async listAllWithOwner(): Promise<Array<AgentTaskSchedule & {
+        owner_email: string | null;
+        last_task_status: string | null;
+        last_task_error: string | null;
+    }>> {
+        const r = await this.query<AgentTaskSchedule & {
+            owner_email: string | null;
+            last_task_status: string | null;
+            last_task_error: string | null;
+        }>(
+            `SELECT s.*, u.email AS owner_email, t.status AS last_task_status, t.error AS last_task_error
+             FROM agent_task_schedules s
+             LEFT JOIN users u ON u.id = s.user_id
+             LEFT JOIN agent_tasks t ON t.id = s.last_task_id
+             ORDER BY s.created_at DESC`,
+        );
+        return r.rows;
+    }
+
     async countByUser(userId: string): Promise<number> {
         const r = await this.query<{ count: string }>(
             'SELECT COUNT(*)::text AS count FROM agent_task_schedules WHERE user_id = $1', [userId]);

--- a/apps/api/src/routes/admin-agent-task-schedules.routes.ts
+++ b/apps/api/src/routes/admin-agent-task-schedules.routes.ts
@@ -1,0 +1,29 @@
+/**
+ * @module routes/admin-agent-task-schedules
+ * @description 전체 에이전트 작업 스케줄 조회 — admin 전용.
+ *
+ * 스케줄 목록 API(GET /api/agent-task-schedules)는 본인 소유만 반환하므로,
+ * 관리자가 모든 사용자의 반복 트리거(cron/interval)를 한눈에 점검할 수 있는
+ * 읽기 전용 진입점을 제공한다. 개별 스케줄 조작(수정/삭제/즉시실행)은 기존
+ * /api/agent-task-schedules/:id 라우트가 admin 을 이미 허용한다(assertResourceOwnerOrAdmin).
+ *
+ * 엔드포인트 (requireAuth + requireAdmin):
+ *   GET /api/admin/agent-task-schedules — 전체 스케줄 목록(소유자 이메일·최근 task 상태 포함)
+ */
+import { Router, type Request, type Response } from 'express';
+import { requireAuth, requireAdmin } from '../auth';
+import { asyncHandler } from '../utils/error-handler';
+import { success } from '../utils/api-response';
+import { getPool } from '../data/models/unified-database';
+import { AgentTaskScheduleRepository } from '../data/repositories/agent-task-schedule-repository';
+
+const router = Router();
+router.use(requireAuth, requireAdmin);
+
+router.get('/', asyncHandler(async (_req: Request, res: Response) => {
+    const repo = new AgentTaskScheduleRepository(getPool());
+    const schedules = await repo.listAllWithOwner();
+    res.json(success({ schedules, total: schedules.length }));
+}));
+
+export { router as adminAgentTaskSchedulesRouter };

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -37,6 +37,7 @@ export { default as auditRouter } from './audit.routes';
 export { default as researchRouter } from './research.routes';
 export { default as agentTaskRouter } from './agent-task.routes';
 export { default as agentTaskScheduleRouter } from './agent-task-schedule.routes';
+export { adminAgentTaskSchedulesRouter } from './admin-agent-task-schedules.routes';
 export { default as agentTaskTemplateRouter } from './agent-task-template.routes';
 export { default as agentSuggestionsRouter } from './agent-suggestions.routes';
 export { default as externalRouter } from './external.routes';

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -45,6 +45,7 @@ import {
     researchRouter,
     agentTaskRouter,
     agentTaskScheduleRouter,
+    adminAgentTaskSchedulesRouter,
     agentTaskTemplateRouter,
     agentSuggestionsRouter,
     externalRouter,
@@ -185,6 +186,7 @@ export function setupApiRoutes(
     app.use('/api/admin/mcp', mcpCatalogAdminRouter);
     app.use('/api/admin', adminModelRolesRouter);
     app.use('/api/admin/mcp', mcpAdminMonitoringRouter);
+    app.use('/api/admin/agent-task-schedules', adminAgentTaskSchedulesRouter);
     // F2 자가개선 — 프롬프트 제안 검토/승인 (관리자)
     app.use('/api/admin/agent-suggestions', agentSuggestionsRouter);
     app.use('/api/debug-queue', debugQueueRouter);

--- a/apps/web/app/(workspace)/admin/schedules/page.tsx
+++ b/apps/web/app/(workspace)/admin/schedules/page.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { CalendarClock, RefreshCw, Loader2 } from "lucide-react";
+import {
+  PageHeader,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  Badge,
+  Button,
+  Table,
+  Th,
+  Td,
+} from "@/components/ui/primitives";
+import { AdminTabs } from "@/components/hub-tabs";
+import type { ApiSuccess } from "@openmake/shared-types";
+import { ApiClient } from "@/lib/api-client";
+
+/* ── 타입 (백엔드 /api/admin/agent-task-schedules) ── */
+interface AdminSchedule {
+  id: string;
+  user_id?: string;
+  owner_email: string | null;
+  goal: string;
+  cron?: string | null;
+  interval_seconds?: number | null;
+  enabled: boolean;
+  next_run_at: string;
+  last_run_at?: string | null;
+  last_task_status: string | null;
+  last_task_error: string | null;
+  consecutive_failures: number;
+  created_at: string;
+}
+interface SchedulesPayload {
+  schedules: AdminSchedule[];
+  total: number;
+}
+
+const TASK_STATUS_TONE: Record<string, "success" | "danger" | "warn" | "neutral"> = {
+  completed: "success",
+  failed: "danger",
+  running: "warn",
+  paused: "warn",
+  queued: "neutral",
+};
+
+function fmtDateTime(s?: string | null) {
+  if (!s) return "-";
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return "-";
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")} ${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+/** 전체 사용자의 에이전트 작업 스케줄 조회 — admin 전용(읽기). */
+export default function AdminSchedulesPage() {
+  const t = useTranslations("adminSchedules");
+  const [payload, setPayload] = useState<SchedulesPayload | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const r = await ApiClient.get<ApiSuccess<SchedulesPayload>>("/api/admin/agent-task-schedules");
+      setPayload(r?.data ?? null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("loadError"));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    queueMicrotask(() => void load());
+  }, [load]);
+
+  const schedules = payload?.schedules ?? [];
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title={t("title")} description={t("description")} />
+
+      <AdminTabs />
+      {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle className="flex items-center gap-2">
+            <CalendarClock className="h-4 w-4" aria-hidden />
+            {t("listTitle", { count: payload?.total ?? 0 })}
+          </CardTitle>
+          <Button size="sm" variant="outline" disabled={loading} onClick={() => void load()}>
+            {loading
+              ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              : <RefreshCw className="h-4 w-4" aria-hidden />}
+            {t("refresh")}
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {schedules.length === 0 && !loading ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">{t("empty")}</p>
+          ) : (
+            <Table>
+              <thead>
+                <tr>
+                  <Th>{t("cols.owner")}</Th>
+                  <Th>{t("cols.goal")}</Th>
+                  <Th>{t("cols.trigger")}</Th>
+                  <Th>{t("cols.enabled")}</Th>
+                  <Th>{t("cols.nextRun")}</Th>
+                  <Th>{t("cols.lastRun")}</Th>
+                  <Th>{t("cols.lastResult")}</Th>
+                  <Th>{t("cols.failures")}</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {schedules.map((s) => (
+                  <tr key={s.id}>
+                    <Td className="whitespace-nowrap">{s.owner_email ?? s.user_id ?? "-"}</Td>
+                    <Td className="max-w-[280px]">
+                      <span className="block truncate" title={s.goal}>{s.goal}</span>
+                    </Td>
+                    <Td className="whitespace-nowrap font-mono text-xs">
+                      {s.cron ?? (s.interval_seconds != null ? t("intervalSec", { sec: s.interval_seconds }) : "-")}
+                    </Td>
+                    <Td>
+                      <Badge tone={s.enabled ? "success" : "neutral"}>
+                        {s.enabled ? t("status.enabled") : t("status.disabled")}
+                      </Badge>
+                    </Td>
+                    <Td className="whitespace-nowrap">{fmtDateTime(s.next_run_at)}</Td>
+                    <Td className="whitespace-nowrap">{fmtDateTime(s.last_run_at)}</Td>
+                    <Td>
+                      {s.last_task_status ? (
+                        <Badge
+                          tone={TASK_STATUS_TONE[s.last_task_status] ?? "neutral"}
+                          title={s.last_task_error ?? undefined}
+                        >
+                          {s.last_task_status}
+                        </Badge>
+                      ) : "-"}
+                    </Td>
+                    <Td className="text-center">{s.consecutive_failures}</Td>
+                  </tr>
+                ))}
+              </tbody>
+              </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/components/hub-tabs.tsx
+++ b/apps/web/components/hub-tabs.tsx
@@ -73,6 +73,7 @@ export function AdminTabs() {
         { href: "/admin/alerts", label: tNav("items.alerts") },
         { href: "/admin/mcp-catalog", label: tNav("items.mcpCatalogAdmin") },
         { href: "/admin/model-roles", label: tNav("items.modelRolesAdmin") },
+        { href: "/admin/schedules", label: tNav("items.schedulesAdmin") },
       ]}
     />
   );

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -21,7 +21,8 @@
       "alerts": "Alerts",
       "mcpCatalogAdmin": "MCP Catalog Admin",
       "modelRolesAdmin": "Model Roles Admin",
-      "developer": "Developer"
+      "developer": "Developer",
+      "schedulesAdmin": "Task Schedules"
     }
   },
   "sidebar": {
@@ -1430,6 +1431,29 @@
       "save": "Save",
       "placeholder": "Empty = fallback ({fallback})",
       "cacheNote": "Changes take effect within 60 seconds without a restart."
+    }
+  },
+  "adminSchedules": {
+    "title": "Task Schedule Management",
+    "description": "View recurring agent task schedules across all users.",
+    "listTitle": "All schedules ({count})",
+    "refresh": "Refresh",
+    "empty": "No schedules registered.",
+    "loadError": "Failed to load schedules.",
+    "intervalSec": "every {sec}s",
+    "status": {
+      "enabled": "Enabled",
+      "disabled": "Disabled"
+    },
+    "cols": {
+      "owner": "Owner",
+      "goal": "Goal",
+      "trigger": "Trigger (cron/interval)",
+      "enabled": "Status",
+      "nextRun": "Next run",
+      "lastRun": "Last run",
+      "lastResult": "Last result",
+      "failures": "Consecutive failures"
     }
   },
   "usage": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -21,7 +21,8 @@
       "alerts": "アラート",
       "mcpCatalogAdmin": "MCPカタログ管理",
       "modelRolesAdmin": "ロールモデル管理",
-      "developer": "開発者"
+      "developer": "開発者",
+      "schedulesAdmin": "タスクスケジュール"
     }
   },
   "sidebar": {
@@ -1430,6 +1431,29 @@
       "save": "保存",
       "placeholder": "空 = フォールバック ({fallback})",
       "cacheNote": "変更は再起動なしで最大60秒以内に反映されます。"
+    }
+  },
+  "adminSchedules": {
+    "title": "タスクスケジュール管理",
+    "description": "全ユーザーのエージェントタスクの繰り返しスケジュールを表示します。",
+    "listTitle": "全スケジュール（{count}件）",
+    "refresh": "更新",
+    "empty": "登録されたスケジュールはありません。",
+    "loadError": "スケジュール一覧の読み込みに失敗しました。",
+    "intervalSec": "{sec}秒間隔",
+    "status": {
+      "enabled": "有効",
+      "disabled": "無効"
+    },
+    "cols": {
+      "owner": "所有者",
+      "goal": "目標",
+      "trigger": "トリガー（cron/間隔）",
+      "enabled": "状態",
+      "nextRun": "次回実行",
+      "lastRun": "前回実行",
+      "lastResult": "前回結果",
+      "failures": "連続失敗"
     }
   },
   "usage": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -21,7 +21,8 @@
       "alerts": "알림",
       "mcpCatalogAdmin": "MCP 카탈로그 관리",
       "modelRolesAdmin": "역할 모델 관리",
-      "developer": "개발자"
+      "developer": "개발자",
+      "schedulesAdmin": "작업 스케줄"
     }
   },
   "sidebar": {
@@ -1430,6 +1431,29 @@
       "save": "저장",
       "placeholder": "비움 = 폴백 ({fallback})",
       "cacheNote": "변경은 재시작 없이 최대 60초 내에 반영됩니다."
+    }
+  },
+  "adminSchedules": {
+    "title": "작업 스케줄 관리",
+    "description": "전체 사용자의 에이전트 작업 반복 스케줄을 조회합니다.",
+    "listTitle": "전체 스케줄 ({count}개)",
+    "refresh": "새로고침",
+    "empty": "등록된 스케줄이 없습니다.",
+    "loadError": "스케줄 목록을 불러오지 못했습니다.",
+    "intervalSec": "{sec}초 간격",
+    "status": {
+      "enabled": "활성",
+      "disabled": "비활성"
+    },
+    "cols": {
+      "owner": "소유자",
+      "goal": "목표",
+      "trigger": "트리거(cron/간격)",
+      "enabled": "상태",
+      "nextRun": "다음 실행",
+      "lastRun": "최근 실행",
+      "lastResult": "최근 결과",
+      "failures": "연속 실패"
     }
   },
   "usage": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -21,7 +21,8 @@
       "alerts": "告警",
       "mcpCatalogAdmin": "MCP目录管理",
       "modelRolesAdmin": "角色模型管理",
-      "developer": "开发者"
+      "developer": "开发者",
+      "schedulesAdmin": "任务计划"
     }
   },
   "sidebar": {
@@ -1430,6 +1431,29 @@
       "save": "保存",
       "placeholder": "留空 = 回退 ({fallback})",
       "cacheNote": "更改无需重启,最多60秒内生效。"
+    }
+  },
+  "adminSchedules": {
+    "title": "任务计划管理",
+    "description": "查看所有用户的智能体任务重复计划。",
+    "listTitle": "全部计划（{count}个）",
+    "refresh": "刷新",
+    "empty": "暂无已注册的计划。",
+    "loadError": "无法加载计划列表。",
+    "intervalSec": "每 {sec} 秒",
+    "status": {
+      "enabled": "启用",
+      "disabled": "停用"
+    },
+    "cols": {
+      "owner": "所有者",
+      "goal": "目标",
+      "trigger": "触发器（cron/间隔）",
+      "enabled": "状态",
+      "nextRun": "下次执行",
+      "lastRun": "上次执行",
+      "lastResult": "上次结果",
+      "failures": "连续失败"
     }
   },
   "usage": {


### PR DESCRIPTION
## 배경

스케줄 목록 API(`GET /api/agent-task-schedules`)가 본인 소유만 반환해, **관리자도 다른 사용자의 예약을 목록으로 볼 수 없었다**. Discord 릴레이 계정(user 11)으로 등록된 매일 7시 AI 트렌드 리포트 예약이 웹 UI(user 3 로그인)에서 '미등록'으로 보이던 문제의 원인.

개별 스케줄 접근(`/:id` 상세/수정/삭제/즉시실행)은 `assertResourceOwnerOrAdmin` 으로 admin 을 이미 허용하고 있어, **빠져 있던 '전체 목록' 진입점만 추가**한다 (읽기 전용).

## 변경

### Backend
- `GET /api/admin/agent-task-schedules` — `requireAuth + requireAdmin`, 읽기 전용
- `AgentTaskScheduleRepository.listAllWithOwner()` — users/agent_tasks LEFT JOIN 으로 소유자 이메일 + 최근 task 상태/에러 포함
- `/api/admin` 프리픽스 마운트라 기존 adminLimiter 적용

### Frontend
- `/admin/schedules` 페이지 신설 — 소유자·목표·트리거(cron/간격)·상태·다음/최근 실행·최근 결과(뱃지, hover 시 에러)·연속 실패 테이블
- AdminTabs 에 '작업 스케줄' 탭 추가
- i18n 4언어(ko/en/ja/zh) 키 추가

## 검증
- [x] backend `tsc --noEmit` 통과 (본 체크아웃 기준 오류 0)
- [x] web `tsc --noEmit` 통과
- [x] eslint 변경 파일 전부 통과
- 스키마 변경 없음 / env 추가 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)