### PR TITLE
fix(web-search): 소스 라벨 비도메인 식별자(searxng) 정규화

### DIFF
--- a/apps/api/src/mcp/web-search/__tests__/format-sources.test.ts
+++ b/apps/api/src/mcp/web-search/__tests__/format-sources.test.ts
@@ -71,6 +71,23 @@ describe('formatSearchSources', () => {
         expect(out).toContain('[2] X\n');
     });
 
+    it('showSource: 도메인 아닌 source(searxng 등)는 결과 URL 호스트명으로 정규화', () => {
+        const out = formatSearchSources(
+            [{ title: 'S', url: 'https://blog.example.co.kr/post/1', snippet: 's', source: 'searxng' }],
+            { showSource: true },
+        );
+        expect(out).toContain('[1] S · blog.example.co.kr');
+        expect(out).not.toContain('searxng');
+    });
+
+    it('showSource: URL 파싱 실패 시 source 원문으로 폴백', () => {
+        const out = formatSearchSources(
+            [{ title: 'B', url: 'not-a-url', snippet: 's', source: 'searxng' }],
+            { showSource: true },
+        );
+        expect(out).toContain('[1] B · searxng');
+    });
+
     it('showSource 미지정(기본 false)은 기존 포맷 유지 — source 가 있어도 표시 안 함', () => {
         const out = formatSearchSources(
             [{ title: 'N', url: 'http://n', snippet: 's', source: 'naver.com' }],

--- a/apps/api/src/mcp/web-search/format-sources.ts
+++ b/apps/api/src/mcp/web-search/format-sources.ts
@@ -33,6 +33,21 @@ export interface FormatSourcesOptions {
 
 type SourceLike = Pick<SearchResult, 'title' | 'url' | 'snippet'> & Partial<Pick<SearchResult, 'source'>>;
 
+/**
+ * showSource 표시용 라벨 정규화 — source 가 도메인 형태가 아니면(searxng 같은 엔진
+ * 식별자) 결과 URL 의 호스트명으로 대체한다. google(displayLink=결과 사이트 도메인) 등
+ * 다른 provider 라벨과 표기(도메인)를 일관되게 유지하기 위함.
+ */
+function displaySourceLabel(source: string | undefined, url: string): string | undefined {
+    if (!source) return undefined;
+    if (source.includes('.')) return source;
+    try {
+        return new URL(url).hostname || source;
+    } catch {
+        return source;
+    }
+}
+
 /** 검색 결과 배열을 주입용 문자열로 포맷 (결과 수·snippet 길이 캡 적용). */
 export function formatSearchSources(results: SourceLike[], opts: FormatSourcesOptions = {}): string {
     const {
@@ -58,7 +73,8 @@ export function formatSearchSources(results: SourceLike[], opts: FormatSourcesOp
             snip = snip + snippetSuffix;
         }
         const tag = labeled ? `[${sourceWord} ${i + 1}]` : `[${i + 1}]`;
-        const title = showSource && r.source ? `${r.title} · ${r.source}` : r.title;
+        const sourceLabel = showSource ? displaySourceLabel(r.source, r.url) : undefined;
+        const title = sourceLabel ? `${r.title} · ${sourceLabel}` : r.title;
         const urlLine = labeled ? `   URL: ${r.url}` : `   ${r.url}`;
         // 라벨형이라도 내용이 비면 빈 "내용: " 라벨을 출력하지 않는다(누수 방지).
         const contentText = snip || emptySnippet;


### PR DESCRIPTION
## 요약

/code-review(high)에서 CONFIRMED 된 표시 일관성 결함 1건 수정 — `showSource` 라벨에 도메인(naver.com 등)과 엔진 식별자(searxng)가 섞여 표기되던 문제.

## 변경

- `format-sources.ts`: `displaySourceLabel()` — source 가 도메인 형태(`.` 포함)가 아니면 결과 URL 호스트명으로 대체. Google CSE(displayLink=결과 사이트 도메인) 등 기존 라벨과 표기 통일. URL 파싱 실패 시 source 원문 폴백.
- 테스트 2건 추가 (정규화·폴백).

## 검증

- [x] 전체 jest **2416 passed** · tsc 클린 · eslint 클린 · routing 93.3% · response 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)