### PR TITLE
feat(agent-task): 하위 폴더 인지 개선 + 데스크톱 연결 폴더 가시화

### DIFF
--- a/apps/api/src/services/task-sandbox/sandbox.ts
+++ b/apps/api/src/services/task-sandbox/sandbox.ts
@@ -321,7 +321,10 @@ export class TaskSandbox implements TaskExecutor {
     /** workspace 내 디렉토리 목록. 경로 가드(어휘+실경로) 적용. */
     async listDir(relPath = '.'): Promise<string[]> {
         const abs = await safeRealWorkspacePath(this.hostWorkdir, relPath);
-        return readdir(abs);
+        // 디렉토리는 이름 뒤에 '/' — 이름만 주면 모델이 폴더를 파일로 오인해 read 하다
+        // EISDIR 로 실패하고 하위 파일에 영영 못 닿는다(2026-07-26 보고).
+        const entries = await readdir(abs, { withFileTypes: true });
+        return entries.map((e) => (e.isDirectory() ? `${e.name}/` : e.name));
     }
 
     /** 산출물 회수용 — workspace 전체 파일을 상대경로로 재귀 나열. */

--- a/apps/api/src/services/task-sandbox/tools.ts
+++ b/apps/api/src/services/task-sandbox/tools.ts
@@ -27,6 +27,10 @@ export type { SpawnFn } from '../agent-spawn/spawn-agents';
 
 /** 루프가 인식하는 제어 시그널 sentinel (도구 결과 텍스트 prefix). */
 export const TASK_TERMINATE_SENTINEL = '__TASK_TERMINATE__';
+
+/** file_ops tree 상한 — 실행기(walk/listWorkspaceFilesAt)의 1000개 캡과 일치시킨다. */
+const FILE_TREE_MAX = 1000;
+
 export const TASK_ASK_HUMAN_SENTINEL = '__TASK_ASK_HUMAN__';
 
 function textResult(text: string, isError = false): MCPToolResult {
@@ -191,12 +195,15 @@ export function createTaskTools(
     const fileOps: MCPToolDefinition = {
         tool: {
             name: 'file_ops',
-            description: '/workspace 파일 작업: op=read | write | list | delete.',
+            description:
+                '/workspace 파일 작업: op=read | write | list | tree | delete. '
+                + 'list 는 해당 디렉토리만 보여주며 폴더는 이름 뒤에 "/" 가 붙는다. '
+                + '하위 폴더까지 한 번에 보려면 tree 를 쓴다.',
             inputSchema: {
                 type: 'object',
                 properties: {
-                    op: { type: 'string', description: 'read | write | list | delete' },
-                    path: { type: 'string', description: 'workspace 상대 경로 (list 는 기본 ".")' },
+                    op: { type: 'string', description: 'read | write | list | tree | delete' },
+                    path: { type: 'string', description: 'workspace 상대 경로 (list 는 기본 ".", tree 는 무시)' },
                     content: { type: 'string', description: 'write 시 내용' },
                 },
                 required: ['op'],
@@ -209,6 +216,16 @@ export function createTaskTools(
                 if (op === 'read') return textResult(await sandbox.readFile(path));
                 if (op === 'write') { await sandbox.writeFile(path, str(args.content)); return textResult(`기록됨: ${path}`); }
                 if (op === 'list') return textResult((await sandbox.listDir(path || '.')).join('\n') || '(빈 디렉토리)');
+                if (op === 'tree') {
+                    // 하위 폴더 포함 전체 목록 — list 로 한 단계씩 파고들다 폴더를 놓치는
+                    // 문제를 한 번에 해소한다. 상한(1000)에 걸리면 잘렸음을 명시한다.
+                    const all = await sandbox.listWorkspaceFiles();
+                    if (all.length === 0) return textResult('(빈 workspace)');
+                    const capped = all.length >= FILE_TREE_MAX
+                        ? `\n… 목록이 ${FILE_TREE_MAX}개에서 잘렸습니다. 하위 경로를 list 로 좁혀 확인하세요.`
+                        : '';
+                    return textResult(all.join('\n') + capped);
+                }
                 if (op === 'delete') { await sandbox.deleteFile(path); return textResult(`삭제됨: ${path}`); }
                 return textResult(`알 수 없는 op: ${op}`, true);
             } catch (e) {

--- a/apps/desktop/bridge.js
+++ b/apps/desktop/bridge.js
@@ -179,7 +179,14 @@ async function handleExec(m, done) {
       fs.writeFileSync(abs, Buffer.from(m.contentB64 || '', 'base64'));
       done({ ok: true }); return;
     }
-    case 'list': done({ ok: true, entries: fs.readdirSync(safe(m.path)) }); return;
+    case 'list': {
+      // 디렉토리는 '/' 접미사 — 모델이 폴더를 파일로 오인해 read 하다 EISDIR 로
+      // 실패하고 하위 파일에 못 닿는 문제 방지 (샌드박스 실행기와 동일 규약).
+      const entries = fs.readdirSync(safe(m.path), { withFileTypes: true })
+        .map((e) => (e.isDirectory() ? `${e.name}/` : e.name));
+      done({ ok: true, entries });
+      return;
+    }
     case 'listAll': done({ ok: true, entries: walk(folderRoot, folderRoot, []) }); return;
     case 'delete': {
       const abs = safe(m.path);
@@ -283,6 +290,12 @@ module.exports = {
   disconnectFolder,
   getStatus: () => statusText,
   isConnected: () => !!folderRoot,
+  /**
+   * 연결된 작업 폴더의 **전체 경로**. 어느 폴더에 붙었는지 사용자가 확인할 수단이
+   * 없어(서버에는 basename 만 전달) 같은 이름 폴더를 구분할 수 없던 문제 해소용.
+   * 개인정보(사용자명 등)가 포함되므로 **로컬 UI 표시에만** 쓰고 서버로 보내지 않는다.
+   */
+  getFolderPath: () => folderRoot,
   setOnStatusChange: (fn) => { onStatusChange = fn; },
   /** 백엔드 전환 시 재연결 */
   onBackendChanged: (app, backendUrl) => { if (folderRoot) connect(app, backendUrl); },

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -119,8 +119,16 @@ function buildMenu() {
       label: '로컬 작업',
       submenu: [
         { label: `상태: ${bridge.getStatus()}`, enabled: false },
+        // 연결 폴더 전체 경로 — 서버에는 basename 만 가므로 같은 이름 폴더를 구분할
+        // 방법이 없었다. 경로는 로컬 메뉴에만 노출한다(개인정보 서버 전송 없음).
+        { label: `폴더: ${bridge.getFolderPath() || '(미연결)'}`, enabled: false },
         { type: 'separator' },
         { label: '작업 폴더 연결…', click: () => bridge.connectFolder(app, bridgeBackendUrl(), win) },
+        {
+          label: 'Finder 에서 열기',
+          enabled: bridge.isConnected(),
+          click: () => { const f = bridge.getFolderPath(); if (f) shell.openPath(f); },
+        },
         { label: '연결 해제', enabled: bridge.isConnected(), click: () => bridge.disconnectFolder() },
       ],
     },


### PR DESCRIPTION
사용자 보고 2건에 대응합니다.

## ① 하위 폴더가 있으면 관련 파일을 못 읽음

`file_ops` 의 `list` 가 **이름만** 반환했습니다 (`fs.readdirSync(path)` — 디렉토리 표시 없음). 그래서 모델이 이런 흐름으로 막혔습니다:

1. `list` → `["docs", "report.xlsx", "images"]` — 뭐가 폴더인지 알 수 없음
2. `docs` 를 파일로 오인 → `read` 시도 → **EISDIR 실패**
3. 하위 폴더 안 파일에 영영 닿지 못함

재귀 목록(`listWorkspaceFiles`)은 실행기에 **이미 있었지만 도구로 노출되지 않았습니다.**

**수정**
- `list`: 디렉토리에 `/` 접미사 — **Docker 샌드박스와 로컬 브리지 양쪽** 동일 규약 (실행기별로 다르면 더 헷갈립니다)
- `file_ops` 에 **`op=tree`** 추가 — 하위 폴더 포함 재귀 목록
- 1000개 상한에 걸리면 **잘렸음을 명시** (조용한 truncation 금지)
- **도구 설명에 두 규약을 안내** — 모델이 알아야 실제로 씁니다

## ② 어느 폴더에 연결됐는지 알 수 없음

서버로는 `basename` 만 전달되고(개인정보 최소화 의도), 데스크톱 메뉴에도 `상태: 연결됨` 만 있어 **같은 이름 폴더를 구분할 수 없었습니다.**

**수정** — 데스크톱 메뉴에 추가:
```
로컬 작업
  상태: 연결됨
  폴더: /Users/me/projects/openmake     ← 추가
  ─────
  작업 폴더 연결…
  Finder 에서 열기                      ← 추가
  연결 해제
```

전체 경로는 사용자명 등 개인정보를 포함하므로 **로컬 UI 에만 노출하고 서버로는 보내지 않습니다.**

## 검증

**라이브** — 에이전트 작업으로 `docs/sub/` 구조를 만들고 `tree` 로 조회:
```
docs/guide.md
docs/sub/deep.txt
```
하위 폴더 파일까지 정확히 보고했습니다.

**실증** — `list`/`tree` 동작 직접 확인:
```
list(".") → docs/  images/  root.txt          ← 폴더 구분됨
tree      → docs/guide.md  docs/sub/deep.txt  images/logo.png  root.txt
```

**유닛** — 신규 5개(폴더 표기 전달·tree 재귀·빈 workspace·상한 명시·도구 설명 규약).
전체 **2,185개 통과**, `npm run lint` 0 errors, `tsc` 클린.

ℹ️ 전체 실행에서 `circuit-breaker` 스위트가 한 번 실패했으나 단독 실행 시 34개 전부 통과하고 재실행에서도 통과했습니다 — 타이밍 의존 flaky 이며 이번 변경과 무관합니다(파일 목록만 건드림).

## 적용 범위

① 은 서버 변경이라 **배포 즉시 적용**됩니다. ② 는 데스크톱 앱 코드라 **다음 버전(1.6.0) 빌드·게시가 필요**합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
