### PR TITLE
fix(desktop): v1.7.1 — asar 에 agent-browser.js 누락 수정 (창 미표시 결함)

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openmake-desktop",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openmake-desktop",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "dependencies": {
         "ws": "^8.18.0"
       },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmake-desktop",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "description": "OpenMake LLM 데스크톱 셸 (macOS) — 운영 백엔드(외부 공개 도메인 / 로컬)를 네이티브 창으로",
   "author": "OpenMake Team",
@@ -27,7 +27,8 @@
     "files": [
       "main.js",
       "bridge.js",
-      "updater.js"
+      "updater.js",
+      "agent-browser.js"
     ],
     "afterPack": "afterPack.js",
     "mac": {


### PR DESCRIPTION
## 문제

v1.7.0 패키징 앱(dmg)은 **실행해도 창이 아예 뜨지 않는다.**

- `apps/desktop/package.json` 의 electron-builder `build.files` 화이트리스트가 `main.js/bridge.js/updater.js` 뿐이라, #398(Cowork D3)에서 추가된 **`agent-browser.js` 가 app.asar 에 누락**
- 배포된 main.js 10행 `require('./agent-browser')` 가 기동 즉시 throw → `BrowserWindow` 미생성 (GPU·network 헬퍼만 뜨고 렌더러 0, 메인 프로세스는 오류 다이얼로그 대기로 잔존)
- dev 실행(`npx electron .`)은 파일이 디스크에 있어 정상 → 기존 검증에서 미검출
- 깨진 1.7.0 은 updater 도 못 돌므로 자체 업데이트로 복구 불가 (수동 재설치 필요)

## 수정

- `build.files` 에 `agent-browser.js` 추가
- v1.7.1 bump (package.json + package-lock.json)

## 검증 (라이브)

- 재빌드 asar 목록에 `/agent-browser.js` 포함 확인
- 빌드본·설치본(`/Applications`) 모두 기동 2초 내 Renderer 헬퍼 생성(창 표시), `codesign --verify --deep` 통과
- `scripts/publish-desktop.sh` 게시 완료 — `GET /api/desktop/latest` 가 로컬·chat.openmake.cc 모두 v1.7.1 + sha256 일치 서빙

## 재발 방지 메모

`files` 는 화이트리스트라 apps/desktop 에 새 .js 모듈 추가 시 동기화 필수. afterPack 에서 main.js require 대상 존재 검증 추가는 후속 제안.

🤖 Generated with [Claude Code](https://claude.com/claude-code)