### PR TITLE
feat(local-bridge): 브리지 폴더 선택 프로토콜 — 웹에서 CLI 재시작 없이 실행 폴더 선택

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1044,6 +1044,7 @@ AGENT_TASK_TIMEOUT_MS=600000
 # LOCAL_BRIDGE_MAX_WRITE_BYTES=8388608          # write/첨부 전송 상한(8MB)
 # LOCAL_BRIDGE_OUTPUT_CAP=65536                 # exec/read 결과 수신 캡(chars)
 # LOCAL_BRIDGE_MAX_DEVICES=3                     # 유저당 동시 등록 브리지 디바이스 상한(데스크톱+CLI)
+# BRIDGE_FOLDERS_MAX_ENTRIES=200                 # 폴더 선택(folders) 1회 열거 상한(초과 절단+truncated)
 #
 # worktree 격리 — 연결 폴더가 git 레포면 별도 worktree(디렉토리+브랜치)를 만들어 그 안에서만
 # 작업한다. 사용자의 현재 브랜치·작업 중인 파일이 오염되지 않고, 변경분을 git diff 로 캡처해

--- a/apps/api/src/config/local-bridge.ts
+++ b/apps/api/src/config/local-bridge.ts
@@ -23,6 +23,9 @@ export const LOCAL_BRIDGE = {
     /** 유저당 동시 등록 브리지 디바이스 상한 (데스크톱+CLI 병존, 2026-08-21 다중화). */
     MAX_DEVICES: parseInt(process.env.LOCAL_BRIDGE_MAX_DEVICES || '3', 10),
 
+    /** 폴더 선택(folders kind) 1회 열거 상한 — 초과분은 절단 + truncated 플래그(디바이스측 강제). */
+    FOLDERS_MAX_ENTRIES: parseInt(process.env.BRIDGE_FOLDERS_MAX_ENTRIES || '200', 10),
+
     /**
      * 로컬 브라우저(D3a) — 데스크톱 Electron 내장 Chromium 에서 browser 도구를 실행한다.
      * 서버 컨테이너 브라우저와 달리 **사용자 화면에 보이는** 패널로 뜨고, 전용 세션 파티션이라

--- a/apps/api/src/data/models/unified-database.ts
+++ b/apps/api/src/data/models/unified-database.ts
@@ -349,6 +349,7 @@ export class UnifiedDatabase {
         inputImages?: unknown;
         executor?: 'sandbox' | 'local';
         deviceId?: string;
+        folderRel?: string;
     }): Promise<void> {
         return this.agentTaskRepository.createAgentTask(params);
     }

--- a/apps/api/src/data/models/unified-database.types.ts
+++ b/apps/api/src/data/models/unified-database.types.ts
@@ -184,6 +184,8 @@ export interface AgentTask {
     executor?: 'sandbox' | 'local';
     /** 로컬 실행 대상 브리지 디바이스(101) — NULL 은 최근 접속 디바이스 폴백 */
     device_id?: string;
+    /** 로컬 실행 대상 폴더(102) — 연결 루트 기준 상대경로. NULL 은 루트 */
+    folder_rel?: string;
     /** 누적 LLM 토큰(prompt+completion) — terminal 전이 시 기록(066), resume 은 통산 */
     total_tokens?: number;
     /** 완료 출구 구분(091) — 'final_answer' | 'terminate'. 미완료/기존 행은 NULL */

--- a/apps/api/src/data/repositories/agent-task-repository.ts
+++ b/apps/api/src/data/repositories/agent-task-repository.ts
@@ -28,6 +28,8 @@ export class AgentTaskRepository extends BaseRepository {
         executor?: 'sandbox' | 'local';
         /** 로컬 실행 대상 브리지 디바이스 (다중 디바이스, 093) — 미지정은 최근 접속 디바이스 폴백 */
         deviceId?: string;
+        /** 로컬 실행 대상 폴더 (102) — 연결 루트 기준 상대경로. 미지정은 루트 */
+        folderRel?: string;
     }): Promise<void> {
         // input_files/input_images 는 값이 있을 때만 컬럼에 포함 — 056/057 마이그레이션
         // 미적용 배포에서도 해당 값 없는 기존 생성 경로가 깨지지 않게 한다(2단계 배포 안전).
@@ -48,6 +50,10 @@ export class AgentTaskRepository extends BaseRepository {
         if (params.deviceId !== undefined) {
             cols.push('device_id');
             values.push(params.deviceId);
+        }
+        if (params.folderRel !== undefined) {
+            cols.push('folder_rel');
+            values.push(params.folderRel);
         }
         await this.query(
             `INSERT INTO agent_tasks (${cols.join(', ')}) VALUES (${values.map((_, i) => `$${i + 1}`).join(', ')})`,

--- a/apps/api/src/routes/agent-task.helpers.ts
+++ b/apps/api/src/routes/agent-task.helpers.ts
@@ -7,7 +7,31 @@ import { Request, Response } from 'express';
 import { notFound } from '../utils/api-response';
 import { assertResourceOwnerOrAdmin } from '../auth/ownership';
 import { getUnifiedDatabase } from '../data/models/unified-database';
+import { LOCAL_BRIDGE } from '../config/local-bridge';
+import { getLocalBridgeRegistry } from '../services/local-bridge/registry';
 import type { AgentTaskInputFile } from '../services/AgentTaskService';
+
+/**
+ * executor='local' 작업 생성 전 검증 — 기능 게이트/디바이스 연결/폴더 선택(102).
+ * folderRel 은 deviceId 지정 시에만 유효하며, 디바이스가 folders 열거로 스스로 보고한
+ * 값만 통과(세션 캐시 검증) — 웹발 임의 경로가 디바이스로 내려가지 않는 불변식.
+ * 문제 시 사용자 메시지 반환, 정상이면 null.
+ */
+export function validateLocalExecutorInput(userId: string, deviceId?: string, folderRel?: string): string | null {
+    if (!LOCAL_BRIDGE.ENABLED) return '로컬 실행 기능이 비활성화되어 있습니다 (LOCAL_EXECUTOR_ENABLED)';
+    if (!getLocalBridgeRegistry().getDevice(userId, deviceId)) {
+        return deviceId
+            ? `지정한 디바이스(${deviceId.slice(0, 12)}…)가 연결되어 있지 않습니다 — 디바이스에서 폴더를 다시 연결하세요`
+            : '연결된 로컬 디바이스가 없습니다 — 데스크톱 앱 또는 CLI 로 작업 폴더를 먼저 연결하세요';
+    }
+    if (folderRel) {
+        if (!deviceId) return 'folderRel 은 deviceId 와 함께 지정해야 합니다';
+        if (!getLocalBridgeRegistry().isEnumeratedFolder(userId, deviceId, folderRel)) {
+            return '디바이스가 보고하지 않은 폴더입니다 — 폴더 목록을 다시 조회한 뒤 선택하세요';
+        }
+    }
+    return null;
+}
 
 /** 소유권 검증 후 작업 반환 — 없거나 권한 없으면 응답 종료하고 undefined 반환 */
 export async function loadOwnedTask(req: Request, res: Response, taskId: string) {

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -120,7 +120,7 @@ router.post('/', (req: Request, res: Response, next) => {
     } else {
         input = req.body as CreateAgentTaskInput;
     }
-    const { goal, maxTurns, files, images, executor, deviceId } = input;
+    const { goal, maxTurns, files, images, executor, deviceId, folderRel } = input;
 
     const taskId = uuidv4();
     const db = getUnifiedDatabase();
@@ -137,6 +137,18 @@ router.post('/', (req: Request, res: Response, next) => {
                 ? `지정한 디바이스(${deviceId.slice(0, 12)}…)가 연결되어 있지 않습니다 — 디바이스에서 폴더를 다시 연결하세요`
                 : '연결된 로컬 디바이스가 없습니다 — 데스크톱 앱 또는 CLI 로 작업 폴더를 먼저 연결하세요'));
             return;
+        }
+        // 폴더 선택(102): deviceId 지정 시에만 유효 + 디바이스가 folders 열거로 스스로 보고한
+        // 값만 통과(세션 캐시 검증) — 웹발 임의 경로가 디바이스로 내려가지 않는 불변식.
+        if (folderRel) {
+            if (!deviceId) {
+                res.status(400).json(badRequest('folderRel 은 deviceId 와 함께 지정해야 합니다'));
+                return;
+            }
+            if (!getLocalBridgeRegistry().isEnumeratedFolder(userId, deviceId, folderRel)) {
+                res.status(400).json(badRequest('디바이스가 보고하지 않은 폴더입니다 — 폴더 목록을 다시 조회한 뒤 선택하세요'));
+                return;
+            }
         }
     }
 
@@ -227,6 +239,7 @@ router.post('/', (req: Request, res: Response, next) => {
         inputImages: Array.isArray(images) && images.length > 0 ? images : undefined,
         executor,
         deviceId: executor === 'local' ? deviceId : undefined,
+        folderRel: executor === 'local' ? folderRel : undefined,
     });
 
     const task = await db.getAgentTask(taskId);
@@ -343,6 +356,7 @@ router.post('/:taskId/execute', validate(executeAgentTaskSchema), asyncHandler(a
             images: Array.isArray(task.input_images) ? task.input_images as string[] : undefined,
             executor: (task.executor === 'local' ? 'local' : undefined),
             deviceId: task.device_id ?? undefined,
+            folderRel: task.folder_rel ?? undefined,
         }),
     });
 
@@ -428,6 +442,7 @@ router.post('/:taskId/resume', asyncHandler(async (req: Request, res: Response) 
             images: Array.isArray(task.input_images) ? task.input_images as string[] : undefined,
             executor: (task.executor === 'local' ? 'local' : undefined),
             deviceId: task.device_id ?? undefined,
+            folderRel: task.folder_rel ?? undefined,
             resume: {
                 conversation: cp.conversation as ChatMessage[],
                 fromTurn: (cp.completedTurn ?? 0) + 1,

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -51,7 +51,7 @@ import {
 } from '../services/agent-task/upload-store';
 import { claimUploadsAsInputFiles, ChunkStoreError } from '../services/agent-task/chunk-store';
 import { resolveDefaultMaxTurns } from '../services/agent-task/task-inputs';
-import { loadOwnedTask, toPublicTask } from './agent-task.helpers';
+import { loadOwnedTask, toPublicTask, validateLocalExecutorInput } from './agent-task.helpers';
 
 const logger = createLogger('AgentTaskRoutes');
 const router = Router();
@@ -126,29 +126,12 @@ router.post('/', (req: Request, res: Response, next) => {
     const db = getUnifiedDatabase();
     const userId = String(req.user!.id);
 
-    // Cowork D1a: local 실행은 기능 게이트 + 디바이스 연결이 있을 때만.
+    // Cowork D1a: local 실행은 기능 게이트 + 디바이스 연결 + 폴더 선택(102) 검증 (helpers 분리).
     if (executor === 'local') {
-        if (!LOCAL_BRIDGE.ENABLED) {
-            res.status(400).json(badRequest('로컬 실행 기능이 비활성화되어 있습니다 (LOCAL_EXECUTOR_ENABLED)'));
+        const localErr = validateLocalExecutorInput(userId, deviceId, folderRel);
+        if (localErr) {
+            res.status(400).json(badRequest(localErr));
             return;
-        }
-        if (!getLocalBridgeRegistry().getDevice(userId, deviceId)) {
-            res.status(400).json(badRequest(deviceId
-                ? `지정한 디바이스(${deviceId.slice(0, 12)}…)가 연결되어 있지 않습니다 — 디바이스에서 폴더를 다시 연결하세요`
-                : '연결된 로컬 디바이스가 없습니다 — 데스크톱 앱 또는 CLI 로 작업 폴더를 먼저 연결하세요'));
-            return;
-        }
-        // 폴더 선택(102): deviceId 지정 시에만 유효 + 디바이스가 folders 열거로 스스로 보고한
-        // 값만 통과(세션 캐시 검증) — 웹발 임의 경로가 디바이스로 내려가지 않는 불변식.
-        if (folderRel) {
-            if (!deviceId) {
-                res.status(400).json(badRequest('folderRel 은 deviceId 와 함께 지정해야 합니다'));
-                return;
-            }
-            if (!getLocalBridgeRegistry().isEnumeratedFolder(userId, deviceId, folderRel)) {
-                res.status(400).json(badRequest('디바이스가 보고하지 않은 폴더입니다 — 폴더 목록을 다시 조회한 뒤 선택하세요'));
-                return;
-            }
         }
     }
 

--- a/apps/api/src/routes/local-bridge.routes.ts
+++ b/apps/api/src/routes/local-bridge.routes.ts
@@ -6,7 +6,8 @@
 import { Router, Request, Response } from 'express';
 import { requireAuthOrApiKeyScope } from '../middlewares/api-key-auth';
 import { API_KEY_SCOPES } from '../config/api-key-scopes';
-import { success } from '../utils/api-response';
+import { success, badRequest } from '../utils/api-response';
+import { asyncHandler } from '../utils/error-handler';
 import { LOCAL_BRIDGE } from '../config/local-bridge';
 import { getLocalBridgeRegistry } from '../services/local-bridge/registry';
 
@@ -30,5 +31,44 @@ router.get('/status', requireAuthOrApiKeyScope(API_KEY_SCOPES.BRIDGE), (req: Req
         })),
     }));
 });
+
+/**
+ * GET /api/local-bridge/folders?deviceId=&path= — 연결 루트 하위 폴더 온디맨드 열거 (폴더 선택).
+ * 디바이스가 스스로 열거한 상대경로만 응답하며, 서버는 그 목록을 세션 캐시에 병합해
+ * 이후 folder 지정(작업 생성·bridge_exec)의 검증 근거로 쓴다. path 는 이전 응답의 에코만 허용.
+ */
+router.get('/folders', requireAuthOrApiKeyScope(API_KEY_SCOPES.BRIDGE), asyncHandler(async (req: Request, res: Response) => {
+    if (!LOCAL_BRIDGE.ENABLED) {
+        res.status(400).json(badRequest('로컬 실행 기능이 비활성화되어 있습니다 (LOCAL_EXECUTOR_ENABLED)'));
+        return;
+    }
+    const userId = String(req.user!.id);
+    const registry = getLocalBridgeRegistry();
+    const deviceId = typeof req.query.deviceId === 'string' && req.query.deviceId ? req.query.deviceId : undefined;
+    const dev = registry.getDevice(userId, deviceId);
+    if (!dev) {
+        res.status(400).json(badRequest('연결된 로컬 디바이스가 없습니다 — 데스크톱 앱 또는 CLI 로 작업 폴더를 먼저 연결하세요'));
+        return;
+    }
+    const rel = typeof req.query.path === 'string' ? req.query.path : '';
+    if (rel && !registry.isEnumeratedFolder(userId, dev.deviceId, rel)) {
+        res.status(400).json(badRequest('디바이스가 보고하지 않은 경로입니다 — 루트부터 다시 탐색하세요'));
+        return;
+    }
+    const r = await registry.request(userId, { kind: 'folders', ...(rel ? { path: rel } : {}) }, undefined, dev.deviceId);
+    if (!r.ok) {
+        // 구 디바이스(kind 미지원)·타임아웃 등 — 웹은 폴더 피커를 숨기고 루트 고정으로 동작.
+        res.status(400).json(badRequest(r.error ?? '폴더 목록을 가져오지 못했습니다'));
+        return;
+    }
+    const folders = (r.entries ?? []).filter((e) => typeof e === 'string' && e.length > 0);
+    registry.noteEnumeratedFolders(userId, dev.deviceId, folders);
+    res.json(success({
+        deviceId: dev.deviceId,
+        path: rel,
+        folders: folders.map((relPath) => ({ rel: relPath, name: relPath.split('/').pop() ?? relPath })),
+        truncated: !!r.truncated,
+    }));
+}));
 
 export default router;

--- a/apps/api/src/schemas/agent-task.schema.ts
+++ b/apps/api/src/schemas/agent-task.schema.ts
@@ -61,6 +61,13 @@ export const createAgentTaskSchema = z.strictObject({
     executor: z.enum(['sandbox', 'local']).optional(),
     // 다중 디바이스(101): 로컬 실행 대상 브리지 디바이스. 미지정은 최근 접속 디바이스 폴백.
     deviceId: z.string().min(1).max(64).optional(),
+    // 폴더 선택(102): 연결 루트 기준 상대경로 — deviceId 지정 시에만 유효, 디바이스가 folders
+    // 열거로 보고한 값만 라우트가 통과시킨다(세션 캐시 검증). 형식만 여기서 차단.
+    folderRel: z.string().min(1).max(512)
+        .refine((v) => !v.startsWith('/') && !v.includes('\\') && !v.includes('\0')
+            && v.split('/').every((seg) => seg !== '' && seg !== '.' && seg !== '..'),
+            { error: 'folderRel 은 루트 기준 상대경로여야 합니다 (선행 /·빈 세그먼트·.. 금지)' })
+        .optional(),
     files: z.array(taskInputFileSchema).max(FILE_ATTACH_LIMITS.MAX_FILES).optional(),
     images: z.array(
         z.string().startsWith('data:image/').max(FILE_ATTACH_LIMITS.MAX_IMAGE_DATAURL_CHARS)

--- a/apps/api/src/services/agent-task/executor-select.ts
+++ b/apps/api/src/services/agent-task/executor-select.ts
@@ -22,7 +22,7 @@ export interface ExecutorPlan {
 }
 
 export function resolveExecutorPlan(
-    input: Pick<AgentTaskRunInput, 'executor' | 'approvalPolicy' | 'deviceId'>,
+    input: Pick<AgentTaskRunInput, 'executor' | 'approvalPolicy' | 'deviceId' | 'folderRel'>,
     taskId: string,
     userId: string,
 ): ExecutorPlan {
@@ -37,6 +37,6 @@ export function resolveExecutorPlan(
     return {
         sandboxCfg,
         runtimeEnabled: sandboxCfg.enabled || isLocal,
-        remoteExecutor: isLocal ? new RemoteExecutor(taskId, userId, input.deviceId) : undefined,
+        remoteExecutor: isLocal ? new RemoteExecutor(taskId, userId, input.deviceId, input.folderRel) : undefined,
     };
 }

--- a/apps/api/src/services/agent-task/types.ts
+++ b/apps/api/src/services/agent-task/types.ts
@@ -66,6 +66,8 @@ export interface AgentTaskRunInput {
     executor?: 'sandbox' | 'local';
     /** 로컬 실행 대상 브리지 디바이스(101, 다중 디바이스) — 미지정은 최근 접속 폴백. */
     deviceId?: string;
+    /** 로컬 실행 대상 폴더(102, 폴더 선택) — 연결 루트 기준 상대경로. 미지정=루트. */
+    folderRel?: string;
     /** resume(이어하기): 기존 end-of-turn checkpoint 에서 복원 */
     resume?: {
         conversation: ChatMessage[];

--- a/apps/api/src/services/local-bridge/registry.folders.test.ts
+++ b/apps/api/src/services/local-bridge/registry.folders.test.ts
@@ -1,0 +1,100 @@
+/**
+ * 폴더 선택(102, 2026-08-21) — 열거 캐시(enumeratedFolders) 검증.
+ * folders 응답 병합, 루트 항상 유효, 미보고 폴더 거부, 재등록 시 캐시 리셋,
+ * RemoteExecutor folder 첨부(요청 페이로드)를 검증한다.
+ */
+import { getLocalBridgeRegistry, type DeviceSession } from './registry';
+import { RemoteExecutor } from './remote-executor';
+import type { WebSocket } from 'ws';
+
+function fakeWs(): { ws: WebSocket; sent: unknown[] } {
+    const sent: unknown[] = [];
+    const ws = {
+        readyState: 1, OPEN: 1, close: jest.fn(),
+        send: jest.fn((data: string) => sent.push(JSON.parse(data))),
+    } as unknown as WebSocket;
+    return { ws, sent };
+}
+
+function session(userId: string, deviceId: string, ws: WebSocket): DeviceSession {
+    return { userId, deviceId, label: `dev-${deviceId}`, folderName: 'root', ws, connectedAt: Date.now() };
+}
+
+describe('LocalBridgeRegistry 폴더 선택 열거 캐시', () => {
+    const reg = getLocalBridgeRegistry();
+    const wsList: WebSocket[] = [];
+
+    afterEach(() => {
+        for (const ws of wsList.splice(0)) reg.unregister(ws);
+    });
+
+    function add(userId: string, deviceId: string): { ws: WebSocket; sent: unknown[] } {
+        const f = fakeWs();
+        wsList.push(f.ws);
+        expect(reg.register(session(userId, deviceId, f.ws))).toBe(true);
+        return f;
+    }
+
+    test('루트(빈값/미지정)는 항상 유효, 미보고 폴더는 거부된다', () => {
+        add('u1', 'cli');
+        expect(reg.isEnumeratedFolder('u1', 'cli', undefined)).toBe(true);
+        expect(reg.isEnumeratedFolder('u1', 'cli', '')).toBe(true);
+        expect(reg.isEnumeratedFolder('u1', 'cli', 'apps')).toBe(false);
+    });
+
+    test('noteEnumeratedFolders 병합 후 통과, 미등록 디바이스는 무시된다', () => {
+        add('u1', 'cli');
+        reg.noteEnumeratedFolders('u1', 'cli', ['apps', 'apps/web']);
+        expect(reg.isEnumeratedFolder('u1', 'cli', 'apps')).toBe(true);
+        expect(reg.isEnumeratedFolder('u1', 'cli', 'apps/web')).toBe(true);
+        expect(reg.isEnumeratedFolder('u1', 'cli', 'docs')).toBe(false);
+        // 미등록 디바이스에 대한 병합은 no-op, 조회는 false
+        reg.noteEnumeratedFolders('u1', 'ghost', ['x']);
+        expect(reg.isEnumeratedFolder('u1', 'ghost', 'x')).toBe(false);
+    });
+
+    test('같은 deviceId 재등록(재연결)은 열거 캐시를 리셋한다', () => {
+        add('u1', 'cli');
+        reg.noteEnumeratedFolders('u1', 'cli', ['apps']);
+        expect(reg.isEnumeratedFolder('u1', 'cli', 'apps')).toBe(true);
+        add('u1', 'cli'); // 재등록 — 다른 루트로 재연결됐을 수 있으므로 리셋
+        expect(reg.isEnumeratedFolder('u1', 'cli', 'apps')).toBe(false);
+        expect(reg.isEnumeratedFolder('u1', 'cli', '')).toBe(true);
+    });
+});
+
+describe('RemoteExecutor 폴더 선택 folder 첨부', () => {
+    const reg = getLocalBridgeRegistry();
+    const wsList: WebSocket[] = [];
+
+    afterEach(() => {
+        for (const ws of wsList.splice(0)) reg.unregister(ws);
+    });
+
+    test('folderRel 지정 시 모든 브리지 요청 페이로드에 folder 가 실린다', async () => {
+        const f = fakeWs();
+        wsList.push(f.ws);
+        reg.register(session('u1', 'cli', f.ws));
+        const exec = new RemoteExecutor('task-1234-abcd', 'u1', 'cli', 'apps/web');
+        // 왕복 응답을 기다리지 않고 발신 프레임만 검증 (결과는 타임아웃 전에 수동 해소).
+        const p = exec.readFile('src/a.ts');
+        const frame = f.sent[0] as { type: string; reqId: string; kind: string; path: string; folder?: string };
+        expect(frame.type).toBe('bridge_exec');
+        expect(frame.kind).toBe('read');
+        expect(frame.folder).toBe('apps/web');
+        reg.handleResult('u1', frame.reqId, { ok: true, content: 'x' }, 'cli');
+        await expect(p).resolves.toBe('x');
+    });
+
+    test('folderRel 미지정이면 folder 필드가 없다 (현행 동작 회귀 없음)', async () => {
+        const f = fakeWs();
+        wsList.push(f.ws);
+        reg.register(session('u1', 'cli', f.ws));
+        const exec = new RemoteExecutor('task-1234-abcd', 'u1', 'cli');
+        const p = exec.readFile('src/a.ts');
+        const frame = f.sent[0] as { reqId: string; folder?: string };
+        expect(frame.folder).toBeUndefined();
+        reg.handleResult('u1', frame.reqId, { ok: true, content: 'y' }, 'cli');
+        await expect(p).resolves.toBe('y');
+    });
+});

--- a/apps/api/src/services/local-bridge/registry.ts
+++ b/apps/api/src/services/local-bridge/registry.ts
@@ -23,7 +23,7 @@ import { createLogger } from '../../utils/logger';
 const logger = createLogger('LocalBridge');
 
 /** 서버→디바이스 도구 요청 종류 — 이 외의 kind 는 존재하지 않는다(임의 RPC 금지). */
-export type BridgeKind = 'exec' | 'read' | 'write' | 'list' | 'listAll' | 'delete' | 'task_end' | 'browser' | 'worktree';
+export type BridgeKind = 'exec' | 'read' | 'write' | 'list' | 'listAll' | 'delete' | 'task_end' | 'browser' | 'worktree' | 'folders';
 
 /** worktree 연산 — 서버는 op 만 지정하고 git 명령은 디바이스가 고정 인자로 조립한다(명령 주입 차단). */
 export type WorktreeOp = 'add' | 'diff' | 'remove';
@@ -43,6 +43,14 @@ export interface BridgeRequestPayload {
      * (디바이스의 **작업 단위 일괄 승인** 범위 식별)에 쓰인다.
      */
     taskId?: string;
+    /**
+     * 폴더 선택(2026-08-21) — 연결 루트 기준 상대경로. exec cwd·파일 경로·worktree base 를
+     * 이 하위 폴더로 재지정한다. 웹 입력은 **작업 생성 시점**에 isEnumeratedFolder 로 검증
+     * (디바이스가 folders 응답으로 스스로 보고한 값만 — 웹발 임의 경로 차단)하고, 여기서
+     * 재검증하지 않는다(디바이스 재접속 시 세션 캐시가 리셋돼 실행 중 작업이 깨짐).
+     * 디바이스가 기존 safe()(realpath, 루트 탈출 차단)로 항상 재검증한다. 미지정=루트.
+     */
+    folder?: string;
 }
 
 /** 디바이스가 돌려주는 결과 (bridge_result). */
@@ -63,6 +71,8 @@ export interface BridgeResult {
     branch?: string;
     /** worktree remove 결과 — 변경분이 남아 보존했으면 true. */
     kept?: boolean;
+    /** folders 결과 — 열거 상한 초과로 목록이 절단됐으면 true. */
+    truncated?: boolean;
 }
 
 export interface DeviceSession {
@@ -73,6 +83,12 @@ export interface DeviceSession {
     folderName: string;
     ws: WebSocket;
     connectedAt: number;
+    /**
+     * 폴더 선택 세션 캐시 — 이 디바이스가 folders 응답으로 스스로 열거·보고한 루트 기준
+     * 상대경로 집합('' = 루트). 작업 생성·bridge_exec 의 folder 값은 이 집합에 있어야만
+     * 디바이스로 내려간다(디바이스 발원 검증). WS 세션과 수명을 같이한다.
+     */
+    enumeratedFolders?: Set<string>;
 }
 
 interface Pending {
@@ -108,6 +124,8 @@ class LocalBridgeRegistry {
             // 구 소켓을 능동 종료 — 방치하면 unregister 가 새 ws 만 매칭해 구 ws 는 유휴로 남는다.
             try { prev.ws.close(1000, 'device_reregistered'); } catch { /* already closing */ }
         }
+        // 루트('')는 항상 유효 — 열거 캐시는 등록 시점에 리셋(재연결 시 다른 루트일 수 있음).
+        session.enumeratedFolders = new Set(['']);
         byDevice.set(session.deviceId, session);
         logger.info(`[Bridge] 디바이스 등록: user=${session.userId} device=${session.deviceId} label="${session.label}" folder="${session.folderName}" (${byDevice.size}대)`);
         return true;
@@ -148,6 +166,20 @@ class LocalBridgeRegistry {
         const byDevice = this.devices.get(userId);
         if (!byDevice) return [];
         return [...byDevice.values()].sort((a, b) => a.connectedAt - b.connectedAt);
+    }
+
+    /** folders 응답 수신 시 열거 캐시 병합 — 이후 folder 지정 요청·작업 생성의 검증 근거. */
+    noteEnumeratedFolders(userId: string, deviceId: string, rels: string[]): void {
+        const dev = this.devices.get(userId)?.get(deviceId);
+        if (!dev) return;
+        dev.enumeratedFolders ??= new Set(['']);
+        for (const rel of rels) dev.enumeratedFolders.add(rel);
+    }
+
+    /** folder 값이 이 디바이스가 스스로 보고한 폴더인지 검증 ('' 또는 미지정 = 루트, 항상 유효). */
+    isEnumeratedFolder(userId: string, deviceId: string, rel: string | undefined): boolean {
+        if (!rel) return true;
+        return this.devices.get(userId)?.get(deviceId)?.enumeratedFolders?.has(rel) ?? false;
     }
 
     /** 도구 1회 왕복. 타임아웃/연결단절 시 ok=false 결과로 해소(throw 하지 않음 — 도구 오류로 전달). */

--- a/apps/api/src/services/local-bridge/remote-executor.ts
+++ b/apps/api/src/services/local-bridge/remote-executor.ts
@@ -54,10 +54,17 @@ export class RemoteExecutor implements TaskExecutor {
     /** worktree 작업 브랜치명 — 사용자 안내·결과 보고용. */
     private worktreeBranch: string | null = null;
 
-    constructor(taskId: string, userId: string, deviceId?: string) {
+    /**
+     * 폴더 선택(102) — 연결 루트 기준 상대경로. 지정 시 모든 브리지 요청에 folder 로 첨부되어
+     * 디바이스가 exec cwd·파일 경로·worktree base 를 이 하위 폴더로 재지정한다. undefined=루트.
+     */
+    private readonly folderRel?: string;
+
+    constructor(taskId: string, userId: string, deviceId?: string, folderRel?: string) {
         this.taskId = taskId;
         this.userId = userId;
         this.deviceId = deviceId;
+        this.folderRel = folderRel;
     }
 
     get label(): string { return `local:${this.deviceLabel}`; }
@@ -88,7 +95,8 @@ export class RemoteExecutor implements TaskExecutor {
     }
 
     private req(payload: BridgeRequestPayload): Promise<BridgeResult> {
-        return getLocalBridgeRegistry().request(this.userId, payload, undefined, this.deviceId);
+        const withFolder = this.folderRel ? { ...payload, folder: this.folderRel } : payload;
+        return getLocalBridgeRegistry().request(this.userId, withFolder, undefined, this.deviceId);
     }
 
     /** 파일 경로를 worktree 기준으로 변환. 격리가 없으면 원래 경로 그대로. */

--- a/apps/cli/src/bridge.ts
+++ b/apps/cli/src/bridge.ts
@@ -29,6 +29,8 @@ const SECRET_SUBPATHS = ['.ssh', '.aws', '.gnupg', '.kube', '.docker', '.config/
 const WORKTREE_DIR = '.openmake/worktrees';
 const WORKTREE_BRANCH_PREFIX = 'omk-task/';
 const TASK_ID_RE = /^[a-zA-Z0-9-]{8,64}$/;
+/** folders(하위 폴더 열거) 1회 상한 — 서버 BRIDGE_FOLDERS_MAX_ENTRIES 와 같은 축(디바이스측 강제). */
+const FOLDERS_MAX_ENTRIES = 200;
 
 const EXEC_DENYLIST: { re: RegExp; why: string }[] = [
     { re: /(^|[;&|(]|\s)sudo\s/, why: '권한 상승(sudo)' },
@@ -57,6 +59,8 @@ interface BridgeMsg {
     taskId?: string;
     spec?: unknown;
     message?: string;
+    /** 폴더 선택 — 연결 루트 기준 상대경로. exec cwd·파일 경로·worktree base 재지정. */
+    folder?: string;
 }
 interface BridgeResult {
     ok: boolean;
@@ -70,6 +74,7 @@ interface BridgeResult {
     worktreeRel?: string;
     branch?: string;
     kept?: boolean;
+    truncated?: boolean;
 }
 
 /** confirmExec 어댑터 — 터미널에서 y(실행)/a(작업 동안 모두)/n(거부). 비대화형은 자동 거부(fail-safe). */
@@ -153,15 +158,32 @@ export class CliBridge {
         } catch { return null; }
     }
 
-    /** 경로 스코프 가드 — 연결 폴더 밖/심링크 탈출 차단 (데스크톱 safe 이식). */
-    private safe(rel: string | undefined): string {
-        const abs = path.resolve(this.folderRoot, rel || '.');
-        if (abs !== this.folderRoot && !abs.startsWith(this.folderRoot + path.sep)) throw new Error(`폴더 스코프 밖 경로 거부: ${rel}`);
+    /** 경로 스코프 가드 — base 밖/심링크 탈출 차단 (데스크톱 safe 이식, 폴더 선택으로 base 일반화). */
+    private safeFrom(baseAbs: string, rel: string | undefined): string {
+        const abs = path.resolve(baseAbs, rel || '.');
+        if (abs !== baseAbs && !abs.startsWith(baseAbs + path.sep)) throw new Error(`폴더 스코프 밖 경로 거부: ${rel}`);
         let probe = abs;
         while (!fs.existsSync(probe)) probe = path.dirname(probe);
         const real = fs.realpathSync(probe);
-        if (real !== this.folderRoot && !real.startsWith(this.folderRoot + path.sep)) throw new Error(`심링크 스코프 탈출 거부: ${rel}`);
+        const baseReal = fs.realpathSync(baseAbs);
+        if (real !== baseReal && !real.startsWith(baseReal + path.sep)) throw new Error(`심링크 스코프 탈출 거부: ${rel}`);
         return abs;
+    }
+
+    /** 연결 루트 기준 스코프 가드 (기존 계약). */
+    private safe(rel: string | undefined): string {
+        return this.safeFrom(this.folderRoot, rel);
+    }
+
+    /**
+     * 폴더 선택(folder 필드) base 해석 — 루트 기준 상대경로를 safe() 재검증 후 실행 base 로 쓴다.
+     * 서버는 디바이스가 folders 로 보고한 값만 에코하지만, 여기서 다시 스코프를 강제한다(2중 방어).
+     */
+    private resolveBase(m: BridgeMsg): string {
+        if (!m.folder) return this.folderRoot;
+        const base = this.safe(m.folder);
+        if (!fs.existsSync(base) || !fs.statSync(base).isDirectory()) throw new Error(`실행 폴더가 존재하지 않습니다: ${m.folder}`);
+        return base;
     }
 
     // ── worktree (데스크톱 이식) ──
@@ -172,8 +194,8 @@ export class CliBridge {
             });
         });
     }
-    private async isGitRepo(): Promise<boolean> {
-        const r = await this.git(['rev-parse', '--is-inside-work-tree'], this.folderRoot);
+    private async isGitRepo(cwd: string): Promise<boolean> {
+        const r = await this.git(['rev-parse', '--is-inside-work-tree'], cwd);
         return r.code === 0 && r.stdout.trim() === 'true';
     }
     private excludeWorktreeDir(gitDir: string): void {
@@ -209,21 +231,23 @@ export class CliBridge {
         } catch { /* noop */ }
         return 'HEAD';
     }
-    private async handleWorktree(m: BridgeMsg, done: (r: BridgeResult) => void): Promise<void> {
+    private async handleWorktree(m: BridgeMsg, done: (r: BridgeResult) => void, base: string): Promise<void> {
         const taskId = String(m.taskId || '');
         if (!TASK_ID_RE.test(taskId)) { done({ ok: false, error: '잘못된 taskId 형식' }); return; }
+        // 폴더 선택 시 worktree 도 base(선택 폴더) 하위에 만들고, worktreeRel 은 base 기준
+        // 상대경로로 돌려준다 — 서버는 folder+worktreeRel 을 그대로 합성해 라우팅한다.
         const rel = `${WORKTREE_DIR}/${taskId}`;
-        const abs = path.join(this.folderRoot, rel);
+        const abs = path.join(base, rel);
         const branch = `${WORKTREE_BRANCH_PREFIX}${taskId.slice(0, 8)}`;
         if (m.op === 'add') {
-            if (!(await this.isGitRepo())) { done({ ok: false, error: 'git 레포가 아닙니다' }); return; }
-            const prefixR = await this.git(['rev-parse', '--show-prefix'], this.folderRoot);
+            if (!(await this.isGitRepo(base))) { done({ ok: false, error: 'git 레포가 아닙니다' }); return; }
+            const prefixR = await this.git(['rev-parse', '--show-prefix'], base);
             const sub = prefixR.code === 0 ? prefixR.stdout.trim().replace(/\/+$/, '') : '';
             const workRel = sub ? `${rel}/${sub}` : rel;
-            const gitDirR = await this.git(['rev-parse', '--absolute-git-dir'], this.folderRoot);
+            const gitDirR = await this.git(['rev-parse', '--absolute-git-dir'], base);
             if (gitDirR.code === 0) this.excludeWorktreeDir(gitDirR.stdout.trim());
             if (fs.existsSync(abs)) { done({ ok: true, worktreeRel: workRel, branch }); return; }
-            const r = await this.git(['worktree', 'add', abs, '-b', branch], this.folderRoot);
+            const r = await this.git(['worktree', 'add', abs, '-b', branch], base);
             if (r.code !== 0) { done({ ok: false, error: `worktree 생성 실패: ${(r.stderr || r.stdout).trim().slice(0, 300)}` }); return; }
             await this.writeBaseSha(abs);
             done({ ok: true, worktreeRel: workRel, branch });
@@ -243,9 +267,9 @@ export class CliBridge {
             const head = await this.git(['rev-parse', 'HEAD'], abs);
             const moved = head.code === 0 && head.stdout.trim() !== (await this.readBaseSha(abs));
             if ((st.code === 0 && st.stdout.trim() !== '') || moved) { done({ ok: true, kept: true, branch }); return; }
-            const r = await this.git(['worktree', 'remove', '--force', abs], this.folderRoot);
+            const r = await this.git(['worktree', 'remove', '--force', abs], base);
             if (r.code !== 0) { done({ ok: true, kept: true, branch }); return; }
-            await this.git(['branch', '-D', branch], this.folderRoot);
+            await this.git(['branch', '-D', branch], base);
             done({ ok: true, kept: false, branch });
             return;
         }
@@ -262,27 +286,30 @@ export class CliBridge {
         return out;
     }
 
-    private async confirmExec(command: string, taskId: string | undefined): Promise<boolean> {
+    private async confirmExec(command: string, taskId: string | undefined, base: string): Promise<boolean> {
         if (this.opts.autoApproveAll || process.env.OMK_BRIDGE_AUTO_APPROVE === '1') return true;
         if (taskId && this.autoApproveTasks.has(taskId)) return true;
-        const ans = await this.opts.confirm(command, taskId, this.folderRoot);
+        // 확인 창엔 유효 실행 폴더(base)를 보여준다 — 어느 폴더에서 도는지 투명하게.
+        const ans = await this.opts.confirm(command, taskId, base);
         if (ans === 'all' && taskId) { this.autoApproveTasks.add(taskId); return true; }
         return ans === 'yes';
     }
 
     private async handleExec(m: BridgeMsg, done: (r: BridgeResult) => void): Promise<void> {
+        // 폴더 선택(folder 필드) — 유효 base 를 먼저 확정. 미지정은 연결 루트(현행 동작).
+        const base = this.resolveBase(m);
         switch (m.kind) {
             case 'exec': {
                 const denied = matchDenylist(String(m.command || ''));
                 if (denied) { done({ ok: false, error: `위험 명령으로 차단됨: ${denied}`, exitCode: 126 }); return; }
-                if (!(await this.confirmExec(String(m.command || ''), m.taskId))) {
+                if (!(await this.confirmExec(String(m.command || ''), m.taskId, base))) {
                     done({ ok: false, error: '사용자가 명령 실행을 거부했습니다', exitCode: 126 }); return;
                 }
                 if (SANDBOX_ENABLED && !this.sandboxProfilePath) {
                     done({ ok: false, error: 'exec 샌드박스 프로파일을 준비하지 못해 실행을 거부했습니다. 비격리 실행이 필요하면 OMK_BRIDGE_SANDBOX=0 으로 실행하세요.', exitCode: 126 });
                     return;
                 }
-                const opts = { cwd: this.folderRoot, timeout: EXEC_TIMEOUT_MS, maxBuffer: MAX_BUFFER, encoding: 'utf8' as const, env: { ...process.env, PATH: this.resolveExecPath() } };
+                const opts = { cwd: base, timeout: EXEC_TIMEOUT_MS, maxBuffer: MAX_BUFFER, encoding: 'utf8' as const, env: { ...process.env, PATH: this.resolveExecPath() } };
                 const cb = (err: import('child_process').ExecFileException | null, stdout: string, stderr: string) => {
                     done({ ok: true, stdout: String(stdout), stderr: String(stderr), exitCode: err ? (typeof err.code === 'number' ? err.code : 1) : 0 });
                 };
@@ -293,29 +320,42 @@ export class CliBridge {
                 }
                 return;
             }
-            case 'read': done({ ok: true, content: fs.readFileSync(this.safe(m.path), 'utf8') }); return;
+            case 'read': done({ ok: true, content: fs.readFileSync(this.safeFrom(base, m.path), 'utf8') }); return;
             case 'write': {
-                const abs = this.safe(m.path);
+                const abs = this.safeFrom(base, m.path);
                 fs.mkdirSync(path.dirname(abs), { recursive: true });
                 fs.writeFileSync(abs, Buffer.from(m.contentB64 || '', 'base64'));
                 done({ ok: true }); return;
             }
             case 'list': {
-                const entries = fs.readdirSync(this.safe(m.path), { withFileTypes: true })
+                const entries = fs.readdirSync(this.safeFrom(base, m.path), { withFileTypes: true })
                     .map((e) => (e.isDirectory() ? `${e.name}/` : e.name));
                 done({ ok: true, entries }); return;
             }
-            case 'listAll': done({ ok: true, entries: this.walk(this.folderRoot, this.folderRoot, []) }); return;
+            case 'listAll': done({ ok: true, entries: this.walk(base, base, []) }); return;
             case 'delete': {
-                const abs = this.safe(m.path);
-                if (abs === this.folderRoot) throw new Error('연결 폴더 루트는 삭제할 수 없습니다');
+                const abs = this.safeFrom(base, m.path);
+                if (abs === base) throw new Error('연결 폴더 루트는 삭제할 수 없습니다');
                 fs.rmSync(abs, { recursive: true, force: true });
                 done({ ok: true }); return;
+            }
+            case 'folders': {
+                // 하위 폴더 온디맨드 열거(폴더 선택) — path 는 루트 기준, 숨김·심링크 제외,
+                // 결과는 루트 기준 상대경로(서버가 세션 캐시에 병합해 folder 검증 근거로 쓴다).
+                const dirAbs = this.safe(m.path);
+                const entries: string[] = [];
+                let truncated = false;
+                for (const e of fs.readdirSync(dirAbs, { withFileTypes: true })) {
+                    if (!e.isDirectory() || e.name.startsWith('.')) continue;
+                    if (entries.length >= FOLDERS_MAX_ENTRIES) { truncated = true; break; }
+                    entries.push(path.relative(this.folderRoot, path.join(dirAbs, e.name)).split(path.sep).join('/'));
+                }
+                done({ ok: true, entries, truncated }); return;
             }
             case 'browser':
                 done({ ok: false, error: 'CLI 브리지는 로컬 브라우저를 지원하지 않습니다' }); return;
             case 'worktree':
-                await this.handleWorktree(m, done); return;
+                await this.handleWorktree(m, done, base); return;
             case 'task_end':
                 if (m.taskId) this.autoApproveTasks.delete(m.taskId);
                 done({ ok: true }); return;

--- a/apps/desktop/bridge.js
+++ b/apps/desktop/bridge.js
@@ -113,7 +113,7 @@ let mainWin = null;          // exec 확인 다이얼로그의 부모 창
 const autoApproveTasks = new Set();
 
 /** exec 실행 전 사용자 확인(비우회). 거부/취소면 false. 실행될 명령 원문을 그대로 보여준다. */
-async function confirmExec(command, taskId) {
+async function confirmExec(command, taskId, base) {
   // 테스트 훅(개발/E2E 전용): 다이얼로그 없이 자동 승인 (다른 OMK_BRIDGE_* 훅과 동일 계열).
   if (process.env.OMK_BRIDGE_AUTO_APPROVE === '1') return true;
   if (taskId && autoApproveTasks.has(taskId)) return true;
@@ -121,7 +121,8 @@ async function confirmExec(command, taskId) {
   const r = await dialog.showMessageBox(mainWin || undefined, {
     type: 'warning',
     message: '에이전트가 이 셸 명령을 당신의 컴퓨터에서 실행하려고 합니다',
-    detail: `${preview}\n\n연결 폴더: ${folderRoot}\n${SANDBOX_ENABLED && sandboxProfilePath
+    // 폴더 선택 시 유효 실행 폴더(base)를 보여준다 — 어느 폴더에서 도는지 투명하게.
+    detail: `${preview}\n\n실행 폴더: ${base || folderRoot}\n${SANDBOX_ENABLED && sandboxProfilePath
       ? 'OS 샌드박스 적용: 폴더 밖 쓰기와 비밀 파일(.ssh/.aws 등) 읽기는 차단됩니다. 그 외 읽기·네트워크는 허용됩니다.'
       : '⚠️ 샌드박스 미적용: 이 명령은 당신 계정 권한으로 폴더 밖 파일·네트워크에 접근할 수 있습니다.'}${
       taskId ? '\n\n"이 작업 동안 모두 실행"을 고르면 이 작업이 끝날 때까지 다시 묻지 않습니다(다른 작업에는 적용되지 않습니다).' : ''}`,
@@ -201,17 +202,35 @@ function writeSandboxProfile(app, root, gitDir) {
     }
 }
 
-/** 스코프 가드 — 연결 폴더 밖 경로/심링크 탈출을 차단 (서버 safeRealWorkspacePath 등가). */
-function safe(rel) {
-  const abs = path.resolve(folderRoot, rel || '.');
-  if (abs !== folderRoot && !abs.startsWith(folderRoot + path.sep)) throw new Error(`폴더 스코프 밖 경로 거부: ${rel}`);
+/** 스코프 가드 — base 밖 경로/심링크 탈출을 차단 (서버 safeRealWorkspacePath 등가, 폴더 선택으로 base 일반화). */
+function safeFrom(baseAbs, rel) {
+  const abs = path.resolve(baseAbs, rel || '.');
+  if (abs !== baseAbs && !abs.startsWith(baseAbs + path.sep)) throw new Error(`폴더 스코프 밖 경로 거부: ${rel}`);
   // 존재하는 최근접 조상의 realpath 도 스코프 안이어야 함 (컨테이너 없는 로컬은 심링크가 유일한 탈출로).
   let probe = abs;
   while (!fs.existsSync(probe)) probe = path.dirname(probe);
   const real = fs.realpathSync(probe);
-  if (real !== folderRoot && !real.startsWith(folderRoot + path.sep)) throw new Error(`심링크 스코프 탈출 거부: ${rel}`);
+  const baseReal = fs.realpathSync(baseAbs);
+  if (real !== baseReal && !real.startsWith(baseReal + path.sep)) throw new Error(`심링크 스코프 탈출 거부: ${rel}`);
   return abs;
 }
+
+/** 연결 루트 기준 스코프 가드 (기존 계약). */
+function safe(rel) { return safeFrom(folderRoot, rel); }
+
+/**
+ * 폴더 선택(folder 필드) base 해석 — 루트 기준 상대경로를 safe() 재검증 후 실행 base 로 쓴다.
+ * 서버는 디바이스가 folders 로 보고한 값만 에코하지만, 여기서 다시 스코프를 강제한다(2중 방어).
+ */
+function resolveBase(m) {
+  if (!m.folder) return folderRoot;
+  const base = safe(m.folder);
+  if (!fs.existsSync(base) || !fs.statSync(base).isDirectory()) throw new Error(`실행 폴더가 존재하지 않습니다: ${m.folder}`);
+  return base;
+}
+
+/** folders(하위 폴더 열거) 1회 상한 — 서버 BRIDGE_FOLDERS_MAX_ENTRIES 와 같은 축(디바이스측 강제). */
+const FOLDERS_MAX_ENTRIES = 200;
 
 // ── worktree 격리 (로컬 실행기) ──────────────────────────────────────────
 // 에이전트가 사용자의 현재 작업트리·브랜치를 직접 건드리지 않도록, 연결 폴더가 git 레포면
@@ -236,9 +255,9 @@ function git(args, cwd) {
   });
 }
 
-/** 연결 폴더가 git 작업트리인지. worktree 안에서 재연결한 경우도 정상 동작한다. */
-async function isGitRepo() {
-  const r = await git(['rev-parse', '--is-inside-work-tree'], folderRoot);
+/** 연결 폴더(또는 선택 base)가 git 작업트리인지. worktree 안에서 재연결한 경우도 정상 동작한다. */
+async function isGitRepo(cwd) {
+  const r = await git(['rev-parse', '--is-inside-work-tree'], cwd);
   return r.code === 0 && r.stdout.trim() === 'true';
 }
 
@@ -287,26 +306,28 @@ async function readBaseSha(wtAbs) {
   return 'HEAD';
 }
 
-async function handleWorktree(m, done) {
+async function handleWorktree(m, done, base) {
   if (!folderRoot) { done({ ok: false, error: '폴더가 연결되지 않았습니다' }); return; }
   const taskId = String(m.taskId || '');
   if (!TASK_ID_RE.test(taskId)) { done({ ok: false, error: '잘못된 taskId 형식' }); return; }
+  // 폴더 선택 시 worktree 도 base(선택 폴더) 하위에 만들고, worktreeRel 은 base 기준
+  // 상대경로로 돌려준다 — 서버는 folder+worktreeRel 을 그대로 합성해 라우팅한다.
   const rel = `${WORKTREE_DIR}/${taskId}`;
-  const abs = path.join(folderRoot, rel);
+  const abs = path.join(base, rel);
   const branch = `${WORKTREE_BRANCH_PREFIX}${taskId.slice(0, 8)}`;
 
   if (m.op === 'add') {
-    if (!(await isGitRepo())) { done({ ok: false, error: 'git 레포가 아닙니다' }); return; }
+    if (!(await isGitRepo(base))) { done({ ok: false, error: 'git 레포가 아닙니다' }); return; }
     // worktree 는 **레포 전체**를 체크아웃한다. 연결 폴더가 레포 루트가 아니라 하위 디렉토리면
     // (예: 레포 /repo 를 두고 /repo/apps/web 을 연결) worktree 루트는 /repo 에 대응하므로,
     // 에이전트의 상대경로가 그대로면 다른 위치를 가리킨다. show-prefix 만큼 더 내려가 맞춘다.
-    const prefixR = await git(['rev-parse', '--show-prefix'], folderRoot);
+    const prefixR = await git(['rev-parse', '--show-prefix'], base);
     const sub = prefixR.code === 0 ? prefixR.stdout.trim().replace(/\/+$/, '') : '';
     const workRel = sub ? `${rel}/${sub}` : rel;
-    const gitDirR = await git(['rev-parse', '--absolute-git-dir'], folderRoot);
+    const gitDirR = await git(['rev-parse', '--absolute-git-dir'], base);
     if (gitDirR.code === 0) excludeWorktreeDir(gitDirR.stdout.trim());
     if (fs.existsSync(abs)) { done({ ok: true, worktreeRel: workRel, branch }); return; } // 재개 시 재사용
-    const r = await git(['worktree', 'add', abs, '-b', branch], folderRoot);
+    const r = await git(['worktree', 'add', abs, '-b', branch], base);
     if (r.code !== 0) { done({ ok: false, error: `worktree 생성 실패: ${(r.stderr || r.stdout).trim().slice(0, 300)}` }); return; }
     await writeBaseSha(abs);
     done({ ok: true, worktreeRel: workRel, branch });
@@ -334,9 +355,9 @@ async function handleWorktree(m, done) {
     const head = await git(['rev-parse', 'HEAD'], abs);
     const moved = head.code === 0 && head.stdout.trim() !== (await readBaseSha(abs));
     if ((st.code === 0 && st.stdout.trim() !== '') || moved) { done({ ok: true, kept: true, branch }); return; }
-    const r = await git(['worktree', 'remove', '--force', abs], folderRoot);
+    const r = await git(['worktree', 'remove', '--force', abs], base);
     if (r.code !== 0) { done({ ok: true, kept: true, branch }); return; } // 제거 실패도 보존으로 취급
-    await git(['branch', '-D', branch], folderRoot); // 변경 없는 빈 브랜치 정리(실패 무시)
+    await git(['branch', '-D', branch], base); // 변경 없는 빈 브랜치 정리(실패 무시)
     done({ ok: true, kept: false, branch });
     return;
   }
@@ -355,13 +376,15 @@ function walk(dir, base, out) {
 }
 
 async function handleExec(m, done) {
+  // 폴더 선택(folder 필드) — 유효 base 를 먼저 확정. 미지정은 연결 루트(현행 동작).
+  const base = resolveBase(m);
   switch (m.kind) {
     case 'exec': {
       // ① 명백히 위험한 패턴은 확인 없이 즉시 거부 (guardrail).
       const denied = matchDenylist(m.command);
       if (denied) { done({ ok: false, error: `위험 명령으로 차단됨: ${denied}`, exitCode: 126 }); return; }
       // ② 나머지는 실행 전 사용자 확인 (비우회). 같은 작업 안에서는 사용자가 일괄 승인할 수 있다.
-      if (!(await confirmExec(String(m.command || ''), m.taskId))) {
+      if (!(await confirmExec(String(m.command || ''), m.taskId, base))) {
         done({ ok: false, error: '사용자가 명령 실행을 거부했습니다', exitCode: 126 }); return;
       }
       // ③ OS 샌드박스로 감싸 실행 — 폴더 밖 쓰기·비밀 읽기를 커널이 차단한다.
@@ -370,7 +393,7 @@ async function handleExec(m, done) {
         done({ ok: false, error: 'exec 샌드박스 프로파일을 준비하지 못해 실행을 거부했습니다(폴더 재연결 필요). 비격리 실행이 필요하면 OMK_BRIDGE_SANDBOX=0 으로 앱을 실행하세요.', exitCode: 126 });
         return;
       }
-      const opts = { cwd: folderRoot, timeout: EXEC_TIMEOUT_MS, maxBuffer: MAX_BUFFER, env: { ...process.env, PATH: resolveExecPath() } };
+      const opts = { cwd: base, timeout: EXEC_TIMEOUT_MS, maxBuffer: MAX_BUFFER, env: { ...process.env, PATH: resolveExecPath() } };
       const cb = (err, stdout, stderr) => {
         done({ ok: true, stdout: String(stdout), stderr: String(stderr), exitCode: err ? (err.code ?? 1) : 0 });
       };
@@ -381,9 +404,9 @@ async function handleExec(m, done) {
       }
       return;
     }
-    case 'read': done({ ok: true, content: fs.readFileSync(safe(m.path), 'utf8') }); return;
+    case 'read': done({ ok: true, content: fs.readFileSync(safeFrom(base, m.path), 'utf8') }); return;
     case 'write': {
-      const abs = safe(m.path);
+      const abs = safeFrom(base, m.path);
       fs.mkdirSync(path.dirname(abs), { recursive: true });
       fs.writeFileSync(abs, Buffer.from(m.contentB64 || '', 'base64'));
       done({ ok: true }); return;
@@ -391,17 +414,31 @@ async function handleExec(m, done) {
     case 'list': {
       // 디렉토리는 '/' 접미사 — 모델이 폴더를 파일로 오인해 read 하다 EISDIR 로
       // 실패하고 하위 파일에 못 닿는 문제 방지 (샌드박스 실행기와 동일 규약).
-      const entries = fs.readdirSync(safe(m.path), { withFileTypes: true })
+      const entries = fs.readdirSync(safeFrom(base, m.path), { withFileTypes: true })
         .map((e) => (e.isDirectory() ? `${e.name}/` : e.name));
       done({ ok: true, entries });
       return;
     }
-    case 'listAll': done({ ok: true, entries: walk(folderRoot, folderRoot, []) }); return;
+    case 'listAll': done({ ok: true, entries: walk(base, base, []) }); return;
     case 'delete': {
-      const abs = safe(m.path);
-      if (abs === folderRoot) throw new Error('연결 폴더 루트는 삭제할 수 없습니다');
+      const abs = safeFrom(base, m.path);
+      if (abs === base) throw new Error('연결 폴더 루트는 삭제할 수 없습니다');
       fs.rmSync(abs, { recursive: true, force: true });
       done({ ok: true }); return;
+    }
+    case 'folders': {
+      // 하위 폴더 온디맨드 열거(폴더 선택) — path 는 루트 기준, 숨김·심링크 제외,
+      // 결과는 루트 기준 상대경로(서버가 세션 캐시에 병합해 folder 검증 근거로 쓴다).
+      const dirAbs = safe(m.path);
+      const entries = [];
+      let truncated = false;
+      for (const e of fs.readdirSync(dirAbs, { withFileTypes: true })) {
+        if (!e.isDirectory() || e.name.startsWith('.')) continue;
+        if (entries.length >= FOLDERS_MAX_ENTRIES) { truncated = true; break; }
+        entries.push(path.relative(folderRoot, path.join(dirAbs, e.name)).split(path.sep).join('/'));
+      }
+      done({ ok: true, entries, truncated });
+      return;
     }
     case 'browser': {
       // 로컬 브라우저(D3) — Electron 내장 Chromium 에서 액션 실행.
@@ -417,7 +454,7 @@ async function handleExec(m, done) {
       return;
     }
     case 'worktree':
-      await handleWorktree(m, done); return;
+      await handleWorktree(m, done, base); return;
     case 'task_end':
       agentBrowser.closeAll();   // 작업 종료 시 브라우저 패널 정리
       // 일괄 승인은 그 작업에만 유효 — 종료 즉시 회수한다.

--- a/apps/web/app/(workspace)/agent-tasks/page.tsx
+++ b/apps/web/app/(workspace)/agent-tasks/page.tsx
@@ -63,6 +63,8 @@ interface AgentTask {
   totalTokens?: number;
   /** Cowork D2: 'local' 이면 데스크톱 브리지 폴더에서 실행 */
   executor?: "sandbox" | "local";
+  /** 폴더 선택(102): 연결 루트 기준 실행 폴더 — 미지정은 루트 */
+  folderRel?: string;
   /** 실패 사유 — 코드(goal_incomplete/max_turns_exhausted/interrupted) 또는 자유 텍스트. */
   error?: string;
   /** 소유자 id — admin 전체 보기(viewAll)에서 타 사용자 작업 뱃지 표시용. */
@@ -91,6 +93,8 @@ interface ApiAgentTask {
   total_tokens?: number | null;
   /** Cowork D2: 실행 백엔드 — 'local' 이면 데스크톱 브리지 폴더에서 실행됨 */
   executor?: "sandbox" | "local";
+  /** 폴더 선택(102) — 연결 루트 기준 실행 폴더 (folder_rel 컬럼) */
+  folder_rel?: string | null;
   /** 실패 사유 (toPublicTask 가 노출하는 error 컬럼) */
   error?: string;
   /** 소유자 (toPublicTask 가 user_id 그대로 노출 — admin viewAll 에서 소유자 뱃지용) */
@@ -177,6 +181,7 @@ function mapTask(tr: TFn, t: ApiAgentTask): AgentTask {
     resumable: t.resumable,
     totalTokens: typeof t.total_tokens === "number" ? t.total_tokens : undefined,
     executor: t.executor,
+    folderRel: t.folder_rel || undefined,
     error: t.error || undefined,
     ownerId: t.user_id != null ? String(t.user_id) : undefined,
   };
@@ -356,7 +361,7 @@ function TaskDetailModal({
             <p className="text-sm text-fg">{detail.task.goal}</p>
             {detail.task.executor === "local" && (
               <span className="mt-2 inline-flex items-center rounded-full border border-accent bg-accent-soft px-2 py-0.5 text-[10px] font-medium text-accent">
-                {t("localBadge")}
+                {t("localBadge")}{detail.task.folder_rel ? ` · ${detail.task.folder_rel}` : ""}
               </span>
             )}
             <div className="mt-2 flex items-center gap-3 text-xs text-faint">

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -192,6 +192,7 @@ export function Composer() {
     agentApprovalMode,
     agentLocalExecutor,
     agentLocalDeviceId,
+    agentLocalFolderRel,
     imageMode,
     artifactMode,
     structuredMode,
@@ -203,6 +204,7 @@ export function Composer() {
     setAgentApprovalMode,
     setAgentLocalExecutor,
     setAgentLocalDeviceId,
+    setAgentLocalFolderRel,
     cycleStyle,
     setInputDraft,
     auth,
@@ -241,12 +243,25 @@ export function Composer() {
   });
   const bridgeConnected = !!bridgeData?.data?.connected;
   const bridgeDevices = bridgeData?.data?.devices ?? [];
+  // 폴더 선택(102): 연결 루트 하위 폴더 온디맨드 탐색 — 열 때마다 루트부터(서버 세션 캐시가
+  // 탐색 경로를 따라 쌓여야 folderRel 검증을 통과한다. 재접속 후 이전 선택 경로 직행 금지).
+  const [folderPickerOpen, setFolderPickerOpen] = useState(false);
+  const [folderBrowsePath, setFolderBrowsePath] = useState("");
   // 다중 디바이스(101): 선택 디바이스가 있으면 그것, 없으면 최근 접속(마지막) 디바이스로 고정.
   // 선택기가 안 뜨는 단일 디바이스에서도 명시 deviceId 를 작업에 실어 create↔execute 간
   // "최근 접속" 폴백이 다른 디바이스로 튀는 것을 막는다(서버 M3 회귀 차단).
   const selectedBridgeDevice = bridgeDevices.find((d) => d.deviceId === agentLocalDeviceId)
     ?? bridgeDevices[bridgeDevices.length - 1] ?? null;
   const bridgeFolder = selectedBridgeDevice?.folderName ?? bridgeData?.data?.folderName ?? "";
+  const { data: bridgeFoldersData, isLoading: bridgeFoldersLoading, isError: bridgeFoldersError } = useQuery({
+    queryKey: ["local-bridge-folders", selectedBridgeDevice?.deviceId, folderBrowsePath],
+    queryFn: () => ApiClient.get<{ data: { folders: { rel: string; name: string }[]; truncated: boolean } }>(
+      `/api/local-bridge/folders?deviceId=${encodeURIComponent(selectedBridgeDevice?.deviceId ?? "")}${folderBrowsePath ? `&path=${encodeURIComponent(folderBrowsePath)}` : ""}`,
+    ),
+    enabled: agentTaskMode && agentLocalExecutor && folderPickerOpen && !!selectedBridgeDevice,
+    staleTime: 10_000,
+    retry: false, // 구 디바이스(kind 미지원)는 재시도 무의미 — 즉시 미지원 안내
+  });
   // 검색어 없으면("/") 카테고리 그룹핑(전체), 있으면 평면 검색 목록
   const slashGrouped = slashDebounced.trim() === "";
   const rawSlashSkills: SkillSummary[] = slashCandidate ? slashSkillsData ?? [] : [];
@@ -337,6 +352,7 @@ export function Composer() {
         agentApprovalMode,
         agentLocalExecutor || undefined,
         agentLocalExecutor ? (selectedBridgeDevice?.deviceId ?? null) : null,
+        agentLocalExecutor ? agentLocalFolderRel : null,
       );
     } else if (structuredMode) {
       // 구조화 답변 토글 ON — REST /api/chat/structured (비스트리밍, 카드 렌더). 첨부는 미지원.
@@ -626,9 +642,19 @@ export function Composer() {
               {!bridgeConnected
                 ? t("localExec.disconnected")
                 : agentLocalExecutor
-                  ? t("localExec.on", { folder: bridgeFolder })
+                  ? t("localExec.on", { folder: agentLocalFolderRel ? `${bridgeFolder}/${agentLocalFolderRel}` : bridgeFolder })
                   : t("localExec.off")}
             </button>
+            {/* 폴더 선택(102): 연결 루트 하위 폴더 탐색·선택 — CLI 재시작 없이 실행 폴더 변경 */}
+            {agentLocalExecutor && bridgeConnected && (
+              <button
+                type="button"
+                onClick={() => { setFolderBrowsePath(""); setFolderPickerOpen((v) => !v); }}
+                className="rounded-md border border-border bg-surface-2 px-2 py-1 text-xs text-fg-1"
+              >
+                {t("localExec.folderPick")}
+              </button>
+            )}
             {/* 다중 디바이스(101): 2대 이상 접속 시 대상 디바이스 선택 — 1대면 현행 토글 UX 유지 */}
             {agentLocalExecutor && bridgeConnected && bridgeDevices.length > 1 && (
               <select
@@ -642,6 +668,51 @@ export function Composer() {
                   </option>
                 ))}
               </select>
+            )}
+          </div>
+        )}
+        {/* 폴더 선택(102) 탐색 패널 — 디바이스가 folders 로 열거해 보고한 하위 폴더만 표시 */}
+        {agentTaskMode && agentLocalExecutor && bridgeConnected && folderPickerOpen && (
+          <div className="mx-3 mt-1 rounded-md border border-border bg-surface-2 p-2 text-xs">
+            <div className="flex items-center gap-2 pb-1">
+              <span className="min-w-0 flex-1 truncate text-muted">{bridgeFolder}/{folderBrowsePath}</span>
+              {folderBrowsePath && (
+                <button
+                  type="button"
+                  onClick={() => setFolderBrowsePath(folderBrowsePath.split("/").slice(0, -1).join("/"))}
+                  className="shrink-0 rounded border border-border px-1.5 py-0.5 text-fg-1"
+                >
+                  {t("localExec.folderUp")}
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => { setAgentLocalFolderRel(folderBrowsePath || null); setFolderPickerOpen(false); }}
+                className="shrink-0 rounded border border-accent bg-accent-soft px-1.5 py-0.5 text-accent"
+              >
+                {t("localExec.folderSelectHere")}
+              </button>
+            </div>
+            {bridgeFoldersError ? (
+              <p className="text-muted">{t("localExec.folderUnsupported")}</p>
+            ) : bridgeFoldersLoading ? (
+              <p className="text-muted">…</p>
+            ) : (bridgeFoldersData?.data?.folders?.length ?? 0) === 0 ? (
+              <p className="text-muted">{t("localExec.folderEmpty")}</p>
+            ) : (
+              <div className="flex max-h-40 flex-wrap gap-1 overflow-y-auto">
+                {bridgeFoldersData?.data?.folders?.map((f) => (
+                  <button
+                    key={f.rel}
+                    type="button"
+                    onClick={() => setFolderBrowsePath(f.rel)}
+                    className="rounded border border-border px-1.5 py-0.5 text-fg-1 hover:bg-surface-3"
+                  >
+                    {f.name}/
+                  </button>
+                ))}
+                {bridgeFoldersData?.data?.truncated && <span className="text-muted">{t("localExec.folderTruncated")}</span>}
+              </div>
             )}
           </div>
         )}

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -177,6 +177,8 @@ interface AppState {
   agentLocalExecutor: boolean;
   /** 다중 디바이스(101): 로컬 실행 대상 브리지 디바이스 id — null 은 최근 접속 디바이스 폴백. */
   agentLocalDeviceId: string | null;
+  /** 폴더 선택(102): 로컬 실행 폴더 — 연결 루트 기준 상대경로. null 은 루트. */
+  agentLocalFolderRel: string | null;
   imageMode: boolean;
   artifactMode: boolean;
   /** 구조화 답변 모드 — ON 시 메시지를 REST /api/chat/structured 로 보내 카드 UI 로 렌더(비스트리밍). */
@@ -244,6 +246,7 @@ interface AppState {
   setAgentApprovalMode: (m: "all" | "high-risk" | "none") => void;
   setAgentLocalExecutor: (v: boolean) => void;
   setAgentLocalDeviceId: (v: string | null) => void;
+  setAgentLocalFolderRel: (v: string | null) => void;
   cycleStyle: () => void;
   setStyle: (m: ChatStyle) => void;
   setAuth: (auth: AppState["auth"]) => void;
@@ -309,6 +312,7 @@ export const useAppStore = create<AppState>()(
   agentApprovalMode: "all",
   agentLocalExecutor: false,
   agentLocalDeviceId: null,
+  agentLocalFolderRel: null,
   imageMode: false,
   artifactMode: false,
   structuredMode: false,
@@ -479,7 +483,9 @@ export const useAppStore = create<AppState>()(
   setSelectedModel: (m) => set({ selectedModel: m }),
   setAgentApprovalMode: (m) => set({ agentApprovalMode: m }),
   setAgentLocalExecutor: (v) => set({ agentLocalExecutor: v }),
-  setAgentLocalDeviceId: (v) => set({ agentLocalDeviceId: v }),
+  // 디바이스 변경 시 폴더 선택은 리셋 — 다른 디바이스의 경로가 남지 않게.
+  setAgentLocalDeviceId: (v) => set({ agentLocalDeviceId: v, agentLocalFolderRel: null }),
+  setAgentLocalFolderRel: (v) => set({ agentLocalFolderRel: v }),
   cycleStyle: () =>
     set((s) => ({
       style: STYLE_ORDER[(STYLE_ORDER.indexOf(s.style) + 1) % STYLE_ORDER.length],

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -588,6 +588,8 @@ export function useChatSocket() {
       localExecutor?: boolean,
       /** 다중 디바이스(101): 로컬 실행 대상 디바이스 id — 미지정은 최근 접속 디바이스 */
       localDeviceId?: string | null,
+      /** 폴더 선택(102): 연결 루트 기준 상대경로 — deviceId 와 함께일 때만 유효. null/미지정=루트 */
+      localFolderRel?: string | null,
     ) => {
       const goal = message.trim();
       const s = useAppStore.getState();
@@ -614,7 +616,7 @@ export function useChatSocket() {
               goal,
               files: [...payloadFiles, ...uploadRefs],
               ...(images && images.length > 0 ? { images } : {}),
-              ...(localExecutor ? { executor: "local", ...(localDeviceId ? { deviceId: localDeviceId } : {}) } : {}),
+              ...(localExecutor ? { executor: "local", ...(localDeviceId ? { deviceId: localDeviceId } : {}), ...(localDeviceId && localFolderRel ? { folderRel: localFolderRel } : {}) } : {}),
             },
           );
         } else if (binaryParts.length > 0) {
@@ -626,7 +628,7 @@ export function useChatSocket() {
             goal,
             ...(payloadFiles.length > 0 ? { files: payloadFiles } : {}),
             ...(images && images.length > 0 ? { images } : {}),
-            ...(localExecutor ? { executor: "local", ...(localDeviceId ? { deviceId: localDeviceId } : {}) } : {}),
+            ...(localExecutor ? { executor: "local", ...(localDeviceId ? { deviceId: localDeviceId } : {}), ...(localDeviceId && localFolderRel ? { folderRel: localFolderRel } : {}) } : {}),
           }));
           for (const f of binaryParts) fd.append("files", f.rawFile!, f.name);
           const resp = await fetch("/api/agent-tasks", {
@@ -650,7 +652,7 @@ export function useChatSocket() {
                 ? { files: files.map(toWireFile) }
                 : {}),
               ...(images && images.length > 0 ? { images } : {}),
-              ...(localExecutor ? { executor: "local", ...(localDeviceId ? { deviceId: localDeviceId } : {}) } : {}),
+              ...(localExecutor ? { executor: "local", ...(localDeviceId ? { deviceId: localDeviceId } : {}), ...(localDeviceId && localFolderRel ? { folderRel: localFolderRel } : {}) } : {}),
             },
           );
         }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -306,7 +306,13 @@
       "label": "Local run:",
       "off": "Run in server sandbox",
       "on": "Run in local folder: {folder}",
-      "disconnected": "Desktop app not connected"
+      "disconnected": "Desktop app not connected",
+      "folderPick": "Change folder",
+      "folderUp": "Up",
+      "folderSelectHere": "Run in this folder",
+      "folderUnsupported": "This device does not support folder browsing — update the CLI/app",
+      "folderEmpty": "No subfolders",
+      "folderTruncated": "…list truncated"
     }
   },
   "chat": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -306,7 +306,13 @@
       "label": "ローカル実行:",
       "off": "サーバーサンドボックスで実行",
       "on": "ローカルフォルダで実行: {folder}",
-      "disconnected": "デスクトップアプリ未接続"
+      "disconnected": "デスクトップアプリ未接続",
+      "folderPick": "フォルダ変更",
+      "folderUp": "上へ",
+      "folderSelectHere": "このフォルダで実行",
+      "folderUnsupported": "このデバイスはフォルダ探索に対応していません — CLI/アプリを更新してください",
+      "folderEmpty": "サブフォルダがありません",
+      "folderTruncated": "…一覧が省略されました"
     }
   },
   "chat": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -306,7 +306,13 @@
       "label": "로컬 실행:",
       "off": "서버 샌드박스에서 실행",
       "on": "로컬 폴더에서 실행: {folder}",
-      "disconnected": "데스크톱 앱 미연결"
+      "disconnected": "데스크톱 앱 미연결",
+      "folderPick": "폴더 변경",
+      "folderUp": "상위",
+      "folderSelectHere": "이 폴더에서 실행",
+      "folderUnsupported": "이 디바이스는 폴더 탐색을 지원하지 않습니다 — CLI/앱을 업데이트하세요",
+      "folderEmpty": "하위 폴더가 없습니다",
+      "folderTruncated": "…목록이 잘렸습니다"
     }
   },
   "chat": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -306,7 +306,13 @@
       "label": "本地执行:",
       "off": "在服务器沙箱中运行",
       "on": "在本地文件夹运行: {folder}",
-      "disconnected": "未连接桌面应用"
+      "disconnected": "未连接桌面应用",
+      "folderPick": "更改文件夹",
+      "folderUp": "上级",
+      "folderSelectHere": "在此文件夹中运行",
+      "folderUnsupported": "该设备不支持文件夹浏览 — 请更新 CLI/应用",
+      "folderEmpty": "没有子文件夹",
+      "folderTruncated": "…列表已截断"
     }
   },
   "chat": {

--- a/db/migrations/102_agent_task_folder_rel.sql
+++ b/db/migrations/102_agent_task_folder_rel.sql
@@ -1,0 +1,4 @@
+-- 102: 로컬 실행 대상 폴더 영속 (브리지 폴더 선택, 2026-08-21)
+-- executor='local' 작업이 연결 루트의 어느 하위 폴더를 cwd 로 실행되는지 기록 —
+-- 도구 위임 시 bridge 요청의 folder 값 + 상세/뱃지 노출용. NULL 은 연결 루트(현행 동작).
+ALTER TABLE agent_tasks ADD COLUMN IF NOT EXISTS folder_rel TEXT;


### PR DESCRIPTION
## 요약

로컬 실행(브리지)의 연결 루트(보안 경계)는 그대로 두고, **웹 composer 가 루트 하위 폴더를 온디맨드 탐색·선택**해 그 폴더를 cwd 로 로컬 agent-task 를 실행합니다 — CLI 재시작(재 connect) 불필요.

## 설계 핵심 (보안 불변식)

- 폴더 후보는 항상 **디바이스가 `folders` 요청에 스스로 열거해 보고한 상대경로**뿐. 서버는 그 목록을 WS 세션 캐시에 병합하고, 작업 생성의 `folderRel` 은 캐시에 있는 값만 통과(에코 검증) — 웹발 임의 경로가 디바이스로 내려가지 않음.
- 디바이스는 추가로 기존 `safe()`(realpath, 루트 탈출·심링크 차단)로 항상 재검증 — 서버 침해 시에도 노출 범위는 connect 로 동의한 루트를 넘지 못함(현행과 동일).
- `request()` 시점 재검증은 두지 않음: 디바이스 재접속 시 세션 캐시가 리셋돼 실행 중 작업이 깨지는 문제(생성 시 엄격 검증 + 디바이스 재검증으로 충족).

## 변경

- **프로토콜(추가 전용, 무중단)**: 신규 kind `folders`(숨김·심링크 제외, 상한 200 + truncated) + 전 kind 공통 `folder` 필드(exec cwd·파일 경로·worktree base 재지정). 구 디바이스는 `folders` 미지원 오류 → 웹은 피커 숨김·루트 고정(현행 동작).
- **서버**: registry `enumeratedFolders` 세션 캐시(재등록 리셋), `GET /api/local-bridge/folders`, 생성 스키마 `folderRel`(형식 차단) + 라우트 에코 검증, `agent_tasks.folder_rel`(마이그레이션 102, 멱등), RemoteExecutor 전 요청 folder 첨부.
- **디바이스(CLI `apps/cli/src/bridge.ts` · 데스크톱 `apps/desktop/bridge.js` 동일 이식)**: `safeFrom`(base 일반화), exec cwd·worktree(base 하위 생성, base 기준 worktreeRel)·listAll base 화, 승인 프롬프트에 유효 실행 폴더 표기.
- **웹**: composer 폴더 피커(열 때마다 루트부터 탐색 — 세션 캐시가 경로를 따라 쌓여야 검증 통과), store `agentLocalFolderRel`(디바이스 변경 시 리셋), 작업 상세 뱃지 폴더 표기, i18n 4언어.
- env: `BRIDGE_FOLDERS_MAX_ENTRIES`(기본 200) — `.env.example` 반영.

## 검증

- [x] `npm run lint` (변경 파일 0 errors)
- [x] `npx jest` 전체 2765 passed (신규 `registry.folders.test.ts` 포함 — 캐시 병합/재등록 리셋/미보고 거부/RemoteExecutor folder 첨부)
- [x] tsc 클린: apps/api · apps/cli · apps/web
- [x] DB 스키마 변경: 마이그레이션 `102_agent_task_folder_rel.sql` 포함(순번 충돌 없음, 부팅 자동 적용)
- [x] 환경변수 추가: `.env.example` 업데이트
- [ ] 라이브 E2E(배포 후): CLI connect → 웹 하위 폴더 선택 → exec cwd·worktree 브랜치 귀속 확인

전 기능이 `LOCAL_EXECUTOR_ENABLED` 게이트 뒤 — OFF 환경 무영향. 서버/디바이스/웹 배포 순서 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)