### PR TITLE
docs(env): 브리지 디바이스 상한의 WS 세션 상한 종속 명시

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1052,6 +1052,10 @@ AGENT_TASK_TIMEOUT_MS=600000
 # LOCAL_BRIDGE_MAX_WRITE_BYTES=8388608          # write/첨부 전송 상한(8MB)
 # LOCAL_BRIDGE_OUTPUT_CAP=65536                 # exec/read 결과 수신 캡(chars)
 # LOCAL_BRIDGE_MAX_DEVICES=3                     # 유저당 동시 등록 브리지 디바이스 상한(데스크톱+CLI)
+# ⚠️ 브리지 디바이스는 유저당 WS 소켓을 1개씩 점유하므로 실질 상한은 WS_MAX_CONNECTIONS_PER_USER
+#    (기본 5, sockets/handler.ts 가드)다 — 브라우저 탭도 같은 풀을 소모한다. MAX_DEVICES 를
+#    5 이상으로 올릴 땐 아래 값도 함께 올려야 하며, 안 그러면 'WebSocket 세션 한도' 로 거부된다.
+# WS_MAX_CONNECTIONS_PER_USER=5                  # 유저당 동시 WS 세션 상한(브리지 디바이스 + 브라우저 탭)
 # BRIDGE_FOLDERS_MAX_ENTRIES=200                 # 폴더 선택(folders) 1회 열거 상한(초과 절단+truncated)
 #
 # worktree 격리 — 연결 폴더가 git 레포면 별도 worktree(디렉토리+브랜치)를 만들어 그 안에서만


### PR DESCRIPTION
## 배경

`LOCAL_BRIDGE_MAX_DEVICES` 를 6 으로 올렸는데도 브리지 디바이스가 5대에서 막히는 현상을 라이브(chat.openmake.cc)에서 실측했다.

원인은 브리지 상한이 아니라 **그 앞단의 WS 연결 가드**였다:
- `apps/api/src/sockets/handler.ts:167` — `getActiveConnectionsForUser(userId) >= WS_LIMITS.MAX_CONNECTIONS_PER_USER` → `close(1008,'connection_limit_exceeded')`
- `apps/api/src/config/timeouts.ts:196` — `MAX_CONNECTIONS_PER_USER: Number(process.env.WS_MAX_CONNECTIONS_PER_USER) || 5`

브리지 디바이스는 유저당 WS 소켓을 1개씩 점유하므로 **실질 상한은 `WS_MAX_CONNECTIONS_PER_USER`** 다. 브라우저 탭도 같은 풀을 소모한다. 거부 메시지가 "동시 WebSocket 세션 한도" 라 브리지 설정만 봐서는 원인이 드러나지 않는다.

## 변경

`.env.example` 에 `WS_MAX_CONNECTIONS_PER_USER` 키와 종속관계 경고 주석 추가 (문서 전용, 코드 변경 없음).

## 실측

`WS_MAX_CONNECTIONS_PER_USER` 미설정(기본 5) 상태:

| 시도 | 결과 |
|---|---|
| Companion 2대 + maxtest-1~3 (누적 5대) | OK 등록 |
| maxtest-4 (6번째) | REJECT — 동시 WebSocket 세션 한도를 초과했습니다 |

운영 `.env` 에 `WS_MAX_CONNECTIONS_PER_USER=12` 적용 후 (pm2 delete→start):

| 시도 | 결과 |
|---|---|
| Companion 2대 + maxtest-1~4 (누적 6대) | OK 등록, `GET /api/local-bridge/status` 6대 노출 |
| maxtest-5 (7번째) | REJECT — 브리지 디바이스 상한(6대)을 초과했습니다 |

거부 주체가 의도한 `LOCAL_BRIDGE_MAX_DEVICES` 로 정정됨을 확인. 검증용 API key 2건은 폐기, 테스트 소켓 해제 후 원상 복구했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)