### PR TITLE
fix(security): 외부 provider 키·OAuth 토큰 복호화를 fail-closed 로 전환

### DIFF
--- a/apps/api/src/data/repositories/external-keys-repo.ts
+++ b/apps/api/src/data/repositories/external-keys-repo.ts
@@ -15,7 +15,7 @@
  * @see db/migrations/016_external_provider_integration.sql
  */
 import { BaseRepository } from './base-repository';
-import { encryptToken, decryptToken } from '../../utils/token-crypto';
+import { encryptToken, decryptToken, isDecryptionFailure } from '../../utils/token-crypto';
 import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('ExternalKeysRepo');
@@ -228,7 +228,16 @@ export class ExternalKeysRepository extends BaseRepository {
         );
         const row = result.rows[0];
         if (!row) return null;
-        return decryptToken(row.encrypted_key);
+        const plain = decryptToken(row.encrypted_key);
+        // decryptToken 은 fail-open — 키 부재·포맷 오류 시 예외 대신 암호문을 그대로 돌려준다.
+        // 그대로 반환하면 암호문이 provider API 키로 쓰여 조용한 인증 실패가 된다.
+        // 호출자 6곳이 모두 null 을 "키 없음/복호화 실패"로 처리하므로 null 로 내린다
+        // (throw 로 올리면 model.routes 의 provider 단위 skip 이 목록 전체 실패로 바뀐다).
+        if (isDecryptionFailure(plain)) {
+            logger.error(`외부 키 복호화 실패 (user=${userId}, provider=${providerId}): 암호문이 그대로 남았습니다 — TOKEN_ENCRYPTION_KEY 확인 필요`);
+            return null;
+        }
+        return plain;
     }
 
     /**

--- a/apps/api/src/data/repositories/external-repository.ts
+++ b/apps/api/src/data/repositories/external-repository.ts
@@ -8,8 +8,31 @@
  */
 import { BaseRepository, QueryParam } from './base-repository';
 import type { ExternalConnection, ExternalFile, ExternalServiceType, MCPServerRow } from '../models/unified-database.types';
-import { encryptToken, decryptToken } from '../../utils/token-crypto';
+import { encryptToken, decryptToken, isDecryptionFailure } from '../../utils/token-crypto';
 import { QUERY_ROW_LIMITS } from '../../config/runtime-limits';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('ExternalRepository');
+
+/**
+ * OAuth 토큰 1개 복호화 — 실패 시 null.
+ *
+ * decryptToken 은 fail-open 이라 키 부재·포맷 오류 시 예외 대신 암호문을 그대로 돌려준다.
+ * 그 값을 그대로 반환하면 암호문이 그대로 Bearer 토큰으로 쓰여(services/github-token.ts)
+ * 외부 API 가 401 을 내는 조용한 실패가 된다. null 로 내리면 소비자들이 이미 갖춘
+ * "토큰 없음" 폴백(clone/push/PR skip)으로 자연스럽게 degrade 된다.
+ *
+ * 커넥션 단위로만 무효화하므로 목록 조회에서 한 건이 손상돼도 나머지는 정상 반환된다.
+ */
+function decryptTokenField(value: unknown, field: string, connectionId?: unknown): string | undefined {
+    if (value == null) return undefined;
+    const plain = decryptToken(value as string);
+    if (isDecryptionFailure(plain)) {
+        logger.error(`OAuth ${field} 복호화 실패 (connection=${String(connectionId ?? 'unknown')}): 암호문이 그대로 남았습니다 — TOKEN_ENCRYPTION_KEY 확인 필요`);
+        return undefined;
+    }
+    return plain;
+}
 
 type DbRow = Record<string, unknown>;
 
@@ -59,8 +82,8 @@ export class ExternalRepository extends BaseRepository {
         );
         return result.rows.map((row) => ({
             ...row,
-            access_token: row.access_token != null ? decryptToken(row.access_token as string) : row.access_token,
-            refresh_token: row.refresh_token != null ? decryptToken(row.refresh_token as string) : row.refresh_token,
+            access_token: decryptTokenField(row.access_token, 'access_token', row.id),
+            refresh_token: decryptTokenField(row.refresh_token, 'refresh_token', row.id),
             is_active: !!row.is_active,
             metadata: row.metadata || {}
         }));
@@ -73,8 +96,8 @@ export class ExternalRepository extends BaseRepository {
 
         return {
             ...row,
-            access_token: row.access_token != null ? decryptToken(row.access_token as unknown as string) : row.access_token,
-            refresh_token: row.refresh_token != null ? decryptToken(row.refresh_token as unknown as string) : row.refresh_token,
+            access_token: decryptTokenField(row.access_token, 'access_token', row.id),
+            refresh_token: decryptTokenField(row.refresh_token, 'refresh_token', row.id),
             is_active: !!row.is_active,
             metadata: row.metadata || {}
         };
@@ -90,8 +113,8 @@ export class ExternalRepository extends BaseRepository {
 
         return {
             ...row,
-            access_token: row.access_token != null ? decryptToken(row.access_token as unknown as string) : row.access_token,
-            refresh_token: row.refresh_token != null ? decryptToken(row.refresh_token as unknown as string) : row.refresh_token,
+            access_token: decryptTokenField(row.access_token, 'access_token', row.id),
+            refresh_token: decryptTokenField(row.refresh_token, 'refresh_token', row.id),
             is_active: !!row.is_active,
             metadata: row.metadata || {}
         };

--- a/apps/api/src/data/repositories/server-external-keys-repo.ts
+++ b/apps/api/src/data/repositories/server-external-keys-repo.ts
@@ -9,7 +9,7 @@
  * @see db/migrations/070_server_external_api_keys.sql
  */
 import { BaseRepository } from './base-repository';
-import { encryptToken, decryptToken } from '../../utils/token-crypto';
+import { encryptToken, decryptToken, isDecryptionFailure } from '../../utils/token-crypto';
 import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('ServerExternalKeysRepo');
@@ -73,7 +73,15 @@ export class ServerExternalKeysRepository extends BaseRepository {
         const enc = result.rows[0]?.encrypted_key;
         if (!enc) return null;
         try {
-            return decryptToken(enc);
+            const plain = decryptToken(enc);
+            // decryptToken 은 fail-open — 키 부재·포맷 오류 시 예외 대신 암호문을 그대로
+            // 돌려주므로 아래 catch 가 발동하지 않는다. 그대로 반환하면 암호문이 API 키로
+            // 쓰여 조용한 인증 실패가 된다. 명시적으로 판별해 의도대로 null 을 돌려준다.
+            if (isDecryptionFailure(plain)) {
+                logger.error(`서버 키 복호화 실패 (${providerId}): 암호문이 그대로 남았습니다 — TOKEN_ENCRYPTION_KEY 확인 필요`);
+                return null;
+            }
+            return plain;
         } catch (err) {
             logger.error(`서버 키 복호화 실패 (${providerId}):`, err);
             return null;

--- a/apps/api/src/utils/token-crypto.ts
+++ b/apps/api/src/utils/token-crypto.ts
@@ -110,9 +110,31 @@ export function encryptToken(plaintext: string): string {
 }
 
 /**
+ * 복호화 결과가 실패인지 판별합니다.
+ *
+ * decryptToken 은 fail-open 이라 키 부재·포맷 오류 시 예외 없이 **암호문을 그대로**
+ * 돌려줍니다. 따라서 "decryptToken 을 호출했다"가 "평문을 얻었다"를 보장하지 않습니다.
+ * 반환값이 여전히 v1: 로 시작하면 복호화가 되지 않은 것이므로, 그 값을 실제 자격증명처럼
+ * 쓰면 안 됩니다(자식 프로세스 env 주입·외부 API 호출 등에서 조용한 인증 실패로 나타남).
+ *
+ * 호출 관용구:
+ *   const plain = decryptToken(v);
+ *   if (isDecryptionFailure(plain)) { ...실패 처리... }
+ *
+ * @param decrypted - decryptToken 의 반환값
+ * @returns 복호화되지 않은(암호문이 그대로 남은) 값이면 true
+ */
+export function isDecryptionFailure(decrypted: string): boolean {
+    return typeof decrypted === 'string' && decrypted.startsWith(ENCRYPTED_PREFIX);
+}
+
+/**
  * 암호화된 토큰을 복호화합니다.
  * v1: prefix가 없으면 레거시 평문 토큰으로 간주하고 그대로 반환합니다.
  * TOKEN_ENCRYPTION_KEY가 없으면 값을 그대로 반환합니다.
+ *
+ * ⚠️ fail-open — 실패해도 throw 하지 않고 입력을 그대로 반환합니다. 반환값을 자격증명으로
+ * 쓰기 전에 {@link isDecryptionFailure} 로 검사하세요.
  */
 export function decryptToken(value: string): string {
     if (!value) return value;


### PR DESCRIPTION
## 문제

`decryptToken` 은 **fail-open** 이다.

```ts
// token-crypto.ts
if (!key) { logger.warn(...); return value; }                // :127 — 암호문 그대로
if (parts.length !== 3) { logger.error(...); return value; }  // :134 — 암호문 그대로
```

따라서 **"복호화를 호출했다"가 "평문을 얻었다"를 보장하지 않는다.** 반환값을 그대로 쓰면 암호문이 실제 자격증명 자리에 들어가고, 요청은 정상적으로 나가지만 401 만 돌아오는 진단이 어려운 실패가 된다.

MCP 경로는 #393 에서 고쳤고, 같은 함정이 남아 있던 세 곳을 정리한다.

## 변경

### 공용 판별 — `isDecryptionFailure()`

반환값에 `v1:` 이 남았는지 확인하는 관용구를 `token-crypto` 에 추가한다.

**`decryptToken` 자체는 그대로 둔다.** 이 함수는 "v1: 없으면 레거시 평문으로 간주"하는 하위호환에 의존하는 호출처가 있어, throw 로 바꾸면 조사 범위 밖까지 영향이 간다. 호출 지점에서 판별하는 편이 안전하다.

### `external-keys-repo.decryptKey` — 실패 시 `null`

호출자 6곳이 모두 `if (!key)` 가드로 "키 없음"을 처리한다. throw 로 올리면 `model.routes.ts:177` 의 provider 단위 `continue`(부분 skip)가 **목록 전체 실패**로 바뀌므로, `null` 이 최소 변경이자 안전하다.

### `server-external-keys-repo.decryptKey` — 의도대로 동작하게

이미 `try/catch` 로 `null` 반환을 **의도**하고 있었다(주석: "복호화 실패 시 null"). 그런데 `decryptToken` 이 throw 하지 않으니 **catch 가 영영 발동하지 않아** 암호문이 그대로 반환되고 있었다.

### `external-repository` OAuth 토큰 3함수 — 필드 단위 무효화

실질 피해 지점은 `services/github-token.ts:19` 로, **암호문이 그대로 GitHub Bearer 토큰에 실려** 나가고 있었다.

`decryptTokenField()` 로 `undefined` 를 내리면 소비자(`git-ops.ts`)의 기존 "토큰 없음" 폴백(clone/push/PR skip)으로 자연스럽게 degrade 한다.

**커넥션 단위로만 무효화**하는 점이 중요하다 — `getUserConnections` 는 목록 조회라, row 하나의 복호화 실패가 `.map` 에서 전파되면 목록 전체가 500 이 된다. 손상된 커넥션의 토큰만 비우고 나머지는 정상 반환한다.

## 테스트 (12건 추가)

- `isDecryptionFailure` 4건 — 판별 정확성 + **fail-open 동작 자체를 고정**(손상 암호문을 그대로 돌려주는 것이 현재 계약임을 명시)
- repo fail-closed 8건 — 정상 복호화 / 실패 시 null·undefined / **목록 부분 실패 격리**

전체 **2222 passed**, `tsc --noEmit` 0, eslint 0 errors.

## 검증 (라이브)

재시작 후 복호화 실패 로그 **0건**, 실제 등록된 외부 키 4건(`chatgpt`·`nvidia`·`ollama-cloud`·`openrouter`) **전부 평문 복호화 정상**.

`external_connections`(OAuth)는 현재 활성 행이 0건이라 실데이터 검증은 불가했고, 유닛 테스트로 대체했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)