### PR TITLE
feat(history): 히스토리 커버리지 확장 — structured 저장·관리자 작업/리서치 탭·OpenAI 호환 세션 연속성

### DIFF
--- a/apps/api/src/__tests__/routes/chat-structured-persistence.routes.test.ts
+++ b/apps/api/src/__tests__/routes/chat-structured-persistence.routes.test.ts
@@ -1,0 +1,102 @@
+/**
+ * POST /api/chat/structured — 대화 기록 영속화 회귀 테스트.
+ *
+ * 2026-08-07: structured 라우트가 composeStructuredAnswer 를 직접 호출하면서
+ * 사용자 질문·구조화 답변을 conversation DB 에 전혀 저장하지 않던 결함의 회귀 가드.
+ * request-persistence 헬퍼(ensureSession/saveUserMessage/saveAssistantMessage)를
+ * 재사용해 저장하며, saveHistory === false 는 본문 저장을 생략하고, 저장 실패는
+ * 응답을 죽이지 않아야(fail-open) 한다.
+ */
+import express from 'express';
+import request from 'supertest';
+
+// 무거운 의존성 mock — 라우트의 저장 배선만 검증한다.
+const ensureSession = jest.fn();
+const saveUserMessage = jest.fn();
+const saveAssistantMessage = jest.fn();
+jest.mock('../../chat/request-persistence', () => ({
+    ensureSession: (...a: unknown[]) => ensureSession(...a),
+    saveUserMessage: (...a: unknown[]) => saveUserMessage(...a),
+    saveAssistantMessage: (...a: unknown[]) => saveAssistantMessage(...a),
+}));
+
+const composeStructuredAnswer = jest.fn();
+jest.mock('../../services/answer-composer', () => ({
+    composeStructuredAnswer: (...a: unknown[]) => composeStructuredAnswer(...a),
+}));
+
+jest.mock('../../mcp/web-search/build-search-context', () => ({
+    buildWebSearchContext: jest.fn().mockResolvedValue({ webSearchContext: '' }),
+}));
+
+jest.mock('../../llm/client', () => ({
+    createClient: jest.fn(() => ({ model: 'test-model', chat: jest.fn() })),
+}));
+
+import chatRouter from '../../routes/chat.routes';
+
+const MARKDOWN = '# 제목\n\n답변 본문';
+const COMPOSED = {
+    intent: 'explanation',
+    structured: { intent: 'explanation', title: '제목', conclusion: '결론', sections: [], confidence: 'high' },
+    markdown: MARKDOWN,
+};
+
+const mkApp = () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/chat', chatRouter);
+    return app;
+};
+
+const post = (body: Record<string, unknown>) =>
+    request(mkApp()).post('/api/chat/structured').send(body);
+
+describe('POST /api/chat/structured — 대화 기록 영속화', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        ensureSession.mockResolvedValue('sess-new');
+        composeStructuredAnswer.mockResolvedValue(COMPOSED);
+    });
+
+    it('sessionId 미지정 시 ensureSession 으로 자동 생성하고 질문·답변을 저장한다', async () => {
+        const res = await post({ message: '안녕', anonSessionId: 'anon-xyz', userLanguage: 'ko' });
+
+        expect(res.status).toBe(200);
+        expect(ensureSession).toHaveBeenCalledTimes(1);
+        // (sessionId, authenticatedUserId, message, anonSessionId, userRole)
+        expect(ensureSession.mock.calls[0][0]).toBeUndefined();
+        expect(ensureSession.mock.calls[0][2]).toBe('안녕');
+        expect(ensureSession.mock.calls[0][3]).toBe('anon-xyz');
+
+        // user 메시지 = 원 질문, persistContent(마지막 인자) = true
+        expect(saveUserMessage).toHaveBeenCalledWith('sess-new', 'anon-xyz', '안녕', 'test-model', true);
+        // assistant 메시지 = 렌더된 마크다운, persistContent = true
+        const asstCall = saveAssistantMessage.mock.calls[0];
+        expect(asstCall[0]).toBe('sess-new');
+        expect(asstCall[2]).toBe(MARKDOWN);
+        expect(asstCall[5]).toBe(true);
+
+        // 응답 본문에 세션 id 노출 (클라이언트 세션 연속용)
+        expect(res.body?.data?.sessionId).toBe('sess-new');
+    });
+
+    it('saveHistory === false 는 본문 저장을 생략한다(persistContent=false)', async () => {
+        const res = await post({ message: '안녕', anonSessionId: 'anon-xyz', saveHistory: false });
+
+        expect(res.status).toBe(200);
+        expect(saveUserMessage).toHaveBeenCalledWith('sess-new', 'anon-xyz', '안녕', 'test-model', false);
+        expect(saveAssistantMessage.mock.calls[0][5]).toBe(false);
+    });
+
+    it('저장 실패는 응답을 죽이지 않는다(fail-open)', async () => {
+        ensureSession.mockRejectedValue(new Error('DB down'));
+
+        const res = await post({ message: '안녕', anonSessionId: 'anon-xyz' });
+
+        expect(res.status).toBe(200);
+        expect(res.body?.data?.markdown).toBe(MARKDOWN);
+        // 저장 실패 시 세션 id 는 노출되지 않는다
+        expect(res.body?.data?.sessionId).toBeUndefined();
+    });
+});

--- a/apps/api/src/__tests__/routes/openai-compat-images.routes.test.ts
+++ b/apps/api/src/__tests__/routes/openai-compat-images.routes.test.ts
@@ -15,6 +15,16 @@ jest.mock('../../chat/profile-resolver', () => ({
     listAvailableModels: () => [{ id: 'test-model' }],
 }));
 
+// 세션 연속성 조회는 실제 pg pool 에 닿는다 — DB 없는 CI 에선 연결 시도가 hang 해
+// jest 타임아웃을 초과하므로(로컬은 빠른 실패 → fail-open 통과) repository 를 격리한다.
+jest.mock('../../data/repositories/oaicompat-session-repo', () => ({
+    OpenAICompatSessionRepository: jest.fn().mockImplementation(() => ({
+        findByKeyForUser: jest.fn().mockResolvedValue(undefined),
+        findByKeyForAnon: jest.fn().mockResolvedValue(undefined),
+        tagKey: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
 import openaiCompatRouter, { setClusterManager } from '../../routes/openai-compat.routes';
 
 const IMAGE_DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==';

--- a/apps/api/src/config/openai-compat.ts
+++ b/apps/api/src/config/openai-compat.ts
@@ -1,0 +1,15 @@
+/**
+ * OpenAI 호환 엔드포인트 세션 연속성 설정.
+ *
+ * OpenAI 호환 클라이언트(Discord 봇 등)는 대화 세션 개념이 없어 매 요청이 독립적이다.
+ * 동일 클라이언트의 연속 호출을 하나의 conversation 세션으로 묶기 위해, 요청 정보로부터
+ * 결정적(deterministic) 세션 키를 유도해 세션 metadata 에 태깅하고 다음 호출에서 조회한다.
+ */
+export const OPENAI_COMPAT_SESSION = {
+    /** 유도된 세션 키의 prefix — 일반 세션과 구분/디버깅용 식별자 */
+    KEY_PREFIX: 'oaicompat-',
+    /** sha256 hex 에서 취할 앞 글자 수 (32 = 128bit, 충돌 사실상 0) */
+    HASH_HEX_LENGTH: 32,
+    /** 세션 metadata 에 세션 키를 보관하는 필드명 (조회 키) */
+    METADATA_FIELD: 'oaicompatKey',
+} as const;

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -227,6 +227,11 @@ export const RESEARCH_DEPTH_LOOPS: Record<string, number> = {
     deep: 4,
 };
 
+/** 관리자 전체 조회(/admin/conversations 리서치 탭, ?viewAll=true) 기본 목록 상한.
+ *  RESEARCH_LIST_ALL_DEFAULT 로 오버라이드(기본 200). */
+export const RESEARCH_SESSION_LIST_ALL_DEFAULT =
+    parseInt(process.env.RESEARCH_LIST_ALL_DEFAULT || '', 10) || 200;
+
 /**
  * Deep Research 인용 검증 (A3)
  *
@@ -1274,6 +1279,9 @@ export const AGENT_TASK_LIMITS = {
     GOAL_MAX_CHARS: parseInt(process.env.AGENT_TASK_GOAL_MAX_CHARS || '', 10) || 20000,
     /** 기본 최대 턴 수 */
     DEFAULT_MAX_TURNS: 10,
+    /** 관리자 전체 조회(/admin/conversations 작업 탭, ?viewAll=true) 기본 목록 상한.
+     *  AGENT_TASK_LIST_ALL_DEFAULT 로 오버라이드(기본 200). */
+    LIST_ALL_DEFAULT: parseInt(process.env.AGENT_TASK_LIST_ALL_DEFAULT || '', 10) || 200,
     /** 작업 전체 타임아웃 (ms) — AGENT_TASK_TIMEOUT_MS 환경변수로 오버라이드.
      *  기본 10분: HTML/디자인 등 장문 deliverable 생성은 단일 LLM 호출이 수 분 걸릴 수 있음. */
     TOTAL_TIMEOUT_MS: parseInt(process.env.AGENT_TASK_TIMEOUT_MS || '', 10) || 10 * 60 * 1000,

--- a/apps/api/src/data/models/unified-database.ts
+++ b/apps/api/src/data/models/unified-database.ts
@@ -332,9 +332,7 @@ export class UnifiedDatabase {
     }
 
     /** 관리자 전체 조회(/admin/conversations) — user_id 포함, 최신순. */
-    async getAllResearchSessions(limit: number = 200): Promise<ResearchSession[]> {
-        return this.researchRepository.getAllResearchSessions(limit);
-    }
+    async getAllResearchSessions(limit: number = 200): Promise<ResearchSession[]> { return this.researchRepository.getAllResearchSessions(limit); }
 
     async deleteResearchSession(sessionId: string): Promise<void> {
         return this.researchRepository.deleteSessionWithSteps(sessionId);
@@ -392,9 +390,7 @@ export class UnifiedDatabase {
     }
 
     /** 관리자 전체 조회(/admin/conversations) — user_id 포함, 최신순. */
-    async getAllAgentTasks(limit: number = 200): Promise<AgentTask[]> {
-        return this.agentTaskRepository.getAllAgentTasks(limit);
-    }
+    async getAllAgentTasks(limit: number = 200): Promise<AgentTask[]> { return this.agentTaskRepository.getAllAgentTasks(limit); }
 
     async deleteAgentTask(taskId: string): Promise<void> {
         return this.agentTaskRepository.deleteAgentTaskWithSteps(taskId);

--- a/apps/api/src/data/models/unified-database.ts
+++ b/apps/api/src/data/models/unified-database.ts
@@ -331,6 +331,11 @@ export class UnifiedDatabase {
         return this.researchRepository.getUserResearchSessions(userId, limit);
     }
 
+    /** 관리자 전체 조회(/admin/conversations) — user_id 포함, 최신순. */
+    async getAllResearchSessions(limit: number = 200): Promise<ResearchSession[]> {
+        return this.researchRepository.getAllResearchSessions(limit);
+    }
+
     async deleteResearchSession(sessionId: string): Promise<void> {
         return this.researchRepository.deleteSessionWithSteps(sessionId);
     }
@@ -384,6 +389,11 @@ export class UnifiedDatabase {
 
     async getUserAgentTasks(userId: string, limit: number = 20): Promise<AgentTask[]> {
         return this.agentTaskRepository.getUserAgentTasks(userId, limit);
+    }
+
+    /** 관리자 전체 조회(/admin/conversations) — user_id 포함, 최신순. */
+    async getAllAgentTasks(limit: number = 200): Promise<AgentTask[]> {
+        return this.agentTaskRepository.getAllAgentTasks(limit);
     }
 
     async deleteAgentTask(taskId: string): Promise<void> {

--- a/apps/api/src/data/repositories/agent-task-repository.ts
+++ b/apps/api/src/data/repositories/agent-task-repository.ts
@@ -194,6 +194,15 @@ export class AgentTaskRepository extends BaseRepository {
         return result.rows;
     }
 
+    /** 관리자 전체 조회(/admin/conversations) — user_id 포함, 최신순. */
+    async getAllAgentTasks(limit: number = 200): Promise<AgentTask[]> {
+        const result = await this.query<AgentTask>(
+            'SELECT * FROM agent_tasks ORDER BY created_at DESC LIMIT $1',
+            [limit]
+        );
+        return result.rows;
+    }
+
     /** 크로스-task 학습(5-2)용 — 유저 최근 terminal task 의 경량 메타만 조회(checkpoint 등 대형 컬럼 제외). */
     async getRecentTerminalTaskMetas(userId: string, limit: number): Promise<Array<
         Pick<AgentTask, 'id' | 'goal' | 'status' | 'error' | 'current_turn'>

--- a/apps/api/src/data/repositories/oaicompat-session-repo.ts
+++ b/apps/api/src/data/repositories/oaicompat-session-repo.ts
@@ -1,0 +1,54 @@
+/**
+ * @module data/repositories/oaicompat-session-repo
+ * @description OpenAI 호환 엔드포인트 세션 연속성 데이터 접근 계층
+ *
+ * OpenAI 호환 클라이언트(Discord 봇 등)는 대화 세션 개념이 없어 매 요청이 독립적이다.
+ * 라우트가 유도한 결정적 세션 키를 `conversation_sessions.metadata` 에 태깅하고,
+ * 다음 호출에서 그 키로 기존 세션을 조회해 하나의 세션에 누적한다.
+ *
+ * @see apps/api/src/routes/openai-compat.routes.ts
+ * @see apps/api/src/config/openai-compat.ts
+ */
+import { BaseRepository } from './base-repository';
+import { OPENAI_COMPAT_SESSION } from '../../config/openai-compat';
+
+export class OpenAICompatSessionRepository extends BaseRepository {
+    /**
+     * 세션 키로 인증 사용자 소유의 최근 세션 id 를 조회한다. 없으면 undefined.
+     */
+    async findByKeyForUser(sessionKey: string, userId: string): Promise<string | undefined> {
+        const result = await this.query<{ id: string }>(
+            `SELECT id FROM conversation_sessions
+             WHERE metadata->>$2 = $1 AND user_id = $3
+             ORDER BY updated_at DESC LIMIT 1`,
+            [sessionKey, OPENAI_COMPAT_SESSION.METADATA_FIELD, userId],
+        );
+        return result.rows[0]?.id;
+    }
+
+    /**
+     * 세션 키로 익명 소유(anon_session_id = 세션 키)의 최근 세션 id 를 조회한다. 없으면 undefined.
+     * API key 에 user 가 없는 경로용 — 세션 키가 곧 익명 소유자 식별자가 된다.
+     */
+    async findByKeyForAnon(sessionKey: string): Promise<string | undefined> {
+        const result = await this.query<{ id: string }>(
+            `SELECT id FROM conversation_sessions
+             WHERE metadata->>$2 = $1 AND user_id IS NULL AND anon_session_id = $1
+             ORDER BY updated_at DESC LIMIT 1`,
+            [sessionKey, OPENAI_COMPAT_SESSION.METADATA_FIELD],
+        );
+        return result.rows[0]?.id;
+    }
+
+    /**
+     * 새로 생성된 세션에 세션 키를 metadata 로 태깅한다 (다음 호출의 조회 대상).
+     */
+    async tagKey(sessionId: string, sessionKey: string): Promise<void> {
+        await this.query(
+            `UPDATE conversation_sessions
+             SET metadata = jsonb_set(COALESCE(metadata, '{}'::jsonb), $2, to_jsonb($3::text))
+             WHERE id = $1`,
+            [sessionId, `{${OPENAI_COMPAT_SESSION.METADATA_FIELD}}`, sessionKey],
+        );
+    }
+}

--- a/apps/api/src/data/repositories/research-repository.ts
+++ b/apps/api/src/data/repositories/research-repository.ts
@@ -121,6 +121,19 @@ export class ResearchRepository extends BaseRepository {
         }));
     }
 
+    /** 관리자 전체 조회(/admin/conversations) — user_id 포함, 최신순. */
+    async getAllResearchSessions(limit: number = 200): Promise<ResearchSession[]> {
+        const result = await this.query<ResearchSession>(
+            'SELECT * FROM research_sessions ORDER BY created_at DESC LIMIT $1',
+            [limit]
+        );
+        return result.rows.map((row) => ({
+            ...row,
+            key_findings: row.key_findings || [],
+            sources: row.sources || []
+        }));
+    }
+
     async deleteSessionWithSteps(sessionId: string): Promise<void> {
         const client = await this.pool.connect();
 

--- a/apps/api/src/routes/__tests__/admin-list-scope.test.ts
+++ b/apps/api/src/routes/__tests__/admin-list-scope.test.ts
@@ -1,0 +1,25 @@
+import { resolveSessionListScope } from '../../controllers/session.controller';
+
+/**
+ * GET /api/agent-tasks 와 GET /api/research/sessions 의 관리자 전체 조회(viewAll) 옵트인 계약.
+ * 두 라우트는 session.controller 의 resolveSessionListScope 를 재사용한다 —
+ * requireAuth 라 userId 가 항상 존재하므로 스코프는 'all'(관리자 옵트인) 또는 'user' 뿐이다.
+ * 회귀 방어: 비관리자의 viewAll 은 무시되고 반드시 본인 것만 반환되어야 한다(정보 유출 차단).
+ */
+describe('관리자 목록 전체 조회 옵트인 (agent-tasks · research)', () => {
+    test('관리자 + viewAll=true → 전체 조회', () => {
+        expect(resolveSessionListScope({ isAdmin: true, viewAll: true, userId: 'u-admin' })).toBe('all');
+    });
+
+    test('관리자 + viewAll 없음 → 본인 것만', () => {
+        expect(resolveSessionListScope({ isAdmin: true, viewAll: false, userId: 'u-admin' })).toBe('user');
+    });
+
+    test('비관리자 + viewAll=true → 무시하고 본인 것만', () => {
+        expect(resolveSessionListScope({ isAdmin: false, viewAll: true, userId: 'u-user' })).toBe('user');
+    });
+
+    test('비관리자 + viewAll 없음 → 본인 것만', () => {
+        expect(resolveSessionListScope({ isAdmin: false, viewAll: false, userId: 'u-user' })).toBe('user');
+    });
+});

--- a/apps/api/src/routes/__tests__/openai-compat-session-key.test.ts
+++ b/apps/api/src/routes/__tests__/openai-compat-session-key.test.ts
@@ -1,0 +1,59 @@
+/**
+ * deriveOpenAICompatSessionKey 결정성 회귀 테스트.
+ *
+ * OpenAI 호환 클라이언트(Discord 봇 등)의 연속 호출을 하나의 conversation 세션으로
+ * 묶기 위해 (owner, requestUser, UTC 날짜)로부터 결정적 세션 키를 유도한다.
+ * 이 키가 결정적이지 않거나 날짜/사용자 축을 무시하면 세션이 파편화되거나 뒤섞인다.
+ */
+import { deriveOpenAICompatSessionKey } from '../openai-compat.routes';
+import { OPENAI_COMPAT_SESSION } from '../../config/openai-compat';
+
+describe('deriveOpenAICompatSessionKey', () => {
+    const day = new Date('2026-08-07T10:00:00Z');
+    const sameDayLater = new Date('2026-08-07T23:59:59Z');
+    const nextDay = new Date('2026-08-08T00:00:01Z');
+
+    it('같은 입력 → 같은 키 (결정성)', () => {
+        const a = deriveOpenAICompatSessionKey('user-1', 'bot-a', day);
+        const b = deriveOpenAICompatSessionKey('user-1', 'bot-a', day);
+        expect(a).toBe(b);
+    });
+
+    it('prefix 와 해시 길이가 config 상수를 따른다', () => {
+        const key = deriveOpenAICompatSessionKey('user-1', 'bot-a', day);
+        expect(key.startsWith(OPENAI_COMPAT_SESSION.KEY_PREFIX)).toBe(true);
+        const hex = key.slice(OPENAI_COMPAT_SESSION.KEY_PREFIX.length);
+        expect(hex).toHaveLength(OPENAI_COMPAT_SESSION.HASH_HEX_LENGTH);
+        expect(hex).toMatch(/^[0-9a-f]+$/);
+    });
+
+    it('다른 requestUser → 다른 키', () => {
+        const a = deriveOpenAICompatSessionKey('user-1', 'bot-a', day);
+        const b = deriveOpenAICompatSessionKey('user-1', 'bot-b', day);
+        expect(a).not.toBe(b);
+    });
+
+    it('다른 owner → 다른 키', () => {
+        const a = deriveOpenAICompatSessionKey('user-1', 'bot-a', day);
+        const b = deriveOpenAICompatSessionKey('user-2', 'bot-a', day);
+        expect(a).not.toBe(b);
+    });
+
+    it('requestUser 없으면 default 로 취급 (undefined 와 "default" 동일)', () => {
+        const a = deriveOpenAICompatSessionKey('user-1', undefined, day);
+        const b = deriveOpenAICompatSessionKey('user-1', 'default', day);
+        expect(a).toBe(b);
+    });
+
+    it('같은 UTC 날짜 내에서는 시각이 달라도 같은 키', () => {
+        const a = deriveOpenAICompatSessionKey('user-1', 'bot-a', day);
+        const b = deriveOpenAICompatSessionKey('user-1', 'bot-a', sameDayLater);
+        expect(a).toBe(b);
+    });
+
+    it('UTC 날짜 경계를 넘으면 다른 키 (일자 파편화 방지)', () => {
+        const a = deriveOpenAICompatSessionKey('user-1', 'bot-a', sameDayLater);
+        const b = deriveOpenAICompatSessionKey('user-1', 'bot-a', nextDay);
+        expect(a).not.toBe(b);
+    });
+});

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -25,6 +25,7 @@ import { requireAuth } from '../auth';
 import { assertResourceOwnerOrAdmin } from '../auth/ownership';
 import { validate, validateWithSecurity } from '../middlewares/validation';
 import { getUnifiedDatabase } from '../data/models/unified-database';
+import { resolveSessionListScope } from '../controllers/session.controller';
 import { LOCAL_BRIDGE } from '../config/local-bridge';
 import { getLocalBridgeRegistry } from '../services/local-bridge/registry';
 import { v4 as uuidv4 } from 'uuid';
@@ -263,11 +264,21 @@ router.post('/', (req: Request, res: Response, next) => {
 
 /**
  * GET /api/agent-tasks
- * 사용자의 작업 목록
+ * 사용자의 작업 목록. 관리자 전용 화면(/admin/conversations)은 ?viewAll=true 로
+ * 전체 사용자 작업을 옵트인 조회한다(비관리자의 viewAll 은 무시 — session.controller 동일 관용구).
+ * toPublicTask 는 user_id 를 그대로 노출하므로 소유자 식별에 별도 필드가 필요 없다.
  */
 router.get('/', asyncHandler(async (req: Request, res: Response) => {
     const db = getUnifiedDatabase();
-    const tasks = await db.getUserAgentTasks(String(req.user!.id));
+    const userId = String(req.user!.id);
+    const scope = resolveSessionListScope({
+        isAdmin: req.user!.role === 'admin',
+        viewAll: req.query.viewAll === 'true',
+        userId,
+    });
+    const tasks = scope === 'all'
+        ? await db.getAllAgentTasks(AGENT_TASK_LIMITS.LIST_ALL_DEFAULT)
+        : await db.getUserAgentTasks(userId);
     res.json(success({ tasks: tasks.map(t => toPublicTask(t as unknown as Record<string, unknown>)), total: tasks.length }));
 }));
 

--- a/apps/api/src/routes/chat.routes.ts
+++ b/apps/api/src/routes/chat.routes.ts
@@ -26,6 +26,7 @@ import { chatRateLimiter } from '../middlewares/chat-rate-limiter';
 import { validate } from '../middlewares/validation';
 import { chatRequestSchema } from '../schemas';
 import { ChatRequestHandler, ChatRequestError } from '../chat/request-handler';
+import { ensureSession, saveUserMessage, saveAssistantMessage } from '../chat/request-persistence';
 import { createClient } from '../llm/client';
 import { AppError } from '../utils/error-handler';
 import { parseFullModelId } from '../providers/i-provider';
@@ -240,7 +241,7 @@ router.post('/stream', optionalApiKey, optionalAuth, chatRateLimiter, validate(c
  * 응답: { intent, structured(StructuredAnswer JSON), markdown }.
  */
 router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncHandler(async (req: Request, res: Response) => {
-    const { message } = req.body;
+    const { message, sessionId } = req.body;
     if (typeof message !== 'string' || !message.trim()) {
         res.status(400).json({ error: 'message 는 필수입니다' });
         return;
@@ -250,6 +251,16 @@ router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncH
     if (!userContext) {
         res.status(401).json(unauthorized('인증이 필요합니다'));
         return;
+    }
+
+    // 세션 소유권 검증 (IDOR 방지) — /chat·/chat/stream 과 동일 정책.
+    if (sessionId && isPersistableUserId(userContext.userId)) {
+        const convDB = getConversationDB();
+        const session = await convDB.getSession(sessionId);
+        if (session && String(session.userId) !== String(userContext.userId)) {
+            res.status(403).json({ error: '이 세션에 접근할 권한이 없습니다' });
+            return;
+        }
     }
 
     // 출력 언어: 명시적 선호(userLanguage) 우선, 없으면 메시지 내용으로 감지.
@@ -320,6 +331,7 @@ router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncH
             signal: abortController.signal,
         });
 
+        const startTime = Date.now();
         const composed = await composeStructuredAnswer({
             message,
             userLanguage,
@@ -328,11 +340,42 @@ router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncH
             currentDate: getCurrentDate(),
         });
         settled = true;
+
+        // 대화 기록 저장 (fail-open) — 원 질문 + 구조화 답변을 conversation DB 에 영속.
+        // 스트리밍 경로(request-handler)와 동일한 request-persistence 헬퍼를 재사용해
+        // sessionId 미지정 시 ensureSession 이 자동 생성한다. saveHistory === false 는
+        // 본문 저장 생략(감사 로그만) — 기존 정책과 동일. 저장 실패는 응답을 죽이지 않는다.
+        let savedSessionId: string | undefined;
+        try {
+            const auditUserId = userContext.authenticatedUserId || userContext.anonSessionId || 'anonymous';
+            const persistContent = req.body.saveHistory !== false;
+            const currentSessionId = await ensureSession(
+                sessionId,
+                userContext.authenticatedUserId,
+                message,
+                userContext.anonSessionId,
+                userContext.userRole,
+            );
+            await saveUserMessage(currentSessionId, auditUserId, message, usedModel, persistContent);
+            // 히스토리 재열람 시 JSON blob 이 아니라 완성 답변이 보이도록 렌더된 마크다운을
+            // 본문으로 저장한다. (markdown 은 항상 string 이나 방어적으로 직렬화 폴백.)
+            const assistantContent = typeof composed.markdown === 'string'
+                ? composed.markdown
+                : JSON.stringify(composed.markdown);
+            await saveAssistantMessage(
+                currentSessionId, auditUserId, assistantContent, usedModel, Date.now() - startTime, persistContent,
+            );
+            savedSessionId = currentSessionId;
+        } catch (persistErr) {
+            logger.warn(`[structured] 대화 기록 저장 실패 (continue): ${persistErr instanceof Error ? persistErr.message : persistErr}`);
+        }
+
         res.json(success({
             intent: composed.intent,
             structured: composed.structured,
             markdown: composed.markdown,
             model: usedModel,
+            ...(savedSessionId ? { sessionId: savedSessionId } : {}),
         }));
     } catch (err) {
         settled = true;

--- a/apps/api/src/routes/openai-compat.routes.ts
+++ b/apps/api/src/routes/openai-compat.routes.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response } from 'express';
+import { createHash } from 'crypto';
 import { ClusterManager } from '../cluster/manager';
 import { asyncHandler } from '../utils/error-handler';
 import { ChatRequestError, ChatRequestHandler, ChatUserContext } from '../chat/request-handler';
@@ -12,9 +13,13 @@ import { listAvailableModels } from '../chat/profile-resolver';
 import { parseFullModelId } from '../providers/i-provider';
 import { getProviderCatalogEntry } from '../config/external-providers';
 import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
+import { OpenAICompatSessionRepository } from '../data/repositories/oaicompat-session-repo';
 import { getPool } from '../data/models/unified-database';
+import { OPENAI_COMPAT_SESSION } from '../config/openai-compat';
+import { createLogger } from '../utils/logger';
 
 const openaiCompatRouter = Router();
+const log = createLogger('OpenAICompatRoute');
 let clusterManager: ClusterManager;
 
 export function setClusterManager(cluster: ClusterManager): void {
@@ -80,6 +85,87 @@ function buildUserContext(req: Request): ChatUserContext {
         userRole: 'user',
         userId: req.apiKeyRecord?.user_id?.toString() || `apikey_${req.apiKeyId}`,
     };
+}
+
+/**
+ * OpenAI 호환 요청으로부터 결정적(deterministic) 세션 키를 유도한다.
+ *
+ * 같은 (owner, requestUser, UTC 날짜) 조합은 항상 같은 키를 반환하므로 동일 클라이언트의
+ * 연속 호출이 하나의 세션에 누적된다. 세션 키에 UTC 날짜(YYYYMMDD)를 포함해 하루 단위로
+ * 새 세션이 되도록 하여, 세션이 영원히 한 줄로 이어져 무한히 길어지는 것을 막는다
+ * (일자 파편화 vs 무한 세션 트레이드오프).
+ *
+ * @param owner       계정 스코프 식별자 — 인증된 user id, 없으면 API key 스코프 문자열
+ * @param requestUser OpenAI 요청 body 의 `user` 필드 (없으면 'default')
+ * @param date        키 유도 기준 시각 (기본 현재) — UTC 날짜만 사용
+ */
+export function deriveOpenAICompatSessionKey(
+    owner: string,
+    requestUser: string | undefined,
+    date: Date = new Date(),
+): string {
+    const utcDate = date.toISOString().slice(0, 10).replace(/-/g, ''); // YYYYMMDD (UTC)
+    const material = `${owner}:${requestUser || 'default'}:${utcDate}`;
+    const hex = createHash('sha256')
+        .update(material)
+        .digest('hex')
+        .slice(0, OPENAI_COMPAT_SESSION.HASH_HEX_LENGTH);
+    return `${OPENAI_COMPAT_SESSION.KEY_PREFIX}${hex}`;
+}
+
+interface SessionContinuity {
+    /** 재사용할 기존 세션 ID (없으면 새 세션이 생성됨) */
+    reuseSessionId: string | undefined;
+    /** 유도된 세션 키 — 새 세션 생성 후 metadata 태깅에 사용 */
+    sessionKey: string;
+}
+
+/**
+ * 결정적 세션 키로 기존 conversation 세션을 조회한다.
+ *
+ * 인증 사용자는 user_id 로, 비인증(API key 에 user 없음)은 anon_session_id(=세션 키)로
+ * 소유권을 스코프한다. 비인증 경로는 재사용 세션이 ensureSession 의 익명 소유권 검증을
+ * 통과하도록 userContext.anonSessionId 를 세션 키로 채운다.
+ */
+async function resolveSessionContinuity(
+    body: OpenAIChatCompletionRequest,
+    userContext: ChatUserContext,
+    apiKeyId: string | undefined,
+): Promise<SessionContinuity> {
+    const authUserId = userContext.authenticatedUserId;
+    const owner = authUserId ?? `apikey:${apiKeyId ?? 'unknown'}`;
+    const sessionKey = deriveOpenAICompatSessionKey(owner, body.user);
+
+    // 비인증 경로: 재사용 세션이 ensureSession 익명 소유권 검증을 통과하도록 anon id 를 세션 키로 고정.
+    if (!authUserId) {
+        userContext.anonSessionId = sessionKey;
+    }
+
+    // 연속성 조회 실패는 fail-open — 세션 재사용만 포기하고 새 세션으로 정상 진행.
+    // (조회가 processChat 앞단에 있어, 여기서 throw 하면 DB 순단이 응답 전체를 500 으로 만든다.)
+    let reuseSessionId: string | undefined;
+    try {
+        const repo = new OpenAICompatSessionRepository(getPool());
+        reuseSessionId = authUserId
+            ? await repo.findByKeyForUser(sessionKey, authUserId)
+            : await repo.findByKeyForAnon(sessionKey);
+    } catch (e) {
+        log.warn(`세션 연속성 조회 실패 (새 세션으로 진행): ${e instanceof Error ? e.message : e}`);
+    }
+
+    return { reuseSessionId, sessionKey };
+}
+
+/**
+ * 새로 생성된 세션에 세션 키를 metadata 로 태깅한다 (다음 호출의 조회 대상).
+ * 태깅 실패는 세션 연속성만 잃을 뿐 응답을 막지 않으므로 warn 후 무시(fail-open).
+ */
+async function tagSessionKey(sessionId: string, sessionKey: string): Promise<void> {
+    try {
+        await new OpenAICompatSessionRepository(getPool()).tagKey(sessionId, sessionKey);
+    } catch (e) {
+        log.warn(`세션 키 태깅 실패 (연속성 유실, 응답은 정상): ${e instanceof Error ? e.message : e}`);
+    }
 }
 
 function openaiError(res: Response, status: number, message: string): void {
@@ -195,6 +281,11 @@ openaiCompatRouter.post('/chat/completions', asyncHandler(async (req: Request, r
     const userContext = buildUserContext(req);
     const tools = convertTools(body);
 
+    // 세션 연속성: OpenAI 호환 클라이언트의 연속 호출을 결정적 세션 키로 하나의 세션에 누적.
+    // 매 호출마다 새 세션이 파편 생성되던 문제 해소 (createSession 이 클라이언트 id 를 받지 않아
+    // metadata lookup 방식 채택 — 기존 세션이 있으면 그 실제 id 를 재사용, 없으면 생성 후 태깅).
+    const { reuseSessionId, sessionKey } = await resolveSessionContinuity(body, userContext, req.apiKeyId);
+
     if (body.stream === true) {
         res.setHeader('Content-Type', 'text/event-stream');
         res.setHeader('Cache-Control', 'no-cache');
@@ -221,6 +312,7 @@ openaiCompatRouter.post('/chat/completions', asyncHandler(async (req: Request, r
                 message: converted.message,
                 model: body.model,
                 history: converted.history,
+                sessionId: reuseSessionId,
                 ...(converted.images && converted.images.length > 0 ? { images: converted.images } : {}),
                 tools,
                 tool_choice: body.tool_choice,
@@ -242,6 +334,11 @@ openaiCompatRouter.post('/chat/completions', asyncHandler(async (req: Request, r
             });
 
             const resultModel = result.model || body.model;
+
+            // 새로 생성된 세션이면 세션 키를 태깅 — 다음 호출이 이 세션을 재사용하도록.
+            if (!reuseSessionId && result.sessionId) {
+                await tagSessionKey(result.sessionId, sessionKey);
+            }
 
             if (!aborted && result.tool_calls && result.tool_calls.length > 0) {
                 res.write(`data: ${JSON.stringify(OpenAICompatService.buildStreamChunk({
@@ -292,6 +389,7 @@ openaiCompatRouter.post('/chat/completions', asyncHandler(async (req: Request, r
             message: converted.message,
             model: body.model,
             history: converted.history,
+            sessionId: reuseSessionId,
             ...(converted.images && converted.images.length > 0 ? { images: converted.images } : {}),
             tools,
             tool_choice: body.tool_choice,
@@ -302,6 +400,11 @@ openaiCompatRouter.post('/chat/completions', asyncHandler(async (req: Request, r
                 // non-streaming endpoint intentionally ignores token events
             },
         });
+
+        // 새로 생성된 세션이면 세션 키를 태깅 — 다음 호출이 이 세션을 재사용하도록.
+        if (!reuseSessionId && result.sessionId) {
+            await tagSessionKey(result.sessionId, sessionKey);
+        }
 
         // content array 가 섞여 있어도 안전하게 텍스트만 추출 — string 인 경우만 join, 배열인 경우 text 블록 합산
         const promptTextParts: string[] = [];

--- a/apps/api/src/routes/research.routes.ts
+++ b/apps/api/src/routes/research.routes.ts
@@ -31,11 +31,12 @@ import { requireAuth } from '../auth';
 import { assertResourceOwnerOrAdmin } from '../auth/ownership';
 import { validate } from '../middlewares/validation';
 import { getUnifiedDatabase } from '../data/models/unified-database';
+import { resolveSessionListScope } from '../controllers/session.controller';
 import { v4 as uuidv4 } from 'uuid';
 import { createDeepResearchService } from '../services/DeepResearchService';
 import { resolveRoleClientForUser } from '../services/model-role-resolver';
 import { detectLanguage } from '../chat/language-policy';
-import { RESEARCH_DEPTH_LOOPS } from '../config/runtime-limits';
+import { RESEARCH_DEPTH_LOOPS, RESEARCH_SESSION_LIST_ALL_DEFAULT } from '../config/runtime-limits';
 import {
     createResearchSessionSchema,
     addResearchStepSchema,
@@ -80,13 +81,23 @@ router.post('/sessions', validate(createResearchSessionSchema), asyncHandler(asy
 
 /**
  * GET /api/research/sessions
- * 사용자의 리서치 세션 목록 조회
+ * 사용자의 리서치 세션 목록 조회. 관리자 전용 화면(/admin/conversations)은 ?viewAll=true 로
+ * 전체 사용자 세션을 옵트인 조회한다(비관리자의 viewAll 은 무시 — session.controller 동일 관용구).
+ * 세션 row 는 user_id 를 포함하므로 소유자 식별에 별도 필드가 필요 없다.
  */
 router.get('/sessions', asyncHandler(async (req: Request, res: Response) => {
     const limit = parseInt(req.query.limit as string, 10) || 20;
 
     const db = getUnifiedDatabase();
-    const sessions = await db.getUserResearchSessions(String(req.user!.id), limit);
+    const userId = String(req.user!.id);
+    const scope = resolveSessionListScope({
+        isAdmin: req.user!.role === 'admin',
+        viewAll: req.query.viewAll === 'true',
+        userId,
+    });
+    const sessions = scope === 'all'
+        ? await db.getAllResearchSessions(RESEARCH_SESSION_LIST_ALL_DEFAULT)
+        : await db.getUserResearchSessions(userId, limit);
 
     res.json(success({ sessions, total: sessions.length }));
 }));

--- a/apps/web/app/(workspace)/admin/conversations/page.tsx
+++ b/apps/web/app/(workspace)/admin/conversations/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
 import { MessagesSquare, Search, X, Loader2 } from "lucide-react";
 import type { ApiSuccess } from "@openmake/shared-types";
 import {
@@ -33,6 +34,41 @@ interface ApiConversation {
 
 type ConversationsResponse = ApiSuccess<{ sessions: ApiConversation[] }>;
 
+/* GET /api/agent-tasks?viewAll=true → res.data.tasks (toPublicTask, snake_case). */
+interface ApiAgentTask {
+  id: string;
+  goal: string;
+  status: string;
+  user_id?: string | null;
+  created_at?: string;
+}
+
+type AgentTasksResponse = ApiSuccess<{ tasks: ApiAgentTask[] }>;
+
+/* GET /api/research/sessions?viewAll=true → res.data.sessions (snake_case row). */
+interface ApiResearchSession {
+  id: string;
+  topic: string;
+  status: string;
+  user_id?: string | null;
+  created_at?: string;
+}
+
+type ResearchListResponse = ApiSuccess<{ sessions: ApiResearchSession[] }>;
+
+interface ApiResearchStep {
+  step_number: number;
+  step_type: string;
+  query?: string | null;
+  result?: string | null;
+  status?: string | null;
+}
+
+type ResearchDetailResponse = ApiSuccess<{
+  session?: ApiResearchSession;
+  steps?: ApiResearchStep[];
+}>;
+
 interface AdminUserLite {
   id: string;
   email: string;
@@ -42,6 +78,8 @@ interface AdminUserLite {
 type MessagesResponse = ApiSuccess<{
   messages?: Array<{ role: string; content: string }>;
 }>;
+
+type TabKey = "conversations" | "tasks" | "research";
 
 function fmtDateTime(iso: string | undefined, locale: string): string {
   if (!iso) return "-";
@@ -55,31 +93,64 @@ function fmtDateTime(iso: string | undefined, locale: string): string {
   });
 }
 
+/** 작업/리서치 상태 → Badge 색조. 미지정 상태는 neutral. */
+function statusTone(status: string): "accent" | "success" | "warn" | "danger" | "neutral" {
+  switch (status) {
+    case "completed":
+      return "success";
+    case "failed":
+    case "cancelled":
+      return "danger";
+    case "running":
+    case "paused":
+    case "queued":
+    case "pending":
+      return "accent";
+    default:
+      return "neutral";
+  }
+}
+
 export default function AdminConversationsPage() {
   const t = useTranslations("adminConversations");
   const locale = toBcp47(useLocale());
+  const router = useRouter();
+
+  const [tab, setTab] = useState<TabKey>("conversations");
 
   const [sessions, setSessions] = useState<ApiConversation[]>([]);
+  const [tasks, setTasks] = useState<ApiAgentTask[]>([]);
+  const [research, setResearch] = useState<ApiResearchSession[]>([]);
   const [userMap, setUserMap] = useState<Record<string, AdminUserLite>>({});
   const [loading, setLoading] = useState(true);
   const [query, setQuery] = useState("");
 
-  // 상세 모달 — 선택 세션의 메시지 전문
+  // 상세 모달 — 대화(메시지 전문) / 리서치(스텝 전문)
   const [detail, setDetail] = useState<ApiConversation | null>(null);
   const [detailMsgs, setDetailMsgs] = useState<Array<{ role: string; content: string }> | null>(null);
+  const [researchDetail, setResearchDetail] = useState<ApiResearchSession | null>(null);
+  const [researchSteps, setResearchSteps] = useState<ApiResearchStep[] | null>(null);
 
   useEffect(() => {
     let alive = true;
     (async () => {
-      // 세션 전체 목록(admin 옵트인)과 사용자 목록(이메일 매핑용)을 병렬 조회.
+      // 세 목록(admin 옵트인)과 사용자 목록(이메일 매핑용)을 병렬 조회.
       // 사용자 목록 실패는 허용 — 그 경우 원 userId 로 표시.
-      const [convRes, usersRes] = await Promise.allSettled([
+      const [convRes, taskRes, researchRes, usersRes] = await Promise.allSettled([
         ApiClient.get<ConversationsResponse>("/api/chat/conversations?viewAll=true&limit=200"),
+        ApiClient.get<AgentTasksResponse>("/api/agent-tasks?viewAll=true"),
+        ApiClient.get<ResearchListResponse>("/api/research/sessions?viewAll=true"),
         ApiClient.get<ApiSuccess<{ users?: AdminUserLite[] }>>("/api/admin/users?limit=500"),
       ]);
       if (!alive) return;
       if (convRes.status === "fulfilled") {
         setSessions(convRes.value?.data?.sessions ?? []);
+      }
+      if (taskRes.status === "fulfilled") {
+        setTasks(taskRes.value?.data?.tasks ?? []);
+      }
+      if (researchRes.status === "fulfilled") {
+        setResearch(researchRes.value?.data?.sessions ?? []);
       }
       if (usersRes.status === "fulfilled") {
         const users = usersRes.value?.data?.users ?? [];
@@ -92,15 +163,17 @@ export default function AdminConversationsPage() {
     };
   }, []);
 
-  const ownerLabel = (s: ApiConversation): string => {
-    if (s.userId) {
-      const u = userMap[String(s.userId)];
-      return u ? u.name || u.email : String(s.userId);
+  const ownerLabelById = (userId: string | null | undefined): string => {
+    if (userId) {
+      const u = userMap[String(userId)];
+      return u ? u.name || u.email : String(userId);
     }
     return t("guest");
   };
 
-  const filtered = useMemo(() => {
+  const ownerLabel = (s: ApiConversation): string => ownerLabelById(s.userId);
+
+  const filteredConversations = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return sessions;
     return sessions.filter(
@@ -111,6 +184,35 @@ export default function AdminConversationsPage() {
     // ownerLabel 은 userMap 파생 — deps 로 잡는다
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessions, query, userMap]);
+
+  const filteredTasks = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return tasks;
+    return tasks.filter(
+      (t2) =>
+        (t2.goal ?? "").toLowerCase().includes(q) ||
+        ownerLabelById(t2.user_id).toLowerCase().includes(q),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tasks, query, userMap]);
+
+  const filteredResearch = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return research;
+    return research.filter(
+      (r) =>
+        (r.topic ?? "").toLowerCase().includes(q) ||
+        ownerLabelById(r.user_id).toLowerCase().includes(q),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [research, query, userMap]);
+
+  const activeCount =
+    tab === "conversations"
+      ? filteredConversations.length
+      : tab === "tasks"
+        ? filteredTasks.length
+        : filteredResearch.length;
 
   const openDetail = async (s: ApiConversation) => {
     setDetail(s);
@@ -125,6 +227,27 @@ export default function AdminConversationsPage() {
     }
   };
 
+  // 리서치 상세: 프론트 /research 페이지는 소유자 목록 전제라 딥링크가 없어, 상세 API
+  // (admin 통과)로 스텝을 받아 모달로 표시한다.
+  const openResearchDetail = async (r: ApiResearchSession) => {
+    setResearchDetail(r);
+    setResearchSteps(null);
+    try {
+      const res = await ApiClient.get<ResearchDetailResponse>(
+        `/api/research/sessions/${r.id}`,
+      );
+      setResearchSteps(res?.data?.steps ?? []);
+    } catch {
+      setResearchSteps([]);
+    }
+  };
+
+  const tabDefs: Array<{ key: TabKey; label: string }> = [
+    { key: "conversations", label: t("tabs.conversations") },
+    { key: "tasks", label: t("tabs.tasks") },
+    { key: "research", label: t("tabs.research") },
+  ];
+
   return (
     <>
       <PageHeader
@@ -132,14 +255,29 @@ export default function AdminConversationsPage() {
         description={t("description")}
         actions={
           <Badge tone="neutral">
-            <MessagesSquare className="h-3.5 w-3.5" /> {t("countBadge", { count: filtered.length })}
+            <MessagesSquare className="h-3.5 w-3.5" /> {t("countBadge", { count: activeCount })}
           </Badge>
         }
       />
       <AdminTabs />
 
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
-        <div className="mb-4 flex items-center gap-2">
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          <div className="flex gap-1 rounded-md border border-border bg-surface p-1">
+            {tabDefs.map((d) => (
+              <button
+                key={d.key}
+                onClick={() => setTab(d.key)}
+                className={`rounded px-3 py-1.5 text-sm transition ${
+                  tab === d.key
+                    ? "bg-surface-2 font-medium text-fg"
+                    : "text-muted hover:text-fg-2"
+                }`}
+              >
+                {d.label}
+              </button>
+            ))}
+          </div>
           <div className="relative w-full max-w-sm">
             <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-faint" />
             <input
@@ -153,54 +291,146 @@ export default function AdminConversationsPage() {
 
         <Card>
           <CardContent className="p-0">
-            <Table>
-              <thead>
-                <tr>
-                  <Th>{t("th.title")}</Th>
-                  <Th>{t("th.owner")}</Th>
-                  <Th>{t("th.messages")}</Th>
-                  <Th>{t("th.model")}</Th>
-                  <Th>{t("th.updatedAt")}</Th>
-                </tr>
-              </thead>
-              <tbody>
-                {loading ? (
+            {tab === "conversations" && (
+              <Table>
+                <thead>
                   <tr>
-                    <Td className="py-8 text-center text-muted" colSpan={5}>
-                      <Loader2 className="mx-auto h-5 w-5 animate-spin" />
-                    </Td>
+                    <Th>{t("th.title")}</Th>
+                    <Th>{t("th.owner")}</Th>
+                    <Th>{t("th.messages")}</Th>
+                    <Th>{t("th.model")}</Th>
+                    <Th>{t("th.updatedAt")}</Th>
                   </tr>
-                ) : filtered.length === 0 ? (
-                  <tr>
-                    <Td className="py-8 text-center text-muted" colSpan={5}>
-                      {t("empty")}
-                    </Td>
-                  </tr>
-                ) : (
-                  filtered.map((s) => (
-                    <tr
-                      key={s.id}
-                      onClick={() => openDetail(s)}
-                      className="cursor-pointer transition hover:bg-surface-2"
-                    >
-                      <Td className="max-w-[28rem] truncate font-medium text-fg">
-                        {s.title?.trim() || t("untitled")}
+                </thead>
+                <tbody>
+                  {loading ? (
+                    <tr>
+                      <Td className="py-8 text-center text-muted" colSpan={5}>
+                        <Loader2 className="mx-auto h-5 w-5 animate-spin" />
                       </Td>
-                      <Td>
-                        {s.userId ? (
-                          ownerLabel(s)
-                        ) : (
-                          <Badge tone="neutral">{t("guest")}</Badge>
-                        )}
-                      </Td>
-                      <Td>{s.messageCount ?? 0}</Td>
-                      <Td className="max-w-[12rem] truncate">{s.model || "-"}</Td>
-                      <Td>{fmtDateTime(s.updatedAt || s.createdAt, locale)}</Td>
                     </tr>
-                  ))
-                )}
-              </tbody>
-            </Table>
+                  ) : filteredConversations.length === 0 ? (
+                    <tr>
+                      <Td className="py-8 text-center text-muted" colSpan={5}>
+                        {t("empty")}
+                      </Td>
+                    </tr>
+                  ) : (
+                    filteredConversations.map((s) => (
+                      <tr
+                        key={s.id}
+                        onClick={() => openDetail(s)}
+                        className="cursor-pointer transition hover:bg-surface-2"
+                      >
+                        <Td className="max-w-[28rem] truncate font-medium text-fg">
+                          {s.title?.trim() || t("untitled")}
+                        </Td>
+                        <Td>
+                          {s.userId ? (
+                            ownerLabel(s)
+                          ) : (
+                            <Badge tone="neutral">{t("guest")}</Badge>
+                          )}
+                        </Td>
+                        <Td>{s.messageCount ?? 0}</Td>
+                        <Td className="max-w-[12rem] truncate">{s.model || "-"}</Td>
+                        <Td>{fmtDateTime(s.updatedAt || s.createdAt, locale)}</Td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </Table>
+            )}
+
+            {tab === "tasks" && (
+              <Table>
+                <thead>
+                  <tr>
+                    <Th>{t("taskTh.goal")}</Th>
+                    <Th>{t("taskTh.owner")}</Th>
+                    <Th>{t("taskTh.status")}</Th>
+                    <Th>{t("taskTh.createdAt")}</Th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {loading ? (
+                    <tr>
+                      <Td className="py-8 text-center text-muted" colSpan={4}>
+                        <Loader2 className="mx-auto h-5 w-5 animate-spin" />
+                      </Td>
+                    </tr>
+                  ) : filteredTasks.length === 0 ? (
+                    <tr>
+                      <Td className="py-8 text-center text-muted" colSpan={4}>
+                        {t("tasksEmpty")}
+                      </Td>
+                    </tr>
+                  ) : (
+                    filteredTasks.map((task) => (
+                      <tr
+                        key={task.id}
+                        onClick={() => router.push(`/agent-tasks?task=${task.id}`)}
+                        className="cursor-pointer transition hover:bg-surface-2"
+                      >
+                        <Td className="max-w-[32rem] truncate font-medium text-fg">
+                          {task.goal?.trim() || t("untitled")}
+                        </Td>
+                        <Td>{ownerLabelById(task.user_id)}</Td>
+                        <Td>
+                          <Badge tone={statusTone(task.status)}>{task.status}</Badge>
+                        </Td>
+                        <Td>{fmtDateTime(task.created_at, locale)}</Td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </Table>
+            )}
+
+            {tab === "research" && (
+              <Table>
+                <thead>
+                  <tr>
+                    <Th>{t("researchTh.topic")}</Th>
+                    <Th>{t("researchTh.owner")}</Th>
+                    <Th>{t("researchTh.status")}</Th>
+                    <Th>{t("researchTh.createdAt")}</Th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {loading ? (
+                    <tr>
+                      <Td className="py-8 text-center text-muted" colSpan={4}>
+                        <Loader2 className="mx-auto h-5 w-5 animate-spin" />
+                      </Td>
+                    </tr>
+                  ) : filteredResearch.length === 0 ? (
+                    <tr>
+                      <Td className="py-8 text-center text-muted" colSpan={4}>
+                        {t("researchEmpty")}
+                      </Td>
+                    </tr>
+                  ) : (
+                    filteredResearch.map((r) => (
+                      <tr
+                        key={r.id}
+                        onClick={() => openResearchDetail(r)}
+                        className="cursor-pointer transition hover:bg-surface-2"
+                      >
+                        <Td className="max-w-[32rem] truncate font-medium text-fg">
+                          {r.topic?.trim() || t("untitled")}
+                        </Td>
+                        <Td>{ownerLabelById(r.user_id)}</Td>
+                        <Td>
+                          <Badge tone={statusTone(r.status)}>{r.status}</Badge>
+                        </Td>
+                        <Td>{fmtDateTime(r.created_at, locale)}</Td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </Table>
+            )}
           </CardContent>
         </Card>
       </div>
@@ -241,6 +471,60 @@ export default function AdminConversationsPage() {
                     <p className="mt-1 whitespace-pre-wrap break-words text-sm text-fg-2">
                       {m.content}
                     </p>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {researchDetail && (
+        <div
+          role="dialog"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+          onClick={(ev) => { if (ev.target === ev.currentTarget) setResearchDetail(null); }}
+        >
+          <div className="relative mx-4 flex max-h-[80vh] w-full max-w-2xl flex-col rounded-lg bg-surface shadow-xl">
+            <div className="flex items-start justify-between gap-4 border-b border-border p-4">
+              <div className="min-w-0">
+                <h2 className="truncate text-sm font-semibold text-fg">
+                  {researchDetail.topic?.trim() || t("untitled")}
+                </h2>
+                <p className="mt-0.5 text-xs text-muted">
+                  {ownerLabelById(researchDetail.user_id)} · {fmtDateTime(researchDetail.created_at, locale)}
+                </p>
+              </div>
+              <button
+                onClick={() => setResearchDetail(null)}
+                className="shrink-0 text-faint hover:text-fg"
+                aria-label={t("detail.close")}
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="min-h-0 flex-1 space-y-3 overflow-y-auto p-4">
+              {researchSteps === null ? (
+                <p className="py-6 text-center text-sm text-muted">{t("detail.loading")}</p>
+              ) : researchSteps.length === 0 ? (
+                <p className="py-6 text-center text-sm text-muted">{t("researchDetail.empty")}</p>
+              ) : (
+                researchSteps.map((step, i) => (
+                  <div key={i}>
+                    <div className="flex items-center gap-2">
+                      <Badge tone="neutral">
+                        {t("researchDetail.step", { n: step.step_number })}
+                      </Badge>
+                      <span className="text-xs text-muted">{step.step_type}</span>
+                    </div>
+                    {step.query && (
+                      <p className="mt-1 text-sm font-medium text-fg-2">{step.query}</p>
+                    )}
+                    {step.result && (
+                      <p className="mt-1 whitespace-pre-wrap break-words text-sm text-muted">
+                        {step.result}
+                      </p>
+                    )}
                   </div>
                 ))
               )}

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -722,6 +722,15 @@ export function Composer() {
             e.target.style.height = "auto";
             e.target.style.height = Math.min(e.target.scrollHeight, 200) + "px";
           }}
+          onPaste={(e) => {
+            // 클립보드에 파일이 있으면(스크린샷 캡처·Finder 파일 복사) 드롭과 동일하게
+            // addFiles 로 첨부한다. preventDefault 로 파일명 텍스트가 입력창에 붙는 것을
+            // 막고, 파일이 없는 일반 텍스트 붙여넣기는 기본 동작 그대로 둔다.
+            if (e.clipboardData?.files?.length) {
+              e.preventDefault();
+              void addFiles(e.clipboardData.files);
+            }
+          }}
           onKeyDown={(e) => {
             // 슬래시 메뉴가 열려 있으면 네비게이션/선택 우선 처리.
             // 활성 인덱스는 스킬(0..n-1) + "전체 보기"(n) 를 순회.

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1230,6 +1230,29 @@
       "loading": "Loading messages…",
       "empty": "No messages",
       "close": "Close"
+    },
+    "tabs": {
+      "conversations": "Conversations",
+      "tasks": "Agent Tasks",
+      "research": "Deep Research"
+    },
+    "tasksEmpty": "No agent tasks",
+    "researchEmpty": "No research sessions",
+    "taskTh": {
+      "goal": "Goal",
+      "owner": "User",
+      "status": "Status",
+      "createdAt": "Created"
+    },
+    "researchTh": {
+      "topic": "Topic",
+      "owner": "User",
+      "status": "Status",
+      "createdAt": "Created"
+    },
+    "researchDetail": {
+      "empty": "No research steps",
+      "step": "Step {n}"
     }
   },
   "adminAudit": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1230,6 +1230,29 @@
       "loading": "メッセージを読み込み中…",
       "empty": "メッセージがありません",
       "close": "閉じる"
+    },
+    "tabs": {
+      "conversations": "会話",
+      "tasks": "エージェント作業",
+      "research": "ディープリサーチ"
+    },
+    "tasksEmpty": "エージェント作業がありません",
+    "researchEmpty": "リサーチセッションがありません",
+    "taskTh": {
+      "goal": "目標",
+      "owner": "ユーザー",
+      "status": "ステータス",
+      "createdAt": "作成日"
+    },
+    "researchTh": {
+      "topic": "トピック",
+      "owner": "ユーザー",
+      "status": "ステータス",
+      "createdAt": "作成日"
+    },
+    "researchDetail": {
+      "empty": "リサーチステップがありません",
+      "step": "ステップ {n}"
     }
   },
   "adminAudit": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1230,6 +1230,29 @@
       "loading": "메시지를 불러오는 중…",
       "empty": "메시지가 없습니다",
       "close": "닫기"
+    },
+    "tabs": {
+      "conversations": "대화",
+      "tasks": "에이전트 작업",
+      "research": "딥 리서치"
+    },
+    "tasksEmpty": "에이전트 작업이 없습니다",
+    "researchEmpty": "리서치 세션이 없습니다",
+    "taskTh": {
+      "goal": "목표",
+      "owner": "사용자",
+      "status": "상태",
+      "createdAt": "생성일"
+    },
+    "researchTh": {
+      "topic": "주제",
+      "owner": "사용자",
+      "status": "상태",
+      "createdAt": "생성일"
+    },
+    "researchDetail": {
+      "empty": "리서치 스텝이 없습니다",
+      "step": "스텝 {n}"
     }
   },
   "adminAudit": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1230,6 +1230,29 @@
       "loading": "正在加载消息…",
       "empty": "暂无消息",
       "close": "关闭"
+    },
+    "tabs": {
+      "conversations": "对话",
+      "tasks": "智能体任务",
+      "research": "深度研究"
+    },
+    "tasksEmpty": "暂无智能体任务",
+    "researchEmpty": "暂无研究会话",
+    "taskTh": {
+      "goal": "目标",
+      "owner": "用户",
+      "status": "状态",
+      "createdAt": "创建时间"
+    },
+    "researchTh": {
+      "topic": "主题",
+      "owner": "用户",
+      "status": "状态",
+      "createdAt": "创建时间"
+    },
+    "researchDetail": {
+      "empty": "暂无研究步骤",
+      "step": "步骤 {n}"
     }
   },
   "adminAudit": {


### PR DESCRIPTION
## 요약

히스토리 전수 조사(#442 후속)에서 확인된 "사용자 질문·답변이 히스토리에 남지 않는" 공백 3건을 해소하고, 채팅 입력창 클립보드 붙여넣기 첨부를 추가한다. 3건은 병렬 구현 후 상호영향 지점(ensureSession 계약·viewAll 관용구·i18n·저장 정책) 기준으로 통합 검증했다.

## 변경 내용

### 1. `POST /api/chat/structured` 대화 저장 (chat.routes.ts)
- processChat 을 우회해 질문·답변이 전혀 저장되지 않던 **유일한 "완전 미저장" 사용자 경로**.
- `request-persistence` 헬퍼 재사용: sessionId 미지정 시 ensureSession 자동 생성, `saveHistory=false` 본문 생략, 저장 실패 fail-open, 형제 라우트(`/`·`/stream`)와 동일한 IDOR 사전 검증.
- assistant 본문은 JSON blob 이 아닌 **렌더된 마크다운**으로 저장(히스토리 재열람 시 완성 답변 표시, WS 경로와 일관). 성공 시 응답에 `sessionId` 포함.

### 2. 관리자 전체 조회 확장 (`/admin/conversations` 탭 3개)
- 대화 | 에이전트 작업 | 딥 리서치 탭 — 관리자가 다른 사용자의 작업·리서치를 **목록으로** 볼 수 없던 갭 해소 (상세 권한 `assertResourceOwnerOrAdmin` 은 기존부터 admin 통과).
- `GET /api/agent-tasks?viewAll=true`·`GET /api/research/sessions?viewAll=true` — #442 의 `resolveSessionListScope` 재사용(admin+viewAll 만 전체, 비관리자 viewAll 무시).
- 데이터 계층 `getAllAgentTasks`/`getAllResearchSessions` 추가(파라미터화, 상한은 config 상수+env 오버라이드). 리서치 상세는 페이지 내 모달(steps), 작업 행은 기존 `/agent-tasks?task={id}` 딥링크.

### 3. OpenAI 호환 API 세션 연속성 (openai-compat.routes.ts)
- 매 호출 새 세션이 생겨 대화가 1턴짜리로 파편화되던 문제(Discord 등 게이트웨이 클라이언트).
- 결정적 세션 키 `oaicompat-` + sha256(`owner:body.user:UTC일자`) 32hex 를 세션 metadata 에 태깅, 다음 호출이 같은 세션 재사용. UTC 일자 포함으로 무한 세션 방지(일 단위 분절).
- `createSession` 이 호출자 지정 id 를 받지 않아 **metadata lookup 방식** 채택. 조회·태깅 모두 fail-open — 조회가 processChat 앞단이라 DB 순단이 응답 전체를 500 으로 만들지 않도록 보강(기존 openai-compat-images 테스트 회귀로 검출·수정).
- 키 유도는 export 순수 함수, SQL 은 repository 계층 분리(routes SQL 금지 규칙).

### 4. 채팅 입력창 클립보드 붙여넣기 첨부 (composer.tsx)
- textarea `onPaste` 에서 `clipboardData.files` 존재 시 기존 `addFiles` 경로로 첨부(⌘V/Ctrl+V 스크린샷·파일 복사). 텍스트 붙여넣기는 기본 동작 유지.

## 검증

- [x] 전체 jest — **2398 passed** (신규 스위트 3종 + 기존 openai-compat-images 회귀 수정 포함, 실패 0)
- [x] `tsc --noEmit` — apps/api·apps/web 모두 클린
- [x] `check:i18n` — 4개 로케일 1,265키 정합
- [x] eslint — 변경 파일 0 error (max-lines 경고 1건은 기존 초과·600줄 가드 미만)
- [x] `conversation_sessions.metadata` jsonb 타입 실 DB 확인 (metadata lookup SQL 전제)

🤖 Generated with [Claude Code](https://claude.com/claude-code)