### PR TITLE
fix(agent-task): 추출 실패 문서도 턴 예산 상향 대상에 포함

### DIFF
--- a/apps/api/src/services/agent-task/task-inputs.ts
+++ b/apps/api/src/services/agent-task/task-inputs.ts
@@ -19,10 +19,16 @@ export function resolveDefaultMaxTurns(
     files: AgentTaskInputFile[] | undefined,
 ): number {
     if (explicit) return explicit;
-    const hasLargeInput = (files ?? []).some(
-        (f) => (f.size ?? 0) > DOC_EXTRACT_LIMITS.MAX_BYTES_PER_FILE,
-    );
-    return hasLargeInput ? AGENT_TASK_LIMITS.LARGE_INPUT_MAX_TURNS : AGENT_TASK_LIMITS.DEFAULT_MAX_TURNS;
+    // 크기 초과뿐 아니라 "추출 텍스트를 확보하지 못한 문서"(스캔본·추출 타임아웃 등)도
+    // 샌드박스 자체 파싱이 필요해 동일하게 턴 예산을 상향한다 (2026-08-08 13MB 스캔 PDF
+    // 추출 60s 타임아웃 → 10턴 소진 실측).
+    const needsSandboxParsing = (files ?? []).some((f) => {
+        if ((f.size ?? 0) > DOC_EXTRACT_LIMITS.MAX_BYTES_PER_FILE) return true;
+        const ext = (f.name ?? '').toLowerCase().split('.').pop() ?? '';
+        const isDoc = DOC_EXTRACT_LIMITS.PDF_EXTS.includes(ext) || DOC_EXTRACT_LIMITS.OFFICE_EXTS.includes(ext);
+        return isDoc && typeof f.content !== 'string';
+    });
+    return needsSandboxParsing ? AGENT_TASK_LIMITS.LARGE_INPUT_MAX_TURNS : AGENT_TASK_LIMITS.DEFAULT_MAX_TURNS;
 }
 
 const logger = createLogger('AgentTaskService');


### PR DESCRIPTION
## Summary
#454 후속 사각: 크기(>30MB) 조건만으로는 **≤30MB인데 추출에 실패한 문서**(스캔본·추출 타임아웃)가 여전히 10턴으로 샌드박스 자체 파싱을 하다 소진된다 — 2026-08-08 13MB 스캔 PDF가 추출 60s 타임아웃 후 턴 10/10 소진 실측. `resolveDefaultMaxTurns`에 "문서 확장자 + content 미확보" 조건 추가.

## Test plan
- [x] agent-task 스위트 143 통과, tsc 클린
🤖 Generated with [Claude Code](https://claude.com/claude-code)