### PR TITLE
docs(chat): system 병합 주석의 400 근거를 라이브 실측에 맞게 정정

### DIFF
--- a/apps/api/src/chat/__tests__/external-tool-calling.test.ts
+++ b/apps/api/src/chat/__tests__/external-tool-calling.test.ts
@@ -1,9 +1,10 @@
 /**
  * 외부 Tool Calling 경로 — 클라이언트 system 메시지 병합 회귀 테스트.
  *
- * history 에 role='system' 이 섞여 오면 자체 system(index 0) 뒤에 두 번째 system 이
- * 중간 위치로 들어가 vLLM/qwen 템플릿이 400 "System message must be at the beginning"
- * 으로 거부했다. 병합(드롭 아님)으로 고친 동작을 고정한다.
+ * OpenAI 호환 API 의 `convertMessages` 는 클라이언트가 보낸 role='system' 을 그대로
+ * history 에 싣는다. 이를 배열에 두면 자체 system(index 0) 뒤 두 번째 system 이 되어
+ * 수용 여부가 채팅 템플릿 구현에 달리고, 버리면 호출자의 지시 계약이 사라진다.
+ * 맨 앞 system 에 병합(드롭 아님)하는 동작을 고정한다.
  */
 
 import { processExternalToolCalling } from '../external-tool-calling';

--- a/apps/api/src/chat/external-tool-calling.ts
+++ b/apps/api/src/chat/external-tool-calling.ts
@@ -76,11 +76,18 @@ export async function processExternalToolCalling(params: {
     ];
 
     // history 에 섞인 system 메시지는 배열에 두지 않고 맨 앞 system 에 병합한다.
-    // 자체 system 이 index 0 을 차지하므로 history 의 system 을 그대로 두면 두 번째 system 이
-    // 중간 위치에 들어가 vLLM/qwen 템플릿이 "System message must be at the beginning"
-    // (400 BadRequest) 으로 거부한다. 드롭이 아니라 병합인 이유 — OpenAI 호환 API 에서
-    // system 은 클라이언트의 지시 계약이라 조용히 버리면 외부 에이전트가 지시 없이 동작한다.
-    // (tools 없는 일반 채팅 경로의 대응: services/chat-service/external-provider.ts)
+    //
+    // 병합인 이유(드롭 아님) — OpenAI 호환 API 에서 system 은 호출자의 지시 계약이다.
+    // convertMessages 가 클라이언트 system 을 history 에 그대로 싣는데, 이를 버리면 외부
+    // CLI/에이전트가 자기 지시 없이 동작한다 (2026-08-20 라이브 실측: 드롭하던 일반 채팅
+    // 경로에서 클라이언트 system 지시가 실제로 무시됨).
+    //
+    // 배열에 남기지 않는 이유 — 자체 system 이 index 0 을 차지하므로 history 의 system 은
+    // 두 번째 system 이 된다. 이 형태의 수용 여부는 채팅 템플릿/provider 구현에 달려 있고,
+    // 거부하는 구현은 400 "System message must be at the beginning" 을 낸다. 현행
+    // qwen3.6-35b-a3b 에선 재현되지 않았으나(같은 실측), 구현에 의존하지 않도록 정규화한다.
+    //
+    // tools 없는 일반 채팅 경로의 동일 대응: services/chat-service/external-provider.ts
     const clientSystemParts: string[] = [];
 
     if (history && history.length > 0) {

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -133,13 +133,10 @@ export async function runExternalStream(
         messages.push({ role: 'system', content: systemContent });
     }
 
-    // history 에 섞인 system 메시지는 배열에 두지 않고 맨 앞 system 에 병합한다.
-    // 자체 system 이 index 0 을 차지하므로 history 의 system 을 그대로 두면 두 번째 system 이
-    // 중간 위치에 들어가 vLLM/qwen 템플릿이 "System message must be at the beginning"
-    // (400 BadRequest) 으로 거부한다. 드롭이 아니라 병합인 이유 — OpenAI 호환 API 에서
-    // system 은 클라이언트의 지시 계약이라 조용히 버리면 외부 클라이언트가 지시 없이 동작한다
-    // (convertMessages 가 클라이언트 system 을 history 에 그대로 싣는다).
-    // tools 요청 경로의 동일 대응: chat/external-tool-calling.ts
+    // history 에 섞인 system 은 배열에 두지 않고 맨 앞 system 에 병합한다 — 드롭하면
+    // 호출자의 지시 계약이 사라지고(2026-08-20 실측), 배열에 남기면 두 번째 system 의
+    // 수용 여부가 채팅 템플릿/provider 구현에 의존한다.
+    // 근거 전문 + tools 요청 경로의 동일 대응: chat/external-tool-calling.ts
     const clientSystemParts: string[] = [];
 
     for (const h of req.history ?? []) {


### PR DESCRIPTION
#543 후속. 주석 전용 변경으로 **동작 변화 없음**.

## 문제

병합의 근거로 주석이 vLLM/qwen 템플릿의 `400 "System message must be at the beginning"` 을 단정하고 있었다. #543 라이브 검증에서 이 400 은 현행 `qwen3.6-35b-a3b` 로 **재현되지 않았다**:

| 케이스 | 결과 |
|---|---|
| `tools` 있음, 두 번째 system 이 배열 첫 위치 | HTTP 200 |
| `tools` 있음, 두 번째 system 이 대화 **중간** | HTTP 200 |

실제로 확인된 결함은 `tools` 없는 경로의 **드롭으로 인한 클라이언트 지시 무시**(200 인데 지시가 반영되지 않음)였다.

## 변경

주석을 실측대로 다시 썼다 — 근거를 두 갈래로 분리:

1. **병합인 이유(드롭 아님)** — OpenAI 호환 API 에서 system 은 호출자의 지시 계약. 버리면 외부 CLI/에이전트가 자기 지시 없이 동작한다 (2026-08-20 실측 근거 명시).
2. **배열에 남기지 않는 이유** — 두 번째 system 형태의 수용 여부가 채팅 템플릿/provider 구현에 달려 있다. 거부하는 구현은 위 400 을 낸다. 현행 모델에선 미재현이나, 구현에 의존하지 않도록 정규화한다.

대상: `chat/external-tool-calling.ts`, `services/chat-service/external-provider.ts`, `chat/__tests__/external-tool-calling.test.ts` 의 docblock.

## 검증

- [x] `npx tsc --noEmit` (apps/api) 통과
- [x] `eslint` 오류 0 (`max-lines` 경고는 기존 초과, 주석은 카운트에 미포함 — 428 유지)
- [x] 해당 회귀 테스트 2 suites / 4 tests 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)