### PR TITLE
chore(stability): handler 선제 분할 + 관측 테이블 보존 정책

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,9 @@ LLM_TIMEOUT=120000                              # HTTP 요청 타임아웃 (ms)
 # 오케스트레이션 자동 배정 (Stage 1) — 모델이 토론(start_discussion)·백그라운드 작업
 # (delegate_agent_task)을 도구로 직접 배정. 의도 프리필터 매칭 턴에만 도구 노출.
 # ORCHESTRATION_AUTO_DISPATCH=true
+# 관측 메트릭·셰도우 테이블 보존 일수 (model_pool_metrics·routing_shadow_decisions·
+# orchestration_dispatch_decisions). 기본 90일.
+# METRICS_RETENTION_DAYS=90
 # 모델 학습 지식 컷오프 라벨 — 프롬프트 "학습 기준일" 명시용. 기본 모델/외부 provider 교체 시 조정.
 # LLM_KNOWLEDGE_CUTOFF_KO=2024년 12월
 # LLM_KNOWLEDGE_CUTOFF_EN=December 2024

--- a/apps/api/src/data/db-retention.ts
+++ b/apps/api/src/data/db-retention.ts
@@ -167,6 +167,32 @@ async function runRetention(): Promise<void> {
             }
         }
 
+        // 9. 관측 메트릭·셰도우 테이블 보존 (기본 90일)
+        // model_pool_metrics(context-fit 안전망 관측)·routing_shadow_decisions(tail 게이트
+        // 셰도우)·orchestration_dispatch_decisions(배정 셰도우)는 append-only 로 무한 증가한다.
+        // 분석은 최근 구간만 쓰므로 오래된 행은 삭제한다 (테이블별 env 없이 공통 상수 —
+        // 세분화가 필요해지면 그때 분리).
+        const metricsRetentionDays = parseInt(
+            process.env.METRICS_RETENTION_DAYS ?? '90',
+            10,
+        );
+        if (Number.isFinite(metricsRetentionDays) && metricsRetentionDays > 0) {
+            for (const table of ['model_pool_metrics', 'routing_shadow_decisions', 'orchestration_dispatch_decisions']) {
+                try {
+                    const r = await pool.query(
+                        `DELETE FROM ${table} WHERE created_at < NOW() - ($1 || ' days')::interval`,
+                        [metricsRetentionDays.toString()],
+                    );
+                    if ((r.rowCount ?? 0) > 0) {
+                        logger.info(`[DbRetention] ${table} ${r.rowCount}건 정리 완료 (${metricsRetentionDays}일 초과)`);
+                    }
+                } catch (e) {
+                    // 테이블 미생성(마이그레이션 이전 인스턴스) 등은 무시 — 다른 정리를 막지 않는다.
+                    logger.warn(`[DbRetention] ${table} 정리 건너뜀: ${e instanceof Error ? e.message : e}`);
+                }
+            }
+        }
+
     } catch (err) {
         logger.error('[DbRetention] 정리 작업 중 오류 발생:', err);
     }

--- a/apps/api/src/sockets/handler.ts
+++ b/apps/api/src/sockets/handler.ts
@@ -54,6 +54,7 @@ import { getEventBus, AGENT_TASK_PROGRESS, type AgentTaskProgressEvent } from '.
 import { runWithRequestContext } from '../utils/request-context';
 import { isOriginAllowed } from '../security/cors-policy';
 import { WsConnectionGuard } from './ws-connection-guard';
+import { broadcastWithBackpressure, sendToConnections, sweepHeartbeat } from './ws-broadcast';
 
 const log = createLogger('WebSocketHandler');
 
@@ -417,17 +418,7 @@ export class WebSocketHandler {
     private startHeartbeat(): void {
         this.heartbeatInterval = setInterval(() => {
             // 🔒 Phase 3: 순회 중 삭제 방지 — 먼저 좀비 연결을 수집 후 일괄 처리
-            const deadConnections: WebSocket[] = [];
-
-            for (const ws of this.clients) {
-                const extWs = ws as ExtendedWebSocket;
-                if (!extWs._isAlive || this.isTokenExpired(extWs)) {
-                    deadConnections.push(ws);
-                } else if (ws.readyState === WebSocket.OPEN) {
-                    extWs._isAlive = false;
-                    ws.ping();
-                }
-            }
+            const deadConnections = sweepHeartbeat(this.clients, (w: ExtendedWebSocket) => this.isTokenExpired(w));
 
             // 수집된 좀비 연결 일괄 종료 (Set 순회 완료 후)
             for (const ws of deadConnections) {
@@ -522,43 +513,7 @@ export class WebSocketHandler {
      * @param data - 전송할 JSON 직렬화 가능 데이터
      */
     public broadcast(data: Record<string, unknown>): void {
-        const message = JSON.stringify(data);
-        const threshold = WS_LIMITS.BROADCAST_BACKPRESSURE_THRESHOLD_BYTES;
-        const terminateAfter = WS_LIMITS.BROADCAST_BACKPRESSURE_TERMINATE_AFTER;
-        let skipped = 0;
-        let terminated = 0;
-
-        for (const client of this.clients) {
-            if (client.readyState !== WebSocket.OPEN) continue;
-
-            // 슬로우 클라이언트 감지 — bufferedAmount 가 임계 초과
-            if (client.bufferedAmount > threshold) {
-                const count = (this.slowClientCounters.get(client) ?? 0) + 1;
-                this.slowClientCounters.set(client, count);
-                skipped++;
-
-                if (terminateAfter > 0 && count >= terminateAfter) {
-                    // 만성적 stall — 강제 종료 (close 핸들러가 cleanup 처리)
-                    client.terminate();
-                    this.slowClientCounters.delete(client);
-                    terminated++;
-                }
-                continue;
-            }
-
-            // 정상 송신 — slow 카운터 리셋
-            if (this.slowClientCounters.has(client)) {
-                this.slowClientCounters.delete(client);
-            }
-            client.send(message);
-        }
-
-        if (skipped > 0 || terminated > 0) {
-            log.warn(
-                `broadcast backpressure: skipped=${skipped}, terminated=${terminated} ` +
-                `(threshold=${threshold}B, terminateAfter=${terminateAfter})`
-            );
-        }
+        broadcastWithBackpressure(this.clients, this.slowClientCounters, data);
     }
 
     /**
@@ -588,11 +543,6 @@ export class WebSocketHandler {
         if (!userId) return;
         const connections = this.guard.getUserConnections(userId);
         if (connections.size === 0) return;
-        const message = JSON.stringify(data);
-        for (const client of connections) {
-            if (client.readyState === WebSocket.OPEN) {
-                client.send(message);
-            }
-        }
+        sendToConnections(connections, data);
     }
 }

--- a/apps/api/src/sockets/ws-broadcast.ts
+++ b/apps/api/src/sockets/ws-broadcast.ts
@@ -1,0 +1,106 @@
+/**
+ * ============================================================
+ * WS Broadcast / Heartbeat Sweep — 연결 집합 대상 송신 유틸
+ * ============================================================
+ *
+ * handler.ts 에서 분리(파일 크기 가드 선제 대응): 클래스 상태에 의존하지 않는
+ * "연결 집합 → 송신/정리" 로직만 순수 함수로 추출한다. 동작 동일.
+ *
+ * @module sockets/ws-broadcast
+ */
+import { WebSocket } from 'ws';
+import { WS_LIMITS } from '../config/timeouts';
+import type { ExtendedWebSocket } from './ws-types';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('WebSocketHandler');
+
+/**
+ * 모든 연결에 backpressure 정책으로 브로드캐스트한다.
+ *
+ * 정책:
+ *  - bufferedAmount > THRESHOLD_BYTES: 송신 skip + slowClient 카운터 증가
+ *  - 카운터가 TERMINATE_AFTER 초과: ws.terminate() 로 강제 종료
+ *    (heartbeat 가 없는 dead connection 정리)
+ *  - 정상 송신 시 카운터 리셋
+ *
+ * 이전 동작(await/콜백 없는 단순 send)은 슬로우 클라이언트가 이벤트 루프와
+ * Node 메모리를 점유해 fast 클라이언트의 latency 까지 끌어올렸다.
+ */
+export function broadcastWithBackpressure(
+    clients: Iterable<WebSocket>,
+    slowClientCounters: WeakMap<WebSocket, number>,
+    data: Record<string, unknown>,
+): void {
+    const message = JSON.stringify(data);
+    const threshold = WS_LIMITS.BROADCAST_BACKPRESSURE_THRESHOLD_BYTES;
+    const terminateAfter = WS_LIMITS.BROADCAST_BACKPRESSURE_TERMINATE_AFTER;
+    let skipped = 0;
+    let terminated = 0;
+
+    for (const client of clients) {
+        if (client.readyState !== WebSocket.OPEN) continue;
+
+        // 슬로우 클라이언트 감지 — bufferedAmount 가 임계 초과
+        if (client.bufferedAmount > threshold) {
+            const count = (slowClientCounters.get(client) ?? 0) + 1;
+            slowClientCounters.set(client, count);
+            skipped++;
+
+            if (terminateAfter > 0 && count >= terminateAfter) {
+                // 만성적 stall — 강제 종료 (close 핸들러가 cleanup 처리)
+                client.terminate();
+                slowClientCounters.delete(client);
+                terminated++;
+            }
+            continue;
+        }
+
+        // 정상 송신 — slow 카운터 리셋
+        if (slowClientCounters.has(client)) {
+            slowClientCounters.delete(client);
+        }
+        client.send(message);
+    }
+
+    if (skipped > 0 || terminated > 0) {
+        log.warn(
+            `broadcast backpressure: skipped=${skipped}, terminated=${terminated} ` +
+            `(threshold=${threshold}B, terminateAfter=${terminateAfter})`
+        );
+    }
+}
+
+/** 지정 연결 집합에 메시지 전송 (OPEN 만). 연결이 없으면 no-op. */
+export function sendToConnections(
+    connections: Iterable<WebSocket>,
+    data: Record<string, unknown>,
+): void {
+    const message = JSON.stringify(data);
+    for (const client of connections) {
+        if (client.readyState === WebSocket.OPEN) {
+            client.send(message);
+        }
+    }
+}
+
+/**
+ * 하트비트 1회 스윕 — 좀비 연결을 수집해 반환하고, 살아있는 연결엔 ping 을 보낸다.
+ * ⚠️ 순회 중 삭제 금지(Set 변경) — 종료 처리는 호출부가 반환된 목록으로 수행한다.
+ */
+export function sweepHeartbeat(
+    clients: Iterable<WebSocket>,
+    isTokenExpired: (ws: ExtendedWebSocket) => boolean,
+): WebSocket[] {
+    const dead: WebSocket[] = [];
+    for (const ws of clients) {
+        const extWs = ws as ExtendedWebSocket;
+        if (!extWs._isAlive || isTokenExpired(extWs)) {
+            dead.push(ws);
+        } else if (ws.readyState === WebSocket.OPEN) {
+            extWs._isAlive = false;
+            ws.ping();
+        }
+    }
+    return dead;
+}


### PR DESCRIPTION
## 배경

전체 안정화 점검(인프라·DB·코드·품질 4계층) 결과 **즉시 위험은 없었고**, 예방 성격의 잔여 항목 2건을 처리한다.

## 변경 내용

**1. `sockets/handler.ts` 598 → 548줄 (파일 크기 가드 선제 대응)**
CI 가드(600줄)까지 2줄 여유라 다음 수정에서 반드시 걸리는 상태였다. 클래스 상태에 의존하지 않는 로직만 `ws-broadcast.ts` 로 순수 함수 추출 — `broadcastWithBackpressure`(슬로우 클라이언트 정책) · `sendToConnections` · `sweepHeartbeat`(좀비 수집). **동작 동일**, 호출부는 위임만.

**2. 관측 테이블 90일 보존 정책 추가**
`model_pool_metrics`(5,987행, 5월부터 누적) · `routing_shadow_decisions` · `orchestration_dispatch_decisions` 는 append-only 로 무한 증가하는데 보존 정책이 없었다. 기존 DbRetention 스케줄러에 편입 — `METRICS_RETENTION_DAYS`(기본 90). 테이블 미생성 인스턴스는 건너뛰고 다른 정리를 막지 않는다.

## 점검 중 확인된 사항 (조치 불요)

- 인덱스 보강을 검토했으나 **이미 적절한 인덱스가 존재**했다(`idx_rsd_created` · `idx_model_pool_metrics_created`). 앞선 `seq_scan > idx_scan` 관측은 행이 적어 planner 가 seq scan 을 고른 정상 동작이었다 — 중복 인덱스를 만들지 않았다
- 빈 catch 0건, 백엔드 strict 우회 사실상 없음(2건, 외부 라이브러리 사유 명시), 파일 크기 가드 초과 0건, 전체 테스트 2,222개 통과

## 검증

- [x] `tsc` 통과, sockets/data 테스트 44개 통과
- [x] 빌드·운영 재시작 후 WS 채팅·브로드캐스트 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)