### PR TITLE
fix(local-bridge): 로컬 실행기 준비 로그에 선택 폴더(folderRel) 기록

### DIFF
--- a/apps/api/src/services/local-bridge/remote-executor.ts
+++ b/apps/api/src/services/local-bridge/remote-executor.ts
@@ -80,7 +80,9 @@ export class RemoteExecutor implements TaskExecutor {
         const dev = getLocalBridgeRegistry().getDevice(this.userId, this.deviceId);
         if (!dev) throw new Error('연결된 로컬 디바이스가 없습니다 — 데스크톱 앱 또는 CLI 로 작업 폴더를 먼저 연결하세요.');
         this.deviceLabel = `${dev.label}`;
-        logger.info(`[${this.taskId}] 로컬 실행기 준비 (device=${dev.deviceId}, folder="${dev.folderName}")`);
+        // folderRel(폴더 선택, 102)까지 남긴다 — 로그만으로 "어느 폴더에서 돌았는지" 추적 가능해야
+        // 한다(DB folder_rel 조회 없이 사고 분석·감사가 되도록).
+        logger.info(`[${this.taskId}] 로컬 실행기 준비 (device=${dev.deviceId}, folder="${dev.folderName}"${this.folderRel ? `/${this.folderRel}` : ''})`);
 
         if (!LOCAL_BRIDGE.WORKTREE_ENABLED) return;
         const r = await this.req({ kind: 'worktree', op: 'add', taskId: this.taskId });


### PR DESCRIPTION
## 요약

폴더 선택(#549, 102) 도입 후 남은 관측 공백을 메웁니다. `RemoteExecutor.create()` 의 준비 로그가 **연결 루트 이름만** 찍어, 작업이 실제로 어느 하위 폴더에서 실행됐는지는 DB `agent_tasks.folder_rel` 을 조회해야만 알 수 있었습니다. 사고 분석·감사가 로그 단독으로 가능하도록 `folderRel` 을 덧붙입니다.

**변경 전**
```
[task-xxx] 로컬 실행기 준비 (device=0ee81c86, folder="my-project")
```
**변경 후** (folderRel 지정 시에만 덧붙음 — 미지정은 기존 출력 그대로)
```
[task-xxx] 로컬 실행기 준비 (device=0ee81c86, folder="my-project/apps/web")
```

동작 변경 없음 — 로그 문자열 한 곳만 수정했습니다.

## 배경

#549 의 plan 5단계에 "관측: folderRel 기록"을 적어두고 구현에서 누락했던 항목입니다. 후속 점검에서 발견해 보완합니다.

## 검증

- [x] `npx tsc --noEmit` (apps/api) 클린
- [x] local-bridge 테스트 4 suites / 29 tests 통과
- [x] 파일 크기 가드(600줄) 통과

## 참고 — 문서 갱신은 이 PR 에 없음

같은 후속 작업으로 CLAUDE.md 에 로컬 실행 브리지 축(kind 화이트리스트, API key bridge 스코프만 WS Origin 면제, 보안 3축, worktree 격리, 폴더 선택 불변식, `apps/cli` 워크스페이스, Local Bridge env 블록, Phase 용어집 행)을 문서화했습니다. 다만 **CLAUDE.md 는 #193 에서 의도적으로 untrack 된 로컬 전용 문서**(`.gitignore` 의 `/CLAUDE.md`)라 커밋 대상에서 제외했고, 로컬 파일로만 갱신했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)