### PR TITLE
chore(infra): 외부 도메인 openmake.cc → chat.openmake.cc 이전

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ body.txt
 tbody.txt
 up_chat.json
 up_models.json
+
+# Cloudflare Tunnel 설정 — git 커밋 금지 지침 (라이브: ~/.cloudflared/config.yml)
+scripts/cloudflared/

--- a/apps/api/src/controllers/auth-oauth-helpers.ts
+++ b/apps/api/src/controllers/auth-oauth-helpers.ts
@@ -176,7 +176,7 @@ function validateAndConsumeStateFallback(state: string, expectedProvider: string
  *
  * 우선순위:
  * 1. OAUTH_REDIRECT_URI 환경변수 (명시적 설정 시) -- 요청 host 와 무관하게 이 canonical
- *    URI 로 항상 고정 (외부 접속을 openmake.cc 단일 origin 으로 수렴)
+ *    URI 로 항상 고정 (외부 접속을 chat.openmake.cc 단일 origin 으로 수렴)
  * 2. 요청의 Host/Origin 기반 동적 생성 (개발 환경 localhost 폴백)
  *
  * OAUTH_REDIRECT_URI는 Google용으로 설정되어 있어도 provider 부분을 자동 교체합니다.
@@ -198,7 +198,7 @@ export function buildRedirectUri(req: Request, provider: 'google' | 'github' | '
     // OAUTH_REDIRECT_URI가 명시적으로 설정된 경우(프로덕션), 요청 host 와 무관하게 항상 이
     // canonical URI 로 고정한다. ts.net(Funnel)·rasplay 등 다른 host 로 진입하면 리버스 프록시가
     // 평문이라 proto=http 로 동적 URI 가 만들어져 Google redirect_uri_mismatch 로 실패하던 문제를
-    // 차단한다. 어느 진입점이든 로그인 완료는 openmake.cc 단일 origin 으로 착지한다.
+    // 차단한다. 어느 진입점이든 로그인 완료는 chat.openmake.cc 단일 origin 으로 착지한다.
     // (redirect_uri 를 요청 host 가 아닌 신뢰된 상수로 고정 → open-redirect 관점에서도 더 안전)
     if (configuredUri && !configuredUri.includes('localhost')) {
         try {


### PR DESCRIPTION
## 요약

외부 공개 도메인을 apex `openmake.cc` 에서 **`chat.openmake.cc`** 로 이전. apex 는 추후 다른 기능에 사용할 예정이라 터널 ingress 에서 제외했다 (DNS CNAME 은 Cloudflare 존에 잔존, 현재 catch-all 404).

## 변경 내용

- **`.gitignore`** — `scripts/cloudflared/` 등록 (Cloudflare Tunnel 설정은 git 커밋 금지 지침, 라이브는 `~/.cloudflared/config.yml`)
- **`apps/api/src/controllers/auth-oauth-helpers.ts`** — 주석 2곳 canonical origin 표기 현행화 (로직 무변경)

## 함께 적용된 운영 변경 (git 외부)

- cloudflared ingress hostname: `openmake.cc` → `chat.openmake.cc` (`~/.cloudflared/config.yml`, LaunchAgent 재시작 반영)
- `.env`: `OAUTH_REDIRECT_URI` · `CORS_ORIGINS` · `OMK_APP_URL` → chat 도메인 (pm2 delete→start→save 반영)
- Cloudflare: `chat.openmake.cc` CNAME → 터널 라우트 생성
- Google Cloud Console / Kakao Developers: 신규 redirect URI 등록 완료

## 검증

- [x] `https://chat.openmake.cc` 페이지·`/api/health`·`/login` 200
- [x] WebSocket 핸드셰이크 성공 (origin 검증 통과)
- [x] Google OAuth: 계정 선택 화면 진입 (`app_domain=chat.openmake.cc` 인식, mismatch 없음) + **실계정 로그인 성공 확인**
- [x] Kakao OAuth: 로그인 폼 진입 (KOE006 없음)
- [x] 콜백 bad state → `302 /login?error=invalid_state` 정상
- [x] apex `openmake.cc` → 404 (의도된 분리)

코드 로직 변경 없음(.gitignore + 주석) — lint/unit 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)