### PR TITLE
feat(usage): 비용 환산에 집계 시작일(coverage) 명시

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -354,9 +354,9 @@ NAVER_API_HUB_KEY=your_ncp_apigw_key_here
 NAVER_API_DAILY_LIMIT=25000
 
 # 가상 비용 환산(usage /cost) 참조 단가 — 실제 과금 아님, "상용 API 였다면" 표시용
-# 기본값은 실제 Qwen 요금표(Alibaba Cloud Model Studio, Qwen3-30B-A3B 급) 기준
-TOKEN_COST_INPUT_USD_PER_1M=0.20
-TOKEN_COST_OUTPUT_USD_PER_1M=0.80
+# 기본값은 실제 Qwen 요금표(Alibaba Cloud Model Studio, Qwen3.8-Max) 기준
+TOKEN_COST_INPUT_USD_PER_1M=2.00
+TOKEN_COST_OUTPUT_USD_PER_1M=6.00
 # 총 토큰 중 출력 비중 가정 (입출력 미구분 데이터 보정)
 TOKEN_COST_OUTPUT_RATIO=0.25
 TOKEN_COST_USD_KRW=1400

--- a/apps/api/src/config/pricing.ts
+++ b/apps/api/src/config/pricing.ts
@@ -41,14 +41,14 @@ export const MODEL_PRICING: Readonly<Record<string, { input: number; output: num
  *
  * usage 대시보드의 일/월/년 비용 환산에 사용. 저장된 토큰이 입력/출력 미구분(총합)이라
  * OUTPUT_RATIO 가정으로 혼합 단가를 만든다. 기본값은 실제 Qwen 요금표(Alibaba Cloud
- * Model Studio, Qwen3-30B-A3B 급 — qwen3.6-35b-a3b 와 동급 A3B MoE) 공시가.
+ * Model Studio, Qwen3.8-Max 공시가: 입력 $2 / 출력 $6 per 1M) 기준.
  * 배포별 조정은 env 로 (No-Hardcoding L1).
  */
 export const REFERENCE_COST = {
     /** 입력 토큰 단가 (USD per 1M tokens) */
-    INPUT_USD_PER_1M: parseFloat(process.env.TOKEN_COST_INPUT_USD_PER_1M || '0.20'),
+    INPUT_USD_PER_1M: parseFloat(process.env.TOKEN_COST_INPUT_USD_PER_1M || '2.00'),
     /** 출력 토큰 단가 (USD per 1M tokens) */
-    OUTPUT_USD_PER_1M: parseFloat(process.env.TOKEN_COST_OUTPUT_USD_PER_1M || '0.80'),
+    OUTPUT_USD_PER_1M: parseFloat(process.env.TOKEN_COST_OUTPUT_USD_PER_1M || '6.00'),
     /** 총 토큰 중 출력 비중 가정 (입출력 분리 데이터 부재 보정) */
     OUTPUT_RATIO: parseFloat(process.env.TOKEN_COST_OUTPUT_RATIO || '0.25'),
     /** 원화 환산 환율 */

--- a/apps/api/src/data/repositories/conversation-repository.ts
+++ b/apps/api/src/data/repositories/conversation-repository.ts
@@ -161,6 +161,28 @@ export class ConversationRepository extends BaseRepository {
         return result.rows;
     }
 
+    /**
+     * 본인 토큰 기록의 최초 일자 — 비용 환산 화면의 "집계 시작일" 안내용.
+     * (대화 30일 롤링 삭제 + 토큰 영속 도입(2026-07) 이전 기록 부재로, 집계가
+     *  전체 사용 이력이 아님을 사용자에게 명시하기 위함.)
+     */
+    async getUserTokenSince(userId: string): Promise<string | null> {
+        const result = await this.query<{ since: string | null }>(
+            `WITH tok AS (
+                 SELECT m.created_at AS ts
+                 FROM conversation_messages m
+                 JOIN conversation_sessions s ON m.session_id = s.id
+                 WHERE s.user_id = $1 AND m.tokens > 0
+                 UNION ALL
+                 SELECT t.created_at FROM agent_tasks t
+                 WHERE t.user_id = $1 AND t.total_tokens > 0
+             )
+             SELECT to_char(MIN(ts), 'YYYY-MM-DD') AS since FROM tok`,
+            [userId]
+        );
+        return result.rows[0]?.since ?? null;
+    }
+
     /** 본인 일별 토큰/메시지 통계 */
     async getUserDailyUsage(userId: string, days: number): Promise<Array<{ date: string; tokens: string; messages: string }>> {
         const result = await this.query<{ date: string; tokens: string; messages: string }>(

--- a/apps/api/src/routes/usage.routes.ts
+++ b/apps/api/src/routes/usage.routes.ts
@@ -137,10 +137,11 @@ router.get('/cost', asyncHandler(async (req: Request, res: Response) => {
     };
 
     const repo = new ConversationRepository(getPool());
-    const [day, month, year] = await Promise.all([
+    const [day, month, year, since] = await Promise.all([
         repo.getUserTokenBuckets(userId, 'day'),
         repo.getUserTokenBuckets(userId, 'month'),
         repo.getUserTokenBuckets(userId, 'year'),
+        repo.getUserTokenSince(userId),
     ]);
     const yearRows = year.map(toCost);
     const totalTokens = yearRows.reduce((n, x) => n + x.tokens, 0);
@@ -152,6 +153,8 @@ router.get('/cost', asyncHandler(async (req: Request, res: Response) => {
         month: month.map(toCost),
         year: yearRows,
         total: { tokens: totalTokens, costUsd: totalUsd, costKrw: totalUsd * r.USD_KRW },
+        // 집계 시작일 — 토큰 기록이 존재하는 최초 일자(전체 사용 이력 아님을 명시)
+        coverage: { since },
     }));
 }));
 

--- a/apps/web/app/(workspace)/usage/page.tsx
+++ b/apps/web/app/(workspace)/usage/page.tsx
@@ -81,6 +81,8 @@ interface CostEstimate {
   month: CostBucket[];
   year: CostBucket[];
   total: { tokens: number; costUsd: number; costKrw: number };
+  /** 토큰 기록 최초 일자 — 그 이전 사용분은 기록 부재로 미포함 */
+  coverage?: { since: string | null };
 }
 type CostGranularity = "day" | "month" | "year";
 
@@ -178,6 +180,12 @@ function CostEstimateSection() {
           </div>
         )}
         <p className="text-[11px] text-faint">
+          {data.coverage?.since && (
+            <>
+              {t("costCoverage", { since: data.coverage.since })}
+              <br />
+            </>
+          )}
           {t("costRateNote", {
             input: data.rates.INPUT_USD_PER_1M,
             output: data.rates.OUTPUT_USD_PER_1M,

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1627,7 +1627,8 @@
     "costColUsd": "USD",
     "costColKrw": "KRW",
     "costRateNote": "Assumed rates: input ${input}/1M · output ${output}/1M (output share {ratio}%) · FX ₩{fx}/$ — adjustable via server env",
-    "costNoData": "No usage to aggregate"
+    "costNoData": "No usage to aggregate",
+    "costCoverage": "Coverage: records since {since} (earlier usage not included — no token records)"
   },
   "developer": {
     "pageTitle": "Developer Docs",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1627,7 +1627,8 @@
     "costColUsd": "USD",
     "costColKrw": "KRW",
     "costRateNote": "単価の仮定: 入力 ${input}/1M · 出力 ${output}/1M（出力比率 {ratio}%）· 為替 ₩{fx}/$ — サーバー環境変数で調整可能",
-    "costNoData": "集計する使用量がありません"
+    "costNoData": "集計する使用量がありません",
+    "costCoverage": "集計範囲: {since} 以降の記録（それ以前はトークン記録がなく未含）"
   },
   "developer": {
     "pageTitle": "開発者ドキュメント",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1627,7 +1627,8 @@
     "costColUsd": "USD",
     "costColKrw": "KRW",
     "costRateNote": "단가 가정: 입력 ${input}/1M · 출력 ${output}/1M (출력 비중 {ratio}%) · 환율 ₩{fx}/$ — 서버 환경변수로 조정 가능",
-    "costNoData": "집계할 사용량이 없습니다"
+    "costNoData": "집계할 사용량이 없습니다",
+    "costCoverage": "집계 범위: {since} 이후 기록 기준 (그 이전 사용분은 토큰 기록 부재로 미포함)"
   },
   "developer": {
     "pageTitle": "개발자 문서",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1627,7 +1627,8 @@
     "costColUsd": "USD",
     "costColKrw": "KRW",
     "costRateNote": "价格假设：输入 ${input}/1M · 输出 ${output}/1M（输出占比 {ratio}%）· 汇率 ₩{fx}/$ — 可通过服务器环境变量调整",
-    "costNoData": "没有可汇总的使用量"
+    "costNoData": "没有可汇总的使用量",
+    "costCoverage": "统计范围：{since} 之后的记录（此前用量无令牌记录，未包含）"
   },
   "developer": {
     "pageTitle": "开发者文档",


### PR DESCRIPTION
토큰 기록이 2026-07 이후에만 존재(대화 30일 롤링 삭제 + 토큰 영속 도입 시점)하므로,
/cost 응답에 coverage.since(최초 기록일)를 추가하고 화면 각주에
"집계 범위: {since} 이후 기록 기준" 을 표시 — 전체 사용 이력으로 오인 방지.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
