### PR TITLE
fix(infra): mcp-runtime 이미지에 chromium 시스템 의존성 베이킹

### DIFF
--- a/infra/mcp-runtime/Dockerfile
+++ b/infra/mcp-runtime/Dockerfile
@@ -18,6 +18,21 @@ RUN apt-get update \
     && apt-get purge -y curl \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# ── Chromium(Playwright) 실행 시스템 의존성 — 브라우저 사용 MCP 서버 지원 ──
+# noapi-google-search-mcp 등 playwright 기반 서버가 chromium 을 launch 하려면 공유
+# 라이브러리가 필요하다. 컨테이너는 --read-only + cap-drop ALL 이라 런타임 apt 설치가
+# 불가(2026-07-25 7시 예약 리포트가 "Executable doesn't exist" 로 무산된 원인) → 이미지에
+# 베이킹한다. 브라우저 본체는 서버별 캐시 볼륨(~/.cache/ms-playwright)에 설치·유지되며,
+# 서버 패키지의 playwright 버전이 바뀌면 볼륨에 `python -m playwright install chromium`
+# 재실행이 필요하다(버전-리비전 정합). 폰트는 스크린샷 한글 렌더용.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libglib2.0-0 libnss3 libnspr4 libdbus-1-3 libatk1.0-0 libatk-bridge2.0-0 \
+        libatspi2.0-0 libx11-6 libxcb1 libxext6 libxcomposite1 libxdamage1 libxfixes3 \
+        libxrandr2 libgbm1 libxkbcommon0 libasound2 libcups2 libcairo2 libpango-1.0-0 \
+        fonts-liberation fonts-noto-cjk \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # node:22 이미지 기본 제공 'node' 유저(uid 1000) 사용 — sandbox-docker 의 --user 1000:1000 과 일치.
 # (useradd 로 새 uid 1000 생성하면 node 와 충돌해 실패하므로 기존 유저 재사용)
 USER node


### PR DESCRIPTION
## 배경 — 오늘(07-25) 7시 예약 리포트 무산의 근본 원인

07:00 예약 실행이 1분41초 만에 '완료'로 끝났지만 **report.html 미생성** (턴 상한 20턴 소진, 빈 완료):

1. `google_news`/`google_search`(noapi-google-search-mcp, playwright 기반)가 **'BrowserType.launch: Executable doesn't exist'** 로 전부 실패 — MCP 샌드박스의 서버별 캐시 볼륨에 브라우저가 없음
2. 폴백(curl/python)은 task 샌드박스가 network=none 이라 전부 실패
3. 모든 도구가 즉시 실패 → 20턴 고속 소진 → '턴 상한 종료' 경로로 completed 오표시

컨테이너가 `--read-only + --cap-drop ALL` 이라 런타임 복구(apt)가 불가 → 이미지 베이킹이 유일한 경로.

## 변경

- chromium 공유 라이브러리(libnss3·libgbm1·libasound2 등) + 한글 폰트(fonts-noto-cjk) 베이킹
- 브라우저 본체는 서버별 캐시 볼륨(`~/.cache/ms-playwright`) 운영 — playwright 버전 bump 시 볼륨 재설치 필요함을 주석 명시

## 별도 발견 (이 PR 범위 밖)

- **턴 상한 종료 경로가 goal judge 를 우회** → 아무것도 못 했는데 completed 로 기록됨. '빈 완료' 차단 로직이 이 경로에도 필요 — 후속 이슈 권장

## 검증 계획
- [x] 이미지 로컬 빌드
- [ ] noapi 컨테이너 재생성 후 google_news 라이브 호출 성공
- [ ] 7시 예약 즉시 재실행 → report.html 생성 완주

🤖 Generated with [Claude Code](https://claude.com/claude-code)