### PR TITLE
feat(ios): 카카오 지도 블록을 네이티브 지도 카드로 렌더

### DIFF
--- a/apps/ios/OpenMakeApp/Features/Conversations/KakaoMapCard.swift
+++ b/apps/ios/OpenMakeApp/Features/Conversations/KakaoMapCard.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+import MapKit
+import OpenMakeKit
+
+/// ```kakaomap 블록을 네이티브 지도 카드로 렌더한다.
+///
+/// 백엔드는 카카오 search-places 결과를 이 블록으로 결정적 주입하는데, 앱에 렌더러가
+/// 없어 raw JSON 코드블록으로 보였다 — 사용자에게는 "앱에서만 카카오가 안 된다"로
+/// 보이던 갭(2026-08-18 실측). 지도 자체는 MapKit 으로 그리고(서드파티 0 유지),
+/// 각 장소는 카카오맵 상세 페이지로 연결한다.
+struct KakaoMapCard: View {
+    let payload: KakaoMapPayload
+
+    @State private var camera: MapCameraPosition = .automatic
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Map(position: $camera) {
+                ForEach(payload.places) { place in
+                    Marker(place.name, coordinate: place.coordinate)
+                        .tint(Lumen.accent)
+                }
+                if payload.route.count > 1 {
+                    MapPolyline(coordinates: payload.route.map(\.coordinate))
+                        .stroke(Lumen.accent, lineWidth: 4)
+                }
+            }
+            .frame(height: 220)
+            .allowsHitTesting(true)
+
+            if !payload.places.isEmpty {
+                Divider().overlay(Lumen.border)
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(payload.places.enumerated()), id: \.element.id) { index, place in
+                        if index > 0 { Divider().overlay(Lumen.border).padding(.leading, 12) }
+                        placeRow(place)
+                    }
+                }
+            }
+        }
+        .background(Lumen.surface, in: RoundedRectangle(cornerRadius: 14))
+        .overlay(RoundedRectangle(cornerRadius: 14).strokeBorder(Lumen.border))
+        .onAppear { camera = .region(payload.region) }
+    }
+
+    @ViewBuilder
+    private func placeRow(_ place: KakaoPlace) -> some View {
+        Button {
+            if let raw = place.url, let url = URL(string: raw) { openURL(url) }
+        } label: {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "mappin.circle.fill")
+                    .font(.system(size: 15))
+                    .foregroundStyle(Lumen.accent)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(place.name)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(Lumen.fg)
+                    if let address = place.address {
+                        Text(address)
+                            .font(.caption)
+                            .foregroundStyle(Lumen.muted)
+                    }
+                }
+                Spacer(minLength: 0)
+                if place.url != nil {
+                    Image(systemName: "chevron.right")
+                        .font(.caption2)
+                        .foregroundStyle(Lumen.faint)
+                }
+            }
+            .padding(12)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(place.url == nil)
+        .accessibilityHint(place.url == nil ? "" : "카카오맵에서 열기")
+    }
+}
+
+private extension KakaoPlace {
+    var coordinate: CLLocationCoordinate2D { .init(latitude: lat, longitude: lng) }
+}
+
+private extension KakaoRoutePoint {
+    var coordinate: CLLocationCoordinate2D { .init(latitude: lat, longitude: lng) }
+}
+
+private extension KakaoMapPayload {
+    /// 모든 지점이 들어오도록 경계 상자를 잡고 여유를 준다. 한 점뿐이면 고정 배율.
+    var region: MKCoordinateRegion {
+        let coords = places.map { ($0.lat, $0.lng) } + route.map { ($0.lat, $0.lng) }
+        guard let first = coords.first else {
+            return MKCoordinateRegion(
+                center: .init(latitude: 37.5665, longitude: 126.9780),
+                span: .init(latitudeDelta: 0.05, longitudeDelta: 0.05))
+        }
+        var minLat = first.0, maxLat = first.0, minLng = first.1, maxLng = first.1
+        for (lat, lng) in coords {
+            minLat = min(minLat, lat); maxLat = max(maxLat, lat)
+            minLng = min(minLng, lng); maxLng = max(maxLng, lng)
+        }
+        let center = CLLocationCoordinate2D(
+            latitude: (minLat + maxLat) / 2,
+            longitude: (minLng + maxLng) / 2)
+        let span = MKCoordinateSpan(
+            latitudeDelta: max((maxLat - minLat) * 1.4, 0.006),
+            longitudeDelta: max((maxLng - minLng) * 1.4, 0.006))
+        return MKCoordinateRegion(center: center, span: span)
+    }
+}

--- a/apps/ios/OpenMakeApp/Features/Conversations/MarkdownText.swift
+++ b/apps/ios/OpenMakeApp/Features/Conversations/MarkdownText.swift
@@ -33,7 +33,12 @@ struct MarkdownText: View {
             case .text(let text):
                 RichTextBlock(text: text)
             case .code(let language, let body):
-                CodeBlockView(language: language, code: body)
+                // ```kakaomap 은 지도 카드로 — 그대로 두면 좌표 JSON 이 노출된다
+                if language == KakaoMapBlock.language, let payload = KakaoMapBlock.parse(body) {
+                    KakaoMapCard(payload: payload)
+                } else {
+                    CodeBlockView(language: language, code: body)
+                }
             }
         }
     }

--- a/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/KakaoMapBlock.swift
+++ b/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/KakaoMapBlock.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// ```kakaomap 블록이 담는 장소 하나.
+/// 백엔드(external-deterministic-append)가 search-places 도구 결과로 결정적 주입한다.
+public struct KakaoPlace: Equatable, Sendable, Identifiable {
+    public let name: String
+    public let lat: Double
+    public let lng: Double
+    public let address: String?
+    public let url: String?
+
+    /// 같은 이름의 지점이 여러 개일 수 있어 좌표까지 묶어 식별자로 쓴다.
+    public var id: String { "\(name)@\(lat),\(lng)" }
+
+    public init(name: String, lat: Double, lng: Double, address: String? = nil, url: String? = nil) {
+        self.name = name
+        self.lat = lat
+        self.lng = lng
+        self.address = address
+        self.url = url
+    }
+}
+
+/// 경로 폴리라인 좌표.
+public struct KakaoRoutePoint: Equatable, Sendable {
+    public let lat: Double
+    public let lng: Double
+
+    public init(lat: Double, lng: Double) {
+        self.lat = lat
+        self.lng = lng
+    }
+}
+
+public struct KakaoMapPayload: Equatable, Sendable {
+    public let places: [KakaoPlace]
+    public let route: [KakaoRoutePoint]
+
+    public var isEmpty: Bool { places.isEmpty && route.isEmpty }
+}
+
+/// ```kakaomap 코드펜스 본문(JSON) 파서.
+///
+/// 앱에 렌더러가 없어 이 블록이 raw JSON 으로 노출되던 갭을 메운다 — 웹은
+/// components/chat/kakao-map.tsx 가 지도로 렌더하는데 앱에는 대응이 없었다(2026-08-18 실측).
+/// 좌표가 유한값이 아닌 항목은 버린다(웹 구현과 동일 규칙).
+public enum KakaoMapBlock {
+    public static let language = "kakaomap"
+
+    public static func parse(_ json: String) -> KakaoMapPayload? {
+        guard let data = json.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+
+        let places: [KakaoPlace] = (root["places"] as? [[String: Any]] ?? []).compactMap { raw in
+            guard let name = raw["name"] as? String, !name.isEmpty,
+                  let lat = finiteDouble(raw["lat"]),
+                  let lng = finiteDouble(raw["lng"]) else { return nil }
+            let address = (raw["address"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+            let url = (raw["url"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+            return KakaoPlace(name: name, lat: lat, lng: lng, address: address, url: url)
+        }
+
+        let route: [KakaoRoutePoint] = (root["route"] as? [[String: Any]] ?? []).compactMap { raw in
+            guard let lat = finiteDouble(raw["lat"]), let lng = finiteDouble(raw["lng"]) else { return nil }
+            return KakaoRoutePoint(lat: lat, lng: lng)
+        }
+
+        let payload = KakaoMapPayload(places: places, route: route)
+        return payload.isEmpty ? nil : payload
+    }
+
+    private static func finiteDouble(_ value: Any?) -> Double? {
+        let number: Double?
+        switch value {
+        case let d as Double: number = d
+        case let i as Int: number = Double(i)
+        case let s as String: number = Double(s)
+        default: number = nil
+        }
+        guard let number, number.isFinite else { return nil }
+        return number
+    }
+}

--- a/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/KakaoMapBlockTests.swift
+++ b/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/KakaoMapBlockTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import OpenMakeKit
+
+final class KakaoMapBlockTests: XCTestCase {
+    func testParsesPlacesFromServerPayload() throws {
+        let json = """
+        {"places":[
+          {"name":"스타벅스 선릉세화빌딩점","lat":37.5044,"lng":127.0489,"address":"서울 강남구 대치동 889-70","url":"http://place.map.kakao.com/1"},
+          {"name":"써트커피","lat":37.5061,"lng":127.0533}
+        ]}
+        """
+        let payload = try XCTUnwrap(KakaoMapBlock.parse(json))
+        XCTAssertEqual(payload.places.count, 2)
+        XCTAssertEqual(payload.places[0].name, "스타벅스 선릉세화빌딩점")
+        XCTAssertEqual(payload.places[0].address, "서울 강남구 대치동 889-70")
+        XCTAssertNil(payload.places[1].address)
+        XCTAssertTrue(payload.route.isEmpty)
+    }
+
+    func testDropsPlacesWithInvalidCoordinates() throws {
+        let json = """
+        {"places":[
+          {"name":"정상","lat":37.5,"lng":127.0},
+          {"name":"좌표없음"},
+          {"name":"문자열좌표","lat":"37.6","lng":"127.1"}
+        ]}
+        """
+        let payload = try XCTUnwrap(KakaoMapBlock.parse(json))
+        XCTAssertEqual(payload.places.map(\.name), ["정상", "문자열좌표"])
+    }
+
+    func testParsesRoutePoints() throws {
+        let json = #"{"places":[],"route":[{"lat":37.5,"lng":127.0},{"lat":37.6,"lng":127.1}]}"#
+        let payload = try XCTUnwrap(KakaoMapBlock.parse(json))
+        XCTAssertEqual(payload.route.count, 2)
+    }
+
+    func testReturnsNilForEmptyOrInvalidPayload() {
+        XCTAssertNil(KakaoMapBlock.parse("not json"))
+        XCTAssertNil(KakaoMapBlock.parse(#"{"places":[]}"#))
+        XCTAssertNil(KakaoMapBlock.parse(#"{"places":[{"name":"좌표없음"}]}"#))
+    }
+
+    func testPlaceIdDistinguishesSameNameDifferentBranches() {
+        let a = KakaoPlace(name: "스타벅스", lat: 37.5, lng: 127.0)
+        let b = KakaoPlace(name: "스타벅스", lat: 37.6, lng: 127.1)
+        XCTAssertNotEqual(a.id, b.id)
+    }
+}


### PR DESCRIPTION
## 문제 — "앱에서만 카카오가 안 된다"

시뮬레이터로 재현해보니 **MCP 는 정상 동작하고 있었다**. 서버 로그(앱에서 보낸 요청):

```
[ToolMerger] user MCP 자동 노출: 46개 중 12개(8KB) 노출
[Map] 위치/지도 의도 감지 — generate_image 억제 (잔여 도구 25종)
[Map] 첫 턴 tool_choice 강제: mcp-kakao::search-places
[MCP] 🔧 도구 실행: mcp-kakao::search-places (user: 3)
[ChatExternalProvider] 외부 provider 호출 완료 (in=31156, out=190, tools=25)
```

좌표·주소가 담긴 ` ```kakaomap ` 블록도 정상 주입됐다. 진짜 문제는 **앱에 그 블록의 렌더러가 없어** 사용자에게 raw JSON 코드블록으로 보인 것이다:

```
kakaomap
{"places":[{"name":"스타벅스 선릉세화빌딩점","lat":37.5…
```

웹은 `apps/web/components/chat/kakao-map.tsx` 가 지도로 렌더하는데 앱에는 대응이 없었다. 서버가 잘 주는데 클라이언트 한쪽만 못 받는, `project_external_path_skill_memory_omission` 과 같은 계열의 비대칭이다.

## 변경

| 파일 | 역할 |
|---|---|
| `KakaoMapBlock` (Kit) | ` ```kakaomap ` 본문 파서. 좌표가 유한값이 아닌 항목은 버린다(웹과 동일 규칙). `places`/`route` 둘 다 비면 `nil` → 기존 코드블록으로 폴백 |
| `KakaoMapCard` (앱) | MapKit 지도(마커 + route 폴리라인) + 장소 목록. **서드파티 0 유지**. 각 행은 카카오맵 상세 페이지로 연결(`url` 없으면 비활성) |
| `MarkdownText` | 코드블록 분기에서 `language == "kakaomap"` 이고 파싱 성공 시 카드로 렌더 |

카메라는 전 지점을 담는 경계 상자에 여유를 주고, 한 점뿐이면 최소 배율을 보장한다.

## 검증

- [x] OpenMakeKit **70** 테스트(신규 5 — 파싱·잘못된 좌표 제거·route·빈 payload nil·동명 지점 id 구분)
- [x] 시뮬레이터 라이브: 선릉역 질의에서 핀 + 장소 목록 정상 렌더 (raw JSON → 지도)
- [ ] 본 PR CI

## 참고

같은 점검에서 나온 별건 둘은 따로 다룬다 — searxng SSRF 차단은 #525, 사용자 MCP 도구 노출 상한(46개 중 12개 round-robin)은 설정 판단이 필요해 보류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)