### PR TITLE
feat(metrics): 도구 결과 절단 셰도우 계측 (G3, measure-first)

### DIFF
--- a/apps/api/src/data/db-retention.ts
+++ b/apps/api/src/data/db-retention.ts
@@ -178,7 +178,7 @@ async function runRetention(): Promise<void> {
             10,
         );
         if (Number.isFinite(metricsRetentionDays) && metricsRetentionDays > 0) {
-            for (const table of ['model_pool_metrics', 'routing_shadow_decisions', 'orchestration_dispatch_decisions']) {
+            for (const table of ['model_pool_metrics', 'routing_shadow_decisions', 'orchestration_dispatch_decisions', 'tool_result_truncations']) {
                 try {
                     const r = await pool.query(
                         `DELETE FROM ${table} WHERE created_at < NOW() - ($1 || ' days')::interval`,

--- a/apps/api/src/services/__tests__/tool-result-truncation-recorder.test.ts
+++ b/apps/api/src/services/__tests__/tool-result-truncation-recorder.test.ts
@@ -1,0 +1,40 @@
+/**
+ * G3 절단 셰도우 레코더 단위 테스트 (2026-08-08)
+ * 무DB 환경 pg hang 함정 방지 — getPool 은 mock (실 연결 금지).
+ */
+import { recordToolResultTruncation } from '../tool-result-truncation-recorder';
+
+const queryMock = jest.fn().mockResolvedValue({ rowCount: 1 });
+jest.mock('../../data/models/unified-database', () => ({
+    getPool: () => ({ query: (...args: unknown[]) => queryMock(...args) }),
+}));
+
+/** fire-and-forget 이 마이크로태스크로 실행되므로 큐 소진 후 단언 */
+const flush = () => new Promise((r) => setImmediate(r));
+
+describe('recordToolResultTruncation (G3)', () => {
+    beforeEach(() => queryMock.mockClear());
+
+    it('절단 발생 시 truncated=true 로 적재한다', async () => {
+        recordToolResultTruncation({ path: 'chat', toolName: 'web_scrape', rawChars: 12000, capChars: 8000 });
+        await flush();
+        expect(queryMock).toHaveBeenCalledTimes(1);
+        const [sql, params] = queryMock.mock.calls[0] as [string, unknown[]];
+        expect(sql).toContain('INSERT INTO tool_result_truncations');
+        expect(params).toEqual(['chat', 'web_scrape', 12000, 8000, true]);
+    });
+
+    it('캡 이내면 truncated=false 로 적재한다 (분모 확보)', async () => {
+        recordToolResultTruncation({ path: 'agent_task', toolName: 'bash', rawChars: 500, capChars: 8000 });
+        await flush();
+        expect(queryMock.mock.calls[0][1]).toEqual(['agent_task', 'bash', 500, 8000, false]);
+    });
+
+    it('DB 오류는 흡수한다 (fail-open — 본 흐름 비차단)', async () => {
+        queryMock.mockRejectedValueOnce(new Error('db down'));
+        expect(() =>
+            recordToolResultTruncation({ path: 'chat', toolName: 'x', rawChars: 1, capChars: 8000 }),
+        ).not.toThrow();
+        await flush();
+    });
+});

--- a/apps/api/src/services/agent-task/task-steps.ts
+++ b/apps/api/src/services/agent-task/task-steps.ts
@@ -8,6 +8,7 @@ import type { UserContext } from '../../mcp/user-sandbox';
 import type { ExtractedArtifact } from '../../llm/artifact-parser';
 import { takeReportSource } from '../chat-service/report-block';
 import { MAX_TOOL_RESULT_CHARS, AGENT_TASK_LIMITS } from '../../config/runtime-limits';
+import { recordToolResultTruncation } from '../tool-result-truncation-recorder';
 import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('AgentTaskService');
@@ -61,6 +62,10 @@ export async function runTool(
         // 문자열/JSON 양쪽 모두 캡 적용 — 대형 결과가 통째로 대화에 들어가면
         // 컨텍스트·체크포인트가 부풀어 token_limit abort 로 작업이 실패한다.
         const raw = typeof r.content === 'string' ? r.content : JSON.stringify(r.content);
+        // G3 셰도우 계측 — 절단 발생률/폭 실측 (chunk-요약 도입 판단 게이트, fire-and-forget)
+        recordToolResultTruncation({
+            path: 'agent_task', toolName: name, rawChars: raw.length, capChars: MAX_TOOL_RESULT_CHARS,
+        });
         const text = raw.length > MAX_TOOL_RESULT_CHARS
             ? raw.slice(0, MAX_TOOL_RESULT_CHARS) + '\n...[결과가 길어 잘렸습니다]'
             : raw;

--- a/apps/api/src/services/chat-service/external-tool-exec.ts
+++ b/apps/api/src/services/chat-service/external-tool-exec.ts
@@ -12,6 +12,7 @@
  */
 import { createLogger } from '../../utils/logger';
 import { MAX_TOOL_RESULT_CHARS } from '../../config/runtime-limits';
+import { recordToolResultTruncation } from '../tool-result-truncation-recorder';
 import { getUnifiedMCPClient } from '../../mcp/unified-client';
 import { isPersistableUserId } from '../../utils/user-id-validation';
 import type { ResolvedProvider } from '../../providers/provider-router';
@@ -56,7 +57,14 @@ export async function executeExternalTool(
         if (result.isError) {
             return `Error: ${typeof result.content === 'string' ? result.content : JSON.stringify(result.content)}`;
         }
-        if (typeof result.content === 'string') return result.content;
+        if (typeof result.content === 'string') {
+            // 문자열 분기는 캡 미적용 — 분모 확보를 위해 동일하게 계측한다 (G3).
+            const contentStr: string = result.content;
+            recordToolResultTruncation({
+                path: 'chat', toolName, rawChars: contentStr.length, capChars: MAX_TOOL_RESULT_CHARS,
+            });
+            return contentStr;
+        }
         // 카카오 지도 블록은 8000자 캡(slice)·JSON.stringify 이스케이프에 소실되지 않도록
         // 원본 텍스트에서 추출해 반환 문자열 앞에 실제 개행으로 prepend 한다.
         // (search-places 출력이 길어 블록이 끝에 있으면 캡에 잘리던 문제 — 호출부가 이 블록을 결정적 첨부)
@@ -70,7 +78,12 @@ export async function executeExternalTool(
             const m = rawText.match(/```kakaomap[\s\S]*?```/);
             if (m) mapPrefix = `${m[0]}\n\n`;
         }
-        return mapPrefix + JSON.stringify(result.content).slice(0, MAX_TOOL_RESULT_CHARS);
+        const serialized = JSON.stringify(result.content);
+        // G3 셰도우 계측 — 8000자 절단 발생률/폭 실측 (chunk-요약 도입 판단 게이트)
+        recordToolResultTruncation({
+            path: 'chat', toolName, rawChars: serialized.length, capChars: MAX_TOOL_RESULT_CHARS,
+        });
+        return mapPrefix + serialized.slice(0, MAX_TOOL_RESULT_CHARS);
     } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         logger.warn(`외부 LLM 도구 실행 실패 (${toolName}): ${msg}`);

--- a/apps/api/src/services/tool-result-truncation-recorder.ts
+++ b/apps/api/src/services/tool-result-truncation-recorder.ts
@@ -1,0 +1,51 @@
+/**
+ * ============================================================
+ * Tool Result Truncation Recorder — tool_result_truncations 적재 (G3, 2026-08-08)
+ * ============================================================
+ *
+ * MAX_TOOL_RESULT_CHARS 단순 절단의 발생률·절단 폭 셰도우 계측 (measure-first).
+ * chunk→병렬요약 등 긴 결과 처리 도입 판단은 이 데이터가 게이트다.
+ * 실행 경로를 바꾸지 않으며 절대 도구 흐름을 차단하지 않는다(모든 에러 무시).
+ * (orchestration-shadow-recorder 와 동일 패턴 — fire-and-forget, await 금지)
+ *
+ * 집계 예시 (판단 게이트):
+ *   SELECT tool_name, COUNT(*) total, COUNT(*) FILTER (WHERE truncated) cut,
+ *          ROUND(AVG(raw_chars) FILTER (WHERE truncated)) avg_raw
+ *   FROM tool_result_truncations GROUP BY 1 ORDER BY cut DESC;
+ *
+ * @module services/tool-result-truncation-recorder
+ */
+import { getPool } from '../data/models/unified-database';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('TruncationShadow');
+
+/**
+ * 도구 결과 길이/절단 여부를 적재한다 (fire-and-forget — await 하지 말 것).
+ * 전 도구 호출을 적재한다 (절단률의 분모 확보 — 절단 건만 적재하면 비율을 못 구함).
+ */
+export function recordToolResultTruncation(params: {
+    /** 절단 적용 경로: 채팅 도구 루프 | 에이전트 작업 */
+    path: 'chat' | 'agent_task';
+    toolName: string;
+    /** 절단 전 원본 문자 수 */
+    rawChars: number;
+    /** 적용된 캡 (MAX_TOOL_RESULT_CHARS) */
+    capChars: number;
+}): void {
+    const { path, toolName, rawChars, capChars } = params;
+    void (async () => {
+        try {
+            const pool = getPool();
+            if (!pool) return;
+            await pool.query(
+                `INSERT INTO tool_result_truncations (path, tool_name, raw_chars, cap_chars, truncated)
+                 VALUES ($1, $2, $3, $4, $5)`,
+                [path, toolName, rawChars, capChars, rawChars > capChars],
+            );
+        } catch (e) {
+            // 계측 실패는 본 흐름에 영향 없음 — 디버그 수준으로만 남긴다.
+            logger.debug(`절단 계측 적재 실패(무시): ${e instanceof Error ? e.message : e}`);
+        }
+    })();
+}

--- a/db/migrations/089_tool_result_truncations.sql
+++ b/db/migrations/089_tool_result_truncations.sql
@@ -1,0 +1,24 @@
+-- 089: 도구 결과 절단 셰도우 계측 (G3, 2026-08-08)
+--
+-- MAX_TOOL_RESULT_CHARS(기본 8000자) 단순 절단이 실제로 얼마나 자주·얼마나 크게
+-- 발생하는지 실측한다 (measure-first — chunk→병렬요약 도입은 이 데이터가 게이트).
+-- 전 도구 호출을 적재해 도구별 절단률(truncated/total)과 절단 폭(raw_chars-cap_chars)을
+-- 집계할 수 있게 한다. 실행 경로는 바꾸지 않는다 (fire-and-forget, 086 과 동일 패턴).
+-- 보존: db-retention 이 METRICS_RETENTION_DAYS 로 정리 (append-only 무한 증가 방지).
+
+CREATE TABLE IF NOT EXISTS tool_result_truncations (
+    id BIGSERIAL PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- 절단이 적용된 경로: 'chat'(external-tool-exec) | 'agent_task'(task-steps runTool)
+    path TEXT NOT NULL,
+    tool_name TEXT NOT NULL,
+    -- 절단 전 원본 문자 수 / 적용된 캡
+    raw_chars INTEGER NOT NULL,
+    cap_chars INTEGER NOT NULL,
+    truncated BOOLEAN NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_tool_result_truncations_created
+    ON tool_result_truncations (created_at);
+CREATE INDEX IF NOT EXISTS idx_tool_result_truncations_tool
+    ON tool_result_truncations (tool_name, truncated);


### PR DESCRIPTION
## Summary
Web Content Engine 검토에서 확정한 G3 — `MAX_TOOL_RESULT_CHARS`(8000자) 단순 절단이 실제로 얼마나 자주·크게 발생하는지 셰도우 계측. chunk→병렬요약 도입은 이 데이터가 게이트 (measure-first).

- **089 마이그레이션**: `tool_result_truncations(path, tool_name, raw_chars, cap_chars, truncated)` — 부팅 자동 적용
- **레코더**: `services/tool-result-truncation-recorder.ts` — 086 orchestration 셰도우와 동형 fire-and-forget. **전 도구 호출 적재**(절단 건만 적재하면 비율의 분모를 못 구함), DB 오류 흡수(본 흐름 비차단)
- **배선**: 채팅 `external-tool-exec.ts`(문자열 분기는 캡 미적용이나 분모 확보 위해 동일 계측 + 배열 분기), 에이전트 작업 `task-steps.ts runTool`
- **보존**: db-retention `METRICS_RETENTION_DAYS`(90일) 목록 등록 — append-only 무한 증가 방지

집계 게이트 쿼리(레코더 주석에 포함):
```sql
SELECT tool_name, COUNT(*) total, COUNT(*) FILTER (WHERE truncated) cut,
       ROUND(AVG(raw_chars) FILTER (WHERE truncated)) avg_raw
FROM tool_result_truncations GROUP BY 1 ORDER BY cut DESC;
```

## Test plan
- [x] 신규 3케이스: truncated=true/false 파라미터 적재, DB 오류 fail-open (getPool mock — 무DB pg hang 함정 방지)
- [x] tsc·eslint 클린, 실행 경로 무변경(관측 전용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)