### PR TITLE
chore(repo): 도구 세션 상태 .omo/ gitignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,6 @@ up_models.json
 # Cloudflare Tunnel 설정 — git 커밋 금지 지침 (라이브: ~/.cloudflared/config.yml)
 scripts/cloudflared/
 data/desktop-updates/
+
+# 도구 세션 상태(run-continuation) — 저장소와 무관
+.omo/


### PR DESCRIPTION
## 개요
`.omo/run-continuation/*.json`(백그라운드 작업 세션 상태)이 미추적 상태로 남아 `git status` 를 계속 오염시켜 무시 목록에 추가합니다.

저장소 산출물이 아니라 도구가 생성하는 런타임 상태 파일입니다.

## 참고 — 함께 수행한 운영 작업 (git 변경 없음)
`Playwright Browser` MCP 서버 복구는 **DB row + 캐시 볼륨** 상태 변경이라 저장소에 남지 않습니다:
- 캐시 볼륨에 버전 정합 chromium 설치(`playwright@1.62.0-alpha-1783623505000`)
- `mcp_servers.args` 에 `--browser chromium` 추가
- 앱 재시작 없이 `POST /api/mcp/servers/:id/connect` 로 반영 (connected · 24 tools)
- 채팅 E2E 로 LLM 의 실제 도구 호출까지 확인

카탈로그는 저장소 시드가 없는 런타임 DB 관리라 코드 변경 대상이 아닙니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)