### PR TITLE
feat(install): 배포 제품화 마감 — update 서브커맨드 + 인스톨러 CI 게이트 2단

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # ==============================================================
 # GitHub Actions CI Pipeline
 # ==============================================================
-# 7 게이트: Contract Drift → Jest → TypeScript Build → File Size Guard → ESLint → Routing Eval → Response Eval
+# 8 게이트: Contract Drift → Installer Lint → Jest → TypeScript Build → File Size Guard → ESLint → Routing Eval → Response Eval
 # 로컬 `npm test`/`npm run build`/`npm run lint` 와 같은 스크립트로 돈다(별도 미러 스크립트 없음).
 # Docker 사용 없음 (프로젝트 방침 영구 제외)
 # ==============================================================
@@ -74,6 +74,19 @@ jobs:
             exit 1
           fi
           echo "계약 산출물 최신 상태 확인"
+
+      # ─── Gate 0.5: Installer Lint ───
+      # install.sh(47KB)·openmake_llm.sh 는 레포 파일 구조를 참조하는 배포 진입점인데
+      # 어떤 게이트도 검사하지 않아, 리팩터링이 인스톨러를 조용히 깨뜨려도 신규 설치자가
+      # 실패할 때까지 발견되지 않았다 (4축 배포 제품화 대조, 2026-08-22). bash -n(문법) +
+      # shellcheck warning 이상 0건을 강제한다 — 도입 시점 클린 실측(지적 4건 전부 수정).
+      # 전체 설치 완주는 별도 주간 워크플로우(install-smoke.yml — 러너 15분급이라 per-PR 과대).
+      - name: "Gate 0.5: Installer Lint"
+        run: |
+          bash -n install.sh
+          bash -n openmake_llm.sh
+          shellcheck -S warning install.sh openmake_llm.sh
+          echo "인스톨러 lint 통과 (bash -n + shellcheck)"
 
       # ─── Gate 1: Jest ───
       # 로컬 `npm test` 와 **같은 러너**로 돈다. 이전에는 bun test 로 돌렸는데, 로컬은 jest 라

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,0 +1,72 @@
+# ==============================================================
+# 주간 클린 설치 스모크 — install.sh 완주 검증 (4축 배포 제품화, 2026-08-22)
+# ==============================================================
+# ci.yml 의 Gate 0.5(lint)는 문법·정적 결함만 잡는다. 이 워크플로우는 진짜 질문 —
+# "깨끗한 머신에서 원샷 설치가 지금도 완주하는가"—에 답한다. 러너 ~15분급이라
+# per-PR 은 과대해 주 1회 + 수동 dispatch 로 돈다.
+#
+# 검증 축: toolchain 확보 → .env 생성(시크릿) → compose(PG+Redis) → 마이그레이션
+# → 백엔드·프론트 빌드 → PM2 기동 → /health 200. LLM 은 placeholder(미설정) —
+# 설치 완주와 서비스 기동은 LLM 없이 성립해야 한다(설치 후 관리자가 설정하는 흐름).
+name: Install Smoke
+
+on:
+  schedule:
+    # 매주 월요일 새벽(UTC 20:47 일요일 = KST 월 05:47) — :00/:30 회피 관례.
+    - cron: '47 20 * * 0'
+  workflow_dispatch: {}
+
+concurrency:
+  group: install-smoke
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Clean install → health
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # 러너에 이미 있는 Node 가 24가 아니어도 인스톨러가 스스로 확보해야 하지만,
+      # 러너의 npm 글로벌 권한·버전 관리자 상호작용 변수를 줄이기 위해 24를 미리 둔다
+      # (인스톨러의 ensure_node 는 "이미 24면 통과" 경로 — 자체 설치 경로는 lint 가 지킨다).
+      - name: Setup Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+
+      - name: Run installer (non-interactive)
+        run: ./install.sh --yes
+
+      - name: Verify health + processes
+        run: |
+          set -euo pipefail
+          PORT=$(grep -E '^PORT=' .env | cut -d= -f2)
+          PORT=${PORT:-52416}
+          echo "health 확인: http://127.0.0.1:$PORT/health"
+          curl -fsS "http://127.0.0.1:$PORT/health" | head -c 300; echo
+          npx pm2 list
+          npx pm2 jlist | node -e '
+            const l=JSON.parse(require("fs").readFileSync(0,"utf8"));
+            const bad=l.filter(p=>p.pm2_env.status!=="online");
+            if(l.length===0){console.error("PM2 앱 0개");process.exit(1);}
+            if(bad.length){console.error("offline:",bad.map(p=>p.name));process.exit(1);}
+            console.log("PM2 online:",l.map(p=>p.name).join(", "));'
+
+      - name: Verify migrations applied
+        run: |
+          docker exec openmake-postgres \
+            psql -U "$(grep -E '^POSTGRES_USER=' .env | cut -d= -f2)" \
+                 -d "$(grep -E '^POSTGRES_DB=' .env | cut -d= -f2)" \
+                 -tAc "SELECT count(*) FROM migration_versions;" | tee /tmp/mig
+          [ "$(cat /tmp/mig)" -gt 0 ] || { echo "::error::마이그레이션 0건"; exit 1; }
+
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          echo "── pm2 logs ──"; npx pm2 logs --nostream --lines 60 || true
+          echo "── docker ps ──"; docker ps -a || true
+          echo "── compose logs ──"; docker compose --env-file .env -f infra/docker-compose.yml logs --tail 50 || true
+          echo "── .env 키 목록(값 제외) ──"; grep -oE '^[A-Z_]+' .env | head -40 || true

--- a/README.md
+++ b/README.md
@@ -234,6 +234,25 @@ On macOS the installer works with Docker Desktop, OrbStack, or **Colima**
 plugin isn't registered with the docker CLI, the installer adds `cliPluginsExtraDirs` to
 `~/.docker/config.json` for you.
 
+### Updating an installed instance
+
+```bash
+./openmake_llm.sh update            # git pull (ff-only) → build → migrate → restart
+./openmake_llm.sh update --yes      # skip the migration confirmation (non-interactive)
+```
+
+`update` refuses to touch a tree with uncommitted changes or diverged local commits — it
+never overwrites your edits. If nothing new was pulled it skips the redeploy (`--force` to
+redeploy anyway). Tarball installs (no git) should re-run `install.sh` instead, which
+repairs in place.
+
+To pin an install to a release instead of `main`, set `OMK_REF` on the one-liner:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/openmake/openmake_llm/main/install.sh \
+  | OMK_REF=v1.31.1 bash -s -- --yes
+```
+
 ### Prerequisites (handled by the installer)
 
 - **git** — on a fresh macOS, the very first `git clone` triggers the Xcode Command

--- a/install.sh
+++ b/install.sh
@@ -319,7 +319,11 @@ try_node_version_manager() {
     if [[ -s "$nvm_sh" ]]; then
         log_info "nvm 으로 Node $NODE_PINNED_VERSION 설치 시도"
         # nvm.sh 는 set -u 환경에서 미정의 변수를 건드리므로 잠시 해제한다.
-        set +u; . "$nvm_sh"; nvm install "$NODE_PINNED_VERSION" >/dev/null 2>&1 || true
+        set +u
+        # nvm.sh 경로는 런타임 결정이라 정적 추적 불가가 정상 (지시자는 바로 다음 명령에만 적용).
+        # shellcheck source=/dev/null
+        . "$nvm_sh"
+        nvm install "$NODE_PINNED_VERSION" >/dev/null 2>&1 || true
         nvm use "$NODE_PINNED_VERSION" >/dev/null 2>&1 || true; set -u
         if [[ "$(node_major)" -ge $NODE_MAJOR_MIN ]]; then
             persist_path "$(dirname "$(command -v node)")"; return 0

--- a/openmake_llm.sh
+++ b/openmake_llm.sh
@@ -39,7 +39,8 @@
 # ==============================================================================
 set -euo pipefail
 
-readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+readonly SCRIPT_DIR
 
 # install.sh 가 홈 디렉터리에 Node/PM2 를 설치한 경우 그 PATH 를 이어받는다.
 # (시스템에 Node 24 / pm2 가 없어도 이 스크립트가 그대로 동작하도록.)
@@ -137,7 +138,7 @@ port_listening() {
         ss -ltn "sport = :$port" 2>/dev/null | grep -q LISTEN && return 0
     fi
     if command -v netstat >/dev/null 2>&1; then
-        netstat -an 2>/dev/null | grep -qE "[.:]$port[[:space:]].*LISTEN" && return 0
+        netstat -an 2>/dev/null | grep -qE "[.:]${port}[[:space:]].*LISTEN" && return 0
     fi
     # 최종 판정 — 실제 연결을 시도한다 (localhost 바인딩만 감지 가능).
     (exec 3<>/dev/tcp/127.0.0.1/"$port") >/dev/null 2>&1 && return 0
@@ -540,6 +541,49 @@ confirm_or_exit() {
     esac
 }
 
+# ── update: 설치본 최신화 (git ff-only pull → deploy 위임) ──────────────────
+# 설치자(install.sh 사용자) 대상의 표준 업데이트 경로. 원칙:
+#   · ff-only — 로컬 커밋이 있으면 히스토리를 합치지 않고 중단(설치본 변형 보호)
+#   · 미커밋 변경 감지 시 중단 안내(덮어쓰기 없음) — 개발 트리 오염 방지
+#   · 변경 없으면 deploy 를 건너뛴다(무의미한 재시작 방지, --force 로 강제)
+cmd_update() {
+    local FORCE=0 PASS=()
+    for arg in "$@"; do
+        case "$arg" in
+            --force) FORCE=1 ;;
+            *) PASS+=("$arg") ;;   # --yes / --no-migrate 는 deploy 로 전달
+        esac
+    done
+    parse_deploy_opts "${PASS[@]}"
+
+    log_step "Update: git pull(ff-only) → deploy"
+    command -v git >/dev/null 2>&1 || { log_err "git 이 필요합니다"; exit 1; }
+    git -C "$SCRIPT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+        || { log_err "git 레포가 아닙니다 — tarball 설치본은 재설치(install.sh)로 갱신하세요"; exit 1; }
+
+    if [[ -n "$(git -C "$SCRIPT_DIR" status --porcelain 2>/dev/null)" ]]; then
+        log_err "미커밋 로컬 변경이 있어 업데이트를 중단합니다 (덮어쓰지 않음)."
+        echo "  변경을 정리(commit/stash)한 뒤 다시 실행하세요: git -C \"$SCRIPT_DIR\" status"
+        exit 1
+    fi
+
+    local before after
+    before="$(git -C "$SCRIPT_DIR" rev-parse --short HEAD)"
+    git -C "$SCRIPT_DIR" fetch --tags --prune || { log_err "git fetch 실패"; exit 1; }
+    if ! git -C "$SCRIPT_DIR" pull --ff-only; then
+        log_err "fast-forward 불가 — 로컬 커밋이 원격과 갈라졌습니다. 수동으로 정리 후 재시도하세요."
+        exit 1
+    fi
+    after="$(git -C "$SCRIPT_DIR" rev-parse --short HEAD)"
+
+    if [[ "$before" == "$after" && "$FORCE" -ne 1 ]]; then
+        log_ok "이미 최신입니다 ($after) — deploy 생략 (강제: --force)"
+        return 0
+    fi
+    log_ok "업데이트: $before → $after"
+    cmd_deploy "${PASS[@]}"
+}
+
 cmd_deploy() {
     parse_deploy_opts "$@"
     preflight
@@ -618,6 +662,8 @@ OpenMake LLM 통합 서비스 매니저
   deploy    build + migrate + restart 통합 (코드 변경 운영 반영)
             백엔드(openmake-llm)와 프론트(openmake-next) 모두 재시작
             옵션: --yes (확인 프롬프트 skip), --no-migrate (마이그 생략)
+  update    git pull(ff-only) → deploy — 설치본 표준 업데이트 경로
+            미커밋 변경·비ff 이력이면 중단(덮어쓰지 않음). 옵션: deploy 와 동일 + --force
 
 관측:
   status    모든 계층 상태 확인 (포트 + docker + PM2)
@@ -653,6 +699,7 @@ main() {
         build)    cmd_build "$@" ;;
         migrate)  cmd_migrate ;;
         deploy)   cmd_deploy "$@" ;;
+        update)   cmd_update "$@" ;;
         status)   show_status ;;
         health)   show_health ;;
         logs)     show_logs ;;


### PR DESCRIPTION
## 배경 (4축 대조 결론)

설치 부트스트랩 자체는 완성 상태였습니다(8/14 개선 트랙, 실환경 완주, 완성도 95~98%). 비어 있던 것은 **지속성** 두 축입니다: 설치자가 쓸 업데이트 경로가 없고, 47KB 인스톨러를 지키는 CI 검증이 0이었습니다(리팩터링이 인스톨러를 조용히 깨뜨려도 신규 설치자가 실패할 때까지 미발견).

## ① `openmake_llm.sh update`

\`git pull(ff-only) → deploy\` 위임. 안전 원칙: 미커밋 변경·갈라진 이력이면 **중단(덮어쓰지 않음)**, 변경 없으면 deploy 생략(\`--force\` 강행). dirty 트리에서 중단·무손상을 실검증했습니다. README 에 Updating 절과 \`OMK_REF\` 릴리스 태그 고정 설치를 문서화.

## ② 인스톨러 CI 게이트 2단

**Gate 0.5 (per-PR, 수 초)** — \`bash -n\` + \`shellcheck -S warning\` (install.sh·openmake_llm.sh). 도입 전 실측에서 지적 4건을 전부 수정해 클린 상태로 게이트를 겁니다. 그중 SC1087 은 실오류(\`\$port[[:space:]]\` 경계), SC1090 은 \`set +u\` 와 한 줄에 있어 지시자가 source 명령에 못 미치던 배치 문제였습니다.

**install-smoke.yml (주 1회 + 수동 dispatch)** — ubuntu 러너 클린 머신에서 \`./install.sh --yes\` 완주 → \`/health\` 200 → PM2 전 앱 online → 마이그레이션 적용 수 > 0. 실패 시 pm2·compose 로그 자동 덤프. per-PR 로는 15분급이라 과대해 주기 검증으로 분리했습니다.

## 검증

- update 가드: dirty 트리 중단 + 무손상 실검증
- shellcheck warning 0건(2파일), bash -n 통과, 워크플로우 YAML 파싱 OK
- **머지 후 \`gh workflow run install-smoke\` 로 스모크 1회 실구동 예정** — 클린 설치 완주는 러너에서만 진짜 검증이 됩니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)