### PR TITLE
feat(desktop-native): 다중 루트 연결 — 루트당 독립 브리지 연결(파생 deviceId)

### DIFF
--- a/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/CompanionApp.swift
+++ b/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/CompanionApp.swift
@@ -42,7 +42,7 @@ struct CompanionApp: App {
     @StateObject private var helper = HelperManager.shared
 
     var body: some Scene {
-        MenuBarExtra("OpenMake", systemImage: helper.connectedFolder != nil ? "folder.badge.gearshape" : "folder.badge.questionmark") {
+        MenuBarExtra("OpenMake", systemImage: !helper.connectedFolders.isEmpty ? "folder.badge.gearshape" : "folder.badge.questionmark") {
             MenuContent().environmentObject(helper)
         }
         Settings {
@@ -56,19 +56,22 @@ struct MenuContent: View {
     @Environment(\.openSettings) private var openSettings
 
     var body: some View {
-        Text("상태: \(helper.statusText)")
-        if let f = helper.connectedFolder {
-            Text("폴더: \(f)") // 전체 경로 — 로컬 표시 전용(서버엔 basename 만 감)
+        if helper.connectedFolders.isEmpty {
+            Text("상태: \(helper.statusText)")
+        }
+        // 다중 루트 — 루트별 서브메뉴 (전체 경로는 로컬 표시 전용, 서버엔 basename 만 감)
+        ForEach(helper.connectedFolders, id: \.self) { f in
+            Menu("폴더: \(URL(fileURLWithPath: f).lastPathComponent)") {
+                Text(f)
+                if let st = helper.rootStatus[f] { Text("상태: \(st)") }
+                Button("Finder 에서 열기") { NSWorkspace.shared.open(URL(fileURLWithPath: f)) }
+                Button("연결 해제") { helper.disconnect(folder: f) }
+            }
         }
         Divider()
-        Button("작업 폴더 연결…") { helper.chooseFolderAndConnect() }
-        if helper.connectedFolder != nil {
-            Button("연결 해제") { helper.disconnect() }
-            Button("Finder 에서 열기") {
-                if let f = helper.connectedFolder {
-                    NSWorkspace.shared.open(URL(fileURLWithPath: f))
-                }
-            }
+        Button(helper.connectedFolders.isEmpty ? "작업 폴더 연결…" : "작업 폴더 추가…") { helper.chooseFolderAndConnect() }
+        if helper.connectedFolders.count > 1 {
+            Button("전체 연결 해제") { helper.disconnectAll() }
         }
         if helper.autoApproveCount > 0 {
             Button("일괄 승인 해제 (\(helper.autoApproveCount)개 작업)") { helper.clearAutoApprove() }

--- a/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/HelperManager.swift
+++ b/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/HelperManager.swift
@@ -17,7 +17,10 @@ final class HelperManager: NSObject, ObservableObject {
     static let shared = HelperManager()
 
     @Published var statusText = "미연결"
-    @Published var connectedFolder: String? = nil
+    /** 연결된 루트들(realpath) — 루트당 독립 브리지 연결(파생 deviceId), 서버엔 별개 디바이스. */
+    @Published var connectedFolders: [String] = []
+    /** 루트별 최근 상태 텍스트 (연결됨/재연결 중/서버 오류 등). */
+    @Published var rootStatus: [String: String] = [:]
     @Published var autoApproveCount = 0
 
     private var process: Process?
@@ -37,10 +40,18 @@ final class HelperManager: NSObject, ObservableObject {
     var backend: (id: String, label: String, url: String, webUrl: String) {
         Self.backends.first { $0.id == backendId } ?? Self.backends[0]
     }
-    /** 마지막 연결 폴더 — 재기동 시 자동 재연결용(로컬 UserDefaults, 서버 미전송). */
-    var lastFolder: String? {
-        get { UserDefaults.standard.string(forKey: "lastFolder") }
-        set { UserDefaults.standard.set(newValue, forKey: "lastFolder") }
+    /** 마지막 연결 폴더들 — 재기동 시 자동 재연결용(로컬 UserDefaults, 서버 미전송).
+        구 단일 키(lastFolder)는 최초 1회 마이그레이션한다. */
+    var lastFolders: [String] {
+        get {
+            if let arr = UserDefaults.standard.stringArray(forKey: "lastFolders") { return arr }
+            if let one = UserDefaults.standard.string(forKey: "lastFolder") { return [one] }
+            return []
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: "lastFolders")
+            UserDefaults.standard.removeObject(forKey: "lastFolder")
+        }
     }
 
     // ── 헬퍼 프로세스 lifecycle ──
@@ -86,8 +97,9 @@ final class HelperManager: NSObject, ObservableObject {
             Task { @MainActor in
                 self?.process = nil
                 self?.stdinPipe = nil
-                if self?.connectedFolder != nil { self?.statusText = "헬퍼 종료됨 — 다시 연결하세요" }
-                self?.connectedFolder = nil
+                if !(self?.connectedFolders.isEmpty ?? true) { self?.statusText = "헬퍼 종료됨 — 다시 연결하세요" }
+                self?.connectedFolders = []
+                self?.rootStatus = [:]
             }
         }
         do { try p.run() } catch {
@@ -104,7 +116,8 @@ final class HelperManager: NSObject, ObservableObject {
         let p = process
         process = nil
         stdinPipe = nil
-        connectedFolder = nil
+        connectedFolders = []
+        rootStatus = [:]
         // quit 처리(결과 flush 100ms) 뒤에도 살아 있으면 강제 종료 — 좀비 방지 2중선.
         DispatchQueue.global().asyncAfter(deadline: .now() + 1.0) { if let p, p.isRunning { p.terminate() } }
     }
@@ -121,7 +134,7 @@ final class HelperManager: NSObject, ObservableObject {
     /** 폴더 연결 — 권한 부여의 유일한 발원: 사용자가 패널에서 직접 고른 폴더만 헬퍼로 전달된다. */
     func chooseFolderAndConnect() {
         let panel = NSOpenPanel()
-        panel.title = "에이전트 작업에 연결할 폴더 선택"
+        panel.title = "에이전트 작업에 연결할 폴더 선택 (여러 폴더를 각각 추가할 수 있습니다)"
         panel.message = "이 폴더(와 하위 폴더)를 작업 기준으로 파일을 읽고 씁니다. 셸 명령은 실행 전 매번 확인을 받고, 승인해도 OS 샌드박스가 폴더 밖 쓰기와 비밀 파일(.ssh 등) 읽기를 차단합니다."
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
@@ -133,7 +146,9 @@ final class HelperManager: NSObject, ObservableObject {
 
     func connect(folder: String) {
         guard ensureHelper() else { return }
-        lastFolder = folder
+        var l = lastFolders
+        if !l.contains(folder) { l.append(folder) }
+        lastFolders = l
         send(["cmd": "connect", "folder": folder])
     }
 
@@ -141,12 +156,23 @@ final class HelperManager: NSObject, ObservableObject {
         // 테스트 훅(개발/E2E 전용): 폴더가 env 로 지정되면 패널 없이 자동 연결
         // (Electron 의 OMK_BRIDGE_FOLDER 와 동일 계열).
         if let f = ProcessInfo.processInfo.environment["OMK_COMPANION_FOLDER"] { connect(folder: f); return }
-        if let f = lastFolder, Keychain.load() != nil { connect(folder: f) }
+        guard Keychain.load() != nil else { return }
+        for f in lastFolders { connect(folder: f) }
     }
 
-    func disconnect() {
+    /** 루트 개별 해제 — 자동 재연결 목록에서도 제거한다. */
+    func disconnect(folder: String) {
+        send(["cmd": "disconnect", "folder": folder])
+        lastFolders = lastFolders.filter { $0 != folder && !folder.hasSuffix($0) && !$0.hasSuffix(folder) }
+        connectedFolders.removeAll { $0 == folder }
+        rootStatus[folder] = nil
+    }
+
+    func disconnectAll() {
         send(["cmd": "disconnect"])
-        connectedFolder = nil
+        lastFolders = []
+        connectedFolders = []
+        rootStatus = [:]
     }
 
     func clearAutoApprove() { send(["cmd": "clearAutoApprove"]) }
@@ -154,10 +180,10 @@ final class HelperManager: NSObject, ObservableObject {
     /** 백엔드 전환 — 헬퍼 재기동(서버 URL 은 spawn 인자) 후 재연결. */
     func switchBackend(_ id: String) {
         backendId = id
-        let wasConnected = connectedFolder ?? lastFolder
+        let folders = connectedFolders.isEmpty ? lastFolders : connectedFolders
         stopHelper()
-        if let f = wasConnected {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { self.connect(folder: f) }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+            for f in folders { self.connect(folder: f) }
         }
     }
 
@@ -181,10 +207,20 @@ final class HelperManager: NSObject, ObservableObject {
     private func handle(_ kind: String, _ ev: [String: Any]) {
         switch kind {
         case "status":
-            statusText = ev["text"] as? String ?? ""
-            if statusText == "미연결" { connectedFolder = nil }
+            let text = ev["text"] as? String ?? ""
+            if let f = ev["folder"] as? String {
+                rootStatus[f] = text // 루트별 상태 (연결됨/재연결 중/서버 오류)
+            } else {
+                statusText = text
+                if text == "미연결" { connectedFolders = []; rootStatus = [:] }
+            }
         case "connected":
-            connectedFolder = ev["folder"] as? String
+            if let f = ev["folder"] as? String, !connectedFolders.contains(f) { connectedFolders.append(f) }
+        case "disconnected":
+            if let f = ev["folder"] as? String {
+                connectedFolders.removeAll { $0 == f }
+                rootStatus[f] = nil
+            }
         case "autoApprove":
             autoApproveCount = ev["count"] as? Int ?? 0
         case "confirm":
@@ -201,7 +237,7 @@ final class HelperManager: NSObject, ObservableObject {
         let id = ev["id"] as? Int ?? 0
         let command = ev["command"] as? String ?? ""
         let taskId = ev["taskId"] as? String
-        let base = ev["base"] as? String ?? connectedFolder ?? ""
+        let base = ev["base"] as? String ?? ev["folder"] as? String ?? ""
         let sandboxed = ev["sandbox"] as? Bool ?? false
         let preview = command.count > 800 ? String(command.prefix(800)) + "…" : command
 

--- a/apps/desktop-native/README.md
+++ b/apps/desktop-native/README.md
@@ -16,6 +16,7 @@ build.sh                 # helper 번들(esbuild) → 하네스 → swift build 
 - 브리지 보안 코어(경로 스코프·exec 3단 방어·git 고정 조립·worktree)는 **`packages/local-bridge-core` 재사용** — Swift 재구현 금지(plan §6 게이트).
 - 앱↔헬퍼 stdio 계약은 `helper.mjs` 상단 주석 참고. confirm 응답은 항상 앱(사용자 다이얼로그)만 발원.
 - 인증: API key(`omk_live_*`, bridge 스코프) → Keychain 저장, 헬퍼엔 env(`OMK_COMPANION_API_KEY`)로 전달 (ps 노출 방지).
+- **다중 루트(0.2.0)**: 메뉴 "작업 폴더 추가…" 로 여러 루트를 각각 연결 — 루트당 독립 브리지 연결(파생 deviceId = base id + 경로 해시)이라 **서버·프로토콜 무변경**, 웹엔 루트마다 별개 디바이스로 표시(기존 디바이스 선택기 사용). 유저당 총 디바이스 수는 서버 `LOCAL_BRIDGE_MAX_DEVICES`(기본 3)가 강제 — 초과는 해당 루트 상태에 서버 오류로 표면화. 스코프·샌드박스·일괄승인 회수는 루트별 독립(코어 인스턴스 분리).
 - 업데이트: `GET /api/desktop/latest` 의 `native` 채널(추가 전용 필드) — sha256 검증 후 분리 스크립트가 교체·재실행 (Electron updater.js 이식).
 
 ## 빌드 / 게시

--- a/apps/desktop-native/helper/harness.cjs
+++ b/apps/desktop-native/helper/harness.cjs
@@ -5,6 +5,7 @@
  *  - 인증: Authorization Bearer(API key) 헤더, Origin 없음 (CLI 계약과 동일)
  *  - confirmExec: 자동승인 훅이 아니라 **실제 stdio 왕복** — 승인(yes)/거부(no) 양쪽
  *  - browser: 어댑터 미주입 → 코어 미지원 거부
+ *  - 다중 루트(0.2.0): 루트당 독립 연결·파생 deviceId·스코프 상호 격리·개별 해제
  *  - stdin 종료 = 즉시 정리 종료 (좀비 방지)
  *
  * 실행: node apps/desktop-native/helper/harness.cjs
@@ -25,37 +26,46 @@ const { WebSocketServer } = require('ws');
     git(['-c', 'user.email=h@h', '-c', 'user.name=h', 'commit', '--allow-empty', '-q', '-m', 'init']);
     fs.writeFileSync(path.join(folder, 'seed.txt'), 'seed');
     fs.mkdirSync(path.join(folder, 'subdir'));
+    // 두 번째 루트 (git 아님) — 다중 루트 검증용
+    const folder2 = fs.mkdtempSync(path.join(os.tmpdir(), 'omk-cpharness2-'));
+    fs.writeFileSync(path.join(folder2, 'other.txt'), 'other-root');
 
-    // 가짜 브리지 서버
-    const received = [];
+    // 가짜 브리지 서버 — deviceId 별 소켓 추적 (다중 루트 = 다중 연결)
+    const received = [];       // {frame, deviceId}
     const waiters = [];
+    const socks = new Map();   // deviceId -> ws
+    const hellos = [];         // {frame, headers}
     const wss = new WebSocketServer({ port: 0 });
     await new Promise((r) => wss.once('listening', r));
     const port = wss.address().port;
-    let sock = null;
-    let helloHeaders = null;
     wss.on('connection', (ws, req) => {
-        sock = ws; helloHeaders = req.headers;
+        let myDeviceId = null;
         ws.on('message', (d) => {
             const f = JSON.parse(d.toString());
-            received.push(f);
-            for (let i = waiters.length - 1; i >= 0; i--) {
-                if (waiters[i].pred(f)) { waiters[i].resolve(f); waiters.splice(i, 1); }
+            if (f.type === 'bridge_hello') {
+                myDeviceId = f.deviceId;
+                socks.set(myDeviceId, ws);
+                hellos.push({ frame: f, headers: req.headers });
+                ws.send(JSON.stringify({ type: 'bridge_ready', deviceId: myDeviceId }));
             }
-            if (f.type === 'bridge_hello') ws.send(JSON.stringify({ type: 'bridge_ready' }));
+            received.push({ frame: f, deviceId: myDeviceId });
+            for (let i = waiters.length - 1; i >= 0; i--) {
+                if (waiters[i].pred(f, myDeviceId)) { waiters[i].resolve(f); waiters.splice(i, 1); }
+            }
         });
+        ws.on('close', () => { if (myDeviceId && socks.get(myDeviceId) === ws) socks.delete(myDeviceId); });
     });
     const waitFor = (pred, ms = 8000) => {
-        const hit = received.find(pred);
-        if (hit) return Promise.resolve(hit);
+        const hit = received.find((r) => pred(r.frame, r.deviceId));
+        if (hit) return Promise.resolve(hit.frame);
         return new Promise((resolve, reject) => {
-            const t = setTimeout(() => reject(new Error('frame timeout: ' + received.map((f) => f.type).join(','))), ms);
+            const t = setTimeout(() => reject(new Error('frame timeout: ' + received.map((r) => r.frame.type).join(','))), ms);
             waiters.push({ pred, resolve: (f) => { clearTimeout(t); resolve(f); } });
         });
     };
-    const exec = (m) => {
+    const execVia = (deviceId, m) => {
         const reqId = 'h-' + Math.random().toString(36).slice(2, 8);
-        sock.send(JSON.stringify({ type: 'bridge_exec', reqId, ...m }));
+        socks.get(deviceId).send(JSON.stringify({ type: 'bridge_exec', reqId, ...m }));
         return waitFor((f) => f.type === 'bridge_result' && f.reqId === reqId).then((f) => f.result);
     };
 
@@ -88,63 +98,90 @@ const { WebSocketServer } = require('ws');
         });
     };
     const send = (obj) => helper.stdin.write(JSON.stringify(obj) + '\n');
+    const realFolder = fs.realpathSync(folder);
+    const realFolder2 = fs.realpathSync(folder2);
 
     // ① connect → hello: Bearer 인증, Origin 없음, 디바이스 메타
     send({ cmd: 'connect', folder });
     const hello = await waitFor((f) => f.type === 'bridge_hello');
     assert.equal(hello.folderName, path.basename(folder), 'hello folderName');
-    assert.equal(helloHeaders.authorization, 'Bearer omk_live_harness', 'Bearer 인증 헤더');
-    assert.ok(!helloHeaders.origin, 'Origin 헤더 없음 (네이티브 클라이언트)');
-    const connected = await waitEv((e) => e.ev === 'connected');
-    assert.equal(connected.folder, fs.realpathSync(folder), 'connected 이벤트 folder');
+    assert.equal(hellos[0].headers.authorization, 'Bearer omk_live_harness', 'Bearer 인증 헤더');
+    assert.ok(!hellos[0].headers.origin, 'Origin 헤더 없음 (네이티브 클라이언트)');
+    const dev1 = hello.deviceId;
+    await waitEv((e) => e.ev === 'connected' && e.folder === realFolder);
 
     // ② 파일 kind 왕복 + 스코프
-    assert.equal((await exec({ kind: 'read', path: 'seed.txt' })).content, 'seed', 'read');
-    await exec({ kind: 'write', path: 'subdir/out.txt', contentB64: Buffer.from('written').toString('base64') });
+    assert.equal((await execVia(dev1, { kind: 'read', path: 'seed.txt' })).content, 'seed', 'read');
+    await execVia(dev1, { kind: 'write', path: 'subdir/out.txt', contentB64: Buffer.from('written').toString('base64') });
     assert.equal(fs.readFileSync(path.join(folder, 'subdir/out.txt'), 'utf8'), 'written', 'write');
-    assert.equal((await exec({ kind: 'read', path: '../../etc/hosts' })).ok, false, '스코프 탈출 거부');
-    const all = await exec({ kind: 'listAll' });
+    assert.equal((await execVia(dev1, { kind: 'read', path: '../../etc/hosts' })).ok, false, '스코프 탈출 거부');
+    const all = await execVia(dev1, { kind: 'listAll' });
     assert.ok(all.entries.includes('seed.txt') && all.entries.includes('subdir/out.txt'), 'listAll');
 
     // ③ exec — denylist / stdio confirm 승인 / 거부
-    assert.equal((await exec({ kind: 'exec', command: 'sudo ls' })).exitCode, 126, 'denylist 126');
-    const runP = exec({ kind: 'exec', command: 'echo -n from-companion', taskId: 'harness-task-000000000001' });
+    assert.equal((await execVia(dev1, { kind: 'exec', command: 'sudo ls' })).exitCode, 126, 'denylist 126');
+    const runP = execVia(dev1, { kind: 'exec', command: 'echo -n from-companion', taskId: 'harness-task-000000000001' });
     const c1 = await waitEv((e) => e.ev === 'confirm');
     assert.ok(c1.command.includes('from-companion') && c1.sandbox === true, 'confirm 이벤트 내용');
+    assert.equal(c1.folder, realFolder, 'confirm 이벤트 루트 표기');
     send({ cmd: 'confirm', id: c1.id, result: 'yes' });
     const ran = await runP;
     assert.deepEqual([ran.ok, ran.stdout], [true, 'from-companion'], 'confirm yes → 실행');
-    const denyP = exec({ kind: 'exec', command: 'echo denied-cmd' });
+    const denyP = execVia(dev1, { kind: 'exec', command: 'echo denied-cmd' });
     const c2 = await waitEv((e) => e.ev === 'confirm' && e.id !== c1.id);
     send({ cmd: 'confirm', id: c2.id, result: 'no' });
     const deniedR = await denyP;
     assert.deepEqual([deniedR.ok, deniedR.exitCode], [false, 126], 'confirm no → 거부');
 
     // ③-B 일괄 승인('all') — 같은 작업 내 재확인 없음 + task_end 회수
-    const allP = exec({ kind: 'exec', command: 'echo -n bulk-1', taskId: 'harness-task-000000000002' });
+    const allP = execVia(dev1, { kind: 'exec', command: 'echo -n bulk-1', taskId: 'harness-task-000000000002' });
     const c3 = await waitEv((e) => e.ev === 'confirm' && e.id > c2.id);
     send({ cmd: 'confirm', id: c3.id, result: 'all' });
     assert.equal((await allP).stdout, 'bulk-1', 'all 승인 실행');
     await waitEv((e) => e.ev === 'autoApprove' && e.count === 1);
     const confirmsBefore = events.filter((e) => e.ev === 'confirm').length;
-    assert.equal((await exec({ kind: 'exec', command: 'echo -n bulk-2', taskId: 'harness-task-000000000002' })).stdout, 'bulk-2', 'all 후 재확인 없이 실행');
+    assert.equal((await execVia(dev1, { kind: 'exec', command: 'echo -n bulk-2', taskId: 'harness-task-000000000002' })).stdout, 'bulk-2', 'all 후 재확인 없이 실행');
     assert.equal(events.filter((e) => e.ev === 'confirm').length, confirmsBefore, 'all 승인 중 confirm 미발생');
-    await exec({ kind: 'task_end', taskId: 'harness-task-000000000002' });
+    await execVia(dev1, { kind: 'task_end', taskId: 'harness-task-000000000002' });
     await waitEv((e) => e.ev === 'taskEnd');
     await waitEv((e) => e.ev === 'autoApprove' && e.count === 0);
 
     // ④ folders 열거 / browser 미지원 / worktree
-    assert.deepEqual((await exec({ kind: 'folders', path: '.' })).entries, ['subdir'], 'folders 열거');
-    assert.equal((await exec({ kind: 'browser', spec: {} })).ok, false, 'browser 미지원 거부');
+    assert.deepEqual((await execVia(dev1, { kind: 'folders', path: '.' })).entries, ['subdir'], 'folders 열거');
+    assert.equal((await execVia(dev1, { kind: 'browser', spec: {} })).ok, false, 'browser 미지원 거부');
     const taskId = 'harness-task-000000000003';
-    const wt = await exec({ kind: 'worktree', op: 'add', taskId });
+    const wt = await execVia(dev1, { kind: 'worktree', op: 'add', taskId });
     assert.ok(wt.ok && wt.worktreeRel.endsWith(taskId), 'worktree add');
     fs.writeFileSync(path.join(folder, wt.worktreeRel, 'change.txt'), 'diff-me');
-    const diff = await exec({ kind: 'worktree', op: 'diff', taskId });
+    const diff = await execVia(dev1, { kind: 'worktree', op: 'diff', taskId });
     assert.ok(diff.ok && diff.stdout.includes('diff-me'), 'worktree diff');
 
-    // ⑤ stdin 종료 = 정리 종료 (좀비 방지) — pending confirm 은 'no' 로 해소
-    const zombieP = exec({ kind: 'exec', command: 'echo never-runs' });
+    // ⑤ 다중 루트 — 두 번째 루트 연결: 파생 deviceId 상이, 루트별 스코프 격리, 개별 해제
+    send({ cmd: 'connect', folder: folder2 });
+    const hello2 = await waitFor((f) => f.type === 'bridge_hello' && f.folderName === path.basename(folder2));
+    const dev2 = hello2.deviceId;
+    assert.notEqual(dev2, dev1, '루트별 파생 deviceId 상이');
+    assert.ok(dev1.length <= 64 && dev2.length <= 64, 'deviceId 64자 상한');
+    assert.ok(dev1.split('-r-')[0] === dev2.split('-r-')[0], '기기 base id 공유');
+    await waitEv((e) => e.ev === 'connected' && e.folder === realFolder2);
+    assert.equal((await execVia(dev2, { kind: 'read', path: 'other.txt' })).content, 'other-root', '루트2 read');
+    // 루트 간 상호 격리 — 루트2 연결이 루트1 파일에 닿지 못한다
+    assert.equal((await execVia(dev2, { kind: 'read', path: '../' + path.basename(folder) + '/seed.txt' })).ok, false, '루트 간 스코프 격리');
+    // 루트2 confirm 이벤트는 루트2 base 를 표기한다
+    const runP2 = execVia(dev2, { kind: 'exec', command: 'echo -n in-root2' });
+    const c4 = await waitEv((e) => e.ev === 'confirm' && e.command.includes('in-root2'));
+    assert.equal(c4.folder, realFolder2, '루트2 confirm 루트 표기');
+    send({ cmd: 'confirm', id: c4.id, result: 'yes' });
+    assert.equal((await runP2).stdout, 'in-root2', '루트2 exec');
+    // 루트1 개별 해제 — 루트2 는 유지
+    send({ cmd: 'disconnect', folder });
+    await waitEv((e) => e.ev === 'disconnected' && e.folder === realFolder);
+    await new Promise((r) => setTimeout(r, 200));
+    assert.ok(!socks.has(dev1), '루트1 소켓 종료');
+    assert.equal((await execVia(dev2, { kind: 'read', path: 'other.txt' })).content, 'other-root', '루트1 해제 후 루트2 생존');
+
+    // ⑥ stdin 종료 = 정리 종료 (좀비 방지) — pending confirm 은 'no' 로 해소
+    const zombieP = execVia(dev2, { kind: 'exec', command: 'echo never-runs' });
     await waitEv((e) => e.ev === 'confirm' && e.command.includes('never-runs'));
     helper.stdin.end();
     const code = await new Promise((r) => helper.on('exit', r));
@@ -153,6 +190,8 @@ const { WebSocketServer } = require('ws');
     assert.deepEqual([zombieR.ok, zombieR.exitCode], [false, 126], '종료 시 pending confirm 거부 해소');
 
     wss.close();
-    console.log('OK — Companion 헬퍼 하네스 전 케이스 통과 (frames=%d, events=%d)', received.length, events.length);
+    fs.rmSync(folder, { recursive: true, force: true });
+    fs.rmSync(folder2, { recursive: true, force: true });
+    console.log('OK — Companion 헬퍼 하네스 전 케이스 통과 (frames=%d, events=%d, roots=2)', received.length, events.length);
     process.exit(0);
 })().catch((e) => { console.error('HARNESS FAIL:', e.message); process.exit(1); });

--- a/apps/desktop-native/helper/src/helper.mjs
+++ b/apps/desktop-native/helper/src/helper.mjs
@@ -10,10 +10,15 @@
 //   - browser: 미지원 → 코어가 거부 응답 (capability 미보고 degrade)
 //   - deviceId·샌드박스 프로파일: ~/Library/Application Support/OpenMakeCompanion
 //
-// stdio 계약 (한 줄 = JSON 하나):
-//   helper→app: {ev:'status',text} {ev:'confirm',id,command,taskId,base,sandbox}
-//               {ev:'autoApprove',count} {ev:'taskEnd',taskId} {ev:'connected',folder}
-//   app→helper: {cmd:'connect',folder} {cmd:'disconnect'}
+// 다중 루트(0.2.0): 루트당 독립 BridgeCore+BridgeConnection, deviceId 는 기기 base id +
+// 루트 경로 해시 파생(재접속 안정) — 서버는 루트마다 별개 디바이스로 본다(프로토콜 무변경,
+// 유저당 LOCAL_BRIDGE_MAX_DEVICES 상한은 서버가 강제하고 초과는 status 로 표면화).
+//
+// stdio 계약 (한 줄 = JSON 하나, folder = 루트 realpath):
+//   helper→app: {ev:'status',folder?,text} {ev:'confirm',id,command,taskId,base,folder,sandbox}
+//               {ev:'autoApprove',count}(전 루트 합계) {ev:'taskEnd',taskId,folder}
+//               {ev:'connected',folder} {ev:'disconnected',folder}
+//   app→helper: {cmd:'connect',folder} {cmd:'disconnect',folder?}(folder 없으면 전체)
 //               {cmd:'confirm',id,result:'yes'|'all'|'no'} {cmd:'clearAutoApprove'} {cmd:'quit'}
 import * as fs from 'fs';
 import * as os from 'os';
@@ -33,7 +38,7 @@ fs.mkdirSync(SUPPORT_DIR, { recursive: true });
 
 function send(obj) { process.stdout.write(JSON.stringify(obj) + '\n'); }
 
-function deviceId() {
+function baseDeviceId() {
   const p = path.join(SUPPORT_DIR, 'device-id');
   try { return fs.readFileSync(p, 'utf8').trim(); } catch { /* 최초 생성 */ }
   const id = crypto.randomUUID();
@@ -41,53 +46,70 @@ function deviceId() {
   return id;
 }
 
+/** 루트별 파생 deviceId — 재접속 시 같은 값(서버 세션 대체 규칙과 정합). 36+3+12=51 ≤ 서버 64 상한. */
+function rootDeviceId(root) {
+  return `${baseDeviceId()}-r-${crypto.createHash('sha256').update(root).digest('hex').slice(0, 12)}`;
+}
+
 // confirm 왕복 — id 상관. 앱이 죽으면(stdin close) 전 대기를 'no' 로 해소하고 종료.
 let confirmSeq = 0;
 const pendingConfirms = new Map(); // id -> resolve
-function stdioConfirm(command, taskId, base) {
-  return new Promise((resolve) => {
-    const id = ++confirmSeq;
-    pendingConfirms.set(id, resolve);
-    send({ ev: 'confirm', id, command, taskId: taskId ?? null, base, sandbox: SANDBOX_ENABLED });
-  });
-}
 
-let core = null;
-let connection = null;
-let folderRoot = null;
+/** 연결 루트들 — realpath → {core, connection} */
+const roots = new Map();
+
+function totalAutoApprove() {
+  let n = 0;
+  for (const r of roots.values()) n += r.core.autoApprovedCount();
+  return n;
+}
 
 function connectFolder(folder) {
   if (!apiKey) { send({ ev: 'status', text: 'API key 필요 — 앱 설정에서 입력' }); return; }
   let real;
   try { real = fs.realpathSync(folder); } catch (e) { send({ ev: 'status', text: `폴더 열기 실패: ${e.message}` }); return; }
-  if (connection) connection.disconnect();
-  folderRoot = real;
-  core = new BridgeCore({
-    folder: folderRoot,
-    confirm: stdioConfirm,
+  const prev = roots.get(real);
+  if (prev) prev.connection.disconnect(); // 같은 루트 재연결 = 세션 갱신
+  const core = new BridgeCore({
+    folder: real,
+    confirm: (command, taskId, base) => new Promise((resolve) => {
+      const id = ++confirmSeq;
+      pendingConfirms.set(id, resolve);
+      send({ ev: 'confirm', id, command, taskId: taskId ?? null, base, folder: real, sandbox: SANDBOX_ENABLED });
+    }),
     sandboxProfileDir: SUPPORT_DIR,
-    onTaskEnd: (taskId) => send({ ev: 'taskEnd', taskId: taskId ?? null }),
-    onAutoApproveChange: () => send({ ev: 'autoApprove', count: core ? core.autoApprovedCount() : 0 }),
+    onTaskEnd: (taskId) => send({ ev: 'taskEnd', taskId: taskId ?? null, folder: real }),
+    onAutoApproveChange: () => send({ ev: 'autoApprove', count: totalAutoApprove() }),
   });
-  connection = new BridgeConnection({
+  const connection = new BridgeConnection({
     serverUrl,
     core,
-    deviceId: deviceId(),
-    label: `${os.hostname()} · ${path.basename(folderRoot)}`,
+    deviceId: rootDeviceId(real),
+    label: `${os.hostname()} · ${path.basename(real)}`,
     headers: () => ({ Authorization: `Bearer ${apiKey}` }),
-    onStatus: (s) => send({ ev: 'status', text: s }),
-    shouldReconnect: () => !!folderRoot,
+    onStatus: (s) => send({ ev: 'status', folder: real, text: s }),
+    shouldReconnect: () => roots.has(real),
   });
+  roots.set(real, { core, connection });
   void connection.connect();
-  send({ ev: 'connected', folder: folderRoot });
+  send({ ev: 'connected', folder: real });
 }
 
-function disconnectFolder() {
-  folderRoot = null;
-  if (connection) connection.disconnect(); // 일괄 승인 회수 포함
-  connection = null;
-  core = null;
-  send({ ev: 'status', text: '미연결' });
+function disconnectFolder(folder) {
+  if (folder === undefined) { // 전체 해제 (구 계약 호환)
+    for (const real of [...roots.keys()]) disconnectFolder(real);
+    return;
+  }
+  let real = folder;
+  try { real = fs.realpathSync(folder); } catch { /* 이미 삭제된 폴더도 등록 키로 시도 */ }
+  const r = roots.get(real) ?? roots.get(folder);
+  const key = roots.has(real) ? real : folder;
+  if (!r) return;
+  roots.delete(key);                 // shouldReconnect 가 false 가 된 뒤 끊는다
+  r.connection.disconnect();         // 일괄 승인 회수 포함
+  send({ ev: 'disconnected', folder: key });
+  send({ ev: 'autoApprove', count: totalAutoApprove() });
+  if (roots.size === 0) send({ ev: 'status', text: '미연결' });
 }
 
 const rl = readline.createInterface({ input: process.stdin });
@@ -96,7 +118,7 @@ rl.on('line', (line) => {
   try { m = JSON.parse(line); } catch { return; }
   switch (m.cmd) {
     case 'connect': if (typeof m.folder === 'string') connectFolder(m.folder); break;
-    case 'disconnect': disconnectFolder(); break;
+    case 'disconnect': disconnectFolder(typeof m.folder === 'string' ? m.folder : undefined); break;
     case 'confirm': {
       const resolve = pendingConfirms.get(m.id);
       if (resolve) {
@@ -105,7 +127,7 @@ rl.on('line', (line) => {
       }
       break;
     }
-    case 'clearAutoApprove': if (core) core.clearAutoApprove(); break;
+    case 'clearAutoApprove': for (const r of roots.values()) r.core.clearAutoApprove(); break;
     case 'quit': shutdown(); break;
     default: break;
   }
@@ -120,7 +142,7 @@ function shutdown() {
   shuttingDown = true;
   for (const resolve of pendingConfirms.values()) resolve('no');
   pendingConfirms.clear();
-  setTimeout(() => { disconnectFolder(); process.exit(0); }, 100);
+  setTimeout(() => { disconnectFolder(undefined); process.exit(0); }, 100);
 }
 rl.on('close', shutdown);
 process.on('SIGTERM', shutdown);


### PR DESCRIPTION
## 요약
Companion 0.2.0 — plan 후속 '다중 루트 연결'. 메뉴 **작업 폴더 추가…** 로 여러 루트를 각각 연결한다.

## 설계
- **서버·프로토콜 무변경**: 루트당 독립 BridgeCore+BridgeConnection, deviceId 는 `<base uuid>-r-<sha256(root)[:12]>` 파생(≤64자, 재접속 시 동일 → 세션 대체 규칙 정합). 웹엔 루트마다 별개 디바이스로 표시 — 기존 다중 디바이스 선택기(composer) 재사용
- 스코프·샌드박스 프로파일·일괄승인 회수는 루트별 독립(코어 인스턴스 분리)
- 유저당 총 디바이스 수는 서버 `LOCAL_BRIDGE_MAX_DEVICES`(기본 3)가 강제 — 초과는 루트 상태에 서버 오류로 표면화
- 앱: 루트별 서브메뉴(경로·상태·Finder·개별 해제) + 전체 해제, `lastFolders` 자동 재연결(구 단일 키 마이그레이션)

## 검증
- [x] 헬퍼 하네스 확장 통과 — 2루트: 파생 deviceId 상이·base 공유, 상호 스코프 격리, 루트별 confirm 표기, 개별 해제 후 잔여 루트 생존, 좀비 방지
- [x] 라이브 E2E (chat.openmake.cc, user 3): 2루트 동시 등록 → 루트2 대상 작업 생성·네이티브 승인 → `multiroot-test.txt` 산출(completed)·루트1 비오염
- [x] swift build 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)