### PR TITLE
fix(agent-task): 기본 max_turns 10 → 32

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -928,7 +928,8 @@ AGENT_TASK_TIMEOUT_MS=600000
 # AGENT_TASK_TURN_RETRY_MAX=2
 # AGENT_TASK_TURN_RETRY_BACKOFF_MS=2000
 # 대형 첨부(생성 시점 추출 상한 초과 → 샌드박스 자체 파싱) task 의 기본 턴 수 —
-# 기본 10턴은 수백 페이지 문서에 부족해 goal_incomplete 실패 (명시 maxTurns 우선, 상한 20)
+# 종전 기본 10턴은 수백 페이지 문서에 부족해 goal_incomplete 실패 (명시 maxTurns 우선).
+# ⚠️ AGENT_TASK_DEFAULT_MAX_TURNS(32)보다 작으면 실효가 없다 — 코드가 Math.max 로 역전을 막는다.
 # AGENT_TASK_LARGE_INPUT_MAX_TURNS=20
 
 # Agent Task — 플랜 자동 진행. 단계 완료/차단 후 in_progress 가 없으면 첫 not_started 를
@@ -1001,6 +1002,11 @@ AGENT_TASK_TIMEOUT_MS=600000
 
 # Agent Task — 사용자 지정 max_turns 절대 상한 (Zod 입력 검증 상한도 동일). 기본 32.
 # AGENT_TASK_MAX_TURNS_CEILING=32
+
+# Agent Task — maxTurns 미지정 작업의 기본 턴 수. 기본 32 (2026-08-19 상향, 종전 10).
+# 종전 10 은 기본값 실행 141건 중 25건이 10/10 을 소진해 실패했다. 상한을 지정한 32턴 작업은
+# 도달 사례가 0건(최대 28턴)이라 여유가 있고, 작업이 일찍 끝나면 남는 턴은 소모되지 않는다.
+# AGENT_TASK_DEFAULT_MAX_TURNS=32
 
 # Agent Task — 마무리 턴 본문 채택 임계(글자). 자원 상한으로 도구를 막은 턴에서 모델이 도구 호출과
 # 본문을 함께 뱉었을 때, 본문이 이 길이 이상이면 최종 답변으로 채택해 완료 관문으로 보낸다.

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1422,13 +1422,24 @@ export const AGENT_TASK_LIMITS = {
      * 262K 컨텍스트의 4% 수준이라 안전하다.
      */
     GOAL_MAX_CHARS: parseInt(process.env.AGENT_TASK_GOAL_MAX_CHARS || '', 10) || 20000,
-    /** 기본 최대 턴 수 */
-    DEFAULT_MAX_TURNS: 10,
+    /** 기본 최대 턴 수(요청이 maxTurns 를 명시하지 않았을 때).
+     *  종전 10 은 근거 없이 낮았다 — 2026-08-19 실측: 기본값으로 실행된 141건 중 25건이 10/10 을
+     *  소진해 실패했고, 그중엔 조사·검증을 다 끝내고 산출물 저장 직전에 턴이 끊긴 건도 있었다
+     *  (6ad7b822: 검색 8회·fact_check 3회 성공 후 data.json 을 쓰지 못하고 goal_incomplete).
+     *  반면 천장(32)을 지정한 12건은 상한 도달이 0건(최대 28턴)이라 32 는 사실상 여유가 있다.
+     *  턴 상한은 "여기까지만 돌린다"는 안전판이지 예산이 아니다 — 작업이 일찍 끝나면 남는 턴은
+     *  소모되지 않으므로, 상향의 비용은 실패·루프 작업이 더 오래 도는 경우로 한정된다. 그 경우도
+     *  MAX_TOTAL_TOKENS·TOKEN_SOFT_RATIO 가 별도로 먼저 걸린다.
+     *  AGENT_TASK_DEFAULT_MAX_TURNS 로 오버라이드(상한은 MAX_TURNS_CEILING). */
+    DEFAULT_MAX_TURNS: parseInt(process.env.AGENT_TASK_DEFAULT_MAX_TURNS || '', 10) || 32,
     /**
      * 대형 첨부(생성 시점 추출 상한 초과 — 샌드박스에서 에이전트가 직접 파싱/OCR) 시 기본 턴 수.
-     * 기본 10턴은 수백 페이지 문서의 읽기+정리에 부족해 goal_incomplete 로 실패한다
+     * 종전 기본 10턴은 수백 페이지 문서의 읽기+정리에 부족해 goal_incomplete 로 실패했다
      * (2026-08-08 실측: 66MB 스캔 PDF 가 턴 10/10 소진, 57MB 도 10/10 턱걸이 완주).
      * 명시 maxTurns 가 오면 그 값이 우선.
+     * ⚠️ DEFAULT_MAX_TURNS 상향(10→32, 2026-08-19)으로 이 값이 기본보다 작아졌다. 이 상수는
+     * "상향"이 목적이므로 resolveDefaultMaxTurns 가 Math.max 로 역전을 막는다 — 실효를 가지려면
+     * 기본값보다 크게 잡을 것.
      */
     LARGE_INPUT_MAX_TURNS: parseInt(process.env.AGENT_TASK_LARGE_INPUT_MAX_TURNS || '', 10) || 20,
     /** 관리자 전체 조회(/admin/conversations 작업 탭, ?viewAll=true) 기본 목록 상한.

--- a/apps/api/src/services/agent-task/__tests__/resolve-default-max-turns.test.ts
+++ b/apps/api/src/services/agent-task/__tests__/resolve-default-max-turns.test.ts
@@ -1,0 +1,25 @@
+import { resolveDefaultMaxTurns } from '../task-inputs';
+import { AGENT_TASK_LIMITS, DOC_EXTRACT_LIMITS } from '../../../config/runtime-limits';
+
+/**
+ * 기본 턴 수 결정 — 특히 LARGE_INPUT_MAX_TURNS 가 DEFAULT_MAX_TURNS 보다 작아졌을 때
+ * (기본 10→32 상향, 2026-08-19) 대형 첨부가 오히려 손해를 보는 역전이 없어야 한다.
+ * 둘 다 env 로 조정 가능해 역전 자체는 언제든 재현될 수 있다.
+ */
+describe('resolveDefaultMaxTurns', () => {
+    const bigFile = { name: 'scan.pdf', size: DOC_EXTRACT_LIMITS.MAX_BYTES_PER_FILE + 1 };
+
+    it('명시 maxTurns 가 오면 그대로 쓴다', () => {
+        expect(resolveDefaultMaxTurns(7, undefined)).toBe(7);
+        expect(resolveDefaultMaxTurns(7, [bigFile] as never)).toBe(7);
+    });
+
+    it('첨부가 없으면 기본값', () => {
+        expect(resolveDefaultMaxTurns(undefined, undefined)).toBe(AGENT_TASK_LIMITS.DEFAULT_MAX_TURNS);
+    });
+
+    it('대형 첨부는 기본값보다 작아지지 않는다(역전 방지)', () => {
+        expect(resolveDefaultMaxTurns(undefined, [bigFile] as never))
+            .toBeGreaterThanOrEqual(AGENT_TASK_LIMITS.DEFAULT_MAX_TURNS);
+    });
+});

--- a/apps/api/src/services/agent-task/task-inputs.ts
+++ b/apps/api/src/services/agent-task/task-inputs.ts
@@ -28,7 +28,10 @@ export function resolveDefaultMaxTurns(
         const isDoc = DOC_EXTRACT_LIMITS.PDF_EXTS.includes(ext) || DOC_EXTRACT_LIMITS.OFFICE_EXTS.includes(ext);
         return isDoc && typeof f.content !== 'string';
     });
-    return needsSandboxParsing ? AGENT_TASK_LIMITS.LARGE_INPUT_MAX_TURNS : AGENT_TASK_LIMITS.DEFAULT_MAX_TURNS;
+    // LARGE_INPUT 은 기본값 "상향"이 목적이므로 기본보다 낮아지면 안 된다 — 둘 다 env 로 조정
+    // 가능해 역전이 가능하다(기본 32 > LARGE_INPUT 20 이면 대형 첨부가 오히려 손해).
+    if (!needsSandboxParsing) return AGENT_TASK_LIMITS.DEFAULT_MAX_TURNS;
+    return Math.max(AGENT_TASK_LIMITS.LARGE_INPUT_MAX_TURNS, AGENT_TASK_LIMITS.DEFAULT_MAX_TURNS);
 }
 
 const logger = createLogger('AgentTaskService');


### PR DESCRIPTION
## 문제

`maxTurns`를 명시하지 않은 작업에 붙는 `DEFAULT_MAX_TURNS`가 근거 없이 **10**이었다. 이 값은 UI 어디에서도 노출·조정되지 않아(스케줄 페이지는 조회 전용, 작업 생성 폼에 필드 없음) 사실상 대부분의 작업이 조용히 10턴으로 실행된다.

## 실측 (agent_tasks 전량, 2026-08-19)

| max_turns | 작업 수 | 최대 도달 턴 | 상한 소진 |
|---|---|---|---|
| **10 (기본값)** | 141 | 10 | **25건** |
| 20 | 34 | 20 | **21건 (62%)** |
| **32 (천장)** | 12 | 28 | **0건** |

기본값으로 돈 141건 중 25건이 `10/10`을 소진해 실패했다. 20도 62%가 부딪혀 중간값으로는 부족하고, 도달률이 0인 건 32뿐이다.

## 대표 사례 `6ad7b822`

`web_search` 8회 · `fact_check` 3회를 모두 성공해 **데이터를 다 모으고 data.json 내용까지 완성한 뒤**, 저장할 턴이 없어 `goal_incomplete`로 끝났다. 10턴 중 5턴이 `plan_create`/`plan_update`(실질 산출 0)에 쓰였고, 마지막 턴은 `final_turn` 게이트가 도구를 막아 `file_ops(write)` 한 번을 못 했다.

## 왜 상향의 비용이 작은가

턴 상한은 예산이 아니라 **안전판**이다. 작업이 일찍 끝나면 남는 턴은 소모되지 않는다(32 지정 12건의 실제 사용은 8~28턴). 상향의 비용은 실패·루프 작업이 더 오래 도는 경우로 한정되고, 그마저 `MAX_TOTAL_TOKENS`·`TOKEN_SOFT_RATIO`가 먼저 걸린다.

## 변경

- `DEFAULT_MAX_TURNS`: `10` → `32`, `AGENT_TASK_DEFAULT_MAX_TURNS`로 오버라이드 가능(종전엔 env 훅조차 없는 하드코딩)
- **파생 수정** — `LARGE_INPUT_MAX_TURNS`(20)가 기본값보다 작아져 **대형 첨부가 오히려 손해를 보는 역전**이 생긴다. 이 상수는 "상향"이 목적이므로 `resolveDefaultMaxTurns`가 `Math.max`로 막고, 회귀 방지 테스트를 추가했다
- `.env.example` 갱신

## 검증

- `tsc --noEmit` 통과
- `resolve-default-max-turns.test.ts` 신규 3건 통과
- 기존 `agent-task-max-turns` · `agent-task-input-files` 15건 통과 (모두 `maxTurns` 명시라 영향 없음)

## 남은 것 (별건)

`final_turn` 게이트가 마지막 턴에 도구를 전면 차단해, 산출물을 만들어 놓고도 저장하지 못하는 패턴이 남는다. 턴이 넉넉해도 언젠가 상한에 닿는 작업은 생기므로 쓰기 계열 도구는 남기는 편이 낫다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)