### PR TITLE
feat(agent-task): Execution Graph 증분 1 — 스텝 도구의도 영속 + 턴 재시도 + HITL 무응답 강등

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -823,6 +823,13 @@ AGENT_MAX_SEARCH_CALLS=5
 # Agent Task — 작업 전체 타임아웃 ms (기본 600000=10분. HTML/디자인 장문 생성 감안)
 AGENT_TASK_TIMEOUT_MS=600000
 
+# Agent Task — 턴 LLM 호출의 일시적 오류(5xx·408·429·connection/timeout) 재시도.
+# 후향 실측(failed 20건 중 6~7건이 timeout/connection 류) 기반 노드 retry 정책 1단계.
+# 재시도 횟수(0=비활성, 기본 2)·지수 백오프 기저 ms(기본 2000 — n번째 재시도 전 기저×2^(n-1) 대기).
+# 사용자 취소·예산 소진은 재시도하지 않는다. 재시도는 stepType='retry' 스텝으로 집계된다.
+# AGENT_TASK_TURN_RETRY_MAX=2
+# AGENT_TASK_TURN_RETRY_BACKOFF_MS=2000
+
 # Agent Task — 작업 생성 요청 body 상한 bytes (기본 1048576000=1000MB).
 # /api/agent-tasks 의 express.json 파서·validate 미들웨어·multipart 파일 상한이 이 값을 공유한다.
 # JSON(base64) 경로는 4/3 팽창으로 원본 실효 상한 약 3/4 — 대용량은 multipart 경로가 원본

--- a/.env.example
+++ b/.env.example
@@ -830,6 +830,12 @@ AGENT_TASK_TIMEOUT_MS=600000
 # AGENT_TASK_TURN_RETRY_MAX=2
 # AGENT_TASK_TURN_RETRY_BACKOFF_MS=2000
 
+# Agent Task — HITL 무응답 강등. 승인 무응답(timeout, 명시 거절 아님)이 이 횟수에 달하면
+# 이후 턴에서 승인 필요 도구(+ask_human)를 제거하고 확보한 정보로 최종 산출물 작성을 유도.
+# 방치된 task 가 승인 대기(TASK_SANDBOX_APPROVAL_TIMEOUT_MS, 기본 30분)×N 반복으로 예산만
+# 소진하고 산출물 0 으로 종결되던 패턴 차단. 0=비활성 (기본 2).
+# AGENT_TASK_HITL_TIMEOUT_DEGRADE_AFTER=2
+
 # Agent Task — 작업 생성 요청 body 상한 bytes (기본 1048576000=1000MB).
 # /api/agent-tasks 의 express.json 파서·validate 미들웨어·multipart 파일 상한이 이 값을 공유한다.
 # JSON(base64) 경로는 4/3 팽창으로 원본 실효 상한 약 3/4 — 대용량은 multipart 경로가 원본

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1289,6 +1289,11 @@ export const AGENT_TASK_LIMITS = {
     /** 턴 재시도 지수 백오프 기저(ms) — n번째 재시도 전 기저 × 2^(n-1) 대기(abort 시 즉시 중단).
      *  AGENT_TASK_TURN_RETRY_BACKOFF_MS 로 오버라이드(기본 2초). */
     TURN_RETRY_BACKOFF_MS: parseInt(process.env.AGENT_TASK_TURN_RETRY_BACKOFF_MS || '', 10) || 2_000,
+    /** HITL 무응답 강등 — 승인 무응답(timeout, 명시 거절 아님)이 이 횟수에 달하면 이후 턴에서
+     *  승인 필요 도구(+ask_human)를 제거하고 확보한 정보로 마무리를 유도한다. 후향 실측: 방치
+     *  task 가 승인 대기(30분)×N 반복으로 예산만 소진하고 산출물 0 으로 종결되던 패턴 차단.
+     *  0 이면 비활성. AGENT_TASK_HITL_TIMEOUT_DEGRADE_AFTER 로 오버라이드(기본 2). */
+    HITL_TIMEOUT_DEGRADE_AFTER: parseInt(process.env.AGENT_TASK_HITL_TIMEOUT_DEGRADE_AFTER || '2', 10),
     /**
      * 마무리 턴 강제(2026-08-03) — 자원 상한에 **닿기 전에** 도구를 끊고 종합 답변을 받는다.
      *

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1281,6 +1281,14 @@ export const AGENT_TASK_LIMITS = {
      *  멀티턴 도구 작업은 매 턴 prompt_tokens(전체 컨텍스트)를 누적 카운트하므로 200k 는
      *  3턴 만에 소진됐다(샌드박스 도구 작업이 terminate 전에 실패). 기본 1M 으로 상향. */
     MAX_TOTAL_TOKENS: parseInt(process.env.AGENT_MAX_TOTAL_TOKENS || '', 10) || 1_000_000,
+    /** 턴 LLM 호출의 일시적 오류(5xx·408·429·connection/timeout) 재시도 횟수 — 후향 실측
+     *  (2026-08-05, failed 20건 중 6~7건이 timeout/connection 류)에 근거한 노드 retry 정책 1단계.
+     *  0 이면 비활성. 사용자 취소·예산 소진(signal abort)은 재시도하지 않는다.
+     *  AGENT_TASK_TURN_RETRY_MAX 로 오버라이드(기본 2). */
+    TURN_RETRY_MAX: parseInt(process.env.AGENT_TASK_TURN_RETRY_MAX || '2', 10),
+    /** 턴 재시도 지수 백오프 기저(ms) — n번째 재시도 전 기저 × 2^(n-1) 대기(abort 시 즉시 중단).
+     *  AGENT_TASK_TURN_RETRY_BACKOFF_MS 로 오버라이드(기본 2초). */
+    TURN_RETRY_BACKOFF_MS: parseInt(process.env.AGENT_TASK_TURN_RETRY_BACKOFF_MS || '', 10) || 2_000,
     /**
      * 마무리 턴 강제(2026-08-03) — 자원 상한에 **닿기 전에** 도구를 끊고 종합 답변을 받는다.
      *

--- a/apps/api/src/prompts/agent-task-prompt.ts
+++ b/apps/api/src/prompts/agent-task-prompt.ts
@@ -207,6 +207,21 @@ export function getAgentTaskFinalTurnNudge(reason: 'turns' | 'tokens'): string {
     ].join('\n');
 }
 
+/**
+ * HITL 무응답 강등 시 주입 — 승인 무응답이 연속 임계에 달하면 승인 필요 도구를 제거하고
+ * 이 지시를 준다. 후향 실측(2026-08-05): 방치된 task 가 승인 대기(30분)×N 을 반복하며
+ * 예산만 소진하고 산출물 0 으로 종결되던 패턴의 차단 — 사용자 부재 시에도 확보한 정보로
+ * 최선의 산출물을 남기게 한다(명시 거절은 이 경로가 아님 — 거절은 모델이 대안 모색).
+ */
+export function getAgentTaskApprovalTimeoutNudge(): string {
+    return [
+        '사용자가 승인 요청에 반복해서 응답하지 않고 있습니다(자리 비움으로 판단). 승인이 필요한 도구는 더 이상 사용할 수 없습니다.',
+        '승인을 다시 기다리거나 질문하지 말고, 지금까지 확보한 정보와 이미 만든 산출물만으로 목표에 최대한 가까운 최종 결과물을 작성하세요.',
+        '수행하지 못한 부분이 있다면 어떤 승인이 없어서 무엇을 못 했는지 결과에 명시하세요.',
+        '목표를 달성하지 못했다면 첫 줄에 [GOAL_INCOMPLETE] 를 쓰고, 무엇까지 했고 무엇이 남았는지 적으세요.',
+    ].join('\n');
+}
+
 /** 산출물 문법/컴파일 검사 실패 시 주입(Phase 2-B) — 오류를 근거로 코드 산출물을 1회 자가수정 유도. */
 export function getAgentTaskVerifyFailedNudge(report: string): string {
     return [

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -355,6 +355,13 @@ export class AgentTaskService {
                 const result = await chatTurnWithRoleFallback(roleState, {
                     conversation, tools: effectiveTools, signal: callSignal,
                     taskId, userId: String(userId),
+                    // 일시적 오류 재시도를 스텝으로 남긴다 — 발동 빈도·사유를 DB 로 집계(fail-open).
+                    onRetry: ({ attempt, maxAttempts, error }) => {
+                        const note = `일시적 LLM 오류 — 재시도 ${attempt}/${maxAttempts}: ${error}`;
+                        void db.addAgentTaskStep({ taskId, stepNumber: stepNumber++, stepType: 'retry', content: note })
+                            .catch(() => { /* 관측 실패가 작업을 죽이지 않게 fail-open */ });
+                        emitStep('retry', undefined, note);
+                    },
                 });
                 this.client = roleState.client;
                 totalTokens +=

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -21,7 +21,7 @@ import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { getUnifiedDatabase } from '../data/models/unified-database';
 import { AGENT_TASK_LIMITS, AGENT_SPAWN } from '../config/runtime-limits';
 import { emitAgentTaskProgress } from '../utils/event-bus';
-import { getAgentTaskDeliverableNudge, getAgentTaskStuckNudge, getAgentTaskBrowserLimitNudge, getAgentTaskFinalTurnNudge, getAgentTaskApprovalTimeoutNudge, getTaskSandboxGuidance, getAgentTaskUploadedFilesNote, getAgentTaskVerifyFailedNudge, AGENT_TASK_INCOMPLETE_MARKER } from '../prompts/agent-task-prompt';
+import { getAgentTaskDeliverableNudge, getAgentTaskStuckNudge, getTaskSandboxGuidance, getAgentTaskUploadedFilesNote, getAgentTaskVerifyFailedNudge, AGENT_TASK_INCOMPLETE_MARKER } from '../prompts/agent-task-prompt';
 import { extractAndStripArtifacts } from '../llm/artifact-parser';
 import { applyReportRender } from './chat-service/report-block';
 import { getPushService } from './PushService';
@@ -33,12 +33,13 @@ import { buildTaskSpawnFn } from './agent-spawn/spawn-agents';
 import { mergeToolsWithSkills, type ActiveSkillBinding } from './chat-service/tool-merger';
 import { filterRestrictedTools } from './chat-service/tool-restrictions';
 import { TaskRuntime } from './task-sandbox/runtime';
-import { getApprovalRegistry, stripApprovalGatedTools } from './task-sandbox/approval-gate';
+import { getApprovalRegistry } from './task-sandbox/approval-gate';
+import { applyTurnResourceGates, type TurnGateFlags } from './agent-task/turn-gate';
 import { buildFileContext } from './chat-service/attach-context';
 import { AgentTaskAbort, assertWithinLimits, type AgentTaskRunInput } from './agent-task/types';
 import { writeInputFilesToWorkspace } from './agent-task/task-inputs';
 import { judgeGoalAchieved, buildJudgeExecutionContext } from './agent-task/goal-judge';
-import { persistArtifactSteps, isSearchTool } from './agent-task/task-steps';
+import { persistArtifactSteps } from './agent-task/task-steps';
 import { initWorkspaceBaseline, maybePersistCodeDiff, captureDiffOnCleanup } from './agent-task/code-diff';
 import { getSteeringRegistry, applyPendingSteering } from './agent-task/steering';
 import { setupTaskRepo, maybePushAndOpenPR } from './agent-task/git-ops';
@@ -110,13 +111,14 @@ export class AgentTaskService {
         // 개별 대기는 approvalTimeoutMs 가 별도 상한이므로 무한 연장은 불가.
         let pausedMs = 0;
         let searchCalls = 0;
-        let searchLimitNotified = false;
         let browserCalls = 0;
-        let browserLimitNotified = false;
-        let finalTurnNotified = false;
         // HITL 무응답 강등: 승인 timeout(명시 거절 아님) 누적 — 임계 도달 시 승인 필요 도구 제거.
         let approvalTimeouts = 0;
-        let approvalDegradeNotified = false;
+        // 턴 자원 가드의 "1회 nudge" 플래그 — turn-gate 가 제자리 갱신.
+        const gateFlags: TurnGateFlags = {
+            searchLimitNotified: false, browserLimitNotified: false,
+            finalTurnNotified: false, approvalDegradeNotified: false,
+        };
         let curStatus = 'pending';
         let curProgress = 0;
         let curTurn = 0;
@@ -282,81 +284,15 @@ export class AgentTaskService {
                 }
                 await update({ currentTurn: turn + 1, progress: nextProgress });
 
-                // 검색류/브라우저 도구 호출이 한도를 넘으면 해당 도구를 제거해 강제로 종합/작성 단계로 유도.
-                // 프롬프트 지시를 LLM 이 무시하더라도 도구 자체가 사라지므로 탐색 폭주가 끊긴다.
-                // browser 는 SEARCH_TOOL_KEYWORDS 에 안 잡혀 검색 throttle 로 제어 불가하므로 별도 cap.
-                const overSearchLimit = searchCalls >= AGENT_TASK_LIMITS.MAX_SEARCH_CALLS;
-                const overBrowserLimit = browserCalls >= AGENT_TASK_LIMITS.MAX_BROWSER_CALLS;
-                // HITL 무응답 강등 — 승인 timeout 이 임계에 달하면 승인 필요 도구를 제거해
-                // 대기-소진 반복 대신 확보한 정보로 마무리를 강제한다(명시 거절은 카운트 안 함).
-                const hitlDegraded = AGENT_TASK_LIMITS.HITL_TIMEOUT_DEGRADE_AFTER > 0
-                    && approvalTimeouts >= AGENT_TASK_LIMITS.HITL_TIMEOUT_DEGRADE_AFTER;
-
-                // 마무리 턴 — 자원 상한에 **닿기 전에** 도구를 전부 끊어 종합 답변을 받는다.
-                // 상한에서 그냥 끊으면 산출물을 이미 만든 작업도 사족에서 절단돼 결과가 남지 않는다
-                // (2026-08-03: 예약 리포트 20/20 3건 중 2건이 리포트 생성 후 검증 사족에서 절단).
-                // 도구가 사라지면 모델은 최종 답변을 낼 수밖에 없고, 그러면 terminate 완료 경로 +
-                // goal judge 판정을 정상적으로 탄다(달성이면 completed, 아니면 goal_incomplete).
-                // 턴 사유는 **도구를 쓸 턴이 최소 하나 있었을 때만** 건다 — maxTurns=1 이면
-                // 유일한 턴이 곧 마지막이라 조건 없이 걸면 도구를 한 번도 못 쓴다.
-                // 토큰 사유엔 이 가드가 없다: 누적이 임계를 넘었다는 건 resume 으로 이미 예산을
-                // 소진하고 들어왔다는 뜻이라, 첫 턴부터 마무리로 보내는 것이 맞다.
-                const finalTurnReason = !AGENT_TASK_LIMITS.FINAL_TURN_NUDGE_ENABLED
-                    ? null
-                    : totalTokens >= AGENT_TASK_LIMITS.MAX_TOTAL_TOKENS * AGENT_TASK_LIMITS.TOKEN_SOFT_RATIO
-                        ? 'tokens' as const
-                        : (turn > startTurn && turn === turnCeiling - 1)
-                            ? 'turns' as const
-                            : null;
-
-                const cappedTools = finalTurnReason
-                    ? []
-                    : (overSearchLimit || overBrowserLimit)
-                        ? tools.filter((t) => {
-                            const n = t.function.name;
-                            if (overSearchLimit && isSearchTool(n)) return false;
-                            if (overBrowserLimit && n === 'browser') return false;
-                            return true;
-                        })
-                        : tools;
-                const effectiveTools = hitlDegraded
-                    ? stripApprovalGatedTools(cappedTools, sandboxCfg.approvalPolicy,
-                        { deviceGatesShell: sandboxCfg.deviceGatesShell })
-                    : cappedTools;
-                if (finalTurnReason && !finalTurnNotified) {
-                    conversation.push({ role: 'user', content: getAgentTaskFinalTurnNudge(finalTurnReason) });
-                    finalTurnNotified = true;
-                    // 스텝으로 남긴다 — ① 사용자에겐 "왜 도구가 갑자기 멈췄는지"의 설명이 되고
-                    // ② 발동 빈도·사유를 DB 로 집계할 수 있다(로그만으론 재기동 시 유실).
-                    const note = `자원 상한 임박(${finalTurnReason === 'tokens' ? '토큰 예산' : '남은 턴'})`
-                        + ` — 도구를 중단하고 최종 정리로 전환 (턴 ${turn + 1}/${turnCeiling}, 누적 ${totalTokens} 토큰)`;
-                    await db.addAgentTaskStep({ taskId, stepNumber: stepNumber++, stepType: 'final_turn', content: note })
-                        .catch(() => { /* 관측 실패가 작업을 죽이지 않게 fail-open */ });
-                    emitStep('final_turn', undefined, note);
-                    logger.info(`[AgentTask] 마무리 턴 전환: ${taskId} (사유=${finalTurnReason}, `
-                        + `턴 ${turn + 1}/${turnCeiling}, 누적 ${totalTokens} 토큰)`);
-                }
-                if (hitlDegraded && !approvalDegradeNotified) {
-                    conversation.push({ role: 'user', content: getAgentTaskApprovalTimeoutNudge() });
-                    approvalDegradeNotified = true;
-                    // 스텝으로 남긴다 — 발동 빈도·시점을 DB 로 집계(final_turn 과 동일 관측 패턴).
-                    const note = `승인 무응답 ${approvalTimeouts}회 — 승인 필요 도구를 제거하고 확보한 정보로 마무리 전환 (턴 ${turn + 1}/${turnCeiling})`;
-                    await db.addAgentTaskStep({ taskId, stepNumber: stepNumber++, stepType: 'hitl_degrade', content: note })
-                        .catch(() => { /* 관측 실패가 작업을 죽이지 않게 fail-open */ });
-                    emitStep('hitl_degrade', undefined, note);
-                    logger.info(`[AgentTask] HITL 무응답 강등: ${taskId} (timeouts=${approvalTimeouts}, 턴 ${turn + 1})`);
-                }
-                if (overSearchLimit && !searchLimitNotified) {
-                    conversation.push({
-                        role: 'user',
-                        content: '검색 횟수 한도에 도달했습니다. 더 이상 검색하지 말고, 지금까지 수집한 정보만으로 최종 결과물(예: 블로그 초안)을 완성해 작성하세요.',
-                    });
-                    searchLimitNotified = true;
-                }
-                if (overBrowserLimit && !browserLimitNotified) {
-                    conversation.push({ role: 'user', content: getAgentTaskBrowserLimitNudge() });
-                    browserLimitNotified = true;
-                }
+                // 턴 자원 가드(검색/브라우저 cap·마무리 턴·HITL 무응답 강등) — 도구 세트 축소 +
+                // 최초 발동 시 nudge 주입·스텝 기록. 판정 근거는 agent-task/turn-gate 참고.
+                const gate = await applyTurnResourceGates({
+                    taskId, turn, startTurn, turnCeiling, totalTokens,
+                    searchCalls, browserCalls, approvalTimeouts,
+                    tools, sandboxCfg, conversation, flags: gateFlags, stepNumber, emitStep,
+                });
+                stepNumber = gate.stepNumber;
+                const { effectiveTools, finalTurnReason } = gate;
 
                 // 실행 중 사용자 중간 지시(steering) — 이 턴 경계에 도착한 지시를 conversation 에
                 // user 메시지로 주입해 방향을 조정한다. 턴 경계 소비라 tool_call_id 매칭이 유지되고

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -428,13 +428,19 @@ export class AgentTaskService {
                 const stepType = turn === 0
                     ? 'plan'
                     : (hasToolCalls ? 'assistant_tool_call' : 'assistant');
+                // 턴이 호출한 도구명 기록(콤마 결합) — 실행 결과는 tool_result 행에 남지만,
+                // 중단/거부로 실행되지 않은 호출 의도까지 남겨 턴 단위 집계를 가능하게 한다.
+                const turnToolNames = hasToolCalls
+                    ? result.tool_calls!.map((tc) => tc.function.name).join(',')
+                    : undefined;
                 await db.addAgentTaskStep({
                     taskId,
                     stepNumber: stepNumber++,
                     stepType,
+                    toolName: turnToolNames,
                     content: stepContent,
                 });
-                emitStep(stepType, undefined, stepContent);
+                emitStep(stepType, turnToolNames, stepContent);
 
                 if (!hasToolCalls) {
                     // 목표 미달성 선언: 모델이 마커로 "수행 불가"를 밝히면 completed 대신 failed(goal_incomplete)

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -21,7 +21,7 @@ import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { getUnifiedDatabase } from '../data/models/unified-database';
 import { AGENT_TASK_LIMITS, AGENT_SPAWN } from '../config/runtime-limits';
 import { emitAgentTaskProgress } from '../utils/event-bus';
-import { getAgentTaskDeliverableNudge, getAgentTaskStuckNudge, getAgentTaskBrowserLimitNudge, getAgentTaskFinalTurnNudge, getTaskSandboxGuidance, getAgentTaskUploadedFilesNote, getAgentTaskVerifyFailedNudge, AGENT_TASK_INCOMPLETE_MARKER } from '../prompts/agent-task-prompt';
+import { getAgentTaskDeliverableNudge, getAgentTaskStuckNudge, getAgentTaskBrowserLimitNudge, getAgentTaskFinalTurnNudge, getAgentTaskApprovalTimeoutNudge, getTaskSandboxGuidance, getAgentTaskUploadedFilesNote, getAgentTaskVerifyFailedNudge, AGENT_TASK_INCOMPLETE_MARKER } from '../prompts/agent-task-prompt';
 import { extractAndStripArtifacts } from '../llm/artifact-parser';
 import { applyReportRender } from './chat-service/report-block';
 import { getPushService } from './PushService';
@@ -33,7 +33,7 @@ import { buildTaskSpawnFn } from './agent-spawn/spawn-agents';
 import { mergeToolsWithSkills, type ActiveSkillBinding } from './chat-service/tool-merger';
 import { filterRestrictedTools } from './chat-service/tool-restrictions';
 import { TaskRuntime } from './task-sandbox/runtime';
-import { getApprovalRegistry } from './task-sandbox/approval-gate';
+import { getApprovalRegistry, stripApprovalGatedTools } from './task-sandbox/approval-gate';
 import { buildFileContext } from './chat-service/attach-context';
 import { AgentTaskAbort, assertWithinLimits, type AgentTaskRunInput } from './agent-task/types';
 import { writeInputFilesToWorkspace } from './agent-task/task-inputs';
@@ -114,6 +114,9 @@ export class AgentTaskService {
         let browserCalls = 0;
         let browserLimitNotified = false;
         let finalTurnNotified = false;
+        // HITL 무응답 강등: 승인 timeout(명시 거절 아님) 누적 — 임계 도달 시 승인 필요 도구 제거.
+        let approvalTimeouts = 0;
+        let approvalDegradeNotified = false;
         let curStatus = 'pending';
         let curProgress = 0;
         let curTurn = 0;
@@ -284,6 +287,10 @@ export class AgentTaskService {
                 // browser 는 SEARCH_TOOL_KEYWORDS 에 안 잡혀 검색 throttle 로 제어 불가하므로 별도 cap.
                 const overSearchLimit = searchCalls >= AGENT_TASK_LIMITS.MAX_SEARCH_CALLS;
                 const overBrowserLimit = browserCalls >= AGENT_TASK_LIMITS.MAX_BROWSER_CALLS;
+                // HITL 무응답 강등 — 승인 timeout 이 임계에 달하면 승인 필요 도구를 제거해
+                // 대기-소진 반복 대신 확보한 정보로 마무리를 강제한다(명시 거절은 카운트 안 함).
+                const hitlDegraded = AGENT_TASK_LIMITS.HITL_TIMEOUT_DEGRADE_AFTER > 0
+                    && approvalTimeouts >= AGENT_TASK_LIMITS.HITL_TIMEOUT_DEGRADE_AFTER;
 
                 // 마무리 턴 — 자원 상한에 **닿기 전에** 도구를 전부 끊어 종합 답변을 받는다.
                 // 상한에서 그냥 끊으면 산출물을 이미 만든 작업도 사족에서 절단돼 결과가 남지 않는다
@@ -302,7 +309,7 @@ export class AgentTaskService {
                             ? 'turns' as const
                             : null;
 
-                const effectiveTools = finalTurnReason
+                const cappedTools = finalTurnReason
                     ? []
                     : (overSearchLimit || overBrowserLimit)
                         ? tools.filter((t) => {
@@ -312,6 +319,10 @@ export class AgentTaskService {
                             return true;
                         })
                         : tools;
+                const effectiveTools = hitlDegraded
+                    ? stripApprovalGatedTools(cappedTools, sandboxCfg.approvalPolicy,
+                        { deviceGatesShell: sandboxCfg.deviceGatesShell })
+                    : cappedTools;
                 if (finalTurnReason && !finalTurnNotified) {
                     conversation.push({ role: 'user', content: getAgentTaskFinalTurnNudge(finalTurnReason) });
                     finalTurnNotified = true;
@@ -324,6 +335,16 @@ export class AgentTaskService {
                     emitStep('final_turn', undefined, note);
                     logger.info(`[AgentTask] 마무리 턴 전환: ${taskId} (사유=${finalTurnReason}, `
                         + `턴 ${turn + 1}/${turnCeiling}, 누적 ${totalTokens} 토큰)`);
+                }
+                if (hitlDegraded && !approvalDegradeNotified) {
+                    conversation.push({ role: 'user', content: getAgentTaskApprovalTimeoutNudge() });
+                    approvalDegradeNotified = true;
+                    // 스텝으로 남긴다 — 발동 빈도·시점을 DB 로 집계(final_turn 과 동일 관측 패턴).
+                    const note = `승인 무응답 ${approvalTimeouts}회 — 승인 필요 도구를 제거하고 확보한 정보로 마무리 전환 (턴 ${turn + 1}/${turnCeiling})`;
+                    await db.addAgentTaskStep({ taskId, stepNumber: stepNumber++, stepType: 'hitl_degrade', content: note })
+                        .catch(() => { /* 관측 실패가 작업을 죽이지 않게 fail-open */ });
+                    emitStep('hitl_degrade', undefined, note);
+                    logger.info(`[AgentTask] HITL 무응답 강등: ${taskId} (timeouts=${approvalTimeouts}, 턴 ${turn + 1})`);
                 }
                 if (overSearchLimit && !searchLimitNotified) {
                     conversation.push({
@@ -518,7 +539,7 @@ export class AgentTaskService {
                     toolCalls: result.tool_calls!,
                     taskRuntime, sandboxCfg, extraToolNames, mcp, userCtx,
                     userId: String(userId), taskId, turn, conversation, usedTools, signal,
-                    stepNumber, searchCalls, browserCalls, pausedMs,
+                    stepNumber, searchCalls, browserCalls, pausedMs, approvalTimeouts,
                     getCurStatus: () => curStatus,
                     update, emitStep,
                 });
@@ -526,6 +547,7 @@ export class AgentTaskService {
                 searchCalls = turnExec.searchCalls;
                 browserCalls = turnExec.browserCalls;
                 pausedMs = turnExec.pausedMs;
+                approvalTimeouts = turnExec.approvalTimeouts;
                 const { terminated, terminateSummary } = turnExec;
 
                 // terminate 도구 호출 — 깔끔한 완료 시그널(max_turns 소진 아님).

--- a/apps/api/src/services/agent-task/role-client.test.ts
+++ b/apps/api/src/services/agent-task/role-client.test.ts
@@ -1,0 +1,108 @@
+// TURN_RETRY_* 는 .env 에 좌우된다 — 재시도 2회·백오프 1ms 로 고정해 결정적으로 만든다.
+jest.mock('../../config/runtime-limits', () => {
+    const actual = jest.requireActual('../../config/runtime-limits');
+    return {
+        ...actual,
+        AGENT_TASK_LIMITS: {
+            ...actual.AGENT_TASK_LIMITS,
+            TURN_RETRY_MAX: 2,
+            TURN_RETRY_BACKOFF_MS: 1,
+        },
+    };
+});
+// 로컬 폴백 경로가 실제 클라이언트를 만들지 않게 차단(이 스위트는 재시도 정책만 검증).
+jest.mock('../../llm', () => ({ createClient: jest.fn() }));
+jest.mock('../model-role-resolver', () => ({ resolveRoleClientForUser: jest.fn() }));
+
+import { chatTurnWithRoleFallback, isTransientLLMError, type AgentRoleState } from './role-client';
+import type { LLMClient } from '../../llm';
+
+/** status 를 가진 오류 생성(openai SDK APIError 형태 흉내). */
+function statusError(status: number, message = `http ${status}`): Error {
+    const e = new Error(message) as Error & { status: number };
+    e.status = status;
+    return e;
+}
+
+/** chat 이 impls 를 순서대로 소비하는 가짜 클라이언트 상태. */
+function fakeState(impls: Array<() => Promise<unknown>>): { state: AgentRoleState; calls: () => number } {
+    let i = 0;
+    const chat = jest.fn(() => {
+        const impl = impls[Math.min(i, impls.length - 1)];
+        i++;
+        return impl();
+    });
+    const client = { derive: () => ({ chat }) } as unknown as LLMClient;
+    return { state: { client, external: false, fallbackDone: true }, calls: () => i };
+}
+
+const params = (signal: AbortSignal = new AbortController().signal) => ({
+    conversation: [], tools: [], signal, taskId: 't1', userId: 'u1',
+});
+
+describe('isTransientLLMError', () => {
+    it('5xx·408·429 는 일시적', () => {
+        expect(isTransientLLMError(statusError(500))).toBe(true);
+        expect(isTransientLLMError(statusError(503))).toBe(true);
+        expect(isTransientLLMError(statusError(408))).toBe(true);
+        expect(isTransientLLMError(statusError(429))).toBe(true);
+    });
+
+    it('그 외 4xx 는 비일시적', () => {
+        expect(isTransientLLMError(statusError(400))).toBe(false);
+        expect(isTransientLLMError(statusError(404))).toBe(false);
+    });
+
+    it('status 없는 연결류 메시지는 일시적', () => {
+        expect(isTransientLLMError(new Error('Connection error.'))).toBe(true);
+        expect(isTransientLLMError(new Error('Request timed out.'))).toBe(true);
+        expect(isTransientLLMError(new Error('read ECONNRESET'))).toBe(true);
+    });
+
+    it('abort·도메인 오류는 비일시적', () => {
+        expect(isTransientLLMError(new Error('Request was aborted.'))).toBe(false);
+        expect(isTransientLLMError(new Error('invalid tool arguments'))).toBe(false);
+    });
+});
+
+describe('chatTurnWithRoleFallback 재시도', () => {
+    it('일시적 오류는 재시도 후 성공을 반환하고 onRetry 를 호출한다', async () => {
+        const ok = { content: 'done' };
+        const { state, calls } = fakeState([
+            () => Promise.reject(new Error('Connection error.')),
+            () => Promise.resolve(ok),
+        ]);
+        const onRetry = jest.fn();
+        const result = await chatTurnWithRoleFallback(state, { ...params(), onRetry });
+        expect(result).toBe(ok);
+        expect(calls()).toBe(2);
+        expect(onRetry).toHaveBeenCalledTimes(1);
+        expect(onRetry).toHaveBeenCalledWith(
+            expect.objectContaining({ attempt: 1, maxAttempts: 2, error: 'Connection error.' }));
+    });
+
+    it('재시도 소진 시 마지막 오류를 throw 한다', async () => {
+        const { state, calls } = fakeState([
+            () => Promise.reject(statusError(500, 'upstream down')),
+        ]);
+        await expect(chatTurnWithRoleFallback(state, params())).rejects.toThrow('upstream down');
+        expect(calls()).toBe(3); // 최초 1 + 재시도 2
+    });
+
+    it('비일시적 오류는 재시도 없이 즉시 throw 한다', async () => {
+        const { state, calls } = fakeState([
+            () => Promise.reject(statusError(400, 'bad request')),
+        ]);
+        await expect(chatTurnWithRoleFallback(state, params())).rejects.toThrow('bad request');
+        expect(calls()).toBe(1);
+    });
+
+    it('signal aborted 면 일시적 오류도 재시도하지 않는다', async () => {
+        const ac = new AbortController();
+        const { state, calls } = fakeState([
+            () => { ac.abort(); return Promise.reject(new Error('Connection error.')); },
+        ]);
+        await expect(chatTurnWithRoleFallback(state, params(ac.signal))).rejects.toThrow('Connection error.');
+        expect(calls()).toBe(1);
+    });
+});

--- a/apps/api/src/services/agent-task/role-client.ts
+++ b/apps/api/src/services/agent-task/role-client.ts
@@ -44,13 +44,40 @@ export async function initAgentRoleState(
 }
 
 /**
+ * 일시적 LLM 오류 판별 — 노드 retry 정책의 재시도 대상.
+ * ① HTTP 5xx·408·429 ② status 없는 연결류(connection/timeout/reset 등) 만 참.
+ * 4xx(429 제외)·abort·그 외 도메인 오류는 거짓 — 재시도해도 결과가 같은 부류.
+ */
+export function isTransientLLMError(err: unknown): boolean {
+    const status = (err as { status?: number }).status;
+    if (typeof status === 'number') {
+        return status >= 500 || status === 408 || status === 429;
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    return /connection error|request timed out|econnrefused|econnreset|etimedout|socket hang up|fetch failed/i.test(msg);
+}
+
+/** abort 가능 대기 — 재시도 백오프 중 사용자 취소/예산 소진이 오면 즉시 중단. */
+function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
+    return new Promise((resolve, reject) => {
+        if (signal.aborted) { reject(new Error('aborted during retry backoff')); return; }
+        const timer = setTimeout(() => { signal.removeEventListener('abort', onAbort); resolve(); }, ms);
+        const onAbort = (): void => { clearTimeout(timer); reject(new Error('aborted during retry backoff')); };
+        signal.addEventListener('abort', onAbort, { once: true });
+    });
+}
+
+/**
  * 턴 1회 chat 호출. reasoning OFF — qwen3.6 가 디자인/장문 작업에서 수만 토큰의
  * thinking 을 생성해 토큰 한도를 소진하고 deliverable 을 못 쓰는 폭주 차단.
  * 도구 루프의 단계별 reasoning 은 대화 구조 자체가 대신한다.
  *
  * 외부 role 모델의 4xx(tools 미지원 등 — 예: NVIDIA 소형 모델 tools 400) 는
  * 로컬 default 로 1회 강등 후 같은 턴을 재시도한다 (state.client 교체).
- * 재발/그 외 에러는 기존 경로대로 throw.
+ *
+ * 일시적 오류(isTransientLLMError)는 지수 백오프로 TURN_RETRY_MAX 회 재시도 —
+ * 후향 실측(failed 20건 중 6~7건이 timeout/connection 류)에 근거한 노드 retry 정책.
+ * signal abort(사용자 취소·예산 소진)는 재시도하지 않는다. 그 외 에러는 기존 경로대로 throw.
  */
 export async function chatTurnWithRoleFallback(
     state: AgentRoleState,
@@ -60,6 +87,8 @@ export async function chatTurnWithRoleFallback(
         signal: AbortSignal;
         taskId: string;
         userId: string;
+        /** 재시도 발생 시 관측 훅(스텝 기록용) — 동기 호출, 실패해도 재시도를 막지 않을 것 */
+        onRetry?: (info: { attempt: number; maxAttempts: number; error: string }) => void;
     },
 ): Promise<Awaited<ReturnType<LLMClient['chat']>>> {
     // openai SDK 요청 타임아웃을 task 총 예산에 맞춰 늘린다(파생 클라이언트, baseUrl/model 유지).
@@ -70,19 +99,33 @@ export async function chatTurnWithRoleFallback(
         .chat(p.conversation, undefined, undefined, {
             tools: p.tools, signal: p.signal, think: false,
         });
-    try {
-        return await call();
-    } catch (chatErr) {
-        const status = (chatErr as { status?: number }).status;
-        if (state.external && !state.fallbackDone
-            && typeof status === 'number' && status >= 400 && status < 500) {
-            state.fallbackDone = true;
-            state.external = false;
-            logger.warn(`[AgentTask] ${p.taskId} 외부 role 모델 ${status} — 로컬 폴백: ${chatErr instanceof Error ? chatErr.message : chatErr}`);
-            state.client = createClient({ model: getModelForRole('agent'), userId: p.userId });
+    const maxRetries = Math.max(0, AGENT_TASK_LIMITS.TURN_RETRY_MAX);
+    let attempt = 0;
+    for (;;) {
+        try {
             return await call();
+        } catch (chatErr) {
+            const status = (chatErr as { status?: number }).status;
+            const msg = chatErr instanceof Error ? chatErr.message : String(chatErr);
+            // 외부 role 모델 4xx → 로컬 강등(작업당 1회) 후 즉시 같은 턴 재호출.
+            // continue 라 강등 후의 일시적 오류도 아래 재시도 대상이 된다.
+            if (state.external && !state.fallbackDone
+                && typeof status === 'number' && status >= 400 && status < 500) {
+                state.fallbackDone = true;
+                state.external = false;
+                logger.warn(`[AgentTask] ${p.taskId} 외부 role 모델 ${status} — 로컬 폴백: ${msg}`);
+                state.client = createClient({ model: getModelForRole('agent'), userId: p.userId });
+                continue;
+            }
+            if (p.signal.aborted || !isTransientLLMError(chatErr) || attempt >= maxRetries) {
+                throw chatErr;
+            }
+            attempt++;
+            const delayMs = AGENT_TASK_LIMITS.TURN_RETRY_BACKOFF_MS * 2 ** (attempt - 1);
+            logger.warn(`[AgentTask] ${p.taskId} 일시적 LLM 오류 — ${delayMs}ms 후 재시도 ${attempt}/${maxRetries}: ${msg}`);
+            try { p.onRetry?.({ attempt, maxAttempts: maxRetries, error: msg }); } catch { /* 관측 실패 무시 */ }
+            await abortableDelay(delayMs, p.signal);
         }
-        throw chatErr;
     }
 }
 

--- a/apps/api/src/services/agent-task/turn-executor.ts
+++ b/apps/api/src/services/agent-task/turn-executor.ts
@@ -43,6 +43,8 @@ export interface TurnToolExecInput {
     searchCalls: number;
     browserCalls: number;
     pausedMs: number;
+    /** 승인 무응답(timeout) 누적 횟수 — HITL 강등 판단(호출부). */
+    approvalTimeouts: number;
     /** 상태 전이(paused↔running) 판단용 — 최신 curStatus 를 읽는다. */
     getCurStatus: () => string;
     update: (u: AgentTaskUpdatePayload) => Promise<void>;
@@ -57,6 +59,7 @@ export interface TurnToolExecResult {
     searchCalls: number;
     browserCalls: number;
     pausedMs: number;
+    approvalTimeouts: number;
 }
 
 /**
@@ -69,7 +72,11 @@ export async function executeTurnToolCalls(input: TurnToolExecInput): Promise<Tu
         turn, conversation, usedTools, signal, getCurStatus, update, emitStep,
     } = input;
     const db = getUnifiedDatabase();
-    let { stepNumber, searchCalls, browserCalls, pausedMs } = input;
+    let { stepNumber, searchCalls, browserCalls, pausedMs, approvalTimeouts } = input;
+    // 승인 무응답 카운트 — task 도구(runtime 내부 게이트)·extra 도구(아래 명시 게이트) 공용.
+    const onApprovalRejected = (info: { toolName: string; reason: string }): void => {
+        if (info.reason === 'timeout') approvalTimeouts++;
+    };
 
     // 도구 실행 + 체크포인트
     let terminated = false;
@@ -98,6 +105,7 @@ export async function executeTurnToolCalls(input: TurnToolExecInput): Promise<Tu
                 signal,
                 onApprovalPending: (p) => onApprovalPending(p.toolName),
                 onApprovalWaited: (ms) => { pausedMs += ms; },
+                onApprovalRejected,
             });
             if (getCurStatus() === 'paused') await update({ status: 'running' }).catch(() => { /* noop */ });
             if (toolResult.includes(TASK_TERMINATE_SENTINEL)) {
@@ -109,18 +117,23 @@ export async function executeTurnToolCalls(input: TurnToolExecInput): Promise<Tu
             // (이 도구들은 격리 컨테이너가 아니라 API 프로세스에서 실행되므로 승인 우회를 닫는다.)
             // extraToolNames 는 샌드박스 ENABLED(활성·degrade) 일 때만 채워지므로 legacy OFF 경로엔 영향 없음.
             let decision: 'approved' | 'rejected' = 'approved';
+            let rejectReason: string | undefined;
             if (requiresApproval(sandboxCfg.approvalPolicy, name, args)) {
                 const r = await getApprovalRegistry().request(
                     { taskId, userId, toolName: name, args },
                     { timeoutMs: sandboxCfg.approvalTimeoutMs, signal, onPending: (p) => onApprovalPending(p.toolName) },
                 );
                 decision = r.decision;
+                rejectReason = r.reason;
                 pausedMs += r.waitedMs; // 4-1 pause-aware
+                if (decision === 'rejected') onApprovalRejected({ toolName: name, reason: rejectReason ?? 'user' });
             }
             if (getCurStatus() === 'paused') await update({ status: 'running' }).catch(() => { /* noop */ });
             toolResult = decision === 'approved'
                 ? await runTool(mcp, name, args, userCtx)
-                : `Error: 사용자가 도구 실행을 승인하지 않았습니다 (${name}). 다른 방법을 시도하거나 작업을 종료하세요.`;
+                : rejectReason === 'timeout'
+                    ? `Error: 승인 대기 시간이 초과되었습니다(무응답, ${name}). 사용자가 자리를 비운 것으로 보입니다 — 승인이 필요 없는 방법으로 진행하거나, 지금까지 확보한 결과로 최종 산출물을 작성하세요.`
+                    : `Error: 사용자가 도구 실행을 승인하지 않았습니다 (${name}). 다른 방법을 시도하거나 작업을 종료하세요.`;
         } else {
             toolResult = await runTool(mcp, name, args, userCtx);
         }
@@ -148,5 +161,5 @@ export async function executeTurnToolCalls(input: TurnToolExecInput): Promise<Tu
         }
     }
 
-    return { terminated, terminateSummary, stepNumber, searchCalls, browserCalls, pausedMs };
+    return { terminated, terminateSummary, stepNumber, searchCalls, browserCalls, pausedMs, approvalTimeouts };
 }

--- a/apps/api/src/services/agent-task/turn-gate.ts
+++ b/apps/api/src/services/agent-task/turn-gate.ts
@@ -1,0 +1,140 @@
+/**
+ * Agent Task 턴 자원 가드 — AgentTaskService 에서 분리 (파일 크기 가드).
+ *
+ * 턴 시작 시 자원 상태(검색/브라우저 호출 수·토큰 예산·남은 턴·승인 무응답)를 판정해
+ * 이 턴에 노출할 도구 세트를 깎고, 각 가드의 최초 발동 시 1회 nudge 주입 + 스텝 기록을
+ * 수행한다. 프롬프트 지시를 모델이 무시해도 도구 자체가 사라지므로 폭주가 끊긴다.
+ *
+ * @module services/agent-task/turn-gate
+ */
+import { getUnifiedDatabase } from '../../data/models/unified-database';
+import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
+import { getAgentTaskBrowserLimitNudge, getAgentTaskFinalTurnNudge, getAgentTaskApprovalTimeoutNudge } from '../../prompts/agent-task-prompt';
+import { stripApprovalGatedTools } from '../task-sandbox/approval-gate';
+import { isSearchTool } from './task-steps';
+import { createLogger } from '../../utils/logger';
+import type { ChatMessage, ToolDefinition } from '../../llm/types';
+import type { TaskSandboxConfig } from '../../config/task-sandbox';
+
+const logger = createLogger('AgentTaskService');
+
+export type FinalTurnReason = 'turns' | 'tokens' | null;
+
+/** 가드별 "1회 nudge 주입" 플래그 — 턴 루프가 소유하고 이 모듈이 제자리 갱신한다. */
+export interface TurnGateFlags {
+    searchLimitNotified: boolean;
+    browserLimitNotified: boolean;
+    finalTurnNotified: boolean;
+    approvalDegradeNotified: boolean;
+}
+
+export interface TurnGateInput {
+    taskId: string;
+    turn: number;
+    startTurn: number;
+    turnCeiling: number;
+    totalTokens: number;
+    searchCalls: number;
+    browserCalls: number;
+    /** 승인 무응답(timeout) 누적 — HITL 강등 판정(명시 거절은 카운트 제외). */
+    approvalTimeouts: number;
+    tools: ToolDefinition[];
+    sandboxCfg: TaskSandboxConfig;
+    /** nudge 주입 대상 — 제자리 갱신. */
+    conversation: ChatMessage[];
+    /** 제자리 갱신. */
+    flags: TurnGateFlags;
+    stepNumber: number;
+    emitStep: (stepType: string, toolName?: string, content?: string | null) => void;
+}
+
+export interface TurnGateResult {
+    effectiveTools: ToolDefinition[];
+    /** 마무리 턴 전환 사유 — 호출부의 "마무리 턴 도구 차단" 가드가 이어서 사용. */
+    finalTurnReason: FinalTurnReason;
+    stepNumber: number;
+}
+
+/**
+ * 턴 자원 가드 일괄 적용. 각 가드의 근거·순서는 다음과 같다.
+ *
+ * - 마무리 턴: 자원 상한에 **닿기 전에** 도구를 전부 끊어 종합 답변을 받는다. 상한에서 그냥
+ *   끊으면 산출물을 이미 만든 작업도 사족에서 절단돼 결과가 남지 않는다(2026-08-03: 예약
+ *   리포트 20/20 3건 중 2건이 리포트 생성 후 검증 사족에서 절단). 턴 사유는 도구를 쓸 턴이
+ *   최소 하나 있었을 때만 건다 — maxTurns=1 이면 유일한 턴이 곧 마지막이라 조건 없이 걸면
+ *   도구를 한 번도 못 쓴다. 토큰 사유엔 이 가드가 없다: 누적이 임계를 넘었다는 건 resume 으로
+ *   이미 예산을 소진하고 들어왔다는 뜻이라 첫 턴부터 마무리로 보내는 것이 맞다.
+ * - 검색/브라우저 cap: browser 는 SEARCH_TOOL_KEYWORDS 에 안 잡혀 검색 throttle 로 제어
+ *   불가하므로 별도 cap.
+ * - HITL 무응답 강등: 승인 timeout 이 임계에 달하면 승인 필요 도구를 제거해 대기-소진 반복
+ *   대신 확보한 정보로 마무리를 강제한다(명시 거절은 카운트 안 함).
+ *
+ * nudge 발동은 스텝으로 남긴다 — ① 사용자에겐 "왜 도구가 갑자기 멈췄는지"의 설명이 되고
+ * ② 발동 빈도·사유를 DB 로 집계할 수 있다(로그만으론 재기동 시 유실). 기록 실패는 fail-open.
+ */
+export async function applyTurnResourceGates(p: TurnGateInput): Promise<TurnGateResult> {
+    const { taskId, turn, turnCeiling, totalTokens, conversation, flags, emitStep } = p;
+    const db = getUnifiedDatabase();
+    let stepNumber = p.stepNumber;
+
+    const overSearchLimit = p.searchCalls >= AGENT_TASK_LIMITS.MAX_SEARCH_CALLS;
+    const overBrowserLimit = p.browserCalls >= AGENT_TASK_LIMITS.MAX_BROWSER_CALLS;
+    const hitlDegraded = AGENT_TASK_LIMITS.HITL_TIMEOUT_DEGRADE_AFTER > 0
+        && p.approvalTimeouts >= AGENT_TASK_LIMITS.HITL_TIMEOUT_DEGRADE_AFTER;
+    const finalTurnReason: FinalTurnReason = !AGENT_TASK_LIMITS.FINAL_TURN_NUDGE_ENABLED
+        ? null
+        : totalTokens >= AGENT_TASK_LIMITS.MAX_TOTAL_TOKENS * AGENT_TASK_LIMITS.TOKEN_SOFT_RATIO
+            ? 'tokens'
+            : (turn > p.startTurn && turn === turnCeiling - 1)
+                ? 'turns'
+                : null;
+
+    const cappedTools = finalTurnReason
+        ? []
+        : (overSearchLimit || overBrowserLimit)
+            ? p.tools.filter((t) => {
+                const n = t.function.name;
+                if (overSearchLimit && isSearchTool(n)) return false;
+                if (overBrowserLimit && n === 'browser') return false;
+                return true;
+            })
+            : p.tools;
+    const effectiveTools = hitlDegraded
+        ? stripApprovalGatedTools(cappedTools, p.sandboxCfg.approvalPolicy,
+            { deviceGatesShell: p.sandboxCfg.deviceGatesShell })
+        : cappedTools;
+
+    if (finalTurnReason && !flags.finalTurnNotified) {
+        conversation.push({ role: 'user', content: getAgentTaskFinalTurnNudge(finalTurnReason) });
+        flags.finalTurnNotified = true;
+        const note = `자원 상한 임박(${finalTurnReason === 'tokens' ? '토큰 예산' : '남은 턴'})`
+            + ` — 도구를 중단하고 최종 정리로 전환 (턴 ${turn + 1}/${turnCeiling}, 누적 ${totalTokens} 토큰)`;
+        await db.addAgentTaskStep({ taskId, stepNumber: stepNumber++, stepType: 'final_turn', content: note })
+            .catch(() => { /* 관측 실패가 작업을 죽이지 않게 fail-open */ });
+        emitStep('final_turn', undefined, note);
+        logger.info(`[AgentTask] 마무리 턴 전환: ${taskId} (사유=${finalTurnReason}, `
+            + `턴 ${turn + 1}/${turnCeiling}, 누적 ${totalTokens} 토큰)`);
+    }
+    if (hitlDegraded && !flags.approvalDegradeNotified) {
+        conversation.push({ role: 'user', content: getAgentTaskApprovalTimeoutNudge() });
+        flags.approvalDegradeNotified = true;
+        const note = `승인 무응답 ${p.approvalTimeouts}회 — 승인 필요 도구를 제거하고 확보한 정보로 마무리 전환 (턴 ${turn + 1}/${turnCeiling})`;
+        await db.addAgentTaskStep({ taskId, stepNumber: stepNumber++, stepType: 'hitl_degrade', content: note })
+            .catch(() => { /* 관측 실패가 작업을 죽이지 않게 fail-open */ });
+        emitStep('hitl_degrade', undefined, note);
+        logger.info(`[AgentTask] HITL 무응답 강등: ${taskId} (timeouts=${p.approvalTimeouts}, 턴 ${turn + 1})`);
+    }
+    if (overSearchLimit && !flags.searchLimitNotified) {
+        conversation.push({
+            role: 'user',
+            content: '검색 횟수 한도에 도달했습니다. 더 이상 검색하지 말고, 지금까지 수집한 정보만으로 최종 결과물(예: 블로그 초안)을 완성해 작성하세요.',
+        });
+        flags.searchLimitNotified = true;
+    }
+    if (overBrowserLimit && !flags.browserLimitNotified) {
+        conversation.push({ role: 'user', content: getAgentTaskBrowserLimitNudge() });
+        flags.browserLimitNotified = true;
+    }
+
+    return { effectiveTools, finalTurnReason, stepNumber };
+}

--- a/apps/api/src/services/task-sandbox/approval-gate.test.ts
+++ b/apps/api/src/services/task-sandbox/approval-gate.test.ts
@@ -1,4 +1,4 @@
-import { requiresApproval, ApprovalRegistry } from './approval-gate';
+import { requiresApproval, stripApprovalGatedTools, ApprovalRegistry } from './approval-gate';
 
 describe('requiresApproval', () => {
     it("정책 all — 부작용 도구 전부 승인, 제어 시그널 제외", () => {
@@ -31,6 +31,32 @@ describe('requiresApproval', () => {
     });
 });
 
+describe('stripApprovalGatedTools (HITL 무응답 강등)', () => {
+    const tool = (name: string) => ({ function: { name } });
+    const names = (ts: Array<{ function: { name: string } }>) => ts.map((t) => t.function.name);
+
+    it("정책 all — 승인 불요 도구(플래닝·terminate 등)만 남고 ask_human 도 제거", () => {
+        const tools = ['bash', 'str_replace_editor', 'plan_update', 'terminate', 'ask_human', 'delegate'].map(tool);
+        expect(names(stripApprovalGatedTools(tools, 'all'))).toEqual(['plan_update', 'terminate', 'delegate']);
+    });
+
+    it('정책 high-risk — bash·browser·python·skill_run 제거, 나머지(+인자 의존 file_ops)는 유지', () => {
+        const tools = ['bash', 'browser', 'python_execute', 'skill_run', 'file_ops', 'str_replace_editor', 'ask_human'].map(tool);
+        expect(names(stripApprovalGatedTools(tools, 'high-risk'))).toEqual(['file_ops', 'str_replace_editor']);
+    });
+
+    it('정책 none — ask_human 만 제거(항상 사람 대기라 부재 시 무의미)', () => {
+        const tools = ['bash', 'ask_human'].map(tool);
+        expect(names(stripApprovalGatedTools(tools, 'none'))).toEqual(['bash']);
+    });
+
+    it('deviceGatesShell — 디바이스가 게이트하는 exec 계열은 유지', () => {
+        const tools = ['bash', 'python_execute', 'str_replace_editor'].map(tool);
+        expect(names(stripApprovalGatedTools(tools, 'all', { deviceGatesShell: true })))
+            .toEqual(['bash', 'python_execute']);
+    });
+});
+
 describe('ApprovalRegistry', () => {
     const baseInput = { taskId: 't1', userId: 'u1', toolName: 'bash', args: { command: 'ls' } };
 
@@ -45,12 +71,12 @@ describe('ApprovalRegistry', () => {
         expect(reg.list('u1')).toHaveLength(0); // 정리됨
     });
 
-    it('reject 시 rejected 로 resolve', async () => {
+    it("reject 시 rejected(reason='user') 로 resolve", async () => {
         const reg = new ApprovalRegistry();
         let id = '';
         const p = reg.request(baseInput, { timeoutMs: 5000, onPending: (pa) => { id = pa.approvalId; } });
         expect(reg.reject(id)).toBe(true);
-        await expect(p).resolves.toMatchObject({ decision: 'rejected' });
+        await expect(p).resolves.toMatchObject({ decision: 'rejected', reason: 'user' });
     });
 
     it('answer 시 approved + 자유텍스트로 resolve', async () => {
@@ -69,18 +95,18 @@ describe('ApprovalRegistry', () => {
         expect(new ApprovalRegistry().answer('nope', 'x')).toBe(false);
     });
 
-    it('timeout 시 자동 rejected', async () => {
+    it("timeout 시 자동 rejected(reason='timeout') — HITL 강등 카운트 대상", async () => {
         const reg = new ApprovalRegistry();
         const p = reg.request(baseInput, { timeoutMs: 30 });
-        await expect(p).resolves.toMatchObject({ decision: 'rejected' });
+        await expect(p).resolves.toMatchObject({ decision: 'rejected', reason: 'timeout' });
     });
 
-    it('abort signal 시 rejected', async () => {
+    it("abort signal 시 rejected(reason='abort') — 강등 카운트 비대상", async () => {
         const reg = new ApprovalRegistry();
         const ac = new AbortController();
         const p = reg.request(baseInput, { timeoutMs: 5000, signal: ac.signal });
         ac.abort();
-        await expect(p).resolves.toMatchObject({ decision: 'rejected' });
+        await expect(p).resolves.toMatchObject({ decision: 'rejected', reason: 'abort' });
     });
 
     it('자동승인(4-2): 활성 시 즉시 approved, ask_human 은 여전히 대기', async () => {

--- a/apps/api/src/services/task-sandbox/approval-gate.ts
+++ b/apps/api/src/services/task-sandbox/approval-gate.ts
@@ -55,14 +55,35 @@ export function requiresApproval(
 }
 
 export type ApprovalDecision = 'approved' | 'rejected';
+/** 거절 사유 — 'timeout'(무응답 만료) 은 사용자 부재 신호로, 명시 거절('user')과 달리
+ *  HITL 무응답 강등(연속 N회 시 승인 필요 도구 제거 → 산출물 유도)의 카운트 대상이다. */
+export type ApprovalRejectReason = 'timeout' | 'user' | 'abort';
 
 /** 승인 요청의 해소 결과 — 결정 + (ask_human 자유텍스트 응답 시) 사용자 답변 본문. */
 export interface ApprovalResult {
     decision: ApprovalDecision;
+    /** rejected 인 경우에만 채워짐 — 무응답 만료/명시 거절/실행 중단 구분. */
+    reason?: ApprovalRejectReason;
     /** answer() 로 해소된 경우에만 채워짐 — ask_human 질문에 대한 사용자 자유텍스트 답변. */
     text?: string;
     /** 승인 대기에 소요된 시간(ms) — pause-aware 타임아웃(4-1)이 총 예산에서 제외하는 데 사용. */
     waitedMs: number;
+}
+
+/**
+ * PURE: HITL 무응답 강등 — 승인을 요구할 도구(+승인 정책과 무관하게 항상 사람을 기다리는
+ * ask_human)를 도구 세트에서 제거한다. 사용자 부재 시 남은 턴을 승인 불요 경로로 강제해
+ * "대기→만료 반복으로 예산만 소진하고 산출물 0" 대신 확보한 정보로 마무리하게 한다.
+ * ⚠️ args 미지 상태의 보수 판정({}) — high-risk 정책의 file_ops(delete 만 승인 대상)처럼
+ * 인자 의존 도구는 남는다(해당 호출은 여전히 게이트에서 거절되고, 강등 nudge 가 우회를 지시).
+ */
+export function stripApprovalGatedTools<T extends { function: { name: string } }>(
+    tools: T[],
+    policy: TaskSandboxApprovalPolicy,
+    opts: { deviceGatesShell?: boolean } = {},
+): T[] {
+    return tools.filter((t) => t.function.name !== 'ask_human'
+        && !requiresApproval(policy, t.function.name, {}, opts));
 }
 
 export interface PendingApproval {
@@ -141,14 +162,14 @@ export class ApprovalRegistry {
                 if (!w) return;
                 clearTimeout(w.timer);
                 this.waiters.delete(approvalId);
-                if (r.decision === 'rejected') logger.info(`[${input.taskId}] 승인 거절/만료: ${input.toolName}`);
+                if (r.decision === 'rejected') logger.info(`[${input.taskId}] 승인 거절/만료(${r.reason}): ${input.toolName}`);
                 resolvePromise({ ...r, waitedMs: Date.now() - pending.createdAt });
             };
-            const timer = setTimeout(() => settle({ decision: 'rejected' }), opts.timeoutMs);
+            const timer = setTimeout(() => settle({ decision: 'rejected', reason: 'timeout' }), opts.timeoutMs);
             this.waiters.set(approvalId, { pending, resolve: (r) => settle(r), timer });
             if (opts.signal) {
-                if (opts.signal.aborted) { settle({ decision: 'rejected' }); return; }
-                opts.signal.addEventListener('abort', () => settle({ decision: 'rejected' }), { once: true });
+                if (opts.signal.aborted) { settle({ decision: 'rejected', reason: 'abort' }); return; }
+                opts.signal.addEventListener('abort', () => settle({ decision: 'rejected', reason: 'abort' }), { once: true });
             }
             opts.onPending?.(pending);
         });
@@ -166,7 +187,7 @@ export class ApprovalRegistry {
     reject(approvalId: string): boolean {
         const w = this.waiters.get(approvalId);
         if (!w) return false;
-        w.resolve({ decision: 'rejected', waitedMs: Date.now() - w.pending.createdAt });
+        w.resolve({ decision: 'rejected', reason: 'user', waitedMs: Date.now() - w.pending.createdAt });
         return true;
     }
 

--- a/apps/api/src/services/task-sandbox/runtime.ts
+++ b/apps/api/src/services/task-sandbox/runtime.ts
@@ -18,7 +18,7 @@ import { recordBrowserMetric } from './browser-metrics';
 import { AGENT_TASK_LIMITS, ORCHESTRATION_DISPATCH } from '../../config/runtime-limits';
 import { saveProceduralSkill, resolveProceduralSpec } from '../agent-task/procedural-skill';
 import { TaskPlan, type PlanStep } from './planning';
-import { requiresApproval, getApprovalRegistry, type PendingApproval } from './approval-gate';
+import { requiresApproval, getApprovalRegistry, type PendingApproval, type ApprovalRejectReason } from './approval-gate';
 import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('TaskRuntime');
@@ -48,6 +48,8 @@ export interface ExecuteTaskToolOpts {
     onApprovalPending?: (p: PendingApproval) => void;
     /** 승인 대기 종료 시 대기시간(ms) 통지 — pause-aware 타임아웃(4-1)이 총 예산에서 제외. */
     onApprovalWaited?: (ms: number) => void;
+    /** 승인 거절 시 사유 통지 — 호출부가 무응답('timeout') 연속 횟수를 세어 HITL 강등 판단. */
+    onApprovalRejected?: (info: { toolName: string; reason: ApprovalRejectReason }) => void;
 }
 
 export class TaskRuntime {
@@ -158,13 +160,16 @@ export class TaskRuntime {
         // 자체가 HITL 이므로 승인 레지스트리(pause + push + REST approve/reject/answer)를 응답 채널로 사용.
         if (name === 'ask_human') {
             const question = String(args.question ?? '');
-            const { decision, text, waitedMs } = await getApprovalRegistry().request(
+            const { decision, reason, text, waitedMs } = await getApprovalRegistry().request(
                 { taskId: this.taskId, userId: this.userId, toolName: name, args },
                 { timeoutMs: this.cfg.approvalTimeoutMs, signal: opts.signal, onPending: opts.onApprovalPending },
             );
             opts.onApprovalWaited?.(waitedMs);
             if (decision !== 'approved') {
-                return `사용자가 거절했거나 응답 시간이 초과되었습니다(질문: ${question}). 이 방향을 중단하고 대안을 시도하거나 terminate 로 마무리하세요.`;
+                opts.onApprovalRejected?.({ toolName: name, reason: reason ?? 'user' });
+                return reason === 'timeout'
+                    ? `사용자가 응답하지 않았습니다(대기 시간 초과, 질문: ${question}). 사용자가 자리를 비운 것으로 보입니다 — 다시 질문하지 말고, 합리적인 가정을 명시한 뒤 지금까지 확보한 정보로 작업을 이어가거나 마무리하세요.`
+                    : `사용자가 거절했거나 응답 시간이 초과되었습니다(질문: ${question}). 이 방향을 중단하고 대안을 시도하거나 terminate 로 마무리하세요.`;
             }
             // 자유텍스트 답변이 있으면 그대로 전달(에이전트가 실제 답을 받아 진행), 없으면 단순 승인.
             return text && text.trim()
@@ -173,13 +178,16 @@ export class TaskRuntime {
         }
 
         if (requiresApproval(this.cfg.approvalPolicy, name, args, { deviceGatesShell: this.cfg.deviceGatesShell })) {
-            const { decision, waitedMs } = await getApprovalRegistry().request(
+            const { decision, reason, waitedMs } = await getApprovalRegistry().request(
                 { taskId: this.taskId, userId: this.userId, toolName: name, args },
                 { timeoutMs: this.cfg.approvalTimeoutMs, signal: opts.signal, onPending: opts.onApprovalPending },
             );
             opts.onApprovalWaited?.(waitedMs);
             if (decision !== 'approved') {
-                return `Error: 사용자가 도구 실행을 승인하지 않았습니다 (${name}). 다른 방법을 시도하거나 작업을 종료하세요.`;
+                opts.onApprovalRejected?.({ toolName: name, reason: reason ?? 'user' });
+                return reason === 'timeout'
+                    ? `Error: 승인 대기 시간이 초과되었습니다(무응답, ${name}). 사용자가 자리를 비운 것으로 보입니다 — 승인이 필요 없는 방법으로 진행하거나, 지금까지 확보한 결과로 최종 산출물을 작성하세요.`
+                    : `Error: 사용자가 도구 실행을 승인하지 않았습니다 (${name}). 다른 방법을 시도하거나 작업을 종료하세요.`;
             }
         }
 


### PR DESCRIPTION
## 배경 — Execution Graph 후향 실측 (2026-08-05)

Agent Task 를 노드 속성(deps·권한·비용·retry·완료기준) DAG 로 바꾸는 구상의 사전 실측을 운영 DB(agent_tasks 153건)로 수행한 결과:

- **벽시계 대기의 지배 요인은 HITL 승인 방치** — 스텝 간격 합계의 99%가 60s+ 대기, 방치 task 는 승인 대기(30분)×N 반복 후 산출물 0 으로 종결
- **failed 20건 중 6~7건이 일시적 인프라 오류** (timeout 3·connection 2·LiteLLM 500 1 등) — 재시도면 구제 가능했던 부류
- 순수 병렬화 이득은 약함(연속 read-only 런은 검색 버스트 위주, 초 단위 절감)

→ 전면 그래프 구축 대신 **실측 신호가 강한 노드 속성부터 증분 도입** (measure-first).

## 커밋 3건

### 1. 스텝 도구 호출 의도 영속 (`150127a4`)
- `assistant_tool_call`/`plan` 스텝에 그 턴이 호출한 도구명(콤마 결합)을 `tool_name` 으로 기록 (기존 741건 전부 미기록)
- 중단·승인 거부로 실행 안 된 호출 의도까지 남겨 턴 단위 집계(다중 승인 턴 빈도 등 후속 실측) 가능

### 2. 턴 LLM 호출 일시적 오류 재시도 (`8b45df60`)
- `isTransientLLMError`: 5xx·408·429 + status 없는 연결류만 재시도 대상 — 그 외 4xx·abort·도메인 오류는 즉시 throw
- 지수 백오프 `AGENT_TASK_TURN_RETRY_MAX`(기본 2회) × `AGENT_TASK_TURN_RETRY_BACKOFF_MS`(기본 2s), abort 가능 대기
- 사용자 취소·예산 소진(signal abort)은 재시도 안 함. 기존 외부 role 4xx 로컬 강등은 유지하되 강등 후 일시 오류도 재시도 대상화
- `stepType='retry'` 스텝 영속 — 발동 빈도 DB 집계

### 3. HITL 무응답 강등 (`34d10a81`)
- `ApprovalResult` 에 거절 사유 도입: `'timeout'`(무응답) / `'user'`(명시 거절) / `'abort'` — 명시 거절은 기존 의미 유지(모델이 대안 모색)
- 무응답 누적이 `AGENT_TASK_HITL_TIMEOUT_DEGRADE_AFTER`(기본 2)에 달하면 이후 턴에서 승인 필요 도구(+항상 사람을 기다리는 `ask_human`) 제거 + 마무리 nudge 1회 주입 — `final_turn`·`overSearchLimit` 와 동일 패턴
- 무응답 시 도구 결과 메시지 구분(재질문 대신 가정 명시·마무리 유도), `stepType='hitl_degrade'` 스텝 영속
- 예약(무인) 경로는 approval policy `none` 이라 무영향 — `ask_human` 무인 hang 방어는 강화

## 체크리스트

- [x] `npm run lint` 통과 (오류 0)
- [x] `npm test` 전체 통과 (201 suites / 2370 tests, 신규 14건 포함)
- [x] 환경변수 3건 추가 → `.env.example` 갱신
- [ ] 라우팅/응답 변경 없음 · DB 스키마 변경 없음 · UI 변경 없음 (신규 stepType 은 기존 generic 뱃지로 렌더)

## 롤백

env 로 개별 비활성 가능: `AGENT_TASK_TURN_RETRY_MAX=0`, `AGENT_TASK_HITL_TIMEOUT_DEGRADE_AFTER=0` (재시작 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)