### PR TITLE
docs(readme): 마이그레이션 부팅 자동 적용·버전 배지 동적화

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   <a href="https://github.com/openmake/openmake_llm/actions/workflows/ci.yml"><img src="https://github.com/openmake/openmake_llm/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
-  <img src="https://img.shields.io/badge/version-1.5.6-green.svg" alt="Version" />
+  <img src="https://img.shields.io/github/package-json/v/openmake/openmake_llm?label=version&color=green" alt="Version" />
   <img src="https://img.shields.io/badge/node-%3E%3D24%20%3C25-brightgreen.svg" alt="Node >=24 <25" />
   <img src="https://img.shields.io/badge/TypeScript-strict-3178c6.svg" alt="TypeScript strict" />
   <img src="https://img.shields.io/badge/Next.js-16-black.svg" alt="Next.js 16" />
@@ -222,7 +222,7 @@ npm run lint                # ESLint
 
 ### Database migrations
 
-Files in `db/migrations/` are **not** auto-applied on boot (only `db/init/` schema is) — run migrations with the CLI:
+Files in `db/migrations/` are applied **automatically on boot** — after the `db/init/` baseline schema, pending migrations run under a PostgreSQL advisory lock (serializing multi-instance startups) and failures fail fast. Set `DB_AUTO_MIGRATE=false` to opt out and run them manually with the CLI:
 
 ```bash
 npx ts-node apps/api/src/data/migrations/cli.ts status    # show pending


### PR DESCRIPTION
README 검토 중 발견한 낡은 서술 2건 정정 (문서 변경만, 코드 델타 0):

1. **Database migrations** — "not auto-applied on boot" 서술은 2026-07-22 부팅 자동 적용 전환(`server.ts` → `applyPendingWithLock`, advisory lock 직렬화, `DB_AUTO_MIGRATE=false` opt-out) 이전의 내용이라 실제 동작으로 정정.
2. **버전 배지** — 하드코딩 `1.5.6`(실제 1.16.1)을 shields.io `github/package-json/v` 동적 배지로 교체 — release-please 버전 bump 를 자동 추종해 재발 방지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)