### PR TITLE
feat(llm): 외부 BYOK provider 를 로컬 토큰 쿼터에서 명시 면제

### DIFF
--- a/apps/api/src/llm/client.ts
+++ b/apps/api/src/llm/client.ts
@@ -89,6 +89,8 @@ export class LLMClient {
     }
 
     private async checkQuota(): Promise<void> {
+        // 외부 BYOK provider 는 로컬 vLLM 용량을 쓰지 않으므로 쿼터 면제 (LLMConfig.quotaExempt 참고).
+        if (this.config.quotaExempt) return;
         // per-user enforcement (KVStore 기반, 멀티프로세스 정합). 전역 tracker 는
         // record 경로에서 관측(dashboard)용으로만 누적 — "한 사용자 소진 시 전체 차단" 버그 제거.
         // fail-open 은 checkUserQuota 내부 처리 (QuotaExceededError 만 throw).
@@ -181,8 +183,12 @@ export class LLMClient {
                 const totalTokens =
                     (result.metrics?.prompt_tokens ?? 0) + (result.metrics?.completion_tokens ?? 0);
                 if (totalTokens > 0) {
-                    getApiUsageTracker().record(totalTokens);  // 전역 aggregate (dashboard 관측용)
-                    void recordUserUsage(this.config.userId, totalTokens, Date.now());  // per-user enforcement 누적
+                    // 로컬 사용량 계정: 면제(외부 BYOK)면 로컬 대시보드·쿼터 버킷을 오염시키지
+                    // 않도록 건너뛴다. BYOK 귀속(onUsage)은 면제와 무관하게 항상 수행.
+                    if (!this.config.quotaExempt) {
+                        getApiUsageTracker().record(totalTokens);  // 전역 aggregate (dashboard 관측용)
+                        void recordUserUsage(this.config.userId, totalTokens, Date.now());  // per-user enforcement 누적
+                    }
                     try {
                         this.config.onUsage?.({
                             model: poolDecision.model,

--- a/apps/api/src/llm/types.ts
+++ b/apps/api/src/llm/types.ts
@@ -31,6 +31,19 @@ export interface LLMConfig {
      * 예외는 client 가 삼킨다 (관측 실패가 호출을 죽이지 않음).
      */
     onUsage?: (usage: { model: string; promptTokens: number; completionTokens: number }) => void;
+    /**
+     * 로컬 토큰 쿼터 면제 (외부 BYOK provider 전용).
+     *
+     * 정책(2026-07-26 결정): `LLM_HOURLY/WEEKLY_TOKEN_LIMIT` 는 **로컬 vLLM 용량을
+     * 보호하기 위한 것**이다. 외부 provider 는 사용자 본인 키·본인 과금으로 돌아가고
+     * 서버 GPU 를 쓰지 않으므로 쿼터 대상이 아니다. 면제 시 검사(checkUserQuota)와
+     * 로컬 누적(recordUserUsage·전역 tracker)을 모두 건너뛰되, **BYOK 비용 귀속
+     * (onUsage → external_provider_usage)은 그대로 수행**한다.
+     *
+     * 채팅 경로(chat-service/external-provider)는 애초에 LLMClient 를 우회하므로
+     * 이미 면제 상태이며, 이 플래그가 role 경로를 같은 정책으로 맞춘다.
+     */
+    quotaExempt?: boolean;
 }
 
 /**

--- a/apps/api/src/providers/chatgpt-oauth/role-client.ts
+++ b/apps/api/src/providers/chatgpt-oauth/role-client.ts
@@ -21,8 +21,6 @@
  */
 import { LLMClient } from '../../llm';
 import type { ChatMessage, ToolDefinition, UsageMetrics } from '../../llm/types';
-import { checkUserQuota, recordUserUsage } from '../../llm/user-quota';
-import { getApiUsageTracker } from '../../llm/usage-tracker';
 import type { IProvider } from '../i-provider';
 import { ProviderError } from '../provider-errors';
 import { createLogger } from '../../utils/logger';
@@ -101,9 +99,6 @@ function getProviderRoleClientCtor(): new (opts: ProviderRoleClientOptions) => L
             onToken?: (token: string, thinking?: string) => void,
             advancedOptions?: Parameters<LLMClient['chat']>[3],
         ): Promise<ChatMessage & { metrics?: UsageMetrics }> {
-            // 로컬 경로와 동일한 per-user 토큰 쿼터 규약 유지 (fail-open 은 내부 처리)
-            await checkUserQuota(this.quotaUserId, Date.now());
-
             const onUsage = this.onUsage;
             const tools: ToolDefinition[] | undefined = advancedOptions?.tools;
             try {
@@ -127,9 +122,8 @@ function getProviderRoleClientCtor(): new (opts: ProviderRoleClientOptions) => L
                 const completionTokens = result.usage?.completion_tokens ?? 0;
                 const totalTokens = promptTokens + completionTokens;
                 if (totalTokens > 0) {
-                    // 로컬 경로(LLMClient)와 동일 규약 — 전역 관측 + per-user 누적 + BYOK 귀속
-                    getApiUsageTracker().record(totalTokens);
-                    void recordUserUsage(this.quotaUserId, totalTokens, Date.now());
+                    // 외부 BYOK 는 로컬 토큰 쿼터 면제 (정책: LLMConfig.quotaExempt) —
+                    // 검사·로컬 누적은 하지 않고 BYOK 비용 귀속만 수행한다.
                     try {
                         onUsage?.({ model: this.modelId, promptTokens, completionTokens });
                     } catch { /* 관측 훅 실패는 호출 결과에 영향 없음 */ }

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -111,6 +111,12 @@ export async function runExternalStream(
         ...(req.images ? { images: req.images } : {}),
     });
 
+    // 토큰 쿼터 정책(2026-07-26 결정): 이 경로는 LLMClient 를 우회하므로 로컬 쿼터
+    // (LLM_HOURLY/WEEKLY_TOKEN_LIMIT)를 타지 않는다. **의도된 면제**다 — 그 한도는 로컬
+    // vLLM 용량 보호용이고 외부 provider 는 사용자 본인 키·과금으로 서버 GPU 를 쓰지 않는다.
+    // 비용 가시성은 external_provider_usage 기록(recordExternalUsageFireAndForget)이 담당.
+    // role 경로도 같은 정책으로 맞춰져 있다 (LLMConfig.quotaExempt).
+
     // capability 는 카탈로그 우선으로 해석한다 — provider.getCapabilities() 는 외부의 경우
     // 모델 ID 휴리스틱이라 실제 비전 모델을 vision:false 로 오판한다(실측).
     const { caps, source: capsSource } = await resolveModelCapabilities(

--- a/apps/api/src/services/model-role-resolver.ts
+++ b/apps/api/src/services/model-role-resolver.ts
@@ -208,6 +208,8 @@ async function tryBuildExternalResolution(
     return {
         client: createClient({
             baseUrl, apiKey: plaintextKey, model: modelId, userId,
+            // 외부 BYOK 는 로컬 vLLM 용량을 쓰지 않으므로 토큰 쿼터 면제 (정책: LLMConfig.quotaExempt)
+            quotaExempt: true,
             // BYOK 사용량 귀속 — 비용 대시보드(external_provider_usage) 반영 (fire-and-forget)
             onUsage: (u) => void externalKeysRepo.recordUsage({
                 userId, providerId, modelId: u.model,
@@ -259,6 +261,8 @@ async function tryBuildServerKeyResolution(
     return {
         client: createClient({
             baseUrl, apiKey: plaintextKey, model: modelId, userId,
+            // 외부 provider — 로컬 쿼터 면제 (서버 키 자체 상한은 recordServerKeyUsage 가 별도 관리)
+            quotaExempt: true,
             // 서버 키 사용량 귀속(운영자 비용 뷰) + 상한 카운터 누적
             onUsage: (u) => {
                 void serverKeysRepo.recordUsage({


### PR DESCRIPTION
## 문제

토큰 쿼터 적용이 **경로마다 제각각**이었고, 의도인지 결함인지 코드로 알 수 없었습니다.

| 경로 | 검사 | 로컬 누적 | BYOK 귀속 |
|---|---|---|---|
| 로컬 모델 | ✅ | ✅ | — |
| 외부 — role 경로 (API 키) | ✅ | ✅ | ✅ |
| 외부 — role 경로 (OAuth) | ✅ | ❌ | ✅ (#377) |
| 외부 — 채팅 경로 | ❌ | ❌ | ✅ |

특히 OAuth 경로는 **검사만 하고 적립하지 않아** 쿼터가 실제로는 누적되지 않는 비대칭이었습니다.

## 정책 결정 (2026-07-26)

**외부 provider 는 면제합니다.** `LLM_HOURLY/WEEKLY_TOKEN_LIMIT` 는 **로컬 vLLM 용량을 보호하기 위한 한도**이고, 외부는 사용자 본인 키·본인 과금으로 서버 GPU 를 전혀 쓰지 않기 때문입니다.

## 구현

- **`LLMConfig.quotaExempt` 도입** — 검사(`checkUserQuota`)와 로컬 누적(`recordUserUsage`·전역 tracker)을 건너뛰되 **BYOK 비용 귀속(`onUsage` → `external_provider_usage`)은 그대로 유지**
- `model-role-resolver` 의 외부 클라이언트 **2곳**(사용자 BYOK · 서버 공용 키)에 적용
- `ProviderRoleClient`(OAuth)도 같은 정책으로 정렬 — 검사·로컬 누적 제거, 귀속 유지
- 채팅 경로(`external-provider`)는 원래 우회 상태였는데, **"의도된 면제"임을 주석으로 명시**

핵심은 면제와 **비용 가시성을 분리**한 것입니다. 쿼터는 면제하되 누가 얼마나 썼는지는 계속 기록되므로, BYOK 비용 대시보드는 그대로 동작합니다. 또 로컬 대시보드·쿼터 버킷에 외부 토큰이 섞여 들어가 수치를 왜곡하던 것도 함께 해소됩니다.

## 결과

| 경로 | 검사 | 로컬 누적 | BYOK 귀속 |
|---|---|---|---|
| 로컬 모델 | ✅ | ✅ | — |
| 외부 (role · 채팅 · OAuth 전부) | ❌ 면제 | ❌ 면제 | ✅ |

세 경로가 한 정책을 따르고, 근거가 코드에 남습니다.

## 검증

**라이브** (배포본)
- 외부 채팅 `'오슬로'` · 로컬 채팅 `'헬싱키'` — 양쪽 정상
- 에이전트 작업 1건 → ChatGPT 호출 3건이 `external_provider_usage` 에 기록 (984 → 989, 로컬 1건 포함)

**유닛** — 신규 1개(쿼터 모듈 미호출 검증) 포함 chatgpt 스위트 33개.
전체 **2,180개 통과**, `npm run lint` 0 errors, `tsc` 클린.
ℹ️ 테스트 파일은 저장소 정책상 커밋되지 않습니다.

## 마무리

이로써 2026-07-26 전수 점검에서 나온 항목이 **전부 해소**되었습니다 (비전 오차단 · 채팅 폴백 · 모델 필터 · 폴백 고지 · 딥리서치 도구/스킬 · 사용량 기록 · 쿼터 정책).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
