### PR TITLE
test(desktop): 브리지 하네스 CI 편입 + 검증 축 2종 추가 — 축2 심화 증분

### DIFF
--- a/apps/desktop/bridge-harness.cjs
+++ b/apps/desktop/bridge-harness.cjs
@@ -110,6 +110,11 @@ const fakeApp = {
     const esc = await exec({ kind: 'read', path: '../../etc/hosts' });
     assert.equal(esc.ok, false, '스코프 탈출 거부');
 
+    // ②-B listAll 재귀 나열 — 심링크 제외·상대경로 규약
+    const all = await exec({ kind: 'listAll' });
+    assert.ok(all.entries.includes('seed.txt'), 'listAll 루트 파일');
+    assert.ok(all.entries.includes('subdir/out.txt'), 'listAll 하위 파일');
+
     // ③ exec (denylist / 자동승인 실행)
     const denied = await exec({ kind: 'exec', command: 'sudo ls' });
     assert.equal(denied.exitCode, 126, 'denylist 126');
@@ -133,6 +138,12 @@ const fakeApp = {
     assert.ok(br.ok && JSON.parse(br.stdout).harness === true, 'browser 어댑터');
     await exec({ kind: 'task_end', taskId });
     assert.equal(stubs.browserClosed, 1, 'task_end → agent-browser.closeAll');
+
+    // ⑥-B 서버 error 프레임 — 상태에 반영되고 연결은 살아 있다
+    sock.send(JSON.stringify({ type: 'error', message: '검증용 서버 오류' }));
+    await new Promise((r) => setTimeout(r, 150));
+    assert.ok(statuses.some((s) => s.includes('서버 오류: 검증용 서버 오류')), 'error 프레임 상태 반영');
+    assert.equal((await exec({ kind: 'read', path: 'seed.txt' })).ok, true, 'error 프레임 후에도 연결 생존');
 
     // ⑦ 해제 — 상태·일괄승인 회수
     bridge.disconnectFolder();

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "dev:frontend-next": "cd apps/web && npm run dev",
         "start": "node apps/api/dist/server.js",
         "start:api": "node apps/api/dist/server.js",
-        "test": "npm run build:packages && npm test --workspace=@openmake/local-bridge-core && npm test --workspace=apps/api",
+        "test": "npm run build:packages && npm test --workspace=@openmake/local-bridge-core && npm run test:bridge-harness && npm test --workspace=apps/api",
         "test:backend": "npm run build:packages && npm test --workspace=apps/api",
         "test:e2e": "npx playwright test",
         "test:e2e:ui": "npx playwright test --ui",
@@ -23,7 +23,8 @@
         "contracts:export": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\",\"moduleResolution\":\"node\"}' ts-node --transpile-only scripts/export-openapi.ts",
         "clean": "rm -rf */dist **/dist",
         "version": "node -e \"const v=require('./package.json').version;const fs=require('fs');['apps/api/package.json','apps/web/package.json'].forEach(f=>{const p=JSON.parse(fs.readFileSync(f,'utf8'));p.version=v;fs.writeFileSync(f,JSON.stringify(p,null,4)+'\\n')});console.log('✅ 모든 workspace 버전 동기화 완료:',v)\" && git add apps/api/package.json apps/web/package.json",
-        "build:discord-bot": "cd apps/discord-bot && npm run build"
+        "build:discord-bot": "cd apps/discord-bot && npm run build",
+        "test:bridge-harness": "node scripts/copy-desktop-bridge-core.mjs && node apps/desktop/bridge-harness.cjs"
     },
     "keywords": [
         "ai",


### PR DESCRIPTION
## 배경

데스크톱 헤드리스 하네스(#570)가 **일회성 수동 검증**이라, 앞으로의 브리지 변경에서 데스크톱 어댑터 회귀 가드가 CI 에 없는 공백이 있었습니다.

## 사전 선언 기준 → 결과

| 기준 | 목표 | 결과 |
|---|---|---|
| 검증 항목 | assert ≥18 (신규 축: `listAll`, 서버 `error` 프레임 수신·생존) | **20** |
| CI 편입 | 루트 test 체인에서 매 PR 전 케이스 실행 | ✅ |
| 소요 | <60s (CI 부담 상한) | **0.86s** |
| 코어 로직 변경 | 0줄 | ✅ |

체인: `build:packages → 코어 유닛(49) → bridge-harness(코어 복사 포함) → apps/api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)