### PR TITLE
feat(agent-task): 청크 업로드 — Cloudflare 요청당 100MB 상한 우회

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -834,6 +834,17 @@ AGENT_TASK_TIMEOUT_MS=600000
 # TASK_SANDBOX_WORKSPACE_QUOTA(기본 512MB)도 파일 크기에 맞게 조정할 것.
 # AGENT_TASK_UPLOAD_ROOT=/path/to/uploads
 
+# Agent Task — 청크 업로드 (/api/agent-task-uploads). 외부(chat.openmake.cc)는 Cloudflare
+# 무료 플랜의 요청당 100MB 상한이 있어, 대용량 첨부는 청크로 나눠 올린 뒤 uploadId 로
+# 작업을 생성한다(프론트가 합계 60MB 초과 시 자동 전환). 청크 크기(기본 32MB)·업로드당
+# 청크 수(기본 256)·미완성 업로드 보관 시한(기본 24h).
+# AGENT_TASK_CHUNK_MAX_BYTES=33554432
+# AGENT_TASK_CHUNK_MAX_COUNT=256
+# AGENT_TASK_CHUNK_TTL_MS=86400000
+# 청크 업로드 레이트 리밋 (15분 창, IP/사용자별 요청 수 — 기본 300, 약 9GB 분량).
+# RL_CHUNK_UPLOAD_IP=300
+# RL_CHUNK_UPLOAD_USER=300
+
 # Agent Task — 목표 달성 judge (아티팩트 없는 최종 답변을 판정 전용 LLM 1회 호출로 검증,
 # 미달성이면 completed 대신 failed(goal_incomplete)). 기본 ON. 'false' 로 비활성.
 # AGENT_TASK_GOAL_JUDGE=true

--- a/apps/api/src/config/rate-limits.ts
+++ b/apps/api/src/config/rate-limits.ts
@@ -260,6 +260,7 @@ const _windowMsInvariant = [
     { name: 'RL_RESEARCH', cfg: RL_RESEARCH },
     { name: 'RL_AGENT_TASK', cfg: RL_AGENT_TASK },
     { name: 'RL_UPLOAD', cfg: RL_UPLOAD },
+    { name: 'RL_CHUNK_UPLOAD', cfg: RL_CHUNK_UPLOAD },
     { name: 'RL_WEB_SEARCH', cfg: RL_WEB_SEARCH },
     { name: 'RL_MEMORY', cfg: RL_MEMORY },
     { name: 'RL_MCP', cfg: RL_MCP },

--- a/apps/api/src/config/rate-limits.ts
+++ b/apps/api/src/config/rate-limits.ts
@@ -99,6 +99,16 @@ export const RL_UPLOAD = {
 } as const;
 
 /**
+ * 청크 업로드 레이트 리밋 — 파일 하나가 청크 수십 개(예: 1GB = 32MB×32)로 쪼개져
+ * 오므로 일반 업로드보다 훨씬 높은 요청 수를 허용해야 한다(15분 창 기준 약 9GB 분량).
+ */
+export const RL_CHUNK_UPLOAD = {
+    windowMs: WINDOW_15M,
+    ipLimit: Number(process.env.RL_CHUNK_UPLOAD_IP) || 300,
+    userLimit: Number(process.env.RL_CHUNK_UPLOAD_USER) || 300,
+} as const;
+
+/**
  * 웹 검색 레이트 리밋 (외부 API 호출 — 비용 높음)
  */
 export const RL_WEB_SEARCH = {

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1231,6 +1231,20 @@ export const AGENT_TASK_LIMITS = {
      *  AGENT_TASK_UPLOAD_ROOT(기본 <cwd>/data/uploads/agent-tasks). */
     UPLOAD_ROOT: process.env.AGENT_TASK_UPLOAD_ROOT
         || `${process.cwd()}/data/uploads/agent-tasks`,
+    /**
+     * 청크 업로드(2026-08-04) — chat.openmake.cc 외부 경로는 Cloudflare 무료 플랜의
+     * 요청당 100MB 상한이 있어 단일 multipart/json 으로는 대용량 첨부가 edge 413 으로
+     * 거절된다. 파일을 청크로 나눠 /api/agent-task-uploads 로 올린 뒤 uploadId 참조로
+     * 작업을 생성하면 요청당 크기가 CHUNK_MAX_BYTES 이하로 유지돼 상한을 우회한다.
+     */
+    /** 청크 1개 최대 크기(bytes) — Cloudflare 100MB 상한 대비 충분한 여유.
+     *  AGENT_TASK_CHUNK_MAX_BYTES(기본 32MB). */
+    CHUNK_MAX_BYTES: parseInt(process.env.AGENT_TASK_CHUNK_MAX_BYTES || '', 10) || 32 * 1024 * 1024,
+    /** 업로드당 청크 수 상한 — REQUEST_BODY_MAX_BYTES(1000MB)/최소 실용 청크 기준 여유값. */
+    CHUNK_MAX_COUNT: parseInt(process.env.AGENT_TASK_CHUNK_MAX_COUNT || '', 10) || 256,
+    /** 미완성(미클레임) 청크 업로드 보관 시한(ms) — init 시 지난 것을 기회적으로 청소.
+     *  AGENT_TASK_CHUNK_TTL_MS(기본 24h). */
+    CHUNK_UPLOAD_TTL_MS: parseInt(process.env.AGENT_TASK_CHUNK_TTL_MS || '', 10) || 24 * 60 * 60 * 1000,
     /** 사용자 지정 max_turns 의 절대 상한 */
     MAX_TURNS_CEILING: 20,
     /**

--- a/apps/api/src/middlewares/index.ts
+++ b/apps/api/src/middlewares/index.ts
@@ -22,6 +22,7 @@ export {
     chatLimiter,
     researchLimiter,
     uploadLimiter,
+    chunkUploadLimiter,
     webSearchLimiter,
     memoryLimiter,
     mcpLimiter,

--- a/apps/api/src/middlewares/rate-limiters.ts
+++ b/apps/api/src/middlewares/rate-limiters.ts
@@ -6,7 +6,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { rateLimited } from '../utils/api-response';
 import {
-    RL_GENERAL, RL_AUTH, RL_CHAT, RL_RESEARCH, RL_UPLOAD,
+    RL_GENERAL, RL_AUTH, RL_CHAT, RL_RESEARCH, RL_UPLOAD, RL_CHUNK_UPLOAD,
     RL_WEB_SEARCH, RL_MEMORY, RL_MCP, RL_API_KEY_MGMT, RL_PUSH, RL_ADMIN,
     RL_AGENT_TASK,
 } from '../config/rate-limits';
@@ -396,6 +396,17 @@ export const uploadLimiter = createAdvancedRateLimiter({
         { path: /^POST:\/api\/documents\/upload(?:\/|$)/, limit: RL_UPLOAD.uploadLimit },
     ],
     message: '업로드 요청이 너무 많습니다. 잠시 후 다시 시도하세요.',
+});
+
+/**
+ * 청크 업로드 (agent-task 대용량 첨부) 레이트 리미터 — 파일 하나가 청크 수십 개로
+ * 나뉘어 도착하므로 uploadLimiter(30/15분)와 별도로 높은 상한을 갖는다.
+ */
+export const chunkUploadLimiter = createAdvancedRateLimiter({
+    windowMs: RL_CHUNK_UPLOAD.windowMs,
+    ipLimit: RL_CHUNK_UPLOAD.ipLimit,
+    userLimit: RL_CHUNK_UPLOAD.userLimit,
+    message: '청크 업로드 요청이 너무 많습니다. 잠시 후 다시 시도하세요.',
 });
 
 /**

--- a/apps/api/src/middlewares/setup.ts
+++ b/apps/api/src/middlewares/setup.ts
@@ -23,6 +23,7 @@ import {
     authLimiter,
     researchLimiter,
     uploadLimiter,
+    chunkUploadLimiter,
     webSearchLimiter,
     memoryLimiter,
     mcpLimiter,
@@ -137,6 +138,8 @@ export function setupParsersAndLimiting(app: Application): void {
     app.use('/api/chat', chatLimiter);
     app.use('/api/research', researchLimiter);
     app.use('/api/upload', uploadLimiter);
+    // 청크 업로드 — 파일 하나가 청크 수십 개로 쪼개져 오므로 전용(고상한) 리미터
+    app.use('/api/agent-task-uploads', chunkUploadLimiter);
     app.use('/api/web-search', webSearchLimiter);
     app.use('/api/users/me/memories', memoryLimiter);
     app.use('/api/mcp', mcpLimiter);

--- a/apps/api/src/routes/agent-task-upload.routes.ts
+++ b/apps/api/src/routes/agent-task-upload.routes.ts
@@ -1,0 +1,89 @@
+/**
+ * ============================================================
+ * Agent Task 청크 업로드 라우트 — Cloudflare 100MB 상한 우회
+ * ============================================================
+ *
+ * 외부 경로(chat.openmake.cc)는 Cloudflare 무료 플랜의 요청당 100MB 상한 때문에
+ * 대용량 첨부가 edge 413 으로 거절된다. 이 라우트는 파일을 청크 단위로 수신해
+ * 서버에서 조립하고, 작업 생성(POST /api/agent-tasks)이 uploadId 로 참조한다.
+ *
+ * - POST   /api/agent-task-uploads                    - 업로드 세션 시작 (선언)
+ * - PUT    /api/agent-task-uploads/:id/chunks/:index  - 청크 전송 (octet-stream)
+ * - POST   /api/agent-task-uploads/:id/complete       - 조립 완료
+ * - DELETE /api/agent-task-uploads/:id                - 중단/폐기
+ *
+ * @module routes/agent-task-upload.routes
+ */
+import express, { Router, Request, Response } from 'express';
+import { success, badRequest } from '../utils/api-response';
+import { asyncHandler } from '../utils/error-handler';
+import { requireAuth } from '../auth';
+import { validate } from '../middlewares/validation';
+import { AGENT_TASK_LIMITS } from '../config/runtime-limits';
+import { chunkedUploadInitSchema, type ChunkedUploadInitInput } from '../schemas/agent-task.schema';
+import {
+    initChunkedUpload, writeChunk, completeChunkedUpload, abortChunkedUpload,
+    ChunkStoreError,
+} from '../services/agent-task/chunk-store';
+
+const router = Router();
+router.use(requireAuth);
+
+/** ChunkStoreError → HTTP 매핑. 그 외는 asyncHandler 가 error-handler 로 위임. */
+function sendStoreError(res: Response, e: unknown): boolean {
+    if (e instanceof ChunkStoreError) {
+        res.status(e.statusCode).json(badRequest(e.message));
+        return true;
+    }
+    return false;
+}
+
+router.post('/', validate(chunkedUploadInitSchema), asyncHandler(async (req: Request, res: Response) => {
+    const decl = req.body as ChunkedUploadInitInput;
+    try {
+        const { uploadId } = await initChunkedUpload(String(req.user!.id), decl);
+        res.status(201).json(success({ uploadId, chunkMaxBytes: AGENT_TASK_LIMITS.CHUNK_MAX_BYTES }));
+    } catch (e) {
+        if (!sendStoreError(res, e)) throw e;
+    }
+}));
+
+// 청크 본문은 octet-stream 전용 raw 파서 — 전역 express.json(1mb)은 content-type 불일치로
+// 이 요청을 건드리지 않는다. 파서 상한 초과는 413 으로 떨어지며 청크 재분할로 해소 가능.
+router.put(
+    '/:uploadId/chunks/:index',
+    express.raw({ type: 'application/octet-stream', limit: AGENT_TASK_LIMITS.CHUNK_MAX_BYTES }),
+    asyncHandler(async (req: Request, res: Response) => {
+        if (!Buffer.isBuffer(req.body)) {
+            return res.status(400).json(badRequest('Content-Type: application/octet-stream 으로 전송하세요'));
+        }
+        const index = Number(req.params.index);
+        try {
+            await writeChunk(req.params.uploadId, String(req.user!.id), index, req.body);
+            res.json(success({ received: index, bytes: req.body.length }));
+        } catch (e) {
+            if (!sendStoreError(res, e)) throw e;
+        }
+    }),
+);
+
+router.post('/:uploadId/complete', asyncHandler(async (req: Request, res: Response) => {
+    try {
+        const file = await completeChunkedUpload(req.params.uploadId, String(req.user!.id));
+        res.json(success({ file }));
+    } catch (e) {
+        if (!sendStoreError(res, e)) throw e;
+    }
+}));
+
+router.delete('/:uploadId', asyncHandler(async (req: Request, res: Response) => {
+    try {
+        await abortChunkedUpload(req.params.uploadId, String(req.user!.id));
+        res.json(success({ message: '업로드가 폐기되었습니다' }));
+    } catch (e) {
+        if (!sendStoreError(res, e)) throw e;
+    }
+}));
+
+export default router;
+export { router as agentTaskUploadRouter };

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -49,6 +49,7 @@ import {
     ensureUploadTmpDir, finalizeUploadedFile, resolveStoredPath,
     discardTmpFiles, removeTaskFiles, safeBaseName,
 } from '../services/agent-task/upload-store';
+import { claimUploadsAsInputFiles, ChunkStoreError } from '../services/agent-task/chunk-store';
 
 const logger = createLogger('AgentTaskRoutes');
 const router = Router();
@@ -167,10 +168,12 @@ router.post('/', (req: Request, res: Response, next) => {
     // base64 원본도 함께 보존해 실행 시 샌드박스 uploads/ 에 원본 바이트로 기록
     // (에이전트가 openpyxl 등으로 직접 파싱). 응답에선 toPublicTask 가 메타만 노출.
     let inputFiles: AgentTaskInputFile[] | undefined;
-    if (Array.isArray(files) && files.length > 0) {
-        const originalData = files.map((f) => (typeof f.data === 'string' && f.data.length > 0 ? f.data : undefined));
-        await extractAttachedDocuments(files); // in-place: data → content 추출 후 data 제거
-        inputFiles = files.map((f, i) => ({
+    const inlineFiles = Array.isArray(files) ? files.filter((f) => !f.uploadId) : [];
+    const uploadRefs = Array.isArray(files) ? files.filter((f) => !!f.uploadId) : [];
+    if (inlineFiles.length > 0) {
+        const originalData = inlineFiles.map((f) => (typeof f.data === 'string' && f.data.length > 0 ? f.data : undefined));
+        await extractAttachedDocuments(inlineFiles); // in-place: data → content 추출 후 data 제거
+        inputFiles = inlineFiles.map((f, i) => ({
             name: f.name,
             type: f.type,
             content: f.content,
@@ -179,6 +182,21 @@ router.post('/', (req: Request, res: Response, next) => {
             ...(originalData[i] ? { data: originalData[i] } : {}),
             ...(originalData[i] && typeof f.content === 'string' ? { extracted: true } : {}),
         }));
+    }
+
+    // 입력 첨부(청크 업로드 참조 경로): /api/agent-task-uploads 로 완료된 업로드를
+    // task 디렉토리로 소모(claim) — Cloudflare 요청당 100MB 상한 우회의 마지막 단계.
+    if (uploadRefs.length > 0) {
+        try {
+            const claimed = await claimUploadsAsInputFiles(
+                uploadRefs.map((f) => ({ uploadId: f.uploadId!, type: f.type })), userId, taskId);
+            inputFiles = [...(inputFiles ?? []), ...claimed];
+        } catch (e) {
+            await removeTaskFiles(taskId); // 앞서 클레임된 파일 롤백
+            const status = e instanceof ChunkStoreError ? e.statusCode : 500;
+            res.status(status).json(badRequest(`업로드 참조 처리 실패: ${e instanceof Error ? e.message : String(e)}`));
+            return;
+        }
     }
 
     // 입력 첨부(multipart 경로): 스트리밍된 원본을 task 디렉토리로 이동하고 storedPath 로

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -36,6 +36,7 @@ export { default as agentsMonitoringRouter } from './agents-monitoring.routes';
 export { default as auditRouter } from './audit.routes';
 export { default as researchRouter } from './research.routes';
 export { default as agentTaskRouter } from './agent-task.routes';
+export { default as agentTaskUploadRouter } from './agent-task-upload.routes';
 export { default as localBridgeRouter } from './local-bridge.routes';
 export { default as desktopUpdateRouter } from './desktop-update.routes';
 export { default as agentTaskScheduleRouter } from './agent-task-schedule.routes';

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -44,6 +44,7 @@ import {
     auditRouter,
     researchRouter,
     agentTaskRouter,
+    agentTaskUploadRouter,
     localBridgeRouter,
     desktopUpdateRouter,
     agentTaskScheduleRouter,
@@ -257,6 +258,8 @@ export function setupApiRoutes(
     app.use('/api/audit', auditRouter);
     app.use('/api/research', researchRouter);
     app.use('/api/agent-tasks', agentTaskRouter);
+    // 청크 업로드 — Cloudflare 요청당 100MB 상한 우회 (대용량 첨부는 조각으로 수신)
+    app.use('/api/agent-task-uploads', agentTaskUploadRouter);
     app.use('/api/local-bridge', localBridgeRouter);
     app.use('/api/desktop', desktopUpdateRouter);
     app.use('/api/agent-task-schedules', agentTaskScheduleRouter);

--- a/apps/api/src/schemas/agent-task.schema.ts
+++ b/apps/api/src/schemas/agent-task.schema.ts
@@ -23,9 +23,24 @@ const taskInputFileSchema = z.object({
     // 가능 여부는 DOC_EXTRACT_LIMITS.MAX_BYTES_PER_FILE 가 별도 결정(초과 시 추출만 생략,
     // 원본 바이트는 샌드박스 uploads/ 로 전달되어 에이전트가 직접 파싱).
     data: z.string().max(AGENT_TASK_LIMITS.REQUEST_BODY_MAX_BYTES).optional(),
+    // 청크 업로드 참조 — /api/agent-task-uploads 로 완료(complete)된 업로드의 id.
+    // 지정 시 content/data 대신 서버 디스크의 조립 원본을 storedPath 로 소모(claim)한다.
+    uploadId: z.uuid().optional(),
     size: z.number().int().nonnegative().optional(),
     truncated: z.boolean().optional(),
 });
+
+/**
+ * 청크 업로드 세션 시작(init) 스키마 — 파일 선언(이름·크기·청크 수).
+ * 청크당 크기 상한은 AGENT_TASK_LIMITS.CHUNK_MAX_BYTES(라우트 raw 파서와 스토어가 이중 검증).
+ */
+export const chunkedUploadInitSchema = z.strictObject({
+    name: z.string().min(1).max(FILE_ATTACH_LIMITS.MAX_NAME_LENGTH),
+    type: z.string().max(100).optional(),
+    size: z.number().int().positive().max(AGENT_TASK_LIMITS.REQUEST_BODY_MAX_BYTES),
+    totalChunks: z.number().int().min(1).max(AGENT_TASK_LIMITS.CHUNK_MAX_COUNT),
+});
+export type ChunkedUploadInitInput = z.infer<typeof chunkedUploadInitSchema>;
 
 /**
  * 에이전트 작업 생성 스키마

--- a/apps/api/src/services/agent-task/__tests__/chunk-store.test.ts
+++ b/apps/api/src/services/agent-task/__tests__/chunk-store.test.ts
@@ -1,0 +1,110 @@
+/**
+ * 청크 업로드 스토어 유닛 테스트 — init/write/complete/claim 수명주기와 방어 로직.
+ * UPLOAD_ROOT 를 임시 디렉토리로 격리(모듈 로드 전 env 오버라이드).
+ */
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+const TMP_ROOT = path.join(os.tmpdir(), `chunk-store-test-${process.pid}`);
+process.env.AGENT_TASK_UPLOAD_ROOT = TMP_ROOT;
+
+// env 반영을 위해 상수 모듈보다 늦게 import (jest 는 파일 내 import 호이스팅 — require 사용)
+const {
+    initChunkedUpload, writeChunk, completeChunkedUpload, claimChunkedUpload,
+    abortChunkedUpload,
+} = require('../chunk-store') as typeof import('../chunk-store');
+
+const USER = 'user-1';
+const OTHER = 'user-2';
+
+afterAll(async () => {
+    await fs.rm(TMP_ROOT, { recursive: true, force: true });
+});
+
+async function makeUpload(content: Buffer, chunkSize: number) {
+    const totalChunks = Math.max(1, Math.ceil(content.length / chunkSize));
+    const { uploadId } = await initChunkedUpload(USER, {
+        name: 'test.bin', type: 'application/octet-stream', size: content.length, totalChunks,
+    });
+    for (let i = 0; i < totalChunks; i++) {
+        await writeChunk(uploadId, USER, i, content.subarray(i * chunkSize, (i + 1) * chunkSize));
+    }
+    return { uploadId, totalChunks };
+}
+
+describe('chunk-store 수명주기', () => {
+    it('init → chunk → complete → claim 이 원본을 그대로 복원한다', async () => {
+        const content = Buffer.from('A'.repeat(1000) + 'B'.repeat(500));
+        const { uploadId } = await makeUpload(content, 400);
+        const done = await completeChunkedUpload(uploadId, USER);
+        expect(done).toMatchObject({ name: 'test.bin', size: 1500 });
+
+        const claimed = await claimChunkedUpload(uploadId, USER, 'task-abc', 1000);
+        expect(claimed.storedPath).toContain('task-abc');
+        const restored = await fs.readFile(path.join(TMP_ROOT, claimed.storedPath));
+        expect(restored.equals(content)).toBe(true);
+        // claim 후 업로드 디렉토리는 제거됨 → 재클레임 불가
+        await expect(claimChunkedUpload(uploadId, USER, 'task-abc', 1001))
+            .rejects.toMatchObject({ statusCode: 404 });
+    });
+
+    it('complete 는 멱등 — 두 번 호출해도 같은 결과', async () => {
+        const { uploadId } = await makeUpload(Buffer.from('hello'), 3);
+        await completeChunkedUpload(uploadId, USER);
+        const again = await completeChunkedUpload(uploadId, USER);
+        expect(again.size).toBe(5);
+        await abortChunkedUpload(uploadId, USER);
+    });
+});
+
+describe('chunk-store 방어', () => {
+    it('소유자가 아니면 403', async () => {
+        const { uploadId } = await makeUpload(Buffer.from('x'), 10);
+        await expect(writeChunk(uploadId, OTHER, 0, Buffer.from('y')))
+            .rejects.toMatchObject({ statusCode: 403 });
+        await expect(claimChunkedUpload(uploadId, OTHER, 't', 0))
+            .rejects.toMatchObject({ statusCode: 403 });
+        await abortChunkedUpload(uploadId, USER);
+    });
+
+    it('경로 성분이 든 uploadId 는 400', async () => {
+        await expect(writeChunk('../evil', USER, 0, Buffer.from('x')))
+            .rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it('청크 누락 시 complete 는 409, 보충 후 성공', async () => {
+        const content = Buffer.from('0123456789');
+        const { uploadId } = await initChunkedUpload(USER, {
+            name: 'gap.bin', size: 10, totalChunks: 2,
+        });
+        await writeChunk(uploadId, USER, 0, content.subarray(0, 5));
+        await expect(completeChunkedUpload(uploadId, USER))
+            .rejects.toMatchObject({ statusCode: 409 });
+        await writeChunk(uploadId, USER, 1, content.subarray(5));
+        const done = await completeChunkedUpload(uploadId, USER);
+        expect(done.size).toBe(10);
+        await abortChunkedUpload(uploadId, USER);
+    });
+
+    it('선언 크기와 수신 합계 불일치는 409', async () => {
+        const { uploadId } = await initChunkedUpload(USER, {
+            name: 'short.bin', size: 100, totalChunks: 1,
+        });
+        await writeChunk(uploadId, USER, 0, Buffer.from('too-short'));
+        await expect(completeChunkedUpload(uploadId, USER))
+            .rejects.toMatchObject({ statusCode: 409 });
+        await abortChunkedUpload(uploadId, USER);
+    });
+
+    it('index 범위 밖 청크·완료 전 claim 은 거절', async () => {
+        const { uploadId } = await initChunkedUpload(USER, {
+            name: 'r.bin', size: 3, totalChunks: 1,
+        });
+        await expect(writeChunk(uploadId, USER, 5, Buffer.from('x')))
+            .rejects.toMatchObject({ statusCode: 400 });
+        await expect(claimChunkedUpload(uploadId, USER, 't', 0))
+            .rejects.toMatchObject({ statusCode: 409 });
+        await abortChunkedUpload(uploadId, USER);
+    });
+});

--- a/apps/api/src/services/agent-task/chunk-store.ts
+++ b/apps/api/src/services/agent-task/chunk-store.ts
@@ -1,0 +1,215 @@
+/**
+ * Agent Task 청크 업로드 스토어 — Cloudflare 요청당 100MB 상한 우회용.
+ *
+ * 외부 경로(chat.openmake.cc)는 Cloudflare 무료 플랜이 요청 body 를 100MB 로 제한해
+ * 단일 multipart/base64-JSON 으로는 대용량 첨부가 edge 413 으로 거절된다. 파일을
+ * CHUNK_MAX_BYTES 이하 조각으로 나눠 올린 뒤(init → chunk×N → complete) uploadId 로
+ * 작업 생성 시 참조(claim)하면, 요청당 크기가 상한 아래로 유지된다.
+ *
+ * 디스크 레이아웃(DB 미사용 — 서버 재시작에도 파일시스템만으로 이어짐):
+ *   <UPLOAD_ROOT>/chunked/<uploadId>/meta.json   소유자·선언 크기·청크 수
+ *   <UPLOAD_ROOT>/chunked/<uploadId>/chunk.<n>   수신된 n번째 조각
+ *   <UPLOAD_ROOT>/chunked/<uploadId>/assembled   complete 시 조립된 원본
+ *
+ * claim 은 assembled 를 기존 upload-store 의 task 디렉토리 계약(finalizeUploadedFile)으로
+ * 이동시키므로, 이후 흐름(추출·샌드박스 주입·task 삭제 시 정리)은 multipart 경로와 동일.
+ *
+ * @module services/agent-task/chunk-store
+ */
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+import { AGENT_TASK_LIMITS, DOC_EXTRACT_LIMITS } from '../../config/runtime-limits';
+import { createLogger } from '../../utils/logger';
+import { safeBaseName, finalizeUploadedFile, resolveStoredPath } from './upload-store';
+import { extractAttachedDocuments } from '../chat-service/doc-extractor';
+import type { AgentTaskInputFile } from './types';
+
+const logger = createLogger('AgentTaskChunkStore');
+
+const CHUNK_ROOT = path.join(path.resolve(AGENT_TASK_LIMITS.UPLOAD_ROOT), 'chunked');
+
+/** uploadId 는 서버 발급 uuid 만 유효 — 경로 성분 주입 차단. */
+const UPLOAD_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+export interface ChunkedUploadMeta {
+    userId: string;
+    name: string;
+    type?: string;
+    size: number;
+    totalChunks: number;
+    createdAt: number;
+}
+
+/** 스토어 오류 — 라우트가 statusCode 로 HTTP 매핑. */
+export class ChunkStoreError extends Error {
+    constructor(message: string, public readonly statusCode: 400 | 403 | 404 | 409) {
+        super(message);
+        this.name = 'ChunkStoreError';
+    }
+}
+
+function uploadDir(uploadId: string): string {
+    if (!UPLOAD_ID_RE.test(uploadId)) throw new ChunkStoreError('유효하지 않은 uploadId 입니다', 400);
+    return path.join(CHUNK_ROOT, uploadId);
+}
+
+async function loadMeta(uploadId: string, userId: string): Promise<ChunkedUploadMeta> {
+    const dir = uploadDir(uploadId); // 형식 오류는 여기서 400 — 아래 catch(404)에 삼키지 않는다
+    let raw: string;
+    try {
+        raw = await fs.readFile(path.join(dir, 'meta.json'), 'utf8');
+    } catch {
+        throw new ChunkStoreError('업로드를 찾을 수 없습니다 (만료되었거나 존재하지 않음)', 404);
+    }
+    const meta = JSON.parse(raw) as ChunkedUploadMeta;
+    if (meta.userId !== userId) throw new ChunkStoreError('이 업로드에 대한 권한이 없습니다', 403);
+    return meta;
+}
+
+/** TTL 지난 미클레임 업로드 청소 — init 때 기회적으로 호출(전용 스케줄러 불필요). */
+async function cleanupStale(): Promise<void> {
+    let entries: string[];
+    try { entries = await fs.readdir(CHUNK_ROOT); } catch { return; }
+    const cutoff = Date.now() - AGENT_TASK_LIMITS.CHUNK_UPLOAD_TTL_MS;
+    for (const id of entries) {
+        if (!UPLOAD_ID_RE.test(id)) continue;
+        try {
+            const st = await fs.stat(path.join(CHUNK_ROOT, id));
+            if (st.mtimeMs < cutoff) {
+                await fs.rm(path.join(CHUNK_ROOT, id), { recursive: true, force: true });
+                logger.info(`[ChunkStore] 만료 업로드 정리: ${id}`);
+            }
+        } catch { /* 경합 삭제 등 — 무시 */ }
+    }
+}
+
+/** 업로드 세션 시작 — 선언(파일명·크기·청크 수)을 기록하고 uploadId 발급. */
+export async function initChunkedUpload(
+    userId: string,
+    decl: { name: string; type?: string; size: number; totalChunks: number },
+): Promise<{ uploadId: string }> {
+    const expectedChunks = Math.max(1, Math.ceil(decl.size / AGENT_TASK_LIMITS.CHUNK_MAX_BYTES));
+    if (decl.totalChunks < expectedChunks) {
+        throw new ChunkStoreError(
+            `totalChunks(${decl.totalChunks})가 선언 크기 대비 부족합니다 — 청크당 최대 ${AGENT_TASK_LIMITS.CHUNK_MAX_BYTES} bytes`, 400);
+    }
+    void cleanupStale(); // 비동기 기회적 청소 — init 응답을 막지 않음
+    const uploadId = uuidv4();
+    const dir = uploadDir(uploadId);
+    await fs.mkdir(dir, { recursive: true });
+    const meta: ChunkedUploadMeta = {
+        userId,
+        name: safeBaseName(decl.name, 'file'),
+        type: decl.type,
+        size: decl.size,
+        totalChunks: decl.totalChunks,
+        createdAt: Date.now(),
+    };
+    await fs.writeFile(path.join(dir, 'meta.json'), JSON.stringify(meta), 'utf8');
+    return { uploadId };
+}
+
+/** 청크 저장 — 같은 index 재전송은 덮어쓰기(클라이언트 재시도 허용). */
+export async function writeChunk(uploadId: string, userId: string, index: number, buf: Buffer): Promise<void> {
+    const meta = await loadMeta(uploadId, userId);
+    if (!Number.isInteger(index) || index < 0 || index >= meta.totalChunks) {
+        throw new ChunkStoreError(`청크 index 범위 오류 (0..${meta.totalChunks - 1})`, 400);
+    }
+    if (buf.length === 0) throw new ChunkStoreError('빈 청크는 허용되지 않습니다', 400);
+    if (buf.length > AGENT_TASK_LIMITS.CHUNK_MAX_BYTES) {
+        throw new ChunkStoreError(`청크가 너무 큽니다 (최대 ${AGENT_TASK_LIMITS.CHUNK_MAX_BYTES} bytes)`, 400);
+    }
+    await fs.writeFile(path.join(uploadDir(uploadId), `chunk.${index}`), buf);
+}
+
+/**
+ * 조립 — 모든 청크를 순서대로 이어붙여 assembled 생성. 합계가 선언 크기와 다르면 409
+ * (청크는 보존 — 누락분 재전송 후 다시 complete 가능). 이미 조립됐으면 멱등 성공.
+ */
+export async function completeChunkedUpload(
+    uploadId: string, userId: string,
+): Promise<{ name: string; type?: string; size: number }> {
+    const meta = await loadMeta(uploadId, userId);
+    const dir = uploadDir(uploadId);
+    const assembled = path.join(dir, 'assembled');
+    if (await fs.stat(assembled).then(() => true, () => false)) {
+        return { name: meta.name, type: meta.type, size: meta.size };
+    }
+    let total = 0;
+    for (let i = 0; i < meta.totalChunks; i++) {
+        const st = await fs.stat(path.join(dir, `chunk.${i}`)).catch(() => null);
+        if (!st) throw new ChunkStoreError(`청크 ${i} 미수신 — 재전송 후 다시 완료 요청하세요`, 409);
+        total += st.size;
+    }
+    if (total !== meta.size) {
+        throw new ChunkStoreError(`크기 불일치 — 선언 ${meta.size}, 수신 ${total} bytes`, 409);
+    }
+    const partial = `${assembled}.partial`;
+    await fs.rm(partial, { force: true });
+    for (let i = 0; i < meta.totalChunks; i++) {
+        await fs.appendFile(partial, await fs.readFile(path.join(dir, `chunk.${i}`)));
+    }
+    await fs.rename(partial, assembled);
+    for (let i = 0; i < meta.totalChunks; i++) {
+        await fs.rm(path.join(dir, `chunk.${i}`), { force: true });
+    }
+    logger.info(`[ChunkStore] 조립 완료: ${uploadId} (${meta.name}, ${meta.size} bytes, ${meta.totalChunks} chunks)`);
+    return { name: meta.name, type: meta.type, size: meta.size };
+}
+
+/**
+ * 작업 생성 시 참조 소모 — assembled 를 task 디렉토리로 이동(storedPath 반환) 후
+ * 업로드 디렉토리 정리. complete 전이면 409.
+ */
+export async function claimChunkedUpload(
+    uploadId: string, userId: string, taskId: string, index: number,
+): Promise<{ name: string; type?: string; size: number; storedPath: string }> {
+    const meta = await loadMeta(uploadId, userId);
+    const dir = uploadDir(uploadId);
+    const assembled = path.join(dir, 'assembled');
+    if (!(await fs.stat(assembled).then(() => true, () => false))) {
+        throw new ChunkStoreError('완료(complete)되지 않은 업로드는 첨부할 수 없습니다', 409);
+    }
+    const storedPath = await finalizeUploadedFile(taskId, assembled, meta.name, index);
+    await fs.rm(dir, { recursive: true, force: true });
+    return { name: meta.name, type: meta.type, size: meta.size, storedPath };
+}
+
+/** 업로드 중단/폐기 — 소유자 검증 후 디렉토리 제거. */
+export async function abortChunkedUpload(uploadId: string, userId: string): Promise<void> {
+    await loadMeta(uploadId, userId);
+    await fs.rm(uploadDir(uploadId), { recursive: true, force: true });
+}
+
+/**
+ * 작업 생성 라우트용 고수준 헬퍼 — 업로드 참조 목록을 일괄 claim 하고
+ * AgentTaskInputFile 로 변환한다. 추출 정책은 multipart 경로와 동일:
+ * DOC_EXTRACT 상한 이하만 텍스트 추출 병행, 초과 파일은 원본만 샌드박스로 전달.
+ * claim index 는 1000+ — multipart parts 의 0-기반 index 와 파일명 충돌 방지.
+ */
+export async function claimUploadsAsInputFiles(
+    refs: Array<{ uploadId: string; type?: string }>,
+    userId: string,
+    taskId: string,
+): Promise<AgentTaskInputFile[]> {
+    const out: AgentTaskInputFile[] = [];
+    for (const [i, ref] of refs.entries()) {
+        const c = await claimChunkedUpload(ref.uploadId, userId, taskId, 1000 + i);
+        const entry: AgentTaskInputFile = { name: c.name, type: c.type ?? ref.type, size: c.size, storedPath: c.storedPath };
+        if (c.size <= DOC_EXTRACT_LIMITS.MAX_BYTES_PER_FILE) {
+            const probe: AgentTaskInputFile = {
+                name: c.name, type: entry.type,
+                data: (await fs.readFile(resolveStoredPath(c.storedPath))).toString('base64'),
+            };
+            await extractAttachedDocuments([probe]);
+            if (typeof probe.content === 'string') {
+                entry.content = probe.content;
+                entry.truncated = probe.truncated;
+                entry.extracted = true;
+            }
+        }
+        out.push(entry);
+    }
+    return out;
+}

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -27,6 +27,42 @@ function toWireFile(f: AttachedFileUI): WsAttachedFile {
   return rest;
 }
 
+/** 청크 업로드 임계값 — chat.openmake.cc 는 Cloudflare 무료 플랜이라 요청당 100MB 상한.
+ *  바이너리 합계가 이를 넘보면 단일 multipart 대신 청크 경로로 전환한다(여유 마진 포함). */
+const CHUNKED_UPLOAD_THRESHOLD_BYTES = 60 * 1024 * 1024;
+/** 청크 크기 — Cloudflare 상한(100MB) 대비 충분히 작게. 서버 상한(기본 32MB) 이하여야 한다. */
+const CHUNK_SIZE_BYTES = 24 * 1024 * 1024;
+
+/** 파일 하나를 청크로 나눠 업로드(init → PUT×N → complete)하고 uploadId 를 반환.
+ *  각 요청이 CHUNK_SIZE 이하라 Cloudflare 100MB 상한에 걸리지 않는다. */
+async function uploadFileInChunks(file: File): Promise<string> {
+  const totalChunks = Math.max(1, Math.ceil(file.size / CHUNK_SIZE_BYTES));
+  const init = await ApiClient.post<{ data: { uploadId: string } }>(
+    "/api/agent-task-uploads",
+    { name: file.name, type: file.type || undefined, size: file.size, totalChunks },
+  );
+  const uploadId = init?.data?.uploadId;
+  if (!uploadId) throw new Error("업로드 세션 생성 실패");
+  for (let i = 0; i < totalChunks; i++) {
+    const blob = file.slice(i * CHUNK_SIZE_BYTES, Math.min((i + 1) * CHUNK_SIZE_BYTES, file.size));
+    const resp = await fetch(`/api/agent-task-uploads/${uploadId}/chunks/${i}`, {
+      method: "PUT",
+      credentials: "include",
+      headers: { "Content-Type": "application/octet-stream", ...(await csrfHeaders()) },
+      body: blob,
+    });
+    if (!resp.ok) throw new Error(`청크 ${i + 1}/${totalChunks} 업로드 실패 (HTTP ${resp.status})`);
+  }
+  const done = await fetch(`/api/agent-task-uploads/${uploadId}/complete`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json", ...(await csrfHeaders()) },
+    body: "{}",
+  });
+  if (!done.ok) throw new Error(`업로드 완료 처리 실패 (HTTP ${done.status})`);
+  return uploadId;
+}
+
 /**
  * 채팅 WebSocket hook — 백엔드 sockets/ws-chat-handler.ts 프로토콜.
  *
@@ -537,9 +573,29 @@ export function useChatSocket() {
       try {
         // 바이너리 원본(rawFile)이 있으면 multipart 로 스트리밍 업로드 — base64-in-JSON 의
         // 크기/메모리 한계를 피하는 근본 경로. 텍스트 첨부·이미지는 payload JSON 에 동승.
+        // 단, 합계가 Cloudflare 요청당 상한(100MB)을 넘보면 청크 업로드로 전환 —
+        // 파일별로 조각 업로드 후 uploadId 참조만 담은 JSON 으로 작업을 생성한다.
         const binaryParts = (files ?? []).filter((f) => f.rawFile);
+        const totalBinaryBytes = binaryParts.reduce((sum, f) => sum + (f.rawFile?.size ?? 0), 0);
         let created: { data?: { task?: { id?: string } } } | null;
-        if (binaryParts.length > 0) {
+        if (totalBinaryBytes > CHUNKED_UPLOAD_THRESHOLD_BYTES) {
+          const uploadRefs = [];
+          for (const f of binaryParts) {
+            const uploadId = await uploadFileInChunks(f.rawFile!);
+            uploadRefs.push({ name: f.name, type: f.type, size: f.rawFile!.size, uploadId });
+          }
+          const payloadFiles = (files ?? []).filter((f) => !f.rawFile).map(toWireFile);
+          created = await ApiClient.post<{ data: { task: { id: string } } }>(
+            "/api/agent-tasks",
+            {
+              goal,
+              files: [...payloadFiles, ...uploadRefs],
+              ...(images && images.length > 0 ? { images } : {}),
+              ...(repoUrl && repoUrl.trim() ? { repoUrl: repoUrl.trim() } : {}),
+              ...(localExecutor ? { executor: "local" } : {}),
+            },
+          );
+        } else if (binaryParts.length > 0) {
           const payloadFiles = (files ?? [])
             .filter((f) => !f.rawFile)
             .map(toWireFile);


### PR DESCRIPTION
## Summary
chat.openmake.cc(Cloudflare Tunnel) 경유 대용량 첨부가 edge의 **요청당 100MB 상한**으로 413 거절되던 문제(실사고: 도시개발 PDF 첨부 시 "에이전트 작업을 시작하지 못했습니다: HTTP 413")를 청크 업로드로 해소.

### 백엔드
- **`services/agent-task/chunk-store.ts`** 신규 — 디스크 기반 청크 스토어. `init → chunk×N → complete(조립·크기검증) → claim(작업 생성 시 소모)`. meta.json 소유권 검증, uuid 형식 검증(경로 주입 차단), 미클레임 업로드 TTL 24h 기회적 청소, claim 은 기존 `finalizeUploadedFile` 계약 재사용이라 하류(추출·샌드박스 주입·작업 삭제 시 정리)는 multipart 경로와 동일
- **`routes/agent-task-upload.routes.ts`** 신규 — `POST /api/agent-task-uploads`(init), `PUT :id/chunks/:n`(octet-stream raw, 기본 32MB 상한), `POST :id/complete`, `DELETE :id`. 전용 `chunkUploadLimiter`(기본 300/15분 — 파일 하나가 청크 수십 개로 도착)
- `POST /api/agent-tasks` 의 `files[].uploadId` 수용 — claim 실패 시 선클레임분 롤백(`removeTaskFiles`)
- 상수는 `AGENT_TASK_LIMITS.CHUNK_*` + env 오버라이드(`.env.example` 문서화)

### 프론트 (apps/web)
- `use-chat-socket.ts` — 바이너리 첨부 합계가 60MB 초과 시 단일 multipart 대신 파일별 24MB 청크 업로드 후 uploadId 참조 JSON 으로 작업 생성. 이하는 기존 multipart 경로 유지(회귀 없음)

## Test plan
- [x] 유닛 `chunk-store.test.ts` 7/7 (수명주기·멱등 complete·소유권 403·경로주입 400·누락 409·크기 불일치 409)
- [x] agent-task 전체 스위트 17 suites / 130 tests 통과, `tsc --noEmit` 0, eslint 0 errors, 600줄 가드 통과(584)
- [x] **curl 라이브 E2E (Cloudflare 경유)**: 130MB 랜덤 파일 6청크 업로드 → complete → 작업 생성(201) → 서버 저장본 **sha256 원본 일치** → 청크 임시디렉토리 정리 → 작업 삭제 시 파일 정리
- [x] **브라우저 라이브 E2E (운영 UI)**: chat.openmake.cc 에서 65MB PDF 첨부 → 배포 번들이 자동 분기해 init→청크 3개→complete→작업 생성(201)→execute(202) 네트워크 실측 → 테스트 작업 취소·삭제 완료
- [x] 운영 반영·검증 완료 (백엔드/프론트 빌드+재시작, health 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)