### PR TITLE
chore(desktop): v1.9.0 — 브리지 폴더 선택 반영 버전 bump

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmake-desktop",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "private": true,
   "description": "OpenMake LLM 데스크톱 셸 (macOS) — 운영 백엔드(외부 공개 도메인 / 로컬)를 네이티브 창으로",
   "author": "OpenMake Team",


### PR DESCRIPTION
## 요약

데스크톱 앱 버전을 1.8.1 → **1.9.0** 으로 올립니다. #549 의 폴더 선택 지원(`bridge.js` 의 `folders` kind + `folder` base 재지정)을 담은 빌드를 배포하기 위한 범프입니다.

`apps/desktop` 은 release-please 의 `extra-files` 대상이 아니라 수동 범프입니다. 1.8.1 게시(8/15) 이후 데스크톱 변경은 이 건 하나이고, 기능 추가라 기존 관행대로 minor 를 올렸습니다 (1.6.0 연결폴더 가시화, 1.7.0 browser 도구와 같은 축).

## 배포 상태 — 이미 게시 완료

dmg 는 git 에 넣지 않고 서버 디렉토리에 두는 구조라, 이 PR 은 버전 문자열 한 줄만 담습니다. 실제 게시는 이미 끝났습니다.

| 항목 | 값 |
|---|---|
| dmg | `OpenMake-1.9.0-arm64.dmg` (96MB, afterPack ad-hoc 재서명) |
| sha256 | `c921626e28a4798dba9294b98af52fd5bfe6c0ff010eb1b6e8922653f58b998e` |
| 게시 | `scripts/publish-desktop.sh` → `data/desktop-updates/` |
| 확인 | `GET /api/desktop/latest` → `1.9.0` (매니페스트는 요청 시점에 읽혀 재시작 불필요) |

이전 `OpenMake-1.8.1-arm64.dmg` 는 롤백 여지로 남겨뒀습니다.

## 검증

빌드 산출물이 실제로 새 코드를 담았는지 **번들 내부를 직접 확인**했습니다 (과거 "러너는 COPY라 재빌드 필수" 유형의 함정 대비):

```
app.asar 내 문자열 검색
  case 'folders'        → 1건
  FOLDERS_MAX_ENTRIES   → 존재
  resolveBase           → 존재
```

## 영향

이 배포 전까지 데스크톱 사용자는 웹 폴더 피커에서 "이 디바이스는 폴더 탐색을 지원하지 않습니다" 폴백을 보게 됩니다(설계된 안전 폴백이라 장애는 아님). 1.9.0 업데이트를 받으면 CLI 사용자와 동일하게 폴더 선택을 쓸 수 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)