### PR TITLE
feat(deep-research): 스킬 지식 + MCP 도구 근거를 리서치 파이프라인에 연결

### DIFF
--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -952,6 +952,29 @@ export const ROUTING_VERIFICATION = {
  * 외부 모델 가용성 프로브 (services/model-availability-probe).
  * provider 카탈로그를 최소 요청으로 찔러 실사용 가능 모델만 남기는 점검의 한도.
  */
+/**
+ * 딥리서치 컨텍스트 (스킬 지식 + MCP 근거 수집).
+ * 리서치는 웹검색 전용 파이프라인이라 도구·스킬이 없었다(2026-07-26 점검) — 이 상수들이
+ * 도구폭주(전체 카탈로그 전달 시 vLLM 문법 컴파일 101s 실측) 없이 붙이기 위한 상한이다.
+ */
+export const RESEARCH_CONTEXT = {
+    /** MCP 근거 수집 단계 게이트 — RESEARCH_MCP_EVIDENCE=false 로 opt-out */
+    MCP_EVIDENCE_ENABLED: process.env.RESEARCH_MCP_EVIDENCE !== 'false',
+    /** LLM 에 노출할 관련 도구 상한 (목표 관련성 top-K). RESEARCH_MCP_TOOL_BUDGET */
+    MCP_TOOL_BUDGET: parseInt(process.env.RESEARCH_MCP_TOOL_BUDGET || '8', 10),
+    /** 1회 수집에서 실행할 도구 호출 상한. RESEARCH_MCP_MAX_CALLS */
+    MCP_MAX_CALLS: parseInt(process.env.RESEARCH_MCP_MAX_CALLS || '3', 10),
+    /** 수집 턴의 출력 토큰 상한 (도구 호출 인자만 필요). RESEARCH_MCP_MAX_TOKENS */
+    MCP_MAX_TOKENS: parseInt(process.env.RESEARCH_MCP_MAX_TOKENS || '1024', 10),
+    MCP_MIN_RESULT_CHARS: parseInt(process.env.RESEARCH_MCP_MIN_RESULT_CHARS || '40', 10),
+    /** 도구 결과 본문 캡 — 합성 컨텍스트 팽창 방지 */
+    MCP_RESULT_CHAR_CAP: parseInt(process.env.RESEARCH_MCP_RESULT_CHAR_CAP || '8000', 10),
+    /** 리서치에 부적합해 제외하는 도구 (웹검색은 파이프라인이 이미 수행) */
+    MCP_EXCLUDED_TOOLS: (process.env.RESEARCH_MCP_EXCLUDED_TOOLS
+        || 'web_search,web_scrape,web_crawl,web_map,extract_webpage,research_topic,generate_image')
+        .split(',').map((s) => s.trim()).filter(Boolean),
+} as const;
+
 export const MODEL_AVAILABILITY_PROBE = {
     /** 모델 1건당 상한 — 초과 시 '판정 보류'(기록 안 함). MODEL_PROBE_TIMEOUT_MS */
     TIMEOUT_MS: parseInt(process.env.MODEL_PROBE_TIMEOUT_MS || '20000', 10),

--- a/apps/api/src/routes/research.routes.ts
+++ b/apps/api/src/routes/research.routes.ts
@@ -251,7 +251,10 @@ router.post('/sessions/:sessionId/execute', validate(executeResearchSchema), asy
     // (사용자 매핑 → 전역 env → 로컬 default, 외부 매핑은 BYOK 키로 직결)
     const language = detectLanguage(session.topic).language;
     const resolved = await resolveRoleClientForUser('research', String(req.user!.id));
-    const service = createDeepResearchService({ maxLoops: loops, language }, resolved.client);
+    const service = createDeepResearchService(
+        { maxLoops: loops, language, userId: String(req.user!.id), userRole: 'user' },
+        resolved.client,
+    );
 
     // 백그라운드 실행 (응답은 즉시 반환)
     service.executeResearch(sessionId, session.topic).catch((error) => {

--- a/apps/api/src/services/DeepResearchService.ts
+++ b/apps/api/src/services/DeepResearchService.ts
@@ -38,6 +38,7 @@ import { searchSubTopics } from './deep-research/source-searcher';
 import { scrapeSources } from './deep-research/content-scraper';
 import { synthesizeFindings, checkNeedsMoreInfo } from './deep-research/findings-synthesizer';
 import { generateReport } from './deep-research/report-generator';
+import { buildResearchSkillBlock, gatherMcpEvidence } from './deep-research/research-context';
 
 // Re-export types so consumers don't break
 export type { ResearchConfig, ResearchProgress, ResearchResult };
@@ -104,7 +105,12 @@ export class DeepResearchService {
             // 1단계: 주제 분해 (0-5%)
             this.throwIfAborted();
             this.reportProgress(onProgress, sessionId, 'running', 0, this.config.maxLoops, 'decompose', 2, getResearchMessage('analyzing', this.config.language));
+            // 스킬 지식(활성 매니페스트) — 분해·합성·보고서 프롬프트에 공통 주입.
+            // 실패 시 '' 라 리서치 흐름을 막지 않는다.
+            const skillBlock = await buildResearchSkillBlock(this.config.userId);
+
             const subTopics = await decomposeTopics({
+                skillBlock,
                 client: this.client,
                 config: this.config,
                 topic,
@@ -162,6 +168,28 @@ export class DeepResearchService {
                     throwIfAborted: () => this.throwIfAborted()
                 });
                 this.throwIfAborted();
+
+                // MCP 근거 수집(루프 1회) — 웹으로 닿지 않는 사내 데이터·노트북·설치 MCP
+                // 서버 자료를 소스로 합류시킨다. 스크래핑 대상에서 제외하려고 URL 을
+                // scrapedUrls 에 미리 등록한다(내용은 이미 확보).
+                if (loopNumber === 1) {
+                    const mcpSources = await gatherMcpEvidence({
+                        client: this.client,
+                        topic,
+                        ...(this.config.userId ? { userId: this.config.userId } : {}),
+                        ...(this.config.userRole ? { userRole: this.config.userRole } : {}),
+                        ...(this.abortController ? { abortSignal: this.abortController.signal } : {}),
+                    });
+                    for (const src of mcpSources) {
+                        if (sourceMap.has(src.url)) continue;
+                        sourceMap.set(src.url, src);
+                        seenUrls.add(src.url);
+                        scrapedUrls.add(src.url);
+                    }
+                    if (mcpSources.length > 0) {
+                        logger.info(`[DeepResearch] MCP 근거 ${mcpSources.length}건 합류`);
+                    }
+                }
 
                 const uniqueSources = Array.from(sourceMap.values());
                 this.reportProgress(
@@ -225,6 +253,7 @@ export class DeepResearchService {
                 );
 
                 const synthesis = await synthesizeFindings({
+                    skillBlock,
                     client: this.client,
                     config: this.config,
                     topic,
@@ -296,6 +325,7 @@ export class DeepResearchService {
             this.throwIfAborted();
             this.reportProgress(onProgress, sessionId, 'running', this.config.maxLoops, this.config.maxLoops, 'report', 85, getResearchMessage('generatingReport', this.config.language));
             const report = await generateReport({
+                skillBlock,
                 client: this.client,
                 config: this.config,
                 topic,

--- a/apps/api/src/services/chat-strategies/deep-research-strategy.ts
+++ b/apps/api/src/services/chat-strategies/deep-research-strategy.ts
@@ -68,6 +68,9 @@ export class DeepResearchStrategy implements ChatStrategy<DeepResearchStrategyCo
             maxScrapePerLoop: RESEARCH_STRATEGY_PARAMS.MAX_SCRAPE_PER_LOOP,
             scrapeTimeoutMs: LLM_TIMEOUTS.SCRAPE_TIMEOUT_MS,
             chunkSize: RESEARCH_STRATEGY_PARAMS.CHUNK_SIZE,
+            // 스킬 지식·MCP 근거 수집 대상 (research-context) — 게스트/익명은 자동 skip
+            ...(userId ? { userId: String(userId) } : {}),
+            ...(context.req.userRole ? { userRole: context.req.userRole } : {}),
         }, context.client);
 
         // 연구 세션 ID 생성 및 DB 저장 (추후 조회/이어하기용)

--- a/apps/api/src/services/deep-research-types.ts
+++ b/apps/api/src/services/deep-research-types.ts
@@ -28,6 +28,10 @@ export interface ResearchConfig {
     maxScrapePerLoop: number;    // 루프당 최대 스크래핑 수 (기본: 15, env DEEP_RESEARCH_MAX_SCRAPE_PER_LOOP)
     scrapeTimeoutMs: number;     // 개별 스크래핑 타임아웃 (기본: 15000)
     chunkSize: number;           // 중간 요약용 청크 사이즈 (기본: 10)
+    /** 스킬 지식·MCP 근거 수집 대상 사용자 (미지정 시 두 기능 모두 skip) */
+    userId?: string;
+    /** 도구 역할 게이팅용 (기본 'user') */
+    userRole?: 'admin' | 'user' | 'guest';
 }
 
 /** 리서치 진행 상황 */

--- a/apps/api/src/services/deep-research/findings-synthesizer.ts
+++ b/apps/api/src/services/deep-research/findings-synthesizer.ts
@@ -11,6 +11,7 @@ import type { LLMClient } from '../../llm';
 import type { SearchResult } from '../../mcp/web-search';
 import type { ResearchConfig, SynthesisResult } from '../deep-research-types';
 import { getUnifiedDatabase } from '../../data/models/unified-database';
+import { withSkillContext } from './research-context';
 import { createLogger } from '../../utils/logger';
 import { TRUNCATION, RESEARCH_DEFAULTS } from '../../config/runtime-limits';
 import { LLM_TEMPERATURES } from '../../config/llm-parameters';
@@ -50,6 +51,8 @@ function measureTotalContent(sources: SearchResult[]): number {
  * 검색 결과를 청크로 나눠 LLM 합성
  */
 export async function synthesizeFindings(params: {
+    /** 활성 스킬 지식 블록 (research-context) */
+    skillBlock?: string;
     client: LLMClient;
     config: ResearchConfig;
     topic: string;
@@ -235,6 +238,8 @@ async function singleMerge(params: {
     summaries: string[];
     abortSignal?: AbortSignal;
     throwIfAborted: () => void;
+    /** 활성 스킬 지식 블록 (research-context) */
+    skillBlock?: string;
 }): Promise<string> {
     const { client, config, topic, summaries, abortSignal, throwIfAborted } = params;
 
@@ -243,7 +248,7 @@ async function singleMerge(params: {
     try {
         const response = await chatWithAbortTimeout(
             client,
-            [{ role: 'user', content: mergedPrompt }],
+            [{ role: 'user', content: withSkillContext(mergedPrompt, params.skillBlock ?? '') }],
             { temperature: LLM_TEMPERATURES.RESEARCH_REPORT },
             LLM_TIMEOUTS.SYNTHESIS_MERGE_TIMEOUT_MS,
             abortSignal,

--- a/apps/api/src/services/deep-research/report-generator.ts
+++ b/apps/api/src/services/deep-research/report-generator.ts
@@ -10,6 +10,7 @@ import { type LLMClient } from '../../llm';
 import type { SearchResult } from '../../mcp/web-search';
 import type { ResearchConfig, SubTopic } from '../deep-research-types';
 import { getUnifiedDatabase } from '../../data/models/unified-database';
+import { withSkillContext } from './research-context';
 import { createLogger } from '../../utils/logger';
 import { TRUNCATION } from '../../config/runtime-limits';
 import { LLM_TEMPERATURES } from '../../config/llm-parameters';
@@ -114,6 +115,8 @@ function buildFallbackReport(lang: string, topic: string, findings: string[], so
  * 최종 보고서 생성
  */
 export async function generateReport(params: {
+    /** 활성 스킬 지식 블록 (research-context) */
+    skillBlock?: string;
     client: LLMClient;
     config: ResearchConfig;
     topic: string;
@@ -176,7 +179,7 @@ export async function generateReport(params: {
         // stall 여부를 가시화한다. onToken 모드에서도 client 는 최종 content 를 누적 반환한다.
         let accumulatedChars = 0;
         const response = await reportClient.chat(
-            [{ role: 'user', content: prompt }],
+            [{ role: 'user', content: withSkillContext(prompt, params.skillBlock ?? '') }],
             { temperature: LLM_TEMPERATURES.RESEARCH_SYNTHESIS },
             (token) => {
                 accumulatedChars += token.length;

--- a/apps/api/src/services/deep-research/research-context.ts
+++ b/apps/api/src/services/deep-research/research-context.ts
@@ -1,0 +1,159 @@
+/**
+ * ============================================================
+ * 딥리서치 컨텍스트 — 스킬 지식 + MCP 도구 근거 수집
+ * ============================================================
+ *
+ * 딥리서치는 웹검색·스크래핑 전용 결정적 파이프라인이라 **MCP 도구도 스킬도
+ * 전달되지 않았다**(2026-07-26 점검). 채팅·에이전트 작업은 둘 다 쓰는데 리서치만
+ * 사내 데이터·전문 지식에 접근할 수 없었다.
+ *
+ * 이 모듈이 두 가지를 붙인다:
+ *   ① 스킬 지식 — 활성 스킬 매니페스트를 프롬프트 앞에 주입 (분해·합성·보고서)
+ *   ② MCP 근거 — 도구를 1회 호출해 얻은 결과를 SearchResult 로 변환, 웹 소스와
+ *      동일하게 합성·인용 파이프라인에 태운다
+ *
+ * 도구폭주 방지: 전체 카탈로그(~150)를 넘기면 vLLM 문법 컴파일이 폭주한다(실측
+ * 101s). 목표 관련성 top-K 로 캡하고 턴 수도 제한한다.
+ *
+ * @module services/deep-research/research-context
+ */
+import type { LLMClient, ToolDefinition } from '../../llm';
+import type { SearchResult } from '../../mcp/web-search';
+import { getUnifiedMCPClient } from '../../mcp/unified-client';
+import { getSkillManager } from '../../agents/skill-manager';
+import { selectRelevantToolsEmbedding } from '../agent-task/tool-selector-embedding';
+import { filterRestrictedTools } from '../chat-service/tool-restrictions';
+import { RESEARCH_CONTEXT } from '../../config/runtime-limits';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('DeepResearch:Context');
+
+/**
+ * 딥리서치의 스킬 스코프 sentinel — 산업 agent 페르소나를 우회하므로
+ * `__global__` + `user:{userId}` 스킬만 매칭된다 (agent-task 의 `__agent_task__` 관행).
+ */
+export const RESEARCH_SKILL_AGENT_ID = '__deep_research__';
+
+/** MCP 도구 결과를 소스로 표시할 때 쓰는 스킴 — 스크래핑 대상에서 제외된다. */
+export const MCP_SOURCE_SCHEME = 'mcp://';
+
+/**
+ * 활성 스킬 지식 블록. 실패/부재 시 '' — 리서치 흐름을 막지 않는다.
+ */
+export async function buildResearchSkillBlock(userId?: string): Promise<string> {
+    if (!userId || userId === 'guest') return '';
+    try {
+        const block = await getSkillManager().buildManifestPrompt(RESEARCH_SKILL_AGENT_ID, userId);
+        if (block) logger.info('[DeepResearch] 스킬 지식 주입');
+        return block ?? '';
+    } catch (e) {
+        logger.debug(`스킬 주입 실패 — 무시: ${e instanceof Error ? e.message : e}`);
+        return '';
+    }
+}
+
+/** 프롬프트 앞에 스킬 블록을 붙인다 (블록이 비면 원본 그대로). */
+export function withSkillContext(prompt: string, skillBlock: string): string {
+    return skillBlock ? `${skillBlock}\n\n---\n\n${prompt}` : prompt;
+}
+
+/**
+ * MCP 도구로 추가 근거를 수집해 SearchResult 로 변환한다.
+ *
+ * 웹으로는 닿지 않는 자료(사내 DB·노트북·설치한 MCP 서버)를 리서치에 포함시키는 것이
+ * 목적이다. 실패·미지원·도구 없음은 모두 빈 배열 — 리서치 본류를 막지 않는다.
+ */
+export async function gatherMcpEvidence(params: {
+    client: LLMClient;
+    topic: string;
+    userId?: string;
+    userRole?: 'admin' | 'user' | 'guest';
+    abortSignal?: AbortSignal;
+}): Promise<SearchResult[]> {
+    const { client, topic, userId, userRole, abortSignal } = params;
+    if (!RESEARCH_CONTEXT.MCP_EVIDENCE_ENABLED) return [];
+    if (!userId || userId === 'guest') return [];
+
+    let tools: ToolDefinition[] = [];
+    try {
+        const all = filterRestrictedTools(
+            (await getUnifiedMCPClient().getToolRouter().getLLMTools({ userId })) as unknown as ToolDefinition[],
+            userRole ?? 'user',
+        );
+        // 목표 관련성 top-K 만 — 전체 카탈로그 전달은 문법 컴파일 폭주를 유발한다.
+        tools = await selectRelevantToolsEmbedding(topic, all, {
+            budget: RESEARCH_CONTEXT.MCP_TOOL_BUDGET,
+            exclude: new Set(RESEARCH_CONTEXT.MCP_EXCLUDED_TOOLS),
+        });
+    } catch (e) {
+        logger.debug(`도구 선별 실패 — MCP 근거 수집 생략: ${e instanceof Error ? e.message : e}`);
+        return [];
+    }
+    if (tools.length === 0) return [];
+
+    logger.info(
+        `[DeepResearch] MCP 근거 수집 — 관련 도구 ${tools.length}종: `
+        + tools.map((t) => t.function.name).join(', '),
+    );
+
+    try {
+        const response = await client.chat(
+            [
+                {
+                    role: 'system',
+                    content:
+                        '너는 리서치 근거 수집 보조자다. 주어진 도구들은 **웹 검색으로는 접근할 수 없는 '
+                        + '내부 데이터**(사내 DB·노트북·설치된 MCP 서버 자료)에 닿는 통로다. '
+                        + '리서치 주제가 내부 시스템·자체 데이터·특정 문서를 가리키면 해당 도구를 '
+                        + '적극적으로 호출해 근거를 수집하라. '
+                        + '웹 검색은 파이프라인이 이미 수행하므로, 공개 웹에서 쉽게 찾을 수 있는 일반 정보만 '
+                        + '필요한 주제라면 도구를 호출하지 말고 빈 답을 내라.',
+                },
+                { role: 'user', content: `리서치 주제: ${topic}` },
+            ],
+            { num_predict: RESEARCH_CONTEXT.MCP_MAX_TOKENS },
+            undefined,
+            { tools, tool_choice: 'auto', think: false, ...(abortSignal ? { signal: abortSignal } : {}) },
+        );
+
+        const calls = response.tool_calls ?? [];
+        if (calls.length === 0) {
+            logger.info('[DeepResearch] MCP 도구 호출 없음 — 웹 소스만 사용');
+            return [];
+        }
+
+        const results: SearchResult[] = [];
+        const mcp = getUnifiedMCPClient();
+        for (const [i, call] of calls.slice(0, RESEARCH_CONTEXT.MCP_MAX_CALLS).entries()) {
+            const name = call.function.name;
+            try {
+                const out = await mcp.executeToolWithContext(
+                    name,
+                    (call.function.arguments ?? {}) as Record<string, unknown>,
+                    { userId, role: userRole ?? 'user' },
+                );
+                // MCPToolResult → 텍스트 (content 배열의 text 파트 결합)
+                const text = (out.content ?? [])
+                    .map((c) => (typeof c === 'object' && c && 'text' in c ? String((c as { text?: unknown }).text ?? '') : ''))
+                    .join('\n')
+                    .trim();
+                if (!text || text.length < RESEARCH_CONTEXT.MCP_MIN_RESULT_CHARS) continue;
+                results.push({
+                    title: `MCP 도구 결과: ${name}`,
+                    // 스크래핑 대상에서 제외되도록 별도 스킴을 쓴다 (호출자가 scrapedUrls 에 등록)
+                    url: `${MCP_SOURCE_SCHEME}${name}/${i + 1}`,
+                    snippet: text.slice(0, 300),
+                    fullContent: text.slice(0, RESEARCH_CONTEXT.MCP_RESULT_CHAR_CAP),
+                    source: `mcp/${name}`,
+                });
+                logger.info(`[DeepResearch] MCP 근거 확보: ${name} (${text.length}자)`);
+            } catch (e) {
+                logger.warn(`[DeepResearch] MCP 도구 '${name}' 실행 실패 — 건너뜀: ${e instanceof Error ? e.message : e}`);
+            }
+        }
+        return results;
+    } catch (e) {
+        logger.warn(`[DeepResearch] MCP 근거 수집 실패 — 웹 소스로 계속: ${e instanceof Error ? e.message : e}`);
+        return [];
+    }
+}

--- a/apps/api/src/services/deep-research/topic-decomposer.ts
+++ b/apps/api/src/services/deep-research/topic-decomposer.ts
@@ -15,6 +15,7 @@ import { LLM_TEMPERATURES } from '../../config/llm-parameters';
 import { LLM_TIMEOUTS } from '../../config/timeouts';
 import { clampImportance, buildFallbackSubTopics } from '../deep-research-utils';
 import { getDecomposePrompt, getResearchMessage } from '../deep-research-prompts';
+import { withSkillContext } from './research-context';
 import { chatWithAbortTimeout } from './chat-with-timeout';
 
 const logger = createLogger('DeepResearch:TopicDecomposer');
@@ -29,11 +30,13 @@ export async function decomposeTopics(params: {
     sessionId: string;
     abortSignal?: AbortSignal;
     throwIfAborted: () => void;
+    /** 활성 스킬 지식 블록 (research-context) — 있으면 프롬프트 앞에 주입 */
+    skillBlock?: string;
 }): Promise<SubTopic[]> {
     const { client, config, topic, sessionId, abortSignal, throwIfAborted } = params;
 
     throwIfAborted();
-    const prompt = getDecomposePrompt(config.language, topic);
+    const prompt = withSkillContext(getDecomposePrompt(config.language, topic), params.skillBlock ?? '');
 
     try {
         const response = await chatWithAbortTimeout(


### PR DESCRIPTION
## 문제

딥리서치는 웹검색·스크래핑 전용 **결정적 파이프라인**이라 tool-calling 루프가 없고, 그 결과 **MCP 도구도 스킬도 전혀 전달되지 않았습니다** (2026-07-26 전수 점검).

| | 채팅 | 에이전트 작업 | 딥리서치 |
|---|---|---|---|
| MCP 도구 | ✅ | ✅ | ❌ **0개** |
| 스킬 매니페스트 | ✅ | ✅ | ❌ |
| load_skill | ✅ | ✅ | ❌ |

사내 DB·노트북·설치한 MCP 서버 자료가 리서치에 전혀 반영되지 않았습니다.

## 구현

**`deep-research/research-context.ts` 신설** — 두 가지를 붙입니다.

**① 스킬 지식 주입**
활성 스킬 매니페스트를 **주제 분해 · 합성 · 보고서** 프롬프트 앞에 주입합니다. 스코프 sentinel `__deep_research__` 를 써서 `__global__` + `user:{id}` 스킬만 매칭합니다 (에이전트 작업의 `__agent_task__` 관행 그대로).

**② MCP 근거 수집**
루프 1회에 한해, 목표 관련성 top-K 도구로 1턴 호출하고 그 결과를 `SearchResult`(`mcp://` 스킴)로 변환해 **웹 소스와 동일하게** 합성·인용 파이프라인에 태웁니다. `mcp://` 소스는 `scrapedUrls` 에 선등록해 스크래핑 대상에서 빠집니다(내용은 이미 확보).

## 핵심 제약: 도구폭주 방지

이 프로젝트에는 전체 카탈로그(~150종)를 LLM에 넘겼다가 **vLLM 문법 컴파일이 101초** 걸린 전례가 있습니다. 그래서:

- 도구 **8종** 상한 (목표 관련성 embedding 선별 — 에이전트 작업의 선별기 재사용)
- 도구 호출 **3회** 상한, 결과 본문 **8,000자** 캡
- 웹검색류 도구는 파이프라인이 이미 수행하므로 **제외**
- 모든 실패 경로(도구 선별 실패·LLM 실패·개별 도구 실패)는 빈 값 반환 — **리서치 본류를 막지 않음**
- `RESEARCH_CONTEXT` 로 전부 외부화, `RESEARCH_MCP_EVIDENCE=false` 로 opt-out

## 라이브 검증

| 주제 | 동작 | 판정 |
|---|---|---|
| "MCP 표준의 2026년 채택 사례" (공개 정보) | 도구 8종 선별 → **호출 없음**, 웹 소스만 사용 | ✅ 의도된 동작 |
| "내부 PostgreSQL agent_tasks 테이블 조회" | **`agent_task_list` 호출 → 4,411자 근거 확보** | ✅ |
| 스킬 주입 | `[DeepResearch] 스킬 지식 주입` 로그 확인 | ✅ |

첫 케이스가 중요합니다 — 웹으로 충분한 주제에는 도구를 부르지 않아 불필요한 지연·비용이 없습니다.

한 가지 짚어둘 점: **첫 시도에서는 내부 DB 주제에도 도구를 호출하지 않았습니다.** 선별된 도구가 로그에 없어 원인을 특정할 수 없었고, 도구명 로깅을 추가한 뒤 프롬프트를 "이 도구들은 웹으로 접근 불가한 내부 데이터 통로"라고 명시하도록 고쳐서 호출되기 시작했습니다. 관측이 없으면 진단이 막힌다는 교훈이 반영돼 있습니다.

## 테스트

신규 11개 (스킬 주입·게스트 skip·실패 graceful·도구 예산·mcp:// 변환·부분 실패 처리·짧은 결과 배제).
전체 **2,176개 통과**, `npm run lint` 0 errors, `tsc` 클린, 파일 크기 가드 통과.
ℹ️ 테스트 파일은 저장소 정책상 커밋되지 않습니다.

## 남은 갭

`load_skill` 자율 선택은 이번 범위에서 제외했습니다 — 리서치엔 도구 루프가 없어 도구 형태로는 붙일 수 없고, 매니페스트 주입으로 대체했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
