### PR TITLE
docs(chatgpt-oauth): 주석의 외부 프로젝트 참조 제거

### DIFF
--- a/apps/api/src/config/chatgpt-oauth.ts
+++ b/apps/api/src/config/chatgpt-oauth.ts
@@ -3,14 +3,13 @@
  * @description ChatGPT OAuth (Codex device flow) 설정 — L2 config + env override
  *
  * ChatGPT Plus/Pro 구독 계정으로 Codex 지원 GPT 모델을 사용하는 OAuth 통합.
- * 공식 Codex CLI 의 OAuth 클라이언트를 차용하는 방식으로, opencode ·
+ * 공식 Codex CLI 의 OAuth 클라이언트를 차용하는 방식으로,
  * openai-oauth(EvanZhouDev) 와 동일 계열 기법이다.
  *
  * ⚠️ 비공식 endpoint — OpenAI 가 언제든 변경/차단할 수 있다. 값이 바뀌면
  * env 로 무중단 오버라이드 가능하도록 전부 외부화한다.
  *
  * @see https://github.com/EvanZhouDev/openai-oauth (packages/core)
- * @see https://github.com/anomalyco/opencode (packages/opencode/src/plugin/openai/codex.ts)
  */
 
 /** 카탈로그 provider id — fullId prefix ('chatgpt:gpt-5.x') */

--- a/apps/api/src/providers/chatgpt-oauth/provider.ts
+++ b/apps/api/src/providers/chatgpt-oauth/provider.ts
@@ -8,10 +8,9 @@
  * responses-lite 등)는 @openai-oauth/core 의 transport fetch 가 담당하고,
  * 본 클래스는 IProvider 계약 ↔ Responses API 변환만 수행한다.
  *
- * ⚠️ Codex 백엔드는 Chat Completions 미지원 — **Responses API 전용**
- *    (opencode·openai-oauth 소스로 교차 확인, 2026-07-26).
+ * ⚠️ Codex 백엔드는 Chat Completions 미지원 — **Responses API 전용**.
  * ⚠️ temperature/max_output_tokens 는 Codex 가 거부할 수 있어 전달하지 않는다
- *    (opencode 의 chat.params 처리와 동일).
+ *    (Codex Responses API 제약에 맞춤).
  *
  * ESM 주의: @openai-oauth/core 는 ESM-only. Node 24 의 require(esm) 로 로드
  * 가능하지만 Jest CJS 런타임은 불가 — moduleNameMapper 로 shim 처리되며,

--- a/apps/api/src/providers/chatgpt-oauth/session.ts
+++ b/apps/api/src/providers/chatgpt-oauth/session.ts
@@ -70,7 +70,7 @@ export function parseJwtClaims(token: string): Record<string, unknown> | undefin
 
 /**
  * 토큰 응답에서 ChatGPT 계정 ID 추출.
- * id_token 우선, access_token fallback — opencode 와 동일한 클레임 위치.
+ * id_token 우선, access_token fallback — 두 토큰 모두에서 계정 ID 클레임을 탐색한다.
  */
 export function extractAccountId(tokens: {
     id_token?: string;

--- a/apps/api/src/routes/external-oauth.routes.ts
+++ b/apps/api/src/routes/external-oauth.routes.ts
@@ -174,7 +174,7 @@ router.post('/:providerId/oauth/poll',
             },
         );
 
-        // 403/404 = 아직 미승인 (opencode 동일 시맨틱) — pending 으로 응답
+        // 403/404 = 아직 미승인 — pending 으로 응답
         if (pollResponse.status === 403 || pollResponse.status === 404) {
             res.json(success({ status: 'pending' }));
             return;

--- a/db/migrations/072_user_agents_model.sql
+++ b/db/migrations/072_user_agents_model.sql
@@ -1,7 +1,7 @@
 -- Migration 072 — user_agents.model (에이전트 정의 단위 모델 배정)
 --
 -- Role-based Orchestration 2차 Phase C (2026-07-15).
--- Custom Agent 가 자체 모델(fullId)을 가질 수 있다 (OpenCode 의 per-agent model 패턴).
+-- Custom Agent 가 자체 모델(fullId)을 가질 수 있다.
 -- NULL = 상속(요청 모델/기본 모델). 적용 규칙: 요청 model 이 자동('default'/빈값)일 때만
 -- 에이전트 model 로 대체 — 사용자의 명시적 모델 선택이 항상 우선.
 -- 외부 fullId 는 그 소유자의 BYOK 키(user_external_api_keys)로 실행된다.


### PR DESCRIPTION
## 무엇

chatgpt-oauth 계열 주석과 마이그레이션 072 헤더에서 외부 프로젝트(opencode) 참조를 제거한다.

**로직 변경 없음** — 주석·문서 문자열만 수정 (5 files, +6 / -8).

| 파일 | 변경 |
|---|---|
| `config/chatgpt-oauth.ts` | 문장 내 참조 + `@see` 링크 제거 |
| `providers/chatgpt-oauth/provider.ts` | 교차확인 출처 문구 제거, 근거를 Codex Responses API 제약으로 재서술 |
| `providers/chatgpt-oauth/session.ts` | 클레임 위치 설명을 자기완결적 문장으로 교체 |
| `routes/external-oauth.routes.ts` | 참조 제거 (설명은 유지) |
| `db/migrations/072_user_agents_model.sql` | 참조 제거 (목적 문장은 유지) |

## 왜 2줄을 복원했는지

참조를 걷어내는 과정에서 opencode와 무관한 설명 2줄이 통째로 사라져 있었다. 참조 부분만 제외하고 되살렸다.

- `external-oauth.routes.ts` — 403/404 를 `pending` 으로 처리하는 이유. **직관에 반하는 동작이라 주석 없이는 오독하기 쉽다.**
- `072_user_agents_model.sql` — 해당 마이그레이션의 목적 문장.

## 검증

- [x] `npx tsc --noEmit` (apps/api) 통과
- [x] 레포 전체 opencode 참조 **0건** 확인
- [x] 로직 변경 없음 (주석·SQL 헤더 주석만)

## 참고

`db/migrations/072` 는 이미 적용된 마이그레이션이다. **주석만 바뀌어 실행에는 영향이 없으나**, 적용된 마이그레이션 파일 수정은 이 레포 관행에서 벗어난다 — 되돌리는 편이 낫다고 판단되면 해당 파일만 revert 하면 된다(그 경우 참조 문구도 함께 복귀).

🤖 Generated with [Claude Code](https://claude.com/claude-code)