### PR TITLE
feat(agent-task): local 작업 생성 감사 기록 — OpenMake Code 축1 마감

### DIFF
--- a/apps/api/src/routes/agent-task.helpers.ts
+++ b/apps/api/src/routes/agent-task.helpers.ts
@@ -55,3 +55,23 @@ export function toPublicTask(t: Record<string, unknown>) {
         : undefined;
     return { ...rest, ...(fileMetas ? { input_files: fileMetas } : {}), resumable: !!checkpoint && t.status === 'failed' };
 }
+
+/**
+ * 로컬 실행 작업 생성 감사 — 사용자 머신에서 도구가 실행되는 보안 관련 행위라 어느
+ * 디바이스·폴더로 위임됐는지 이력을 남긴다 (축1 plan 6단계. CRITICAL_ACTIONS 미등록 =
+ * 알림 없음·기록만). fire-and-forget — 실패는 생성 결과에 영향 없음.
+ */
+export async function auditLocalTaskCreate(
+    userId: string, taskId: string, deviceId?: string, folderRel?: string,
+): Promise<void> {
+    try {
+        const { getAuditService } = await import('../services/AuditService');
+        await getAuditService().logAudit({
+            action: 'agent_task_local_create',
+            userId,
+            resourceType: 'agent_task',
+            resourceId: taskId,
+            details: { deviceId, folderRel: folderRel ?? null },
+        });
+    } catch { /* 감사 실패가 작업 생성을 되돌리지 않는다 */ }
+}

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -226,6 +226,20 @@ router.post('/', (req: Request, res: Response, next) => {
         folderRel: executor === 'local' ? folderRel : undefined,
     });
 
+    // 로컬 실행 작업 생성 감사 — 사용자 머신에서 도구가 실행되는 보안 관련 행위라
+    // 어느 디바이스·폴더로 위임됐는지 이력을 남긴다 (축1 plan 6단계, CRITICAL_ACTIONS
+    // 미등록 = 알림 없음·기록만). 실패는 생성 결과에 영향 없음.
+    if (executor === 'local') {
+        const { getAuditService } = await import('../services/AuditService');
+        await getAuditService().logAudit({
+            action: 'agent_task_local_create',
+            userId,
+            resourceType: 'agent_task',
+            resourceId: taskId,
+            details: { deviceId, folderRel: folderRel ?? null },
+        }).catch((e) => logger.warn(`[AgentTask] 로컬 생성 감사 기록 실패(무시): ${e instanceof Error ? e.message : e}`));
+    }
+
     const task = await db.getAgentTask(taskId);
     // 목록/상세와 동일하게 메타만 노출 — 첨부 본문(content/data)·내부 경로(storedPath) 응답 제외
     res.status(201).json(success({

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -51,7 +51,7 @@ import {
 } from '../services/agent-task/upload-store';
 import { claimUploadsAsInputFiles, ChunkStoreError } from '../services/agent-task/chunk-store';
 import { resolveDefaultMaxTurns } from '../services/agent-task/task-inputs';
-import { loadOwnedTask, toPublicTask, validateLocalExecutorInput } from './agent-task.helpers';
+import { auditLocalTaskCreate, loadOwnedTask, toPublicTask, validateLocalExecutorInput } from './agent-task.helpers';
 import { isAdminRole } from '../data/user-manager';
 
 const logger = createLogger('AgentTaskRoutes');
@@ -226,19 +226,8 @@ router.post('/', (req: Request, res: Response, next) => {
         folderRel: executor === 'local' ? folderRel : undefined,
     });
 
-    // 로컬 실행 작업 생성 감사 — 사용자 머신에서 도구가 실행되는 보안 관련 행위라
-    // 어느 디바이스·폴더로 위임됐는지 이력을 남긴다 (축1 plan 6단계, CRITICAL_ACTIONS
-    // 미등록 = 알림 없음·기록만). 실패는 생성 결과에 영향 없음.
-    if (executor === 'local') {
-        const { getAuditService } = await import('../services/AuditService');
-        await getAuditService().logAudit({
-            action: 'agent_task_local_create',
-            userId,
-            resourceType: 'agent_task',
-            resourceId: taskId,
-            details: { deviceId, folderRel: folderRel ?? null },
-        }).catch((e) => logger.warn(`[AgentTask] 로컬 생성 감사 기록 실패(무시): ${e instanceof Error ? e.message : e}`));
-    }
+    // 로컬 실행 작업 생성 감사 (helpers — 위임 이력, fire-and-forget)
+    if (executor === 'local') await auditLocalTaskCreate(userId, taskId, deviceId, folderRel);
 
     const task = await db.getAgentTask(taskId);
     // 목록/상세와 동일하게 메타만 노출 — 첨부 본문(content/data)·내부 경로(storedPath) 응답 제외


### PR DESCRIPTION
## 배경

OpenMake Code 축1 plan(2026-08-21)을 현행 코드와 대조한 결과, **1~5단계는 당일 배포분(#546 CLI·#547 API key 스코프·#549 폴더 선택)에 이미 구현돼 있었습니다** — registry 다중 디바이스, WS API key 인증+스코프, 작업 계약 `deviceId`/`folderRel`(마이그 101·102), status `devices[]`, 컴포저 디바이스·폴더 선택기, 작업 목록/상세 로컬 뱃지까지. 운영 게이트도 `LOCAL_EXECUTOR_ENABLED=true` 로 이미 ON 입니다.

유일한 공백이 6단계의 **감사 기록**이었습니다.

## 변경

`executor='local'` 작업 생성 시 `audit_logs` 에 `agent_task_local_create` 를 남깁니다(deviceId·folderRel 포함). 사용자 머신에서 도구가 실행되는 보안 관련 행위라 위임 이력이 필요합니다. CRITICAL_ACTIONS 에는 넣지 않아 알림 없이 기록만 하며, 감사 실패는 생성 결과에 영향을 주지 않습니다(fire-and-forget).

## 검증

라이브 E2E(가짜 브리지 디바이스)로 경로 전체를 검증했습니다:
1. `bridge` 스코프 API key 발급 → 2. WS `bridge_hello` 등록(`bridge_ready` 수신) → 3. local 작업 생성 **201** → 4. 정리(작업 삭제·키 폐기)

audit 행 자체는 현 운영 dist 에 이 코드가 없어 0건이 정상 — **배포 후 같은 하네스로 재확인 예정**입니다. tsc·lint 통과.

## 비고

plan 1단계의 "디바이스당 폴더 다중(`folders[]` hello)" 은 #549 가 열거(`folders` kind)+`folderRel` 방식으로 설계를 대체해 폐기됐습니다 — 루트는 디바이스당 1개, 하위 폴더는 열거로 선택합니다. plan 문서(로컬)에 완료 상태와 함께 기록했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)