### PR TITLE
chore(desktop): v1.3.0 — 보안 하드닝 반영 버전 bump

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmake-desktop",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "private": true,
   "description": "OpenMake LLM 데스크톱 셸 (macOS) — 운영 백엔드(외부 공개 도메인 / 로컬)를 네이티브 창으로",
   "author": "OpenMake Team",


### PR DESCRIPTION
## 개요
데스크톱 앱 보안 하드닝(#362)을 담은 **v1.3.0** 빌드에 맞춰 `apps/desktop/package.json` 버전을 올립니다.

## 버전 결정
`apps/desktop` 은 release-please 관리 대상이 아니라 수동 버저닝입니다(매니페스트는 `"." : 1.7.1` 만 관리). 이번 변경은 순수 버그픽스가 아니라 **exec 실행 시 매번 사용자 확인 다이얼로그**라는 체감 동작 변경을 포함하므로 patch(1.2.2)가 아닌 **minor 1.3.0**.

## 포함 변경 (#362)
- 업데이터: HTTPS(또는 루프백) 강제 + sha256 필수화
- 로컬 브리지 exec: denylist hard-block + 비우회 사용자 확인
- 창: `openExternal` 스킴 화이트리스트, `will-navigate` 제한, `did-fail-load` 안전화, `sandbox: true`

## 빌드 검증
- `OpenMake-1.3.0-arm64.dmg` (96MB) 빌드 완료, `CFBundleShortVersionString = 1.3.0`
- `app.asar` 에 `isSecureUpdateOrigin`·`EXEC_DENYLIST`·`confirmExec`·`isExternallyOpenable`·`will-navigate` 포함 확인
- 기존 설치본(v1.2.1) 구 업데이터는 sha256 조건부 검사라 새 매니페스트를 정상 수용 → 자동 업데이트 경로 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)