### PR TITLE
feat(admin): 관리자 전용 전체 대화 조회 화면 분리

### DIFF
--- a/apps/api/src/controllers/__tests__/session-access.test.ts
+++ b/apps/api/src/controllers/__tests__/session-access.test.ts
@@ -1,4 +1,4 @@
-import { evaluateSessionAccess } from '../session.controller';
+import { evaluateSessionAccess, resolveSessionListScope } from '../session.controller';
 
 type SessionLike = { userId?: string; anonSessionId?: string };
 
@@ -40,5 +40,29 @@ describe('evaluateSessionAccess — IDOR 회귀', () => {
 
     test('세션이 없으면 (비-admin) 접근 불가', () => {
         expect(evaluateSessionAccess(undefined, { userId: 'u-owner', isAdmin: false })).toBe(false);
+    });
+});
+
+describe('resolveSessionListScope — 관리자 전체 조회 옵트인', () => {
+    // 🔴 회귀 방어: 과거엔 관리자 기본이 전체 조회라 개인 히스토리·사이드바에
+    // 모든 사용자의 대화가 섞여 노출됐다. 전체 조회는 viewAll=true 옵트인만 허용.
+    test('관리자도 viewAll 없이는 자신의 세션만', () => {
+        expect(resolveSessionListScope({ isAdmin: true, viewAll: false, userId: 'u-admin' })).toBe('user');
+    });
+
+    test('관리자 + viewAll=true 는 전체 조회', () => {
+        expect(resolveSessionListScope({ isAdmin: true, viewAll: true, userId: 'u-admin' })).toBe('all');
+    });
+
+    test('비관리자의 viewAll 은 무시 — 자신의 세션만', () => {
+        expect(resolveSessionListScope({ isAdmin: false, viewAll: true, userId: 'u-user' })).toBe('user');
+    });
+
+    test('비로그인 + anonSessionId 는 익명 스코프', () => {
+        expect(resolveSessionListScope({ isAdmin: false, viewAll: false, anonSessionId: 'anon-abc' })).toBe('anon');
+    });
+
+    test('비로그인 + viewAll 도 무시 — 인증 정보 없으면 none', () => {
+        expect(resolveSessionListScope({ isAdmin: false, viewAll: true })).toBe('none');
     });
 });

--- a/apps/api/src/controllers/session.controller.ts
+++ b/apps/api/src/controllers/session.controller.ts
@@ -41,6 +41,31 @@ export function evaluateSessionAccess(
     return false;
 }
 
+/** 세션 목록 조회 범위 (순수 함수 — 단위 테스트 가능) */
+export type SessionListScope = 'all' | 'user' | 'anon' | 'none';
+
+/**
+ * 세션 목록 조회 범위 판정.
+ *
+ * 관리자 전체 조회는 명시적 옵트인(`viewAll=true`, 관리자 전용 화면 /admin/conversations 사용)
+ * 으로만 허용한다 — 과거엔 관리자 기본이 전체 조회라 개인 히스토리·사이드바에
+ * 모든 사용자의 대화가 섞여 노출됐다. 비관리자의 viewAll 은 무시된다.
+ */
+export function resolveSessionListScope(
+    ctx: { isAdmin: boolean; viewAll: boolean; userId?: string; anonSessionId?: string },
+): SessionListScope {
+    if (ctx.isAdmin && ctx.viewAll) {
+        return 'all';
+    }
+    if (ctx.userId) {
+        return 'user';
+    }
+    if (ctx.anonSessionId) {
+        return 'anon';
+    }
+    return 'none';
+}
+
 /**
  * 대화 세션 관리 컨트롤러
  * 
@@ -78,24 +103,26 @@ export class SessionController {
          this.router.get('/', optionalAuth, asyncHandler(async (req: Request, res: Response) => {
              const user = req.user;
              const anonSessionId = req.query.anonSessionId as string;
-             const viewMineOnly = req.query.viewMineOnly === 'true';
              const limit = parseInt(req.query.limit as string) || 50;
 
-             // 🔒 Phase 3: DEBUG 로그 제거 (프로덕션 정리)
+             const userIdStr = user?.id ? String(user.id) : undefined;
+             const scope = resolveSessionListScope({
+                 isAdmin: user?.role === 'admin',
+                 viewAll: req.query.viewAll === 'true',
+                 userId: userIdStr,
+                 anonSessionId: typeof anonSessionId === 'string' ? anonSessionId : undefined,
+             });
 
              let sessions: ConversationSession[];
-             const isAdminUser = user?.role === 'admin';
-
-             // 🔑 관리자: 기본적으로 전체 조회 (viewMineOnly=true면 자신만)
-             if (isAdminUser && !viewMineOnly) {
+             if (scope === 'all') {
+                 // 🔑 관리자 전용 화면(/admin/conversations)의 명시적 전체 조회
                  sessions = await conversationDb.getAllSessions(limit);
                  log.info(`[Chat Sessions] 관리자 전체 조회: ${sessions.length}개`);
-             } else if (user?.id) {
-                 // 🔐 로그인 사용자: 자신의 대화만 (userId를 문자열로 변환하여 비교)
-                 const userIdStr = String(user.id);
-                 sessions = await conversationDb.getSessionsByUserId(userIdStr, limit);
+             } else if (scope === 'user') {
+                 // 🔐 로그인 사용자: 자신의 대화만 (관리자도 개인 화면에선 동일)
+                 sessions = await conversationDb.getSessionsByUserId(userIdStr!, limit);
                  log.info(`[Chat Sessions] 사용자 ${userIdStr} 조회: ${sessions.length}개`);
-             } else if (anonSessionId) {
+             } else if (scope === 'anon') {
                  // 🔒 비로그인 사용자: 해당 익명 세션만
                  sessions = await conversationDb.getSessionsByAnonId(anonSessionId, limit);
                  log.info(`[Chat Sessions] 익명 세션 ${anonSessionId} 조회: ${sessions.length}개`);

--- a/apps/web/app/(workspace)/admin/conversations/page.tsx
+++ b/apps/web/app/(workspace)/admin/conversations/page.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { MessagesSquare, Search, X, Loader2 } from "lucide-react";
+import type { ApiSuccess } from "@openmake/shared-types";
+import {
+  PageHeader,
+  Card,
+  CardContent,
+  Badge,
+  Table,
+  Th,
+  Td,
+} from "@/components/ui/primitives";
+import { AdminTabs } from "@/components/hub-tabs";
+import { ApiClient } from "@/lib/api-client";
+import { toBcp47 } from "@/i18n/config";
+
+/* ── 백엔드 응답 타입 ──────────────────────────────────────────
+ * GET /api/chat/conversations?viewAll=true (admin 옵트인) → res.data.sessions (camelCase).
+ * 개인 히스토리와 달리 소유자 식별용 userId/anonSessionId 를 함께 사용한다. */
+interface ApiConversation {
+  id: string;
+  title: string | null;
+  userId?: string | null;
+  anonSessionId?: string | null;
+  updatedAt?: string;
+  createdAt?: string;
+  model?: string;
+  messageCount?: number;
+}
+
+type ConversationsResponse = ApiSuccess<{ sessions: ApiConversation[] }>;
+
+interface AdminUserLite {
+  id: string;
+  email: string;
+  name?: string;
+}
+
+type MessagesResponse = ApiSuccess<{
+  messages?: Array<{ role: string; content: string }>;
+}>;
+
+function fmtDateTime(iso: string | undefined, locale: string): string {
+  if (!iso) return "-";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "-";
+  return d.toLocaleString(locale, {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default function AdminConversationsPage() {
+  const t = useTranslations("adminConversations");
+  const locale = toBcp47(useLocale());
+
+  const [sessions, setSessions] = useState<ApiConversation[]>([]);
+  const [userMap, setUserMap] = useState<Record<string, AdminUserLite>>({});
+  const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState("");
+
+  // 상세 모달 — 선택 세션의 메시지 전문
+  const [detail, setDetail] = useState<ApiConversation | null>(null);
+  const [detailMsgs, setDetailMsgs] = useState<Array<{ role: string; content: string }> | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      // 세션 전체 목록(admin 옵트인)과 사용자 목록(이메일 매핑용)을 병렬 조회.
+      // 사용자 목록 실패는 허용 — 그 경우 원 userId 로 표시.
+      const [convRes, usersRes] = await Promise.allSettled([
+        ApiClient.get<ConversationsResponse>("/api/chat/conversations?viewAll=true&limit=200"),
+        ApiClient.get<ApiSuccess<{ users?: AdminUserLite[] }>>("/api/admin/users?limit=500"),
+      ]);
+      if (!alive) return;
+      if (convRes.status === "fulfilled") {
+        setSessions(convRes.value?.data?.sessions ?? []);
+      }
+      if (usersRes.status === "fulfilled") {
+        const users = usersRes.value?.data?.users ?? [];
+        setUserMap(Object.fromEntries(users.map((u) => [String(u.id), u])));
+      }
+      setLoading(false);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const ownerLabel = (s: ApiConversation): string => {
+    if (s.userId) {
+      const u = userMap[String(s.userId)];
+      return u ? u.name || u.email : String(s.userId);
+    }
+    return t("guest");
+  };
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return sessions;
+    return sessions.filter(
+      (s) =>
+        (s.title ?? "").toLowerCase().includes(q) ||
+        ownerLabel(s).toLowerCase().includes(q),
+    );
+    // ownerLabel 은 userMap 파생 — deps 로 잡는다
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessions, query, userMap]);
+
+  const openDetail = async (s: ApiConversation) => {
+    setDetail(s);
+    setDetailMsgs(null);
+    try {
+      const res = await ApiClient.get<MessagesResponse>(
+        `/api/chat/sessions/${s.id}/messages?limit=200`,
+      );
+      setDetailMsgs(res?.data?.messages ?? []);
+    } catch {
+      setDetailMsgs([]);
+    }
+  };
+
+  return (
+    <>
+      <PageHeader
+        title={t("title")}
+        description={t("description")}
+        actions={
+          <Badge tone="neutral">
+            <MessagesSquare className="h-3.5 w-3.5" /> {t("countBadge", { count: filtered.length })}
+          </Badge>
+        }
+      />
+      <AdminTabs />
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-6">
+        <div className="mb-4 flex items-center gap-2">
+          <div className="relative w-full max-w-sm">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-faint" />
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={t("searchPlaceholder")}
+              className="h-9 w-full rounded-md border border-border bg-surface pl-9 pr-3 text-sm text-fg-2 outline-none focus:border-border-strong"
+            />
+          </div>
+        </div>
+
+        <Card>
+          <CardContent className="p-0">
+            <Table>
+              <thead>
+                <tr>
+                  <Th>{t("th.title")}</Th>
+                  <Th>{t("th.owner")}</Th>
+                  <Th>{t("th.messages")}</Th>
+                  <Th>{t("th.model")}</Th>
+                  <Th>{t("th.updatedAt")}</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading ? (
+                  <tr>
+                    <Td className="py-8 text-center text-muted" colSpan={5}>
+                      <Loader2 className="mx-auto h-5 w-5 animate-spin" />
+                    </Td>
+                  </tr>
+                ) : filtered.length === 0 ? (
+                  <tr>
+                    <Td className="py-8 text-center text-muted" colSpan={5}>
+                      {t("empty")}
+                    </Td>
+                  </tr>
+                ) : (
+                  filtered.map((s) => (
+                    <tr
+                      key={s.id}
+                      onClick={() => openDetail(s)}
+                      className="cursor-pointer transition hover:bg-surface-2"
+                    >
+                      <Td className="max-w-[28rem] truncate font-medium text-fg">
+                        {s.title?.trim() || t("untitled")}
+                      </Td>
+                      <Td>
+                        {s.userId ? (
+                          ownerLabel(s)
+                        ) : (
+                          <Badge tone="neutral">{t("guest")}</Badge>
+                        )}
+                      </Td>
+                      <Td>{s.messageCount ?? 0}</Td>
+                      <Td className="max-w-[12rem] truncate">{s.model || "-"}</Td>
+                      <Td>{fmtDateTime(s.updatedAt || s.createdAt, locale)}</Td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+
+      {detail && (
+        <div
+          role="dialog"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+          onClick={(ev) => { if (ev.target === ev.currentTarget) setDetail(null); }}
+        >
+          <div className="relative mx-4 flex max-h-[80vh] w-full max-w-2xl flex-col rounded-lg bg-surface shadow-xl">
+            <div className="flex items-start justify-between gap-4 border-b border-border p-4">
+              <div className="min-w-0">
+                <h2 className="truncate text-sm font-semibold text-fg">
+                  {detail.title?.trim() || t("untitled")}
+                </h2>
+                <p className="mt-0.5 text-xs text-muted">
+                  {ownerLabel(detail)} · {fmtDateTime(detail.updatedAt || detail.createdAt, locale)}
+                </p>
+              </div>
+              <button
+                onClick={() => setDetail(null)}
+                className="shrink-0 text-faint hover:text-fg"
+                aria-label={t("detail.close")}
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="min-h-0 flex-1 space-y-3 overflow-y-auto p-4">
+              {detailMsgs === null ? (
+                <p className="py-6 text-center text-sm text-muted">{t("detail.loading")}</p>
+              ) : detailMsgs.length === 0 ? (
+                <p className="py-6 text-center text-sm text-muted">{t("detail.empty")}</p>
+              ) : (
+                detailMsgs.map((m, i) => (
+                  <div key={i}>
+                    <Badge tone={m.role === "user" ? "success" : "neutral"}>{m.role}</Badge>
+                    <p className="mt-1 whitespace-pre-wrap break-words text-sm text-fg-2">
+                      {m.content}
+                    </p>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/components/hub-tabs.tsx
+++ b/apps/web/components/hub-tabs.tsx
@@ -65,6 +65,7 @@ export function AdminTabs() {
     <PageTabs
       tabs={[
         { href: "/admin", label: t("dashboard") },
+        { href: "/admin/conversations", label: tNav("items.conversationsAdmin") },
         { href: "/admin/analytics", label: tNav("items.analytics") },
         { href: "/admin/metrics", label: tNav("items.metrics") },
         { href: "/mcp-monitoring", label: tNav("items.mcpMonitoring") },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -16,6 +16,7 @@
       "usage": "Usage",
       "admin": "Admin",
       "analytics": "Analytics",
+      "conversationsAdmin": "Conversations",
       "auditLog": "Audit Log",
       "metrics": "Metrics",
       "alerts": "Alerts",
@@ -1208,6 +1209,27 @@
       "4": "Thu",
       "5": "Fri",
       "6": "Sat"
+    }
+  },
+  "adminConversations": {
+    "title": "All Conversations",
+    "description": "Browse conversation history across all users and guests",
+    "countBadge": "{count} sessions",
+    "searchPlaceholder": "Search title or user",
+    "guest": "Guest",
+    "untitled": "Untitled conversation",
+    "empty": "No conversations",
+    "th": {
+      "title": "Title",
+      "owner": "User",
+      "messages": "Messages",
+      "model": "Model",
+      "updatedAt": "Last activity"
+    },
+    "detail": {
+      "loading": "Loading messages…",
+      "empty": "No messages",
+      "close": "Close"
     }
   },
   "adminAudit": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -16,6 +16,7 @@
       "usage": "使用量",
       "admin": "管理者",
       "analytics": "アナリティクス",
+      "conversationsAdmin": "会話一覧",
       "auditLog": "監査ログ",
       "metrics": "メトリクス",
       "alerts": "アラート",
@@ -1208,6 +1209,27 @@
       "4": "木",
       "5": "金",
       "6": "土"
+    }
+  },
+  "adminConversations": {
+    "title": "全会話の閲覧",
+    "description": "すべてのユーザー・ゲストの会話履歴を閲覧します",
+    "countBadge": "{count}件のセッション",
+    "searchPlaceholder": "タイトル・ユーザーを検索",
+    "guest": "ゲスト",
+    "untitled": "無題の会話",
+    "empty": "会話がありません",
+    "th": {
+      "title": "タイトル",
+      "owner": "ユーザー",
+      "messages": "メッセージ",
+      "model": "モデル",
+      "updatedAt": "最終アクティビティ"
+    },
+    "detail": {
+      "loading": "メッセージを読み込み中…",
+      "empty": "メッセージがありません",
+      "close": "閉じる"
     }
   },
   "adminAudit": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -16,6 +16,7 @@
       "usage": "사용량",
       "admin": "관리자",
       "analytics": "애널리틱스",
+      "conversationsAdmin": "전체 대화",
       "auditLog": "감사 로그",
       "metrics": "메트릭",
       "alerts": "알림",
@@ -1208,6 +1209,27 @@
       "4": "목",
       "5": "금",
       "6": "토"
+    }
+  },
+  "adminConversations": {
+    "title": "전체 대화 조회",
+    "description": "모든 사용자·게스트의 대화 히스토리를 조회합니다",
+    "countBadge": "{count}개 세션",
+    "searchPlaceholder": "제목·사용자 검색",
+    "guest": "게스트",
+    "untitled": "제목 없는 대화",
+    "empty": "대화가 없습니다",
+    "th": {
+      "title": "제목",
+      "owner": "사용자",
+      "messages": "메시지",
+      "model": "모델",
+      "updatedAt": "마지막 활동"
+    },
+    "detail": {
+      "loading": "메시지를 불러오는 중…",
+      "empty": "메시지가 없습니다",
+      "close": "닫기"
     }
   },
   "adminAudit": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -16,6 +16,7 @@
       "usage": "使用量",
       "admin": "管理员",
       "analytics": "分析",
+      "conversationsAdmin": "全部对话",
       "auditLog": "审计日志",
       "metrics": "指标",
       "alerts": "告警",
@@ -1208,6 +1209,27 @@
       "4": "周四",
       "5": "周五",
       "6": "周六"
+    }
+  },
+  "adminConversations": {
+    "title": "全部对话查看",
+    "description": "查看所有用户和访客的对话历史",
+    "countBadge": "{count} 个会话",
+    "searchPlaceholder": "搜索标题或用户",
+    "guest": "访客",
+    "untitled": "无标题对话",
+    "empty": "暂无对话",
+    "th": {
+      "title": "标题",
+      "owner": "用户",
+      "messages": "消息",
+      "model": "模型",
+      "updatedAt": "最后活动"
+    },
+    "detail": {
+      "loading": "正在加载消息…",
+      "empty": "暂无消息",
+      "close": "关闭"
     }
   },
   "adminAudit": {


### PR DESCRIPTION
## 요약

관리자의 전체 대화 조회를 개인 히스토리에서 분리해 **관리자 전용 화면(`/admin/conversations`)** 으로 옮긴다.

기존에는 `GET /api/chat/conversations` 가 관리자면 **기본으로 전체 세션**을 반환해, 관리자 계정의 개인 히스토리 페이지·사이드바 "최근 대화"에 모든 사용자(게스트 포함)의 대화가 자기 것과 구분 없이 섞여 노출됐다.

## 변경 내용

### 백엔드 (`session.controller.ts`)
- 전체 조회를 명시적 옵트인 `?viewAll=true` (admin 한정)으로 전환 — 관리자도 파라미터 없이는 자기 대화만 반환. 비관리자의 `viewAll` 은 무시
- 기존 `viewMineOnly` 파라미터 제거 (프론트·테스트 사용처 0건 확인)
- 목록 범위 판정을 순수 함수 `resolveSessionListScope` 로 추출 (기존 `evaluateSessionAccess` 와 동일 패턴) + 회귀 방어 테스트 5건
- 개별 세션 메시지 열람 권한(`evaluateSessionAccess` admin 통과)은 변경 없음 — 관리자 화면의 대화 전문 열람에 사용

### 프론트 (`apps/web`)
- `/admin/conversations` 페이지 신설: 전체 세션 테이블(제목·소유자·메시지 수·모델·마지막 활동), 게스트 세션은 뱃지 표시, 로그인 사용자는 `/api/admin/users` 로 이메일/이름 매핑, 행 클릭 시 모달로 대화 전문 열람, 제목·사용자 검색 필터
- `AdminTabs` 에 "전체 대화" 탭 추가 (admin 역할만 렌더)
- i18n 4개 로케일(ko/en/ja/zh) 키 추가

## 검증

- [x] jest `session-access.test.ts` 13/13 통과 (신규 5건 포함)
- [x] `tsc --noEmit` — apps/api·apps/web 모두 클린
- [x] eslint — 변경 파일 클린 (기존 `global-error.tsx` 에러 1건은 무관·미변경)
- [x] `check:i18n` — 4개 로케일 1,250키 정합

🤖 Generated with [Claude Code](https://claude.com/claude-code)