### PR TITLE
fix(chat): 외부 모델 비전 오차단 교정 + 실패 시 로컬 폴백

### DIFF
--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -941,6 +941,22 @@ export const ROUTING_VERIFICATION = {
  *
  * services/ChatService.ts streamFromExternalProvider 에서 참조한다.
  */
+/**
+ * 채팅 경로의 외부 provider 실패 → 로컬 기본 모델 폴백 정책.
+ *
+ * 역할(role) 경로에는 4xx 강등이 있었으나 채팅에는 없어, 기본 모델을 외부로 둔 사용자가
+ * 구독 한도(429)·세션 만료(401)를 만나면 대화가 통째로 실패했다(2026-07-26 점검).
+ * 스트리밍 도중 교체는 답변이 섞이므로, 폴백은 "첫 토큰 이전"에만 수행한다.
+ */
+export const EXTERNAL_CHAT_FALLBACK = {
+    /** 기능 게이트 — 끄려면 EXTERNAL_CHAT_LOCAL_FALLBACK=false */
+    ENABLED: process.env.EXTERNAL_CHAT_LOCAL_FALLBACK !== 'false',
+    /** status 코드가 없을 때 폴백 대상으로 볼 ProviderError code (CSV 오버라이드 가능) */
+    RETRYABLE_CODES: (process.env.EXTERNAL_CHAT_FALLBACK_CODES
+        || 'INVALID_API_KEY,QUOTA_EXCEEDED,INSUFFICIENT_CREDIT,SUBSCRIPTION_REQUIRED,MODEL_NOT_FOUND,UPSTREAM_ERROR')
+        .split(',').map((s) => s.trim()).filter(Boolean),
+} as const;
+
 export const EXTERNAL_LLM_TOOL_BLACKLIST: readonly string[] = [
     'vision_ocr',
     'analyze_image',

--- a/apps/api/src/services/ChatService.ts
+++ b/apps/api/src/services/ChatService.ts
@@ -52,7 +52,7 @@ import {
     streamFromExternalProvider as streamFromExternalProviderFn,
     type ExternalProviderDeps,
     type StreamFromExternalContext,
-} from './chat-service/external-provider';
+} from './chat-service/external-fallback';
 
 // Re-export all types so consumers importing from ChatService don't break
 export type {

--- a/apps/api/src/services/chat-service/external-fallback.ts
+++ b/apps/api/src/services/chat-service/external-fallback.ts
@@ -1,0 +1,99 @@
+/**
+ * ============================================================
+ * 채팅 provider dispatch — 외부 실패 시 로컬 폴백
+ * ============================================================
+ *
+ * 스트리밍 루프 본체(external-provider)에서 **재시도 정책만** 분리한 계층
+ * (파일 크기 가드 + 책임 분리). 소비처는 이 모듈의 streamFromExternalProvider 를
+ * 채팅 dispatch 단일 진입점으로 사용한다.
+ *
+ * @module services/chat-service/external-fallback
+ */
+import type { ChatMessageRequest } from '../chat-service-types';
+import type { ResolvedProvider } from '../../providers/provider-router';
+import { EXTERNAL_CHAT_FALLBACK } from '../../config/runtime-limits';
+import { getConfig } from '../../config/env';
+import { createLogger } from '../../utils/logger';
+import {
+    runExternalStream,
+    type ExternalProviderDeps,
+    type StreamFromExternalContext,
+} from './external-provider';
+
+// 소비처(ChatService)가 dispatch 진입점 한 곳에서 타입까지 가져오도록 재노출
+export type { ExternalProviderDeps, StreamFromExternalContext };
+
+const logger = createLogger('ChatExternalProvider');
+
+/**
+ * 외부 provider 실패 시 로컬 기본 모델로 1회 폴백하는 래퍼.
+ *
+ * 배경: 역할(role) 경로에는 4xx 로컬 강등이 있었지만 **채팅 경로에는 없었다**.
+ * 기본 모델을 외부로 두면 구독 한도(429)·세션 만료(401)에 그 대화가 통째로
+ * 에러로 죽었다 (2026-07-26 점검에서 확인).
+ *
+ * 안전 조건 — 아래를 모두 만족할 때만 폴백한다:
+ *   ① 외부 provider 였을 것 (로컬 실패는 폴백해도 같은 결과)
+ *   ② **아직 사용자에게 토큰을 한 글자도 내보내지 않았을 것** — 스트리밍 도중
+ *      교체하면 앞부분과 이어지지 않는 답변이 섞인다
+ *   ③ 사용자 중단(abort)이 아닐 것
+ *   ④ 재시도가 의미 있는 실패일 것 (인증·한도·모델부재·업스트림 오류)
+ */
+async function shouldFallbackToLocal(err: unknown, req: ChatMessageRequest): Promise<boolean> {
+    if (!EXTERNAL_CHAT_FALLBACK.ENABLED) return false;
+    if (req.abortSignal?.aborted) return false;
+
+    const status = (err as { status?: number; statusCode?: number })?.status
+        ?? (err as { statusCode?: number })?.statusCode;
+    if (typeof status === 'number') {
+        // 400(우리가 던진 vision 게이트 등 요청 자체 문제)은 재시도 무의미 — 제외
+        if (status === 400) return false;
+        if (status >= 401 && status < 600) return true;
+    }
+    const code = (err as { code?: string })?.code;
+    return !!code && EXTERNAL_CHAT_FALLBACK.RETRYABLE_CODES.includes(code);
+}
+
+/**
+ * 채팅 provider dispatch 진입점 (로컬 포함 단일 경로).
+ * 외부 실패 시 위 조건에서 로컬 기본 모델로 1회 재시도한다.
+ */
+export async function streamFromExternalProvider(
+    deps: ExternalProviderDeps,
+    resolved: ResolvedProvider,
+    req: ChatMessageRequest,
+    onToken: (token: string, thinking?: string) => void,
+    ctx: StreamFromExternalContext = {},
+): Promise<string> {
+    let emittedVisibleToken = false;
+    const trackedOnToken = (token: string, thinking?: string): void => {
+        if (token) emittedVisibleToken = true;
+        onToken(token, thinking);
+    };
+
+    try {
+        return await runExternalStream(deps, resolved, req, trackedOnToken, ctx);
+    } catch (err) {
+        if (resolved.providerId === 'local-llm' || emittedVisibleToken) throw err;
+        if (!(await shouldFallbackToLocal(err, req))) throw err;
+        if (!deps.providerRouter) throw err;
+
+        const localFullId = `local-llm:${getConfig().llmDefaultModel}`;
+        let localResolved: ResolvedProvider;
+        try {
+            localResolved = await deps.providerRouter.resolve(localFullId, {
+                ...(req.userId ? { userId: String(req.userId) } : {}),
+                ...(req.userRole ? { userRole: req.userRole } : {}),
+            });
+        } catch (resolveErr) {
+            logger.warn(`로컬 폴백 해석 실패 — 원본 오류 전파: ${resolveErr instanceof Error ? resolveErr.message : resolveErr}`);
+            throw err;
+        }
+
+        logger.warn(
+            `외부 provider 실패 → 로컬 폴백: ${resolved.fullId} → ${localFullId} `
+            + `(${err instanceof Error ? err.message.slice(0, 120) : String(err).slice(0, 120)})`,
+        );
+        return runExternalStream(deps, localResolved, req, onToken, ctx);
+    }
+}

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -29,6 +29,10 @@ import { WEB_SEARCH_TEMPLATES, getLocalizedTemplate } from '../../sockets/ws-cha
 
 import { executeExternalTool, recordExternalUsageFireAndForget } from './external-tool-exec';
 
+import { resolveModelCapabilities } from './model-capabilities';
+import { EXTERNAL_CHAT_FALLBACK } from '../../config/runtime-limits';
+import { getConfig } from '../../config/env';
+
 const logger = createLogger('ChatExternalProvider');
 
 export interface ExternalProviderDeps {
@@ -67,7 +71,7 @@ export interface StreamFromExternalContext {
 /**
  * 외부 LLM provider stream + multi-turn tool calling.
  */
-export async function streamFromExternalProvider(
+async function runExternalStream(
     deps: ExternalProviderDeps,
     resolved: ResolvedProvider,
     req: ChatMessageRequest,
@@ -107,17 +111,30 @@ export async function streamFromExternalProvider(
         ...(req.images ? { images: req.images } : {}),
     });
 
-    const caps = resolved.provider.getCapabilities(resolved.modelId);
+    // capability 는 카탈로그 우선으로 해석한다 — provider.getCapabilities() 는 외부의 경우
+    // 모델 ID 휴리스틱이라 실제 비전 모델을 vision:false 로 오판한다(실측).
+    const { caps, source: capsSource } = await resolveModelCapabilities(
+        resolved, req.userId, deps.providerRouter?.getExternalKeysRepo(),
+    );
 
     const hasImages = (req.images && req.images.length > 0)
         || (req.history ?? []).some((h) => h.images && h.images.length > 0);
     if (hasImages && !caps.vision) {
-        const err = new Error(
-            `Model '${resolved.fullId}' does not support vision input (capabilities.vision=false). ` +
-            'Use a vision-capable model or remove images from the request.',
-        );
-        (err as Error & { statusCode?: number }).statusCode = 400;
-        throw err;
+        // 휴리스틱 기반 '부정' 은 신뢰하지 않는다 — 오차단(진짜 비전 모델 400)이 실제
+        // 장애였다. 이 경우 그대로 진행하고, 정말 미지원이면 upstream 오류 →
+        // 로컬 폴백(withLocalFallback)이 받아낸다.
+        if (capsSource === 'heuristic') {
+            logger.warn(
+                `[Vision] '${resolved.fullId}' vision 판정이 휴리스틱(부정) — 차단하지 않고 진행`,
+            );
+        } else {
+            const err = new Error(
+                `Model '${resolved.fullId}' does not support vision input (capabilities.vision=false, source=${capsSource}). ` +
+                'Use a vision-capable model or remove images from the request.',
+            );
+            (err as Error & { statusCode?: number }).statusCode = 400;
+            throw err;
+        }
     }
 
     // 명시적 아티팩트 생성 요청(사용자 아티팩트 토글 또는 메시지 패턴)이면 distractor
@@ -513,3 +530,77 @@ export async function streamFromExternalProvider(
 
 // 도구 실행·사용량 기록은 external-tool-exec.ts 로 분리(600줄 CI 가드) — 기존 import 경로 호환 재노출.
 export { executeExternalTool, recordExternalUsageFireAndForget };
+
+
+/**
+ * 외부 provider 실패 시 로컬 기본 모델로 1회 폴백하는 래퍼.
+ *
+ * 배경: 역할(role) 경로에는 4xx 로컬 강등이 있었지만 **채팅 경로에는 없었다**.
+ * 기본 모델을 외부로 두면 구독 한도(429)·세션 만료(401)에 그 대화가 통째로
+ * 에러로 죽었다 (2026-07-26 점검에서 확인).
+ *
+ * 안전 조건 — 아래를 모두 만족할 때만 폴백한다:
+ *   ① 외부 provider 였을 것 (로컬 실패는 폴백해도 같은 결과)
+ *   ② **아직 사용자에게 토큰을 한 글자도 내보내지 않았을 것** — 스트리밍 도중
+ *      교체하면 앞부분과 이어지지 않는 답변이 섞인다
+ *   ③ 사용자 중단(abort)이 아닐 것
+ *   ④ 재시도가 의미 있는 실패일 것 (인증·한도·모델부재·업스트림 오류)
+ */
+async function shouldFallbackToLocal(err: unknown, req: ChatMessageRequest): Promise<boolean> {
+    if (!EXTERNAL_CHAT_FALLBACK.ENABLED) return false;
+    if (req.abortSignal?.aborted) return false;
+
+    const status = (err as { status?: number; statusCode?: number })?.status
+        ?? (err as { statusCode?: number })?.statusCode;
+    if (typeof status === 'number') {
+        // 400(우리가 던진 vision 게이트 등 요청 자체 문제)은 재시도 무의미 — 제외
+        if (status === 400) return false;
+        if (status >= 401 && status < 600) return true;
+    }
+    const code = (err as { code?: string })?.code;
+    return !!code && EXTERNAL_CHAT_FALLBACK.RETRYABLE_CODES.includes(code);
+}
+
+/**
+ * 채팅 provider dispatch 진입점 (로컬 포함 단일 경로).
+ * 외부 실패 시 위 조건에서 로컬 기본 모델로 1회 재시도한다.
+ */
+export async function streamFromExternalProvider(
+    deps: ExternalProviderDeps,
+    resolved: ResolvedProvider,
+    req: ChatMessageRequest,
+    onToken: (token: string, thinking?: string) => void,
+    ctx: StreamFromExternalContext = {},
+): Promise<string> {
+    let emittedVisibleToken = false;
+    const trackedOnToken = (token: string, thinking?: string): void => {
+        if (token) emittedVisibleToken = true;
+        onToken(token, thinking);
+    };
+
+    try {
+        return await runExternalStream(deps, resolved, req, trackedOnToken, ctx);
+    } catch (err) {
+        if (resolved.providerId === 'local-llm' || emittedVisibleToken) throw err;
+        if (!(await shouldFallbackToLocal(err, req))) throw err;
+        if (!deps.providerRouter) throw err;
+
+        const localFullId = `local-llm:${getConfig().llmDefaultModel}`;
+        let localResolved: ResolvedProvider;
+        try {
+            localResolved = await deps.providerRouter.resolve(localFullId, {
+                ...(req.userId ? { userId: String(req.userId) } : {}),
+                ...(req.userRole ? { userRole: req.userRole } : {}),
+            });
+        } catch (resolveErr) {
+            logger.warn(`로컬 폴백 해석 실패 — 원본 오류 전파: ${resolveErr instanceof Error ? resolveErr.message : resolveErr}`);
+            throw err;
+        }
+
+        logger.warn(
+            `외부 provider 실패 → 로컬 폴백: ${resolved.fullId} → ${localFullId} `
+            + `(${err instanceof Error ? err.message.slice(0, 120) : String(err).slice(0, 120)})`,
+        );
+        return runExternalStream(deps, localResolved, req, onToken, ctx);
+    }
+}

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -30,8 +30,6 @@ import { WEB_SEARCH_TEMPLATES, getLocalizedTemplate } from '../../sockets/ws-cha
 import { executeExternalTool, recordExternalUsageFireAndForget } from './external-tool-exec';
 
 import { resolveModelCapabilities } from './model-capabilities';
-import { EXTERNAL_CHAT_FALLBACK } from '../../config/runtime-limits';
-import { getConfig } from '../../config/env';
 
 const logger = createLogger('ChatExternalProvider');
 
@@ -71,7 +69,7 @@ export interface StreamFromExternalContext {
 /**
  * 외부 LLM provider stream + multi-turn tool calling.
  */
-async function runExternalStream(
+export async function runExternalStream(
     deps: ExternalProviderDeps,
     resolved: ResolvedProvider,
     req: ChatMessageRequest,
@@ -530,77 +528,3 @@ async function runExternalStream(
 
 // 도구 실행·사용량 기록은 external-tool-exec.ts 로 분리(600줄 CI 가드) — 기존 import 경로 호환 재노출.
 export { executeExternalTool, recordExternalUsageFireAndForget };
-
-
-/**
- * 외부 provider 실패 시 로컬 기본 모델로 1회 폴백하는 래퍼.
- *
- * 배경: 역할(role) 경로에는 4xx 로컬 강등이 있었지만 **채팅 경로에는 없었다**.
- * 기본 모델을 외부로 두면 구독 한도(429)·세션 만료(401)에 그 대화가 통째로
- * 에러로 죽었다 (2026-07-26 점검에서 확인).
- *
- * 안전 조건 — 아래를 모두 만족할 때만 폴백한다:
- *   ① 외부 provider 였을 것 (로컬 실패는 폴백해도 같은 결과)
- *   ② **아직 사용자에게 토큰을 한 글자도 내보내지 않았을 것** — 스트리밍 도중
- *      교체하면 앞부분과 이어지지 않는 답변이 섞인다
- *   ③ 사용자 중단(abort)이 아닐 것
- *   ④ 재시도가 의미 있는 실패일 것 (인증·한도·모델부재·업스트림 오류)
- */
-async function shouldFallbackToLocal(err: unknown, req: ChatMessageRequest): Promise<boolean> {
-    if (!EXTERNAL_CHAT_FALLBACK.ENABLED) return false;
-    if (req.abortSignal?.aborted) return false;
-
-    const status = (err as { status?: number; statusCode?: number })?.status
-        ?? (err as { statusCode?: number })?.statusCode;
-    if (typeof status === 'number') {
-        // 400(우리가 던진 vision 게이트 등 요청 자체 문제)은 재시도 무의미 — 제외
-        if (status === 400) return false;
-        if (status >= 401 && status < 600) return true;
-    }
-    const code = (err as { code?: string })?.code;
-    return !!code && EXTERNAL_CHAT_FALLBACK.RETRYABLE_CODES.includes(code);
-}
-
-/**
- * 채팅 provider dispatch 진입점 (로컬 포함 단일 경로).
- * 외부 실패 시 위 조건에서 로컬 기본 모델로 1회 재시도한다.
- */
-export async function streamFromExternalProvider(
-    deps: ExternalProviderDeps,
-    resolved: ResolvedProvider,
-    req: ChatMessageRequest,
-    onToken: (token: string, thinking?: string) => void,
-    ctx: StreamFromExternalContext = {},
-): Promise<string> {
-    let emittedVisibleToken = false;
-    const trackedOnToken = (token: string, thinking?: string): void => {
-        if (token) emittedVisibleToken = true;
-        onToken(token, thinking);
-    };
-
-    try {
-        return await runExternalStream(deps, resolved, req, trackedOnToken, ctx);
-    } catch (err) {
-        if (resolved.providerId === 'local-llm' || emittedVisibleToken) throw err;
-        if (!(await shouldFallbackToLocal(err, req))) throw err;
-        if (!deps.providerRouter) throw err;
-
-        const localFullId = `local-llm:${getConfig().llmDefaultModel}`;
-        let localResolved: ResolvedProvider;
-        try {
-            localResolved = await deps.providerRouter.resolve(localFullId, {
-                ...(req.userId ? { userId: String(req.userId) } : {}),
-                ...(req.userRole ? { userRole: req.userRole } : {}),
-            });
-        } catch (resolveErr) {
-            logger.warn(`로컬 폴백 해석 실패 — 원본 오류 전파: ${resolveErr instanceof Error ? resolveErr.message : resolveErr}`);
-            throw err;
-        }
-
-        logger.warn(
-            `외부 provider 실패 → 로컬 폴백: ${resolved.fullId} → ${localFullId} `
-            + `(${err instanceof Error ? err.message.slice(0, 120) : String(err).slice(0, 120)})`,
-        );
-        return runExternalStream(deps, localResolved, req, onToken, ctx);
-    }
-}

--- a/apps/api/src/services/chat-service/model-capabilities.ts
+++ b/apps/api/src/services/chat-service/model-capabilities.ts
@@ -1,0 +1,105 @@
+/**
+ * ============================================================
+ * 모델 capability 해석 — 카탈로그 우선, 휴리스틱은 최후
+ * ============================================================
+ *
+ * 외부 provider 의 `getCapabilities()` 는 **모델 ID 문자열 휴리스틱**이다
+ * (openai-compat-provider 의 inferCapabilitiesFromModelId). 이 값으로 vision 게이트를
+ * 걸면 실제 비전 모델이 400 으로 조기 차단된다 — 실측:
+ *   vision X  meta/llama-4-maverick-17b-128e-instruct  ← 진짜 비전 모델
+ *   vision X  google/gemma-4-31b-it
+ * 게다가 카탈로그(config fallbackModels)엔 vision:true 로 적혀 있어 UI 표시와
+ * 런타임 판정이 모순이었다 (2026-07-26 실측).
+ *
+ * 해결: 신뢰도 순으로 출처를 정해 해석하고, **출처를 함께 반환**한다.
+ * 호출부는 "휴리스틱 기반 부정"으로는 요청을 차단하지 않는다 (오차단 방지).
+ *
+ *   1. local      — 로컬 provider 프리셋 (model-presets, 명시 관리)
+ *   2. catalog    — 사용자별 라이브 모델 캐시 (OpenRouter 는 architecture.input_modalities
+ *                   등 API 응답 기반이라 정확)
+ *   3. config     — EXTERNAL_PROVIDER_CATALOG.fallbackModels (운영자 큐레이션)
+ *   4. heuristic  — provider.getCapabilities() 문자열 추론 (최후, 부정 신뢰 불가)
+ *
+ * @module services/chat-service/model-capabilities
+ */
+import type { ProviderCapabilities } from '../../providers/i-provider';
+import type { ResolvedProvider } from '../../providers/provider-router';
+import type { ExternalKeysRepository } from '../../data/repositories/external-keys-repo';
+import { getProviderCatalogEntry } from '../../config/external-providers';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('ModelCapabilities');
+
+/** capability 출처 — 'heuristic' 만 신뢰도가 낮아 차단 근거로 쓰지 않는다. */
+export type CapabilitySource = 'local' | 'catalog' | 'config' | 'heuristic';
+
+export interface ResolvedCapabilities {
+    caps: ProviderCapabilities;
+    source: CapabilitySource;
+}
+
+/** 캐시 조회 TTL — model.routes 와 동일 env 를 공유 (기본 1h) */
+function cacheTtlMs(): number {
+    return parseInt(process.env.EXTERNAL_MODELS_CACHE_TTL_MS ?? '3600000', 10);
+}
+
+type CachedModelEntry = {
+    id?: string;
+    fullId?: string;
+    capabilities?: Partial<ProviderCapabilities>;
+};
+
+function fromPartial(
+    partial: Partial<ProviderCapabilities>,
+    base: ProviderCapabilities,
+): ProviderCapabilities {
+    return {
+        streaming: partial.streaming ?? base.streaming,
+        toolCalling: partial.toolCalling ?? base.toolCalling,
+        vision: partial.vision ?? base.vision,
+        thinking: partial.thinking ?? base.thinking,
+    };
+}
+
+/**
+ * 실행 대상 모델의 capability 를 신뢰도 순으로 해석한다.
+ * 어떤 단계에서 실패해도 예외를 던지지 않는다 — 최후에는 provider 휴리스틱으로 수렴.
+ */
+export async function resolveModelCapabilities(
+    resolved: ResolvedProvider,
+    userId?: string,
+    repo?: ExternalKeysRepository,
+): Promise<ResolvedCapabilities> {
+    const heuristic = resolved.provider.getCapabilities(resolved.modelId);
+
+    // 로컬은 프리셋 기반이라 그대로 신뢰 (부정도 유효한 정보)
+    if (resolved.providerId === 'local-llm') {
+        return { caps: heuristic, source: 'local' };
+    }
+
+    // ② 사용자별 라이브 카탈로그 캐시 (provider API 응답 기반 — 가장 정확)
+    if (userId && repo) {
+        try {
+            const cached = (await repo.getCachedModels(
+                userId, resolved.providerId, cacheTtlMs(),
+            )) as CachedModelEntry[] | null;
+            const hit = cached?.find(
+                (m) => m.id === resolved.modelId || m.fullId === resolved.fullId,
+            );
+            if (hit?.capabilities) {
+                return { caps: fromPartial(hit.capabilities, heuristic), source: 'catalog' };
+            }
+        } catch (e) {
+            logger.debug(`카탈로그 캐시 조회 실패 (휴리스틱 계속): ${e instanceof Error ? e.message : e}`);
+        }
+    }
+
+    // ③ 운영자 큐레이션 카탈로그 (config)
+    const entry = getProviderCatalogEntry(resolved.providerId);
+    const known = entry?.fallbackModels?.find((m) => m.id === resolved.modelId);
+    if (known?.capabilities) {
+        return { caps: fromPartial(known.capabilities, heuristic), source: 'config' };
+    }
+
+    return { caps: heuristic, source: 'heuristic' };
+}


### PR DESCRIPTION
외부 모델 사용 시 로컬 모델과의 기능 격차 2건을 해소합니다 (2026-07-26 전수 점검 결과 중 심각도 상위 2건).

## ① 비전 모델 오차단 — 실사용 장애

외부 provider 의 `getCapabilities()` 는 **모델 ID 문자열 휴리스틱**입니다. 실제로 돌려보니:

```
vision X  meta/llama-4-maverick-17b-128e-instruct   ← 진짜 비전 모델인데 차단
vision X  google/gemma-4-31b-it
vision O  openai/gpt-5, anthropic/claude-opus-4.5, mistralai/pixtral-12b
```

이미지를 첨부하면 `external-provider.ts` 의 vision 게이트가 **400 으로 조기 거부**했습니다. 게다가 `EXTERNAL_PROVIDER_CATALOG` 에는 같은 모델이 `vision: true` 로 등록돼 있어 **UI 표시와 런타임 판정이 모순**이었습니다.

**수정** — `chat-service/model-capabilities.ts` 신설. 신뢰도 순으로 해석하고 **출처를 함께 반환**합니다:

| 우선순위 | 출처 | 신뢰도 |
|---|---|---|
| 1 | `local` — 로컬 프리셋 | 높음 (명시 관리) |
| 2 | `catalog` — 사용자별 라이브 모델 캐시 (OpenRouter `input_modalities` 등 API 기반) | 높음 |
| 3 | `config` — 카탈로그 `fallbackModels` (운영자 큐레이션) | 높음 |
| 4 | `heuristic` — provider ID 문자열 추론 | **낮음** |

게이트는 **`heuristic` 기반 '부정' 으로는 차단하지 않습니다.** 정말 미지원이면 upstream 오류가 나고 ②의 폴백이 받아냅니다 — "멀쩡한 모델을 막는 것" 보다 "안 되는 모델을 시도했다가 폴백" 이 낫다는 판단입니다.

## ② 채팅 경로 로컬 폴백 부재

역할(role) 경로에는 4xx 로컬 강등이 있었지만 **채팅 경로에는 없었습니다.** 기본 모델을 외부로 둔 사용자가 구독 한도(429)·세션 만료(401)를 만나면 **대화가 통째로 에러로 실패**했습니다.

**수정** — `streamFromExternalProvider` 를 래퍼로 감싸 실패 시 로컬 기본 모델로 1회 재시도합니다.

안전 조건 (모두 만족해야 폴백):
- 외부 provider 였을 것 (로컬 실패는 재시도 무의미)
- **아직 사용자에게 토큰을 한 글자도 내보내지 않았을 것** — 스트리밍 도중 교체하면 앞뒤가 안 맞는 답변이 섞입니다
- 사용자 중단(abort)이 아닐 것
- 재시도가 의미 있는 실패일 것 (인증·한도·모델부재·업스트림). **400(요청 자체 문제)은 제외**

`EXTERNAL_CHAT_FALLBACK` 로 게이트·대상 코드 목록을 외부화했습니다 (기본 ON, `EXTERNAL_CHAT_LOCAL_FALLBACK=false` 로 opt-out).

## 검증

**라이브** — ChatGPT 세션을 일시 무효화해 401 을 유발(원본 백업 후 즉시 복구):

| 단계 | 결과 |
|---|---|
| 정상 상태 | ChatGPT 직접 응답 `'서울'` |
| 세션 무효화 후 | **`success: true`, 응답 `'서울'`** — 사용자에겐 장애 없음 |
| 서버 로그 | `외부 provider 실패 → 로컬 폴백: chatgpt:gpt-5.4-mini → local-llm:qwen3.6-35b-a3b` |
| 사용량 기록 | 실패 시도가 `error_code=INVALID_API_KEY` 로 남고, 폴백 성공분은 `local-llm` 으로 기록 |
| 세션 복구 후 | ChatGPT 직접 응답 `'도쿄'` 정상 |

**유닛** — 신규 12개 (capability 출처 우선순위 6 + 폴백 조건 6: 429·401 폴백, 토큰 방출 후 미폴백, 로컬 실패 미폴백, abort 미폴백, 400 미폴백).
전체 **2,158개 통과**, `npm run lint` 0 errors, `tsc` 클린.
ℹ️ 테스트 파일은 저장소 정책상 커밋되지 않습니다 (`.gitignore`).

## 남은 항목 (이번 PR 범위 밖)

같은 점검에서 확인된 나머지는 별도 논의가 필요해 제외했습니다:
- 딥리서치 경로에 MCP 도구·스킬 미전달 (설계 변경 사안)
- 외부 사용량이 채팅 경로에서만 기록됨 (딥리서치·에이전트 작업 미기록)
- 토큰 쿼터가 외부 모델에 미적용 (BYOK 면제가 의도인지 정책 결정 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
