### PR TITLE
feat(artifacts): 실행 불가 코드에 실행 버튼을 노출하지 않도록 판정 추가

### DIFF
--- a/apps/web/components/chat/artifact-panel.tsx
+++ b/apps/web/components/chat/artifact-panel.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { X, Code2, Eye, Copy, Check, Play, Loader2, Download, Share2 } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { X, Code2, Eye, Copy, Check, Play, Loader2, Download, Share2, PackageX } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useAppStore } from "@/lib/store";
 import type { Artifact } from "@/lib/store";
 import { ApiClient, ApiError } from "@/lib/api-client";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { buildArtifactSrcDoc, previewKindFor } from "@/lib/artifact-render";
+import { checkRunnable } from "@openmake/config";
 import { appendAnonSessionId } from "@/lib/anon-session";
 import { ArtifactFrame } from "./artifact-frame";
 import { ArtifactShareModal } from "./artifact-share-modal";
@@ -35,8 +36,8 @@ interface ExecResult {
   truncated: boolean;
 }
 
-/** 서버 실행 가능 언어 (백엔드 ARTIFACT_EXEC_RUNTIMES 와 정합). */
-const RUNNABLE_LANGS = new Set(["python", "py", "python3", "javascript", "js", "node", "nodejs"]);
+// 실행 가능 언어 판정 + import 정적 분석은 lib/artifact-runnable 로 분리.
+// 언어만 보고 버튼을 노출하면 django 같은 외부 의존 코드에서 ModuleNotFoundError 만 보게 된다.
 
 function CodeArtifactView({
   artifact,
@@ -49,7 +50,10 @@ function CodeArtifactView({
 }) {
   const t = useTranslations("artifacts");
   const lang = (artifact.lang ?? "").toLowerCase().trim();
-  const runnable = RUNNABLE_LANGS.has(lang);
+  const verdict = useMemo(() => checkRunnable(lang, artifact.content), [lang, artifact.content]);
+  const runnable = verdict.runnable;
+  // 언어는 지원하지만 외부 패키지 의존이라 실행이 불가능한 경우 — 버튼 대신 이유를 보여준다.
+  const blockedDeps = !verdict.runnable && verdict.reason === "external-deps" ? verdict.packages : null;
   const [running, setRunning] = useState(false);
   const [result, setResult] = useState<ExecResult | null>(null);
   const [restored, setRestored] = useState(false);
@@ -121,6 +125,12 @@ function CodeArtifactView({
             {running ? t("run.running") : t("run.run")}
           </button>
           <span className="text-[11px] text-faint">{t("run.sandbox", { lang })}</span>
+        </div>
+      )}
+      {blockedDeps && (
+        <div className="flex items-start gap-1.5 border-b border-border px-3 py-1.5 text-[11px] text-faint">
+          <PackageX className="mt-px h-3.5 w-3.5 shrink-0" />
+          <span>{t("run.externalDeps", { packages: blockedDeps.join(", ") })}</span>
         </div>
       )}
       <div className="min-h-0 flex-1 overflow-auto px-3">

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -404,7 +404,8 @@
       "running": "Running…",
       "run": "Run",
       "sandbox": "Sandbox (network blocked) · {lang}",
-      "restored": "last run"
+      "restored": "last run",
+      "externalDeps": "Cannot run in the sandbox — requires {packages} (standard library only)."
     },
     "output": {
       "title": "Output",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -404,7 +404,8 @@
       "running": "実行中…",
       "run": "実行",
       "sandbox": "サンドボックス（ネットワーク遮断） · {lang}",
-      "restored": "前回の実行結果"
+      "restored": "前回の実行結果",
+      "externalDeps": "{packages} が必要なためサンドボックスでは実行できません（標準ライブラリのみ対応）。"
     },
     "output": {
       "title": "出力",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -404,7 +404,8 @@
       "running": "실행 중…",
       "run": "실행",
       "sandbox": "샌드박스(네트워크 차단) · {lang}",
-      "restored": "이전 실행 결과"
+      "restored": "이전 실행 결과",
+      "externalDeps": "{packages} 패키지가 필요해 샌드박스에서 실행할 수 없습니다 (표준 라이브러리만 지원)."
     },
     "output": {
       "title": "출력",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -404,7 +404,8 @@
       "running": "执行中…",
       "run": "执行",
       "sandbox": "沙箱（网络已阻断） · {lang}",
-      "restored": "上次运行结果"
+      "restored": "上次运行结果",
+      "externalDeps": "无法在沙箱中运行 — 需要 {packages}（仅支持标准库）。"
     },
     "output": {
       "title": "输出",

--- a/packages/config/src/artifact-runnable.ts
+++ b/packages/config/src/artifact-runnable.ts
@@ -1,0 +1,125 @@
+/**
+ * 아티팩트 코드 실행 가능성 판정.
+ *
+ * 실행 샌드박스(openmake-mcp-runtime)는 `--network none` 으로 격리돼 외부 패키지를 설치할 수
+ * 없고 **표준 라이브러리만** 존재한다(2026-07-29 실측: 서드파티 pip 패키지 0개).
+ * 따라서 django·express 같은 외부 의존이 있는 코드는 실행하면 반드시 ModuleNotFoundError 로
+ * 끝난다. 언어만 보고 실행 버튼을 노출하면 사용자가 "코드가 잘못됐나" 오해하므로,
+ * import 를 정적 분석해 미리 걸러낸다.
+ *
+ * 목록은 샌드박스 이미지에서 직접 추출했다
+ * (python3.11 `sys.stdlib_module_names` / node22 `module.builtinModules`).
+ */
+
+/** python3.11 표준 라이브러리 (샌드박스 실측) */
+const PY_STDLIB = new Set([
+    "abc", "aifc", "antigravity", "argparse", "array", "ast", "asynchat", "asyncio", "asyncore", "atexit",
+    "audioop", "base64", "bdb", "binascii", "bisect", "builtins", "bz2", "cProfile", "calendar", "cgi",
+    "cgitb", "chunk", "cmath", "cmd", "code", "codecs", "codeop", "collections", "colorsys", "compileall",
+    "concurrent", "configparser", "contextlib", "contextvars", "copy", "copyreg", "crypt", "csv", "ctypes", "curses",
+    "dataclasses", "datetime", "dbm", "decimal", "difflib", "dis", "distutils", "doctest", "email", "encodings",
+    "ensurepip", "enum", "errno", "faulthandler", "fcntl", "filecmp", "fileinput", "fnmatch", "fractions", "ftplib",
+    "functools", "gc", "genericpath", "getopt", "getpass", "gettext", "glob", "graphlib", "grp", "gzip",
+    "hashlib", "heapq", "hmac", "html", "http", "idlelib", "imaplib", "imghdr", "imp", "importlib",
+    "inspect", "io", "ipaddress", "itertools", "json", "keyword", "lib2to3", "linecache", "locale", "logging",
+    "lzma", "mailbox", "mailcap", "marshal", "math", "mimetypes", "mmap", "modulefinder", "msilib", "msvcrt",
+    "multiprocessing", "netrc", "nis", "nntplib", "nt", "ntpath", "nturl2path", "numbers", "opcode", "operator",
+    "optparse", "os", "ossaudiodev", "pathlib", "pdb", "pickle", "pickletools", "pipes", "pkgutil", "platform",
+    "plistlib", "poplib", "posix", "posixpath", "pprint", "profile", "pstats", "pty", "pwd", "py_compile",
+    "pyclbr", "pydoc", "pydoc_data", "pyexpat", "queue", "quopri", "random", "re", "readline", "reprlib",
+    "resource", "rlcompleter", "runpy", "sched", "secrets", "select", "selectors", "shelve", "shlex", "shutil",
+    "signal", "site", "smtpd", "smtplib", "sndhdr", "socket", "socketserver", "spwd", "sqlite3", "sre_compile",
+    "sre_constants", "sre_parse", "ssl", "stat", "statistics", "string", "stringprep", "struct", "subprocess", "sunau",
+    "symtable", "sys", "sysconfig", "syslog", "tabnanny", "tarfile", "telnetlib", "tempfile", "termios", "textwrap",
+    "this", "threading", "time", "timeit", "tkinter", "token", "tokenize", "tomllib", "trace", "traceback",
+    "tracemalloc", "tty", "turtle", "turtledemo", "types", "typing", "unicodedata", "unittest", "urllib", "uu",
+    "uuid", "venv", "warnings", "wave", "weakref", "webbrowser", "winreg", "winsound", "wsgiref", "xdrlib",
+    "xml", "xmlrpc", "zipapp", "zipfile", "zipimport", "zlib", "zoneinfo",
+]);
+
+/** node22 내장 모듈 (샌드박스 실측) */
+const NODE_BUILTINS = new Set([
+    "assert", "assert/strict", "async_hooks", "buffer", "child_process", "cluster", "console", "constants",
+    "crypto", "dgram", "diagnostics_channel", "dns", "dns/promises", "domain", "events", "fs",
+    "fs/promises", "http", "http2", "https", "inspector", "inspector/promises", "module", "net",
+    "os", "path", "path/posix", "path/win32", "perf_hooks", "process", "punycode", "querystring",
+    "readline", "readline/promises", "repl", "stream", "stream/consumers", "stream/promises", "stream/web", "string_decoder",
+    "sys", "timers", "timers/promises", "tls", "trace_events", "tty", "url", "util",
+    "util/types", "v8", "vm", "wasi", "worker_threads", "zlib",
+]);
+
+/** 서버 실행 가능 언어 (백엔드 ARTIFACT_EXEC_RUNTIMES 와 정합) */
+const PY_LANGS = new Set(["python", "py", "python3"]);
+const JS_LANGS = new Set(["javascript", "js", "node", "nodejs"]);
+
+export type RunnableVerdict =
+  /** 실행 가능 */
+  | { runnable: true }
+  /** 서버가 실행을 지원하지 않는 언어 */
+  | { runnable: false; reason: "unsupported-language" }
+  /** 샌드박스에 없는 외부 패키지에 의존 */
+  | { runnable: false; reason: "external-deps"; packages: string[] };
+
+/** import 스펙에서 최상위 패키지명만 추출 (`django.http` → `django`, `node:fs` → `fs`) */
+function topLevel(spec: string): string {
+  const bare = spec.replace(/^node:/, "");
+  // node 내장은 'fs/promises' 처럼 슬래시 형태가 그대로 유효하므로 먼저 확인
+  if (NODE_BUILTINS.has(bare)) return bare;
+  return bare.split("/")[0]!.split(".")[0]!;
+}
+
+/** 상대경로 import 는 같은 아티팩트 내 참조이므로 외부 의존이 아니다. */
+function isRelative(spec: string): boolean {
+  return spec.startsWith(".") || spec.startsWith("/");
+}
+
+function pythonImports(code: string): string[] {
+  const found = new Set<string>();
+  // `import a, b.c as x`
+  for (const m of code.matchAll(/^[ \t]*import[ \t]+([^\n#]+)/gm)) {
+    for (const part of m[1]!.split(",")) {
+      const name = part.trim().split(/\s+as\s+/)[0]!.trim();
+      if (name && !isRelative(name)) found.add(topLevel(name));
+    }
+  }
+  // `from a.b import c` — `from . import x` 같은 상대 import 는 제외
+  for (const m of code.matchAll(/^[ \t]*from[ \t]+(\S+)[ \t]+import[ \t]/gm)) {
+    const name = m[1]!.trim();
+    if (name && !isRelative(name)) found.add(topLevel(name));
+  }
+  return [...found];
+}
+
+function jsImports(code: string): string[] {
+  const found = new Set<string>();
+  for (const m of code.matchAll(/\brequire\(\s*['"]([^'"]+)['"]\s*\)/g)) {
+    const s = m[1]!;
+    if (!isRelative(s)) found.add(topLevel(s));
+  }
+  for (const m of code.matchAll(/^[ \t]*import\s+(?:[^'"]*?\bfrom\s+)?['"]([^'"]+)['"]/gm)) {
+    const s = m[1]!;
+    if (!isRelative(s)) found.add(topLevel(s));
+  }
+  return [...found];
+}
+
+/**
+ * 이 코드가 실행 샌드박스에서 돌 수 있는지 판정한다.
+ *
+ * @param lang - 아티팩트 language (대소문자 무관)
+ * @param code - 아티팩트 본문
+ */
+export function checkRunnable(lang: string | null | undefined, code: string): RunnableVerdict {
+  const l = (lang ?? "").toLowerCase().trim();
+  const isPy = PY_LANGS.has(l);
+  const isJs = JS_LANGS.has(l);
+  if (!isPy && !isJs) return { runnable: false, reason: "unsupported-language" };
+
+  const imports = isPy ? pythonImports(code) : jsImports(code);
+  const known = isPy ? PY_STDLIB : NODE_BUILTINS;
+  const missing = imports.filter((m) => !known.has(m)).sort();
+
+  return missing.length > 0
+    ? { runnable: false, reason: "external-deps", packages: missing }
+    : { runnable: true };
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -26,3 +26,6 @@ export const PORTS = {
 
 /** 변경(mutating) 메서드 — CSRF 헤더 주입 대상. */
 export const MUTATING_METHODS = ["POST", "PUT", "PATCH", "DELETE"] as const;
+
+/** 아티팩트 코드 실행 가능성 판정 (샌드박스 표준 라이브러리 기준). */
+export { checkRunnable, type RunnableVerdict } from "./artifact-runnable";


### PR DESCRIPTION
## 문제

실행 버튼 노출을 **언어(python/js)만 보고** 결정하고 있었다.

```ts
const RUNNABLE_LANGS = new Set(["python", "py", ...]);
const runnable = RUNNABLE_LANGS.has(lang);   // ← 코드 내용은 안 봄
```

아티팩트 실행 샌드박스는 `--network none` 이라 패키지 설치가 불가능하고 **표준 라이브러리만** 있다(실측: 서드파티 pip 패키지 0개). 그래서 외부 의존이 있는 코드는 버튼을 눌러도 `ModuleNotFoundError` 만 나오고, 사용자는 **"코드가 잘못됐나"** 오해하게 된다.

### 실제 사례 (2026-07-28)

"파이썬을 이용해서 hello world 프린트하는 장고 소스 작성해서 화면에 보여줘"

- 아티팩트 3개는 **정상 생성**됨 (django-hello-world / django-hello-views / django-project-structure)
- 실행 버튼을 누르자 `artifact_executions` 에 남은 결과:

```
Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
ModuleNotFoundError: No module named 'django'
exit_code: 1  (196ms)
```

애초에 Django 는 `views.py` 하나만 떼어 실행할 수 없는 구조(settings·urls·manage.py 필요)라, 패키지가 있어도 단독 실행은 불가능하다.

## 변경

`checkRunnable(lang, code)` 을 `@openmake/config` 에 추가하고, 버튼 노출 조건을 이 판정으로 바꾼다. 외부 의존이 있으면 버튼 대신 이유를 보여준다.

> django 패키지가 필요해 샌드박스에서 실행할 수 없습니다 (표준 라이브러리만 지원).

**설계상 신경 쓴 점**

- **표준 라이브러리 목록을 샌드박스 이미지에서 직접 추출**했다 (`python3.11 sys.stdlib_module_names` 217개 / `node22 module.builtinModules` 54개). 추정 목록이 아니라 실제 실행 환경과 일치한다.
- 상대 import(`from . import x`, `./local.js`)는 같은 아티팩트 내 참조이므로 통과.
- `node:fs/promises` 처럼 접두사·슬래시 형태의 내장 모듈도 인식.
- 서브모듈은 최상위로 집계(`django.http` → `django`).
- 프론트·백엔드 공통 로직이라 `apps/web/lib` 가 아니라 **`@openmake/config`** 에 뒀다. `apps/api` tsconfig `rootDir` 밖 참조 문제도 함께 해소된다.

## 검증

**라이브 (실제 화면)**

| 아티팩트 | 결과 |
|---|---|
| `django-hello-views` (사고 당사자) | 버튼 사라짐 + 안내 문구 노출 ✅ |
| `TestReverse` (`import unittest` 만) | **실행 버튼 유지** ✅ (`샌드박스(네트워크 차단) · python`) |

i18n raw 키 노출 0건.

**정적**

- 유닛 10건 추가 — 정상 코드 / 표준 라이브러리 / 외부 의존 / 상대 import / 주석 안 import / `node:` 접두사 / 미지원 언어
- 전체 **2232 passed**, api·web `tsc --noEmit` 0, eslint 0
- `check:i18n` 4로케일 1206키 정합

## 남은 개선 여지 (이번 범위 밖)

백엔드 `POST /api/artifacts/execute` 는 여전히 언어만 검사한다. API 를 직접 호출하면 실행이 시도되지만, 그 경우 지금처럼 `ModuleNotFoundError` 가 날 뿐이라 보안·정합성 문제는 없다. 필요하면 같은 판정을 서버에서도 태워 조기 거절할 수 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)