### PR TITLE
feat(agent-task): 로컬 브리지 실행기 — 사용자 머신에서 도구 실행 (Cowork D1a)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -790,6 +790,12 @@ AGENT_TASK_TIMEOUT_MS=600000
 # AGENT_TASK_VERIFY_DELIVERABLE_MAX_RETRIES=1
 
 # Agent Task — 동시성 큐 (전역·유저별 동시 실행 상한, 초과 시 queued 대기). 기본 OFF.
+# ── Local Bridge (Cowork D1a) — 데스크톱 로컬 실행기 ──
+# 에이전트 작업을 서버 샌드박스 대신 사용자 머신(데스크톱 앱 브리지)에서 실행. 기본 OFF.
+# LOCAL_EXECUTOR_ENABLED=false
+# LOCAL_BRIDGE_REQUEST_TIMEOUT_MS=180000        # 도구 1회 왕복 대기 상한
+# LOCAL_BRIDGE_MAX_WRITE_BYTES=8388608          # write/첨부 전송 상한(8MB)
+# LOCAL_BRIDGE_OUTPUT_CAP=65536                 # exec/read 결과 수신 캡(chars)
 # AGENT_TASK_QUEUE_ENABLED=true
 # AGENT_TASK_QUEUE_GLOBAL_MAX=4
 # AGENT_TASK_QUEUE_USER_MAX=2

--- a/apps/api/src/config/local-bridge.ts
+++ b/apps/api/src/config/local-bridge.ts
@@ -1,0 +1,22 @@
+/**
+ * Local Bridge 설정 — Cowork 트랙 D1a (No-Hardcoding L1/L2).
+ *
+ * 데스크톱(또는 임의 브리지 클라이언트)이 채팅 WS 로 접속해 등록한 "로컬 실행기"로
+ * Agent Task 도구 호출을 위임하는 기능의 게이트·한도.
+ *
+ * @module config/local-bridge
+ */
+
+export const LOCAL_BRIDGE = {
+    /** 기능 게이트 — 기본 OFF. executor='local' 작업 생성/실행 허용 여부. */
+    ENABLED: process.env.LOCAL_EXECUTOR_ENABLED === 'true',
+
+    /** 브리지 요청(도구 1회) 응답 대기 상한(ms). bash 장기 명령을 고려해 exec 타임아웃보다 여유. */
+    REQUEST_TIMEOUT_MS: parseInt(process.env.LOCAL_BRIDGE_REQUEST_TIMEOUT_MS || '180000', 10),
+
+    /** write/importFile 1회 전송 상한(bytes) — WS 페이로드 폭주 방지. */
+    MAX_WRITE_BYTES: parseInt(process.env.LOCAL_BRIDGE_MAX_WRITE_BYTES || String(8 * 1024 * 1024), 10),
+
+    /** read/exec 결과 수신 캡(chars) — 모델 컨텍스트/스텝 저장 보호(샌드박스 outputCap 관행과 동일 축). */
+    OUTPUT_CAP: parseInt(process.env.LOCAL_BRIDGE_OUTPUT_CAP || '65536', 10),
+} as const;

--- a/apps/api/src/data/models/unified-database.ts
+++ b/apps/api/src/data/models/unified-database.ts
@@ -345,8 +345,7 @@ export class UnifiedDatabase {
         model?: string;
         inputFiles?: unknown;
         inputImages?: unknown;
-        gitRepoUrl?: string; gitBranch?: string;
-        executor?: 'sandbox' | 'local';
+        gitRepoUrl?: string; gitBranch?: string; executor?: 'sandbox' | 'local';
     }): Promise<void> {
         return this.agentTaskRepository.createAgentTask(params);
     }

--- a/apps/api/src/data/models/unified-database.ts
+++ b/apps/api/src/data/models/unified-database.ts
@@ -346,6 +346,7 @@ export class UnifiedDatabase {
         inputFiles?: unknown;
         inputImages?: unknown;
         gitRepoUrl?: string; gitBranch?: string;
+        executor?: 'sandbox' | 'local';
     }): Promise<void> {
         return this.agentTaskRepository.createAgentTask(params);
     }

--- a/apps/api/src/data/models/unified-database.types.ts
+++ b/apps/api/src/data/models/unified-database.types.ts
@@ -188,6 +188,8 @@ export interface AgentTask {
     git_pr_url?: string;
     /** Phase 2c Git: push 된 작업 브랜치명(078) */
     git_pushed_branch?: string;
+    /** Cowork D1a: 실행 백엔드(081) — 'sandbox'(기본) | 'local'(로컬 브리지) */
+    executor?: 'sandbox' | 'local';
     /** 누적 LLM 토큰(prompt+completion) — terminal 전이 시 기록(066), resume 은 통산 */
     total_tokens?: number;
     created_at: string;

--- a/apps/api/src/data/repositories/agent-task-repository.ts
+++ b/apps/api/src/data/repositories/agent-task-repository.ts
@@ -28,6 +28,8 @@ export class AgentTaskRepository extends BaseRepository {
         gitRepoUrl?: string;
         /** Phase 2 Git: clone 할 base 브랜치 */
         gitBranch?: string;
+        /** Cowork D1a: 실행 백엔드 — 'sandbox'(기본) | 'local'(로컬 브리지) */
+        executor?: 'sandbox' | 'local';
     }): Promise<void> {
         // input_files/input_images/git_* 는 값이 있을 때만 컬럼에 포함 — 056/057/077 마이그레이션
         // 미적용 배포에서도 해당 값 없는 기존 생성 경로가 깨지지 않게 한다(2단계 배포 안전).
@@ -48,6 +50,10 @@ export class AgentTaskRepository extends BaseRepository {
         if (params.gitBranch !== undefined) {
             cols.push('git_branch');
             values.push(params.gitBranch);
+        }
+        if (params.executor !== undefined) {
+            cols.push('executor');
+            values.push(params.executor);
         }
         await this.query(
             `INSERT INTO agent_tasks (${cols.join(', ')}) VALUES (${values.map((_, i) => `$${i + 1}`).join(', ')})`,

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -25,6 +25,8 @@ import { requireAuth } from '../auth';
 import { assertResourceOwnerOrAdmin } from '../auth/ownership';
 import { validateWithSecurity } from '../middlewares/validation';
 import { getUnifiedDatabase } from '../data/models/unified-database';
+import { LOCAL_BRIDGE } from '../config/local-bridge';
+import { getLocalBridgeRegistry } from '../services/local-bridge/registry';
 import { v4 as uuidv4 } from 'uuid';
 import { AgentTaskService, type AgentTaskInputFile } from '../services/AgentTaskService';
 import type { ChatMessage } from '../llm/types';
@@ -135,11 +137,27 @@ router.post('/', (req: Request, res: Response, next) => {
     } else {
         input = req.body as CreateAgentTaskInput;
     }
-    const { goal, maxTurns, files, images, repoUrl, branch } = input;
+    const { goal, maxTurns, files, images, repoUrl, branch, executor } = input;
 
     const taskId = uuidv4();
     const db = getUnifiedDatabase();
     const userId = String(req.user!.id);
+
+    // Cowork D1a: local 실행은 기능 게이트 + 디바이스 연결 + git repo 미지정(호스트 clone 불가)일 때만.
+    if (executor === 'local') {
+        if (!LOCAL_BRIDGE.ENABLED) {
+            res.status(400).json(badRequest('로컬 실행 기능이 비활성화되어 있습니다 (LOCAL_EXECUTOR_ENABLED)'));
+            return;
+        }
+        if (repoUrl) {
+            res.status(400).json(badRequest('로컬 실행 작업은 git repo 지정을 지원하지 않습니다 — 로컬 폴더가 작업 대상입니다'));
+            return;
+        }
+        if (!getLocalBridgeRegistry().getDevice(userId)) {
+            res.status(400).json(badRequest('연결된 로컬 디바이스가 없습니다 — 데스크톱 앱에서 작업 폴더를 먼저 연결하세요'));
+            return;
+        }
+    }
 
     // 입력 첨부(JSON 경로): 바이너리 문서(base64 data)는 지금 텍스트로 추출해 저장한다 —
     // 실행은 detached 백그라운드라 여기서 추출해야 실패를 생성 응답에서 인지 가능하다.
@@ -207,6 +225,7 @@ router.post('/', (req: Request, res: Response, next) => {
         inputImages: Array.isArray(images) && images.length > 0 ? images : undefined,
         gitRepoUrl: repoUrl,
         gitBranch: branch,
+        executor,
     });
 
     const task = await db.getAgentTask(taskId);
@@ -312,6 +331,7 @@ router.post('/:taskId/execute', asyncHandler(async (req: Request, res: Response)
             images: Array.isArray(task.input_images) ? task.input_images as string[] : undefined,
             gitRepoUrl: task.git_repo_url ?? undefined,
             gitBranch: task.git_branch ?? undefined,
+            executor: (task.executor === 'local' ? 'local' : undefined),
         }),
     });
 

--- a/apps/api/src/schemas/agent-task.schema.ts
+++ b/apps/api/src/schemas/agent-task.schema.ts
@@ -37,6 +37,8 @@ const taskInputFileSchema = z.object({
 export const createAgentTaskSchema = z.object({
     goal: secureTextSchema({ minLength: 1, maxLength: 2000, fieldName: 'goal', detectMaliciousPatterns: false }),
     maxTurns: z.number().int().min(1).max(AGENT_TASK_LIMITS.MAX_TURNS_CEILING).optional(),
+    // Cowork D1a: 실행 백엔드 — 'local' 은 LOCAL_EXECUTOR_ENABLED + 디바이스 연결 필요(라우트가 검증).
+    executor: z.enum(['sandbox', 'local']).optional(),
     files: z.array(taskInputFileSchema).max(FILE_ATTACH_LIMITS.MAX_FILES).optional(),
     images: z.array(
         z.string().startsWith('data:image/').max(FILE_ATTACH_LIMITS.MAX_IMAGE_DATAURL_CHARS)

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -30,7 +30,6 @@ import { getSkillManager } from '../agents/skill-manager';
 import { buildDelegateFn } from './agent-task/delegate';
 import { buildTaskSpawnFn } from './agent-spawn/spawn-agents';
 import { mergeToolsWithSkills, type ActiveSkillBinding } from './chat-service/tool-merger';
-import { getTaskSandboxConfig } from '../config/task-sandbox';
 import { TaskRuntime } from './task-sandbox/runtime';
 import { TASK_TERMINATE_SENTINEL } from './task-sandbox/tools';
 import { requiresApproval, getApprovalRegistry } from './task-sandbox/approval-gate';
@@ -42,8 +41,7 @@ import { persistArtifactSteps, runTool, isSearchTool } from './agent-task/task-s
 import { initWorkspaceBaseline, maybePersistCodeDiff, captureDiffOnCleanup } from './agent-task/code-diff';
 import { getSteeringRegistry, applyPendingSteering } from './agent-task/steering';
 import { setupTaskRepo, maybePushAndOpenPR } from './agent-task/git-ops';
-import { RemoteExecutor } from './local-bridge/remote-executor';
-import { LOCAL_BRIDGE } from '../config/local-bridge';
+import { resolveExecutorPlan } from './agent-task/executor-select';
 import { recoverTextToolCalls } from './agent-task/text-tool-calls';
 import { assembleAgentTools } from './agent-task/tool-assembly';
 import { verifyCodeArtifacts } from './agent-task/deliverable-verify';
@@ -204,14 +202,9 @@ export class AgentTaskService {
             // 영속 샌드박스(Manus화, 플래그 ON 시만). 생성 실패는 샌드박스 없이 진행(graceful degrade).
             // 설정은 한 번만 읽어 스냅샷 공유. 승인 3모드는 input.approvalPolicy 로 이 실행에만 override
             // (비영속, resume은 전역 폴백; requiresApproval 호출부 2곳이 이 cfg 를 읽어 단일 지점 주입).
-            // Cowork D1a: 로컬 실행기 — 격리(docker) 없이 사용자 머신에서 실행되므로 승인 'all' 강제
-            // (input.approvalPolicy 보다 우선). 게이트 OFF 면 sandbox 로 폴백(생성 시점에 이미 검증되나 방어).
-            const isLocalExecutor = input.executor === 'local' && LOCAL_BRIDGE.ENABLED;
-            const sandboxCfg = isLocalExecutor
-                ? { ...getTaskSandboxConfig(), approvalPolicy: 'all' as const }
-                : input.approvalPolicy
-                    ? { ...getTaskSandboxConfig(), approvalPolicy: input.approvalPolicy } : getTaskSandboxConfig();
-            if (sandboxCfg.enabled || isLocalExecutor) {
+            // Cowork D1a: 실행 백엔드(docker/local)·승인 정책 결정 — 상세는 agent-task/executor-select.
+            const { sandboxCfg, runtimeEnabled, remoteExecutor } = resolveExecutorPlan(input, taskId, userId);
+            if (runtimeEnabled) {
                 try {
                     // G4 위임 — 상세는 agent-task/delegate (SUBAGENT_ENABLED 시 depth=1 tool-loop 승격,
                     // 토큰·승인대기는 부모 누적에 합산되어 runaway 가드·pause-aware 타임아웃 공유).
@@ -228,8 +221,6 @@ export class AgentTaskService {
                             onPausedMs: (ms) => { pausedMs += ms; },
                         })
                         : undefined;
-                    // D1a: local 이면 RemoteExecutor 주입(도구 호출이 브리지로 위임), 아니면 기본(docker).
-                    const remoteExecutor = isLocalExecutor ? new RemoteExecutor(taskId, userId) : undefined;
                     taskRuntime = new TaskRuntime(taskId, userId, sandboxCfg, delegateFn, spawnFn, remoteExecutor);
                     await taskRuntime.create();
                     await db.updateAgentTask(taskId, {

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -42,6 +42,8 @@ import { persistArtifactSteps, runTool, isSearchTool } from './agent-task/task-s
 import { initWorkspaceBaseline, maybePersistCodeDiff, captureDiffOnCleanup } from './agent-task/code-diff';
 import { getSteeringRegistry, applyPendingSteering } from './agent-task/steering';
 import { setupTaskRepo, maybePushAndOpenPR } from './agent-task/git-ops';
+import { RemoteExecutor } from './local-bridge/remote-executor';
+import { LOCAL_BRIDGE } from '../config/local-bridge';
 import { recoverTextToolCalls } from './agent-task/text-tool-calls';
 import { assembleAgentTools } from './agent-task/tool-assembly';
 import { verifyCodeArtifacts } from './agent-task/deliverable-verify';
@@ -202,9 +204,14 @@ export class AgentTaskService {
             // 영속 샌드박스(Manus화, 플래그 ON 시만). 생성 실패는 샌드박스 없이 진행(graceful degrade).
             // 설정은 한 번만 읽어 스냅샷 공유. 승인 3모드는 input.approvalPolicy 로 이 실행에만 override
             // (비영속, resume은 전역 폴백; requiresApproval 호출부 2곳이 이 cfg 를 읽어 단일 지점 주입).
-            const sandboxCfg = input.approvalPolicy
-                ? { ...getTaskSandboxConfig(), approvalPolicy: input.approvalPolicy } : getTaskSandboxConfig();
-            if (sandboxCfg.enabled) {
+            // Cowork D1a: 로컬 실행기 — 격리(docker) 없이 사용자 머신에서 실행되므로 승인 'all' 강제
+            // (input.approvalPolicy 보다 우선). 게이트 OFF 면 sandbox 로 폴백(생성 시점에 이미 검증되나 방어).
+            const isLocalExecutor = input.executor === 'local' && LOCAL_BRIDGE.ENABLED;
+            const sandboxCfg = isLocalExecutor
+                ? { ...getTaskSandboxConfig(), approvalPolicy: 'all' as const }
+                : input.approvalPolicy
+                    ? { ...getTaskSandboxConfig(), approvalPolicy: input.approvalPolicy } : getTaskSandboxConfig();
+            if (sandboxCfg.enabled || isLocalExecutor) {
                 try {
                     // G4 위임 — 상세는 agent-task/delegate (SUBAGENT_ENABLED 시 depth=1 tool-loop 승격,
                     // 토큰·승인대기는 부모 누적에 합산되어 runaway 가드·pause-aware 타임아웃 공유).
@@ -221,11 +228,13 @@ export class AgentTaskService {
                             onPausedMs: (ms) => { pausedMs += ms; },
                         })
                         : undefined;
-                    taskRuntime = new TaskRuntime(taskId, userId, sandboxCfg, delegateFn, spawnFn);
+                    // D1a: local 이면 RemoteExecutor 주입(도구 호출이 브리지로 위임), 아니면 기본(docker).
+                    const remoteExecutor = isLocalExecutor ? new RemoteExecutor(taskId, userId) : undefined;
+                    taskRuntime = new TaskRuntime(taskId, userId, sandboxCfg, delegateFn, spawnFn, remoteExecutor);
                     await taskRuntime.create();
                     await db.updateAgentTask(taskId, {
                         sandboxContainerId: taskRuntime.containerName,
-                        workspacePath: taskRuntime.workspacePath,
+                        workspacePath: taskRuntime.localWorkdir ?? undefined,
                     });
                     // 새 대화(resume 아님)면 system 에 작업환경 안내 주입. 이어서 Phase 2 Git: repo 지정 시 호스트 clone(토큰 컨테이너 미주입)+안내.
                     if (!input.resume && conversation[0]?.role === 'system') {

--- a/apps/api/src/services/agent-task/code-diff.ts
+++ b/apps/api/src/services/agent-task/code-diff.ts
@@ -29,6 +29,8 @@ const GIT = 'git -c safe.directory=/workspace -c user.email=agent@openmake.local
  * 것을 막는다.) 입력 첨부(uploads/) 기록 후에 호출해 첨부가 baseline 에 포함되게 한다.
  */
 export async function initWorkspaceBaseline(runtime: TaskRuntime): Promise<void> {
+    // 로컬 실행기(D1a): 사용자 폴더에 git init/commit 을 만들면 안 된다 — diff 캡처 자체를 생략.
+    if (runtime.localWorkdir === null) return;
     try {
         const r = await runtime.execRaw(
             `[ -d .git ] || { ${GIT} init -q && ${GIT} add -A && ${GIT} commit -q --allow-empty -m baseline; }`,
@@ -47,6 +49,8 @@ export async function initWorkspaceBaseline(runtime: TaskRuntime): Promise<void>
  * outputCap 이 적용되며, 잘린 경우 말미에 표식을 덧붙인다.
  */
 export async function captureWorkspaceDiff(runtime: TaskRuntime): Promise<string | null> {
+    // 로컬 실행기(D1a): baseline 미생성(위 가드) — 사용자 폴더에 git 명령을 대지 않는다.
+    if (runtime.localWorkdir === null) return null;
     try {
         const r = await runtime.execRaw(
             `[ -d .git ] && ${GIT} add -A && ${GIT} diff --cached --no-color`,

--- a/apps/api/src/services/agent-task/executor-select.ts
+++ b/apps/api/src/services/agent-task/executor-select.ts
@@ -1,0 +1,40 @@
+/**
+ * 실행 백엔드/승인 정책 결정 (Cowork D1a) — AgentTaskService 에서 분리(파일 크기 가드).
+ *
+ * - executor='local' + 게이트 ON → RemoteExecutor(로컬 브리지) + 승인 'all' 강제
+ *   (docker 격리가 없으므로 전건 승인. input.approvalPolicy 보다 우선.)
+ * - 그 외 → 현행 docker 샌드박스, input.approvalPolicy 는 이 실행에 한해 override.
+ * - 게이트 OFF 면 sandbox 로 폴백(생성 시점에 이미 검증되나 방어).
+ *
+ * @module services/agent-task/executor-select
+ */
+import { getTaskSandboxConfig, type TaskSandboxConfig } from '../../config/task-sandbox';
+import { LOCAL_BRIDGE } from '../../config/local-bridge';
+import { RemoteExecutor } from '../local-bridge/remote-executor';
+import type { AgentTaskRunInput } from './types';
+
+export interface ExecutorPlan {
+    sandboxCfg: TaskSandboxConfig;
+    /** TaskRuntime 조립 여부 — docker 샌드박스 ON 이거나 로컬 실행기일 때. */
+    runtimeEnabled: boolean;
+    /** local 이면 TaskRuntime 에 주입할 실행기, 아니면 undefined(기본 docker). */
+    remoteExecutor?: RemoteExecutor;
+}
+
+export function resolveExecutorPlan(
+    input: Pick<AgentTaskRunInput, 'executor' | 'approvalPolicy'>,
+    taskId: string,
+    userId: string,
+): ExecutorPlan {
+    const isLocal = input.executor === 'local' && LOCAL_BRIDGE.ENABLED;
+    const sandboxCfg = isLocal
+        ? { ...getTaskSandboxConfig(), approvalPolicy: 'all' as const }
+        : input.approvalPolicy
+            ? { ...getTaskSandboxConfig(), approvalPolicy: input.approvalPolicy }
+            : getTaskSandboxConfig();
+    return {
+        sandboxCfg,
+        runtimeEnabled: sandboxCfg.enabled || isLocal,
+        remoteExecutor: isLocal ? new RemoteExecutor(taskId, userId) : undefined,
+    };
+}

--- a/apps/api/src/services/agent-task/types.ts
+++ b/apps/api/src/services/agent-task/types.ts
@@ -66,6 +66,9 @@ export interface AgentTaskRunInput {
     gitRepoUrl?: string;
     /** Phase 2 Git: clone 할 브랜치(base). 미지정 시 repo 기본 브랜치. */
     gitBranch?: string;
+    /** Cowork D1a: 실행 백엔드 — 'local' 이면 로컬 브리지(RemoteExecutor)로 도구를 위임.
+     *  LOCAL_EXECUTOR_ENABLED + 디바이스 연결 필요, 승인 정책은 'all' 강제. 미지정=sandbox. */
+    executor?: 'sandbox' | 'local';
     /** resume(이어하기): 기존 end-of-turn checkpoint 에서 복원 */
     resume?: {
         conversation: ChatMessage[];

--- a/apps/api/src/services/local-bridge/registry.ts
+++ b/apps/api/src/services/local-bridge/registry.ts
@@ -1,0 +1,148 @@
+/**
+ * ============================================================
+ * Local Bridge Registry — 디바이스 연결 레지스트리 (Cowork D1a)
+ * ============================================================
+ *
+ * 채팅 WS 로 접속한 브리지 클라이언트(데스크톱 앱)를 userId 별로 1대 등록하고,
+ * RemoteExecutor 의 도구 호출을 reqId 상관관계로 왕복시킨다.
+ *
+ * in-memory 싱글턴 (steering 레지스트리 관행) — 멀티프로세스 확장 시 Redis 이전.
+ *
+ * 보안:
+ *   - 등록은 인증된 WS(_authenticatedUserId)에서만 (handler.ts 가 보장)
+ *   - 서버→디바이스로 나가는 메시지는 bridge_exec 고정 형태만 — 임의 RPC 금지
+ *   - 비밀(토큰 등)은 프로토콜에 싣지 않는다
+ *
+ * @module services/local-bridge/registry
+ */
+import { randomUUID } from 'crypto';
+import type { WebSocket } from 'ws';
+import { LOCAL_BRIDGE } from '../../config/local-bridge';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('LocalBridge');
+
+/** 서버→디바이스 도구 요청 종류 — 이 외의 kind 는 존재하지 않는다(임의 RPC 금지). */
+export type BridgeKind = 'exec' | 'read' | 'write' | 'list' | 'listAll' | 'delete' | 'task_end';
+
+export interface BridgeRequestPayload {
+    kind: BridgeKind;
+    command?: string;
+    path?: string;
+    /** write 전용 — base64 본문 (바이너리 안전). */
+    contentB64?: string;
+}
+
+/** 디바이스가 돌려주는 결과 (bridge_result). */
+export interface BridgeResult {
+    ok: boolean;
+    stdout?: string;
+    stderr?: string;
+    exitCode?: number;
+    /** read 결과 (utf8) */
+    content?: string;
+    /** list/listAll 결과 */
+    entries?: string[];
+    error?: string;
+    durationMs?: number;
+}
+
+export interface DeviceSession {
+    userId: string;
+    deviceId: string;
+    /** 관측/영속용 라벨 (예: "MacBook-Pro · my-project") */
+    label: string;
+    folderName: string;
+    ws: WebSocket;
+    connectedAt: number;
+}
+
+interface Pending {
+    resolve: (r: BridgeResult) => void;
+    timer: NodeJS.Timeout;
+    userId: string;
+}
+
+class LocalBridgeRegistry {
+    /** userId → 세션 (유저당 1대 — 새 등록이 기존을 대체). */
+    private readonly devices = new Map<string, DeviceSession>();
+    private readonly pending = new Map<string, Pending>();
+
+    register(session: DeviceSession): void {
+        const prev = this.devices.get(session.userId);
+        if (prev && prev.ws !== session.ws) {
+            logger.info(`[Bridge] 기존 디바이스 대체: user=${session.userId} ${prev.label} → ${session.label}`);
+            this.rejectPendingFor(session.userId, '다른 디바이스가 연결되어 세션이 대체되었습니다');
+        }
+        this.devices.set(session.userId, session);
+        logger.info(`[Bridge] 디바이스 등록: user=${session.userId} device=${session.deviceId} label="${session.label}" folder="${session.folderName}"`);
+    }
+
+    /** WS 종료 시 호출 — 이 소켓이 현재 등록 세션이면 해제 + pending 전부 reject. */
+    unregister(ws: WebSocket): void {
+        for (const [userId, s] of this.devices) {
+            if (s.ws === ws) {
+                this.devices.delete(userId);
+                this.rejectPendingFor(userId, '디바이스 연결이 끊어졌습니다');
+                logger.info(`[Bridge] 디바이스 해제: user=${userId} label="${s.label}"`);
+                return;
+            }
+        }
+    }
+
+    getDevice(userId: string): DeviceSession | null {
+        return this.devices.get(userId) ?? null;
+    }
+
+    /** 도구 1회 왕복. 타임아웃/연결단절 시 ok=false 결과로 해소(throw 하지 않음 — 도구 오류로 전달). */
+    request(userId: string, payload: BridgeRequestPayload, timeoutMs = LOCAL_BRIDGE.REQUEST_TIMEOUT_MS): Promise<BridgeResult> {
+        const dev = this.devices.get(userId);
+        if (!dev || dev.ws.readyState !== dev.ws.OPEN) {
+            return Promise.resolve({ ok: false, error: '연결된 로컬 디바이스가 없습니다 — 데스크톱 앱에서 폴더를 연결하세요.' });
+        }
+        const reqId = randomUUID();
+        return new Promise<BridgeResult>((resolve) => {
+            const timer = setTimeout(() => {
+                this.pending.delete(reqId);
+                resolve({ ok: false, error: `로컬 실행 응답 시간 초과 (${Math.round(timeoutMs / 1000)}s)` });
+            }, timeoutMs);
+            this.pending.set(reqId, { resolve, timer, userId });
+            try {
+                dev.ws.send(JSON.stringify({ type: 'bridge_exec', reqId, ...payload }));
+            } catch (e) {
+                clearTimeout(timer);
+                this.pending.delete(reqId);
+                resolve({ ok: false, error: `브리지 전송 실패: ${e instanceof Error ? e.message : String(e)}` });
+            }
+        });
+    }
+
+    /** bridge_result 수신 — reqId 상관관계 해소. 소유 userId 불일치는 무시(교차 주입 차단). */
+    handleResult(userId: string, reqId: string, result: BridgeResult): void {
+        const p = this.pending.get(reqId);
+        if (!p) return; // 이미 타임아웃/해소됨
+        if (p.userId !== userId) {
+            logger.warn(`[Bridge] reqId 소유 불일치 무시: req=${reqId} owner=${p.userId} sender=${userId}`);
+            return;
+        }
+        clearTimeout(p.timer);
+        this.pending.delete(reqId);
+        p.resolve(result);
+    }
+
+    private rejectPendingFor(userId: string, reason: string): void {
+        for (const [reqId, p] of this.pending) {
+            if (p.userId === userId) {
+                clearTimeout(p.timer);
+                this.pending.delete(reqId);
+                p.resolve({ ok: false, error: reason });
+            }
+        }
+    }
+}
+
+let instance: LocalBridgeRegistry | null = null;
+export function getLocalBridgeRegistry(): LocalBridgeRegistry {
+    if (!instance) instance = new LocalBridgeRegistry();
+    return instance;
+}

--- a/apps/api/src/services/local-bridge/remote-executor.ts
+++ b/apps/api/src/services/local-bridge/remote-executor.ts
@@ -1,0 +1,114 @@
+/**
+ * ============================================================
+ * Remote Executor — 로컬 브리지 경유 TaskExecutor 구현 (Cowork D1a)
+ * ============================================================
+ *
+ * Agent Task 의 도구 호출을 연결된 디바이스(사용자 머신)로 위임한다.
+ * 경로 스코프 강제는 디바이스측이 1차(realpath), 서버는 요청 형태만 고정(임의 RPC 금지).
+ *
+ * 샌드박스와의 차이:
+ *   - localWorkdir=null → 호스트측 git 연산(diff/clone/PR)·파일 다운로드 미지원(가드로 skip)
+ *   - runBrowser 미지원(D1) · cleanup 은 task_end 통지만 — **사용자 폴더를 삭제하지 않는다**
+ *
+ * @module services/local-bridge/remote-executor
+ */
+import type { TaskExecutor, ExecResult } from '../task-sandbox/executor';
+import { getLocalBridgeRegistry, type BridgeResult, type BridgeRequestPayload } from './registry';
+import { LOCAL_BRIDGE } from '../../config/local-bridge';
+import { readFile as fsReadFile, stat } from 'fs/promises';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('RemoteExecutor');
+
+function toExecResult(r: BridgeResult): ExecResult {
+    return {
+        stdout: (r.stdout ?? '').slice(0, LOCAL_BRIDGE.OUTPUT_CAP),
+        stderr: (r.ok ? (r.stderr ?? '') : (r.error ?? r.stderr ?? '로컬 실행 실패')).slice(0, LOCAL_BRIDGE.OUTPUT_CAP),
+        exitCode: r.ok ? (r.exitCode ?? 0) : (r.exitCode ?? -1),
+        truncated: (r.stdout?.length ?? 0) > LOCAL_BRIDGE.OUTPUT_CAP,
+        timedOut: false,
+        durationMs: r.durationMs ?? 0,
+    };
+}
+
+export class RemoteExecutor implements TaskExecutor {
+    readonly taskId: string;
+    readonly localWorkdir = null;
+    readonly isBrowserEnabled = false;
+    readonly browserStatePath = null;
+    private readonly userId: string;
+    private deviceLabel = 'local-device';
+
+    constructor(taskId: string, userId: string) {
+        this.taskId = taskId;
+        this.userId = userId;
+    }
+
+    get label(): string { return `local:${this.deviceLabel}`; }
+
+    /** 실행 준비 = 디바이스 연결 확인(도구 왕복 없음). 미연결이면 throw → 호출부 graceful degrade. */
+    async create(): Promise<void> {
+        const dev = getLocalBridgeRegistry().getDevice(this.userId);
+        if (!dev) throw new Error('연결된 로컬 디바이스가 없습니다 — 데스크톱 앱에서 작업 폴더를 먼저 연결하세요.');
+        this.deviceLabel = `${dev.label}`;
+        logger.info(`[${this.taskId}] 로컬 실행기 준비 (device=${dev.deviceId}, folder="${dev.folderName}")`);
+    }
+
+    private req(payload: BridgeRequestPayload): Promise<BridgeResult> {
+        return getLocalBridgeRegistry().request(this.userId, payload);
+    }
+
+    async exec(command: string): Promise<ExecResult> {
+        return toExecResult(await this.req({ kind: 'exec', command }));
+    }
+
+    async runBrowser(): Promise<ExecResult> {
+        return { stdout: '', stderr: '로컬 실행 작업에서는 browser 도구를 지원하지 않습니다(D1).', exitCode: -1, truncated: false, timedOut: false, durationMs: 0 };
+    }
+
+    async writeFile(relPath: string, content: string | Buffer): Promise<void> {
+        const buf = Buffer.isBuffer(content) ? content : Buffer.from(content, 'utf8');
+        if (buf.byteLength > LOCAL_BRIDGE.MAX_WRITE_BYTES) {
+            throw new Error(`파일이 너무 큽니다 (${buf.byteLength}b > ${LOCAL_BRIDGE.MAX_WRITE_BYTES}b)`);
+        }
+        const r = await this.req({ kind: 'write', path: relPath, contentB64: buf.toString('base64') });
+        if (!r.ok) throw new Error(r.error ?? '로컬 파일 쓰기 실패');
+    }
+
+    /** 호스트 파일(입력 첨부 스풀)을 읽어 브리지로 전송 — 캡 초과는 거부. */
+    async importFile(relPath: string, srcAbsPath: string): Promise<void> {
+        const st = await stat(srcAbsPath);
+        if (st.size > LOCAL_BRIDGE.MAX_WRITE_BYTES) {
+            throw new Error(`첨부가 로컬 전송 상한을 초과합니다 (${st.size}b > ${LOCAL_BRIDGE.MAX_WRITE_BYTES}b)`);
+        }
+        await this.writeFile(relPath, await fsReadFile(srcAbsPath));
+    }
+
+    async readFile(relPath: string): Promise<string> {
+        const r = await this.req({ kind: 'read', path: relPath });
+        if (!r.ok) throw new Error(r.error ?? '로컬 파일 읽기 실패');
+        return (r.content ?? '').slice(0, LOCAL_BRIDGE.OUTPUT_CAP);
+    }
+
+    async listDir(relPath = '.'): Promise<string[]> {
+        const r = await this.req({ kind: 'list', path: relPath });
+        if (!r.ok) throw new Error(r.error ?? '로컬 디렉토리 조회 실패');
+        return r.entries ?? [];
+    }
+
+    async listWorkspaceFiles(): Promise<string[]> {
+        const r = await this.req({ kind: 'listAll' });
+        return r.ok ? (r.entries ?? []) : [];
+    }
+
+    async deleteFile(relPath: string): Promise<void> {
+        const r = await this.req({ kind: 'delete', path: relPath });
+        if (!r.ok) throw new Error(r.error ?? '로컬 파일 삭제 실패');
+    }
+
+    /** 종료 통지만 — 사용자 폴더는 절대 삭제하지 않는다(removeWorkspace 무시). */
+    async cleanup(): Promise<void> {
+        await this.req({ kind: 'task_end' }).catch(() => { /* best-effort */ });
+        logger.info(`[${this.taskId}] 로컬 실행기 세션 종료 통지`);
+    }
+}

--- a/apps/api/src/services/task-sandbox/runtime.ts
+++ b/apps/api/src/services/task-sandbox/runtime.ts
@@ -96,6 +96,9 @@ export class TaskRuntime {
     /** 관측/영속(sandboxContainerId)용 실행기 라벨 — docker: 컨테이너명, 원격(D1): 디바이스 라벨. */
     get containerName(): string { return this.executor.label; }
 
+    /** 호스트 workspace 경로 or null(원격 실행기) — 호스트측 소비자(diff·git·영속)의 가드 기준. */
+    get localWorkdir(): string | null { return this.executor.localWorkdir; }
+
     /** 호스트 workspace 절대경로 — 호스트측 git 연산(code-diff·clone·PR)이 의존.
      *  원격 실행기(D1)는 호스트 workspace 가 없으므로 호출부가 사용 전 가드해야 한다. */
     get workspacePath(): string {

--- a/apps/api/src/sockets/handler.ts
+++ b/apps/api/src/sockets/handler.ts
@@ -47,7 +47,7 @@ import { getBuildId } from '../config/build-id';
 import { handleChatMessage } from './ws-chat-handler';
 import { handleRequestAgents } from './ws-agents-handler';
 import { getLocalBridgeRegistry } from '../services/local-bridge/registry';
-import { LOCAL_BRIDGE } from '../config/local-bridge';
+import { handleBridgeMessage } from './ws-bridge-handler';
 import { withSpan } from '../observability/otel';
 import { getAnalyticsSystem } from '../monitoring/analytics';
 import { getEventBus, AGENT_TASK_PROGRESS, type AgentTaskProgressEvent } from '../utils/event-bus';
@@ -304,9 +304,9 @@ export class WebSocketHandler {
         const typedMsg = msg as WSMessage;
 
         // Local Bridge (Cowork D1a): 데스크톱 실행기 등록/결과 — 인증된 연결 전용.
-        // 채팅 파이프라인과 무관한 얇은 위임이라 validTypes/span 밖에서 조기 처리.
+        // 채팅 파이프라인과 무관한 얇은 위임이라 validTypes/span 밖에서 조기 처리(ws-bridge-handler).
         if (typedMsg.type === 'bridge_hello' || typedMsg.type === 'bridge_result') {
-            await this.handleBridgeMessage(ws, typedMsg);
+            await handleBridgeMessage(ws, typedMsg);
             return;
         }
 
@@ -346,36 +346,6 @@ export class WebSocketHandler {
                     break;
             }
         });
-    }
-
-    /**
-     * Local Bridge (Cowork D1a) — 데스크톱 로컬 실행기 등록·도구 결과 수신.
-     * 인증 필수(게스트 거부). 등록은 유저당 1대(새 등록이 기존 대체).
-     */
-    private async handleBridgeMessage(ws: WebSocket, msg: WSMessage): Promise<void> {
-        const extWs = ws as ExtendedWebSocket;
-        const userId = extWs._authenticatedUserId;
-        if (!userId) {
-            ws.send(JSON.stringify({ type: 'error', message: '로컬 브리지는 로그인이 필요합니다' }));
-            return;
-        }
-        if (!LOCAL_BRIDGE.ENABLED) {
-            ws.send(JSON.stringify({ type: 'error', message: '로컬 실행 기능이 비활성화되어 있습니다 (LOCAL_EXECUTOR_ENABLED)' }));
-            return;
-        }
-        const registry = getLocalBridgeRegistry();
-        if (msg.type === 'bridge_hello') {
-            const deviceId = typeof msg.deviceId === 'string' && msg.deviceId.trim() ? msg.deviceId.trim().slice(0, 64) : 'unknown';
-            const label = typeof msg.label === 'string' && msg.label.trim() ? msg.label.trim().slice(0, 120) : deviceId;
-            const folderName = typeof msg.folderName === 'string' ? msg.folderName.trim().slice(0, 200) : '';
-            registry.register({ userId, deviceId, label, folderName, ws, connectedAt: Date.now() });
-            ws.send(JSON.stringify({ type: 'bridge_ready', deviceId }));
-            return;
-        }
-        // bridge_result — reqId 상관관계 해소 (소유 검증은 레지스트리가 수행)
-        if (typeof msg.reqId === 'string' && msg.result && typeof msg.result === 'object') {
-            registry.handleResult(userId, msg.reqId, msg.result as unknown as import('../services/local-bridge/registry').BridgeResult);
-        }
     }
 
     private async handleRefresh(ws: WebSocket, msg: WSMessage): Promise<void> {

--- a/apps/api/src/sockets/handler.ts
+++ b/apps/api/src/sockets/handler.ts
@@ -46,6 +46,8 @@ import { WS_SECURITY } from '../config/security';
 import { getBuildId } from '../config/build-id';
 import { handleChatMessage } from './ws-chat-handler';
 import { handleRequestAgents } from './ws-agents-handler';
+import { getLocalBridgeRegistry } from '../services/local-bridge/registry';
+import { LOCAL_BRIDGE } from '../config/local-bridge';
 import { withSpan } from '../observability/otel';
 import { getAnalyticsSystem } from '../monitoring/analytics';
 import { getEventBus, AGENT_TASK_PROGRESS, type AgentTaskProgressEvent } from '../utils/event-bus';
@@ -216,6 +218,8 @@ export class WebSocketHandler {
 
             ws.on('close', () => {
                 this.unregisterConnection(ws);
+                // Local Bridge: 이 소켓이 등록한 로컬 실행기 세션 해제(pending 요청 reject).
+                getLocalBridgeRegistry().unregister(ws);
                 // 🔒 Phase 2 보안 패치: 연결 종료 시 진행 중인 AI 생성 중단
                 // GPU/CPU 리소스 해제 및 불필요한 토큰 생성 방지
                 if (extWs._abortController) {
@@ -298,6 +302,14 @@ export class WebSocketHandler {
         }
 
         const typedMsg = msg as WSMessage;
+
+        // Local Bridge (Cowork D1a): 데스크톱 실행기 등록/결과 — 인증된 연결 전용.
+        // 채팅 파이프라인과 무관한 얇은 위임이라 validTypes/span 밖에서 조기 처리.
+        if (typedMsg.type === 'bridge_hello' || typedMsg.type === 'bridge_result') {
+            await this.handleBridgeMessage(ws, typedMsg);
+            return;
+        }
+
         const validTypes: WSMessage['type'][] = ['refresh', 'request_agents', 'chat', 'abort'];
         if (!validTypes.includes(typedMsg.type)) {
             log.debug(`[WS] 알 수 없는 메시지 타입: ${typedMsg.type}`);
@@ -334,6 +346,36 @@ export class WebSocketHandler {
                     break;
             }
         });
+    }
+
+    /**
+     * Local Bridge (Cowork D1a) — 데스크톱 로컬 실행기 등록·도구 결과 수신.
+     * 인증 필수(게스트 거부). 등록은 유저당 1대(새 등록이 기존 대체).
+     */
+    private async handleBridgeMessage(ws: WebSocket, msg: WSMessage): Promise<void> {
+        const extWs = ws as ExtendedWebSocket;
+        const userId = extWs._authenticatedUserId;
+        if (!userId) {
+            ws.send(JSON.stringify({ type: 'error', message: '로컬 브리지는 로그인이 필요합니다' }));
+            return;
+        }
+        if (!LOCAL_BRIDGE.ENABLED) {
+            ws.send(JSON.stringify({ type: 'error', message: '로컬 실행 기능이 비활성화되어 있습니다 (LOCAL_EXECUTOR_ENABLED)' }));
+            return;
+        }
+        const registry = getLocalBridgeRegistry();
+        if (msg.type === 'bridge_hello') {
+            const deviceId = typeof msg.deviceId === 'string' && msg.deviceId.trim() ? msg.deviceId.trim().slice(0, 64) : 'unknown';
+            const label = typeof msg.label === 'string' && msg.label.trim() ? msg.label.trim().slice(0, 120) : deviceId;
+            const folderName = typeof msg.folderName === 'string' ? msg.folderName.trim().slice(0, 200) : '';
+            registry.register({ userId, deviceId, label, folderName, ws, connectedAt: Date.now() });
+            ws.send(JSON.stringify({ type: 'bridge_ready', deviceId }));
+            return;
+        }
+        // bridge_result — reqId 상관관계 해소 (소유 검증은 레지스트리가 수행)
+        if (typeof msg.reqId === 'string' && msg.result && typeof msg.result === 'object') {
+            registry.handleResult(userId, msg.reqId, msg.result as unknown as import('../services/local-bridge/registry').BridgeResult);
+        }
     }
 
     private async handleRefresh(ws: WebSocket, msg: WSMessage): Promise<void> {

--- a/apps/api/src/sockets/ws-bridge-handler.ts
+++ b/apps/api/src/sockets/ws-bridge-handler.ts
@@ -1,0 +1,37 @@
+/**
+ * Local Bridge WS 핸들러 (Cowork D1a) — 데스크톱 로컬 실행기 등록·도구 결과 수신.
+ * handler.ts 의 메시지 스위치에서 위임(파일 크기 가드 분리). 인증 필수(게스트 거부),
+ * 등록은 유저당 1대(새 등록이 기존 대체).
+ *
+ * @module sockets/ws-bridge-handler
+ */
+import type { WebSocket } from 'ws';
+import type { WSMessage, ExtendedWebSocket } from './ws-types';
+import { getLocalBridgeRegistry, type BridgeResult } from '../services/local-bridge/registry';
+import { LOCAL_BRIDGE } from '../config/local-bridge';
+
+export async function handleBridgeMessage(ws: WebSocket, msg: WSMessage): Promise<void> {
+    const extWs = ws as ExtendedWebSocket;
+    const userId = extWs._authenticatedUserId;
+    if (!userId) {
+        ws.send(JSON.stringify({ type: 'error', message: '로컬 브리지는 로그인이 필요합니다' }));
+        return;
+    }
+    if (!LOCAL_BRIDGE.ENABLED) {
+        ws.send(JSON.stringify({ type: 'error', message: '로컬 실행 기능이 비활성화되어 있습니다 (LOCAL_EXECUTOR_ENABLED)' }));
+        return;
+    }
+    const registry = getLocalBridgeRegistry();
+    if (msg.type === 'bridge_hello') {
+        const deviceId = typeof msg.deviceId === 'string' && msg.deviceId.trim() ? msg.deviceId.trim().slice(0, 64) : 'unknown';
+        const label = typeof msg.label === 'string' && msg.label.trim() ? msg.label.trim().slice(0, 120) : deviceId;
+        const folderName = typeof msg.folderName === 'string' ? msg.folderName.trim().slice(0, 200) : '';
+        registry.register({ userId, deviceId, label, folderName, ws, connectedAt: Date.now() });
+        ws.send(JSON.stringify({ type: 'bridge_ready', deviceId }));
+        return;
+    }
+    // bridge_result — reqId 상관관계 해소 (소유 검증은 레지스트리가 수행)
+    if (typeof msg.reqId === 'string' && msg.result && typeof msg.result === 'object') {
+        registry.handleResult(userId, msg.reqId, msg.result as unknown as BridgeResult);
+    }
+}

--- a/apps/api/src/sockets/ws-types.ts
+++ b/apps/api/src/sockets/ws-types.ts
@@ -36,6 +36,13 @@ export interface WSMessage {
      * settings.html 의 saveHistoryToggle UI 와 연결.
      */
     saveHistory?: boolean;
+    /** Local Bridge (Cowork D1a) — bridge_hello 등록 필드 */
+    deviceId?: string;
+    label?: string;
+    folderName?: string;
+    /** Local Bridge — bridge_result 상관관계·결과 */
+    reqId?: string;
+    result?: Record<string, unknown>;
     /**
      * 장기 메모리 자동 추출 여부.
      * 기본 true (생략 시 추출). false 면 MemoryService 호출 자체 스킵.

--- a/db/migrations/081_agent_task_executor.sql
+++ b/db/migrations/081_agent_task_executor.sql
@@ -1,0 +1,19 @@
+-- 081: Agent Task 실행 백엔드 선택 (Cowork D1a)
+--
+-- 'sandbox'(서버 Docker, 현행 기본) | 'local'(데스크톱 브리지 경유 사용자 머신 실행).
+-- local 은 LOCAL_EXECUTOR_ENABLED + 디바이스 연결 시에만 실행 가능(미연결이면 graceful degrade).
+-- 멱등(ADD COLUMN IF NOT EXISTS). 부팅 자동 적용(runner).
+
+ALTER TABLE agent_tasks ADD COLUMN IF NOT EXISTS executor TEXT NOT NULL DEFAULT 'sandbox';
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'agent_tasks_executor_check'
+    ) THEN
+        ALTER TABLE agent_tasks
+            ADD CONSTRAINT agent_tasks_executor_check CHECK (executor IN ('sandbox', 'local'));
+    END IF;
+END $$;
+
+COMMENT ON COLUMN agent_tasks.executor IS 'D1a: 실행 백엔드 — sandbox(서버 Docker) | local(로컬 브리지). 기본 sandbox.';


### PR DESCRIPTION
## 목적

Cowork형 "로컬 폴더 작업"의 **서버측 절반**입니다. 에이전트 루프(LLM·plan·판단·승인·resume)는 서버에 남기고, **도구 실행만** 채팅 WS로 연결된 디바이스로 위임합니다. D0(#351, TaskExecutor 추상화) 위에 얹는 구현이며 **기본 OFF**(`LOCAL_EXECUTOR_ENABLED`).

```
[서버] Agent Task 루프 ─ RemoteExecutor ─ WS(bridge_exec/bridge_result) ─> [디바이스] 폴더 스코프 실행
```

## 구성

| 파일 | 역할 |
|---|---|
| `services/local-bridge/registry.ts` | 디바이스 레지스트리(유저당 1대) — reqId 상관 왕복, 타임아웃·연결단절 시 pending reject, reqId 소유 불일치 무시(교차 주입 차단) |
| `services/local-bridge/remote-executor.ts` | `TaskExecutor` 구현 — exec/read/write/list/listAll/delete. `localWorkdir=null`, cleanup은 `task_end` 통지만(**사용자 폴더 절대 삭제 안 함**) |
| `sockets/handler.ts` | `bridge_hello`/`bridge_result` 수신(인증 필수·게이트 검사), close 시 해제 |
| `081_agent_task_executor.sql` | `agent_tasks.executor` ('sandbox'\|'local'), 부팅 자동 적용 |
| 생성 경로 | 스키마/라우트 `executor:'local'` — 게이트 + 디바이스 연결 + **git repo 미지정** 3중 검증 |
| AgentTaskService | RemoteExecutor 주입 + **승인 정책 'all' 강제**(docker 격리가 없으므로 전건 승인) |

## 보안 설계 (리뷰 포인트)

- **고정 도구 표면만**: 서버→디바이스 메시지는 `bridge_exec` 의 kind 화이트리스트뿐 — 임의 RPC 경로 없음
- **비밀 비주입**: 프로토콜에 토큰·자격증명을 싣지 않음 (Git/PR 토큰 비주입 원칙 계승)
- **사용자 폴더 보호**: ① cleanup은 통지만 ② code-diff 가드 — 로컬 실행 시 `git init`/diff 명령이 사용자 폴더에 닿지 않음 ③ git-ops는 생성 시점 거부로 no-op
- 경로 스코프는 디바이스측 realpath 가드(1차) — D1b Electron에 동일 이식 예정

## 라이브 E2E

모의 디바이스 스크립트(브리지 프로토콜 headless 구현 = D1b Electron 사양서)로 검증:

- `executor=local` 작업 → bash가 **디바이스 스코프 폴더에** `hello-local.txt(COWORK-D1A-OK)` 생성 → read로 회수 → 최종 답변 반영, `completed`
- 서버 workspace **미생성**(`workspace_path NULL`) / 사용자 폴더 `.git` **미생성**(diff 가드 작동)
- `sandbox_container_id = local:MockMac · e2e` (실행기 라벨 영속)
- 등록→준비→exec→task_end→해제 수명주기 로그 확인

`tsc --noEmit` ✅ / eslint ✅ (경고 2건은 기존 max-lines)

## 다음 (범위 밖)

- D1b: Electron 폴더 선택 UI + 동일 프로토콜 이식 + 스코프 가드 — D0ⓐ(Apple Developer 서명) 선행 필요
- 머지 시 Release PR #352가 이 feat을 포함해 v1.6.0으로 자동 갱신될 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)