### PR TITLE
feat(cli): CLI 채팅 히스토리 저장 + MCP 샌드박스 대화 데드코드 정리

### DIFF
--- a/apps/api/src/chat/index.ts
+++ b/apps/api/src/chat/index.ts
@@ -10,6 +10,7 @@
 
 import inquirer from 'inquirer';
 import chalk from 'chalk';
+import * as os from 'os';
 import { LLMClient } from '../llm';
 import {
     ChatMessage,
@@ -20,8 +21,13 @@ import { getSystemPrompt } from './prompt';
 import { showCompactBanner, showModelInfo, showDivider } from '../ui/banner';
 import { createSpinner } from '../ui/spinner';
 import { createLogger } from '../utils/logger';
+import { getConversationDB } from '../data/conversation-db';
+import { closeDatabase } from '../data/models/unified-database';
 
 const logger = createLogger('ChatModule');
+
+/** CLI 발 세션 식별 마커 — conversation_sessions.metadata.source 값 (admin 화면 'CLI' 뱃지) */
+export const CLI_SESSION_SOURCE = 'cli';
 
 export interface ChatOptions {
     model?: string;
@@ -33,6 +39,12 @@ export class ChatSession {
     private messages: ChatMessage[] = [];
     private systemPrompt: string;
     private modelOptions: ModelOptions;
+    /** 현재 대화가 기록 중인 conversation_sessions.id (첫 교환 성공 시 생성, clear 시 리셋) */
+    private convSessionId: string | null = null;
+    /** DB 접근 실패 시 true — 이후 저장 시도를 중단해 매 턴 연결 대기를 막는다 (fail-open) */
+    private persistDisabled = false;
+    /** 이번 실행에서 한 번이라도 저장했는지 — 종료 시 pool 정리 여부 판단 */
+    private persisted = false;
 
     constructor(client: LLMClient, options: ChatOptions = {}) {
         this.client = client;
@@ -64,6 +76,11 @@ export class ChatSession {
         logger.info(chalk.gray('채팅을 시작합니다. "exit" 또는 "quit"을 입력하면 종료됩니다.\n'));
 
         await this.loop();
+
+        // 저장에 사용한 pg pool 이 이벤트 루프를 잡아 프로세스 종료를 막지 않도록 정리
+        if (this.persisted) {
+            await closeDatabase().catch(() => undefined);
+        }
     }
 
     private async loop(): Promise<void> {
@@ -131,6 +148,7 @@ export class ChatSession {
             }
 
             this.messages.push(response);
+            await this.persistExchange(content, response.content ?? '');
         } catch (error) {
             spinner.fail('응답 생성 실패');
 
@@ -154,6 +172,39 @@ export class ChatSession {
             content: this.systemPrompt
         }];
         this.client.clearContext();
+        // 기록 초기화 = 새 대화 — 다음 교환부터 새 세션에 저장
+        this.convSessionId = null;
+    }
+
+    /**
+     * 성공한 질문/답변 한 쌍을 conversation DB 에 저장한다 (fail-open).
+     *
+     * CLI 는 인증 주체가 없어 userId/anonSessionId 없이 저장하며, 소유권 검증
+     * (evaluateSessionAccess) 특성상 관리자만 열람 가능하다. metadata.source='cli'
+     * 마커로 admin 화면(/admin/conversations)에서 'CLI' 뱃지로 구분된다.
+     * DB 연결 실패 시 경고 1회 후 이후 저장을 중단해 채팅 흐름을 막지 않는다.
+     */
+    private async persistExchange(question: string, answer: string): Promise<void> {
+        if (this.persistDisabled) return;
+        try {
+            const db = getConversationDB();
+            if (!this.convSessionId) {
+                const session = await db.createSession(
+                    undefined,
+                    question.substring(0, 30),
+                    { source: CLI_SESSION_SOURCE, host: os.hostname() },
+                );
+                this.convSessionId = session.id;
+            }
+            await db.saveMessage(this.convSessionId, 'user', question, { model: this.client.model });
+            await db.saveMessage(this.convSessionId, 'assistant', answer, { model: this.client.model });
+            this.persisted = true;
+        } catch (error) {
+            this.persistDisabled = true;
+            logger.info(chalk.gray(
+                `⚠️  대화 기록 저장 비활성화 (DB 연결 실패): ${error instanceof Error ? error.message : error}`,
+            ));
+        }
     }
 
     private showHelp(): void {

--- a/apps/api/src/mcp/user-sandbox.ts
+++ b/apps/api/src/mcp/user-sandbox.ts
@@ -25,8 +25,7 @@
  * └── {userId}/
  *     ├── workspace/    # 작업 디렉토리 (fs_read_file 등의 기준)
  *     ├── data/          # 사용자 DB 및 데이터 파일
- *     │   ├── user.db
- *     │   └── conversations.db
+ *     │   └── user.db
  *     ├── temp/          # 임시 파일 (자동 정리 대상)
  *     └── config.json    # 사용자 설정
  * ```
@@ -226,17 +225,6 @@ export class UserSandbox {
         // 디렉토리 초기화 (존재하지 않으면 생성)
         await this.initUserDirs(userId);
         return path.resolve(getUserDataRoot(), String(userId), 'data', 'user.db');
-    }
-
-    /**
-     * 사용자별 대화 DB 파일 경로 반환
-     *
-     * @param userId - 사용자 ID
-     * @returns DB 파일 절대 경로 (data/conversations.db)
-     */
-    static async getUserConversationDbPath(userId: string | number): Promise<string> {
-        await this.initUserDirs(userId);
-        return path.resolve(getUserDataRoot(), String(userId), 'data', 'conversations.db');
     }
 
     /**

--- a/apps/web/app/(workspace)/admin/conversations/page.tsx
+++ b/apps/web/app/(workspace)/admin/conversations/page.tsx
@@ -30,6 +30,8 @@ interface ApiConversation {
   createdAt?: string;
   model?: string;
   messageCount?: number;
+  /** 세션 출처 마커 — source='cli' 는 서버 CLI 채팅 (게스트와 구분해 표시) */
+  metadata?: { source?: string } | null;
 }
 
 type ConversationsResponse = ApiSuccess<{ sessions: ApiConversation[] }>;
@@ -171,7 +173,8 @@ export default function AdminConversationsPage() {
     return t("guest");
   };
 
-  const ownerLabel = (s: ApiConversation): string => ownerLabelById(s.userId);
+  const ownerLabel = (s: ApiConversation): string =>
+    !s.userId && s.metadata?.source === "cli" ? t("cliSource") : ownerLabelById(s.userId);
 
   const filteredConversations = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -329,7 +332,9 @@ export default function AdminConversationsPage() {
                           {s.userId ? (
                             ownerLabel(s)
                           ) : (
-                            <Badge tone="neutral">{t("guest")}</Badge>
+                            <Badge tone="neutral">
+                              {s.metadata?.source === "cli" ? t("cliSource") : t("guest")}
+                            </Badge>
                           )}
                         </Td>
                         <Td>{s.messageCount ?? 0}</Td>

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1217,6 +1217,7 @@
     "countBadge": "{count} sessions",
     "searchPlaceholder": "Search title or user",
     "guest": "Guest",
+    "cliSource": "CLI",
     "untitled": "Untitled conversation",
     "empty": "No conversations",
     "th": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1217,6 +1217,7 @@
     "countBadge": "{count}件のセッション",
     "searchPlaceholder": "タイトル・ユーザーを検索",
     "guest": "ゲスト",
+    "cliSource": "CLI",
     "untitled": "無題の会話",
     "empty": "会話がありません",
     "th": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1217,6 +1217,7 @@
     "countBadge": "{count}개 세션",
     "searchPlaceholder": "제목·사용자 검색",
     "guest": "게스트",
+    "cliSource": "CLI",
     "untitled": "제목 없는 대화",
     "empty": "대화가 없습니다",
     "th": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1217,6 +1217,7 @@
     "countBadge": "{count} 个会话",
     "searchPlaceholder": "搜索标题或用户",
     "guest": "访客",
+    "cliSource": "CLI",
     "untitled": "无标题对话",
     "empty": "暂无对话",
     "th": {


### PR DESCRIPTION
## 요약

히스토리 전수 조사(#443 후속)에서 남아 있던 마지막 공백 2건을 해소한다.

## 변경 내용

### 1. CLI 채팅 히스토리 저장 (`chat/index.ts`)
- CLI 대화형 채팅(`cli.js chat`)의 질문·답변이 어디에도 저장되지 않던 문제 → 교환 성공 시 conversation DB 에 저장.
- `metadata.source='cli'` + `host`(호스트명) 마커로 세션 태깅. `clear` 명령 시 새 세션.
- **fail-open**: DB 연결 실패 시 경고 1회 출력 후 저장만 비활성화(채팅 흐름 유지). 종료 시 pg pool 정리로 프로세스 정상 종료.
- 소유자 없는 세션(userId·anonSessionId 모두 null)이라 `evaluateSessionAccess` 특성상 **관리자만 열람 가능**.

### 2. 관리자 화면 'CLI' 뱃지 (`/admin/conversations`)
- CLI 세션이 게스트와 섞여 보이지 않도록 `metadata.source==='cli'` 이면 'CLI' 뱃지 표시. i18n 4개 로케일 키 추가.

### 3. MCP 샌드박스 SQLite 대화 — 데드코드로 판명, 정리 (`mcp/user-sandbox.ts`)
- 조사 결과 `getUserConversationDbPath` 는 **호출처 0곳**, `data/users/` 디렉토리는 **파일 0건** — "사용자별 SQLite 에 격리된 대화"는 실존한 적이 없다 (MCP 도구 사용 대화는 일반 채팅 파이프라인을 타서 이미 Postgres 에 저장됨).
- 오해를 만드는 죽은 경로 헬퍼와 주석만 제거 (동작 변경 없음).

## 검증

- [x] CI 6게이트 로컬 재현 전부 통과: jest **2398 passed** · tsc(api·web) 클린 · 파일 크기(223·354줄) · lint 0 error · routing 93.3% · response 100%
- [x] 라이브 E2E (ts-node): CLI 로 질문 → DB `conversation_sessions/messages` 에 `source='cli'`·host 포함 저장 확인, `exit` 시 **프로세스 정상 종료(exit 0)** 확인
- [x] `check:i18n` 4로케일 1,266키 정합

🤖 Generated with [Claude Code](https://claude.com/claude-code)