### PR TITLE
feat(agent-task): 스킬 자동 선택(load_skill) 을 에이전트 작업에도 적용

### DIFF
--- a/apps/api/src/providers/chatgpt-oauth/role-client.ts
+++ b/apps/api/src/providers/chatgpt-oauth/role-client.ts
@@ -54,79 +54,105 @@ export interface ProviderRoleClientOptions {
     userId?: string;
 }
 
-export class ProviderRoleClient extends LLMClient {
-    private readonly provider: IProvider;
-    private readonly modelId: string;
-    private readonly quotaUserId?: string;
+/**
+ * 서브클래스 정의를 **모듈 로드 시점이 아니라 최초 생성 시점**으로 미룬다.
+ *
+ * 최상위에서 `class X extends LLMClient` 를 평가하면, 이 모듈을 (전이적으로라도)
+ * import 하는 모든 코드가 실제 LLMClient 클래스에 의존하게 된다. `../llm` 을
+ * 모킹하는 테스트에서 AgentTaskService 를 import 하는 것만으로
+ * "Class extends value undefined" 로 죽는다 (2026-07-26 실측: 3개 스위트).
+ * 지연 평가하면 import 는 안전하고, 실제 사용 시점에만 실 클래스를 요구한다.
+ */
+let CachedCtor: (new (opts: ProviderRoleClientOptions) => LLMClient) | undefined;
 
-    constructor(opts: ProviderRoleClientOptions) {
-        // base LLMClient 는 타입 정체성 유지를 위해서만 초기화한다 (호출 경로는 전부 override).
-        super({ model: opts.modelId, ...(opts.userId ? { userId: opts.userId } : {}) });
-        this.provider = opts.provider;
-        this.modelId = opts.modelId;
-        if (opts.userId) this.quotaUserId = opts.userId;
-    }
+function getProviderRoleClientCtor(): new (opts: ProviderRoleClientOptions) => LLMClient {
+    if (CachedCtor) return CachedCtor;
 
-    /** timeout 등 파생은 provider 계층이 관리 — 동일 인스턴스를 그대로 돌려준다. */
-    override derive(): LLMClient {
-        return this;
-    }
+    class ProviderRoleClientImpl extends LLMClient {
+        private readonly provider: IProvider;
+        private readonly modelId: string;
+        private readonly quotaUserId?: string;
 
-    override async chat(
-        messages: ChatMessage[],
-        options?: Parameters<LLMClient['chat']>[1],
-        onToken?: (token: string, thinking?: string) => void,
-        advancedOptions?: Parameters<LLMClient['chat']>[3],
-    ): Promise<ChatMessage & { metrics?: UsageMetrics }> {
-        // 로컬 경로와 동일한 per-user 토큰 쿼터 규약 유지 (fail-open 은 내부 처리)
-        await checkUserQuota(this.quotaUserId, Date.now());
+        constructor(opts: ProviderRoleClientOptions) {
+            // base LLMClient 는 타입 정체성 유지를 위해서만 초기화한다 (호출 경로는 전부 override).
+            super({ model: opts.modelId, ...(opts.userId ? { userId: opts.userId } : {}) });
+            this.provider = opts.provider;
+            this.modelId = opts.modelId;
+            if (opts.userId) this.quotaUserId = opts.userId;
+        }
 
-        const tools: ToolDefinition[] | undefined = advancedOptions?.tools;
-        try {
-            const result = await this.provider.streamChat(
-                {
-                    messages,
-                    modelId: this.modelId,
-                    ...(options?.temperature !== undefined ? { temperature: options.temperature } : {}),
-                    ...(options?.num_predict !== undefined ? { maxTokens: options.num_predict } : {}),
-                    ...(tools && tools.length > 0 ? { tools } : {}),
-                    ...(advancedOptions?.tool_choice ? { tool_choice: advancedOptions.tool_choice } : {}),
-                    ...(advancedOptions?.signal ? { abortSignal: advancedOptions.signal } : {}),
-                },
-                {
-                    onToken: (token) => onToken?.(token),
-                    onThinking: (thinking) => onToken?.('', thinking),
-                },
-            );
+        /** timeout 등 파생은 provider 계층이 관리 — 동일 인스턴스를 그대로 돌려준다. */
+        override derive(): LLMClient {
+            return this;
+        }
 
-            return {
-                role: 'assistant',
-                content: result.content,
-                ...(result.thinking ? { thinking: result.thinking } : {}),
-                ...(result.toolCalls && result.toolCalls.length > 0
-                    ? {
-                        tool_calls: result.toolCalls.map((tc) => ({
-                            id: tc.id,
-                            type: 'function' as const,
-                            function: {
-                                name: tc.name,
-                                arguments: (tc.args ?? {}) as Record<string, unknown>,
-                            },
-                        })),
+        override async chat(
+            messages: ChatMessage[],
+            options?: Parameters<LLMClient['chat']>[1],
+            onToken?: (token: string, thinking?: string) => void,
+            advancedOptions?: Parameters<LLMClient['chat']>[3],
+        ): Promise<ChatMessage & { metrics?: UsageMetrics }> {
+            // 로컬 경로와 동일한 per-user 토큰 쿼터 규약 유지 (fail-open 은 내부 처리)
+            await checkUserQuota(this.quotaUserId, Date.now());
+
+            const tools: ToolDefinition[] | undefined = advancedOptions?.tools;
+            try {
+                const result = await this.provider.streamChat(
+                    {
+                        messages,
+                        modelId: this.modelId,
+                        ...(options?.temperature !== undefined ? { temperature: options.temperature } : {}),
+                        ...(options?.num_predict !== undefined ? { maxTokens: options.num_predict } : {}),
+                        ...(tools && tools.length > 0 ? { tools } : {}),
+                        ...(advancedOptions?.tool_choice ? { tool_choice: advancedOptions.tool_choice } : {}),
+                        ...(advancedOptions?.signal ? { abortSignal: advancedOptions.signal } : {}),
+                    },
+                    {
+                        onToken: (token) => onToken?.(token),
+                        onThinking: (thinking) => onToken?.('', thinking),
+                    },
+                );
+
+                return {
+                    role: 'assistant',
+                    content: result.content,
+                    ...(result.thinking ? { thinking: result.thinking } : {}),
+                    ...(result.toolCalls && result.toolCalls.length > 0
+                        ? {
+                            tool_calls: result.toolCalls.map((tc) => ({
+                                id: tc.id,
+                                type: 'function' as const,
+                                function: {
+                                    name: tc.name,
+                                    arguments: (tc.args ?? {}) as Record<string, unknown>,
+                                },
+                            })),
+                        }
+                        : {}),
+                    metrics: result.usage,
+                };
+            } catch (err) {
+                if (err instanceof ProviderError) {
+                    const status = PROVIDER_ERROR_STATUS[err.code];
+                    if (status !== undefined) {
+                        // 기존 4xx 폴백 규약과 맞물리도록 status 를 부착해 재throw
+                        Object.defineProperty(err, 'status', { value: status, enumerable: false });
                     }
-                    : {}),
-                metrics: result.usage,
-            };
-        } catch (err) {
-            if (err instanceof ProviderError) {
-                const status = PROVIDER_ERROR_STATUS[err.code];
-                if (status !== undefined) {
-                    // 기존 4xx 폴백 규약과 맞물리도록 status 를 부착해 재throw
-                    Object.defineProperty(err, 'status', { value: status, enumerable: false });
+                    logger.warn(`role 경로 provider 호출 실패 (${err.code}): ${err.message.slice(0, 120)}`);
                 }
-                logger.warn(`role 경로 provider 호출 실패 (${err.code}): ${err.message.slice(0, 120)}`);
+                throw err;
             }
-            throw err;
         }
     }
+
+    CachedCtor = ProviderRoleClientImpl;
+    return CachedCtor;
+}
+
+/**
+ * role 실행용 LLMClient 어댑터 생성 (provider dispatch).
+ * 클래스가 아닌 팩토리인 이유는 위 getProviderRoleClientCtor 주석 참고.
+ */
+export function createProviderRoleClient(opts: ProviderRoleClientOptions): LLMClient {
+    return new (getProviderRoleClientCtor())(opts);
 }

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -46,7 +46,7 @@ import { resolveExecutorPlan } from './agent-task/executor-select';
 import { recoverTextToolCalls } from './agent-task/text-tool-calls';
 import { assembleAgentTools } from './agent-task/tool-assembly';
 import { verifyCodeArtifacts } from './agent-task/deliverable-verify';
-import { buildAgentTaskSystemContent, AGENT_TASK_SKILL_AGENT_ID } from './agent-task/skill-block';
+import { buildAgentTaskSystemContent, resolveSkillToolBindings } from './agent-task/skill-block';
 
 // 기존 import 호환 재노출 — 타입/에러는 services/agent-task/types 로 분리 (파일 크기 가드).
 export { AgentTaskAbort, type AgentTaskRunInput, type AgentTaskInputFile } from './agent-task/types';
@@ -179,26 +179,10 @@ export class AgentTaskService {
                 userId,
             })) as unknown as ToolDefinition[], userRole);
 
-            // 활성 스킬(global+user)의 tool_bindings 를 머지.
-            // base 가 전체 도구라 실효는 사실상 denied(특정 도구 차단)뿐이다.
-            // 조회 실패는 작업을 실패시키지 않고 빈 바인딩으로 흡수.
-            let skillBindings: ActiveSkillBinding[] = [];
-            try {
-                skillBindings = await getSkillManager().getActiveSkillBindings(AGENT_TASK_SKILL_AGENT_ID, userId);
-            } catch (e) {
-                logger.debug('[AgentTask] 스킬 도구 바인딩 조회 실패 — 빈 배열', e);
-            }
-            // 스킬 범위 지정 시(allowedSkills): 활성 바인딩을 해당 skill_id 집합으로 제한.
-            // 미지정/빈 배열이면 전체 사용(기존 동작).
-            if (allowedSkills && allowedSkills.length > 0) {
-                const allow = new Set(allowedSkills);
-                const before = skillBindings.length;
-                skillBindings = skillBindings.filter((b) => allow.has(b.skill_id));
-                logger.debug(`[AgentTask] 스킬 범위 제한: ${before} → ${skillBindings.length} (allowedSkills=${allowedSkills.length})`);
-            }
-            const mcpTools = skillBindings.length > 0
-                ? mergeToolsWithSkills({ allTools, userToggled: allTools, profileRequired: [], skillBindings })
-                : allTools;
+            // 활성 스킬(global+user)의 tool_bindings 머지 — 상세는 agent-task/skill-block.
+            const { mcpTools, skillBindings } = await resolveSkillToolBindings({
+                userId, allTools, ...(allowedSkills ? { allowedSkills } : {}),
+            });
 
             // 영속 샌드박스(Manus화, 플래그 ON 시만). 생성 실패는 샌드박스 없이 진행(graceful degrade).
             // 설정은 한 번만 읽어 스냅샷 공유. 승인 3모드는 input.approvalPolicy 로 이 실행에만 override

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -260,7 +260,12 @@ export class AgentTaskService {
 
             // LLM 에 전달할 도구 세트 조립(샌드박스 도구 + extraTools + 2-A 동적 도구). 상세는
             // agent-task/tool-assembly. extraToolNames = 호스트 실행 도구(디스패치 승인 게이트 대상).
-            const { tools, extraToolNames } = await assembleAgentTools({ mcpTools, taskRuntime, sandboxCfg, goal });
+            // injectedSkillIds: 시스템 프롬프트로 전문 주입된 스킬은 load_skill 카탈로그에서 제외
+            // (채팅 경로가 활성 바인딩을 제외하는 것과 동일 규칙 — 중복 노출 방지).
+            const { tools, extraToolNames } = await assembleAgentTools({
+                mcpTools, taskRuntime, sandboxCfg, goal,
+                injectedSkillIds: new Set(skillBindings.map((b) => b.skill_id)),
+            });
 
             // 스텝 실시간 발행(4-5) — DB 기록 직후 요약을 WS 로 브로드캐스트(채팅 인라인 카드의 "현재 단계").
             const emitStep = (stepType: string, toolName?: string, content?: string | null): void => {

--- a/apps/api/src/services/ChatService.ts
+++ b/apps/api/src/services/ChatService.ts
@@ -28,7 +28,7 @@ import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { CHAT_ALWAYS_ON_TOOL_NAMES } from '../mcp/agent-task-tools';
 import { MCP_META_TOOL_NAMES } from '../mcp/mcp-meta-tools';
 import { CHAT_USER_MCP_TOOL_CAP, CHAT_USER_MCP_SCHEMA_BUDGET_BYTES, MCP_PROGRESSIVE_DISCLOSURE_ENABLED, MAP_INTENT_PATTERNS, ROUTE_INTENT_PATTERNS, WEB_SEARCH_INTENT_PATTERNS } from '../config/runtime-limits';
-import { LOAD_SKILL_TOOL_NAME } from '../mcp/load-skill-tool';
+import { applySkillCatalog as applySkillCatalogShared } from './skill-catalog-tool';
 import { LLMClient } from '../llm';
 import { type ToolDefinition } from '../llm';
 import type { ResearchProgress } from './DeepResearchService';
@@ -250,30 +250,10 @@ export class ChatService {
     private async applySkillCatalog(
         tools: ToolDefinition[], allTools: ToolDefinition[], reqCtx: RequestContext,
     ): Promise<ToolDefinition[]> {
-        const without = tools.filter((t) => t.function.name !== LOAD_SKILL_TOOL_NAME);
-        if (process.env.SKILL_AUTO_SELECT_ENABLED !== 'true') return without;
-
-        const base = allTools.find((t) => t.function.name === LOAD_SKILL_TOOL_NAME);
-        if (!base) return without; // load_skill 미등록 — 노출 안 함
-
-        try {
-            const excludeIds = new Set(reqCtx.skillBindings.map((b) => b.skill_id));
-            const { catalog, count } = await getSkillManager().buildSkillCatalog({ excludeIds });
-            if (count === 0) return without;
-
-            const augmented: ToolDefinition = {
-                type: 'function',
-                function: {
-                    name: LOAD_SKILL_TOOL_NAME,
-                    description: `${base.function.description}\n\n## Skill Library (${count})\n${catalog}`,
-                    parameters: base.function.parameters,
-                },
-            };
-            return [...without, augmented];
-        } catch (e) {
-            logger.warn('스킬 카탈로그 주입 실패 (load_skill 제외):', e);
-            return without;
-        }
+        // 구현은 services/skill-catalog-tool 로 추출 (에이전트 작업 경로와 공용 — SSoT)
+        return applySkillCatalogShared(tools, allTools, {
+            excludeIds: new Set(reqCtx.skillBindings.map((b) => b.skill_id)),
+        });
     }
 
     /**

--- a/apps/api/src/services/agent-task/skill-block.ts
+++ b/apps/api/src/services/agent-task/skill-block.ts
@@ -2,7 +2,9 @@
  * Agent Task 스킬 프롬프트 블록 — AgentTaskService 에서 분리 (파일 크기 가드).
  * @module services/agent-task/skill-block
  */
-import { getSkillManager } from '../../agents/skill-manager';
+import { getSkillManager, type ActiveSkillBinding } from '../../agents/skill-manager';
+import type { ToolDefinition } from '../../llm/types';
+import { mergeToolsWithSkills } from '../chat-service/tool-merger';
 import { getAgentTaskSystemPrompt } from '../../prompts/agent-task-prompt';
 import { buildLearningBlock } from './task-learning';
 import { buildProceduralSkillBlock } from './procedural-skill';
@@ -45,4 +47,37 @@ export async function buildAgentTaskSystemContent(userId: string, goal: string, 
         + (await buildSkillPromptBlock(userId))
         + (await buildLearningBlock(userId, goal, taskId))
         + (await buildProceduralSkillBlock(userId, goal));
+}
+
+/**
+ * 활성 스킬 바인딩 해석 + 도구 머지 — AgentTaskService 에서 이동 (파일 크기 가드).
+ *
+ * base 가 전체 도구라 바인딩의 실효는 사실상 denied(특정 도구 차단)뿐이다.
+ * 조회 실패는 작업을 실패시키지 않고 빈 바인딩으로 흡수한다.
+ *
+ * @param allowedSkills 범위 지정 시 해당 skill_id 집합으로 제한 (미지정/빈 배열이면 전체)
+ * @returns 머지된 도구 목록과 적용된 바인딩(카탈로그 dedup 용 skill_id 확보)
+ */
+export async function resolveSkillToolBindings(params: {
+    userId: string;
+    allTools: ToolDefinition[];
+    allowedSkills?: string[];
+}): Promise<{ mcpTools: ToolDefinition[]; skillBindings: ActiveSkillBinding[] }> {
+    const { userId, allTools, allowedSkills } = params;
+    let skillBindings: ActiveSkillBinding[] = [];
+    try {
+        skillBindings = await getSkillManager().getActiveSkillBindings(AGENT_TASK_SKILL_AGENT_ID, userId);
+    } catch (e) {
+        logger.debug('[AgentTask] 스킬 도구 바인딩 조회 실패 — 빈 배열', e);
+    }
+    if (allowedSkills && allowedSkills.length > 0) {
+        const allow = new Set(allowedSkills);
+        const before = skillBindings.length;
+        skillBindings = skillBindings.filter((b) => allow.has(b.skill_id));
+        logger.debug(`[AgentTask] 스킬 범위 제한: ${before} → ${skillBindings.length} (allowedSkills=${allowedSkills.length})`);
+    }
+    const mcpTools = skillBindings.length > 0
+        ? mergeToolsWithSkills({ allTools, userToggled: allTools, profileRequired: [], skillBindings })
+        : allTools;
+    return { mcpTools, skillBindings };
 }

--- a/apps/api/src/services/agent-task/tool-assembly.ts
+++ b/apps/api/src/services/agent-task/tool-assembly.ts
@@ -11,6 +11,8 @@ import type { ToolDefinition } from '../../llm/types';
 import type { TaskRuntime } from '../task-sandbox/runtime';
 import type { TaskSandboxConfig } from '../../config/task-sandbox';
 import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
+import { applySkillCatalog } from '../skill-catalog-tool';
+import { LOAD_SKILL_TOOL_NAME } from '../../mcp/load-skill-tool';
 import { selectRelevantTools } from './tool-selector';
 import { selectRelevantToolsEmbedding } from './tool-selector-embedding';
 import { createLogger } from '../../utils/logger';
@@ -32,9 +34,38 @@ export async function assembleAgentTools(params: {
     taskRuntime: TaskRuntime | null;
     sandboxCfg: TaskSandboxConfig;
     goal: string;
+    /**
+     * 시스템 프롬프트로 이미 전문 주입된 스킬 id — load_skill 카탈로그에서 제외(중복 방지).
+     * 미지정 시 전체 카탈로그 노출.
+     */
+    injectedSkillIds?: ReadonlySet<string>;
 }): Promise<AssembledTools> {
-    const { mcpTools, taskRuntime, sandboxCfg, goal } = params;
+    const { mcpTools, taskRuntime, sandboxCfg, goal, injectedSkillIds } = params;
     const extraToolNames = new Set<string>();
+
+    /**
+     * 조립된 도구 세트에 load_skill(스킬 카탈로그 포함)을 합류시킨다.
+     *
+     * 에이전트 작업은 산업 agent 페르소나를 우회해 `__agent_task__` 스코프 스킬만
+     * 프롬프트로 주입받는다(실측 1개). 나머지 스킬 라이브러리는 이 도구로만 닿을 수
+     * 있는데, 카탈로그가 없으면 모델이 이름을 몰라 호출 자체를 못 한다 —
+     * 실제로 load_skill 호출이 0건이었다(2026-07-26). 스키마 1종 추가라 도구 예산
+     * 영향은 무시할 수준이고, 기능 OFF(SKILL_AUTO_SELECT_ENABLED != 'true')거나
+     * 카탈로그가 비면 공용 헬퍼가 알아서 제거한다.
+     */
+    const withSkillCatalog = async (tools: ToolDefinition[]): Promise<ToolDefinition[]> => {
+        const before = tools.length;
+        const next = await applySkillCatalog(tools, mcpTools, {
+            ...(injectedSkillIds ? { excludeIds: injectedSkillIds } : {}),
+        });
+        const added = next.some((t) => t.function.name === LOAD_SKILL_TOOL_NAME)
+            && !tools.some((t) => t.function.name === LOAD_SKILL_TOOL_NAME);
+        if (added) {
+            extraToolNames.add(LOAD_SKILL_TOOL_NAME); // 호스트 실행 — 승인 게이트 대상
+            logger.info(`[AgentTask] load_skill 카탈로그 합류 (도구 ${before} → ${next.length})`);
+        }
+        return next;
+    };
 
     // 샌드박스로 대체 불가한 소수 고가치 내장 도구(extraTools 화이트리스트)를 이름으로 선별.
     const buildExtra = (sandboxToolNames: Set<string>): ToolDefinition[] => {
@@ -75,7 +106,10 @@ export async function assembleAgentTools(params: {
                 logger.info(`[AgentTask] 동적 도구 ${dynamicExtra.length}개 합류 (${AGENT_TASK_LIMITS.DYNAMIC_TOOLS_MODE}, 예산 ${budget}, 총 ${sandboxTools.length + staticExtra.length + dynamicExtra.length})`);
             }
         }
-        return { tools: [...staticExtra, ...dynamicExtra, ...sandboxTools], extraToolNames };
+        return {
+            tools: await withSkillCatalog([...staticExtra, ...dynamicExtra, ...sandboxTools]),
+            extraToolNames,
+        };
     }
 
     if (sandboxCfg.enabled) {
@@ -83,9 +117,10 @@ export async function assembleAgentTools(params: {
         // 화이트리스트 도구만으로 진행 — 셸 작업은 불가하나 검색·이미지·작성 작업은 계속 가능.
         const tools = buildExtra(new Set<string>());
         logger.warn(`[AgentTask] 샌드박스 미가용 — extraTools(${extraToolNames.size}개)만으로 진행 (전체 카탈로그 미전달)`);
-        return { tools, extraToolNames };
+        return { tools: await withSkillCatalog(tools), extraToolNames };
     }
 
     // 샌드박스 OFF(legacy) 경로 — 기존대로 전체 MCP 도구 사용.
-    return { tools: mcpTools, extraToolNames };
+    // 이 경로엔 이미 전체 카탈로그(load_skill 포함)가 들어있으므로 카탈로그 주입만 적용.
+    return { tools: await withSkillCatalog(mcpTools), extraToolNames };
 }

--- a/apps/api/src/services/model-role-resolver.ts
+++ b/apps/api/src/services/model-role-resolver.ts
@@ -46,7 +46,7 @@ import {
     createExternalProviderInstance,
     buildOAuthSessionPersist,
 } from '../providers/provider-router';
-import { ProviderRoleClient } from '../providers/chatgpt-oauth/role-client';
+import { createProviderRoleClient } from '../providers/chatgpt-oauth/role-client';
 import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
 import { UserModelRolesRepository } from '../data/repositories/user-model-roles-repo';
 import { ServerExternalKeysRepository } from '../data/repositories/server-external-keys-repo';
@@ -184,7 +184,7 @@ async function tryBuildExternalResolution(
                 buildOAuthSessionPersist(externalKeysRepo, userId, providerId),
             );
             return {
-                client: new ProviderRoleClient({ provider, modelId, userId }),
+                client: createProviderRoleClient({ provider, modelId, userId }),
                 role,
                 fullId,
                 providerId,

--- a/apps/api/src/services/skill-catalog-tool.ts
+++ b/apps/api/src/services/skill-catalog-tool.ts
@@ -1,0 +1,71 @@
+/**
+ * ============================================================
+ * load_skill 카탈로그 주입 — 채팅·에이전트 작업 공용 (SSoT)
+ * ============================================================
+ *
+ * `load_skill` 은 "스킬을 불러오는 도구" 일 뿐, **어떤 스킬이 있는지는 도구
+ * description 에 카탈로그를 실어줘야** 모델이 고를 수 있다(progressive disclosure).
+ * 카탈로그 없이 도구만 노출하면 모델은 이름을 몰라 호출하지 못한다.
+ *
+ * 원래 ChatService 안의 private 메서드였는데, 에이전트 작업 경로에는 없어서
+ * load_skill 이 노출돼도 실제 호출이 0건이었다(2026-07-26 실측). 두 경로가 같은
+ * 규칙을 쓰도록 여기로 추출한다.
+ *
+ * @module services/skill-catalog-tool
+ */
+import type { ToolDefinition } from '../llm/types';
+import { getSkillManager } from '../agents/skill-manager';
+import { LOAD_SKILL_TOOL_NAME } from '../mcp/load-skill-tool';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('SkillCatalogTool');
+
+export interface SkillCatalogOptions {
+    /**
+     * 이미 시스템 프롬프트로 전문 주입된 스킬 id — 카탈로그에서 제외(중복 노출 방지).
+     * 채팅은 활성 바인딩, 에이전트 작업은 매니페스트 주입분이 해당.
+     */
+    excludeIds?: ReadonlySet<string>;
+}
+
+/**
+ * 도구 목록의 `load_skill` 을 스킬 카탈로그가 실린 정의로 교체한다.
+ *
+ * - `SKILL_AUTO_SELECT_ENABLED !== 'true'` (기본): load_skill 을 목록에서 제거 (기능 OFF)
+ * - 카탈로그가 비었거나 조회 실패: 제거 (graceful — 흐름 무영향)
+ * - 정상: description 에 "## Skill Library (N)" 카탈로그를 덧붙인 정의로 교체
+ *
+ * @param tools    노출 후보 도구 목록
+ * @param allTools 전체 도구 카탈로그 — load_skill 기본 정의(파라미터 스키마) 확보용
+ */
+export async function applySkillCatalog(
+    tools: ToolDefinition[],
+    allTools: ToolDefinition[],
+    opts: SkillCatalogOptions = {},
+): Promise<ToolDefinition[]> {
+    const without = tools.filter((t) => t.function.name !== LOAD_SKILL_TOOL_NAME);
+    if (process.env.SKILL_AUTO_SELECT_ENABLED !== 'true') return without;
+
+    const base = allTools.find((t) => t.function.name === LOAD_SKILL_TOOL_NAME);
+    if (!base) return without; // load_skill 미등록 — 노출 안 함
+
+    try {
+        const { catalog, count } = await getSkillManager().buildSkillCatalog(
+            opts.excludeIds ? { excludeIds: opts.excludeIds } : {},
+        );
+        if (count === 0) return without;
+
+        const augmented: ToolDefinition = {
+            type: 'function',
+            function: {
+                name: LOAD_SKILL_TOOL_NAME,
+                description: `${base.function.description}\n\n## Skill Library (${count})\n${catalog}`,
+                parameters: base.function.parameters,
+            },
+        };
+        return [...without, augmented];
+    } catch (e) {
+        logger.warn('스킬 카탈로그 주입 실패 (load_skill 제외):', e);
+        return without;
+    }
+}


### PR DESCRIPTION
## 문제

에이전트 작업에서 **스킬 라이브러리가 사실상 닿지 않는 상태**였습니다.

- 에이전트 작업은 산업 agent 페르소나를 우회하고 `__agent_task__` sentinel 을 쓰므로, `__global__` + `user:{id}` 스코프 스킬만 프롬프트로 주입됩니다 — **실측 1개**
- 나머지 라이브러리(활성 **168개**)는 `load_skill` 로만 닿을 수 있는데, 카탈로그를 도구 description 에 실어주는 `applySkillCatalog()` 가 **`ChatService` 안의 private 메서드로만 존재**했습니다
- 결과: 도구는 노출돼도 모델이 스킬 이름을 몰라 호출 자체가 불가능 → **`load_skill` 호출 이력 0건**

## 수정

**1) 공용 모듈 추출** — `services/skill-catalog-tool.ts`
채팅·에이전트가 같은 구현을 공유(SSoT). `ChatService` 는 위임만 남으며 **동작 변화 없음**.

**2) 에이전트 경로 배선** — `agent-task/tool-assembly.ts` 의 3개 분기(샌드박스 활성 / degrade / legacy) 모두에 적용

설계상 챙긴 것:
- **도구 예산 영향 없음** — 스키마 1종 추가. 동적 선택(embedding top-K) 과 무관하게 결정적으로 합류하므로 관련성 점수에 밀려 누락되지 않습니다
- **HITL 승인 게이트 적용** — `load_skill` 은 샌드박스가 아닌 호스트 실행이라 `extraToolNames` 에 등록해 다른 호스트 도구와 동일 취급
- **중복 노출 방지** — 프롬프트로 이미 전문 주입된 스킬은 `injectedSkillIds` 로 카탈로그에서 제외 (채팅이 활성 바인딩을 제외하는 규칙과 동일)
- **기존 안전장치 유지** — 플래그 OFF · 카탈로그 없음 · 조회 실패 시 도구를 조용히 제거(graceful)

## 함께 포함된 fix 커밋 (`f8c35a1a`)

`ProviderRoleClient` 의 서브클래스 정의를 **지연 평가**로 전환했습니다.

모듈 최상위에서 `class extends LLMClient` 를 평가하면 이 모듈을 전이적으로 import 하는 모든 코드가 실제 `LLMClient` 클래스에 의존합니다. `../llm` 을 모킹한 테스트가 `AgentTaskService` 를 import 하는 것만으로 `Class extends value undefined` 로 죽었습니다 — **실측 3개 스위트**(agent-task-skill-injection · agent-task-input-files · spawn-agents).

⚠️ **#369 가 도입한 회귀이고 CI 가 못 잡았습니다.** 이 저장소는 테스트가 gitignore 대상(추적 0건)이라 CI 의 Test 게이트에 실행할 테스트가 없습니다. 로컬 전체 실행에서만 드러납니다.

## 검증

**라이브 (브라우저 에이전트 작업 2회)** — 168개 카탈로그에서 주제에 맞는 스킬을 **자율 선택**

| 지시 | 모델이 고른 스킬 | 결과 |
|---|---|---|
| "도움이 될 스킬 하나 불러와라" | `Skill Author Guide` | ✅ 로드 후 지침 보고 |
| "**보안 점검**에 도움이 될 스킬" | `사이버보안 전문가 전문 스킬` | ✅ 로드 후 지침 보고 |

`agent_task_steps` 기준 `load_skill` 호출 **0건 → 2건**.

**유닛** — 신규 7개(카탈로그 주입·플래그 OFF·빈 카탈로그·조회 실패 graceful·excludeIds 전달·중복 방지) 추가.
전체 **2,146개 통과** (수정 전 3개 스위트 실패 → 복구), `npm run lint` 0 errors, `tsc` 클린.
ℹ️ 테스트 파일은 저장소 정책상 커밋되지 않습니다.

## 영향 범위

`SKILL_AUTO_SELECT_ENABLED=true` 인 환경의 에이전트 작업에 도구 1종이 추가됩니다. 채팅 경로는 구현 위치만 옮겼을 뿐 동작이 동일합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
