### PR TITLE
fix: 세션 refresh CSRF 403 원복 해소·데스크톱 exec PATH 보강(v1.8.1)·OpenWork형 사이드바

### DIFF
--- a/apps/desktop/bridge.js
+++ b/apps/desktop/bridge.js
@@ -27,6 +27,37 @@ const agentBrowser = require('./agent-browser');
 const EXEC_TIMEOUT_MS = 120000;
 const MAX_BUFFER = 1024 * 1024;
 const RECONNECT_MS = 10000;
+const PATH_PROBE_TIMEOUT_MS = 5000;
+
+// ── exec PATH 보강 ───────────────────────────────────────────────────────
+// Finder 기동 GUI 앱은 로그인 셸 PATH 를 물려받지 못해 mise/Homebrew 런타임(node·npm 등)을
+// 못 찾는다 (2026-08-15 실측: 최소 PATH 에서 `node: command not found`). ① 로그인 셸 PATH
+// 캡처 ② mise 도구 경로(activate 가 zshrc 전용이라 ①에도 안 잡힘 — bin-paths 직접 조회,
+// cwd=연결 폴더라 프로젝트 버전 반영) ③ 표준 설치 경로 폴백을 병합한다. 폴더 연결 시 1회
+// 계산하고, 각 단계 실패는 다음 폴백으로 넘어간다(exec 자체를 막지 않음).
+let execPathCache = null;
+function resolveExecPath() {
+  if (execPathCache) return execPathCache;
+  const parts = [];
+  try {
+    parts.push(...execFileSync(process.env.SHELL || '/bin/zsh', ['-lc', 'echo -n "$PATH"'],
+      { encoding: 'utf8', timeout: PATH_PROBE_TIMEOUT_MS }).trim().split(':'));
+  } catch { /* 로그인 셸 실패 → 아래 폴백만 사용 */ }
+  parts.push(...(process.env.PATH || '').split(':'));
+  parts.push('/opt/homebrew/bin', '/usr/local/bin',
+    path.join(os.homedir(), '.local/bin'), path.join(os.homedir(), '.local/share/mise/shims'));
+  const base = [...new Set(parts.filter(Boolean))].join(':');
+  let merged = base;
+  try {
+    const misePaths = execFileSync('mise', ['bin-paths'],
+      { encoding: 'utf8', timeout: PATH_PROBE_TIMEOUT_MS, cwd: folderRoot || os.homedir(), env: { ...process.env, PATH: base } })
+      .trim().split('\n').filter(Boolean);
+    // 프로젝트 버전이 이기도록 mise 경로를 앞에 둔다.
+    merged = [...new Set([...misePaths, ...base.split(':')])].join(':');
+  } catch { /* mise 부재/미신뢰 설정 — base 만 사용 */ }
+  execPathCache = merged;
+  return execPathCache;
+}
 
 // ── exec OS 샌드박스 (macOS sandbox-exec) ───────────────────────────────
 // 승인된 명령이라도 OS 레벨에서 ① 연결 폴더 밖 쓰기 ② 비밀 파일 읽기를 차단한다.
@@ -339,7 +370,7 @@ async function handleExec(m, done) {
         done({ ok: false, error: 'exec 샌드박스 프로파일을 준비하지 못해 실행을 거부했습니다(폴더 재연결 필요). 비격리 실행이 필요하면 OMK_BRIDGE_SANDBOX=0 으로 앱을 실행하세요.', exitCode: 126 });
         return;
       }
-      const opts = { cwd: folderRoot, timeout: EXEC_TIMEOUT_MS, maxBuffer: MAX_BUFFER };
+      const opts = { cwd: folderRoot, timeout: EXEC_TIMEOUT_MS, maxBuffer: MAX_BUFFER, env: { ...process.env, PATH: resolveExecPath() } };
       const cb = (err, stdout, stderr) => {
         done({ ok: true, stdout: String(stdout), stderr: String(stderr), exitCode: err ? (err.code ?? 1) : 0 });
       };
@@ -468,6 +499,7 @@ async function connectFolder(app, backendUrl, win) {
     folder = r.filePaths[0];
   }
   folderRoot = fs.realpathSync(folder);
+  execPathCache = null; // 폴더가 바뀌면 mise 프로젝트 버전도 바뀔 수 있다 — PATH 재계산.
   // 연결 폴더 기준으로 exec 샌드박스 프로파일 갱신 (폴더가 바뀌면 스코프도 바뀐다).
   sandboxProfilePath = SANDBOX_ENABLED ? writeSandboxProfile(app, folderRoot, detectGitDir(folderRoot)) : null;
   await connect(app, backendUrl);

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmake-desktop",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "private": true,
   "description": "OpenMake LLM 데스크톱 셸 (macOS) — 운영 백엔드(외부 공개 도메인 / 로컬)를 네이티브 창으로",
   "author": "OpenMake Team",

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -30,6 +30,25 @@ interface SessionRow {
   sessionId?: string;
   title?: string;
   name?: string;
+  updatedAt?: string;
+  createdAt?: string;
+}
+
+/** OpenWork형 날짜 그룹 — 최근 대화를 시간대별로 묶어 밀도 있게 표시. */
+type SessionGroupKey = "today" | "yesterday" | "previous7Days" | "older";
+const SESSION_GROUP_ORDER: SessionGroupKey[] = ["today", "yesterday", "previous7Days", "older"];
+
+function sessionGroupKey(updatedAt?: string): SessionGroupKey {
+  if (!updatedAt) return "older";
+  const ts = new Date(updatedAt).getTime();
+  if (!Number.isFinite(ts)) return "older";
+  const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const dayMs = 86_400_000;
+  if (ts >= startOfToday) return "today";
+  if (ts >= startOfToday - dayMs) return "yesterday";
+  if (ts >= startOfToday - 7 * dayMs) return "previous7Days";
+  return "older";
 }
 
 export function Sidebar() {
@@ -154,6 +173,12 @@ export function Sidebar() {
       )
     : sessions;
 
+  // OpenWork형 시간대 그룹핑 — 최신순 20개를 today/yesterday/previous7Days/older 로 묶는다.
+  const groupedSessions = SESSION_GROUP_ORDER.map((key) => ({
+    key,
+    rows: filteredSessions.slice(0, 20).filter((s) => sessionGroupKey(s.updatedAt ?? s.createdAt) === key),
+  })).filter((g) => g.rows.length > 0);
+
   return (
     <aside className="flex h-full w-[264px] flex-col border-r border-border bg-surface-2/60">
       <Link href="/" className="flex items-center gap-2 px-4 pt-4 transition hover:opacity-80">
@@ -197,7 +222,7 @@ export function Sidebar() {
               <Link
                 href={item.href}
                 className={cn(
-                  "flex items-center gap-2.5 rounded-md px-2.5 py-2 text-sm transition",
+                  "flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-[13px] transition",
                   isActive(item.href)
                     ? "bg-accent-soft font-medium text-accent"
                     : "text-fg-2 hover:bg-surface-3 hover:text-fg",
@@ -220,45 +245,50 @@ export function Sidebar() {
 
         {sessions.length > 0 && (
           <div className="pt-3">
-            <p className="px-1 pb-1 text-[11px] font-medium uppercase tracking-wider text-faint">
-              {t("recentChats")}
-            </p>
             {filteredSessions.length === 0 && (
               <p className="px-2.5 py-1.5 text-sm text-faint">{t("noResults")}</p>
             )}
-            <ul className="space-y-0.5">
-              {filteredSessions.slice(0, 20).map((s, i) => {
-                const sid = s.id ?? s.sessionId;
-                const active = !!sid && sid === currentSessionId;
-                const title = s.title ?? s.name ?? t("untitledChat");
-                return (
-                  <li key={sid ?? i} className="group relative">
-                    <button
-                      type="button"
-                      onClick={() => openSession(sid)}
-                      className={cn(
-                        "w-full truncate rounded-md px-2.5 py-1.5 text-left text-sm transition group-hover:pr-8",
-                        active
-                          ? "bg-accent-soft font-medium text-accent"
-                          : "text-muted hover:bg-surface-3 hover:text-fg",
-                      )}
-                    >
-                      {title}
-                    </button>
-                    {sid && (
-                      <button
-                        type="button"
-                        aria-label={t("deleteChat")}
-                        onClick={() => void deleteSession(sid, title)}
-                        className="absolute right-1 top-1/2 grid h-6 w-6 -translate-y-1/2 place-items-center rounded text-faint opacity-0 transition group-hover:opacity-100 hover:bg-surface-3 hover:text-danger"
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </button>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
+            {groupedSessions.map((group) => (
+              <div key={group.key} className="pb-2">
+                <p className="flex items-center gap-1.5 px-1 pb-1 text-[11px] font-medium uppercase tracking-wider text-faint">
+                  <span className="h-1.5 w-1.5 rounded-full bg-accent/50" />
+                  {t(`groups.${group.key}`)}
+                </p>
+                <ul className="space-y-px">
+                  {group.rows.map((s, i) => {
+                    const sid = s.id ?? s.sessionId;
+                    const active = !!sid && sid === currentSessionId;
+                    const title = s.title ?? s.name ?? t("untitledChat");
+                    return (
+                      <li key={sid ?? i} className="group relative">
+                        <button
+                          type="button"
+                          onClick={() => openSession(sid)}
+                          className={cn(
+                            "w-full truncate rounded-md px-2.5 py-1.5 text-left text-[13px] leading-tight transition group-hover:pr-8",
+                            active
+                              ? "bg-accent-soft font-medium text-accent"
+                              : "text-muted hover:bg-surface-3 hover:text-fg",
+                          )}
+                        >
+                          {title}
+                        </button>
+                        {sid && (
+                          <button
+                            type="button"
+                            aria-label={t("deleteChat")}
+                            onClick={() => void deleteSession(sid, title)}
+                            className="absolute right-1 top-1/2 grid h-6 w-6 -translate-y-1/2 place-items-center rounded text-faint opacity-0 transition group-hover:opacity-100 hover:bg-surface-3 hover:text-danger"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </button>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            ))}
           </div>
         )}
         {/* 히스토리 진입점 — 최근 대화 유무와 무관하게 상시 노출 (없으면 이 링크가 /history 유일 경로) */}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -43,7 +43,13 @@
     "themeToggle": "Toggle theme",
     "viewAll": "View all",
     "noResults": "No results",
-    "accountMenu": "Account menu"
+    "accountMenu": "Account menu",
+    "groups": {
+      "today": "Today",
+      "yesterday": "Yesterday",
+      "previous7Days": "Previous 7 days",
+      "older": "Older"
+    }
   },
   "mobileNav": {
     "chat": "Chat",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -43,7 +43,13 @@
     "themeToggle": "テーマ切替",
     "viewAll": "すべて表示",
     "noResults": "検索結果なし",
-    "accountMenu": "アカウントメニュー"
+    "accountMenu": "アカウントメニュー",
+    "groups": {
+      "today": "今日",
+      "yesterday": "昨日",
+      "previous7Days": "過去7日間",
+      "older": "それ以前"
+    }
   },
   "mobileNav": {
     "chat": "チャット",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -43,7 +43,13 @@
     "themeToggle": "테마 전환",
     "viewAll": "모두 보기",
     "noResults": "검색 결과 없음",
-    "accountMenu": "계정 메뉴"
+    "accountMenu": "계정 메뉴",
+    "groups": {
+      "today": "오늘",
+      "yesterday": "어제",
+      "previous7Days": "지난 7일",
+      "older": "이전"
+    }
   },
   "mobileNav": {
     "chat": "채팅",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -43,7 +43,13 @@
     "themeToggle": "切换主题",
     "viewAll": "查看全部",
     "noResults": "无搜索结果",
-    "accountMenu": "账户菜单"
+    "accountMenu": "账户菜单",
+    "groups": {
+      "today": "今天",
+      "yesterday": "昨天",
+      "previous7Days": "过去 7 天",
+      "older": "更早"
+    }
   },
   "mobileNav": {
     "chat": "聊天",

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -66,7 +66,10 @@ let refreshInFlight: Promise<boolean> | null = null;
 
 function refreshOnce(): Promise<boolean> {
   if (!refreshInFlight) {
-    refreshInFlight = fetch("/api/auth/refresh", { method: "POST", credentials: "include" })
+    // CSRF_PROTECTION=enforce 에서 헤더 없는 refresh 는 403 — 만료 후 첫 401 인터셉트가
+    // 항상 실패해 /login 으로 원복되던 결함 (2026-08-15). 헤더를 붙여 호출한다.
+    refreshInFlight = csrfHeaders()
+      .then((headers) => fetch("/api/auth/refresh", { method: "POST", credentials: "include", headers }))
       .then((r) => r.ok)
       .catch(() => false)
       .finally(() => {


### PR DESCRIPTION
## 요약

세 갈래 수정 배치 (전부 운영 라이브 검증 완료):

### 1. 로그인 "성공 후 원복" 회귀 수정 (`packages/api-client`)
- 원인: `refreshOnce()` 가 CSRF 헤더 없이 `POST /api/auth/refresh` 호출 → `CSRF_PROTECTION=enforce` 에서 항상 403 → 액세스 토큰(15분) 만료 후 첫 401 인터셉트가 refresh 에 실패해 `/login` 리다이렉트 (웹·데스크톱 공통 체감: "로그인했는데 다시 로그인 화면").
- 수정: `csrfHeaders()` 로 CSRF 헤더 첨부. 다른 두 호출처(providers 선제 갱신·use-chat-socket)는 ApiClient 경유라 이미 정상 — raw fetch 인 이 지점만 갭이었음.
- 검증: 운영에서 만료 토큰 상태 재현 → refresh 200 → `auth_token` 재발급 → 세션 유지 확인.

### 2. 데스크톱 exec PATH 보강 + v1.8.1 (`apps/desktop`)
- 원인(실측): Finder 기동 GUI 앱은 로그인 셸 PATH 를 물려받지 못해 로컬 실행 exec 에서 mise/Homebrew 런타임이 `command not found` (node·npm 불가, 시스템 python3·java 만 동작).
- 수정: 로그인 셸 PATH 캡처(5s 타임아웃) + `mise bin-paths`(연결 폴더 cwd — 프로젝트 버전 반영) + 표준 설치 경로 폴백 병합. 폴더 연결 시 1회 계산, 단계별 fail-open.
- 검증: 최소 PATH 하네스에서 수정 전 node not found → 수정 후 node/npm/python/java 전부 해석. v1.8.1 dmg 게시 + 설치본 1.8.0→1.8.1 자동 업데이트 3종 증거(서버 다운로드 로그·Info.plist·렌더러) 확인.

### 3. OpenWork형 사이드바 (`apps/web`)
- 대화 목록 시간대 그룹핑(오늘/어제/지난 7일/이전, 도트 헤더) + 리스트 밀도 상향. 라우트·store 계약·기존 로직 무변경.
- i18n: 4개 언어(ko/en/ja/zh) `sidebar.groups` 4키 추가 — 키 패리티 검증 완료.

## 체크리스트
- [x] `npm run lint` 통과 (0 errors)
- [x] `npm test` 통과 (2580 passed / 0 failed)
- [x] tsc `--noEmit` web·api 0
- [x] 라우팅/응답 변경 없음 (eval 해당 없음)
- [x] DB 스키마 변경 없음
- [x] 환경변수 추가 없음
- [x] UI 변경: 운영 라이브 스크린샷 검증 완료 (사이드바 그룹핑 렌더 확인)
- [x] 보안: CSRF 정책 완화 없음 — 클라이언트가 기존 정책(이중제출)을 준수하도록 수정. 데스크톱 PATH 보강은 exec 승인 다이얼로그·denylist·sandbox-exec 게이트 무변경

## 참고
- 운영에는 이미 배포·검증된 상태의 코드입니다 (서버/웹 deploy + 데스크톱 dmg 자체 업데이트 게시 완료).
- 같은 세션에서 도입 검토했던 컴퓨터 제어(computer_use)·cli_agent 는 방침 결정으로 전면 철회되어 이 PR 에 포함되지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)