### PR TITLE
feat(providers): ChatGPT 구독 OAuth provider + /v1 외부 모델 개방

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,6 +128,17 @@ LLM_WEEKLY_TOKEN_LIMIT=5000000
 # LLM_POOL_MIN_OUTPUT_TOKENS=4096                 # 안전망 최소 출력 보장
 # LLM_POOL_TOKENS_PER_IMAGE=1500                  # vision 이미지 1장당 토큰 추정치 (overflow 방지)
 
+# ChatGPT OAuth (구독 로그인, provider 'chatgpt') — 기본값은 코드 내 상수.
+# ⚠️ Codex CLI 차용 비공식 endpoint — OpenAI 변경 시 아래로 무중단 오버라이드.
+# CHATGPT_OAUTH_CLIENT_ID=app_EMoamEEZ73f0CkXaXp7hrann
+# CHATGPT_OAUTH_ISSUER=https://auth.openai.com
+# CHATGPT_CODEX_BASE_URL=https://chatgpt.com/backend-api/codex
+# CHATGPT_OAUTH_DEVICE_POLL_INTERVAL_SEC=5        # 디바이스 승인 폴링 간격 (초)
+# CHATGPT_OAUTH_REFRESH_MARGIN_MS=60000           # access token 만료 전 선제 refresh 여유
+# CHATGPT_OAUTH_ACCESS_TTL_SEC=3600               # expires_in 미제공 시 가정 수명
+# CHATGPT_MODEL_CONTEXT_WINDOW=272000             # Codex GPT-5 계열 context 추정
+# CHATGPT_MODEL_OUTPUT_LIMIT=128000               # 출력 한도 추정
+
 # vLLM extra_body.reasoning_effort 전송 (opt-in, 기본 비활성).
 # 모델/서버가 reasoning 지원 시에만 'true' 로 활성화 — vLLM 서버 가동 시
 # `--reasoning-parser deepseek_r1|qwen3|granite|...` 옵션 함께 지정 필요.

--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -28,6 +28,9 @@ module.exports = {
         // ESM-only 패키지를 jest CJS 런타임에서 로드 가능하게 하는 로컬 shim.
         // 개별 테스트의 jest.mock(..., factory)은 그대로 우선 적용된다.
         '^uuid$': '<rootDir>/__mocks__/uuid.js',
+        // @openai-oauth/core 는 ESM-only — 런타임(Node 24)은 require(esm) 로 로드하지만
+        // jest CJS 런타임은 불가. 테스트는 provider 의 transportFactory 주입으로 대체.
+        '^@openai-oauth/core$': '<rootDir>/__mocks__/empty.js',
         '^jsdom$': '<rootDir>/__mocks__/empty.js',
         '^@mozilla/readability$': '<rootDir>/__mocks__/empty.js',
         '^turndown$': '<rootDir>/__mocks__/empty.js',

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,7 @@
         "@anthropic-ai/sdk": "^0.95.1",
         "@modelcontextprotocol/sdk": "^1.25.3",
         "@mozilla/readability": "^0.6.0",
+        "@openai-oauth/core": "^2.0.0",
         "@opendataloader/pdf": "^2.4.7",
         "@openmake/shared-types": "*",
         "@opentelemetry/api": "^1.9.1",

--- a/apps/api/src/chat/external-tool-calling.ts
+++ b/apps/api/src/chat/external-tool-calling.ts
@@ -11,6 +11,7 @@
 
 import { randomBytes } from 'crypto';
 import type { LLMClient, ChatMessage, ToolDefinition } from '../llm';
+import type { IProvider } from '../providers/i-provider';
 import { getPromptConfig } from './prompt';
 import { determineLanguagePolicy } from './language-policy';
 import { getConfig } from '../config/env';
@@ -30,6 +31,11 @@ export async function processExternalToolCalling(params: {
     tools: ToolDefinition[];
     tool_choice?: 'auto' | 'none' | 'required' | { type: 'function'; function: { name: string } };
     client: LLMClient;
+    /**
+     * 외부 provider dispatch (Phase 2, 2026-07-26) — 요청 모델이 외부 fullId
+     * ('chatgpt:*', 'openrouter:*' 등)로 해석된 경우 로컬 client 대신 이 어댑터로 호출.
+     */
+    externalProvider?: { provider: IProvider; modelId: string };
     onToken: (token: string) => void;
     abortSignal?: AbortSignal;
 }): Promise<{
@@ -37,7 +43,7 @@ export async function processExternalToolCalling(params: {
     tool_calls?: OpenAIToolCall[];
     finish_reason: 'stop' | 'tool_calls';
 }> {
-    const { message, history, images, tools, tool_choice, client, onToken, abortSignal: _abortSignal } = params;
+    const { message, history, images, tools, tool_choice, client, externalProvider, onToken, abortSignal: _abortSignal } = params;
 
     // 언어 정책 결정 (메시지 기반 감지 — 외부 Tool Calling 경로는 userLanguagePreference 없음)
     const config = getConfig();
@@ -100,6 +106,48 @@ export async function processExternalToolCalling(params: {
         content: message,
         ...(images && images.length > 0 && { images }),
     });
+
+    // 외부 provider 경로 — provider.streamChat 로 단일 턴 호출 후 동일 형태로 반환
+    if (externalProvider) {
+        let externalContent = '';
+        const streamResult = await externalProvider.provider.streamChat(
+            {
+                messages,
+                modelId: externalProvider.modelId,
+                ...(effectiveTools ? { tools: effectiveTools } : {}),
+                ...(tool_choice !== undefined && tool_choice !== 'none'
+                    ? { tool_choice }
+                    : {}),
+                ...(_abortSignal ? { abortSignal: _abortSignal } : {}),
+            },
+            {
+                onToken: (token: string) => {
+                    externalContent += token;
+                    onToken(token);
+                },
+            },
+        );
+        if (streamResult.toolCalls && streamResult.toolCalls.length > 0) {
+            return {
+                response: streamResult.content || '',
+                tool_calls: streamResult.toolCalls.map((tc) => ({
+                    id: tc.id || `call_${randomBytes(12).toString('hex')}`,
+                    type: 'function' as const,
+                    function: {
+                        name: tc.name,
+                        arguments: typeof tc.args === 'string'
+                            ? tc.args
+                            : JSON.stringify(tc.args ?? {}),
+                    },
+                })),
+                finish_reason: 'tool_calls',
+            };
+        }
+        return {
+            response: streamResult.content || externalContent,
+            finish_reason: 'stop',
+        };
+    }
 
     // LLM 호출 (단일 턴)
     let fullContent = '';

--- a/apps/api/src/chat/request-handler.ts
+++ b/apps/api/src/chat/request-handler.ts
@@ -42,6 +42,7 @@ import { extractAndStripArtifacts, findArtifactPlaceholderIds, stripArtifactPlac
 import { ArtifactRepository, ArtifactSizeError, type ArtifactKind } from '../data/repositories/artifact-repository';
 import { processExternalToolCalling } from './external-tool-calling';
 import { ensureSession, saveUserMessage, saveAssistantMessage } from './request-persistence';
+import { getProviderCatalogEntry } from '../config/external-providers';
 import { createThinkingSummarySession } from '../services/chat-service/thinking-summarizer';
 import { getConversationDB } from '../data/conversation-db';
 import type {
@@ -288,6 +289,30 @@ export class ChatRequestHandler {
         // ChatService를 우회하여 단일 턴 LLM 호출 후 tool_calls 반환
         // ═══════════════════════════════════════════════════════
         if (tools && tools.length > 0) {
+            // 외부 provider fullId (Phase 2, 2026-07-26): 'chatgpt:*'/'openrouter:*' 등은
+            // provider gate 로 해석해 외부 어댑터로 dispatch — 이전엔 로컬 client 로
+            // silent fallback 되어 CLI 도구(tools 파라미터) 경로에서 외부 모델이 무시됐다.
+            // 해석 실패(키 미등록 등)는 ProviderError 를 그대로 전파해 명시 거절.
+            let externalProvider: { provider: import('../providers/i-provider').IProvider; modelId: string } | undefined;
+            {
+                const reqModel = (model || '').trim();
+                const colonIdx = reqModel.indexOf(':');
+                const prefix = colonIdx > 0 ? reqModel.slice(0, colonIdx) : '';
+                if (prefix && prefix !== 'local-llm' && getProviderCatalogEntry(prefix)) {
+                    const providerRouter = new ProviderRouter({
+                        localProvider: new LocalLLMProvider(client),
+                        externalKeysRepo: new ExternalKeysRepository(getPool()),
+                    });
+                    const resolved = await providerRouter.resolve(reqModel, {
+                        ...(userContext.authenticatedUserId
+                            ? { userId: userContext.authenticatedUserId }
+                            : {}),
+                        userRole: userContext.userRole,
+                    });
+                    externalProvider = { provider: resolved.provider, modelId: resolved.modelId };
+                }
+            }
+
             const result = await processExternalToolCalling({
                 message,
                 history,
@@ -295,6 +320,7 @@ export class ChatRequestHandler {
                 tools,
                 tool_choice,
                 client,
+                ...(externalProvider ? { externalProvider } : {}),
                 onToken,
                 abortSignal,
             });

--- a/apps/api/src/config/chatgpt-oauth.ts
+++ b/apps/api/src/config/chatgpt-oauth.ts
@@ -1,0 +1,49 @@
+/**
+ * @module config/chatgpt-oauth
+ * @description ChatGPT OAuth (Codex device flow) 설정 — L2 config + env override
+ *
+ * ChatGPT Plus/Pro 구독 계정으로 Codex 지원 GPT 모델을 사용하는 OAuth 통합.
+ * 공식 Codex CLI 의 OAuth 클라이언트를 차용하는 방식으로, opencode ·
+ * openai-oauth(EvanZhouDev) 와 동일 계열 기법이다.
+ *
+ * ⚠️ 비공식 endpoint — OpenAI 가 언제든 변경/차단할 수 있다. 값이 바뀌면
+ * env 로 무중단 오버라이드 가능하도록 전부 외부화한다.
+ *
+ * @see https://github.com/EvanZhouDev/openai-oauth (packages/core)
+ * @see https://github.com/anomalyco/opencode (packages/opencode/src/plugin/openai/codex.ts)
+ */
+
+/** 카탈로그 provider id — fullId prefix ('chatgpt:gpt-5.x') */
+export const CHATGPT_PROVIDER_ID = 'chatgpt';
+
+export const CHATGPT_OAUTH = {
+    /** Codex CLI 공식 OAuth 클라이언트 ID (공개 값 — PKCE public client) */
+    CLIENT_ID: process.env.CHATGPT_OAUTH_CLIENT_ID || 'app_EMoamEEZ73f0CkXaXp7hrann',
+
+    /** OAuth 발급자 (authorize/token/deviceauth 공통 origin) */
+    ISSUER: process.env.CHATGPT_OAUTH_ISSUER || 'https://auth.openai.com',
+
+    /** Codex 백엔드 base URL — Responses API 전용 upstream */
+    CODEX_BASE_URL:
+        process.env.CHATGPT_CODEX_BASE_URL || 'https://chatgpt.com/backend-api/codex',
+
+    /** 디바이스 코드 폴링 기본 간격 (초) — usercode 응답의 interval 이 우선 */
+    DEVICE_POLL_INTERVAL_SEC: parseInt(
+        process.env.CHATGPT_OAUTH_DEVICE_POLL_INTERVAL_SEC || '5', 10,
+    ),
+
+    /** access token 만료 전 이 여유(ms) 이내면 선제 refresh */
+    REFRESH_MARGIN_MS: parseInt(
+        process.env.CHATGPT_OAUTH_REFRESH_MARGIN_MS || '60000', 10,
+    ),
+
+    /** refresh 실패 등으로 expires 를 모를 때 가정하는 access token 수명 (초) */
+    DEFAULT_ACCESS_TOKEN_TTL_SEC: parseInt(
+        process.env.CHATGPT_OAUTH_ACCESS_TTL_SEC || '3600', 10,
+    ),
+} as const;
+
+/** 사용자가 코드를 입력할 검증 페이지 URL */
+export function chatgptDeviceVerifyUrl(): string {
+    return `${CHATGPT_OAUTH.ISSUER}/codex/device`;
+}

--- a/apps/api/src/config/external-providers.ts
+++ b/apps/api/src/config/external-providers.ts
@@ -108,6 +108,29 @@ export const EXTERNAL_PROVIDER_CATALOG: ReadonlyArray<ExternalProviderCatalogEnt
         ],
     },
     {
+        id: 'chatgpt',
+        displayName: 'ChatGPT (구독 로그인)',
+        sdkType: 'openai-compatible',
+        // Codex 백엔드 upstream — 실제 요청 조립은 ChatGPTOAuthProvider 의 transport 가 담당.
+        // api_key 등록 경로가 아니므로 사용자가 base_url 을 입력하지 않는다 (informational).
+        defaultBaseUrl: 'https://chatgpt.com/backend-api/codex',
+        validatePath: '/models',
+        enabled: true,
+        sortOrder: 25,
+        helpText:
+            'ChatGPT Plus/Pro 구독 계정으로 로그인하여 Codex 지원 GPT 모델을 사용합니다. ' +
+            'API 키가 아닌 OAuth 디바이스 로그인 방식입니다 — "로그인" 버튼을 누르고 ' +
+            '표시되는 코드를 OpenAI 인증 페이지에 입력하세요. ' +
+            '⚠️ 비공식 통합: 반드시 본인 계정만 사용해야 하며, OpenAI 정책 변경 시 ' +
+            '중단될 수 있습니다.',
+        authMethods: ['oauth'] as const,
+        // Codex 카탈로그 조회 실패 시 폴백 — 계정 플랜에 따라 실제 목록은 다를 수 있음.
+        fallbackModels: [
+            { id: 'gpt-5.4',      displayName: 'GPT-5.4 (ChatGPT)',      isFree: false, capabilities: { streaming: true, toolCalling: true, vision: true, thinking: true } },
+            { id: 'gpt-5.4-mini', displayName: 'GPT-5.4 Mini (ChatGPT)', isFree: false, capabilities: { streaming: true, toolCalling: true, vision: true, thinking: true } },
+        ],
+    },
+    {
         id: 'ollama-local',
         displayName: 'Ollama (Local)',
         sdkType: 'openai-compatible',

--- a/apps/api/src/data/repositories/external-keys-repo.ts
+++ b/apps/api/src/data/repositories/external-keys-repo.ts
@@ -25,7 +25,17 @@ const logger = createLogger('ExternalKeysRepo');
  */
 const KEY_PREFIX_LENGTH = 12;
 
+/** DB key_prefix 컬럼 상한 (VARCHAR(16), 마이그레이션 016) — 초과 시 INSERT 실패 */
+const KEY_PREFIX_COLUMN_MAX = 16;
+
 export type ExternalSdkType = 'anthropic' | 'openai-compatible';
+
+/**
+ * 키 인증 방식 (마이그레이션 082).
+ * - 'api_key': encrypted_key = 평문 API 키 암호화 (기존 동작)
+ * - 'oauth':   encrypted_key = OAuth 세션 JSON 암호화 (ChatGPT 디바이스 플로우)
+ */
+export type ExternalAuthMethod = 'api_key' | 'oauth';
 
 /**
  * 평문 API 키를 받지 않는 안전 조회 결과 (UI/일반 로직용)
@@ -35,9 +45,14 @@ export interface ExternalApiKeyRow {
     userId: string;
     providerId: string;
     sdkType: ExternalSdkType;
+    authMethod: ExternalAuthMethod;
     displayName: string;
     baseUrl: string | null;
     keyPrefix: string;
+    /** OAuth 계정 식별자 (auth_method='oauth' 전용, 복호화 없이 노출 가능) */
+    oauthAccountId: string | null;
+    /** OAuth access token 만료 시각 (auth_method='oauth' 전용) */
+    oauthExpiresAt: Date | null;
     isActive: boolean;
     lastValidatedAt: Date | null;
     lastValidationOk: boolean | null;
@@ -53,8 +68,14 @@ export interface UpsertExternalApiKeyInput {
     sdkType: ExternalSdkType;
     displayName: string;
     baseUrl?: string | null;
-    /** 평문 API 키 — repo 내부에서 즉시 암호화, 평문 보관 금지 */
+    /** 평문 API 키 또는 OAuth 세션 JSON — repo 내부에서 즉시 암호화, 평문 보관 금지 */
     apiKey: string;
+    /** 인증 방식 — 미지정 시 'api_key' */
+    authMethod?: ExternalAuthMethod;
+    /** OAuth 계정 식별자 (authMethod='oauth' 시) */
+    oauthAccountId?: string | null;
+    /** OAuth access token 만료 시각 (authMethod='oauth' 시) */
+    oauthExpiresAt?: Date | null;
 }
 
 interface DbRow {
@@ -62,10 +83,13 @@ interface DbRow {
     user_id: string;
     provider_id: string;
     sdk_type: ExternalSdkType;
+    auth_method: ExternalAuthMethod;
     display_name: string;
     base_url: string | null;
     encrypted_key: string;
     key_prefix: string;
+    oauth_account_id: string | null;
+    oauth_expires_at: Date | null;
     is_active: boolean;
     last_validated_at: Date | null;
     last_validation_ok: boolean | null;
@@ -89,9 +113,12 @@ function toRow(row: DbRow): ExternalApiKeyRow {
         userId: row.user_id,
         providerId: row.provider_id,
         sdkType: row.sdk_type,
+        authMethod: row.auth_method ?? 'api_key',
         displayName: row.display_name,
         baseUrl: row.base_url,
         keyPrefix: row.key_prefix,
+        oauthAccountId: row.oauth_account_id ?? null,
+        oauthExpiresAt: row.oauth_expires_at ?? null,
         isActive: row.is_active,
         lastValidatedAt: row.last_validated_at,
         lastValidationOk: row.last_validation_ok,
@@ -110,18 +137,27 @@ export class ExternalKeysRepository extends BaseRepository {
      * 평문 키는 즉시 암호화되며 `encrypted_key` 컬럼에만 저장됩니다.
      */
     async upsert(input: UpsertExternalApiKeyInput): Promise<ExternalApiKeyRow> {
+        const authMethod: ExternalAuthMethod = input.authMethod ?? 'api_key';
         const encrypted = encryptToken(input.apiKey);
-        const prefix = buildKeyPrefix(input.apiKey);
+        // OAuth 세션 JSON 은 prefix 로 노출하면 페이로드 조각이 새므로 계정 기반 표시로 대체.
+        // key_prefix 컬럼은 VARCHAR(16) — 'oauth:' (6자) + 계정 앞 10자로 상한을 지킨다.
+        const prefix = authMethod === 'oauth'
+            ? `oauth:${(input.oauthAccountId ?? 'session').slice(0, KEY_PREFIX_COLUMN_MAX - 6)}`
+            : buildKeyPrefix(input.apiKey);
         const result = await this.query<DbRow>(
             `INSERT INTO user_external_api_keys
-                (user_id, provider_id, sdk_type, display_name, base_url, encrypted_key, key_prefix)
-             VALUES ($1, $2, $3, $4, $5, $6, $7)
+                (user_id, provider_id, sdk_type, display_name, base_url, encrypted_key, key_prefix,
+                 auth_method, oauth_account_id, oauth_expires_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
              ON CONFLICT (user_id, provider_id) DO UPDATE SET
                 sdk_type = EXCLUDED.sdk_type,
                 display_name = EXCLUDED.display_name,
                 base_url = EXCLUDED.base_url,
                 encrypted_key = EXCLUDED.encrypted_key,
                 key_prefix = EXCLUDED.key_prefix,
+                auth_method = EXCLUDED.auth_method,
+                oauth_account_id = EXCLUDED.oauth_account_id,
+                oauth_expires_at = EXCLUDED.oauth_expires_at,
                 is_active = TRUE,
                 last_validated_at = NULL,
                 last_validation_ok = NULL,
@@ -136,6 +172,9 @@ export class ExternalKeysRepository extends BaseRepository {
                 input.baseUrl ?? null,
                 encrypted,
                 prefix,
+                authMethod,
+                input.oauthAccountId ?? null,
+                input.oauthExpiresAt?.toISOString() ?? null,
             ],
         );
         const row = result.rows[0];
@@ -190,6 +229,39 @@ export class ExternalKeysRepository extends BaseRepository {
         const row = result.rows[0];
         if (!row) return null;
         return decryptToken(row.encrypted_key);
+    }
+
+    /**
+     * OAuth 세션 갱신 (refresh token rotate) 후 암호화 페이로드·만료 메타를 갱신합니다.
+     * 평문 세션 JSON 은 즉시 암호화되며 로그에 남기지 않습니다.
+     */
+    async updateOAuthSession(
+        userId: string,
+        providerId: string,
+        input: {
+            /** 평문 OAuth 세션 JSON (repo 내부에서 즉시 암호화) */
+            plaintextSession: string;
+            oauthExpiresAt: Date | null;
+            oauthAccountId?: string | null;
+        },
+    ): Promise<void> {
+        const encrypted = encryptToken(input.plaintextSession);
+        await this.query(
+            `UPDATE user_external_api_keys
+             SET encrypted_key = $3,
+                 oauth_expires_at = $4,
+                 oauth_account_id = COALESCE($5, oauth_account_id),
+                 updated_at = now()
+             WHERE user_id = $1 AND provider_id = $2 AND is_active = TRUE`,
+            [
+                userId,
+                providerId,
+                encrypted,
+                input.oauthExpiresAt?.toISOString() ?? null,
+                input.oauthAccountId ?? null,
+            ],
+        );
+        logger.debug(`OAuth 세션 갱신: user=${userId} provider=${providerId}`);
     }
 
     /**

--- a/apps/api/src/providers/chatgpt-oauth/provider.ts
+++ b/apps/api/src/providers/chatgpt-oauth/provider.ts
@@ -1,0 +1,287 @@
+/**
+ * ============================================================
+ * ChatGPTOAuthProvider — ChatGPT 구독(OAuth) 기반 GPT 모델 어댑터
+ * ============================================================
+ *
+ * ChatGPT Plus/Pro 계정의 OAuth 세션으로 Codex 백엔드
+ * (chatgpt.com/backend-api/codex)를 호출한다. 요청 정규화(헤더·모델 카탈로그·
+ * responses-lite 등)는 @openai-oauth/core 의 transport fetch 가 담당하고,
+ * 본 클래스는 IProvider 계약 ↔ Responses API 변환만 수행한다.
+ *
+ * ⚠️ Codex 백엔드는 Chat Completions 미지원 — **Responses API 전용**
+ *    (opencode·openai-oauth 소스로 교차 확인, 2026-07-26).
+ * ⚠️ temperature/max_output_tokens 는 Codex 가 거부할 수 있어 전달하지 않는다
+ *    (opencode 의 chat.params 처리와 동일).
+ *
+ * ESM 주의: @openai-oauth/core 는 ESM-only. Node 24 의 require(esm) 로 로드
+ * 가능하지만 Jest CJS 런타임은 불가 — moduleNameMapper 로 shim 처리되며,
+ * 테스트에서는 transportFactory 주입으로 대체한다.
+ *
+ * @module providers/chatgpt-oauth/provider
+ */
+import OpenAI from 'openai';
+import {
+    IProvider,
+    SdkType,
+    ProviderCapabilities,
+    ProviderModel,
+    ChatStreamOptions,
+    ChatStreamCallbacks,
+    ChatStreamResult,
+    buildFullModelId,
+} from '../i-provider';
+import { ProviderError } from '../provider-errors';
+import { createLogger } from '../../utils/logger';
+import { createPinnedFetch } from '../../security/ssrf-guard';
+import { CHATGPT_OAUTH, CHATGPT_PROVIDER_ID } from '../../config/chatgpt-oauth';
+import {
+    ChatGPTOAuthSessionPayload,
+    isSessionExpired,
+    refreshSession,
+} from './session';
+import {
+    toResponsesInput,
+    toResponsesTools,
+    toResponsesToolChoice,
+    ResponsesStreamCollector,
+    ToolNameCodec,
+    type ResponsesStreamEvent,
+} from './responses-mapping';
+
+const logger = createLogger('ChatGPTOAuthProvider');
+
+/** Codex GPT-5 계열 보수적 한도 (context/output) — 카탈로그가 한도를 주지 않음 */
+const CHATGPT_CONTEXT_WINDOW_TOKENS = parseInt(
+    process.env.CHATGPT_MODEL_CONTEXT_WINDOW || '272000', 10,
+);
+const CHATGPT_OUTPUT_LIMIT_TOKENS = parseInt(
+    process.env.CHATGPT_MODEL_OUTPUT_LIMIT || '128000', 10,
+);
+
+/** @openai-oauth/core transport 의 본 모듈 사용 표면 (로컬 타이핑 — ESM 타입 결합 회피) */
+interface CodexTransport {
+    baseURL: string;
+    fetch: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+}
+
+type TransportFactory = (settings: {
+    auth: () => Promise<{
+        accessToken: string;
+        accountId: string;
+        refreshToken?: string;
+        expiresAt?: string;
+    }>;
+    baseURL?: string;
+    fetch?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+}) => CodexTransport;
+
+/** ESM-only core 를 CJS 에서 lazy require — 모듈 로드 시점 부작용 제거 */
+function loadTransportFactory(): TransportFactory {
+    const core = require('@openai-oauth/core') as {
+        createOpenAIOAuthTransport: TransportFactory;
+    };
+    return core.createOpenAIOAuthTransport;
+}
+
+function mapChatGPTError(err: unknown): ProviderError {
+    if (err instanceof ProviderError) return err;
+    const message = err instanceof Error ? err.message : String(err);
+    if (err && typeof err === 'object' && 'status' in err) {
+        const status = (err as { status?: number }).status;
+        if (status === 401 || status === 403) {
+            return new ProviderError(
+                'INVALID_API_KEY',
+                `ChatGPT OAuth 인증 실패 — 재로그인이 필요합니다: ${message}`,
+                err,
+            );
+        }
+        if (status === 429) {
+            return new ProviderError('QUOTA_EXCEEDED', `ChatGPT 사용량 한도 초과: ${message}`, err);
+        }
+        if (status === 404) {
+            return new ProviderError('MODEL_NOT_FOUND', `모델 미발견: ${message}`, err);
+        }
+    }
+    return new ProviderError('UPSTREAM_ERROR', `ChatGPT(Codex) 호출 실패: ${message}`, err);
+}
+
+export interface ChatGPTOAuthProviderOptions {
+    session: ChatGPTOAuthSessionPayload;
+    /** 세션 refresh 후 영속화 콜백 (미지정 시 in-memory 갱신만) */
+    persistSession?: (session: ChatGPTOAuthSessionPayload) => Promise<void>;
+    /** 테스트 전용 — core transport 대체 주입 */
+    transportFactory?: TransportFactory;
+}
+
+export class ChatGPTOAuthProvider implements IProvider {
+    readonly id = CHATGPT_PROVIDER_ID;
+    readonly sdkType: SdkType = 'openai-compatible';
+    readonly displayName = 'ChatGPT (OAuth)';
+
+    private client: OpenAI;
+    private session: ChatGPTOAuthSessionPayload;
+    private readonly persistSession?: (s: ChatGPTOAuthSessionPayload) => Promise<void>;
+    /** 동시 요청의 중복 refresh 방지 (single-flight) */
+    private refreshing?: Promise<ChatGPTOAuthSessionPayload>;
+
+    constructor(opts: ChatGPTOAuthProviderOptions) {
+        this.session = opts.session;
+        this.persistSession = opts.persistSession;
+
+        const factory = opts.transportFactory ?? loadTransportFactory();
+        const transport = factory({
+            auth: async () => {
+                const s = await this.getFreshSession();
+                return {
+                    accessToken: s.accessToken,
+                    accountId: s.accountId ?? '',
+                    refreshToken: s.refreshToken,
+                    expiresAt: s.expiresAt,
+                };
+            },
+            baseURL: CHATGPT_OAUTH.CODEX_BASE_URL,
+            // 🔒 SSRF: transport 내부의 실제 outbound 호출도 pinned fetch 로 —
+            //   DNS rebinding 차단 정책을 외부 provider 공통으로 유지.
+            fetch: createPinnedFetch(),
+        });
+
+        this.client = new OpenAI({
+            // 인증은 transport fetch 가 Bearer/chatgpt-account-id 헤더로 처리 — placeholder
+            apiKey: 'chatgpt-oauth',
+            baseURL: transport.baseURL,
+            fetch: transport.fetch,
+        });
+    }
+
+    /** 만료(또는 임박) 시 refresh 후 최신 세션 반환 — 갱신분은 persistSession 으로 영속화 */
+    private async getFreshSession(): Promise<ChatGPTOAuthSessionPayload> {
+        if (!isSessionExpired(this.session)) return this.session;
+        if (!this.refreshing) {
+            this.refreshing = refreshSession(this.session)
+                .then(async (next) => {
+                    this.session = next;
+                    try {
+                        await this.persistSession?.(next);
+                    } catch (err) {
+                        // 영속화 실패는 치명 아님 (다음 요청에서 재갱신) — 호출은 계속
+                        logger.warn(`OAuth 세션 영속화 실패: ${err instanceof Error ? err.message : err}`);
+                    }
+                    return next;
+                })
+                .finally(() => {
+                    this.refreshing = undefined;
+                });
+        }
+        return this.refreshing;
+    }
+
+    getCapabilities(modelId: string): ProviderCapabilities {
+        // Codex 카탈로그의 채팅 모델은 전부 GPT-5 계열 reasoning 모델 —
+        // thinking(summary)/tool calling/vision/streaming 모두 지원.
+        const isImageModel = /image/i.test(modelId);
+        return {
+            streaming: !isImageModel,
+            toolCalling: !isImageModel,
+            vision: true,
+            thinking: !isImageModel,
+        };
+    }
+
+    async listModels(): Promise<ProviderModel[]> {
+        try {
+            const list = await this.client.models.list();
+            return list.data.map((m) => ({
+                id: m.id,
+                fullId: buildFullModelId(this.id, m.id),
+                displayName: `${m.id} (ChatGPT)`,
+                contextWindow: CHATGPT_CONTEXT_WINDOW_TOKENS,
+                outputLimit: CHATGPT_OUTPUT_LIMIT_TOKENS,
+                capabilities: this.getCapabilities(m.id),
+            }));
+        } catch (err) {
+            logger.warn(`ChatGPT(Codex) 모델 목록 조회 실패: ${err instanceof Error ? err.message : err}`);
+            return [];
+        }
+    }
+
+    async validateCredentials(): Promise<{ ok: boolean; error?: string; latencyMs?: number }> {
+        const start = Date.now();
+        try {
+            const list = await this.client.models.list();
+            if (!list.data || list.data.length === 0) {
+                return {
+                    ok: false,
+                    error: 'Codex 모델 카탈로그가 비어있습니다 (플랜/세션 확인)',
+                    latencyMs: Date.now() - start,
+                };
+            }
+            return { ok: true, latencyMs: Date.now() - start };
+        } catch (err) {
+            return {
+                ok: false,
+                error: err instanceof Error ? err.message : String(err),
+                latencyMs: Date.now() - start,
+            };
+        }
+    }
+
+    async streamChat(
+        opts: ChatStreamOptions,
+        callbacks: ChatStreamCallbacks,
+    ): Promise<ChatStreamResult> {
+        // Codex 는 도구 이름 패턴(^[a-zA-Z0-9_-]+$)을 강제 — MCP 도구명에 섞인
+        // 비허용 문자를 정규화하고 응답 tool call 에서 원래 이름으로 복원한다.
+        const codec = new ToolNameCodec();
+        const tools = opts.tools && opts.tools.length > 0
+            ? toResponsesTools(opts.tools, codec)
+            : undefined;
+        const { instructions, input } = toResponsesInput(opts.messages, codec);
+        const renamed = codec.renamed();
+        if (renamed.length > 0) {
+            logger.debug(
+                `Codex 도구명 정규화 ${renamed.length}건: ${renamed.slice(0, 5).map((r) => `${r.from}→${r.to}`).join(', ')}`,
+            );
+        }
+
+        let aborted = false;
+        opts.abortSignal?.addEventListener('abort', () => { aborted = true; });
+
+        try {
+            const requestParams = {
+                model: opts.modelId,
+                input,
+                stream: true as const,
+                store: false,
+                ...(instructions ? { instructions } : {}),
+                ...(tools ? { tools } : {}),
+                ...(opts.tool_choice
+                    ? { tool_choice: toResponsesToolChoice(opts.tool_choice, codec) }
+                    : {}),
+                // temperature / max_output_tokens 미전달 — Codex 백엔드 거부 회피
+            };
+
+            const stream = await this.client.responses.create(
+                requestParams as never,
+                opts.abortSignal ? { signal: opts.abortSignal } : undefined,
+            );
+
+            const collector = new ResponsesStreamCollector(codec);
+            for await (const event of stream as unknown as AsyncIterable<ResponsesStreamEvent>) {
+                if (aborted) break;
+                collector.handleEvent(event, callbacks);
+            }
+
+            const failure = collector.getFailure();
+            if (failure && !aborted) {
+                throw new ProviderError('UPSTREAM_ERROR', `ChatGPT(Codex) 스트림 실패: ${failure}`);
+            }
+
+            return collector.finalize(callbacks, aborted);
+        } catch (err) {
+            if (aborted) {
+                throw new ProviderError('UPSTREAM_ERROR', 'ChatGPT(Codex) 호출 중단', err);
+            }
+            throw mapChatGPTError(err);
+        }
+    }
+}

--- a/apps/api/src/providers/chatgpt-oauth/responses-mapping.ts
+++ b/apps/api/src/providers/chatgpt-oauth/responses-mapping.ts
@@ -1,0 +1,350 @@
+/**
+ * ============================================================
+ * Responses API 매핑 — ChatMessage ↔ OpenAI Responses 변환
+ * ============================================================
+ *
+ * Codex 백엔드(chatgpt.com/backend-api/codex)는 Chat Completions 가 아닌
+ * **Responses API 전용**이다. 이 모듈은 IProvider 계약(ChatMessage/ToolDefinition/
+ * ChatStreamCallbacks)과 Responses 요청/스트리밍 이벤트 사이의 순수 변환만 담당한다
+ * (네트워크·SDK 의존 없음 — 단위 테스트 대상).
+ *
+ * @module providers/chatgpt-oauth/responses-mapping
+ */
+import type { ChatMessage, ToolDefinition, UsageMetrics } from '../../llm';
+import type { ChatStreamCallbacks, ChatStreamResult } from '../i-provider';
+import { inferImageMime } from '../../utils/image-mime';
+
+/* ── 도구 이름 정규화 ──────────────────────────────────────── */
+
+/**
+ * Codex 백엔드가 허용하는 도구 이름 패턴 — Chat Completions 보다 엄격하다.
+ * (라이브 E2E 에서 확인: 위반 시 400 "string does not match pattern".)
+ */
+const CODEX_TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+/** 보수적 길이 상한 — OpenAI function name 관례 */
+const CODEX_TOOL_NAME_MAX = 64;
+
+/**
+ * 도구 이름 정규화 코덱.
+ *
+ * MCP 서버가 등록하는 도구 이름에는 Codex 가 거부하는 문자(공백·점·콜론 등)가
+ * 섞일 수 있다. 요청 방향으로는 안전한 이름으로 치환하고, 응답의 tool call 은
+ * 원래 이름으로 되돌려 도구 실행 계층(이름으로 dispatch)이 그대로 동작하게 한다.
+ */
+export class ToolNameCodec {
+    private readonly toSanitized = new Map<string, string>();
+    private readonly toOriginal = new Map<string, string>();
+
+    /** 원래 이름 → Codex 안전 이름 (멱등, 충돌 시 suffix 부여) */
+    register(original: string): string {
+        const existing = this.toSanitized.get(original);
+        if (existing) return existing;
+
+        let candidate = original
+            .replace(/[^a-zA-Z0-9_-]/g, '_')
+            .slice(0, CODEX_TOOL_NAME_MAX);
+        if (!candidate || !CODEX_TOOL_NAME_PATTERN.test(candidate)) {
+            candidate = `tool_${this.toSanitized.size}`;
+        }
+        // 서로 다른 원본이 같은 안전 이름으로 접히면 dispatch 가 깨진다 — suffix 로 분리
+        let unique = candidate;
+        let n = 1;
+        while (this.toOriginal.has(unique) && this.toOriginal.get(unique) !== original) {
+            const suffix = `_${n++}`;
+            unique = `${candidate.slice(0, CODEX_TOOL_NAME_MAX - suffix.length)}${suffix}`;
+        }
+
+        this.toSanitized.set(original, unique);
+        this.toOriginal.set(unique, original);
+        return unique;
+    }
+
+    /** Codex 안전 이름 → 원래 이름 (미등록 이름은 그대로 통과) */
+    restore(sanitized: string): string {
+        return this.toOriginal.get(sanitized) ?? sanitized;
+    }
+
+    /** 정규화가 실제로 일어난 항목 (관측/로깅용) */
+    renamed(): Array<{ from: string; to: string }> {
+        return [...this.toSanitized.entries()]
+            .filter(([from, to]) => from !== to)
+            .map(([from, to]) => ({ from, to }));
+    }
+}
+
+/* ── 요청 변환 ─────────────────────────────────────────────── */
+
+type ResponsesContentPart =
+    | { type: 'input_text'; text: string }
+    | { type: 'input_image'; image_url: string; detail: 'auto' }
+    | { type: 'output_text'; text: string };
+
+type ResponsesInputItem =
+    | { type: 'message'; role: 'user' | 'assistant'; content: ResponsesContentPart[] }
+    | { type: 'function_call'; call_id: string; name: string; arguments: string }
+    | { type: 'function_call_output'; call_id: string; output: string };
+
+export interface ResponsesRequestParts {
+    /** system 메시지 병합 — Responses 의 instructions 파라미터로 전달 */
+    instructions?: string;
+    input: ResponsesInputItem[];
+}
+
+/**
+ * ChatMessage 히스토리 → Responses input 배열.
+ * - system → instructions 로 분리 병합 (Codex 는 message role 대신 instructions 사용)
+ * - user images → input_image 파트 (dataURL)
+ * - assistant tool_calls → function_call 아이템
+ * - tool 결과 → function_call_output 아이템
+ */
+export function toResponsesInput(
+    messages: ChatMessage[],
+    codec?: ToolNameCodec,
+): ResponsesRequestParts {
+    const systemParts: string[] = [];
+    const input: ResponsesInputItem[] = [];
+
+    for (const [idx, msg] of messages.entries()) {
+        if (msg.role === 'system') {
+            if (msg.content) systemParts.push(msg.content);
+            continue;
+        }
+
+        if (msg.role === 'tool') {
+            input.push({
+                type: 'function_call_output',
+                call_id: msg.tool_call_id ?? msg.tool_name ?? `tool_${idx}`,
+                output: msg.content ?? '',
+            });
+            continue;
+        }
+
+        if (msg.role === 'assistant') {
+            if (msg.content) {
+                input.push({
+                    type: 'message',
+                    role: 'assistant',
+                    content: [{ type: 'output_text', text: msg.content }],
+                });
+            }
+            for (const [i, tc] of (msg.tool_calls ?? []).entries()) {
+                input.push({
+                    type: 'function_call',
+                    call_id: tc.id ?? `call_${tc.function.name}_${i}`,
+                    // 히스토리의 도구 이름도 tools 정의와 같은 정규화를 거쳐야 매칭된다
+                    name: codec ? codec.register(tc.function.name) : tc.function.name,
+                    arguments: JSON.stringify(tc.function.arguments ?? {}),
+                });
+            }
+            continue;
+        }
+
+        // user
+        const parts: ResponsesContentPart[] = [];
+        if (msg.content) parts.push({ type: 'input_text', text: msg.content });
+        for (const img of msg.images ?? []) {
+            const url = img.startsWith('data:')
+                ? img
+                : `data:${inferImageMime(img)};base64,${img}`;
+            parts.push({ type: 'input_image', image_url: url, detail: 'auto' });
+        }
+        if (parts.length > 0) {
+            input.push({ type: 'message', role: 'user', content: parts });
+        }
+    }
+
+    return {
+        ...(systemParts.length > 0 ? { instructions: systemParts.join('\n\n') } : {}),
+        input,
+    };
+}
+
+/**
+ * ToolDefinition (Chat Completions nested) → Responses flat function 스키마.
+ * codec 전달 시 Codex 허용 패턴으로 이름을 정규화한다.
+ */
+export function toResponsesTools(
+    tools: ToolDefinition[],
+    codec?: ToolNameCodec,
+): Array<{
+    type: 'function';
+    name: string;
+    description: string;
+    parameters: unknown;
+    strict: false;
+}> {
+    return tools.map((t) => ({
+        type: 'function' as const,
+        name: codec ? codec.register(t.function.name) : t.function.name,
+        description: t.function.description,
+        parameters: t.function.parameters,
+        strict: false as const,
+    }));
+}
+
+/** tool_choice — Chat Completions 형식 → Responses 형식 */
+export function toResponsesToolChoice(
+    choice: 'auto' | 'none' | 'required' | { type: 'function'; function: { name: string } },
+    codec?: ToolNameCodec,
+): 'auto' | 'none' | 'required' | { type: 'function'; name: string } {
+    if (typeof choice === 'string') return choice;
+    return {
+        type: 'function',
+        name: codec ? codec.register(choice.function.name) : choice.function.name,
+    };
+}
+
+/* ── 스트리밍 이벤트 수집 ──────────────────────────────────── */
+
+/** Responses SSE 이벤트 중 본 모듈이 소비하는 최소 형태 */
+export interface ResponsesStreamEvent {
+    type: string;
+    delta?: string;
+    item_id?: string;
+    item?: {
+        type?: string;
+        id?: string;
+        call_id?: string;
+        name?: string;
+        arguments?: string;
+    };
+    response?: {
+        status?: string;
+        incomplete_details?: { reason?: string } | null;
+        usage?: { input_tokens?: number; output_tokens?: number };
+        error?: { message?: string } | null;
+    };
+}
+
+/**
+ * Responses 스트리밍 이벤트를 ChatStreamResult 로 누적하는 수집기.
+ * 이벤트 스키마: OpenAI Responses API streaming events.
+ */
+export class ResponsesStreamCollector {
+    private content = '';
+    private thinking = '';
+    private readonly toolBuffers = new Map<
+        string,
+        { callId: string; name: string; jsonBuffer: string; done: boolean }
+    >();
+    private usage: UsageMetrics = {};
+    private finishReason: ChatStreamResult['finishReason'] = 'stop';
+    private failure: string | null = null;
+
+    /** 도구 이름 정규화 코덱 — 응답의 tool call 이름을 원래 이름으로 되돌린다 */
+    constructor(private readonly codec?: ToolNameCodec) {}
+
+    handleEvent(event: ResponsesStreamEvent, callbacks: ChatStreamCallbacks): void {
+        switch (event.type) {
+            case 'response.output_text.delta': {
+                if (event.delta) {
+                    this.content += event.delta;
+                    callbacks.onToken?.(event.delta);
+                }
+                return;
+            }
+            case 'response.reasoning_summary_text.delta':
+            case 'response.reasoning_text.delta': {
+                if (event.delta) {
+                    this.thinking += event.delta;
+                    callbacks.onThinking?.(event.delta);
+                }
+                return;
+            }
+            case 'response.output_item.added': {
+                const item = event.item;
+                if (item?.type === 'function_call' && item.id) {
+                    this.toolBuffers.set(item.id, {
+                        callId: item.call_id ?? item.id,
+                        name: item.name ?? '',
+                        jsonBuffer: item.arguments ?? '',
+                        done: false,
+                    });
+                }
+                return;
+            }
+            case 'response.function_call_arguments.delta': {
+                const buf = event.item_id ? this.toolBuffers.get(event.item_id) : undefined;
+                if (buf && event.delta) buf.jsonBuffer += event.delta;
+                return;
+            }
+            case 'response.output_item.done': {
+                const item = event.item;
+                if (item?.type === 'function_call') {
+                    const key = item.id ?? '';
+                    const buf = this.toolBuffers.get(key) ?? {
+                        callId: item.call_id ?? key,
+                        name: item.name ?? '',
+                        jsonBuffer: '',
+                        done: false,
+                    };
+                    // done 이벤트의 완성 arguments 가 있으면 델타 누적보다 우선
+                    if (item.arguments) buf.jsonBuffer = item.arguments;
+                    if (item.name) buf.name = item.name;
+                    if (item.call_id) buf.callId = item.call_id;
+                    buf.done = true;
+                    this.toolBuffers.set(key || buf.callId, buf);
+                }
+                return;
+            }
+            case 'response.completed':
+            case 'response.incomplete': {
+                const usage = event.response?.usage;
+                this.usage = {
+                    prompt_tokens: usage?.input_tokens || undefined,
+                    completion_tokens: usage?.output_tokens || undefined,
+                };
+                if (event.response?.incomplete_details?.reason === 'max_output_tokens') {
+                    this.finishReason = 'length';
+                }
+                callbacks.onUsage?.(this.usage);
+                return;
+            }
+            case 'response.failed':
+            case 'error': {
+                this.failure =
+                    event.response?.error?.message ?? 'Responses 스트림 실패 (원인 미상)';
+                return;
+            }
+            default:
+                return; // 알 수 없는 이벤트는 무시 (스키마 전방 호환)
+        }
+    }
+
+    /** 스트림 실패 이벤트 발생 여부 — 발생 시 메시지 반환 */
+    getFailure(): string | null {
+        return this.failure;
+    }
+
+    finalize(callbacks: ChatStreamCallbacks, aborted: boolean): ChatStreamResult {
+        const toolCalls: Array<{ id: string; name: string; args: unknown }> = [];
+        for (const buf of this.toolBuffers.values()) {
+            let args: unknown = {};
+            try {
+                args = buf.jsonBuffer ? JSON.parse(buf.jsonBuffer) : {};
+            } catch {
+                // 파싱 실패 시 {} 강등 — openai-compat-provider 와 동일 정책
+            }
+            const call = {
+                id: buf.callId,
+                // 정규화된 이름 → 원래 이름 복원 (도구 dispatch 는 원래 이름 기준)
+                name: this.codec ? this.codec.restore(buf.name) : buf.name,
+                args,
+            };
+            toolCalls.push(call);
+            callbacks.onToolCall?.(call);
+        }
+
+        return {
+            content: this.content,
+            ...(this.thinking ? { thinking: this.thinking } : {}),
+            ...(toolCalls.length > 0 ? { toolCalls } : {}),
+            usage: this.usage,
+            finishReason: aborted
+                ? 'aborted'
+                : toolCalls.length > 0
+                    ? 'tool_calls'
+                    : this.finishReason,
+        };
+    }
+}

--- a/apps/api/src/providers/chatgpt-oauth/session.ts
+++ b/apps/api/src/providers/chatgpt-oauth/session.ts
@@ -1,0 +1,136 @@
+/**
+ * ============================================================
+ * ChatGPT OAuth 세션 — 페이로드 계약 + 토큰 갱신
+ * ============================================================
+ *
+ * user_external_api_keys.encrypted_key(auth_method='oauth')에 암호화 저장되는
+ * 세션 JSON 의 스키마와, refresh token 을 이용한 access token 갱신을 담당한다.
+ *
+ * 갱신 endpoint 는 표준 OAuth token grant (auth.openai.com/oauth/token)이며,
+ * 디바이스 플로우 발급 경로는 routes/external-oauth.routes.ts 참고.
+ *
+ * @module providers/chatgpt-oauth/session
+ */
+import { CHATGPT_OAUTH } from '../../config/chatgpt-oauth';
+import { ProviderError } from '../provider-errors';
+
+/**
+ * 암호화 저장되는 OAuth 세션 페이로드 (평문 JSON 계약).
+ * 필드 추가는 하위호환(optional)으로만 — 기존 저장분 파싱이 깨지면 안 됨.
+ */
+export interface ChatGPTOAuthSessionPayload {
+    accessToken: string;
+    refreshToken: string;
+    /** ChatGPT 계정 ID — Codex 요청의 chatgpt-account-id 헤더 값 */
+    accountId?: string;
+    /** access token 만료 시각 (ISO 8601) */
+    expiresAt?: string;
+}
+
+/** 세션 JSON 파싱 — 형식 오류 시 null (호출부에서 INVALID_API_KEY 처리) */
+export function parseSessionPayload(plaintext: string): ChatGPTOAuthSessionPayload | null {
+    try {
+        const parsed = JSON.parse(plaintext) as Record<string, unknown>;
+        if (typeof parsed?.accessToken !== 'string' || typeof parsed?.refreshToken !== 'string') {
+            return null;
+        }
+        return {
+            accessToken: parsed.accessToken,
+            refreshToken: parsed.refreshToken,
+            accountId: typeof parsed.accountId === 'string' ? parsed.accountId : undefined,
+            expiresAt: typeof parsed.expiresAt === 'string' ? parsed.expiresAt : undefined,
+        };
+    } catch {
+        return null;
+    }
+}
+
+export function serializeSessionPayload(session: ChatGPTOAuthSessionPayload): string {
+    return JSON.stringify(session);
+}
+
+/** 만료 여부 판정 — REFRESH_MARGIN_MS 이내로 남았으면 만료 취급 (선제 갱신) */
+export function isSessionExpired(session: ChatGPTOAuthSessionPayload): boolean {
+    if (!session.expiresAt) return true; // 만료 미상 → 보수적으로 갱신
+    const expiresMs = Date.parse(session.expiresAt);
+    if (!Number.isFinite(expiresMs)) return true;
+    return expiresMs - Date.now() < CHATGPT_OAUTH.REFRESH_MARGIN_MS;
+}
+
+/** JWT payload 디코드 (서명 검증 없음 — 클레임 추출 전용) */
+export function parseJwtClaims(token: string): Record<string, unknown> | undefined {
+    const parts = token.split('.');
+    if (parts.length !== 3) return undefined;
+    try {
+        return JSON.parse(Buffer.from(parts[1], 'base64url').toString()) as Record<string, unknown>;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * 토큰 응답에서 ChatGPT 계정 ID 추출.
+ * id_token 우선, access_token fallback — opencode 와 동일한 클레임 위치.
+ */
+export function extractAccountId(tokens: {
+    id_token?: string;
+    access_token?: string;
+}): string | undefined {
+    for (const token of [tokens.id_token, tokens.access_token]) {
+        if (!token) continue;
+        const claims = parseJwtClaims(token);
+        if (!claims) continue;
+        if (typeof claims.chatgpt_account_id === 'string') return claims.chatgpt_account_id;
+        const authClaim = claims['https://api.openai.com/auth'] as
+            | { chatgpt_account_id?: unknown }
+            | undefined;
+        if (typeof authClaim?.chatgpt_account_id === 'string') {
+            return authClaim.chatgpt_account_id;
+        }
+        const orgs = claims.organizations as Array<{ id?: unknown }> | undefined;
+        if (Array.isArray(orgs) && typeof orgs[0]?.id === 'string') return orgs[0].id;
+    }
+    return undefined;
+}
+
+interface TokenGrantResponse {
+    access_token: string;
+    refresh_token?: string;
+    id_token?: string;
+    expires_in?: number;
+}
+
+/**
+ * refresh token grant 로 세션 갱신.
+ * refresh token rotate(응답에 새 refresh_token 포함) 시 교체, 미포함 시 기존 유지.
+ *
+ * @throws {ProviderError} INVALID_API_KEY — grant 거절 (재로그인 필요)
+ */
+export async function refreshSession(
+    session: ChatGPTOAuthSessionPayload,
+    fetchImpl: typeof fetch = fetch,
+): Promise<ChatGPTOAuthSessionPayload> {
+    const response = await fetchImpl(`${CHATGPT_OAUTH.ISSUER}/oauth/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: session.refreshToken,
+            client_id: CHATGPT_OAUTH.CLIENT_ID,
+        }).toString(),
+    });
+    if (!response.ok) {
+        throw new ProviderError(
+            'INVALID_API_KEY',
+            `ChatGPT OAuth 토큰 갱신 실패 (HTTP ${response.status}) — 재로그인이 필요합니다`,
+        );
+    }
+    const tokens = (await response.json()) as TokenGrantResponse;
+    const expiresInSec = tokens.expires_in ?? CHATGPT_OAUTH.DEFAULT_ACCESS_TOKEN_TTL_SEC;
+    return {
+        accessToken: tokens.access_token,
+        refreshToken: tokens.refresh_token || session.refreshToken,
+        accountId: extractAccountId(tokens) ?? session.accountId,
+        expiresAt: new Date(Date.now() + expiresInSec * 1000).toISOString(),
+    };
+}

--- a/apps/api/src/providers/provider-router.ts
+++ b/apps/api/src/providers/provider-router.ts
@@ -20,6 +20,12 @@ import { ProviderError } from './provider-errors';
 import { LocalLLMProvider } from './local-llm-provider';
 import { AnthropicProvider } from './anthropic-provider';
 import { OpenAICompatProvider } from './openai-compat-provider';
+import { ChatGPTOAuthProvider } from './chatgpt-oauth/provider';
+import {
+    parseSessionPayload,
+    serializeSessionPayload,
+    type ChatGPTOAuthSessionPayload,
+} from './chatgpt-oauth/session';
 import type { ExternalKeysRepository, ExternalApiKeyRow } from '../data/repositories/external-keys-repo';
 import { createLogger } from '../utils/logger';
 
@@ -45,6 +51,12 @@ export interface ProviderRouterDeps {
     // Phase 4: openaiCompatProvider 팩토리
 }
 
+/** 외부 provider 인스턴스화 옵션 — OAuth 세션 갱신 영속화 콜백 등 */
+export interface ExternalProviderInstanceDeps {
+    /** OAuth refresh 후 세션 재암호화 저장 (미지정 시 in-memory 갱신만) */
+    onOAuthSessionUpdate?: (session: ChatGPTOAuthSessionPayload) => Promise<void>;
+}
+
 /**
  * sdk_type → 외부 provider 인스턴스 팩토리 맵.
  * 새 provider 추가 시 이 맵에 한 항목만 등록 (No-Hardcoding: switch/if 체인 금지 → Record lookup).
@@ -52,14 +64,33 @@ export interface ProviderRouterDeps {
  */
 const EXTERNAL_PROVIDER_FACTORIES: Record<
     string,
-    (args: { providerId: string; keyRow: ExternalApiKeyRow; plaintextKey: string }) => IProvider
+    (args: {
+        providerId: string;
+        keyRow: ExternalApiKeyRow;
+        plaintextKey: string;
+        deps?: ExternalProviderInstanceDeps;
+    }) => IProvider
 > = {
     anthropic: ({ keyRow, plaintextKey }) =>
         new AnthropicProvider({
             apiKey: plaintextKey,
             baseUrl: keyRow.baseUrl,
         }),
-    'openai-compatible': ({ providerId, keyRow, plaintextKey }) => {
+    'openai-compatible': ({ providerId, keyRow, plaintextKey, deps }) => {
+        // OAuth 행(ChatGPT 디바이스 플로우) — 평문은 API 키가 아닌 세션 JSON
+        if (keyRow.authMethod === 'oauth') {
+            const session = parseSessionPayload(plaintextKey);
+            if (!session) {
+                throw new ProviderError(
+                    'INVALID_API_KEY',
+                    `'${providerId}' OAuth 세션이 손상되었습니다 — 재로그인이 필요합니다`,
+                );
+            }
+            return new ChatGPTOAuthProvider({
+                session,
+                persistSession: deps?.onOAuthSessionUpdate,
+            });
+        }
         if (!keyRow.baseUrl) {
             throw new ProviderError(
                 'NOT_SUPPORTED',
@@ -75,16 +106,18 @@ const EXTERNAL_PROVIDER_FACTORIES: Record<
 };
 
 /**
- * 외부 provider 인스턴스 생성.
+ * 외부 provider 인스턴스 생성 (공용 진입점).
  *
  * 호출 시점에 해당 사용자의 키를 복호화하여 새 어댑터 인스턴스를 만든다.
  * 캐싱은 의도적으로 도입하지 않음 — 키 변경/삭제 즉시 반영, MVP 단계 단순성 우선.
+ * routes(model.routes / external-keys.routes)에서도 이 함수를 사용해
+ * provider별 분기(OAuth 등)를 한 곳에 유지한다.
  */
-async function instantiateExternalProvider(
-    providerId: string,
+export function createExternalProviderInstance(
     keyRow: ExternalApiKeyRow,
     plaintextKey: string,
-): Promise<IProvider> {
+    deps?: ExternalProviderInstanceDeps,
+): IProvider {
     const factory = EXTERNAL_PROVIDER_FACTORIES[keyRow.sdkType];
     if (!factory) {
         throw new ProviderError(
@@ -92,7 +125,26 @@ async function instantiateExternalProvider(
             `알 수 없는 sdk_type: ${keyRow.sdkType}`,
         );
     }
-    return factory({ providerId, keyRow, plaintextKey });
+    return factory({ providerId: keyRow.providerId, keyRow, plaintextKey, deps });
+}
+
+/**
+ * repo 기반 OAuth 세션 영속화 콜백 빌더 — provider-router / routes 공용.
+ */
+export function buildOAuthSessionPersist(
+    repo: ExternalKeysRepository,
+    userId: string,
+    providerId: string,
+): ExternalProviderInstanceDeps {
+    return {
+        onOAuthSessionUpdate: async (session) => {
+            await repo.updateOAuthSession(userId, providerId, {
+                plaintextSession: serializeSessionPayload(session),
+                oauthExpiresAt: session.expiresAt ? new Date(session.expiresAt) : null,
+                oauthAccountId: session.accountId ?? null,
+            });
+        },
+    };
 }
 
 export class ProviderRouter {
@@ -178,7 +230,13 @@ export class ProviderRouter {
             );
         }
 
-        const provider = await instantiateExternalProvider(providerId, keyRow, plaintextKey);
+        const provider = createExternalProviderInstance(
+            keyRow,
+            plaintextKey,
+            keyRow.authMethod === 'oauth'
+                ? buildOAuthSessionPersist(this.deps.externalKeysRepo, ctx.userId, providerId)
+                : undefined,
+        );
 
         return {
             provider,

--- a/apps/api/src/routes/external-keys.routes.ts
+++ b/apps/api/src/routes/external-keys.routes.ts
@@ -32,8 +32,11 @@ import {
     getProviderCatalogEntry,
 } from '../config/external-providers';
 import { validateOutboundUrl } from '../security/ssrf-guard';
-import { AnthropicProvider } from '../providers/anthropic-provider';
 import { OpenAICompatProvider } from '../providers/openai-compat-provider';
+import {
+    createExternalProviderInstance,
+    buildOAuthSessionPersist,
+} from '../providers/provider-router';
 
 /** 등록 직후 즉시 검증 타임아웃 (ms) — 죽은 LAN IP 등에서 등록 응답이 hang 되지 않도록 상한.
  *  env EXTERNAL_KEY_VALIDATION_TIMEOUT_MS 로 오버라이드. */
@@ -90,6 +93,7 @@ router.get('/',
                 provider_id: entry.id,
                 display_name: entry.displayName,
                 sdk_type: entry.sdkType,
+                auth_methods: entry.authMethods,
                 default_base_url: entry.defaultBaseUrl,
                 key_prefix_pattern: entry.keyPrefixPattern,
                 enabled: entry.enabled,
@@ -100,6 +104,8 @@ router.get('/',
                           display_name: userKey.displayName,
                           key_prefix: userKey.keyPrefix,
                           base_url: userKey.baseUrl,
+                          auth_method: userKey.authMethod,
+                          oauth_account_id: userKey.oauthAccountId,
                           last_validated_at: userKey.lastValidatedAt,
                           last_validation_ok: userKey.lastValidationOk,
                           last_validation_error: userKey.lastValidationError,
@@ -129,6 +135,16 @@ router.post('/:providerId',
         const catalogEntry = getProviderCatalogEntry(providerId);
         if (!catalogEntry) {
             res.status(404).json(notFound(`Unknown provider: ${providerId}`));
+            return;
+        }
+
+        // OAuth 전용 provider (chatgpt) 는 API 키 등록 경로 차단 — 디바이스 로그인 사용
+        if (!catalogEntry.authMethods.includes('api_key')) {
+            res.status(400).json(
+                badRequest(
+                    `Provider '${providerId}' 는 API 키 등록을 지원하지 않습니다 — OAuth 로그인을 사용하세요`,
+                ),
+            );
             return;
         }
 
@@ -340,24 +356,19 @@ router.post('/:providerId/validate',
             return;
         }
 
+        // 공용 팩토리 — OAuth 행(chatgpt) 분기 포함, sdk_type 오류는 ProviderError 로 전파
         let provider: IProvider;
-        if (existing.sdkType === 'anthropic') {
-            provider = new AnthropicProvider({ apiKey: plaintextKey, baseUrl: existing.baseUrl });
-        } else if (existing.sdkType === 'openai-compatible') {
-            if (!existing.baseUrl) {
-                res.status(400).json(
-                    badRequest(`'${providerId}' 키에 base_url 이 등록되지 않았습니다`),
-                );
-                return;
-            }
-            provider = new OpenAICompatProvider({
-                providerId,
-                apiKey: plaintextKey,
-                baseUrl: existing.baseUrl,
-            });
-        } else {
+        try {
+            provider = createExternalProviderInstance(
+                existing,
+                plaintextKey,
+                existing.authMethod === 'oauth'
+                    ? buildOAuthSessionPersist(getRepo(), userId, providerId)
+                    : undefined,
+            );
+        } catch (err) {
             res.status(400).json(
-                badRequest(`알 수 없는 sdk_type: ${existing.sdkType}`),
+                badRequest(err instanceof Error ? err.message : 'provider 인스턴스 생성 실패'),
             );
             return;
         }

--- a/apps/api/src/routes/external-oauth.routes.ts
+++ b/apps/api/src/routes/external-oauth.routes.ts
@@ -1,0 +1,234 @@
+/**
+ * ============================================================
+ * External OAuth Routes — ChatGPT 디바이스 플로우 로그인
+ * ============================================================
+ *
+ * ChatGPT Plus/Pro 계정을 OAuth 디바이스 코드 플로우로 연결한다.
+ * localhost 콜백이 필요 없어 웹/CLI 어디서든 동작:
+ *
+ *   1. POST /api/external-keys/chatgpt/oauth/start
+ *      → OpenAI deviceauth 에서 user_code 발급, 검증 URL 과 함께 반환
+ *   2. 사용자가 verification_url(auth.openai.com/codex/device)에서 코드 입력
+ *   3. POST /api/external-keys/chatgpt/oauth/poll  (프론트가 interval 간격 반복 호출)
+ *      → 승인 전: { status: 'pending' }
+ *      → 승인 후: authorization_code 교환 → 세션 암호화 저장 → { status: 'complete' }
+ *
+ * 서버는 폴링 상태를 보관하지 않는다(stateless) — device_auth_id/user_code 는
+ * 클라이언트가 들고 다니며, 저장은 승인 완료 시점의 upsert 1회뿐.
+ *
+ * ⚠️ deviceauth/* 는 비공식 endpoint (Codex CLI 차용) — 사용 전 재검토 필요 시
+ *    config/chatgpt-oauth.ts 의 env override 로 무중단 대응.
+ *
+ * @module routes/external-oauth.routes
+ */
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { requireAuth } from '../auth';
+import { validate } from '../middlewares/validation';
+import { asyncHandler } from '../utils/error-handler';
+import { success, badRequest, unauthorized } from '../utils/api-response';
+import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
+import { getPool } from '../data/models/unified-database';
+import {
+    CHATGPT_OAUTH,
+    CHATGPT_PROVIDER_ID,
+    chatgptDeviceVerifyUrl,
+} from '../config/chatgpt-oauth';
+import { getProviderCatalogEntry } from '../config/external-providers';
+import {
+    serializeSessionPayload,
+    extractAccountId,
+} from '../providers/chatgpt-oauth/session';
+import { createLogger } from '../utils/logger';
+
+const router = Router();
+const logger = createLogger('ExternalOAuthRoutes');
+
+let repoInstance: ExternalKeysRepository | null = null;
+function getRepo(): ExternalKeysRepository {
+    if (!repoInstance) {
+        repoInstance = new ExternalKeysRepository(getPool());
+    }
+    return repoInstance;
+}
+
+function getUserId(req: Request): string | null {
+    if (req.user && 'userId' in req.user) {
+        return (req.user as { userId: string }).userId;
+    }
+    if (req.user && 'id' in req.user) {
+        return String((req.user as { id: unknown }).id);
+    }
+    return null;
+}
+
+/**
+ * POST /chatgpt/oauth/start — 디바이스 코드 발급
+ */
+router.post('/chatgpt/oauth/start',
+    requireAuth,
+    asyncHandler(async (req: Request, res: Response) => {
+        const userId = getUserId(req);
+        if (!userId) {
+            res.status(401).json(unauthorized('User ID not found.'));
+            return;
+        }
+
+        const response = await fetch(
+            `${CHATGPT_OAUTH.ISSUER}/api/accounts/deviceauth/usercode`,
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ client_id: CHATGPT_OAUTH.CLIENT_ID }),
+            },
+        );
+        if (!response.ok) {
+            logger.warn(`deviceauth usercode 발급 실패: HTTP ${response.status}`);
+            res.status(502).json(
+                badRequest(`ChatGPT 디바이스 인증 시작 실패 (HTTP ${response.status})`),
+            );
+            return;
+        }
+
+        const data = (await response.json()) as {
+            device_auth_id?: string;
+            user_code?: string;
+            interval?: string | number;
+        };
+        if (!data.device_auth_id || !data.user_code) {
+            res.status(502).json(badRequest('디바이스 인증 응답 형식 오류'));
+            return;
+        }
+
+        const intervalSec = Math.max(
+            parseInt(String(data.interval), 10) || CHATGPT_OAUTH.DEVICE_POLL_INTERVAL_SEC,
+            1,
+        );
+
+        logger.info(`ChatGPT 디바이스 인증 시작: user=${userId}`);
+        res.json(success({
+            device_auth_id: data.device_auth_id,
+            user_code: data.user_code,
+            verification_url: chatgptDeviceVerifyUrl(),
+            interval_sec: intervalSec,
+        }));
+    }),
+);
+
+const pollSchema = z.object({
+    device_auth_id: z.string().min(1).max(256),
+    user_code: z.string().min(1).max(64),
+});
+
+/**
+ * POST /chatgpt/oauth/poll — 승인 확인 (1회 폴링) + 완료 시 토큰 교환·저장
+ */
+router.post('/chatgpt/oauth/poll',
+    requireAuth,
+    validate(pollSchema),
+    asyncHandler(async (req: Request, res: Response) => {
+        const userId = getUserId(req);
+        if (!userId) {
+            res.status(401).json(unauthorized('User ID not found.'));
+            return;
+        }
+        const { device_auth_id, user_code } = req.body as z.infer<typeof pollSchema>;
+
+        const pollResponse = await fetch(
+            `${CHATGPT_OAUTH.ISSUER}/api/accounts/deviceauth/token`,
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ device_auth_id, user_code }),
+            },
+        );
+
+        // 403/404 = 아직 미승인 (opencode 동일 시맨틱) — pending 으로 응답
+        if (pollResponse.status === 403 || pollResponse.status === 404) {
+            res.json(success({ status: 'pending' }));
+            return;
+        }
+        if (!pollResponse.ok) {
+            logger.warn(`deviceauth token 폴링 실패: HTTP ${pollResponse.status}`);
+            res.status(502).json(
+                badRequest(`디바이스 인증 확인 실패 (HTTP ${pollResponse.status}) — 처음부터 다시 시도하세요`),
+            );
+            return;
+        }
+
+        const approved = (await pollResponse.json()) as {
+            authorization_code?: string;
+            code_verifier?: string;
+        };
+        if (!approved.authorization_code || !approved.code_verifier) {
+            res.status(502).json(badRequest('디바이스 승인 응답 형식 오류'));
+            return;
+        }
+
+        // authorization_code → 토큰 교환 (PKCE verifier 는 deviceauth 가 발급)
+        const tokenResponse = await fetch(`${CHATGPT_OAUTH.ISSUER}/oauth/token`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({
+                grant_type: 'authorization_code',
+                code: approved.authorization_code,
+                redirect_uri: `${CHATGPT_OAUTH.ISSUER}/deviceauth/callback`,
+                client_id: CHATGPT_OAUTH.CLIENT_ID,
+                code_verifier: approved.code_verifier,
+            }).toString(),
+        });
+        if (!tokenResponse.ok) {
+            logger.warn(`OAuth 토큰 교환 실패: HTTP ${tokenResponse.status}`);
+            res.status(502).json(
+                badRequest(`토큰 교환 실패 (HTTP ${tokenResponse.status}) — 처음부터 다시 시도하세요`),
+            );
+            return;
+        }
+
+        const tokens = (await tokenResponse.json()) as {
+            access_token?: string;
+            refresh_token?: string;
+            id_token?: string;
+            expires_in?: number;
+        };
+        if (!tokens.access_token || !tokens.refresh_token) {
+            res.status(502).json(badRequest('토큰 응답 형식 오류'));
+            return;
+        }
+
+        const accountId = extractAccountId(tokens);
+        const expiresAt = new Date(
+            Date.now() + (tokens.expires_in ?? CHATGPT_OAUTH.DEFAULT_ACCESS_TOKEN_TTL_SEC) * 1000,
+        );
+        const catalogEntry = getProviderCatalogEntry(CHATGPT_PROVIDER_ID);
+
+        await getRepo().upsert({
+            userId,
+            providerId: CHATGPT_PROVIDER_ID,
+            sdkType: 'openai-compatible',
+            displayName: catalogEntry?.displayName ?? 'ChatGPT',
+            baseUrl: catalogEntry?.defaultBaseUrl ?? CHATGPT_OAUTH.CODEX_BASE_URL,
+            apiKey: serializeSessionPayload({
+                accessToken: tokens.access_token,
+                refreshToken: tokens.refresh_token,
+                accountId,
+                expiresAt: expiresAt.toISOString(),
+            }),
+            authMethod: 'oauth',
+            oauthAccountId: accountId ?? null,
+            oauthExpiresAt: expiresAt,
+        });
+        await getRepo().invalidateCachedModels(userId, CHATGPT_PROVIDER_ID);
+
+        logger.info(
+            `ChatGPT OAuth 연결 완료: user=${userId} account=${accountId ?? 'unknown'}`,
+        );
+        res.json(success({
+            status: 'complete',
+            provider_id: CHATGPT_PROVIDER_ID,
+            account_id: accountId ?? null,
+        }));
+    }),
+);
+
+export default router;

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -56,6 +56,7 @@ export { default as apiKeysRouter } from './api-keys.routes';
 
 // 🆕 외부 LLM provider BYO Key 관리 라우트
 export { default as externalKeysRouter } from './external-keys.routes';
+export { default as externalOAuthRouter } from './external-oauth.routes';
 
 // 🆕 Developer Documentation 라우트
 export { default as developerDocsRouter } from './developer-docs.routes';

--- a/apps/api/src/routes/model.routes.ts
+++ b/apps/api/src/routes/model.routes.ts
@@ -24,7 +24,10 @@ import { requireAuth, requireAdmin, optionalAuth } from '../auth';
 import { getModelHealthMonitor } from '../services/model-health-monitor';
 import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
 import { getPool } from '../data/models/unified-database';
-import { OpenAICompatProvider } from '../providers/openai-compat-provider';
+import {
+    createExternalProviderInstance,
+    buildOAuthSessionPersist,
+} from '../providers/provider-router';
 import { buildFullModelId } from '../providers/i-provider';
 import { getProviderCatalogEntry } from '../config/external-providers';
 import { isRoleAssignableModel } from '../config/role-model-filter';
@@ -170,11 +173,15 @@ router.get('/models', optionalAuth, asyncHandler(async (req: Request, res: Respo
                         if (!list || list.length === 0) {
                             const plaintextKey = await repo.decryptKey(userId, keyRow.providerId);
                             if (!plaintextKey) continue;
-                            const provider = new OpenAICompatProvider({
-                                providerId: keyRow.providerId,
-                                apiKey: plaintextKey,
-                                baseUrl: keyRow.baseUrl,
-                            });
+                            // 공용 팩토리 사용 — OAuth 행(chatgpt)은 Codex transport 기반
+                            // ChatGPTOAuthProvider 로 분기된다 (refresh 시 세션 영속화 포함).
+                            const provider = createExternalProviderInstance(
+                                keyRow,
+                                plaintextKey,
+                                keyRow.authMethod === 'oauth'
+                                    ? buildOAuthSessionPersist(repo, userId, keyRow.providerId)
+                                    : undefined,
+                            );
                             const fresh = await provider.listModels();
                             list = fresh.map((m) => ({
                                 id: m.id,

--- a/apps/api/src/routes/openai-compat.routes.ts
+++ b/apps/api/src/routes/openai-compat.routes.ts
@@ -10,6 +10,9 @@ import {
 } from '../services/OpenAICompatService';
 import { listAvailableModels } from '../chat/profile-resolver';
 import { parseFullModelId } from '../providers/i-provider';
+import { getProviderCatalogEntry } from '../config/external-providers';
+import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
+import { getPool } from '../data/models/unified-database';
 
 const openaiCompatRouter = Router();
 let clusterManager: ClusterManager;
@@ -137,21 +140,42 @@ openaiCompatRouter.post('/chat/completions', asyncHandler(async (req: Request, r
     // body.model 검증 (2026-05-19): 이전엔 임의 문자열도 buildExecutionPlan() 가 기본 모델로
     // silent override → 운영자/외부 클라이언트가 *잘못된 모델 이름* 을 보내도 알 길 없음.
     // vLLM/OpenAI spec 준수 위해 listAvailableModels() 에 없는 model id 는 404 로 거절.
-    // 호환: 'local-llm:<model>' fullId 형식 허용. 그 외 알 수 없는 prefix 는
-    // 아래 available 검증에서 404 로 명시 거절.
+    // 호환: 'local-llm:<model>' fullId 형식 허용.
+    // 외부 provider 개방 (2026-07-26 Phase 2): 카탈로그 등록 provider 의 fullId
+    // ('openrouter:*', 'chatgpt:*' 등)는 요청 사용자의 BYO 키/OAuth 세션이 등록돼
+    // 있으면 통과 — CLI/서드파티 OpenAI 호환 클라이언트에서 외부 모델 사용 가능.
+    // 다운스트림 dispatch 는 채팅 단일 경로의 provider gate 가 동일하게 처리한다.
+    // 그 외 알 수 없는 prefix 는 아래 available 검증에서 404 로 명시 거절.
     {
         const available = new Set(listAvailableModels().map((m) => m.id));
         const requested = body.model;
         let resolvedModelId: string = requested;
+        let externalAllowed = false;
         if (requested.includes(':')) {
             try {
                 const parsed = parseFullModelId(requested);
                 if (parsed.providerId === 'local-llm') {
                     resolvedModelId = parsed.modelId;
+                } else if (getProviderCatalogEntry(parsed.providerId)) {
+                    const apiUserId = req.apiKeyRecord?.user_id?.toString() || null;
+                    if (apiUserId) {
+                        const keyRow = await new ExternalKeysRepository(getPool())
+                            .getByUserAndProvider(apiUserId, parsed.providerId);
+                        externalAllowed = !!keyRow;
+                    }
+                    if (!externalAllowed) {
+                        openaiError(
+                            res,
+                            403,
+                            `Model '${requested}' requires a registered '${parsed.providerId}' key for this account. ` +
+                            `Register it in Settings → 외부 LLM 연동.`,
+                        );
+                        return;
+                    }
                 }
             } catch { /* invalid fullId 형식 — 그대로 검증 */ }
         }
-        if (!available.has(requested) && !available.has(resolvedModelId)) {
+        if (!externalAllowed && !available.has(requested) && !available.has(resolvedModelId)) {
             openaiError(
                 res,
                 404,

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -57,6 +57,7 @@ import {
     chatFeedbackRouter,
     apiKeysRouter,
     externalKeysRouter,
+    externalOAuthRouter,
     artifactsRouter,
     artifactPublicationRouter,
 } from './index';
@@ -261,6 +262,8 @@ export function setupApiRoutes(
     app.use('/api/push', pushRouter);
     app.use('/api/docs', developerDocsRouter);
     app.use('/api/api-keys', apiKeysRouter);
+    // OAuth 디바이스 플로우 (chatgpt) — /:providerId 패턴과 경로 충돌 없도록 선행 마운트
+    app.use('/api/external-keys', externalOAuthRouter);
     app.use('/api/external-keys', externalKeysRouter);
 
     // Swagger 설정

--- a/apps/api/src/routes/v1/index.ts
+++ b/apps/api/src/routes/v1/index.ts
@@ -39,6 +39,10 @@ import { pushRouter } from '../push.routes';
 import apiKeysRouter from '../api-keys.routes';
 import openaiCompatRouter from '../openai-compat.routes';
 import { listAvailableModels } from '../../chat/profile-resolver';
+import { ExternalKeysRepository } from '../../data/repositories/external-keys-repo';
+import { getPool } from '../../data/models/unified-database';
+import { getProviderCatalogEntry } from '../../config/external-providers';
+import { buildFullModelId } from '../../providers/i-provider';
 import { success, unauthorized } from '../../utils/api-response';
 import { requireApiKey } from '../../middlewares/api-key-auth';
 import { apiKeyRateLimiter, apiKeyTPMLimiter } from '../../middlewares/api-key-limiter';
@@ -144,21 +148,56 @@ v1Router.use('/push', pushRouter);
 v1Router.use('/api-keys', apiKeysRouter);
 
 // §9 모델 목록 (외부 API Key 사용자용)
-v1Router.get('/models', asyncHandler(async (_req, res) => {
+v1Router.get('/models', asyncHandler(async (req, res) => {
     const created = Math.floor(Date.now() / 1000);
     const models = listAvailableModels();
-    res.json({
-        object: 'list',
-        data: models.map(m => ({
-            id: m.id,
-            object: 'model',
-            created,
-            owned_by: 'openmake',
-            name: m.name,
-            description: m.description,
-            capabilities: m.capabilities,
-        })),
-    });
+    const data: Array<Record<string, unknown>> = models.map(m => ({
+        id: m.id,
+        object: 'model',
+        created,
+        owned_by: 'openmake',
+        name: m.name,
+        description: m.description,
+        capabilities: m.capabilities,
+    }));
+
+    // 외부 provider 모델 노출 (Phase 2, 2026-07-26): API 키 사용자가 등록한
+    // BYO/OAuth provider 의 모델을 fullId 로 나열 — CLI/서드파티 클라이언트가
+    // /v1/models 디스커버리만으로 'chatgpt:*' 등을 선택할 수 있게 한다.
+    // 라이브 호출 없이 캐시(external_provider_models_cache) → 카탈로그 fallback 순.
+    const apiUserId = req.apiKeyRecord?.user_id?.toString() || null;
+    if (apiUserId) {
+        try {
+            const repo = new ExternalKeysRepository(getPool());
+            const cacheTtlMs = parseInt(process.env.EXTERNAL_MODELS_CACHE_TTL_MS ?? '3600000', 10);
+            const keys = await repo.listByUser(apiUserId);
+            for (const keyRow of keys) {
+                const cached = await repo.getCachedModels(apiUserId, keyRow.providerId, cacheTtlMs) as
+                    | Array<{ id?: string; fullId?: string }>
+                    | null;
+                const entries = (cached && cached.length > 0)
+                    ? cached.map((m) => ({
+                        fullId: m.fullId ?? buildFullModelId(keyRow.providerId, m.id ?? ''),
+                    }))
+                    : (getProviderCatalogEntry(keyRow.providerId)?.fallbackModels ?? []).map((m) => ({
+                        fullId: buildFullModelId(keyRow.providerId, m.id),
+                    }));
+                for (const m of entries) {
+                    if (!m.fullId) continue;
+                    data.push({
+                        id: m.fullId,
+                        object: 'model',
+                        created,
+                        owned_by: keyRow.providerId,
+                    });
+                }
+            }
+        } catch {
+            // 외부 카탈로그 조회 실패는 로컬 목록 응답을 막지 않는다 (fail-open)
+        }
+    }
+
+    res.json({ object: 'list', data });
 }));
 
 export default v1Router;

--- a/apps/api/src/services/chat-service/provider-gate.ts
+++ b/apps/api/src/services/chat-service/provider-gate.ts
@@ -39,6 +39,7 @@ import type {
 const KNOWN_FULLID_PREFIXES: readonly string[] = [
     'local-llm',
     'openrouter',
+    'chatgpt',
     'ollama-local',
     'ollama-cloud',
     'nvidia',

--- a/apps/api/src/services/model-assignment-validation.ts
+++ b/apps/api/src/services/model-assignment-validation.ts
@@ -12,6 +12,10 @@ import { getPool } from '../data/models/unified-database';
 import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
 import { EXTERNAL_PROVIDER_CATALOG } from '../config/external-providers';
 import { isExternalFullId, toLocalModelTag } from '../config/model-roles';
+import {
+    createExternalProviderInstance,
+    buildOAuthSessionPersist,
+} from '../providers/provider-router';
 import { createClient } from '../llm';
 import { createLogger } from '../utils/logger';
 
@@ -39,13 +43,36 @@ async function validateExternalAssignment(userId: string, fullId: string): Promi
 
     // 실호출 probe — /models 카탈로그에 있어도 계정별로 추론이 404/403 인 모델이 있다
     // (NVIDIA 무료티어 등). 실제 역할 수행 불가 모델을 배정 시점에 거부한다.
+    //
+    // provider 별 호출 규약 차이(OAuth 세션·Responses API 등)는 공용 팩토리가 흡수한다 —
+    // 직접 LLMClient 를 조립하면 ChatGPT(OAuth) 처럼 base_url+Bearer 규약이 아닌
+    // provider 가 Cloudflare 403 으로 떨어진다 (2026-07-26 라이브에서 확인).
     const plaintextKey = await keysRepo.decryptKey(userId, providerId);
     if (!plaintextKey) return `'${providerId}' 키 복호화 실패`;
-    const baseUrl = keyRow.baseUrl || entry.defaultBaseUrl;
     try {
-        const client = createClient({ baseUrl, apiKey: plaintextKey, model: modelId, userId });
-        await client.derive({ timeout: ASSIGNMENT_PROBE_TIMEOUT_MS })
-            .chat([{ role: 'user', content: 'ping' }], { num_predict: 1 }, undefined, { think: false });
+        const provider = createExternalProviderInstance(
+            keyRow,
+            plaintextKey,
+            keyRow.authMethod === 'oauth'
+                ? buildOAuthSessionPersist(keysRepo, userId, providerId)
+                : undefined,
+        );
+        const abort = new AbortController();
+        const timer = setTimeout(() => abort.abort(), ASSIGNMENT_PROBE_TIMEOUT_MS);
+        timer.unref?.();
+        try {
+            await provider.streamChat(
+                {
+                    messages: [{ role: 'user', content: 'ping' }],
+                    modelId,
+                    maxTokens: 1,
+                    abortSignal: abort.signal,
+                },
+                {},
+            );
+        } finally {
+            clearTimeout(timer);
+        }
     } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         logger.warn(`모델 배정 probe 실패 (${fullId}): ${msg}`);

--- a/apps/web/components/settings/provider-keys-section.tsx
+++ b/apps/web/components/settings/provider-keys-section.tsx
@@ -34,6 +34,8 @@ interface UserKey {
   display_name: string;
   key_prefix: string;
   base_url: string | null;
+  auth_method?: "api_key" | "oauth";
+  oauth_account_id?: string | null;
   last_validation_ok: boolean | null;
   last_used_at: string | null;
   created_at: string;
@@ -43,9 +45,18 @@ interface ProviderEntry {
   provider_id: string;
   display_name: string;
   sdk_type: SdkType;
+  auth_methods?: Array<"api_key" | "oauth">;
   default_base_url: string | null;
   help_text?: string;
   user_key: UserKey | null;
+}
+
+/** OAuth 디바이스 플로우 시작 응답 (backend external-oauth.routes) */
+interface OAuthStartData {
+  device_auth_id: string;
+  user_code: string;
+  verification_url: string;
+  interval_sec: number;
 }
 
 /** SdkType → 번역 키 (렌더 시 t() 로 해석) */
@@ -252,6 +263,10 @@ function AddKeyForm({
   const [formError, setFormError] = useState<string | null>(null);
 
   const selected = providers.find((p) => p.provider_id === providerId);
+  const isOAuthOnly =
+    !!selected?.auth_methods &&
+    selected.auth_methods.includes("oauth") &&
+    !selected.auth_methods.includes("api_key");
 
   async function handleSubmit() {
     if (!displayName.trim() || apiKey.trim().length < 8) {
@@ -346,29 +361,35 @@ function AddKeyForm({
               />
             </label>
           </div>
-          <label className="block">
-            <span className="mb-1 block text-xs font-medium text-fg-2">
-              {t("apiKeyLabel")}
-            </span>
-            <input
-              type="password"
-              value={apiKey}
-              onChange={(e) => setApiKey(e.target.value)}
-              placeholder="sk-..."
-              className="h-9 w-full rounded-md border border-border-strong bg-surface px-3 font-mono text-sm text-fg outline-none focus:border-accent"
-            />
-          </label>
-          <label className="block">
-            <span className="mb-1 block text-xs font-medium text-fg-2">
-              {t("baseUrlLabel")}
-            </span>
-            <input
-              value={baseUrl}
-              onChange={(e) => setBaseUrl(e.target.value)}
-              placeholder={selected?.default_base_url ?? "https://..."}
-              className="h-9 w-full rounded-md border border-border-strong bg-surface px-3 font-mono text-sm text-fg outline-none focus:border-accent"
-            />
-          </label>
+          {isOAuthOnly ? (
+            <OAuthConnect providerId={providerId} onConnected={onSaved} />
+          ) : (
+            <>
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium text-fg-2">
+                  {t("apiKeyLabel")}
+                </span>
+                <input
+                  type="password"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  placeholder="sk-..."
+                  className="h-9 w-full rounded-md border border-border-strong bg-surface px-3 font-mono text-sm text-fg outline-none focus:border-accent"
+                />
+              </label>
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium text-fg-2">
+                  {t("baseUrlLabel")}
+                </span>
+                <input
+                  value={baseUrl}
+                  onChange={(e) => setBaseUrl(e.target.value)}
+                  placeholder={selected?.default_base_url ?? "https://..."}
+                  className="h-9 w-full rounded-md border border-border-strong bg-surface px-3 font-mono text-sm text-fg outline-none focus:border-accent"
+                />
+              </label>
+            </>
+          )}
 
           {formError && <p className="text-xs text-danger">{formError}</p>}
 
@@ -376,17 +397,146 @@ function AddKeyForm({
             <Button type="button" variant="outline" onClick={onClose}>
               {t("cancel")}
             </Button>
-            <Button type="submit" disabled={saving}>
-              {saving ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Save className="h-4 w-4" />
-              )}
-              {t("save")}
-            </Button>
+            {!isOAuthOnly && (
+              <Button type="submit" disabled={saving}>
+                {saving ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Save className="h-4 w-4" />
+                )}
+                {t("save")}
+              </Button>
+            )}
           </div>
         </form>
       </CardContent>
     </Card>
+  );
+}
+
+/* ── OAuth 디바이스 플로우 연결 (ChatGPT) ─────────────────── */
+function OAuthConnect({
+  providerId,
+  onConnected,
+}: {
+  providerId: string;
+  onConnected: () => void | Promise<void>;
+}) {
+  const t = useTranslations("apiKeys");
+  const [start, setStart] = useState<OAuthStartData | null>(null);
+  const [starting, setStarting] = useState(false);
+  const [connected, setConnected] = useState(false);
+  const [oauthError, setOauthError] = useState<string | null>(null);
+
+  async function handleStart() {
+    setStarting(true);
+    setOauthError(null);
+    try {
+      const res = await ApiClient.post<ApiSuccess<OAuthStartData>>(
+        `/api/external-keys/${providerId}/oauth/start`,
+        {},
+      );
+      if (!res?.data?.user_code) throw new Error(t("serverError"));
+      setStart(res.data);
+    } catch (e) {
+      setOauthError(
+        t("oauthFailed", {
+          error: e instanceof Error ? e.message : t("serverError"),
+        }),
+      );
+    } finally {
+      setStarting(false);
+    }
+  }
+
+  // 승인 폴링 — start 후 interval_sec 간격으로 poll, complete 시 종료
+  useEffect(() => {
+    if (!start || connected) return;
+    let cancelled = false;
+    const intervalMs = Math.max(start.interval_sec, 1) * 1000;
+    const timer = setInterval(() => {
+      void (async () => {
+        try {
+          const res = await ApiClient.post<
+            ApiSuccess<{ status: "pending" | "complete" }>
+          >(`/api/external-keys/${providerId}/oauth/poll`, {
+            device_auth_id: start.device_auth_id,
+            user_code: start.user_code,
+          });
+          if (cancelled) return;
+          if (res?.data?.status === "complete") {
+            setConnected(true);
+            clearInterval(timer);
+            await onConnected();
+          }
+        } catch (e) {
+          if (cancelled) return;
+          clearInterval(timer);
+          setOauthError(
+            t("oauthFailed", {
+              error: e instanceof Error ? e.message : t("serverError"),
+            }),
+          );
+          setStart(null);
+        }
+      })();
+    }, intervalMs);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [start, connected, providerId, onConnected, t]);
+
+  if (connected) {
+    return (
+      <p className="rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-fg">
+        ✅ {t("oauthConnected")}
+      </p>
+    );
+  }
+
+  if (start) {
+    return (
+      <div className="space-y-3 rounded-md border border-border bg-surface-2 p-4">
+        <p className="text-xs leading-relaxed text-muted">
+          {t("oauthInstruction")}
+        </p>
+        <div>
+          <span className="mb-1 block text-xs font-medium text-fg-2">
+            {t("oauthCodeLabel")}
+          </span>
+          <code className="block select-all rounded-md border border-border-strong bg-surface px-3 py-2 text-center font-mono text-lg tracking-widest text-fg">
+            {start.user_code}
+          </code>
+        </div>
+        <a
+          href={start.verification_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-sm font-medium text-accent hover:underline"
+        >
+          {t("oauthOpenPage")} ↗
+        </a>
+        <p className="flex items-center gap-2 text-xs text-muted">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          {t("oauthWaiting")}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-muted">{t("oauthHint")}</p>
+      <Button type="button" onClick={() => void handleStart()} disabled={starting}>
+        {starting ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <KeyRound className="h-4 w-4" />
+        )}
+        {t("oauthLogin")}
+      </Button>
+      {oauthError && <p className="text-xs text-danger">{oauthError}</p>}
+    </div>
   );
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1362,7 +1362,17 @@
       "anthropic": "Anthropic",
       "openaiCompatible": "OpenAI-compatible"
     },
-    "validationWarning": "Key saved, but endpoint validation failed: {error} — check the URL/key and save again."
+    "validationWarning": "Key saved, but endpoint validation failed: {error} — check the URL/key and save again.",
+    "oauthLogin": "Sign in with ChatGPT",
+    "oauthStart": "Start sign-in",
+    "oauthHint": "This provider uses OAuth sign-in instead of an API key.",
+    "oauthCodeLabel": "Verification code",
+    "oauthInstruction": "Open the link below, enter this code, and approve. The connection completes automatically once approved.",
+    "oauthOpenPage": "Open verification page",
+    "oauthWaiting": "Waiting for approval...",
+    "oauthConnected": "Connected",
+    "oauthFailed": "Sign-in failed: {error}",
+    "oauthAccount": "Account"
   },
   "modelRoles": {
     "title": "Model Roles",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1362,7 +1362,17 @@
       "anthropic": "Anthropic",
       "openaiCompatible": "OpenAI互換"
     },
-    "validationWarning": "キーは保存されましたが、endpoint の検証に失敗しました: {error} — URL/キーを確認して再保存してください。"
+    "validationWarning": "キーは保存されましたが、endpoint の検証に失敗しました: {error} — URL/キーを確認して再保存してください。",
+    "oauthLogin": "ChatGPT でログイン",
+    "oauthStart": "ログイン開始",
+    "oauthHint": "このプロバイダーは API キーの代わりに OAuth ログインを使用します。",
+    "oauthCodeLabel": "認証コード",
+    "oauthInstruction": "以下のリンクを開き、このコードを入力して承認してください。承認が確認されると自動的に接続されます。",
+    "oauthOpenPage": "認証ページを開く",
+    "oauthWaiting": "承認待ち...",
+    "oauthConnected": "接続完了",
+    "oauthFailed": "ログイン失敗: {error}",
+    "oauthAccount": "アカウント"
   },
   "modelRoles": {
     "title": "ロール別モデル割り当て",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1362,7 +1362,17 @@
       "anthropic": "Anthropic",
       "openaiCompatible": "OpenAI 호환"
     },
-    "validationWarning": "키는 저장됐지만 endpoint 검증에 실패했습니다: {error} — 주소/키를 확인 후 다시 저장하세요."
+    "validationWarning": "키는 저장됐지만 endpoint 검증에 실패했습니다: {error} — 주소/키를 확인 후 다시 저장하세요.",
+    "oauthLogin": "ChatGPT 로그인",
+    "oauthStart": "로그인 시작",
+    "oauthHint": "이 공급자는 API 키 대신 OAuth 로그인을 사용합니다.",
+    "oauthCodeLabel": "인증 코드",
+    "oauthInstruction": "아래 링크를 열고 이 코드를 입력한 뒤 승인하세요. 승인이 확인되면 자동으로 연결됩니다.",
+    "oauthOpenPage": "인증 페이지 열기",
+    "oauthWaiting": "승인 대기 중...",
+    "oauthConnected": "연결 완료",
+    "oauthFailed": "로그인 실패: {error}",
+    "oauthAccount": "계정"
   },
   "modelRoles": {
     "title": "역할별 모델 배정",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1362,7 +1362,17 @@
       "anthropic": "Anthropic",
       "openaiCompatible": "OpenAI 兼容"
     },
-    "validationWarning": "密钥已保存，但 endpoint 验证失败：{error} — 请检查地址/密钥后重新保存。"
+    "validationWarning": "密钥已保存，但 endpoint 验证失败：{error} — 请检查地址/密钥后重新保存。",
+    "oauthLogin": "使用 ChatGPT 登录",
+    "oauthStart": "开始登录",
+    "oauthHint": "此提供商使用 OAuth 登录，无需 API 密钥。",
+    "oauthCodeLabel": "验证码",
+    "oauthInstruction": "打开下方链接，输入此验证码并批准。批准后将自动完成连接。",
+    "oauthOpenPage": "打开验证页面",
+    "oauthWaiting": "等待批准...",
+    "oauthConnected": "连接成功",
+    "oauthFailed": "登录失败：{error}",
+    "oauthAccount": "账户"
   },
   "modelRoles": {
     "title": "按角色分配模型",

--- a/db/migrations/082_chatgpt_oauth_keys.sql
+++ b/db/migrations/082_chatgpt_oauth_keys.sql
@@ -1,0 +1,17 @@
+-- 082: ChatGPT OAuth (디바이스 플로우) — user_external_api_keys 인증방식 확장
+--
+-- auth_method='oauth' 행은 encrypted_key 에 API 키 대신 OAuth 세션 JSON
+-- ({accessToken, refreshToken, accountId, expiresAt})을 AES-256-GCM 암호화하여 저장.
+-- 만료 시각·계정 ID 는 복호화 없이 조회할 수 있도록 별도 컬럼으로 병행 보관.
+
+ALTER TABLE user_external_api_keys
+    ADD COLUMN IF NOT EXISTS auth_method VARCHAR(16) NOT NULL DEFAULT 'api_key',
+    ADD COLUMN IF NOT EXISTS oauth_account_id TEXT,
+    ADD COLUMN IF NOT EXISTS oauth_expires_at TIMESTAMPTZ;
+
+DO $$ BEGIN
+    ALTER TABLE user_external_api_keys
+        ADD CONSTRAINT user_external_api_keys_auth_method_chk
+        CHECK (auth_method IN ('api_key', 'oauth'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;

--- a/db/migrations/rollbacks/082_chatgpt_oauth_keys.sql
+++ b/db/migrations/rollbacks/082_chatgpt_oauth_keys.sql
@@ -1,0 +1,7 @@
+-- 082 rollback: ChatGPT OAuth 컬럼 제거
+ALTER TABLE user_external_api_keys
+    DROP CONSTRAINT IF EXISTS user_external_api_keys_auth_method_chk;
+ALTER TABLE user_external_api_keys
+    DROP COLUMN IF EXISTS auth_method,
+    DROP COLUMN IF EXISTS oauth_account_id,
+    DROP COLUMN IF EXISTS oauth_expires_at;

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,11 +44,12 @@
         },
         "apps/api": {
             "name": "openmake-api",
-            "version": "1.5.6",
+            "version": "1.8.0",
             "dependencies": {
                 "@anthropic-ai/sdk": "^0.95.1",
                 "@modelcontextprotocol/sdk": "^1.25.3",
                 "@mozilla/readability": "^0.6.0",
+                "@openai-oauth/core": "^2.0.0",
                 "@opendataloader/pdf": "^2.4.7",
                 "@openmake/shared-types": "*",
                 "@opentelemetry/api": "^1.9.1",
@@ -123,7 +124,7 @@
         },
         "apps/discord-bot": {
             "name": "openmake-discord-bot",
-            "version": "1.5.6",
+            "version": "1.8.0",
             "dependencies": {
                 "discord.js": "^14.16.3",
                 "dotenv": "^16.4.5"
@@ -150,7 +151,7 @@
         },
         "apps/web": {
             "name": "@openmake/web",
-            "version": "0.1.0",
+            "version": "1.8.0",
             "dependencies": {
                 "@openmake/api-client": "*",
                 "@openmake/config": "*",
@@ -3501,6 +3502,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12.4.0"
+            }
+        },
+        "node_modules/@openai-oauth/core": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@openai-oauth/core/-/core-2.0.0.tgz",
+            "integrity": "sha512-z9NYbfS8AQjriUnM8sPjGlpR//7oFwVxqYmabraXlwUokXfsUWk4V4O60jGWOJChUvE21B1A5G0CWDazM15+8g==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/@opendataloader/pdf": {
@@ -17785,7 +17795,7 @@
         },
         "packages/api-client": {
             "name": "@openmake/api-client",
-            "version": "1.5.6",
+            "version": "1.8.0",
             "dependencies": {
                 "@openmake/config": "*",
                 "@openmake/shared-types": "*"
@@ -17793,11 +17803,11 @@
         },
         "packages/config": {
             "name": "@openmake/config",
-            "version": "1.5.6"
+            "version": "1.8.0"
         },
         "packages/shared-types": {
             "name": "@openmake/shared-types",
-            "version": "1.5.6"
+            "version": "1.8.0"
         }
     }
 }


### PR DESCRIPTION
## 요약

ChatGPT Plus/Pro 구독 계정을 **OAuth 디바이스 코드 플로우**로 연결해, Codex 지원 GPT 모델을 openrouter/nvidia 와 **동일한 UX**(모델 셀렉터 · 역할별 배정)로 쓸 수 있게 합니다. 함께 서버 `/v1` OpenAI 호환 API에 외부 모델을 개방해 CLI·서드파티 클라이언트에서도 사용 가능합니다.

인증 기법은 opencode(anomalyco/opencode) · openai-oauth(EvanZhouDev)와 동일 계열로, 공식 Codex CLI 의 OAuth 클라이언트를 차용합니다.

## Phase 1 — ChatGPT OAuth

- **`config/chatgpt-oauth.ts`** — client id · issuer · Codex endpoint 전부 env 오버라이드 가능 (비공식 endpoint 라 OpenAI 변경 시 무중단 대응 필요)
- **`providers/chatgpt-oauth/`** — 세션 / Responses 매핑 / provider 3모듈
  - Codex 백엔드는 **Chat Completions 미지원**이라 `openai` SDK 의 `responses.create` 스트리밍 경로를 신규 구현 (텍스트 · reasoning · tool call · usage 이벤트 매핑)
  - 만료 시 single-flight refresh → 재암호화 저장
- **디바이스 코드 플로우** — `localhost:1455` 콜백이나 브라우저 확장 없이 웹 설정 화면에서 바로 연결
- **마이그레이션 082** — `auth_method` / `oauth_account_id` / `oauth_expires_at` (멱등, 롤백 포함)
- **`createExternalProviderInstance()` 공용 팩토리** — 채팅 · 모델목록 · 키검증 · 역할배정 4개 소비처가 provider 분기를 공유

## Phase 2 — `/v1` 외부 모델 개방

- `/v1/chat/completions` — 등록된 외부 provider fullId 통과 (미등록 403, 미지 모델 404 유지)
- `/v1/models` — 사용자 등록 외부 모델을 fullId 로 노출 (캐시 우선, 라이브 호출 없음)
- `tools` 파라미터 경로도 외부 provider 로 dispatch — **기존엔 로컬 모델로 silent fallback** 되던 갭

## 라이브 검증에서 발견·수정한 결함 3건

1. **`key_prefix` VARCHAR(16) 초과** — OAuth prefix 가 18자라 INSERT 실패. 유닛 테스트가 DB를 안 타서 놓친 갭
2. **Codex 도구명 패턴 거부** — `400 tools[6].name does not match '^[a-zA-Z0-9_-]+$'`. MCP 도구명 정규화 코덱 도입(요청 시 치환, 응답 tool call 은 원래 이름 복원, 충돌 분리 · 길이 상한). 없으면 **도구가 붙은 모든 대화가 실패**
3. **역할 배정 probe 가 공용 팩토리 미사용** — `base_url + Bearer` 직접 조립이라 OAuth provider 가 Cloudflare 403 → 모든 배정이 400 거부

## 테스트

- **라이브 E2E 13/13 통과** — 실제 ChatGPT 계정으로 검증
  - 디바이스 코드 발급 · 폴링 · 토큰 refresh + DB 영속화
  - 라이브 Codex 카탈로그 7종 모델 노출
  - 실제 채팅 (gpt-5.4 / gpt-5.5), **도구 호출 루프** (web_search 실행 → 출처 인용)
  - CLI 경로 `/v1/chat/completions` · 게이팅(403/404) · 로컬 모델 회귀
- **Playwright 브라우저 E2E** — 설정에서 모델 선택 → 컴포저 반영 → WS 스트리밍 채팅 → 도구 호출 → Thinking 모드
- 유닛 테스트 2,135개 통과 (신규 34개), `npm run lint` 0 errors, 백엔드·프론트 `tsc` 클린
- ℹ️ 신규 테스트 34개는 저장소 정책상 커밋되지 않습니다 (`.gitignore` 의 `**/__tests__/`, `*.test.ts` — 추적 중인 테스트 파일 0건)

## 리스크 / 유의사항

- ⚠️ **비공식 통합** — Codex 내부 endpoint 차용. OpenAI 가 언제든 차단·변경할 수 있고, 계정 정책 위반 리스크는 사용자 책임입니다. 반드시 **본인 계정만** 사용해야 하며 토큰 공유는 금지입니다
- 사용 가능 모델은 **Codex 지원 모델만** (gpt-5.6-sol/terra/luna, gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-image-2)
- gpt-5.6 계열은 카탈로그에 `tool_mode: code_mode_only` 플래그가 있습니다. 실측상 MCP 도구가 동작하지만, 도구 중심 역할에는 플래그 없는 gpt-5.5 / gpt-5.4-mini 권장
- 세션은 기존 `token-crypto.ts`(AES-256-GCM)로 암호화 저장되며, SSRF pinned fetch 를 transport 에 주입해 기존 방어를 유지합니다

## 스크린샷

브라우저 E2E 로 설정 화면 OAuth 로그인 UI(코드 표시 + 폴링)와 ChatGPT 모델 채팅을 확인했습니다. 필요 시 첨부하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
