### PR TITLE
fix(ios): 카카오 지도 임베드를 /api/embed 로 이동 (외부 경로 404)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -344,7 +344,7 @@ GITHUB_CLIENT_SECRET=
 KAKAO_CLIENT_ID=
 KAKAO_CLIENT_SECRET=
 
-# 카카오 지도 JS SDK 키 — 네이티브 앱용 임베드(/embed/kakao-map)가 이 값으로 지도를 그린다.
+# 카카오 지도 JS SDK 키 — 네이티브 앱용 임베드(/api/embed/kakao-map)가 이 값으로 지도를 그린다.
 # 웹의 NEXT_PUBLIC_KAKAO_JS_KEY 와 같은 값(클라이언트 노출용, 카카오 콘솔의 JS SDK 도메인
 # 제한으로 보호). 미설정 시 앱은 MapKit 지도로 자동 폴백한다.
 # ⚠️ 앱이 접속하는 서버 도메인이 카카오 콘솔 [플랫폼 > Web]에 등록돼 있어야 타일이 뜬다.

--- a/apps/api/src/routes/kakao-map-embed.routes.ts
+++ b/apps/api/src/routes/kakao-map-embed.routes.ts
@@ -16,7 +16,7 @@ import { KAKAO_MAP_EMBED } from '../config/runtime-limits';
 const router = Router();
 
 /**
- * GET /embed/kakao-map
+ * GET /api/embed/kakao-map
  * 인증 없이 제공한다 — 담긴 비밀은 JS 키뿐이고, 그 키는 웹 번들에도 이미 들어 있으며
  * 카카오 콘솔의 도메인 제한으로 보호된다. 장소 데이터는 응답에 포함되지 않는다.
  */

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -228,8 +228,11 @@ export function setupApiRoutes(
     // 첫 실행 셋업 마법사 (admin 0명일 때만 동작하는 일회성 공개 엔드포인트, auth 계열 리미터)
     app.use('/api/setup', authLimiter, firstRunSetupRouter);
 
-    // 카카오 지도 임베드 HTML — 네이티브 앱 WKWebView 전용, /api 스코프 밖(인증·CSRF 무관).
-    app.use('/embed', kakaoMapEmbedRouter);
+    // 카카오 지도 임베드 HTML — 네이티브 앱 WKWebView 전용.
+    // /api 하위에 둔다: 운영 프록시(Caddy/Next)가 /api 만 백엔드로 보내므로 그 밖이면
+    // 외부 경로에서 404 가 된다(2026-08-18 실측). GET 이라 CSRF 는 스킵되고, /api 스코프
+    // 미들웨어는 Deprecation 헤더만 붙일 뿐 인증을 강제하지 않는다.
+    app.use('/api/embed', kakaoMapEmbedRouter);
     app.use('/api/admin', createAdminController());
     // GDPR Phase B Fix 6 (B7) — 동의 조회/철회 API
     app.use('/api/users/me/consent', createConsentController());

--- a/apps/ios/OpenMakeApp/Features/Conversations/KakaoMapCard.swift
+++ b/apps/ios/OpenMakeApp/Features/Conversations/KakaoMapCard.swift
@@ -125,7 +125,7 @@ private extension KakaoMapPayload {
     }
 }
 
-/// 서버가 내려주는 카카오 지도 임베드(`/embed/kakao-map`)를 띄우는 웹뷰.
+/// 서버가 내려주는 카카오 지도 임베드(`/api/embed/kakao-map`)를 띄우는 웹뷰.
 ///
 /// 앱이 카카오 SDK 를 직접 부르려면 JS 키를 바이너리에 넣어야 하고 콘솔의 도메인 제한과도
 /// 어긋난다. 서버 HTML 을 그대로 로드하면 키는 서버에만 남고 origin 도 서버 도메인이 된다.
@@ -147,7 +147,7 @@ private struct KakaoMapWebView: UIViewRepresentable {
         webView.backgroundColor = .clear
         webView.scrollView.isScrollEnabled = false   // 카드 안이라 지도 제스처만 남긴다
 
-        var request = URLRequest(url: AppConfig.serverURL.appendingPathComponent("embed/kakao-map"))
+        var request = URLRequest(url: AppConfig.serverURL.appendingPathComponent("api/embed/kakao-map"))
         request.timeoutInterval = Coordinator.loadTimeout
         webView.load(request)
         context.coordinator.startWatchdog()


### PR DESCRIPTION
## 문제

#527 이 임베드 라우트를 `/embed` 에 뒀는데, 운영 프록시는 **`/api` 만 Express 로 보내고** 나머지는 Next 로 넘긴다. 배포 후 실측:

```
로컬  http://127.0.0.1:52416/embed/kakao-map   → 200 (appkey 정상 주입)
외부  https://chat.openmake.cc/embed/kakao-map → 404
```

앱은 외부 경로로 붙으므로 웹뷰 로드가 실패하고, 폴백이 동작해 **조용히 MapKit 지도**가 나온다. 기능이 죽는 대신 이전 모습으로 돌아가는 형태라 눈치채기 어렵다.

## 변경

`/api/embed/kakao-map` 으로 옮긴다.

- GET 이라 CSRF 는 스킵된다
- `/api` 스코프 미들웨어는 Deprecation 헤더만 붙일 뿐 인증을 강제하지 않아 웹뷰 로드에 지장이 없다
- 프록시 설정(인프라)을 건드리지 않고 코드만으로 해결된다

앱 URL·`.env`·`.env.example` 주석도 함께 맞춘다.

## 검증

- [x] `tsc --noEmit`
- [ ] 배포 후 외부 경로 200 확인 → 실기기 카카오 타일 렌더

🤖 Generated with [Claude Code](https://claude.com/claude-code)