### PR TITLE
feat(ios): LUMEN 2차 백로그 — 에이전트·아티팩트·푸시·스킬 표시

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1278,6 +1278,12 @@ VAPID_PUBLIC_KEY=
 VAPID_PRIVATE_KEY=
 VAPID_SUBJECT=mailto:admin@openmake.ai
 
+# iOS APNs — Apple Developer Program의 Push Notifications capability와 .p8 키 필요
+# 개인 개발 팀에서는 비워 두면 웹 푸시만 동작하며, iOS 앱은 로컬 완료 알림을 사용합니다.
+APNS_KEY_ID=
+APNS_TEAM_ID=
+APNS_PRIVATE_KEY=
+
 # 이미지 생성 — LiteLLM image_generation 모델명 (vLLM-Omni FLUX.2-klein). 미설정 시 generate_image 도구 비활성
 IMAGE_GEN_MODEL=flux2-klein
 # 이미지 생성 타임아웃 ms (기본 180000)

--- a/apps/api/src/chat/__tests__/slash-command.test.ts
+++ b/apps/api/src/chat/__tests__/slash-command.test.ts
@@ -4,6 +4,8 @@ import {
     matchesSlug,
     buildAugmentedMessage,
     applySlashCommand,
+    mergeActivatedSkillNames,
+    type ApplySlashDeps,
 } from '../slash-command';
 
 describe('parseSlashCommand', () => {
@@ -79,6 +81,30 @@ describe('applySlashCommand', () => {
         const find = jest.fn().mockRejectedValue(new Error('db down'));
         const out = await applySlashCommand('/billing x', { findSkillBySlug: find, enabled: true });
         expect(out).toBe('/billing x');
+    });
+});
+
+describe('slash skill activation metadata', () => {
+    it('명시 호출된 스킬 이름을 활성화 이벤트용 콜백으로 전달한다', async () => {
+        const find = jest.fn().mockResolvedValue({ name: 'Billing Guide', content: 'rules' });
+        const onSkillApplied = jest.fn();
+        const deps: ApplySlashDeps & { onSkillApplied: (skillName: string) => void } = {
+            findSkillBySlug: find,
+            enabled: true,
+            onSkillApplied,
+        };
+
+        const message = await applySlashCommand('/billing-guide 환불', deps);
+
+        expect(message).toContain('rules');
+        expect(onSkillApplied).toHaveBeenCalledWith('Billing Guide');
+    });
+
+    it('명시 호출과 자동 선택 스킬을 순서 보존·중복 제거해 병합한다', () => {
+        expect(mergeActivatedSkillNames(
+            [' Billing Guide ', 'web-search'],
+            ['web-search', 'Report', ''],
+        )).toEqual(['Billing Guide', 'web-search', 'Report']);
     });
 });
 

--- a/apps/api/src/chat/slash-command.ts
+++ b/apps/api/src/chat/slash-command.ts
@@ -75,8 +75,13 @@ export interface ApplySlashDeps {
     userId?: string;
     /** slug 로 active 스킬을 찾는 함수 (없으면 기본 구현 — skill-manager) */
     findSkillBySlug?: (slug: string, userId?: string) => Promise<SlashSkill | null>;
+    onSkillApplied?: (skillName: string) => void;
     /** 강제 on/off (테스트용). 기본 SLASH_COMMANDS_ENABLED */
     enabled?: boolean;
+}
+
+export function mergeActivatedSkillNames(...groups: string[][]): string[] {
+    return [...new Set(groups.flatMap((names) => names.map((name) => name.trim()).filter(Boolean)))];
 }
 
 /** 기본 스킬 해석기 — active 스킬을 검색해 slug 정확 매칭.
@@ -115,6 +120,7 @@ export async function applySlashCommand(message: string, deps: ApplySlashDeps = 
         const skill = await find(parsed.slug, deps.userId);
         if (!skill) return message; // 미매칭 — 원문 유지(일반 텍스트로 취급)
         logger.info(`슬래시 명령 적용: /${parsed.slug} → 스킬 "${skill.name}"`);
+        deps.onSkillApplied?.(skill.name);
         return buildAugmentedMessage(skill, parsed.rest);
     } catch (e) {
         logger.warn(`슬래시 명령 처리 실패 (원문 유지): ${e instanceof Error ? e.message : String(e)}`);

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -185,6 +185,9 @@ export const envSchema = z
         VAPID_PUBLIC_KEY: z.string().default(''),
         VAPID_PRIVATE_KEY: z.string().default(''),
         VAPID_SUBJECT: z.string().default('mailto:admin@openmake.ai'),
+        APNS_KEY_ID: z.string().default(''),
+        APNS_TEAM_ID: z.string().default(''),
+        APNS_PRIVATE_KEY: z.string().default(''),
         // 운영자 알림 webhook (Slack/Discord incoming) — severity 별 URL 우선, 없으면 단일 URL fallback
         OPERATOR_WEBHOOK_URL: z.string().default(''),
         OPERATOR_WEBHOOK_URL_CRITICAL: z.string().default(''),

--- a/apps/api/src/routes/push.routes.ts
+++ b/apps/api/src/routes/push.routes.ts
@@ -22,8 +22,14 @@ import { success, serviceUnavailable } from '../utils/api-response';
 import { createLogger } from '../utils/logger';
 import { asyncHandler } from '../utils/error-handler';
 import { validate } from '../middlewares/validation';
-import { pushSubscribeSchema, pushUnsubscribeSchema } from '../schemas/push.schema';
+import {
+    nativePushSubscribeSchema,
+    nativePushUnsubscribeSchema,
+    pushSubscribeSchema,
+    pushUnsubscribeSchema,
+} from '../schemas/push.schema';
 import { getPushService, PushSubscription } from '../services/PushService';
+import { getNativePushService } from '../services/NativePushService';
 
 const logger = createLogger('PushRoutes');
 
@@ -108,6 +114,26 @@ router.post('/unsubscribe', requireAuth, validate(pushUnsubscribeSchema), asyncH
     void pushService.unsubscribe(String(req.user!.id), endpoint).catch(err => logger.error('[Push] DB 구독 삭제 실패:', err));
     
     res.json(success({ message: deleted ? 'Push 구독이 해제되었습니다.' : '해당 구독을 찾을 수 없습니다.' }));
+}));
+
+router.post('/native/subscribe', requireAuth, validate(nativePushSubscribeSchema), asyncHandler(async (req: Request, res: Response) => {
+    const { deviceToken, environment, bundleId } = req.body as {
+        deviceToken: string;
+        environment: 'development' | 'production';
+        bundleId: string;
+    };
+    await getNativePushService().subscribe(String(req.user!.id), {
+        deviceToken: deviceToken.toLowerCase(),
+        environment,
+        bundleId,
+    });
+    res.json(success({ message: 'iOS 푸시 토큰이 등록되었습니다.' }));
+}));
+
+router.post('/native/unsubscribe', requireAuth, validate(nativePushUnsubscribeSchema), asyncHandler(async (req: Request, res: Response) => {
+    const { deviceToken } = req.body as { deviceToken: string };
+    await getNativePushService().unsubscribe(String(req.user!.id), deviceToken.toLowerCase());
+    res.json(success({ message: 'iOS 푸시 토큰이 해제되었습니다.' }));
 }));
 
 export default router;

--- a/apps/api/src/schemas/push.schema.ts
+++ b/apps/api/src/schemas/push.schema.ts
@@ -35,7 +35,19 @@ export const pushUnsubscribeSchema = z.object({
     endpoint: z.string().min(1, 'endpoint는 필수입니다').max(2048)
 });
 
+export const nativePushSubscribeSchema = z.strictObject({
+    deviceToken: z.string().min(16).max(512).regex(/^[a-fA-F0-9]+$/),
+    environment: z.enum(['development', 'production']),
+    bundleId: z.string().min(3).max(255).regex(/^[A-Za-z0-9.-]+$/),
+});
+
+export const nativePushUnsubscribeSchema = z.strictObject({
+    deviceToken: z.string().min(16).max(512).regex(/^[a-fA-F0-9]+$/),
+});
+
 /** Push 구독 등록 요청 TypeScript 타입 */
 export type PushSubscribeInput = z.infer<typeof pushSubscribeSchema>;
 /** Push 구독 해제 요청 TypeScript 타입 */
 export type PushUnsubscribeInput = z.infer<typeof pushUnsubscribeSchema>;
+export type NativePushSubscribeInput = z.infer<typeof nativePushSubscribeSchema>;
+export type NativePushUnsubscribeInput = z.infer<typeof nativePushUnsubscribeSchema>;

--- a/apps/api/src/services/NativePushService.ts
+++ b/apps/api/src/services/NativePushService.ts
@@ -1,0 +1,197 @@
+import * as http2 from 'http2';
+import * as jwt from 'jsonwebtoken';
+import type { Pool } from 'pg';
+import { getPool } from '../data/models/unified-database';
+import { createLogger } from '../utils/logger';
+
+export interface NativePushToken {
+    deviceToken: string;
+    environment: 'development' | 'production';
+    bundleId: string;
+}
+
+export interface NativePushPayload {
+    title: string;
+    body: string;
+    url?: string;
+}
+
+export interface APNsDeliveryResult {
+    status: number;
+    reason?: string;
+}
+
+type APNsDeliver = (token: NativePushToken, payload: NativePushPayload) => Promise<APNsDeliveryResult>;
+
+interface APNsConfig {
+    keyId: string;
+    teamId: string;
+    privateKey: string;
+}
+
+const logger = createLogger('NativePushService');
+let cachedProviderToken: { value: string; createdAt: number; fingerprint: string } | null = null;
+
+function readAPNsConfig(): APNsConfig | null {
+    const keyId = process.env.APNS_KEY_ID?.trim();
+    const teamId = process.env.APNS_TEAM_ID?.trim();
+    const privateKey = process.env.APNS_PRIVATE_KEY?.replace(/\\n/g, '\n').trim();
+    if (!keyId || !teamId || !privateKey) return null;
+    return { keyId, teamId, privateKey };
+}
+
+function providerToken(config: APNsConfig): string {
+    const now = Date.now();
+    const fingerprint = `${config.teamId}:${config.keyId}`;
+    if (cachedProviderToken
+        && cachedProviderToken.fingerprint === fingerprint
+        && now - cachedProviderToken.createdAt < 50 * 60 * 1000) {
+        return cachedProviderToken.value;
+    }
+    const options: jwt.SignOptions = {
+        algorithm: 'ES256',
+        issuer: config.teamId,
+        keyid: config.keyId,
+    };
+    const value = jwt.sign({}, config.privateKey, options);
+    cachedProviderToken = { value, createdAt: now, fingerprint };
+    return value;
+}
+
+export async function deliverAPNsNotification(
+    token: NativePushToken,
+    payload: NativePushPayload,
+): Promise<APNsDeliveryResult> {
+    const config = readAPNsConfig();
+    if (!config) return { status: 0, reason: 'NotConfigured' };
+    const host = token.environment === 'production'
+        ? 'api.push.apple.com'
+        : 'api.sandbox.push.apple.com';
+    const client = http2.connect(`https://${host}`);
+
+    return new Promise<APNsDeliveryResult>((resolve) => {
+        let status = 0;
+        let responseBody = '';
+        let settled = false;
+        const finish = (result: APNsDeliveryResult) => {
+            if (settled) return;
+            settled = true;
+            client.close();
+            resolve(result);
+        };
+        client.once('error', (error) => finish({ status: 0, reason: error.message }));
+        const request = client.request({
+            ':method': 'POST',
+            ':path': `/3/device/${token.deviceToken}`,
+            authorization: `bearer ${providerToken(config)}`,
+            'apns-topic': token.bundleId,
+            'apns-push-type': 'alert',
+            'apns-priority': '10',
+            'content-type': 'application/json',
+        });
+        request.on('response', (headers) => {
+            status = Number(headers[':status'] ?? 0);
+        });
+        request.setEncoding('utf8');
+        request.on('data', (chunk: string) => { responseBody += chunk; });
+        request.once('error', (error) => finish({ status: 0, reason: error.message }));
+        request.on('end', () => {
+            let reason: string | undefined;
+            if (responseBody) {
+                try {
+                    const parsed = JSON.parse(responseBody) as { reason?: unknown };
+                    if (typeof parsed.reason === 'string') reason = parsed.reason;
+                } catch {
+                    reason = 'InvalidAPNsResponse';
+                }
+            }
+            finish({ status, reason });
+        });
+        request.end(JSON.stringify({
+            aps: {
+                alert: { title: payload.title, body: payload.body },
+                sound: 'default',
+            },
+            ...(payload.url ? { url: payload.url } : {}),
+        }));
+    });
+}
+
+export class NativePushService {
+    constructor(
+        private readonly pool: Pool = getPool(),
+        private readonly deliver: APNsDeliver = deliverAPNsNotification,
+    ) {}
+
+    async subscribe(
+        userId: string,
+        token: NativePushToken,
+    ): Promise<void> {
+        await this.pool.query(
+            `INSERT INTO mobile_push_tokens (user_id, device_token, environment, bundle_id)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT (device_token) DO UPDATE SET
+                user_id = EXCLUDED.user_id,
+                environment = EXCLUDED.environment,
+                bundle_id = EXCLUDED.bundle_id,
+                updated_at = NOW()`,
+            [userId, token.deviceToken, token.environment, token.bundleId],
+        );
+    }
+
+    async unsubscribe(userId: string, deviceToken: string): Promise<void> {
+        await this.pool.query(
+            'DELETE FROM mobile_push_tokens WHERE user_id = $1 AND device_token = $2',
+            [userId, deviceToken],
+        );
+    }
+
+    async sendPush(userId: string, payload: NativePushPayload): Promise<void> {
+        const result = await this.pool.query<{
+            device_token: string;
+            environment: 'development' | 'production';
+            bundle_id: string;
+        }>(
+            `SELECT device_token, environment, bundle_id
+             FROM mobile_push_tokens WHERE user_id = $1`,
+            [userId],
+        );
+        await Promise.all(result.rows.map(async (row) => {
+            const token: NativePushToken = {
+                deviceToken: row.device_token,
+                environment: row.environment,
+                bundleId: row.bundle_id,
+            };
+            const outcome = await this.deliver(token, payload);
+            if (outcome.status >= 200 && outcome.status < 300) {
+                await this.pool.query(
+                    'UPDATE mobile_push_tokens SET last_used = NOW() WHERE device_token = $1',
+                    [token.deviceToken],
+                );
+                return;
+            }
+            if (outcome.status === 410 || outcome.reason === 'Unregistered' || outcome.reason === 'BadDeviceToken') {
+                await this.pool.query(
+                    'DELETE FROM mobile_push_tokens WHERE device_token = $1',
+                    [token.deviceToken],
+                );
+                return;
+            }
+            if (outcome.reason !== 'NotConfigured') {
+                logger.warn('apns.delivery_failed', {
+                    status: outcome.status,
+                    reason: outcome.reason,
+                    environment: token.environment,
+                    bundleId: token.bundleId,
+                });
+            }
+        }));
+    }
+}
+
+let nativePushService: NativePushService | null = null;
+
+export function getNativePushService(): NativePushService {
+    if (!nativePushService) nativePushService = new NativePushService();
+    return nativePushService;
+}

--- a/apps/api/src/services/PushService.ts
+++ b/apps/api/src/services/PushService.ts
@@ -2,6 +2,7 @@ import { getPool } from '../data/models/unified-database';
 import webPush from 'web-push';
 import { getVapidKeys } from '../utils/vapid';
 import { createLogger } from '../utils/logger';
+import { getNativePushService } from './NativePushService';
 
 const logger = createLogger('PushService');
 
@@ -82,12 +83,23 @@ export class PushService {
      * 410 Gone / 404 (만료 구독)은 자동 정리. fire-and-forget 호출 전제.
      */
     async sendPush(userId: string, payload: { title: string; body: string; url?: string }): Promise<void> {
+        const nativeDelivery = getNativePushService().sendPush(userId, payload).catch((error) => {
+            logger.warn('native_push.dispatch_failed', {
+                error: error instanceof Error ? error.message : String(error),
+            });
+        });
         const { publicKey, privateKey } = getVapidKeys(); // setVapidDetails 보장
-        if (!publicKey || !privateKey) return; // VAPID 미설정 — 발송 불가, no-op
+        if (!publicKey || !privateKey) {
+            await nativeDelivery;
+            return;
+        }
         const subs = await this.getActiveSubscriptions(userId);
-        if (subs.length === 0) return;
+        if (subs.length === 0) {
+            await nativeDelivery;
+            return;
+        }
         const data = JSON.stringify(payload);
-        await Promise.all(subs.map(async (sub) => {
+        await Promise.all([nativeDelivery, ...subs.map(async (sub) => {
             try {
                 await webPush.sendNotification(
                     { endpoint: sub.endpoint, keys: { p256dh: sub.keys.p256dh, auth: sub.keys.auth } },
@@ -103,7 +115,7 @@ export class PushService {
                     logger.warn(`push 발송 실패 (user=${userId}, code=${code ?? 'n/a'}): ${(err as Error)?.message ?? err}`);
                 }
             }
-        }));
+        })]);
     }
 
     async listStoredSubscriptions(): Promise<StoredPushSubscription[]> {

--- a/apps/api/src/services/__tests__/native-push-service.test.ts
+++ b/apps/api/src/services/__tests__/native-push-service.test.ts
@@ -1,0 +1,59 @@
+import type { Pool } from 'pg';
+import {
+    NativePushService,
+    type APNsDeliveryResult,
+    type NativePushPayload,
+    type NativePushToken,
+} from '../NativePushService';
+
+function makeService() {
+    const query = jest.fn();
+    const deliver = jest.fn<Promise<APNsDeliveryResult>, [NativePushToken, NativePushPayload]>();
+    const pool = { query } as unknown as Pool;
+    return { query, deliver, service: new NativePushService(pool, deliver) };
+}
+
+describe('NativePushService', () => {
+    it('upserts an iOS token for the authenticated user', async () => {
+        const { query, service } = makeService();
+        query.mockResolvedValueOnce({ rows: [] });
+
+        await service.subscribe('u1', {
+            deviceToken: 'a'.repeat(64),
+            environment: 'development',
+            bundleId: 'cc.openmake.chat',
+        });
+
+        expect(query).toHaveBeenCalledWith(
+            expect.stringContaining('INSERT INTO mobile_push_tokens'),
+            ['u1', 'a'.repeat(64), 'development', 'cc.openmake.chat'],
+        );
+    });
+
+    it('removes an APNs token after an unregistered response', async () => {
+        const { query, deliver, service } = makeService();
+        const token: NativePushToken = {
+            deviceToken: 'b'.repeat(64),
+            environment: 'production',
+            bundleId: 'cc.openmake.chat',
+        };
+        query
+            .mockResolvedValueOnce({ rows: [{
+                device_token: token.deviceToken,
+                environment: token.environment,
+                bundle_id: token.bundleId,
+            }] })
+            .mockResolvedValueOnce({ rows: [] });
+        deliver.mockResolvedValueOnce({ status: 410, reason: 'Unregistered' });
+
+        await service.sendPush('u1', { title: '완료', body: '작업이 끝났습니다', url: '/agent-tasks' });
+
+        expect(deliver).toHaveBeenCalledWith(token, {
+            title: '완료', body: '작업이 끝났습니다', url: '/agent-tasks',
+        });
+        expect(query).toHaveBeenLastCalledWith(
+            expect.stringContaining('DELETE FROM mobile_push_tokens'),
+            [token.deviceToken],
+        );
+    });
+});

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -17,7 +17,7 @@ import { createLogger } from '../utils/logger';
 import { WSMessage, ExtendedWebSocket } from './ws-types';
 import { WS_ERROR_MESSAGES, WS_PROVIDER_ERROR_MESSAGES, getLocalizedTemplate } from './ws-chat-locales';
 import { detectLanguage, type SupportedLanguageCode } from '../chat/language-policy';
-import { applySlashCommand } from '../chat/slash-command';
+import { applySlashCommand, mergeActivatedSkillNames } from '../chat/slash-command';
 import { WS_LIMITS } from '../config/timeouts';
 import { FILE_ATTACH_LIMITS } from '../config/runtime-limits';
 import { ArtifactStreamParser, type ArtifactInfo } from '../llm/artifact-parser';
@@ -68,7 +68,11 @@ export async function handleChatMessage(
     // 슬래시 명령(P-4): `/skill-slug ...` 가 active 스킬과 매칭되면 스킬 컨텍스트를 주입.
     // 비슬래시/미매칭/비활성은 원문 그대로(무영향·무비용), 오류는 graceful(원문 유지).
     const slashUserId = extWs._authenticatedUserId !== undefined ? String(extWs._authenticatedUserId) : undefined;
-    const message = await applySlashCommand((msg.message ?? '').trim(), { userId: slashUserId });
+    const explicitSkillNames: string[] = [];
+    const message = await applySlashCommand((msg.message ?? '').trim(), {
+        userId: slashUserId,
+        onSkillApplied: (skillName) => explicitSkillNames.push(skillName),
+    });
 
     // 사용자 언어 감지 — 설정에서 선택한 언어를 우선, 없으면 메시지 기반 자동 감지
     const userLangPreference = (typeof msg.language === 'string' && msg.language.trim()) ? msg.language.trim() as SupportedLanguageCode : undefined;
@@ -132,7 +136,6 @@ export async function handleChatMessage(
             ws.send(JSON.stringify({ type: 'error', message: rateLimitError }));
             return;
         }
-
         // 첨부 파일(이미지 외) → LLM 주입용 컨텍스트 (transient — DB 미저장, webSearchContext 와 동급 채널)
         // 레이트 리밋 통과 후 조립 — 거부될 요청에 최대 300k 자 문자열 조립 비용을 쓰지 않는다.
         // 바이너리 문서(PDF/docx/xlsx/pptx 등)는 base64(data)를 텍스트로 추출해 content 를 채운다.
@@ -266,6 +269,10 @@ export async function handleChatMessage(
             artifactStreamParser.feed(token);
         };
 
+        if (explicitSkillNames.length > 0) {
+            ws.send(JSON.stringify({ type: 'skills_activated', skillNames: explicitSkillNames }));
+        }
+
         // ChatRequestHandler.processChat으로 통합 처리
         const result = await ChatRequestHandler.processChat({
             message,
@@ -312,7 +319,10 @@ export async function handleChatMessage(
             onAgentSelected: (agent) => ws.send(JSON.stringify({ type: 'agent_selected', agent })),
             onDiscussionProgress: (progress) => ws.send(JSON.stringify({ type: 'discussion_progress', progress })),
             onResearchProgress: (progress) => ws.send(JSON.stringify({ type: 'research_progress', progress })),
-            onSkillsActivated: (skillNames) => ws.send(JSON.stringify({ type: 'skills_activated', skillNames })),
+            onSkillsActivated: (skillNames) => ws.send(JSON.stringify({
+                type: 'skills_activated',
+                skillNames: mergeActivatedSkillNames(explicitSkillNames, skillNames),
+            })),
             // MCP tool 호출 결과의 resource content 를 frontend 로 emit
             // (예: create_skill → openmake://skill-draft/{id} → chat.js 가 인라인 카드 렌더)
             onMcpToolResult: (event) => {

--- a/apps/api/src/types/jsonwebtoken.d.ts
+++ b/apps/api/src/types/jsonwebtoken.d.ts
@@ -12,6 +12,8 @@ declare module 'jsonwebtoken' {
         expiresIn?: string | number;
         jwtid?: string;
         algorithm?: Algorithm;
+        issuer?: string;
+        keyid?: string;
     }
 
     export interface VerifyOptions {

--- a/apps/ios/DESIGN.md
+++ b/apps/ios/DESIGN.md
@@ -1,0 +1,95 @@
+# OpenMake iOS Design System — LUMEN
+
+## 1. Product identity
+
+OpenMake iOS is the native companion for conversations, autonomous agent work, deep research, generated images, and reusable artifacts. The product should feel calm while work is in progress and precise when results arrive. The visual signature is the LUMEN dot: one small point of light that communicates model presence and activity without turning the interface into a dashboard.
+
+## 2. Design principles
+
+1. **Result first.** Put the user's content and finished output ahead of controls or telemetry.
+2. **One clear activity line.** While the system is working, show one short, truthful status such as “자료를 찾고 있어요”. Never expose private chain-of-thought or stack multiple spinners.
+3. **Progressive disclosure.** Keep advanced modes in the composer and drawer; reveal steps, artifacts, and task detail only when requested.
+4. **Native confidence.** Prefer SwiftUI navigation, system symbols, Dynamic Type, sheets, and platform gestures over web-shaped chrome.
+5. **Durable work.** Agent tasks and research continue independently from the current screen and are recoverable from the drawer.
+
+## 3. Color tokens
+
+All runtime colors are defined in `OpenMakeApp/App/Theme.swift` and must support light and dark appearances.
+
+| Token | Light | Dark | Use |
+|---|---:|---:|---|
+| `Lumen.bg` | `#F7F8FA` | `#0E1014` | App background |
+| `Lumen.surface` | `#FFFFFF` | `#15181E` | Cards and inputs |
+| `Lumen.surface2` | `#F1F3F6` | `#1B1F27` | Secondary controls and user messages |
+| `Lumen.surface3` | `#E9ECF1` | `#222732` | Disabled and tertiary controls |
+| `Lumen.fg` | `#14161C` | `#ECEEF2` | Primary text |
+| `Lumen.fg2` | `#3A3F4A` | `#C3C9D2` | Secondary text |
+| `Lumen.muted` | `#626B7A` | `#97A0AE` | Metadata |
+| `Lumen.faint` | `#8A93A1` | `#6B7480` | Disabled content |
+| `Lumen.border` | `#E4E7EC` | `#262B34` | Hairline borders |
+| `Lumen.accent` | `#2F6BFF` | `#5B8CFF` | Primary actions and active state |
+| `Lumen.accentSoft` | `#EAF1FF` | `#182134` | Selected chips and quiet emphasis |
+| `Lumen.success` | `#149A6B` | `#3FBD8C` | Completed states |
+| `Lumen.warn` | `#B5730A` | `#E0A040` | Thinking, paused, and attention states |
+
+System red is reserved for destructive actions and errors.
+
+## 4. Typography and iconography
+
+- Use San Francisco through SwiftUI system fonts. Body copy is 15 pt at the default content-size category; metadata is 11–12 pt; screen titles use the native navigation title scale.
+- Respect Dynamic Type for user-facing copy. Fixed-size typography is permitted only for compact labels when the surrounding control remains readable at accessibility sizes.
+- Use monospaced system text for code and machine identifiers.
+- Use SF Symbols for every visible icon. Do not use emoji as product icons or attachment labels.
+- The `Wordmark` uses heavy system weight and the accent only on “Make”.
+
+## 5. Spacing, shape, and layout
+
+- Base spacing unit: 4 pt. Common gaps are 4, 8, 12, 16, and 24 pt.
+- Minimum interactive target: 44 × 44 pt, even when the visible glyph is smaller.
+- Message and content corners: 10–18 pt. Composer radius: 22 pt. Mode and attachment labels use capsules.
+- Primary screens are edge-to-edge on `Lumen.bg`; content cards use `Lumen.surface` with a one-pixel `Lumen.border` stroke.
+- The drawer is at most 86% of compact-screen width and leaves a scrim that dismisses with tap or drag.
+
+## 6. Reusable primitives
+
+### Brand primitives
+
+- `Wordmark`: product title in navigation and drawer header.
+- `LumenDot`: semantic presence dot. Pulse only while work is active and honor Reduce Motion.
+
+### Work primitives
+
+- `ActivityStatusLine`: exactly one short line with a pulsing dot. States: preparing, agent, tool, research, artifact, finalizing, paused, and error. New activity replaces the previous line.
+- `ModeChip`: active composer mode with symbol, label, accent-soft background, and an accessibility value of “켜짐”.
+- `AgentTaskCard`: goal, status, progress, current/max turn, latest step, and relevant action. Completed cards reveal the result; failed cards reveal the error.
+- `ArtifactCard`: kind symbol, title, language/kind metadata, and open action. Streaming artifacts show a progress state without presenting partial HTML as executable content.
+
+### Navigation primitives
+
+- `LumenDrawer`: profile summary, new conversation, agent tasks, deep research shortcut, conversations, and settings.
+- `DrawerRow`: SF Symbol, title, optional badge, full-row tap target, selected tint.
+
+### Content primitives
+
+- `MarkdownText`: text, fenced code, links, and generated images. Relative image URLs resolve against the configured OpenMake server.
+- `ArtifactViewer`: Markdown/code text selection and copy; HTML/SVG in an isolated `WKWebView`; unsupported interactive kinds fall back to source display.
+
+## 7. Component states and behavior
+
+- **Empty:** explain the next action in one sentence and provide a direct primary action where useful.
+- **Loading:** retain navigation and show a single `ActivityStatusLine`; do not replace the entire screen unless no prior content exists.
+- **Streaming:** show the assistant header, current status until the first answer token, then the partial answer. The status line must disappear when output begins.
+- **Completed:** stop motion, use success color only for a durable completion label, and surface artifacts next to the response that produced them.
+- **Paused:** use warning color and show the approval or resume action.
+- **Failed:** show a plain-language error and retry/resume only when the server state supports it.
+- **Offline:** preserve already-loaded content and explain that refresh or execution requires a connection.
+
+## 8. Accessibility, motion, and content rules
+
+- Every icon-only button has an accessibility label. Decorative dots are hidden from VoiceOver; status text carries the semantic announcement.
+- Important status changes use polite live announcements and never repeat on every token.
+- Honor Reduce Motion: replace dot scaling with a static dot and avoid automatic drawer or progress animations.
+- Maintain readable contrast in both appearances; never encode task state by color alone.
+- Generated images include server-provided alt text or the fallback “생성된 이미지”.
+- Links and code remain selectable. External links open through the system URL environment.
+- Hidden chain-of-thought is never displayed. Status copy describes observable work only, in one concise Korean line.

--- a/apps/ios/DESIGN.md
+++ b/apps/ios/DESIGN.md
@@ -61,6 +61,8 @@ System red is reserved for destructive actions and errors.
 
 - `ActivityStatusLine`: exactly one short line with a pulsing dot. States: preparing, agent, tool, research, artifact, finalizing, paused, and error. New activity replaces the previous line.
 - `ModeChip`: active composer mode with symbol, label, accent-soft background, and an accessibility value of “켜짐”.
+- `SkillChip`: a non-interactive label for a skill selected for the current question, using the `sparkles` symbol and secondary surface colors.
+- `ActiveSkillBar`: a horizontally scrollable row of `SkillChip` values above the composer. It resets when a new question is sent and remains visible after streaming completes until the next question.
 - `AgentTaskCard`: goal, status, progress, current/max turn, latest step, and relevant action. Completed cards reveal the result; failed cards reveal the error.
 - `ArtifactCard`: kind symbol, title, language/kind metadata, and open action. Streaming artifacts show a progress state without presenting partial HTML as executable content.
 
@@ -78,7 +80,7 @@ System red is reserved for destructive actions and errors.
 
 - **Empty:** explain the next action in one sentence and provide a direct primary action where useful.
 - **Loading:** retain navigation and show a single `ActivityStatusLine`; do not replace the entire screen unless no prior content exists.
-- **Streaming:** show the assistant header, current status until the first answer token, then the partial answer. The status line must disappear when output begins.
+- **Streaming:** show the assistant header, current status until the first answer token, then the partial answer. When skills are activated, the status names them with “적용 중” and `ActiveSkillBar` keeps the same context visible after output begins. The status line must disappear when output begins.
 - **Completed:** stop motion, use success color only for a durable completion label, and surface artifacts next to the response that produced them.
 - **Paused:** use warning color and show the approval or resume action.
 - **Failed:** show a plain-language error and retry/resume only when the server state supports it.
@@ -87,6 +89,7 @@ System red is reserved for destructive actions and errors.
 ## 8. Accessibility, motion, and content rules
 
 - Every icon-only button has an accessibility label. Decorative dots are hidden from VoiceOver; status text carries the semantic announcement.
+- Skill chips announce “사용 스킬” followed by the skill name; the horizontal bar remains readable without requiring interaction.
 - Important status changes use polite live announcements and never repeat on every token.
 - Honor Reduce Motion: replace dot scaling with a static dot and avoid automatic drawer or progress animations.
 - Maintain readable contrast in both appearances; never encode task state by color alone.

--- a/apps/ios/Info.plist
+++ b/apps/ios/Info.plist
@@ -14,5 +14,7 @@
 			</array>
 		</dict>
 	</array>
+	<key>OpenMakeRemotePushEnabled</key>
+	<false/>
 </dict>
 </plist>

--- a/apps/ios/OpenMakeApp/App/AppModel.swift
+++ b/apps/ios/OpenMakeApp/App/AppModel.swift
@@ -32,6 +32,7 @@ final class AppModel {
         var artifact = false
         var discussion = false
         var deepResearch = false
+        var agentTask = false
         var style: Style = .styleDefault
 
         var activeLabels: [String] {
@@ -42,6 +43,7 @@ final class AppModel {
             if artifact { labels.append("아티팩트") }
             if discussion { labels.append("토론") }
             if deepResearch { labels.append("딥리서치") }
+            if agentTask { labels.append("에이전트 작업") }
             return labels
         }
     }
@@ -59,6 +61,7 @@ final class AppModel {
         self.client = client ?? OpenMakeClient(
             configuration: .init(serverURL: AppConfig.serverURL),
             tokenStore: store)
+        NotificationManager.shared.bind(client: self.client)
     }
 
     /// 앱 시작 시 저장된 세션 확인 (Keychain 토큰 → me)
@@ -89,12 +92,14 @@ final class AppModel {
     func login(email: String, password: String) async throws {
         let user = try await client.login(email: email, password: password)
         authState = .loggedIn(user)
+        await NotificationManager.shared.activate()
     }
 
     /// OAuth exchange code → 로그인 (축 2 계약 — `openmake://auth/callback?code=` 수신 후)
     func exchangeLogin(code: String) async throws {
         let user = try await client.exchange(code: code)
         authState = .loggedIn(user)
+        await NotificationManager.shared.activate()
     }
 
     func logout() async {

--- a/apps/ios/OpenMakeApp/App/ContentView.swift
+++ b/apps/ios/OpenMakeApp/App/ContentView.swift
@@ -6,6 +6,19 @@ struct ContentView: View {
     @State private var model = AppModel()
 
     var body: some View {
+        #if DEBUG
+        if ProcessInfo.processInfo.environment["OPENMAKE_DESIGN_SHOWCASE"] == "1" {
+            DesignSystemShowcase()
+        } else {
+            authenticatedContent
+        }
+        #else
+        authenticatedContent
+        #endif
+    }
+
+    @ViewBuilder
+    private var authenticatedContent: some View {
         Group {
             switch model.authState {
             case .checking:
@@ -17,7 +30,10 @@ struct ContentView: View {
             }
         }
         .environment(model)
-        .task { await model.bootstrap() }
+        .task {
+            await model.bootstrap()
+            await NotificationManager.shared.activate()
+        }
     }
 }
 

--- a/apps/ios/OpenMakeApp/App/LumenComponents.swift
+++ b/apps/ios/OpenMakeApp/App/LumenComponents.swift
@@ -1,0 +1,163 @@
+import SwiftUI
+import OpenMakeKit
+
+struct ActivityStatusLine: View {
+    let text: String
+    var kind: ChatActivityKind = .preparing
+
+    private var color: Color {
+        switch kind {
+        case .thinking:
+            Lumen.warn
+        case .agent, .research, .tool, .artifact:
+            Lumen.accent
+        case .preparing, .finalizing:
+            Lumen.success
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            LumenDot(color: color, size: 6, pulsing: true)
+            Text(text)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(Lumen.muted)
+                .lineLimit(1)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(text)
+        .accessibilityAddTraits(.updatesFrequently)
+        .transition(.opacity)
+    }
+}
+
+struct ModeChip: View {
+    let label: String
+    var systemImage: String?
+
+    var body: some View {
+        HStack(spacing: 5) {
+            if let systemImage {
+                Image(systemName: systemImage)
+                    .font(.system(size: 10, weight: .semibold))
+            } else {
+                LumenDot(size: 5)
+            }
+            Text(label)
+                .lineLimit(1)
+        }
+        .font(.system(size: 11, weight: .semibold))
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Lumen.accentSoft, in: Capsule())
+        .foregroundStyle(Lumen.accent)
+        .accessibilityElement(children: .combine)
+        .accessibilityValue("켜짐")
+    }
+}
+
+#if DEBUG
+struct DesignSystemShowcase: View {
+    @State private var showDrawer = ProcessInfo.processInfo.environment["OPENMAKE_DESIGN_DRAWER"] == "1"
+    @State private var selectedArtifact: ArtifactDocument?
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    Wordmark(size: 24)
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("작업 상태")
+                            .font(.headline)
+                        ActivityStatusLine(text: "요청을 분석하고 있어요", kind: .preparing)
+                        ActivityStatusLine(text: "웹에서 자료를 찾고 있어요", kind: .research)
+                        ActivityStatusLine(text: "아티팩트를 만들고 있어요", kind: .artifact)
+                    }
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("활성 모드")
+                            .font(.headline)
+                        HStack {
+                            ModeChip(label: "에이전트 작업", systemImage: "wand.and.stars")
+                            ModeChip(label: "딥리서치", systemImage: "magnifyingglass.circle")
+                        }
+                    }
+                    AgentTaskCard(task: sampleTask, latestStep: sampleStep)
+                    ArtifactCard(document: sampleArtifact) {
+                        selectedArtifact = sampleArtifact
+                    }
+                    ArtifactCard(document: sampleHTMLArtifact) {
+                        selectedArtifact = sampleHTMLArtifact
+                    }
+                }
+                .padding(20)
+            }
+            .background(Lumen.bg)
+            .navigationTitle("LUMEN")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("메뉴", systemImage: "line.3.horizontal") {
+                        showDrawer = true
+                    }
+                }
+            }
+        }
+        .sheet(item: $selectedArtifact) { artifact in
+            ArtifactViewer(document: artifact)
+        }
+        .overlay {
+            if showDrawer {
+                LumenDrawer(
+                    sessions: [],
+                    email: "hello@openmake.cc",
+                    onDismiss: { showDrawer = false },
+                    onNewChat: { showDrawer = false },
+                    onAgentTasks: { showDrawer = false },
+                    onDeepResearch: { showDrawer = false },
+                    onConversation: { _ in showDrawer = false },
+                    onSettings: { showDrawer = false })
+            }
+        }
+    }
+
+    private var sampleTask: AgentTask {
+        AgentTask(
+            id: "showcase-task",
+            goal: "공식 자료를 조사하고 핵심 결과를 정리해줘",
+            status: .running,
+            progress: 42,
+            currentTurn: 3,
+            maxTurns: 10)
+    }
+
+    private var sampleArtifact: ArtifactDocument {
+        ArtifactDocument(
+            id: "showcase",
+            kind: "code",
+            title: "Sample.swift",
+            language: "swift",
+            content: "let answer = 42",
+            isComplete: true)
+    }
+
+    private var sampleHTMLArtifact: ArtifactDocument {
+        ArtifactDocument(
+            id: "showcase-html",
+            kind: "html",
+            title: "Research Summary.html",
+            language: "html",
+            content: "<h1>연구 요약</h1><p>공식 문서의 핵심 근거를 정리했습니다.</p>",
+            isComplete: true)
+    }
+
+    private var sampleStep: AgentTaskStep {
+        AgentTaskStep(
+            id: 3,
+            taskId: sampleTask.id,
+            stepNumber: 3,
+            stepType: "research",
+            content: "공식 문서를 비교하고 핵심 근거를 정리하고 있어요",
+            status: "running")
+    }
+}
+#endif

--- a/apps/ios/OpenMakeApp/App/LumenComponents.swift
+++ b/apps/ios/OpenMakeApp/App/LumenComponents.swift
@@ -56,6 +56,41 @@ struct ModeChip: View {
     }
 }
 
+struct SkillChip: View {
+    let name: String
+
+    var body: some View {
+        Label(name, systemImage: "sparkles")
+            .font(.system(size: 11, weight: .medium))
+            .lineLimit(1)
+            .foregroundStyle(Lumen.muted)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(Lumen.surface2, in: Capsule())
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("사용 스킬 \(name)")
+    }
+}
+
+struct ActiveSkillBar: View {
+    let skills: [String]
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(skills, id: \.self) { skill in
+                    SkillChip(name: skill)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+        }
+        .background(Lumen.bg)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("사용 스킬")
+    }
+}
+
 #if DEBUG
 struct DesignSystemShowcase: View {
     @State private var showDrawer = ProcessInfo.processInfo.environment["OPENMAKE_DESIGN_DRAWER"] == "1"
@@ -80,6 +115,11 @@ struct DesignSystemShowcase: View {
                             ModeChip(label: "에이전트 작업", systemImage: "wand.and.stars")
                             ModeChip(label: "딥리서치", systemImage: "magnifyingglass.circle")
                         }
+                    }
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("사용 스킬")
+                            .font(.headline)
+                        ActiveSkillBar(skills: ["web-search", "report", "artifact"])
                     }
                     AgentTaskCard(task: sampleTask, latestStep: sampleStep)
                     ArtifactCard(document: sampleArtifact) {

--- a/apps/ios/OpenMakeApp/App/LumenDrawer.swift
+++ b/apps/ios/OpenMakeApp/App/LumenDrawer.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+import OpenMakeKit
+
+struct LumenDrawer: View {
+    let sessions: [OpenMakeClient.SessionSummary]
+    let email: String?
+    let onDismiss: () -> Void
+    let onNewChat: () -> Void
+    let onAgentTasks: () -> Void
+    let onDeepResearch: () -> Void
+    let onConversation: (OpenMakeClient.SessionSummary) -> Void
+    let onSettings: () -> Void
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Color.black.opacity(0.28)
+                    .ignoresSafeArea()
+                    .onTapGesture(perform: onDismiss)
+                    .accessibilityLabel("메뉴 닫기")
+
+                VStack(alignment: .leading, spacing: 0) {
+                    HStack(alignment: .top) {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Wordmark(size: 22)
+                            if let email {
+                                Text(email)
+                                    .font(.caption)
+                                    .foregroundStyle(Lumen.muted)
+                                    .lineLimit(1)
+                            }
+                        }
+                        Spacer()
+                        Button("메뉴 닫기", systemImage: "xmark", action: onDismiss)
+                            .labelStyle(.iconOnly)
+                            .frame(width: 44, height: 44)
+                            .foregroundStyle(Lumen.fg2)
+                    }
+                    .padding(.horizontal, 18)
+                    .padding(.top, 20)
+                    .padding(.bottom, 16)
+
+                    VStack(spacing: 4) {
+                        DrawerRow(title: "새 대화", systemImage: "square.and.pencil", accent: true, action: onNewChat)
+                        DrawerRow(title: "에이전트 작업", systemImage: "wand.and.stars", action: onAgentTasks)
+                        DrawerRow(title: "딥리서치", systemImage: "magnifyingglass.circle", action: onDeepResearch)
+                    }
+                    .padding(.horizontal, 8)
+
+                    Divider().overlay(Lumen.border).padding(.vertical, 12)
+
+                    Text("최근 대화")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Lumen.muted)
+                        .padding(.horizontal, 18)
+                        .padding(.bottom, 6)
+
+                    ScrollView {
+                        LazyVStack(spacing: 2) {
+                            ForEach(sessions.prefix(20), id: \.id) { session in
+                                DrawerRow(
+                                    title: session.title,
+                                    systemImage: "bubble.left",
+                                    action: { onConversation(session) })
+                            }
+                        }
+                        .padding(.horizontal, 8)
+                    }
+
+                    Divider().overlay(Lumen.border)
+                    DrawerRow(title: "설정", systemImage: "gearshape", action: onSettings)
+                        .padding(8)
+                }
+                .frame(width: min(proxy.size.width * 0.86, 360))
+                .frame(maxHeight: .infinity)
+                .background(Lumen.surface)
+                .shadow(color: .black.opacity(0.18), radius: 24, x: 8)
+                .gesture(
+                    DragGesture(minimumDistance: 20)
+                        .onEnded { value in
+                            if value.translation.width < -60 { onDismiss() }
+                        })
+                .accessibilityAddTraits(.isModal)
+            }
+        }
+        .transition(reduceMotion ? .opacity : .move(edge: .leading).combined(with: .opacity))
+        .zIndex(20)
+    }
+}
+
+private struct DrawerRow: View {
+    let title: String
+    let systemImage: String
+    var accent = false
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 15, weight: .medium))
+                    .frame(width: 22)
+                Text(title)
+                    .font(.system(size: 15, weight: accent ? .semibold : .regular))
+                    .lineLimit(1)
+                Spacer()
+            }
+            .foregroundStyle(accent ? Lumen.accent : Lumen.fg2)
+            .padding(.horizontal, 10)
+            .frame(minHeight: 44)
+            .background(accent ? Lumen.accentSoft : Color.clear, in: RoundedRectangle(cornerRadius: 10))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/apps/ios/OpenMakeApp/App/NotificationManager.swift
+++ b/apps/ios/OpenMakeApp/App/NotificationManager.swift
@@ -1,0 +1,184 @@
+import Foundation
+import Observation
+import UIKit
+import UserNotifications
+import OpenMakeKit
+
+@MainActor
+@Observable
+final class NotificationManager {
+    enum RemoteStatus {
+        case localOnly
+        case registering
+        case registered
+        case failed
+    }
+
+    static let shared = NotificationManager()
+
+    private(set) var authorizationStatus: UNAuthorizationStatus = .notDetermined
+    private(set) var remoteStatus: RemoteStatus = .localOnly
+    private var client: OpenMakeClient?
+    private var pendingDeviceToken: Data?
+    private var notifiedTaskIds: Set<String> = []
+
+    private init() {}
+
+    var statusText: String {
+        switch authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            switch remoteStatus {
+            case .registered: "원격 푸시 등록됨"
+            case .registering: "원격 푸시 등록 중"
+            case .failed: "기기 알림 켜짐 · 원격 등록 실패"
+            case .localOnly: "기기 알림 켜짐"
+            }
+        case .denied: "알림이 꺼져 있습니다"
+        case .notDetermined: "알림을 아직 허용하지 않았습니다"
+        @unknown default: "알림 상태를 확인할 수 없습니다"
+        }
+    }
+
+    var remotePushEnabled: Bool {
+        Bundle.main.object(forInfoDictionaryKey: "OpenMakeRemotePushEnabled") as? Bool == true
+    }
+
+    func bind(client: OpenMakeClient) {
+        self.client = client
+        if let pendingDeviceToken {
+            Task { await register(deviceToken: pendingDeviceToken) }
+        }
+    }
+
+    func refreshStatus() async {
+        authorizationStatus = await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
+    }
+
+    func requestAuthorization() async {
+        do {
+            _ = try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound])
+            await activate()
+        } catch {
+            await refreshStatus()
+        }
+    }
+
+    func activate() async {
+        await refreshStatus()
+        guard isAuthorized, remotePushEnabled else {
+            remoteStatus = .localOnly
+            return
+        }
+        if let pendingDeviceToken {
+            await register(deviceToken: pendingDeviceToken)
+            if self.pendingDeviceToken == nil { return }
+        }
+        remoteStatus = .registering
+        UIApplication.shared.registerForRemoteNotifications()
+    }
+
+    func register(deviceToken: Data) async {
+        pendingDeviceToken = deviceToken
+        guard let client,
+              let bundleId = Bundle.main.bundleIdentifier else { return }
+        let token = deviceToken.map { String(format: "%02x", $0) }.joined()
+        let environment: NativePushEnvironment
+        #if DEBUG
+        environment = .development
+        #else
+        environment = .production
+        #endif
+        do {
+            try await client.registerNativePushToken(
+                token,
+                environment: environment,
+                bundleId: bundleId)
+            remoteStatus = .registered
+            pendingDeviceToken = nil
+        } catch {
+            remoteStatus = .failed
+        }
+    }
+
+    func registrationFailed() {
+        remoteStatus = .failed
+    }
+
+    func notifyAgentTaskFinished(_ task: AgentTask) async {
+        guard !notifiedTaskIds.contains(task.id) else { return }
+        notifiedTaskIds.insert(task.id)
+        let title = task.status == .completed ? "에이전트 작업 완료" : "에이전트 작업 종료"
+        let body = task.status == .completed
+            ? String(task.goal.prefix(80))
+            : (task.error ?? String(task.goal.prefix(80)))
+        await schedule(title: title, body: body, url: "/agent-tasks")
+    }
+
+    func schedule(title: String, body: String, url: String? = nil) async {
+        await refreshStatus()
+        guard isAuthorized else { return }
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+        if let url { content.userInfo["url"] = url }
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false))
+        try? await UNUserNotificationCenter.current().add(request)
+    }
+
+    private var isAuthorized: Bool {
+        [.authorized, .provisional, .ephemeral].contains(authorizationStatus)
+    }
+}
+
+final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        Task { @MainActor in
+            await NotificationManager.shared.register(deviceToken: deviceToken)
+        }
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        Task { @MainActor in
+            NotificationManager.shared.registrationFailed()
+        }
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        [.banner, .sound]
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        guard let url = response.notification.request.content.userInfo["url"] as? String else { return }
+        await MainActor.run {
+            NotificationCenter.default.post(name: .openMakeNotificationURL, object: url)
+        }
+    }
+}
+
+extension Notification.Name {
+    static let openMakeNotificationURL = Notification.Name("OpenMakeNotificationURL")
+}

--- a/apps/ios/OpenMakeApp/App/OpenMakeApp.swift
+++ b/apps/ios/OpenMakeApp/App/OpenMakeApp.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 @main
 struct OpenMakeApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/apps/ios/OpenMakeApp/App/Theme.swift
+++ b/apps/ios/OpenMakeApp/App/Theme.swift
@@ -55,14 +55,20 @@ struct LumenDot: View {
     var pulsing = false
 
     @State private var dim = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         Circle()
             .fill(color)
             .frame(width: size, height: size)
-            .opacity(pulsing && dim ? 0.25 : 1)
-            .scaleEffect(pulsing && dim ? 0.7 : 1)
-            .animation(pulsing ? .easeInOut(duration: 0.6).repeatForever(autoreverses: true) : .default, value: dim)
-            .onAppear { if pulsing { dim = true } }
+            .opacity(pulsing && dim && !reduceMotion ? 0.25 : 1)
+            .scaleEffect(pulsing && dim && !reduceMotion ? 0.7 : 1)
+            .animation(
+                pulsing && !reduceMotion
+                    ? .easeInOut(duration: 0.6).repeatForever(autoreverses: true)
+                    : .default,
+                value: dim)
+            .onAppear { if pulsing && !reduceMotion { dim = true } }
+            .accessibilityHidden(true)
     }
 }

--- a/apps/ios/OpenMakeApp/Features/AgentTasks/AgentTaskViews.swift
+++ b/apps/ios/OpenMakeApp/Features/AgentTasks/AgentTaskViews.swift
@@ -1,0 +1,481 @@
+import SwiftUI
+import OpenMakeKit
+
+struct AgentTaskCard: View {
+    let task: AgentTask
+    var latestStep: AgentTaskStep?
+    var onOpen: (() -> Void)? = nil
+
+    var body: some View {
+        Group {
+            if let onOpen {
+                Button(action: onOpen) { cardContent }
+                    .buttonStyle(.plain)
+                    .accessibilityHint("작업 상세 열기")
+            } else {
+                cardContent
+                    .accessibilityElement(children: .combine)
+            }
+        }
+        .accessibilityLabel("\(task.goal), \(statusTitle)")
+        .accessibilityValue("\(Int(task.progress))%")
+    }
+
+    private var cardContent: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                LumenDot(color: statusColor, size: 7, pulsing: isActive)
+                Text(statusTitle)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(statusColor)
+                Spacer()
+                Text("\(task.currentTurn)/\(task.maxTurns) 단계")
+                    .font(.caption2)
+                    .foregroundStyle(Lumen.muted)
+            }
+            Text(task.goal)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(Lumen.fg)
+                .lineLimit(2)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            ProgressView(value: min(max(task.progress, 0), 100), total: 100)
+                .tint(statusColor)
+            if let detailText {
+                Text(detailText)
+                    .font(.caption)
+                    .foregroundStyle(task.status == .failed ? .red : Lumen.muted)
+                    .lineLimit(2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(14)
+        .background(Lumen.surface, in: RoundedRectangle(cornerRadius: 14))
+        .overlay(RoundedRectangle(cornerRadius: 14).strokeBorder(Lumen.border))
+    }
+
+    private var isActive: Bool {
+        [.pending, .queued, .running].contains(task.status)
+    }
+
+    private var statusTitle: String {
+        switch task.status {
+        case .pending: "준비 중"
+        case .queued: "실행 대기"
+        case .running: "작업 중"
+        case .paused: "승인 대기"
+        case .completed: "완료"
+        case .failed: "실패"
+        case .cancelled: "취소됨"
+        }
+    }
+
+    private var statusColor: Color {
+        switch task.status {
+        case .completed: Lumen.success
+        case .failed, .cancelled: .red
+        case .paused: Lumen.warn
+        default: Lumen.accent
+        }
+    }
+
+    private var detailText: String? {
+        if task.status == .failed { return task.error }
+        if task.status == .completed { return task.result }
+        return latestStep?.content
+    }
+}
+
+struct AgentTaskListView: View {
+    @Environment(AppModel.self) private var model
+    @State private var tasks: [AgentTask] = []
+    @State private var approvals: [AgentTaskApproval] = []
+    @State private var showNewTask = false
+    @State private var errorMessage: String?
+    @State private var selectedTaskId: String?
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 12) {
+                if !approvals.isEmpty {
+                    Text("승인 대기")
+                        .font(.headline)
+                        .foregroundStyle(Lumen.fg)
+                    ForEach(approvals) { approval in
+                        AgentTaskApprovalCard(approval: approval) {
+                            await load()
+                        }
+                    }
+                }
+
+                if tasks.isEmpty && errorMessage == nil {
+                    ContentUnavailableView(
+                        "에이전트 작업이 없습니다",
+                        systemImage: "wand.and.stars",
+                        description: Text("목표를 적으면 앱을 닫아도 서버에서 계속 작업합니다"))
+                        .padding(.top, 80)
+                } else {
+                    ForEach(tasks) { task in
+                        AgentTaskCard(task: task, latestStep: nil) {
+                            selectedTaskId = task.id
+                        }
+                    }
+                }
+            }
+            .padding(16)
+        }
+        .background(Lumen.bg)
+        .navigationTitle("에이전트 작업")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("새 작업", systemImage: "plus") {
+                    showNewTask = true
+                }
+            }
+        }
+        .overlay(alignment: .bottom) {
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+                    .padding(12)
+                    .background(.regularMaterial, in: Capsule())
+                    .padding(.bottom, 12)
+            }
+        }
+        .sheet(isPresented: $showNewTask) {
+            NewAgentTaskSheet {
+                await load()
+            }
+        }
+        .navigationDestination(isPresented: Binding(
+            get: { selectedTaskId != nil },
+            set: { if !$0 { selectedTaskId = nil } }
+        )) {
+            if let selectedTaskId {
+                AgentTaskDetailView(taskId: selectedTaskId)
+            }
+        }
+        .task {
+            while !Task.isCancelled {
+                await load()
+                let hasActive = tasks.contains { [.pending, .queued, .running, .paused].contains($0.status) }
+                do {
+                    try await Task.sleep(for: .seconds(hasActive ? 2 : 8))
+                } catch {
+                    return
+                }
+            }
+        }
+    }
+
+    private func load() async {
+        do {
+            async let taskRequest = model.client.agentTasks()
+            async let approvalRequest = model.client.pendingAgentTaskApprovals()
+            tasks = try await taskRequest
+            approvals = (try? await approvalRequest) ?? []
+            errorMessage = nil
+        } catch {
+            errorMessage = "작업 목록을 불러오지 못했습니다"
+        }
+    }
+}
+
+private struct NewAgentTaskSheet: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.dismiss) private var dismiss
+    @State private var goal = ""
+    @State private var policy = AgentTaskApprovalPolicy.highRisk
+    @State private var isSubmitting = false
+    @State private var errorMessage: String?
+    let onCreated: () async -> Void
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("목표") {
+                    TextEditor(text: $goal)
+                        .frame(minHeight: 130)
+                }
+                Section("도구 승인") {
+                    Picker("정책", selection: $policy) {
+                        Text("고위험만 확인").tag(AgentTaskApprovalPolicy.highRisk)
+                        Text("항상 확인").tag(AgentTaskApprovalPolicy.all)
+                        Text("자동 실행").tag(AgentTaskApprovalPolicy.none)
+                    }
+                    Text("고위험 작업은 실행 전에 에이전트 작업 화면에서 승인할 수 있습니다")
+                        .font(.footnote)
+                        .foregroundStyle(Lumen.muted)
+                }
+                if let errorMessage {
+                    Section {
+                        Text(errorMessage).foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("새 에이전트 작업")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("취소") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("시작") {
+                        Task { await submit() }
+                    }
+                    .disabled(goal.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSubmitting)
+                }
+            }
+        }
+    }
+
+    private func submit() async {
+        let trimmed = goal.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        isSubmitting = true
+        defer { isSubmitting = false }
+        do {
+            let creation = try await model.client.createAgentTask(goal: trimmed)
+            _ = try await model.client.executeAgentTask(id: creation.task.id, approvalPolicy: policy)
+            await NotificationManager.shared.requestAuthorization()
+            await onCreated()
+            dismiss()
+        } catch let error as OpenMakeAPIError {
+            if case .server(_, _, let message) = error {
+                errorMessage = message ?? "작업을 시작하지 못했습니다"
+            } else {
+                errorMessage = "작업을 시작하지 못했습니다"
+            }
+        } catch {
+            errorMessage = "작업을 시작하지 못했습니다"
+        }
+    }
+}
+
+struct AgentTaskDetailView: View {
+    let taskId: String
+    @Environment(AppModel.self) private var model
+    @State private var detail: AgentTaskDetail?
+    @State private var approvals: [AgentTaskApproval] = []
+    @State private var steering = ""
+    @State private var errorMessage: String?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if let detail {
+                    AgentTaskCard(task: detail.task, latestStep: detail.steps.last)
+
+                    ForEach(approvals.filter { $0.taskId == taskId }) { approval in
+                        AgentTaskApprovalCard(approval: approval) {
+                            await load()
+                        }
+                    }
+
+                    if let result = detail.task.result, !result.isEmpty {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("결과")
+                                .font(.headline)
+                            MarkdownText(content: result)
+                        }
+                    }
+
+                    if !detail.steps.isEmpty {
+                        VStack(alignment: .leading, spacing: 10) {
+                            Text("작업 기록")
+                                .font(.headline)
+                            ForEach(detail.steps.suffix(20)) { step in
+                                HStack(alignment: .top, spacing: 8) {
+                                    LumenDot(color: Lumen.faint, size: 5)
+                                        .padding(.top, 6)
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(step.toolName ?? step.stepType)
+                                            .font(.caption.weight(.semibold))
+                                            .foregroundStyle(Lumen.fg2)
+                                        if let content = step.content, !content.isEmpty {
+                                            Text(content)
+                                                .font(.caption)
+                                                .foregroundStyle(Lumen.muted)
+                                                .lineLimit(4)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if [.pending, .queued, .running, .paused].contains(detail.task.status) {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("중간 지시")
+                                .font(.headline)
+                            HStack {
+                                TextField("다음 단계에 반영할 내용", text: $steering)
+                                    .textFieldStyle(.roundedBorder)
+                                Button("보내기") {
+                                    Task { await steer() }
+                                }
+                                .disabled(steering.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                            }
+                            Button("작업 취소", role: .destructive) {
+                                Task { await cancel() }
+                            }
+                        }
+                    } else if detail.task.resumable {
+                        Button("중단 지점에서 이어하기") {
+                            Task { await resume() }
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                } else {
+                    ProgressView("작업을 불러오고 있어요")
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 80)
+                }
+            }
+            .padding(16)
+        }
+        .background(Lumen.bg)
+        .navigationTitle("작업 상세")
+        .navigationBarTitleDisplayMode(.inline)
+        .overlay(alignment: .bottom) {
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+                    .padding(10)
+                    .background(.regularMaterial, in: Capsule())
+                    .padding(.bottom, 12)
+            }
+        }
+        .task {
+            while !Task.isCancelled {
+                await load()
+                let isActive = detail.map { [.pending, .queued, .running, .paused].contains($0.task.status) } ?? true
+                do {
+                    try await Task.sleep(for: .seconds(isActive ? 2 : 10))
+                } catch {
+                    return
+                }
+            }
+        }
+    }
+
+    private func load() async {
+        do {
+            async let detailRequest = model.client.agentTask(id: taskId)
+            async let approvalRequest = model.client.pendingAgentTaskApprovals()
+            detail = try await detailRequest
+            approvals = (try? await approvalRequest) ?? []
+            errorMessage = nil
+        } catch {
+            errorMessage = "작업 상태를 불러오지 못했습니다"
+        }
+    }
+
+    private func steer() async {
+        let value = steering.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return }
+        do {
+            try await model.client.steerAgentTask(id: taskId, message: value)
+            steering = ""
+        } catch {
+            errorMessage = "지시를 보내지 못했습니다"
+        }
+    }
+
+    private func cancel() async {
+        do {
+            try await model.client.cancelAgentTask(id: taskId)
+            await load()
+        } catch {
+            errorMessage = "작업을 취소하지 못했습니다"
+        }
+    }
+
+    private func resume() async {
+        do {
+            _ = try await model.client.resumeAgentTask(id: taskId)
+            await load()
+        } catch {
+            errorMessage = "작업을 이어서 시작하지 못했습니다"
+        }
+    }
+}
+
+private struct AgentTaskApprovalCard: View {
+    let approval: AgentTaskApproval
+    let onResolved: () async -> Void
+    @Environment(AppModel.self) private var model
+    @State private var answer = ""
+    @State private var isBusy = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label(
+                approval.toolName == "ask_human" ? "에이전트 질문" : "도구 실행 승인",
+                systemImage: approval.toolName == "ask_human" ? "questionmark.bubble" : "checkmark.shield")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Lumen.warn)
+            Text(approval.toolName)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(Lumen.muted)
+            if approval.toolName == "ask_human" {
+                TextField("에이전트에게 답변", text: $answer)
+                    .textFieldStyle(.roundedBorder)
+                HStack {
+                    Button("거절", role: .destructive) {
+                        Task { await decide(approve: false) }
+                    }
+                    Spacer()
+                    Button("답변 보내기") {
+                        Task { await sendAnswer() }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(answer.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isBusy)
+                }
+            } else {
+                HStack {
+                    Button("거절", role: .destructive) {
+                        Task { await decide(approve: false) }
+                    }
+                    Spacer()
+                    Button("이후 자동 승인") {
+                        Task { await autoApprove() }
+                    }
+                    Button("승인") {
+                        Task { await decide(approve: true) }
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .disabled(isBusy)
+            }
+        }
+        .padding(14)
+        .background(Lumen.surface, in: RoundedRectangle(cornerRadius: 14))
+        .overlay(RoundedRectangle(cornerRadius: 14).strokeBorder(Lumen.warn.opacity(0.5)))
+    }
+
+    private func decide(approve: Bool) async {
+        isBusy = true
+        defer { isBusy = false }
+        try? await model.client.resolveAgentTaskApproval(id: approval.id, approve: approve)
+        await onResolved()
+    }
+
+    private func sendAnswer() async {
+        let value = answer.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return }
+        isBusy = true
+        defer { isBusy = false }
+        try? await model.client.answerAgentTaskApproval(id: approval.id, text: value)
+        await onResolved()
+    }
+
+    private func autoApprove() async {
+        isBusy = true
+        defer { isBusy = false }
+        try? await model.client.autoApproveAgentTask(id: approval.taskId)
+        await onResolved()
+    }
+}

--- a/apps/ios/OpenMakeApp/Features/Artifacts/ArtifactViewer.swift
+++ b/apps/ios/OpenMakeApp/Features/Artifacts/ArtifactViewer.swift
@@ -1,0 +1,188 @@
+import SwiftUI
+import UIKit
+import WebKit
+import OpenMakeKit
+
+struct ArtifactDocument: Identifiable, Equatable {
+    let id: String
+    let kind: String
+    let title: String
+    let language: String?
+    let content: String
+    let isComplete: Bool
+
+    init(
+        id: String,
+        kind: String,
+        title: String,
+        language: String?,
+        content: String,
+        isComplete: Bool
+    ) {
+        self.id = id
+        self.kind = kind
+        self.title = title
+        self.language = language
+        self.content = content
+        self.isComplete = isComplete
+    }
+
+    init(streamed: ChatArtifact) {
+        self.init(
+            id: streamed.id,
+            kind: streamed.kind,
+            title: streamed.title,
+            language: streamed.language,
+            content: streamed.content,
+            isComplete: streamed.isComplete)
+    }
+
+    init(stored: SessionArtifact) {
+        self.init(
+            id: stored.id,
+            kind: stored.kind,
+            title: stored.title,
+            language: stored.language,
+            content: stored.content,
+            isComplete: true)
+    }
+}
+
+struct ArtifactCard: View {
+    let document: ArtifactDocument
+    let onOpen: () -> Void
+
+    var body: some View {
+        Button(action: onOpen) {
+            HStack(spacing: 12) {
+                Image(systemName: symbol)
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundStyle(Lumen.accent)
+                    .frame(width: 34, height: 34)
+                    .background(Lumen.accentSoft, in: RoundedRectangle(cornerRadius: 9))
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(document.title)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(Lumen.fg)
+                        .lineLimit(1)
+                    Text(document.language ?? document.kind.uppercased())
+                        .font(.caption2)
+                        .foregroundStyle(Lumen.muted)
+                }
+                Spacer(minLength: 8)
+                if document.isComplete {
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Lumen.faint)
+                } else {
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(Lumen.accent)
+                }
+            }
+            .padding(12)
+            .background(Lumen.surface, in: RoundedRectangle(cornerRadius: 12))
+            .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(Lumen.border))
+        }
+        .buttonStyle(.plain)
+        .disabled(!document.isComplete)
+        .accessibilityLabel("아티팩트 \(document.title)")
+        .accessibilityValue(document.isComplete ? "열기" : "생성 중")
+    }
+
+    private var symbol: String {
+        switch document.kind.lowercased() {
+        case "code", "react": "chevron.left.forwardslash.chevron.right"
+        case "html": "safari"
+        case "svg", "chart", "excalidraw": "chart.xyaxis.line"
+        case "csv": "tablecells"
+        case "slide": "rectangle.on.rectangle"
+        default: "doc.richtext"
+        }
+    }
+}
+
+struct ArtifactViewer: View {
+    let document: ArtifactDocument
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch document.kind.lowercased() {
+                case "markdown":
+                    ScrollView {
+                        MarkdownText(content: document.content)
+                            .padding(16)
+                    }
+                case "html", "svg":
+                    SafeArtifactWebView(document: document)
+                default:
+                    ScrollView {
+                        CodeBlockView(
+                            language: document.language ?? document.kind,
+                            code: document.content)
+                            .padding(16)
+                    }
+                }
+            }
+            .background(Lumen.bg)
+            .navigationTitle(document.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("완료") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+private struct SafeArtifactWebView: UIViewRepresentable {
+    let document: ArtifactDocument
+    @Environment(\.colorScheme) private var colorScheme
+
+    func makeUIView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.defaultWebpagePreferences.allowsContentJavaScript = false
+        return WKWebView(frame: .zero, configuration: configuration)
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        let source: String
+        if document.kind.lowercased() == "svg" {
+            source = "<main>\(document.content)</main>"
+        } else {
+            source = document.content
+        }
+        let traits = UITraitCollection(
+            userInterfaceStyle: colorScheme == .dark ? .dark : .light)
+        let foreground = UIColor(Lumen.fg).resolvedColor(with: traits).cssColor
+        let background = UIColor(Lumen.bg).resolvedColor(with: traits).cssColor
+        let html = """
+        <!doctype html><html><head>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:">
+        <style>body{font:16px -apple-system;margin:16px;color:\(foreground);background:\(background)}img,svg{max-width:100%;height:auto}</style>
+        </head><body>\(source)</body></html>
+        """
+        webView.isOpaque = false
+        webView.backgroundColor = UIColor(Lumen.bg).resolvedColor(with: traits)
+        webView.loadHTMLString(html, baseURL: nil)
+    }
+}
+
+private extension UIColor {
+    var cssColor: String {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        guard getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
+            return "rgba(0,0,0,1)"
+        }
+        return String(
+            format: "rgba(%d,%d,%d,%.3f)",
+            Int(red * 255), Int(green * 255), Int(blue * 255), alpha)
+    }
+}

--- a/apps/ios/OpenMakeApp/Features/Conversations/ChatSessionModel.swift
+++ b/apps/ios/OpenMakeApp/Features/Conversations/ChatSessionModel.swift
@@ -18,6 +18,9 @@ final class ChatSessionModel {
     private(set) var errorMessage: String?
     /// 도구/리서치/토론 진행 한 줄 (ChatStreamState.statusText)
     private(set) var statusText: String?
+    private(set) var activityKind: ChatActivityKind = .preparing
+    private(set) var artifacts: [ArtifactDocument] = []
+    private(set) var activeAgentTask: AgentTaskDetail?
 
     init(client: OpenMakeClient, serverURL: URL, sessionId: String?) {
         self.client = client
@@ -29,6 +32,7 @@ final class ChatSessionModel {
         guard let sessionId else { return }
         do {
             messages = try await client.messages(sessionId: sessionId)
+            artifacts = (try? await client.artifacts(sessionId: sessionId).map(ArtifactDocument.init(stored:))) ?? []
         } catch {
             errorMessage = "이력을 불러오지 못했습니다"
         }
@@ -46,8 +50,18 @@ final class ChatSessionModel {
         messages.append(.init(
             role: .user, content: text, model: nil, tokens: nil,
             images: images.isEmpty ? nil : images, created_at: nil))
+
+        if modes.agentTask {
+            await startAgentTask(goal: text, images: images, files: files)
+            return
+        }
+
         isStreaming = true
         defer { isStreaming = false }
+
+        var state = ChatStreamState()
+        state.begin()
+        apply(state)
 
         do {
             guard let bearer = await client.accessToken else {
@@ -82,12 +96,9 @@ final class ChatSessionModel {
                 style: modes.style == .styleDefault ? nil : modes.style,
                 userAgentId: userAgentId))
 
-            var state = ChatStreamState()
             for await event in events {
                 state.apply(event)
-                streamingText = state.streamingText
-                isThinking = state.isThinking
-                statusText = state.statusText
+                apply(state)
                 if let sid = state.sessionId { sessionId = sid }
                 if state.needsTokenRefresh {
                     // 웹과 동일 규약: REST refresh — 다음 재연결이 새 토큰 사용
@@ -100,6 +111,12 @@ final class ChatSessionModel {
                 errorMessage = error
             }
             finalizeAssistantMessage()
+            if modes.deepResearch, state.errorMessage == nil {
+                await NotificationManager.shared.schedule(
+                    title: "딥리서치 완료",
+                    body: "요청하신 조사 결과가 준비되었습니다",
+                    url: sessionId.map { "/chat/\($0)" })
+            }
         } catch {
             errorMessage = "연결에 실패했습니다"
             finalizeAssistantMessage()
@@ -107,10 +124,108 @@ final class ChatSessionModel {
     }
 
     func teardown() {
+        agentPollTask?.cancel()
         Task { [socket] in await socket.disconnect() }
     }
 
     private var currentEvents: AsyncStream<WsServerEvent>?
+    private var agentPollTask: Task<Void, Never>?
+
+    private func apply(_ state: ChatStreamState) {
+        streamingText = state.streamingText
+        isThinking = state.isThinking
+        statusText = state.statusText
+        activityKind = state.activityKind ?? .preparing
+        for artifact in state.artifacts {
+            let document = ArtifactDocument(streamed: artifact)
+            if let index = artifacts.firstIndex(where: { $0.id == document.id }) {
+                artifacts[index] = document
+            } else {
+                artifacts.append(document)
+            }
+        }
+    }
+
+    private func startAgentTask(
+        goal: String,
+        images: [String],
+        files: [WsAttachedFile]
+    ) async {
+        isStreaming = true
+        statusText = "에이전트 작업을 만들고 있어요"
+        activityKind = .agent
+        defer { isStreaming = false }
+        do {
+            let creation = try await client.createAgentTask(
+                goal: goal,
+                files: files,
+                images: images)
+            activeAgentTask = AgentTaskDetail(task: creation.task, steps: [])
+            let execution = try await client.executeAgentTask(id: creation.task.id)
+            await NotificationManager.shared.requestAuthorization()
+            statusText = execution.queued
+                ? "에이전트 작업이 실행 대기 중이에요"
+                : "에이전트가 첫 단계를 준비하고 있어요"
+            agentPollTask?.cancel()
+            agentPollTask = Task { [weak self] in
+                await self?.pollAgentTask(id: creation.task.id)
+            }
+        } catch let error as OpenMakeAPIError {
+            errorMessage = apiErrorText(error)
+            statusText = nil
+        } catch {
+            errorMessage = "에이전트 작업을 시작하지 못했습니다"
+            statusText = nil
+        }
+    }
+
+    private func pollAgentTask(id: String) async {
+        while !Task.isCancelled {
+            do {
+                let detail = try await client.agentTask(id: id)
+                activeAgentTask = detail
+                switch detail.task.status {
+                case .completed, .failed, .cancelled:
+                    statusText = nil
+                    await NotificationManager.shared.notifyAgentTaskFinished(detail.task)
+                    return
+                case .paused:
+                    statusText = "승인을 기다리고 있어요"
+                case .queued:
+                    statusText = "에이전트 작업이 실행 대기 중이에요"
+                case .pending, .running:
+                    if let latest = detail.steps.last?.content, !latest.isEmpty {
+                        statusText = oneLine(latest)
+                    } else {
+                        statusText = "에이전트가 \(max(detail.task.currentTurn, 1))번째 단계를 진행하고 있어요"
+                    }
+                }
+            } catch {
+                errorMessage = "에이전트 작업 상태를 불러오지 못했습니다"
+                return
+            }
+            do {
+                try await Task.sleep(for: .seconds(2))
+            } catch {
+                return
+            }
+        }
+    }
+
+    private func oneLine(_ value: String) -> String {
+        String(value
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+            .prefix(120))
+    }
+
+    private func apiErrorText(_ error: OpenMakeAPIError) -> String {
+        if case .server(_, _, let message) = error, let message, !message.isEmpty {
+            return message
+        }
+        return "에이전트 작업을 시작하지 못했습니다"
+    }
 
     private func finalizeAssistantMessage() {
         if !streamingText.isEmpty {

--- a/apps/ios/OpenMakeApp/Features/Conversations/ChatSessionModel.swift
+++ b/apps/ios/OpenMakeApp/Features/Conversations/ChatSessionModel.swift
@@ -19,6 +19,7 @@ final class ChatSessionModel {
     /// 도구/리서치/토론 진행 한 줄 (ChatStreamState.statusText)
     private(set) var statusText: String?
     private(set) var activityKind: ChatActivityKind = .preparing
+    private(set) var activeSkills: [String] = []
     private(set) var artifacts: [ArtifactDocument] = []
     private(set) var activeAgentTask: AgentTaskDetail?
 
@@ -47,6 +48,7 @@ final class ChatSessionModel {
         modes: AppModel.ChatModes = .init()
     ) async {
         errorMessage = nil
+        activeSkills = []
         messages.append(.init(
             role: .user, content: text, model: nil, tokens: nil,
             images: images.isEmpty ? nil : images, created_at: nil))
@@ -136,6 +138,7 @@ final class ChatSessionModel {
         isThinking = state.isThinking
         statusText = state.statusText
         activityKind = state.activityKind ?? .preparing
+        activeSkills = state.activeSkillNames
         for artifact in state.artifacts {
             let document = ArtifactDocument(streamed: artifact)
             if let index = artifacts.firstIndex(where: { $0.id == document.id }) {

--- a/apps/ios/OpenMakeApp/Features/Conversations/ConversationDetailView.swift
+++ b/apps/ios/OpenMakeApp/Features/Conversations/ConversationDetailView.swift
@@ -142,6 +142,8 @@ private struct ChatTranscriptView: View {
     @State private var pendingFiles: [WsAttachedFile] = []
     @State private var showFileImporter = false
     @State private var attachError: String?
+    @State private var selectedArtifact: ArtifactDocument?
+    @State private var selectedAgentTaskId: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -176,6 +178,17 @@ private struct ChatTranscriptView: View {
         .onChange(of: photoItems) {
             Task { await loadPhotos() }
         }
+        .sheet(item: $selectedArtifact) { artifact in
+            ArtifactViewer(document: artifact)
+        }
+        .navigationDestination(isPresented: Binding(
+            get: { selectedAgentTaskId != nil },
+            set: { if !$0 { selectedAgentTaskId = nil } }
+        )) {
+            if let selectedAgentTaskId {
+                AgentTaskDetailView(taskId: selectedAgentTaskId)
+            }
+        }
     }
 
     private var transcript: some View {
@@ -186,11 +199,24 @@ private struct ChatTranscriptView: View {
                         MessageRow(message: message)
                     }
 
-                    if let status = chat.statusText {
-                        StatusLine(text: status, color: Lumen.success)
+                    if let task = chat.activeAgentTask {
+                        AgentTaskCard(task: task.task, latestStep: task.steps.last) {
+                            selectedAgentTaskId = task.task.id
+                        }
                     }
-                    if chat.isThinking {
-                        StatusLine(text: "생각 중…", color: Lumen.warn)
+
+                    ForEach(chat.artifacts) { artifact in
+                        ArtifactCard(document: artifact) {
+                            selectedArtifact = artifact
+                        }
+                    }
+
+                    if chat.streamingText.isEmpty {
+                        if let status = chat.statusText {
+                            ActivityStatusLine(text: status, kind: chat.activityKind)
+                        } else if chat.isThinking {
+                            ActivityStatusLine(text: "답변을 생각하고 있어요", kind: .thinking)
+                        }
                     }
                     if !chat.streamingText.isEmpty {
                         VStack(alignment: .leading, spacing: 6) {
@@ -292,7 +318,7 @@ private struct MessageRow: View {
                 Spacer(minLength: 48)
                 VStack(alignment: .trailing, spacing: 4) {
                     if let images = message.images, !images.isEmpty {
-                        Text("🖼️ 사진 \(images.count)장")
+                        Label("사진 \(images.count)장", systemImage: "photo.on.rectangle")
                             .font(.caption2)
                             .foregroundStyle(Lumen.muted)
                     }
@@ -315,21 +341,6 @@ private struct MessageRow: View {
                 MarkdownText(content: message.content)
             }
         }
-    }
-}
-
-private struct StatusLine: View {
-    let text: String
-    var color: Color = Lumen.accent
-
-    var body: some View {
-        HStack(spacing: 7) {
-            LumenDot(color: color, size: 6, pulsing: true)
-            Text(text)
-                .font(.system(size: 12))
-                .foregroundStyle(Lumen.muted)
-        }
-        .transition(.opacity)
     }
 }
 
@@ -371,6 +382,7 @@ private struct ChatComposer: View {
                         Toggle("아티팩트", systemImage: "doc.richtext", isOn: $model.modes.artifact)
                         Toggle("토론", systemImage: "person.2.wave.2", isOn: $model.modes.discussion)
                         Toggle("딥리서치", systemImage: "magnifyingglass.circle", isOn: $model.modes.deepResearch)
+                        Toggle("에이전트 작업", systemImage: "wand.and.stars", isOn: $model.modes.agentTask)
                     }
                     Picker("응답 스타일", systemImage: "text.alignleft", selection: $model.modes.style) {
                         Text("간결").tag(Style.concise)
@@ -421,15 +433,7 @@ private struct ChatComposer: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 6) {
                     ForEach(labels, id: \.self) { label in
-                        HStack(spacing: 5) {
-                            LumenDot(size: 5)
-                            Text(label)
-                        }
-                        .font(.system(size: 11, weight: .semibold))
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 5)
-                        .background(Lumen.accentSoft, in: Capsule())
-                        .foregroundStyle(Lumen.accent)
+                        ModeChip(label: label, systemImage: modeSymbol(label))
                     }
                 }
                 .padding(.horizontal, 4)
@@ -443,10 +447,12 @@ private struct ChatComposer: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 8) {
                     if !pendingImages.isEmpty {
-                        chip(label: "🖼️ 사진 \(pendingImages.count)장") { pendingImages.removeAll() }
+                        chip(label: "사진 \(pendingImages.count)장", systemImage: "photo.on.rectangle") {
+                            pendingImages.removeAll()
+                        }
                     }
                     ForEach(pendingFiles, id: \.id) { file in
-                        chip(label: "📄 \(file.name)") {
+                        chip(label: file.name, systemImage: "doc") {
                             pendingFiles.removeAll { $0.id == file.id }
                         }
                     }
@@ -456,8 +462,9 @@ private struct ChatComposer: View {
         }
     }
 
-    private func chip(label: String, onRemove: @escaping () -> Void) -> some View {
+    private func chip(label: String, systemImage: String, onRemove: @escaping () -> Void) -> some View {
         HStack(spacing: 4) {
+            Image(systemName: systemImage).font(.caption)
             Text(label).font(.caption)
             Button(action: onRemove) {
                 Image(systemName: "xmark.circle.fill").font(.caption)
@@ -467,5 +474,18 @@ private struct ChatComposer: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
         .background(Lumen.surface2, in: Capsule())
+    }
+
+    private func modeSymbol(_ label: String) -> String? {
+        switch label {
+        case "웹 검색": "globe"
+        case "추론": "brain"
+        case "이미지": "photo.badge.plus"
+        case "아티팩트": "doc.richtext"
+        case "토론": "person.2.wave.2"
+        case "딥리서치": "magnifyingglass.circle"
+        case "에이전트 작업": "wand.and.stars"
+        default: nil
+        }
     }
 }

--- a/apps/ios/OpenMakeApp/Features/Conversations/ConversationDetailView.swift
+++ b/apps/ios/OpenMakeApp/Features/Conversations/ConversationDetailView.swift
@@ -157,6 +157,11 @@ private struct ChatTranscriptView: View {
                     .padding(.bottom, 4)
             }
 
+            if !chat.activeSkills.isEmpty {
+                ActiveSkillBar(skills: chat.activeSkills)
+                    .transition(.opacity)
+            }
+
             ChatComposer(
                 draft: $draft,
                 photoItems: $photoItems,

--- a/apps/ios/OpenMakeApp/Features/Conversations/ConversationListView.swift
+++ b/apps/ios/OpenMakeApp/Features/Conversations/ConversationListView.swift
@@ -4,11 +4,15 @@ import OpenMakeKit
 
 struct ConversationListView: View {
     @Environment(AppModel.self) private var model
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var sessions: [OpenMakeClient.SessionSummary] = []
     @State private var isLoading = false
     @State private var errorMessage: String?
     @State private var showNewChat = false
     @State private var showSettings = false
+    @State private var showDrawer = false
+    @State private var showAgentTasks = false
+    @State private var selectedSession: OpenMakeClient.SessionSummary?
     @State private var searchText = ""
     @State private var autoChatFired = false
 
@@ -81,8 +85,8 @@ struct ConversationListView: View {
                     Wordmark(size: 18)
                 }
                 ToolbarItem(placement: .topBarLeading) {
-                    Button("설정", systemImage: "gearshape") {
-                        showSettings = true
+                    Button("메뉴", systemImage: "line.3.horizontal") {
+                        setDrawerPresented(true)
                     }
                     .tint(Lumen.fg2)
                 }
@@ -94,6 +98,17 @@ struct ConversationListView: View {
             }
             .navigationDestination(isPresented: $showNewChat) {
                 ConversationDetailView(session: nil)
+            }
+            .navigationDestination(isPresented: $showAgentTasks) {
+                AgentTaskListView()
+            }
+            .navigationDestination(isPresented: Binding(
+                get: { selectedSession != nil },
+                set: { if !$0 { selectedSession = nil } }
+            )) {
+                if let selectedSession {
+                    ConversationDetailView(session: selectedSession)
+                }
             }
             .sheet(isPresented: $showSettings) {
                 SettingsSheet()
@@ -111,8 +126,81 @@ struct ConversationListView: View {
                 }
                 #endif
             }
+            .onReceive(NotificationCenter.default.publisher(for: .openMakeNotificationURL)) { notification in
+                guard let url = notification.object as? String else { return }
+                handleNotificationURL(url)
+            }
         }
         .tint(Lumen.accent)
+        .overlay {
+            if showDrawer {
+                LumenDrawer(
+                    sessions: sessions,
+                    email: accountEmail,
+                    onDismiss: { setDrawerPresented(false) },
+                    onNewChat: {
+                        showDrawer = false
+                        showNewChat = true
+                    },
+                    onAgentTasks: {
+                        showDrawer = false
+                        showAgentTasks = true
+                    },
+                    onDeepResearch: {
+                        model.modes.deepResearch = true
+                        model.modes.agentTask = false
+                        showDrawer = false
+                        showNewChat = true
+                    },
+                    onConversation: { session in
+                        showDrawer = false
+                        selectedSession = session
+                    },
+                    onSettings: {
+                        showDrawer = false
+                        showSettings = true
+                    })
+            }
+        }
+    }
+
+    private var accountEmail: String? {
+        if case .loggedIn(let user) = model.authState { return user.email }
+        return nil
+    }
+
+    private func setDrawerPresented(_ presented: Bool) {
+        if reduceMotion {
+            showDrawer = presented
+        } else {
+            withAnimation(.easeOut(duration: 0.2)) {
+                showDrawer = presented
+            }
+        }
+    }
+
+    private func handleNotificationURL(_ url: String) {
+        showDrawer = false
+        if url.hasPrefix("/agent-tasks") {
+            selectedSession = nil
+            showNewChat = false
+            showAgentTasks = true
+            return
+        }
+        let chatPrefix = "/chat/"
+        guard url.hasPrefix(chatPrefix) else { return }
+        let sessionId = String(url.dropFirst(chatPrefix.count))
+        guard !sessionId.isEmpty else { return }
+        showAgentTasks = false
+        showNewChat = false
+        if let session = sessions.first(where: { $0.id == sessionId }) {
+            selectedSession = session
+            return
+        }
+        Task {
+            await load()
+            selectedSession = sessions.first { $0.id == sessionId }
+        }
     }
 
     /// "local-llm:qwen3.6-35b-a3b" → "qwen3.6-35b-a3b" (provider prefix 제거)

--- a/apps/ios/OpenMakeApp/Features/Conversations/MarkdownText.swift
+++ b/apps/ios/OpenMakeApp/Features/Conversations/MarkdownText.swift
@@ -1,42 +1,54 @@
 // 마크다운 렌더러 — 서드파티 0 원칙: 코드펜스는 수동 분리, 인라인은 AttributedString(markdown:)
 import SwiftUI
 import UIKit
+import OpenMakeKit
 
 struct MarkdownText: View {
     let content: String
 
-    private enum Segment {
+    private enum BlockSegment {
         case text(String)
         case code(language: String?, body: String)
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
+            ForEach(Array(MarkdownContentParser.segments(in: content).enumerated()), id: \.offset) { _, segment in
                 switch segment {
                 case .text(let text):
-                    Text(inlineAttributed(text))
-                        .font(.system(size: 15))
-                        .lineSpacing(3)
-                        .foregroundStyle(Lumen.fg)
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                case .code(let language, let body):
-                    CodeBlockView(language: language, code: body)
+                    textBlocks(text)
+                case .image(let alt, let source):
+                    GeneratedImageView(alt: alt, source: source)
                 }
             }
         }
     }
 
-    /// ``` 펜스 기준 텍스트/코드 분리
-    private var segments: [Segment] {
-        var result: [Segment] = []
+    @ViewBuilder
+    private func textBlocks(_ text: String) -> some View {
+        ForEach(Array(blocks(in: text).enumerated()), id: \.offset) { _, segment in
+            switch segment {
+            case .text(let text):
+                Text(inlineAttributed(text))
+                    .font(.system(size: 15))
+                    .lineSpacing(3)
+                    .foregroundStyle(Lumen.fg)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            case .code(let language, let body):
+                CodeBlockView(language: language, code: body)
+            }
+        }
+    }
+
+    private func blocks(in text: String) -> [BlockSegment] {
+        var result: [BlockSegment] = []
         var currentText: [String] = []
         var codeLines: [String] = []
         var codeLanguage: String?
         var inCode = false
 
-        for line in content.components(separatedBy: "\n") {
+        for line in text.components(separatedBy: "\n") {
             if line.hasPrefix("```") {
                 if inCode {
                     result.append(.code(language: codeLanguage, body: codeLines.joined(separator: "\n")))
@@ -75,6 +87,43 @@ struct MarkdownText: View {
     }
 }
 
+private struct GeneratedImageView: View {
+    let alt: String
+    let source: String
+
+    var body: some View {
+        AsyncImage(url: imageURL) { phase in
+            switch phase {
+            case .empty:
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Lumen.surface2)
+                    .aspectRatio(4 / 3, contentMode: .fit)
+                    .overlay { ProgressView().tint(Lumen.accent) }
+            case .success(let image):
+                image
+                    .resizable()
+                    .scaledToFit()
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(Lumen.border))
+            case .failure:
+                ContentUnavailableView(
+                    "이미지를 불러오지 못했습니다",
+                    systemImage: "photo.badge.exclamationmark",
+                    description: Text(source))
+                    .frame(minHeight: 160)
+                    .background(Lumen.surface2, in: RoundedRectangle(cornerRadius: 12))
+            @unknown default:
+                EmptyView()
+            }
+        }
+        .accessibilityLabel(alt.isEmpty ? "생성된 이미지" : alt)
+    }
+
+    private var imageURL: URL? {
+        GeneratedImageURLResolver.resolve(source: source, serverURL: AppConfig.serverURL)
+    }
+}
+
 struct CodeBlockView: View {
     let language: String?
     let code: String
@@ -92,10 +141,11 @@ struct CodeBlockView: View {
                     Image(systemName: "doc.on.doc")
                         .font(.caption2)
                         .foregroundStyle(Lumen.muted)
+                        .frame(width: 44, height: 44)
                 }
+                .accessibilityLabel("코드 복사")
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
+            .padding(.leading, 12)
             .background(Lumen.surface2)
 
             ScrollView(.horizontal, showsIndicators: false) {

--- a/apps/ios/OpenMakeApp/Features/Settings/SettingsSheet.swift
+++ b/apps/ios/OpenMakeApp/Features/Settings/SettingsSheet.swift
@@ -5,6 +5,7 @@ import OpenMakeKit
 struct SettingsSheet: View {
     @Environment(AppModel.self) private var model
     @Environment(\.dismiss) private var dismiss
+    @State private var notifications = NotificationManager.shared
 
     var body: some View {
         @Bindable var model = model
@@ -33,6 +34,27 @@ struct SettingsSheet: View {
                     }
                 }
 
+                Section("알림") {
+                    LabeledContent("상태", value: notifications.statusText)
+                    Button(notifications.authorizationStatus == .notDetermined ? "알림 허용" : "알림 권한 다시 확인") {
+                        Task { await notifications.requestAuthorization() }
+                    }
+                    if notifications.authorizationStatus == .authorized {
+                        Button("테스트 알림 보내기") {
+                            Task {
+                                await notifications.schedule(
+                                    title: "OpenMake 알림",
+                                    body: "에이전트 작업과 딥리서치 완료를 알려드릴게요")
+                            }
+                        }
+                    }
+                    if !notifications.remotePushEnabled {
+                        Text("현재 서명은 로컬 알림 모드입니다. Apple Push capability를 활성화하면 원격 푸시 등록을 켤 수 있습니다.")
+                            .font(.footnote)
+                            .foregroundStyle(Lumen.muted)
+                    }
+                }
+
                 Section {
                     Button("로그아웃", role: .destructive) {
                         Task {
@@ -53,6 +75,7 @@ struct SettingsSheet: View {
                     Button("완료") { dismiss() }
                 }
             }
+            .task { await notifications.refreshStatus() }
         }
     }
 

--- a/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/ChatStreamState.swift
+++ b/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/ChatStreamState.swift
@@ -8,6 +8,42 @@ public struct ChatStreamMetrics: Equatable, Sendable {
     public let tokensPerSec: String
 }
 
+public enum ChatActivityKind: Equatable, Sendable {
+    case preparing
+    case thinking
+    case agent
+    case tool
+    case research
+    case artifact
+    case finalizing
+}
+
+public struct ChatArtifact: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let kind: String
+    public let title: String
+    public let language: String?
+    public private(set) var content: String
+    public private(set) var isComplete: Bool
+
+    init(meta: ArtifactMeta) {
+        id = meta.id
+        kind = meta.kind
+        title = meta.title
+        language = meta.lang
+        content = ""
+        isComplete = false
+    }
+
+    mutating func append(_ delta: String) {
+        content += delta
+    }
+
+    mutating func complete() {
+        isComplete = true
+    }
+}
+
 public struct ChatStreamState: Sendable {
     public private(set) var streamingText = ""
     public private(set) var isThinking = false
@@ -19,48 +55,122 @@ public struct ChatStreamState: Sendable {
     public private(set) var needsTokenRefresh = false
     /// 진행 상태 한 줄 (도구 실행·리서치/토론 진행 등) — token 수신 시 자동 해제
     public private(set) var statusText: String?
+    public private(set) var activityKind: ChatActivityKind?
+    public private(set) var artifacts: [ChatArtifact] = []
 
     public init() {}
+
+    public mutating func begin() {
+        statusText = "요청을 분석하고 있어요"
+        activityKind = .preparing
+    }
 
     public mutating func apply(_ event: WsServerEvent) {
         switch event.type {
         case .token:
             isThinking = false
             statusText = nil
+            activityKind = nil
             streamingText += event.token ?? ""
         case .thinking:
             isThinking = true
+            setActivity("답변을 생각하고 있어요", kind: .thinking)
+        case .thinkingSummary:
+            isThinking = true
+            setActivity(event.summary ?? event.message ?? "생각을 정리하고 있어요", kind: .thinking)
+        case .agentSelected:
+            let name = event.agent?.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let name, !name.isEmpty {
+                setActivity("\(name) 에이전트가 작업을 준비하고 있어요", kind: .agent)
+            } else {
+                setActivity("에이전트가 작업을 준비하고 있어요", kind: .agent)
+            }
+        case .skillsActivated:
+            setActivity("필요한 기능을 준비하고 있어요", kind: .agent)
+        case .agentTaskProgress:
+            if let preview = event.step?.preview, !preview.isEmpty {
+                setActivity(preview, kind: .agent)
+            } else if let currentTurn = event.currentTurn {
+                setActivity("에이전트가 \(Int(currentTurn))번째 단계를 진행하고 있어요", kind: .agent)
+            } else {
+                setActivity(event.message ?? "에이전트가 작업을 진행하고 있어요", kind: .agent)
+            }
         case .mcpToolStart:
-            statusText = event.toolName.map { "도구 실행 중 · \($0)" } ?? "도구 실행 중…"
+            setActivity(toolActivity(event.toolName), kind: .tool)
         case .mcpToolResult:
-            statusText = nil
+            setActivity("도구 결과를 검토하고 있어요", kind: .finalizing)
         case .researchProgress:
-            statusText = event.message ?? "딥리서치 진행 중…"
+            setActivity(event.message ?? "딥리서치를 진행하고 있어요", kind: .research)
         case .discussionProgress:
-            statusText = event.message ?? "토론 진행 중…"
+            setActivity(event.message ?? "에이전트 토론을 진행하고 있어요", kind: .agent)
         case .artifactStart:
-            statusText = "아티팩트 생성 중…"
+            if let meta = event.artifact {
+                artifacts.removeAll { $0.id == meta.id }
+                artifacts.append(ChatArtifact(meta: meta))
+            }
+            setActivity("아티팩트를 만들고 있어요", kind: .artifact)
+        case .artifactChunk:
+            guard let id = event.id,
+                  let index = artifacts.firstIndex(where: { $0.id == id }) else { break }
+            artifacts[index].append(event.delta ?? "")
         case .artifactEnd:
-            statusText = nil
+            if let id = event.id,
+               let index = artifacts.firstIndex(where: { $0.id == id }) {
+                artifacts[index].complete()
+            }
+            setActivity("답변을 정리하고 있어요", kind: .finalizing)
         case .sessionCreated:
             sessionId = event.sessionID
         case .done:
+            if let cleanedContent = event.cleanedContent {
+                streamingText = cleanedContent
+            }
             isDone = true
             isThinking = false
+            statusText = nil
+            activityKind = nil
             if let raw = event.metrics {
                 metrics = ChatStreamMetrics(tokenCount: raw.tokenCount, tokensPerSec: raw.tokensPerSEC)
             }
         case .aborted:
             isDone = true
             isThinking = false
+            statusText = nil
+            activityKind = nil
         case .error:
             errorMessage = event.message ?? event.errorType ?? "오류가 발생했습니다"
             isDone = true
             isThinking = false
+            statusText = nil
+            activityKind = nil
         case .tokenWarning:
             needsTokenRefresh = true
         default:
-            break // build_id·debug_retained·agent_selected 등 — MVP 범위 밖, 무시
+            break
         }
+    }
+
+    private mutating func setActivity(_ text: String, kind: ChatActivityKind) {
+        let oneLine = text
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        statusText = oneLine.isEmpty ? nil : String(oneLine.prefix(120))
+        activityKind = statusText == nil ? nil : kind
+    }
+
+    private func toolActivity(_ toolName: String?) -> String {
+        guard let toolName, !toolName.isEmpty else { return "도구를 사용하고 있어요" }
+        let lowered = toolName.lowercased()
+        if lowered.contains("search") || lowered.contains("browse") || lowered.contains("fetch") {
+            return "웹에서 자료를 찾고 있어요"
+        }
+        if lowered.contains("read") || lowered.contains("open") {
+            return "자료를 읽고 있어요"
+        }
+        if lowered.contains("write") || lowered.contains("edit") || lowered.contains("patch") {
+            return "결과물을 작성하고 있어요"
+        }
+        return "\(toolName) 도구를 사용하고 있어요"
     }
 }

--- a/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/ChatStreamState.swift
+++ b/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/ChatStreamState.swift
@@ -56,11 +56,13 @@ public struct ChatStreamState: Sendable {
     /// 진행 상태 한 줄 (도구 실행·리서치/토론 진행 등) — token 수신 시 자동 해제
     public private(set) var statusText: String?
     public private(set) var activityKind: ChatActivityKind?
+    public private(set) var activeSkillNames: [String] = []
     public private(set) var artifacts: [ChatArtifact] = []
 
     public init() {}
 
     public mutating func begin() {
+        activeSkillNames = []
         statusText = "요청을 분석하고 있어요"
         activityKind = .preparing
     }
@@ -86,7 +88,12 @@ public struct ChatStreamState: Sendable {
                 setActivity("에이전트가 작업을 준비하고 있어요", kind: .agent)
             }
         case .skillsActivated:
-            setActivity("필요한 기능을 준비하고 있어요", kind: .agent)
+            activeSkillNames = normalizedSkillNames(event.skillNames ?? [])
+            if activeSkillNames.isEmpty {
+                setActivity("필요한 기능을 준비하고 있어요", kind: .agent)
+            } else {
+                setActivity("\(activeSkillNames.joined(separator: ", ")) 적용 중", kind: .agent)
+            }
         case .agentTaskProgress:
             if let preview = event.step?.preview, !preview.isEmpty {
                 setActivity(preview, kind: .agent)
@@ -172,5 +179,14 @@ public struct ChatStreamState: Sendable {
             return "결과물을 작성하고 있어요"
         }
         return "\(toolName) 도구를 사용하고 있어요"
+    }
+
+    private func normalizedSkillNames(_ names: [String]) -> [String] {
+        var seen = Set<String>()
+        return names.compactMap { name in
+            let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, seen.insert(trimmed).inserted else { return nil }
+            return trimmed
+        }
     }
 }

--- a/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/MarkdownContentParser.swift
+++ b/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/MarkdownContentParser.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+public enum MarkdownContentSegment: Equatable, Sendable {
+    case text(String)
+    case image(alt: String, source: String)
+}
+
+public enum MarkdownContentParser {
+    public static func segments(in content: String) -> [MarkdownContentSegment] {
+        let pattern = #"!\[([^\]]*)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)"#
+        guard let expression = try? NSRegularExpression(pattern: pattern) else {
+            return [.text(content)]
+        }
+        let matches = expression.matches(
+            in: content,
+            range: NSRange(content.startIndex..<content.endIndex, in: content))
+        guard !matches.isEmpty else { return [.text(content)] }
+
+        var result: [MarkdownContentSegment] = []
+        var cursor = content.startIndex
+        for match in matches {
+            guard let whole = Range(match.range(at: 0), in: content),
+                  let alt = Range(match.range(at: 1), in: content),
+                  let source = Range(match.range(at: 2), in: content) else { continue }
+            if cursor < whole.lowerBound {
+                result.append(.text(String(content[cursor..<whole.lowerBound])))
+            }
+            result.append(.image(
+                alt: String(content[alt]),
+                source: String(content[source])))
+            cursor = whole.upperBound
+        }
+        if cursor < content.endIndex {
+            result.append(.text(String(content[cursor...])))
+        }
+        return result.isEmpty ? [.text(content)] : result
+    }
+}
+
+public enum GeneratedImageURLResolver {
+    public static func resolve(source: String, serverURL: URL) -> URL? {
+        guard let resolved = URL(string: source, relativeTo: serverURL)?.absoluteURL,
+              resolved.scheme?.lowercased() == serverURL.scheme?.lowercased(),
+              resolved.host?.lowercased() == serverURL.host?.lowercased(),
+              resolved.port == serverURL.port,
+              resolved.path.hasPrefix("/generated/") else { return nil }
+        return resolved
+    }
+}

--- a/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/OpenMakeClient+AgentTasks.swift
+++ b/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/OpenMakeClient+AgentTasks.swift
@@ -1,0 +1,323 @@
+import Foundation
+
+public enum AgentTaskStatus: String, Codable, Sendable, CaseIterable {
+    case pending
+    case queued
+    case running
+    case paused
+    case completed
+    case failed
+    case cancelled
+}
+
+public enum AgentTaskApprovalPolicy: String, Codable, Sendable, CaseIterable {
+    case all
+    case highRisk = "high-risk"
+    case none
+}
+
+public struct AgentTask: Codable, Identifiable, Sendable, Equatable {
+    public let id: String
+    public let goal: String
+    public let status: AgentTaskStatus
+    public let progress: Double
+    public let currentTurn: Int
+    public let maxTurns: Int
+    public let model: String?
+    public let result: String?
+    public let error: String?
+    public let executor: String?
+    public let totalTokens: Int?
+    public let gitPrURL: String?
+    public let gitPushedBranch: String?
+    public let resumable: Bool
+    public let createdAt: Date
+    public let updatedAt: Date
+    public let completedAt: Date?
+
+    public init(
+        id: String,
+        goal: String,
+        status: AgentTaskStatus,
+        progress: Double,
+        currentTurn: Int,
+        maxTurns: Int,
+        model: String? = nil,
+        result: String? = nil,
+        error: String? = nil,
+        executor: String? = nil,
+        totalTokens: Int? = nil,
+        gitPrURL: String? = nil,
+        gitPushedBranch: String? = nil,
+        resumable: Bool = false,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        completedAt: Date? = nil
+    ) {
+        self.id = id
+        self.goal = goal
+        self.status = status
+        self.progress = progress
+        self.currentTurn = currentTurn
+        self.maxTurns = maxTurns
+        self.model = model
+        self.result = result
+        self.error = error
+        self.executor = executor
+        self.totalTokens = totalTokens
+        self.gitPrURL = gitPrURL
+        self.gitPushedBranch = gitPushedBranch
+        self.resumable = resumable
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.completedAt = completedAt
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case goal
+        case status
+        case progress
+        case currentTurn = "current_turn"
+        case maxTurns = "max_turns"
+        case model
+        case result
+        case error
+        case executor
+        case totalTokens = "total_tokens"
+        case gitPrURL = "git_pr_url"
+        case gitPushedBranch = "git_pushed_branch"
+        case resumable
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+        case completedAt = "completed_at"
+    }
+}
+
+public struct AgentTaskStep: Codable, Identifiable, Sendable, Equatable {
+    public let id: Int
+    public let taskId: String
+    public let stepNumber: Int
+    public let stepType: String
+    public let toolName: String?
+    public let content: String?
+    public let status: String
+    public let createdAt: Date
+
+    public init(
+        id: Int,
+        taskId: String,
+        stepNumber: Int,
+        stepType: String,
+        toolName: String? = nil,
+        content: String? = nil,
+        status: String,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.taskId = taskId
+        self.stepNumber = stepNumber
+        self.stepType = stepType
+        self.toolName = toolName
+        self.content = content
+        self.status = status
+        self.createdAt = createdAt
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case taskId = "task_id"
+        case stepNumber = "step_number"
+        case stepType = "step_type"
+        case toolName = "tool_name"
+        case content
+        case status
+        case createdAt = "created_at"
+    }
+}
+
+public struct AgentTaskDetail: Sendable, Equatable {
+    public let task: AgentTask
+    public let steps: [AgentTaskStep]
+
+    public init(task: AgentTask, steps: [AgentTaskStep]) {
+        self.task = task
+        self.steps = steps
+    }
+}
+
+public struct AgentTaskCreation: Sendable, Equatable {
+    public let task: AgentTask
+    public let concurrentActive: Int
+    public let warnings: [String]
+}
+
+public struct AgentTaskExecution: Sendable, Equatable {
+    public let taskId: String
+    public let message: String
+    public let queued: Bool
+}
+
+public struct AgentTaskApproval: Decodable, Identifiable, Sendable, Equatable {
+    public let id: String
+    public let taskId: String
+    public let toolName: String
+
+    enum CodingKeys: String, CodingKey {
+        case id = "approvalId"
+        case taskId
+        case toolName
+    }
+}
+
+public extension OpenMakeClient {
+    func agentTasks() async throws -> [AgentTask] {
+        struct Payload: Decodable {
+            let tasks: [AgentTask]
+        }
+        struct Envelope: Decodable {
+            let data: Payload
+        }
+        let (data, _) = try await authorizedSend(method: "GET", path: "/api/agent-tasks")
+        return try decodeContract(Envelope.self, from: data).data.tasks
+    }
+
+    func agentTask(id: String) async throws -> AgentTaskDetail {
+        struct Payload: Decodable {
+            let task: AgentTask
+            let steps: [AgentTaskStep]
+        }
+        struct Envelope: Decodable {
+            let data: Payload
+        }
+        let (data, _) = try await authorizedSend(method: "GET", path: "/api/agent-tasks/\(id)")
+        let payload = try decodeContract(Envelope.self, from: data).data
+        return AgentTaskDetail(task: payload.task, steps: payload.steps)
+    }
+
+    func createAgentTask(
+        goal: String,
+        maxTurns: Int? = nil,
+        files: [WsAttachedFile] = [],
+        images: [String] = []
+    ) async throws -> AgentTaskCreation {
+        struct Request: Encodable {
+            let goal: String
+            let maxTurns: Int?
+            let files: [WsAttachedFile]?
+            let images: [String]?
+        }
+        struct Payload: Decodable {
+            let task: AgentTask
+            let concurrentActive: Int
+            let warnings: [String]
+        }
+        struct Envelope: Decodable {
+            let data: Payload
+        }
+        let request = Request(
+            goal: goal,
+            maxTurns: maxTurns,
+            files: files.isEmpty ? nil : files,
+            images: images.isEmpty ? nil : images)
+        let (data, _) = try await authorizedSend(
+            method: "POST", path: "/api/agent-tasks", body: request)
+        let payload = try decodeContract(Envelope.self, from: data).data
+        return AgentTaskCreation(
+            task: payload.task,
+            concurrentActive: payload.concurrentActive,
+            warnings: payload.warnings)
+    }
+
+    func executeAgentTask(
+        id: String,
+        approvalPolicy: AgentTaskApprovalPolicy = .highRisk
+    ) async throws -> AgentTaskExecution {
+        struct Request: Encodable {
+            let approvalPolicy: AgentTaskApprovalPolicy
+        }
+        return try await taskExecution(
+            path: "/api/agent-tasks/\(id)/execute",
+            body: Request(approvalPolicy: approvalPolicy))
+    }
+
+    func resumeAgentTask(id: String) async throws -> AgentTaskExecution {
+        struct Empty: Encodable {}
+        return try await taskExecution(path: "/api/agent-tasks/\(id)/resume", body: Empty())
+    }
+
+    func cancelAgentTask(id: String) async throws {
+        struct Empty: Encodable {}
+        _ = try await authorizedSend(
+            method: "POST", path: "/api/agent-tasks/\(id)/cancel", body: Empty())
+    }
+
+    func steerAgentTask(id: String, message: String) async throws {
+        struct Request: Encodable {
+            let message: String
+        }
+        _ = try await authorizedSend(
+            method: "POST", path: "/api/agent-tasks/\(id)/steer", body: Request(message: message))
+    }
+
+    func pendingAgentTaskApprovals() async throws -> [AgentTaskApproval] {
+        struct Payload: Decodable {
+            let pending: [AgentTaskApproval]
+        }
+        struct Envelope: Decodable {
+            let data: Payload
+        }
+        let (data, _) = try await authorizedSend(
+            method: "GET", path: "/api/agent-tasks/approvals/pending")
+        return try decodeContract(Envelope.self, from: data).data.pending
+    }
+
+    func resolveAgentTaskApproval(id: String, approve: Bool) async throws {
+        struct Empty: Encodable {}
+        let decision = approve ? "approve" : "reject"
+        _ = try await authorizedSend(
+            method: "POST",
+            path: "/api/agent-tasks/approvals/\(id)/\(decision)",
+            body: Empty())
+    }
+
+    func answerAgentTaskApproval(id: String, text: String) async throws {
+        struct Request: Encodable {
+            let text: String
+        }
+        _ = try await authorizedSend(
+            method: "POST",
+            path: "/api/agent-tasks/approvals/\(id)/answer",
+            body: Request(text: text))
+    }
+
+    func autoApproveAgentTask(id: String) async throws {
+        struct Request: Encodable {
+            let enabled: Bool
+        }
+        _ = try await authorizedSend(
+            method: "POST",
+            path: "/api/agent-tasks/\(id)/approvals/auto-approve",
+            body: Request(enabled: true))
+    }
+
+    private func taskExecution(
+        path: String,
+        body: any Encodable
+    ) async throws -> AgentTaskExecution {
+        struct Payload: Decodable {
+            let message: String
+            let taskId: String
+            let queued: Bool
+        }
+        struct Envelope: Decodable {
+            let data: Payload
+        }
+        let (data, _) = try await authorizedSend(method: "POST", path: path, body: body)
+        let payload = try decodeContract(Envelope.self, from: data).data
+        return AgentTaskExecution(
+            taskId: payload.taskId,
+            message: payload.message,
+            queued: payload.queued)
+    }
+}

--- a/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/OpenMakeClient+Artifacts.swift
+++ b/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/OpenMakeClient+Artifacts.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public struct SessionArtifact: Codable, Identifiable, Sendable, Equatable {
+    public let id: String
+    public let version: Int
+    public let sessionId: String
+    public let messageId: String?
+    public let kind: String
+    public let title: String
+    public let language: String?
+    public let content: String
+    public let createdAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id = "artifact_id"
+        case version
+        case sessionId = "session_id"
+        case messageId = "message_id"
+        case kind
+        case title
+        case language
+        case content
+        case createdAt = "created_at"
+    }
+}
+
+public extension OpenMakeClient {
+    func artifacts(sessionId: String) async throws -> [SessionArtifact] {
+        struct Payload: Decodable {
+            let artifacts: [SessionArtifact]
+        }
+        struct Envelope: Decodable {
+            let data: Payload
+        }
+        let path = "/api/sessions/\(sessionId)/artifacts"
+        let (data, _) = try await authorizedSend(method: "GET", path: path)
+        return try decodeContract(Envelope.self, from: data).data.artifacts
+    }
+}

--- a/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/OpenMakeClient+Push.swift
+++ b/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/OpenMakeClient+Push.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+public enum NativePushEnvironment: String, Codable, Sendable {
+    case development
+    case production
+}
+
+public extension OpenMakeClient {
+    func registerNativePushToken(
+        _ deviceToken: String,
+        environment: NativePushEnvironment,
+        bundleId: String
+    ) async throws {
+        struct Request: Encodable {
+            let deviceToken: String
+            let environment: NativePushEnvironment
+            let bundleId: String
+        }
+        _ = try await authorizedSend(
+            method: "POST",
+            path: "/api/push/native/subscribe",
+            body: Request(
+                deviceToken: deviceToken,
+                environment: environment,
+                bundleId: bundleId))
+    }
+
+    func unregisterNativePushToken(_ deviceToken: String) async throws {
+        struct Request: Encodable {
+            let deviceToken: String
+        }
+        _ = try await authorizedSend(
+            method: "POST",
+            path: "/api/push/native/unsubscribe",
+            body: Request(deviceToken: deviceToken))
+    }
+}

--- a/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/ChatStreamStateTests.swift
+++ b/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/ChatStreamStateTests.swift
@@ -74,6 +74,23 @@ final class ChatStreamStateTests: XCTestCase {
         XCTAssertEqual(state.activityKind, .research)
     }
 
+    func testActivatedSkillsAreVisibleUntilNextQuestion() {
+        var state = ChatStreamState()
+        state.begin()
+        state.apply(event(#"{"type":"skills_activated","skillNames":[" web-search ","report","web-search",""]}"#))
+
+        XCTAssertEqual(state.activeSkillNames, ["web-search", "report"])
+        XCTAssertEqual(state.statusText, "web-search, report 적용 중")
+        XCTAssertEqual(state.activityKind, .agent)
+
+        state.apply(event(#"{"type":"token","token":"결과"}"#))
+        XCTAssertNil(state.statusText)
+        XCTAssertEqual(state.activeSkillNames, ["web-search", "report"])
+
+        state.begin()
+        XCTAssertTrue(state.activeSkillNames.isEmpty)
+    }
+
     func testAgentTaskProgressUsesStepPreviewWithoutMultilineOutput() {
         var state = ChatStreamState()
         state.apply(event(#"{"type":"agent_task_progress","taskId":"task-1","currentTurn":2,"status":"running","step":{"stepType":"tool_result","toolName":"web_search","preview":"공식 문서를\n확인했어요"}}"#))

--- a/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/ChatStreamStateTests.swift
+++ b/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/ChatStreamStateTests.swift
@@ -9,8 +9,11 @@ final class ChatStreamStateTests: XCTestCase {
 
     func testTokenAccumulationEndsThinking() {
         var state = ChatStreamState()
+        state.begin()
+        XCTAssertEqual(state.statusText, "요청을 분석하고 있어요")
         state.apply(event(#"{"type":"thinking","token":"…"}"#))
         XCTAssertTrue(state.isThinking)
+        XCTAssertEqual(state.statusText, "답변을 생각하고 있어요")
         state.apply(event(#"{"type":"token","token":"안녕"}"#))
         state.apply(event(#"{"type":"token","token":"하세요"}"#))
         XCTAssertEqual(state.streamingText, "안녕하세요")
@@ -25,8 +28,11 @@ final class ChatStreamStateTests: XCTestCase {
 
     func testDoneCarriesMetrics() {
         var state = ChatStreamState()
-        state.apply(event(#"{"type":"done","messageId":"m1","metrics":{"tokenCount":42,"tokensPerSec":"12.50"}}"#))
+        state.begin()
+        state.apply(event(#"{"type":"done","messageId":"m1","cleanedContent":"정리된 답변","metrics":{"tokenCount":42,"tokensPerSec":"12.50"}}"#))
         XCTAssertTrue(state.isDone)
+        XCTAssertEqual(state.streamingText, "정리된 답변")
+        XCTAssertNil(state.statusText)
         XCTAssertEqual(state.metrics, ChatStreamMetrics(tokenCount: 42, tokensPerSec: "12.50"))
     }
 
@@ -53,8 +59,38 @@ final class ChatStreamStateTests: XCTestCase {
     func testIrrelevantEventsAreNoops() {
         var state = ChatStreamState()
         state.apply(event(#"{"type":"build_id","buildId":"b1"}"#))
-        state.apply(event(#"{"type":"skills_activated","skillNames":["a"]}"#))
         XCTAssertEqual(state.streamingText, "")
         XCTAssertFalse(state.isDone)
+    }
+
+    func testAgentAndResearchEventsExposeOneSafeActivityLine() {
+        var state = ChatStreamState()
+        state.apply(event(#"{"type":"agent_selected","agent":{"name":"Researcher","type":"researcher"}}"#))
+        XCTAssertEqual(state.statusText, "Researcher 에이전트가 작업을 준비하고 있어요")
+        XCTAssertEqual(state.activityKind, .agent)
+
+        state.apply(event(#"{"type":"research_progress","message":"자료를 찾는 중\n  2 / 5"}"#))
+        XCTAssertEqual(state.statusText, "자료를 찾는 중 2 / 5")
+        XCTAssertEqual(state.activityKind, .research)
+    }
+
+    func testAgentTaskProgressUsesStepPreviewWithoutMultilineOutput() {
+        var state = ChatStreamState()
+        state.apply(event(#"{"type":"agent_task_progress","taskId":"task-1","currentTurn":2,"status":"running","step":{"stepType":"tool_result","toolName":"web_search","preview":"공식 문서를\n확인했어요"}}"#))
+        XCTAssertEqual(state.statusText, "공식 문서를 확인했어요")
+        XCTAssertEqual(state.activityKind, .agent)
+    }
+
+    func testArtifactLifecycleAccumulatesContent() {
+        var state = ChatStreamState()
+        state.apply(event(#"{"type":"artifact_start","artifact":{"id":"a1","kind":"code","lang":"swift","title":"Sample.swift"}}"#))
+        state.apply(event(#"{"type":"artifact_chunk","id":"a1","delta":"let answer = "}"#))
+        state.apply(event(#"{"type":"artifact_chunk","id":"a1","delta":"42"}"#))
+        XCTAssertEqual(state.artifacts.first?.content, "let answer = 42")
+        XCTAssertFalse(state.artifacts.first?.isComplete ?? true)
+
+        state.apply(event(#"{"type":"artifact_end","id":"a1"}"#))
+        XCTAssertTrue(state.artifacts.first?.isComplete ?? false)
+        XCTAssertEqual(state.statusText, "답변을 정리하고 있어요")
     }
 }

--- a/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/MarkdownContentTests.swift
+++ b/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/MarkdownContentTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import OpenMakeKit
+
+final class MarkdownContentTests: XCTestCase {
+    func testParserSeparatesGeneratedImageFromSurroundingMarkdown() {
+        let segments = MarkdownContentParser.segments(
+            in: "요청하신 이미지입니다.\n\n![푸른 산](/generated/mountain.png)\n\n완료했어요.")
+
+        XCTAssertEqual(segments, [
+            .text("요청하신 이미지입니다.\n\n"),
+            .image(alt: "푸른 산", source: "/generated/mountain.png"),
+            .text("\n\n완료했어요."),
+        ])
+    }
+
+    func testParserLeavesMalformedImageAsText() {
+        let source = "![미완성](/generated/file.png"
+        XCTAssertEqual(MarkdownContentParser.segments(in: source), [.text(source)])
+    }
+
+    func testGeneratedImageURLStaysOnOpenMakeOrigin() {
+        let serverURL = URL(string: "https://chat.openmake.cc")!
+
+        XCTAssertEqual(
+            GeneratedImageURLResolver.resolve(
+                source: "/generated/image.png",
+                serverURL: serverURL)?.absoluteString,
+            "https://chat.openmake.cc/generated/image.png")
+        XCTAssertNil(GeneratedImageURLResolver.resolve(
+            source: "https://example.com/image.png",
+            serverURL: serverURL))
+        XCTAssertNil(GeneratedImageURLResolver.resolve(
+            source: "http://127.0.0.1/generated/image.png",
+            serverURL: serverURL))
+        XCTAssertNil(GeneratedImageURLResolver.resolve(
+            source: "/api/private",
+            serverURL: serverURL))
+    }
+}

--- a/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/OpenMakeClientTests.swift
+++ b/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/OpenMakeClientTests.swift
@@ -79,6 +79,21 @@ final class OpenMakeClientTests: XCTestCase {
         MockURLProtocol.script("/api/csrf-token", .init(status: 200, json: #"{"token":"csrf-1"}"#))
     }
 
+    private func bodyData(from request: URLRequest?) -> Data? {
+        if let data = request?.httpBody { return data }
+        guard let stream = request?.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var result = Data()
+        var buffer = [UInt8](repeating: 0, count: 1024)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            if count <= 0 { break }
+            result.append(buffer, count: count)
+        }
+        return result
+    }
+
     func testLoginStoresTokensAndSendsCsrfHeader() async throws {
         scriptCsrf()
         MockURLProtocol.script("/api/auth/login", .init(status: 200, json:
@@ -200,6 +215,64 @@ final class OpenMakeClientTests: XCTestCase {
         let agents = try await client.userAgents()
         XCTAssertEqual(agents.first?.name, "도우미")
         XCTAssertEqual(agents.first?.icon, "🤖")
+    }
+
+    func testAgentTaskCreateAndExecuteUseDetachedAPI() async throws {
+        store.save(AuthTokens(access: "at", refresh: "rt"))
+        MockURLProtocol.script("/api/agent-tasks", .init(status: 201, json:
+            #"{"success":true,"data":{"task":{"id":"t1","goal":"앱을 점검해줘","status":"pending","progress":0,"current_turn":0,"max_turns":10,"created_at":"2026-08-16T00:00:00.000Z","updated_at":"2026-08-16T00:00:00.000Z","resumable":false},"concurrentActive":0,"warnings":[]},"meta":\#(Self.meta)}"#))
+        MockURLProtocol.script("/api/agent-tasks/t1/execute", .init(status: 202, json:
+            #"{"success":true,"data":{"message":"작업이 시작되었습니다.","taskId":"t1","queued":false},"meta":\#(Self.meta)}"#))
+
+        let created = try await client.createAgentTask(goal: "앱을 점검해줘")
+        XCTAssertEqual(created.task.id, "t1")
+        XCTAssertEqual(created.task.status, .pending)
+        let execution = try await client.executeAgentTask(id: "t1", approvalPolicy: .highRisk)
+        XCTAssertFalse(execution.queued)
+
+        let request = MockURLProtocol.requests(to: "/api/agent-tasks/t1/execute").first
+        let body = try XCTUnwrap(bodyData(from: request))
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: String])
+        XCTAssertEqual(json["approvalPolicy"], "high-risk")
+    }
+
+    func testAgentTaskDetailDecodesSteps() async throws {
+        store.save(AuthTokens(access: "at", refresh: "rt"))
+        MockURLProtocol.script("/api/agent-tasks/t1", .init(status: 200, json:
+            #"{"success":true,"data":{"task":{"id":"t1","goal":"조사","status":"running","progress":35,"current_turn":2,"max_turns":10,"created_at":"2026-08-16T00:00:00.000Z","updated_at":"2026-08-16T00:01:00.000Z","resumable":false},"steps":[{"id":1,"task_id":"t1","step_number":0,"step_type":"tool_result","tool_name":"web_search","content":"공식 문서 확인","status":"completed","created_at":"2026-08-16T00:01:00.000Z"}]},"meta":\#(Self.meta)}"#))
+
+        let detail = try await client.agentTask(id: "t1")
+        XCTAssertEqual(detail.task.currentTurn, 2)
+        XCTAssertEqual(detail.steps.first?.toolName, "web_search")
+    }
+
+    func testArtifactsListDecodesLatestContent() async throws {
+        store.save(AuthTokens(access: "at", refresh: "rt"))
+        MockURLProtocol.script("/api/sessions/s1/artifacts", .init(status: 200, json:
+            #"{"success":true,"data":{"artifacts":[{"pk_id":1,"artifact_id":"a1","version":2,"session_id":"s1","message_id":"m1","user_id":"u1","kind":"code","title":"Sample.swift","language":"swift","content":"let answer = 42","deps":null,"created_at":"2026-08-16T00:00:00.000Z"}],"total":1},"meta":\#(Self.meta)}"#))
+
+        let artifacts = try await client.artifacts(sessionId: "s1")
+        XCTAssertEqual(artifacts.first?.id, "a1")
+        XCTAssertEqual(artifacts.first?.content, "let answer = 42")
+        XCTAssertEqual(artifacts.first?.version, 2)
+    }
+
+    func testNativePushTokenRegistrationUsesAuthenticatedEndpoint() async throws {
+        store.save(AuthTokens(access: "at", refresh: "rt"))
+        MockURLProtocol.script("/api/push/native/subscribe", .init(status: 200, json:
+            #"{"success":true,"data":{"message":"등록됨"},"meta":\#(Self.meta)}"#))
+
+        try await client.registerNativePushToken(
+            "abc123abc123abc123",
+            environment: .development,
+            bundleId: "cc.openmake.chat")
+
+        let request = MockURLProtocol.requests(to: "/api/push/native/subscribe").first
+        XCTAssertEqual(request?.value(forHTTPHeaderField: "Authorization"), "Bearer at")
+        let body = try XCTUnwrap(bodyData(from: request))
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: String])
+        XCTAssertEqual(json["environment"], "development")
+        XCTAssertEqual(json["bundleId"], "cc.openmake.chat")
     }
 
     func testNoSessionThrowsNotAuthenticated() async {

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -40,6 +40,20 @@ cd apps/ios && xcodebuild -project OpenMakeApp.xcodeproj -scheme OpenMakeApp \
 번들 ID `cc.openmake.chat` · 최소 iOS 17 · 서드파티 의존 0 (Apple 공식 swift-openapi-runtime 만).
 app scheme 은 서버 `MOBILE_AUTH.APP_SCHEME`(기본 `openmake`) 와 일치해야 한다 (축 2).
 
+## 알림
+
+알림 권한, 로컬 완료 알림, APNs 토큰 등록 클라이언트와 서버 발송 경로가 포함되어 있다.
+현재 개인 개발 팀 서명을 유지하기 위해 `Info.plist`의 `OpenMakeRemotePushEnabled` 기본값은 `false`다.
+
+원격 푸시를 켤 때는 다음을 함께 적용한다.
+
+1. Apple Developer Program의 App ID와 Xcode 타깃에서 Push Notifications capability를 활성화한다.
+2. `Info.plist`의 `OpenMakeRemotePushEnabled`를 `true`로 바꾼다.
+3. 서버에 `APNS_KEY_ID`, `APNS_TEAM_ID`, `APNS_PRIVATE_KEY`를 설정한다.
+4. `db/migrations/098_mobile_push_tokens.sql`을 배포 DB에 적용한다.
+
+APNs 키가 비어 있으면 서버의 기존 Web Push는 그대로 동작하고 APNs 발송만 no-op이다.
+
 ## TestFlight (Step 8 — 로컬 수동, 서명 비밀은 CI 금지)
 
 1회 선행: ① Apple Developer Program 계정으로 Xcode > Settings > Accounts 로그인

--- a/db/migrations/098_mobile_push_tokens.sql
+++ b/db/migrations/098_mobile_push_tokens.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS mobile_push_tokens (
+    device_token TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    environment TEXT NOT NULL CHECK (environment IN ('development', 'production')),
+    bundle_id TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_used TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_mobile_push_tokens_user
+    ON mobile_push_tokens (user_id, updated_at DESC);


### PR DESCRIPTION
## 개요

iOS 2차 백로그 3커밋 (Codex 작업 인수 후 검증·마무리). #516 후속.

- **36d3d7ea — LUMEN 백로그 대형**: 에이전트 작업 화면(목록·상세·진행), 아티팩트 뷰어, 마크다운 파서 강화(`MarkdownContentParser`), **APNs 네이티브 푸시**(서버 `NativePushService` + `POST /api/push` 확장 + 마이그레이션 `098_mobile_push_tokens` + iOS `NotificationManager`/AppDelegate), ChatStreamState 확장(활동 라인 `activityKind`·아티팩트 수명주기 누적·`cleanedContent` 반영·상태 문구), DEBUG 디자인 쇼케이스, DESIGN.md
- **c8a577e8 — 채팅 사용 스킬 표시**: `skills_activated` 수신 → 스킬 칩 UI(`LumenComponents`), 다음 질문까지 유지
- **963f7148 — 서버 카운터파트(인수 후 완성)**: 슬래시 명령(`/skill-slug`)으로 주입된 스킬이 어떤 클라이언트에도 표시되지 않던 공백 — `onSkillApplied` 훅으로 수집해 스트림 시작 시 즉시 emit + 자동 활성 스킬과 `mergeActivatedSkillNames`(trim·중복 제거) 병합

## 검증 (인수 후 전체 재검증)

- [x] 백엔드: `tsc --noEmit` 0 · slash-command/native-push 테스트 22/22 · eslint 에러 0(기존 max-lines 경고만)
- [x] iOS: OpenMakeKit 42/42(+라이브 3 skip) · 시뮬레이터 빌드 SUCCEEDED
- [x] codegen·계약 drift 0 (Gate 0·iOS Gate 2 사전 재현)
- [x] 마이그레이션 098 멱등 (부팅 자동 적용 규약)
- [ ] 본 PR CI

## 참고

- APNs 실발송은 `.env` 의 APNs 키 설정 후 활성 (미설정 시 등록만 저장 — fail-open). TestFlight/유료 계정 준비와 함께 라이브 검증 예정
- main 직접 커밋돼 있던 것을 브랜치로 이관하고 main 은 origin 으로 원복함 (레포 관행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)