### PR TITLE
feat(desktop): 에이전트 browser 도구를 로컬 Electron Chromium 에서 실행 (Cowork D3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -812,6 +812,13 @@ AGENT_TASK_TIMEOUT_MS=600000
 # LOCAL_BRIDGE_REQUEST_TIMEOUT_MS=180000        # 도구 1회 왕복 대기 상한
 # LOCAL_BRIDGE_MAX_WRITE_BYTES=8388608          # write/첨부 전송 상한(8MB)
 # LOCAL_BRIDGE_OUTPUT_CAP=65536                 # exec/read 결과 수신 캡(chars)
+#
+# ── 로컬 에이전트 브라우저 (Cowork D3) ──
+# browser 도구를 데스크톱 Electron 내장 Chromium 에서 실행(Playwright 미번들).
+# 전용 세션 파티션이라 개인 Chrome 쿠키·로그인과 분리되고, 화면에 보이는 패널로 뜬다.
+# allowlist 밖 호스트·http(s) 외 스킴 차단, 다운로드는 연결 폴더 안으로만. 기본 OFF.
+# LOCAL_BRIDGE_BROWSER_ENABLED=false
+# LOCAL_BRIDGE_BROWSER_TIMEOUT_MS=60000         # 액션 배열 1회 실행 상한
 # AGENT_TASK_QUEUE_ENABLED=true
 # AGENT_TASK_QUEUE_GLOBAL_MAX=4
 # AGENT_TASK_QUEUE_USER_MAX=2

--- a/apps/api/src/config/local-bridge.ts
+++ b/apps/api/src/config/local-bridge.ts
@@ -19,4 +19,14 @@ export const LOCAL_BRIDGE = {
 
     /** read/exec 결과 수신 캡(chars) — 모델 컨텍스트/스텝 저장 보호(샌드박스 outputCap 관행과 동일 축). */
     OUTPUT_CAP: parseInt(process.env.LOCAL_BRIDGE_OUTPUT_CAP || '65536', 10),
+
+    /**
+     * 로컬 브라우저(D3a) — 데스크톱 Electron 내장 Chromium 에서 browser 도구를 실행한다.
+     * 서버 컨테이너 브라우저와 달리 **사용자 화면에 보이는** 패널로 뜨고, 전용 세션 파티션이라
+     * 개인 Chrome 쿠키·로그인에 접근하지 않는다. 기본 OFF — 켤 때 위 ENABLED 도 함께 필요.
+     */
+    BROWSER_ENABLED: process.env.LOCAL_BRIDGE_BROWSER_ENABLED === 'true',
+
+    /** 브라우저 액션 배열 1회 실행 상한(ms). 컨테이너 runner 기본값과 같은 축. */
+    BROWSER_TIMEOUT_MS: parseInt(process.env.LOCAL_BRIDGE_BROWSER_TIMEOUT_MS || '60000', 10),
 } as const;

--- a/apps/api/src/services/local-bridge/registry.ts
+++ b/apps/api/src/services/local-bridge/registry.ts
@@ -23,11 +23,13 @@ import { createLogger } from '../../utils/logger';
 const logger = createLogger('LocalBridge');
 
 /** 서버→디바이스 도구 요청 종류 — 이 외의 kind 는 존재하지 않는다(임의 RPC 금지). */
-export type BridgeKind = 'exec' | 'read' | 'write' | 'list' | 'listAll' | 'delete' | 'task_end';
+export type BridgeKind = 'exec' | 'read' | 'write' | 'list' | 'listAll' | 'delete' | 'task_end' | 'browser';
 
 export interface BridgeRequestPayload {
     kind: BridgeKind;
     command?: string;
+    /** browser 전용 — 액션 spec({actions,allowlist,timeoutMs}). 데스크톱이 내장 Chromium 으로 실행. */
+    spec?: Record<string, unknown>;
     path?: string;
     /** write 전용 — base64 본문 (바이너리 안전). */
     contentB64?: string;

--- a/apps/api/src/services/local-bridge/remote-executor.ts
+++ b/apps/api/src/services/local-bridge/remote-executor.ts
@@ -34,7 +34,13 @@ function toExecResult(r: BridgeResult): ExecResult {
 export class RemoteExecutor implements TaskExecutor {
     readonly taskId: string;
     readonly localWorkdir = null;
-    readonly isBrowserEnabled = false;
+    /**
+     * D3 — 로컬 브라우저 게이트. 서버 샌드박스의 TASK_SANDBOX_BROWSER_ENABLED 와 **별개**로
+     * LOCAL_BRIDGE_BROWSER_ENABLED 를 본다. false 면 tools.ts 의 browser 핸들러가 진입 단계에서
+     * 막으므로 runBrowser 까지 오지 않는다(D1 시절 하드코딩 false 로 인해 실제로 그랬다).
+     */
+    readonly isBrowserEnabled = LOCAL_BRIDGE.BROWSER_ENABLED;
+    /** 세션 영속은 데스크톱 파티션(persist:openmake-agent)이 담당 — 서버측 상태 파일 불필요. */
     readonly browserStatePath = null;
     private readonly userId: string;
     private deviceLabel = 'local-device';

--- a/apps/api/src/services/local-bridge/remote-executor.ts
+++ b/apps/api/src/services/local-bridge/remote-executor.ts
@@ -62,8 +62,34 @@ export class RemoteExecutor implements TaskExecutor {
         return toExecResult(await this.req({ kind: 'exec', command }));
     }
 
-    async runBrowser(): Promise<ExecResult> {
-        return { stdout: '', stderr: '로컬 실행 작업에서는 browser 도구를 지원하지 않습니다(D1).', exitCode: -1, truncated: false, timedOut: false, durationMs: 0 };
+    /**
+     * 로컬 브라우저 실행(D3a) — 데스크톱 Electron 내장 Chromium 에서 액션을 수행한다.
+     *
+     * 컨테이너 경로(`browser-runner.mjs`)와 **출력 계약을 동일**하게 맞춘다
+     * (`{ok, finalUrl, results[]}` JSON 을 stdout 으로) — 서버측 파싱·프롬프트를 재사용하기 위함.
+     * 액션 spec 은 에이전트가 워크스페이스(=사용자 폴더)에 써둔 JSON 이므로 브리지 read 로 가져온다.
+     */
+    async runBrowser(actionsRelPath: string): Promise<ExecResult> {
+        if (!LOCAL_BRIDGE.BROWSER_ENABLED) {
+            return {
+                stdout: '', exitCode: -1, truncated: false, timedOut: false, durationMs: 0,
+                stderr: '로컬 브라우저가 비활성화되어 있습니다 (LOCAL_BRIDGE_BROWSER_ENABLED=false).',
+            };
+        }
+        let spec: unknown;
+        try {
+            spec = JSON.parse(await this.readFile(actionsRelPath));
+        } catch (e) {
+            return {
+                stdout: '', exitCode: -1, truncated: false, timedOut: false, durationMs: 0,
+                stderr: `브라우저 액션 파일을 읽지 못했습니다 (${actionsRelPath}): ${e instanceof Error ? e.message : String(e)}`,
+            };
+        }
+        // timeout 은 서버 상한으로 고정 — 액션 파일이 제시한 값을 그대로 믿지 않는다.
+        return toExecResult(await this.req({
+            kind: 'browser',
+            spec: { ...(spec as Record<string, unknown>), timeoutMs: LOCAL_BRIDGE.BROWSER_TIMEOUT_MS },
+        }));
     }
 
     async writeFile(relPath: string, content: string | Buffer): Promise<void> {

--- a/apps/desktop/agent-browser.js
+++ b/apps/desktop/agent-browser.js
@@ -1,0 +1,331 @@
+// Local Agent Browser (Cowork D3) — 서버 Agent Task 의 `browser` 도구를
+// **데스크톱 Electron 내장 Chromium** 에서 실행한다. Playwright 를 번들하지 않으므로
+// 앱 크기 증가가 없고, 사용자가 화면으로 보면서 언제든 중단할 수 있다.
+//
+// 출력 계약은 컨테이너 경로(infra/task-runtime/browser-runner.mjs)와 **동일**하게 맞춘다:
+//   { ok, finalUrl, results: [{ i, type, ok, ... }] }
+// 서버측 파싱·프롬프트를 그대로 재사용하기 위함.
+//
+// 보안 불변식:
+//  - 전용 세션 파티션(persist:openmake-agent) — 사용자 개인 Chrome 쿠키·로그인 미접근
+//  - allowlist 가 있으면 비허용 호스트 요청을 webRequest 로 차단
+//  - file:// 및 그 외 비 http(s) 스킴 차단 (로컬 파일 열람 방지)
+//  - 항상 화면에 보이는 View — 백그라운드 은닉 실행 금지
+//  - 다운로드는 연결 폴더 안으로만 저장(경로 이탈 차단)
+const { WebContentsView, session } = require('electron');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const PARTITION = 'persist:openmake-agent';
+const DEFAULT_TIMEOUT_MS = 60_000;
+/** 멀티탭 확장 대비 — 지금은 1개만 쓰지만 자료구조는 맵으로 둔다(D3 후속). */
+const tabs = new Map();
+const MAX_TABS = 1;
+
+let getWindow = () => null;
+let getFolderRoot = () => null;
+
+function configure(opts) {
+  if (opts.getWindow) getWindow = opts.getWindow;
+  if (opts.getFolderRoot) getFolderRoot = opts.getFolderRoot;
+}
+
+/* ── 세션 · 보안 ─────────────────────────────────────────── */
+
+let sessionReady = false;
+
+/** 전용 파티션 세션을 준비하고 allowlist·다운로드 정책을 건다. */
+function ensureSession(allowlist) {
+  const ses = session.fromPartition(PARTITION);
+  // allowlist 는 호출마다 바뀔 수 있으므로 핸들러를 매번 다시 건다(중복 등록 방지 위해 null 로 해제 후 설정).
+  ses.webRequest.onBeforeRequest(null);
+  ses.webRequest.onBeforeRequest({ urls: ['<all_urls>'] }, (details, cb) => {
+    let u;
+    try { u = new URL(details.url); } catch { return cb({ cancel: true }); }
+    // http(s) 외 스킴 전면 차단 — file:// 로 로컬 파일을 읽는 경로를 막는다.
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return cb({ cancel: true });
+    if (!hostAllowed(u.hostname, allowlist)) return cb({ cancel: true });
+    cb({ cancel: false });
+  });
+
+  if (!sessionReady) {
+    // 다운로드: 연결 폴더 안으로만. 폴더 미연결이면 취소.
+    ses.on('will-download', (_event, item) => {
+      const root = getFolderRoot();
+      if (!root) { item.cancel(); return; }
+      const name = path.basename(item.getFilename() || 'download');
+      const dest = path.join(root, name);
+      // 경로 이탈 방어 — basename 을 썼어도 realpath 기준으로 한 번 더 확인.
+      const rootReal = fs.realpathSync(root);
+      if (!path.resolve(dest).startsWith(rootReal + path.sep) && path.resolve(dest) !== rootReal) {
+        item.cancel(); return;
+      }
+      item.setSavePath(dest);
+    });
+    // 새 창 요청은 외부 브라우저로 넘기지 않고 무시(에이전트가 goto 로만 이동).
+    sessionReady = true;
+  }
+  return ses;
+}
+
+function hostAllowed(hostname, allowlist) {
+  if (!Array.isArray(allowlist) || allowlist.length === 0) return true;
+  const h = String(hostname || '').toLowerCase();
+  return allowlist.some((d) => {
+    const dd = String(d).toLowerCase();
+    return h === dd || h.endsWith('.' + dd);
+  });
+}
+
+/* ── 탭 생명주기 ─────────────────────────────────────────── */
+
+function ensureTab(allowlist) {
+  const win = getWindow();
+  if (!win) throw new Error('데스크톱 창이 없습니다');
+  const ses = ensureSession(allowlist);
+
+  let tab = tabs.get('default');
+  if (tab && !tab.view.webContents.isDestroyed()) return tab;
+
+  const view = new WebContentsView({
+    webPreferences: { session: ses, contextIsolation: true, nodeIntegration: false, sandbox: true },
+  });
+  win.contentView.addChildView(view);
+  layout(view);
+  win.on('resize', () => layout(view));
+  tab = { view };
+  tabs.set('default', tab);
+  return tab;
+}
+
+/** 창 하단 60% 를 브라우저 패널로 — 사용자가 진행 상황을 본다. */
+function layout(view) {
+  const win = getWindow();
+  if (!win || view.webContents.isDestroyed()) return;
+  const [w, h] = win.getContentSize();
+  const top = Math.round(h * 0.4);
+  view.setBounds({ x: 0, y: top, width: w, height: h - top });
+}
+
+function closeAll() {
+  const win = getWindow();
+  for (const [, tab] of tabs) {
+    try {
+      if (win) win.contentView.removeChildView(tab.view);
+      tab.view.webContents.close();
+    } catch { /* 이미 파기됨 */ }
+  }
+  tabs.clear();
+}
+
+/* ── 페이지 내 실행 스크립트 ──────────────────────────────
+ * Playwright 의 getByRole/ariaSnapshot 에 대응하는 API 가 Electron 에 없으므로
+ * DOM 을 직접 순회해 {role,name} 을 산출한다(D3c). 완전한 접근성 트리는 아니지만
+ * 상호작용 요소 식별에는 충분하다 — 목적이 "CSS 셀렉터가 깨졌을 때의 폴백" 이기 때문.
+ */
+const A11Y_LIB = `
+(() => {
+  const ROLE_BY_TAG = { a:'link', button:'button', select:'combobox', textarea:'textbox', summary:'button' };
+  const INPUT_ROLE = { checkbox:'checkbox', radio:'radio', button:'button', submit:'button',
+                       reset:'button', search:'searchbox', email:'textbox', tel:'textbox',
+                       text:'textbox', password:'textbox', url:'textbox', number:'spinbutton' };
+  function roleOf(el) {
+    const explicit = el.getAttribute && el.getAttribute('role');
+    if (explicit) return explicit.trim().split(/\\s+/)[0];
+    const tag = el.tagName.toLowerCase();
+    if (tag === 'input') return INPUT_ROLE[(el.type || 'text').toLowerCase()] || 'textbox';
+    if (/^h[1-6]$/.test(tag)) return 'heading';
+    return ROLE_BY_TAG[tag] || null;
+  }
+  function nameOf(el) {
+    const byLabel = el.getAttribute && el.getAttribute('aria-label');
+    if (byLabel) return byLabel.trim();
+    const ref = el.getAttribute && el.getAttribute('aria-labelledby');
+    if (ref) { const t = document.getElementById(ref); if (t) return (t.innerText || '').trim(); }
+    if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
+      if (el.labels && el.labels[0]) return (el.labels[0].innerText || '').trim();
+      return (el.placeholder || el.getAttribute('title') || el.value || '').trim();
+    }
+    if (el.tagName === 'IMG') return (el.alt || '').trim();
+    return ((el.innerText || el.textContent || '').trim()).slice(0, 120);
+  }
+  function visible(el) {
+    const r = el.getBoundingClientRect();
+    if (r.width === 0 && r.height === 0) return false;
+    const s = getComputedStyle(el);
+    return s.visibility !== 'hidden' && s.display !== 'none';
+  }
+  window.__omkCollect = function () {
+    const sel = 'a,button,input,select,textarea,summary,[role],[onclick],[tabindex]';
+    const out = [];
+    for (const el of document.querySelectorAll(sel)) {
+      if (!visible(el)) continue;
+      const role = roleOf(el);
+      if (!role) continue;
+      out.push({ role, name: nameOf(el), el });
+      if (out.length >= 300) break;
+    }
+    window.__omkEls = out.map((o) => o.el);
+    return out.map((o, i) => ({ index: i, role: o.role, name: o.name }));
+  };
+  window.__omkFind = function (role, name, nth) {
+    const list = window.__omkCollect();
+    const want = String(name || '').trim().toLowerCase();
+    const hits = list.filter((e) => e.role === role &&
+      (want === '' || e.name.toLowerCase() === want || e.name.toLowerCase().includes(want)));
+    const hit = hits[Number(nth) || 0];
+    return hit ? hit.index : -1;
+  };
+})();`;
+
+/** 페이지에서 JS 실행 — 항상 A11Y_LIB 를 먼저 주입해 헬퍼를 보장한다. */
+async function evalInPage(wc, expr) {
+  await wc.executeJavaScript(A11Y_LIB, true);
+  return wc.executeJavaScript(expr, true);
+}
+
+const jsStr = (v) => JSON.stringify(String(v ?? ''));
+
+/** 셀렉터 등장 대기(폴링) — Playwright waitForSelector 대응. */
+async function waitForSelector(wc, selector, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const found = await evalInPage(wc, `!!document.querySelector(${jsStr(selector)})`);
+    if (found) return true;
+    if (Date.now() > deadline) throw new Error(`waitFor 시간 초과: ${selector}`);
+    await new Promise((r) => setTimeout(r, 120));
+  }
+}
+
+function loadUrl(wc, url, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => { cleanup(); reject(new Error(`goto 시간 초과: ${url}`)); }, timeoutMs);
+    const ok = () => { cleanup(); resolve(); };
+    const fail = (_e, code, desc) => { cleanup(); reject(new Error(`goto 실패(${code}): ${desc || url}`)); };
+    function cleanup() {
+      clearTimeout(timer);
+      wc.off('did-finish-load', ok);
+      wc.off('did-fail-load', fail);
+    }
+    wc.on('did-finish-load', ok);
+    wc.on('did-fail-load', fail);
+    wc.loadURL(url).catch(fail);
+  });
+}
+
+/**
+ * 액션 배열 실행 — 컨테이너 runner 와 동일한 결과 계약을 반환한다.
+ * @param {{actions: any[], allowlist?: string[], timeoutMs?: number}} spec
+ */
+async function runActions(spec) {
+  const actions = Array.isArray(spec?.actions) ? spec.actions : [];
+  const allowlist = Array.isArray(spec?.allowlist) ? spec.allowlist : null;
+  const timeout = Math.min(Number(spec?.timeoutMs) || DEFAULT_TIMEOUT_MS, DEFAULT_TIMEOUT_MS);
+  const results = [];
+  let finalUrl = '';
+
+  let wc;
+  try {
+    wc = ensureTab(allowlist).view.webContents;
+  } catch (e) {
+    return { ok: false, error: e.message, results };
+  }
+
+  for (let i = 0; i < actions.length; i++) {
+    const a = actions[i] || {};
+    try {
+      switch (a.type) {
+        case 'goto': {
+          const u = new URL(String(a.url));
+          if (u.protocol !== 'http:' && u.protocol !== 'https:') throw new Error('http(s) URL 만 허용됩니다');
+          if (!hostAllowed(u.hostname, allowlist)) throw new Error(`허용되지 않은 호스트: ${u.hostname}`);
+          await loadUrl(wc, u.toString(), timeout);
+          results.push({ i, type: a.type, ok: true }); break;
+        }
+        case 'click': {
+          const r = await evalInPage(wc, `(() => { const e=document.querySelector(${jsStr(a.selector)}); if(!e) return 'notfound'; e.click(); return 'ok'; })()`);
+          if (r !== 'ok') throw new Error(`요소를 찾지 못했습니다: ${a.selector}`);
+          results.push({ i, type: a.type, ok: true }); break;
+        }
+        case 'fill': {
+          const r = await evalInPage(wc, `(() => { const e=document.querySelector(${jsStr(a.selector)}); if(!e) return 'notfound';
+            e.focus(); e.value=${jsStr(a.text)};
+            e.dispatchEvent(new Event('input',{bubbles:true})); e.dispatchEvent(new Event('change',{bubbles:true})); return 'ok'; })()`);
+          if (r !== 'ok') throw new Error(`요소를 찾지 못했습니다: ${a.selector}`);
+          results.push({ i, type: a.type, ok: true }); break;
+        }
+        case 'press': {
+          const key = String(a.key || '');
+          wc.sendInputEvent({ type: 'keyDown', keyCode: key });
+          wc.sendInputEvent({ type: 'keyUp', keyCode: key });
+          results.push({ i, type: a.type, ok: true }); break;
+        }
+        case 'wait':
+          await new Promise((r) => setTimeout(r, Math.min(Number(a.ms) || 0, timeout)));
+          results.push({ i, type: a.type, ok: true }); break;
+        case 'waitFor':
+          await waitForSelector(wc, String(a.selector), timeout);
+          results.push({ i, type: a.type, ok: true }); break;
+        case 'screenshot': {
+          // ⚠️ capturePage 는 **창이 화면에 표시돼 있어야** 유효한 이미지를 준다.
+          //    창이 숨겨졌거나 최소화된 상태면 빈 이미지/실패가 된다(실측 확인).
+          //    에이전트 브라우저는 어차피 항상 보이는 패널이므로 정상 경로에서는 문제없다.
+          const win = getWindow();
+          if (win && (!win.isVisible() || win.isMinimized())) {
+            throw new Error('창이 보이지 않아 스크린샷을 찍을 수 없습니다 (창을 복원한 뒤 다시 시도하세요)');
+          }
+          const img = await wc.capturePage();
+          const root = getFolderRoot();
+          if (!root) throw new Error('연결된 폴더가 없어 스크린샷을 저장할 수 없습니다');
+          const rel = path.basename(String(a.path || `screenshot-${Date.now()}.png`));
+          fs.writeFileSync(path.join(root, rel), img.toPNG());
+          results.push({ i, type: a.type, ok: true, path: rel }); break;
+        }
+        case 'extractText': {
+          const expr = a.selector
+            ? `(() => { const e=document.querySelector(${jsStr(a.selector)}); return e ? (e.innerText||'') : null; })()`
+            : `document.body ? (document.body.innerText||'') : ''`;
+          const text = await evalInPage(wc, expr);
+          if (text === null) throw new Error(`요소를 찾지 못했습니다: ${a.selector}`);
+          results.push({ i, type: a.type, ok: true, text: String(text).slice(0, 50000) }); break;
+        }
+        case 'extractHtml': {
+          const expr = a.selector
+            ? `(() => { const e=document.querySelector(${jsStr(a.selector)}); return e ? e.outerHTML : null; })()`
+            : `document.documentElement.outerHTML`;
+          const html = await evalInPage(wc, expr);
+          if (html === null) throw new Error(`요소를 찾지 못했습니다: ${a.selector}`);
+          results.push({ i, type: a.type, ok: true, html: String(html).slice(0, 50000) }); break;
+        }
+        /* ── D3c: CSS 가 깨졌을 때의 role/name 폴백 ── */
+        case 'snapshot': {
+          const elements = await evalInPage(wc, `window.__omkCollect()`);
+          results.push({ i, type: a.type, ok: true, elements: (elements || []).slice(0, 100) }); break;
+        }
+        case 'smartClick': {
+          const idx = await evalInPage(wc, `window.__omkFind(${jsStr(a.role)}, ${jsStr(a.name)}, ${Number(a.nth) || 0})`);
+          if (idx < 0) throw new Error(`role=${a.role} name=${a.name} 요소를 찾지 못했습니다`);
+          await evalInPage(wc, `(() => { window.__omkCollect(); window.__omkEls[${idx}].click(); return 'ok'; })()`);
+          results.push({ i, type: a.type, ok: true }); break;
+        }
+        case 'smartFill': {
+          const idx = await evalInPage(wc, `window.__omkFind(${jsStr(a.role)}, ${jsStr(a.name)}, ${Number(a.nth) || 0})`);
+          if (idx < 0) throw new Error(`role=${a.role} name=${a.name} 요소를 찾지 못했습니다`);
+          await evalInPage(wc, `(() => { window.__omkCollect(); const e=window.__omkEls[${idx}];
+            e.focus(); e.value=${jsStr(a.text)};
+            e.dispatchEvent(new Event('input',{bubbles:true})); e.dispatchEvent(new Event('change',{bubbles:true})); return 'ok'; })()`);
+          results.push({ i, type: a.type, ok: true }); break;
+        }
+        default:
+          throw new Error(`지원하지 않는 액션: ${a.type}`);
+      }
+    } catch (e) {
+      results.push({ i, type: a?.type, ok: false, error: e.message });
+      break; // 컨테이너 runner 와 동일 — 실패 시 중단
+    }
+  }
+  try { finalUrl = wc.getURL(); } catch { /* 파기됨 */ }
+  return { ok: results.length > 0 && results.every((r) => r.ok), finalUrl, results };
+}
+
+module.exports = { configure, runActions, closeAll, MAX_TABS };

--- a/apps/desktop/bridge.js
+++ b/apps/desktop/bridge.js
@@ -4,6 +4,8 @@
 //
 // 보안 불변식:
 //  - 고정 kind 화이트리스트만 처리 (임의 RPC 거부)
+//  - browser kind(D3): 전용 세션 파티션의 Electron 내장 Chromium. 개인 브라우저와 분리,
+//    http(s) 외 스킴·비allowlist 호스트 차단, 다운로드는 연결 폴더 안으로만
 //  - 파일 kind(read/write/list/delete)의 경로는 연결 폴더 realpath 스코프 안에서만
 //    해석 (심링크 탈출 차단)
 //  - exec 3단 방어: ① 명백히 위험한 패턴을 디바이스에서 hard-block(EXEC_DENYLIST)
@@ -18,6 +20,7 @@ const path = require('path');
 const { execFile } = require('child_process');
 const crypto = require('crypto');
 const WebSocket = require('ws');
+const agentBrowser = require('./agent-browser');
 
 const EXEC_TIMEOUT_MS = 120000;
 const MAX_BUFFER = 1024 * 1024;
@@ -194,7 +197,22 @@ async function handleExec(m, done) {
       fs.rmSync(abs, { recursive: true, force: true });
       done({ ok: true }); return;
     }
-    case 'task_end': done({ ok: true }); return;
+    case 'browser': {
+      // 로컬 브라우저(D3) — Electron 내장 Chromium 에서 액션 실행.
+      // 전용 세션 파티션이라 사용자 개인 브라우저와 분리되고, 화면에 보이는 패널로 뜬다.
+      try {
+        agentBrowser.configure({ getWindow: () => mainWin, getFolderRoot: () => folderRoot });
+        const out = await agentBrowser.runActions(m.spec || {});
+        // 컨테이너 runner 와 동일하게 stdout 에 JSON 을 싣는다(서버 파싱 재사용).
+        done({ ok: true, stdout: JSON.stringify(out), exitCode: out.ok ? 0 : 1 });
+      } catch (e) {
+        done({ ok: false, error: `로컬 브라우저 실행 실패: ${e.message}` });
+      }
+      return;
+    }
+    case 'task_end':
+      agentBrowser.closeAll();   // 작업 종료 시 브라우저 패널 정리
+      done({ ok: true }); return;
     default: done({ ok: false, error: `지원하지 않는 kind: ${m.kind}` });
   }
 }

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -7,6 +7,7 @@ const { app, BrowserWindow, Menu, shell } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const bridge = require('./bridge');
+const agentBrowser = require('./agent-browser');
 const updater = require('./updater');
 
 const BACKENDS = {
@@ -130,6 +131,9 @@ function buildMenu() {
           click: () => { const f = bridge.getFolderPath(); if (f) shell.openPath(f); },
         },
         { label: '연결 해제', enabled: bridge.isConnected(), click: () => bridge.disconnectFolder() },
+        { type: 'separator' },
+        // D3 — 에이전트 브라우저는 작업 중 화면 하단에 뜬다. 사용자가 언제든 닫을 수 있어야 한다.
+        { label: '에이전트 브라우저 닫기', click: () => agentBrowser.closeAll() },
       ],
     },
     { role: 'editMenu' },


### PR DESCRIPTION
## 문제

로컬 실행기(`executor='local'`)는 `runBrowser` 를 지원하지 않았다. 사용자 폴더에서 작업하다 웹이 필요하면 이렇게 막혔다.

```
로컬 실행 작업에서는 browser 도구를 지원하지 않습니다(D1).
```

## 접근 — Playwright 를 번들하지 않는다

openwork(`different-ai/openwork`) 를 조사한 결과 **Playwright 의존이 없고** `apps/desktop/electron/browser-panel.mjs` 가 **Electron 내장 Chromium(`WebContentsView`) + 격리 세션 파티션**을 쓴다. 우리도 이미 Electron 셸이 있으므로 같은 방식이 가능하다.

- Playwright 번들 ≈300MB → **앱 크기 증가 0**
- 사용자가 **화면으로 보면서** 언제든 중단 가능

## 설계 제약 — 서버를 건드리지 않는다

**출력 계약을 컨테이너 runner 와 동일**하게 맞췄다 (`{ok, finalUrl, results[]}` JSON in stdout).

```
[서버] browser 도구 (승인 HIGH_RISK, 액션 12종, allowlist)
          ↓ executor.runBrowser(actionsRelPath)
   ├ TaskSandbox    → 컨테이너 + Playwright     (무변경)
   └ RemoteExecutor → bridge kind:'browser'     (신규)
                        ↓
[데스크톱] WebContentsView(격리 세션) → 액션 실행
```

`TaskExecutor` 인터페이스(D0) 덕에 **실행기만 갈아끼우면 되고**, 도구 스키마·프롬프트·승인 게이트는 그대로다.

## 액션 12종 전부 지원

| 계열 | 액션 | 구현 |
|---|---|---|
| CSS (9) | `goto` `click` `fill` `press` `wait` `waitFor` `screenshot` `extractText` `extractHtml` | `loadURL` · `executeJavaScript` · `capturePage` · `sendInputEvent` |
| a11y (3) | `snapshot` `smartClick` `smartFill` | **DOM 순회로 role/name 직접 산출** |

⚠️ Electron 에는 Playwright 의 `ariaSnapshot()`/`getByRole()` 대응 API가 **없다**. `A11Y_LIB` 로 접근성 정보를 직접 만든다 — role 은 tag·input type 매핑, name 은 `aria-label > labelledby > label > placeholder > alt > textContent` 우선순위. 완전한 접근성 트리는 아니지만 목적(CSS 셀렉터가 깨졌을 때의 폴백)에는 충분하다.

## 보안

| 항목 | 방식 |
|---|---|
| 세션 격리 | 전용 파티션 `persist:openmake-agent` — **개인 Chrome 쿠키·로그인 미접근** |
| 도메인 제한 | `allowlist` 밖 호스트 차단(`webRequest`) — 컨테이너 `context.route` 대응 |
| 스킴 | http(s) 외 **전면 차단** — `file://` 로컬 파일 읽기 봉쇄 |
| 다운로드 | 연결 폴더 안으로만 (`basename` + realpath 이탈 차단) |
| 가시성 | 항상 보이는 패널(창 하단 60%). `task_end`·메뉴에서 정리 |
| 브리지 원칙 | `kind` 하나 추가 — **임의 RPC 를 여는 것이 아님** |
| 게이트 | `LOCAL_BRIDGE_BROWSER_ENABLED` **기본 OFF** |

## 검증

**Electron 런타임 실측 9/9 PASS**

| 항목 | 결과 |
|---|---|
| goto + extractText + screenshot | PASS (`Example Domain` 추출, 파일 생성) |
| snapshot 요소 수집 | PASS (`{index:0, role:'link', name:'Learn more'}`) |
| smartClick(role/name) | PASS |
| allowlist 밖 호스트 차단 | PASS |
| `file://` 스킴 거부 | PASS |
| 세션 격리 | PASS |

⚠️ **실측 발견**: `capturePage()` 는 **창이 표시돼 있어야** 유효하다(숨김/최소화 시 실패). 가드를 넣어 명확한 에러 메시지로 바꿨다.

**정적**: 서버 계약 유닛 8건 추가(allowlist 매칭 규칙·결과 형태), 전체 **2240 passed**, `tsc` 0, eslint 0. **컨테이너 브라우저 경로 무변경**(task-sandbox 77건 통과).

## 결정 사항

1. **다운로드 허용** — 연결 폴더 안으로만
2. **단일 탭** — `tabs` Map + `MAX_TABS=1`, 멀티탭은 자료구조 변경 없이 확장 가능
3. **`executor='local'` 일 때만** — 서버 모드에서 섞어 쓰는 구성은 실익이 작아 제외(격리 세션이라 사용자 로그인도 못 씀)

## 남은 것

- 운영 게이트 활성화는 별도 판단 (기본 OFF)
- 멀티탭·주소 표시줄 UI
- `press` 특수키 매핑이 Playwright 와 완전 동일하지 않을 수 있음 — 실사용 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)