### PR TITLE
fix(mcp): 수동 [연결]이 user 소유 서버를 전역 등록해 타 사용자에게 노출되던 문제

### DIFF
--- a/apps/api/src/mcp/lifecycle-supervisor.ts
+++ b/apps/api/src/mcp/lifecycle-supervisor.ts
@@ -154,6 +154,14 @@ export class MCPLifecycleSupervisor implements LifecycleSupervisor {
         }
     }
 
+    /**
+     * 단일 유저 서버 spawn — killUserServer 의 대칭(수동 [연결] 경로용).
+     *
+     * user 소유 서버는 **반드시 이 경로(userPool)** 로 띄워야 한다. 전역 server-registry
+     * 로 띄우면 tool-router 의 전역 externalTools fallback(visibility=global 전용)에
+     * 도구가 등록돼 **다른 사용자도 그 도구를 실행**할 수 있다(= 남의 자격증명으로
+     * 접근하는 데이터가 유출).
+     */
     async spawnUserServer(userId: string, serverId: string): Promise<ExternalMCPClient> {
         const existing = this.userPool.get(userId, serverId);
         if (existing) return existing;

--- a/apps/api/src/routes/mcp.routes.ts
+++ b/apps/api/src/routes/mcp.routes.ts
@@ -314,17 +314,34 @@ export const mcpRouter = Router();
       const actor = { id: userId, role };
       const { id } = req.params;
       const repo = new McpCatalogRepository(getUnifiedDatabase().getPool());
-      {
-          const server = await repo.getServerById(id);
-          if (!server) {
-              res.status(404).json(notFound('서버'));
-              return;
-          }
-          if (!canStartStopServer(actor, server)) {
-              res.status(403).json(forbidden('해당 서버를 연결할 권한이 없습니다'));
-              return;
-          }
+      const target = await repo.getServerById(id);
+      if (!target) {
+          res.status(404).json(notFound('서버'));
+          return;
       }
+      if (!canStartStopServer(actor, target)) {
+          res.status(403).json(forbidden('해당 서버를 연결할 권한이 없습니다'));
+          return;
+      }
+
+      // 🔒 user 소유 서버는 전역 registry 가 아니라 소유자의 userPool 로 띄운다.
+      //    registry 로 띄우면 tool-router 의 전역 externalTools fallback
+      //    (visibility=global 전용)에 도구가 등록돼 **다른 사용자도 그 도구를 실행**할 수
+      //    있다(= 남의 자격증명으로 접근하는 데이터가 유출). 부팅 로드 경로에는 이미
+      //    visibility 필터가 있었으나 이 수동 경로만 우회하고 있었다.
+      //    부수 효과로 자동 spawn(userPool)과 풀이 일치해 컨테이너 중복도 사라진다.
+      if (target.visibility !== 'global') {
+          const supervisor = getLifecycleSupervisor();
+          if (!supervisor) {
+              res.status(503).json(internalError('MCP lifecycle supervisor 가 초기화되지 않았습니다'));
+              return;
+          }
+          const ownerId = String(target.user_id ?? userId);
+          const client = await supervisor.spawnUserServer(ownerId, id);
+          res.json(success({ status: client.getStatus() }));
+          return;
+      }
+
       const db = getUnifiedDatabase();
       const server = await db.getMcpServerById(id);
 
@@ -364,18 +381,30 @@ export const mcpRouter = Router();
       const role = req.user?.role ?? 'user';
       const actor = { id: userId, role };
       const { id } = req.params;
-      {
-          const repo = new McpCatalogRepository(getUnifiedDatabase().getPool());
-          const server = await repo.getServerById(id);
-          if (!server) {
-              res.status(404).json(notFound('서버'));
-              return;
-          }
-          if (!canStartStopServer(actor, server)) {
-              res.status(403).json(forbidden('해당 서버를 연결 해제할 권한이 없습니다'));
-              return;
-          }
+      const repo = new McpCatalogRepository(getUnifiedDatabase().getPool());
+      const target = await repo.getServerById(id);
+      if (!target) {
+          res.status(404).json(notFound('서버'));
+          return;
       }
+      if (!canStartStopServer(actor, target)) {
+          res.status(403).json(forbidden('해당 서버를 연결 해제할 권한이 없습니다'));
+          return;
+      }
+
+      // connect 와 대칭 — user 소유 서버는 userPool 에 떠 있으므로 registry 만 정리하면
+      // 컨테이너가 살아남아 "해제했는데 계속 동작"하게 된다.
+      if (target.visibility !== 'global') {
+          const supervisor = getLifecycleSupervisor();
+          if (supervisor) {
+              await supervisor.killUserServer(String(target.user_id ?? userId), id);
+          }
+          // 과거 경로로 registry 에 등록됐을 수 있으니 함께 정리(멱등).
+          await getUnifiedMCPClient().getServerRegistry().disconnectServer(id).catch(() => { /* 미등록이면 무시 */ });
+          res.json(success({ disconnected: true }));
+          return;
+      }
+
       const registry = getUnifiedMCPClient().getServerRegistry();
       await registry.disconnectServer(id);
 


### PR DESCRIPTION
## 문제

`POST /servers/:id/connect` 가 소유 주체와 무관하게 `registry.connectServer` 로 띄우고 있었다. 전역 registry 에 올라간 서버의 도구는 `tool-router` 의 **전역 externalTools fallback**(`visibility=global` 전용 설계)에 등록되므로, `user_private` 서버의 도구를 **다른 사용자가 실행**할 수 있었다.

부팅 로드 경로는 이미 `getGlobalMcpServers()` 로 visibility 를 거르고 있었는데, **이 수동 경로만 그 필터를 우회**하고 있었다.

### 라이브 재현 (수정 전)

```
user 92 (비-admin, 비소유자)
  → POST /api/mcp/tools/notebooklm::notebook_list/execute
  → HTTP 200
  → user 3 소유 계정의 노트북 목록 반환
```

도구 목록 API 에는 노출되지 않아(게스트 시점 외부 도구 0개) 이름을 미리 알아야 하지만, 이름 규칙이 `서버명::도구명` 이라 인가 부재를 가려주지 못한다.

## 수정

| 라우트 | 변경 |
|---|---|
| `connect` | `visibility !== 'global'` 이면 `supervisor.spawnUserServer(ownerId, id)` 로 **소유자 userPool** 에 띄운다 (기존 메서드 — 소유자 불일치 검증 내장) |
| `disconnect` | 대칭 처리. connect 만 고치면 userPool 에 뜬 것을 registry 에서 빼려 해서 **"해제했는데 컨테이너가 계속 사는"** 상태가 된다. 과거 경로로 registry 에 남은 잔재도 멱등 정리 |

부수 효과로 자동 spawn(userPool)과 풀이 일치해 **컨테이너 중복도 사라진다** (같은 서버가 registry·userPool 양쪽에 떠서 2개씩 생기던 문제).

## 검증 (라이브)

| 항목 | 결과 |
|---|---|
| 소유자 [연결] | 200, 컨테이너 **1개** (중복 없음) |
| **타 사용자 도구 실행** | **403, 데이터 노출 없음** |
| 소유자 도구 실행 | 200, 정상 |
| [연결 해제] | 200, 컨테이너 **0개** (실제 종료) |

`tsc --noEmit` 0, eslint 0, 관련 유닛 80/80.

## 악용 이력 조사

`audit_logs` 의 `mcp_tool_call` 708건(2026-06-22~)을 서버 소유자와 대조해 **비소유자 호출 12건**을 추출했다. 이번 경로로 인한 외부 호출 흔적은 없다.

- **3건** — 오늘 취약점 실증/수정 검증 테스트 (성공 1 + 차단 2)
- **6건** — 2026-07-11 전역 레지스트리 사건 (**별개 경로·기수정**). 당시 전역 경로는 암호문을 그대로 넘겨 키 필요 서버는 인증 실패했고, 실제 실행된 `mcp-kakao` 3건은 지도 검색으로 민감 데이터가 아니다
- **3건** — admin 계정(user 11) 호출

한계: **[연결] 버튼을 누른 이력 자체는 감사 로그에 남지 않아**, 과거 일시적 노출 구간의 존재 자체를 완전히 배제할 수는 없다. 다만 그 구간에 비소유자 호출이 있었다면 위 조회에 잡혔을 것이고, 잡힌 것은 위 3분류뿐이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)