### PR TITLE
fix(chat): 이미지 생성 소요시간을 루프 wall-clock 예산에서 공제

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1228,6 +1228,8 @@ IMAGE_GEN_TIMEOUT_MS=180000
 # IMAGE_GEN_PARALLEL_ENABLED=true
 # 이미지 병렬 생성 동시 상한 (기본 3 — FLUX 서버 큐 과점유 방지)
 # IMAGE_GEN_PARALLEL_MAX=3
+# 루프 wall-clock 예산에서 공제할 이미지 생성 소요시간 상한 ms (기본 180000)
+# IMAGE_GEN_CREDIT_MAX_MS=180000
 # MAX_TOOL_RESULT_CHARS=8000               # 도구 결과를 LLM 컨텍스트로 주입 시 단일 결과 최대 문자수
 
 # ────────────────────────────────────────────────────────────

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1171,6 +1171,15 @@ export const IMAGE_GEN_PARALLEL = {
     ENABLED: process.env.IMAGE_GEN_PARALLEL_ENABLED !== 'false',
     /** 동시 생성 상한 — vLLM-Omni FLUX 서버 큐 과점유 방지. */
     MAX_CONCURRENT: parseInt(process.env.IMAGE_GEN_PARALLEL_MAX || '3', 10),
+    /**
+     * 루프 wall-clock 예산에서 공제할 이미지 생성 소요시간 상한 (ms).
+     *
+     * 이미지 3장 배치(실측 166s, FLUX 직렬 큐)가 AGENT_LOOP_LIMITS.MAX_WALL_CLOCK_MS
+     * (180s)를 잠식해 후속 덱 저장 턴이 "도구 비활성 최종 턴"으로 강제 전환되던 결함
+     * (2026-08-14 라이브 실측) 보정 — 디퓨전 대기는 모델/도구 폭주가 아니므로 예산에서
+     * 공제하되, 상한을 둬 최악 요청 시간을 예산+상한으로 묶는다.
+     */
+    WALL_CLOCK_CREDIT_MAX_MS: parseInt(process.env.IMAGE_GEN_CREDIT_MAX_MS || '180000', 10),
 } as const;
 
 /**

--- a/apps/api/src/services/chat-service/external-loop-guards.ts
+++ b/apps/api/src/services/chat-service/external-loop-guards.ts
@@ -1,0 +1,86 @@
+/**
+ * 외부 provider 도구 루프의 예산·반복 가드 — external-provider.ts 에서 분리 (600줄 CI 가드).
+ *
+ * 두 가드 모두 "도구를 끈 최종 턴으로 전환"을 유도하는 넛지 user 메시지를 messages 에
+ * 밀어 넣고 boolean 을 반환한다 — 호출부(runExternalStream 루프)가 suppressTools 전환을
+ * 담당한다(루프 지역 상태라 여기서 직접 만지지 않음).
+ *
+ * @module services/chat-service/external-loop-guards
+ */
+import { createLogger } from '../../utils/logger';
+import { LOOP_DETECTION, AGENT_LOOP_LIMITS } from '../../config/runtime-limits';
+import type { ChatMessage } from '../../llm';
+
+const logger = createLogger('ChatExternalProvider');
+
+/**
+ * Wall-clock 예산 가드 — 턴 수와 별개로 누적 시간 초과 시 도구 끄고 최종 응답 유도.
+ * 이미지 생성(디퓨전 수십 초~수 분) 소요시간은 공제(imageGenCreditMs) — 예산의
+ * 목적(모델/도구 폭주 차단)과 무관한 정상 대기가 후속 턴(덱 저장 등)을 잘라내던
+ * 결함 보정 (2026-08-14 라이브 실측: 3장 배치 166s → 도구 비활성 전환).
+ *
+ * @returns true 면 예산 초과 — 호출부는 suppressTools 로 전환한다.
+ */
+export function applyWallClockGuard(p: {
+    startedAt: number;
+    imageGenCreditMs: number;
+    messages: ChatMessage[];
+}): boolean {
+    if (AGENT_LOOP_LIMITS.MAX_WALL_CLOCK_MS <= 0
+        || Date.now() - p.startedAt - p.imageGenCreditMs <= AGENT_LOOP_LIMITS.MAX_WALL_CLOCK_MS) {
+        return false;
+    }
+    logger.warn(`⏱️ 외부 LLM 루프 wall-clock 예산 초과 (${AGENT_LOOP_LIMITS.MAX_WALL_CLOCK_MS}ms) — 도구 비활성 최종 턴으로 전환`);
+    p.messages.push({
+        role: 'user',
+        content: '처리 시간이 초과되었습니다. 추가 도구 호출 없이 현재까지 수집한 정보로 답변을 완성하세요.',
+    });
+    return true;
+}
+
+/**
+ * 같은 도구 반복 사용 가드 (인자 무관) — 검색어만 바꿔가며 부르는 패턴은
+ * doom-loop(도구+인자 해시)에 걸리지 않아 최대 턴까지 소진된다.
+ * 매 턴 모델 prefill 이 누적되므로 지연의 지배 요인이다(2026-08-02 실측).
+ *
+ * BREAK_AT 도달 시 중단 넛지를 push 하고 true 반환 — 호출부는 suppressTools 전환 후
+ * continue. WARN_AT 도달 시(도구별 1회) 마무리 유도 넛지만 push 하고 false 반환.
+ */
+export function applyToolOveruseGuard(p: {
+    toolCalls: ReadonlyArray<{ name: string }>;
+    toolUseCounts: Map<string, number>;
+    warnedTools: Set<string>;
+    messages: ChatMessage[];
+}): boolean {
+    for (const tc of p.toolCalls) {
+        p.toolUseCounts.set(tc.name, (p.toolUseCounts.get(tc.name) ?? 0) + 1);
+    }
+    const overusedTool = [...p.toolUseCounts.entries()]
+        .find(([, n]) => n >= LOOP_DETECTION.SAME_TOOL_BREAK_AT);
+    if (overusedTool) {
+        logger.warn(`🔁 도구 과다 사용 — ${overusedTool[0]} ${overusedTool[1]}회 `
+            + `(상한 ${LOOP_DETECTION.SAME_TOOL_BREAK_AT}) — 도구 비활성 최종 턴으로 전환`);
+        p.messages.push({
+            role: 'user',
+            content: `${overusedTool[0]} 도구를 ${overusedTool[1]}회 호출했습니다. `
+                + '더 검색하지 말고 지금까지 수집한 정보로 답변을 완성하세요. '
+                + '확인되지 않은 부분은 모른다고 밝히면 됩니다. '
+                + '(이 제한은 이번 응답에만 적용됩니다 — 당신의 도구 능력이 사라진 것이 아니므로 '
+                + '"검색 불가"라고 말하지 마세요.)',
+        });
+        return true;
+    }
+    const warnTool = [...p.toolUseCounts.entries()]
+        .find(([name, n]) => n >= LOOP_DETECTION.SAME_TOOL_WARN_AT && !p.warnedTools.has(name));
+    if (warnTool) {
+        p.warnedTools.add(warnTool[0]);
+        logger.info(`⚠️ 도구 반복 경고 — ${warnTool[0]} ${warnTool[1]}회 (마무리 유도)`);
+        p.messages.push({
+            role: 'user',
+            content: `${warnTool[0]} 도구를 이미 ${warnTool[1]}회 호출했습니다. `
+                + '검색어를 바꿔 다시 시도하기보다, 지금까지의 결과로 답변을 정리하세요. '
+                + '정말 필요한 경우에만 한 번 더 호출하세요.',
+        });
+    }
+    return false;
+}

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -206,6 +206,8 @@ export async function runExternalStream(
     }
 
     const startedAt = Date.now();
+    // 이미지 생성 소요시간 누적 — wall-clock 예산 공제용 (상한 WALL_CLOCK_CREDIT_MAX_MS).
+    let imageGenCreditMs = 0;
     // TTFT 분해 계측 — 구간 계산은 호출부(ws-chat-handler)가 상위 시작 시각과 함께 수행.
     const timings: ChatTimings = {
         enteredAt: enteredAtMs, firstLlmCallAt: 0, firstChunkAt: 0, toolMs: 0, turns: 0,
@@ -253,9 +255,12 @@ export async function runExternalStream(
 
     try {
         for (let turn = 0; turn < MAX_TOOL_TURNS; turn++) {
-            // Wall-clock 예산 가드 — 턴 수와 별개로 누적 시간 초과 시 도구 끄고 최종 응답 유도
+            // Wall-clock 예산 가드 — 턴 수와 별개로 누적 시간 초과 시 도구 끄고 최종 응답 유도.
+            // 이미지 생성(디퓨전 수십 초~수 분) 소요시간은 공제(imageGenCreditMs) — 예산의
+            // 목적(모델/도구 폭주 차단)과 무관한 정상 대기가 후속 턴(덱 저장 등)을 잘라내던
+            // 결함 보정 (2026-08-14 라이브 실측: 3장 배치 166s → 도구 비활성 전환).
             if (!suppressTools && AGENT_LOOP_LIMITS.MAX_WALL_CLOCK_MS > 0
-                && Date.now() - startedAt > AGENT_LOOP_LIMITS.MAX_WALL_CLOCK_MS) {
+                && Date.now() - startedAt - imageGenCreditMs > AGENT_LOOP_LIMITS.MAX_WALL_CLOCK_MS) {
                 logger.warn(`⏱️ 외부 LLM 루프 wall-clock 예산 초과 (${AGENT_LOOP_LIMITS.MAX_WALL_CLOCK_MS}ms) — 도구 비활성 최종 턴으로 전환`);
                 suppressTools = true;
                 messages.push({
@@ -373,6 +378,7 @@ export async function runExternalStream(
             const imageCalls = result.toolCalls.filter((tc) => tc.name === 'generate_image');
             if (IMAGE_GEN_PARALLEL.ENABLED && imageCalls.length >= 2) {
                 logger.info(`🎨 generate_image ${imageCalls.length}건 병렬 실행 (동시 상한 ${IMAGE_GEN_PARALLEL.MAX_CONCURRENT})`);
+                const imageBatchStartedAt = Date.now();
                 await parallelBatch(
                     imageCalls,
                     async (tc) => {
@@ -382,6 +388,10 @@ export async function runExternalStream(
                         );
                     },
                     { concurrency: IMAGE_GEN_PARALLEL.MAX_CONCURRENT },
+                );
+                imageGenCreditMs = Math.min(
+                    imageGenCreditMs + (Date.now() - imageBatchStartedAt),
+                    IMAGE_GEN_PARALLEL.WALL_CLOCK_CREDIT_MAX_MS,
                 );
             }
             for (const tc of result.toolCalls) {
@@ -430,8 +440,17 @@ export async function runExternalStream(
                     }
                 } else {
                     // 병렬 선실행된 이미지 결과가 있으면 재실행 없이 소비.
+                    // 단건 이미지 생성도 소요시간을 공제 누적한다 (배치와 동일 근거).
+                    const singleImageStartedAt = tc.name === 'generate_image' && !parallelImageResults.has(tc.id)
+                        ? Date.now() : 0;
                     toolResult = parallelImageResults.get(tc.id)
                         ?? await executeExternalTool(deps, tc.name, tc.args as Record<string, unknown>);
+                    if (singleImageStartedAt > 0) {
+                        imageGenCreditMs = Math.min(
+                            imageGenCreditMs + (Date.now() - singleImageStartedAt),
+                            IMAGE_GEN_PARALLEL.WALL_CLOCK_CREDIT_MAX_MS,
+                        );
+                    }
                 }
                 if (tc.name === 'generate_image') {
                     const m = toolResult.match(/!\[[^\]]*\]\(\/generated\/[^)]+\)/);

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -22,6 +22,7 @@ import { CHAT_DELEGATE_TOOL_NAME, runChatDelegate } from './chat-delegate';
 import { SPAWN_AGENTS_TOOL_NAME, runChatSpawnAgents } from '../agent-spawn/spawn-agents';
 import { CHAT_SUBAGENT, AGENT_SPAWN } from '../../config/runtime-limits';
 import { buildExternalToolPlan, detectOrchestrationIntents } from './external-tool-plan';
+import { applyWallClockGuard, applyToolOveruseGuard } from './external-loop-guards';
 import { isOrchestrationTool, runOrchestrationTool } from './orchestration-dispatch';
 import type { ChatMessage, ToolDefinition } from '../../llm';
 import type { ChatMessageRequest } from '../chat-service-types';
@@ -255,18 +256,9 @@ export async function runExternalStream(
 
     try {
         for (let turn = 0; turn < MAX_TOOL_TURNS; turn++) {
-            // Wall-clock 예산 가드 — 턴 수와 별개로 누적 시간 초과 시 도구 끄고 최종 응답 유도.
-            // 이미지 생성(디퓨전 수십 초~수 분) 소요시간은 공제(imageGenCreditMs) — 예산의
-            // 목적(모델/도구 폭주 차단)과 무관한 정상 대기가 후속 턴(덱 저장 등)을 잘라내던
-            // 결함 보정 (2026-08-14 라이브 실측: 3장 배치 166s → 도구 비활성 전환).
-            if (!suppressTools && AGENT_LOOP_LIMITS.MAX_WALL_CLOCK_MS > 0
-                && Date.now() - startedAt - imageGenCreditMs > AGENT_LOOP_LIMITS.MAX_WALL_CLOCK_MS) {
-                logger.warn(`⏱️ 외부 LLM 루프 wall-clock 예산 초과 (${AGENT_LOOP_LIMITS.MAX_WALL_CLOCK_MS}ms) — 도구 비활성 최종 턴으로 전환`);
+            // Wall-clock 예산 가드(이미지 생성 소요시간 공제) — 상세는 external-loop-guards.
+            if (!suppressTools && applyWallClockGuard({ startedAt, imageGenCreditMs, messages })) {
                 suppressTools = true;
-                messages.push({
-                    role: 'user',
-                    content: '처리 시간이 초과되었습니다. 추가 도구 호출 없이 현재까지 수집한 정보로 답변을 완성하세요.',
-                });
             }
             const turnTools = suppressTools ? [] : tools;
             // A. context-fit 안전망: external 경로는 LLMClient.chat 의 model-pool truncate 를
@@ -492,39 +484,10 @@ export async function runExternalStream(
             }
             timings.toolMs += Date.now() - toolBatchStartedAt;
 
-            // 같은 도구 반복 사용 가드 (인자 무관) — 검색어만 바꿔가며 부르는 패턴은
-            // 위 doom-loop(도구+인자 해시)에 걸리지 않아 최대 턴까지 소진된다.
-            // 매 턴 모델 prefill 이 누적되므로 지연의 지배 요인이다(2026-08-02 실측).
-            for (const tc of result.toolCalls) {
-                toolUseCounts.set(tc.name, (toolUseCounts.get(tc.name) ?? 0) + 1);
-            }
-            const overusedTool = [...toolUseCounts.entries()]
-                .find(([, n]) => n >= LOOP_DETECTION.SAME_TOOL_BREAK_AT);
-            if (overusedTool) {
-                logger.warn(`🔁 도구 과다 사용 — ${overusedTool[0]} ${overusedTool[1]}회 `
-                    + `(상한 ${LOOP_DETECTION.SAME_TOOL_BREAK_AT}) — 도구 비활성 최종 턴으로 전환`);
+            // 같은 도구 반복 사용 가드 (인자 무관, WARN/BREAK) — 상세는 external-loop-guards.
+            if (applyToolOveruseGuard({ toolCalls: result.toolCalls, toolUseCounts, warnedTools, messages })) {
                 suppressTools = true;
-                messages.push({
-                    role: 'user',
-                    content: `${overusedTool[0]} 도구를 ${overusedTool[1]}회 호출했습니다. `
-                        + '더 검색하지 말고 지금까지 수집한 정보로 답변을 완성하세요. '
-                        + '확인되지 않은 부분은 모른다고 밝히면 됩니다. '
-                        + '(이 제한은 이번 응답에만 적용됩니다 — 당신의 도구 능력이 사라진 것이 아니므로 '
-                        + '"검색 불가"라고 말하지 마세요.)',
-                });
                 continue;
-            }
-            const warnTool = [...toolUseCounts.entries()]
-                .find(([name, n]) => n >= LOOP_DETECTION.SAME_TOOL_WARN_AT && !warnedTools.has(name));
-            if (warnTool) {
-                warnedTools.add(warnTool[0]);
-                logger.info(`⚠️ 도구 반복 경고 — ${warnTool[0]} ${warnTool[1]}회 (마무리 유도)`);
-                messages.push({
-                    role: 'user',
-                    content: `${warnTool[0]} 도구를 이미 ${warnTool[1]}회 호출했습니다. `
-                        + '검색어를 바꿔 다시 시도하기보다, 지금까지의 결과로 답변을 정리하세요. '
-                        + '정말 필요한 경우에만 한 번 더 호출하세요.',
-                });
             }
         }
         if (!result) throw new Error('streamChat 호출 결과 없음');


### PR DESCRIPTION
## 문제 (2026-08-14 라이브 E2E 실측)

발표자료 스킬 E2E 에서 `generate_image` 3건 병렬 배치가 정상 작동(전건 성공)했으나, FLUX 서버가 내부 직렬 큐라 배치에 166초 소요 → 루프 wall-clock 예산 `MAX_WALL_CLOCK_MS`(180s)가 이미지 완료 직후 초과되어 **도구 비활성 최종 턴으로 강제 전환**. 후속 덱 저장(`open-design::create_artifact`) 턴이 잘렸다 (채팅 아티팩트는 산출됨, OD 워크스페이스 저장만 유실).

## 수정

- 디퓨전 대기는 wall-clock 예산의 목적(모델/도구 폭주 차단)과 무관한 정상 대기 — `generate_image` 소요시간(병렬 배치 + 단건)을 예산 검사에서 공제(`imageGenCreditMs`).
- 공제 상한 `IMAGE_GEN_PARALLEL.WALL_CLOCK_CREDIT_MAX_MS`(기본 180s, `IMAGE_GEN_CREDIT_MAX_MS` env) — 최악 요청 시간은 예산+상한(기본 360s)으로 유계. 폭주 가드(same-tool break=5, doom-loop, MAX_TURNS)는 그대로 유효.

## 테스트

- [x] `tsc --noEmit` 통과
- [x] 관련 suite (skill-required-tool-exemption·od-artifact-echo) 14/14 통과
- [ ] 머지·배포 후 라이브 E2E 재실행 (이미지 3장 + OD 저장 + 채팅 아티팩트 완주 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)