### PR TITLE
feat(model-roles): 배정 변경 감사 로그 추가 (previous 포함)

### DIFF
--- a/apps/api/src/controllers/user-model-roles.controller.ts
+++ b/apps/api/src/controllers/user-model-roles.controller.ts
@@ -25,6 +25,7 @@ import { getPool } from '../data/models/unified-database';
 import { UserModelRolesRepository } from '../data/repositories/user-model-roles-repo';
 import { ModelRole, USER_ASSIGNABLE_MODEL_ROLES } from '../config/model-roles';
 import { validateModelAssignment } from '../services/model-assignment-validation';
+import { getAuditService } from '../services/AuditService';
 import { createLogger } from '../utils/logger';
 import { success, internalError, unauthorized, badRequest, notFound } from '../utils/api-response';
 
@@ -49,6 +50,20 @@ function parseAssignableRole(value: string): ModelRole | null {
     return (USER_ASSIGNABLE_MODEL_ROLES as readonly string[]).includes(value)
         ? (value as ModelRole)
         : null;
+}
+
+/**
+ * 배정 변경 감사 기록 — 2026-08-08 배정 전체 소실(0행) 사건에서 변경 이력이 없어
+ * 원인 추적이 불가했던 갭 해소. previous 를 함께 남겨 소실 시 복원 근거로 쓴다.
+ * (admin-model-roles.routes 의 auditChange 와 동일 관용구 — 실패는 응답에 영향 없음)
+ */
+function auditChange(userId: string, action: string, details: Record<string, unknown>): void {
+    void getAuditService().logAudit({
+        action,
+        userId,
+        resourceType: 'model_role',
+        details,
+    }).catch(() => { /* audit 실패는 응답에 영향 없음 */ });
 }
 
 export function createUserModelRolesController(): Router {
@@ -91,8 +106,10 @@ export function createUserModelRolesController(): Router {
             }
 
             const repo = new UserModelRolesRepository(getPool());
+            const previous = (await repo.listByUser(userId)).find((m) => m.role === role)?.fullModelId ?? null;
             const mapping = await repo.upsert(userId, role, fullId);
             log.info(`역할 매핑 저장: userId=${userId} role=${role} model=${fullId}`);
+            auditChange(userId, 'user_model_role_set', { role, model: fullId, previous });
             res.json(success({ mapping }));
         } catch (err) {
             log.error('upsert 실패:', err);
@@ -110,9 +127,11 @@ export function createUserModelRolesController(): Router {
         }
         try {
             const repo = new UserModelRolesRepository(getPool());
+            const previous = (await repo.listByUser(userId)).find((m) => m.role === role)?.fullModelId ?? null;
             const deleted = await repo.delete(userId, role);
             if (!deleted) { res.status(404).json(notFound('매핑 없음')); return; }
             log.info(`역할 매핑 해제: userId=${userId} role=${role}`);
+            auditChange(userId, 'user_model_role_unset', { role, previous });
             res.json(success({ deleted: true }));
         } catch (err) {
             log.error('delete 실패:', err);

--- a/apps/api/src/routes/admin-model-roles.routes.ts
+++ b/apps/api/src/routes/admin-model-roles.routes.ts
@@ -110,9 +110,11 @@ adminModelRolesRouter.put('/model-roles/:role', validate(putRoleSchema), asyncHa
     }
 
     const repo = new GlobalModelRolesRepository(getPool());
+    // previous 기록 — 2026-08-08 배정 전체 소실 사건의 추적 갭 해소(소실 시 복원 근거)
+    const previous = (await repo.list()).find((m) => m.role === role)?.fullModelId ?? null;
     const mapping = await repo.upsert(role, fullId);
     clearGlobalRolesCache();
-    auditChange(req, 'admin_global_model_role_set', { role, model: fullId });
+    auditChange(req, 'admin_global_model_role_set', { role, model: fullId, previous });
     logger.info(`전역 역할 매핑 저장: role=${role} model=${fullId}`);
     res.json(success({ mapping }));
 }));
@@ -124,13 +126,14 @@ adminModelRolesRouter.delete('/model-roles/:role', asyncHandler(async (req: Requ
         return;
     }
     const repo = new GlobalModelRolesRepository(getPool());
+    const previous = (await repo.list()).find((m) => m.role === role)?.fullModelId ?? null;
     const deleted = await repo.delete(role);
     if (!deleted) {
         res.status(404).json(notFound('매핑 없음'));
         return;
     }
     clearGlobalRolesCache();
-    auditChange(req, 'admin_global_model_role_unset', { role });
+    auditChange(req, 'admin_global_model_role_unset', { role, previous });
     res.json(success({ deleted: true }));
 }));
 


### PR DESCRIPTION
2026-08-08 역할 배정 전체 소실(user·global 0행) 사건에서 변경 이력이 없어 원인
추적이 불가했던 갭 해소:
- user PUT/DELETE(user_model_role_set/unset) 에 logAudit 신설 — 기존엔 무기록
- admin set/unset 감사에 previous(이전 배정값) 동봉 — 소실 시 복원 근거
라이브 검증: PUT 후 audit_logs 에 role/model/previous 기록 확인.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
