### PR TITLE
feat(usage): 토큰 사용량 가상 비용 환산 — 일/월/년

### DIFF
--- a/apps/api/src/config/pricing.ts
+++ b/apps/api/src/config/pricing.ts
@@ -35,3 +35,21 @@ export const MODEL_PRICING: Readonly<Record<string, { input: number; output: num
     'gemma4:e4b': { input: 0, output: 0 },
     'default': { input: 0, output: 0 },
 } as const;
+
+/**
+ * 가상 비용 환산 참조 단가 — "상용 API 로 지불했다면" 얼마인지 보여주는 용도(실제 과금 아님).
+ *
+ * usage 대시보드의 일/월/년 비용 환산에 사용. 저장된 토큰이 입력/출력 미구분(총합)이라
+ * OUTPUT_RATIO 가정으로 혼합 단가를 만든다. 기본값은 동급(30B급 MoE) 상용 API 시세 근사 —
+ * 배포별 조정은 env 로 (No-Hardcoding L1).
+ */
+export const REFERENCE_COST = {
+    /** 입력 토큰 단가 (USD per 1M tokens) */
+    INPUT_USD_PER_1M: parseFloat(process.env.TOKEN_COST_INPUT_USD_PER_1M || '0.40'),
+    /** 출력 토큰 단가 (USD per 1M tokens) */
+    OUTPUT_USD_PER_1M: parseFloat(process.env.TOKEN_COST_OUTPUT_USD_PER_1M || '1.20'),
+    /** 총 토큰 중 출력 비중 가정 (입출력 분리 데이터 부재 보정) */
+    OUTPUT_RATIO: parseFloat(process.env.TOKEN_COST_OUTPUT_RATIO || '0.25'),
+    /** 원화 환산 환율 */
+    USD_KRW: parseFloat(process.env.TOKEN_COST_USD_KRW || '1400'),
+} as const;

--- a/apps/api/src/data/repositories/conversation-repository.ts
+++ b/apps/api/src/data/repositories/conversation-repository.ts
@@ -122,6 +122,45 @@ export class ConversationRepository extends BaseRepository {
         return result.rows;
     }
 
+    /**
+     * 본인 토큰 사용량 기간 버킷 집계 — 가상 비용 환산(usage /cost)용.
+     *
+     * 소스는 대화(conversation_messages.tokens) + 에이전트 작업(agent_tasks.total_tokens) 합산 —
+     * 실측상 작업 토큰이 지배적(18.8M vs 0.3M)이라 대화만 집계하면 비용이 크게 과소평가된다.
+     * granularity: 'day'(최근 30일) | 'month'(최근 12개월) | 'year'(전체).
+     */
+    async getUserTokenBuckets(
+        userId: string,
+        granularity: 'day' | 'month' | 'year',
+    ): Promise<Array<{ period: string; tokens: string }>> {
+        // 컬럼/포맷은 granularity 별 하드코딩 상수 선택(값 바인딩만 파라미터) — 인젝션 없음
+        const spec = {
+            day: { trunc: 'day', fmt: 'YYYY-MM-DD', since: `NOW() - interval '30 days'` },
+            month: { trunc: 'month', fmt: 'YYYY-MM', since: `NOW() - interval '12 months'` },
+            year: { trunc: 'year', fmt: 'YYYY', since: `'epoch'::timestamptz` },
+        }[granularity];
+        const result = await this.query<{ period: string; tokens: string }>(
+            `WITH tok AS (
+                 SELECT m.created_at AS ts, m.tokens AS tokens
+                 FROM conversation_messages m
+                 JOIN conversation_sessions s ON m.session_id = s.id
+                 WHERE s.user_id = $1 AND m.tokens > 0
+                 UNION ALL
+                 SELECT t.created_at AS ts, t.total_tokens AS tokens
+                 FROM agent_tasks t
+                 WHERE t.user_id = $1 AND t.total_tokens > 0
+             )
+             SELECT to_char(date_trunc('${spec.trunc}', ts), '${spec.fmt}') AS period,
+                    COALESCE(SUM(tokens), 0) AS tokens
+             FROM tok
+             WHERE ts >= ${spec.since}
+             GROUP BY 1
+             ORDER BY 1`,
+            [userId]
+        );
+        return result.rows;
+    }
+
     /** 본인 일별 토큰/메시지 통계 */
     async getUserDailyUsage(userId: string, days: number): Promise<Array<{ date: string; tokens: string; messages: string }>> {
         const result = await this.query<{ date: string; tokens: string; messages: string }>(

--- a/apps/api/src/routes/usage.routes.ts
+++ b/apps/api/src/routes/usage.routes.ts
@@ -22,6 +22,7 @@ import { requireAuth } from '../auth';
 import { asyncHandler } from '../utils/error-handler';
 import { getPool } from '../data/models/unified-database';
 import { ConversationRepository } from '../data/repositories/conversation-repository';
+import { REFERENCE_COST } from '../config/pricing';
 
 const router = Router();
 
@@ -109,6 +110,49 @@ router.get('/daily', asyncHandler(async (req: Request, res: Response) => {
         messages: Number(row.messages),
     }));
     res.json(success({ daily }));
+}));
+
+/**
+ * 가상 비용 환산 — "상용 API 였다면 얼마" (실제 과금 아님)
+ * GET /api/usage/cost
+ *
+ * 대화 + 에이전트 작업 토큰 합산을 일(최근 30일)/월(최근 12개월)/년(전체) 버킷으로
+ * 집계하고, config/pricing REFERENCE_COST 혼합 단가로 USD/KRW 를 환산해 반환한다.
+ */
+router.get('/cost', asyncHandler(async (req: Request, res: Response) => {
+    const userId = getUserId(req);
+    const empty = { day: [], month: [], year: [], total: { tokens: 0, costUsd: 0, costKrw: 0 } };
+    if (!userId) {
+        res.json(success({ rates: REFERENCE_COST, ...empty }));
+        return;
+    }
+
+    const r = REFERENCE_COST;
+    // 혼합 단가(USD per token): 입출력 미구분 총 토큰에 출력 비중 가정 적용
+    const blendedPerToken = ((1 - r.OUTPUT_RATIO) * r.INPUT_USD_PER_1M + r.OUTPUT_RATIO * r.OUTPUT_USD_PER_1M) / 1_000_000;
+    const toCost = (row: { period: string; tokens: string }) => {
+        const tokens = Number(row.tokens);
+        const costUsd = tokens * blendedPerToken;
+        return { period: row.period, tokens, costUsd, costKrw: costUsd * r.USD_KRW };
+    };
+
+    const repo = new ConversationRepository(getPool());
+    const [day, month, year] = await Promise.all([
+        repo.getUserTokenBuckets(userId, 'day'),
+        repo.getUserTokenBuckets(userId, 'month'),
+        repo.getUserTokenBuckets(userId, 'year'),
+    ]);
+    const yearRows = year.map(toCost);
+    const totalTokens = yearRows.reduce((n, x) => n + x.tokens, 0);
+    const totalUsd = totalTokens * blendedPerToken;
+
+    res.json(success({
+        rates: r,
+        day: day.map(toCost),
+        month: month.map(toCost),
+        year: yearRows,
+        total: { tokens: totalTokens, costUsd: totalUsd, costKrw: totalUsd * r.USD_KRW },
+    }));
 }));
 
 export default router;

--- a/apps/web/app/(workspace)/usage/page.tsx
+++ b/apps/web/app/(workspace)/usage/page.tsx
@@ -68,6 +68,128 @@ const fmtMs = (n?: number) => (n != null && n > 0 ? `${Math.round(n)}ms` : "-");
 const fmtCost = (n?: number) =>
   n != null ? `$${n.toFixed(4)}` : "-";
 
+/* ── 가상 비용 환산 섹션 (일/월/년) — "상용 API 였다면 얼마" (실제 과금 아님) ── */
+interface CostBucket {
+  period: string;
+  tokens: number;
+  costUsd: number;
+  costKrw: number;
+}
+interface CostEstimate {
+  rates: { INPUT_USD_PER_1M: number; OUTPUT_USD_PER_1M: number; OUTPUT_RATIO: number; USD_KRW: number };
+  day: CostBucket[];
+  month: CostBucket[];
+  year: CostBucket[];
+  total: { tokens: number; costUsd: number; costKrw: number };
+}
+type CostGranularity = "day" | "month" | "year";
+
+function CostEstimateSection() {
+  const t = useTranslations("usage");
+  const locale = toBcp47(useLocale());
+  const [data, setData] = useState<CostEstimate | null>(null);
+  const [gran, setGran] = useState<CostGranularity>("day");
+
+  useEffect(() => {
+    let alive = true;
+    void ApiClient.get<ApiSuccess<CostEstimate>>("/api/usage/cost")
+      .then((res) => {
+        if (alive) setData(res?.data ?? null);
+      })
+      .catch(() => {
+        /* 비로그인/오류 — 섹션 미표시 */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (!data) return null;
+
+  const fmtKrw = (n: number) => `₩${Math.round(n).toLocaleString(locale)}`;
+  const fmtUsd = (n: number) => `$${n.toFixed(2)}`;
+  // 오늘/이번 달 카드 — 버킷 키(UTC 기준 date_trunc)와 매칭
+  const todayKey = new Date().toISOString().slice(0, 10);
+  const monthKey = todayKey.slice(0, 7);
+  const todayRow = data.day.find((r) => r.period === todayKey);
+  const monthRow = data.month.find((r) => r.period === monthKey);
+  const rows = [...data[gran]].reverse(); // 최신 우선
+  const TABS: Array<{ key: CostGranularity; labelKey: string }> = [
+    { key: "day", labelKey: "costTabDay" },
+    { key: "month", labelKey: "costTabMonth" },
+    { key: "year", labelKey: "costTabYear" },
+  ];
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <CardTitle>{t("costTitle")}</CardTitle>
+          <p className="mt-0.5 text-xs text-muted">{t("costSubtitle")}</p>
+        </div>
+        <div className="flex gap-1">
+          {TABS.map(({ key, labelKey }) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setGran(key)}
+              className={cn(
+                "rounded-md border px-2.5 py-1 text-xs transition",
+                gran === key
+                  ? "border-accent bg-accent-soft text-accent"
+                  : "border-border text-muted hover:text-fg",
+              )}
+            >
+              {t(labelKey)}
+            </button>
+          ))}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-3 gap-4">
+          <StatCard label={t("costToday")} value={fmtKrw(todayRow?.costKrw ?? 0)} delta={fmtUsd(todayRow?.costUsd ?? 0)} />
+          <StatCard label={t("costMonth")} value={fmtKrw(monthRow?.costKrw ?? 0)} delta={fmtUsd(monthRow?.costUsd ?? 0)} />
+          <StatCard label={t("costTotal")} value={fmtKrw(data.total.costKrw)} delta={fmtUsd(data.total.costUsd)} />
+        </div>
+        {rows.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted">{t("costNoData")}</p>
+        ) : (
+          <div className="max-h-72 overflow-y-auto">
+            <Table>
+              <thead>
+                <tr>
+                  <Th>{t("costColPeriod")}</Th>
+                  <Th>{t("costColTokens")}</Th>
+                  <Th>{t("costColUsd")}</Th>
+                  <Th>{t("costColKrw")}</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r) => (
+                  <tr key={r.period}>
+                    <Td className="font-mono">{r.period}</Td>
+                    <Td>{r.tokens.toLocaleString(locale)}</Td>
+                    <Td>{fmtUsd(r.costUsd)}</Td>
+                    <Td>{fmtKrw(r.costKrw)}</Td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </div>
+        )}
+        <p className="text-[11px] text-faint">
+          {t("costRateNote", {
+            input: data.rates.INPUT_USD_PER_1M,
+            output: data.rates.OUTPUT_USD_PER_1M,
+            ratio: Math.round(data.rates.OUTPUT_RATIO * 100),
+            fx: data.rates.USD_KRW,
+          })}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
 /* ── 시스템 토큰 모니터링 섹션 (관리자 전용) ────────────────── */
 interface MonitoringCosts {
   today: {
@@ -357,6 +479,9 @@ export default function UsagePage() {
                   deltaTone={month?.totalErrors ? "danger" : "success"}
                 />
               </div>
+
+              {/* 가상 비용 환산 (일/월/년) — 상용 API 였다면 얼마 */}
+              <CostEstimateSection />
 
               {/* 일별 사용량 추이 (CSS 바 차트) */}
               <Card>

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1613,7 +1613,21 @@
       "tokens": "Tokens",
       "share": "Share",
       "distribution": "Distribution"
-    }
+    },
+    "costTitle": "Hypothetical Cost",
+    "costSubtitle": "If billed at commercial API rates (not actual charges)",
+    "costToday": "Today",
+    "costMonth": "This month",
+    "costTotal": "All time",
+    "costTabDay": "Daily",
+    "costTabMonth": "Monthly",
+    "costTabYear": "Yearly",
+    "costColPeriod": "Period",
+    "costColTokens": "Tokens",
+    "costColUsd": "USD",
+    "costColKrw": "KRW",
+    "costRateNote": "Assumed rates: input ${input}/1M · output ${output}/1M (output share {ratio}%) · FX ₩{fx}/$ — adjustable via server env",
+    "costNoData": "No usage to aggregate"
   },
   "developer": {
     "pageTitle": "Developer Docs",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1613,7 +1613,21 @@
       "tokens": "トークン",
       "share": "割合",
       "distribution": "分布"
-    }
+    },
+    "costTitle": "仮想コスト換算",
+    "costSubtitle": "商用APIの単価で支払った場合（実際の課金ではありません）",
+    "costToday": "今日",
+    "costMonth": "今月",
+    "costTotal": "累計",
+    "costTabDay": "日別",
+    "costTabMonth": "月別",
+    "costTabYear": "年別",
+    "costColPeriod": "期間",
+    "costColTokens": "トークン",
+    "costColUsd": "USD",
+    "costColKrw": "KRW",
+    "costRateNote": "単価の仮定: 入力 ${input}/1M · 出力 ${output}/1M（出力比率 {ratio}%）· 為替 ₩{fx}/$ — サーバー環境変数で調整可能",
+    "costNoData": "集計する使用量がありません"
   },
   "developer": {
     "pageTitle": "開発者ドキュメント",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1613,7 +1613,21 @@
       "tokens": "토큰",
       "share": "비중",
       "distribution": "분포"
-    }
+    },
+    "costTitle": "가상 비용 환산",
+    "costSubtitle": "상용 API 단가로 지불했다면 (실제 과금 아님)",
+    "costToday": "오늘",
+    "costMonth": "이번 달",
+    "costTotal": "누적 전체",
+    "costTabDay": "일별",
+    "costTabMonth": "월별",
+    "costTabYear": "연도별",
+    "costColPeriod": "기간",
+    "costColTokens": "토큰",
+    "costColUsd": "USD",
+    "costColKrw": "KRW",
+    "costRateNote": "단가 가정: 입력 ${input}/1M · 출력 ${output}/1M (출력 비중 {ratio}%) · 환율 ₩{fx}/$ — 서버 환경변수로 조정 가능",
+    "costNoData": "집계할 사용량이 없습니다"
   },
   "developer": {
     "pageTitle": "개발자 문서",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1613,7 +1613,21 @@
       "tokens": "令牌",
       "share": "占比",
       "distribution": "分布"
-    }
+    },
+    "costTitle": "虚拟成本换算",
+    "costSubtitle": "若按商用API价格付费（非实际收费）",
+    "costToday": "今天",
+    "costMonth": "本月",
+    "costTotal": "累计",
+    "costTabDay": "按日",
+    "costTabMonth": "按月",
+    "costTabYear": "按年",
+    "costColPeriod": "期间",
+    "costColTokens": "令牌",
+    "costColUsd": "USD",
+    "costColKrw": "KRW",
+    "costRateNote": "价格假设：输入 ${input}/1M · 输出 ${output}/1M（输出占比 {ratio}%）· 汇率 ₩{fx}/$ — 可通过服务器环境变量调整",
+    "costNoData": "没有可汇总的使用量"
   },
   "developer": {
     "pageTitle": "开发者文档",


### PR DESCRIPTION
## 개요
"실제로 비용을 지불했다면 얼마인가"를 일/월/년 단위로 보여주는 기능 (실제 과금 아님 — 명시 라벨).

## 구현
- **데이터**: 대화(conversation_messages.tokens) + **에이전트 작업(agent_tasks.total_tokens)** 합산 — 실측상 작업 토큰이 지배적(18.8M vs 0.3M)이라 대화만 집계하면 크게 과소평가됨. (token_daily_stats 는 0행 미적재 확인 → 미사용)
- **백엔드**: `GET /api/usage/cost` — 일(최근 30일)/월(최근 12개월)/년(전체) 버킷 + 총계. 단가는 `REFERENCE_COST`(config/pricing) — 입력 $0.40/출력 $1.20 per 1M(30B급 상용 시세 근사)·출력 비중 25% 가정·환율 ₩1,400, 전부 `TOKEN_COST_*` env 오버라이드
- **프론트**: /usage 에 "가상 비용 환산" 섹션 — 오늘/이번 달/누적 카드(₩·$ 병기) + 일/월/년 탭 표 + 단가 가정 각주. i18n 4언어

## 라이브 검증 (chat.openmake.cc, user 3)
- API: 누적 7,107,509 토큰 ≈ $4.26 / ₩5,970 · 월별 2026-07/08 분리 · 일별 30일
- UI: 섹션 렌더·탭 전환·카드 값 일치 (공유 브라우저 확인)

## 게이트
- [x] tsc(api·web) · lint 0 errors · 영향 테스트(usage/conversation/pricing) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)