### PR TITLE
feat(admin): 에이전트 작업 워크플로우 관측 지표 4종

### DIFF
--- a/apps/api/src/data/repositories/__tests__/agent-task-metrics-repository.test.ts
+++ b/apps/api/src/data/repositories/__tests__/agent-task-metrics-repository.test.ts
@@ -71,4 +71,60 @@ describe('AgentTaskMetricsRepository', () => {
         const sql = (pool.query as jest.Mock).mock.calls[0][0];
         expect(sql).toMatch(/tool_name IS NOT NULL/);
     });
+    it('getCompletionVerdictDistribution: completed 한정 + NULL 판정 행 보존', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({
+            rows: [
+                { completion_path: 'final_answer', judge_verdict: 'achieved', tasks: '31' },
+                { completion_path: 'terminate', judge_verdict: null, tasks: '22' },
+                { completion_path: null, judge_verdict: null, tasks: '14' },
+            ],
+        });
+        const rows = await repo.getCompletionVerdictDistribution(30);
+        // 무판정(NULL) 행을 버리면 지표의 목적 자체가 사라지므로 그대로 올라와야 한다
+        expect(rows).toHaveLength(3);
+        expect(rows[2]).toEqual({ completion_path: null, judge_verdict: null, tasks: '14' });
+        const [sql, params] = (pool.query as jest.Mock).mock.calls[0];
+        expect(sql).toMatch(/status = 'completed'/);
+        expect(sql).toMatch(/GROUP BY completion_path, judge_verdict/);
+        expect(params).toEqual(['30']);
+    });
+
+    it('getFailureReasons: failed 한정 + error NULL 은 (unknown) 으로 집계', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({
+            rows: [{ reason: 'goal_incomplete', tasks: '9' }],
+        });
+        const rows = await repo.getFailureReasons(30, 10);
+        expect(rows[0].reason).toBe('goal_incomplete');
+        const [sql, params] = (pool.query as jest.Mock).mock.calls[0];
+        expect(sql).toMatch(/status = 'failed'/);
+        expect(sql).toMatch(/COALESCE\(error, '\(unknown\)'\)/);
+        expect(params).toEqual(['30', 10]);
+    });
+
+    it('getInterventionCounts: retry·hitl_degrade 스텝 보유 작업 수 + 빈 결과 0 기본값', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({
+            rows: [{ total_tasks: '120', retry_tasks: '18', hitl_degrade_tasks: '7' }],
+        });
+        const row = await repo.getInterventionCounts(30);
+        expect(row.retry_tasks).toBe('18');
+        const sql = (pool.query as jest.Mock).mock.calls[0][0];
+        expect(sql).toMatch(/step_type = 'retry'/);
+        expect(sql).toMatch(/step_type = 'hitl_degrade'/);
+
+        (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+        const empty = await repo.getInterventionCounts(7);
+        expect(empty).toEqual({ total_tasks: '0', retry_tasks: '0', hitl_degrade_tasks: '0' });
+    });
+
+    it('getPlanAttributionCoverage: plan 있는 작업으로 분모 한정', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({
+            rows: [{ planned_tasks: '40', total_steps: '860', attributed_steps: '731' }],
+        });
+        const row = await repo.getPlanAttributionCoverage(30);
+        expect(row.attributed_steps).toBe('731');
+        const sql = (pool.query as jest.Mock).mock.calls[0][0];
+        // plan 없는 작업까지 세면 커버리지가 구조적으로 낮게 나온다
+        expect(sql).toMatch(/t\.plan IS NOT NULL/);
+        expect(sql).toMatch(/COUNT\(s\.plan_step_index\) AS attributed_steps/);
+    });
 });

--- a/apps/api/src/data/repositories/agent-task-metrics-repository.ts
+++ b/apps/api/src/data/repositories/agent-task-metrics-repository.ts
@@ -39,6 +39,33 @@ export interface ToolErrorByToolRow {
     count: string;
 }
 
+/** 완료 판정 분포 — 완료 출구(completion_path) × goal judge 결과(judge_verdict) */
+export interface CompletionVerdictRow {
+    completion_path: string | null;
+    judge_verdict: string | null;
+    tasks: string;
+}
+
+/** 실패 사유 분포 — error 첫 줄 정규화 기준 */
+export interface FailureReasonRow {
+    reason: string;
+    tasks: string;
+}
+
+/** 구제 장치(retry·hitl_degrade) 발생 작업 수 */
+export interface InterventionRow {
+    total_tasks: string;
+    retry_tasks: string;
+    hitl_degrade_tasks: string;
+}
+
+/** plan 귀속 커버리지 — plan 이 있는 작업의 스텝 중 plan_step_index 가 채워진 비율 */
+export interface PlanCoverageRow {
+    planned_tasks: string;
+    total_steps: string;
+    attributed_steps: string;
+}
+
 export class AgentTaskMetricsRepository extends BaseRepository {
     /**
      * 기간별 도구 오류 요약 — 총 도구 실행 수, 오류 수, 오류 발생 고유 작업 수.
@@ -110,5 +137,83 @@ export class AgentTaskMetricsRepository extends BaseRepository {
             [String(days), limit]
         );
         return result.rows;
+    }
+    /**
+     * 완료 판정 분포 — completed 작업이 어느 출구로 나갔고 goal judge 가 무엇을 판정했는지.
+     * 091 이전 행은 두 컬럼 모두 NULL 이라 '미기록' 으로 뭉쳐 구분한다
+     * (무판정 완료 비율을 관측하는 것이 이 지표의 목적이므로 NULL 을 버리면 안 된다).
+     */
+    async getCompletionVerdictDistribution(days: number): Promise<CompletionVerdictRow[]> {
+        const result = await this.query<CompletionVerdictRow>(
+            `SELECT completion_path,
+                    judge_verdict,
+                    COUNT(*) AS tasks
+             FROM agent_tasks
+             WHERE status = 'completed'
+               AND created_at >= NOW() - ($1 || ' days')::interval
+             GROUP BY completion_path, judge_verdict
+             ORDER BY tasks DESC`,
+            [String(days)]
+        );
+        return result.rows;
+    }
+
+    /**
+     * 실패 사유 분포 — failed 작업의 error 첫 줄 앞 80자 기준 GROUP BY.
+     * goal_incomplete(목표 미달성 판정) 가 얼마나 차지하는지 보는 것이 주 용도.
+     */
+    async getFailureReasons(days: number, limit: number): Promise<FailureReasonRow[]> {
+        const result = await this.query<FailureReasonRow>(
+            `SELECT left(regexp_replace(COALESCE(error, '(unknown)'), E'\\n.*', '', 'g'), 80) AS reason,
+                    COUNT(*) AS tasks
+             FROM agent_tasks
+             WHERE status = 'failed'
+               AND created_at >= NOW() - ($1 || ' days')::interval
+             GROUP BY 1
+             ORDER BY tasks DESC, reason
+             LIMIT $2`,
+            [String(days), limit]
+        );
+        return result.rows;
+    }
+
+    /**
+     * 구제 장치 발생률 — 기간 내 작업 중 turn retry / HITL 무응답 강등이 걸린 작업 수.
+     * 증분 1(#432) 로 넣은 두 장치가 실제로 발동하는지, HITL 방치가 얼마나 되는지의 신호.
+     */
+    async getInterventionCounts(days: number): Promise<InterventionRow> {
+        const result = await this.query<InterventionRow>(
+            `SELECT COUNT(*) AS total_tasks,
+                    COUNT(*) FILTER (WHERE s.retry > 0) AS retry_tasks,
+                    COUNT(*) FILTER (WHERE s.degrade > 0) AS hitl_degrade_tasks
+             FROM agent_tasks t
+             LEFT JOIN LATERAL (
+                 SELECT COUNT(*) FILTER (WHERE step_type = 'retry') AS retry,
+                        COUNT(*) FILTER (WHERE step_type = 'hitl_degrade') AS degrade
+                 FROM agent_task_steps
+                 WHERE task_id = t.id
+             ) s ON TRUE
+             WHERE t.created_at >= NOW() - ($1 || ' days')::interval`,
+            [String(days)]
+        );
+        return result.rows[0] ?? { total_tasks: '0', retry_tasks: '0', hitl_degrade_tasks: '0' };
+    }
+
+    /**
+     * plan 귀속 커버리지 — plan 이 있는 작업으로 한정한 뒤 스텝 중 plan_step_index 가 채워진 비율.
+     * plan 없는 작업까지 분모에 넣으면 커버리지가 구조적으로 낮게 나와 증분 3 의 효과를 못 본다.
+     */
+    async getPlanAttributionCoverage(days: number): Promise<PlanCoverageRow> {
+        const result = await this.query<PlanCoverageRow>(
+            `SELECT COUNT(DISTINCT t.id) AS planned_tasks,
+                    COUNT(s.id) AS total_steps,
+                    COUNT(s.plan_step_index) AS attributed_steps
+             FROM agent_tasks t
+             JOIN agent_task_steps s ON s.task_id = t.id
+             WHERE t.plan IS NOT NULL
+               AND t.created_at >= NOW() - ($1 || ' days')::interval`,
+            [String(days)]
+        );
+        return result.rows[0] ?? { planned_tasks: '0', total_steps: '0', attributed_steps: '0' };
     }
 }

--- a/apps/api/src/routes/metrics.routes.ts
+++ b/apps/api/src/routes/metrics.routes.ts
@@ -260,6 +260,67 @@ router.get('/agent-tasks/tool-errors', asyncHandler(async (req: Request, res: Re
 }));
 
 /**
+ * GET /api/metrics/agent-tasks/workflow?days=N
+ * 에이전트 작업 워크플로우 관측 (관리자). 기본 30일.
+ * ① 완료 판정 분포(completion_path × judge_verdict) ② 실패 사유 분포
+ * ③ 구제 장치(retry·hitl_degrade) 발생률 ④ plan 귀속 커버리지.
+ */
+router.get('/agent-tasks/workflow', asyncHandler(async (req: Request, res: Response) => {
+    const days = parseDays(req.query.days, 30);
+    const repo = new AgentTaskMetricsRepository(getPool());
+    const [verdictRows, failureRows, interventionRow, coverageRow] = await Promise.all([
+        repo.getCompletionVerdictDistribution(days),
+        repo.getFailureReasons(days, 10),
+        repo.getInterventionCounts(days),
+        repo.getPlanAttributionCoverage(days),
+    ]);
+
+    const completedTasks = verdictRows.reduce((sum, r) => sum + Number(r.tasks), 0);
+    // 무판정 = judge 가 achieved/not_achieved 를 내지 않은 완료 (미기록·skipped·unknown 포함).
+    const unjudgedTasks = verdictRows
+        .filter((r) => r.judge_verdict !== 'achieved' && r.judge_verdict !== 'not_achieved')
+        .reduce((sum, r) => sum + Number(r.tasks), 0);
+
+    const totalTasks = Number(interventionRow.total_tasks);
+    const retryTasks = Number(interventionRow.retry_tasks);
+    const hitlDegradeTasks = Number(interventionRow.hitl_degrade_tasks);
+
+    const totalSteps = Number(coverageRow.total_steps);
+    const attributedSteps = Number(coverageRow.attributed_steps);
+
+    res.json(success({
+        days,
+        completion: {
+            completedTasks,
+            unjudgedTasks,
+            unjudgedRate: completedTasks > 0 ? unjudgedTasks / completedTasks : 0,
+            byVerdict: verdictRows.map((r) => ({
+                completionPath: r.completion_path,
+                judgeVerdict: r.judge_verdict,
+                tasks: Number(r.tasks),
+            })),
+        },
+        failures: failureRows.map((r) => ({
+            reason: r.reason,
+            tasks: Number(r.tasks),
+        })),
+        intervention: {
+            totalTasks,
+            retryTasks,
+            retryRate: totalTasks > 0 ? retryTasks / totalTasks : 0,
+            hitlDegradeTasks,
+            hitlDegradeRate: totalTasks > 0 ? hitlDegradeTasks / totalTasks : 0,
+        },
+        planCoverage: {
+            plannedTasks: Number(coverageRow.planned_tasks),
+            totalSteps,
+            attributedSteps,
+            coverage: totalSteps > 0 ? attributedSteps / totalSteps : 0,
+        },
+    }));
+}));
+
+/**
  * GET /api/analytics
  * 종합 분석 대시보드
  */

--- a/apps/web/app/(workspace)/admin/metrics/page.tsx
+++ b/apps/web/app/(workspace)/admin/metrics/page.tsx
@@ -97,6 +97,35 @@ interface ToolErrorData {
   byToolName: { toolName: string; count: number }[];
 }
 
+/* ── 작업 워크플로우 관측 타입 ─────────────────────────────── */
+interface WorkflowData {
+  days: number;
+  completion: {
+    completedTasks: number;
+    unjudgedTasks: number;
+    unjudgedRate: number;
+    byVerdict: {
+      completionPath: string | null;
+      judgeVerdict: string | null;
+      tasks: number;
+    }[];
+  };
+  failures: { reason: string; tasks: number }[];
+  intervention: {
+    totalTasks: number;
+    retryTasks: number;
+    retryRate: number;
+    hitlDegradeTasks: number;
+    hitlDegradeRate: number;
+  };
+  planCoverage: {
+    plannedTasks: number;
+    totalSteps: number;
+    attributedSteps: number;
+    coverage: number;
+  };
+}
+
 export default function AdminMetricsPage() {
   const t = useTranslations("adminMetrics");
   const locale = toBcp47(useLocale());
@@ -107,6 +136,7 @@ export default function AdminMetricsPage() {
   const [agentSummary, setAgentSummary] = useState<AgentSummary | null>(null);
   const [agentMetrics, setAgentMetrics] = useState<AgentMetric[] | null>(null);
   const [toolErrors, setToolErrors] = useState<ToolErrorData | null>(null);
+  const [workflow, setWorkflow] = useState<WorkflowData | null>(null);
   const maxV = Math.max(...TIMESERIES.map((t) => t.value));
 
   const load = useCallback(async () => {
@@ -188,6 +218,13 @@ export default function AdminMetricsPage() {
       ).catch(() => null);
       if (toolErrRes?.data) {
         setToolErrors(toolErrRes.data);
+      }
+      // 작업 워크플로우 관측 로드 (기본 30일)
+      const workflowRes = await ApiClient.get<{ data: WorkflowData }>(
+        "/api/metrics/agent-tasks/workflow",
+      ).catch(() => null);
+      if (workflowRes?.data) {
+        setWorkflow(workflowRes.data);
       }
     } catch {
       /* 401/실패 시 목업 유지 */
@@ -347,6 +384,98 @@ export default function AdminMetricsPage() {
                     })}
                   </tbody>
                 </Table>
+              )}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* 작업 워크플로우 관측 — 완료 판정·실패 사유·구제 장치·플랜 귀속 */}
+        {workflow && (
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle>
+                {t("workflow.title", { days: workflow.days })}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+                <StatCard
+                  label={t("workflow.unjudgedRate")}
+                  value={`${(workflow.completion.unjudgedRate * 100).toFixed(1)}%`}
+                  delta={t("workflow.ofCompleted", {
+                    unjudged: workflow.completion.unjudgedTasks.toLocaleString(),
+                    completed: workflow.completion.completedTasks.toLocaleString(),
+                  })}
+                />
+                <StatCard
+                  label={t("workflow.retryRate")}
+                  value={`${(workflow.intervention.retryRate * 100).toFixed(1)}%`}
+                  delta={t("workflow.ofTasks", {
+                    count: workflow.intervention.retryTasks.toLocaleString(),
+                    total: workflow.intervention.totalTasks.toLocaleString(),
+                  })}
+                />
+                <StatCard
+                  label={t("workflow.hitlDegradeRate")}
+                  value={`${(workflow.intervention.hitlDegradeRate * 100).toFixed(1)}%`}
+                  delta={t("workflow.ofTasks", {
+                    count: workflow.intervention.hitlDegradeTasks.toLocaleString(),
+                    total: workflow.intervention.totalTasks.toLocaleString(),
+                  })}
+                />
+                <StatCard
+                  label={t("workflow.planCoverage")}
+                  value={`${(workflow.planCoverage.coverage * 100).toFixed(1)}%`}
+                  delta={t("workflow.ofSteps", {
+                    attributed: workflow.planCoverage.attributedSteps.toLocaleString(),
+                    total: workflow.planCoverage.totalSteps.toLocaleString(),
+                  })}
+                />
+              </div>
+              {workflow.completion.byVerdict.length > 0 && (
+                <Table>
+                  <thead>
+                    <tr>
+                      <Th>{t("workflow.th.path")}</Th>
+                      <Th>{t("workflow.th.verdict")}</Th>
+                      <Th className="text-right">{t("workflow.th.tasks")}</Th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {workflow.completion.byVerdict.map((v, i) => (
+                      <tr key={i}>
+                        <Td className="font-mono text-xs text-fg-2">
+                          {v.completionPath ?? t("workflow.unrecorded")}
+                        </Td>
+                        <Td>
+                          <Badge
+                            tone={
+                              v.judgeVerdict === "achieved"
+                                ? "success"
+                                : v.judgeVerdict === "not_achieved"
+                                  ? "danger"
+                                  : "warn"
+                            }
+                          >
+                            {v.judgeVerdict ?? t("workflow.unrecorded")}
+                          </Badge>
+                        </Td>
+                        <Td className="text-right font-mono text-fg-2">
+                          {v.tasks.toLocaleString()}
+                        </Td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              )}
+              {workflow.failures.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {workflow.failures.map((f, i) => (
+                    <Badge key={i} tone="danger">
+                      {f.reason} · {f.tasks.toLocaleString()}
+                    </Badge>
+                  ))}
+                </div>
               )}
             </CardContent>
           </Card>

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1374,6 +1374,22 @@
         "signature": "Error Signature",
         "count": "Count"
       }
+    },
+    "workflow": {
+      "title": "Task Workflow (last {days} days)",
+      "unjudgedRate": "Unjudged Completions",
+      "ofCompleted": "{unjudged} of {completed} completed",
+      "retryRate": "Turn Retries",
+      "hitlDegradeRate": "HITL Timeout Degrades",
+      "ofTasks": "{count} of {total} tasks",
+      "planCoverage": "Plan Attribution Coverage",
+      "ofSteps": "{attributed} of {total} steps",
+      "unrecorded": "unrecorded",
+      "th": {
+        "path": "Completion Path",
+        "verdict": "Verdict",
+        "tasks": "Tasks"
+      }
     }
   },
   "adminAlerts": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1374,6 +1374,22 @@
         "signature": "エラーシグネチャ",
         "count": "件数"
       }
+    },
+    "workflow": {
+      "title": "タスクワークフロー (直近{days}日)",
+      "unjudgedRate": "完了時の未判定率",
+      "ofCompleted": "完了{completed}件中{unjudged}件",
+      "retryRate": "ターン再試行の発生",
+      "hitlDegradeRate": "HITL無応答による降格",
+      "ofTasks": "タスク{total}件中{count}件",
+      "planCoverage": "プラン紐付けカバレッジ",
+      "ofSteps": "ステップ{total}個中{attributed}個",
+      "unrecorded": "未記録",
+      "th": {
+        "path": "完了経路",
+        "verdict": "判定",
+        "tasks": "タスク数"
+      }
     }
   },
   "adminAlerts": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1374,6 +1374,22 @@
         "signature": "오류 시그니처",
         "count": "건수"
       }
+    },
+    "workflow": {
+      "title": "작업 워크플로우 (최근 {days}일)",
+      "unjudgedRate": "완료 무판정 비율",
+      "ofCompleted": "완료 {completed}건 중 {unjudged}건",
+      "retryRate": "턴 재시도 발생",
+      "hitlDegradeRate": "HITL 무응답 강등",
+      "ofTasks": "작업 {total}건 중 {count}건",
+      "planCoverage": "플랜 귀속 커버리지",
+      "ofSteps": "스텝 {total}개 중 {attributed}개",
+      "unrecorded": "미기록",
+      "th": {
+        "path": "완료 출구",
+        "verdict": "판정",
+        "tasks": "작업 수"
+      }
     }
   },
   "adminAlerts": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1374,6 +1374,22 @@
         "signature": "错误签名",
         "count": "次数"
       }
+    },
+    "workflow": {
+      "title": "任务工作流（最近 {days} 天）",
+      "unjudgedRate": "完成未判定比例",
+      "ofCompleted": "共 {completed} 个完成中 {unjudged} 个",
+      "retryRate": "轮次重试发生",
+      "hitlDegradeRate": "HITL 无响应降级",
+      "ofTasks": "共 {total} 个任务中 {count} 个",
+      "planCoverage": "计划归属覆盖率",
+      "ofSteps": "共 {total} 个步骤中 {attributed} 个",
+      "unrecorded": "未记录",
+      "th": {
+        "path": "完成出口",
+        "verdict": "判定",
+        "tasks": "任务数"
+      }
     }
   },
   "adminAlerts": {


### PR DESCRIPTION
## 배경

개별 작업 모니터링은 `/agent-tasks` 에 이미 있으나(진행률·step 타임라인·HITL 승인·재시도), **작업 전체를 가로지르는 집계 뷰가 없었다.** 데이터는 DB 에 쌓이고 있는데 보는 화면이 없어 SQL 을 직접 쳐야 했다.

Execution Graph 로드맵의 다음 판단(노드별 완료기준 vs HITL 독립분기)이 `retry`/`hitl_degrade`/`plan_step_index` 전향 데이터를 게이트로 두고 있어, 이 지표들은 "있으면 좋은 대시보드"가 아니라 다음 결정에 필요한 계측기다.

## 지표 4종

전부 기존 컬럼 기반 — **신규 마이그레이션 없음.**

| 지표 | 근거 컬럼 | 무엇을 보는가 |
|---|---|---|
| 완료 판정 분포 | `completion_path` × `judge_verdict` (091) | 무판정으로 나가는 완료 비율 |
| 실패 사유 분포 | `agent_tasks.error` (failed 한정) | `goal_incomplete` 비중 |
| 구제 장치 발생률 | `step_type IN ('retry','hitl_degrade')` | 증분 1(#432) 효과 · HITL 방치 신호 |
| 플랜 귀속 커버리지 | `plan_step_index` (088) | 증분 3(#440)이 45%에서 얼마나 올렸는지 |

## 설계 판단

- **무판정 완료를 버리지 않는다** — `judge_verdict`/`completion_path` 가 NULL 인 행(091 이전)을 `미기록` 으로 살려 집계한다. "completed 의 58.7% 가 무판정"을 재는 것이 목적이라 NULL 을 제외하면 지표 자체가 무의미해진다. 유닛 테스트로 고정.
- **plan 커버리지 분모를 `plan IS NOT NULL` 작업으로 한정** — plan 없는 작업까지 세면 커버리지가 구조적으로 낮게 나와 증분 3 효과가 가려진다. 이것도 테스트로 고정.
- **HITL 승인 대기 시간은 제외** — 승인 이력 테이블이 없고 `pausedMs` 도 영속되지 않아 DB 에서 산출할 근거가 없다. 추정치를 만들지 않고 `hitl_degrade` 발생률을 관측 가능한 대체 신호로 둔다.

## 변경

- `AgentTaskMetricsRepository` 집계 쿼리 4개 (읽기 전용·파라미터화, 기존 도구오류 쿼리와 동일 패턴)
- `GET /api/metrics/agent-tasks/workflow?days=N` (관리자 전용, 기본 30일)
- `/admin/metrics` 카드 1개 — 신규 라우트·사이드바 항목 추가 없음 (기존 페이지 확장)
- i18n ko·en·ja·zh 각 16키 (순수 추가, 재포맷 0)

## 검증

- `tsc --noEmit` — apps/api ✅ / apps/web ✅
- `eslint` — 0 errors
- `jest agent-task-metrics-repository` — **9 passed** (기존 5 + 신규 4)
- 총 +415줄 / 삭제 0

## 체크리스트

- [x] lint 통과
- [x] 유닛 테스트 통과
- [x] DB 스키마 변경 없음 (마이그레이션 불필요)
- [x] 환경변수 추가 없음
- [ ] UI 스크린샷 — 머지 후 운영 데이터로 첨부 예정 (로컬은 표본 부족)