### PR TITLE
feat(extensions): marketplace.json 인덱스 지원 — Claude Code/Qwen 마켓플레이스 설치

### DIFF
--- a/apps/api/src/agents/git-ingest/__tests__/extension-ingest-service.test.ts
+++ b/apps/api/src/agents/git-ingest/__tests__/extension-ingest-service.test.ts
@@ -270,6 +270,76 @@ describe('ExtensionIngestService', () => {
         expect(archiveCalls.length).toBe(2);
     });
 
+    describe('marketplace 인덱스', () => {
+        const MARKETPLACE = JSON.stringify({
+            name: 'my-market',
+            plugins: [
+                {
+                    name: 'core',
+                    description: 'core plugin',
+                    source: { source: 'git-subdir', url: 'https://github.com/foo/bar.git', path: 'src/capabilities/core', ref: 'core-v1' },
+                },
+                { name: 'extra', description: 'extra plugin', source: './extra' },
+            ],
+        });
+
+        it('plugin 미지정 → 플러그인 목록 반환 (selectionRequired + marketplace)', async () => {
+            mockFetcher.resolveRef.mockResolvedValueOnce('abc123');
+            mockFetcher.listTree.mockResolvedValueOnce(treeOf('.claude-plugin/marketplace.json', 'src/capabilities/core/.claude-plugin/plugin.json'));
+            mockFetcher.fetchFile.mockResolvedValueOnce(MARKETPLACE);
+
+            const svc = makeService();
+            const r = await svc.import({ userId: 'user-1', isAdmin: false, gitUrl: 'foo/bar' });
+            expect('selectionRequired' in r && r.selectionRequired).toBe(true);
+            if (!('selectionRequired' in r && r.selectionRequired)) return;
+            expect(r.marketplace?.name).toBe('my-market');
+            expect(r.marketplace?.plugins.map(p => p.name)).toEqual(['core', 'extra']);
+        });
+
+        it('plugin 지정 → 고정 ref 로 해당 플러그인 설치 (tracking_ref=엔트리 ref)', async () => {
+            mockFetcher.resolveRef.mockResolvedValueOnce('abc123');   // HEAD
+            mockFetcher.listTree.mockResolvedValueOnce(treeOf('.claude-plugin/marketplace.json'));
+            mockFetcher.fetchFile.mockResolvedValueOnce(MARKETPLACE); // marketplace.json
+            mockFetcher.resolveRef.mockResolvedValueOnce('tagsha1');  // entry.ref 'core-v1'
+            mockFetcher.listTree.mockResolvedValueOnce(treeOf('src/capabilities/core/.claude-plugin/plugin.json'));
+            mockFetcher.fetchFile.mockResolvedValueOnce(JSON.stringify({
+                name: 'core-pack', version: '1.0.2',
+                mcpServers: { srv: { command: 'uvx', args: ['core'] } },
+            }));
+            const q = mockPool.query as jest.Mock;
+            q.mockResolvedValueOnce({ rows: [] });                    // dedupe
+            q.mockResolvedValueOnce({ rows: [] });                    // findActiveByName
+            q.mockResolvedValueOnce({ rows: [{ count: '0' }] });      // count
+            (mockLLM.chat as jest.Mock).mockResolvedValueOnce({
+                content: JSON.stringify({ findings: [] }), metrics: { completion_tokens: 30 },
+            });
+            q.mockResolvedValueOnce({ rows: [] });                    // unique name
+            q.mockResolvedValueOnce({ rows: [{ id: 'mcp-m1' }] });    // insertDraft
+            q.mockResolvedValueOnce({ rows: [{ id: 'user-ext-m1', name: 'core-pack', version: '1.0.2', status: 'active' }] });  // ext INSERT
+            q.mockResolvedValueOnce({ rows: [] });                    // link
+
+            const svc = makeService();
+            const r = await svc.import({ userId: 'user-1', isAdmin: false, gitUrl: 'foo/bar', plugin: 'core' });
+            if ('selectionRequired' in r && r.selectionRequired) throw new Error('expected single');
+            expect(r.gitRef).toBe('tagsha1');
+            expect(r.gitPath).toBe('src/capabilities/core/.claude-plugin/plugin.json');
+            expect(r.mcpServers[0].serverId).toBe('mcp-m1');
+            // user_extensions INSERT 의 tracking_ref 파라미터가 엔트리 고정 ref
+            const insertCall = q.mock.calls.find((c: unknown[]) => String(c[0]).includes('INSERT INTO user_extensions'));
+            expect(insertCall![1]).toContain('core-v1');
+        });
+
+        it('plugin 이 목록에 없으면 PLUGIN_NOT_IN_MARKETPLACE', async () => {
+            mockFetcher.resolveRef.mockResolvedValueOnce('abc123');
+            mockFetcher.listTree.mockResolvedValueOnce(treeOf('.claude-plugin/marketplace.json'));
+            mockFetcher.fetchFile.mockResolvedValueOnce(MARKETPLACE);
+
+            const svc = makeService();
+            await expect(svc.import({ userId: 'user-1', isAdmin: false, gitUrl: 'foo/bar', plugin: 'nope' }))
+                .rejects.toThrow('PLUGIN_NOT_IN_MARKETPLACE');
+        });
+    });
+
     describe('checkForUpdate', () => {
         it('sha 동일 → updateAvailable=false', async () => {
             mockFetcher.resolveRef.mockResolvedValueOnce('abc123');

--- a/apps/api/src/agents/git-ingest/__tests__/extension-manifest-validator.test.ts
+++ b/apps/api/src/agents/git-ingest/__tests__/extension-manifest-validator.test.ts
@@ -2,6 +2,7 @@ import {
     validateExtensionManifest,
     parseMcpJsonFile,
     normalizeMcpServers,
+    parseMarketplaceFile,
 } from '../extension-manifest-validator';
 
 describe('extension-manifest-validator', () => {
@@ -80,6 +81,50 @@ describe('extension-manifest-validator', () => {
             const r = normalizeMcpServers({ broken: {} });
             expect(r.servers).toHaveLength(0);
             expect(r.errors[0]).toContain('command 또는 url 필수');
+        });
+    });
+
+    describe('parseMarketplaceFile', () => {
+        it('git-subdir 객체 소스 + 상대 경로 문자열 소스 정규화', () => {
+            const r = parseMarketplaceFile(JSON.stringify({
+                name: 'my-market',
+                plugins: [
+                    {
+                        name: 'core',
+                        description: 'core plugin',
+                        source: { source: 'git-subdir', url: 'https://github.com/o/r.git', path: 'src/capabilities/core', ref: 'core-v1.0.2' },
+                    },
+                    { name: 'local', source: './plugins/local/' },
+                ],
+            }));
+            expect(r.ok).toBe(true);
+            if (!r.ok) return;
+            expect(r.marketplace.name).toBe('my-market');
+            expect(r.marketplace.plugins[0]).toEqual({
+                name: 'core', description: 'core plugin',
+                url: 'https://github.com/o/r.git', path: 'src/capabilities/core', ref: 'core-v1.0.2',
+            });
+            expect(r.marketplace.plugins[1]).toEqual({
+                name: 'local', description: undefined, url: undefined, path: 'plugins/local', ref: undefined,
+            });
+        });
+
+        it('path traversal 엔트리는 제외', () => {
+            const r = parseMarketplaceFile(JSON.stringify({
+                name: 'm',
+                plugins: [
+                    { name: 'evil', source: '../../etc' },
+                    { name: 'ok', source: './fine' },
+                ],
+            }));
+            expect(r.ok).toBe(true);
+            if (!r.ok) return;
+            expect(r.marketplace.plugins.map(p => p.name)).toEqual(['ok']);
+        });
+
+        it('plugins 전량 무효 또는 빈 목록이면 실패', () => {
+            expect(parseMarketplaceFile(JSON.stringify({ name: 'm', plugins: [] })).ok).toBe(false);
+            expect(parseMarketplaceFile('nope').ok).toBe(false);
         });
     });
 

--- a/apps/api/src/agents/git-ingest/__tests__/git-fetcher.test.ts
+++ b/apps/api/src/agents/git-ingest/__tests__/git-fetcher.test.ts
@@ -68,10 +68,38 @@ describe('GitFetcher', () => {
         expect(content).toBe('# Hello\n');
     });
 
-    it('404 → throws REPO_NOT_FOUND', async () => {
-        mockFetch.mockResolvedValueOnce({ ok: false, status: 404, headers: mkHeaders() });
+    it('404 → throws REPO_NOT_FOUND (heads 404 후 tags 폴백도 404)', async () => {
+        mockFetch.mockResolvedValueOnce({ ok: false, status: 404, headers: mkHeaders() });  // refs/heads
+        mockFetch.mockResolvedValueOnce({ ok: false, status: 404, headers: mkHeaders() });  // refs/tags 폴백
         const f = new GitFetcher();
         await expect(f.resolveRef('foo', 'missing', 'main')).rejects.toThrow(/REPO_NOT_FOUND/);
+    });
+
+    it('resolveRef: 브랜치 404 → 태그 폴백 (lightweight tag)', async () => {
+        mockFetch.mockResolvedValueOnce({ ok: false, status: 404, headers: mkHeaders() });  // refs/heads 404
+        mockFetch.mockResolvedValueOnce({
+            ok: true, status: 200,
+            json: async () => ({ object: { sha: 'tagsha1234', type: 'commit' } }),
+            headers: mkHeaders(),
+        });  // refs/tags
+        const f = new GitFetcher();
+        await expect(f.resolveRef('foo', 'bar', 'v1.0.2')).resolves.toBe('tagsha1234');
+    });
+
+    it('resolveRef: annotated tag 는 commit sha 로 역참조', async () => {
+        mockFetch.mockResolvedValueOnce({ ok: false, status: 404, headers: mkHeaders() });  // refs/heads 404
+        mockFetch.mockResolvedValueOnce({
+            ok: true, status: 200,
+            json: async () => ({ object: { sha: 'tagobj111', type: 'tag' } }),
+            headers: mkHeaders(),
+        });  // refs/tags → tag object
+        mockFetch.mockResolvedValueOnce({
+            ok: true, status: 200,
+            json: async () => ({ object: { sha: 'commitsha222' } }),
+            headers: mkHeaders(),
+        });  // git/tags/{sha} 역참조
+        const f = new GitFetcher();
+        await expect(f.resolveRef('foo', 'bar', 'v2.0.0')).resolves.toBe('commitsha222');
     });
 
     it('403 + rate-limit-remaining 0 → throws GITHUB_RATE_LIMITED', async () => {

--- a/apps/api/src/agents/git-ingest/extension-ingest-service.ts
+++ b/apps/api/src/agents/git-ingest/extension-ingest-service.ts
@@ -26,10 +26,11 @@ import { createLogger } from '../../utils/logger';
 import { parseGitUrl } from '../../schemas/git-ingest.schema';
 import type { ImportExtensionFromGitInput } from '../../schemas/extension-ingest.schema';
 import { GitFetcher } from './git-fetcher';
-import { scanForExtensionManifests, resolveExtensionRoot, type ManifestCandidate } from './repo-scanner';
+import { scanForExtensionManifests, scanForMarketplaceManifests, resolveExtensionRoot, type ManifestCandidate } from './repo-scanner';
 import {
     validateExtensionManifest,
     parseMcpJsonFile,
+    parseMarketplaceFile,
     type NormalizedMcpServer,
 } from './extension-manifest-validator';
 import { ConventionChecker, type ConventionFinding } from './convention-checker';
@@ -99,6 +100,11 @@ export interface CandidateListResult {
     candidates: ManifestCandidate[];
     totalCandidates: number;
     selectionRequired: true;
+    /** marketplace.json 인덱스 발견 시 — plugin 인자로 이름을 지정해 재호출 */
+    marketplace?: {
+        name: string;
+        plugins: Array<{ name: string; description?: string }>;
+    };
 }
 
 export interface ExtensionIngestOptions {
@@ -118,30 +124,91 @@ export class ExtensionIngestService {
         // (1) URL parse
         const parsed = parseGitUrl(input.gitUrl);
         if (!parsed) throw new Error(`INVALID_GIT_URL: ${input.gitUrl}`);
-        const { owner, repo } = parsed;
+        let { owner, repo } = parsed;
+        // marketplace 엔트리가 다른 저장소/고정 ref 를 가리킬 수 있어 effective 값으로 관리
+        let effectiveGitUrl = input.gitUrl;
+        let effectiveTrackingRef: string | null = input.gitRef ?? null;
 
         // (2) fetcher
         const fetcher = this.opts.fetcherFactory({ accessToken: input.accessToken });
-        const sha = await fetcher.resolveRef(owner, repo, input.gitRef ?? 'HEAD');
+        let sha = await fetcher.resolveRef(owner, repo, input.gitRef ?? 'HEAD');
 
-        // (3) tree → candidates
-        const tree = await fetcher.listTree(owner, repo, sha, SKILL_CREATOR.gitMaxTreeEntries);
-        const candidates = scanForExtensionManifests(tree.entries, input.gitPath);
-        if (candidates.length === 0) {
-            throw new Error(`NO_EXTENSION_FOUND: tree 에 plugin.json 후보 없음 (gitUrl=${input.gitUrl}, ref=${sha})`);
+        // (3) tree
+        let tree = await fetcher.listTree(owner, repo, sha, SKILL_CREATOR.gitMaxTreeEntries);
+        let candidate: ManifestCandidate | undefined;
+
+        // (3-a) marketplace.json 인덱스 (gitPath 미지정 시) — Claude Code 마켓플레이스 저장소
+        if (!input.gitPath) {
+            const mkCandidates = scanForMarketplaceManifests(tree.entries);
+            if (mkCandidates.length > 0) {
+                const mkRaw = await fetcher.fetchFile(owner, repo, sha, mkCandidates[0].path, EXTENSION_INGEST.manifestMaxBytes);
+                const mk = parseMarketplaceFile(mkRaw);
+                if (mk.ok && !input.plugin) {
+                    // 목록만 반환 — plugin 인자로 재호출 유도
+                    return {
+                        gitUrl: input.gitUrl,
+                        gitRef: sha,
+                        candidates: [],
+                        totalCandidates: mk.marketplace.plugins.length,
+                        selectionRequired: true,
+                        marketplace: {
+                            name: mk.marketplace.name,
+                            plugins: mk.marketplace.plugins.map(p => ({ name: p.name, description: p.description })),
+                        },
+                    };
+                }
+                if (mk.ok && input.plugin) {
+                    const entry = mk.marketplace.plugins.find(p => p.name === input.plugin);
+                    if (!entry) {
+                        throw new Error(`PLUGIN_NOT_IN_MARKETPLACE: "${input.plugin}" — 가능한 플러그인: ${mk.marketplace.plugins.map(p => p.name).join(', ')}`);
+                    }
+                    // 다른 저장소를 가리키는 엔트리 (git-subdir url)
+                    if (entry.url) {
+                        const p2 = parseGitUrl(entry.url);
+                        if (p2 && (p2.owner !== owner || p2.repo !== repo)) {
+                            owner = p2.owner;
+                            repo = p2.repo;
+                            effectiveGitUrl = entry.url;
+                        }
+                    }
+                    // 고정 ref (릴리스 태그) 또는 저장소 변경 시 tree 재조회
+                    if (entry.ref || effectiveGitUrl !== input.gitUrl) {
+                        sha = await fetcher.resolveRef(owner, repo, entry.ref ?? 'HEAD');
+                        tree = await fetcher.listTree(owner, repo, sha, SKILL_CREATOR.gitMaxTreeEntries);
+                    }
+                    if (entry.ref) effectiveTrackingRef = entry.ref;
+                    const prefix = entry.path ? `${entry.path}/` : '';
+                    const pj = tree.entries.find(e => e.path === `${prefix}.claude-plugin/plugin.json`)
+                        ?? tree.entries.find(e => e.path === `${prefix}plugin.json`);
+                    if (!pj) {
+                        throw new Error(`MARKETPLACE_PLUGIN_MANIFEST_NOT_FOUND: "${input.plugin}" (path=${entry.path || '.'}, ref=${sha.slice(0, 7)})`);
+                    }
+                    candidate = { path: pj.path, sha: pj.sha, size: pj.size };
+                    logger.info(`marketplace plugin resolved: ${input.plugin} → ${owner}/${repo}@${sha.slice(0, 7)}:${pj.path}`);
+                }
+                // mk 파싱 실패 → 일반 plugin.json 스캔으로 폴백
+            }
         }
-        if (candidates.length > 1 && !input.gitPath) {
-            return {
-                gitUrl: input.gitUrl,
-                gitRef: sha,
-                candidates,
-                totalCandidates: candidates.length,
-                selectionRequired: true,
-            };
+
+        // (3-b) 일반 plugin.json 스캔 (marketplace 미해당)
+        if (!candidate) {
+            const candidates = scanForExtensionManifests(tree.entries, input.gitPath);
+            if (candidates.length === 0) {
+                throw new Error(`NO_EXTENSION_FOUND: tree 에 plugin.json 후보 없음 (gitUrl=${input.gitUrl}, ref=${sha})`);
+            }
+            if (candidates.length > 1 && !input.gitPath) {
+                return {
+                    gitUrl: input.gitUrl,
+                    gitRef: sha,
+                    candidates,
+                    totalCandidates: candidates.length,
+                    selectionRequired: true,
+                };
+            }
+            candidate = candidates[0];
         }
 
         // (4) plugin.json fetch + validate
-        const candidate = candidates[0];
         const manifestRaw = await fetcher.fetchFile(owner, repo, sha, candidate.path, EXTENSION_INGEST.manifestMaxBytes);
         const validation = validateExtensionManifest(manifestRaw);
         if (!validation.ok) {
@@ -152,7 +219,7 @@ export class ExtensionIngestService {
 
         // (5) dedupe + 상한 + 동명 충돌
         const sourceHash = 'sha256:' + crypto.createHash('sha256')
-            .update(JSON.stringify({ uid: input.userId, url: input.gitUrl, sha, path: candidate.path }))
+            .update(JSON.stringify({ uid: input.userId, url: effectiveGitUrl, sha, path: candidate.path }))
             .digest('hex');
         const extRepo = new UserExtensionRepository(this.opts.pool);
 
@@ -205,7 +272,7 @@ export class ExtensionIngestService {
                 const r = await skillService.import({
                     userId: input.userId,
                     isAdmin: input.isAdmin,
-                    gitUrl: input.gitUrl,
+                    gitUrl: effectiveGitUrl,
                     gitRef: sha,
                     gitPath: path,
                     accessToken: input.accessToken,
@@ -266,7 +333,7 @@ export class ExtensionIngestService {
                             version: '1.0',
                             source: 'extension',
                             createdAt: new Date().toISOString(),
-                            gitUrl: input.gitUrl,
+                            gitUrl: effectiveGitUrl,
                             gitRef: sha,
                             gitPath: candidate.path,
                             extensionName: manifest.name,
@@ -316,7 +383,7 @@ export class ExtensionIngestService {
                 sourceRef: sha,
                 sourcePath: candidate.path,
                 sourceHash,
-                trackingRef: input.gitRef ?? null,
+                trackingRef: effectiveTrackingRef,
                 manifest: componentManifest,
             });
             if (!row) throw new Error(`EXTENSION_UPDATE_FAILED: ${updateTarget.id} 갱신 실패`);
@@ -326,11 +393,11 @@ export class ExtensionIngestService {
                 name: manifest.name,
                 version: manifest.version,
                 description: manifest.description ?? null,
-                sourceUrl: input.gitUrl,
+                sourceUrl: effectiveGitUrl,
                 sourceRef: sha,
                 sourcePath: candidate.path,
                 sourceHash,
-                trackingRef: input.gitRef ?? null,
+                trackingRef: effectiveTrackingRef,
                 manifest: componentManifest,
             });
         }
@@ -348,7 +415,7 @@ export class ExtensionIngestService {
             description: manifest.description ?? '',
             status: 'active',
             source: 'git-url',
-            gitUrl: input.gitUrl,
+            gitUrl: effectiveGitUrl,
             gitRef: sha,
             gitPath: candidate.path,
             skills: skillResults,

--- a/apps/api/src/agents/git-ingest/extension-manifest-validator.ts
+++ b/apps/api/src/agents/git-ingest/extension-manifest-validator.ts
@@ -119,6 +119,87 @@ export function validateExtensionManifest(jsonText: string): ValidationResult {
     };
 }
 
+// ── marketplace.json (Claude Code 마켓플레이스 인덱스) ──────────────────────
+
+const marketplaceSourceSchema = z.union([
+    // 상대 경로 축약형 ("./plugins/foo")
+    z.string().min(1).max(500),
+    // git-subdir 등 객체형 ({ source, url, path, ref })
+    z.object({
+        source: z.string().max(50).optional(),
+        url: z.string().max(500).optional(),
+        path: z.string().max(500).optional(),
+        ref: z.string().max(200).optional(),
+    }),
+]);
+
+const marketplaceSchema = z.object({
+    name: z.string().min(1).max(120),
+    plugins: z.array(z.object({
+        name: z.string().min(1).max(120),
+        description: z.string().max(2000).optional(),
+        source: marketplaceSourceSchema.optional(),
+    })).max(100),
+});
+
+export interface MarketplacePluginEntry {
+    name: string;
+    description?: string;
+    /** 다른 저장소를 가리키는 경우 (git-subdir url) */
+    url?: string;
+    /** 플러그인 루트 디렉토리 (저장소 상대 경로, './' 정규화됨) */
+    path?: string;
+    /** 고정 ref (태그/브랜치/SHA) — 설치 시 tracking_ref 로 영속 */
+    ref?: string;
+}
+
+export interface MarketplaceIndex {
+    name: string;
+    plugins: MarketplacePluginEntry[];
+}
+
+export type MarketplaceParseResult =
+    | { ok: true; marketplace: MarketplaceIndex }
+    | { ok: false; errors: string[] };
+
+/** marketplace.json 파싱 + 엔트리 정규화 (path traversal 차단). */
+export function parseMarketplaceFile(jsonText: string): MarketplaceParseResult {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(jsonText);
+    } catch {
+        return { ok: false, errors: ['marketplace.json 이 유효한 JSON 이 아님'] };
+    }
+    const result = marketplaceSchema.safeParse(parsed);
+    if (!result.success) {
+        return { ok: false, errors: result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`) };
+    }
+    const plugins: MarketplacePluginEntry[] = [];
+    const errors: string[] = [];
+    for (const p of result.data.plugins) {
+        let url: string | undefined;
+        let path: string | undefined;
+        let ref: string | undefined;
+        if (typeof p.source === 'string') {
+            path = p.source;
+        } else if (p.source) {
+            url = p.source.url;
+            path = p.source.path;
+            ref = p.source.ref;
+        }
+        path = path?.replace(/^\.\//, '').replace(/\/+$/, '');
+        if (path && path.includes('..')) {
+            errors.push(`${p.name}: path traversal 차단 — .. 미허용`);
+            continue;
+        }
+        plugins.push({ name: p.name, description: p.description, url, path, ref });
+    }
+    if (plugins.length === 0) {
+        return { ok: false, errors: errors.length > 0 ? errors : ['plugins 목록이 비어있음'] };
+    }
+    return { ok: true, marketplace: { name: result.data.name, plugins } };
+}
+
 /**
  * 별도 mcp.json 파싱 ({ mcpServers: {...} } 또는 최상위가 곧 server record 인 축약형).
  * plugin.json 에 mcpServers 가 이미 있으면 호출하지 않는다 (plugin.json 우선).

--- a/apps/api/src/agents/git-ingest/git-fetcher.ts
+++ b/apps/api/src/agents/git-ingest/git-fetcher.ts
@@ -63,9 +63,25 @@ export class GitFetcher {
         if (/^[0-9a-f]{7,40}$/i.test(ref)) return ref;
         // GitHub API 는 `/git/refs/heads/HEAD` 를 인식 못 함 (404). HEAD 면 default_branch 조회 후 그 이름으로 재시도.
         const effectiveRef = ref === 'HEAD' || !ref ? await this.getDefaultBranch(owner, repo) : ref;
-        const res = await this.req(`/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/git/refs/heads/${encodeURIComponent(effectiveRef)}`);
-        const data = await res.json() as { object?: { sha: string } };
+        const repoPath = `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+        let data: { object?: { sha: string; type?: string } };
+        try {
+            const res = await this.req(`${repoPath}/git/refs/heads/${encodeURIComponent(effectiveRef)}`);
+            data = await res.json() as typeof data;
+        } catch (e) {
+            // 브랜치가 아니면 태그 폴백 (릴리스 태그 고정 ref — marketplace 엔트리 등)
+            if (!(e instanceof Error && e.message.startsWith('REPO_NOT_FOUND'))) throw e;
+            const res = await this.req(`${repoPath}/git/refs/tags/${encodeURIComponent(effectiveRef)}`);
+            data = await res.json() as typeof data;
+        }
         if (!data.object?.sha) throw new Error(`INVALID_REF: ${ref}`);
+        // annotated tag 는 tag object 를 가리킴 — commit sha 로 역참조
+        if (data.object.type === 'tag') {
+            const res = await this.req(`${repoPath}/git/tags/${data.object.sha}`);
+            const tagData = await res.json() as { object?: { sha: string } };
+            if (!tagData.object?.sha) throw new Error(`INVALID_REF: ${ref} (annotated tag dereference 실패)`);
+            return tagData.object.sha;
+        }
         return data.object.sha;
     }
 

--- a/apps/api/src/agents/git-ingest/repo-scanner.ts
+++ b/apps/api/src/agents/git-ingest/repo-scanner.ts
@@ -104,6 +104,20 @@ export function scanForExtensionManifests(tree: TreeEntry[], explicitPath?: stri
 }
 
 /**
+ * marketplace.json (Claude Code 마켓플레이스 인덱스) 탐지.
+ * .claude-plugin/marketplace.json (표준) 또는 root marketplace.json.
+ * root 에 가까운 순(경로 길이 오름차순)으로 정렬 — 첫 항목이 대표 인덱스.
+ */
+const MARKETPLACE_MANIFEST_PATTERN = /(^|\/)(\.claude-plugin\/)?marketplace\.json$/;
+
+export function scanForMarketplaceManifests(tree: TreeEntry[]): ManifestCandidate[] {
+    return tree
+        .filter(e => MARKETPLACE_MANIFEST_PATTERN.test(e.path))
+        .map(e => ({ path: e.path, sha: e.sha, size: e.size }))
+        .sort((a, b) => a.path.length - b.path.length);
+}
+
+/**
  * plugin.json 경로 → 확장 루트 디렉토리 prefix ('' = repo root, 아니면 'dir/').
  * Claude Code 마켓플레이스 레이아웃(.claude-plugin/plugin.json)은 그 부모가 루트.
  */

--- a/apps/api/src/mcp/extension-ingest-tool.ts
+++ b/apps/api/src/mcp/extension-ingest-tool.ts
@@ -23,12 +23,13 @@ interface ImportExtensionFromGitArgs extends Record<string, unknown> {
     gitRef?: string;
     gitPath?: string;
     accessToken?: string;
+    plugin?: string;
 }
 
 export const importExtensionFromGitTool: MCPToolDefinition<ImportExtensionFromGitArgs> = {
     tool: {
         name: 'import_extension_from_git',
-        description: 'GitHub URL 의 plugin.json (Agent Plugins v1) 확장 번들을 설치합니다 — skills/*/SKILL.md 와 MCP 서버 정의를 한 번에 draft 로 가져옵니다. 같은 저장소의 이미 설치된 확장을 다시 요청하면 최신 ref 로 업데이트합니다 (구 구성요소는 archive). 사용자가 명시적으로 "이 확장/플러그인 설치해줘", "이 확장 업데이트해줘" 같은 요청을 했을 때만 호출하세요. plugin.json 이 여러 개면 후보 목록만 반환 (재호출에서 gitPath 명시 필요). 단일 스킬/에이전트/MCP 서버만 가져올 때는 import_skill_from_git / import_agent_from_git / import_mcp_server_from_git 를 대신 사용하세요.',
+        description: 'GitHub URL 의 plugin.json (Agent Plugins v1) 확장 번들을 설치합니다 — skills/*/SKILL.md 와 MCP 서버 정의를 한 번에 draft 로 가져옵니다. 마켓플레이스 저장소(.claude-plugin/marketplace.json)면 먼저 플러그인 목록을 반환하고, plugin 인자로 이름을 지정해 재호출하면 해당 플러그인을 설치합니다 (엔트리의 고정 ref 추적). 같은 저장소의 이미 설치된 확장을 다시 요청하면 최신 ref 로 업데이트합니다 (구 구성요소는 archive). 사용자가 명시적으로 "이 확장/플러그인 설치해줘", "이 확장 업데이트해줘" 같은 요청을 했을 때만 호출하세요. plugin.json 이 여러 개면 후보 목록만 반환 (재호출에서 gitPath 명시 필요). 단일 스킬/에이전트/MCP 서버만 가져올 때는 import_skill_from_git / import_agent_from_git / import_mcp_server_from_git 를 대신 사용하세요.',
         inputSchema: {
             type: 'object',
             properties: {
@@ -47,6 +48,10 @@ export const importExtensionFromGitTool: MCPToolDefinition<ImportExtensionFromGi
                 accessToken: {
                     type: 'string',
                     description: 'GitHub access token (선택). private repo 접근 또는 rate limit 우회 (60→5000/hr). 요청 한정 — DB 미저장.',
+                },
+                plugin: {
+                    type: 'string',
+                    description: '마켓플레이스 저장소(.claude-plugin/marketplace.json 보유)에서 설치할 플러그인 이름 (선택). 미지정 시 마켓플레이스 목록만 반환 — 목록에서 이름을 골라 이 인자로 재호출.',
                 },
             },
             required: ['gitUrl'],
@@ -89,7 +94,18 @@ export const importExtensionFromGitTool: MCPToolDefinition<ImportExtensionFromGi
                 gitRef: args.gitRef,
                 gitPath: args.gitPath,
                 accessToken: args.accessToken,
+                plugin: args.plugin,
             });
+
+            // marketplace 인덱스 — 플러그인 목록 반환 (plugin 인자로 재호출 유도)
+            if ('selectionRequired' in result && result.selectionRequired && result.marketplace) {
+                const list = result.marketplace.plugins
+                    .map((p, i) => `  ${i + 1}. ${p.name}${p.description ? ` — ${p.description.slice(0, 120)}` : ''}`)
+                    .join('\n');
+                const text = `마켓플레이스 "${result.marketplace.name}" 발견 — 플러그인 ${result.totalCandidates}개. 설치할 플러그인 이름을 \`plugin\` 인자로 지정해 재호출하세요:\n\n${list}\n\n예: \`import_extension_from_git({ gitUrl: "${args.gitUrl}", plugin: "${result.marketplace.plugins[0].name}" })\``;
+                logger.info(`MCP import_extension_from_git marketplace listing: ${result.totalCandidates} (user=${userId}, gitUrl=${args.gitUrl})`);
+                return { content: [{ type: 'text', text }] };
+            }
 
             // multi-candidate — 후보 목록 반환
             if ('selectionRequired' in result && result.selectionRequired) {

--- a/apps/api/src/schemas/extension-ingest.schema.ts
+++ b/apps/api/src/schemas/extension-ingest.schema.ts
@@ -12,6 +12,8 @@ export const importExtensionFromGitSchema = z.object({
         .refine(p => !p.includes('..'), 'path traversal 차단 — .. 미허용')
         .optional(),
     accessToken: z.string().max(200).optional(),  // 요청 한정, DB 미저장
+    // marketplace.json 인덱스가 있는 저장소에서 설치할 플러그인 이름
+    plugin: z.string().max(120).optional(),
 });
 
 export type ImportExtensionFromGitInput = z.infer<typeof importExtensionFromGitSchema>;

--- a/infra/mcp-runtime/Dockerfile
+++ b/infra/mcp-runtime/Dockerfile
@@ -11,9 +11,10 @@
 #   -v openmake-mcp-cache:/home/node/.cache   (named volume, 자동 생성)
 FROM node:22-slim
 
-# uv (uvx) + python — uvx 계열 MCP 서버용. uv 는 /usr/local/bin 에 설치(비-root 도 사용 가능).
+# uv (uvx) + python + git — uvx 계열 MCP 서버용. uv 는 /usr/local/bin 에 설치(비-root 도 사용 가능).
+# git: uvx 의 git+https 의존성 fetch 용 (Qwen-MM-Plugins 등 git 배포 MCP 서버 — 2026-08-16 실측).
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl python3 \
+    && apt-get install -y --no-install-recommends ca-certificates curl python3 git \
     && curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh \
     && apt-get purge -y curl \
     && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## 요약

확장 로드맵의 마지막 갭 — **marketplace.json 인덱스 소비** (#499~#503 후속). Qwen Code의 `qwen extensions install <marketplace>` 동등 기능으로, Claude Code/Qwen 생태계의 마켓플레이스 저장소를 목록 조회 → 이름 지정 설치할 수 있다.

## 변경 내용

- **marketplace 흐름**: `.claude-plugin/marketplace.json`(또는 root `marketplace.json`) 발견 시 — `plugin` 미지정이면 플러그인 목록 반환, `plugin=<이름>` 지정이면 해당 엔트리 설치. `git-subdir` 객체 소스(url/path/**고정 ref**)와 상대 경로 문자열 소스 모두 지원. 엔트리의 고정 ref(릴리스 태그)는 `tracking_ref`로 영속 → 업데이트 확인 기준. 교차 저장소 엔트리는 effective url/ref로 전환 후 동일 파이프라인. path traversal 차단, 100개 상한.
- **GitFetcher 태그 지원**: `resolveRef` 브랜치 404 시 `refs/tags` 폴백 + annotated tag는 commit sha로 역참조 — 전 ingest 경로(skill/agent/MCP) 공통 개선. (기존엔 릴리스 태그 ref가 `REPO_NOT_FOUND`)
- **mcp-runtime 이미지에 git 추가**: uvx의 `git+https` 의존성 fetch — git 배포 MCP 서버(Qwen-MM-Plugins 등)가 "Git executable not found"로 즉사하던 원인 (라이브 실측). 이미지 재빌드 필요: `docker build -t openmake-mcp-runtime:latest infra/mcp-runtime`
- 도구 `import_extension_from_git`에 `plugin` 인자 추가 + 마켓플레이스 목록 응답.

## 검증

- [x] `tsc --noEmit`·eslint 통과, 유닛 41건(신규: marketplace 파서/서비스 6 + 태그 폴백 3) 통과
- [x] **라이브 E2E (chat.openmake.cc, user 3) — 실제 QwenLM/Qwen-MM-Plugins(★2.5k)로 풀 사이클**:
  1. `gitUrl`만 → 마켓플레이스 "qwen-mm-plugins" 목록 8개 반환
  2. `plugin: qwen-mm-plugins-core` → 고정 태그 `qwen-mm-plugins-core-v1.0.2` 역참조(`ec9fbd1`) → skill 1 + MCP 서버 1 draft 설치, `tracking_ref` 영속
  3. 구성요소 승인 → Docker 샌드박스에서 uvx 스폰 성공 → **"7 tools discovered"** — 스킬+MCP가 하나의 패키지로 활성 동작
- DB 변경 없음 (기존 093~095 스키마 그대로)

🤖 Generated with [Claude Code](https://claude.com/claude-code)