### PR TITLE
fix(web): WS 직접 연결 포트 하드코딩 제거 — 포트 이동 시 연결 끊김 수정

### DIFF
--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -78,11 +78,15 @@ function resolveWsUrl(): string {
   const env = process.env.NEXT_PUBLIC_WS_URL;
   if (env) return env;
   const proto = location.protocol === "https:" ? "wss:" : "ws:";
-  // Next dev 직접(:3000, Caddy 미경유)일 때만 백엔드 WS 포트(:52416)로 직접 연결.
-  // 그 외(Caddy 경유 :33000 — 로컬 테스트/외부 공개)는 same-origin → Caddy 가 WS upgrade 를
-  // 백엔드로 프록시한다. (Next.js rewrites 는 WS 를 프록시하지 못하므로 프록시 계층이 필수.)
-  if (location.port === "3000") {
-    return `${proto}//${location.hostname}:52416`;
+  // Next 직접 서빙(Caddy/Nginx 미경유)일 때만 백엔드 WS 포트로 직접 연결.
+  // 그 외(프록시 경유)는 same-origin → 프록시가 WS upgrade 를 백엔드로 넘긴다.
+  // (Next.js rewrites 는 WS 를 프록시하지 못하므로 프록시 계층이 필수.)
+  // 포트는 빌드 시점에 주입된다 — install.sh 가 포트 충돌로 3000/52416 을 옮겨도
+  // (예: 웹 :13000) 직접 연결 판정과 백엔드 포트가 함께 따라온다.
+  const webPort = process.env.NEXT_PUBLIC_WEB_PORT || "3000";
+  const wsPort = process.env.NEXT_PUBLIC_WS_PORT || "52416";
+  if (location.port === webPort) {
+    return `${proto}//${location.hostname}:${wsPort}`;
   }
   return `${proto}//${location.host}`;
 }

--- a/install.sh
+++ b/install.sh
@@ -805,7 +805,10 @@ build_app() {
         return 0
     fi
     log_info "npm run build (백엔드 tsc + 프론트 Next.js) — 수 분 걸릴 수 있습니다"
-    ( cd "$SCRIPT_DIR" && npm run build ) || die "빌드 실패"
+    # NEXT_PUBLIC_* 는 Next 빌드 시점에 번들로 인라인된다 — 포트 충돌 회피로
+    # 3000/52416 이 옮겨진 경우 프론트의 WS 직접 연결 판정이 따라오도록 주입.
+    ( cd "$SCRIPT_DIR" && NEXT_PUBLIC_WEB_PORT="$WEB_PORT" NEXT_PUBLIC_WS_PORT="$APP_PORT" \
+        npm run build ) || die "빌드 실패"
     log_ok "빌드 완료"
 }
 
@@ -818,7 +821,10 @@ start_app() {
     log_info "PM2 기동 (ecosystem.config.js)"
     # ecosystem.config.js 는 시작 시점 셸 환경의 PORT/OMK_WEB_PORT 를 읽는다 —
     # 명시적으로 넘겨야 --port/--web-port/자동 대체 포트가 PM2 에 반영된다.
+    # API_PROXY_TARGET: Next rewrites(/api, /generated)의 런타임 백엔드 주소 —
+    # API 포트가 대체된 경우에도 REST 프록시가 올바른 포트를 가리키게 한다.
     ( cd "$SCRIPT_DIR" && PORT="$APP_PORT" OMK_WEB_PORT="$WEB_PORT" \
+        API_PROXY_TARGET="http://localhost:$APP_PORT" \
         "$PM2_BIN" start ecosystem.config.js --update-env ) || die "PM2 기동 실패"
 
     log_info "health check 대기 (최대 $((HEALTH_RETRIES * HEALTH_INTERVAL))s)"


### PR DESCRIPTION
## 문제
`resolveWsUrl` 이 웹 `:3000` / API `:52416` 을 하드코딩. install.sh 의 포트 충돌 자동 회피(#480)로 웹이 `:13000` 으로 옮겨진 머신에서 same-origin WS(`ws://host:13000/`)로 빠져 연결 실패 → 채팅 화면에 "서버와 연결이 끊겼습니다" 상시 표시 (실사용자 보고).

## 해결
- 직접 연결 판정 포트와 백엔드 WS 포트를 `NEXT_PUBLIC_WEB_PORT` / `NEXT_PUBLIC_WS_PORT` 빌드타임 주입으로 대체 (미설정 시 3000/52416 — 기존 동작 그대로)
- install.sh 빌드 단계에서 실제 포트 주입, 기동 단계에서 `API_PROXY_TARGET` 전달 (API 포트 대체 시 Next rewrites 도 추적)

## 검증
- `tsc --noEmit` 통과
- `NEXT_PUBLIC_*` 는 리터럴 접근이라 Next 번들 인라인 대상임을 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)