### PR TITLE
feat(admin): 운영 설정 DB 이관(system_settings) + 관리자 시스템 설정 UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,12 @@
 #   - DEFAULT_ADMIN_EMAIL    → 관리자 로그인 email
 #
 # 64-hex 시크릿 생성:  openssl rand -hex 32
+#
+# 💡 운영 설정의 UI 관리 (system_settings): OAuth·웹 검색·운영 알림 webhook·
+#    웹 푸시(VAPID)·LLM 게이트웨이 값은 관리자 UI(관리자 → 시스템 설정)에서도
+#    설정/변경할 수 있습니다. UI 저장값(DB)이 .env 보다 우선하며, UI 에서
+#    "초기화" 하면 .env 값으로 복귀합니다. (아래 ⭐ 필수 5개와 시크릿 키들은
+#    부트스트랩 특성상 .env 전용)
 
 # *******************************************************
 # 🤖 LLM Backend (vLLM via LiteLLM proxy)

--- a/apps/api/src/__tests__/routes/admin-system-settings.routes.test.ts
+++ b/apps/api/src/__tests__/routes/admin-system-settings.routes.test.ts
@@ -1,0 +1,130 @@
+/**
+ * admin-system-settings.routes — admin 전용 운영 설정 API 테스트.
+ *
+ * 무DB — service/audit 은 mock, auth 미들웨어는 role 주입 mock 으로 우회.
+ */
+import express, { type Request, type Response, type NextFunction } from 'express';
+import request from 'supertest';
+
+let currentRole: 'admin' | 'user' = 'admin';
+
+jest.mock('../../auth', () => ({
+    requireAuth: (req: Request & { user?: object }, _res: Response, next: NextFunction) => {
+        req.user = { id: 'test-admin', userId: 'test-admin', role: currentRole };
+        next();
+    },
+    requireAdmin: (req: Request & { user?: { role?: string } }, res: Response, next: NextFunction) => {
+        if (req.user?.role === 'admin') next();
+        else res.status(403).json({ success: false, error: 'FORBIDDEN' });
+    },
+}));
+
+const mockService = {
+    describe: jest.fn().mockReturnValue([
+        { key: 'GOOGLE_CSE_ID', group: 'search', secret: false, requiresRestart: false, source: 'env', isSet: true, value: 'cse' },
+        { key: 'GOOGLE_API_KEY', group: 'search', secret: true, requiresRestart: false, source: 'db', isSet: true },
+    ]),
+    update: jest.fn().mockResolvedValue({ requiresRestart: ['LLM_BASE_URL'] }),
+    reset: jest.fn().mockResolvedValue(true),
+};
+jest.mock('../../services/system-settings-service', () => ({
+    getSystemSettingsService: () => mockService,
+}));
+
+const logAudit = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../services/AuditService', () => ({
+    getAuditService: () => ({ logAudit }),
+}));
+
+import { adminSystemSettingsRouter } from '../../routes/admin-system-settings.routes';
+
+describe('admin-system-settings.routes', () => {
+    let app: express.Express;
+
+    beforeAll(() => {
+        app = express();
+        app.use(express.json());
+        app.use('/api/admin', adminSystemSettingsRouter);
+    });
+
+    beforeEach(() => {
+        currentRole = 'admin';
+        jest.clearAllMocks();
+    });
+
+    test('GET — 설정 뷰 반환 (시크릿은 isSet 만)', async () => {
+        const r = await request(app).get('/api/admin/system-settings');
+        expect(r.status).toBe(200);
+        expect(r.body.data.settings).toHaveLength(2);
+        const secret = r.body.data.settings.find((s: { key: string }) => s.key === 'GOOGLE_API_KEY');
+        expect(secret.value).toBeUndefined();
+    });
+
+    test('GET — 일반 사용자 403', async () => {
+        currentRole = 'user';
+        const r = await request(app).get('/api/admin/system-settings');
+        expect(r.status).toBe(403);
+        expect(mockService.describe).not.toHaveBeenCalled();
+    });
+
+    test('PUT — 정상 저장 시 검증된 값으로 update 호출 + audit(키 목록만)', async () => {
+        const r = await request(app)
+            .put('/api/admin/system-settings')
+            .send({ entries: { GOOGLE_CSE_ID: '  my-cse-id  ', LLM_BASE_URL: 'https://gw.example.com' } });
+        expect(r.status).toBe(200);
+        // registry validate 의 trim 변환이 적용된 값으로 저장
+        expect(mockService.update).toHaveBeenCalledWith(
+            { GOOGLE_CSE_ID: 'my-cse-id', LLM_BASE_URL: 'https://gw.example.com' },
+            'test-admin',
+        );
+        expect(r.body.data.requiresRestart).toEqual(['LLM_BASE_URL']);
+        // audit details 에 값이 실리지 않는다
+        expect(logAudit).toHaveBeenCalledWith(
+            expect.objectContaining({
+                action: 'system_settings.updated',
+                details: { keys: ['GOOGLE_CSE_ID', 'LLM_BASE_URL'], requiresRestart: ['LLM_BASE_URL'] },
+            }),
+        );
+        const auditArg = JSON.stringify(logAudit.mock.calls[0][0]);
+        expect(auditArg).not.toContain('my-cse-id');
+    });
+
+    test('PUT — 허용되지 않은 키 400', async () => {
+        const r = await request(app)
+            .put('/api/admin/system-settings')
+            .send({ entries: { EVIL_KEY: 'x' } });
+        expect(r.status).toBe(400);
+        expect(mockService.update).not.toHaveBeenCalled();
+    });
+
+    test('PUT — 형식 위반 400 (webhook 은 https 필수)', async () => {
+        const r = await request(app)
+            .put('/api/admin/system-settings')
+            .send({ entries: { OPERATOR_WEBHOOK_URL: 'http://insecure.example.com' } });
+        expect(r.status).toBe(400);
+        expect(mockService.update).not.toHaveBeenCalled();
+    });
+
+    test('PUT — 빈 entries 400', async () => {
+        const r = await request(app).put('/api/admin/system-settings').send({ entries: {} });
+        expect(r.status).toBe(400);
+    });
+
+    test('DELETE — env 폴백 복귀 + audit', async () => {
+        const r = await request(app).delete('/api/admin/system-settings/GOOGLE_CSE_ID');
+        expect(r.status).toBe(200);
+        expect(mockService.reset).toHaveBeenCalledWith('GOOGLE_CSE_ID');
+        expect(logAudit).toHaveBeenCalledWith(
+            expect.objectContaining({ action: 'system_settings.reset', details: { key: 'GOOGLE_CSE_ID' } }),
+        );
+    });
+
+    test('DELETE — 허용되지 않은 키 400 / DB 미설정 키 404', async () => {
+        const bad = await request(app).delete('/api/admin/system-settings/EVIL_KEY');
+        expect(bad.status).toBe(400);
+
+        mockService.reset.mockResolvedValueOnce(false);
+        const missing = await request(app).delete('/api/admin/system-settings/GOOGLE_CSE_ID');
+        expect(missing.status).toBe(404);
+    });
+});

--- a/apps/api/src/config/__tests__/system-settings-overlay.test.ts
+++ b/apps/api/src/config/__tests__/system-settings-overlay.test.ts
@@ -1,0 +1,86 @@
+/**
+ * system_settings overlay — config 해석 우선순위(DB > env > 기본값) 검증.
+ */
+import { applySettingsOverlay, getConfig, resetConfig, loadConfig } from '../env';
+import { SYSTEM_SETTINGS_REGISTRY, SETTING_DEFS_BY_KEY } from '../system-settings-registry';
+
+describe('applySettingsOverlay', () => {
+    const ORIGINAL_CSE = process.env.GOOGLE_CSE_ID;
+
+    afterEach(() => {
+        applySettingsOverlay({});
+        if (ORIGINAL_CSE === undefined) delete process.env.GOOGLE_CSE_ID;
+        else process.env.GOOGLE_CSE_ID = ORIGINAL_CSE;
+        resetConfig();
+    });
+
+    it('overlay 값이 process.env 보다 우선한다 (DB > env)', () => {
+        process.env.GOOGLE_CSE_ID = 'env-cse-id';
+        resetConfig();
+        expect(getConfig().googleCseId).toBe('env-cse-id');
+
+        applySettingsOverlay({ GOOGLE_CSE_ID: 'db-cse-id' });
+        expect(getConfig().googleCseId).toBe('db-cse-id');
+    });
+
+    it('overlay 를 비우면 env 값으로 복귀한다 (DELETE = env 폴백)', () => {
+        process.env.GOOGLE_CSE_ID = 'env-cse-id';
+        applySettingsOverlay({ GOOGLE_CSE_ID: 'db-cse-id' });
+        expect(getConfig().googleCseId).toBe('db-cse-id');
+
+        applySettingsOverlay({});
+        expect(getConfig().googleCseId).toBe('env-cse-id');
+    });
+
+    it('applySettingsOverlay 는 캐시를 무효화해 이후 getConfig 호출에 즉시 반영된다', () => {
+        const before = getConfig();
+        applySettingsOverlay({ GOOGLE_CSE_ID: 'fresh-value' });
+        const after = getConfig();
+        expect(after).not.toBe(before);
+        expect(after.googleCseId).toBe('fresh-value');
+    });
+});
+
+describe('system-settings-registry', () => {
+    it('키가 중복 없이 정의되어 있다', () => {
+        const keys = SYSTEM_SETTINGS_REGISTRY.map((d) => d.key);
+        expect(new Set(keys).size).toBe(keys.length);
+        expect(SETTING_DEFS_BY_KEY.size).toBe(keys.length);
+    });
+
+    it('모든 레지스트리 키가 loadConfig 의 safeParse 입력에 배선되어 있다', () => {
+        // 배선 누락(과거 NAVER_API_HUB_* 실버그) 회귀 방지 — overlay 로 넣은 값이
+        // 실제 config 에 도달하는지 키마다 확인한다. 값 검증이 있는 키는 형식을 맞춘다.
+        const sample: Record<string, string> = {};
+        for (const def of SYSTEM_SETTINGS_REGISTRY) {
+            if (def.key === 'NAVER_API_DAILY_LIMIT') sample[def.key] = '777';
+            else if (def.key.startsWith('OPERATOR_WEBHOOK') || def.key === 'OAUTH_REDIRECT_URI' || def.key === 'LLM_BASE_URL')
+                sample[def.key] = 'https://example.com/wired';
+            else if (def.key === 'VAPID_SUBJECT') sample[def.key] = 'mailto:wired@example.com';
+            else sample[def.key] = `wired-${def.key.toLowerCase()}`;
+        }
+        applySettingsOverlay(sample);
+        try {
+            const cfg = loadConfig();
+            const flat = JSON.stringify(cfg);
+            for (const def of SYSTEM_SETTINGS_REGISTRY) {
+                expect(flat).toContain(sample[def.key]);
+            }
+        } finally {
+            applySettingsOverlay({});
+        }
+    });
+
+    it('검증 스키마가 잘못된 형식을 거부한다', () => {
+        const url = SETTING_DEFS_BY_KEY.get('OPERATOR_WEBHOOK_URL')!;
+        expect(url.validate.safeParse('http://insecure.example.com').success).toBe(false);
+        expect(url.validate.safeParse('https://hooks.slack.com/services/x').success).toBe(true);
+
+        const limit = SETTING_DEFS_BY_KEY.get('NAVER_API_DAILY_LIMIT')!;
+        expect(limit.validate.safeParse('abc').success).toBe(false);
+        expect(limit.validate.safeParse('25000').success).toBe(true);
+
+        const anyKey = SETTING_DEFS_BY_KEY.get('GOOGLE_CLIENT_ID')!;
+        expect(anyKey.validate.safeParse('').success).toBe(false);
+    });
+});

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -179,6 +179,11 @@ export const envSchema = z
         VAPID_PUBLIC_KEY: z.string().default(''),
         VAPID_PRIVATE_KEY: z.string().default(''),
         VAPID_SUBJECT: z.string().default('mailto:admin@openmake.ai'),
+        // 운영자 알림 webhook (Slack/Discord incoming) — severity 별 URL 우선, 없으면 단일 URL fallback
+        OPERATOR_WEBHOOK_URL: z.string().default(''),
+        OPERATOR_WEBHOOK_URL_CRITICAL: z.string().default(''),
+        OPERATOR_WEBHOOK_URL_WARNING: z.string().default(''),
+        OPERATOR_WEBHOOK_URL_INFO: z.string().default(''),
 
         // Database Pool
         DB_POOL_MAX: positiveIntWithDefault(20),

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -117,6 +117,12 @@ export interface EnvConfig {
     vapidPrivateKey: string;
     vapidSubject: string;
 
+    // 운영자 알림 webhook (monitoring/alerts) — severity 별 URL 우선, 없으면 단일 URL fallback
+    operatorWebhookUrl: string;
+    operatorWebhookUrlCritical: string;
+    operatorWebhookUrlWarning: string;
+    operatorWebhookUrlInfo: string;
+
     // Swagger
     swaggerBaseUrl: string;
 
@@ -239,6 +245,10 @@ const DEFAULT_CONFIG: EnvConfig = {
     vapidPublicKey: '',
     vapidPrivateKey: '',
     vapidSubject: 'mailto:admin@openmake.ai',
+    operatorWebhookUrl: '',
+    operatorWebhookUrlCritical: '',
+    operatorWebhookUrlWarning: '',
+    operatorWebhookUrlInfo: '',
 
     // Swagger
     swaggerBaseUrl: '',
@@ -303,15 +313,37 @@ function parseEnvFile(filePath: string): Record<string, string> {
     return env;
 }
 
+/**
+ * system_settings(DB) overlay — admin 시스템 설정이 env 보다 우선한다.
+ * services/system-settings-service 가 부팅 후·설정 변경 시 applySettingsOverlay 로 주입.
+ * config 모듈은 DB 를 직접 import 하지 않는다 (순환 의존 차단, late-binding).
+ */
+let settingsOverlay: Record<string, string> = {};
+
+/** DB 설정 overlay 교체 + 캐시 무효화 — 이후 getConfig() 호출자부터 새 값 반영 */
+export function applySettingsOverlay(overlay: Record<string, string>): void {
+    settingsOverlay = { ...overlay };
+    resetConfig();
+}
+
+/** overlay 를 제외한 env 원값 (process.env > .env 파일) — 설정 출처(env/기본값) 판별용 */
+export function readRawEnvValue(key: string): string | undefined {
+    const envPath = path.resolve(process.cwd(), '.env');
+    const projectEnvPath = path.resolve(__dirname, '../../.env');
+    const fileEnv = parseEnvFile(fs.existsSync(envPath) ? envPath : projectEnvPath);
+    return process.env[key] || fileEnv[key] || undefined;
+}
+
 export function loadConfig(): EnvConfig {
     // 프로젝트 루트에서 .env 파일 찾기
     const envPath = path.resolve(process.cwd(), '.env');
     const projectEnvPath = path.resolve(__dirname, '../../.env');
 
-    // 환경변수 우선순위: process.env > .env 파일 > 기본값
+    // 환경변수 우선순위: DB overlay(system_settings) > process.env > .env 파일 > 기본값
     const fileEnv = parseEnvFile(fs.existsSync(envPath) ? envPath : projectEnvPath);
 
-    const env = (key: string): string | undefined => process.env[key] || fileEnv[key];
+    const env = (key: string): string | undefined =>
+        settingsOverlay[key] ?? (process.env[key] || fileEnv[key]);
 
     const parsedResult = envSchema.safeParse({
         NODE_ENV: env('NODE_ENV'),
@@ -358,6 +390,9 @@ export function loadConfig(): EnvConfig {
         GOOGLE_CSE_ID: env('GOOGLE_CSE_ID'),
         NAVER_CLIENT_ID: env('NAVER_CLIENT_ID'),
         NAVER_CLIENT_SECRET: env('NAVER_CLIENT_SECRET'),
+        NAVER_API_HUB_KEY_ID: env('NAVER_API_HUB_KEY_ID'),
+        NAVER_API_HUB_KEY: env('NAVER_API_HUB_KEY'),
+        NAVER_API_DAILY_LIMIT: env('NAVER_API_DAILY_LIMIT'),
         GITHUB_TOKEN: env('GITHUB_TOKEN'),
         DOCUMENT_TTL_HOURS: env('DOCUMENT_TTL_HOURS'),
         MAX_UPLOADED_DOCUMENTS: env('MAX_UPLOADED_DOCUMENTS'),
@@ -367,6 +402,10 @@ export function loadConfig(): EnvConfig {
         VAPID_PUBLIC_KEY: env('VAPID_PUBLIC_KEY'),
         VAPID_PRIVATE_KEY: env('VAPID_PRIVATE_KEY'),
         VAPID_SUBJECT: env('VAPID_SUBJECT'),
+        OPERATOR_WEBHOOK_URL: env('OPERATOR_WEBHOOK_URL'),
+        OPERATOR_WEBHOOK_URL_CRITICAL: env('OPERATOR_WEBHOOK_URL_CRITICAL'),
+        OPERATOR_WEBHOOK_URL_WARNING: env('OPERATOR_WEBHOOK_URL_WARNING'),
+        OPERATOR_WEBHOOK_URL_INFO: env('OPERATOR_WEBHOOK_URL_INFO'),
         SWAGGER_BASE_URL: env('SWAGGER_BASE_URL'),
         API_KEY_PEPPER: env('API_KEY_PEPPER'),
         API_KEY_MAX_PER_USER: env('API_KEY_MAX_PER_USER'),
@@ -494,6 +533,12 @@ export function loadConfig(): EnvConfig {
         vapidPublicKey: parsed.VAPID_PUBLIC_KEY ?? DEFAULT_CONFIG.vapidPublicKey,
         vapidPrivateKey: parsed.VAPID_PRIVATE_KEY ?? DEFAULT_CONFIG.vapidPrivateKey,
         vapidSubject: parsed.VAPID_SUBJECT ?? DEFAULT_CONFIG.vapidSubject,
+
+        // Operator webhook
+        operatorWebhookUrl: parsed.OPERATOR_WEBHOOK_URL ?? DEFAULT_CONFIG.operatorWebhookUrl,
+        operatorWebhookUrlCritical: parsed.OPERATOR_WEBHOOK_URL_CRITICAL ?? DEFAULT_CONFIG.operatorWebhookUrlCritical,
+        operatorWebhookUrlWarning: parsed.OPERATOR_WEBHOOK_URL_WARNING ?? DEFAULT_CONFIG.operatorWebhookUrlWarning,
+        operatorWebhookUrlInfo: parsed.OPERATOR_WEBHOOK_URL_INFO ?? DEFAULT_CONFIG.operatorWebhookUrlInfo,
 
         // Swagger
         swaggerBaseUrl: parsed.SWAGGER_BASE_URL ?? DEFAULT_CONFIG.swaggerBaseUrl,

--- a/apps/api/src/config/system-settings-registry.ts
+++ b/apps/api/src/config/system-settings-registry.ts
@@ -1,0 +1,82 @@
+/**
+ * @module config/system-settings-registry
+ * @description system_settings 허용 키 화이트리스트 (L2 config).
+ *
+ * admin 시스템 설정(DB system_settings 테이블)으로 관리 가능한 운영 설정 키를
+ * 정의한다. 여기 없는 키는 API 가 저장을 거부한다 (임의 키 저장 금지).
+ * 해석 우선순위는 DB > env > 기본값 (config/env.ts applySettingsOverlay).
+ *
+ * 범위 제외(계속 .env 전용): DATABASE_URL/PORT(부트스트랩 순환),
+ * JWT_SECRET/API_KEY_PEPPER/TOKEN_ENCRYPTION_KEY(런타임 변경 시 세션·암호문 무효화,
+ * 특히 TOKEN_ENCRYPTION_KEY 는 이 테이블 암호화의 뿌리), CORS_ORIGINS/COOKIE_SECURE
+ * (admin 탈취 시 UI 로 보안 경계 개방 방지).
+ *
+ * @see docs/superpowers/plans/2026-08-12-system-settings-admin-ui.md
+ */
+import { z } from 'zod';
+
+export type SettingGroup = 'oauth' | 'search' | 'alerts' | 'push' | 'llm';
+
+export interface SystemSettingDef {
+    /** env 변수명과 동일한 설정 키 */
+    key: string;
+    group: SettingGroup;
+    /** true 면 AES-256-GCM 암호화 저장 + API 응답에 값 미포함 (write-only) */
+    secret: boolean;
+    /** true 면 저장은 되되 부팅 시 구성 요소(cluster 등)라 재시작 후 반영 */
+    requiresRestart: boolean;
+    /** 키별 형식 검증 — 빈 문자열 저장 금지 (해제는 DELETE 로 env 폴백 복귀) */
+    validate: z.ZodType<string>;
+}
+
+const nonEmpty = z.string().trim().min(1, '값이 비어 있습니다').max(2000, '2000자 이하여야 합니다');
+const httpUrl = nonEmpty.refine((v) => /^https?:\/\//.test(v), 'http(s):// URL 이어야 합니다');
+const httpsUrl = nonEmpty.refine((v) => /^https:\/\//.test(v), 'https:// URL 이어야 합니다');
+const nonNegativeIntString = z
+    .string()
+    .trim()
+    .regex(/^\d+$/, '0 이상의 정수여야 합니다');
+const mailtoOrHttps = nonEmpty.refine(
+    (v) => /^(mailto:|https:\/\/)/.test(v),
+    'mailto: 또는 https:// 형식이어야 합니다',
+);
+
+export const SYSTEM_SETTINGS_REGISTRY: SystemSettingDef[] = [
+    // ── OAuth (소셜 로그인) — 미설정 시 해당 provider 로그인 비활성 ──
+    { key: 'GOOGLE_CLIENT_ID', group: 'oauth', secret: false, requiresRestart: false, validate: nonEmpty },
+    { key: 'GOOGLE_CLIENT_SECRET', group: 'oauth', secret: true, requiresRestart: false, validate: nonEmpty },
+    { key: 'OAUTH_REDIRECT_URI', group: 'oauth', secret: false, requiresRestart: false, validate: httpUrl },
+    { key: 'GITHUB_CLIENT_ID', group: 'oauth', secret: false, requiresRestart: false, validate: nonEmpty },
+    { key: 'GITHUB_CLIENT_SECRET', group: 'oauth', secret: true, requiresRestart: false, validate: nonEmpty },
+    { key: 'KAKAO_CLIENT_ID', group: 'oauth', secret: false, requiresRestart: false, validate: nonEmpty },
+    { key: 'KAKAO_CLIENT_SECRET', group: 'oauth', secret: true, requiresRestart: false, validate: nonEmpty },
+
+    // ── 웹 검색 (Google CSE / Naver) — 미설정 시 해당 검색 소스만 비활성 ──
+    { key: 'GOOGLE_API_KEY', group: 'search', secret: true, requiresRestart: false, validate: nonEmpty },
+    { key: 'GOOGLE_CSE_ID', group: 'search', secret: false, requiresRestart: false, validate: nonEmpty },
+    { key: 'NAVER_CLIENT_ID', group: 'search', secret: false, requiresRestart: false, validate: nonEmpty },
+    { key: 'NAVER_CLIENT_SECRET', group: 'search', secret: true, requiresRestart: false, validate: nonEmpty },
+    { key: 'NAVER_API_HUB_KEY_ID', group: 'search', secret: false, requiresRestart: false, validate: nonEmpty },
+    { key: 'NAVER_API_HUB_KEY', group: 'search', secret: true, requiresRestart: false, validate: nonEmpty },
+    { key: 'NAVER_API_DAILY_LIMIT', group: 'search', secret: false, requiresRestart: false, validate: nonNegativeIntString },
+
+    // ── 운영 알림 webhook — URL 자체가 발송 자격증명이라 전부 secret ──
+    { key: 'OPERATOR_WEBHOOK_URL', group: 'alerts', secret: true, requiresRestart: false, validate: httpsUrl },
+    { key: 'OPERATOR_WEBHOOK_URL_CRITICAL', group: 'alerts', secret: true, requiresRestart: false, validate: httpsUrl },
+    { key: 'OPERATOR_WEBHOOK_URL_WARNING', group: 'alerts', secret: true, requiresRestart: false, validate: httpsUrl },
+    { key: 'OPERATOR_WEBHOOK_URL_INFO', group: 'alerts', secret: true, requiresRestart: false, validate: httpsUrl },
+
+    // ── 웹 푸시 (VAPID) ──
+    { key: 'VAPID_PUBLIC_KEY', group: 'push', secret: false, requiresRestart: false, validate: nonEmpty },
+    { key: 'VAPID_PRIVATE_KEY', group: 'push', secret: true, requiresRestart: false, validate: nonEmpty },
+    { key: 'VAPID_SUBJECT', group: 'push', secret: false, requiresRestart: false, validate: mailtoOrHttps },
+
+    // ── LLM 게이트웨이 — base URL/key 는 cluster manager 가 부팅 시 구성 → 재시작 필요 ──
+    { key: 'LLM_BASE_URL', group: 'llm', secret: false, requiresRestart: true, validate: httpUrl },
+    { key: 'LLM_API_KEY', group: 'llm', secret: true, requiresRestart: true, validate: nonEmpty },
+    { key: 'LLM_DEFAULT_MODEL', group: 'llm', secret: false, requiresRestart: false, validate: nonEmpty },
+];
+
+export const SETTING_DEFS_BY_KEY: ReadonlyMap<string, SystemSettingDef> = new Map(
+    SYSTEM_SETTINGS_REGISTRY.map((def) => [def.key, def]),
+);

--- a/apps/api/src/data/repositories/system-settings-repo.ts
+++ b/apps/api/src/data/repositories/system-settings-repo.ts
@@ -1,0 +1,76 @@
+/**
+ * @module data/repositories/system-settings-repo
+ * @description 운영 설정(system_settings) 저장소 — admin UI 관리, env 폴백.
+ *
+ * 민감 키(is_secret)의 value 는 utils/token-crypto SSoT (AES-256-GCM,
+ * TOKEN_ENCRYPTION_KEY) 로 암호화 저장한다 — server-external-keys-repo 와 동일 패턴.
+ *
+ * @see db/migrations/092_system_settings.sql
+ * @see config/system-settings-registry.ts (허용 키 화이트리스트)
+ */
+import { BaseRepository } from './base-repository';
+import { encryptToken, decryptToken, isDecryptionFailure } from '../../utils/token-crypto';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('SystemSettingsRepo');
+
+export interface SystemSettingRow {
+    key: string;
+    /** 평문 값 — 복호화 실패 시 null (호출자가 미설정 취급) */
+    value: string | null;
+    isSecret: boolean;
+    updatedAt: Date;
+}
+
+interface DbRow {
+    key: string;
+    value: string;
+    is_secret: boolean;
+    updated_at: Date;
+    [key: string]: unknown;
+}
+
+function toRow(row: DbRow): SystemSettingRow {
+    let value: string | null = row.value;
+    if (row.is_secret) {
+        const plain = decryptToken(row.value);
+        // decryptToken 은 fail-open — 실패 시 암호문을 그대로 반환하므로 명시 판별.
+        // 실패한 키는 null(미설정 취급) 로 돌려 env 폴백이 살아나게 한다.
+        if (isDecryptionFailure(plain)) {
+            logger.error(`설정 복호화 실패 (${row.key}) — TOKEN_ENCRYPTION_KEY 확인 필요, env 폴백으로 동작`);
+            value = null;
+        } else {
+            value = plain;
+        }
+    }
+    return { key: row.key, value, isSecret: row.is_secret, updatedAt: row.updated_at };
+}
+
+export class SystemSettingsRepository extends BaseRepository {
+    /** 전체 설정 조회 (시크릿은 복호화, 실패 시 value=null) */
+    async findAll(): Promise<SystemSettingRow[]> {
+        const result = await this.query<DbRow>(`SELECT * FROM system_settings ORDER BY key`);
+        return result.rows.map(toRow);
+    }
+
+    /** 등록/갱신 — 시크릿은 즉시 암호화 저장 */
+    async upsert(key: string, value: string, isSecret: boolean, updatedBy: string | null): Promise<void> {
+        const stored = isSecret ? encryptToken(value) : value;
+        await this.query(
+            `INSERT INTO system_settings (key, value, is_secret, updated_by)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT (key) DO UPDATE SET
+                value = EXCLUDED.value,
+                is_secret = EXCLUDED.is_secret,
+                updated_by = EXCLUDED.updated_by,
+                updated_at = now()`,
+            [key, stored, isSecret, updatedBy],
+        );
+    }
+
+    /** 삭제 — env/기본값 폴백으로 복귀 */
+    async deleteKey(key: string): Promise<boolean> {
+        const result = await this.query(`DELETE FROM system_settings WHERE key = $1`, [key]);
+        return (result.rowCount ?? 0) > 0;
+    }
+}

--- a/apps/api/src/mcp/web-search/providers.ts
+++ b/apps/api/src/mcp/web-search/providers.ts
@@ -15,18 +15,11 @@ import { LLM_TIMEOUTS } from '../../config/timeouts';
 import { getSearchLocale } from '../../i18n/search-locale';
 import { buildNaverSearchRequest } from './naver-client';
 
-/** Google Custom Search API 키 */
-const GOOGLE_API_KEY = getConfig().googleApiKey;
-/** Google Custom Search Engine ID */
-const GOOGLE_CSE_ID = getConfig().googleCseId;
 /** Logger instance */
 const logger = createLogger('WebSearch');
 
-// API 키 미설정 경고
-if (!GOOGLE_API_KEY || !GOOGLE_CSE_ID) {
-    logger.warn('GOOGLE_API_KEY 또는 GOOGLE_CSE_ID가 설정되지 않았습니다.');
-    logger.warn('Google 검색 기능이 비활성화됩니다. .env 파일에 설정하세요.');
-}
+// API 키 미설정 경고 1회 발행 여부 — 키는 런타임 변경(admin 설정) 반영을 위해 호출마다 getConfig() 로 읽는다
+let googleKeyWarned = false;
 
 /**
  * 검색 프로바이더용 fetch — 개별 timeout 과 외부 abort signal 을 결합한다.
@@ -92,14 +85,19 @@ function decodeXmlEntities(text: string): string {
 export async function searchGoogle(query: string, maxResults: number = 10, globalSearch: boolean = true, language: string = 'en', signal?: AbortSignal): Promise<SearchResult[]> {
     const results: SearchResult[] = [];
 
-    if (!GOOGLE_API_KEY || !GOOGLE_CSE_ID) {
+    const { googleApiKey, googleCseId } = getConfig();
+    if (!googleApiKey || !googleCseId) {
+        if (!googleKeyWarned) {
+            googleKeyWarned = true;
+            logger.warn('GOOGLE_API_KEY 또는 GOOGLE_CSE_ID가 설정되지 않아 Google 검색이 비활성화됩니다.');
+        }
         return results;
     }
 
     try {
         // 전세계 검색: 언어/지역 제한 없음
         // 한국어 검색: gl=kr&lr=lang_ko 추가
-        let url = `https://www.googleapis.com/customsearch/v1?key=${GOOGLE_API_KEY}&cx=${GOOGLE_CSE_ID}&q=${encodeURIComponent(query)}&num=${Math.min(maxResults, 10)}`;
+        let url = `https://www.googleapis.com/customsearch/v1?key=${googleApiKey}&cx=${googleCseId}&q=${encodeURIComponent(query)}&num=${Math.min(maxResults, 10)}`;
 
         if (!globalSearch) {
             url += getSearchLocale(language).googleParams;

--- a/apps/api/src/monitoring/alerts.ts
+++ b/apps/api/src/monitoring/alerts.ts
@@ -21,8 +21,33 @@ import nodemailer, { type Transporter } from 'nodemailer';
 import type { Pool } from 'pg';
 import { createLogger } from '../utils/logger';
 import { ALERT_THRESHOLDS } from '../config/timeouts';
+import { getConfig } from '../config/env';
 
 const logger = createLogger('AlertSystem');
+
+/**
+ * config(env + system settings overlay)에서 운영자 webhook URL 을 해석합니다.
+ * getConfig 는 미설정을 '' 로 반환하므로 undefined 로 정규화한다
+ * (webhookUrlBySeverity 는 `?? fallback` 체인이라 '' 가 남으면 fallback 이 죽는다).
+ */
+function resolveOperatorWebhooks(): {
+    url?: string;
+    bySeverity: { info?: string; warning?: string; critical?: string };
+} {
+    const cfg = getConfig();
+    const norm = (s: string): string | undefined => s.trim() || undefined;
+    const url = norm(cfg.operatorWebhookUrl);
+    return {
+        url,
+        bySeverity: {
+            // info 는 명시 시만 발송 (default 미설정 — Slack noise 차단)
+            info: norm(cfg.operatorWebhookUrlInfo),
+            // warning/critical 은 specific 우선, legacy fallback
+            warning: norm(cfg.operatorWebhookUrlWarning) ?? url,
+            critical: norm(cfg.operatorWebhookUrlCritical) ?? url,
+        },
+    };
+}
 
 /** 알림 발송 채널 타입 */
 type AlertChannel = 'console' | 'email' | 'webhook';
@@ -151,14 +176,11 @@ export class AlertSystem {
      * @param config - 알림 설정 (부분 지정 가능, 미지정 항목은 기본값 사용)
      */
     constructor(config?: Partial<AlertConfig>) {
-        // env-driven defaults — config 미지정 시 환경변수로 자동 활성.
+        // env-driven defaults — config 미지정 시 환경변수(getConfig, system settings overlay 포함)로 자동 활성.
         // OPERATOR_WEBHOOK_URL (Slack/Discord incoming webhook) 가 있으면 webhook 채널 자동 추가.
         // severity 별 URL (CRITICAL/WARNING/INFO) 우선, 없으면 legacy 단일 URL fallback.
-        const envWebhookUrl = process.env.OPERATOR_WEBHOOK_URL?.trim();
-        const envWebhookCritical = process.env.OPERATOR_WEBHOOK_URL_CRITICAL?.trim();
-        const envWebhookWarning = process.env.OPERATOR_WEBHOOK_URL_WARNING?.trim();
-        const envWebhookInfo = process.env.OPERATOR_WEBHOOK_URL_INFO?.trim();
-        const anyWebhook = envWebhookUrl || envWebhookCritical || envWebhookWarning || envWebhookInfo;
+        const hooks = resolveOperatorWebhooks();
+        const anyWebhook = hooks.url || hooks.bySeverity.info || hooks.bySeverity.warning || hooks.bySeverity.critical;
         const defaultChannels: ('console' | 'email' | 'webhook')[] = ['console'];
         if (anyWebhook) defaultChannels.push('webhook');
 
@@ -173,14 +195,8 @@ export class AlertSystem {
             },
             cooldownMinutes: config?.cooldownMinutes ?? 15,
             emailConfig: config?.emailConfig,
-            webhookUrl: config?.webhookUrl ?? envWebhookUrl,
-            webhookUrlBySeverity: config?.webhookUrlBySeverity ?? {
-                // info 는 env 명시 시만 발송 (default 미설정 — Slack noise 차단)
-                info: envWebhookInfo,
-                // warning/critical 은 specific 우선, legacy fallback
-                warning: envWebhookWarning ?? envWebhookUrl,
-                critical: envWebhookCritical ?? envWebhookUrl,
-            },
+            webhookUrl: config?.webhookUrl ?? hooks.url,
+            webhookUrlBySeverity: config?.webhookUrlBySeverity ?? hooks.bySeverity,
             cooldownBySeverity: config?.cooldownBySeverity ?? {
                 info: parseInt(process.env.ALERT_COOLDOWN_INFO_MIN ?? '60', 10),
                 warning: parseInt(process.env.ALERT_COOLDOWN_WARNING_MIN ?? '15', 10),
@@ -199,6 +215,25 @@ export class AlertSystem {
         }
 
         logger.info('알림 시스템 초기화됨', { channels: this.config.channels });
+    }
+
+    /**
+     * webhook 채널 구성을 config(env + system settings overlay)에서 다시 해석합니다.
+     *
+     * admin 시스템 설정에서 OPERATOR_WEBHOOK_URL* 변경 시 호출 — 싱글톤이 생성자에서
+     * 1회 읽은 URL 을 재시작 없이 갱신한다. 생성자에 명시 전달된 webhookUrl 설정도
+     * 덮어쓰므로, 런타임 설정 변경 경로에서만 호출할 것.
+     */
+    reloadWebhookChannels(): void {
+        const hooks = resolveOperatorWebhooks();
+        this.config.webhookUrl = hooks.url;
+        this.config.webhookUrlBySeverity = hooks.bySeverity;
+
+        const anyWebhook = !!(hooks.url || hooks.bySeverity.info || hooks.bySeverity.warning || hooks.bySeverity.critical);
+        const idx = this.config.channels.indexOf('webhook');
+        if (anyWebhook && idx < 0) this.config.channels.push('webhook');
+        if (!anyWebhook && idx >= 0) this.config.channels.splice(idx, 1);
+        logger.info('AlertSystem: webhook 채널 재구성됨', { channels: this.config.channels });
     }
 
     /**

--- a/apps/api/src/routes/admin-system-settings.routes.ts
+++ b/apps/api/src/routes/admin-system-settings.routes.ts
@@ -1,0 +1,109 @@
+/**
+ * @module routes/admin-system-settings
+ * @description 운영 설정(system_settings) 관리 — admin 전용.
+ *
+ * 엔드포인트 (모두 requireAuth + requireAdmin, /api/admin 전역 adminLimiter 적용):
+ *   GET    /api/admin/system-settings       — 전체 설정 뷰 (시크릿 값 미포함, 출처 뱃지용 source)
+ *   PUT    /api/admin/system-settings       — 일괄 저장 (body: { entries: { KEY: value } })
+ *   DELETE /api/admin/system-settings/:key  — 삭제 (env/기본값 폴백 복귀)
+ *
+ * 허용 키는 config/system-settings-registry.ts 화이트리스트 — 그 외 400.
+ * 변경은 logAudit 기록 (details 에 키 목록만, 값 절대 미포함) — CRITICAL_ACTIONS
+ * 등록으로 운영 webhook 자동 알림.
+ */
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+import { requireAuth, requireAdmin } from '../auth';
+import { validate } from '../middlewares/validation';
+import { asyncHandler } from '../utils/error-handler';
+import { success, badRequest, notFound } from '../utils/api-response';
+import { getSystemSettingsService } from '../services/system-settings-service';
+import { SETTING_DEFS_BY_KEY } from '../config/system-settings-registry';
+import { getAuditService } from '../services/AuditService';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('AdminSystemSettingsRoutes');
+
+/** 한 번에 저장 가능한 설정 수 상한 — registry 전체(현 24종)보다 넉넉한 방어값 */
+const MAX_ENTRIES_PER_REQUEST = 50;
+
+const putSettingsSchema = z.object({
+    entries: z.record(z.string().max(100), z.string().max(2000)),
+});
+
+function adminUserId(req: Request): string | null {
+    return req.user?.id !== undefined ? String(req.user.id) : null;
+}
+
+async function auditChange(req: Request, action: string, details: Record<string, unknown>): Promise<void> {
+    try {
+        await getAuditService().logAudit({
+            action,
+            userId: adminUserId(req) ?? undefined,
+            resourceType: 'system_settings',
+            details,
+        });
+    } catch (err) {
+        // 감사 실패가 저장 자체를 되돌리진 않지만, 애플리케이션 로그로 복원 가능하게 남긴다.
+        logger.error('시스템 설정 감사 기록 실패 (변경은 반영됨):', { action, details, err });
+    }
+}
+
+export const adminSystemSettingsRouter = Router();
+adminSystemSettingsRouter.use(requireAuth, requireAdmin);
+
+adminSystemSettingsRouter.get('/system-settings', asyncHandler(async (_req: Request, res: Response) => {
+    res.json(success({ settings: getSystemSettingsService().describe() }));
+}));
+
+adminSystemSettingsRouter.put('/system-settings', validate(putSettingsSchema), asyncHandler(async (req: Request, res: Response) => {
+    const { entries } = req.body as z.infer<typeof putSettingsSchema>;
+    const keys = Object.keys(entries);
+    if (keys.length === 0) {
+        res.status(400).json(badRequest('저장할 설정이 없습니다'));
+        return;
+    }
+    if (keys.length > MAX_ENTRIES_PER_REQUEST) {
+        res.status(400).json(badRequest(`설정은 요청당 최대 ${MAX_ENTRIES_PER_REQUEST}건입니다`));
+        return;
+    }
+
+    // 키 화이트리스트 + 키별 형식 검증 (registry validate 는 trim 변환 포함)
+    const validated: Record<string, string> = {};
+    for (const [key, raw] of Object.entries(entries)) {
+        const def = SETTING_DEFS_BY_KEY.get(key);
+        if (!def) {
+            res.status(400).json(badRequest(`허용되지 않은 설정 키: '${key}'`));
+            return;
+        }
+        const parsed = def.validate.safeParse(raw);
+        if (!parsed.success) {
+            const message = parsed.error.issues[0]?.message ?? '형식 오류';
+            res.status(400).json(badRequest(`'${key}': ${message}`));
+            return;
+        }
+        validated[key] = parsed.data;
+    }
+
+    const { requiresRestart } = await getSystemSettingsService().update(validated, adminUserId(req));
+    // details 에는 키 목록만 — 시크릿 포함 값은 절대 기록하지 않는다
+    await auditChange(req, 'system_settings.updated', { keys: Object.keys(validated), requiresRestart });
+    logger.info(`시스템 설정 저장: ${Object.keys(validated).join(', ')}`);
+    res.json(success({ settings: getSystemSettingsService().describe(), requiresRestart }));
+}));
+
+adminSystemSettingsRouter.delete('/system-settings/:key', asyncHandler(async (req: Request, res: Response) => {
+    const key = req.params.key;
+    if (!SETTING_DEFS_BY_KEY.has(key)) {
+        res.status(400).json(badRequest(`허용되지 않은 설정 키: '${key}'`));
+        return;
+    }
+    const deleted = await getSystemSettingsService().reset(key);
+    if (!deleted) {
+        res.status(404).json(notFound(`DB 에 설정되지 않은 키: '${key}' (이미 env/기본값 동작)`));
+        return;
+    }
+    await auditChange(req, 'system_settings.reset', { key });
+    logger.info(`시스템 설정 삭제(env 폴백 복귀): ${key}`);
+    res.json(success({ settings: getSystemSettingsService().describe() }));
+}));

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -20,6 +20,7 @@ export { mcpServerIngestRouter } from './mcp-server-ingest.routes';
 export { mcpCatalogAdminRouter } from './mcp-catalog-admin.routes';
 export { mcpAdminMonitoringRouter } from './mcp-admin-monitoring.routes';
 export { adminModelRolesRouter } from './admin-model-roles.routes';
+export { adminSystemSettingsRouter } from './admin-system-settings.routes';
 
 // 🆕 리팩토링된 라우트
 export { default as chatRouter, setClusterManager as setChatCluster } from './chat.routes';

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -37,6 +37,7 @@ import {
     mcpCatalogAdminRouter,
     mcpAdminMonitoringRouter,
     adminModelRolesRouter,
+    adminSystemSettingsRouter,
     usageRouter,
     nodesRouter,
     setNodesCluster,
@@ -190,6 +191,7 @@ export function setupApiRoutes(
     }));
     app.use('/api/admin/mcp', mcpCatalogAdminRouter);
     app.use('/api/admin', adminModelRolesRouter);
+    app.use('/api/admin', adminSystemSettingsRouter);
     app.use('/api/admin/mcp', mcpAdminMonitoringRouter);
     app.use('/api/admin/agent-task-schedules', adminAgentTaskSchedulesRouter);
     // F2 자가개선 — 프롬프트 제안 검토/승인 (관리자)

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -221,6 +221,15 @@ export class DashboardServer {
             }
         }
 
+        // 시스템 설정(DB system_settings) 로드 → config overlay 적용 (DB > env > 기본값).
+        // 마이그레이션 직후·소비자 초기화 전에 실행. fail-open — 실패해도 env 만으로 부팅 지속.
+        try {
+            const { getSystemSettingsService } = await import('./services/system-settings-service');
+            await getSystemSettingsService().loadAndApply();
+        } catch (err) {
+            console.error('[Server] 시스템 설정 로드 실패 (env 폴백으로 계속):', err);
+        }
+
         // 외부 MCP 서버 초기화 (DB에서 설정 로드 → stdio 연결)
         try {
             const { getUnifiedMCPClient } = await import('./mcp');

--- a/apps/api/src/services/AuditService.ts
+++ b/apps/api/src/services/AuditService.ts
@@ -171,6 +171,9 @@ const CRITICAL_ACTIONS: Record<string, 'info' | 'warning' | 'critical'> = {
     // 키 삭제·회전은 보안 이벤트라 warning 채널(webhook 알림), 생성·수정은 audit 만.
     'api_key.delete': 'warning',
     'api_key.rotate': 'warning',
+    // admin 시스템 설정 변경 (routes/admin-system-settings) — 운영 설정 변조 감지용
+    'system_settings.updated': 'warning',
+    'system_settings.reset': 'warning',
     // info 는 audit 만 (alert webhook 안 보냄)
     // context_overflow 는 사용자 입력 검증 에러(>262K) — 2026-06-15 1M 제거로 흔해져
     // webhook noise 방지 위해 warning→info 강등 (audit 추적 + console 만 유지)

--- a/apps/api/src/services/__tests__/system-settings-service.test.ts
+++ b/apps/api/src/services/__tests__/system-settings-service.test.ts
@@ -1,0 +1,127 @@
+/**
+ * SystemSettingsService — DB overlay 적용·갱신·조회 뷰 검증 (repo mock, 무DB).
+ */
+import { SystemSettingsService } from '../system-settings-service';
+import { applySettingsOverlay, getConfig } from '../../config/env';
+import type { SystemSettingsRepository, SystemSettingRow } from '../../data/repositories/system-settings-repo';
+
+const reloadWebhookChannels = jest.fn();
+jest.mock('../../monitoring/alerts', () => ({
+    getAlertSystem: () => ({ reloadWebhookChannels }),
+}));
+
+// 실 DB 접근 차단 — 서비스는 명시 주입 repo 만 쓰지만 default 경로의 getPool 을 막는다
+jest.mock('../../data/models/unified-database', () => ({
+    getPool: () => {
+        throw new Error('테스트에서 실 DB 접근 금지');
+    },
+}));
+
+function makeRepo(rows: SystemSettingRow[]): jest.Mocked<SystemSettingsRepository> {
+    return {
+        findAll: jest.fn().mockResolvedValue(rows),
+        upsert: jest.fn().mockResolvedValue(undefined),
+        deleteKey: jest.fn().mockResolvedValue(true),
+    } as unknown as jest.Mocked<SystemSettingsRepository>;
+}
+
+function row(key: string, value: string | null, isSecret = false): SystemSettingRow {
+    return { key, value, isSecret, updatedAt: new Date() };
+}
+
+afterEach(() => {
+    applySettingsOverlay({});
+    jest.clearAllMocks();
+});
+
+describe('loadAndApply', () => {
+    it('DB 값을 overlay 로 적용하고 소비자 훅을 호출한다', async () => {
+        const repo = makeRepo([row('GOOGLE_CSE_ID', 'db-cse-id')]);
+        const svc = new SystemSettingsService(repo);
+        await svc.loadAndApply();
+
+        expect(getConfig().googleCseId).toBe('db-cse-id');
+        expect(reloadWebhookChannels).toHaveBeenCalled();
+    });
+
+    it('레지스트리 외 키와 복호화 실패(value=null) 키는 제외한다', async () => {
+        const repo = makeRepo([
+            row('UNKNOWN_KEY', 'x'),
+            row('NAVER_API_HUB_KEY', null, true),
+            row('NAVER_CLIENT_ID', 'db-naver-id'),
+        ]);
+        const svc = new SystemSettingsService(repo);
+        await svc.loadAndApply();
+
+        const cfg = getConfig();
+        expect(cfg.naverClientId).toBe('db-naver-id');
+        // 복호화 실패 키는 overlay 미포함 → env/기본값 유지 (db 값 'null' 문자열 아님)
+        const view = svc.describe().find((v) => v.key === 'NAVER_API_HUB_KEY')!;
+        expect(view.source).not.toBe('db');
+    });
+});
+
+describe('update / reset', () => {
+    it('허용되지 않은 키는 거부한다', async () => {
+        const svc = new SystemSettingsService(makeRepo([]));
+        await expect(svc.update({ EVIL_KEY: 'x' }, 'admin-1')).rejects.toThrow('허용되지 않은 설정 키');
+        await expect(svc.reset('EVIL_KEY')).rejects.toThrow('허용되지 않은 설정 키');
+    });
+
+    it('시크릿 여부를 registry 에서 결정해 저장하고 재시작 필요 키를 보고한다', async () => {
+        const repo = makeRepo([]);
+        const svc = new SystemSettingsService(repo);
+        const result = await svc.update(
+            { GOOGLE_CLIENT_SECRET: 'plain-secret', LLM_BASE_URL: 'https://gw.example.com' },
+            'admin-1',
+        );
+
+        expect(repo.upsert).toHaveBeenCalledWith('GOOGLE_CLIENT_SECRET', 'plain-secret', true, 'admin-1');
+        expect(repo.upsert).toHaveBeenCalledWith('LLM_BASE_URL', 'https://gw.example.com', false, 'admin-1');
+        expect(result.requiresRestart).toEqual(['LLM_BASE_URL']);
+        expect(repo.findAll).toHaveBeenCalled(); // 저장 후 재적재
+    });
+
+    it('reset 은 삭제 후 재적재해 env 폴백으로 복귀시킨다', async () => {
+        const repo = makeRepo([]);
+        const svc = new SystemSettingsService(repo);
+        const deleted = await svc.reset('GOOGLE_CSE_ID');
+        expect(deleted).toBe(true);
+        expect(repo.deleteKey).toHaveBeenCalledWith('GOOGLE_CSE_ID');
+        expect(repo.findAll).toHaveBeenCalled();
+    });
+});
+
+describe('describe', () => {
+    it('시크릿 키는 값을 절대 포함하지 않는다 (isSet 만)', async () => {
+        const repo = makeRepo([row('GOOGLE_CLIENT_SECRET', 'top-secret', true)]);
+        const svc = new SystemSettingsService(repo);
+        await svc.loadAndApply();
+
+        for (const view of svc.describe()) {
+            if (view.secret) expect(view).not.toHaveProperty('value');
+        }
+        const secretView = svc.describe().find((v) => v.key === 'GOOGLE_CLIENT_SECRET')!;
+        expect(secretView.source).toBe('db');
+        expect(secretView.isSet).toBe(true);
+    });
+
+    it('출처를 db > env 순으로 판별한다', async () => {
+        const original = process.env.GOOGLE_CSE_ID;
+        process.env.GOOGLE_CSE_ID = 'env-cse';
+        try {
+            const repo = makeRepo([row('NAVER_CLIENT_ID', 'db-naver')]);
+            const svc = new SystemSettingsService(repo);
+            await svc.loadAndApply();
+
+            const views = svc.describe();
+            expect(views.find((v) => v.key === 'NAVER_CLIENT_ID')!.source).toBe('db');
+            const cse = views.find((v) => v.key === 'GOOGLE_CSE_ID')!;
+            expect(cse.source).toBe('env');
+            expect(cse.value).toBe('env-cse');
+        } finally {
+            if (original === undefined) delete process.env.GOOGLE_CSE_ID;
+            else process.env.GOOGLE_CSE_ID = original;
+        }
+    });
+});

--- a/apps/api/src/services/system-settings-service.ts
+++ b/apps/api/src/services/system-settings-service.ts
@@ -1,0 +1,136 @@
+/**
+ * @module services/system-settings-service
+ * @description 운영 설정(system_settings) 해석·전파 서비스.
+ *
+ * DB 설정을 읽어 config 로더의 overlay(applySettingsOverlay)로 주입한다.
+ * 우선순위: DB > env(.env/process.env) > 기본값. 소비자 대다수가 per-call
+ * getConfig() 라 overlay 교체(=resetConfig)만으로 반영되고, AlertSystem 만
+ * 싱글톤 생성자에서 1회 읽으므로 reloadWebhookChannels() 훅을 함께 호출한다.
+ *
+ * 부팅 배선: server.ts 가 마이그레이션 자동 적용 직후 loadAndApply() 를 호출
+ * (fail-open — DB 조회 실패 시 env 만으로 부팅 지속).
+ *
+ * @see config/system-settings-registry.ts (허용 키 화이트리스트)
+ * @see docs/superpowers/plans/2026-08-12-system-settings-admin-ui.md
+ */
+import { applySettingsOverlay, readRawEnvValue } from '../config/env';
+import {
+    SETTING_DEFS_BY_KEY,
+    SYSTEM_SETTINGS_REGISTRY,
+    type SettingGroup,
+} from '../config/system-settings-registry';
+import { SystemSettingsRepository } from '../data/repositories/system-settings-repo';
+import { getPool } from '../data/models/unified-database';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('SystemSettingsService');
+
+/** 설정 1건의 조회 뷰 — 시크릿은 값 미포함 (write-only) */
+export interface SettingView {
+    key: string;
+    group: SettingGroup;
+    secret: boolean;
+    requiresRestart: boolean;
+    /** 유효값의 출처 — db(설정됨) / env(.env·process.env 상속) / default */
+    source: 'db' | 'env' | 'default';
+    /** 값 존재 여부 (시크릿 포함) */
+    isSet: boolean;
+    /** 비시크릿 키의 표시값 (db 또는 env 값). 시크릿은 항상 미포함 */
+    value?: string;
+}
+
+export class SystemSettingsService {
+    private repo: SystemSettingsRepository;
+    /** 마지막 적용 overlay 스냅샷 — describe() 출처 판별용 (시크릿 값 포함, 외부 미노출) */
+    private snapshot: Record<string, string> = {};
+
+    constructor(repo?: SystemSettingsRepository) {
+        this.repo = repo ?? new SystemSettingsRepository(getPool());
+    }
+
+    /**
+     * DB 설정을 읽어 config overlay 로 적용하고 소비자 훅을 갱신합니다.
+     * fail-open: DB 조회 실패 시 기존 overlay 유지(부팅 시엔 빈 overlay = env 동작).
+     */
+    async loadAndApply(): Promise<void> {
+        const rows = await this.repo.findAll();
+        const overlay: Record<string, string> = {};
+        for (const row of rows) {
+            if (!SETTING_DEFS_BY_KEY.has(row.key)) {
+                logger.warn(`레지스트리에 없는 설정 키 무시: ${row.key}`);
+                continue;
+            }
+            if (row.value === null) continue; // 복호화 실패 — repo 가 이미 로깅, env 폴백
+            overlay[row.key] = row.value;
+        }
+        this.snapshot = overlay;
+        applySettingsOverlay(overlay);
+        await this.refreshConsumers();
+        logger.info(`시스템 설정 적용됨 — DB 설정 ${Object.keys(overlay).length}건`);
+    }
+
+    /**
+     * 설정 일괄 저장 (키·형식 검증은 라우트 zod + registry 에서 선행) 후 재적용.
+     * @returns 재시작 후 반영되는 키 목록
+     */
+    async update(entries: Record<string, string>, updatedBy: string | null): Promise<{ requiresRestart: string[] }> {
+        const requiresRestart: string[] = [];
+        for (const [key, value] of Object.entries(entries)) {
+            const def = SETTING_DEFS_BY_KEY.get(key);
+            if (!def) throw new Error(`허용되지 않은 설정 키: ${key}`);
+            await this.repo.upsert(key, value, def.secret, updatedBy);
+            if (def.requiresRestart) requiresRestart.push(key);
+        }
+        await this.loadAndApply();
+        return { requiresRestart };
+    }
+
+    /** 설정 삭제 — env/기본값 폴백으로 복귀 */
+    async reset(key: string): Promise<boolean> {
+        if (!SETTING_DEFS_BY_KEY.has(key)) throw new Error(`허용되지 않은 설정 키: ${key}`);
+        const deleted = await this.repo.deleteKey(key);
+        if (deleted) await this.loadAndApply();
+        return deleted;
+    }
+
+    /** 전체 설정 조회 뷰 — 시크릿 값은 절대 포함하지 않는다 */
+    describe(): SettingView[] {
+        return SYSTEM_SETTINGS_REGISTRY.map((def) => {
+            const dbValue = this.snapshot[def.key];
+            const envValue = readRawEnvValue(def.key);
+            const source: SettingView['source'] =
+                dbValue !== undefined ? 'db' : envValue !== undefined ? 'env' : 'default';
+            const effective = dbValue ?? envValue;
+            return {
+                key: def.key,
+                group: def.group,
+                secret: def.secret,
+                requiresRestart: def.requiresRestart,
+                source,
+                isSet: effective !== undefined && effective !== '',
+                ...(def.secret ? {} : effective !== undefined ? { value: effective } : {}),
+            };
+        });
+    }
+
+    /**
+     * 싱글톤이 생성자에서 config 를 1회 읽는 소비자 갱신.
+     * 현재는 AlertSystem(webhook 채널) 1곳 — 새 훅 추가 시 여기에 배선.
+     * fail-open: 훅 실패가 설정 적용 자체를 죽이지 않는다.
+     */
+    private async refreshConsumers(): Promise<void> {
+        try {
+            const { getAlertSystem } = await import('../monitoring/alerts');
+            getAlertSystem().reloadWebhookChannels();
+        } catch (err) {
+            logger.warn(`설정 소비자 갱신 실패 (무시): ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+}
+
+let instance: SystemSettingsService | null = null;
+
+export function getSystemSettingsService(): SystemSettingsService {
+    if (!instance) instance = new SystemSettingsService();
+    return instance;
+}

--- a/apps/web/app/(workspace)/admin/system-settings/page.tsx
+++ b/apps/web/app/(workspace)/admin/system-settings/page.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { KeyRound, Search, Bell, BellRing, Cpu, Save, RotateCcw, Loader2, AlertTriangle } from "lucide-react";
+import {
+  PageHeader,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  Badge,
+  Button,
+} from "@/components/ui/primitives";
+import { AdminTabs } from "@/components/hub-tabs";
+import type { ApiSuccess } from "@openmake/shared-types";
+import { ApiClient } from "@/lib/api-client";
+
+/* ── 타입 (백엔드 /api/admin/system-settings) ── */
+type SettingGroup = "oauth" | "search" | "alerts" | "push" | "llm";
+interface SettingView {
+  key: string;
+  group: SettingGroup;
+  secret: boolean;
+  requiresRestart: boolean;
+  source: "db" | "env" | "default";
+  isSet: boolean;
+  value?: string;
+}
+interface SettingsPayload {
+  settings: SettingView[];
+}
+
+const GROUP_ORDER: SettingGroup[] = ["llm", "oauth", "search", "alerts", "push"];
+const GROUP_ICONS: Record<SettingGroup, typeof KeyRound> = {
+  oauth: KeyRound,
+  search: Search,
+  alerts: Bell,
+  push: BellRing,
+  llm: Cpu,
+};
+
+const inputCls =
+  "h-9 w-full rounded-md border border-border bg-surface-2 px-3 text-sm text-fg placeholder:text-muted focus:border-accent focus:outline-none";
+
+/** 설정 1행 — 출처 뱃지 + 입력 + 저장/초기화 */
+function SettingRow({ setting, busy, onSave, onReset }: {
+  setting: SettingView;
+  busy: boolean;
+  onSave: (key: string, value: string) => void;
+  onReset: (key: string) => void;
+}) {
+  const t = useTranslations("adminSystemSettings");
+  const [draft, setDraft] = useState("");
+
+  // 비시크릿은 현재 유효값을 프리필 — 시크릿은 항상 빈 입력(write-only)
+  useEffect(() => {
+    if (!setting.secret) setDraft(setting.value ?? "");
+  }, [setting.secret, setting.value]);
+
+  const sourceTone = setting.source === "db" ? "accent" : setting.source === "env" ? "neutral" : "neutral";
+  const sourceLabel =
+    setting.source === "db" ? t("sourceDb") : setting.source === "env" ? t("sourceEnv") : t("sourceDefault");
+  const changed = setting.secret ? draft.trim().length > 0 : draft.trim() !== (setting.value ?? "");
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border p-3 sm:flex-row sm:items-center">
+      <div className="flex min-w-72 flex-wrap items-center gap-2">
+        <code className="text-xs font-medium">{setting.key}</code>
+        <Badge tone={sourceTone} className="shrink-0 whitespace-nowrap">{sourceLabel}</Badge>
+        {setting.requiresRestart && (
+          <Badge tone="warn" className="shrink-0 whitespace-nowrap">{t("restartRequired")}</Badge>
+        )}
+      </div>
+      <input
+        className={inputCls}
+        type={setting.secret ? "password" : "text"}
+        autoComplete="off"
+        placeholder={
+          setting.secret
+            ? setting.isSet ? t("secretSetPlaceholder") : t("secretUnsetPlaceholder")
+            : t("valuePlaceholder")
+        }
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+      />
+      <div className="flex shrink-0 gap-1">
+        <Button size="sm" className="whitespace-nowrap" disabled={busy || !changed}
+          onClick={() => onSave(setting.key, draft.trim())}>
+          {busy ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> : <Save className="h-4 w-4" aria-hidden />}
+          {t("save")}
+        </Button>
+        {setting.source === "db" && (
+          <Button variant="ghost" size="sm" className="whitespace-nowrap" disabled={busy}
+            aria-label={t("reset")} title={t("resetHelp")}
+            onClick={() => onReset(setting.key)}>
+            <RotateCcw className="h-4 w-4" aria-hidden />
+            {t("reset")}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * 운영 설정(system_settings) 관리 — admin 전용.
+ * 우선순위 DB > env > 기본값. 시크릿은 write-only(값 재조회 불가), 변경은 audit 기록.
+ */
+export default function AdminSystemSettingsPage() {
+  const t = useTranslations("adminSystemSettings");
+  const [settings, setSettings] = useState<SettingView[]>([]);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [restartKeys, setRestartKeys] = useState<string[]>([]);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const r = await ApiClient.get<ApiSuccess<SettingsPayload>>("/api/admin/system-settings");
+      setSettings(r?.data?.settings ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("loadError"));
+    }
+  }, [t]);
+
+  useEffect(() => {
+    queueMicrotask(() => void load());
+  }, [load]);
+
+  async function save(key: string, value: string) {
+    setBusyKey(key);
+    setError(null);
+    try {
+      const r = await ApiClient.put<ApiSuccess<SettingsPayload & { requiresRestart: string[] }>>(
+        "/api/admin/system-settings",
+        { entries: { [key]: value } },
+      );
+      if (r?.data?.requiresRestart?.length) {
+        setRestartKeys((prev) => [...new Set([...prev, ...r.data.requiresRestart])]);
+      }
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("saveFailed"));
+    } finally {
+      setBusyKey(null);
+    }
+  }
+
+  async function reset(key: string) {
+    if (!window.confirm(t("resetConfirm", { key }))) return;
+    setBusyKey(key);
+    setError(null);
+    try {
+      await ApiClient.del(`/api/admin/system-settings/${key}`);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("saveFailed"));
+    } finally {
+      setBusyKey(null);
+    }
+  }
+
+  const grouped = useMemo(() => {
+    const map = new Map<SettingGroup, SettingView[]>();
+    for (const g of GROUP_ORDER) map.set(g, []);
+    for (const s of settings) map.get(s.group)?.push(s);
+    return map;
+  }, [settings]);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title={t("title")} description={t("description")} />
+
+      <AdminTabs />
+      {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
+      {restartKeys.length > 0 && (
+        <div className="flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-sm" role="status">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" aria-hidden />
+          <span>{t("restartNotice", { keys: restartKeys.join(", ") })}</span>
+        </div>
+      )}
+
+      {GROUP_ORDER.map((group) => {
+        const items = grouped.get(group) ?? [];
+        if (items.length === 0) return null;
+        const Icon = GROUP_ICONS[group];
+        return (
+          <Card key={group}>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Icon className="h-4 w-4" aria-hidden />
+                {t(`groups.${group}.title`)}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <p className="text-sm text-muted-foreground">{t(`groups.${group}.description`)}</p>
+              {items.map((s) => (
+                <SettingRow key={s.key} setting={s} busy={busyKey === s.key} onSave={save} onReset={reset} />
+              ))}
+            </CardContent>
+          </Card>
+        );
+      })}
+
+      <p className="text-xs text-muted-foreground">{t("priorityNote")}</p>
+    </div>
+  );
+}

--- a/apps/web/components/hub-tabs.tsx
+++ b/apps/web/components/hub-tabs.tsx
@@ -74,6 +74,7 @@ export function AdminTabs() {
         { href: "/admin/alerts", label: tNav("items.alerts") },
         { href: "/admin/mcp-catalog", label: tNav("items.mcpCatalogAdmin") },
         { href: "/admin/model-roles", label: tNav("items.modelRolesAdmin") },
+        { href: "/admin/system-settings", label: tNav("items.systemSettingsAdmin") },
         { href: "/admin/schedules", label: tNav("items.schedulesAdmin") },
       ]}
     />

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -22,6 +22,7 @@
       "alerts": "Alerts",
       "mcpCatalogAdmin": "MCP Catalog Admin",
       "modelRolesAdmin": "Model Roles Admin",
+      "systemSettingsAdmin": "System Settings",
       "developer": "Developer",
       "schedulesAdmin": "Task Schedules"
     },
@@ -1559,6 +1560,47 @@
       "save": "Save",
       "placeholder": "Empty = fallback ({fallback})",
       "cacheNote": "Changes take effect within 60 seconds without a restart."
+    }
+  },
+  "adminSystemSettings": {
+    "title": "System Settings",
+    "description": "Manage operational settings (OAuth, search, alerts, push, LLM gateway). Values saved here (DB) take precedence over .env.",
+    "loadError": "Failed to load.",
+    "saveFailed": "Failed to save.",
+    "save": "Save",
+    "reset": "Reset",
+    "resetHelp": "Delete the DB value and fall back to .env/default.",
+    "resetConfirm": "Delete '{key}' and fall back to env/default?",
+    "sourceDb": "Set in DB",
+    "sourceEnv": "From env",
+    "sourceDefault": "Default",
+    "secretSetPlaceholder": "●●●● set — enter a new value to change",
+    "secretUnsetPlaceholder": "Not set — enter a value",
+    "valuePlaceholder": "Enter a value",
+    "restartRequired": "Restart required",
+    "restartNotice": "Saved. These settings take effect after a server restart: {keys}",
+    "priorityNote": "Precedence: DB (this page) > .env > defaults. Secret values cannot be viewed after saving; every change is audit-logged.",
+    "groups": {
+      "llm": {
+        "title": "LLM Gateway",
+        "description": "LiteLLM gateway URL, key, and default model. URL/key changes apply after a server restart."
+      },
+      "oauth": {
+        "title": "Social Login (OAuth)",
+        "description": "Google/GitHub/Kakao credentials. Providers without credentials are hidden from the login page."
+      },
+      "search": {
+        "title": "Web Search",
+        "description": "Google Custom Search and Naver API keys. Unset keys only disable that search source."
+      },
+      "alerts": {
+        "title": "Operator Alerts",
+        "description": "Slack/Discord incoming webhook URLs. Severity-specific URLs win; otherwise the single URL is used."
+      },
+      "push": {
+        "title": "Web Push (VAPID)",
+        "description": "VAPID keys for browser push notifications. Set the public/private key pair together."
+      }
     }
   },
   "adminSchedules": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -22,6 +22,7 @@
       "alerts": "アラート",
       "mcpCatalogAdmin": "MCPカタログ管理",
       "modelRolesAdmin": "ロールモデル管理",
+      "systemSettingsAdmin": "システム設定",
       "developer": "開発者",
       "schedulesAdmin": "タスクスケジュール"
     },
@@ -1559,6 +1560,47 @@
       "save": "保存",
       "placeholder": "空 = フォールバック ({fallback})",
       "cacheNote": "変更は再起動なしで最大60秒以内に反映されます。"
+    }
+  },
+  "adminSystemSettings": {
+    "title": "システム設定",
+    "description": "運用設定（OAuth・検索・通知・プッシュ・LLM ゲートウェイ）を管理します。ここで保存した値（DB）が .env より優先されます。",
+    "loadError": "読み込みに失敗しました。",
+    "saveFailed": "保存に失敗しました。",
+    "save": "保存",
+    "reset": "リセット",
+    "resetHelp": "DB の値を削除し、.env／デフォルトに戻します。",
+    "resetConfirm": "'{key}' を削除して env／デフォルトに戻しますか？",
+    "sourceDb": "DB 設定済み",
+    "sourceEnv": "env 継承",
+    "sourceDefault": "デフォルト",
+    "secretSetPlaceholder": "●●●● 設定済み — 変更するには新しい値を入力",
+    "secretUnsetPlaceholder": "未設定 — 値を入力してください",
+    "valuePlaceholder": "値を入力してください",
+    "restartRequired": "再起動が必要",
+    "restartNotice": "保存しました。次の設定はサーバー再起動後に反映されます: {keys}",
+    "priorityNote": "優先順位: DB（この画面）> .env > デフォルト。シークレット値は保存後に再表示できず、すべての変更は監査ログに記録されます。",
+    "groups": {
+      "llm": {
+        "title": "LLM ゲートウェイ",
+        "description": "LiteLLM ゲートウェイの URL・キー・デフォルトモデル。URL／キーの変更は再起動後に反映されます。"
+      },
+      "oauth": {
+        "title": "ソーシャルログイン (OAuth)",
+        "description": "Google/GitHub/Kakao の資格情報。未設定のプロバイダはログイン画面に表示されません。"
+      },
+      "search": {
+        "title": "ウェブ検索",
+        "description": "Google Custom Search・Naver 検索 API キー。未設定の場合は該当ソースのみ無効になります。"
+      },
+      "alerts": {
+        "title": "運用アラート",
+        "description": "Slack/Discord incoming webhook URL。重大度別 URL が優先され、なければ単一 URL に送信されます。"
+      },
+      "push": {
+        "title": "ウェブプッシュ (VAPID)",
+        "description": "ブラウザプッシュ通知用の VAPID キー。公開鍵／秘密鍵のペアを一緒に設定してください。"
+      }
     }
   },
   "adminSchedules": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -22,6 +22,7 @@
       "alerts": "알림",
       "mcpCatalogAdmin": "MCP 카탈로그 관리",
       "modelRolesAdmin": "역할 모델 관리",
+      "systemSettingsAdmin": "시스템 설정",
       "developer": "개발자",
       "schedulesAdmin": "작업 스케줄"
     },
@@ -1559,6 +1560,47 @@
       "save": "저장",
       "placeholder": "비움 = 폴백 ({fallback})",
       "cacheNote": "변경은 재시작 없이 최대 60초 내에 반영됩니다."
+    }
+  },
+  "adminSystemSettings": {
+    "title": "시스템 설정",
+    "description": "운영 설정(OAuth·검색·알림·푸시·LLM 게이트웨이)을 관리합니다. UI 저장값(DB)이 .env 보다 우선합니다.",
+    "loadError": "불러오기에 실패했습니다.",
+    "saveFailed": "저장에 실패했습니다.",
+    "save": "저장",
+    "reset": "초기화",
+    "resetHelp": "DB 설정을 삭제하고 .env/기본값으로 복귀합니다.",
+    "resetConfirm": "'{key}' 설정을 삭제하고 env/기본값으로 복귀할까요?",
+    "sourceDb": "DB 설정됨",
+    "sourceEnv": "env 상속",
+    "sourceDefault": "기본값",
+    "secretSetPlaceholder": "●●●● 설정됨 — 변경하려면 새 값 입력",
+    "secretUnsetPlaceholder": "미설정 — 값을 입력하세요",
+    "valuePlaceholder": "값을 입력하세요",
+    "restartRequired": "재시작 필요",
+    "restartNotice": "저장되었습니다. 다음 설정은 서버 재시작 후 반영됩니다: {keys}",
+    "priorityNote": "우선순위: DB(이 화면) > .env > 기본값. 시크릿 값은 저장 후 다시 조회할 수 없으며, 모든 변경은 감사 로그에 기록됩니다.",
+    "groups": {
+      "llm": {
+        "title": "LLM 게이트웨이",
+        "description": "LiteLLM 게이트웨이 주소·키·기본 모델. 주소/키 변경은 서버 재시작 후 반영됩니다."
+      },
+      "oauth": {
+        "title": "소셜 로그인 (OAuth)",
+        "description": "Google/GitHub/Kakao 로그인 자격증명. 미설정 provider 는 로그인 버튼이 표시되지 않습니다."
+      },
+      "search": {
+        "title": "웹 검색",
+        "description": "Google Custom Search·Naver 검색 API 키. 미설정 시 해당 검색 소스만 비활성화됩니다."
+      },
+      "alerts": {
+        "title": "운영 알림",
+        "description": "Slack/Discord incoming webhook URL. 심각도별 URL 이 우선하며, 없으면 단일 URL 로 발송됩니다."
+      },
+      "push": {
+        "title": "웹 푸시 (VAPID)",
+        "description": "브라우저 푸시 알림용 VAPID 키. 공개키/비밀키 쌍을 함께 설정하세요."
+      }
     }
   },
   "adminSchedules": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -22,6 +22,7 @@
       "alerts": "告警",
       "mcpCatalogAdmin": "MCP目录管理",
       "modelRolesAdmin": "角色模型管理",
+      "systemSettingsAdmin": "系统设置",
       "developer": "开发者",
       "schedulesAdmin": "任务计划"
     },
@@ -1559,6 +1560,47 @@
       "save": "保存",
       "placeholder": "留空 = 回退 ({fallback})",
       "cacheNote": "更改无需重启,最多60秒内生效。"
+    }
+  },
+  "adminSystemSettings": {
+    "title": "系统设置",
+    "description": "管理运营设置（OAuth、搜索、通知、推送、LLM 网关）。此处保存的值（DB）优先于 .env。",
+    "loadError": "加载失败。",
+    "saveFailed": "保存失败。",
+    "save": "保存",
+    "reset": "重置",
+    "resetHelp": "删除 DB 中的值并回退到 .env/默认值。",
+    "resetConfirm": "删除 '{key}' 并回退到 env/默认值吗？",
+    "sourceDb": "已在 DB 设置",
+    "sourceEnv": "继承自 env",
+    "sourceDefault": "默认值",
+    "secretSetPlaceholder": "●●●● 已设置 — 输入新值以更改",
+    "secretUnsetPlaceholder": "未设置 — 请输入值",
+    "valuePlaceholder": "请输入值",
+    "restartRequired": "需要重启",
+    "restartNotice": "已保存。以下设置将在服务器重启后生效: {keys}",
+    "priorityNote": "优先级: DB（本页面）> .env > 默认值。密钥值保存后无法再次查看，所有更改都会记录到审计日志。",
+    "groups": {
+      "llm": {
+        "title": "LLM 网关",
+        "description": "LiteLLM 网关地址、密钥与默认模型。地址/密钥更改需重启服务器后生效。"
+      },
+      "oauth": {
+        "title": "社交登录 (OAuth)",
+        "description": "Google/GitHub/Kakao 凭据。未配置的提供商不会显示登录按钮。"
+      },
+      "search": {
+        "title": "网页搜索",
+        "description": "Google Custom Search 与 Naver 搜索 API 密钥。未设置时仅禁用对应搜索源。"
+      },
+      "alerts": {
+        "title": "运营通知",
+        "description": "Slack/Discord incoming webhook URL。按严重级别的 URL 优先，否则使用单一 URL。"
+      },
+      "push": {
+        "title": "网页推送 (VAPID)",
+        "description": "浏览器推送通知的 VAPID 密钥。请同时设置公钥/私钥对。"
+      }
     }
   },
   "adminSchedules": {

--- a/db/init/002-schema.sql
+++ b/db/init/002-schema.sql
@@ -662,3 +662,15 @@ END $$;
 
 -- (구 UIR 스키마(uir_shadow_log/uir_rollout_config/uir_perf_stats)는 090 에서 최종 제거 —
 --  017 이 DROP 했지만 이 baseline 의 CREATE 가 부팅마다 되살리던 결함 해소.)
+
+-- ============================================
+-- system_settings — 운영 설정 DB 이관 (092 와 한 쌍, admin UI 관리·env 폴백)
+-- 우선순위 DB > env > 기본값. 허용 키는 config/system-settings-registry.ts
+-- ============================================
+CREATE TABLE IF NOT EXISTS system_settings (
+    key         TEXT PRIMARY KEY,
+    value       TEXT NOT NULL,
+    is_secret   BOOLEAN NOT NULL DEFAULT false,
+    updated_by  TEXT REFERENCES users(id) ON DELETE SET NULL,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/db/migrations/092_system_settings.sql
+++ b/db/migrations/092_system_settings.sql
@@ -1,0 +1,19 @@
+-- 092: system_settings — 운영 설정 DB 이관 (admin UI 관리, env 폴백)
+--
+-- 배경: curl/npm 패키지 배포 로드맵 — 설치 후 .env 수동 편집 없이 관리자 화면에서
+-- 운영 설정(OAuth/검색/알림/푸시/LLM 게이트웨이)을 입력/변경한다.
+-- 해석 우선순위는 DB > env > 기본값 (config/env.ts applySettingsOverlay).
+-- 허용 키 화이트리스트는 config/system-settings-registry.ts (임의 키 저장 금지).
+-- 민감 키(is_secret=true)의 value 는 utils/token-crypto (AES-256-GCM, v1: prefix) 암호문.
+
+CREATE TABLE IF NOT EXISTS system_settings (
+    key         TEXT PRIMARY KEY,
+    value       TEXT NOT NULL,
+    is_secret   BOOLEAN NOT NULL DEFAULT false,
+    updated_by  TEXT REFERENCES users(id) ON DELETE SET NULL,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE system_settings IS '운영 설정 key-value. 우선순위 DB > env > 기본값. 허용 키는 config/system-settings-registry.ts';
+COMMENT ON COLUMN system_settings.key IS 'env 변수명과 동일한 설정 키 (registry 화이트리스트 내)';
+COMMENT ON COLUMN system_settings.value IS 'is_secret=true 면 v1: AES-256-GCM 암호문, 아니면 평문';

--- a/db/migrations/rollbacks/092_system_settings.sql
+++ b/db/migrations/rollbacks/092_system_settings.sql
@@ -1,0 +1,2 @@
+-- 092 rollback: system_settings 제거
+DROP TABLE IF EXISTS system_settings;


### PR DESCRIPTION
## 요약

curl/npm 패키지 배포 로드맵의 선행 작업 — 설치 후 `.env` 수동 편집 없이 **관리자 → 시스템 설정** 화면에서 운영 설정을 관리한다.

- **범위(24키 화이트리스트)**: OAuth(Google/GitHub/Kakao) · 웹 검색(Google CSE/Naver) · 운영 알림 webhook · 웹 푸시(VAPID) · LLM 게이트웨이
- **우선순위**: DB > env > 기본값 — `config/env.ts` `applySettingsOverlay()` overlay 계층(process.env 변조 없음), UI "초기화"로 env 폴백 복귀
- **보안**: 시크릿은 token-crypto(AES-256-GCM) 암호화 + API 응답 값 미반환(write-only, 관리자도 재조회 불가), 전 변경 audit(`system_settings.updated/reset`=warning, 키 목록만 기록) → 운영 webhook 자동 알림
- **경계**: `DATABASE_URL`/`JWT_SECRET`/`TOKEN_ENCRYPTION_KEY`/`CORS_ORIGINS` 등은 의도적으로 .env 전용 잔류(부트스트랩 순환·보안 경계)
- **전파**: 대부분 저장 즉시 반영(per-call getConfig + resetConfig), `LLM_BASE_URL`/`LLM_API_KEY`만 "재시작 필요" 뱃지(cluster 부팅 구성)

### 선행 배선 결함 3건 동반 수정
1. **실버그**: `NAVER_API_HUB_KEY_ID`/`KEY`/`DAILY_LIMIT`가 loadConfig safeParse 입력에서 누락 — env 설정이 전혀 반영되지 않던 문제
2. web-search Google 키 모듈 로드 상수 → per-call `getConfig()` (런타임 교체 가능)
3. `OPERATOR_WEBHOOK_URL*` 4종 config 로더 편입 + `AlertSystem.reloadWebhookChannels()` 훅(싱글톤 생성자 1회 읽기 한계 보완)

## 체크리스트

- [x] `npm run lint` 통과 (0 errors)
- [x] `npm test` 통과 (2507 passed — 신규 21 tests: overlay/registry/service/routes)
- [x] DB 스키마 변경: 마이그레이션 092 포함 (rollbacks/ + 002-schema 쌍, 순번 충돌 없음)
- [x] `.env.example` 업데이트 (UI 관리 가능 그룹 안내)
- [x] UI 변경: 라이브 스크린샷 검증 완료 (5그룹 카드·출처 뱃지·시크릿 마스킹·재시작 경고)
- [x] 보안 영향: admin 전용(requireAuth+requireAdmin, 401/403 라이브 검증), 시크릿 write-only, 감사 로그 + warning 알림, 허용 키 화이트리스트로 임의 키 저장 차단

## 라이브 E2E (chat.openmake.cc, 운영 반영·검증 완료)

| 검증 | 결과 |
|---|---|
| 비인증 GET | 401 |
| admin GET | 200, 시크릿 값 미포함(isSet만) |
| PUT VAPID_SUBJECT | source=db 전환 + 런타임 즉시 적용 로그 |
| DELETE | source=default 복귀 |
| 허용 외 키 PUT | 400 |
| audit_logs | updated/reset 기록(값 없이 키만) |
| AlertSystem 훅 | 변경 시 webhook 채널 재구성 로그 |

## 후속(별도)

시크릿 자동 생성 + 첫 실행 셋업 마법사 — `docs/superpowers/plans/2026-08-12-system-settings-admin-ui.md` §1-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)