### PR TITLE
feat(ios): 표를 폰 화면용 카드로 구조화

### DIFF
--- a/apps/ios/OpenMakeApp/Features/Conversations/MarkdownText.swift
+++ b/apps/ios/OpenMakeApp/Features/Conversations/MarkdownText.swift
@@ -87,6 +87,7 @@ private struct RichTextBlock: View {
         case quote(text: String)
         case divider
         case paragraph(text: String)
+        case table(MarkdownTable)
 
         var id: String { String(describing: self) + UUID().uuidString }
     }
@@ -120,6 +121,8 @@ private struct RichTextBlock: View {
                         .padding(.vertical, 4)
                 case .paragraph(let text):
                     body(text)
+                case .table(let table):
+                    MarkdownTableView(table: table)
                 }
             }
         }
@@ -165,13 +168,24 @@ private struct RichTextBlock: View {
             paragraph = []
         }
 
-        for rawLine in text.components(separatedBy: "\n") {
+        let rawLines = text.components(separatedBy: "\n")
+        var index = 0
+        while index < rawLines.count {
+            let rawLine = rawLines[index]
+            index += 1
             let indent = rawLine.prefix { $0 == " " || $0 == "\t" }.count
             let line = rawLine.trimmingCharacters(in: .whitespaces)
             let depth = min(indent / 2, 3)
 
             if line.isEmpty {
                 flush()
+                continue
+            }
+            // 표: 헤더 + |---| 구분행 — 폰에서는 카드로 재구성 (MarkdownTableView)
+            if let parsed = MarkdownTableParser.parse(rawLines, from: index - 1) {
+                flush()
+                result.append(.table(parsed.table))
+                index = (index - 1) + parsed.consumed
                 continue
             }
             // 구분선: ---, ***, ___ (3자 이상)
@@ -255,6 +269,74 @@ private struct GeneratedImageView: View {
 
     private var imageURL: URL? {
         GeneratedImageURLResolver.resolve(source: source, serverURL: AppConfig.serverURL)
+    }
+}
+
+/// 표 → 폰 화면용 카드 목록.
+/// 좁은 화면에서 열을 그대로 그리면 글자가 잘려 읽을 수 없으므로, 행을 카드로 세워
+/// 첫 열을 제목, 나머지를 "헤더 · 값" 줄로 편다. 2열 표는 라벨-값 한 줄로 압축한다.
+struct MarkdownTableView: View {
+    let table: MarkdownTable
+
+    private var isPair: Bool { table.headers.count == 2 }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: isPair ? 6 : 8) {
+            if isPair {
+                ForEach(Array(table.rows.enumerated()), id: \.offset) { _, row in
+                    HStack(alignment: .top, spacing: 8) {
+                        Text(inline(row.first ?? ""))
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(Lumen.fg)
+                            .frame(minWidth: 72, alignment: .leading)
+                        Text(inline(row.count > 1 ? row[1] : ""))
+                            .font(.system(size: 14))
+                            .foregroundStyle(Lumen.fg2)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .padding(.vertical, 2)
+                }
+            } else {
+                ForEach(Array(table.rows.enumerated()), id: \.offset) { _, row in
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text(inline(row.first ?? ""))
+                            .font(.system(size: 14.5, weight: .bold))
+                            .foregroundStyle(Lumen.fg)
+                        ForEach(Array(table.fields(of: row, skippingFirst: true).enumerated()), id: \.offset) { _, field in
+                            HStack(alignment: .top, spacing: 6) {
+                                Text(field.header)
+                                    .font(.system(size: 11.5, weight: .semibold))
+                                    .foregroundStyle(Lumen.accent)
+                                    .padding(.horizontal, 6)
+                                    .padding(.vertical, 2)
+                                    .background(Lumen.accentSoft, in: RoundedRectangle(cornerRadius: 5))
+                                Text(inline(field.value))
+                                    .font(.system(size: 13.5))
+                                    .lineSpacing(2)
+                                    .foregroundStyle(Lumen.fg2)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Lumen.surface, in: RoundedRectangle(cornerRadius: 10))
+                    .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Lumen.border))
+                }
+            }
+        }
+        .textSelection(.enabled)
+        .padding(.vertical, 2)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("표 \(table.rows.count)행")
+    }
+
+    private func inline(_ text: String) -> AttributedString {
+        (try? AttributedString(
+            markdown: text,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)))
+            ?? AttributedString(text)
     }
 }
 

--- a/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/MarkdownTable.swift
+++ b/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/MarkdownTable.swift
@@ -1,0 +1,75 @@
+// OpenMakeKit — 마크다운 표 파서 (폰 화면용 구조화)
+//
+// 서버 answer-format 가드는 "비교는 표로 정리" 를 지시하므로 답변에 표가 자주 온다.
+// 폰에서 표를 그대로 그리면 열이 좁아 읽을 수 없어, 앱은 행 단위 카드로 재구성한다.
+// 파싱은 순수 로직이라 Kit 에 두고 단위 테스트로 고정한다 (렌더는 앱 책임).
+import Foundation
+
+public struct MarkdownTable: Equatable, Sendable {
+    public let headers: [String]
+    public let rows: [[String]]
+
+    public init(headers: [String], rows: [[String]]) {
+        self.headers = headers
+        self.rows = rows
+    }
+
+    /// 행을 (헤더, 값) 쌍으로 — 첫 열은 카드 제목으로 쓰이므로 제외 가능
+    public func fields(of row: [String], skippingFirst: Bool) -> [(header: String, value: String)] {
+        let start = skippingFirst ? 1 : 0
+        guard headers.count > start else { return [] }
+        return (start..<headers.count).compactMap { index in
+            let value = index < row.count ? row[index] : ""
+            guard !value.isEmpty else { return nil }
+            return (headers[index], value)
+        }
+    }
+}
+
+public enum MarkdownTableParser {
+    /// 표 블록 판정 — 헤더 행 + `|---|` 구분 행이 연속으로 있어야 한다.
+    public static func isTableStart(_ lines: [String], at index: Int) -> Bool {
+        guard index + 1 < lines.count else { return false }
+        return isRow(lines[index]) && isDivider(lines[index + 1])
+    }
+
+    /// index 부터 이어지는 표를 파싱하고, 소비한 라인 수를 함께 반환한다.
+    public static func parse(_ lines: [String], from index: Int) -> (table: MarkdownTable, consumed: Int)? {
+        guard isTableStart(lines, at: index) else { return nil }
+        let headers = cells(in: lines[index])
+        guard !headers.isEmpty else { return nil }
+
+        var rows: [[String]] = []
+        var cursor = index + 2 // 헤더 + 구분 행
+        while cursor < lines.count, isRow(lines[cursor]), !isDivider(lines[cursor]) {
+            let row = cells(in: lines[cursor])
+            if !row.isEmpty { rows.append(row) }
+            cursor += 1
+        }
+        guard !rows.isEmpty else { return nil }
+        return (MarkdownTable(headers: headers, rows: rows), cursor - index)
+    }
+
+    private static func isRow(_ line: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        return trimmed.hasPrefix("|") && trimmed.dropFirst().contains("|")
+    }
+
+    /// `|---|:--:|` 형태의 정렬 구분 행
+    private static func isDivider(_ line: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("|") else { return false }
+        let body = trimmed.trimmingCharacters(in: CharacterSet(charactersIn: "|"))
+        guard !body.isEmpty else { return false }
+        return body.allSatisfy { "-: |".contains($0) } && body.contains("-")
+    }
+
+    private static func cells(in line: String) -> [String] {
+        var trimmed = line.trimmingCharacters(in: .whitespaces)
+        if trimmed.hasPrefix("|") { trimmed.removeFirst() }
+        if trimmed.hasSuffix("|") { trimmed.removeLast() }
+        return trimmed
+            .components(separatedBy: "|")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+    }
+}

--- a/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/MarkdownTableTests.swift
+++ b/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/MarkdownTableTests.swift
@@ -1,0 +1,50 @@
+// 마크다운 표 파서 테스트 — 폰 카드 렌더의 입력 계약
+import XCTest
+@testable import OpenMakeKit
+
+final class MarkdownTableTests: XCTestCase {
+    private let sample = [
+        "| 상황 | 추천 | 이유 |",
+        "|---|---|---|",
+        "| 실무 취직 | React | 채용 공고가 많음 |",
+        "| 초보자 | Vue | 진입 장벽이 낮음 |",
+        "",
+        "다음 문단",
+    ]
+
+    func testParsesHeadersAndRows() throws {
+        let parsed = try XCTUnwrap(MarkdownTableParser.parse(sample, from: 0))
+        XCTAssertEqual(parsed.table.headers, ["상황", "추천", "이유"])
+        XCTAssertEqual(parsed.table.rows.count, 2)
+        XCTAssertEqual(parsed.table.rows[0], ["실무 취직", "React", "채용 공고가 많음"])
+        XCTAssertEqual(parsed.consumed, 4, "헤더+구분+데이터 2행만 소비하고 빈 줄에서 멈춘다")
+    }
+
+    func testFieldsSkipFirstColumnForCardTitle() throws {
+        let parsed = try XCTUnwrap(MarkdownTableParser.parse(sample, from: 0))
+        let fields = parsed.table.fields(of: parsed.table.rows[0], skippingFirst: true)
+        XCTAssertEqual(fields.map(\.header), ["추천", "이유"])
+        XCTAssertEqual(fields.first?.value, "React")
+    }
+
+    func testAlignmentDividerIsAccepted() throws {
+        let aligned = ["| A | B |", "|:--|--:|", "| 1 | 2 |"]
+        let parsed = try XCTUnwrap(MarkdownTableParser.parse(aligned, from: 0))
+        XCTAssertEqual(parsed.table.headers, ["A", "B"])
+        XCTAssertEqual(parsed.table.rows, [["1", "2"]])
+    }
+
+    func testNonTableIsRejected() {
+        XCTAssertNil(MarkdownTableParser.parse(["| 파이프만 있고 구분행 없음 |", "본문"], from: 0))
+        XCTAssertNil(MarkdownTableParser.parse(["그냥 문단", "또 문단"], from: 0))
+        // 헤더+구분행만 있고 데이터가 없으면 표로 보지 않는다
+        XCTAssertNil(MarkdownTableParser.parse(["| A | B |", "|---|---|"], from: 0))
+    }
+
+    func testEmptyCellsAreDroppedFromFields() throws {
+        let sparse = ["| 항목 | 값 | 비고 |", "|---|---|---|", "| A | 1 |  |"]
+        let parsed = try XCTUnwrap(MarkdownTableParser.parse(sparse, from: 0))
+        let fields = parsed.table.fields(of: parsed.table.rows[0], skippingFirst: true)
+        XCTAssertEqual(fields.map(\.header), ["값"], "빈 셀은 카드에 표시하지 않는다")
+    }
+}


### PR DESCRIPTION
## 문제

"iOS 답변이 폰 사이즈에 맞게 구조화됐으면 좋겠다"는 요청으로 점검한 결과, 가장 큰 원인은 **표가 raw 마크다운으로 노출**되는 것이었다.

서버 `answer-format` 가드(구조적 답변 프로파일)가 **"선택지·항목을 비교할 때는 표로 정리한다"**고 지시하므로 비교·의사결정 답변에는 표가 자주 온다. 그런데 앱에는 표 렌더가 없어 아래처럼 보였다:

```
| 상황 | 추천 프레임워크 | 이유 |
|---|---|---|
| 실무 취직/이직 최우선 | React | 채용 공고 70% 이상이 React... |
```

좁은 화면에서 가장 읽기 나쁜 부분이었다(스크린샷 대조 확인).

## 수정

- **Kit**: `MarkdownTable` + `MarkdownTableParser` — 헤더/구분행/데이터 판정, 정렬 구분행(`|:--|--:|`) 허용, 데이터 없는 표 거부, 빈 셀 제외. 순수 로직이라 Kit에 두고 테스트 5건으로 고정
- **앱**: `MarkdownTableView` — 폰에서 열을 그대로 그리면 글자가 잘리므로 **행을 카드로 세워** 첫 열을 제목, 나머지를 "헤더 칩 + 값" 줄로 편다. 2열 표는 라벨-값 한 줄로 압축
- `RichTextBlock` 파서를 인덱스 기반으로 전환해 여러 줄 소비(표) 지원

## 검증

- [x] 시뮬레이터: React/Vue/Svelte 비교 답변 — **파이프 사라지고 카드 구조 렌더**(전/후 스크린샷 대조)
- [x] OpenMakeKit **54 테스트** · 시뮬레이터 빌드
- [ ] 본 PR CI

## 후속 후보

- 서버에 모바일 클라이언트 힌트를 전달해 답변 자체를 폰 친화 포맷(짧은 문단·표 대신 목록)으로 유도 — 계약(WsChatRequest) 변경이 필요해 별도 판단
- 긴 답변 섹션 접기

🤖 Generated with [Claude Code](https://claude.com/claude-code)