### PR TITLE
feat(web): 컴포저 로컬 실행 토글 + 작업 목록 뱃지 (Cowork D2)

### DIFF
--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -36,6 +36,7 @@ export { default as agentsMonitoringRouter } from './agents-monitoring.routes';
 export { default as auditRouter } from './audit.routes';
 export { default as researchRouter } from './research.routes';
 export { default as agentTaskRouter } from './agent-task.routes';
+export { default as localBridgeRouter } from './local-bridge.routes';
 export { default as agentTaskScheduleRouter } from './agent-task-schedule.routes';
 export { adminAgentTaskSchedulesRouter } from './admin-agent-task-schedules.routes';
 export { default as agentTaskTemplateRouter } from './agent-task-template.routes';

--- a/apps/api/src/routes/local-bridge.routes.ts
+++ b/apps/api/src/routes/local-bridge.routes.ts
@@ -1,0 +1,25 @@
+/**
+ * Local Bridge 상태 조회 (Cowork D2) — 컴포저 "로컬 실행" 토글의 활성 판단용.
+ * GET /api/local-bridge/status → { enabled, connected, label }
+ * @module routes/local-bridge
+ */
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../auth';
+import { success } from '../utils/api-response';
+import { LOCAL_BRIDGE } from '../config/local-bridge';
+import { getLocalBridgeRegistry } from '../services/local-bridge/registry';
+
+const router = Router();
+
+router.get('/status', requireAuth, (req: Request, res: Response) => {
+    const userId = String(req.user!.id);
+    const dev = LOCAL_BRIDGE.ENABLED ? getLocalBridgeRegistry().getDevice(userId) : null;
+    res.json(success({
+        enabled: LOCAL_BRIDGE.ENABLED,
+        connected: !!dev,
+        label: dev?.label ?? null,
+        folderName: dev?.folderName ?? null,
+    }));
+});
+
+export default router;

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -44,6 +44,7 @@ import {
     auditRouter,
     researchRouter,
     agentTaskRouter,
+    localBridgeRouter,
     agentTaskScheduleRouter,
     adminAgentTaskSchedulesRouter,
     agentTaskTemplateRouter,
@@ -251,6 +252,7 @@ export function setupApiRoutes(
     app.use('/api/audit', auditRouter);
     app.use('/api/research', researchRouter);
     app.use('/api/agent-tasks', agentTaskRouter);
+    app.use('/api/local-bridge', localBridgeRouter);
     app.use('/api/agent-task-schedules', agentTaskScheduleRouter);
     app.use('/api/agent-task-templates', agentTaskTemplateRouter);
     app.use('/api/external', externalRouter);

--- a/apps/web/app/(workspace)/agent-tasks/page.tsx
+++ b/apps/web/app/(workspace)/agent-tasks/page.tsx
@@ -58,6 +58,8 @@ interface AgentTask {
   resumable?: boolean;
   /** 누적 LLM 토큰(4-4) — terminal 시 기록. */
   totalTokens?: number;
+  /** Cowork D2: 'local' 이면 데스크톱 브리지 폴더에서 실행 */
+  executor?: "sandbox" | "local";
 }
 
 type PlanStepStatus = "not_started" | "in_progress" | "completed" | "blocked";
@@ -81,6 +83,8 @@ interface ApiAgentTask {
   plan?: PlanStep[] | null;
   total_tokens?: number | null;
   git_pr_url?: string | null;
+  /** Cowork D2: 실행 백엔드 — 'local' 이면 데스크톱 브리지 폴더에서 실행됨 */
+  executor?: "sandbox" | "local";
 }
 
 type TaskFilesResponse = ApiSuccess<{ files: string[] }>;
@@ -143,6 +147,7 @@ function mapTask(tr: TFn, t: ApiAgentTask): AgentTask {
     checklist: [],
     resumable: t.resumable,
     totalTokens: typeof t.total_tokens === "number" ? t.total_tokens : undefined,
+    executor: t.executor,
   };
 }
 
@@ -306,6 +311,11 @@ function TaskDetailModal({
           <div className="rounded-md border border-border bg-surface-2 p-4">
             <p className="mb-1 text-xs font-medium text-muted">{t("goalLabel")}</p>
             <p className="text-sm text-fg">{detail.task.goal}</p>
+            {detail.task.executor === "local" && (
+              <span className="mt-2 inline-flex items-center rounded-full border border-accent bg-accent-soft px-2 py-0.5 text-[10px] font-medium text-accent">
+                {t("localBadge")}
+              </span>
+            )}
             <div className="mt-2 flex items-center gap-3 text-xs text-faint">
               <span className="flex items-center gap-1">
                 {t("stateLabel")} {detail.task.status}
@@ -958,6 +968,11 @@ export default function AgentTasksPage() {
                   >
                     {task.goal}
                   </h3>
+                  {task.executor === "local" && (
+                    <span className="mb-2 inline-flex w-fit items-center rounded-full border border-accent bg-accent-soft px-2 py-0.5 text-[10px] font-medium text-accent">
+                      {t("localBadge")}
+                    </span>
+                  )}
 
                   {total > 0 ? (
                     <ul className="mb-4 flex-1 space-y-1.5">

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -190,6 +190,7 @@ export function Composer() {
     agentTaskMode,
     agentApprovalMode,
     agentRepoUrl,
+    agentLocalExecutor,
     imageMode,
     artifactMode,
     structuredMode,
@@ -200,6 +201,7 @@ export function Composer() {
     setSelectedModel,
     setAgentApprovalMode,
     setAgentRepoUrl,
+    setAgentLocalExecutor,
     cycleStyle,
     setInputDraft,
     auth,
@@ -236,6 +238,16 @@ export function Composer() {
     staleTime: 300_000,
   });
   const repoSuggestions = repoData?.data?.repos ?? [];
+  // Cowork D2: 로컬 브리지(데스크톱 앱) 연결 상태 — 토글 활성 판단. 15s 갱신.
+  const { data: bridgeData } = useQuery({
+    queryKey: ["local-bridge-status"],
+    queryFn: () => ApiClient.get<{ data: { enabled: boolean; connected: boolean; folderName: string | null } }>("/api/local-bridge/status"),
+    enabled: agentTaskMode,
+    refetchInterval: 15_000,
+    staleTime: 10_000,
+  });
+  const bridgeConnected = !!bridgeData?.data?.connected;
+  const bridgeFolder = bridgeData?.data?.folderName ?? "";
   // 검색어 없으면("/") 카테고리 그룹핑(전체), 있으면 평면 검색 목록
   const slashGrouped = slashDebounced.trim() === "";
   const rawSlashSkills: SkillSummary[] = slashCandidate ? slashSkillsData ?? [] : [];
@@ -306,6 +318,7 @@ export function Composer() {
         images.length ? images.map((i) => i.dataUrl) : undefined,
         agentApprovalMode,
         agentRepoUrl.trim() || undefined,
+        agentLocalExecutor || undefined,
       );
     } else if (structuredMode) {
       // 구조화 답변 토글 ON — REST /api/chat/structured (비스트리밍, 카드 렌더). 첨부는 미지원.
@@ -565,6 +578,30 @@ export function Composer() {
                 ))}
               </datalist>
             )}
+          </div>
+        )}
+        {/* Cowork D2 — 로컬 실행: 데스크톱 앱이 연결한 폴더에서 작업 실행. repo 지정과는 상호배타. */}
+        {agentTaskMode && (
+          <div className="flex items-center gap-2 px-3 pt-2 text-xs">
+            <span className="shrink-0 text-muted">{t("localExec.label")}</span>
+            <button
+              type="button"
+              onClick={() => setAgentLocalExecutor(!agentLocalExecutor)}
+              disabled={!bridgeConnected || !!agentRepoUrl.trim()}
+              className={cn(
+                "rounded-md border px-2 py-1 text-xs",
+                agentLocalExecutor && bridgeConnected
+                  ? "border-accent bg-accent-soft text-accent"
+                  : "border-border bg-surface-2 text-fg-1",
+                (!bridgeConnected || !!agentRepoUrl.trim()) && "opacity-50",
+              )}
+            >
+              {!bridgeConnected
+                ? t("localExec.disconnected")
+                : agentLocalExecutor
+                  ? t("localExec.on", { folder: bridgeFolder })
+                  : t("localExec.off")}
+            </button>
           </div>
         )}
         {/* 승인 3모드(Manual/Auto/Skip) — 에이전트 작업 위임 시 이 실행의 도구 승인 정책 선택. */}

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -161,6 +161,8 @@ interface AppState {
   agentApprovalMode: "all" | "high-risk" | "none";
   /** 에이전트 작업 Git repo URL(Phase 2) — 있으면 태스크가 해당 repo 를 clone 해 작업 후 PR 생성. */
   agentRepoUrl: string;
+  /** Cowork D2: 로컬 실행 토글 — ON 이면 작업이 데스크톱 앱이 연결한 폴더에서 실행(executor='local'). */
+  agentLocalExecutor: boolean;
   imageMode: boolean;
   artifactMode: boolean;
   /** 구조화 답변 모드 — ON 시 메시지를 REST /api/chat/structured 로 보내 카드 UI 로 렌더(비스트리밍). */
@@ -223,6 +225,7 @@ interface AppState {
   setSelectedModel: (m: string) => void;
   setAgentApprovalMode: (m: "all" | "high-risk" | "none") => void;
   setAgentRepoUrl: (u: string) => void;
+  setAgentLocalExecutor: (v: boolean) => void;
   cycleStyle: () => void;
   setStyle: (m: ChatStyle) => void;
   setAuth: (auth: AppState["auth"]) => void;
@@ -286,6 +289,7 @@ export const useAppStore = create<AppState>()(
   agentTaskMode: false,
   agentApprovalMode: "all",
   agentRepoUrl: "",
+  agentLocalExecutor: false,
   imageMode: false,
   artifactMode: false,
   structuredMode: false,
@@ -440,6 +444,7 @@ export const useAppStore = create<AppState>()(
   setSelectedModel: (m) => set({ selectedModel: m }),
   setAgentApprovalMode: (m) => set({ agentApprovalMode: m }),
   setAgentRepoUrl: (u) => set({ agentRepoUrl: u }),
+  setAgentLocalExecutor: (v) => set({ agentLocalExecutor: v }),
   cycleStyle: () =>
     set((s) => ({
       style: STYLE_ORDER[(STYLE_ORDER.indexOf(s.style) + 1) % STYLE_ORDER.length],

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -404,6 +404,8 @@ export function useChatSocket() {
       images?: string[],
       approvalPolicy?: "all" | "high-risk" | "none",
       repoUrl?: string,
+      /** Cowork D2: true 면 데스크톱 브리지가 연결한 로컬 폴더에서 실행 (승인은 서버가 'all' 강제) */
+      localExecutor?: boolean,
     ) => {
       const goal = message.trim();
       const s = useAppStore.getState();
@@ -424,6 +426,7 @@ export function useChatSocket() {
             ...(payloadFiles.length > 0 ? { files: payloadFiles } : {}),
             ...(images && images.length > 0 ? { images } : {}),
             ...(repoUrl && repoUrl.trim() ? { repoUrl: repoUrl.trim() } : {}),
+            ...(localExecutor ? { executor: "local" } : {}),
           }));
           for (const f of binaryParts) fd.append("files", f.rawFile!, f.name);
           const resp = await fetch("/api/agent-tasks", {
@@ -448,6 +451,7 @@ export function useChatSocket() {
                 : {}),
               ...(images && images.length > 0 ? { images } : {}),
               ...(repoUrl && repoUrl.trim() ? { repoUrl: repoUrl.trim() } : {}),
+              ...(localExecutor ? { executor: "local" } : {}),
             },
           );
         }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -281,6 +281,12 @@
     },
     "repo": {
       "label": "Repo (optional):"
+    },
+    "localExec": {
+      "label": "Local run:",
+      "off": "Run in server sandbox",
+      "on": "Run in local folder: {folder}",
+      "disconnected": "Desktop app not connected"
     }
   },
   "chat": {
@@ -754,7 +760,8 @@
       "started": "Task started from template."
     },
     "viewPr": "View PR",
-    "downloadFailed": "Download failed: {error}"
+    "downloadFailed": "Download failed: {error}",
+    "localBadge": "Local folder run"
   },
   "customAgents": {
     "pageTitle": "Custom Agents",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -281,6 +281,12 @@
     },
     "repo": {
       "label": "リポジトリ(任意):"
+    },
+    "localExec": {
+      "label": "ローカル実行:",
+      "off": "サーバーサンドボックスで実行",
+      "on": "ローカルフォルダで実行: {folder}",
+      "disconnected": "デスクトップアプリ未接続"
     }
   },
   "chat": {
@@ -754,7 +760,8 @@
       "started": "テンプレートからタスクを開始しました。"
     },
     "viewPr": "PR を表示",
-    "downloadFailed": "ダウンロードに失敗しました: {error}"
+    "downloadFailed": "ダウンロードに失敗しました: {error}",
+    "localBadge": "ローカルフォルダ実行"
   },
   "customAgents": {
     "pageTitle": "カスタムエージェント",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -281,6 +281,12 @@
     },
     "repo": {
       "label": "저장소(선택):"
+    },
+    "localExec": {
+      "label": "로컬 실행:",
+      "off": "서버 샌드박스에서 실행",
+      "on": "로컬 폴더에서 실행: {folder}",
+      "disconnected": "데스크톱 앱 미연결"
     }
   },
   "chat": {
@@ -754,7 +760,8 @@
       "started": "템플릿으로 작업을 시작했습니다."
     },
     "viewPr": "PR 보기",
-    "downloadFailed": "다운로드 실패: {error}"
+    "downloadFailed": "다운로드 실패: {error}",
+    "localBadge": "로컬 폴더 실행"
   },
   "customAgents": {
     "pageTitle": "커스텀 에이전트",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -281,6 +281,12 @@
     },
     "repo": {
       "label": "仓库(可选):"
+    },
+    "localExec": {
+      "label": "本地执行:",
+      "off": "在服务器沙箱中运行",
+      "on": "在本地文件夹运行: {folder}",
+      "disconnected": "未连接桌面应用"
     }
   },
   "chat": {
@@ -754,7 +760,8 @@
       "started": "已从模板启动任务。"
     },
     "viewPr": "查看 PR",
-    "downloadFailed": "下载失败: {error}"
+    "downloadFailed": "下载失败: {error}",
+    "localBadge": "本地文件夹执行"
   },
   "customAgents": {
     "pageTitle": "自定义智能体",


### PR DESCRIPTION
## 목적

D1a/D1b(#353·#354)의 로컬 브리지를 **UI에 노출** — API 없이 채팅 컴포저에서 "이 폴더에서 작업해줘"가 됩니다. Cowork 트랙 UX 마감.

## 구성

- **`GET /api/local-bridge/status`**: 연결 디바이스 유무·라벨·폴더명 (토글 활성 판단, 15s 폴링)
- **컴포저 토글**: 에이전트 모드에서 "로컬 실행" — 미연결 시 비활성+안내, **repo 지정과 상호배타**(서버 검증과 일치). ON이면 생성 body에 `executor:'local'` (JSON·multipart 두 경로)
- **작업 목록·상세 뱃지**: `executor='local'` → "로컬 폴더 실행"
- i18n 4-locale (`check:i18n` 1188키 통과)

**follow-up("같은 폴더로 이어서")은 별도 기능 불필요** — 브리지 폴더 연결이 디바이스 세션 단위로 지속되므로 새 작업이 자연히 같은 폴더에서 실행됩니다.

## 라이브 E2E (실제 브라우저 UI 전 구간)

에이전트 모드 → 토글 렌더·연결 감지 → ON(`로컬 폴더에서 실행: electron-workdir`) → 전송 → `executor=local` 생성 → **승인 'all' 강제** 대기 → 승인 → `completed`, 파일이 Electron 연결 폴더에 실존(`D2-UI-OK`). 목록 뱃지 렌더 확인.

검증 중 발견한 제 스크립트 오류(승인 경로 오타→429)는 앱 결함 아님 — 올바른 경로(`/api/agent-tasks/approvals/:id/approve`)로 완주.

이 PR 머지 시 Release PR #352(v1.6.0)에 합류합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)