### PR TITLE
fix(agents): 스킬 상시 주입 오염 — triggers 선언 스킬은 관련 턴에만

### DIFF
--- a/apps/api/src/agents/__tests__/skill-trigger-gate.test.ts
+++ b/apps/api/src/agents/__tests__/skill-trigger-gate.test.ts
@@ -1,0 +1,63 @@
+import { parseManifestTriggers, matchesSkillTriggers, readMetaTriggers } from '../skill-manager';
+
+describe('parseManifestTriggers', () => {
+    it('블록 시퀀스 형태를 파싱한다', () => {
+        const yaml = [
+            'name: presentation-designer',
+            'category: design',
+            'triggers:',
+            '  - 발표자료',
+            '  - "슬라이드"',
+            '  - PPT',
+            'version: 1.0.3',
+        ].join('\n');
+        expect(parseManifestTriggers(yaml)).toEqual(['발표자료', '슬라이드', 'PPT']);
+    });
+
+    it('인라인 배열 형태를 파싱한다', () => {
+        expect(parseManifestTriggers('triggers: [발표자료, 슬라이드]')).toEqual(['발표자료', '슬라이드']);
+    });
+
+    it('triggers 미선언이면 빈 배열', () => {
+        expect(parseManifestTriggers('name: x\ncategory: design')).toEqual([]);
+    });
+
+    it('tool_bindings 등 다른 시퀀스 키를 삼키지 않는다', () => {
+        const yaml = ['name: x', 'tool_bindings:', '  - tool_name: "a"', '    mode: required'].join('\n');
+        expect(parseManifestTriggers(yaml)).toEqual([]);
+    });
+});
+
+describe('matchesSkillTriggers', () => {
+    const triggers = ['발표자료', '슬라이드', 'PPT'];
+
+    it('질의가 트리거를 포함하면 주입한다', () => {
+        expect(matchesSkillTriggers(triggers, '이 자료로 발표자료 만들어줘')).toBe(true);
+        expect(matchesSkillTriggers(triggers, 'ppt 로 정리해줘')).toBe(true); // 대소문자 무관
+    });
+
+    it('무관한 질의에는 주입하지 않는다', () => {
+        expect(matchesSkillTriggers(triggers, 'AWS, Azure, GCP의 한국 리전과 가격 모델을 표로 정리해줘')).toBe(false);
+    });
+
+    it('triggers 미선언 스킬은 항상 주입한다 (기존 동작 유지)', () => {
+        expect(matchesSkillTriggers([], '아무 질의')).toBe(true);
+    });
+
+    it('질의를 알 수 없으면 게이트하지 않는다 (판단 근거 부재)', () => {
+        expect(matchesSkillTriggers(triggers, undefined)).toBe(true);
+        expect(matchesSkillTriggers(triggers, '   ')).toBe(true);
+    });
+});
+
+describe('readMetaTriggers', () => {
+    it('문자열 배열만 추려낸다', () => {
+        expect(readMetaTriggers({ triggers: ['a', '', 3, ' b '] })).toEqual(['a', 'b']);
+    });
+
+    it('triggers 가 없거나 배열이 아니면 빈 배열', () => {
+        expect(readMetaTriggers({})).toEqual([]);
+        expect(readMetaTriggers({ triggers: 'a,b' })).toEqual([]);
+        expect(readMetaTriggers(undefined)).toEqual([]);
+    });
+});

--- a/apps/api/src/agents/skill-manager.ts
+++ b/apps/api/src/agents/skill-manager.ts
@@ -92,79 +92,16 @@ export function assessSkillOverload(
     return { overloaded: reasons.length > 0, activeCount, totalChars, reasons };
 }
 
-/** triggers 활성화에 사용할 노출 상한 (프롬프트 비대화 방지) */
-const SKILL_TRIGGER_HINT_MAX = Number(process.env.SKILL_TRIGGER_HINT_MAX) || 8;
+// 스킬 triggers 파싱·주입 게이트는 skill-triggers.ts 로 분리 (파일 크기 가드).
+// 기존 사용처 호환을 위해 여기서 re-export 한다.
+import {
+    formatTriggerHint,
+    parseManifestTriggers,
+    readMetaTriggers,
+    matchesSkillTriggers,
+} from './skill-triggers';
 
-/**
- * manifestMeta.triggers 를 스킬 블록에 넣을 "적용 상황" 힌트 문자열로 변환 (순수 함수).
- * triggers 가 없거나 비면 빈 문자열(기존 동작과 동일).
- *
- * @param manifestMeta - 스킬 manifest 메타 (triggers 배열 보유 가능)
- * @returns " (적용 상황: a, b, c)" 형태 또는 ''
- */
-export function formatTriggerHint(manifestMeta?: Record<string, unknown>): string {
-    const raw = manifestMeta?.triggers;
-    if (!Array.isArray(raw)) return '';
-    const triggers = raw
-        .filter((t): t is string => typeof t === 'string' && t.trim().length > 0)
-        .map(t => t.trim().replace(/[<>"&]/g, ''))
-        .slice(0, SKILL_TRIGGER_HINT_MAX);
-    if (triggers.length === 0) return '';
-    return ` (적용 상황: ${triggers.join(', ')})`;
-}
-
-/**
- * manifest yaml 의 `triggers:` 블록을 문자열 배열로 파싱 (순수 함수).
- * 저장된 manifest_yaml 은 fence 없는 순수 yaml 이라 최상위 키를 multiline 으로 매칭한다.
- *
- * 지원 형태:
- *   triggers: [발표자료, 슬라이드]
- *   triggers:
- *     - 발표자료
- *     - "슬라이드"
- */
-export function parseManifestTriggers(manifestYaml: string): string[] {
-    const inline = /^triggers:\s*\[([^\]]*)\]\s*$/m.exec(manifestYaml);
-    if (inline) {
-        return inline[1].split(',')
-            .map(t => t.trim().replace(/^['"]|['"]$/g, ''))
-            .filter(Boolean);
-    }
-    const block = /^triggers:\s*\n((?:\s*-\s*[^\n]+\n?)+)/m.exec(manifestYaml);
-    if (!block) return [];
-    return block[1].split('\n')
-        .map(line => /^\s*-\s*(.+)$/.exec(line)?.[1]?.trim().replace(/^['"]|['"]$/g, '') ?? '')
-        .filter(Boolean);
-}
-
-/**
- * 스킬 주입 관련성 게이트 (순수 함수, LLM 호출 없음).
- *
- * 개인 지정 스킬은 카테고리 필터를 우회해 모든 대화에 주입되므로, 스킬 하나가 무관한
- * 질의까지 자기 워크플로우로 끌어가는 오염이 생긴다 — 발표자료 스킬이 클라우드 비교
- * 질문의 답을 슬라이드 아티팩트로 만들어버린 실측 사례(2026-08-18).
- *
- * 스킬이 `triggers` 를 **선언한 경우에만** 게이트한다. 미선언 스킬은 종전대로 항상 주입해
- * 기존 배포에 회귀가 없다. 트리거는 대소문자 무관 부분일치.
- *
- * @param triggers - 스킬이 선언한 적용 상황 키워드
- * @param query - 이번 턴의 사용자 질의 (없으면 게이트하지 않음 — 판단 근거 부재)
- */
-export function readMetaTriggers(manifestMeta?: Record<string, unknown>): string[] {
-    const raw = manifestMeta?.triggers;
-    if (!Array.isArray(raw)) return [];
-    return raw.filter((t): t is string => typeof t === 'string' && t.trim().length > 0).map(t => t.trim());
-}
-
-export function matchesSkillTriggers(triggers: string[], query?: string): boolean {
-    if (triggers.length === 0) return true;
-    if (!query || query.trim().length === 0) return true;
-    const haystack = query.toLowerCase();
-    return triggers.some(t => {
-        const needle = t.toLowerCase().trim();
-        return needle.length > 0 && haystack.includes(needle);
-    });
-}
+export { formatTriggerHint, parseManifestTriggers, readMetaTriggers, matchesSkillTriggers };
 
 // ========================================
 // SkillManager 클래스

--- a/apps/api/src/agents/skill-manager.ts
+++ b/apps/api/src/agents/skill-manager.ts
@@ -113,6 +113,59 @@ export function formatTriggerHint(manifestMeta?: Record<string, unknown>): strin
     return ` (적용 상황: ${triggers.join(', ')})`;
 }
 
+/**
+ * manifest yaml 의 `triggers:` 블록을 문자열 배열로 파싱 (순수 함수).
+ * 저장된 manifest_yaml 은 fence 없는 순수 yaml 이라 최상위 키를 multiline 으로 매칭한다.
+ *
+ * 지원 형태:
+ *   triggers: [발표자료, 슬라이드]
+ *   triggers:
+ *     - 발표자료
+ *     - "슬라이드"
+ */
+export function parseManifestTriggers(manifestYaml: string): string[] {
+    const inline = /^triggers:\s*\[([^\]]*)\]\s*$/m.exec(manifestYaml);
+    if (inline) {
+        return inline[1].split(',')
+            .map(t => t.trim().replace(/^['"]|['"]$/g, ''))
+            .filter(Boolean);
+    }
+    const block = /^triggers:\s*\n((?:\s*-\s*[^\n]+\n?)+)/m.exec(manifestYaml);
+    if (!block) return [];
+    return block[1].split('\n')
+        .map(line => /^\s*-\s*(.+)$/.exec(line)?.[1]?.trim().replace(/^['"]|['"]$/g, '') ?? '')
+        .filter(Boolean);
+}
+
+/**
+ * 스킬 주입 관련성 게이트 (순수 함수, LLM 호출 없음).
+ *
+ * 개인 지정 스킬은 카테고리 필터를 우회해 모든 대화에 주입되므로, 스킬 하나가 무관한
+ * 질의까지 자기 워크플로우로 끌어가는 오염이 생긴다 — 발표자료 스킬이 클라우드 비교
+ * 질문의 답을 슬라이드 아티팩트로 만들어버린 실측 사례(2026-08-18).
+ *
+ * 스킬이 `triggers` 를 **선언한 경우에만** 게이트한다. 미선언 스킬은 종전대로 항상 주입해
+ * 기존 배포에 회귀가 없다. 트리거는 대소문자 무관 부분일치.
+ *
+ * @param triggers - 스킬이 선언한 적용 상황 키워드
+ * @param query - 이번 턴의 사용자 질의 (없으면 게이트하지 않음 — 판단 근거 부재)
+ */
+export function readMetaTriggers(manifestMeta?: Record<string, unknown>): string[] {
+    const raw = manifestMeta?.triggers;
+    if (!Array.isArray(raw)) return [];
+    return raw.filter((t): t is string => typeof t === 'string' && t.trim().length > 0).map(t => t.trim());
+}
+
+export function matchesSkillTriggers(triggers: string[], query?: string): boolean {
+    if (triggers.length === 0) return true;
+    if (!query || query.trim().length === 0) return true;
+    const haystack = query.toLowerCase();
+    return triggers.some(t => {
+        const needle = t.toLowerCase().trim();
+        return needle.length > 0 && haystack.includes(needle);
+    });
+}
+
 // ========================================
 // SkillManager 클래스
 // ========================================
@@ -421,7 +474,7 @@ export class SkillManager {
      * 않아 프론트의 "스킬 활성화" 표시가 뜨지 않았다(2026-08-02 실측: 21/21 주입인데 이름 0개).
      */
     async buildManifestPrompt(
-        agentId: string, userId?: string, agentCategory?: string,
+        agentId: string, userId?: string, agentCategory?: string, query?: string,
     ): Promise<{ prompt: string; skillNames: string[] } | null> {
         let pool: Pool;
         try {
@@ -469,6 +522,9 @@ export class SkillManager {
         // agentCategory 필터: manifest_yaml 의 category 가 agent.category 와 일치하거나
         // user-* prefix (사용자 개인 manifest) 인 경우만 포함 — 무관한 skill 의 프롬프트 오염 방지.
         const filtered = rows.filter(r => {
+            // triggers 선언 스킬은 관련 턴에만 주입 — 개인 스킬의 카테고리 우회(아래)와
+            // 결합돼 무관한 질의까지 오염시키던 경로를 막는다. 미선언 스킬은 종전 동작.
+            if (!matchesSkillTriggers(parseManifestTriggers(r.manifest_yaml), query)) return false;
             if (!agentCategory) return true;
             if (r.id.startsWith('user-')) return true;
             const cat = /^---[\s\S]*?\bcategory:\s*([^\n]+)/.exec(r.manifest_yaml);
@@ -497,6 +553,7 @@ export class SkillManager {
                 const manifestIds = new Set(rows.map(r => r.id));
                 const userSkills = (await this.getUserSkills(userId)).filter(s =>
                     !manifestIds.has(s.id) &&
+                    matchesSkillTriggers(readMetaTriggers(s.manifestMeta), query) &&
                     (!agentCategory || s.category === agentCategory || s.category === 'general'));
                 for (const s of userSkills.slice(0, Math.max(0, 15 - blocks.length))) {
                     const safeName = s.name.replace(/[<>"&]/g, '');

--- a/apps/api/src/agents/skill-triggers.ts
+++ b/apps/api/src/agents/skill-triggers.ts
@@ -1,0 +1,78 @@
+/**
+ * @module agents/skill-triggers
+ * @description
+ * 스킬 `triggers` 파싱·매칭 순수 함수 모음 (LLM 호출 없음).
+ *
+ * 개인 지정 스킬(manifest id `user-` prefix)은 카테고리 필터를 우회해 모든 대화에
+ * 주입되므로, 스킬 하나가 무관한 질의까지 자기 워크플로우로 끌어가는 오염이 생긴다 —
+ * 발표자료 스킬이 클라우드 비교 질문의 답을 슬라이드 아티팩트로 만들어버린 실측
+ * 사례(2026-08-18). 여기 함수들이 그 주입 게이트를 담당한다.
+ */
+
+/** triggers 활성화에 사용할 노출 상한 (프롬프트 비대화 방지) */
+const SKILL_TRIGGER_HINT_MAX = Number(process.env.SKILL_TRIGGER_HINT_MAX) || 8;
+
+/**
+ * manifestMeta.triggers 를 스킬 블록에 넣을 "적용 상황" 힌트 문자열로 변환.
+ * triggers 가 없거나 비면 빈 문자열(기존 동작과 동일).
+ *
+ * @param manifestMeta - 스킬 manifest 메타 (triggers 배열 보유 가능)
+ * @returns " (적용 상황: a, b, c)" 형태 또는 ''
+ */
+export function formatTriggerHint(manifestMeta?: Record<string, unknown>): string {
+    const triggers = readMetaTriggers(manifestMeta)
+        .map(t => t.replace(/[<>"&]/g, ''))
+        .slice(0, SKILL_TRIGGER_HINT_MAX);
+    if (triggers.length === 0) return '';
+    return ` (적용 상황: ${triggers.join(', ')})`;
+}
+
+/**
+ * manifest yaml 의 `triggers:` 블록을 문자열 배열로 파싱.
+ * 저장된 manifest_yaml 은 fence 없는 순수 yaml 이라 최상위 키를 multiline 으로 매칭한다.
+ *
+ * 지원 형태:
+ *   triggers: [발표자료, 슬라이드]
+ *   triggers:
+ *     - 발표자료
+ *     - "슬라이드"
+ */
+export function parseManifestTriggers(manifestYaml: string): string[] {
+    const inline = /^triggers:\s*\[([^\]]*)\]\s*$/m.exec(manifestYaml);
+    if (inline) {
+        return inline[1].split(',')
+            .map(t => t.trim().replace(/^['"]|['"]$/g, ''))
+            .filter(Boolean);
+    }
+    const block = /^triggers:\s*\n((?:\s*-\s*[^\n]+\n?)+)/m.exec(manifestYaml);
+    if (!block) return [];
+    return block[1].split('\n')
+        .map(line => /^\s*-\s*(.+)$/.exec(line)?.[1]?.trim().replace(/^['"]|['"]$/g, '') ?? '')
+        .filter(Boolean);
+}
+
+/** manifestMeta(JSON) 의 triggers 배열에서 유효 문자열만 추린다. */
+export function readMetaTriggers(manifestMeta?: Record<string, unknown>): string[] {
+    const raw = manifestMeta?.triggers;
+    if (!Array.isArray(raw)) return [];
+    return raw.filter((t): t is string => typeof t === 'string' && t.trim().length > 0).map(t => t.trim());
+}
+
+/**
+ * 스킬 주입 관련성 게이트.
+ *
+ * 스킬이 `triggers` 를 **선언한 경우에만** 게이트한다. 미선언 스킬은 종전대로 항상
+ * 주입해 기존 배포에 회귀가 없다. 트리거는 대소문자 무관 부분일치.
+ *
+ * @param triggers - 스킬이 선언한 적용 상황 키워드
+ * @param query - 이번 턴의 사용자 질의 (없으면 게이트하지 않음 — 판단 근거 부재)
+ */
+export function matchesSkillTriggers(triggers: string[], query?: string): boolean {
+    if (triggers.length === 0) return true;
+    if (!query || query.trim().length === 0) return true;
+    const haystack = query.toLowerCase();
+    return triggers.some(t => {
+        const needle = t.toLowerCase().trim();
+        return needle.length > 0 && haystack.includes(needle);
+    });
+}

--- a/apps/api/src/agents/system-prompt.ts
+++ b/apps/api/src/agents/system-prompt.ts
@@ -214,7 +214,12 @@ function applyPromptPlaceholders(template: string, values: Record<string, string
  * @param userId - 사용자 ID (개인 스킬 포함 여부 결정)
  * @returns {Promise<{ prompt: string; skillNames: string[] }>} - 조합된 프롬프트와 활성 스킬 이름 목록
  */
-export async function getAgentSystemMessage(selection: AgentSelection, userId?: string, languageCode: string = 'en'): Promise<{ prompt: string; skillNames: string[] }> {
+export async function getAgentSystemMessage(
+    selection: AgentSelection,
+    userId?: string,
+    languageCode: string = 'en',
+    query?: string,
+): Promise<{ prompt: string; skillNames: string[] }> {
     const agent = AGENTS[selection.primaryAgent];
     if (!agent) {
         return { prompt: getDefaultSystemPrompt(languageCode), skillNames: [] };
@@ -247,7 +252,7 @@ ${applyPromptPlaceholders(promptTemplate.workingOn, { phase: getPhaseLabel(selec
     let hasDbSkills = false;
     const skillNames: string[] = [];
     try {
-        const manifest = await getSkillManager().buildManifestPrompt(agent.id, userId, agent.category);
+        const manifest = await getSkillManager().buildManifestPrompt(agent.id, userId, agent.category, query);
         if (manifest) {
             result += manifest.prompt;
             hasDbSkills = true;

--- a/apps/api/src/services/chat-service/agent-resolver.ts
+++ b/apps/api/src/services/chat-service/agent-resolver.ts
@@ -129,7 +129,9 @@ export async function resolveAgent(
 ): Promise<AgentResolutionResult> {
     const agentSelection: AgentSelection = await selectAgent(message);
 
-    const { prompt: agentSystemMessage, skillNames } = await getAgentSystemMessage(agentSelection, userId || undefined, languageCode);
+    // query 전달 — triggers 를 선언한 스킬은 관련 턴에만 주입된다(skill-manager 게이트).
+    const { prompt: agentSystemMessage, skillNames } = await getAgentSystemMessage(
+        agentSelection, userId || undefined, languageCode, message);
     const selectedAgent = AGENTS[agentSelection.primaryAgent];
     logger.info(`에이전트: ${selectedAgent.emoji} ${selectedAgent.name}`);
 


### PR DESCRIPTION
## 문제

개인 지정 스킬(manifest id `user-` prefix)은 `buildManifestPrompt` 의 카테고리 필터를 **무조건 통과**한다(`skill-manager.ts`). 의도는 "개인 스킬은 어느 에이전트에서든 쓰게" 였지만, 결과적으로 스킬 하나가 무관한 질의까지 자기 워크플로우로 끌어간다.

**실측** (2026-08-18, user 3, 아이폰 실기기 점검 중 발견):
`presentation-designer`(발표자료 → 오픈디자인 MCP 슬라이드 덱 워크플로우)가 **"AWS, Azure, GCP의 한국 리전과 가격 모델을 마크다운 표로 정리해줘"** 에도 주입됐다. 답변은 표 대신 "오픈디자인 데몬이 실행 중이지 않아 저장 단계는 건너뛰고…" 로 시작해 아티팩트만 남았다.

```
[AgentSystem] Manifest 스킬 주입됨: 클라우드 아키텍트 (cloud-architect)
  [presentation-designer, 클라우드 아키텍트 전문 스킬]
```
04:53 / 05:31 / 05:34 / 05:45 / 05:47 — 질의 종류와 무관하게 매 턴.

## 게이트

스킬이 manifest 에 **`triggers` 를 선언한 경우에만** 질의와 매칭될 때 주입한다.

- 미선언 스킬은 종전대로 항상 주입 → **기존 배포 회귀 없음**
- 질의를 모르는 호출 경로(`chat-delegate`, `agent-task/delegate`, `spawn-agents`)는 게이트하지 않는다 — 판단 근거가 없으면 막지 않는다
- LLM 호출 없는 순수 문자열 매칭이라 CLAUDE.md 의 **판단 경계(A형 앞단 판단 금지)를 넓히지 않는다**

| 함수 | 역할 |
|---|---|
| `parseManifestTriggers` | manifest yaml 의 `triggers:` 파싱 — 블록/인라인 두 형태, `tool_bindings` 등 다른 시퀀스 키 오식별 방지 |
| `matchesSkillTriggers` | 대소문자 무관 부분일치. 미선언·질의부재는 통과 |
| `readMetaTriggers` | 개인 스킬 union 경로(manifest 미보유분)에도 동일 게이트 |

호출 사슬: `resolveAgent(message)` → `getAgentSystemMessage(..., query)` → `buildManifestPrompt(..., query)`.

## 데이터 (별도 적용 완료)

`user-3-presentation-designer` manifest 를 **v1.0.3** 으로 올려 triggers 선언:
`발표자료 / 프레젠테이션 / 슬라이드 / PPT / ppt / deck / 피치덱 / 발표 자료`
(prompt_md 무변경이라 checksum 동일, 이전 버전 이력 보존)

## 검증

- [x] 테스트 **13**건(신규 10) — 파서 두 형태·오식별 방지·매칭·미선언 통과·질의부재 통과
- [x] `npm run lint` 0 errors · `tsc --noEmit` 통과
- [ ] 배포 후 라이브: 발표자료 질의는 주입 유지 / 클라우드 비교 질의는 미주입

🤖 Generated with [Claude Code](https://claude.com/claude-code)