### PR TITLE
feat(desktop-native): SwiftUI 네이티브 컴패니언 1차 — 헬퍼 브리지·승인·알림·native 업데이트 채널

### DIFF
--- a/.github/workflows/desktop-native.yml
+++ b/.github/workflows/desktop-native.yml
@@ -1,0 +1,56 @@
+# ==============================================================
+# Desktop Native Companion CI (plan §2 레포 배치)
+# ==============================================================
+# path-filter: apps/desktop-native 또는 브리지 코어(packages/local-bridge-core) 변경 시에만 실행.
+# 코어가 바뀌었는데 헬퍼 번들/하네스가 깨지는 커밋을 여기서 잡는다 (iOS ci 패턴 준용).
+# ad-hoc 서명·dmg 게시는 로컬 수동(scripts/publish-desktop.sh) — CI 는 빌드 검증만.
+# ==============================================================
+
+name: Desktop Native
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'apps/desktop-native/**'
+      - 'packages/local-bridge-core/**'
+      - '.github/workflows/desktop-native.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'apps/desktop-native/**'
+      - 'packages/local-bridge-core/**'
+      - '.github/workflows/desktop-native.yml'
+
+concurrency:
+  group: desktop-native-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  companion:
+    name: Companion (Helper harness → Swift build)
+    runs-on: macos-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # ─── Gate 1: 헬퍼 번들 + 하네스 ───
+      # local-bridge-core dist 빌드 → esbuild 번들 → stdio confirm 왕복 포함 회귀 하네스.
+      - name: "Gate 1: Helper bundle + harness"
+        run: |
+          npm ci --ignore-scripts
+          npm run build:packages
+          npx esbuild apps/desktop-native/helper/src/helper.mjs --bundle --platform=node \
+            --target=node20 --format=cjs --outfile=apps/desktop-native/helper/dist/helper.cjs
+          node apps/desktop-native/helper/harness.cjs
+
+      # ─── Gate 2: Swift 릴리스 빌드 (무서명) ───
+      - name: "Gate 2: Swift build"
+        run: swift build -c release --package-path apps/desktop-native/OpenMakeCompanion

--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,8 @@ data/desktop-updates/
 # 도구 세션 상태(run-continuation) — 저장소와 무관
 .omo/
 apps/desktop/local-bridge-core/
+
+# SwiftUI 네이티브 컴패니언 빌드 산출물 (apps/desktop-native)
+apps/desktop-native/dist/
+apps/desktop-native/helper/dist/
+apps/desktop-native/OpenMakeCompanion/.build/

--- a/apps/api/src/routes/desktop-update.routes.ts
+++ b/apps/api/src/routes/desktop-update.routes.ts
@@ -23,16 +23,25 @@ const router = Router();
 router.get('/latest', (_req: Request, res: Response) => {
     const manifestPath = path.join(DESKTOP_UPDATE.DIR, 'latest.json');
     try {
-        const m = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as { version?: string; file?: string; sha256?: string };
+        const m = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
+            version?: string; file?: string; sha256?: string;
+            native?: { version?: string; file?: string; sha256?: string };
+        };
         if (!m.version || !m.file || !DESKTOP_UPDATE.FILE_PATTERN.test(m.file)) {
             res.status(404).json(notFound('업데이트 매니페스트가 올바르지 않습니다'));
             return;
         }
+        // native 채널(SwiftUI 컴패니언) — 추가 전용: 블록이 없거나 형식이 어긋나면 기존 응답 그대로
+        const n = m.native;
+        const native = n && n.version && n.file && DESKTOP_UPDATE.FILE_PATTERN.test(n.file)
+            ? { version: n.version, file: n.file, sha256: n.sha256 ?? null, url: `/api/desktop/download/${n.file}` }
+            : null;
         res.json(success({
             version: m.version,
             file: m.file,
             sha256: m.sha256 ?? null,
             url: `/api/desktop/download/${m.file}`,
+            ...(native ? { native } : {}),
         }));
     } catch {
         res.status(404).json(notFound('배포된 데스크톱 업데이트가 없습니다'));

--- a/apps/desktop-native/OpenMakeCompanion/Package.swift
+++ b/apps/desktop-native/OpenMakeCompanion/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version:5.9
+// OpenMake Companion — 로컬 에이전트 컴패니언 (SwiftUI, macOS 메뉴바 상주).
+// 서드파티 의존 0 (plan §3 — iOS 축과 동일 원칙). 브리지 코어는 Node 헬퍼로 동봉.
+import PackageDescription
+
+let package = Package(
+    name: "OpenMakeCompanion",
+    platforms: [.macOS(.v14)],
+    targets: [
+        .executableTarget(name: "OpenMakeCompanion", path: "Sources/OpenMakeCompanion"),
+    ]
+)

--- a/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/CompanionApp.swift
+++ b/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/CompanionApp.swift
@@ -1,0 +1,126 @@
+// OpenMake Companion — 메뉴바 상주 로컬 에이전트 컴패니언.
+// 역할 한정(plan §1 비목표): 채팅 UI 없음 — 깊은 작업은 웹으로 딥링크 핸드오프.
+import AppKit
+import SwiftUI
+import UserNotifications
+
+final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(.accessory) // 메뉴바 전용 (Dock 미노출)
+        let center = UNUserNotificationCenter.current()
+        center.delegate = self
+        center.requestAuthorization(options: [.alert, .sound]) { _, _ in /* 거부는 fail-open */ }
+        Task { @MainActor in
+            HelperManager.shared.reconnectIfPossible()
+            Updater.shared.scheduleStartupCheck(backendUrl: HelperManager.shared.backend.url)
+        }
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        Task { @MainActor in HelperManager.shared.stopHelper() }
+    }
+
+    // 알림 클릭 → 웹 핸드오프
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse) async {
+        if let s = response.notification.request.content.userInfo["url"] as? String,
+           let url = URL(string: s) {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    // 앱이 전면일 때도 배너 표시
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification) async -> UNNotificationPresentationOptions {
+        [.banner, .sound]
+    }
+}
+
+@main
+struct CompanionApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    @StateObject private var helper = HelperManager.shared
+
+    var body: some Scene {
+        MenuBarExtra("OpenMake", systemImage: helper.connectedFolder != nil ? "folder.badge.gearshape" : "folder.badge.questionmark") {
+            MenuContent().environmentObject(helper)
+        }
+        Settings {
+            SettingsView().environmentObject(helper)
+        }
+    }
+}
+
+struct MenuContent: View {
+    @EnvironmentObject var helper: HelperManager
+    @Environment(\.openSettings) private var openSettings
+
+    var body: some View {
+        Text("상태: \(helper.statusText)")
+        if let f = helper.connectedFolder {
+            Text("폴더: \(f)") // 전체 경로 — 로컬 표시 전용(서버엔 basename 만 감)
+        }
+        Divider()
+        Button("작업 폴더 연결…") { helper.chooseFolderAndConnect() }
+        if helper.connectedFolder != nil {
+            Button("연결 해제") { helper.disconnect() }
+            Button("Finder 에서 열기") {
+                if let f = helper.connectedFolder {
+                    NSWorkspace.shared.open(URL(fileURLWithPath: f))
+                }
+            }
+        }
+        if helper.autoApproveCount > 0 {
+            Button("일괄 승인 해제 (\(helper.autoApproveCount)개 작업)") { helper.clearAutoApprove() }
+        }
+        Divider()
+        Button("웹에서 열기") { helper.openWeb() }
+        Button("업데이트 확인…") {
+            Task { await Updater.shared.check(backendUrl: helper.backend.url, interactive: true) }
+        }
+        Button("설정…") {
+            openSettings()
+            NSApp.activate(ignoringOtherApps: true)
+        }
+        Divider()
+        Button("종료") {
+            helper.stopHelper()
+            NSApp.terminate(nil)
+        }
+    }
+}
+
+struct SettingsView: View {
+    @EnvironmentObject var helper: HelperManager
+    @State private var apiKey: String = Keychain.load() ?? ""
+    @State private var backendId: String = HelperManager.shared.backendId
+    @State private var saved = false
+
+    var body: some View {
+        Form {
+            Section("인증") {
+                SecureField("API key (omk_live_…)", text: $apiKey)
+                Text("웹 설정 → API 키에서 bridge 스코프 키를 발급해 붙여넣으세요. Keychain 에 저장됩니다.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+            Section("백엔드") {
+                Picker("서버", selection: $backendId) {
+                    ForEach(HelperManager.backends, id: \.id) { b in
+                        Text(b.label).tag(b.id)
+                    }
+                }
+            }
+            HStack {
+                Button("저장") {
+                    Keychain.save(apiKey.trimmingCharacters(in: .whitespacesAndNewlines))
+                    if backendId != helper.backendId { helper.switchBackend(backendId) }
+                    saved = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) { saved = false }
+                }
+                if saved { Text("저장됨").foregroundStyle(.green) }
+            }
+        }
+        .padding(20)
+        .frame(width: 420)
+    }
+}

--- a/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/HelperManager.swift
+++ b/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/HelperManager.swift
@@ -1,0 +1,243 @@
+// HelperManager — Node 헬퍼(브리지 코어) 프로세스의 유일한 spawn 주체.
+//
+// 보안 설계 (plan §3·목표 원칙):
+//  - 로컬 실행 권한의 범위는 항상 "사용자가 NSOpenPanel 로 직접 지정한 폴더 + 하위" —
+//    경로 스코프 강제는 헬퍼(코어)의 realpath safe() 가 담당하고, 여기서는 발원만 담당한다.
+//  - exec 승인/거절의 선택 주체는 항상 사용자(네이티브 다이얼로그, 비우회). 'all'(일괄 승인)
+//    은 그 작업 한정이며 회수는 코어가 관리, 여기서는 카운트 표시·즉시 해제만 제공한다.
+//  - API key 는 argv 가 아니라 env 로 전달(ps 노출 방지), 저장은 Keychain.
+//  - 좀비 방지: 앱 종료 시 stdin 닫힘 → 헬퍼가 스스로 정리 종료(하네스 검증됨). 추가로
+//    terminate() 를 명시 호출한다.
+import AppKit
+import Foundation
+import UserNotifications
+
+@MainActor
+final class HelperManager: NSObject, ObservableObject {
+    static let shared = HelperManager()
+
+    @Published var statusText = "미연결"
+    @Published var connectedFolder: String? = nil
+    @Published var autoApproveCount = 0
+
+    private var process: Process?
+    private var stdinPipe: Pipe?
+    private var stdoutBuf = Data()
+
+    // 백엔드 선택 — Electron 셸과 동일 2종. 로컬은 Next(3000)가 WS 를 프록시하지 못하므로
+    // 백엔드(52416) 직결 (기존 bridgeBackendUrl 관행).
+    static let backends: [(id: String, label: String, url: String, webUrl: String)] = [
+        ("external", "외부 (chat.openmake.cc)", "https://chat.openmake.cc", "https://chat.openmake.cc"),
+        ("local", "로컬 (localhost:52416)", "http://localhost:52416", "http://localhost:3000"),
+    ]
+    var backendId: String {
+        get { UserDefaults.standard.string(forKey: "backend") ?? "external" }
+        set { UserDefaults.standard.set(newValue, forKey: "backend") }
+    }
+    var backend: (id: String, label: String, url: String, webUrl: String) {
+        Self.backends.first { $0.id == backendId } ?? Self.backends[0]
+    }
+    /** 마지막 연결 폴더 — 재기동 시 자동 재연결용(로컬 UserDefaults, 서버 미전송). */
+    var lastFolder: String? {
+        get { UserDefaults.standard.string(forKey: "lastFolder") }
+        set { UserDefaults.standard.set(newValue, forKey: "lastFolder") }
+    }
+
+    // ── 헬퍼 프로세스 lifecycle ──
+
+    private func resourceURL(_ name: String) -> URL? {
+        // 번들 실행(정식) → Resources, 개발 실행(swift run) → env 훅으로 경로 주입.
+        if let env = ProcessInfo.processInfo.environment["OMK_COMPANION_\(name.uppercased())"] {
+            return URL(fileURLWithPath: env)
+        }
+        return Bundle.main.resourceURL?.appendingPathComponent(name)
+    }
+
+    private func ensureHelper() -> Bool {
+        if let p = process, p.isRunning { return true }
+        // 테스트 훅(개발/E2E 전용): env key 가 있으면 Keychain 대신 사용 — Electron 의
+        // OMK_BRIDGE_TOKEN 관행과 동일 계열. 정식 실행 경로는 Keychain 만 쓴다.
+        let envKey = ProcessInfo.processInfo.environment["OMK_COMPANION_API_KEY"]
+        guard let apiKey = envKey ?? Keychain.load(), !apiKey.isEmpty else {
+            statusText = "API key 필요 — 설정에서 입력"
+            return false
+        }
+        guard let nodeURL = resourceURL("node"), FileManager.default.isExecutableFile(atPath: nodeURL.path),
+              let helperURL = resourceURL("helper.cjs"), FileManager.default.fileExists(atPath: helperURL.path) else {
+            statusText = "헬퍼 리소스 없음 (재설치 필요)"
+            return false
+        }
+        let p = Process()
+        p.executableURL = nodeURL
+        p.arguments = [helperURL.path, "--server", backend.url]
+        var env = ProcessInfo.processInfo.environment
+        env["OMK_COMPANION_API_KEY"] = apiKey
+        p.environment = env
+        let inPipe = Pipe(), outPipe = Pipe()
+        p.standardInput = inPipe
+        p.standardOutput = outPipe
+        p.standardError = FileHandle.nullDevice
+        outPipe.fileHandleForReading.readabilityHandler = { [weak self] h in
+            let d = h.availableData
+            guard !d.isEmpty else { return }
+            Task { @MainActor in self?.consume(d) }
+        }
+        p.terminationHandler = { [weak self] _ in
+            Task { @MainActor in
+                self?.process = nil
+                self?.stdinPipe = nil
+                if self?.connectedFolder != nil { self?.statusText = "헬퍼 종료됨 — 다시 연결하세요" }
+                self?.connectedFolder = nil
+            }
+        }
+        do { try p.run() } catch {
+            statusText = "헬퍼 실행 실패: \(error.localizedDescription)"
+            return false
+        }
+        process = p
+        stdinPipe = inPipe
+        return true
+    }
+
+    func stopHelper() {
+        send(["cmd": "quit"])
+        let p = process
+        process = nil
+        stdinPipe = nil
+        connectedFolder = nil
+        // quit 처리(결과 flush 100ms) 뒤에도 살아 있으면 강제 종료 — 좀비 방지 2중선.
+        DispatchQueue.global().asyncAfter(deadline: .now() + 1.0) { if let p, p.isRunning { p.terminate() } }
+    }
+
+    private func send(_ obj: [String: Any]) {
+        guard let pipe = stdinPipe,
+              let data = try? JSONSerialization.data(withJSONObject: obj) else { return }
+        pipe.fileHandleForWriting.write(data)
+        pipe.fileHandleForWriting.write(Data("\n".utf8))
+    }
+
+    // ── 사용자 액션 ──
+
+    /** 폴더 연결 — 권한 부여의 유일한 발원: 사용자가 패널에서 직접 고른 폴더만 헬퍼로 전달된다. */
+    func chooseFolderAndConnect() {
+        let panel = NSOpenPanel()
+        panel.title = "에이전트 작업에 연결할 폴더 선택"
+        panel.message = "이 폴더(와 하위 폴더)를 작업 기준으로 파일을 읽고 씁니다. 셸 명령은 실행 전 매번 확인을 받고, 승인해도 OS 샌드박스가 폴더 밖 쓰기와 비밀 파일(.ssh 등) 읽기를 차단합니다."
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.canCreateDirectories = true
+        NSApp.activate(ignoringOtherApps: true)
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        connect(folder: url.path)
+    }
+
+    func connect(folder: String) {
+        guard ensureHelper() else { return }
+        lastFolder = folder
+        send(["cmd": "connect", "folder": folder])
+    }
+
+    func reconnectIfPossible() {
+        // 테스트 훅(개발/E2E 전용): 폴더가 env 로 지정되면 패널 없이 자동 연결
+        // (Electron 의 OMK_BRIDGE_FOLDER 와 동일 계열).
+        if let f = ProcessInfo.processInfo.environment["OMK_COMPANION_FOLDER"] { connect(folder: f); return }
+        if let f = lastFolder, Keychain.load() != nil { connect(folder: f) }
+    }
+
+    func disconnect() {
+        send(["cmd": "disconnect"])
+        connectedFolder = nil
+    }
+
+    func clearAutoApprove() { send(["cmd": "clearAutoApprove"]) }
+
+    /** 백엔드 전환 — 헬퍼 재기동(서버 URL 은 spawn 인자) 후 재연결. */
+    func switchBackend(_ id: String) {
+        backendId = id
+        let wasConnected = connectedFolder ?? lastFolder
+        stopHelper()
+        if let f = wasConnected {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { self.connect(folder: f) }
+        }
+    }
+
+    func openWeb() {
+        if let url = URL(string: backend.webUrl) { NSWorkspace.shared.open(url) }
+    }
+
+    // ── 헬퍼 이벤트 소비 ──
+
+    private func consume(_ d: Data) {
+        stdoutBuf.append(d)
+        while let nl = stdoutBuf.firstIndex(of: 0x0A) {
+            let line = stdoutBuf.subdata(in: stdoutBuf.startIndex..<nl)
+            stdoutBuf.removeSubrange(stdoutBuf.startIndex...nl)
+            guard let ev = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
+                  let kind = ev["ev"] as? String else { continue }
+            handle(kind, ev)
+        }
+    }
+
+    private func handle(_ kind: String, _ ev: [String: Any]) {
+        switch kind {
+        case "status":
+            statusText = ev["text"] as? String ?? ""
+            if statusText == "미연결" { connectedFolder = nil }
+        case "connected":
+            connectedFolder = ev["folder"] as? String
+        case "autoApprove":
+            autoApproveCount = ev["count"] as? Int ?? 0
+        case "confirm":
+            presentConfirm(ev)
+        case "taskEnd":
+            notifyTaskEnd(taskId: ev["taskId"] as? String)
+        default:
+            break
+        }
+    }
+
+    /** exec 승인 — 비우회 네이티브 다이얼로그. 실행될 명령 원문·실행 폴더를 그대로 보여준다. */
+    private func presentConfirm(_ ev: [String: Any]) {
+        let id = ev["id"] as? Int ?? 0
+        let command = ev["command"] as? String ?? ""
+        let taskId = ev["taskId"] as? String
+        let base = ev["base"] as? String ?? connectedFolder ?? ""
+        let sandboxed = ev["sandbox"] as? Bool ?? false
+        let preview = command.count > 800 ? String(command.prefix(800)) + "…" : command
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "에이전트가 이 셸 명령을 당신의 컴퓨터에서 실행하려고 합니다"
+        var detail = "\(preview)\n\n실행 폴더: \(base)\n"
+        detail += sandboxed
+            ? "OS 샌드박스 적용: 폴더 밖 쓰기와 비밀 파일(.ssh/.aws 등) 읽기는 차단됩니다. 그 외 읽기·네트워크는 허용됩니다."
+            : "⚠️ 샌드박스 미적용: 이 명령은 당신 계정 권한으로 폴더 밖 파일·네트워크에 접근할 수 있습니다."
+        if taskId != nil {
+            detail += "\n\n\"이 작업 동안 모두 실행\"을 고르면 이 작업이 끝날 때까지 다시 묻지 않습니다(다른 작업에는 적용되지 않습니다)."
+        }
+        alert.informativeText = detail
+        alert.addButton(withTitle: "실행")
+        if taskId != nil { alert.addButton(withTitle: "이 작업 동안 모두 실행") }
+        alert.addButton(withTitle: "거부")
+        NSApp.activate(ignoringOtherApps: true)
+        let r = alert.runModal()
+        let result: String
+        if r == .alertFirstButtonReturn { result = "yes" }
+        else if taskId != nil && r == .alertSecondButtonReturn { result = "all" }
+        else { result = "no" }
+        send(["cmd": "confirm", "id": id, "result": result])
+    }
+
+    /** 작업 종료 알림 — 클릭 시 웹 작업 상세로 핸드오프(상세 UI 는 웹 단일 구현 원칙).
+        ask_human/승인 대기 알림은 서버 web-push 가 담당(turn-executor onApprovalPending) — 중복 구현 안 함. */
+    private func notifyTaskEnd(taskId: String?) {
+        let content = UNMutableNotificationContent()
+        content.title = "에이전트 작업 종료"
+        content.body = "로컬 작업이 끝났습니다. 결과를 웹에서 확인하세요."
+        // 웹 작업 상세 딥링크 계약: /agent-tasks?task=<id> (admin/conversations 와 동일 패턴)
+        let url = taskId.map { "\(backend.webUrl)/agent-tasks?task=\($0)" } ?? backend.webUrl
+        content.userInfo = ["url": url]
+        let req = UNNotificationRequest(identifier: taskId ?? UUID().uuidString, content: content, trigger: nil)
+        UNUserNotificationCenter.current().add(req) { _ in /* 권한 거부 등은 무시(fail-open) */ }
+    }
+}

--- a/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/Keychain.swift
+++ b/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/Keychain.swift
@@ -1,0 +1,36 @@
+// Keychain — API key(omk_live_*) 저장. 디스크 평문 저장 금지(설정 파일·UserDefaults 불가).
+import Foundation
+import Security
+
+enum Keychain {
+    private static let service = "cc.openmake.companion"
+    private static let account = "api-key"
+
+    static func save(_ value: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(query as CFDictionary)
+        guard !value.isEmpty else { return }
+        var add = query
+        add[kSecValueData as String] = Data(value.utf8)
+        add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        SecItemAdd(add as CFDictionary, nil)
+    }
+
+    static func load() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/Updater.swift
+++ b/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/Updater.swift
@@ -1,0 +1,177 @@
+// 자체 업데이터 — 서버 매니페스트(native 채널) 확인 → dmg 다운로드 → sha256 검증 →
+// 분리 프로세스가 앱 교체 + 재실행 (Electron updater.js 와 동일 흐름·동일 안전장치).
+//
+// 보안:
+//  - 업데이트 확인은 HTTPS(또는 로컬호스트) 백엔드에서만 허용 (MITM 차단)
+//  - sha256 필수 — 매니페스트에 없으면 거부 (ad-hoc 서명 배포의 무결성 검증 수단)
+//  - 교체는 스테이징(.new) → 스왑 → 실패 시 롤백(.old) — 도중 실패에도 기존 앱 보존
+import AppKit
+import CryptoKit
+import Foundation
+
+@MainActor
+final class Updater: ObservableObject {
+    static let shared = Updater()
+
+    @Published var checking = false
+
+    private var currentVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0"
+    }
+
+    /** 기동 5초 후 자동 확인 (Electron 관행 준수). 새 버전 있을 때만 다이얼로그. */
+    func scheduleStartupCheck(backendUrl: String) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            Task { await self.check(backendUrl: backendUrl, interactive: false) }
+        }
+    }
+
+    func check(backendUrl: String, interactive: Bool) async {
+        guard !checking else { return }
+        checking = true
+        defer { checking = false }
+        do {
+            guard isSecureOrigin(backendUrl) else {
+                throw UpdateError.message("업데이트는 HTTPS(또는 로컬호스트) 백엔드에서만 허용됩니다")
+            }
+            guard let url = URL(string: "\(backendUrl)/api/desktop/latest") else {
+                throw UpdateError.message("잘못된 백엔드 주소")
+            }
+            let (data, _) = try await URLSession.shared.data(from: url)
+            guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let payload = root["data"] as? [String: Any],
+                  let native = payload["native"] as? [String: Any],
+                  let version = native["version"] as? String,
+                  let file = native["file"] as? String,
+                  let sha256 = native["sha256"] as? String, sha256.count == 64
+            else {
+                if interactive { info("업데이트 없음", "native 채널 배포가 아직 없거나 매니페스트가 없습니다. (현재 v\(currentVersion))") }
+                return
+            }
+            guard isNewer(version, than: currentVersion) else {
+                if interactive { info("최신 버전", "현재 v\(currentVersion) 가 최신입니다.") }
+                return
+            }
+            // 테스트 훅(개발/E2E 전용): 다이얼로그 없이 즉시 진행 — OMK_COMPANION_* env 훅 계열.
+            if ProcessInfo.processInfo.environment["OMK_COMPANION_AUTO_UPDATE"] != "1" {
+                let alert = NSAlert()
+                alert.messageText = "새 버전 v\(version) 이 있습니다 (현재 v\(currentVersion))"
+                alert.informativeText = "지금 받아서 설치할까요? 설치 중 앱이 잠시 종료됐다가 다시 열립니다."
+                alert.addButton(withTitle: "업데이트")
+                alert.addButton(withTitle: "나중에")
+                NSApp.activate(ignoringOtherApps: true)
+                guard alert.runModal() == .alertFirstButtonReturn else { return }
+            }
+
+            let dmgURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(file)
+            guard let dl = URL(string: "\(backendUrl)/api/desktop/download/\(file)") else {
+                throw UpdateError.message("잘못된 다운로드 주소")
+            }
+            let (tmp, _) = try await URLSession.shared.download(from: dl)
+            try? FileManager.default.removeItem(at: dmgURL)
+            try FileManager.default.moveItem(at: tmp, to: dmgURL)
+
+            let digest = SHA256.hash(data: try Data(contentsOf: dmgURL))
+            let hex = digest.map { String(format: "%02x", $0) }.joined()
+            guard hex == sha256.lowercased() else {
+                try? FileManager.default.removeItem(at: dmgURL)
+                throw UpdateError.message("다운로드 무결성 검증 실패(sha256 불일치)")
+            }
+
+            try spawnReplaceScript(dmgPath: dmgURL.path)
+            HelperManager.shared.stopHelper()
+            NSApp.terminate(nil)
+        } catch let e as UpdateError {
+            if case let .message(m) = e, interactive { info("업데이트 확인 실패", m) }
+        } catch {
+            if interactive { info("업데이트 확인 실패", error.localizedDescription) }
+        }
+    }
+
+    private func isSecureOrigin(_ s: String) -> Bool {
+        guard let u = URL(string: s), let host = u.host else { return false }
+        return u.scheme == "https" || host == "localhost" || host == "127.0.0.1"
+    }
+
+    /** 단순 수치 버전 비교 (a > b) — 자리수 다르면 부족분 0 취급. */
+    private func isNewer(_ a: String, than b: String) -> Bool {
+        let pa = a.split(separator: ".").map { Int($0) ?? 0 }
+        let pb = b.split(separator: ".").map { Int($0) ?? 0 }
+        for i in 0..<max(pa.count, pb.count) {
+            let x = i < pa.count ? pa[i] : 0, y = i < pb.count ? pb[i] : 0
+            if x != y { return x > y }
+        }
+        return false
+    }
+
+    /** 교체 스크립트 — Electron updater.js 의 검증된 시퀀스 이식 (스테이징→스왑→롤백·오류 시 osascript 경고). */
+    private func spawnReplaceScript(dmgPath: String) throws {
+        guard let appPath = Bundle.main.bundlePath.hasSuffix(".app") ? Bundle.main.bundlePath : nil else {
+            throw UpdateError.message("앱 번들 경로를 찾지 못했습니다(개발 실행에서는 업데이트 불가)")
+        }
+        let ts = Int(Date().timeIntervalSince1970)
+        let logPath = NSTemporaryDirectory() + "openmake-companion-update-\(ts).log"
+        let script = """
+        #!/bin/bash
+        exec >>"\(logPath)" 2>&1
+        set -u
+        APP="\(appPath)"
+        DMG="\(dmgPath)"
+
+        fail() {
+          echo "FAIL: $1"
+          /usr/bin/osascript -e "display alert \\"업데이트 실패\\" message \\"$1\\n\\n로그: \(logPath)\\" as critical" || true
+          [ -d "$APP" ] && open -a "$APP" || true
+          rm -f "$DMG"
+          exit 1
+        }
+
+        sleep 2
+        MNT=$(hdiutil attach -nobrowse "$DMG" | grep -o '/Volumes/.*' | tail -1)
+        [ -n "$MNT" ] || fail "디스크 이미지를 마운트하지 못했습니다."
+        [ -d "$MNT/OpenMake Companion.app" ] || { hdiutil detach "$MNT" -quiet; fail "이미지 안에서 앱을 찾지 못했습니다."; }
+
+        STAGE="$APP.new"
+        rm -rf "$STAGE"
+        if ! ditto "$MNT/OpenMake Companion.app" "$STAGE"; then
+          rm -rf "$STAGE"; hdiutil detach "$MNT" -quiet
+          fail "새 버전 복사에 실패했습니다(설치 폴더 권한을 확인하세요)."
+        fi
+        hdiutil detach "$MNT" -quiet
+
+        BACKUP="$APP.old"
+        rm -rf "$BACKUP"
+        mv "$APP" "$BACKUP" || { rm -rf "$STAGE"; fail "기존 앱을 교체할 수 없습니다."; }
+        if ! mv "$STAGE" "$APP"; then
+          mv "$BACKUP" "$APP" 2>/dev/null
+          fail "새 버전 설치에 실패해 이전 버전으로 되돌렸습니다."
+        fi
+        rm -rf "$BACKUP"
+
+        xattr -dr com.apple.quarantine "$APP" 2>/dev/null
+        rm -f "$DMG"
+        open -a "$APP" || fail "업데이트는 됐지만 앱을 다시 열지 못했습니다."
+        echo "OK: updated $APP"
+        rm -f "$0"
+        """
+        let shPath = NSTemporaryDirectory() + "openmake-companion-update-\(ts).sh"
+        try script.write(toFile: shPath, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: shPath)
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/bin/bash")
+        p.arguments = [shPath]
+        p.standardOutput = FileHandle.nullDevice
+        p.standardError = FileHandle.nullDevice
+        try p.run() // detached 성격 — 부모 종료 후에도 계속 실행됨(스크립트가 sleep 후 교체)
+    }
+
+    private func info(_ title: String, _ body: String) {
+        let a = NSAlert()
+        a.messageText = title
+        a.informativeText = body
+        NSApp.activate(ignoringOtherApps: true)
+        a.runModal()
+    }
+}
+
+enum UpdateError: Error { case message(String) }

--- a/apps/desktop-native/README.md
+++ b/apps/desktop-native/README.md
@@ -1,0 +1,38 @@
+# OpenMake Companion (SwiftUI 네이티브 데스크톱)
+
+메뉴바 상주 **로컬 에이전트 컴패니언** — 폴더 연결·디바이스 상태·exec 승인·작업 종료 알림·웹 딥링크만 담당한다.
+채팅 등 깊은 UI 는 웹(chat.openmake.cc)이 전담한다 (plan §1 비목표: 채팅 UI 재구현 금지).
+Plan: `docs/proposals/2026-08-22-desktop-native-companion-plan.md` (로컬 보관).
+
+## 구조
+
+```
+helper/src/helper.mjs    # Node 헬퍼 — @openmake/local-bridge-core 의 stdio JSON-lines 어댑터
+helper/harness.cjs       # 헬퍼 회귀 하네스 (build.sh 가 게이트로 실행)
+OpenMakeCompanion/       # SwiftPM 앱 (MenuBarExtra + 설정 + HelperManager + Updater)
+build.sh                 # helper 번들(esbuild) → 하네스 → swift build → .app 조립 → ad-hoc 서명 → dmg
+```
+
+- 브리지 보안 코어(경로 스코프·exec 3단 방어·git 고정 조립·worktree)는 **`packages/local-bridge-core` 재사용** — Swift 재구현 금지(plan §6 게이트).
+- 앱↔헬퍼 stdio 계약은 `helper.mjs` 상단 주석 참고. confirm 응답은 항상 앱(사용자 다이얼로그)만 발원.
+- 인증: API key(`omk_live_*`, bridge 스코프) → Keychain 저장, 헬퍼엔 env(`OMK_COMPANION_API_KEY`)로 전달 (ps 노출 방지).
+- 업데이트: `GET /api/desktop/latest` 의 `native` 채널(추가 전용 필드) — sha256 검증 후 분리 스크립트가 교체·재실행 (Electron updater.js 이식).
+
+## 빌드 / 게시
+
+```bash
+npm run build:packages                      # local-bridge-core dist 선행
+bash apps/desktop-native/build.sh 0.1.1     # dist/OpenMake-Companion-<v>-arm64.dmg
+bash scripts/publish-desktop.sh apps/desktop-native/dist/OpenMake-Companion-0.1.1-arm64.dmg
+# → latest.json 의 native 블록만 갱신 (Electron 필드 보존)
+```
+
+## 개발/E2E 전용 env 훅 (정식 경로는 Keychain·NSOpenPanel·다이얼로그만)
+
+| env | 효과 |
+|---|---|
+| `OMK_COMPANION_API_KEY` | Keychain 대신 이 키 사용 (헬퍼 스폰 env) |
+| `OMK_COMPANION_FOLDER` | 기동 시 패널 없이 이 폴더 자동 연결 |
+| `OMK_COMPANION_NODE` / `OMK_COMPANION_HELPER.CJS` | 번들 Resources 대신 이 경로 사용 (swift run 개발 실행) |
+| `OMK_COMPANION_AUTO_UPDATE=1` | 업데이트 다이얼로그 없이 즉시 진행 (업데이터 E2E) |
+| `OMK_BRIDGE_SANDBOX=0` / `OMK_BRIDGE_AUTO_APPROVE=1` | 코어 공통 훅 (CLI·Electron 과 동일) |

--- a/apps/desktop-native/build.sh
+++ b/apps/desktop-native/build.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# OpenMake Companion 빌드 — 헬퍼 번들 + Swift 빌드 + .app 조립 + ad-hoc 서명 + dmg.
+# 사전: npm run build:packages (local-bridge-core dist 필요)
+# 사용: bash apps/desktop-native/build.sh [버전]   (기본 버전: 0.1.0)
+set -euo pipefail
+cd "$(dirname "$0")"
+ROOT="$(cd ../.. && pwd)"
+VERSION="${1:-0.1.0}"
+APP_NAME="OpenMake Companion"
+BUNDLE_ID="cc.openmake.companion"
+OUT="dist"
+APP="$OUT/$APP_NAME.app"
+
+# 1) 헬퍼 번들 (코어 재사용 — 보안 코드 재구현 금지 원칙)
+test -f "$ROOT/packages/local-bridge-core/dist/index.js" || { echo "core dist 없음 — npm run build:packages 먼저"; exit 1; }
+(cd "$ROOT" && npx esbuild apps/desktop-native/helper/src/helper.mjs --bundle --platform=node \
+  --target=node20 --format=cjs --outfile=apps/desktop-native/helper/dist/helper.cjs)
+
+# 2) 헬퍼 하네스 (회귀 게이트 — 실패 시 빌드 중단)
+(cd "$ROOT" && node apps/desktop-native/helper/harness.cjs)
+
+# 3) Swift 릴리스 빌드
+(cd OpenMakeCompanion && swift build -c release)
+
+# 4) .app 번들 조립
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
+cp OpenMakeCompanion/.build/release/OpenMakeCompanion "$APP/Contents/MacOS/"
+cp helper/dist/helper.cjs "$APP/Contents/Resources/helper.cjs"
+# Node 런타임 동봉 — 시스템 node 미의존 (plan Step 0 결정)
+NODE_BIN="$(command -v node)"
+NODE_BIN="$(node -e 'console.log(process.execPath)')"
+cp "$NODE_BIN" "$APP/Contents/Resources/node"
+chmod +x "$APP/Contents/Resources/node"
+
+cat > "$APP/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>CFBundleName</key><string>$APP_NAME</string>
+  <key>CFBundleDisplayName</key><string>$APP_NAME</string>
+  <key>CFBundleIdentifier</key><string>$BUNDLE_ID</string>
+  <key>CFBundleVersion</key><string>$VERSION</string>
+  <key>CFBundleShortVersionString</key><string>$VERSION</string>
+  <key>CFBundleExecutable</key><string>OpenMakeCompanion</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>LSMinimumSystemVersion</key><string>14.0</string>
+  <key>LSUIElement</key><true/>
+  <key>NSHumanReadableCopyright</key><string>OpenMake</string>
+</dict></plist>
+PLIST
+
+# 5) ad-hoc 서명 (기존 Electron dmg 관행 — sha256 매니페스트로 무결성 검증)
+codesign --force --deep --sign - "$APP"
+
+# 6) dmg (파일명은 서버 FILE_PATTERN ^OpenMake-[A-Za-z0-9.-]+\.dmg$ 준수)
+DMG="$OUT/OpenMake-Companion-$VERSION-arm64.dmg"
+rm -f "$DMG"
+hdiutil create -volname "$APP_NAME" -srcfolder "$APP" -ov -format UDZO "$DMG" >/dev/null
+shasum -a 256 "$DMG"
+echo "빌드 완료: $DMG"

--- a/apps/desktop-native/helper/harness.cjs
+++ b/apps/desktop-native/helper/harness.cjs
@@ -1,0 +1,158 @@
+/**
+ * Companion 헬퍼 헤드리스 하네스 — helper.cjs 를 실프로세스로 spawn 해 회귀 검증.
+ *
+ * 데스크톱 하네스(apps/desktop/bridge-harness.cjs)와 동일 축이되 호스트 차이를 검증한다:
+ *  - 인증: Authorization Bearer(API key) 헤더, Origin 없음 (CLI 계약과 동일)
+ *  - confirmExec: 자동승인 훅이 아니라 **실제 stdio 왕복** — 승인(yes)/거부(no) 양쪽
+ *  - browser: 어댑터 미주입 → 코어 미지원 거부
+ *  - stdin 종료 = 즉시 정리 종료 (좀비 방지)
+ *
+ * 실행: node apps/desktop-native/helper/harness.cjs
+ *      (사전: npm run build:packages + esbuild 번들 — build.sh 참조)
+ * 종료코드 0 = 전 케이스 통과.
+ */
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync, spawn } = require('node:child_process');
+const { WebSocketServer } = require('ws');
+
+(async () => {
+    const folder = fs.mkdtempSync(path.join(os.tmpdir(), 'omk-cpharness-'));
+    const git = (args) => execFileSync('git', args, { cwd: folder, encoding: 'utf8' });
+    git(['init', '-q']);
+    git(['-c', 'user.email=h@h', '-c', 'user.name=h', 'commit', '--allow-empty', '-q', '-m', 'init']);
+    fs.writeFileSync(path.join(folder, 'seed.txt'), 'seed');
+    fs.mkdirSync(path.join(folder, 'subdir'));
+
+    // 가짜 브리지 서버
+    const received = [];
+    const waiters = [];
+    const wss = new WebSocketServer({ port: 0 });
+    await new Promise((r) => wss.once('listening', r));
+    const port = wss.address().port;
+    let sock = null;
+    let helloHeaders = null;
+    wss.on('connection', (ws, req) => {
+        sock = ws; helloHeaders = req.headers;
+        ws.on('message', (d) => {
+            const f = JSON.parse(d.toString());
+            received.push(f);
+            for (let i = waiters.length - 1; i >= 0; i--) {
+                if (waiters[i].pred(f)) { waiters[i].resolve(f); waiters.splice(i, 1); }
+            }
+            if (f.type === 'bridge_hello') ws.send(JSON.stringify({ type: 'bridge_ready' }));
+        });
+    });
+    const waitFor = (pred, ms = 8000) => {
+        const hit = received.find(pred);
+        if (hit) return Promise.resolve(hit);
+        return new Promise((resolve, reject) => {
+            const t = setTimeout(() => reject(new Error('frame timeout: ' + received.map((f) => f.type).join(','))), ms);
+            waiters.push({ pred, resolve: (f) => { clearTimeout(t); resolve(f); } });
+        });
+    };
+    const exec = (m) => {
+        const reqId = 'h-' + Math.random().toString(36).slice(2, 8);
+        sock.send(JSON.stringify({ type: 'bridge_exec', reqId, ...m }));
+        return waitFor((f) => f.type === 'bridge_result' && f.reqId === reqId).then((f) => f.result);
+    };
+
+    // 헬퍼 spawn — API key 는 env(ps 인자 비노출 계약)
+    const helper = spawn(process.execPath, [
+        path.join(__dirname, 'dist/helper.cjs'), '--server', `http://127.0.0.1:${port}`,
+    ], { env: { ...process.env, OMK_COMPANION_API_KEY: 'omk_live_harness' }, stdio: ['pipe', 'pipe', 'inherit'] });
+    const events = [];
+    const evWaiters = [];
+    let buf = '';
+    helper.stdout.on('data', (d) => {
+        buf += d.toString();
+        let nl;
+        while ((nl = buf.indexOf('\n')) >= 0) {
+            const line = buf.slice(0, nl); buf = buf.slice(nl + 1);
+            if (!line.trim()) continue;
+            const ev = JSON.parse(line);
+            events.push(ev);
+            for (let i = evWaiters.length - 1; i >= 0; i--) {
+                if (evWaiters[i].pred(ev)) { evWaiters[i].resolve(ev); evWaiters.splice(i, 1); }
+            }
+        }
+    });
+    const waitEv = (pred, ms = 8000) => {
+        const hit = events.find(pred);
+        if (hit) return Promise.resolve(hit);
+        return new Promise((resolve, reject) => {
+            const t = setTimeout(() => reject(new Error('event timeout: ' + events.map((e) => e.ev).join(','))), ms);
+            evWaiters.push({ pred, resolve: (e) => { clearTimeout(t); resolve(e); } });
+        });
+    };
+    const send = (obj) => helper.stdin.write(JSON.stringify(obj) + '\n');
+
+    // ① connect → hello: Bearer 인증, Origin 없음, 디바이스 메타
+    send({ cmd: 'connect', folder });
+    const hello = await waitFor((f) => f.type === 'bridge_hello');
+    assert.equal(hello.folderName, path.basename(folder), 'hello folderName');
+    assert.equal(helloHeaders.authorization, 'Bearer omk_live_harness', 'Bearer 인증 헤더');
+    assert.ok(!helloHeaders.origin, 'Origin 헤더 없음 (네이티브 클라이언트)');
+    const connected = await waitEv((e) => e.ev === 'connected');
+    assert.equal(connected.folder, fs.realpathSync(folder), 'connected 이벤트 folder');
+
+    // ② 파일 kind 왕복 + 스코프
+    assert.equal((await exec({ kind: 'read', path: 'seed.txt' })).content, 'seed', 'read');
+    await exec({ kind: 'write', path: 'subdir/out.txt', contentB64: Buffer.from('written').toString('base64') });
+    assert.equal(fs.readFileSync(path.join(folder, 'subdir/out.txt'), 'utf8'), 'written', 'write');
+    assert.equal((await exec({ kind: 'read', path: '../../etc/hosts' })).ok, false, '스코프 탈출 거부');
+    const all = await exec({ kind: 'listAll' });
+    assert.ok(all.entries.includes('seed.txt') && all.entries.includes('subdir/out.txt'), 'listAll');
+
+    // ③ exec — denylist / stdio confirm 승인 / 거부
+    assert.equal((await exec({ kind: 'exec', command: 'sudo ls' })).exitCode, 126, 'denylist 126');
+    const runP = exec({ kind: 'exec', command: 'echo -n from-companion', taskId: 'harness-task-000000000001' });
+    const c1 = await waitEv((e) => e.ev === 'confirm');
+    assert.ok(c1.command.includes('from-companion') && c1.sandbox === true, 'confirm 이벤트 내용');
+    send({ cmd: 'confirm', id: c1.id, result: 'yes' });
+    const ran = await runP;
+    assert.deepEqual([ran.ok, ran.stdout], [true, 'from-companion'], 'confirm yes → 실행');
+    const denyP = exec({ kind: 'exec', command: 'echo denied-cmd' });
+    const c2 = await waitEv((e) => e.ev === 'confirm' && e.id !== c1.id);
+    send({ cmd: 'confirm', id: c2.id, result: 'no' });
+    const deniedR = await denyP;
+    assert.deepEqual([deniedR.ok, deniedR.exitCode], [false, 126], 'confirm no → 거부');
+
+    // ③-B 일괄 승인('all') — 같은 작업 내 재확인 없음 + task_end 회수
+    const allP = exec({ kind: 'exec', command: 'echo -n bulk-1', taskId: 'harness-task-000000000002' });
+    const c3 = await waitEv((e) => e.ev === 'confirm' && e.id > c2.id);
+    send({ cmd: 'confirm', id: c3.id, result: 'all' });
+    assert.equal((await allP).stdout, 'bulk-1', 'all 승인 실행');
+    await waitEv((e) => e.ev === 'autoApprove' && e.count === 1);
+    const confirmsBefore = events.filter((e) => e.ev === 'confirm').length;
+    assert.equal((await exec({ kind: 'exec', command: 'echo -n bulk-2', taskId: 'harness-task-000000000002' })).stdout, 'bulk-2', 'all 후 재확인 없이 실행');
+    assert.equal(events.filter((e) => e.ev === 'confirm').length, confirmsBefore, 'all 승인 중 confirm 미발생');
+    await exec({ kind: 'task_end', taskId: 'harness-task-000000000002' });
+    await waitEv((e) => e.ev === 'taskEnd');
+    await waitEv((e) => e.ev === 'autoApprove' && e.count === 0);
+
+    // ④ folders 열거 / browser 미지원 / worktree
+    assert.deepEqual((await exec({ kind: 'folders', path: '.' })).entries, ['subdir'], 'folders 열거');
+    assert.equal((await exec({ kind: 'browser', spec: {} })).ok, false, 'browser 미지원 거부');
+    const taskId = 'harness-task-000000000003';
+    const wt = await exec({ kind: 'worktree', op: 'add', taskId });
+    assert.ok(wt.ok && wt.worktreeRel.endsWith(taskId), 'worktree add');
+    fs.writeFileSync(path.join(folder, wt.worktreeRel, 'change.txt'), 'diff-me');
+    const diff = await exec({ kind: 'worktree', op: 'diff', taskId });
+    assert.ok(diff.ok && diff.stdout.includes('diff-me'), 'worktree diff');
+
+    // ⑤ stdin 종료 = 정리 종료 (좀비 방지) — pending confirm 은 'no' 로 해소
+    const zombieP = exec({ kind: 'exec', command: 'echo never-runs' });
+    await waitEv((e) => e.ev === 'confirm' && e.command.includes('never-runs'));
+    helper.stdin.end();
+    const code = await new Promise((r) => helper.on('exit', r));
+    assert.equal(code, 0, 'stdin 종료 → exit 0');
+    const zombieR = await zombieP;
+    assert.deepEqual([zombieR.ok, zombieR.exitCode], [false, 126], '종료 시 pending confirm 거부 해소');
+
+    wss.close();
+    console.log('OK — Companion 헬퍼 하네스 전 케이스 통과 (frames=%d, events=%d)', received.length, events.length);
+    process.exit(0);
+})().catch((e) => { console.error('HARNESS FAIL:', e.message); process.exit(1); });

--- a/apps/desktop-native/helper/src/helper.mjs
+++ b/apps/desktop-native/helper/src/helper.mjs
@@ -1,0 +1,129 @@
+// OpenMake Companion 헬퍼 — @openmake/local-bridge-core 의 네이티브 앱(SwiftUI) 어댑터.
+//
+// 프로토콜·경로 스코프·exec 3단 방어·worktree 격리는 전부 코어 패키지가 담당한다
+// (데스크톱 Electron·CLI 와 동일 코어 — 보안 코드 재구현 금지 원칙, plan §3).
+// 이 파일은 호스트 차이만 남는다:
+//   - 인증: API key(omk_live_*) Authorization 헤더 (CLI 와 동일 계약).
+//     key 는 argv 가 아니라 env(OMK_COMPANION_API_KEY)로 받는다 — ps 인자 노출 방지.
+//   - confirmExec: stdio JSON-lines 로 부모(네이티브 앱)에 위임 — 비우회 사용자 확인의
+//     선택 주체는 항상 앱의 네이티브 다이얼로그(사용자)다. stdin 소실 시 'no'(fail-safe).
+//   - browser: 미지원 → 코어가 거부 응답 (capability 미보고 degrade)
+//   - deviceId·샌드박스 프로파일: ~/Library/Application Support/OpenMakeCompanion
+//
+// stdio 계약 (한 줄 = JSON 하나):
+//   helper→app: {ev:'status',text} {ev:'confirm',id,command,taskId,base,sandbox}
+//               {ev:'autoApprove',count} {ev:'taskEnd',taskId} {ev:'connected',folder}
+//   app→helper: {cmd:'connect',folder} {cmd:'disconnect'}
+//               {cmd:'confirm',id,result:'yes'|'all'|'no'} {cmd:'clearAutoApprove'} {cmd:'quit'}
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import * as readline from 'readline';
+import { BridgeConnection, BridgeCore, SANDBOX_ENABLED } from '../../../../packages/local-bridge-core/dist/index.js';
+
+const serverUrl = (() => {
+  const i = process.argv.indexOf('--server');
+  return i >= 0 ? process.argv[i + 1] : 'https://chat.openmake.cc';
+})();
+const apiKey = process.env.OMK_COMPANION_API_KEY || '';
+
+const SUPPORT_DIR = path.join(os.homedir(), 'Library', 'Application Support', 'OpenMakeCompanion');
+fs.mkdirSync(SUPPORT_DIR, { recursive: true });
+
+function send(obj) { process.stdout.write(JSON.stringify(obj) + '\n'); }
+
+function deviceId() {
+  const p = path.join(SUPPORT_DIR, 'device-id');
+  try { return fs.readFileSync(p, 'utf8').trim(); } catch { /* 최초 생성 */ }
+  const id = crypto.randomUUID();
+  try { fs.writeFileSync(p, id); } catch { /* noop */ }
+  return id;
+}
+
+// confirm 왕복 — id 상관. 앱이 죽으면(stdin close) 전 대기를 'no' 로 해소하고 종료.
+let confirmSeq = 0;
+const pendingConfirms = new Map(); // id -> resolve
+function stdioConfirm(command, taskId, base) {
+  return new Promise((resolve) => {
+    const id = ++confirmSeq;
+    pendingConfirms.set(id, resolve);
+    send({ ev: 'confirm', id, command, taskId: taskId ?? null, base, sandbox: SANDBOX_ENABLED });
+  });
+}
+
+let core = null;
+let connection = null;
+let folderRoot = null;
+
+function connectFolder(folder) {
+  if (!apiKey) { send({ ev: 'status', text: 'API key 필요 — 앱 설정에서 입력' }); return; }
+  let real;
+  try { real = fs.realpathSync(folder); } catch (e) { send({ ev: 'status', text: `폴더 열기 실패: ${e.message}` }); return; }
+  if (connection) connection.disconnect();
+  folderRoot = real;
+  core = new BridgeCore({
+    folder: folderRoot,
+    confirm: stdioConfirm,
+    sandboxProfileDir: SUPPORT_DIR,
+    onTaskEnd: (taskId) => send({ ev: 'taskEnd', taskId: taskId ?? null }),
+    onAutoApproveChange: () => send({ ev: 'autoApprove', count: core ? core.autoApprovedCount() : 0 }),
+  });
+  connection = new BridgeConnection({
+    serverUrl,
+    core,
+    deviceId: deviceId(),
+    label: `${os.hostname()} · ${path.basename(folderRoot)}`,
+    headers: () => ({ Authorization: `Bearer ${apiKey}` }),
+    onStatus: (s) => send({ ev: 'status', text: s }),
+    shouldReconnect: () => !!folderRoot,
+  });
+  void connection.connect();
+  send({ ev: 'connected', folder: folderRoot });
+}
+
+function disconnectFolder() {
+  folderRoot = null;
+  if (connection) connection.disconnect(); // 일괄 승인 회수 포함
+  connection = null;
+  core = null;
+  send({ ev: 'status', text: '미연결' });
+}
+
+const rl = readline.createInterface({ input: process.stdin });
+rl.on('line', (line) => {
+  let m;
+  try { m = JSON.parse(line); } catch { return; }
+  switch (m.cmd) {
+    case 'connect': if (typeof m.folder === 'string') connectFolder(m.folder); break;
+    case 'disconnect': disconnectFolder(); break;
+    case 'confirm': {
+      const resolve = pendingConfirms.get(m.id);
+      if (resolve) {
+        pendingConfirms.delete(m.id);
+        resolve(m.result === 'yes' || m.result === 'all' ? m.result : 'no');
+      }
+      break;
+    }
+    case 'clearAutoApprove': if (core) core.clearAutoApprove(); break;
+    case 'quit': shutdown(); break;
+    default: break;
+  }
+});
+
+// 부모 앱 사망(stdin 종료) = 좀비 방지 최후 방어선 — 대기 confirm 전부 거부 후 종료.
+// 거부 결과가 서버로 송신될 시간(microtask + WS flush)을 준 뒤 연결을 닫는다 —
+// 즉시 exit 하면 서버는 거부 대신 요청 타임아웃을 겪는다.
+let shuttingDown = false;
+function shutdown() {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  for (const resolve of pendingConfirms.values()) resolve('no');
+  pendingConfirms.clear();
+  setTimeout(() => { disconnectFolder(); process.exit(0); }, 100);
+}
+rl.on('close', shutdown);
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);
+
+send({ ev: 'status', text: '미연결' });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,9 @@ export default [
       "**/.next/**",
       "apps/web/**",
       "apps/desktop/**",
+      // Companion 헬퍼 하네스 — bridge-harness.cjs(ignored apps/desktop) 와 동일한
+      // CommonJS spawn 하네스라 require 가 필수. 앱 소스가 아니라 lint 대상에서 제외.
+      "apps/desktop-native/helper/harness.cjs",
       "**/node_modules/**",
       "**/.claude/**",
       "**/*.min.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
                 "@types/nodemailer": "^7.0.9",
                 "@types/supertest": "^7.2.0",
                 "concurrently": "^8.2.2",
+                "esbuild": "0.28.2",
                 "eslint": "^9.0.0",
                 "jest": "^30.4.2",
                 "playwright": "^1.58.0",
@@ -1109,6 +1110,448 @@
             "optional": true,
             "dependencies": {
                 "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+            "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+            "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+            "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+            "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+            "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+            "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+            "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+            "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+            "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+            "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+            "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+            "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+            "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+            "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+            "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+            "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+            "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+            "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+            "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+            "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+            "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+            "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+            "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -7791,6 +8234,48 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/esbuild": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+            "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.28.2",
+                "@esbuild/android-arm": "0.28.2",
+                "@esbuild/android-arm64": "0.28.2",
+                "@esbuild/android-x64": "0.28.2",
+                "@esbuild/darwin-arm64": "0.28.2",
+                "@esbuild/darwin-x64": "0.28.2",
+                "@esbuild/freebsd-arm64": "0.28.2",
+                "@esbuild/freebsd-x64": "0.28.2",
+                "@esbuild/linux-arm": "0.28.2",
+                "@esbuild/linux-arm64": "0.28.2",
+                "@esbuild/linux-ia32": "0.28.2",
+                "@esbuild/linux-loong64": "0.28.2",
+                "@esbuild/linux-mips64el": "0.28.2",
+                "@esbuild/linux-ppc64": "0.28.2",
+                "@esbuild/linux-riscv64": "0.28.2",
+                "@esbuild/linux-s390x": "0.28.2",
+                "@esbuild/linux-x64": "0.28.2",
+                "@esbuild/netbsd-arm64": "0.28.2",
+                "@esbuild/netbsd-x64": "0.28.2",
+                "@esbuild/openbsd-arm64": "0.28.2",
+                "@esbuild/openbsd-x64": "0.28.2",
+                "@esbuild/openharmony-arm64": "0.28.2",
+                "@esbuild/sunos-x64": "0.28.2",
+                "@esbuild/win32-arm64": "0.28.2",
+                "@esbuild/win32-ia32": "0.28.2",
+                "@esbuild/win32-x64": "0.28.2"
             }
         },
         "node_modules/escalade": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "@types/nodemailer": "^7.0.9",
         "@types/supertest": "^7.2.0",
         "concurrently": "^8.2.2",
+        "esbuild": "0.28.2",
         "eslint": "^9.0.0",
         "jest": "^30.4.2",
         "playwright": "^1.58.0",

--- a/scripts/publish-desktop.sh
+++ b/scripts/publish-desktop.sh
@@ -3,16 +3,37 @@
 #   사용법: bash scripts/publish-desktop.sh [dmg경로]
 #   기본:  apps/desktop/dist 의 최신 OpenMake-*.dmg
 # 산출: $DESKTOP_UPDATE_DIR(기본 data/desktop-updates)/ 에 dmg 복사 + latest.json 생성.
+#
+# native 채널(SwiftUI 컴패니언): 파일명이 OpenMake-Companion-* 이면 latest.json 의
+# `native` 블록만 갱신한다 — Electron 필드(version/file/sha256)는 보존 (추가 전용 계약).
+# 반대로 Electron dmg 게시 시에도 기존 native 블록을 보존한다.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DIR="${DESKTOP_UPDATE_DIR:-$ROOT/data/desktop-updates}"
 DMG="${1:-$(ls -t "$ROOT"/apps/desktop/dist/OpenMake-*.dmg 2>/dev/null | head -1)}"
 [ -f "$DMG" ] || { echo "dmg 없음: $DMG"; exit 1; }
 FILE="$(basename "$DMG")"
-VERSION="$(echo "$FILE" | sed -E 's/OpenMake-([0-9.]+)-.*/\1/')"
 SHA=$(shasum -a 256 "$DMG" | awk '{print $1}')
 mkdir -p "$DIR"
 cp "$DMG" "$DIR/$FILE"
-printf '{"version":"%s","file":"%s","sha256":"%s"}\n' "$VERSION" "$FILE" "$SHA" > "$DIR/latest.json"
-echo "게시됨: v$VERSION → $DIR/$FILE"
+
+if [[ "$FILE" == OpenMake-Companion-* ]]; then
+  VERSION="$(echo "$FILE" | sed -E 's/OpenMake-Companion-([0-9.]+)-.*/\1/')"
+  CHANNEL=native
+else
+  VERSION="$(echo "$FILE" | sed -E 's/OpenMake-([0-9.]+)-.*/\1/')"
+  CHANNEL=electron
+fi
+
+CHANNEL="$CHANNEL" VERSION="$VERSION" FILE="$FILE" SHA="$SHA" MANIFEST="$DIR/latest.json" node -e '
+const fs = require("fs");
+const { CHANNEL, VERSION, FILE, SHA, MANIFEST } = process.env;
+let m = {};
+try { m = JSON.parse(fs.readFileSync(MANIFEST, "utf8")); } catch { /* 최초 생성 */ }
+const entry = { version: VERSION, file: FILE, sha256: SHA };
+if (CHANNEL === "native") m.native = entry;
+else m = { ...entry, ...(m.native ? { native: m.native } : {}) };
+fs.writeFileSync(MANIFEST, JSON.stringify(m) + "\n");
+'
+echo "게시됨($CHANNEL): v$VERSION → $DIR/$FILE"
 cat "$DIR/latest.json"


### PR DESCRIPTION
## 요약
데스크톱을 **로컬 에이전트 컴패니언**으로 한정한 SwiftUI 네이티브 앱 1차 (plan: desktop-native-companion, 로컬 보관).
브리지 보안 코어(경로 스코프·exec 3단 방어·git 고정 조립·worktree)는 `packages/local-bridge-core` 를 **Node 헬퍼로 동봉·재사용** — Swift 재구현 없음.

## 구성
- `apps/desktop-native/helper/` — 코어 stdio JSON-lines 어댑터 + 헤드리스 회귀 하네스(confirm 승인/거부 실왕복 포함, build.sh 게이트)
- `apps/desktop-native/OpenMakeCompanion/` — MenuBarExtra + 설정(API key→Keychain) + HelperManager(유일 spawn 주체, 좀비 방지 2중선) + exec 승인 네이티브 다이얼로그(비우회) + taskEnd 알림 → `/agent-tasks?task=<id>` 딥링크 + Updater(sha256 검증, 스테이징→스왑→롤백 — Electron updater 이식)
- 서버 `GET /api/desktop/latest` 에 `native` 채널 **추가 전용** 필드 (Electron 응답 무변경), `publish-desktop.sh` 는 Companion dmg 감지 시 native 블록만 머지
- CI `desktop-native.yml` — path-filter macos job (하네스 → swift build), esbuild 루트 devDep 고정

## 라이브 검증 (chat.openmake.cc, user 3)
- 헬퍼 디바이스 등록 → 웹 API 작업 생성(executor=local) → 헬퍼 stdio confirm 1회 승인 → 로컬 실행 → `upper.txt` 산출·`completed` 확인
- 0.1.0 → 0.1.1 자체 교체 라이브 확인 (다운로드→sha256→교체 스크립트→재실행, `OK: updated`)
- 매니페스트 native 채널 외부 응답 확인 (Electron 필드 보존)

## 스코프 노트
- ask_human/승인 대기 알림은 기존 서버 web-push 담당(turn-executor onApprovalPending) — 컴패니언 중복 구현 안 함
- browser kind 미지원 → capability 미보고 degrade (plan 비목표)
- 발견된 코어 엣지(본 PR 범위 외): git 레포 하위의 **untracked 폴더** 연결 시 worktree 체크아웃에 해당 경로가 없어 exec cwd 실패 — 후속 이슈로 관리

## 체크리스트
- [x] `npm run lint` 통과 (오류 0)
- [x] `npm test` 통과 (2786 passed)
- [x] 환경변수 추가 없음 / DB 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)