### PR TITLE
fix: 모델 역할 배정 감사 원자성 + HTML HSTS/X-Powered-By 하드닝

### DIFF
--- a/apps/api/src/controllers/user-model-roles.controller.ts
+++ b/apps/api/src/controllers/user-model-roles.controller.ts
@@ -57,13 +57,19 @@ function parseAssignableRole(value: string): ModelRole | null {
  * 원인 추적이 불가했던 갭 해소. previous 를 함께 남겨 소실 시 복원 근거로 쓴다.
  * (admin-model-roles.routes 의 auditChange 와 동일 관용구 — 실패는 응답에 영향 없음)
  */
-function auditChange(userId: string, action: string, details: Record<string, unknown>): void {
-    void getAuditService().logAudit({
-        action,
-        userId,
-        resourceType: 'model_role',
-        details,
-    }).catch(() => { /* audit 실패는 응답에 영향 없음 */ });
+async function auditChange(userId: string, action: string, details: Record<string, unknown>): Promise<void> {
+    try {
+        await getAuditService().logAudit({
+            action,
+            userId,
+            resourceType: 'model_role',
+            details,
+        });
+    } catch (err) {
+        // 감사 실패가 배정 자체를 되돌리진 않지만, 조용히 삼키지 않고 details(previous 포함)와
+        // 함께 남겨 '배정은 됐는데 기록은 없는' 추적 갭에서 최소한 애플리케이션 로그로 복원 가능하게 한다.
+        log.error('배정 감사 기록 실패 (배정은 반영됨):', { action, details, err });
+    }
 }
 
 export function createUserModelRolesController(): Router {
@@ -106,10 +112,9 @@ export function createUserModelRolesController(): Router {
             }
 
             const repo = new UserModelRolesRepository(getPool());
-            const previous = (await repo.listByUser(userId)).find((m) => m.role === role)?.fullModelId ?? null;
-            const mapping = await repo.upsert(userId, role, fullId);
+            const { mapping, previous } = await repo.upsert(userId, role, fullId);
             log.info(`역할 매핑 저장: userId=${userId} role=${role} model=${fullId}`);
-            auditChange(userId, 'user_model_role_set', { role, model: fullId, previous });
+            await auditChange(userId, 'user_model_role_set', { role, model: fullId, previous });
             res.json(success({ mapping }));
         } catch (err) {
             log.error('upsert 실패:', err);
@@ -127,11 +132,10 @@ export function createUserModelRolesController(): Router {
         }
         try {
             const repo = new UserModelRolesRepository(getPool());
-            const previous = (await repo.listByUser(userId)).find((m) => m.role === role)?.fullModelId ?? null;
-            const deleted = await repo.delete(userId, role);
+            const { deleted, previous } = await repo.delete(userId, role);
             if (!deleted) { res.status(404).json(notFound('매핑 없음')); return; }
             log.info(`역할 매핑 해제: userId=${userId} role=${role}`);
-            auditChange(userId, 'user_model_role_unset', { role, previous });
+            await auditChange(userId, 'user_model_role_unset', { role, previous });
             res.json(success({ deleted: true }));
         } catch (err) {
             log.error('delete 실패:', err);

--- a/apps/api/src/data/repositories/global-model-roles-repo.ts
+++ b/apps/api/src/data/repositories/global-model-roles-repo.ts
@@ -31,21 +31,53 @@ export class GlobalModelRolesRepository extends BaseRepository {
         return result.rows.map(toRow);
     }
 
-    async upsert(role: ModelRole, fullModelId: string): Promise<GlobalModelRoleRow> {
-        const result = await this.query<DbRow>(
-            `INSERT INTO global_model_roles (role, full_model_id)
-             VALUES ($1, $2)
-             ON CONFLICT (role) DO UPDATE SET
-                full_model_id = EXCLUDED.full_model_id,
-                updated_at = now()
-             RETURNING *`,
-            [role, fullModelId],
-        );
-        return toRow(result.rows[0]);
+    /**
+     * 배정/변경 — 직전 값(previous)을 같은 트랜잭션에서 원자적으로 캡처해 함께 반환한다.
+     * previous 는 쓰기의 부산물이라 별도 선-조회가 없다 → 감사용 조회 실패가 배정 자체를
+     * 막던 회귀를 제거한다. per-role advisory lock 으로 같은 role 동시 변경을 직렬화해
+     * previous 가 실제 직전값과 일치하도록 보장한다(소실 사건의 복원 근거 정확성).
+     */
+    async upsert(
+        role: ModelRole,
+        fullModelId: string,
+    ): Promise<{ mapping: GlobalModelRoleRow; previous: string | null }> {
+        const client = await this.pool.connect();
+        try {
+            await client.query('BEGIN');
+            await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`gmr:${role}`]);
+            const prev = await client.query<DbRow>(
+                `SELECT full_model_id FROM global_model_roles WHERE role = $1`,
+                [role],
+            );
+            const previous = prev.rows[0]?.full_model_id ?? null;
+            const upserted = await client.query<DbRow>(
+                `INSERT INTO global_model_roles (role, full_model_id)
+                 VALUES ($1, $2)
+                 ON CONFLICT (role) DO UPDATE SET
+                    full_model_id = EXCLUDED.full_model_id,
+                    updated_at = now()
+                 RETURNING *`,
+                [role, fullModelId],
+            );
+            await client.query('COMMIT');
+            return { mapping: toRow(upserted.rows[0]), previous };
+        } catch (err) {
+            try { await client.query('ROLLBACK'); } catch { /* rollback best-effort */ }
+            throw err;
+        } finally {
+            client.release();
+        }
     }
 
-    async delete(role: ModelRole): Promise<boolean> {
-        const result = await this.query(`DELETE FROM global_model_roles WHERE role = $1`, [role]);
-        return (result.rowCount ?? 0) > 0;
+    /**
+     * 매핑 해제 — 삭제된 직전 값(previous)을 RETURNING 으로 원자적으로 함께 반환한다.
+     * 반환값이 곧 삭제 대상이라 별도 선-조회 없이 감사 previous 를 정확히 남긴다.
+     */
+    async delete(role: ModelRole): Promise<{ deleted: boolean; previous: string | null }> {
+        const result = await this.query<{ full_model_id: string }>(
+            `DELETE FROM global_model_roles WHERE role = $1 RETURNING full_model_id`,
+            [role],
+        );
+        return { deleted: (result.rowCount ?? 0) > 0, previous: result.rows[0]?.full_model_id ?? null };
     }
 }

--- a/apps/api/src/data/repositories/user-model-roles-repo.ts
+++ b/apps/api/src/data/repositories/user-model-roles-repo.ts
@@ -53,25 +53,54 @@ export class UserModelRolesRepository extends BaseRepository {
         return result.rows.map(toRow);
     }
 
-    async upsert(userId: string, role: ModelRole, fullModelId: string): Promise<UserModelRoleRow> {
-        const result = await this.query<DbRow>(
-            `INSERT INTO user_model_roles (user_id, role, full_model_id)
-             VALUES ($1, $2, $3)
-             ON CONFLICT (user_id, role) DO UPDATE SET
-                full_model_id = EXCLUDED.full_model_id,
-                updated_at = now()
-             RETURNING *`,
-            [userId, role, fullModelId],
-        );
-        return toRow(result.rows[0]);
+    /**
+     * 배정/변경 — 직전 값(previous)을 같은 트랜잭션에서 원자적으로 캡처해 함께 반환한다.
+     * previous 는 쓰기의 부산물이라 별도 선-조회가 없다 → 감사용 조회 실패가 배정 자체를
+     * 막던 회귀를 제거한다. per-key advisory lock 으로 같은 (user,role) 동시 변경을 직렬화해
+     * previous 가 실제 직전값과 일치하도록 보장한다(2026-08-08 소실 사건의 복원 근거 정확성).
+     */
+    async upsert(
+        userId: string,
+        role: ModelRole,
+        fullModelId: string,
+    ): Promise<{ mapping: UserModelRoleRow; previous: string | null }> {
+        const client = await this.pool.connect();
+        try {
+            await client.query('BEGIN');
+            await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`umr:${userId}:${role}`]);
+            const prev = await client.query<DbRow>(
+                `SELECT full_model_id FROM user_model_roles WHERE user_id = $1 AND role = $2`,
+                [userId, role],
+            );
+            const previous = prev.rows[0]?.full_model_id ?? null;
+            const upserted = await client.query<DbRow>(
+                `INSERT INTO user_model_roles (user_id, role, full_model_id)
+                 VALUES ($1, $2, $3)
+                 ON CONFLICT (user_id, role) DO UPDATE SET
+                    full_model_id = EXCLUDED.full_model_id,
+                    updated_at = now()
+                 RETURNING *`,
+                [userId, role, fullModelId],
+            );
+            await client.query('COMMIT');
+            return { mapping: toRow(upserted.rows[0]), previous };
+        } catch (err) {
+            try { await client.query('ROLLBACK'); } catch { /* rollback best-effort */ }
+            throw err;
+        } finally {
+            client.release();
+        }
     }
 
-    /** 매핑 해제 — 삭제 성공 여부 반환 */
-    async delete(userId: string, role: ModelRole): Promise<boolean> {
-        const result = await this.query(
-            `DELETE FROM user_model_roles WHERE user_id = $1 AND role = $2`,
+    /**
+     * 매핑 해제 — 삭제된 직전 값(previous)을 RETURNING 으로 원자적으로 함께 반환한다.
+     * 반환값이 곧 삭제 대상이라 별도 선-조회 없이 감사 previous 를 정확히 남긴다.
+     */
+    async delete(userId: string, role: ModelRole): Promise<{ deleted: boolean; previous: string | null }> {
+        const result = await this.query<{ full_model_id: string }>(
+            `DELETE FROM user_model_roles WHERE user_id = $1 AND role = $2 RETURNING full_model_id`,
             [userId, role],
         );
-        return (result.rowCount ?? 0) > 0;
+        return { deleted: (result.rowCount ?? 0) > 0, previous: result.rows[0]?.full_model_id ?? null };
     }
 }

--- a/apps/api/src/routes/admin-model-roles.routes.ts
+++ b/apps/api/src/routes/admin-model-roles.routes.ts
@@ -59,13 +59,19 @@ function adminUserId(req: Request): string | undefined {
     return req.user?.id !== undefined ? String(req.user.id) : undefined;
 }
 
-function auditChange(req: Request, action: string, details: Record<string, unknown>): void {
-    void getAuditService().logAudit({
-        action,
-        userId: adminUserId(req),
-        resourceType: 'model_role',
-        details,
-    }).catch(() => { /* audit 실패는 응답에 영향 없음 */ });
+async function auditChange(req: Request, action: string, details: Record<string, unknown>): Promise<void> {
+    try {
+        await getAuditService().logAudit({
+            action,
+            userId: adminUserId(req),
+            resourceType: 'model_role',
+            details,
+        });
+    } catch (err) {
+        // 감사 실패가 배정 자체를 되돌리진 않지만, 조용히 삼키지 않고 details(previous 포함)와
+        // 함께 남겨 '배정은 됐는데 기록은 없는' 추적 갭에서 최소한 애플리케이션 로그로 복원 가능하게 한다.
+        logger.error('모델 역할 감사 기록 실패 (변경은 반영됨):', { action, details, err });
+    }
 }
 
 export const adminModelRolesRouter = Router();
@@ -110,11 +116,10 @@ adminModelRolesRouter.put('/model-roles/:role', validate(putRoleSchema), asyncHa
     }
 
     const repo = new GlobalModelRolesRepository(getPool());
-    // previous 기록 — 2026-08-08 배정 전체 소실 사건의 추적 갭 해소(소실 시 복원 근거)
-    const previous = (await repo.list()).find((m) => m.role === role)?.fullModelId ?? null;
-    const mapping = await repo.upsert(role, fullId);
+    // previous 는 upsert 트랜잭션에서 원자적으로 캡처된다 — 2026-08-08 배정 소실 사건의 복원 근거.
+    const { mapping, previous } = await repo.upsert(role, fullId);
     clearGlobalRolesCache();
-    auditChange(req, 'admin_global_model_role_set', { role, model: fullId, previous });
+    await auditChange(req, 'admin_global_model_role_set', { role, model: fullId, previous });
     logger.info(`전역 역할 매핑 저장: role=${role} model=${fullId}`);
     res.json(success({ mapping }));
 }));
@@ -126,14 +131,13 @@ adminModelRolesRouter.delete('/model-roles/:role', asyncHandler(async (req: Requ
         return;
     }
     const repo = new GlobalModelRolesRepository(getPool());
-    const previous = (await repo.list()).find((m) => m.role === role)?.fullModelId ?? null;
-    const deleted = await repo.delete(role);
+    const { deleted, previous } = await repo.delete(role);
     if (!deleted) {
         res.status(404).json(notFound('매핑 없음'));
         return;
     }
     clearGlobalRolesCache();
-    auditChange(req, 'admin_global_model_role_unset', { role, previous });
+    await auditChange(req, 'admin_global_model_role_unset', { role, previous });
     res.json(success({ deleted: true }));
 }));
 
@@ -167,7 +171,7 @@ adminModelRolesRouter.put('/server-external-keys/:providerId', validate(putServe
         dailyTokenLimit: body.dailyTokenLimit,
         monthlyTokenLimit: body.monthlyTokenLimit ?? null,
     });
-    auditChange(req, 'admin_server_external_key_set', {
+    await auditChange(req, 'admin_server_external_key_set', {
         providerId, dailyTokenLimit: body.dailyTokenLimit, monthlyTokenLimit: body.monthlyTokenLimit ?? null,
     });
     logger.info(`서버 공용 키 등록: provider=${providerId} daily=${body.dailyTokenLimit}`);
@@ -181,6 +185,6 @@ adminModelRolesRouter.delete('/server-external-keys/:providerId', asyncHandler(a
         res.status(404).json(notFound('서버 키 없음'));
         return;
     }
-    auditChange(req, 'admin_server_external_key_delete', { providerId: req.params.providerId });
+    await auditChange(req, 'admin_server_external_key_delete', { providerId: req.params.providerId });
     res.json(success({ deleted: true }));
 }));

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -20,6 +20,9 @@ const nextConfig: NextConfig = {
     "@openmake/api-client",
     "@openmake/config",
   ],
+  // 기술 스택 식별 헤더(X-Powered-By: Next.js) 제거 — 백엔드 helmet 은 이미 숨기지만
+  // Next 가 서빙하는 HTML 응답엔 기본 노출된다(정보 노출, CWE-200).
+  poweredByHeader: false,
   // Next 16 dev: 외부 origin(rasplay) 에서 /_next/* (HMR 등) 접근을 기본 차단 → HMR WS 실패로
   // 클라이언트 hydration 이 죽어 게스트로 표시됨. 외부 공개 dev 접속을 허용한다.
   // (운영은 next build + next start 권장 — production 은 HMR 자체가 없어 이 문제 무관.)
@@ -45,6 +48,12 @@ const nextConfig: NextConfig = {
           { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
           { key: "Content-Security-Policy", value: "frame-ancestors 'self'" },
+          // HSTS — Next 가 서빙하는 HTML 경로엔 백엔드 helmet 의 HSTS 가 닿지 않아 누락됐다.
+          // 백엔드 HSTS_POLICY(2년·includeSubDomains, preload 미포함=롤백 여지)와 값을 맞춘다.
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains",
+          },
         ],
       },
     ];


### PR DESCRIPTION
## 배경
코드 리뷰(high, 워크플로우 2회)와 외부 보안 진단 보고서(chat.openmake.cc) 검토에서 확인된 결함을 수정합니다.

## 변경 1 — 모델 역할 배정 감사 원자성 (코드 리뷰 findings 4건)
`2026-08-08 배정 소실 사건`의 복원 근거로 추가된 `previous` 기록 경로에서 검증된 결함:

- **fail-open 회귀 (CONFIRMED)**: `previous` 를 얻으려던 별도 `listByUser()`/`list()` 선조회가 `try` 안에서 throw 를 전파 → DB 일시 오류 시 원래 성공했을 배정이 500 으로 실패. `previous` 를 쓰기의 부산물로 만들어 독립 실패 경로 제거.
- **비원자성 race (PLAUSIBLE)**: 조회↔upsert 분리로 동시 변경 시 audit `previous` 오기록. `upsert` 를 `BEGIN + pg_advisory_xact_lock(per-key) + SELECT + ON CONFLICT` 단일 트랜잭션으로 직렬화, `delete` 는 `DELETE ... RETURNING`.
- **fire-and-forget 감사 (PLAUSIBLE)**: `auditChange` async 전환 + 전 호출 `await` 로 응답 전 커밋 보장. 내부 try/catch 로 배정은 죽이지 않되 실패를 `details`(previous 포함)와 함께 `log.error`.
- **정리 (CONFIRMED)**: `listByUser().find()` 재구현 제거 — 단일 인덱스 조회로만. `getRoleModel` 은 resolver 가 계속 사용.

> `FOR UPDATE` 를 CTE 에 넣는 방식은 같은 문의 INSERT 와 충돌해 `previous` 가 null 로 비어 나옴을 실측 확인 → advisory-lock 트랜잭션으로 확정.

**대상**: `user-model-roles.controller.ts`, `admin-model-roles.routes.ts`, `user-model-roles-repo.ts`, `global-model-roles-repo.ts`

## 변경 2 — HTML 보안 헤더 (보안 진단 Medium/Info)
Next 서빙 HTML 경로에 백엔드 helmet 의 HSTS 가 닿지 않고 `X-Powered-By: Next.js` 가 노출되던 문제.
- `Strict-Transport-Security: max-age=63072000; includeSubDomains` (백엔드 `HSTS_POLICY` 정합)
- `poweredByHeader: false`

## 검증
- 핵심 SQL 관용구를 실제 DB 임시 테이블로 검증 (신규=null·갱신=직전값·삭제=직전값)
- `tsc --noEmit` 통과, 변경 파일 ESLint clean, resolver 유닛 18/18 통과
- 배포 후 라이브(chat.openmake.cc): HTML `/`·`/login` 에 HSTS 적용·X-Powered-By 제거 확인, model-roles API 401 정상 배선
- 응답 형태(`{mapping}`/`{deleted}`) 불변 → 프론트 영향 0

## 범위 밖 (별도 조치 필요)
- DNS: SPF/DMARC/CAA/DNSSEC (Cloudflare 대시보드 — 이 레포/머신에서 미적용)
- 강제 CSP(default-src/script-src): Next nonce 배선 + 아티팩트 iframe CSP 상속 블로커로 별도 작업

🤖 Generated with [Claude Code](https://claude.com/claude-code)