### PR TITLE
feat(routing): URL 단독 질의 LLM 라우팅 스킵 + 도메인 힌트

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -521,6 +521,16 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # "키워드 없음" 판단 신뢰도 상한 — 키워드 라우터 무매칭 기본값(0.3) 이하 (기본 0.3)
 # OMK_AGENT_SHORT_QUERY_KEYWORD_CEILING=0.3
 
+# URL 하나만 붙여넣은 질의는 LLM 라우팅을 건너뛴다 (기본 true).
+# 본문이 없어 LLM 이 볼 수 있는 건 도메인뿐이라 일반 콘텐츠 사이트에서는 근거 없이
+# 에이전트를 골랐다(실측 2026-08-19~21: URL 단독 13건, 건당 ~2s).
+# OMK_AGENT_URL_ONLY_SKIP=true
+
+# URL 단독 질의의 도메인 → 에이전트 힌트 (형식: "domain=agentId,domain=agentId").
+# 스킵으로 잃게 되는 값(법령 포털 → 법률 에이전트 승격)을 LLM 없이 결정적으로 보존한다.
+# 미설정 시 기본값: law.go.kr·easylaw.go.kr → compliance-officer
+# OMK_AGENT_URL_DOMAIN_HINTS=law.go.kr=compliance-officer,easylaw.go.kr=compliance-officer
+
 # GV(Generate-Verify) 건너뛰기 임계값 - 이 점수 미만이면 GV 단계 생략 (기본값: 0.3)
 # primary 키는 OMK_GV_SKIP_THRESHOLD (OMK_A2A_SKIP_THRESHOLD 는 legacy fallback alias)
 # OMK_GV_SKIP_THRESHOLD=0.3

--- a/apps/api/src/config/routing-config.ts
+++ b/apps/api/src/config/routing-config.ts
@@ -110,6 +110,45 @@ export const AGENT_SHORT_QUERY_MAX_CHARS =
 export const AGENT_SHORT_QUERY_KEYWORD_CEILING =
     Number(process.env.OMK_AGENT_SHORT_QUERY_KEYWORD_CEILING ?? '0.3');
 
+// ── URL 단독 질의 LLM 스킵 (2026-08-22) ──────────────────────
+// 위 실측에서 남은 LLM 발동 60건 중 13건이 "URL 하나만 붙여넣은" 질의였다. 본문이
+// 없으니 LLM 이 볼 수 있는 건 도메인 문자열뿐이고, 실제로 brunch·arca·chatgpt/share
+// 같은 일반 콘텐츠 사이트는 근거 없이 content-writer 로 뭉쳤다(건당 ~2s 낭비).
+//
+// ⚠️ 단, 같은 13건 중 6건은 법령 포털(law.go.kr·easylaw.go.kr)이었고 LLM 이 법률
+// 에이전트로 올바로 승격했다. 일괄 스킵하면 이 값까지 잃는다 — 키워드 라우터는
+// 호스트명에서 신호를 전혀 못 잡는 것을 실측으로 확인했다(law/easylaw 모두 general 0.3).
+// 그래서 스킵과 함께 **도메인 힌트 맵**을 둔다: 알려진 도메인은 LLM 없이 결정적으로
+// 해당 에이전트로 보내고(0ms), 모르는 도메인만 general 로 보낸다.
+// 힌트가 LLM 보다 나은 이유 — 같은 답을 2초 없이 내고, 도메인당 답이 고정된다.
+
+/** URL 단독 질의에서 LLM 라우팅을 건너뛸지 (env: OMK_AGENT_URL_ONLY_SKIP, 기본 true) */
+export const AGENT_URL_ONLY_SKIP =
+    (process.env.OMK_AGENT_URL_ONLY_SKIP ?? 'true') === 'true';
+
+/**
+ * URL 단독 질의의 도메인 → 에이전트 힌트. 키는 호스트 접미사(서브도메인 무관 매칭).
+ * 실측(2026-08-19~21) 에서 LLM 이 반복해서 같은 답을 낸 도메인만 넣는다 —
+ * 추측으로 채우면 잘못된 스킬을 결정적으로 주입하게 되므로 근거 있는 것만.
+ * env `OMK_AGENT_URL_DOMAIN_HINTS` 로 오버라이드 (형식: "domain=agentId,domain=agentId").
+ */
+export const AGENT_URL_DOMAIN_HINTS: Record<string, string> = (() => {
+    const base: Record<string, string> = {
+        // 국가법령정보센터·찾기쉬운 생활법령 — 법령 원문 링크. LLM 은 labor/corporate 로
+        // 갈렸는데 둘 다 특정 분야 포털이 아니라, 분야 중립인 compliance-officer 로 둔다.
+        'law.go.kr': 'compliance-officer',
+        'easylaw.go.kr': 'compliance-officer',
+    };
+    const raw = process.env.OMK_AGENT_URL_DOMAIN_HINTS;
+    if (!raw) return base;
+    const parsed: Record<string, string> = {};
+    for (const pair of raw.split(',')) {
+        const [domain, agentId] = pair.split('=').map((s) => s.trim());
+        if (domain && agentId) parsed[domain.toLowerCase()] = agentId;
+    }
+    return Object.keys(parsed).length > 0 ? parsed : base;
+})();
+
 // ── Complexity Assessor 설정 ─────────────────────────────────
 
 /** GV 건너뛰기 임계값 - 이 점수 미만이면 Generate-Verify 생략 (env: OMK_GV_SKIP_THRESHOLD) */

--- a/apps/api/src/services/chat-service/__tests__/agent-resolver.test.ts
+++ b/apps/api/src/services/chat-service/__tests__/agent-resolver.test.ts
@@ -19,7 +19,7 @@ import { getCacheSystem } from '../../../cache';
 jest.mock('../../../agents/llm-router', () => ({
     routeWithLLM: jest.fn(),
     isValidAgentId: jest.fn((id: string) =>
-        ['general', 'software-engineer', 'data-analyst'].includes(id)),
+        ['general', 'software-engineer', 'data-analyst', 'compliance-officer'].includes(id)),
 }));
 
 jest.mock('../../../agents', () => ({
@@ -98,5 +98,37 @@ describe('agent-resolver 경량화 라우팅', () => {
         mockRouteToAgent.mockResolvedValue(keywordResult('software-engineer', 0.9));
         const r = await resolveAgent(msg, 'u1', 'ko');
         expect(r.agentSelection.primaryAgent).toBe('software-engineer');
+    });
+
+    describe('URL 단독 질의 스킵 (2026-08-22)', () => {
+        it('본문 없는 일반 URL: general 직행, LLM 미호출', async () => {
+            mockRouteToAgent.mockResolvedValue(keywordResult('general', 0.3));
+            const r = await resolveAgent('https://brunch.co.kr/@aideveloper/158', 'u1', 'ko');
+            expect(r.agentSelection.primaryAgent).toBe('general');
+            expect(r.agentSelection.reason).toMatch(/^\[URL-only\]/);
+            expect(mockRouteWithLLM).not.toHaveBeenCalled();
+        });
+
+        it('도메인 힌트 매칭: 결정적 승격, LLM 미호출', async () => {
+            mockRouteToAgent.mockResolvedValue(keywordResult('general', 0.3));
+            const r = await resolveAgent('https://www.law.go.kr/lsInfoP.do?lsiSeq=1', 'u1', 'ko');
+            expect(r.agentSelection.primaryAgent).toBe('compliance-officer');
+            expect(r.agentSelection.reason).toMatch(/도메인 힌트/);
+            expect(mockRouteWithLLM).not.toHaveBeenCalled();
+        });
+
+        it('서브도메인도 힌트 접미사 매칭', async () => {
+            mockRouteToAgent.mockResolvedValue(keywordResult('general', 0.3));
+            const r = await resolveAgent('https://open.law.go.kr/x', 'u1', 'ko');
+            expect(r.agentSelection.primaryAgent).toBe('compliance-officer');
+        });
+
+        it('URL + 설명이 붙으면 스킵 대상이 아니다 (LLM 경로 유지)', async () => {
+            mockRouteToAgent.mockResolvedValue(keywordResult('general', 0.3));
+            mockRouteWithLLM.mockResolvedValue({ agentId: 'data-analyst', confidence: 0.9, reasoning: 'r' });
+            const r = await resolveAgent('https://brunch.co.kr/@x/1 이 글 요약해줘', 'u1', 'ko');
+            expect(mockRouteWithLLM).toHaveBeenCalled();
+            expect(r.agentSelection.primaryAgent).toBe('data-analyst');
+        });
     });
 });

--- a/apps/api/src/services/chat-service/agent-resolver.ts
+++ b/apps/api/src/services/chat-service/agent-resolver.ts
@@ -3,7 +3,7 @@
  * Agent Resolver — 에이전트 라우팅 모듈
  * ============================================================
  *
- * 경량화 3단계(캐시 → 키워드 선분류 → 短문장 직행)를 거친 뒤에만
+ * 경량화 4단계(캐시 → 키워드 선분류 → URL 단독 직행 → 短문장 직행)를 거친 뒤에만
  * LLM 의미론적 라우팅을 호출하고, 실패 시 키워드 결과로 폴백합니다.
  * (2026-07-04: LLM 라우팅이 매 채팅 첫 청크에 ~2-3s + ~2.7k 토큰의
  * 고정 비용을 부과하던 것을 절감 — 단순/반복 질문은 LLM 호출 0회.)
@@ -20,16 +20,42 @@ import {
     AGENT_KEYWORD_PRECLASSIFY_CONFIDENCE,
     AGENT_SHORT_QUERY_MAX_CHARS,
     AGENT_SHORT_QUERY_KEYWORD_CEILING,
+    AGENT_URL_ONLY_SKIP,
+    AGENT_URL_DOMAIN_HINTS,
 } from '../../config/routing-config';
 
 const logger = createLogger('AgentResolver');
+
+/**
+ * "URL 하나만" 질의인지 판별하고 호스트명을 돌려준다.
+ * 본문 없이 링크만 붙여넣은 경우가 대상 — 링크에 설명이 한 줄이라도 붙으면
+ * 그 텍스트로 라우팅해야 하므로 대상이 아니다.
+ */
+function urlOnlyHost(message: string): string | null {
+    const trimmed = message.trim();
+    if (!/^https?:\/\/\S+$/i.test(trimmed)) return null;
+    try {
+        return new URL(trimmed).hostname.replace(/^www\./i, '').toLowerCase();
+    } catch {
+        return null;
+    }
+}
+
+/** 호스트 접미사 매칭 — 서브도메인이 붙어도 같은 힌트를 쓴다 */
+function domainHintFor(host: string): string | null {
+    for (const [domain, agentId] of Object.entries(AGENT_URL_DOMAIN_HINTS)) {
+        if (host === domain || host.endsWith(`.${domain}`)) return agentId;
+    }
+    return null;
+}
 
 /**
  * 에이전트 선택 — LLM 호출 전 경량 경로 3단계를 우선 시도.
  *
  * 1. **캐시**: 정규화된 동일 질문의 이전 라우팅 결과 재사용 (LRU, cache/index.ts)
  * 2. **키워드 선분류**: 키워드 라우터 신뢰도가 임계 이상이면 그대로 채택
- * 3. **短문장 직행**: 짧은 질문 + 키워드 신호 없음 → 'general' (단답형 잡담·산술 등)
+ * 3-A. **URL 단독 직행**: 본문 없는 링크 → 도메인 힌트 또는 'general' (길이 규칙보다 먼저)
+ * 3-B. **短문장 직행**: 짧은 질문 + 키워드 신호 없음 → 'general' (단답형 잡담·산술 등)
  * 4. **LLM 라우팅**: 위 모두 미해당 시에만 호출. 실패하면 1회 실행해 둔 키워드
  *    결과를 재사용해 폴백 (기존의 폴백 재호출 1회도 절감).
  */
@@ -60,6 +86,29 @@ async function selectAgent(message: string): Promise<AgentSelection> {
         const selection = { ...keywordSelection, reason: `[Keyword] ${keywordSelection.reason}` };
         if (AGENT_ROUTE_CACHE_ENABLED) cache.setRoutingResult(message, selection.primaryAgent, keywordConfidence);
         return selection;
+    }
+
+    // ③-A URL 단독 질의 → LLM 스킵. 본문이 없어 LLM 이 볼 수 있는 건 도메인뿐이라
+    // 일반 콘텐츠 사이트에서는 근거 없이 에이전트를 골랐다(실측 2026-08-19~21).
+    // 알려진 도메인은 힌트 맵으로 결정적 승격, 나머지는 general.
+    // 短문장 직행(③)보다 먼저 본다 — 짧은 URL 이 길이 규칙에 먼저 걸리면 도메인 힌트를 놓친다.
+    if (AGENT_URL_ONLY_SKIP) {
+        const host = urlOnlyHost(message);
+        if (host) {
+            const hinted = domainHintFor(host);
+            const agentId = hinted && isValidAgentId(hinted) ? hinted : 'general';
+            logger.info(`URL 단독 직행: ${agentId} (host ${host}${hinted ? ', 도메인 힌트' : ''}) — LLM 라우팅 스킵`);
+            return {
+                primaryAgent: agentId,
+                category: getAgentById(agentId)?.category || 'general',
+                phase: detectPhase(message),
+                reason: hinted
+                    ? `[URL-only] 도메인 힌트 매칭(${host}) — 결정적 라우팅`
+                    : '[URL-only] 본문 없는 링크 — 범용 에이전트 직행',
+                confidence: keywordConfidence,
+                matchedKeywords: [],
+            };
+        }
     }
 
     // ③ 短문장 + 키워드 신호 없음 → 'general' 직행 (예: "1+1은?", "고마워")
@@ -110,7 +159,7 @@ export interface AgentResolutionResult {
 }
 
 /**
- * 경량 3단계(캐시/키워드 선분류/短문장 직행) → LLM 라우팅 → 키워드 폴백 순으로
+ * 경량 4단계(캐시/키워드 선분류/URL 단독/短문장 직행) → LLM 라우팅 → 키워드 폴백 순으로
  * 에이전트를 선택하고 시스템 프롬프트를 구성합니다.
  *
  * @param message - 사용자 메시지


### PR DESCRIPTION
## 배경

실측(2026-08-19~21, `scripts/daily-routing-report.sh`)에서 LLM 라우팅 발동 60건 중 **13건이 "URL 하나만" 붙여넣은 질의**였습니다. 본문이 없어 LLM 이 볼 수 있는 건 도메인 문자열뿐이라, brunch·arca·chatgpt/share 같은 일반 콘텐츠 사이트는 근거 없이 `content-writer` 로 뭉갰습니다(건당 ~2s).

## 일괄 스킵이 아니라 스킵 + 도메인 힌트

⚠️ 일괄 스킵은 **측정된 가치를 함께 버립니다.** 같은 13건 중 6건이 법령 포털(`law.go.kr`·`easylaw.go.kr`)이었고 LLM 이 법률 에이전트로 올바로 승격했습니다.

키워드 라우터가 호스트명에서 신호를 잡을 수 있는지 먼저 실측했는데 `law go kr`·`easylaw go kr` 모두 `general(0.3)` 으로 아무것도 잡지 못했습니다. 그래서 스킵과 함께 **도메인 힌트 맵**(`AGENT_URL_DOMAIN_HINTS`)을 둡니다 — 알려진 도메인은 LLM 없이 결정적 승격(0ms), 모르는 도메인만 `general`.

힌트가 LLM 보다 나은 이유: 같은 답을 2초 없이 내고, 도메인당 답이 고정됩니다.

법령 포털은 `compliance-officer` 로 배정했습니다. LLM 은 `labor-lawyer`/`corporate-lawyer` 로 갈렸는데 둘 다 특정 분야 포털이 아니라 분야 중립이 맞습니다. **실측에서 반복 확인된 도메인만** 넣었습니다 — 추측으로 채우면 잘못된 스킬을 결정적으로 주입하게 됩니다.

## 순서 주의 (테스트가 잡은 결함)

URL 판정을 短문장 직행(③)보다 **먼저** 둡니다. 뒤에 두면 30자 이하의 짧은 URL 이 길이 규칙에 먼저 걸려 도메인 힌트를 놓칩니다. 추가한 서브도메인 테스트(`open.law.go.kr`)가 이 결함을 잡았습니다 — 운영에서 짧은 법령 링크가 조용히 `general` 로 가던 경로입니다.

## 범위

URL 에 설명이 한 줄이라도 붙으면 대상이 아니며 기존 LLM 경로를 그대로 탑니다. 게이트 `OMK_AGENT_URL_ONLY_SKIP`(기본 true), 힌트는 `OMK_AGENT_URL_DOMAIN_HINTS` 로 오버라이드 가능합니다.

## 검증

- 테스트 4건 추가 — agent-resolver 9건 전부 통과
- tsc·lint 통과
- `.env.example` 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)