### PR TITLE
fix(mcp): mcp-python-repl 에 mcp<2 제약 — mcp 2.x fastmcp 제거로 기동 실패 회피

### DIFF
--- a/infra/mcp-runtime/Dockerfile
+++ b/infra/mcp-runtime/Dockerfile
@@ -49,7 +49,9 @@ RUN mkdir -p /home/node/.cache/npm /home/node/.cache/uv
 # 컨테이너로 격리하면 런타임 uvx 다운로드가 불가하므로 이미지에 미리 설치한다.
 # uv tool install 은 /home/node/.local 에 self-contained venv 로 설치 →
 # 런타임에 볼륨 마운트되는 /home/node/.cache 와 분리되어 net=none(오프라인)에도 동작.
-RUN uv tool install mcp-python-repl
+# --with 'mcp<2': mcp-python-repl 은 상한 없는 `mcp>=1.7.0` 선언이라 mcp 2.x 가 설치되면
+# `mcp.server.fastmcp` 제거로 기동 실패(2026-08-08 no-cache 재빌드에서 실측) — noapi 와 동일 회피.
+RUN uv tool install --with 'mcp<2' mcp-python-repl
 ENV PATH=/home/node/.local/bin:${PATH}
 
 # ── NotebookLM MCP 서버(notebooklm-mcp-cli) — 이미지에 baked ─────────────────


### PR DESCRIPTION
## Summary
- mcp-runtime 이미지의 `uv tool install mcp-python-repl` 에 `--with 'mcp<2'` 제약 추가.
- 원인: mcp-python-repl(0.1.1)은 상한 없는 `mcp>=1.7.0` 선언 — 2026-08-08 `--no-cache` 재빌드에서 mcp 2.x 가 설치되며 `mcp.server.fastmcp` 제거로 임포트 크래시, Python REPL 서버 연결 실패(운영 로그 실측). 업스트림 미수정 확인.
- noapi-google-search 가 이미 쓰는 `--with "mcp<2"` 회피와 동일 패턴(058 마이그레이션의 mcp-fetch 정정과도 동형).

## Test plan
- [x] 수정 이미지에서 `mcp-python-repl` 기동 — fastmcp 임포트 크래시 소멸
- [x] 운영 재시작 후 `Connected to "Python REPL" — 12 tools discovered` 로그 확인
- [x] Playwright(24)·noapi-google-search(38) 등 여타 서버 연결 무영향
- [x] 라이브 WS E2E(PDF 첨부 채팅) 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)