### PR TITLE
chore(mcp): notebooklm-mcp-cli 0.8.9 → 0.9.13

### DIFF
--- a/infra/mcp-runtime/Dockerfile
+++ b/infra/mcp-runtime/Dockerfile
@@ -65,7 +65,7 @@ ENV PATH=/home/node/.local/bin:${PATH}
 # 불필요 — 인증은 NOTEBOOKLM_COOKIES env(-e 주입)만으로 초기화된다.
 # 카탈로그(db/migrations/075_mcp_notebooklm_catalog.sql)는 `notebooklm-mcp` 로 실행.
 # 런타임 uvx-fetch 없이 즉시 spawn 하도록 사전설치(버전 고정).
-RUN uv tool install notebooklm-mcp-cli==0.8.9
+RUN uv tool install notebooklm-mcp-cli==0.9.13
 
 # ── Kakao(Map/Search) MCP 서버 — 이미지에 baked ─────────────────────────────
 # 벤더링된 수정 소스(vendor/kakao-api-mcp-server: deps 정정 + bin/shebang, ATTRIBUTION.md


### PR DESCRIPTION
## 요약

mcp-runtime 이미지에 baked 된 NotebookLM MCP 서버를 최신(0.9.13)으로 올린다. 호스트 CLI(uv tool)와 에이전트 클라이언트가 이미 0.9.x 를 쓰고 있어 앱 경로만 0.8.9 로 뒤처져 있던 상태를 정렬한 것.

전체 MCP 최신화 점검의 일부다. 나머지 활성 서버(mcp-filesystem 2026.7.10 · Playwright 0.0.79 · noapi 0.3.2 · Python REPL 0.1.1 · mcp-kakao 벤더링)는 이미 최신이라 변경 없음.

## 변경

- `infra/mcp-runtime/Dockerfile`: `uv tool install notebooklm-mcp-cli==0.8.9` → `==0.9.13` (1줄)

## 검증

- 이미지 재빌드 후 `notebooklm_mcp_cli-0.9.13.dist-info` 확인, kakao·python-repl 동반 정상
- stdio `initialize` + `tools/list` 정상 — 도구 **39 → 43개**
- `NOTEBOOKLM_COOKIES` env 계약은 0.9.13 에도 유지됨(`core/base.py`) — 주입 인터페이스 변경 없음
- 파생 이미지 `openmake-task-runtime` 재빌드로 베이스 갱신 반영, 실기동 검증(python venv 전 패키지 import · tesseract 161 언어팩 · chromium `network=none` launch + 한글 렌더 · opendataloader-pdf)
- 앱 경로 실호출: `POST /api/mcp/tools/mcp_call/execute` → `notebook_list` 실데이터 반환 (로컬 · chat.openmake.cc 양쪽)

## 운영 메모 (코드 변경 아님)

앱 DB 의 `NOTEBOOKLM_COOKIES` 가 만료 상태였고, **쿠키 재발급으로는 해결되지 않는다**. 쿠키만 주면 CSRF/session 자동 추출 요청이 `accounts.google.com` 으로 리다이렉트돼 거부되며, 이는 0.8.9 · 0.9.13 양쪽 동일(버전 회귀 아님)이다.

복구는 코드 변경 없이 운영 설정으로 처리했다 — `mcp_servers.env` 를 `HOME=/home/node/.cache/nlmhome` 하나로 바꾸고, 서버 캐시 볼륨에 호스트 프로필(`auth.json` + `profiles/`, 36KB)을 배치. `sandbox-docker.ts` 가 `-e HOME=/home/node` 뒤에 서버 env 를 붙이므로 후행 값이 이기는 구조를 이용한 것이며, 캐시 볼륨이 `/home/node/.cache` 에 마운트돼 프로필이 컨테이너 재생성에도 영속한다.

## 배포 시 필요한 조치

- 호스트에서 `docker build -t openmake-mcp-runtime:latest infra/mcp-runtime` 후 파생 `openmake-task-runtime` 도 재빌드
- 앱 재시작은 불필요(`decryptEnvForSpawn` 이 spawn 시점 DB 조회)하나, 연결 상태 캐시 때문에 `POST /api/mcp/servers/:id/disconnect` → `connect` 로 강제 재연결 필요 (toolCount 39→43 이 적용 신호)

🤖 Generated with [Claude Code](https://claude.com/claude-code)