### PR TITLE
feat(web-search): 네이버 검색 NAVER API HUB 듀얼 경로 + 무료 한도 가드

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -345,6 +345,14 @@ GOOGLE_CSE_ID=your_google_cse_id_here
 NAVER_CLIENT_ID=your_naver_client_id_here
 NAVER_CLIENT_SECRET=your_naver_client_secret_here
 
+# NAVER API HUB (NCP 이관 — 2026-06-29 공지, 기존 개발자센터 키는 2027-06-30 까지 유예)
+# 설정 시 검색 API 가 HUB 경로(naverapihub.apigw.ntruss.com)로 전환됩니다. 비우면 legacy 경로.
+# 발급: NCP 콘솔 → Application Services → NAVER API HUB
+NAVER_API_HUB_KEY_ID=your_ncp_apigw_key_id_here
+NAVER_API_HUB_KEY=your_ncp_apigw_key_here
+# 일일 호출 한도 가드 (기본 25000 = 무료 허용량, 0 = 무제한) — 도달 시 호출 차단(빈 결과 graceful)
+NAVER_API_DAILY_LIMIT=25000
+
 # *******************************************************
 # 📊 인프라 및 네트워크 설정
 # *******************************************************

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -171,6 +171,10 @@ export const envSchema = z
         GOOGLE_CSE_ID: z.string().default(''),
         NAVER_CLIENT_ID: z.string().default(''),
         NAVER_CLIENT_SECRET: z.string().default(''),
+        // NAVER API HUB (NCP 이관, 2026-06-29 공지) — 설정 시 legacy 대신 HUB 경로 사용
+        NAVER_API_HUB_KEY_ID: z.string().default(''),
+        NAVER_API_HUB_KEY: z.string().default(''),
+        NAVER_API_DAILY_LIMIT: z.coerce.number().int().min(0).default(25000),
         GITHUB_TOKEN: z.string().default(''),
         VAPID_PUBLIC_KEY: z.string().default(''),
         VAPID_PRIVATE_KEY: z.string().default(''),

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -95,6 +95,10 @@ export interface EnvConfig {
     googleCseId: string;
     naverClientId: string;
     naverClientSecret: string;
+    naverApiHubKeyId: string;
+    naverApiHubKey: string;
+    /** 네이버 검색 API 일일 호출 한도(무료 한도 가드, 0=무제한) */
+    naverApiDailyLimit: number;
     githubToken: string;
 
     // Documents
@@ -215,6 +219,9 @@ const DEFAULT_CONFIG: EnvConfig = {
     googleCseId: '',
     naverClientId: '',
     naverClientSecret: '',
+    naverApiHubKeyId: '',
+    naverApiHubKey: '',
+    naverApiDailyLimit: 25000,
     githubToken: '',
 
     // Documents
@@ -467,6 +474,9 @@ export function loadConfig(): EnvConfig {
         googleCseId: parsed.GOOGLE_CSE_ID ?? DEFAULT_CONFIG.googleCseId,
         naverClientId: parsed.NAVER_CLIENT_ID ?? DEFAULT_CONFIG.naverClientId,
         naverClientSecret: parsed.NAVER_CLIENT_SECRET ?? DEFAULT_CONFIG.naverClientSecret,
+        naverApiHubKeyId: parsed.NAVER_API_HUB_KEY_ID ?? DEFAULT_CONFIG.naverApiHubKeyId,
+        naverApiHubKey: parsed.NAVER_API_HUB_KEY ?? DEFAULT_CONFIG.naverApiHubKey,
+        naverApiDailyLimit: parsed.NAVER_API_DAILY_LIMIT ?? DEFAULT_CONFIG.naverApiDailyLimit,
         githubToken: parsed.GITHUB_TOKEN ?? DEFAULT_CONFIG.githubToken,
 
         // Documents

--- a/apps/api/src/mcp/web-search/__tests__/naver-client.test.ts
+++ b/apps/api/src/mcp/web-search/__tests__/naver-client.test.ts
@@ -1,0 +1,123 @@
+/**
+ * naver-client — legacy ↔ NAVER API HUB 듀얼 경로 + 일일 한도 가드 단위 테스트.
+ * env 파생 상수는 getConfig mock 으로 고정 (project_jest_env_dependent_tests 관용구).
+ */
+import { buildNaverSearchRequest } from '../naver-client';
+import { getConfig } from '../../../config';
+import { getKeyValueStore } from '../../../storage';
+
+jest.mock('../../../config', () => ({
+    ...jest.requireActual('../../../config'),
+    getConfig: jest.fn(),
+}));
+jest.mock('../../../storage', () => ({
+    getKeyValueStore: jest.fn(),
+}));
+
+const mockGetConfig = getConfig as jest.Mock;
+const mockGetStore = getKeyValueStore as jest.Mock;
+
+function setConfig(partial: Record<string, unknown>) {
+    mockGetConfig.mockReturnValue({
+        naverClientId: '',
+        naverClientSecret: '',
+        naverApiHubKeyId: '',
+        naverApiHubKey: '',
+        naverApiDailyLimit: 25000,
+        ...partial,
+    });
+}
+
+function setStoreCount(used: number) {
+    mockGetStore.mockReturnValue({
+        incrBy: jest.fn().mockResolvedValue(used),
+        expire: jest.fn().mockResolvedValue(true),
+    });
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    setStoreCount(1);
+});
+
+describe('buildNaverSearchRequest — 듀얼 경로', () => {
+    it('HUB 키 설정 시 HUB URL + NCP 헤더', async () => {
+        setConfig({ naverApiHubKeyId: 'hub-id', naverApiHubKey: 'hub-secret' });
+        const req = await buildNaverSearchRequest('news', 'query=ai&display=5&sort=date');
+        expect(req).not.toBeNull();
+        expect(req!.route).toBe('hub');
+        expect(req!.url).toBe('https://naverapihub.apigw.ntruss.com/search/v1/news?query=ai&display=5&sort=date');
+        expect(req!.headers).toEqual({
+            'X-NCP-APIGW-API-KEY-ID': 'hub-id',
+            'X-NCP-APIGW-API-KEY': 'hub-secret',
+        });
+    });
+
+    it('HUB 키 미설정 + legacy 키 설정 시 legacy URL(.json) + X-Naver 헤더', async () => {
+        setConfig({ naverClientId: 'legacy-id', naverClientSecret: 'legacy-secret' });
+        const req = await buildNaverSearchRequest('webkr', 'query=ai&display=10');
+        expect(req).not.toBeNull();
+        expect(req!.route).toBe('legacy');
+        expect(req!.url).toBe('https://openapi.naver.com/v1/search/webkr.json?query=ai&display=10');
+        expect(req!.headers).toEqual({
+            'X-Naver-Client-Id': 'legacy-id',
+            'X-Naver-Client-Secret': 'legacy-secret',
+        });
+    });
+
+    it('HUB 키가 있으면 legacy 키가 있어도 HUB 우선', async () => {
+        setConfig({
+            naverClientId: 'legacy-id', naverClientSecret: 'legacy-secret',
+            naverApiHubKeyId: 'hub-id', naverApiHubKey: 'hub-secret',
+        });
+        const req = await buildNaverSearchRequest('news', 'query=x');
+        expect(req!.route).toBe('hub');
+    });
+
+    it('키 전부 미설정이면 null (graceful)', async () => {
+        setConfig({});
+        expect(await buildNaverSearchRequest('news', 'query=x')).toBeNull();
+    });
+});
+
+describe('buildNaverSearchRequest — 일일 한도 가드', () => {
+    it('한도 이내면 요청 반환 + 카운터 증가', async () => {
+        setConfig({ naverClientId: 'id', naverClientSecret: 'sec', naverApiDailyLimit: 100 });
+        setStoreCount(100); // 증가 후 100 == limit → 허용 (used > limit 만 차단)
+        const req = await buildNaverSearchRequest('news', 'query=x');
+        expect(req).not.toBeNull();
+        expect(mockGetStore().incrBy).toHaveBeenCalled();
+    });
+
+    it('한도 초과면 null (요청 차단)', async () => {
+        setConfig({ naverClientId: 'id', naverClientSecret: 'sec', naverApiDailyLimit: 100 });
+        setStoreCount(101);
+        expect(await buildNaverSearchRequest('news', 'query=x')).toBeNull();
+    });
+
+    it('한도 0 = 무제한 (카운터 미사용)', async () => {
+        setConfig({ naverClientId: 'id', naverClientSecret: 'sec', naverApiDailyLimit: 0 });
+        const store = { incrBy: jest.fn(), expire: jest.fn() };
+        mockGetStore.mockReturnValue(store);
+        const req = await buildNaverSearchRequest('news', 'query=x');
+        expect(req).not.toBeNull();
+        expect(store.incrBy).not.toHaveBeenCalled();
+    });
+
+    it('KVStore 장애 시 fail-open (요청 허용)', async () => {
+        setConfig({ naverClientId: 'id', naverClientSecret: 'sec', naverApiDailyLimit: 100 });
+        mockGetStore.mockImplementation(() => { throw new Error('redis down'); });
+        expect(await buildNaverSearchRequest('news', 'query=x')).not.toBeNull();
+    });
+
+    it('일일 버킷 키는 KST 자정 경계로 바뀐다', async () => {
+        setConfig({ naverClientId: 'id', naverClientSecret: 'sec', naverApiDailyLimit: 100 });
+        const incrBy = jest.fn().mockResolvedValue(1);
+        mockGetStore.mockReturnValue({ incrBy, expire: jest.fn().mockResolvedValue(true) });
+        // 2026-08-07T14:59:59Z = KST 2026-08-07 23:59:59 / 15:00:00Z = KST 8/8 00:00:00
+        await buildNaverSearchRequest('news', 'query=x', Date.parse('2026-08-07T14:59:59Z'));
+        await buildNaverSearchRequest('news', 'query=x', Date.parse('2026-08-07T15:00:00Z'));
+        const keys = incrBy.mock.calls.map((c) => c[0]);
+        expect(keys[0]).not.toBe(keys[1]);
+    });
+});

--- a/apps/api/src/mcp/web-search/naver-client.ts
+++ b/apps/api/src/mcp/web-search/naver-client.ts
@@ -1,0 +1,113 @@
+/**
+ * ============================================================
+ * 네이버 검색 API 요청 조립 — legacy ↔ NAVER API HUB 듀얼 경로 + 일일 한도 가드
+ * ============================================================
+ *
+ * 2026-06-29 공지로 Search API 가 NCP NAVER API HUB 로 이관됨(기존 개발자센터 키는
+ * 2027-06-30 까지 유예). `NAVER_API_HUB_KEY_ID`/`NAVER_API_HUB_KEY` 가 설정되면
+ * HUB 경로(NCP 게이트웨이 헤더)를, 아니면 legacy 경로를 사용한다 — env 제거만으로
+ * 즉시 롤백 가능한 점진 전환. 파라미터·응답 JSON 계약은 양쪽 동일(문서 실측).
+ *
+ * 일일 한도 가드: `NAVER_API_DAILY_LIMIT`(기본 25,000 — 공식 문서의 일일 허용량)
+ * 도달 시 요청을 만들지 않고 null 을 반환한다 → 호출부는 빈 배열 graceful.
+ * 무료 한도 초과분이 과금으로 이어지지 않게 하는 안전망. KVStore calendar-bucket
+ * (llm/user-quota 관용구) — 멀티프로세스 정합, KVStore 장애 시 fail-open(호출 허용).
+ * 버킷 경계는 KST 자정(네이버 한도 리셋 기준) 정렬.
+ *
+ * @module mcp/web-search/naver-client
+ */
+import { getConfig } from '../../config';
+import { getKeyValueStore } from '../../storage';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('NaverClient');
+
+/** legacy 개발자센터 엔드포인트 (경로에 `.json` 확장자, X-Naver-* 헤더) */
+const LEGACY_BASE_URL = 'https://openapi.naver.com/v1/search';
+/** NAVER API HUB 엔드포인트 (NCP API Gateway, `format=json` 기본이라 확장자 없음) */
+const HUB_BASE_URL = 'https://naverapihub.apigw.ntruss.com/search/v1';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+/** KST(UTC+9) 자정 기준 일일 버킷 — 네이버 일일 한도 리셋과 정렬 */
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+/** 버킷 경계 직후에도 직전 버킷 조회 가능하도록 2배 TTL (user-quota 관용구) */
+const DAY_TTL_MS = 2 * DAY_MS;
+
+function dayKey(now: number): string {
+    return `naverq:d:${Math.floor((now + KST_OFFSET_MS) / DAY_MS)}`;
+}
+
+export type NaverSearchEndpoint = 'news' | 'webkr';
+
+export interface NaverSearchRequest {
+    url: string;
+    headers: Record<string, string>;
+    /** 어느 경로를 탔는지 — 로그/테스트 관측용 */
+    route: 'hub' | 'legacy';
+}
+
+/**
+ * 오늘 버킷에 1 증가 후 한도 검사. 한도 도달이면 false (요청 차단).
+ * 증가가 먼저라 race-free — 한도 초과 시 카운터가 한도를 넘겨 있지만 요청은 안 나간다.
+ */
+async function underDailyLimit(now: number): Promise<boolean> {
+    const limit = getConfig().naverApiDailyLimit;
+    if (limit <= 0) return true; // 0 = 무제한 (가드 해제)
+    try {
+        const store = getKeyValueStore();
+        const key = dayKey(now);
+        const used = await store.incrBy(key, 1);
+        void store.expire(key, DAY_TTL_MS);
+        if (used > limit) {
+            // 하루 한 번만 경고가 도배되지 않도록 초과 직후 구간만 로그
+            if (used <= limit + 3) {
+                logger.warn(`네이버 검색 일일 한도(${limit}) 도달 — 오늘 호출 차단 (KST 자정 리셋)`);
+            }
+            return false;
+        }
+        return true;
+    } catch (e) {
+        logger.warn('네이버 일일 한도 검사 실패 (fail-open):', e);
+        return true;
+    }
+}
+
+/**
+ * 네이버 검색 요청 조립. 키 미설정/일일 한도 도달이면 null → 호출부는 빈 배열 graceful.
+ *
+ * @param endpoint - 'news' | 'webkr'
+ * @param queryString - `query=...&display=...` 형태의 인코딩 완료 쿼리스트링
+ */
+export async function buildNaverSearchRequest(
+    endpoint: NaverSearchEndpoint,
+    queryString: string,
+    now: number = Date.now(),
+): Promise<NaverSearchRequest | null> {
+    const cfg = getConfig();
+
+    let req: NaverSearchRequest;
+    if (cfg.naverApiHubKeyId && cfg.naverApiHubKey) {
+        req = {
+            url: `${HUB_BASE_URL}/${endpoint}?${queryString}`,
+            headers: {
+                'X-NCP-APIGW-API-KEY-ID': cfg.naverApiHubKeyId,
+                'X-NCP-APIGW-API-KEY': cfg.naverApiHubKey,
+            },
+            route: 'hub',
+        };
+    } else if (cfg.naverClientId && cfg.naverClientSecret) {
+        req = {
+            url: `${LEGACY_BASE_URL}/${endpoint}.json?${queryString}`,
+            headers: {
+                'X-Naver-Client-Id': cfg.naverClientId,
+                'X-Naver-Client-Secret': cfg.naverClientSecret,
+            },
+            route: 'legacy',
+        };
+    } else {
+        return null; // 키 미설정 — 기존 graceful 동작 유지
+    }
+
+    if (!(await underDailyLimit(now))) return null;
+    return req;
+}

--- a/apps/api/src/mcp/web-search/providers.ts
+++ b/apps/api/src/mcp/web-search/providers.ts
@@ -13,15 +13,12 @@ import { createLogger } from '../../utils/logger';
 import { CAPACITY } from '../../config/runtime-limits';
 import { LLM_TIMEOUTS } from '../../config/timeouts';
 import { getSearchLocale } from '../../i18n/search-locale';
+import { buildNaverSearchRequest } from './naver-client';
 
 /** Google Custom Search API 키 */
 const GOOGLE_API_KEY = getConfig().googleApiKey;
 /** Google Custom Search Engine ID */
 const GOOGLE_CSE_ID = getConfig().googleCseId;
-/** Naver 검색 API Client ID (웹문서 검색) */
-const NAVER_CLIENT_ID = getConfig().naverClientId;
-/** Naver 검색 API Client Secret */
-const NAVER_CLIENT_SECRET = getConfig().naverClientSecret;
 /** Logger instance */
 const logger = createLogger('WebSearch');
 
@@ -328,24 +325,17 @@ export async function searchDuckDuckGoAPI(query: string, signal?: AbortSignal): 
 export async function searchNaverNews(query: string, maxResults: number = 5, signal?: AbortSignal): Promise<SearchResult[]> {
     const results: SearchResult[] = [];
 
-    if (!NAVER_CLIENT_ID || !NAVER_CLIENT_SECRET) {
-        return results;
-    }
-
     try {
         const display = Math.min(Math.max(maxResults, 1), 100);
-        const url = `https://openapi.naver.com/v1/search/news.json?query=${encodeURIComponent(query)}&display=${display}&sort=date`;
+        // legacy ↔ NAVER API HUB 듀얼 경로 + 일일 한도 가드 — 키 미설정/한도 도달 시 null → 빈 배열 graceful
+        const req = await buildNaverSearchRequest('news', `query=${encodeURIComponent(query)}&display=${display}&sort=date`);
+        if (!req) return results;
 
-        const response = await searchFetch(url, signal, {
-            headers: {
-                'X-Naver-Client-Id': NAVER_CLIENT_ID,
-                'X-Naver-Client-Secret': NAVER_CLIENT_SECRET,
-            },
-        });
+        const response = await searchFetch(req.url, signal, { headers: req.headers });
 
         if (!response.ok) {
-            // 403 = 등록 앱에 '검색' API 미설정 (개발자센터 > Application > API 설정에서 활성화).
-            logger.error(`네이버 뉴스 API 오류: ${response.status}${response.status === 403 ? ' (앱 검색 API 미설정 가능성)' : ''}`);
+            // 403 = 등록 앱에 '검색' API 미설정, 429 = 일일 허용량 초과 (HUB 문서 명시).
+            logger.error(`네이버 뉴스 API 오류(${req.route}): ${response.status}${response.status === 403 ? ' (앱 검색 API 미설정 가능성)' : response.status === 429 ? ' (일일 허용량 초과)' : ''}`);
             return results;
         }
 
@@ -396,24 +386,17 @@ function stripNaverTags(text: string): string {
 export async function searchNaverWeb(query: string, maxResults: number = 10, signal?: AbortSignal): Promise<SearchResult[]> {
     const results: SearchResult[] = [];
 
-    if (!NAVER_CLIENT_ID || !NAVER_CLIENT_SECRET) {
-        return results;
-    }
-
     try {
         const display = Math.min(Math.max(maxResults, 1), 100);
-        const url = `https://openapi.naver.com/v1/search/webkr.json?query=${encodeURIComponent(query)}&display=${display}`;
+        // legacy ↔ NAVER API HUB 듀얼 경로 + 일일 한도 가드 — 키 미설정/한도 도달 시 null → 빈 배열 graceful
+        const req = await buildNaverSearchRequest('webkr', `query=${encodeURIComponent(query)}&display=${display}`);
+        if (!req) return results;
 
-        const response = await searchFetch(url, signal, {
-            headers: {
-                'X-Naver-Client-Id': NAVER_CLIENT_ID,
-                'X-Naver-Client-Secret': NAVER_CLIENT_SECRET,
-            },
-        });
+        const response = await searchFetch(req.url, signal, { headers: req.headers });
 
         if (!response.ok) {
-            // 403 = 등록 앱에 '검색' API 미설정 (개발자센터 > Application > API 설정에서 활성화).
-            logger.error(`네이버 웹문서 API 오류: ${response.status}${response.status === 403 ? ' (앱 검색 API 미설정 가능성)' : ''}`);
+            // 403 = 등록 앱에 '검색' API 미설정, 429 = 일일 허용량 초과 (HUB 문서 명시).
+            logger.error(`네이버 웹문서 API 오류(${req.route}): ${response.status}${response.status === 403 ? ' (앱 검색 API 미설정 가능성)' : response.status === 429 ? ' (일일 허용량 초과)' : ''}`);
             return results;
         }
 


### PR DESCRIPTION
## 배경
네이버 개발자센터 Search API 가 NCP **NAVER API HUB** 로 이관(2026-06-29 공지, 기존 키는 2027-06-30 까지 유예). openmake_llm 사용분은 뉴스(news)·웹문서(webkr) 2개 — 종료 대상(쇼핑/책/전문자료)은 미사용.

## 변경
- **듀얼 경로**: `NAVER_API_HUB_KEY_ID/KEY` 설정 시 HUB(`naverapihub.apigw.ntruss.com/search/v1/*` + `X-NCP-APIGW-API-KEY*` 헤더), 미설정 시 legacy. 택일 구조라 이중 호출/이중 과금 없음, env 제거만으로 즉시 롤백
- **일일 무료 한도 가드**: `NAVER_API_DAILY_LIMIT`(기본 25,000) 도달 시 호출 차단(빈 결과 graceful). KVStore KST-자정 calendar-bucket(user-quota 관용구), fail-open
- 파라미터·응답 계약 동일(문서 실측) — 파싱/stripNaverTags 무변경. 429 로그 구분 추가

## 비용 안전 (요구사항: 비용 발생 절대 금지)
- NAVER API HUB 는 현재 **한시 무료**(공식 가이드: "한시적으로 무료로 제공되며, 유료 전환 시 사전에 별도 공지"), 한도 초과는 과금이 아닌 **429 차단**
- 콘솔 실측: 일 25,000회/월 775,000회 무료 쿼터 표기
- 우리 쪽 25,000/일 가드가 이중 안전망

## 검증
- [x] 유닛 9건(naver-client) + web-search 31건 + 전체 jest 2,436
- [x] tsc·lint 0 errors·eval:routing 93.3%·eval:response 100%
- [x] 라이브: HUB 프로브 200(뉴스·웹문서) → 실채팅 웹검색 → **NCP 콘솔 사용량 집계 증가 확인**(공유 브라우저)

🤖 Generated with [Claude Code](https://claude.com/claude-code)