### PR TITLE
chore(desktop): v1.6.0 — 연결 폴더 가시화 반영 버전 bump

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmake-desktop",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "description": "OpenMake LLM 데스크톱 셸 (macOS) — 운영 백엔드(외부 공개 도메인 / 로컬)를 네이티브 창으로",
   "author": "OpenMake Team",


### PR DESCRIPTION
## 배경

#382 의 데스크톱 변경은 **앱 번들에 들어가야** 사용자에게 닿는다 (서버 배포로는 안 됨):

- 메뉴에 연결된 작업 폴더 **전체 경로** 표시 + **Finder 에서 열기**
- 로컬 브리지 `list` 의 디렉토리 `/` 접미사 (Docker 샌드박스와 동일 규약)

자체 업데이터가 새 버전을 인지하도록 `apps/desktop/package.json` 버전만 1.5.0 → 1.6.0 으로 올린다.

## 게시 완료

| 항목 | 값 |
|---|---|
| 파일 | `OpenMake-1.6.0-arm64.dmg` |
| sha256 | `11d95b1e4a5406e02b99c88fb8412ebf430ebf5c61be10ff4ce5fb71f903cee4` |

검증:
- `GET /api/desktop/latest` → v1.6.0 (로컬 :52416, 외부 chat.openmake.cc 양쪽)
- 다운로드 바이트 sha256 = 매니페스트 sha256 일치
- 빌드된 `app.asar` 에 신규 코드 포함 확인 (`getFolderPath`, `Finder 에서 열기`, `isDirectory ? name + '/'`)

## 참고 — arm64 전용

기존 배포와 동일하게 arm64 dmg 만 게시한다. Intel Mac 사용자가 있다면 universal 빌드가 별도로 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)