### PR TITLE
chore(pricing): 가상 비용 기본 단가를 실제 Qwen 요금표로 정렬 + .env.example 문서화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -353,6 +353,14 @@ NAVER_API_HUB_KEY=your_ncp_apigw_key_here
 # 일일 호출 한도 가드 (기본 25000 = 무료 허용량, 0 = 무제한) — 도달 시 호출 차단(빈 결과 graceful)
 NAVER_API_DAILY_LIMIT=25000
 
+# 가상 비용 환산(usage /cost) 참조 단가 — 실제 과금 아님, "상용 API 였다면" 표시용
+# 기본값은 실제 Qwen 요금표(Alibaba Cloud Model Studio, Qwen3-30B-A3B 급) 기준
+TOKEN_COST_INPUT_USD_PER_1M=0.20
+TOKEN_COST_OUTPUT_USD_PER_1M=0.80
+# 총 토큰 중 출력 비중 가정 (입출력 미구분 데이터 보정)
+TOKEN_COST_OUTPUT_RATIO=0.25
+TOKEN_COST_USD_KRW=1400
+
 # *******************************************************
 # 📊 인프라 및 네트워크 설정
 # *******************************************************

--- a/apps/api/src/config/pricing.ts
+++ b/apps/api/src/config/pricing.ts
@@ -40,14 +40,15 @@ export const MODEL_PRICING: Readonly<Record<string, { input: number; output: num
  * 가상 비용 환산 참조 단가 — "상용 API 로 지불했다면" 얼마인지 보여주는 용도(실제 과금 아님).
  *
  * usage 대시보드의 일/월/년 비용 환산에 사용. 저장된 토큰이 입력/출력 미구분(총합)이라
- * OUTPUT_RATIO 가정으로 혼합 단가를 만든다. 기본값은 동급(30B급 MoE) 상용 API 시세 근사 —
+ * OUTPUT_RATIO 가정으로 혼합 단가를 만든다. 기본값은 실제 Qwen 요금표(Alibaba Cloud
+ * Model Studio, Qwen3-30B-A3B 급 — qwen3.6-35b-a3b 와 동급 A3B MoE) 공시가.
  * 배포별 조정은 env 로 (No-Hardcoding L1).
  */
 export const REFERENCE_COST = {
     /** 입력 토큰 단가 (USD per 1M tokens) */
-    INPUT_USD_PER_1M: parseFloat(process.env.TOKEN_COST_INPUT_USD_PER_1M || '0.40'),
+    INPUT_USD_PER_1M: parseFloat(process.env.TOKEN_COST_INPUT_USD_PER_1M || '0.20'),
     /** 출력 토큰 단가 (USD per 1M tokens) */
-    OUTPUT_USD_PER_1M: parseFloat(process.env.TOKEN_COST_OUTPUT_USD_PER_1M || '1.20'),
+    OUTPUT_USD_PER_1M: parseFloat(process.env.TOKEN_COST_OUTPUT_USD_PER_1M || '0.80'),
     /** 총 토큰 중 출력 비중 가정 (입출력 분리 데이터 부재 보정) */
     OUTPUT_RATIO: parseFloat(process.env.TOKEN_COST_OUTPUT_RATIO || '0.25'),
     /** 원화 환산 환율 */


### PR DESCRIPTION
Alibaba Cloud Model Studio 공시가(Qwen3-30B-A3B 급, qwen3.6-35b-a3b 동급 A3B MoE):
입력 $0.20 / 출력 $0.80 per 1M — 기존 근사치($0.40/$1.20) 대체.
TOKEN_COST_* env 4종 .env.example 등재 (#460 누락분).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
