### PR TITLE
feat(local-bridge): 셸 명령 작업 단위 일괄 승인 + 레포 .git 샌드박스 쓰기 허용

### DIFF
--- a/apps/api/src/services/local-bridge/registry.ts
+++ b/apps/api/src/services/local-bridge/registry.ts
@@ -38,7 +38,10 @@ export interface BridgeRequestPayload {
     contentB64?: string;
     /** worktree 전용 — 수행할 연산. */
     op?: WorktreeOp;
-    /** worktree 전용 — task 식별자(디렉토리·브랜치명 파생). 디바이스가 형식을 재검증한다. */
+    /**
+     * task 식별자. worktree(디렉토리·브랜치명 파생, 디바이스가 형식 재검증)와 exec·task_end
+     * (디바이스의 **작업 단위 일괄 승인** 범위 식별)에 쓰인다.
+     */
     taskId?: string;
 }
 

--- a/apps/api/src/services/local-bridge/remote-executor.ts
+++ b/apps/api/src/services/local-bridge/remote-executor.ts
@@ -99,7 +99,9 @@ export class RemoteExecutor implements TaskExecutor {
         // 디바이스는 cwd=연결 폴더로 실행하므로, 격리 시 worktree 로 이동해 수행한다.
         // (감싼 문자열이 사용자 확인 창에 그대로 보이므로 어디서 실행되는지 투명하다.)
         const scopedCommand = this.worktreeRel ? `cd ${this.worktreeRel} && ${command}` : command;
-        return toExecResult(await this.req({ kind: 'exec', command: scopedCommand }));
+        // taskId 를 함께 보낸다 — 디바이스가 승인 게이트를 **작업 단위**로 일괄 처리할 수 있게
+        // (에이전트 작업 하나가 셸 명령을 수십 번 부르므로 매번 확인은 실사용이 어렵다).
+        return toExecResult(await this.req({ kind: 'exec', command: scopedCommand, taskId: this.taskId }));
     }
 
     /**
@@ -204,7 +206,8 @@ export class RemoteExecutor implements TaskExecutor {
                 logger.info(`[${this.taskId}] worktree ${r.kept ? `보존 (branch=${this.worktreeBranch})` : '정리 완료'}`);
             }
         }
-        await this.req({ kind: 'task_end' }).catch(() => { /* best-effort */ });
+        // taskId 포함 — 디바이스가 이 작업의 일괄 승인을 즉시 회수한다.
+        await this.req({ kind: 'task_end', taskId: this.taskId }).catch(() => { /* best-effort */ });
         logger.info(`[${this.taskId}] 로컬 실행기 세션 종료 통지`);
     }
 }

--- a/apps/api/src/services/local-bridge/worktree.test.ts
+++ b/apps/api/src/services/local-bridge/worktree.test.ts
@@ -120,7 +120,7 @@ describe('worktree 격리 실패 시 폴백', () => {
         await ex.create();
         requests.length = 0;
         await ex.cleanup();
-        expect(requests).toEqual([{ kind: 'task_end' }]);
+        expect(requests).toEqual([{ kind: 'task_end', taskId: 'task-abcdef12' }]);
     });
 
     it('디바이스 미연결이면 create 가 throw 한다 (기존 계약 유지)', async () => {

--- a/apps/desktop/bridge.js
+++ b/apps/desktop/bridge.js
@@ -9,7 +9,9 @@
 //  - 파일 kind(read/write/list/delete)의 경로는 연결 폴더 realpath 스코프 안에서만
 //    해석 (심링크 탈출 차단)
 //  - exec 3단 방어: ① 명백히 위험한 패턴을 디바이스에서 hard-block(EXEC_DENYLIST)
-//    ② 나머지는 실행 전 매번 사용자 확인(confirmExec) — 서버 승인 설정과 무관한 비우회 게이트
+//    ② 나머지는 실행 전 사용자 확인(confirmExec) — 서버 승인 설정과 무관한 비우회 게이트.
+//       사용자가 원하면 **그 작업 동안만** 일괄 승인할 수 있고(작업 종료·연결 해제 시 회수),
+//       서버가 임의로 켤 수는 없다(선택 주체가 항상 사용자)
 //    ③ 승인된 명령도 OS 샌드박스(sandbox-exec)로 감싸 폴더 밖 쓰기·비밀 읽기를 커널이 차단
 //    (읽기 일반·네트워크는 허용 — 개발 명령 호환. 막는 축은 '파괴'와 '비밀 유출')
 //  - 인증은 앱 세션의 auth_token 쿠키 재사용 (토큰을 디스크에 저장하지 않음)
@@ -17,7 +19,7 @@ const { session, dialog } = require('electron');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execFile } = require('child_process');
+const { execFile, execFileSync } = require('child_process');
 const crypto = require('crypto');
 const WebSocket = require('ws');
 const agentBrowser = require('./agent-browser');
@@ -69,24 +71,43 @@ let statusText = '미연결';
 let onStatusChange = () => {};
 let mainWin = null;          // exec 확인 다이얼로그의 부모 창
 
+/**
+ * 작업 단위 일괄 승인 — 사용자가 "이 작업 동안 모두 실행"을 고른 taskId 집합.
+ *
+ * 에이전트 작업 하나가 셸 명령을 수십 번 부르므로 매번 묻는 것은 실사용이 어렵다(2026-08-09
+ * GUI 검증에서 확인). 범위를 **그 작업으로 한정**해 다른 작업까지 열리지 않게 하고, 작업 종료
+ * (task_end)·폴더 연결 해제 시 즉시 비운다. 나머지 방어(EXEC_DENYLIST hard-block, OS
+ * 샌드박스의 폴더 밖 쓰기·비밀 읽기 차단)는 자동 승인이어도 그대로 적용된다.
+ */
+const autoApproveTasks = new Set();
+
 /** exec 실행 전 사용자 확인(비우회). 거부/취소면 false. 실행될 명령 원문을 그대로 보여준다. */
-async function confirmExec(command) {
+async function confirmExec(command, taskId) {
   // 테스트 훅(개발/E2E 전용): 다이얼로그 없이 자동 승인 (다른 OMK_BRIDGE_* 훅과 동일 계열).
   if (process.env.OMK_BRIDGE_AUTO_APPROVE === '1') return true;
+  if (taskId && autoApproveTasks.has(taskId)) return true;
   const preview = command.length > 800 ? command.slice(0, 800) + '…' : command;
   const r = await dialog.showMessageBox(mainWin || undefined, {
     type: 'warning',
     message: '에이전트가 이 셸 명령을 당신의 컴퓨터에서 실행하려고 합니다',
     detail: `${preview}\n\n연결 폴더: ${folderRoot}\n${SANDBOX_ENABLED && sandboxProfilePath
       ? 'OS 샌드박스 적용: 폴더 밖 쓰기와 비밀 파일(.ssh/.aws 등) 읽기는 차단됩니다. 그 외 읽기·네트워크는 허용됩니다.'
-      : '⚠️ 샌드박스 미적용: 이 명령은 당신 계정 권한으로 폴더 밖 파일·네트워크에 접근할 수 있습니다.'}`,
-    buttons: ['실행', '거부'],
-    defaultId: 1,
-    cancelId: 1,
+      : '⚠️ 샌드박스 미적용: 이 명령은 당신 계정 권한으로 폴더 밖 파일·네트워크에 접근할 수 있습니다.'}${
+      taskId ? '\n\n"이 작업 동안 모두 실행"을 고르면 이 작업이 끝날 때까지 다시 묻지 않습니다(다른 작업에는 적용되지 않습니다).' : ''}`,
+    buttons: taskId ? ['실행', '이 작업 동안 모두 실행', '거부'] : ['실행', '거부'],
+    defaultId: taskId ? 2 : 1,
+    cancelId: taskId ? 2 : 1,
     noLink: true,
   });
+  if (taskId && r.response === 1) { autoApproveTasks.add(taskId); buildMenuHook(); return true; }
   return r.response === 0;
 }
+
+/** 메뉴 라벨(자동 승인 중 표시) 갱신 훅 — main.js 가 setOnStatusChange 로 주입한 콜백 재사용. */
+function buildMenuHook() { try { onStatusChange(statusText); } catch { /* noop */ } }
+
+/** 현재 일괄 승인 중인 작업 수 — 메뉴 표시용(사용자가 상태를 인지할 수 있게). */
+function autoApprovedCount() { return autoApproveTasks.size; }
 
 function deviceId(app) {
   const p = path.join(app.getPath('userData'), 'device-id');
@@ -104,7 +125,22 @@ function sbq(p) { return `"${String(p).replace(/\\/g, '\\\\').replace(/"/g, '\\"
  * 정책: 기본 allow → 쓰기는 폴더·임시·툴캐시로 제한, 비밀 경로는 읽기 차단.
  * (SBPL 은 last-match-wins 이라 deny 뒤에 allow 를 두어야 예외가 성립한다.)
  */
-function writeSandboxProfile(app, root) {
+/**
+ * 연결 폴더가 git 레포(하위 폴더 포함)면 레포의 .git 절대경로, 아니면 null.
+ * 레포 **하위 폴더**를 연결하면 .git 이 폴더 밖에 있어 샌드박스가 git 쓰기를 막았다 —
+ * 레포 루트를 연결했을 때는 이미 허용되던 쓰기라, 허용해도 권한이 새로 넓어지지 않는다
+ * (같은 레포인데 연결 지점에 따라 동작이 갈리던 비일관성 해소. worktree 커밋의 index.lock 이
+ * `.git/worktrees/<name>/` 에 생겨 2026-08-09 GUI 검증에서 실제 실패로 드러났다).
+ */
+function detectGitDir(root) {
+  try {
+    const out = execFileSync('git', ['rev-parse', '--absolute-git-dir'],
+      { cwd: root, encoding: 'utf8', timeout: 5000 }).trim();
+    return out || null;
+  } catch { return null; }
+}
+
+function writeSandboxProfile(app, root, gitDir) {
     try {
         const home = fs.realpathSync(os.homedir());
         const sub = (base, list) => list.map((d) => `(subpath ${sbq(path.join(base, d))})`).join(' ');
@@ -113,6 +149,8 @@ function writeSandboxProfile(app, root) {
             '(allow default)',
             '(deny file-write*)',
             `(allow file-write* (subpath ${sbq(root)}))`,
+            // 레포 하위 폴더 연결 시 .git 은 폴더 밖 — git(커밋·인덱스) 쓰기를 열어준다(위 detectGitDir 주석).
+            ...(gitDir ? [`(allow file-write* (subpath ${sbq(gitDir)}))`] : []),
             '(allow file-write* (subpath "/private/tmp") (subpath "/private/var/folders") (subpath "/dev"))',
             `(allow file-write* ${sub(home, CACHE_SUBPATHS)})`,
             `(deny file-read* ${sub(home, SECRET_SUBPATHS)})`,
@@ -285,8 +323,8 @@ async function handleExec(m, done) {
       // ① 명백히 위험한 패턴은 확인 없이 즉시 거부 (guardrail).
       const denied = matchDenylist(m.command);
       if (denied) { done({ ok: false, error: `위험 명령으로 차단됨: ${denied}`, exitCode: 126 }); return; }
-      // ② 나머지는 실행 전 사용자 확인 (비우회).
-      if (!(await confirmExec(String(m.command || '')))) {
+      // ② 나머지는 실행 전 사용자 확인 (비우회). 같은 작업 안에서는 사용자가 일괄 승인할 수 있다.
+      if (!(await confirmExec(String(m.command || ''), m.taskId))) {
         done({ ok: false, error: '사용자가 명령 실행을 거부했습니다', exitCode: 126 }); return;
       }
       // ③ OS 샌드박스로 감싸 실행 — 폴더 밖 쓰기·비밀 읽기를 커널이 차단한다.
@@ -345,6 +383,8 @@ async function handleExec(m, done) {
       await handleWorktree(m, done); return;
     case 'task_end':
       agentBrowser.closeAll();   // 작업 종료 시 브라우저 패널 정리
+      // 일괄 승인은 그 작업에만 유효 — 종료 즉시 회수한다.
+      if (m.taskId && autoApproveTasks.delete(m.taskId)) buildMenuHook();
       done({ ok: true }); return;
     default: done({ ok: false, error: `지원하지 않는 kind: ${m.kind}` });
   }
@@ -423,7 +463,7 @@ async function connectFolder(app, backendUrl, win) {
   }
   folderRoot = fs.realpathSync(folder);
   // 연결 폴더 기준으로 exec 샌드박스 프로파일 갱신 (폴더가 바뀌면 스코프도 바뀐다).
-  sandboxProfilePath = SANDBOX_ENABLED ? writeSandboxProfile(app, folderRoot) : null;
+  sandboxProfilePath = SANDBOX_ENABLED ? writeSandboxProfile(app, folderRoot, detectGitDir(folderRoot)) : null;
   await connect(app, backendUrl);
 }
 
@@ -431,6 +471,7 @@ function disconnectFolder() {
   folderRoot = null;
   clearTimeout(reconnectTimer);
   clearInterval(refreshTimer);
+  autoApproveTasks.clear();   // 연결이 끊기면 일괄 승인도 회수한다(다음 연결로 새지 않게).
   try { if (ws) ws.close(); } catch { /* noop */ }
   ws = null;
   setStatus('미연결');
@@ -447,6 +488,10 @@ module.exports = {
    * 개인정보(사용자명 등)가 포함되므로 **로컬 UI 표시에만** 쓰고 서버로 보내지 않는다.
    */
   getFolderPath: () => folderRoot,
+  /** 일괄 승인 중인 작업 수 — 메뉴에 노출해 사용자가 상태를 인지하게 한다. */
+  autoApprovedCount,
+  /** 일괄 승인 전체 해제 — 메뉴에서 즉시 회수할 수 있어야 한다. */
+  clearAutoApprove: () => { autoApproveTasks.clear(); buildMenuHook(); },
   setOnStatusChange: (fn) => { onStatusChange = fn; },
   /** 백엔드 전환 시 재연결 */
   onBackendChanged: (app, backendUrl) => { if (folderRoot) connect(app, backendUrl); },

--- a/apps/desktop/bridge.js
+++ b/apps/desktop/bridge.js
@@ -154,6 +154,12 @@ function writeSandboxProfile(app, root, gitDir) {
             '(allow file-write* (subpath "/private/tmp") (subpath "/private/var/folders") (subpath "/dev"))',
             `(allow file-write* ${sub(home, CACHE_SUBPATHS)})`,
             `(deny file-read* ${sub(home, SECRET_SUBPATHS)})`,
+            // 훅·config 는 커밋에 불필요하면서 영구 코드주입 벡터다 — 에이전트가 .git/hooks 나
+            // core.hooksPath 를 심으면 사용자가 나중에 git 을 쓸 때 **샌드박스 밖에서** 실행된다.
+            // SBPL 은 last-match-wins 라 이 deny 를 **프로파일 맨 끝**에 둔다(레포가 상위 allow
+            // 경로 안에 있어도 확실히 이기도록 — /private/tmp 아래 레포로 실측 검증).
+            // identity 설정이 필요하면 `git -c user.email=...` 인라인을 쓰면 된다.
+            ...(gitDir ? [`(deny file-write* (subpath ${sbq(path.join(gitDir, 'hooks'))}) (literal ${sbq(path.join(gitDir, 'config'))}))`] : []),
             '',
         ].join('\n');
         const p = path.join(app.getPath('userData'), 'exec-sandbox.sb');

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -132,6 +132,10 @@ function buildMenu() {
         },
         { label: '연결 해제', enabled: bridge.isConnected(), click: () => bridge.disconnectFolder() },
         { type: 'separator' },
+        // 셸 명령 일괄 승인 상태 — 켜져 있으면 사용자가 반드시 인지·회수할 수 있어야 한다.
+        { label: `명령 일괄 승인: ${bridge.autoApprovedCount() > 0 ? `${bridge.autoApprovedCount()}개 작업` : '없음'}`, enabled: false },
+        { label: '일괄 승인 모두 해제', enabled: bridge.autoApprovedCount() > 0, click: () => bridge.clearAutoApprove() },
+        { type: 'separator' },
         // D3 — 에이전트 브라우저는 작업 중 화면 하단에 뜬다. 사용자가 언제든 닫을 수 있어야 한다.
         { label: '에이전트 브라우저 닫기', click: () => agentBrowser.closeAll() },
       ],

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmake-desktop",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "private": true,
   "description": "OpenMake LLM 데스크톱 셸 (macOS) — 운영 백엔드(외부 공개 도메인 / 로컬)를 네이티브 창으로",
   "author": "OpenMake Team",


### PR DESCRIPTION
## 배경

worktree 격리(#469, #470)를 실제 GUI(데스크톱 앱 dev 모드)로 검증하다 실사용 문제 두 건이 드러나 고칩니다.

## ① 셸 명령 승인 다이얼로그 반복

에이전트 작업 하나가 셸 명령을 수십 번 부르므로 매번 확인 다이얼로그가 뜨는 것은 실사용이 어렵습니다(사용자 실보고). 다이얼로그에 버튼을 추가합니다:

```
[ 실행 ]  [ 이 작업 동안 모두 실행 ]  [ 거부 ]
```

**설계 원칙**
- 범위는 **그 작업(taskId) 하나로 한정** — 서버가 `exec`/`task_end` 요청에 taskId 를 싣고, 디바이스가 작업 종료·폴더 연결 해제 시 즉시 회수합니다. 다른 작업·다음 작업에는 적용되지 않습니다.
- **선택 주체는 항상 사용자** — 서버 측 자동승인 설정과 별개 계층이며, 서버가 임의로 켤 수 없습니다.
- 일괄 승인 중에도 나머지 방어는 그대로입니다 — `EXEC_DENYLIST` hard-block(sudo·pipe-to-shell·.ssh 등), OS 샌드박스(폴더 밖 쓰기·비밀 파일 읽기 커널 차단).
- 메뉴 `로컬 작업` 에 상태(`명령 일괄 승인: N개 작업`)와 `일괄 승인 모두 해제` 를 노출해 사용자가 항상 인지·회수할 수 있게 했습니다.

## ② 레포 하위 폴더 연결 시 git 사용 불가

GUI 검증 중 에이전트의 `git commit` 이 **`index.lock` 권한 오류**로 실패했습니다. worktree 커밋의 index 는 레포 루트의 `.git/worktrees/<name>/` 에 생기는데, 연결 폴더가 레포 **하위 디렉토리**면 `.git` 이 폴더 밖이라 `sandbox-exec` 가 쓰기를 차단합니다.

이는 worktree 가 만든 문제가 아니라 **기존 비일관성**입니다 — 레포 루트를 연결하면 `.git` 이 폴더 안이라 이미 쓰기가 허용됐고, 하위 폴더를 연결하면 같은 레포인데 막혔습니다. 연결 시점에 `git rev-parse --absolute-git-dir` 로 감지한 `.git` 절대경로를 프로파일에 추가합니다. **권한이 새로 넓어지는 것이 아니라 연결 지점 간 일관성을 맞추는 것**입니다.


## ③ 하드닝 — .git 쓰기에서 훅·config 차단 (점검 중 추가)

②로 `.git` 쓰기를 열면 에이전트가 `.git/hooks/*` 나 `core.hooksPath`(config)를 심을 수 있고, 이는 사용자가 나중에 git 을 쓸 때 **샌드박스 밖에서** 실행되는 영구 코드주입 벡터입니다(레포 루트 연결에선 종전부터 존재하던 구멍 — 이번에 루트·하위 연결 모두 막습니다).

- 커밋에 필요한 경로(index·objects·refs·`worktrees/`)는 그대로, **hooks 디렉토리·config 파일만 deny**
- deny 는 프로파일 **맨 끝** — SBPL last-match-wins 라 레포가 상위 allow 경로 안에 있어도 이기게. 실측으로 확인: 중간 배치 시 `/private/tmp` 아래 레포에서 차단이 무효였음
- `sandbox-exec` 4케이스 검증: 훅 쓰기 ✅차단 · config 쓰기 ✅차단 · 일반 커밋 ✅성공 · worktree 커밋 ✅성공
- identity 필요 시 `git -c user.email=...` 인라인 사용(글로벌 ~/.gitconfig 쓰기는 원래부터 차단)

## GUI 라이브 검증

데스크톱 앱(dev 모드)에서 사용자가 실제 버튼을 눌러 검증했습니다:

- 일괄 승인 1회 → **bash 7턴 재질문 없음**
- **git 커밋 성공**(`142455e agent work`) — 직전 실행에서 index.lock 으로 실패했던 그 명령
- 커밋 후에도 diff 에 신규·수정 파일 **모두 포함** — #470 기준점 고정의 GUI 경로 재확인
- 사용자 원본 파일·브랜치·`git status` 불변, 격리 사본에만 변경 기록
- 작업 종료(`task_end`) 시 일괄 승인 **자동 회수**
- 완료 관문 기록: `completion_path='terminate'`

## 변경 범위

- `apps/desktop/bridge.js` — 일괄 승인 집합·다이얼로그 3버튼·회수 경로·`.git` 감지/프로파일 반영
- `apps/desktop/main.js` — 메뉴 상태 표시·전체 해제
- `remote-executor.ts` / `registry.ts` — `exec`/`task_end` 에 taskId 동봉(프로토콜 주석 갱신)
- `worktree.test.ts` — task_end 페이로드 검증 갱신

**데스크톱 앱 재빌드·배포 필요** — 서버만 배포 시 taskId 는 무시되어 종전(매번 확인)과 동일하게 동작합니다(하위호환).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
