### PR TITLE
fix: 모델 폴백 표기 정정 + PDF vision 해상도 상한

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -986,6 +986,9 @@ AGENT_TASK_TIMEOUT_MS=600000
 # PDF_VISION_TOTAL_IMAGE_CAP=4
 # PDF_VISION_MAX_PAGES=4
 # PDF_VISION_DPI=120
+# 렌더 이미지 긴 변 픽셀 상한 — 판형이 큰 문서(대형 슬라이드·도면)에서 초대형 이미지가
+# 나와 vision prefill 이 게이트웨이 타임아웃을 넘기는 것을 막는다. 초과 시 -scale-to 로 축소.
+# PDF_VISION_MAX_EDGE_PX=1600
 # PDF_VISION_RENDER_TIMEOUT_MS=20000
 
 # Agent Task — 목표 달성 judge (아티팩트 없는 최종 답변을 판정 전용 LLM 1회 호출로 검증,

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -446,6 +446,13 @@ export const PDF_VISION_LIMITS = {
     MAX_PAGES: parseInt(process.env.PDF_VISION_MAX_PAGES || '4', 10),
     /** 렌더 해상도 dpi — 문서 판독 라이브 실측(2026-08-19) 120 이면 충분, 상향은 비전 토큰 비례 증가 */
     DPI: parseInt(process.env.PDF_VISION_DPI || '120', 10),
+    /**
+     * 렌더 이미지 긴 변 픽셀 상한 — dpi 만으로는 판형이 큰 문서(대형 슬라이드·도면·포스터)에서
+     * 초대형 이미지가 나온다. 실측(2026-08-20): A0급 스캔 슬라이드가 120dpi 에서 4134×5847px
+     * (24MP)로 렌더돼 vision prefill 이 LiteLLM 소켓 읽기 타임아웃을 넘겨 요청 자체가 실패했다.
+     * 예상 픽셀이 이 값을 넘으면 dpi 대신 pdftoppm -scale-to 로 긴 변을 맞춘다.
+     */
+    MAX_EDGE_PX: parseInt(process.env.PDF_VISION_MAX_EDGE_PX || '1600', 10),
     /** 렌더(pdftoppm)·페이지 수 조회(pdfinfo) 타임아웃 ms */
     RENDER_TIMEOUT_MS: parseInt(process.env.PDF_VISION_RENDER_TIMEOUT_MS || '20000', 10),
 } as const;

--- a/apps/api/src/services/chat-service/external-fallback.ts
+++ b/apps/api/src/services/chat-service/external-fallback.ts
@@ -104,6 +104,8 @@ export async function streamFromExternalProvider(
                 from: resolved.fullId,
                 to: localFullId,
                 reason: err instanceof Error ? err.message.slice(0, 200) : String(err).slice(0, 200),
+                // 사유 코드 — 프론트가 사용자 언어 문구로 매핑한다(reason 원문은 provider 영문이 섞임).
+                ...((err as { code?: string })?.code ? { code: String((err as { code?: string }).code) } : {}),
             },
         });
         // 실제로 답하는 모델이 바뀌었다 — 배지 고지와 같은 이유로 응답의 model 도 갱신한다.

--- a/apps/api/src/services/chat-service/message-pipeline.ts
+++ b/apps/api/src/services/chat-service/message-pipeline.ts
@@ -107,7 +107,17 @@ export async function runMessagePipeline(svc: ChatService,
     });
     // 여기가 "어느 모델이 답하는가"가 확정되는 유일한 지점 — 호출자에게 알려 응답·대화기록의
     // model 이 요청 모델이 아니라 실제 응답 모델을 싣게 한다. (폴백 시 external-fallback 이 갱신)
-    req.onServedModel?.(servedModelLabel(externalResolved));
+    //
+    // 아래 관측 로그(ChatTiming)도 같은 값을 써야 한다 — externalResolved 를 그대로 쓰면
+    // 폴백(429·401 등) 이 일어나도 로그가 요청 모델로 남아 실제 응답 모델과 어긋난다.
+    // 콜백을 래핑해 갱신을 여기서도 받는다(상위 콜백은 그대로 호출).
+    let servedModel = servedModelLabel(externalResolved);
+    const upstreamOnServedModel = req.onServedModel;
+    req.onServedModel = (fullId: string): void => {
+        servedModel = fullId;
+        upstreamOnServedModel?.(fullId);
+    };
+    req.onServedModel(servedModel);
 
     // ── 보안 사전 검사 ──
     const securityPreCheck = preRequestCheck(message || '');
@@ -453,7 +463,7 @@ export async function runMessagePipeline(svc: ChatService,
         const ttfcMs = tm.firstChunkAt > 0 ? tm.firstChunkAt - tm.firstLlmCallAt : -1;
         logger.info(
             `[ChatTiming] prep=${prepMs}ms ttfc=${ttfcMs}ms tool=${tm.toolMs}ms turns=${tm.turns} `
-            + `total=${Date.now() - startTime}ms model=${externalResolved.fullId}`,
+            + `total=${Date.now() - startTime}ms model=${servedModel}`,
             {
                 event: 'chat_timing',
                 prep_ms: prepMs,
@@ -461,7 +471,7 @@ export async function runMessagePipeline(svc: ChatService,
                 tool_ms: tm.toolMs,
                 turns: tm.turns,
                 total_ms: Date.now() - startTime,
-                model: externalResolved.fullId,
+                model: servedModel,
             },
         );
     }

--- a/apps/api/src/services/chat-service/pdf-vision.ts
+++ b/apps/api/src/services/chat-service/pdf-vision.ts
@@ -36,17 +36,40 @@ function checkPdftoppm(): Promise<boolean> {
     return pdftoppmAvailable;
 }
 
-/** pdfinfo 로 총 페이지 수 조회 (실패 시 undefined — 안내문에서 총수만 생략) */
-async function getPageCount(pdfPath: string): Promise<number | undefined> {
+/** pdfinfo 결과 — 총 페이지 수와 첫 페이지 판형(pt). 실패 시 각 항목 undefined. */
+interface PdfInfo { pages?: number; longEdgePt?: number }
+
+/** pdfinfo 로 총 페이지 수 + 판형 조회 (실패 시 빈 값 — 안내문 총수 생략·기본 dpi 렌더) */
+async function getPdfInfo(pdfPath: string): Promise<PdfInfo> {
     try {
         const { stdout } = await execFileAsync('pdfinfo', [pdfPath], {
             timeout: PDF_VISION_LIMITS.RENDER_TIMEOUT_MS,
         });
-        const m = /^Pages:\s+(\d+)/m.exec(String(stdout));
-        return m ? parseInt(m[1], 10) : undefined;
+        const out = String(stdout);
+        const pm = /^Pages:\s+(\d+)/m.exec(out);
+        // "Page size:  960.009 x 540 pts" — 페이지마다 다를 수 있으나 pdfinfo 는 첫 페이지 기준.
+        const sm = /^Page size:\s+([\d.]+)\s+x\s+([\d.]+)\s+pts/m.exec(out);
+        return {
+            ...(pm ? { pages: parseInt(pm[1], 10) } : {}),
+            ...(sm ? { longEdgePt: Math.max(parseFloat(sm[1]), parseFloat(sm[2])) } : {}),
+        };
     } catch {
-        return undefined;
+        return {};
     }
+}
+
+/**
+ * 렌더 인자 선택 — 기본은 dpi 렌더지만, 판형이 커서 예상 픽셀이 상한을 넘으면
+ * -scale-to 로 긴 변을 고정한다(작은 페이지를 확대하지 않도록 조건부).
+ * 판형을 모르면 기존 동작(dpi)을 유지한다.
+ */
+function renderScaleArgs(longEdgePt: number | undefined): string[] {
+    const cap = PDF_VISION_LIMITS.MAX_EDGE_PX;
+    if (longEdgePt && cap > 0) {
+        const expectedPx = (longEdgePt / 72) * PDF_VISION_LIMITS.DPI;
+        if (expectedPx > cap) return ['-scale-to', String(cap)];
+    }
+    return ['-r', String(PDF_VISION_LIMITS.DPI)];
 }
 
 /** 렌더 산출 jpg 파일명의 페이지 번호 (p-1.jpg / p-01.jpg 숫자 정렬용) */
@@ -101,10 +124,11 @@ export async function buildPdfVisionAttachment(
             await fs.mkdir(dir, { recursive: true });
             const pdfPath = path.join(dir, 'in.pdf');
             await fs.writeFile(pdfPath, buf);
-            const total = await getPageCount(pdfPath);
+            const { pages: total, longEdgePt } = await getPdfInfo(pdfPath);
             const want = total !== undefined ? Math.min(budget, total) : budget;
+            const scaleArgs = renderScaleArgs(longEdgePt);
             await execFileAsync('pdftoppm', [
-                '-jpeg', '-r', String(PDF_VISION_LIMITS.DPI),
+                '-jpeg', ...scaleArgs,
                 '-f', '1', '-l', String(want),
                 pdfPath, path.join(dir, 'p'),
             ], { timeout: PDF_VISION_LIMITS.RENDER_TIMEOUT_MS });
@@ -120,7 +144,10 @@ export async function buildPdfVisionAttachment(
             budget -= pages.length;
             const range = pages.length === 1 ? '1페이지' : `1–${pages.length}페이지`;
             noteLines.push(`- ${f.name}: ${total !== undefined ? `총 ${total}페이지 중 ` : ''}${range} 이미지 첨부`);
-            logger.info(`[PdfVision] ${f.name}: ${pages.length}페이지 렌더 주입 (dpi ${PDF_VISION_LIMITS.DPI})`);
+            const scaleLabel = scaleArgs[0] === '-scale-to'
+                ? `긴 변 ${scaleArgs[1]}px 로 축소(판형 초과)`
+                : `dpi ${PDF_VISION_LIMITS.DPI}`;
+            logger.info(`[PdfVision] ${f.name}: ${pages.length}페이지 렌더 주입 (${scaleLabel})`);
         } catch (e) {
             logger.warn(`[PdfVision] ${f.name} 렌더 실패 — 텍스트 추출만 사용: ${e instanceof Error ? e.message : e}`);
         } finally {

--- a/apps/api/src/sockets/chat-metrics-log.ts
+++ b/apps/api/src/sockets/chat-metrics-log.ts
@@ -1,0 +1,49 @@
+/**
+ * 채팅 성공 턴의 운영 측정 로그 — ws-chat-handler 에서 분리 (600줄 파일 크기 가드).
+ *
+ * 평문 한 줄(하위호환 grep: "[ChatMetrics]" 로 추출 후 컬럼 파싱)과 구조화 meta
+ * (집계/대시보드용 — 성공/에러 통일 스키마 event=chat_llm_call)를 함께 남긴다.
+ *
+ * @module sockets/chat-metrics-log
+ */
+import type { createLogger } from '../utils/logger';
+
+export interface ChatSuccessMetrics {
+    /**
+     * 실제로 답한 모델 — 요청 모델이 아니다(외부 provider 폴백 시 갈린다).
+     * 모델 미지정 요청(자동 선택)에서 undefined 가 될 수 있어 기존 표기를 그대로 둔다.
+     */
+    model: string | undefined;
+    ttfbMs: number;
+    generationMs: number;
+    totalMs: number;
+    tokens: number;
+    /** toFixed(2) 문자열 — 평문 로그 표기를 그대로 쓴다. */
+    tokensPerSec: string;
+    routingMeta?: { fastPath?: boolean; agentBypass?: boolean; summaryCacheHit?: boolean };
+}
+
+export function logChatSuccessMetrics(
+    log: ReturnType<typeof createLogger>,
+    m: ChatSuccessMetrics,
+): void {
+    const rm = m.routingMeta;
+    log.info(
+        `[ChatMetrics] ttfb=${m.ttfbMs}ms fp=${rm?.fastPath ? 'Y' : 'N'} `
+        + `agent_bypass=${rm?.agentBypass ? 'Y' : 'N'} cache_hit=${rm?.summaryCacheHit ? 'Y' : 'N'} `
+        + `tokens=${m.tokens} tps=${m.tokensPerSec} total=${m.totalMs}ms model=${m.model}`,
+        {
+            event: 'chat_llm_call',
+            status: 'success',
+            model: m.model,
+            ttft_ms: m.ttfbMs,
+            ttlt_ms: m.generationMs,
+            total_ms: m.totalMs,
+            tokens: m.tokens,
+            tps: Number(m.tokensPerSec),
+            fast_path: !!rm?.fastPath,
+            agent_bypass: !!rm?.agentBypass,
+            summary_cache_hit: !!rm?.summaryCacheHit,
+        },
+    );
+}

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -394,15 +394,18 @@ export async function handleChatMessage(
         // 운영 측정용 단일 라인 로그: TTFB + 경로 분기 플래그 + 토큰 처리량.
         // grep 패턴: "[ChatMetrics]" 로 추출, 컬럼 파싱으로 분기별 p50/p95 분석 가능.
         const rm = result.routingMeta;
+        // model 은 **실제로 답한 모델**(result.model = servedModel)을 쓴다 — 요청 모델을 쓰면
+        // 외부 provider 폴백(429·401 등) 시 로그가 chatgpt 로 남아 실제 응답(로컬)과 어긋난다.
+        const servedModel = result.model || selectedModel;
         // 평문(하위호환 grep) + 구조화 meta(집계/대시보드용 — 성공/에러 통일 스키마 event=chat_llm_call).
         log.info(
             `[ChatMetrics] ttfb=${ttfb}ms fp=${rm?.fastPath ? 'Y' : 'N'} ` +
             `agent_bypass=${rm?.agentBypass ? 'Y' : 'N'} cache_hit=${rm?.summaryCacheHit ? 'Y' : 'N'} ` +
-            `tokens=${tokenCount} tps=${tokensPerSec} total=${result.responseTime}ms model=${selectedModel}`,
+            `tokens=${tokenCount} tps=${tokensPerSec} total=${result.responseTime}ms model=${servedModel}`,
             {
                 event: 'chat_llm_call',
                 status: 'success',
-                model: selectedModel,
+                model: servedModel,
                 ttft_ms: ttfb,
                 ttlt_ms: generationDuration,
                 total_ms: result.responseTime,

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -14,6 +14,7 @@ import { KeyExhaustionError } from '../errors/key-exhaustion.error';
 import { ProviderError } from '../providers/provider-errors';
 import { checkChatRateLimit } from '../middlewares/chat-rate-limiter';
 import { createLogger } from '../utils/logger';
+import { logChatSuccessMetrics } from './chat-metrics-log';
 import { WSMessage, ExtendedWebSocket } from './ws-types';
 import { WS_ERROR_MESSAGES, WS_PROVIDER_ERROR_MESSAGES, getLocalizedTemplate } from './ws-chat-locales';
 import { detectLanguage, type SupportedLanguageCode } from '../chat/language-policy';
@@ -391,31 +392,17 @@ export async function handleChatMessage(
             : '0.00';
         const ttfb = firstTokenTime > 0 ? firstTokenTime - generationStartTime : -1;
 
-        // 운영 측정용 단일 라인 로그: TTFB + 경로 분기 플래그 + 토큰 처리량.
-        // grep 패턴: "[ChatMetrics]" 로 추출, 컬럼 파싱으로 분기별 p50/p95 분석 가능.
-        const rm = result.routingMeta;
         // model 은 **실제로 답한 모델**(result.model = servedModel)을 쓴다 — 요청 모델을 쓰면
         // 외부 provider 폴백(429·401 등) 시 로그가 chatgpt 로 남아 실제 응답(로컬)과 어긋난다.
-        const servedModel = result.model || selectedModel;
-        // 평문(하위호환 grep) + 구조화 meta(집계/대시보드용 — 성공/에러 통일 스키마 event=chat_llm_call).
-        log.info(
-            `[ChatMetrics] ttfb=${ttfb}ms fp=${rm?.fastPath ? 'Y' : 'N'} ` +
-            `agent_bypass=${rm?.agentBypass ? 'Y' : 'N'} cache_hit=${rm?.summaryCacheHit ? 'Y' : 'N'} ` +
-            `tokens=${tokenCount} tps=${tokensPerSec} total=${result.responseTime}ms model=${servedModel}`,
-            {
-                event: 'chat_llm_call',
-                status: 'success',
-                model: servedModel,
-                ttft_ms: ttfb,
-                ttlt_ms: generationDuration,
-                total_ms: result.responseTime,
-                tokens: tokenCount,
-                tps: Number(tokensPerSec),
-                fast_path: !!rm?.fastPath,
-                agent_bypass: !!rm?.agentBypass,
-                summary_cache_hit: !!rm?.summaryCacheHit,
-            },
-        );
+        logChatSuccessMetrics(log, {
+            model: result.model || selectedModel,
+            ttfbMs: ttfb,
+            generationMs: generationDuration,
+            totalMs: result.responseTime,
+            tokens: tokenCount,
+            tokensPerSec,
+            routingMeta: result.routingMeta,
+        });
         // Artifact parser flush — 닫는 태그 없이 끝난 partial 도 emit (defensive).
         artifactStreamParser.flush();
 

--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -552,6 +552,19 @@ function FeedbackButtons({ messageId }: { messageId: string }) {
   );
 }
 
+
+/** 폴백 사유 코드 중 번역 문구가 있는 것만 표시한다 — 그 외는 생략(원문은 배지 title 에 남는다). */
+const FALLBACK_REASON_KEYS = new Set([
+  "QUOTA_EXCEEDED",
+  "SUBSCRIPTION_REQUIRED",
+  "INVALID_API_KEY",
+  "MISSING_API_KEY",
+  "UPSTREAM_ERROR",
+]);
+function fallbackReasonKey(code?: string): string | null {
+  return code && FALLBACK_REASON_KEYS.has(code) ? code : null;
+}
+
 export function MessageList() {
   const t = useTranslations("chat");
   const chatHistory = useAppStore((s) => s.chatHistory);
@@ -658,8 +671,10 @@ export function MessageList() {
             <div className="min-w-0 flex-1">
               <p className="mb-1 text-xs font-medium text-muted">OpenMake</p>
               {m.modelFallback && (
+                /* 폴백 고지 — 어느 모델이 실제로 답했는지 알리는 유일한 표시라 본문과 같은 대비로 둔다
+                   (text-muted 로는 흘려보게 된다). 사유는 코드→번역 매핑, 원문은 title 로 유지. */
                 <div
-                  className="mb-2 flex items-start gap-1.5 rounded-md border border-warn/30 bg-warn/5 px-2.5 py-1.5 text-xs text-muted"
+                  className="mb-2 flex items-start gap-1.5 rounded-md border border-warn/50 bg-warn/10 px-2.5 py-1.5 text-xs text-fg-2"
                   title={m.modelFallback.reason}
                 >
                   <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warn" aria-hidden />
@@ -668,6 +683,11 @@ export function MessageList() {
                       from: m.modelFallback.from,
                       to: m.modelFallback.to,
                     })}
+                    {fallbackReasonKey(m.modelFallback.code) && (
+                      <span className="text-muted">
+                        {" "}({t(`modelFallbackReasons.${fallbackReasonKey(m.modelFallback.code)}`)})
+                      </span>
+                    )}
                   </span>
                 </div>
               )}

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -35,7 +35,7 @@ export interface ChatMessage extends Pick<SharedChatMessage, "role" | "content" 
    * 모델 폴백 고지 — 선택한 모델이 실패해 다른 모델이 답한 경우.
    * 표시가 없으면 사용자가 "선택한 모델이 답했다"고 오인한다(실측).
    */
-  modelFallback?: { from: string; to: string; reason?: string };
+  modelFallback?: { from: string; to: string; reason?: string; code?: string };
 }
 
 /** 에이전트 작업 인라인 카드 상태. */

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -346,11 +346,12 @@ export function useChatSocket() {
         case "system_event":
           // 백엔드 메타 알림 — 현재는 모델 폴백 고지만 처리한다.
           if (data.payload?.type === "model_fallback") {
-            const md = (data.payload.metadata ?? {}) as { from?: string; to?: string; reason?: string };
+            const md = (data.payload.metadata ?? {}) as { from?: string; to?: string; reason?: string; code?: string };
             setModelFallback({
               from: String(md.from ?? ""),
               to: String(md.to ?? ""),
               ...(md.reason ? { reason: String(md.reason) } : {}),
+              ...(md.code ? { code: String(md.code) } : {}),
             });
           }
           break;

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -408,7 +408,14 @@
       "copied": "Copied",
       "download": "Download .patch"
     },
-    "modelFallbackNotice": "The selected model ({from}) did not respond, so the default model ({to}) answered instead."
+    "modelFallbackNotice": "The selected model ({from}) did not respond, so the default model ({to}) answered instead.",
+    "modelFallbackReasons": {
+      "QUOTA_EXCEEDED": "usage limit reached",
+      "SUBSCRIPTION_REQUIRED": "subscription required",
+      "INVALID_API_KEY": "authentication error",
+      "MISSING_API_KEY": "authentication error",
+      "UPSTREAM_ERROR": "upstream error"
+    }
   },
   "artifacts": {
     "exec": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -408,7 +408,14 @@
       "copied": "コピー済み",
       "download": ".patch をダウンロード"
     },
-    "modelFallbackNotice": "選択したモデル({from})が応答しなかったため、既定のモデル({to})が回答しました。"
+    "modelFallbackNotice": "選択したモデル({from})が応答しなかったため、既定のモデル({to})が回答しました。",
+    "modelFallbackReasons": {
+      "QUOTA_EXCEEDED": "利用上限に到達",
+      "SUBSCRIPTION_REQUIRED": "サブスクリプションが必要",
+      "INVALID_API_KEY": "認証エラー",
+      "MISSING_API_KEY": "認証エラー",
+      "UPSTREAM_ERROR": "アップストリームエラー"
+    }
   },
   "artifacts": {
     "exec": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -408,7 +408,14 @@
       "copied": "복사됨",
       "download": ".patch 다운로드"
     },
-    "modelFallbackNotice": "선택한 모델({from})이 응답하지 않아 기본 모델({to})로 답변했습니다."
+    "modelFallbackNotice": "선택한 모델({from})이 응답하지 않아 기본 모델({to})로 답변했습니다.",
+    "modelFallbackReasons": {
+      "QUOTA_EXCEEDED": "사용량 한도 초과",
+      "SUBSCRIPTION_REQUIRED": "구독 필요",
+      "INVALID_API_KEY": "인증 오류",
+      "MISSING_API_KEY": "인증 오류",
+      "UPSTREAM_ERROR": "업스트림 오류"
+    }
   },
   "artifacts": {
     "exec": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -408,7 +408,14 @@
       "copied": "已复制",
       "download": "下载 .patch"
     },
-    "modelFallbackNotice": "所选模型（{from}）未响应，已由默认模型（{to}）作答。"
+    "modelFallbackNotice": "所选模型（{from}）未响应，已由默认模型（{to}）作答。",
+    "modelFallbackReasons": {
+      "QUOTA_EXCEEDED": "已达使用上限",
+      "SUBSCRIPTION_REQUIRED": "需要订阅",
+      "INVALID_API_KEY": "认证错误",
+      "MISSING_API_KEY": "认证错误",
+      "UPSTREAM_ERROR": "上游错误"
+    }
   },
   "artifacts": {
     "exec": {


### PR DESCRIPTION
외부 provider 폴백은 잘 동작하는데 **어느 모델이 실제로 답했는지 표기가 정확하지 않았다.** 관측 로그는 요청 모델로 남고, 사용자 고지는 눈에 띄지 않아 흘려보기 쉬웠다.

발단: `chatgpt:gpt-5.6-luna` 를 골라도 로컬로 답하는 것 같다는 제보 → 점검 결과 ChatGPT 계정 사용량 한도(429)로 **설계대로 로컬 폴백**이 동작한 것이었다. 폴백 자체는 옳고, 표기만 문제였다.

## ① 관측 로그의 모델 (`46a3ca40`)

폴백 후에도 `ChatTiming`·`ChatMetrics` 의 `model=` 이 요청 모델로 남았다. 그대로 집계하면 외부 모델의 사용량·지연이 부풀려진다.

- `ws-chat-handler`: `selectedModel` → `result.model || selectedModel` (`result.model` = servedModel, request-handler 가 이미 실제 응답 모델로 채운다)
- `message-pipeline`: 폴백은 `external-fallback` 안에서 일어나 파이프라인이 알 수 없었다. `req.onServedModel` 을 래핑해 갱신을 여기서도 받는다(상위 콜백은 그대로 호출)

평문 로그 + 구조화 meta(`event=chat_timing`·`chat_llm_call`) 양쪽 적용.

**라이브 검증** — chatgpt 429 폴백 요청:
```
warn: 외부 provider 실패 → 로컬 폴백: chatgpt:gpt-5.6-luna → local-llm:qwen3.6-35b-a3b
      (ChatGPT 사용량 한도 초과: 429 The usage limit has been reached)
info: [ChatTiming]  ... total=3727ms model=qwen3.6-35b-a3b
info: [ChatMetrics] ... total=3730ms model=qwen3.6-35b-a3b
```

## ② 폴백 고지 가시성 (`a1078c17`)

배지가 `text-muted` 라 흘려보기 쉬웠고, 실패 사유는 툴팁에만 있었다.

- `external-fallback`: 고지 metadata 에 `code`(ProviderError code) 동봉 — 기존 `reason` 은 provider 영문이 섞여 다국어 표시에 쓸 수 없다
- 배지에 사유 부기. 번역 문구가 있는 코드만 표시하고 없으면 생략(원문은 title 유지)
- 대비 상향: `text-muted`→`text-fg-2`, `border-warn/30`→`/50`, `bg-warn/5`→`/10`
- i18n `chat.modelFallbackReasons` 5코드 × 4언어

**라이브 검증** — 데스크톱 앱에서 chatgpt 429 재현:

> ⚠ 선택한 모델(chatgpt:gpt-5.6-luna)이 응답하지 않아 기본 모델(local-llm:qwen3.6-35b-a3b)로 답변했습니다. **(사용량 한도 초과)**

원문(`429 The usage limit has been reached`)은 툴팁에 유지되고, 본문은 로컬 모델이 답한 내용이었다.

## ③ 메트릭 로그 모듈 분리 (`2900b09b`)

①의 3줄 추가로 `ws-chat-handler.ts` 가 602줄이 되어 CI 파일 크기 가드(600)에 걸렸다. 이 파일은 이전부터 599줄로 한계에 붙어 있었으므로 줄을 깎는 대신 독립적인 로깅 블록을 떼어냈다 — `sockets/chat-metrics-log.ts` 신설, 589줄로 감소. **로그 형식·필드 변경 없음.**

## ④ PDF vision 렌더 해상도 상한 (`a2ca23c7`)

점검 중 발견한 별개 결함. 판형이 큰 PDF(대형 슬라이드·도면·포스터)를 첨부하면 **채팅 요청 자체가 실패**했다 — dpi 만으로 렌더해 픽셀 상한이 없었던 탓이다.

실측: A0급 스캔 슬라이드가 120dpi 에서 **4134×5847px(24MP, 760KB/장)** 로 렌더 → vision prefill 이 길어져 LiteLLM 이 `Timeout on reading data from socket` 으로 스트림을 끊고, 앱에는 `upstream_error` 가 떴다. **1페이지만 첨부해도 재현**된다(장수 문제가 아니다).

- `PDF_VISION_LIMITS.MAX_EDGE_PX`(기본 1600, env `PDF_VISION_MAX_EDGE_PX`) 추가
- `pdfinfo` 의 `Page size` 로 예상 픽셀을 계산해 **상한 초과 시에만** `pdftoppm -scale-to` 적용 — 작은 페이지를 확대하지 않도록 조건부이고, 판형을 못 읽으면 기존 dpi 경로 유지(fail-open)
- `getPageCount` → `getPdfInfo`(페이지 수 + 판형), 렌더 로그에 축소 여부 표기

검증: 대형 슬라이드 4134×5847 → **1132×1600**(760KB→116KB), letter 판형은 예상 1320px 로 상한 미만이라 기존 경로 유지(회귀 없음).

## 검증

- `tsc --noEmit` — apps/api · apps/web 통과
- `external-local-fallback.test.ts` 10/10 통과
- eslint 0 error
- 라이브(chat.openmake.cc + 데스크톱 앱) — 위 ①②

🤖 Generated with [Claude Code](https://claude.com/claude-code)

