### PR TITLE
feat(chat): 오케스트레이션 자동 배정 Stage 1 — 모델이 토론·작업위임을 도구로 직접 배정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,9 @@ LLM_TIMEOUT=120000                              # HTTP 요청 타임아웃 (ms)
 # 빈값/미설정 = 전부 direct 호출. provider별 롤백은 목록에서 제거 + 재시작.
 # ollama-local(사용자별 endpoint)·chatgpt(OAuth) 는 목록과 무관하게 direct 유지.
 # LLM_GATEWAY_PROVIDERS=openrouter,ollama-cloud,nvidia
+# 오케스트레이션 자동 배정 (Stage 1) — 모델이 토론(start_discussion)·백그라운드 작업
+# (delegate_agent_task)을 도구로 직접 배정. 의도 프리필터 매칭 턴에만 도구 노출.
+# ORCHESTRATION_AUTO_DISPATCH=true
 # 모델 학습 지식 컷오프 라벨 — 프롬프트 "학습 기준일" 명시용. 기본 모델/외부 provider 교체 시 조정.
 # LLM_KNOWLEDGE_CUTOFF_KO=2024년 12월
 # LLM_KNOWLEDGE_CUTOFF_EN=December 2024

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1325,6 +1325,43 @@ export const AGENT_SPAWN = {
         .split(',').map((s) => s.trim().toLowerCase()).filter(Boolean),
 } as const;
 
+/**
+ * 오케스트레이션 자동 배정 (Stage 1, 2026-08-01) — 모델이 토론(start_discussion)·
+ * 백그라운드 작업(delegate_agent_task)을 도구 호출로 직접 배정한다.
+ *
+ * 설계 원칙 (실측 근거):
+ *  - 앞단 라우터 LLM 금지(Phase B 제거 이력) — 메인 모델의 tool_choice:auto 한 턴으로 결정.
+ *  - 도구 상시 노출 금지(도구폭주 함정) — 아래 *_INTENT_PATTERNS 프리필터에 걸릴 때만 노출.
+ *  - 고비용 경로 가드 — delegate 작업은 기존 승인 정책(TASK_SANDBOX_APPROVAL_POLICY)을
+ *    그대로 타고, 토론은 축소 프로파일(전문가 수·라운드 캡)로 실행.
+ */
+export const ORCHESTRATION_DISPATCH = {
+    /** 기본 OFF — 셰도우 관찰(노출·호출 로그) 후 운영 활성화. ORCHESTRATION_AUTO_DISPATCH=true. */
+    ENABLED: process.env.ORCHESTRATION_AUTO_DISPATCH === 'true',
+    /** 도구 경유 토론의 전문가 수 캡(기본 3) — 토글 토론(기본 10)보다 축소해 채팅 지연 억제. */
+    DISCUSSION_MAX_AGENTS: parseInt(process.env.ORCH_DISCUSSION_MAX_AGENTS || '3', 10),
+    /** 도구 경유 토론 시간 상한(ms, 기본 120초) — 초과 시 도구 결과로 오류 반환. */
+    DISCUSSION_TIMEOUT_MS: parseInt(process.env.ORCH_DISCUSSION_TIMEOUT_MS || '120000', 10),
+    /** 도구 결과 문자열 캡 — 토론 합성 결과의 컨텍스트 폭주 방지. */
+    RESULT_CAP_CHARS: parseInt(process.env.ORCH_RESULT_CAP_CHARS || '8000', 10),
+    /** 메시지당 오케스트레이션 도구 호출 캡(종류 무관 합산, 기본 1). */
+    MAX_CALLS_PER_MESSAGE: parseInt(process.env.ORCH_MAX_CALLS_PER_MESSAGE || '1', 10),
+} as const;
+
+/** 토론 의도 프리필터 — start_discussion 노출 게이트 (매칭 시에만 도구 노출). */
+export const DISCUSSION_INTENT_PATTERNS: readonly RegExp[] = [
+    /토론|찬반|논쟁|양쪽\s*(의견|입장)|여러\s*(관점|시각)|다각도|전문가.{0,6}(의견|관점|시각)/i,
+    /debate|pros\s+and\s+cons|multiple\s+perspectives/i,
+];
+
+/** 백그라운드 작업 위임 의도 프리필터 — delegate_agent_task 노출 게이트.
+ *  ⚠️ '보고서' 는 P1 인라인 보고서 파이프라인과 충돌하므로 의도적으로 제외.
+ *  프론트 Option B(파일 첨부+연산 → 자동 위임)와 상보적 — 여긴 텍스트-온리 중작업 커버. */
+export const TASK_DELEGATE_INTENT_PATTERNS: readonly RegExp[] = [
+    /백그라운드|에이전트\s*작업|(파일|엑셀|xlsx|csv|pdf|pptx?|스크립트)\s*(로|으로)?\s*(만들|생성|저장|변환)|코드를?\s*(실행|돌려)|장시간|오래\s*걸리/i,
+    /in\s+the\s+background|as\s+an?\s+agent\s+task|(create|generate|build)\s+(a\s+)?(file|excel|csv|pdf|script)/i,
+];
+
 
 /**
  * NotebookLM composer 연동 (routes/notebooklm.routes.ts).

--- a/apps/api/src/services/chat-service/__tests__/orchestration-dispatch.test.ts
+++ b/apps/api/src/services/chat-service/__tests__/orchestration-dispatch.test.ts
@@ -1,0 +1,96 @@
+/**
+ * 오케스트레이션 자동 배정 (Stage 1) — 프리필터·도구 노출 게이트 단위 테스트.
+ *
+ * env 파생 상수(ORCHESTRATION_DISPATCH.ENABLED)는 requireActual+override mock 으로 고정
+ * (프로젝트 관행 — env 의존 테스트 고정 패턴).
+ */
+jest.mock('../../../config/runtime-limits', () => {
+    const actual = jest.requireActual('../../../config/runtime-limits');
+    return {
+        ...actual,
+        ORCHESTRATION_DISPATCH: { ...actual.ORCHESTRATION_DISPATCH, ENABLED: true },
+    };
+});
+
+import { detectOrchestrationIntents, buildExternalToolPlan } from '../external-tool-plan';
+import {
+    START_DISCUSSION_TOOL_NAME,
+    DELEGATE_AGENT_TASK_TOOL_NAME,
+    isOrchestrationTool,
+} from '../orchestration-dispatch';
+import type { ChatMessageRequest } from '../../chat-service-types';
+
+function makeReq(message: string): ChatMessageRequest {
+    return { message } as ChatMessageRequest;
+}
+
+describe('detectOrchestrationIntents (프리필터)', () => {
+    it('토론 의도 매칭 — "찬반 토론해줘"', () => {
+        const r = detectOrchestrationIntents('원격근무 찬반 토론해줘');
+        expect(r.discussion).toBe(true);
+        expect(r.taskDelegate).toBe(false);
+    });
+
+    it('작업 위임 의도 매칭 — "엑셀로 만들어줘" / "백그라운드로"', () => {
+        expect(detectOrchestrationIntents('이 데이터를 엑셀로 만들어줘').taskDelegate).toBe(true);
+        expect(detectOrchestrationIntents('백그라운드 작업으로 처리해줘').taskDelegate).toBe(true);
+    });
+
+    it('단순 질문은 미매칭 — 오케스트레이션 도구 미노출 경로', () => {
+        const r = detectOrchestrationIntents('오늘 날씨 어때?');
+        expect(r.discussion).toBe(false);
+        expect(r.taskDelegate).toBe(false);
+    });
+
+    it('보고서 단독 의도는 위임 미매칭 (P1 인라인 파이프라인과 충돌 방지)', () => {
+        expect(detectOrchestrationIntents('시장 분석 보고서 작성해줘').taskDelegate).toBe(false);
+    });
+});
+
+describe('buildExternalToolPlan (노출 게이트)', () => {
+    const base = {
+        allowedTools: [],
+        toolCalling: true,
+        wantsMap: false,
+    };
+
+    it('의도 매칭 시에만 오케스트레이션 도구 노출', () => {
+        const plan = buildExternalToolPlan({
+            ...base,
+            req: makeReq('찬반 토론해줘'),
+            orchestration: { discussion: true, taskDelegate: false },
+        });
+        const names = plan.tools.map((t) => t.function.name);
+        expect(names).toContain(START_DISCUSSION_TOOL_NAME);
+        expect(names).not.toContain(DELEGATE_AGENT_TASK_TOOL_NAME);
+    });
+
+    it('의도 미매칭이면 미노출 (상시 노출 금지 — 도구폭주 방지)', () => {
+        const plan = buildExternalToolPlan({
+            ...base,
+            req: makeReq('안녕'),
+            orchestration: { discussion: false, taskDelegate: false },
+        });
+        const names = plan.tools.map((t) => t.function.name);
+        expect(names).not.toContain(START_DISCUSSION_TOOL_NAME);
+        expect(names).not.toContain(DELEGATE_AGENT_TASK_TOOL_NAME);
+    });
+
+    it('toolCalling=false 모델이면 의도가 있어도 미노출', () => {
+        const plan = buildExternalToolPlan({
+            ...base,
+            toolCalling: false,
+            req: makeReq('찬반 토론해줘'),
+            orchestration: { discussion: true, taskDelegate: true },
+        });
+        expect(plan.tools).toHaveLength(0);
+    });
+});
+
+describe('isOrchestrationTool', () => {
+    it('두 도구 이름만 참', () => {
+        expect(isOrchestrationTool(START_DISCUSSION_TOOL_NAME)).toBe(true);
+        expect(isOrchestrationTool(DELEGATE_AGENT_TASK_TOOL_NAME)).toBe(true);
+        expect(isOrchestrationTool('web_search')).toBe(false);
+    });
+});

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -13,14 +13,16 @@
  * @module services/chat-service/external-provider
  */
 import { createLogger } from '../../utils/logger';
-import { EXTERNAL_LLM_TOOL_BLACKLIST, LOOP_DETECTION, AGENT_LOOP_LIMITS, ARTIFACT_REQUEST_SUPPRESSED_TOOLS, ARTIFACT_INTENT_PATTERNS, MAP_INTENT_PATTERNS, ROUTE_INTENT_PATTERNS, WEB_SEARCH_INTENT_PATTERNS, EXTERNAL_LLM_INPUT_TOKEN_BUDGET, REPORT_PIPELINE, REPORT_INTENT_PATTERNS } from '../../config/runtime-limits';
+import { LOOP_DETECTION, AGENT_LOOP_LIMITS, MAP_INTENT_PATTERNS, EXTERNAL_LLM_INPUT_TOKEN_BUDGET, REPORT_PIPELINE, ORCHESTRATION_DISPATCH } from '../../config/runtime-limits';
 import { tryRenderReportBlock } from './report-block';
 import { estimateMessageTokens, truncateMessagesPreservingSystem } from '../../llm/model-pool';
 import { type Style } from '../../chat/style';
 import { buildExternalSystemPrompt } from './external-system-prompt';
-import { CHAT_DELEGATE_TOOL_NAME, buildChatDelegateTool, runChatDelegate } from './chat-delegate';
-import { SPAWN_AGENTS_TOOL_NAME, buildSpawnAgentsTool, runChatSpawnAgents } from '../agent-spawn/spawn-agents';
+import { CHAT_DELEGATE_TOOL_NAME, runChatDelegate } from './chat-delegate';
+import { SPAWN_AGENTS_TOOL_NAME, runChatSpawnAgents } from '../agent-spawn/spawn-agents';
 import { CHAT_SUBAGENT, AGENT_SPAWN } from '../../config/runtime-limits';
+import { buildExternalToolPlan, detectOrchestrationIntents } from './external-tool-plan';
+import { isOrchestrationTool, runOrchestrationTool } from './orchestration-dispatch';
 import type { ChatMessage, ToolDefinition } from '../../llm';
 import type { ChatMessageRequest } from '../chat-service-types';
 import type { UserContext } from '../../mcp/user-sandbox';
@@ -85,9 +87,11 @@ export async function runExternalStream(
 
     // 위치/지도 의도면 카카오 도구 우선 라우팅 — 시스템 프롬프트 넛지 + 도구 강제 주입에 함께 쓰인다.
     const wantsMap = MAP_INTENT_PATTERNS.some((re) => re.test(req.message ?? ''));
+    // 오케스트레이션 자동 배정 의도 — 프롬프트 가이드 주입(아래)과 도구 노출(플랜)이 공유.
+    const orchestration = detectOrchestrationIntents(req.message);
 
     // 시스템 프롬프트 조립(정적 헌법 → DYNAMIC → 가변)은 external-system-prompt 로 분리.
-    const systemContent = buildExternalSystemPrompt({ req, resolved, ctx, wantsMap });
+    const systemContent = buildExternalSystemPrompt({ req, resolved, ctx, wantsMap, orchestration });
     if (systemContent) {
         messages.push({ role: 'system', content: systemContent });
     }
@@ -146,63 +150,15 @@ export async function runExternalStream(
         }
     }
 
-    // 명시적 아티팩트 생성 요청(사용자 아티팩트 토글 또는 메시지 패턴)이면 distractor
-    // always-on 도구(generate_image 등)를 제외해 모델이 도구 호출 대신 <artifact> 산출물을
-    // 쓰도록 유도 (2026-06-23 통제실험 근거).
-    // 보고서 의도(P1 파이프라인)는 산출물이 reportdata→아티팩트이므로 아티팩트 의도와
-    // 동일하게 distractor 를 억제한다 (web_search 는 억제 목록에 없어 조사 가능).
-    const wantsReport = REPORT_PIPELINE.ENABLED
-        && REPORT_INTENT_PATTERNS.some((re) => re.test(req.message ?? ''));
-    const wantsArtifact = req.artifactMode === true
-        || wantsReport
-        || ARTIFACT_INTENT_PATTERNS.some((re) => re.test(req.message ?? ''));
-    // 위치/지도 의도(wantsMap, 위에서 계산)면 generate_image 를 제외 — 모델이 가짜 지도
-    // 이미지를 그리는 대신 카카오 검색 + 네이티브 지도 블록을 쓰도록 유도 (distractor 억제).
-    const tools = caps.toolCalling
-        ? deps.allowedTools.filter((t) =>
-            !EXTERNAL_LLM_TOOL_BLACKLIST.includes(t.function.name)
-            && !(wantsArtifact && ARTIFACT_REQUEST_SUPPRESSED_TOOLS.includes(t.function.name))
-            && !(wantsMap && t.function.name === 'generate_image'))
-        : [];
-    // 채팅 서브에이전트(chat-delegate): 전문가 위임 도구 노출 — 스키마 +1 은 문법 컴파일 무해.
-    if (CHAT_SUBAGENT.ENABLED && caps.toolCalling) {
-        tools.push(buildChatDelegateTool());
-    }
-    // 병렬 서브에이전트 fan-out(spawn_agents): 독립 하위 작업 N개 병렬 위임 — agent-spawn 공용 모듈.
-    if (AGENT_SPAWN.ENABLED && caps.toolCalling) {
-        tools.push(buildSpawnAgentsTool());
-    }
-    if (wantsArtifact && caps.toolCalling) {
-        logger.info(`[Artifact] 명시적 아티팩트 요청 감지 — distractor 도구 억제 (잔여 도구 ${tools.length}종)`);
-    }
-    if (wantsMap && caps.toolCalling) {
-        logger.info(`[Map] 위치/지도 의도 감지 — generate_image 억제 (잔여 도구 ${tools.length}종)`);
-    }
-    // 지도/길찾기 의도 시 첫 턴에 카카오 도구를 강제 호출(tool_choice)한다. 길찾기면 find-route,
-    // 그 외 지도면 search-places. 넛지만으론 qwen 이 web_search/자체아티팩트로 이탈 → 강제로
-    // 블록 확보 후 결정적 주입.
-    const routeIntent = ROUTE_INTENT_PATTERNS.some((re) => re.test(req.message ?? ''));
-    const forcedKakaoToolName = caps.toolCalling
-        ? (routeIntent
-            ? tools.find((t) => t.function.name.includes('find-route'))?.function.name
-            : (wantsMap ? tools.find((t) => t.function.name.includes('search-places'))?.function.name : undefined))
-        : undefined;
-    if (forcedKakaoToolName) {
-        logger.info(`[Map] 첫 턴 tool_choice 강제: ${forcedKakaoToolName}`);
-    }
-    // 명시적 웹 검색 요청이면 첫 턴에 web_search 를 강제한다 — 봇 히스토리에 남은
-    // "검색 불가/오프라인" 자기 발언 재주입 시 qwen 이 시스템 지시로도 교정되지 않고
-    // 도구 호출을 거부하는 환각의 결정적 차단 (카카오 tool_choice 강제와 동일 선례).
-    const forcedWebSearchToolName = !forcedKakaoToolName
-        && (WEB_SEARCH_INTENT_PATTERNS.some((re) => re.test(req.message ?? '')) || ctx.tailWebGround === true)
-        ? tools.find((t) => t.function.name === 'web_search')?.function.name
-        : undefined;
-    if (forcedWebSearchToolName) {
-        logger.info(ctx.tailWebGround === true
-            ? '[TailGate] Stage 2B factual tail — 첫 턴 tool_choice 강제: web_search'
-            : '[WebSearch] 명시적 검색 요청 — 첫 턴 tool_choice 강제: web_search');
-    }
-    const forcedFirstTurnToolName = forcedKakaoToolName ?? forcedWebSearchToolName;
+    // 도구 노출·억제·첫 턴 강제 결정은 external-tool-plan 으로 분리 (동작 동일).
+    const { tools, forcedFirstTurnToolName } = buildExternalToolPlan({
+        allowedTools: deps.allowedTools,
+        req,
+        toolCalling: caps.toolCalling,
+        wantsMap,
+        ...(ctx.tailWebGround !== undefined ? { tailWebGround: ctx.tailWebGround } : {}),
+        orchestration,
+    });
 
     const startedAt = Date.now();
     let errorCode: string | null = null;
@@ -223,6 +179,8 @@ export async function runExternalStream(
     let delegateCalls = 0;
     // 병렬 fan-out 호출 집계 — 메시지당 캡(AGENT_SPAWN.MAX_CALLS_PER_MESSAGE) 초과 시 거부.
     let spawnCalls = 0;
+    // 오케스트레이션 배정 호출 집계 — 메시지당 캡(ORCHESTRATION_DISPATCH.MAX_CALLS_PER_MESSAGE).
+    let orchestrationCalls = 0;
 
     // generate_image 결과의 이미지 마크다운 추적 — 일부 모델(qwen 등)이 도구 지시("마크다운
     // 그대로 포함")를 누락해 생성된 이미지가 채팅에 표시되지 않는 문제 보정용.
@@ -359,6 +317,19 @@ export async function runExternalStream(
                             args: tc.args as Record<string, unknown>,
                             chatTools: tools,
                             userCtx: deps.currentUserContext ?? { userId: 'guest', role: 'guest' },
+                            ...(req.abortSignal ? { signal: req.abortSignal } : {}),
+                        });
+                } else if (isOrchestrationTool(tc.name)) {
+                    // 오케스트레이션 자동 배정 — 토론 인라인 실행 / 백그라운드 작업 위임.
+                    deps.mcpToolStartCallback?.({ toolName: tc.name });
+                    orchestrationCalls++;
+                    toolResult = orchestrationCalls > ORCHESTRATION_DISPATCH.MAX_CALLS_PER_MESSAGE
+                        ? `Error: 이 메시지의 오케스트레이션 호출 한도(${ORCHESTRATION_DISPATCH.MAX_CALLS_PER_MESSAGE}회)에 도달했습니다. 지금까지의 결과로 직접 답변하세요.`
+                        : await runOrchestrationTool({
+                            name: tc.name,
+                            args: tc.args as Record<string, unknown>,
+                            userCtx: deps.currentUserContext ?? { userId: 'guest', role: 'guest' },
+                            ...(req.userLanguagePreference ? { userLanguage: req.userLanguagePreference } : {}),
                             ...(req.abortSignal ? { signal: req.abortSignal } : {}),
                         });
                 } else {

--- a/apps/api/src/services/chat-service/external-system-prompt.ts
+++ b/apps/api/src/services/chat-service/external-system-prompt.ts
@@ -12,6 +12,7 @@ import type { ResolvedProvider } from '../../providers/provider-router';
 import { getExternalProviderSystemGuards } from '../../chat/prompt';
 import { getCurrentDate } from '../../utils/datetime';
 import { getStyleGuard, normalizeStyle } from '../../chat/style';
+import { ORCHESTRATION_PROMPT_GUIDE } from './orchestration-dispatch';
 import type { StreamFromExternalContext } from './external-provider';
 
 /**
@@ -23,8 +24,10 @@ export function buildExternalSystemPrompt(params: {
     resolved: ResolvedProvider;
     ctx: StreamFromExternalContext;
     wantsMap: boolean;
+    /** 오케스트레이션 자동 배정 의도(external-tool-plan 과 공유) — 매칭 턴에만 가이드 주입. */
+    orchestration?: { discussion: boolean; taskDelegate: boolean };
 }): string {
-    const { req, resolved, ctx, wantsMap } = params;
+    const { req, resolved, ctx, wantsMap, orchestration } = params;
     const systemPromptParts: string[] = [];
 
     // ════════════════════════════════════════════════════════════════════
@@ -149,6 +152,12 @@ export function buildExternalSystemPrompt(params: {
             '⚠️ 지도는 시스템이 도구 결과로 자동 표시하니, 당신은 kakaomap 코드 블록이나 좌표(lat/lng) ' +
             '목록을 절대 직접 작성하지 마세요. 사람이 읽을 요약(장소명·주소·거리·소요시간 등)만 작성하세요.',
         );
+    }
+
+    // 오케스트레이션 자동 배정(Stage 1) — 해당 의도 프리필터 매칭 턴에만 배정 가이드 주입
+    // (도구 노출과 동일 조건 공유 — external-tool-plan.detectOrchestrationIntents).
+    if (orchestration && (orchestration.discussion || orchestration.taskDelegate)) {
+        systemPromptParts.push(ORCHESTRATION_PROMPT_GUIDE.trim());
     }
 
     return systemPromptParts.join('\n\n');

--- a/apps/api/src/services/chat-service/external-tool-plan.ts
+++ b/apps/api/src/services/chat-service/external-tool-plan.ts
@@ -1,0 +1,137 @@
+/**
+ * ============================================================
+ * External Tool Plan — 채팅 턴의 도구 노출·억제·강제 결정
+ * ============================================================
+ *
+ * external-provider 에서 분리(파일 크기 가드): 의도 프리필터 기반으로
+ * "이 턴에 어떤 도구를 노출/억제하고 첫 턴에 무엇을 강제할지"를 한 곳에서 결정한다.
+ *
+ * - distractor 억제: 아티팩트/보고서 의도 → generate_image 등 제외 (2026-06-23 통제실험)
+ * - 지도 의도 → 카카오 도구 강제(tool_choice), 명시 검색 의도 → web_search 강제
+ * - 서브에이전트: delegate_expert(CHAT_SUBAGENT) · spawn_agents(AGENT_SPAWN)
+ * - 오케스트레이션 자동 배정(Stage 1): 토론/작업위임 의도 프리필터 매칭 시에만
+ *   start_discussion / delegate_agent_task 노출 (상시 노출 금지 — 도구폭주 방지)
+ *
+ * @module services/chat-service/external-tool-plan
+ */
+import {
+    EXTERNAL_LLM_TOOL_BLACKLIST, ARTIFACT_REQUEST_SUPPRESSED_TOOLS, ARTIFACT_INTENT_PATTERNS,
+    ROUTE_INTENT_PATTERNS, WEB_SEARCH_INTENT_PATTERNS, REPORT_PIPELINE, REPORT_INTENT_PATTERNS,
+    CHAT_SUBAGENT, AGENT_SPAWN, ORCHESTRATION_DISPATCH, DISCUSSION_INTENT_PATTERNS, TASK_DELEGATE_INTENT_PATTERNS,
+} from '../../config/runtime-limits';
+import { buildChatDelegateTool } from './chat-delegate';
+import { buildSpawnAgentsTool } from '../agent-spawn/spawn-agents';
+import { buildStartDiscussionTool, buildDelegateAgentTaskTool } from './orchestration-dispatch';
+import type { ToolDefinition } from '../../llm';
+import type { ChatMessageRequest } from '../chat-service-types';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('ChatExternalProvider');
+
+export interface OrchestrationIntents {
+    discussion: boolean;
+    taskDelegate: boolean;
+}
+
+/** PURE: 오케스트레이션 자동 배정 의도 감지 — 프롬프트 가이드 주입과 도구 노출이 공유. */
+export function detectOrchestrationIntents(message: string | undefined): OrchestrationIntents {
+    if (!ORCHESTRATION_DISPATCH.ENABLED) return { discussion: false, taskDelegate: false };
+    const msg = message ?? '';
+    return {
+        discussion: DISCUSSION_INTENT_PATTERNS.some((re) => re.test(msg)),
+        taskDelegate: TASK_DELEGATE_INTENT_PATTERNS.some((re) => re.test(msg)),
+    };
+}
+
+export interface ExternalToolPlan {
+    tools: ToolDefinition[];
+    /** 첫 턴 tool_choice 강제 대상 (카카오 지도 > web_search 우선순위). */
+    forcedFirstTurnToolName?: string;
+}
+
+/**
+ * 이 턴의 도구 목록과 첫 턴 강제 도구를 결정한다.
+ * (external-provider 의 기존 로직 이동 — 동작 동일, 오케스트레이션 노출만 추가)
+ */
+export function buildExternalToolPlan(params: {
+    allowedTools: ToolDefinition[];
+    req: ChatMessageRequest;
+    toolCalling: boolean;
+    wantsMap: boolean;
+    tailWebGround?: boolean;
+    orchestration: OrchestrationIntents;
+}): ExternalToolPlan {
+    const { allowedTools, req, toolCalling, wantsMap, tailWebGround, orchestration } = params;
+
+    // 명시적 아티팩트 생성 요청(사용자 아티팩트 토글 또는 메시지 패턴)이면 distractor
+    // always-on 도구(generate_image 등)를 제외해 모델이 도구 호출 대신 <artifact> 산출물을
+    // 쓰도록 유도 (2026-06-23 통제실험 근거).
+    // 보고서 의도(P1 파이프라인)는 산출물이 reportdata→아티팩트이므로 아티팩트 의도와
+    // 동일하게 distractor 를 억제한다 (web_search 는 억제 목록에 없어 조사 가능).
+    const wantsReport = REPORT_PIPELINE.ENABLED
+        && REPORT_INTENT_PATTERNS.some((re) => re.test(req.message ?? ''));
+    const wantsArtifact = req.artifactMode === true
+        || wantsReport
+        || ARTIFACT_INTENT_PATTERNS.some((re) => re.test(req.message ?? ''));
+    // 위치/지도 의도(wantsMap)면 generate_image 를 제외 — 모델이 가짜 지도
+    // 이미지를 그리는 대신 카카오 검색 + 네이티브 지도 블록을 쓰도록 유도 (distractor 억제).
+    const tools = toolCalling
+        ? allowedTools.filter((t) =>
+            !EXTERNAL_LLM_TOOL_BLACKLIST.includes(t.function.name)
+            && !(wantsArtifact && ARTIFACT_REQUEST_SUPPRESSED_TOOLS.includes(t.function.name))
+            && !(wantsMap && t.function.name === 'generate_image'))
+        : [];
+    // 채팅 서브에이전트(chat-delegate): 전문가 위임 도구 노출 — 스키마 +1 은 문법 컴파일 무해.
+    if (CHAT_SUBAGENT.ENABLED && toolCalling) {
+        tools.push(buildChatDelegateTool());
+    }
+    // 병렬 서브에이전트 fan-out(spawn_agents): 독립 하위 작업 N개 병렬 위임 — agent-spawn 공용 모듈.
+    if (AGENT_SPAWN.ENABLED && toolCalling) {
+        tools.push(buildSpawnAgentsTool());
+    }
+    // 오케스트레이션 자동 배정(Stage 1): 의도 프리필터 매칭 턴에만 노출.
+    if (orchestration.discussion && toolCalling) {
+        tools.push(buildStartDiscussionTool());
+        logger.info('[Orchestration] 토론 의도 감지 — start_discussion 노출');
+    }
+    if (orchestration.taskDelegate && toolCalling) {
+        tools.push(buildDelegateAgentTaskTool());
+        logger.info('[Orchestration] 작업 위임 의도 감지 — delegate_agent_task 노출');
+    }
+    if (wantsArtifact && toolCalling) {
+        logger.info(`[Artifact] 명시적 아티팩트 요청 감지 — distractor 도구 억제 (잔여 도구 ${tools.length}종)`);
+    }
+    if (wantsMap && toolCalling) {
+        logger.info(`[Map] 위치/지도 의도 감지 — generate_image 억제 (잔여 도구 ${tools.length}종)`);
+    }
+    // 지도/길찾기 의도 시 첫 턴에 카카오 도구를 강제 호출(tool_choice)한다. 길찾기면 find-route,
+    // 그 외 지도면 search-places. 넛지만으론 qwen 이 web_search/자체아티팩트로 이탈 → 강제로
+    // 블록 확보 후 결정적 주입.
+    const routeIntent = ROUTE_INTENT_PATTERNS.some((re) => re.test(req.message ?? ''));
+    const forcedKakaoToolName = toolCalling
+        ? (routeIntent
+            ? tools.find((t) => t.function.name.includes('find-route'))?.function.name
+            : (wantsMap ? tools.find((t) => t.function.name.includes('search-places'))?.function.name : undefined))
+        : undefined;
+    if (forcedKakaoToolName) {
+        logger.info(`[Map] 첫 턴 tool_choice 강제: ${forcedKakaoToolName}`);
+    }
+    // 명시적 웹 검색 요청이면 첫 턴에 web_search 를 강제한다 — 봇 히스토리에 남은
+    // "검색 불가/오프라인" 자기 발언 재주입 시 qwen 이 시스템 지시로도 교정되지 않고
+    // 도구 호출을 거부하는 환각의 결정적 차단 (카카오 tool_choice 강제와 동일 선례).
+    const forcedWebSearchToolName = !forcedKakaoToolName
+        && (WEB_SEARCH_INTENT_PATTERNS.some((re) => re.test(req.message ?? '')) || tailWebGround === true)
+        ? tools.find((t) => t.function.name === 'web_search')?.function.name
+        : undefined;
+    if (forcedWebSearchToolName) {
+        logger.info(tailWebGround === true
+            ? '[TailGate] Stage 2B factual tail — 첫 턴 tool_choice 강제: web_search'
+            : '[WebSearch] 명시적 검색 요청 — 첫 턴 tool_choice 강제: web_search');
+    }
+    const forcedFirstTurnToolName = forcedKakaoToolName ?? forcedWebSearchToolName;
+
+    return {
+        tools,
+        ...(forcedFirstTurnToolName ? { forcedFirstTurnToolName } : {}),
+    };
+}

--- a/apps/api/src/services/chat-service/orchestration-dispatch.ts
+++ b/apps/api/src/services/chat-service/orchestration-dispatch.ts
@@ -1,0 +1,204 @@
+/**
+ * ============================================================
+ * 오케스트레이션 자동 배정 (Stage 1) — 모델이 도구로 직접 배정
+ * ============================================================
+ *
+ * 채팅 도구 루프에 두 도구를 의도 프리필터 게이트로 노출한다:
+ *  - start_discussion: 다각 관점 토론(discussion engine 축소 프로파일)을 인라인 실행
+ *  - delegate_agent_task: 장시간·파일 산출 작업을 백그라운드 에이전트 작업으로 위임
+ *
+ * 설계 원칙 (arch.md §4-5 정합):
+ *  - 별도 라우터 LLM 없음 — 메인 모델의 tool_choice:auto 가 같은 턴에 결정.
+ *  - 상시 노출 금지 — DISCUSSION/TASK_DELEGATE_INTENT_PATTERNS 매칭 시에만 노출(도구폭주 방지).
+ *  - 비용 가드 — 토론은 전문가·시간 캡, 위임 작업은 기존 승인 정책(HITL)·큐·goal judge 를 그대로 탄다.
+ *  - 실행 주체는 앱 — LiteLLM 게이트웨이는 모델 호출만 담당(이중 라우팅 없음).
+ *
+ * @module services/chat-service/orchestration-dispatch
+ */
+import { randomUUID } from 'crypto';
+import { createClient } from '../../llm';
+import type { ChatMessage } from '../../llm';
+import type { ToolDefinition } from '../../llm/types';
+import type { UserContext } from '../../mcp/user-sandbox';
+import { getModelForRole } from '../../config/model-roles';
+import { createDiscussionEngine } from '../../agents/discussion-engine';
+import { getUnifiedDatabase } from '../../data/models/unified-database';
+import { AgentTaskService } from '../AgentTaskService';
+import { dispatchAgentTask } from '../agent-task/task-queue';
+import { ORCHESTRATION_DISPATCH, MODEL_CONTEXT_DEFAULTS, AGENT_TASK_LIMITS } from '../../config/runtime-limits';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('OrchestrationDispatch');
+
+export const START_DISCUSSION_TOOL_NAME = 'start_discussion';
+export const DELEGATE_AGENT_TASK_TOOL_NAME = 'delegate_agent_task';
+
+export function isOrchestrationTool(name: string): boolean {
+    return name === START_DISCUSSION_TOOL_NAME || name === DELEGATE_AGENT_TASK_TOOL_NAME;
+}
+
+/** 시스템 프롬프트에 주입하는 배정 가이드 — 해당 의도 프리필터 매칭 턴에만 주입된다. */
+export const ORCHESTRATION_PROMPT_GUIDE =
+    '\n\n[오케스트레이션 배정]\n'
+    + '- 다각 관점 비교·찬반 논쟁이 명확히 유용한 질문이고 start_discussion 도구가 제공된 경우에만 그 도구로 전문가 토론을 실행해 결과를 종합하세요.\n'
+    + '- 파일 생성·코드 실행·장시간 처리가 필요한 요청이고 delegate_agent_task 도구가 제공된 경우 백그라운드 작업으로 위임하고, 작업 id 와 확인 방법을 사용자에게 안내하세요.\n'
+    + '- 그 외에는 도구 없이 직접 답하는 것이 기본입니다 — 단순 질문에 오케스트레이션을 쓰지 마세요.';
+
+export function buildStartDiscussionTool(): ToolDefinition {
+    return {
+        type: 'function',
+        function: {
+            name: START_DISCUSSION_TOOL_NAME,
+            description: '주제에 대해 전문가 에이전트 여러 명의 토론을 실행하고 합성된 결론을 반환합니다. '
+                + '찬반·다각 관점 비교가 답변 품질을 실제로 바꾸는 경우에만 사용하세요 '
+                + `(실행에 수십 초가 걸립니다). 전문가는 최대 ${ORCHESTRATION_DISPATCH.DISCUSSION_MAX_AGENTS}명이 자동 선정됩니다.`,
+            parameters: {
+                type: 'object',
+                properties: {
+                    topic: { type: 'string', description: '토론 주제 (사용자 질문을 구체적 쟁점으로 정리)' },
+                },
+                required: ['topic'],
+            },
+        },
+    };
+}
+
+export function buildDelegateAgentTaskTool(): ToolDefinition {
+    return {
+        type: 'function',
+        function: {
+            name: DELEGATE_AGENT_TASK_TOOL_NAME,
+            description: '파일 생성·코드 실행·다단계 장시간 처리가 필요한 요청을 백그라운드 에이전트 작업으로 위임합니다. '
+                + '작업은 샌드박스에서 실행되며 위험 도구는 사용자 승인(HITL)을 거칩니다. '
+                + '즉시 답할 수 있는 질문에는 사용하지 말고 직접 답하세요.',
+            parameters: {
+                type: 'object',
+                properties: {
+                    goal: { type: 'string', description: '작업 목표 — 산출물과 완료 조건을 구체적으로 기술' },
+                    max_turns: { type: 'number', description: `최대 턴 수 (선택, 기본 ${AGENT_TASK_LIMITS.DEFAULT_MAX_TURNS})` },
+                },
+                required: ['goal'],
+            },
+        },
+    };
+}
+
+/** start_discussion 실행 — 축소 프로파일(전문가·라운드 캡) 토론을 동기 실행해 합성 결과를 반환. */
+async function runStartDiscussion(params: {
+    args: Record<string, unknown>;
+    userLanguage?: string;
+    signal?: AbortSignal;
+}): Promise<string> {
+    const topic = String(params.args.topic ?? '').trim();
+    if (!topic) return 'Error: topic 이 필요합니다.';
+
+    const client = createClient({ model: getModelForRole('chat') });
+    const generateResponse = async (systemPrompt: string, userMessage: string): Promise<string> => {
+        if (params.signal?.aborted) throw new Error('aborted');
+        let response = '';
+        const chatMessages: ChatMessage[] = [
+            { role: 'system', content: systemPrompt },
+            { role: 'user', content: userMessage },
+        ];
+        await client.chat(chatMessages, { num_predict: MODEL_CONTEXT_DEFAULTS.DEFAULT_NUM_PREDICT }, (token, thinking) => {
+            if (!thinking) response += token;
+            if (params.signal?.aborted) throw new Error('aborted');
+        });
+        return response;
+    };
+
+    const engine = createDiscussionEngine(generateResponse, {
+        maxAgents: ORCHESTRATION_DISPATCH.DISCUSSION_MAX_AGENTS,
+        maxRounds: 1,
+        enableCrossReview: false,
+        enableFactCheck: false,
+        enableDeepThinking: false,
+        ...(params.userLanguage ? { userLanguage: params.userLanguage } : {}),
+    });
+
+    const started = Date.now();
+    try {
+        const result = await Promise.race([
+            engine.startDiscussion(topic),
+            new Promise<never>((_, rej) => setTimeout(
+                () => rej(new Error(`토론 시간 상한(${ORCHESTRATION_DISPATCH.DISCUSSION_TIMEOUT_MS}ms) 초과`)),
+                ORCHESTRATION_DISPATCH.DISCUSSION_TIMEOUT_MS,
+            )),
+        ]);
+        logger.info(`[start_discussion] 완료 ${Date.now() - started}ms, 참여 ${result.participants.length}명`);
+        const body = `참여 전문가: ${result.participants.join(', ')}\n\n${result.finalAnswer}`;
+        return body.length > ORCHESTRATION_DISPATCH.RESULT_CAP_CHARS
+            ? `${body.slice(0, ORCHESTRATION_DISPATCH.RESULT_CAP_CHARS)}\n...(길이 상한으로 잘림)`
+            : body;
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.warn(`[start_discussion] 실패: ${msg}`);
+        return `Error: 토론 실행 실패 — ${msg}. 지금까지의 지식으로 직접 답변하세요.`;
+    }
+}
+
+/** delegate_agent_task 실행 — 작업 생성 + 백그라운드 디스패치(즉시 반환, HITL·큐는 기존 경로). */
+async function runDelegateAgentTask(params: {
+    args: Record<string, unknown>;
+    userCtx: UserContext;
+}): Promise<string> {
+    const goal = String(params.args.goal ?? '').trim();
+    if (!goal) return 'Error: goal 이 필요합니다.';
+    const userId = String(params.userCtx.userId ?? '');
+    if (!userId || userId === 'guest') return 'Error: 로그인된 사용자만 에이전트 작업을 위임할 수 있습니다.';
+
+    const rawTurns = Number(params.args.max_turns);
+    const maxTurns = Number.isFinite(rawTurns) && rawTurns > 0
+        ? Math.min(Math.floor(rawTurns), AGENT_TASK_LIMITS.MAX_TURNS_CEILING)
+        : AGENT_TASK_LIMITS.DEFAULT_MAX_TURNS;
+
+    try {
+        const taskId = randomUUID();
+        const db = getUnifiedDatabase();
+        await db.createAgentTask({ id: taskId, userId, goal, maxTurns });
+        const service = new AgentTaskService();
+        const outcome = await dispatchAgentTask({
+            taskId,
+            userId,
+            run: () => service.execute({
+                taskId,
+                goal,
+                userId,
+                userRole: (params.userCtx.role === 'admin' ? 'admin' : 'user'),
+                maxTurns,
+            }),
+        });
+        logger.info(`[delegate_agent_task] 작업 위임: ${taskId} (${outcome})`);
+        return JSON.stringify({
+            task_id: taskId,
+            status: outcome,
+            note: '백그라운드 에이전트 작업으로 위임되었습니다. 위험 도구 사용 시 채팅/작업 페이지에 승인 요청이 표시됩니다. '
+                + '진행 상황은 agent_task_get 도구 또는 "에이전트 작업" 페이지에서 확인할 수 있습니다.',
+        });
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.warn(`[delegate_agent_task] 실패: ${msg}`);
+        return `Error: 작업 위임 실패 — ${msg}`;
+    }
+}
+
+/** 오케스트레이션 도구 실행 진입점 — 실패는 문자열로 흡수(채팅 루프를 죽이지 않음). */
+export async function runOrchestrationTool(params: {
+    name: string;
+    args: Record<string, unknown>;
+    userCtx: UserContext;
+    userLanguage?: string;
+    signal?: AbortSignal;
+}): Promise<string> {
+    if (params.name === START_DISCUSSION_TOOL_NAME) {
+        return runStartDiscussion({
+            args: params.args,
+            ...(params.userLanguage ? { userLanguage: params.userLanguage } : {}),
+            ...(params.signal ? { signal: params.signal } : {}),
+        });
+    }
+    if (params.name === DELEGATE_AGENT_TASK_TOOL_NAME) {
+        return runDelegateAgentTask({ args: params.args, userCtx: params.userCtx });
+    }
+    return `Error: 알 수 없는 오케스트레이션 도구 — ${params.name}`;
+}


### PR DESCRIPTION
## 요약

사용자 모드 토글 없이도 **모델이 같은 턴에서 오케스트레이션을 직접 배정**한다. 별도 라우터 LLM을 두지 않고(Phase B 제거 이력 준수) 메인 모델의 `tool_choice: auto` 한 턴으로 결정한다.

## 설계 (실측 근거 반영)

| 원칙 | 구현 |
|---|---|
| 앞단 라우터 LLM 금지 (Phase B) | 같은 턴 tool_choice:auto — 추가 LLM 호출·지연 0 |
| 도구 상시 노출 금지 (도구폭주 함정) | `DISCUSSION/TASK_DELEGATE_INTENT_PATTERNS` regex 프리필터 매칭 턴에만 노출 |
| 고비용 경로 가드 | 토론=축소 프로파일(전문가 3·1라운드·120s 상한·결과 캡), 위임 작업=기존 승인 정책(HITL)·큐·goal judge 그대로 경유 |
| 남용 억제 | 메시지당 호출 캡(기본 1) — delegate_expert/spawn_agents 캡 관행 |
| 롤백 | `ORCHESTRATION_AUTO_DISPATCH` env (기본 OFF) — 플래그 제거+재시작 |

## 변경 내용

- **신규 `orchestration-dispatch.ts`** — `start_discussion`(discussion engine 인라인, 합성 결과 반환)·`delegate_agent_task`(작업 생성+백그라운드 디스패치, task id 즉시 반환) + 배정 프롬프트 가이드
- **신규 `external-tool-plan.ts`** — external-provider 의 도구 노출·억제·첫 턴 강제 로직 이동(동작 동일) + 오케스트레이션 노출 게이트 통합. 파일 크기 가드 대응(596→567줄)
- `external-system-prompt.ts` — 의도 매칭 턴에만 배정 가이드 주입
- `runtime-limits.ts` — `ORCHESTRATION_DISPATCH` 상수 + 의도 패턴 2종 ('보고서'는 P1 인라인 파이프라인 충돌 방지로 위임 패턴에서 의도적 제외)

## 검증

- [x] 유닛 8개 신규(프리필터·노출 게이트·toolCalling=false) + chat-service 56개 회귀 통과, `tsc` 통과, lint error 0
- [x] **라이브**: "찬반 토론해줘" → `start_discussion` 발동 → 전문가 3인 토론 37s → 합성 답변 470tok 스트리밍
- [x] **라이브**: "CSV 파일로 만들어줘"(첨부 없음) → `delegate_agent_task` 발동 → 작업 생성·running → **HITL `paused` 정상 진입**(승인 가드 동작 확인)
- [x] 단순 질문엔 도구 미노출(프리필터)
- [x] 운영 `.env` `ORCHESTRATION_AUTO_DISPATCH=true` 반영·검증 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)