### PR TITLE
fix(mcp): 수동 [연결] 경로에서 암호화된 env 를 복호화하지 않던 문제

### DIFF
--- a/apps/api/src/routes/mcp.routes.ts
+++ b/apps/api/src/routes/mcp.routes.ts
@@ -313,8 +313,8 @@ export const mcpRouter = Router();
       const role = req.user?.role ?? 'user';
       const actor = { id: userId, role };
       const { id } = req.params;
+      const repo = new McpCatalogRepository(getUnifiedDatabase().getPool());
       {
-          const repo = new McpCatalogRepository(getUnifiedDatabase().getPool());
           const server = await repo.getServerById(id);
           if (!server) {
               res.status(404).json(notFound('서버'));
@@ -333,6 +333,13 @@ export const mcpRouter = Router();
           return;
       }
 
+      // getMcpServerById 는 DB 원본(암호문 v1:)을 그대로 돌려주므로 복호화가 필수다.
+      // 빠뜨리면 암호문이 그대로 자식 프로세스 env 로 들어가 서버는 뜨고 도구 목록도
+      // 정상 등록되지만(연결 자체는 자격증명을 안 쓴다) 실제 API 호출만 401 로 실패한다.
+      // lifecycle-supervisor.safeSpawn 은 decryptEnvForSpawn 을 쓰므로 자동 spawn 경로는
+      // 정상이고, 수동 [연결] 경로만 갈라져 있었다.
+      const decryptedEnv = await repo.decryptEnvForSpawn(id);
+
       const registry = getUnifiedMCPClient().getServerRegistry();
       await registry.connectServer(id, {
           id: server.id,
@@ -340,7 +347,7 @@ export const mcpRouter = Router();
           transport_type: server.transport_type as MCPTransportType,
           command: server.command || undefined,
           args: server.args || undefined,
-          env: server.env || undefined,
+          env: Object.keys(decryptedEnv).length > 0 ? decryptedEnv : undefined,
           url: server.url || undefined,
           enabled: server.enabled,
           created_at: server.created_at,


### PR DESCRIPTION
## 문제

`POST /servers/:id/connect` 가 `getMcpServerById` 의 **DB 원본(암호문 `v1:`)을 그대로** `registry.connectServer` 에 넘겨, 자격증명이 암호문 상태로 자식 프로세스 env 에 주입됐다.

```ts
const server = await db.getMcpServerById(id);   // 암호문 그대로
...
env: server.env || undefined,                    // ← 복호화 누락
```

`lifecycle-supervisor.safeSpawn` 은 `decryptEnvForSpawn()` 을 쓰므로 **자동 spawn 경로는 정상**이고, 수동 [연결] 경로만 갈라져 있었다.

### 증상이 잘 드러나지 않는 형태였다

MCP 연결 수립 자체는 자격증명을 쓰지 않기 때문에:

- 서버는 정상적으로 뜨고
- 도구 목록도 전부 등록되며 (`Registered 39 tools from "notebooklm"`)
- 서버 목록 UI 에도 `connected` 로 표시된다

그 뒤 **실제 API 호출만 401** 로 실패한다. 겉으로는 아무 문제 없어 보이는 게 이 버그의 고약한 점이다.

## 발견 경위

자격증명(env) 교체 후 서버가 `disconnected` 가 되어 UI 에서 [연결] 버튼을 누른 흐름에서 드러났다. 교체 기능 자체는 정상이었고(저장·암호화·감사 로그 모두 의도대로), 재연결 경로가 원인이었다.

## 수정

`connect` 라우트도 `decryptEnvForSpawn()` 을 쓰도록 맞춘다. 권한 검사 블록에서만 쓰이던 `repo` 를 핸들러 스코프로 올려 재사용한다.

## 검증 (라이브)

| 항목 | 수정 전 | 수정 후 |
|---|---|---|
| 컨테이너 내부 `printenv` | 암호문 4361자 (`v1:1afced…`) | **평문 2150자** (`NID=533=…`) |
| `notebook_list` 실호출 | **401** | **200** — 실제 노트북 목록 반환 |

자동 spawn 경로도 평문 유지 확인(회귀 없음). `tsc --noEmit` 0, eslint 0.

## 참고 — 함께 확인했으나 손대지 않은 것

`server-registry.rowToConfig` (`server-registry.ts:46`) 도 raw env 를 쓴다. 다만 **global 서버 전용 경로**이고 현재 global 서버 env 는 전부 비-secret 평문(`MEMORY_FILE_PATH`, `REPL_TIMEOUT` 등)이라 영향이 없다. 향후 global 에 secret 을 넣으면 같은 함정이므로 별도 정리 대상으로 남긴다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)