### PR TITLE
fix(chat): user MCP 도구 노출 cap 12 → 20 (예산이 실질 가드)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1347,8 +1347,10 @@ IMAGE_GEN_TIMEOUT_MS=180000
 # docker compose 로 기동 후 URL 지정. 미설정 시 비활성.
 # SEARXNG_URL=http://127.0.0.1:8888
 
-# 채팅 자동 노출 user MCP 도구 상한 (설치=기본 ON, 로컬 qwen tool-bloat 방지)
-CHAT_USER_MCP_TOOL_CAP=12
+# 채팅 자동 노출 user MCP 도구 상한 (설치=기본 ON, 로컬 qwen tool-bloat 방지).
+# 실질 가드는 CHAT_USER_MCP_SCHEMA_BUDGET_BYTES(스키마 바이트) — 개수만 늘려도
+# 바이트 예산에서 잘린다. 2026-08-19 12→20 (예산 16KB 중 8KB만 쓰고 개수에서 잘리던 문제)
+CHAT_USER_MCP_TOOL_CAP=20
 
 # MCP 진행적 공개 메타 도구(mcp_list_tools/mcp_call) — cap 밖 서버 도구 on-demand 접근. 기본 ON
 # 비활성화하려면 false 로 설정(opt-out)

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1133,9 +1133,16 @@ export const EXTERNAL_LLM_TOOL_BLACKLIST: readonly string[] = [
  * 설치한 사용자의 경우 전체 도구 스키마가 과대해져 vLLM 첫 토큰 컴파일이 지연/hang
  * 되는 것을 막기 위해(과거 ~150 도구 786KB → 첫토큰 101s 사례) 노출 수를 제한한다.
  * 초과분은 drop 하고 로그로 알린다. picker 로 끈 도구는 cap 계산 전에 제외된다.
+ *
+ * 2026-08-19: 12 → 20. 실측상 **개수 cap 이 바이트 예산보다 먼저 걸려** 정원을 낭비하고
+ * 있었다 — 운영 로그가 매 요청 `46개 중 12개(8KB)` 로, SCHEMA_BUDGET(16KB)의 절반만
+ * 쓰고도 개수에서 잘렸다. 도구당 평균 ~0.67KB 이므로 20개여도 ~13KB 로 예산 안이며,
+ * 바이트 상한이 실질 가드로 남는다(hang 근거였던 786KB 와는 두 자릿수 차이).
+ * 도구가 많은 서버(notebooklm 39·open-design 18)를 쓰는 사용자는 이 상한 때문에
+ * round-robin 앞쪽 2~3개만 노출돼 나머지에 접근할 방법이 서버명 언급뿐이었다.
  */
 export const CHAT_USER_MCP_TOOL_CAP = parseInt(
-    process.env.CHAT_USER_MCP_TOOL_CAP || '12',
+    process.env.CHAT_USER_MCP_TOOL_CAP || '20',
     10,
 );
 

--- a/apps/api/src/services/chat-service/__tests__/tool-merger-cap.test.ts
+++ b/apps/api/src/services/chat-service/__tests__/tool-merger-cap.test.ts
@@ -1,0 +1,91 @@
+/**
+ * user MCP 자동 노출 선정 — 개수 cap 과 스키마 바이트 예산의 이중 상한.
+ *
+ * 운영 실측(2026-08-19)에서 개수 cap 이 바이트 예산보다 먼저 걸려 정원을 낭비했다
+ * (`46개 중 12개(8KB)` / 예산 16KB). cap 상향 후에도 바이트 상한이 실질 가드로
+ * 남는지, 서버 언급 시 depth 우선이 유지되는지를 고정한다.
+ */
+import { selectUserMcpAutoOn } from '../tool-merger';
+
+type Tool = { type: 'function'; function: { name: string; description: string; parameters: unknown } };
+
+function makeTool(name: string, padding = 0): Tool {
+    return {
+        type: 'function',
+        function: {
+            name,
+            description: 'x'.repeat(padding),
+            parameters: { type: 'object', properties: {} },
+        },
+    };
+}
+
+function makeGroup(displayName: string, toolNames: string[], shortNames: string[] = []) {
+    return { displayName, tools: toolNames, shortNames };
+}
+
+describe('selectUserMcpAutoOn', () => {
+    it('cap 까지 채우되 서버마다 최소 1개는 대표된다', () => {
+        const groups = [
+            makeGroup('notebooklm', Array.from({ length: 39 }, (_, i) => `nb_${i}`)),
+            makeGroup('mcp-kakao', Array.from({ length: 7 }, (_, i) => `kakao_${i}`)),
+            makeGroup('open-design', Array.from({ length: 18 }, (_, i) => `od_${i}`)),
+        ];
+        const all = groups.flatMap(g => g.tools.map(n => makeTool(n))) as never;
+
+        const picked = selectUserMcpAutoOn(all, groups as never, {}, 12, 100_000, '');
+        expect(picked).toHaveLength(12);
+        const names = picked.map(t => t.function.name);
+        expect(names.some(n => n.startsWith('nb_'))).toBe(true);
+        expect(names.some(n => n.startsWith('kakao_'))).toBe(true);
+        expect(names.some(n => n.startsWith('od_'))).toBe(true);
+    });
+
+    it('cap 을 올리면 그만큼 더 노출된다 (예산이 넉넉할 때)', () => {
+        const groups = [
+            makeGroup('a', Array.from({ length: 30 }, (_, i) => `a_${i}`)),
+            makeGroup('b', Array.from({ length: 30 }, (_, i) => `b_${i}`)),
+        ];
+        const all = groups.flatMap(g => g.tools.map(n => makeTool(n))) as never;
+
+        expect(selectUserMcpAutoOn(all, groups as never, {}, 12, 100_000, '')).toHaveLength(12);
+        expect(selectUserMcpAutoOn(all, groups as never, {}, 20, 100_000, '')).toHaveLength(20);
+    });
+
+    it('바이트 예산이 개수보다 빡빡하면 예산이 실질 가드가 된다', () => {
+        const groups = [makeGroup('big', Array.from({ length: 30 }, (_, i) => `big_${i}`))];
+        // 도구 하나당 ~1KB 로 부풀려 예산(5KB)이 먼저 걸리게 한다
+        const all = groups[0].tools.map(n => makeTool(n, 1000)) as never;
+
+        const picked = selectUserMcpAutoOn(all, groups as never, {}, 20, 5_000, '');
+        expect(picked.length).toBeLessThan(20);
+        expect(picked.length).toBeGreaterThan(0);
+    });
+
+    it('예산이 아주 작아도 최소 1개는 노출한다', () => {
+        const groups = [makeGroup('big', ['big_0', 'big_1'])];
+        const all = groups[0].tools.map(n => makeTool(n, 5000)) as never;
+
+        expect(selectUserMcpAutoOn(all, groups as never, {}, 20, 10, '')).toHaveLength(1);
+    });
+
+    it('메시지가 서버를 언급하면 그 서버 도구를 우선 채운다', () => {
+        const groups = [
+            makeGroup('notebooklm', Array.from({ length: 10 }, (_, i) => `nb_${i}`)),
+            makeGroup('mcp-kakao', Array.from({ length: 10 }, (_, i) => `kakao_${i}`)),
+        ];
+        const all = groups.flatMap(g => g.tools.map(n => makeTool(n))) as never;
+
+        const picked = selectUserMcpAutoOn(all, groups as never, {}, 12, 100_000, 'notebooklm 으로 정리해줘');
+        const nb = picked.filter(t => t.function.name.startsWith('nb_'));
+        expect(nb).toHaveLength(10); // 참조 서버는 전부 우선
+    });
+
+    it('명시적으로 끈 도구(enabledTools=false)는 제외된다', () => {
+        const groups = [makeGroup('a', ['a_0', 'a_1', 'a_2'])];
+        const all = groups[0].tools.map(n => makeTool(n)) as never;
+
+        const picked = selectUserMcpAutoOn(all, groups as never, { a_1: false }, 20, 100_000, '');
+        expect(picked.map(t => t.function.name)).toEqual(['a_0', 'a_2']);
+    });
+});


### PR DESCRIPTION
## 문제 — 개수 cap 이 예산보다 먼저 걸려 정원을 낭비

운영 로그가 **매 요청** 같은 줄을 찍고 있었다:

```
[ToolMerger] user MCP 자동 노출: 46개 중 12개(8KB) 노출 (cap=12, round-robin)
```

`CHAT_USER_MCP_SCHEMA_BUDGET_BYTES` 는 16KB 인데 **8KB 만 쓰고 개수에서 잘렸다.** 도구가 많은 서버를 쓰는 사용자는 round-robin 앞쪽 2~3개만 노출돼, 나머지에 닿는 방법이 서버명 언급(의도 depth)뿐이었다.

**실사용 대비 정원 배분** (전체 로그 집계):

| 서버 | 도구 수 | 실제 호출 |
|---|---|---|
| notebooklm | 39 | 1 |
| open-design | 18 | 2 |
| mcp-filesystem | 14 | 2 |
| mcp-kakao | 7 | **10** |

정원을 가장 많이 차지하는 서버가 가장 적게 쓰인다.

## 변경

`CHAT_USER_MCP_TOOL_CAP` 12 → **20**.

- 도구당 평균 ~0.67KB 라 20개여도 ~13KB 로 예산 안 — **바이트 상한이 실질 가드로 남는다**
- hang 근거였던 사례(~150 도구 **786KB** → 첫토큰 101s)와는 두 자릿수 차이라 안전 범위
- 개수를 늘려도 스키마가 큰 서버는 여전히 바이트에서 잘린다

⚠️ 운영 `.env` 에 `CHAT_USER_MCP_TOOL_CAP=12` 가 명시돼 있어 **코드 기본값만으로는 반영되지 않는다.** `.env` 도 20 으로 갱신했다(배포 시 적용).

## 테스트

`tool-merger` 첫 테스트 6건:
cap 도달 시 서버별 최소 1개 대표 · cap 상향 효과 · 예산이 개수보다 빡빡할 때 예산 우선 · 예산이 아주 작아도 최소 1개 · 의도 depth(서버 언급 시 전량 우선) · `enabledTools=false` 명시 차단

## 참고 — 이미 있는 안전망

`MCP_PROGRESSIVE_DISCLOSURE_ENABLED`(기본 ON)의 `mcp_list_tools`/`mcp_call` 로 cap 밖 도구도 on-demand 접근이 가능하다(실사용 로그에 `mcp_list_tools` 3회). cap 이 절대적 차단은 아니지만, 모델이 그 경로를 자주 택하지는 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)