### PR TITLE
feat(web-search): web_search 도구 결과에 검색 소스 라벨 표시

### DIFF
--- a/apps/api/src/mcp/web-search/__tests__/format-sources.test.ts
+++ b/apps/api/src/mcp/web-search/__tests__/format-sources.test.ts
@@ -59,6 +59,26 @@ describe('formatSearchSources', () => {
         expect(out.trim().endsWith('URL: http://c')).toBe(true);
     });
 
+    it('showSource=true 는 제목 옆에 소스 도메인 표시, source 없는 결과는 제목만', () => {
+        const out = formatSearchSources(
+            [
+                { title: 'N', url: 'http://n', snippet: 's', source: 'naver.com' },
+                { title: 'X', url: 'http://x', snippet: 's' },
+            ],
+            { showSource: true },
+        );
+        expect(out).toContain('[1] N · naver.com');
+        expect(out).toContain('[2] X\n');
+    });
+
+    it('showSource 미지정(기본 false)은 기존 포맷 유지 — source 가 있어도 표시 안 함', () => {
+        const out = formatSearchSources(
+            [{ title: 'N', url: 'http://n', snippet: 's', source: 'naver.com' }],
+        );
+        expect(out).toContain('[1] N\n');
+        expect(out).not.toContain('naver.com');
+    });
+
     it('snippet 컷이 surrogate pair(이모지) 중간을 분할하지 않는다', () => {
         // '😀' = U+1F600 (surrogate pair, 길이 2). 캡 3 이면 코드포인트 3개까지 = 'ab😀'
         const out = formatSearchSources([{ title: 'E', url: 'http://e', snippet: 'ab😀cd' }], { maxSnippetChars: 3 });

--- a/apps/api/src/mcp/web-search/format-sources.ts
+++ b/apps/api/src/mcp/web-search/format-sources.ts
@@ -26,9 +26,12 @@ export interface FormatSourcesOptions {
     emptySnippet?: string;
     /** 간결형에서 snippet 뒤에 붙일 접미사 (예: '...') */
     snippetSuffix?: string;
+    /** true: 제목 뒤에 검색 소스 도메인 표시 (예: `제목 · naver.com`) — 결과가 어느 엔진에서
+     *  왔는지 구분용. 기본 false (프롬프트 주입 경로의 기존 포맷·인용 파서 영향 없음). */
+    showSource?: boolean;
 }
 
-type SourceLike = Pick<SearchResult, 'title' | 'url' | 'snippet'>;
+type SourceLike = Pick<SearchResult, 'title' | 'url' | 'snippet'> & Partial<Pick<SearchResult, 'source'>>;
 
 /** 검색 결과 배열을 주입용 문자열로 포맷 (결과 수·snippet 길이 캡 적용). */
 export function formatSearchSources(results: SourceLike[], opts: FormatSourcesOptions = {}): string {
@@ -41,6 +44,7 @@ export function formatSearchSources(results: SourceLike[], opts: FormatSourcesOp
         separator = '\n\n',
         emptySnippet = '',
         snippetSuffix = '',
+        showSource = false,
     } = opts;
 
     const limited = maxResults > 0 ? results.slice(0, maxResults) : results;
@@ -54,13 +58,14 @@ export function formatSearchSources(results: SourceLike[], opts: FormatSourcesOp
             snip = snip + snippetSuffix;
         }
         const tag = labeled ? `[${sourceWord} ${i + 1}]` : `[${i + 1}]`;
+        const title = showSource && r.source ? `${r.title} · ${r.source}` : r.title;
         const urlLine = labeled ? `   URL: ${r.url}` : `   ${r.url}`;
         // 라벨형이라도 내용이 비면 빈 "내용: " 라벨을 출력하지 않는다(누수 방지).
         const contentText = snip || emptySnippet;
         const contentLine = labeled
             ? (contentText ? `\n   ${contentWord}: ${contentText}` : '')
             : (snip ? `\n   ${snip}` : '');
-        return `${tag} ${r.title}\n${urlLine}${contentLine}`;
+        return `${tag} ${title}\n${urlLine}${contentLine}`;
     });
     return lines.join(separator);
 }

--- a/apps/api/src/mcp/web-search/tools.ts
+++ b/apps/api/src/mcp/web-search/tools.ts
@@ -41,9 +41,10 @@ export const webSearchTool: MCPToolDefinition = {
             return { content: [{ type: 'text', text: `검색 결과 없음: "${query}"` }] };
         }
 
-        // MCP 도구 출력(사용자 직접 표시) — 주입 캡 미적용, snippet 100자 요약만 유지
+        // MCP 도구 출력(사용자 직접 표시) — 주입 캡 미적용, snippet 100자 요약만 유지.
+        // showSource: 결과가 어느 검색엔진(naver.com·google.com 등)에서 왔는지 제목 옆에 표시.
         const output = `검색 결과 (${results.length}개)\n\n` +
-            formatSearchSources(results, { maxSnippetChars: 100, snippetSuffix: '...' });
+            formatSearchSources(results, { maxSnippetChars: 100, snippetSuffix: '...', showSource: true });
 
         return { content: [{ type: 'text', text: output }] };
     }


### PR DESCRIPTION
## 요약

`web_search` 내장 도구의 병합 결과(구글 CSE·네이버·위키피디아·DuckDuckGo 등 6소스)에 각 결과가 어느 검색엔진에서 왔는지 **소스 도메인 라벨**을 표시한다 (예: `[1] 제목 · naver.com`).

## 변경 내용

- `format-sources.ts`: `showSource` 옵션 추가 (기본 **false** — 기존 소비처 포맷 전부 무변경). `SearchResult.source` 는 provider 가 이미 기록 중(naver.com·google.com·wikipedia.org 등)이라 표시만 추가.
- `tools.ts` web_search 핸들러: 사용자 표시용 도구 출력에만 `showSource: true` 활성화.
- 출처 인용 결정적 첨부 파서(`external-deterministic-append.ts`)는 labeled(`URL:`) 형만 파싱하므로 영향 없음 — 간결형 도구 출력은 원래 매칭 대상 아님(확인).

## 검증

- [x] 전체 jest **2414 passed** (format-sources 신규 2건 포함) · tsc 클린 · eslint 클린 · routing 93.3% · response 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)