### PR TITLE
feat(chat): 추론 강도(reasoning effort) 사용자 선택 — 채팅 UI 3단 + 모델별 정규화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -181,7 +181,13 @@ LLM_WEEKLY_TOKEN_LIMIT=5000000
 # vLLM extra_body.reasoning_effort 전송 (opt-in, 기본 비활성).
 # 모델/서버가 reasoning 지원 시에만 'true' 로 활성화 — vLLM 서버 가동 시
 # `--reasoning-parser deepseek_r1|qwen3|granite|...` 옵션 함께 지정 필요.
+# true 로 켜면 채팅 UI 의 "추론 강도"(낮음·보통·높음) 선택이 실제 reasoning_effort 로 전달된다.
+# 모델별 지원값 차이는 config/reasoning-effort.ts 가 정규화하므로 켜도 400 이 나지 않는다
+# (실측 2026-08-23: qwen3.6 은 low/medium/high/xhigh, qwen3.8 은 high 를 거절 → xhigh 로 승격).
 LLM_ENABLE_REASONING_EFFORT=false
+# 모델 접두어별 지원 강도 override (JSON). 새 모델 도입 시 배포 없이 대응.
+# 예: {"qwen3.8":["low","medium","xhigh"],"llama-4":["low","medium","high"]}
+# LLM_REASONING_EFFORTS_JSON=
 
 # Tail 라우팅 셰도우 모드. true 면 채팅 요청마다 tail 게이트 결정(errorScore·verifiability·isTail)을
 # 계산해 routing_shadow_decisions 테이블에 적재만 한다(실행 경로 무변경, 사용자 영향 0).

--- a/apps/api/src/config/reasoning-effort.test.ts
+++ b/apps/api/src/config/reasoning-effort.test.ts
@@ -1,0 +1,59 @@
+/**
+ * 추론 강도 정규화 — 모델별 지원값 차이 흡수 회귀.
+ *
+ * 배경(실측 2026-08-23, DGX 라이브): qwen3.8 은 reasoning_effort='high' 를 400 으로 거절한다
+ * ("Supported types are xhigh (default), medium, and low"). 반면 qwen3.6 은 4값 모두 200.
+ * UI 는 모델 불문 3단(낮음·보통·높음)을 노출하므로 서버 정규화가 없으면 모델 교체 시 요청이 죽는다.
+ */
+import {
+    normalizeEffort,
+    resetReasoningEffortCache,
+    supportedEfforts,
+    type ReasoningEffort,
+} from './reasoning-effort';
+
+describe('reasoning-effort 정규화', () => {
+    const savedEnv = process.env.LLM_REASONING_EFFORTS_JSON;
+    beforeEach(() => {
+        delete process.env.LLM_REASONING_EFFORTS_JSON;
+        resetReasoningEffortCache();
+    });
+    afterAll(() => {
+        if (savedEnv !== undefined) process.env.LLM_REASONING_EFFORTS_JSON = savedEnv;
+        else delete process.env.LLM_REASONING_EFFORTS_JSON;
+        resetReasoningEffortCache();
+    });
+
+    it('qwen3.6 은 요청값을 그대로 쓴다 (4값 모두 지원)', () => {
+        for (const e of ['low', 'medium', 'high', 'xhigh'] as ReasoningEffort[]) {
+            expect(normalizeEffort('qwen3.6-35b-a3b', e)).toBe(e);
+        }
+    });
+
+    it('qwen3.8 의 high 는 xhigh 로 승격된다 (거절값 회피 + 의도 보존)', () => {
+        expect(supportedEfforts('qwen3.8-27b-awq')).not.toContain('high');
+        expect(normalizeEffort('qwen3.8-27b-awq', 'high')).toBe('xhigh');
+        expect(normalizeEffort('qwen3.8-27b-awq', 'low')).toBe('low');
+        expect(normalizeEffort('qwen3.8-27b-awq', 'medium')).toBe('medium');
+    });
+
+    it('미등록 모델은 OpenAI 표준 3단으로 보수 처리 — xhigh 는 high 로 강등', () => {
+        expect(supportedEfforts('llama-3.3-70b')).toEqual(['low', 'medium', 'high']);
+        expect(normalizeEffort('llama-3.3-70b', 'xhigh')).toBe('high');
+        expect(normalizeEffort(undefined, 'medium')).toBe('medium');
+    });
+
+    it('env override 로 새 모델을 배포 없이 등록할 수 있다', () => {
+        process.env.LLM_REASONING_EFFORTS_JSON = JSON.stringify({ 'newmodel': ['low', 'xhigh'] });
+        resetReasoningEffortCache();
+        expect(supportedEfforts('newmodel-9b')).toEqual(['low', 'xhigh']);
+        // medium(idx1) → low(d=1) vs xhigh(d=2) → 가까운 low
+        expect(normalizeEffort('newmodel-9b', 'medium')).toBe('low');
+    });
+
+    it('잘못된 env 는 기본 카탈로그로 폴백한다 (부팅 실패 금지)', () => {
+        process.env.LLM_REASONING_EFFORTS_JSON = '{"broken": ["ultra"]}';
+        resetReasoningEffortCache();
+        expect(supportedEfforts('qwen3.8-27b')).not.toContain('high');
+    });
+});

--- a/apps/api/src/config/reasoning-effort.ts
+++ b/apps/api/src/config/reasoning-effort.ts
@@ -1,0 +1,103 @@
+/**
+ * 추론 강도(reasoning effort) 정책 — 모델별 지원값 차이 흡수.
+ *
+ * vLLM 은 모델 chat_template 이 선언한 값만 받는다. 실측(2026-08-23, DGX 라이브):
+ *   - qwen3.6-35b-a3b : low / medium / high / xhigh 모두 200
+ *   - qwen3.8-27b     : high 를 **400 거절** ("Supported types are xhigh (default), medium, and low")
+ * 사용자 UI 는 모델과 무관한 3단(낮음·보통·높음)을 노출하고, 서버가 대상 모델이 받는
+ * 값으로 정규화한다 — 모델을 바꿔도 UI·프론트 계약은 그대로다.
+ *
+ * @module config/reasoning-effort
+ */
+
+/** 강도 사다리 — 낮은 것부터. 정규화 시 인접값 탐색 기준. */
+export const REASONING_EFFORT_LADDER = ['low', 'medium', 'high', 'xhigh'] as const;
+
+export type ReasoningEffort = typeof REASONING_EFFORT_LADDER[number];
+
+/** 지원 목록 미상 모델의 보수적 기본값 — OpenAI 표준 3단만 가정(xhigh 는 벤더 확장). */
+const FALLBACK_SUPPORTED: readonly ReasoningEffort[] = ['low', 'medium', 'high'];
+
+/**
+ * 모델 id 접두어 → 지원 강도 목록. `matchCapabilityPreset` 과 동일한
+ * startsWith-longest 규칙을 쓴다(중간 substring 오매칭 배제).
+ * env `LLM_REASONING_EFFORTS_JSON` 으로 통째 override 가능 — 새 모델 도입 시 배포 없이 대응.
+ */
+const DEFAULT_MODEL_EFFORTS: Readonly<Record<string, readonly ReasoningEffort[]>> = {
+    'qwen3.6': ['low', 'medium', 'high', 'xhigh'],
+    // 실측 거절값(high)을 제외 — 사용자가 '높음'을 고르면 아래 정규화가 xhigh 로 올린다.
+    'qwen3.8': ['low', 'medium', 'xhigh'],
+};
+
+let _cached: Readonly<Record<string, readonly ReasoningEffort[]>> | null = null;
+
+function isEffort(v: unknown): v is ReasoningEffort {
+    return typeof v === 'string' && (REASONING_EFFORT_LADDER as readonly string[]).includes(v);
+}
+
+function getModelEfforts(): Readonly<Record<string, readonly ReasoningEffort[]>> {
+    if (_cached) return _cached;
+    const raw = process.env.LLM_REASONING_EFFORTS_JSON;
+    if (raw) {
+        try {
+            const parsed = JSON.parse(raw) as Record<string, unknown>;
+            const out: Record<string, readonly ReasoningEffort[]> = {};
+            for (const [prefix, list] of Object.entries(parsed)) {
+                if (Array.isArray(list) && list.every(isEffort) && list.length > 0) {
+                    out[prefix.toLowerCase()] = list as ReasoningEffort[];
+                }
+            }
+            if (Object.keys(out).length > 0) {
+                _cached = out;
+                return _cached;
+            }
+        } catch { /* 형식 오류는 기본값으로 폴백 */ }
+    }
+    _cached = DEFAULT_MODEL_EFFORTS;
+    return _cached;
+}
+
+/** 테스트 훅 — env 변경 후 캐시 리셋. */
+export function resetReasoningEffortCache(): void {
+    _cached = null;
+}
+
+/** 모델이 받는 강도 목록 (미등록 모델은 보수적 기본값). */
+export function supportedEfforts(modelId: string | undefined): readonly ReasoningEffort[] {
+    if (!modelId) return FALLBACK_SUPPORTED;
+    const lower = modelId.toLowerCase();
+    let best: readonly ReasoningEffort[] | null = null;
+    let bestLen = -1;
+    for (const [prefix, list] of Object.entries(getModelEfforts())) {
+        if (lower.startsWith(prefix) && prefix.length > bestLen) {
+            best = list;
+            bestLen = prefix.length;
+        }
+    }
+    return best ?? FALLBACK_SUPPORTED;
+}
+
+/**
+ * 요청 강도를 대상 모델이 받는 값으로 정규화.
+ * 미지원이면 사다리에서 가장 가까운 값으로 대체하고, 거리가 같으면 **상위**를 택한다
+ * (사용자가 '높음'을 고른 의도를 낮추지 않는다 — qwen3.8 의 high → xhigh).
+ */
+export function normalizeEffort(
+    modelId: string | undefined,
+    requested: ReasoningEffort,
+): ReasoningEffort {
+    const supported = supportedEfforts(modelId);
+    if (supported.includes(requested)) return requested;
+    const want = REASONING_EFFORT_LADDER.indexOf(requested);
+    let best = supported[0];
+    let bestScore = Number.POSITIVE_INFINITY;
+    for (const cand of supported) {
+        const d = Math.abs(REASONING_EFFORT_LADDER.indexOf(cand) - want);
+        // 거리가 같으면 사다리 상위(더 강한 추론)를 선호 — `<=` 로 뒤쪽(상위) 우선.
+        if (d <= bestScore) {
+            bestScore = d;
+            best = cand;
+        }
+    }
+    return best;
+}

--- a/apps/api/src/llm/client.ts
+++ b/apps/api/src/llm/client.ts
@@ -177,7 +177,8 @@ export class LLMClient {
                 ...(advancedOptions.tool_choice !== undefined && { tool_choice: advancedOptions.tool_choice }),
             }),
         };
-        const extraBody = buildExtraBody(advancedOptions?.think);
+        // 실제 라우팅된 모델 기준으로 reasoning_effort 를 정규화한다(모델별 지원값 상이).
+        const extraBody = buildExtraBody(advancedOptions?.think, poolDecision.model);
 
         return withSpan(
             'llm-client',

--- a/apps/api/src/llm/reasoning-adapter.effort.test.ts
+++ b/apps/api/src/llm/reasoning-adapter.effort.test.ts
@@ -1,0 +1,45 @@
+/**
+ * buildExtraBody — 추론 강도가 모델별로 정규화되어 나가는지 고정.
+ * (LLM_ENABLE_REASONING_EFFORT 가 켜졌을 때만 reasoning_effort 를 싣는 기존 계약도 함께 검증.)
+ */
+import { buildExtraBody } from './reasoning-adapter';
+
+describe('buildExtraBody — reasoning_effort 정규화', () => {
+    const saved = process.env.LLM_ENABLE_REASONING_EFFORT;
+    afterAll(() => {
+        if (saved !== undefined) process.env.LLM_ENABLE_REASONING_EFFORT = saved;
+        else delete process.env.LLM_ENABLE_REASONING_EFFORT;
+    });
+
+    it('게이트가 꺼져 있으면 reasoning_effort 를 보내지 않는다 (기존 동작)', () => {
+        process.env.LLM_ENABLE_REASONING_EFFORT = 'false';
+        const body = buildExtraBody('high', 'qwen3.8-27b-awq');
+        expect(body?.reasoning_effort).toBeUndefined();
+        expect(body?.chat_template_kwargs).toEqual({ enable_thinking: true });
+    });
+
+    it('게이트 ON: qwen3.8 의 high 는 xhigh 로 바꿔 보낸다 (400 회피)', () => {
+        process.env.LLM_ENABLE_REASONING_EFFORT = 'true';
+        expect(buildExtraBody('high', 'qwen3.8-27b-awq')?.reasoning_effort).toBe('xhigh');
+        expect(buildExtraBody('low', 'qwen3.8-27b-awq')?.reasoning_effort).toBe('low');
+    });
+
+    it('게이트 ON: qwen3.6 은 요청값 그대로', () => {
+        process.env.LLM_ENABLE_REASONING_EFFORT = 'true';
+        expect(buildExtraBody('high', 'qwen3.6-35b-a3b')?.reasoning_effort).toBe('high');
+        expect(buildExtraBody('medium', 'qwen3.6-35b-a3b')?.reasoning_effort).toBe('medium');
+    });
+
+    it('think=true(단계 미지정)는 high 의도로 해석 후 모델별 정규화', () => {
+        process.env.LLM_ENABLE_REASONING_EFFORT = 'true';
+        expect(buildExtraBody(true, 'qwen3.8-27b-awq')?.reasoning_effort).toBe('xhigh');
+        expect(buildExtraBody(true, 'qwen3.6-35b-a3b')?.reasoning_effort).toBe('high');
+    });
+
+    it('think=false 는 강도를 싣지 않고 thinking 을 강제 OFF 한다', () => {
+        process.env.LLM_ENABLE_REASONING_EFFORT = 'true';
+        const body = buildExtraBody(false, 'qwen3.6-35b-a3b');
+        expect(body?.reasoning_effort).toBeUndefined();
+        expect(body?.chat_template_kwargs).toEqual({ enable_thinking: false });
+    });
+});

--- a/apps/api/src/llm/reasoning-adapter.ts
+++ b/apps/api/src/llm/reasoning-adapter.ts
@@ -11,9 +11,15 @@
  *
  * @module llm/reasoning-adapter
  */
+import { normalizeEffort, type ReasoningEffort } from '../config/reasoning-effort';
 import type { ThinkOption } from './types';
 
-export function thinkToReasoningEffort(t: ThinkOption | undefined): 'low' | 'medium' | 'high' | undefined {
+/**
+ * think 옵션 → reasoning_effort 값.
+ * `true`(단계 미지정)는 '높음' 의도로 보고 'high' 로 해석하되, 최종값은 호출부가
+ * modelId 로 정규화한다 — 모델마다 받는 값이 다르다(qwen3.8 은 high 를 400 거절).
+ */
+export function thinkToReasoningEffort(t: ThinkOption | undefined): ReasoningEffort | undefined {
     if (t === undefined || t === false) return undefined;
     if (t === true) return 'high';
     return t;
@@ -38,20 +44,24 @@ export function thinkToReasoningEffort(t: ThinkOption | undefined): 'low' | 'med
  * 측정: reasoning 모델 기준 TTFB 8.2s → 3.1s (reasoning OFF, 62% 단축).
  * vLLM 0.21+ 에서 chat_template 이 `enable_thinking` 변수를 인식해야 작동.
  */
-export function buildExtraBody(t: ThinkOption | undefined): Record<string, unknown> | undefined {
+export function buildExtraBody(
+    t: ThinkOption | undefined,
+    modelId?: string,
+): Record<string, unknown> | undefined {
     const result: Record<string, unknown> = {};
 
     const reasoningEnabled = (process.env.LLM_ENABLE_REASONING_EFFORT ?? 'false').toLowerCase() === 'true';
     if (reasoningEnabled) {
         const effort = thinkToReasoningEffort(t);
-        if (effort) result.reasoning_effort = effort;
+        // 대상 모델이 받지 않는 값은 인접 지원값으로 강등/승격 — 미정규화 전송은 400 이다.
+        if (effort) result.reasoning_effort = normalizeEffort(modelId, effort);
     }
 
     const disableThinkingByDefault = (process.env.LLM_DISABLE_THINKING_BY_DEFAULT ?? 'false').toLowerCase() === 'true';
     if (t === false) {
         // 명시적 비활성 — env 와 무관하게 강제 OFF.
         result.chat_template_kwargs = { enable_thinking: false };
-    } else if (t === true || t === 'low' || t === 'medium' || t === 'high') {
+    } else if (t === true || t === 'low' || t === 'medium' || t === 'high' || t === 'xhigh') {
         // 명시적 활성 — disableThinkingByDefault 가 true 여도 호출자 요청 우선.
         result.chat_template_kwargs = { enable_thinking: true };
     } else if (disableThinkingByDefault) {

--- a/apps/api/src/llm/types.ts
+++ b/apps/api/src/llm/types.ts
@@ -14,6 +14,7 @@
  * LLM 클라이언트 기본 설정 (vLLM/LiteLLM proxy 또는 OpenAI 호환 endpoint)
  * @interface LLMConfig
  */
+import type { ReasoningEffort } from '../config/reasoning-effort';
 export interface LLMConfig {
     /** LLM 서버 기본 URL (예: http://localhost:4000 — LiteLLM proxy) */
     baseUrl: string;
@@ -187,7 +188,7 @@ export interface ToolCall {
  *
  * @type ThinkOption
  */
-export type ThinkOption = boolean | 'low' | 'medium' | 'high';
+export type ThinkOption = boolean | ReasoningEffort;
 
 /**
  * 구조화된 출력 형식 옵션

--- a/apps/api/src/providers/i-provider.ts
+++ b/apps/api/src/providers/i-provider.ts
@@ -13,6 +13,7 @@
  */
 
 import type { ChatMessage, ToolDefinition, UsageMetrics } from '../llm';
+import type { ReasoningEffort } from '../config/reasoning-effort';
 
 /**
  * 어댑터가 사용하는 SDK 종류 — 디버깅/관측 목적의 메타 정보.
@@ -113,8 +114,12 @@ export interface ChatStreamOptions {
     temperature?: number;
     /** 최대 출력 토큰 */
     maxTokens?: number;
-    /** Thinking 활성화 — boolean 또는 토큰 budget 객체 */
-    thinking?: boolean | { budget: number };
+    /**
+     * Thinking 활성화 — boolean, 추론 강도('low'|'medium'|'high'|'xhigh'), 또는 토큰 budget 객체.
+     * 강도 문자열은 로컬(vLLM) 경로에서 reasoning_effort 로 전달되며, 모델이 받지 않는 값은
+     * config/reasoning-effort 가 인접 지원값으로 정규화한다.
+     */
+    thinking?: boolean | ReasoningEffort | { budget: number };
     /** 사용 가능한 도구 목록 */
     tools?: ToolDefinition[];
     /** 도구 선택 강제 — 특정 도구를 반드시 호출하게 하거나(function) 도구 사용을 강제/차단. vLLM tool_choice 시맨틱. */

--- a/apps/api/src/providers/local-llm-provider.ts
+++ b/apps/api/src/providers/local-llm-provider.ts
@@ -200,6 +200,8 @@ export class LocalLLMProvider implements IProvider {
                 },
                 onTokenCombined,
                 {
+                    // 강도 문자열('low'|'medium'|'high'|'xhigh')은 그대로 넘겨 reasoning_effort 로
+                    // 매핑되게 한다. budget 객체는 로컬에서 미지원이라 단순 활성으로 축약.
                     think: typeof opts.thinking === 'object'
                         ? true
                         : opts.thinking,

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -40,6 +40,18 @@ import type { ExternalProviderDeps, ChatTimings, StreamFromExternalContext } fro
 /**
  * 외부 LLM provider stream + multi-turn tool calling.
  */
+/**
+ * thinking 옵션 결정 — 토글이 켜져 있으면 사용자가 고른 추론 강도를 그대로 넘긴다.
+ * 강도 미지정(구 클라이언트)은 `true` 로 기존 동작을 유지하며, 모델이 받지 않는 값은
+ * config/reasoning-effort 가 정규화한다.
+ */
+function resolveThinking(
+    req: { thinkingMode?: boolean; thinkingLevel?: 'low' | 'medium' | 'high' },
+): boolean | 'low' | 'medium' | 'high' {
+    if (req.thinkingMode !== true) return false;
+    return req.thinkingLevel ?? true;
+}
+
 export async function runExternalStream(
     deps: ExternalProviderDeps,
     resolved: ResolvedProvider,
@@ -161,7 +173,7 @@ export async function runExternalStream(
                 {
                     messages: fittedMessages,
                     modelId: resolved.modelId,
-                    thinking: req.thinkingMode === true,
+                    thinking: resolveThinking(req),
                     ...(turnTools.length > 0 ? { tools: turnTools } : {}),
                     // 첫 턴만 도구 강제(카카오 지도 또는 명시적 웹 검색) — 이후 턴은 auto(모델이 결과로 답변 작성).
                     ...(turn === 0 && forcedFirstTurnToolName && turnTools.length > 0
@@ -281,7 +293,7 @@ export async function runExternalStream(
                 {
                     messages: fittedFinal,
                     modelId: resolved.modelId,
-                    thinking: req.thinkingMode === true,
+                    thinking: resolveThinking(req),
                     ...(req.abortSignal ? { abortSignal: req.abortSignal } : {}),
                 },
                 {

--- a/apps/api/src/sockets/ws-types.ts
+++ b/apps/api/src/sockets/ws-types.ts
@@ -28,7 +28,11 @@ export interface WSMessage {
     /** 아티팩트 모드 — ON 이면 모델이 <artifact> 산출물을 생성하도록 유도 (wantsArtifact 강제) */
     artifactMode?: boolean;
     thinkingMode?: boolean;
-    thinkingLevel?: string;
+    /**
+     * 추론 강도 — thinkingMode=true 일 때만 의미. 미지정이면 'high' 로 간주(기존 동작).
+     * 모델별 지원값 차이(qwen3.8 은 high 거절)는 서버가 config/reasoning-effort 로 정규화한다.
+     */
+    thinkingLevel?: 'low' | 'medium' | 'high';
     /**
      * 메시지 본문을 conversation_messages 에 저장할지 여부.
      * 기본 true (생략 시 저장). false 면 본문은 저장하지 않고

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -212,6 +212,7 @@ export function Composer() {
     structuredMode,
     selectedModel,
     style,
+    thinkingLevel,
     inputDraft,
     toggle,
     setSelectedModel,
@@ -220,6 +221,7 @@ export function Composer() {
     setAgentLocalDeviceId,
     setAgentLocalFolderRel,
     cycleStyle,
+    cycleThinkingLevel,
     setInputDraft,
     auth,
   } = useAppStore();
@@ -936,6 +938,18 @@ export function Composer() {
           >
             {tSettings(`responseStyles.${style}`)}
           </button>
+
+          {/* 추론 강도 — Thinking 토글이 켜진 경우에만 노출. 낮음→보통→높음 순환(스타일 버튼과 동일 패턴).
+              모델마다 받는 값이 달라(qwen3.8 은 high 거절) 정규화는 서버가 담당한다. */}
+          {thinkingEnabled && (
+            <button
+              onClick={cycleThinkingLevel}
+              className="rounded-md px-2 py-1.5 text-xs font-medium text-muted hover:bg-surface-2 hover:text-fg"
+              title={t("thinkingLevel.title")}
+            >
+              {t(`thinkingLevel.${thinkingLevel}`)}
+            </button>
+          )}
 
           {/* 사용 중인 LLM 모델 — 표시 전용 (변경은 설정 → 모델&응답 → 기본 모델).
               '자동' 이면 서버 기본모델명을 병기해 실제 사용 모델을 노출한다.

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -125,6 +125,9 @@ export interface Artifact {
 
 export type ChatStyle = "concise" | "default" | "verbose";
 
+/** 추론 강도 — thinkingEnabled 가 켜졌을 때만 의미. 백엔드 ws `thinkingLevel` 계약과 1:1. */
+export type ThinkingLevel = "low" | "medium" | "high";
+
 /** store 인증 사용자 — shared-types User 의 표시용 부분집합 (name 은 username 매핑). */
 export interface AuthUser {
   id: string;
@@ -166,6 +169,8 @@ interface AppState {
 
   // 모드 토글 (기존 state.js)
   thinkingEnabled: boolean;
+  /** 추론 강도 — thinkingEnabled=true 일 때 전송. 모델별 지원값 정규화는 서버 담당. */
+  thinkingLevel: ThinkingLevel;
   discussionMode: boolean;
   deepResearchMode: boolean;
   webSearchEnabled: boolean;
@@ -249,10 +254,14 @@ interface AppState {
   setAgentLocalFolderRel: (v: string | null) => void;
   cycleStyle: () => void;
   setStyle: (m: ChatStyle) => void;
+  cycleThinkingLevel: () => void;
+  setThinkingLevel: (v: ThinkingLevel) => void;
   setAuth: (auth: AppState["auth"]) => void;
 }
 
 const STYLE_ORDER: ChatStyle[] = ["default", "concise", "verbose"];
+// 낮음 → 보통 → 높음 순환. 기본 medium (기존 서버 폴백 high 보다 보수적 — 추론 토큰 낭비 억제).
+const THINKING_LEVEL_ORDER: ThinkingLevel[] = ["low", "medium", "high"];
 
 /**
  * primary(전용) 모드 — 상호배타. 하나를 켜면 나머지는 자동으로 꺼진다.
@@ -305,6 +314,7 @@ export const useAppStore = create<AppState>()(
   artifactPanelOpen: false,
 
   thinkingEnabled: true, // 기본 ON — tool calling 중 추론(thinking) 과정을 화면에 노출
+  thinkingLevel: "medium",
   discussionMode: false,
   deepResearchMode: false,
   webSearchEnabled: false,
@@ -491,6 +501,14 @@ export const useAppStore = create<AppState>()(
       style: STYLE_ORDER[(STYLE_ORDER.indexOf(s.style) + 1) % STYLE_ORDER.length],
     })),
   setStyle: (m) => set({ style: m }),
+  cycleThinkingLevel: () =>
+    set((s) => ({
+      thinkingLevel:
+        THINKING_LEVEL_ORDER[
+          (THINKING_LEVEL_ORDER.indexOf(s.thinkingLevel) + 1) % THINKING_LEVEL_ORDER.length
+        ],
+    })),
+  setThinkingLevel: (v) => set({ thinkingLevel: v }),
   setAuth: (auth) => set({ auth }),
     }),
     {
@@ -499,7 +517,7 @@ export const useAppStore = create<AppState>()(
         typeof window !== "undefined" ? window.localStorage : noopStorage,
       ),
       // 사용자 환경설정만 영속화 — 채팅/아티팩트 등 휘발성 세션 상태는 제외
-      partialize: (s) => ({ selectedModel: s.selectedModel, style: s.style, activeUserAgent: s.activeUserAgent }),
+      partialize: (s) => ({ selectedModel: s.selectedModel, style: s.style, thinkingLevel: s.thinkingLevel, activeUserAgent: s.activeUserAgent }),
     },
   ),
 );

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -528,6 +528,8 @@ export function useChatSocket() {
         deepResearchMode: s.deepResearchMode,
         discussionMode: s.discussionMode,
         thinkingMode: s.thinkingEnabled,
+        // 추론 강도 — 토글이 켜진 경우에만 의미(서버가 thinkingMode=false 면 무시).
+        ...(s.thinkingEnabled ? { thinkingLevel: s.thinkingLevel } : {}),
         imageMode: s.imageMode,
         artifactMode: s.artifactMode,
         style: s.style,

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -318,6 +318,12 @@
       "folderUnsupported": "This device does not support folder browsing — update the CLI/app",
       "folderEmpty": "No subfolders",
       "folderTruncated": "…list truncated"
+    },
+    "thinkingLevel": {
+      "title": "Reasoning effort",
+      "low": "Reasoning: Low",
+      "medium": "Reasoning: Medium",
+      "high": "Reasoning: High"
     }
   },
   "chat": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -318,6 +318,12 @@
       "folderUnsupported": "このデバイスはフォルダ探索に対応していません — CLI/アプリを更新してください",
       "folderEmpty": "サブフォルダがありません",
       "folderTruncated": "…一覧が省略されました"
+    },
+    "thinkingLevel": {
+      "title": "推論の強度",
+      "low": "推論: 低",
+      "medium": "推論: 中",
+      "high": "推論: 高"
     }
   },
   "chat": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -318,6 +318,12 @@
       "folderUnsupported": "이 디바이스는 폴더 탐색을 지원하지 않습니다 — CLI/앱을 업데이트하세요",
       "folderEmpty": "하위 폴더가 없습니다",
       "folderTruncated": "…목록이 잘렸습니다"
+    },
+    "thinkingLevel": {
+      "title": "추론 강도",
+      "low": "추론 낮음",
+      "medium": "추론 보통",
+      "high": "추론 높음"
     }
   },
   "chat": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -318,6 +318,12 @@
       "folderUnsupported": "该设备不支持文件夹浏览 — 请更新 CLI/应用",
       "folderEmpty": "没有子文件夹",
       "folderTruncated": "…列表已截断"
+    },
+    "thinkingLevel": {
+      "title": "推理强度",
+      "low": "推理: 低",
+      "medium": "推理: 中",
+      "high": "推理: 高"
     }
   },
   "chat": {


### PR DESCRIPTION
## 배경

`thinkingLevel` 계약은 이미 WS·REST 스키마·ExecutionPlan·ChatRequest 에 존재했지만 **LLM 호출까지 도달하지 않았습니다.** 실제 소비처는 관리자 디버그 응답(`chat.routes.ts:112`) 한 곳뿐이었고, 채팅 경로는 `thinking: req.thinkingMode === true` 로 boolean 만 넘기고 있었습니다. 즉 사용자는 추론을 켜고 끌 수만 있고 **강도는 고를 수 없었습니다.**

이 PR 은 그 죽은 필드를 끝까지 배선하고 채팅 UI 에 선택 수단을 붙입니다. 새 개념을 만들지 않고 기존 계약을 살리는 방향입니다.

## 모델마다 받는 값이 다릅니다 (실측)

DGX 라이브에서 두 모델에 직접 요청해 확인했습니다(2026-08-23).

| effort | qwen3.6-35b-a3b | qwen3.8-27B |
|---|---|---|
| low | 200 | 200 |
| medium | 200 | 200 |
| **high** | 200 | **400 거절** |
| xhigh | 200 | 200 (기본값) |

qwen3.8 오류: `Unexpected reasoning effort high. Supported types are xhigh (default), medium, and low.`

그런데 기존 `thinkToReasoningEffort()` 는 `think: true` 를 **`'high'`** 로 매핑합니다. 지금은 `LLM_ENABLE_REASONING_EFFORT=false` 라 값을 안 보내서 무해하지만, **이 기능을 켜는 순간 qwen3.8 계열에서 모든 thinking 요청이 400 으로 죽습니다.** 그래서 정규화 계층을 함께 넣었습니다.

## 변경

**신규 `config/reasoning-effort.ts`**
- 강도 사다리 `low < medium < high < xhigh`, 모델 접두어별 지원 목록(`matchCapabilityPreset` 과 동일한 startsWith-longest 규칙)
- `normalizeEffort(modelId, requested)` — 미지원 값은 인접 지원값으로 대체. **거리가 같으면 상위 선호**(qwen3.8 의 `high` → `xhigh`)라 사용자가 고른 '높음' 의도를 낮추지 않습니다
- 미등록 모델은 OpenAI 표준 3단(`low/medium/high`)으로 보수 처리 → 모델을 바꿔도 400 이 나지 않습니다
- env `LLM_REASONING_EFFORTS_JSON` 로 배포 없이 신규 모델 등록 (형식 오류는 기본 카탈로그로 폴백, 부팅 실패 없음)

**배선** — 프론트 → WS `thinkingLevel` → `external-provider`(신규 `resolveThinking`) → `i-provider.thinking` → `local-llm-provider.think` → `buildExtraBody(think, modelId)`. `ThinkOption` 에 `'xhigh'` 추가, `buildExtraBody` 가 실제 라우팅된 모델(`poolDecision.model`)로 정규화합니다.

**채팅 UI** — Thinking 토글이 켜져 있을 때만 "추론 낮음 / 보통 / 높음" 순환 버튼이 응답 스타일 버튼 옆에 나타납니다(동일 패턴). store `thinkingLevel` 기본 `medium`(서버 폴백 `high` 보다 보수적 — 추론 토큰 낭비 억제), 선택값은 `style` 과 함께 영속됩니다. i18n 4개 언어(ko/en/ja/zh) 키 추가.

**게이트** — `LLM_ENABLE_REASONING_EFFORT` 는 기존대로 opt-in 유지했습니다. 켜는 시점의 안전성은 위 정규화가 보장하며, `.env.example` 에 사용법과 실측 근거를 적었습니다.

## 검증

- 신규 유닛 **10건** — 모델별 정규화(qwen3.6 그대로 / qwen3.8 high→xhigh / 미등록 모델 xhigh→high), env override, 잘못된 env 폴백, 게이트 OFF 시 미전송, `think:false` 강제 OFF
- API 전체 유닛 **2,788건 통과**(256 suites)
- `npm run lint` 0 errors, `apps/web` tsc 통과

## 남은 것

이 PR 은 배선과 안전장치까지입니다. 실제로 사용자에게 노출하려면 운영 `.env` 에서 `LLM_ENABLE_REASONING_EFFORT=true` 로 전환해야 합니다(별도 배포 판단).

🤖 Generated with [Claude Code](https://claude.com/claude-code)