### PR TITLE
fix(deps): workspace 내부 참조를 버전 무관(*)으로 — Release PR npm ci 404 수정

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,7 +24,7 @@
         "@modelcontextprotocol/sdk": "^1.25.3",
         "@mozilla/readability": "^0.6.0",
         "@opendataloader/pdf": "^2.4.7",
-        "@openmake/shared-types": "1.5.6",
+        "@openmake/shared-types": "*",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
         "@opentelemetry/instrumentation-express": "^0.67.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,9 +10,9 @@
     "check:i18n": "node scripts/check-i18n-keys.mjs"
   },
   "dependencies": {
-    "@openmake/api-client": "1.5.6",
-    "@openmake/config": "1.5.6",
-    "@openmake/shared-types": "1.5.6",
+    "@openmake/api-client": "*",
+    "@openmake/config": "*",
+    "@openmake/shared-types": "*",
     "@tanstack/react-query": "^5.101.0",
     "clsx": "^2.1.1",
     "katex": "^0.17.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
                 "@modelcontextprotocol/sdk": "^1.25.3",
                 "@mozilla/readability": "^0.6.0",
                 "@opendataloader/pdf": "^2.4.7",
-                "@openmake/shared-types": "1.5.6",
+                "@openmake/shared-types": "*",
                 "@opentelemetry/api": "^1.9.1",
                 "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
                 "@opentelemetry/instrumentation-express": "^0.67.0",
@@ -152,9 +152,9 @@
             "name": "@openmake/web",
             "version": "0.1.0",
             "dependencies": {
-                "@openmake/api-client": "1.5.6",
-                "@openmake/config": "1.5.6",
-                "@openmake/shared-types": "1.5.6",
+                "@openmake/api-client": "*",
+                "@openmake/config": "*",
+                "@openmake/shared-types": "*",
                 "@tanstack/react-query": "^5.101.0",
                 "clsx": "^2.1.1",
                 "katex": "^0.17.0",
@@ -17787,8 +17787,8 @@
             "name": "@openmake/api-client",
             "version": "1.5.6",
             "dependencies": {
-                "@openmake/config": "1.5.6",
-                "@openmake/shared-types": "1.5.6"
+                "@openmake/config": "*",
+                "@openmake/shared-types": "*"
             }
         },
         "packages/config": {

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -9,7 +9,7 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@openmake/shared-types": "1.5.6",
-    "@openmake/config": "1.5.6"
+    "@openmake/shared-types": "*",
+    "@openmake/config": "*"
   }
 }


### PR DESCRIPTION
## 문제

Release PR #349 의 CI가 `npm ci` 에서 즉사했습니다:

```
npm error 404 Not Found - GET https://registry.npmjs.org/@openmake%2fshared-types
npm error 404 '@openmake/shared-types@1.5.6' could not be found
```

## 원인

workspace 패키지끼리 **정확 버전**(`"@openmake/shared-types": "1.5.6"`)으로 참조하고 있었습니다. release-please가 `extra-files` 로 각 패키지의 `version` 을 1.5.7로 올리면 **의존성 선언(1.5.6)과 어긋나** npm이 workspace 매칭에 실패하고, 레지스트리로 폴백 → private 패키지라 404.

즉, 버전을 bump하는 **모든** Release PR이 같은 방식으로 깨지는 구조적 문제입니다.

## 수정

내부 workspace 참조 6곳(`apps/api`, `apps/web`, `packages/api-client`)을 `"*"` 로 변경하고 package-lock을 재생성했습니다. npm workspaces는 로컬 패키지를 항상 우선 링크하므로 앞으로의 버전 bump와 무관하게 정합이 유지됩니다. 이 패키지들은 publish 대상이 아니라 버전 범위 지정의 의미가 없습니다.

## 검증

```
npm ls @openmake/shared-types
├── @openmake/shared-types@1.5.6 -> ./packages/shared-types   (workspace 링크 정상)
```

## 머지 후

release-please가 Release PR #349 를 자동 갱신합니다(이 fix 포함, v1.5.7 유지). 갱신된 #349 의 CI는 이번엔 통과해야 정상입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)