### PR TITLE
fix(bridge): untracked 하위 폴더 연결 시 worktree cwd ENOENT 해소

### DIFF
--- a/apps/desktop-native/build.sh
+++ b/apps/desktop-native/build.sh
@@ -32,6 +32,8 @@ NODE_BIN="$(command -v node)"
 NODE_BIN="$(node -e 'console.log(process.execPath)')"
 cp "$NODE_BIN" "$APP/Contents/Resources/node"
 chmod +x "$APP/Contents/Resources/node"
+# 앱 아이콘 — 기존 Electron 앱과 동일 자산 재사용
+cp "$ROOT/apps/desktop/assets/icon.icns" "$APP/Contents/Resources/icon.icns"
 
 cat > "$APP/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
@@ -46,6 +48,7 @@ cat > "$APP/Contents/Info.plist" <<PLIST
   <key>CFBundlePackageType</key><string>APPL</string>
   <key>LSMinimumSystemVersion</key><string>14.0</string>
   <key>LSUIElement</key><true/>
+  <key>CFBundleIconFile</key><string>icon</string>
   <key>NSHumanReadableCopyright</key><string>OpenMake</string>
 </dict></plist>
 PLIST

--- a/packages/local-bridge-core/src/__tests__/worktree.test.ts
+++ b/packages/local-bridge-core/src/__tests__/worktree.test.ts
@@ -95,6 +95,23 @@ describe('handleWorktree', () => {
         expect(r.worktreeRel).toBe(`.openmake/worktrees/${TASK}/apps/web`);
     });
 
+    it('untracked 하위 폴더 base: 체크아웃에 없는 경로를 빈 디렉토리로 보장한다 (exec cwd ENOENT 회귀)', async () => {
+        // HEAD 에 없는(untracked) 하위 폴더를 연결/선택한 경우 — worktree 체크아웃에 해당
+        // 경로가 없어 exec cwd 가 실패하던 결함의 회귀 가드.
+        const sub = path.join(repo, 'newdir');
+        fs.mkdirSync(sub, { recursive: true }); // 커밋하지 않는다
+        const r = await run({ kind: 'worktree', op: 'add', taskId: TASK }, sub);
+        expect(r.ok).toBe(true);
+        expect(r.worktreeRel).toBe(`.openmake/worktrees/${TASK}/newdir`);
+        // 서버가 합성하는 실행 cwd(base + worktreeRel)가 실제로 존재해야 한다
+        expect(fs.existsSync(path.join(sub, r.worktreeRel!))).toBe(true);
+        // 재사용 경로에서도 보장된다
+        fs.rmSync(path.join(sub, r.worktreeRel!), { recursive: true, force: true });
+        const again = await run({ kind: 'worktree', op: 'add', taskId: TASK }, sub);
+        expect(again.ok).toBe(true);
+        expect(fs.existsSync(path.join(sub, again.worktreeRel!))).toBe(true);
+    });
+
     it('git 레포가 아니면 add 를 거부한다', async () => {
         const plain = fs.mkdtempSync(path.join(os.tmpdir(), 'omk-plain-'));
         try {

--- a/packages/local-bridge-core/src/worktree.ts
+++ b/packages/local-bridge-core/src/worktree.ts
@@ -94,12 +94,19 @@ export async function handleWorktree(m: BridgeMsg, done: (r: BridgeResult) => vo
         const prefixR = await gitRun(['rev-parse', '--show-prefix'], base);
         const sub = prefixR.code === 0 ? prefixR.stdout.trim().replace(/\/+$/, '') : '';
         const workRel = sub ? `${rel}/${sub}` : rel;
+        // 연결/선택 폴더가 **untracked**(HEAD 에 없는) 하위 디렉토리면 worktree 체크아웃에
+        // 해당 경로가 없어 exec cwd 가 ENOENT 로 실패한다 — 빈 디렉토리로 보장한다.
+        // (worktree 는 어차피 tracked 내용만 담으므로 격리 의미는 동일: 빈 폴더에서 시작.)
+        const ensureSub = (): void => {
+            if (sub) { try { fs.mkdirSync(path.join(abs, sub), { recursive: true }); } catch { /* exec 가 후속 실패로 노출 */ } }
+        };
         const gitDirR = await gitRun(['rev-parse', '--absolute-git-dir'], base);
         if (gitDirR.code === 0) excludeWorktreeDir(gitDirR.stdout.trim());
-        if (fs.existsSync(abs)) { done({ ok: true, worktreeRel: workRel, branch }); return; } // 재개 시 재사용
+        if (fs.existsSync(abs)) { ensureSub(); done({ ok: true, worktreeRel: workRel, branch }); return; } // 재개 시 재사용
         const r = await gitRun(['worktree', 'add', abs, '-b', branch], base);
         if (r.code !== 0) { done({ ok: false, error: `worktree 생성 실패: ${(r.stderr || r.stdout).trim().slice(0, 300)}` }); return; }
         await writeBaseSha(abs);
+        ensureSub();
         done({ ok: true, worktreeRel: workRel, branch });
         return;
     }


### PR DESCRIPTION
## 요약
#575 라이브 검증에서 발견된 코어 엣지 후속: 연결/선택 폴더가 git 레포 하위의 **untracked** 디렉토리면 `git worktree add`(HEAD 체크아웃)에 해당 경로가 없어 서버가 합성한 exec cwd(`base + worktreeRel`)가 ENOENT 로 실패했다.

## 수정
- `worktree.ts` add op: 생성·재사용 양쪽에서 show-prefix 하위 경로를 `mkdirSync(recursive)` 로 보장 — worktree 는 어차피 tracked 내용만 담으므로 격리 의미 동일(빈 폴더에서 시작)
- 회귀 테스트 추가: untracked 하위 폴더 base 에서 add → `base+worktreeRel` 실존 + 재사용 경로 보장

## 검증
- [x] 코어 유닛 50 passed (+1)
- [x] 데스크톱 하네스·Companion 헬퍼 하네스 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)