### PR TITLE
fix(agent-task): 잘못 놓인 요청 옵션을 조용히 버리지 않고 거절

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -862,6 +862,9 @@ AGENT_TASK_TIMEOUT_MS=600000
 # AGENT_TASK_STEERING_MAX_CHARS=2000                   # 지시 1건 최대 글자 수
 # AGENT_TASK_STEERING_MAX_PENDING=10                   # task 당 미소비 지시 대기 상한(초과 429)
 
+# Agent Task — POST /:taskId/execute 의 allowedSkills 배열 상한(초과 시 400).
+# AGENT_TASK_EXECUTE_MAX_ALLOWED_SKILLS=50
+
 # 채팅 서브에이전트 — 채팅 도구 루프에 delegate_expert(전문가 위임 depth=1 tool-loop) 노출. 기본 OFF.
 # 위임 1회 = 서브 LLM 최대 3턴이라 응답 지연 증가 — 발동률·지연 관찰 후 조정 권장.
 # CHAT_SUBAGENT_ENABLED=true

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1262,6 +1262,8 @@ export const AGENT_TASK_LIMITS = {
     STEERING_MAX_CHARS: parseInt(process.env.AGENT_TASK_STEERING_MAX_CHARS || '2000', 10),
     /** task 당 미소비 steering 대기 상한 — 초과 시 429(플러딩 방지). AGENT_TASK_STEERING_MAX_PENDING(기본 10). */
     STEERING_MAX_PENDING: parseInt(process.env.AGENT_TASK_STEERING_MAX_PENDING || '10', 10),
+    /** execute 의 allowedSkills 배열 상한 — 초과 시 400(잘라내지 않는다). AGENT_TASK_EXECUTE_MAX_ALLOWED_SKILLS(기본 50). */
+    EXECUTE_MAX_ALLOWED_SKILLS: parseInt(process.env.AGENT_TASK_EXECUTE_MAX_ALLOWED_SKILLS || '50', 10),
 } as const;
 
 /** 채팅 서브에이전트(delegate_expert) — 채팅 도구 루프에서 전문가 위임(depth=1 tool-loop). */

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -23,7 +23,7 @@ import { success, badRequest, notFound } from '../utils/api-response';
 import { asyncHandler } from '../utils/error-handler';
 import { requireAuth } from '../auth';
 import { assertResourceOwnerOrAdmin } from '../auth/ownership';
-import { validateWithSecurity } from '../middlewares/validation';
+import { validate, validateWithSecurity } from '../middlewares/validation';
 import { getUnifiedDatabase } from '../data/models/unified-database';
 import { LOCAL_BRIDGE } from '../config/local-bridge';
 import { getLocalBridgeRegistry } from '../services/local-bridge/registry';
@@ -31,7 +31,10 @@ import { v4 as uuidv4 } from 'uuid';
 import { AgentTaskService, type AgentTaskInputFile } from '../services/AgentTaskService';
 import type { ChatMessage } from '../llm/types';
 import { AGENT_TASK_LIMITS } from '../config/runtime-limits';
-import { createAgentTaskSchema, type CreateAgentTaskInput } from '../schemas/agent-task.schema';
+import {
+    createAgentTaskSchema, executeAgentTaskSchema,
+    type CreateAgentTaskInput, type ExecuteAgentTaskInput,
+} from '../schemas/agent-task.schema';
 import { extractAttachedDocuments } from '../services/chat-service/doc-extractor';
 import { getApprovalRegistry } from '../services/task-sandbox/approval-gate';
 import { getSteeringRegistry } from '../services/agent-task/steering';
@@ -285,7 +288,7 @@ router.get('/:taskId/steps', asyncHandler(async (req: Request, res: Response) =>
  * POST /api/agent-tasks/:taskId/execute
  * 비동기 실행 (HTTP 202) — detached 백그라운드. 연결과 무관하게 진행.
  */
-router.post('/:taskId/execute', asyncHandler(async (req: Request, res: Response) => {
+router.post('/:taskId/execute', validate(executeAgentTaskSchema), asyncHandler(async (req: Request, res: Response) => {
     const task = await loadOwnedTask(req, res, req.params.taskId);
     if (!task) return;
 
@@ -300,17 +303,9 @@ router.post('/:taskId/execute', asyncHandler(async (req: Request, res: Response)
 
     const role: UserRole = (req.user!.role as UserRole) || 'user';
 
-    // 스킬 범위(allowedSkills): 이 실행에서 쓸 skill_id 목록 — 옵션. 문자열 배열만 수용,
-    // 최대 50개로 캡. 미지정이면 전체 활성 스킬 사용(기존 동작).
-    const rawSkills = (req.body as { allowedSkills?: unknown })?.allowedSkills;
-    const allowedSkills = Array.isArray(rawSkills)
-        ? rawSkills.filter((s): s is string => typeof s === 'string' && s.length > 0 && s.length <= 200).slice(0, 50)
-        : undefined;
-
-    // 승인 3모드(Manual/Auto/Skip) — 이 실행에만 적용할 승인 정책(옵션). 유효 enum 만 수용.
-    const rawPolicy = (req.body as { approvalPolicy?: unknown })?.approvalPolicy;
-    const approvalPolicy = rawPolicy === 'all' || rawPolicy === 'high-risk' || rawPolicy === 'none'
-        ? rawPolicy : undefined;
+    // 스킬 범위(allowedSkills, 미지정이면 전체 활성 스킬)와 승인 3모드(Manual/Auto/Skip)는
+    // executeAgentTaskSchema 가 검증한다 — 잘못된 값은 여기 오기 전에 400 이다.
+    const { allowedSkills, approvalPolicy } = req.body as ExecuteAgentTaskInput;
 
     // 백그라운드 detached 실행 (응답은 즉시 반환). AgentTaskService 가 자체
     // AbortController 를 소유하므로 ws.close 와 무관하게 끝까지 진행한다.

--- a/apps/api/src/schemas/agent-task.schema.ts
+++ b/apps/api/src/schemas/agent-task.schema.ts
@@ -29,12 +29,17 @@ const taskInputFileSchema = z.object({
 
 /**
  * 에이전트 작업 생성 스키마
+ *
+ * strict — 미선언 키는 strip 이 아니라 400 으로 거절한다. 조용한 strip 은 오타(`maxTurn`)나
+ * 잘못된 위치의 옵션(`approvalPolicy`)을 "요청은 200 인데 설정만 안 먹는" 형태로 감춰서,
+ * 증상만 보고는 원인을 알 수 없다.
+ *
  * @property {string} goal - 작업 목표 (1~2000자, 필수)
  * @property {number} [maxTurns] - 최대 도구 루프 턴 수 (1~상한, 기본값: DEFAULT_MAX_TURNS)
  * @property {Array} [files] - 입력 첨부 파일 (채팅 첨부와 동일 캡)
  * @property {Array} [images] - 입력 첨부 이미지 dataURL (vision 채널 전달)
  */
-export const createAgentTaskSchema = z.object({
+export const createAgentTaskSchema = z.strictObject({
     goal: secureTextSchema({ minLength: 1, maxLength: 2000, fieldName: 'goal', detectMaliciousPatterns: false }),
     maxTurns: z.number().int().min(1).max(AGENT_TASK_LIMITS.MAX_TURNS_CEILING).optional(),
     // Cowork D1a: 실행 백엔드 — 'local' 은 LOCAL_EXECUTOR_ENABLED + 디바이스 연결 필요(라우트가 검증).
@@ -47,6 +52,12 @@ export const createAgentTaskSchema = z.object({
     // 엄격한 형식 검증은 서버 parseGithubRepo 가 수행 — 여기선 prefix·길이·안전문자만.
     repoUrl: z.string().startsWith('https://github.com/').max(300).optional(),
     branch: z.string().max(200).regex(/^[A-Za-z0-9._/-]+$/).optional(),
+    // 승인 정책은 **실행 단위** 옵션이라 생성이 아니라 execute 에 넘긴다. 여기 실리면
+    // 조용히 버려져(비-strict 객체는 미선언 키를 strip) "정책을 none 으로 줬는데 첫 도구에서
+    // 승인 대기" 로만 보인다 — 원인이 드러나지 않으므로 명시적으로 거절한다.
+    approvalPolicy: z.never({
+        error: '승인 정책은 생성이 아니라 POST /api/agent-tasks/:taskId/execute 에 전달하세요',
+    }).optional(),
 });
 
 /** 에이전트 작업 생성 요청 TypeScript 타입 */
@@ -55,9 +66,14 @@ export type CreateAgentTaskInput = z.infer<typeof createAgentTaskSchema>;
 /**
  * 에이전트 작업 실행(execute) 요청 스키마 — 승인 3모드(Manual/Auto/Skip)를 이 실행에 한해 지정.
  * all=Manual(전부 승인·기본), high-risk=Auto(고위험만), none=Skip(전부 자동). 미지정 시 전역 정책.
+ *
+ * 생성 스키마와 같은 이유로 strict. allowedSkills 도 여기 선언해야 한다 — 라우트가 body 에서
+ * 직접 읽으므로 스키마에서 빠지면 미들웨어가 검증된 body 로 치환할 때 통째로 사라진다.
  */
-export const executeAgentTaskSchema = z.object({
+export const executeAgentTaskSchema = z.strictObject({
     approvalPolicy: z.enum(['all', 'high-risk', 'none']).optional(),
+    /** 이 실행에서 쓸 skill_id 목록 — 미지정이면 전체 활성 스킬. */
+    allowedSkills: z.array(z.string().min(1).max(200)).max(AGENT_TASK_LIMITS.EXECUTE_MAX_ALLOWED_SKILLS).optional(),
 });
 export type ExecuteAgentTaskInput = z.infer<typeof executeAgentTaskSchema>;
 


### PR DESCRIPTION
## 문제

`approvalPolicy` 를 작업 생성(`POST /api/agent-tasks`)에 실어 보내면 **아무 일도 일어나지 않는다**. 생성 스키마가 비-strict 객체라 미선언 키를 strip 하고, 요청은 201 이며 작업도 만들어진다. 증상은 "정책을 `none` 으로 줬는데 첫 도구에서 승인 대기" 로만 보이고, 요청·응답 어디에도 원인이 남지 않는다.

승인 정책은 설계상 **실행 단위** 옵션이라 `POST /:taskId/execute` 가 받는 것이 맞다 (프론트도 그렇게 보낸다 — `use-chat-socket.ts:482`). 문제는 위치가 아니라 **틀린 위치가 침묵한다**는 점이다.

## 수정

**① 생성 스키마 strict + `approvalPolicy` 명시 거절**

미선언 키는 strip 대신 400. `approvalPolicy` 는 `z.never` 로 선언해 **어디로 보내야 하는지** 메시지로 알려준다. 오타(`maxTurn`)도 같은 부류의 침묵이라 함께 걸린다.

**② `executeAgentTaskSchema` 배선 — 정의만 되고 쓰이지 않고 있었다**

라우트가 스키마를 무시하고 body 를 손수 파싱해, 같은 enum 허용목록이 두 곳에 있었다. 미들웨어를 붙이면서 `allowedSkills` 를 스키마에 선언했다 — **빠뜨리면 검증된 body 로 치환될 때 통째로 사라져** 지금 고치는 결함을 그대로 재생산한다. 상한 초과 시 조용히 `slice(0,50)` 하던 것도 400 으로 바꿨다 (캡은 `AGENT_TASK_LIMITS.EXECUTE_MAX_ALLOWED_SKILLS`, env override).

## 검증 (임시 포트 52999 — pm2 무영향)

| 요청 | 결과 |
|---|---|
| 생성 + `approvalPolicy` | 400 `승인 정책은 생성이 아니라 POST /api/agent-tasks/:taskId/execute 에 전달하세요` |
| 생성 + `maxTurn` 오타 | 400 `Unrecognized key: "maxTurn"` |
| 생성 (정상) | 201 |
| execute + `approvalPolicy:"auto"` | 400 |
| execute + `allowedSkills` 51개 | 400 (잘라내지 않음) |
| execute + `approvalPolicy:"none"` | 202 |

**차등 확인** — 기본 정책 작업은 첫 도구에서 `paused`, `none` 작업은 shell·`file_ops` 를 거쳐 3턴 만에 `completed`. 정책이 실제 승인 게이트까지 도달함을 확인.

유닛 2193 passed (0 failed) · lint 0 errors · tsc clean. 신규 스키마 계약 테스트 8개 추가 (테스트는 gitignore 대상이라 diff 에 없음).

## 호환성

`.strict()` 는 **동작 변경**이다. 지금까지 무시되던 미선언 필드가 400 이 된다. 현재 이 엔드포인트 호출자는 프론트뿐이고 (`apps/web`) 보내는 필드는 전부 선언돼 있어 영향 없다. 자체 스크립트로 호출 중이라면 미선언 필드를 빼야 한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)