### PR TITLE
fix(providers): OAuth role 경로의 사용량 기록 누락

### DIFF
--- a/apps/api/src/providers/chatgpt-oauth/role-client.ts
+++ b/apps/api/src/providers/chatgpt-oauth/role-client.ts
@@ -21,7 +21,8 @@
  */
 import { LLMClient } from '../../llm';
 import type { ChatMessage, ToolDefinition, UsageMetrics } from '../../llm/types';
-import { checkUserQuota } from '../../llm/user-quota';
+import { checkUserQuota, recordUserUsage } from '../../llm/user-quota';
+import { getApiUsageTracker } from '../../llm/usage-tracker';
 import type { IProvider } from '../i-provider';
 import { ProviderError } from '../provider-errors';
 import { createLogger } from '../../utils/logger';
@@ -52,6 +53,12 @@ export interface ProviderRoleClientOptions {
     modelId: string;
     /** 토큰 쿼터 enforcement 대상 사용자 (미지정 시 skip) */
     userId?: string;
+    /**
+     * 사용량 관측 훅 — BYOK 비용 귀속(external_provider_usage)에 쓴다.
+     * API 키 provider 는 LLMClient 가 같은 훅을 호출하지만, 이 어댑터는 LLMClient
+     * 본체를 우회하므로 여기서 직접 발화해야 기록이 남는다(2026-07-26 누락 확인).
+     */
+    onUsage?: (u: { model: string; promptTokens: number; completionTokens: number }) => void;
 }
 
 /**
@@ -72,6 +79,7 @@ function getProviderRoleClientCtor(): new (opts: ProviderRoleClientOptions) => L
         private readonly provider: IProvider;
         private readonly modelId: string;
         private readonly quotaUserId?: string;
+        private readonly onUsage?: ProviderRoleClientOptions['onUsage'];
 
         constructor(opts: ProviderRoleClientOptions) {
             // base LLMClient 는 타입 정체성 유지를 위해서만 초기화한다 (호출 경로는 전부 override).
@@ -79,6 +87,7 @@ function getProviderRoleClientCtor(): new (opts: ProviderRoleClientOptions) => L
             this.provider = opts.provider;
             this.modelId = opts.modelId;
             if (opts.userId) this.quotaUserId = opts.userId;
+            if (opts.onUsage) this.onUsage = opts.onUsage;
         }
 
         /** timeout 등 파생은 provider 계층이 관리 — 동일 인스턴스를 그대로 돌려준다. */
@@ -95,6 +104,7 @@ function getProviderRoleClientCtor(): new (opts: ProviderRoleClientOptions) => L
             // 로컬 경로와 동일한 per-user 토큰 쿼터 규약 유지 (fail-open 은 내부 처리)
             await checkUserQuota(this.quotaUserId, Date.now());
 
+            const onUsage = this.onUsage;
             const tools: ToolDefinition[] | undefined = advancedOptions?.tools;
             try {
                 const result = await this.provider.streamChat(
@@ -112,6 +122,18 @@ function getProviderRoleClientCtor(): new (opts: ProviderRoleClientOptions) => L
                         onThinking: (thinking) => onToken?.('', thinking),
                     },
                 );
+
+                const promptTokens = result.usage?.prompt_tokens ?? 0;
+                const completionTokens = result.usage?.completion_tokens ?? 0;
+                const totalTokens = promptTokens + completionTokens;
+                if (totalTokens > 0) {
+                    // 로컬 경로(LLMClient)와 동일 규약 — 전역 관측 + per-user 누적 + BYOK 귀속
+                    getApiUsageTracker().record(totalTokens);
+                    void recordUserUsage(this.quotaUserId, totalTokens, Date.now());
+                    try {
+                        onUsage?.({ model: this.modelId, promptTokens, completionTokens });
+                    } catch { /* 관측 훅 실패는 호출 결과에 영향 없음 */ }
+                }
 
                 return {
                     role: 'assistant',

--- a/apps/api/src/services/model-role-resolver.ts
+++ b/apps/api/src/services/model-role-resolver.ts
@@ -184,7 +184,15 @@ async function tryBuildExternalResolution(
                 buildOAuthSessionPersist(externalKeysRepo, userId, providerId),
             );
             return {
-                client: createProviderRoleClient({ provider, modelId, userId }),
+                client: createProviderRoleClient({
+                    provider, modelId, userId,
+                    // BYOK 사용량 귀속 — API 키 provider(아래 createClient 분기)와 동일 규약.
+                    // 이 어댑터는 LLMClient 본체를 우회하므로 훅을 명시 전달해야 기록된다.
+                    onUsage: (u) => void externalKeysRepo.recordUsage({
+                        userId, providerId, modelId: u.model,
+                        inputTokens: u.promptTokens, outputTokens: u.completionTokens,
+                    }).catch(() => { /* 관측 실패 무시 */ }),
+                }),
                 role,
                 fullId,
                 providerId,


### PR DESCRIPTION
## 문제

역할(`agent`/`judge`/`spawn`/`review`/`research`)에 **ChatGPT(OAuth) 모델을 배정하면 호출이 `external_provider_usage` 에 전혀 남지 않아** BYOK 비용 집계에서 빠졌습니다.

**원인**: API 키 provider 는 `LLMClient` 본체가 `onUsage` 훅을 호출해 기록하는데, `ProviderRoleClient`(OAuth 어댑터, #369)는 **`LLMClient` 를 우회**하므로 훅이 발화되지 않았습니다.

같은 이유로 per-user 토큰 누적(`recordUserUsage`)도 빠져 있었습니다 — 쿼터를 **검사만 하고 적립하지 않는** 비대칭이었습니다.

## 📝 이전 보고 정정

전수 점검 때 *"딥리서치·에이전트 경로 전체에서 외부 사용량이 기록되지 않는다"* 고 보고드렸는데, **부정확했습니다.** 코드를 다시 확인하니 API 키 provider(openrouter/nvidia 등)는 `model-role-resolver` 가 `createClient({ onUsage })` 로 이미 기록하고 있었습니다. 실제 누락은 **OAuth 경로 하나**뿐입니다.

## 수정

- `ProviderRoleClient` 에 `onUsage` 옵션 추가하고, 전역 관측(`getApiUsageTracker`)·per-user 누적(`recordUserUsage`)까지 발화 — **API 키 경로(LLMClient)와 동일 규약**
- `model-role-resolver` OAuth 분기에서 `externalKeysRepo.recordUsage` 훅 전달 (API 키 분기와 같은 형태)
- 토큰이 0이면 미발화(빈 기록 방지), 훅 예외는 호출 결과에 영향 없음(관측 격리)

## 검증

**라이브** — 에이전트 작업 1건 실행 (agent 역할 = `chatgpt:gpt-5.5`, judge = `chatgpt:gpt-5.4-mini`)

| | 값 |
|---|---|
| 실행 전 기록 수 | 978 |
| 실행 후 | **981** (+3) |
| 기록 내용 | `chatgpt/gpt-5.5` 9,594+62 · `chatgpt/gpt-5.5` 9,681+6 · `chatgpt/gpt-5.4-mini` 312+125 |

agent 루프 2턴 + goal judge 1회가 정확히 기록됐습니다.

**유닛** — 신규 3개 (onUsage 발화, 토큰 0 미발화, 훅 예외 격리).
전체 **2,179개 통과**, `npm run lint` 0 errors, `tsc` 클린.
ℹ️ 테스트 파일은 저장소 정책상 커밋되지 않습니다.

## 남은 항목

점검 목록의 마지막 건 — **외부 모델 토큰 쿼터 미적용(채팅 경로)** 은 정책 결정이 필요해 별도로 남겨둡니다. 이번 수정으로 role 경로는 로컬과 동일하게 적립되지만, 채팅 경로(`external-provider`)는 여전히 `LLMClient` 를 우회해 쿼터를 타지 않습니다. BYOK 면제가 의도라면 코드에 명시하는 편이 좋겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
