### PR TITLE
feat(chat): 오케스트레이션 자동 배정 Stage 2 — 셰도우 계측 (086)

### DIFF
--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -71,6 +71,9 @@ export interface StreamFromExternalContext {
     tailWebGround?: boolean;
     /** P1 보고서 파이프라인 — 보고서 의도 턴에만 주입되는 reportdata 데이터 계약 가이드. */
     reportGuideBlock?: string;
+    /** 오케스트레이션 배정 텔레메트리(Stage 2) — 스트림 종료 시 external-provider 가 채워
+     *  되돌려준다(호출부가 셰도우 적재). 의도 미매칭 턴은 undefined 유지. */
+    orchestrationTelemetry?: import('./orchestration-shadow-recorder').OrchestrationTelemetry;
 }
 
 /**
@@ -159,6 +162,14 @@ export async function runExternalStream(
         ...(ctx.tailWebGround !== undefined ? { tailWebGround: ctx.tailWebGround } : {}),
         orchestration,
     });
+    // Stage 2 셰도우 계측 — 의도 매칭 턴만 텔레메트리를 초기화(호출 시 아래 루프가 갱신).
+    if (orchestration.discussion || orchestration.taskDelegate) {
+        ctx.orchestrationTelemetry = {
+            discussionIntent: orchestration.discussion,
+            taskDelegateIntent: orchestration.taskDelegate,
+            exposed: tools.filter((t) => isOrchestrationTool(t.function.name)).map((t) => t.function.name),
+        };
+    }
 
     const startedAt = Date.now();
     let errorCode: string | null = null;
@@ -332,6 +343,11 @@ export async function runExternalStream(
                             ...(req.userLanguagePreference ? { userLanguage: req.userLanguagePreference } : {}),
                             ...(req.abortSignal ? { signal: req.abortSignal } : {}),
                         });
+                    // Stage 2 셰도우 계측 — 첫 호출의 도구명·성공 여부 기록.
+                    if (ctx.orchestrationTelemetry && !ctx.orchestrationTelemetry.called) {
+                        ctx.orchestrationTelemetry.called = tc.name;
+                        ctx.orchestrationTelemetry.success = !toolResult.startsWith('Error');
+                    }
                 } else {
                     toolResult = await executeExternalTool(deps, tc.name, tc.args as Record<string, unknown>);
                 }

--- a/apps/api/src/services/chat-service/message-pipeline.ts
+++ b/apps/api/src/services/chat-service/message-pipeline.ts
@@ -34,6 +34,9 @@ import { resolveModeExternalClient } from './mode-external-client';
 import { buildUserContextBlocks } from './user-context-blocks';
 import { autoFormMemories } from './memory-extraction';
 import type { RequestContext } from './request-context';
+import { recordOrchestrationDispatch } from './orchestration-shadow-recorder';
+import { detectOrchestrationIntents } from './external-tool-plan';
+import { ORCHESTRATION_DISPATCH } from '../../config/runtime-limits';
 
 const logger = createLogger('MessagePipeline');
 
@@ -150,12 +153,29 @@ export async function runMessagePipeline(svc: ChatService,
         ? await resolveModeExternalClient(externalResolved, req.userId, effectiveDiscussionMode ? 'Discussion' : 'DeepResearch')
         : undefined;
 
+    // Stage 2 셰도우 — 사용자 토글 턴에서 의도 패턴이 잡히는지(재현율 프록시) 적재.
+    const recordToggleShadow = (userMode: 'discussion' | 'deep-research') => {
+        if (!ORCHESTRATION_DISPATCH.ENABLED) return;
+        const intents = detectOrchestrationIntents(message);
+        recordOrchestrationDispatch({
+            userId, queryLength: (message || '').length,
+            telemetry: {
+                discussionIntent: intents.discussion,
+                taskDelegateIntent: intents.taskDelegate,
+                exposed: [],
+            },
+            userMode,
+        });
+    };
+
     // 토론 모드: 사용자 명시 토글.
     if (effectiveDiscussionMode) {
+        recordToggleShadow('discussion');
         return svc.processMessageWithDiscussion(req, onToken, onDiscussionProgress, modeExternalClient);
     }
 
     if (deepResearchMode) {
+        recordToggleShadow('deep-research');
         return svc.processMessageWithDeepResearch(req, onToken, onResearchProgress, modeExternalClient);
     }
 
@@ -359,7 +379,8 @@ export async function runMessagePipeline(svc: ChatService,
         extArtifactGuide = '';
         logger.info('[Report] 보고서 의도 감지 — reportdata 계약 가이드 주입 (artifact 가이드 대체)');
     }
-    const externalResponse = await svc.streamFromExternalProvider(externalResolved, req, streamToken, {
+    // 명명된 ctx — external-provider 가 orchestrationTelemetry(Stage 2)를 여기에 되돌려준다.
+    const extStreamCtx: import('./external-provider').StreamFromExternalContext = {
         agentSystemMessage: agentSysMsgForExternal,
         enhancedMessage: finalEnhancedMessage,
         resolvedLanguage: languagePolicy?.resolvedLanguage,
@@ -370,7 +391,8 @@ export async function runMessagePipeline(svc: ChatService,
         style: req.style,
         tailWebGround: reqCtx.tailWebGround,
         ...(extReportGuide ? { reportGuideBlock: extReportGuide } : {}),
-    }, reqCtx);
+    };
+    const externalResponse = await svc.streamFromExternalProvider(externalResolved, req, streamToken, extStreamCtx, reqCtx);
 
     // ── Step 5: 라우팅 로그 + 메트릭 기록 ──
     // regex 분류(LLM 호출 0회)로 queryType/모델을 채워 라우팅 분석 관측 확보 (2026-07-18).
@@ -381,6 +403,17 @@ export async function runMessagePipeline(svc: ChatService,
     routingLog.queryFeatures.queryType = extHasImages ? 'vision' : extClassified.type;
     routingLog.queryFeatures.confidence = extClassified.confidence;
     routingLog.modelUsed = externalResolved.fullId;
+
+    // Stage 2 셰도우 — 오케스트레이션 의도 매칭 턴의 노출·호출·성공을 적재
+    // (external-provider 가 ctx 에 되돌려준 텔레메트리, 미매칭 턴은 undefined).
+    if (extStreamCtx.orchestrationTelemetry) {
+        recordOrchestrationDispatch({
+            ...(routingLog.requestId ? { requestId: routingLog.requestId } : {}),
+            userId, queryLength: (message || '').length,
+            telemetry: extStreamCtx.orchestrationTelemetry,
+            userMode: 'none',
+        });
+    }
 
     svc.recordMetricsAndVerify({
         fullResponse, startTime, message: message || '', req,

--- a/apps/api/src/services/chat-service/orchestration-shadow-recorder.ts
+++ b/apps/api/src/services/chat-service/orchestration-shadow-recorder.ts
@@ -1,0 +1,69 @@
+/**
+ * ============================================================
+ * Orchestration Shadow Recorder — orchestration_dispatch_decisions 적재
+ * ============================================================
+ *
+ * 오케스트레이션 자동 배정(Stage 1)의 관측 계층(Stage 2): 의도 프리필터 노출
+ * 대비 실제 호출률, 사용자 토글과의 상관을 fire-and-forget 로 DB 에 적재한다.
+ * 실행 경로를 바꾸지 않으며 절대 채팅 흐름을 차단하지 않는다(모든 에러 무시).
+ * (tail-shadow-recorder 와 동일 패턴)
+ *
+ * @module services/chat-service/orchestration-shadow-recorder
+ */
+import { getPool } from '../../data/models/unified-database';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('OrchestrationShadow');
+
+/** 외부 스트림이 ctx 에 되돌려주는 오케스트레이션 텔레메트리. */
+export interface OrchestrationTelemetry {
+    discussionIntent: boolean;
+    taskDelegateIntent: boolean;
+    /** 이 턴에 노출된 오케스트레이션 도구 이름들 (미노출 = 빈 배열) */
+    exposed: string[];
+    /** 모델이 실제 호출한 도구 (미호출 = undefined — 모델 재량 직접 답변) */
+    called?: string;
+    /** 호출 결과 성공 여부 (도구 결과가 'Error' 로 시작하지 않음) */
+    success?: boolean;
+}
+
+/**
+ * 배정 결정을 적재한다 (fire-and-forget — await 하지 말 것).
+ * 의도 미매칭·미노출 턴은 호출부가 걸러서 관측 노이즈를 줄인다
+ * (전수 적재가 필요해지면 호출부 게이트만 제거하면 된다).
+ */
+export function recordOrchestrationDispatch(params: {
+    requestId?: string;
+    userId?: string;
+    queryLength: number;
+    telemetry: OrchestrationTelemetry;
+    /** 같은 턴의 사용자 수동 토글 — 의도 패턴 재현율 측정용. */
+    userMode: 'discussion' | 'deep-research' | 'none';
+}): void {
+    const { requestId, userId, queryLength, telemetry, userMode } = params;
+    void (async () => {
+        try {
+            const pool = getPool();
+            if (!pool) return;
+            await pool.query(
+                `INSERT INTO orchestration_dispatch_decisions
+                   (request_id, user_id, query_length, discussion_intent, task_delegate_intent,
+                    tools_exposed, tool_called, tool_success, user_mode)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+                [
+                    requestId ?? null,
+                    userId && userId !== 'guest' ? userId : null,
+                    queryLength,
+                    telemetry.discussionIntent,
+                    telemetry.taskDelegateIntent,
+                    telemetry.exposed,
+                    telemetry.called ?? null,
+                    telemetry.success ?? null,
+                    userMode,
+                ],
+            );
+        } catch (e) {
+            logger.warn('오케스트레이션 셰도우 적재 실패 (무시):', e instanceof Error ? e.message : e);
+        }
+    })();
+}

--- a/db/migrations/086_orchestration_dispatch_decisions.sql
+++ b/db/migrations/086_orchestration_dispatch_decisions.sql
@@ -1,0 +1,36 @@
+-- ============================================================
+-- 086: 오케스트레이션 자동 배정 Stage 2 — 셰도우 계측 테이블
+-- ============================================================
+-- Stage 1(모델이 start_discussion/delegate_agent_task 를 도구로 배정, PR #417)의
+-- 관측 계층. 의도 프리필터 노출 대비 실제 호출률, 사용자 토글과의 상관을 적재해
+-- 패턴 튜닝·활성화 기준 판단의 근거로 쓴다 (tail routing_shadow_decisions 패턴).
+--
+-- 분석 예시:
+--   -- 노출 대비 호출률 (도구별)
+--   SELECT tool_called, count(*) FROM orchestration_dispatch_decisions
+--    WHERE discussion_intent OR task_delegate_intent GROUP BY tool_called;
+--   -- 사용자 토글 턴에서 의도 패턴이 잡혔는가 (재현율 프록시)
+--   SELECT user_mode, discussion_intent, count(*) FROM orchestration_dispatch_decisions
+--    WHERE user_mode <> 'none' GROUP BY 1, 2;
+
+CREATE TABLE IF NOT EXISTS orchestration_dispatch_decisions (
+    id BIGSERIAL PRIMARY KEY,
+    request_id TEXT,
+    user_id TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    query_length INTEGER NOT NULL DEFAULT 0,
+    -- 프리필터 의도 판정 (노출 게이트)
+    discussion_intent BOOLEAN NOT NULL DEFAULT false,
+    task_delegate_intent BOOLEAN NOT NULL DEFAULT false,
+    -- 이 턴에 노출된 오케스트레이션 도구 이름 목록 (빈 배열 = 미노출)
+    tools_exposed TEXT[] NOT NULL DEFAULT '{}',
+    -- 모델이 실제 호출한 도구 (NULL = 노출됐지만 미호출 — 모델 재량 직접 답변)
+    tool_called TEXT,
+    -- 호출 결과 성공 여부 (도구 결과가 Error 로 시작하지 않음)
+    tool_success BOOLEAN,
+    -- 같은 턴의 사용자 수동 토글: discussion | deep-research | none
+    user_mode TEXT NOT NULL DEFAULT 'none'
+);
+
+CREATE INDEX IF NOT EXISTS idx_orch_dispatch_created
+    ON orchestration_dispatch_decisions (created_at);


### PR DESCRIPTION
## 요약

Stage 1(#417, 모델의 오케스트레이션 도구 배정)의 **관측 계층**. `routing_shadow_decisions`(tail 라우팅) 패턴을 그대로 따라, 배정 결정을 fire-and-forget 로 적재해 패턴 튜닝·활성화 판단의 근거를 만든다.

## 적재 스키마 (`086_orchestration_dispatch_decisions`)

| 컬럼 | 의미 |
|---|---|
| `discussion_intent` / `task_delegate_intent` | 프리필터 의도 판정 |
| `tools_exposed` | 이 턴에 노출된 오케스트레이션 도구 |
| `tool_called` / `tool_success` | 모델이 실제 호출한 도구·성공 여부 (NULL=노출됐지만 모델 재량 직접 답변) |
| `user_mode` | 같은 턴의 수동 토글(discussion/deep-research/none) — **토글 턴에서 의도 패턴이 잡히는지 = 재현율 프록시** |

## 배선

- `external-provider` → 스트림 ctx 로 텔레메트리 회신 (의도 미매칭 턴은 undefined — 관측 노이즈 0)
- `message-pipeline` → 외부 경로 Step 5 적재 + discussion/deep-research **토글 조기 분기에도 적재**(재현율 측정)
- `ORCHESTRATION_AUTO_DISPATCH=false` 면 완전 무기록

## 검증

- [x] tsc·chat-service 56개 회귀 통과, 파일 크기 가드 여유(583/425줄)
- [x] 부팅 자동 마이그레이션 086 적용 확인
- [x] **라이브 3종 적재 확인**: ① 노출-미호출(`tools_exposed={start_discussion}, tool_called=NULL`) ② 노출-호출-성공(`tool_called=start_discussion, success=t`) ③ 토글 턴(`user_mode=discussion, discussion_intent=t`)

## 분석 쿼리 (마이그레이션 주석에 포함)

```sql
-- 노출 대비 호출률
SELECT tool_called, count(*) FROM orchestration_dispatch_decisions
 WHERE discussion_intent OR task_delegate_intent GROUP BY tool_called;
-- 토글 턴 재현율 프록시
SELECT user_mode, discussion_intent, count(*) FROM orchestration_dispatch_decisions
 WHERE user_mode <> 'none' GROUP BY 1, 2;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)