### PR TITLE
fix(security): 소스 보안 감사 수정 13건 — IDOR·RCE·SSRF·인증·CSRF·하드닝

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -370,9 +370,9 @@ COOKIE_SECURE=false
 
 # CSRF Double-Submit Cookie 정책:
 #   off     = 검증 비활성
-#   warn    = 불일치 로깅만, 요청 통과 (기본, 롤아웃 모니터링용)
-#   enforce = 불일치 시 403 반환
-# CSRF_PROTECTION=warn
+#   warn    = 불일치 로깅만, 요청 통과 (롤아웃 모니터링용)
+#   enforce = 불일치 시 403 반환 (기본 — 프론트가 X-CSRF-Token 자동 주입)
+# CSRF_PROTECTION=enforce
 
 # Shared Storage 백엔드 (rate limiter, OAuth state, per-user 토큰 쿼터):
 #   memory = per-instance in-memory (기본, 단일 인스턴스 배포)

--- a/apps/api/src/auth/auth-core.ts
+++ b/apps/api/src/auth/auth-core.ts
@@ -13,6 +13,7 @@
  */
 
 import * as jwt from 'jsonwebtoken';
+import type { Algorithm } from 'jsonwebtoken';
 import type { Response } from 'express';
 import { JWTPayload } from './types';
 import { PublicUser, UserRole } from '../data/user-manager';
@@ -178,7 +179,8 @@ export async function verifyRefreshToken(token: string): Promise<JWTPayload | nu
              return null;
          }
 
-         const decoded = jwt.verify(token, JWT_SECRET);
+         // algorithms 화이트리스트 고정(HS256) — alg 혼동 공격 방어(sign 은 대칭 HS256).
+         const decoded = jwt.verify(token, JWT_SECRET, { algorithms: ['HS256'] as Algorithm[] });
          if (!isValidJWTPayload(decoded)) {
              logger.warn('JWT 페이로드 형식 불일치');
              return null;
@@ -222,7 +224,8 @@ export async function verifyToken(token: string): Promise<JWTPayload | null> {
              return null;
          }
 
-         const decoded = jwt.verify(token, JWT_SECRET);
+         // algorithms 화이트리스트 고정(HS256) — alg 혼동 공격 방어(sign 은 대칭 HS256).
+         const decoded = jwt.verify(token, JWT_SECRET, { algorithms: ['HS256'] as Algorithm[] });
          if (!isValidJWTPayload(decoded)) {
              logger.warn('JWT 페이로드 형식 불일치');
              return null;

--- a/apps/api/src/config/artifact-viewer.ts
+++ b/apps/api/src/config/artifact-viewer.ts
@@ -30,9 +30,10 @@ export const ARTIFACT_VIEWER = {
     /**
      * 뷰어 접근토큰(authenticated/private) 서명 키 — HMAC-SHA256.
      * link visibility 는 share_token(DB) 사용, 그 외는 이 키로 서명한 단기 토큰.
-     * 미설정 시 JWT_SECRET 재사용(별도 운영 키 권장).
+     * 미설정 시 JWT_SECRET 재사용(별도 운영 키 권장). 예측 가능한 하드코딩 fallback 은
+     * 제거 — 토큰 위조를 막기 위해 JWT_SECRET(프로덕션 필수·검증됨)을 최종 fallback 으로 둔다.
      */
-    signingKey: process.env.ARTIFACT_VIEWER_SIGNING_KEY || process.env.JWT_SECRET || 'dev-viewer-key',
+    signingKey: process.env.ARTIFACT_VIEWER_SIGNING_KEY || process.env.JWT_SECRET || '',
 
     /** authenticated/private 접근토큰 TTL (초). 갤러리에서 열 때마다 새로 발급. */
     accessTokenTtlSec: parseInt(process.env.ARTIFACT_VIEWER_TOKEN_TTL_SEC || '3600', 10),

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -74,8 +74,8 @@ export const envSchema = z
 
         // Security — CSRF Double-Submit Cookie policy (additive)
         // off: disabled / warn: log mismatches, allow / enforce: 403 on mismatch
-        // default 'warn' enables monitoring from deploy without breaking existing clients
-        CSRF_PROTECTION: z.enum(['off', 'warn', 'enforce']).default('warn'),
+        // default 'enforce' — 프론트가 X-CSRF-Token 을 자동 주입(@openmake/api-client). 완화 필요 시 warn.
+        CSRF_PROTECTION: z.enum(['off', 'warn', 'enforce']).default('enforce'),
 
         // Storage backend for rate-limiter and OAuth state (additive; default preserves single-instance)
         // memory: per-instance in-memory (current behavior) / redis: shared across instances

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -245,8 +245,10 @@ const DEFAULT_CONFIG: EnvConfig = {
     // Security — Blacklist Policy (additive; 'open' maintains legacy fail-open behavior)
     blacklistFailMode: 'open' as const,
 
-    // Security — CSRF Double-Submit Cookie (additive; 'warn' logs without blocking)
-    csrfProtection: 'warn' as const,
+    // Security — CSRF Double-Submit Cookie. 프론트(@openmake/api-client)가 mutating 요청에
+    // X-CSRF-Token 을 자동 주입하고 SSE/WS 도 csrfHeaders 를 붙이므로 기본 'enforce'.
+    // 문제 발생 시 CSRF_PROTECTION=warn 으로 즉시 완화 가능.
+    csrfProtection: 'enforce' as const,
 
     // Storage — default memory preserves single-instance in-memory behavior
     storageBackend: 'memory' as const,

--- a/apps/api/src/config/local-models.ts
+++ b/apps/api/src/config/local-models.ts
@@ -225,7 +225,7 @@ async function pingEmbeddingModel(
  *   - Stage 2 ping 실패한 모델: available=false (demote)
  *   - 카탈로그의 explicit available=false 모델: ping 시도조차 안 함 (운영자가 명시적 비활성)
  *
- * @param llmBaseUrl proxy base URL (예: http://rockyhan.duckdns.org:13401)
+ * @param llmBaseUrl proxy base URL (예: http://<llm-host>:13401)
  * @param apiKey proxy API key (LLM_API_KEY)
  * @param timeoutMs ping 호출 timeout (default 8초)
  */

--- a/apps/api/src/config/timeouts.ts
+++ b/apps/api/src/config/timeouts.ts
@@ -166,13 +166,13 @@ export const WEBSOCKET_TIMEOUTS = {
  */
 export const WS_LIMITS = {
     /**
-     * WebSocket 프레임 최대 페이로드 (bytes). **0 = 무제한**(ws 는 maxPayload>0 일 때만 검사).
-     * 파일/이미지 업로드 용량 제한을 두지 않기 위해 기본 0(무제한). 단, 무제한은 거대 프레임이
-     * 서버 메모리를 한 번에 점유할 수 있으므로(OOM/DoS 여지), 운영상 상한이 필요하면
-     * 환경변수 WS_MAX_PAYLOAD_BYTES 에 바이트 수를 지정해 재설정한다(예: 67108864=64MB).
-     * 프론트 가드(chat.js WS_MAX_PAYLOAD_BYTES)도 0=무제한 sentinel 로 정합.
+     * WebSocket 프레임 최대 페이로드 (bytes). ws 는 maxPayload>0 일 때만 프레임 단위로 검사한다.
+     * 기본 128MB — 거대 프레임이 char 검사(MAX_MESSAGE_CHARS, 64MB) 이전에 서버 메모리를
+     * 무제한 점유하는 OOM/DoS 를 ws 계층에서 1차 차단한다. base64 첨부(1 byte/char)가 64MB char
+     * 한도를 통과할 때의 바이트 크기를 넉넉히 상회하므로 정상 첨부는 거부되지 않는다.
+     * 무제한이 필요하면 WS_MAX_PAYLOAD_BYTES=0, 다른 상한은 바이트 수로 재설정한다.
      */
-    MAX_PAYLOAD_BYTES: process.env.WS_MAX_PAYLOAD_BYTES !== undefined ? Number(process.env.WS_MAX_PAYLOAD_BYTES) : 0,
+    MAX_PAYLOAD_BYTES: process.env.WS_MAX_PAYLOAD_BYTES !== undefined ? Number(process.env.WS_MAX_PAYLOAD_BYTES) : 128 * 1024 * 1024,
     /**
      * 단일 메시지 문자열 최대 길이(chars). MAX_PAYLOAD_BYTES(0=무제한 sentinel)와 별개로,
      * 메시지 핸들러가 raw.length 로 거대 텍스트 프레임을 즉시 거부하는 가드.

--- a/apps/api/src/controllers/auth-oauth.controller.ts
+++ b/apps/api/src/controllers/auth-oauth.controller.ts
@@ -270,11 +270,13 @@ export class AuthOAuthController {
                     }
                 });
                 const emails = await emailRes.json() as GitHubEmail[];
-                const primaryEmail = emails.find(e => e.primary);
+                // 🔒 verified 된 primary 이메일만 신뢰 — Google(email_verified)/Kakao(is_email_verified)
+                //   와 대칭. 미검증 이메일로 기존 계정과 병합되는 계정 탈취를 차단한다.
+                const primaryEmail = emails.find(e => e.primary && e.verified);
                 // BUG-R3-003: 가짜 @github.local 도메인 대신 이메일 비공개 사용자는 로그인 거부
-                // primary 이메일이 없으면 OAuth 프로필에서 public 이메일 사용, 그것도 없으면 거부
+                // 검증된 primary 이메일이 없으면 거부(공개 이메일 없거나 미검증 포함)
                 if (!primaryEmail?.email) {
-                    log.warn(`[OAuth GitHub] 이메일 비공개 사용자 로그인 거부: login=${githubUser.login}`);
+                    log.warn(`[OAuth GitHub] 검증된 primary 이메일 없음 — 로그인 거부: login=${githubUser.login}`);
                     res.redirect('/login?error=email_required');
                     return;
                 }

--- a/apps/api/src/controllers/cluster.controller.ts
+++ b/apps/api/src/controllers/cluster.controller.ts
@@ -7,6 +7,7 @@
 
 import { Request, Response, Router } from 'express';
 import { ClusterManager, getClusterManager } from '../cluster/manager';
+import { requireAuth, requireAdmin } from '../auth';
 import { success } from '../utils/api-response';
 
 /**
@@ -35,6 +36,10 @@ export class ClusterController {
     }
 
     private setupRoutes(): void {
+        // 🔒 내부 노드 토폴로지(host:port)·모델 카탈로그를 노출하므로 admin 전용으로 게이트한다.
+        //   /api/nodes 와 동일 정책. (구 cluster.html 전용이었고 현재 프론트는 미사용)
+        this.router.use(requireAuth, requireAdmin);
+
         // 클러스터 전체 정보
         this.router.get('/', this.getClusterInfo.bind(this));
 

--- a/apps/api/src/controllers/session.controller.ts
+++ b/apps/api/src/controllers/session.controller.ts
@@ -16,6 +16,32 @@ import { historySummaryCache } from '../services/chat-service/history-summary-ca
 const log = createLogger('SessionController');
 
 /**
+ * 세션 접근 권한 판정 (순수 함수 — 단위 테스트 가능).
+ *
+ * ⚠️ 양쪽 비교값이 truthy 일 때만 매칭한다. session 의 userId/anonSessionId 는 서로
+ * 배타적이라 항상 한쪽이 undefined 이고, 요청측도 미인증·무파라미터면 둘 다 undefined 라
+ * `undefined === undefined` 로 통과하는 IDOR 가 발생한다 (artifact-session-access.ts 와 동일 가드).
+ */
+export function evaluateSessionAccess(
+    session: Pick<ConversationSession, 'userId' | 'anonSessionId'> | undefined,
+    ctx: { userId?: string; anonSessionId?: string; isAdmin: boolean },
+): boolean {
+    if (ctx.isAdmin) {
+        return true;
+    }
+    if (!session) {
+        return false;
+    }
+    if (ctx.userId && session.userId === ctx.userId) {
+        return true;
+    }
+    if (ctx.anonSessionId && session.anonSessionId === ctx.anonSessionId) {
+        return true;
+    }
+    return false;
+}
+
+/**
  * 대화 세션 관리 컨트롤러
  * 
  * @class SessionController
@@ -41,22 +67,12 @@ export class SessionController {
 
     private setupRoutes(): void {
         const conversationDb = getConversationDB();
-        const hasSessionAccess = (session: ConversationSession | undefined, req: Request): boolean => {
-            if (req.user?.role === 'admin') {
-                return true;
-            }
-
-            if (!session) {
-                return false;
-            }
-
-            const requestUserId = req.user?.id ? String(req.user.id) : undefined;
-            const requestAnonSessionId = typeof req.query.anonSessionId === 'string'
-                ? req.query.anonSessionId
-                : undefined;
-
-            return session.userId === requestUserId || session.anonSessionId === requestAnonSessionId;
-        };
+        const hasSessionAccess = (session: ConversationSession | undefined, req: Request): boolean =>
+            evaluateSessionAccess(session, {
+                userId: req.user?.id ? String(req.user.id) : undefined,
+                anonSessionId: typeof req.query.anonSessionId === 'string' ? req.query.anonSessionId : undefined,
+                isAdmin: req.user?.role === 'admin',
+            });
 
          // 세션 목록 조회 (사용자 격리 적용)
          this.router.get('/', optionalAuth, asyncHandler(async (req: Request, res: Response) => {

--- a/apps/api/src/mcp/external-client.ts
+++ b/apps/api/src/mcp/external-client.ts
@@ -29,6 +29,7 @@ import type { MCPServerConfig, MCPConnectionStatus, MCPTool, MCPToolResult } fro
 import { buildSandboxedCommand } from './sandbox-docker';
 import { isConnectionDeathError } from './tool-error-classifier';
 import { createLogger } from '../utils/logger';
+import { createPinnedFetch } from '../security/ssrf-guard';
 
 const logger = createLogger('ExternalMCP');
 
@@ -337,13 +338,15 @@ export class ExternalMCPClient extends EventEmitter {
                 if (!this.config.url) {
                     throw new Error(`SSE transport requires "url" for server "${this.config.name}"`);
                 }
-                return new SSEClientTransport(new URL(this.config.url));
+                // 🔒 SSRF: URL 은 등록 시 1회만 검증되므로, 런타임 network 는 매번 재검증 + resolved IP
+                //   고정하는 fetch 로 DNS Rebinding(TOCTOU)을 차단한다.
+                return new SSEClientTransport(new URL(this.config.url), { fetch: createPinnedFetch() });
             }
             case 'streamable-http': {
                 if (!this.config.url) {
                     throw new Error(`streamable-http transport requires "url" for server "${this.config.name}"`);
                 }
-                return new StreamableHTTPClientTransport(new URL(this.config.url));
+                return new StreamableHTTPClientTransport(new URL(this.config.url), { fetch: createPinnedFetch() });
             }
             default:
                 throw new Error(`Unknown transport type: ${this.config.transport_type}`);

--- a/apps/api/src/mcp/sandbox-docker.ts
+++ b/apps/api/src/mcp/sandbox-docker.ts
@@ -24,9 +24,6 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
-import { createLogger } from '../utils/logger';
-
-const logger = createLogger('McpSandbox');
 
 /** 'full'=bridge, 'none'=--network none, 'host'=컨테이너 없이 호스트 직접 실행(opt-out) */
 export type SandboxNetwork = 'full' | 'none' | 'host';
@@ -151,13 +148,6 @@ export function buildDockerArgs(input: SandboxInput, cfg: SandboxConfig): string
     return a;
 }
 
-const warned = new Set<string>();
-function warnOnce(key: string, msg: string): void {
-    if (warned.has(key)) return;
-    warned.add(key);
-    logger.warn(msg);
-}
-
 /**
  * 외부 MCP stdio command 를 docker run 으로 감싼다. 게이트 미충족 시 원본 그대로(no-op).
  * sandboxed=true 이면 env 는 args(-e)에 baked 되므로 호출자는 StdioClientTransport env 를 비워야 한다.
@@ -168,8 +158,12 @@ export function buildSandboxedCommand(input: SandboxInput, cfg: SandboxConfig = 
     if (input.network === 'host') return { command: input.command, args: input.args, sandboxed: false };
     if (!cfg.enabled) return { command: input.command, args: input.args, sandboxed: false };
     if (!cfg.dockerPath) {
-        warnOnce('docker', 'docker 바이너리를 찾지 못해 MCP 샌드박스 미적용(비격리 실행). Docker 설치/실행 확인 필요.');
-        return { command: input.command, args: input.args, sandboxed: false };
+        // fail-closed: 샌드박스가 명시적으로 활성(cfg.enabled)인데 docker 가 없으면 비격리로 조용히
+        // 실행하지 않고 spawn 을 거부한다. 격리를 요구한 서버를 unsandboxed 로 돌리는 fail-open 은
+        // "격리했다"는 오인을 준다. host 네트워크 opt-out(신뢰 서버)은 위에서 이미 통과했고,
+        // 비격리가 필요하면 MCP_SANDBOX_ENABLED=false 또는 서버별 sandbox_network='host' 로 명시한다.
+        // (throw 는 external-client.connect 의 catch 에서 연결 error 로 처리 — 서버 크래시 아님)
+        throw new Error('MCP 샌드박스가 활성화(MCP_SANDBOX_ENABLED)됐으나 docker 바이너리를 찾을 수 없습니다. 비격리 실행을 거부합니다 — Docker 설치/실행을 확인하거나 sandbox_network=host 로 opt-out 하세요.');
     }
     const dockerArgs = buildDockerArgs(input, cfg);
     return { command: cfg.dockerPath, args: dockerArgs, sandboxed: true };

--- a/apps/api/src/middlewares/chat-rate-limiter.ts
+++ b/apps/api/src/middlewares/chat-rate-limiter.ts
@@ -212,12 +212,22 @@ export function chatRateLimiter(req: Request, res: Response, next: NextFunction)
 export async function checkChatRateLimit(
     userId: string | null,
     role: string,
-    anonSessionId?: string
+    anonSessionId?: string,
+    clientIp?: string
 ): Promise<string | null> {
     const normalizedAnonSessionId = typeof anonSessionId === 'string' ? anonSessionId.trim() : '';
-    const anonKey = /^[a-zA-Z0-9_-]{8,128}$/.test(normalizedAnonSessionId)
-        ? `anon:${normalizedAnonSessionId}`
-        : 'ws-anonymous';
+    const normalizedIp = typeof clientIp === 'string' ? clientIp.trim() : '';
+    // 게스트 키는 IP 를 우선한다 — anonSessionId 는 클라이언트가 생성/회전할 수 있어 일일 한도를
+    // 리셋하는 우회가 가능했다. IP 가 있으면 IP 로 묶어(회전해도 같은 IP 는 동일 버킷) 비용 남용을 막고,
+    // IP 를 못 얻는 경우에만 기존 anonSessionId 기반으로 폴백한다.
+    let anonKey: string;
+    if (normalizedIp) {
+        anonKey = `anon:ip:${normalizedIp}`;
+    } else if (/^[a-zA-Z0-9_-]{8,128}$/.test(normalizedAnonSessionId)) {
+        anonKey = `anon:${normalizedAnonSessionId}`;
+    } else {
+        anonKey = 'ws-anonymous';
+    }
     const key = userId || anonKey;
     const limit = getDailyLimit(role);
 

--- a/apps/api/src/middlewares/setup.ts
+++ b/apps/api/src/middlewares/setup.ts
@@ -118,7 +118,6 @@ export function setupParsersAndLimiting(app: Application): void {
     //    → 모든 POST req.body=undefined(400), OAuth 후 req.cookies 미파싱(/me 401) 회귀.
     //    body parser 는 정적 서빙과 무관하므로 여기(parsers)로 이동해 항상 등록되게 한다.
     app.use('/api/chat', express.json({ limit: '10mb' }));
-    app.use('/api/documents', express.json({ limit: '50mb' }));
     // 에이전트 작업 생성은 입력 첨부(base64 문서 포함)를 받는다 — 파서 상한은
     // validate 미들웨어(maxBodySizeBytes)와 AGENT_TASK_LIMITS.REQUEST_BODY_MAX_BYTES 를 공유
     app.use('/api/agent-tasks', express.json({ limit: AGENT_TASK_LIMITS.REQUEST_BODY_MAX_BYTES }));

--- a/apps/api/src/providers/openai-compat-provider.ts
+++ b/apps/api/src/providers/openai-compat-provider.ts
@@ -29,6 +29,7 @@ import {
 import { ProviderError } from './provider-errors';
 import type { ChatMessage, ToolDefinition, UsageMetrics } from '../llm';
 import { createLogger } from '../utils/logger';
+import { createPinnedFetch } from '../security/ssrf-guard';
 
 const logger = createLogger('OpenAICompatProvider');
 
@@ -306,6 +307,9 @@ export class OpenAICompatProvider implements IProvider {
         this.client = new OpenAI({
             apiKey: opts.apiKey,
             baseURL: opts.baseUrl,
+            // 🔒 SSRF: base_url 은 등록 시 1회만 검증되므로, 런타임 호출은 매번 재검증 + resolved IP
+            //   고정하는 fetch 로 DNS Rebinding(TOCTOU)을 차단한다. hostname 이 보존되어 TLS SNI 정상.
+            fetch: createPinnedFetch(),
             ...(defaultHeaders && Object.keys(defaultHeaders).length > 0
                 ? { defaultHeaders }
                 : {}),

--- a/apps/api/src/routes/mcp.routes.ts
+++ b/apps/api/src/routes/mcp.routes.ts
@@ -167,6 +167,17 @@ export const mcpRouter = Router();
           return;
       }
 
+      // 🔒 비-global(user_private/user_shared)은 body 의 임의 command/args/env 를 그대로 spawn 하는
+      // RCE 경로이자 전역 ToolRouter 노출 경로다. 사용자 서버는 command 를 body 가 아닌 카탈로그
+      // 템플릿에서만 취하는 POST /api/mcp/servers/from-catalog 로만 등록해야 한다. 이 레거시 라우트는
+      // admin 이 관리하는 global 서버 등록 전용으로 제한한다.
+      if (visibility !== 'global') {
+          res.status(403).json(forbidden(
+              '사용자 서버(user_private/user_shared)는 POST /api/mcp/servers/from-catalog 로 등록하세요 (임의 stdio command 금지)',
+          ));
+          return;
+      }
+
       // SSRF guard — sse/http URL 등록 시 외부 호스트 검증
       if ((transport_type === 'sse' || transport_type === 'streamable-http') && url) {
           try {
@@ -193,19 +204,8 @@ export const mcpRouter = Router();
 
       const db = getUnifiedDatabase();
       const registry = getUnifiedMCPClient().getServerRegistry();
-      // global 만 즉시 spawn — user_* 는 Phase 7 lifecycle-supervisor 의 hook 으로 위임
-      // (현재 phase 에서는 db.upsertMcpServer 동등 동작으로 fallback. registry.registerServer 는 connect 시도 포함.)
-      const status = visibility === 'global'
-          ? await registry.registerServer(config, db)
-          : await registry.registerServer(config, db);
-      // visibility / user_id / catalog_template_id 컬럼은 ALTER (023) 후 별도 update —
-      // server-registry 의 db.addMcpServer 가 컬럼을 모를 수 있어 수동 UPDATE:
-      if (visibility !== 'global') {
-          await db.getPool().query(
-              `UPDATE mcp_servers SET user_id = $1, visibility = $2, catalog_template_id = $3 WHERE id = $4`,
-              [userId, visibility, catalog_template_id ?? null, id],
-          );
-      }
+      // 여기 도달하면 visibility === 'global' (admin) — 즉시 spawn(connect 포함).
+      const status = await registry.registerServer(config, db);
 
       res.status(201).json(success({ server: config, connectionStatus: status }));
   }));

--- a/apps/api/src/security/ssrf-guard.ts
+++ b/apps/api/src/security/ssrf-guard.ts
@@ -363,3 +363,32 @@ export async function safeFetch(
     logger.warn('SSRF blocked: too many redirects', { rawUrl, maxRedirects: SSRF_LIMITS.MAX_REDIRECTS });
     throw new Error('SSRF blocked: too many redirects');
 }
+
+/**
+ * SSRF-safe 한 `fetch` 구현체를 만든다 — OpenAI SDK / MCP SSE·streamable-http transport 처럼
+ * 자체적으로 DNS 를 재조회해 `safeFetch` 를 우회하는 클라이언트에 주입한다.
+ *
+ * 왜 필요한가: base_url / MCP URL 은 등록 시점(`validateOutboundUrl`)에만 1회 검증되므로,
+ * 공격자가 등록 후 DNS 를 사설/메타데이터 IP 로 rebinding 하면 런타임 호출이 내부망에 도달한다
+ * (TOCTOU). 이 fetch 는 매 요청마다 재검증 + resolved IP 고정으로 그 갭을 닫는다.
+ *
+ * 반환 시그니처는 MCP SDK 의 `FetchLike` 및 OpenAI SDK 의 `Fetch` 와 호환된다.
+ */
+export function createPinnedFetch(
+    resolver: DnsResolver = dns.lookup,
+): (input: string | URL | Request, init?: RequestInit) => Promise<Response> {
+    return async (input, init) => {
+        if (typeof input === 'string' || input instanceof URL) {
+            return safeFetch(input.toString(), init, resolver);
+        }
+        // Request 객체로 호출되는 드문 경로 — url/method/headers/body 를 init 로 승격해 위임.
+        const req = input;
+        const merged: RequestInit = {
+            method: req.method,
+            headers: req.headers,
+            ...(req.body ? { body: req.body, duplex: 'half' } as RequestInit : {}),
+            ...init,
+        };
+        return safeFetch(req.url, merged, resolver);
+    };
+}

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -30,6 +30,7 @@ import { getSkillManager } from '../agents/skill-manager';
 import { buildDelegateFn } from './agent-task/delegate';
 import { buildTaskSpawnFn } from './agent-spawn/spawn-agents';
 import { mergeToolsWithSkills, type ActiveSkillBinding } from './chat-service/tool-merger';
+import { filterRestrictedTools } from './chat-service/tool-restrictions';
 import { TaskRuntime } from './task-sandbox/runtime';
 import { TASK_TERMINATE_SENTINEL } from './task-sandbox/tools';
 import { requiresApproval, getApprovalRegistry } from './task-sandbox/approval-gate';
@@ -173,10 +174,13 @@ export class AgentTaskService {
             // stepNumber 0 재시작으로 인한 (task_id, step_number) 중복·표시 혼선을 방지.
             if (!input.resume) await db.deleteAgentTaskSteps(taskId);
 
-            // 허용 도구 목록 (LLMTool ≈ ToolDefinition) — 전체 노출
-            const allTools = (await mcp.getToolRouter().getLLMTools({
+            // 허용 도구 목록 (LLMTool ≈ ToolDefinition). 채팅 경로(ChatService.getAllowedTools)와
+            // 동일하게 고위험 전역 서버 도구(Python REPL 등)를 역할 미달 사용자에게서 제거한다 —
+            // 미적용 시 일반 user 가 에이전트 작업으로 admin 전용 도구를 호출할 수 있었다.
+            const rawTools = (await mcp.getToolRouter().getLLMTools({
                 userId,
             })) as unknown as ToolDefinition[];
+            const allTools = filterRestrictedTools(rawTools, userRole);
 
             // 활성 스킬(global+user)의 tool_bindings 를 머지.
             // base 가 전체 도구라 실효는 사실상 denied(특정 도구 차단)뿐이다.

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -174,13 +174,10 @@ export class AgentTaskService {
             // stepNumber 0 재시작으로 인한 (task_id, step_number) 중복·표시 혼선을 방지.
             if (!input.resume) await db.deleteAgentTaskSteps(taskId);
 
-            // 허용 도구 목록 (LLMTool ≈ ToolDefinition). 채팅 경로(ChatService.getAllowedTools)와
-            // 동일하게 고위험 전역 서버 도구(Python REPL 등)를 역할 미달 사용자에게서 제거한다 —
-            // 미적용 시 일반 user 가 에이전트 작업으로 admin 전용 도구를 호출할 수 있었다.
-            const rawTools = (await mcp.getToolRouter().getLLMTools({
+            // 역할 게이팅(채팅 경로와 동일) — 고위험 전역 도구(Python REPL 등)를 역할 미달 user 에게서 제거.
+            const allTools = filterRestrictedTools((await mcp.getToolRouter().getLLMTools({
                 userId,
-            })) as unknown as ToolDefinition[];
-            const allTools = filterRestrictedTools(rawTools, userRole);
+            })) as unknown as ToolDefinition[], userRole);
 
             // 활성 스킬(global+user)의 tool_bindings 를 머지.
             // base 가 전체 도구라 실효는 사실상 denied(특정 도구 차단)뿐이다.

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -123,6 +123,7 @@ export async function handleChatMessage(
             extWs._authenticatedUserId,
             userContext.userRole,
             userContext.anonSessionId,
+            extWs._clientIp,
         );
         if (rateLimitError) {
             ws.send(JSON.stringify({ type: 'error', message: rateLimitError }));

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -19,6 +19,7 @@ import { WS_ERROR_MESSAGES, WS_PROVIDER_ERROR_MESSAGES, getLocalizedTemplate } f
 import { detectLanguage, type SupportedLanguageCode } from '../chat/language-policy';
 import { applySlashCommand } from '../chat/slash-command';
 import { WS_LIMITS } from '../config/timeouts';
+import { FILE_ATTACH_LIMITS } from '../config/runtime-limits';
 import { ArtifactStreamParser, type ArtifactInfo } from '../llm/artifact-parser';
 import { buildFileContext, buildUrlContext, getCachedAttachContext, appendCachedAttachContext } from '../services/chat-service/attach-context';
 import { buildWebSearchContext } from '../mcp/web-search/build-search-context';
@@ -45,6 +46,17 @@ export async function handleChatMessage(
 
     if (!hasMessage && !hasImages && !hasFiles) {
         ws.send(JSON.stringify({ type: 'error', message: '메시지가 필요합니다' }));
+        return;
+    }
+
+    // 첨부 개수 상한 — REST/agent-task 스키마(FILE_ATTACH_LIMITS)와 동일 계약을 WS 채팅에도 적용한다.
+    // WS 는 Zod 검증을 거치지 않아 개수 캡이 비어 있었고, 대량 배열로 파이프라인 자원을 소모할 수 있었다.
+    if (hasImages && (msg.images as unknown[]).length > FILE_ATTACH_LIMITS.MAX_IMAGES) {
+        ws.send(JSON.stringify({ type: 'error', message: `이미지는 최대 ${FILE_ATTACH_LIMITS.MAX_IMAGES}개까지 첨부할 수 있습니다` }));
+        return;
+    }
+    if (hasFiles && (msg.files as unknown[]).length > FILE_ATTACH_LIMITS.MAX_FILES) {
+        ws.send(JSON.stringify({ type: 'error', message: `파일은 최대 ${FILE_ATTACH_LIMITS.MAX_FILES}개까지 첨부할 수 있습니다` }));
         return;
     }
 

--- a/apps/api/src/types/jsonwebtoken.d.ts
+++ b/apps/api/src/types/jsonwebtoken.d.ts
@@ -1,9 +1,21 @@
 declare module 'jsonwebtoken' {
     export type Secret = string;
 
+    export type Algorithm =
+        | 'HS256' | 'HS384' | 'HS512'
+        | 'RS256' | 'RS384' | 'RS512'
+        | 'ES256' | 'ES384' | 'ES512'
+        | 'PS256' | 'PS384' | 'PS512'
+        | 'none';
+
     export interface SignOptions {
         expiresIn?: string | number;
         jwtid?: string;
+        algorithm?: Algorithm;
+    }
+
+    export interface VerifyOptions {
+        algorithms?: Algorithm[];
     }
 
     export function sign(
@@ -12,7 +24,7 @@ declare module 'jsonwebtoken' {
         options?: SignOptions
     ): string;
 
-    export function verify(token: string, secretOrPublicKey: Secret): unknown;
+    export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): unknown;
 
     export function decode(token: string): null | string | Record<string, unknown>;
 }


### PR DESCRIPTION
## 개요
전체 소스 보안 감사(2026-07-26)에서 확인된 취약점을 심각도순으로 수정합니다. 테스트는 저장소 관례상 `.gitignore`(`**/__tests__/`·`*.test.ts`) 미추적이라 PR에는 소스만 포함하고, 로컬 회귀 테스트로 검증했습니다.

## 🔴 Critical/High
- **세션 IDOR** (`session.controller.ts`) — `undefined===undefined` 우회로 미인증 요청이 타인 대화 조회/주입/삭제. 순수 함수 `evaluateSessionAccess`로 추출 + 양쪽 truthy 가드.
- **MCP 임의 stdio 등록 → 조건부 RCE** (`mcp.routes.ts`) — 비-global 등록 403 거부, `from-catalog`로 유도. admin global 전용화. user_private 전역 노출 버그 동시 해소.

## 🟡 Medium
- **SSRF DNS rebinding ×2** (`ssrf-guard.ts`, `openai-compat-provider.ts`, `external-client.ts`) — `createPinnedFetch()`(매 요청 재검증+IP 고정)를 OpenAI SDK·MCP transport에 주입.
- **클러스터 무인증 노출** (`cluster.controller.ts`) — `requireAuth+requireAdmin` 게이트.
- **에이전트 작업 역할 게이팅 우회** (`AgentTaskService.ts`) — `filterRestrictedTools(role)` 적용.
- **GitHub OAuth 미검증 이메일 병합** (`auth-oauth.controller.ts`) — `e.primary && e.verified`만 신뢰.
- **WS 프레임 무제한 + 첨부 캡 부재** (`timeouts.ts`, `ws-chat-handler.ts`) — 프레임 128MB 상한 + `FILE_ATTACH_LIMITS` 강제.
- **CSRF warn→enforce** (`env.ts`, `env.schema.ts`, `.env.example`) — 프론트 토큰 자동주입 완비. ⚠️ 배포 시 라이브 검증 권장, `CSRF_PROTECTION=warn` 롤백 가능.

## 🟢 Low
- **jwt.verify algorithms 화이트리스트(HS256)** (`auth-core.ts`, `types/jsonwebtoken.d.ts`) + **artifact-viewer 하드코딩 키 제거** (`artifact-viewer.ts`).
- **죽은 /api/documents 50MB 파서 제거** (`setup.ts`).
- **게스트 rate-limit IP 우선 키잉** (`chat-rate-limiter.ts`, `ws-chat-handler.ts`) — anonSessionId 회전 우회 차단.
- **MCP 샌드박스 fail-closed** (`sandbox-docker.ts`) — docker 부재 시 비격리 실행 거부.
- **JSDoc 개인식별자 익명화** (`local-models.ts`).

## 검증
- 전체 백엔드 타입 체크(`tsc --noEmit`): 오류 없음
- 로컬 테스트: 세션 IDOR 8/8, SSRF 62/62, agent-task 96/96, CSRF 13/13, sandbox-docker 10/10, external-client+auth 43/43, routes-setup 9/9, mcp-visibility 9/9
- `eslint`: error 0 (일부 파일 max-lines는 warning, `eslint .` 비차단)

## 후속(미포함) — 인프라 작업
`scripts/vllm/*.service`·`*.sh`의 기능적 개인 경로(`/home/smith/...`)는 실제 배포 config라 변경 시 배포가 깨져, 파라미터화가 필요한 별도 인프라 작업으로 남깁니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)