### PR TITLE
fix(skills): 확장 설치 스킬 채팅 노출 4결함 — userId 전파·general 통과·manifest union

### DIFF
--- a/apps/api/src/agents/__tests__/skill-auto-select.test.ts
+++ b/apps/api/src/agents/__tests__/skill-auto-select.test.ts
@@ -128,3 +128,24 @@ describe('buildSkillPromptForIds 권한 필터 (camelCase 회귀)', () => {
         expect(await mgr.buildSkillPromptForIds(['g1'], 'anyone')).toContain('OPEN');
     });
 });
+
+describe('searchSkills userId 전파 (비공개 확장 스킬 포함, 2026-08-16)', () => {
+    function managerWithSpy(skills: AgentSkill[]) {
+        const mgr = new SkillManager();
+        const searchSkills = jest.fn(async () => ({ skills, total: skills.length, limit: 200, offset: 0 }));
+        (mgr as unknown as { repo: unknown }).repo = { searchSkills };
+        return { mgr, searchSkills };
+    }
+
+    it('buildSkillCatalog 이 userId 를 repo 검색에 전달한다', async () => {
+        const { mgr, searchSkills } = managerWithSpy([skill({ id: 's1', name: 'A' })]);
+        await mgr.buildSkillCatalog({ userId: 'u3' });
+        expect(searchSkills).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u3' }));
+    });
+
+    it('buildSkillPromptForNames 가 userId 를 repo 검색에 전달한다', async () => {
+        const { mgr, searchSkills } = managerWithSpy([skill({ id: 's1', name: 'A' })]);
+        await mgr.buildSkillPromptForNames(['A'], 'u3');
+        expect(searchSkills).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u3' }));
+    });
+});

--- a/apps/api/src/agents/__tests__/skill-manifest-union.test.ts
+++ b/apps/api/src/agents/__tests__/skill-manifest-union.test.ts
@@ -1,0 +1,76 @@
+/**
+ * buildManifestPrompt — 개인 지정(user-assign) 스킬 union 회귀 테스트 (2026-08-16).
+ *
+ * 확장 설치 스킬 등 agent_skills 에만 있고 skill_manifests 행이 없는 스킬은,
+ * manifest 스킬이 하나라도 활성이면 legacy fallback 이 실행되지 않아 지정해도
+ * 조용히 누락됐다. manifest 결과에 manifest 미보유 개인 지정 스킬을 union 한다.
+ */
+import { SkillManager } from '../skill-manager';
+import type { AgentSkill } from '../../data/repositories/skill-repository';
+
+const MANIFEST_ROWS = [{
+    id: 'user-3-presentation-designer',
+    prompt_md: 'PRESENT_RULES',
+    manifest_yaml: '---\nname: presentation-designer\ncategory: design\n---',
+}];
+
+jest.mock('../../data/models/unified-database', () => ({
+    getUnifiedDatabase: () => ({
+        getPool: () => ({ query: async () => ({ rows: MANIFEST_ROWS }) }),
+    }),
+}));
+
+function skill(partial: Partial<AgentSkill> & { id: string; name: string }): AgentSkill {
+    return {
+        description: '', content: 'CONTENT', category: 'general',
+        isPublic: false, createdBy: '3', status: 'active',
+        createdAt: new Date(0), updatedAt: new Date(0),
+        ...partial,
+    } as unknown as AgentSkill;
+}
+
+function managerWithUserSkills(userSkills: AgentSkill[]): SkillManager {
+    const mgr = new SkillManager();
+    (mgr as unknown as { repo: unknown }).repo = {
+        getUserSkills: async () => userSkills,
+    };
+    return mgr;
+}
+
+describe('buildManifestPrompt — 개인 지정 스킬 union', () => {
+    it('manifest 미보유 개인 지정 스킬(general)을 에이전트 카테고리 턴에도 포함한다', async () => {
+        const mgr = managerWithUserSkills([
+            skill({ id: 'user-skill-x1', name: 'design-critique', content: 'CRITIQUE_RULES', category: 'general' }),
+        ]);
+        const out = await mgr.buildManifestPrompt('ui-ux-designer', '3', 'design');
+        expect(out).not.toBeNull();
+        expect(out!.skillNames).toEqual(expect.arrayContaining(['presentation-designer', 'design-critique']));
+        expect(out!.prompt).toContain('CRITIQUE_RULES');
+        expect(out!.prompt).toContain('PRESENT_RULES');
+    });
+
+    it('카테고리가 다른(비 general) 개인 지정 스킬은 union 에서 제외한다', async () => {
+        const mgr = managerWithUserSkills([
+            skill({ id: 'user-skill-x2', name: 'redis-tuning', content: 'REDIS', category: 'engineering' }),
+        ]);
+        const out = await mgr.buildManifestPrompt('ui-ux-designer', '3', 'design');
+        expect(out!.skillNames).not.toContain('redis-tuning');
+    });
+
+    it('이미 manifest 로 주입된 스킬은 union 에서 중복 제외한다', async () => {
+        const mgr = managerWithUserSkills([
+            skill({ id: 'user-3-presentation-designer', name: 'presentation-designer', content: 'DUP' }),
+        ]);
+        const out = await mgr.buildManifestPrompt('ui-ux-designer', '3', 'design');
+        expect(out!.skillNames.filter((n) => n === 'presentation-designer')).toHaveLength(1);
+        expect(out!.prompt).not.toContain('DUP');
+    });
+
+    it('userId 없으면 union 하지 않는다 (기존 동작 유지)', async () => {
+        const mgr = managerWithUserSkills([
+            skill({ id: 'user-skill-x1', name: 'design-critique', content: 'CRITIQUE_RULES' }),
+        ]);
+        const out = await mgr.buildManifestPrompt('ui-ux-designer', undefined, 'design');
+        expect(out!.skillNames).toEqual(['presentation-designer']);
+    });
+});

--- a/apps/api/src/agents/skill-manager.ts
+++ b/apps/api/src/agents/skill-manager.ts
@@ -316,9 +316,11 @@ export class SkillManager {
      *
      * @param opts.excludeIds \uc774\ubbf8 \uc8fc\uc785\ub41c \ubc14\uc778\ub529 \uc2a4\ud0ac \u2014 \uc774\uc911 \ub178\ucd9c \ubc29\uc9c0(dedup)
      */
-    async buildSkillCatalog(opts: { excludeIds?: ReadonlySet<string> } = {}): Promise<{ catalog: string; count: number }> {
+    async buildSkillCatalog(opts: { excludeIds?: ReadonlySet<string>; userId?: string } = {}): Promise<{ catalog: string; count: number }> {
         const repo = await this.ensureInitialized();
-        const result = await repo.searchSkills({ status: 'active', sortBy: 'name', limit: SKILL_CATALOG_MAX_ITEMS });
+        // userId 전달 시 본인 소유 비공개 스킬 포함(public OR own) — 미전달이면 public 전용.
+        // 확장 설치 스킬(전부 비공개)이 카탈로그에 안 실려 자동 호출이 불가능하던 갭 (2026-08-16).
+        const result = await repo.searchSkills({ status: 'active', sortBy: 'name', limit: SKILL_CATALOG_MAX_ITEMS, userId: opts.userId });
         const lines: string[] = [];
         for (const s of result.skills) {
             if (opts.excludeIds?.has(s.id)) continue;
@@ -339,7 +341,8 @@ export class SkillManager {
     ): Promise<{ prompt: string; matched: string[] }> {
         if (!Array.isArray(names) || names.length === 0) return { prompt: '', matched: [] };
         const repo = await this.ensureInitialized();
-        const result = await repo.searchSkills({ status: 'active', limit: SKILL_CATALOG_MAX_ITEMS });
+        // userId 전달로 본인 소유 비공개 스킬도 검색 대상에 포함 — 아래 visible 필터와 동일 규칙.
+        const result = await repo.searchSkills({ status: 'active', limit: SKILL_CATALOG_MAX_ITEMS, userId });
         const wanted = names.slice(0, Math.max(1, topK)).map((n) => String(n).toLowerCase().trim()).filter(Boolean);
         const seen = new Set<string>();
         const picked: AgentSkill[] = [];
@@ -477,6 +480,29 @@ export class SkillManager {
             const m = /^---[\s\S]*?\bname:\s*([^\n]+)/.exec(r.manifest_yaml);
             return m?.[1]?.trim().replace(/^['"]|['"]$/g, '') || r.id;
         });
+
+        // 개인 지정(user-assign) 스킬 중 manifest 미보유분 union — 확장 설치 스킬 등은
+        // agent_skills 에만 존재하는데, manifest 스킬이 하나라도 있으면 legacy fallback 이
+        // 실행되지 않아 지정해도 조용히 누락되던 갭 (2026-08-16). agent/global 스킬은
+        // 기존대로 manifest 가 지배하고, 개인 지정분만 보충한다 (전체 15개 상한 유지).
+        if (userId) {
+            try {
+                const manifestIds = new Set(rows.map(r => r.id));
+                const userSkills = (await this.getUserSkills(userId)).filter(s =>
+                    !manifestIds.has(s.id) &&
+                    (!agentCategory || s.category === agentCategory || s.category === 'general'));
+                for (const s of userSkills.slice(0, Math.max(0, 15 - blocks.length))) {
+                    const safeName = s.name.replace(/[<>"&]/g, '');
+                    const content = s.content.length > MAX_SKILL_CONTENT_LENGTH
+                        ? s.content.slice(0, MAX_SKILL_CONTENT_LENGTH) + '\n... (truncated)'
+                        : s.content;
+                    blocks.push(`<skill_context name="${safeName}">\n${content}\n</skill_context>`);
+                    skillNames.push(s.name);
+                }
+            } catch (e) {
+                logger.debug('개인 지정 스킬 union 실패 (manifest 분만 주입)', e);
+            }
+        }
         return { prompt: `\n\n## 적용된 스킬 (manifest)\n${blocks.join('\n\n')}`, skillNames };
     }
 

--- a/apps/api/src/chat/__tests__/slash-command.test.ts
+++ b/apps/api/src/chat/__tests__/slash-command.test.ts
@@ -82,6 +82,27 @@ describe('applySlashCommand', () => {
     });
 });
 
+describe('기본 해석기 — userId 전달·하이픈 이름 재검색 (2026-08-16)', () => {
+    it('searchSkills 에 userId 가 전달되고, 공백 복원 검색이 놓친 하이픈 이름을 원 slug 로 재검색해 매칭한다', async () => {
+        const searchSkills = jest.fn()
+            // 1차: 'design critique' (공백 복원) — 하이픈 이름이라 미매칭
+            .mockResolvedValueOnce({ skills: [], total: 0, limit: 10, offset: 0 })
+            // 2차: 'design-critique' (원 slug) — 매칭
+            .mockResolvedValueOnce({
+                skills: [{ name: 'design-critique', content: 'CRITIQUE_RULES' }],
+                total: 1, limit: 10, offset: 0,
+            });
+        jest.doMock('../../agents/skill-manager', () => ({ getSkillManager: () => ({ searchSkills }) }));
+
+        const out = await applySlashCommand('/design-critique 버튼 평가', { userId: 'u3' });
+        expect(out).toContain('CRITIQUE_RULES');
+        expect(searchSkills).toHaveBeenNthCalledWith(1, expect.objectContaining({ search: 'design critique', userId: 'u3' }));
+        expect(searchSkills).toHaveBeenNthCalledWith(2, expect.objectContaining({ search: 'design-critique', userId: 'u3' }));
+
+        jest.dontMock('../../agents/skill-manager');
+    });
+});
+
 describe('한글 스킬명 slug (2026-07-04 유니코드 대응)', () => {
     it('한글 이름이 빈 slug 로 붕괴하지 않는다', () => {
         expect(slugify('데이터 시각화 가이드')).toBe('데이터-시각화-가이드');

--- a/apps/api/src/chat/slash-command.ts
+++ b/apps/api/src/chat/slash-command.ts
@@ -81,14 +81,20 @@ export interface ApplySlashDeps {
 
 /** 기본 스킬 해석기 — active 스킬을 검색해 slug 정확 매칭.
  *  검색어는 slug 의 '-' 를 공백으로 복원 — 스킬 이름은 공백 구분이라 하이픈 그대로는
- *  ILIKE 검색이 매칭되지 않음 (다단어 스킬명 slash 호출이 불가능하던 결함, 2026-07-04). */
-async function defaultFindSkillBySlug(slug: string): Promise<SlashSkill | null> {
+ *  ILIKE 검색이 매칭되지 않음 (다단어 스킬명 slash 호출이 불가능하던 결함, 2026-07-04).
+ *  하이픈 이름(확장 스킬 등)은 공백 복원 검색이 name ILIKE 를 놓치므로 원 slug 로도 검색.
+ *  userId 를 전달해야 본인 소유 비공개 스킬이 검색됨 — 미전달 시 public 전용이라
+ *  확장 설치 스킬(전부 비공개)의 슬래시 호출이 불가능하던 결함 (2026-08-16). */
+async function defaultFindSkillBySlug(slug: string, userId?: string): Promise<SlashSkill | null> {
     const { getSkillManager } = await import('../agents/skill-manager');
-    const result = await getSkillManager().searchSkills({
-        search: slug.replace(/-/g, ' '), status: 'active', limit: 10,
-    });
-    const matched = result.skills.find((s) => matchesSlug(s.name, slug));
-    return matched ? { name: matched.name, content: matched.content } : null;
+    const manager = getSkillManager();
+    for (const search of [slug.replace(/-/g, ' '), slug]) {
+        const result = await manager.searchSkills({ search, status: 'active', limit: 10, userId });
+        const matched = result.skills.find((s) => matchesSlug(s.name, slug));
+        if (matched) return { name: matched.name, content: matched.content };
+        if (!slug.includes('-')) break; // 하이픈 없으면 두 검색어가 동일 — 재검색 불필요
+    }
+    return null;
 }
 
 /**

--- a/apps/api/src/data/repositories/__tests__/skill-assignment-category.test.ts
+++ b/apps/api/src/data/repositories/__tests__/skill-assignment-category.test.ts
@@ -1,0 +1,35 @@
+/**
+ * getSkillsForAgent 개인 스킬 카테고리 필터 회귀 테스트.
+ *
+ * 에이전트 선택 턴에서 user-assign 개인 스킬은 카테고리 일치 시에만 주입되는데,
+ * 확장 설치 스킬 등 기본 카테고리 'general' 은 어떤 에이전트와도 일치하지 않아
+ * 지정이 무의미했다 (2026-08-16). 'general' 은 카테고리 무관 통과해야 한다.
+ */
+import { SkillAssignmentRepository } from '../skill-assignment-repository';
+
+function repoWithCapture() {
+    const repo = new SkillAssignmentRepository({} as never);
+    const calls: { sql: string; params: unknown[] }[] = [];
+    (repo as unknown as { query: unknown }).query = (sql: string, params: unknown[]) => {
+        calls.push({ sql, params });
+        return Promise.resolve({ rows: [], rowCount: 0 });
+    };
+    return { repo, calls };
+}
+
+describe('getSkillsForAgent — 개인 스킬 카테고리 필터', () => {
+    it("에이전트 카테고리 지정 시 'general' 개인 스킬도 통과하는 조건을 포함한다", async () => {
+        const { repo, calls } = repoWithCapture();
+        await repo.getSkillsForAgent('ui-ux-designer', '3', 'design');
+        expect(calls).toHaveLength(1);
+        expect(calls[0].sql).toContain("OR s.category = 'general'");
+        expect(calls[0].params).toEqual(expect.arrayContaining(['user:3', 'design']));
+    });
+
+    it('에이전트 카테고리 미지정 시 개인 스킬은 카테고리 필터 없이 포함된다', async () => {
+        const { repo, calls } = repoWithCapture();
+        await repo.getSkillsForAgent('ui-ux-designer', '3');
+        expect(calls[0].sql).not.toContain('s.category =');
+        expect(calls[0].params).toEqual(expect.arrayContaining(['user:3']));
+    });
+});

--- a/apps/api/src/data/repositories/skill-assignment-repository.ts
+++ b/apps/api/src/data/repositories/skill-assignment-repository.ts
@@ -37,7 +37,7 @@ export class SkillAssignmentRepository extends BaseRepository {
     /**
      * 에이전트에 연결된 스킬 목록 반환.
      *   - 에이전트 고유 스킬 + '__global__' 가상 에이전트 스킬
-     *   - userId 가 주어지면 'user:{userId}' 개인 스킬도 포함 (카테고리 일치 시)
+     *   - userId 가 주어지면 'user:{userId}' 개인 스킬도 포함 (카테고리 일치 또는 'general')
      *   - status='active' 만 (draft/archived 는 prompt 주입 경로에서 차단)
      */
     async getSkillsForAgent(agentId: string, userId?: string, agentCategory?: string): Promise<AgentSkill[]> {
@@ -46,7 +46,10 @@ export class SkillAssignmentRepository extends BaseRepository {
 
         if (userId) {
             if (agentCategory) {
-                conditions.push(`(a.agent_id = $${params.length + 1} AND s.category = $${params.length + 2})`);
+                // 'general' 은 카테고리 무관 통과 — 확장 설치 스킬 등 기본 카테고리가 general 이라
+                // 에이전트 선택 턴마다 제외돼 개인 지정(user-assign)이 무의미하던 갭 (2026-08-16).
+                // 지정은 사용자의 명시적 opt-in 이고 아래 LIMIT 캡이 과주입을 막는다.
+                conditions.push(`(a.agent_id = $${params.length + 1} AND (s.category = $${params.length + 2} OR s.category = 'general'))`);
                 params.push(`user:${userId}`, agentCategory);
             } else {
                 conditions.push(`a.agent_id = $${params.length + 1}`);

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -266,6 +266,7 @@ export class AgentTaskService {
             const { tools, extraToolNames } = await assembleAgentTools({
                 mcpTools, taskRuntime, sandboxCfg, goal,
                 injectedSkillIds: new Set(skillBindings.map((b) => b.skill_id)),
+                userId,
             });
 
             // 스텝 실시간 발행(4-5) — DB 기록 직후 요약을 WS 로 브로드캐스트(채팅 인라인 카드의 "현재 단계").

--- a/apps/api/src/services/ChatService.ts
+++ b/apps/api/src/services/ChatService.ts
@@ -280,8 +280,10 @@ export class ChatService {
         tools: ToolDefinition[], allTools: ToolDefinition[], reqCtx: RequestContext,
     ): Promise<ToolDefinition[]> {
         // 구현은 services/skill-catalog-tool 로 추출 (에이전트 작업 경로와 공용 — SSoT)
+        const rawUserId = reqCtx.userContext.userId;
         return applySkillCatalogShared(tools, allTools, {
             excludeIds: new Set(reqCtx.skillBindings.map((b) => b.skill_id)),
+            ...(rawUserId !== undefined && rawUserId !== null ? { userId: String(rawUserId) } : {}),
         });
     }
 

--- a/apps/api/src/services/agent-task/tool-assembly.ts
+++ b/apps/api/src/services/agent-task/tool-assembly.ts
@@ -39,8 +39,10 @@ export async function assembleAgentTools(params: {
      * 미지정 시 전체 카탈로그 노출.
      */
     injectedSkillIds?: ReadonlySet<string>;
+    /** 작업 소유자 id — 본인 소유 비공개 스킬(확장 설치분 등)을 카탈로그에 포함. */
+    userId?: string;
 }): Promise<AssembledTools> {
-    const { mcpTools, taskRuntime, sandboxCfg, goal, injectedSkillIds } = params;
+    const { mcpTools, taskRuntime, sandboxCfg, goal, injectedSkillIds, userId } = params;
     const extraToolNames = new Set<string>();
 
     /**
@@ -57,6 +59,7 @@ export async function assembleAgentTools(params: {
         const before = tools.length;
         const next = await applySkillCatalog(tools, mcpTools, {
             ...(injectedSkillIds ? { excludeIds: injectedSkillIds } : {}),
+            ...(userId ? { userId } : {}),
         });
         const added = next.some((t) => t.function.name === LOAD_SKILL_TOOL_NAME)
             && !tools.some((t) => t.function.name === LOAD_SKILL_TOOL_NAME);

--- a/apps/api/src/services/skill-catalog-tool.ts
+++ b/apps/api/src/services/skill-catalog-tool.ts
@@ -26,6 +26,8 @@ export interface SkillCatalogOptions {
      * 채팅은 활성 바인딩, 에이전트 작업은 매니페스트 주입분이 해당.
      */
     excludeIds?: ReadonlySet<string>;
+    /** 본인 소유 비공개 스킬(확장 설치분 등)을 카탈로그에 포함하기 위한 사용자 id. */
+    userId?: string;
 }
 
 /**
@@ -50,9 +52,10 @@ export async function applySkillCatalog(
     if (!base) return without; // load_skill 미등록 — 노출 안 함
 
     try {
-        const { catalog, count } = await getSkillManager().buildSkillCatalog(
-            opts.excludeIds ? { excludeIds: opts.excludeIds } : {},
-        );
+        const { catalog, count } = await getSkillManager().buildSkillCatalog({
+            ...(opts.excludeIds ? { excludeIds: opts.excludeIds } : {}),
+            ...(opts.userId ? { userId: opts.userId } : {}),
+        });
         if (count === 0) return without;
 
         const augmented: ToolDefinition = {


### PR DESCRIPTION
## 문제

확장(extension) 설치로 들어온 스킬은 전부 `is_public=false` + `category='general'` 로 생성되는데, 채팅의 세 노출 경로가 모두 이를 놓쳐 **승인해도 채팅에서 쓸 방법이 사실상 없었다** (2026-08-16 chat.openmake.cc 라이브 실측 — 공개 스킬 `/seo` 대조군은 주입되고 확장 스킬 `/design-critique` 는 일반 텍스트 처리).

## 수정 4건

1. **슬래시 명령** (`chat/slash-command.ts`): `defaultFindSkillBySlug` 가 받은 `userId` 를 `searchSkills` 에 전달하지 않아 `is_public=TRUE` 폴백으로 비공개 스킬 매칭 불가 → userId 전달. 하이픈 이름(확장 스킬)은 공백 복원 검색이 name ILIKE 를 놓치므로 원 slug 재검색 추가.
2. **load_skill 카탈로그** (`skill-manager.ts`·`skill-catalog-tool.ts`): `buildSkillCatalog`·`buildSkillPromptForNames` 동일 원인으로 public 전용 → userId 전파. 채팅(`ChatService`)·에이전트 작업(`tool-assembly`+`AgentTaskService`) 양 경로 배선 (외부 분기 대칭). 권한 규칙은 기존 public-or-own 그대로.
3. **user-assign 카테고리 필터** (`skill-assignment-repository.ts`): 에이전트 턴에서 `s.category = agentCategory` 정확 일치만 통과 → `'general'` 도 통과. 지정은 명시적 opt-in 이고 LIMIT 15 캡 유지.
4. **manifest 경로 함정** (`skill-manager.ts` `buildManifestPrompt`): 시스템 프롬프트 주입은 manifest 경로 우선, legacy 는 manifest null 일 때만 fallback — 확장 스킬은 `skill_manifests` 행이 없어 manifest 스킬이 하나라도 활성이면 지정해도 조용히 누락. manifest 결과에 **manifest 미보유 개인 지정(user:{userId}) 스킬 union** (전체 15개 상한 유지, agent/global 스킬은 기존대로 manifest 지배).

## 검증

- 유닛: 전체 2645 passed (회귀 테스트 9개 추가 — userId 전파 2, 슬래시 재검색 1, SQL 카테고리 2, manifest union 4)
- 라이브 (chat.openmake.cc, user 3, saveHistory:false):
  - `/design-critique` → `슬래시 명령 적용` 로그 + SKILL.md 전문 skill_context 주입
  - load_skill 지목 호출 → `load_skill: detecting-data-anomalies (user=3)` 로드 성공
  - user-assign 후 에이전트 턴 → `skills_activated` 에 design-critique 포함
- `npm run lint` 0 errors / tsc 0

## 체크리스트

- [x] lint 통과
- [x] npm test 통과 (2645 passed)
- [ ] 라우팅/응답 변경 아님 (도구 카탈로그·프롬프트 주입 범위만)
- [x] DB 스키마 변경 없음
- [x] 환경변수 추가 없음
- [x] UI 변경 없음
- [x] 보안 영향: 비공개 스킬 노출 범위 확대 없음 — 모든 경로가 기존 public-or-own 권한 규칙 유지, 본인 소유 스킬만 본인에게 추가 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)