### PR TITLE
fix(agent-task): 대용량 첨부 근본 해결 — 1MB 검증 캡 제거 + multipart 디스크 스트리밍

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -760,6 +760,11 @@ AGENT_MAX_SEARCH_CALLS=5
 # Agent Task — 작업 전체 타임아웃 ms (기본 600000=10분. HTML/디자인 장문 생성 감안)
 AGENT_TASK_TIMEOUT_MS=600000
 
+# Agent Task — 작업 생성 요청 body 상한 bytes (기본 1048576000=1000MB).
+# /api/agent-tasks 의 express.json 파서와 validate 미들웨어가 이 값을 공유한다.
+# 첨부는 base64 로 4/3 팽창하므로 원본 파일 실효 상한은 약 3/4 (~750MB).
+# AGENT_TASK_BODY_MAX_BYTES=1048576000
+
 # Agent Task — 목표 달성 judge (아티팩트 없는 최종 답변을 판정 전용 LLM 1회 호출로 검증,
 # 미달성이면 completed 대신 failed(goal_incomplete)). 기본 ON. 'false' 로 비활성.
 # AGENT_TASK_GOAL_JUDGE=true

--- a/.env.example
+++ b/.env.example
@@ -761,9 +761,15 @@ AGENT_MAX_SEARCH_CALLS=5
 AGENT_TASK_TIMEOUT_MS=600000
 
 # Agent Task — 작업 생성 요청 body 상한 bytes (기본 1048576000=1000MB).
-# /api/agent-tasks 의 express.json 파서와 validate 미들웨어가 이 값을 공유한다.
-# 첨부는 base64 로 4/3 팽창하므로 원본 파일 실효 상한은 약 3/4 (~750MB).
+# /api/agent-tasks 의 express.json 파서·validate 미들웨어·multipart 파일 상한이 이 값을 공유한다.
+# JSON(base64) 경로는 4/3 팽창으로 원본 실효 상한 약 3/4 — 대용량은 multipart 경로가 원본
+# 크기 그대로 디스크 스트리밍된다(프론트가 자동 선택).
 # AGENT_TASK_BODY_MAX_BYTES=1048576000
+
+# Agent Task — multipart 입력 첨부 원본 저장 루트 (기본 <cwd>/data/uploads/agent-tasks).
+# task 삭제 시 함께 정리된다. 실행 시 샌드박스 workspace 로 복사되므로
+# TASK_SANDBOX_WORKSPACE_QUOTA(기본 512MB)도 파일 크기에 맞게 조정할 것.
+# AGENT_TASK_UPLOAD_ROOT=/path/to/uploads
 
 # Agent Task — 목표 달성 judge (아티팩트 없는 최종 답변을 판정 전용 LLM 1회 호출로 검증,
 # 미달성이면 completed 대신 failed(goal_incomplete)). 기본 ON. 'false' 로 비활성.

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1073,6 +1073,11 @@ export const AGENT_TASK_LIMITS = {
      *  거부하던 불일치 방지). 첨부는 base64 로 4/3 팽창하므로 원본 파일 실효 상한은 약 3/4.
      *  AGENT_TASK_BODY_MAX_BYTES(기본 1000MB). */
     REQUEST_BODY_MAX_BYTES: parseInt(process.env.AGENT_TASK_BODY_MAX_BYTES || '', 10) || 1000 * 1024 * 1024,
+    /** 입력 첨부 원본 저장 루트(호스트) — multipart 업로드가 디스크로 스트리밍되는 위치.
+     *  base64-in-JSON 경로와 달리 메모리에 body 를 올리지 않는다. task 삭제 시 함께 정리.
+     *  AGENT_TASK_UPLOAD_ROOT(기본 <cwd>/data/uploads/agent-tasks). */
+    UPLOAD_ROOT: process.env.AGENT_TASK_UPLOAD_ROOT
+        || `${process.cwd()}/data/uploads/agent-tasks`,
     /** 사용자 지정 max_turns 의 절대 상한 */
     MAX_TURNS_CEILING: 20,
     /** 기본 최대 턴 수 */

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1068,6 +1068,11 @@ export const ROUTE_INTENT_PATTERNS: readonly RegExp[] = [
  * 백그라운드 detached 실행이라 사람이 지켜보지 않으므로 토큰/시간 폭주 방지가 필수.
  */
 export const AGENT_TASK_LIMITS = {
+    /** 작업 생성 요청 body 상한(bytes) — /api/agent-tasks 의 express.json 파서와 validate
+     *  미들웨어(maxBodySizeBytes)가 공유하는 단일 소스(정합 고정: 파서만 크고 검증이 1MB 로
+     *  거부하던 불일치 방지). 첨부는 base64 로 4/3 팽창하므로 원본 파일 실효 상한은 약 3/4.
+     *  AGENT_TASK_BODY_MAX_BYTES(기본 1000MB). */
+    REQUEST_BODY_MAX_BYTES: parseInt(process.env.AGENT_TASK_BODY_MAX_BYTES || '', 10) || 1000 * 1024 * 1024,
     /** 사용자 지정 max_turns 의 절대 상한 */
     MAX_TURNS_CEILING: 20,
     /** 기본 최대 턴 수 */

--- a/apps/api/src/middlewares/setup.ts
+++ b/apps/api/src/middlewares/setup.ts
@@ -35,6 +35,7 @@ import { requestIdMiddleware } from './request-id';
 import { errorHandler, notFoundHandler } from '../utils/error-handler';
 import { getConfig } from '../config';
 import { buildPermissionsPolicyHeader, HSTS_POLICY } from '../config/security';
+import { AGENT_TASK_LIMITS } from '../config/runtime-limits';
 
 /**
  * 정적 자산(생성 이미지 등) 응답 헤더 — content-type + 캐시 정책.
@@ -118,8 +119,9 @@ export function setupParsersAndLimiting(app: Application): void {
     //    body parser 는 정적 서빙과 무관하므로 여기(parsers)로 이동해 항상 등록되게 한다.
     app.use('/api/chat', express.json({ limit: '10mb' }));
     app.use('/api/documents', express.json({ limit: '50mb' }));
-    // 에이전트 작업 생성은 입력 첨부(base64 문서 포함)를 받으므로 documents 와 동일 상한
-    app.use('/api/agent-tasks', express.json({ limit: '50mb' }));
+    // 에이전트 작업 생성은 입력 첨부(base64 문서 포함)를 받는다 — 파서 상한은
+    // validate 미들웨어(maxBodySizeBytes)와 AGENT_TASK_LIMITS.REQUEST_BODY_MAX_BYTES 를 공유
+    app.use('/api/agent-tasks', express.json({ limit: AGENT_TASK_LIMITS.REQUEST_BODY_MAX_BYTES }));
     app.use('/api/', express.json({ limit: '1mb' }));
     app.use(express.json({ limit: '1mb' }));
     app.use(cookieParser());

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -23,7 +23,7 @@ import { success, badRequest, notFound } from '../utils/api-response';
 import { asyncHandler } from '../utils/error-handler';
 import { requireAuth } from '../auth';
 import { assertResourceOwnerOrAdmin } from '../auth/ownership';
-import { validate } from '../middlewares/validation';
+import { validateWithSecurity } from '../middlewares/validation';
 import { getUnifiedDatabase } from '../data/models/unified-database';
 import { v4 as uuidv4 } from 'uuid';
 import { AgentTaskService, type AgentTaskInputFile } from '../services/AgentTaskService';
@@ -73,7 +73,11 @@ function toPublicTask(t: Record<string, unknown>) {
  * POST /api/agent-tasks
  * 작업 생성
  */
-router.post('/', validate(createAgentTaskSchema), asyncHandler(async (req: Request, res: Response) => {
+// body 상한은 express.json 파서와 동일 상수 공유 — validate 기본값(1MB)이 파서 상한을
+// 무력화해 대용량 첨부가 "요청 본문이 너무 큽니다" 로 거부되던 정합 버그 방지.
+router.post('/', validateWithSecurity(createAgentTaskSchema, {
+    maxBodySizeBytes: AGENT_TASK_LIMITS.REQUEST_BODY_MAX_BYTES,
+}), asyncHandler(async (req: Request, res: Response) => {
     const { goal, maxTurns, files, images, repoUrl, branch } = req.body as CreateAgentTaskInput;
 
     const taskId = uuidv4();

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -37,6 +37,13 @@ import { listUserRepos } from '../services/agent-task/git-ops';
 import { dispatchAgentTask, getAgentTaskQueue } from '../services/agent-task/task-queue';
 import { safeRealWorkspacePath, listWorkspaceFilesAt } from '../services/task-sandbox/sandbox';
 import { basename } from 'path';
+import multer from 'multer';
+import * as fs from 'fs/promises';
+import { FILE_ATTACH_LIMITS, DOC_EXTRACT_LIMITS } from '../config/runtime-limits';
+import {
+    ensureUploadTmpDir, finalizeUploadedFile, resolveStoredPath,
+    discardTmpFiles, removeTaskFiles, safeBaseName,
+} from '../services/agent-task/upload-store';
 
 const logger = createLogger('AgentTaskRoutes');
 const router = Router();
@@ -71,20 +78,70 @@ function toPublicTask(t: Record<string, unknown>) {
 
 /**
  * POST /api/agent-tasks
- * 작업 생성
+ * 작업 생성 — 두 가지 전송 방식 지원:
+ *
+ * ① application/json  — 기존 계약. 텍스트 content / 소형 바이너리(base64 data).
+ * ② multipart/form-data — 대용량 첨부의 근본 경로. `payload` 필드(JSON: goal 등 +
+ *    텍스트 첨부)와 `files` 파트(바이너리 원본)를 받아 multer 가 디스크로 스트리밍한다.
+ *    base64-in-JSON 과 달리 body 전체를 메모리에 올리지 않고, DB 에는 storedPath 만 남는다.
  */
+const uploadMw = multer({
+    storage: multer.diskStorage({
+        destination: (_req, _file, cb) => {
+            ensureUploadTmpDir().then((d) => cb(null, d), (e) => cb(e as Error, ''));
+        },
+        filename: (_req, _file, cb) => cb(null, uuidv4()),
+    }),
+    limits: { fileSize: AGENT_TASK_LIMITS.REQUEST_BODY_MAX_BYTES, files: FILE_ATTACH_LIMITS.MAX_FILES },
+}).array('files', FILE_ATTACH_LIMITS.MAX_FILES);
+
 // body 상한은 express.json 파서와 동일 상수 공유 — validate 기본값(1MB)이 파서 상한을
 // 무력화해 대용량 첨부가 "요청 본문이 너무 큽니다" 로 거부되던 정합 버그 방지.
-router.post('/', validateWithSecurity(createAgentTaskSchema, {
+const jsonValidateMw = validateWithSecurity(createAgentTaskSchema, {
     maxBodySizeBytes: AGENT_TASK_LIMITS.REQUEST_BODY_MAX_BYTES,
-}), asyncHandler(async (req: Request, res: Response) => {
-    const { goal, maxTurns, files, images, repoUrl, branch } = req.body as CreateAgentTaskInput;
+});
+
+router.post('/', (req: Request, res: Response, next) => {
+    if (!req.is('multipart/form-data')) return jsonValidateMw(req, res, next);
+    uploadMw(req, res, (err?: unknown) => {
+        if (!err) return next();
+        const msg = err instanceof multer.MulterError
+            ? (err.code === 'LIMIT_FILE_SIZE'
+                ? `첨부 파일이 너무 큽니다 (최대 ${AGENT_TASK_LIMITS.REQUEST_BODY_MAX_BYTES} bytes)`
+                : `업로드 형식 오류: ${err.code}`)
+            : (err instanceof Error ? err.message : String(err));
+        res.status(400).json(badRequest(msg));
+    });
+}, asyncHandler(async (req: Request, res: Response) => {
+    const parts = (req.files as Express.Multer.File[] | undefined) ?? [];
+
+    // multipart 는 payload 필드(JSON)를 동일 스키마로 검증 — 실패 시 tmp 파일 롤백.
+    let input: CreateAgentTaskInput;
+    if (parts.length > 0 || req.is('multipart/form-data')) {
+        let parsedPayload: unknown;
+        try {
+            parsedPayload = JSON.parse(String((req.body as Record<string, unknown>)?.payload ?? '{}'));
+        } catch {
+            await discardTmpFiles(parts.map((p) => p.path));
+            return res.status(400).json(badRequest('payload 필드가 유효한 JSON 이 아닙니다'));
+        }
+        const v = createAgentTaskSchema.safeParse(parsedPayload);
+        if (!v.success) {
+            await discardTmpFiles(parts.map((p) => p.path));
+            const first = v.error.issues[0];
+            return res.status(400).json(badRequest(`payload 검증 실패: ${first ? `${first.path.join('.')} — ${first.message}` : '알 수 없는 오류'}`));
+        }
+        input = v.data;
+    } else {
+        input = req.body as CreateAgentTaskInput;
+    }
+    const { goal, maxTurns, files, images, repoUrl, branch } = input;
 
     const taskId = uuidv4();
     const db = getUnifiedDatabase();
     const userId = String(req.user!.id);
 
-    // 입력 첨부: 바이너리 문서(base64 data)는 지금 텍스트로 추출해 저장한다 —
+    // 입력 첨부(JSON 경로): 바이너리 문서(base64 data)는 지금 텍스트로 추출해 저장한다 —
     // 실행은 detached 백그라운드라 여기서 추출해야 실패를 생성 응답에서 인지 가능하다.
     // base64 원본도 함께 보존해 실행 시 샌드박스 uploads/ 에 원본 바이트로 기록
     // (에이전트가 openpyxl 등으로 직접 파싱). 응답에선 toPublicTask 가 메타만 노출.
@@ -101,6 +158,36 @@ router.post('/', validateWithSecurity(createAgentTaskSchema, {
             ...(originalData[i] ? { data: originalData[i] } : {}),
             ...(originalData[i] && typeof f.content === 'string' ? { extracted: true } : {}),
         }));
+    }
+
+    // 입력 첨부(multipart 경로): 스트리밍된 원본을 task 디렉토리로 이동하고 storedPath 로
+    // 참조한다(DB 에 base64 미저장). 추출 상한 이하 문서만 텍스트 추출을 병행 —
+    // 초과 파일은 추출 없이 원본만 샌드박스로 전달돼 에이전트가 직접 파싱한다.
+    if (parts.length > 0) {
+        const stored: AgentTaskInputFile[] = [];
+        for (const [i, p] of parts.entries()) {
+            // busboy 가 latin1 로 넘긴 한글 파일명 복원 (이미 UTF-8 이면 고문자 부재로 무변환)
+            const rawName = /[\u0080-\u00ff]/.test(p.originalname)
+                ? Buffer.from(p.originalname, 'latin1').toString('utf8')
+                : p.originalname;
+            const name = safeBaseName(rawName, `file_${i}`);
+            const storedPath = await finalizeUploadedFile(taskId, p.path, rawName, i);
+            const entry: AgentTaskInputFile = { name, type: p.mimetype, size: p.size, storedPath };
+            if (p.size <= DOC_EXTRACT_LIMITS.MAX_BYTES_PER_FILE) {
+                const probe: AgentTaskInputFile = {
+                    name, type: p.mimetype,
+                    data: (await fs.readFile(resolveStoredPath(storedPath))).toString('base64'),
+                };
+                await extractAttachedDocuments([probe]);
+                if (typeof probe.content === 'string') {
+                    entry.content = probe.content;
+                    entry.truncated = probe.truncated;
+                    entry.extracted = true;
+                }
+            }
+            stored.push(entry);
+        }
+        inputFiles = [...(inputFiles ?? []), ...stored];
     }
 
     // 비동기 에이전트 중복 인지(P-6): 이미 진행 중인 작업이 있으면 경고를 함께 반환 —
@@ -123,7 +210,12 @@ router.post('/', validateWithSecurity(createAgentTaskSchema, {
     });
 
     const task = await db.getAgentTask(taskId);
-    res.status(201).json(success({ task, concurrentActive: active.length, warnings }));
+    // 목록/상세와 동일하게 메타만 노출 — 첨부 본문(content/data)·내부 경로(storedPath) 응답 제외
+    res.status(201).json(success({
+        task: task ? toPublicTask(task as unknown as Record<string, unknown>) : task,
+        concurrentActive: active.length,
+        warnings,
+    }));
 }));
 
 /**
@@ -322,6 +414,7 @@ router.delete('/:taskId', asyncHandler(async (req: Request, res: Response) => {
     AgentTaskService.cancel(task.id);
     const db = getUnifiedDatabase();
     await db.deleteAgentTask(task.id);
+    await removeTaskFiles(task.id); // multipart 업로드 원본 디스크 정리 (없으면 no-op)
     res.json(success({ message: '작업이 삭제되었습니다.', taskId: task.id }));
 }));
 

--- a/apps/api/src/schemas/agent-task.schema.ts
+++ b/apps/api/src/schemas/agent-task.schema.ts
@@ -7,7 +7,7 @@
  */
 import { z } from 'zod';
 import { secureTextSchema } from './security.schema';
-import { AGENT_TASK_LIMITS, FILE_ATTACH_LIMITS, DOC_EXTRACT_LIMITS } from '../config/runtime-limits';
+import { AGENT_TASK_LIMITS, FILE_ATTACH_LIMITS } from '../config/runtime-limits';
 
 /**
  * 작업 입력 첨부 파일 — 채팅 WS files[](WsAttachedFile) 와 동일 계약.
@@ -19,8 +19,10 @@ const taskInputFileSchema = z.object({
     name: z.string().min(1).max(FILE_ATTACH_LIMITS.MAX_NAME_LENGTH),
     type: z.string().max(100).optional(),
     content: z.string().max(FILE_ATTACH_LIMITS.MAX_CHARS_PER_FILE).optional(),
-    // base64 는 원본 바이트의 4/3 — 추출 상한 바이트 기준으로 환산 캡
-    data: z.string().max(Math.ceil(DOC_EXTRACT_LIMITS.MAX_BYTES_PER_FILE * 4 / 3) + 4).optional(),
+    // 전송 캡은 요청 body 상한과 정합(base64 문자열은 body 보다 클 수 없음) — 텍스트 추출
+    // 가능 여부는 DOC_EXTRACT_LIMITS.MAX_BYTES_PER_FILE 가 별도 결정(초과 시 추출만 생략,
+    // 원본 바이트는 샌드박스 uploads/ 로 전달되어 에이전트가 직접 파싱).
+    data: z.string().max(AGENT_TASK_LIMITS.REQUEST_BODY_MAX_BYTES).optional(),
     size: z.number().int().nonnegative().optional(),
     truncated: z.boolean().optional(),
 });

--- a/apps/api/src/services/agent-task/task-inputs.ts
+++ b/apps/api/src/services/agent-task/task-inputs.ts
@@ -5,6 +5,7 @@
 import { TASK_UPLOAD_DIR } from '../../config/task-sandbox';
 import type { TaskRuntime } from '../task-sandbox/runtime';
 import type { AgentTaskInputFile } from './types';
+import { resolveStoredPath } from './upload-store';
 import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('AgentTaskService');
@@ -40,13 +41,24 @@ export async function writeInputFilesToWorkspace(
     };
     for (const [i, f] of files.entries()) {
         const base = ((f.name.split(/[\\/]/).pop() ?? '').replace(/\p{Cc}/gu, '_').trim()) || `file_${i}`;
+        const hasStored = typeof f.storedPath === 'string' && f.storedPath.length > 0;
         const hasData = typeof f.data === 'string' && f.data.length > 0;
         const hasContent = typeof f.content === 'string' && f.content.length > 0;
-        if (!hasData && !hasContent) {
+        if (!hasStored && !hasData && !hasContent) {
             lines.push(`- (내용을 추출하지 못해 제외됨: ${f.name})`);
             continue;
         }
-        if (hasData) {
+        if (hasStored) {
+            // multipart 업로드 원본 — 디스크 스토어에서 fs copy 로 주입 (base64/Buffer 미적재)
+            const rel = `${TASK_UPLOAD_DIR}/${claim(base, i)}`;
+            try {
+                await runtime.importWorkspaceFile(rel, resolveStoredPath(f.storedPath!));
+                lines.push(`- ${rel} (원본 파일)`);
+            } catch (e) {
+                logger.warn(`[AgentTask] 입력 파일 복사 실패 (${rel}): ${e instanceof Error ? e.message : e}`);
+                lines.push(`- (기록 실패로 제외됨: ${rel})`);
+            }
+        } else if (hasData) {
             // 바이너리 원본 — base64 디코드해 그대로 기록 (직접 파싱용)
             await write(`${TASK_UPLOAD_DIR}/${claim(base, i)}`, Buffer.from(f.data!, 'base64'), ' (원본 파일)');
         }

--- a/apps/api/src/services/agent-task/types.ts
+++ b/apps/api/src/services/agent-task/types.ts
@@ -35,6 +35,9 @@ export function assertWithinLimits(
 export interface AgentTaskInputFile extends AttachedFileInput {
     /** 바이너리 문서(PDF/docx 등)에서 추출된 텍스트임 — workspace 기록 시 .txt 확장자 부여 */
     extracted?: boolean;
+    /** multipart 업로드 원본의 디스크 저장 상대 경로(upload-store ROOT 기준) —
+     *  base64(data) 대신 사용. 실행 시 샌드박스 uploads/ 로 스트리밍 복사. */
+    storedPath?: string;
 }
 
 export interface AgentTaskRunInput {

--- a/apps/api/src/services/agent-task/upload-store.ts
+++ b/apps/api/src/services/agent-task/upload-store.ts
@@ -1,0 +1,77 @@
+/**
+ * Agent Task 입력 첨부 디스크 스토어 — multipart 업로드 원본의 보관/이동/정리.
+ *
+ * base64-in-JSON 전송의 근본 한계(V8 문자열 상한·파싱 메모리 스파이크·DB 비대화)를 피해,
+ * multer 가 tmp/ 로 스트리밍한 파일을 task 확정 후 <root>/<taskId>/ 로 이동(rename)하고
+ * DB 에는 상대 경로(storedPath)만 남긴다. task 삭제 시 removeTaskFiles 로 함께 정리.
+ *
+ * @module services/agent-task/upload-store
+ */
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('AgentTaskUploadStore');
+
+const ROOT = path.resolve(AGENT_TASK_LIMITS.UPLOAD_ROOT);
+
+/** multer destination — 업로드 진행 중 임시 보관 위치. */
+export const UPLOAD_TMP_DIR = path.join(ROOT, 'tmp');
+
+export async function ensureUploadTmpDir(): Promise<string> {
+    await fs.mkdir(UPLOAD_TMP_DIR, { recursive: true });
+    return UPLOAD_TMP_DIR;
+}
+
+/** 파일명 정규화 — 경로 성분 제거 + 제어문자 치환 (task-inputs 와 동일 규칙). */
+export function safeBaseName(name: string, fallback: string): string {
+    return ((name.split(/[\\/]/).pop() ?? '').replace(/\p{Cc}/gu, '_').trim()) || fallback;
+}
+
+/** taskId 하위 저장 디렉토리의 절대 경로. taskId 는 서버 생성 uuid 만 온다(경로 주입 불가). */
+function taskDir(taskId: string): string {
+    return path.join(ROOT, taskId);
+}
+
+/**
+ * tmp 에 스트리밍된 업로드 파일을 task 디렉토리로 이동하고 상대 저장 경로를 반환.
+ * 같은 파일시스템이므로 rename — 대용량도 즉시 완료.
+ */
+export async function finalizeUploadedFile(
+    taskId: string,
+    tmpPath: string,
+    originalName: string,
+    index: number,
+): Promise<string> {
+    const dir = taskDir(taskId);
+    await fs.mkdir(dir, { recursive: true });
+    const rel = `${index}_${safeBaseName(originalName, `file_${index}`)}`;
+    await fs.rename(tmpPath, path.join(dir, rel));
+    return path.join(taskId, rel);
+}
+
+/** storedPath(상대) → 절대 경로. ROOT 밖으로 나가는 경로는 거부(방어). */
+export function resolveStoredPath(storedPath: string): string {
+    const abs = path.resolve(ROOT, storedPath);
+    if (abs !== ROOT && !abs.startsWith(ROOT + path.sep)) {
+        throw new Error(`잘못된 저장 경로: ${storedPath}`);
+    }
+    return abs;
+}
+
+/** 업로드 임시 파일 제거 (검증 실패 등 롤백용). 실패는 로그만. */
+export async function discardTmpFiles(tmpPaths: string[]): Promise<void> {
+    for (const p of tmpPaths) {
+        try { await fs.unlink(p); } catch { /* 이미 없음 */ }
+    }
+}
+
+/** task 의 저장 파일 전체 정리 (task 삭제 시). 실패는 로그만 — 삭제 흐름을 막지 않는다. */
+export async function removeTaskFiles(taskId: string): Promise<void> {
+    try {
+        await fs.rm(taskDir(taskId), { recursive: true, force: true });
+    } catch (e) {
+        logger.warn(`[UploadStore] task 파일 정리 실패 (${taskId}): ${e instanceof Error ? e.message : e}`);
+    }
+}

--- a/apps/api/src/services/task-sandbox/runtime.ts
+++ b/apps/api/src/services/task-sandbox/runtime.ts
@@ -101,6 +101,9 @@ export class TaskRuntime {
     /** 입력 첨부 주입 등 호스트 측 workspace 파일 쓰기 — 경로 가드(safeRealWorkspacePath)+쿼터 적용. */
     async writeWorkspaceFile(relPath: string, content: string | Buffer): Promise<void> { return this.sandbox.writeFile(relPath, content); }
 
+    /** 호스트 파일을 workspace 로 복사 — 대용량 입력 첨부의 스트리밍 주입(Buffer 미적재). */
+    async importWorkspaceFile(relPath: string, srcAbsPath: string): Promise<void> { return this.sandbox.importFile(relPath, srcAbsPath); }
+
     /** 내부 검증용 원시 exec — 승인 게이트 우회(에이전트 도구 호출이 아닌 시스템 산출물 검증).
      *  컨테이너는 격리(network none·자원 캡)이고 문법/컴파일 검사는 코드를 실행하지 않아 안전. */
     async execRaw(command: string): Promise<ExecResult> { return this.sandbox.exec(command); }

--- a/apps/api/src/services/task-sandbox/sandbox.ts
+++ b/apps/api/src/services/task-sandbox/sandbox.ts
@@ -15,7 +15,7 @@
  * @module services/task-sandbox/sandbox
  */
 import { spawn } from 'child_process';
-import { mkdir, rm, writeFile as fsWriteFile, readFile as fsReadFile, readdir, stat, realpath } from 'fs/promises';
+import { mkdir, rm, writeFile as fsWriteFile, readFile as fsReadFile, readdir, stat, realpath, copyFile as fsCopyFile } from 'fs/promises';
 import { resolve, sep, join, dirname, basename, relative } from 'path';
 import { getTaskSandboxConfig, type TaskSandboxConfig } from '../../config/task-sandbox';
 import { createLogger } from '../../utils/logger';
@@ -295,6 +295,19 @@ export class TaskSandbox {
         }
         await mkdir(dirname(abs), { recursive: true });
         await fsWriteFile(abs, content);
+    }
+
+    /** 호스트 파일을 workspace 로 복사 (대용량 입력 첨부 — Buffer 메모리 적재 없이 fs copy).
+     *  경로 가드 + 디스크 쿼터는 writeFile 과 동일하게 적용. */
+    async importFile(relPath: string, srcAbsPath: string): Promise<void> {
+        const abs = await safeRealWorkspacePath(this.hostWorkdir, relPath);
+        const st = await stat(srcAbsPath);
+        const size = await dirSizeBytes(this.hostWorkdir, this.cfg.workspaceQuota + 1);
+        if (size + st.size > this.cfg.workspaceQuota) {
+            throw new Error(`workspace 디스크 쿼터 초과(상한 ${Math.round(this.cfg.workspaceQuota / 1024 / 1024)}MB) — 파일이 너무 큽니다.`);
+        }
+        await mkdir(dirname(abs), { recursive: true });
+        await fsCopyFile(srcAbsPath, abs);
     }
 
     /** workspace 내 파일 읽기. 경로 가드(어휘+실경로) 적용. */

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -23,7 +23,7 @@ import {
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import type { WsAttachedFile } from "@openmake/shared-types";
+import type { AttachedFileUI } from "@/lib/use-chat-socket";
 import { useAppStore, INTERCEPT_MODE_KEYS } from "@/lib/store";
 import { NotebookPicker } from "./notebook-picker";
 import { useChatSocket } from "@/lib/use-chat-socket";
@@ -47,6 +47,9 @@ const MAX_FILES = 50;
 const MAX_IMAGES = 20;
 const MAX_CHARS_PER_FILE = 2_000_000;
 const MAX_TOTAL_CHARS = 10_000_000;
+// base64 인라인(채팅 WS 경로 호환) 상한 — 백엔드 DOC_EXTRACT MAX_BYTES_PER_FILE 기본값과 일치.
+// 초과 문서는 rawFile 만 유지 → 에이전트 작업 생성 시 multipart 로 원본 스트리밍(크기 무관).
+const MAX_INLINE_DOC_BYTES = 30 * 1024 * 1024;
 // 모든 파일 타입 허용(accept 미지정). 처리 분기:
 //  - 이미지(image/*) → base64 data URL → vision 채널(images)
 //  - 문서(EXTRACT_EXTS: PDF/Word/Excel/PowerPoint 등) → base64 원본(data) → 백엔드가 텍스트 추출
@@ -98,7 +101,7 @@ export function Composer() {
   const { sendChat, abort, startAgentTask, sendStructured } = useChatSocket();
   const router = useRouter();
   const [text, setText] = useState("");
-  const [files, setFiles] = useState<WsAttachedFile[]>([]);
+  const [files, setFiles] = useState<AttachedFileUI[]>([]);
   // 이미지 첨부 — base64 data URL 로 vision 채널 전송. 미리보기/제거를 위해 메타와 함께 보관.
   const [images, setImages] = useState<{ id: string; name: string; dataUrl: string }[]>([]);
   // 드래그앤드롭 오버레이 표시 상태
@@ -129,16 +132,17 @@ export function Composer() {
         if (!dataUrl) continue;
         nextImages.push({ id: crypto.randomUUID(), name: file.name.slice(0, 200), dataUrl });
       } else if (EXTRACT_EXTS.includes(extOf(file.name))) {
-        // 문서(PDF/Word/Excel/PPT 등) → base64 원본 전송, 백엔드가 텍스트 추출
+        // 문서(PDF/Word/Excel/PPT 등) — File 원본을 유지해 에이전트 작업은 multipart 로
+        // 스트리밍 전송. 추출 상한 이하만 base64 를 병행(채팅 WS 경로에서 백엔드 텍스트 추출용).
         if (nextFiles.length >= MAX_FILES) continue;
-        const data = await readFileBase64(file);
-        if (!data) continue;
+        const data = file.size <= MAX_INLINE_DOC_BYTES ? await readFileBase64(file) : undefined;
         nextFiles.push({
           id: crypto.randomUUID(),
           name: file.name.slice(0, 200),
           type: file.type || "application/octet-stream",
-          data,
+          ...(data ? { data } : {}),
           size: file.size,
+          rawFile: file,
         });
       } else {
         if (nextFiles.length >= MAX_FILES || total >= MAX_TOTAL_CHARS) continue;

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -4,9 +4,22 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import type { WsChatRequest, WsServerEvent, WsAttachedFile } from "@openmake/shared-types";
 import { useAppStore, type StructuredAnswerData, type PendingApproval, type AgentTaskState } from "./store";
-import { ApiClient } from "./api-client";
+import { ApiClient, csrfHeaders } from "./api-client";
+
 import { getAnonSessionId } from "./anon-session";
 import { CLIENT_TIMING } from "./config";
+
+/** 첨부 파일 UI 상태 — WS 계약(WsAttachedFile)에 브라우저 File 원본을 얹은 로컬 확장.
+ *  rawFile 이 있으면 에이전트 작업 생성 시 multipart 로 원본을 스트리밍 업로드한다
+ *  (base64-in-JSON 의 메모리/크기 한계 회피). WS 채팅 전송 시에는 제거된다. */
+export type AttachedFileUI = WsAttachedFile & { rawFile?: File };
+
+/** WS/REST 직렬화용 — 브라우저 File(rawFile)을 계약 필드에서 제거한다. */
+function toWireFile(f: AttachedFileUI): WsAttachedFile {
+  const { rawFile, ...rest } = f;
+  void rawFile;
+  return rest;
+}
 
 /**
  * 채팅 WebSocket hook — 백엔드 sockets/ws-chat-handler.ts 프로토콜.
@@ -309,7 +322,7 @@ export function useChatSocket() {
   }, [connect]);
 
   const sendChat = useCallback(
-    (message: string, images?: string[], files?: WsAttachedFile[], notebook?: { id: string; title: string } | null) => {
+    (message: string, images?: string[], files?: AttachedFileUI[], notebook?: { id: string; title: string } | null) => {
       const s = useAppStore.getState();
       const hasFiles = Array.isArray(files) && files.length > 0;
       // 텍스트가 비어도 첨부 파일만으로 전송 가능
@@ -345,7 +358,8 @@ export function useChatSocket() {
         sessionId: s.currentSessionId,
         anonSessionId: getAnonSessionId(),
         images: images ?? [],
-        files: files ?? [],
+        // rawFile(브라우저 File)은 WS 직렬화 불가 — 계약 필드만 전송
+        files: (files ?? []).map(toWireFile),
         webSearch: s.webSearchEnabled,
         deepResearchMode: s.deepResearchMode,
         discussionMode: s.discussionMode,
@@ -386,7 +400,7 @@ export function useChatSocket() {
   const startAgentTask = useCallback(
     async (
       message: string,
-      files?: WsAttachedFile[],
+      files?: AttachedFileUI[],
       images?: string[],
       approvalPolicy?: "all" | "high-risk" | "none",
       repoUrl?: string,
@@ -396,15 +410,47 @@ export function useChatSocket() {
       if (!goal || s.isGenerating) return;
       appendMessage({ role: "user", content: goal });
       try {
-        const created = await ApiClient.post<{ data: { task: { id: string } } }>(
-          "/api/agent-tasks",
-          {
+        // 바이너리 원본(rawFile)이 있으면 multipart 로 스트리밍 업로드 — base64-in-JSON 의
+        // 크기/메모리 한계를 피하는 근본 경로. 텍스트 첨부·이미지는 payload JSON 에 동승.
+        const binaryParts = (files ?? []).filter((f) => f.rawFile);
+        let created: { data?: { task?: { id?: string } } } | null;
+        if (binaryParts.length > 0) {
+          const payloadFiles = (files ?? [])
+            .filter((f) => !f.rawFile)
+            .map(toWireFile);
+          const fd = new FormData();
+          fd.append("payload", JSON.stringify({
             goal,
-            ...(files && files.length > 0 ? { files } : {}),
+            ...(payloadFiles.length > 0 ? { files: payloadFiles } : {}),
             ...(images && images.length > 0 ? { images } : {}),
             ...(repoUrl && repoUrl.trim() ? { repoUrl: repoUrl.trim() } : {}),
-          },
-        );
+          }));
+          for (const f of binaryParts) fd.append("files", f.rawFile!, f.name);
+          const resp = await fetch("/api/agent-tasks", {
+            method: "POST",
+            credentials: "include",
+            headers: { ...(await csrfHeaders()) },
+            body: fd,
+          });
+          const body = await resp.json().catch(() => null);
+          if (!resp.ok) {
+            const detail = (body as { error?: { message?: string } } | null)?.error?.message;
+            throw new Error(detail || `HTTP ${resp.status}`);
+          }
+          created = body as { data?: { task?: { id?: string } } };
+        } else {
+          created = await ApiClient.post<{ data: { task: { id: string } } }>(
+            "/api/agent-tasks",
+            {
+              goal,
+              ...(files && files.length > 0
+                ? { files: files.map(toWireFile) }
+                : {}),
+              ...(images && images.length > 0 ? { images } : {}),
+              ...(repoUrl && repoUrl.trim() ? { repoUrl: repoUrl.trim() } : {}),
+            },
+          );
+        }
         const taskId = created?.data?.task?.id;
         if (!taskId) throw new Error(tRef.current("taskIdMissing"));
         // 진행상황 카드 — agent_task_progress 이벤트로 taskId 로 식별해 라이브 업데이트.


### PR DESCRIPTION
## 문제

대용량 첨부로 에이전트 작업 생성 시 **'요청 본문이 너무 큽니다 (최대 1048576 bytes)'** 로 거부됨.

1. `validate()` 미들웨어 기본 1MB 캡이 50MB 파서·스키마 한도를 무력화 (직접 원인)
2. base64-in-JSON 전송 자체의 구조적 한계 — V8 문자열 상한(실효 ~750MB), 파싱 메모리 스파이크(수 GB), DB `input_files` 에 base64 통째 저장 (근본 문제)

## 커밋 1 — 1MB 검증 캡 제거·상수 정합 (`be155e41`)

- `AGENT_TASK_LIMITS.REQUEST_BODY_MAX_BYTES` 신설 (기본 **1000MB**, `AGENT_TASK_BODY_MAX_BYTES` env)
- `/api/agent-tasks` 파서·validate·multipart 파일 상한이 **단일 상수 공유**
- 파일당 base64 `data` 스키마 캡도 동일 상수로 정합

## 커밋 2 — multipart 디스크 스트리밍 (근본 해결, `2b255ba4`)

**Backend**
- `POST /api/agent-tasks` 가 `multipart/form-data` 추가 수용 — multer diskStorage 로 **body 메모리 적재 없이 디스크 스트리밍**. `payload` 필드(JSON)는 동일 Zod 스키마 검증(실패 시 tmp 롤백). 기존 JSON 계약 그대로 유지
- `upload-store` 신설: `<UPLOAD_ROOT>/<taskId>/` 원자적 이동, 경로 가드, **task 삭제 시 디스크 정리**
- DB 에는 base64 대신 **storedPath 만 저장** (JSONB — 마이그레이션 불요). 추출 상한(30MB) 이하만 텍스트 추출 병행, 초과분은 원본만 샌드박스 전달
- 샌드박스 주입: `sandbox.importFile`(fs copy, 쿼터·경로 가드 동일) — Buffer 미적재
- 생성 응답 `toPublicTask` 적용 — 기존에 base64 가 응답으로 그대로 새던 것도 함께 차단
- busboy latin1 한글 파일명 복원

**Frontend**
- composer: 문서 첨부에 File 원본(rawFile) 유지 — 30MB 이하만 base64 병행(채팅 WS 호환), 초과는 작업 전용
- `startAgentTask`: rawFile 있으면 **FormData + CSRF 헤더**로 전송, 없으면 기존 JSON

## 검증 (워크트리 서버 :52998 라이브 스모크 — 운영 무접촉)

- [x] 2MB 한글명 PDF multipart → 201, 디스크 원본 **SHA 일치**, DB 메타만, 응답에 storedPath 미노출
- [x] 1.2MB JSON(사용자가 겪은 원래 케이스) → 201 (수정 전 400 재현 확인됨)
- [x] DELETE → 저장 디렉토리 정리 확인
- [x] backend/web tsc·eslint 통과

## 운영 노트

- `TASK_SANDBOX_WORKSPACE_QUOTA`(기본 512MB) 가 샌드박스 주입 시 상한 — 초대용량 상시 사용 시 함께 상향 필요 (.env.example 에 명시)
- `/api/documents` 50mb 파서는 죽은 마운트(라우터 2026-05-19 폐기) — 정합 이슈 없음. `/api/chat` REST 동일 패턴은 WS 미영향, 후속 후보

🤖 Generated with [Claude Code](https://claude.com/claude-code)