### PR TITLE
fix(providers): 역할 배정된 ChatGPT 모델이 403 으로 로컬 폴백되던 문제

### DIFF
--- a/apps/api/src/providers/chatgpt-oauth/role-client.ts
+++ b/apps/api/src/providers/chatgpt-oauth/role-client.ts
@@ -1,0 +1,132 @@
+/**
+ * ============================================================
+ * ProviderRoleClient — IProvider 를 LLMClient 계약으로 감싼 어댑터
+ * ============================================================
+ *
+ * 역할(role) 실행 경로(model-role-resolver)는 `LLMClient` 를 반환하는 계약이고,
+ * 소비처(Agent Task 턴 루프·goal judge·spawn·review·research)가 전부
+ * `client.chat()` / `client.derive()` 를 호출한다. 그런데 LLMClient 는
+ * `baseUrl + Bearer apiKey` 로 Chat Completions 를 때리는 thin wrapper 라,
+ * ChatGPT(OAuth) 처럼 **다른 호출 규약**(OAuth 세션 + Responses API)을 쓰는
+ * provider 는 그 경로로 호출할 수 없다.
+ *
+ * 실제 증상 (2026-07-26 라이브): 역할에 chatgpt 모델을 배정하면 UI 는 "배정됨"
+ * 인데 실행 시 Cloudflare `403 <html>` 이 나고 조용히 로컬로 폴백됐다.
+ * 즉 배정이 무시되고 있었다.
+ *
+ * 해결: LLMClient 를 상속해 chat/derive 만 provider dispatch 로 대체한다.
+ * 타입 정체성이 유지되므로 소비처는 한 줄도 바뀌지 않는다.
+ *
+ * @module providers/chatgpt-oauth/role-client
+ */
+import { LLMClient } from '../../llm';
+import type { ChatMessage, ToolDefinition, UsageMetrics } from '../../llm/types';
+import { checkUserQuota } from '../../llm/user-quota';
+import type { IProvider } from '../i-provider';
+import { ProviderError } from '../provider-errors';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('ProviderRoleClient');
+
+/**
+ * ProviderError code → HTTP 상태 근사값.
+ *
+ * 역할 경로의 기존 폴백 규약(4xx 면 로컬 1회 강등 — agent-task/role-client.ts)이
+ * `err.status` 숫자를 보고 판단하므로, provider 에러에도 같은 신호를 실어준다.
+ * 이게 없으면 ChatGPT 인증 만료/한도 초과 시 폴백이 동작하지 않고 작업이 죽는다.
+ */
+const PROVIDER_ERROR_STATUS: Record<string, number> = {
+    INVALID_API_KEY: 401,
+    GUEST_NOT_ALLOWED: 403,
+    SUBSCRIPTION_REQUIRED: 403,
+    MODEL_NOT_FOUND: 404,
+    QUOTA_EXCEEDED: 429,
+    INSUFFICIENT_CREDIT: 402,
+    NOT_SUPPORTED: 400,
+    INVALID_MODEL_ID: 400,
+};
+
+export interface ProviderRoleClientOptions {
+    provider: IProvider;
+    /** provider 내부 모델 id (fullId 의 model 부분) */
+    modelId: string;
+    /** 토큰 쿼터 enforcement 대상 사용자 (미지정 시 skip) */
+    userId?: string;
+}
+
+export class ProviderRoleClient extends LLMClient {
+    private readonly provider: IProvider;
+    private readonly modelId: string;
+    private readonly quotaUserId?: string;
+
+    constructor(opts: ProviderRoleClientOptions) {
+        // base LLMClient 는 타입 정체성 유지를 위해서만 초기화한다 (호출 경로는 전부 override).
+        super({ model: opts.modelId, ...(opts.userId ? { userId: opts.userId } : {}) });
+        this.provider = opts.provider;
+        this.modelId = opts.modelId;
+        if (opts.userId) this.quotaUserId = opts.userId;
+    }
+
+    /** timeout 등 파생은 provider 계층이 관리 — 동일 인스턴스를 그대로 돌려준다. */
+    override derive(): LLMClient {
+        return this;
+    }
+
+    override async chat(
+        messages: ChatMessage[],
+        options?: Parameters<LLMClient['chat']>[1],
+        onToken?: (token: string, thinking?: string) => void,
+        advancedOptions?: Parameters<LLMClient['chat']>[3],
+    ): Promise<ChatMessage & { metrics?: UsageMetrics }> {
+        // 로컬 경로와 동일한 per-user 토큰 쿼터 규약 유지 (fail-open 은 내부 처리)
+        await checkUserQuota(this.quotaUserId, Date.now());
+
+        const tools: ToolDefinition[] | undefined = advancedOptions?.tools;
+        try {
+            const result = await this.provider.streamChat(
+                {
+                    messages,
+                    modelId: this.modelId,
+                    ...(options?.temperature !== undefined ? { temperature: options.temperature } : {}),
+                    ...(options?.num_predict !== undefined ? { maxTokens: options.num_predict } : {}),
+                    ...(tools && tools.length > 0 ? { tools } : {}),
+                    ...(advancedOptions?.tool_choice ? { tool_choice: advancedOptions.tool_choice } : {}),
+                    ...(advancedOptions?.signal ? { abortSignal: advancedOptions.signal } : {}),
+                },
+                {
+                    onToken: (token) => onToken?.(token),
+                    onThinking: (thinking) => onToken?.('', thinking),
+                },
+            );
+
+            return {
+                role: 'assistant',
+                content: result.content,
+                ...(result.thinking ? { thinking: result.thinking } : {}),
+                ...(result.toolCalls && result.toolCalls.length > 0
+                    ? {
+                        tool_calls: result.toolCalls.map((tc) => ({
+                            id: tc.id,
+                            type: 'function' as const,
+                            function: {
+                                name: tc.name,
+                                arguments: (tc.args ?? {}) as Record<string, unknown>,
+                            },
+                        })),
+                    }
+                    : {}),
+                metrics: result.usage,
+            };
+        } catch (err) {
+            if (err instanceof ProviderError) {
+                const status = PROVIDER_ERROR_STATUS[err.code];
+                if (status !== undefined) {
+                    // 기존 4xx 폴백 규약과 맞물리도록 status 를 부착해 재throw
+                    Object.defineProperty(err, 'status', { value: status, enumerable: false });
+                }
+                logger.warn(`role 경로 provider 호출 실패 (${err.code}): ${err.message.slice(0, 120)}`);
+            }
+            throw err;
+        }
+    }
+}

--- a/apps/api/src/services/model-role-resolver.ts
+++ b/apps/api/src/services/model-role-resolver.ts
@@ -42,6 +42,11 @@ import {
 } from '../config/model-roles';
 import { EXTERNAL_PROVIDER_CATALOG } from '../config/external-providers';
 import { createClient, LLMClient } from '../llm';
+import {
+    createExternalProviderInstance,
+    buildOAuthSessionPersist,
+} from '../providers/provider-router';
+import { ProviderRoleClient } from '../providers/chatgpt-oauth/role-client';
 import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
 import { UserModelRolesRepository } from '../data/repositories/user-model-roles-repo';
 import { ServerExternalKeysRepository } from '../data/repositories/server-external-keys-repo';
@@ -167,6 +172,29 @@ async function tryBuildExternalResolution(
 
     const plaintextKey = await externalKeysRepo.decryptKey(userId, providerId);
     if (!plaintextKey) return `'${providerId}' 키 복호화 실패`;
+
+    // OAuth provider(ChatGPT 등)는 baseUrl+Bearer 규약이 아니라 provider 계층이
+    // 호출 규약(세션·Responses API)을 갖는다. LLMClient 로 직결하면 Cloudflare 403
+    // 이 나고 조용히 로컬 폴백되어 배정이 무시된다 (2026-07-26 라이브 확인).
+    if (keyRow.authMethod === 'oauth') {
+        try {
+            const provider = createExternalProviderInstance(
+                keyRow,
+                plaintextKey,
+                buildOAuthSessionPersist(externalKeysRepo, userId, providerId),
+            );
+            return {
+                client: new ProviderRoleClient({ provider, modelId, userId }),
+                role,
+                fullId,
+                providerId,
+                modelId,
+                source: 'user',
+            };
+        } catch (err) {
+            return `'${providerId}' OAuth role 클라이언트 생성 실패: ${err instanceof Error ? err.message : String(err)}`;
+        }
+    }
 
     const baseUrl = keyRow.baseUrl || entry.defaultBaseUrl;
     return {


### PR DESCRIPTION
## 문제

역할(`agent`/`judge`/`spawn`/`review`/`research`)에 ChatGPT 모델을 배정하면 **UI 에는 "배정됨" 으로 보이지만 실제로는 ChatGPT 가 한 번도 실행되지 않았습니다.** 매 호출이 Cloudflare `403 <html>` 로 실패한 뒤 조용히 로컬 모델로 폴백됐고, 작업은 "완료" 로 끝나서 겉으로는 정상처럼 보였습니다.

라이브 브라우저 테스트(에이전트 작업 생성 → 승인 → 실행) 중 **서버 로그**로 발견했습니다:

```
[AgentTask] agent role 외부 모델 사용: chatgpt:gpt-5.5     ← 배정은 인식
[AgentTask] 외부 role 모델 403 — 로컬 폴백: 403 <html>      ← 실제 호출은 실패
[AgentTask] judge 호출 실패 — fail-open: 403 <html>
```

## 원인

`model-role-resolver` 가 역할 모델을 `createClient({ baseUrl, apiKey })` 로 직결합니다. ChatGPT 는 `base_url + Bearer` 규약이 아니라 **OAuth 세션 + Responses API** 를 쓰므로 그 경로로는 호출할 수 없습니다.

#367 에서 배정 검증(probe)의 같은 문제를 고쳤는데, **실행 경로가 5번째 소비처로 남아 있었습니다** — 검증은 통과시키면서 정작 실행은 못 하는 상태였습니다.

## 수정

**`ProviderRoleClient` 어댑터 신설** (`providers/chatgpt-oauth/role-client.ts`)

- `LLMClient` 를 상속해 `chat()` / `derive()` 만 provider dispatch 로 대체 → 타입 정체성이 유지되므로 **소비처는 무변경** (Agent Task 턴 루프 · goal judge · subagent · delegate · review · research)
- `ProviderError` code → HTTP status 매핑 부착. 기존 4xx 로컬 강등 로직이 `err.status` 숫자를 보기 때문으로, **이게 없으면 인증 만료(401)·구독 한도(429) 시 폴백이 동작하지 않고 작업이 죽습니다**
- per-user 토큰 쿼터 규약은 로컬 경로와 동일하게 유지

## 검증

**라이브 (브라우저 에이전트 작업)**

| | 수정 전 | 수정 후 |
|---|---|---|
| role 해석 | chatgpt:gpt-5.5 | chatgpt:gpt-5.5 |
| 실제 실행 | ❌ 403 → 로컬 폴백 | ✅ **ChatGPT 실행** |
| goal judge | ❌ 403 fail-open | ✅ 정상 |
| 결과 | 로컬이 계산 | 645498 (987×654, 정답), 2턴 22초 |

재실행 로그에 403·폴백 **0건**입니다.

**유닛** — 신규 회귀 4개(반환 형태 변환, 401/429 status 매핑, tools·tool_choice·abort 전달) 포함 chatgpt 스위트 29개 · resolver 스위트 18개 통과, `tsc` 클린.
ℹ️ 테스트 파일은 저장소 정책상 커밋되지 않습니다 (`.gitignore` 의 `**/__tests__/`, `*.test.ts`).

## 영향 범위

ChatGPT(OAuth) 를 역할에 배정한 사용자만 해당합니다. openrouter/nvidia 등 API 키 provider 는 기존 `createClient` 경로를 그대로 타므로 동작 변화가 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
