### PR TITLE
docs(caddy): rasplay 외부 직결 폐기 반영 — Caddyfile 토폴로지 주석 정정

### DIFF
--- a/scripts/caddy/Caddyfile
+++ b/scripts/caddy/Caddyfile
@@ -1,12 +1,17 @@
 # ============================================================
 # OpenMake LLM — 외부 공개용 리버스 프록시 (Caddy)
 # ============================================================
-# 목적: 외부(rasplay.tplinkdns.com:33000)에서 프론트 + REST + WebSocket 을
-#       단일 origin 으로 접근. 백엔드(52416)는 외부에 직접 노출하지 않는다.
+# 목적: 프론트 + REST + WebSocket 을 단일 origin(:33000)으로 묶는다.
+#       백엔드(52416)는 직접 노출하지 않는다.
+#
+# ⚠️ 2026-08-04 정정: 구 rasplay.tplinkdns.com:33000 외부 직결 경로는 폐기됨
+#    (라우터 포트포워딩 제거 — DDNS 레코드만 잔존하므로 DNS 가 resolve 된다고
+#    살아있다고 판단하지 말 것). 외부 공개는 chat.openmake.cc(Cloudflare Tunnel)
+#    단일 경로다. 이 :33000 블록의 현재 역할은 두 가지뿐:
+#      ① cloudflared 의 로컬 업스트림  ② LAN 내부 접속(http://<Mac LAN IP>:33000)
 #
 # 토폴로지:
-#   [외부 브라우저 rasplay.tplinkdns.com:33000]
-#        → [라우터 포트포워딩 33000 → 이 Mac:33000]
+#   [Cloudflare edge(chat.openmake.cc) → cloudflared] 또는 [LAN 브라우저]
 #        → [Caddy :33000]  ──┬─ WS upgrade ─→ 백엔드 Express WS (localhost:52416)
 #                            ├─ /api/*      ─→ 백엔드 REST       (localhost:52416)
 #                            └─ 그 외        ─→ Next.js 페이지/정적 (localhost:3000)
@@ -15,16 +20,13 @@
 #   brew install caddy
 #   caddy run --config /Volumes/MAC_APP/openmake_llm/scripts/caddy/Caddyfile
 #   # 또는 백그라운드: brew services 로 등록하거나 `caddy start`
-#
-# 라우터 설정:
-#   외부 33000 → 이 Mac 의 LAN IP:33000 (기존 33000→3000 을 33000→33000 으로 변경)
+#   (운영: /opt/homebrew/etc/Caddyfile 이 이 파일로의 심링크 — 이 파일이 SoT)
 #
 # 주의:
 #   - Caddy reverse_proxy 는 X-Forwarded-Host/Proto/For 를 자동 전달 →
-#     백엔드 buildRedirectUri(OAuth) 가 rasplay:33000 을 올바르게 인식한다.
-#   - WS origin(http://rasplay.tplinkdns.com:33000)은 백엔드 CORS_ORIGINS 에 등록되어 있어야 한다(완료).
+#     백엔드 buildRedirectUri(OAuth) 가 진입 host 를 올바르게 인식한다.
 #   - HTTP 운영(HTTPS 아님)이므로 `:33000` 으로 명시 — Caddy 자동 HTTPS 비활성.
-#     추후 도메인+TLS 도입 시 `rasplay.tplinkdns.com` 블록 + `tls` 로 전환 권장.
+#     TLS 는 Cloudflare edge 가 종단한다.
 
 :33000 {
 	# ── 채팅 WebSocket upgrade → 백엔드 Express WS ──


### PR DESCRIPTION
## Summary
- `scripts/caddy/Caddyfile` 헤더 주석 정정: 구 `rasplay.tplinkdns.com:33000` 외부 직결 경로는 폐기됨(라우터 포트포워딩 제거 — DDNS 레코드만 잔존). 외부 공개는 chat.openmake.cc(Cloudflare Tunnel) 단일 경로.
- `:33000` 의 현재 역할 명시: ① cloudflared 로컬 업스트림 ② LAN 내부 접속.
- 운영 `/opt/homebrew/etc/Caddyfile` 이 이 파일로의 심링크(SoT)임을 부기.

배경: 낡은 주석이 존재하지 않는 우회 접속 경로의 근거로 재사용되는 사고가 있어, 참조본을 2026-08-04 실측(공인IP:33000 접속 불가, LAN 200) 상태와 일치시킴. 주석만 변경 — 동작 무영향.

## Test plan
- [x] 주석 전용 변경 (Caddy 지시자 무변경) — `caddy validate` 불필요하나 diff 로 확인
- [x] 심링크 경유 라이브 파일 동일 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)