### PR TITLE
fix(bridge): 파일 kind FS 호출 async 전환 + 타임아웃 가드

### DIFF
--- a/packages/local-bridge-core/src/__tests__/fs-timeout.test.ts
+++ b/packages/local-bridge-core/src/__tests__/fs-timeout.test.ts
@@ -1,0 +1,68 @@
+/**
+ * 파일 kind FS 타임아웃 가드 — 외장 볼륨 TCC 권한 미결로 readdir 가 open 에서 영구
+ * 블록되던 실사례(2026-08-23) 회귀. sync 시절엔 이벤트 루프가 굶어 pong 이 끊기고
+ * 헬퍼의 모든 루트 연결이 하트비트로 강제 종료됐다 — async+타임아웃 전환으로
+ * ① 블록된 요청이 오류로 해소되고 ② 그동안 다른 요청이 계속 처리됨을 검증한다.
+ */
+process.env.OMK_BRIDGE_FS_TIMEOUT_MS = '300'; // constants 가 import 시점에 읽으므로 require 전에 설정
+
+const fs = require('fs') as typeof import('fs');
+const os = require('os') as typeof import('os');
+const path = require('path') as typeof import('path');
+const { BridgeCore } = require('../core') as typeof import('../core');
+import type { BridgeMsg, BridgeResult } from '../types';
+
+type Core = InstanceType<typeof BridgeCore>;
+
+function run(core: Core, m: BridgeMsg): Promise<BridgeResult> {
+    return new Promise((resolve, reject) => {
+        core.handleExec(m, resolve).catch(reject);
+    });
+}
+
+describe('FS 타임아웃 가드 (FS_OP_TIMEOUT_MS)', () => {
+    let base: string;
+    beforeEach(() => {
+        base = fs.mkdtempSync(path.join(os.tmpdir(), 'omk-fsto-'));
+        fs.writeFileSync(path.join(base, 'hello.txt'), 'world');
+        fs.mkdirSync(path.join(base, 'sub'));
+    });
+    afterEach(() => {
+        jest.restoreAllMocks();
+        fs.rmSync(base, { recursive: true, force: true });
+    });
+
+    function makeCore(): Core {
+        return new BridgeCore({
+            folder: base,
+            confirm: async () => 'yes',
+            sandboxProfileDir: fs.mkdtempSync(path.join(os.tmpdir(), 'omk-prof-')),
+        });
+    }
+
+    it('블록된 folders 는 타임아웃 오류로 해소되고, 그동안 다른 요청은 계속 처리된다', async () => {
+        const core = makeCore();
+        // readdir 영구 블록 시뮬레이션 (TCC 미결 시 open$NOCANCEL 영구 대기와 등가)
+        jest.spyOn(fs.promises, 'readdir').mockImplementation(() => new Promise(() => { /* never */ }));
+        const blocked = run(core, { kind: 'folders', path: '.' });
+        blocked.catch(() => { /* 아래에서 assert — unhandled rejection 방지 */ });
+        // 블록 중에도 read 는 정상 처리 — 이벤트 루프가 살아 있다(= pong 유지 = 다른 루트 생존)
+        expect(await run(core, { kind: 'read', path: 'hello.txt' })).toMatchObject({ ok: true, content: 'world' });
+        await expect(blocked).rejects.toThrow(/folders 시간 초과/);
+    });
+
+    it('블록된 listAll 도 동일하게 타임아웃된다', async () => {
+        const core = makeCore();
+        jest.spyOn(fs.promises, 'readdir').mockImplementation(() => new Promise(() => { /* never */ }));
+        await expect(run(core, { kind: 'listAll' })).rejects.toThrow(/listAll 시간 초과/);
+    });
+
+    it('정상 폴더에서는 타임아웃 없이 기존 규약대로 동작한다', async () => {
+        const core = makeCore();
+        const r = await run(core, { kind: 'folders', path: '.' });
+        expect(r).toMatchObject({ ok: true, entries: ['sub'], truncated: false });
+        const list = await run(core, { kind: 'list', path: '.' });
+        expect(list.entries).toContain('sub/');
+        expect(list.entries).toContain('hello.txt');
+    });
+});

--- a/packages/local-bridge-core/src/__tests__/security.test.ts
+++ b/packages/local-bridge-core/src/__tests__/security.test.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { matchDenylist } from '../denylist';
-import { safeFrom } from '../scope';
+import { safeFrom, safeFromAsync } from '../scope';
 import { writeSandboxProfile } from '../sandbox';
 
 describe('EXEC_DENYLIST', () => {
@@ -67,6 +67,14 @@ describe('safeFrom — 경로 스코프', () => {
     it('아직 존재하지 않는 경로도 최근접 조상 기준으로 검증한다', () => {
         expect(safeFrom(base, 'sub/new-dir/new.txt')).toBe(path.join(base, 'sub', 'new-dir', 'new.txt'));
         expect(() => safeFrom(base, 'link-out/new/new.txt')).toThrow(/심링크 스코프 탈출/);
+    });
+
+    it('safeFromAsync — sync 판과 동일한 검증 의미를 유지한다', async () => {
+        expect(await safeFromAsync(base, 'sub/a.txt')).toBe(path.join(base, 'sub', 'a.txt'));
+        await expect(safeFromAsync(base, '../' + path.basename(outside) + '/secret.txt')).rejects.toThrow(/스코프 밖/);
+        await expect(safeFromAsync(base, outside)).rejects.toThrow(/스코프 밖/);
+        await expect(safeFromAsync(base, 'link-out/secret.txt')).rejects.toThrow(/심링크 스코프 탈출/);
+        expect(await safeFromAsync(base, 'sub/new-dir/new.txt')).toBe(path.join(base, 'sub', 'new-dir', 'new.txt'));
     });
 });
 

--- a/packages/local-bridge-core/src/constants.ts
+++ b/packages/local-bridge-core/src/constants.ts
@@ -26,6 +26,13 @@ export const FOLDERS_MAX_ENTRIES = 200;
 /** listAll 재귀 나열 상한. */
 export const LIST_ALL_MAX = 1000;
 
+/**
+ * 파일 kind(read/write/list/listAll/delete/folders) 1회 처리 타임아웃 — OS 가 FS 호출을
+ * 무기한 블록하면(외장 볼륨 TCC 권한 미결 실사례, 2026-08-23) 요청을 오류로 해소해
+ * 연결(하트비트)을 지킨다. 블록된 호출 자체는 취소할 수 없어 threadpool 스레드는 남는다.
+ */
+export const FS_OP_TIMEOUT_MS = Number(process.env.OMK_BRIDGE_FS_TIMEOUT_MS || 15000);
+
 /** SBPL 문자열 리터럴 escape. */
 export function sbq(p: string): string {
     return `"${String(p).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;

--- a/packages/local-bridge-core/src/core.ts
+++ b/packages/local-bridge-core/src/core.ts
@@ -16,15 +16,17 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execFile } from 'child_process';
 import {
-    EXEC_TIMEOUT_MS, FOLDERS_MAX_ENTRIES, LIST_ALL_MAX, MAX_BUFFER,
+    EXEC_TIMEOUT_MS, FOLDERS_MAX_ENTRIES, FS_OP_TIMEOUT_MS, LIST_ALL_MAX, MAX_BUFFER,
     SANDBOX_BIN, SANDBOX_ENABLED,
 } from './constants';
 import { matchDenylist } from './denylist';
 import { resolveExecPath } from './exec-path';
 import { detectGitDir, writeSandboxProfile } from './sandbox';
-import { safeFrom } from './scope';
+import { safeFromAsync } from './scope';
 import { handleWorktree } from './worktree';
 import type { BridgeCoreOptions, BridgeMsg, BridgeResult } from './types';
+
+const fsp = fs.promises;
 
 export class BridgeCore {
     readonly folderRoot: string;
@@ -72,25 +74,44 @@ export class BridgeCore {
         return ans === 'yes';
     }
 
-    /** 연결 루트 기준 스코프 가드 (기존 계약). */
-    private safe(rel: string | undefined): string { return safeFrom(this.folderRoot, rel); }
+    /**
+     * 파일 kind FS 처리 타임아웃 가드 — OS 가 FS 호출을 무기한 블록하면(외장 볼륨 TCC
+     * 권한 미결 실사례: readdir 가 open 에서 영구 대기 → sync 시절엔 이벤트 루프가 굶어
+     * pong 이 끊기고 이 헬퍼의 **모든 루트 연결**이 하트비트로 강제 종료됐다) 요청을
+     * 오류로 해소한다. FS 호출은 전부 async(fsp)라 블록돼도 threadpool 에서 대기할 뿐
+     * 이벤트 루프·다른 루트는 살아 있다. 블록된 호출 자체는 취소 불가(스레드 점유 잔존).
+     */
+    private async timedFs<T>(label: string, fn: () => Promise<T>): Promise<T> {
+        let timer: NodeJS.Timeout | undefined;
+        try {
+            return await Promise.race([
+                fn(),
+                new Promise<never>((_, reject) => {
+                    timer = setTimeout(() => reject(new Error(
+                        `${label} 시간 초과 (${Math.round(FS_OP_TIMEOUT_MS / 1000)}s) — 폴더 접근이 차단됐을 수 있습니다(디스크 접근 권한 확인)`,
+                    )), FS_OP_TIMEOUT_MS);
+                }),
+            ]);
+        } finally { clearTimeout(timer); }
+    }
 
     /**
-     * 폴더 선택(folder 필드) base 해석 — 루트 기준 상대경로를 safe() 재검증 후 실행 base 로 쓴다.
+     * 폴더 선택(folder 필드) base 해석 — 루트 기준 상대경로를 스코프 재검증 후 실행 base 로 쓴다.
      * 서버는 디바이스가 folders 로 보고한 값만 에코하지만, 여기서 다시 스코프를 강제한다(2중 방어).
      */
-    private resolveBase(m: BridgeMsg): string {
+    private async resolveBase(m: BridgeMsg): Promise<string> {
         if (!m.folder) return this.folderRoot;
-        const base = this.safe(m.folder);
-        if (!fs.existsSync(base) || !fs.statSync(base).isDirectory()) throw new Error(`실행 폴더가 존재하지 않습니다: ${m.folder}`);
+        const base = await safeFromAsync(this.folderRoot, m.folder);
+        const st = await fsp.stat(base).catch(() => null);
+        if (!st || !st.isDirectory()) throw new Error(`실행 폴더가 존재하지 않습니다: ${m.folder}`);
         return base;
     }
 
-    private walk(dir: string, base: string, out: string[]): string[] {
-        for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    private async walk(dir: string, base: string, out: string[]): Promise<string[]> {
+        for (const e of await fsp.readdir(dir, { withFileTypes: true })) {
             const p = path.join(dir, e.name);
             if (e.isSymbolicLink()) continue; // 심링크는 나열하지 않음
-            if (e.isDirectory()) this.walk(p, base, out); else out.push(path.relative(base, p));
+            if (e.isDirectory()) await this.walk(p, base, out); else out.push(path.relative(base, p));
             if (out.length >= LIST_ALL_MAX) return out;
         }
         return out;
@@ -98,7 +119,7 @@ export class BridgeCore {
 
     async handleExec(m: BridgeMsg, done: (r: BridgeResult) => void): Promise<void> {
         // 폴더 선택(folder 필드) — 유효 base 를 먼저 확정. 미지정은 연결 루트(현행 동작).
-        const base = this.resolveBase(m);
+        const base = await this.timedFs('실행 폴더 확인', () => this.resolveBase(m));
         switch (m.kind) {
             case 'exec': {
                 // ① 명백히 위험한 패턴은 확인 없이 즉시 거부 (guardrail).
@@ -129,39 +150,50 @@ export class BridgeCore {
                 }
                 return;
             }
-            case 'read': done({ ok: true, content: fs.readFileSync(safeFrom(base, m.path), 'utf8') }); return;
+            case 'read': {
+                const content = await this.timedFs('read', async () => fsp.readFile(await safeFromAsync(base, m.path), 'utf8'));
+                done({ ok: true, content }); return;
+            }
             case 'write': {
-                const abs = safeFrom(base, m.path);
-                fs.mkdirSync(path.dirname(abs), { recursive: true });
-                fs.writeFileSync(abs, Buffer.from(m.contentB64 || '', 'base64'));
+                await this.timedFs('write', async () => {
+                    const abs = await safeFromAsync(base, m.path);
+                    await fsp.mkdir(path.dirname(abs), { recursive: true });
+                    await fsp.writeFile(abs, Buffer.from(m.contentB64 || '', 'base64'));
+                });
                 done({ ok: true }); return;
             }
             case 'list': {
                 // 디렉토리는 '/' 접미사 — 모델이 폴더를 파일로 오인해 read 하다 EISDIR 로
                 // 실패하고 하위 파일에 못 닿는 문제 방지 (샌드박스 실행기와 동일 규약).
-                const entries = fs.readdirSync(safeFrom(base, m.path), { withFileTypes: true })
-                    .map((e) => (e.isDirectory() ? `${e.name}/` : e.name));
+                const entries = await this.timedFs('list', async () =>
+                    (await fsp.readdir(await safeFromAsync(base, m.path), { withFileTypes: true }))
+                        .map((e) => (e.isDirectory() ? `${e.name}/` : e.name)));
                 done({ ok: true, entries }); return;
             }
-            case 'listAll': done({ ok: true, entries: this.walk(base, base, []) }); return;
+            case 'listAll': done({ ok: true, entries: await this.timedFs('listAll', () => this.walk(base, base, [])) }); return;
             case 'delete': {
-                const abs = safeFrom(base, m.path);
-                if (abs === base) throw new Error('연결 폴더 루트는 삭제할 수 없습니다');
-                fs.rmSync(abs, { recursive: true, force: true });
+                await this.timedFs('delete', async () => {
+                    const abs = await safeFromAsync(base, m.path);
+                    if (abs === base) throw new Error('연결 폴더 루트는 삭제할 수 없습니다');
+                    await fsp.rm(abs, { recursive: true, force: true });
+                });
                 done({ ok: true }); return;
             }
             case 'folders': {
                 // 하위 폴더 온디맨드 열거(폴더 선택) — path 는 루트 기준, 숨김·심링크 제외,
                 // 결과는 루트 기준 상대경로(서버가 세션 캐시에 병합해 folder 검증 근거로 쓴다).
-                const dirAbs = this.safe(m.path);
-                const entries: string[] = [];
-                let truncated = false;
-                for (const e of fs.readdirSync(dirAbs, { withFileTypes: true })) {
-                    if (!e.isDirectory() || e.name.startsWith('.')) continue;
-                    if (entries.length >= FOLDERS_MAX_ENTRIES) { truncated = true; break; }
-                    entries.push(path.relative(this.folderRoot, path.join(dirAbs, e.name)).split(path.sep).join('/'));
-                }
-                done({ ok: true, entries, truncated }); return;
+                const r = await this.timedFs('folders', async () => {
+                    const dirAbs = await safeFromAsync(this.folderRoot, m.path);
+                    const entries: string[] = [];
+                    let truncated = false;
+                    for (const e of await fsp.readdir(dirAbs, { withFileTypes: true })) {
+                        if (!e.isDirectory() || e.name.startsWith('.')) continue;
+                        if (entries.length >= FOLDERS_MAX_ENTRIES) { truncated = true; break; }
+                        entries.push(path.relative(this.folderRoot, path.join(dirAbs, e.name)).split(path.sep).join('/'));
+                    }
+                    return { entries, truncated };
+                });
+                done({ ok: true, ...r }); return;
             }
             case 'browser': {
                 // 로컬 브라우저(D3) — 데스크톱(Electron 내장 Chromium)만 어댑터로 구현한다.

--- a/packages/local-bridge-core/src/scope.ts
+++ b/packages/local-bridge-core/src/scope.ts
@@ -16,3 +16,19 @@ export function safeFrom(baseAbs: string, rel: string | undefined): string {
     if (real !== baseReal && !real.startsWith(baseReal + path.sep)) throw new Error(`심링크 스코프 탈출 거부: ${rel}`);
     return abs;
 }
+
+/**
+ * safeFrom 의 async 판 — 파일 kind 처리 경로 전용. OS 가 FS 호출을 무기한 블록해도
+ * (예: 외장 볼륨 TCC 권한 미결) libuv threadpool 에서 대기해 이벤트 루프(WS pong)가
+ * 계속 돌게 한다. 검증 의미는 sync 판과 동일하게 유지할 것.
+ */
+export async function safeFromAsync(baseAbs: string, rel: string | undefined): Promise<string> {
+    const abs = path.resolve(baseAbs, rel || '.');
+    if (abs !== baseAbs && !abs.startsWith(baseAbs + path.sep)) throw new Error(`폴더 스코프 밖 경로 거부: ${rel}`);
+    let probe = abs;
+    while (!(await fs.promises.access(probe).then(() => true, () => false))) probe = path.dirname(probe);
+    const real = await fs.promises.realpath(probe);
+    const baseReal = await fs.promises.realpath(baseAbs);
+    if (real !== baseReal && !real.startsWith(baseReal + path.sep)) throw new Error(`심링크 스코프 탈출 거부: ${rel}`);
+    return abs;
+}


### PR DESCRIPTION
## 결함 (라이브 실사례, 2026-08-23)

Companion 을 외장 볼륨(`/Volumes/MAC_APP/project`)에 연결한 상태에서 웹이 `folders` 열거를 요청하자:

1. 디바이스측 `readdirSync` 가 macOS TCC 권한 미결로 `open$NOCANCEL` 에서 **영구 블록** (`sample` 스택으로 확인)
2. 브리지 헬퍼는 단일 이벤트 루프라 루프 전체가 굶음 → 서버 ping 에 pong 을 못 보냄
3. 60초 뒤 서버 하트비트가 연결 종료 — **같은 헬퍼에 물린 다른 루트 연결까지 전부 사망**
4. 서버 `GET /folders` 는 32s+ 대기 후 400 (`registry.request` 기본 180s 타임아웃 축)

## 수정 (`packages/local-bridge-core`)

- **파일 kind 전면 async 전환**: `read`/`write`/`list`/`listAll`/`delete`/`folders` + `resolveBase`(folder base 해석)를 `fs.promises` 로 — FS 가 블록돼도 libuv threadpool 대기일 뿐 이벤트 루프(pong)와 다른 루트는 생존
- **디바이스측 타임아웃 가드 `FS_OP_TIMEOUT_MS`** (기본 15s, `OMK_BRIDGE_FS_TIMEOUT_MS` 훅): 블록된 요청을 오류로 해소해 서버가 180s 대신 즉시 도구 오류를 받음. 오류 메시지에 디스크 접근 권한 안내 포함
- `scope.ts` 에 `safeFromAsync` 추가 — 검증 의미(스코프 밖 거부·심링크 탈출 거부·최근접 조상 realpath)는 sync 판과 동일 유지. sync `safeFrom` 은 export 계약 보존
- `exec` 3단 방어·worktree·browser·task_end 경로는 무변경 (exec 는 원래 async `execFile`)

블록된 FS 호출 자체는 취소 불가(threadpool 스레드 점유 잔존)라는 한계는 코드 주석에 명시.

## 검증

- 유닛 49→**54** 전부 통과. 신규 5건:
  - `readdir` 영구 블록 시뮬레이션 → `folders`/`listAll` 이 타임아웃 오류로 해소
  - **블록 중에도 같은 코어의 `read` 요청이 정상 처리** (이벤트 루프 생존 = pong 유지 = 타 루트 생존 등가)
  - `safeFromAsync` 스코프 패리티 (상향 탈출·절대경로·심링크·미존재 경로)
- `npm run test:bridge-harness` (데스크톱 하네스 13 프레임) 통과, CLI 빌드 통과, lint 0 errors

## 배포 노트

코어는 패키지 단일화(2026-08-22) 상태라 이 수정 1회로 CLI·데스크톱·Companion 헬퍼가 모두 커버되지만, **Companion(native)·데스크톱 앱은 재빌드·재배포 전까지 구 동작**입니다. 다음 native 채널 게시 때 함께 나갑니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)