### PR TITLE
feat(desktop): exec OS 샌드박스(sandbox-exec) — 3단 방어 완성 (v1.4.0)

### DIFF
--- a/apps/desktop/bridge.js
+++ b/apps/desktop/bridge.js
@@ -6,21 +6,34 @@
 //  - 고정 kind 화이트리스트만 처리 (임의 RPC 거부)
 //  - 파일 kind(read/write/list/delete)의 경로는 연결 폴더 realpath 스코프 안에서만
 //    해석 (심링크 탈출 차단)
-//  - ⚠️ exec 는 폴더 스코프에 갇히지 않는다 — 셸 명령은 사용자 계정 권한으로 실행되어
-//    폴더 밖 파일·네트워크에도 접근할 수 있다. 그래서 exec 는 ① 명백히 위험한 패턴을
-//    디바이스에서 hard-block(EXEC_DENYLIST) 하고 ② 나머지는 실행 전 매번 사용자
-//    확인(confirmExec)을 받는다 — 서버 승인 설정과 무관한 비우회 게이트.
+//  - exec 3단 방어: ① 명백히 위험한 패턴을 디바이스에서 hard-block(EXEC_DENYLIST)
+//    ② 나머지는 실행 전 매번 사용자 확인(confirmExec) — 서버 승인 설정과 무관한 비우회 게이트
+//    ③ 승인된 명령도 OS 샌드박스(sandbox-exec)로 감싸 폴더 밖 쓰기·비밀 읽기를 커널이 차단
+//    (읽기 일반·네트워크는 허용 — 개발 명령 호환. 막는 축은 '파괴'와 '비밀 유출')
 //  - 인증은 앱 세션의 auth_token 쿠키 재사용 (토큰을 디스크에 저장하지 않음)
 const { session, dialog } = require('electron');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
-const { exec } = require('child_process');
+const { execFile } = require('child_process');
 const crypto = require('crypto');
 const WebSocket = require('ws');
 
 const EXEC_TIMEOUT_MS = 120000;
 const MAX_BUFFER = 1024 * 1024;
 const RECONNECT_MS = 10000;
+
+// ── exec OS 샌드박스 (macOS sandbox-exec) ───────────────────────────────
+// 승인된 명령이라도 OS 레벨에서 ① 연결 폴더 밖 쓰기 ② 비밀 파일 읽기를 차단한다.
+// 승인 게이트(사용자 확인)의 백스톱 — 오승인·프롬프트 인젝션으로 새는 피해를 제한.
+// 읽기는 폭넓게 허용(개발 명령 호환), 네트워크도 허용(npm/git 필수) — 막는 축은 '파괴'와 '비밀'.
+const SANDBOX_BIN = '/usr/bin/sandbox-exec';
+const SANDBOX_ENABLED = process.env.OMK_BRIDGE_SANDBOX !== '0';
+/** 워크스페이스 밖이지만 쓰기를 허용해야 하는 툴 캐시 — 없으면 npm/pip/cargo 계열이 깨진다. */
+const CACHE_SUBPATHS = ['.npm', '.cache', 'Library/Caches', '.cargo', '.gradle', '.m2', '.yarn', '.pnpm-store', 'go/pkg'];
+/** 읽기를 차단할 비밀 경로. */
+const SECRET_SUBPATHS = ['.ssh', '.aws', '.gnupg', '.kube', '.docker', '.config/gcloud', 'Library/Keychains'];
+let sandboxProfilePath = null;
 
 // exec 가드레일(보안 경계 아님, 우발·명백 유출 백스톱) — 매칭 시 확인 없이 즉시 거부.
 // 난독화로 우회 가능함을 인정하되, LLM 인젝션·실수로 인한 명백한 파괴/유출을 차단한다.
@@ -61,7 +74,9 @@ async function confirmExec(command) {
   const r = await dialog.showMessageBox(mainWin || undefined, {
     type: 'warning',
     message: '에이전트가 이 셸 명령을 당신의 컴퓨터에서 실행하려고 합니다',
-    detail: `${preview}\n\n연결 폴더: ${folderRoot}\n이 명령은 당신 계정 권한으로 실행되며 폴더 밖 파일·네트워크에도 접근할 수 있습니다.`,
+    detail: `${preview}\n\n연결 폴더: ${folderRoot}\n${SANDBOX_ENABLED && sandboxProfilePath
+      ? 'OS 샌드박스 적용: 폴더 밖 쓰기와 비밀 파일(.ssh/.aws 등) 읽기는 차단됩니다. 그 외 읽기·네트워크는 허용됩니다.'
+      : '⚠️ 샌드박스 미적용: 이 명령은 당신 계정 권한으로 폴더 밖 파일·네트워크에 접근할 수 있습니다.'}`,
     buttons: ['실행', '거부'],
     defaultId: 1,
     cancelId: 1,
@@ -76,6 +91,36 @@ function deviceId(app) {
   const id = crypto.randomUUID();
   try { fs.writeFileSync(p, id); } catch { /* noop */ }
   return id;
+}
+
+/** SBPL 문자열 리터럴 escape. */
+function sbq(p) { return `"${String(p).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`; }
+
+/**
+ * 연결 폴더 기준 sandbox-exec 프로파일을 생성해 경로를 반환한다(실패 시 null).
+ * 정책: 기본 allow → 쓰기는 폴더·임시·툴캐시로 제한, 비밀 경로는 읽기 차단.
+ * (SBPL 은 last-match-wins 이라 deny 뒤에 allow 를 두어야 예외가 성립한다.)
+ */
+function writeSandboxProfile(app, root) {
+    try {
+        const home = fs.realpathSync(os.homedir());
+        const sub = (base, list) => list.map((d) => `(subpath ${sbq(path.join(base, d))})`).join(' ');
+        const profile = [
+            '(version 1)',
+            '(allow default)',
+            '(deny file-write*)',
+            `(allow file-write* (subpath ${sbq(root)}))`,
+            '(allow file-write* (subpath "/private/tmp") (subpath "/private/var/folders") (subpath "/dev"))',
+            `(allow file-write* ${sub(home, CACHE_SUBPATHS)})`,
+            `(deny file-read* ${sub(home, SECRET_SUBPATHS)})`,
+            '',
+        ].join('\n');
+        const p = path.join(app.getPath('userData'), 'exec-sandbox.sb');
+        fs.writeFileSync(p, profile);
+        return p;
+    } catch {
+        return null;
+    }
 }
 
 /** 스코프 가드 — 연결 폴더 밖 경로/심링크 탈출을 차단 (서버 safeRealWorkspacePath 등가). */
@@ -110,9 +155,21 @@ async function handleExec(m, done) {
       if (!(await confirmExec(String(m.command || '')))) {
         done({ ok: false, error: '사용자가 명령 실행을 거부했습니다', exitCode: 126 }); return;
       }
-      exec(m.command, { cwd: folderRoot, timeout: EXEC_TIMEOUT_MS, maxBuffer: MAX_BUFFER }, (err, stdout, stderr) => {
+      // ③ OS 샌드박스로 감싸 실행 — 폴더 밖 쓰기·비밀 읽기를 커널이 차단한다.
+      //    프로파일 준비 실패 시 fail-closed(비격리 실행 거부). 해제는 OMK_BRIDGE_SANDBOX=0.
+      if (SANDBOX_ENABLED && !sandboxProfilePath) {
+        done({ ok: false, error: 'exec 샌드박스 프로파일을 준비하지 못해 실행을 거부했습니다(폴더 재연결 필요). 비격리 실행이 필요하면 OMK_BRIDGE_SANDBOX=0 으로 앱을 실행하세요.', exitCode: 126 });
+        return;
+      }
+      const opts = { cwd: folderRoot, timeout: EXEC_TIMEOUT_MS, maxBuffer: MAX_BUFFER };
+      const cb = (err, stdout, stderr) => {
         done({ ok: true, stdout: String(stdout), stderr: String(stderr), exitCode: err ? (err.code ?? 1) : 0 });
-      });
+      };
+      if (SANDBOX_ENABLED) {
+        execFile(SANDBOX_BIN, ['-f', sandboxProfilePath, '/bin/bash', '-c', String(m.command)], opts, cb);
+      } else {
+        execFile('/bin/bash', ['-c', String(m.command)], opts, cb);
+      }
       return;
     }
     case 'read': done({ ok: true, content: fs.readFileSync(safe(m.path), 'utf8') }); return;
@@ -200,13 +257,15 @@ async function connectFolder(app, backendUrl, win) {
   if (!folder) {
     const r = await dialog.showOpenDialog(win, {
       title: '에이전트 작업에 연결할 폴더 선택',
-      message: '이 폴더를 작업 기준으로 파일을 읽고 씁니다. 셸 명령은 실행 전 매번 확인을 받으며, 승인 시 당신 계정 권한으로 실행됩니다(폴더 밖·네트워크 접근 가능).',
+      message: '이 폴더를 작업 기준으로 파일을 읽고 씁니다. 셸 명령은 실행 전 매번 확인을 받고, 승인해도 OS 샌드박스가 폴더 밖 쓰기와 비밀 파일(.ssh 등) 읽기를 차단합니다.',
       properties: ['openDirectory', 'createDirectory'],
     });
     if (r.canceled || !r.filePaths[0]) return;
     folder = r.filePaths[0];
   }
   folderRoot = fs.realpathSync(folder);
+  // 연결 폴더 기준으로 exec 샌드박스 프로파일 갱신 (폴더가 바뀌면 스코프도 바뀐다).
+  sandboxProfilePath = SANDBOX_ENABLED ? writeSandboxProfile(app, folderRoot) : null;
   await connect(app, backendUrl);
 }
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmake-desktop",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "OpenMake LLM 데스크톱 셸 (macOS) — 운영 백엔드(외부 공개 도메인 / 로컬)를 네이티브 창으로",
   "author": "OpenMake Team",


### PR DESCRIPTION
## 개요
로컬 브리지 `exec` 신뢰 모델의 마지막 로드맵 항목입니다. 기존 2단 방어(denylist hard-block → 비우회 사용자 확인)에 **OS 커널 격리**를 3단으로 추가해, **승인된 명령이라도** 폴더 밖 파괴와 비밀 유출을 막습니다.

## 위협 모델
승인 게이트는 사람이 판단하므로 오승인·프롬프트 인젝션이 통과할 수 있습니다. 이 레이어는 그 백스톱입니다 — "사용자가 실수로 승인해도 피해 범위가 폴더로 제한된다".

## 구현
- **`writeSandboxProfile`**: 연결 폴더 기준 SBPL 프로파일을 `userData/exec-sandbox.sb` 에 생성(폴더 변경 시 재생성)
  - 기본 `allow` → **쓰기**는 연결 폴더 · 임시 · 툴 캐시로 제한
  - **비밀 경로 읽기 차단**: `.ssh` `.aws` `.gnupg` `.kube` `.docker` `.config/gcloud` `Library/Keychains`
- **exec 래핑**: `sandbox-exec -f <profile> /bin/bash -c <command>` (`execFile` 사용 — 프로파일 경로가 셸을 경유하지 않음)
- **fail-closed**: 프로파일 준비 실패 시 비격리 실행을 거부(기존 MCP 샌드박스 정책과 동일 기조)
- **정직한 고지**: 승인 다이얼로그가 샌드박스 적용/미적용을 명시
- **탈출구**: `OMK_BRIDGE_SANDBOX=0`

## 설계 판단 — 왜 "읽기 일반·네트워크는 허용"인가
전면 차단(deny default)은 임의의 개발 명령에 지나치게 취약해 사용자가 기능을 끄게 만듭니다. 실측 결과 **툴 캐시(`~/.npm` 등) 쓰기를 막으면 npm 계열이 전부 깨졌습니다.** 그래서 막는 축을 **'파괴'(폴더 밖 쓰기)와 '비밀'(자격증명 읽기)** 로 좁혀, 호환성을 유지하면서 실질 피해를 차단합니다.

## 실측 검증 (macOS 26.5.2, 실제 실행 경로 재현)
**방어**
| 시나리오 | 결과 |
|---|---|
| 폴더 밖 파일 생성 | `Operation not permitted` ✓ |
| 폴더 밖 파일 **삭제** | `Operation not permitted` (파일 생존 확인) ✓ |
| 폴더 밖 파일 **덮어쓰기** | 차단, 원본 유지 ✓ |
| `~/.ssh` 읽기 | `Operation not permitted` ✓ |

**호환성**: 폴더 내 쓰기 · `git commit` · `npm view` · `curl`(200) · `python3` 모두 정상

## 버전
`1.3.0 → 1.4.0` (새 보안 기능 — minor). 빌드·게시는 머지 후 별도 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)