### PR TITLE
fix(web-search): 검색 쿼리 길이 캡 — 장문 프롬프트의 provider 414 차단

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -755,6 +755,8 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # WEB_SEARCH_INJECT_MAX_RESULTS=10
 # 주입 결과당 snippet 최대 글자 수 (0/비정수 = 무제한, 기본 500)
 # WEB_SEARCH_INJECT_MAX_SNIPPET=500
+# 검색 쿼리 최대 글자 수 (초과분 단어 경계 절단, 0=무제한) — 장문 프롬프트가 쿼리로 흘러 provider URI 한도 414 나는 것 차단
+# WEB_SEARCH_QUERY_MAX_CHARS=200
 # 랭킹 관련도 중 쿼리 단어 매칭 비중(나머지는 수집순서). 0~1, 기본 0.7. 높일수록 검색어 매칭 우선.
 # SEARCH_TERM_RELEVANCE_WEIGHT=0.7
 

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -523,6 +523,12 @@ export const WEB_SEARCH_INJECTION = {
     MAX_RESULTS: parseInjectLimit(process.env.WEB_SEARCH_INJECT_MAX_RESULTS, 10),
     /** 결과당 주입 snippet 최대 글자 수 (초과 절단). 0 = 무제한(절단 안 함). 300→500: 결정적 사실이 스니펫 뒤쪽에 있어도 포함되게. */
     MAX_SNIPPET_CHARS: parseInjectLimit(process.env.WEB_SEARCH_INJECT_MAX_SNIPPET, 500),
+    /**
+     * 검색 쿼리 최대 글자 수 — 장문 프롬프트 전체가 웹검색 쿼리로 흘러가 provider URI 한도에
+     * 걸리던 414(네이버 hub·Daum, 2026-08-21 라이브) 차단. 검색엔진 실효 질의는 앞부분 수십
+     * 자로 충분하며, 초과분은 단어 경계에서 절단한다. 0 = 무제한.
+     */
+    QUERY_MAX_CHARS: parseInjectLimit(process.env.WEB_SEARCH_QUERY_MAX_CHARS, 200),
 } as const;
 
 /**

--- a/apps/api/src/mcp/web-search/search-orchestrator.ts
+++ b/apps/api/src/mcp/web-search/search-orchestrator.ts
@@ -100,6 +100,16 @@ function computeTermRelevance(terms: string[], result: SearchResult): number {
 export async function performWebSearch(query: string, options: { maxResults?: number; globalSearch?: boolean; language?: string; signal?: AbortSignal; preferRecent?: boolean } = {}): Promise<SearchResult[]> {
     const { maxResults = 30, globalSearch = true, language = 'en', signal, preferRecent = false } = options;
 
+    // 쿼리 길이 캡 — 장문 프롬프트 전체가 쿼리로 흘러오면 provider URI 한도에 걸린다
+    // (네이버 hub·Daum 414, 2026-08-21 라이브). 단어 경계에서 절단해 실효 질의만 남긴다.
+    const queryCap = WEB_SEARCH_INJECTION.QUERY_MAX_CHARS;
+    if (queryCap > 0 && query.length > queryCap) {
+        const cut = query.slice(0, queryCap);
+        const lastSpace = cut.lastIndexOf(' ');
+        query = (lastSpace > queryCap / 2 ? cut.slice(0, lastSpace) : cut).trim();
+        logger.info(`쿼리 절단: ${query.length}자로 캡 (원문 초과분 제거)`);
+    }
+
     // 고볼륨 모드: maxResults > 15이면 모든 소스에서 병렬 수집 (Deep Research 용)
     const highVolumeMode = maxResults > 15;
 


### PR DESCRIPTION
## 개요
웹검색 모드에 장문 프롬프트(수천 자)를 보내면 원문 전체가 검색 쿼리가 되어 네이버 hub·Daum 이 전부 414(URI Too Long)로 실패하던 문제를 수정합니다 (2026-08-21 라이브 6건 관측).

## 변경
- `performWebSearch` 진입부에서 쿼리를 `WEB_SEARCH_QUERY_MAX_CHARS`(기본 200, 0=무제한)로 단어 경계 절단 + 절단 로그
- `.env.example` 문서화

## 검증 (라이브)
- 짧은 쿼리 hub 직접 호출 200 확인(키·경로 정상) → 원인은 쿼리 길이로 특정
- 3,000자 쿼리 재현: 198자 절단 → 414 소멸, 네이버 웹문서 10건 정상 수신
- 웹검색 테스트 45 통과, tsc·lint 통과

## 참고
같이 점검한 `GET /api/desktop/manifest` 404 는 레포 이력 전체에 존재한 적 없는 경로(외부 스캐너 추정, 2회) — 조치 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)