### PR TITLE
chore(config): remove dead GEMINI_* env settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -210,14 +210,6 @@ SEARCH_SEMANTIC_RERANK_ENABLED=false
 LLM_DISABLE_THINKING_BY_DEFAULT=true
 
 # *******************************************************
-# 🌌 GEMINI 전용 상세 설정 (외부 BYO 키 — settings 페이지에서 등록)
-# *******************************************************
-GEMINI_THINK_ENABLED=true
-GEMINI_THINK_LEVEL=high
-GEMINI_NUM_CTX=32768
-GEMINI_WEB_SEARCH_ENABLED=true
-
-# *******************************************************
 # 🔐 서버 및 보안 설정
 # *******************************************************
 PORT=52416

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -25,7 +25,6 @@ function isUnsafeEnv(env: string | undefined): boolean {
     return !SAFE_ENVS_FOR_MISSING_SECRETS.has(env ?? '');
 }
 const logLevelSchema = z.enum(['debug', 'info', 'warn', 'error']);
-const geminiThinkLevelSchema = z.enum(['low', 'medium', 'high']);
 
 const booleanFromString = (defaultValue: boolean) =>
     z.preprocess((value) => {
@@ -159,12 +158,6 @@ export const envSchema = z
 
         // Logging
         LOG_LEVEL: logLevelSchema.default('info'),
-
-        // Gemini
-        GEMINI_THINK_ENABLED: booleanFromString(true),
-        GEMINI_THINK_LEVEL: geminiThinkLevelSchema.default('high'),
-        GEMINI_NUM_CTX: positiveIntWithDefault(32768),
-        GEMINI_WEB_SEARCH_ENABLED: booleanFromString(true),
 
         // External
         GOOGLE_API_KEY: z.string().default(''),

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -85,12 +85,6 @@ export interface EnvConfig {
     // Log
     logLevel: 'debug' | 'info' | 'warn' | 'error';
 
-    // Gemini
-    geminiThinkEnabled: boolean;
-    geminiThinkLevel: 'low' | 'medium' | 'high';
-    geminiNumCtx: number;
-    geminiWebSearchEnabled: boolean;
-
     // External services
     googleApiKey: string;
     googleCseId: string;
@@ -220,12 +214,6 @@ const DEFAULT_CONFIG: EnvConfig = {
 
     // Log
     logLevel: 'info',
-
-    // Gemini
-    geminiThinkEnabled: true,
-    geminiThinkLevel: 'high' as const,
-    geminiNumCtx: 32768,
-    geminiWebSearchEnabled: true,
 
     // External services
     googleApiKey: '',
@@ -364,10 +352,6 @@ export function loadConfig(): EnvConfig {
         LLM_GATEWAY_PROVIDERS: env('LLM_GATEWAY_PROVIDERS'),
         LLM_DISABLE_THINKING_BY_DEFAULT: env('LLM_DISABLE_THINKING_BY_DEFAULT'),
         LOG_LEVEL: env('LOG_LEVEL'),
-        GEMINI_THINK_ENABLED: env('GEMINI_THINK_ENABLED'),
-        GEMINI_THINK_LEVEL: env('GEMINI_THINK_LEVEL'),
-        GEMINI_NUM_CTX: env('GEMINI_NUM_CTX'),
-        GEMINI_WEB_SEARCH_ENABLED: env('GEMINI_WEB_SEARCH_ENABLED'),
         GOOGLE_API_KEY: env('GOOGLE_API_KEY'),
         GOOGLE_CSE_ID: env('GOOGLE_CSE_ID'),
         NAVER_CLIENT_ID: env('NAVER_CLIENT_ID'),
@@ -486,12 +470,6 @@ export function loadConfig(): EnvConfig {
 
         // Log
         logLevel: parsed.LOG_LEVEL ?? DEFAULT_CONFIG.logLevel,
-
-        // Gemini
-        geminiThinkEnabled: parsed.GEMINI_THINK_ENABLED ?? DEFAULT_CONFIG.geminiThinkEnabled,
-        geminiThinkLevel: parsed.GEMINI_THINK_LEVEL ?? DEFAULT_CONFIG.geminiThinkLevel,
-        geminiNumCtx: parsed.GEMINI_NUM_CTX ?? DEFAULT_CONFIG.geminiNumCtx,
-        geminiWebSearchEnabled: parsed.GEMINI_WEB_SEARCH_ENABLED ?? DEFAULT_CONFIG.geminiWebSearchEnabled,
 
         // External services
         googleApiKey: parsed.GOOGLE_API_KEY ?? DEFAULT_CONFIG.googleApiKey,


### PR DESCRIPTION
## 요약
- 죽은 `GEMINI_*` env 설정 4종 제거 (`GEMINI_THINK_ENABLED` / `GEMINI_THINK_LEVEL` / `GEMINI_NUM_CTX` / `GEMINI_WEB_SEARCH_ENABLED`)
- config 로드만 되고 코드 소비처 0건 — 2026-06-22 운영 `.env` 점검에서 이미 주석 처리된 상태
- `env.ts` 인터페이스/기본값/매핑 4곳, `env.schema.ts` Zod 키 4개 + 고아 `geminiThinkLevelSchema`, `.env.example` GEMINI 섹션 삭제

## 검증
- `tsc --noEmit` 통과
- config 유닛 테스트 9 스위트 72개 통과
- 변경 파일 eslint 통과
- 레포 전체 `GEMINI_*` env 참조 잔존 0건 확인 (llm-parameters.ts 의 `GEMINI_*` 프리셋 상수는 로컬 모델 role 프리셋으로 실사용 중이라 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)