### PR TITLE
refactor(task-sandbox): 도구 실행 백엔드 TaskExecutor 추상화 (Cowork 트랙 D0)

### DIFF
--- a/apps/api/src/services/task-sandbox/executor.ts
+++ b/apps/api/src/services/task-sandbox/executor.ts
@@ -1,0 +1,85 @@
+/**
+ * ============================================================
+ * Task Executor — 도구 실행 백엔드 추상화 (Cowork 트랙 D0)
+ * ============================================================
+ *
+ * Agent Task 의 "두뇌(루프·판단·승인)"와 "손발(도구 실행·파일 I/O)"을 분리하는
+ * 인터페이스. TaskRuntime/tools.ts 는 이 인터페이스에만 의존한다.
+ *
+ * 구현체:
+ *   - TaskSandbox (sandbox.ts)  — 현행 서버 Docker 샌드박스 (D0 에서 랩)
+ *   - RemoteExecutor (D1 예정)  — 데스크톱 브리지 경유 사용자 머신 로컬 실행
+ *
+ * 설계 불변식 (D1 에서도 유지할 것):
+ *   - 실행기는 이 인터페이스의 고정 도구 표면만 노출한다 — 임의 RPC 금지.
+ *   - 비밀(토큰·자격증명)은 실행기 프로토콜에 싣지 않는다 (Git/PR 토큰 비주입 원칙과 동일).
+ *   - 경로는 workspace 스코프 안에서만 해석한다 (safeRealWorkspacePath 등가 가드 필수).
+ *
+ * @module services/task-sandbox/executor
+ */
+
+/** 도구 실행 결과 — 출력 캡/timeout 메타 포함 (기존 sandbox.ts 에서 이동, 재노출 유지). */
+export interface ExecResult {
+    stdout: string;
+    stderr: string;
+    exitCode: number;
+    truncated: boolean;
+    timedOut: boolean;
+    durationMs: number;
+}
+
+/**
+ * 도구 실행 백엔드 인터페이스.
+ *
+ * TaskSandbox 의 공개 표면과 1:1 — D0 은 동작 무변경 추출이며,
+ * 원격 실행기 특화 요구(디바이스 핸드셰이크 등)는 D1 에서 이 계약 위에 얹는다.
+ */
+export interface TaskExecutor {
+    readonly taskId: string;
+
+    /** 관측/로그·영속(sandboxContainerId)용 식별 라벨 — docker: 컨테이너명, 원격: 디바이스 라벨. */
+    readonly label: string;
+
+    /**
+     * 서버(호스트) 파일시스템에 workspace 가 있으면 그 절대경로, 원격 실행기는 null.
+     * 호스트측 git 연산(code-diff·clone·PR)과 대용량 첨부 스트리밍 주입이 의존한다 —
+     * null 이면 해당 기능은 실행기 위임으로 대체해야 한다(D1).
+     */
+    readonly localWorkdir: string | null;
+
+    /** browser 도구 활성 여부 (도구 노출 게이트). */
+    readonly isBrowserEnabled: boolean;
+
+    /** 브라우저 세션 지속 ON 이면 storageState 상대경로, OFF 면 null. */
+    readonly browserStatePath: string | null;
+
+    /** 실행 환경 준비 (docker: 컨테이너 기동 / 원격: 디바이스 세션 확립). 멱등. */
+    create(): Promise<void>;
+
+    /** 셸 명령 실행 — bash 도구의 실행 백엔드. */
+    exec(command: string): Promise<ExecResult>;
+
+    /** 브라우저 액션 배치 실행 (actions JSON 은 workspace 상대경로에 사전 기록). */
+    runBrowser(actionsRelPath: string): Promise<ExecResult>;
+
+    /** workspace 상대경로에 파일 쓰기 — 경로 가드 + 디스크 쿼터 적용. */
+    writeFile(relPath: string, content: string | Buffer): Promise<void>;
+
+    /** 호스트 파일을 workspace 로 복사(대용량 첨부 — Buffer 미적재 스트리밍). */
+    importFile(relPath: string, srcAbsPath: string): Promise<void>;
+
+    /** workspace 파일 읽기 (utf8). 경로 가드 적용. */
+    readFile(relPath: string): Promise<string>;
+
+    /** workspace 디렉토리 목록. 경로 가드 적용. */
+    listDir(relPath?: string): Promise<string[]>;
+
+    /** 산출물 회수용 — workspace 전체 파일 상대경로 재귀 나열. */
+    listWorkspaceFiles(): Promise<string[]>;
+
+    /** workspace 파일/디렉토리 삭제. 루트 삭제 금지. */
+    deleteFile(relPath: string): Promise<void>;
+
+    /** 실행 환경 정리. removeWorkspace=false 면 산출물 회수를 위해 workspace 보존. 멱등. */
+    cleanup(removeWorkspace?: boolean): Promise<void>;
+}

--- a/apps/api/src/services/task-sandbox/runtime.ts
+++ b/apps/api/src/services/task-sandbox/runtime.ts
@@ -12,6 +12,7 @@ import type { ToolDefinition } from '../../llm/types';
 import type { MCPToolDefinition } from '../../mcp/types';
 import { getTaskSandboxConfig, type TaskSandboxConfig } from '../../config/task-sandbox';
 import { TaskSandbox, type ExecResult } from './sandbox';
+import type { TaskExecutor } from './executor';
 import { createTaskTools, type DelegateFn, type SpawnFn, type ProceduralHooks } from './tools';
 import { recordBrowserMetric } from './browser-metrics';
 import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
@@ -53,7 +54,7 @@ export class TaskRuntime {
     readonly taskId: string;
     readonly userId: string;
     private readonly cfg: TaskSandboxConfig;
-    private readonly sandbox: TaskSandbox;
+    private readonly executor: TaskExecutor;
     private readonly plan = new TaskPlan();
     private readonly handlers = new Map<string, MCPToolDefinition['handler']>();
     private readonly defs: MCPToolDefinition[];
@@ -64,11 +65,13 @@ export class TaskRuntime {
         cfg: TaskSandboxConfig = getTaskSandboxConfig(),
         delegate?: DelegateFn,
         spawn?: SpawnFn,
+        /** 실행 백엔드 주입(D1 원격 실행기용). 미지정 시 현행 Docker 샌드박스. */
+        executor?: TaskExecutor,
     ) {
         this.taskId = taskId;
         this.userId = userId;
         this.cfg = cfg;
-        this.sandbox = new TaskSandbox(taskId, cfg);
+        this.executor = executor ?? new TaskSandbox(taskId, cfg);
         // #1 절차 스킬: 저장/조회 훅을 userId 로 바인딩(재생 실행은 tools.ts 가 sandbox 로 수행). 플래그 OFF 면 미노출.
         const procedural: ProceduralHooks | undefined = AGENT_TASK_LIMITS.PROCEDURAL_SKILLS_ENABLED
             ? {
@@ -83,30 +86,38 @@ export class TaskRuntime {
         const browserMetrics = AGENT_TASK_LIMITS.BROWSER_METRICS_ENABLED
             ? (stdout: string) => recordBrowserMetric(this.taskId, this.userId, stdout)
             : undefined;
-        this.defs = createTaskTools(this.sandbox, this.plan, delegate, spawn, procedural, browserMetrics);
+        this.defs = createTaskTools(this.executor, this.plan, delegate, spawn, procedural, browserMetrics);
         for (const d of this.defs) this.handlers.set(d.tool.name, d.handler);
     }
 
     /** 현재 실행 계획 스냅샷 (진행 가시성·영속용). */
     getPlanSnapshot(): PlanStep[] { return this.plan.snapshot(); }
 
-    get containerName(): string { return this.sandbox.containerName; }
-    get workspacePath(): string { return this.sandbox.hostWorkdir; }
+    /** 관측/영속(sandboxContainerId)용 실행기 라벨 — docker: 컨테이너명, 원격(D1): 디바이스 라벨. */
+    get containerName(): string { return this.executor.label; }
 
-    async create(): Promise<void> { await this.sandbox.create(); }
+    /** 호스트 workspace 절대경로 — 호스트측 git 연산(code-diff·clone·PR)이 의존.
+     *  원격 실행기(D1)는 호스트 workspace 가 없으므로 호출부가 사용 전 가드해야 한다. */
+    get workspacePath(): string {
+        const p = this.executor.localWorkdir;
+        if (p === null) throw new Error(`원격 실행기는 호스트 workspace 가 없습니다 (${this.taskId}) — localWorkdir 가드 필요`);
+        return p;
+    }
+
+    async create(): Promise<void> { await this.executor.create(); }
     /** removeWorkspace=false 면 산출물 다운로드를 위해 workspace 보존(컨테이너만 제거). */
-    async cleanup(removeWorkspace = true): Promise<void> { await this.sandbox.cleanup(removeWorkspace); }
+    async cleanup(removeWorkspace = true): Promise<void> { await this.executor.cleanup(removeWorkspace); }
     /** 산출물 회수용 — workspace 파일 목록(상대경로, 재귀). */
-    async listWorkspace(): Promise<string[]> { return this.sandbox.listWorkspaceFiles(); }
+    async listWorkspace(): Promise<string[]> { return this.executor.listWorkspaceFiles(); }
     /** 입력 첨부 주입 등 호스트 측 workspace 파일 쓰기 — 경로 가드(safeRealWorkspacePath)+쿼터 적용. */
-    async writeWorkspaceFile(relPath: string, content: string | Buffer): Promise<void> { return this.sandbox.writeFile(relPath, content); }
+    async writeWorkspaceFile(relPath: string, content: string | Buffer): Promise<void> { return this.executor.writeFile(relPath, content); }
 
     /** 호스트 파일을 workspace 로 복사 — 대용량 입력 첨부의 스트리밍 주입(Buffer 미적재). */
-    async importWorkspaceFile(relPath: string, srcAbsPath: string): Promise<void> { return this.sandbox.importFile(relPath, srcAbsPath); }
+    async importWorkspaceFile(relPath: string, srcAbsPath: string): Promise<void> { return this.executor.importFile(relPath, srcAbsPath); }
 
     /** 내부 검증용 원시 exec — 승인 게이트 우회(에이전트 도구 호출이 아닌 시스템 산출물 검증).
      *  컨테이너는 격리(network none·자원 캡)이고 문법/컴파일 검사는 코드를 실행하지 않아 안전. */
-    async execRaw(command: string): Promise<ExecResult> { return this.sandbox.exec(command); }
+    async execRaw(command: string): Promise<ExecResult> { return this.executor.exec(command); }
 
     /** task-scoped 도구를 LLM 형식으로. AgentTaskService 가 effectiveTools 에 합류. */
     getLLMTools(): ToolDefinition[] { return this.defs.map(toLLMTool); }

--- a/apps/api/src/services/task-sandbox/sandbox.ts
+++ b/apps/api/src/services/task-sandbox/sandbox.ts
@@ -18,7 +18,11 @@ import { spawn } from 'child_process';
 import { mkdir, rm, writeFile as fsWriteFile, readFile as fsReadFile, readdir, stat, realpath, copyFile as fsCopyFile } from 'fs/promises';
 import { resolve, sep, join, dirname, basename, relative } from 'path';
 import { getTaskSandboxConfig, type TaskSandboxConfig } from '../../config/task-sandbox';
+import type { TaskExecutor, ExecResult } from './executor';
 import { createLogger } from '../../utils/logger';
+
+// 기존 소비처(runtime/tools 등)가 './sandbox' 에서 ExecResult 를 import 하므로 재노출 유지.
+export type { ExecResult } from './executor';
 
 const logger = createLogger('TaskSandbox');
 
@@ -128,15 +132,6 @@ export async function safeRealWorkspacePath(hostWorkdir: string, userPath: strin
     }
 }
 
-export interface ExecResult {
-    stdout: string;
-    stderr: string;
-    exitCode: number;
-    truncated: boolean;
-    timedOut: boolean;
-    durationMs: number;
-}
-
 /** 자식 프로세스를 실행하고 출력 캡/timeout 을 적용 (docker CLI 호출 공용). */
 function runProcess(
     dockerPath: string,
@@ -192,8 +187,9 @@ function runProcess(
 /**
  * 단일 task 의 영속 샌드박스. create() → exec()/파일 I/O 반복 → cleanup().
  * 파일 I/O 는 bind-mount 된 호스트 workdir 에 직접 수행(빠르고 docker cp 불요).
+ * TaskExecutor 의 Docker 구현체 (D0 — 원격 실행기는 D1 에서 같은 계약으로 추가).
  */
-export class TaskSandbox {
+export class TaskSandbox implements TaskExecutor {
     readonly taskId: string;
     readonly containerName: string;
     readonly hostWorkdir: string;
@@ -259,6 +255,12 @@ export class TaskSandbox {
         const size = await dirSizeBytes(this.hostWorkdir, this.cfg.workspaceQuota + 1);
         return size > this.cfg.workspaceQuota;
     }
+
+    /** TaskExecutor.label — 관측/영속용 식별 라벨 = 컨테이너명. */
+    get label(): string { return this.containerName; }
+
+    /** TaskExecutor.localWorkdir — docker 는 bind-mount 라 호스트 workspace 가 항상 존재. */
+    get localWorkdir(): string { return this.hostWorkdir; }
 
     /** 브라우저 도구 활성 여부. */
     get isBrowserEnabled(): boolean { return this.cfg.browserEnabled; }

--- a/apps/api/src/services/task-sandbox/tools.ts
+++ b/apps/api/src/services/task-sandbox/tools.ts
@@ -14,7 +14,7 @@
  * @module services/task-sandbox/tools
  */
 import type { MCPToolDefinition, MCPToolResult } from '../../mcp/types';
-import type { TaskSandbox, ExecResult } from './sandbox';
+import type { TaskExecutor, ExecResult } from './executor';
 import { TaskPlan, type PlanStepStatus } from './planning';
 import {
     SPAWN_AGENTS_TOOL_NAME,
@@ -76,7 +76,7 @@ export interface ProceduralHooks {
 }
 
 export function createTaskTools(
-    sandbox: TaskSandbox,
+    sandbox: TaskExecutor,
     plan: TaskPlan = new TaskPlan(),
     delegate?: DelegateFn,
     spawn?: SpawnFn,


### PR DESCRIPTION
## 목적

Cowork형 로컬 실행(사용자 머신에서 도구 실행) 도입의 선행 공사입니다. Agent Task의 **두뇌(루프·판단·승인)와 손발(도구 실행·파일 I/O)을 인터페이스로 분리**해, D1(데스크톱 브리지 RemoteExecutor)이 한 지점으로 꽂히게 합니다. **동작 무변경 리팩터**입니다.

## 변경

```
신규  executor.ts   TaskExecutor 인터페이스 + ExecResult (계약 SoT)
수정  sandbox.ts    TaskSandbox implements TaskExecutor (+label·localWorkdir)
수정  runtime.ts    TaskExecutor 의존 + 생성자 executor 주입 파라미터
수정  tools.ts      타입 어노테이션만 (14개 도구 핸들러 코드 무변경)
```

### 설계 포인트

- **D1 불변식을 인터페이스에 명문화**: 고정 도구 표면만(임의 RPC 금지) · 비밀 비주입(Git/PR 토큰 비주입 원칙과 동일) · 경로 스코프 가드 필수
- **docker 누출 2개를 계약으로 흡수**:
  - `containerName` → `label` — 원격 실행기는 디바이스 라벨. `sandboxContainerId` 영속 경로가 이 getter를 탑니다
  - `hostWorkdir` → `localWorkdir: string | null` — 원격은 null. 호스트측 git 소비자(code-diff·git-ops)가 D1에서 가드해야 할 지점을 **타입으로 표시**
- `TaskRuntime.workspacePath` 는 null 시 명시 throw — 현행 docker 경로에선 도달 불가, D1 가드 지점 문서화

## 검증

- `tsc --noEmit` ✅ / eslint ✅ (경고 1건은 sandbox.ts 기존 max-lines)
- 로컬 jest: **판정 불가** — git stash 검증으로 변경 전에도 동일 실패 확인(로컬 babel 환경 문제). CI는 이 gitignored 테스트를 원래 skip
- **라이브 E2E (대체 게이트)** ✅ — 운영 반영 후 실제 Agent Task로 샌드박스 실경로 완주:
  컨테이너 생성 → bash `echo D0-EXECUTOR-OK` → 파일 읽기 → 최종 답변에 문자열 반영 → 정리(workspace 보존). `sandbox_container_id` 에 새 `label` 경유 값 정확히 영속

## 참고

Cowork 트랙 다음 단계: D1 = WS 브리지 프로토콜 + 디바이스 페어링 + Electron 로컬 실행기 MVP (별도 계획 예정). D0ⓐ(Apple Developer 서명)는 사용자 액션 대기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)