### PR TITLE
fix(agent-task): 대형 PDF 워크플로우 3중 결함 — 한글 파일명·턴 예산·승인 대기 가시성

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -835,6 +835,9 @@ AGENT_TASK_TIMEOUT_MS=600000
 # 사용자 취소·예산 소진은 재시도하지 않는다. 재시도는 stepType='retry' 스텝으로 집계된다.
 # AGENT_TASK_TURN_RETRY_MAX=2
 # AGENT_TASK_TURN_RETRY_BACKOFF_MS=2000
+# 대형 첨부(생성 시점 추출 상한 초과 → 샌드박스 자체 파싱) task 의 기본 턴 수 —
+# 기본 10턴은 수백 페이지 문서에 부족해 goal_incomplete 실패 (명시 maxTurns 우선, 상한 20)
+# AGENT_TASK_LARGE_INPUT_MAX_TURNS=20
 
 # Agent Task — 플랜 자동 진행. 단계 완료/차단 후 in_progress 가 없으면 첫 not_started 를
 # 자동 승격(모델이 [~] 마킹을 생략해도 스텝→노드 귀속·진행 표시가 비지 않게). 기본 ON.

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1279,6 +1279,13 @@ export const AGENT_TASK_LIMITS = {
     GOAL_MAX_CHARS: parseInt(process.env.AGENT_TASK_GOAL_MAX_CHARS || '', 10) || 20000,
     /** 기본 최대 턴 수 */
     DEFAULT_MAX_TURNS: 10,
+    /**
+     * 대형 첨부(생성 시점 추출 상한 초과 — 샌드박스에서 에이전트가 직접 파싱/OCR) 시 기본 턴 수.
+     * 기본 10턴은 수백 페이지 문서의 읽기+정리에 부족해 goal_incomplete 로 실패한다
+     * (2026-08-08 실측: 66MB 스캔 PDF 가 턴 10/10 소진, 57MB 도 10/10 턱걸이 완주).
+     * 명시 maxTurns 가 오면 그 값이 우선.
+     */
+    LARGE_INPUT_MAX_TURNS: parseInt(process.env.AGENT_TASK_LARGE_INPUT_MAX_TURNS || '', 10) || 20,
     /** 관리자 전체 조회(/admin/conversations 작업 탭, ?viewAll=true) 기본 목록 상한.
      *  AGENT_TASK_LIST_ALL_DEFAULT 로 오버라이드(기본 200). */
     LIST_ALL_DEFAULT: parseInt(process.env.AGENT_TASK_LIST_ALL_DEFAULT || '', 10) || 200,

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -241,11 +241,18 @@ router.post('/', (req: Request, res: Response, next) => {
         ? [`진행 중인 에이전트 작업이 ${active.length}건 있습니다. 중복 실행이 아닌지 확인하세요.`]
         : [];
 
+    // 대형 첨부(추출 상한 초과 → 샌드박스 자체 파싱 필요)는 기본 턴 예산을 상향 —
+    // 기본 10턴으로는 수백 페이지 문서 읽기+정리가 안 돼 goal_incomplete 로 실패한다.
+    const hasLargeInput = (inputFiles ?? []).some(
+        (f) => (f.size ?? 0) > DOC_EXTRACT_LIMITS.MAX_BYTES_PER_FILE,
+    );
     await db.createAgentTask({
         id: taskId,
         userId,
         goal,
-        maxTurns: maxTurns ?? AGENT_TASK_LIMITS.DEFAULT_MAX_TURNS,
+        maxTurns: maxTurns ?? (hasLargeInput
+            ? AGENT_TASK_LIMITS.LARGE_INPUT_MAX_TURNS
+            : AGENT_TASK_LIMITS.DEFAULT_MAX_TURNS),
         inputFiles,
         inputImages: Array.isArray(images) && images.length > 0 ? images : undefined,
         gitRepoUrl: repoUrl,

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -31,7 +31,6 @@ import { getLocalBridgeRegistry } from '../services/local-bridge/registry';
 import { v4 as uuidv4 } from 'uuid';
 import { AgentTaskService, type AgentTaskInputFile } from '../services/AgentTaskService';
 import type { ChatMessage } from '../llm/types';
-import { AGENT_TASK_LIMITS } from '../config/runtime-limits';
 import {
     createAgentTaskSchema, executeAgentTaskSchema,
     type CreateAgentTaskInput, type ExecuteAgentTaskInput,
@@ -45,12 +44,13 @@ import { safeRealWorkspacePath, listWorkspaceFilesAt } from '../services/task-sa
 import { basename } from 'path';
 import multer from 'multer';
 import * as fs from 'fs/promises';
-import { FILE_ATTACH_LIMITS, DOC_EXTRACT_LIMITS } from '../config/runtime-limits';
+import { AGENT_TASK_LIMITS, FILE_ATTACH_LIMITS, DOC_EXTRACT_LIMITS } from '../config/runtime-limits';
 import {
     ensureUploadTmpDir, finalizeUploadedFile, resolveStoredPath,
     discardTmpFiles, removeTaskFiles, safeBaseName,
 } from '../services/agent-task/upload-store';
 import { claimUploadsAsInputFiles, ChunkStoreError } from '../services/agent-task/chunk-store';
+import { resolveDefaultMaxTurns } from '../services/agent-task/task-inputs';
 
 const logger = createLogger('AgentTaskRoutes');
 const router = Router();
@@ -241,18 +241,12 @@ router.post('/', (req: Request, res: Response, next) => {
         ? [`진행 중인 에이전트 작업이 ${active.length}건 있습니다. 중복 실행이 아닌지 확인하세요.`]
         : [];
 
-    // 대형 첨부(추출 상한 초과 → 샌드박스 자체 파싱 필요)는 기본 턴 예산을 상향 —
-    // 기본 10턴으로는 수백 페이지 문서 읽기+정리가 안 돼 goal_incomplete 로 실패한다.
-    const hasLargeInput = (inputFiles ?? []).some(
-        (f) => (f.size ?? 0) > DOC_EXTRACT_LIMITS.MAX_BYTES_PER_FILE,
-    );
     await db.createAgentTask({
         id: taskId,
         userId,
         goal,
-        maxTurns: maxTurns ?? (hasLargeInput
-            ? AGENT_TASK_LIMITS.LARGE_INPUT_MAX_TURNS
-            : AGENT_TASK_LIMITS.DEFAULT_MAX_TURNS),
+        // 대형 첨부는 기본 턴 상향(LARGE_INPUT_MAX_TURNS) — resolveDefaultMaxTurns 주석 참고
+        maxTurns: resolveDefaultMaxTurns(maxTurns, inputFiles),
         inputFiles,
         inputImages: Array.isArray(images) && images.length > 0 ? images : undefined,
         gitRepoUrl: repoUrl,

--- a/apps/api/src/services/agent-task/task-inputs.ts
+++ b/apps/api/src/services/agent-task/task-inputs.ts
@@ -7,6 +7,23 @@ import type { TaskRuntime } from '../task-sandbox/runtime';
 import type { AgentTaskInputFile } from './types';
 import { resolveStoredPath } from './upload-store';
 import { createLogger } from '../../utils/logger';
+import { AGENT_TASK_LIMITS, DOC_EXTRACT_LIMITS } from '../../config/runtime-limits';
+
+/**
+ * 작업 생성 시 기본 턴 수 결정 — 명시 maxTurns 우선. 대형 첨부(생성 시점 추출 상한 초과
+ * → 샌드박스에서 에이전트가 직접 파싱/OCR)는 기본 10턴으로 수백 페이지 처리가 안 돼
+ * goal_incomplete 로 실패하므로(2026-08-08 실측) LARGE_INPUT_MAX_TURNS 를 적용한다.
+ */
+export function resolveDefaultMaxTurns(
+    explicit: number | undefined,
+    files: AgentTaskInputFile[] | undefined,
+): number {
+    if (explicit) return explicit;
+    const hasLargeInput = (files ?? []).some(
+        (f) => (f.size ?? 0) > DOC_EXTRACT_LIMITS.MAX_BYTES_PER_FILE,
+    );
+    return hasLargeInput ? AGENT_TASK_LIMITS.LARGE_INPUT_MAX_TURNS : AGENT_TASK_LIMITS.DEFAULT_MAX_TURNS;
+}
 
 const logger = createLogger('AgentTaskService');
 

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -45,6 +45,28 @@ export function Sidebar() {
   const [query, setQuery] = useState("");
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  // 승인 대기 배지 — 위임된 작업이 HITL 승인에서 멈춘 것을 어느 화면/재접속 후에도 발견할 수 있게
+  // (WS 인라인 프롬프트는 연결 끊김·세션 이동 시 유실 — 2026-08-08 대형 PDF "인식 못함" 오인 사례).
+  const [pendingApprovals, setPendingApprovals] = useState(0);
+  useEffect(() => {
+    if (!user) { setPendingApprovals(0); return; }
+    let alive = true;
+    const poll = async () => {
+      try {
+        const r = await ApiClient.get<{ data: { pending: unknown[] } }>(
+          "/api/agent-tasks/approvals/pending",
+          { redirectOnUnauthorized: false },
+        );
+        if (alive) setPendingApprovals(r.data?.pending?.length ?? 0);
+      } catch {
+        /* 미인증/일시 오류 — 배지 유지 안 함 */
+        if (alive) setPendingApprovals(0);
+      }
+    };
+    void poll();
+    const timer = setInterval(poll, 30_000);
+    return () => { alive = false; clearInterval(timer); };
+  }, [user]);
 
   // 라우트 이동·바깥 클릭 시 프로필 메뉴 닫기
   useEffect(() => setMenuOpen(false), [pathname]);
@@ -183,6 +205,14 @@ export function Sidebar() {
               >
                 <item.icon className="h-[18px] w-[18px]" />
                 {tNav(item.labelKey)}
+                {item.href === "/agent-tasks" && pendingApprovals > 0 && (
+                  <span
+                    className="ml-auto inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-amber-500 px-1.5 text-[11px] font-semibold text-white"
+                    title={tNav("pendingApprovals", { count: pendingApprovals })}
+                  >
+                    {pendingApprovals}
+                  </span>
+                )}
               </Link>
             </li>
           ))}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -24,7 +24,8 @@
       "modelRolesAdmin": "Model Roles Admin",
       "developer": "Developer",
       "schedulesAdmin": "Task Schedules"
-    }
+    },
+    "pendingApprovals": "{count} pending approval(s) — agent tasks are waiting for your approval"
   },
   "sidebar": {
     "newChat": "New chat",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -24,7 +24,8 @@
       "modelRolesAdmin": "ロールモデル管理",
       "developer": "開発者",
       "schedulesAdmin": "タスクスケジュール"
-    }
+    },
+    "pendingApprovals": "承認待ち {count}件 — エージェント作業がユーザーの承認を待っています"
   },
   "sidebar": {
     "newChat": "新しいチャット",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -24,7 +24,8 @@
       "modelRolesAdmin": "역할 모델 관리",
       "developer": "개발자",
       "schedulesAdmin": "작업 스케줄"
-    }
+    },
+    "pendingApprovals": "승인 대기 {count}건 — 에이전트 작업이 사용자 승인을 기다리고 있습니다"
   },
   "sidebar": {
     "newChat": "새 대화",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -24,7 +24,8 @@
       "modelRolesAdmin": "角色模型管理",
       "developer": "开发者",
       "schedulesAdmin": "任务计划"
-    }
+    },
+    "pendingApprovals": "{count} 个待批准 — 代理任务正在等待您的批准"
   },
   "sidebar": {
     "newChat": "新对话",

--- a/infra/mcp-runtime/Dockerfile
+++ b/infra/mcp-runtime/Dockerfile
@@ -52,6 +52,11 @@ RUN mkdir -p /home/node/.cache/npm /home/node/.cache/uv
 # --with 'mcp<2': mcp-python-repl 은 상한 없는 `mcp>=1.7.0` 선언이라 mcp 2.x 가 설치되면
 # `mcp.server.fastmcp` 제거로 기동 실패(2026-08-08 no-cache 재빌드에서 실측) — noapi 와 동일 회피.
 RUN uv tool install --with 'mcp<2' mcp-python-repl
+
+# UTF-8 로케일 — 기본 POSIX 로케일에선 JVM(sun.jnu.encoding=ANSI)이 한글 등 비ASCII
+# 파일명을 열지 못한다(2026-08-08 실측: opendataloader-pdf 가 한글 파일명 PDF 무산출로
+# 대형 문서 task 실패). task-runtime 등 파생 이미지도 이 ENV 를 상속한다.
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV PATH=/home/node/.local/bin:${PATH}
 
 # ── NotebookLM MCP 서버(notebooklm-mcp-cli) — 이미지에 baked ─────────────────


### PR DESCRIPTION
## Summary
운영 라이브 사건("PDF 파일을 인식하지 못함") 추적 결과 — 파일 인식은 정상이었고, 대형 PDF 워크플로우의 3중 결함 연쇄가 원인:

1. **컨테이너 한글 파일명 실패**: task-runtime 기본 로케일이 POSIX → JVM `sun.jnu.encoding=ANSI` → `opendataloader-pdf`가 한글 파일명 PDF를 못 열어 무산출(-q라 조용히) 실패. **컨테이너에서 재현 후 `ENV LANG/LC_ALL=C.UTF-8`(mcp-runtime, 파생 이미지 상속)로 수정·재검증 완료.**
2. **대형 첨부 턴 예산 부족**: >30MB 첨부는 생성 시점 추출을 생략(CF 100s 가드)하고 샌드박스에서 에이전트가 직접 파싱하는 설계인데, 기본 10턴으로는 수백 페이지 읽기+정리가 불가 — 실측: 66MB 스캔 PDF 턴 10/10 소진 후 `goal_incomplete` 실패, 57MB는 10/10 턱걸이 완주. `AGENT_TASK_LIMITS.LARGE_INPUT_MAX_TURNS`(기본 20, env 오버라이드) 신설, 대형 첨부 존재 + maxTurns 미지정 시 적용.
3. **승인 대기 발견성**: 작업 시작 직후 WS 끊김+JWT 만료로 승인 프롬프트가 유실되면 작업이 20분+ 방치(사용자에겐 "인식 못함/멈춤"으로 체감). 사이드바 "에이전트 작업" 메뉴에 **승인 대기 배지**(30초 폴링, 기존 `GET /api/agent-tasks/approvals/pending` 재사용) — 어느 화면·재접속 후에도 발견 가능. i18n 4개 언어.

운영 조치(코드 외): `.env` `TASK_SANDBOX_WORKSPACE_QUOTA` 512MB→2GB (66MB 원본+페이지 래스터화가 쿼터 초과했던 부분).

## Test plan
- [x] 한글 파일명: 수정 전 컨테이너에서 실패 재현 → ENV 적용 이미지에서 추출 성공 검증
- [x] jest 전체 2,427 통과 (agent-task 스위트 143 포함), api/web tsc·eslint 클린
- [x] 로케일 파일 diff 최소(키 4줄 추가만)
- [ ] merge 후 배포 → 실사건 파일(66MB 2040인천 PDF) 재실행으로 E2E 검증 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)