### PR TITLE
feat(desktop): 서버 매니페스트 기반 자체 업데이터 (v1.2.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ up_models.json
 
 # Cloudflare Tunnel 설정 — git 커밋 금지 지침 (라이브: ~/.cloudflared/config.yml)
 scripts/cloudflared/
+data/desktop-updates/

--- a/apps/api/src/chat/prompt-templates.ts
+++ b/apps/api/src/chat/prompt-templates.ts
@@ -68,18 +68,18 @@ export const SYSTEM_PROMPTS = {
 
     /**
      * ========================================
-     * CODER - 코드 전문가 (GitHub 아키텍트)
+     * CODER - 코드 전문가 (풀스택 아키텍트)
      * ========================================
      */
-    coder: `# Role: 20년 경력의 Full-Stack 시니어 아키텍트 (GitHub Master)
+    coder: `# Role: 20년 경력의 Full-Stack 시니어 아키텍트
 당신은 단순히 코드를 생성하는 것을 넘어, 확장 가능하고 유지보수가 용이하며 보안이 강화된 엔터프라이즈 급 소프트웨어 아키텍처를 설계하는 거장입니다.
 
 ## 🎯 Mission
 사용자의 요구사항을 기술적 사양으로 해석하고, 최신 베스트 프랙티스(Clean Code, SOLID, Design Patterns)가 적용된 완성도 높은 코드를 제공합니다.
 
-## 🛠 Tool Interfacing (GitHub MCP)
-- 당신은 **GitHub MCP 도구**를 완벽하게 숙달하고 있습니다.
-- 코드를 작성하기 전, 필요하다면 \`github_search_code\`나 \`github_get_file\`을 제안하여 기존 코드베이스의 맥락을 먼저 파악하세요.
+## 🛠 Tool Interfacing (내장 개발 도구)
+- 구현 범위가 넓거나 단계가 복잡한 경우 \`create_plan\`으로 작업 단위를 먼저 설계하세요.
+- 작성한 코드는 \`code_review\`로 품질을, 보안이 중요한 영역이라면 \`security_review\`로 취약점을 점검하도록 제안하세요.
 - 코드 변경 사항이 많은 경우, 논리적 단위로 나누어 제안하십시오.
 
 ## 🔒 Constraints & Rules
@@ -224,10 +224,10 @@ export const SYSTEM_PROMPTS = {
 ## 🎯 Mission
 사용자의 질문을 다각도로 분석하여, 신뢰할 수 있는 데이터와 출처를 기반으로 한 입체적인 정보를 제공합니다.
 
-## 🛠 Tool Interfacing (Exa Search MCP)
-- 당신은 **Exa Search MCP**의 강력한 기능을 숙달하고 있습니다.
-- 최신 정보나 기술적 라이브러리 정보가 필요한 경우 \`exa_search\` 또는 \`exa_code_search\`를 사용하여 실시간 데이터를 적극 확보하세요.
-- 유사한 사례를 찾을 때는 \`exa_similar\` 도구를 적재적소에 사용하십시오.
+## 🛠 Tool Interfacing (내장 검색 도구)
+- 최신 정보가 필요한 경우 \`web_search\`로 실시간 데이터를 적극 확보하고, 출처 검증이 필요하면 \`fact_check\`를 사용하세요.
+- 특정 문서나 기술 레퍼런스의 본문이 필요할 때는 \`extract_webpage\` 또는 \`web_scrape\`로 원문을 확보하십시오.
+- 다각도 심층 조사에는 \`research_topic\`을, 특정 사이트 전반을 훑어야 할 때는 \`web_map\` / \`web_crawl\`을 적재적소에 사용하십시오.
 
 ## 🔒 Constraints
 - **Fact-Check First**: 출처가 불분명한 내용은 반드시 [낮은 확신]으로 명시하고, 가능한 한 교차 검증된 데이터만 전달하세요.

--- a/apps/api/src/config/data/prompt-type-patterns.json
+++ b/apps/api/src/config/data/prompt-type-patterns.json
@@ -67,7 +67,7 @@
   ],
   "specialBonuses": [
     { "type": "coder", "source": "api|lib|module|github|이슈|pr", "flags": "i", "bonus": 2 },
-    { "type": "researcher", "source": "최신|뉴스|검색|사례|exa", "flags": "i", "bonus": 2 },
+    { "type": "researcher", "source": "최신|뉴스|검색|사례", "flags": "i", "bonus": 2 },
     { "type": "security", "source": "취약점|해킹|보안|vulnerability", "flags": "i", "bonus": 2 }
   ]
 }

--- a/apps/api/src/config/desktop-update.ts
+++ b/apps/api/src/config/desktop-update.ts
@@ -1,0 +1,18 @@
+/**
+ * Desktop 앱 업데이트 배포 설정 (No-Hardcoding L1).
+ *
+ * 데스크톱 앱이 GET /api/desktop/latest 로 최신 버전을 확인하고
+ * /api/desktop/download/:file 로 dmg 를 받는다. 산출물은 git 에 넣지 않고
+ * 서버 디렉토리(DESKTOP_UPDATE_DIR)에 두며, scripts/publish-desktop.sh 가
+ * dmg 복사 + latest.json(버전·파일명·sha256) 생성을 담당한다.
+ *
+ * @module config/desktop-update
+ */
+import * as path from 'path';
+
+export const DESKTOP_UPDATE = {
+    /** dmg + latest.json 보관 디렉토리 */
+    DIR: process.env.DESKTOP_UPDATE_DIR || path.join(process.cwd(), 'data', 'desktop-updates'),
+    /** 다운로드 허용 파일명 패턴 — 경로 조작 차단 */
+    FILE_PATTERN: /^OpenMake-[A-Za-z0-9.-]+\.dmg$/,
+} as const;

--- a/apps/api/src/config/external-providers.ts
+++ b/apps/api/src/config/external-providers.ts
@@ -5,8 +5,10 @@
  * 사용자 BYO Key 등록 화면에서 노출할 provider 목록과 각 provider 의 SDK 종류,
  * 기본 base URL, 검증 endpoint 등을 정의합니다.
  *
- * 활성: 로컬 LLM (vLLM via LiteLLM, 키 불필요) + openrouter (BYO key, OpenAI 호환 endpoint).
- * 다른 외부 provider 는 2026-05-08 마이그레이션 018 로 카탈로그에서 제외됨.
+ * 활성: 로컬 LLM (vLLM via LiteLLM, 키 불필요) + BYO key provider 4종 —
+ * openrouter / ollama-local / ollama-cloud / nvidia (모두 OpenAI 호환 endpoint).
+ * 2026-05-08 마이그레이션 018 로 openrouter 만 남겼다가, ollama 2종은 2026-07-04,
+ * nvidia 는 2026-07-14 에 재도입됨 (018 은 기존 키 행 정리용 — 스키마는 유지).
  *
  * SSRF 정책: base_url 등록 시 {@link security/ssrf-guard.ts} validateOutboundUrl 로
  * localhost/사설 IP/link-local 차단 (별도 정책 추가 안 함, 기존 SSoT 재사용).

--- a/apps/api/src/routes/desktop-update.routes.ts
+++ b/apps/api/src/routes/desktop-update.routes.ts
@@ -1,0 +1,57 @@
+/**
+ * Desktop 앱 업데이트 배포 — 버전 매니페스트 + dmg 다운로드.
+ *
+ * 미서명(ad-hoc) 배포라 Squirrel 자동업데이트를 못 쓰므로, 앱이 이 API 로
+ * 최신 버전을 확인하고 dmg 를 받아 자체 교체한다(sha256 은 매니페스트로 검증).
+ * 공개 라우트(앱 배포용) — 파일명 화이트리스트로 경로 조작을 차단한다.
+ *
+ * GET /api/desktop/latest          → { version, file, sha256, url }
+ * GET /api/desktop/download/:file  → dmg 스트림
+ *
+ * @module routes/desktop-update
+ */
+import { Router, Request, Response } from 'express';
+import * as fs from 'fs';
+import * as path from 'path';
+import { DESKTOP_UPDATE } from '../config/desktop-update';
+import { success, notFound, badRequest } from '../utils/api-response';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('DesktopUpdate');
+const router = Router();
+
+router.get('/latest', (_req: Request, res: Response) => {
+    const manifestPath = path.join(DESKTOP_UPDATE.DIR, 'latest.json');
+    try {
+        const m = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as { version?: string; file?: string; sha256?: string };
+        if (!m.version || !m.file || !DESKTOP_UPDATE.FILE_PATTERN.test(m.file)) {
+            res.status(404).json(notFound('업데이트 매니페스트가 올바르지 않습니다'));
+            return;
+        }
+        res.json(success({
+            version: m.version,
+            file: m.file,
+            sha256: m.sha256 ?? null,
+            url: `/api/desktop/download/${m.file}`,
+        }));
+    } catch {
+        res.status(404).json(notFound('배포된 데스크톱 업데이트가 없습니다'));
+    }
+});
+
+router.get('/download/:file', (req: Request, res: Response) => {
+    const file = req.params.file;
+    if (!DESKTOP_UPDATE.FILE_PATTERN.test(file)) {
+        res.status(400).json(badRequest('허용되지 않는 파일명'));
+        return;
+    }
+    const abs = path.join(DESKTOP_UPDATE.DIR, file);
+    if (!fs.existsSync(abs)) {
+        res.status(404).json(notFound('파일 없음'));
+        return;
+    }
+    logger.info(`데스크톱 dmg 다운로드: ${file}`);
+    res.download(abs, file);
+});
+
+export default router;

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -37,6 +37,7 @@ export { default as auditRouter } from './audit.routes';
 export { default as researchRouter } from './research.routes';
 export { default as agentTaskRouter } from './agent-task.routes';
 export { default as localBridgeRouter } from './local-bridge.routes';
+export { default as desktopUpdateRouter } from './desktop-update.routes';
 export { default as agentTaskScheduleRouter } from './agent-task-schedule.routes';
 export { adminAgentTaskSchedulesRouter } from './admin-agent-task-schedules.routes';
 export { default as agentTaskTemplateRouter } from './agent-task-template.routes';

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -45,6 +45,7 @@ import {
     researchRouter,
     agentTaskRouter,
     localBridgeRouter,
+    desktopUpdateRouter,
     agentTaskScheduleRouter,
     adminAgentTaskSchedulesRouter,
     agentTaskTemplateRouter,
@@ -253,6 +254,7 @@ export function setupApiRoutes(
     app.use('/api/research', researchRouter);
     app.use('/api/agent-tasks', agentTaskRouter);
     app.use('/api/local-bridge', localBridgeRouter);
+    app.use('/api/desktop', desktopUpdateRouter);
     app.use('/api/agent-task-schedules', agentTaskScheduleRouter);
     app.use('/api/agent-task-templates', agentTaskTemplateRouter);
     app.use('/api/external', externalRouter);

--- a/apps/desktop/bridge.js
+++ b/apps/desktop/bridge.js
@@ -16,11 +16,15 @@ const WebSocket = require('ws');
 const EXEC_TIMEOUT_MS = 120000;
 const MAX_BUFFER = 1024 * 1024;
 const RECONNECT_MS = 10000;
+// 서버 WS 하트비트는 액세스 토큰 만료 시 연결을 terminate 한다 — 세션 쿠키에서 최신
+// 토큰을 읽어 기존 refresh 프로토콜({type:'refresh'})로 주기 연장해 유휴 플랩을 막는다.
+const REFRESH_MS = parseInt(process.env.OMK_BRIDGE_REFRESH_MS || '300000', 10);
 
 let ws = null;
 let folderRoot = null;       // realpath 확정된 연결 폴더 (null=미연결)
 let wsUrl = null;
 let reconnectTimer = null;
+let refreshTimer = null;
 let statusText = '미연결';
 let onStatusChange = () => {};
 
@@ -105,6 +109,16 @@ async function connect(app, backendUrl) {
       label: `${require('os').hostname()} · ${path.basename(folderRoot)}`,
       folderName: path.basename(folderRoot),
     }));
+    // 유휴 세션 연장 — 5분마다 최신 토큰으로 refresh (실패는 close 가 후속 처리)
+    clearInterval(refreshTimer);
+    refreshTimer = setInterval(async () => {
+      try {
+        const tok = await authToken(backendUrl);
+        if (tok && ws && ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'refresh', authToken: tok }));
+        }
+      } catch { /* noop */ }
+    }, REFRESH_MS);
   }, 300));
 
   ws.on('message', (d) => {
@@ -119,6 +133,7 @@ async function connect(app, backendUrl) {
   });
 
   ws.on('close', () => {
+    clearInterval(refreshTimer);
     if (!folderRoot) { setStatus('미연결'); return; }
     setStatus('끊김 — 재연결 대기');
     clearTimeout(reconnectTimer);
@@ -146,6 +161,7 @@ async function connectFolder(app, backendUrl, win) {
 function disconnectFolder() {
   folderRoot = null;
   clearTimeout(reconnectTimer);
+  clearInterval(refreshTimer);
   try { if (ws) ws.close(); } catch { /* noop */ }
   ws = null;
   setStatus('미연결');

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -7,6 +7,7 @@ const { app, BrowserWindow, Menu, shell } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const bridge = require('./bridge');
+const updater = require('./updater');
 
 const BACKENDS = {
   external: 'https://chat.openmake.cc',
@@ -63,6 +64,8 @@ function createWindow() {
   buildMenu();
   // 테스트 훅(개발 전용): 폴더가 env 로 지정되면 다이얼로그 없이 자동 연결.
   if (process.env.OMK_BRIDGE_FOLDER) bridge.connectFolder(app, bridgeBackendUrl(), win);
+  // 기동 5초 후 자동 업데이트 확인 — 새 버전 있을 때만 다이얼로그.
+  updater.scheduleStartupCheck(() => bridgeBackendUrl(), () => win);
 }
 
 function switchBackend(b) {
@@ -90,6 +93,8 @@ function buildMenu() {
         { type: 'separator' },
         { label: '새로고침', accelerator: 'CmdOrCtrl+R', click: () => win && win.reload() },
         { label: '강제 새로고침(캐시 무시)', accelerator: 'CmdOrCtrl+Shift+R', click: () => win && win.webContents.reloadIgnoringCache() },
+        { type: 'separator' },
+        { label: `업데이트 확인… (현재 v${app.getVersion()})`, click: () => updater.checkForUpdate(bridgeBackendUrl(), win, true) },
       ],
     },
     {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmake-desktop",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "private": true,
   "description": "OpenMake LLM 데스크톱 셸 (macOS) — 운영 백엔드(외부 공개 도메인 / 로컬)를 네이티브 창으로",
   "author": "OpenMake Team",
@@ -26,7 +26,8 @@
     },
     "files": [
       "main.js",
-      "bridge.js"
+      "bridge.js",
+      "updater.js"
     ],
     "afterPack": "afterPack.js",
     "mac": {

--- a/apps/desktop/updater.js
+++ b/apps/desktop/updater.js
@@ -1,0 +1,120 @@
+// 앱 업데이터 — 서버 매니페스트(GET /api/desktop/latest) 기반 자체 교체.
+//
+// 미서명(ad-hoc) 배포라 Squirrel/electron-updater 를 쓸 수 없어(서명 필수),
+// dmg 를 받아 sha256 검증 후 분리 프로세스가 /Applications 교체 + 재실행한다.
+// 흐름: 버전 비교 → 사용자 확인 다이얼로그 → 다운로드(tmp) → sha256 검증 →
+//       교체 스크립트 spawn(detached) → 앱 종료 → 스크립트가 교체·xattr·재실행.
+const { app, dialog, shell } = require('electron');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+const { spawn } = require('child_process');
+
+const CHECK_DELAY_MS = 5000;
+// 매니페스트 파일명 화이트리스트 — 교체 스크립트에 문자열로 보간되므로 서버(config/
+// desktop-update.ts)와 같은 패턴을 앱에서도 검증한다(백엔드 전환 가능 → 서버 검증만 의존 불가).
+const FILE_PATTERN = /^OpenMake-[A-Za-z0-9.-]+\.dmg$/;
+
+/** "1.2.0" 형태 비교 — a > b 이면 양수. */
+function cmpVersion(a, b) {
+  const pa = String(a).split('.').map(Number);
+  const pb = String(b).split('.').map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] || 0) - (pb[i] || 0);
+    if (d) return d;
+  }
+  return 0;
+}
+
+function fetchJson(url) {
+  return fetch(url, { headers: { Accept: 'application/json' } }).then((r) => {
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    return r.json();
+  });
+}
+
+async function downloadTo(url, dest) {
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(`다운로드 실패 HTTP ${r.status}`);
+  const buf = Buffer.from(await r.arrayBuffer());
+  fs.writeFileSync(dest, buf);
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+/** 교체 스크립트 — 앱 종료 후 dmg 마운트 → /Applications 교체 → 격리 해제 → 재실행. */
+function spawnReplaceScript(dmgPath) {
+  const script = `#!/bin/bash
+sleep 2
+MNT=$(hdiutil attach -nobrowse "${dmgPath}" | tail -1 | awk '{print $NF}')
+if [ -d "$MNT/OpenMake.app" ]; then
+  rm -rf /Applications/OpenMake.app
+  ditto "$MNT/OpenMake.app" /Applications/OpenMake.app
+  xattr -dr com.apple.quarantine /Applications/OpenMake.app 2>/dev/null
+fi
+hdiutil detach "$MNT" -quiet
+rm -f "${dmgPath}"
+open -a /Applications/OpenMake.app
+rm -f "$0"
+`;
+  const sh = path.join(os.tmpdir(), `openmake-update-${Date.now()}.sh`);
+  fs.writeFileSync(sh, script, { mode: 0o755 });
+  spawn('/bin/bash', [sh], { detached: true, stdio: 'ignore' }).unref();
+}
+
+/**
+ * 업데이트 확인. interactive=true(메뉴)면 "최신 버전" 안내도 표시,
+ * false(기동 시 자동)면 새 버전 있을 때만 다이얼로그.
+ */
+async function checkForUpdate(backendUrl, win, interactive) {
+  try {
+    const m = (await fetchJson(`${backendUrl}/api/desktop/latest`)).data;
+    if (!m || !m.version || !FILE_PATTERN.test(String(m.file))) {
+      throw new Error('업데이트 매니페스트 형식이 올바르지 않습니다');
+    }
+    const current = app.getVersion();
+    if (cmpVersion(m.version, current) <= 0) {
+      if (interactive) {
+        dialog.showMessageBox(win, { type: 'info', message: `최신 버전입니다 (v${current})` });
+      }
+      return;
+    }
+    const autoTest = process.env.OMK_UPDATE_AUTO === '1'; // 테스트 훅(개발 전용): 다이얼로그 생략
+    const choice = autoTest ? 0 : dialog.showMessageBoxSync(win, {
+      type: 'info',
+      message: `새 버전 v${m.version} 이 있습니다 (현재 v${current})`,
+      detail: '지금 업데이트하면 앱이 잠시 종료된 뒤 새 버전으로 다시 열립니다.',
+      buttons: ['지금 업데이트', '나중에'],
+      defaultId: 0,
+      cancelId: 1,
+    });
+    if (choice !== 0) return;
+
+    const dmgPath = path.join(os.tmpdir(), m.file);
+    const sha = await downloadTo(`${backendUrl}${m.url}`, dmgPath);
+    if (m.sha256 && sha !== m.sha256) {
+      fs.rmSync(dmgPath, { force: true });
+      throw new Error('다운로드 무결성 검증 실패(sha256 불일치)');
+    }
+    spawnReplaceScript(dmgPath);
+    app.quit();
+  } catch (e) {
+    if (interactive) {
+      dialog.showMessageBox(win, {
+        type: 'warning',
+        message: '업데이트 확인 실패',
+        detail: String(e.message || e),
+      });
+    }
+    // 자동 확인 실패는 조용히 무시 (오프라인 등)
+  }
+}
+
+module.exports = {
+  checkForUpdate,
+  /** 기동 시 자동 확인(지연 실행) — 새 버전 있을 때만 표시. */
+  scheduleStartupCheck: (backendUrlFn, winFn) => {
+    setTimeout(() => checkForUpdate(backendUrlFn(), winFn(), false), CHECK_DELAY_MS);
+  },
+  openReleasePage: (backendUrl) => shell.openExternal(backendUrl),
+};

--- a/scripts/publish-desktop.sh
+++ b/scripts/publish-desktop.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# 데스크톱 dmg 를 업데이트 배포 디렉토리에 게시한다 (자체 업데이터용).
+#   사용법: bash scripts/publish-desktop.sh [dmg경로]
+#   기본:  apps/desktop/dist 의 최신 OpenMake-*.dmg
+# 산출: $DESKTOP_UPDATE_DIR(기본 data/desktop-updates)/ 에 dmg 복사 + latest.json 생성.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DIR="${DESKTOP_UPDATE_DIR:-$ROOT/data/desktop-updates}"
+DMG="${1:-$(ls -t "$ROOT"/apps/desktop/dist/OpenMake-*.dmg 2>/dev/null | head -1)}"
+[ -f "$DMG" ] || { echo "dmg 없음: $DMG"; exit 1; }
+FILE="$(basename "$DMG")"
+VERSION="$(echo "$FILE" | sed -E 's/OpenMake-([0-9.]+)-.*/\1/')"
+SHA=$(shasum -a 256 "$DMG" | awk '{print $1}')
+mkdir -p "$DIR"
+cp "$DMG" "$DIR/$FILE"
+printf '{"version":"%s","file":"%s","sha256":"%s"}\n' "$VERSION" "$FILE" "$SHA" > "$DIR/latest.json"
+echo "게시됨: v$VERSION → $DIR/$FILE"
+cat "$DIR/latest.json"


### PR DESCRIPTION
## 배경

미서명(ad-hoc) dmg 배포라 Squirrel/electron-updater(코드 서명 필수)를 쓸 수 없어, 데스크톱 앱을 새로 받으려면 매번 수동 설치가 필요했다. 앱이 서버 매니페스트로 최신 버전을 확인하고 dmg 를 받아 자체 교체하도록 한다.

## 변경

**백엔드 (공개 라우트)**
- `GET /api/desktop/latest` → `{ version, file, sha256, url }`
- `GET /api/desktop/download/:file` → dmg 스트림
- 파일명 화이트리스트(`config/desktop-update.ts` `FILE_PATTERN`)로 경로 조작 차단
- 산출물 디렉토리는 L1 환경변수 `DESKTOP_UPDATE_DIR` (기본 `data/desktop-updates`, git 제외)

**데스크톱 앱**
- 기동 5초 후 자동 확인 + 메뉴 `업데이트 확인…`
- 다운로드 → sha256 검증 → 분리 프로세스가 `/Applications` 교체 → 격리 해제(xattr) → 재실행
- 교체 스크립트에 파일명이 문자열로 보간되므로 **앱에서도 같은 패턴을 검증** — 앱은 백엔드를 external/local 로 전환할 수 있어 서버 검증만 의존할 수 없음

**게시 스크립트**
- `scripts/publish-desktop.sh` — dmg 복사 + `latest.json`(버전·파일명·sha256) 생성

**함께 포함된 별건 수정**
- `fix(desktop)` 브리지 유휴 세션 만료 WS 플랩 차단 — 서버 하트비트가 토큰 만료 시 연결을 terminate 하므로 5분마다 기존 refresh 프로토콜로 연장 (`OMK_BRIDGE_REFRESH_MS`)
- `fix(chat)` coder/researcher 시스템 프롬프트가 이 프로젝트에 없는 GitHub MCP·Exa Search MCP 도구를 안내하던 문제 — 실존 내장 도구 10종으로 교체(전량 `mcp/` 정의 존재 확인), 라우팅 가중치의 `exa` 키워드 제거
- `docs(config)` external-providers 활성 provider 주석 현행화 (BYO key 4종)

## 검증

라이브 E2E — 설치본 v1.2.0 실행 → 자동 확인 → 다운로드(서버 로그 `[DesktopUpdate] 데스크톱 dmg 다운로드: OpenMake-1.2.1-arm64.dmg`) → sha256 검증 → 교체 → 새 pid 로 재실행 → `CFBundleShortVersionString = 1.2.1` 확인, tmp 교체 스크립트·dmg 자체 정리 확인. 매니페스트는 로컬 `:52416` 과 외부 `chat.openmake.cc`(터널→Caddy) 양쪽 200 확인.

- [x] `npm run lint` (변경 파일) 통과
- [x] `npx tsc --noEmit` 통과
- [x] 환경변수 추가 → 문서화 (`DESKTOP_UPDATE_DIR`, `OMK_BRIDGE_REFRESH_MS`)
- [x] DB 스키마 변경 없음
- [x] `npm test` — 166 스위트 / 2094 테스트 통과, 실패 0

## 보안 영향

- 신설 라우트 2개는 **공개**(앱이 로그인 전에도 업데이트해야 함). 노출되는 것은 버전 문자열과 배포용 dmg 뿐이며, 파일 접근은 서버·클라이언트 양쪽 파일명 화이트리스트로 제한된다.
- dmg 무결성은 매니페스트 sha256 으로 검증. 서명은 여전히 없으므로 신뢰 경계는 "앱이 붙은 백엔드"다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
