### PR TITLE
feat(web): 작업 상세 스텝에 플랜 노드 뱃지 (plan_step_index 가시화)

### DIFF
--- a/apps/web/app/(workspace)/agent-tasks/page.tsx
+++ b/apps/web/app/(workspace)/agent-tasks/page.tsx
@@ -102,6 +102,8 @@ interface ApiTaskStep {
   tool_name?: string;
   tool_input?: Record<string, unknown>;
   tool_output?: string;
+  /** 스텝 기록 시점의 플랜 단계 인덱스(0-base, 088) — 없으면 플랜 외 구간 */
+  plan_step_index?: number | null;
   created_at?: string;
 }
 
@@ -450,6 +452,9 @@ function TaskDetailModal({
                       <div className="pb-3 min-w-0 flex-1">
                         <div className="flex items-center gap-2 text-xs text-muted mb-0.5">
                           <Badge tone="neutral">{stepType ?? "step"}</Badge>
+                          {typeof step.plan_step_index === "number" && (
+                            <Badge tone="accent">{t("planNode", { n: step.plan_step_index + 1 })}</Badge>
+                          )}
                           {step.tool_name && <span className="font-mono">{step.tool_name}</span>}
                         </div>
                         {body && (isDiff ? (

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -780,7 +780,8 @@
       "max_turns_exhausted": "Turn/resource limit reached",
       "interrupted": "Interrupted by server restart",
       "resumableHint": "Can be resumed"
-    }
+    },
+    "planNode": "Step {n}"
   },
   "customAgents": {
     "pageTitle": "Custom Agents",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -780,7 +780,8 @@
       "max_turns_exhausted": "ターン・リソース上限に到達",
       "interrupted": "サーバー再起動により中断",
       "resumableHint": "再開できます"
-    }
+    },
+    "planNode": "ステップ{n}"
   },
   "customAgents": {
     "pageTitle": "カスタムエージェント",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -780,7 +780,8 @@
       "max_turns_exhausted": "턴·자원 상한 소진",
       "interrupted": "서버 재시작으로 중단",
       "resumableHint": "이어하기로 재개할 수 있습니다"
-    }
+    },
+    "planNode": "{n}단계"
   },
   "customAgents": {
     "pageTitle": "커스텀 에이전트",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -780,7 +780,8 @@
       "max_turns_exhausted": "已达轮次/资源上限",
       "interrupted": "因服务器重启而中断",
       "resumableHint": "可继续执行"
-    }
+    },
+    "planNode": "步骤{n}"
   },
   "customAgents": {
     "pageTitle": "自定义智能体",


### PR DESCRIPTION
## 변경

Execution Graph 증분 2·3으로 영속되기 시작한 **스텝→플랜 노드 귀속**(`plan_step_index`, 088 + autoAdvance)을 작업 상세 타임라인에 노출한다 — 각 스텝에 어느 플랜 단계 소속인지 **'{n}단계' accent 뱃지** 표시(플랜 외 구간은 뱃지 없음).

- 프론트만 변경 — 백엔드 steps 응답(`SELECT *`)에 컬럼이 이미 실려 있음
- `agentTasks.planNode` 신규 키 4로케일 (check:i18n 1234키 정합)

## 체크리스트

- [x] apps/web tsc · eslint · check:i18n · `next build` 통과
- [x] 백엔드·스키마·환경변수 무변경
- [ ] 배포 후 라이브 확인 코멘트 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)