### PR TITLE
feat(local-bridge): 로컬 실행기 worktree 격리 + 변경분 diff 캡처

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -940,6 +940,12 @@ AGENT_TASK_TIMEOUT_MS=600000
 # LOCAL_BRIDGE_MAX_WRITE_BYTES=8388608          # write/첨부 전송 상한(8MB)
 # LOCAL_BRIDGE_OUTPUT_CAP=65536                 # exec/read 결과 수신 캡(chars)
 #
+# worktree 격리 — 연결 폴더가 git 레포면 별도 worktree(디렉토리+브랜치)를 만들어 그 안에서만
+# 작업한다. 사용자의 현재 브랜치·작업 중인 파일이 오염되지 않고, 변경분을 git diff 로 캡처해
+# diff 스텝으로 남긴다(로컬 실행기는 종전에 diff 를 남길 수 없었다). git 레포가 아니거나
+# 생성 실패면 기존 동작으로 폴백. 기본 ON('false' 로 비활성).
+# LOCAL_BRIDGE_WORKTREE=true
+#
 # ── 로컬 에이전트 브라우저 (Cowork D3) ──
 # browser 도구를 데스크톱 Electron 내장 Chromium 에서 실행(Playwright 미번들).
 # 전용 세션 파티션이라 개인 Chrome 쿠키·로그인과 분리되고, 화면에 보이는 패널로 뜬다.

--- a/apps/api/src/config/local-bridge.ts
+++ b/apps/api/src/config/local-bridge.ts
@@ -29,4 +29,13 @@ export const LOCAL_BRIDGE = {
 
     /** 브라우저 액션 배열 1회 실행 상한(ms). 컨테이너 runner 기본값과 같은 축. */
     BROWSER_TIMEOUT_MS: parseInt(process.env.LOCAL_BRIDGE_BROWSER_TIMEOUT_MS || '60000', 10),
+
+    /**
+     * worktree 격리 — 연결 폴더가 git 레포면 별도 worktree(디렉토리+브랜치)를 만들어 그 안에서만
+     * 작업한다. 사용자의 현재 작업트리·브랜치가 오염되지 않고, 작업 결과를 `git diff HEAD` 로
+     * 정확히 캡처할 수 있다(샌드박스와 달리 인위적 baseline 커밋이 필요 없다 — 레포의 실제
+     * HEAD 가 기준점이다). git 레포가 아니거나 생성 실패면 기존 동작으로 폴백(fail-open).
+     * 기본 ON — LOCAL_EXECUTOR_ENABLED 자체가 기본 OFF 라 이 값만으로 동작이 바뀌지 않는다.
+     */
+    WORKTREE_ENABLED: process.env.LOCAL_BRIDGE_WORKTREE !== 'false',
 } as const;

--- a/apps/api/src/prompts/agent-task-prompt.ts
+++ b/apps/api/src/prompts/agent-task-prompt.ts
@@ -82,6 +82,21 @@ export function getAgentTaskDeliverableNudge(): string {
  * 영속 샌드박스(Manus화) 활성 시 system 에 덧붙이는 안내 — 작업 환경(셸+파일시스템) 인지 +
  * 구조화 플랜 도구 사용 유도(G3). 샌드박스 비활성 시 미주입.
  */
+/**
+ * 로컬 실행기 worktree 격리 안내 — 사용자의 현재 브랜치·작업트리를 건드리지 않고 별도 브랜치에서
+ * 작업 중임을 모델에게 알려, 최종 답변에 브랜치명을 명시하게 한다(사용자가 검토·머지할 지점).
+ */
+export function getWorktreeIsolationNote(branch: string): string {
+    return [
+        '',
+        '## 작업 브랜치 (격리)',
+        `- 당신의 변경은 사용자 저장소의 별도 작업 브랜치 \`${branch}\` 에서만 이뤄집니다.`,
+        '  사용자의 현재 브랜치·작업 중인 파일은 영향을 받지 않습니다.',
+        '- 브랜치를 직접 바꾸거나(checkout/switch) 병합하지 마세요 — 검토·병합은 사용자가 합니다.',
+        `- 최종 답변에 작업 브랜치명(\`${branch}\`)을 반드시 밝히세요.`,
+    ].join('\n');
+}
+
 export function getTaskSandboxGuidance(): string {
     return [
         '',

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -21,7 +21,7 @@ import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { getUnifiedDatabase } from '../data/models/unified-database';
 import { AGENT_TASK_LIMITS, AGENT_SPAWN } from '../config/runtime-limits';
 import { emitAgentTaskProgress } from '../utils/event-bus';
-import { getAgentTaskDeliverableNudge, getAgentTaskStuckNudge, getTaskSandboxGuidance, getAgentTaskUploadedFilesNote, AGENT_TASK_INCOMPLETE_MARKER } from '../prompts/agent-task-prompt';
+import { getAgentTaskDeliverableNudge, getAgentTaskStuckNudge, getTaskSandboxGuidance, getWorktreeIsolationNote, getAgentTaskUploadedFilesNote, AGENT_TASK_INCOMPLETE_MARKER } from '../prompts/agent-task-prompt';
 import { extractAndStripArtifacts } from '../llm/artifact-parser';
 import { applyReportRender } from './chat-service/report-block';
 import { getPushService } from './PushService';
@@ -228,6 +228,9 @@ export class AgentTaskService {
                     // 새 대화(resume 아님)면 system 에 작업환경 안내 주입. 이어서 Phase 2 Git: repo 지정 시 호스트 clone(토큰 컨테이너 미주입)+안내.
                     if (!input.resume && conversation[0]?.role === 'system') {
                         conversation[0].content += getTaskSandboxGuidance();
+                        // 로컬 실행기 worktree 격리가 걸렸으면 작업 브랜치를 알린다(사용자 검토 지점).
+                        const isolated = remoteExecutor?.isolatedBranch;
+                        if (isolated) conversation[0].content += getWorktreeIsolationNote(isolated);
                     }
                     await setupTaskRepo(taskRuntime, input, userId, conversation);
                     logger.info(`[AgentTask] 샌드박스 활성 (${taskId}, ${taskRuntime.containerName})`);

--- a/apps/api/src/services/agent-task/code-diff.ts
+++ b/apps/api/src/services/agent-task/code-diff.ts
@@ -49,6 +49,13 @@ export async function initWorkspaceBaseline(runtime: TaskRuntime): Promise<void>
  * outputCap 이 적용되며, 잘린 경우 말미에 표식을 덧붙인다.
  */
 export async function captureWorkspaceDiff(runtime: TaskRuntime): Promise<string | null> {
+    // 실행기가 자체 diff 를 제공하면 우선(로컬 브리지 worktree — 레포 HEAD 기준 변경분).
+    try {
+        const fromExecutor = await runtime.captureExecutorDiff();
+        if (fromExecutor) return fromExecutor;
+    } catch (e) {
+        logger.warn(`[AgentTask] 실행기 diff 캡처 실패: ${e instanceof Error ? e.message : e}`);
+    }
     // 로컬 실행기(D1a): baseline 미생성(위 가드) — 사용자 폴더에 git 명령을 대지 않는다.
     if (runtime.localWorkdir === null) return null;
     try {

--- a/apps/api/src/services/local-bridge/registry.ts
+++ b/apps/api/src/services/local-bridge/registry.ts
@@ -23,7 +23,10 @@ import { createLogger } from '../../utils/logger';
 const logger = createLogger('LocalBridge');
 
 /** 서버→디바이스 도구 요청 종류 — 이 외의 kind 는 존재하지 않는다(임의 RPC 금지). */
-export type BridgeKind = 'exec' | 'read' | 'write' | 'list' | 'listAll' | 'delete' | 'task_end' | 'browser';
+export type BridgeKind = 'exec' | 'read' | 'write' | 'list' | 'listAll' | 'delete' | 'task_end' | 'browser' | 'worktree';
+
+/** worktree 연산 — 서버는 op 만 지정하고 git 명령은 디바이스가 고정 인자로 조립한다(명령 주입 차단). */
+export type WorktreeOp = 'add' | 'diff' | 'remove';
 
 export interface BridgeRequestPayload {
     kind: BridgeKind;
@@ -33,6 +36,10 @@ export interface BridgeRequestPayload {
     path?: string;
     /** write 전용 — base64 본문 (바이너리 안전). */
     contentB64?: string;
+    /** worktree 전용 — 수행할 연산. */
+    op?: WorktreeOp;
+    /** worktree 전용 — task 식별자(디렉토리·브랜치명 파생). 디바이스가 형식을 재검증한다. */
+    taskId?: string;
 }
 
 /** 디바이스가 돌려주는 결과 (bridge_result). */
@@ -47,6 +54,12 @@ export interface BridgeResult {
     entries?: string[];
     error?: string;
     durationMs?: number;
+    /** worktree add 결과 — 연결 폴더 기준 상대경로(서버는 이 prefix 로 파일·exec 를 라우팅). */
+    worktreeRel?: string;
+    /** worktree add 결과 — 생성된 작업 브랜치명(사용자 안내용). */
+    branch?: string;
+    /** worktree remove 결과 — 변경분이 남아 보존했으면 true. */
+    kept?: boolean;
 }
 
 export interface DeviceSession {

--- a/apps/api/src/services/local-bridge/remote-executor.ts
+++ b/apps/api/src/services/local-bridge/remote-executor.ts
@@ -44,6 +44,13 @@ export class RemoteExecutor implements TaskExecutor {
     readonly browserStatePath = null;
     private readonly userId: string;
     private deviceLabel = 'local-device';
+    /**
+     * worktree 격리 시 연결 폴더 기준 상대경로(예: `.openmake/worktrees/<taskId>`). null 이면
+     * 격리 없이 연결 폴더에서 직접 작업하는 기존 동작이다(git 레포가 아니거나 생성 실패).
+     */
+    private worktreeRel: string | null = null;
+    /** worktree 작업 브랜치명 — 사용자 안내·결과 보고용. */
+    private worktreeBranch: string | null = null;
 
     constructor(taskId: string, userId: string) {
         this.taskId = taskId;
@@ -52,20 +59,62 @@ export class RemoteExecutor implements TaskExecutor {
 
     get label(): string { return `local:${this.deviceLabel}`; }
 
-    /** 실행 준비 = 디바이스 연결 확인(도구 왕복 없음). 미연결이면 throw → 호출부 graceful degrade. */
+    /** worktree 격리가 실제로 적용됐는지(호출부 안내·diff 캡처 판단용). */
+    get isolatedBranch(): string | null { return this.worktreeBranch; }
+
+    /**
+     * 실행 준비 = 디바이스 연결 확인 + worktree 격리 시도.
+     * 미연결이면 throw → 호출부 graceful degrade. worktree 실패는 throw 하지 않는다(fail-open).
+     */
     async create(): Promise<void> {
         const dev = getLocalBridgeRegistry().getDevice(this.userId);
         if (!dev) throw new Error('연결된 로컬 디바이스가 없습니다 — 데스크톱 앱에서 작업 폴더를 먼저 연결하세요.');
         this.deviceLabel = `${dev.label}`;
         logger.info(`[${this.taskId}] 로컬 실행기 준비 (device=${dev.deviceId}, folder="${dev.folderName}")`);
+
+        if (!LOCAL_BRIDGE.WORKTREE_ENABLED) return;
+        const r = await this.req({ kind: 'worktree', op: 'add', taskId: this.taskId });
+        if (r.ok && r.worktreeRel) {
+            this.worktreeRel = r.worktreeRel;
+            this.worktreeBranch = r.branch ?? null;
+            logger.info(`[${this.taskId}] worktree 격리 활성 (${r.worktreeRel}, branch=${r.branch})`);
+        } else {
+            // git 레포가 아니거나 생성 실패 — 격리 없이 진행한다(기존 동작 유지).
+            logger.info(`[${this.taskId}] worktree 격리 미적용: ${r.error ?? 'worktreeRel 없음'}`);
+        }
     }
 
     private req(payload: BridgeRequestPayload): Promise<BridgeResult> {
         return getLocalBridgeRegistry().request(this.userId, payload);
     }
 
+    /** 파일 경로를 worktree 기준으로 변환. 격리가 없으면 원래 경로 그대로. */
+    private scoped(relPath: string): string {
+        if (!this.worktreeRel) return relPath;
+        const clean = (relPath ?? '.').replace(/^\.\/+/, '');
+        return clean === '' || clean === '.' ? this.worktreeRel : `${this.worktreeRel}/${clean}`;
+    }
+
     async exec(command: string): Promise<ExecResult> {
-        return toExecResult(await this.req({ kind: 'exec', command }));
+        // 디바이스는 cwd=연결 폴더로 실행하므로, 격리 시 worktree 로 이동해 수행한다.
+        // (감싼 문자열이 사용자 확인 창에 그대로 보이므로 어디서 실행되는지 투명하다.)
+        const scopedCommand = this.worktreeRel ? `cd ${this.worktreeRel} && ${command}` : command;
+        return toExecResult(await this.req({ kind: 'exec', command: scopedCommand }));
+    }
+
+    /**
+     * worktree 변경분 diff — 레포의 실제 HEAD 가 기준점이라 인위적 baseline 커밋이 필요 없다.
+     * 격리가 없거나 실패하면 null(호출부는 diff 스텝을 남기지 않는다).
+     */
+    async captureDiff(): Promise<string | null> {
+        if (!this.worktreeRel) return null;
+        const r = await this.req({ kind: 'worktree', op: 'diff', taskId: this.taskId });
+        if (!r.ok) {
+            logger.warn(`[${this.taskId}] worktree diff 실패: ${r.error}`);
+            return null;
+        }
+        const out = (r.stdout ?? '').slice(0, LOCAL_BRIDGE.OUTPUT_CAP);
+        return out.trim() === '' ? null : out;
     }
 
     /**
@@ -103,7 +152,7 @@ export class RemoteExecutor implements TaskExecutor {
         if (buf.byteLength > LOCAL_BRIDGE.MAX_WRITE_BYTES) {
             throw new Error(`파일이 너무 큽니다 (${buf.byteLength}b > ${LOCAL_BRIDGE.MAX_WRITE_BYTES}b)`);
         }
-        const r = await this.req({ kind: 'write', path: relPath, contentB64: buf.toString('base64') });
+        const r = await this.req({ kind: 'write', path: this.scoped(relPath), contentB64: buf.toString('base64') });
         if (!r.ok) throw new Error(r.error ?? '로컬 파일 쓰기 실패');
     }
 
@@ -117,29 +166,44 @@ export class RemoteExecutor implements TaskExecutor {
     }
 
     async readFile(relPath: string): Promise<string> {
-        const r = await this.req({ kind: 'read', path: relPath });
+        const r = await this.req({ kind: 'read', path: this.scoped(relPath) });
         if (!r.ok) throw new Error(r.error ?? '로컬 파일 읽기 실패');
         return (r.content ?? '').slice(0, LOCAL_BRIDGE.OUTPUT_CAP);
     }
 
     async listDir(relPath = '.'): Promise<string[]> {
-        const r = await this.req({ kind: 'list', path: relPath });
+        const r = await this.req({ kind: 'list', path: this.scoped(relPath) });
         if (!r.ok) throw new Error(r.error ?? '로컬 디렉토리 조회 실패');
         return r.entries ?? [];
     }
 
+    /** listAll 은 연결 폴더 전체를 훑으므로, 격리 시 worktree 하위만 남기고 prefix 를 벗긴다. */
     async listWorkspaceFiles(): Promise<string[]> {
         const r = await this.req({ kind: 'listAll' });
-        return r.ok ? (r.entries ?? []) : [];
+        const all = r.ok ? (r.entries ?? []) : [];
+        if (!this.worktreeRel) return all;
+        const prefix = `${this.worktreeRel}/`;
+        return all.filter((p) => p.startsWith(prefix)).map((p) => p.slice(prefix.length));
     }
 
     async deleteFile(relPath: string): Promise<void> {
-        const r = await this.req({ kind: 'delete', path: relPath });
+        const r = await this.req({ kind: 'delete', path: this.scoped(relPath) });
         if (!r.ok) throw new Error(r.error ?? '로컬 파일 삭제 실패');
     }
 
-    /** 종료 통지만 — 사용자 폴더는 절대 삭제하지 않는다(removeWorkspace 무시). */
+    /**
+     * 종료 통지 + worktree 정리 — 사용자 폴더는 절대 삭제하지 않는다(removeWorkspace 무시).
+     * worktree 도 **변경분이 없을 때만** 제거한다(디바이스가 판단). 변경이 남아 있으면 브랜치와
+     * 함께 보존해 사용자가 검토·머지할 수 있게 한다.
+     */
     async cleanup(): Promise<void> {
+        if (this.worktreeRel) {
+            const r = await this.req({ kind: 'worktree', op: 'remove', taskId: this.taskId })
+                .catch(() => ({ ok: false } as BridgeResult));
+            if (r.ok) {
+                logger.info(`[${this.taskId}] worktree ${r.kept ? `보존 (branch=${this.worktreeBranch})` : '정리 완료'}`);
+            }
+        }
         await this.req({ kind: 'task_end' }).catch(() => { /* best-effort */ });
         logger.info(`[${this.taskId}] 로컬 실행기 세션 종료 통지`);
     }

--- a/apps/api/src/services/local-bridge/worktree.test.ts
+++ b/apps/api/src/services/local-bridge/worktree.test.ts
@@ -1,0 +1,134 @@
+/**
+ * RemoteExecutor worktree 격리 라우팅 테스트.
+ *
+ * 로컬 실행기는 사용자 머신에서 직접 파일을 만지므로, 격리가 걸린 뒤에는 **모든 경로가
+ * worktree 하위로 라우팅**되어야 한다. 하나라도 새면 사용자의 현재 작업트리를 건드린다.
+ * 격리 실패 시에는 기존 동작(연결 폴더 직접 작업)으로 폴백해야 한다 — 지금 되던 작업이
+ * 죽으면 안 되기 때문이다.
+ */
+const requests: Array<Record<string, unknown>> = [];
+let respond: (p: Record<string, unknown>) => Record<string, unknown>;
+
+jest.mock('./registry', () => ({
+    getLocalBridgeRegistry: () => ({
+        getDevice: () => ({ deviceId: 'dev-1', label: 'MacBook', folderName: 'proj' }),
+        request: async (_userId: string, payload: Record<string, unknown>) => {
+            requests.push(payload);
+            return respond(payload);
+        },
+    }),
+}));
+
+import { RemoteExecutor } from './remote-executor';
+
+const WT_REL = '.openmake/worktrees/task-abcdef12';
+const BRANCH = 'omk-task/task-abc';
+
+/** worktree add 를 성공시키는 기본 응답기. */
+const okResponder = (p: Record<string, unknown>): Record<string, unknown> => {
+    if (p.kind === 'worktree' && p.op === 'add') return { ok: true, worktreeRel: WT_REL, branch: BRANCH };
+    if (p.kind === 'worktree' && p.op === 'diff') return { ok: true, stdout: 'diff --git a/x b/x\n+hello' };
+    if (p.kind === 'worktree' && p.op === 'remove') return { ok: true, kept: false };
+    if (p.kind === 'listAll') return { ok: true, entries: [`${WT_REL}/src/a.ts`, 'other/b.ts'] };
+    return { ok: true, stdout: '', entries: [], content: '' };
+};
+
+beforeEach(() => {
+    requests.length = 0;
+    respond = okResponder;
+});
+
+async function isolated(): Promise<RemoteExecutor> {
+    const ex = new RemoteExecutor('task-abcdef12', 'user-1');
+    await ex.create();
+    requests.length = 0; // create 왕복은 이후 검증에서 제외
+    return ex;
+}
+
+describe('worktree 격리 — 경로 라우팅', () => {
+    it('create 가 worktree 를 요청하고 브랜치를 노출한다', async () => {
+        const ex = new RemoteExecutor('task-abcdef12', 'user-1');
+        await ex.create();
+        expect(requests).toContainEqual(expect.objectContaining({ kind: 'worktree', op: 'add', taskId: 'task-abcdef12' }));
+        expect(ex.isolatedBranch).toBe(BRANCH);
+    });
+
+    it('파일 쓰기·읽기·삭제 경로가 worktree 하위로 라우팅된다', async () => {
+        const ex = await isolated();
+        await ex.writeFile('src/a.ts', 'x');
+        await ex.readFile('src/a.ts');
+        await ex.deleteFile('src/a.ts');
+        for (const r of requests) expect(r.path).toBe(`${WT_REL}/src/a.ts`);
+    });
+
+    it('디렉토리 목록의 기본 경로(.)는 worktree 루트로 해석된다', async () => {
+        const ex = await isolated();
+        await ex.listDir();
+        expect(requests[0].path).toBe(WT_REL);
+    });
+
+    it('exec 는 worktree 로 이동해 실행된다', async () => {
+        const ex = await isolated();
+        await ex.exec('npm test');
+        expect(requests[0]).toMatchObject({ kind: 'exec', command: `cd ${WT_REL} && npm test` });
+    });
+
+    it('전체 목록은 worktree 하위만 남기고 prefix 를 벗긴다', async () => {
+        const ex = await isolated();
+        expect(await ex.listWorkspaceFiles()).toEqual(['src/a.ts']);
+    });
+});
+
+describe('worktree 격리 — diff·정리', () => {
+    it('captureDiff 가 worktree diff 를 돌려준다', async () => {
+        const ex = await isolated();
+        expect(await ex.captureDiff()).toContain('+hello');
+        expect(requests[0]).toMatchObject({ kind: 'worktree', op: 'diff' });
+    });
+
+    it('변경이 없으면(빈 diff) null — diff 스텝을 남기지 않는다', async () => {
+        const ex = await isolated();
+        respond = (p) => (p.kind === 'worktree' && p.op === 'diff' ? { ok: true, stdout: '  \n' } : okResponder(p));
+        expect(await ex.captureDiff()).toBeNull();
+    });
+
+    it('cleanup 이 worktree 정리 후 세션 종료를 통지한다', async () => {
+        const ex = await isolated();
+        await ex.cleanup();
+        expect(requests.map((r) => `${r.kind}:${r.op ?? ''}`)).toEqual(['worktree:remove', 'task_end:']);
+    });
+});
+
+describe('worktree 격리 실패 시 폴백', () => {
+    it('git 레포가 아니면 격리 없이 기존 경로로 동작한다', async () => {
+        respond = (p) => (p.kind === 'worktree' ? { ok: false, error: 'git 레포가 아닙니다' } : okResponder(p));
+        const ex = new RemoteExecutor('task-abcdef12', 'user-1');
+        await ex.create();
+        requests.length = 0;
+
+        expect(ex.isolatedBranch).toBeNull();
+        await ex.writeFile('src/a.ts', 'x');
+        expect(requests[0].path).toBe('src/a.ts');
+        await ex.exec('npm test');
+        expect(requests[1].command).toBe('npm test');
+        expect(await ex.captureDiff()).toBeNull();
+    });
+
+    it('격리가 없으면 cleanup 이 worktree 정리를 시도하지 않는다', async () => {
+        respond = (p) => (p.kind === 'worktree' ? { ok: false, error: 'git 레포가 아닙니다' } : okResponder(p));
+        const ex = new RemoteExecutor('task-abcdef12', 'user-1');
+        await ex.create();
+        requests.length = 0;
+        await ex.cleanup();
+        expect(requests).toEqual([{ kind: 'task_end' }]);
+    });
+
+    it('디바이스 미연결이면 create 가 throw 한다 (기존 계약 유지)', async () => {
+        jest.resetModules();
+        jest.doMock('./registry', () => ({
+            getLocalBridgeRegistry: () => ({ getDevice: () => null, request: async () => ({ ok: false }) }),
+        }));
+        const { RemoteExecutor: R } = require('./remote-executor');
+        await expect(new R('task-abcdef12', 'user-1').create()).rejects.toThrow('연결된 로컬 디바이스가 없습니다');
+    });
+});

--- a/apps/api/src/services/task-sandbox/executor.ts
+++ b/apps/api/src/services/task-sandbox/executor.ts
@@ -56,6 +56,13 @@ export interface TaskExecutor {
     /** 실행 환경 준비 (docker: 컨테이너 기동 / 원격: 디바이스 세션 확립). 멱등. */
     create(): Promise<void>;
 
+    /**
+     * 실행기가 자체적으로 변경분 diff 를 제공하면 구현한다(로컬 브리지의 worktree — 레포의 실제
+     * HEAD 가 기준점이라 인위적 baseline 커밋이 필요 없다). 미구현이면 호스트측 workspace git
+     * 캡처(code-diff)로 폴백한다. 변경 없음·불가는 null.
+     */
+    captureDiff?(): Promise<string | null>;
+
     /** 셸 명령 실행 — bash 도구의 실행 백엔드. */
     exec(command: string): Promise<ExecResult>;
 

--- a/apps/api/src/services/task-sandbox/runtime.ts
+++ b/apps/api/src/services/task-sandbox/runtime.ts
@@ -117,6 +117,11 @@ export class TaskRuntime {
     /** 호스트 workspace 경로 or null(원격 실행기) — 호스트측 소비자(diff·git·영속)의 가드 기준. */
     get localWorkdir(): string | null { return this.executor.localWorkdir; }
 
+    /** 실행기 자체 diff(로컬 worktree). 미지원이면 null → 호출부가 workspace git 캡처로 폴백. */
+    async captureExecutorDiff(): Promise<string | null> {
+        return this.executor.captureDiff ? this.executor.captureDiff() : null;
+    }
+
     /** 호스트 workspace 절대경로 — 호스트측 git 연산(code-diff·clone·PR)이 의존.
      *  원격 실행기(D1)는 호스트 workspace 가 없으므로 호출부가 사용 전 가드해야 한다. */
     get workspacePath(): string {

--- a/apps/desktop/bridge.js
+++ b/apps/desktop/bridge.js
@@ -190,12 +190,18 @@ async function handleWorktree(m, done) {
 
   if (m.op === 'add') {
     if (!(await isGitRepo())) { done({ ok: false, error: 'git 레포가 아닙니다' }); return; }
+    // worktree 는 **레포 전체**를 체크아웃한다. 연결 폴더가 레포 루트가 아니라 하위 디렉토리면
+    // (예: 레포 /repo 를 두고 /repo/apps/web 을 연결) worktree 루트는 /repo 에 대응하므로,
+    // 에이전트의 상대경로가 그대로면 다른 위치를 가리킨다. show-prefix 만큼 더 내려가 맞춘다.
+    const prefixR = await git(['rev-parse', '--show-prefix'], folderRoot);
+    const sub = prefixR.code === 0 ? prefixR.stdout.trim().replace(/\/+$/, '') : '';
+    const workRel = sub ? `${rel}/${sub}` : rel;
     const gitDirR = await git(['rev-parse', '--absolute-git-dir'], folderRoot);
     if (gitDirR.code === 0) excludeWorktreeDir(gitDirR.stdout.trim());
-    if (fs.existsSync(abs)) { done({ ok: true, worktreeRel: rel, branch }); return; } // 재개 시 재사용
+    if (fs.existsSync(abs)) { done({ ok: true, worktreeRel: workRel, branch }); return; } // 재개 시 재사용
     const r = await git(['worktree', 'add', abs, '-b', branch], folderRoot);
     if (r.code !== 0) { done({ ok: false, error: `worktree 생성 실패: ${(r.stderr || r.stdout).trim().slice(0, 300)}` }); return; }
-    done({ ok: true, worktreeRel: rel, branch });
+    done({ ok: true, worktreeRel: workRel, branch });
     return;
   }
 

--- a/apps/desktop/bridge.js
+++ b/apps/desktop/bridge.js
@@ -138,6 +138,92 @@ function safe(rel) {
   return abs;
 }
 
+// ── worktree 격리 (로컬 실행기) ──────────────────────────────────────────
+// 에이전트가 사용자의 현재 작업트리·브랜치를 직접 건드리지 않도록, 연결 폴더가 git 레포면
+// 별도 worktree(=별도 디렉토리 + 별도 브랜치)를 만들어 그 안에서만 작업하게 한다.
+//
+// 왜 연결 폴더 '안'인가: exec 는 sandbox-exec 로 폴더 밖 쓰기가 커널 차단되고, 파일 kind 는
+// safe() 스코프에 걸린다. 폴더 밖에 만들면 두 방어에 모두 막혀 아무것도 못 한다.
+// 대신 .git/info/exclude 에 등록해 사용자의 git status·.gitignore 를 오염시키지 않는다.
+//
+// git 명령은 **서버 문자열을 쓰지 않고 여기서 인자 배열로 조립**한다(명령 주입 차단).
+// 그래서 confirmExec(사용자 확인) 없이 수행해도 안전하다 — 실행 대상이 고정된 git 연산뿐이다.
+const WORKTREE_DIR = '.openmake/worktrees';
+const WORKTREE_BRANCH_PREFIX = 'omk-task/';
+/** taskId 재검증 — 경로·브랜치명에 들어가므로 UUID 문자만 허용(디렉토리 탈출·옵션 주입 차단). */
+const TASK_ID_RE = /^[a-zA-Z0-9-]{8,64}$/;
+
+function git(args, cwd) {
+  return new Promise((resolve) => {
+    execFile('git', args, { cwd, timeout: EXEC_TIMEOUT_MS, maxBuffer: MAX_BUFFER }, (err, stdout, stderr) => {
+      resolve({ code: err ? (err.code ?? 1) : 0, stdout: String(stdout), stderr: String(stderr) });
+    });
+  });
+}
+
+/** 연결 폴더가 git 작업트리인지. worktree 안에서 재연결한 경우도 정상 동작한다. */
+async function isGitRepo() {
+  const r = await git(['rev-parse', '--is-inside-work-tree'], folderRoot);
+  return r.code === 0 && r.stdout.trim() === 'true';
+}
+
+/** worktree 디렉토리를 로컬 전용 제외 목록에 등록 — 사용자의 .gitignore 는 건드리지 않는다. */
+function excludeWorktreeDir(gitDir) {
+  try {
+    const infoDir = path.join(gitDir, 'info');
+    fs.mkdirSync(infoDir, { recursive: true });
+    const p = path.join(infoDir, 'exclude');
+    const cur = fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : '';
+    if (!cur.split('\n').some((l) => l.trim() === '.openmake/')) {
+      fs.appendFileSync(p, `${cur.endsWith('\n') || cur === '' ? '' : '\n'}.openmake/\n`);
+    }
+  } catch { /* 제외 등록 실패는 치명적이지 않다(사용자 status 에 보일 뿐) */ }
+}
+
+async function handleWorktree(m, done) {
+  if (!folderRoot) { done({ ok: false, error: '폴더가 연결되지 않았습니다' }); return; }
+  const taskId = String(m.taskId || '');
+  if (!TASK_ID_RE.test(taskId)) { done({ ok: false, error: '잘못된 taskId 형식' }); return; }
+  const rel = `${WORKTREE_DIR}/${taskId}`;
+  const abs = path.join(folderRoot, rel);
+  const branch = `${WORKTREE_BRANCH_PREFIX}${taskId.slice(0, 8)}`;
+
+  if (m.op === 'add') {
+    if (!(await isGitRepo())) { done({ ok: false, error: 'git 레포가 아닙니다' }); return; }
+    const gitDirR = await git(['rev-parse', '--absolute-git-dir'], folderRoot);
+    if (gitDirR.code === 0) excludeWorktreeDir(gitDirR.stdout.trim());
+    if (fs.existsSync(abs)) { done({ ok: true, worktreeRel: rel, branch }); return; } // 재개 시 재사용
+    const r = await git(['worktree', 'add', abs, '-b', branch], folderRoot);
+    if (r.code !== 0) { done({ ok: false, error: `worktree 생성 실패: ${(r.stderr || r.stdout).trim().slice(0, 300)}` }); return; }
+    done({ ok: true, worktreeRel: rel, branch });
+    return;
+  }
+
+  if (m.op === 'diff') {
+    if (!fs.existsSync(abs)) { done({ ok: false, error: 'worktree 없음' }); return; }
+    // -N: 새 파일을 인덱스에 '의도만' 등록해 diff 에 포함시킨다(실제 스테이징·커밋은 하지 않음).
+    await git(['add', '-A', '-N', '.'], abs);
+    const r = await git(['diff', 'HEAD'], abs);
+    if (r.code !== 0) { done({ ok: false, error: `diff 실패: ${(r.stderr || '').trim().slice(0, 200)}` }); return; }
+    done({ ok: true, stdout: r.stdout, branch });
+    return;
+  }
+
+  if (m.op === 'remove') {
+    if (!fs.existsSync(abs)) { done({ ok: true, kept: false }); return; }
+    // 변경분이 남아 있으면 **지우지 않는다** — 사용자 디스크의 작업 결과를 임의 삭제하지 않는다.
+    const st = await git(['status', '--porcelain'], abs);
+    if (st.code === 0 && st.stdout.trim() !== '') { done({ ok: true, kept: true, branch }); return; }
+    const r = await git(['worktree', 'remove', '--force', abs], folderRoot);
+    if (r.code !== 0) { done({ ok: true, kept: true, branch }); return; } // 제거 실패도 보존으로 취급
+    await git(['branch', '-D', branch], folderRoot); // 변경 없는 빈 브랜치 정리(실패 무시)
+    done({ ok: true, kept: false, branch });
+    return;
+  }
+
+  done({ ok: false, error: `지원하지 않는 worktree op: ${m.op}` });
+}
+
 function walk(dir, base, out) {
   for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
     const p = path.join(dir, e.name);
@@ -210,6 +296,8 @@ async function handleExec(m, done) {
       }
       return;
     }
+    case 'worktree':
+      await handleWorktree(m, done); return;
     case 'task_end':
       agentBrowser.closeAll();   // 작업 종료 시 브라우저 패널 정리
       done({ ok: true }); return;


### PR DESCRIPTION
## 배경

로컬 실행기(`executor='local'`)는 Docker 격리 없이 **사용자 머신의 연결 폴더에서 직접** 파일을 만집니다. 그래서 두 가지가 걸려 있었습니다.

1. 사용자의 현재 브랜치·작업 중인 파일이 그대로 노출됨
2. **변경분을 볼 방법이 없음** — `code-diff.ts:32` 가 *"사용자 폴더에 git init/commit 을 만들면 안 된다"* 는 이유로 diff 캡처를 통째로 생략합니다

②가 특히 아팠습니다. 로컬 코드 작업의 산출물은 곧 파일 변경인데, 그걸 볼 수단이 없으면 사용자가 결과를 검증할 방법이 없고 완료 판정도 텍스트 답변에만 의존하게 됩니다.

## 접근

연결 폴더가 git 레포면 **별도 worktree(디렉토리 + 브랜치)** 를 만들어 그 안에서만 작업합니다.

`git worktree add` 는 레포의 이력·현재 작업트리를 건드리지 않으므로 위 제약을 위반하지 않습니다. 그리고 **레포의 실제 HEAD 가 기준점**이라 샌드박스처럼 인위적 baseline 커밋을 만들 필요도 없습니다 — `git diff HEAD` 한 줄이면 "이 커밋 기준 에이전트가 무엇을 바꿨나"가 정확히 나옵니다.

## 설계 결정

**worktree 위치는 연결 폴더 안** (`.openmake/worktrees/<taskId>`)
폴더 밖에 두면 exec 의 `sandbox-exec` 프로파일(폴더 밖 쓰기 커널 차단)과 파일 kind 의 `safe()` 스코프에 **모두** 막혀 아무것도 못 합니다. 대신 `.git/info/exclude` 에 등록해 사용자의 `git status`·`.gitignore` 를 오염시키지 않습니다.

**git 명령은 디바이스가 조립**
서버는 `op`(add/diff/remove)와 `taskId` 만 보내고, 실제 git 명령은 `bridge.js` 가 고정 인자 배열로 만듭니다. 명령 주입 여지가 없어 `confirmExec`(사용자 확인) 없이 수행해도 안전합니다 — 실행 대상이 고정된 git 연산뿐입니다. taskId 는 디바이스에서 형식을 재검증합니다.

**정리는 "변경이 없을 때만"**
변경분이 남아 있으면 worktree 와 브랜치를 **보존**해 사용자가 검토·머지합니다. `RemoteExecutor.cleanup` 의 기존 원칙(*"사용자 폴더는 절대 삭제하지 않는다"*)을 그대로 따릅니다.

**폴백**
git 레포가 아니거나 생성 실패면 격리 없이 기존 동작으로 진행합니다(fail-open). 지금 되던 작업이 죽으면 안 되기 때문입니다.

## 변경

- `registry.ts` — `BridgeKind` 에 `worktree` 추가, `op`/`taskId` 페이로드와 `worktreeRel`/`branch`/`kept` 결과
- `bridge.js` — worktree 핸들러(add/diff/remove), `.git/info/exclude` 등록, git 레포 판별
- `remote-executor.ts` — 경로 prefix 라우팅, exec `cd` 감싸기, `captureDiff()`, cleanup 정리
- `executor.ts` / `runtime.ts` — 선택적 `captureDiff()` 인터페이스
- `code-diff.ts` — 실행기 자체 diff 를 우선 사용, 없으면 기존 workspace git 캡처로 폴백
- `agent-task-prompt.ts` — 격리 시 작업 브랜치를 system 에 알려 최종 답변에 명시하게 함

## ⚠️ 배포 시 주의

**데스크톱 앱 변경이 포함됩니다**(`apps/desktop/bridge.js`). 서버만 배포하면 디바이스가 `worktree` kind 를 모르고 `지원하지 않는 kind` 를 반환하는데, 이 경우 서버는 격리 없이 폴백하므로 **동작은 깨지지 않습니다**. 격리를 실제로 쓰려면 앱 재빌드·배포가 필요합니다.

상위 게이트 `LOCAL_EXECUTOR_ENABLED` 가 기본 OFF 라 이 PR 만으로 운영 동작은 바뀌지 않습니다. `LOCAL_BRIDGE_WORKTREE=false` 로 개별 비활성도 가능합니다.


## 구현 중 발견·수정한 결함

리뷰 도중 **레포 하위 폴더를 연결한 경우 경로가 어긋나는 문제**를 발견해 같은 PR 에서 고쳤습니다(커밋 `d59151eb`).

worktree 는 레포 **전체**를 체크아웃합니다. 그래서 레포 `/repo` 를 두고 `/repo/apps/web` 을 연결 폴더로 쓰면, worktree 루트가 `/repo` 에 대응하므로 에이전트의 상대경로 `src/a.txt` 가 `<wt>/src/a.txt` 로 해석돼 **의도한 파일과 전혀 다른 위치**를 가리킵니다.

`git rev-parse --show-prefix` 만큼 더 내려간 경로를 `worktreeRel` 로 돌려주도록 고쳤고, 실제 git 으로 확인했습니다:

```
show-prefix: [apps/web/]
worktree 루트 내용: apps
<wt>/apps/web/src/a.txt 존재? YES
<wt>/src/a.txt        존재? NO
```

같은 임시 레포로 diff·remove 도 확인했습니다 — `git add -A -N` 후 `git diff HEAD` 가 수정 파일과 **신규 파일을 모두** 잡고, `status --porcelain` 으로 변경 유무 판정이 정상 동작합니다.

## 검증

- 신규 유닛 11건 — 경로 라우팅(write/read/delete/list/listAll), exec 감싸기, diff 캡처, 빈 diff → null, cleanup 순서, **격리 실패 시 폴백 전량**
- 전체 jest 2565건 통과 · tsc · 600줄 가드 · lint 0 errors · routing 93.3% · response 100%
- `node --check apps/desktop/bridge.js` 문법 확인

라이브 E2E 는 데스크톱 앱 재빌드가 선행돼야 해서 이 PR 에는 포함하지 못했습니다.


## 알려진 한계 (이번 범위 밖)

**로컬 브라우저 다운로드는 연결 폴더 루트로 떨어집니다.** `agent-browser.js` 가 `getFolderRoot()`(연결 폴더)를 다운로드 위치로 쓰는데, 폴더 연결 시점에 1회 설정되므로 어느 task 의 worktree 인지 알 수 없습니다. 정확히 맞추려면 브라우저 요청에도 taskId 를 싣고 디바이스가 worktree 경로를 다시 계산해야 하는데(서브패스 포함), 상태 관리가 늘어나 이번 PR 에서는 제외했습니다.

영향은 제한적입니다 — `LOCAL_BRIDGE_BROWSER_ENABLED` 는 기본 OFF 이고, 다운로드 파일이 worktree 밖(연결 폴더 루트)에 생길 뿐 격리가 깨지지는 않습니다.

입력 첨부(`uploads/`)는 `writeFile` 경유라 자동으로 worktree 안에 기록됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)