### PR TITLE
chore(metrics): tail 라우팅 게이트 반려 — 주간 리포트 판정 대상에서 제외

### DIFF
--- a/apps/api/src/monitoring/__tests__/gate-report.test.ts
+++ b/apps/api/src/monitoring/__tests__/gate-report.test.ts
@@ -19,12 +19,6 @@ function makeInput(overrides?: Partial<GateReportInput>): GateReportInput {
             goalIncompleteTasks: 3,
         },
         orchestration: { totalTurns: 800, exposedTurns: 60, calledTurns: 20, successTurns: 18 },
-        tailShadow: {
-            totalDecisions: 206,
-            tailDecisions: 4,
-            labeledDecisions: 120,
-            lastDecisionAt: '2026-07-30T01:00:00.000Z',
-        },
         ...overrides,
     };
 }
@@ -51,10 +45,15 @@ describe('gate-report 순수 헬퍼', () => {
 });
 
 describe('buildGateVerdicts', () => {
-    it('표본 충분 시 3개 게이트 모두 판정 가능', () => {
+    it('표본 충분 시 2개 게이트 모두 판정 가능', () => {
         const verdicts = buildGateVerdicts(makeInput(), 30);
-        expect(verdicts).toHaveLength(3);
+        expect(verdicts).toHaveLength(2);
         expect(verdicts.every((v) => v.tone === 'ok')).toBe(true);
+    });
+
+    it('반려된 tail 게이트는 판정 대상에서 제외된다 (2026-08-22)', () => {
+        const verdicts = buildGateVerdicts(makeInput(), 30);
+        expect(verdicts.some((v) => /tail/i.test(v.gate))).toBe(false);
     });
 
     it('표본 부족 시 warn 톤 — 계속 관측', () => {
@@ -67,19 +66,6 @@ describe('buildGateVerdicts', () => {
         expect(orch.status).toContain('표본 부족');
     });
 
-    it('tail 셰도우 적재 0건이면 danger — 플래그 확인 안내 포함', () => {
-        const verdicts = buildGateVerdicts(
-            makeInput({
-                tailShadow: { totalDecisions: 0, tailDecisions: 0, labeledDecisions: 0, lastDecisionAt: null },
-            }),
-            30
-        );
-        const tail = verdicts[2];
-        expect(tail.tone).toBe('danger');
-        expect(tail.status).toContain('적재 중단');
-        expect(tail.note).toContain('TAIL_ROUTING_SHADOW_ENABLED');
-        expect(tail.note).toContain('없음');
-    });
 });
 
 describe('renderGateReportHtml', () => {
@@ -90,7 +76,7 @@ describe('renderGateReportHtml', () => {
         expect(html).not.toContain('{{'); // placeholder 잔존 없음
         expect(html).toContain('Execution Graph');
         expect(html).toContain('오케스트레이션 자동 배정 상세');
-        expect(html).toContain('Tail 셰도우 상세');
+        expect(html).not.toContain('Tail 셰도우 상세'); // 반려된 게이트는 렌더되지 않는다
     });
 
     it('동적 값 escape — 날짜 파라미터에 태그가 섞여도 그대로 출력되지 않는다', async () => {

--- a/apps/api/src/monitoring/gate-report.ts
+++ b/apps/api/src/monitoring/gate-report.ts
@@ -2,12 +2,17 @@
  * 주간 게이트 판정 리포트 — measure-first 게이트의 판정 근거 스냅샷 (무-LLM 결정적 렌더).
  *
  * plan: docs/proposals/2026-08-22-quality-flywheel-gate-observability-plan.md Stage 2.
- * 대상 게이트 3종은 Stage 1 집계(repository)를 그대로 재사용한다:
+ * 대상 게이트 2종은 Stage 1 집계(repository)를 그대로 재사용한다:
  *   ① Execution Graph 증분 — agent_tasks/agent_task_steps (retry·hitl_degrade·plan 귀속)
  *   ② 오케스트레이션 자동 배정 — orchestration_dispatch_decisions(086)
- *   ③ tail 라우팅 셰도우 — routing_shadow_decisions(061, 적재 중단 감지 포함)
  * agent-resolver 게이트는 winston 로그 기반 별도 스크립트(scripts/daily-routing-report.sh)가
  * 담당하므로 여기 포함하지 않는다.
+ *
+ * tail 라우팅 게이트(061 셰도우)는 **반려 확정(2026-08-22)** 되어 제외했다. 골드셋 30건
+ * 사람 판정 대조 결과 게이트가 오류를 예측하지 못했다 — tail 로 지목한 층의 오답률 50%
+ * (판정가능 6건 중 3건) 대비 통과시킨 non-tail 층이 60%(10건 중 6건)로 오히려 높았고,
+ * error_score 평균도 오답 0.365 / 정답 0.360 으로 판별력이 없었다. 축 A 재설계 없이는
+ * 되살릴 근거가 없으므로 판정 대상에서 뺀다(셰도우 테이블·env 게이트 자체는 존치).
  *
  * 노출 경로: admin push 알림 + admin 전용 라우트(GET /api/metrics/routing/report).
  * 예약 리포트의 공개 정적 게시(schedule-publish)를 재사용하지 않는 이유 — 그 경로는 인증
@@ -69,12 +74,6 @@ export interface GateReportInput {
         calledTurns: number;
         successTurns: number;
     };
-    tailShadow: {
-        totalDecisions: number;
-        tailDecisions: number;
-        labeledDecisions: number;
-        lastDecisionAt: string | null;
-    };
 }
 
 export interface GateVerdict {
@@ -99,7 +98,6 @@ export function buildGateVerdicts(input: GateReportInput, minSample: number): Ga
 
     const wf = input.workflow;
     const orch = input.orchestration;
-    const tail = input.tailShadow;
 
     const verdicts: GateVerdict[] = [
         {
@@ -115,23 +113,6 @@ export function buildGateVerdicts(input: GateReportInput, minSample: number): Ga
             note: `노출 ${orch.exposedTurns}턴 → 호출 ${orch.calledTurns}턴 → 성공 ${orch.successTurns}턴 (전체 ${orch.totalTurns}턴)`,
         },
     ];
-
-    if (tail.totalDecisions === 0) {
-        verdicts.push({
-            gate: 'Tail 라우팅 Stage 2 (061 셰도우)',
-            sample: 0,
-            tone: 'danger',
-            status: '적재 중단 — 게이트 판정 불가',
-            note: `기간 내 셰도우 결정 0건. 마지막 적재 ${tail.lastDecisionAt ?? '없음'} — TAIL_ROUTING_SHADOW_ENABLED 확인 필요`,
-        });
-    } else {
-        verdicts.push({
-            gate: 'Tail 라우팅 Stage 2 (061 셰도우)',
-            sample: tail.totalDecisions,
-            ...sampleStatus(tail.totalDecisions),
-            note: `tail ${tail.tailDecisions}/${tail.totalDecisions}건 · 캘리브레이션 라벨 ${tail.labeledDecisions}건`,
-        });
-    }
     return verdicts;
 }
 
@@ -154,7 +135,6 @@ function renderSectionsHtml(input: GateReportInput): string {
     const pct = (v: number) => `${(v * 100).toFixed(1)}%`;
     const wf = input.workflow;
     const orch = input.orchestration;
-    const tail = input.tailShadow;
     const rate = (num: number, den: number) => (den > 0 ? pct(num / den) : '—');
 
     const table = (title: string, rows: string[]) =>
@@ -174,12 +154,6 @@ function renderSectionsHtml(input: GateReportInput): string {
             row('도구 노출 턴', String(orch.exposedTurns)),
             row('호출 턴 (노출 대비)', `${orch.calledTurns} (${rate(orch.calledTurns, orch.exposedTurns)})`),
             row('성공 턴 (호출 대비)', `${orch.successTurns} (${rate(orch.successTurns, orch.calledTurns)})`),
-        ]),
-        table('Tail 셰도우 상세', [
-            row('셰도우 결정', String(tail.totalDecisions)),
-            row('tail 판정', `${tail.tailDecisions} (${rate(tail.tailDecisions, tail.totalDecisions)})`),
-            row('캘리브레이션 라벨', String(tail.labeledDecisions)),
-            row('마지막 적재 (전기간)', tail.lastDecisionAt ?? '없음'),
         ]),
     ].join('\n');
 }
@@ -207,13 +181,12 @@ async function collectGateReportInput(days: number): Promise<GateReportInput> {
     const routingRepo = new RoutingMetricsRepository(pool);
     const taskRepo = new AgentTaskMetricsRepository(pool);
 
-    const [verdictRows, failureRows, interventionRow, coverageRow, dispatchRow, tailRow] = await Promise.all([
+    const [verdictRows, failureRows, interventionRow, coverageRow, dispatchRow] = await Promise.all([
         taskRepo.getCompletionVerdictDistribution(days),
         taskRepo.getFailureReasons(days, 20),
         taskRepo.getInterventionCounts(days),
         taskRepo.getPlanAttributionCoverage(days),
         routingRepo.getOrchestrationDispatchSummary(days),
-        routingRepo.getTailShadowSummary(days),
     ]);
 
     const completedTasks = verdictRows.reduce((sum, r) => sum + Number(r.tasks), 0);
@@ -240,15 +213,6 @@ async function collectGateReportInput(days: number): Promise<GateReportInput> {
             exposedTurns: Number(dispatchRow.exposed_turns),
             calledTurns: Number(dispatchRow.called_turns),
             successTurns: Number(dispatchRow.success_turns),
-        },
-        tailShadow: {
-            totalDecisions: Number(tailRow.total_decisions),
-            tailDecisions: Number(tailRow.tail_decisions),
-            labeledDecisions: Number(tailRow.labeled_decisions),
-            // pg 는 TIMESTAMPTZ 를 Date 로 돌려준다 — 렌더는 문자열 전제라 여기서 정규화.
-            lastDecisionAt: tailRow.last_decision_at == null
-                ? null
-                : new Date(tailRow.last_decision_at).toISOString(),
         },
     };
 }

--- a/apps/api/src/scripts/label-tail-shadow.ts
+++ b/apps/api/src/scripts/label-tail-shadow.ts
@@ -9,9 +9,24 @@
  * 학습 라벨 생성용 오프라인 1회성 배치 — 재실행 안전(라벨 NULL 행만 처리).
  *
  * 실행: npx ts-node apps/api/src/scripts/label-tail-shadow.ts [--dry-run] [--limit N]
+ *       [--verifiable-only] [--user ID] [--no-local-fallback]
  *
  * 판정 3값: correct/incorrect → a_was_correct 기록, unsure → NULL 유지(스킵).
  * 실시간성 질문(날씨 등)·판단 불가는 unsure 로 유도해 라벨 오염을 막는다.
+ *
+ * `--verifiable-only`: verifiability='none' 행을 대상에서 제외한다. 게이트가
+ * `isTail = errorScore≥θ AND verifiability≠'none'` 이라 none 행은 애초에 tail 이 될 수
+ * 없어 캘리브레이션에 기여하지 못한다. 게다가 그 모집단은 대부분 잡담·피드백이라
+ * judge 가 unsure 규칙을 지키지 못하고 incorrect 를 남발해 라벨을 오염시켰다
+ * (2026-08-22 실측: 무필터 dry-run 20건 중 incorrect 12건 — 실제 오답률로 비현실적).
+ *
+ * `--user ID`: 해당 사용자 행만 처리. judge role 이 사용자별 매핑(BYOK)으로 외부
+ * 모델에 배정된 경우, 매핑이 없는 사용자의 행은 로컬로 fail-open 되어 같은 배치에
+ * 서로 다른 판정자의 라벨이 섞인다. 그걸 막는다.
+ *
+ * `--no-local-fallback`: judge 연속 실패 시 로컬 강등 대신 즉시 중단한다. 라벨링에서
+ * 로컬 강등은 곧 '답변을 쓴 모델이 자기 답변을 채점'하는 상태로의 복귀라, 조용히
+ * 이어가면 라벨 절반이 오염된 채 완료된 것처럼 보인다. 배치에선 멈추는 편이 낫다.
  *
  * @module scripts/label-tail-shadow
  */
@@ -67,7 +82,7 @@ const JUDGE_SYSTEM = [
 
 type Verdict = 'correct' | 'incorrect' | 'unsure';
 
-async function judgeOne(client: LLMClient, row: LabelRow): Promise<Verdict | null> {
+async function judgeOne(client: LLMClient, row: LabelRow, think: boolean): Promise<Verdict | null> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), JUDGE_TIMEOUT_MS);
     try {
@@ -77,7 +92,7 @@ async function judgeOne(client: LLMClient, row: LabelRow): Promise<Verdict | nul
         ].join('\n\n');
         const r = await client.chat(
             [{ role: 'system', content: JUDGE_SYSTEM }, { role: 'user', content: user }],
-            undefined, undefined, { think: false, signal: controller.signal },
+            undefined, undefined, { think, signal: controller.signal },
         );
         const m = (r.content ?? '').match(/"verdict"\s*:\s*"(correct|incorrect|unsure)"/);
         return m ? (m[1] as Verdict) : null;
@@ -88,8 +103,18 @@ async function judgeOne(client: LLMClient, row: LabelRow): Promise<Verdict | nul
 
 async function main(): Promise<void> {
     const dryRun = process.argv.includes('--dry-run');
+    const verifiableOnly = process.argv.includes('--verifiable-only');
+    const noLocalFallback = process.argv.includes('--no-local-fallback');
+    // 판정은 조건부 규칙('검색 인용 실시간 답변은 unsure' 등)을 지켜야 하는 작업이라
+    // 추론 깊이가 결과를 가를 수 있다. 기본 off 는 로컬 qwen 의 thinking 폭주 방지 관성.
+    // ⚠️ chatgpt(OAuth) role 경로에는 효과가 없다 — ProviderRoleClient.chat 이 think 를
+    //    provider 요청에 싣지 않고, Codex 백엔드의 GPT-5 계열은 서버측에서 기본 추론한다
+    //    (2026-08-22 실측: 동일 30행 off/on 27행 동일 판정). 로컬/openai-compatible 전용.
+    const think = process.argv.includes('--think');
     const limitArg = process.argv.indexOf('--limit');
     const limit = limitArg >= 0 ? Number(process.argv[limitArg + 1]) || 0 : 0;
+    const userArg = process.argv.indexOf('--user');
+    const onlyUserId = userArg >= 0 ? String(process.argv[userArg + 1] ?? '').trim() : '';
 
     const pool = getPool();
     const { rows } = await pool.query<LabelRow>(
@@ -119,12 +144,19 @@ async function main(): Promise<void> {
            AND r.a_was_correct IS NULL
            AND char_length(um.content) > 0
            AND char_length(am.content) > 0
+           ${verifiableOnly ? "AND r.verifiability <> 'none'" : ''}
+           ${onlyUserId ? 'AND r.user_id = $4' : ''}
          ORDER BY r.id
          ${limit > 0 ? 'LIMIT ' + limit : ''}`,
-        [MATCH_WINDOW_SEC, MATCH_LEN_TOLERANCE, ANSWER_WINDOW],
+        onlyUserId
+            ? [MATCH_WINDOW_SEC, MATCH_LEN_TOLERANCE, ANSWER_WINDOW, onlyUserId]
+            : [MATCH_WINDOW_SEC, MATCH_LEN_TOLERANCE, ANSWER_WINDOW],
     );
 
-    logger.info(`라벨링 대상 ${rows.length}건 (dry-run=${dryRun})`);
+    logger.info(
+        `라벨링 대상 ${rows.length}건 (dry-run=${dryRun}, verifiable-only=${verifiableOnly}` +
+        `, user=${onlyUserId || 'all'}, no-local-fallback=${noLocalFallback}, think=${think})`,
+    );
     if (rows.length === 0) {
         logger.info('처리할 행 없음 — 종료');
         return;
@@ -155,7 +187,7 @@ async function main(): Promise<void> {
                 client = cached;
             }
             try {
-                const verdict = await judgeOne(client, row);
+                const verdict = await judgeOne(client, row, think);
                 consecutiveFailures = 0;
                 if (verdict === null) {
                     stats.parse_fail++;
@@ -174,6 +206,12 @@ async function main(): Promise<void> {
                 consecutiveFailures++;
                 logger.warn(`#${row.id} judge 실패 (${consecutiveFailures}연속): ${e instanceof Error ? e.message : e}`);
                 if (!degradedToLocal && consecutiveFailures >= FALLBACK_AFTER_CONSECUTIVE_FAILURES) {
+                    if (noLocalFallback) {
+                        // 로컬 강등 = 피판정 모델로의 복귀. 라벨 오염을 남기느니 중단한다.
+                        logger.error(`연속 실패 ${consecutiveFailures}회 — --no-local-fallback 이므로 중단`);
+                        work.length = 0;
+                        return;
+                    }
                     degradedToLocal = true;
                     logger.warn(`연속 실패 ${consecutiveFailures}회 — 로컬 default 모델로 강등`);
                 }


### PR DESCRIPTION
## 결정

**tail 라우팅 게이트를 반려**하고 주간 게이트 리포트의 판정 대상에서 제외합니다.

## 근거 (골드셋 30건 사람 판정 대조)

층화 추출(tail 12 / non-tail·verifiable 12 / verifiability=none 6) 후 사람이 판정하고 게이트 신호와 교차했습니다.

| 측정 | 결과 | 해석 |
|---|---|---|
| tail 층 오답률 | 50% (판정가능 6건 중 3건) | 게이트가 지목한 "위험" 집단 |
| non-tail 층 오답률 | **60%** (10건 중 6건) | 통과시킨 집단이 **더 나빴다** |
| error_score 평균 | 오답 0.365 / 정답 0.360 | 축 A 판별력 없음 |

신호가 정방향도 아니고 크기도 없습니다. 축 A 재설계 없이는 되살릴 근거가 없어 판정 대상에서 뺐고 수집도 중단했습니다. 셰도우 테이블(061)과 `TAIL_ROUTING_SHADOW_ENABLED` env 게이트 자체는 재설계 여지를 남겨 **존치**합니다.

## 부수 결정 — 자동 라벨링 배치 중단

judge(`chatgpt:gpt-5.6-luna`)와 사람 판정의 일치율이 10건 대조에서 **60%** 였고, 불일치 4건이 전부 "정상 답변을 오답으로 몰기"였습니다(정확한 TDD 파이썬 코드, 원문 수치와 전부 일치하는 요약 등). 이 정확도로 714건을 라벨링하면 캘리브레이션을 개선하는 게 아니라 오염시킵니다. `routing_shadow_decisions.a_was_correct` 는 **한 건도 쓰지 않았습니다**.

재개 시 필요한 플래그를 `label-tail-shadow.ts` 에 남겼습니다 — `--verifiable-only`(게이트가 배제하는 none 층 제외), `--user`(판정자 혼재 방지), `--think`, `--no-local-fallback`. 마지막 것이 특히 중요합니다: 로컬 강등은 곧 **답변을 쓴 모델이 자기 답변을 채점하는 상태로의 복귀**라, 조용히 이어가면 라벨 절반이 오염된 채 완료된 것처럼 보입니다. `--think` 는 chatgpt OAuth 경로에서 무효임을 실측(동일 30행 off/on 27행 동일 판정)으로 확인해 주석에 남겼습니다.

## 검증

- `npm run lint` 통과 (0 errors)
- 관련 테스트 15건 통과 (tail 제외 회귀 테스트 추가)
- 라이브 데이터로 리포트 재생성 — 판정 카드가 Execution Graph·오케스트레이션 2종만 남고 tail 언급 0건 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)