### PR TITLE
fix: 공개 저장소의 개인 식별자·고정 자격증명 제거

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -329,6 +329,11 @@ DATABASE_URL=postgresql://openmake:your_password@localhost:5432/openmake_llm  # 
 # POSTGRES_DB=openmake_llm
 # POSTGRES_PORT=5432
 # REDIS_PORT=6379
+# 초기 관리자 계정 — 빈 볼륨 첫 기동 시 db/init/004-admin-user.sh 가 1회 생성.
+# 미설정이면 계정을 만들지 않는다 (저장소에 고정 자격증명을 두지 않기 위함).
+# ADMIN_INITIAL_PASSWORD=change_me_before_first_boot
+# ADMIN_INITIAL_USERNAME=admin
+# ADMIN_INITIAL_EMAIL=admin@openmake.ai
 # docker compose 파일 경로. openmake_llm.sh / docker compose 가 -f 로 참조.
 # 미설정 시 레포의 infra/docker-compose.yml 사용 (openmake_llm.sh 기본값). 절대경로로 override 가능.
 # COMPOSE_FILE=/path/to/docker-compose.yml

--- a/apps/web/app/(workspace)/admin/alerts/page.tsx
+++ b/apps/web/app/(workspace)/admin/alerts/page.tsx
@@ -65,14 +65,6 @@ const RULES: AlertRule[] = [
   { id: "r5", nameKey: "rules.roleChange.name", conditionKey: "rules.roleChange.condition", channel: ["webhook", "email"], enabled: true },
 ];
 
-const MOCK_EVENTS: { id: string; severity: Severity; messageKey: string; timestamp: string }[] = [
-  { id: "e1", severity: "critical", messageKey: "events.e1", timestamp: "2026-06-21T03:40:22Z" },
-  { id: "e2", severity: "warning", messageKey: "events.e2", timestamp: "2026-06-21T03:12:00Z" },
-  { id: "e3", severity: "warning", messageKey: "events.e3", timestamp: "2026-06-21T03:31:05Z" },
-  { id: "e4", severity: "info", messageKey: "events.e4", timestamp: "2026-06-21T02:00:00Z" },
-  { id: "e5", severity: "critical", messageKey: "events.e5", timestamp: "2026-06-20T22:31:00Z" },
-];
-
 function fmt(s: string, locale: string) {
   return new Date(s).toLocaleString(locale, {
     month: "2-digit",
@@ -96,14 +88,8 @@ export default function AdminAlertsPage() {
   const t = useTranslations("adminAlerts");
   const locale = toBcp47(useLocale());
   const [rules, setRules] = useState<AlertRule[]>(RULES);
-  const [events, setEvents] = useState<AlertEvent[]>(() =>
-    MOCK_EVENTS.map((e) => ({
-      id: e.id,
-      severity: e.severity,
-      message: t(e.messageKey),
-      timestamp: e.timestamp,
-    })),
-  );
+  // 실데이터만 표시 — alert_history 응답이 비면 빈 상태(t("empty"))로 둔다.
+  const [events, setEvents] = useState<AlertEvent[]>([]);
   const [acknowledged, setAcknowledged] = useState<Set<string>>(new Set());
   const [ackLoading, setAckLoading] = useState<Set<string>>(new Set());
 
@@ -207,6 +193,7 @@ export default function AdminAlertsPage() {
             </CardHeader>
             <CardContent>
               <ol className="relative space-y-4 border-l border-border pl-5">
+                {events.length === 0 && <li className="py-4 text-sm text-muted">{t("empty")}</li>}
                 {events.map((e) => {
                   const Icon = SEV_ICON[e.severity];
                   const isAcked = acknowledged.has(e.id);

--- a/apps/web/app/(workspace)/admin/audit/page.tsx
+++ b/apps/web/app/(workspace)/admin/audit/page.tsx
@@ -41,18 +41,6 @@ const SEV_LABEL_KEY: Record<Severity, string> = {
   info: "status.info",
 };
 
-// TODO: API 연동 (/api/audit) — 응답 실패 시 폴백 목업
-const MOCK_LOGS: AuditLog[] = [
-  { id: "a1", timestamp: "2026-06-21T03:42:11Z", actor: "devops@partner.co.kr", action: "user.delete", target: "u_1031", severity: "critical", ip: "203.0.113.41" },
-  { id: "a2", timestamp: "2026-06-21T03:31:05Z", actor: "system", action: "llm.context_overflow", target: "conv_88412", severity: "warn", ip: "127.0.0.1" },
-  { id: "a3", timestamp: "2026-06-21T02:58:47Z", actor: "minji.kim@openmake.io", action: "apikey.create", target: "key_7f3a", severity: "info", ip: "211.45.12.9" },
-  { id: "a4", timestamp: "2026-06-21T02:40:22Z", actor: "devops@partner.co.kr", action: "user.role_change", target: "u_1040 → admin", severity: "critical", ip: "203.0.113.41" },
-  { id: "a5", timestamp: "2026-06-21T01:55:10Z", actor: "system", action: "alert.dispatched", target: "rule_cpu_high", severity: "warn", ip: "127.0.0.1" },
-  { id: "a6", timestamp: "2026-06-21T01:12:33Z", actor: "sangho.park@openmake.io", action: "auth.login", target: "session_a91", severity: "info", ip: "118.32.74.201" },
-  { id: "a7", timestamp: "2026-06-20T23:48:01Z", actor: "research.lab@yonsei.ac.kr", action: "mcp.server_register", target: "srv_filesystem", severity: "info", ip: "166.104.5.18" },
-  { id: "a8", timestamp: "2026-06-20T22:30:55Z", actor: "system", action: "auth.failed_attempt", target: "unknown@spam.io", severity: "warn", ip: "45.33.21.7" },
-];
-
 const ALL_ACTIONS = "__all__";
 const ACTIONS = [ALL_ACTIONS, "user.delete", "user.role_change", "apikey.create", "auth.login", "auth.failed_attempt", "mcp.server_register", "llm.context_overflow", "alert.dispatched"];
 const SEVERITIES: { key: "all" | Severity; labelKey: string }[] = [
@@ -94,7 +82,8 @@ interface ApiAuditLog {
 export default function AdminAuditPage() {
   const t = useTranslations("adminAudit");
   const locale = toBcp47(useLocale());
-  const [logs, setLogs] = useState<AuditLog[]>(MOCK_LOGS);
+  // 실데이터만 표시 — API 응답이 비면 빈 상태(t("empty"))로 둔다.
+  const [logs, setLogs] = useState<AuditLog[]>([]);
   const [action, setAction] = useState(ALL_ACTIONS);
   const [severity, setSeverity] = useState<"all" | Severity>("all");
   const [period, setPeriod] = useState("days7");

--- a/apps/web/app/(workspace)/admin/page.tsx
+++ b/apps/web/app/(workspace)/admin/page.tsx
@@ -47,14 +47,6 @@ const ROLE_TONE: Record<string, "danger" | "success" | "neutral"> = {
   guest: "neutral",
 };
 
-const MOCK_USERS: AdminUser[] = [
-  { id: "u_1042", email: "minji.kim@openmake.io", role: "user", is_active: true, created_at: "2026-06-19T09:12:00Z", last_login: "2026-06-21T02:30:00Z" },
-  { id: "u_1041", email: "devops@partner.co.kr", role: "admin", is_active: true, created_at: "2026-06-18T15:40:00Z", last_login: "2026-06-20T22:05:00Z" },
-  { id: "u_1040", email: "guest.trial+93@gmail.com", role: "guest", is_active: false, created_at: "2026-06-18T11:03:00Z", last_login: null },
-  { id: "u_1039", email: "research.lab@yonsei.ac.kr", role: "user", is_active: true, created_at: "2026-06-17T08:22:00Z", last_login: "2026-06-21T01:11:00Z" },
-  { id: "u_1038", email: "sangho.park@openmake.io", role: "user", is_active: true, created_at: "2026-06-16T19:55:00Z", last_login: "2026-06-20T13:48:00Z" },
-];
-
 function fmtDate(s?: string | null) {
   if (!s) return "-";
   const d = new Date(s);
@@ -282,8 +274,9 @@ function DeleteUserModal({
 
 export default function AdminPage() {
   const t = useTranslations("admin");
-  const [users, setUsers] = useState<AdminUser[]>(MOCK_USERS);
-  const [stats, setStats] = useState({ total: 1042, active: 318, today: 4821, status: t("statusNormal") });
+  // 실데이터만 표시 — API 응답 전/실패 시 가짜 값을 실적처럼 보여주지 않는다.
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [stats, setStats] = useState({ total: 0, active: 0, today: 0, status: t("statusNormal") });
   const [guardianPending, setGuardianPending] = useState<GuardianPending[]>([]);
   const [approvingIds, setApprovingIds] = useState<Set<string>>(new Set());
 
@@ -435,6 +428,13 @@ export default function AdminPage() {
                 </tr>
               </thead>
               <tbody>
+                {users.length === 0 && (
+                  <tr>
+                    <Td className="py-8 text-center text-muted" colSpan={7}>
+                      {t("empty")}
+                    </Td>
+                  </tr>
+                )}
                 {users.map((u) => (
                   <tr key={u.id}>
                     <Td className="font-mono text-xs text-muted">{u.id}</Td>

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1127,7 +1127,8 @@
       "actions": "Actions",
       "edit": "Edit",
       "delete": "Delete"
-    }
+    },
+    "empty": "No users to display."
   },
   "adminAnalytics": {
     "title": "Analytics",
@@ -1288,13 +1289,7 @@
         "condition": "user.role_change → admin"
       }
     },
-    "events": {
-      "e1": "Admin privilege grant detected — u_1040 (by devops@partner.co.kr)",
-      "e2": "redis-kv node load 78% — may affect rate-limit consistency",
-      "e3": "1 LLM context overflow — truncation applied to conv_88412",
-      "e4": "Daily backup complete — postgres-primary (2.1GB)",
-      "e5": "12 abnormal login attempts — 45.33.21.7 blocked"
-    }
+    "empty": "No recent alerts."
   },
   "adminMcpCatalog": {
     "close": "Close",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1127,7 +1127,8 @@
       "actions": "操作",
       "edit": "編集",
       "delete": "削除"
-    }
+    },
+    "empty": "表示するユーザーがありません。"
   },
   "adminAnalytics": {
     "title": "アナリティクス",
@@ -1288,13 +1289,7 @@
         "condition": "user.role_change → admin"
       }
     },
-    "events": {
-      "e1": "管理者権限の付与を検知 — u_1040（devops@partner.co.kr が実行）",
-      "e2": "redis-kvノード負荷78% — rate-limit整合性に影響の可能性",
-      "e3": "LLMコンテキストオーバーフロー1件 — conv_88412にtruncate適用",
-      "e4": "日次バックアップ完了 — postgres-primary（2.1GB）",
-      "e5": "異常なログイン試行12回 — 45.33.21.7をブロック"
-    }
+    "empty": "最近発生したアラートはありません。"
   },
   "adminMcpCatalog": {
     "close": "閉じる",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1127,7 +1127,8 @@
       "actions": "액션",
       "edit": "편집",
       "delete": "삭제"
-    }
+    },
+    "empty": "표시할 사용자가 없습니다."
   },
   "adminAnalytics": {
     "title": "애널리틱스",
@@ -1288,13 +1289,7 @@
         "condition": "user.role_change → admin"
       }
     },
-    "events": {
-      "e1": "관리자 권한 부여 감지 — u_1040 (devops@partner.co.kr 수행)",
-      "e2": "redis-kv 노드 부하 78% — rate-limit 정합 영향 가능",
-      "e3": "LLM 컨텍스트 오버플로 1건 — conv_88412 truncate 적용",
-      "e4": "일일 백업 완료 — postgres-primary (2.1GB)",
-      "e5": "비정상 로그인 시도 12회 — 45.33.21.7 차단됨"
-    }
+    "empty": "최근 발생한 알림이 없습니다."
   },
   "adminMcpCatalog": {
     "close": "닫기",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1127,7 +1127,8 @@
       "actions": "操作",
       "edit": "编辑",
       "delete": "删除"
-    }
+    },
+    "empty": "没有可显示的用户。"
   },
   "adminAnalytics": {
     "title": "分析",
@@ -1288,13 +1289,7 @@
         "condition": "user.role_change → admin"
       }
     },
-    "events": {
-      "e1": "检测到管理员权限授予 — u_1040（由 devops@partner.co.kr 执行）",
-      "e2": "redis-kv 节点负载 78% — 可能影响限流一致性",
-      "e3": "1 次 LLM 上下文溢出 — 已对 conv_88412 应用截断",
-      "e4": "每日备份完成 — postgres-primary（2.1GB）",
-      "e5": "12 次异常登录尝试 — 已封禁 45.33.21.7"
-    }
+    "empty": "暂无最近告警。"
   },
   "adminMcpCatalog": {
     "close": "关闭",

--- a/db/init/003-seed.sql
+++ b/db/init/003-seed.sql
@@ -1,17 +1,10 @@
 -- ============================================
--- OpenMake.Ai - Default Admin User
--- Password: admin123 (bcrypt hashed)
+-- OpenMake.Ai - Seed Data
 -- ============================================
-
-INSERT INTO users (id, username, password_hash, email, role, is_active)
-VALUES (
-    'admin-default-001',
-    'admin',
-    '$2a$10$8K1p/a0dR1xqM0eGJi.sDOQP4RGIhBhEW2.HfGR7BjmJqC6V1Kyuy',
-    'admin@openmake.ai',
-    'admin',
-    TRUE
-) ON CONFLICT (username) DO NOTHING;
+-- 초기 관리자 계정은 이 파일에서 만들지 않는다 — 고정 비밀번호를 저장소에 두면
+-- 모든 배포가 같은 자격증명으로 열리기 때문. 생성은 004-admin-user.sh 가
+-- ADMIN_INITIAL_PASSWORD 환경변수를 받아 처리한다.
+-- ============================================
 
 -- ============================================
 -- 🔌 Default MCP Server: noapi-google-search-mcp

--- a/db/init/004-admin-user.sh
+++ b/db/init/004-admin-user.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# ============================================
+# OpenMake.Ai - 초기 관리자 계정 (빈 볼륨 첫 기동 시 1회)
+# ============================================
+# 고정 비밀번호를 저장소에 두지 않기 위해 SQL 시드에서 분리했다. 해시는
+# pgcrypto 의 crypt(pw, gen_salt('bf', 10)) 로 만들며 앱의 bcryptjs.compare
+# (user-manager.ts) 와 호환되는 $2a$ 포맷이다.
+#
+# 필요 환경변수 (infra/docker-compose.yml 이 .env 에서 전달):
+#   ADMIN_INITIAL_PASSWORD   미설정 시 계정을 만들지 않고 건너뛴다
+#   ADMIN_INITIAL_USERNAME   기본 admin
+#   ADMIN_INITIAL_EMAIL      기본 admin@openmake.ai
+set -euo pipefail
+
+if [ -z "${ADMIN_INITIAL_PASSWORD:-}" ]; then
+  echo "[004-admin-user] ADMIN_INITIAL_PASSWORD 미설정 — 초기 관리자 계정을 만들지 않습니다."
+  echo "[004-admin-user] 계정이 필요하면 .env 에 설정 후 빈 볼륨으로 재초기화하세요."
+  exit 0
+fi
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" \
+  -v username="${ADMIN_INITIAL_USERNAME:-admin}" \
+  -v email="${ADMIN_INITIAL_EMAIL:-admin@openmake.ai}" \
+  -v password="$ADMIN_INITIAL_PASSWORD" <<'SQL'
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+INSERT INTO users (id, username, password_hash, email, role, is_active)
+VALUES (
+    'admin-default-001',
+    :'username',
+    crypt(:'password', gen_salt('bf', 10)),
+    :'email',
+    'admin',
+    TRUE
+) ON CONFLICT (username) DO NOTHING;
+SQL
+
+echo "[004-admin-user] 초기 관리자 계정 생성 완료: ${ADMIN_INITIAL_USERNAME:-admin}"

--- a/db/migrations/037_mcp_catalog_open_design.sql
+++ b/db/migrations/037_mcp_catalog_open_design.sql
@@ -6,8 +6,9 @@
 --       조회하고(get_artifact/list_projects) 완성 디자인을 워크스페이스에 저장
 --       (create_artifact/write_file)하는 UI/UX 디자인 도구로 사용된다.
 --
--- command_template 의 절대 경로는 배포 환경(L3 DB 설정) 값 — 다른 머신에 배포
--- 시 admin 콘솔(POST/PUT /admin/mcp/catalog)에서 경로를 수정한다.
+-- command_template 의 경로는 배포 환경(L3 DB 설정) 값이라 머신마다 다르다. 여기서는
+-- 중립 플레이스홀더로 시드하고, 실제 경로는 admin 콘솔(POST/PUT /admin/mcp/catalog)
+-- 에서 해당 머신의 Open Design 설치 경로로 교체한다.
 --
 -- ON CONFLICT (id) DO NOTHING 으로 멱등 — admin 수정 사항 보존.
 -- ============================================================
@@ -21,9 +22,9 @@ INSERT INTO mcp_server_catalog (
     'Open Design',
     '로컬 디자인 워크스페이스 (Open Design). 프로젝트의 디자인 토큰·컴포넌트·아티팩트를 조회하고 HTML/JSX/CSS 디자인 산출물을 저장. UI/UX 디자인 작업 시 디자인 언어 일관성 유지에 활용.',
     'stdio',
-    '/Users/openmake_mac/.local/share/mise/installs/node/24.16.0/bin/node /Users/openmake_mac/open-design/apps/daemon/dist/cli.js mcp',
+    'node <OPEN_DESIGN_HOME>/apps/daemon/dist/cli.js mcp',
     '{}'::jsonb,
-    '{"type": "object", "required": ["OD_DATA_DIR"], "properties": {"OD_DATA_DIR": {"type": "string", "title": "데이터 디렉토리", "description": "Open Design 데이터 디렉토리 (기본: /Users/openmake_mac/open-design/.od)"}}}'::jsonb,
+    '{"type": "object", "required": ["OD_DATA_DIR"], "properties": {"OD_DATA_DIR": {"type": "string", "title": "데이터 디렉토리", "description": "Open Design 데이터 디렉토리 (예: <OPEN_DESIGN_HOME>/.od)"}}}'::jsonb,
     'pro',
     TRUE
 )

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -26,6 +26,10 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-openmake}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD 를 .env 에 설정하세요 (DATABASE_URL 비번과 동일)}
       POSTGRES_DB: ${POSTGRES_DB:-openmake_llm}
+      # 초기 관리자 계정 (004-admin-user.sh). 미설정 시 계정을 만들지 않는다.
+      ADMIN_INITIAL_PASSWORD: ${ADMIN_INITIAL_PASSWORD:-}
+      ADMIN_INITIAL_USERNAME: ${ADMIN_INITIAL_USERNAME:-admin}
+      ADMIN_INITIAL_EMAIL: ${ADMIN_INITIAL_EMAIL:-admin@openmake.ai}
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:


### PR DESCRIPTION
## 배경

공개 저장소(★22 / fork 3) 전수 감사에서 나온 노출 항목을 제거한다. **실제 API 키·토큰 리터럴은 0건**이었고(히스토리의 `backend/api/.env.test`도 플레이스홀더뿐), 문제는 목업 데이터와 시드에 있었다.

## 1. 관리자 화면 목업의 개인 식별자

`MOCK_USERS` / `MOCK_LOGS` / `MOCK_EVENTS` 가 실존 가능한 이메일(개인 이름 형태 사내 주소, 대학·협력사 도메인, gmail)과 **실제 라우팅 가능한 IP**(`211.45.12.9`, `118.32.74.201`, `166.104.5.18`, `45.33.21.7`)를 담고 있었다. 목업 자체를 제거했다.

부수 효과로 오표시 문제도 사라진다 — 목업이 `useState` 초기값이라 API가 빈 응답을 주면 가짜 사용자·감사로그·알림·통계(`1042`/`318`/`4821`)가 실데이터처럼 관리자 화면에 남아 있었다. 이제 실데이터만 표시하고 비면 빈 상태 문구를 보여준다.

알림 **규칙 목록(`RULES`)은 백엔드 CRUD가 없어 의도된 목업**이므로 유지했다(개인정보 없음).

## 2. 시드의 고정 관리자 자격증명

`db/init/003-seed.sql` 에 모든 배포가 공유하는 `admin` / `admin123` 이 bcrypt 해시로 들어가 있고 주석에 평문까지 적혀 있었다. 계정 생성을 `004-admin-user.sh` 로 분리하고 `ADMIN_INITIAL_PASSWORD` 로 환경변수화했다. 미설정이면 계정을 만들지 않는다.

해시는 `pgcrypto` 의 `crypt(pw, gen_salt('bf', 10))` 로 생성하며 앱의 `bcryptjs.compare`(`user-manager.ts`)와 호환되는 `$2a$` 포맷이다.

## 3. 개인 로컬 경로

`db/migrations/037` 의 `/Users/openmake_mac/...` 3곳을 `<OPEN_DESIGN_HOME>` 플레이스홀더로 교체했다. 실제 경로는 파일 주석에 이미 있던 안내대로 admin 콘솔에서 설정한다. 적용 완료된 마이그레이션이라 기존 DB에는 영향이 없다(신규 설치에만 반영).

## 유지 판정

`/home/smith`(scripts/vllm)·`/Volumes/MAC_APP`(infra·caddy)는 CLAUDE.md에 문서화된 배포 자산이라 운영에 필요하므로 유지했다. 히스토리의 `openai_node/` 537개 파일(외부 SDK 통째 커밋 후 삭제)은 현재 tracked 0, 저장소 30MB, 오픈소스라 비밀도 아니어서 **히스토리 재작성은 하지 않는다** — fork 3개와 기존 클론을 깨뜨리는 대가가 더 크다.

## 검증

- 임시 `postgres:16` 컨테이너로 init 전 과정 2회 실행: 비밀번호 설정 시 계정 생성 + 생성된 해시가 `bcryptjs.compare` 로 검증/거부 정상, 미설정 시 `users` 0건으로 건너뜀. 컨테이너는 삭제함(운영 DB 무관)
- `npx tsc --noEmit` (apps/web) 통과
- i18n 4개 언어 키 정합 확인 (누락·추가 0)
- 제거 대상 식별자 전량 `git grep` 0건

## 배포 메모

`apps/web/messages/*` 가 바뀌었으므로 운영 반영 시 `npm run build:frontend-next` + 재시작이 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)