### PR TITLE
fix(chat): 게스트 히스토리 즉시 반영 + 관리자 전체 대화 서버 페이지네이션

### DIFF
--- a/apps/api/src/controllers/session.controller.ts
+++ b/apps/api/src/controllers/session.controller.ts
@@ -105,6 +105,8 @@ export class SessionController {
              const user = req.user;
              const anonSessionId = req.query.anonSessionId as string;
              const limit = parseInt(req.query.limit as string) || 50;
+             // offset 은 관리자 전체 조회(scope 'all') 페이지네이션 전용 — 음수/비정상 입력은 0
+             const offset = Math.max(0, parseInt(req.query.offset as string) || 0);
              const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
 
              const userIdStr = user?.id ? String(user.id) : undefined;
@@ -117,6 +119,8 @@ export class SessionController {
 
              let sessions: ConversationSession[];
              let snippets: Record<string, string> = {};
+             // 관리자 전체 조회의 총 건수 — 페이지네이션 UI 용 (다른 scope 는 undefined 유지, 하위 호환)
+             let total: number | undefined;
              if (q && (scope === 'user' || scope === 'anon')) {
                  const hit = await conversationDb.searchSessionsByOwner(
                      scope === 'user' ? { userId: userIdStr } : { anonSessionId },
@@ -126,9 +130,12 @@ export class SessionController {
                  snippets = hit.snippets;
                  log.info(`[Chat Sessions] 검색(${scope}) "${q.slice(0, 40)}": ${sessions.length}개`);
              } else if (scope === 'all') {
-                 // 🔑 관리자 전용 화면(/admin/conversations)의 명시적 전체 조회
-                 sessions = await conversationDb.getAllSessions(limit);
-                 log.info(`[Chat Sessions] 관리자 전체 조회: ${sessions.length}개`);
+                 // 🔑 관리자 전용 화면(/admin/conversations)의 명시적 전체 조회 — offset 페이지네이션
+                 [sessions, total] = await Promise.all([
+                     conversationDb.getAllSessions(limit, offset),
+                     conversationDb.countAllSessions(),
+                 ]);
+                 log.info(`[Chat Sessions] 관리자 전체 조회: ${sessions.length}개 (offset=${offset}, total=${total})`);
              } else if (scope === 'user') {
                  // 🔐 로그인 사용자: 자신의 대화만 (관리자도 개인 화면에선 동일)
                  sessions = await conversationDb.getSessionsByUserId(userIdStr!, limit);
@@ -159,7 +166,8 @@ export class SessionController {
                  ...(snippets[s.id] ? { snippet: snippets[s.id] } : {}),
              }));
 
-             res.json(success({ sessions: formattedSessions }));
+             // total 은 관리자 전체 조회(scope 'all')에만 실림 — 기존 소비처(사이드바/히스토리) 무영향
+             res.json(success({ sessions: formattedSessions, ...(total !== undefined ? { total } : {}) }));
          }));
 
          // 🆕 익명 세션 이관: 로그인 후 기존 익명 대화를 사용자에게 귀속

--- a/apps/api/src/data/conversation-db.ts
+++ b/apps/api/src/data/conversation-db.ts
@@ -66,6 +66,7 @@ class ConversationDB {
     getSessionsByUserId = sessions.getSessionsByUserId;
     getSessionsByAnonId = sessions.getSessionsByAnonId;
     getAllSessions = sessions.getAllSessions;
+    countAllSessions = sessions.countAllSessions;
     searchSessionsByOwner = sessions.searchSessionsByOwner;
     getSessions = sessions.getSessions;
     getUserSessions = sessions.getUserSessions;

--- a/apps/api/src/data/conversation-sessions.ts
+++ b/apps/api/src/data/conversation-sessions.ts
@@ -245,20 +245,36 @@ function excerptAround(content: string, query: string, radius: number = CONVERSA
 }
 
 /**
- * 전체 세션 목록 조회
+ * 전체 세션 목록 조회 (관리자 전용 화면 — offset 페이지네이션 지원)
  */
-export async function getAllSessions(limit: number = CONVERSATION_LIMITS.SESSION_LIST_ALL_DEFAULT): Promise<ConversationSession[]> {
+export async function getAllSessions(
+    limit: number = CONVERSATION_LIMITS.SESSION_LIST_ALL_DEFAULT,
+    offset: number = 0,
+): Promise<ConversationSession[]> {
     const pool = getPool();
     const result = await pool.query(
         `SELECT * FROM conversation_sessions cs
          WHERE EXISTS (SELECT 1 FROM conversation_messages m WHERE m.session_id = cs.id)
-         ORDER BY cs.updated_at DESC LIMIT $1`,
-        [limit]
+         ORDER BY cs.updated_at DESC LIMIT $1 OFFSET $2`,
+        [limit, offset]
     );
 
     // list view: 세션당 최근 50개만 — 5K+ 메시지 사용자의 메모리 spike 방지.
     // single-session detail 은 getSession() 의 LIMIT 500 으로 별도 로드.
     return loadMessagesForSessions(result.rows as SessionRow[], { maxMessagesPerSession: CONVERSATION_LIMITS.LIST_MESSAGES_PER_SESSION });
+}
+
+/**
+ * 전체 세션 총 건수 — getAllSessions 와 동일 필터(메시지 있는 세션만).
+ * 관리자 화면 페이지네이션의 전체 페이지 수 계산에 사용.
+ */
+export async function countAllSessions(): Promise<number> {
+    const pool = getPool();
+    const result = await pool.query<{ count: string }>(
+        `SELECT COUNT(*) AS count FROM conversation_sessions cs
+         WHERE EXISTS (SELECT 1 FROM conversation_messages m WHERE m.session_id = cs.id)`
+    );
+    return parseInt(result.rows[0]?.count ?? '0', 10);
 }
 
 /**

--- a/apps/web/app/(workspace)/admin/conversations/page.tsx
+++ b/apps/web/app/(workspace)/admin/conversations/page.tsx
@@ -34,7 +34,11 @@ interface ApiConversation {
   metadata?: { source?: string } | null;
 }
 
-type ConversationsResponse = ApiSuccess<{ sessions: ApiConversation[] }>;
+/** total 은 viewAll(관리자 전체 조회) 응답에만 실린다 — 페이지네이션 계산용 */
+type ConversationsResponse = ApiSuccess<{ sessions: ApiConversation[]; total?: number }>;
+
+/** 대화 목록 페이지 크기 — 서버 offset 페이지네이션과 쌍 */
+const CONV_PAGE_SIZE = 50;
 
 /* GET /api/agent-tasks?viewAll=true → res.data.tasks (toPublicTask, snake_case). */
 interface ApiAgentTask {
@@ -121,10 +125,15 @@ export default function AdminConversationsPage() {
   const [tab, setTab] = useState<TabKey>("conversations");
 
   const [sessions, setSessions] = useState<ApiConversation[]>([]);
+  // 대화 탭 페이지네이션 — 0-base 페이지 번호 + 서버가 준 총 건수
+  const [convPage, setConvPage] = useState(0);
+  const [convTotal, setConvTotal] = useState(0);
   const [tasks, setTasks] = useState<ApiAgentTask[]>([]);
   const [research, setResearch] = useState<ApiResearchSession[]>([]);
   const [userMap, setUserMap] = useState<Record<string, AdminUserLite>>({});
   const [loading, setLoading] = useState(true);
+  // 작업·리서치 탭 로딩 — 대화 탭(loading, 페이지네이션 재조회)과 분리
+  const [sideLoading, setSideLoading] = useState(true);
   const [query, setQuery] = useState("");
 
   // 상세 모달 — 대화(메시지 전문) / 리서치(스텝 전문)
@@ -136,18 +145,15 @@ export default function AdminConversationsPage() {
   useEffect(() => {
     let alive = true;
     (async () => {
-      // 세 목록(admin 옵트인)과 사용자 목록(이메일 매핑용)을 병렬 조회.
+      // 작업·리서치 목록(admin 옵트인)과 사용자 목록(이메일 매핑용)을 병렬 조회.
       // 사용자 목록 실패는 허용 — 그 경우 원 userId 로 표시.
-      const [convRes, taskRes, researchRes, usersRes] = await Promise.allSettled([
-        ApiClient.get<ConversationsResponse>("/api/chat/conversations?viewAll=true&limit=200"),
+      // (대화 목록은 페이지네이션 때문에 아래 convPage 효과에서 별도 조회)
+      const [taskRes, researchRes, usersRes] = await Promise.allSettled([
         ApiClient.get<AgentTasksResponse>("/api/agent-tasks?viewAll=true"),
         ApiClient.get<ResearchListResponse>("/api/research/sessions?viewAll=true"),
         ApiClient.get<ApiSuccess<{ users?: AdminUserLite[] }>>("/api/admin/users?limit=500"),
       ]);
       if (!alive) return;
-      if (convRes.status === "fulfilled") {
-        setSessions(convRes.value?.data?.sessions ?? []);
-      }
       if (taskRes.status === "fulfilled") {
         setTasks(taskRes.value?.data?.tasks ?? []);
       }
@@ -158,12 +164,36 @@ export default function AdminConversationsPage() {
         const users = usersRes.value?.data?.users ?? [];
         setUserMap(Object.fromEntries(users.map((u) => [String(u.id), u])));
       }
-      setLoading(false);
+      setSideLoading(false);
     })();
     return () => {
       alive = false;
     };
   }, []);
+
+  // 대화 목록 — 서버 offset 페이지네이션 (페이지 이동 시 재조회)
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    (async () => {
+      try {
+        const res = await ApiClient.get<ConversationsResponse>(
+          `/api/chat/conversations?viewAll=true&limit=${CONV_PAGE_SIZE}&offset=${convPage * CONV_PAGE_SIZE}`,
+        );
+        if (!alive) return;
+        setSessions(res?.data?.sessions ?? []);
+        setConvTotal(res?.data?.total ?? 0);
+      } catch {
+        if (!alive) return;
+        setSessions([]);
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [convPage]);
 
   const ownerLabelById = (userId: string | null | undefined): string => {
     if (userId) {
@@ -347,6 +377,36 @@ export default function AdminConversationsPage() {
               </Table>
             )}
 
+            {tab === "conversations" && convTotal > CONV_PAGE_SIZE && (
+              <div className="flex items-center justify-between border-t border-border px-4 py-3 text-sm text-muted">
+                <span>
+                  {t("pagination.info", {
+                    page: convPage + 1,
+                    pages: Math.max(1, Math.ceil(convTotal / CONV_PAGE_SIZE)),
+                    total: convTotal,
+                  })}
+                </span>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    disabled={loading || convPage === 0}
+                    onClick={() => setConvPage((p) => Math.max(0, p - 1))}
+                    className="rounded-md border border-border px-3 py-1 transition hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    {t("pagination.prev")}
+                  </button>
+                  <button
+                    type="button"
+                    disabled={loading || (convPage + 1) * CONV_PAGE_SIZE >= convTotal}
+                    onClick={() => setConvPage((p) => p + 1)}
+                    className="rounded-md border border-border px-3 py-1 transition hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    {t("pagination.next")}
+                  </button>
+                </div>
+              </div>
+            )}
+
             {tab === "tasks" && (
               <Table>
                 <thead>
@@ -358,7 +418,7 @@ export default function AdminConversationsPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {loading ? (
+                  {sideLoading ? (
                     <tr>
                       <Td className="py-8 text-center text-muted" colSpan={4}>
                         <Loader2 className="mx-auto h-5 w-5 animate-spin" />
@@ -403,7 +463,7 @@ export default function AdminConversationsPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {loading ? (
+                  {sideLoading ? (
                     <tr>
                       <Td className="py-8 text-center text-muted" colSpan={4}>
                         <Loader2 className="mx-auto h-5 w-5 animate-spin" />

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import type { WsChatRequest, WsServerEvent, WsAttachedFile } from "@openmake/shared-types";
 import { useAppStore, type StructuredAnswerData, type PendingApproval, type AgentTaskState } from "./store";
@@ -87,6 +88,10 @@ function resolveWsUrl(): string {
 
 export function useChatSocket() {
   const t = useTranslations("chatSocket");
+  // 스트림 종료 시 사이드바/히스토리의 대화 목록 캐시를 무효화하기 위한 핸들.
+  // (없으면 방금 만든 세션이 새로고침 전까지 "최근 대화"에 안 보임 — 게스트는 목록이
+  // 비어 있어 "히스토리에 안 남는다"로 체감되던 결함)
+  const queryClient = useQueryClient();
   // 콜백들이 stale deps(useCallback([]) 등)로 메모이즈되어 t 가 클로저에 갇히므로
   // ref 로 최신 t 를 참조한다(렌더 중 ref 쓰기 금지 규칙이라 effect 에서 갱신).
   const tRef = useRef(t);
@@ -175,6 +180,9 @@ export function useChatSocket() {
 
     // 스트림 종료(done/aborted/error) 후 지연된 배포 reload / 토큰 갱신 재연결을 실행.
     const runDeferredAfterStream = () => {
+      // 대화 목록 캐시 무효화 — 이번 턴이 만든/갱신한 세션이 사이드바 "최근 대화"에
+      // 즉시 반영되게 한다(게스트 포함). 실패해도 다음 마운트 fetch 가 복구하므로 fire-and-forget.
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
       if (moduleReloadPending) {
         moduleReloadPending = false;
         location.reload();

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1267,6 +1267,11 @@
     "researchDetail": {
       "empty": "No research steps",
       "step": "Step {n}"
+    },
+    "pagination": {
+      "info": "{total} total · page {page}/{pages}",
+      "prev": "Previous",
+      "next": "Next"
     }
   },
   "adminAudit": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1267,6 +1267,11 @@
     "researchDetail": {
       "empty": "リサーチステップがありません",
       "step": "ステップ {n}"
+    },
+    "pagination": {
+      "info": "全{total}件 · {page}/{pages}ページ",
+      "prev": "前へ",
+      "next": "次へ"
     }
   },
   "adminAudit": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1267,6 +1267,11 @@
     "researchDetail": {
       "empty": "리서치 스텝이 없습니다",
       "step": "스텝 {n}"
+    },
+    "pagination": {
+      "info": "총 {total}건 · {page}/{pages} 페이지",
+      "prev": "이전",
+      "next": "다음"
     }
   },
   "adminAudit": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1267,6 +1267,11 @@
     "researchDetail": {
       "empty": "暂无研究步骤",
       "step": "步骤 {n}"
+    },
+    "pagination": {
+      "info": "共{total}条 · 第{page}/{pages}页",
+      "prev": "上一页",
+      "next": "下一页"
     }
   },
   "adminAudit": {


### PR DESCRIPTION
## 요약

두 가지 히스토리 가시성 결함/개선을 담는다.

### 1. 게스트 히스토리 즉시 반영 (fix)
게스트(비로그인) 대화는 `anonSessionId` 로 항상 DB 에 저장되지만, 채팅 종료 후 사이드바 "최근 대화"의 react-query `["conversations"]` 캐시가 무효화되지 않아 **새로고침 전까지 목록에 안 보였다**. 게스트는 목록이 처음부터 비어 있어 "히스토리에 안 남는다"로 체감되던 결함. 스트림 종료 공통 지점(`runDeferredAfterStream` — done/aborted/error)에서 캐시를 무효화한다.

### 2. 관리자 전체 대화 서버 페이지네이션 (feat)
`/admin/conversations` 가 `limit=200` 단발 조회라 그보다 오래된 대화(게스트 포함)는 열람 불가였다. 서버 offset 페이지네이션으로 전환:
- `GET /api/chat/conversations?viewAll=true` 에 `offset` + `total` 응답 추가 (`total` 은 scope `all` 전용 — 사이드바/개인 히스토리 하위 호환)
- `getAllSessions(limit, offset)` + `countAllSessions()` (동일 EXISTS 필터 쌍)
- 대화 탭 50건/페이지 + 하단 "총 N건 · 페이지/전체" + 이전/다음 (i18n ko/en/ja/zh)
- 작업·리서치 탭 로딩을 `sideLoading` 으로 분리 (대화 페이지 재조회와 독립)

## 검증

- [x] `npm run lint` 통과 (0 errors, 변경 파일 경고 0)
- [x] `npm test` 통과 (2436 passed / 96 skipped)
- [x] `npm run build` 통과, 600줄 파일 가드 통과
- [x] `eval:routing` 93.3% / `eval:response` 100% (라우팅/응답 로직 무변경)
- [x] 라이브 E2E (chat.openmake.cc): 게스트 질문 → 답변 직후 새로고침 없이 사이드바 반영, 항목 클릭 시 과거 Q&A 재로드
- [x] 라이브 E2E (admin): "총 610건 · 1/13 페이지" 표시, 다음/이전 페이지 이동, offset=0/50/600 API 검증(마지막 페이지 10건), 게스트 스코프 응답에 `total` 미포함(하위 호환) 확인

## 영향 범위

- API 응답 계약: `total` 필드는 관리자 `viewAll` 응답에만 추가 (optional) — 기존 소비처 무영향
- DB 스키마 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)