### PR TITLE
fix(chat): 응답·대화기록의 model 을 실제로 답한 모델로 기록

### DIFF
--- a/apps/api/src/chat/request-handler.ts
+++ b/apps/api/src/chat/request-handler.ts
@@ -31,7 +31,6 @@ import { buildExecutionPlan } from './profile-resolver';
 import { applySlashCommand } from './slash-command';
 import { detectFastPath } from './fast-path-detector';
 import { historySummaryCache } from '../services/chat-service/history-summary-cache';
-import { servedModelLabel } from '../services/chat-service/provider-gate';
 import { summarizeHistory } from './history-summarizer';
 import { HISTORY_SUMMARIZER } from '../config/runtime-limits';
 import { createLogger } from '../utils/logger';
@@ -41,9 +40,8 @@ import { ExternalKeysRepository } from '../data/repositories/external-keys-repo'
 import { getPool } from '../data/models/unified-database';
 import { extractAndStripArtifacts, findArtifactPlaceholderIds, stripArtifactPlaceholders } from '../llm/artifact-parser';
 import { ArtifactRepository, ArtifactSizeError, type ArtifactKind } from '../data/repositories/artifact-repository';
-import { processExternalToolCalling } from './external-tool-calling';
 import { ensureSession, saveUserMessage, saveAssistantMessage } from './request-persistence';
-import { getProviderCatalogEntry } from '../config/external-providers';
+import { handleToolCallingPath } from './tool-calling-path';
 import { createThinkingSummarySession } from '../services/chat-service/thinking-summarizer';
 import { getConversationDB } from '../data/conversation-db';
 import type {
@@ -293,65 +291,11 @@ export class ChatRequestHandler {
         // ChatService를 우회하여 단일 턴 LLM 호출 후 tool_calls 반환
         // ═══════════════════════════════════════════════════════
         if (tools && tools.length > 0) {
-            // 외부 provider fullId (Phase 2, 2026-07-26): 'chatgpt:*'/'openrouter:*' 등은
-            // provider gate 로 해석해 외부 어댑터로 dispatch — 이전엔 로컬 client 로
-            // silent fallback 되어 CLI 도구(tools 파라미터) 경로에서 외부 모델이 무시됐다.
-            // 해석 실패(키 미등록 등)는 ProviderError 를 그대로 전파해 명시 거절.
-            let externalProvider: { provider: import('../providers/i-provider').IProvider; modelId: string } | undefined;
-            {
-                const reqModel = (model || '').trim();
-                const colonIdx = reqModel.indexOf(':');
-                const prefix = colonIdx > 0 ? reqModel.slice(0, colonIdx) : '';
-                if (prefix && prefix !== 'local-llm' && getProviderCatalogEntry(prefix)) {
-                    const providerRouter = new ProviderRouter({
-                        localProvider: new LocalLLMProvider(client),
-                        externalKeysRepo: new ExternalKeysRepository(getPool()),
-                    });
-                    const resolved = await providerRouter.resolve(reqModel, {
-                        ...(userContext.authenticatedUserId
-                            ? { userId: userContext.authenticatedUserId }
-                            : {}),
-                        userRole: userContext.userRole,
-                    });
-                    externalProvider = { provider: resolved.provider, modelId: resolved.modelId };
-                    servedModel = servedModelLabel(resolved);
-                }
-            }
-
-            const result = await processExternalToolCalling({
-                message,
-                history,
-                images,
-                tools,
-                tool_choice,
-                client,
-                ...(externalProvider ? { externalProvider } : {}),
-                onToken,
-                abortSignal,
+            return handleToolCallingPath({
+                message, history, images, tools, tool_choice, model, client, userContext,
+                sessionId: currentSessionId, auditUserId, persistContent, plan, startTime,
+                onToken, abortSignal,
             });
-
-            const endTime = Date.now();
-            const responseTime = endTime - startTime;
-
-            // AI 응답 저장 (tool_calls인 경우에도 히스토리에 기록)
-            await saveAssistantMessage(
-                currentSessionId,
-                auditUserId,
-                result.response,
-                servedModel,
-                responseTime,
-                persistContent,
-            );
-
-            return {
-                response: result.response,
-                sessionId: currentSessionId,
-                model: servedModel,
-                executionPlan: plan,
-                responseTime,
-                tool_calls: result.tool_calls,
-                finish_reason: result.finish_reason,
-            };
         }
 
         // ═══════════════════════════════════════════════════════

--- a/apps/api/src/chat/request-handler.ts
+++ b/apps/api/src/chat/request-handler.ts
@@ -31,6 +31,7 @@ import { buildExecutionPlan } from './profile-resolver';
 import { applySlashCommand } from './slash-command';
 import { detectFastPath } from './fast-path-detector';
 import { historySummaryCache } from '../services/chat-service/history-summary-cache';
+import { servedModelLabel } from '../services/chat-service/provider-gate';
 import { summarizeHistory } from './history-summarizer';
 import { HISTORY_SUMMARIZER } from '../config/runtime-limits';
 import { createLogger } from '../utils/logger';
@@ -276,6 +277,9 @@ export class ChatRequestHandler {
 
         // 4. 사용자 메시지 저장
         const maskedModel = client.model;
+        // 실제로 답한 모델 — provider gate 해석 전이라 일단 로컬 기본값. 아래에서 gate/폴백이
+        // 확정하면 갱신된다. 이 값을 응답과 대화기록에 쓴다(요청 모델이 아니라 응답 모델).
+        let servedModel = maskedModel;
         // 감사 로그용 사용자 식별자 — 인증된 user id 우선, 익명 세션 id, 최종 'anonymous'
         const auditUserId = userContext.authenticatedUserId || userContext.anonSessionId || 'anonymous';
         // saveHistory 미지정 → true (기본 보존)
@@ -310,6 +314,7 @@ export class ChatRequestHandler {
                         userRole: userContext.userRole,
                     });
                     externalProvider = { provider: resolved.provider, modelId: resolved.modelId };
+                    servedModel = servedModelLabel(resolved);
                 }
             }
 
@@ -333,7 +338,7 @@ export class ChatRequestHandler {
                 currentSessionId,
                 auditUserId,
                 result.response,
-                maskedModel,
+                servedModel,
                 responseTime,
                 persistContent,
             );
@@ -341,7 +346,7 @@ export class ChatRequestHandler {
             return {
                 response: result.response,
                 sessionId: currentSessionId,
-                model: maskedModel,
+                model: servedModel,
                 executionPlan: plan,
                 responseTime,
                 tool_calls: result.tool_calls,
@@ -406,6 +411,7 @@ export class ChatRequestHandler {
             abortSignal,
             userLanguagePreference,
             format: params.format,
+            onServedModel: (fullId) => { servedModel = fullId; },
         };
 
         // 생각 요약 세션 (클로드 웹식 헤드라인): 중간(진행형)·최종(과거형) 요약을
@@ -524,7 +530,7 @@ export class ChatRequestHandler {
             currentSessionId,
             auditUserId,
             cleanedResponse,
-            maskedModel,
+            servedModel,
             responseTime,
             persistContent,
             summarySession.getThinking() || undefined,
@@ -566,7 +572,7 @@ export class ChatRequestHandler {
             response: cleanedResponse,
             artifacts: extractedArtifacts.length > 0 ? extractedArtifacts : undefined,
             sessionId: currentSessionId,
-            model: maskedModel,
+            model: servedModel,
             executionPlan: plan,
             responseTime,
             finish_reason: 'stop',

--- a/apps/api/src/chat/tool-calling-path.ts
+++ b/apps/api/src/chat/tool-calling-path.ts
@@ -1,0 +1,123 @@
+/**
+ * ============================================================
+ * §10 외부 Tool Calling 경로 — `tools` 파라미터가 제공된 요청
+ * ============================================================
+ *
+ * OpenAI 호환 클라이언트(CLI 등)가 도구 목록을 직접 넘기는 경로. ChatService 파이프라인
+ * (에이전트 라우팅·스킬·메모리·아티팩트)을 우회하고 **단일 턴** LLM 호출 후 tool_calls 를
+ * 그대로 돌려준다 — 도구 실행 주체가 서버가 아니라 호출자이기 때문.
+ *
+ * request-handler.processChat 에서 분리(파일 크기 가드 600줄). 조기 return 하는 독립
+ * 분기라 경계가 명확하다.
+ *
+ * @module chat/tool-calling-path
+ */
+import type { LLMClient } from '../llm';
+import { LocalLLMProvider } from '../providers/local-llm-provider';
+import { ProviderRouter } from '../providers/provider-router';
+import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
+import { getPool } from '../data/models/unified-database';
+import { getProviderCatalogEntry } from '../config/external-providers';
+import { servedModelLabel } from '../services/chat-service/provider-gate';
+import { processExternalToolCalling } from './external-tool-calling';
+import { saveAssistantMessage } from './request-persistence';
+import type { IProvider } from '../providers/i-provider';
+import type { ChatUserContext, ChatResult } from './request-handler-types';
+import type { ExecutionPlan } from './profile-resolver';
+
+/** 하위 호출부 시그니처를 그대로 따라간다 — 별도 선언은 drift 를 만든다. */
+type ToolCallingCallParams = Parameters<typeof processExternalToolCalling>[0];
+
+/** processChat 이 이미 확보한 컨텍스트 — 이 경로가 스스로 만들지 않는 값들. */
+export interface ToolCallingPathParams {
+    message: string;
+    history?: ToolCallingCallParams['history'];
+    images?: string[];
+    tools: ToolCallingCallParams['tools'];
+    tool_choice?: ToolCallingCallParams['tool_choice'];
+    /** 요청 모델 ID — 'chatgpt:gpt-5.5' 처럼 provider prefix 가 붙을 수 있다. */
+    model?: string;
+    /** 로컬 기본 클라이언트 — 외부 provider 로 해석되지 않으면 이 클라이언트가 응답한다. */
+    client: LLMClient;
+    userContext: ChatUserContext;
+    sessionId: string;
+    auditUserId: string;
+    persistContent: boolean;
+    plan: ExecutionPlan;
+    /** processChat 이 측정을 시작한 시각 — 응답시간을 한 기준으로 재기 위해 넘겨받는다. */
+    startTime: number;
+    onToken: (token: string) => void;
+    abortSignal?: AbortSignal;
+}
+
+/**
+ * 요청 모델을 외부 provider 로 해석한다.
+ *
+ * 이전엔 prefix 를 무시하고 로컬 client 로 silent fallback 되어, CLI 도구 경로에서만
+ * 외부 모델이 조용히 무시됐다. 해석 실패(키 미등록 등)는 ProviderError 를 그대로
+ * 전파해 명시적으로 거절한다.
+ */
+async function resolveExternal(
+    model: string | undefined,
+    client: LLMClient,
+    userContext: ChatUserContext,
+): Promise<{ externalProvider: { provider: IProvider; modelId: string }; servedModel: string } | null> {
+    const reqModel = (model || '').trim();
+    const colonIdx = reqModel.indexOf(':');
+    const prefix = colonIdx > 0 ? reqModel.slice(0, colonIdx) : '';
+    if (!prefix || prefix === 'local-llm' || !getProviderCatalogEntry(prefix)) return null;
+
+    const providerRouter = new ProviderRouter({
+        localProvider: new LocalLLMProvider(client),
+        externalKeysRepo: new ExternalKeysRepository(getPool()),
+    });
+    const resolved = await providerRouter.resolve(reqModel, {
+        ...(userContext.authenticatedUserId ? { userId: userContext.authenticatedUserId } : {}),
+        userRole: userContext.userRole,
+    });
+    return {
+        externalProvider: { provider: resolved.provider, modelId: resolved.modelId },
+        servedModel: servedModelLabel(resolved),
+    };
+}
+
+/** 단일 턴 호출 → tool_calls 반환. 응답은 히스토리에도 기록한다. */
+export async function handleToolCallingPath(p: ToolCallingPathParams): Promise<ChatResult> {
+    const external = await resolveExternal(p.model, p.client, p.userContext);
+    // 실제로 답한 모델 — 외부로 해석됐으면 그 모델, 아니면 로컬 클라이언트 모델.
+    const servedModel = external?.servedModel ?? p.client.model;
+
+    const result = await processExternalToolCalling({
+        message: p.message,
+        history: p.history,
+        images: p.images,
+        tools: p.tools,
+        tool_choice: p.tool_choice,
+        client: p.client,
+        ...(external ? { externalProvider: external.externalProvider } : {}),
+        onToken: p.onToken,
+        abortSignal: p.abortSignal,
+    });
+
+    const responseTime = Date.now() - p.startTime;
+
+    // AI 응답 저장 (tool_calls 인 경우에도 히스토리에 기록)
+    await saveAssistantMessage(
+        p.sessionId,
+        p.auditUserId,
+        result.response,
+        servedModel,
+        responseTime,
+        p.persistContent,
+    );
+
+    return {
+        response: result.response,
+        sessionId: p.sessionId,
+        model: servedModel,
+        executionPlan: p.plan,
+        responseTime,
+        tool_calls: result.tool_calls,
+        finish_reason: result.finish_reason,
+    };
+}

--- a/apps/api/src/services/chat-service-types.ts
+++ b/apps/api/src/services/chat-service-types.ts
@@ -214,6 +214,14 @@ export interface ChatMessageRequest {
     enabledTools?: Record<string, boolean>;
     /** 요청 중단 시그널 (SSE 연결 종료 시 사용) */
     abortSignal?: AbortSignal;
+    /**
+     * 실제로 답한 모델 통지 — provider gate 해석 직후, 그리고 외부→로컬 폴백이 일어나면
+     * 폴백 모델로 다시 호출된다(마지막 호출값이 실제 응답 모델).
+     *
+     * 파이프라인이 문자열(응답 본문)만 반환해 "요청 모델"과 "응답 모델"을 구분할 방법이
+     * 없었고, 그래서 응답·대화기록의 model 이 항상 로컬 기본 모델로 기록됐다.
+     */
+    onServedModel?: (fullId: string) => void;
     /** 사용자가 설정에서 선택한 선호 언어 (language-policy userPreference) */
     userLanguagePreference?: string;
     /** 구조화된 출력 형식 ('json' 또는 JSON Schema 객체) */

--- a/apps/api/src/services/chat-service/external-fallback.ts
+++ b/apps/api/src/services/chat-service/external-fallback.ts
@@ -11,6 +11,7 @@
  */
 import type { ChatMessageRequest } from '../chat-service-types';
 import type { ResolvedProvider } from '../../providers/provider-router';
+import { servedModelLabel } from './provider-gate';
 import { EXTERNAL_CHAT_FALLBACK } from '../../config/runtime-limits';
 import { getConfig } from '../../config/env';
 import { createLogger } from '../../utils/logger';
@@ -105,6 +106,8 @@ export async function streamFromExternalProvider(
                 reason: err instanceof Error ? err.message.slice(0, 200) : String(err).slice(0, 200),
             },
         });
+        // 실제로 답하는 모델이 바뀌었다 — 배지 고지와 같은 이유로 응답의 model 도 갱신한다.
+        req.onServedModel?.(servedModelLabel(localResolved));
         return runExternalStream(deps, localResolved, req, onToken, ctx);
     }
 }

--- a/apps/api/src/services/chat-service/message-pipeline.ts
+++ b/apps/api/src/services/chat-service/message-pipeline.ts
@@ -26,7 +26,7 @@ import type { ChatMessageRequest, SystemEventCallback } from '../chat-service-ty
 import { getExecutionPlanBuilder } from '../../chat/execution-plan-builder';
 import { normalizeStyle } from '../../chat/style';
 import { resolveAnswerFormatProfile, getAnswerFormatGuard } from '../../chat/answer-format';
-import { runProviderGate } from './provider-gate';
+import { runProviderGate, servedModelLabel } from './provider-gate';
 import { buildNotebookContextPrefix } from '../../prompts/notebook-context';
 import { applyAgentModelOverride } from './agent-model-override';
 import { resolveModeExternalClient } from './mode-external-client';
@@ -100,6 +100,9 @@ export async function runMessagePipeline(svc: ChatService,
         fallbackModel: svc.client.model,
         ctx: { userId: req.userId, userRole: req.userRole },
     });
+    // 여기가 "어느 모델이 답하는가"가 확정되는 유일한 지점 — 호출자에게 알려 응답·대화기록의
+    // model 이 요청 모델이 아니라 실제 응답 모델을 싣게 한다. (폴백 시 external-fallback 이 갱신)
+    req.onServedModel?.(servedModelLabel(externalResolved));
 
     // ── 보안 사전 검사 ──
     const securityPreCheck = preRequestCheck(message || '');

--- a/apps/api/src/services/chat-service/provider-gate.ts
+++ b/apps/api/src/services/chat-service/provider-gate.ts
@@ -89,3 +89,14 @@ export async function runProviderGate(
     const fullId = normalizeToFullId(input.requestedModel, input.fallbackModel);
     return router.resolve(fullId, input.ctx);
 }
+
+/**
+ * 응답에 실을 "실제로 답한 모델" 표기.
+ *
+ * 로컬은 기존과 동일하게 bare model id ('qwen3.6-35b-a3b') 를 유지하고, 외부만
+ * fullId ('chatgpt:gpt-5.5') 로 표기한다 — 로컬까지 fullId 로 바꾸면 기존 응답 표기가
+ * 통째로 달라져 model 값을 비교하는 클라이언트를 깨뜨린다.
+ */
+export function servedModelLabel(resolved: ResolvedProvider): string {
+    return resolved.providerId === 'local-llm' ? resolved.modelId : resolved.fullId;
+}


### PR DESCRIPTION
## 문제

외부 모델로 채팅해도 응답의 `model` 과 대화기록의 model 컬럼이 **항상 로컬 기본 모델**로 남았다.

```
요청: {"message":"2+2는?","model":"chatgpt:gpt-5.5"}
응답: {"response":"4","model":"qwen3.6-35b-a3b"}   ← 실제로는 ChatGPT 가 답함
```

`maskedModel = client.model` (로컬 클라이언트의 모델) 을 그대로 실어 보냈다. 본문은 ChatGPT 가 쓴 것인데 기록은 qwen 이라 **어느 모델이 답했는지 사후에 알 수 없고**, 외부→로컬 폴백이 일어나도 구분되지 않았다.

원인은 파이프라인이 문자열(응답 본문)만 반환해 "요청 모델"과 "응답 모델"을 구분할 통로가 없었던 것.

## 수정

반환 타입을 넓히는 대신 통지 콜백을 뒀다 — 호출 사슬 전체를 건드리지 않는다.

| 지점 | 동작 |
|---|---|
| `ChatMessageRequest.onServedModel` | 어느 모델이 답하는지 확정되는 지점에서 통지 |
| `message-pipeline` | provider gate 해석 직후 통지 |
| `external-fallback` | 외부→로컬 폴백 시 폴백 모델로 **재통지** (배지 고지와 같은 이유) |
| `request-handler` | 마지막 통지값을 응답 `model` + 대화기록 저장에 사용 |
| 도구 호출 경로 (`tools` 파라미터) | 자체 해석 결과로 직접 설정 |

**표기 규약** (`servedModelLabel`): 로컬은 기존대로 bare id (`qwen3.6-35b-a3b`), 외부만 fullId (`chatgpt:gpt-5.5`). 로컬까지 fullId 로 바꾸면 기존 응답 표기가 통째로 달라져 `model` 값을 비교하는 클라이언트를 깨뜨린다. `/api/chat/structured` 가 이미 쓰던 규약과 같다.

## 검증 (임시 포트 52999 — pm2 무영향)

| 경로 | before | after |
|---|---|---|
| 로컬 | `qwen3.6-35b-a3b` | `qwen3.6-35b-a3b` (변화 없음) |
| 외부 ChatGPT | `qwen3.6-35b-a3b` ❌ | `chatgpt:gpt-5.5` ✅ |

**DB 차등** — `conversation_messages` 에 수정 전/후 동일한 외부 응답("4")이 나란히 남았다:

```
chatgpt:gpt-5.5   | 4    ← 수정 후
qwen3.6-35b-a3b   | 4    ← 수정 전 (같은 외부 모델이 답한 것)
```

유닛 2197 passed (0 failed) · lint 0 errors · tsc clean. 폴백 통지·표기 규약 테스트 4개 추가 (테스트는 gitignore 대상이라 diff 에 없음).

## 함께 교정되는 표면

`/api/chat/stream`(119) 과 `/api/v1` openai-compat(`result.model || body.model`) 은 `result.model` 을 그대로 싣고 있어 자동으로 함께 고쳐진다. WS 채팅은 완료 페이로드에 model 을 싣지 않아(메트릭 로그의 `selectedModel` 은 "요청 모델" 로 별개 의미) 손대지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)