### PR TITLE
feat(agent-task): 완료 판정 관문 단일화 + 판정 관측 영속(091)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -898,8 +898,20 @@ AGENT_TASK_TIMEOUT_MS=600000
 
 # Agent Task — 목표 달성 judge (아티팩트 없는 최종 답변을 판정 전용 LLM 1회 호출로 검증,
 # 미달성이면 completed 대신 failed(goal_incomplete)). 기본 ON. 'false' 로 비활성.
+# 판정 결과는 agent_tasks.judge_verdict, 완료 출구는 completion_path 로 영속(091).
 # AGENT_TASK_GOAL_JUDGE=true
 # AGENT_TASK_GOAL_JUDGE_MAX_CHARS=6000   # judge 에 넘기는 최종 답변 최대 글자 수
+
+# Agent Task — 도구 호출 인자 영속 (스텝에 마스킹된 args 기록, 사후 원인 분석용). 기본 ON.
+# AGENT_TASK_TOOL_ARGS_PERSIST=true
+# AGENT_TASK_TOOL_ARGS_MAX_CHARS=2000    # 초과 시 절단 표식으로 대체
+
+# Agent Task — 사용자 지정 max_turns 절대 상한 (Zod 입력 검증 상한도 동일). 기본 32.
+# AGENT_TASK_MAX_TURNS_CEILING=32
+
+# Agent Task — 마무리 턴 본문 채택 임계(글자). 자원 상한으로 도구를 막은 턴에서 모델이 도구 호출과
+# 본문을 함께 뱉었을 때, 본문이 이 길이 이상이면 최종 답변으로 채택해 완료 관문으로 보낸다.
+# AGENT_TASK_FINAL_TURN_MIN_ANSWER=200
 
 # Agent Task — 부팅 자동 복구 (재시작으로 중단된 task 를 checkpoint 에서 자동 resume). 기본 ON.
 # AGENT_TASK_BOOT_RECOVERY=true

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1268,8 +1268,14 @@ export const AGENT_TASK_LIMITS = {
     /** 미완성(미클레임) 청크 업로드 보관 시한(ms) — init 시 지난 것을 기회적으로 청소.
      *  AGENT_TASK_CHUNK_TTL_MS(기본 24h). */
     CHUNK_UPLOAD_TTL_MS: parseInt(process.env.AGENT_TASK_CHUNK_TTL_MS || '', 10) || 24 * 60 * 60 * 1000,
-    /** 사용자 지정 max_turns 의 절대 상한 */
-    MAX_TURNS_CEILING: 20,
+    /** 사용자 지정 max_turns 의 절대 상한(Zod 입력 검증 상한도 이 값을 참조).
+     *  20 은 조사→데이터 생성→렌더→검증이 이어지는 작업엔 부족하다 — 2026-08-09 실측: 예약
+     *  리포트 최근 5회가 **전부 20/20 을 소진**했고, 성공한 회차조차 마진이 0이라 조금만 흔들리면
+     *  실패했다. 천장만 올리는 것이라 요청 maxTurns 가 작은 작업(기본 10)에는 영향이 없다.
+     *  ⚠️ 턴을 늘려도 MAX_TOTAL_TOKENS(1M)·TOKEN_SOFT_RATIO 가 먼저 걸릴 수 있다 — 토큰 사유로
+     *  마무리 턴에 들어가면 shouldAdoptFinalTurnAnswer 가 본문을 살린다.
+     *  AGENT_TASK_MAX_TURNS_CEILING 로 오버라이드. */
+    MAX_TURNS_CEILING: parseInt(process.env.AGENT_TASK_MAX_TURNS_CEILING || '', 10) || 32,
     /**
      * 작업 목표(goal) 최대 길이. 종전 2,000자는 스키마에 하드코딩돼 있었고 근거가 없었다 —
      * 채팅 message 는 100,000자, tool arguments 는 200,000자를 받는데 goal 만 50배 좁았다.
@@ -1383,6 +1389,19 @@ export const AGENT_TASK_LIMITS = {
     VERIFY_DELIVERABLE_ENABLED: process.env.AGENT_TASK_VERIFY_DELIVERABLE !== 'false',
     /** 산출물 검증 실패 시 자가수정 재시도 최대 횟수 — 초과하면 검증을 건너뛰고 완료(무한루프 방지). */
     VERIFY_DELIVERABLE_MAX_RETRIES: parseInt(process.env.AGENT_TASK_VERIFY_DELIVERABLE_MAX_RETRIES || '1', 10),
+    /** 마무리 턴 본문 채택 임계(글자) — 자원 상한으로 도구를 막은 턴에서 모델이 도구 호출과 본문을
+     *  함께 뱉었을 때, 본문이 이 길이 이상이면 최종 답변으로 채택해 완료 관문으로 보낸다.
+     *  (미만이면 종전대로 응답을 버리고 다음 턴/턴상한 종료 — "산출물 다 만들고 실패 기록" 방지와
+     *  "의도 선언만 하고 완료 오표시" 방지의 경계. 2026-08-09 예약 리포트 실측: 실패 사례의 의도
+     *  선언문은 100자 안팎, 정상 최종 정리는 수백 자.) AGENT_TASK_FINAL_TURN_MIN_ANSWER 로 오버라이드. */
+    FINAL_TURN_MIN_ANSWER_CHARS: parseInt(process.env.AGENT_TASK_FINAL_TURN_MIN_ANSWER || '200', 10),
+    /** 도구 호출 인자 영속(091) — tool_result 스텝에 마스킹된 args 를 남겨 사후 원인 분석을 연다.
+     *  (종전엔 tool_name 만 남아 "어떤 인자로 호출해서 실패했는가"를 복기할 수 없었다.)
+     *  AGENT_TASK_TOOL_ARGS_PERSIST=false 로 비활성(기본 on). */
+    TOOL_ARGS_PERSIST_ENABLED: process.env.AGENT_TASK_TOOL_ARGS_PERSIST !== 'false',
+    /** 영속하는 인자 JSON 의 최대 글자 수 — 초과 시 절단 표식으로 대체(저장 팽창 방지).
+     *  파일 내용을 통째로 넘기는 write 계열 인자가 있어 캡이 필요하다. */
+    TOOL_ARGS_MAX_CHARS: parseInt(process.env.AGENT_TASK_TOOL_ARGS_MAX_CHARS || '2000', 10),
     /** 동시성 큐(Phase 3-B) — /execute·resume·부팅복구가 즉시 발사 대신 큐에 제출. 전역·유저별
      *  동시 실행 상한을 넘으면 'queued' 로 대기, 슬롯이 비면 dequeue. 기본 OFF(켜면 즉시발사→큐).
      *  ⚠️ 단일 프로세스 전제(API instances:1). 멀티프로세스 확장 시 Redis 백엔드 필요. */

--- a/apps/api/src/data/models/unified-database.ts
+++ b/apps/api/src/data/models/unified-database.ts
@@ -54,7 +54,6 @@ import type {
     UserApiKey,
     UserApiKeyPublic,
     AgentTask,
-    AgentTaskStatus,
     AgentTaskStep,
 } from './unified-database.types';
 import { API_KEY_LIMITS as _API_KEY_LIMITS } from './unified-database.types';
@@ -357,18 +356,8 @@ export class UnifiedDatabase {
         return this.agentTaskRepository.getAgentTask(taskId);
     }
 
-    async updateAgentTask(taskId: string, updates: {
-        status?: AgentTaskStatus;
-        progress?: number;
-        currentTurn?: number;
-        result?: string;
-        error?: string;
-        checkpoint?: unknown;
-        sandboxContainerId?: string;
-        workspacePath?: string;
-        plan?: unknown;
-        totalTokens?: number; gitPrUrl?: string; gitPushedBranch?: string;
-    }): Promise<void> {
+    // 파라미터 계약은 repository 가 SoT — 중복 선언하면 필드 추가 시 양쪽이 어긋난다(091 에서 정리).
+    async updateAgentTask(taskId: string, updates: Parameters<AgentTaskRepository['updateAgentTask']>[1]): Promise<void> {
         return this.agentTaskRepository.updateAgentTask(taskId, updates);
     }
 

--- a/apps/api/src/data/models/unified-database.types.ts
+++ b/apps/api/src/data/models/unified-database.types.ts
@@ -192,6 +192,10 @@ export interface AgentTask {
     executor?: 'sandbox' | 'local';
     /** 누적 LLM 토큰(prompt+completion) — terminal 전이 시 기록(066), resume 은 통산 */
     total_tokens?: number;
+    /** 완료 출구 구분(091) — 'final_answer' | 'terminate'. 미완료/기존 행은 NULL */
+    completion_path?: string;
+    /** goal judge 결과(091) — 'achieved' | 'not_achieved' | 'unknown' | 'skipped' */
+    judge_verdict?: string;
     created_at: string;
     updated_at: string;
     completed_at?: string;
@@ -206,6 +210,8 @@ export interface AgentTaskStep {
     content?: string;
     messages_snapshot?: unknown;
     status: string;
+    /** 도구 호출 인자(091) — 민감 키 마스킹·크기 캡 적용. 사후 원인 분석용 */
+    tool_args?: unknown;
     created_at: string;
 }
 

--- a/apps/api/src/data/repositories/agent-task-repository.ts
+++ b/apps/api/src/data/repositories/agent-task-repository.ts
@@ -79,6 +79,10 @@ export class AgentTaskRepository extends BaseRepository {
         totalTokens?: number;
         gitPrUrl?: string;
         gitPushedBranch?: string;
+        /** 완료 출구 구분(091) — 'final_answer' | 'terminate'. 완료 판정 관측용 */
+        completionPath?: string;
+        /** goal judge 결과(091) — 'achieved' | 'not_achieved' | 'unknown' | 'skipped' */
+        judgeVerdict?: string;
     }): Promise<void> {
         const sets: string[] = ['updated_at = NOW()'];
         const params: QueryParam[] = [];
@@ -136,6 +140,14 @@ export class AgentTaskRepository extends BaseRepository {
             sets.push(`git_pushed_branch = $${paramIdx++}`);
             params.push(updates.gitPushedBranch);
         }
+        if (updates.completionPath !== undefined) {
+            sets.push(`completion_path = $${paramIdx++}`);
+            params.push(updates.completionPath);
+        }
+        if (updates.judgeVerdict !== undefined) {
+            sets.push(`judge_verdict = $${paramIdx++}`);
+            params.push(updates.judgeVerdict);
+        }
 
         params.push(taskId);
         await this.query(`UPDATE agent_tasks SET ${sets.join(', ')} WHERE id = $${paramIdx}`, params);
@@ -151,14 +163,16 @@ export class AgentTaskRepository extends BaseRepository {
         status?: string;
         /** 스텝 기록 시점의 in_progress 플랜 단계 인덱스(0-base) — 노드별 비용/정합 집계(088). */
         planStepIndex?: number;
+        /** 도구 호출 인자(091) — 호출부에서 마스킹·크기 캡을 적용한 값만 넘긴다. */
+        toolArgs?: unknown;
     }): Promise<void> {
         // NUL(0x00) 제거 — 바이너리 파일을 도구로 열람하면 도구 결과에 0x00 이 섞일 수 있고,
         // Postgres TEXT/JSON 은 이를 거부한다("invalid byte sequence for encoding UTF8: 0x00").
         // 저장 backstop 으로 content·messages_snapshot 모두 정화한다(resultToString 소스 차단과 병행).
         const stripNul = (s: string): string => s.replace(/\u0000/g, '');
         await this.query(
-            `INSERT INTO agent_task_steps (task_id, step_number, step_type, tool_name, content, messages_snapshot, status, plan_step_index)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+            `INSERT INTO agent_task_steps (task_id, step_number, step_type, tool_name, content, messages_snapshot, status, plan_step_index, tool_args)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
             [
                 params.taskId,
                 params.stepNumber,
@@ -167,7 +181,8 @@ export class AgentTaskRepository extends BaseRepository {
                 params.content != null ? stripNul(params.content) : params.content,
                 params.messagesSnapshot !== undefined ? stripNul(JSON.stringify(params.messagesSnapshot)) : null,
                 params.status || 'completed',
-                params.planStepIndex ?? null
+                params.planStepIndex ?? null,
+                params.toolArgs !== undefined ? stripNul(JSON.stringify(params.toolArgs)) : null
             ]
         );
     }

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -16,12 +16,12 @@
  */
 import { type LLMClient } from '../llm';
 import type { ChatMessage, ToolDefinition } from '../llm/types';
-import { initAgentRoleState, chatTurnWithRoleFallback, judgeClientFor, defaultAgentClient } from './agent-task/role-client';
+import { initAgentRoleState, chatTurnWithRoleFallback, defaultAgentClient } from './agent-task/role-client';
 import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { getUnifiedDatabase } from '../data/models/unified-database';
 import { AGENT_TASK_LIMITS, AGENT_SPAWN } from '../config/runtime-limits';
 import { emitAgentTaskProgress } from '../utils/event-bus';
-import { getAgentTaskDeliverableNudge, getAgentTaskStuckNudge, getTaskSandboxGuidance, getAgentTaskUploadedFilesNote, getAgentTaskVerifyFailedNudge, AGENT_TASK_INCOMPLETE_MARKER } from '../prompts/agent-task-prompt';
+import { getAgentTaskDeliverableNudge, getAgentTaskStuckNudge, getTaskSandboxGuidance, getAgentTaskUploadedFilesNote, AGENT_TASK_INCOMPLETE_MARKER } from '../prompts/agent-task-prompt';
 import { extractAndStripArtifacts } from '../llm/artifact-parser';
 import { applyReportRender } from './chat-service/report-block';
 import { getPushService } from './PushService';
@@ -35,11 +35,11 @@ import { filterRestrictedTools } from './chat-service/tool-restrictions';
 import { TaskRuntime } from './task-sandbox/runtime';
 import { getApprovalRegistry } from './task-sandbox/approval-gate';
 import { currentPlanStepIndex } from './task-sandbox/planning';
-import { applyTurnResourceGates, type TurnGateFlags } from './agent-task/turn-gate';
+import { applyTurnResourceGates, shouldAdoptFinalTurnAnswer, type TurnGateFlags } from './agent-task/turn-gate';
 import { buildFileContext } from './chat-service/attach-context';
 import { AgentTaskAbort, assertWithinLimits, type AgentTaskRunInput } from './agent-task/types';
 import { writeInputFilesToWorkspace } from './agent-task/task-inputs';
-import { judgeGoalAchieved, buildJudgeExecutionContext } from './agent-task/goal-judge';
+import { finalizeTask } from './agent-task/finalize';
 import { persistArtifactSteps } from './agent-task/task-steps';
 import { initWorkspaceBaseline, maybePersistCodeDiff, captureDiffOnCleanup } from './agent-task/code-diff';
 import { getSteeringRegistry, applyPendingSteering } from './agent-task/steering';
@@ -47,8 +47,8 @@ import { setupTaskRepo, maybePushAndOpenPR } from './agent-task/git-ops';
 import { resolveExecutorPlan } from './agent-task/executor-select';
 import { recoverTextToolCalls } from './agent-task/text-tool-calls';
 import { executeTurnToolCalls } from './agent-task/turn-executor';
+import { prepareToolArgs } from './agent-task/tool-args';
 import { assembleAgentTools } from './agent-task/tool-assembly';
-import { verifyCodeArtifacts } from './agent-task/deliverable-verify';
 import { buildAgentTaskSystemContent, resolveSkillToolBindings } from './agent-task/skill-block';
 
 // 기존 import 호환 재노출 — 타입/에러는 services/agent-task/types 로 분리 (파일 크기 가드).
@@ -344,13 +344,31 @@ export class AgentTaskService {
                 const finalTurnHasNativeTools = !!(result.tool_calls && result.tool_calls.length > 0);
                 const finalTurnHasTextTools = !!finalTurnReason && !finalTurnHasNativeTools
                     && !!result.content && recoverTextToolCalls(result.content).length > 0;
-                if (finalTurnReason && (finalTurnHasNativeTools || finalTurnHasTextTools)) {
+                // 실질 답변 채택: 도구 호출이 섞였어도 본문이 충분하면 그 텍스트를 최종 답변으로 삼는다.
+                // 종전엔 응답 전체를 버려서, 산출물을 다 만들어 놓고 마지막 턴에 도구를 한 번 더 부르려 한
+                // 작업이 max_turns_exhausted 로 실패 기록됐다(2026-08-08 예약 리포트: 렌더 완료된 36KB
+                // report.html 이 게시되지 못하고 workspace 와 함께 폐기). 텍스트 도구 호출(XML) 케이스는
+                // 본문 자체가 도구 호출문이라 채택하지 않는다 — native tool_calls 만 버리고 본문을 살린다.
+                const finalTurnAnswerLen = (result.content ?? '').trim().length;
+                const finalTurnAnswerUsable = shouldAdoptFinalTurnAnswer({
+                    finalTurn: !!finalTurnReason,
+                    hasNativeTools: finalTurnHasNativeTools,
+                    hasTextTools: finalTurnHasTextTools,
+                    answerLength: finalTurnAnswerLen,
+                });
+                if (finalTurnReason && (finalTurnHasNativeTools || finalTurnHasTextTools) && !finalTurnAnswerUsable) {
                     logger.info(`[AgentTask] 마무리 턴 도구 호출 무시: ${taskId} (turn ${turn + 1})`);
                     conversation.push({ role: 'assistant', content: result.content });
                     const stType = turn === 0 ? 'plan' : 'assistant';
                     await db.addAgentTaskStep({ taskId, stepNumber: stepNumber++, stepType: stType, content: result.content });
                     emitStep(stType, undefined, result.content);
                     continue;
+                }
+                if (finalTurnAnswerUsable) {
+                    // 도구 호출만 떨궈 아래 최종 답변 경로(finalize 관문)로 자연 진입시킨다.
+                    logger.info(`[AgentTask] 마무리 턴 도구 호출 폐기·본문 채택: ${taskId} `
+                        + `(turn ${turn + 1}, ${finalTurnAnswerLen}자, 폐기 ${result.tool_calls!.length}건)`);
+                    result.tool_calls = undefined;
                 }
 
                 conversation.push({
@@ -410,69 +428,37 @@ export class AgentTaskService {
                     toolName: turnToolNames,
                     content: stepContent,
                     planStepIndex: planIdx(),
+                    // 호출 의도의 인자까지 영속(091) — 중단·거부로 실행되지 않아 tool_result 행이
+                    // 남지 않는 호출도 사후에 복기할 수 있게 한다(tool_name 영속과 같은 취지).
+                    toolArgs: hasToolCalls
+                        ? prepareToolArgs(result.tool_calls!.map((tc) => ({ name: tc.function.name, args: tc.function.arguments })))
+                        : undefined,
                 });
                 emitStep(stepType, turnToolNames, stepContent);
 
                 if (!hasToolCalls) {
-                    // 목표 미달성 선언: 모델이 마커로 "수행 불가"를 밝히면 completed 대신 failed(goal_incomplete)
-                    // 로 종료(오표시 차단), result 엔 마커 뗀 사유. 턴 0 재촉 가드보다 먼저(불가 선언을 안 뭉갬).
-                    if (stepContent && stepContent.includes(AGENT_TASK_INCOMPLETE_MARKER)) {
-                        await update({
-                            status: 'failed',
-                            error: 'goal_incomplete',
-                            result: stepContent.replace(AGENT_TASK_INCOMPLETE_MARKER, '').trim(),
-                            checkpoint: null,
-                        });
-                        logger.info(`[AgentTask] 목표 미달성 종료: ${taskId} (turn ${turn + 1})`);
-                        return;
-                    }
                     // 턴 0 계획-만 가드: 도구가 필요 없는 목표에서 모델이 계획만 쓰고 멈추면
                     // 결과물 없이 종료된다 — deliverable(artifact) 이 없으면 1회 재촉 후 계속.
-                    if (turn === startTurn && extracted!.artifacts.length === 0) {
+                    // 단 모델이 수행 불가를 선언(마커)했으면 재촉하지 않고 관문으로 보낸다
+                    // (재촉이 불가 선언을 뭉개면 미달성이 completed 로 흘러간다).
+                    if (turn === startTurn && extracted!.artifacts.length === 0
+                        && !(stepContent && stepContent.includes(AGENT_TASK_INCOMPLETE_MARKER))) {
                         conversation.push({ role: 'user', content: getAgentTaskDeliverableNudge() });
                         continue;
                     }
-                    // 목표 달성 judge(마커 미준수 보완): 아티팩트 없는 최종 답변만 판정 LLM 1회 검증(있으면 생략).
-                    // fail-open(완료 유지), 미달성 확정 시만 실패. 5-3(b) 실행 컨텍스트(도구·턴·계획) 제공.
-                    if (extracted!.artifacts.length === 0 && AGENT_TASK_LIMITS.GOAL_JUDGE_ENABLED) {
-                        const execCtx = buildJudgeExecutionContext(usedTools, turn + 1, taskRuntime?.getPlanSnapshot() ?? []);
-                        const achieved = await judgeGoalAchieved(
-                            await judgeClientFor(String(userId)), goal, stepContent ?? '', callSignal, execCtx);
-                        if (achieved === false) {
-                            await update({
-                                status: 'failed',
-                                error: 'goal_incomplete',
-                                result: stepContent,
-                                checkpoint: null,
-                            });
-                            logger.info(`[AgentTask] judge 목표 미달성 종료: ${taskId} (turn ${turn + 1})`);
-                            return;
-                        }
-                    }
-                    // 2-B 산출물 실행 검증: 코드 deliverable 을 완료 전 문법/컴파일 검사(샌드박스 활성 시).
-                    // 실패면 오류 리포트를 주입하고 1회 자가수정 유도(재시도 상한 내). 검사 대상 없음/통과/
-                    // fail-open 이면 그대로 완료. 재시도 상한 초과 시엔 검증을 건너뛰고 완료(무한루프 방지).
-                    if (taskRuntime
-                        && AGENT_TASK_LIMITS.VERIFY_DELIVERABLE_ENABLED
-                        && verifyRetries < AGENT_TASK_LIMITS.VERIFY_DELIVERABLE_MAX_RETRIES
-                        && extracted!.artifacts.length > 0) {
-                        const verify = await verifyCodeArtifacts(taskRuntime, extracted!.artifacts, callSignal);
-                        if (!verify.ok) {
-                            verifyRetries++;
-                            conversation.push({ role: 'user', content: getAgentTaskVerifyFailedNudge(verify.report) });
-                            logger.info(`[AgentTask] 산출물 검증 실패 → 자가수정 유도: ${taskId} (재시도 ${verifyRetries})`);
-                            continue;
-                        }
-                    }
-                    stepNumber = await persistArtifactSteps(taskId, extracted!.artifacts, stepNumber);
-                    stepNumber = await maybePersistCodeDiff(taskRuntime, sandboxCfg, taskId, stepNumber, emitStep);
-                    await update({
-                        status: 'completed',
-                        progress: 100,
-                        result: stepContent,
-                        checkpoint: null, // 완료 작업은 재개 대상 아님 — checkpoint 잔존 시 resume 허용·저장 팽창
+                    // 완료 판정은 finalizeTask 단일 관문 — 마커·verify·judge·산출물 영속(091).
+                    const fin = await finalizeTask({
+                        taskId, goal, userId: String(userId), path: 'final_answer',
+                        rawContent: result.content ?? '',
+                        taskRuntime, sandboxCfg, usedTools, turn, stepNumber, verifyRetries,
+                        signal: callSignal, update, emitStep,
                     });
-                    logger.info(`[AgentTask] 완료: ${taskId} (${turn + 1} 턴, ${totalTokens} 토큰, 아티팩트 ${extracted!.artifacts.length}개)`);
+                    stepNumber = fin.stepNumber;
+                    if (fin.kind === 'verify_retry') {
+                        verifyRetries++;
+                        conversation.push({ role: 'user', content: fin.nudge });
+                        continue;
+                    }
                     return;
                 }
 
@@ -494,17 +480,21 @@ export class AgentTaskService {
                 const { terminated, terminateSummary } = turnExec;
 
                 // terminate 도구 호출 — 깔끔한 완료 시그널(max_turns 소진 아님).
+                // 종전엔 이 경로가 판정 없이 바로 completed 였다(빈 terminate 로 산출물 0 완료가
+                // 라이브 재현). 최종 답변 경로와 같은 관문을 지나게 한다(091).
                 if (terminated) {
-                    const ex = extractAndStripArtifacts(applyReportRender(result.content ?? ''));
-                    stepNumber = await persistArtifactSteps(taskId, ex.artifacts, stepNumber);
-                    stepNumber = await maybePersistCodeDiff(taskRuntime, sandboxCfg, taskId, stepNumber, emitStep);
-                    await update({
-                        status: 'completed',
-                        progress: 100,
-                        result: terminateSummary || ex.cleanedContent || '작업을 완료했습니다.',
-                        checkpoint: null,
+                    const fin = await finalizeTask({
+                        taskId, goal, userId: String(userId), path: 'terminate',
+                        rawContent: result.content ?? '', terminateSummary,
+                        taskRuntime, sandboxCfg, usedTools, turn, stepNumber, verifyRetries,
+                        signal: callSignal, update, emitStep,
                     });
-                    logger.info(`[AgentTask] terminate 완료: ${taskId} (${turn + 1} 턴)`);
+                    stepNumber = fin.stepNumber;
+                    if (fin.kind === 'verify_retry') {
+                        verifyRetries++;
+                        conversation.push({ role: 'user', content: fin.nudge });
+                        continue;
+                    }
                     return;
                 }
 

--- a/apps/api/src/services/agent-task/finalize.test.ts
+++ b/apps/api/src/services/agent-task/finalize.test.ts
@@ -1,0 +1,158 @@
+// judge/verify 는 .env 플래그에 좌우되므로 고정해 결정적으로 만든다.
+jest.mock('../../config/runtime-limits', () => {
+    const actual = jest.requireActual('../../config/runtime-limits');
+    return {
+        ...actual,
+        AGENT_TASK_LIMITS: {
+            ...actual.AGENT_TASK_LIMITS,
+            GOAL_JUDGE_ENABLED: true,
+            VERIFY_DELIVERABLE_ENABLED: true,
+            VERIFY_DELIVERABLE_MAX_RETRIES: 1,
+        },
+    };
+});
+jest.mock('./goal-judge', () => ({
+    judgeGoalAchieved: jest.fn(),
+    buildJudgeExecutionContext: jest.fn(() => 'ctx'),
+}));
+jest.mock('./deliverable-verify', () => ({ verifyCodeArtifacts: jest.fn(async () => ({ ok: true, report: '' })) }));
+jest.mock('./role-client', () => ({ judgeClientFor: jest.fn(async () => ({})) }));
+jest.mock('./task-steps', () => ({ persistArtifactSteps: jest.fn(async (_t: string, _a: unknown[], n: number) => n + 1) }));
+jest.mock('./code-diff', () => ({ maybePersistCodeDiff: jest.fn(async (_r: unknown, _c: unknown, _t: string, n: number) => n) }));
+
+import { finalizeTask, type FinalizeInput } from './finalize';
+import { judgeGoalAchieved } from './goal-judge';
+import { verifyCodeArtifacts } from './deliverable-verify';
+import { AGENT_TASK_INCOMPLETE_MARKER } from '../../prompts/agent-task-prompt';
+import type { TaskRuntime } from '../task-sandbox/runtime';
+import type { TaskSandboxConfig } from '../../config/task-sandbox';
+
+const judgeMock = judgeGoalAchieved as jest.MockedFunction<typeof judgeGoalAchieved>;
+const verifyMock = verifyCodeArtifacts as jest.MockedFunction<typeof verifyCodeArtifacts>;
+
+/** 코드 아티팩트 1개를 담은 최종 응답 — 실제 파서를 통과하는 형태. */
+const WITH_ARTIFACT = '정리했습니다.\n<artifact kind="code" lang="python" title="t">print(1)</artifact>';
+
+function input(over: Partial<FinalizeInput> = {}): FinalizeInput {
+    const updates: Array<Record<string, unknown>> = [];
+    const base: FinalizeInput = {
+        taskId: 'task-1',
+        goal: '보고서를 작성한다',
+        userId: '3',
+        path: 'final_answer',
+        rawContent: '작업을 마쳤습니다.',
+        taskRuntime: { getPlanSnapshot: () => [] } as unknown as TaskRuntime,
+        sandboxCfg: {} as TaskSandboxConfig,
+        usedTools: new Set<string>(['bash']),
+        turn: 1,
+        stepNumber: 5,
+        verifyRetries: 0,
+        signal: new AbortController().signal,
+        update: async (u) => { updates.push(u as Record<string, unknown>); },
+        emitStep: () => { /* noop */ },
+        ...over,
+    };
+    // 마지막 update 페이로드를 검사할 수 있게 배열을 노출한다.
+    (base as FinalizeInput & { _updates: typeof updates })._updates = updates;
+    return base;
+}
+const lastUpdate = (i: FinalizeInput): Record<string, unknown> => {
+    const us = (i as FinalizeInput & { _updates: Array<Record<string, unknown>> })._updates;
+    return us[us.length - 1];
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    verifyMock.mockResolvedValue({ ok: true, report: '' });
+});
+
+describe('finalizeTask — 완료 관문 단일화(091)', () => {
+    it('terminate 경로도 goal judge 를 거친다 (종전엔 우회)', async () => {
+        judgeMock.mockResolvedValue(true);
+        const i = input({ path: 'terminate', terminateSummary: '완료했습니다.' });
+
+        const out = await finalizeTask(i);
+
+        expect(judgeMock).toHaveBeenCalledTimes(1);
+        expect(out.kind).toBe('completed');
+        expect(lastUpdate(i)).toMatchObject({
+            status: 'completed', completionPath: 'terminate', judgeVerdict: 'achieved',
+        });
+    });
+
+    it('terminate 인데 목표 미달성이면 completed 가 아니라 failed(goal_incomplete)', async () => {
+        judgeMock.mockResolvedValue(false);
+        const i = input({ path: 'terminate', terminateSummary: '' });
+
+        const out = await finalizeTask(i);
+
+        expect(out.kind).toBe('goal_incomplete');
+        expect(lastUpdate(i)).toMatchObject({
+            status: 'failed', error: 'goal_incomplete', completionPath: 'terminate', judgeVerdict: 'not_achieved',
+        });
+    });
+
+    it('judge 판정 불가는 fail-open — 완료 유지하되 verdict=unknown 으로 남긴다', async () => {
+        judgeMock.mockResolvedValue(null);
+        const i = input();
+
+        const out = await finalizeTask(i);
+
+        expect(out.kind).toBe('completed');
+        expect(lastUpdate(i)).toMatchObject({ status: 'completed', judgeVerdict: 'unknown' });
+    });
+
+    it('아티팩트가 있으면 judge 를 생략하고 verdict=skipped (발동 조건 유지)', async () => {
+        const i = input({ rawContent: WITH_ARTIFACT });
+
+        const out = await finalizeTask(i);
+
+        expect(judgeMock).not.toHaveBeenCalled();
+        expect(out.kind).toBe('completed');
+        expect(lastUpdate(i)).toMatchObject({ status: 'completed', judgeVerdict: 'skipped' });
+    });
+
+    it('미달성 마커는 judge 없이 failed(goal_incomplete) — 마커는 결과 본문에서 제거', async () => {
+        const i = input({ rawContent: `${AGENT_TASK_INCOMPLETE_MARKER}\n권한이 없어 수행하지 못했습니다.` });
+
+        const out = await finalizeTask(i);
+
+        expect(judgeMock).not.toHaveBeenCalled();
+        expect(out.kind).toBe('goal_incomplete');
+        const u = lastUpdate(i);
+        expect(u).toMatchObject({ status: 'failed', error: 'goal_incomplete', judgeVerdict: 'skipped' });
+        expect(String(u.result)).not.toContain(AGENT_TASK_INCOMPLETE_MARKER);
+        expect(String(u.result)).toContain('권한이 없어');
+    });
+
+    it('산출물 검증 실패는 완료시키지 않고 자가수정 nudge 를 돌려준다', async () => {
+        verifyMock.mockResolvedValue({ ok: false, report: 'SyntaxError' });
+        const i = input({ rawContent: WITH_ARTIFACT });
+
+        const out = await finalizeTask(i);
+
+        expect(out.kind).toBe('verify_retry');
+        expect(out.kind === 'verify_retry' && out.nudge).toContain('SyntaxError');
+        const us = (i as FinalizeInput & { _updates: unknown[] })._updates;
+        expect(us).toHaveLength(0); // 상태 전이 없음 — 루프가 계속된다
+    });
+
+    it('verify 재시도 상한을 넘으면 검증을 건너뛰고 완료한다(무한루프 방지)', async () => {
+        verifyMock.mockResolvedValue({ ok: false, report: 'SyntaxError' });
+        const i = input({ rawContent: WITH_ARTIFACT, verifyRetries: 1 });
+
+        const out = await finalizeTask(i);
+
+        expect(verifyMock).not.toHaveBeenCalled();
+        expect(out.kind).toBe('completed');
+    });
+
+    it('terminate summary 가 결과 본문이 된다', async () => {
+        judgeMock.mockResolvedValue(true);
+        const i = input({ path: 'terminate', terminateSummary: '3개 파일을 생성했습니다.', rawContent: '' });
+
+        await finalizeTask(i);
+
+        expect(lastUpdate(i).result).toBe('3개 파일을 생성했습니다.');
+    });
+});

--- a/apps/api/src/services/agent-task/finalize.ts
+++ b/apps/api/src/services/agent-task/finalize.ts
@@ -1,0 +1,156 @@
+/**
+ * Agent Task 완료 관문 — 모든 완료 출구가 지나는 단일 판정 지점 (091).
+ *
+ * 종전엔 completed 로 나가는 출구가 둘이었고 판정 강도가 서로 달랐다:
+ *   ① 도구 없는 최종 답변 — 마커 → judge(아티팩트 0 한정) → verify
+ *   ② terminate 도구      — **판정 없음**, 아티팩트만 영속하고 즉시 completed
+ * 2026-08-09 후향 실측(completed 155건)에서 ②가 22건(14.2%)이고 전부 아티팩트 0,
+ * 평균 결과 길이 139자였다. 빈 terminate 로 산출물 없이 completed 되는 것이 라이브에서
+ * 재현되기도 했다(2026-08-06). 두 출구를 이 모듈로 모아 같은 관문을 지나게 한다.
+ *
+ * 판정 순서는 **결정적 검사 → LLM 판정** 이다. 코드가 깨졌으면 목표 달성 여부를 물을 것
+ * 없이 자가수정 루프로 돌려보내는 편이 싸고 정확하다(실행 grounding > self-critique).
+ *   1. `[GOAL_INCOMPLETE]` 마커(모델 자기신고) → failed(goal_incomplete)
+ *   2. deliverable verify(코드 산출물 문법/컴파일) → 실패 시 자가수정 유도로 반환
+ *   3. goal judge(LLM 1회) → 미달성 확정 시 failed(goal_incomplete), 판정 실패는 fail-open
+ *   4. 아티팩트·코드 diff 영속 → completed
+ *
+ * judge 발동 조건(아티팩트 0)은 종전 그대로다 — 확대는 judge_verdict 전향 데이터를 본 뒤.
+ *
+ * @module services/agent-task/finalize
+ */
+import type { getUnifiedDatabase } from '../../data/models/unified-database';
+import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
+import { extractAndStripArtifacts } from '../../llm/artifact-parser';
+import { applyReportRender } from '../chat-service/report-block';
+import { AGENT_TASK_INCOMPLETE_MARKER, getAgentTaskVerifyFailedNudge } from '../../prompts/agent-task-prompt';
+import { judgeGoalAchieved, buildJudgeExecutionContext } from './goal-judge';
+import { verifyCodeArtifacts } from './deliverable-verify';
+import { persistArtifactSteps } from './task-steps';
+import { maybePersistCodeDiff } from './code-diff';
+import { judgeClientFor } from './role-client';
+import { createLogger } from '../../utils/logger';
+import type { TaskRuntime } from '../task-sandbox/runtime';
+import type { TaskSandboxConfig } from '../../config/task-sandbox';
+
+const logger = createLogger('AgentTaskService');
+
+type UnifiedDb = ReturnType<typeof getUnifiedDatabase>;
+type AgentTaskUpdatePayload = Parameters<UnifiedDb['updateAgentTask']>[1];
+
+/** 완료 관문을 지난 출구 구분 — 091 관측 컬럼 `agent_tasks.completion_path`. */
+export type CompletionPath = 'final_answer' | 'terminate';
+/** goal judge 결과 — 091 관측 컬럼 `agent_tasks.judge_verdict`. */
+export type JudgeVerdict = 'achieved' | 'not_achieved' | 'unknown' | 'skipped';
+
+export interface FinalizeInput {
+    taskId: string;
+    goal: string;
+    userId: string;
+    /** 어느 출구로 도달했는지 — 판정 로직은 동일하고 관측에만 쓰인다. */
+    path: CompletionPath;
+    /** 모델 최종 응답 원문(아티팩트 추출 전). */
+    rawContent: string;
+    /** terminate 도구의 summary 인자 — 있으면 결과 본문으로 우선한다. */
+    terminateSummary?: string;
+    taskRuntime: TaskRuntime | null;
+    sandboxCfg: TaskSandboxConfig;
+    /** 실행 중 사용한 도구 — judge 실행 컨텍스트. */
+    usedTools: ReadonlySet<string>;
+    /** 0-base 턴 인덱스. */
+    turn: number;
+    stepNumber: number;
+    /** 지금까지의 verify 자가수정 횟수 — 상한 초과 시 검증을 건너뛴다(무한루프 방지). */
+    verifyRetries: number;
+    signal: AbortSignal;
+    update: (u: AgentTaskUpdatePayload) => Promise<void>;
+    emitStep: (stepType: string, toolName?: string, content?: string | null) => void;
+}
+
+export type FinalizeOutcome =
+    /** 완료 처리까지 끝냈다 — 호출부는 즉시 종료한다. */
+    | { kind: 'completed'; stepNumber: number }
+    /** 목표 미달성으로 failed 기록까지 끝냈다 — 호출부는 즉시 종료한다. */
+    | { kind: 'goal_incomplete'; stepNumber: number }
+    /** 산출물 검증 실패 — 호출부가 nudge 를 conversation 에 넣고 루프를 계속한다. */
+    | { kind: 'verify_retry'; stepNumber: number; nudge: string };
+
+/**
+ * 완료 판정 관문. 상태 갱신(completed/failed)까지 이 함수가 수행하고, 호출부는 반환 kind 로
+ * 종료/계속만 결정한다. judge·verify 는 모두 fail-open 이라 판정 인프라 장애가 완료를 막지 않는다.
+ */
+export async function finalizeTask(input: FinalizeInput): Promise<FinalizeOutcome> {
+    const {
+        taskId, goal, userId, path, rawContent, terminateSummary,
+        taskRuntime, sandboxCfg, usedTools, turn, signal, update, emitStep,
+    } = input;
+    let stepNumber = input.stepNumber;
+
+    const extracted = extractAndStripArtifacts(applyReportRender(rawContent ?? ''));
+    const artifacts = extracted.artifacts;
+    // terminate 는 summary 를 결과 본문으로 우선(도구 인자가 곧 모델의 완료 선언).
+    const body = path === 'terminate'
+        ? (terminateSummary || extracted.cleanedContent || '작업을 완료했습니다.')
+        : extracted.cleanedContent;
+
+    // 1. 목표 미달성 자기신고 — 마커를 뗀 사유를 결과로 남기고 failed 로 종료.
+    if (body && body.includes(AGENT_TASK_INCOMPLETE_MARKER)) {
+        await update({
+            status: 'failed',
+            error: 'goal_incomplete',
+            result: body.replace(AGENT_TASK_INCOMPLETE_MARKER, '').trim(),
+            checkpoint: null,
+            completionPath: path,
+            judgeVerdict: 'skipped',
+        });
+        logger.info(`[AgentTask] 목표 미달성 종료: ${taskId} (turn ${turn + 1}, ${path})`);
+        return { kind: 'goal_incomplete', stepNumber };
+    }
+
+    // 2. 산출물 실행 검증(결정적) — 코드 deliverable 이 컴파일되지 않으면 판정 전에 자가수정.
+    if (taskRuntime
+        && AGENT_TASK_LIMITS.VERIFY_DELIVERABLE_ENABLED
+        && input.verifyRetries < AGENT_TASK_LIMITS.VERIFY_DELIVERABLE_MAX_RETRIES
+        && artifacts.length > 0) {
+        const verify = await verifyCodeArtifacts(taskRuntime, artifacts, signal);
+        if (!verify.ok) {
+            logger.info(`[AgentTask] 산출물 검증 실패 → 자가수정 유도: ${taskId} (재시도 ${input.verifyRetries + 1})`);
+            return { kind: 'verify_retry', stepNumber, nudge: getAgentTaskVerifyFailedNudge(verify.report) };
+        }
+    }
+
+    // 3. goal judge — 아티팩트 없는 완료만 LLM 1회 검증(마커 미준수 보완). 결과는 관측 컬럼에 남긴다.
+    let verdict: JudgeVerdict = 'skipped';
+    if (artifacts.length === 0 && AGENT_TASK_LIMITS.GOAL_JUDGE_ENABLED) {
+        const execCtx = buildJudgeExecutionContext(usedTools, turn + 1, taskRuntime?.getPlanSnapshot() ?? []);
+        const achieved = await judgeGoalAchieved(
+            await judgeClientFor(userId), goal, body ?? '', signal, execCtx);
+        verdict = achieved === null ? 'unknown' : achieved ? 'achieved' : 'not_achieved';
+        if (achieved === false) {
+            await update({
+                status: 'failed',
+                error: 'goal_incomplete',
+                result: body,
+                checkpoint: null,
+                completionPath: path,
+                judgeVerdict: verdict,
+            });
+            logger.info(`[AgentTask] judge 목표 미달성 종료: ${taskId} (turn ${turn + 1}, ${path})`);
+            return { kind: 'goal_incomplete', stepNumber };
+        }
+    }
+
+    // 4. 산출물 영속 후 완료.
+    stepNumber = await persistArtifactSteps(taskId, artifacts, stepNumber);
+    stepNumber = await maybePersistCodeDiff(taskRuntime, sandboxCfg, taskId, stepNumber, emitStep);
+    await update({
+        status: 'completed',
+        progress: 100,
+        result: body,
+        checkpoint: null, // 완료 작업은 재개 대상 아님 — checkpoint 잔존 시 resume 허용·저장 팽창
+        completionPath: path,
+        judgeVerdict: verdict,
+    });
+    logger.info(`[AgentTask] 완료: ${taskId} (${turn + 1} 턴, ${path}, judge=${verdict}, 아티팩트 ${artifacts.length}개)`);
+    return { kind: 'completed', stepNumber };
+}

--- a/apps/api/src/services/agent-task/tool-args.test.ts
+++ b/apps/api/src/services/agent-task/tool-args.test.ts
@@ -1,0 +1,63 @@
+// TOOL_ARGS_* 는 .env 에 좌우되므로 고정해 결정적으로 만든다.
+jest.mock('../../config/runtime-limits', () => {
+    const actual = jest.requireActual('../../config/runtime-limits');
+    return {
+        ...actual,
+        AGENT_TASK_LIMITS: {
+            ...actual.AGENT_TASK_LIMITS,
+            TOOL_ARGS_PERSIST_ENABLED: true,
+            TOOL_ARGS_MAX_CHARS: 200,
+        },
+    };
+});
+
+import { prepareToolArgs } from './tool-args';
+
+describe('prepareToolArgs', () => {
+    it('민감 키 값을 마스킹한다 (중첩 포함)', () => {
+        const out = prepareToolArgs({
+            url: 'https://example.com',
+            headers: { authorization: 'Bearer abc', 'x-api-key': 'sk-live-1' },
+            nested: { deep: { password: 'p@ss' } },
+        }) as Record<string, unknown>;
+
+        expect(out.url).toBe('https://example.com');
+        expect(out.headers).toEqual({ authorization: '[REDACTED]', 'x-api-key': '[REDACTED]' });
+        expect((out.nested as { deep: { password: string } }).deep.password).toBe('[REDACTED]');
+    });
+
+    it('민감하지 않은 값은 원형을 유지한다', () => {
+        expect(prepareToolArgs({ path: '/workspace/a.py', lines: 10, ok: true }))
+            .toEqual({ path: '/workspace/a.py', lines: 10, ok: true });
+    });
+
+    it('캡을 넘으면 절단 표식으로 대체한다', () => {
+        const out = prepareToolArgs({ content: 'x'.repeat(500) }) as Record<string, unknown>;
+        expect(out._truncated).toBe(true);
+        expect(out._chars).toBeGreaterThan(200);
+        expect(String(out.preview)).toHaveLength(200);
+    });
+
+    it('긴 배열은 앞부분만 남기고 잔여 개수를 표기한다', () => {
+        const out = prepareToolArgs({ items: Array.from({ length: 25 }, (_, i) => i) }) as { items: unknown[] };
+        expect(out.items).toHaveLength(21);
+        expect(out.items[20]).toBe('[+5 more]');
+    });
+
+    it('빈 인자·null 은 저장하지 않는다(undefined)', () => {
+        expect(prepareToolArgs({})).toBeUndefined();
+        expect(prepareToolArgs(null)).toBeUndefined();
+        expect(prepareToolArgs(undefined)).toBeUndefined();
+    });
+
+    it('순환 참조는 깊이 제한에서 끊긴다 (throw 없음)', () => {
+        const cyclic: Record<string, unknown> = { a: 1 };
+        cyclic.self = cyclic;
+        expect(() => prepareToolArgs(cyclic)).not.toThrow();
+        expect(JSON.stringify(prepareToolArgs(cyclic))).toContain('[DEPTH_LIMIT]');
+    });
+
+    it('직렬화 불가 값은 관측을 포기한다 (실행은 계속)', () => {
+        expect(prepareToolArgs({ n: BigInt(1) })).toBeUndefined();
+    });
+});

--- a/apps/api/src/services/agent-task/tool-args.ts
+++ b/apps/api/src/services/agent-task/tool-args.ts
@@ -1,0 +1,65 @@
+/**
+ * 도구 호출 인자 영속 준비 — 마스킹 + 크기 캡 (091).
+ *
+ * 스텝에는 tool_name 만 남아 있어 "어떤 인자로 호출해 실패했는가"를 사후에 복기할 수 없었다.
+ * 인자를 그대로 저장하면 두 가지가 문제라 이 모듈을 거친다:
+ *   ① 사용자 BYOK·토큰이 MCP 도구 인자로 흘러들 수 있음 → 민감 키 재귀 마스킹
+ *   ② write 계열 도구는 파일 본문 전체를 인자로 받음 → 직렬화 길이 캡
+ *
+ * @module services/agent-task/tool-args
+ */
+import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
+
+/** 값을 가려야 하는 키 이름 조각 — error-handler 의 sanitizeForLog 와 같은 기준. */
+const SENSITIVE_KEY_PATTERNS = [
+    'password', 'token', 'api_key', 'apikey', 'secret', 'key',
+    'authorization', 'auth', 'credential', 'cookie', 'session',
+] as const;
+
+const REDACTED = '[REDACTED]';
+/** 재귀 깊이 상한 — 순환/과대 중첩 방어. 초과 구간은 표식으로 대체. */
+const MAX_DEPTH = 6;
+/** 배열 원소 상한 — 긴 배열은 앞부분만 남긴다(대표성 유지). */
+const MAX_ARRAY_ITEMS = 20;
+
+function isSensitiveKey(key: string): boolean {
+    const lk = key.toLowerCase();
+    return SENSITIVE_KEY_PATTERNS.some((p) => lk.includes(p));
+}
+
+function maskValue(value: unknown, depth: number): unknown {
+    if (depth > MAX_DEPTH) return '[DEPTH_LIMIT]';
+    if (value === null || typeof value !== 'object') return value;
+    if (Array.isArray(value)) {
+        const head = value.slice(0, MAX_ARRAY_ITEMS).map((v) => maskValue(v, depth + 1));
+        return value.length > MAX_ARRAY_ITEMS
+            ? [...head, `[+${value.length - MAX_ARRAY_ITEMS} more]`]
+            : head;
+    }
+    return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).map(([k, v]) =>
+            isSensitiveKey(k) ? [k, REDACTED] : [k, maskValue(v, depth + 1)]),
+    );
+}
+
+/**
+ * 도구 인자를 영속 가능한 형태로 정규화한다. 절대 throw 하지 않는다(관측이 실행을 막지 않음).
+ *
+ * @returns 저장할 값. 비활성이거나 인자가 비었으면 undefined(= 컬럼 NULL).
+ *          캡을 넘으면 `{ _truncated: true, _chars, preview }` 형태로 대체한다.
+ */
+export function prepareToolArgs(args: unknown): unknown {
+    if (!AGENT_TASK_LIMITS.TOOL_ARGS_PERSIST_ENABLED) return undefined;
+    if (args === null || args === undefined) return undefined;
+    try {
+        if (typeof args === 'object' && !Array.isArray(args) && Object.keys(args).length === 0) return undefined;
+        const masked = maskValue(args, 0);
+        const json = JSON.stringify(masked) ?? '';
+        const cap = AGENT_TASK_LIMITS.TOOL_ARGS_MAX_CHARS;
+        if (json.length <= cap) return masked;
+        return { _truncated: true, _chars: json.length, preview: json.slice(0, cap) };
+    } catch {
+        // 순환 참조·직렬화 불가 값 — 관측을 포기하고 실행은 계속한다.
+        return undefined;
+    }
+}

--- a/apps/api/src/services/agent-task/turn-executor.ts
+++ b/apps/api/src/services/agent-task/turn-executor.ts
@@ -15,6 +15,7 @@ import { TASK_TERMINATE_SENTINEL } from '../task-sandbox/tools';
 import { requiresApproval, getApprovalRegistry } from '../task-sandbox/approval-gate';
 import { currentPlanStepIndex } from '../task-sandbox/planning';
 import { runTool, isSearchTool } from './task-steps';
+import { prepareToolArgs } from './tool-args';
 import { AgentTaskAbort } from './types';
 import type { TaskRuntime } from '../task-sandbox/runtime';
 import type { TaskSandboxConfig } from '../../config/task-sandbox';
@@ -152,6 +153,8 @@ export async function executeTurnToolCalls(input: TurnToolExecInput): Promise<Tu
             content: toolResult,
             // 스텝→플랜 노드 귀속(088) — plan_update 직후엔 갱신된 스냅샷 기준(새 단계로 귀속).
             planStepIndex: taskRuntime ? currentPlanStepIndex(taskRuntime.getPlanSnapshot()) : undefined,
+            // 호출 인자 영속(091) — 마스킹·크기 캡은 prepareToolArgs 가 담당(사후 원인 분석).
+            toolArgs: prepareToolArgs(args),
         });
         emitStep('tool_result', name, toolResult);
         // 턴 중간 체크포인트(6-4, opt-in): 도구 결과 단위로 저장 — 이 시점 conversation 은

--- a/apps/api/src/services/agent-task/turn-gate.test.ts
+++ b/apps/api/src/services/agent-task/turn-gate.test.ts
@@ -1,0 +1,44 @@
+// 임계값은 .env(AGENT_TASK_FINAL_TURN_MIN_ANSWER)에 좌우되므로 고정해 결정적으로 만든다.
+jest.mock('../../config/runtime-limits', () => {
+    const actual = jest.requireActual('../../config/runtime-limits');
+    return {
+        ...actual,
+        AGENT_TASK_LIMITS: { ...actual.AGENT_TASK_LIMITS, FINAL_TURN_MIN_ANSWER_CHARS: 200 },
+    };
+});
+
+import { shouldAdoptFinalTurnAnswer } from './turn-gate';
+
+const base = { finalTurn: true, hasNativeTools: true, hasTextTools: false, answerLength: 500 };
+
+describe('shouldAdoptFinalTurnAnswer — 마무리 턴 본문 채택', () => {
+    it('도구 호출이 섞여도 본문이 충분하면 채택한다 (완성 산출물 폐기 방지)', () => {
+        expect(shouldAdoptFinalTurnAnswer(base)).toBe(true);
+    });
+
+    it('본문이 임계 미만인 의도 선언은 채택하지 않는다', () => {
+        // 실측 사례: "Last turn. I need to produce the data.json ... Let me do this" (100자 안팎)
+        expect(shouldAdoptFinalTurnAnswer({ ...base, answerLength: 100 })).toBe(false);
+    });
+
+    it('본문이 비었으면 채택하지 않는다', () => {
+        expect(shouldAdoptFinalTurnAnswer({ ...base, answerLength: 0 })).toBe(false);
+    });
+
+    it('텍스트(XML) 도구 호출은 본문 자체가 호출문이라 채택하지 않는다', () => {
+        expect(shouldAdoptFinalTurnAnswer({ ...base, hasNativeTools: false, hasTextTools: true })).toBe(false);
+    });
+
+    it('마무리 턴이 아니면 판정 대상이 아니다 (정상 도구 루프)', () => {
+        expect(shouldAdoptFinalTurnAnswer({ ...base, finalTurn: false })).toBe(false);
+    });
+
+    it('도구 호출이 없으면 이 경로를 타지 않는다', () => {
+        expect(shouldAdoptFinalTurnAnswer({ ...base, hasNativeTools: false })).toBe(false);
+    });
+
+    it('임계 경계값은 채택한다', () => {
+        expect(shouldAdoptFinalTurnAnswer({ ...base, answerLength: 200 })).toBe(true);
+        expect(shouldAdoptFinalTurnAnswer({ ...base, answerLength: 199 })).toBe(false);
+    });
+});

--- a/apps/api/src/services/agent-task/turn-gate.ts
+++ b/apps/api/src/services/agent-task/turn-gate.ts
@@ -138,3 +138,25 @@ export async function applyTurnResourceGates(p: TurnGateInput): Promise<TurnGate
 
     return { effectiveTools, finalTurnReason, stepNumber };
 }
+
+/**
+ * 마무리 턴(자원 상한으로 도구를 막은 턴)에서 모델이 도구 호출과 본문을 함께 뱉었을 때,
+ * 본문을 최종 답변으로 채택할지 판정한다.
+ *
+ * 종전엔 도구 호출이 섞이면 응답 전체를 버려서, 산출물을 다 만들어 놓고 마지막 턴에 확인용
+ * 도구를 한 번 더 부르려 한 작업이 `max_turns_exhausted` 로 실패 기록됐다(2026-08-08 예약
+ * 리포트 — 렌더 완료된 report.html 이 게시되지 못하고 workspace 와 함께 폐기).
+ *
+ * 텍스트 도구 호출(XML) 케이스는 본문 자체가 도구 호출문이라 채택하지 않는다.
+ */
+export function shouldAdoptFinalTurnAnswer(p: {
+    /** 자원 상한으로 도구를 막은 턴인가(finalTurnReason 유무). */
+    finalTurn: boolean;
+    hasNativeTools: boolean;
+    hasTextTools: boolean;
+    /** 본문 trim 후 길이. */
+    answerLength: number;
+}): boolean {
+    if (!p.finalTurn || !p.hasNativeTools || p.hasTextTools) return false;
+    return p.answerLength >= AGENT_TASK_LIMITS.FINAL_TURN_MIN_ANSWER_CHARS;
+}

--- a/db/migrations/091_agent_task_completion_observability.sql
+++ b/db/migrations/091_agent_task_completion_observability.sql
@@ -1,0 +1,24 @@
+-- 091: 완료 판정 관측 (Execution Graph — 완성 판별 ①③)
+--
+-- 배경(2026-08-09 후향 실측, completed 155건): completed 로 나가는 출구가 3개인데
+-- terminate 경로(22건·14.2%)는 goal judge·deliverable verify 를 통째로 우회했고,
+-- 아티팩트가 있으면 judge 를 생략하는 규칙까지 겹쳐 **completed 의 58.7% 가 무판정**이었다.
+-- 관문을 하나로 모으는 것(①)과 별개로, 그 효과를 사후 측정할 근거가 DB 에 전혀 없었다
+-- (judge 판정은 로그로만 흘렀고, 완료 경로는 스텝 tool_name 역추적으로만 구분 가능).
+--
+--  * completion_path : 어느 출구로 완료됐는지 (final_answer | terminate). 기존 행은 NULL.
+--  * judge_verdict   : goal judge 결과 (achieved | not_achieved | unknown | skipped).
+--                      unknown = 호출/파싱 실패로 fail-open 통과, skipped = 발동 조건 밖.
+--  * tool_args       : 도구 호출 인자(민감값 마스킹·크기 캡) — 사후 원인 분석의 관측 갭.
+--
+-- 기존 행·기존 동작 무영향(전부 NULL 허용).
+ALTER TABLE agent_tasks ADD COLUMN IF NOT EXISTS completion_path TEXT;
+ALTER TABLE agent_tasks ADD COLUMN IF NOT EXISTS judge_verdict TEXT;
+ALTER TABLE agent_task_steps ADD COLUMN IF NOT EXISTS tool_args JSONB;
+
+COMMENT ON COLUMN agent_tasks.completion_path IS
+    '완료 출구 구분: final_answer(도구 없는 최종 답변) | terminate(종료 도구). 미완료/기존 행은 NULL (091)';
+COMMENT ON COLUMN agent_tasks.judge_verdict IS
+    'goal judge 결과: achieved | not_achieved | unknown(호출·파싱 실패 fail-open) | skipped(발동 조건 밖). 기존 행은 NULL (091)';
+COMMENT ON COLUMN agent_task_steps.tool_args IS
+    '도구 호출 인자 — 민감 키 [REDACTED] 마스킹 + 크기 캡 적용. 사후 원인 분석용 (091)';

--- a/db/migrations/rollbacks/091_agent_task_completion_observability.sql
+++ b/db/migrations/rollbacks/091_agent_task_completion_observability.sql
@@ -1,0 +1,5 @@
+-- 091 롤백: 완료 판정 관측 컬럼 제거.
+-- 관측 전용 컬럼이라 제거해도 실행 동작에는 영향이 없다(코드 참조 제거 후 적용할 것).
+ALTER TABLE agent_tasks DROP COLUMN IF EXISTS completion_path;
+ALTER TABLE agent_tasks DROP COLUMN IF EXISTS judge_verdict;
+ALTER TABLE agent_task_steps DROP COLUMN IF EXISTS tool_args;

--- a/infra/task-runtime/report-template/render_report.py
+++ b/infra/task-runtime/report-template/render_report.py
@@ -132,8 +132,13 @@ def main():
     open(out_path, "w", encoding="utf-8").write(html_out)
 
     grouped = sum(counts.values())
-    print(f"렌더 완료: {out_path} ({len(html_out)} bytes, 토큰 {len(ks)}개, "
-          f"기사 {grouped}건 {counts})")
+    # 종전 "토큰 N개" 는 **치환에 성공한** 토큰 수인데, 에이전트가 매번 "미해결 N개"로 읽었다
+    # (2026-08-09: 정상 렌더된 리포트에 [GOAL_INCOMPLETE] 마커를 붙여 실패 기록·게시 누락).
+    # 성공/실패를 문구로 단정해 오해의 여지를 없앤다 — 미치환 수를 실제로 세서 함께 보고한다.
+    leftover = len(TOKEN_RE.findall(html_out))
+    status = "정상" if leftover == 0 else f"미치환 {leftover}개 남음"
+    print(f"렌더 완료({status}): {out_path} ({len(html_out)} bytes, "
+          f"치환 {len(ks)}개·미치환 {leftover}개, 기사 {grouped}건 {counts})")
     missing = [k for k in ks if not k.endswith("_COUNT") and k not in auto and k not in data]
     if missing:
         print("경고 — data.json 미제공 키(—로 채움): " + ", ".join(missing))


### PR DESCRIPTION
## 배경

Agent Task 의 "완성 판별"을 점검하다가 `completed` 로 나가는 출구가 둘인데 **판정 강도가 서로 다르다**는 것을 확인했습니다.

후향 실측 (completed 155건, 전 기간):

| 지표 | 값 |
|---|---|
| terminate 경유 완료 | 22건 (14.2%) — **전부 아티팩트 0**, 평균 결과 길이 139자 |
| judge 발동 | 64건 (41.3%) |
| **무판정으로 완료** | **58.7%** |

`terminate` 는 goal judge·deliverable verify 를 통째로 우회했고(빈 terminate 로 산출물 없이 완료되는 것이 2026-08-06 라이브에서 재현), 아티팩트가 있으면 judge 를 생략하는 규칙까지 겹쳐 절반 이상이 아무 판정 없이 완료로 기록됐습니다. 게다가 judge 결과가 로그로만 흘러 **개선 효과를 측정할 근거 자체가 DB 에 없었습니다.**

## 변경

### 1. 완료 관문 단일화 (`agent-task/finalize.ts`)

최종답변·terminate 양쪽이 같은 관문을 지납니다. 순서는 **결정적 검사 → LLM 판정** 입니다 — 코드가 깨졌으면 목표 달성 여부를 물을 것 없이 자가수정으로 돌려보내는 편이 싸고 정확합니다.

```
[GOAL_INCOMPLETE] 마커 → deliverable verify → goal judge → 산출물 영속 → completed
```

judge 발동 조건(아티팩트 0)은 **그대로 유지**했습니다. 확대는 아래 관측 데이터를 본 뒤 결정합니다.

### 2. 판정 관측 영속 (마이그레이션 091)

| 컬럼 | 내용 |
|---|---|
| `agent_tasks.completion_path` | `final_answer` \| `terminate` |
| `agent_tasks.judge_verdict` | `achieved` \| `not_achieved` \| `unknown`(fail-open) \| `skipped` |
| `agent_task_steps.tool_args` | 민감 키 마스킹 + 크기 캡. 실행되지 않은 호출 의도까지 기록 |

### 3. 동반 수정 — 예약 리포트 5일 연속 실패

게시가 8/4 에서 멈춰 있었고, 매일 47~81만 토큰을 쓰면서 산출물은 0이었습니다. 원인이 세 겹이었습니다.

- **마무리 턴 응답 폐기** — 자원 상한으로 도구를 막은 턴에서 도구 호출이 섞이면 응답 전체를 버렸습니다. 8/8 실행은 리포트를 다 만들어 놓고(`렌더 완료 ... 36KB`, 미치환 0) `max_turns_exhausted` 로 실패 기록돼 게시되지 못했습니다. → `shouldAdoptFinalTurnAnswer` 로 본문이 200자 이상이면 최종 답변으로 채택합니다.
- **`MAX_TURNS_CEILING` 20 → 32** (env override) — 최근 5회가 전부 20/20 을 소진, 성공한 회차조차 마진 0이었습니다. 천장만 올리므로 요청 턴 수가 작은 작업엔 영향이 없습니다.
- **`render_report.py` 로그 오해** — `토큰 N개` 는 *치환에 성공한* 수(성공 지표)인데 모델이 "미해결 N개"로 읽고 정상 리포트에 `[GOAL_INCOMPLETE]` 를 붙였습니다. 실패 task 의 `data.json` 을 복원해 같은 렌더러로 돌리니 미치환 0·경고 0·36KB 정상 리포트가 나와 확증했습니다. → `렌더 완료(정상): ... 치환 56개·미치환 0개` 로 분리 표기.

## ⚠️ 배포 시 필요한 것

1. **마이그레이션 091** — 부팅 시 자동 적용됩니다(`DB_AUTO_MIGRATE`). 수동 적용도 가능합니다.
2. **task-runtime 이미지 재빌드** — 리포트 템플릿이 이미지에 베이킹돼 있습니다.
   ```
   docker build -t openmake-task-runtime:latest infra/task-runtime
   ```

## 남은 과제 (별건)

- **토큰이 진짜 병목** — 턴을 32로 올려도 23턴/70만 토큰에서 소프트 리밋이 먼저 걸립니다. 도구 결과 총량은 2.2만 토큰인데 누적이 80만인 것은 **매 턴 컨텍스트 재전송** 때문입니다.
- `plan_create` 인자가 깨져 5단계 계획이 1단계로 뭉치는 문제(로컬 모델에서도 재현).
- `extract_webpage` 는 검색과 달리 호출 상한이 없습니다.

## 검증

- 유닛 22건 신규(finalize 8 · tool-args 7 · turn-gate 7), 전체 jest 2554건 통과
- CI 6게이트 로컬 재현: tsc · 600줄 · lint 0 errors · routing 93.3% · response 100%
- **라이브 E2E**: terminate 경로가 judge 를 거쳐 `completion_path='terminate'`, `judge_verdict='achieved'` 로 기록되는 것을 실앱에서 확인. `tool_args` 영속 확인(7스텝 중 6건)
- terminate + `not_achieved` 조합은 라이브 재현에 실패했습니다 — 두 번 시도했고 모델이 모두 `[GOAL_INCOMPLETE]` 마커를 택했습니다(마커 규약을 잘 지킨다는 뜻). 해당 분기는 유닛 테스트로 커버돼 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
