### PR TITLE
fix(agent-task): 산출물 검증 프로브 파일(.verify_*) 검사 후 정리

### DIFF
--- a/apps/api/src/services/agent-task/deliverable-verify.test.ts
+++ b/apps/api/src/services/agent-task/deliverable-verify.test.ts
@@ -22,9 +22,11 @@ function fakeRuntime(execImpl: (cmd: string) => ExecResult): {
     runtime: TaskRuntime;
     writes: Array<{ path: string; content: string }>;
     cmds: string[];
+    deletes: string[];
 } {
     const writes: Array<{ path: string; content: string }> = [];
     const cmds: string[] = [];
+    const deletes: string[] = [];
     const runtime = {
         writeWorkspaceFile: async (path: string, content: string | Buffer) => {
             writes.push({ path, content: String(content) });
@@ -33,8 +35,11 @@ function fakeRuntime(execImpl: (cmd: string) => ExecResult): {
             cmds.push(cmd);
             return execImpl(cmd);
         },
+        deleteWorkspaceFile: async (path: string) => {
+            deletes.push(path);
+        },
     } as unknown as TaskRuntime;
-    return { runtime, writes, cmds };
+    return { runtime, writes, cmds, deletes };
 }
 
 const OK: ExecResult = { stdout: '', stderr: '', exitCode: 0, truncated: false, timedOut: false, durationMs: 5 };
@@ -61,6 +66,15 @@ describe('verifyCodeArtifacts', () => {
         expect(r.ok).toBe(false);
         expect(r.report).toContain('SyntaxError');
         expect(r.report).toContain('분석 스크립트');
+    });
+
+    it('검증 프로브 파일은 검사 후 삭제된다 (성공·실패 모두)', async () => {
+        const ok = fakeRuntime(() => OK);
+        await verifyCodeArtifacts(ok.runtime, [artifact({ lang: 'python' })]);
+        expect(ok.deletes).toEqual(['.verify_0.py']);
+        const fail = fakeRuntime(() => FAIL);
+        await verifyCodeArtifacts(fail.runtime, [artifact({ lang: 'python' })]);
+        expect(fail.deletes).toEqual(['.verify_0.py']);
     });
 
     it('js 는 node --check 로 검사', async () => {

--- a/apps/api/src/services/agent-task/deliverable-verify.ts
+++ b/apps/api/src/services/agent-task/deliverable-verify.ts
@@ -72,6 +72,9 @@ export async function verifyCodeArtifacts(
             } catch (e) {
                 // 개별 산출물 검사 실패는 통과 취급(fail-open) — 인프라 문제로 완료를 막지 않음.
                 logger.debug(`[Verify] 검사 스킵(${a.id}): ${e instanceof Error ? e.message : e}`);
+            } finally {
+                // 검증 프로브 정리 — 로컬 실행기에선 workspace 가 사용자 연결 폴더라 잔재가 남는다.
+                try { await runtime.deleteWorkspaceFile(file); } catch { /* 정리 실패 무시 */ }
             }
         }
         if (failures.length === 0) return { ok: true, report: '' };

--- a/apps/api/src/services/task-sandbox/runtime.ts
+++ b/apps/api/src/services/task-sandbox/runtime.ts
@@ -138,6 +138,9 @@ export class TaskRuntime {
     /** 입력 첨부 주입 등 호스트 측 workspace 파일 쓰기 — 경로 가드(safeRealWorkspacePath)+쿼터 적용. */
     async writeWorkspaceFile(relPath: string, content: string | Buffer): Promise<void> { return this.executor.writeFile(relPath, content); }
 
+    /** 시스템 임시 파일(검증 프로브 등) 정리 — 로컬 실행기에선 workspace 가 사용자 폴더다. */
+    async deleteWorkspaceFile(relPath: string): Promise<void> { return this.executor.deleteFile(relPath); }
+
     /** 호스트 파일을 workspace 로 복사 — 대용량 입력 첨부의 스트리밍 주입(Buffer 미적재). */
     async importWorkspaceFile(relPath: string, srcAbsPath: string): Promise<void> { return this.executor.importFile(relPath, srcAbsPath); }
 


### PR DESCRIPTION
## 문제

`deliverable-verify`(코드 산출물 문법/컴파일 검사)가 workspace 에 쓴 임시 프로브 파일(`.verify_N.ext`)을 검사 후 삭제하지 않았다. Docker 샌드박스에선 보이지 않지만, **로컬 실행기(Local Bridge)에선 workspace = 사용자 연결 폴더**라 잔재가 사용자 폴더에 그대로 남는다 (실측: `openmake_iphone/.verify_0.py`).

## 수정

- `TaskRuntime.deleteWorkspaceFile()` 노출 — 기존 `TaskExecutor.deleteFile`(docker `sandbox.ts`·`remote-executor.ts` 양쪽 구현 완료) 위임
- 검사 루프 `finally` 에서 프로브를 항상 삭제 (성공·실패·예외 모두, 정리 실패는 무시 — fail-open 불변식 유지)

## 검증

- 신규 테스트: 검사 성공·실패 양쪽에서 `.verify_0.py` 삭제 호출 검증
- deliverable-verify·runtime 스위트 14/14 통과, tsc·eslint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)