### PR TITLE
fix(desktop): 자동 업데이트 교체 로직 3가지 결함 수정 (v1.5.0)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmake-desktop",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "description": "OpenMake LLM 데스크톱 셸 (macOS) — 운영 백엔드(외부 공개 도메인 / 로컬)를 네이티브 창으로",
   "author": "OpenMake Team",

--- a/apps/desktop/updater.js
+++ b/apps/desktop/updater.js
@@ -53,19 +53,105 @@ async function downloadTo(url, dest) {
   return crypto.createHash('sha256').update(buf).digest('hex');
 }
 
-/** 교체 스크립트 — 앱 종료 후 dmg 마운트 → /Applications 교체 → 격리 해제 → 재실행. */
-function spawnReplaceScript(dmgPath) {
+/**
+ * 현재 실행 중인 .app 번들 경로를 해석한다.
+ *
+ * 교체 대상을 `/Applications` 로 하드코딩하면 `~/Applications` 등 다른 위치에 설치한
+ * 사용자에게서 조용히 어긋난다 — 교체는 엉뚱한 곳에 이뤄지고 원래 앱은 구버전으로
+ * 남으며, 재실행 대상이 없어 앱이 다시 열리지 않는다. 실제 위치를 쓴다.
+ *
+ * @returns {string|null} .app 번들 절대경로 (패키징되지 않은 실행이면 null)
+ */
+function resolveAppBundlePath() {
+  // /path/to/OpenMake.app/Contents/MacOS/OpenMake → /path/to/OpenMake.app
+  const m = /^(.*\.app)\/Contents\/MacOS\/[^/]+$/.exec(process.execPath);
+  return m ? m[1] : null;
+}
+
+/**
+ * 교체 가능 여부를 사전 점검한다. 앱을 종료한 뒤에는 사용자에게 알릴 수단이 없으므로
+ * **종료 전에** 실패 조건을 걸러낸다.
+ *
+ * @returns {{ ok: true, appPath: string } | { ok: false, reason: string }}
+ */
+function checkReplaceable() {
+  const appPath = resolveAppBundlePath();
+  if (!appPath) {
+    return { ok: false, reason: '패키징된 앱에서만 업데이트할 수 있습니다(개발 실행 중).' };
+  }
+  // dmg/외장 볼륨에서 바로 실행 중이면 교체해도 유실된다 — 설치 후 재시도하도록 안내.
+  if (appPath.startsWith('/Volumes/')) {
+    return {
+      ok: false,
+      reason: '디스크 이미지에서 실행 중입니다. 앱을 응용 프로그램 폴더로 옮긴 뒤 다시 시도하세요.',
+    };
+  }
+  const parent = path.dirname(appPath);
+  try {
+    fs.accessSync(parent, fs.constants.W_OK);
+  } catch {
+    return {
+      ok: false,
+      reason: `설치 폴더에 쓸 권한이 없습니다: ${parent}\n관리자 계정으로 실행하거나, 앱을 사용자 폴더(~/Applications)로 옮긴 뒤 다시 시도하세요.`,
+    };
+  }
+  return { ok: true, appPath };
+}
+
+/**
+ * 교체 스크립트 — 앱 종료 후 dmg 마운트 → 실제 설치 경로 교체 → 격리 해제 → 재실행.
+ *
+ * 실패해도 사용자가 알 수 있어야 한다(기존에는 stdio 무시 + 오류 처리 없음이라
+ * "앱이 종료됐는데 안 돌아온다" 로만 보였다):
+ *   - 각 단계 실패 시 osascript 로 네이티브 경고를 띄우고 **원래 앱을 다시 연다**
+ *   - 전 과정 로그를 파일로 남겨 사후 진단이 가능하게 한다
+ */
+function spawnReplaceScript(dmgPath, appPath) {
+  const logPath = path.join(os.tmpdir(), `openmake-update-${Date.now()}.log`);
   const script = `#!/bin/bash
+exec >>"${logPath}" 2>&1
+set -u
+APP="${appPath}"
+DMG="${dmgPath}"
+
+fail() {
+  echo "FAIL: $1"
+  # 앱이 이미 종료된 뒤라 Electron 다이얼로그를 쓸 수 없다 — 네이티브 경고로 알린다.
+  /usr/bin/osascript -e "display alert \\"업데이트 실패\\" message \\"$1\\n\\n로그: ${logPath}\\" as critical" || true
+  [ -d "$APP" ] && open -a "$APP" || true
+  rm -f "$DMG"
+  exit 1
+}
+
 sleep 2
-MNT=$(hdiutil attach -nobrowse "${dmgPath}" | tail -1 | awk '{print $NF}')
-if [ -d "$MNT/OpenMake.app" ]; then
-  rm -rf /Applications/OpenMake.app
-  ditto "$MNT/OpenMake.app" /Applications/OpenMake.app
-  xattr -dr com.apple.quarantine /Applications/OpenMake.app 2>/dev/null
+# 마운트 경로 파싱: hdiutil 출력은 탭 구분이고 볼륨명에 공백이 있을 수 있다.
+# 마지막 필드만 자르면(awk '{print $NF}') 공백에서 끊기므로 /Volumes 이후 전체를 취한다.
+MNT=$(hdiutil attach -nobrowse "$DMG" | grep -o '/Volumes/.*' | tail -1)
+[ -n "$MNT" ] || fail "디스크 이미지를 마운트하지 못했습니다."
+[ -d "$MNT/OpenMake.app" ] || { hdiutil detach "$MNT" -quiet; fail "이미지 안에서 앱을 찾지 못했습니다."; }
+
+# 교체는 임시 이름으로 먼저 복사한 뒤 스왑 — 도중 실패해도 기존 앱이 남는다.
+STAGE="$APP.new"
+rm -rf "$STAGE"
+if ! ditto "$MNT/OpenMake.app" "$STAGE"; then
+  rm -rf "$STAGE"; hdiutil detach "$MNT" -quiet
+  fail "새 버전 복사에 실패했습니다(설치 폴더 권한을 확인하세요)."
 fi
 hdiutil detach "$MNT" -quiet
-rm -f "${dmgPath}"
-open -a /Applications/OpenMake.app
+
+BACKUP="$APP.old"
+rm -rf "$BACKUP"
+mv "$APP" "$BACKUP" || { rm -rf "$STAGE"; fail "기존 앱을 교체할 수 없습니다."; }
+if ! mv "$STAGE" "$APP"; then
+  mv "$BACKUP" "$APP" 2>/dev/null   # 롤백
+  fail "새 버전 설치에 실패해 이전 버전으로 되돌렸습니다."
+fi
+rm -rf "$BACKUP"
+
+xattr -dr com.apple.quarantine "$APP" 2>/dev/null
+rm -f "$DMG"
+open -a "$APP" || fail "업데이트는 됐지만 앱을 다시 열지 못했습니다."
+echo "OK: updated $APP"
 rm -f "$0"
 `;
   const sh = path.join(os.tmpdir(), `openmake-update-${Date.now()}.sh`);
@@ -105,13 +191,18 @@ async function checkForUpdate(backendUrl, win, interactive) {
     });
     if (choice !== 0) return;
 
+    // 교체 가능 여부를 **다운로드 전에** 확인한다 — 앱을 종료한 뒤에는 알릴 수단이 없고,
+    // 못 고칠 조건(권한·dmg 실행 등)이면 100MB 를 받는 것 자체가 낭비다.
+    const pre = checkReplaceable();
+    if (!pre.ok) throw new Error(pre.reason);
+
     const dmgPath = path.join(os.tmpdir(), m.file);
     const sha = await downloadTo(`${backendUrl}${m.url}`, dmgPath);
     if (sha.toLowerCase() !== String(m.sha256).toLowerCase()) {
       fs.rmSync(dmgPath, { force: true });
       throw new Error('다운로드 무결성 검증 실패(sha256 불일치)');
     }
-    spawnReplaceScript(dmgPath);
+    spawnReplaceScript(dmgPath, pre.appPath);
     app.quit();
   } catch (e) {
     if (interactive) {


### PR DESCRIPTION
## 배경

"다른 Mac 에서 데스크톱 앱 설치 후 자동 업데이트 오류" 보고로 점검했습니다.

**서버 측은 정상이었습니다** — 매니페스트(`/api/desktop/latest`), dmg 다운로드(외부 도메인 100MB), sha256 무결성 모두 확인했고, 배포본 1.0.0/1.2.1/1.4.0 전부 백엔드 URL이 `chat.openmake.cc` 로 올바릅니다.

문제는 **클라이언트 교체 스크립트**에 있었고, 전부 **환경 의존적**이라 개발 Mac(`/Applications` + 관리자 권한)에서는 우연히 동작했습니다.

## ① 설치 경로 하드코딩

```bash
rm -rf /Applications/OpenMake.app
ditto "$MNT/OpenMake.app" /Applications/OpenMake.app
open -a /Applications/OpenMake.app
```

`~/Applications` 등 다른 위치에 설치했다면 교체가 **엉뚱한 곳**에 이뤄지고, 원래 앱은 구버전으로 남으며, 재실행 대상이 없어 **앱이 다시 열리지 않습니다.**

→ `process.execPath` 로 실제 번들 경로를 해석해 사용합니다.

## ② 실패가 전혀 표면화되지 않음

스크립트를 `stdio: 'ignore'` 로 분리 실행하고 오류 처리가 없어, `ditto` 가 권한으로 실패해도 그대로 진행했습니다. 사용자에겐 **"앱이 종료됐는데 안 돌아온다"** 로만 보입니다.

- **종료 전** 사전 점검(`checkReplaceable`) — 미패키징 실행 · dmg 에서 직접 실행 · 설치 폴더 쓰기 권한 없음이면 **다운로드 전에** 사유를 다이얼로그로 안내 (100MB 낭비도 방지)
- **종료 후** 실패는 `osascript` 네이티브 경고 + **원래 앱 재실행** + 로그 파일 보존
- 교체를 **stage → swap** 방식으로 바꿔, 도중 실패 시 이전 버전으로 **롤백**

## ③ 마운트 경로 파싱 취약

`hdiutil attach | tail -1 | awk '{print $NF}'` 는 볼륨명에 공백이 있으면 끊깁니다. 실제로 시험해 확인했습니다:

```
볼륨 "OpenMake Test Vol"
  기존 파싱 → 'Vol'                      ❌ 경로 깨짐 → 교체 무산
  수정 파싱 → '/Volumes/OpenMake Test Vol'  ✅
```

현재 볼륨명이 `OpenMake`(공백 없음)라 잠복해 있던 결함입니다.

## 검증

- 생성되는 셸 스크립트를 추출해 `bash -n` 통과, **공백 포함 경로** 보간 확인
- 마운트 파싱 구/신 **실측 비교** (위 표)
- 사전 점검 4개 케이스 확인 — `/Applications` 정상 · 사용자 폴더 정상 · dmg 직접 실행 차단 · 미패키징 차단
- `npm run lint` 0 errors

## 남은 확인 사항 (사용자 회신 대기)

원인 확정에는 그쪽 Mac 정보가 필요합니다 — 오류 메시지 전문, 설치 위치, 칩셋(Apple Silicon/Intel), 설치 버전. 특히 **Intel Mac 이라면 별개 문제**입니다: 빌드 설정에 arch 지정이 없어 빌드 머신(arm64) 기준으로만 dmg 가 나오므로 Intel 에서는 앱 자체가 실행되지 않습니다. 그 경우 universal 빌드가 필요하며, 이번 PR 범위 밖입니다.

## 배포 방법

이 수정은 **새 버전(1.5.0)을 설치해야 적용**됩니다 — 구버전에 들어있는 옛 업데이터가 교체를 수행하기 때문입니다. 머지 후 `scripts/publish-desktop.sh` 로 1.5.0 dmg 를 게시하면, 1.2.1 이상 사용자는 기존 업데이터로 받게 되고 그 이후부터 개선된 로직이 동작합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
