### PR TITLE
feat(chat): PDF 첨부 vision 하이브리드 — 앞쪽 페이지 이미지 병행 주입

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -978,6 +978,15 @@ AGENT_TASK_TIMEOUT_MS=600000
 # DOC_EXTRACT_OCR_PARALLEL=4
 # DOC_EXTRACT_OCR_MAX_BYTES=314572800
 
+# PDF 첨부 vision 페이지 주입 (채팅 하이브리드 — 텍스트 추출 + 앞쪽 페이지 이미지, 2026-08-19).
+# pdftoppm(poppler) 필요 — 미설치 시 자동 생략(텍스트 추출만). 특수 모드(딥리서치/이미지생성/토론) 제외.
+# PDF_VISION_ENABLED=true
+# 요청당 프롬프트 이미지 총 상한 — vLLM --limit-mm-per-prompt '{"image": N}' 와 반드시 페어로 조정
+# PDF_VISION_TOTAL_IMAGE_CAP=4
+# PDF_VISION_MAX_PAGES=4
+# PDF_VISION_DPI=120
+# PDF_VISION_RENDER_TIMEOUT_MS=20000
+
 # Agent Task — 목표 달성 judge (아티팩트 없는 최종 답변을 판정 전용 LLM 1회 호출로 검증,
 # 미달성이면 completed 대신 failed(goal_incomplete)). 기본 ON. 'false' 로 비활성.
 # 판정 결과는 agent_tasks.judge_verdict, 완료 출구는 completion_path 로 영속(091).

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -429,6 +429,28 @@ export const DOC_EXTRACT_LIMITS = {
 } as const;
 
 /**
+ * PDF 첨부 vision 페이지 주입 한도 (2026-08-19)
+ * 채팅 PDF 첨부를 하이브리드로 처리 — 기존 doc-extractor 텍스트 추출에 더해 앞쪽
+ * 페이지를 pdftoppm 으로 JPEG 렌더해 vision(images) 채널에 병행 주입한다
+ * (표·차트 등 텍스트 추출로 소실되는 레이아웃 보강). pdftoppm 미설치 시 graceful skip.
+ *
+ * services/chat-service/pdf-vision.ts 에서 참조
+ */
+export const PDF_VISION_LIMITS = {
+    /** 기능 on/off (기본 on — 'false' 명시 시에만 비활성) */
+    ENABLED: process.env.PDF_VISION_ENABLED !== 'false',
+    /** 요청당 프롬프트 이미지 총 상한 — vLLM `--limit-mm-per-prompt '{"image": N}'` 와 페어.
+     *  사용자 첨부 이미지가 이 값을 채우면 페이지 주입은 잔여분만 사용 */
+    TOTAL_IMAGE_CAP: parseInt(process.env.PDF_VISION_TOTAL_IMAGE_CAP || '4', 10),
+    /** 요청당 렌더 페이지 최대 수 (PDF 여러 개면 순서대로 예산 소진) */
+    MAX_PAGES: parseInt(process.env.PDF_VISION_MAX_PAGES || '4', 10),
+    /** 렌더 해상도 dpi — 문서 판독 라이브 실측(2026-08-19) 120 이면 충분, 상향은 비전 토큰 비례 증가 */
+    DPI: parseInt(process.env.PDF_VISION_DPI || '120', 10),
+    /** 렌더(pdftoppm)·페이지 수 조회(pdfinfo) 타임아웃 ms */
+    RENDER_TIMEOUT_MS: parseInt(process.env.PDF_VISION_RENDER_TIMEOUT_MS || '20000', 10),
+} as const;
+
+/**
  * 채팅 메시지 내 URL 자동 분석 한도 (2026-06-13)
  * 사용자 메시지에서 URL 감지 시 LLM 호출 전 scrapePage 로 본문을 가져와
  * fileContext 채널로 주입한다 (결정적 사전 분석 — 환각 방지).

--- a/apps/api/src/services/chat-service/__tests__/pdf-vision.test.ts
+++ b/apps/api/src/services/chat-service/__tests__/pdf-vision.test.ts
@@ -1,0 +1,101 @@
+/**
+ * pdf-vision 유닛 테스트 — 예산 계산·게이트·graceful skip·다중 PDF 예산 공유.
+ * pdftoppm/pdfinfo 는 child_process mock 으로 대체 (CI poppler 미설치 무관).
+ */
+import * as fsSync from 'fs';
+import * as path from 'path';
+
+// promisify(execFile) 이 {stdout, stderr} 를 돌려주도록 promisify.custom 구현을 심는다.
+// 동작은 테스트별로 mockExecHandler 를 교체해 제어한다.
+let mockExecHandler: (cmd: string, args: string[]) => Promise<{ stdout: string; stderr: string }>;
+jest.mock('child_process', () => {
+    const actual = jest.requireActual('child_process');
+    const util = jest.requireActual('util');
+    const execFile: any = jest.fn();
+    execFile[util.promisify.custom] = (cmd: string, args: string[]) => mockExecHandler(cmd, args);
+    return { ...actual, execFile };
+});
+
+import { buildPdfVisionAttachment } from '../pdf-vision';
+import { PDF_VISION_LIMITS } from '../../../config/runtime-limits';
+
+const PDF_DATA = Buffer.from('%PDF-1.4 dummy').toString('base64');
+
+/** pdftoppm 렌더 콜을 흉내내 출력 prefix 에 페이지 jpg 를 실제로 만들어 둔다 */
+function fakeRender(args: string[], actualPages: number): void {
+    const prefix = args[args.length - 1];
+    const last = parseInt(args[args.indexOf('-l') + 1], 10);
+    const n = Math.min(last, actualPages);
+    for (let i = 1; i <= n; i++) {
+        fsSync.writeFileSync(`${prefix}-${i}.jpg`, Buffer.from(`jpg-${path.basename(prefix)}-${i}`));
+    }
+}
+
+/** 정상 동작 핸들러 — pdfinfo 는 pages 페이지 보고, pdftoppm 은 실제 파일 생성 */
+function okHandler(pagesByCall: number[]): (cmd: string, args: string[]) => Promise<{ stdout: string; stderr: string }> {
+    let renderIdx = 0;
+    let infoIdx = 0;
+    return async (cmd, args) => {
+        if (cmd === 'pdftoppm' && args[0] === '-v') return { stdout: '', stderr: 'pdftoppm ok' };
+        if (cmd === 'pdfinfo') return { stdout: `Pages: ${pagesByCall[infoIdx++]}\n`, stderr: '' };
+        if (cmd === 'pdftoppm') { fakeRender(args, pagesByCall[renderIdx++]); return { stdout: '', stderr: '' }; }
+        throw new Error(`unexpected cmd: ${cmd}`);
+    };
+}
+
+describe('buildPdfVisionAttachment', () => {
+    beforeEach(() => {
+        mockExecHandler = okHandler([3]);
+    });
+
+    it('PDF 없음/파일 없음이면 빈 결과', async () => {
+        expect((await buildPdfVisionAttachment(undefined, 0)).images).toHaveLength(0);
+        expect((await buildPdfVisionAttachment([], 0)).images).toHaveLength(0);
+        expect((await buildPdfVisionAttachment([{ name: 'a.txt', content: 'x' }], 0)).images).toHaveLength(0);
+        // content 가 이미 있는 파일(data 병존)은 렌더 대상 아님
+        expect((await buildPdfVisionAttachment([{ name: 'a.pdf', content: 'x', data: PDF_DATA }], 0)).images).toHaveLength(0);
+    });
+
+    it('사용자 이미지가 총 상한을 채우면 예산 0 — 렌더 시도 없이 빈 결과', async () => {
+        mockExecHandler = () => { throw new Error('호출되면 안 됨'); };
+        const r = await buildPdfVisionAttachment(
+            [{ name: 'a.pdf', data: PDF_DATA }],
+            PDF_VISION_LIMITS.TOTAL_IMAGE_CAP,
+        );
+        expect(r.images).toHaveLength(0);
+        expect(r.note).toBe('');
+    });
+
+    it('3페이지 PDF → 3장 렌더 + 안내문에 총 페이지 수 기재', async () => {
+        mockExecHandler = okHandler([3]);
+        const r = await buildPdfVisionAttachment([{ name: 'report.pdf', data: PDF_DATA }], 0);
+        expect(r.images).toHaveLength(Math.min(3, PDF_VISION_LIMITS.MAX_PAGES));
+        expect(r.images[0].startsWith('data:image/jpeg;base64,')).toBe(true);
+        expect(r.note).toContain('report.pdf');
+        expect(r.note).toContain('총 3페이지');
+    });
+
+    it('다중 PDF 는 순서대로 예산 공유 (3p + 5p, 예산 4 → 3장 + 1장)', async () => {
+        mockExecHandler = okHandler([3, 5]);
+        const r = await buildPdfVisionAttachment(
+            [{ name: 'a.pdf', data: PDF_DATA }, { name: 'b.pdf', data: PDF_DATA }],
+            0,
+        );
+        expect(r.images.length).toBeLessThanOrEqual(PDF_VISION_LIMITS.MAX_PAGES);
+        expect(r.note).toContain('a.pdf');
+        if (PDF_VISION_LIMITS.MAX_PAGES >= 4) {
+            expect(r.images).toHaveLength(4);
+            expect(r.note).toContain('b.pdf: 총 5페이지 중 1페이지 이미지 첨부');
+        }
+    });
+
+    it('렌더 실패는 graceful skip — 빈 결과, throw 없음', async () => {
+        mockExecHandler = async (cmd, args) => {
+            if (cmd === 'pdftoppm' && args[0] === '-v') return { stdout: '', stderr: '' };
+            throw new Error('render boom');
+        };
+        const r = await buildPdfVisionAttachment([{ name: 'a.pdf', data: PDF_DATA }], 0);
+        expect(r.images).toHaveLength(0);
+        expect(r.note).toBe('');
+    });
+});

--- a/apps/api/src/services/chat-service/__tests__/pdf-vision.test.ts
+++ b/apps/api/src/services/chat-service/__tests__/pdf-vision.test.ts
@@ -16,6 +16,18 @@ jest.mock('child_process', () => {
     return { ...actual, execFile };
 });
 
+// 운영 .env 값(예: CAP 8 상향)에 흔들리지 않도록 한도를 고정 — .env 의존 테스트 함정 방지
+jest.mock('../../../config/runtime-limits', () => {
+    const actual = jest.requireActual('../../../config/runtime-limits');
+    return {
+        ...actual,
+        PDF_VISION_LIMITS: {
+            ...actual.PDF_VISION_LIMITS,
+            ENABLED: true, TOTAL_IMAGE_CAP: 4, MAX_PAGES: 4, DPI: 120, RENDER_TIMEOUT_MS: 5000,
+        },
+    };
+});
+
 import { buildPdfVisionAttachment } from '../pdf-vision';
 import { PDF_VISION_LIMITS } from '../../../config/runtime-limits';
 
@@ -69,7 +81,7 @@ describe('buildPdfVisionAttachment', () => {
     it('3페이지 PDF → 3장 렌더 + 안내문에 총 페이지 수 기재', async () => {
         mockExecHandler = okHandler([3]);
         const r = await buildPdfVisionAttachment([{ name: 'report.pdf', data: PDF_DATA }], 0);
-        expect(r.images).toHaveLength(Math.min(3, PDF_VISION_LIMITS.MAX_PAGES));
+        expect(r.images).toHaveLength(3);
         expect(r.images[0].startsWith('data:image/jpeg;base64,')).toBe(true);
         expect(r.note).toContain('report.pdf');
         expect(r.note).toContain('총 3페이지');
@@ -81,12 +93,9 @@ describe('buildPdfVisionAttachment', () => {
             [{ name: 'a.pdf', data: PDF_DATA }, { name: 'b.pdf', data: PDF_DATA }],
             0,
         );
-        expect(r.images.length).toBeLessThanOrEqual(PDF_VISION_LIMITS.MAX_PAGES);
+        expect(r.images).toHaveLength(4);
         expect(r.note).toContain('a.pdf');
-        if (PDF_VISION_LIMITS.MAX_PAGES >= 4) {
-            expect(r.images).toHaveLength(4);
-            expect(r.note).toContain('b.pdf: 총 5페이지 중 1페이지 이미지 첨부');
-        }
+        expect(r.note).toContain('b.pdf: 총 5페이지 중 1페이지 이미지 첨부');
     });
 
     it('렌더 실패는 graceful skip — 빈 결과, throw 없음', async () => {

--- a/apps/api/src/services/chat-service/pdf-vision.ts
+++ b/apps/api/src/services/chat-service/pdf-vision.ts
@@ -1,0 +1,135 @@
+/**
+ * PDF 첨부 vision 페이지 주입 (2026-08-19)
+ *
+ * claude.ai/ChatGPT 의 하이브리드 PDF 처리(텍스트 추출 + 페이지 이미지)를 로컬 vLLM
+ * 이미지 상한 안에서 재현한다: 첨부 PDF 의 앞쪽 페이지를 pdftoppm 으로 JPEG 렌더해
+ * vision(images) 채널에 병행 주입 — 표·차트 등 텍스트 추출로 소실되는 레이아웃을 보강.
+ * 전체 본문 문맥은 기존 doc-extractor 텍스트 추출이 계속 담당한다.
+ *
+ * 반드시 extractAttachedDocuments 이전(data 소거 전)에 호출할 것.
+ * pdftoppm(poppler) 미설치·렌더 실패는 graceful skip — 기존 텍스트 경로 무영향.
+ *
+ * @module services/chat-service/pdf-vision
+ */
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as crypto from 'crypto';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { createLogger } from '../../utils/logger';
+import { DOC_EXTRACT_LIMITS, PDF_VISION_LIMITS } from '../../config/runtime-limits';
+import type { AttachedFileInput } from './attach-context';
+
+const logger = createLogger('PdfVision');
+const execFileAsync = promisify(execFile);
+
+/** pdftoppm(poppler) 가용성 — 1회 검사 후 캐시 (doc-extractor 네이티브 OCR 경로와 동일 패턴) */
+let pdftoppmAvailable: Promise<boolean> | null = null;
+function checkPdftoppm(): Promise<boolean> {
+    if (!pdftoppmAvailable) {
+        pdftoppmAvailable = execFileAsync('pdftoppm', ['-v']).then(() => true, () => {
+            logger.info('[PdfVision] pdftoppm 미설치 — PDF vision 페이지 주입 생략(텍스트 추출만)');
+            return false;
+        });
+    }
+    return pdftoppmAvailable;
+}
+
+/** pdfinfo 로 총 페이지 수 조회 (실패 시 undefined — 안내문에서 총수만 생략) */
+async function getPageCount(pdfPath: string): Promise<number | undefined> {
+    try {
+        const { stdout } = await execFileAsync('pdfinfo', [pdfPath], {
+            timeout: PDF_VISION_LIMITS.RENDER_TIMEOUT_MS,
+        });
+        const m = /^Pages:\s+(\d+)/m.exec(String(stdout));
+        return m ? parseInt(m[1], 10) : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+/** 렌더 산출 jpg 파일명의 페이지 번호 (p-1.jpg / p-01.jpg 숫자 정렬용) */
+function pageNumOf(name: string): number {
+    const m = /-(\d+)\.jpg$/.exec(name);
+    return m ? parseInt(m[1], 10) : 0;
+}
+
+export interface PdfVisionResult {
+    /** 렌더된 페이지 dataURL — vision(images) 채널에 사용자 이미지 뒤로 병합 */
+    images: string[];
+    /** fileContext 뒤에 덧붙일 안내문 ('' = 주입 없음).
+     *  ⚠️ 세션 캐시(appendCachedAttachContext) 대상에는 넣지 말 것 — 이미지는 이번 턴에만 존재 */
+    note: string;
+}
+
+const EMPTY: PdfVisionResult = { images: [], note: '' };
+
+/**
+ * 첨부 PDF 의 앞쪽 페이지를 JPEG dataURL 로 렌더해 vision 채널 주입분을 만든다.
+ * 예산 = min(MAX_PAGES, TOTAL_IMAGE_CAP − 사용자 첨부 이미지 수) 를 PDF 순서대로 소진.
+ */
+export async function buildPdfVisionAttachment(
+    files: AttachedFileInput[] | undefined,
+    userImageCount: number,
+): Promise<PdfVisionResult> {
+    if (!PDF_VISION_LIMITS.ENABLED || !Array.isArray(files)) return EMPTY;
+    let budget = Math.min(
+        PDF_VISION_LIMITS.MAX_PAGES,
+        PDF_VISION_LIMITS.TOTAL_IMAGE_CAP - userImageCount,
+    );
+    if (budget <= 0) return EMPTY;
+
+    const pdfs = files.filter((f) => {
+        if (!f || typeof f.data !== 'string' || f.data.length === 0) return false;
+        if (typeof f.content === 'string') return false; // 이미 텍스트 내용 보유 — 추출/렌더 대상 아님
+        const i = f.name.lastIndexOf('.');
+        const ext = i >= 0 ? f.name.slice(i + 1).toLowerCase() : '';
+        return DOC_EXTRACT_LIMITS.PDF_EXTS.includes(ext);
+    });
+    if (pdfs.length === 0) return EMPTY;
+    if (!(await checkPdftoppm())) return EMPTY;
+
+    const images: string[] = [];
+    const noteLines: string[] = [];
+    for (const f of pdfs) {
+        if (budget <= 0) break;
+        const buf = Buffer.from(f.data as string, 'base64');
+        if (buf.length === 0 || buf.length > DOC_EXTRACT_LIMITS.OCR_MAX_BYTES) continue;
+        const dir = path.join(os.tmpdir(), `om-pdfvis-${crypto.randomUUID()}`);
+        try {
+            await fs.mkdir(dir, { recursive: true });
+            const pdfPath = path.join(dir, 'in.pdf');
+            await fs.writeFile(pdfPath, buf);
+            const total = await getPageCount(pdfPath);
+            const want = total !== undefined ? Math.min(budget, total) : budget;
+            await execFileAsync('pdftoppm', [
+                '-jpeg', '-r', String(PDF_VISION_LIMITS.DPI),
+                '-f', '1', '-l', String(want),
+                pdfPath, path.join(dir, 'p'),
+            ], { timeout: PDF_VISION_LIMITS.RENDER_TIMEOUT_MS });
+            const pages = (await fs.readdir(dir))
+                .filter((n) => n.endsWith('.jpg'))
+                .sort((a, b) => pageNumOf(a) - pageNumOf(b))
+                .slice(0, budget);
+            if (pages.length === 0) continue;
+            for (const p of pages) {
+                const jpg = await fs.readFile(path.join(dir, p));
+                images.push(`data:image/jpeg;base64,${jpg.toString('base64')}`);
+            }
+            budget -= pages.length;
+            const range = pages.length === 1 ? '1페이지' : `1–${pages.length}페이지`;
+            noteLines.push(`- ${f.name}: ${total !== undefined ? `총 ${total}페이지 중 ` : ''}${range} 이미지 첨부`);
+            logger.info(`[PdfVision] ${f.name}: ${pages.length}페이지 렌더 주입 (dpi ${PDF_VISION_LIMITS.DPI})`);
+        } catch (e) {
+            logger.warn(`[PdfVision] ${f.name} 렌더 실패 — 텍스트 추출만 사용: ${e instanceof Error ? e.message : e}`);
+        } finally {
+            await fs.rm(dir, { recursive: true, force: true }).catch(() => { /* noop */ });
+        }
+    }
+    if (images.length === 0) return EMPTY;
+    const note = '\n\n[첨부 PDF 페이지 이미지] 아래 PDF 는 본문 텍스트 추출과 별도로 앞쪽 페이지가 이미지로도 첨부되어 있다. '
+        + '표·차트·레이아웃이 필요한 판독은 이미지를 근거로 할 것.\n'
+        + noteLines.join('\n');
+    return { images, note };
+}

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -22,6 +22,7 @@ import { WS_LIMITS } from '../config/timeouts';
 import { FILE_ATTACH_LIMITS } from '../config/runtime-limits';
 import { ArtifactStreamParser, type ArtifactInfo } from '../llm/artifact-parser';
 import { buildFileContext, buildUrlContext, getCachedAttachContext, appendCachedAttachContext } from '../services/chat-service/attach-context';
+import type { PdfVisionResult } from '../services/chat-service/pdf-vision';
 import { hasScriptMixing } from '../services/chat-service/script-purity';
 import { citationMarkersWereCleaned } from '../services/chat-service/external-deterministic-append';
 import { saveAssistantMessage } from '../chat/request-persistence';
@@ -140,7 +141,15 @@ export async function handleChatMessage(
         // 레이트 리밋 통과 후 조립 — 거부될 요청에 최대 300k 자 문자열 조립 비용을 쓰지 않는다.
         // 바이너리 문서(PDF/docx/xlsx/pptx 등)는 base64(data)를 텍스트로 추출해 content 를 채운다.
         // (무거운 파서는 첨부가 있을 때만 lazy 로딩)
+        let pdfVision: PdfVisionResult = { images: [], note: '' };
         if (hasFiles) {
+            // PDF 하이브리드 (2026-08-19): 텍스트 추출에 더해 앞쪽 페이지를 vision 채널로 병행 주입.
+            // 추출(data 소거) 전에 렌더해야 하며, 특수 모드는 제외 — 딥리서치(첨부 자체 거부),
+            // 이미지 생성(vision 미소비), 토론(참여 모델 수만큼 비전 비용 배수).
+            if (msg.deepResearchMode !== true && msg.imageMode !== true && msg.discussionMode !== true) {
+                const { buildPdfVisionAttachment } = await import('../services/chat-service/pdf-vision');
+                pdfVision = await buildPdfVisionAttachment(msg.files, images?.length ?? 0);
+            }
             const { extractAttachedDocuments } = await import('../services/chat-service/doc-extractor');
             await extractAttachedDocuments(msg.files);
         }
@@ -279,10 +288,12 @@ export async function handleChatMessage(
             model: selectedModel,
             nodeId,
             history,
-            images,
+            // PDF 하이브리드: 렌더된 페이지 이미지를 사용자 첨부 뒤에 병합 (예산은 pdf-vision 이 관리)
+            images: pdfVision.images.length > 0 ? [...(images ?? []), ...pdfVision.images] : images,
             sessionId: validSessionId,
             webSearchContext,
-            fileContext: effectiveAttachContext || undefined,
+            // pdfVision.note 는 이번 턴 한정 — 세션 캐시(appendCachedAttachContext)엔 attachContext 만 저장
+            fileContext: (effectiveAttachContext + pdfVision.note) || undefined,
             discussionMode: msg.discussionMode === true,
             deepResearchMode: msg.deepResearchMode === true,
             imageMode: msg.imageMode === true,

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -141,15 +141,13 @@ export async function handleChatMessage(
         // 레이트 리밋 통과 후 조립 — 거부될 요청에 최대 300k 자 문자열 조립 비용을 쓰지 않는다.
         // 바이너리 문서(PDF/docx/xlsx/pptx 등)는 base64(data)를 텍스트로 추출해 content 를 채운다.
         // (무거운 파서는 첨부가 있을 때만 lazy 로딩)
+        // PDF 하이브리드(2026-08-19): 추출(data 소거) 전 앞쪽 페이지 vision 렌더 주입 — 특수 모드(딥리서치·이미지생성·토론) 제외
         let pdfVision: PdfVisionResult = { images: [], note: '' };
+        if (hasFiles && msg.deepResearchMode !== true && msg.imageMode !== true && msg.discussionMode !== true) {
+            const { buildPdfVisionAttachment } = await import('../services/chat-service/pdf-vision');
+            pdfVision = await buildPdfVisionAttachment(msg.files, images?.length ?? 0);
+        }
         if (hasFiles) {
-            // PDF 하이브리드 (2026-08-19): 텍스트 추출에 더해 앞쪽 페이지를 vision 채널로 병행 주입.
-            // 추출(data 소거) 전에 렌더해야 하며, 특수 모드는 제외 — 딥리서치(첨부 자체 거부),
-            // 이미지 생성(vision 미소비), 토론(참여 모델 수만큼 비전 비용 배수).
-            if (msg.deepResearchMode !== true && msg.imageMode !== true && msg.discussionMode !== true) {
-                const { buildPdfVisionAttachment } = await import('../services/chat-service/pdf-vision');
-                pdfVision = await buildPdfVisionAttachment(msg.files, images?.length ?? 0);
-            }
             const { extractAttachedDocuments } = await import('../services/chat-service/doc-extractor');
             await extractAttachedDocuments(msg.files);
         }
@@ -288,11 +286,9 @@ export async function handleChatMessage(
             model: selectedModel,
             nodeId,
             history,
-            // PDF 하이브리드: 렌더된 페이지 이미지를 사용자 첨부 뒤에 병합 (예산은 pdf-vision 이 관리)
             images: pdfVision.images.length > 0 ? [...(images ?? []), ...pdfVision.images] : images,
             sessionId: validSessionId,
             webSearchContext,
-            // pdfVision.note 는 이번 턴 한정 — 세션 캐시(appendCachedAttachContext)엔 attachContext 만 저장
             fileContext: (effectiveAttachContext + pdfVision.note) || undefined,
             discussionMode: msg.discussionMode === true,
             deepResearchMode: msg.deepResearchMode === true,

--- a/scripts/vllm/qwen-serve.sh
+++ b/scripts/vllm/qwen-serve.sh
@@ -2,7 +2,9 @@
 # ============================================================
 # qwen3.6-35b-a3b — 기본 채팅 (262K context) @ :8002
 # ============================================================
-# DGX 실측 serve 명령 기준 (2026-08-02 동기화 — prefix caching 추가).
+# DGX 실측 serve 명령 기준 (2026-08-19 동기화 — --limit-mm-per-prompt image 4→8:
+# 채팅 PDF 하이브리드(pdf-vision 페이지 주입, PDF_VISION_TOTAL_IMAGE_CAP=8 페어) 지원.
+# 2026-08-02 prefix caching 추가).
 #
 # --enable-prefix-caching (2026-08-02 추가):
 #   앱은 이 기능을 전제로 프롬프트를 배치한다 — external-system-prompt.ts 가 정적 헌법을
@@ -47,7 +49,7 @@ exec vllm serve "$MODEL_DIR" \
   --reasoning-parser qwen3 \
   --enable-auto-tool-choice \
   --tool-call-parser qwen3_coder \
-  --limit-mm-per-prompt '{"image": 4}' \
+  --limit-mm-per-prompt '{"image": 8}' \
   --speculative-config '{"method": "mtp", "num_speculative_tokens": 1}' \
   --kv-cache-dtype fp8 \
   --enable-prefix-caching \


### PR DESCRIPTION
## 요약

채팅 PDF 첨부를 claude.ai/ChatGPT 식 **하이브리드**(텍스트 추출 + 페이지 이미지)로 처리한다. 기존 doc-extractor 텍스트 추출에 더해, 첨부 PDF 의 앞쪽 페이지를 pdftoppm 120dpi JPEG 로 렌더해 vision(`images`) 채널에 병행 주입 — 표·차트·레이아웃 등 텍스트 추출로 소실되는 시각 정보를 보강한다 (스캔본 PDF 포함).

## 변경 내역

- **`services/chat-service/pdf-vision.ts` 신설** — 페이지 렌더·예산 관리. 예산 = `min(PDF_VISION_MAX_PAGES, PDF_VISION_TOTAL_IMAGE_CAP − 사용자 첨부 이미지 수)`, 다중 PDF 는 순서대로 소진. poppler 부재·렌더 실패는 graceful skip (기존 텍스트 경로 무영향)
- **`sockets/ws-chat-handler.ts`** — 추출(`data` 소거) **전에** 렌더 → `images` 병합 + fileContext 에 "총 N페이지 중 1–k 이미지 첨부" 안내. 딥리서치(첨부 거부)/이미지생성/토론(비용 배수) 모드 제외. 안내문은 세션 캐시 미저장(이미지는 해당 턴에만 존재)
- **`config/runtime-limits.ts` `PDF_VISION_LIMITS` + `.env.example`** — `PDF_VISION_ENABLED`(킬스위치)·`TOTAL_IMAGE_CAP`·`MAX_PAGES`·`DPI`·`RENDER_TIMEOUT_MS`
- **`scripts/vllm/qwen-serve.sh`** — `--limit-mm-per-prompt` image 4→8 (DGX 실물 2026-08-19 적용·재기동 완료본과 동기화)

⚠️ **페어 불변식**: `PDF_VISION_TOTAL_IMAGE_CAP`(운영 .env=8) = vLLM `--limit-mm-per-prompt '{"image": 8}'`. 한쪽만 변경 시 vLLM 400.

## 검증

- [x] `npm run lint` 통과 (기존 max-lines 경고 2건 외 0 error)
- [x] 유닛 테스트: `pdf-vision.test.ts` 5건 신규 (child_process mock — CI poppler 불요) + chat-service/sockets 16 스위트 136건 회귀 없음
- [x] `.env.example` 업데이트
- [x] **라이브 E2E (chat.openmake.cc)**: ① 스캔형 PDF → 표 수치 전부 + 텍스트로 알 수 없는 시각 정보(표 헤더 회색 배경·제목 아래 구분선) 정확 판독, 서버 로그 `[PdfVision] 1페이지 렌더 주입` 확증 ② 21페이지 실문서 → 8페이지 주입, vLLM 8장 수용, 30.8 tok/s 정상
- 프론트엔드 변경 불필요 (주입은 서버 내부, 프론트는 기존대로 `files[].data` 전송)

🤖 Generated with [Claude Code](https://claude.com/claude-code)