### PR TITLE
feat(agent-task): OpenMake Code — 로컬 기반 CLI 에이전트 작업

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -699,10 +699,12 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # 차단우회 허용 도메인 화이트리스트 (SSRF·남용 방지)
 # SCRAPER_IMPERSONATE_WHITELIST=reddit.com,www.reddit.com,old.reddit.com,oauth.reddit.com
 # curl_cffi 임퍼소네이션 브라우저 프로필
-# SCRAPER_IMPERSONATE_TARGET=chrome120
+# SCRAPER_IMPERSONATE_TARGET=chrome136
 # 차단우회 응답 최대 바이트 / 타임아웃 ms
 # SCRAPER_IMPERSONATE_MAX_BYTES=5000000
 # SCRAPER_IMPERSONATE_TIMEOUT_MS=15000
+# 봇 챌린지 판별 제목 패턴 (소문자 부분일치)
+# SCRAPER_BOT_CHALLENGE_TITLES=just a moment,attention required,access denied,verify you are human,verifying you are human,security check
 # python3 실행 경로 (curl_cffi 호출용)
 # SCRAPER_PYTHON_BIN=python3
 # 스크랩 결과 KVStore 캐시 (G1) — 동일 URL 반복 fetch 방지 (기본 on, TTL 30분)

--- a/.env.example
+++ b/.env.example
@@ -1043,6 +1043,7 @@ AGENT_TASK_TIMEOUT_MS=600000
 # LOCAL_BRIDGE_REQUEST_TIMEOUT_MS=180000        # 도구 1회 왕복 대기 상한
 # LOCAL_BRIDGE_MAX_WRITE_BYTES=8388608          # write/첨부 전송 상한(8MB)
 # LOCAL_BRIDGE_OUTPUT_CAP=65536                 # exec/read 결과 수신 캡(chars)
+# LOCAL_BRIDGE_MAX_DEVICES=3                     # 유저당 동시 등록 브리지 디바이스 상한(데스크톱+CLI)
 #
 # worktree 격리 — 연결 폴더가 git 레포면 별도 worktree(디렉토리+브랜치)를 만들어 그 안에서만
 # 작업한다. 사용자의 현재 브랜치·작업 중인 파일이 오염되지 않고, 변경분을 git diff 로 캡처해

--- a/apps/api/src/config/local-bridge.ts
+++ b/apps/api/src/config/local-bridge.ts
@@ -20,6 +20,9 @@ export const LOCAL_BRIDGE = {
     /** read/exec 결과 수신 캡(chars) — 모델 컨텍스트/스텝 저장 보호(샌드박스 outputCap 관행과 동일 축). */
     OUTPUT_CAP: parseInt(process.env.LOCAL_BRIDGE_OUTPUT_CAP || '65536', 10),
 
+    /** 유저당 동시 등록 브리지 디바이스 상한 (데스크톱+CLI 병존, 2026-08-21 다중화). */
+    MAX_DEVICES: parseInt(process.env.LOCAL_BRIDGE_MAX_DEVICES || '3', 10),
+
     /**
      * 로컬 브라우저(D3a) — 데스크톱 Electron 내장 Chromium 에서 browser 도구를 실행한다.
      * 서버 컨테이너 브라우저와 달리 **사용자 화면에 보이는** 패널로 뜨고, 전용 세션 파티션이라

--- a/apps/api/src/config/web-scraper.ts
+++ b/apps/api/src/config/web-scraper.ts
@@ -34,8 +34,16 @@ export const SCRAPER_CONFIG = {
         || 'reddit.com,www.reddit.com,old.reddit.com,oauth.reddit.com')
         .split(',').map((s) => s.trim().toLowerCase()).filter(Boolean),
 
-    /** curl_cffi 임퍼소네이션 브라우저 프로필 */
-    IMPERSONATE_TARGET: process.env.SCRAPER_IMPERSONATE_TARGET || 'chrome120',
+    /** curl_cffi 임퍼소네이션 브라우저 프로필 (curl_cffi 0.16 지원 목록 기준) */
+    IMPERSONATE_TARGET: process.env.SCRAPER_IMPERSONATE_TARGET || 'chrome136',
+
+    /**
+     * 봇 챌린지 안내 페이지 판별 제목 패턴 (소문자 부분일치) — fetch/Playwright 가 챌린지
+     * 페이지("Just a moment...")를 정상 본문으로 반환하던 갭 차단, 임퍼소네이션 폴백 트리거.
+     */
+    BOT_CHALLENGE_TITLE_PATTERNS: (process.env.SCRAPER_BOT_CHALLENGE_TITLES
+        || 'just a moment,attention required,access denied,verify you are human,verifying you are human,security check')
+        .split(',').map((s) => s.trim().toLowerCase()).filter(Boolean),
 
     /** 차단 우회 응답 최대 바이트 (메모리 보호) */
     IMPERSONATE_MAX_BYTES: parseInt(process.env.SCRAPER_IMPERSONATE_MAX_BYTES || '5000000', 10),

--- a/apps/api/src/data/models/unified-database.ts
+++ b/apps/api/src/data/models/unified-database.ts
@@ -348,6 +348,7 @@ export class UnifiedDatabase {
         inputFiles?: unknown;
         inputImages?: unknown;
         executor?: 'sandbox' | 'local';
+        deviceId?: string;
     }): Promise<void> {
         return this.agentTaskRepository.createAgentTask(params);
     }

--- a/apps/api/src/data/models/unified-database.types.ts
+++ b/apps/api/src/data/models/unified-database.types.ts
@@ -182,6 +182,8 @@ export interface AgentTask {
     input_images?: unknown;
     /** Cowork D1a: 실행 백엔드(081) — 'sandbox'(기본) | 'local'(로컬 브리지) */
     executor?: 'sandbox' | 'local';
+    /** 로컬 실행 대상 브리지 디바이스(101) — NULL 은 최근 접속 디바이스 폴백 */
+    device_id?: string;
     /** 누적 LLM 토큰(prompt+completion) — terminal 전이 시 기록(066), resume 은 통산 */
     total_tokens?: number;
     /** 완료 출구 구분(091) — 'final_answer' | 'terminate'. 미완료/기존 행은 NULL */

--- a/apps/api/src/data/repositories/agent-task-repository.ts
+++ b/apps/api/src/data/repositories/agent-task-repository.ts
@@ -26,6 +26,8 @@ export class AgentTaskRepository extends BaseRepository {
         inputImages?: unknown;
         /** Cowork D1a: 실행 백엔드 — 'sandbox'(기본) | 'local'(로컬 브리지) */
         executor?: 'sandbox' | 'local';
+        /** 로컬 실행 대상 브리지 디바이스 (다중 디바이스, 093) — 미지정은 최근 접속 디바이스 폴백 */
+        deviceId?: string;
     }): Promise<void> {
         // input_files/input_images 는 값이 있을 때만 컬럼에 포함 — 056/057 마이그레이션
         // 미적용 배포에서도 해당 값 없는 기존 생성 경로가 깨지지 않게 한다(2단계 배포 안전).
@@ -42,6 +44,10 @@ export class AgentTaskRepository extends BaseRepository {
         if (params.executor !== undefined) {
             cols.push('executor');
             values.push(params.executor);
+        }
+        if (params.deviceId !== undefined) {
+            cols.push('device_id');
+            values.push(params.deviceId);
         }
         await this.query(
             `INSERT INTO agent_tasks (${cols.join(', ')}) VALUES (${values.map((_, i) => `$${i + 1}`).join(', ')})`,

--- a/apps/api/src/middlewares/api-key-auth.ts
+++ b/apps/api/src/middlewares/api-key-auth.ts
@@ -126,6 +126,19 @@ export async function requireApiKey(req: Request, res: Response, next: NextFunct
 }
 
 /**
+ * JWT 또는 API Key 병용 필수 인증 (2026-08-21, CLI 브리지·에이전트 작업용).
+ * Authorization/X-API-Key 에 omk_live_ 키가 있으면 API Key 경로로, 아니면 기존 requireAuth(JWT).
+ */
+export async function requireAuthOrApiKey(req: Request, res: Response, next: NextFunction): Promise<void> {
+    if (extractApiKey(req)) {
+        await requireApiKey(req, res, next);
+        return;
+    }
+    const { requireAuth } = await import('../auth/middleware');
+    await requireAuth(req, res, next);
+}
+
+/**
  * API Key 인증 선택적 미들웨어
  * API Key가 있으면 검증하고 req에 첨부, 없으면 통과
  * 기존 optionalAuth와 결합하여 JWT 또는 API Key 인증 지원

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -21,7 +21,7 @@ import { Router, Request, Response } from 'express';
 import { createLogger } from '../utils/logger';
 import { success, badRequest, notFound } from '../utils/api-response';
 import { asyncHandler } from '../utils/error-handler';
-import { requireAuth } from '../auth';
+import { requireAuthOrApiKey } from '../middlewares/api-key-auth';
 import { assertResourceOwnerOrAdmin } from '../auth/ownership';
 import { validate, validateWithSecurity } from '../middlewares/validation';
 import { getUnifiedDatabase } from '../data/models/unified-database';
@@ -56,7 +56,7 @@ const logger = createLogger('AgentTaskRoutes');
 const router = Router();
 
 // 모든 엔드포인트 인증 필요
-router.use(requireAuth);
+router.use(requireAuthOrApiKey);
 
 type UserRole = 'admin' | 'user' | 'guest';
 
@@ -119,7 +119,7 @@ router.post('/', (req: Request, res: Response, next) => {
     } else {
         input = req.body as CreateAgentTaskInput;
     }
-    const { goal, maxTurns, files, images, executor } = input;
+    const { goal, maxTurns, files, images, executor, deviceId } = input;
 
     const taskId = uuidv4();
     const db = getUnifiedDatabase();
@@ -131,8 +131,10 @@ router.post('/', (req: Request, res: Response, next) => {
             res.status(400).json(badRequest('로컬 실행 기능이 비활성화되어 있습니다 (LOCAL_EXECUTOR_ENABLED)'));
             return;
         }
-        if (!getLocalBridgeRegistry().getDevice(userId)) {
-            res.status(400).json(badRequest('연결된 로컬 디바이스가 없습니다 — 데스크톱 앱에서 작업 폴더를 먼저 연결하세요'));
+        if (!getLocalBridgeRegistry().getDevice(userId, deviceId)) {
+            res.status(400).json(badRequest(deviceId
+                ? `지정한 디바이스(${deviceId.slice(0, 12)}…)가 연결되어 있지 않습니다 — 디바이스에서 폴더를 다시 연결하세요`
+                : '연결된 로컬 디바이스가 없습니다 — 데스크톱 앱 또는 CLI 로 작업 폴더를 먼저 연결하세요'));
             return;
         }
     }
@@ -223,6 +225,7 @@ router.post('/', (req: Request, res: Response, next) => {
         inputFiles,
         inputImages: Array.isArray(images) && images.length > 0 ? images : undefined,
         executor,
+        deviceId: executor === 'local' ? deviceId : undefined,
     });
 
     const task = await db.getAgentTask(taskId);
@@ -301,8 +304,8 @@ router.post('/:taskId/execute', validate(executeAgentTaskSchema), asyncHandler(a
         if (!LOCAL_BRIDGE.ENABLED) {
             return res.status(400).json(badRequest('로컬 실행 기능이 비활성화되어 있습니다 (LOCAL_EXECUTOR_ENABLED)'));
         }
-        if (!getLocalBridgeRegistry().getDevice(String(req.user!.id))) {
-            return res.status(400).json(badRequest('연결된 로컬 디바이스가 없습니다 — 데스크톱 앱에서 작업 폴더를 먼저 연결하세요'));
+        if (!getLocalBridgeRegistry().getDevice(String(req.user!.id), task.device_id ?? undefined)) {
+            return res.status(400).json(badRequest('작업 대상 로컬 디바이스가 연결되어 있지 않습니다 — 데스크톱 앱 또는 CLI 로 작업 폴더를 먼저 연결하세요'));
         }
     }
 
@@ -338,6 +341,7 @@ router.post('/:taskId/execute', validate(executeAgentTaskSchema), asyncHandler(a
             files: Array.isArray(task.input_files) ? task.input_files as AgentTaskInputFile[] : undefined,
             images: Array.isArray(task.input_images) ? task.input_images as string[] : undefined,
             executor: (task.executor === 'local' ? 'local' : undefined),
+            deviceId: task.device_id ?? undefined,
         }),
     });
 

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -398,6 +398,16 @@ router.post('/:taskId/resume', asyncHandler(async (req: Request, res: Response) 
     if (!cp || !Array.isArray(cp.conversation) || cp.conversation.length === 0) {
         return res.status(400).json(badRequest('이어할 체크포인트가 없는 작업입니다.'));
     }
+    // 로컬 실행 작업 재개 가드 — execute 와 대칭. 없으면 로컬 작업이 조용히 docker 샌드박스로
+    // 폴백해(RemoteExecutor 미생성) 사용자 폴더/worktree 가 없는 채로 오작동한다.
+    if (task.executor === 'local') {
+        if (!LOCAL_BRIDGE.ENABLED) {
+            return res.status(400).json(badRequest('로컬 실행 기능이 비활성화되어 있습니다 (LOCAL_EXECUTOR_ENABLED)'));
+        }
+        if (!getLocalBridgeRegistry().getDevice(String(req.user!.id), task.device_id ?? undefined)) {
+            return res.status(400).json(badRequest('작업 대상 로컬 디바이스가 연결되어 있지 않습니다 — 데스크톱 앱 또는 CLI 로 작업 폴더를 먼저 연결하세요'));
+        }
+    }
 
     const role: UserRole = (req.user!.role as UserRole) || 'user';
     const db = getUnifiedDatabase();
@@ -415,6 +425,8 @@ router.post('/:taskId/resume', asyncHandler(async (req: Request, res: Response) 
             maxTurns: task.max_turns,
             files: Array.isArray(task.input_files) ? task.input_files as AgentTaskInputFile[] : undefined,
             images: Array.isArray(task.input_images) ? task.input_images as string[] : undefined,
+            executor: (task.executor === 'local' ? 'local' : undefined),
+            deviceId: task.device_id ?? undefined,
             resume: {
                 conversation: cp.conversation as ChatMessage[],
                 fromTurn: (cp.completedTurn ?? 0) + 1,

--- a/apps/api/src/routes/local-bridge.routes.ts
+++ b/apps/api/src/routes/local-bridge.routes.ts
@@ -4,21 +4,29 @@
  * @module routes/local-bridge
  */
 import { Router, Request, Response } from 'express';
-import { requireAuth } from '../auth';
+import { requireAuthOrApiKey } from '../middlewares/api-key-auth';
 import { success } from '../utils/api-response';
 import { LOCAL_BRIDGE } from '../config/local-bridge';
 import { getLocalBridgeRegistry } from '../services/local-bridge/registry';
 
 const router = Router();
 
-router.get('/status', requireAuth, (req: Request, res: Response) => {
+router.get('/status', requireAuthOrApiKey, (req: Request, res: Response) => {
     const userId = String(req.user!.id);
-    const dev = LOCAL_BRIDGE.ENABLED ? getLocalBridgeRegistry().getDevice(userId) : null;
+    const devices = LOCAL_BRIDGE.ENABLED ? getLocalBridgeRegistry().getDevices(userId) : [];
+    // 구 필드(connected/label/folderName)는 최근 접속 디바이스 기준으로 병존 — 구 프론트 무중단.
+    const latest = LOCAL_BRIDGE.ENABLED ? getLocalBridgeRegistry().getDevice(userId) : null;
     res.json(success({
         enabled: LOCAL_BRIDGE.ENABLED,
-        connected: !!dev,
-        label: dev?.label ?? null,
-        folderName: dev?.folderName ?? null,
+        connected: !!latest,
+        label: latest?.label ?? null,
+        folderName: latest?.folderName ?? null,
+        devices: devices.map((d) => ({
+            deviceId: d.deviceId,
+            label: d.label,
+            folderName: d.folderName,
+            connectedAt: d.connectedAt,
+        })),
     }));
 });
 

--- a/apps/api/src/schemas/agent-task.schema.ts
+++ b/apps/api/src/schemas/agent-task.schema.ts
@@ -59,6 +59,8 @@ export const createAgentTaskSchema = z.strictObject({
     maxTurns: z.number().int().min(1).max(AGENT_TASK_LIMITS.MAX_TURNS_CEILING).optional(),
     // Cowork D1a: 실행 백엔드 — 'local' 은 LOCAL_EXECUTOR_ENABLED + 디바이스 연결 필요(라우트가 검증).
     executor: z.enum(['sandbox', 'local']).optional(),
+    // 다중 디바이스(101): 로컬 실행 대상 브리지 디바이스. 미지정은 최근 접속 디바이스 폴백.
+    deviceId: z.string().min(1).max(64).optional(),
     files: z.array(taskInputFileSchema).max(FILE_ATTACH_LIMITS.MAX_FILES).optional(),
     images: z.array(
         z.string().startsWith('data:image/').max(FILE_ATTACH_LIMITS.MAX_IMAGE_DATAURL_CHARS)

--- a/apps/api/src/services/agent-task/boot-recovery.ts
+++ b/apps/api/src/services/agent-task/boot-recovery.ts
@@ -64,6 +64,19 @@ export async function recoverInterruptedAgentTasks(): Promise<{ resumed: number;
                 continue;
             }
 
+            // 로컬 실행 작업은 자동 재개하지 않는다 — 부팅 시점엔 브리지 디바이스가 아직
+            // 연결되지 않아(CLI/데스크톱은 서버 기동 후 재접속) RemoteExecutor.create 가
+            // 미연결로 실패한다. 상태만 failed(interrupted)로 정리해 완료 오표시·영구 polling 을
+            // 막고, 사용자가 디바이스 재연결 후 /resume 으로 수동 재개하게 한다.
+            if (task.executor === 'local') {
+                if (task.status === 'running' || task.status === 'paused') {
+                    await db.updateAgentTask(task.id, { status: 'failed', error: 'interrupted_local_device' });
+                    failed++;
+                    logger.info(`[BootRecovery] 로컬 실행 작업 자동재개 보류 → failed(디바이스 재연결 후 수동 resume): ${task.id}`);
+                }
+                continue;
+            }
+
             // 원자적 소유권 획득 — 실패(rowCount=0)면 다른 프로세스가 이미 복구 중이므로 건너뜀.
             const claimed = await taskRepo.claimAgentTaskForRecovery(task.id);
             if (!claimed) continue;

--- a/apps/api/src/services/agent-task/executor-select.ts
+++ b/apps/api/src/services/agent-task/executor-select.ts
@@ -22,7 +22,7 @@ export interface ExecutorPlan {
 }
 
 export function resolveExecutorPlan(
-    input: Pick<AgentTaskRunInput, 'executor' | 'approvalPolicy'>,
+    input: Pick<AgentTaskRunInput, 'executor' | 'approvalPolicy' | 'deviceId'>,
     taskId: string,
     userId: string,
 ): ExecutorPlan {
@@ -37,6 +37,6 @@ export function resolveExecutorPlan(
     return {
         sandboxCfg,
         runtimeEnabled: sandboxCfg.enabled || isLocal,
-        remoteExecutor: isLocal ? new RemoteExecutor(taskId, userId) : undefined,
+        remoteExecutor: isLocal ? new RemoteExecutor(taskId, userId, input.deviceId) : undefined,
     };
 }

--- a/apps/api/src/services/agent-task/types.ts
+++ b/apps/api/src/services/agent-task/types.ts
@@ -64,6 +64,8 @@ export interface AgentTaskRunInput {
     /** Cowork D1a: 실행 백엔드 — 'local' 이면 로컬 브리지(RemoteExecutor)로 도구를 위임.
      *  LOCAL_EXECUTOR_ENABLED + 디바이스 연결 필요, 승인 정책은 'all' 강제. 미지정=sandbox. */
     executor?: 'sandbox' | 'local';
+    /** 로컬 실행 대상 브리지 디바이스(101, 다중 디바이스) — 미지정은 최근 접속 폴백. */
+    deviceId?: string;
     /** resume(이어하기): 기존 end-of-turn checkpoint 에서 복원 */
     resume?: {
         conversation: ChatMessage[];

--- a/apps/api/src/services/chat-service/__tests__/hallucinated-map-html.test.ts
+++ b/apps/api/src/services/chat-service/__tests__/hallucinated-map-html.test.ts
@@ -1,0 +1,57 @@
+/**
+ * 지도 환각 HTML 결정적 제거 — stripHallucinatedMapHtml / mapHtmlWasCleaned.
+ * "kakaomap 블록 직접 작성 금지" 넛지 하에서 qwen 이 존재하지 않는 lmap.kakao.com
+ * 정적 이미지 <img> 링크로 우회 환각한 라이브 사례(2026-08-20)의 후처리 검증.
+ */
+import { stripHallucinatedMapHtml, mapHtmlWasCleaned } from '../external-deterministic-append';
+
+// 2026-08-20 라이브 관측 원문 그대로.
+const LIVE_HALLUCINATION = `광화문 주변 검색 결과를 표시합니다.
+
+<center> <a href="https://map.kakao.com/?itemtype=place&itemId=8234642&org.lat=37.57596445980707&org.lon=126.97685309595215"> <img src="https://lmap.kakao.com/view/new/detail/Zz926X9OJhZ8v7b5q9Y8Zz926X9O.jpg" width="500" height="400" alt="Kakao Map - 광화문"> </a> </center> <br>`;
+
+describe('stripHallucinatedMapHtml', () => {
+    test('라이브 관측 사례: <center><a><img></a></center> <br> 전체가 제거된다', () => {
+        const r = stripHallucinatedMapHtml(LIVE_HALLUCINATION);
+        expect(r.removed).toBe(1);
+        expect(r.content).not.toMatch(/<img|<a |<center|<br/i);
+        expect(r.content).toContain('광화문 주변 검색 결과를 표시합니다.');
+    });
+
+    test('단독 <img> (앵커 없음) 도 제거된다', () => {
+        const r = stripHallucinatedMapHtml('지도: <img src="https://lmap.kakao.com/x/y.jpg" alt="map"> 입니다.');
+        expect(r.removed).toBe(1);
+        expect(r.content).toBe('지도:  입니다.');
+    });
+
+    test('마크다운 이미지 형태의 카카오 지도 URL 도 제거된다', () => {
+        const r = stripHallucinatedMapHtml('![광화문 지도](https://t1.daumcdn.net/mapjs/fake.png)');
+        expect(r.removed).toBe(1);
+        expect(r.content).toBe('');
+    });
+
+    test('카카오 계열이 아닌 이미지/링크는 건드리지 않는다', () => {
+        const text = '사진 ![a](https://example.com/a.png) 과 <img src="/generated/x.png"> 유지. [지도](https://map.kakao.com/?q=광화문) 텍스트 링크도 유지.';
+        const r = stripHallucinatedMapHtml(text);
+        expect(r.removed).toBe(0);
+        expect(r.content).toBe(text);
+    });
+
+    test('kakaomap 코드 블록(결정적 주입 산출물)은 건드리지 않는다', () => {
+        const text = '결과입니다.\n\n```kakaomap\n{"places":[{"name":"광화문","lat":37.57,"lng":126.97}]}\n```';
+        const r = stripHallucinatedMapHtml(text);
+        expect(r.removed).toBe(0);
+        expect(r.content).toBe(text);
+    });
+});
+
+describe('mapHtmlWasCleaned', () => {
+    test('스트리밍본엔 환각 HTML 이 있고 최종본에선 제거됐으면 true', () => {
+        const final = stripHallucinatedMapHtml(LIVE_HALLUCINATION).content;
+        expect(mapHtmlWasCleaned(LIVE_HALLUCINATION, final)).toBe(true);
+    });
+
+    test('환각 HTML 이 없던 턴은 false', () => {
+        expect(mapHtmlWasCleaned('일반 응답입니다.', '일반 응답입니다.')).toBe(false);
+    });
+});

--- a/apps/api/src/services/chat-service/external-deterministic-append.ts
+++ b/apps/api/src/services/chat-service/external-deterministic-append.ts
@@ -66,6 +66,41 @@ export function citationMarkersWereCleaned(streamed: string, final: string): boo
     return false;
 }
 
+/** 카카오 지도 계열 호스트의 이미지 URL — 모델이 환각으로 지어내는 정적 지도 이미지 src 대상. */
+const MAP_IMG_URL_SRC = String.raw`https?:\/\/(?:[a-z0-9-]+\.)*(?:kakao\.com|kakaocdn\.net|daumcdn\.net)\/[^"'\s)>]*`;
+/** 위 URL 을 src 로 갖는 <img> 태그. */
+const MAP_IMG_TAG_SRC = String.raw`<img\b[^>]*\bsrc=["']${MAP_IMG_URL_SRC}["'][^>]*\/?>`;
+
+/**
+ * 모델이 환각으로 만든 카카오 지도 HTML(<a><img></a>·단독 <img>·마크다운 이미지)을 제거한다 —
+ * "kakaomap 블록/좌표 직접 작성 금지" 넛지 하에서 qwen 이 존재하지 않는 lmap.kakao.com
+ * 정적 이미지 링크로 우회 환각한 라이브 사례(2026-08-20)의 결정적 후처리. 실제 지도는
+ * 아래 kakaomapBlocks 결정적 첨부가 담당하므로 이 HTML 은 저장 히스토리에서 제거해도
+ * 정보 손실이 없다. 화면(이미 스트리밍된 본문)은 ws-chat-handler 의 done.cleanedContent
+ * 교체가 정리한다 (죽은 인용 마커와 동일 패턴).
+ */
+export function stripHallucinatedMapHtml(content: string): { content: string; removed: number } {
+    let removed = 0;
+    const count = () => {
+        removed++;
+        return '';
+    };
+    let out = content
+        .replace(new RegExp(String.raw`<a\b[^>]*>\s*${MAP_IMG_TAG_SRC}\s*<\/a>`, 'gi'), count)
+        .replace(new RegExp(MAP_IMG_TAG_SRC, 'gi'), count)
+        .replace(new RegExp(String.raw`!\[[^\]]*\]\(\s*${MAP_IMG_URL_SRC}\s*\)`, 'gi'), count);
+    if (removed > 0) {
+        // 제거로 비어버린 <center> 래퍼와 직후 <br> 잔재 정리.
+        out = out.replace(/<center>\s*<\/center>\s*(?:<br\s*\/?>\s*)*/gi, '');
+    }
+    return { content: out, removed };
+}
+
+/** 스트리밍 본문엔 지도 환각 HTML 이 있었는데 최종본에선 제거됐는지 — cleanedContent 교체 판정용. */
+export function mapHtmlWasCleaned(streamed: string, final: string): boolean {
+    return stripHallucinatedMapHtml(streamed).removed > 0 && stripHallucinatedMapHtml(final).removed === 0;
+}
+
 export interface DeterministicAppendInput {
     /** 모델이 만든 최종 본문 (이미 라이브 스트리밍된 텍스트). */
     finalContent: string;
@@ -149,6 +184,13 @@ export function appendDeterministicBlocks(input: DeterministicAppendInput): stri
         onToken(appended, undefined);
         finalContent += appended;
         logger.info(`🖼️ 생성 이미지 ${missingImages.length}개 자동 첨부 (LLM 응답 누락 보정)`);
+    }
+
+    // 지도 환각 HTML 결정적 제거 — 저장 히스토리(반환값)가 대상. 화면은 done.cleanedContent 교체.
+    const mapStrip = stripHallucinatedMapHtml(finalContent);
+    if (mapStrip.removed > 0) {
+        finalContent = mapStrip.content;
+        logger.info(`🧹 지도 환각 HTML ${mapStrip.removed}개 제거 (카카오 이미지 링크 환각)`);
     }
 
     // 카카오 지도 블록도 동일하게 — LLM 이 옮기지 않았으면 결정적 첨부(라이브 stream + 저장 히스토리).

--- a/apps/api/src/services/local-bridge/registry.multi-device.test.ts
+++ b/apps/api/src/services/local-bridge/registry.multi-device.test.ts
@@ -1,0 +1,96 @@
+/**
+ * 레지스트리 다중 디바이스(101, 2026-08-21) — 데스크톱+CLI 병존.
+ * 유저당 여러 디바이스 등록, 같은 deviceId 재등록 대체, deviceId 지정/미지정 라우팅,
+ * 상한 초과 거부, 해제 시 해당 디바이스 pending 만 reject 를 검증한다.
+ */
+import { getLocalBridgeRegistry, type DeviceSession } from './registry';
+import type { WebSocket } from 'ws';
+
+function fakeWs(): WebSocket {
+    return { readyState: 1, OPEN: 1, send: jest.fn() } as unknown as WebSocket;
+}
+
+function session(userId: string, deviceId: string, connectedAt: number, ws = fakeWs()): DeviceSession {
+    return { userId, deviceId, label: `dev-${deviceId}`, folderName: `folder-${deviceId}`, ws, connectedAt };
+}
+
+describe('LocalBridgeRegistry 다중 디바이스', () => {
+    const reg = getLocalBridgeRegistry();
+    const wsList: WebSocket[] = [];
+
+    afterEach(() => {
+        for (const ws of wsList.splice(0)) reg.unregister(ws);
+    });
+
+    function add(userId: string, deviceId: string, connectedAt: number): { ws: WebSocket; ok: boolean } {
+        const ws = fakeWs();
+        wsList.push(ws);
+        return { ws, ok: reg.register(session(userId, deviceId, connectedAt, ws)) };
+    }
+
+    test('유저당 여러 디바이스가 병존한다', () => {
+        expect(add('u1', 'desktop', 100).ok).toBe(true);
+        expect(add('u1', 'cli', 200).ok).toBe(true);
+        expect(reg.getDevices('u1').map((d) => d.deviceId)).toEqual(['desktop', 'cli']);
+    });
+
+    test('deviceId 지정 조회는 정확 일치, 미지정은 최근 접속 디바이스', () => {
+        add('u1', 'desktop', 100);
+        add('u1', 'cli', 200);
+        expect(reg.getDevice('u1', 'desktop')?.deviceId).toBe('desktop');
+        expect(reg.getDevice('u1')?.deviceId).toBe('cli'); // 최근 접속
+        expect(reg.getDevice('u1', 'unknown')).toBeNull();
+    });
+
+    test('같은 deviceId 재등록은 기존 세션을 대체한다 (디바이스 수 불변)', () => {
+        add('u1', 'cli', 100);
+        add('u1', 'cli', 200);
+        expect(reg.getDevices('u1')).toHaveLength(1);
+        expect(reg.getDevice('u1', 'cli')?.connectedAt).toBe(200);
+    });
+
+    test('상한(MAX_DEVICES=3) 초과 신규 등록은 거부된다', () => {
+        expect(add('u1', 'd1', 1).ok).toBe(true);
+        expect(add('u1', 'd2', 2).ok).toBe(true);
+        expect(add('u1', 'd3', 3).ok).toBe(true);
+        expect(add('u1', 'd4', 4).ok).toBe(false);
+        expect(reg.getDevices('u1')).toHaveLength(3);
+        // 기존 디바이스 재등록은 상한과 무관하게 허용
+        expect(add('u1', 'd3', 5).ok).toBe(true);
+    });
+
+    test('한 디바이스 해제는 다른 디바이스에 영향을 주지 않는다', () => {
+        const a = add('u1', 'desktop', 100);
+        add('u1', 'cli', 200);
+        reg.unregister(a.ws);
+        expect(reg.getDevice('u1', 'desktop')).toBeNull();
+        expect(reg.getDevice('u1', 'cli')?.deviceId).toBe('cli');
+    });
+
+    test('request 는 deviceId 로 해당 디바이스에만 전송된다', async () => {
+        const a = add('u1', 'desktop', 100);
+        const b = add('u1', 'cli', 200);
+        void reg.request('u1', { kind: 'read', path: 'x' }, 1000, 'desktop');
+        expect((a.ws.send as jest.Mock)).toHaveBeenCalledTimes(1);
+        expect((b.ws.send as jest.Mock)).not.toHaveBeenCalled();
+        // pending 정리 (타이머 leak 방지) — desktop 해제로 reject
+        reg.unregister(a.ws);
+    });
+
+    test('디바이스 해제 시 그 디바이스의 pending 만 reject 된다', async () => {
+        const a = add('u1', 'desktop', 100);
+        const b = add('u1', 'cli', 200);
+        const pA = reg.request('u1', { kind: 'read', path: 'x' }, 60000, 'desktop');
+        const pB = reg.request('u1', { kind: 'read', path: 'y' }, 60000, 'cli');
+        reg.unregister(a.ws);
+        const rA = await pA;
+        expect(rA.ok).toBe(false);
+        expect(rA.error).toContain('끊어');
+        // cli pending 은 살아 있다 — 결과 주입으로 정상 해소
+        const sent = JSON.parse((b.ws.send as jest.Mock).mock.calls[0][0] as string);
+        reg.handleResult('u1', sent.reqId, { ok: true, content: 'data' });
+        const rB = await pB;
+        expect(rB.ok).toBe(true);
+        expect(rB.content).toBe('data');
+    });
+});

--- a/apps/api/src/services/local-bridge/registry.multi-device.test.ts
+++ b/apps/api/src/services/local-bridge/registry.multi-device.test.ts
@@ -7,7 +7,7 @@ import { getLocalBridgeRegistry, type DeviceSession } from './registry';
 import type { WebSocket } from 'ws';
 
 function fakeWs(): WebSocket {
-    return { readyState: 1, OPEN: 1, send: jest.fn() } as unknown as WebSocket;
+    return { readyState: 1, OPEN: 1, send: jest.fn(), close: jest.fn() } as unknown as WebSocket;
 }
 
 function session(userId: string, deviceId: string, connectedAt: number, ws = fakeWs()): DeviceSession {
@@ -57,6 +57,30 @@ describe('LocalBridgeRegistry 다중 디바이스', () => {
         expect(reg.getDevices('u1')).toHaveLength(3);
         // 기존 디바이스 재등록은 상한과 무관하게 허용
         expect(add('u1', 'd3', 5).ok).toBe(true);
+    });
+
+    test('같은 deviceId 재등록 시 구 소켓을 close 한다 (M2)', () => {
+        const a = add('u1', 'cli', 100);
+        add('u1', 'cli', 200); // 같은 deviceId, 새 ws
+        expect((a.ws.close as jest.Mock)).toHaveBeenCalled();
+    });
+
+    test('getDeviceIdByWs 는 소켓의 deviceId 를 돌려준다 (L1 발신자 검증)', () => {
+        const a = add('u1', 'desktop', 100);
+        expect(reg.getDeviceIdByWs('u1', a.ws)).toBe('desktop');
+        expect(reg.getDeviceIdByWs('u1', fakeWs())).toBeNull();
+    });
+
+    test('handleResult 는 발신 디바이스 불일치를 무시한다 (L1)', async () => {
+        const a = add('u1', 'desktop', 100);
+        add('u1', 'cli', 200);
+        const p = reg.request('u1', { kind: 'read', path: 'x' }, 60000, 'desktop');
+        const sent = JSON.parse((a.ws.send as jest.Mock).mock.calls[0][0] as string);
+        // 다른 디바이스(cli)가 desktop 으로 라우팅된 reqId 결과를 위조 → 무시되어야 함
+        reg.handleResult('u1', sent.reqId, { ok: true, content: 'forged' }, 'cli');
+        // 올바른 디바이스(desktop)가 응답하면 정상 해소
+        reg.handleResult('u1', sent.reqId, { ok: true, content: 'real' }, 'desktop');
+        expect((await p).content).toBe('real');
     });
 
     test('한 디바이스 해제는 다른 디바이스에 영향을 주지 않는다', () => {

--- a/apps/api/src/services/local-bridge/registry.ts
+++ b/apps/api/src/services/local-bridge/registry.ts
@@ -105,6 +105,8 @@ class LocalBridgeRegistry {
         if (prev && prev.ws !== session.ws) {
             logger.info(`[Bridge] 동일 디바이스 재등록 대체: user=${session.userId} ${prev.label} → ${session.label}`);
             this.rejectPendingFor(session.userId, session.deviceId, '디바이스가 재연결되어 세션이 대체되었습니다');
+            // 구 소켓을 능동 종료 — 방치하면 unregister 가 새 ws 만 매칭해 구 ws 는 유휴로 남는다.
+            try { prev.ws.close(1000, 'device_reregistered'); } catch { /* already closing */ }
         }
         byDevice.set(session.deviceId, session);
         logger.info(`[Bridge] 디바이스 등록: user=${session.userId} device=${session.deviceId} label="${session.label}" folder="${session.folderName}" (${byDevice.size}대)`);
@@ -171,12 +173,28 @@ class LocalBridgeRegistry {
         });
     }
 
-    /** bridge_result 수신 — reqId 상관관계 해소. 소유 userId 불일치는 무시(교차 주입 차단). */
-    handleResult(userId: string, reqId: string, result: BridgeResult): void {
+    /** ws 소켓에 해당하는 디바이스 id (없으면 null) — bridge_result 발신자 검증용. */
+    getDeviceIdByWs(userId: string, ws: WebSocket): string | null {
+        const byDevice = this.devices.get(userId);
+        if (!byDevice) return null;
+        for (const [deviceId, s] of byDevice) if (s.ws === ws) return deviceId;
+        return null;
+    }
+
+    /**
+     * bridge_result 수신 — reqId 상관관계 해소. 소유 userId 불일치는 무시(교차 주입 차단).
+     * senderDeviceId 지정 시 요청을 라우팅한 디바이스와 일치하는지도 검증한다(같은 유저의
+     * 다른 디바이스가 결과를 위조 주입하는 것 차단 — rejectPendingFor 의 deviceId 격리와 대칭).
+     */
+    handleResult(userId: string, reqId: string, result: BridgeResult, senderDeviceId?: string): void {
         const p = this.pending.get(reqId);
         if (!p) return; // 이미 타임아웃/해소됨
         if (p.userId !== userId) {
             logger.warn(`[Bridge] reqId 소유 불일치 무시: req=${reqId} owner=${p.userId} sender=${userId}`);
+            return;
+        }
+        if (senderDeviceId && p.deviceId && senderDeviceId !== p.deviceId) {
+            logger.warn(`[Bridge] reqId 디바이스 불일치 무시: req=${reqId} routed=${p.deviceId} sender=${senderDeviceId}`);
             return;
         }
         clearTimeout(p.timer);

--- a/apps/api/src/services/local-bridge/registry.ts
+++ b/apps/api/src/services/local-bridge/registry.ts
@@ -79,44 +79,80 @@ interface Pending {
     resolve: (r: BridgeResult) => void;
     timer: NodeJS.Timeout;
     userId: string;
+    deviceId: string;
 }
 
 class LocalBridgeRegistry {
-    /** userId → 세션 (유저당 1대 — 새 등록이 기존을 대체). */
-    private readonly devices = new Map<string, DeviceSession>();
+    /**
+     * userId → (deviceId → 세션). 유저당 여러 디바이스 병존(데스크톱+CLI, 상한 MAX_DEVICES) —
+     * 같은 deviceId 재등록은 기존 세션을 대체한다(구 1대 정책의 의미 유지).
+     */
+    private readonly devices = new Map<string, Map<string, DeviceSession>>();
     private readonly pending = new Map<string, Pending>();
 
-    register(session: DeviceSession): void {
-        const prev = this.devices.get(session.userId);
-        if (prev && prev.ws !== session.ws) {
-            logger.info(`[Bridge] 기존 디바이스 대체: user=${session.userId} ${prev.label} → ${session.label}`);
-            this.rejectPendingFor(session.userId, '다른 디바이스가 연결되어 세션이 대체되었습니다');
+    /** 등록. 디바이스 상한 초과 시 false (호출부가 오류 응답). */
+    register(session: DeviceSession): boolean {
+        let byDevice = this.devices.get(session.userId);
+        if (!byDevice) {
+            byDevice = new Map();
+            this.devices.set(session.userId, byDevice);
         }
-        this.devices.set(session.userId, session);
-        logger.info(`[Bridge] 디바이스 등록: user=${session.userId} device=${session.deviceId} label="${session.label}" folder="${session.folderName}"`);
+        const prev = byDevice.get(session.deviceId);
+        if (!prev && byDevice.size >= LOCAL_BRIDGE.MAX_DEVICES) {
+            logger.warn(`[Bridge] 디바이스 상한 초과 거부: user=${session.userId} device=${session.deviceId} (max=${LOCAL_BRIDGE.MAX_DEVICES})`);
+            return false;
+        }
+        if (prev && prev.ws !== session.ws) {
+            logger.info(`[Bridge] 동일 디바이스 재등록 대체: user=${session.userId} ${prev.label} → ${session.label}`);
+            this.rejectPendingFor(session.userId, session.deviceId, '디바이스가 재연결되어 세션이 대체되었습니다');
+        }
+        byDevice.set(session.deviceId, session);
+        logger.info(`[Bridge] 디바이스 등록: user=${session.userId} device=${session.deviceId} label="${session.label}" folder="${session.folderName}" (${byDevice.size}대)`);
+        return true;
     }
 
-    /** WS 종료 시 호출 — 이 소켓이 현재 등록 세션이면 해제 + pending 전부 reject. */
+    /** WS 종료 시 호출 — 이 소켓의 세션만 해제 + 그 디바이스의 pending 만 reject. */
     unregister(ws: WebSocket): void {
-        for (const [userId, s] of this.devices) {
-            if (s.ws === ws) {
-                this.devices.delete(userId);
-                this.rejectPendingFor(userId, '디바이스 연결이 끊어졌습니다');
-                logger.info(`[Bridge] 디바이스 해제: user=${userId} label="${s.label}"`);
-                return;
+        for (const [userId, byDevice] of this.devices) {
+            for (const [deviceId, s] of byDevice) {
+                if (s.ws === ws) {
+                    byDevice.delete(deviceId);
+                    if (byDevice.size === 0) this.devices.delete(userId);
+                    this.rejectPendingFor(userId, deviceId, '디바이스 연결이 끊어졌습니다');
+                    logger.info(`[Bridge] 디바이스 해제: user=${userId} device=${deviceId} label="${s.label}"`);
+                    return;
+                }
             }
         }
     }
 
-    getDevice(userId: string): DeviceSession | null {
-        return this.devices.get(userId) ?? null;
+    /**
+     * 디바이스 조회. deviceId 지정 시 정확 일치, 미지정(구 계약)은 가장 최근 접속 디바이스
+     * — 1대 운용이던 기존 동작과 동일하고, 다대 접속 시에도 결정적이다.
+     */
+    getDevice(userId: string, deviceId?: string): DeviceSession | null {
+        const byDevice = this.devices.get(userId);
+        if (!byDevice || byDevice.size === 0) return null;
+        if (deviceId) return byDevice.get(deviceId) ?? null;
+        let latest: DeviceSession | null = null;
+        for (const s of byDevice.values()) {
+            if (!latest || s.connectedAt > latest.connectedAt) latest = s;
+        }
+        return latest;
+    }
+
+    /** 유저의 접속 디바이스 전체 (접속 순 정렬 — status API 노출용). */
+    getDevices(userId: string): DeviceSession[] {
+        const byDevice = this.devices.get(userId);
+        if (!byDevice) return [];
+        return [...byDevice.values()].sort((a, b) => a.connectedAt - b.connectedAt);
     }
 
     /** 도구 1회 왕복. 타임아웃/연결단절 시 ok=false 결과로 해소(throw 하지 않음 — 도구 오류로 전달). */
-    request(userId: string, payload: BridgeRequestPayload, timeoutMs = LOCAL_BRIDGE.REQUEST_TIMEOUT_MS): Promise<BridgeResult> {
-        const dev = this.devices.get(userId);
+    request(userId: string, payload: BridgeRequestPayload, timeoutMs = LOCAL_BRIDGE.REQUEST_TIMEOUT_MS, deviceId?: string): Promise<BridgeResult> {
+        const dev = this.getDevice(userId, deviceId);
         if (!dev || dev.ws.readyState !== dev.ws.OPEN) {
-            return Promise.resolve({ ok: false, error: '연결된 로컬 디바이스가 없습니다 — 데스크톱 앱에서 폴더를 연결하세요.' });
+            return Promise.resolve({ ok: false, error: '연결된 로컬 디바이스가 없습니다 — 데스크톱 앱 또는 CLI 로 작업 폴더를 연결하세요.' });
         }
         const reqId = randomUUID();
         return new Promise<BridgeResult>((resolve) => {
@@ -124,7 +160,7 @@ class LocalBridgeRegistry {
                 this.pending.delete(reqId);
                 resolve({ ok: false, error: `로컬 실행 응답 시간 초과 (${Math.round(timeoutMs / 1000)}s)` });
             }, timeoutMs);
-            this.pending.set(reqId, { resolve, timer, userId });
+            this.pending.set(reqId, { resolve, timer, userId, deviceId: dev.deviceId });
             try {
                 dev.ws.send(JSON.stringify({ type: 'bridge_exec', reqId, ...payload }));
             } catch (e) {
@@ -148,9 +184,9 @@ class LocalBridgeRegistry {
         p.resolve(result);
     }
 
-    private rejectPendingFor(userId: string, reason: string): void {
+    private rejectPendingFor(userId: string, deviceId: string, reason: string): void {
         for (const [reqId, p] of this.pending) {
-            if (p.userId === userId) {
+            if (p.userId === userId && p.deviceId === deviceId) {
                 clearTimeout(p.timer);
                 this.pending.delete(reqId);
                 p.resolve({ ok: false, error: reason });

--- a/apps/api/src/services/local-bridge/remote-executor.ts
+++ b/apps/api/src/services/local-bridge/remote-executor.ts
@@ -43,6 +43,8 @@ export class RemoteExecutor implements TaskExecutor {
     /** 세션 영속은 데스크톱 파티션(persist:openmake-agent)이 담당 — 서버측 상태 파일 불필요. */
     readonly browserStatePath = null;
     private readonly userId: string;
+    /** 라우팅 대상 디바이스(101, 다중 디바이스) — undefined 는 최근 접속 디바이스 폴백. */
+    private readonly deviceId?: string;
     private deviceLabel = 'local-device';
     /**
      * worktree 격리 시 연결 폴더 기준 상대경로(예: `.openmake/worktrees/<taskId>`). null 이면
@@ -52,9 +54,10 @@ export class RemoteExecutor implements TaskExecutor {
     /** worktree 작업 브랜치명 — 사용자 안내·결과 보고용. */
     private worktreeBranch: string | null = null;
 
-    constructor(taskId: string, userId: string) {
+    constructor(taskId: string, userId: string, deviceId?: string) {
         this.taskId = taskId;
         this.userId = userId;
+        this.deviceId = deviceId;
     }
 
     get label(): string { return `local:${this.deviceLabel}`; }
@@ -67,8 +70,8 @@ export class RemoteExecutor implements TaskExecutor {
      * 미연결이면 throw → 호출부 graceful degrade. worktree 실패는 throw 하지 않는다(fail-open).
      */
     async create(): Promise<void> {
-        const dev = getLocalBridgeRegistry().getDevice(this.userId);
-        if (!dev) throw new Error('연결된 로컬 디바이스가 없습니다 — 데스크톱 앱에서 작업 폴더를 먼저 연결하세요.');
+        const dev = getLocalBridgeRegistry().getDevice(this.userId, this.deviceId);
+        if (!dev) throw new Error('연결된 로컬 디바이스가 없습니다 — 데스크톱 앱 또는 CLI 로 작업 폴더를 먼저 연결하세요.');
         this.deviceLabel = `${dev.label}`;
         logger.info(`[${this.taskId}] 로컬 실행기 준비 (device=${dev.deviceId}, folder="${dev.folderName}")`);
 
@@ -85,7 +88,7 @@ export class RemoteExecutor implements TaskExecutor {
     }
 
     private req(payload: BridgeRequestPayload): Promise<BridgeResult> {
-        return getLocalBridgeRegistry().request(this.userId, payload);
+        return getLocalBridgeRegistry().request(this.userId, payload, undefined, this.deviceId);
     }
 
     /** 파일 경로를 worktree 기준으로 변환. 격리가 없으면 원래 경로 그대로. */

--- a/apps/api/src/sockets/handler.ts
+++ b/apps/api/src/sockets/handler.ts
@@ -124,8 +124,14 @@ export class WebSocketHandler {
             // CSWSH 방어: Origin 헤더 화이트리스트 검증
             // CORS는 WS upgrade에 적용되지 않으므로 서버가 직접 검증해야 한다.
             const origin = req.headers.origin;
+            // API key(omk_live_*) 인증 요청은 Origin 검증 면제 — CSWSH 는 브라우저가 쿠키를
+            // 자동 첨부하는 쿠키기반 공격이라, 헤더로 API key 를 제시하는 네이티브 클라이언트
+            // (CLI 브리지)엔 성립하지 않는다(ambient credential 부재). 쿠키 세션엔 그대로 적용.
+            const authHeader = req.headers.authorization || '';
+            const isApiKeyClient = authHeader.startsWith('Bearer omk_live_')
+                || (typeof req.headers['x-api-key'] === 'string' && (req.headers['x-api-key'] as string).startsWith('omk_live_'));
             // REST CORS 와 동일한 allowlist 정책(security/cors-policy) 사용 — '*' reflect 금지, 정확 비교.
-            if (!isOriginAllowed(origin)) {
+            if (!isApiKeyClient && !isOriginAllowed(origin)) {
                 const clientIpForLog = this.guard.getClientIp(req);
                 log.warn(`[WS] Origin 거부: origin=${origin ?? '<none>'}, ip=${clientIpForLog}`);
                 try {

--- a/apps/api/src/sockets/ws-auth.ts
+++ b/apps/api/src/sockets/ws-auth.ts
@@ -5,6 +5,8 @@
  */
 import { IncomingMessage } from 'http';
 import { verifyToken } from '../auth';
+import { hashApiKey, isValidApiKeyFormat, API_KEY_PREFIX } from '../auth/api-key-utils';
+import { getUnifiedDatabase } from '../data/models/unified-database';
 import { createLogger } from '../utils/logger';
 import { isOriginAllowed } from '../security/cors-policy';
 import { AUTH_COOKIES } from '../config/security';
@@ -24,6 +26,53 @@ function tokenFingerprint(token: string): string {
         return token;
     }
     return `${token.slice(0, 6)}...${token.slice(-6)}`;
+}
+
+const GUEST_RESULT: WebSocketAuthResult = {
+    userId: null,
+    userRole: 'guest',
+    tokenExpiresAtMs: null,
+    tokenIssuedAtMs: null,
+    tokenJti: null,
+    tokenFingerprint: null,
+    authMethod: 'none',
+};
+
+/**
+ * API key(omk_live_*) 로 WS 인증 — CLI 브리지 상주 연결용 (2026-08-21).
+ * JWT(15분)와 달리 만료 없이 유지되므로, 하트비트의 토큰 만료 종료 대상이 아니다
+ * (tokenExpiresAtMs = 키의 expires_at 또는 null). 검증 축은 REST requireApiKey 와 동일
+ * (해시 조회 + is_active + expires_at).
+ */
+async function resolveAuthFromApiKey(
+    plainKey: string,
+    logger: ReturnType<typeof createLogger>,
+): Promise<WebSocketAuthResult> {
+    if (!isValidApiKeyFormat(plainKey)) return { ...GUEST_RESULT };
+    try {
+        const db = getUnifiedDatabase();
+        const key = await db.getApiKeyByHash(hashApiKey(plainKey));
+        if (!key || !key.is_active) return { ...GUEST_RESULT };
+        if (key.expires_at && new Date(key.expires_at) < new Date()) {
+            logger.warn('[WS] 만료된 API key 연결 시도 차단');
+            return { ...GUEST_RESULT };
+        }
+        const user = await db.getUserById(key.user_id);
+        if (!user || !user.is_active) return { ...GUEST_RESULT };
+        logger.info(`[WS] API key 인증 연결: userId=${user.id}`);
+        return {
+            userId: String(user.id),
+            userRole: (user.role as 'admin' | 'user' | 'guest') || 'user',
+            tokenExpiresAtMs: key.expires_at ? new Date(key.expires_at).getTime() : null,
+            tokenIssuedAtMs: null,
+            tokenJti: null,
+            tokenFingerprint: tokenFingerprint(plainKey),
+            authMethod: 'bearer',
+        };
+    } catch (e) {
+        logger.warn('[WS] API key 인증 실패:', e);
+        return { ...GUEST_RESULT };
+    }
 }
 
 async function resolveAuthFromToken(
@@ -96,6 +145,10 @@ export async function authenticateWebSocket(
         const headerToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null;
 
         const token = cookieToken || headerToken;
+        // API key (CLI 브리지) — JWT 검증 전에 접두사로 분기 (JWT 형식이 아니므로).
+        if (token && token.startsWith(API_KEY_PREFIX)) {
+            return await resolveAuthFromApiKey(token, logger);
+        }
         if (token) {
             const authMethod: 'cookie' | 'bearer' = cookieToken ? 'cookie' : 'bearer';
             const authResult = await resolveAuthFromToken(token, logger, authMethod);

--- a/apps/api/src/sockets/ws-bridge-handler.ts
+++ b/apps/api/src/sockets/ws-bridge-handler.ts
@@ -26,7 +26,11 @@ export async function handleBridgeMessage(ws: WebSocket, msg: WSMessage): Promis
         const deviceId = typeof msg.deviceId === 'string' && msg.deviceId.trim() ? msg.deviceId.trim().slice(0, 64) : 'unknown';
         const label = typeof msg.label === 'string' && msg.label.trim() ? msg.label.trim().slice(0, 120) : deviceId;
         const folderName = typeof msg.folderName === 'string' ? msg.folderName.trim().slice(0, 200) : '';
-        registry.register({ userId, deviceId, label, folderName, ws, connectedAt: Date.now() });
+        const ok = registry.register({ userId, deviceId, label, folderName, ws, connectedAt: Date.now() });
+        if (!ok) {
+            ws.send(JSON.stringify({ type: 'error', message: `브리지 디바이스 상한(${LOCAL_BRIDGE.MAX_DEVICES}대)을 초과했습니다 — 다른 디바이스 연결을 해제하세요` }));
+            return;
+        }
         ws.send(JSON.stringify({ type: 'bridge_ready', deviceId }));
         return;
     }

--- a/apps/api/src/sockets/ws-bridge-handler.ts
+++ b/apps/api/src/sockets/ws-bridge-handler.ts
@@ -29,13 +29,17 @@ export async function handleBridgeMessage(ws: WebSocket, msg: WSMessage): Promis
         const ok = registry.register({ userId, deviceId, label, folderName, ws, connectedAt: Date.now() });
         if (!ok) {
             ws.send(JSON.stringify({ type: 'error', message: `브리지 디바이스 상한(${LOCAL_BRIDGE.MAX_DEVICES}대)을 초과했습니다 — 다른 디바이스 연결을 해제하세요` }));
+            // 미등록 소켓을 열어두면 좀비로 남아 MAX_CONNECTIONS_PER_USER 만 갉아먹는다 — 명시 종료.
+            try { ws.close(1008, 'bridge_device_limit'); } catch { /* already closing */ }
             return;
         }
         ws.send(JSON.stringify({ type: 'bridge_ready', deviceId }));
         return;
     }
-    // bridge_result — reqId 상관관계 해소 (소유 검증은 레지스트리가 수행)
+    // bridge_result — reqId 상관관계 해소 (소유 검증은 레지스트리가 수행). 발신 소켓의
+    // deviceId 를 함께 넘겨 요청을 라우팅한 디바이스와 일치하는지 검증(교차 디바이스 주입 차단).
     if (typeof msg.reqId === 'string' && msg.result && typeof msg.result === 'object') {
-        registry.handleResult(userId, msg.reqId, msg.result as unknown as BridgeResult);
+        const senderDeviceId = registry.getDeviceIdByWs(userId, ws) ?? undefined;
+        registry.handleResult(userId, msg.reqId, msg.result as unknown as BridgeResult, senderDeviceId);
     }
 }

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -25,7 +25,7 @@ import { ArtifactStreamParser, type ArtifactInfo } from '../llm/artifact-parser'
 import { buildFileContext, buildUrlContext, getCachedAttachContext, appendCachedAttachContext } from '../services/chat-service/attach-context';
 import type { PdfVisionResult } from '../services/chat-service/pdf-vision';
 import { hasScriptMixing } from '../services/chat-service/script-purity';
-import { citationMarkersWereCleaned } from '../services/chat-service/external-deterministic-append';
+import { citationMarkersWereCleaned, mapHtmlWasCleaned } from '../services/chat-service/external-deterministic-append';
 import { saveAssistantMessage } from '../chat/request-persistence';
 import { buildWebSearchContext } from '../mcp/web-search/build-search-context';
 
@@ -430,11 +430,14 @@ export async function handleChatMessage(
         // 그 차이가 있을 때만 정확히 겨냥해 reset 한다(그 외 턴은 기존대로 undefined).
         // 죽은 인용 마커 제거(external-deterministic-append)가 적용된 턴도 동일 패턴으로 교체 —
         // 스트리밍 화면에 남은 [출처 N](수집 목록 밖 번호) 마커를 완료 시점에 정리한다.
+        // 지도 환각 HTML 제거(stripHallucinatedMapHtml)가 적용된 턴도 동일 — 화면에 코드
+        // 텍스트로 노출된 가짜 카카오 이미지 링크를 완료 시점에 정리한다.
         const cleanedContent = (result.artifacts && result.artifacts.length > 0)
             ? result.response
             : (result.response
                 && ((hasScriptMixing(partialAssistantResponse) && !hasScriptMixing(result.response))
-                    || citationMarkersWereCleaned(partialAssistantResponse, result.response))
+                    || citationMarkersWereCleaned(partialAssistantResponse, result.response)
+                    || mapHtmlWasCleaned(partialAssistantResponse, result.response))
                 ? result.response
                 : undefined);
         ws.send(JSON.stringify({

--- a/apps/api/src/utils/__tests__/bot-challenge-detect.test.ts
+++ b/apps/api/src/utils/__tests__/bot-challenge-detect.test.ts
@@ -1,0 +1,20 @@
+/**
+ * 봇 챌린지 페이지 판별 — isBotChallengeResult.
+ * fetch/Playwright 가 Cloudflare 챌린지("Just a moment...")를 정상 본문으로
+ * 반환하던 갭의 판별 로직 검증 (2026-08-20, 임퍼소네이션 폴백 트리거).
+ */
+import { isBotChallengeResult } from '../web-scraper';
+
+describe('isBotChallengeResult', () => {
+    test('Cloudflare 챌린지 제목은 참', () => {
+        expect(isBotChallengeResult({ title: 'Just a moment...' })).toBe(true);
+        expect(isBotChallengeResult({ title: 'Attention Required! | Cloudflare' })).toBe(true);
+        expect(isBotChallengeResult({ title: 'Access denied' })).toBe(true);
+    });
+
+    test('일반 문서 제목은 거짓', () => {
+        expect(isBotChallengeResult({ title: '로컬 LLM 활용기 - Ai 언어모델 채널' })).toBe(false);
+        expect(isBotChallengeResult({ title: '' })).toBe(false);
+        expect(isBotChallengeResult({ title: undefined as unknown as string })).toBe(false);
+    });
+});

--- a/apps/api/src/utils/__tests__/chatgpt-share-handler.test.ts
+++ b/apps/api/src/utils/__tests__/chatgpt-share-handler.test.ts
@@ -1,0 +1,74 @@
+/**
+ * ChatGPT 공유 대화 구조화 핸들러 — hydrateTurboStream / parseChatGptShareHtml.
+ * 공유 페이지는 SPA 셸이라 Readability 본문이 0 — 인라인 turbo-stream 그래프에서
+ * 대화를 복원하는 0단계 핸들러 검증 (2026-08-20 도입).
+ */
+import { hydrateTurboStream, parseChatGptShareHtml } from '../web-scraper-handlers';
+
+/** 실페이지 인코딩과 동형의 최소 픽스처 그래프를 구성한다. */
+function buildFixtureValues(): unknown[] {
+    const V: unknown[] = [null]; // 0 = root (마지막에 채움)
+    const add = (v: unknown) => { V.push(v); return V.length - 1; };
+    const kRole = add('role');
+    const kAuthor = add('author');
+    const kContentType = add('content_type');
+    const kParts = add('parts');
+    const kContent = add('content');
+    const kMessage = add('message');
+    const mkNode = (roleStr: string, contentType: string, textStr: string) => {
+        const author = add({ [`_${kRole}`]: add(roleStr) });
+        const content = add({
+            [`_${kContentType}`]: add(contentType),
+            [`_${kParts}`]: add([add(textStr)]),
+        });
+        return add({ [`_${kMessage}`]: add({ [`_${kAuthor}`]: author, [`_${kContent}`]: content }) });
+    };
+    const linear = add([
+        mkNode('system', 'text', '시스템 프롬프트'),
+        mkNode('user', 'text', '질문입니다'),
+        mkNode('assistant', 'thoughts', '내부 사고'),
+        mkNode('assistant', 'text', '답변입니다'),
+    ]);
+    const data = add({ [`_${add('title')}`]: add('공유 테스트'), [`_${add('linear_conversation')}`]: linear });
+    V[0] = { [`_${add('loaderData')}`]: data };
+    return V;
+}
+
+function fixtureHtml(): string {
+    const payload = JSON.stringify(JSON.stringify(buildFixtureValues()));
+    return `<html><body><script>window.__reactRouterContext.streamController.enqueue(${payload});</script></body></html>`;
+}
+
+describe('hydrateTurboStream', () => {
+    test('객체 키(_K)·배열·참조 인덱스를 복원한다', () => {
+        const values = ['안 씀', 'k', { _1: 3 }, [4], 'v'];
+        expect(hydrateTurboStream(values, 2)).toEqual({ k: ['v'] });
+    });
+
+    test('음수 인덱스(특수값)는 null 로 강등한다', () => {
+        expect(hydrateTurboStream(['k', { _0: -5 }], 1)).toEqual({ k: null });
+    });
+});
+
+describe('parseChatGptShareHtml', () => {
+    test('user/assistant text 턴만 순서대로 markdown 으로 추출한다', () => {
+        const r = parseChatGptShareHtml(fixtureHtml());
+        expect(r).not.toBeNull();
+        expect(r!.title).toBe('공유 테스트');
+        expect(r!.markdown).toContain('# 공유 테스트');
+        expect(r!.markdown).toContain('**사용자:**\n\n질문입니다');
+        expect(r!.markdown).toContain('**ChatGPT:**\n\n답변입니다');
+        expect(r!.markdown).not.toContain('시스템 프롬프트'); // system 제외
+        expect(r!.markdown).not.toContain('내부 사고'); // thoughts 채널 제외
+        expect(r!.markdown.indexOf('질문입니다')).toBeLessThan(r!.markdown.indexOf('답변입니다'));
+    });
+
+    test('스트림 청크가 없는 일반 HTML 은 null (fallback 단계로 진행)', () => {
+        expect(parseChatGptShareHtml('<html><body><p>hello</p></body></html>')).toBeNull();
+    });
+
+    test('청크가 있어도 대화 데이터가 없으면 null', () => {
+        const html = `<script>streamController.enqueue(${JSON.stringify(JSON.stringify([{ _1: 2 }, 'k', 'v']))})</script>`;
+        expect(parseChatGptShareHtml(html)).toBeNull();
+    });
+});

--- a/apps/api/src/utils/impersonate-fetch.ts
+++ b/apps/api/src/utils/impersonate-fetch.ts
@@ -48,16 +48,19 @@ const PY_SCRIPT = `
 import sys, json
 data = json.load(sys.stdin)
 try:
-    from curl_cffi import requests
+    from curl_cffi import requests, CurlOpt
 except Exception:
     print(json.dumps({"error": "curl_cffi_not_installed"})); sys.exit(0)
 try:
-    r = requests.get(
+    s = requests.Session()
+    # 검증한 IP 로만 연결 (DNS rebinding 차단) — requests API 의 resolve kwarg 는
+    # 어떤 curl_cffi 버전에도 없음(0.16 실측 TypeError) → 저수준 CurlOpt.RESOLVE 사용
+    s.curl.setopt(CurlOpt.RESOLVE, [data["resolve"].encode()])
+    r = s.get(
         data["url"],
         impersonate=data["target"],
         allow_redirects=False,
         timeout=data["timeout"],
-        resolve=[data["resolve"]],
         headers={"Accept-Language": "en-US,en;q=0.9"},
     )
     body = r.text

--- a/apps/api/src/utils/web-scraper-handlers.ts
+++ b/apps/api/src/utils/web-scraper-handlers.ts
@@ -83,6 +83,104 @@ async function hnHandler(url: string): Promise<ScrapeResult | null> {
 }
 
 // ============================================
+// ChatGPT 공유 대화 핸들러
+// ============================================
+
+/**
+ * react-router turbo-stream flat graph 를 복원한다 — 값 배열에서 정수는 다른 인덱스 참조,
+ * 객체 키 `_K`는 키 문자열 인덱스. 음수 인덱스(undefined/NaN 등 특수값)는 null 로 강등.
+ * ChatGPT 공유 페이지가 대화 데이터를 이 인코딩의 인라인 스크립트로 임베드한다 (SSR 본문 없음).
+ */
+export function hydrateTurboStream(values: unknown[], idx: unknown, depth = 0): unknown {
+    if (typeof idx !== 'number' || !Number.isInteger(idx)) return idx;
+    if (idx < 0 || idx >= values.length || depth > 64) return null;
+    const v = values[idx];
+    if (Array.isArray(v)) return v.map((x) => hydrateTurboStream(values, x, depth + 1));
+    if (v && typeof v === 'object') {
+        const out: Record<string, unknown> = {};
+        for (const [k, vi] of Object.entries(v)) {
+            if (!k.startsWith('_')) continue;
+            const key = values[Number(k.slice(1))];
+            if (typeof key === 'string') out[key] = hydrateTurboStream(values, vi, depth + 1);
+        }
+        return out;
+    }
+    return v;
+}
+
+interface ChatGptShareNode {
+    message?: {
+        author?: { role?: string };
+        content?: { content_type?: string; parts?: unknown[] };
+    };
+}
+
+/** 복원된 그래프에서 대화 데이터(title + linear_conversation/mapping 보유 객체)를 깊이 탐색. */
+function findConversationData(o: unknown, depth = 0): Record<string, unknown> | null {
+    if (!o || typeof o !== 'object' || depth > 12) return null;
+    const rec = o as Record<string, unknown>;
+    if (!Array.isArray(o) && typeof rec.title === 'string'
+        && (Array.isArray(rec.linear_conversation) || (rec.mapping && typeof rec.mapping === 'object'))) {
+        return rec;
+    }
+    for (const v of Array.isArray(o) ? o : Object.values(rec)) {
+        const found = findConversationData(v, depth + 1);
+        if (found) return found;
+    }
+    return null;
+}
+
+/**
+ * ChatGPT 공유 페이지 HTML 에서 대화를 markdown 으로 추출한다. 대화가 안 보이면 null —
+ * 호출부(핸들러)가 null 을 반환하면 scrapePage 는 일반 fallback 단계로 넘어간다.
+ */
+export function parseChatGptShareHtml(html: string): ScrapeResult | null {
+    // 인라인 스크립트의 streamController.enqueue("...") 중 가장 큰 청크가 초기 그래프.
+    const chunks = [...html.matchAll(/streamController\.enqueue\(("(?:[^"\\]|\\.)*")\)/g)]
+        .map((m) => m[1]).sort((a, b) => b.length - a.length);
+    if (chunks.length === 0) return null;
+    let values: unknown;
+    try {
+        values = JSON.parse(JSON.parse(chunks[0]) as string); // JS 문자열 리터럴 → JSON 배열
+    } catch {
+        return null;
+    }
+    if (!Array.isArray(values)) return null;
+    const data = findConversationData(hydrateTurboStream(values, 0));
+    if (!data) return null;
+
+    const title = String(data.title);
+    const nodes = (Array.isArray(data.linear_conversation)
+        ? data.linear_conversation
+        : Object.values(data.mapping as Record<string, unknown>)) as ChatGptShareNode[];
+    const turns: string[] = [];
+    for (const node of nodes) {
+        const msg = node?.message;
+        if (!msg) continue;
+        const role = msg.author?.role;
+        if (role !== 'user' && role !== 'assistant') continue; // system/tool 노이즈 제외
+        if (msg.content?.content_type !== 'text') continue; // thoughts/code 등 내부 채널 제외
+        const text = (msg.content.parts ?? [])
+            .filter((p): p is string => typeof p === 'string').join('\n').trim();
+        if (!text) continue;
+        turns.push(`**${role === 'user' ? '사용자' : 'ChatGPT'}:**\n\n${text}`);
+    }
+    if (turns.length === 0) return null;
+    return {
+        markdown: `# ${title}\n\n${turns.join('\n\n---\n\n')}`,
+        title,
+        links: [],
+    };
+}
+
+/** ChatGPT 공유 대화 → 임베드 turbo-stream 데이터 파싱 (SPA 라 Readability 로는 본문 0). */
+async function chatgptShareHandler(url: string): Promise<ScrapeResult | null> {
+    const res = await safeFetch(url, { headers: browserHeaders() });
+    if (!res.ok) return null;
+    return parseChatGptShareHtml(await res.text());
+}
+
+// ============================================
 // 차단 우회 핸들러 (impersonate)
 // ============================================
 
@@ -139,6 +237,10 @@ const STRUCTURED_HANDLERS: Array<{ match: (u: URL) => boolean; handler: (url: st
     { match: (u) => /(?:^|\.)youtube\.com$/.test(u.hostname) && u.pathname === '/watch', handler: youtubeHandler },
     { match: (u) => u.hostname === 'youtu.be', handler: youtubeHandler },
     { match: (u) => u.hostname === 'news.ycombinator.com' && u.pathname === '/item', handler: hnHandler },
+    {
+        match: (u) => ['chatgpt.com', 'chat.openai.com'].includes(u.hostname) && u.pathname.startsWith('/share/'),
+        handler: chatgptShareHandler,
+    },
 ];
 
 const BLOCKED_HANDLERS: Array<{ match: (u: URL) => boolean; handler: (url: string) => Promise<ScrapeResult | null> }> = [

--- a/apps/api/src/utils/web-scraper.ts
+++ b/apps/api/src/utils/web-scraper.ts
@@ -22,6 +22,13 @@ import { createLogger } from './logger';
 import { LLM_TIMEOUTS } from '../config/timeouts';
 import { SCRAPER_CONFIG, browserHeaders } from '../config/web-scraper';
 import { resolveStructuredSource, resolveBlockedSource, tryRssFallback } from './web-scraper-handlers';
+import { impersonateFetch } from './impersonate-fetch';
+
+/** Cloudflare 등 봇 챌린지 안내 페이지 여부 — 제목 패턴 부분일치 (config 관리). */
+export function isBotChallengeResult(result: Pick<ScrapeResult, 'title'>): boolean {
+    const t = (result.title || '').toLowerCase();
+    return SCRAPER_CONFIG.BOT_CHALLENGE_TITLE_PATTERNS.some((p) => t.includes(p));
+}
 
 const logger = createLogger('WebScraper');
 
@@ -172,7 +179,9 @@ export async function scrapePage(url: string, options: ScrapeOptions = {}): Prom
     if (SCRAPER_CONFIG.CACHE_ENABLED) {
         try {
             const hit = await getKeyValueStore().get<ScrapeResult>(cacheKey);
-            if (hit && typeof hit.markdown === 'string' && hit.markdown.trim().length > 0) {
+            // 챌린지 판별 도입 전 캐시된 봇 챌린지 페이지는 히트로 인정하지 않음 (재스크랩 유도)
+            if (hit && typeof hit.markdown === 'string' && hit.markdown.trim().length > 0
+                && !isBotChallengeResult(hit)) {
                 logger.info(`[${normalized}] 스크랩 캐시 히트`);
                 return hit;
             }
@@ -228,11 +237,11 @@ async function scrapePageLive(url: string, options: ScrapeOptions = {}): Promise
     // 1단계: safeFetch + Readability
     try {
         const result = await scrapeWithFetch(url, timeoutMs, onlyMainContent, options.signal);
-        if (result.markdown.trim().length > 0) {
+        if (result.markdown.trim().length > 0 && !isBotChallengeResult(result)) {
             recordSuccess();
             return result;
         }
-        logger.info(`[${url}] safeFetch 결과 비어있음 → Playwright fallback`);
+        logger.info(`[${url}] safeFetch 결과 ${isBotChallengeResult(result) ? '봇 챌린지 페이지' : '비어있음'} → Playwright fallback`);
     } catch (error) {
         logger.warn(`[${url}] safeFetch 실패: ${error instanceof Error ? error.message : String(error)}`);
     }
@@ -245,13 +254,29 @@ async function scrapePageLive(url: string, options: ScrapeOptions = {}): Promise
     }
     try {
         const result = await scrapeWithPlaywright(url, timeoutMs, onlyMainContent);
-        if (result.markdown.trim().length > 0) {
+        if (result.markdown.trim().length > 0 && !isBotChallengeResult(result)) {
             recordSuccess();
             return result;
         }
-        logger.info(`[${url}] Playwright 결과 비어있음 → RSS 폴백`);
+        logger.info(`[${url}] Playwright 결과 ${isBotChallengeResult(result) ? '봇 챌린지 페이지' : '비어있음'} → 임퍼소네이션/RSS 폴백`);
     } catch (error) {
         logger.warn(`[${url}] Playwright 실패: ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    // 2b단계: TLS 임퍼소네이션 폴백 (curl_cffi) — Cloudflare 류 챌린지로 fetch/Playwright 가
+    // 막힌 사이트용. 플래그 OFF·비화이트리스트 도메인이면 impersonateFetch 가 null (graceful skip).
+    try {
+        const imp = await impersonateFetch(url);
+        if (imp && imp.status === 200) {
+            const result = parseHtmlToMarkdown(imp.body, url, onlyMainContent);
+            if (result.markdown.trim().length > 0 && !isBotChallengeResult(result)) {
+                logger.info(`[${url}] 임퍼소네이션 폴백 성공 (${result.markdown.length}자)`);
+                recordSuccess();
+                return result;
+            }
+        }
+    } catch (error) {
+        logger.warn(`[${url}] 임퍼소네이션 폴백 실패: ${error instanceof Error ? error.message : String(error)}`);
     }
 
     // 3단계: RSS 폴백 (본문 추출 전부 실패/빈 결과)
@@ -266,7 +291,7 @@ async function scrapePageLive(url: string, options: ScrapeOptions = {}): Promise
     }
 
     recordFailure();
-    throw new Error(`스크래핑 실패 (${url}): 모든 단계(구조화·차단우회·fetch·playwright·rss) 실패`);
+    throw new Error(`스크래핑 실패 (${url}): 모든 단계(구조화·차단우회·fetch·playwright·임퍼소네이션·rss) 실패`);
 }
 
 // ============================================

--- a/apps/cli/.gitignore
+++ b/apps/cli/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "@openmake/cli",
+    "version": "0.1.0",
+    "private": true,
+    "description": "OpenMake Code — 로컬 브리지 CLI (에이전트 작업 로컬 실행 클라이언트)",
+    "main": "dist/index.js",
+    "bin": {
+        "openmake-code": "dist/index.js"
+    },
+    "scripts": {
+        "build": "tsc -p tsconfig.json",
+        "start": "node dist/index.js"
+    },
+    "dependencies": {
+        "ws": "^8.18.3"
+    },
+    "devDependencies": {
+        "@types/ws": "^8.5.12"
+    }
+}

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -1,0 +1,68 @@
+/**
+ * OpenMake Code CLI — REST API 클라이언트 (에이전트 작업 생성·폴링·승인).
+ * API key(omk_live_*) 를 X-API-Key 헤더로 인증한다. Node18+ 내장 fetch 사용.
+ */
+export interface ApiTask {
+    id: string;
+    status: string;
+    progress?: number;
+    result?: string;
+    error?: string;
+    executor?: string;
+    device_id?: string;
+}
+
+export interface PendingApproval {
+    approvalId: string;
+    taskId: string;
+    toolName: string;
+    args?: unknown;
+    kind?: string;
+    question?: string;
+}
+
+export class ApiClient {
+    constructor(private readonly serverUrl: string, private readonly apiKey: string) {}
+
+    private async req<T>(method: string, path: string, body?: unknown): Promise<T> {
+        const res = await fetch(`${this.serverUrl}${path}`, {
+            method,
+            headers: {
+                'X-API-Key': this.apiKey,
+                ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+            },
+            body: body !== undefined ? JSON.stringify(body) : undefined,
+        });
+        const text = await res.text();
+        let json: unknown = null;
+        try { json = text ? JSON.parse(text) : null; } catch { /* non-json */ }
+        if (!res.ok) {
+            const msg = (json as { error?: { message?: string } } | null)?.error?.message || text || `HTTP ${res.status}`;
+            throw new Error(msg);
+        }
+        return (json as { data?: T })?.data ?? (json as T);
+    }
+
+    createTask(goal: string, deviceId: string): Promise<{ task: ApiTask }> {
+        return this.req('POST', '/api/agent-tasks', { goal, executor: 'local', deviceId });
+    }
+    getTask(taskId: string): Promise<{ task?: ApiTask } | ApiTask> {
+        return this.req('GET', `/api/agent-tasks/${taskId}`);
+    }
+    executeTask(taskId: string): Promise<unknown> {
+        return this.req('POST', `/api/agent-tasks/${taskId}/execute`, {});
+    }
+    /** 작업 단위 서버 승인 자동화 (데스크톱 일괄 승인과 동등) — 헤드리스/CI 실행용. */
+    setAutoApprove(taskId: string, enabled: boolean): Promise<unknown> {
+        return this.req('POST', `/api/agent-tasks/${taskId}/approvals/auto-approve`, { enabled });
+    }
+    listPending(): Promise<{ pending: PendingApproval[] }> {
+        return this.req('GET', '/api/agent-tasks/approvals/pending');
+    }
+    answerApproval(approvalId: string, decision: 'approve' | 'reject'): Promise<unknown> {
+        return this.req('POST', `/api/agent-tasks/approvals/${approvalId}/${decision}`);
+    }
+    bridgeStatus(): Promise<{ enabled: boolean; connected: boolean; devices?: { deviceId: string; label: string; folderName: string }[] }> {
+        return this.req('GET', '/api/local-bridge/status');
+    }
+}

--- a/apps/cli/src/bridge.ts
+++ b/apps/cli/src/bridge.ts
@@ -1,0 +1,376 @@
+/**
+ * OpenMake Code CLI 브리지 — 서버 로컬 브리지 프로토콜의 CLI 클라이언트.
+ *
+ * apps/desktop/bridge.js 의 호스트 비의존 코어(프로토콜·경로 스코프·exec 3단 방어·worktree
+ * 격리)를 이식하고, Electron 의존부(session 쿠키·dialog·agent-browser)만 CLI 어댑터로 대체한다:
+ *   - 인증: 세션 쿠키 → API key(omk_live_*) 헤더
+ *   - confirmExec: dialog.showMessageBox → 터미널 y/N/a 프롬프트
+ *   - browser: 미지원(서버가 LOCAL_BRIDGE_BROWSER_ENABLED 로 게이트하므로 진입 안 함)
+ *
+ * 보안 불변식(데스크톱과 동일): 고정 kind 화이트리스트만, 파일 경로 realpath 스코프,
+ * exec = DENYLIST hard-block → confirmExec → sandbox-exec(macOS), worktree 는 서버 op 만 받아
+ * 디바이스가 git 인자를 고정 조립(명령 주입 차단).
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFile, execFileSync } from 'child_process';
+import WebSocket from 'ws';
+import { deviceId } from './config';
+
+const EXEC_TIMEOUT_MS = 120000;
+const MAX_BUFFER = 1024 * 1024;
+const RECONNECT_MS = 10000;
+const PATH_PROBE_TIMEOUT_MS = 5000;
+const SANDBOX_BIN = '/usr/bin/sandbox-exec';
+const SANDBOX_ENABLED = process.platform === 'darwin' && process.env.OMK_BRIDGE_SANDBOX !== '0';
+const CACHE_SUBPATHS = ['.npm', '.cache', 'Library/Caches', '.cargo', '.gradle', '.m2', '.yarn', '.pnpm-store', 'go/pkg'];
+const SECRET_SUBPATHS = ['.ssh', '.aws', '.gnupg', '.kube', '.docker', '.config/gcloud', 'Library/Keychains'];
+const WORKTREE_DIR = '.openmake/worktrees';
+const WORKTREE_BRANCH_PREFIX = 'omk-task/';
+const TASK_ID_RE = /^[a-zA-Z0-9-]{8,64}$/;
+
+const EXEC_DENYLIST: { re: RegExp; why: string }[] = [
+    { re: /(^|[;&|(]|\s)sudo\s/, why: '권한 상승(sudo)' },
+    { re: /(^|[;&|(]|\s)doas\s/, why: '권한 상승(doas)' },
+    { re: /(curl|wget)\s[^|]*\|\s*(sh|bash|zsh)\b/, why: '원격 스크립트 직접 실행(pipe-to-shell)' },
+    { re: /\|\s*(sh|bash|zsh)\b/, why: '파이프-투-셸 실행' },
+    { re: /\brm\s+-\w*\s+(\/|~|\$HOME|\$\{HOME\})(\s|$)/, why: '홈/루트 대량 삭제' },
+    { re: /\.ssh(\/|\b)/, why: 'SSH 키 디렉토리 접근' },
+    { re: /id_rsa|id_ed25519|\.aws\/credentials|\.config\/gcloud/, why: '자격증명 파일 접근' },
+    { re: /:\s*\(\s*\)\s*\{/, why: 'fork bomb' },
+    { re: /\bdd\s+if=|\bmkfs\b|>\s*\/dev\/(disk|sd|rdisk)/, why: '디스크 파괴 연산' },
+];
+function matchDenylist(cmd: string): string | null {
+    for (const d of EXEC_DENYLIST) if (d.re.test(String(cmd))) return d.why;
+    return null;
+}
+
+interface BridgeMsg {
+    type?: string;
+    kind?: string;
+    reqId?: string;
+    command?: string;
+    path?: string;
+    contentB64?: string;
+    op?: string;
+    taskId?: string;
+    spec?: unknown;
+    message?: string;
+}
+interface BridgeResult {
+    ok: boolean;
+    stdout?: string;
+    stderr?: string;
+    exitCode?: number;
+    content?: string;
+    entries?: string[];
+    error?: string;
+    durationMs?: number;
+    worktreeRel?: string;
+    branch?: string;
+    kept?: boolean;
+}
+
+/** confirmExec 어댑터 — 터미널에서 y(실행)/a(작업 동안 모두)/n(거부). 비대화형은 자동 거부(fail-safe). */
+export type ConfirmFn = (command: string, taskId: string | undefined, folderRoot: string) => Promise<'yes' | 'all' | 'no'>;
+
+export interface BridgeOptions {
+    serverUrl: string;
+    apiKey: string;
+    folders: string[];
+    confirm: ConfirmFn;
+    onStatus?: (s: string) => void;
+    autoApproveAll?: boolean; // 테스트/비대화형 훅
+}
+
+export class CliBridge {
+    private ws: WebSocket | null = null;
+    private folderRoot: string;
+    private readonly folders: string[];
+    private sandboxProfilePath: string | null = null;
+    private execPathCache: string | null = null;
+    private readonly autoApproveTasks = new Set<string>();
+    private reconnectTimer: NodeJS.Timeout | null = null;
+    private closed = false;
+
+    constructor(private readonly opts: BridgeOptions) {
+        this.folders = opts.folders.map((f) => fs.realpathSync(f));
+        this.folderRoot = this.folders[0];
+    }
+
+    private status(s: string): void { this.opts.onStatus?.(s); }
+
+    // ── PATH 보강 (데스크톱 resolveExecPath 이식) ──
+    private resolveExecPath(): string {
+        if (this.execPathCache) return this.execPathCache;
+        const parts: string[] = [];
+        try {
+            parts.push(...execFileSync(process.env.SHELL || '/bin/zsh', ['-lc', 'echo -n "$PATH"'],
+                { encoding: 'utf8', timeout: PATH_PROBE_TIMEOUT_MS }).trim().split(':'));
+        } catch { /* noop */ }
+        parts.push(...(process.env.PATH || '').split(':'));
+        parts.push('/opt/homebrew/bin', '/usr/local/bin',
+            path.join(os.homedir(), '.local/bin'), path.join(os.homedir(), '.local/share/mise/shims'));
+        let base = [...new Set(parts.filter(Boolean))].join(':');
+        try {
+            const misePaths = execFileSync('mise', ['bin-paths'],
+                { encoding: 'utf8', timeout: PATH_PROBE_TIMEOUT_MS, cwd: this.folderRoot || os.homedir(), env: { ...process.env, PATH: base } })
+                .trim().split('\n').filter(Boolean);
+            base = [...new Set([...misePaths, ...base.split(':')])].join(':');
+        } catch { /* noop */ }
+        this.execPathCache = base;
+        return base;
+    }
+
+    private sbq(p: string): string { return `"${String(p).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`; }
+
+    private detectGitDir(root: string): string | null {
+        try {
+            return execFileSync('git', ['rev-parse', '--absolute-git-dir'], { cwd: root, encoding: 'utf8', timeout: 5000 }).trim() || null;
+        } catch { return null; }
+    }
+
+    private writeSandboxProfile(root: string, gitDir: string | null): string | null {
+        try {
+            const home = fs.realpathSync(os.homedir());
+            const sub = (base: string, list: string[]) => list.map((d) => `(subpath ${this.sbq(path.join(base, d))})`).join(' ');
+            const profile = [
+                '(version 1)',
+                '(allow default)',
+                '(deny file-write*)',
+                `(allow file-write* (subpath ${this.sbq(root)}))`,
+                ...(gitDir ? [`(allow file-write* (subpath ${this.sbq(gitDir)}))`] : []),
+                '(allow file-write* (subpath "/private/tmp") (subpath "/private/var/folders") (subpath "/dev"))',
+                `(allow file-write* ${sub(home, CACHE_SUBPATHS)})`,
+                `(deny file-read* ${sub(home, SECRET_SUBPATHS)})`,
+                // 훅·config deny 는 반드시 맨 끝 (SBPL last-match-wins).
+                ...(gitDir ? [`(deny file-write* (subpath ${this.sbq(path.join(gitDir, 'hooks'))}) (literal ${this.sbq(path.join(gitDir, 'config'))}))`] : []),
+                '',
+            ].join('\n');
+            const p = path.join(os.tmpdir(), `omk-cli-sandbox-${process.pid}.sb`);
+            fs.writeFileSync(p, profile);
+            return p;
+        } catch { return null; }
+    }
+
+    /** 경로 스코프 가드 — 연결 폴더 밖/심링크 탈출 차단 (데스크톱 safe 이식). */
+    private safe(rel: string | undefined): string {
+        const abs = path.resolve(this.folderRoot, rel || '.');
+        if (abs !== this.folderRoot && !abs.startsWith(this.folderRoot + path.sep)) throw new Error(`폴더 스코프 밖 경로 거부: ${rel}`);
+        let probe = abs;
+        while (!fs.existsSync(probe)) probe = path.dirname(probe);
+        const real = fs.realpathSync(probe);
+        if (real !== this.folderRoot && !real.startsWith(this.folderRoot + path.sep)) throw new Error(`심링크 스코프 탈출 거부: ${rel}`);
+        return abs;
+    }
+
+    // ── worktree (데스크톱 이식) ──
+    private git(args: string[], cwd: string): Promise<{ code: number; stdout: string; stderr: string }> {
+        return new Promise((resolve) => {
+            execFile('git', args, { cwd, timeout: EXEC_TIMEOUT_MS, maxBuffer: MAX_BUFFER }, (err, stdout, stderr) => {
+                resolve({ code: err ? ((err as NodeJS.ErrnoException & { code?: number }).code ?? 1) : 0, stdout: String(stdout), stderr: String(stderr) });
+            });
+        });
+    }
+    private async isGitRepo(): Promise<boolean> {
+        const r = await this.git(['rev-parse', '--is-inside-work-tree'], this.folderRoot);
+        return r.code === 0 && r.stdout.trim() === 'true';
+    }
+    private excludeWorktreeDir(gitDir: string): void {
+        try {
+            const infoDir = path.join(gitDir, 'info');
+            fs.mkdirSync(infoDir, { recursive: true });
+            const p = path.join(infoDir, 'exclude');
+            const cur = fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : '';
+            if (!cur.split('\n').some((l) => l.trim() === '.openmake/')) {
+                fs.appendFileSync(p, `${cur.endsWith('\n') || cur === '' ? '' : '\n'}.openmake/\n`);
+            }
+        } catch { /* noop */ }
+    }
+    private async worktreeMetaDir(wtAbs: string): Promise<string | null> {
+        const r = await this.git(['rev-parse', '--absolute-git-dir'], wtAbs);
+        return r.code === 0 ? r.stdout.trim() : null;
+    }
+    private async writeBaseSha(wtAbs: string): Promise<void> {
+        try {
+            const meta = await this.worktreeMetaDir(wtAbs);
+            const head = await this.git(['rev-parse', 'HEAD'], wtAbs);
+            if (meta && head.code === 0) fs.writeFileSync(path.join(meta, 'omk-base'), head.stdout.trim());
+        } catch { /* noop */ }
+    }
+    private async readBaseSha(wtAbs: string): Promise<string> {
+        try {
+            const meta = await this.worktreeMetaDir(wtAbs);
+            const p = meta && path.join(meta, 'omk-base');
+            if (p && fs.existsSync(p)) {
+                const sha = fs.readFileSync(p, 'utf8').trim();
+                if (/^[0-9a-f]{7,40}$/.test(sha)) return sha;
+            }
+        } catch { /* noop */ }
+        return 'HEAD';
+    }
+    private async handleWorktree(m: BridgeMsg, done: (r: BridgeResult) => void): Promise<void> {
+        const taskId = String(m.taskId || '');
+        if (!TASK_ID_RE.test(taskId)) { done({ ok: false, error: '잘못된 taskId 형식' }); return; }
+        const rel = `${WORKTREE_DIR}/${taskId}`;
+        const abs = path.join(this.folderRoot, rel);
+        const branch = `${WORKTREE_BRANCH_PREFIX}${taskId.slice(0, 8)}`;
+        if (m.op === 'add') {
+            if (!(await this.isGitRepo())) { done({ ok: false, error: 'git 레포가 아닙니다' }); return; }
+            const prefixR = await this.git(['rev-parse', '--show-prefix'], this.folderRoot);
+            const sub = prefixR.code === 0 ? prefixR.stdout.trim().replace(/\/+$/, '') : '';
+            const workRel = sub ? `${rel}/${sub}` : rel;
+            const gitDirR = await this.git(['rev-parse', '--absolute-git-dir'], this.folderRoot);
+            if (gitDirR.code === 0) this.excludeWorktreeDir(gitDirR.stdout.trim());
+            if (fs.existsSync(abs)) { done({ ok: true, worktreeRel: workRel, branch }); return; }
+            const r = await this.git(['worktree', 'add', abs, '-b', branch], this.folderRoot);
+            if (r.code !== 0) { done({ ok: false, error: `worktree 생성 실패: ${(r.stderr || r.stdout).trim().slice(0, 300)}` }); return; }
+            await this.writeBaseSha(abs);
+            done({ ok: true, worktreeRel: workRel, branch });
+            return;
+        }
+        if (m.op === 'diff') {
+            if (!fs.existsSync(abs)) { done({ ok: false, error: 'worktree 없음' }); return; }
+            await this.git(['add', '-A', '-N', '.'], abs);
+            const r = await this.git(['diff', await this.readBaseSha(abs)], abs);
+            if (r.code !== 0) { done({ ok: false, error: `diff 실패: ${(r.stderr || '').trim().slice(0, 200)}` }); return; }
+            done({ ok: true, stdout: r.stdout, branch });
+            return;
+        }
+        if (m.op === 'remove') {
+            if (!fs.existsSync(abs)) { done({ ok: true, kept: false }); return; }
+            const st = await this.git(['status', '--porcelain'], abs);
+            const head = await this.git(['rev-parse', 'HEAD'], abs);
+            const moved = head.code === 0 && head.stdout.trim() !== (await this.readBaseSha(abs));
+            if ((st.code === 0 && st.stdout.trim() !== '') || moved) { done({ ok: true, kept: true, branch }); return; }
+            const r = await this.git(['worktree', 'remove', '--force', abs], this.folderRoot);
+            if (r.code !== 0) { done({ ok: true, kept: true, branch }); return; }
+            await this.git(['branch', '-D', branch], this.folderRoot);
+            done({ ok: true, kept: false, branch });
+            return;
+        }
+        done({ ok: false, error: `지원하지 않는 worktree op: ${m.op}` });
+    }
+
+    private walk(dir: string, base: string, out: string[]): string[] {
+        for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+            const p = path.join(dir, e.name);
+            if (e.isSymbolicLink()) continue;
+            if (e.isDirectory()) this.walk(p, base, out); else out.push(path.relative(base, p));
+            if (out.length >= 1000) return out;
+        }
+        return out;
+    }
+
+    private async confirmExec(command: string, taskId: string | undefined): Promise<boolean> {
+        if (this.opts.autoApproveAll || process.env.OMK_BRIDGE_AUTO_APPROVE === '1') return true;
+        if (taskId && this.autoApproveTasks.has(taskId)) return true;
+        const ans = await this.opts.confirm(command, taskId, this.folderRoot);
+        if (ans === 'all' && taskId) { this.autoApproveTasks.add(taskId); return true; }
+        return ans === 'yes';
+    }
+
+    private async handleExec(m: BridgeMsg, done: (r: BridgeResult) => void): Promise<void> {
+        switch (m.kind) {
+            case 'exec': {
+                const denied = matchDenylist(String(m.command || ''));
+                if (denied) { done({ ok: false, error: `위험 명령으로 차단됨: ${denied}`, exitCode: 126 }); return; }
+                if (!(await this.confirmExec(String(m.command || ''), m.taskId))) {
+                    done({ ok: false, error: '사용자가 명령 실행을 거부했습니다', exitCode: 126 }); return;
+                }
+                if (SANDBOX_ENABLED && !this.sandboxProfilePath) {
+                    done({ ok: false, error: 'exec 샌드박스 프로파일을 준비하지 못해 실행을 거부했습니다. 비격리 실행이 필요하면 OMK_BRIDGE_SANDBOX=0 으로 실행하세요.', exitCode: 126 });
+                    return;
+                }
+                const opts = { cwd: this.folderRoot, timeout: EXEC_TIMEOUT_MS, maxBuffer: MAX_BUFFER, encoding: 'utf8' as const, env: { ...process.env, PATH: this.resolveExecPath() } };
+                const cb = (err: import('child_process').ExecFileException | null, stdout: string, stderr: string) => {
+                    done({ ok: true, stdout: String(stdout), stderr: String(stderr), exitCode: err ? (typeof err.code === 'number' ? err.code : 1) : 0 });
+                };
+                if (SANDBOX_ENABLED && this.sandboxProfilePath) {
+                    execFile(SANDBOX_BIN, ['-f', this.sandboxProfilePath, '/bin/bash', '-c', String(m.command)], opts, cb);
+                } else {
+                    execFile('/bin/bash', ['-c', String(m.command)], opts, cb);
+                }
+                return;
+            }
+            case 'read': done({ ok: true, content: fs.readFileSync(this.safe(m.path), 'utf8') }); return;
+            case 'write': {
+                const abs = this.safe(m.path);
+                fs.mkdirSync(path.dirname(abs), { recursive: true });
+                fs.writeFileSync(abs, Buffer.from(m.contentB64 || '', 'base64'));
+                done({ ok: true }); return;
+            }
+            case 'list': {
+                const entries = fs.readdirSync(this.safe(m.path), { withFileTypes: true })
+                    .map((e) => (e.isDirectory() ? `${e.name}/` : e.name));
+                done({ ok: true, entries }); return;
+            }
+            case 'listAll': done({ ok: true, entries: this.walk(this.folderRoot, this.folderRoot, []) }); return;
+            case 'delete': {
+                const abs = this.safe(m.path);
+                if (abs === this.folderRoot) throw new Error('연결 폴더 루트는 삭제할 수 없습니다');
+                fs.rmSync(abs, { recursive: true, force: true });
+                done({ ok: true }); return;
+            }
+            case 'browser':
+                done({ ok: false, error: 'CLI 브리지는 로컬 브라우저를 지원하지 않습니다' }); return;
+            case 'worktree':
+                await this.handleWorktree(m, done); return;
+            case 'task_end':
+                if (m.taskId) this.autoApproveTasks.delete(m.taskId);
+                done({ ok: true }); return;
+            default: done({ ok: false, error: `지원하지 않는 kind: ${m.kind}` });
+        }
+    }
+
+    connect(): void {
+        this.closed = false;
+        this.sandboxProfilePath = SANDBOX_ENABLED ? this.writeSandboxProfile(this.folderRoot, this.detectGitDir(this.folderRoot)) : null;
+        // 데스크톱 bridge.js 와 동일 — 서버 WSS 는 { server } 라 경로 무관(패스 미부착).
+        const wsUrl = this.opts.serverUrl.replace(/^http/, 'ws');
+        try { if (this.ws) { this.ws.removeAllListeners(); this.ws.close(); } } catch { /* noop */ }
+        // 네이티브 클라이언트라 Origin 헤더를 보내지 않는다 — 인증은 API key(헤더). 서버는
+        // API key 요청에 한해 Origin 검증을 면제한다(CSWSH 는 쿠키 기반 브라우저 공격).
+        this.ws = new WebSocket(wsUrl, { headers: { Authorization: `Bearer ${this.opts.apiKey}` } });
+        this.status('연결 중…');
+        this.ws.on('open', () => setTimeout(() => {
+            // 서버가 연결을 등록하고 메시지 리스너를 부착할 때까지 대기(데스크톱 bridge.js 와 동일 300ms).
+            // 즉시 전송하면 리스너 부착 전 프레임이 유실돼 등록이 안 된다(라이브에서 확인).
+            if (!this.ws || this.ws.readyState !== this.ws.OPEN) return;
+            this.ws.send(JSON.stringify({
+                type: 'bridge_hello',
+                deviceId: deviceId(),
+                label: `${os.hostname()} · ${path.basename(this.folderRoot)}`,
+                folderName: path.basename(this.folderRoot),
+            }));
+        }, 300));
+        this.ws.on('message', (d: WebSocket.RawData) => {
+            let m: BridgeMsg;
+            try { m = JSON.parse(d.toString()) as BridgeMsg; } catch { return; }
+            if (m.type === 'bridge_ready') { this.status(`연결됨: ${path.basename(this.folderRoot)}`); return; }
+            if (m.type === 'error') { this.status(`서버 오류: ${m.message ?? ''}`); return; }
+            if (m.type !== 'bridge_exec') return;
+            const t0 = Date.now();
+            const done = (result: BridgeResult) => {
+                try { this.ws!.send(JSON.stringify({ type: 'bridge_result', reqId: m.reqId, result: { durationMs: Date.now() - t0, ...result } })); } catch { /* noop */ }
+            };
+            Promise.resolve().then(() => this.handleExec(m, done)).catch((e) => done({ ok: false, error: String((e as Error).message || e) }));
+        });
+        this.ws.on('close', () => {
+            if (this.closed) { this.status('종료'); return; }
+            this.status('끊김 — 재연결 대기');
+            if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = setTimeout(() => this.connect(), RECONNECT_MS);
+        });
+        this.ws.on('error', () => { /* close 가 후속 처리 */ });
+    }
+
+    disconnect(): void {
+        this.closed = true;
+        if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+        this.autoApproveTasks.clear();
+        try { if (this.ws) this.ws.close(); } catch { /* noop */ }
+        this.ws = null;
+    }
+}

--- a/apps/cli/src/bridge.ts
+++ b/apps/cli/src/bridge.ts
@@ -78,7 +78,8 @@ export type ConfirmFn = (command: string, taskId: string | undefined, folderRoot
 export interface BridgeOptions {
     serverUrl: string;
     apiKey: string;
-    folders: string[];
+    /** 연결 폴더(단일) — 서버는 디바이스당 폴더 하나만 지원한다. */
+    folder: string;
     confirm: ConfirmFn;
     onStatus?: (s: string) => void;
     autoApproveAll?: boolean; // 테스트/비대화형 훅
@@ -86,8 +87,7 @@ export interface BridgeOptions {
 
 export class CliBridge {
     private ws: WebSocket | null = null;
-    private folderRoot: string;
-    private readonly folders: string[];
+    private readonly folderRoot: string;
     private sandboxProfilePath: string | null = null;
     private execPathCache: string | null = null;
     private readonly autoApproveTasks = new Set<string>();
@@ -95,8 +95,7 @@ export class CliBridge {
     private closed = false;
 
     constructor(private readonly opts: BridgeOptions) {
-        this.folders = opts.folders.map((f) => fs.realpathSync(f));
-        this.folderRoot = this.folders[0];
+        this.folderRoot = fs.realpathSync(opts.folder);
     }
 
     private status(s: string): void { this.opts.onStatus?.(s); }

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -1,0 +1,45 @@
+/**
+ * OpenMake Code CLI 설정 — ~/.openmake/config.json (0600) + device-id.
+ * 서버 URL 과 API key(omk_live_*) 를 영속한다. 키는 평문 저장이므로 파일 권한으로 보호.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as crypto from 'crypto';
+
+export const CONFIG_DIR = path.join(os.homedir(), '.openmake');
+const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
+const DEVICE_ID_PATH = path.join(CONFIG_DIR, 'device-id');
+
+export interface CliConfig {
+    serverUrl: string;
+    apiKey: string;
+}
+
+export function loadConfig(): CliConfig | null {
+    try {
+        const raw = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8')) as Partial<CliConfig>;
+        if (typeof raw.serverUrl === 'string' && typeof raw.apiKey === 'string') {
+            return { serverUrl: raw.serverUrl.replace(/\/+$/, ''), apiKey: raw.apiKey };
+        }
+    } catch { /* 미설정 */ }
+    return null;
+}
+
+export function saveConfig(cfg: CliConfig): void {
+    fs.mkdirSync(CONFIG_DIR, { recursive: true });
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2), { mode: 0o600 });
+    fs.chmodSync(CONFIG_PATH, 0o600);
+}
+
+/** 호스트 고정 디바이스 id — 재실행에도 같은 디바이스로 식별된다(데스크톱 device-id 와 동일 패턴). */
+export function deviceId(): string {
+    try {
+        const id = fs.readFileSync(DEVICE_ID_PATH, 'utf8').trim();
+        if (id) return id;
+    } catch { /* 최초 생성 */ }
+    const id = crypto.randomUUID();
+    fs.mkdirSync(CONFIG_DIR, { recursive: true });
+    try { fs.writeFileSync(DEVICE_ID_PATH, id); } catch { /* noop */ }
+    return id;
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * OpenMake Code CLI — 로컬 코딩 에이전트 클라이언트.
+ *
+ * 서버 AgentTaskService 하네스가 턴을 오케스트레이션하고, 이 CLI 는 브리지 디바이스(도구 실행)
+ * + 터미널 렌더만 담당한다(자체 에이전트 루프 없음). 명령:
+ *   login                  API key·서버 URL 저장
+ *   connect [dir...]       폴더 상주 연결(데몬 전경 실행)
+ *   status                 연결 상태·디바이스 조회
+ *   "목표" [--dir .]        cwd(또는 --dir)에서 로컬 에이전트 작업 1회 실행
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as readline from 'readline';
+import { loadConfig, saveConfig, deviceId } from './config';
+import { CliBridge, type ConfirmFn } from './bridge';
+import { ApiClient, type ApiTask } from './api';
+
+function prompt(q: string): Promise<string> {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    return new Promise((resolve) => rl.question(q, (a) => { rl.close(); resolve(a.trim()); }));
+}
+
+/** 터미널 confirmExec — 대화형이면 y/a/n, 비대화형(TTY 아님)이면 자동 거부(fail-safe). */
+const terminalConfirm: ConfirmFn = async (command, taskId, folderRoot) => {
+    if (!process.stdin.isTTY) return 'no';
+    process.stdout.write(`\n\x1b[33m⚠ 에이전트가 셸 명령을 실행하려 합니다\x1b[0m (폴더: ${folderRoot})\n  ${command.slice(0, 800)}\n`);
+    const opt = taskId ? 'y=실행 / a=이 작업 동안 모두 / n=거부' : 'y=실행 / n=거부';
+    const ans = (await prompt(`  ${opt}: `)).toLowerCase();
+    if (ans === 'a' && taskId) return 'all';
+    return ans === 'y' || ans === 'yes' ? 'yes' : 'no';
+};
+
+async function cmdLogin(): Promise<void> {
+    const existing = loadConfig();
+    const serverUrl = (await prompt(`서버 URL [${existing?.serverUrl ?? 'https://chat.openmake.cc'}]: `))
+        || existing?.serverUrl || 'https://chat.openmake.cc';
+    const apiKey = (await prompt('API key (omk_live_...): ')) || existing?.apiKey || '';
+    if (!apiKey.startsWith('omk_live_')) {
+        console.error('\x1b[31mAPI key 형식이 올바르지 않습니다 (omk_live_ 로 시작). 설정에서 발급하세요.\x1b[0m');
+        process.exit(1);
+    }
+    saveConfig({ serverUrl: serverUrl.replace(/\/+$/, ''), apiKey });
+    console.log(`\x1b[32m✓ 저장됨\x1b[0m (~/.openmake/config.json, device=${deviceId().slice(0, 8)}…)`);
+}
+
+function requireConfig(): { serverUrl: string; apiKey: string } {
+    const cfg = loadConfig();
+    if (!cfg) { console.error('먼저 `openmake-code login` 을 실행하세요.'); process.exit(1); }
+    return cfg;
+}
+
+async function cmdStatus(): Promise<void> {
+    const cfg = requireConfig();
+    const api = new ApiClient(cfg.serverUrl, cfg.apiKey);
+    try {
+        const s = await api.bridgeStatus();
+        console.log(`서버: ${cfg.serverUrl}`);
+        console.log(`로컬 실행 기능: ${s.enabled ? '활성' : '비활성(LOCAL_EXECUTOR_ENABLED=false)'}`);
+        console.log(`이 디바이스 id: ${deviceId()}`);
+        const devices = s.devices ?? [];
+        if (devices.length === 0) { console.log('접속 디바이스: 없음 — `openmake-code connect` 로 연결하세요.'); return; }
+        console.log('접속 디바이스:');
+        for (const d of devices) console.log(`  - ${d.label} (${d.deviceId.slice(0, 8)}…) → ${d.folderName}`);
+    } catch (e) {
+        console.error(`상태 조회 실패: ${(e as Error).message}`);
+        process.exit(1);
+    }
+}
+
+function connectBridge(cfg: { serverUrl: string; apiKey: string }, folders: string[]): CliBridge {
+    for (const f of folders) {
+        if (!fs.existsSync(f) || !fs.statSync(f).isDirectory()) {
+            console.error(`폴더가 존재하지 않습니다: ${f}`); process.exit(1);
+        }
+    }
+    const bridge = new CliBridge({
+        serverUrl: cfg.serverUrl, apiKey: cfg.apiKey, folders,
+        confirm: terminalConfirm,
+        onStatus: (s) => console.log(`\x1b[36m[bridge]\x1b[0m ${s}`),
+    });
+    bridge.connect();
+    return bridge;
+}
+
+async function cmdConnect(dirs: string[]): Promise<void> {
+    const cfg = requireConfig();
+    const folders = (dirs.length ? dirs : [process.cwd()]).map((d) => path.resolve(d));
+    connectBridge(cfg, folders);
+    console.log(`연결 폴더: ${folders.join(', ')}\n종료: Ctrl+C`);
+    process.on('SIGINT', () => { console.log('\n연결을 종료합니다.'); process.exit(0); });
+    await new Promise(() => { /* 상주 */ });
+}
+
+function taskOf(r: { task?: ApiTask } | ApiTask): ApiTask {
+    return (r as { task?: ApiTask }).task ?? (r as ApiTask);
+}
+
+async function cmdRun(goal: string, dir: string, autoApprove: boolean): Promise<void> {
+    const cfg = requireConfig();
+    const folder = path.resolve(dir);
+    const api = new ApiClient(cfg.serverUrl, cfg.apiKey);
+    // --yes 또는 비대화형(비-TTY)이면 서버 승인을 작업 단위로 자동화한다 — 그렇지 않으면
+    // 파일 쓰기류 서버 HITL 이 매번 y/N 을 요구해 헤드리스/CI 실행이 막힌다. 셸/파이썬은
+    // 별도로 디바이스 confirmExec 이 게이트하므로(OMK_BRIDGE_AUTO_APPROVE), 이 플래그는 서버측만.
+    const serverAutoApprove = autoApprove || !process.stdin.isTTY;
+    const bridge = connectBridge(cfg, [folder]);
+
+    // 브리지 등록 대기 (서버가 이 디바이스를 인지할 때까지 최대 ~10s).
+    const myId = deviceId();
+    let registered = false;
+    for (let i = 0; i < 20; i++) {
+        await new Promise((r) => setTimeout(r, 500));
+        try {
+            const s = await api.bridgeStatus();
+            if (!s.enabled) { console.error('서버에서 로컬 실행 기능이 비활성화되어 있습니다.'); bridge.disconnect(); process.exit(1); }
+            if ((s.devices ?? []).some((d) => d.deviceId === myId)) { registered = true; break; }
+        } catch { /* 재시도 */ }
+    }
+    if (!registered) { console.error('브리지 연결에 실패했습니다.'); bridge.disconnect(); process.exit(1); }
+
+    console.log(`\x1b[32m✓ 연결됨\x1b[0m — 작업을 생성합니다.`);
+    const created = taskOf(await api.createTask(goal, myId));
+    const taskId = created.id;
+    if (serverAutoApprove) {
+        await api.setAutoApprove(taskId, true);
+        console.log('\x1b[2m서버 승인 자동화 활성(--yes/비대화형) — 파일 쓰기류 HITL 자동 승인\x1b[0m');
+    }
+    await api.executeTask(taskId);
+    console.log(`\x1b[36m작업 ${taskId} 실행 중…\x1b[0m (Ctrl+C 로 CLI 종료)`);
+
+    // 진행 폴링 — 승인 대기(pending)는 터미널에서 즉시 처리, 상태는 변할 때만 출력.
+    let lastStatus = '';
+    let lastProgress = -1;
+    const seenApprovals = new Set<string>();
+    for (;;) {
+        await new Promise((r) => setTimeout(r, 2000));
+        // 이 작업의 승인 대기 처리 (confirmExec 은 브리지가 별도로 처리 — 여기선 서버 HITL 게이트).
+        try {
+            const { pending } = await api.listPending();
+            for (const p of pending.filter((p) => p.taskId === taskId && !seenApprovals.has(p.approvalId))) {
+                seenApprovals.add(p.approvalId);
+                const desc = p.question || `${p.toolName}${p.kind ? ` (${p.kind})` : ''}`;
+                const ans = process.stdin.isTTY ? (await prompt(`\n\x1b[33m승인 필요\x1b[0m: ${desc}\n  y=승인 / n=거부: `)).toLowerCase() : 'n';
+                await api.answerApproval(p.approvalId, ans === 'y' || ans === 'yes' ? 'approve' : 'reject');
+            }
+        } catch { /* 폴링 실패 무시 */ }
+
+        let task: ApiTask;
+        try { task = taskOf(await api.getTask(taskId)); } catch { continue; }
+        if (task.status !== lastStatus || (task.progress ?? 0) !== lastProgress) {
+            lastStatus = task.status;
+            lastProgress = task.progress ?? 0;
+            console.log(`  [${task.status}] ${Math.round((task.progress ?? 0))}%`);
+        }
+        if (['completed', 'failed', 'cancelled'].includes(task.status)) {
+            console.log(`\n\x1b[1m결과 (${task.status})\x1b[0m`);
+            if (task.result) console.log(task.result);
+            if (task.error) console.error(`\x1b[31m${task.error}\x1b[0m`);
+            bridge.disconnect();
+            process.exit(task.status === 'completed' ? 0 : 1);
+        }
+    }
+}
+
+async function main(): Promise<void> {
+    const argv = process.argv.slice(2);
+    const cmd = argv[0];
+    if (cmd === 'login') return cmdLogin();
+    if (cmd === 'status') return cmdStatus();
+    if (cmd === 'connect') return cmdConnect(argv.slice(1));
+    if (!cmd || cmd === 'help' || cmd === '--help' || cmd === '-h') {
+        console.log(`OpenMake Code — 로컬 코딩 에이전트 CLI
+
+사용법:
+  openmake-code login              API key·서버 URL 저장
+  openmake-code connect [dir...]   폴더 상주 연결 (웹에서 작업을 시작할 수 있게 됨)
+  openmake-code status             연결 상태·디바이스 조회
+  openmake-code "목표" [--dir .] [--yes]   로컬 에이전트 작업 1회 실행
+                                   (--yes: 파일 쓰기류 서버 승인 자동화. 셸은 별도 확인)`);
+        return;
+    }
+    // 나머지는 목표 실행 — "목표" [--dir path]
+    const dirIdx = argv.indexOf('--dir');
+    const dir = dirIdx >= 0 ? argv[dirIdx + 1] ?? '.' : '.';
+    const autoApprove = argv.includes('--yes') || argv.includes('-y');
+    const goal = argv
+        .filter((a, i) => a !== '--dir' && i !== dirIdx + 1 && a !== '--yes' && a !== '-y')
+        .join(' ').trim();
+    if (!goal) { console.error('목표를 입력하세요. `openmake-code help` 참고.'); process.exit(1); }
+    return cmdRun(goal, dir, autoApprove);
+}
+
+main().catch((e) => { console.error(`\x1b[31m오류: ${(e as Error).message}\x1b[0m`); process.exit(1); });

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -5,7 +5,7 @@
  * 서버 AgentTaskService 하네스가 턴을 오케스트레이션하고, 이 CLI 는 브리지 디바이스(도구 실행)
  * + 터미널 렌더만 담당한다(자체 에이전트 루프 없음). 명령:
  *   login                  API key·서버 URL 저장
- *   connect [dir...]       폴더 상주 연결(데몬 전경 실행)
+ *   connect [dir]          폴더 상주 연결(데몬 전경 실행, 단일 폴더)
  *   status                 연결 상태·디바이스 조회
  *   "목표" [--dir .]        cwd(또는 --dir)에서 로컬 에이전트 작업 1회 실행
  */
@@ -68,14 +68,12 @@ async function cmdStatus(): Promise<void> {
     }
 }
 
-function connectBridge(cfg: { serverUrl: string; apiKey: string }, folders: string[]): CliBridge {
-    for (const f of folders) {
-        if (!fs.existsSync(f) || !fs.statSync(f).isDirectory()) {
-            console.error(`폴더가 존재하지 않습니다: ${f}`); process.exit(1);
-        }
+function connectBridge(cfg: { serverUrl: string; apiKey: string }, folder: string): CliBridge {
+    if (!fs.existsSync(folder) || !fs.statSync(folder).isDirectory()) {
+        console.error(`폴더가 존재하지 않습니다: ${folder}`); process.exit(1);
     }
     const bridge = new CliBridge({
-        serverUrl: cfg.serverUrl, apiKey: cfg.apiKey, folders,
+        serverUrl: cfg.serverUrl, apiKey: cfg.apiKey, folder,
         confirm: terminalConfirm,
         onStatus: (s) => console.log(`\x1b[36m[bridge]\x1b[0m ${s}`),
     });
@@ -85,9 +83,15 @@ function connectBridge(cfg: { serverUrl: string; apiKey: string }, folders: stri
 
 async function cmdConnect(dirs: string[]): Promise<void> {
     const cfg = requireConfig();
-    const folders = (dirs.length ? dirs : [process.cwd()]).map((d) => path.resolve(d));
-    connectBridge(cfg, folders);
-    console.log(`연결 폴더: ${folders.join(', ')}\n종료: Ctrl+C`);
+    // 서버는 디바이스당 단일 폴더만 지원한다(다중 폴더는 후속). 여러 인자를 조용히
+    // 버리지 않고 명시적으로 거절 — 여러 폴더가 필요하면 디바이스를 여러 개 띄운다.
+    if (dirs.length > 1) {
+        console.error('폴더는 하나만 지정할 수 있습니다 — 여러 폴더는 별도 터미널에서 각각 connect 하세요.');
+        process.exit(1);
+    }
+    const folder = path.resolve(dirs[0] ?? process.cwd());
+    connectBridge(cfg, folder);
+    console.log(`연결 폴더: ${folder}\n종료: Ctrl+C`);
     process.on('SIGINT', () => { console.log('\n연결을 종료합니다.'); process.exit(0); });
     await new Promise(() => { /* 상주 */ });
 }
@@ -104,7 +108,7 @@ async function cmdRun(goal: string, dir: string, autoApprove: boolean): Promise<
     // 파일 쓰기류 서버 HITL 이 매번 y/N 을 요구해 헤드리스/CI 실행이 막힌다. 셸/파이썬은
     // 별도로 디바이스 confirmExec 이 게이트하므로(OMK_BRIDGE_AUTO_APPROVE), 이 플래그는 서버측만.
     const serverAutoApprove = autoApprove || !process.stdin.isTTY;
-    const bridge = connectBridge(cfg, [folder]);
+    const bridge = connectBridge(cfg, folder);
 
     // 브리지 등록 대기 (서버가 이 디바이스를 인지할 때까지 최대 ~10s).
     const myId = deviceId();
@@ -133,7 +137,16 @@ async function cmdRun(goal: string, dir: string, autoApprove: boolean): Promise<
     let lastStatus = '';
     let lastProgress = -1;
     const seenApprovals = new Set<string>();
+    // 안전 상한 — 서버 작업이 종료 상태로 수렴하지 않고(스톨·거부 반복 등) 무기한 폴링하는 것을
+    // 막는다. 도달 시 CLI 만 종료하며 서버 작업은 계속된다(웹/재실행으로 확인 가능).
+    const POLL_DEADLINE_MS = 60 * 60 * 1000;
+    const startedAt = Date.now();
     for (;;) {
+        if (Date.now() - startedAt > POLL_DEADLINE_MS) {
+            console.error('\n\x1b[33m폴링 상한(1시간) 도달 — CLI 를 종료합니다. 작업은 서버에서 계속되며 웹에서 확인할 수 있습니다.\x1b[0m');
+            bridge.disconnect();
+            process.exit(1);
+        }
         await new Promise((r) => setTimeout(r, 2000));
         // 이 작업의 승인 대기 처리 (confirmExec 은 브리지가 별도로 처리 — 여기선 서버 HITL 게이트).
         try {
@@ -174,7 +187,7 @@ async function main(): Promise<void> {
 
 사용법:
   openmake-code login              API key·서버 URL 저장
-  openmake-code connect [dir...]   폴더 상주 연결 (웹에서 작업을 시작할 수 있게 됨)
+  openmake-code connect [dir]      폴더 상주 연결 (웹에서 작업을 시작할 수 있게 됨)
   openmake-code status             연결 상태·디바이스 조회
   openmake-code "목표" [--dir .] [--yes]   로컬 에이전트 작업 1회 실행
                                    (--yes: 파일 쓰기류 서버 승인 자동화. 셸은 별도 확인)`);

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "outDir": "dist",
+        "rootDir": "src",
+        "strict": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "declaration": false,
+        "sourceMap": false,
+        "types": ["node"]
+    },
+    "include": ["src/**/*.ts"]
+}

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -241,8 +241,11 @@ export function Composer() {
   });
   const bridgeConnected = !!bridgeData?.data?.connected;
   const bridgeDevices = bridgeData?.data?.devices ?? [];
-  // 다중 디바이스(101): 선택 디바이스가 있으면 그 폴더를, 없으면 최근 접속 디바이스 폴더를 표시.
-  const selectedBridgeDevice = bridgeDevices.find((d) => d.deviceId === agentLocalDeviceId) ?? null;
+  // 다중 디바이스(101): 선택 디바이스가 있으면 그것, 없으면 최근 접속(마지막) 디바이스로 고정.
+  // 선택기가 안 뜨는 단일 디바이스에서도 명시 deviceId 를 작업에 실어 create↔execute 간
+  // "최근 접속" 폴백이 다른 디바이스로 튀는 것을 막는다(서버 M3 회귀 차단).
+  const selectedBridgeDevice = bridgeDevices.find((d) => d.deviceId === agentLocalDeviceId)
+    ?? bridgeDevices[bridgeDevices.length - 1] ?? null;
   const bridgeFolder = selectedBridgeDevice?.folderName ?? bridgeData?.data?.folderName ?? "";
   // 검색어 없으면("/") 카테고리 그룹핑(전체), 있으면 평면 검색 목록
   const slashGrouped = slashDebounced.trim() === "";

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -191,6 +191,7 @@ export function Composer() {
     agentTaskMode,
     agentApprovalMode,
     agentLocalExecutor,
+    agentLocalDeviceId,
     imageMode,
     artifactMode,
     structuredMode,
@@ -201,6 +202,7 @@ export function Composer() {
     setSelectedModel,
     setAgentApprovalMode,
     setAgentLocalExecutor,
+    setAgentLocalDeviceId,
     cycleStyle,
     setInputDraft,
     auth,
@@ -232,13 +234,16 @@ export function Composer() {
   // Cowork D2: 로컬 브리지(데스크톱 앱) 연결 상태 — 토글 활성 판단. 15s 갱신.
   const { data: bridgeData } = useQuery({
     queryKey: ["local-bridge-status"],
-    queryFn: () => ApiClient.get<{ data: { enabled: boolean; connected: boolean; folderName: string | null } }>("/api/local-bridge/status"),
+    queryFn: () => ApiClient.get<{ data: { enabled: boolean; connected: boolean; folderName: string | null; devices?: { deviceId: string; label: string; folderName: string; connectedAt: number }[] } }>("/api/local-bridge/status"),
     enabled: agentTaskMode,
     refetchInterval: 15_000,
     staleTime: 10_000,
   });
   const bridgeConnected = !!bridgeData?.data?.connected;
-  const bridgeFolder = bridgeData?.data?.folderName ?? "";
+  const bridgeDevices = bridgeData?.data?.devices ?? [];
+  // 다중 디바이스(101): 선택 디바이스가 있으면 그 폴더를, 없으면 최근 접속 디바이스 폴더를 표시.
+  const selectedBridgeDevice = bridgeDevices.find((d) => d.deviceId === agentLocalDeviceId) ?? null;
+  const bridgeFolder = selectedBridgeDevice?.folderName ?? bridgeData?.data?.folderName ?? "";
   // 검색어 없으면("/") 카테고리 그룹핑(전체), 있으면 평면 검색 목록
   const slashGrouped = slashDebounced.trim() === "";
   const rawSlashSkills: SkillSummary[] = slashCandidate ? slashSkillsData ?? [] : [];
@@ -328,6 +333,7 @@ export function Composer() {
         images.length ? images.map((i) => i.dataUrl) : undefined,
         agentApprovalMode,
         agentLocalExecutor || undefined,
+        agentLocalExecutor ? (selectedBridgeDevice?.deviceId ?? null) : null,
       );
     } else if (structuredMode) {
       // 구조화 답변 토글 ON — REST /api/chat/structured (비스트리밍, 카드 렌더). 첨부는 미지원.
@@ -620,6 +626,20 @@ export function Composer() {
                   ? t("localExec.on", { folder: bridgeFolder })
                   : t("localExec.off")}
             </button>
+            {/* 다중 디바이스(101): 2대 이상 접속 시 대상 디바이스 선택 — 1대면 현행 토글 UX 유지 */}
+            {agentLocalExecutor && bridgeConnected && bridgeDevices.length > 1 && (
+              <select
+                value={selectedBridgeDevice?.deviceId ?? bridgeDevices[bridgeDevices.length - 1]?.deviceId ?? ""}
+                onChange={(e) => setAgentLocalDeviceId(e.target.value || null)}
+                className="max-w-[220px] truncate rounded-md border border-border bg-surface-2 px-1.5 py-1 text-xs text-fg-1"
+              >
+                {bridgeDevices.map((d) => (
+                  <option key={d.deviceId} value={d.deviceId}>
+                    {d.label}
+                  </option>
+                ))}
+              </select>
+            )}
           </div>
         )}
         {/* 승인 3모드(Manual/Auto/Skip) — 에이전트 작업 위임 시 이 실행의 도구 승인 정책 선택. */}

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -175,6 +175,8 @@ interface AppState {
   /** 에이전트 작업 Git repo URL(Phase 2) — 있으면 태스크가 해당 repo 를 clone 해 작업 후 PR 생성. */
   /** Cowork D2: 로컬 실행 토글 — ON 이면 작업이 데스크톱 앱이 연결한 폴더에서 실행(executor='local'). */
   agentLocalExecutor: boolean;
+  /** 다중 디바이스(101): 로컬 실행 대상 브리지 디바이스 id — null 은 최근 접속 디바이스 폴백. */
+  agentLocalDeviceId: string | null;
   imageMode: boolean;
   artifactMode: boolean;
   /** 구조화 답변 모드 — ON 시 메시지를 REST /api/chat/structured 로 보내 카드 UI 로 렌더(비스트리밍). */
@@ -241,6 +243,7 @@ interface AppState {
   setSelectedModel: (m: string) => void;
   setAgentApprovalMode: (m: "all" | "high-risk" | "none") => void;
   setAgentLocalExecutor: (v: boolean) => void;
+  setAgentLocalDeviceId: (v: string | null) => void;
   cycleStyle: () => void;
   setStyle: (m: ChatStyle) => void;
   setAuth: (auth: AppState["auth"]) => void;
@@ -305,6 +308,7 @@ export const useAppStore = create<AppState>()(
   agentTaskMode: false,
   agentApprovalMode: "all",
   agentLocalExecutor: false,
+  agentLocalDeviceId: null,
   imageMode: false,
   artifactMode: false,
   structuredMode: false,
@@ -475,6 +479,7 @@ export const useAppStore = create<AppState>()(
   setSelectedModel: (m) => set({ selectedModel: m }),
   setAgentApprovalMode: (m) => set({ agentApprovalMode: m }),
   setAgentLocalExecutor: (v) => set({ agentLocalExecutor: v }),
+  setAgentLocalDeviceId: (v) => set({ agentLocalDeviceId: v }),
   cycleStyle: () =>
     set((s) => ({
       style: STYLE_ORDER[(STYLE_ORDER.indexOf(s.style) + 1) % STYLE_ORDER.length],

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -586,6 +586,8 @@ export function useChatSocket() {
       approvalPolicy?: "all" | "high-risk" | "none",
       /** Cowork D2: true 면 데스크톱 브리지가 연결한 로컬 폴더에서 실행 (승인은 서버가 'all' 강제) */
       localExecutor?: boolean,
+      /** 다중 디바이스(101): 로컬 실행 대상 디바이스 id — 미지정은 최근 접속 디바이스 */
+      localDeviceId?: string | null,
     ) => {
       const goal = message.trim();
       const s = useAppStore.getState();
@@ -612,7 +614,7 @@ export function useChatSocket() {
               goal,
               files: [...payloadFiles, ...uploadRefs],
               ...(images && images.length > 0 ? { images } : {}),
-              ...(localExecutor ? { executor: "local" } : {}),
+              ...(localExecutor ? { executor: "local", ...(localDeviceId ? { deviceId: localDeviceId } : {}) } : {}),
             },
           );
         } else if (binaryParts.length > 0) {
@@ -624,7 +626,7 @@ export function useChatSocket() {
             goal,
             ...(payloadFiles.length > 0 ? { files: payloadFiles } : {}),
             ...(images && images.length > 0 ? { images } : {}),
-            ...(localExecutor ? { executor: "local" } : {}),
+            ...(localExecutor ? { executor: "local", ...(localDeviceId ? { deviceId: localDeviceId } : {}) } : {}),
           }));
           for (const f of binaryParts) fd.append("files", f.rawFile!, f.name);
           const resp = await fetch("/api/agent-tasks", {
@@ -648,7 +650,7 @@ export function useChatSocket() {
                 ? { files: files.map(toWireFile) }
                 : {}),
               ...(images && images.length > 0 ? { images } : {}),
-              ...(localExecutor ? { executor: "local" } : {}),
+              ...(localExecutor ? { executor: "local", ...(localDeviceId ? { deviceId: localDeviceId } : {}) } : {}),
             },
           );
         }

--- a/db/migrations/101_agent_task_device.sql
+++ b/db/migrations/101_agent_task_device.sql
@@ -1,0 +1,4 @@
+-- 101: 로컬 실행 대상 브리지 디바이스 영속 (다중 디바이스, 2026-08-21)
+-- executor='local' 작업이 어느 디바이스(데스크톱/CLI)로 라우팅되는지 기록 —
+-- 다대 접속 시 도구 위임의 결정적 라우팅 + 상세/뱃지 노출용. 미지정(NULL)은 최근 접속 폴백.
+ALTER TABLE agent_tasks ADD COLUMN IF NOT EXISTS device_id TEXT;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "workspaces": [
                 "apps/api",
                 "apps/web",
+                "apps/cli",
                 "apps/discord-bot",
                 "packages/*"
             ],
@@ -45,7 +46,7 @@
         },
         "apps/api": {
             "name": "openmake-api",
-            "version": "1.25.0",
+            "version": "1.26.0",
             "dependencies": {
                 "@anthropic-ai/sdk": "^0.95.1",
                 "@modelcontextprotocol/sdk": "^1.25.3",
@@ -122,9 +123,22 @@
                 "node": ">=12"
             }
         },
+        "apps/cli": {
+            "name": "@openmake/cli",
+            "version": "0.1.0",
+            "dependencies": {
+                "ws": "^8.18.3"
+            },
+            "bin": {
+                "openmake-code": "dist/index.js"
+            },
+            "devDependencies": {
+                "@types/ws": "^8.5.12"
+            }
+        },
         "apps/discord-bot": {
             "name": "openmake-discord-bot",
-            "version": "1.25.0",
+            "version": "1.26.0",
             "dependencies": {
                 "discord.js": "^14.16.3",
                 "dotenv": "^16.4.5"
@@ -151,7 +165,7 @@
         },
         "apps/web": {
             "name": "@openmake/web",
-            "version": "1.25.0",
+            "version": "1.26.0",
             "dependencies": {
                 "@openmake/api-client": "*",
                 "@openmake/config": "*",
@@ -3103,6 +3117,10 @@
         },
         "node_modules/@openmake/api-contracts": {
             "resolved": "packages/api-contracts",
+            "link": true
+        },
+        "node_modules/@openmake/cli": {
+            "resolved": "apps/cli",
             "link": true
         },
         "node_modules/@openmake/config": {
@@ -17028,7 +17046,7 @@
         },
         "packages/api-client": {
             "name": "@openmake/api-client",
-            "version": "1.25.0",
+            "version": "1.26.0",
             "dependencies": {
                 "@openmake/config": "*",
                 "@openmake/shared-types": "*"
@@ -17040,11 +17058,11 @@
         },
         "packages/config": {
             "name": "@openmake/config",
-            "version": "1.25.0"
+            "version": "1.26.0"
         },
         "packages/shared-types": {
             "name": "@openmake/shared-types",
-            "version": "1.25.0"
+            "version": "1.26.0"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "workspaces": [
         "apps/api",
         "apps/web",
+        "apps/cli",
         "apps/discord-bot",
         "packages/*"
     ],


### PR DESCRIPTION
## 개요

웹·데스크톱·CLI 세 접점에서 사용자 **로컬 폴더 대상 에이전트 작업**(`executor='local'`)을 시작할 수 있게 하는 **OpenMake Code** 를 추가합니다. 하네스(`AgentTaskService`)는 무변경 — CLI 는 데스크톱 앱과 동일한 브리지 프로토콜의 두 번째 클라이언트로, 도구 실행 + 터미널 렌더만 담당하고 자체 에이전트 루프는 없습니다.

## 주요 변경

**서버**
- 로컬 브리지 레지스트리 다중 디바이스/폴더화 (유저당 1대→N대, `deviceId` 라우팅, 상한 `LOCAL_BRIDGE_MAX_DEVICES`)
- API key(`omk_live_*`) WS 인증 — CLI 상주 연결용(만료 없음). Origin 검증은 API key 요청에 한해 면제(CSWSH 는 쿠키 기반 브라우저 공격)
- 작업 계약에 `deviceId`/`folderName` + `agent_tasks.device_id`(마이그레이션 101). create/execute/resume/boot-recovery 전 경로 대칭
- 브리지 status API 를 `devices[]` 로 확장(구 필드 병존 — 구 프론트 무중단)

**웹** (`apps/web`)
- 컴포저 로컬 실행 토글을 디바이스·폴더 선택기로 확장 (2대+ 시 노출, 1대는 현행 UX 유지)

**CLI** (`apps/cli`, `@openmake/cli`)
- `login`/`connect`/`status`/`"목표"` 명령. `apps/desktop/bridge.js` 코어(경로 스코프·exec 3단 방어·worktree 격리) 이식 + 터미널 confirmExec/API key 어댑터
- `--yes` 로 서버 승인 자동화(헤드리스/CI). 비-TTY 는 자동 거부(fail-safe)

**부산물(별도 커밋)**: 지도 환각 HTML strip, ChatGPT 공유 URL 파싱, Cloudflare 봇 챌린지 임퍼소네이션 폴백

## 검증

- 라이브 E2E: CLI→서버→로컬 worktree 파일 생성(완전 헤드리스), 웹 UI 2대 디바이스 선택기 렌더(Playwright)
- 코드 리뷰 재점검으로 결함 8건 발견·수정(resume 로컬 라우팅 유실 H1 포함) 후 라이브 재검증
- 백엔드 테스트 202 통과, 3개 워크스페이스 타입체크·lint 통과

## 리스크·참고

- macOS 전용(sandbox-exec SBPL). Linux 지원은 비범위
- 품질 병목은 qwen 툴콜 정확도 — CLI 는 접근성만 늘림
- `LOCAL_EXECUTOR_ENABLED` 게이트 뒤(운영 ON). 구 데스크톱 앱은 단수 `folderName` hello 로 하위호환
- plan: `docs/proposals/2026-08-21-openmake-code-axis1·2`

## 체크리스트

- [x] `npm run lint` 통과
- [x] `npm test`(백엔드 유닛) 통과 (202)
- [x] DB 스키마 변경: 마이그레이션 101 포함
- [x] 환경변수 추가: `.env.example` 업데이트(`LOCAL_BRIDGE_MAX_DEVICES` 등)
- [x] UI 변경: 컴포저 디바이스 선택기(Playwright 검증)
- [x] 보안: API key WS 인증·Origin 면제 근거 명시, exec 3단 방어·worktree 격리 이식

🤖 Generated with [Claude Code](https://claude.com/claude-code)
