### PR TITLE
fix(live-check): G3 task 도구 계측 사각 + 작업 아티팩트 버전조회 404 소음 제거

### DIFF
--- a/apps/api/src/services/task-sandbox/runtime.ts
+++ b/apps/api/src/services/task-sandbox/runtime.ts
@@ -15,7 +15,8 @@ import { TaskSandbox, type ExecResult } from './sandbox';
 import type { TaskExecutor } from './executor';
 import { createTaskTools, type DelegateFn, type SpawnFn, type ProceduralHooks } from './tools';
 import { recordBrowserMetric } from './browser-metrics';
-import { AGENT_TASK_LIMITS, ORCHESTRATION_DISPATCH } from '../../config/runtime-limits';
+import { AGENT_TASK_LIMITS, ORCHESTRATION_DISPATCH, MAX_TOOL_RESULT_CHARS } from '../../config/runtime-limits';
+import { recordToolResultTruncation } from '../tool-result-truncation-recorder';
 import { saveProceduralSkill, resolveProceduralSpec } from '../agent-task/procedural-skill';
 import { TaskPlan, type PlanStep } from './planning';
 import { requiresApproval, getApprovalRegistry, type PendingApproval, type ApprovalRejectReason } from './approval-gate';
@@ -35,7 +36,7 @@ export function toLLMTool(def: MCPToolDefinition): ToolDefinition {
     };
 }
 
-function resultToString(r: { content: Array<{ text?: string }>; isError?: boolean }, cap = 8000): string {
+function resultToString(r: { content: Array<{ text?: string }>; isError?: boolean }, cap = MAX_TOOL_RESULT_CHARS): string {
     // NUL(0x00) 제거 — 바이너리 파일을 도구로 열람하면 결과에 0x00 이 섞일 수 있고, 이는 모델
     // 컨텍스트/스텝 저장(Postgres TEXT·JSON)으로 흘러가면 "invalid byte sequence" 로 태스크를 깨뜨린다.
     const text = r.content.map((c) => c.text ?? '').join('\n').replace(/\u0000/g, '').slice(0, cap);
@@ -193,7 +194,15 @@ export class TaskRuntime {
 
         try {
             const r = await handler(args, { userId: this.userId, role: 'user' });
-            return resultToString(r as { content: Array<{ text?: string }>; isError?: boolean });
+            const typed = r as { content: Array<{ text?: string }>; isError?: boolean };
+            // G3 셰도우 계측 — task 도구는 turn-executor 의 runTool 을 타지 않아(이 경로가 캡 지점)
+            // 여기서 적재한다 (2026-08-08 라이브 점검에서 발견된 계측 사각).
+            recordToolResultTruncation({
+                path: 'agent_task', toolName: name,
+                rawChars: typed.content.map((c) => c.text ?? '').join('\n').length,
+                capChars: MAX_TOOL_RESULT_CHARS,
+            });
+            return resultToString(typed);
         } catch (e) {
             const msg = e instanceof Error ? e.message : String(e);
             logger.warn(`[${this.taskId}] task 도구 실행 실패 (${name}): ${msg}`);

--- a/apps/web/components/chat/artifact-panel.tsx
+++ b/apps/web/components/chat/artifact-panel.tsx
@@ -359,10 +359,11 @@ export function ArtifactPanel() {
   const active = artifacts.find((a) => a.id === activeArtifactId) ?? artifacts[artifacts.length - 1];
 
   // 활성 artifact 변경 시 버전 목록 로드 + override 초기화.
+  // Agent Task 산출물(taskId)은 세션 artifacts 테이블에 없어 버전 조회가 404 — 요청 자체를 생략.
   useEffect(() => {
     setOverride(null);
     setVersions([]);
-    if (!currentSessionId || !active || active.streaming) return;
+    if (!currentSessionId || !active || active.streaming || active.taskId) return;
     let alive = true;
     (async () => {
       try {


### PR DESCRIPTION
## Summary
v1.22.0 배포 직후 Playwright MCP 라이브 점검(로그인→URL 캐시→웹검색 출처→PDF 첨부 자동위임 E2E)에서 발견한 결함 2건 수정:

1. **G3 계측 사각 (task 샌드박스 도구)** — task 도구는 `turn-executor`의 `runTool`이 아닌 `taskRuntime.executeTaskTool` 경로로 실행되어 절단 계측이 전혀 적재되지 않았다. 라이브 실측: PDF 자동위임 작업이 `file_ops`·`str_replace_editor` 2회 실행(tool_result 스텝 존재)했으나 `pg_stat` INSERT 시도 0. 실제 캡 지점(`executeTaskTool` → `resultToString`)에 적재 추가. `resultToString`의 매직 넘버 `cap = 8000`도 `MAX_TOOL_RESULT_CHARS`(기본 8000)로 통일 — 동작 무변경, env 오버라이드 노브 일원화.
2. **작업 유래 아티팩트 버전조회 404** — 채팅 인라인 렌더된 Agent Task 산출물은 세션 artifacts 테이블에 없어 `/api/sessions/{id}/artifacts/{aid}/versions`가 항상 404(브라우저 콘솔 에러 소음, JS로 억제 불가). `Artifact.taskId` 필드가 정확히 이 목적으로 존재하고 export는 이미 분기했으나 버전 조회만 미분기 — `taskId` 존재 시 요청 생략.

## Test plan
- [x] jest 전체 2,427 통과 (task-sandbox·runtime·truncation 스위트 포함)
- [x] apps/api·apps/web tsc 클린, eslint 클린
- [ ] merge 후 배포 → 라이브 재검증: 작업 도구 실행 시 `tool_result_truncations`에 `agent_task` 행 적재 + PDF 자동위임 시 콘솔 404 소멸

🤖 Generated with [Claude Code](https://claude.com/claude-code)