### PR TITLE
feat(install): Linux/macOS 원샷 설치 스크립트 (installer 브랜치 부활 rebase)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,11 @@
 .env
 .env.local
 .env.*.local
-# 운영 .env 백업 — 실제 시크릿이 들어 있어 절대 커밋 금지
+# 운영 .env 백업 (gen-env.mjs --force 백업 포함) — 실제 시크릿이 들어 있어 절대 커밋 금지
 .env.bak*
+
+# install.sh 가 만든 로컬 toolchain (홈에 설치한 Node/PM2 의 PATH 등)
+/.openmake/
 # Docker is permanently excluded from this project (PM2 + direct deploy only)
 
 # Dependencies

--- a/README.md
+++ b/README.md
@@ -175,39 +175,91 @@ OpenMake separates **policy** (deciding *how* to answer) from **execution** (act
 
 ## Getting Started
 
-### Prerequisites
+Supported platforms: **Linux** and **macOS** (Intel & Apple Silicon).
 
-- **Node.js** `>=24 <25`
-- **Docker** (for PostgreSQL/Redis and the MCP/agent sandboxes)
-- An OpenAI-compatible LLM endpoint: a local **vLLM + LiteLLM** stack, or an external provider key
-
-### Setup
+### Install (one command)
 
 ```bash
-# 1. Clone & install (npm workspaces)
 git clone https://github.com/openmake/openmake_llm.git
 cd openmake_llm
-npm install
-
-# 2. Configure environment
-cp .env.example .env      # then fill in the values below
-
-# 3. Start PostgreSQL (schema auto-generates on first launch)
-docker compose -f infra/docker-compose.yml up -d postgres
+./install.sh
 ```
 
-Minimum `.env` values (see `.env.example` for the full list):
+That's it. The installer checks your toolchain (Node 24, Docker, PM2 — installing what's
+missing, without `sudo` where possible), generates a `.env` with freshly random secrets,
+installs dependencies, starts PostgreSQL + Redis, applies all migrations, builds both apps,
+launches them under PM2, and waits for `/health`. It prints your web URL and the generated
+admin password at the end.
+
+It asks one question — which OpenAI-compatible LLM endpoint to use (Ollama / OpenRouter /
+custom / decide later). To skip every prompt:
+
+```bash
+./install.sh --yes                                    # placeholder LLM, fill in .env later
+./install.sh --yes \
+  --llm-base-url https://openrouter.ai/api/v1 \
+  --llm-api-key  sk-or-... \
+  --llm-model    qwen/qwen3-235b-a22b
+```
+
+Re-running `./install.sh` is safe — it repairs rather than overwrites. Useful flags:
+`--skip-docker` (you run Postgres/Redis yourself), `--skip-build`, `--no-start`,
+`--force-env`, `--port` / `--web-port`. See `./install.sh --help`.
+
+### Prerequisites (handled by the installer)
+
+- **Node.js** `>=24 <25` — provisioned via `mise`/`fnm`/`nvm`, Homebrew, or a local
+  `~/.openmake/node` tarball if none of those exist
+- **Docker** — required for PostgreSQL/Redis and the MCP/agent sandboxes. On Linux the
+  installer offers to run the official `get.docker.com` script; on macOS you need
+  Docker Desktop or OrbStack
+- An OpenAI-compatible LLM endpoint: a local **vLLM + LiteLLM** stack, **Ollama**, or an
+  external provider key
+
+### Manual setup
+
+If you'd rather wire it up yourself, `install.sh` is a readable transcript of these steps:
+
+```bash
+npm install
+node scripts/setup/gen-env.mjs        # minimal .env with generated secrets
+docker compose --env-file .env -f infra/docker-compose.yml up -d postgres redis
+npx ts-node apps/api/src/data/migrations/cli.ts migrate
+npm run build && pm2 start ecosystem.config.js
+```
+
+> The `--env-file .env` is not optional: Compose resolves its default `.env` relative to the
+> compose file's directory (`infra/`), so without it `POSTGRES_PASSWORD` is empty and startup fails.
+
+`gen-env.mjs` writes only the keys required to boot. `.env.example` is the full reference —
+copy optional blocks (OAuth, web search, MCP sandbox, Discord bot) out of it as you need them:
 
 | Variable | Purpose |
 |---|---|
 | `PORT` | API port (default `52416`) |
-| `DATABASE_URL` | PostgreSQL connection string |
-| `JWT_SECRET` | JWT signing secret |
-| `TOKEN_ENCRYPTION_KEY` | AES-256-GCM key for external provider credentials |
+| `DATABASE_URL` | PostgreSQL connection string (password must match `POSTGRES_PASSWORD`) |
+| `JWT_SECRET` | JWT signing secret (≥32 chars) |
+| `API_KEY_PEPPER` | API-key hashing pepper — required in production |
+| `TOKEN_ENCRYPTION_KEY` | AES-256-GCM key for external provider credentials (exactly 64 hex) |
+| `ADMIN_PASSWORD` | Bootstrap admin account password — required in production |
 | `LLM_BASE_URL` / `LLM_API_KEY` / `LLM_DEFAULT_MODEL` | LiteLLM proxy endpoint, master key, default model |
-| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth (optional) |
 
 ### Run
+
+Day-to-day operation goes through `openmake_llm.sh`, which sequences the three layers
+(PostgreSQL → Redis → app) on both Linux and macOS:
+
+```bash
+./openmake_llm.sh start     # bring everything up, then stream logs
+./openmake_llm.sh status    # port + docker + PM2 state for every layer
+./openmake_llm.sh logs      # live PM2 logs
+./openmake_llm.sh health    # GET /health
+./openmake_llm.sh deploy    # build + migrate + restart (apply code changes)
+./openmake_llm.sh stop      # reverse-order shutdown
+```
+
+Or drive the pieces directly:
 
 ```bash
 # Development
@@ -220,6 +272,9 @@ npm run build               # backend + frontend
 npm start                   # node apps/api/dist/server.js
 ```
 
+To survive reboots, register PM2 with your init system — `pm2 startup` (prints a command to
+run: `launchd` on macOS, `systemd` on Linux), then `pm2 save`.
+
 ### Test & lint
 
 ```bash
@@ -227,6 +282,9 @@ npm test                    # Jest unit tests (apps/api)
 npm run test:e2e            # Playwright (chromium + webkit)
 npm run lint                # ESLint
 ```
+
+> `apps/api` unit tests are git-ignored (local-only), so `npm test` reports "0 matches" on a
+> fresh clone — that's expected, not a broken install. CI skips the gate the same way.
 
 ### Database migrations
 
@@ -262,9 +320,12 @@ openmake_llm/
 ├── db/               # init schema + migrations (+ rollbacks/) — read at runtime
 ├── packages/         # shared-types, config, api-client (shared workspaces)
 ├── infra/            # Dockerfiles & compose (mcp-runtime, task-runtime, artifact-viewer, egress-proxy)
-├── scripts/          # host setup for the LLM backend — vLLM/LiteLLM systemd units,
-│                     # serve scripts, litellm.config.yaml, Caddyfile, diagnostics
-└── tests/            # Playwright E2E
+├── scripts/          # setup/ (gen-env.mjs) + host setup for the LLM backend — vLLM/LiteLLM
+│                     # systemd units, serve scripts, litellm.config.yaml, Caddyfile, diagnostics
+├── tests/            # Playwright E2E
+├── install.sh        # one-shot installer (Linux/macOS): toolchain → .env → DB → build → PM2
+├── openmake_llm.sh   # service manager: start/stop/restart/deploy/status/logs/health
+└── ecosystem.config.js  # PM2 process definitions (API, Next frontend, optional Discord bot)
 ```
 
 **What the running server actually needs:** the built `apps/api/dist` + `apps/web/.next`, `db/` (the boot path applies `db/init/`, and the migration CLI resolves `db/migrations/` from the working directory), and `infra/` for the Docker-isolated sandboxes. `scripts/` and `tests/` are *not* loaded by any runtime code — but `scripts/vllm/` and `scripts/caddy/` are the deployment artifacts you copy onto the GPU host when standing up or rebuilding the inference backend, so keep them with the repo.

--- a/README.md
+++ b/README.md
@@ -204,7 +204,19 @@ custom / decide later). To skip every prompt:
 
 Re-running `./install.sh` is safe — it repairs rather than overwrites. Useful flags:
 `--skip-docker` (you run Postgres/Redis yourself), `--skip-build`, `--no-start`,
-`--force-env`, `--port` / `--web-port`. See `./install.sh --help`.
+`--force-env`, and the port overrides below. See `./install.sh --help`.
+
+Already running Postgres or Redis on the default ports? Move the containers instead of
+fighting over 5432/6379 — the ports land in `.env`, and `openmake_llm.sh` reads them back:
+
+```bash
+./install.sh --yes --postgres-port 55432 --redis-port 56379
+```
+
+On macOS the installer works with Docker Desktop, OrbStack, or **Colima**
+(`brew install colima docker docker-compose` — headless, no GUI). If Homebrew's compose
+plugin isn't registered with the docker CLI, the installer adds `cliPluginsExtraDirs` to
+`~/.docker/config.json` for you.
 
 ### Prerequisites (handled by the installer)
 

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -19,7 +19,32 @@
  *   # 미설정 시 단일 로그 파일이 무한 증가 → 디스크 가득 위험
  */
 const { execSync } = require('child_process');
+const fs = require('fs');
 const path = require('path');
+
+/** 포트/로그 위치는 .env 나 셸 환경으로 덮어쓸 수 있다 (No-Hardcoding). */
+const API_PORT = process.env.PORT || '52416';
+const WEB_PORT = process.env.OMK_WEB_PORT || '3000';
+/**
+ * 로그 디렉터리. 기본은 기존 동작 유지(/tmp)지만, 여러 사용자가 쓰는 리눅스 호스트에서는
+ * /tmp/openmake-*.log 소유자 충돌로 PM2 가 EACCES 로 죽는다 → OMK_LOG_DIR 로 분리 가능.
+ */
+const LOG_DIR = process.env.OMK_LOG_DIR || '/tmp';
+const logFile = (name) => path.join(LOG_DIR, name);
+
+/**
+ * Next 실행 파일 경로 해석.
+ * npm workspaces 는 next 를 루트 node_modules 로 hoist 하므로 apps/web/node_modules/next 는
+ * 보통 존재하지 않는다(신규 클론에서 프론트가 안 뜨던 원인). require.resolve 로 hoist/nested
+ * 양쪽을 모두 처리한다.
+ */
+function resolveNextBin(webDir) {
+    try {
+        return require.resolve('next/dist/bin/next', { paths: [webDir, __dirname] });
+    } catch {
+        return './node_modules/next/dist/bin/next'; // 마지막 수단 — 기존 동작
+    }
+}
 
 /**
  * JVM 위치를 크로스플랫폼으로 탐지한다 (opendataloader-pdf 의 PDF 텍스트 추출에 필요).
@@ -52,17 +77,19 @@ function resolveJavaHome() {
 const JAVA_HOME = resolveJavaHome();
 const JAVA_PATH_PREFIX = JAVA_HOME ? path.join(JAVA_HOME, 'bin') + path.delimiter : '';
 
-module.exports = {
-    apps: [{
+const WEB_DIR = path.join(__dirname, 'apps/web');
+const DISCORD_ENTRY = path.join(__dirname, 'apps/discord-bot/dist/index.js');
+
+const apps = [{
         name: 'openmake-llm',
         script: 'apps/api/dist/cli.js',
-        args: 'cluster --port 52416',
+        args: `cluster --port ${API_PORT}`,
         cwd: __dirname,
-        
+
         // 환경 설정
         env: {
             NODE_ENV: 'production',
-            PORT: 52416,
+            PORT: API_PORT,
             // 문서 첨부 추출(opendataloader-pdf)은 Java 11+ 가 필요하다.
             // pm2 프로세스가 JVM 을 찾도록 자동 탐지한 JAVA_HOME 과 PATH 를 주입 (크로스플랫폼).
             ...(JAVA_HOME ? { JAVA_HOME } : {}),
@@ -82,8 +109,8 @@ module.exports = {
         
         // 로그 설정
         log_date_format: 'YYYY-MM-DD HH:mm:ss',
-        error_file: '/tmp/openmake-llm-error.log',
-        out_file: '/tmp/openmake-llm-out.log',
+        error_file: logFile('openmake-llm-error.log'),
+        out_file: logFile('openmake-llm-out.log'),
         merge_logs: true,
         log_type: 'json',
         
@@ -106,13 +133,14 @@ module.exports = {
         // 운영: Nginx 가 / 를 이 앱(:3000)으로, /api·/ws 를 openmake-llm(:52416)으로 프록시.
         // 선행: `npm run build:frontend-next` 로 apps/web/.next 생성 필요.
         name: 'openmake-next',
-        cwd: __dirname + '/apps/web',
+        cwd: WEB_DIR,
         // npm 을 fork 하면 pm2 ProcessContainerFork 가 crash → next 바이너리를 직접 node 로 실행.
-        script: './node_modules/next/dist/bin/next',
-        args: 'start -p 3000',
+        // (workspaces hoist 때문에 경로는 require.resolve 로 찾는다 — resolveNextBin 주석 참고)
+        script: resolveNextBin(WEB_DIR),
+        args: `start -p ${WEB_PORT}`,
         env: {
             NODE_ENV: 'production',
-            PORT: 3000,
+            PORT: WEB_PORT,
             // 운영은 same-origin Nginx 프록시이므로 WS 도 same-origin(미설정 시 location.host).
             // API_PROXY_TARGET 은 dev 전용(.env.local). 운영에서 Next rewrites 를 쓰려면 여기서 지정.
         },
@@ -123,11 +151,18 @@ module.exports = {
         min_uptime: '10s',
         restart_delay: 3000,
         max_memory_restart: '1G',
-        error_file: '/tmp/openmake-next-error.log',
-        out_file: '/tmp/openmake-next-out.log',
+        error_file: logFile('openmake-next-error.log'),
+        out_file: logFile('openmake-next-out.log'),
         merge_logs: true,
         log_date_format: 'YYYY-MM-DD HH:mm:ss',
-    }, {
+    }];
+
+// ── Discord Gateway Bot (선택) ────────────────────────────────────────────
+// dist 가 없으면 PM2 가 MODULE_NOT_FOUND 로 재시작 루프를 돌다 errored 로 남는다
+// (신규 설치는 `npm run build` 에 discord-bot 이 포함되지 않아 항상 이 상태였음).
+// 빌드 산출물이 실제로 있을 때만 등록한다.
+if (fs.existsSync(DISCORD_ENTRY)) {
+    apps.push({
         // ── Discord Gateway Bot ─────────────────────────────────
         // Discord 메시지를 /api/v1/chat/completions 로 중계하는 독립 gateway 프로세스.
         // 선행: 루트 .env 에 DISCORD_BOT_TOKEN·DISCORD_BOT_API_KEY + 접근 제어 설정,
@@ -147,9 +182,11 @@ module.exports = {
         min_uptime: '10s',
         restart_delay: 3000,
         max_memory_restart: '300M',
-        error_file: '/tmp/openmake-discord-error.log',
-        out_file: '/tmp/openmake-discord-out.log',
+        error_file: logFile('openmake-discord-error.log'),
+        out_file: logFile('openmake-discord-out.log'),
         merge_logs: true,
         log_date_format: 'YYYY-MM-DD HH:mm:ss',
-    }],
-};
+    });
+}
+
+module.exports = { apps };

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -3,12 +3,16 @@
 # 목적: 호스트 brew(postgresql@16, redis) 대신 버전 고정·격리·이식 가능한 컨테이너로 운영.
 # 애플리케이션(apps/api, apps/web)은 여전히 PM2 + 직접 배포 (이 compose 에 포함하지 않음).
 #
-# 사용:
-#   docker compose up -d                 # DB+Redis 기동
-#   docker compose ps                    # 상태
-#   docker compose logs -f postgres      # 로그
-#   docker compose down                  # 정지 (볼륨 유지)
-#   docker compose down -v               # 정지 + 데이터 볼륨 삭제(주의)
+# 사용 (레포 루트에서):
+#   docker compose --env-file .env -f infra/docker-compose.yml up -d       # DB+Redis 기동
+#   docker compose --env-file .env -f infra/docker-compose.yml ps          # 상태
+#   docker compose --env-file .env -f infra/docker-compose.yml logs -f postgres
+#   docker compose --env-file .env -f infra/docker-compose.yml down        # 정지 (볼륨 유지)
+#   docker compose --env-file .env -f infra/docker-compose.yml down -v     # 정지 + 볼륨 삭제(주의)
+#
+# ⚠ --env-file 은 선택이 아니다: compose 는 기본 .env 를 "compose 파일이 있는 디렉터리"
+#   (= infra/) 기준으로 찾는다. 루트 .env 를 명시하지 않으면 POSTGRES_PASSWORD 가 비어
+#   `:?` 검증에 걸려 기동이 실패한다. (install.sh / openmake_llm.sh 는 자동으로 붙인다.)
 #
 # 선행: .env 에 POSTGRES_PASSWORD 를 DATABASE_URL 의 비밀번호와 동일하게 설정.
 #   (DATABASE_URL=postgresql://openmake:<PW>@127.0.0.1:5432/openmake_llm ↔ POSTGRES_PASSWORD=<PW>)

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,9 @@
 #   --skip-build         빌드 산출물이 이미 있을 때
 #   --no-start           설치만 하고 PM2 기동은 하지 않음
 #   --force-env          기존 .env 를 백업하고 새로 생성
+#   --port / --web-port  API(52416) / 웹(3000) 포트 변경
+#   --postgres-port      PostgreSQL 포트 변경 (기본 5432 가 이미 점유된 경우)
+#   --redis-port         Redis 포트 변경 (기본 6379)
 #
 # 재실행 안전(idempotent): 이미 된 단계는 건너뛰거나 갱신만 한다.
 #
@@ -100,6 +103,8 @@ parse_args() {
             --llm-model)     LLM_MODEL="${2:-}"; shift ;;
             --port)          APP_PORT="${2:-}"; shift ;;
             --web-port)      WEB_PORT="${2:-}"; shift ;;
+            --postgres-port) PG_PORT="${2:-}"; shift ;;
+            --redis-port)    RD_PORT="${2:-}"; shift ;;
             -h|--help)       usage; exit 0 ;;
             *) log_err "알 수 없는 옵션: $1"; echo ""; usage; exit 1 ;;
         esac
@@ -254,15 +259,55 @@ ensure_node() {
 # ── 2. Docker ────────────────────────────────────────────────────────────────
 DOCKER_COMPOSE=""   # "docker compose" 또는 "docker-compose"
 
+# Homebrew 의 docker-compose 는 플러그인을 /opt/homebrew/lib/docker/cli-plugins 에 두는데,
+# docker CLI 는 이 경로를 기본으로 보지 않는다 → `docker compose` 가 "unknown command" 로 실패.
+# brew 가 caveat 로 안내하는 대로 ~/.docker/config.json 에 cliPluginsExtraDirs 를 등록한다.
+register_brew_compose_plugin() {
+    has brew || return 1
+    local plugin_dir
+    plugin_dir="$(brew --prefix)/lib/docker/cli-plugins"
+    [[ -e "$plugin_dir/docker-compose" ]] || return 1
+
+    local cfg="$HOME/.docker/config.json"
+    mkdir -p "$HOME/.docker"
+    # 기존 설정을 보존한 채 병합 (node 는 이 시점에 반드시 있다).
+    node -e '
+        const fs = require("fs");
+        const [cfgPath, dir] = process.argv.slice(1);
+        let cfg = {};
+        try { cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8")); } catch {}
+        const dirs = Array.isArray(cfg.cliPluginsExtraDirs) ? cfg.cliPluginsExtraDirs : [];
+        if (!dirs.includes(dir)) dirs.push(dir);
+        cfg.cliPluginsExtraDirs = dirs;
+        fs.writeFileSync(cfgPath, JSON.stringify(cfg, null, 2) + "\n");
+    ' "$cfg" "$plugin_dir" 2>/dev/null || return 1
+
+    log_info "docker compose 플러그인 경로 등록 → ~/.docker/config.json ($plugin_dir)"
+    docker compose version >/dev/null 2>&1
+}
+
 detect_compose() {
     if docker compose version >/dev/null 2>&1; then
         DOCKER_COMPOSE="docker compose"
-    elif has docker-compose; then
-        DOCKER_COMPOSE="docker-compose"
-        log_warn "compose v1(docker-compose) 사용 — v2(docker compose) 업그레이드를 권장합니다."
-    else
-        return 1
+        return 0
     fi
+
+    # Homebrew 로 방금 깔았는데 플러그인 등록만 안 된 흔한 상태 — 자동 복구를 시도.
+    if register_brew_compose_plugin; then
+        DOCKER_COMPOSE="docker compose"
+        return 0
+    fi
+
+    if has docker-compose; then
+        DOCKER_COMPOSE="docker-compose"
+        # 진짜 구형 v1 일 때만 경고한다 (brew 의 standalone 바이너리는 최신 Compose 다).
+        case "$(docker-compose version --short 2>/dev/null)" in
+            1.*) log_warn "compose v1(docker-compose) 사용 — v2 이상 업그레이드를 권장합니다." ;;
+        esac
+        return 0
+    fi
+
+    return 1
 }
 
 install_docker() {
@@ -298,7 +343,14 @@ ensure_docker_daemon() {
 
     log_warn "Docker 데몬이 응답하지 않습니다 — 기동을 시도합니다."
     if [[ "$OS" == "macos" ]]; then
-        open -a Docker 2>/dev/null || open -a OrbStack 2>/dev/null || true
+        # colima 는 CLI 로 기동해야 한다 (Docker Desktop/OrbStack 처럼 .app 이 아님).
+        # docker CLI 만 설치하고 colima 를 백엔드로 쓰는 헤드리스 구성이 흔하다.
+        if has colima; then
+            log_info "colima 기동 (colima start)"
+            colima start >/dev/null 2>&1 || true
+        else
+            open -a Docker 2>/dev/null || open -a OrbStack 2>/dev/null || true
+        fi
     else
         sudo systemctl start docker 2>/dev/null || sudo service docker start 2>/dev/null || true
     fi
@@ -507,8 +559,7 @@ start_app() {
 
 # ── 마무리 안내 ──────────────────────────────────────────────────────────────
 summary() {
-    local admin_user admin_pass admin_email llm_url
-    admin_user="$(env_value ADMIN_INITIAL_USERNAME)"
+    local admin_pass admin_email llm_url
     admin_pass="$(env_value ADMIN_PASSWORD)"
     admin_email="$(env_value DEFAULT_ADMIN_EMAIL)"
     llm_url="$(env_value LLM_BASE_URL)"
@@ -520,7 +571,8 @@ summary() {
     echo "  웹 UI     http://localhost:$WEB_PORT"
     echo "  API       http://localhost:$APP_PORT   (health: /health)"
     echo ""
-    echo "  로그인    ${admin_email:-admin@openmake.local}  (또는 사용자명 ${admin_user:-admin})"
+    # 로그인 식별자는 email 이다 (auth.schema.ts loginSchema — username 필드는 없음).
+    echo "  로그인    ${admin_email:-admin@openmake.local}   ← 이메일로 로그인합니다"
     echo "  비밀번호  ${admin_pass:-<.env 의 ADMIN_PASSWORD 참조>}"
     printf "  %s첫 로그인 후 비밀번호를 바꾸세요. 비밀번호는 .env 에 평문으로 저장됩니다.%s\n" "$C_DIM" "$C_RESET"
     echo ""

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,568 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# OpenMake LLM — 원샷 설치 스크립트 (Linux / macOS)
+# ==============================================================================
+# 클론 직후 이 스크립트 하나만 실행하면 바로 쓸 수 있는 상태까지 만든다:
+#
+#   toolchain 점검(Node 24 / Docker / PM2) → .env 생성 → 의존성 설치
+#   → PostgreSQL·Redis 기동 → DB 마이그레이션 → 빌드 → PM2 기동 → health check
+#
+# 사용:
+#   ./install.sh                     # 대화형 (LLM 엔드포인트를 물어봄)
+#   ./install.sh --yes               # 비대화형 (기본값으로 진행, 프롬프트 없음)
+#   ./install.sh --llm-base-url https://openrouter.ai/api/v1 \
+#                --llm-api-key sk-or-... --llm-model qwen/qwen3-235b-a22b --yes
+#
+# 주요 옵션 (--help 로 전체 확인):
+#   --yes, -y            모든 확인을 자동 승인 (비대화형)
+#   --skip-docker        PostgreSQL/Redis 를 직접 운영 중일 때 (compose 건너뜀)
+#   --skip-build         빌드 산출물이 이미 있을 때
+#   --no-start           설치만 하고 PM2 기동은 하지 않음
+#   --force-env          기존 .env 를 백업하고 새로 생성
+#
+# 재실행 안전(idempotent): 이미 된 단계는 건너뛰거나 갱신만 한다.
+#
+# 종료 코드:
+#   0 성공 / 1 사용법·전제조건 오류 / 2 설치 단계 실패 / 3 health check 실패
+# ==============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+readonly SCRIPT_DIR
+readonly NODE_MAJOR_MIN=24
+readonly NODE_PINNED_VERSION="24.16.0"   # mise.toml / .node-version 과 동일
+readonly TOOLCHAIN_DIR="$SCRIPT_DIR/.openmake"
+readonly TOOLCHAIN_ENV="$TOOLCHAIN_DIR/toolchain.env"
+readonly HEALTH_RETRIES=45
+readonly HEALTH_INTERVAL=2
+
+APP_PORT="${OMK_PORT:-52416}"
+WEB_PORT="${OMK_WEB_PORT:-3000}"
+PG_PORT="${OMK_POSTGRES_PORT:-5432}"
+RD_PORT="${OMK_REDIS_PORT:-6379}"
+
+ASSUME_YES=0
+SKIP_DOCKER=0
+SKIP_BUILD=0
+NO_START=0
+FORCE_ENV=0
+LLM_BASE_URL=""
+LLM_API_KEY=""
+LLM_MODEL=""
+
+# ── 출력 ─────────────────────────────────────────────────────────────────────
+if [[ -t 1 ]]; then
+    C_RESET=$'\033[0m'; C_INFO=$'\033[1;34m'; C_OK=$'\033[1;32m'
+    C_WARN=$'\033[1;33m'; C_ERR=$'\033[1;31m'; C_DIM=$'\033[2m'
+else
+    C_RESET=""; C_INFO=""; C_OK=""; C_WARN=""; C_ERR=""; C_DIM=""
+fi
+
+log_info() { printf "%s[INFO]%s  %s\n" "$C_INFO" "$C_RESET" "$*"; }
+log_ok()   { printf "%s[OK]%s    %s\n" "$C_OK"   "$C_RESET" "$*"; }
+log_warn() { printf "%s[WARN]%s  %s\n" "$C_WARN" "$C_RESET" "$*"; }
+log_err()  { printf "%s[ERR]%s   %s\n" "$C_ERR"  "$C_RESET" "$*" >&2; }
+log_step() { printf "\n%s━━ %s ━━%s\n" "$C_INFO" "$*" "$C_RESET"; }
+
+die() { log_err "$*"; exit 2; }
+
+# y/N 확인. --yes 또는 비대화형(파이프 실행)이면 자동 승인.
+confirm() {
+    local prompt="$1"
+    if [[ $ASSUME_YES -eq 1 ]] || [[ ! -t 0 ]]; then
+        log_info "$prompt → 자동 승인"
+        return 0
+    fi
+    local reply=""
+    read -r -p "$(printf '%s%s%s [y/N]: ' "$C_WARN" "$prompt" "$C_RESET")" reply || true
+    case "$reply" in [yY]|[yY][eE][sS]) return 0 ;; *) return 1 ;; esac
+}
+
+has() { command -v "$1" >/dev/null 2>&1; }
+
+usage() {
+    # 파일 상단 주석 블록(셔뱅 다음 ~ 첫 비주석 줄 전)을 그대로 사용법으로 출력한다.
+    # 헤더를 고쳐도 --help 가 자동으로 따라오도록 줄 번호를 하드코딩하지 않는다.
+    sed -n '2,/^[^#]/p' "${BASH_SOURCE[0]}" | sed '$d' | sed 's/^# \{0,1\}//'
+}
+
+# ── 인자 파싱 ────────────────────────────────────────────────────────────────
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -y|--yes)        ASSUME_YES=1 ;;
+            --skip-docker)   SKIP_DOCKER=1 ;;
+            --skip-build)    SKIP_BUILD=1 ;;
+            --no-start)      NO_START=1 ;;
+            --force-env)     FORCE_ENV=1 ;;
+            --llm-base-url)  LLM_BASE_URL="${2:-}"; shift ;;
+            --llm-api-key)   LLM_API_KEY="${2:-}"; shift ;;
+            --llm-model)     LLM_MODEL="${2:-}"; shift ;;
+            --port)          APP_PORT="${2:-}"; shift ;;
+            --web-port)      WEB_PORT="${2:-}"; shift ;;
+            -h|--help)       usage; exit 0 ;;
+            *) log_err "알 수 없는 옵션: $1"; echo ""; usage; exit 1 ;;
+        esac
+        shift
+    done
+}
+
+# ── 플랫폼 감지 ──────────────────────────────────────────────────────────────
+OS=""          # linux | macos
+ARCH=""        # x64 | arm64
+PKG=""         # brew | apt | dnf | yum | pacman | zypper | ""
+
+detect_platform() {
+    case "$(uname -s)" in
+        Darwin) OS="macos" ;;
+        Linux)  OS="linux" ;;
+        *) log_err "지원하지 않는 OS: $(uname -s) (Linux / macOS 만 지원)"; exit 1 ;;
+    esac
+
+    case "$(uname -m)" in
+        x86_64|amd64)  ARCH="x64" ;;
+        arm64|aarch64) ARCH="arm64" ;;
+        *) log_err "지원하지 않는 아키텍처: $(uname -m)"; exit 1 ;;
+    esac
+
+    if   has brew;    then PKG="brew"
+    elif has apt-get; then PKG="apt"
+    elif has dnf;     then PKG="dnf"
+    elif has yum;     then PKG="yum"
+    elif has pacman;  then PKG="pacman"
+    elif has zypper;  then PKG="zypper"
+    fi
+
+    log_ok "플랫폼: $OS/$ARCH${PKG:+ (패키지 관리자: $PKG)}"
+}
+
+# 설치 중에만 유효한 PATH 를 파일로 남겨 openmake_llm.sh 가 이어받게 한다.
+persist_path() {
+    local dir="$1"
+    mkdir -p "$TOOLCHAIN_DIR"
+    if [[ -f "$TOOLCHAIN_ENV" ]] && grep -qF "$dir" "$TOOLCHAIN_ENV" 2>/dev/null; then
+        return 0
+    fi
+    {
+        [[ -f "$TOOLCHAIN_ENV" ]] || echo "# install.sh 가 생성 — openmake_llm.sh 가 자동으로 source 한다."
+        echo "export PATH=\"$dir:\$PATH\""
+    } >> "$TOOLCHAIN_ENV"
+    log_info "PATH 등록 → .openmake/toolchain.env ($dir)"
+}
+
+# ── 1. Node.js ───────────────────────────────────────────────────────────────
+node_major() { node -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0; }
+
+# 버전 관리자(mise/fnm/nvm/asdf)가 있으면 그것으로 Node 24 를 활성화한다.
+try_node_version_manager() {
+    if has mise; then
+        log_info "mise 로 Node $NODE_PINNED_VERSION 설치 시도 (mise.toml 핀)"
+        if mise install node@"$NODE_PINNED_VERSION" >/dev/null 2>&1; then
+            local bin
+            bin="$(mise where node@"$NODE_PINNED_VERSION" 2>/dev/null)/bin"
+            if [[ -x "$bin/node" ]]; then
+                export PATH="$bin:$PATH"; persist_path "$bin"; return 0
+            fi
+        fi
+    fi
+    if has fnm; then
+        log_info "fnm 로 Node $NODE_PINNED_VERSION 설치 시도"
+        if fnm install "$NODE_PINNED_VERSION" >/dev/null 2>&1; then
+            eval "$(fnm env --shell bash 2>/dev/null)" || true
+            fnm use "$NODE_PINNED_VERSION" >/dev/null 2>&1 || true
+            [[ "$(node_major)" -ge $NODE_MAJOR_MIN ]] && return 0
+        fi
+    fi
+    # nvm 은 함수라 command -v 로 안 잡힌다 — 스크립트를 직접 source.
+    local nvm_sh="${NVM_DIR:-$HOME/.nvm}/nvm.sh"
+    if [[ -s "$nvm_sh" ]]; then
+        log_info "nvm 으로 Node $NODE_PINNED_VERSION 설치 시도"
+        # nvm.sh 는 set -u 환경에서 미정의 변수를 건드리므로 잠시 해제한다.
+        set +u; . "$nvm_sh"; nvm install "$NODE_PINNED_VERSION" >/dev/null 2>&1 || true
+        nvm use "$NODE_PINNED_VERSION" >/dev/null 2>&1 || true; set -u
+        if [[ "$(node_major)" -ge $NODE_MAJOR_MIN ]]; then
+            persist_path "$(dirname "$(command -v node)")"; return 0
+        fi
+    fi
+    return 1
+}
+
+# 마지막 수단: nodejs.org 공식 tarball 을 홈 디렉터리에 푼다 (sudo 불필요).
+install_node_tarball() {
+    local plat="linux-$ARCH"
+    [[ "$OS" == "macos" ]] && plat="darwin-$ARCH"
+    local url="https://nodejs.org/dist/v$NODE_PINNED_VERSION/node-v$NODE_PINNED_VERSION-$plat.tar.gz"
+    local dest="$HOME/.openmake/node"
+
+    if [[ -x "$dest/bin/node" ]]; then
+        export PATH="$dest/bin:$PATH"; persist_path "$dest/bin"
+        [[ "$(node_major)" -ge $NODE_MAJOR_MIN ]] && return 0
+    fi
+
+    has curl || die "curl 이 필요합니다 (Node 자동 설치용). 패키지 관리자로 curl 을 먼저 설치하세요."
+    log_info "Node $NODE_PINNED_VERSION 다운로드: $url"
+    rm -rf "$dest"; mkdir -p "$dest"
+    # --strip-components=1 로 node-v24.x-plat/ 껍데기를 벗긴다.
+    if ! curl -fsSL "$url" | tar -xz -C "$dest" --strip-components=1; then
+        die "Node 다운로드/압축해제 실패 — 네트워크를 확인하거나 Node 24 를 직접 설치한 뒤 재실행하세요."
+    fi
+    export PATH="$dest/bin:$PATH"; persist_path "$dest/bin"
+    [[ "$(node_major)" -ge $NODE_MAJOR_MIN ]] || die "Node 설치 후에도 버전 확인 실패"
+}
+
+ensure_node() {
+    log_step "1/8 Node.js"
+
+    # 이미 등록된 toolchain PATH 가 있으면 먼저 반영 (재실행 시나리오).
+    # shellcheck source=/dev/null
+    [[ -f "$TOOLCHAIN_ENV" ]] && . "$TOOLCHAIN_ENV"
+
+    if has node && [[ "$(node_major)" -ge $NODE_MAJOR_MIN ]]; then
+        log_ok "node $(node -v) / npm $(npm -v 2>/dev/null || echo '?')"
+        if [[ "$(node_major)" -gt $NODE_MAJOR_MIN ]]; then
+            log_warn "package.json engines 는 node >=24 <25 를 명시합니다 (현재 $(node -v))."
+            log_warn "설치는 계속되지만 .npmrc 에 engine-strict=true 가 있으면 실패합니다."
+        fi
+        return 0
+    fi
+
+    if has node; then
+        log_warn "node $(node -v) 는 최소 요구 버전(v$NODE_MAJOR_MIN)보다 낮습니다 — Node 24 를 준비합니다."
+    else
+        log_warn "node 미설치 — Node $NODE_PINNED_VERSION 을 준비합니다."
+    fi
+
+    if try_node_version_manager && [[ "$(node_major)" -ge $NODE_MAJOR_MIN ]]; then
+        log_ok "node $(node -v) 활성화"
+        return 0
+    fi
+
+    if [[ "$PKG" == "brew" ]] && confirm "brew 로 node@24 를 설치할까요?"; then
+        brew install node@24 || true
+        local brew_bin
+        brew_bin="$(brew --prefix)/opt/node@24/bin"
+        if [[ -x "$brew_bin/node" ]]; then
+            export PATH="$brew_bin:$PATH"; persist_path "$brew_bin"
+            log_ok "node $(node -v) 활성화"; return 0
+        fi
+    fi
+
+    install_node_tarball
+    log_ok "node $(node -v) 준비 완료 (~/.openmake/node)"
+}
+
+# ── 2. Docker ────────────────────────────────────────────────────────────────
+DOCKER_COMPOSE=""   # "docker compose" 또는 "docker-compose"
+
+detect_compose() {
+    if docker compose version >/dev/null 2>&1; then
+        DOCKER_COMPOSE="docker compose"
+    elif has docker-compose; then
+        DOCKER_COMPOSE="docker-compose"
+        log_warn "compose v1(docker-compose) 사용 — v2(docker compose) 업그레이드를 권장합니다."
+    else
+        return 1
+    fi
+}
+
+install_docker() {
+    if [[ "$OS" == "macos" ]]; then
+        log_err "Docker 가 없습니다. macOS 는 Docker Desktop 또는 OrbStack 이 필요합니다."
+        if [[ "$PKG" == "brew" ]] && confirm "brew 로 Docker Desktop 을 설치할까요? (설치 후 앱을 한 번 실행해야 합니다)"; then
+            brew install --cask docker || die "Docker Desktop 설치 실패"
+            log_info "Docker.app 실행 중 — 최초 실행은 권한 승인이 필요할 수 있습니다."
+            open -a Docker || true
+            return 0
+        fi
+        echo "  설치: https://www.docker.com/products/docker-desktop/  또는  brew install --cask docker"
+        exit 2
+    fi
+
+    log_err "Docker 가 없습니다."
+    if confirm "공식 스크립트로 Docker 를 설치할까요? (sudo 필요: curl -fsSL https://get.docker.com | sudo sh)"; then
+        has curl || die "curl 이 필요합니다."
+        curl -fsSL https://get.docker.com -o "$TOOLCHAIN_DIR/get-docker.sh" || die "Docker 설치 스크립트 다운로드 실패"
+        sudo sh "$TOOLCHAIN_DIR/get-docker.sh" || die "Docker 설치 실패"
+        sudo systemctl enable --now docker 2>/dev/null || true
+        # 현재 셸은 아직 docker 그룹이 아니므로 이번 실행에서는 sudo 가 필요할 수 있다.
+        sudo usermod -aG docker "$USER" 2>/dev/null || true
+        log_warn "docker 그룹 반영에는 재로그인이 필요합니다. 이번 실행에서 권한 오류가 나면 다시 로그인 후 재실행하세요."
+        return 0
+    fi
+    echo "  설치 안내: https://docs.docker.com/engine/install/"
+    exit 2
+}
+
+ensure_docker_daemon() {
+    if docker info >/dev/null 2>&1; then return 0; fi
+
+    log_warn "Docker 데몬이 응답하지 않습니다 — 기동을 시도합니다."
+    if [[ "$OS" == "macos" ]]; then
+        open -a Docker 2>/dev/null || open -a OrbStack 2>/dev/null || true
+    else
+        sudo systemctl start docker 2>/dev/null || sudo service docker start 2>/dev/null || true
+    fi
+
+    local i
+    for ((i = 1; i <= 30; i++)); do
+        docker info >/dev/null 2>&1 && { log_ok "Docker 데몬 준비 완료 (~$((i * 2))s)"; return 0; }
+        sleep 2
+    done
+    die "Docker 데몬 기동 실패 — Docker 를 직접 실행한 뒤 재시도하세요 (linux: sudo systemctl start docker)."
+}
+
+ensure_docker() {
+    log_step "2/8 Docker"
+    if [[ $SKIP_DOCKER -eq 1 ]]; then
+        log_info "--skip-docker — PostgreSQL/Redis 는 직접 운영 중이라고 가정합니다."
+        return 0
+    fi
+    has docker || install_docker
+    has docker || die "docker 명령을 찾을 수 없습니다. 새 셸에서 재실행하세요."
+    ensure_docker_daemon
+    detect_compose || die "docker compose 를 찾을 수 없습니다 (Docker Compose v2 필요)."
+    log_ok "$(docker --version) / $($DOCKER_COMPOSE version --short 2>/dev/null || echo compose)"
+}
+
+# ── 3. PM2 ───────────────────────────────────────────────────────────────────
+PM2_BIN=""
+
+ensure_pm2() {
+    log_step "3/8 PM2"
+    if has pm2; then
+        PM2_BIN="pm2"; log_ok "pm2 $(pm2 -v 2>/dev/null)"; return 0
+    fi
+
+    log_info "pm2 전역 설치 시도 (npm i -g pm2)"
+    if npm install -g pm2 >/dev/null 2>&1 && has pm2; then
+        PM2_BIN="pm2"; log_ok "pm2 $(pm2 -v) 설치 완료"; return 0
+    fi
+
+    # 전역 prefix 에 쓰기 권한이 없는 환경(시스템 Node 등) — 홈 아래로 우회 설치.
+    log_warn "전역 설치 실패 — 홈 디렉터리에 설치합니다 (~/.openmake/npm-global)"
+    local prefix="$HOME/.openmake/npm-global"
+    mkdir -p "$prefix"
+    npm install -g --prefix "$prefix" pm2 >/dev/null 2>&1 \
+        || die "pm2 설치 실패 — 'npm i -g pm2' 를 직접 실행한 뒤 재시도하세요."
+    export PATH="$prefix/bin:$PATH"; persist_path "$prefix/bin"
+    has pm2 || die "pm2 설치 후에도 실행 파일을 찾을 수 없습니다."
+    PM2_BIN="pm2"
+    log_ok "pm2 $(pm2 -v) 설치 완료 (홈 디렉터리)"
+}
+
+# ── 4. .env ──────────────────────────────────────────────────────────────────
+# 대화형으로 LLM 엔드포인트를 고른다. --llm-* 플래그가 있으면 건너뛴다.
+prompt_llm() {
+    [[ -n "$LLM_BASE_URL" ]] && return 0
+    if [[ $ASSUME_YES -eq 1 ]] || [[ ! -t 0 ]]; then
+        log_warn "LLM 엔드포인트 미지정 — 자리표시자(http://localhost:4000)로 설정합니다."
+        log_warn "채팅을 쓰려면 나중에 .env 의 LLM_BASE_URL / LLM_API_KEY / LLM_DEFAULT_MODEL 을 채우세요."
+        return 0
+    fi
+
+    echo ""
+    echo "  OpenMake 는 OpenAI 호환 엔드포인트 하나가 필요합니다. 어디에 연결할까요?"
+    echo "    1) Ollama (로컬)          http://localhost:11434/v1"
+    echo "    2) OpenRouter            https://openrouter.ai/api/v1  (API 키 필요)"
+    echo "    3) 직접 입력             LiteLLM/vLLM 등 OpenAI 호환 주소"
+    echo "    4) 나중에 설정           지금은 자리표시자만 채움"
+    local choice=""
+    read -r -p "  선택 [1-4] (기본 4): " choice || true
+    case "${choice:-4}" in
+        1)
+            LLM_BASE_URL="http://localhost:11434/v1"
+            LLM_API_KEY="ollama"
+            read -r -p "  모델 ID (기본 qwen3:8b): " LLM_MODEL || true
+            LLM_MODEL="${LLM_MODEL:-qwen3:8b}"
+            has ollama || log_warn "ollama 가 설치되어 있지 않습니다 — https://ollama.com 에서 설치 후 'ollama pull $LLM_MODEL'"
+            ;;
+        2)
+            LLM_BASE_URL="https://openrouter.ai/api/v1"
+            read -r -p "  OpenRouter API 키: " LLM_API_KEY || true
+            read -r -p "  모델 ID (기본 qwen/qwen3-235b-a22b): " LLM_MODEL || true
+            LLM_MODEL="${LLM_MODEL:-qwen/qwen3-235b-a22b}"
+            ;;
+        3)
+            read -r -p "  Base URL (예: http://localhost:4000): " LLM_BASE_URL || true
+            read -r -p "  API 키 (없으면 엔터): " LLM_API_KEY || true
+            read -r -p "  모델 ID: " LLM_MODEL || true
+            ;;
+        *)
+            log_info "LLM 설정을 건너뜁니다 — .env 에서 나중에 채우세요."
+            ;;
+    esac
+    echo ""
+}
+
+setup_env() {
+    log_step "4/8 .env 설정"
+    prompt_llm
+
+    # 서브셸에서 export — 빈 LLM_* 는 내보내지 않아야 gen-env.mjs 의 기본값이 살아난다.
+    (
+        export OMK_PORT="$APP_PORT"
+        export OMK_WEB_PORT="$WEB_PORT"
+        export OMK_POSTGRES_PORT="$PG_PORT"
+        export OMK_REDIS_PORT="$RD_PORT"
+        [[ -n "$LLM_BASE_URL" ]] && export OMK_LLM_BASE_URL="$LLM_BASE_URL"
+        [[ -n "$LLM_API_KEY"  ]] && export OMK_LLM_API_KEY="$LLM_API_KEY"
+        [[ -n "$LLM_MODEL"    ]] && export OMK_LLM_MODEL="$LLM_MODEL"
+        if [[ $FORCE_ENV -eq 1 ]]; then
+            node "$SCRIPT_DIR/scripts/setup/gen-env.mjs" --force >/dev/null
+        else
+            node "$SCRIPT_DIR/scripts/setup/gen-env.mjs" >/dev/null
+        fi
+    ) || die ".env 생성 실패"
+
+    log_ok ".env 준비 완료"
+}
+
+# .env 에서 키 하나를 읽는다 (source 하지 않는다 — 값에 공백/특수문자가 있어도 안전).
+# `|| true`: 키가 없으면 grep 이 1 을 반환하고 pipefail+set -e 가 스크립트를 죽인다.
+env_value() {
+    local key="$1"
+    [[ -f "$SCRIPT_DIR/.env" ]] || return 0
+    grep -E "^${key}=" "$SCRIPT_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2- || true
+}
+
+# ── 5. 의존성 설치 ───────────────────────────────────────────────────────────
+install_deps() {
+    log_step "5/8 npm 의존성 설치 (workspaces)"
+    ( cd "$SCRIPT_DIR" && npm install --no-audit --no-fund ) || die "npm install 실패"
+    log_ok "의존성 설치 완료"
+}
+
+# ── 6. 인프라 기동 + 마이그레이션 ────────────────────────────────────────────
+compose_up() {
+    log_step "6/8 PostgreSQL / Redis"
+    if [[ $SKIP_DOCKER -eq 1 ]]; then
+        log_info "--skip-docker — 컨테이너 기동을 건너뜁니다."
+        return 0
+    fi
+
+    # compose 파일이 infra/ 에 있으므로 project directory 도 infra/ 가 된다.
+    # → 루트 .env 를 --env-file 로 명시하지 않으면 POSTGRES_PASSWORD 가 비어 기동이 실패한다.
+    $DOCKER_COMPOSE --env-file "$SCRIPT_DIR/.env" -f "$SCRIPT_DIR/infra/docker-compose.yml" \
+        up -d postgres redis || die "PostgreSQL/Redis 기동 실패"
+
+    log_info "PostgreSQL 준비 대기"
+    local i
+    for ((i = 1; i <= HEALTH_RETRIES; i++)); do
+        if docker exec openmake-postgres pg_isready -U "$(env_value POSTGRES_USER)" \
+             -d "$(env_value POSTGRES_DB)" >/dev/null 2>&1; then
+            log_ok "PostgreSQL 준비 완료 (~$((i * HEALTH_INTERVAL))s)"
+            break
+        fi
+        [[ $i -eq $HEALTH_RETRIES ]] && die "PostgreSQL 기동 실패 — docker logs openmake-postgres 확인"
+        sleep "$HEALTH_INTERVAL"
+    done
+
+    docker exec openmake-redis redis-cli ping >/dev/null 2>&1 \
+        && log_ok "Redis 준비 완료" \
+        || log_warn "Redis ping 실패 — docker logs openmake-redis 확인"
+}
+
+run_migrations() {
+    log_step "7/8 DB 마이그레이션"
+    ( cd "$SCRIPT_DIR/apps/api" && npx ts-node src/data/migrations/cli.ts migrate ) \
+        || die "마이그레이션 실패 — DATABASE_URL 과 POSTGRES_PASSWORD 가 일치하는지 확인하세요."
+    log_ok "마이그레이션 완료"
+}
+
+# ── 7. 빌드 + 기동 ───────────────────────────────────────────────────────────
+build_app() {
+    log_step "8/8 빌드 & 기동"
+    if [[ $SKIP_BUILD -eq 1 ]]; then
+        log_info "--skip-build — 빌드를 건너뜁니다."
+        return 0
+    fi
+    log_info "npm run build (백엔드 tsc + 프론트 Next.js) — 수 분 걸릴 수 있습니다"
+    ( cd "$SCRIPT_DIR" && npm run build ) || die "빌드 실패"
+    log_ok "빌드 완료"
+}
+
+start_app() {
+    if [[ $NO_START -eq 1 ]]; then
+        log_info "--no-start — PM2 기동을 건너뜁니다. './openmake_llm.sh start' 로 직접 기동하세요."
+        return 0
+    fi
+
+    log_info "PM2 기동 (ecosystem.config.js)"
+    ( cd "$SCRIPT_DIR" && "$PM2_BIN" start ecosystem.config.js --update-env ) || die "PM2 기동 실패"
+
+    log_info "health check 대기 (최대 $((HEALTH_RETRIES * HEALTH_INTERVAL))s)"
+    local i
+    for ((i = 1; i <= HEALTH_RETRIES; i++)); do
+        if curl -fsS --max-time 3 "http://localhost:$APP_PORT/health" >/dev/null 2>&1; then
+            log_ok "API health check 성공 (~$((i * HEALTH_INTERVAL))s)"
+            return 0
+        fi
+        sleep "$HEALTH_INTERVAL"
+    done
+
+    log_err "health check 실패 — 최근 로그 50줄:"
+    "$PM2_BIN" logs openmake-llm --lines 50 --nostream 2>/dev/null || true
+    exit 3
+}
+
+# ── 마무리 안내 ──────────────────────────────────────────────────────────────
+summary() {
+    local admin_user admin_pass admin_email llm_url
+    admin_user="$(env_value ADMIN_INITIAL_USERNAME)"
+    admin_pass="$(env_value ADMIN_PASSWORD)"
+    admin_email="$(env_value DEFAULT_ADMIN_EMAIL)"
+    llm_url="$(env_value LLM_BASE_URL)"
+
+    printf "\n%s══════════════════════════════════════════════════════%s\n" "$C_OK" "$C_RESET"
+    printf "%s  OpenMake LLM 설치 완료%s\n" "$C_OK" "$C_RESET"
+    printf "%s══════════════════════════════════════════════════════%s\n\n" "$C_OK" "$C_RESET"
+
+    echo "  웹 UI     http://localhost:$WEB_PORT"
+    echo "  API       http://localhost:$APP_PORT   (health: /health)"
+    echo ""
+    echo "  로그인    ${admin_email:-admin@openmake.local}  (또는 사용자명 ${admin_user:-admin})"
+    echo "  비밀번호  ${admin_pass:-<.env 의 ADMIN_PASSWORD 참조>}"
+    printf "  %s첫 로그인 후 비밀번호를 바꾸세요. 비밀번호는 .env 에 평문으로 저장됩니다.%s\n" "$C_DIM" "$C_RESET"
+    echo ""
+    echo "  자주 쓰는 명령"
+    echo "    ./openmake_llm.sh status     상태 확인"
+    echo "    ./openmake_llm.sh logs       실시간 로그"
+    echo "    ./openmake_llm.sh stop       전체 정지"
+    echo "    ./openmake_llm.sh deploy     코드 변경 반영 (build + migrate + restart)"
+    echo ""
+
+    if [[ "$llm_url" == "http://localhost:4000" ]]; then
+        printf "  %s[할 일]%s LLM 엔드포인트가 아직 자리표시자입니다 — 채팅이 동작하지 않습니다.\n" "$C_WARN" "$C_RESET"
+        echo "         .env 의 LLM_BASE_URL / LLM_API_KEY / LLM_DEFAULT_MODEL 을 채운 뒤"
+        echo "         ./openmake_llm.sh restart 하세요."
+        echo ""
+    fi
+
+    printf "  %s부팅 시 자동 시작:%s  %s startup   후 안내되는 명령 실행 →  %s save\n\n" \
+        "$C_DIM" "$C_RESET" "${PM2_BIN:-pm2}" "${PM2_BIN:-pm2}"
+}
+
+# ── main ─────────────────────────────────────────────────────────────────────
+main() {
+    parse_args "$@"
+
+    printf "\n%s╔══════════════════════════════════════════════════╗%s\n" "$C_INFO" "$C_RESET"
+    printf "%s║        OpenMake LLM — 원샷 설치 (Linux/macOS)     ║%s\n" "$C_INFO" "$C_RESET"
+    printf "%s╚══════════════════════════════════════════════════╝%s\n" "$C_INFO" "$C_RESET"
+
+    detect_platform
+    has curl || log_warn "curl 미설치 — health check 를 건너뛰게 됩니다."
+
+    ensure_node
+    ensure_docker
+    ensure_pm2
+    setup_env
+    install_deps
+    compose_up
+    run_migrations
+    build_app
+    start_app
+    summary
+}
+
+main "$@"

--- a/openmake_llm.sh
+++ b/openmake_llm.sh
@@ -48,17 +48,28 @@ readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 readonly APP_NAME="openmake-llm"
 readonly FRONT_APP_NAME="openmake-next"
-readonly APP_PORT="${PORT:-52416}"
-readonly POSTGRES_PORT="${POSTGRES_PORT:-5432}"
-readonly REDIS_PORT="${REDIS_PORT:-6379}"
+
+# .env 에서 키 하나만 추출한다 (전체 source 안 함 — 값에 공백/특수문자가 있어도 안전).
+# `|| true` 필수: 키가 없으면 grep 이 1 로 끝나고 pipefail+set -e 가 스크립트를 즉시 종료시킨다.
+env_line() {
+    [[ -f "$SCRIPT_DIR/.env" ]] || return 0
+    grep -E "^$1=" "$SCRIPT_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2- | tr -d ' ' || true
+}
+
+# 포트 우선순위: 셸 환경변수 > .env > 기본값.
+# .env 를 봐야 하는 이유 — 기본 포트가 이미 점유돼 install.sh --postgres-port 등으로
+# 다른 포트에 띄운 경우, .env 를 무시하면 status/기동대기가 엉뚱한 포트를 본다.
+_app_port="${PORT:-$(env_line PORT)}"
+_pg_port="${POSTGRES_PORT:-$(env_line POSTGRES_PORT)}"
+_rd_port="${REDIS_PORT:-$(env_line REDIS_PORT)}"
+readonly APP_PORT="${_app_port:-52416}"
+readonly POSTGRES_PORT="${_pg_port:-5432}"
+readonly REDIS_PORT="${_rd_port:-6379}"
+
 # DB/Redis 는 docker compose 로 운영 (2026-06-21 brew postgresql@16 제거 → docker 단독).
 # COMPOSE_FILE 로 compose 위치 지정. 우선순위: 셸 환경변수 > .env > 기본값(레포의 infra/docker-compose.yml).
-# (.env 는 COMPOSE_FILE 한 줄만 추출, 전체 source 안 함)
-_compose_file_env=""
-# `|| true` 필수: COMPOSE_FILE 줄이 없으면 grep 이 1 로 끝나고 pipefail+set -e 가
-# 스크립트를 즉시 종료시킨다 (COMPOSE_FILE 을 안 쓰는 .env 가 정상 케이스).
-[[ -f "$SCRIPT_DIR/.env" ]] && _compose_file_env="$(grep -E '^COMPOSE_FILE=' "$SCRIPT_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2- | tr -d ' ' || true)"
-readonly COMPOSE_FILE="${COMPOSE_FILE:-${_compose_file_env:-$SCRIPT_DIR/infra/docker-compose.yml}}"
+_compose_file="${COMPOSE_FILE:-$(env_line COMPOSE_FILE)}"
+readonly COMPOSE_FILE="${_compose_file:-$SCRIPT_DIR/infra/docker-compose.yml}"
 readonly HEALTH_RETRIES=15
 readonly HEALTH_INTERVAL=2
 
@@ -186,7 +197,9 @@ wait_for_app_with_logs() {
 }
 
 # ── docker compose 헬퍼 (DB/Redis 운영) ──────────────────────────────────────
-# compose v2(docker compose) 우선, 없으면 v1(docker-compose) 폴백.
+# 플러그인형(docker compose) 우선, 없으면 standalone 바이너리(docker-compose) 폴백.
+# (Homebrew 는 플러그인을 기본 탐색 경로 밖에 두므로 standalone 폴백이 실제로 쓰인다.
+#  ~/.docker/config.json 자동 등록은 install.sh 담당 — 여기서 사용자 설정을 건드리지 않는다.)
 compose_cmd() {
     if docker compose version >/dev/null 2>&1; then
         echo "docker compose"

--- a/openmake_llm.sh
+++ b/openmake_llm.sh
@@ -11,6 +11,7 @@
 #       로컬 Ollama 데몬은 더 이상 기동하지 않는다. `LLM_*` 환경변수 참조.
 #
 # 사용법:
+#   ./openmake_llm.sh install    # 최초 1회 원샷 설치 (install.sh 위임)
 #   ./openmake_llm.sh start      # 의존성 → 앱 순서로 기동 (빌드/마이그레이션 X)
 #                                # 기동 후 실시간 로그 스트리밍 지속 (Ctrl+C로 종료)
 #   ./openmake_llm.sh stop       # 앱 → 의존성 역순으로 정지
@@ -24,11 +25,11 @@
 #   ./openmake_llm.sh logs       # OpenMake LLM 실시간 로그
 #   ./openmake_llm.sh health     # /health 엔드포인트 응답 확인
 #
-# 환경 가정 (macOS):
+# 환경 가정 (Linux / macOS 공통):
 #   - PostgreSQL/Redis는 docker compose 로 관리 (2026-06-21 brew postgresql@16 제거 → docker 단독)
 #     · compose 위치: ./infra/docker-compose.yml (COMPOSE_FILE env 로 override 가능)
 #   - OpenMake LLM 앱은 PM2로 관리
-#   - mise / nvm 등으로 Node 24+ 활성화 상태
+#   - Node 24+ 활성화 상태 (mise / nvm / fnm, 또는 install.sh 가 준비한 .openmake/toolchain.env)
 #
 # 종료 코드:
 #   0  성공
@@ -39,6 +40,12 @@
 set -euo pipefail
 
 readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# install.sh 가 홈 디렉터리에 Node/PM2 를 설치한 경우 그 PATH 를 이어받는다.
+# (시스템에 Node 24 / pm2 가 없어도 이 스크립트가 그대로 동작하도록.)
+# shellcheck source=/dev/null
+[[ -f "$SCRIPT_DIR/.openmake/toolchain.env" ]] && . "$SCRIPT_DIR/.openmake/toolchain.env"
+
 readonly APP_NAME="openmake-llm"
 readonly FRONT_APP_NAME="openmake-next"
 readonly APP_PORT="${PORT:-52416}"
@@ -48,7 +55,9 @@ readonly REDIS_PORT="${REDIS_PORT:-6379}"
 # COMPOSE_FILE 로 compose 위치 지정. 우선순위: 셸 환경변수 > .env > 기본값(레포의 infra/docker-compose.yml).
 # (.env 는 COMPOSE_FILE 한 줄만 추출, 전체 source 안 함)
 _compose_file_env=""
-[[ -f "$SCRIPT_DIR/.env" ]] && _compose_file_env="$(grep -E '^COMPOSE_FILE=' "$SCRIPT_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2- | tr -d ' ')"
+# `|| true` 필수: COMPOSE_FILE 줄이 없으면 grep 이 1 로 끝나고 pipefail+set -e 가
+# 스크립트를 즉시 종료시킨다 (COMPOSE_FILE 을 안 쓰는 .env 가 정상 케이스).
+[[ -f "$SCRIPT_DIR/.env" ]] && _compose_file_env="$(grep -E '^COMPOSE_FILE=' "$SCRIPT_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2- | tr -d ' ' || true)"
 readonly COMPOSE_FILE="${COMPOSE_FILE:-${_compose_file_env:-$SCRIPT_DIR/infra/docker-compose.yml}}"
 readonly HEALTH_RETRIES=15
 readonly HEALTH_INTERVAL=2
@@ -87,20 +96,40 @@ require_cmd() {
 
 preflight() {
     local missing=0
-    for cmd in docker pm2 curl node npm lsof; do
+    # lsof 는 필수가 아니다 — 리눅스 최소 이미지에는 없는 경우가 많아
+    # port_listening 이 ss/netstat//dev/tcp 로 대체한다.
+    for cmd in docker pm2 curl node npm; do
         if ! command -v "$cmd" >/dev/null 2>&1; then
             log_err "필수 명령 미설치: $cmd"
             missing=1
         fi
     done
-    [[ $missing -eq 0 ]] || exit 1
+    if [[ $missing -ne 0 ]]; then
+        log_info "최초 설치라면 './install.sh' 를 먼저 실행하세요."
+        exit 1
+    fi
 }
 
 # ── 포트 점검 헬퍼 ────────────────────────────────────────────────────────────
+# 도구 가용성이 배포판마다 달라 4단계로 폴백한다:
+#   lsof(macOS 기본) → ss(최신 리눅스) → netstat(구형) → bash /dev/tcp(무도구)
 port_listening() {
     local port="$1"
-    # nc는 macOS 기본 미설치 가능 — lsof로 대체
-    lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+    if command -v lsof >/dev/null 2>&1; then
+        lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1 && return 0
+        return 1
+    fi
+    if command -v ss >/dev/null 2>&1; then
+        ss -ltn "sport = :$port" 2>/dev/null | grep -q LISTEN && return 0
+        return 1
+    fi
+    if command -v netstat >/dev/null 2>&1; then
+        netstat -an 2>/dev/null | grep -qE "[.:]$port[[:space:]].*LISTEN" && return 0
+        return 1
+    fi
+    # 마지막 수단 — 실제 연결을 시도한다 (localhost 바인딩만 감지 가능).
+    (exec 3<>/dev/tcp/127.0.0.1/"$port") >/dev/null 2>&1 && return 0
+    return 1
 }
 
 wait_for_port() {
@@ -157,6 +186,17 @@ wait_for_app_with_logs() {
 }
 
 # ── docker compose 헬퍼 (DB/Redis 운영) ──────────────────────────────────────
+# compose v2(docker compose) 우선, 없으면 v1(docker-compose) 폴백.
+compose_cmd() {
+    if docker compose version >/dev/null 2>&1; then
+        echo "docker compose"
+    elif command -v docker-compose >/dev/null 2>&1; then
+        echo "docker-compose"
+    else
+        return 1
+    fi
+}
+
 ensure_docker_service() {
     # $1=up|down  $2=service  $3=label
     local action="$1" svc="$2" label="$3"
@@ -168,15 +208,28 @@ ensure_docker_service() {
         log_err "compose 파일을 찾을 수 없음: $COMPOSE_FILE"
         return 2
     fi
+
+    local dc
+    if ! dc="$(compose_cmd)"; then
+        log_err "docker compose 를 찾을 수 없음 (Compose v2 설치 필요)"
+        return 2
+    fi
+
+    # compose 파일이 infra/ 에 있으면 project directory 도 infra/ 라서 compose 가 infra/.env 를
+    # 찾는다 → 루트 .env 의 POSTGRES_PASSWORD 가 안 읽혀 `:?` 로 기동이 실패한다.
+    # 루트 .env 를 명시적으로 넘겨 이 함정을 없앤다.
+    local env_args=()
+    [[ -f "$SCRIPT_DIR/.env" ]] && env_args=(--env-file "$SCRIPT_DIR/.env")
+
     if [[ "$action" == "up" ]]; then
-        log_info "$label 시작 중 (docker compose up -d $svc)"
-        if ! docker compose -f "$COMPOSE_FILE" up -d "$svc" >/dev/null 2>&1; then
-            log_err "$label docker 기동 실패 — docker compose -f $COMPOSE_FILE logs $svc 확인"
+        log_info "$label 시작 중 ($dc up -d $svc)"
+        if ! $dc ${env_args[@]+"${env_args[@]}"} -f "$COMPOSE_FILE" up -d "$svc" >/dev/null 2>&1; then
+            log_err "$label docker 기동 실패 — $dc -f $COMPOSE_FILE logs $svc 확인"
             return 2
         fi
     else
-        log_info "$label 정지 중 (docker compose stop $svc)"
-        docker compose -f "$COMPOSE_FILE" stop "$svc" >/dev/null 2>&1 || log_warn "$label docker 정지 실패(이미 정지일 수 있음)"
+        log_info "$label 정지 중 ($dc stop $svc)"
+        $dc ${env_args[@]+"${env_args[@]}"} -f "$COMPOSE_FILE" stop "$svc" >/dev/null 2>&1 || log_warn "$label docker 정지 실패(이미 정지일 수 있음)"
     fi
 }
 
@@ -479,12 +532,23 @@ cmd_deploy() {
     show_status
 }
 
+cmd_install() {
+    local installer="$SCRIPT_DIR/install.sh"
+    [[ -x "$installer" ]] || { log_err "install.sh 를 찾을 수 없음: $installer"; return 2; }
+    log_step "원샷 설치 (install.sh 위임)"
+    exec "$installer" "$@"
+}
+
 usage() {
     cat <<EOF
 OpenMake LLM 통합 서비스 매니저
 
 사용법:
   $0 <command> [options]
+
+최초 설치:
+  install   toolchain 점검 → .env → 의존성 → DB → 빌드 → 기동 (install.sh 위임)
+            옵션은 './install.sh --help' 참고
 
 서비스 관리:
   start     PostgreSQL → Redis → OpenMake LLM 순차 기동
@@ -507,9 +571,9 @@ OpenMake LLM 통합 서비스 매니저
   logs      OpenMake LLM 실시간 로그 (PM2)
 
 환경 가정:
-  - macOS (DB/Redis 는 docker compose, 앱은 PM2 로 관리)
-  - PM2 전역 설치 (npm i -g pm2)
-  - Node 24+ (mise/nvm으로 활성)
+  - Linux / macOS (DB/Redis 는 docker compose, 앱은 PM2 로 관리)
+  - PM2 설치 (npm i -g pm2 — install.sh 가 자동 처리)
+  - Node 24+ (mise/nvm/fnm 또는 install.sh 가 만든 .openmake/toolchain.env)
 
 오버라이드 환경변수:
   PORT (기본 52416), POSTGRES_PORT (5432), REDIS_PORT (6379)
@@ -528,6 +592,7 @@ main() {
     local cmd="${1:-}"
     shift || true
     case "$cmd" in
+        install)  cmd_install "$@" ;;
         start)    cmd_start ;;
         stop)     cmd_stop ;;
         restart)  cmd_restart ;;

--- a/scripts/setup/gen-env.mjs
+++ b/scripts/setup/gen-env.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/**
+ * ==============================================================================
+ * OpenMake LLM — .env 생성/보수 (idempotent)
+ * ==============================================================================
+ * .env.example 은 1100줄 넘는 reference 문서라 그대로 복사하면 첫 부팅이 실패한다
+ * (JWT_SECRET / API_KEY_PEPPER / TOKEN_ENCRYPTION_KEY / ADMIN_PASSWORD 는 빈 값이면
+ *  production 부팅이 중단됨 — apps/api/src/config/env.schema.ts superRefine).
+ *
+ * 이 스크립트는 "부팅에 필요한 최소 집합"만 실제 값으로 채운 .env 를 만든다.
+ * 나머지 선택 설정은 .env.example 에서 필요할 때 골라 붙이면 된다.
+ *
+ * 동작:
+ *   .env 없음  → 신규 생성 (시크릿 랜덤 생성)
+ *   .env 있음  → 보수 모드: 빠진 필수 키만 파일 끝에 덧붙임. 기존 값은 절대 건드리지 않음
+ *   --force    → 기존 파일을 .env.bak.<타임스탬프> 로 백업하고 새로 생성
+ *
+ * 사용:
+ *   node scripts/setup/gen-env.mjs [--force] [--quiet]
+ *
+ * 입력(환경변수 — install.sh 가 주입, 미지정 시 기본값):
+ *   OMK_PORT(52416) OMK_WEB_PORT(3000) OMK_POSTGRES_PORT(5432) OMK_REDIS_PORT(6379)
+ *   OMK_LLM_BASE_URL OMK_LLM_API_KEY OMK_LLM_MODEL
+ *   OMK_ADMIN_USERNAME(admin) OMK_ADMIN_EMAIL(admin@openmake.local)
+ *
+ * 출력: 마지막 줄에 `GENERATED=1` 또는 `REPAIRED=<n>` 또는 `UNCHANGED=0` (install.sh 파싱용)
+ * ==============================================================================
+ */
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(HERE, '../..');
+const ENV_PATH = path.join(ROOT, '.env');
+
+const argv = process.argv.slice(2);
+const FORCE = argv.includes('--force');
+const QUIET = argv.includes('--quiet');
+
+const say = (msg) => { if (!QUIET) process.stderr.write(`${msg}\n`); };
+
+/** 64자 hex — JWT_SECRET / API_KEY_PEPPER / TOKEN_ENCRYPTION_KEY (후자는 정확히 64자 강제). */
+const hex32 = () => crypto.randomBytes(32).toString('hex');
+/** DATABASE_URL 에 그대로 들어가므로 URL 인코딩이 필요없는 문자만 사용. */
+const dbPassword = () => crypto.randomBytes(18).toString('hex');
+/** 사람이 한 번은 입력할 관리자 비밀번호 — 혼동되는 글자(0/O/l/1) 제외. */
+function adminPassword(len = 20) {
+    const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789';
+    const bytes = crypto.randomBytes(len);
+    let out = '';
+    for (let i = 0; i < len; i++) out += alphabet[bytes[i] % alphabet.length];
+    return out;
+}
+
+const env = (key, fallback) => {
+    const v = process.env[key];
+    return v !== undefined && v !== '' ? v : fallback;
+};
+
+const PORT = env('OMK_PORT', '52416');
+const WEB_PORT = env('OMK_WEB_PORT', '3000');
+const PG_PORT = env('OMK_POSTGRES_PORT', '5432');
+const REDIS_PORT = env('OMK_REDIS_PORT', '6379');
+const ADMIN_USERNAME = env('OMK_ADMIN_USERNAME', 'admin');
+const ADMIN_EMAIL = env('OMK_ADMIN_EMAIL', 'admin@openmake.local');
+const LLM_BASE_URL = env('OMK_LLM_BASE_URL', 'http://localhost:4000');
+const LLM_API_KEY = env('OMK_LLM_API_KEY', 'sk-no-key');
+const LLM_MODEL = env('OMK_LLM_MODEL', 'qwen3.6-35b-a3b');
+
+const PG_USER = 'openmake';
+const PG_DB = 'openmake_llm';
+
+/**
+ * 필수 키 정의. value 는 파일 생성 시점에 1회 평가된다.
+ * `section` 이 같은 항목끼리 묶여 출력된다.
+ */
+function buildEntries() {
+    const pgPass = dbPassword();
+    const adminPass = adminPassword();
+
+    return [
+        ['server', 'NODE_ENV', 'production', '실행 모드. dev 로 띄우려면 npm run dev 사용'],
+        ['server', 'PORT', PORT, 'API 서버 포트'],
+        ['server', 'SERVER_HOST', '0.0.0.0', '바인드 주소'],
+        ['server', 'LOG_LEVEL', 'info', 'error | warn | info | debug'],
+        ['server', 'OMK_APP_URL', `http://localhost:${WEB_PORT}`, '웹 UI 공개 주소'],
+        ['server', 'CORS_ORIGINS', `http://localhost:${WEB_PORT},http://127.0.0.1:${WEB_PORT},http://localhost:${PORT}`,
+            '쉼표 구분. production 에서 * 는 부팅 거부'],
+        ['server', 'COOKIE_SECURE', 'false', 'HTTPS 로 서비스하면 true 로 바꾸세요'],
+        ['server', 'ALLOW_INSECURE_COOKIES', 'true',
+            'HTTP 로컬 실행 허용(위 COOKIE_SECURE=false 의 명시적 opt-out). HTTPS 배포 시 false'],
+
+        ['secret', 'JWT_SECRET', hex32(), '세션 서명 키 — 바꾸면 모든 로그인 세션이 무효화됨'],
+        ['secret', 'API_KEY_PEPPER', hex32(), 'API Key 해시 pepper'],
+        ['secret', 'TOKEN_ENCRYPTION_KEY', hex32(), '외부 provider 자격증명 AES-256-GCM 키 (정확히 64 hex)'],
+
+        ['admin', 'ADMIN_PASSWORD', adminPass, '앱이 부팅 시 만드는 관리자 계정 비밀번호'],
+        ['admin', 'DEFAULT_ADMIN_EMAIL', ADMIN_EMAIL, '관리자 로그인 email'],
+        ['admin', 'ADMIN_EMAILS', ADMIN_EMAIL, '관리자 권한 email 목록(쉼표 구분)'],
+        ['admin', 'ADMIN_INITIAL_USERNAME', ADMIN_USERNAME, 'DB 최초 초기화 시 생성되는 계정 (db/init/004)'],
+        ['admin', 'ADMIN_INITIAL_EMAIL', ADMIN_EMAIL, ''],
+        ['admin', 'ADMIN_INITIAL_PASSWORD', adminPass, 'ADMIN_PASSWORD 와 동일하게 유지'],
+
+        ['infra', 'POSTGRES_USER', PG_USER, 'infra/docker-compose.yml 이 읽음'],
+        ['infra', 'POSTGRES_PASSWORD', pgPass, 'DATABASE_URL 의 비밀번호와 반드시 동일해야 함'],
+        ['infra', 'POSTGRES_DB', PG_DB, ''],
+        ['infra', 'POSTGRES_PORT', PG_PORT, ''],
+        ['infra', 'DATABASE_URL', `postgresql://${PG_USER}:${pgPass}@127.0.0.1:${PG_PORT}/${PG_DB}`, ''],
+        ['infra', 'REDIS_PORT', REDIS_PORT, ''],
+        ['infra', 'REDIS_URL', `redis://127.0.0.1:${REDIS_PORT}`, ''],
+        ['infra', 'STORAGE_BACKEND', 'redis', 'memory | redis. cluster 모드에서는 redis 필요'],
+
+        ['llm', 'LLM_BASE_URL', LLM_BASE_URL, 'OpenAI 호환 엔드포인트 (LiteLLM/vLLM/Ollama/OpenRouter …)'],
+        ['llm', 'LLM_API_KEY', LLM_API_KEY, '인증 없는 로컬 프록시면 sk-no-key 유지'],
+        ['llm', 'LLM_DEFAULT_MODEL', LLM_MODEL, '위 엔드포인트가 실제로 서빙하는 모델 ID'],
+    ];
+}
+
+const SECTION_TITLES = {
+    server: '서버 / 네트워크',
+    secret: '시크릿 (자동 생성됨 — 유출 금지, 재생성 시 세션·저장된 키가 무효화됨)',
+    admin: '관리자 계정',
+    infra: 'PostgreSQL / Redis (infra/docker-compose.yml 과 공유)',
+    llm: 'LLM 백엔드 (OpenAI 호환)',
+};
+
+function render(entries) {
+    const lines = [
+        '# ==============================================================================',
+        '# OpenMake LLM — 로컬 실행 설정 (install.sh 가 생성)',
+        '# ==============================================================================',
+        '# 부팅에 필요한 최소 집합만 들어있습니다.',
+        '# 선택 기능(OAuth, 웹검색 API, MCP 샌드박스, Discord 봇 등)은 .env.example 에서',
+        '# 필요한 항목만 골라 아래에 덧붙이세요.',
+        '#',
+        '# 이 파일은 .gitignore 대상입니다. 커밋하지 마세요.',
+        '# ==============================================================================',
+        '',
+    ];
+
+    let current = null;
+    for (const [section, key, value, comment] of entries) {
+        if (section !== current) {
+            current = section;
+            lines.push(`# ── ${SECTION_TITLES[section]} ${'─'.repeat(Math.max(3, 60 - SECTION_TITLES[section].length))}`);
+        }
+        if (comment) lines.push(`# ${comment}`);
+        lines.push(`${key}=${value}`);
+        lines.push('');
+    }
+    return lines.join('\n');
+}
+
+/** .env 에서 선언된 키 목록만 추출 (값 파싱은 하지 않는다 — 보수 판정용). */
+function declaredKeys(text) {
+    const keys = new Set();
+    for (const raw of text.split('\n')) {
+        const line = raw.trim();
+        if (!line || line.startsWith('#')) continue;
+        const m = line.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=/);
+        if (m) keys.add(m[1]);
+    }
+    return keys;
+}
+
+function timestamp() {
+    // Date 대신 파일 mtime 기반 고유값이 필요 없으므로 단순 난수 접미사를 쓴다.
+    return crypto.randomBytes(4).toString('hex');
+}
+
+function main() {
+    const exists = fs.existsSync(ENV_PATH);
+
+    if (exists && FORCE) {
+        const backup = `${ENV_PATH}.bak.${timestamp()}`;
+        fs.copyFileSync(ENV_PATH, backup);
+        say(`기존 .env 백업 → ${path.relative(ROOT, backup)}`);
+    }
+
+    if (!exists || FORCE) {
+        fs.writeFileSync(ENV_PATH, render(buildEntries()), { mode: 0o600 });
+        say(`.env 생성 완료 (권한 600)`);
+        process.stdout.write('GENERATED=1\n');
+        return;
+    }
+
+    // ── 보수 모드: 빠진 필수 키만 덧붙인다 ──────────────────────────────────
+    const text = fs.readFileSync(ENV_PATH, 'utf8');
+    const present = declaredKeys(text);
+    const missing = buildEntries().filter(([, key]) => !present.has(key));
+
+    if (missing.length === 0) {
+        say('.env 에 필수 키가 모두 있습니다 — 변경 없음');
+        process.stdout.write('UNCHANGED=0\n');
+        return;
+    }
+
+    // 보수로 채운 DATABASE_URL/POSTGRES_PASSWORD 가 서로 어긋나는 사고를 막는다:
+    // 둘 중 하나만 빠졌다면 자동 생성 값이 기존 값과 불일치할 수 있으므로 경고한다.
+    const pgPair = ['POSTGRES_PASSWORD', 'DATABASE_URL'];
+    const missingKeys = missing.map(([, k]) => k);
+    if (pgPair.some((k) => missingKeys.includes(k)) && !pgPair.every((k) => missingKeys.includes(k))) {
+        say('⚠ POSTGRES_PASSWORD 와 DATABASE_URL 중 하나만 없습니다.');
+        say('  자동 생성 값이 기존 값과 다를 수 있으니 두 값의 비밀번호가 같은지 직접 확인하세요.');
+    }
+
+    const appended = [
+        '',
+        '# ── install.sh 자동 보완 (빠져 있던 필수 키) ─────────────────────',
+        ...missing.flatMap(([, key, value, comment]) =>
+            (comment ? [`# ${comment}`] : []).concat([`${key}=${value}`])),
+        '',
+    ].join('\n');
+
+    fs.appendFileSync(ENV_PATH, appended);
+    say(`.env 보수 완료 — ${missing.length}개 키 추가: ${missingKeys.join(', ')}`);
+    process.stdout.write(`REPAIRED=${missing.length}\n`);
+}
+
+main();


### PR DESCRIPTION
## 배경

`feat/cross-platform-installer` (7/28, main 대비 84커밋 behind) 에 잔존하던 미머지 작업의 부활 — main 에서 새로 따서 두 커밋을 cherry-pick 하고 중복분을 정리했다. 공개 self-hosting 리포에 원샷 설치 진입점을 제공한다.

## 변경 (원 커밋 `19129009`·`aabb08ad` 기반)

- **`install.sh` (신규, 620줄)** — toolchain 점검(Node 24/Docker/PM2) → .env 생성 → 의존성 → DB 기동 → 마이그레이션 → 빌드 → PM2 → health check. 멱등 재실행, `--yes` 비대화형, `--postgres-port`/`--redis-port`, compose 플러그인 자동 복구, colima 지원
- **`scripts/setup/gen-env.mjs` (신규)** — 부팅 필수 키만 시크릿 랜덤 생성, 기존 .env 보존·보수
- **`ecosystem.config.js`** — next 경로 `require.resolve` (workspaces hoist 로 신규 클론 프론트 미기동 수정), discord-bot 은 dist 존재 시에만 등록, 포트/로그 경로 env 오버라이드 (기본값 불변 — 기존 운영 동작 동일)
- **`openmake_llm.sh`** — install 서브커맨드, Linux 대응(lsof→ss/netstat//dev/tcp 폴백), 포트 .env 읽기, COMPOSE_FILE 미존재 시 pipefail 종료 수정
- README 설치 절차 원샷 기준 재작성 (#434 배너·구성과 공존 확인)

## 원 브랜치와의 차이 (rebase 시 정리)

- **마이그레이션 011 수정 제거** — 동일 가드가 2026-07-31 별도 경로로 main 에 이미 반영됨 (이 PR 은 db/ 무변경)
- package-lock 은 main(v1.21.0) 버전 유지

## 검증

- [x] `bash -n` install.sh·openmake_llm.sh / `node --check` gen-env.mjs·ecosystem.config.js
- [x] 충돌 마커 0 · db/migrations diff 0 · README #434 구성과 병합 정합
- [x] ecosystem 기본값 불변 (pm2 delete→start 전까지 운영 무영향)
- 원 커밋은 신규 설치 라이브 E2E 실측 검증 이력 있음 (health/UI/로그인/멱등 — 커밋 메시지 참고). 84커밋 이후의 재-E2E 는 별도 클린 환경 필요으로 범위 외

머지 후 구 브랜치 `feat/cross-platform-installer` 삭제 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)