### PR TITLE
fix(ops): port_listening 조기 return 으로 폴백 체인이 끊기던 버그 수정

### DIFF
--- a/openmake_llm.sh
+++ b/openmake_llm.sh
@@ -126,19 +126,20 @@ preflight() {
 #   lsof(macOS 기본) → ss(최신 리눅스) → netstat(구형) → bash /dev/tcp(무도구)
 port_listening() {
     local port="$1"
+    # 각 도구의 "못 찾음"은 단정이 아니다 — 비루트 lsof 는 root 소유
+    # docker-proxy 소켓을 못 봐서, 여기서 return 1 로 끊으면 컨테이너 포트가
+    # 항상 미응답으로 오판된다 (start 가 postgres 대기에서 죽던 원인).
+    # 긍정(발견)만 즉시 반환하고, 부정은 다음 도구로 계속 내려간다.
     if command -v lsof >/dev/null 2>&1; then
         lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1 && return 0
-        return 1
     fi
     if command -v ss >/dev/null 2>&1; then
         ss -ltn "sport = :$port" 2>/dev/null | grep -q LISTEN && return 0
-        return 1
     fi
     if command -v netstat >/dev/null 2>&1; then
         netstat -an 2>/dev/null | grep -qE "[.:]$port[[:space:]].*LISTEN" && return 0
-        return 1
     fi
-    # 마지막 수단 — 실제 연결을 시도한다 (localhost 바인딩만 감지 가능).
+    # 최종 판정 — 실제 연결을 시도한다 (localhost 바인딩만 감지 가능).
     (exec 3<>/dev/tcp/127.0.0.1/"$port") >/dev/null 2>&1 && return 0
     return 1
 }


### PR DESCRIPTION
## 문제
`openmake_llm.sh` 의 `port_listening` 이 lsof→ss→netstat→/dev/tcp 4단계 폴백으로 설계됐지만, 각 분기가 부정 판정 시 `return 1` 로 즉시 종료해 **첫 존재하는 도구의 결과가 최종 판정**이 됐다.

비루트 lsof 는 root 소유 docker-proxy 소켓을 보지 못하므로, lsof 가 설치된 Linux 서버에서 컨테이너 포트가 항상 "미응답" 으로 오판:
- `./openmake_llm.sh start` → postgres 포트 대기 30초 실패 → `set -e` 로 종료 → **redis 는 시작도 안 됨** (실사용자 보고, docker events 로 재생 확인)
- `status` → 정상 컨테이너 둘 다 ✗ 표시

## 해결
긍정(발견)만 즉시 반환하고 부정은 다음 도구로 폴백. 마지막 /dev/tcp 연결 시도만 최종 판정.

## 검증
- 열린 포트(도커 5432 / PM2 3000), 닫힌 포트 정상 판별
- lsof 를 항상-빈손으로 가장한 시뮬레이션에서 폴백이 도커 포트 감지 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)