### PR TITLE
feat(auth): iOS 축 2 — 모바일 인증 (refresh body 모드·OAuth exchange code)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -756,6 +756,14 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # OAUTH_STATE_CLEANUP_INTERVAL_MS=60000
 
 # *******************************************************
+# 모바일 인증 (iOS) — OAuth exchange code 흐름 (config/security.ts MOBILE_AUTH)
+# *******************************************************
+# iOS 앱 URL scheme (기본 openmake — Xcode URL Types 와 일치 필요)
+# MOBILE_APP_SCHEME=openmake
+# exchange code 만료 (ms, 기본 60초=60000)
+# MOBILE_EXCHANGE_CODE_TTL_MS=60000
+
+# *******************************************************
 # 채팅 일일 한도 / rate limit 캐시 — middlewares/chat-rate-limiter
 # *******************************************************
 # 등급/역할별 일일 채팅 한도 (admin·enterprise 는 무제한 고정)

--- a/apps/api/src/__tests__/contracts/mobile-auth-contract.test.ts
+++ b/apps/api/src/__tests__/contracts/mobile-auth-contract.test.ts
@@ -1,0 +1,254 @@
+/**
+ * 모바일 인증 (iOS 축 2) — 동작 + 응답 계약 테스트.
+ *
+ * 무DB — pg 는 throw mock (OAuth state 는 인메모리 폴백 경로), exchange code 는
+ * 실제 MemoryStore(KVStore) 로 일회성 시맨틱을 검증한다. validation 은 real(zod 400 검증).
+ */
+import express, { type Request, type Response, type NextFunction } from 'express';
+import request from 'supertest';
+import cookieParser from 'cookie-parser';
+import type { PublicUser } from '../../data/user-manager';
+import { expectContract } from './contract-validator';
+
+const sampleUser: PublicUser = {
+    id: 'u1',
+    email: 'riskpw@gmail.com',
+    role: 'user',
+    created_at: '2026-08-16T00:00:00.000Z',
+    is_active: true,
+};
+
+const cookieSpies = {
+    setTokenCookie: jest.fn(),
+    setRefreshTokenCookie: jest.fn(),
+};
+
+jest.mock('../../auth', () => ({
+    requireAuth: (req: Request, _res: Response, next: NextFunction) => {
+        req.user = sampleUser;
+        next();
+    },
+    optionalAuth: (_req: Request, _res: Response, next: NextFunction) => next(),
+    extractToken: () => null,
+    blacklistToken: jest.fn(),
+    setTokenCookie: (...args: unknown[]) => cookieSpies.setTokenCookie(...args),
+    clearTokenCookie: jest.fn(),
+    setRefreshTokenCookie: (...args: unknown[]) => cookieSpies.setRefreshTokenCookie(...args),
+    generateRefreshToken: () => 'new-refresh-token',
+    generateToken: () => 'new-access-token',
+    verifyRefreshToken: jest.fn(),
+    removeSessionFromMap: jest.fn(),
+}));
+
+const mockAuthService = {
+    login: jest.fn(),
+    getAvailableProviders: () => ['google'],
+};
+jest.mock('../../services/AuthService', () => ({
+    getAuthService: () => mockAuthService,
+}));
+
+const mockUserManager = { getUserById: jest.fn() };
+jest.mock('../../data/user-manager', () => ({
+    getUserManager: () => mockUserManager,
+}));
+
+jest.mock('../../services/AuditService', () => ({
+    getAuditService: () => ({ logAudit: jest.fn().mockResolvedValue(undefined) }),
+}));
+
+// 무DB — helpers 의 oauth_states 접근은 전부 인메모리 폴백으로 유도
+jest.mock('../../data/models/unified-database', () => ({
+    getPool: () => {
+        throw new Error('no db in test');
+    },
+}));
+
+jest.mock('../../middlewares/rate-limiters', () => ({
+    authLimiter: (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+jest.mock('../../mcp/lifecycle-hooks', () => ({
+    emitUserLogout: jest.fn(),
+}));
+
+const testConfig = {
+    port: 0,
+    cookieSecure: false,
+    csrfProtection: 'off',
+    storageBackend: 'memory',
+    googleClientId: 'gid',
+    googleClientSecret: 'gsecret',
+    oauthRedirectUri: '',
+};
+jest.mock('../../config/env', () => ({ getConfig: () => testConfig }));
+jest.mock('../../config', () => ({ getConfig: () => testConfig }));
+
+import { createAuthController } from '../../controllers/auth.controller';
+import {
+    generateSecureState,
+    validateAndConsumeState,
+    issueMobileExchangeRedirect,
+} from '../../controllers/auth-oauth-helpers';
+import { verifyRefreshToken, blacklistToken } from '../../auth';
+
+describe('모바일 인증 (iOS 축 2)', () => {
+    let app: express.Express;
+
+    beforeAll(() => {
+        app = express();
+        app.use(cookieParser());
+        app.use(express.json());
+        app.use('/api/auth', createAuthController(0));
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (verifyRefreshToken as jest.Mock).mockResolvedValue({ userId: 'u1' });
+        mockUserManager.getUserById.mockResolvedValue(sampleUser);
+    });
+
+    describe('refresh body 모드', () => {
+        test('body.refreshToken → 새 refreshToken body 반환 + 쿠키 미설정', async () => {
+            const r = await request(app).post('/api/auth/refresh').send({ refreshToken: 'mobile-rt' });
+            expect(r.status).toBe(200);
+            expect(r.body.data.refreshToken).toBe('new-refresh-token');
+            expect(r.headers['set-cookie']).toBeUndefined();
+            expect(cookieSpies.setTokenCookie).not.toHaveBeenCalled();
+            expect(cookieSpies.setRefreshTokenCookie).not.toHaveBeenCalled();
+            expect(blacklistToken).toHaveBeenCalledWith('mobile-rt'); // rotation
+            expectContract('/api/auth/refresh', 'post', '200', r.body);
+        });
+
+        test('쿠키 모드 기존 동작 무변경 — body 에 refreshToken 없음 + 쿠키 회전', async () => {
+            const r = await request(app).post('/api/auth/refresh').set('Cookie', ['refresh_token=web-rt']);
+            expect(r.status).toBe(200);
+            expect(r.body.data.refreshToken).toBeUndefined();
+            expect(cookieSpies.setTokenCookie).toHaveBeenCalled();
+            expect(cookieSpies.setRefreshTokenCookie).toHaveBeenCalled();
+            expectContract('/api/auth/refresh', 'post', '200', r.body);
+        });
+
+        test('무효 refresh token → 401', async () => {
+            (verifyRefreshToken as jest.Mock).mockResolvedValue(null);
+            const r = await request(app).post('/api/auth/refresh').send({ refreshToken: 'bad' });
+            expect(r.status).toBe(401);
+            expectContract('/api/auth/refresh', 'post', '401', r.body);
+        });
+    });
+
+    describe('login returnRefreshToken', () => {
+        test('true → refreshToken body 포함 + 쿠키 미설정', async () => {
+            mockAuthService.login.mockResolvedValue({ success: true, token: 'at', user: sampleUser });
+            const r = await request(app)
+                .post('/api/auth/login')
+                .send({ email: 'riskpw@gmail.com', password: 'pw', returnRefreshToken: true });
+            expect(r.status).toBe(200);
+            expect(r.body.data.refreshToken).toBe('new-refresh-token');
+            expect(cookieSpies.setTokenCookie).not.toHaveBeenCalled();
+            expect(cookieSpies.setRefreshTokenCookie).not.toHaveBeenCalled();
+            expectContract('/api/auth/login', 'post', '200', r.body);
+        });
+
+        test('미지정 → 기존 쿠키 동작 무변경', async () => {
+            mockAuthService.login.mockResolvedValue({ success: true, token: 'at', user: sampleUser });
+            const r = await request(app)
+                .post('/api/auth/login')
+                .send({ email: 'riskpw@gmail.com', password: 'pw' });
+            expect(r.status).toBe(200);
+            expect(r.body.data.refreshToken).toBeUndefined();
+            expect(cookieSpies.setTokenCookie).toHaveBeenCalled();
+            expect(cookieSpies.setRefreshTokenCookie).toHaveBeenCalled();
+        });
+    });
+
+    describe('logout body refreshToken', () => {
+        test('body.refreshToken 블랙리스트 처리', async () => {
+            const r = await request(app).post('/api/auth/logout').send({ refreshToken: 'mobile-rt' });
+            expect(r.status).toBe(200);
+            expect(blacklistToken).toHaveBeenCalledWith('mobile-rt');
+        });
+    });
+
+    describe('OAuth state client 귀속 (인메모리 폴백 경로)', () => {
+        test('client=ios 저장 → 소비 시 client 반환 + 일회성', async () => {
+            const state = await generateSecureState('google', 'ios');
+            const first = await validateAndConsumeState(state, 'google');
+            expect(first).toEqual({ valid: true, client: 'ios' });
+            // 재사용 불가
+            const second = await validateAndConsumeState(state, 'google');
+            expect(second.valid).toBe(false);
+        });
+
+        test('client 미지정 = 웹 (null)', async () => {
+            const state = await generateSecureState('google');
+            expect(await validateAndConsumeState(state, 'google')).toEqual({ valid: true, client: null });
+        });
+    });
+
+    describe('mobile exchange', () => {
+        /** issueMobileExchangeRedirect 로 실제 발급된 code 를 캡처 */
+        async function issueCode(): Promise<string> {
+            const redirect = jest.fn();
+            await issueMobileExchangeRedirect(
+                { redirect } as unknown as Response, 'u1', 'google');
+            const target: string = redirect.mock.calls[0][0];
+            expect(target).toMatch(/^openmake:\/\/auth\/callback\?code=[0-9a-f]{64}$/);
+            return target.split('code=')[1];
+        }
+
+        test('정상 교환 → 토큰 3종 body 반환, 쿠키 미설정', async () => {
+            const code = await issueCode();
+            const r = await request(app).post('/api/auth/mobile/exchange').send({ code });
+            expect(r.status).toBe(200);
+            expect(r.body.data.token).toBe('new-access-token');
+            expect(r.body.data.refreshToken).toBe('new-refresh-token');
+            expect(r.body.data.user.id).toBe('u1');
+            expect(r.headers['set-cookie']).toBeUndefined();
+            expectContract('/api/auth/mobile/exchange', 'post', '200', r.body);
+        });
+
+        test('코드 재사용 → 401 (일회성)', async () => {
+            const code = await issueCode();
+            await request(app).post('/api/auth/mobile/exchange').send({ code });
+            const r = await request(app).post('/api/auth/mobile/exchange').send({ code });
+            expect(r.status).toBe(401);
+            expectContract('/api/auth/mobile/exchange', 'post', '401', r.body);
+        });
+
+        test('존재하지 않는 코드 → 401', async () => {
+            const r = await request(app)
+                .post('/api/auth/mobile/exchange')
+                .send({ code: 'f'.repeat(64) });
+            expect(r.status).toBe(401);
+            expectContract('/api/auth/mobile/exchange', 'post', '401', r.body);
+        });
+
+        test('형식 오류 코드 → 400 (zod)', async () => {
+            const r = await request(app).post('/api/auth/mobile/exchange').send({ code: 'short' });
+            expect(r.status).toBe(400);
+            expectContract('/api/auth/mobile/exchange', 'post', '400', r.body);
+        });
+
+        test('TTL 만료 코드 → 401', async () => {
+            const { getKeyValueStore } = await import('../../storage');
+            const { MOBILE_AUTH } = await import('../../config/security');
+            const code = 'a'.repeat(64);
+            await getKeyValueStore().set(
+                MOBILE_AUTH.EXCHANGE_KEY_PREFIX + code,
+                { userId: 'u1', provider: 'google' },
+                10, // 10ms 만료
+            );
+            await new Promise((resolve) => setTimeout(resolve, 30));
+            const r = await request(app).post('/api/auth/mobile/exchange').send({ code });
+            expect(r.status).toBe(401);
+        });
+
+        test('비활성 사용자 → 401', async () => {
+            mockUserManager.getUserById.mockResolvedValue({ ...sampleUser, is_active: false });
+            const code = await issueCode();
+            const r = await request(app).post('/api/auth/mobile/exchange').send({ code });
+            expect(r.status).toBe(401);
+        });
+    });
+});

--- a/apps/api/src/config/security.ts
+++ b/apps/api/src/config/security.ts
@@ -162,3 +162,26 @@ export const AUTH_COOKIES = {
     /** 리프레시 토큰 (HttpOnly, path=/api/auth/refresh) */
     REFRESH: AUTH.REFRESH_COOKIE_NAME,
 } as const;
+
+/**
+ * 모바일 인증 (iOS 축 2) — OAuth exchange code 흐름.
+ *
+ * ASWebAuthenticationSession 은 앱 URLSession 과 쿠키 저장소가 분리되어 쿠키로는
+ * 토큰이 앱에 도달하지 못한다. 콜백에서 단명 일회성 코드를 app scheme 으로 전달하고
+ * `POST /api/auth/mobile/exchange` 에서 토큰으로 교환한다. app scheme URL 은 로그·타 앱
+ * 가로채기에 노출될 수 있어 refresh token 을 직접 싣지 않는다.
+ */
+export const MOBILE_AUTH = {
+    /** 앱 URL scheme — iOS Xcode URL Types 와 동일해야 함 */
+    APP_SCHEME: process.env.MOBILE_APP_SCHEME || 'openmake',
+    /** scheme 뒤 콜백 경로 — `openmake://auth/callback?code=...` */
+    CALLBACK_HOST_PATH: 'auth/callback',
+    /** exchange code 만료 (ms, 기본 60초) */
+    EXCHANGE_CODE_TTL_MS: Number(process.env.MOBILE_EXCHANGE_CODE_TTL_MS) || 60 * 1000,
+    /** KVStore 키 prefix */
+    EXCHANGE_KEY_PREFIX: 'mobile_exchange:',
+    /** code 엔트로피 (bytes → hex 2배 길이) */
+    EXCHANGE_CODE_BYTES: 32,
+    /** 허용 클라이언트 식별자 화이트리스트 (`?client=`) */
+    ALLOWED_CLIENTS: ['ios'],
+} as const;

--- a/apps/api/src/controllers/auth-oauth-helpers.ts
+++ b/apps/api/src/controllers/auth-oauth-helpers.ts
@@ -10,6 +10,7 @@ import { Request, Response } from 'express';
 import * as crypto from 'crypto';
 import { createLogger } from '../utils/logger';
 import { getConfig } from '../config/env';
+import { MOBILE_AUTH } from '../config/security';
 
 const log = createLogger('AuthOAuthHelpers');
 
@@ -20,7 +21,7 @@ const STATE_TTL_MS = Number(process.env.OAUTH_STATE_TTL_MS) || 5 * 60 * 1000; //
 const STATE_CLEANUP_INTERVAL_MS = Number(process.env.OAUTH_STATE_CLEANUP_INTERVAL_MS) || 60 * 1000; // 기본 60초
 
 // 인메모리 폴백: DB 연결 실패 시 임시 사용 (단일 프로세스 한정)
-const oauthStatesFallback = new Map<string, { provider: string; createdAt: number }>();
+const oauthStatesFallback = new Map<string, { provider: string; client: string | null; createdAt: number }>();
 
 /**
  * DB 기반 OAuth state 저장소 헬퍼 (안전 폴백)
@@ -36,9 +37,12 @@ async function ensureOauthStateTable(): Promise<void> {
             CREATE TABLE IF NOT EXISTS oauth_states (
                 state TEXT PRIMARY KEY,
                 provider TEXT NOT NULL,
+                client TEXT,
                 created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
             )
         `);
+        // 구 스키마 폴백 (097 마이그레이션 미적용 부팅 대비 — 멱등)
+        await pool.query('ALTER TABLE oauth_states ADD COLUMN IF NOT EXISTS client TEXT');
     } catch (e) {
         log.warn('[OAuth] oauth_states 테이블 생성 실패 (폴백 사용):', e);
     }
@@ -87,36 +91,46 @@ export function stopOAuthCleanup(): void {
 }
 
 /**
- * 🔒 보안 강화된 OAuth state 생성 (DB 저장)
+ * state 검증 결과 — client 는 OAuth 시작 시 귀속된 모바일 클라이언트 식별자 (null = 웹)
  */
-export async function generateSecureState(provider: string): Promise<string> {
+export interface OAuthStateResult {
+    valid: boolean;
+    client: string | null;
+}
+
+/**
+ * 🔒 보안 강화된 OAuth state 생성 (DB 저장)
+ * @param client 모바일 클라이언트 식별자 ('ios' 등, 화이트리스트 검증은 호출부) — 콜백 분기용
+ */
+export async function generateSecureState(provider: string, client?: string): Promise<string> {
     const state = crypto.randomBytes(32).toString('hex');
     try {
         const { getPool } = await import('../data/models/unified-database');
         const pool = getPool();
         await pool.query(
-            'INSERT INTO oauth_states (state, provider) VALUES ($1, $2)',
-            [state, provider]
+            'INSERT INTO oauth_states (state, provider, client) VALUES ($1, $2, $3)',
+            [state, provider, client ?? null]
         );
     } catch (e) {
         log.warn('[OAuth] DB state 저장 실패, 인메모리 폴백 사용:', e);
-        oauthStatesFallback.set(state, { provider, createdAt: Date.now() });
+        oauthStatesFallback.set(state, { provider, client: client ?? null, createdAt: Date.now() });
     }
     return state;
 }
 
 /**
  * 🔒 OAuth state 검증 및 소비 (일회성, DB 기반)
+ * @returns valid + 시작 시 귀속된 client (웹이면 null)
  */
-export async function validateAndConsumeState(state: string | undefined, expectedProvider: string): Promise<boolean> {
-    if (!state) return false;
+export async function validateAndConsumeState(state: string | undefined, expectedProvider: string): Promise<OAuthStateResult> {
+    if (!state) return { valid: false, client: null };
 
     try {
         const { getPool } = await import('../data/models/unified-database');
         const pool = getPool();
         // 일회성: DELETE ... RETURNING으로 조회 + 삭제 원자적 처리
         const result = await pool.query(
-            'DELETE FROM oauth_states WHERE state = $1 RETURNING provider, created_at',
+            'DELETE FROM oauth_states WHERE state = $1 RETURNING provider, client, created_at',
             [state]
         );
 
@@ -130,16 +144,16 @@ export async function validateAndConsumeState(state: string | undefined, expecte
         // 만료 체크
         if (Date.now() - new Date(row.created_at).getTime() > STATE_TTL_MS) {
             log.error('[OAuth] State expired');
-            return false;
+            return { valid: false, client: null };
         }
 
         // Provider 일치 체크
         if (row.provider !== expectedProvider) {
             log.error(`[OAuth] Provider mismatch: expected ${expectedProvider}, got ${row.provider}`);
-            return false;
+            return { valid: false, client: null };
         }
 
-        return true;
+        return { valid: true, client: row.client ?? null };
     } catch (e) {
         log.warn('[OAuth] DB state 검증 실패, 인메모리 폴백 사용:', e);
         return validateAndConsumeStateFallback(state, expectedProvider);
@@ -149,26 +163,26 @@ export async function validateAndConsumeState(state: string | undefined, expecte
 /**
  * 인메모리 폴백 state 검증 (DB 장애 시)
  */
-function validateAndConsumeStateFallback(state: string, expectedProvider: string): boolean {
+function validateAndConsumeStateFallback(state: string, expectedProvider: string): OAuthStateResult {
     const data = oauthStatesFallback.get(state);
     if (!data) {
         log.error(`[OAuth] State not found: ${state?.substring(0, 10)}...`);
-        return false;
+        return { valid: false, client: null };
     }
 
     oauthStatesFallback.delete(state);
 
     if (Date.now() - data.createdAt > STATE_TTL_MS) {
         log.error('[OAuth] State expired (fallback)');
-        return false;
+        return { valid: false, client: null };
     }
 
     if (data.provider !== expectedProvider) {
         log.error(`[OAuth] Provider mismatch (fallback): expected ${expectedProvider}, got ${data.provider}`);
-        return false;
+        return { valid: false, client: null };
     }
 
-    return true;
+    return { valid: true, client: data.client };
 }
 
 /**
@@ -230,6 +244,40 @@ export function buildRedirectUri(req: Request, provider: 'google' | 'github' | '
  * 게스트로 떨어지던 문제를 우회한다. 200 응답의 Set-Cookie 는 정상 전파됨.
  * path 는 내부 고정 경로만 전달 (open redirect / XSS 불가).
  */
+/**
+ * 모바일(iOS) OAuth 완료 — 일회성 exchange code 를 발급하고 app scheme 으로 리다이렉트.
+ *
+ * app scheme URL 은 로그·타 앱 가로채기에 노출될 수 있으므로 토큰을 직접 싣지 않고
+ * 단명(기본 60s)·일회성 코드만 전달한다. 앱은 `POST /api/auth/mobile/exchange` 로 교환.
+ * (config/security.ts MOBILE_AUTH 참고 — iOS 축 2)
+ */
+export async function issueMobileExchangeRedirect(res: Response, userId: string, provider: string): Promise<void> {
+    const { getKeyValueStore } = await import('../storage');
+    const code = crypto.randomBytes(MOBILE_AUTH.EXCHANGE_CODE_BYTES).toString('hex');
+    await getKeyValueStore().set(
+        MOBILE_AUTH.EXCHANGE_KEY_PREFIX + code,
+        { userId, provider },
+        MOBILE_AUTH.EXCHANGE_CODE_TTL_MS,
+    );
+    const target = `${MOBILE_AUTH.APP_SCHEME}://${MOBILE_AUTH.CALLBACK_HOST_PATH}?code=${code}`;
+    log.info(`[OAuth] 모바일 exchange code 발급 (provider=${provider}, user=${userId})`);
+    res.redirect(target);
+}
+
+/**
+ * exchange code 소비 (일회성) — 유효하면 payload 반환 후 즉시 삭제, 아니면 null.
+ * get→del 이 비원자적이지만 단일 프로세스 운영 + 60s TTL + 암호학적 코드라 위험은 미미.
+ */
+export async function consumeMobileExchangeCode(code: string): Promise<{ userId: string; provider: string } | null> {
+    const { getKeyValueStore } = await import('../storage');
+    const store = getKeyValueStore();
+    const key = MOBILE_AUTH.EXCHANGE_KEY_PREFIX + code;
+    const entry = await store.get<{ userId: string; provider: string }>(key);
+    if (!entry || typeof entry.userId !== 'string') return null;
+    await store.del(key);
+    return entry;
+}
+
 export function sendOAuthSuccessRedirect(res: Response, path: string): void {
     res.status(200).type('html').send(
         '<!DOCTYPE html><html lang="ko"><head><meta charset="utf-8">' +

--- a/apps/api/src/controllers/auth-oauth.controller.ts
+++ b/apps/api/src/controllers/auth-oauth.controller.ts
@@ -11,17 +11,24 @@
 import { Request, Response, Router } from 'express';
 import { getAuthService } from '../services/AuthService';
 import type { OAuthTokenResponse, GoogleUserInfo, GitHubUser, GitHubEmail, KakaoUserInfo } from '../auth/types';
-import { setTokenCookie, setRefreshTokenCookie, generateRefreshToken } from '../auth';
+import { setTokenCookie, setRefreshTokenCookie, generateRefreshToken, generateToken } from '../auth';
+import { getUserManager } from '../data/user-manager';
 import { createLogger } from '../utils/logger';
-import { success, badRequest, serviceUnavailable } from '../utils/api-response';
+import { success, badRequest, unauthorized, serviceUnavailable, internalError } from '../utils/api-response';
 import { getConfig } from '../config/env';
 import { APP_USER_AGENT } from '../config/constants';
+import { MOBILE_AUTH } from '../config/security';
 import { GOOGLE_OAUTH, GITHUB_OAUTH, GITHUB_API, KAKAO_OAUTH } from '../config/external-services';
+import { authLimiter } from '../middlewares/rate-limiters';
+import { validate } from '../middlewares/validation';
+import { mobileExchangeSchema } from '../schemas';
 import {
     generateSecureState,
     validateAndConsumeState,
     buildRedirectUri,
     sendOAuthSuccessRedirect,
+    issueMobileExchangeRedirect,
+    consumeMobileExchangeCode,
 } from './auth-oauth-helpers';
 
 // server.ts 종료 훅이 참조하는 정리 함수 (auth.controller.ts 경유 re-export 체인 유지)
@@ -63,6 +70,73 @@ export class AuthOAuthController {
         this.router.get('/callback/google', this.googleCallback.bind(this));
         this.router.get('/callback/github', this.githubCallback.bind(this));
         this.router.get('/callback/kakao', this.kakaoCallback.bind(this));
+        // 모바일(iOS) 전용: OAuth exchange code → 토큰 교환 (사전 인증 POST — CSRF 부트스트랩 대상)
+        this.router.post('/mobile/exchange', authLimiter, validate(mobileExchangeSchema), this.mobileExchange.bind(this));
+    }
+
+    /**
+     * `?client=` 화이트리스트 해석 — 허용 목록 외 값은 웹으로 취급 (undefined)
+     */
+    private resolveMobileClient(req: Request): string | undefined {
+        const client = req.query.client;
+        return typeof client === 'string' && (MOBILE_AUTH.ALLOWED_CLIENTS as readonly string[]).includes(client)
+            ? client
+            : undefined;
+    }
+
+    /**
+     * POST /api/auth/mobile/exchange - exchange code → 토큰 교환 (iOS 축 2)
+     *
+     * OAuth 콜백이 발급한 일회성 코드(60s TTL)를 access/refresh token 으로 교환한다.
+     * 응답은 body 전용 — 쿠키 미설정 (앱은 Keychain 에 저장).
+     */
+    private async mobileExchange(req: Request, res: Response): Promise<void> {
+        const { code } = req.body as { code: string };
+        try {
+            const entry = await consumeMobileExchangeCode(code);
+            if (!entry) {
+                this.auditMobileExchange(req, false, undefined, 'invalid_or_expired_code');
+                res.status(401).json(unauthorized('유효하지 않거나 만료된 코드입니다'));
+                return;
+            }
+
+            const user = await getUserManager().getUserById(entry.userId);
+            if (!user || !user.is_active) {
+                this.auditMobileExchange(req, false, entry.userId, 'user_not_found_or_inactive');
+                res.status(401).json(unauthorized('사용자를 찾을 수 없습니다'));
+                return;
+            }
+
+            const token = generateToken(user);
+            const refreshToken = generateRefreshToken(user);
+            this.auditMobileExchange(req, true, user.id, entry.provider);
+            log.info(`[OAuth] 모바일 exchange 성공: ${user.email} (${entry.provider})`);
+            res.json(success({ token, refreshToken, user }));
+        } catch (error) {
+            log.error('[OAuth] 모바일 exchange 오류:', error);
+            res.status(500).json(internalError('토큰 교환 중 오류가 발생했습니다'));
+        }
+    }
+
+    /**
+     * mobile exchange 감사 로그 (login.failed 패턴과 대칭 — fire-and-forget)
+     */
+    private auditMobileExchange(req: Request, ok: boolean, userId: string | undefined, detail: string): void {
+        void (async () => {
+            try {
+                const { getAuditService } = await import('../services/AuditService');
+                await getAuditService().logAudit({
+                    action: ok ? 'auth.mobile_exchange' : 'auth.mobile_exchange_failed',
+                    userId,
+                    resourceType: 'auth',
+                    details: { detail },
+                    ipAddress: req.ip,
+                    userAgent: req.headers['user-agent'],
+                });
+            } catch (e) {
+                log.warn('[audit] mobile_exchange 기록 실패:', e);
+            }
+        })();
     }
 
     /**
@@ -85,8 +159,8 @@ export class AuthOAuthController {
             return;
         }
 
-        // 🔒 Phase 2 보안 패치: 암호학적으로 안전한 state 생성
-        const state = await generateSecureState('google');
+        // 🔒 Phase 2 보안 패치: 암호학적으로 안전한 state 생성 (?client=ios 는 state 에 귀속 — 콜백 분기용)
+        const state = await generateSecureState('google', this.resolveMobileClient(req));
         const authUrl = new URL(GOOGLE_OAUTH.AUTH_URL);
         authUrl.searchParams.set('client_id', clientId);
         authUrl.searchParams.set('redirect_uri', redirectUri);
@@ -112,8 +186,8 @@ export class AuthOAuthController {
             return;
         }
 
-        // 🔒 Phase 2 보안 패치: 암호학적으로 안전한 state 생성
-        const state = await generateSecureState('github');
+        // 🔒 Phase 2 보안 패치: 암호학적으로 안전한 state 생성 (?client=ios 는 state 에 귀속 — 콜백 분기용)
+        const state = await generateSecureState('github', this.resolveMobileClient(req));
         const authUrl = new URL(GITHUB_OAUTH.AUTH_URL);
         authUrl.searchParams.set('client_id', clientId);
         authUrl.searchParams.set('redirect_uri', redirectUri);
@@ -142,7 +216,8 @@ export class AuthOAuthController {
         }
 
         // 🔒 Phase 2 CSRF 방어: state 검증 (Phase 3: DB 기반 비동기)
-        if (!await validateAndConsumeState(state, 'google')) {
+        const stateResult = await validateAndConsumeState(state, 'google');
+        if (!stateResult.valid) {
             log.error('[OAuth] Google callback: Invalid or expired state');
             res.redirect('/login?error=invalid_state');
             return;
@@ -191,6 +266,11 @@ export class AuthOAuthController {
 
             if (!result.success || !result.token || !result.user) throw new Error(result.error || '인증 실패');
 
+            if (stateResult.client) {
+                // 모바일: 쿠키 대신 일회성 exchange code 를 app scheme 으로 전달 (iOS 축 2)
+                await issueMobileExchangeRedirect(res, String(result.user.id), 'google');
+                return;
+            }
             setTokenCookie(res, result.token);
             setRefreshTokenCookie(res, generateRefreshToken(result.user));
             sendOAuthSuccessRedirect(res, '/?auth=callback');
@@ -218,7 +298,8 @@ export class AuthOAuthController {
         }
 
         // 🔒 Phase 2 CSRF 방어: state 검증 (Phase 3: DB 기반 비동기)
-        if (!await validateAndConsumeState(state, 'github')) {
+        const stateResult = await validateAndConsumeState(state, 'github');
+        if (!stateResult.valid) {
             log.error('[OAuth] GitHub callback: Invalid or expired state');
             res.redirect('/login?error=invalid_state');
             return;
@@ -288,6 +369,11 @@ export class AuthOAuthController {
 
             if (!result.success || !result.token || !result.user) throw new Error(result.error || '인증 실패');
 
+            if (stateResult.client) {
+                // 모바일: 쿠키 대신 일회성 exchange code 를 app scheme 으로 전달 (iOS 축 2)
+                await issueMobileExchangeRedirect(res, String(result.user.id), 'github');
+                return;
+            }
             setTokenCookie(res, result.token);
             setRefreshTokenCookie(res, generateRefreshToken(result.user));
             sendOAuthSuccessRedirect(res, '/?auth=callback');
@@ -309,8 +395,8 @@ export class AuthOAuthController {
             return;
         }
 
-        // 🔒 암호학적으로 안전한 state 생성 (CSRF 방어)
-        const state = await generateSecureState('kakao');
+        // 🔒 암호학적으로 안전한 state 생성 (CSRF 방어, ?client=ios 는 state 에 귀속 — 콜백 분기용)
+        const state = await generateSecureState('kakao', this.resolveMobileClient(req));
         const authUrl = new URL(KAKAO_OAUTH.AUTH_URL);
         authUrl.searchParams.set('client_id', clientId);
         authUrl.searchParams.set('redirect_uri', redirectUri);
@@ -342,7 +428,8 @@ export class AuthOAuthController {
         }
 
         // 🔒 CSRF 방어: state 검증 (일회성, DB 기반)
-        if (!await validateAndConsumeState(state, 'kakao')) {
+        const stateResult = await validateAndConsumeState(state, 'kakao');
+        if (!stateResult.valid) {
             log.error('[OAuth] Kakao callback: Invalid or expired state');
             res.redirect('/login?error=invalid_state');
             return;
@@ -401,6 +488,11 @@ export class AuthOAuthController {
 
             if (!result.success || !result.token || !result.user) throw new Error(result.error || '인증 실패');
 
+            if (stateResult.client) {
+                // 모바일: 쿠키 대신 일회성 exchange code 를 app scheme 으로 전달 (iOS 축 2)
+                await issueMobileExchangeRedirect(res, String(result.user.id), 'kakao');
+                return;
+            }
             setTokenCookie(res, result.token);
             setRefreshTokenCookie(res, generateRefreshToken(result.user));
             sendOAuthSuccessRedirect(res, '/?auth=callback');

--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -147,6 +147,12 @@ export class AuthController {
                 return;
             }
 
+            // 모바일(iOS) 신호: returnRefreshToken=true 면 쿠키 미설정, refresh token 을 body 로 반환 (축 2)
+            const mobileMode = req.body?.returnRefreshToken === true;
+            if (result.token && result.user && mobileMode) {
+                res.json(success({ ...result, refreshToken: generateRefreshToken(result.user) }));
+                return;
+            }
             if (result.token) {
                 setTokenCookie(res, result.token);
                 if (result.user) {
@@ -179,8 +185,10 @@ export class AuthController {
             blacklistToken(cookieToken);
         }
         // Refresh 토큰: 블랙리스트 + activeSessionMap 정리 (bug_004)
-        const refreshToken = req.cookies?.refresh_token;
-        if (refreshToken) {
+        // 모바일(iOS)은 쿠키가 없어 body.refreshToken 으로 전달 (축 2) — 웹 쿠키와 병존, 둘 다 폐기
+        const bodyRefreshToken = typeof req.body?.refreshToken === 'string' ? req.body.refreshToken : undefined;
+        for (const refreshToken of new Set([req.cookies?.refresh_token, bodyRefreshToken])) {
+            if (!refreshToken) continue;
             const decoded = jwt.decode(refreshToken) as { userId?: string | number; jti?: string } | null;
             if (decoded?.userId && decoded.jti) {
                 removeSessionFromMap(String(decoded.userId), decoded.jti);
@@ -281,7 +289,11 @@ export class AuthController {
      * 리프레시 토큰 로테이션: 사용된 리프레시 토큰은 블랙리스트 처리
      */
     private async refresh(req: Request, res: Response): Promise<void> {
-        const refreshToken = req.cookies?.refresh_token;
+        // 모바일(iOS) 모드: body.refreshToken 존재 자체가 신호 (축 2) — 쿠키 미설정,
+        // 새 refresh token 을 body 로 반환 (앱은 Keychain 저장). 웹 쿠키 흐름과 병존.
+        const bodyRefreshToken = typeof req.body?.refreshToken === 'string' ? req.body.refreshToken : undefined;
+        const mobileMode = !!bodyRefreshToken;
+        const refreshToken = bodyRefreshToken ?? req.cookies?.refresh_token;
 
         if (!refreshToken) {
             res.status(401).json(unauthorized('리프레시 토큰이 없습니다'));
@@ -318,6 +330,12 @@ export class AuthController {
             // 새 액세스 + 리프레시 토큰 발급
             const newAccessToken = generateToken(user);
             const newRefreshToken = generateRefreshToken(user);
+
+            if (mobileMode) {
+                log.info(`[Auth] 토큰 갱신 성공 (mobile): ${user.email}`);
+                res.json(success({ token: newAccessToken, refreshToken: newRefreshToken, user }));
+                return;
+            }
 
             setTokenCookie(res, newAccessToken);
             setRefreshTokenCookie(res, newRefreshToken);

--- a/apps/api/src/schemas/auth.schema.ts
+++ b/apps/api/src/schemas/auth.schema.ts
@@ -18,7 +18,9 @@ import { secureTextSchema } from './security.schema';
  */
 export const loginSchema = z.object({
     email: z.string().trim().email('유효한 이메일 주소를 입력하세요'),
-    password: z.string().min(1, '비밀번호를 입력하세요')
+    password: z.string().min(1, '비밀번호를 입력하세요'),
+    // 모바일(iOS) 신호: true 면 refresh token 을 쿠키 대신 응답 body 로 반환 (축 2 — 앱은 Keychain 저장)
+    returnRefreshToken: z.boolean().optional()
 });
 
 /**
@@ -42,6 +44,14 @@ export const registerSchema = z.object({
     birthDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, '생년월일은 YYYY-MM-DD 형식이어야 합니다'),
     // 14세 미만 시 server-side enforce — locale 별 임계값 미달 시 필수.
     guardianEmail: z.string().email().optional(),
+});
+
+/**
+ * 모바일 exchange code 교환 요청 스키마 (iOS 축 2)
+ * @property {string} code - OAuth 콜백이 발급한 일회성 hex 코드 (32B → 64자)
+ */
+export const mobileExchangeSchema = z.object({
+    code: z.string().regex(/^[0-9a-f]{64}$/, '유효하지 않은 코드 형식입니다')
 });
 
 /**

--- a/apps/api/src/swagger/paths-auth.ts
+++ b/apps/api/src/swagger/paths-auth.ts
@@ -19,7 +19,7 @@ export const authPaths = {
         post: {
             tags: ['Auth'],
             summary: '로그인',
-            description: '이메일과 비밀번호로 로그인합니다. access token 은 응답 body 와 HttpOnly 쿠키 양쪽에 발급됩니다 (refresh token 은 쿠키 전용 — 모바일 body 모드는 축 2 도입 예정). 사전 인증 POST 이므로 CSRF 부트스트랩 필요 (모듈 설명 참고).',
+            description: '이메일과 비밀번호로 로그인합니다. access token 은 응답 body 와 HttpOnly 쿠키 양쪽에 발급됩니다. `returnRefreshToken: true`(모바일) 지정 시 쿠키를 설정하지 않고 refresh token 을 body 로 반환합니다 (앱은 Keychain 저장). 사전 인증 POST 이므로 CSRF 부트스트랩 필요 (모듈 설명 참고).',
             security: [],
             requestBody: {
                 required: true,
@@ -30,7 +30,8 @@ export const authPaths = {
                             required: ['email', 'password'],
                             properties: {
                                 email: { type: 'string', format: 'email' },
-                                password: { type: 'string' }
+                                password: { type: 'string' },
+                                returnRefreshToken: { type: 'boolean', description: '모바일 신호 — true 면 쿠키 미설정, refresh token body 반환' }
                             }
                         }
                     }
@@ -47,6 +48,7 @@ export const authPaths = {
                                 properties: {
                                     success: { type: 'boolean', enum: [true] },
                                     token: { type: 'string', description: 'JWT access token' },
+                                    refreshToken: { type: 'string', description: 'returnRefreshToken=true 요청에만 존재' },
                                     user: { $ref: '#/components/schemas/PublicUser' }
                                 }
                             })
@@ -158,8 +160,21 @@ export const authPaths = {
         post: {
             tags: ['Auth'],
             summary: '토큰 갱신 (rotation)',
-            description: 'refresh token 쿠키(`path=/api/auth/refresh`)로 새 access token 을 발급합니다. 구 refresh token 은 블랙리스트 처리되고 새 refresh token 이 쿠키로 회전 발급됩니다. 사전 인증 POST 이므로 CSRF 부트스트랩 필요. (모바일 body 모드 — body.refreshToken 수용·반환 — 는 축 2 도입 후 본 계약에 반영.)',
+            description: 'refresh token 으로 새 access token 을 발급합니다 — 웹은 쿠키(`path=/api/auth/refresh`), 모바일은 `body.refreshToken`(존재 자체가 모바일 신호 — 쿠키 미설정, 새 refresh token 을 body 로 반환). 구 refresh token 은 블랙리스트 처리(rotation). 사전 인증 POST 이므로 CSRF 부트스트랩 필요.',
             security: [],
+            requestBody: {
+                required: false,
+                content: {
+                    'application/json': {
+                        schema: {
+                            type: 'object',
+                            properties: {
+                                refreshToken: { type: 'string', description: '모바일 모드 — 쿠키 대신 body 로 전달' }
+                            }
+                        }
+                    }
+                }
+            },
             responses: {
                 '200': {
                     description: '갱신 성공',
@@ -170,6 +185,7 @@ export const authPaths = {
                                 required: ['token', 'user'],
                                 properties: {
                                     token: { type: 'string', description: '새 JWT access token' },
+                                    refreshToken: { type: 'string', description: '모바일 모드 요청에만 존재 — 새 refresh token' },
                                     user: { $ref: '#/components/schemas/PublicUser' }
                                 }
                             })
@@ -212,11 +228,63 @@ export const authPaths = {
         get: {
             tags: ['Auth'],
             summary: 'Google OAuth 시작',
-            description: 'Google 인가 페이지로 302 리다이렉트합니다. 완료 시 서버 콜백(`/api/auth/callback/google` — 서버↔IdP 표면이라 본 계약 비노출)이 인증 쿠키를 설정하고 웹으로 리다이렉트합니다. (모바일 `?client=ios` + exchange code 흐름은 축 2 도입 후 반영.)',
+            description: 'Google 인가 페이지로 302 리다이렉트합니다. 완료 시 서버 콜백(`/api/auth/callback/google` — 서버↔IdP 표면이라 본 계약 비노출)이 웹은 인증 쿠키 + 웹 리다이렉트, `?client=ios` 는 일회성 exchange code 를 app scheme(`openmake://auth/callback?code=...`)으로 전달합니다. 앱은 `/api/auth/mobile/exchange` 로 교환.',
             security: [],
+            parameters: [
+                {
+                    name: 'client',
+                    in: 'query',
+                    required: false,
+                    schema: { type: 'string', enum: ['ios'] },
+                    description: '모바일 클라이언트 식별 — 지정 시 콜백이 exchange code 흐름으로 분기'
+                }
+            ],
             responses: {
                 '302': { description: 'Google 인가 URL 로 리다이렉트' },
-                '500': failureResponse('OAuth 미설정 (client id 없음)')
+                '503': failureResponse('OAuth 미설정 (client id 없음)')
+            }
+        }
+    },
+    '/api/auth/mobile/exchange': {
+        post: {
+            tags: ['Auth'],
+            summary: '모바일 exchange code → 토큰 교환',
+            description: 'OAuth 콜백(`?client=ios`)이 app scheme 으로 전달한 일회성 코드(TTL 60s)를 access/refresh token 으로 교환합니다. 응답은 body 전용 — 쿠키 미설정 (앱은 Keychain 저장). 코드는 소비 즉시 무효화(재사용 불가). 사전 인증 POST 이므로 CSRF 부트스트랩 필요.',
+            security: [],
+            requestBody: {
+                required: true,
+                content: {
+                    'application/json': {
+                        schema: {
+                            type: 'object',
+                            required: ['code'],
+                            properties: {
+                                code: { type: 'string', pattern: '^[0-9a-f]{64}$', description: '일회성 hex 코드 (64자)' }
+                            }
+                        }
+                    }
+                }
+            },
+            responses: {
+                '200': {
+                    description: '교환 성공',
+                    content: {
+                        'application/json': {
+                            schema: envelope({
+                                type: 'object',
+                                required: ['token', 'refreshToken', 'user'],
+                                properties: {
+                                    token: { type: 'string', description: 'JWT access token' },
+                                    refreshToken: { type: 'string', description: 'refresh token (Keychain 저장)' },
+                                    user: { $ref: '#/components/schemas/PublicUser' }
+                                }
+                            })
+                        }
+                    }
+                },
+                '400': failureResponse('코드 형식 오류'),
+                '401': failureResponse('유효하지 않거나 만료/재사용된 코드'),
+                '429': failureResponse('요청 과다 (authLimiter)')
             }
         }
     },

--- a/db/init/002-schema.sql
+++ b/db/init/002-schema.sql
@@ -384,6 +384,8 @@ CREATE TABLE IF NOT EXISTS user_api_keys (
 CREATE TABLE IF NOT EXISTS oauth_states (
     state TEXT PRIMARY KEY,
     provider TEXT NOT NULL,
+    -- 모바일 클라이언트 식별 ('ios' 등). NULL = 웹 — 콜백에서 쿠키/exchange code 분기 (097)
+    client TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 

--- a/db/migrations/097_oauth_states_client.sql
+++ b/db/migrations/097_oauth_states_client.sql
@@ -1,0 +1,4 @@
+-- 097: oauth_states 에 client 컬럼 추가 (iOS 축 2 — 모바일 OAuth)
+-- OAuth 시작 시 ?client=ios 를 state 에 귀속 → 콜백에서 웹(쿠키)/모바일(exchange code) 분기.
+-- NULL = 웹 (기존 동작 무변경). 멱등 — 재실행 안전.
+ALTER TABLE oauth_states ADD COLUMN IF NOT EXISTS client TEXT;

--- a/packages/api-contracts/openapi.v1.json
+++ b/packages/api-contracts/openapi.v1.json
@@ -1048,7 +1048,7 @@
           "Auth"
         ],
         "summary": "로그인",
-        "description": "이메일과 비밀번호로 로그인합니다. access token 은 응답 body 와 HttpOnly 쿠키 양쪽에 발급됩니다 (refresh token 은 쿠키 전용 — 모바일 body 모드는 축 2 도입 예정). 사전 인증 POST 이므로 CSRF 부트스트랩 필요 (모듈 설명 참고).",
+        "description": "이메일과 비밀번호로 로그인합니다. access token 은 응답 body 와 HttpOnly 쿠키 양쪽에 발급됩니다. `returnRefreshToken: true`(모바일) 지정 시 쿠키를 설정하지 않고 refresh token 을 body 로 반환합니다 (앱은 Keychain 저장). 사전 인증 POST 이므로 CSRF 부트스트랩 필요 (모듈 설명 참고).",
         "security": [],
         "requestBody": {
           "required": true,
@@ -1067,6 +1067,10 @@
                   },
                   "password": {
                     "type": "string"
+                  },
+                  "returnRefreshToken": {
+                    "type": "boolean",
+                    "description": "모바일 신호 — true 면 쿠키 미설정, refresh token body 반환"
                   }
                 }
               }
@@ -1107,6 +1111,10 @@
                         "token": {
                           "type": "string",
                           "description": "JWT access token"
+                        },
+                        "refreshToken": {
+                          "type": "string",
+                          "description": "returnRefreshToken=true 요청에만 존재"
                         },
                         "user": {
                           "$ref": "#/components/schemas/PublicUser"
@@ -1388,8 +1396,24 @@
           "Auth"
         ],
         "summary": "토큰 갱신 (rotation)",
-        "description": "refresh token 쿠키(`path=/api/auth/refresh`)로 새 access token 을 발급합니다. 구 refresh token 은 블랙리스트 처리되고 새 refresh token 이 쿠키로 회전 발급됩니다. 사전 인증 POST 이므로 CSRF 부트스트랩 필요. (모바일 body 모드 — body.refreshToken 수용·반환 — 는 축 2 도입 후 본 계약에 반영.)",
+        "description": "refresh token 으로 새 access token 을 발급합니다 — 웹은 쿠키(`path=/api/auth/refresh`), 모바일은 `body.refreshToken`(존재 자체가 모바일 신호 — 쿠키 미설정, 새 refresh token 을 body 로 반환). 구 refresh token 은 블랙리스트 처리(rotation). 사전 인증 POST 이므로 CSRF 부트스트랩 필요.",
         "security": [],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "refreshToken": {
+                    "type": "string",
+                    "description": "모바일 모드 — 쿠키 대신 body 로 전달"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "갱신 성공",
@@ -1419,6 +1443,10 @@
                         "token": {
                           "type": "string",
                           "description": "새 JWT access token"
+                        },
+                        "refreshToken": {
+                          "type": "string",
+                          "description": "모바일 모드 요청에만 존재 — 새 refresh token"
                         },
                         "user": {
                           "$ref": "#/components/schemas/PublicUser"
@@ -1519,14 +1547,137 @@
           "Auth"
         ],
         "summary": "Google OAuth 시작",
-        "description": "Google 인가 페이지로 302 리다이렉트합니다. 완료 시 서버 콜백(`/api/auth/callback/google` — 서버↔IdP 표면이라 본 계약 비노출)이 인증 쿠키를 설정하고 웹으로 리다이렉트합니다. (모바일 `?client=ios` + exchange code 흐름은 축 2 도입 후 반영.)",
+        "description": "Google 인가 페이지로 302 리다이렉트합니다. 완료 시 서버 콜백(`/api/auth/callback/google` — 서버↔IdP 표면이라 본 계약 비노출)이 웹은 인증 쿠키 + 웹 리다이렉트, `?client=ios` 는 일회성 exchange code 를 app scheme(`openmake://auth/callback?code=...`)으로 전달합니다. 앱은 `/api/auth/mobile/exchange` 로 교환.",
         "security": [],
+        "parameters": [
+          {
+            "name": "client",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "ios"
+              ]
+            },
+            "description": "모바일 클라이언트 식별 — 지정 시 콜백이 exchange code 흐름으로 분기"
+          }
+        ],
         "responses": {
           "302": {
             "description": "Google 인가 URL 로 리다이렉트"
           },
-          "500": {
+          "503": {
             "description": "OAuth 미설정 (client id 없음)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiFailure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/mobile/exchange": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "모바일 exchange code → 토큰 교환",
+        "description": "OAuth 콜백(`?client=ios`)이 app scheme 으로 전달한 일회성 코드(TTL 60s)를 access/refresh token 으로 교환합니다. 응답은 body 전용 — 쿠키 미설정 (앱은 Keychain 저장). 코드는 소비 즉시 무효화(재사용 불가). 사전 인증 POST 이므로 CSRF 부트스트랩 필요.",
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "code"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "pattern": "^[0-9a-f]{64}$",
+                    "description": "일회성 hex 코드 (64자)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "교환 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "type": "object",
+                      "required": [
+                        "token",
+                        "refreshToken",
+                        "user"
+                      ],
+                      "properties": {
+                        "token": {
+                          "type": "string",
+                          "description": "JWT access token"
+                        },
+                        "refreshToken": {
+                          "type": "string",
+                          "description": "refresh token (Keychain 저장)"
+                        },
+                        "user": {
+                          "$ref": "#/components/schemas/PublicUser"
+                        }
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/ApiMeta"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "코드 형식 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiFailure"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "유효하지 않거나 만료/재사용된 코드",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiFailure"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "요청 과다 (authLimiter)",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
## 개요

iOS 3축 중 **축 2(모바일 인증)** — iOS 앱이 쿠키 없이 토큰 라이프사이클(발급→갱신→회전→로그아웃)을 수행하도록 인증 표면을 확장. **웹 쿠키 흐름은 무변경 병존** (body 신호 시에만 분기, 엔드포인트 이중화 없음). #512(축 1) 후속.

## 변경 내용

### refresh / login / logout 모바일 수용 (`auth.controller.ts`)
- `POST /api/auth/refresh`: `body.refreshToken` 존재 = 모바일 신호 → 쿠키 미설정, 새 refresh token 을 body 로 반환. rotation·블랙리스트 로직은 쿠키 경로와 공유
- `POST /api/auth/login`: `returnRefreshToken: true` 시 refresh token body 반환·쿠키 미설정 (loginSchema 등재 — validate 가 req.body 를 zod parse 결과로 교체하므로 필수)
- `POST /api/auth/logout`: 쿠키·body refresh token 둘 다 블랙리스트

### OAuth exchange code 흐름 (3사 대칭)
- `ASWebAuthenticationSession` 은 앱 URLSession 과 쿠키 저장소가 분리 → 쿠키로는 토큰이 앱에 도달 불가. `?client=ios` 를 `oauth_states.client`(마이그레이션 097, 002-schema·ensure 폴백 동반, 멱등)에 귀속 → 콜백에서 **일회성 exchange code**(KVStore, TTL 60s)를 `openmake://auth/callback?code=…` 로 전달 → `POST /api/auth/mobile/exchange` 로 교환
- app scheme URL 에 토큰 직접 전달 금지 (로그·타 앱 가로채기 방어), 코드는 소비 즉시 무효화
- exchange: authLimiter + 64-hex zod 검증 + audit `auth.mobile_exchange[_failed]`
- config 외부화: `MOBILE_AUTH` (`MOBILE_APP_SCHEME` 기본 openmake, `MOBILE_EXCHANGE_CODE_TTL_MS`) + `.env.example`

### 계약 반영 (축 1 Step 6)
- paths-auth 갱신(+`/api/auth/mobile/exchange`·`client` 파라미터·google login 응답코드 500→실코드 503 정정) + `contracts:export` 재생성 (Gate 0 통과)

## 검증

- [x] 신규 테스트 14케이스 (`mobile-auth-contract.test.ts`): refresh body/쿠키 무변경/401 · login 신호/무신호 · logout body 블랙리스트 · state client 귀속+일회성 · exchange 정상/재사용 401/미존재 401/형식 400/**TTL 만료 401**/비활성 401
- [x] 계약 테스트 전체 38/38 · `tsc --noEmit` 0 · eslint 0 · contracts drift 0
- [ ] 라이브 검증(배포 후): WS Bearer 핸드셰이크 · OAuth `?client=ios` 완주(chat.openmake.cc) · 웹 로그인 수동 회귀

## 참고

- CSRF: 사전 인증 POST(login/refresh/exchange)는 기존 Double-Submit 규약 그대로 — iOS 가 `GET /api/csrf-token` 부트스트랩 (서버 변경 없음, 계약에 명기됨)
- 후속: 축 3(iOS SwiftUI MVP) — `apps/ios/` 별도 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)