### PR TITLE
fix(desktop): afterPack 에 asar 로컬 require 검증 추가 (build.files 누락 재발 방지)

### DIFF
--- a/apps/desktop/afterPack.js
+++ b/apps/desktop/afterPack.js
@@ -4,11 +4,31 @@
 // dmg 패키징 직전(앱 pack 직후) 번들 전체를 ad-hoc 로 재서명해 Sealed Resources 를 채운다.
 const { execFileSync } = require('child_process');
 const path = require('path');
+const asar = require('@electron/asar');
+
+// asar 로컬 require 검증 — build.files 는 화이트리스트라 새 .js 모듈을 추가하고
+// files 에 안 넣으면 dev 는 정상인데 패키징 앱만 기동 즉시 죽는다(v1.7.0 agent-browser.js
+// 누락 사고: require throw → 창 미표시). 패키징된 각 .js 의 `require('./x')` 대상이
+// asar 안에 실재하는지 빌드에서 검증해 같은 사고를 배포 전에 잡는다.
+function assertLocalRequiresPacked(appPath) {
+  const asarPath = path.join(appPath, 'Contents', 'Resources', 'app.asar');
+  const entries = new Set(asar.listPackage(asarPath).map((p) => p.replace(/\\/g, '/')));
+  for (const entry of [...entries].filter((p) => /^\/[^/]+\.js$/.test(p))) {
+    const src = asar.extractFile(asarPath, entry.slice(1)).toString('utf8');
+    for (const m of src.matchAll(/require\(\s*['"]\.\/([\w.-]+?)(?:\.js)?['"]\s*\)/g)) {
+      const dep = `/${m[1]}.js`;
+      if (!entries.has(dep)) {
+        throw new Error(`asar 누락 모듈: ${entry} 가 require 하는 ${dep} 가 패키징에 없음 — package.json build.files 에 추가하세요`);
+      }
+    }
+  }
+}
 
 exports.default = async function afterPack(context) {
   if (context.electronPlatformName !== 'darwin') return;
   const appName = context.packager.appInfo.productFilename; // OpenMake
   const appPath = path.join(context.appOutDir, `${appName}.app`);
+  assertLocalRequiresPacked(appPath);
   execFileSync('codesign', ['--force', '--deep', '--sign', '-', appPath], { stdio: 'inherit' });
   execFileSync('codesign', ['--verify', '--deep', '--strict', appPath], { stdio: 'inherit' });
 };


### PR DESCRIPTION
## 배경

#401 에서 고친 v1.7.0 사고의 재발 방지. `build.files` 는 화이트리스트라 apps/desktop 에 새 .js 모듈을 추가하고 files 동기화를 빠뜨리면 **dev 는 정상 · 패키징 앱만 기동 즉시 죽는** 결함이 조용히 배포된다.

## 변경

`afterPack.js` 에 `assertLocalRequiresPacked()` 추가 — 패키징된 app.asar 의 최상위 `.js` 각각을 스캔해 `require('./x')` 대상이 asar 안에 실재하는지 확인, 없으면 빌드를 실패시킨다(코드사인 전에 fail-fast). `@electron/asar` 는 electron-builder 의존성 트리로 이미 존재.

## 검증 (로컬 실측)

- **음성**: `files` 에서 `agent-browser.js` 를 일시 제거 후 `electron-builder --mac dir` → exit 1, `asar 누락 모듈: /bridge.js 가 require 하는 /agent-browser.js 가 패키징에 없음 — package.json build.files 에 추가하세요`
- **양성**: 정상 구성 빌드 → exit 0, 서명 단계까지 정상 수행

앱 런타임 코드 무변경(빌드 훅만)이라 버전 bump·재게시는 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)