### PR TITLE
fix(local-bridge): worktree diff 기준점 고정 + 커밋된 작업 보존

### DIFF
--- a/apps/desktop/bridge.js
+++ b/apps/desktop/bridge.js
@@ -180,6 +180,38 @@ function excludeWorktreeDir(gitDir) {
   } catch { /* 제외 등록 실패는 치명적이지 않다(사용자 status 에 보일 뿐) */ }
 }
 
+/**
+ * diff 기준점(worktree 생성 시점 커밋) 저장·조회.
+ *
+ * worktree 메타 디렉토리(`.git/worktrees/<name>/`)에 둔다 — 작업트리 밖이라 diff·status 에
+ * 잡히지 않고, `git worktree remove` 시 함께 정리된다. 읽기 실패 시 'HEAD' 로 폴백한다
+ * (커밋이 있었다면 그 변경은 놓치지만, diff 캡처 자체가 죽지는 않는다).
+ */
+async function worktreeMetaDir(wtAbs) {
+  const r = await git(['rev-parse', '--absolute-git-dir'], wtAbs);
+  return r.code === 0 ? r.stdout.trim() : null;
+}
+
+async function writeBaseSha(wtAbs) {
+  try {
+    const meta = await worktreeMetaDir(wtAbs);
+    const head = await git(['rev-parse', 'HEAD'], wtAbs);
+    if (meta && head.code === 0) fs.writeFileSync(path.join(meta, 'omk-base'), head.stdout.trim());
+  } catch { /* 기준점 기록 실패는 치명적이지 않다(HEAD 폴백) */ }
+}
+
+async function readBaseSha(wtAbs) {
+  try {
+    const meta = await worktreeMetaDir(wtAbs);
+    const p = meta && path.join(meta, 'omk-base');
+    if (p && fs.existsSync(p)) {
+      const sha = fs.readFileSync(p, 'utf8').trim();
+      if (/^[0-9a-f]{7,40}$/.test(sha)) return sha;
+    }
+  } catch { /* noop */ }
+  return 'HEAD';
+}
+
 async function handleWorktree(m, done) {
   if (!folderRoot) { done({ ok: false, error: '폴더가 연결되지 않았습니다' }); return; }
   const taskId = String(m.taskId || '');
@@ -201,6 +233,7 @@ async function handleWorktree(m, done) {
     if (fs.existsSync(abs)) { done({ ok: true, worktreeRel: workRel, branch }); return; } // 재개 시 재사용
     const r = await git(['worktree', 'add', abs, '-b', branch], folderRoot);
     if (r.code !== 0) { done({ ok: false, error: `worktree 생성 실패: ${(r.stderr || r.stdout).trim().slice(0, 300)}` }); return; }
+    await writeBaseSha(abs);
     done({ ok: true, worktreeRel: workRel, branch });
     return;
   }
@@ -209,7 +242,10 @@ async function handleWorktree(m, done) {
     if (!fs.existsSync(abs)) { done({ ok: false, error: 'worktree 없음' }); return; }
     // -N: 새 파일을 인덱스에 '의도만' 등록해 diff 에 포함시킨다(실제 스테이징·커밋은 하지 않음).
     await git(['add', '-A', '-N', '.'], abs);
-    const r = await git(['diff', 'HEAD'], abs);
+    // 기준점은 **worktree 생성 시점의 커밋**이다. HEAD 를 쓰면 에이전트가 중간에 커밋했을 때
+    // 그 변경이 diff 에서 사라진다(2026-08-09 라이브 E2E 에서 실제 발생 — 모델이 작업을 커밋해
+    // diff 에 마지막 미커밋 파일 하나만 남았다).
+    const r = await git(['diff', await readBaseSha(abs)], abs);
     if (r.code !== 0) { done({ ok: false, error: `diff 실패: ${(r.stderr || '').trim().slice(0, 200)}` }); return; }
     done({ ok: true, stdout: r.stdout, branch });
     return;
@@ -218,8 +254,11 @@ async function handleWorktree(m, done) {
   if (m.op === 'remove') {
     if (!fs.existsSync(abs)) { done({ ok: true, kept: false }); return; }
     // 변경분이 남아 있으면 **지우지 않는다** — 사용자 디스크의 작업 결과를 임의 삭제하지 않는다.
+    // 미커밋 변경뿐 아니라 **에이전트가 만든 커밋**도 보존 대상이다(HEAD 가 기준점에서 움직였는지).
     const st = await git(['status', '--porcelain'], abs);
-    if (st.code === 0 && st.stdout.trim() !== '') { done({ ok: true, kept: true, branch }); return; }
+    const head = await git(['rev-parse', 'HEAD'], abs);
+    const moved = head.code === 0 && head.stdout.trim() !== (await readBaseSha(abs));
+    if ((st.code === 0 && st.stdout.trim() !== '') || moved) { done({ ok: true, kept: true, branch }); return; }
     const r = await git(['worktree', 'remove', '--force', abs], folderRoot);
     if (r.code !== 0) { done({ ok: true, kept: true, branch }); return; } // 제거 실패도 보존으로 취급
     await git(['branch', '-D', branch], folderRoot); // 변경 없는 빈 브랜치 정리(실패 무시)


### PR DESCRIPTION
## 배경

#469 로 도입한 worktree 격리를 **라이브 E2E 로 검증하다 실제 결함 두 개**를 발견해 고칩니다. 실제 `apps/desktop/bridge.js` 를 헤드리스로 구동하고(로직 복제가 아니라 배포될 코드 그 자체), 레포 하위 폴더를 연결 폴더로 붙인 시나리오로 돌렸습니다.

## 결함 1 — 에이전트가 커밋하면 diff 가 변경을 놓친다

모델이 worktree 안에서 `git commit` 을 하자 `git diff HEAD` 가 커밋된 변경을 보지 못했습니다. 두 파일을 만들고 커밋한 작업인데 diff 스텝에는 **무관한 파일 1건만** 남았습니다.

```
worktree 커밋 이력: 0548cfe add hello worktree file / 3cd5cb0 init
저장된 diff:       apps/web/feature.txt 하나뿐 (created.txt·existing.txt 누락)
```

**수정**: worktree 생성 시점의 커밋 SHA 를 기준점으로 저장하고 그것과 비교합니다. 저장 위치는 worktree 메타 디렉토리(`.git/worktrees/<name>/omk-base`) — 작업트리 밖이라 diff·status 에 잡히지 않고 `git worktree remove` 시 함께 정리됩니다. 읽기 실패는 `HEAD` 폴백이라 캡처 자체가 죽지는 않습니다.

## 결함 2 — 커밋된 작업이 삭제될 수 있다

정리(remove) 판정이 미커밋 변경(`status --porcelain`)만 봤습니다. 에이전트가 작업을 **커밋해 두면 "깨끗함"으로 오판해 worktree 를 삭제**할 수 있었고, 그러면 커밋된 작업 결과가 사라집니다.

**수정**: HEAD 가 기준점에서 움직였는지도 함께 보고, 어느 쪽이든 변경이 있으면 보존합니다.

## 라이브 E2E 결과 — 11/11 통과

수정 후 재실행(레포 하위 폴더 연결 + 에이전트가 커밋하는 시나리오):

```
✅ worktree 디렉토리 생성
✅ show-prefix 반영 경로에 파일 작업
✅ 신규 파일 내용 — hello worktree
✅ 기존 파일 수정 — modified by agent
✅ 사용자 원본 파일 불변 — original content
✅ 사용자 폴더에 신규 파일 없음
✅ 사용자 브랜치 불변
✅ 사용자 git status 청결(.openmake 제외됨)
✅ 작업 브랜치 존재 — omk-task/e8ab0ebe
✅ diff 스텝 영속
✅ diff 에 신규·수정 파일 포함(에이전트가 커밋해도) — created.txt, existing.txt
```

보존 판정도 확인했습니다 — 에이전트 커밋(`6fa6d33`)이 있어 worktree 가 정상 보존됐습니다.

부수 확인: 완료 경로가 `completion_path='terminate'`, `judge_verdict='achieved'` 로 기록돼 #467 의 완료 관문도 라이브에서 재확인됐고, 모델이 최종 답변에 작업 브랜치명을 밝혀 프롬프트 안내도 동작했습니다.

## 변경 범위

`apps/desktop/bridge.js` 만 변경합니다(서버 코드 무변경). **데스크톱 앱 재빌드·배포가 필요**합니다 — 구버전 앱은 기준점 파일이 없어 `HEAD` 폴백으로 동작하므로 깨지지는 않지만, 커밋 시 diff 누락이 남습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
