### PR TITLE
feat(ios): 카카오 타일로 지도 렌더 (서버 임베드 + MapKit 폴백)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -344,6 +344,12 @@ GITHUB_CLIENT_SECRET=
 KAKAO_CLIENT_ID=
 KAKAO_CLIENT_SECRET=
 
+# 카카오 지도 JS SDK 키 — 네이티브 앱용 임베드(/embed/kakao-map)가 이 값으로 지도를 그린다.
+# 웹의 NEXT_PUBLIC_KAKAO_JS_KEY 와 같은 값(클라이언트 노출용, 카카오 콘솔의 JS SDK 도메인
+# 제한으로 보호). 미설정 시 앱은 MapKit 지도로 자동 폴백한다.
+# ⚠️ 앱이 접속하는 서버 도메인이 카카오 콘솔 [플랫폼 > Web]에 등록돼 있어야 타일이 뜬다.
+# KAKAO_JS_KEY=
+
 # *******************************************************
 # 🔍 웹 검색 설정 (Google Custom Search)
 # *******************************************************

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -544,6 +544,14 @@ export const RESEARCH_TAVILY = {
     SEARCH_DEPTH: (process.env.RESEARCH_TAVILY_DEPTH === 'basic' ? 'basic' : 'advanced') as 'basic' | 'advanced',
 } as const;
 
+/** 카카오 지도 임베드 HTML (네이티브 앱 WKWebView 용) */
+export const KAKAO_MAP_EMBED = {
+    /** 정적 HTML 이라 캐시 허용 — 장소 데이터는 앱이 주입하므로 응답에 없다 */
+    CACHE_SECONDS: Number(process.env.KAKAO_MAP_EMBED_CACHE_SECONDS) || 3600,
+    /** 단일 지점일 때의 기본 확대 레벨 (카카오 기준: 작을수록 확대) */
+    DEFAULT_LEVEL: Number(process.env.KAKAO_MAP_EMBED_DEFAULT_LEVEL) || 4,
+} as const;
+
 export const SEARXNG_CATEGORY_SCOPE = {
     /** 기술/개발 질의 → `it` 카테고리 (github·stackoverflow·mdn·pypi·docker hub).
      *  ⚠️ 단독 `코드` 같은 일반어 토큰 금지 — '할인 코드' 류 비기술 질의가 매칭돼 카테고리를 오염시킨다. */

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -22,6 +22,7 @@ export { mcpAdminMonitoringRouter } from './mcp-admin-monitoring.routes';
 export { adminModelRolesRouter } from './admin-model-roles.routes';
 export { adminSystemSettingsRouter } from './admin-system-settings.routes';
 export { firstRunSetupRouter } from './first-run-setup.routes';
+export { default as kakaoMapEmbedRouter } from './kakao-map-embed.routes';
 
 // 🆕 리팩토링된 라우트
 export { default as chatRouter, setClusterManager as setChatCluster } from './chat.routes';

--- a/apps/api/src/routes/kakao-map-embed.routes.ts
+++ b/apps/api/src/routes/kakao-map-embed.routes.ts
@@ -1,0 +1,116 @@
+/**
+ * 카카오 지도 임베드 HTML — 네이티브 앱(WKWebView)이 로드한다.
+ *
+ * 앱이 카카오 SDK 를 직접 부르려면 JS 키를 앱 바이너리에 넣어야 하고, 카카오 콘솔의
+ * 도메인 제한(JS 키 보호 수단)과도 맞지 않는다. 그래서 서버가 HTML 을 내려주고 앱은
+ * 그 URL 을 웹뷰로 띄운다 — 키는 서버에만 남고 origin 도 자연히 서버 도메인이 된다.
+ *
+ * 장소 데이터는 URL 로 넘기지 않고, 앱이 로드 후 `window.renderKakaoMap(payload)` 로
+ * 주입한다(장소 수가 늘어도 URL 길이 제한에 걸리지 않는다).
+ *
+ * @module routes/kakao-map-embed.routes
+ */
+import { Router, Request, Response } from 'express';
+import { KAKAO_MAP_EMBED } from '../config/runtime-limits';
+
+const router = Router();
+
+/**
+ * GET /embed/kakao-map
+ * 인증 없이 제공한다 — 담긴 비밀은 JS 키뿐이고, 그 키는 웹 번들에도 이미 들어 있으며
+ * 카카오 콘솔의 도메인 제한으로 보호된다. 장소 데이터는 응답에 포함되지 않는다.
+ */
+router.get('/kakao-map', (_req: Request, res: Response) => {
+    const jsKey = process.env.KAKAO_JS_KEY || '';
+    res.type('html');
+    res.setHeader('Cache-Control', `public, max-age=${KAKAO_MAP_EMBED.CACHE_SECONDS}`);
+    res.send(renderHtml(jsKey));
+});
+
+function renderHtml(jsKey: string): string {
+    // jsKey 는 콘솔 발급 값이라 영숫자만 오지만, 스크립트 URL 에 넣기 전에 한 번 더 좁힌다.
+    const safeKey = /^[A-Za-z0-9]{0,64}$/.test(jsKey) ? jsKey : '';
+    return `<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+<style>
+  html,body{margin:0;padding:0;height:100%;background:transparent;}
+  #map{width:100%;height:100%;}
+  #err{display:none;font:13px -apple-system,system-ui,sans-serif;color:#888;padding:12px;}
+</style>
+</head>
+<body>
+<div id="map"></div>
+<div id="err">지도를 불러오지 못했습니다</div>
+<script>
+(function(){
+  var pending = null, ready = false;
+
+  // 앱이 로드 완료 전에 호출해도 잃지 않도록 보관했다가 SDK 준비 시 그린다.
+  window.renderKakaoMap = function(payload){
+    if (!ready) { pending = payload; return; }
+    draw(payload);
+  };
+
+  function fail(){
+    document.getElementById('map').style.display='none';
+    document.getElementById('err').style.display='block';
+    if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.mapStatus) {
+      window.webkit.messageHandlers.mapStatus.postMessage('failed');
+    }
+  }
+
+  function draw(payload){
+    try {
+      var places = (payload && payload.places) || [];
+      var route = (payload && payload.route) || [];
+      var container = document.getElementById('map');
+      var first = places[0] || route[0];
+      if (!first) { fail(); return; }
+      var map = new kakao.maps.Map(container, {
+        center: new kakao.maps.LatLng(first.lat, first.lng),
+        level: ${KAKAO_MAP_EMBED.DEFAULT_LEVEL}
+      });
+      var bounds = new kakao.maps.LatLngBounds();
+      places.forEach(function(p){
+        var pos = new kakao.maps.LatLng(p.lat, p.lng);
+        bounds.extend(pos);
+        var marker = new kakao.maps.Marker({ map: map, position: pos, title: p.name });
+        if (p.name) {
+          var iw = new kakao.maps.InfoWindow({
+            content: '<div style="padding:4px 8px;font-size:12px;white-space:nowrap">' +
+              String(p.name).replace(/[<>&"]/g, '') + '</div>'
+          });
+          kakao.maps.event.addListener(marker, 'click', function(){ iw.open(map, marker); });
+        }
+      });
+      if (route.length > 1) {
+        var path = route.map(function(r){ var ll = new kakao.maps.LatLng(r.lat, r.lng); bounds.extend(ll); return ll; });
+        new kakao.maps.Polyline({ map: map, path: path, strokeWeight: 4, strokeColor: '#2F6BFF', strokeOpacity: 0.9 });
+      }
+      if (places.length + route.length > 1) { map.setBounds(bounds); }
+      if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.mapStatus) {
+        window.webkit.messageHandlers.mapStatus.postMessage('ready');
+      }
+    } catch (e) { fail(); }
+  }
+
+  if (!'${safeKey}') { fail(); return; }
+  var s = document.createElement('script');
+  s.src = 'https://dapi.kakao.com/v2/maps/sdk.js?appkey=${safeKey}&autoload=false';
+  s.async = true;
+  s.onload = function(){
+    if (!window.kakao || !window.kakao.maps) { fail(); return; }
+    kakao.maps.load(function(){ ready = true; if (pending) draw(pending); });
+  };
+  s.onerror = fail;
+  document.head.appendChild(s);
+})();
+</script>
+</body>
+</html>`;
+}
+
+export default router;

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -40,6 +40,7 @@ import {
     adminModelRolesRouter,
     adminSystemSettingsRouter,
     firstRunSetupRouter,
+    kakaoMapEmbedRouter,
     usageRouter,
     nodesRouter,
     setNodesCluster,
@@ -226,6 +227,9 @@ export function setupApiRoutes(
     app.use('/api/auth', createAuthController(getConfig().port));
     // 첫 실행 셋업 마법사 (admin 0명일 때만 동작하는 일회성 공개 엔드포인트, auth 계열 리미터)
     app.use('/api/setup', authLimiter, firstRunSetupRouter);
+
+    // 카카오 지도 임베드 HTML — 네이티브 앱 WKWebView 전용, /api 스코프 밖(인증·CSRF 무관).
+    app.use('/embed', kakaoMapEmbedRouter);
     app.use('/api/admin', createAdminController());
     // GDPR Phase B Fix 6 (B7) — 동의 조회/철회 API
     app.use('/api/users/me/consent', createConsentController());

--- a/apps/ios/OpenMakeApp/Features/Conversations/KakaoMapCard.swift
+++ b/apps/ios/OpenMakeApp/Features/Conversations/KakaoMapCard.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import MapKit
+import WebKit
 import OpenMakeKit
 
 /// ```kakaomap 블록을 네이티브 지도 카드로 렌더한다.
@@ -12,22 +13,19 @@ struct KakaoMapCard: View {
     let payload: KakaoMapPayload
 
     @State private var camera: MapCameraPosition = .automatic
+    @State private var kakaoFailed = false
     @Environment(\.openURL) private var openURL
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Map(position: $camera) {
-                ForEach(payload.places) { place in
-                    Marker(place.name, coordinate: place.coordinate)
-                        .tint(Lumen.accent)
-                }
-                if payload.route.count > 1 {
-                    MapPolyline(coordinates: payload.route.map(\.coordinate))
-                        .stroke(Lumen.accent, lineWidth: 4)
-                }
+            // 카카오 타일이 기본 — 검색 결과가 카카오 기준이라 지도도 같은 출처가 맞다.
+            // SDK 키 미설정·도메인 미등록·네트워크 실패 시 MapKit 으로 되돌아간다.
+            if kakaoFailed {
+                mapKitView
+            } else {
+                KakaoMapWebView(payload: payload, onFailure: { kakaoFailed = true })
+                    .frame(height: 220)
             }
-            .frame(height: 220)
-            .allowsHitTesting(true)
 
             if !payload.places.isEmpty {
                 Divider().overlay(Lumen.border)
@@ -41,6 +39,22 @@ struct KakaoMapCard: View {
         }
         .background(Lumen.surface, in: RoundedRectangle(cornerRadius: 14))
         .overlay(RoundedRectangle(cornerRadius: 14).strokeBorder(Lumen.border))
+    }
+
+    private var mapKitView: some View {
+        VStack(spacing: 0) {
+            Map(position: $camera) {
+                ForEach(payload.places) { place in
+                    Marker(place.name, coordinate: place.coordinate)
+                        .tint(Lumen.accent)
+                }
+                if payload.route.count > 1 {
+                    MapPolyline(coordinates: payload.route.map(\.coordinate))
+                        .stroke(Lumen.accent, lineWidth: 4)
+                }
+            }
+            .frame(height: 220)
+        }
         .onAppear { camera = .region(payload.region) }
     }
 
@@ -108,5 +122,124 @@ private extension KakaoMapPayload {
             latitudeDelta: max((maxLat - minLat) * 1.4, 0.006),
             longitudeDelta: max((maxLng - minLng) * 1.4, 0.006))
         return MKCoordinateRegion(center: center, span: span)
+    }
+}
+
+/// 서버가 내려주는 카카오 지도 임베드(`/embed/kakao-map`)를 띄우는 웹뷰.
+///
+/// 앱이 카카오 SDK 를 직접 부르려면 JS 키를 바이너리에 넣어야 하고 콘솔의 도메인 제한과도
+/// 어긋난다. 서버 HTML 을 그대로 로드하면 키는 서버에만 남고 origin 도 서버 도메인이 된다.
+/// 장소 데이터는 URL 이 아니라 로드 완료 후 JS 로 주입한다(장소가 많아도 길이 제한이 없다).
+private struct KakaoMapWebView: UIViewRepresentable {
+    let payload: KakaoMapPayload
+    let onFailure: () -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator(payload: payload, onFailure: onFailure) }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .nonPersistent()
+        config.userContentController.add(context.coordinator, name: "mapStatus")
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = context.coordinator
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.scrollView.isScrollEnabled = false   // 카드 안이라 지도 제스처만 남긴다
+
+        var request = URLRequest(url: AppConfig.serverURL.appendingPathComponent("embed/kakao-map"))
+        request.timeoutInterval = Coordinator.loadTimeout
+        webView.load(request)
+        context.coordinator.startWatchdog()
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        context.coordinator.webView = webView
+    }
+
+    static func dismantleUIView(_ webView: WKWebView, coordinator: Coordinator) {
+        coordinator.cancelWatchdog()
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "mapStatus")
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
+        static let loadTimeout: TimeInterval = 8
+
+        private let payload: KakaoMapPayload
+        private let onFailure: () -> Void
+        private var didSettle = false
+        private var watchdog: Task<Void, Never>?
+        weak var webView: WKWebView?
+
+        init(payload: KakaoMapPayload, onFailure: @escaping () -> Void) {
+            self.payload = payload
+            self.onFailure = onFailure
+        }
+
+        /// SDK 가 조용히 멈추는 경우까지 덮는다 — 시간 안에 'ready' 가 안 오면 MapKit 으로.
+        func startWatchdog() {
+            watchdog = Task { [weak self] in
+                try? await Task.sleep(for: .seconds(Coordinator.loadTimeout))
+                guard let self, !Task.isCancelled else { return }
+                await MainActor.run { self.settleAsFailure() }
+            }
+        }
+
+        func cancelWatchdog() {
+            watchdog?.cancel()
+            watchdog = nil
+        }
+
+        @MainActor
+        private func settleAsFailure() {
+            guard !didSettle else { return }
+            didSettle = true
+            cancelWatchdog()
+            onFailure()
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            guard let json = encodedPayload() else {
+                Task { @MainActor in settleAsFailure() }
+                return
+            }
+            webView.evaluateJavaScript("window.renderKakaoMap(\(json));") { [weak self] _, error in
+                if error != nil { Task { @MainActor in self?.settleAsFailure() } }
+            }
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            Task { @MainActor in settleAsFailure() }
+        }
+
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            Task { @MainActor in settleAsFailure() }
+        }
+
+        func userContentController(_ controller: WKUserContentController, didReceive message: WKScriptMessage) {
+            guard message.name == "mapStatus", let status = message.body as? String else { return }
+            Task { @MainActor in
+                if status == "ready" {
+                    didSettle = true
+                    cancelWatchdog()
+                } else {
+                    settleAsFailure()
+                }
+            }
+        }
+
+        private func encodedPayload() -> String? {
+            let places: [[String: Any]] = payload.places.map { place in
+                var item: [String: Any] = ["name": place.name, "lat": place.lat, "lng": place.lng]
+                if let address = place.address { item["address"] = address }
+                return item
+            }
+            let route: [[String: Any]] = payload.route.map { ["lat": $0.lat, "lng": $0.lng] }
+            let root: [String: Any] = ["places": places, "route": route]
+            guard let data = try? JSONSerialization.data(withJSONObject: root),
+                  let json = String(data: data, encoding: .utf8) else { return nil }
+            return json
+        }
     }
 }


### PR DESCRIPTION
## 배경

#526 에서 지도 카드가 붙었지만, 카카오 검색 결과를 **Apple 지도**에 핀으로 찍고 있었다. 검색이 카카오 기준이니 지도도 같은 출처가 맞다는 판단으로 카카오 타일을 기본으로 바꾼다.

## 왜 서버 임베드인가

앱이 카카오 SDK 를 직접 부르려면 JS 키를 앱 바이너리에 넣어야 한다. 그런데 이 키를 보호하는 수단이 **카카오 콘솔의 도메인 제한**이라, 앱 origin 과는 애초에 맞물리지 않는다.

그래서 서버가 임베드 HTML(`GET /embed/kakao-map`)을 내려주고 앱은 그 URL 을 `WKWebView` 로 띄운다:

- JS 키는 **서버에만** 남는다 (앱 바이너리 노출 0)
- origin 이 자연히 서버 도메인이라 콘솔의 도메인 등록과 그대로 맞는다
- 장소 데이터는 URL 이 아니라 로드 후 `window.renderKakaoMap(payload)` 로 주입 — 장소가 많아도 URL 길이 제한이 없고, HTML 자체는 정적이라 캐시된다

## 폴백 — 지도가 안 보이는 경우는 없다

| 상황 | 동작 |
|---|---|
| `KAKAO_JS_KEY` 미설정 | MapKit 카드 |
| 콘솔에 도메인 미등록 / SDK 스크립트 오류 | MapKit 카드 |
| 네트워크 실패 | MapKit 카드 |
| SDK 가 조용히 멈춤 | 8초 watchdog → MapKit 카드 |

장소 목록과 카카오맵 링크는 어느 경로든 동일하게 나온다.

## 보안

라우트는 `/api` 스코프 **밖**에 둔다 — 웹뷰가 여는 정적 HTML 이라 인증·CSRF 대상이 아니다. 응답에 담기는 비밀은 JS 키뿐이고, 이는 웹 번들(`NEXT_PUBLIC_KAKAO_JS_KEY`)에도 이미 들어 있는 값이다. 키는 스크립트 URL 에 넣기 전 영숫자 64자 이내로 한 번 더 좁힌다.

## 배포 시 필요한 것

1. `.env` 에 `KAKAO_JS_KEY=<웹과 동일한 값>` 추가
2. 카카오 콘솔 [플랫폼 > Web] 에 **앱이 접속하는 서버 도메인** 등록 (미등록 시 조용히 MapKit 폴백)

## 검증

- [x] `tsc --noEmit` · 시뮬레이터 빌드
- [ ] 배포 후 실기기: 카카오 타일 렌더 확인
- [ ] 본 PR CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)