### PR TITLE
fix(chat): OpenAI 호환 클라이언트 system 메시지를 드롭 대신 맨 앞 system 에 병합

### DIFF
--- a/apps/api/src/chat/__tests__/external-tool-calling.test.ts
+++ b/apps/api/src/chat/__tests__/external-tool-calling.test.ts
@@ -1,0 +1,70 @@
+/**
+ * 외부 Tool Calling 경로 — 클라이언트 system 메시지 병합 회귀 테스트.
+ *
+ * history 에 role='system' 이 섞여 오면 자체 system(index 0) 뒤에 두 번째 system 이
+ * 중간 위치로 들어가 vLLM/qwen 템플릿이 400 "System message must be at the beginning"
+ * 으로 거부했다. 병합(드롭 아님)으로 고친 동작을 고정한다.
+ */
+
+import { processExternalToolCalling } from '../external-tool-calling';
+import type { ChatMessage, LLMClient, ToolDefinition } from '../../llm';
+
+const TOOLS: ToolDefinition[] = [
+    {
+        type: 'function',
+        function: {
+            name: 'noop',
+            description: 'test tool',
+            parameters: { type: 'object', properties: {} },
+        },
+    },
+];
+
+function createClient(capture: { messages?: ChatMessage[] }): LLMClient {
+    return {
+        chat: jest.fn(async (messages: ChatMessage[]) => {
+            capture.messages = messages;
+            return { content: 'ok' };
+        }),
+    } as unknown as LLMClient;
+}
+
+describe('processExternalToolCalling — system 메시지 위치', () => {
+    it('history 의 system 을 맨 앞 system 에 병합하고 배열에는 남기지 않는다', async () => {
+        const capture: { messages?: ChatMessage[] } = {};
+
+        await processExternalToolCalling({
+            message: 'hello',
+            history: [
+                { role: 'system', content: 'CLIENT_SYSTEM_INSTRUCTION' },
+                { role: 'user', content: 'prev question' },
+                { role: 'assistant', content: 'prev answer' },
+            ],
+            tools: TOOLS,
+            client: createClient(capture),
+            onToken: () => { /* noop */ },
+        });
+
+        const messages = capture.messages!;
+        const systemMessages = messages.filter((m) => m.role === 'system');
+
+        expect(systemMessages).toHaveLength(1);
+        expect(messages[0].role).toBe('system');
+        expect(messages[0].content).toContain('CLIENT_SYSTEM_INSTRUCTION');
+        expect(messages.map((m) => m.role)).toEqual(['system', 'user', 'assistant', 'user']);
+    });
+
+    it('history 에 system 이 없으면 배열 구성이 그대로다', async () => {
+        const capture: { messages?: ChatMessage[] } = {};
+
+        await processExternalToolCalling({
+            message: 'hello',
+            history: [{ role: 'user', content: 'prev question' }],
+            tools: TOOLS,
+            client: createClient(capture),
+            onToken: () => { /* noop */ },
+        });
+
+        expect(capture.messages!.map((m) => m.role)).toEqual(['system', 'user', 'user']);
+    });
+});

--- a/apps/api/src/chat/external-tool-calling.ts
+++ b/apps/api/src/chat/external-tool-calling.ts
@@ -75,8 +75,21 @@ export async function processExternalToolCalling(params: {
         { role: 'system', content: promptConfig.systemPrompt },
     ];
 
+    // history 에 섞인 system 메시지는 배열에 두지 않고 맨 앞 system 에 병합한다.
+    // 자체 system 이 index 0 을 차지하므로 history 의 system 을 그대로 두면 두 번째 system 이
+    // 중간 위치에 들어가 vLLM/qwen 템플릿이 "System message must be at the beginning"
+    // (400 BadRequest) 으로 거부한다. 드롭이 아니라 병합인 이유 — OpenAI 호환 API 에서
+    // system 은 클라이언트의 지시 계약이라 조용히 버리면 외부 에이전트가 지시 없이 동작한다.
+    // (tools 없는 일반 채팅 경로의 대응: services/chat-service/external-provider.ts)
+    const clientSystemParts: string[] = [];
+
     if (history && history.length > 0) {
         for (const h of history) {
+            if (h.role === 'system') {
+                if (h.content) clientSystemParts.push(h.content);
+                continue;
+            }
+
             const msg: ChatMessage = {
                 role: h.role as ChatMessage['role'],
                 content: h.content || '',
@@ -98,6 +111,10 @@ export async function processExternalToolCalling(params: {
 
             messages.push(msg);
         }
+    }
+
+    if (clientSystemParts.length > 0) {
+        messages[0].content = [promptConfig.systemPrompt, ...clientSystemParts].join('\n\n');
     }
 
     // 현재 사용자 메시지 추가

--- a/apps/api/src/services/chat-service/__tests__/external-provider-client-system.test.ts
+++ b/apps/api/src/services/chat-service/__tests__/external-provider-client-system.test.ts
@@ -1,0 +1,70 @@
+/**
+ * 일반 채팅 경로(도구 없는 요청) — 클라이언트 system 메시지 병합 회귀 테스트.
+ *
+ * OpenAI 호환 API 의 `convertMessages` 는 클라이언트가 보낸 role='system' 을 그대로
+ * history 에 싣는다. 이전엔 external-provider 가 이를 드롭해, tools 없는 요청에서만
+ * 클라이언트 지시가 조용히 사라졌다(도구 경로는 병합). 병합 동작을 고정한다.
+ */
+import { streamFromExternalProvider } from '../external-fallback';
+import type { ResolvedProvider } from '../../../providers/provider-router';
+import type { ChatMessage } from '../../../llm';
+
+type StreamImpl = (
+    opts: unknown,
+    cb: { onToken?: (t: string) => void; onUsage?: (u: unknown) => void },
+) => Promise<unknown>;
+
+function makeResolved(streamChat: StreamImpl): ResolvedProvider {
+    return {
+        providerId: 'local-llm',
+        modelId: 'qwen3.6-35b-a3b',
+        fullId: 'local-llm:qwen3.6-35b-a3b',
+        provider: {
+            id: 'local-llm',
+            sdkType: 'local-llm',
+            displayName: 'local-llm',
+            getCapabilities: () => ({ streaming: true, toolCalling: false, vision: true, thinking: false }),
+            listModels: async () => [],
+            validateCredentials: async () => ({ ok: true }),
+            streamChat,
+        },
+    } as unknown as ResolvedProvider;
+}
+
+const deps = {
+    currentUserContext: null,
+    allowedTools: [],
+    providerRouter: { resolve: jest.fn(), getExternalKeysRepo: () => undefined },
+} as never;
+
+/** streamChat 에 실제로 넘어간 messages 를 잡아둔다. */
+function captureRun(history: Array<{ role: string; content: string }>) {
+    const capture: { messages?: ChatMessage[] } = {};
+    const resolved = makeResolved(async (opts, cb) => {
+        capture.messages = (opts as { messages: ChatMessage[] }).messages;
+        cb.onToken?.('응답');
+        return { content: '응답', usage: {}, finishReason: 'stop' };
+    });
+    const req = { message: '안녕', userId: 'u1', userRole: 'user' as const, history };
+    return streamFromExternalProvider(deps, resolved, req as never, () => {}).then(() => capture.messages!);
+}
+
+describe('runExternalStream — 클라이언트 system 메시지 위치', () => {
+    it('history 의 system 을 맨 앞 system 에 병합하고 배열에는 남기지 않는다', async () => {
+        const messages = await captureRun([
+            { role: 'system', content: 'CLIENT_SYSTEM_INSTRUCTION' },
+            { role: 'user', content: '이전 질문' },
+            { role: 'assistant', content: '이전 답변' },
+        ]);
+
+        expect(messages.filter((m) => m.role === 'system')).toHaveLength(1);
+        expect(messages[0].role).toBe('system');
+        expect(messages[0].content).toContain('CLIENT_SYSTEM_INSTRUCTION');
+        expect(messages.map((m) => m.role)).toEqual(['system', 'user', 'assistant', 'user']);
+    });
+
+    it('history 에 system 이 없으면 배열 구성이 그대로다', async () => {
+        const messages = await captureRun([{ role: 'user', content: '이전 질문' }]);
+        expect(messages.map((m) => m.role)).toEqual(['system', 'user', 'user']);
+    });
+});

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -133,12 +133,20 @@ export async function runExternalStream(
         messages.push({ role: 'system', content: systemContent });
     }
 
+    // history 에 섞인 system 메시지는 배열에 두지 않고 맨 앞 system 에 병합한다.
+    // 자체 system 이 index 0 을 차지하므로 history 의 system 을 그대로 두면 두 번째 system 이
+    // 중간 위치에 들어가 vLLM/qwen 템플릿이 "System message must be at the beginning"
+    // (400 BadRequest) 으로 거부한다. 드롭이 아니라 병합인 이유 — OpenAI 호환 API 에서
+    // system 은 클라이언트의 지시 계약이라 조용히 버리면 외부 클라이언트가 지시 없이 동작한다
+    // (convertMessages 가 클라이언트 system 을 history 에 그대로 싣는다).
+    // tools 요청 경로의 동일 대응: chat/external-tool-calling.ts
+    const clientSystemParts: string[] = [];
+
     for (const h of req.history ?? []) {
-        // history 에 섞인 system 메시지는 제외한다. external-provider 는 위(151)에서 자체
-        // system 을 맨 앞에 조립하므로, history 의 system 을 그대로 두면 두 번째 system 이
-        // 중간 위치에 들어가 vLLM/qwen 템플릿이 "System message must be at the beginning"
-        // (400 BadRequest) 으로 거부한다.
-        if (h.role === 'system') continue;
+        if (h.role === 'system') {
+            if (h.content) clientSystemParts.push(h.content);
+            continue;
+        }
         const role = h.role === 'user' || h.role === 'assistant'
             ? h.role
             : 'user';
@@ -147,6 +155,15 @@ export async function runExternalStream(
             content: h.content,
             ...(h.images ? { images: h.images } : {}),
         });
+    }
+
+    if (clientSystemParts.length > 0) {
+        // 자체 system 이 없는 경우(systemContent 빈 값)엔 클라이언트 system 이 맨 앞 system 이 된다.
+        if (messages[0]?.role === 'system') {
+            messages[0].content = [messages[0].content, ...clientSystemParts].join('\n\n');
+        } else {
+            messages.unshift({ role: 'system', content: clientSystemParts.join('\n\n') });
+        }
     }
 
     messages.push({


### PR DESCRIPTION
## 문제

`OpenAICompatService.convertMessages` 는 클라이언트가 보낸 `role='system'` 을 그대로 `history` 에 싣는다. 두 채팅 경로 모두 자체 system 프롬프트를 index 0 에 조립하므로, history 의 system 을 그대로 두면 두 번째 system 이 배열 중간에 들어간다.

경로별로 처리가 갈려 있었다:

| 경로 | 진입점 | 수정 전 |
|---|---|---|
| `tools` 있는 요청 | `chat/external-tool-calling.ts` | 배열에 그대로 (두 번째 system) |
| `tools` 없는 일반 요청 | `services/chat-service/external-provider.ts` | `continue` → **조용히 드롭** |

드롭은 400 은 막지만 클라이언트의 지시 계약이 사라진다 — OpenAI 호환 API 에서 `system` 은 호출자의 지시이므로, 외부 CLI/에이전트가 지시 없이 동작하게 된다.

## 변경

두 경로를 **병합(merge)** 으로 통일한다 — history 의 system 을 맨 앞 system 뒤에 `\n\n` 으로 이어 붙이고 배열에는 남기지 않는다.

- `chat/external-tool-calling.ts` — 병합 추가
- `services/chat-service/external-provider.ts` — 드롭 → 병합. 자체 system 이 비어 있는 경우엔 클라이언트 system 을 맨 앞에 `unshift`
- 각 경로 회귀 테스트 신규 2파일

메시지 조립부 전수 grep 결과 이 두 곳 외 누락 없음 (`anthropic-provider` / `chatgpt-oauth` 는 자체적으로 system 을 hoist 하므로 무관).

## 라이브 baseline 실측 (chat.openmake.cc, 수정 전)

검증 가능한 지시(`"반드시 BANANA 한 단어만 출력"`)를 `system` 으로 보내 확인:

| 케이스 | 결과 | 판정 |
|---|---|---|
| A. `tools` 없음, system 첫 위치 | HTTP 200, `"저는 AI라서 기분이 없다지만…"` | ❌ **지시 무시 — 드롭 확인** |
| B. `tools` 있음, system 첫 위치 | HTTP 200, `"BANANA"` | ✅ 지시 반영 |
| C. `tools` 있음, system 이 대화 **중간** | HTTP 200, `"BANANA"` | ✅ 지시 반영 |

**정정**: 코드 주석이 근거로 든 `400 "System message must be at the beginning"` 은 현재 모델(`qwen3.6-35b-a3b`)에서 **재현되지 않았다** (B·C 모두 200). 해당 주석은 이전 템플릿 기준의 잔재로 보인다.

따라서 이 PR 이 실제로 고치는 결함은 **A 한 건**(`tools` 없는 경로의 클라이언트 system 드롭)이며, `tools` 경로의 변경은 관측되는 동작 변화가 없는 **정규화**(배열에 두 번째 system 을 남기지 않아 템플릿 구현에 의존하지 않게 함)다.

## 검증

- [x] 신규 테스트가 수정 없이는 실패함을 확인 (병합 라인 제거 → 1 failed, 복원 → pass)
- [x] `npx tsc --noEmit` (apps/api) 통과
- [x] `eslint` 오류 0 — `external-provider.ts` 의 `max-lines` 경고(417→428)는 수정 전부터 있던 초과라 분할하지 않음
- [x] `npx jest` 전체: 246 suites / 2731 tests 통과, 실패 0
- [x] 라이브 baseline (수정 전) — 위 표
- [ ] 배포 후 라이브 재확인 (A 가 `BANANA` 로 바뀌는지)

## 보안 영향

없음. 클라이언트가 이미 보낸 지시를 프롬프트에 반영할 뿐이며, 자체 system(헌법)이 **앞에** 오는 순서는 유지된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)