### PR TITLE
feat(skills): git-ingest 시 skill_manifests 동시 생성 — manifest 경로 근본 개선

### DIFF
--- a/apps/api/src/agents/__tests__/skill-manifest-union.test.ts
+++ b/apps/api/src/agents/__tests__/skill-manifest-union.test.ts
@@ -14,9 +14,12 @@ const MANIFEST_ROWS = [{
     manifest_yaml: '---\nname: presentation-designer\ncategory: design\n---',
 }];
 
+const capturedSql: string[] = [];
 jest.mock('../../data/models/unified-database', () => ({
     getUnifiedDatabase: () => ({
-        getPool: () => ({ query: async () => ({ rows: MANIFEST_ROWS }) }),
+        getPool: () => ({
+            query: async (sql: string) => { capturedSql.push(sql); return { rows: MANIFEST_ROWS }; },
+        }),
     }),
 }));
 
@@ -72,5 +75,12 @@ describe('buildManifestPrompt — 개인 지정 스킬 union', () => {
         ]);
         const out = await mgr.buildManifestPrompt('ui-ux-designer', undefined, 'design');
         expect(out!.skillNames).toEqual(['presentation-designer']);
+    });
+
+    it("manifest 조회는 agent_skills.status='active' 게이트를 포함한다 — draft(승인 전)·archived(확장 제거) 주입 차단", async () => {
+        const mgr = managerWithUserSkills([]);
+        await mgr.buildManifestPrompt('ui-ux-designer', '3', 'design');
+        const manifestSql = capturedSql.find((q) => q.includes('FROM skill_manifests'));
+        expect(manifestSql).toContain("ags.status = 'active'");
     });
 });

--- a/apps/api/src/agents/git-ingest/__tests__/git-ingest-service.test.ts
+++ b/apps/api/src/agents/git-ingest/__tests__/git-ingest-service.test.ts
@@ -123,4 +123,61 @@ This is a test skill body for unit testing.`;
         expect(r.target).toBe('user');
         expect(r.validationWarnings).toContain('ADMIN_REQUIRED');
     });
+
+    it('ingest 시 skill_manifests 행도 함께 생성한다 (2026-08-16 근본 개선)', async () => {
+        mockFetcher.resolveRef.mockResolvedValueOnce('abc123');
+        mockFetcher.listTree.mockResolvedValueOnce({
+            sha: 'abc123',
+            entries: [{ path: 'SKILL.md', sha: 'def456', size: 500, type: 'blob' }],
+            truncated: false, rateLimitRemaining: 4999,
+        });
+        mockFetcher.fetchFile.mockResolvedValueOnce(validSkillMd);
+        (mockLLM.chat as jest.Mock).mockResolvedValueOnce({
+            content: JSON.stringify({ findings: [] }), metrics: { completion_tokens: 10 },
+        });
+        (mockPool.query as jest.Mock)
+            .mockResolvedValueOnce({ rows: [] })                  // dedupe lookup
+            .mockResolvedValueOnce({ rows: [{ count: '0' }] })    // draft count
+            .mockResolvedValueOnce({ rows: [] })                  // agent_skills INSERT
+            .mockResolvedValueOnce({ rows: [] });                 // skill_manifests INSERT
+
+        const svc = makeService();
+        const r = await svc.import({ userId: 'user-1', isAdmin: false, gitUrl: 'foo/bar', target: 'user' });
+        if ('selectionRequired' in r && r.selectionRequired) throw new Error('expected single');
+
+        const manifestCall = (mockPool.query as jest.Mock).mock.calls
+            .find(([sql]) => typeof sql === 'string' && sql.includes('INSERT INTO skill_manifests'));
+        expect(manifestCall).toBeDefined();
+        const [, params] = manifestCall!;
+        expect(params[0]).toBe(r.skillId);            // id = agent_skills 와 동일
+        expect(params[1]).toBe('1.0.0');              // version (frontmatter)
+        expect(params[2]).toContain('name: Legal Skill'); // manifest_yaml = 원본 frontmatter
+        expect(params[3]).toContain('This is a test skill body'); // prompt_md
+        expect(params[5]).toBe('user-1');             // created_by
+        expect(params[6]).toBe(false);                // is_public (user target)
+    });
+
+    it('skill_manifests INSERT 실패는 fail-soft — ingest 결과는 정상 반환', async () => {
+        mockFetcher.resolveRef.mockResolvedValueOnce('abc123');
+        mockFetcher.listTree.mockResolvedValueOnce({
+            sha: 'abc123',
+            entries: [{ path: 'SKILL.md', sha: 'def456', size: 500, type: 'blob' }],
+            truncated: false, rateLimitRemaining: 4999,
+        });
+        mockFetcher.fetchFile.mockResolvedValueOnce(validSkillMd);
+        (mockLLM.chat as jest.Mock).mockResolvedValueOnce({
+            content: JSON.stringify({ findings: [] }), metrics: { completion_tokens: 10 },
+        });
+        (mockPool.query as jest.Mock)
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [{ count: '0' }] })
+            .mockResolvedValueOnce({ rows: [] })
+            .mockRejectedValueOnce(new Error('manifest table down')); // skill_manifests INSERT 실패
+
+        const svc = makeService();
+        const r = await svc.import({ userId: 'user-1', isAdmin: false, gitUrl: 'foo/bar', target: 'user' });
+        if ('selectionRequired' in r && r.selectionRequired) throw new Error('expected single');
+        expect(r.skillId).toMatch(/^user-skill-/);
+        expect(r.status).toBe('draft');
+    });
 });

--- a/apps/api/src/agents/git-ingest/git-ingest-service.ts
+++ b/apps/api/src/agents/git-ingest/git-ingest-service.ts
@@ -184,6 +184,32 @@ export class GitIngestService {
                 JSON.stringify(manifestMeta),
             ]
         );
+
+        // (10) skill_manifests 동시 생성 — 시스템 프롬프트 주입의 SoT 는
+        // buildManifestPrompt(skill_manifests JOIN)라, agent_skills 만 만들면 manifest
+        // 스킬이 하나라도 활성일 때 legacy fallback 이 실행되지 않아 지정해도 조용히
+        // 누락된다(2026-08-16 라이브 실측). buildManifestPrompt 의 status='active' 게이트가
+        // draft 주입을 막으므로 승인 전 노출은 없다. 실패는 fail-soft — ingest 는 유지되고
+        // 개인 지정 union(스킬매니저)이 안전망으로 커버한다.
+        try {
+            await this.opts.pool.query(
+                `INSERT INTO skill_manifests
+                   (id, version, manifest_yaml, prompt_md, checksum, signature, created_by, is_public, created_at)
+                 VALUES ($1, $2, $3, $4, $5, NULL, $6, $7, NOW())
+                 ON CONFLICT (id, version) DO NOTHING`,
+                [
+                    skillId,
+                    validation.manifest.version,
+                    validation.raw_yaml,
+                    validation.prompt_md,
+                    validation.checksum,
+                    effectiveTarget === 'system' ? null : input.userId,
+                    effectiveTarget === 'system',
+                ]
+            );
+        } catch (e) {
+            logger.warn(`skill_manifests 생성 실패 (fail-soft, union 안전망 커버): ${skillId}`, e);
+        }
         logger.info(`git-ingest created: ${skillId} (${owner}/${repo}@${sha.slice(0, 7)}:${candidate.path})`);
 
         return {

--- a/apps/api/src/agents/skill-manager.ts
+++ b/apps/api/src/agents/skill-manager.ts
@@ -440,10 +440,15 @@ export class SkillManager {
             params.push(`user:${userId}`);
         }
 
+        // agent_skills.status='active' 게이트 — git-ingest 가 draft 시점에 manifest 를 함께
+        // 만들므로(2026-08-16 근본 개선) 승인 전 draft·확장 제거/업데이트로 archived 된
+        // 스킬의 잔존 manifest 가 주입되지 않게 막는다. 할당된 manifest 는 전부
+        // agent_skills 행을 가진다(ManifestImporter placeholder·git-ingest 동시 INSERT).
         const sql = `
             SELECT sm.id, sm.prompt_md, sm.manifest_yaml
             FROM skill_manifests sm
             INNER JOIN agent_skill_assignments asa ON asa.skill_id = sm.id
+            INNER JOIN agent_skills ags ON ags.id = sm.id AND ags.status = 'active'
             WHERE (asa.agent_id = $1 OR asa.agent_id = $2${userClause})
               AND sm.version = (
                   SELECT MAX(version) FROM skill_manifests WHERE id = sm.id
@@ -475,9 +480,11 @@ export class SkillManager {
             const safeId = r.id.replace(/[<>"&]/g, '');
             return `<skill_context name="${safeId}">\n${r.prompt_md}\n</skill_context>`;
         });
-        // 표시용 이름 — manifest_yaml 의 name 을 쓰고, 없으면 id 로 대체(category 추출과 같은 방식).
+        // 표시용 이름 — manifest_yaml 의 name 을 쓰고, 없으면 id 로 대체.
+        // 저장된 manifest_yaml 은 fence('---') 없는 순수 yaml 이라 '^---' 전제 정규식은
+        // 항상 실패해 uuid id 가 그대로 표시되던 결함 수정 — 최상위 name: 키를 multiline 매칭.
         const skillNames = filtered.map(r => {
-            const m = /^---[\s\S]*?\bname:\s*([^\n]+)/.exec(r.manifest_yaml);
+            const m = /^name:\s*([^\n]+)/m.exec(r.manifest_yaml);
             return m?.[1]?.trim().replace(/^['"]|['"]$/g, '') || r.id;
         });
 


### PR DESCRIPTION
## 배경

#510 은 확장 설치 스킬(agent_skills 전용)이 manifest 주입 경로에서 누락되는 것을 **읽기 측 union 안전망**으로 해소했다. 이 PR 은 쓰기 측 근본 개선 — git-ingest 가 스킬 생성 시 `skill_manifests` 를 함께 만들어 신규 설치부터 manifest 경로 네이티브로 동작하게 한다.

## 변경 3건

1. **설치 시 manifest 동시 생성** (`git-ingest-service.ts`): SKILL.md 검증 산출물(원본 frontmatter `raw_yaml`·본문 `prompt_md`·checksum)을 `skill_manifests` 에 INSERT (id=스킬 id, version=frontmatter semver, 기본 1.0.0, `ON CONFLICT DO NOTHING`). 실패는 fail-soft — ingest 유지, #510 union 이 안전망. 단일 스킬 import·확장 번들 공통 경로라 양쪽 모두 적용.
2. **`buildManifestPrompt` 에 `agent_skills.status='active'` 게이트** (`skill-manager.ts`): draft 시점에 manifest 가 생기므로 승인 전 주입 차단(승인 게이트 유지의 필수 조건) + 확장 제거/업데이트로 archived 된 스킬의 잔존 manifest 주입 차단. 운영 DB 사전 검증: 할당된 manifest 중 비-active 스킬 0건, agent_skills 행 없는 manifest 2건은 무할당 테스트 잔재 — **기존 주입 손실 0**.
3. **표시명 추출 정규식 수정**: 저장된 `manifest_yaml` 은 fence(`---`) 없는 순수 yaml 이라 `^---` 전제 정규식이 항상 실패 → `skills_activated` 에 uuid id 가 노출되던 기존 결함(라이브 검증 중 발견). 최상위 `name:` 키 multiline 매칭으로 수정. (category 필터 정규식은 동작 변경 위험이 있어 미변경 — 현행 유지)

## 검증

- 라이브 (chat.openmake.cc, user 3): `ticket-triage` 신규 ingest → manifest 행 생성(draft·v1.0.0·원본 frontmatter) → draft 지정 시도 409 `SKILL_NOT_ACTIVE`(1차 게이트) → 승인·지정 후 manifest 경로 주입 + 표시명 정상(`skills_activated: ["presentation-designer", ..., "ticket-triage"]`). 테스트 스킬은 정리 완료.
- 유닛: 전체 2648 passed — 신규 3개 (manifest INSERT 파라미터, fail-soft, status 게이트 SQL) + 표시명 회귀는 기존 union 테스트가 커버
- 기존 10개 확장 스킬: backfill 없이 #510 union 안전망으로 커버 (yaml 재구성 위험 회피)

## 체크리스트

- [x] lint 통과
- [x] npm test 통과 (2648 passed)
- [x] DB 스키마 변경 없음 (기존 skill_manifests 테이블 사용)
- [x] 환경변수 추가 없음
- [x] UI 변경 없음 (skills_activated 표시명 정상화만)
- [x] 보안 영향: draft/archived manifest 주입 차단으로 노출 범위 축소 방향, 신규 노출 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)