### PR TITLE
feat(agent-task): 실행 스텝→플랜 노드 귀속 계측 (Execution Graph 증분 2)

### DIFF
--- a/apps/api/src/data/models/unified-database.ts
+++ b/apps/api/src/data/models/unified-database.ts
@@ -369,17 +369,8 @@ export class UnifiedDatabase {
         return this.agentTaskRepository.updateAgentTask(taskId, updates);
     }
 
-    async addAgentTaskStep(params: {
-        taskId: string;
-        stepNumber: number;
-        stepType: string;
-        toolName?: string;
-        content?: string;
-        messagesSnapshot?: unknown;
-        status?: string;
-        /** 스텝 기록 시점의 in_progress 플랜 단계 인덱스(0-base) — 노드별 비용/정합 집계(088). */
-        planStepIndex?: number;
-    }): Promise<void> {
+    // 파라미터 계약은 repository 가 SoT — 중복 선언하면 필드 추가 시 양쪽이 어긋난다(088 에서 정리).
+    async addAgentTaskStep(params: Parameters<AgentTaskRepository['addAgentTaskStep']>[0]): Promise<void> {
         return this.agentTaskRepository.addAgentTaskStep(params);
     }
 

--- a/apps/api/src/data/models/unified-database.ts
+++ b/apps/api/src/data/models/unified-database.ts
@@ -377,6 +377,8 @@ export class UnifiedDatabase {
         content?: string;
         messagesSnapshot?: unknown;
         status?: string;
+        /** 스텝 기록 시점의 in_progress 플랜 단계 인덱스(0-base) — 노드별 비용/정합 집계(088). */
+        planStepIndex?: number;
     }): Promise<void> {
         return this.agentTaskRepository.addAgentTaskStep(params);
     }

--- a/apps/api/src/data/repositories/agent-task-repository.ts
+++ b/apps/api/src/data/repositories/agent-task-repository.ts
@@ -149,14 +149,16 @@ export class AgentTaskRepository extends BaseRepository {
         content?: string;
         messagesSnapshot?: unknown;
         status?: string;
+        /** 스텝 기록 시점의 in_progress 플랜 단계 인덱스(0-base) — 노드별 비용/정합 집계(088). */
+        planStepIndex?: number;
     }): Promise<void> {
         // NUL(0x00) 제거 — 바이너리 파일을 도구로 열람하면 도구 결과에 0x00 이 섞일 수 있고,
         // Postgres TEXT/JSON 은 이를 거부한다("invalid byte sequence for encoding UTF8: 0x00").
         // 저장 backstop 으로 content·messages_snapshot 모두 정화한다(resultToString 소스 차단과 병행).
         const stripNul = (s: string): string => s.replace(/\u0000/g, '');
         await this.query(
-            `INSERT INTO agent_task_steps (task_id, step_number, step_type, tool_name, content, messages_snapshot, status)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+            `INSERT INTO agent_task_steps (task_id, step_number, step_type, tool_name, content, messages_snapshot, status, plan_step_index)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
             [
                 params.taskId,
                 params.stepNumber,
@@ -164,7 +166,8 @@ export class AgentTaskRepository extends BaseRepository {
                 params.toolName,
                 params.content != null ? stripNul(params.content) : params.content,
                 params.messagesSnapshot !== undefined ? stripNul(JSON.stringify(params.messagesSnapshot)) : null,
-                params.status || 'completed'
+                params.status || 'completed',
+                params.planStepIndex ?? null
             ]
         );
     }

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -34,6 +34,7 @@ import { mergeToolsWithSkills, type ActiveSkillBinding } from './chat-service/to
 import { filterRestrictedTools } from './chat-service/tool-restrictions';
 import { TaskRuntime } from './task-sandbox/runtime';
 import { getApprovalRegistry } from './task-sandbox/approval-gate';
+import { currentPlanStepIndex } from './task-sandbox/planning';
 import { applyTurnResourceGates, type TurnGateFlags } from './agent-task/turn-gate';
 import { buildFileContext } from './chat-service/attach-context';
 import { AgentTaskAbort, assertWithinLimits, type AgentTaskRunInput } from './agent-task/types';
@@ -128,6 +129,9 @@ export class AgentTaskService {
         let verifyRetries = 0;
         // 5-3(b): 실제 사용한 도구 추적 — goal judge 의 실행 컨텍스트(수행 흔적)로 전달.
         const usedTools = new Set<string>();
+        // 스텝→플랜 노드 귀속(088): 기록 시점의 in_progress 단계 인덱스(결정적, 추정 귀속 없음).
+        const planIdx = (): number | undefined =>
+            taskRuntime ? currentPlanStepIndex(taskRuntime.getPlanSnapshot()) : undefined;
 
         // DB 갱신 + 진행상황 발행(fire-and-forget). ws 계층이 구독해 owner user 에게 relay.
         // ws 를 직접 참조하지 않으므로 소켓 연결 여부와 무관하게 실행은 끝까지 진행된다.
@@ -315,7 +319,7 @@ export class AgentTaskService {
                     // 일시적 오류 재시도를 스텝으로 남긴다 — 발동 빈도·사유를 DB 로 집계(fail-open).
                     onRetry: ({ attempt, maxAttempts, error }) => {
                         const note = `일시적 LLM 오류 — 재시도 ${attempt}/${maxAttempts}: ${error}`;
-                        void db.addAgentTaskStep({ taskId, stepNumber: stepNumber++, stepType: 'retry', content: note })
+                        void db.addAgentTaskStep({ taskId, stepNumber: stepNumber++, stepType: 'retry', content: note, planStepIndex: planIdx() })
                             .catch(() => { /* 관측 실패가 작업을 죽이지 않게 fail-open */ });
                         emitStep('retry', undefined, note);
                     },
@@ -403,6 +407,7 @@ export class AgentTaskService {
                     stepType,
                     toolName: turnToolNames,
                     content: stepContent,
+                    planStepIndex: planIdx(),
                 });
                 emitStep(stepType, turnToolNames, stepContent);
 

--- a/apps/api/src/services/agent-task/turn-executor.ts
+++ b/apps/api/src/services/agent-task/turn-executor.ts
@@ -13,6 +13,7 @@ import { getPushService } from '../PushService';
 import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
 import { TASK_TERMINATE_SENTINEL } from '../task-sandbox/tools';
 import { requiresApproval, getApprovalRegistry } from '../task-sandbox/approval-gate';
+import { currentPlanStepIndex } from '../task-sandbox/planning';
 import { runTool, isSearchTool } from './task-steps';
 import { AgentTaskAbort } from './types';
 import type { TaskRuntime } from '../task-sandbox/runtime';
@@ -149,6 +150,8 @@ export async function executeTurnToolCalls(input: TurnToolExecInput): Promise<Tu
             stepType: 'tool_result',
             toolName: name,
             content: toolResult,
+            // 스텝→플랜 노드 귀속(088) — plan_update 직후엔 갱신된 스냅샷 기준(새 단계로 귀속).
+            planStepIndex: taskRuntime ? currentPlanStepIndex(taskRuntime.getPlanSnapshot()) : undefined,
         });
         emitStep('tool_result', name, toolResult);
         // 턴 중간 체크포인트(6-4, opt-in): 도구 결과 단위로 저장 — 이 시점 conversation 은

--- a/apps/api/src/services/task-sandbox/planning.test.ts
+++ b/apps/api/src/services/task-sandbox/planning.test.ts
@@ -1,4 +1,4 @@
-import { TaskPlan } from './planning';
+import { TaskPlan, currentPlanStepIndex } from './planning';
 
 describe('TaskPlan', () => {
     it('create → 모든 단계 not_started, 빈 문자열 제거', () => {
@@ -61,5 +61,24 @@ describe('TaskPlan', () => {
         expect(s[1]).toMatchObject({ text: 'B', status: 'in_progress', note: '진행중' });
         expect(s[2]).toMatchObject({ text: 'D', status: 'not_started' });
         expect(p.length).toBe(3);
+    });
+});
+
+describe('currentPlanStepIndex (088 스텝→플랜 노드 귀속)', () => {
+    const step = (status: 'not_started' | 'in_progress' | 'completed' | 'blocked') =>
+        ({ text: 's', status });
+
+    it('첫 in_progress 단계의 0-base 인덱스', () => {
+        expect(currentPlanStepIndex([step('completed'), step('in_progress'), step('not_started')])).toBe(1);
+    });
+
+    it('in_progress 복수면 첫 번째', () => {
+        expect(currentPlanStepIndex([step('in_progress'), step('in_progress')])).toBe(0);
+    });
+
+    it('in_progress 없으면 undefined — 추정 귀속(첫 미완료 등) 금지', () => {
+        expect(currentPlanStepIndex([step('completed'), step('not_started')])).toBeUndefined();
+        expect(currentPlanStepIndex([step('blocked')])).toBeUndefined();
+        expect(currentPlanStepIndex([])).toBeUndefined();
     });
 });

--- a/apps/api/src/services/task-sandbox/planning.ts
+++ b/apps/api/src/services/task-sandbox/planning.ts
@@ -25,6 +25,17 @@ const STATUS_MARK: Record<PlanStepStatus, string> = {
     blocked: '[!]',
 };
 
+/**
+ * PURE: 스텝→플랜 노드 귀속(088) — 현재 in_progress 단계의 0-base 인덱스.
+ * 엄격 판정: 모델이 in_progress 로 마킹한 단계가 없으면 undefined(NULL 저장) —
+ * "첫 미완료 단계" 같은 추정 귀속은 하지 않는다(정합률 계측이 목적이므로 날조 금지).
+ * in_progress 가 복수면 첫 번째(모델이 순차 마킹하는 정상 흐름 기준).
+ */
+export function currentPlanStepIndex(steps: PlanStep[]): number | undefined {
+    const i = steps.findIndex((s) => s.status === 'in_progress');
+    return i < 0 ? undefined : i;
+}
+
 /** task 실행 계획. 단계 목록 + 상태. 순수 로직(유닛테스트 대상). */
 export class TaskPlan {
     private steps: PlanStep[] = [];

--- a/db/migrations/088_agent_task_step_plan_index.sql
+++ b/db/migrations/088_agent_task_step_plan_index.sql
@@ -1,0 +1,10 @@
+-- 088: 실행 스텝 → 플랜 노드 귀속 (Execution Graph 증분 2 — 노드 실체화 계측)
+--
+-- plan(계획)과 steps(실행 로그)는 각각 존재하지만 연결이 없어, 노드별 비용/정합
+-- 실측과 노드 속성(완료 기준·비용 한도) 부착 지점이 없었다. 스텝 기록 시점의
+-- "현재 in_progress 플랜 단계 인덱스"를 결정적으로 스탬프한다 (LLM 판단 없음).
+-- plan 이 없는 task / 플랜 외 구간은 NULL — 기존 행·기존 동작 무영향.
+ALTER TABLE agent_task_steps ADD COLUMN IF NOT EXISTS plan_step_index INTEGER;
+
+COMMENT ON COLUMN agent_task_steps.plan_step_index IS
+    '스텝 기록 시점에 in_progress 였던 플랜 단계 인덱스(0-base). plan 부재/플랜 외 구간은 NULL. 노드별 비용·정합 집계용 (088)';


### PR DESCRIPTION
## 배경

Execution Graph 로드맵의 다음 증분 — plan(계획)과 steps(실행 로그)는 각각 존재하지만 연결이 없어, 노드별 비용/정합 실측과 노드 속성(완료 기준·비용 한도·HITL 분기)의 부착 지점이 없었다. **행동 무변경, 계측만** 추가한다.

## 변경

- **마이그레이션 088**: `agent_task_steps.plan_step_index` (nullable int, 멱등 ADD COLUMN — 기존 행·기존 task 무영향, 부팅 자동 적용)
- **`currentPlanStepIndex` (순수 함수)**: 첫 `in_progress` 단계의 0-base 인덱스, 없으면 `undefined`(NULL 저장). **추정 귀속 금지** — 정합률 계측이 목적이므로 '첫 미완료 단계' 같은 날조를 하지 않는다
- **스탬핑 (결정적, LLM 판단 0)**: assistant*/plan 스텝(호출 의도), tool_result(turn-executor — plan_update 직후엔 갱신 스냅샷 기준), retry. 관리 이벤트(final_turn/hitl_degrade/steering/diff)는 의도적으로 NULL

## 후향 실측 (기존 데이터 plan 렌더 [~] 마커 재구성)

| 지표 | 값 |
|---|---|
| plan 보유 task | 36/146 (25%) |
| plan 렌더 중 in_progress 마킹 존재 | 40% — 모델이 [~] 생략, completed 직행 패턴 |
| 도구 스텝 노드 귀속 가능률 (엄격 기준) | **~45%** |
| 귀속 노드당 도구 호출 | p50 4회 · max 26회 |

커버리지 45%의 원인은 구조가 아니라 모델의 마킹 습관 — 마킹 유도 프롬프트 도입 여부는 이 컬럼의 전향 데이터로 결정한다(measure-first, 지금은 프롬프트 무변경).

## 확보하는 것

노드당 비용 분포 → 비용 한도 노드화 근거 · 플랜↔실행 정합률 → 그래프 실행기 go/no-go 게이트 · 이후 노드별 완료 기준·HITL 독립 분기의 부착 지점

## 체크리스트

- [x] tsc · 관련 jest 19 suites/148 tests(신규 3) · eslint 통과
- [x] DB 마이그레이션 포함 (088, 순번 충돌 없음, 멱등) · 환경변수 추가 없음 · UI 무변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)