### PR TITLE
fix(web): composer 한글 IME Enter 이중 제출 가드

### DIFF
--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -754,6 +754,10 @@ export function Composer() {
             }
           }}
           onKeyDown={(e) => {
+            // 한글 등 IME 조합 중 Enter 는 조합 확정 이벤트가 keydown 을 한 번 더 발생시켜
+            // 제출이 2회 실행된다(조합 중이던 음절만 담긴 유령 메시지/작업 생성 실측).
+            // keyCode 229 는 isComposing 이 false 로 오는 WebKit 조합 커밋 케이스 보강.
+            if (e.key === "Enter" && (e.nativeEvent.isComposing || e.keyCode === 229)) return;
             // 슬래시 메뉴가 열려 있으면 네비게이션/선택 우선 처리.
             // 활성 인덱스는 스킬(0..n-1) + "전체 보기"(n) 를 순회.
             if (slashMenuOpen) {


### PR DESCRIPTION
## 문제

한글 등 IME 조합 중 Enter 를 치면 조합 확정 이벤트가 keydown 을 한 번 더 발생시켜 composer 제출이 2회 실행된다. 실측: 에이전트 모드에서 20ms 간격으로 작업 2건이 생성됐고, 두 번째는 조합 중이던 음절만 담긴 유령 작업(goal=`접`)으로 `failed(goal_incomplete)` 처리됐다.

## 수정

`composer.tsx` onKeyDown 최상단에 가드 1건 추가:

- `e.nativeEvent.isComposing || e.keyCode === 229` 인 Enter 는 무시 (229 는 isComposing 이 false 로 오는 WebKit 조합 커밋 케이스 보강)
- 제출(Enter)·슬래시 메뉴 선택(Enter) 두 경로를 모두 커버

## 검증

- tsc `--noEmit`·eslint 통과
- 프로덕션 빌드 + `openmake-next` 재시작, 로컬(:3000)·외부(chat.openmake.cc) 200 확인 (선배포됨)
- 실제 IME 조합 이중발화는 기계 재현이 어려워 실사용 관찰로 재발 확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)