### PR TITLE
fix(mcp): 샌드박스 env 값이 ps 인자로 평문 노출되던 문제 차단

### DIFF
--- a/apps/api/src/mcp/external-client.ts
+++ b/apps/api/src/mcp/external-client.ts
@@ -309,7 +309,7 @@ export class ExternalMCPClient extends EventEmitter {
                     throw new Error(`stdio transport requires "command" for server "${this.config.name}"`);
                 }
                 // 🔒 OS 격리: docker 컨테이너로 command/args 를 감싼다(게이트 미충족 시 원본 no-op).
-                //   env 는 sandboxed 시 컨테이너에 -e 로 baked 되므로, 그 경우 SDK env 는 비운다.
+                //   sandboxed 시 인자엔 `-e KEY`(이름만) 만 들어가고 값은 sb.env 로 온다.
                 const sb = buildSandboxedCommand({
                     command: this.config.command,
                     args: this.config.args || [],
@@ -326,10 +326,11 @@ export class ExternalMCPClient extends EventEmitter {
                     // 🔒 보안: process.env 전체 상속 금지 — 외부(승인) MCP 서버가 호스트 비밀
                     //   (DATABASE_URL/JWT_SECRET/TOKEN_ENCRYPTION_KEY/LLM_API_KEY/GOOGLE_* 등)에
                     //   접근하던 누출을 차단. SDK 가 getDefaultEnvironment()(PATH/HOME 등 안전
-                    //   부분집합)를 base 로 병합한다. sandboxed(docker) 시엔 env 가 컨테이너 -e 로
-                    //   들어가므로 여기선 undefined(docker 프로세스는 PATH 만 있으면 됨).
+                    //   부분집합)를 base 로 병합한다. sandboxed(docker) 시엔 sb.env 를 넘겨 docker
+                    //   프로세스가 `-e KEY` 로 컨테이너에 전달하게 한다 — 값을 인자에 baked 하면
+                    //   같은 호스트의 아무 프로세스나 `ps` 로 비밀을 읽을 수 있다.
                     env: sb.sandboxed
-                        ? undefined
+                        ? sb.env
                         : (this.config.env ? { ...this.config.env } as Record<string, string> : undefined),
                     stderr: 'pipe',
                 });

--- a/apps/api/src/mcp/sandbox-docker.ts
+++ b/apps/api/src/mcp/sandbox-docker.ts
@@ -10,7 +10,10 @@
  *
  * 격리(컨테이너 기본):
  *  - 파일시스템: 호스트 경로 미마운트 → 호스트 FS·비밀 접근 불가(컨테이너 기본 격리).
- *  - env: config.env 만 `-e` 로 주입(호스트 env 미상속 — #151 과 동일 원칙, 더 강력).
+ *  - env: config.env 만 주입(호스트 env 미상속 — #151 과 동일 원칙, 더 강력).
+ *    값은 `-e KEY=값` 으로 인자에 넣지 않고 `-e KEY`(이름만) + docker 프로세스 env 로 전달한다.
+ *    커맨드라인 인자는 같은 호스트의 모든 사용자가 `ps` 로 읽을 수 있어 API 키·세션 쿠키가
+ *    평문 노출되기 때문(프로세스 env 는 소유자만 접근 가능).
  *  - 네트워크: full(bridge) | none(--unshare 대신 --network none). 서버별 정책.
  *  - 권한: --cap-drop ALL + no-new-privileges + 비-root user + pids/memory 상한(cgroups).
  *  - 내부 loopback(127.0.0.1/localhost) → host.docker.internal 자동 치환
@@ -42,6 +45,11 @@ export interface SandboxResult {
     args: string[];
     /** 실제 docker 로 감쌌는지 (false = no-op 통과) */
     sandboxed: boolean;
+    /**
+     * sandboxed=true 일 때 docker 프로세스에 넘길 env — 컨테이너는 `-e KEY`(이름만) 로
+     * 여기서 값을 상속받는다. 값이 인자에 없으므로 `ps` 에 비밀이 노출되지 않는다.
+     */
+    env?: Record<string, string>;
 }
 
 /** 게이트/프로파일 입력 — 테스트 주입 가능(순수성). */
@@ -116,6 +124,19 @@ export function rewriteLoopback(s: string): string {
     return s.replace(LOOPBACK_RE, 'host.docker.internal');
 }
 
+/**
+ * PURE: 컨테이너에 전달할 env 값 조립 (loopback 치환 적용).
+ * buildDockerArgs 가 `-e KEY`(이름만) 를 넣으므로, 실제 값은 이 결과를 docker 프로세스의
+ * spawn env 로 넘겨야 컨테이너까지 도달한다.
+ */
+export function buildSandboxedEnv(input: SandboxInput): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(input.env ?? {})) {
+        out[k] = rewriteLoopback(String(v));
+    }
+    return out;
+}
+
 /** PURE: docker run 인자 조립 (유닛테스트 대상). */
 export function buildDockerArgs(input: SandboxInput, cfg: SandboxConfig): string[] {
     const net = (input.network ?? 'full') === 'none' ? 'none' : 'bridge';
@@ -139,9 +160,12 @@ export function buildDockerArgs(input: SandboxInput, cfg: SandboxConfig): string
     a.push('-e', 'HOME=/home/node');
     a.push('-e', 'NPM_CONFIG_CACHE=/home/node/.cache/npm');
     a.push('-e', 'UV_CACHE_DIR=/home/node/.cache/uv');
-    // 서버 config.env 만 컨테이너에 주입 (호스트 env 미상속)
-    for (const [k, v] of Object.entries(input.env ?? {})) {
-        a.push('-e', `${k}=${rewriteLoopback(String(v))}`);
+    // 서버 config.env 만 컨테이너에 주입 (호스트 env 미상속).
+    // 🔒 값은 인자에 넣지 않는다 — `-e KEY`(이름만) 형태면 docker 가 호출 프로세스의 env 에서
+    //    값을 읽어 컨테이너로 전달하므로, `ps` 로 읽히는 커맨드라인에 비밀이 남지 않는다.
+    //    값 자체는 buildSandboxedEnv() 가 돌려주고 호출자가 spawn env 로 넘긴다.
+    for (const k of Object.keys(input.env ?? {})) {
+        a.push('-e', k);
     }
     a.push(cfg.image);
     a.push(rewriteLoopback(input.command), ...input.args.map((x) => rewriteLoopback(String(x))));
@@ -150,7 +174,8 @@ export function buildDockerArgs(input: SandboxInput, cfg: SandboxConfig): string
 
 /**
  * 외부 MCP stdio command 를 docker run 으로 감싼다. 게이트 미충족 시 원본 그대로(no-op).
- * sandboxed=true 이면 env 는 args(-e)에 baked 되므로 호출자는 StdioClientTransport env 를 비워야 한다.
+ * sandboxed=true 이면 인자엔 `-e KEY`(이름만) 가 들어가므로, 호출자는 반환된 `env` 를
+ * StdioClientTransport env 로 넘겨야 한다(값이 docker 프로세스를 거쳐 컨테이너에 전달됨).
  */
 export function buildSandboxedCommand(input: SandboxInput, cfg: SandboxConfig = defaultSandboxConfig()): SandboxResult {
     // per-server opt-out — 호스트 설치 바이너리 의존 등으로 컨테이너 미동작인 신뢰 서버는
@@ -166,5 +191,5 @@ export function buildSandboxedCommand(input: SandboxInput, cfg: SandboxConfig = 
         throw new Error('MCP 샌드박스가 활성화(MCP_SANDBOX_ENABLED)됐으나 docker 바이너리를 찾을 수 없습니다. 비격리 실행을 거부합니다 — Docker 설치/실행을 확인하거나 sandbox_network=host 로 opt-out 하세요.');
     }
     const dockerArgs = buildDockerArgs(input, cfg);
-    return { command: cfg.dockerPath, args: dockerArgs, sandboxed: true };
+    return { command: cfg.dockerPath, args: dockerArgs, sandboxed: true, env: buildSandboxedEnv(input) };
 }


### PR DESCRIPTION
## 문제

MCP 샌드박스가 서버 env 를 `docker run -e KEY=값` 형태로 조립해, **같은 호스트의 아무 프로세스나 `ps -ef` 로 커맨드라인 인자를 읽어 API 키·세션 쿠키를 평문으로 획득**할 수 있었다.

컨테이너 격리(`--cap-drop ALL`, `no-new-privileges`, non-root 등)는 갖춰져 있었지만, 격리 대상 프로세스에 비밀을 **전달하는 경로**가 호스트에서 평문이라 격리 목적이 전달 방식에서 새고 있었다.

## 해결

`-e KEY=값`(인자 baked) → **`-e KEY`(이름만) + 값은 spawn env** 로 전환.

docker 는 `-e KEY` 에 값이 없으면 호출 프로세스의 env 에서 값을 읽어 컨테이너로 전달한다. 커맨드라인에는 키 이름만 남고, 프로세스 env 는 소유자만 접근 가능하다.

`--env-file` 도 검토했으나 임시 파일 수명·권한 관리 부담이 있어 채택하지 않았다.

| 파일 | 변경 |
|---|---|
| `sandbox-docker.ts` | `buildDockerArgs` 가 이름만 push / `buildSandboxedEnv()` 신설(값 조립 + loopback 치환 유지) / `SandboxResult.env` 추가 |
| `external-client.ts` | `StdioClientTransport.env` 로 값 전달 |

SDK 가 `{...getDefaultEnvironment(), ...env}` 로 **병합**하므로(`stdio.js:74`) PATH 는 유지되어 docker 실행에 지장이 없다.

사용처는 `external-client.createTransport` 단일 후킹뿐이라 영향 범위가 닫혀 있다.

## 검증

- **호스트 `ps`**: `docker run` 프로세스 13건 전수 검사 — 비밀 패턴 **0건**. 인자엔 키 이름만 노출
- **컨테이너 내부 `printenv`**: 값 정상 도달 확인 — "노출은 막혔는데 기능이 조용히 깨진" 경우를 배제
- **도구 discovery 정상**: github 26 / notebooklm 39 / firecrawl 26 / brave-search 8
- **회귀 가드 테스트 추가**: 값이 인자에 다시 baked 되면 실패하도록
- 백엔드 유닛테스트 **2,198 passed**, `tsc --noEmit` 0, eslint 0 errors

## 알려진 잔여

`mcp-postgres-001` 은 DSN 이 env 가 아니라 **args 배열**에 있어 이 수정 범위 밖이다(`@modelcontextprotocol/server-postgres@0.6.2` 가 deprecated + argv only 라 env 이전 불가). 다만 해당 롤이 애초에 DB 에 존재하지 않아 `tools/list` 만 성공하고 실제 query 는 실패하는 죽은 도구였으므로, 등록을 비활성화하는 것으로 종결했다.

## 보안 영향 범위

- 노출 경로: 호스트 로컬. 같은 머신에서 프로세스 목록을 읽을 수 있는 주체 (원격 노출 아님)
- 수정 후: 커맨드라인에서 값 획득 불가
- 운영 배포 완료 (빌드 + 재시작 + 라이브 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)