### PR TITLE
feat(chat): 이미지 생성 병렬화 + 스킬 required 도구 억제 면제 — 디자인 워크플로우 qwen∥flux2-klein

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1224,6 +1224,10 @@ VAPID_SUBJECT=mailto:admin@openmake.ai
 IMAGE_GEN_MODEL=flux2-klein
 # 이미지 생성 타임아웃 ms (기본 180000)
 IMAGE_GEN_TIMEOUT_MS=180000
+# 같은 턴 generate_image 다중 호출 병렬 실행 (기본 true — false 로 순차 복귀)
+# IMAGE_GEN_PARALLEL_ENABLED=true
+# 이미지 병렬 생성 동시 상한 (기본 3 — FLUX 서버 큐 과점유 방지)
+# IMAGE_GEN_PARALLEL_MAX=3
 # MAX_TOOL_RESULT_CHARS=8000               # 도구 결과를 LLM 컨텍스트로 주입 시 단일 결과 최대 문자수
 
 # ────────────────────────────────────────────────────────────

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1161,6 +1161,19 @@ export const OD_ARTIFACT_ECHO = {
 } as const;
 
 /**
+ * 이미지 생성 병렬화 — 같은 턴에 generate_image 가 2회 이상 호출되면 순차 await 대신
+ * 동시 실행한다. FLUX 디퓨전 1장이 수십 초라 다중 이미지(발표자료 삽화 등)에서 도구 배치
+ * 시간이 장수에 비례해 늘던 것을 1장 수준으로 줄인다. 다른 도구는 순차 유지(부수효과·
+ * 메시지 순서 보존), 결과는 원래 호출 순서대로 tool 메시지에 배치된다.
+ */
+export const IMAGE_GEN_PARALLEL = {
+    /** 기본 ON — IMAGE_GEN_PARALLEL_ENABLED=false 로 비활성화(순차 복귀). */
+    ENABLED: process.env.IMAGE_GEN_PARALLEL_ENABLED !== 'false',
+    /** 동시 생성 상한 — vLLM-Omni FLUX 서버 큐 과점유 방지. */
+    MAX_CONCURRENT: parseInt(process.env.IMAGE_GEN_PARALLEL_MAX || '3', 10),
+} as const;
+
+/**
  * 보고서 작성 의도 판정 패턴. 매칭 시 ① report-guide(reportdata JSON 계약) 시스템 프롬프트
  * 주입 ② 아티팩트 의도와 동일한 distractor 도구 억제. 실사용 문구 기반(운영 로그 2026-07):
  * "html 로 보고서를 작성해서 보고해", "보고서 형식으로 만들어줘", "리포트 작성해줘" 류.

--- a/apps/api/src/services/ChatService.ts
+++ b/apps/api/src/services/ChatService.ts
@@ -532,6 +532,11 @@ export class ChatService {
             onUsage: (usage) => { this.lastProviderUsage = usage; },
             ...(this.currentSystemEventCallback ? { onSystemEvent: this.currentSystemEventCallback } : {}),
             allowedTools: await this.getAllowedTools(reqCtx),
+            // 스킬 required 바인딩 도구는 도구 플랜의 distractor 억제(아티팩트/지도 의도)에서
+            // 면제된다 — 스킬의 명시 의도가 일반화 휴리스틱보다 우선 (external-tool-plan).
+            skillRequiredToolNames: reqCtx.skillBindings
+                .filter((b) => b.binding_mode === 'required')
+                .map((b) => b.tool_name),
         };
     }
 

--- a/apps/api/src/services/chat-service/__tests__/skill-required-tool-exemption.test.ts
+++ b/apps/api/src/services/chat-service/__tests__/skill-required-tool-exemption.test.ts
@@ -1,0 +1,65 @@
+/**
+ * 스킬 required 도구의 distractor 억제 면제 회귀 테스트 (2026-08-14).
+ *
+ * 아티팩트/지도 의도 턴은 generate_image 등 distractor 도구를 억제하는데
+ * (2026-06-23 통제실험), 활성 스킬이 required 로 바인딩한 도구까지 함께 잘려
+ * 스킬 워크플로우(예: 발표자료 스킬의 병렬 삽화 생성)가 막히던 갭을 면제로 해소.
+ * 스킬의 명시 의도 > 일반화된 distractor 휴리스틱.
+ */
+import { buildExternalToolPlan } from '../external-tool-plan';
+import type { ChatMessageRequest } from '../../chat-service-types';
+import type { ToolDefinition } from '../../../llm';
+
+const makeTool = (name: string): ToolDefinition => ({
+    type: 'function',
+    function: { name, description: name, parameters: { type: 'object', properties: {} } },
+});
+
+const toolNames = (plan: { tools: ToolDefinition[] }) => plan.tools.map((t) => t.function.name);
+
+describe('buildExternalToolPlan — 스킬 required 도구 억제 면제', () => {
+    const generateImage = makeTool('generate_image');
+    const odCreate = makeTool('open-design::create_artifact');
+    const base = {
+        allowedTools: [generateImage, odCreate],
+        toolCalling: true,
+        wantsMap: false,
+        orchestration: { discussion: false, taskDelegate: false },
+    };
+    // ARTIFACT_INTENT_PATTERNS 매칭 문구 ("html ... 만들어줘")
+    const artifactReq = { message: 'html 페이지로 만들어줘' } as ChatMessageRequest;
+
+    it('아티팩트 의도면 generate_image 를 억제한다 (기존 동작 보존)', () => {
+        const plan = buildExternalToolPlan({ ...base, req: artifactReq });
+        expect(toolNames(plan)).not.toContain('generate_image');
+    });
+
+    it('스킬 required 바인딩이면 아티팩트 의도에도 generate_image 를 유지한다', () => {
+        const plan = buildExternalToolPlan({
+            ...base,
+            req: artifactReq,
+            skillRequiredToolNames: ['generate_image'],
+        });
+        expect(toolNames(plan)).toContain('generate_image');
+        expect(toolNames(plan)).toContain('open-design::create_artifact');
+    });
+
+    it('스킬 required 바인딩이면 지도 의도에도 generate_image 를 유지한다', () => {
+        const plan = buildExternalToolPlan({
+            ...base,
+            req: { message: '근처 카페 지도 보여줘' } as ChatMessageRequest,
+            wantsMap: true,
+            skillRequiredToolNames: ['generate_image'],
+        });
+        expect(toolNames(plan)).toContain('generate_image');
+    });
+
+    it('required 목록에 없는 도구는 여전히 억제된다 (면제 스코프 한정)', () => {
+        const plan = buildExternalToolPlan({
+            ...base,
+            req: artifactReq,
+            skillRequiredToolNames: ['open-design::create_artifact'],
+        });
+        expect(toolNames(plan)).not.toContain('generate_image');
+    });
+});

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -34,7 +34,8 @@ import { executeExternalTool, recordExternalUsageFireAndForget } from './externa
 import { resolveModelCapabilities } from './model-capabilities';
 import { markModelUnusableFireAndForget } from './external-model-availability';
 import { appendDeterministicBlocks, captureOdArtifactHtml, normalizeOdToolCall, type OdArtifactCapture } from './external-deterministic-append';
-import { OD_ARTIFACT_ECHO } from '../../config/runtime-limits';
+import { OD_ARTIFACT_ECHO, IMAGE_GEN_PARALLEL } from '../../config/runtime-limits';
+import { parallelBatch } from '../../workflow/graph-engine';
 
 const logger = createLogger('ChatExternalProvider');
 
@@ -53,6 +54,8 @@ export interface ExternalProviderDeps {
     onSystemEvent?: (event: { type: string; message: string; metadata?: Record<string, unknown> }) => void;
     /** Allowed tools (agent 매칭 후) */
     allowedTools: ToolDefinition[];
+    /** 활성 스킬이 required 로 바인딩한 도구 이름 — 도구 플랜의 distractor 억제 면제용 */
+    skillRequiredToolNames?: readonly string[];
 }
 
 /**
@@ -191,6 +194,7 @@ export async function runExternalStream(
         wantsMap,
         ...(ctx.tailWebGround !== undefined ? { tailWebGround: ctx.tailWebGround } : {}),
         orchestration,
+        ...(deps.skillRequiredToolNames ? { skillRequiredToolNames: deps.skillRequiredToolNames } : {}),
     });
     // Stage 2 셰도우 계측 — 의도 매칭 턴만 텔레메트리를 초기화(호출 시 아래 루프가 갱신).
     if (orchestration.discussion || orchestration.taskDelegate) {
@@ -360,6 +364,26 @@ export async function runExternalStream(
 
             // 도구 실행 시간 누적 — TTFT 분해에서 "모델이 느린가 / 도구가 느린가"를 가른다.
             const toolBatchStartedAt = Date.now();
+            // 이미지 생성 병렬화 — 같은 턴의 generate_image 다중 호출(발표자료 삽화 등)은
+            // FLUX 디퓨전(수십 초/장)이 지배하므로 동시 실행해 배치 시간을 1장 수준으로
+            // 줄인다. executeExternalTool 은 콜백·에러를 자체 처리(실패는 'Error:' 문자열)
+            // 하므로 동시 실행에 안전하고, 결과는 아래 순차 루프가 원래 호출 순서대로
+            // tool 메시지에 배치한다.
+            const parallelImageResults = new Map<string, string>();
+            const imageCalls = result.toolCalls.filter((tc) => tc.name === 'generate_image');
+            if (IMAGE_GEN_PARALLEL.ENABLED && imageCalls.length >= 2) {
+                logger.info(`🎨 generate_image ${imageCalls.length}건 병렬 실행 (동시 상한 ${IMAGE_GEN_PARALLEL.MAX_CONCURRENT})`);
+                await parallelBatch(
+                    imageCalls,
+                    async (tc) => {
+                        parallelImageResults.set(
+                            tc.id,
+                            await executeExternalTool(deps, tc.name, tc.args as Record<string, unknown>),
+                        );
+                    },
+                    { concurrency: IMAGE_GEN_PARALLEL.MAX_CONCURRENT },
+                );
+            }
             for (const tc of result.toolCalls) {
                 let toolResult: string;
                 if (tc.name === CHAT_DELEGATE_TOOL_NAME) {
@@ -405,7 +429,9 @@ export async function runExternalStream(
                         ctx.orchestrationTelemetry.success = !toolResult.startsWith('Error');
                     }
                 } else {
-                    toolResult = await executeExternalTool(deps, tc.name, tc.args as Record<string, unknown>);
+                    // 병렬 선실행된 이미지 결과가 있으면 재실행 없이 소비.
+                    toolResult = parallelImageResults.get(tc.id)
+                        ?? await executeExternalTool(deps, tc.name, tc.args as Record<string, unknown>);
                 }
                 if (tc.name === 'generate_image') {
                     const m = toolResult.match(/!\[[^\]]*\]\(\/generated\/[^)]+\)/);

--- a/apps/api/src/services/chat-service/external-tool-plan.ts
+++ b/apps/api/src/services/chat-service/external-tool-plan.ts
@@ -61,8 +61,11 @@ export function buildExternalToolPlan(params: {
     wantsMap: boolean;
     tailWebGround?: boolean;
     orchestration: OrchestrationIntents;
+    /** 활성 스킬이 required 로 바인딩한 도구 이름 — distractor 억제에서 면제. */
+    skillRequiredToolNames?: readonly string[];
 }): ExternalToolPlan {
     const { allowedTools, req, toolCalling, wantsMap, tailWebGround, orchestration } = params;
+    const skillRequired = new Set(params.skillRequiredToolNames ?? []);
 
     // 명시적 아티팩트 생성 요청(사용자 아티팩트 토글 또는 메시지 패턴)이면 distractor
     // always-on 도구(generate_image 등)를 제외해 모델이 도구 호출 대신 <artifact> 산출물을
@@ -76,11 +79,14 @@ export function buildExternalToolPlan(params: {
         || ARTIFACT_INTENT_PATTERNS.some((re) => re.test(req.message ?? ''));
     // 위치/지도 의도(wantsMap)면 generate_image 를 제외 — 모델이 가짜 지도
     // 이미지를 그리는 대신 카카오 검색 + 네이티브 지도 블록을 쓰도록 유도 (distractor 억제).
+    // 단, 활성 스킬이 required 로 바인딩한 도구는 억제 면제 — 스킬의 명시 의도(예:
+    // 발표자료 스킬의 generate_image 삽화 생성)가 일반화된 distractor 휴리스틱보다 우선.
     const tools = toolCalling
         ? allowedTools.filter((t) =>
-            !EXTERNAL_LLM_TOOL_BLACKLIST.includes(t.function.name)
-            && !(wantsArtifact && ARTIFACT_REQUEST_SUPPRESSED_TOOLS.includes(t.function.name))
-            && !(wantsMap && t.function.name === 'generate_image'))
+            skillRequired.has(t.function.name)
+            || (!EXTERNAL_LLM_TOOL_BLACKLIST.includes(t.function.name)
+                && !(wantsArtifact && ARTIFACT_REQUEST_SUPPRESSED_TOOLS.includes(t.function.name))
+                && !(wantsMap && t.function.name === 'generate_image')))
         : [];
     // 채팅 서브에이전트(chat-delegate): 전문가 위임 도구 노출 — 스키마 +1 은 문법 컴파일 무해.
     if (CHAT_SUBAGENT.ENABLED && toolCalling) {


### PR DESCRIPTION
## 목적

디자인/발표자료 처리 시 qwen(덱·HTML 작성)과 flux2-klein(삽화 생성)이 **병렬로 함께** 작동하도록 고도화.

점검 결과 기존 설계는: ① 도구 루프가 `for...await` 순차 실행이라 같은 턴의 다중 `generate_image` 도 한 장씩 생성 ② `presentation-designer` 스킬에 이미지 도구 미바인딩 ③ 아티팩트 의도 턴에서 `generate_image` 가 distractor 로 일괄 억제 — 세 지점 모두 병렬 협업 불가.

## 변경

1. **`generate_image` 병렬 실행** (`external-provider.ts`)
   - 같은 턴 2회 이상 호출 시 `parallelBatch`(기존 공용 유틸) 동시 실행. `IMAGE_GEN_PARALLEL` (기본 ON, `IMAGE_GEN_PARALLEL_ENABLED`/`IMAGE_GEN_PARALLEL_MAX`(기본 3) env).
   - `executeExternalTool` 은 콜백·에러 자체완결('Error:' 문자열 반환)이라 동시 실행 안전. 결과는 원래 호출 순서대로 tool 메시지 배치 — 부수효과·순서 보존.
   - 다른 도구는 순차 유지 (스코프 한정).

2. **스킬 required 도구는 distractor 억제 면제** (`external-tool-plan.ts` + `ChatService.ts` 배선)
   - 활성 스킬이 `required` 로 바인딩한 도구는 아티팩트/지도 의도 억제(2026-06-23 통제실험)에서 면제. 스킬의 명시 의도 > 일반화 휴리스틱.
   - 면제는 required 목록에 한정 — 스킬 미활성 턴의 기존 억제 동작 그대로.

3. 설정 외부화: `runtime-limits.ts` `IMAGE_GEN_PARALLEL` + `.env.example` 문서화 (No-Hardcoding 3계층 준수).

## 후속 (별도 반영)

- `presentation-designer` 스킬 v1.0.2: `generate_image` required 바인딩 + "삽화는 한 턴에 모아 호출(병렬)" 가이드 — .SKILL 업로드 경로로 반영 (코드 아님).

## 테스트

- [x] 신규 `skill-required-tool-exemption.test.ts` 4케이스 (억제 보존 + required 면제 + 스코프 한정)
- [x] `npm test` 전체 유닛 suite 통과 (exit 0)
- [x] `tsc --noEmit` / eslint 통과 (max-lines 경고는 기존 상태, 600줄 가드 이내)

🤖 Generated with [Claude Code](https://claude.com/claude-code)