### PR TITLE
fix(mcp): instance pid 미기록 — 헬스체크가 죽은 프로세스를 판별하지 못하던 문제

### DIFF
--- a/apps/api/src/__tests__/lifecycle-supervisor.test.ts
+++ b/apps/api/src/__tests__/lifecycle-supervisor.test.ts
@@ -19,6 +19,9 @@ function mkRepo(): MockRepo {
     };
 }
 
+/** stdio 자식 프로세스 pid — 'running' 전이에 함께 기록되는지 검증하기 위한 고정값 */
+const MOCK_PID = 4242;
+
 function mkClientFactory() {
     const created: Array<{ serverId: string; client: unknown }> = [];
     const factory = jest.fn().mockImplementation((config: { id: string }) => {
@@ -28,6 +31,7 @@ function mkClientFactory() {
             listTools: jest.fn().mockResolvedValue({ tools: [] }),
             callTool: jest.fn(),
             on: jest.fn(),
+            getPid: jest.fn().mockReturnValue(MOCK_PID),
         };
         created.push({ serverId: config.id, client });
         return client;
@@ -76,7 +80,8 @@ describe('MCPLifecycleSupervisor', () => {
         expect(userPool.has('u-1', 's-chat')).toBe(false);
         expect(userPool.has('u-1', 's-off')).toBe(false);
         expect(repo.recordInstanceTransition).toHaveBeenCalledWith('s-session', 'u-1', 'starting');
-        expect(repo.recordInstanceTransition).toHaveBeenCalledWith('s-session', 'u-1', 'running');
+        // pid 를 함께 기록해야 헬스체크가 생존을 검증할 수 있다 (미전달 시 전량 NULL → missingPid 만 반환)
+        expect(repo.recordInstanceTransition).toHaveBeenCalledWith('s-session', 'u-1', 'running', MOCK_PID);
     });
 
     test('onChatStart: per_chat + per_session(auto_spawn) ensure, auto_spawn=false 제외', async () => {

--- a/apps/api/src/mcp/external-client.ts
+++ b/apps/api/src/mcp/external-client.ts
@@ -284,6 +284,27 @@ export class ExternalMCPClient extends EventEmitter {
     }
 
     /**
+     * stdio transport 가 spawn 한 자식 프로세스의 pid.
+     *
+     * lifecycle-supervisor 가 'running' 전이를 기록할 때 함께 남겨,
+     * 이후 헬스체크(process.kill(pid,0))가 실제 생존을 검증할 수 있게 한다.
+     * 이 접근자가 없어 pid 가 한 번도 기록되지 않았고(운영 3,404행 전부 NULL),
+     * 헬스체크가 항상 missingPid 만 반환했다.
+     *
+     * 원격 transport(sse/streamable-http)는 로컬 프로세스가 없으므로 null.
+     * Docker 샌드박스 경로에서는 `docker run` 프로세스의 pid 로, 컨테이너가 사는 동안
+     * 함께 살아 있어 생존 신호로 유효하다.
+     *
+     * @returns 자식 프로세스 pid, 없으면 null
+     */
+    getPid(): number | null {
+        const t = this.transport;
+        if (!t || !('pid' in t)) return null;
+        const pid = (t as { pid: number | null }).pid;
+        return typeof pid === 'number' ? pid : null;
+    }
+
+    /**
      * 서버 설정 반환
      *
      * @returns MCPServerConfig 복사본

--- a/apps/api/src/mcp/lifecycle-supervisor.ts
+++ b/apps/api/src/mcp/lifecycle-supervisor.ts
@@ -253,8 +253,12 @@ export class MCPLifecycleSupervisor implements LifecycleSupervisor {
 
         await client.connect();
         this.userPool.add(userId, serverId, client);
-        await this.repo.recordInstanceTransition(serverId, userId, 'running').catch(() => { /* noop */ });
-        logger.info(`spawn 완료 u=${userId} s=${serverId}`);
+        // pid 를 함께 남긴다 — 이게 없어서 운영 instance 행이 전부 pid NULL 이었고,
+        // 헬스체크(verifyRunningInstancesByPid)가 항상 missingPid 만 반환해
+        // 죽은 프로세스를 판별하지 못했다. 원격 transport 는 pid 가 없어 종전대로 null.
+        const pid = client.getPid?.() ?? undefined;
+        await this.repo.recordInstanceTransition(serverId, userId, 'running', pid).catch(() => { /* noop */ });
+        logger.info(`spawn 완료 u=${userId} s=${serverId} pid=${pid ?? 'n/a'}`);
         return client;
     }
 }


### PR DESCRIPTION
#523 후속. 그 PR 에서 배선한 MCP 인스턴스 헬스체크가 **실제로는 아무것도 검증하지 못하고 있던** 것을 고친다.

## 문제

`verifyRunningInstancesByPid` 는 `process.kill(pid, 0)` 으로 생존을 확인하는데, **pid 가 한 번도 기록된 적이 없었다.**

```
SELECT count(*) total, count(pid) with_pid FROM mcp_server_instances;
--  total = 3404,  with_pid = 0
```

따라서 헬스체크는 언제 눌러도 `verified=0, declaredDead=0, missingPid=N` 만 반환했다. pid 가 null 인 행은 `missingPid++` 후 `continue` 라 죽은 것으로 표시되지 않기 때문이다.

원인은 **딱 한 곳**이다. 저장 계층 `recordInstanceTransition(serverId, userId, status, pid?, lastError?)` 은 이미 pid 를 INSERT 하고 있는데, **호출부 7곳이 전부 pid 인자를 생략**했다 (`lifecycle-supervisor` 5곳, `mcp-catalog.routes` 2곳).

## 수정

- **`external-client.ts`** — `getPid()` 추가. SDK `StdioClientTransport` 가 노출하는 자식 프로세스 pid 를 반환한다. 원격 transport(sse/streamable-http)는 로컬 프로세스가 없어 `null`. Docker 샌드박스 경로에서는 `docker run` 프로세스의 pid 인데, 컨테이너가 사는 동안 함께 살아 있어 생존 신호로 유효하다.
- **`lifecycle-supervisor.ts`** — `'running'` 전이에 pid 를 함께 기록. spawn 로그에도 노출. `clientFactory` 를 스텁으로 주입하는 호출자를 위해 옵셔널 호출(`getPid?.()`).
- **테스트** — 목 클라이언트에 `getPid` 추가 + `'running'` 전이가 pid 를 실어 기록하는지 단언.

기존 NULL pid 행은 **append-only 이력**이라 그대로 둔다(정리 마이그레이션 불필요). 헬스체크는 그 행들을 `missingPid` 로만 집계한다.

## 라이브 검증 (chat.openmake.cc)

| 단계 | 결과 |
|---|---|
| `POST /api/mcp/servers/:id/start` | transition 행에 **`pid=57375` 기록** (직전 기동까지는 NULL). `ps` 로 해당 pid 가 `docker run --rm -i --init --network bridge --cap-drop ALL ...` 임을 확인 |
| `POST .../instances/health-check` | **`verified=1`**, declaredDead=0, missingPid=297 (구 이력분) |
| 존재하지 않는 pid(999999)로 `running` 행 합성 후 재실행 | **`declaredDead=1`** — 해당 행이 `status='crashed'`, `last_error='process not alive (health check)'` 로 정확히 갱신. 합성 행은 검증 후 삭제 |

`tsc` 0, eslint 0 error, `npm test --workspace=apps/api` **240 suites / 2704 tests 통과**.

---

## 📌 #523 코멘트 정정 — "좀비 row 3,250건" 은 사실이 아니었다

이 작업 중 확인한 결과, #523 코멘트와 본문에서 내가 쓴 *"좀비 row 3,250건 / 1,437건이 1일 이상 running"* 은 **틀렸다.** `mcp_server_instances` 는 append-only 이력 테이블이고, 그 3,404행은 정상적인 누적 transition 기록이다(예: notebooklm 단독 508회 기동).

내가 근거로 삼은 숫자는 `getUserInstancesSummary` 의 `currentRunning` 인데, 이 쿼리가 **이력 전체를 세고 있다**:

```sql
COUNT(*) FILTER (WHERE status IN ('starting','running')) AS current_running
```

반면 같은 리포지토리의 `getServerInstanceMetrics` 는 **최신 transition 1건**으로 올바르게 계산한다:

```sql
(CASE WHEN (SELECT status FROM mcp_server_instances
            WHERE mcp_server_id=$1 AND user_id=$2
            ORDER BY started_at DESC LIMIT 1) = 'running' THEN 1 ELSE 0 END)
```

그래서 UI 패널의 "실행 중"은 notebooklm 기준 `1` 로 정확히 나온다. 즉 **데이터가 오염된 게 아니라 `getUserInstancesSummary` 한 쿼리가 잘못됐다.**

이 PR 범위 밖이라 손대지 않았다. 고친다면 최신 transition 기준(서버별 `DISTINCT ON` 후 집계)으로 바꾸면 된다. 현재 `GET /api/mcp/instances/summary` 는 프론트에서 사용하지 않아 사용자 노출은 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
