### PR TITLE
fix(build-info): version·gitTag 가 /health 응답에 실리지 않던 누락 수정

### DIFF
--- a/apps/api/src/config/build-id.ts
+++ b/apps/api/src/config/build-id.ts
@@ -37,7 +37,7 @@ let _cached: BuildInfo | null = null;
 
 /**
  * 서버 build-info 전체 반환. 최초 호출 시 1회 파일 read 후 메모리 캐시.
- * @returns {BuildInfo} { buildTime, gitHash, gitDate } — 누락/파싱 실패 시 fallback
+ * @returns {BuildInfo} { buildTime, gitHash, gitDate, version?, gitTag? } — 누락/파싱 실패 시 fallback
  */
 export function getBuildInfo(): BuildInfo {
     if (_cached !== null) {
@@ -52,6 +52,9 @@ export function getBuildInfo(): BuildInfo {
                     ? parsed.gitHash.trim()
                     : FALLBACK_BUILD_ID,
                 gitDate: typeof parsed.gitDate === 'string' ? parsed.gitDate : FALLBACK_BUILD_INFO.gitDate,
+                // version·gitTag 는 구 build-info.json 엔 없으므로 있을 때만 싣는다(undefined 키 미노출).
+                ...(typeof parsed.version === 'string' ? { version: parsed.version } : {}),
+                ...(typeof parsed.gitTag === 'string' && parsed.gitTag !== '' ? { gitTag: parsed.gitTag } : {}),
             };
             return _cached;
         }


### PR DESCRIPTION
## 문제

PR #347에서 `BuildInfo` 인터페이스에 `version`·`gitTag` 를 추가했지만, **`getBuildInfo()` 의 파싱부를 함께 고치지 않았습니다.**

이 함수는 `build-info.json` 을 읽어 **필드를 명시적으로 골라 담는** 구조라, 타입에만 필드를 추가해서는 값이 응답까지 전달되지 않습니다.

**라이브 증상** — 파일에는 있는데 응답에는 없음:

```jsonc
// apps/api/dist/build-info.json
{"version":"1.5.6", …, "gitTag":"v1.5.6"}

// GET /health 의 build (수정 전)
{"buildTime":"…","gitHash":"c4350bb4","gitDate":"2026-07-25"}   // ← version·gitTag 누락
```

## 수정

파싱부에서 두 필드를 함께 싣습니다. 구 `build-info.json`(필드 없음) 호환을 위해 **값이 있을 때만** 추가하며, 빈 `gitTag` 는 키 자체를 노출하지 않습니다.

## 검증 (라이브)

빌드 → pm2 재시작 후 `GET /health`:

```json
{"buildTime":"2026-07-25T08:35:39.094Z","gitHash":"c4350bb4","gitDate":"2026-07-25",
 "version":"1.5.6","gitTag":"v1.5.6"}
```

이제 운영에서 `v1.5.6 (c4350bb4)` 로 식별됩니다. `tsc --noEmit` 통과.

## 참고

이 PR은 release-please 도입 후 **첫 user-facing 커밋**(`fix:`)이라, 머지되면 Release PR이 자동 생성되어 **v1.5.7** 이 제안될 예정입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)