### PR TITLE
fix(chat): 수집 목록 밖 죽은 인용 마커 결정적 제거 + done 시 화면 정리

### DIFF
--- a/apps/api/src/services/chat-service/__tests__/dead-citation-markers.test.ts
+++ b/apps/api/src/services/chat-service/__tests__/dead-citation-markers.test.ts
@@ -1,0 +1,61 @@
+/**
+ * 죽은 인용 마커 결정적 제거 — stripDeadCitationMarkers / citationMarkersWereCleaned.
+ * 모델(qwen)이 수집 목록에 없는 출처 번호를 지어내는 비순응(2026-08-15 실측 73% 순응)의 후처리 검증.
+ */
+import { stripDeadCitationMarkers, citationMarkersWereCleaned } from '../external-deterministic-append';
+
+const VALID = new Set(['1', '2', '3', '8', '10']);
+
+describe('stripDeadCitationMarkers', () => {
+    test('수집 목록 밖 번호 마커는 제거된다 (선행 공백 포함)', () => {
+        const r = stripDeadCitationMarkers('유가가 상승했다 [출처 14]. 다음 문장.', VALID);
+        expect(r.content).toBe('유가가 상승했다. 다음 문장.');
+        expect(r.removed).toBe(1);
+    });
+
+    test('유효 번호 마커는 그대로 유지된다', () => {
+        const text = '사실이다 [출처 3]. 그리고 [Source 8]도.';
+        const r = stripDeadCitationMarkers(text, VALID);
+        expect(r.content).toBe(text);
+        expect(r.removed).toBe(0);
+    });
+
+    test('복합 인용에서 일부만 유효하면 유효 번호로 재작성된다', () => {
+        const r = stripDeadCitationMarkers('근거 [출처 3, 14]이다.', VALID);
+        expect(r.content).toBe('근거 [출처 3]이다.');
+        expect(r.removed).toBe(1);
+    });
+
+    test('7개 언어 라벨을 모두 인식한다', () => {
+        const r = stripDeadCitationMarkers('a [Source 15] b [出典 14] c [来源 13] d [Fuente 12] e [Quelle 11]', VALID);
+        expect(r.content).toBe('a b c d e');
+        expect(r.removed).toBe(5);
+    });
+
+    test('라벨 없는 대괄호 숫자([14]·마크다운 링크·각주)는 건드리지 않는다', () => {
+        const text = '배열 [14] 와 링크 [제목 99](https://x.com) 유지.';
+        const r = stripDeadCitationMarkers(text, VALID);
+        expect(r.content).toBe(text);
+        expect(r.removed).toBe(0);
+    });
+});
+
+describe('citationMarkersWereCleaned', () => {
+    test('스트리밍본에 있던 마커가 최종본에서 사라지면 true', () => {
+        expect(citationMarkersWereCleaned('본문 [출처 14] 끝', '본문 끝')).toBe(true);
+    });
+
+    test('복합 인용이 축소돼도 true', () => {
+        expect(citationMarkersWereCleaned('근거 [출처 3, 14]', '근거 [출처 3]')).toBe(true);
+    });
+
+    test('마커 변화가 없으면 false (출처 목록 append 만 있어도)', () => {
+        const streamed = '본문 [출처 3]';
+        const final = '본문 [출처 3]\n\n---\n\n**출처**\n3. [제목](https://x.com)';
+        expect(citationMarkersWereCleaned(streamed, final)).toBe(false);
+    });
+
+    test('마커가 아예 없으면 false', () => {
+        expect(citationMarkersWereCleaned('그냥 본문', '그냥 본문 + 첨부')).toBe(false);
+    });
+});

--- a/apps/api/src/services/chat-service/external-deterministic-append.ts
+++ b/apps/api/src/services/chat-service/external-deterministic-append.ts
@@ -22,6 +22,50 @@ import type { StreamFromExternalContext } from './external-provider';
 
 const logger = createLogger('ChatExternalProvider');
 
+/** 7개 언어 sourceLabel 의 정규식 alternation (중복 제거·이스케이프) — 템플릿이 SoT */
+const SOURCE_LABEL_ALT = [...new Set(Object.values(WEB_SEARCH_TEMPLATES).map((t) => t.sourceLabel))]
+    .map((l) => l.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|');
+/** 라벨 인용 마커 소스 — `[출처 3]`·`[Source 1, 2]` 형태. 라벨 없는 `[3]` 은 각주/코드 오탐 위험으로 제외. */
+const CITATION_MARKER_SRC = `\\[\\s*(?:${SOURCE_LABEL_ALT})\\s*\\d+(?:\\s*[,·、]\\s*\\d+)*\\s*\\]`;
+
+/**
+ * 수집 목록(validNums)에 없는 번호의 죽은 인용 마커를 제거한다 — 모델(qwen)이 주입 상한을
+ * 넘는 번호([출처 11]~)를 지어내는 비순응의 결정적 후처리 (프롬프트 지시 단독 73% 순응, 2026-08-15 실측).
+ * 전부 무효면 마커 삭제(선행 공백 1개 포함), 일부만 유효면 유효 번호로 재작성.
+ */
+export function stripDeadCitationMarkers(
+    content: string,
+    validNums: ReadonlySet<string>,
+): { content: string; removed: number } {
+    let removed = 0;
+    const out = content.replace(new RegExp(`\\s?${CITATION_MARKER_SRC}`, 'gi'), (match) => {
+        const nums = match.match(/\d+/g) ?? [];
+        const valid = nums.filter((n) => validNums.has(n));
+        if (valid.length === nums.length) return match;
+        removed++;
+        if (valid.length === 0) return '';
+        const label = new RegExp(`(${SOURCE_LABEL_ALT})`, 'i').exec(match)?.[1] ?? '출처';
+        return `${match.startsWith(' ') ? ' ' : ''}[${label} ${valid.join(', ')}]`;
+    });
+    return { content: out, removed };
+}
+
+/**
+ * 스트리밍 본문(streamed)에 있던 인용 마커가 최종본(final)에서 제거/축소됐는지 감지 —
+ * ws-chat-handler 가 done.cleanedContent 로 화면 본문을 교체할지 판정하는 데 사용
+ * (artifact placeholder·script-purity 교체와 동일 패턴: 차이가 있는 턴만 정확히 겨냥).
+ */
+export function citationMarkersWereCleaned(streamed: string, final: string): boolean {
+    const collect = (s: string) =>
+        new Set((s.match(new RegExp(CITATION_MARKER_SRC, 'gi')) ?? []).map((m) => m.replace(/\s+/g, '')));
+    const before = collect(streamed);
+    if (before.size === 0) return false;
+    const after = collect(final);
+    for (const m of before) if (!after.has(m)) return true;
+    return false;
+}
+
 export interface DeterministicAppendInput {
     /** 모델이 만든 최종 본문 (이미 라이브 스트리밍된 텍스트). */
     finalContent: string;
@@ -149,6 +193,13 @@ export function appendDeterministicBlocks(input: DeterministicAppendInput): stri
             if (!numToSource.has(mm[1])) {
                 numToSource.set(mm[1], { title: mm[2].trim(), url: mm[3].trim() });
             }
+        }
+        // 수집 목록에 없는 번호의 죽은 인용 마커 결정적 제거 — 저장 히스토리(반환값)가 대상.
+        // 이미 스트리밍된 화면은 ws-chat-handler 의 done.cleanedContent 교체가 완료 시점에 정리.
+        const stripRes = stripDeadCitationMarkers(finalContent, new Set(numToSource.keys()));
+        if (stripRes.removed > 0) {
+            finalContent = stripRes.content;
+            logger.info(`🧹 죽은 인용 마커 ${stripRes.removed}개 제거 (수집 목록 밖 번호)`);
         }
         // 본문에 인용된 소스 번호 ([출처 N]/[Source N]/[N] — 수집 목록에 있는 번호만 인정).
         // 대괄호 안 숫자를 전부 인정 — `[출처 3, 8]` 복합 인용에서 마지막 숫자만 잡혀 앞 번호

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -23,6 +23,7 @@ import { FILE_ATTACH_LIMITS } from '../config/runtime-limits';
 import { ArtifactStreamParser, type ArtifactInfo } from '../llm/artifact-parser';
 import { buildFileContext, buildUrlContext, getCachedAttachContext, appendCachedAttachContext } from '../services/chat-service/attach-context';
 import { hasScriptMixing } from '../services/chat-service/script-purity';
+import { citationMarkersWereCleaned } from '../services/chat-service/external-deterministic-append';
 import { saveAssistantMessage } from '../chat/request-persistence';
 import { buildWebSearchContext } from '../mcp/web-search/build-search-context';
 
@@ -415,11 +416,13 @@ export async function handleChatMessage(
         // 스크립트 순수성 교정(script-purity)이 실제로 적용된 경우에도 본문을 교체한다 —
         // 스트리밍으로 이미 나간 화면엔 한자 혼입이 남아 있고 최종본만 교정돼 있으므로,
         // 그 차이가 있을 때만 정확히 겨냥해 reset 한다(그 외 턴은 기존대로 undefined).
+        // 죽은 인용 마커 제거(external-deterministic-append)가 적용된 턴도 동일 패턴으로 교체 —
+        // 스트리밍 화면에 남은 [출처 N](수집 목록 밖 번호) 마커를 완료 시점에 정리한다.
         const cleanedContent = (result.artifacts && result.artifacts.length > 0)
             ? result.response
             : (result.response
-                && hasScriptMixing(partialAssistantResponse)
-                && !hasScriptMixing(result.response)
+                && ((hasScriptMixing(partialAssistantResponse) && !hasScriptMixing(result.response))
+                    || citationMarkersWereCleaned(partialAssistantResponse, result.response))
                 ? result.response
                 : undefined);
         ws.send(JSON.stringify({


### PR DESCRIPTION
## 요약

프롬프트 제약(#489)만으로는 qwen 이 주입 상한(10개)을 넘는 출처 번호를 지어내는 비순응을 못 막았다 (배포 후 라이브 3쿼리 실측: 인용 26개 중 invented 7개, 73% 순응, 3/3 쿼리 발생 — 전부 11~15 패턴). 이 PR 은 결정적 후처리로 마무리한다.

- **`stripDeadCitationMarkers`** (`external-deterministic-append.ts`): 수집 목록(`numToSource`)에 없는 번호의 라벨 인용 마커 제거. 전부 무효 → 마커 삭제(선행 공백 포함), 일부 유효(`[출처 3, 14]`) → `[출처 3]` 재작성. 라벨 alternation 은 `WEB_SEARCH_TEMPLATES` 7개 언어 sourceLabel 에서 동적 생성(SoT), 라벨 없는 `[14]`·마크다운 링크·각주는 미대상(오탐 방지). append 단계에서 출처 목록 첨부 전 적용 → 저장 히스토리 정리.
- **`citationMarkersWereCleaned`** + `ws-chat-handler` `done.cleanedContent` 조건 합류: 마커가 실제 제거/축소된 턴만 겨냥해 완료 시점에 화면 본문을 정본으로 교체 (artifact placeholder·script-purity 와 동일 패턴, 그 외 턴 무변경).
- 한계(설계상 수용): 스트리밍 도중엔 마커가 잠깐 보였다가 `done` 에서 사라짐 — 이미 전송된 토큰은 회수 불가 (report-block 접기와 동일).

## 테스트

- 신규 `dead-citation-markers.test.ts` 9건 (제거/유지/복합 재작성/7언어 라벨/비라벨 보호 + 감지 4케이스)
- `npx tsc --noEmit` 통과, 백엔드 전체 **2,580 passed / 0 failed**
- 머지·배포 후 라이브 순응도 재실측 예정 (목표: invented 0)

## 체크리스트

- [x] lint/typecheck·전체 유닛 통과
- [ ] 환경변수/DB 스키마/UI 변경 — 해당 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)