### PR TITLE
fix(test): CircuitBreaker 플레이키 수정 (CI 간헐 실패)

### DIFF
--- a/apps/api/src/__tests__/circuit-breaker.test.ts
+++ b/apps/api/src/__tests__/circuit-breaker.test.ts
@@ -100,12 +100,12 @@ describe('CircuitBreaker', () => {
         test('resetTimeout 경과 후 getState()가 HALF_OPEN 반환', async () => {
             const cb = new CircuitBreaker('test', {
                 failureThreshold: 1,
-                resetTimeout: 10   // 10ms
+                resetTimeout: 100   // 느린 CI 러너에서도 OPEN 판정이 앞서도록 여유 확보
             });
             await cb.execute(fail).catch(() => {});
             expect(cb.getState()).toBe('OPEN');
 
-            await new Promise(r => setTimeout(r, 20));
+            await new Promise(r => setTimeout(r, 150));
             expect(cb.getState()).toBe('HALF_OPEN');
         });
 
@@ -119,14 +119,20 @@ describe('CircuitBreaker', () => {
         });
 
         test('HALF_OPEN에서 실패 → OPEN 복귀', async () => {
+            // ⚠️ resetTimeout 은 넉넉히 잡는다(2026-08-01 CI 플레이키 수정).
+            // getState() 는 "OPEN + resetTimeout 경과" 를 보면 HALF_OPEN 으로 **전이시키는**
+            // 부수효과가 있다. 10ms 로 두면 느린 러너에서 마지막 execute→getState 사이가
+            // 10ms 를 넘겨 OPEN 이 즉시 HALF_OPEN 으로 되돌아가 간헐 실패했다.
             const cb = new CircuitBreaker('test', {
                 failureThreshold: 1,
-                resetTimeout: 10
+                resetTimeout: 200
             });
             await cb.execute(fail).catch(() => {});
-            await new Promise(r => setTimeout(r, 20));
+            await new Promise(r => setTimeout(r, 250));
             expect(cb.getState()).toBe('HALF_OPEN');
 
+            // HALF_OPEN 에서 실패 → OPEN. 이후 판정은 resetTimeout(200ms) 안에 끝나므로
+            // 자동 재전이 없이 안정적이다.
             await cb.execute(fail).catch(() => {});
             expect(cb.getState()).toBe('OPEN');
         });


### PR DESCRIPTION
## 배경

릴리스 PR #421의 CI 2차 실행이 `circuit-breaker.test.ts` 1건으로 실패했습니다 — **로컬 6회 반복은 전부 통과**하는 CI 전용 플레이키였습니다.

## 원인

`getState()`는 "OPEN + resetTimeout 경과"를 보면 **HALF_OPEN으로 전이시키는 부수효과**를 가집니다. 테스트가 `resetTimeout: 10ms`에 의존해서, 느린 러너에서 마지막 `execute(fail)` → `getState()` 사이가 10ms를 넘기면 방금 OPEN이 된 회로가 즉시 HALF_OPEN으로 되돌아가 `Expected "OPEN", Received "HALF_OPEN"`이 납니다.

## 수정

해당 테스트 200ms, 인접 테스트 100ms로 타이밍 여유 확보. **구현 코드는 변경하지 않았습니다** — 테스트 자체가 비현실적으로 짧은 타이머에 의존한 문제입니다.

- [x] 수정 후 4회 반복 전부 34/34 통과

## 별건 (이 PR 범위 밖)

#421 **1차** 실행은 다른 원인이었습니다 — 모든 게이트가 success인데 총 **15분 02초**로 `timeout-minutes: 15`를 2초 초과해 job이 cancelled 됐습니다. CI 소요가 13~15분으로 상한에 붙어 있어 재발 가능성이 있으니 `timeout-minutes`를 25로 올리는 것을 권합니다. (워크플로 파일 수정은 OAuth `workflow` scope가 필요해 이 PR에 포함하지 못했습니다.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)