### PR TITLE
docs(db): 010 마이그레이션의 'deploy 자동 백업' 주석 정정

### DIFF
--- a/db/migrations/010_feedback_schema_fixes.sql
+++ b/db/migrations/010_feedback_schema_fixes.sql
@@ -29,8 +29,9 @@ ON CONFLICT (version) DO NOTHING;
 -- ---------------------------------------------------------------
 -- 사전 정리: 비숫자 message_id (UUID, msg-{ts} 등 legacy 형식)는
 -- conversation_messages.id (INTEGER SERIAL)와 매핑 불가능한 orphan이므로 삭제.
--- 운영 데이터 손실 가능성 → backend/api/logs/db-backups/ 에 사전 dump 권장
--- (운영 환경에서는 openmake_llm.sh deploy가 실행 전 자동 백업)
+-- 운영 데이터 손실 가능성 → 사전 dump 권장.
+-- (정정 2026-07-31: openmake_llm.sh deploy 는 자동 백업을 수행하지 않는다 —
+--  백업은 별도 일일 pg_dump 스케줄 체계가 담당. arch.md §13 참고)
 DELETE FROM message_feedback
  WHERE message_id IS NOT NULL
    AND message_id !~ '^[0-9]+$';


### PR DESCRIPTION
arch.md §13에서 지적된 불일치 정정 — `openmake_llm.sh deploy` 는 실행 전 자동 백업을 수행하지 않습니다. 실제 백업은 별도 일일 `pg_dump` 스케줄 체계(로컬 14일 보존 + DGX 오프사이트)가 담당합니다. 주석만 변경 (SQL 로직 무변경, 기적용 마이그레이션 — runner 는 version 만 추적하므로 안전).

🤖 Generated with [Claude Code](https://claude.com/claude-code)