### PR TITLE
fix(extensions): 채팅 설치 UX — 의도 프리필터 강제 포함 + 마켓플레이스 오호출 자가 교정

### DIFF
--- a/apps/api/src/agents/git-ingest/extension-ingest-service.ts
+++ b/apps/api/src/agents/git-ingest/extension-ingest-service.ts
@@ -194,6 +194,12 @@ export class ExtensionIngestService {
         if (!candidate) {
             const candidates = scanForExtensionManifests(tree.entries, input.gitPath);
             if (candidates.length === 0) {
+                // 잘못된 gitPath 로 마켓플레이스 분기를 우회한 경우 — plugin 인자 사용을 안내해
+                // 도구 루프 내 자가 교정 유도 (2026-08-16 라이브 실측: 모델이 gitPath 를 지어냄)
+                const mk = scanForMarketplaceManifests(tree.entries);
+                if (mk.length > 0) {
+                    throw new Error(`NO_EXTENSION_FOUND: 해당 gitPath 에 plugin.json 없음. 이 저장소는 마켓플레이스(.claude-plugin/marketplace.json)입니다 — gitPath 대신 plugin 인자로 플러그인 이름을 지정해 재호출하세요. 예: import_extension_from_git({ gitUrl: "${input.gitUrl}", plugin: "<플러그인 이름>" }) (gitPath/gitRef 는 생략)`);
+                }
                 throw new Error(`NO_EXTENSION_FOUND: tree 에 plugin.json 후보 없음 (gitUrl=${input.gitUrl}, ref=${sha})`);
             }
             if (candidates.length > 1 && !input.gitPath) {

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1708,6 +1708,18 @@ export const PLAN_INTENT_PATTERNS: readonly RegExp[] = [
     /implementation\s+plan/i,
 ];
 
+/** 확장 설치 의도 프리필터 — import_extension_from_git 강제 포함 게이트.
+ *  확장/플러그인/마켓플레이스 설치는 always-on/토글 어디에도 없어 채팅에서 도달
+ *  불가능했다(2026-08-16 라이브 실측 — 모델이 filesystem MCP 로 이탈). Settings
+ *  확장 탭의 안내("채팅에서 '이 확장 설치해줘: URL' 로 요청")와 UX 계약을 맞춘다.
+ *  git URL/저장소 언급 + 설치/업데이트 동사의 결합만 매칭 (오탐 억제). */
+export const EXTENSION_IMPORT_INTENT_PATTERNS: readonly RegExp[] = [
+    /(확장|플러그인|extension|plugin)[^\n]{0,40}?(설치|추가|가져와|업데이트|install|import|update)/i,
+    /(설치|추가|install)[^\n]{0,20}?(확장|플러그인|extension|plugin)/i,
+    /(마켓플레이스|marketplace)[^\n]{0,30}?(설치|목록|보여|열어|install|list)/i,
+    /import_extension_from_git/i,
+];
+
 /** 병렬 위임 의도 프리필터 — spawn_agents 사용 가이드 주입 게이트 (도구는 상시 노출).
  *  spawn 자발 채택 0 의 원인 = description 의 보수적 경고 + 사용 가이드 부재
  *  (2026-08-11 진단, 명시 유도 시엔 fan-out 정상 동작 실증 2026-07-17). */

--- a/apps/api/src/services/ChatService.ts
+++ b/apps/api/src/services/ChatService.ts
@@ -27,7 +27,7 @@ import type { UserContext } from '../mcp/user-sandbox';
 import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { CHAT_ALWAYS_ON_TOOL_NAMES } from '../mcp/agent-task-tools';
 import { MCP_META_TOOL_NAMES } from '../mcp/mcp-meta-tools';
-import { CHAT_USER_MCP_TOOL_CAP, CHAT_USER_MCP_SCHEMA_BUDGET_BYTES, MCP_PROGRESSIVE_DISCLOSURE_ENABLED, MAP_INTENT_PATTERNS, ROUTE_INTENT_PATTERNS, WEB_SEARCH_INTENT_PATTERNS, PLAN_INTENT_PATTERNS } from '../config/runtime-limits';
+import { CHAT_USER_MCP_TOOL_CAP, CHAT_USER_MCP_SCHEMA_BUDGET_BYTES, MCP_PROGRESSIVE_DISCLOSURE_ENABLED, MAP_INTENT_PATTERNS, ROUTE_INTENT_PATTERNS, WEB_SEARCH_INTENT_PATTERNS, PLAN_INTENT_PATTERNS, EXTENSION_IMPORT_INTENT_PATTERNS } from '../config/runtime-limits';
 import { applySkillCatalog as applySkillCatalogShared } from './skill-catalog-tool';
 import { LLMClient } from '../llm';
 import { type ToolDefinition } from '../llm';
@@ -248,6 +248,17 @@ export class ChatService {
             if (cp && !finalCombined.some((x) => x.function.name === cp.function.name)) {
                 finalCombined = [...finalCombined, cp];
                 logger.info('[PlanMode] 계획수립 의도 — create_plan 강제 포함');
+            }
+        }
+        // 확장/플러그인 설치 요청이면 import_extension_from_git 을 강제 포함한다 — import 계열은
+        // always-on 이 아니라 토글로만 노출되는데, Settings 확장 탭 안내는 "채팅에서 요청" 이
+        // 계약이라 노출 없이는 모델이 다른 도구로 이탈한다(2026-08-16 라이브 실측). 동일 선례:
+        // web_search/create_plan 강제 포함.
+        if (EXTENSION_IMPORT_INTENT_PATTERNS.some((re) => re.test(reqCtx.message ?? ''))) {
+            const ie = allTools.find((x) => x.function.name === 'import_extension_from_git');
+            if (ie && !finalCombined.some((x) => x.function.name === ie.function.name)) {
+                finalCombined = [...finalCombined, ie];
+                logger.info('[Extension] 확장 설치 의도 — import_extension_from_git 강제 포함');
             }
         }
         return this.applySkillCatalog(finalCombined, allTools, reqCtx);


### PR DESCRIPTION
## 요약

채팅에서 "이 확장 설치해줘: URL"이 실제로 동작하게 만드는 라이브 실측 수정 2건 (#504 후속).

## 실측 결함과 수정

1. **도구 미노출로 모델 이탈**: `import_extension_from_git`은 always-on도 토글 기본값도 아니라, 확장 설치 요청 시 모델이 filesystem MCP 등 엉뚱한 도구로 이탈 (WS 채팅 E2E 실측). Settings 확장 탭 안내("채팅에서 요청하세요")와 UX 계약 불일치. → `EXTENSION_IMPORT_INTENT_PATTERNS` 프리필터 매칭 시 강제 포함 (web_search 2026-07-17 / create_plan 2026-08-11 선례와 동일, B형 규약 준수 — 관련 턴에만 노출, 라우터 LLM 없음).
2. **마켓플레이스 오호출 루프**: 목록 응답 후 모델이 `plugin` 인자 대신 `gitPath`를 지어내 `NO_EXTENSION_FOUND` 반복. → 해당 에러에 "plugin 인자로 재호출" 안내를 포함해 도구 루프 내 자가 교정 유도.

## 검증 (WS 채팅 라이브 E2E, chat.openmake.cc, user 3)

- [x] 1턴 "이 확장 설치해줘: github.com/QwenLM/Qwen-MM-Plugins" → 도구 강제 포함 로그 → 모델이 `import_extension_from_git` 호출 → 마켓플레이스 8개 목록으로 되물음
- [x] 2턴 "qwen-mm-plugins-search 설치해줘" → (수정 전: gitPath 오호출 반복 실패 / 수정 후) `plugin` 인자로 정확 호출 → **설치 성공** — skill+MCP draft(3중 잠금 유지), 고정 태그 `v1.0.3` 추적, 인라인 설치 카드 리소스 발행
- [x] 유닛 33건·eslint·tsc 통과. 테스트 설치는 정리 완료 (core 패키지는 유지)

## 비고

- 이 검증 중 **운영 장애 1건 발견·복구**: 8/15 재부팅 이후 LiteLLM 게이트웨이가 PM2에서 누락돼 다운 상태(외부 LLM 오류의 원인, fail-open 컨벤션 검사에 가려짐) → `pm2 start litellm` + `pm2 save`로 복구·영속화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)