### PR TITLE
feat(agent-task): 업로드 원본 보존 스윕 — 종료 후 N일 지난 원본 회수

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -959,6 +959,10 @@ AGENT_TASK_TIMEOUT_MS=600000
 # AGENT_TASK_CHUNK_MAX_BYTES=33554432
 # AGENT_TASK_CHUNK_MAX_COUNT=256
 # AGENT_TASK_CHUNK_TTL_MS=86400000
+# Agent Task 업로드 원본 보존 기간(일) — 종료(completed/failed/cancelled) 후 이 기간이
+# 지나면 스윕(부팅+6h)이 디스크 원본만 회수한다. DB 메타·추출텍스트는 유지되어 이후
+# 재시도는 추출텍스트로 degrade. 0 = 원본 회수 비활성(tmp/청크 잔재 청소는 계속).
+# AGENT_TASK_UPLOAD_RETENTION_DAYS=30
 # 청크 업로드 레이트 리밋 (15분 창, IP/사용자별 요청 수 — 기본 300, 약 9GB 분량).
 # RL_CHUNK_UPLOAD_IP=300
 # RL_CHUNK_UPLOAD_USER=300

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1377,6 +1377,12 @@ export const AGENT_TASK_LIMITS = {
     /** 미완성(미클레임) 청크 업로드 보관 시한(ms) — init 시 지난 것을 기회적으로 청소.
      *  AGENT_TASK_CHUNK_TTL_MS(기본 24h). */
     CHUNK_UPLOAD_TTL_MS: parseInt(process.env.AGENT_TASK_CHUNK_TTL_MS || '', 10) || 24 * 60 * 60 * 1000,
+    /** 종료(completed/failed/cancelled) 후 업로드 원본 보존 기간(ms) — 지나면 보존 스윕이
+     *  디스크 원본만 회수한다. DB 메타(input_files 추출텍스트·input_images base64)는 유지되므로
+     *  이후 재시도는 추출텍스트로 degrade 될 뿐 실패하지 않는다(task-inputs 의 복사 실패 내성).
+     *  AGENT_TASK_UPLOAD_RETENTION_DAYS(기본 30, 0 = 원본 회수 비활성 — tmp/청크 청소는 계속). */
+    UPLOAD_RETENTION_MS: ((d) => (Number.isFinite(d) && d >= 0 ? d : 30) * 24 * 60 * 60 * 1000)(
+        parseInt(process.env.AGENT_TASK_UPLOAD_RETENTION_DAYS || '', 10)),
     /** 사용자 지정 max_turns 의 절대 상한(Zod 입력 검증 상한도 이 값을 참조).
      *  20 은 조사→데이터 생성→렌더→검증이 이어지는 작업엔 부족하다 — 2026-08-09 실측: 예약
      *  리포트 최근 5회가 **전부 20/20 을 소진**했고, 성공한 회차조차 마진이 0이라 조금만 흔들리면

--- a/apps/api/src/schedulers/index.ts
+++ b/apps/api/src/schedulers/index.ts
@@ -93,6 +93,28 @@ export async function startAllSchedulers(): Promise<void> {
         logger.warn('Agent Task 스케줄러 등록 실패(무시):', err);
     }
 
+    // 8-D. Agent Task 업로드 보존 스윕 — 종료 후 보존기간 지난 task 의 디스크 원본 회수 +
+    //      tmp/·chunked/ 잔재 청소(부팅 + 6h 주기). 샌드박스 플래그와 무관 — 업로드 원본은
+    //      비-샌드박스 task 도 무기한 쌓인다(removeTaskFiles 호출처가 롤백·삭제 2곳뿐).
+    try {
+        const { sweepExpiredTaskUploads } = await import('../services/agent-task/upload-retention');
+        const { cleanupStaleChunkUploads } = await import('../services/agent-task/chunk-store');
+        const { getPool } = await import('../data/models/unified-database');
+        const sweep = async () => {
+            const r = await sweepExpiredTaskUploads(getPool());
+            await cleanupStaleChunkUploads();
+            if (r.sweptTasks || r.orphanDirs || r.tmpFiles) {
+                logger.info(`Agent Task 업로드 정리: 원본 회수 ${r.sweptTasks} / 고아 ${r.orphanDirs} / tmp ${r.tmpFiles}`);
+            }
+        };
+        await sweep().catch(() => { /* noop */ });
+        const SIX_HOURS = 6 * 60 * 60 * 1000;
+        setInterval(() => { void sweep().catch(() => { /* noop */ }); }, SIX_HOURS).unref();
+        logger.debug('Agent Task 업로드 보존 스윕 등록 완료');
+    } catch (err) {
+        logger.warn('Agent Task 업로드 보존 스윕 등록 실패(무시):', err);
+    }
+
     // 9. 아티팩트 실행 히스토리 TTL 스윕 — persistTtlMs 초과 실행 결과 삭제(부팅 + 6h 주기).
     try {
         const { ARTIFACT_EXEC } = await import('../config/artifact-exec');

--- a/apps/api/src/services/agent-task/__tests__/upload-retention.test.ts
+++ b/apps/api/src/services/agent-task/__tests__/upload-retention.test.ts
@@ -1,0 +1,138 @@
+/**
+ * 업로드 보존 스윕 유닛 테스트 — 종료+만료 task 원본 회수, 진행형/최근 종료 보호,
+ * 고아 디렉토리 mtime 가드, tmp/ 잔재 청소, retention 0 비활성.
+ * UPLOAD_ROOT 를 임시 디렉토리로 격리(모듈 로드 전 env 오버라이드).
+ */
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import type { Pool } from 'pg';
+
+const TMP_ROOT = path.join(os.tmpdir(), `upload-retention-test-${process.pid}`);
+process.env.AGENT_TASK_UPLOAD_ROOT = TMP_ROOT;
+
+// env 반영을 위해 상수 모듈보다 늦게 import (jest 는 파일 내 import 호이스팅 — require 사용)
+const { sweepExpiredTaskUploads } = require('../upload-retention') as typeof import('../upload-retention');
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = 1_800_000_000_000; // 고정 기준 시각
+const RETENTION = 30 * DAY;    // 기본값과 동일
+
+function poolWithRows(rows: Array<{ id: string; status: string; finished_at: Date | null }>): Pool {
+    return { query: jest.fn().mockResolvedValue({ rows }) } as unknown as Pool;
+}
+
+async function makeTaskDir(name: string, files: Record<string, string> = { 'a.txt': 'x' }): Promise<string> {
+    const dir = path.join(TMP_ROOT, name);
+    await fs.mkdir(dir, { recursive: true });
+    for (const [f, c] of Object.entries(files)) await fs.writeFile(path.join(dir, f), c);
+    return dir;
+}
+
+async function exists(p: string): Promise<boolean> {
+    try { await fs.stat(p); return true; } catch { return false; }
+}
+
+beforeEach(async () => {
+    await fs.rm(TMP_ROOT, { recursive: true, force: true });
+    await fs.mkdir(TMP_ROOT, { recursive: true });
+});
+
+afterAll(async () => {
+    await fs.rm(TMP_ROOT, { recursive: true, force: true });
+});
+
+describe('sweepExpiredTaskUploads', () => {
+    it('종료+만료 task 원본만 회수하고 진행형·최근 종료는 유지한다', async () => {
+        const expired = await makeTaskDir('task-expired');
+        const recent = await makeTaskDir('task-recent');
+        const running = await makeTaskDir('task-running');
+        const pool = poolWithRows([
+            { id: 'task-expired', status: 'completed', finished_at: new Date(NOW - RETENTION - DAY) },
+            { id: 'task-recent', status: 'failed', finished_at: new Date(NOW - DAY) },
+            { id: 'task-running', status: 'running', finished_at: new Date(NOW - RETENTION - DAY) },
+        ]);
+
+        const r = await sweepExpiredTaskUploads(pool, NOW);
+
+        expect(r.sweptTasks).toBe(1);
+        expect(await exists(expired)).toBe(false);
+        expect(await exists(recent)).toBe(true);
+        expect(await exists(running)).toBe(true);
+    });
+
+    it('tmp/·chunked/ 는 task 스윕 대상에서 제외한다', async () => {
+        await makeTaskDir('tmp');
+        await makeTaskDir('chunked');
+        const pool = poolWithRows([]);
+
+        await sweepExpiredTaskUploads(pool, NOW);
+
+        // DB 조회 자체가 일어나지 않아야 한다 (task 디렉토리 0개)
+        expect((pool.query as jest.Mock)).not.toHaveBeenCalled();
+        expect(await exists(path.join(TMP_ROOT, 'chunked'))).toBe(true);
+    });
+
+    it('DB 행이 없는 고아 디렉토리는 mtime 이 보존기간을 지난 것만 제거한다', async () => {
+        const oldOrphan = await makeTaskDir('orphan-old');
+        const freshOrphan = await makeTaskDir('orphan-fresh');
+        const oldTime = new Date(NOW - RETENTION - DAY);
+        await fs.utimes(oldOrphan, oldTime, oldTime);
+        const freshTime = new Date(NOW - DAY);
+        await fs.utimes(freshOrphan, freshTime, freshTime);
+        const pool = poolWithRows([]);
+
+        const r = await sweepExpiredTaskUploads(pool, NOW);
+
+        expect(r.orphanDirs).toBe(1);
+        expect(await exists(oldOrphan)).toBe(false);
+        expect(await exists(freshOrphan)).toBe(true);
+    });
+
+    it('tmp/ 의 오래된 잔재 파일만 지운다', async () => {
+        const tmpDir = path.join(TMP_ROOT, 'tmp');
+        await fs.mkdir(tmpDir, { recursive: true });
+        const stale = path.join(tmpDir, 'stale.part');
+        const fresh = path.join(tmpDir, 'fresh.part');
+        await fs.writeFile(stale, 'x');
+        await fs.writeFile(fresh, 'y');
+        const staleTime = new Date(NOW - 2 * DAY); // CHUNK_UPLOAD_TTL_MS 기본 24h 초과
+        await fs.utimes(stale, staleTime, staleTime);
+        const freshTime = new Date(NOW - 60 * 1000); // 고정 NOW 기준의 "방금" (실제 시계와 무관)
+        await fs.utimes(fresh, freshTime, freshTime);
+        const pool = poolWithRows([]);
+
+        const r = await sweepExpiredTaskUploads(pool, NOW);
+
+        expect(r.tmpFiles).toBe(1);
+        expect(await exists(stale)).toBe(false);
+        expect(await exists(fresh)).toBe(true);
+    });
+
+    it('retention 0 이면 원본 회수 없이 tmp 청소만 수행한다', async () => {
+        process.env.AGENT_TASK_UPLOAD_RETENTION_DAYS = '0';
+        jest.resetModules();
+        const mod = require('../upload-retention') as typeof import('../upload-retention');
+        try {
+            const expired = await makeTaskDir('task-expired-off');
+            const tmpDir = path.join(TMP_ROOT, 'tmp');
+            await fs.mkdir(tmpDir, { recursive: true });
+            const stale = path.join(tmpDir, 'stale.part');
+            await fs.writeFile(stale, 'x');
+            const staleTime = new Date(NOW - 2 * DAY);
+            await fs.utimes(stale, staleTime, staleTime);
+            const pool = poolWithRows([
+                { id: 'task-expired-off', status: 'completed', finished_at: new Date(NOW - RETENTION - DAY) },
+            ]);
+
+            const r = await mod.sweepExpiredTaskUploads(pool, NOW);
+
+            expect(r).toEqual({ sweptTasks: 0, orphanDirs: 0, tmpFiles: 1 });
+            expect((pool.query as jest.Mock)).not.toHaveBeenCalled();
+            expect(await exists(expired)).toBe(true);
+        } finally {
+            delete process.env.AGENT_TASK_UPLOAD_RETENTION_DAYS;
+            jest.resetModules();
+        }
+    });
+});

--- a/apps/api/src/services/agent-task/chunk-store.ts
+++ b/apps/api/src/services/agent-task/chunk-store.ts
@@ -84,6 +84,12 @@ async function cleanupStale(): Promise<void> {
     }
 }
 
+/** TTL 지난 미클레임 업로드 청소 — 보존 스윕 스케줄러(schedulers/index.ts)에서 주기 호출.
+ *  init 시 기회적 청소만으로는 업로드가 끊긴 뒤 새 업로드가 없으면 영영 안 치워진다. */
+export async function cleanupStaleChunkUploads(): Promise<void> {
+    await cleanupStale();
+}
+
 /** 업로드 세션 시작 — 선언(파일명·크기·청크 수)을 기록하고 uploadId 발급. */
 export async function initChunkedUpload(
     userId: string,

--- a/apps/api/src/services/agent-task/upload-retention.ts
+++ b/apps/api/src/services/agent-task/upload-retention.ts
@@ -1,0 +1,103 @@
+/**
+ * Agent Task 업로드 보존 스윕 — 무기한 쌓이던 업로드 원본의 회수 경로.
+ *
+ * removeTaskFiles 는 생성 롤백과 task 삭제에서만 불려 완료된 task 의 원본이 디스크에
+ * 무기한 남았다. 이 스윕이 (부팅 + 주기, schedulers/index.ts) 다음 셋을 정리한다:
+ *   1. 종료(completed/failed/cancelled) 후 보존기간(UPLOAD_RETENTION_MS)이 지난 task 의
+ *      원본 디렉토리 — DB 메타(input_files 추출텍스트·input_images base64)는 유지.
+ *   2. DB 행이 없는 고아 디렉토리(task 삭제 시 rm 실패 잔재) — 생성 직후 "디렉토리는
+ *      있으나 행은 아직" 경합 창을 피하려고 mtime 이 보존기간을 지난 것만.
+ *   3. tmp/ 의 오래된 multer 잔재(업로드 중단·크래시) — CHUNK_UPLOAD_TTL_MS 기준.
+ *
+ * @module services/agent-task/upload-retention
+ */
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import type { Pool } from 'pg';
+import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
+import { removeTaskFiles, UPLOAD_TMP_DIR } from './upload-store';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('AgentTaskUploadRetention');
+
+const ROOT = path.resolve(AGENT_TASK_LIMITS.UPLOAD_ROOT);
+/** task 디렉토리가 아닌 고정 하위 경로 — 스윕 대상에서 제외. */
+const NON_TASK_DIRS = new Set(['tmp', 'chunked']);
+/** 원본 회수 대상 상태 — 진행형(pending/running/paused)은 절대 건드리지 않는다. */
+const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled']);
+
+export interface UploadRetentionResult {
+    /** 보존기간 경과로 원본을 회수한 task 수 */
+    sweptTasks: number;
+    /** DB 행이 없어 제거한 고아 디렉토리 수 */
+    orphanDirs: number;
+    /** tmp/ 에서 제거한 잔재 파일 수 */
+    tmpFiles: number;
+}
+
+/** tmp/ 잔재 청소 — 업로드 중단으로 남은 multer 스트리밍 파일. */
+async function sweepTmpFiles(now: number): Promise<number> {
+    let entries: string[];
+    try { entries = await fs.readdir(UPLOAD_TMP_DIR); } catch { return 0; }
+    const cutoff = now - AGENT_TASK_LIMITS.CHUNK_UPLOAD_TTL_MS;
+    let removed = 0;
+    for (const name of entries) {
+        const p = path.join(UPLOAD_TMP_DIR, name);
+        try {
+            const st = await fs.stat(p);
+            if (st.isFile() && st.mtimeMs < cutoff) {
+                await fs.unlink(p);
+                removed++;
+            }
+        } catch { /* 경합 삭제 등 — 무시 */ }
+    }
+    return removed;
+}
+
+/**
+ * 업로드 보존 스윕 1회 실행. 실패는 항목 단위로 삼켜 스윕 전체를 죽이지 않는다.
+ * UPLOAD_RETENTION_MS <= 0 이면 원본 회수는 건너뛰고 tmp/ 청소만 수행.
+ */
+export async function sweepExpiredTaskUploads(pool: Pool, now = Date.now()): Promise<UploadRetentionResult> {
+    const result: UploadRetentionResult = { sweptTasks: 0, orphanDirs: 0, tmpFiles: 0 };
+    result.tmpFiles = await sweepTmpFiles(now);
+
+    const retentionMs = AGENT_TASK_LIMITS.UPLOAD_RETENTION_MS;
+    if (retentionMs <= 0) return result;
+
+    let entries;
+    try { entries = await fs.readdir(ROOT, { withFileTypes: true }); } catch { return result; }
+    const taskIds = entries
+        .filter((e) => e.isDirectory() && !NON_TASK_DIRS.has(e.name))
+        .map((e) => e.name);
+    if (!taskIds.length) return result;
+
+    const { rows } = await pool.query<{ id: string; status: string; finished_at: Date | string | null }>(
+        `SELECT id, status, COALESCE(completed_at, updated_at) AS finished_at
+           FROM agent_tasks WHERE id = ANY($1)`,
+        [taskIds],
+    );
+    const byId = new Map(rows.map((r) => [r.id, r]));
+    const cutoff = now - retentionMs;
+
+    for (const id of taskIds) {
+        const row = byId.get(id);
+        if (row) {
+            if (!TERMINAL_STATUSES.has(row.status) || !row.finished_at) continue;
+            if (new Date(row.finished_at).getTime() >= cutoff) continue;
+            await removeTaskFiles(id);
+            result.sweptTasks++;
+        } else {
+            try {
+                const st = await fs.stat(path.join(ROOT, id));
+                if (st.mtimeMs >= cutoff) continue;
+                await fs.rm(path.join(ROOT, id), { recursive: true, force: true });
+                result.orphanDirs++;
+            } catch { /* 경합 삭제 등 — 무시 */ }
+        }
+    }
+    if (result.sweptTasks || result.orphanDirs) {
+        logger.info(`[UploadRetention] 원본 회수 ${result.sweptTasks}건 / 고아 디렉토리 ${result.orphanDirs}건`);
+    }
+    return result;
+}


### PR DESCRIPTION
## 배경
`data/uploads/agent-tasks/<taskId>/` 업로드 원본이 무기한 보존되고 있었다.
- `removeTaskFiles()` 호출처가 생성 롤백(`agent-task.routes.ts:174`)·task 삭제(`:462`) 2곳뿐 — 정상 완료된 task 의 원본에는 회수 경로가 없음
- `tmp/` (multer 스트리밍 임시 위치)는 정리 경로 자체가 없음
- `chunked/` 는 새 업로드 init 시에만 기회적 청소 — 업로드가 끊기면 영영 안 치워짐

## 변경
- **`services/agent-task/upload-retention.ts` (신규)**: 종료(completed/failed/cancelled) 후 `AGENT_TASK_UPLOAD_RETENTION_DAYS`(기본 30, `0`=원본 회수 비활성) 지난 task 의 디스크 원본만 회수
  - DB 메타(input_files 추출텍스트·input_images base64)는 유지 → 이후 재시도는 task-inputs 의 복사 실패 내성으로 추출텍스트 degrade (실패하지 않음)
  - 진행형(pending/running/paused)은 절대 불변
  - DB 행 없는 고아 디렉토리는 mtime 가드(생성 직후 "디렉토리만 있고 행은 아직" 경합 창 보호) 후 제거
  - `tmp/` 잔재는 `CHUNK_UPLOAD_TTL_MS`(24h) 기준 청소
- **`schedulers/index.ts`**: 부팅 + 6h 주기 배선 (8-D — 아티팩트 실행 히스토리 TTL 스윕과 동일 패턴). `chunked/` 청소(`cleanupStaleChunkUploads` export)도 같은 슬롯에서 주기 실행
- **`config/runtime-limits.ts`**: `UPLOAD_RETENTION_MS` 추가, **`.env.example`** 갱신

## 검증
- 유닛 테스트 5건 신규 (`upload-retention.test.ts`): 만료 회수 / 진행형·최근 종료 보호 / tmp·chunked 스윕 제외 / 고아 mtime 가드 / tmp 잔재 청소 / retention 0 비활성
- `tsc --noEmit` 통과, eslint 0 errors, jest 12/12 (신규 5 + chunk-store 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)