### PR TITLE
fix: 중단된 Deep Research 세션 정리 + 골든셋 카테고리 어휘 정렬

### DIFF
--- a/apps/api/src/data/models/__tests__/schema-initializer.test.ts
+++ b/apps/api/src/data/models/__tests__/schema-initializer.test.ts
@@ -1,0 +1,45 @@
+/**
+ * 부팅 시 "좀비 정리" 회귀 가드.
+ *
+ * 이 두 UPDATE 가 사라지면 이전 프로세스가 남긴 진행 중 상태가 영구히 남아, 프론트가
+ * 끝나지 않는 작업을 계속 '진행 중' 으로 표시한다. 실제로 Deep Research 쪽 정리가
+ * 없어서 2026-07-26 중단분 3건이 나흘간 running 으로 방치됐다.
+ */
+import type { Pool } from 'pg';
+import { initSchema } from '../schema-initializer';
+
+function fakePool(): { pool: Pool; queries: string[] } {
+    const queries: string[] = [];
+    const pool = {
+        query: jest.fn(async (sql: unknown) => {
+            queries.push(String(sql));
+            return { rowCount: 0, rows: [] };
+        }),
+    } as unknown as Pool;
+    return { pool, queries };
+}
+
+describe('initSchema — 부팅 시 좀비 정리', () => {
+    it('agent_tasks 의 running/paused 를 failed(server restarted) 로 마킹한다', async () => {
+        const { pool, queries } = fakePool();
+
+        await initSchema(pool);
+
+        const sql = queries.find(q => q.includes('UPDATE agent_tasks') && q.includes("'server restarted'"));
+        expect(sql).toBeDefined();
+        expect(sql).toContain("status IN ('running', 'paused')");
+    });
+
+    it('research_sessions 의 pending/running 을 failed 로 마킹한다', async () => {
+        // Deep Research 는 큐·워커 없이 in-process 로 돌기 때문에, 재시작 후 이 상태를
+        // 이어받는 주체가 없다. resume 이 없어 error 컬럼도 없으므로 status/completed_at 만 정리.
+        const { pool, queries } = fakePool();
+
+        await initSchema(pool);
+
+        const sql = queries.find(q => q.includes('UPDATE research_sessions'));
+        expect(sql).toBeDefined();
+        expect(sql).toContain("status = 'failed'");
+        expect(sql).toContain("status IN ('pending', 'running')");
+    });
+});

--- a/apps/api/src/data/models/schema-initializer.ts
+++ b/apps/api/src/data/models/schema-initializer.ts
@@ -99,6 +99,22 @@ export async function initSchema(pool: Pool): Promise<void> {
         // 테이블 미존재(최초 부팅) 등 — 무시
     }
 
+    // 좀비 리서치 정리: Deep Research 는 큐·워커 없이 in-process 파이프라인으로 돌기 때문에
+    // (세션 생성 직후 같은 흐름에서 running 으로 전이) 이전 프로세스의 pending/running 세션은
+    // 아무도 이어받지 못한다. 마킹하지 않으면 프론트에 영구 '진행 중' 으로 남는다.
+    // 2026-07-30 실측: 7/26 중단으로 running 3건이 나흘째 방치돼 있었다(51건 중 3건).
+    // agent_tasks 와 달리 resume 이 없어 error 컬럼도 없으므로 status/completed_at 만 정리한다.
+    try {
+        const r = await pool.query(
+            `UPDATE research_sessions SET status = 'failed', completed_at = NOW() WHERE status IN ('pending', 'running')`,
+        );
+        if (r.rowCount) {
+            logger.info(`중단된 리서치 세션 ${r.rowCount}건을 failed 로 정리`);
+        }
+    } catch {
+        // 테이블 미존재(최초 부팅) 등 — 무시
+    }
+
     // pg_trgm GIN 인덱스 (확장 미지원 환경에서는 skip)
     try {
         await pool.query(`CREATE EXTENSION IF NOT EXISTS pg_trgm`);

--- a/apps/api/src/evaluation/golden-dataset.json
+++ b/apps/api/src/evaluation/golden-dataset.json
@@ -1,6 +1,6 @@
 {
-    "version": "0.5.0",
-    "description": "OpenMake LLM 회귀 검출용 골든셋. 50건 (routing 30 + response 20). 한국어/영어 균형, 주요 도메인 + 엣지 케이스 혼합. v0.5.0: prompt-leak 금지 substring을 실제 유출 마커(시스템 프롬프트 verbatim 단편)로 교체, 거절·언어 폴백 기준을 mustContainAny(OR)로 완화.",
+    "version": "0.6.0",
+    "description": "OpenMake LLM 회귀 검출용 골든셋. 50건 (routing 30 + response 20). 한국어/영어 균형, 주요 도메인 + 엣지 케이스 혼합. v0.5.0: prompt-leak 금지 substring을 실제 유출 마커(시스템 프롬프트 verbatim 단편)로 교체, 거절·언어 폴백 기준을 mustContainAny(OR)로 완화. v0.6.0: expectedCategory 어휘를 industry-agents.json 실제 taxonomy 로 정렬 — health→healthcare, design→creative, marketing→business, data→technology. 이 4개는 taxonomy 에 없는 이름이라 라우팅이 정확해도 통과가 불가능했다(측정 버그).",
     "cases": [
         {
             "id": "routing-001",
@@ -22,7 +22,7 @@
             "id": "routing-003",
             "category": "routing-accuracy",
             "query": "Help me design a marketing campaign for a new SaaS product",
-            "expectedCategory": "marketing",
+            "expectedCategory": "business",
             "language": "en",
             "tags": ["marketing"]
         },
@@ -30,7 +30,7 @@
             "id": "routing-004",
             "category": "routing-accuracy",
             "query": "Analyze sales data trends over the last quarter",
-            "expectedCategory": "data",
+            "expectedCategory": "technology",
             "language": "en",
             "tags": ["data-analysis"]
         },
@@ -38,7 +38,7 @@
             "id": "routing-005",
             "category": "routing-accuracy",
             "query": "Create a UX wireframe for a mobile banking app",
-            "expectedCategory": "design",
+            "expectedCategory": "creative",
             "language": "en",
             "tags": ["design", "ux"]
         },
@@ -110,7 +110,7 @@
             "id": "routing-014",
             "category": "routing-accuracy",
             "query": "병원 예약 시스템 데이터베이스 스키마 설계",
-            "expectedCategories": ["technology", "health"],
+            "expectedCategories": ["technology", "healthcare"],
             "language": "ko",
             "tags": ["database", "healthcare", "korean"]
         },
@@ -118,7 +118,7 @@
             "id": "routing-015",
             "category": "routing-accuracy",
             "query": "사용자 인터뷰를 통해 페르소나를 만드는 방법",
-            "expectedCategories": ["design"],
+            "expectedCategories": ["creative"],
             "language": "ko",
             "tags": ["ux", "research", "korean"]
         },
@@ -182,7 +182,7 @@
             "id": "routing-023",
             "category": "routing-accuracy",
             "query": "Recommend exercise routine for desk workers",
-            "expectedCategories": ["health"],
+            "expectedCategories": ["healthcare"],
             "language": "en",
             "tags": ["health", "fitness"]
         },
@@ -198,7 +198,7 @@
             "id": "routing-025",
             "category": "routing-accuracy",
             "query": "구글 광고 ROAS 개선 방법 알려주세요",
-            "expectedCategories": ["marketing"],
+            "expectedCategories": ["business"],
             "language": "ko",
             "tags": ["marketing", "ads", "korean"]
         },


### PR DESCRIPTION
계측에서 발견한 결함 2건. 둘 다 "조용히 잘못된 상태로 남는" 유형이다.

## ① 중단된 Deep Research 세션이 영구 '진행 중' 으로 남음

Deep Research 는 큐·워커 없이 in-process 파이프라인으로 돈다(세션 생성 직후 같은 흐름에서 `running` 전이). 프로세스가 재시작되면 `pending`/`running` 세션을 이어받는 주체가 없는데, 좀비 정리가 `agent_tasks` 에만 있고 `research_sessions` 에는 없었다.

**실측**: 7/26 중단으로 `running` 3건이 나흘째 방치 — 51건 중 3건(5.9%). 프론트에는 끝나지 않는 '진행 중' 으로 계속 표시된다.

- `schema-initializer` 에 `agent_tasks` 와 동일 패턴의 정리 추가 (`pending`/`running` → `failed`)
- resume 이 없어 `error` 컬럼도 없으므로 `status`/`completed_at` 만 정리
- 두 정리 로직이 조용히 사라지지 않도록 회귀 테스트 추가

배포 시 부팅 과정에서 기존 3건이 자동 정리된다.

## ② Gate 5 가 라우터 품질이 아니라 어휘 드리프트를 측정하고 있었음

골든셋의 `expectedCategory` 4개(`health`·`design`·`marketing`·`data`)가 `industry-agents.json` taxonomy(18종)에 **존재하지 않는 이름**이었다. 라우터가 정확히 라우팅해도 통과가 불가능한 케이스들이다.

실제 소속을 확인해 정렬했다 — `ui-ux-designer`→creative, `marketing-manager`→business, `physician`→healthcare, `data-scientist`→technology:

| 기존 | 정정 |
|---|---|
| health | healthcare |
| design | creative |
| marketing | business |
| data | technology |

**결과: 통과율 50.0% → 60.0%** (임계 ≥50% 대비 여유 10pp). 이전에는 임계값에 정확히 걸쳐 있어 다음 라우팅 변경 한 번에 CI 가 막힐 상태였다.

어휘 정정만으로 통과한 3건은 모두 라우팅이 **원래 옳았던** 케이스다 — 005(UX 와이어프레임→ui-ux-designer), 014(병원 DB 스키마→physician), 025(광고 ROAS→marketing-manager).

### ⚠️ 남은 12건은 실패로 남겼다

기대치를 느슨하게 해서 통과율을 올리지 않았다. 진짜 라우터 결함이고, 영어 기술 질의가 엉뚱한 산업으로 가는 패턴이 두드러진다.

| 질의 | 기대 | 실제 |
|---|---|---|
| Kubernetes ingress 설정 | technology | **energy**/renewable-energy-engineer |
| nginx reverse proxy SSL | technology | **engineering**/mechanical-engineer |
| SQL injection 방지 | technology | **science**/data-analyst |
| Write a haiku | creative·general | **technology**/data-scientist |
| Translate to Japanese | general·creative | **finance**/financial-analyst |

`keyword-router` 튜닝은 별건으로 다뤄야 하며, 그때 이 골든셋이 비로소 실제 지표로 기능한다.

## 검증

- Jest **187 suite / 2,265 test** 통과 (신규 회귀 테스트 2건 포함)
- ESLint 0 error · 600줄 가드 통과
- Gate 5 routing **60.0%**(≥50) · Gate 6 response **100.0%**

## 배경

이 두 건은 "단일 API 프로세스를 worker 로 분리할지" 판단하려고 돌린 계측에서 나왔다. **분리는 반려**했다 — 메모리 166MB/1024MB(16%), OOM·크래시·불안정 재시작 0건, 재시작 피해는 128 작업 중 1건(0.8%)이고 최근 사례도 6주 전이다. 대신 계측이 드러낸 실제 결함이 이 PR 이다. (worker 로 분리해도 그 worker 가 죽으면 ①은 똑같이 발생한다 — 필요한 건 정리 로직이지 프로세스 분리가 아니다.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)