### PR TITLE
feat(auth): API key bridge/chat 스코프 하드닝

### DIFF
--- a/apps/api/src/config/__tests__/api-key-scopes.test.ts
+++ b/apps/api/src/config/__tests__/api-key-scopes.test.ts
@@ -1,0 +1,35 @@
+/**
+ * API Key 스코프 헬퍼 — apiKeyHasScope (2026-08-21 하드닝).
+ * 와일드카드·빈 배열(하위호환)·정확 매칭·미보유 케이스를 검증한다.
+ */
+import { apiKeyHasScope, API_KEY_SCOPES, ALLOWED_API_KEY_SCOPES } from '../api-key-scopes';
+
+describe('apiKeyHasScope', () => {
+    test('와일드카드(*)는 모든 스코프를 허용', () => {
+        expect(apiKeyHasScope(['*'], API_KEY_SCOPES.BRIDGE)).toBe(true);
+        expect(apiKeyHasScope(['*'], API_KEY_SCOPES.CHAT)).toBe(true);
+    });
+
+    test('빈 배열·undefined 는 기존 전권 키로 간주해 허용(하위호환)', () => {
+        expect(apiKeyHasScope([], API_KEY_SCOPES.BRIDGE)).toBe(true);
+        expect(apiKeyHasScope(undefined, API_KEY_SCOPES.BRIDGE)).toBe(true);
+        expect(apiKeyHasScope(null, API_KEY_SCOPES.CHAT)).toBe(true);
+    });
+
+    test('정확한 스코프 매칭', () => {
+        expect(apiKeyHasScope(['bridge'], API_KEY_SCOPES.BRIDGE)).toBe(true);
+        expect(apiKeyHasScope(['chat'], API_KEY_SCOPES.CHAT)).toBe(true);
+    });
+
+    test('미보유 스코프는 거부', () => {
+        expect(apiKeyHasScope(['bridge'], API_KEY_SCOPES.CHAT)).toBe(false); // bridge 키는 추론 API 불가
+        expect(apiKeyHasScope(['chat'], API_KEY_SCOPES.BRIDGE)).toBe(false); // chat 키는 브리지 불가
+    });
+
+    test('허용 스코프 화이트리스트', () => {
+        expect(ALLOWED_API_KEY_SCOPES.has('*')).toBe(true);
+        expect(ALLOWED_API_KEY_SCOPES.has('bridge')).toBe(true);
+        expect(ALLOWED_API_KEY_SCOPES.has('chat')).toBe(true);
+        expect(ALLOWED_API_KEY_SCOPES.has('admin')).toBe(false);
+    });
+});

--- a/apps/api/src/config/api-key-scopes.ts
+++ b/apps/api/src/config/api-key-scopes.ts
@@ -1,0 +1,39 @@
+/**
+ * API Key 스코프 정의 (L2) — 키가 접근할 수 있는 기능 축을 좁혀 유출 피해를 제한한다.
+ *
+ * 와일드카드 `*` 는 전 스코프 허용(기존/UI 발급 키 기본값 — 하위호환). 특정 스코프만 가진
+ * 키는 해당 축에서만 동작한다:
+ *   - bridge: 로컬 브리지(CLI/데스크톱) 등록 + 로컬 에이전트 작업 REST (WS bridge_hello,
+ *             /api/local-bridge, /api/agent-tasks 로컬 실행). 토큰 소진 추론 API 는 불가.
+ *   - chat:   OpenAI 호환 추론 API (/api/v1/*) — 토큰을 소비하는 축.
+ *
+ * @module config/api-key-scopes
+ */
+
+export const API_KEY_SCOPES = {
+    BRIDGE: 'bridge',
+    CHAT: 'chat',
+} as const;
+
+export type ApiKeyScope = typeof API_KEY_SCOPES[keyof typeof API_KEY_SCOPES];
+
+/** UI 발급 폼에 노출할 스코프 프리셋 (No-Hardcoding — 프론트도 이 목록과 정합). */
+export const API_KEY_SCOPE_PRESETS: ReadonlyArray<{ value: string; scopes: string[] }> = [
+    { value: 'full', scopes: ['*'] },
+    { value: 'bridge', scopes: [API_KEY_SCOPES.BRIDGE] },
+    { value: 'chat', scopes: [API_KEY_SCOPES.CHAT] },
+];
+
+/** 발급 시 허용하는 스코프 문자열 화이트리스트 (미지 스코프 거부 — 오타·권한 오해 방지). */
+export const ALLOWED_API_KEY_SCOPES: ReadonlySet<string> = new Set([
+    '*', API_KEY_SCOPES.BRIDGE, API_KEY_SCOPES.CHAT,
+]);
+
+/**
+ * 키의 scopes 가 요구 스코프를 만족하는가. `*` 는 전부 허용. scopes 미지정/빈 배열은
+ * 기존 키(전권)로 간주해 허용한다(하위호환 — repository 기본값이 ['*'] 라 실질 무영향).
+ */
+export function apiKeyHasScope(scopes: string[] | undefined | null, required: ApiKeyScope): boolean {
+    if (!scopes || scopes.length === 0) return true;
+    return scopes.includes('*') || scopes.includes(required);
+}

--- a/apps/api/src/middlewares/api-key-auth.ts
+++ b/apps/api/src/middlewares/api-key-auth.ts
@@ -13,6 +13,7 @@ import { hashApiKey, isValidApiKeyFormat, API_KEY_PREFIX } from '../auth/api-key
 import { getUnifiedDatabase } from '../data/models/unified-database';
 import { error as apiError, ErrorCodes } from '../utils/api-response';
 import { createLogger } from '../utils/logger';
+import { apiKeyHasScope, type ApiKeyScope } from '../config/api-key-scopes';
 
 const logger = createLogger('ApiKeyAuth');
 
@@ -136,6 +137,40 @@ export async function requireAuthOrApiKey(req: Request, res: Response, next: Nex
     }
     const { requireAuth } = await import('../auth/middleware');
     await requireAuth(req, res, next);
+}
+
+/** 인증 통과한 요청이 API Key 라면 요구 스코프를 가졌는지 검사(JWT/쿠키 인증은 스코프 무관 통과). */
+function enforceApiKeyScope(req: Request, res: Response, scope: ApiKeyScope): boolean {
+    if (req.authMethod !== 'api-key') return true; // JWT/쿠키 유저는 스코프 개념 없음
+    const scopes = req.apiKeyRecord?.scopes as string[] | undefined;
+    if (apiKeyHasScope(scopes, scope)) return true;
+    res.status(403).json(apiError(
+        ErrorCodes.FORBIDDEN,
+        `이 API key 는 '${scope}' 스코프가 없습니다. 해당 스코프의 키를 발급하세요.`,
+    ));
+    return false;
+}
+
+/**
+ * 스코프 검사만 수행 (재인증 없음) — 상위에서 requireApiKey 가 이미 인증을 마친 경로용.
+ * v1 처럼 전역 requireApiKey 뒤에 특정 하위 경로만 스코프로 좁힐 때 사용한다.
+ */
+export function requireScope(scope: ApiKeyScope) {
+    return (req: Request, res: Response, next: NextFunction): void => {
+        if (enforceApiKeyScope(req, res, scope)) next();
+    };
+}
+
+/**
+ * JWT 또는 (요구 스코프를 가진) API Key 병용 인증 (2026-08-21). 로컬 브리지·에이전트 작업
+ * REST 에 사용 — 웹(JWT)은 그대로, CLI(API Key)는 bridge 스코프를 요구한다.
+ */
+export function requireAuthOrApiKeyScope(scope: ApiKeyScope) {
+    return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        await requireAuthOrApiKey(req, res, () => {
+            if (enforceApiKeyScope(req, res, scope)) next();
+        });
+    };
 }
 
 /**

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -21,7 +21,8 @@ import { Router, Request, Response } from 'express';
 import { createLogger } from '../utils/logger';
 import { success, badRequest, notFound } from '../utils/api-response';
 import { asyncHandler } from '../utils/error-handler';
-import { requireAuthOrApiKey } from '../middlewares/api-key-auth';
+import { requireAuthOrApiKeyScope } from '../middlewares/api-key-auth';
+import { API_KEY_SCOPES } from '../config/api-key-scopes';
 import { assertResourceOwnerOrAdmin } from '../auth/ownership';
 import { validate, validateWithSecurity } from '../middlewares/validation';
 import { getUnifiedDatabase } from '../data/models/unified-database';
@@ -56,7 +57,7 @@ const logger = createLogger('AgentTaskRoutes');
 const router = Router();
 
 // 모든 엔드포인트 인증 필요
-router.use(requireAuthOrApiKey);
+router.use(requireAuthOrApiKeyScope(API_KEY_SCOPES.BRIDGE));
 
 type UserRole = 'admin' | 'user' | 'guest';
 

--- a/apps/api/src/routes/api-keys.routes.ts
+++ b/apps/api/src/routes/api-keys.routes.ts
@@ -34,6 +34,12 @@ import { validate } from '../middlewares/validation';
 import { asyncHandler } from '../utils/error-handler';
 import { success, notFound, badRequest, unauthorized, rateLimited } from '../utils/api-response';
 import { getApiKeyService, ApiKeyError } from '../services/ApiKeyService';
+import { ALLOWED_API_KEY_SCOPES } from '../config/api-key-scopes';
+
+/** 발급/수정 시 허용 스코프 화이트리스트 검증 — 미지 스코프(오타·권한 오해)를 거부. */
+const scopesSchema = z.array(z.string().refine((s) => ALLOWED_API_KEY_SCOPES.has(s), {
+    message: `허용되지 않은 스코프입니다 (${[...ALLOWED_API_KEY_SCOPES].join(', ')} 중 선택)`,
+})).optional();
 
 const router = Router();
 
@@ -50,7 +56,7 @@ const router = Router();
 const createApiKeySchema = z.object({
     name: z.string().min(1).max(100),
     description: z.string().max(500).optional(),
-    scopes: z.array(z.string()).optional(),
+    scopes: scopesSchema,
     allowed_models: z.array(z.string()).optional(),
     expires_at: z.string().datetime().optional(),
 });
@@ -67,7 +73,7 @@ const createApiKeySchema = z.object({
 const updateApiKeySchema = z.object({
     name: z.string().min(1).max(100).optional(),
     description: z.string().max(500).optional(),
-    scopes: z.array(z.string()).optional(),
+    scopes: scopesSchema,
     allowed_models: z.array(z.string()).optional(),
     is_active: z.boolean().optional(),
     expires_at: z.string().datetime().nullable().optional(),

--- a/apps/api/src/routes/local-bridge.routes.ts
+++ b/apps/api/src/routes/local-bridge.routes.ts
@@ -4,14 +4,15 @@
  * @module routes/local-bridge
  */
 import { Router, Request, Response } from 'express';
-import { requireAuthOrApiKey } from '../middlewares/api-key-auth';
+import { requireAuthOrApiKeyScope } from '../middlewares/api-key-auth';
+import { API_KEY_SCOPES } from '../config/api-key-scopes';
 import { success } from '../utils/api-response';
 import { LOCAL_BRIDGE } from '../config/local-bridge';
 import { getLocalBridgeRegistry } from '../services/local-bridge/registry';
 
 const router = Router();
 
-router.get('/status', requireAuthOrApiKey, (req: Request, res: Response) => {
+router.get('/status', requireAuthOrApiKeyScope(API_KEY_SCOPES.BRIDGE), (req: Request, res: Response) => {
     const userId = String(req.user!.id);
     const devices = LOCAL_BRIDGE.ENABLED ? getLocalBridgeRegistry().getDevices(userId) : [];
     // 구 필드(connected/label/folderName)는 최근 접속 디바이스 기준으로 병존 — 구 프론트 무중단.

--- a/apps/api/src/routes/v1/index.ts
+++ b/apps/api/src/routes/v1/index.ts
@@ -44,7 +44,8 @@ import { getPool } from '../../data/models/unified-database';
 import { getProviderCatalogEntry } from '../../config/external-providers';
 import { buildFullModelId } from '../../providers/i-provider';
 import { success, unauthorized } from '../../utils/api-response';
-import { requireApiKey } from '../../middlewares/api-key-auth';
+import { requireApiKey, requireScope } from '../../middlewares/api-key-auth';
+import { API_KEY_SCOPES } from '../../config/api-key-scopes';
 import { apiKeyRateLimiter, apiKeyTPMLimiter } from '../../middlewares/api-key-limiter';
 import { asyncHandler } from '../../utils/error-handler';
 import { getApiKeyService } from '../../services/ApiKeyService';
@@ -54,6 +55,11 @@ const v1Router = Router();
 // §4 Rate Limit 미들웨어 — API Key 인증 요청에만 동작 (비인증 자동 스킵)
 // 전역 API 인증 미들웨어
 v1Router.use(requireApiKey);
+
+// 스코프 게이트 — v1 은 외부 개발자 추론 API 면이라 'chat' 스코프를 요구한다(와일드카드 '*'
+// 포함 키는 통과). CLI 브리지 전용('bridge') 키는 여기서 차단돼 토큰 소진을 못 한다.
+// CLI 는 /api/v1 을 쓰지 않고 /api/local-bridge·/api/agent-tasks 만 쓴다.
+v1Router.use(requireScope(API_KEY_SCOPES.CHAT));
 
 // API 키 기반 RPM 제한 (인증 이후에 적용되어 키 단위 카운트 보장)
 v1Router.use(apiKeyRateLimiter);

--- a/apps/api/src/sockets/handler.ts
+++ b/apps/api/src/sockets/handler.ts
@@ -175,6 +175,7 @@ export class WebSocketHandler {
             // WebSocket 인스턴스에 인증 정보 및 중단 컨트롤러 저장
             extWs._authenticatedUserId = auth.userId;
             extWs._authenticatedUserRole = auth.userRole;
+            extWs._apiKeyScopes = auth.apiKeyScopes ?? undefined; // API key 연결이면 스코프(브리지 게이트)
             extWs._abortController = null;
             // 🔒 Phase 2: heartbeat alive 플래그 초기화
             extWs._isAlive = true;

--- a/apps/api/src/sockets/ws-auth.ts
+++ b/apps/api/src/sockets/ws-auth.ts
@@ -19,6 +19,8 @@ export interface WebSocketAuthResult {
     tokenJti?: string | null;
     tokenFingerprint?: string | null;
     authMethod?: 'cookie' | 'bearer' | 'none';
+    /** API key 인증 시 그 키의 스코프(브리지 등록 게이트용). JWT/쿠키 인증은 undefined. */
+    apiKeyScopes?: string[] | null;
 }
 
 function tokenFingerprint(token: string): string {
@@ -68,6 +70,7 @@ async function resolveAuthFromApiKey(
             tokenJti: null,
             tokenFingerprint: tokenFingerprint(plainKey),
             authMethod: 'bearer',
+            apiKeyScopes: (key.scopes as string[] | undefined) ?? ['*'],
         };
     } catch (e) {
         logger.warn('[WS] API key 인증 실패:', e);

--- a/apps/api/src/sockets/ws-bridge-handler.ts
+++ b/apps/api/src/sockets/ws-bridge-handler.ts
@@ -9,6 +9,7 @@ import type { WebSocket } from 'ws';
 import type { WSMessage, ExtendedWebSocket } from './ws-types';
 import { getLocalBridgeRegistry, type BridgeResult } from '../services/local-bridge/registry';
 import { LOCAL_BRIDGE } from '../config/local-bridge';
+import { apiKeyHasScope, API_KEY_SCOPES } from '../config/api-key-scopes';
 
 export async function handleBridgeMessage(ws: WebSocket, msg: WSMessage): Promise<void> {
     const extWs = ws as ExtendedWebSocket;
@@ -19,6 +20,13 @@ export async function handleBridgeMessage(ws: WebSocket, msg: WSMessage): Promis
     }
     if (!LOCAL_BRIDGE.ENABLED) {
         ws.send(JSON.stringify({ type: 'error', message: '로컬 실행 기능이 비활성화되어 있습니다 (LOCAL_EXECUTOR_ENABLED)' }));
+        return;
+    }
+    // API key 연결이면 bridge 스코프 필수 — 스코프 없는(예: chat 전용) 키의 브리지 등록 차단.
+    // JWT/쿠키(데스크톱 앱) 연결은 _apiKeyScopes=undefined 라 apiKeyHasScope 가 통과시킨다.
+    if (extWs._apiKeyScopes !== undefined && !apiKeyHasScope(extWs._apiKeyScopes, API_KEY_SCOPES.BRIDGE)) {
+        ws.send(JSON.stringify({ type: 'error', message: `이 API key 는 '${API_KEY_SCOPES.BRIDGE}' 스코프가 없습니다 — bridge 스코프 키를 발급하세요` }));
+        try { ws.close(1008, 'bridge_scope_required'); } catch { /* already closing */ }
         return;
     }
     const registry = getLocalBridgeRegistry();

--- a/apps/api/src/sockets/ws-types.ts
+++ b/apps/api/src/sockets/ws-types.ts
@@ -93,6 +93,8 @@ export interface ExtendedWebSocket extends WebSocket {
     _authTokenJti?: string | null;
     _authTokenFingerprint?: string | null;
     _authMethod?: 'cookie' | 'bearer' | 'none';
+    /** API key 인증 시 그 키의 스코프(브리지 등록 게이트). JWT/쿠키 인증은 undefined. */
+    _apiKeyScopes?: string[] | null;
     _clientIp?: string;
     _connectedAtMs?: number;
     _lastActivityAtMs?: number;

--- a/apps/web/app/(workspace)/api-access/page.tsx
+++ b/apps/web/app/(workspace)/api-access/page.tsx
@@ -63,6 +63,9 @@ export default function ApiAccessPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [newName, setNewName] = useState("");
+  // 스코프 프리셋 — 백엔드 config/api-key-scopes.ts 의 API_KEY_SCOPE_PRESETS 와 정합.
+  // full=전체(*), bridge=CLI 로컬 실행 전용, chat=추론 API 전용.
+  const [newScope, setNewScope] = useState<"full" | "bridge" | "chat">("full");
   const [creating, setCreating] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
   // 발급/순환 직후 평문 키 1회 노출 (재조회 불가)
@@ -91,11 +94,14 @@ export default function ApiAccessPage() {
     setCreating(true);
     setError(null);
     try {
+      const scopes = newScope === "full" ? ["*"] : [newScope];
       const res = await ApiClient.post<ApiSuccess<CreatedKey>>("/api/api-keys", {
         name: newName.trim(),
+        scopes,
       });
       setRevealed(res.data);
       setNewName("");
+      setNewScope("full");
       await load();
     } catch (e) {
       setError(e instanceof ApiError ? e.message : t("createFailed"));
@@ -230,19 +236,30 @@ export default function ApiAccessPage() {
                 e.preventDefault();
                 void create();
               }}
-              className="flex items-center gap-2"
+              className="flex flex-wrap items-center gap-2"
             >
               <input
                 value={newName}
                 onChange={(e) => setNewName(e.target.value)}
                 maxLength={100}
                 placeholder={t("namePlaceholder")}
-                className="flex-1 rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none transition placeholder:text-muted focus:border-accent focus:ring-2 focus:ring-[var(--accent-ring)]"
+                className="min-w-[180px] flex-1 rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none transition placeholder:text-muted focus:border-accent focus:ring-2 focus:ring-[var(--accent-ring)]"
               />
+              <select
+                value={newScope}
+                onChange={(e) => setNewScope(e.target.value as "full" | "bridge" | "chat")}
+                aria-label={t("scope.label")}
+                className="rounded-md border border-border bg-surface px-2 py-2 text-sm text-fg outline-none focus:border-accent focus:ring-2 focus:ring-[var(--accent-ring)]"
+              >
+                <option value="full">{t("scope.full")}</option>
+                <option value="bridge">{t("scope.bridge")}</option>
+                <option value="chat">{t("scope.chat")}</option>
+              </select>
               <Button type="submit" disabled={!newName.trim() || creating}>
                 {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
                 {t("createButton")}
               </Button>
+              <p className="w-full text-xs text-muted">{t(`scope.hint.${newScope}`)}</p>
             </form>
           </CardContent>
         </Card>

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -230,6 +230,17 @@
       "deactivate": "Deactivate",
       "rotate": "Rotate",
       "delete": "Delete"
+    },
+    "scope": {
+      "label": "Scope",
+      "full": "Full access",
+      "bridge": "Bridge (CLI)",
+      "chat": "Inference API",
+      "hint": {
+        "full": "Access to all APIs.",
+        "bridge": "For OpenMake Code CLI local execution only — no inference API / token usage.",
+        "chat": "OpenAI-compatible inference API only."
+      }
     }
   },
   "composer": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -230,6 +230,17 @@
       "deactivate": "無効化",
       "rotate": "ローテーション",
       "delete": "削除"
+    },
+    "scope": {
+      "label": "スコープ",
+      "full": "フルアクセス",
+      "bridge": "ブリッジ(CLI)",
+      "chat": "推論API",
+      "hint": {
+        "full": "すべてのAPIにアクセスします。",
+        "bridge": "OpenMake Code CLI のローカル実行専用 — 推論API・トークン消費は不可。",
+        "chat": "OpenAI互換の推論API専用。"
+      }
     }
   },
   "composer": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -230,6 +230,17 @@
       "deactivate": "비활성화",
       "rotate": "순환",
       "delete": "삭제"
+    },
+    "scope": {
+      "label": "스코프",
+      "full": "전체 권한",
+      "bridge": "브리지(CLI)",
+      "chat": "추론 API",
+      "hint": {
+        "full": "모든 API 에 접근합니다.",
+        "bridge": "OpenMake Code CLI 의 로컬 실행 전용 — 추론 API·토큰 소비는 불가.",
+        "chat": "OpenAI 호환 추론 API 전용."
+      }
     }
   },
   "composer": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -230,6 +230,17 @@
       "deactivate": "停用",
       "rotate": "轮换",
       "delete": "删除"
+    },
+    "scope": {
+      "label": "范围",
+      "full": "完全访问",
+      "bridge": "桥接(CLI)",
+      "chat": "推理 API",
+      "hint": {
+        "full": "访问所有 API。",
+        "bridge": "仅用于 OpenMake Code CLI 本地执行 — 无法使用推理 API / 消耗令牌。",
+        "chat": "仅限 OpenAI 兼容推理 API。"
+      }
     }
   },
   "composer": {


### PR DESCRIPTION
## 개요

API key 발급 UI 가 `bridge` 스코프를 지원하지 않고, 스코프 자체가 어디서도 강제되지 않던 갭을 수정합니다. 기존엔 CLI 브리지용 키가 전권 키(`*`)로만 발급돼, **유출 시 추론 API 로 토큰 소진**이 가능했습니다.

이는 OpenMake Code CLI(#546)의 plan 이 명시했지만 미구현이던 보안 경계입니다.

## 변경

**스코프 모델** (`config/api-key-scopes.ts`)
- `bridge`(CLI 로컬 실행) · `chat`(추론 API) · 와일드카드 `*`(전체, 기존 키 기본값)
- `apiKeyHasScope(scopes, required)` — `*` 또는 빈 배열은 하위호환 통과

**강제 지점**
- WS `bridge_hello`: `bridge` 스코프 요구 (없으면 등록 거부 + 소켓 종료). API key scope 를 ws-auth→handler→extWs 로 관통
- `/api/v1/*`(추론): `chat` 요구 — bridge 전용 키의 토큰 소진 차단
- `/api/local-bridge`·`/api/agent-tasks`: `bridge` 요구 (웹 JWT 는 scope 무관 통과)
- 발급 스키마: 허용 스코프 화이트리스트 검증(미지 스코프 거부)

**발급 UI** (`api-access`)
- 스코프 선택 드롭다운(전체 권한 / 브리지(CLI) / 추론 API) + 설명 힌트, 4언어 i18n

## 하위호환

- 기존·UI 기본 발급 키는 `scopes=['*']` 라 전 축 통과 — 무영향
- JWT/쿠키 인증(웹)은 스코프 개념 없이 통과
- agent-task 는 CLI(#546) 전까지 API key 를 받지 않던 경로라 기존 API 키 통합 영향 없음

## 검증 (라이브)

- REST 경계: bridge키 `/local-bridge`=200·`/v1`=403, chat키 반대, full키 양쪽 200
- WS `bridge_hello`: bridge키 등록·chat키 거부(명시 메시지)
- 발급 UI(Playwright): "브리지(CLI)" 선택 발급 → DB `scopes=['bridge']` 확인
- 백엔드 테스트 234 통과, 3 워크스페이스 타입체크·lint 통과

## 체크리스트

- [x] `npm run lint` 통과
- [x] `npm test` 통과 (234)
- [x] UI 변경: 스코프 선택 드롭다운(Playwright 검증)
- [x] 보안: 스코프 강제 경계 3축, 화이트리스트 검증, 하위호환 명시

🤖 Generated with [Claude Code](https://claude.com/claude-code)
