### PR TITLE
chore(desktop): v1.7.0 — 에이전트 browser 도구(Cowork D3) 반영 버전 bump

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openmake-desktop",
-  "version": "1.0.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openmake-desktop",
-      "version": "1.0.0",
+      "version": "1.7.0",
       "dependencies": {
         "ws": "^8.18.0"
       },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmake-desktop",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "description": "OpenMake LLM 데스크톱 셸 (macOS) — 운영 백엔드(외부 공개 도메인 / 로컬)를 네이티브 창으로",
   "author": "OpenMake Team",


### PR DESCRIPTION
## 요약
- 데스크톱 앱 버전 1.6.0 → 1.7.0 bump
- PR #398(에이전트 browser 도구를 로컬 Electron Chromium 에서 실행, Cowork D3)의 `apps/desktop` 변경(agent-browser.js/bridge.js/main.js)을 배포본에 반영하기 위한 재빌드 버전

## 배포 상태
- `OpenMake-1.7.0-arm64.dmg` 빌드 완료 (electron-builder 25.1.8, 미서명 — 자체 업데이터 sha256 검증 방식)
- `scripts/publish-desktop.sh` 로 게시 완료 — `/api/desktop/latest` 가 v1.7.0 서빙 확인 (로컬·공개 도메인 모두)

🤖 Generated with [Claude Code](https://claude.com/claude-code)