### PR TITLE
feat(extensions): Phase 2 — 버전/업데이트 확인 + 재설치 업데이트

### DIFF
--- a/apps/api/src/agents/git-ingest/__tests__/extension-ingest-service.test.ts
+++ b/apps/api/src/agents/git-ingest/__tests__/extension-ingest-service.test.ts
@@ -68,8 +68,8 @@ describe('ExtensionIngestService', () => {
         mockFetcher.fetchFile.mockResolvedValueOnce(PLUGIN_MCP_ONLY);
         const q = mockPool.query as jest.Mock;
         q.mockResolvedValueOnce({ rows: [] });                    // findRecentByHash
-        q.mockResolvedValueOnce({ rows: [{ count: '0' }] });      // countActiveForUser
         q.mockResolvedValueOnce({ rows: [] });                    // findActiveByName
+        q.mockResolvedValueOnce({ rows: [{ count: '0' }] });      // countActiveForUser
         (mockLLM.chat as jest.Mock).mockResolvedValueOnce({       // ConventionChecker LLM
             content: JSON.stringify({ findings: [] }), metrics: { completion_tokens: 30 },
         });
@@ -109,8 +109,8 @@ describe('ExtensionIngestService', () => {
         }));
         const q = mockPool.query as jest.Mock;
         q.mockResolvedValueOnce({ rows: [] });                    // dedupe
-        q.mockResolvedValueOnce({ rows: [{ count: '0' }] });      // count
         q.mockResolvedValueOnce({ rows: [] });                    // findActiveByName
+        q.mockResolvedValueOnce({ rows: [{ count: '0' }] });      // count
         (mockLLM.chat as jest.Mock).mockResolvedValueOnce({
             content: JSON.stringify({ findings: [] }), metrics: { completion_tokens: 30 },
         });
@@ -173,14 +173,13 @@ describe('ExtensionIngestService', () => {
         expect(r.mcpServers[0].serverId).toBe('mcp-old');
     });
 
-    it('EXTENSION_ALREADY_INSTALLED: 동명 active 설치 존재', async () => {
+    it('EXTENSION_ALREADY_INSTALLED: 동명 active 설치가 다른 소스면 충돌', async () => {
         mockFetcher.resolveRef.mockResolvedValueOnce('abc123');
         mockFetcher.listTree.mockResolvedValueOnce(treeOf('plugin.json'));
         mockFetcher.fetchFile.mockResolvedValueOnce(PLUGIN_MCP_ONLY);
         const q = mockPool.query as jest.Mock;
         q.mockResolvedValueOnce({ rows: [] });                    // dedupe miss
-        q.mockResolvedValueOnce({ rows: [{ count: '0' }] });      // count
-        q.mockResolvedValueOnce({ rows: [{ id: 'user-ext-dup' }] });  // findActiveByName hit
+        q.mockResolvedValueOnce({ rows: [{ id: 'user-ext-dup', source_url: 'other/elsewhere', source_ref: 'zzz' }] });  // findActiveByName hit (다른 repo)
 
         const svc = makeService();
         await expect(svc.import({ userId: 'user-1', isAdmin: false, gitUrl: 'foo/bar' }))
@@ -193,11 +192,97 @@ describe('ExtensionIngestService', () => {
         mockFetcher.fetchFile.mockResolvedValueOnce(JSON.stringify({ name: 'empty-pack', version: '1.0.0' }));
         const q = mockPool.query as jest.Mock;
         q.mockResolvedValueOnce({ rows: [] });                    // dedupe
-        q.mockResolvedValueOnce({ rows: [{ count: '0' }] });      // count
         q.mockResolvedValueOnce({ rows: [] });                    // findActiveByName
+        q.mockResolvedValueOnce({ rows: [{ count: '0' }] });      // count
 
         const svc = makeService();
         await expect(svc.import({ userId: 'user-1', isAdmin: false, gitUrl: 'foo/bar' }))
             .rejects.toThrow('NO_COMPONENTS_INSTALLED');
+    });
+
+    it('upToDate: 동일 소스·동일 sha 재설치 → 변경 없음', async () => {
+        mockFetcher.resolveRef.mockResolvedValueOnce('abc123');
+        mockFetcher.listTree.mockResolvedValueOnce(treeOf('plugin.json'));
+        mockFetcher.fetchFile.mockResolvedValueOnce(PLUGIN_MCP_ONLY);
+        const q = mockPool.query as jest.Mock;
+        q.mockResolvedValueOnce({ rows: [] });                    // dedupe (24h 지난 재설치 가정)
+        q.mockResolvedValueOnce({ rows: [{                        // findActiveByName — 같은 repo, 같은 sha
+            id: 'user-ext-same', name: 'tool-pack', version: '1.0.0', description: null,
+            source_url: 'foo/bar', source_ref: 'abc123', source_path: 'plugin.json',
+            manifest: { components: { skills: [], mcpServers: [] } },
+        }] });
+
+        const svc = makeService();
+        const r = await svc.import({ userId: 'user-1', isAdmin: false, gitUrl: 'foo/bar' });
+        if ('selectionRequired' in r && r.selectionRequired) throw new Error('expected single');
+        expect(r.upToDate).toBe(true);
+        expect(r.extensionId).toBe('user-ext-same');
+    });
+
+    it('update: 동일 소스·새 sha 재설치 → 구 구성요소 archive + 기존 id 유지 갱신', async () => {
+        mockFetcher.resolveRef.mockResolvedValueOnce('newsha1');
+        mockFetcher.listTree.mockResolvedValueOnce(treeOf('plugin.json'));
+        mockFetcher.fetchFile.mockResolvedValueOnce(JSON.stringify({
+            name: 'tool-pack', version: '1.1.0',
+            mcpServers: { pg: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-postgres'] } },
+        }));
+        const q = mockPool.query as jest.Mock;
+        q.mockResolvedValueOnce({ rows: [] });                    // dedupe
+        q.mockResolvedValueOnce({ rows: [{                        // findActiveByName — 같은 repo, 구 sha
+            id: 'user-ext-u1', name: 'tool-pack', version: '1.0.0', description: null,
+            source_url: 'foo/bar', source_ref: 'oldsha1', source_path: 'plugin.json',
+            manifest: { components: {} },
+        }] });
+        (mockLLM.chat as jest.Mock).mockResolvedValueOnce({
+            content: JSON.stringify({ findings: [] }), metrics: { completion_tokens: 30 },
+        });
+        q.mockResolvedValueOnce({ rows: [] });                    // resolveUniqueServerName
+        q.mockResolvedValueOnce({ rows: [{ id: 'mcp-new1' }] });  // insertDraft
+        q.mockResolvedValueOnce({ rows: [] });                    // archive skills
+        q.mockResolvedValueOnce({ rows: [] });                    // archive mcp
+        q.mockResolvedValueOnce({ rows: [{                        // updateAfterReinstall RETURNING
+            id: 'user-ext-u1', name: 'tool-pack', version: '1.1.0', status: 'active',
+        }] });
+        q.mockResolvedValueOnce({ rows: [] });                    // linkComponents (mcp)
+
+        const svc = makeService();
+        const r = await svc.import({ userId: 'user-1', isAdmin: false, gitUrl: 'foo/bar' });
+        if ('selectionRequired' in r && r.selectionRequired) throw new Error('expected single');
+        expect(r.updated).toBe(true);
+        expect(r.previousVersion).toBe('1.0.0');
+        expect(r.version).toBe('1.1.0');
+        expect(r.extensionId).toBe('user-ext-u1');
+        // 구 구성요소 archive UPDATE 가 실행됐는지
+        const archiveCalls = q.mock.calls.filter((c: unknown[]) => String(c[0]).includes("SET status='archived'"));
+        expect(archiveCalls.length).toBe(2);
+    });
+
+    describe('checkForUpdate', () => {
+        it('sha 동일 → updateAvailable=false', async () => {
+            mockFetcher.resolveRef.mockResolvedValueOnce('abc123');
+            const svc = makeService();
+            const r = await svc.checkForUpdate({ sourceUrl: 'foo/bar', sourcePath: 'plugin.json', currentRef: 'abc123' });
+            expect(r.updateAvailable).toBe(false);
+            expect(r.latestVersion).toBeNull();
+        });
+
+        it('sha 다름 → updateAvailable=true + 최신 plugin.json version', async () => {
+            mockFetcher.resolveRef.mockResolvedValueOnce('newsha1');
+            mockFetcher.fetchFile.mockResolvedValueOnce(JSON.stringify({ name: 'tool-pack', version: '2.0.0' }));
+            const svc = makeService();
+            const r = await svc.checkForUpdate({ sourceUrl: 'foo/bar', sourcePath: 'plugin.json', currentRef: 'oldsha1', trackingRef: null });
+            expect(r.updateAvailable).toBe(true);
+            expect(r.latestRef).toBe('newsha1');
+            expect(r.latestVersion).toBe('2.0.0');
+        });
+
+        it('최신 plugin.json 조회 실패 → latestVersion null (판정은 유지)', async () => {
+            mockFetcher.resolveRef.mockResolvedValueOnce('newsha1');
+            mockFetcher.fetchFile.mockRejectedValueOnce(new Error('404'));
+            const svc = makeService();
+            const r = await svc.checkForUpdate({ sourceUrl: 'foo/bar', sourcePath: 'plugin.json', currentRef: 'oldsha1' });
+            expect(r.updateAvailable).toBe(true);
+            expect(r.latestVersion).toBeNull();
+        });
     });
 });

--- a/apps/api/src/agents/git-ingest/extension-ingest-service.ts
+++ b/apps/api/src/agents/git-ingest/extension-ingest-service.ts
@@ -76,8 +76,21 @@ export interface ImportResult {
     mcpServers: McpServerInstallResult[];
     validationWarnings: string[];
     deduped: boolean;
+    /** 동일 소스 재설치인데 source_ref 가 이미 최신 — 아무것도 변경 안 함 */
+    upToDate?: boolean;
+    /** 동일 이름·동일 소스 재설치 → 기존 설치를 새 ref 로 교체 (구 구성요소 archive) */
+    updated?: boolean;
+    previousVersion?: string;
     selectionRequired?: false;
     candidates?: never;
+}
+
+export interface UpdateCheckResult {
+    updateAvailable: boolean;
+    currentRef: string;
+    latestRef: string;
+    /** 최신 ref 의 plugin.json version (조회 실패 시 null) */
+    latestVersion: string | null;
 }
 
 export interface CandidateListResult {
@@ -149,13 +162,27 @@ export class ExtensionIngestService {
             return this.shapeFromRow(existing, true);
         }
 
-        const activeCount = await extRepo.countActiveForUser(input.userId);
-        if (activeCount >= EXTENSION_INGEST.maxPerUser) {
-            throw new Error(`EXTENSION_LIMIT_EXCEEDED: ${activeCount}/${EXTENSION_INGEST.maxPerUser}`);
-        }
+        // 동일 이름 active 설치: 같은 repo 면 업데이트 모드, 다른 소스면 충돌
         const sameName = await extRepo.findActiveByName(input.userId, manifest.name);
+        let updateTarget: typeof sameName = null;
         if (sameName) {
-            throw new Error(`EXTENSION_ALREADY_INSTALLED: "${manifest.name}" 이 이미 설치됨 (${sameName.id}) — 먼저 제거 후 재설치하세요`);
+            const prevParsed = parseGitUrl(sameName.source_url);
+            if (prevParsed && prevParsed.owner === owner && prevParsed.repo === repo) {
+                if (sameName.source_ref === sha) {
+                    // 이미 최신 — 변경 없음
+                    return { ...this.shapeFromRow(sameName, false), upToDate: true };
+                }
+                updateTarget = sameName;
+            } else {
+                throw new Error(`EXTENSION_ALREADY_INSTALLED: "${manifest.name}" 이 다른 소스(${sameName.source_url})로 이미 설치됨 (${sameName.id}) — 먼저 제거 후 재설치하세요`);
+            }
+        }
+
+        if (!updateTarget) {
+            const activeCount = await extRepo.countActiveForUser(input.userId);
+            if (activeCount >= EXTENSION_INGEST.maxPerUser) {
+                throw new Error(`EXTENSION_LIMIT_EXCEEDED: ${activeCount}/${EXTENSION_INGEST.maxPerUser}`);
+            }
         }
 
         const warnings: string[] = [];
@@ -273,28 +300,47 @@ export class ExtensionIngestService {
             throw new Error(`NO_COMPONENTS_INSTALLED: 설치 가능한 구성요소 없음${detail ? ` (${detail})` : ''}`);
         }
 
-        // (8) user_extensions INSERT + 링크
-        const row = await extRepo.insert({
-            userId: input.userId,
-            name: manifest.name,
-            version: manifest.version,
-            description: manifest.description ?? null,
-            sourceUrl: input.gitUrl,
-            sourceRef: sha,
-            sourcePath: candidate.path,
-            sourceHash,
-            manifest: {
-                plugin: manifest.raw,
-                components: { skills: skillResults, mcpServers: mcpResults },
-            },
-        });
+        // (8) user_extensions INSERT(신규) 또는 UPDATE(재설치) + 링크
+        const componentManifest = {
+            plugin: manifest.raw,
+            components: { skills: skillResults, mcpServers: mcpResults },
+        };
+        let row;
+        let previousVersion: string | undefined;
+        if (updateTarget) {
+            previousVersion = updateTarget.version;
+            await extRepo.archiveLinkedComponents(updateTarget.id);
+            row = await extRepo.updateAfterReinstall(updateTarget.id, {
+                version: manifest.version,
+                description: manifest.description ?? null,
+                sourceRef: sha,
+                sourcePath: candidate.path,
+                sourceHash,
+                trackingRef: input.gitRef ?? null,
+                manifest: componentManifest,
+            });
+            if (!row) throw new Error(`EXTENSION_UPDATE_FAILED: ${updateTarget.id} 갱신 실패`);
+        } else {
+            row = await extRepo.insert({
+                userId: input.userId,
+                name: manifest.name,
+                version: manifest.version,
+                description: manifest.description ?? null,
+                sourceUrl: input.gitUrl,
+                sourceRef: sha,
+                sourcePath: candidate.path,
+                sourceHash,
+                trackingRef: input.gitRef ?? null,
+                manifest: componentManifest,
+            });
+        }
         await extRepo.linkComponents(
             row.id,
             okSkills.map(r => r.skillId!),
             okServers.map(r => r.serverId!),
         );
 
-        logger.info(`extension-ingest created: ${row.id} "${manifest.name}@${manifest.version}" (${owner}/${repo}@${sha.slice(0, 7)}, skills=${okSkills.length}, mcp=${okServers.length})`);
+        logger.info(`extension-ingest ${updateTarget ? 'updated' : 'created'}: ${row.id} "${manifest.name}@${manifest.version}"${previousVersion ? ` (from ${previousVersion})` : ''} (${owner}/${repo}@${sha.slice(0, 7)}, skills=${okSkills.length}, mcp=${okServers.length})`);
         return {
             extensionId: row.id,
             name: manifest.name,
@@ -309,7 +355,37 @@ export class ExtensionIngestService {
             mcpServers: mcpResults,
             validationWarnings: warnings,
             deduped: false,
+            ...(updateTarget ? { updated: true, previousVersion } : {}),
         };
+    }
+
+    /**
+     * 업데이트 확인 — tracking_ref(NULL=HEAD)를 다시 resolve 해 설치된 source_ref 와 비교.
+     * 변경이 있으면 최신 ref 의 plugin.json version 도 조회 (실패 시 null, fail-open).
+     */
+    async checkForUpdate(input: {
+        sourceUrl: string;
+        sourcePath: string;
+        currentRef: string;
+        trackingRef?: string | null;
+        accessToken?: string;
+    }): Promise<UpdateCheckResult> {
+        const parsed = parseGitUrl(input.sourceUrl);
+        if (!parsed) throw new Error(`INVALID_GIT_URL: ${input.sourceUrl}`);
+        const fetcher = this.opts.fetcherFactory({ accessToken: input.accessToken });
+        const latestRef = await fetcher.resolveRef(parsed.owner, parsed.repo, input.trackingRef ?? 'HEAD');
+        if (latestRef === input.currentRef) {
+            return { updateAvailable: false, currentRef: input.currentRef, latestRef, latestVersion: null };
+        }
+        let latestVersion: string | null = null;
+        try {
+            const raw = await fetcher.fetchFile(parsed.owner, parsed.repo, latestRef, input.sourcePath, EXTENSION_INGEST.manifestMaxBytes);
+            const validation = validateExtensionManifest(raw);
+            if (validation.ok) latestVersion = validation.manifest.version;
+        } catch {
+            /* 최신 버전 조회 실패 — updateAvailable 판정에는 영향 없음 */
+        }
+        return { updateAvailable: true, currentRef: input.currentRef, latestRef, latestVersion };
     }
 
     /** mcp_servers (user_id, name) unique 충돌 회피 — McpServerIngestService 관용구 동형. */

--- a/apps/api/src/controllers/user-extensions.controller.ts
+++ b/apps/api/src/controllers/user-extensions.controller.ts
@@ -6,18 +6,26 @@
  * 목록/상세/제거만 제공한다. 구성요소 승인은 기존 skill/MCP draft 경로 그대로.
  *
  * Endpoints (모두 requireAuth, 본인 소유 한정):
- *   GET    /api/users/me/extensions      — active 설치 목록
- *   GET    /api/users/me/extensions/:id  — 상세 (구성요소 현재 상태 포함)
- *   DELETE /api/users/me/extensions/:id  — 제거 (구성요소 archive + soft remove)
+ *   GET    /api/users/me/extensions                   — active 설치 목록
+ *   GET    /api/users/me/extensions/:id               — 상세 (구성요소 현재 상태 포함)
+ *   POST   /api/users/me/extensions/:id/update-check  — 원격 ref 비교 업데이트 확인 (Phase 2)
+ *   DELETE /api/users/me/extensions/:id               — 제거 (구성요소 archive + soft remove)
  *
  * @see data/repositories/user-extension-repository
  */
 import { Router, Request } from 'express';
+import { z } from 'zod';
 import { requireAuth } from '../auth/middleware';
+import { validate } from '../middlewares/validation';
 import { getPool } from '../data/models/unified-database';
 import { UserExtensionRepository, type UserExtensionRow } from '../data/repositories/user-extension-repository';
 import { createLogger } from '../utils/logger';
-import { success, internalError, unauthorized, notFound } from '../utils/api-response';
+import { success, internalError, unauthorized, notFound, badRequest } from '../utils/api-response';
+
+const updateCheckSchema = z.object({
+    // private repo 접근/rate limit 우회용 (요청 한정 — DB 미저장)
+    accessToken: z.string().max(200).optional(),
+});
 
 const log = createLogger('UserExtensionsController');
 
@@ -64,6 +72,40 @@ export function createUserExtensionsController(): Router {
         } catch (err) {
             log.error('get 실패:', err);
             res.status(500).json(internalError('확장 조회 실패'));
+        }
+    });
+
+    router.post('/:id/update-check', requireAuth, validate(updateCheckSchema), async (req, res) => {
+        const userId = getUserId(req);
+        if (!userId) { res.status(401).json(unauthorized()); return; }
+        try {
+            const repo = new UserExtensionRepository(getPool());
+            const row = await repo.getByIdForUser(req.params.id, userId, false);
+            if (!row || row.status !== 'active') { res.status(404).json(notFound('확장 없음')); return; }
+
+            const { ExtensionIngestService } = await import('../agents/git-ingest/extension-ingest-service');
+            const { GitFetcher } = await import('../agents/git-ingest/git-fetcher');
+            const { LLMClient } = await import('../llm/client');
+            const { SKILL_CREATOR } = await import('../config/constants');
+            const service = new ExtensionIngestService({
+                pool: getPool(),
+                llmClientFactory: (model: string) => new LLMClient(model ? { model } : {}),
+                fetcherFactory: (opts) => new GitFetcher({ accessToken: opts.accessToken, timeoutMs: SKILL_CREATOR.gitFetchTimeout }),
+            });
+            const body = req.body as z.infer<typeof updateCheckSchema>;
+            const result = await service.checkForUpdate({
+                sourceUrl: row.source_url,
+                sourcePath: row.source_path,
+                currentRef: row.source_ref,
+                trackingRef: row.tracking_ref,
+                accessToken: body.accessToken,
+            });
+            res.json(success({ ...result, currentVersion: row.version }));
+        } catch (err) {
+            // 원격 조회 실패(레포 삭제/권한/rate limit)는 사용자 입력 기인 — 400 으로 사유 전달
+            const msg = err instanceof Error ? err.message : String(err);
+            log.warn(`update-check 실패: ${msg}`);
+            res.status(400).json(badRequest(`업데이트 확인 실패: ${msg}`));
         }
     });
 

--- a/apps/api/src/data/repositories/user-extension-repository.ts
+++ b/apps/api/src/data/repositories/user-extension-repository.ts
@@ -23,6 +23,7 @@ export interface UserExtensionRow {
     source_ref: string;
     source_path: string;
     source_hash: string;
+    tracking_ref: string | null;
     manifest: Record<string, unknown>;
     status: 'active' | 'removed';
     created_at: Date;
@@ -38,6 +39,7 @@ export interface InsertExtensionInput {
     sourceRef: string;
     sourcePath: string;
     sourceHash: string;
+    trackingRef?: string | null;
     manifest: Record<string, unknown>;
 }
 
@@ -46,8 +48,8 @@ export class UserExtensionRepository extends BaseRepository {
         const id = `user-ext-${uuidv4()}`;
         const r = await this.query<UserExtensionRow>(
             `INSERT INTO user_extensions
-               (id, user_id, name, version, description, source_url, source_ref, source_path, source_hash, manifest, status)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, 'active')
+               (id, user_id, name, version, description, source_url, source_ref, source_path, source_hash, tracking_ref, manifest, status)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, 'active')
              RETURNING *`,
             [
                 id,
@@ -59,10 +61,53 @@ export class UserExtensionRepository extends BaseRepository {
                 input.sourceRef,
                 input.sourcePath,
                 input.sourceHash,
+                input.trackingRef ?? null,
                 JSON.stringify(input.manifest),
             ]
         );
         return r.rows[0];
+    }
+
+    /** 재설치(업데이트) — 기존 id 유지, 버전/ref/manifest 갱신. */
+    async updateAfterReinstall(id: string, input: {
+        version: string;
+        description?: string | null;
+        sourceRef: string;
+        sourcePath: string;
+        sourceHash: string;
+        trackingRef?: string | null;
+        manifest: Record<string, unknown>;
+    }): Promise<UserExtensionRow | null> {
+        const r = await this.query<UserExtensionRow>(
+            `UPDATE user_extensions
+                SET version=$1, description=$2, source_ref=$3, source_path=$4,
+                    source_hash=$5, tracking_ref=$6, manifest=$7::jsonb, updated_at=NOW()
+              WHERE id=$8 AND status='active'
+              RETURNING *`,
+            [
+                input.version,
+                input.description ?? null,
+                input.sourceRef,
+                input.sourcePath,
+                input.sourceHash,
+                input.trackingRef ?? null,
+                JSON.stringify(input.manifest),
+                id,
+            ]
+        );
+        return r.rows[0] ?? null;
+    }
+
+    /** 링크 구성요소 archive (업데이트 시 구버전 정리 — remove 와 동일 규칙, 링크는 해제). */
+    async archiveLinkedComponents(extensionId: string): Promise<void> {
+        await this.query(
+            `UPDATE agent_skills SET status='archived', extension_id=NULL WHERE extension_id=$1`,
+            [extensionId]
+        );
+        await this.query(
+            `UPDATE mcp_servers SET status='archived', enabled=FALSE, extension_id=NULL, updated_at=NOW() WHERE extension_id=$1`,
+            [extensionId]
+        );
     }
 
     async getByIdForUser(id: string, userId: string, isAdmin: boolean): Promise<UserExtensionRow | null> {

--- a/apps/api/src/mcp/extension-ingest-tool.ts
+++ b/apps/api/src/mcp/extension-ingest-tool.ts
@@ -28,7 +28,7 @@ interface ImportExtensionFromGitArgs extends Record<string, unknown> {
 export const importExtensionFromGitTool: MCPToolDefinition<ImportExtensionFromGitArgs> = {
     tool: {
         name: 'import_extension_from_git',
-        description: 'GitHub URL 의 plugin.json (Agent Plugins v1) 확장 번들을 설치합니다 — skills/*/SKILL.md 와 MCP 서버 정의를 한 번에 draft 로 가져옵니다. 사용자가 명시적으로 "이 확장/플러그인 설치해줘", "이 저장소를 확장으로 import 해줘" 같은 요청을 했을 때만 호출하세요. plugin.json 이 여러 개면 후보 목록만 반환 (재호출에서 gitPath 명시 필요). 단일 스킬/에이전트/MCP 서버만 가져올 때는 import_skill_from_git / import_agent_from_git / import_mcp_server_from_git 를 대신 사용하세요.',
+        description: 'GitHub URL 의 plugin.json (Agent Plugins v1) 확장 번들을 설치합니다 — skills/*/SKILL.md 와 MCP 서버 정의를 한 번에 draft 로 가져옵니다. 같은 저장소의 이미 설치된 확장을 다시 요청하면 최신 ref 로 업데이트합니다 (구 구성요소는 archive). 사용자가 명시적으로 "이 확장/플러그인 설치해줘", "이 확장 업데이트해줘" 같은 요청을 했을 때만 호출하세요. plugin.json 이 여러 개면 후보 목록만 반환 (재호출에서 gitPath 명시 필요). 단일 스킬/에이전트/MCP 서버만 가져올 때는 import_skill_from_git / import_agent_from_git / import_mcp_server_from_git 를 대신 사용하세요.',
         inputSchema: {
             type: 'object',
             properties: {
@@ -118,8 +118,15 @@ export const importExtensionFromGitTool: MCPToolDefinition<ImportExtensionFromGi
                 mcpServers: result.mcpServers,
                 validationWarnings: result.validationWarnings,
                 deduped: result.deduped,
+                upToDate: result.upToDate,
+                updated: result.updated,
+                previousVersion: result.previousVersion,
             };
-            const assistantText = result.deduped
+            const assistantText = result.upToDate
+                ? `확장 "${result.name}@${result.version}" 은 이미 최신 상태입니다 (변경 없음).`
+                : result.updated
+                ? `확장 "${result.name}" 을 v${result.previousVersion} → v${result.version} 으로 업데이트했습니다 — skill ${okSkills.length}개, MCP 서버 ${okServers.length}개 (모두 draft, 구버전 구성요소는 보관 처리). 각 구성요소를 검토·승인해야 활성화됩니다.`
+                : result.deduped
                 ? `24시간 내 동일 git ref 라 기존 설치 "${result.name}@${result.version}" 를 재사용했습니다.`
                 : `확장 "${result.name}@${result.version}" 을 설치했습니다 — skill ${okSkills.length}개, MCP 서버 ${okServers.length}개 (모두 draft). 각 구성요소를 검토·승인해야 활성화됩니다.`;
             const failSuffix = (failedSkills.length + failedServers.length) > 0
@@ -129,7 +136,9 @@ export const importExtensionFromGitTool: MCPToolDefinition<ImportExtensionFromGi
                 ? `\n\n⚠ MCP 서버 ${blockedServers.length}개가 위험 명령 패턴으로 차단 표시 — 승인 전 반드시 검토하세요.`
                 : '';
 
-            const llmText = `Installed extension ${result.extensionId} "${result.name}@${result.version}" from ${result.gitUrl}@${result.gitRef.slice(0, 7)} — skills: ${okSkills.length} ok/${failedSkills.length} failed, mcpServers: ${okServers.length} ok/${failedServers.length} failed/${blockedServers.length} convention-blocked. All components are drafts requiring user approval.`;
+            const llmText = result.upToDate
+                ? `Extension ${result.extensionId} "${result.name}@${result.version}" is already up to date (ref ${result.gitRef.slice(0, 7)}). No changes made.`
+                : `${result.updated ? `Updated extension ${result.extensionId} "${result.name}" v${result.previousVersion} -> v${result.version}` : `Installed extension ${result.extensionId} "${result.name}@${result.version}"`} from ${result.gitUrl}@${result.gitRef.slice(0, 7)} — skills: ${okSkills.length} ok/${failedSkills.length} failed, mcpServers: ${okServers.length} ok/${failedServers.length} failed/${blockedServers.length} convention-blocked. All components are drafts requiring user approval.`;
 
             logger.info(`MCP import_extension_from_git: ${result.extensionId} (user=${userId}, gitUrl=${args.gitUrl}, deduped=${result.deduped})`);
             return {

--- a/apps/web/components/settings/extensions-section.tsx
+++ b/apps/web/components/settings/extensions-section.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
-import { Package, Trash2, Loader2, ChevronDown, Puzzle, Server } from "lucide-react";
+import { Package, Trash2, Loader2, ChevronDown, Puzzle, Server, RefreshCw } from "lucide-react";
 import { Button, Card, CardHeader, CardTitle, CardContent } from "@/components/ui/primitives";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { ApiClient } from "@/lib/api-client";
@@ -22,6 +22,12 @@ interface ExtensionComponents {
   mcpServers: Array<{ id: string; name: string; status: string; enabled: boolean }>;
 }
 
+type UpdateCheckState =
+  | { state: "checking" }
+  | { state: "latest" }
+  | { state: "available"; latestVersion: string | null }
+  | { state: "failed" };
+
 /**
  * 확장 번들 (Agent Plugins v1) 관리 — 설치는 채팅 도구 import_extension_from_git,
  * 여기서는 설치 목록/구성요소 상태 조회와 번들 단위 제거만 제공한다 (PR #499 백엔드).
@@ -33,6 +39,7 @@ export function ExtensionsSection() {
   const [openId, setOpenId] = useState<string | null>(null);
   const [components, setComponents] = useState<Record<string, ExtensionComponents>>({});
   const [detailLoading, setDetailLoading] = useState(false);
+  const [updateChecks, setUpdateChecks] = useState<Record<string, UpdateCheckState>>({});
 
   const load = useCallback(async () => {
     try {
@@ -69,6 +76,23 @@ export function ExtensionsSection() {
       } finally {
         setDetailLoading(false);
       }
+    }
+  }
+
+  async function checkUpdate(id: string) {
+    setUpdateChecks((prev) => ({ ...prev, [id]: { state: "checking" } }));
+    try {
+      const res = await ApiClient.post<ApiSuccess<{ updateAvailable: boolean; latestVersion: string | null }>>(
+        `/api/users/me/extensions/${id}/update-check`,
+        {},
+      );
+      if (res?.data?.updateAvailable) {
+        setUpdateChecks((prev) => ({ ...prev, [id]: { state: "available", latestVersion: res.data.latestVersion } }));
+      } else {
+        setUpdateChecks((prev) => ({ ...prev, [id]: { state: "latest" } }));
+      }
+    } catch {
+      setUpdateChecks((prev) => ({ ...prev, [id]: { state: "failed" } }));
     }
   }
 
@@ -120,6 +144,7 @@ export function ExtensionsSection() {
             {extensions.map((ext) => {
               const open = openId === ext.id;
               const comp = components[ext.id];
+              const check = updateChecks[ext.id];
               return (
                 <li key={ext.id} className="rounded-lg border border-border">
                   <div className="flex items-center gap-3 p-3.5">
@@ -141,6 +166,34 @@ export function ExtensionsSection() {
                     <ChevronDown
                       className={`h-4 w-4 shrink-0 text-muted transition-transform ${open ? "rotate-180" : ""}`}
                     />
+                    {check && check.state !== "checking" && (
+                      <span
+                        className={`shrink-0 whitespace-nowrap text-xs ${
+                          check.state === "available" ? "text-warn" : check.state === "latest" ? "text-success" : "text-muted"
+                        }`}
+                      >
+                        {check.state === "available"
+                          ? check.latestVersion
+                            ? t("update.available", { version: check.latestVersion })
+                            : t("update.availableNoVersion")
+                          : check.state === "latest"
+                          ? t("update.latest")
+                          : t("update.failed")}
+                      </span>
+                    )}
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label={t("update.checkAria")}
+                      disabled={check?.state === "checking"}
+                      onClick={() => void checkUpdate(ext.id)}
+                    >
+                      {check?.state === "checking" ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <RefreshCw className="h-4 w-4" />
+                      )}
+                    </Button>
                     <Button
                       variant="ghost"
                       size="icon"
@@ -150,6 +203,9 @@ export function ExtensionsSection() {
                       <Trash2 className="h-4 w-4" />
                     </Button>
                   </div>
+                  {check?.state === "available" && (
+                    <p className="border-t border-border px-3.5 py-2 text-xs text-warn">{t("update.hint")}</p>
+                  )}
                   {open && (
                     <div className="space-y-3 border-t border-border px-3.5 py-3">
                       {detailLoading && !comp ? (

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1801,6 +1801,14 @@
       "draft": "Pending approval",
       "archived": "Archived",
       "disabled": "Disabled"
+    },
+    "update": {
+      "checkAria": "Check for updates",
+      "latest": "Up to date",
+      "available": "v{version} available",
+      "availableNoVersion": "Update available",
+      "failed": "Check failed",
+      "hint": "Ask in chat: \"Update this extension\" to replace it with the new version (old components are archived)."
     }
   }
 }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1801,6 +1801,14 @@
       "draft": "承認待ち",
       "archived": "アーカイブ済み",
       "disabled": "無効"
+    },
+    "update": {
+      "checkAria": "更新を確認",
+      "latest": "最新です",
+      "available": "v{version} が利用可能",
+      "availableNoVersion": "更新があります",
+      "failed": "確認失敗",
+      "hint": "チャットで「この拡張を更新して」と依頼すると新バージョンに置き換わります(旧コンポーネントはアーカイブされます)。"
     }
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1801,6 +1801,14 @@
       "draft": "승인 대기",
       "archived": "보관됨",
       "disabled": "비활성"
+    },
+    "update": {
+      "checkAria": "업데이트 확인",
+      "latest": "최신 상태",
+      "available": "v{version} 업데이트 가능",
+      "availableNoVersion": "업데이트 가능",
+      "failed": "확인 실패",
+      "hint": "채팅에서 \"이 확장 업데이트해줘\" 라고 요청하면 새 버전으로 교체됩니다 (구버전 구성요소는 보관 처리)."
     }
   }
 }

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1801,6 +1801,14 @@
       "draft": "待批准",
       "archived": "已归档",
       "disabled": "已停用"
+    },
+    "update": {
+      "checkAria": "检查更新",
+      "latest": "已是最新",
+      "available": "可更新到 v{version}",
+      "availableNoVersion": "有可用更新",
+      "failed": "检查失败",
+      "hint": "在聊天中请求\"更新这个扩展\"即可替换为新版本(旧组件将被归档)。"
     }
   }
 }

--- a/db/migrations/094_user_extensions_tracking_ref.sql
+++ b/db/migrations/094_user_extensions_tracking_ref.sql
@@ -1,0 +1,13 @@
+-- Migration 094 — user_extensions.tracking_ref (Phase 2: 버전/업데이트 확인)
+--
+-- 2026-08-16. 설치 시 요청한 git ref(브랜치/태그/SHA)를 영속한다.
+-- 기존에는 resolved SHA(source_ref)만 저장해 "무엇을 추적 중인지"를 잃었음 —
+-- 업데이트 확인은 tracking_ref(NULL = 기본 브랜치 HEAD)를 다시 resolve 해
+-- source_ref 와 비교한다. 고정 SHA 추적이면 항상 최신으로 판정(핀 고정).
+--
+-- 멱등 (ADD COLUMN IF NOT EXISTS).
+
+ALTER TABLE user_extensions ADD COLUMN IF NOT EXISTS tracking_ref TEXT;
+
+COMMENT ON COLUMN user_extensions.tracking_ref IS
+    '설치 시 요청한 git ref (브랜치/태그/SHA). NULL = 기본 브랜치 HEAD 추적. 업데이트 확인의 비교 기준.';

--- a/db/migrations/rollbacks/094_user_extensions_tracking_ref.sql
+++ b/db/migrations/rollbacks/094_user_extensions_tracking_ref.sql
@@ -1,0 +1,5 @@
+-- Rollback 094 — tracking_ref 제거
+--
+-- ⚠️ 애플리케이션 코드 참조 제거 후 실행할 것 (2단계 배포 원칙).
+
+ALTER TABLE user_extensions DROP COLUMN IF EXISTS tracking_ref;


### PR DESCRIPTION
## 요약

확장 번들 로드맵 Phase 2. 설치된 확장의 **원격 업데이트 확인**과 **재설치=업데이트** 시맨틱을 추가한다 (#499/#500 후속).

## 변경 내용

- **DB (094)**: `user_extensions.tracking_ref` — 설치 시 요청한 ref(브랜치/태그/SHA) 영속, NULL=기본 브랜치 HEAD. 업데이트 확인의 비교 기준 (고정 SHA는 항상 최신 판정 = 핀 고정). rollback 동봉.
- **REST `POST /:id/update-check`**: `tracking_ref` 재해석 → 설치된 `source_ref`와 비교, 변경 시 최신 `plugin.json` version 조회(조회 실패는 fail-open null). private repo는 body `accessToken`(요청 한정) 지원.
- **재설치=업데이트**: `import_extension_from_git` 재호출 시 같은 repo의 동명 active 설치면 — 구 구성요소 archive(+enabled=false, 링크 해제) 후 **기존 extension id를 유지**한 채 새 ref로 교체(`updated`/`previousVersion`). 동일 sha면 `upToDate`로 무변경 반환. 다른 소스의 동명 충돌만 기존대로 `EXTENSION_ALREADY_INSTALLED`. 설치 상한은 업데이트에 미적용.
- **Settings 확장 탭**: 행별 업데이트 확인 버튼 → `최신 상태`/`vX 업데이트 가능`/`확인 실패` 뱃지 + "채팅에서 업데이트해줘" 안내. i18n 4언어(`extensions.update.*`).

## 검증

- [x] `tsc --noEmit`·eslint 통과, 유닛 26건(신규: 업데이트/upToDate/충돌/checkForUpdate 5건) 통과
- [x] 094 트랜잭션+ROLLBACK 사전 검증 → 부팅 자동 적용 확인
- [x] **라이브 E2E (chat.openmake.cc, user 3)**: v1.0.0 설치 → update-check `false` → 픽스처 v1.1.0 push → update-check `{updateAvailable:true, latestVersion:"1.1.0"}` → 도구 재호출 → **동일 id로 v1.1.0 교체**, 구 skill/MCP archive·링크 해제, 기존 사용자 MCP 서버 무영향 → UI 뱃지 "v1.2.0 업데이트 가능"+안내 문구 렌더 확인 → 테스트 데이터 정리
- 관측된 특성: push 직후 수 초간 GitHub API 복제 지연으로 이전 sha가 반환될 수 있음 (일시적, 재시도로 해소)

## 비고

- Phase 2 잔여(archive/.zip 소스)와 Phase 3(공유/갤러리)는 실수요 확인 후 별도.

🤖 Generated with [Claude Code](https://claude.com/claude-code)