### PR TITLE
fix(desktop): 데스크톱앱 보안 하드닝 + 로컬 브리지 exec 신뢰 모델

### DIFF
--- a/apps/api/src/config/task-sandbox.ts
+++ b/apps/api/src/config/task-sandbox.ts
@@ -57,6 +57,9 @@ export interface TaskSandboxConfig {
     workspaceQuota: number;
     /** 도구 호출 승인 정책 (기본 all — 전부 승인). */
     approvalPolicy: TaskSandboxApprovalPolicy;
+    /** 로컬 브리지 실행 시 true — 코드 실행(bash/python_execute)을 디바이스가 자체 확인하므로
+     *  서버측 승인을 skip 해 이중 프롬프트를 없앤다(executor-select 에서 주입). */
+    deviceGatesShell?: boolean;
     /** 승인 대기 timeout(ms) — 초과 시 자동 거절(작업 일시정지 해제). */
     approvalTimeoutMs: number;
     /** 완료 task workspace 보존 TTL(ms) — 초과한 workspace 디렉토리는 정리 스윕이 삭제. */

--- a/apps/api/src/services/agent-task/executor-select.ts
+++ b/apps/api/src/services/agent-task/executor-select.ts
@@ -27,8 +27,10 @@ export function resolveExecutorPlan(
     userId: string,
 ): ExecutorPlan {
     const isLocal = input.executor === 'local' && LOCAL_BRIDGE.ENABLED;
+    // 로컬: 파일/기타 도구는 서버 승인 유지(디바이스는 파일에 다이얼로그 없음)하되, 코드 실행
+    // (bash/python_execute)은 디바이스 confirmExec 가 게이트하므로 deviceGatesShell 로 서버 승인 skip.
     const sandboxCfg = isLocal
-        ? { ...getTaskSandboxConfig(), approvalPolicy: 'all' as const }
+        ? { ...getTaskSandboxConfig(), approvalPolicy: 'all' as const, deviceGatesShell: true }
         : input.approvalPolicy
             ? { ...getTaskSandboxConfig(), approvalPolicy: input.approvalPolicy }
             : getTaskSandboxConfig();

--- a/apps/api/src/services/agent-task/subagent.ts
+++ b/apps/api/src/services/agent-task/subagent.ts
@@ -43,7 +43,7 @@ export interface SubagentParams {
     /** 승인 레지스트리 키(에이전트 작업 taskId). 채팅 경로는 정책 'none' 이라 실사용 안 됨. */
     taskId: string;
     /** 승인 정책·대기 상한만 사용 — 채팅 경로는 {approvalPolicy:'none', approvalTimeoutMs:0} 전달. */
-    sandboxCfg: Pick<TaskSandboxConfig, 'approvalPolicy' | 'approvalTimeoutMs'>;
+    sandboxCfg: Pick<TaskSandboxConfig, 'approvalPolicy' | 'approvalTimeoutMs' | 'deviceGatesShell'>;
     signal?: AbortSignal;
     /** 서브 LLM 호출 토큰을 부모 누적에 합산. */
     onTokens?: (n: number) => void;
@@ -117,7 +117,7 @@ export async function runSubagent(p: SubagentParams): Promise<string> {
                 const args = (tc.function.arguments ?? {}) as Record<string, unknown>;
                 // 부모와 동일한 승인 게이트 — 정책 우회 없음(자동승인 task 면 즉시 approved).
                 let approved = true;
-                if (requiresApproval(p.sandboxCfg.approvalPolicy, name, args)) {
+                if (requiresApproval(p.sandboxCfg.approvalPolicy, name, args, { deviceGatesShell: p.sandboxCfg.deviceGatesShell })) {
                     const r = await getApprovalRegistry().request(
                         { taskId: p.taskId, userId: String(p.userCtx.userId), toolName: name, args },
                         { timeoutMs: p.sandboxCfg.approvalTimeoutMs, signal: p.signal },

--- a/apps/api/src/services/task-sandbox/approval-gate.ts
+++ b/apps/api/src/services/task-sandbox/approval-gate.ts
@@ -29,16 +29,24 @@ const HIGH_RISK_TOOLS = new Set(['bash', 'browser', 'python_execute', 'skill_run
 const NO_APPROVAL_TOOLS = new Set(['terminate', 'ask_human', 'plan_create', 'plan_update', 'plan_view', 'delegate', 'spawn_agents']);
 /** 고위험으로 보는 file_ops 작업. */
 const HIGH_RISK_FILE_OPS = new Set(['delete']);
+/** 디바이스(로컬 브리지)가 실행 직전 자체 확인하는 코드 실행 도구 — 서버 승인 중복이라 skip 대상. */
+const DEVICE_GATED_SHELL = new Set(['bash', 'python_execute']);
 
-/** PURE: 도구 호출이 승인을 요구하는지 정책에 따라 판정. */
+/** PURE: 도구 호출이 승인을 요구하는지 정책에 따라 판정.
+ *  opts.deviceGatesShell=true(로컬 브리지 실행)면 exec 계열(bash/python_execute)은 디바이스가
+ *  실행 직전 사용자 확인을 강제하므로 서버측 승인을 skip 한다(이중 프롬프트 제거). 파일/기타
+ *  도구는 디바이스가 다이얼로그를 띄우지 않으므로 정책대로 서버 승인을 유지한다. */
 export function requiresApproval(
     policy: TaskSandboxApprovalPolicy,
     toolName: string,
     args: Record<string, unknown>,
+    opts: { deviceGatesShell?: boolean } = {},
 ): boolean {
     if (policy === 'none') return false;
     // 제어 시그널·플래닝은 승인 불요(부작용 없음).
     if (NO_APPROVAL_TOOLS.has(toolName)) return false;
+    // 로컬 브리지: 코드 실행은 디바이스가 게이트 → 서버 승인 중복 제거.
+    if (opts.deviceGatesShell && DEVICE_GATED_SHELL.has(toolName)) return false;
     if (policy === 'all') return true;
     // high-risk
     if (HIGH_RISK_TOOLS.has(toolName)) return true;

--- a/apps/api/src/services/task-sandbox/runtime.ts
+++ b/apps/api/src/services/task-sandbox/runtime.ts
@@ -157,7 +157,7 @@ export class TaskRuntime {
                 : `사용자가 승인했습니다(계속 진행). 질문: ${question}`;
         }
 
-        if (requiresApproval(this.cfg.approvalPolicy, name, args)) {
+        if (requiresApproval(this.cfg.approvalPolicy, name, args, { deviceGatesShell: this.cfg.deviceGatesShell })) {
             const { decision, waitedMs } = await getApprovalRegistry().request(
                 { taskId: this.taskId, userId: this.userId, toolName: name, args },
                 { timeoutMs: this.cfg.approvalTimeoutMs, signal: opts.signal, onPending: opts.onApprovalPending },

--- a/apps/desktop/bridge.js
+++ b/apps/desktop/bridge.js
@@ -1,10 +1,15 @@
 // Local Bridge (Cowork D1b) — 로컬 실행기: 서버 Agent Task 의 도구 호출을
-// 사용자가 승인·연결한 폴더 스코프 안에서 실행한다. 프로토콜은 서버
+// 사용자가 연결한 폴더를 작업 기준으로 실행한다. 프로토콜은 서버
 // apps/api/src/services/local-bridge/ (D1a) 와 1:1.
 //
 // 보안 불변식:
 //  - 고정 kind 화이트리스트만 처리 (임의 RPC 거부)
-//  - 모든 경로는 연결 폴더 realpath 스코프 안에서만 해석 (심링크 탈출 차단)
+//  - 파일 kind(read/write/list/delete)의 경로는 연결 폴더 realpath 스코프 안에서만
+//    해석 (심링크 탈출 차단)
+//  - ⚠️ exec 는 폴더 스코프에 갇히지 않는다 — 셸 명령은 사용자 계정 권한으로 실행되어
+//    폴더 밖 파일·네트워크에도 접근할 수 있다. 그래서 exec 는 ① 명백히 위험한 패턴을
+//    디바이스에서 hard-block(EXEC_DENYLIST) 하고 ② 나머지는 실행 전 매번 사용자
+//    확인(confirmExec)을 받는다 — 서버 승인 설정과 무관한 비우회 게이트.
 //  - 인증은 앱 세션의 auth_token 쿠키 재사용 (토큰을 디스크에 저장하지 않음)
 const { session, dialog } = require('electron');
 const fs = require('fs');
@@ -16,6 +21,25 @@ const WebSocket = require('ws');
 const EXEC_TIMEOUT_MS = 120000;
 const MAX_BUFFER = 1024 * 1024;
 const RECONNECT_MS = 10000;
+
+// exec 가드레일(보안 경계 아님, 우발·명백 유출 백스톱) — 매칭 시 확인 없이 즉시 거부.
+// 난독화로 우회 가능함을 인정하되, LLM 인젝션·실수로 인한 명백한 파괴/유출을 차단한다.
+const EXEC_DENYLIST = [
+  { re: /(^|[;&|(]|\s)sudo\s/, why: '권한 상승(sudo)' },
+  { re: /(^|[;&|(]|\s)doas\s/, why: '권한 상승(doas)' },
+  { re: /(curl|wget)\s[^|]*\|\s*(sh|bash|zsh)\b/, why: '원격 스크립트 직접 실행(pipe-to-shell)' },
+  { re: /\|\s*(sh|bash|zsh)\b/, why: '파이프-투-셸 실행' },
+  { re: /\brm\s+-\w*\s+(\/|~|\$HOME|\$\{HOME\})(\s|$)/, why: '홈/루트 대량 삭제' },
+  { re: /\.ssh(\/|\b)/, why: 'SSH 키 디렉토리 접근' },
+  { re: /id_rsa|id_ed25519|\.aws\/credentials|\.config\/gcloud/, why: '자격증명 파일 접근' },
+  { re: /:\s*\(\s*\)\s*\{/, why: 'fork bomb' },
+  { re: /\bdd\s+if=|\bmkfs\b|>\s*\/dev\/(disk|sd|rdisk)/, why: '디스크 파괴 연산' },
+];
+function matchDenylist(cmd) {
+  const c = String(cmd);
+  for (const d of EXEC_DENYLIST) if (d.re.test(c)) return d.why;
+  return null;
+}
 // 서버 WS 하트비트는 액세스 토큰 만료 시 연결을 terminate 한다 — 세션 쿠키에서 최신
 // 토큰을 읽어 기존 refresh 프로토콜({type:'refresh'})로 주기 연장해 유휴 플랩을 막는다.
 const REFRESH_MS = parseInt(process.env.OMK_BRIDGE_REFRESH_MS || '300000', 10);
@@ -27,6 +51,24 @@ let reconnectTimer = null;
 let refreshTimer = null;
 let statusText = '미연결';
 let onStatusChange = () => {};
+let mainWin = null;          // exec 확인 다이얼로그의 부모 창
+
+/** exec 실행 전 사용자 확인(비우회). 거부/취소면 false. 실행될 명령 원문을 그대로 보여준다. */
+async function confirmExec(command) {
+  // 테스트 훅(개발/E2E 전용): 다이얼로그 없이 자동 승인 (다른 OMK_BRIDGE_* 훅과 동일 계열).
+  if (process.env.OMK_BRIDGE_AUTO_APPROVE === '1') return true;
+  const preview = command.length > 800 ? command.slice(0, 800) + '…' : command;
+  const r = await dialog.showMessageBox(mainWin || undefined, {
+    type: 'warning',
+    message: '에이전트가 이 셸 명령을 당신의 컴퓨터에서 실행하려고 합니다',
+    detail: `${preview}\n\n연결 폴더: ${folderRoot}\n이 명령은 당신 계정 권한으로 실행되며 폴더 밖 파일·네트워크에도 접근할 수 있습니다.`,
+    buttons: ['실행', '거부'],
+    defaultId: 1,
+    cancelId: 1,
+    noLink: true,
+  });
+  return r.response === 0;
+}
 
 function deviceId(app) {
   const p = path.join(app.getPath('userData'), 'device-id');
@@ -58,13 +100,21 @@ function walk(dir, base, out) {
   return out;
 }
 
-function handleExec(m, done) {
+async function handleExec(m, done) {
   switch (m.kind) {
-    case 'exec':
+    case 'exec': {
+      // ① 명백히 위험한 패턴은 확인 없이 즉시 거부 (guardrail).
+      const denied = matchDenylist(m.command);
+      if (denied) { done({ ok: false, error: `위험 명령으로 차단됨: ${denied}`, exitCode: 126 }); return; }
+      // ② 나머지는 실행 전 사용자 확인 (비우회).
+      if (!(await confirmExec(String(m.command || '')))) {
+        done({ ok: false, error: '사용자가 명령 실행을 거부했습니다', exitCode: 126 }); return;
+      }
       exec(m.command, { cwd: folderRoot, timeout: EXEC_TIMEOUT_MS, maxBuffer: MAX_BUFFER }, (err, stdout, stderr) => {
         done({ ok: true, stdout: String(stdout), stderr: String(stderr), exitCode: err ? (err.code ?? 1) : 0 });
       });
       return;
+    }
     case 'read': done({ ok: true, content: fs.readFileSync(safe(m.path), 'utf8') }); return;
     case 'write': {
       const abs = safe(m.path);
@@ -129,7 +179,8 @@ async function connect(app, backendUrl) {
     const done = (result) => {
       try { ws.send(JSON.stringify({ type: 'bridge_result', reqId: m.reqId, result: { durationMs: Date.now() - t0, ...result } })); } catch { /* noop */ }
     };
-    try { handleExec(m, done); } catch (e) { done({ ok: false, error: String(e.message || e) }); }
+    // handleExec 는 async(exec 승인 대기) — sync/async 예외를 모두 done 으로 흡수.
+    Promise.resolve().then(() => handleExec(m, done)).catch((e) => done({ ok: false, error: String(e.message || e) }));
   });
 
   ws.on('close', () => {
@@ -144,11 +195,12 @@ async function connect(app, backendUrl) {
 
 /** 메뉴: 폴더 선택 → 연결. 테스트 훅 OMK_BRIDGE_FOLDER 로 다이얼로그 생략 가능. */
 async function connectFolder(app, backendUrl, win) {
+  mainWin = win || mainWin;
   let folder = process.env.OMK_BRIDGE_FOLDER;
   if (!folder) {
     const r = await dialog.showOpenDialog(win, {
       title: '에이전트 작업에 연결할 폴더 선택',
-      message: '선택한 폴더 안에서만 에이전트가 파일을 읽고 씁니다.',
+      message: '이 폴더를 작업 기준으로 파일을 읽고 씁니다. 셸 명령은 실행 전 매번 확인을 받으며, 승인 시 당신 계정 권한으로 실행됩니다(폴더 밖·네트워크 접근 가능).',
       properties: ['openDirectory', 'createDirectory'],
     });
     if (r.canceled || !r.filePaths[0]) return;

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -32,6 +32,13 @@ function saveBackend(b) {
 let win;
 let current = 'external';
 
+// 웹 콘텐츠가 여는 URL 은 시스템으로 넘기기 전에 스킴을 제한한다 — file:// 나 임의 커스텀
+// 스킴이 로컬 프로토콜 핸들러를 악용하는 것을 막는다(http/https/mailto 만 허용).
+function isExternallyOpenable(url) {
+  try { return ['https:', 'http:', 'mailto:'].includes(new URL(url).protocol); }
+  catch { return false; }
+}
+
 function createWindow() {
   current = loadBackend();
   win = new BrowserWindow({
@@ -41,22 +48,33 @@ function createWindow() {
     minHeight: 600,
     title: 'OpenMake',
     backgroundColor: '#0e1014',
-    webPreferences: { contextIsolation: true, nodeIntegration: false },
+    webPreferences: { contextIsolation: true, nodeIntegration: false, sandbox: true },
   });
   win.loadURL(BACKENDS[current]);
 
-  // 앱 내 target=_blank / 외부 도메인 링크는 시스템 기본 브라우저로 연다.
+  // 앱 내 target=_blank / 외부 도메인 링크는 시스템 기본 브라우저로 연다(안전 스킴만).
   win.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+    if (isExternallyOpenable(url)) shell.openExternal(url);
     return { action: 'deny' };
   });
 
-  // 로드 실패(백엔드 미기동 등) 시 간단 안내.
-  win.webContents.on('did-fail-load', (_e, code, desc, url) => {
+  // 최상위 프레임 이동은 http/https 만 허용 — file:// 등 위험 스킴으로의 네비게이션을 차단한다.
+  // (OAuth https 리다이렉트·로컬 백엔드 http·SPA pushState 는 그대로 동작)
+  win.webContents.on('will-navigate', (e, url) => {
+    let proto;
+    try { proto = new URL(url).protocol; } catch { e.preventDefault(); return; }
+    if (proto !== 'https:' && proto !== 'http:') e.preventDefault();
+  });
+
+  // 로드 실패(백엔드 미기동 등) 시 간단 안내. 최상위 프레임만 대상으로 하고, 메시지는
+  // textContent 로 주입해 url/desc 의 HTML/JS 삽입 소면을 없앤다.
+  win.webContents.on('did-fail-load', (_e, code, desc, url, isMainFrame) => {
     if (code === -3) return; // aborted (정상 재로드)
-    const msg = `백엔드에 연결할 수 없습니다.\\n${url}\\n(${desc})\\n\\n메뉴 '백엔드' 에서 외부/로컬을 전환하거나 서버 상태를 확인하세요.`;
+    if (!isMainFrame) return; // 서브프레임 실패는 페이지를 덮어쓰지 않는다
+    const msg = `백엔드에 연결할 수 없습니다.\n${url}\n(${desc})\n\n메뉴 '백엔드' 에서 외부/로컬을 전환하거나 서버 상태를 확인하세요.`;
+    const containerHtml = '<div style="font-family:-apple-system;color:#eceef2;background:#0e1014;height:100vh;display:flex;align-items:center;justify-content:center;text-align:center;white-space:pre-line;padding:24px"></div>';
     win.webContents.executeJavaScript(
-      `document.body.innerHTML='<div style="font-family:-apple-system;color:#eceef2;background:#0e1014;height:100vh;display:flex;align-items:center;justify-content:center;text-align:center;white-space:pre-line;padding:24px">${msg}</div>'`,
+      `document.body.innerHTML=${JSON.stringify(containerHtml)};document.body.firstChild.textContent=${JSON.stringify(msg)};`,
     ).catch(() => { /* noop */ });
   });
 

--- a/apps/desktop/updater.js
+++ b/apps/desktop/updater.js
@@ -15,6 +15,17 @@ const CHECK_DELAY_MS = 5000;
 // 매니페스트 파일명 화이트리스트 — 교체 스크립트에 문자열로 보간되므로 서버(config/
 // desktop-update.ts)와 같은 패턴을 앱에서도 검증한다(백엔드 전환 가능 → 서버 검증만 의존 불가).
 const FILE_PATTERN = /^OpenMake-[A-Za-z0-9.-]+\.dmg$/;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/i;
+
+// 업데이트는 미서명(ad-hoc) 교체라 무결성 신뢰가 전송 보안에 달려 있다. HTTPS 또는
+// 루프백(로컬 백엔드)에서만 허용해 평문 HTTP MITM 으로 악성 dmg 가 주입되는 것을 막는다.
+function isSecureUpdateOrigin(backendUrl) {
+  try {
+    const u = new URL(backendUrl);
+    if (u.protocol === 'https:') return true;
+    return ['localhost', '127.0.0.1', '::1', '[::1]'].includes(u.hostname);
+  } catch { return false; }
+}
 
 /** "1.2.0" 형태 비교 — a > b 이면 양수. */
 function cmpVersion(a, b) {
@@ -68,9 +79,13 @@ rm -f "$0"
  */
 async function checkForUpdate(backendUrl, win, interactive) {
   try {
+    if (!isSecureUpdateOrigin(backendUrl)) {
+      throw new Error('업데이트는 HTTPS(또는 로컬호스트) 백엔드에서만 허용됩니다');
+    }
     const m = (await fetchJson(`${backendUrl}/api/desktop/latest`)).data;
-    if (!m || !m.version || !FILE_PATTERN.test(String(m.file))) {
-      throw new Error('업데이트 매니페스트 형식이 올바르지 않습니다');
+    // sha256 은 필수 — 없으면(또는 형식 불량) 무결성 검증이 불가하므로 거부한다.
+    if (!m || !m.version || !FILE_PATTERN.test(String(m.file)) || !SHA256_PATTERN.test(String(m.sha256 || ''))) {
+      throw new Error('업데이트 매니페스트 형식이 올바르지 않습니다(version·file·sha256 확인)');
     }
     const current = app.getVersion();
     if (cmpVersion(m.version, current) <= 0) {
@@ -92,7 +107,7 @@ async function checkForUpdate(backendUrl, win, interactive) {
 
     const dmgPath = path.join(os.tmpdir(), m.file);
     const sha = await downloadTo(`${backendUrl}${m.url}`, dmgPath);
-    if (m.sha256 && sha !== m.sha256) {
+    if (sha.toLowerCase() !== String(m.sha256).toLowerCase()) {
       fs.rmSync(dmgPath, { force: true });
       throw new Error('다운로드 무결성 검증 실패(sha256 불일치)');
     }


### PR DESCRIPTION
## 개요
보안 감사 워크플로우를 데스크톱앱(`apps/desktop/`)과 로컬 브리지 실행 경로에 적용해 발견한 결함을 수정합니다. 모든 발견은 소스 정독으로 CONFIRMED, 변경은 동작 보존형 하드닝입니다.

## 🔴 HIGH — 자체 업데이터 무결성 (`updater.js`)
미서명(ad-hoc) dmg 자체 교체 + Gatekeeper 격리 제거인데 무결성이 동일 출처 sha256(조건부)뿐.
- HTTPS(또는 루프백) 강제 — 평문 HTTP MITM 차단
- sha256 필수화(64hex), 누락 시 거부
- 잔여: 서명 공개키 핀 + dmg 분리서명 검증은 서명 인프라 필요 → 후속

## 🔴 HIGH — 로컬 브리지 exec 신뢰 모델 (`bridge.js` + 서버)
`exec` 는 폴더 스코프에 갇히지 않고 사용자 계정 권한으로 실행되는데 디바이스 독립 가드가 없었음. 신뢰 경계를 **실행이 일어나는 디바이스**로 일원화:
- **디바이스 hard-block(denylist)**: sudo·pipe-to-shell·`rm -rf ~//`·`.ssh`·자격증명·fork bomb·디스크 파괴 → 확인 없이 즉시 거부(가드레일)
- **디바이스 비우회 승인(confirmExec)**: 나머지 명령은 실행 전 매번 네이티브 다이얼로그(명령 원문·폴더·권한 고지, 기본 거부)
- **정직한 스코프 고지**: 헤더 불변식·폴더 연결 문구를 "폴더 밖·네트워크 접근 가능, 매번 확인"으로 수정
- **서버측 승인 dedupe**: `requiresApproval` 에 `deviceGatesShell` 추가 → local 은 코드 실행(bash/python_execute) 서버 승인 skip(디바이스가 게이트), 파일/기타는 서버 승인 유지 → 이중 프롬프트 제거
- OS 샌드박스(sandbox-exec + 네트워크 opt-in)는 로드맵

## 🟡 MEDIUM — Electron 창 (`main.js`)
- `shell.openExternal` 스킴 화이트리스트(http/https/mailto) — `file://`·커스텀 스킴 악용 차단
- `will-navigate` http/https 제한 (OAuth·SPA 무영향)

## 🟢 LOW
- `did-fail-load` isMainFrame 가드 + textContent 주입, `sandbox:true` 명시

## 검증
- `tsc --noEmit` 변경 파일 무오류 · `node --check`(desktop) 통과
- approval-gate 테스트 15/15(로컬), CI Gate(Test→Build→Size→Lint) **green**
- 테스트는 저장소 관례상 gitignore → 로컬 검증만, PR 미포함

🤖 Generated with [Claude Code](https://claude.com/claude-code)