### PR TITLE
fix(web): 백엔드↔프론트 정합 점검 후속 — WS 계약 갭·미반영 기능·백엔드 정리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -380,6 +380,11 @@ DATABASE_URL=postgresql://openmake:your_password@localhost:5432/openmake_llm  # 
 # 운영은 Nginx 가 / → Next 를 라우팅하므로 보통 미설정(주석).
 # FRONTEND_REDIRECT_URL=http://localhost:3000
 
+# Google Analytics 4 — 홈페이지(openmake.cc)와 데모(chat.openmake.cc)를 같은 속성으로 측정.
+# 무료 표준 GA4의 측정 ID만 사용하며, API secret이나 결제 설정은 필요하지 않다.
+# 데모에서 전용 스트림과 홈페이지 공통 스트림을 함께 쓸 때 콤마로 구분한다.
+# NEXT_PUBLIC_GA_MEASUREMENT_ID=G-DGVCMQ837F,G-99Z94GHRPN
+
 # CORS 허용 Origin (쉼표 구분, REST/WS 공통 allowlist).
 # credentials(쿠키) 인증 환경이라 와일드카드('*') 금지 — 운영(NODE_ENV=production)에서 '*' 설정 시 부팅 중단.
 # 허용 목록에 정확히 일치하는 Origin 만 reflect 되고, 그 외는 REST/WS 모두 거부된다.

--- a/apps/api/src/controllers/user-preferences.controller.ts
+++ b/apps/api/src/controllers/user-preferences.controller.ts
@@ -99,52 +99,6 @@ export function createUserPreferencesController(): Router {
     );
 
     /**
-     * GET /api/users/me/artifacts-enabled — Anthropic Settings > Capabilities 동등.
-     * 미설정 시 기본 true (Repository 의 DEFAULT TRUE).
-     */
-    router.get('/artifacts-enabled', requireAuth, async (req: Request, res: Response) => {
-        const userId = getUserId(req);
-        if (!userId) {
-            res.status(401).json(unauthorized('사용자 식별 실패'));
-            return;
-        }
-        try {
-            const repo = new UserRepository(getPool());
-            const enabled = await repo.getArtifactsEnabled(userId);
-            res.json(success({ artifactsEnabled: enabled }));
-        } catch (err) {
-            log.error('artifacts_enabled 조회 실패:', err);
-            res.status(500).json(internalError('설정 조회 실패'));
-        }
-    });
-
-    /**
-     * PUT /api/users/me/artifacts-enabled
-     * body: { artifactsEnabled: boolean }
-     */
-    router.put('/artifacts-enabled', requireAuth, async (req: Request, res: Response) => {
-        const userId = getUserId(req);
-        if (!userId) {
-            res.status(401).json(unauthorized('사용자 식별 실패'));
-            return;
-        }
-        const body = req.body as { artifactsEnabled?: unknown };
-        if (typeof body.artifactsEnabled !== 'boolean') {
-            res.status(400).json({ error: 'INVALID_BODY', detail: 'artifactsEnabled (boolean) 필수' });
-            return;
-        }
-        try {
-            const repo = new UserRepository(getPool());
-            await repo.updateArtifactsEnabled(userId, body.artifactsEnabled);
-            log.info(`artifacts_enabled 갱신: userId=${userId} value=${body.artifactsEnabled}`);
-            res.json(success({ saved: true, artifactsEnabled: body.artifactsEnabled }));
-        } catch (err) {
-            log.error('artifacts_enabled 갱신 실패:', err);
-            res.status(500).json(internalError('설정 저장 실패'));
-        }
-    });
-
-    /**
      * GET /api/users/me/preferences — 앱 설정 조회.
      * 미설정 키는 프론트 기본값 적용. { preferences: {...} }
      */

--- a/apps/api/src/data/repositories/user-repository.ts
+++ b/apps/api/src/data/repositories/user-repository.ts
@@ -98,13 +98,4 @@ export class UserRepository extends BaseRepository {
         return result.rows[0]?.artifacts_enabled ?? true;
     }
 
-    /**
-     * Artifacts on/off 설정 갱신 (Settings UI 의 토글).
-     */
-    async updateArtifactsEnabled(userId: string, enabled: boolean): Promise<void> {
-        await this.query(
-            'UPDATE users SET artifacts_enabled = $1, updated_at = NOW() WHERE id = $2',
-            [enabled, userId],
-        );
-    }
 }

--- a/apps/api/src/routes/external-oauth.routes.ts
+++ b/apps/api/src/routes/external-oauth.routes.ts
@@ -6,10 +6,10 @@
  * ChatGPT Plus/Pro 계정을 OAuth 디바이스 코드 플로우로 연결한다.
  * localhost 콜백이 필요 없어 웹/CLI 어디서든 동작:
  *
- *   1. POST /api/external-keys/chatgpt/oauth/start
+ *   1. POST /api/external-keys/:providerId/oauth/start
  *      → OpenAI deviceauth 에서 user_code 발급, 검증 URL 과 함께 반환
  *   2. 사용자가 verification_url(auth.openai.com/codex/device)에서 코드 입력
- *   3. POST /api/external-keys/chatgpt/oauth/poll  (프론트가 interval 간격 반복 호출)
+ *   3. POST /api/external-keys/:providerId/oauth/poll  (프론트가 interval 간격 반복 호출)
  *      → 승인 전: { status: 'pending' }
  *      → 승인 후: authorization_code 교환 → 세션 암호화 저장 → { status: 'complete' }
  *
@@ -26,12 +26,11 @@ import { z } from 'zod';
 import { requireAuth } from '../auth';
 import { validate } from '../middlewares/validation';
 import { asyncHandler } from '../utils/error-handler';
-import { success, badRequest, unauthorized } from '../utils/api-response';
+import { success, badRequest, unauthorized, notFound } from '../utils/api-response';
 import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
 import { getPool } from '../data/models/unified-database';
 import {
     CHATGPT_OAUTH,
-    CHATGPT_PROVIDER_ID,
     chatgptDeviceVerifyUrl,
 } from '../config/chatgpt-oauth';
 import { getProviderCatalogEntry } from '../config/external-providers';
@@ -63,9 +62,29 @@ function getUserId(req: Request): string | null {
 }
 
 /**
- * POST /chatgpt/oauth/start — 디바이스 코드 발급
+ * 제네릭 `:providerId` 경로 가드 — 카탈로그에 존재하고 authMethods 에 'oauth' 를
+ * 포함하는 provider 만 통과시킨다. 아니면 res 에 404 를 쓰고 null 반환.
+ *
+ * 현재 oauth provider 는 chatgpt 하나뿐이라 디바이스 플로우 구현은 CHATGPT_OAUTH
+ * 를 그대로 재사용한다 — 경로만 프론트의 제네릭 호출(`/:providerId/oauth/*`)에 맞춰
+ * 일반화했다(시한 결합 제거).
  */
-router.post('/chatgpt/oauth/start',
+function resolveOAuthProviderOr404(req: Request, res: Response): string | null {
+    const providerId = req.params.providerId;
+    const catalogEntry = getProviderCatalogEntry(providerId);
+    if (!catalogEntry || !catalogEntry.authMethods.includes('oauth')) {
+        res.status(404).json(
+            notFound(`Provider '${providerId}' 는 OAuth 로그인을 지원하지 않습니다`),
+        );
+        return null;
+    }
+    return providerId;
+}
+
+/**
+ * POST /:providerId/oauth/start — 디바이스 코드 발급 (oauth provider 만)
+ */
+router.post('/:providerId/oauth/start',
     requireAuth,
     asyncHandler(async (req: Request, res: Response) => {
         const userId = getUserId(req);
@@ -73,6 +92,7 @@ router.post('/chatgpt/oauth/start',
             res.status(401).json(unauthorized('User ID not found.'));
             return;
         }
+        if (!resolveOAuthProviderOr404(req, res)) return;
 
         const response = await fetch(
             `${CHATGPT_OAUTH.ISSUER}/api/accounts/deviceauth/usercode`,
@@ -121,9 +141,9 @@ const pollSchema = z.object({
 });
 
 /**
- * POST /chatgpt/oauth/poll — 승인 확인 (1회 폴링) + 완료 시 토큰 교환·저장
+ * POST /:providerId/oauth/poll — 승인 확인 (1회 폴링) + 완료 시 토큰 교환·저장
  */
-router.post('/chatgpt/oauth/poll',
+router.post('/:providerId/oauth/poll',
     requireAuth,
     validate(pollSchema),
     asyncHandler(async (req: Request, res: Response) => {
@@ -132,6 +152,8 @@ router.post('/chatgpt/oauth/poll',
             res.status(401).json(unauthorized('User ID not found.'));
             return;
         }
+        const providerId = resolveOAuthProviderOr404(req, res);
+        if (!providerId) return;
         const { device_auth_id, user_code } = req.body as z.infer<typeof pollSchema>;
 
         const pollResponse = await fetch(
@@ -200,11 +222,11 @@ router.post('/chatgpt/oauth/poll',
         const expiresAt = new Date(
             Date.now() + (tokens.expires_in ?? CHATGPT_OAUTH.DEFAULT_ACCESS_TOKEN_TTL_SEC) * 1000,
         );
-        const catalogEntry = getProviderCatalogEntry(CHATGPT_PROVIDER_ID);
+        const catalogEntry = getProviderCatalogEntry(providerId);
 
         await getRepo().upsert({
             userId,
-            providerId: CHATGPT_PROVIDER_ID,
+            providerId,
             sdkType: 'openai-compatible',
             displayName: catalogEntry?.displayName ?? 'ChatGPT',
             baseUrl: catalogEntry?.defaultBaseUrl ?? CHATGPT_OAUTH.CODEX_BASE_URL,
@@ -218,14 +240,14 @@ router.post('/chatgpt/oauth/poll',
             oauthAccountId: accountId ?? null,
             oauthExpiresAt: expiresAt,
         });
-        await getRepo().invalidateCachedModels(userId, CHATGPT_PROVIDER_ID);
+        await getRepo().invalidateCachedModels(userId, providerId);
 
         logger.info(
-            `ChatGPT OAuth 연결 완료: user=${userId} account=${accountId ?? 'unknown'}`,
+            `ChatGPT OAuth 연결 완료: user=${userId} provider=${providerId} account=${accountId ?? 'unknown'}`,
         );
         res.json(success({
             status: 'complete',
-            provider_id: CHATGPT_PROVIDER_ID,
+            provider_id: providerId,
             account_id: accountId ?? null,
         }));
     }),

--- a/apps/api/src/services/task-sandbox/sandbox.test.ts
+++ b/apps/api/src/services/task-sandbox/sandbox.test.ts
@@ -36,6 +36,18 @@ describe('task-sandbox pure functions', () => {
         it('prefix 유사 디렉토리 탈출 차단 (task1-evil)', () => {
             expect(() => safeResolveWorkspacePath(root, '../task1-evil/x')).toThrow('탈출 차단');
         });
+        // 컨테이너 마운트 지점 표기 — 에이전트가 컨테이너 안에서 보는 실제 경로다(2026-08-03).
+        // 종전에는 탈출로 차단돼 예약 리포트가 /workspace/data.json 쓰기에 반복 실패했다.
+        it('컨테이너 절대경로(/workspace/...)는 같은 대상으로 해석', () => {
+            expect(safeResolveWorkspacePath(root, '/workspace/data.json')).toBe('/tmp/ws/task1/data.json');
+            expect(safeResolveWorkspacePath(root, '/workspace/sub/report.html')).toBe('/tmp/ws/task1/sub/report.html');
+            expect(safeResolveWorkspacePath(root, '/workspace')).toBe('/tmp/ws/task1');
+            expect(safeResolveWorkspacePath(root, '/workspace/')).toBe('/tmp/ws/task1');
+        });
+        it('정규화 후에도 탈출은 차단 — /workspace/../ 와 prefix 유사 경로', () => {
+            expect(() => safeResolveWorkspacePath(root, '/workspace/../etc/passwd')).toThrow('탈출 차단');
+            expect(() => safeResolveWorkspacePath(root, '/workspace-evil/x')).toThrow('탈출 차단');
+        });
     });
 
     describe('safeRealWorkspacePath (심링크 탈출 차단 — 실제 FS)', () => {

--- a/apps/api/src/services/task-sandbox/sandbox.ts
+++ b/apps/api/src/services/task-sandbox/sandbox.ts
@@ -88,10 +88,23 @@ export function buildBrowserRunArgs(
  * PURE: workspace 내부로만 해석되는 안전 경로 반환 (유닛테스트 대상).
  * `..`/절대경로 표기 탈출을 차단하는 **어휘적(1차)** 가드 — 심링크는 해석하지 않으므로
  * 실제 파일 I/O 전에는 반드시 safeRealWorkspacePath 로 실경로까지 검증할 것.
+ *
+ * 컨테이너 절대경로(`/workspace/...`)는 **탈출이 아니라 같은 파일의 다른 표기**다. 에이전트는
+ * 컨테이너 안에서 bash 로 작업하므로 `/workspace/data.json` 이 눈에 보이는 정확한 경로이고,
+ * 실제로 그렇게 쓴다 — 그런데 이 검사는 호스트 경로(hostWorkdir) 기준이라 탈출로 판정했다.
+ * 2026-07-22 ~ 08-02 사이 예약 리포트가 `/workspace/data.json`·`/workspace/report.html` 로
+ * 반복 차단당하며 턴을 낭비했고, 08-03 실행은 마지막 턴에 이 차단을 맞아 재시도할 턴이 없어
+ * 리포트 없이 끝났다. 마운트 지점을 상대경로로 정규화해 같은 대상을 같게 해석한다.
+ * 정규화 뒤에도 검사는 그대로 적용되므로 `/workspace/../etc/passwd` 는 여전히 차단된다.
  */
 export function safeResolveWorkspacePath(hostWorkdir: string, userPath: string): string {
     const root = resolve(hostWorkdir);
-    const abs = resolve(root, userPath);
+    const normalized = userPath === WORKSPACE
+        ? '.'
+        : userPath.startsWith(WORKSPACE + '/')
+            ? userPath.slice(WORKSPACE.length + 1) || '.'
+            : userPath;
+    const abs = resolve(root, normalized);
     if (abs !== root && !abs.startsWith(root + sep)) {
         throw new Error(`workspace 경로 탈출 차단: ${userPath}`);
     }

--- a/apps/web/app/(workspace)/agent-tasks/page.tsx
+++ b/apps/web/app/(workspace)/agent-tasks/page.tsx
@@ -60,6 +60,8 @@ interface AgentTask {
   totalTokens?: number;
   /** Cowork D2: 'local' 이면 데스크톱 브리지 폴더에서 실행 */
   executor?: "sandbox" | "local";
+  /** 실패 사유 — 코드(goal_incomplete/max_turns_exhausted/interrupted) 또는 자유 텍스트. */
+  error?: string;
 }
 
 type PlanStepStatus = "not_started" | "in_progress" | "completed" | "blocked";
@@ -85,6 +87,8 @@ interface ApiAgentTask {
   git_pr_url?: string | null;
   /** Cowork D2: 실행 백엔드 — 'local' 이면 데스크톱 브리지 폴더에서 실행됨 */
   executor?: "sandbox" | "local";
+  /** 실패 사유 (toPublicTask 가 노출하는 error 컬럼) */
+  error?: string;
 }
 
 type TaskFilesResponse = ApiSuccess<{ files: string[] }>;
@@ -148,7 +152,20 @@ function mapTask(tr: TFn, t: ApiAgentTask): AgentTask {
     resumable: t.resumable,
     totalTokens: typeof t.total_tokens === "number" ? t.total_tokens : undefined,
     executor: t.executor,
+    error: t.error || undefined,
   };
+}
+
+/** 실패 사유 코드 — i18n 번역 대상. 그 외 값은 자유 텍스트로 원문 표시. */
+const KNOWN_ERROR_CODES = new Set(["goal_incomplete", "max_turns_exhausted", "interrupted"]);
+/** 재개 가능한 사유 — resume 버튼과 시각적으로 연결. */
+const RESUMABLE_ERROR_CODES = new Set(["max_turns_exhausted", "interrupted"]);
+
+/** 실패 사유 라벨: 알려진 코드는 번역, 그 외는 원문 축약(전문은 tooltip). */
+function errorReasonLabel(tr: TFn, error: string): string {
+  return KNOWN_ERROR_CODES.has(error)
+    ? tr(`errorReason.${error}`)
+    : error.length > 48 ? `${error.slice(0, 48)}…` : error;
 }
 
 /* ── 목업 폴백 ─────────────────────────────────────────────── */
@@ -325,6 +342,21 @@ function TaskDetailModal({
               </span>
               <span>{t("turnLabel")} {detail.task.current_turn ?? 0}/{detail.task.max_turns ?? 0}</span>
             </div>
+            {/* 실패 사유 — 상세에도 노출(카드와 동일 규칙) */}
+            {detail.task.status === "failed" && detail.task.error && (
+              <div className="mt-2 flex flex-wrap items-center gap-1.5 text-xs">
+                <span className="text-muted">{t("errorReason.label")}</span>
+                <span
+                  className="inline-flex items-center rounded-md border border-danger/40 bg-danger-soft px-2 py-0.5 font-medium text-danger"
+                  title={detail.task.error}
+                >
+                  {errorReasonLabel(t, detail.task.error)}
+                </span>
+                {RESUMABLE_ERROR_CODES.has(detail.task.error) && (
+                  <span className="text-faint">{t("errorReason.resumableHint")}</span>
+                )}
+              </div>
+            )}
           </div>
 
           {/* 실행 중/일시정지 시 방향 지시(steering) — 취소·재시작 없이 교정. */}
@@ -961,6 +993,21 @@ export default function AgentTasksPage() {
                       {t("turnShort", { current: task.currentTurn, max: task.maxTurns })}
                     </span>
                   </div>
+
+                  {/* 실패 사유 — 알려진 코드는 번역, 재개 가능 사유는 resume 안내 병기 */}
+                  {task.rawStatus === "failed" && task.error && (
+                    <div className="mb-3 flex flex-wrap items-center gap-1.5 text-xs">
+                      <span
+                        className="inline-flex items-center rounded-md border border-danger/40 bg-danger-soft px-2 py-0.5 font-medium text-danger"
+                        title={task.error}
+                      >
+                        {errorReasonLabel(t, task.error)}
+                      </span>
+                      {RESUMABLE_ERROR_CODES.has(task.error) && task.resumable && (
+                        <span className="text-faint">{t("errorReason.resumableHint")}</span>
+                      )}
+                    </div>
+                  )}
 
                   <h3
                     className="mb-4 line-clamp-2 cursor-pointer text-sm font-semibold leading-snug text-fg hover:underline"

--- a/apps/web/app/(workspace)/research/page.tsx
+++ b/apps/web/app/(workspace)/research/page.tsx
@@ -11,6 +11,7 @@ import {
   Link,
   TriangleAlert,
   ChevronDown,
+  Trash2,
 } from "lucide-react";
 import {
   Button,
@@ -254,6 +255,22 @@ export default function ResearchPage() {
     if (!TERMINAL.includes(s.status)) poll(s.id);
   };
 
+  // 지난 리서치 삭제 — 확인 후 DELETE, 목록에서 제거. 열려있는 세션이면 상세를 닫는다.
+  const deleteSession = async (s: ApiResearchSession) => {
+    if (!window.confirm(t("deleteConfirm", { topic: s.topic.slice(0, 40) }))) return;
+    try {
+      await ApiClient.del(`/api/research/sessions/${s.id}`);
+      setSessionList((prev) => prev.filter((p) => p.id !== s.id));
+      if (activeSession?.id === s.id) {
+        if (pollRef.current) clearTimeout(pollRef.current);
+        setActiveSession(null);
+        setStatus(null);
+      }
+    } catch (err) {
+      alert(t("deleteFailed", { message: err instanceof Error ? err.message : t("status.failed") }));
+    }
+  };
+
   // 진행 중인 세션을 폴링 — 완료/실패/취소면 중단.
   const poll = async (sid: string) => {
     if (!aliveRef.current) return;
@@ -338,27 +355,40 @@ export default function ResearchPage() {
                   <p className="py-4 text-center text-xs text-muted">{t("sessionEmpty")}</p>
                 ) : (
                   sessionList.map((s) => (
-                    <button
+                    <div
                       key={s.id}
-                      type="button"
-                      onClick={() => selectSession(s)}
                       className={cn(
-                        "w-full rounded-md border px-3 py-2 text-left transition",
+                        "group relative flex items-stretch rounded-md border transition",
                         s.id === activeSession?.id
                           ? "border-accent bg-accent-soft"
                           : "border-border bg-surface-2 hover:bg-surface-3",
                       )}
                     >
-                      <div className="flex items-center gap-2">
-                        <span className="min-w-0 flex-1 truncate text-sm text-fg">{s.topic}</span>
-                        <Badge tone={STATUS_TONE[s.status]}>{t(STATUS_LABEL_KEY[s.status])}</Badge>
-                      </div>
-                      <div className="mt-0.5 flex items-center gap-2 text-[11px] text-faint">
-                        <span>{fmtDate(s.created_at)}</span>
-                        <span>·</span>
-                        <span>{Math.round(s.progress)}%</span>
-                      </div>
-                    </button>
+                      <button
+                        type="button"
+                        onClick={() => selectSession(s)}
+                        className="min-w-0 flex-1 px-3 py-2 text-left"
+                      >
+                        <div className="flex items-center gap-2">
+                          <span className="min-w-0 flex-1 truncate text-sm text-fg">{s.topic}</span>
+                          <Badge tone={STATUS_TONE[s.status]}>{t(STATUS_LABEL_KEY[s.status])}</Badge>
+                        </div>
+                        <div className="mt-0.5 flex items-center gap-2 text-[11px] text-faint">
+                          <span>{fmtDate(s.created_at)}</span>
+                          <span>·</span>
+                          <span>{Math.round(s.progress)}%</span>
+                        </div>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void deleteSession(s)}
+                        title={t("deleteTitle")}
+                        aria-label={t("deleteTitle")}
+                        className="flex w-8 shrink-0 items-center justify-center rounded-r-md text-faint opacity-0 transition hover:bg-danger-soft hover:text-danger focus:opacity-100 group-hover:opacity-100"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
                   ))
                 )}
               </CardContent>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,6 +3,7 @@ import { JetBrains_Mono } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getTranslations } from "next-intl/server";
 import "./globals.css";
+import { GoogleAnalytics } from "@/components/google-analytics";
 import { Providers } from "./providers";
 
 const jetbrainsMono = JetBrains_Mono({
@@ -43,6 +44,7 @@ export default async function RootLayout({
         <link rel="stylesheet" href="/vendor/pretendard/pretendard.css" />
       </head>
       <body className="min-h-dvh bg-app text-fg antialiased">
+        <GoogleAnalytics />
         <NextIntlClientProvider>
           <Providers>{children}</Providers>
         </NextIntlClientProvider>

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -416,6 +416,17 @@ export function Composer() {
   const MODIFIER_KEYS = new Set<string>(["webSearchEnabled", "artifactMode"]);
   const interceptActive = TOGGLES.some((m) => m.on && INTERCEPT_KEYS.has(m.key));
 
+  // 외부 provider 모델 판별 — 모델 목록의 provider 필드가 SoT('local-llm' 이 로컬).
+  // 목록 미로드 시 fullId prefix('provider:model', local-llm 제외)로 폴백 판별.
+  const selectedModelIsExternal = (() => {
+    if (!selectedModel || selectedModel === "default") return false;
+    const entry = modelsData?.models.find((m) => m.modelId === selectedModel);
+    if (entry) return entry.provider !== "local-llm";
+    return selectedModel.includes(":") && !selectedModel.startsWith("local-llm:");
+  })();
+  // 토론·딥 리서치는 전용 파이프라인이라 외부 모델을 무시하고 로컬 모델로 강제 실행된다.
+  const externalLocalModeNotice = selectedModelIsExternal && (discussionMode || deepResearchMode);
+
   return (
     <div className="mx-auto w-full max-w-3xl px-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
       <div
@@ -569,6 +580,13 @@ export function Composer() {
             );
           })}
         </div>
+
+        {/* 외부 모델 + 토론/딥리서치 조합 안내 — 이 모드는 로컬 모델로 강제 실행됨. */}
+        {externalLocalModeNotice && (
+          <p className="px-3 pt-2 text-[11px] text-warn">
+            {t("externalLocalModeNotice")}
+          </p>
+        )}
 
         {/* Phase 2 Git — repo URL 지정 시 태스크가 해당 repo 를 clone 해 작업 후 PR 생성(선택). */}
         {agentTaskMode && (

--- a/apps/web/components/chat/mcp-resource-card.tsx
+++ b/apps/web/components/chat/mcp-resource-card.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, Package } from "lucide-react";
+import type { McpToolResource } from "@openmake/shared-types";
+
+/**
+ * MCP 도구 결과의 resource content 를 채팅 타임라인에 렌더하는 접이식 카드.
+ *
+ * WS 계약상 resources 를 담을 store 필드가 없어(채팅 메시지에 구조화 필드를 추가하지
+ * 않는다), 페이로드를 sentinel 프리픽스 + JSON 으로 system(notice) 메시지 content 에
+ * 실어 나른다. notice:true 라 히스토리 payload 에는 제외되고(백엔드로 새지 않음),
+ * message-list 가 프리픽스를 감지해 이 카드로 렌더한다.
+ */
+const MCP_RESOURCE_MARK = "mcpres:";
+
+export interface McpResourcePayload {
+  toolName: string;
+  resources: McpToolResource[];
+}
+
+export function encodeMcpResources(payload: McpResourcePayload): string {
+  return MCP_RESOURCE_MARK + JSON.stringify(payload);
+}
+
+export function decodeMcpResources(content: string): McpResourcePayload | null {
+  if (!content.startsWith(MCP_RESOURCE_MARK)) return null;
+  try {
+    const parsed = JSON.parse(content.slice(MCP_RESOURCE_MARK.length)) as McpResourcePayload;
+    if (!parsed || !Array.isArray(parsed.resources)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+const TEXT_CAP = 600;
+
+/** resource uri 의 마지막 세그먼트(가독 라벨용). */
+function resourceLabel(uri: string): string {
+  const trimmed = uri.replace(/\/+$/, "");
+  const seg = trimmed.split("/").pop();
+  return seg && seg.length > 0 ? seg : uri;
+}
+
+export function McpResourceCard({ payload }: { payload: McpResourcePayload }) {
+  const [open, setOpen] = useState(false);
+  const count = payload.resources.length;
+  return (
+    <div className="w-full max-w-full overflow-hidden rounded-lg border border-border bg-surface-1">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium text-fg-2 hover:bg-surface-2"
+      >
+        <Package className="h-3.5 w-3.5 shrink-0 text-accent" />
+        <span className="min-w-0 flex-1 truncate">
+          <span className="font-mono text-fg">{payload.toolName}</span>
+          <span className="ml-1.5 text-muted">· {count}개 리소스 / {count} resource{count === 1 ? "" : "s"}</span>
+        </span>
+        <ChevronDown className={`h-3.5 w-3.5 shrink-0 text-muted transition-transform ${open ? "rotate-180" : ""}`} />
+      </button>
+      {open && (
+        <div className="space-y-2 border-t border-border px-3 py-2">
+          {payload.resources.map((r, i) => (
+            <div key={`${r.uri}-${i}`} className="space-y-1">
+              <p className="break-all font-mono text-[11px] text-muted">{resourceLabel(r.uri)}</p>
+              {r.text && (
+                <pre className="max-h-60 overflow-auto whitespace-pre-wrap break-words rounded-md bg-surface-2 p-2 text-[11px] leading-relaxed text-fg-2">
+                  {r.text.length > TEXT_CAP ? `${r.text.slice(0, TEXT_CAP)}…` : r.text}
+                </pre>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -11,6 +11,7 @@ import { useAppStore, type PendingApproval, type AgentTaskState } from "@/lib/st
 import { ApiClient } from "@/lib/api-client";
 import { Markdown } from "./markdown";
 import { StructuredAnswer } from "./structured-answer";
+import { McpResourceCard, decodeMcpResources } from "@/components/chat/mcp-resource-card";
 import { cn } from "@/lib/utils";
 
 const ARTIFACT_PLACEHOLDER = /\[\[artifact:([^\]]+)\]\]/g;
@@ -157,6 +158,25 @@ function ArtifactBuilding() {
       <FileCode2 className="h-4 w-4 animate-pulse text-accent" />
       {t("artifactBuilding")}
     </span>
+  );
+}
+
+/** system 메시지 — MCP 도구 resource 카드(sentinel content) 이거나 일반 안내/오류 텍스트. */
+function SystemMessage({ content }: { content: string }) {
+  const mcp = decodeMcpResources(content);
+  if (mcp) {
+    return (
+      <div className="flex justify-start">
+        <div className="w-full max-w-2xl">
+          <McpResourceCard payload={mcp} />
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="flex justify-center">
+      <div className="rounded-md bg-danger-soft px-3 py-1.5 text-xs text-danger">{content}</div>
+    </div>
   );
 }
 
@@ -447,12 +467,15 @@ function FeedbackButtons({ messageId }: { messageId: string }) {
   const sessionId = useAppStore((s) => s.currentSessionId);
   const [sent, setSent] = useState<"thumbs_up" | "thumbs_down" | null>(null);
   const send = (signal: "thumbs_up" | "thumbs_down") => {
-    if (sent) return;
+    // sessionId 가 없으면 백엔드 Zod min(1) 검증에 걸려 400 이므로 전송 자체를 스킵.
+    if (sent || !sessionId) return;
     setSent(signal);
-    void ApiClient.post("/api/chat/feedback", { messageId, sessionId: sessionId ?? "", signal }).catch(() => {
+    void ApiClient.post("/api/chat/feedback", { messageId, sessionId, signal }).catch(() => {
       setSent(null); // 실패 시 재시도 허용
     });
   };
+  // 세션이 없으면 피드백을 저장할 수 없다(백엔드가 sessionId 필수) — 버튼을 감춘다.
+  if (!sessionId) return null;
   if (sent) {
     return <div className="mt-1.5 text-xs text-muted">{t("feedbackThanks")}</div>;
   }
@@ -544,11 +567,7 @@ export function MessageList() {
             </div>
           </div>
         ) : m.role === "system" ? (
-          <div key={i} className="flex justify-center">
-            <div className="rounded-md bg-danger-soft px-3 py-1.5 text-xs text-danger">
-              {m.content}
-            </div>
-          </div>
+          <SystemMessage key={i} content={m.content} />
         ) : (
           <div key={i} className="flex gap-3">
             <Image src="/logo.png" alt="OpenMake" width={28} height={28} className="mt-0.5 h-7 w-7 shrink-0 rounded-md object-contain" />

--- a/apps/web/components/google-analytics.tsx
+++ b/apps/web/components/google-analytics.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import Script from "next/script";
+import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+const measurementIds = (process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? "")
+  .split(",")
+  .map((id) => id.trim())
+  .filter(Boolean);
+
+declare global {
+  interface Window {
+    dataLayer: unknown[];
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+export function GoogleAnalytics() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (measurementIds.length === 0 || !window.gtag) return;
+
+    const query = searchParams.toString();
+    const pagePath = query ? `${pathname}?${query}` : pathname;
+    for (const measurementId of measurementIds) {
+      window.gtag("config", measurementId, { page_path: pagePath });
+    }
+  }, [pathname, searchParams]);
+
+  if (measurementIds.length === 0) return null;
+
+  const primaryMeasurementId = measurementIds[0];
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${primaryMeasurementId}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          window.gtag = function(){window.dataLayer.push(arguments);};
+          window.gtag('js', new Date());
+          ${measurementIds
+            .map((measurementId) => `window.gtag('config', '${measurementId}', { send_page_view: false });`)
+            .join("\n          ")}
+        `}
+      </Script>
+    </>
+  );
+}

--- a/apps/web/components/settings/provider-keys-section.tsx
+++ b/apps/web/components/settings/provider-keys-section.tsx
@@ -11,6 +11,7 @@ import {
   X,
   Save,
   AlertTriangle,
+  ShieldCheck,
 } from "lucide-react";
 import {
   Button,
@@ -59,6 +60,23 @@ interface OAuthStartData {
   interval_sec: number;
 }
 
+/** 사용량 요약 응답 (backend GET /api/external-keys/usage/summary) */
+interface UsageSummaryData {
+  days: number;
+  totals_by_provider: Array<{
+    provider_id: string;
+    call_count: number;
+    input_tokens: number;
+    output_tokens: number;
+  }>;
+}
+
+/** provider_id → 최근 사용량 (표시용 집계) */
+interface ProviderUsage {
+  calls: number;
+  tokens: number;
+}
+
 /** SdkType → 번역 키 (렌더 시 t() 로 해석) */
 const SDK_LABEL_KEY: Record<SdkType, string> = {
   anthropic: "sdkType.anthropic",
@@ -80,12 +98,19 @@ function formatDate(iso: string | null | undefined, locale: string) {
  */
 export function ProviderKeysSection() {
   const t = useTranslations("apiKeys");
+  const pt = useTranslations("providerKeys");
   const locale = toBcp47(useLocale());
   const queryClient = useQueryClient();
   const [providers, setProviders] = useState<ProviderEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showForm, setShowForm] = useState(false);
+  const [usage, setUsage] = useState<Record<string, ProviderUsage>>({});
+  const [usageDays, setUsageDays] = useState(30);
+  const [validating, setValidating] = useState<Record<string, boolean>>({});
+  const [validateMsg, setValidateMsg] = useState<
+    Record<string, { ok: boolean; text: string }>
+  >({});
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -102,8 +127,58 @@ export function ProviderKeysSection() {
     } finally {
       setLoading(false);
     }
+    // 사용량 요약은 부가 정보 — 실패해도 키 목록 표시를 막지 않는다(fail-soft).
+    try {
+      const u = await ApiClient.get<ApiSuccess<UsageSummaryData>>(
+        "/api/external-keys/usage/summary",
+      );
+      const map: Record<string, ProviderUsage> = {};
+      for (const row of u?.data?.totals_by_provider ?? []) {
+        map[row.provider_id] = {
+          calls: row.call_count,
+          tokens: row.input_tokens + row.output_tokens,
+        };
+      }
+      setUsage(map);
+      if (u?.data?.days) setUsageDays(u.data.days);
+    } catch {
+      setUsage({});
+    }
     // locale 변경(t) 시 목업 폴백 라벨 재생성
   }, [t]);
+
+  const handleValidate = useCallback(
+    async (providerId: string) => {
+      setValidating((v) => ({ ...v, [providerId]: true }));
+      setValidateMsg((m) => {
+        const next = { ...m };
+        delete next[providerId];
+        return next;
+      });
+      try {
+        await ApiClient.post(`/api/external-keys/${providerId}/validate`, {});
+        setValidateMsg((m) => ({
+          ...m,
+          [providerId]: { ok: true, text: pt("validateOk") },
+        }));
+      } catch (e) {
+        setValidateMsg((m) => ({
+          ...m,
+          [providerId]: {
+            ok: false,
+            text: pt("validateFailed", {
+              error: e instanceof Error ? e.message : pt("error"),
+            }),
+          },
+        }));
+      } finally {
+        setValidating((v) => ({ ...v, [providerId]: false }));
+        // 검증 결과가 last_validation_ok 에 기록됨 — 상태 뱃지 갱신 위해 재조회.
+        await load();
+      }
+    },
+    [pt, load],
+  );
 
   useEffect(() => {
     queueMicrotask(() => void load());
@@ -191,6 +266,8 @@ export function ProviderKeysSection() {
                     {registered.map((p) => {
                       const k = p.user_key!;
                       const ok = k.last_validation_ok;
+                      const u = usage[p.provider_id];
+                      const vMsg = validateMsg[p.provider_id];
                       return (
                         <tr key={p.provider_id}>
                           <Td className="text-fg">
@@ -198,6 +275,15 @@ export function ProviderKeysSection() {
                             <div className="text-xs text-faint">
                               {t(SDK_LABEL_KEY[p.sdk_type])}
                             </div>
+                            {u && u.calls > 0 && (
+                              <div className="mt-0.5 text-xs text-muted">
+                                {pt("usageSummary", {
+                                  days: usageDays,
+                                  calls: u.calls.toLocaleString(locale),
+                                  tokens: u.tokens.toLocaleString(locale),
+                                })}
+                              </div>
+                            )}
                           </Td>
                           <Td>{k.display_name}</Td>
                           <Td className="font-mono text-xs">
@@ -219,16 +305,40 @@ export function ProviderKeysSection() {
                             )}
                           </Td>
                           <Td className="text-right">
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              aria-label={t("deleteAria")}
-                              onClick={() =>
-                                handleDelete(p.provider_id, p.display_name)
-                              }
-                            >
-                              <Trash2 className="h-4 w-4 text-danger" />
-                            </Button>
+                            <div className="flex items-center justify-end gap-1">
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                disabled={validating[p.provider_id]}
+                                onClick={() => void handleValidate(p.provider_id)}
+                              >
+                                {validating[p.provider_id] ? (
+                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                ) : (
+                                  <ShieldCheck className="h-4 w-4" />
+                                )}
+                                {pt("validate")}
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                aria-label={t("deleteAria")}
+                                onClick={() =>
+                                  handleDelete(p.provider_id, p.display_name)
+                                }
+                              >
+                                <Trash2 className="h-4 w-4 text-danger" />
+                              </Button>
+                            </div>
+                            {vMsg && (
+                              <p
+                                className={`mt-1 text-xs ${
+                                  vMsg.ok ? "text-success" : "text-danger"
+                                }`}
+                              >
+                                {vMsg.text}
+                              </p>
+                            )}
                           </Td>
                         </tr>
                       );

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -8,6 +8,12 @@ import { ApiClient, csrfHeaders } from "./api-client";
 
 import { getAnonSessionId } from "./anon-session";
 import { CLIENT_TIMING } from "./config";
+import { encodeMcpResources, type McpResourcePayload } from "@/components/chat/mcp-resource-card";
+
+// 배포 감지·토큰 갱신 상태는 소켓 재연결/훅 재마운트 간에도 유지되어야 하므로 모듈 레벨에 둔다.
+let moduleKnownBuildId: string | null = null;
+let moduleTokenRefreshing = false;
+let moduleReloadPending = false;
 
 /** 첨부 파일 UI 상태 — WS 계약(WsAttachedFile)에 브라우저 File 원본을 얹은 로컬 확장.
  *  rawFile 이 있으면 에이전트 작업 생성 시 multipart 로 원본을 스트리밍 업로드한다
@@ -64,6 +70,11 @@ export function useChatSocket() {
   // 에이전트 작업 taskId → 목표(goal) — agent_task_progress 렌더에 사용
   // 구조화 답변(REST) 진행 중 AbortController — abort() 가 취소할 수 있게 보관
   const structuredAbortRef = useRef<AbortController | null>(null);
+  // token_warning 갱신이 스트리밍 중 도착하면 스트림 종료 후 재연결하기 위한 예약 플래그.
+  const reconnectAfterRefreshRef = useRef(false);
+  // MCP 도구 결과 resource — 스트리밍 중 append 하면 응답이 조각나므로(appendToken 이 카드를
+  // 마지막 메시지로 오인) 버퍼에 모았다가 스트림 종료 시 flush 한다.
+  const pendingMcpResourcesRef = useRef<McpResourcePayload[]>([]);
 
   const {
     appendMessage,
@@ -104,6 +115,59 @@ export function useChatSocket() {
       reconnectRef.current = 0;
     };
 
+    // 버퍼에 모인 MCP resource 를 system(notice) 메시지로 flush — 스트림 종료 후에만 호출.
+    const flushPendingMcpResources = () => {
+      const pending = pendingMcpResourcesRef.current;
+      if (pending.length === 0) return;
+      pendingMcpResourcesRef.current = [];
+      for (const p of pending) {
+        // notice:true → 히스토리 payload 제외(백엔드로 안 샘). content 는 sentinel+JSON,
+        // message-list 가 프리픽스를 감지해 McpResourceCard 로 렌더한다.
+        appendMessage({ role: "system", notice: true, content: encodeMcpResources(p) });
+      }
+    };
+
+    // 명시적 즉시 재연결 — 현재 소켓을 닫으면 onclose 가 짧은 지연 후 새 핸드셰이크를 연다.
+    const reconnectNow = () => {
+      reconnectRef.current = 0;
+      try {
+        wsRef.current?.close();
+      } catch {
+        /* already closed */
+      }
+    };
+
+    // 스트림 종료(done/aborted/error) 후 지연된 배포 reload / 토큰 갱신 재연결을 실행.
+    const runDeferredAfterStream = () => {
+      if (moduleReloadPending) {
+        moduleReloadPending = false;
+        location.reload();
+        return;
+      }
+      if (reconnectAfterRefreshRef.current) {
+        reconnectAfterRefreshRef.current = false;
+        reconnectNow();
+      }
+    };
+
+    // token_warning 처리 — 웹은 HttpOnly 쿠키라 토큰을 못 읽으므로 REST refresh(쿠키 회전) 후
+    // WS 를 재연결(새 핸드셰이크가 새 쿠키로 재인증)한다. 스트리밍 중이면 종료 후로 미룬다.
+    const refreshAndReconnect = () => {
+      if (moduleTokenRefreshing) return;
+      moduleTokenRefreshing = true;
+      void ApiClient.post("/api/auth/refresh", undefined, { redirectOnUnauthorized: false })
+        .then(() => {
+          if (useAppStore.getState().isGenerating) reconnectAfterRefreshRef.current = true;
+          else reconnectNow();
+        })
+        .catch(() => {
+          /* 갱신 실패(세션 만료 등) — 다음 만료 경고/REST 401 인터셉트 흐름에 위임 */
+        })
+        .finally(() => {
+          moduleTokenRefreshing = false;
+        });
+    };
+
     ws.onmessage = (ev) => {
       let data: WsServerEvent;
       try {
@@ -132,25 +196,39 @@ export function useChatSocket() {
           setResearchProgress(null);
           setDiscussionProgress(null);
           setActiveTool(null);
+          flushPendingMcpResources();
+          runDeferredAfterStream();
           break;
         case "aborted":
           setStreaming(false);
           setResearchProgress(null);
           setDiscussionProgress(null);
           setActiveTool(null);
+          flushPendingMcpResources();
+          runDeferredAfterStream();
           break;
-        case "error":
+        case "error": {
+          // 스트리밍 assistant 의 streaming 플래그를 먼저 해소한다(setStreaming 은 마지막
+          // 메시지가 assistant 일 때만 clear) — 이후 system 안내를 append 하면 마지막이
+          // system 이 되어 잔존 플래그를 못 집는다(커서 깜빡임·피드백 버튼 미표시 회귀).
+          setStreaming(false);
+          flushPendingMcpResources();
+          let errMsg = data.message ?? tRef.current("unknownError");
+          if (typeof data.retryAfter === "number" && data.retryAfter > 0) {
+            const sec = Math.ceil(data.retryAfter);
+            errMsg += ` (약 ${sec}초 후 재시도 가능 / retry in ~${sec}s)`;
+          }
           appendMessage({
             role: "system",
-            content: tRef.current("error", {
-              message: data.message ?? tRef.current("unknownError"),
-            }),
+            notice: true,
+            content: tRef.current("error", { message: errMsg }),
           });
-          setStreaming(false);
           setResearchProgress(null);
           setDiscussionProgress(null);
           setActiveTool(null);
+          runDeferredAfterStream();
           break;
+        }
         case "research_progress": {
           // 딥리서치 진행을 채팅 상태 배너로 라이브 표시(스트리밍 시작 전/중).
           const p = data.progress ?? {};
@@ -184,6 +262,37 @@ export function useChatSocket() {
         case "mcp_tool_result":
           // 도구 결과 도착 — 인디케이터 해제(다음 도구 시작 시 다시 표시).
           setActiveTool(null);
+          // resource content 가 있으면 폐기하지 않고 버퍼링 → 스트림 종료 시 카드로 렌더.
+          if (Array.isArray(data.resources) && data.resources.length > 0) {
+            pendingMcpResourcesRef.current.push({
+              toolName: data.toolName,
+              resources: data.resources,
+            });
+          }
+          break;
+        case "build_id":
+          // 배포 감지 — 최초 buildId 를 기억하고, 이후 다른 buildId 재수신 시(재연결로 새 핸드셰이크)
+          // 서버가 재배포된 것이므로 구버전 탭을 새로고침한다(스트리밍 중이면 종료 후).
+          if (data.buildId) {
+            if (moduleKnownBuildId === null) {
+              moduleKnownBuildId = data.buildId;
+            } else if (moduleKnownBuildId !== data.buildId) {
+              if (useAppStore.getState().isGenerating) moduleReloadPending = true;
+              else location.reload();
+            }
+          }
+          break;
+        case "token_warning":
+          // 토큰 만료 임박 — REST refresh(쿠키 회전) 후 재연결로 세션 갱신.
+          refreshAndReconnect();
+          break;
+        case "debug_retained":
+          // 오류 본문 임시 보관 고지 — 사용자에게 보이는 안내(히스토리 제외).
+          appendMessage({
+            role: "system",
+            notice: true,
+            content: `대화 오류가 디버깅을 위해 약 ${data.ttlHours}시간 보관됩니다. / Error details retained ~${data.ttlHours}h for debugging.`,
+          });
           break;
         case "system_event":
           // 백엔드 메타 알림 — 현재는 모델 폴백 고지만 처리한다.
@@ -298,7 +407,7 @@ export function useChatSocket() {
           break;
         }
         default:
-          break; // init / token_warning 등은 추후
+          break; // init / stats / update 등 비채팅 메타는 무시
       }
     };
 
@@ -347,7 +456,7 @@ export function useChatSocket() {
       // 차단하고 재연결을 유도한다. (전송 실패한 메시지는 유실 대신 입력창에 남는다)
       const ws = wsRef.current;
       if (!ws || ws.readyState !== WebSocket.OPEN) {
-        appendMessage({ role: "system", content: tRef.current("disconnected") });
+        appendMessage({ role: "system", notice: true, content: tRef.current("disconnected") });
         connect();
         return;
       }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -238,6 +238,7 @@
     "disclaimer": "OpenMake can make mistakes. Verify important information.",
     "suppressedTag": "(not applied)",
     "modifierSuppressed": "{label} is not applied while an intercept mode is on",
+    "externalLocalModeNotice": "Discussion and Deep Research run on the local model (the selected external model is not used).",
     "toggle": {
       "discussion": "Discussion",
       "thinking": "Thinking",
@@ -771,7 +772,14 @@
     },
     "viewPr": "View PR",
     "downloadFailed": "Download failed: {error}",
-    "localBadge": "Local folder run"
+    "localBadge": "Local folder run",
+    "errorReason": {
+      "label": "Failure reason:",
+      "goal_incomplete": "Goal not met",
+      "max_turns_exhausted": "Turn/resource limit reached",
+      "interrupted": "Interrupted by server restart",
+      "resumableHint": "Can be resumed"
+    }
   },
   "customAgents": {
     "pageTitle": "Custom Agents",
@@ -871,6 +879,9 @@
     "sourceCount": "{count, plural, one {# item} other {# items}}",
     "verified": "Verified",
     "unverified": "Unverified",
+    "deleteTitle": "Delete",
+    "deleteConfirm": "Delete the research \"{topic}...\"?",
+    "deleteFailed": "Delete failed: {message}",
     "status": {
       "pending": "Pending",
       "running": "Running",
@@ -1342,6 +1353,14 @@
     "disabled": "Disabled",
     "editAction": "Edit",
     "deleteAction": "Delete"
+  },
+  "providerKeys": {
+    "validate": "Verify",
+    "validating": "Verifying",
+    "validateOk": "Verification succeeded",
+    "validateFailed": "Verification failed: {error}",
+    "usageSummary": "Last {days}d · {calls} calls · {tokens} tokens",
+    "error": "Error"
   },
   "apiKeys": {
     "title": "API Keys",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -238,6 +238,7 @@
     "disclaimer": "OpenMake は誤ることがあります。重要な情報は確認してください。",
     "suppressedTag": "(未適用)",
     "modifierSuppressed": "{label} はインターセプトモード中は適用されません",
+    "externalLocalModeNotice": "ディスカッション・ディープリサーチはローカルモデルで実行されます（選択した外部モデルは使用されません）。",
     "toggle": {
       "discussion": "ディスカッション",
       "thinking": "思考",
@@ -771,7 +772,14 @@
     },
     "viewPr": "PR を表示",
     "downloadFailed": "ダウンロードに失敗しました: {error}",
-    "localBadge": "ローカルフォルダ実行"
+    "localBadge": "ローカルフォルダ実行",
+    "errorReason": {
+      "label": "失敗理由:",
+      "goal_incomplete": "目標未達成",
+      "max_turns_exhausted": "ターン・リソース上限に到達",
+      "interrupted": "サーバー再起動により中断",
+      "resumableHint": "再開できます"
+    }
   },
   "customAgents": {
     "pageTitle": "カスタムエージェント",
@@ -871,6 +879,9 @@
     "sourceCount": "{count}件",
     "verified": "検証済み",
     "unverified": "未検証",
+    "deleteTitle": "削除",
+    "deleteConfirm": "リサーチ「{topic}...」を削除しますか？",
+    "deleteFailed": "削除に失敗しました: {message}",
     "status": {
       "pending": "待機",
       "running": "実行中",
@@ -1342,6 +1353,14 @@
     "disabled": "無効",
     "editAction": "編集",
     "deleteAction": "削除"
+  },
+  "providerKeys": {
+    "validate": "検証",
+    "validating": "検証中",
+    "validateOk": "検証に成功しました",
+    "validateFailed": "検証に失敗しました: {error}",
+    "usageSummary": "直近{days}日 · {calls}回呼び出し · {tokens}トークン",
+    "error": "エラー"
   },
   "apiKeys": {
     "title": "APIキー",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -238,6 +238,7 @@
     "disclaimer": "OpenMake 는 실수할 수 있습니다. 중요한 정보는 확인하세요.",
     "suppressedTag": "(미적용)",
     "modifierSuppressed": "{label} 은(는) 가로채기 모드에서 적용되지 않습니다",
+    "externalLocalModeNotice": "토론·딥 리서치 모드는 로컬 모델로 실행됩니다 (선택한 외부 모델은 사용되지 않음).",
     "toggle": {
       "discussion": "토론",
       "thinking": "Thinking",
@@ -771,7 +772,14 @@
     },
     "viewPr": "PR 보기",
     "downloadFailed": "다운로드 실패: {error}",
-    "localBadge": "로컬 폴더 실행"
+    "localBadge": "로컬 폴더 실행",
+    "errorReason": {
+      "label": "실패 사유:",
+      "goal_incomplete": "목표 미달성",
+      "max_turns_exhausted": "턴·자원 상한 소진",
+      "interrupted": "서버 재시작으로 중단",
+      "resumableHint": "이어하기로 재개할 수 있습니다"
+    }
   },
   "customAgents": {
     "pageTitle": "커스텀 에이전트",
@@ -871,6 +879,9 @@
     "sourceCount": "{count}건",
     "verified": "검증됨",
     "unverified": "미검증",
+    "deleteTitle": "삭제",
+    "deleteConfirm": "\"{topic}...\" 리서치를 삭제하시겠습니까?",
+    "deleteFailed": "삭제 실패: {message}",
     "status": {
       "pending": "대기",
       "running": "진행중",
@@ -1342,6 +1353,14 @@
     "disabled": "비활성",
     "editAction": "편집",
     "deleteAction": "삭제"
+  },
+  "providerKeys": {
+    "validate": "검증",
+    "validating": "검증 중",
+    "validateOk": "검증 성공",
+    "validateFailed": "검증 실패: {error}",
+    "usageSummary": "최근 {days}일 · {calls}회 호출 · {tokens} 토큰",
+    "error": "오류"
   },
   "apiKeys": {
     "title": "API 키",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -238,6 +238,7 @@
     "disclaimer": "OpenMake 可能会出错，请核实重要信息。",
     "suppressedTag": "(未应用)",
     "modifierSuppressed": "{label} 在拦截模式下不会应用",
+    "externalLocalModeNotice": "讨论和深度研究将使用本地模型运行（不会使用所选的外部模型）。",
     "toggle": {
       "discussion": "讨论",
       "thinking": "思考",
@@ -771,7 +772,14 @@
     },
     "viewPr": "查看 PR",
     "downloadFailed": "下载失败: {error}",
-    "localBadge": "本地文件夹执行"
+    "localBadge": "本地文件夹执行",
+    "errorReason": {
+      "label": "失败原因:",
+      "goal_incomplete": "目标未达成",
+      "max_turns_exhausted": "已达轮次/资源上限",
+      "interrupted": "因服务器重启而中断",
+      "resumableHint": "可继续执行"
+    }
   },
   "customAgents": {
     "pageTitle": "自定义智能体",
@@ -871,6 +879,9 @@
     "sourceCount": "{count} 条",
     "verified": "已验证",
     "unverified": "未验证",
+    "deleteTitle": "删除",
+    "deleteConfirm": "确定删除研究「{topic}...」吗？",
+    "deleteFailed": "删除失败: {message}",
     "status": {
       "pending": "待处理",
       "running": "进行中",
@@ -1342,6 +1353,14 @@
     "disabled": "已禁用",
     "editAction": "编辑",
     "deleteAction": "删除"
+  },
+  "providerKeys": {
+    "validate": "验证",
+    "validating": "验证中",
+    "validateOk": "验证成功",
+    "validateFailed": "验证失败：{error}",
+    "usageSummary": "近{days}天 · {calls}次调用 · {tokens} 令牌",
+    "error": "错误"
   },
   "apiKeys": {
     "title": "API 密钥",

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -125,11 +125,27 @@ export interface ArtifactMeta {
   lang: string | null;
 }
 
+/** MCP 도구 결과의 resource content (백엔드 external-tool-exec 가 추출해 emit). */
+export interface McpToolResource {
+  uri: string;
+  mimeType?: string;
+  text?: string;
+}
+
 export type WsServerEvent =
   | { type: "token"; token: string }
   | { type: "thinking"; token: string; messageId?: string }
   | { type: "thinking_summary"; summary: string; messageId?: string }
   | { type: "session_created"; sessionId: string }
+  /** 연결 직후 서버 build id — 클라가 기억해 두고 다른 build 재수신 시 배포로 간주(reload). */
+  | { type: "build_id"; buildId: string }
+  /**
+   * 인증 토큰 만료 임박 경고(쿨다운 있음). 웹은 HttpOnly 쿠키라 토큰을 못 읽으므로
+   * REST refresh(쿠키 회전) 후 WS 재연결(새 핸드셰이크)로 갱신한다.
+   */
+  | { type: "token_warning"; message: string }
+  /** 오류 시 디버그 본문 24h 임시 보관 고지(saveHistory=false 여도 재현용). */
+  | { type: "debug_retained"; captureId: string; expiresAt: string; ttlHours: number }
   /**
    * 백엔드 메타 알림 (ws-chat-handler onSystemEvent).
    * 현재 소비: 'model_fallback' — 선택 모델 실패로 다른 모델이 답했음을 고지.
@@ -141,13 +157,24 @@ export type WsServerEvent =
   | {
       type: "done";
       messageId?: string;
-      /** 백엔드 실제 페이로드(ws-chat-handler): 스트리밍 완료 시 토큰 메트릭. */
-      metrics?: { tokensPerSec: number; tokenCount: number };
+      /** 백엔드 실제 페이로드(ws-chat-handler): 스트리밍 완료 시 토큰 메트릭. tokensPerSec 는 toFixed(2) 문자열. */
+      metrics?: { tokensPerSec: string; tokenCount: number };
       /** 아티팩트가 있으면 raw 코드펜스가 placeholder 로 치환된 본문 — 클라가 누적 본문을 이걸로 reset. */
       cleanedContent?: string;
     }
   | { type: "aborted"; message?: string }
-  | { type: "error"; message: string }
+  | {
+      type: "error";
+      message: string;
+      /** 에러 분류(quota_exceeded / api_keys_exhausted / provider code 등) */
+      errorType?: string;
+      /** 재시도 가능까지 남은 초(quota/키 소진). */
+      retryAfter?: number;
+      /** 키 쿨다운 해제 시각(ISO) — api_keys_exhausted. */
+      resetTime?: string;
+      totalKeys?: number;
+      keysInCooldown?: number;
+    }
   | { type: "init"; data?: unknown }
   | {
       type: "agent_selected";
@@ -163,7 +190,7 @@ export type WsServerEvent =
   | { type: "skills_activated"; skillNames: string[] }
   // MCP 도구 호출 진행 (백엔드 ws-chat-handler onMcpToolStart/onMcpToolResult)
   | { type: "mcp_tool_start"; toolName: string; messageId?: string }
-  | { type: "mcp_tool_result"; toolName: string; resources?: unknown; messageId?: string }
+  | { type: "mcp_tool_result"; toolName: string; resources?: McpToolResource[]; messageId?: string }
   // 토론 모드 진행 (백엔드 ws-chat-handler onDiscussionProgress → DiscussionProgress)
   | {
       type: "discussion_progress";


### PR DESCRIPTION
## Summary
백엔드 기능 기준 프론트 정합 점검(3축: WS 계약 / REST 커버리지 / 최근 기능 반영)에서 발견된 잘못된 부분·미반영·참고 항목 수정.

### 잘못된 부분 (결함)
- WS 토큰 갱신 경로 사망 → token_warning 시 REST refresh + 유휴 재연결
- 오류/단절 system 메시지가 다음 턴 history 로 유출(외부 provider 400 소지) → notice:true
- feedback 빈 sessionId 400 → 세션 없으면 전송 스킵
- build_id 미처리로 배포 후 stale 탭 잔존 → 재배포 감지 시 유휴 reload
- error 시 스트리밍 플래그 잔존 → setStreaming 순서 수정

### 미반영 기능
- Agent Task 실패 사유(goal_incomplete/max_turns_exhausted/interrupted) i18n 라벨 표시
- Research 세션 삭제 버튼
- MCP 도구 리소스 접이식 카드 렌더(폐기하던 resources 복원)
- debug_retained 24h 보관 고지, error retryAfter 안내
- 외부 키 온디맨드 재검증 + 사용량 요약, 외부 모델+토론/리서치 모드 로컬 강제 안내

### 백엔드 정리 (참고 항목)
- external-oauth 경로 /:providerId/oauth/* 일반화(카탈로그 auth_method 검증)
- 죽은 GET/PUT /users/me/artifacts-enabled + 고아 repo 메서드 제거
- 계약(WsServerEvent) 확장·실측 정정(tokensPerSec string)

### GA4 애널리틱스 (추가 커밋 bf15bc8e)
- `google-analytics.tsx` 신규 — `NEXT_PUBLIC_GA_MEASUREMENT_ID` 콤마 구분 다중 측정 ID 전송(gtag 로더 1회 + ID별 config, SPA 라우트 변경 page_path 수동 전송), 루트 layout 삽입
- 데모 전용(G-DGVCMQ837F) + 홈페이지 공통(G-99Z94GHRPN) 이중 전송으로 openmake.cc↔chat.openmake.cc 사용자 흐름 통합 측정
- 실값은 `apps/web/.env.local`(gitignore) — NEXT_PUBLIC_* 빌드 타임 인라인, `.env.example` 안내 추가
- 운영 반영 완료: 라이브 g/collect 두 tid 204 확인, GA 콘솔 교차 도메인 구성(openmake.cc·chat.openmake.cc) 등록 완료

### 의도적 제외
agents A/B·에이전트-스킬 할당·피드백 API UI 노출(실사용 0 실험 API — 별도 승인 시), REST 채팅 미사용(외부 클라이언트용, 정상).

## Test plan
- [x] apps/api `tsc --noEmit` + jest 2,344 passed
- [x] shared-types build + `next build` 성공 (31 페이지)
- [x] `npm run lint` 0 errors
- [x] i18n 4언어 JSON 파싱 검증
- [x] GA4: 빌드 산출물 두 측정 ID 포함 + chat.openmake.cc 라이브 수집(204) 브라우저 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)