### PR TITLE
chore(desktop): v1.1.0 — 로컬 브리지 포함 미서명 dmg

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmake-desktop",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "OpenMake LLM 데스크톱 셸 (macOS) — 운영 백엔드(외부 공개 도메인 / 로컬)를 네이티브 창으로",
   "author": "OpenMake Team",


### PR DESCRIPTION
데스크톱 독립 버전 1.0.0→1.1.0 (브리지 D1b 포함 첫 배포 빌드). 사용자 결정으로 Apple 서명 없이 ad-hoc 유지 — 수령자는 `xattr -dr com.apple.quarantine` 격리 해제 필요. 산출물 `OpenMake-1.1.0-arm64.dmg`(96MB)는 로컬 dist/ (git 미포함), 번들에 bridge.js·ws·chat.openmake.cc 반영 검증 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)