### PR TITLE
feat(web): 채팅 composer 첨부 버튼을 + 메뉴로 통합 — 파일 첨부/폴더 선택

### DIFF
--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -20,6 +20,8 @@ import {
   X,
   Lock,
   BookOpen,
+  Plus,
+  FolderOpen,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -109,6 +111,18 @@ export function Composer() {
   const [dragging, setDragging] = useState(false);
   // 모드 시트(모바일 최적화) — 7개 토글을 가로스크롤 칩 대신 '도구' 버튼 + 시트로 수납
   const [modeSheetOpen, setModeSheetOpen] = useState(false);
+  // + 메뉴 — 파일 첨부/폴더 선택 진입점 통합. 폴더 선택은 에이전트 모드+로컬 실행이
+  // 전제라 클릭 시 함께 활성화한다(폴더는 로컬 실행 작업에서만 의미가 있음).
+  const [plusMenuOpen, setPlusMenuOpen] = useState(false);
+  const plusMenuRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!plusMenuOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (plusMenuRef.current && !plusMenuRef.current.contains(e.target as Node)) setPlusMenuOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [plusMenuOpen]);
   // NotebookLM 노트북 컨텍스트 — 선택 시 백엔드가 메시지 앞에 grounding 프리픽스 주입,
   // 해제 전까지 같은 대화 내에서 유지. 상태는 store(notebookContext) — 대화 전환/새 대화
   // 리셋은 clearChat·대화 로드 지점(sidebar/history)이 담당해 다른 대화로 누수되지 않는다.
@@ -876,14 +890,44 @@ export function Composer() {
               e.target.value = ""; // 같은 파일 재선택 허용
             }}
           />
-          <button
-            onClick={() => fileInputRef.current?.click()}
-            className="grid h-8 w-8 place-items-center rounded-md text-muted transition hover:bg-surface-2 hover:text-fg disabled:opacity-40"
-            title={t("attachFile")}
-            aria-label={t("attachFileLabel")}
-          >
-            <Paperclip className="h-4 w-4" />
-          </button>
+          <div ref={plusMenuRef} className="relative">
+            <button
+              onClick={() => setPlusMenuOpen((v) => !v)}
+              className="grid h-8 w-8 place-items-center rounded-md text-muted transition hover:bg-surface-2 hover:text-fg disabled:opacity-40"
+              title={t("plusMenu.label")}
+              aria-label={t("plusMenu.label")}
+              aria-expanded={plusMenuOpen}
+            >
+              <Plus className="h-4 w-4" />
+            </button>
+            {plusMenuOpen && (
+              <div className="absolute bottom-full left-0 z-20 mb-1 w-44 rounded-md border border-border bg-surface-2 p-1 shadow-lg">
+                <button
+                  type="button"
+                  onClick={() => { setPlusMenuOpen(false); fileInputRef.current?.click(); }}
+                  className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs text-fg-1 hover:bg-surface-3"
+                  title={t("attachFile")}
+                >
+                  <Paperclip className="h-3.5 w-3.5" />
+                  {t("plusMenu.file")}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setPlusMenuOpen(false);
+                    if (!agentTaskMode) toggle("agentTaskMode");
+                    setAgentLocalExecutor(true);
+                    setFolderBrowsePath("");
+                    setFolderPickerOpen(true);
+                  }}
+                  className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs text-fg-1 hover:bg-surface-3"
+                >
+                  <FolderOpen className="h-3.5 w-3.5" />
+                  {t("plusMenu.folder")}
+                </button>
+              </div>
+            )}
+          </div>
 
           <button
             onClick={cycleStyle}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -254,6 +254,11 @@
     "placeholder": "Type a message or invoke a skill with /...",
     "attachFile": "Attach files (drag & drop supported · any format)",
     "attachFileLabel": "Attach files",
+    "plusMenu": {
+      "label": "Add",
+      "file": "Attach files",
+      "folder": "Select folder"
+    },
     "responseStyle": "Response style",
     "stop": "Stop",
     "send": "Send",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -254,6 +254,11 @@
     "placeholder": "メッセージを入力するか、/ でスキルを呼び出してください...",
     "attachFile": "ファイルを添付（ドラッグ＆ドロップ対応・すべての形式）",
     "attachFileLabel": "ファイルを添付",
+    "plusMenu": {
+      "label": "追加",
+      "file": "ファイルを添付",
+      "folder": "フォルダを選択"
+    },
     "responseStyle": "応答スタイル",
     "stop": "停止",
     "send": "送信",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -254,6 +254,11 @@
     "placeholder": "메시지를 입력하거나 / 로 스킬을 호출하세요...",
     "attachFile": "파일 첨부 (드래그앤드롭 지원 · 모든 형식)",
     "attachFileLabel": "파일 첨부",
+    "plusMenu": {
+      "label": "추가",
+      "file": "파일 첨부",
+      "folder": "폴더 선택"
+    },
     "responseStyle": "응답 스타일",
     "stop": "중단",
     "send": "전송",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -254,6 +254,11 @@
     "placeholder": "输入消息，或用 / 调用技能...",
     "attachFile": "添加文件（支持拖放 · 任意格式）",
     "attachFileLabel": "添加文件",
+    "plusMenu": {
+      "label": "添加",
+      "file": "附加文件",
+      "folder": "选择文件夹"
+    },
     "responseStyle": "回复风格",
     "stop": "停止",
     "send": "发送",


### PR DESCRIPTION
## 요약
채팅 composer 하단의 클립 아이콘(파일 첨부 단일 동작)을 **+ 버튼 메뉴**로 교체한다.

- **파일 첨부**: 기존 파일 선택 다이얼로그 그대로
- **폴더 선택**: 에이전트 모드 + 로컬 실행을 자동 활성화하고 기존 폴더 선택(102, #549) 탐색 패널을 연다. 브리지 미연결이면 기존 '연결 안 됨' 표시로 폴백
- `composer.plusMenu` i18n 키 4언어(ko/en/ja/zh) 추가 — 삽입만

## 범위
프론트(apps/web)만. 백엔드·브리지 프로토콜 무변경 — 폴더 발원지=디바이스 불변식 그대로 (연결 루트 하위 폴더 선택이며, 웹발 루트 추가 아님).

## 검증
- [x] `apps/web` `tsc --noEmit` 통과
- [ ] chat.openmake.cc 실배포 확인은 배포 후 별도

🤖 Generated with [Claude Code](https://claude.com/claude-code)