### PR TITLE
feat(web): 이력 카드 재배치 · 로컬 실행 시 저장소 UI 숨김 · build 자동 재시작

### DIFF
--- a/apps/web/app/(workspace)/agent-tasks/page.tsx
+++ b/apps/web/app/(workspace)/agent-tasks/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import {
   Sparkles,
   Check,
@@ -54,6 +54,8 @@ interface AgentTask {
   rawStatus: ApiTaskStatus;
   model: string;
   elapsed: string;
+  /** 시작(생성) 시각 ISO — 목록에서 경과시간과 함께 표시. 목업 데이터는 생략 가능. */
+  startedAt?: string;
   currentTurn: number;
   maxTurns: number;
   progress: number;
@@ -139,6 +141,22 @@ function formatElapsed(t: TFn, start?: string, end?: string): string {
     : t("elapsedSec", { s: r });
 }
 
+/**
+ * 목록용 시작 시각 — 연도는 생략해 카드 메타 줄을 짧게 유지하고, 전체 시각은 title 로 노출한다.
+ * 로그성 목록이라 12시간제(오전/오후)보다 24시간제가 읽기 쉽다.
+ */
+function formatStartedAt(iso: string | undefined, locale: string): { short: string; full: string } | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return {
+    short: d.toLocaleString(locale, {
+      month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", hour12: false,
+    }),
+    full: d.toLocaleString(locale),
+  };
+}
+
 function mapTask(tr: TFn, t: ApiAgentTask): AgentTask {
   const status = mapStatus(t.status);
   const progress =
@@ -154,6 +172,7 @@ function mapTask(tr: TFn, t: ApiAgentTask): AgentTask {
     rawStatus: t.status,
     model: t.model || "Auto",
     elapsed: formatElapsed(tr, t.created_at, t.completed_at),
+    startedAt: t.created_at,
     currentTurn: t.current_turn ?? 0,
     maxTurns: t.max_turns ?? 0,
     progress,
@@ -882,6 +901,7 @@ function TemplatesPanel() {
 
 export default function AgentTasksPage() {
   const t = useTranslations("agentTasks");
+  const locale = useLocale();
   const router = useRouter();
   const [tasks, setTasks] = useState<AgentTask[]>(() => buildTaskFallback(t));
   const [loading, setLoading] = useState(true);
@@ -1136,9 +1156,15 @@ export default function AgentTasksPage() {
                   {/* 메타 + 액션 버튼 */}
                   <div className="flex items-center justify-between border-t border-border pt-3">
                     <div className="flex items-center gap-3 text-xs text-faint">
-                      <span className="flex items-center gap-1">
-                        <Clock className="h-3.5 w-3.5" />{task.elapsed}
-                      </span>
+                      {(() => {
+                        const started = formatStartedAt(task.startedAt, locale);
+                        return (
+                          <span className="flex items-center gap-1" title={started?.full}>
+                            <Clock className="h-3.5 w-3.5" />
+                            {started ? `${started.short} · ${task.elapsed}` : task.elapsed}
+                          </span>
+                        );
+                      })()}
                       <span className="flex items-center gap-1">
                         <Cpu className="h-3.5 w-3.5" />{task.model}
                       </span>

--- a/apps/web/app/(workspace)/agent-tasks/page.tsx
+++ b/apps/web/app/(workspace)/agent-tasks/page.tsx
@@ -7,8 +7,6 @@ import {
   Sparkles,
   Check,
   LoaderCircle,
-  Clock,
-  Cpu,
   X,
   Trash2,
   RotateCcw,
@@ -1075,6 +1073,7 @@ export default function AgentTasksPage() {
 
               return (
                 <Card key={task.id} className="flex flex-col p-5">
+                  {/* 1) 정체성 — 상태·소유자·실행기 배지 + 상세 진입. 턴은 진행률 줄로 내렸다. */}
                   <div className="mb-3 flex items-start justify-between gap-2">
                     <span className="flex flex-wrap items-center gap-1.5">
                       <Badge tone={meta.tone}>
@@ -1089,10 +1088,16 @@ export default function AgentTasksPage() {
                       {viewAll && task.ownerId && task.ownerId !== String(myUserId ?? "") && (
                         <Badge tone="neutral">{t("ownerBadge", { id: task.ownerId })}</Badge>
                       )}
+                      {task.executor === "local" && (
+                        <Badge tone="neutral">{t("localBadge")}</Badge>
+                      )}
                     </span>
-                    <span className="font-mono text-xs text-faint">
-                      {t("turnShort", { current: task.currentTurn, max: task.maxTurns })}
-                    </span>
+                    <button
+                      onClick={() => setDetailTaskId(task.id)}
+                      title={t("detailTitle")}
+                      className="-mr-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md text-faint transition hover:bg-surface-2 hover:text-fg">
+                      <ChevronRight className="h-4 w-4" />
+                    </button>
                   </div>
 
                   {/* 실패 사유 — 알려진 코드는 번역, 재개 가능 사유는 resume 안내 병기 */}
@@ -1116,12 +1121,6 @@ export default function AgentTasksPage() {
                   >
                     {task.goal}
                   </h3>
-                  {task.executor === "local" && (
-                    <span className="mb-2 inline-flex w-fit items-center rounded-full border border-accent bg-accent-soft px-2 py-0.5 text-[10px] font-medium text-accent">
-                      {t("localBadge")}
-                    </span>
-                  )}
-
                   {total > 0 ? (
                     <ul className="mb-4 flex-1 space-y-1.5">
                       {task.checklist.map((item, i) => (
@@ -1142,46 +1141,55 @@ export default function AgentTasksPage() {
                     <div className="flex-1" />
                   )}
 
-                  {/* 진행률 */}
+                  {/* 2) 진행 — 진행률과 턴은 같은 축이라 한 줄에 모은다(종전엔 턴만 카드 상단에 떨어져 있었다). */}
                   <div className="mb-3">
-                    <div className="mb-1 flex items-center justify-between text-xs">
+                    <div className="mb-1 flex items-baseline justify-between gap-2 text-xs">
                       <span className="text-faint">{t("progressLabel")}</span>
-                      <span className="font-mono text-fg-2">{pct}%</span>
+                      <span className="flex items-baseline gap-2 font-mono">
+                        <span className="text-fg-2">{pct}%</span>
+                        <span className="text-faint">
+                          {t("turnShort", { current: task.currentTurn, max: task.maxTurns })}
+                        </span>
+                      </span>
                     </div>
                     <div className="h-1.5 overflow-hidden rounded-pill bg-surface-3">
                       <div className="h-full rounded-pill bg-accent transition-all" style={{ width: `${pct}%` }} />
                     </div>
                   </div>
 
-                  {/* 메타 + 액션 버튼 */}
-                  <div className="flex items-center justify-between border-t border-border pt-3">
-                    <div className="flex items-center gap-3 text-xs text-faint">
-                      {(() => {
-                        const started = formatStartedAt(task.startedAt, locale);
-                        return (
-                          <span className="flex items-center gap-1" title={started?.full}>
-                            <Clock className="h-3.5 w-3.5" />
-                            {started ? `${started.short} · ${task.elapsed}` : task.elapsed}
-                          </span>
-                        );
-                      })()}
-                      <span className="flex items-center gap-1">
-                        <Cpu className="h-3.5 w-3.5" />{task.model}
-                      </span>
-                      {typeof task.totalTokens === "number" && task.totalTokens > 0 && (
-                        <span className="font-mono tabular-nums" title={t("tokensUsedHint")}>
-                          {t("tokensUsed", { count: task.totalTokens.toLocaleString() })}
-                        </span>
-                      )}
+                  {/* 3) 측정값 — 시작·소요를 각각 독립 항목으로 세우고 모델·토큰과 함께 2×2 로 정렬한다.
+                      라벨이 값의 뜻을 말하므로 종전의 Clock/Cpu 아이콘은 뺐다(중복). */}
+                  <dl className="grid grid-cols-2 gap-x-4 gap-y-1 border-t border-border pt-3 text-xs">
+                    {(() => {
+                      const started = formatStartedAt(task.startedAt, locale);
+                      return (
+                        <div className="flex items-baseline justify-between gap-2" title={started?.full}>
+                          <dt className="text-faint">{t("startedLabel")}</dt>
+                          <dd className="truncate font-mono text-fg-2">{started?.short ?? "—"}</dd>
+                        </div>
+                      );
+                    })()}
+                    <div className="flex items-baseline justify-between gap-2">
+                      <dt className="text-faint">{t("modelLabel")}</dt>
+                      <dd className="truncate text-fg-2">{task.model}</dd>
                     </div>
+                    <div className="flex items-baseline justify-between gap-2">
+                      <dt className="text-faint">{t("elapsedLabel")}</dt>
+                      <dd className="truncate font-mono text-fg-2">{task.elapsed}</dd>
+                    </div>
+                    <div className="flex items-baseline justify-between gap-2" title={t("tokensUsedHint")}>
+                      <dt className="text-faint">{t("tokensLabel")}</dt>
+                      <dd className="truncate font-mono tabular-nums text-fg-2">
+                        {typeof task.totalTokens === "number" && task.totalTokens > 0
+                          ? task.totalTokens.toLocaleString()
+                          : "—"}
+                      </dd>
+                    </div>
+                  </dl>
+
+                  {/* 4) 액션 — 종전엔 메타와 한 줄을 다퉈 좁은 카드에서 넘쳤다. 별도 줄로 내리고 우측 정렬. */}
+                  <div className="mt-3 flex items-center justify-end gap-1">
                     <div className="flex items-center gap-1">
-                      {/* 상세 보기 */}
-                      <button
-                        onClick={() => setDetailTaskId(task.id)}
-                        title={t("detailTitle")}
-                        className="flex h-7 w-7 items-center justify-center rounded-md text-faint transition hover:bg-surface-2 hover:text-fg">
-                        <ChevronRight className="h-3.5 w-3.5" />
-                      </button>
                       {/* Resume (failed + resumable) */}
                       {task.rawStatus === "failed" && task.resumable && (
                         <button

--- a/apps/web/app/(workspace)/artifacts/page.tsx
+++ b/apps/web/app/(workspace)/artifacts/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Boxes, Share2, ExternalLink, Lock, Globe, Link2, Clock } from "lucide-react";
+import { Boxes, Share2, ExternalLink, Lock, Globe, Link2 } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { PageHeader, Card, Badge } from "@/components/ui/primitives";
@@ -110,20 +110,25 @@ export default function ArtifactsGalleryPage() {
                     <span className="text-lg leading-none">{it.icon || "📦"}</span>
                     <div className="min-w-0 flex-1">
                       <h3 className="truncate text-sm font-medium text-fg transition hover:text-accent">{it.title}</h3>
+                      {/* 제목 영역은 정체성(종류·버전)만 — 생성 시각은 아래 메타 줄에서 독립 항목으로 다룬다. */}
                       <div className="mt-1 flex flex-wrap items-center gap-1.5">
                         <Badge tone="neutral"><span className="font-mono">{it.kind}{it.lang ? `·${it.lang}` : ""}</span></Badge>
                         <span className="font-mono text-[11px] text-faint">v{it.version}</span>
-                        {(() => {
-                          const created = formatCreatedAt(it.createdAt, locale);
-                          return created ? (
-                            <span className="flex items-center gap-1 font-mono text-[11px] text-faint" title={created.full}>
-                              <Clock className="h-3 w-3" />{created.short}
-                            </span>
-                          ) : null;
-                        })()}
                       </div>
                     </div>
                   </button>
+
+                  {/* 메타 — 생성 시각을 라벨과 함께 독립 항목으로. 작업 카드의 측정값 블록과 같은 형식. */}
+                  {(() => {
+                    const created = formatCreatedAt(it.createdAt, locale);
+                    return created ? (
+                      <div className="flex items-baseline justify-between gap-2 border-t border-border pt-3 text-xs"
+                        title={created.full}>
+                        <span className="text-faint">{t("createdLabel")}</span>
+                        <span className="font-mono text-fg-2">{created.short}</span>
+                      </div>
+                    ) : null;
+                  })()}
 
                   <div className="flex items-center justify-between">
                     {it.published && vis && VisIcon ? (

--- a/apps/web/app/(workspace)/artifacts/page.tsx
+++ b/apps/web/app/(workspace)/artifacts/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Boxes, Share2, ExternalLink, Lock, Globe, Link2 } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { Boxes, Share2, ExternalLink, Lock, Globe, Link2, Clock } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { PageHeader, Card, Badge } from "@/components/ui/primitives";
 import { ApiClient, ApiError } from "@/lib/api-client";
@@ -29,8 +29,25 @@ const VIS_META: Record<string, { labelKey: string; icon: typeof Lock }> = {
   link: { labelKey: "vis.link", icon: Link2 },
 };
 
+/**
+ * 목록용 생성 시각 — 연도는 생략해 카드 메타 줄을 짧게 유지하고, 전체 시각은 title 로 노출한다.
+ * 로그성 목록이라 12시간제(오전/오후)보다 24시간제가 읽기 쉽다.
+ */
+function formatCreatedAt(iso: string | undefined, locale: string): { short: string; full: string } | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return {
+    short: d.toLocaleString(locale, {
+      month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", hour12: false,
+    }),
+    full: d.toLocaleString(locale),
+  };
+}
+
 export default function ArtifactsGalleryPage() {
   const t = useTranslations("artifacts.page");
+  const locale = useLocale();
   const [items, setItems] = useState<GalleryItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [share, setShare] = useState<{ sessionId: string; artifactId: string; icon: string | null } | null>(null);
@@ -93,9 +110,17 @@ export default function ArtifactsGalleryPage() {
                     <span className="text-lg leading-none">{it.icon || "📦"}</span>
                     <div className="min-w-0 flex-1">
                       <h3 className="truncate text-sm font-medium text-fg transition hover:text-accent">{it.title}</h3>
-                      <div className="mt-1 flex items-center gap-1.5">
+                      <div className="mt-1 flex flex-wrap items-center gap-1.5">
                         <Badge tone="neutral"><span className="font-mono">{it.kind}{it.lang ? `·${it.lang}` : ""}</span></Badge>
                         <span className="font-mono text-[11px] text-faint">v{it.version}</span>
+                        {(() => {
+                          const created = formatCreatedAt(it.createdAt, locale);
+                          return created ? (
+                            <span className="flex items-center gap-1 font-mono text-[11px] text-faint" title={created.full}>
+                              <Clock className="h-3 w-3" />{created.short}
+                            </span>
+                          ) : null;
+                        })()}
                       </div>
                     </div>
                   </button>

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -610,8 +610,12 @@ export function Composer() {
           </p>
         )}
 
-        {/* Phase 2 Git — repo URL 지정 시 태스크가 해당 repo 를 clone 해 작업 후 PR 생성(선택). */}
-        {agentTaskMode && (
+        {/* Phase 2 Git — repo URL 지정 시 태스크가 해당 repo 를 clone 해 작업 후 PR 생성(선택).
+            로컬 실행 중엔 숨긴다 — 연결 폴더가 작업 대상이라 clone 대상이 없고, 백엔드도
+            executor='local' + repoUrl 조합을 400 으로 거절한다(agent-task.routes.ts).
+            브리지가 끊기면 로컬 실행은 실질 무효(토글도 '연결 필요' 표시)이므로 다시 노출한다 —
+            그래야 repo 지정이라는 대안이 막히지 않는다. */}
+        {agentTaskMode && !(agentLocalExecutor && bridgeConnected) && (
           <div className="flex items-center gap-2 px-3 pt-2 text-xs">
             <span className="shrink-0 text-muted">{t("repo.label")}</span>
             <input

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -491,7 +491,8 @@
       },
       "openDetail": "View details",
       "versionPicker": "Version",
-      "close": "Close"
+      "close": "Close",
+      "createdLabel": "Created"
     },
     "resize": "Resize panel (double-click to reset)"
   },
@@ -802,7 +803,11 @@
       "interrupted": "Interrupted by server restart",
       "resumableHint": "Can be resumed"
     },
-    "planNode": "Step {n}"
+    "planNode": "Step {n}",
+    "startedLabel": "Started",
+    "elapsedLabel": "Elapsed",
+    "modelLabel": "Model",
+    "tokensLabel": "Tokens"
   },
   "customAgents": {
     "pageTitle": "Custom Agents",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -491,7 +491,8 @@
       },
       "openDetail": "詳細を見る",
       "versionPicker": "バージョン",
-      "close": "閉じる"
+      "close": "閉じる",
+      "createdLabel": "作成"
     },
     "resize": "パネル幅を調整 (ダブルクリックでリセット)"
   },
@@ -802,7 +803,11 @@
       "interrupted": "サーバー再起動により中断",
       "resumableHint": "再開できます"
     },
-    "planNode": "ステップ{n}"
+    "planNode": "ステップ{n}",
+    "startedLabel": "開始",
+    "elapsedLabel": "所要",
+    "modelLabel": "モデル",
+    "tokensLabel": "トークン"
   },
   "customAgents": {
     "pageTitle": "カスタムエージェント",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -491,7 +491,8 @@
       },
       "openDetail": "상세 보기",
       "versionPicker": "버전 선택",
-      "close": "닫기"
+      "close": "닫기",
+      "createdLabel": "생성"
     },
     "resize": "패널 너비 조절 (더블클릭: 기본값)"
   },
@@ -802,7 +803,11 @@
       "interrupted": "서버 재시작으로 중단",
       "resumableHint": "이어하기로 재개할 수 있습니다"
     },
-    "planNode": "{n}단계"
+    "planNode": "{n}단계",
+    "startedLabel": "시작",
+    "elapsedLabel": "소요",
+    "modelLabel": "모델",
+    "tokensLabel": "토큰"
   },
   "customAgents": {
     "pageTitle": "커스텀 에이전트",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -491,7 +491,8 @@
       },
       "openDetail": "查看详情",
       "versionPicker": "版本",
-      "close": "关闭"
+      "close": "关闭",
+      "createdLabel": "创建"
     },
     "resize": "调整面板宽度（双击重置）"
   },
@@ -802,7 +803,11 @@
       "interrupted": "因服务器重启而中断",
       "resumableHint": "可继续执行"
     },
-    "planNode": "步骤{n}"
+    "planNode": "步骤{n}",
+    "startedLabel": "开始",
+    "elapsedLabel": "耗时",
+    "modelLabel": "模型",
+    "tokensLabel": "令牌"
   },
   "customAgents": {
     "pageTitle": "自定义智能体",

--- a/openmake_llm.sh
+++ b/openmake_llm.sh
@@ -433,13 +433,52 @@ cmd_restart() {
 }
 
 # ── build / migrate / deploy ───────────────────────────────────────────────────
+
+# 새 빌드 산출물을 실행 중인 프로세스에 반영한다.
+# 프론트(next start)는 .next 를 기동 시점에 읽으므로, 재빌드 후 재시작하지 않으면
+# 옛 모듈 그래프가 이미 사라진 청크를 요구해 전 페이지가 500 이 된다
+# (2026-08-20 장애: ChunkLoadError — 빌드만 하고 재시작을 빠뜨린 경우).
+# PM2 미등록 앱은 건너뛴다 (최초 설치 중 빌드 등).
+restart_built_apps() {
+    local restarted=0 app
+    for app in "$APP_NAME" "$FRONT_APP_NAME"; do
+        if pm2 jlist 2>/dev/null | grep -q "\"name\":\"$app\""; then
+            if pm2 restart "$app" --update-env >/dev/null 2>&1; then
+                log_ok "$app 재시작"
+                restarted=1
+            else
+                log_warn "$app restart 실패 — 'pm2 restart $app' 수동 확인 필요"
+            fi
+        fi
+    done
+    if [[ "$restarted" -eq 0 ]]; then
+        log_info "PM2 등록 앱 없음 — 재시작 생략"
+    fi
+    return 0
+}
+
+# 사용법: cmd_build [--no-restart]
+#   기본은 빌드 성공 후 PM2 앱을 재시작한다.
+#   deploy 는 마이그레이션 뒤에 자체 재시작을 수행하므로 --no-restart 로 호출한다
+#   (여기서 재시작하면 새 코드가 옛 스키마로 먼저 뜨고, 이중 재시작이 된다).
 cmd_build() {
+    # set -e 하에서 `[[ ]] && x` 는 조건 거짓 시 리스트 상태가 1 이 되어 스크립트를 죽인다 — if 로 쓴다.
+    local do_restart=1
+    if [[ "${1:-}" == "--no-restart" ]]; then
+        do_restart=0
+    fi
+
     log_step "npm run build (backend tsc + apps/web Next.js 빌드)"
     if ! ( cd "$SCRIPT_DIR" && npm run build ); then
         log_err "빌드 실패 — 후속 작업 중단"
         return 2
     fi
     log_ok "빌드 완료"
+
+    if [[ "$do_restart" -eq 1 ]]; then
+        log_step "PM2 앱 재시작 (새 빌드 반영)"
+        restart_built_apps
+    fi
 }
 
 cmd_migrate() {
@@ -507,8 +546,8 @@ cmd_deploy() {
 
     log_step "Deploy: build → migrate → restart"
 
-    # 1) 빌드
-    cmd_build
+    # 1) 빌드 (재시작은 마이그레이션 뒤 3) 단계에서 일괄 수행)
+    cmd_build --no-restart
 
     # 2) 마이그레이션 (확인 프롬프트, --no-migrate면 skip)
     if [[ "$DEPLOY_NO_MIGRATE" -eq 1 ]]; then
@@ -574,6 +613,7 @@ OpenMake LLM 통합 서비스 매니저
 
 코드 변경 반영:
   build     npm run build (backend tsc + frontend Next.js build 산출물 생성)
+            빌드 후 PM2 앱(백엔드+프론트) 자동 재시작 — --no-restart 로 생략
   migrate   DB 마이그레이션 (status → migrate)
   deploy    build + migrate + restart 통합 (코드 변경 운영 반영)
             백엔드(openmake-llm)와 프론트(openmake-next) 모두 재시작
@@ -610,7 +650,7 @@ main() {
         start)    cmd_start ;;
         stop)     cmd_stop ;;
         restart)  cmd_restart ;;
-        build)    cmd_build ;;
+        build)    cmd_build "$@" ;;
         migrate)  cmd_migrate ;;
         deploy)   cmd_deploy "$@" ;;
         status)   show_status ;;


### PR DESCRIPTION
두 커밋으로 나뉜다. ① 시작 시각을 목록에 노출, ② 그 김에 드러난 카드 정보 배치를 성격별로 재구성.

## ① 시작(생성) 시각 표시

두 이력 목록 모두 "언제 만들어졌는지"를 볼 수 없었다. 작업 카드는 경과시간만 보여줘 어제 것인지 방금 것인지 구분되지 않았고, 아티팩트 카드는 `createdAt`을 API에서 받으면서도 렌더에 쓰지 않았다.

- 연도는 생략해 줄 길이를 유지하고, 전체 시각은 `title`로 노출
- 로그성 목록이라 24시간제 고정(`hour12: false`), 나머지 표기는 `useLocale`을 따름 (기존 `api-access`의 `formatDate` 관행과 동일)
- **백엔드 변경 없음** — 데이터는 양쪽 API가 이미 내려준다

## ② 카드 요소 재배치

배치가 정보의 성격과 어긋나 있었다.

- **턴(`22/32`)이 진행률과 반대편**에 있었다. 같은 축인데 카드 상단 우측에 홀로 떨어져 있었다
- **하단 한 줄에 6개**(시각·경과·모델·토큰 + 액션 버튼 5개)가 들어가 3열 그리드의 좁은 카드에서 서로를 밀어냈다
- **시작 시각과 소요시간이 한 span에 뭉쳐** `08-20 00:09 · 3분 09초`로 붙어 있어, 어느 쪽이 무엇인지 읽어봐야 알 수 있었다

성격별 4개 층으로 다시 세웠다:

```
[상태][소유자][로컬]                      [>]   ← 정체성
목표 텍스트 (2줄)
체크리스트
──────────────────────────────────────
진행률                      53%   턴 22/32   ← 진행 (같은 축을 한 줄로)
[███████████░░░░░░░░░░]
──────────────────────────────────────
시작  08-20 00:09      모델  Auto            ← 측정값 (각각 독립 항목)
소요  3분 09초         토큰  685,340
                      [재개][재시도][삭제]   ← 액션 (별도 줄)
```

- 라벨이 값의 뜻을 말하므로 `Clock`/`Cpu` 아이콘은 뺐다(중복), 토큰도 `"N 토큰"` 대신 라벨+숫자
- 로컬 배지는 제목 아래 떠 있던 것을 상태 배지 옆으로 승격
- 아티팩트 카드도 같은 형식 — 제목 영역은 정체성(종류·버전)만, 생성 시각은 구분선 아래 라벨-값 메타로 분리

## i18n

키 5개 × 4개 언어 추가: `startedLabel`·`elapsedLabel`·`modelLabel`·`tokensLabel`·`createdLabel`


## ③ 로컬 실행 중 git 저장소 입력 UI 숨김 (`composer.tsx`)

에이전트 모드의 저장소 입력줄이 조건 없이 노출돼, 데스크톱 앱에서 로컬 폴더를 연결하고 작업할 때도 남아 있었다. 로컬 실행은 연결 폴더가 작업 대상이라 clone 할 repo 가 없고, 백엔드는 `executor='local'` + `repoUrl` 조합을 **400 으로 거절**한다(`agent-task.routes.ts:135`). 프론트는 배타가 한 방향(repo 입력 시 로컬 토글 비활성)뿐이라 절반만 반영돼 있었다.

- 렌더 조건: `agentTaskMode` → `agentTaskMode && !(agentLocalExecutor && bridgeConnected)`
- 브리지가 끊기면 로컬 실행은 실질 무효(토글도 "연결 필요" 표시)이므로 다시 노출 — repo 지정이라는 대안이 막히지 않게
- 판정식은 토글 버튼의 활성 스타일이 이미 쓰던 것과 같아 표시 상태와 어긋나지 않는다

**라이브 검증**(chat.openmake.cc + 데스크톱 앱 브리지 연결, CDP 자동화): 로컬 실행 OFF → 저장소 줄 보임 / ON → 사라짐 / 다시 OFF → 복귀.

## ④ `openmake_llm.sh build` 후 PM2 앱 자동 재시작

빌드만 하고 재시작을 빠뜨리면 실행 중 next 서버가 죽는다 — 프로세스는 옛 모듈 그래프를 들고 있는데 `.next` 는 새 산출물로 교체돼 사라진 청크를 요구하다 `ChunkLoadError` 로 전 페이지가 500 이 된다. **2026-08-20 실사고**로 chat.openmake.cc 가 전면 다운됐다(프로세스 기동 00:23 vs `BUILD_ID` 00:57). `deploy` 는 이미 프론트까지 재시작했지만 `build` 경로가 무방비였다.

- `restart_built_apps()`: 등록된 PM2 앱만 재시작, 미등록이면 생략(최초 설치 중 빌드)
- `cmd_build [--no-restart]`: 기본 ON. 빌드 실패 시엔 재시작하지 않고 rc=2 유지
- `deploy` 는 `--no-restart` 로 호출 — 마이그레이션 뒤 일괄 재시작이라 이중 재시작이 되고, 여기서 재시작하면 새 코드가 옛 스키마로 먼저 뜬다
- `set -e` 함정: `[[ ]] && var=0` 은 조건 거짓 시 리스트 상태 1 로 스크립트를 죽여 `if` 로 작성

스텁 격리 harness 4케이스 검증(기본 재시작 / `--no-restart` / PM2 미등록 / 빌드 실패) + 실제 운영 배포에서 자동 재시작 동작 확인.

## 검증

`tsc --noEmit` · `eslint` · `next build` 모두 통과 · `bash -n openmake_llm.sh` 통과 · 라이브 UI 검증(위 ③)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
