### PR TITLE
feat(agent-task): 플랜 자동 진행 — 마킹 공백 결정적 승격 (Execution Graph 증분 3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -830,6 +830,10 @@ AGENT_TASK_TIMEOUT_MS=600000
 # AGENT_TASK_TURN_RETRY_MAX=2
 # AGENT_TASK_TURN_RETRY_BACKOFF_MS=2000
 
+# Agent Task — 플랜 자동 진행. 단계 완료/차단 후 in_progress 가 없으면 첫 not_started 를
+# 자동 승격(모델이 [~] 마킹을 생략해도 스텝→노드 귀속·진행 표시가 비지 않게). 기본 ON.
+# AGENT_TASK_PLAN_AUTO_ADVANCE=true
+
 # Agent Task — HITL 무응답 강등. 승인 무응답(timeout, 명시 거절 아님)이 이 횟수에 달하면
 # 이후 턴에서 승인 필요 도구(+ask_human)를 제거하고 확보한 정보로 최종 산출물 작성을 유도.
 # 방치된 task 가 승인 대기(TASK_SANDBOX_APPROVAL_TIMEOUT_MS, 기본 30분)×N 반복으로 예산만

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1289,6 +1289,11 @@ export const AGENT_TASK_LIMITS = {
     /** 턴 재시도 지수 백오프 기저(ms) — n번째 재시도 전 기저 × 2^(n-1) 대기(abort 시 즉시 중단).
      *  AGENT_TASK_TURN_RETRY_BACKOFF_MS 로 오버라이드(기본 2초). */
     TURN_RETRY_BACKOFF_MS: parseInt(process.env.AGENT_TASK_TURN_RETRY_BACKOFF_MS || '', 10) || 2_000,
+    /** 플랜 자동 진행(088 증분 3) — 단계 완료/차단 후 in_progress 가 없으면 첫 not_started 를
+     *  결정적으로 승격. 모델이 [~] 마킹을 생략해도(후향 60%, 명시 지시에도 라이브 재현)
+     *  스텝→노드 귀속(plan_step_index)·진행 표시가 비지 않게 한다. 모델의 명시 마킹이 우선.
+     *  AGENT_TASK_PLAN_AUTO_ADVANCE=false 로 비활성(기본 on). */
+    PLAN_AUTO_ADVANCE: process.env.AGENT_TASK_PLAN_AUTO_ADVANCE !== 'false',
     /** HITL 무응답 강등 — 승인 무응답(timeout, 명시 거절 아님)이 이 횟수에 달하면 이후 턴에서
      *  승인 필요 도구(+ask_human)를 제거하고 확보한 정보로 마무리를 유도한다. 후향 실측: 방치
      *  task 가 승인 대기(30분)×N 반복으로 예산만 소진하고 산출물 0 으로 종결되던 패턴 차단.

--- a/apps/api/src/services/task-sandbox/planning.test.ts
+++ b/apps/api/src/services/task-sandbox/planning.test.ts
@@ -82,3 +82,47 @@ describe('currentPlanStepIndex (088 스텝→플랜 노드 귀속)', () => {
         expect(currentPlanStepIndex([])).toBeUndefined();
     });
 });
+
+describe('TaskPlan autoAdvance (088 증분 3 — 마킹 공백 자동 승격)', () => {
+    it('create 직후 첫 단계가 in_progress 로 승격', () => {
+        const p = new TaskPlan({ autoAdvance: true });
+        p.create(['A', 'B']);
+        expect(p.snapshot().map((s) => s.status)).toEqual(['in_progress', 'not_started']);
+    });
+
+    it('completed 전이 후 in_progress 부재면 다음 not_started 승격 — [~] 생략 흐름 보정', () => {
+        const p = new TaskPlan({ autoAdvance: true });
+        p.create(['A', 'B', 'C']);
+        p.update(1, 'completed'); // 모델이 2를 in_progress 마킹 안 해도
+        expect(p.snapshot().map((s) => s.status)).toEqual(['completed', 'in_progress', 'not_started']);
+    });
+
+    it('모델의 명시 in_progress 마킹이 우선 — 이미 있으면 승격 안 함', () => {
+        const p = new TaskPlan({ autoAdvance: true });
+        p.create(['A', 'B', 'C']);
+        p.update(3, 'in_progress'); // 모델이 순서를 건너뛰어 3을 지목
+        p.update(1, 'completed');
+        expect(p.snapshot().map((s) => s.status)).toEqual(['completed', 'not_started', 'in_progress']);
+    });
+
+    it('blocked 전이 후에도 다음 단계 승격(선형 진행 유지)', () => {
+        const p = new TaskPlan({ autoAdvance: true });
+        p.create(['A', 'B']);
+        p.update(1, 'blocked');
+        expect(p.snapshot().map((s) => s.status)).toEqual(['blocked', 'in_progress']);
+    });
+
+    it('명시 not_started 강등은 존중 — 재승격 안 함', () => {
+        const p = new TaskPlan({ autoAdvance: true });
+        p.create(['A', 'B']);
+        p.update(1, 'not_started'); // 강등(in_progress 전이가 아니므로 advance 미호출)
+        expect(p.snapshot()[0].status).toBe('not_started');
+    });
+
+    it('autoAdvance 미설정(기본) — 기존 동작 그대로', () => {
+        const p = new TaskPlan();
+        p.create(['A', 'B']);
+        p.update(1, 'completed');
+        expect(p.snapshot().map((s) => s.status)).toEqual(['completed', 'not_started']);
+    });
+});

--- a/apps/api/src/services/task-sandbox/planning.ts
+++ b/apps/api/src/services/task-sandbox/planning.ts
@@ -40,6 +40,19 @@ export function currentPlanStepIndex(steps: PlanStep[]): number | undefined {
 export class TaskPlan {
     private steps: PlanStep[] = [];
 
+    /** autoAdvance(088 증분 3): 모델이 [~] 마킹을 생략해도(후향 실측 60%, 명시 지시에도
+     *  라이브 재현) 활성 단계가 비지 않게, 상태 변화 후 in_progress 가 없으면 첫 not_started
+     *  를 결정적으로 승격한다. 선형 실행 가정(모델의 정상 흐름) — 모델의 명시 마킹이 항상 우선. */
+    constructor(private readonly opts: { autoAdvance?: boolean } = {}) {}
+
+    /** in_progress 부재 시 첫 not_started 승격 — create/완료·차단 전이 후에만 호출(명시 강등은 존중). */
+    private maybeAdvance(): void {
+        if (!this.opts.autoAdvance) return;
+        if (this.steps.some((s) => s.status === 'in_progress')) return;
+        const next = this.steps.find((s) => s.status === 'not_started');
+        if (next) next.status = 'in_progress';
+    }
+
     /** 계획 생성/교체 — 상태 보존 병합(4-3). 모델이 plan_create 를 재호출해도(라이브에서 관찰된
      *  행동) 텍스트가 동일한 기존 단계의 status/note 는 보존하고, 신규 단계만 not_started 로
      *  시작한다. 진행률(plan 완료율)·가시성이 재호출로 리셋되던 문제 방지. */
@@ -54,6 +67,7 @@ export class TaskPlan {
                     ? { text, status: old.status, ...(old.note !== undefined ? { note: old.note } : {}) }
                     : { text, status: 'not_started' as PlanStepStatus };
             });
+        this.maybeAdvance();
     }
 
     /** 단계 상태 갱신(1-based index). 범위 밖이면 false. */
@@ -62,6 +76,8 @@ export class TaskPlan {
         if (idx < 0 || idx >= this.steps.length) return false;
         this.steps[idx].status = status;
         if (note !== undefined) this.steps[idx].note = note;
+        // 완료/차단 전이 후에만 자동 승격 — 명시 not_started 강등은 존중(재승격 안 함).
+        if (status === 'completed' || status === 'blocked') this.maybeAdvance();
         return true;
     }
 

--- a/apps/api/src/services/task-sandbox/runtime.ts
+++ b/apps/api/src/services/task-sandbox/runtime.ts
@@ -57,7 +57,7 @@ export class TaskRuntime {
     readonly userId: string;
     private readonly cfg: TaskSandboxConfig;
     private readonly executor: TaskExecutor;
-    private readonly plan = new TaskPlan();
+    private readonly plan = new TaskPlan({ autoAdvance: AGENT_TASK_LIMITS.PLAN_AUTO_ADVANCE });
     private readonly handlers = new Map<string, MCPToolDefinition['handler']>();
     private readonly defs: MCPToolDefinition[];
 


### PR DESCRIPTION
## 배경

증분 2(#439, plan_step_index)의 후향 실측에서 **모델이 [~](in_progress) 마킹을 60% 생략**해 엄격 귀속 커버리지가 ~45%에 그쳤고, 라이브 E2E 에선 **goal 에 마킹을 명시 지시했는데도** 2단계 마킹을 생략했다(프롬프트 지시로는 부족하다는 증거). 활성 단계가 비는 구간을 결정적 보정으로 닫는다.

## 변경

- `TaskPlan({ autoAdvance })`: **create 직후** 및 **completed/blocked 전이 후**, in_progress 가 없으면 첫 not_started 를 승격 (LLM 판단 0 — 선형 실행 가정, 모델의 정상 흐름과 동일)
- **모델의 명시 마킹이 항상 우선** — 이미 in_progress 가 있으면 무동작(비순차 실행 지원), 명시 not_started 강등은 존중(재승격 안 함)
- 프롬프트 무변경 · `AGENT_TASK_PLAN_AUTO_ADVANCE=false` 로 비활성(기본 on)

## 효과

- `plan_step_index` 귀속 커버리지 상승 → 노드별 비용/정합 실측의 데이터 밀도 확보 (다음 게이트: 노드별 완료 기준·HITL 독립 분기)
- 플랜 진행 표시([~])가 실행 중 항상 현재 단계를 가리킴 (UI 부수 개선)

## 체크리스트

- [x] tsc · 관련 jest 27 suites/235 tests(신규 6) · eslint 통과
- [x] DB 스키마 변경 없음 · env 1건 추가 → `.env.example` 갱신 · UI 무변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)