### PR TITLE
fix: 코드리뷰(#484 배치) 후속 9건 수정 — OAuth 계정 바인딩 보안·검색 출처/쿼터 보강

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -365,6 +365,9 @@ NAVER_API_HUB_KEY_ID=your_ncp_apigw_key_id_here
 NAVER_API_HUB_KEY=your_ncp_apigw_key_here
 # 일일 호출 한도 가드 (기본 25000 = 무료 허용량, 0 = 무제한) — 도달 시 호출 차단(빈 결과 graceful)
 NAVER_API_DAILY_LIMIT=25000
+# 보조 endpoint(encyc 백과)의 일일 쿼터 소프트 컷 비율(0~1, 기본 0.9) — 한도×비율 도달 시
+# encyc 만 먼저 중단해 핵심(news/webkr) 쿼터 잠식 방지
+# NAVER_SUPPLEMENTARY_QUOTA_RATIO=0.9
 
 # 카카오(Daum) 검색 API (웹문서 검색, dapi.kakao.com/v2/search/web) — 한국어 2공급원
 # developers.kakao.com 앱의 "REST API 키" 사용 (지도 MCP 서버와 동일 키 재사용 가능).
@@ -374,10 +377,15 @@ KAKAO_REST_API_KEY=your_kakao_rest_api_key_here
 # Exa 검색 API (api.exa.ai) — Tier0 무료 수집 부족 시에만 escalation 호출 (카드 불필요, 월 $10 무료 크레딧)
 # dashboard.exa.ai 에서 발급. 미설정 시 escalation 비활성 (graceful).
 EXA_API_KEY=your_exa_api_key_here
+# SEARCH_ESCALATION_MIN_RESULTS=5    # dedupe 후 결과가 이 값 미만일 때만 Exa 보강 (0 = escalation 비활성)
+# SEARCH_ESCALATION_EXA_RESULTS=10   # escalation 시 Exa 요청 결과 수
+# SEARCH_ESCALATION_TIMEOUT_MS=4000  # escalation 직렬 호출 지연 상한(ms) — 초과 시 보강 포기 (0 = 상한 없음)
 
 # Tavily 검색 API (api.tavily.com) — Deep Research 전용 (카드 불필요, 월 1,000 크레딧 무료)
 # app.tavily.com 에서 발급. 미설정 시 비활성 (graceful).
 TAVILY_API_KEY=tvly-your_tavily_api_key_here
+# RESEARCH_TAVILY_MAX_RESULTS=5      # 쿼리당 Tavily 결과 수 (0 = 비활성)
+# RESEARCH_TAVILY_DEPTH=advanced     # basic(1크레딧)/advanced(2크레딧, 정제 본문 포함)
 
 # 가상 비용 환산(usage /cost) 참조 단가 — 실제 과금 아님, "상용 API 였다면" 표시용
 # 기본값은 실제 Qwen 요금표(Alibaba Cloud Model Studio, Qwen3.8-Max) 기준

--- a/apps/api/src/__tests__/user-manager-auth-lookup.test.ts
+++ b/apps/api/src/__tests__/user-manager-auth-lookup.test.ts
@@ -54,12 +54,23 @@ describe('UserManager 계정 조회·비밀번호 변경', () => {
     });
 
     describe('getUserByEmail', () => {
-        test('email OR username 으로 조회해야 한다 (username 변경 계정의 OAuth 로그인 차단 방지)', async () => {
+        test('email 일치 + username 폴백으로 조회해야 한다 (username 변경 계정의 OAuth 로그인 차단 방지)', async () => {
             await manager.getUserByEmail('rockyhan@iexcello.com');
-            const lookup = queries.find(q => q.sql.startsWith('SELECT * FROM users'));
+            const lookup = queries.find(q => q.sql.trimStart().startsWith('SELECT * FROM users'));
             expect(lookup).toBeDefined();
-            expect(lookup!.sql).toContain('email = $1 OR username = $1');
+            expect(lookup!.sql).toContain('email = $1');
+            expect(lookup!.sql).toContain('username = $1');
             expect(lookup!.params).toEqual(['rockyhan@iexcello.com']);
+        });
+
+        test('username 폴백은 email 이 빈 행만 인정하고 결정적으로 1행을 선택해야 한다 (계정 탈취 차단)', async () => {
+            // email 은 UNIQUE 가 아님 — 타인 계정이 username 만 이 email 로 등록돼 있어도
+            // (email 컬럼에 다른 주소 보유) OAuth 로그인이 그 계정에 바인딩되면 안 된다.
+            await manager.getUserByEmail('victim@example.com');
+            const lookup = queries.find(q => q.sql.trimStart().startsWith('SELECT * FROM users'));
+            expect(lookup!.sql).toMatch(/username = \$1 AND \(email IS NULL OR email = ''\)/);
+            expect(lookup!.sql).toContain('ORDER BY');
+            expect(lookup!.sql).toContain('LIMIT 1');
         });
 
         test('username≠email 계정도 email 컬럼 값으로 반환해야 한다', async () => {

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -512,6 +512,25 @@ export const SEARCH_ESCALATION = {
     MIN_RESULTS: parseInjectLimit(process.env.SEARCH_ESCALATION_MIN_RESULTS, 5),
     /** escalation 시 Exa 요청 결과 수. env: SEARCH_ESCALATION_EXA_RESULTS */
     EXA_NUM_RESULTS: parseInjectLimit(process.env.SEARCH_ESCALATION_EXA_RESULTS, 10),
+    /**
+     * escalation Exa 호출 지연 상한(ms) — 병렬 배치 이후의 **직렬** 호출이라 채팅 TTFT 에
+     * 그대로 가산되므로 provider fetch timeout(~12s)보다 훨씬 짧게 캡한다. 초과 시 보강 포기
+     * (Tier 0 결과만으로 진행). 0 = 상한 없음. env: SEARCH_ESCALATION_TIMEOUT_MS
+     */
+    TIMEOUT_MS: parseInjectLimit(process.env.SEARCH_ESCALATION_TIMEOUT_MS, 4000),
+} as const;
+
+/**
+ * 네이버 검색 일일 쿼터 배분 — 보조 endpoint(encyc)는 일일 한도의 이 비율(0~1)까지만 소모한다.
+ * 백과 추가로 KO 쿼리당 네이버 호출이 2→3회가 되며 같은 일일 한도를 잠식하던 것을 완화 —
+ * 소프트 컷 도달 시 encyc 만 먼저 중단되고 핵심(news/webkr)은 하드 한도까지 계속 동작한다.
+ * env: NAVER_SUPPLEMENTARY_QUOTA_RATIO
+ */
+export const NAVER_QUOTA = {
+    SUPPLEMENTARY_RATIO: (() => {
+        const n = Number(process.env.NAVER_SUPPLEMENTARY_QUOTA_RATIO ?? 0.9);
+        return Number.isFinite(n) && n >= 0 && n <= 1 ? n : 0.9;
+    })(),
 } as const;
 
 /**
@@ -526,10 +545,12 @@ export const RESEARCH_TAVILY = {
 } as const;
 
 export const SEARXNG_CATEGORY_SCOPE = {
-    /** 기술/개발 질의 → `it` 카테고리 (github·stackoverflow·mdn·pypi·docker hub) */
-    IT_PATTERN: /(에러|오류|버그|디버깅|코드|코딩|라이브러리|프레임워크|컴파일|리액트|백엔드|프론트엔드|데이터베이스|프로그래밍|소스\s?코드|개발\s?환경|\bapi\b|\bsdk\b|\bnpm\b|\bpip\b|docker|kubernetes|github|typescript|javascript|python|\bjava\b|\brust\b|golang|react|next\.?js|node\.?js|\bsql\b)/i,
-    /** 학술/논문 질의 → `science` 카테고리 (arxiv·pubmed·google scholar·semantic scholar) */
-    SCIENCE_PATTERN: /(논문|학술|저널|피인용|임상|의학\s?연구|arxiv|pubmed|scholar|preprint|\bpaper\b|research\s+paper|\bstudy\b)/i,
+    /** 기술/개발 질의 → `it` 카테고리 (github·stackoverflow·mdn·pypi·docker hub).
+     *  ⚠️ 단독 `코드` 같은 일반어 토큰 금지 — '할인 코드' 류 비기술 질의가 매칭돼 카테고리를 오염시킨다. */
+    IT_PATTERN: /(에러|오류|버그|디버깅|코드\s?리뷰|코딩|라이브러리|프레임워크|컴파일|리액트|백엔드|프론트엔드|데이터베이스|프로그래밍|소스\s?코드|개발\s?환경|\bapi\b|\bsdk\b|\bnpm\b|\bpip\b|docker|kubernetes|github|typescript|javascript|python|\bjava\b|\brust\b|golang|react|next\.?js|node\.?js|\bsql\b)/i,
+    /** 학술/논문 질의 → `science` 카테고리 (arxiv·pubmed·google scholar·semantic scholar).
+     *  ⚠️ 단독 `paper`/`study` 금지 — 'paper towel'·'study cafe' 류 일반 질의 오매칭. */
+    SCIENCE_PATTERN: /(논문|학술|저널|피인용|임상|의학\s?연구|arxiv|pubmed|scholar|preprint|research\s+paper|academic\s+paper|clinical\s+(trial|study))/i,
 } as const;
 
 /**

--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -12,6 +12,7 @@ import { requireAuth, requireAdmin } from '../auth';
 import { createLogger } from '../utils/logger';
 import { success, badRequest, notFound, internalError } from '../utils/api-response';
 import { CAPACITY } from '../config/runtime-limits';
+import { validatePasswordComplexity } from '../services/AuthService';
 import { listAlertHistory, exportAlertHistoryCsv, getAlertStats, getLlmPoolStats, acknowledgeAlert } from './admin-alerts.controller';
 
 const log = createLogger('AdminController');
@@ -247,8 +248,14 @@ export class AdminController {
                 res.status(400).json(badRequest('유효한 이메일을 입력하세요'));
                 return;
             }
-            if (!password || password.length < 6) {
-                res.status(400).json(badRequest('비밀번호는 6자 이상이어야 합니다'));
+            // 자체 가입과 동일한 비밀번호 정책 적용 (updateUser 와 동일 — 인라인 6자 기준 제거)
+            if (!password) {
+                res.status(400).json(badRequest('비밀번호를 입력하세요'));
+                return;
+            }
+            const passwordValidation = validatePasswordComplexity(password);
+            if (!passwordValidation.valid) {
+                res.status(400).json(badRequest(passwordValidation.errors.join(', ')));
                 return;
             }
             const userRole: UserRole = isUserRole(role) ? role : USER_ROLES.USER;
@@ -312,9 +319,18 @@ export class AdminController {
             const userId = req.params.id;
             const { email, role, is_active, password } = req.body as { email?: string; role?: UserRole; is_active?: boolean; password?: string };
 
-            if (password !== undefined && (typeof password !== 'string' || password.length < 6)) {
-                res.status(400).json(badRequest('비밀번호는 6자 이상이어야 합니다'));
-                return;
+            // 자체 가입과 동일한 비밀번호 정책(PASSWORD_POLICY 길이+복잡도) 적용 — 관리자 경로만
+            // 느슨한 인라인 기준(6자)이 남아 정책이 갈라지던 것을 통일.
+            if (password !== undefined) {
+                if (typeof password !== 'string') {
+                    res.status(400).json(badRequest('비밀번호 형식이 올바르지 않습니다'));
+                    return;
+                }
+                const passwordValidation = validatePasswordComplexity(password);
+                if (!passwordValidation.valid) {
+                    res.status(400).json(badRequest(passwordValidation.errors.join(', ')));
+                    return;
+                }
             }
 
             const user = await userManager.updateUser(userId, { email, role, is_active, password });

--- a/apps/api/src/data/user-manager.ts
+++ b/apps/api/src/data/user-manager.ts
@@ -308,9 +308,18 @@ class UserManagerImpl {
 
     async getUserByEmail(email: string): Promise<{ id: string; email: string; password: string; role: UserRole } | null> {
         const pool = getPool();
-        // username 이 email 과 다르게 변경된 계정도 찾아야 하므로 email OR username 으로 조회
-        // (createUser 의 중복 체크와 동일 기준 — 기준이 달라 OAuth 로그인이 막히던 결함, 2026-08-13)
-        const result = await pool.query('SELECT * FROM users WHERE email = $1 OR username = $1', [email]);
+        // username 이 email 로 남아있는 legacy 계정(email 컬럼 미기입)도 찾아야 하므로 username 폴백 조회
+        // (createUser 의 중복 체크와 기준이 달라 OAuth 로그인이 막히던 결함, 2026-08-13).
+        // ⚠️ email 은 UNIQUE 가 아니므로: ① email 정확 일치 우선 ② username 일치는 email 이 빈 행만
+        // 인정 — 다른 이메일이 등록된 계정(username 만 이 email 인 타인 계정)에 OAuth 로그인이
+        // 비밀번호 검증 없이 바인딩되는 계정 탈취를 차단한다. ③ ORDER BY + LIMIT 1 로 결정적 선택.
+        const result = await pool.query(
+            `SELECT * FROM users
+             WHERE email = $1 OR (username = $1 AND (email IS NULL OR email = ''))
+             ORDER BY (email = $1) DESC NULLS LAST, created_at ASC
+             LIMIT 1`,
+            [email]
+        );
         const row = result.rows[0] as UserRow | undefined;
         if (!row) return null;
         return {

--- a/apps/api/src/mcp/web-search/__tests__/naver-client.test.ts
+++ b/apps/api/src/mcp/web-search/__tests__/naver-client.test.ts
@@ -13,6 +13,11 @@ jest.mock('../../../config', () => ({
 jest.mock('../../../storage', () => ({
     getKeyValueStore: jest.fn(),
 }));
+// env 파생 상수 고정 (project_jest_env_dependent_tests 관용구)
+jest.mock('../../../config/runtime-limits', () => ({
+    ...jest.requireActual('../../../config/runtime-limits'),
+    NAVER_QUOTA: { SUPPLEMENTARY_RATIO: 0.9 },
+}));
 
 const mockGetConfig = getConfig as jest.Mock;
 const mockGetStore = getKeyValueStore as jest.Mock;
@@ -130,6 +135,16 @@ describe('buildNaverSearchRequest — 일일 한도 가드', () => {
     it('KVStore 장애 시 fail-open (요청 허용)', async () => {
         setConfig({ naverClientId: 'id', naverClientSecret: 'sec', naverApiDailyLimit: 100 });
         mockGetStore.mockImplementation(() => { throw new Error('redis down'); });
+        expect(await buildNaverSearchRequest('news', 'query=x')).not.toBeNull();
+    });
+
+    it('보조 endpoint(encyc)는 소프트 컷(한도×비율) 초과 시 차단 + 카운트 환불, 핵심은 계속 허용', async () => {
+        setConfig({ naverClientId: 'id', naverClientSecret: 'sec', naverApiDailyLimit: 100 });
+        const incrBy = jest.fn().mockResolvedValue(95); // 소프트 컷(90) 초과, 하드 한도(100) 이내
+        mockGetStore.mockReturnValue({ incrBy, expire: jest.fn().mockResolvedValue(true) });
+        expect(await buildNaverSearchRequest('encyc', 'query=x')).toBeNull();
+        expect(incrBy).toHaveBeenCalledWith(expect.any(String), -1); // 미발신분 환불
+        expect(await buildNaverSearchRequest('webkr', 'query=x')).not.toBeNull();
         expect(await buildNaverSearchRequest('news', 'query=x')).not.toBeNull();
     });
 

--- a/apps/api/src/mcp/web-search/naver-client.ts
+++ b/apps/api/src/mcp/web-search/naver-client.ts
@@ -17,6 +17,7 @@
  * @module mcp/web-search/naver-client
  */
 import { getConfig } from '../../config';
+import { NAVER_QUOTA } from '../../config/runtime-limits';
 import { getKeyValueStore } from '../../storage';
 import { createLogger } from '../../utils/logger';
 
@@ -49,8 +50,12 @@ export interface NaverSearchRequest {
 /**
  * 오늘 버킷에 1 증가 후 한도 검사. 한도 도달이면 false (요청 차단).
  * 증가가 먼저라 race-free — 한도 초과 시 카운터가 한도를 넘겨 있지만 요청은 안 나간다.
+ *
+ * 보조 endpoint(supplementary=encyc)는 소프트 컷(한도×SUPPLEMENTARY_RATIO)에서 먼저 중단해
+ * 핵심(news/webkr) 쿼터 잠식을 막는다 — 차단 시 요청이 안 나가므로 카운트를 환불해
+ * 잔여 쿼터 집계를 실제 발신 요청 수와 일치시킨다.
  */
-async function underDailyLimit(now: number): Promise<boolean> {
+async function underDailyLimit(now: number, supplementary: boolean): Promise<boolean> {
     const limit = getConfig().naverApiDailyLimit;
     if (limit <= 0) return true; // 0 = 무제한 (가드 해제)
     try {
@@ -58,9 +63,14 @@ async function underDailyLimit(now: number): Promise<boolean> {
         const key = dayKey(now);
         const used = await store.incrBy(key, 1);
         void store.expire(key, DAY_TTL_MS);
-        if (used > limit) {
-            // 하루 한 번만 경고가 도배되지 않도록 초과 직후 구간만 로그
-            if (used <= limit + 3) {
+        const effectiveLimit = supplementary
+            ? Math.floor(limit * NAVER_QUOTA.SUPPLEMENTARY_RATIO)
+            : limit;
+        if (used > effectiveLimit) {
+            if (supplementary) {
+                void store.incrBy(key, -1); // 미발신분 환불
+            } else if (used <= limit + 3) {
+                // 하루 한 번만 경고가 도배되지 않도록 초과 직후 구간만 로그
                 logger.warn(`네이버 검색 일일 한도(${limit}) 도달 — 오늘 호출 차단 (KST 자정 리셋)`);
             }
             return false;
@@ -108,6 +118,6 @@ export async function buildNaverSearchRequest(
         return null; // 키 미설정 — 기존 graceful 동작 유지
     }
 
-    if (!(await underDailyLimit(now))) return null;
+    if (!(await underDailyLimit(now, endpoint === 'encyc'))) return null;
     return req;
 }

--- a/apps/api/src/mcp/web-search/search-orchestrator.ts
+++ b/apps/api/src/mcp/web-search/search-orchestrator.ts
@@ -156,9 +156,19 @@ export async function performWebSearch(query: string, options: { maxResults?: nu
 
     // Tier 1 escalation — 무료(Tier 0) 수집이 부족할 때만 Exa 공식 API 로 보강한다.
     // 결정적 개수 비교뿐(LLM 판단 아님), EXA_API_KEY 미설정이면 searchExa 가 즉시 빈 배열.
+    // 병렬 배치 이후의 직렬 호출이라 TTFT 에 직결 — TIMEOUT_MS 로 지연 상한을 캡한다
+    // (초과 시 보강 포기, Tier 0 결과만으로 진행. 뒤늦게 도착한 결과는 버려질 뿐 무해).
     if (SEARCH_ESCALATION.MIN_RESULTS > 0 && uniqueResults.length < SEARCH_ESCALATION.MIN_RESULTS) {
         const tier0Count = uniqueResults.length;
-        const exaResults = await searchExa(query, SEARCH_ESCALATION.EXA_NUM_RESULTS, signal);
+        const exaPromise = searchExa(query, SEARCH_ESCALATION.EXA_NUM_RESULTS, signal);
+        const exaResults = SEARCH_ESCALATION.TIMEOUT_MS > 0
+            ? await Promise.race([
+                exaPromise,
+                new Promise<SearchResult[]>((resolve) => {
+                    setTimeout(() => resolve([]), SEARCH_ESCALATION.TIMEOUT_MS).unref?.();
+                }),
+            ])
+            : await exaPromise;
         for (const r of exaResults) {
             const normalizedUrl = r.url.replace(/\/$/, '').replace(/^https?:\/\//, '').toLowerCase();
             if (seen.has(normalizedUrl)) continue;

--- a/apps/api/src/routes/admin-system-settings.routes.ts
+++ b/apps/api/src/routes/admin-system-settings.routes.ts
@@ -57,12 +57,15 @@ async function syncAdminProviderKey(adminId: string | null, settingKey: string, 
             if (!entry) return;
             // 카탈로그 sdkType 은 넓은 SdkType — BYOK 테이블은 외부 2종만 허용하므로 내로잉
             if (entry.sdkType !== 'anthropic' && entry.sdkType !== 'openai-compatible') return;
+            // 기존 행의 custom baseUrl 보존 — upsert 가 base_url = EXCLUDED.base_url 이라
+            // 카탈로그 기본값을 넣으면 BYOK 화면에서 설정한 커스텀 endpoint 가 조용히 되돌아간다.
+            const existing = await repo.getByUserAndProvider(adminId, providerId);
             await repo.upsert({
                 userId: adminId,
                 providerId,
                 sdkType: entry.sdkType,
                 displayName: entry.displayName,
-                baseUrl: entry.defaultBaseUrl ?? null,
+                baseUrl: existing?.baseUrl ?? entry.defaultBaseUrl ?? null,
                 apiKey: value,
             });
             // BYOK 등록 경로(external-keys.routes)와 동일한 캐시 무효화 — stale 모델 목록/가용성 제거

--- a/apps/api/src/services/AuthService.ts
+++ b/apps/api/src/services/AuthService.ts
@@ -83,7 +83,7 @@ export interface AuthResult {
  * - At least one number
  * - At least one special character
  */
-function validatePasswordComplexity(password: string): { valid: boolean; errors: string[] } {
+export function validatePasswordComplexity(password: string): { valid: boolean; errors: string[] } {
     const errors: string[] = [];
 
     if (password.length < PASSWORD_POLICY.MIN_LENGTH) {

--- a/apps/api/src/services/chat-service/external-deterministic-append.ts
+++ b/apps/api/src/services/chat-service/external-deterministic-append.ts
@@ -150,12 +150,16 @@ export function appendDeterministicBlocks(input: DeterministicAppendInput): stri
                 numToSource.set(mm[1], { title: mm[2].trim(), url: mm[3].trim() });
             }
         }
-        // 본문에 인용된 소스 번호 ([출처 N]/[Source N]/[N] — 수집 목록에 있는 번호만 인정)
+        // 본문에 인용된 소스 번호 ([출처 N]/[Source N]/[N] — 수집 목록에 있는 번호만 인정).
+        // 대괄호 안 숫자를 전부 인정 — `[출처 3, 8]` 복합 인용에서 마지막 숫자만 잡혀 앞 번호
+        // 출처가 목록에서 빠지던 결함 방지.
         const citedNums: string[] = [];
-        const citeRe = /\[[^\]\n]*?(\d+)\]/g;
+        const citeRe = /\[[^\]\n]*\d[^\]\n]*\]/g;
         let cm: RegExpExecArray | null;
         while ((cm = citeRe.exec(finalContent)) !== null) {
-            if (numToSource.has(cm[1]) && !citedNums.includes(cm[1])) citedNums.push(cm[1]);
+            for (const num of cm[0].match(/\d+/g) ?? []) {
+                if (numToSource.has(num) && !citedNums.includes(num)) citedNums.push(num);
+            }
         }
         if (!alreadyHasSources) {
             // canonical 목록 첨부 — 인용된 번호가 있으면 그 소스만(정밀), 없으면 전체(기존 동작).
@@ -178,9 +182,16 @@ export function appendDeterministicBlocks(input: DeterministicAppendInput): stri
             }
         } else {
             // 모델이 목록 작성 금지 지시를 무시하고 섹션을 만든 경우 — 인용 번호별로 해당
-            // 소스 URL 이 본문 어딘가에 존재하는지 검증, 누락분만 보강. 인용이 전혀 없는데
+            // 소스 URL 이 **출처 섹션 안에** 존재하는지 검증, 누락분만 보강. 인용이 전혀 없는데
             // 섹션에 URL 도 없으면(제목만 나열) 전체 번호 보강 (기존 동작 유지).
-            const missingNums = citedNums.filter((n) => !finalContent.includes(numToSource.get(n)!.url));
+            // 검사는 섹션 스코프(본문 산문의 URL 언급이 섹션 누락을 가리지 않게) + URL 정규화
+            // (프로토콜·트레일링 슬래시·대소문자 변형이 중복 첨부로 이어지지 않게) 비교.
+            const normalizeUrl = (u: string) =>
+                u.replace(/[),.\]]+$/, '').replace(/\/$/, '').replace(/^https?:\/\//i, '').toLowerCase();
+            const sectionUrls = new Set(
+                (finalContent.slice(headerIdx).match(/https?:\/\/[^\s)\]]+/g) ?? []).map(normalizeUrl),
+            );
+            const missingNums = citedNums.filter((n) => !sectionUrls.has(normalizeUrl(numToSource.get(n)!.url)));
             const nums = missingNums.length > 0
                 ? missingNums
                 : citedNums.length === 0 && !/https?:\/\//.test(finalContent.slice(headerIdx))


### PR DESCRIPTION
## 요약

배치 커밋 48d3142c(#484) 코드리뷰에서 검증된 결함 9건 일괄 수정.

### 보안 (영향 범위 명시)

- **OAuth 계정 바인딩 비결정성 차단** (`data/user-manager.ts` `getUserByEmail`)
  - 기존: `WHERE email = $1 OR username = $1` (ORDER BY/LIMIT 없음). `email` 컬럼은 UNIQUE 가 아니라(`username`만 UNIQUE) 두 행 매치 시 임의 행이 선택되고, 유일 호출처인 OAuth `findOrCreateOAuthUser` 가 **비밀번호 검증 없이** 그 계정으로 JWT 를 발급 — username 만 피해자 이메일로 등록한 타 계정에 로그인이 바인딩될 수 있었음.
  - 수정: ① email 정확 일치 우선 ② username 폴백은 email 컬럼이 빈(legacy) 행만 인정 ③ `ORDER BY … LIMIT 1` 결정적 선택. legacy 계정(email 미기입) OAuth 로그인은 기존대로 동작.
  - 영향 범위: OAuth 로그인 경로 한정(Google/Kakao). 일반 로그인(`authenticate`)은 bcrypt 검증이 있어 무변경.

### 채팅/검색 결함

- **복합 인용 출처 유실**: `[출처 3, 8]`에서 마지막 숫자만 캡처돼 앞 번호 출처가 목록에서 빠지던 정규식 수정 — 대괄호 안 숫자 전부 인정 (`external-deterministic-append.ts`)
- **출처 URL 존재 검사 오판**: 문서 전체 substring 매치 → 출처 섹션 스코프 + URL 정규화 비교. 본문 산문 URL 이 섹션 누락을 가리던 회귀와 표기 변형 중복 첨부 모두 해소
- **NAVER 일일 쿼터 잠식**: encyc(보조)는 소프트 컷(한도×0.9, `NAVER_SUPPLEMENTARY_QUOTA_RATIO`) 도달 시 먼저 중단 + 미발신분 카운트 환불 — 핵심(news/webkr) 검색이 하드 한도까지 유지되고 KO 검색 조기 전면 차단이 사라짐 (`naver-client.ts`)
- **Exa escalation TTFT 캡**: 병렬 배치 이후 직렬 Exa 호출에 `SEARCH_ESCALATION_TIMEOUT_MS`(기본 4s, 0=무제한) 상한 — 초과 시 Tier 0 결과로 진행 (`search-orchestrator.ts`)
- **SearXNG 카테고리 패턴 정리**: 단독 `코드`→`코드 리뷰`, 단독 `paper`/`study` 제거 — '할인 코드'·'paper towel' 류 일반 질의 오매칭 방지. `\bapi\b`/`\bsql\b`은 비기술 문맥 오탐 여지가 낮아 유지 (`runtime-limits.ts`)

### 관리자 결함

- **BYOK base_url 덮어쓰기**: admin 시스템 설정의 provider 키 동기화가 기존 행의 custom baseUrl 을 카탈로그 기본값으로 되돌리던 것 — 기존 값 보존 (`admin-system-settings.routes.ts`)
- **비밀번호 정책 통일**: 관리자 사용자 생성·수정의 인라인 6자 기준 제거, 자체 가입과 동일한 `PASSWORD_POLICY`(`validatePasswordComplexity` export·재사용) 적용 (`admin.controller.ts`)

### 문서

- `.env.example`: 누락 4종(`SEARCH_ESCALATION_MIN_RESULTS`/`EXA_RESULTS`, `RESEARCH_TAVILY_MAX_RESULTS`/`DEPTH`) + 신규 2종(`SEARCH_ESCALATION_TIMEOUT_MS`, `NAVER_SUPPLEMENTARY_QUOTA_RATIO`) 문서화

## 테스트

- 회귀 테스트 2건 추가: getUserByEmail 보안 불변식(빈 email 행만 폴백·LIMIT 1), encyc 소프트 컷 차단+환불·핵심 endpoint 지속
- `npx tsc --noEmit` 통과, 변경 파일 eslint 클린(runtime-limits.ts max-lines 경고는 기존)
- 백엔드 유닛 전체 **2,571 passed / 0 failed**

## 체크리스트

- [x] lint 통과 (변경 파일)
- [x] npm test (백엔드 유닛) 통과
- [x] 환경변수 추가 시 .env.example 업데이트
- [x] 보안 관련 변경 영향 범위 명시 (위 보안 절)
- [ ] 라우팅/응답 eval — 해당 없음 (라우팅/응답 템플릿 무변경)
- [ ] DB 스키마 변경 — 해당 없음
- [ ] UI 변경 — 해당 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)