### PR TITLE
feat(web): Settings 확장 관리 탭 — 설치 목록/구성요소 상태/번들 제거

### DIFF
--- a/apps/web/app/(workspace)/settings/page.tsx
+++ b/apps/web/app/(workspace)/settings/page.tsx
@@ -13,6 +13,7 @@ import {
   ShieldCheck,
   Save,
   Loader2,
+  Package,
   type LucideIcon,
 } from "lucide-react";
 import {
@@ -37,9 +38,10 @@ import { ConnectorsSection } from "@/components/settings/connectors-section";
 import { GithubConnectSection } from "@/components/settings/github-connect-section";
 import { ProviderKeysSection } from "@/components/settings/provider-keys-section";
 import { ModelRolesSection } from "@/components/settings/model-roles-section";
+import { ExtensionsSection } from "@/components/settings/extensions-section";
 
 /* ── 탭 정의 ────────────────────────────────────────────── */
-type TabId = "general" | "model" | "interface" | "notifications" | "memory" | "connectors" | "privacy" | "security";
+type TabId = "general" | "model" | "interface" | "notifications" | "memory" | "extensions" | "connectors" | "privacy" | "security";
 
 const TABS: { id: TabId; labelKey: string; icon: LucideIcon }[] = [
   { id: "general", labelKey: "tabs.general", icon: Settings },
@@ -47,6 +49,7 @@ const TABS: { id: TabId; labelKey: string; icon: LucideIcon }[] = [
   { id: "interface", labelKey: "tabs.interface", icon: Palette },
   { id: "notifications", labelKey: "tabs.notifications", icon: Bell },
   { id: "memory", labelKey: "tabs.memory", icon: Brain },
+  { id: "extensions", labelKey: "tabs.extensions", icon: Package },
   { id: "connectors", labelKey: "tabs.connectors", icon: Server },
   { id: "privacy", labelKey: "tabs.privacy", icon: ShieldCheck },
   { id: "security", labelKey: "tabs.security", icon: ShieldCheck },
@@ -755,6 +758,8 @@ export default function SettingsPage() {
             )}
 
             {tab === "memory" && <MemorySection />}
+
+            {tab === "extensions" && <ExtensionsSection />}
 
             {tab === "connectors" && (
               <div className="space-y-6">

--- a/apps/web/components/settings/extensions-section.tsx
+++ b/apps/web/components/settings/extensions-section.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Package, Trash2, Loader2, ChevronDown, Puzzle, Server } from "lucide-react";
+import { Button, Card, CardHeader, CardTitle, CardContent } from "@/components/ui/primitives";
+import type { ApiSuccess } from "@openmake/shared-types";
+import { ApiClient } from "@/lib/api-client";
+
+interface UserExtension {
+  id: string;
+  name: string;
+  version: string;
+  description: string | null;
+  source_url: string;
+  source_ref: string;
+  created_at?: string;
+}
+
+interface ExtensionComponents {
+  skills: Array<{ id: string; name: string; status: string }>;
+  mcpServers: Array<{ id: string; name: string; status: string; enabled: boolean }>;
+}
+
+/**
+ * 확장 번들 (Agent Plugins v1) 관리 — 설치는 채팅 도구 import_extension_from_git,
+ * 여기서는 설치 목록/구성요소 상태 조회와 번들 단위 제거만 제공한다 (PR #499 백엔드).
+ */
+export function ExtensionsSection() {
+  const t = useTranslations("extensions");
+  const [extensions, setExtensions] = useState<UserExtension[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [openId, setOpenId] = useState<string | null>(null);
+  const [components, setComponents] = useState<Record<string, ExtensionComponents>>({});
+  const [detailLoading, setDetailLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await ApiClient.get<ApiSuccess<{ extensions: UserExtension[] }>>("/api/users/me/extensions");
+      setExtensions(res?.data?.extensions ?? []);
+    } catch {
+      /* 비로그인/실패 — 빈 목록 유지 */
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function toggleDetail(id: string) {
+    if (openId === id) {
+      setOpenId(null);
+      return;
+    }
+    setOpenId(id);
+    if (!components[id]) {
+      setDetailLoading(true);
+      try {
+        const res = await ApiClient.get<ApiSuccess<{ components: ExtensionComponents }>>(
+          `/api/users/me/extensions/${id}`,
+        );
+        if (res?.data?.components) {
+          setComponents((prev) => ({ ...prev, [id]: res.data.components }));
+        }
+      } catch {
+        /* 상세 실패 — 요약만 표시 */
+      } finally {
+        setDetailLoading(false);
+      }
+    }
+  }
+
+  async function remove(id: string) {
+    if (!window.confirm(t("removeConfirm"))) return;
+    const prev = extensions;
+    setExtensions((list) => list.filter((e) => e.id !== id));
+    try {
+      await ApiClient.del(`/api/users/me/extensions/${id}`);
+    } catch {
+      setExtensions(prev); // 실패 시 롤백
+    }
+  }
+
+  function statusLabel(status: string, enabled?: boolean) {
+    if (status === "active" && enabled === false) return t("status.disabled");
+    if (status === "active") return t("status.active");
+    if (status === "draft") return t("status.draft");
+    if (status === "archived") return t("status.archived");
+    return status;
+  }
+
+  function statusClass(status: string) {
+    if (status === "active") return "text-success";
+    if (status === "draft") return "text-warn";
+    return "text-muted";
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("title")}</CardTitle>
+        <p className="mt-1 text-xs text-muted">{t("description")}</p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="rounded-lg border border-border bg-surface-2 px-3 py-2.5 text-xs text-fg-2">{t("installHint")}</p>
+
+        {loading ? (
+          <div className="flex justify-center py-10 text-muted">
+            <Loader2 className="h-5 w-5 animate-spin" />
+          </div>
+        ) : extensions.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 rounded-xl border border-dashed border-border py-12 text-center text-muted">
+            <Package className="h-8 w-8 opacity-50" />
+            <p className="text-sm">{t("empty")}</p>
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {extensions.map((ext) => {
+              const open = openId === ext.id;
+              const comp = components[ext.id];
+              return (
+                <li key={ext.id} className="rounded-lg border border-border">
+                  <div className="flex items-center gap-3 p-3.5">
+                    <Package className="h-4 w-4 shrink-0 text-accent" />
+                    <button
+                      type="button"
+                      onClick={() => void toggleDetail(ext.id)}
+                      className="min-w-0 flex-1 text-left"
+                    >
+                      <p className="truncate text-sm font-medium text-fg">
+                        {ext.name}
+                        <span className="ml-1.5 font-mono text-xs text-muted">v{ext.version}</span>
+                      </p>
+                      <p className="mt-0.5 truncate text-xs text-muted">
+                        {ext.description || ext.source_url}
+                        <span className="ml-1.5 font-mono">@{ext.source_ref.slice(0, 7)}</span>
+                      </p>
+                    </button>
+                    <ChevronDown
+                      className={`h-4 w-4 shrink-0 text-muted transition-transform ${open ? "rotate-180" : ""}`}
+                    />
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label={t("removeAria")}
+                      onClick={() => void remove(ext.id)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                  {open && (
+                    <div className="space-y-3 border-t border-border px-3.5 py-3">
+                      {detailLoading && !comp ? (
+                        <div className="flex justify-center py-4 text-muted">
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        </div>
+                      ) : comp ? (
+                        <>
+                          <div>
+                            <p className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-fg-2">
+                              <Puzzle className="h-3.5 w-3.5" /> {t("skills")} ({comp.skills.length})
+                            </p>
+                            {comp.skills.length === 0 ? (
+                              <p className="text-xs text-muted">{t("none")}</p>
+                            ) : (
+                              <ul className="space-y-1">
+                                {comp.skills.map((s) => (
+                                  <li key={s.id} className="flex items-center justify-between text-xs">
+                                    <span className="truncate text-fg">{s.name}</span>
+                                    <span className={statusClass(s.status)}>{statusLabel(s.status)}</span>
+                                  </li>
+                                ))}
+                              </ul>
+                            )}
+                          </div>
+                          <div>
+                            <p className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-fg-2">
+                              <Server className="h-3.5 w-3.5" /> {t("mcpServers")} ({comp.mcpServers.length})
+                            </p>
+                            {comp.mcpServers.length === 0 ? (
+                              <p className="text-xs text-muted">{t("none")}</p>
+                            ) : (
+                              <ul className="space-y-1">
+                                {comp.mcpServers.map((s) => (
+                                  <li key={s.id} className="flex items-center justify-between text-xs">
+                                    <span className="truncate text-fg">{s.name}</span>
+                                    <span className={statusClass(s.status)}>{statusLabel(s.status, s.enabled)}</span>
+                                  </li>
+                                ))}
+                              </ul>
+                            )}
+                          </div>
+                          <p className="text-[11px] text-muted">{t("approvalHint")}</p>
+                        </>
+                      ) : (
+                        <p className="text-xs text-muted">{t("detailFailed")}</p>
+                      )}
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -76,7 +76,8 @@
       "privacy": "Privacy",
       "security": "Security",
       "memory": "Memory",
-      "connectors": "Connectors"
+      "connectors": "Connectors",
+      "extensions": "Extensions"
     },
     "responseStyles": {
       "concise": "Concise",
@@ -1782,5 +1783,24 @@
     "title": "Page not found",
     "description": "The page you are looking for doesn't exist or has been moved.",
     "backHome": "Back to home"
+  },
+  "extensions": {
+    "title": "Extensions",
+    "description": "View and remove installed extension bundles (skills + MCP servers).",
+    "installHint": "To install, ask in chat: \"Install this extension: github.com/owner/repo\". Each component activates after review and approval.",
+    "empty": "No extensions installed.",
+    "skills": "Skills",
+    "mcpServers": "MCP servers",
+    "none": "None",
+    "approvalHint": "Draft components must be approved in the Skill Library / MCP Servers pages before activation.",
+    "detailFailed": "Failed to load component details.",
+    "removeConfirm": "Remove this extension? Its skills and MCP servers will be archived.",
+    "removeAria": "Remove extension",
+    "status": {
+      "active": "Active",
+      "draft": "Pending approval",
+      "archived": "Archived",
+      "disabled": "Disabled"
+    }
   }
 }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -76,7 +76,8 @@
       "privacy": "プライバシー",
       "security": "セキュリティ",
       "memory": "メモリ",
-      "connectors": "コネクタ"
+      "connectors": "コネクタ",
+      "extensions": "拡張機能"
     },
     "responseStyles": {
       "concise": "簡潔",
@@ -1782,5 +1783,24 @@
     "title": "ページが見つかりません",
     "description": "お探しのページは存在しないか、移動された可能性があります。",
     "backHome": "ホームに戻る"
+  },
+  "extensions": {
+    "title": "拡張機能の管理",
+    "description": "インストール済みの拡張バンドル(スキル・MCPサーバー)を確認・削除します。",
+    "installHint": "インストールはチャットで「この拡張をインストールして: github.com/owner/repo」と依頼してください。各コンポーネントは承認後に有効化されます。",
+    "empty": "インストール済みの拡張はありません。",
+    "skills": "スキル",
+    "mcpServers": "MCPサーバー",
+    "none": "なし",
+    "approvalHint": "draft 状態のコンポーネントはスキルライブラリ・MCPサーバーページで承認すると有効化されます。",
+    "detailFailed": "コンポーネント情報の取得に失敗しました。",
+    "removeConfirm": "この拡張を削除しますか?含まれるスキル・MCPサーバーはアーカイブされます。",
+    "removeAria": "拡張を削除",
+    "status": {
+      "active": "有効",
+      "draft": "承認待ち",
+      "archived": "アーカイブ済み",
+      "disabled": "無効"
+    }
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -76,7 +76,8 @@
       "privacy": "개인정보",
       "security": "보안",
       "memory": "메모리",
-      "connectors": "커넥터"
+      "connectors": "커넥터",
+      "extensions": "확장"
     },
     "responseStyles": {
       "concise": "간결",
@@ -1782,5 +1783,24 @@
     "title": "페이지를 찾을 수 없습니다",
     "description": "요청하신 페이지가 존재하지 않거나 이동되었습니다.",
     "backHome": "홈으로 돌아가기"
+  },
+  "extensions": {
+    "title": "확장 관리",
+    "description": "설치된 확장 번들(스킬·MCP 서버 묶음)을 조회하고 제거합니다.",
+    "installHint": "설치는 채팅에서 \"이 확장 설치해줘: github.com/owner/repo\" 처럼 요청하세요. 구성요소는 각각 검토·승인 후 활성화됩니다.",
+    "empty": "설치된 확장이 없습니다.",
+    "skills": "스킬",
+    "mcpServers": "MCP 서버",
+    "none": "없음",
+    "approvalHint": "draft 상태 구성요소는 스킬 라이브러리·MCP 서버 페이지에서 승인해야 활성화됩니다.",
+    "detailFailed": "구성요소 정보를 불러오지 못했습니다.",
+    "removeConfirm": "이 확장을 제거할까요? 포함된 스킬·MCP 서버가 함께 보관 처리됩니다.",
+    "removeAria": "확장 제거",
+    "status": {
+      "active": "활성",
+      "draft": "승인 대기",
+      "archived": "보관됨",
+      "disabled": "비활성"
+    }
   }
 }

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -76,7 +76,8 @@
       "privacy": "隐私",
       "security": "安全",
       "memory": "记忆",
-      "connectors": "连接器"
+      "connectors": "连接器",
+      "extensions": "扩展"
     },
     "responseStyles": {
       "concise": "简洁",
@@ -1782,5 +1783,24 @@
     "title": "找不到页面",
     "description": "您访问的页面不存在或已被移动。",
     "backHome": "返回首页"
+  },
+  "extensions": {
+    "title": "扩展管理",
+    "description": "查看并移除已安装的扩展包(技能与 MCP 服务器)。",
+    "installHint": "安装方式:在聊天中请求\"安装这个扩展: github.com/owner/repo\"。各组件需审核批准后才会启用。",
+    "empty": "暂无已安装的扩展。",
+    "skills": "技能",
+    "mcpServers": "MCP 服务器",
+    "none": "无",
+    "approvalHint": "draft 状态的组件需在技能库/MCP 服务器页面批准后才会启用。",
+    "detailFailed": "组件信息加载失败。",
+    "removeConfirm": "确定移除此扩展吗?其包含的技能与 MCP 服务器将被归档。",
+    "removeAria": "移除扩展",
+    "status": {
+      "active": "已启用",
+      "draft": "待批准",
+      "archived": "已归档",
+      "disabled": "已停用"
+    }
   }
 }


### PR DESCRIPTION
## 요약

PR #499(확장 번들 백엔드)의 관리 UI. 설정 페이지에 **'확장' 탭**을 추가한다 — 설치는 채팅 도구 `import_extension_from_git` 가 담당하고, 이 탭은 조회/제거만 제공.

## 변경 내용

- `components/settings/extensions-section.tsx` (신규): 설치 목록(이름/버전/설명/source ref) → 행 펼침 시 구성요소(스킬·MCP 서버) 현재 상태 lazy 조회(승인 대기/활성/보관/비활성) → 번들 단위 제거(confirm, 낙관적 업데이트+실패 롤백) → 채팅 설치 안내 문구
- `settings/page.tsx`: `extensions` TabId·탭 등록(Package 아이콘)·렌더 분기
- i18n: `settings.tabs.extensions` + `extensions` 네임스페이스 — ko/en/ja/zh 4언어 (순수 추가 diff)
- `ApiClient` 경유(`fetch` 직접 호출 없음), memory-section 관용구 동형

## 검증

- [x] eslint 통과, `next build` 성공
- [x] **라이브 E2E (chat.openmake.cc, user 3)**: 픽스처(`openmake/openmake-ext-fixture`) 설치 → 탭·행 렌더 → 상세 펼침(스킬 1 '승인 대기', MCP 서버 1 '승인 대기' + 승인 안내) → 제거 confirm → 빈 상태 전환 + DB `removed`/`archived` 정합 확인 → 테스트 데이터 정리
- 스크린샷: 세션 캡처로 확인 (다크 테마, 탭·카드·상태 뱃지 정상)

🤖 Generated with [Claude Code](https://claude.com/claude-code)