### PR TITLE
fix(agent-task): 샌드박스 도구 오류 5대 원인 해소 — 안내·관용화·오류 관측

### DIFF
--- a/apps/api/src/data/repositories/__tests__/agent-task-metrics-repository.test.ts
+++ b/apps/api/src/data/repositories/__tests__/agent-task-metrics-repository.test.ts
@@ -1,0 +1,74 @@
+import { Pool } from 'pg';
+import { AgentTaskMetricsRepository } from '../agent-task-metrics-repository';
+
+jest.mock('../../retry-wrapper', () => ({ withRetry: (fn: () => unknown) => fn() }));
+
+function makeMockPool() {
+    return { query: jest.fn() } as unknown as Pool;
+}
+
+describe('AgentTaskMetricsRepository', () => {
+    let pool: Pool;
+    let repo: AgentTaskMetricsRepository;
+
+    beforeEach(() => {
+        pool = makeMockPool();
+        repo = new AgentTaskMetricsRepository(pool);
+    });
+
+    it('getToolErrorSummary: tool_result 필터 + days interval 파라미터화', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({
+            rows: [{ total_tool_executions: '1240', error_count: '201', affected_tasks: '71' }],
+        });
+        const row = await repo.getToolErrorSummary(30);
+        expect(row.total_tool_executions).toBe('1240');
+        expect(row.error_count).toBe('201');
+        const [sql, params] = (pool.query as jest.Mock).mock.calls[0];
+        expect(sql).toMatch(/step_type = 'tool_result'/);
+        expect(sql).toMatch(/content LIKE 'Error:%'/);
+        expect(sql).toMatch(/\$1 \|\| ' days'/);
+        expect(params).toEqual(['30']);
+    });
+
+    it('getToolErrorSummary: 빈 결과 시 0 기본값', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+        const row = await repo.getToolErrorSummary(7);
+        expect(row).toEqual({ total_tool_executions: '0', error_count: '0', affected_tasks: '0' });
+    });
+
+    it('getToolErrorTaskStatusDistribution: agent_tasks 조인 + status GROUP BY', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({
+            rows: [
+                { status: 'completed', tasks: '54' },
+                { status: 'failed', tasks: '13' },
+            ],
+        });
+        const rows = await repo.getToolErrorTaskStatusDistribution(30);
+        expect(rows).toHaveLength(2);
+        const sql = (pool.query as jest.Mock).mock.calls[0][0];
+        expect(sql).toMatch(/JOIN agent_task_steps/);
+        expect(sql).toMatch(/GROUP BY t\.status/);
+    });
+
+    it('getToolErrorSignatures: content 정규화 + limit 파라미터화', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({
+            rows: [{ signature: 'Error: [stderr]', count: '26' }],
+        });
+        const rows = await repo.getToolErrorSignatures(30, 10);
+        expect(rows[0].count).toBe('26');
+        const [sql, params] = (pool.query as jest.Mock).mock.calls[0];
+        expect(sql).toMatch(/regexp_replace/);
+        expect(sql).toMatch(/LIMIT \$2/);
+        expect(params).toEqual(['30', 10]);
+    });
+
+    it('getToolErrorByToolName: tool_name IS NOT NULL 필터', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({
+            rows: [{ tool_name: 'bash', count: '47' }],
+        });
+        const rows = await repo.getToolErrorByToolName(30, 10);
+        expect(rows[0].tool_name).toBe('bash');
+        const sql = (pool.query as jest.Mock).mock.calls[0][0];
+        expect(sql).toMatch(/tool_name IS NOT NULL/);
+    });
+});

--- a/apps/api/src/data/repositories/agent-task-metrics-repository.ts
+++ b/apps/api/src/data/repositories/agent-task-metrics-repository.ts
@@ -1,0 +1,114 @@
+/**
+ * @module data/repositories/agent-task-metrics-repository
+ * @description 에이전트 작업 도구 실행 오류 관측용 읽기 전용 집계 계층
+ *
+ * `agent_task_steps` 의 도구 실행 결과(step_type='tool_result') 중 오류(content LIKE 'Error:%')를
+ * 관리자 대시보드에서 볼 수 있도록 집계한다. 도구 오류는 이전까지 어디에도 집계되지 않아
+ * 운영자가 관측할 수 없었다.
+ *
+ * - 기간별 도구 오류 요약(총 실행 수·오류 수·오류율, 오류 발생 작업 수와 상태 분포)
+ * - 오류 시그니처 상위 N (content 앞부분 정규화 기준 GROUP BY)
+ * - tool_name 별 오류 수 (tool_name 은 088 마이그레이션 이후 스텝에만 존재)
+ *
+ * 전부 파라미터화 쿼리, read-only. 숫자 파싱(COUNT 는 문자열로 옴)은 응답 조립부에 남긴다.
+ */
+import { BaseRepository } from './base-repository';
+
+/** 도구 실행 오류 요약 (총량/오류율/작업 분포) */
+export interface ToolErrorSummaryRow {
+    total_tool_executions: string;
+    error_count: string;
+    affected_tasks: string;
+}
+
+/** 오류 발생 작업의 결말(status) 분포 */
+export interface ToolErrorTaskStatusRow {
+    status: string;
+    tasks: string;
+}
+
+/** 오류 시그니처(정규화된 content 앞부분)별 건수 */
+export interface ToolErrorSignatureRow {
+    signature: string;
+    count: string;
+}
+
+/** tool_name 별 오류 건수 */
+export interface ToolErrorByToolRow {
+    tool_name: string;
+    count: string;
+}
+
+export class AgentTaskMetricsRepository extends BaseRepository {
+    /**
+     * 기간별 도구 오류 요약 — 총 도구 실행 수, 오류 수, 오류 발생 고유 작업 수.
+     * 오류율은 응답 조립부에서 error_count / total 로 계산한다.
+     */
+    async getToolErrorSummary(days: number): Promise<ToolErrorSummaryRow> {
+        const result = await this.query<ToolErrorSummaryRow>(
+            `SELECT
+                    COUNT(*) FILTER (WHERE step_type = 'tool_result') AS total_tool_executions,
+                    COUNT(*) FILTER (WHERE step_type = 'tool_result' AND content LIKE 'Error:%') AS error_count,
+                    COUNT(DISTINCT task_id) FILTER (WHERE step_type = 'tool_result' AND content LIKE 'Error:%') AS affected_tasks
+             FROM agent_task_steps
+             WHERE created_at >= NOW() - ($1 || ' days')::interval`,
+            [String(days)]
+        );
+        return result.rows[0] ?? { total_tool_executions: '0', error_count: '0', affected_tasks: '0' };
+    }
+
+    /** 오류 발생 작업의 status 분포 (completed/failed/cancelled 등) — 결말 구분 */
+    async getToolErrorTaskStatusDistribution(days: number): Promise<ToolErrorTaskStatusRow[]> {
+        const result = await this.query<ToolErrorTaskStatusRow>(
+            `SELECT t.status AS status,
+                    COUNT(DISTINCT t.id) AS tasks
+             FROM agent_tasks t
+             JOIN agent_task_steps s ON s.task_id = t.id
+             WHERE s.step_type = 'tool_result'
+               AND s.content LIKE 'Error:%'
+               AND s.created_at >= NOW() - ($1 || ' days')::interval
+             GROUP BY t.status
+             ORDER BY tasks DESC`,
+            [String(days)]
+        );
+        return result.rows;
+    }
+
+    /**
+     * 오류 시그니처 상위 N — content 첫 줄 앞 120자 기준으로 GROUP BY.
+     * (첫 줄만 남기면 개별 스택트레이스/경로 차이를 뭉개 유사 오류를 묶는다.)
+     */
+    async getToolErrorSignatures(days: number, limit: number): Promise<ToolErrorSignatureRow[]> {
+        const result = await this.query<ToolErrorSignatureRow>(
+            `SELECT left(regexp_replace(content, E'\\n.*', '', 'g'), 120) AS signature,
+                    COUNT(*) AS count
+             FROM agent_task_steps
+             WHERE step_type = 'tool_result'
+               AND content LIKE 'Error:%'
+               AND created_at >= NOW() - ($1 || ' days')::interval
+             GROUP BY 1
+             ORDER BY count DESC, signature
+             LIMIT $2`,
+            [String(days), limit]
+        );
+        return result.rows;
+    }
+
+    /** tool_name 별 오류 수 (tool_name 이 있는 행만 — 088 이후 스텝) */
+    async getToolErrorByToolName(days: number, limit: number): Promise<ToolErrorByToolRow[]> {
+        const result = await this.query<ToolErrorByToolRow>(
+            `SELECT tool_name,
+                    COUNT(*) AS count
+             FROM agent_task_steps
+             WHERE step_type = 'tool_result'
+               AND content LIKE 'Error:%'
+               AND tool_name IS NOT NULL
+               AND created_at >= NOW() - ($1 || ' days')::interval
+             GROUP BY tool_name
+             ORDER BY count DESC, tool_name
+             LIMIT $2`,
+            [String(days), limit]
+        );
+        return result.rows;
+    }
+}

--- a/apps/api/src/data/repositories/index.ts
+++ b/apps/api/src/data/repositories/index.ts
@@ -4,6 +4,7 @@ export { ConversationRepository } from './conversation-repository';
 // MemoryRepository: 2026-05-19 제거 (MemoryService 폐기)
 export { ResearchRepository } from './research-repository';
 export { AgentTaskRepository } from './agent-task-repository';
+export { AgentTaskMetricsRepository } from './agent-task-metrics-repository';
 export { ApiKeyRepository } from './api-key-repository';
 export { AuditRepository } from './audit-repository';
 export { ExternalRepository } from './external-repository';

--- a/apps/api/src/prompts/agent-task-prompt.ts
+++ b/apps/api/src/prompts/agent-task-prompt.ts
@@ -92,6 +92,11 @@ export function getTaskSandboxGuidance(): string {
         '  ⚠️ PDF 에 한글 등 비-라틴 문자가 들어가면 기본 폰트(helvetica)는 실패합니다. 반드시 번들된 한글 폰트를 등록하세요:',
         '  fpdf2 → pdf.add_font("Nanum","","/usr/share/fonts/truetype/nanum/NanumGothic.ttf"); pdf.set_font("Nanum", size=12)',
         '  reportlab → pdfmetrics.registerFont(TTFont("Nanum","/usr/share/fonts/truetype/nanum/NanumGothic.ttf")) 후 해당 폰트 사용.',
+        '- ⚠️ 파일 도구(str_replace_editor·file_ops)는 /workspace 내부만 접근합니다. /opt/report-template 같은',
+        '  컨테이너 내부 경로를 파일 도구로 읽거나 편집하려 하면 "경로 탈출 차단" 오류가 반복됩니다 —',
+        '  그 경로의 파일을 보거나 고쳐야 하면 먼저 bash 로 `cp -r /opt/report-template/. ./tpl/` 처럼',
+        '  workspace 에 복사한 뒤 그 사본을 여세요. 실행만 하면 되는 스크립트는 복사 없이 bash 로 바로',
+        '  `python3 /opt/report-template/render_report.py ...` 처럼 실행하면 됩니다.',
         '- 코드 작업: git 과 ripgrep(rg) 이 설치되어 있습니다. 업로드된 코드의 수정 작업은 /workspace 의',
         '  파일을 직접 편집하세요 — 변경분은 완료 시 자동으로 diff 로 기록되어 사용자에게 표시됩니다',
         '  (커밋은 직접 하지 않아도 됩니다).',
@@ -116,6 +121,8 @@ export function getAgentTaskUploadedFilesNote(fileLines: string[]): string {
         '사용자가 이 작업에 파일을 첨부했습니다. 작업 디렉토리(/workspace)에 저장되어 있습니다:',
         ...fileLines,
         'PDF·오피스 문서는 이미 텍스트로 추출되어 있습니다. 먼저 이 파일들을 읽고(cat/python) 내용을 근거로 작업하세요.',
+        '원본(.xlsx 등) 파싱이 실패하면(웹/JS 로 생성된 엑셀은 스타일 결함으로 openpyxl 로드가 자주 실패합니다)',
+        '같은 파일을 반복해서 열지 말고, 함께 기록된 `<원본명>.txt` 추출 텍스트를 사용해 작업하세요.',
     ].join('\n');
 }
 

--- a/apps/api/src/routes/metrics.routes.ts
+++ b/apps/api/src/routes/metrics.routes.ts
@@ -43,6 +43,7 @@ import { requireAuth, requireAdmin } from '../auth';
 import { asyncHandler } from '../utils/error-handler';
 import { getPool } from '../data/models/unified-database';
 import { ConversationRepository } from '../data/repositories/conversation-repository';
+import { AgentTaskMetricsRepository } from '../data/repositories/agent-task-metrics-repository';
 
 /** days 쿼리 파라미터 정수 파싱 + clamp(1~365). interval 인젝션 방지를 위해 항상 정수 반환. */
 function parseDays(raw: unknown, fallback = 7): number {
@@ -213,6 +214,49 @@ router.get('/analytics/model-usage', asyncHandler(async (req: Request, res: Resp
         count: Number(row.count),
     }));
     res.json(success({ models }));
+}));
+
+/**
+ * GET /api/metrics/agent-tasks/tool-errors?days=N
+ * 에이전트 작업 도구 실행 오류 관측 (관리자). 기본 30일.
+ * 총 도구 실행 수·오류 수·오류율, 오류 발생 작업 수와 상태 분포,
+ * 오류 시그니처 상위 N(기본 10), tool_name 별 오류 수를 반환.
+ */
+router.get('/agent-tasks/tool-errors', asyncHandler(async (req: Request, res: Response) => {
+    const days = parseDays(req.query.days, 30);
+    const repo = new AgentTaskMetricsRepository(getPool());
+    const [summaryRow, statusRows, signatureRows, byToolRows] = await Promise.all([
+        repo.getToolErrorSummary(days),
+        repo.getToolErrorTaskStatusDistribution(days),
+        repo.getToolErrorSignatures(days, 10),
+        repo.getToolErrorByToolName(days, 10),
+    ]);
+
+    const totalToolExecutions = Number(summaryRow.total_tool_executions);
+    const errorCount = Number(summaryRow.error_count);
+    const errorRate = totalToolExecutions > 0 ? errorCount / totalToolExecutions : 0;
+
+    res.json(success({
+        days,
+        summary: {
+            totalToolExecutions,
+            errorCount,
+            errorRate,
+            affectedTasks: Number(summaryRow.affected_tasks),
+        },
+        affectedTaskStatus: statusRows.map((r) => ({
+            status: r.status,
+            tasks: Number(r.tasks),
+        })),
+        topSignatures: signatureRows.map((r) => ({
+            signature: r.signature,
+            count: Number(r.count),
+        })),
+        byToolName: byToolRows.map((r) => ({
+            toolName: r.tool_name,
+            count: Number(r.count),
+        })),
+    }));
 }));
 
 /**

--- a/apps/api/src/services/agent-spawn/spawn-agents.test.ts
+++ b/apps/api/src/services/agent-spawn/spawn-agents.test.ts
@@ -48,6 +48,7 @@ import {
     runSpawnAgents,
     runChatSpawnAgents,
     buildTaskSpawnFn,
+    normalizeSpawnArgs,
 } from './spawn-agents';
 import { SPAWN_AGENT_GENERIC_PROMPT } from '../../prompts/spawn-agent-system';
 
@@ -83,6 +84,24 @@ describe('spawnAgentsArgsSchema / runSpawnAgents 인자 검증', () => {
     it('빈 배열·빈 prompt 도 거부한다', async () => {
         expect(await runSpawnAgents({ ...baseParams, args: { tasks: [] } })).toMatch(/^Error:/);
         expect(await runSpawnAgents({ ...baseParams, args: { tasks: [{ prompt: '  ' }] } })).toMatch(/^Error:/);
+    });
+});
+
+describe('normalizeSpawnArgs (인자 형태 관용 정규화)', () => {
+    it('tasks 가 단일 객체면 배열로 감싼다', () => {
+        expect(normalizeSpawnArgs({ tasks: { prompt: 'a' } })).toEqual({ tasks: [{ prompt: 'a' }] });
+    });
+    it('tasks 키 없이 {prompt} 를 직접 넘기면 tasks 배열로 감싼다', () => {
+        expect(normalizeSpawnArgs({ prompt: 'a', role: 'finance' })).toEqual({ tasks: [{ prompt: 'a', role: 'finance' }] });
+    });
+    it('이미 배열이면 원본을 그대로 통과시킨다', () => {
+        const raw = { tasks: [{ prompt: 'a' }] };
+        expect(normalizeSpawnArgs(raw)).toBe(raw);
+    });
+    it('감싼 형태를 스키마가 수용해 실행된다', async () => {
+        const out = await runSpawnAgents({ ...baseParams, args: { tasks: { prompt: 'solo' } } });
+        expect(out).not.toMatch(/^Error:/);
+        expect(runSubagentMock).toHaveBeenCalled();
     });
 });
 

--- a/apps/api/src/services/agent-spawn/spawn-agents.ts
+++ b/apps/api/src/services/agent-spawn/spawn-agents.ts
@@ -56,6 +56,24 @@ export const spawnAgentsArgsSchema = z.object({
 
 export type SpawnTask = z.infer<typeof spawnAgentsArgsSchema>['tasks'][number];
 
+/**
+ * PURE: 모델이 자주 흘리는 인자 형태를 스키마에 맞게 감싼다(계약 유지 — 값을 버리거나
+ * 바꾸지 않고 형태만 정규화). ① `tasks` 가 단일 객체면 배열로, ② `tasks` 키 없이
+ * `{prompt, ...}` 를 직접 넘긴 경우 `{tasks:[그것]}` 로. 그 외는 원본을 그대로 통과시켜
+ * 검증이 정상적으로 거부하게 둔다.
+ */
+export function normalizeSpawnArgs(raw: unknown): unknown {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return raw;
+    const o = raw as Record<string, unknown>;
+    if (o.tasks && typeof o.tasks === 'object' && !Array.isArray(o.tasks)) {
+        return { ...o, tasks: [o.tasks] };
+    }
+    if (!('tasks' in o) && typeof o.prompt === 'string') {
+        return { tasks: [o] };
+    }
+    return raw;
+}
+
 export const SPAWN_AGENTS_TOOL_DESCRIPTION =
     '서로 독립적인 하위 작업 여러 개를 병렬 서브에이전트들에게 분담시켜 동시에 수행합니다. '
     + '각 태스크는 다른 태스크 결과를 참조할 수 없으므로 자기완결적으로 서술하세요. '
@@ -185,7 +203,7 @@ async function resolveTaskExecution(
  * 도구 결과 텍스트로 조립해 반환. 실패는 문자열로 흡수(호출 루프를 죽이지 않음).
  */
 export async function runSpawnAgents(p: SpawnAgentsParams): Promise<string> {
-    const parsed = spawnAgentsArgsSchema.safeParse(p.args);
+    const parsed = spawnAgentsArgsSchema.safeParse(normalizeSpawnArgs(p.args));
     if (!parsed.success) {
         return 'Error: tasks 배열([{prompt, role?}, ...], 최소 1개)이 필요합니다.';
     }

--- a/apps/api/src/services/task-sandbox/sandbox.ts
+++ b/apps/api/src/services/task-sandbox/sandbox.ts
@@ -106,7 +106,11 @@ export function safeResolveWorkspacePath(hostWorkdir: string, userPath: string):
             : userPath;
     const abs = resolve(root, normalized);
     if (abs !== root && !abs.startsWith(root + sep)) {
-        throw new Error(`workspace 경로 탈출 차단: ${userPath}`);
+        throw new Error(
+            `workspace 경로 탈출 차단: ${userPath}`
+            + ' (파일 도구는 /workspace 내부만 접근 가능 — /opt/... 같은 컨테이너 경로는'
+            + ' bash 로 `cp -r <경로> ./` 하여 workspace 에 복사한 뒤 사본을 여세요)',
+        );
     }
     return abs;
 }

--- a/apps/api/src/services/task-sandbox/tools.test.ts
+++ b/apps/api/src/services/task-sandbox/tools.test.ts
@@ -134,6 +134,37 @@ describe('task-sandbox tools', () => {
             const r = await byName(createTaskTools(fakeSandbox()), 'browser').handler({ actions: [] });
             expect(r.isError).toBe(true);
         });
+        it('단일 액션 객체는 배열로 감싼다', async () => {
+            const sb = fakeSandbox();
+            await byName(createTaskTools(sb), 'browser').handler({ actions: { type: 'goto', url: 'https://example.com' } });
+            const spec = JSON.parse(sb.files.get('.browser-actions.json') as string);
+            expect(spec.actions).toEqual([{ type: 'goto', url: 'https://example.com' }]);
+        });
+    });
+
+    describe('plan_create / plan_update 인자 관용', () => {
+        it('plan_create: 단일 문자열도 배열로 감싼다', async () => {
+            const tools = createTaskTools(fakeSandbox());
+            const r = await byName(tools, 'plan_create').handler({ steps: '조사하기' });
+            expect(r.isError).toBeFalsy();
+            expect(txt(r)).toContain('조사하기');
+        });
+        it('plan_create: 빈 steps 거절', async () => {
+            const r = await byName(createTaskTools(fakeSandbox()), 'plan_create').handler({ steps: [] });
+            expect(r.isError).toBe(true);
+        });
+        it('plan_update: 계획 없을 때 안내 메시지', async () => {
+            const r = await byName(createTaskTools(fakeSandbox()), 'plan_update').handler({ step: 1, status: 'completed' });
+            expect(r.isError).toBe(true);
+            expect(txt(r)).toContain('먼저 plan_create');
+        });
+        it('plan_update: 범위 초과 시 유효 범위를 안내한다', async () => {
+            const tools = createTaskTools(fakeSandbox());
+            await byName(tools, 'plan_create').handler({ steps: ['a', 'b'] });
+            const r = await byName(tools, 'plan_update').handler({ step: 5, status: 'completed' });
+            expect(r.isError).toBe(true);
+            expect(txt(r)).toContain('1..2');
+        });
     });
 
     it('terminate 는 sentinel 반환', async () => {

--- a/apps/api/src/services/task-sandbox/tools.ts
+++ b/apps/api/src/services/task-sandbox/tools.ts
@@ -174,7 +174,7 @@ export function createTaskTools(
                     if (!oldStr) return textResult('old_str 가 필요합니다.', true);
                     const content = await sandbox.readFile(path);
                     const count = content.split(oldStr).length - 1;
-                    if (count === 0) return textResult(`old_str 를 찾을 수 없습니다: ${path}`, true);
+                    if (count === 0) return textResult(`old_str 를 찾을 수 없습니다: ${path} — old_str 는 공백·들여쓰기까지 파일 내용과 정확히 일치해야 합니다. command:view 로 현재 내용을 확인한 뒤 그대로 복사해 쓰세요.`, true);
                     if (count > 1) return textResult(`old_str 가 ${count}회 중복 — 유일해야 합니다.`, true);
                     await sandbox.writeFile(path, content.replace(oldStr, str(args.new_str)));
                     return textResult(`치환 완료: ${path}`);
@@ -264,9 +264,15 @@ export function createTaskTools(
             if (!sandbox.isBrowserEnabled) {
                 return textResult('브라우저 기능이 비활성화되어 있습니다 (TASK_SANDBOX_BROWSER_ENABLED=false).', true);
             }
-            const actions = args.actions;
-            if (!Array.isArray(actions) || actions.length === 0) {
-                return textResult('actions 배열이 필요합니다.', true);
+            // 단일 액션 객체를 넘기는 실수는 배열로 감싼다(계약 유지).
+            const actions = Array.isArray(args.actions)
+                ? args.actions
+                : (args.actions && typeof args.actions === 'object' ? [args.actions] : null);
+            if (!actions || actions.length === 0) {
+                return textResult(
+                    'actions 배열이 필요합니다 — 예: [{"type":"goto","url":"https://example.com"},{"type":"extractText"}].',
+                    true,
+                );
             }
             const spec = {
                 actions,
@@ -299,10 +305,14 @@ export function createTaskTools(
             },
         },
         handler: async (args): Promise<MCPToolResult> => {
-            if (!Array.isArray(args.steps) || args.steps.length === 0) {
-                return textResult('steps 배열이 필요합니다.', true);
+            // 단일 문자열을 넘기는 흔한 실수는 배열로 감싼다(계약 유지 — 값을 버리지 않음).
+            const steps = Array.isArray(args.steps)
+                ? args.steps
+                : (typeof args.steps === 'string' && args.steps.trim() ? [args.steps] : null);
+            if (!steps || steps.length === 0) {
+                return textResult('steps 배열이 필요합니다 — 예: {"steps":["자료 조사","초안 작성","검토"]}.', true);
             }
-            plan.create(args.steps.map(String));
+            plan.create(steps.map(String));
             return textResult(plan.render());
         },
     };
@@ -325,7 +335,15 @@ export function createTaskTools(
             const status = str(args.status);
             if (!VALID_STATUS.has(status)) return textResult(`status 는 ${[...VALID_STATUS].join('|')} 여야 합니다.`, true);
             const ok = plan.update(Number(args.step), status as PlanStepStatus, args.note !== undefined ? str(args.note) : undefined);
-            if (!ok) return textResult(`단계 ${args.step} 가 범위를 벗어났습니다(계획 ${plan.length}단계).`, true);
+            if (!ok) {
+                return textResult(
+                    plan.length === 0
+                        ? '아직 계획이 없습니다 — 먼저 plan_create 로 단계를 세우세요.'
+                        : `단계 ${args.step} 가 범위를 벗어났습니다 — 현재 계획은 ${plan.length}단계입니다`
+                          + `(유효 step: 1..${plan.length}). plan_view 로 계획을 확인하세요.`,
+                    true,
+                );
+            }
             return textResult(plan.render());
         },
     };

--- a/apps/web/app/(workspace)/admin/metrics/page.tsx
+++ b/apps/web/app/(workspace)/admin/metrics/page.tsx
@@ -83,6 +83,20 @@ const STATUS_MAP: Record<string, NodeStatus> = {
   unknown: "degraded",
 };
 
+/* ── 작업 도구 오류 타입 ───────────────────────────────────── */
+interface ToolErrorData {
+  days: number;
+  summary: {
+    totalToolExecutions: number;
+    errorCount: number;
+    errorRate: number;
+    affectedTasks: number;
+  };
+  affectedTaskStatus: { status: string; tasks: number }[];
+  topSignatures: { signature: string; count: number }[];
+  byToolName: { toolName: string; count: number }[];
+}
+
 export default function AdminMetricsPage() {
   const t = useTranslations("adminMetrics");
   const locale = toBcp47(useLocale());
@@ -92,6 +106,7 @@ export default function AdminMetricsPage() {
   const [mem, setMem] = useState<{ value: string; delta: string } | null>(null);
   const [agentSummary, setAgentSummary] = useState<AgentSummary | null>(null);
   const [agentMetrics, setAgentMetrics] = useState<AgentMetric[] | null>(null);
+  const [toolErrors, setToolErrors] = useState<ToolErrorData | null>(null);
   const maxV = Math.max(...TIMESERIES.map((t) => t.value));
 
   const load = useCallback(async () => {
@@ -166,6 +181,13 @@ export default function AdminMetricsPage() {
         if (raw) {
           setAgentMetrics(Object.values(raw));
         }
+      }
+      // 작업 도구 오류 로드 (기본 30일)
+      const toolErrRes = await ApiClient.get<{ data: ToolErrorData }>(
+        "/api/metrics/agent-tasks/tool-errors",
+      ).catch(() => null);
+      if (toolErrRes?.data) {
+        setToolErrors(toolErrRes.data);
       }
     } catch {
       /* 401/실패 시 목업 유지 */
@@ -325,6 +347,77 @@ export default function AdminMetricsPage() {
                     })}
                   </tbody>
                 </Table>
+              )}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* 작업 도구 오류 */}
+        {toolErrors && (
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle>
+                {t("toolError.title", { days: toolErrors.days })}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+                <StatCard
+                  label={t("toolError.errorRate")}
+                  value={`${(toolErrors.summary.errorRate * 100).toFixed(1)}%`}
+                />
+                <StatCard
+                  label={t("toolError.errorCount")}
+                  value={toolErrors.summary.errorCount.toLocaleString()}
+                  delta={t("toolError.ofTotal", {
+                    total: toolErrors.summary.totalToolExecutions.toLocaleString(),
+                  })}
+                />
+                <StatCard
+                  label={t("toolError.affectedTasks")}
+                  value={toolErrors.summary.affectedTasks.toLocaleString()}
+                />
+                <StatCard
+                  label={t("toolError.taskStatus")}
+                  value={
+                    toolErrors.affectedTaskStatus.length > 0
+                      ? toolErrors.affectedTaskStatus
+                          .map((s) => `${s.status} ${s.tasks}`)
+                          .join(" · ")
+                      : "—"
+                  }
+                />
+              </div>
+              {toolErrors.topSignatures.length > 0 && (
+                <Table>
+                  <thead>
+                    <tr>
+                      <Th>{t("toolError.th.signature")}</Th>
+                      <Th className="text-right">{t("toolError.th.count")}</Th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {toolErrors.topSignatures.map((s, i) => (
+                      <tr key={i}>
+                        <Td className="max-w-0 truncate font-mono text-xs text-fg-2" title={s.signature}>
+                          {s.signature}
+                        </Td>
+                        <Td className="text-right font-mono text-fg-2">
+                          {s.count.toLocaleString()}
+                        </Td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              )}
+              {toolErrors.byToolName.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {toolErrors.byToolName.map((tool) => (
+                    <Badge key={tool.toolName} tone="warn">
+                      {tool.toolName} · {tool.count.toLocaleString()}
+                    </Badge>
+                  ))}
+                </div>
               )}
             </CardContent>
           </Card>

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1327,6 +1327,18 @@
       "requests": "Requests",
       "successRate": "Success Rate",
       "avgResponseTime": "Avg Response Time"
+    },
+    "toolError": {
+      "title": "Task Tool Errors (last {days} days)",
+      "errorRate": "Tool Error Rate",
+      "errorCount": "Errors",
+      "ofTotal": "of {total} total",
+      "affectedTasks": "Affected Tasks",
+      "taskStatus": "Task Outcome",
+      "th": {
+        "signature": "Error Signature",
+        "count": "Count"
+      }
     }
   },
   "adminAlerts": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1327,6 +1327,18 @@
       "requests": "リクエスト数",
       "successRate": "成功率",
       "avgResponseTime": "平均応答時間"
+    },
+    "toolError": {
+      "title": "タスクツールエラー (直近{days}日)",
+      "errorRate": "ツールエラー率",
+      "errorCount": "エラー数",
+      "ofTotal": "全{total}回中",
+      "affectedTasks": "エラー発生タスク",
+      "taskStatus": "タスク結果",
+      "th": {
+        "signature": "エラーシグネチャ",
+        "count": "件数"
+      }
     }
   },
   "adminAlerts": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1327,6 +1327,18 @@
       "requests": "요청 수",
       "successRate": "성공률",
       "avgResponseTime": "평균 응답시간"
+    },
+    "toolError": {
+      "title": "작업 도구 오류 (최근 {days}일)",
+      "errorRate": "도구 오류율",
+      "errorCount": "오류 수",
+      "ofTotal": "총 {total}회 중",
+      "affectedTasks": "오류 발생 작업",
+      "taskStatus": "작업 결말",
+      "th": {
+        "signature": "오류 시그니처",
+        "count": "건수"
+      }
     }
   },
   "adminAlerts": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1327,6 +1327,18 @@
       "requests": "请求数",
       "successRate": "成功率",
       "avgResponseTime": "平均响应时间"
+    },
+    "toolError": {
+      "title": "任务工具错误（最近 {days} 天）",
+      "errorRate": "工具错误率",
+      "errorCount": "错误数",
+      "ofTotal": "共 {total} 次中",
+      "affectedTasks": "受影响任务",
+      "taskStatus": "任务结果",
+      "th": {
+        "signature": "错误签名",
+        "count": "次数"
+      }
     }
   },
   "adminAlerts": {


### PR DESCRIPTION
## 요약

에이전트 작업 샌드박스 도구 오류 전수 분석(202건 — 도구 실행 1,240회의 16%, 작업 71/167개에서 발생) 결과 확인된 5대 원인을 해소한다. 오류 대부분은 작업이 결국 완료돼 어디에도 집계되지 않아 운영자가 볼 수 없었다.

## 원인별 조치

| # | 원인 (건수) | 조치 |
|---|---|---|
| 1 | MCP google 검색 브라우저 미기동 (42) | **코드 외 인프라 조치(완료)** — 서버 전용 캐시 볼륨에 playwright 1.62 chromium 설치, `mcp_servers` args 버전 고정(`==0.3.2`). 샌드박스 격리 플래그 하 기동+탐색, 앱 경유 실호출 검증 |
| 2 | workspace 경로 탈출 차단 (18) | 파일 도구는 호스트측 workspace 만 접근(컨테이너 내부 `/opt/report-template` 는 원리상 불가) → 가이던스에 "bash 로 복사 후 편집" 안내 + 차단 메시지에 행동 힌트 |
| 3 | 도구 인자 오류 (~24) | plan `steps`·browser `actions`·spawn `tasks` 의 단일 값/객체 실수를 배열로 관용 래핑(값 보존, 잘못된 형태는 여전히 거부), 오류 메시지에 예시·유효 범위(plan 1-based 1..N)·`old_str` 정확 일치 요건 명시 |
| 4 | 업로드 xlsx 파싱 실패 | 안내 1줄 — 웹/JS 생성 엑셀의 스타일 결함으로 openpyxl 실패 시 재시도 대신 `.txt` 추출본 사용 |
| 5 | 오류 비가시성 | `GET /api/metrics/agent-tasks/tool-errors` (admin — 기간별 오류율·발생 작업 상태 분포·시그니처 상위 N·tool_name 별) + `/admin/metrics` "작업 도구 오류" 섹션 + i18n 4로케일 |

## 검증

- [x] CI 6게이트 로컬 재현 전부 통과: jest **2412 passed**(신규 14건 포함) · tsc(api·web) 클린 · 파일 크기 ≤600 · lint 0 error · routing 93.3% · response 100% · i18n 1,274키 정합
- [x] 신규 집계 SQL: `tool_result` 스텝의 `tool_name` 100% 기록(1240/1240) 실데이터 확인, 파라미터화·read-only
- [x] 인프라(#1): 샌드박스 동일 격리 플래그로 브라우저 기동+구글 탐색 OK, 앱 경유 `google_search` 실호출 launch 오류 소멸

🤖 Generated with [Claude Code](https://claude.com/claude-code)