### PR TITLE
feat(chat): 발표자료 디자인 워크플로우 — OD 아티팩트 결정적 에코 + 발표 의도 위임 예외

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1046,6 +1046,11 @@ AGENT_TASK_TIMEOUT_MS=600000
 # REPORT_TEMPLATES_DIR=/path/to/report-templates        # 템플릿 디렉토리 오버라이드 (기본: apps/api/{src|dist}/report-templates)
 # REPORT_TZ=Asia/Seoul                                  # RUN_DATE 계산 TZ (예약 리포트 렌더러와 동일 키)
 
+# 오픈디자인 산출물 결정적 에코 — open-design MCP 도구로 저장한 자체완결 HTML(슬라이드 덱 등)을
+# 모델이 최종 응답 <artifact> 로 옮기지 않으면 서버가 자동 첨부. 기본 ON.
+# OD_ARTIFACT_ECHO_ENABLED=false                        # 비활성화 스위치
+# OD_ARTIFACT_ECHO_TOOLS=open-design::create_artifact,open-design::write_file  # 캡처 대상 도구 이름
+
 # 아티팩트 export (P1 Phase 3) — html 아티팩트 pdf(chromium print)·보고서 docx(python-docx) 변환.
 # task-runtime 이미지(chromium+한글폰트+python-docx) 필요. 기본 OFF.
 # ARTIFACT_EXPORT_ENABLED=true
@@ -1146,7 +1151,7 @@ TASK_SANDBOX_ENABLED=false
 # TASK_SANDBOX_WORKSPACE_TTL_MS=86400000              # 완료 task workspace 보존 TTL(스윕 삭제). 기본 24h
 # TASK_SANDBOX_APPROVAL_POLICY=all                     # all(전부 승인·기본) | high-risk(bash·삭제만) | none(자동)
 # TASK_SANDBOX_APPROVAL_TIMEOUT_MS=1800000             # 승인 대기 timeout(초과 시 자동 거절). 기본 30분
-# TASK_SANDBOX_EXTRA_TOOLS=generate_image,web_search   # 샌드박스 도구와 함께 노출할 내장 도구 화이트리스트(쉼표). 비면 샌드박스 도구만. ⚠️ 호스트 실행 — FS/셸 변경 없는 생성·조회류만 (승인 게이트는 적용됨)
+# TASK_SANDBOX_EXTRA_TOOLS=generate_image,web_search   # 샌드박스 도구와 함께 노출할 내장 도구 화이트리스트(쉼표). 비면 샌드박스 도구만. ⚠️ 호스트 실행 — FS/셸 변경 없는 생성·조회류만 (승인 게이트는 적용됨). user MCP 도구도 "서버명::도구명" 으로 지정 가능 (예: open-design::create_artifact — 발표자료 워크플로우)
 # TASK_SANDBOX_CODE_DIFF_ENABLED=true               # 코드 작업 diff 캡처(openmake_code v1). 시작 시 git baseline → 완료 시 변경분 diff 스텝 기록. false 로 끔
 # AGENT_MAX_TOTAL_TOKENS=1000000                       # agent task 누적 토큰 상한(멀티턴 누적). 기본 1M
 # AGENT_TASK_FINAL_TURN_NUDGE=true                     # 자원 상한 임박 시 마지막 턴의 도구를 제거하고 종합 답변을 유도(기본 on). 상한에서 그냥 끊으면 산출물을 만든 작업도 사족에서 절단됨

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1146,6 +1146,21 @@ export const REPORT_PIPELINE = {
 } as const;
 
 /**
+ * 오픈디자인(open-design MCP) 산출물 결정적 에코 — 도구 루프에서 create_artifact 로
+ * 워크스페이스에 저장한 HTML 을 모델이 최종 응답 <artifact> 로 옮기지 않는 문제(말로만
+ * "아래에서 확인하세요" 안내, 2026-08-14 라이브 실측)의 보정. 생성 이미지·카카오맵·웹검색
+ * 출처·reportdata 와 동일한 결정적 첨부 패턴 — external-deterministic-append 참고.
+ */
+export const OD_ARTIFACT_ECHO = {
+    /** 기본 ON — OD_ARTIFACT_ECHO_ENABLED=false 로 비활성화. */
+    ENABLED: process.env.OD_ARTIFACT_ECHO_ENABLED !== 'false',
+    /** HTML 캡처 대상 도구 이름 콤마 목록 (네임스페이스 포함 전체 이름). */
+    TOOL_NAMES: (process.env.OD_ARTIFACT_ECHO_TOOLS
+        ?? 'open-design::create_artifact,open-design::write_file')
+        .split(',').map((s) => s.trim()).filter(Boolean),
+} as const;
+
+/**
  * 보고서 작성 의도 판정 패턴. 매칭 시 ① report-guide(reportdata JSON 계약) 시스템 프롬프트
  * 주입 ② 아티팩트 의도와 동일한 distractor 도구 억제. 실사용 문구 기반(운영 로그 2026-07):
  * "html 로 보고서를 작성해서 보고해", "보고서 형식으로 만들어줘", "리포트 작성해줘" 류.

--- a/apps/api/src/services/chat-service/__tests__/od-artifact-echo.test.ts
+++ b/apps/api/src/services/chat-service/__tests__/od-artifact-echo.test.ts
@@ -1,0 +1,101 @@
+/**
+ * 오픈디자인 산출물 결정적 에코 테스트 — 캡처 조건·중복 방지·첨부 계약.
+ * (external-deterministic-append 의 captureOdArtifactHtml + odArtifact 첨부 경로)
+ */
+import {
+    captureOdArtifactHtml,
+    appendDeterministicBlocks,
+    normalizeOdToolCall,
+    type OdArtifactCapture,
+} from '../external-deterministic-append';
+import type { ChatMessageRequest } from '../../chat-service-types';
+import type { StreamFromExternalContext } from '../external-provider';
+
+const DECK_HTML = '<!DOCTYPE html>\n<html lang="ko"><head><title>사내 AI 도입 제안</title></head>'
+    + '<body><section class="slide">s1</section></body></html>';
+
+describe('captureOdArtifactHtml', () => {
+    it('자체완결 HTML content 를 title 태그와 함께 캡처한다', () => {
+        const cap = captureOdArtifactHtml({ name: 'deck.html', content: DECK_HTML }, '{"ok":true}');
+        expect(cap).not.toBeNull();
+        expect(cap!.title).toBe('사내 AI 도입 제안');
+        expect(cap!.id).toMatch(/^deck-/);
+        expect(cap!.html).toBe(DECK_HTML);
+    });
+
+    it('title 태그가 없으면 파일명(확장자 제거)을 제목으로 쓴다', () => {
+        const html = '<html><body>x</body></html>';
+        const cap = captureOdArtifactHtml({ path: 'projects/pitch-deck.html', content: html }, 'ok');
+        expect(cap!.title).toBe('pitch-deck');
+    });
+
+    it('HTML 이 아닌 content(CSS 등 부속 파일)는 캡처하지 않는다', () => {
+        expect(captureOdArtifactHtml({ name: 'tokens.css', content: ':root{--x:1}' }, 'ok')).toBeNull();
+    });
+
+    it('실패한 도구 호출(Error 결과)은 캡처하지 않는다', () => {
+        expect(captureOdArtifactHtml({ name: 'deck.html', content: DECK_HTML }, 'Error: 저장 실패')).toBeNull();
+    });
+
+    it('제목의 큰따옴표는 작은따옴표로 강등한다 (artifact 속성 파싱 보호)', () => {
+        const html = '<html><head><title>"AI" 제안</title></head></html>';
+        const cap = captureOdArtifactHtml({ name: 'deck.html', content: html }, 'ok');
+        expect(cap!.title).toBe("'AI' 제안");
+    });
+});
+
+describe('normalizeOdToolCall', () => {
+    it('mcp_call 간접 호출을 server::tool 로 정규화한다', () => {
+        const eff = normalizeOdToolCall('mcp_call', {
+            server: 'open-design',
+            tool: 'create_artifact',
+            args: { name: 'deck.html', content: DECK_HTML },
+        });
+        expect(eff.name).toBe('open-design::create_artifact');
+        expect(eff.args.content).toBe(DECK_HTML);
+    });
+
+    it('직접 호출은 그대로 반환한다', () => {
+        const args = { name: 'deck.html', content: DECK_HTML };
+        const eff = normalizeOdToolCall('open-design::create_artifact', args);
+        expect(eff.name).toBe('open-design::create_artifact');
+        expect(eff.args).toBe(args);
+    });
+});
+
+describe('appendDeterministicBlocks — odArtifact 첨부', () => {
+    function run(finalContent: string, odArtifact: OdArtifactCapture | null): { out: string; streamed: string } {
+        let streamed = '';
+        const out = appendDeterministicBlocks({
+            finalContent,
+            onToken: (t) => { streamed += t; },
+            generatedImageMarkdowns: [],
+            kakaomapBlocks: [],
+            discussionSourceBlocks: [],
+            odArtifact,
+            req: { message: 'm', userId: '3' } as unknown as ChatMessageRequest,
+            ctx: {} as StreamFromExternalContext,
+        });
+        return { out, streamed };
+    }
+
+    const CAP: OdArtifactCapture = { id: 'deck-abc', title: '사내 AI 도입 제안', html: DECK_HTML };
+
+    it('최종 응답에 html 아티팩트가 없으면 결정적으로 첨부한다 (스트림+히스토리 양쪽)', () => {
+        const { out, streamed } = run('덱을 저장했습니다. 아래에서 확인하세요.', CAP);
+        expect(out).toContain('<artifact id="deck-abc" kind="html" title="사내 AI 도입 제안">');
+        expect(out).toContain(DECK_HTML);
+        expect(streamed).toContain('<artifact id="deck-abc"');
+    });
+
+    it('모델이 이미 html 아티팩트를 출력했으면 중복 첨부하지 않는다', () => {
+        const withArtifact = '완성했습니다.\n\n<artifact id="x" kind="html" title="t">\n<html></html>\n</artifact>';
+        const { out } = run(withArtifact, CAP);
+        expect(out.match(/<artifact\b/g)!.length).toBe(1);
+    });
+
+    it('캡처가 없으면 아무것도 첨부하지 않는다', () => {
+        const { out } = run('일반 답변입니다.', null);
+        expect(out).toBe('일반 답변입니다.');
+    });
+});

--- a/apps/api/src/services/chat-service/external-deterministic-append.ts
+++ b/apps/api/src/services/chat-service/external-deterministic-append.ts
@@ -11,6 +11,11 @@
 import { createLogger } from '../../utils/logger';
 import { REPORT_PIPELINE } from '../../config/runtime-limits';
 import { tryRenderReportBlock } from './report-block';
+import { basename } from 'path';
+import { MCP_NAMESPACE_SEPARATOR } from '../../mcp/types';
+import { MCP_META_TOOL_NAMES } from '../../mcp/mcp-meta-tools';
+
+const MCP_CALL_TOOL_NAME = MCP_META_TOOL_NAMES[1]; // 'mcp_call'
 import { WEB_SEARCH_TEMPLATES, getLocalizedTemplate } from '../../sockets/ws-chat-locales';
 import type { ChatMessageRequest } from '../chat-service-types';
 import type { StreamFromExternalContext } from './external-provider';
@@ -28,8 +33,57 @@ export interface DeterministicAppendInput {
     kakaomapBlocks: string[];
     /** start_discussion 출처 블록. */
     discussionSourceBlocks: string[];
+    /** 오픈디자인 도구로 저장한 HTML 산출물 (마지막 저장본 — captureOdArtifactHtml 참고). */
+    odArtifact?: OdArtifactCapture | null;
     req: ChatMessageRequest;
     ctx: StreamFromExternalContext;
+}
+
+/** open-design 도구 인자에서 캡처한 HTML 산출물. */
+export interface OdArtifactCapture {
+    id: string;
+    title: string;
+    html: string;
+}
+
+/**
+ * mcp_call 메타 도구 경유 간접 호출을 실제 도구 호출로 정규화한다.
+ * mcp_call(server, tool, args) → { name: "server::tool", args } — 직접 호출은 그대로 반환.
+ * (진행적 공개 경로로 open-design 을 부르면 tc.name 이 'mcp_call' 이라 캡처를 놓치는 갭 보정.)
+ */
+export function normalizeOdToolCall(
+    name: string,
+    args: Record<string, unknown>,
+): { name: string; args: Record<string, unknown> } {
+    if (name !== MCP_CALL_TOOL_NAME) return { name, args };
+    const inner = args.args && typeof args.args === 'object'
+        ? args.args as Record<string, unknown> : {};
+    return {
+        name: `${String(args.server ?? '')}${MCP_NAMESPACE_SEPARATOR}${String(args.tool ?? '')}`,
+        args: inner,
+    };
+}
+
+/**
+ * open-design create_artifact/write_file 호출 인자에서 자체완결 HTML 을 캡처한다.
+ * CSS/JSX 등 부속 파일이나 실패한 호출은 null — 호출부는 마지막 캡처만 유지한다(수정본 우선).
+ */
+export function captureOdArtifactHtml(
+    args: Record<string, unknown>,
+    toolResult: string,
+): OdArtifactCapture | null {
+    if (toolResult.startsWith('Error')) return null;
+    const content = typeof args.content === 'string' ? args.content : '';
+    const head = content.trimStart().slice(0, 15).toLowerCase();
+    if (!head.startsWith('<!doctype') && !head.startsWith('<html')) return null;
+    const fileName = typeof args.name === 'string' ? args.name
+        : typeof args.path === 'string' ? args.path : '';
+    const base = basename(fileName).replace(/\.[a-z0-9]+$/i, '') || 'design';
+    const titleTag = /<title[^>]*>([^<]{1,200})<\/title>/i.exec(content)?.[1]?.trim();
+    // 아티팩트 시작 태그 속성은 "..." 파싱 — 제목의 큰따옴표는 작은따옴표로 강등(report-block 동일).
+    const title = (titleTag || base).replace(/"/g, "'").slice(0, 200);
+    const id = `${base.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'design'}-${Date.now().toString(36)}`;
+    return { id, title, html: content };
 }
 
 /**
@@ -131,6 +185,17 @@ export function appendDeterministicBlocks(input: DeterministicAppendInput): stri
                 logger.info(`🔗 출처 링크 ${lines.length}개 보강 (모델 출처 섹션에 URL 누락)`);
             }
         }
+    }
+
+    // 오픈디자인 산출물 결정적 첨부 — create_artifact 로 워크스페이스에 저장한 HTML 덱을
+    // 모델이 최종 응답 <artifact> 로 옮기지 않으면(말로만 안내, 2026-08-14 라이브 실측) 서버가
+    // 1회 첨부한다. 모델이 이미 html 아티팩트를 출력했으면 중복 첨부하지 않는다.
+    if (input.odArtifact && !/<artifact\b[^>]*kind="html"/.test(finalContent)) {
+        const a = input.odArtifact;
+        const block = `\n\n<artifact id="${a.id}" kind="html" title="${a.title}">\n${a.html}\n</artifact>`;
+        onToken(block, undefined);
+        finalContent += block;
+        logger.info(`🎨 오픈디자인 아티팩트 결정적 첨부: "${a.title}" (${a.html.length}B)`);
     }
 
     // 보고서 결정적 렌더 (P1 파이프라인) — 모델이 출력한 ```reportdata JSON 블록을 고정

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -33,7 +33,8 @@ import { executeExternalTool, recordExternalUsageFireAndForget } from './externa
 
 import { resolveModelCapabilities } from './model-capabilities';
 import { markModelUnusableFireAndForget } from './external-model-availability';
-import { appendDeterministicBlocks } from './external-deterministic-append';
+import { appendDeterministicBlocks, captureOdArtifactHtml, normalizeOdToolCall, type OdArtifactCapture } from './external-deterministic-append';
+import { OD_ARTIFACT_ECHO } from '../../config/runtime-limits';
 
 const logger = createLogger('ChatExternalProvider');
 
@@ -242,6 +243,9 @@ export async function runExternalStream(
     // 도구 경유 토론(start_discussion)의 출처 목록 — 모델이 도구 결과를 요약하며 버리므로
     // 마커로 실려 온 블록을 모아 최종 응답에 결정적으로 첨부한다(카카오 지도와 동일 패턴).
     const discussionSourceBlocks: string[] = [];
+    // 오픈디자인 산출물(HTML) — create_artifact/write_file 인자에서 캡처, 마지막 저장본 유지.
+    // 모델이 최종 응답에 <artifact> 를 생략하면 결정적 첨부한다(위 블록들과 동일 패턴).
+    let odArtifact: OdArtifactCapture | null = null;
 
     try {
         for (let turn = 0; turn < MAX_TOOL_TURNS; turn++) {
@@ -409,6 +413,15 @@ export async function runExternalStream(
                         generatedImageMarkdowns.push(m[0]);
                     }
                 }
+                // 오픈디자인 HTML 산출물 캡처 — 저장 성공한 자체완결 HTML 만, 마지막 것 유지.
+                // mcp_call 메타 도구 경유 간접 호출도 server::tool 로 정규화해 동일 캡처한다.
+                if (OD_ARTIFACT_ECHO.ENABLED) {
+                    const eff = normalizeOdToolCall(tc.name, tc.args as Record<string, unknown>);
+                    if (OD_ARTIFACT_ECHO.TOOL_NAMES.includes(eff.name)) {
+                        const captured = captureOdArtifactHtml(eff.args, toolResult);
+                        if (captured) odArtifact = captured;
+                    }
+                }
                 // 카카오 지도 블록 수집(도구명 무관 — 도구 결과에 블록이 있으면).
                 for (const mm of toolResult.matchAll(/```kakaomap\s*\n[\s\S]*?```/g)) {
                     if (!kakaomapBlocks.includes(mm[0])) kakaomapBlocks.push(mm[0]);
@@ -547,6 +560,7 @@ export async function runExternalStream(
         generatedImageMarkdowns,
         kakaomapBlocks,
         discussionSourceBlocks,
+        odArtifact,
         req,
         ctx,
     });

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -37,7 +37,7 @@ import {
 } from "@/lib/skills-api";
 import { SlashSkillMenu } from "@/components/chat/slash-skill-menu";
 import { cn } from "@/lib/utils";
-import { detectFileTaskIntent } from "@/lib/file-task-intent";
+import { detectFileTaskIntent, detectPresentationChatIntent } from "@/lib/file-task-intent";
 import { detectReportTaskIntent } from "@/lib/report-task-intent";
 
 // 슬래시 스킬 호출: "/" + 공백없는 단일 토큰일 때만 드롭다운 표시.
@@ -345,8 +345,11 @@ export function Composer() {
       void sendStructured(text.trim());
     } else if (
       !discussionMode && !deepResearchMode && !imageMode &&
-      files.length > 0 && detectFileTaskIntent(text)
+      files.length > 0 && detectFileTaskIntent(text) && !detectPresentationChatIntent(text)
     ) {
+      // 발표자료 제작 요청은 위임하지 않고 채팅 유지 — presentation-designer 스킬
+      // (open-design 디자인 워크플로우)이 채팅 경로에 배선되어 있다. 단 명시적 pptx
+      // 파일 요청은 detectPresentationChatIntent 가 false 라 기존대로 위임된다.
       // 자동 위임(Option B) — 파일 첨부 + 가공/편집/생성/정밀분석 의도면, 스트리밍 채팅 대신
       // 에이전트 작업으로 매끄럽게 위임한다. 샌드박스가 원본 파일을 python
       // (openpyxl/python-docx/reportlab 등)으로 처리 → 진행·결과·생성파일 다운로드는

--- a/apps/web/lib/file-task-intent.ts
+++ b/apps/web/lib/file-task-intent.ts
@@ -35,3 +35,29 @@ export function detectFileTaskIntent(text: string): boolean {
   if (!t) return false;
   return FILE_TASK_INTENT_TOKENS.some((tok) => t.includes(tok));
 }
+
+/**
+ * 발표자료(프레젠테이션) 제작 의도를 나타내는 토큰 — 매칭 시 자동 위임하지 않고
+ * 채팅에 남긴다. 채팅 경로에만 presentation-designer 스킬(open-design MCP 도구
+ * required 바인딩)이 배선되어 있어, 위임하면 디자인 워크플로우를 잃는다.
+ */
+export const PRESENTATION_CHAT_TOKENS: readonly string[] = [
+  "발표자료", "발표 자료", "발표용", "프레젠테이션", "슬라이드", "피치덱", "피치 덱",
+  "presentation", "slide", "pitch deck",
+];
+
+/**
+ * 명시적 .pptx 파일 산출 요청 — 진짜 파일이 필요하므로 발표 의도라도 에이전트
+ * 작업(샌드박스 python-pptx)으로 위임을 유지한다. ("pptx", "ppt 파일(로)")
+ */
+const EXPLICIT_PPTX_FILE_RE = /pptx|ppt\s*파일/i;
+
+/**
+ * 발표자료 제작 요청이라 채팅에 남겨야 하는지 판정.
+ * 명시적 pptx 파일 요청은 예외 — 위임 유지(true 아님).
+ */
+export function detectPresentationChatIntent(text: string): boolean {
+  const t = text.trim().toLowerCase();
+  if (!t || EXPLICIT_PPTX_FILE_RE.test(t)) return false;
+  return PRESENTATION_CHAT_TOKENS.some((tok) => t.includes(tok));
+}


### PR DESCRIPTION
## 요약

파일 업로드 + 발표자료 요청 시 openmake_llm 이 **open-design MCP 로 슬라이드 덱을 직접 디자인·제공**하는 워크플로우의 코드 배선. (스킬 `user-3-presentation-designer` 는 DB 등록으로 별도 적용됨 — `.SKILL` 매니페스트 업로드, OD 도구 5종 required 바인딩.)

### 1. OD 아티팩트 결정적 에코 (`external-deterministic-append.ts`)
- 도구 루프에서 `open-design::create_artifact`/`write_file` 로 저장한 자체완결 HTML 을 캡처, 모델이 최종 응답 `<artifact>` 로 옮기지 않으면(라이브 실측 — "아래에서 확인하세요" 말만 하고 생략) 서버가 1회 자동 첨부.
- `mcp_call` 메타도구 간접 호출도 `server::tool` 정규화로 캡처 (라이브에서 우회 경로 실측).
- 모델이 이미 html 아티팩트를 출력했으면 dedup 스킵 (라이브 확인).
- 기존 결정적 첨부 패턴(생성 이미지·카카오맵·웹검색 출처·reportdata)과 동일 모듈·동일 계약. `OD_ARTIFACT_ECHO_ENABLED`(기본 ON)·`OD_ARTIFACT_ECHO_TOOLS` env.

### 2. 발표 의도 위임 예외 (`file-task-intent.ts`, `composer.tsx`)
- 파일 첨부 + "발표자료 **만들어줘**"가 `FILE_TASK_INTENT_TOKENS` 의 "만들" 토큰으로 Agent Task 에 자동 위임되어, 채팅 경로에만 배선된 OD 디자인 워크플로우를 잃던 문제.
- 발표 토큰(발표자료/프레젠테이션/슬라이드/피치덱 등) 매칭 시 채팅 유지. 명시적 `pptx`/"ppt 파일" 요청은 진짜 파일이 필요하므로 기존대로 위임.

### 3. 문서 (`.env.example`)
- `TASK_SANDBOX_EXTRA_TOOLS` 에 user MCP 도구(`서버명::도구명`) 지정 가능 부기 — 운영 .env 에는 OD 도구 4종을 추가해 Agent Task 경로에서도 사용 (라이브 검증).

## 라이브 검증 (chat.openmake.cc, user 3)

- 채팅: 스킬 활성화 칩 → `open-design::list_projects` → `create_project` → `create_artifact`(OD 워크스페이스 저장) → 채팅 아티팩트 패널 렌더(11슬라이드, PDF/DOCX export) 전 구간 확인
- 위임 예외: "발표자료 만들어줘" + 첨부 → AgentTaskCard 없이 채팅 유지 확인
- Agent Task: extraTools 로 노출된 `open-design::*` 도구 실행 확인

## 체크리스트

- [x] `npm run lint` 통과 (0 errors)
- [x] `npm test` 통과 (2565 passed)
- [x] 신규 유닛 테스트 10개 (`od-artifact-echo.test.ts`)
- [x] 환경변수 추가 → `.env.example` 갱신
- [ ] DB 스키마 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)