### PR TITLE
fix(mcp): env 복호화를 fail-closed 로 전환하고 전역 로드 경로 복호화 누락 수정

### DIFF
--- a/apps/api/src/data/repositories/mcp-catalog-repository.ts
+++ b/apps/api/src/data/repositories/mcp-catalog-repository.ts
@@ -411,6 +411,14 @@ export class McpCatalogRepository {
     /**
      * spawn 시점에 child process env 로 전달할 평문 env 복호화.
      * 응답 마스킹 (maskEnv) 과 분리 — 본 메서드는 lifecycle-supervisor (Phase 7) 가 호출.
+     *
+     * ⚠️ decryptToken 은 fail-open 이다 — 키 부재나 포맷 오류 시 예외 대신 **암호문을
+     * 그대로 반환**한다(token-crypto.ts). 그대로 넘기면 암호문이 자식 프로세스 env 에
+     * 주입돼, 서버는 뜨고 도구 목록도 등록되지만 실제 API 호출만 인증 실패하는 형태로
+     * 조용히 깨진다(진단이 어려운 실패 모드). 복호화 후에도 v1: 이 남아 있으면 실패로
+     * 보고 throw 한다(fail-closed) — safeSpawn 호출자가 서버 단위로 처리한다.
+     *
+     * @throws {Error} 복호화 실패 시 (TOKEN_ENCRYPTION_KEY 부재/불일치, 저장값 손상)
      */
     async decryptEnvForSpawn(serverId: string): Promise<Record<string, string>> {
         const result = await this.pool.query<{ env: Record<string, string> | null }>(
@@ -421,11 +429,16 @@ export class McpCatalogRepository {
         if (!env) return {};
         const decrypted: Record<string, string> = {};
         for (const [k, v] of Object.entries(env)) {
-            if (typeof v === 'string' && v.startsWith('v1:')) {
-                decrypted[k] = decryptToken(v);
-            } else if (typeof v === 'string') {
+            if (typeof v !== 'string') continue;
+            if (!v.startsWith('v1:')) {
                 decrypted[k] = v;
+                continue;
             }
+            const plain = decryptToken(v);
+            if (plain.startsWith('v1:')) {
+                throw new Error(`env "${k}" 복호화 실패 — 암호문이 그대로 남았습니다 (TOKEN_ENCRYPTION_KEY 설정 및 저장값 포맷을 확인하세요)`);
+            }
+            decrypted[k] = plain;
         }
         return decrypted;
     }

--- a/apps/api/src/mcp/server-registry.ts
+++ b/apps/api/src/mcp/server-registry.ts
@@ -24,6 +24,7 @@ import { ExternalMCPClient } from './external-client';
 import { ToolRouter } from './tool-router';
 import type { MCPServerConfig, MCPConnectionStatus } from './types';
 import type { UnifiedDatabase, MCPServerRow } from '../data/models/unified-database';
+import { decryptToken } from '../utils/token-crypto';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('MCPRegistry');
@@ -36,6 +37,32 @@ const logger = createLogger('MCPRegistry');
  * @param row - DB에서 조회한 MCP 서버 행
  * @returns MCPServerConfig 형식의 서버 설정
  */
+/**
+ * env 값 중 암호문(v1:)만 복호화. 평문 값은 그대로 둔다.
+ *
+ * ⚠️ decryptToken 은 fail-open 이다 — 키 부재나 포맷 오류 시 예외 대신 **암호문을 그대로
+ * 반환**한다(token-crypto.ts). 그대로 넘기면 암호문이 자식 프로세스 env 에 주입돼,
+ * 서버는 뜨고 도구 목록도 등록되지만 실제 API 호출만 인증 실패하는 형태로 조용히 깨진다.
+ * 그래서 복호화 후에도 v1: 이 남아 있으면 실패로 보고 throw 한다(fail-closed).
+ * 호출자(initializeFromDB)가 서버 단위로 잡아 그 서버만 건너뛴다.
+ */
+function decryptEnvValues(env: Record<string, string> | null | undefined): Record<string, string> | undefined {
+    if (!env) return undefined;
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(env)) {
+        if (typeof v !== 'string' || !v.startsWith('v1:')) {
+            out[k] = v;
+            continue;
+        }
+        const decrypted = decryptToken(v);
+        if (decrypted.startsWith('v1:')) {
+            throw new Error(`env "${k}" 복호화 실패 — 암호문이 그대로 남았습니다 (TOKEN_ENCRYPTION_KEY 설정 및 저장값 포맷을 확인하세요)`);
+        }
+        out[k] = decrypted;
+    }
+    return out;
+}
+
 function rowToConfig(row: MCPServerRow): MCPServerConfig {
     return {
         id: row.id,
@@ -43,7 +70,11 @@ function rowToConfig(row: MCPServerRow): MCPServerConfig {
         transport_type: row.transport_type as MCPServerConfig['transport_type'],
         command: row.command || undefined,
         args: row.args || undefined,
-        env: row.env || undefined,
+        // DB 원본은 secret 이 암호문(v1:)으로 저장돼 있으므로 복호화해서 넘긴다.
+        // 빠뜨리면 암호문이 그대로 자식 프로세스 env 로 들어가, 서버는 뜨고 도구 목록도
+        // 정상 등록되지만 실제 API 호출만 인증 실패하는 형태로 조용히 깨진다
+        // (사용자풀 경로의 decryptEnvForSpawn 과 동일한 처리).
+        env: decryptEnvValues(row.env),
         url: row.url || undefined,
         enabled: row.enabled,
         created_at: row.created_at,
@@ -94,12 +125,15 @@ export class MCPServerRegistry {
             logger.info(`Found ${enabledServers.length} enabled MCP servers in DB`);
 
             for (const server of enabledServers) {
-                const config = rowToConfig(server);
+                // rowToConfig 도 try 안에서 호출한다 — env 복호화가 실패하면 그 서버만
+                // 건너뛰어야 하고, 루프 밖이면 예외가 바깥 catch 로 빠져 나머지 서버까지
+                // 통째로 초기화되지 않는다.
                 try {
+                    const config = rowToConfig(server);
                     await this.connectServer(config.id, config);
                 } catch (error) {
                     const msg = error instanceof Error ? error.message : String(error);
-                    logger.error(`Failed to connect "${config.name}" during init:`, msg);
+                    logger.error(`Failed to connect "${server.name}" during init:`, msg);
                     // 초기화 실패는 전체를 중단하지 않음
                 }
             }

--- a/apps/api/src/routes/mcp.routes.ts
+++ b/apps/api/src/routes/mcp.routes.ts
@@ -282,9 +282,12 @@ export const mcpRouter = Router();
           return;
       }
 
-      // 이미 떠 있는 컨테이너는 구 자격증명(stale env)을 그대로 들고 있다. 정리하지 않으면
-      // 키를 바꿨는데도 채팅이 옛 값으로 계속 도구를 호출한다(삭제 경로와 동일한 이유).
-      // 재spawn 은 다음 ensureUserServers(채팅 시작) 가 멱등 처리한다.
+      // 이미 떠 있는 클라이언트는 구 자격증명(stale env)을 그대로 들고 있다. 정리하지 않으면
+      // 키를 바꿔도 옛 값으로 계속 도구를 호출한다(삭제 경로와 동일한 이유).
+      // 소유 주체에 따라 붙어 있는 풀이 다르므로 양쪽 모두 끊어야 한다 —
+      //   user 소유: userPool(lifecycle-supervisor) → 다음 ensureUserServers 가 멱등 respawn
+      //   global   : 전역 registry → 자동 respawn 경로가 없어 수동 [연결] 이 필요
+      // 어느 쪽이든 "다시 연결해야 새 값이 적용된다"는 뜻이므로 respawnRequired=true 로 알린다.
       let respawnRequired = false;
       if (server.user_id) {
           const supervisor = getLifecycleSupervisor();
@@ -293,6 +296,10 @@ export const mcpRouter = Router();
               await supervisor.killUserServer(String(server.user_id), id).catch((e: unknown) =>
                   logger.warn(`env 변경 후 유저풀 정리 실패(변경은 유지): ${id}: ${e instanceof Error ? e.message : String(e)}`));
           }
+      } else {
+          respawnRequired = true;
+          await getUnifiedMCPClient().getServerRegistry().disconnectServer(id).catch((e: unknown) =>
+              logger.warn(`env 변경 후 전역 registry 정리 실패(변경은 유지): ${id}: ${e instanceof Error ? e.message : String(e)}`));
       }
 
       // 자격증명 변경은 감사 대상 — 키 이름만 남기고 값은 절대 기록하지 않는다.
@@ -397,7 +404,10 @@ export const mcpRouter = Router();
       if (target.visibility !== 'global') {
           const supervisor = getLifecycleSupervisor();
           if (supervisor) {
-              await supervisor.killUserServer(String(target.user_id ?? userId), id);
+              // 정리 실패로 500 을 내지 않는다 — PATCH/DELETE 경로와 동일하게 경고만 남기고
+              // 나머지 정리를 계속한다(해제 요청 자체는 최대한 진행시키는 편이 낫다).
+              await supervisor.killUserServer(String(target.user_id ?? userId), id).catch((e: unknown) =>
+                  logger.warn(`연결 해제 시 유저풀 정리 실패: ${id}: ${e instanceof Error ? e.message : String(e)}`));
           }
           // 과거 경로로 registry 에 등록됐을 수 있으니 함께 정리(멱등).
           await getUnifiedMCPClient().getServerRegistry().disconnectServer(id).catch(() => { /* 미등록이면 무시 */ });

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -950,7 +950,7 @@
     "envUnchangedPlaceholder": "unchanged",
     "envSave": "Save",
     "envSaved": "Credentials updated.",
-    "envSavedRespawn": "Credentials updated. The existing connection was closed and will reconnect with the new values on your next chat.",
+    "envSavedRespawn": "Credentials updated. The existing connection was closed; the new values apply once it reconnects.",
     "envUpdateError": "Failed to update credentials"
   },
   "mcpCatalog": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -950,7 +950,7 @@
     "envUnchangedPlaceholder": "変更しない",
     "envSave": "保存",
     "envSaved": "認証情報を変更しました。",
-    "envSavedRespawn": "認証情報を変更しました。既存の接続は終了し、次のチャット開始時に新しい値で再接続されます。",
+    "envSavedRespawn": "認証情報を変更しました。既存の接続は終了し、再接続時に新しい値が適用されます。",
     "envUpdateError": "認証情報の変更に失敗しました"
   },
   "mcpCatalog": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -950,7 +950,7 @@
     "envUnchangedPlaceholder": "변경하지 않음",
     "envSave": "저장",
     "envSaved": "자격증명을 변경했습니다.",
-    "envSavedRespawn": "자격증명을 변경했습니다. 기존 연결이 종료되었으며 다음 대화 시작 시 새 값으로 다시 연결됩니다.",
+    "envSavedRespawn": "자격증명을 변경했습니다. 기존 연결이 종료되었으며, 다시 연결되면 새 값이 적용됩니다.",
     "envUpdateError": "자격증명 변경에 실패했습니다"
   },
   "mcpCatalog": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -950,7 +950,7 @@
     "envUnchangedPlaceholder": "不更改",
     "envSave": "保存",
     "envSaved": "凭据已更新。",
-    "envSavedRespawn": "凭据已更新。现有连接已关闭，将在下次对话开始时使用新值重新连接。",
+    "envSavedRespawn": "凭据已更新。现有连接已关闭，重新连接后将使用新值。",
     "envUpdateError": "更新凭据失败"
   },
   "mcpCatalog": {


### PR DESCRIPTION
## 문제

두 spawn 경로 모두 암호문이 자식 프로세스 env 로 새어 들어갈 수 있었다.

### ① `server-registry.rowToConfig` 복호화 누락

DB 원본(암호문 `v1:`)을 그대로 `config.env` 에 넣고 있었다. 이 경로는 global 서버 전용이고 현재 global env 는 전부 비-secret 평문(`MEMORY_FILE_PATH`, `REPL_TIMEOUT` 등)이라 **실피해는 없었으나**, global 에 secret 을 넣는 순간 조용히 깨진다.

### ② `decryptToken` 이 fail-open 이라 "복호화 호출 = 성공"이 아님

```ts
// token-crypto.ts
if (!key) { logger.warn(...); return value; }              // :127 — 암호문 그대로
if (parts.length !== 3) { logger.error(...); return value; } // :134 — 암호문 그대로
```

키 부재나 포맷 오류 시 **예외 없이 입력을 그대로 반환**한다. 따라서 복호화를 호출해도 실패하면 암호문이 그대로 흘러가고, 결과는 복호화를 아예 빠뜨린 것과 같아진다.

이 실패 모드가 특히 나쁜 이유는 **겉으로 정상처럼 보인다는 점**이다 — MCP 연결 수립에는 자격증명이 쓰이지 않아 서버가 뜨고 도구 목록도 전부 등록되며, 실제 API 호출만 인증 실패한다. #391 에서 겪은 것과 동일한 증상이다.

### ③ `rowToConfig` 가 루프의 try 밖에 있음

`initializeFromDB` 에서 `rowToConfig(server)` 가 서버별 try 블록 **밖**에 있어, ② 의 throw 가 바깥 catch 로 빠지면 **나머지 global 서버까지 통째로** 초기화되지 않는다.

## 수정

| 항목 | 내용 |
|---|---|
| `server-registry` | `decryptEnvValues()` 신설 — 암호문만 복호화, 평문은 보존 |
| **fail-closed** | 복호화 후에도 `v1:` 이 남아 있으면 실패로 보고 throw. `decryptEnvValues` 와 `decryptEnvForSpawn` **양쪽** 적용 |
| `initializeFromDB` | `rowToConfig` 를 try 안으로 이동해 서버 단위 격리 (에러 로그는 `server.name` 사용) |

호출부 영향: 자동 spawn 2곳(`onUserLogin`·`ensureUserServers`)은 이미 서버 단위 `.catch` 로 격리되고, 수동 [연결]은 500 응답 — 조용한 실패보다 낫다.

## 테스트

- **`server-registry` 회귀 4건 신설** — 이 경로에는 테스트가 아예 없었다. 암호문 복호화 / 평문 보존 / env 부재 / **한 서버 실패 시 나머지 계속 초기화**
- `decryptEnvForSpawn` 3건 추가 — 복호화 / **fail-closed throw** / env 부재
- 전체 **2210 passed**, `tsc --noEmit` 0, eslint 0

## 검증 (라이브)

재시작 후:

- global 4개 정상 (`Knowledge Graph Memory` 9 / `Python REPL` 12 / `Playwright` 24 / `noapi-google-search` 38 tools)
- 사용자 서버 전부 연결 (`notebooklm` 39, `Firecrawl-MCP-Server` 26, `mcp-kakao` 7 …)
- **복호화 실패 로그 0건**
- 암호화 키를 쓰는 `mcp-kakao::search-places` 실호출 **200 + 실데이터**

🤖 Generated with [Claude Code](https://claude.com/claude-code)