### PR TITLE
feat(chat): 오케스트레이션 셰도우에 질의 프리뷰 추가 (087)

### DIFF
--- a/apps/api/src/data/db-retention.ts
+++ b/apps/api/src/data/db-retention.ts
@@ -13,6 +13,7 @@
  * - audit_logs                      : AUDIT_PII_RETENTION_DAYS(기본 90일) 초과 ip/ua NULL + details.actor 제거
  * - alert_history                   : ALERT_PII_RETENTION_DAYS(기본 90일) 초과 data.actor/ipAddress/userAgent 제거
  * - mcp_server_instances            : MCP_INSTANCE_RETENTION_DAYS(기본 30일) 초과 transition 이력 삭제 (각 server·user 의 최신 transition 은 보존)
+ * - orchestration_dispatch_decisions: ORCH_PREVIEW_RETENTION_DAYS(기본 30일) 초과 query_preview NULL (집계 지표는 METRICS_RETENTION_DAYS 까지 보존)
  *
  * @module data/db-retention
  */
@@ -190,6 +191,30 @@ async function runRetention(): Promise<void> {
                     // 테이블 미생성(마이그레이션 이전 인스턴스) 등은 무시 — 다른 정리를 막지 않는다.
                     logger.warn(`[DbRetention] ${table} 정리 건너뜀: ${e instanceof Error ? e.message : e}`);
                 }
+            }
+        }
+
+        // 10. 오케스트레이션 셰도우 질의 프리뷰 익명화 (087, 기본 30일)
+        // query_preview 는 description 문구 튜닝의 반례 진단용 텍스트라 집계 지표보다
+        // 짧게 보존한다 — 행 자체(호출률·재현율)는 위 METRICS_RETENTION_DAYS 까지 유지.
+        const orchPreviewRetentionDays = parseInt(
+            process.env.ORCH_PREVIEW_RETENTION_DAYS ?? '30',
+            10,
+        );
+        if (Number.isFinite(orchPreviewRetentionDays) && orchPreviewRetentionDays > 0) {
+            try {
+                const previewResult = await pool.query(
+                    `UPDATE orchestration_dispatch_decisions
+                     SET query_preview = NULL
+                     WHERE created_at < NOW() - ($1 || ' days')::interval
+                       AND query_preview IS NOT NULL`,
+                    [orchPreviewRetentionDays.toString()],
+                );
+                if ((previewResult.rowCount ?? 0) > 0) {
+                    logger.info(`[DbRetention] 오케스트레이션 질의 프리뷰 ${previewResult.rowCount}건 익명화 완료 (${orchPreviewRetentionDays}일 초과)`);
+                }
+            } catch (e) {
+                logger.warn(`[DbRetention] query_preview 익명화 건너뜀: ${e instanceof Error ? e.message : e}`);
             }
         }
 

--- a/apps/api/src/services/chat-service/message-pipeline.ts
+++ b/apps/api/src/services/chat-service/message-pipeline.ts
@@ -165,6 +165,7 @@ export async function runMessagePipeline(svc: ChatService,
                 exposed: [],
             },
             userMode,
+            ...(message ? { message } : {}),
         });
     };
 
@@ -412,6 +413,7 @@ export async function runMessagePipeline(svc: ChatService,
             userId, queryLength: (message || '').length,
             telemetry: extStreamCtx.orchestrationTelemetry,
             userMode: 'none',
+            ...(message ? { message } : {}),
         });
     }
 

--- a/apps/api/src/services/chat-service/orchestration-shadow-recorder.ts
+++ b/apps/api/src/services/chat-service/orchestration-shadow-recorder.ts
@@ -32,6 +32,9 @@ export interface OrchestrationTelemetry {
  * 의도 미매칭·미노출 턴은 호출부가 걸러서 관측 노이즈를 줄인다
  * (전수 적재가 필요해지면 호출부 게이트만 제거하면 된다).
  */
+/** 질의 프리뷰 상한 — 문구 튜닝 반례 진단에 필요한 최소 길이만 저장(087). */
+const QUERY_PREVIEW_MAX_CHARS = 80;
+
 export function recordOrchestrationDispatch(params: {
     requestId?: string;
     userId?: string;
@@ -39,8 +42,17 @@ export function recordOrchestrationDispatch(params: {
     telemetry: OrchestrationTelemetry;
     /** 같은 턴의 사용자 수동 토글 — 의도 패턴 재현율 측정용. */
     userMode: 'discussion' | 'deep-research' | 'none';
+    /**
+     * 질의 원문 — 앞 QUERY_PREVIEW_MAX_CHARS 자만 저장한다(087).
+     * "노출됐는데 모델이 호출하지 않은" 반례를 봐야 도구 description 을 근거 기반으로
+     * 고칠 수 있다(측정만으로는 무엇을 고칠지 알 수 없음). 보존은 db-retention 이 30일로 제한.
+     */
+    message?: string;
 }): void {
-    const { requestId, userId, queryLength, telemetry, userMode } = params;
+    const { requestId, userId, queryLength, telemetry, userMode, message } = params;
+    const preview = message?.trim()
+        ? message.trim().slice(0, QUERY_PREVIEW_MAX_CHARS)
+        : null;
     void (async () => {
         try {
             const pool = getPool();
@@ -48,8 +60,8 @@ export function recordOrchestrationDispatch(params: {
             await pool.query(
                 `INSERT INTO orchestration_dispatch_decisions
                    (request_id, user_id, query_length, discussion_intent, task_delegate_intent,
-                    tools_exposed, tool_called, tool_success, user_mode)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+                    tools_exposed, tool_called, tool_success, user_mode, query_preview)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
                 [
                     requestId ?? null,
                     userId && userId !== 'guest' ? userId : null,
@@ -60,6 +72,7 @@ export function recordOrchestrationDispatch(params: {
                     telemetry.called ?? null,
                     telemetry.success ?? null,
                     userMode,
+                    preview,
                 ],
             );
         } catch (e) {

--- a/db/migrations/087_orchestration_query_preview.sql
+++ b/db/migrations/087_orchestration_query_preview.sql
@@ -1,0 +1,26 @@
+-- ============================================================
+-- 087: 오케스트레이션 셰도우에 질의 프리뷰 추가
+-- ============================================================
+-- Stage 2(086) 는 호출률을 재지만 "어떤 문장에서 모델이 도구를 마다했는지" 를
+-- 알 수 없어 description 문구 튜닝의 근거를 만들 수 없다(measure-first 원칙 위배).
+-- 의도 매칭 턴에 한해 질의 앞부분만 저장해 미호출 반례를 진단 가능하게 한다.
+--
+-- 범위 제한:
+--   - 앞 80자만 (앱 레이어에서 절단) — 전문 저장 아님
+--   - 의도 프리필터 매칭 턴만 적재 (일반 채팅은 애초에 이 테이블에 안 들어옴)
+--   - ORCHESTRATION_AUTO_DISPATCH=false 면 적재 자체가 없음
+--   - 보존: 프리뷰는 ORCH_PREVIEW_RETENTION_DAYS(기본 30일) 후 NULL 처리 —
+--     집계 지표(호출률·재현율)는 행 보존 기간(METRICS_RETENTION_DAYS 90일)까지 유지.
+--     즉 문구 튜닝용 텍스트만 먼저 사라지고 통계는 남는다 (data minimization).
+--
+-- 분석 예시:
+--   -- 노출됐으나 모델이 호출하지 않은 질의 (문구 튜닝 반례)
+--   SELECT query_preview, tools_exposed FROM orchestration_dispatch_decisions
+--    WHERE user_mode='none' AND tool_called IS NULL AND query_preview IS NOT NULL
+--    ORDER BY created_at DESC LIMIT 20;
+
+ALTER TABLE orchestration_dispatch_decisions
+    ADD COLUMN IF NOT EXISTS query_preview TEXT;
+
+COMMENT ON COLUMN orchestration_dispatch_decisions.query_preview IS
+    '의도 매칭 턴의 질의 앞 80자 (description 튜닝 반례 진단용, 기본 30일 후 NULL 처리)';


### PR DESCRIPTION
## 배경

Stage 2 셰도우(#418, 086)는 **호출률은 재지만 진단은 못 합니다** — `query_length`만 저장해서 "어떤 문장에서 모델이 도구를 마다했는지"를 알 수 없습니다. 8/15 분석에서 "호출률 40%"라는 숫자만 얻고 도구 description을 감으로 고치게 되는데, 이 프로젝트의 measure-first 원칙과 어긋납니다.

## 변경

- **087** `query_preview TEXT` — 의도 매칭 턴의 질의 **앞 80자만** 저장(전문 아님)
- 레코더가 `message`를 받아 절단 저장, 호출부 2곳(외부 경로·토글 경로) 배선
- **보존 이원화** (data minimization): 프리뷰는 `ORCH_PREVIEW_RETENTION_DAYS`(기본 30일) 후 NULL, 집계 지표 행은 `METRICS_RETENTION_DAYS`(90일)까지 유지 → **텍스트가 먼저 사라지고 통계는 남음**
- 8/15 리포트 스크립트에 **튜닝 반례**(노출-미호출 질의 20건)·**대조군**(호출 성공 질의 10건) 섹션 추가

## 범위 제한

적재 대상은 의도 프리필터에 매칭된 턴뿐이고(일반 채팅은 애초에 이 테이블에 안 들어옴), `ORCHESTRATION_AUTO_DISPATCH=false`면 적재 자체가 없습니다. 신규 노출면은 아닙니다 — 대화 전문은 이미 `conversation_messages`에 저장되는 구조입니다.

## 검증

- [x] tsc·chat-service 56개 회귀·lint 통과
- [x] 부팅 자동 마이그레이션 087 적용 확인
- [x] **라이브**: "탄소세 도입 찬반 토론이 필요할까?" → `start_discussion` 노출, 모델 미호출, 프리뷰 정상 적재 — 정확히 목표한 반례 케이스 포착

🤖 Generated with [Claude Code](https://claude.com/claude-code)