### PR TITLE
feat(metrics): 게이트 판정 관측 루프 — 라우팅 게이트 집계 + 주간 리포트

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1075,6 +1075,17 @@ AGENT_TASK_TIMEOUT_MS=600000
 # AGENT_TASK_SCHEDULE_PUBLISH_FILE=report.html
 # AGENT_TASK_SCHEDULE_PUBLISH_TZ=Asia/Seoul
 
+# 주간 게이트 판정 리포트 — measure-first 게이트(워크플로우·오케스트레이션·tail 셰도우) 관측
+# 스냅샷을 무-LLM 결정적 렌더로 주 1회 생성. admin push + admin 전용 라우트
+# (GET /api/metrics/routing/report)로만 노출 (운영 지표라 공개 정적 게시 미사용). 기본 ON.
+# GATE_REPORT_ENABLED=true
+# GATE_REPORT_WEEKDAY=1                          # 생성 요일 (ISO 1=월 ~ 7=일)
+# GATE_REPORT_CHECK_INTERVAL_MS=3600000          # due 체크 주기 (당일 스냅샷 부재 시 생성, 멱등)
+# GATE_REPORT_WINDOW_DAYS=7
+# GATE_REPORT_MIN_SAMPLE=30                      # 판정 힌트 최소 표본 (미만이면 '표본 부족')
+# GATE_REPORT_DIR=<cwd>/data/gate-reports
+# GATE_REPORT_TZ=Asia/Seoul
+
 # Agent Task — 크로스-task 학습 (과거 유사 작업의 결과·도구·실패사유를 system 에 주입). 기본 OFF.
 # AGENT_TASK_LEARNING_ENABLED=true
 # AGENT_TASK_LEARNING_LOOKBACK=30

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1843,3 +1843,26 @@ export const AGENT_SELF_IMPROVE = {
     FIRST_RUN_DELAY_MS: parseInt(process.env.AGENT_SELF_IMPROVE_FIRST_RUN_DELAY_MS || '300000', 10),
     INTERVAL_MS: parseInt(process.env.AGENT_SELF_IMPROVE_INTERVAL_MS || String(6 * 60 * 60 * 1000), 10),
 } as const;
+
+/**
+ * 주간 게이트 판정 리포트 — measure-first 게이트(워크플로우·오케스트레이션·tail 셰도우)의
+ * 판정 근거를 무-LLM 결정적 렌더로 주 1회 스냅샷한다 (monitoring/gate-report.ts).
+ * 예약 리포트의 공개 정적 게시(schedule-publish)를 재사용하지 않는 이유: 그 경로는 인증
+ * 없이 서빙되는데 이 리포트는 운영 지표라 admin push + admin 전용 라우트로만 노출한다.
+ */
+export const GATE_REPORT = {
+    /** 기본 ON — 읽기 전용 집계 + admin 전용 노출. GATE_REPORT_ENABLED=false 로 해제. */
+    ENABLED: process.env.GATE_REPORT_ENABLED !== 'false',
+    /** 생성 요일 (ISO 1=월 ~ 7=일). GATE_REPORT_WEEKDAY(기본 1=월). */
+    WEEKDAY: parseInt(process.env.GATE_REPORT_WEEKDAY || '1', 10),
+    /** due 체크 주기(ms) — 해당 요일에 당일 스냅샷 부재 시 생성(멱등). GATE_REPORT_CHECK_INTERVAL_MS(기본 1h). */
+    CHECK_INTERVAL_MS: parseInt(process.env.GATE_REPORT_CHECK_INTERVAL_MS || '', 10) || 60 * 60 * 1000,
+    /** 집계 기간(일). GATE_REPORT_WINDOW_DAYS(기본 7). */
+    WINDOW_DAYS: parseInt(process.env.GATE_REPORT_WINDOW_DAYS || '7', 10),
+    /** 판정 힌트 최소 표본 — 미만이면 '표본 부족 — 계속 관측'. GATE_REPORT_MIN_SAMPLE(기본 30). */
+    MIN_SAMPLE: parseInt(process.env.GATE_REPORT_MIN_SAMPLE || '30', 10),
+    /** 스냅샷 저장 디렉토리 — 레포 루트 /data/ 는 gitignore 런타임 영역. GATE_REPORT_DIR. */
+    DIR: process.env.GATE_REPORT_DIR || `${process.cwd()}/data/gate-reports`,
+    /** 날짜·요일 판정 기준 TZ. GATE_REPORT_TZ(기본 Asia/Seoul). */
+    TZ: process.env.GATE_REPORT_TZ || 'Asia/Seoul',
+} as const;

--- a/apps/api/src/data/repositories/__tests__/routing-metrics-repository.test.ts
+++ b/apps/api/src/data/repositories/__tests__/routing-metrics-repository.test.ts
@@ -1,0 +1,124 @@
+import { Pool } from 'pg';
+import { RoutingMetricsRepository } from '../routing-metrics-repository';
+
+jest.mock('../../retry-wrapper', () => ({ withRetry: (fn: () => unknown) => fn() }));
+
+function makeMockPool() {
+    return { query: jest.fn() } as unknown as Pool;
+}
+
+describe('RoutingMetricsRepository', () => {
+    let pool: Pool;
+    let repo: RoutingMetricsRepository;
+
+    beforeEach(() => {
+        pool = makeMockPool();
+        repo = new RoutingMetricsRepository(pool);
+    });
+
+    it('getOrchestrationDispatchSummary: 의도/노출/호출/성공 FILTER + days 파라미터화', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({
+            rows: [{
+                total_turns: '820',
+                intent_turns: '61',
+                exposed_turns: '58',
+                called_turns: '19',
+                success_turns: '17',
+            }],
+        });
+        const row = await repo.getOrchestrationDispatchSummary(30);
+        expect(row.exposed_turns).toBe('58');
+        const [sql, params] = (pool.query as jest.Mock).mock.calls[0];
+        expect(sql).toMatch(/discussion_intent OR task_delegate_intent/);
+        expect(sql).toMatch(/cardinality\(tools_exposed\) > 0/);
+        expect(sql).toMatch(/tool_called IS NOT NULL/);
+        expect(sql).toMatch(/\$1 \|\| ' days'/);
+        expect(params).toEqual(['30']);
+    });
+
+    it('getOrchestrationDispatchSummary: 빈 결과 시 0 기본값', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+        const row = await repo.getOrchestrationDispatchSummary(7);
+        expect(row).toEqual({
+            total_turns: '0',
+            intent_turns: '0',
+            exposed_turns: '0',
+            called_turns: '0',
+            success_turns: '0',
+        });
+    });
+
+    it('getOrchestrationByTool: tool_called NOT NULL 한정 + GROUP BY', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({
+            rows: [{ tool_called: 'delegate_agent_task', turns: '12', success_turns: '11' }],
+        });
+        const rows = await repo.getOrchestrationByTool(30);
+        expect(rows[0].tool_called).toBe('delegate_agent_task');
+        const sql = (pool.query as jest.Mock).mock.calls[0][0];
+        expect(sql).toMatch(/tool_called IS NOT NULL/);
+        expect(sql).toMatch(/GROUP BY tool_called/);
+    });
+
+    it('getOrchestrationToggleRecall: user_mode none 제외 + 의도별 FILTER', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({
+            rows: [{
+                user_mode: 'discussion',
+                turns: '24',
+                discussion_intent_turns: '18',
+                task_delegate_intent_turns: '1',
+            }],
+        });
+        const rows = await repo.getOrchestrationToggleRecall(30);
+        expect(rows[0].discussion_intent_turns).toBe('18');
+        const sql = (pool.query as jest.Mock).mock.calls[0][0];
+        expect(sql).toMatch(/user_mode <> 'none'/);
+        expect(sql).toMatch(/GROUP BY user_mode/);
+    });
+
+    it('getTailShadowSummary: 라벨·grounding FILTER + 전기간 last_decision_at 서브쿼리', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({
+            rows: [{
+                total_decisions: '206',
+                tail_decisions: '4',
+                labeled_decisions: '120',
+                grounding_fired_decisions: '3',
+                grounding_fixed_decisions: '2',
+                last_decision_at: '2026-07-30T01:00:00.000Z',
+            }],
+        });
+        const row = await repo.getTailShadowSummary(30);
+        expect(row.tail_decisions).toBe('4');
+        const [sql, params] = (pool.query as jest.Mock).mock.calls[0];
+        expect(sql).toMatch(/COUNT\(a_was_correct\) AS labeled_decisions/);
+        // 신선도는 기간 밖 적재 중단도 보여야 하므로 last_decision_at 은 기간 필터 없는 서브쿼리
+        expect(sql).toMatch(/\(SELECT MAX\(created_at\) FROM routing_shadow_decisions\)/);
+        expect(params).toEqual(['30']);
+    });
+
+    it('getTailShadowSummary: 빈 결과 시 0·null 기본값', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+        const row = await repo.getTailShadowSummary(7);
+        expect(row).toEqual({
+            total_decisions: '0',
+            tail_decisions: '0',
+            labeled_decisions: '0',
+            grounding_fired_decisions: '0',
+            grounding_fixed_decisions: '0',
+            last_decision_at: null,
+        });
+    });
+
+    it('getTailShadowByVerifiability: NULL verifiability 행 보존', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({
+            rows: [
+                { verifiability: 'high', decisions: '80', tail_decisions: '4' },
+                { verifiability: null, decisions: '12', tail_decisions: '0' },
+            ],
+        });
+        const rows = await repo.getTailShadowByVerifiability(30);
+        expect(rows).toHaveLength(2);
+        expect(rows[1].verifiability).toBeNull();
+        const sql = (pool.query as jest.Mock).mock.calls[0][0];
+        expect(sql).toMatch(/GROUP BY verifiability/);
+    });
+});

--- a/apps/api/src/data/repositories/routing-metrics-repository.ts
+++ b/apps/api/src/data/repositories/routing-metrics-repository.ts
@@ -1,0 +1,162 @@
+/**
+ * @module data/repositories/routing-metrics-repository
+ * @description 라우팅·오케스트레이션 게이트 판정용 읽기 전용 집계 계층
+ *
+ * measure-first 게이트 판정에 필요한 셰도우 계측 테이블 2종을 집계한다.
+ * (agent-task 쪽 게이트 집계는 agent-task-metrics-repository 가 담당 — #540)
+ *
+ * - `orchestration_dispatch_decisions`(086/087): 오케스트레이션 자동 배정 Stage 1 의
+ *   노출/호출/성공, 사용자 토글 턴의 의도 적중(재현율 프록시). 086 마이그레이션 주석의
+ *   수동 분석 쿼리를 API 로 공식화한 것.
+ * - `routing_shadow_decisions`(061): tail 라우팅 게이트 셰도우. TAIL_ROUTING_SHADOW_ENABLED
+ *   가 기본 OFF 라 "언제까지 적재됐는가"(신선도) 자체가 관측 대상이므로 전기간 마지막
+ *   적재 시각을 함께 반환한다.
+ *
+ * 전부 파라미터화 쿼리, read-only. 숫자 파싱(COUNT 는 문자열로 옴)은 응답 조립부에 남긴다.
+ */
+import { BaseRepository } from './base-repository';
+
+/** 오케스트레이션 배정 요약 — 전체/의도/노출/호출/성공 턴 수 */
+export interface OrchestrationDispatchSummaryRow {
+    total_turns: string;
+    intent_turns: string;
+    exposed_turns: string;
+    called_turns: string;
+    success_turns: string;
+}
+
+/** 실제 호출된 도구별 턴 수·성공 수 */
+export interface OrchestrationByToolRow {
+    tool_called: string;
+    turns: string;
+    success_turns: string;
+}
+
+/** 사용자 수동 토글 턴에서 프리필터 의도가 잡힌 수 (재현율 프록시) */
+export interface OrchestrationToggleRow {
+    user_mode: string;
+    turns: string;
+    discussion_intent_turns: string;
+    task_delegate_intent_turns: string;
+}
+
+/** tail 셰도우 요약 — 기간 내 결정 수와 전기간 마지막 적재 시각(신선도) */
+export interface TailShadowSummaryRow {
+    total_decisions: string;
+    tail_decisions: string;
+    labeled_decisions: string;
+    grounding_fired_decisions: string;
+    grounding_fixed_decisions: string;
+    /** pg 는 TIMESTAMPTZ 를 Date 로 돌려준다 — 문자열 전제 소비처는 정규화할 것 */
+    last_decision_at: Date | string | null;
+}
+
+/** verifiability 축 분포 — tail 판정과의 교차 */
+export interface TailShadowVerifiabilityRow {
+    verifiability: string | null;
+    decisions: string;
+    tail_decisions: string;
+}
+
+export class RoutingMetricsRepository extends BaseRepository {
+    /**
+     * 오케스트레이션 배정 요약 — 노출 대비 호출률·호출 대비 성공률의 분자/분모.
+     * 비율 계산은 응답 조립부에서 수행한다.
+     */
+    async getOrchestrationDispatchSummary(days: number): Promise<OrchestrationDispatchSummaryRow> {
+        const result = await this.query<OrchestrationDispatchSummaryRow>(
+            `SELECT COUNT(*) AS total_turns,
+                    COUNT(*) FILTER (WHERE discussion_intent OR task_delegate_intent) AS intent_turns,
+                    COUNT(*) FILTER (WHERE cardinality(tools_exposed) > 0) AS exposed_turns,
+                    COUNT(*) FILTER (WHERE tool_called IS NOT NULL) AS called_turns,
+                    COUNT(*) FILTER (WHERE tool_success = true) AS success_turns
+             FROM orchestration_dispatch_decisions
+             WHERE created_at >= NOW() - ($1 || ' days')::interval`,
+            [String(days)]
+        );
+        return result.rows[0] ?? {
+            total_turns: '0',
+            intent_turns: '0',
+            exposed_turns: '0',
+            called_turns: '0',
+            success_turns: '0',
+        };
+    }
+
+    /** 실제 호출된 도구별 턴 수·성공 수 (start_discussion / delegate_agent_task) */
+    async getOrchestrationByTool(days: number): Promise<OrchestrationByToolRow[]> {
+        const result = await this.query<OrchestrationByToolRow>(
+            `SELECT tool_called,
+                    COUNT(*) AS turns,
+                    COUNT(*) FILTER (WHERE tool_success = true) AS success_turns
+             FROM orchestration_dispatch_decisions
+             WHERE tool_called IS NOT NULL
+               AND created_at >= NOW() - ($1 || ' days')::interval
+             GROUP BY tool_called
+             ORDER BY turns DESC, tool_called`,
+            [String(days)]
+        );
+        return result.rows;
+    }
+
+    /**
+     * 사용자 토글 턴의 의도 적중 — user_mode ≠ 'none' 인 턴에서 프리필터가
+     * 대응 의도를 잡았는지. 자동 배정이 수동 토글을 대체할 수 있는가의 재현율 프록시.
+     */
+    async getOrchestrationToggleRecall(days: number): Promise<OrchestrationToggleRow[]> {
+        const result = await this.query<OrchestrationToggleRow>(
+            `SELECT user_mode,
+                    COUNT(*) AS turns,
+                    COUNT(*) FILTER (WHERE discussion_intent) AS discussion_intent_turns,
+                    COUNT(*) FILTER (WHERE task_delegate_intent) AS task_delegate_intent_turns
+             FROM orchestration_dispatch_decisions
+             WHERE user_mode <> 'none'
+               AND created_at >= NOW() - ($1 || ' days')::interval
+             GROUP BY user_mode
+             ORDER BY turns DESC, user_mode`,
+            [String(days)]
+        );
+        return result.rows;
+    }
+
+    /**
+     * tail 셰도우 요약. last_decision_at 은 기간 필터 없이 전기간 MAX —
+     * 셰도우 플래그가 꺼져 적재가 멈춘 상태를 그대로 보여주기 위함이다.
+     */
+    async getTailShadowSummary(days: number): Promise<TailShadowSummaryRow> {
+        const result = await this.query<TailShadowSummaryRow>(
+            `SELECT COUNT(*) AS total_decisions,
+                    COUNT(*) FILTER (WHERE is_tail = true) AS tail_decisions,
+                    COUNT(a_was_correct) AS labeled_decisions,
+                    COUNT(*) FILTER (WHERE grounding_fired = true) AS grounding_fired_decisions,
+                    COUNT(*) FILTER (WHERE grounding_fixed = true) AS grounding_fixed_decisions,
+                    (SELECT MAX(created_at) FROM routing_shadow_decisions) AS last_decision_at
+             FROM routing_shadow_decisions
+             WHERE created_at >= NOW() - ($1 || ' days')::interval`,
+            [String(days)]
+        );
+        return result.rows[0] ?? {
+            total_decisions: '0',
+            tail_decisions: '0',
+            labeled_decisions: '0',
+            grounding_fired_decisions: '0',
+            grounding_fixed_decisions: '0',
+            last_decision_at: null,
+        };
+    }
+
+    /** verifiability 축 분포 — NULL(061 이전/미계산) 도 행으로 보존한다 */
+    async getTailShadowByVerifiability(days: number): Promise<TailShadowVerifiabilityRow[]> {
+        const result = await this.query<TailShadowVerifiabilityRow>(
+            `SELECT verifiability,
+                    COUNT(*) AS decisions,
+                    COUNT(*) FILTER (WHERE is_tail = true) AS tail_decisions
+             FROM routing_shadow_decisions
+             WHERE created_at >= NOW() - ($1 || ' days')::interval
+             GROUP BY verifiability
+             ORDER BY decisions DESC`,
+            [String(days)]
+        );
+        return result.rows;
+    }
+}

--- a/apps/api/src/data/user-manager.ts
+++ b/apps/api/src/data/user-manager.ts
@@ -246,6 +246,15 @@ class UserManagerImpl {
         return result.rows.length > 0;
     }
 
+    /** admin 역할 사용자 id 목록 — 운영 알림(주간 게이트 리포트 push 등) 수신자 조회용 */
+    async getAdminUserIds(): Promise<string[]> {
+        const result = await getPool().query<{ id: string }>(
+            `SELECT id FROM users WHERE role = $1 AND is_active = TRUE`,
+            [USER_ROLES.ADMIN]
+        );
+        return result.rows.map((r) => r.id);
+    }
+
     async createUser(input: CreateUserInput): Promise<PublicUser | null> {
         const pool = getPool();
         // 중복 체크 (email 기반, fast path)

--- a/apps/api/src/monitoring/__tests__/gate-report.test.ts
+++ b/apps/api/src/monitoring/__tests__/gate-report.test.ts
@@ -1,0 +1,101 @@
+import {
+    buildGateVerdicts,
+    escapeHtml,
+    gateReportDateStr,
+    gateReportWeekday,
+    renderGateReportHtml,
+    GateReportInput,
+} from '../gate-report';
+
+function makeInput(overrides?: Partial<GateReportInput>): GateReportInput {
+    return {
+        workflow: {
+            totalTasks: 120,
+            retryTasks: 18,
+            hitlDegradeTasks: 7,
+            planCoverage: 0.85,
+            completedTasks: 90,
+            unjudgedRate: 0.2,
+            goalIncompleteTasks: 3,
+        },
+        orchestration: { totalTurns: 800, exposedTurns: 60, calledTurns: 20, successTurns: 18 },
+        tailShadow: {
+            totalDecisions: 206,
+            tailDecisions: 4,
+            labeledDecisions: 120,
+            lastDecisionAt: '2026-07-30T01:00:00.000Z',
+        },
+        ...overrides,
+    };
+}
+
+describe('gate-report 순수 헬퍼', () => {
+    it('gateReportDateStr: TZ 기준 날짜 — UTC 자정 직전도 Seoul 은 다음날', () => {
+        // 2026-08-23(일) 23:30 UTC = Seoul 2026-08-24(월) 08:30
+        const now = new Date('2026-08-23T23:30:00Z');
+        expect(gateReportDateStr(now, 'Asia/Seoul')).toBe('2026-08-24');
+        expect(gateReportDateStr(now, 'UTC')).toBe('2026-08-23');
+    });
+
+    it('gateReportWeekday: ISO 요일 (1=월) — TZ 경계에서 요일이 갈린다', () => {
+        const now = new Date('2026-08-23T23:30:00Z');
+        expect(gateReportWeekday(now, 'Asia/Seoul')).toBe(1); // 월
+        expect(gateReportWeekday(now, 'UTC')).toBe(7); // 일
+    });
+
+    it('escapeHtml: 태그·따옴표 이스케이프', () => {
+        expect(escapeHtml('<script>"a"&b</script>')).toBe(
+            '&lt;script&gt;&quot;a&quot;&amp;b&lt;/script&gt;'
+        );
+    });
+});
+
+describe('buildGateVerdicts', () => {
+    it('표본 충분 시 3개 게이트 모두 판정 가능', () => {
+        const verdicts = buildGateVerdicts(makeInput(), 30);
+        expect(verdicts).toHaveLength(3);
+        expect(verdicts.every((v) => v.tone === 'ok')).toBe(true);
+    });
+
+    it('표본 부족 시 warn 톤 — 계속 관측', () => {
+        const verdicts = buildGateVerdicts(
+            makeInput({ orchestration: { totalTurns: 10, exposedTurns: 5, calledTurns: 2, successTurns: 2 } }),
+            30
+        );
+        const orch = verdicts[1];
+        expect(orch.tone).toBe('warn');
+        expect(orch.status).toContain('표본 부족');
+    });
+
+    it('tail 셰도우 적재 0건이면 danger — 플래그 확인 안내 포함', () => {
+        const verdicts = buildGateVerdicts(
+            makeInput({
+                tailShadow: { totalDecisions: 0, tailDecisions: 0, labeledDecisions: 0, lastDecisionAt: null },
+            }),
+            30
+        );
+        const tail = verdicts[2];
+        expect(tail.tone).toBe('danger');
+        expect(tail.status).toContain('적재 중단');
+        expect(tail.note).toContain('TAIL_ROUTING_SHADOW_ENABLED');
+        expect(tail.note).toContain('없음');
+    });
+});
+
+describe('renderGateReportHtml', () => {
+    it('템플릿 placeholder 치환 + 판정·상세 섹션 포함', async () => {
+        const html = await renderGateReportHtml(makeInput(), 7, '2026-08-24');
+        expect(html).toContain('2026-08-24');
+        expect(html).toContain('최근 7일');
+        expect(html).not.toContain('{{'); // placeholder 잔존 없음
+        expect(html).toContain('Execution Graph');
+        expect(html).toContain('오케스트레이션 자동 배정 상세');
+        expect(html).toContain('Tail 셰도우 상세');
+    });
+
+    it('동적 값 escape — 날짜 파라미터에 태그가 섞여도 그대로 출력되지 않는다', async () => {
+        const html = await renderGateReportHtml(makeInput(), 7, '<img src=x>');
+        expect(html).not.toContain('<img src=x>');
+        expect(html).toContain('&lt;img src=x&gt;');
+    });
+});

--- a/apps/api/src/monitoring/gate-report.ts
+++ b/apps/api/src/monitoring/gate-report.ts
@@ -1,0 +1,315 @@
+/**
+ * 주간 게이트 판정 리포트 — measure-first 게이트의 판정 근거 스냅샷 (무-LLM 결정적 렌더).
+ *
+ * plan: docs/proposals/2026-08-22-quality-flywheel-gate-observability-plan.md Stage 2.
+ * 대상 게이트 3종은 Stage 1 집계(repository)를 그대로 재사용한다:
+ *   ① Execution Graph 증분 — agent_tasks/agent_task_steps (retry·hitl_degrade·plan 귀속)
+ *   ② 오케스트레이션 자동 배정 — orchestration_dispatch_decisions(086)
+ *   ③ tail 라우팅 셰도우 — routing_shadow_decisions(061, 적재 중단 감지 포함)
+ * agent-resolver 게이트는 winston 로그 기반 별도 스크립트(scripts/daily-routing-report.sh)가
+ * 담당하므로 여기 포함하지 않는다.
+ *
+ * 노출 경로: admin push 알림 + admin 전용 라우트(GET /api/metrics/routing/report).
+ * 예약 리포트의 공개 정적 게시(schedule-publish)를 재사용하지 않는 이유 — 그 경로는 인증
+ * 없이 서빙되는데 이 리포트는 운영 지표다 (GATE_REPORT 설정 주석 참고).
+ *
+ * 멱등성: 스냅샷 파일(<DIR>/<YYYY-MM-DD>.html) 존재가 마커 — 재시작·tick 중복에 안전.
+ *
+ * @module monitoring/gate-report
+ */
+import { promises as fs } from 'fs';
+import path from 'path';
+import { GATE_REPORT } from '../config/runtime-limits';
+import { REPORT_TEMPLATES_DIR } from '../config/report-templates';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('GateReport');
+
+/** ISO 요일 매핑 — Intl 'en-US' short weekday 기준 (1=월 ~ 7=일) */
+const WEEKDAY_INDEX: Record<string, number> = {
+    Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6, Sun: 7,
+};
+
+/** 리포트 기준 TZ 의 날짜 문자열(YYYY-MM-DD) — 서버가 UTC 여도 날짜가 밀리지 않게 */
+export function gateReportDateStr(now: Date, tz: string): string {
+    return new Intl.DateTimeFormat('en-CA', {
+        timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit',
+    }).format(now);
+}
+
+/** 리포트 기준 TZ 의 ISO 요일 (1=월 ~ 7=일) */
+export function gateReportWeekday(now: Date, tz: string): number {
+    const name = new Intl.DateTimeFormat('en-US', { timeZone: tz, weekday: 'short' }).format(now);
+    return WEEKDAY_INDEX[name] ?? 0;
+}
+
+/** HTML escape — 리포트에 들어가는 모든 동적 값에 적용 */
+export function escapeHtml(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+/** 게이트별 판정 입력 — repository 집계를 순수 판정 로직에 넘기기 위한 평탄화 형태 */
+export interface GateReportInput {
+    workflow: {
+        totalTasks: number;
+        retryTasks: number;
+        hitlDegradeTasks: number;
+        planCoverage: number;
+        completedTasks: number;
+        unjudgedRate: number;
+        goalIncompleteTasks: number;
+    };
+    orchestration: {
+        totalTurns: number;
+        exposedTurns: number;
+        calledTurns: number;
+        successTurns: number;
+    };
+    tailShadow: {
+        totalDecisions: number;
+        tailDecisions: number;
+        labeledDecisions: number;
+        lastDecisionAt: string | null;
+    };
+}
+
+export interface GateVerdict {
+    gate: string;
+    sample: number;
+    /** 표시용 뱃지 톤 — ok(판정 가능)/warn(표본 부족)/danger(적재 중단) */
+    tone: 'ok' | 'warn' | 'danger';
+    status: string;
+    note: string;
+}
+
+/**
+ * 게이트별 판정 힌트 — 결정적 규칙만 사용한다(LLM 없음).
+ * "판정" 자체(채택/반려)는 사람 몫이고, 여기서는 표본 충분성·적재 중단만 기계 판정한다.
+ */
+export function buildGateVerdicts(input: GateReportInput, minSample: number): GateVerdict[] {
+    const pct = (v: number) => `${(v * 100).toFixed(1)}%`;
+    const sampleStatus = (sample: number): Pick<GateVerdict, 'tone' | 'status'> =>
+        sample >= minSample
+            ? { tone: 'ok', status: '판정 가능' }
+            : { tone: 'warn', status: `표본 부족 (<${minSample}) — 계속 관측` };
+
+    const wf = input.workflow;
+    const orch = input.orchestration;
+    const tail = input.tailShadow;
+
+    const verdicts: GateVerdict[] = [
+        {
+            gate: 'Execution Graph 증분 (DAG 게이트)',
+            sample: wf.totalTasks,
+            ...sampleStatus(wf.totalTasks),
+            note: `turn retry ${wf.retryTasks}건 · HITL 강등 ${wf.hitlDegradeTasks}건 · plan 귀속 ${pct(wf.planCoverage)} · 완료 무판정 ${pct(wf.unjudgedRate)} · goal_incomplete ${wf.goalIncompleteTasks}건`,
+        },
+        {
+            gate: '오케스트레이션 자동 배정 (활성화 기준)',
+            sample: orch.exposedTurns,
+            ...sampleStatus(orch.exposedTurns),
+            note: `노출 ${orch.exposedTurns}턴 → 호출 ${orch.calledTurns}턴 → 성공 ${orch.successTurns}턴 (전체 ${orch.totalTurns}턴)`,
+        },
+    ];
+
+    if (tail.totalDecisions === 0) {
+        verdicts.push({
+            gate: 'Tail 라우팅 Stage 2 (061 셰도우)',
+            sample: 0,
+            tone: 'danger',
+            status: '적재 중단 — 게이트 판정 불가',
+            note: `기간 내 셰도우 결정 0건. 마지막 적재 ${tail.lastDecisionAt ?? '없음'} — TAIL_ROUTING_SHADOW_ENABLED 확인 필요`,
+        });
+    } else {
+        verdicts.push({
+            gate: 'Tail 라우팅 Stage 2 (061 셰도우)',
+            sample: tail.totalDecisions,
+            ...sampleStatus(tail.totalDecisions),
+            note: `tail ${tail.tailDecisions}/${tail.totalDecisions}건 · 캘리브레이션 라벨 ${tail.labeledDecisions}건`,
+        });
+    }
+    return verdicts;
+}
+
+/** 판정 카드 HTML — 값은 전부 escape */
+function renderVerdictsHtml(verdicts: GateVerdict[]): string {
+    return verdicts
+        .map((v) => [
+            '<div class="card">',
+            `<h2>${escapeHtml(v.gate)}<span class="badge ${v.tone}">${escapeHtml(v.status)}</span></h2>`,
+            `<p class="note">표본 ${v.sample.toLocaleString('ko-KR')}건 — ${escapeHtml(v.note)}</p>`,
+            '</div>',
+        ].join('\n'))
+        .join('\n');
+}
+
+/** 상세 수치 테이블 카드 HTML */
+function renderSectionsHtml(input: GateReportInput): string {
+    const row = (label: string, value: string) =>
+        `<tr><td>${escapeHtml(label)}</td><td class="num">${escapeHtml(value)}</td></tr>`;
+    const pct = (v: number) => `${(v * 100).toFixed(1)}%`;
+    const wf = input.workflow;
+    const orch = input.orchestration;
+    const tail = input.tailShadow;
+    const rate = (num: number, den: number) => (den > 0 ? pct(num / den) : '—');
+
+    const table = (title: string, rows: string[]) =>
+        `<div class="card"><h2>${escapeHtml(title)}</h2><table><tbody>${rows.join('')}</tbody></table></div>`;
+
+    return [
+        table('작업 워크플로우 상세', [
+            row('기간 내 작업', String(wf.totalTasks)),
+            row('turn retry 발생 작업', `${wf.retryTasks} (${rate(wf.retryTasks, wf.totalTasks)})`),
+            row('HITL 무응답 강등 작업', `${wf.hitlDegradeTasks} (${rate(wf.hitlDegradeTasks, wf.totalTasks)})`),
+            row('plan 귀속 커버리지', pct(wf.planCoverage)),
+            row('완료 작업 / 무판정 비율', `${wf.completedTasks} / ${pct(wf.unjudgedRate)}`),
+            row('goal_incomplete 실패', String(wf.goalIncompleteTasks)),
+        ]),
+        table('오케스트레이션 자동 배정 상세', [
+            row('계측 턴', String(orch.totalTurns)),
+            row('도구 노출 턴', String(orch.exposedTurns)),
+            row('호출 턴 (노출 대비)', `${orch.calledTurns} (${rate(orch.calledTurns, orch.exposedTurns)})`),
+            row('성공 턴 (호출 대비)', `${orch.successTurns} (${rate(orch.successTurns, orch.calledTurns)})`),
+        ]),
+        table('Tail 셰도우 상세', [
+            row('셰도우 결정', String(tail.totalDecisions)),
+            row('tail 판정', `${tail.tailDecisions} (${rate(tail.tailDecisions, tail.totalDecisions)})`),
+            row('캘리브레이션 라벨', String(tail.labeledDecisions)),
+            row('마지막 적재 (전기간)', tail.lastDecisionAt ?? '없음'),
+        ]),
+    ].join('\n');
+}
+
+/** 템플릿 로드 + 치환 렌더 — 동적 값은 렌더 헬퍼들이 이미 escape 했다 */
+export async function renderGateReportHtml(
+    input: GateReportInput,
+    windowDays: number,
+    generatedAt: string,
+): Promise<string> {
+    const template = await fs.readFile(path.join(REPORT_TEMPLATES_DIR, 'gate-report.html'), 'utf8');
+    return template
+        .replace(/\{\{GENERATED_AT\}\}/g, escapeHtml(generatedAt))
+        .replace(/\{\{WINDOW_DAYS\}\}/g, String(windowDays))
+        .replace('{{VERDICTS_HTML}}', renderVerdictsHtml(buildGateVerdicts(input, GATE_REPORT.MIN_SAMPLE)))
+        .replace('{{SECTIONS_HTML}}', renderSectionsHtml(input));
+}
+
+/** Stage 1 집계 repository 들에서 판정 입력을 수집한다 */
+async function collectGateReportInput(days: number): Promise<GateReportInput> {
+    const { getPool } = await import('../data/models/unified-database');
+    const { RoutingMetricsRepository } = await import('../data/repositories/routing-metrics-repository');
+    const { AgentTaskMetricsRepository } = await import('../data/repositories/agent-task-metrics-repository');
+    const pool = getPool();
+    const routingRepo = new RoutingMetricsRepository(pool);
+    const taskRepo = new AgentTaskMetricsRepository(pool);
+
+    const [verdictRows, failureRows, interventionRow, coverageRow, dispatchRow, tailRow] = await Promise.all([
+        taskRepo.getCompletionVerdictDistribution(days),
+        taskRepo.getFailureReasons(days, 20),
+        taskRepo.getInterventionCounts(days),
+        taskRepo.getPlanAttributionCoverage(days),
+        routingRepo.getOrchestrationDispatchSummary(days),
+        routingRepo.getTailShadowSummary(days),
+    ]);
+
+    const completedTasks = verdictRows.reduce((sum, r) => sum + Number(r.tasks), 0);
+    const unjudgedTasks = verdictRows
+        .filter((r) => r.judge_verdict !== 'achieved' && r.judge_verdict !== 'not_achieved')
+        .reduce((sum, r) => sum + Number(r.tasks), 0);
+    const totalSteps = Number(coverageRow.total_steps);
+    const goalIncompleteTasks = failureRows
+        .filter((r) => r.reason.includes('goal_incomplete'))
+        .reduce((sum, r) => sum + Number(r.tasks), 0);
+
+    return {
+        workflow: {
+            totalTasks: Number(interventionRow.total_tasks),
+            retryTasks: Number(interventionRow.retry_tasks),
+            hitlDegradeTasks: Number(interventionRow.hitl_degrade_tasks),
+            planCoverage: totalSteps > 0 ? Number(coverageRow.attributed_steps) / totalSteps : 0,
+            completedTasks,
+            unjudgedRate: completedTasks > 0 ? unjudgedTasks / completedTasks : 0,
+            goalIncompleteTasks,
+        },
+        orchestration: {
+            totalTurns: Number(dispatchRow.total_turns),
+            exposedTurns: Number(dispatchRow.exposed_turns),
+            calledTurns: Number(dispatchRow.called_turns),
+            successTurns: Number(dispatchRow.success_turns),
+        },
+        tailShadow: {
+            totalDecisions: Number(tailRow.total_decisions),
+            tailDecisions: Number(tailRow.tail_decisions),
+            labeledDecisions: Number(tailRow.labeled_decisions),
+            // pg 는 TIMESTAMPTZ 를 Date 로 돌려준다 — 렌더는 문자열 전제라 여기서 정규화.
+            lastDecisionAt: tailRow.last_decision_at == null
+                ? null
+                : new Date(tailRow.last_decision_at).toISOString(),
+        },
+    };
+}
+
+/** admin 전원에게 리포트 준비 push — 실패는 리포트 생성을 뒤집지 않는다(fire-and-forget) */
+async function notifyAdmins(dateStr: string): Promise<void> {
+    try {
+        const { getUserManager } = await import('../data/user-manager');
+        const { getPushService } = await import('../services/PushService');
+        const ids = await getUserManager().getAdminUserIds();
+        for (const id of ids) {
+            void getPushService().sendPush(id, {
+                title: 'OpenMake 주간 게이트 리포트',
+                body: `${dateStr} 게이트 판정 리포트가 준비되었습니다.`,
+                url: '/api/metrics/routing/report',
+            }).catch(() => { /* noop */ });
+        }
+    } catch (e) {
+        logger.warn(`[GateReport] admin push 실패(무시): ${e instanceof Error ? e.message : e}`);
+    }
+}
+
+/**
+ * due 판정 + 생성 스윕 — 설정 요일에 당일 스냅샷이 없으면 생성한다.
+ * @returns 이번 호출에서 새로 생성했으면 true
+ */
+export async function runGateReportSweep(now: Date = new Date()): Promise<boolean> {
+    if (!GATE_REPORT.ENABLED) return false;
+    if (gateReportWeekday(now, GATE_REPORT.TZ) !== GATE_REPORT.WEEKDAY) return false;
+
+    const dateStr = gateReportDateStr(now, GATE_REPORT.TZ);
+    const datedPath = path.join(GATE_REPORT.DIR, `${dateStr}.html`);
+    try {
+        await fs.access(datedPath);
+        return false; // 당일분 존재 — 멱등
+    } catch { /* 미생성 — 진행 */ }
+
+    const input = await collectGateReportInput(GATE_REPORT.WINDOW_DAYS);
+    const html = await renderGateReportHtml(input, GATE_REPORT.WINDOW_DAYS, dateStr);
+    await fs.mkdir(GATE_REPORT.DIR, { recursive: true });
+    await fs.writeFile(datedPath, html);
+    await fs.writeFile(path.join(GATE_REPORT.DIR, 'latest.html'), html);
+    logger.info(`[GateReport] 주간 게이트 리포트 생성: ${datedPath} (${html.length} bytes)`);
+    await notifyAdmins(dateStr);
+    return true;
+}
+
+/**
+ * 스케줄러 등록 — 부팅 1회 + 주기 due 체크. 파일 존재가 멱등 마커라 중복 실행에 안전하다.
+ * @returns 활성화 여부 (플래그 OFF 면 false)
+ */
+export function startGateReportScheduler(): boolean {
+    if (!GATE_REPORT.ENABLED) return false;
+    void runGateReportSweep().catch((e) => {
+        logger.warn(`[GateReport] 부팅 스윕 실패(무시): ${e instanceof Error ? e.message : e}`);
+    });
+    const timer = setInterval(() => {
+        void runGateReportSweep().catch((e) => {
+            logger.warn(`[GateReport] 스윕 실패(무시): ${e instanceof Error ? e.message : e}`);
+        });
+    }, GATE_REPORT.CHECK_INTERVAL_MS);
+    timer.unref();
+    return true;
+}

--- a/apps/api/src/report-templates/gate-report.html
+++ b/apps/api/src/report-templates/gate-report.html
@@ -1,0 +1,48 @@
+<!-- 주간 게이트 판정 리포트 템플릿 — monitoring/gate-report.ts 가 이중 중괄호 placeholder 치환으로 렌더.
+     무-LLM 결정적 렌더: 동적 값은 전부 코드에서 escape 후 주입된다.
+     placeholder: GENERATED_AT · WINDOW_DAYS · VERDICTS_HTML · SECTIONS_HTML -->
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>주간 게이트 판정 리포트 — {{GENERATED_AT}}</title>
+<style>
+  :root { --fg:#1c1917; --muted:#78716c; --line:#e7e5e4; --bg:#fafaf9; --card:#ffffff;
+          --ok:#166534; --ok-bg:#dcfce7; --warn:#9a3412; --warn-bg:#ffedd5; --danger:#991b1b; --danger-bg:#fee2e2; }
+  @media (prefers-color-scheme: dark) {
+    :root { --fg:#e7e5e4; --muted:#a8a29e; --line:#292524; --bg:#0c0a09; --card:#1c1917;
+            --ok:#86efac; --ok-bg:#14532d; --warn:#fdba74; --warn-bg:#7c2d12; --danger:#fca5a5; --danger-bg:#7f1d1d; }
+  }
+  * { box-sizing: border-box; }
+  body { margin:0; padding:32px 16px; background:var(--bg); color:var(--fg);
+         font:15px/1.6 -apple-system, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif; }
+  main { max-width: 760px; margin: 0 auto; }
+  h1 { font-size:22px; margin:0 0 4px; }
+  .meta { color:var(--muted); font-size:13px; margin-bottom:24px; }
+  .card { background:var(--card); border:1px solid var(--line); border-radius:10px; padding:16px 20px; margin-bottom:16px; }
+  .card h2 { font-size:15px; margin:0 0 10px; }
+  .badge { display:inline-block; font-size:12px; padding:2px 8px; border-radius:999px; margin-left:8px; vertical-align:middle; }
+  .badge.ok { color:var(--ok); background:var(--ok-bg); }
+  .badge.warn { color:var(--warn); background:var(--warn-bg); }
+  .badge.danger { color:var(--danger); background:var(--danger-bg); }
+  .note { color:var(--muted); font-size:13px; margin:4px 0 0; }
+  table { width:100%; border-collapse:collapse; font-size:13px; }
+  th, td { text-align:left; padding:6px 8px; border-bottom:1px solid var(--line); }
+  td.num { text-align:right; font-variant-numeric: tabular-nums; }
+  footer { color:var(--muted); font-size:12px; margin-top:24px; }
+</style>
+</head>
+<body>
+<main>
+  <h1>주간 게이트 판정 리포트</h1>
+  <p class="meta">생성 {{GENERATED_AT}} · 집계 기간 최근 {{WINDOW_DAYS}}일 · 무-LLM 결정적 렌더</p>
+  {{VERDICTS_HTML}}
+  {{SECTIONS_HTML}}
+  <footer>
+    판정 근거 상세는 관리자 메트릭 페이지(/admin/metrics)에서 기간을 바꿔 볼 수 있습니다.
+    agent-resolver 게이트는 로그 기반 별도 집계(scripts/daily-routing-report.sh)가 담당합니다.
+  </footer>
+</main>
+</body>
+</html>

--- a/apps/api/src/routes/metrics.routes.ts
+++ b/apps/api/src/routes/metrics.routes.ts
@@ -31,6 +31,8 @@
  */
 
 import { Router, Request, Response } from 'express';
+import { promises as fsp } from 'fs';
+import * as path from 'path';
 import { getApiUsageTracker } from '../llm';
 import { getCacheSystem } from '../cache';
 import { getAlertSystem } from '../monitoring/alerts';
@@ -40,10 +42,12 @@ import { getAgentMonitor } from '../agents';
 import * as os from 'os';
 import { success } from '../utils/api-response';
 import { requireAuth, requireAdmin } from '../auth';
-import { asyncHandler } from '../utils/error-handler';
+import { asyncHandler, AppError } from '../utils/error-handler';
+import { GATE_REPORT } from '../config/runtime-limits';
 import { getPool } from '../data/models/unified-database';
 import { ConversationRepository } from '../data/repositories/conversation-repository';
 import { AgentTaskMetricsRepository } from '../data/repositories/agent-task-metrics-repository';
+import { RoutingMetricsRepository } from '../data/repositories/routing-metrics-repository';
 
 /** days 쿼리 파라미터 정수 파싱 + clamp(1~365). interval 인젝션 방지를 위해 항상 정수 반환. */
 function parseDays(raw: unknown, fallback = 7): number {
@@ -318,6 +322,92 @@ router.get('/agent-tasks/workflow', asyncHandler(async (req: Request, res: Respo
             coverage: totalSteps > 0 ? attributedSteps / totalSteps : 0,
         },
     }));
+}));
+
+/**
+ * GET /api/metrics/routing/gates?days=N
+ * 라우팅 게이트 관측 (관리자). 기본 30일.
+ * measure-first 게이트 판정 근거 — ① 오케스트레이션 자동 배정(086): 노출/호출/성공,
+ * 사용자 토글 턴 의도 적중(재현율 프록시) ② tail 라우팅 셰도우(061): tail 비율,
+ * 캘리브레이션 라벨·grounding 수, 전기간 마지막 적재 시각(셰도우 OFF 신선도).
+ */
+router.get('/routing/gates', asyncHandler(async (req: Request, res: Response) => {
+    const days = parseDays(req.query.days, 30);
+    const repo = new RoutingMetricsRepository(getPool());
+    const [dispatchRow, byToolRows, toggleRows, tailRow, verifiabilityRows] = await Promise.all([
+        repo.getOrchestrationDispatchSummary(days),
+        repo.getOrchestrationByTool(days),
+        repo.getOrchestrationToggleRecall(days),
+        repo.getTailShadowSummary(days),
+        repo.getTailShadowByVerifiability(days),
+    ]);
+
+    const exposedTurns = Number(dispatchRow.exposed_turns);
+    const calledTurns = Number(dispatchRow.called_turns);
+    const successTurns = Number(dispatchRow.success_turns);
+
+    const totalDecisions = Number(tailRow.total_decisions);
+    const tailDecisions = Number(tailRow.tail_decisions);
+
+    res.json(success({
+        days,
+        orchestration: {
+            totalTurns: Number(dispatchRow.total_turns),
+            intentTurns: Number(dispatchRow.intent_turns),
+            exposedTurns,
+            calledTurns,
+            successTurns,
+            callRate: exposedTurns > 0 ? calledTurns / exposedTurns : 0,
+            successRate: calledTurns > 0 ? successTurns / calledTurns : 0,
+            byTool: byToolRows.map((r) => ({
+                tool: r.tool_called,
+                turns: Number(r.turns),
+                successTurns: Number(r.success_turns),
+            })),
+            toggles: toggleRows.map((r) => ({
+                userMode: r.user_mode,
+                turns: Number(r.turns),
+                discussionIntentTurns: Number(r.discussion_intent_turns),
+                taskDelegateIntentTurns: Number(r.task_delegate_intent_turns),
+            })),
+        },
+        tailShadow: {
+            totalDecisions,
+            tailDecisions,
+            tailRate: totalDecisions > 0 ? tailDecisions / totalDecisions : 0,
+            labeledDecisions: Number(tailRow.labeled_decisions),
+            groundingFired: Number(tailRow.grounding_fired_decisions),
+            groundingFixed: Number(tailRow.grounding_fixed_decisions),
+            lastDecisionAt: tailRow.last_decision_at,
+            byVerifiability: verifiabilityRows.map((r) => ({
+                verifiability: r.verifiability,
+                decisions: Number(r.decisions),
+                tailDecisions: Number(r.tail_decisions),
+            })),
+        },
+    }));
+}));
+
+/**
+ * GET /api/metrics/routing/report?date=YYYY-MM-DD|latest
+ * 주간 게이트 판정 리포트 HTML (관리자). 기본 latest.
+ * monitoring/gate-report.ts 가 주 1회 생성한 스냅샷을 서빙 — 운영 지표라 공개 정적
+ * 경로(schedule-publish) 대신 admin 인증 뒤에서만 노출한다.
+ */
+router.get('/routing/report', asyncHandler(async (req: Request, res: Response) => {
+    const raw = String(req.query.date ?? 'latest');
+    // 날짜 형식 강제 — 파일명으로 쓰이므로 경로 탈출을 원천 차단한다.
+    const name = raw === 'latest' || /^\d{4}-\d{2}-\d{2}$/.test(raw) ? raw : null;
+    if (!name) {
+        throw new AppError('date 는 YYYY-MM-DD 또는 latest 여야 합니다.', 400, true, 'INVALID_DATE');
+    }
+    let html: string;
+    try {
+        html = await fsp.readFile(path.join(GATE_REPORT.DIR, `${name}.html`), 'utf8');
+    } catch {
+        throw new AppError('게이트 리포트가 아직 생성되지 않았습니다.', 404, true, 'REPORT_NOT_FOUND');
+    }
+    res.type('html').send(html);
 }));
 
 /**

--- a/apps/api/src/schedulers/index.ts
+++ b/apps/api/src/schedulers/index.ts
@@ -132,6 +132,14 @@ export async function startAllSchedulers(): Promise<void> {
         logger.warn('아티팩트 실행 히스토리 스윕 등록 실패(무시):', err);
     }
 
+    // 10. 주간 게이트 판정 리포트 — measure-first 게이트 관측 스냅샷(무-LLM, 멱등).
+    try {
+        const { startGateReportScheduler } = await import('../monitoring/gate-report');
+        if (startGateReportScheduler()) logger.debug('GateReportScheduler 등록 완료');
+    } catch (err) {
+        logger.warn('GateReportScheduler 등록 실패(무시):', err);
+    }
+
     logger.info('모든 백그라운드 스케줄러 시작 완료');
 }
 

--- a/apps/web/app/(workspace)/admin/metrics/page.tsx
+++ b/apps/web/app/(workspace)/admin/metrics/page.tsx
@@ -126,6 +126,41 @@ interface WorkflowData {
   };
 }
 
+/* ── 라우팅 게이트 관측 타입 ───────────────────────────────── */
+interface RoutingGatesData {
+  days: number;
+  orchestration: {
+    totalTurns: number;
+    intentTurns: number;
+    exposedTurns: number;
+    calledTurns: number;
+    successTurns: number;
+    callRate: number;
+    successRate: number;
+    byTool: { tool: string; turns: number; successTurns: number }[];
+    toggles: {
+      userMode: string;
+      turns: number;
+      discussionIntentTurns: number;
+      taskDelegateIntentTurns: number;
+    }[];
+  };
+  tailShadow: {
+    totalDecisions: number;
+    tailDecisions: number;
+    tailRate: number;
+    labeledDecisions: number;
+    groundingFired: number;
+    groundingFixed: number;
+    lastDecisionAt: string | null;
+    byVerifiability: {
+      verifiability: string | null;
+      decisions: number;
+      tailDecisions: number;
+    }[];
+  };
+}
+
 export default function AdminMetricsPage() {
   const t = useTranslations("adminMetrics");
   const locale = toBcp47(useLocale());
@@ -137,6 +172,7 @@ export default function AdminMetricsPage() {
   const [agentMetrics, setAgentMetrics] = useState<AgentMetric[] | null>(null);
   const [toolErrors, setToolErrors] = useState<ToolErrorData | null>(null);
   const [workflow, setWorkflow] = useState<WorkflowData | null>(null);
+  const [routingGates, setRoutingGates] = useState<RoutingGatesData | null>(null);
   const maxV = Math.max(...TIMESERIES.map((t) => t.value));
 
   const load = useCallback(async () => {
@@ -225,6 +261,13 @@ export default function AdminMetricsPage() {
       ).catch(() => null);
       if (workflowRes?.data) {
         setWorkflow(workflowRes.data);
+      }
+      // 라우팅 게이트 관측 로드 (기본 30일)
+      const routingRes = await ApiClient.get<{ data: RoutingGatesData }>(
+        "/api/metrics/routing/gates",
+      ).catch(() => null);
+      if (routingRes?.data) {
+        setRoutingGates(routingRes.data);
       }
     } catch {
       /* 401/실패 시 목업 유지 */
@@ -473,6 +516,104 @@ export default function AdminMetricsPage() {
                   {workflow.failures.map((f, i) => (
                     <Badge key={i} tone="danger">
                       {f.reason} · {f.tasks.toLocaleString()}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* 라우팅 게이트 관측 — 오케스트레이션 자동 배정·tail 셰도우 */}
+        {routingGates && (
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle>
+                {t("routing.title", { days: routingGates.days })}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+                <StatCard
+                  label={t("routing.callRate")}
+                  value={`${(routingGates.orchestration.callRate * 100).toFixed(1)}%`}
+                  delta={t("routing.ofExposed", {
+                    called: routingGates.orchestration.calledTurns.toLocaleString(),
+                    exposed: routingGates.orchestration.exposedTurns.toLocaleString(),
+                  })}
+                />
+                <StatCard
+                  label={t("routing.successRate")}
+                  value={`${(routingGates.orchestration.successRate * 100).toFixed(1)}%`}
+                  delta={t("routing.ofCalled", {
+                    success: routingGates.orchestration.successTurns.toLocaleString(),
+                    called: routingGates.orchestration.calledTurns.toLocaleString(),
+                  })}
+                />
+                <StatCard
+                  label={t("routing.tailRate")}
+                  value={`${(routingGates.tailShadow.tailRate * 100).toFixed(1)}%`}
+                  delta={t("routing.ofDecisions", {
+                    tail: routingGates.tailShadow.tailDecisions.toLocaleString(),
+                    total: routingGates.tailShadow.totalDecisions.toLocaleString(),
+                  })}
+                />
+                <StatCard
+                  label={t("routing.lastShadow")}
+                  value={
+                    routingGates.tailShadow.lastDecisionAt
+                      ? new Date(routingGates.tailShadow.lastDecisionAt).toLocaleDateString(locale)
+                      : "—"
+                  }
+                  delta={
+                    routingGates.tailShadow.lastDecisionAt
+                      ? t("routing.labeled", {
+                          labeled: routingGates.tailShadow.labeledDecisions.toLocaleString(),
+                        })
+                      : t("routing.shadowOff")
+                  }
+                />
+              </div>
+              {routingGates.orchestration.toggles.length > 0 && (
+                <Table>
+                  <thead>
+                    <tr>
+                      <Th>{t("routing.th.mode")}</Th>
+                      <Th className="text-right">{t("routing.th.turns")}</Th>
+                      <Th className="text-right">{t("routing.th.discussionHits")}</Th>
+                      <Th className="text-right">{t("routing.th.delegateHits")}</Th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {routingGates.orchestration.toggles.map((row) => (
+                      <tr key={row.userMode}>
+                        <Td className="font-mono text-xs text-fg">{row.userMode}</Td>
+                        <Td className="text-right font-mono text-fg-2">
+                          {row.turns.toLocaleString()}
+                        </Td>
+                        <Td className="text-right font-mono text-fg-2">
+                          {row.discussionIntentTurns.toLocaleString()}
+                        </Td>
+                        <Td className="text-right font-mono text-fg-2">
+                          {row.taskDelegateIntentTurns.toLocaleString()}
+                        </Td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              )}
+              {(routingGates.orchestration.byTool.length > 0 ||
+                routingGates.tailShadow.byVerifiability.length > 0) && (
+                <div className="flex flex-wrap gap-2">
+                  {routingGates.orchestration.byTool.map((tool) => (
+                    <Badge key={tool.tool} tone="success">
+                      {tool.tool} · {tool.successTurns.toLocaleString()}/{tool.turns.toLocaleString()}
+                    </Badge>
+                  ))}
+                  {routingGates.tailShadow.byVerifiability.map((v, i) => (
+                    <Badge key={i} tone="warn">
+                      {v.verifiability ?? t("workflow.unrecorded")} ·{" "}
+                      {v.tailDecisions.toLocaleString()}/{v.decisions.toLocaleString()}
                     </Badge>
                   ))}
                 </div>

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1407,6 +1407,24 @@
         "verdict": "Verdict",
         "tasks": "Tasks"
       }
+    },
+    "routing": {
+      "title": "Routing Gates (last {days} days)",
+      "callRate": "Orchestration Call Rate",
+      "ofExposed": "{called} of {exposed} exposed turns",
+      "successRate": "Tool Call Success",
+      "ofCalled": "{success} of {called} calls",
+      "tailRate": "Tail Decision Rate",
+      "ofDecisions": "{tail} of {total} shadow decisions",
+      "lastShadow": "Last Shadow Record",
+      "labeled": "{labeled} labeled",
+      "shadowOff": "no records — shadow OFF",
+      "th": {
+        "mode": "User Toggle",
+        "turns": "Turns",
+        "discussionHits": "Discussion Intent Hits",
+        "delegateHits": "Delegate Intent Hits"
+      }
     }
   },
   "adminAlerts": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1407,6 +1407,24 @@
         "verdict": "判定",
         "tasks": "タスク数"
       }
+    },
+    "routing": {
+      "title": "ルーティングゲート観測 (直近{days}日)",
+      "callRate": "オーケストレーション呼び出し率",
+      "ofExposed": "露出{exposed}ターン中{called}ターン",
+      "successRate": "ツール呼び出し成功率",
+      "ofCalled": "呼び出し{called}ターン中{success}ターン",
+      "tailRate": "tail判定比率",
+      "ofDecisions": "シャドウ{total}件中{tail}件",
+      "lastShadow": "シャドウ最終記録",
+      "labeled": "ラベル{labeled}件",
+      "shadowOff": "記録なし — シャドウOFF",
+      "th": {
+        "mode": "ユーザートグル",
+        "turns": "ターン数",
+        "discussionHits": "討論意図の的中",
+        "delegateHits": "委任意図の的中"
+      }
     }
   },
   "adminAlerts": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1407,6 +1407,24 @@
         "verdict": "판정",
         "tasks": "작업 수"
       }
+    },
+    "routing": {
+      "title": "라우팅 게이트 관측 (최근 {days}일)",
+      "callRate": "오케스트레이션 호출률",
+      "ofExposed": "노출 {exposed}턴 중 {called}턴",
+      "successRate": "도구 호출 성공률",
+      "ofCalled": "호출 {called}턴 중 {success}턴",
+      "tailRate": "tail 판정 비율",
+      "ofDecisions": "셰도우 {total}건 중 {tail}건",
+      "lastShadow": "셰도우 최근 적재",
+      "labeled": "라벨 {labeled}건",
+      "shadowOff": "적재 없음 — 셰도우 OFF",
+      "th": {
+        "mode": "사용자 토글",
+        "turns": "턴 수",
+        "discussionHits": "토론 의도 적중",
+        "delegateHits": "위임 의도 적중"
+      }
     }
   },
   "adminAlerts": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1407,6 +1407,24 @@
         "verdict": "判定",
         "tasks": "任务数"
       }
+    },
+    "routing": {
+      "title": "路由门控观测（最近 {days} 天）",
+      "callRate": "编排调用率",
+      "ofExposed": "共 {exposed} 个曝光轮次中 {called} 个",
+      "successRate": "工具调用成功率",
+      "ofCalled": "共 {called} 次调用中 {success} 次",
+      "tailRate": "tail 判定比例",
+      "ofDecisions": "共 {total} 条影子记录中 {tail} 条",
+      "lastShadow": "影子最近记录",
+      "labeled": "已标注 {labeled} 条",
+      "shadowOff": "无记录 — 影子已关闭",
+      "th": {
+        "mode": "用户切换",
+        "turns": "轮次数",
+        "discussionHits": "讨论意图命中",
+        "delegateHits": "委派意图命中"
+      }
     }
   },
   "adminAlerts": {


### PR DESCRIPTION
## 배경

measure-first 게이트들이 "전향 데이터가 게이트"인 상태로 멈춰 있었습니다. 데이터는 쌓이는데(086 오케스트레이션 셰도우, 061 tail 셰도우) **집계·판정하는 루프가 없어** 판정 근거를 꺼내볼 수단이 없었습니다.

## Stage 1 — 라우팅 게이트 집계 노출

`RoutingMetricsRepository` 신설 (읽기 전용, #540 패턴 재사용):
- **오케스트레이션(086)**: 노출/호출/성공, 사용자 토글 턴의 의도 적중(재현율 프록시 — 086 마이그레이션 주석의 수동 분석 쿼리를 API 로 공식화)
- **tail 셰도우(061)**: tail 비율·캘리브레이션 라벨, **전기간 마지막 적재 시각** — `TAIL_ROUTING_SHADOW_ENABLED` 가 기본 OFF 라 적재 신선도 자체가 관측 대상

`GET /api/metrics/routing/gates?days=N` (admin) + admin 메트릭 페이지 카드 + i18n 4개 언어.

## Stage 2 — 주간 게이트 판정 리포트 (무-LLM 결정적 렌더)

`monitoring/gate-report.ts` 가 Stage 1 집계를 모아 주 1회 HTML 스냅샷을 만듭니다.

- **판정은 결정적 규칙만**: 표본 ≥ `MIN_SAMPLE` → 판정 가능 / 미만 → 표본 부족 / tail 기간 내 0건 → 적재 중단(플래그 확인 안내). 채택·반려 결정 자체는 사람 몫입니다.
- **멱등**: 당일 스냅샷 파일 존재가 마커 → 재시작·tick 중복에 안전
- **노출은 admin push + admin 전용 라우트만**: 예약 리포트의 공개 정적 게시(`schedule-publish`)는 인증 없이 서빙되는 경로라 운영 지표에는 재사용하지 않았습니다
- `GATE_REPORT` 설정 외부화(요일·주기·표본 임계·TZ·디렉토리), `.env.example` 반영

LLM 요약 대신 결정적 렌더를 택한 이유: 판정 근거가 전부 SQL 집계라 LLM 이 잉여이고, 예약 agent task 방식은 admin 집계 접근 인증 문제가 추가됩니다. agent-resolver 게이트는 기존 `scripts/daily-routing-report.sh`(로그 재집계)가 이미 담당해 중복 구현하지 않았습니다.

## 검증

- `npm run lint` 통과 (0 errors)
- `npm test` 통과 — 2782 passed / 255 suites
- **라이브 DB 실데이터로 생성·멱등 검증**. 실데이터 판정 예: Execution Graph 표본 41건 판정 가능(plan 귀속 86.4%), 오케스트레이션 표본 9건 부족, tail 222건이나 캘리브레이션 라벨 0건
- 그 과정에서 **`pg` 가 TIMESTAMPTZ 를 `Date` 로 반환해 문자열 전제인 렌더가 깨지던 결함**을 발견해 수집 경계 정규화로 수정 (유닛 mock 만으로는 잡히지 않는 경로)

## 보안 영향

신규 엔드포인트 2개 모두 기존 `router.use(requireAuth, requireAdmin)` 하위입니다. 리포트 라우트의 `date` 파라미터는 파일명으로 쓰이므로 `YYYY-MM-DD|latest` 형식을 강제해 경로 탈출을 차단했습니다. 신규 쿼리는 전부 읽기 전용·파라미터화입니다.

## UI 변경

admin 메트릭 페이지에 "라우팅 게이트 관측" 카드 추가 (기존 워크플로우 카드와 동일 패턴). 배포 후 스크린샷 첨부 예정입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)