### PR TITLE
feat(ios): 카메라 촬영·음성 입력 — 폰 기능 3단계

### DIFF
--- a/apps/ios/Info.plist
+++ b/apps/ios/Info.plist
@@ -18,5 +18,11 @@
 	<false/>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>"내 주변" 장소 검색 등 위치 관련 질문에 현재 위치를 활용합니다. 위치 첨부를 켠 메시지에만 1회 사용되며 저장되지 않습니다.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>촬영한 사진을 채팅에 첨부해 AI 에게 질문할 때 카메라를 사용합니다.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>음성으로 메시지를 입력할 때 마이크를 사용합니다.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>음성 입력을 텍스트로 변환할 때 음성 인식을 사용합니다.</string>
 </dict>
 </plist>

--- a/apps/ios/OpenMakeApp/Features/Camera/CameraPicker.swift
+++ b/apps/ios/OpenMakeApp/Features/Camera/CameraPicker.swift
@@ -1,0 +1,63 @@
+// 카메라 촬영 첨부 (폰 기능 3단계) — 촬영 이미지를 기존 vision 채널(dataURL images[])로.
+//
+// PhotosPicker(라이브러리)와 달리 즉석 촬영용. SwiftUI 네이티브 카메라 API 가 없어
+// UIImagePickerController(.camera) 를 래핑한다. 시뮬레이터는 카메라가 없으므로
+// 호출부가 isCameraAvailable 로 메뉴 노출을 가드한다.
+import SwiftUI
+import UIKit
+
+struct CameraPicker: UIViewControllerRepresentable {
+    /// 촬영 완료 시 JPEG 데이터 전달 (취소 시 미호출)
+    let onCapture: (Data) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    static var isCameraAvailable: Bool {
+        UIImagePickerController.isSourceTypeAvailable(.camera)
+    }
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        private let parent: CameraPicker
+        init(_ parent: CameraPicker) { self.parent = parent }
+
+        func imagePickerController(
+            _ picker: UIImagePickerController,
+            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+        ) {
+            // vision 입력엔 원본 해상도가 과함 — 긴 변 1568(모델 권장 상한 축)으로 축소 후 JPEG.
+            if let image = info[.originalImage] as? UIImage,
+               let data = image.resized(maxDimension: 1568).jpegData(compressionQuality: 0.8) {
+                parent.onCapture(data)
+            }
+            parent.dismiss()
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            parent.dismiss()
+        }
+    }
+}
+
+private extension UIImage {
+    func resized(maxDimension: CGFloat) -> UIImage {
+        let longest = max(size.width, size.height)
+        guard longest > maxDimension else { return self }
+        let scale = maxDimension / longest
+        let newSize = CGSize(width: size.width * scale, height: size.height * scale)
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = 1
+        return UIGraphicsImageRenderer(size: newSize, format: format).image { _ in
+            draw(in: CGRect(origin: .zero, size: newSize))
+        }
+    }
+}

--- a/apps/ios/OpenMakeApp/Features/Conversations/ConversationDetailView.swift
+++ b/apps/ios/OpenMakeApp/Features/Conversations/ConversationDetailView.swift
@@ -368,6 +368,12 @@ private struct MessageRow: View {
 /// LUMEN 컴포저 — accent-soft + 버튼, surface 입력 카드, 모드 칩(도트)
 private struct ChatComposer: View {
     @Environment(AppModel.self) private var model
+    /// 카메라 촬영 시트 (폰 기능 3단계) — 촬영 결과는 pendingImages(vision 채널)로
+    @State private var showCamera = false
+    /// 음성 입력 (폰 기능 3단계) — 녹음 중 실시간 전사를 draft 에 반영
+    @State private var speech = SpeechRecognizer()
+    /// 녹음 시작 시점의 기존 입력 — 실시간 전사가 이어붙도록 보존(덮어쓰기 방지)
+    @State private var draftBeforeRecording = ""
     @Binding var draft: String
     @Binding var photoItems: [PhotosPickerItem]
     @Binding var pendingImages: [String]
@@ -391,6 +397,11 @@ private struct ChatComposer: View {
                     Section("첨부") {
                         PhotosPicker(selection: $photoItems, maxSelectionCount: 3, matching: .images) {
                             Label("사진", systemImage: "photo")
+                        }
+                        if CameraPicker.isCameraAvailable {
+                            Button { showCamera = true } label: {
+                                Label("카메라", systemImage: "camera")
+                            }
                         }
                         Button { showFileImporter = true } label: {
                             Label("파일", systemImage: "doc")
@@ -426,6 +437,22 @@ private struct ChatComposer: View {
                         .padding(.leading, 14)
                         .padding(.vertical, 9)
 
+                    Button {
+                        if speech.isRecording {
+                            speech.stop() // 실시간 반영이 이미 draft 를 채움 — 종료만
+                        } else {
+                            draftBeforeRecording = draft
+                            Task { await speech.start() }
+                        }
+                    } label: {
+                        Image(systemName: speech.isRecording ? "mic.fill" : "mic")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(speech.isRecording ? Color.red : Lumen.faint)
+                            .frame(width: 30, height: 30)
+                            .symbolEffect(.pulse, isActive: speech.isRecording)
+                    }
+                    .padding(.bottom, 3)
+
                     Button(action: onSubmit) {
                         Image(systemName: "arrow.up")
                             .font(.system(size: 14, weight: .semibold))
@@ -446,6 +473,17 @@ private struct ChatComposer: View {
         .padding(.top, 6)
         .padding(.bottom, 8)
         .background(Lumen.bg)
+        .sheet(isPresented: $showCamera) {
+            CameraPicker { data in
+                pendingImages.append(DataURL.encode(data, mimeType: "image/jpeg"))
+            }
+            .ignoresSafeArea()
+        }
+        .onChange(of: speech.transcript) { _, text in
+            // 실시간 전사 — 녹음 시작 시점 입력 뒤에 이어붙인다(기존 입력 덮어쓰기 방지)
+            guard speech.isRecording, !text.isEmpty else { return }
+            draft = draftBeforeRecording.isEmpty ? text : draftBeforeRecording + " " + text
+        }
     }
 
     @ViewBuilder

--- a/apps/ios/OpenMakeApp/Features/Voice/SpeechRecognizer.swift
+++ b/apps/ios/OpenMakeApp/Features/Voice/SpeechRecognizer.swift
@@ -1,0 +1,105 @@
+// 음성 입력 (폰 기능 3단계) — Speech framework 온디바이스/서버 전사.
+//
+// 컴포저 마이크 버튼: 탭 → 녹음·실시간 전사(draft 에 반영) → 다시 탭 → 종료.
+// 전사 결과는 일반 텍스트로 기존 채팅 경로를 그대로 탄다(서버 변경 없음).
+// 권한(마이크·음성인식) 거부 시 시작하지 않고 상태만 남긴다(fail-open — 타이핑은 그대로 가능).
+import Foundation
+import Speech
+import AVFoundation
+
+@MainActor
+@Observable
+final class SpeechRecognizer {
+    enum State: Equatable {
+        case idle
+        case recording
+        case denied      // 권한 거부 — 설정 앱 안내용
+        case unavailable // 이 기기/로케일에서 인식 불가
+    }
+
+    private(set) var state: State = .idle
+    /// 이번 세션의 실시간 전사 텍스트 (부분 결과 포함)
+    private(set) var transcript: String = ""
+
+    private let recognizer: SFSpeechRecognizer?
+    private let audioEngine = AVAudioEngine()
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var task: SFSpeechRecognitionTask?
+
+    init(locale: Locale = Locale(identifier: "ko-KR")) {
+        // 기기 언어가 한국어가 아니어도 서비스 주 사용 언어(ko) 우선, 실패 시 기기 로케일
+        recognizer = SFSpeechRecognizer(locale: locale) ?? SFSpeechRecognizer()
+    }
+
+    var isRecording: Bool { state == .recording }
+
+    /// 녹음 시작 — 권한 요청(마이크+음성인식) 후 오디오 엔진 가동.
+    func start() async {
+        guard state != .recording else { return }
+        transcript = ""
+
+        let speechAuth = await withCheckedContinuation { (cont: CheckedContinuation<SFSpeechRecognizerAuthorizationStatus, Never>) in
+            SFSpeechRecognizer.requestAuthorization { cont.resume(returning: $0) }
+        }
+        guard speechAuth == .authorized else { state = .denied; return }
+
+        let micGranted = await AVAudioApplication.requestRecordPermission()
+        guard micGranted else { state = .denied; return }
+
+        guard let recognizer, recognizer.isAvailable else { state = .unavailable; return }
+
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.record, mode: .measurement, options: .duckOthers)
+            try session.setActive(true, options: .notifyOthersOnDeactivation)
+
+            let request = SFSpeechAudioBufferRecognitionRequest()
+            request.shouldReportPartialResults = true
+            self.request = request
+
+            let input = audioEngine.inputNode
+            let format = input.outputFormat(forBus: 0)
+            input.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+                request.append(buffer)
+            }
+            audioEngine.prepare()
+            try audioEngine.start()
+
+            task = recognizer.recognitionTask(with: request) { [weak self] result, error in
+                Task { @MainActor in
+                    guard let self else { return }
+                    if let result {
+                        self.transcript = result.bestTranscription.formattedString
+                    }
+                    if error != nil || (result?.isFinal ?? false) {
+                        self.stopEngineOnly()
+                    }
+                }
+            }
+            state = .recording
+        } catch {
+            stopEngineOnly()
+            state = .unavailable
+        }
+    }
+
+    /// 녹음 종료 — 최종 전사 텍스트를 반환한다.
+    @discardableResult
+    func stop() -> String {
+        request?.endAudio()
+        stopEngineOnly()
+        state = .idle
+        return transcript
+    }
+
+    private func stopEngineOnly() {
+        if audioEngine.isRunning {
+            audioEngine.stop()
+            audioEngine.inputNode.removeTap(onBus: 0)
+        }
+        task?.cancel()
+        task = nil
+        request = nil
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+}


### PR DESCRIPTION
## 개요
폰 기능 3단계 — **카메라 촬영 첨부**와 **음성 입력**을 추가합니다. 서버 변경 없음(기존 채널 재사용: 카메라→vision `images[]` dataURL, 음성→전사 후 일반 텍스트).

## 변경
- **CameraPicker**: `UIImagePickerController(.camera)` 래핑 — 첨부 메뉴에 "카메라"(카메라 없는 기기는 미노출), 촬영 이미지는 긴 변 1568 축소 후 JPEG 로 기존 이미지 첨부 경로 합류
- **SpeechRecognizer**: Speech framework 실시간 전사(ko-KR 우선) — 컴포저 마이크 버튼 토글, 녹음 중 pulse 표시 + draft 실시간 반영(시작 시점 입력 보존·이어붙임), 권한 거부 시 fail-open
- Info.plist 사용 문구 3종(카메라·마이크·음성인식)

## 검증
- 실기기(iPhone 17)·시뮬레이터(CI 동일 명령) 빌드 성공, 아이폰 설치 완료
- 음성인식·카메라는 실기기 전용 기능 — 기기에서 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)