### PR TITLE
fix(extensions): 거대 repo 스킬 설치 실패 — 위임 GitIngestService tree 상한 주입

### DIFF
--- a/apps/api/src/agents/git-ingest/extension-ingest-service.ts
+++ b/apps/api/src/agents/git-ingest/extension-ingest-service.ts
@@ -297,6 +297,8 @@ export class ExtensionIngestService {
             llmClientFactory: this.opts.llmClientFactory,
             // 아카이브 소스면 이미 로드된 동일 ArchiveFetcher 재사용 (재다운로드 방지)
             fetcherFactory: isArchive ? () => fetcher : this.opts.fetcherFactory,
+            // 거대 마켓플레이스 repo — 확장 경로 상한으로 재조회 (스킬 ingest 기본 상한이면 REPO_TOO_LARGE)
+            maxTreeEntries: EXTENSION_INGEST.maxTreeEntries,
         });
         for (const path of skillPaths) {
             try {

--- a/apps/api/src/agents/git-ingest/git-ingest-service.ts
+++ b/apps/api/src/agents/git-ingest/git-ingest-service.ts
@@ -68,6 +68,8 @@ export interface GitIngestOptions {
     pool: Pool;
     llmClientFactory: (model: string) => LLMClient;
     fetcherFactory: (opts: { accessToken?: string }) => GitFetcher;
+    /** tree 상한 override — 확장 번들 체인이 거대 마켓플레이스 repo 용으로 상향 주입 (기본: 스킬 ingest 상한) */
+    maxTreeEntries?: number;
 }
 
 export class GitIngestService {
@@ -94,7 +96,7 @@ export class GitIngestService {
         const sha = await fetcher.resolveRef(owner, repo, input.gitRef ?? 'HEAD');
 
         // (4) tree → candidates
-        const tree = await fetcher.listTree(owner, repo, sha, SKILL_CREATOR.gitMaxTreeEntries);
+        const tree = await fetcher.listTree(owner, repo, sha, this.opts.maxTreeEntries ?? SKILL_CREATOR.gitMaxTreeEntries);
         const candidates = scanForSkillManifests(tree.entries, input.gitPath);
 
         if (candidates.length === 0) {


### PR DESCRIPTION
## 문제

카탈로그에서 `claude-code-plugins-plus`(23,003 blobs)의 플러그인 설치가 전부 `NO_COMPONENTS_INSTALLED` 로 실패 (라이브 실측: `anomaly-detection-system`).

로그: `NO_COMPONENTS_INSTALLED: 설치 가능한 구성요소 없음 (REPO_TOO_LARGE: 23003 blobs > 10000)`

## 원인

#507 에서 확장 서비스 자체의 listTree 는 `EXTENSION_INGEST.maxTreeEntries`(50,000)로 올렸지만, 스킬 설치를 위임받는 `GitIngestService.import` 가 내부 tree 재조회에서 스킬 ingest 상한 `SKILL_CREATOR.gitMaxTreeEntries`(10,000)를 그대로 사용 → 거대 repo 에서 `REPO_TOO_LARGE` → 스킬 0개 → 구성요소 없음.

## 수정

- `GitIngestOptions.maxTreeEntries?` 옵션 추가 — 미지정 시 기존 스킬 ingest 상한 그대로 (일반 스킬 ingest 경로 동작 불변)
- 확장 번들 체인의 skillService 생성부에서만 `EXTENSION_INGEST.maxTreeEntries` 주입

## 검증

- [x] tsc·eslint·git-ingest 유닛 85건 통과
- [x] **라이브 검증 (chat.openmake.cc, user 3)**: `anomaly-detection-system` 카탈로그 설치 200 — 스킬 `detecting-data-anomalies` draft 생성 확인 (`user-skill-e8d32cd0…`), 확장 레코드 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)