### PR TITLE
feat(ocr): 스캔 PDF 처리 — 샌드박스 OCR 도구 + 네이티브 추출 폴백

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -845,6 +845,15 @@ AGENT_TASK_TIMEOUT_MS=600000
 # RL_CHUNK_UPLOAD_IP=300
 # RL_CHUNK_UPLOAD_USER=300
 
+# 문서 추출 — 스캔본 PDF 네이티브 OCR (pdftoppm+tesseract 필요: brew install poppler tesseract tesseract-lang).
+# 미설치 시 구 경로(sips+tesseract.js, 첫 페이지만)로 자동 폴백. 생성 시점 동기 추출이라
+# 페이지·시간 예산으로 상한 — 잔여 페이지는 원본이 샌드박스로 전달돼 에이전트가 직접 OCR.
+# 30MB(DOC_EXTRACT_MAX_BYTES_PER_FILE) 초과 스캔 PDF 도 OCR_MAX_BYTES 까지는 OCR 직행.
+# DOC_EXTRACT_OCR_MAX_PAGES=50
+# DOC_EXTRACT_OCR_DPI=200
+# DOC_EXTRACT_OCR_PARALLEL=4
+# DOC_EXTRACT_OCR_MAX_BYTES=314572800
+
 # Agent Task — 목표 달성 judge (아티팩트 없는 최종 답변을 판정 전용 LLM 1회 호출로 검증,
 # 미달성이면 completed 대신 failed(goal_incomplete)). 기본 ON. 'false' 로 비활성.
 # AGENT_TASK_GOAL_JUDGE=true

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -405,6 +405,22 @@ export const DOC_EXTRACT_LIMITS = {
     OCR_TIMEOUT_MS: parseInt(process.env.DOC_EXTRACT_OCR_TIMEOUT_MS || '120000', 10),
     /** OCR 언어 (tesseract 코드, '+' 로 다중 — 기본 영어+한국어) */
     OCR_LANGS: process.env.DOC_EXTRACT_OCR_LANGS || 'eng+kor',
+    /**
+     * 네이티브 OCR (pdftoppm+tesseract, 2026-08-04) — 구 sips+tesseract.js 폴백은 첫
+     * 페이지만 인식하는 1페이지 한계가 있었다. 호스트에 poppler/tesseract 가 있으면
+     * 다중 페이지 병렬 OCR 로 대체하고, 없으면 구 경로로 자동 폴백(graceful).
+     * 생성 시점 동기 추출이므로 페이지·시간 예산으로 상한을 건다 — 예산 밖 잔여
+     * 페이지는 원본이 샌드박스로 전달돼 에이전트가 컨테이너 내 tesseract 로 직접 처리.
+     */
+    /** 생성 시점 OCR 최대 페이지 수 (한국어 OCR 실측 약 2~7초/페이지 — 예산 내 상한) */
+    OCR_MAX_PAGES: parseInt(process.env.DOC_EXTRACT_OCR_MAX_PAGES || '50', 10),
+    /** OCR 래스터화 해상도 (dpi) — 인쇄물 텍스트는 200 이면 충분, 300 은 2배 이상 느림 */
+    OCR_DPI: parseInt(process.env.DOC_EXTRACT_OCR_DPI || '200', 10),
+    /** OCR 페이지 병렬도 (tesseract 프로세스 동시 실행 수) */
+    OCR_PARALLEL: parseInt(process.env.DOC_EXTRACT_OCR_PARALLEL || '4', 10),
+    /** PDF OCR 경로 전용 크기 상한 — MAX_BYTES_PER_FILE(JVM 보호용 30MB) 초과 스캔본도
+     *  이 상한까지는 OCR 를 시도한다(opendataloader 만 생략, 디스크 경유라 메모리 안전) */
+    OCR_MAX_BYTES: parseInt(process.env.DOC_EXTRACT_OCR_MAX_BYTES || String(300 * 1024 * 1024), 10),
 } as const;
 
 /**

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -212,6 +212,9 @@ router.post('/', (req: Request, res: Response, next) => {
             const name = safeBaseName(rawName, `file_${i}`);
             const storedPath = await finalizeUploadedFile(taskId, p.path, rawName, i);
             const entry: AgentTaskInputFile = { name, type: p.mimetype, size: p.size, storedPath };
+            // 생성 시점 추출은 30MB 이내만 — 대형 스캔 PDF OCR(파일당 ~2분)을 여기서 돌리면
+            // 생성 응답이 Cloudflare 응답 한도(100s, 524)를 초과한다. 대형 파일 텍스트화는
+            // 샌드박스 내 tesseract(에이전트 직접 OCR)가 담당.
             if (p.size <= DOC_EXTRACT_LIMITS.MAX_BYTES_PER_FILE) {
                 const probe: AgentTaskInputFile = {
                     name, type: p.mimetype,

--- a/apps/api/src/services/agent-task/chunk-store.ts
+++ b/apps/api/src/services/agent-task/chunk-store.ts
@@ -197,6 +197,8 @@ export async function claimUploadsAsInputFiles(
     for (const [i, ref] of refs.entries()) {
         const c = await claimChunkedUpload(ref.uploadId, userId, taskId, 1000 + i);
         const entry: AgentTaskInputFile = { name: c.name, type: c.type ?? ref.type, size: c.size, storedPath: c.storedPath };
+        // 생성 시점 추출은 30MB 이내만 — 대형 스캔 OCR 로 생성 응답이 CF 100s(524)를 넘지
+        // 않도록. 대형 파일은 샌드박스 내 tesseract 로 에이전트가 직접 OCR(운영 철학: LLM 주체).
         if (c.size <= DOC_EXTRACT_LIMITS.MAX_BYTES_PER_FILE) {
             const probe: AgentTaskInputFile = {
                 name: c.name, type: entry.type,

--- a/apps/api/src/services/chat-service/__tests__/doc-extractor-ocr-gate.test.ts
+++ b/apps/api/src/services/chat-service/__tests__/doc-extractor-ocr-gate.test.ts
@@ -1,0 +1,36 @@
+/**
+ * doc-extractor OCR 게이트 유닛 테스트 — isExtractableSize 단일 규칙 검증.
+ * (라우트 multipart·chunk-store claim·본문 루프가 이 규칙 하나를 공유 — 비대칭 회귀 방지)
+ */
+import { isExtractableSize } from '../doc-extractor';
+import { DOC_EXTRACT_LIMITS } from '../../../config/runtime-limits';
+
+const FULL = DOC_EXTRACT_LIMITS.MAX_BYTES_PER_FILE;
+const OCR_MAX = DOC_EXTRACT_LIMITS.OCR_MAX_BYTES;
+
+describe('isExtractableSize', () => {
+    it('일반 상한 이내면 확장자 무관 허용', () => {
+        expect(isExtractableSize('a.docx', FULL)).toBe(true);
+        expect(isExtractableSize('a.pdf', 1)).toBe(true);
+    });
+
+    it('빈/음수 크기는 거절', () => {
+        expect(isExtractableSize('a.pdf', 0)).toBe(false);
+        expect(isExtractableSize('a.pdf', -1)).toBe(false);
+    });
+
+    it('일반 상한 초과 PDF 는 OCR 상한까지 허용 (OCR 직행 경로)', () => {
+        expect(isExtractableSize('scan.pdf', FULL + 1)).toBe(DOC_EXTRACT_LIMITS.OCR_ENABLED);
+        expect(isExtractableSize('scan.pdf', OCR_MAX)).toBe(DOC_EXTRACT_LIMITS.OCR_ENABLED);
+        expect(isExtractableSize('scan.pdf', OCR_MAX + 1)).toBe(false);
+    });
+
+    it('일반 상한 초과 비-PDF 는 거절 (JVM/파서 보호 유지)', () => {
+        expect(isExtractableSize('big.docx', FULL + 1)).toBe(false);
+        expect(isExtractableSize('big.xlsx', OCR_MAX)).toBe(false);
+    });
+
+    it('대소문자 확장자 무관', () => {
+        expect(isExtractableSize('SCAN.PDF', FULL + 1)).toBe(DOC_EXTRACT_LIMITS.OCR_ENABLED);
+    });
+});

--- a/apps/api/src/services/chat-service/doc-extractor.ts
+++ b/apps/api/src/services/chat-service/doc-extractor.ts
@@ -29,6 +29,18 @@ function extOf(name: string): string {
 }
 
 /**
+ * 이 이름/크기 조합이 생성 시점 추출 대상인지 — 라우트(multipart)·chunk-store(claim)의
+ * 사전 게이트용 단일 규칙. 일반 상한(MAX_BYTES_PER_FILE) 이내이거나, PDF+OCR 활성이면
+ * OCR_MAX_BYTES 까지 허용(본문 루프의 ocrOnly 분기와 동일 기준 — 비대칭 금지).
+ */
+export function isExtractableSize(name: string, size: number): boolean {
+    if (size <= 0) return false;
+    if (size <= DOC_EXTRACT_LIMITS.MAX_BYTES_PER_FILE) return true;
+    return DOC_EXTRACT_LIMITS.PDF_EXTS.includes(extOf(name)) && DOC_EXTRACT_LIMITS.OCR_ENABLED
+        && size <= DOC_EXTRACT_LIMITS.OCR_MAX_BYTES;
+}
+
+/**
  * Promise 에 타임아웃을 건다. 초과 시 reject (원 작업은 백그라운드에 남을 수 있으나 호출자가 graceful 처리).
  * PDF 는 JVM child process 라 강제 종료가 어려워, 과대 파일은 MAX_BYTES_PER_FILE 로 사전 차단한다.
  */
@@ -72,14 +84,68 @@ async function extractPdf(buf: Buffer): Promise<string> {
     }
 }
 
+/** 네이티브 OCR 바이너리(pdftoppm+tesseract) 가용성 — 1회 검사 후 캐시. */
+let nativeOcrAvailable: Promise<boolean> | null = null;
+function checkNativeOcr(): Promise<boolean> {
+    if (!nativeOcrAvailable) {
+        nativeOcrAvailable = Promise.all([
+            execFileAsync('pdftoppm', ['-v']),
+            execFileAsync('tesseract', ['--version']),
+        ]).then(() => true, () => {
+            logger.warn('[DocExtract] pdftoppm/tesseract 미설치 — 스캔본 OCR 은 구 경로(sips+tesseract.js, 첫 페이지만)로 폴백');
+            return false;
+        });
+    }
+    return nativeOcrAvailable;
+}
+
 /**
- * 스캔본 PDF → text (sips 로 페이지 래스터화 후 tesseract.js OCR).
+ * 스캔본 PDF → text (네이티브 pdftoppm 래스터화 + tesseract 병렬 OCR, 다중 페이지).
+ * 생성 시점 동기 경로이므로 OCR_MAX_PAGES·OCR_TIMEOUT_MS 예산 안에서만 처리 —
+ * 잔여 페이지는 원본이 샌드박스로 전달돼 에이전트가 컨테이너 내 tesseract 로 이어서 처리.
+ */
+async function extractPdfOcrNative(buf: Buffer): Promise<string> {
+    const dir = path.join(os.tmpdir(), `om-ocr-${crypto.randomUUID()}`);
+    await fs.mkdir(dir, { recursive: true });
+    try {
+        const pdf = path.join(dir, 'in.pdf');
+        await fs.writeFile(pdf, buf);
+        await execFileAsync('pdftoppm', [
+            '-r', String(DOC_EXTRACT_LIMITS.OCR_DPI), '-gray', '-jpeg',
+            '-f', '1', '-l', String(DOC_EXTRACT_LIMITS.OCR_MAX_PAGES),
+            pdf, path.join(dir, 'p'),
+        ], { timeout: DOC_EXTRACT_LIMITS.PDF_TIMEOUT_MS });
+        const pages = (await fs.readdir(dir)).filter((f) => f.endsWith('.jpg')).sort();
+        if (pages.length === 0) return '';
+
+        const { parallelBatch } = await import('../../workflow/graph-engine');
+        const run = parallelBatch(pages, async (img) => {
+            const base = path.join(dir, img.replace(/\.jpg$/, ''));
+            await execFileAsync('tesseract', [
+                path.join(dir, img), base, '-l', DOC_EXTRACT_LIMITS.OCR_LANGS, '--psm', '3',
+            ], { timeout: DOC_EXTRACT_LIMITS.OCR_TIMEOUT_MS });
+            return `--- PAGE ${img.replace(/^p-0*|\.jpg$/g, '')} ---\n${await fs.readFile(`${base}.txt`, 'utf8')}`;
+        }, { concurrency: DOC_EXTRACT_LIMITS.OCR_PARALLEL });
+        const results = await withTimeout(run, DOC_EXTRACT_LIMITS.OCR_TIMEOUT_MS, 'PDF OCR(native)');
+        return results.filter((r): r is string => typeof r === 'string').join('\n');
+    } finally {
+        await fs.rm(dir, { recursive: true, force: true }).catch(() => { /* noop */ });
+    }
+}
+
+/** OCR 디스패처 — 네이티브 가능 시 다중 페이지, 아니면 구 경로(첫 페이지). */
+async function extractPdfOcr(buf: Buffer): Promise<string> {
+    return (await checkNativeOcr()) ? extractPdfOcrNative(buf) : extractPdfOcrLegacy(buf);
+}
+
+/**
+ * [구 경로] 스캔본 PDF → text (sips 로 페이지 래스터화 후 tesseract.js OCR).
  * officeparser 의 PDF OCR 은 페이지를 통째로 래스터화하지 않아(임베드 이미지 객체만 처리)
  * 스캔본을 못 읽으므로, macOS 내장 sips 로 PDF→PNG 변환 후 tesseract 로 직접 인식한다.
  * (운영 서버가 macOS 확정 — opendataloader JVM 과 동일하게 환경 종속. 다중 페이지 PDF 는
  * sips 가 첫 페이지만 변환하므로 첫 페이지 위주로 인식된다.)
  */
-async function extractPdfOcr(buf: Buffer): Promise<string> {
+async function extractPdfOcrLegacy(buf: Buffer): Promise<string> {
     const id = crypto.randomUUID();
     const tmpPdf = path.join(os.tmpdir(), `om-ocr-${id}.pdf`);
     const tmpPng = path.join(os.tmpdir(), `om-ocr-${id}.png`);
@@ -147,14 +213,22 @@ export async function extractAttachedDocuments(files: AttachedFileInput[] | unde
         if (!isPdf && !isOffice) { delete f.data; continue; }
 
         const buf = Buffer.from(f.data, 'base64');
-        if (buf.length === 0 || buf.length > DOC_EXTRACT_LIMITS.MAX_BYTES_PER_FILE) {
+        // PDF 는 MAX_BYTES_PER_FILE(JVM 보호) 초과라도 OCR_MAX_BYTES 까지는 OCR 직행 허용 —
+        // opendataloader 만 생략(디스크 경유 래스터화라 메모리 안전). 스캔 대형 문서가
+        // "추출 생략 → 빈 컨텍스트" 로 떨어지던 갭 해소(2026-08-04).
+        // (에이전트 작업의 대형 첨부는 라우트/claim 이 30MB 게이트로 이 함수 호출 자체를
+        //  생략한다 — 생성 응답이 CF 100s 를 넘지 않도록. 여기 ocrOnly 는 그 이하 경로용.)
+        const withinFull = buf.length <= DOC_EXTRACT_LIMITS.MAX_BYTES_PER_FILE;
+        if (buf.length === 0 || !isExtractableSize(typeof f.name === 'string' ? f.name : '', buf.length)) {
             logger.warn(`[DocExtract] ${f.name}: 크기 초과/빈 파일 (${buf.length}B) — 추출 생략`);
             delete f.data;
             continue;
         }
 
         try {
-            const text = isPdf ? await extractPdf(buf) : await extractOffice(buf, ext);
+            const text = isPdf
+                ? (withinFull ? await extractPdf(buf) : await extractPdfOcr(buf))
+                : await extractOffice(buf, ext);
             const trimmed = (text || '').trim();
             if (trimmed.length > 0) {
                 f.content = trimmed.slice(0, FILE_ATTACH_LIMITS.MAX_CHARS_PER_FILE);

--- a/infra/task-runtime/Dockerfile
+++ b/infra/task-runtime/Dockerfile
@@ -16,8 +16,11 @@ USER root
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
 
 # 실작업 상시 도구 + playwright chromium(+OS 의존성). root 설치 후 비-root 복귀.
+# tesseract-ocr(+kor): 스캔 PDF OCR — 텍스트 레이어 없는 문서(이미지 스캔본)는 pypdf 로
+# 추출이 불가능해 goal_incomplete 로 실패하던 갭(2026-08-04, 2040인천 도시기본계획 688p 실사례).
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git curl ca-certificates ripgrep fonts-nanum \
+       tesseract-ocr tesseract-ocr-kor \
     && mkdir -p /workspace /opt/browser \
     && chown node:node /workspace \
     && cd /opt/browser && npm init -y >/dev/null 2>&1 \
@@ -48,8 +51,10 @@ RUN chmod -R a+rX /opt/report-template
 # openpyxl=.xlsx 읽기/쓰기/편집, python-docx=.docx 읽기/쓰기/편집, python-pptx=.pptx 읽기/쓰기/편집,
 # reportlab/fpdf2=PDF 생성, pypdf=PDF 조작(병합/분할/회전/워터마크/폼). lxml·Pillow(docx/pptx 의존)는
 # manylinux wheel 로 시스템 의존성 없이 설치.
+# PyMuPDF=PDF 페이지→이미지 렌더(poppler 불요, 스캔본 OCR 전처리), pytesseract=tesseract 바인딩.
 RUN uv venv /opt/pyenv \
     && VIRTUAL_ENV=/opt/pyenv uv pip install --no-cache openpyxl reportlab fpdf2 python-docx python-pptx pypdf \
+       PyMuPDF pytesseract \
     && chmod -R a+rX /opt/pyenv
 ENV PATH=/opt/pyenv/bin:${PATH}
 


### PR DESCRIPTION
## Summary
스캔본(이미지) PDF 는 텍스트 레이어가 없어 추출 불가 → 에이전트 작업이 `goal_incomplete` 로 실패하던 갭(2040 인천도시기본계획 688p 실사례)을 2축으로 해소.

### ① 샌드박스 OCR — 주 경로 (에이전트가 LLM 주체로 직접 처리)
- `infra/task-runtime/Dockerfile`: `tesseract-ocr`+`tesseract-ocr-kor` + `PyMuPDF`/`pytesseract` 베이킹
- 에이전트가 스캔 문서를 스스로 렌더→OCR→분석 (목차로 대상 장 파악 후 표적 OCR)

### ② 생성 시점 네이티브 OCR 폴백 — 30MB 이하 첨부·채팅 경로
- 구 폴백(sips+tesseract.js)은 **첫 페이지만** 인식 → `pdftoppm`+`tesseract` 다중 페이지 병렬 OCR 로 대체, 바이너리 미설치 시 구 경로 자동 폴백
- 페이지·시간 예산(`DOC_EXTRACT_OCR_MAX_PAGES` 기본 50 등) — 대형 첨부는 생성 시 OCR 생략(Cloudflare 100s 응답 한도 보호), ①이 담당
- `isExtractableSize` 단일 게이트 규칙 + 유닛 테스트

## Test plan
- [x] 유닛 doc-extractor-ocr-gate 5/5, 관련 스위트 135/135, tsc·eslint 0 errors
- [x] 네이티브 폴백 라이브: 66MB 스캔 PDF → 50페이지 71,325자 추출(113.5s)
- [x] **인서비스 완주 (chat.openmake.cc)**: 66MB 스캔 PDF 청크 업로드 → 에이전트가 샌드박스 tesseract 로 13페이지 표적 OCR → 검단 지역 분석 보고서 아티팩트 생성 → **completed** (4턴/79k 토큰). 이전 동일 시나리오는 goal_incomplete 실패였음
- [x] 운영 반영 완료 (이미지 재빌드 + 백엔드 배포, health 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)