### PR TITLE
feat(providers): 외부 provider LiteLLM 통합 게이트웨이 라우팅 (LLM_GATEWAY_PROVIDERS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,10 @@ LLM_BASE_URL=http://localhost:4000              # 서버 PC 의 vLLM/LiteLLM pro
 LLM_API_KEY=sk-litellm-master-key               # LiteLLM master key (또는 vLLM --api-key)
 LLM_DEFAULT_MODEL=qwen3.6-35b-a3b               # proxy 가 라우팅하는 model 명 (chat 기본)
 LLM_TIMEOUT=120000                              # HTTP 요청 타임아웃 (ms)
+# LiteLLM 통합 게이트웨이로 inference 를 라우팅할 외부 provider id 콤마 목록.
+# 빈값/미설정 = 전부 direct 호출. provider별 롤백은 목록에서 제거 + 재시작.
+# ollama-local(사용자별 endpoint)·chatgpt(OAuth) 는 목록과 무관하게 direct 유지.
+# LLM_GATEWAY_PROVIDERS=openrouter,ollama-cloud,nvidia
 # 모델 학습 지식 컷오프 라벨 — 프롬프트 "학습 기준일" 명시용. 기본 모델/외부 provider 교체 시 조정.
 # LLM_KNOWLEDGE_CUTOFF_KO=2024년 12월
 # LLM_KNOWLEDGE_CUTOFF_EN=December 2024

--- a/apps/api/src/config/env-validate.ts
+++ b/apps/api/src/config/env-validate.ts
@@ -1,0 +1,86 @@
+/**
+ * ============================================================
+ * Environment Config Validation — env.ts 에서 분리 (파일 크기 가드)
+ * ============================================================
+ * 필수 환경 변수 검증. 런타임 시작 전에 호출하여 설정 오류를 조기에 발견.
+ *
+ * @module config/env-validate
+ */
+import type { EnvConfig } from './env';
+
+export function validateConfig(config: EnvConfig): void {
+    const errors: string[] = [];
+
+    // URL 검증
+    if (!config.llmBaseUrl || !config.llmBaseUrl.startsWith('http')) {
+        errors.push(`Invalid LLM_BASE_URL: ${config.llmBaseUrl}`);
+    }
+
+    // 모델 이름 검증
+    if (!config.llmDefaultModel || config.llmDefaultModel.trim() === '') {
+        errors.push('LLM_DEFAULT_MODEL is required');
+    }
+
+    // 타임아웃 검증
+    if (config.llmTimeout <= 0 || config.llmTimeout > 600000) {
+        errors.push(`Invalid LLM_TIMEOUT: ${config.llmTimeout} (must be between 1-600000ms)`);
+    }
+
+    // JWT_SECRET 필수 검증 (test 환경 제외 — 랜덤 생성 금지: PM2 재시작마다 세션 무효화)
+    if (config.nodeEnv !== 'test' && (!config.jwtSecret || config.jwtSecret.length < 32)) {
+        errors.push('JWT_SECRET must be at least 32 characters (set in .env). Random generation is forbidden — it invalidates all sessions on restart.');
+    }
+
+    // Production에서 HTTPS 없이 쿠키 전송 방지 — HttpOnly 쿠키가 평문으로 노출되는 것을 차단.
+    // HTTPS 미지원 환경에서는 ALLOW_INSECURE_COOKIES=true 로 명시적 opt-out 가능.
+    if (config.nodeEnv === 'production' && !config.cookieSecure) {
+        if (!config.allowInsecureCookies) {
+            errors.push(
+                'COOKIE_SECURE must be true in production. ' +
+                'Set COOKIE_SECURE=true in .env when running behind HTTPS, ' +
+                'or set ALLOW_INSECURE_COOKIES=true to explicitly opt out (insecure — tokens transmitted in plaintext).'
+            );
+        } else {
+            // Logger가 아직 초기화되지 않았으므로 console.warn 사용
+            console.warn(
+                '\n\x1b[33m[SECURITY WARNING]\x1b[0m COOKIE_SECURE=false in production with ALLOW_INSECURE_COOKIES=true.\n' +
+                '  HttpOnly session cookies (JWT access/refresh tokens) will be transmitted over plaintext HTTP.\n' +
+                '  This is vulnerable to MITM token theft. Deploy HTTPS (e.g. Caddy, Cloudflare Tunnel) as soon as possible.\n'
+            );
+        }
+    }
+
+    // API_KEY_PEPPER 검증 (프로덕션 환경에서 API Key 서비스 사용 시)
+    if (config.nodeEnv === 'production' && config.apiKeyPepper === '') {
+        errors.push('API_KEY_PEPPER is required in production for API key hashing security');
+    }
+
+    // CORS: 전역 credentials=true 환경이므로 와일드카드('*') Origin 은 CORS 스펙상 금지.
+    // 운영 환경에서 CORS_ORIGINS 에 '*' 가 있으면 부팅 중단 (명시적 allowlist 강제).
+    if (config.nodeEnv === 'production' &&
+        config.corsOrigins.split(',').map((o) => o.trim()).includes('*')) {
+        errors.push(
+            'CORS_ORIGINS must not contain a wildcard (*) in production. ' +
+            'credentials 기반 인증 환경에서는 명시적 Origin allowlist 가 필요합니다.'
+        );
+    }
+
+    // Stage 2-H3: STORAGE_BACKEND=redis 선택 시 REDIS_URL 필수
+    if (config.storageBackend === 'redis' && !config.redisUrl) {
+        errors.push('REDIS_URL must be set when STORAGE_BACKEND=redis');
+    }
+
+    // LLM_API_KEY 가 dummy 'sk-no-key' 인데 production 운영 — LiteLLM master_key 설정 시 401 폭발.
+    // 운영자가 LiteLLM 을 비인증 모드로 의도했으면 무시 가능 — 경고로만 출력 (errors push 안 함).
+    if (config.nodeEnv === 'production' && (config.llmApiKey === '' || config.llmApiKey === 'sk-no-key')) {
+        console.warn(
+            '\n\x1b[33m[CONFIG WARN]\x1b[0m LLM_API_KEY is unset or default placeholder (\'sk-no-key\') in production.\n' +
+            '  If LiteLLM master_key or vLLM --api-key is enabled upstream, all requests will be rejected with 401.\n' +
+            '  Set LLM_API_KEY to the actual proxy key in .env, or keep this placeholder only if auth is disabled.\n'
+        );
+    }
+
+    if (errors.length > 0) {
+        throw new Error(`Configuration validation failed:\n${errors.join('\n')}`);
+    }
+}

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -140,6 +140,12 @@ export const envSchema = z
         SEARCH_SEMANTIC_RERANK_ENABLED: z.string().default('false'),
         SEARCH_RERANK_EMBED_MODEL: z.string().optional(),
         /**
+         * LiteLLM 통합 게이트웨이로 inference 를 라우팅할 외부 provider id 콤마 목록
+         * (예: 'openrouter,ollama-cloud,nvidia'). 빈값(기본) = 전부 direct.
+         * ollama-local·OAuth provider 는 목록과 무관하게 direct 유지.
+         */
+        LLM_GATEWAY_PROVIDERS: z.string().optional(),
+        /**
          * Qwen3 등 reasoning 모델의 `extra_body.chat_template_kwargs.enable_thinking` 토글.
          *
          * reasoning 모델은 `enable_thinking` 기본값에 따라 매 응답 reasoning 을 발생시켜

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -69,6 +69,13 @@ export interface EnvConfig {
     searchSemanticRerankEnabled: boolean;
     /** 웹검색 의미 리랭킹에 쓰는 임베딩 모델명 (LiteLLM 카탈로그). 기본 bge-m3. */
     searchRerankEmbedModel: string;
+    /**
+     * LiteLLM 통합 게이트웨이로 inference 를 라우팅할 외부 provider id 목록
+     * (콤마 구분). 빈값(기본) = 전부 direct 호출. provider별 롤백은 목록에서
+     * 해당 id 제거 + 재시작. ollama-local(사용자별 동적 endpoint)·OAuth(chatgpt)
+     * 는 목록에 있어도 direct 유지 (arch.md §4-3·§5-3).
+     */
+    llmGatewayProviders: string[];
 
     // Log
     logLevel: 'debug' | 'info' | 'warn' | 'error';
@@ -188,6 +195,7 @@ const DEFAULT_CONFIG: EnvConfig = {
     searchSemanticRerankShadow: false,
     searchSemanticRerankEnabled: false,
     searchRerankEmbedModel: 'bge-m3',
+    llmGatewayProviders: [] as string[],
 
     // Log
     logLevel: 'info',
@@ -409,6 +417,7 @@ export function loadConfig(): EnvConfig {
         SEARCH_SEMANTIC_RERANK_SHADOW: env('SEARCH_SEMANTIC_RERANK_SHADOW'),
         SEARCH_SEMANTIC_RERANK_ENABLED: env('SEARCH_SEMANTIC_RERANK_ENABLED'),
         SEARCH_RERANK_EMBED_MODEL: env('SEARCH_RERANK_EMBED_MODEL'),
+        LLM_GATEWAY_PROVIDERS: env('LLM_GATEWAY_PROVIDERS'),
         LLM_DISABLE_THINKING_BY_DEFAULT: env('LLM_DISABLE_THINKING_BY_DEFAULT'),
         LOG_LEVEL: env('LOG_LEVEL'),
         GEMINI_THINK_ENABLED: env('GEMINI_THINK_ENABLED'),
@@ -516,6 +525,10 @@ export function loadConfig(): EnvConfig {
         searchSemanticRerankShadow: (parsed.SEARCH_SEMANTIC_RERANK_SHADOW ?? 'false').toLowerCase() === 'true',
         searchSemanticRerankEnabled: (parsed.SEARCH_SEMANTIC_RERANK_ENABLED ?? 'false').toLowerCase() === 'true',
         searchRerankEmbedModel: parsed.SEARCH_RERANK_EMBED_MODEL || DEFAULT_CONFIG.searchRerankEmbedModel,
+        llmGatewayProviders: (parsed.LLM_GATEWAY_PROVIDERS ?? '')
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean),
 
         // Log
         logLevel: parsed.LOG_LEVEL ?? DEFAULT_CONFIG.logLevel,

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -11,8 +11,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { envSchema } from './env.schema';
+import { validateConfig } from './env-validate';
 import { SERVER_CONFIG } from './constants';
 import type { SupportedLanguageCode } from '../chat/language-policy';
+
+// 파일 크기 가드 분리 (2026-07-31): 검증 로직은 env-validate.ts — 기존 import 경로 호환 재노출
+export { validateConfig } from './env-validate';
 
 export interface EnvConfig {
     // Node
@@ -290,87 +294,6 @@ function parseEnvFile(filePath: string): Record<string, string> {
     }
 
     return env;
-}
-
-/**
- * 필수 환경 변수 검증
- * 런타임 시작 전에 호출하여 설정 오류를 조기에 발견
- */
-export function validateConfig(config: EnvConfig): void {
-    const errors: string[] = [];
-
-    // URL 검증
-    if (!config.llmBaseUrl || !config.llmBaseUrl.startsWith('http')) {
-        errors.push(`Invalid LLM_BASE_URL: ${config.llmBaseUrl}`);
-    }
-
-    // 모델 이름 검증
-    if (!config.llmDefaultModel || config.llmDefaultModel.trim() === '') {
-        errors.push('LLM_DEFAULT_MODEL is required');
-    }
-
-    // 타임아웃 검증
-    if (config.llmTimeout <= 0 || config.llmTimeout > 600000) {
-        errors.push(`Invalid LLM_TIMEOUT: ${config.llmTimeout} (must be between 1-600000ms)`);
-    }
-
-    // JWT_SECRET 필수 검증 (test 환경 제외 — 랜덤 생성 금지: PM2 재시작마다 세션 무효화)
-    if (config.nodeEnv !== 'test' && (!config.jwtSecret || config.jwtSecret.length < 32)) {
-        errors.push('JWT_SECRET must be at least 32 characters (set in .env). Random generation is forbidden — it invalidates all sessions on restart.');
-    }
-
-    // Production에서 HTTPS 없이 쿠키 전송 방지 — HttpOnly 쿠키가 평문으로 노출되는 것을 차단.
-    // HTTPS 미지원 환경에서는 ALLOW_INSECURE_COOKIES=true 로 명시적 opt-out 가능.
-    if (config.nodeEnv === 'production' && !config.cookieSecure) {
-        if (!config.allowInsecureCookies) {
-            errors.push(
-                'COOKIE_SECURE must be true in production. ' +
-                'Set COOKIE_SECURE=true in .env when running behind HTTPS, ' +
-                'or set ALLOW_INSECURE_COOKIES=true to explicitly opt out (insecure — tokens transmitted in plaintext).'
-            );
-        } else {
-            // Logger가 아직 초기화되지 않았으므로 console.warn 사용
-            console.warn(
-                '\n\x1b[33m[SECURITY WARNING]\x1b[0m COOKIE_SECURE=false in production with ALLOW_INSECURE_COOKIES=true.\n' +
-                '  HttpOnly session cookies (JWT access/refresh tokens) will be transmitted over plaintext HTTP.\n' +
-                '  This is vulnerable to MITM token theft. Deploy HTTPS (e.g. Caddy, Cloudflare Tunnel) as soon as possible.\n'
-            );
-        }
-    }
-
-    // API_KEY_PEPPER 검증 (프로덕션 환경에서 API Key 서비스 사용 시)
-    if (config.nodeEnv === 'production' && config.apiKeyPepper === '') {
-        errors.push('API_KEY_PEPPER is required in production for API key hashing security');
-    }
-
-    // CORS: 전역 credentials=true 환경이므로 와일드카드('*') Origin 은 CORS 스펙상 금지.
-    // 운영 환경에서 CORS_ORIGINS 에 '*' 가 있으면 부팅 중단 (명시적 allowlist 강제).
-    if (config.nodeEnv === 'production' &&
-        config.corsOrigins.split(',').map((o) => o.trim()).includes('*')) {
-        errors.push(
-            'CORS_ORIGINS must not contain a wildcard (*) in production. ' +
-            'credentials 기반 인증 환경에서는 명시적 Origin allowlist 가 필요합니다.'
-        );
-    }
-
-    // Stage 2-H3: STORAGE_BACKEND=redis 선택 시 REDIS_URL 필수
-    if (config.storageBackend === 'redis' && !config.redisUrl) {
-        errors.push('REDIS_URL must be set when STORAGE_BACKEND=redis');
-    }
-
-    // LLM_API_KEY 가 dummy 'sk-no-key' 인데 production 운영 — LiteLLM master_key 설정 시 401 폭발.
-    // 운영자가 LiteLLM 을 비인증 모드로 의도했으면 무시 가능 — 경고로만 출력 (errors push 안 함).
-    if (config.nodeEnv === 'production' && (config.llmApiKey === '' || config.llmApiKey === 'sk-no-key')) {
-        console.warn(
-            '\n\x1b[33m[CONFIG WARN]\x1b[0m LLM_API_KEY is unset or default placeholder (\'sk-no-key\') in production.\n' +
-            '  If LiteLLM master_key or vLLM --api-key is enabled upstream, all requests will be rejected with 401.\n' +
-            '  Set LLM_API_KEY to the actual proxy key in .env, or keep this placeholder only if auth is disabled.\n'
-        );
-    }
-
-    if (errors.length > 0) {
-        throw new Error(`Configuration validation failed:\n${errors.join('\n')}`);
-    }
 }
 
 export function loadConfig(): EnvConfig {

--- a/apps/api/src/providers/__tests__/gateway-routing.test.ts
+++ b/apps/api/src/providers/__tests__/gateway-routing.test.ts
@@ -1,0 +1,107 @@
+/**
+ * LiteLLM 통합 게이트웨이 라우팅 (LLM_GATEWAY_PROVIDERS) 단위 테스트.
+ *
+ * arch.md 2026-07-31 이전 계약:
+ * - 목록에 있는 API key provider → inference client 가 게이트웨이(baseURL=llmBaseUrl/v1)
+ *   + x-litellm-api-key 헤더 + model prefix
+ * - 목록에 없거나 ollama-local → 기존 direct 동작 무변경
+ * - 카탈로그/검증 client 는 게이트웨이 여부와 무관하게 provider endpoint direct
+ */
+import { createExternalProviderInstance } from '../provider-router';
+import { OpenAICompatProvider } from '../openai-compat-provider';
+import type { ExternalApiKeyRow } from '../../data/repositories/external-keys-repo';
+
+jest.mock('../../config', () => {
+    const actual = jest.requireActual('../../config');
+    return {
+        ...actual,
+        getConfig: () => ({
+            ...actual.getConfig(),
+            llmBaseUrl: 'http://127.0.0.1:13401',
+            llmApiKey: 'sk-test-master',
+            llmGatewayProviders: ['openrouter', 'ollama-cloud', 'nvidia', 'ollama-local'],
+        }),
+    };
+});
+
+function makeKeyRow(overrides: Partial<ExternalApiKeyRow>): ExternalApiKeyRow {
+    return {
+        id: 1,
+        userId: 'u1',
+        providerId: 'openrouter',
+        sdkType: 'openai-compatible',
+        authMethod: 'api_key',
+        displayName: 'test',
+        baseUrl: 'https://openrouter.ai/api/v1',
+        keyPrefix: 'sk-or',
+        oauthAccountId: null,
+        oauthExpiresAt: null,
+        isActive: true,
+        lastValidatedAt: null,
+        lastValidationOk: null,
+        lastValidationError: null,
+        lastUsedAt: null,
+        createdAt: new Date(0),
+        updatedAt: new Date(0),
+        ...overrides,
+    };
+}
+
+/** OpenAI SDK client 내부 상태 접근 헬퍼 (테스트 한정) */
+function inner(provider: OpenAICompatProvider): {
+    client: { baseURL: string };
+    catalogClient: { baseURL: string };
+    modelPrefix?: string;
+} {
+    return provider as unknown as {
+        client: { baseURL: string };
+        catalogClient: { baseURL: string };
+        modelPrefix?: string;
+    };
+}
+
+describe('LLM_GATEWAY_PROVIDERS 게이트웨이 라우팅', () => {
+    it('목록에 있는 provider → inference 는 게이트웨이, 카탈로그는 direct', () => {
+        const provider = createExternalProviderInstance(makeKeyRow({}), 'sk-or-user-key');
+        expect(provider).toBeInstanceOf(OpenAICompatProvider);
+        const p = inner(provider as OpenAICompatProvider);
+        expect(p.client.baseURL).toBe('http://127.0.0.1:13401/v1');
+        expect(p.catalogClient.baseURL).toBe('https://openrouter.ai/api/v1');
+        expect(p.modelPrefix).toBe('openrouter');
+    });
+
+    it('게이트웨이 인증=Authorization(master), 사용자 BYOK=x-api-key 헤더', () => {
+        const provider = createExternalProviderInstance(makeKeyRow({}), 'sk-or-user-key');
+        const client = inner(provider as OpenAICompatProvider).client as unknown as {
+            apiKey?: string;
+            defaultHeaders?: Record<string, string>;
+            _options?: { defaultHeaders?: Record<string, string> };
+        };
+        // SDK apiKey → Authorization: Bearer <master> (게이트웨이 인증)
+        expect(client.apiKey).toBe('sk-test-master');
+        // 사용자 BYOK → x-api-key (LiteLLM 이 upstream 인증으로 전달)
+        const headers = client.defaultHeaders ?? client._options?.defaultHeaders ?? {};
+        expect(headers['x-api-key']).toBe('sk-or-user-key');
+    });
+
+    it('목록에 없는 provider → 기존 direct 동작 (client === catalogClient)', () => {
+        const provider = createExternalProviderInstance(
+            makeKeyRow({ providerId: 'groq', baseUrl: 'https://api.groq.com/openai/v1' }),
+            'gsk-user-key',
+        );
+        const p = inner(provider as OpenAICompatProvider);
+        expect(p.client).toBe(p.catalogClient);
+        expect(p.client.baseURL).toBe('https://api.groq.com/openai/v1');
+        expect(p.modelPrefix).toBeUndefined();
+    });
+
+    it('ollama-local 은 목록에 있어도 direct 유지 (사용자별 동적 endpoint)', () => {
+        const provider = createExternalProviderInstance(
+            makeKeyRow({ providerId: 'ollama-local', baseUrl: 'http://192.168.0.10:11434/v1' }),
+            'ollama-no-key',
+        );
+        const p = inner(provider as OpenAICompatProvider);
+        expect(p.client).toBe(p.catalogClient);
+        expect(p.modelPrefix).toBeUndefined();
+    });
+});

--- a/apps/api/src/providers/openai-compat-mapping.ts
+++ b/apps/api/src/providers/openai-compat-mapping.ts
@@ -1,0 +1,134 @@
+/**
+ * ============================================================
+ * OpenAI Chat Completions 메시지/도구 변환 헬퍼
+ * ============================================================
+ * openai-compat-provider.ts 에서 분리 (파일 크기 가드).
+ * IProvider ChatMessage/ToolDefinition → OpenAI 표준 형식 매핑과
+ * OpenRouter 명시적 prompt caching 판정을 담당한다.
+ *
+ * @module providers/openai-compat-mapping
+ */
+import type { ChatMessage, ToolDefinition } from '../llm';
+
+/**
+ * OpenAI 형식 메시지로 변환.
+ *
+ * - role 매핑: system/user/assistant/tool 그대로 유지
+ * - images: content 배열에 image_url 블록으로 추가 (OpenAI Vision 표준)
+ * - tool_calls: assistant role 에 그대로 첨부
+ * - tool: tool_call_id + content 형식
+ */
+export type OpenAIContentBlock = {
+    type: string;
+    text?: string;
+    image_url?: { url: string };
+    /**
+     * OpenRouter prompt caching marker — Anthropic Claude / Alibaba Qwen 처럼
+     * 명시적 cache breakpoint 가 필요한 모델에 첨부.
+     * 자동 cache provider (OpenAI/Gemini/Groq 등) 는 무시.
+     */
+    cache_control?: { type: 'ephemeral' };
+};
+
+export type OpenAIMessage = {
+    role: 'system' | 'user' | 'assistant' | 'tool';
+    content?: string | OpenAIContentBlock[];
+    tool_calls?: Array<{
+        id: string;
+        type: 'function';
+        function: { name: string; arguments: string };
+    }>;
+    tool_call_id?: string;
+};
+
+/**
+ * 모델 ID 가 OpenRouter 명시적 prompt caching 이 필요한 모델인지 판단.
+ *
+ * OpenRouter docs (guides/best-practices/prompt-caching) 에 따르면:
+ * - 자동 cache: OpenAI / Gemini / DeepSeek / Grok / Moonshot / Groq → 추가 설정 불필요
+ * - 명시 cache_control 필요: Anthropic Claude / Alibaba Qwen 일부 / DeepSeek V3.2
+ *
+ * 본 함수는 명시적 cache 가 필요한 케이스만 true 반환 — system 메시지에
+ * cache_control: { type: 'ephemeral' } 첨부 대상.
+ */
+export function needsExplicitPromptCache(providerId: string, modelId: string): boolean {
+    if (providerId !== 'openrouter') return false;
+    const lower = modelId.toLowerCase();
+    if (lower.includes('claude')) return true;
+    if (/\bqwen3-coder\b|\bqwen-plus\b|\bqwen3-max\b|\bqwen3\.6-plus\b|\bdeepseek-v3\.2\b/.test(lower)) return true;
+    return false;
+}
+
+// inferImageMime 은 utils/image-mime.ts 의 공용 helper 로 이전 (2026-05-19):
+// stream-parser.ts 와 동일 로직 공유 — JPEG/WebP/GIF 등 MIME 매핑 일관성 보장.
+import { inferImageMime } from '../utils/image-mime';
+
+export function toOpenAIMessages(
+    messages: ChatMessage[],
+    opts?: { cacheSystemPrompt?: boolean },
+): OpenAIMessage[] {
+    return messages.map((msg, idx): OpenAIMessage => {
+        if (msg.role === 'tool') {
+            return {
+                role: 'tool',
+                content: msg.content,
+                // 진짜 tool_call_id (직전 assistant.tool_calls[].id) 우선,
+                // 누락 시 tool_name 또는 tool_${idx} 합성 — spec 준수와 외부 history 호환.
+                tool_call_id: msg.tool_call_id ?? msg.tool_name ?? `tool_${idx}`,
+            };
+        }
+
+        if (msg.images && msg.images.length > 0 && (msg.role === 'user' || msg.role === 'system')) {
+            const blocks: OpenAIContentBlock[] = [];
+            if (msg.content) blocks.push({ type: 'text', text: msg.content });
+            for (const img of msg.images) {
+                const url = img.startsWith('data:') ? img : `data:${inferImageMime(img)};base64,${img}`;
+                blocks.push({ type: 'image_url', image_url: { url } });
+            }
+            return { role: msg.role, content: blocks };
+        }
+
+        // System prompt cache breakpoint — Anthropic / Qwen 류 명시적 caching 모델 한정.
+        // content 를 array 로 변환하고 cache_control 첨부 (TTL 5분, OpenRouter 가 sticky routing 으로 cache hit 최대화).
+        if (msg.role === 'system' && opts?.cacheSystemPrompt && typeof msg.content === 'string' && msg.content.length > 0) {
+            return {
+                role: 'system',
+                content: [
+                    { type: 'text', text: msg.content, cache_control: { type: 'ephemeral' } },
+                ],
+            };
+        }
+
+        if (msg.role === 'assistant' && msg.tool_calls && msg.tool_calls.length > 0) {
+            return {
+                role: 'assistant',
+                content: msg.content || '',
+                tool_calls: msg.tool_calls.map((tc, i) => ({
+                    // provider 발급 id (Anthropic/OpenAI/Gemini) 우선 — fake 합성은 fallback 만.
+                    id: tc.id ?? `call_${tc.function.name}_${i}`,
+                    type: 'function' as const,
+                    function: {
+                        name: tc.function.name,
+                        arguments: JSON.stringify(tc.function.arguments),
+                    },
+                })),
+            };
+        }
+
+        return { role: msg.role, content: msg.content };
+    });
+}
+
+export function toOpenAITools(tools: ToolDefinition[]): Array<{
+    type: 'function';
+    function: { name: string; description: string; parameters: unknown };
+}> {
+    return tools.map((t) => ({
+        type: 'function' as const,
+        function: {
+            name: t.function.name,
+            description: t.function.description,
+            parameters: t.function.parameters,
+        },
+    }));
+}

--- a/apps/api/src/providers/openai-compat-provider.ts
+++ b/apps/api/src/providers/openai-compat-provider.ts
@@ -30,6 +30,7 @@ import { ProviderError } from './provider-errors';
 import type { ChatMessage, ToolDefinition, UsageMetrics } from '../llm';
 import { createLogger } from '../utils/logger';
 import { createPinnedFetch } from '../security/ssrf-guard';
+import { needsExplicitPromptCache, toOpenAIMessages, toOpenAITools } from './openai-compat-mapping';
 
 const logger = createLogger('OpenAICompatProvider');
 
@@ -109,129 +110,6 @@ function inferCapabilitiesFromModelId(
     // 임베딩 모델은 별도 분기 미지원 (vector cache / semantic router 폐기 — 2026-05-19)
 
     return caps;
-}
-
-/**
- * OpenAI 형식 메시지로 변환.
- *
- * - role 매핑: system/user/assistant/tool 그대로 유지
- * - images: content 배열에 image_url 블록으로 추가 (OpenAI Vision 표준)
- * - tool_calls: assistant role 에 그대로 첨부
- * - tool: tool_call_id + content 형식
- */
-type OpenAIContentBlock = {
-    type: string;
-    text?: string;
-    image_url?: { url: string };
-    /**
-     * OpenRouter prompt caching marker — Anthropic Claude / Alibaba Qwen 처럼
-     * 명시적 cache breakpoint 가 필요한 모델에 첨부.
-     * 자동 cache provider (OpenAI/Gemini/Groq 등) 는 무시.
-     */
-    cache_control?: { type: 'ephemeral' };
-};
-
-type OpenAIMessage = {
-    role: 'system' | 'user' | 'assistant' | 'tool';
-    content?: string | OpenAIContentBlock[];
-    tool_calls?: Array<{
-        id: string;
-        type: 'function';
-        function: { name: string; arguments: string };
-    }>;
-    tool_call_id?: string;
-};
-
-/**
- * 모델 ID 가 OpenRouter 명시적 prompt caching 이 필요한 모델인지 판단.
- *
- * OpenRouter docs (guides/best-practices/prompt-caching) 에 따르면:
- * - 자동 cache: OpenAI / Gemini / DeepSeek / Grok / Moonshot / Groq → 추가 설정 불필요
- * - 명시 cache_control 필요: Anthropic Claude / Alibaba Qwen 일부 / DeepSeek V3.2
- *
- * 본 함수는 명시적 cache 가 필요한 케이스만 true 반환 — system 메시지에
- * cache_control: { type: 'ephemeral' } 첨부 대상.
- */
-function needsExplicitPromptCache(providerId: string, modelId: string): boolean {
-    if (providerId !== 'openrouter') return false;
-    const lower = modelId.toLowerCase();
-    if (lower.includes('claude')) return true;
-    if (/\bqwen3-coder\b|\bqwen-plus\b|\bqwen3-max\b|\bqwen3\.6-plus\b|\bdeepseek-v3\.2\b/.test(lower)) return true;
-    return false;
-}
-
-// inferImageMime 은 utils/image-mime.ts 의 공용 helper 로 이전 (2026-05-19):
-// stream-parser.ts 와 동일 로직 공유 — JPEG/WebP/GIF 등 MIME 매핑 일관성 보장.
-import { inferImageMime } from '../utils/image-mime';
-
-function toOpenAIMessages(
-    messages: ChatMessage[],
-    opts?: { cacheSystemPrompt?: boolean },
-): OpenAIMessage[] {
-    return messages.map((msg, idx): OpenAIMessage => {
-        if (msg.role === 'tool') {
-            return {
-                role: 'tool',
-                content: msg.content,
-                // 진짜 tool_call_id (직전 assistant.tool_calls[].id) 우선,
-                // 누락 시 tool_name 또는 tool_${idx} 합성 — spec 준수와 외부 history 호환.
-                tool_call_id: msg.tool_call_id ?? msg.tool_name ?? `tool_${idx}`,
-            };
-        }
-
-        if (msg.images && msg.images.length > 0 && (msg.role === 'user' || msg.role === 'system')) {
-            const blocks: OpenAIContentBlock[] = [];
-            if (msg.content) blocks.push({ type: 'text', text: msg.content });
-            for (const img of msg.images) {
-                const url = img.startsWith('data:') ? img : `data:${inferImageMime(img)};base64,${img}`;
-                blocks.push({ type: 'image_url', image_url: { url } });
-            }
-            return { role: msg.role, content: blocks };
-        }
-
-        // System prompt cache breakpoint — Anthropic / Qwen 류 명시적 caching 모델 한정.
-        // content 를 array 로 변환하고 cache_control 첨부 (TTL 5분, OpenRouter 가 sticky routing 으로 cache hit 최대화).
-        if (msg.role === 'system' && opts?.cacheSystemPrompt && typeof msg.content === 'string' && msg.content.length > 0) {
-            return {
-                role: 'system',
-                content: [
-                    { type: 'text', text: msg.content, cache_control: { type: 'ephemeral' } },
-                ],
-            };
-        }
-
-        if (msg.role === 'assistant' && msg.tool_calls && msg.tool_calls.length > 0) {
-            return {
-                role: 'assistant',
-                content: msg.content || '',
-                tool_calls: msg.tool_calls.map((tc, i) => ({
-                    // provider 발급 id (Anthropic/OpenAI/Gemini) 우선 — fake 합성은 fallback 만.
-                    id: tc.id ?? `call_${tc.function.name}_${i}`,
-                    type: 'function' as const,
-                    function: {
-                        name: tc.function.name,
-                        arguments: JSON.stringify(tc.function.arguments),
-                    },
-                })),
-            };
-        }
-
-        return { role: msg.role, content: msg.content };
-    });
-}
-
-function toOpenAITools(tools: ToolDefinition[]): Array<{
-    type: 'function';
-    function: { name: string; description: string; parameters: unknown };
-}> {
-    return tools.map((t) => ({
-        type: 'function' as const,
-        function: {
-            name: t.function.name,
-            description: t.function.description,
-            parameters: t.function.parameters,
-        },
-    }));
 }
 
 function mapOpenAIError(err: unknown): ProviderError {

--- a/apps/api/src/providers/openai-compat-provider.ts
+++ b/apps/api/src/providers/openai-compat-provider.ts
@@ -288,15 +288,37 @@ function buildOpenRouterHeaders(): Record<string, string> {
     return headers;
 }
 
+/**
+ * LiteLLM 통합 게이트웨이 경유 옵션 (arch.md 2026-07-31 이전).
+ *
+ * - url: 게이트웨이 base URL (서버 config `llmBaseUrl` — 사용자 입력 아님)
+ * - masterKey: 게이트웨이 인증 키 (`Authorization: Bearer` 로 전달)
+ * - modelPrefix: 게이트웨이 wildcard deployment prefix (예: 'openrouter' →
+ *   model 'openrouter/<modelId>')
+ *
+ * 헤더 계약 (LiteLLM 1.89.4 + forward_llm_provider_auth_headers, 2026-07-31 라이브 검증):
+ * - `Authorization: Bearer <masterKey>` — 게이트웨이 인증. upstream 으로 전달되지 않음
+ *   (사용자 키를 Authorization 에 실으면 upstream 에 "Missing Authentication header" 401).
+ * - `x-api-key: <사용자 BYOK>` — LiteLLM 이 upstream provider 인증으로 전달.
+ *   openrouter/ollama-cloud/nvidia 3사 모두 이 조합으로 200 확인.
+ */
+export interface GatewayRouteOptions {
+    url: string;
+    masterKey: string;
+    modelPrefix: string;
+}
+
 export class OpenAICompatProvider implements IProvider {
     readonly id: string;
     readonly sdkType: SdkType = 'openai-compatible';
     readonly displayName = PROVIDER_DISPLAY_NAME;
 
     private client: OpenAI;
+    private catalogClient: OpenAI;
     private baseUrl: string;
+    private modelPrefix?: string;
 
-    constructor(opts: { providerId: string; apiKey: string; baseUrl: string }) {
+    constructor(opts: { providerId: string; apiKey: string; baseUrl: string; gateway?: GatewayRouteOptions }) {
         this.id = opts.providerId;
         this.baseUrl = opts.baseUrl;
         // OpenRouter 호출 시 권장 attribution 헤더를 디폴트로 첨부한다.
@@ -304,7 +326,9 @@ export class OpenAICompatProvider implements IProvider {
         const defaultHeaders = opts.providerId === 'openrouter'
             ? buildOpenRouterHeaders()
             : undefined;
-        this.client = new OpenAI({
+        // 모델 카탈로그·credential 검증은 항상 provider endpoint direct
+        // (게이트웨이 /v1/models 는 wildcard 라 provider 별 목록을 주지 못함).
+        this.catalogClient = new OpenAI({
             apiKey: opts.apiKey,
             baseURL: opts.baseUrl,
             // 🔒 SSRF: base_url 은 등록 시 1회만 검증되므로, 런타임 호출은 매번 재검증 + resolved IP
@@ -314,6 +338,22 @@ export class OpenAICompatProvider implements IProvider {
                 ? { defaultHeaders }
                 : {}),
         });
+        if (opts.gateway) {
+            // inference 는 LiteLLM 게이트웨이 경유 — 게이트웨이 인증은 Authorization(master),
+            // 사용자 BYOK 는 x-api-key 헤더 (LiteLLM 이 upstream 인증으로 전달, 위 계약 참고).
+            // 게이트웨이 URL 은 서버 config 값(loopback)이라 SSRF pinned fetch 미적용.
+            this.modelPrefix = opts.gateway.modelPrefix;
+            this.client = new OpenAI({
+                apiKey: opts.gateway.masterKey,
+                baseURL: `${opts.gateway.url.replace(/\/+$/, '')}/v1`,
+                defaultHeaders: {
+                    ...(defaultHeaders ?? {}),
+                    'x-api-key': opts.apiKey,
+                },
+            });
+        } else {
+            this.client = this.catalogClient;
+        }
     }
 
     getCapabilities(modelId: string): ProviderCapabilities {
@@ -325,7 +365,7 @@ export class OpenAICompatProvider implements IProvider {
             return this.listOpenRouterModels();
         }
         try {
-            const list = await this.client.models.list();
+            const list = await this.catalogClient.models.list();
             return list.data.map((m) => ({
                 id: m.id,
                 fullId: buildFullModelId(this.id, m.id),
@@ -362,7 +402,7 @@ export class OpenAICompatProvider implements IProvider {
      */
     private async listOpenRouterModels(): Promise<ProviderModel[]> {
         try {
-            const list = await this.client.models.list();
+            const list = await this.catalogClient.models.list();
             return list.data.map((raw) => {
                 const m = raw as unknown as {
                     id: string;
@@ -416,7 +456,7 @@ export class OpenAICompatProvider implements IProvider {
     async validateCredentials(): Promise<{ ok: boolean; error?: string; latencyMs?: number }> {
         const start = Date.now();
         try {
-            await this.client.models.list();
+            await this.catalogClient.models.list();
             return { ok: true, latencyMs: Date.now() - start };
         } catch (err) {
             return {
@@ -463,7 +503,8 @@ export class OpenAICompatProvider implements IProvider {
             } : {};
 
             const requestParams = {
-                model: opts.modelId,
+                // 게이트웨이 경유 시 wildcard deployment prefix 부착 (예: openrouter/openai/gpt-5)
+                model: this.modelPrefix ? `${this.modelPrefix}/${opts.modelId}` : opts.modelId,
                 messages,
                 stream: true as const,
                 stream_options: { include_usage: true },

--- a/apps/api/src/providers/provider-router.ts
+++ b/apps/api/src/providers/provider-router.ts
@@ -19,7 +19,8 @@ import {
 import { ProviderError } from './provider-errors';
 import { LocalLLMProvider } from './local-llm-provider';
 import { AnthropicProvider } from './anthropic-provider';
-import { OpenAICompatProvider } from './openai-compat-provider';
+import { OpenAICompatProvider, GatewayRouteOptions } from './openai-compat-provider';
+import { getConfig } from '../config';
 import { ChatGPTOAuthProvider } from './chatgpt-oauth/provider';
 import {
     parseSessionPayload,
@@ -55,6 +56,29 @@ export interface ProviderRouterDeps {
 export interface ExternalProviderInstanceDeps {
     /** OAuth refresh 후 세션 재암호화 저장 (미지정 시 in-memory 갱신만) */
     onOAuthSessionUpdate?: (session: ChatGPTOAuthSessionPayload) => Promise<void>;
+}
+
+/**
+ * 게이트웨이 라우팅 제외 provider — LLM_GATEWAY_PROVIDERS 에 있어도 direct 유지.
+ * ollama-local: 사용자별 동적 endpoint 라 정적 게이트웨이 deployment 로 표현 불가
+ * (arch.md §4-3 — 게이트웨이 api_base 는 서버 통제 값만 허용).
+ */
+const GATEWAY_EXCLUDED_PROVIDERS = new Set(['ollama-local']);
+
+/**
+ * providerId 가 LiteLLM 게이트웨이 경유 대상이면 GatewayRouteOptions 반환.
+ * OAuth 행(chatgpt)은 사용자별 세션 격리 미해결로 항상 direct (arch.md §5-3).
+ */
+function resolveGatewayRoute(providerId: string, authMethod: string): GatewayRouteOptions | undefined {
+    if (authMethod === 'oauth') return undefined;
+    if (GATEWAY_EXCLUDED_PROVIDERS.has(providerId)) return undefined;
+    const cfg = getConfig();
+    if (!cfg.llmGatewayProviders.includes(providerId)) return undefined;
+    return {
+        url: cfg.llmBaseUrl,
+        masterKey: cfg.llmApiKey,
+        modelPrefix: providerId,
+    };
 }
 
 /**
@@ -101,6 +125,7 @@ const EXTERNAL_PROVIDER_FACTORIES: Record<
             providerId,
             apiKey: plaintextKey,
             baseUrl: keyRow.baseUrl,
+            gateway: resolveGatewayRoute(providerId, keyRow.authMethod),
         });
     },
 };


### PR DESCRIPTION
## 요약

LiteLLM 게이트웨이의 Mac mini 이전(2026-07-31, arch.md)에 따라 **외부 API key provider(openrouter·ollama-cloud·nvidia)의 inference 를 로컬 모델과 동일한 LiteLLM 게이트웨이로 편입**한다. 인프라 이전(DGX vLLM Tailscale 바인딩, Mac LiteLLM 기동, DGX LiteLLM 제거)은 라이브 완료됐고, 이 PR 은 앱 측 라우팅 델타만 담는다.

## 변경 내용

- **`LLM_GATEWAY_PROVIDERS`** env(콤마 목록) 신설 — 게이트웨이로 라우팅할 provider id 목록. 빈값(기본) = 전부 direct(기존 동작 무변경). provider별 롤백 = 목록에서 제거 + 재시작
- **`OpenAICompatProvider`**: `gateway` 옵션 추가
  - inference client 는 게이트웨이(`llmBaseUrl`/v1) 경유, model 에 provider prefix 부착 (예: `openrouter/openai/gpt-5`)
  - 모델 카탈로그·credential 검증은 기존대로 provider endpoint direct (게이트웨이 wildcard 는 provider별 목록을 주지 못함)
- **`provider-router.ts`**: `resolveGatewayRoute` — `ollama-local`(사용자별 동적 endpoint)과 OAuth 행(chatgpt)은 목록과 무관하게 direct 유지 (arch.md §4-3·§5-3)

## 헤더 계약 (라이브 검증됨)

LiteLLM 1.89.4 + `forward_llm_provider_auth_headers: true` 기준:

| 헤더 | 용도 |
|---|---|
| `Authorization: Bearer <master>` | 게이트웨이 인증 — upstream 으로 전달되지 않음 |
| `x-api-key: <사용자 BYOK>` | LiteLLM 이 upstream provider 인증으로 전달 |

⚠️ 사용자 키를 `Authorization` 에 실으면 upstream 401 "Missing Authentication header" (실측). 사용자 BYOK 는 게이트웨이 config/env 에 영속 저장하지 않는다.

## 검증

- [x] `npm run lint` 통과 (신규 error 0)
- [x] 신규 유닛 테스트 `gateway-routing.test.ts` 4/4 + providers 전체 회귀 통과, `tsc --noEmit` 통과
- [x] 라이브 E2E: 앱 WS 채팅으로 openrouter(`openai/gpt-4o-mini`)·ollama-cloud(`gpt-oss:120b-cloud`)·nvidia(`mistralai/mistral-nemotron`) 모두 게이트웨이 경유 200 확인 (게이트웨이 로그의 upstream egress 로 이중 검증)
- [x] 로컬 경로 회귀 없음: 로컬 chat/stream/tool·bge-m3 embedding·FLUX 이미지 생성 E2E 통과
- [x] `.env.example` 갱신 (환경변수 추가)
- 라우팅/응답 eval: 해당 없음 (로컬 라우팅 로직 무변경 — 외부 provider dispatch 경로만 추가)

## 운영 노트

- 운영 `.env` 에는 `LLM_GATEWAY_PROVIDERS=openrouter,ollama-cloud,nvidia` 적용됨
- NIM `meta/llama-3.3-70b-instruct` 타임아웃은 기존 무료티어 혼잡 함정(게이트웨이 무관), 타 NIM 모델 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)