### PR TITLE
fix(llm): reasoning_effort 를 LiteLLM 게이트웨이가 막던 문제 — 통과 힌트 동봉

### DIFF
--- a/apps/api/src/llm/reasoning-adapter.effort.test.ts
+++ b/apps/api/src/llm/reasoning-adapter.effort.test.ts
@@ -15,7 +15,16 @@ describe('buildExtraBody — reasoning_effort 정규화', () => {
         process.env.LLM_ENABLE_REASONING_EFFORT = 'false';
         const body = buildExtraBody('high', 'qwen3.8-27b-awq');
         expect(body?.reasoning_effort).toBeUndefined();
+        expect(body?.allowed_openai_params).toBeUndefined();
         expect(body?.chat_template_kwargs).toEqual({ enable_thinking: true });
+    });
+
+    it('reasoning_effort 를 보낼 땐 LiteLLM 통과 힌트를 동봉한다 (게이트웨이 400 회귀 차단)', () => {
+        // 라이브 실측: 힌트 없이 보내면 LiteLLM 이 UnsupportedParamsError 400 으로 막는다.
+        process.env.LLM_ENABLE_REASONING_EFFORT = 'true';
+        const body = buildExtraBody('medium', 'qwen3.6-35b-a3b');
+        expect(body?.reasoning_effort).toBe('medium');
+        expect(body?.allowed_openai_params).toEqual(['reasoning_effort']);
     });
 
     it('게이트 ON: qwen3.8 의 high 는 xhigh 로 바꿔 보낸다 (400 회피)', () => {

--- a/apps/api/src/llm/reasoning-adapter.ts
+++ b/apps/api/src/llm/reasoning-adapter.ts
@@ -54,7 +54,16 @@ export function buildExtraBody(
     if (reasoningEnabled) {
         const effort = thinkToReasoningEffort(t);
         // 대상 모델이 받지 않는 값은 인접 지원값으로 강등/승격 — 미정규화 전송은 400 이다.
-        if (effort) result.reasoning_effort = normalizeEffort(modelId, effort);
+        if (effort) {
+            result.reasoning_effort = normalizeEffort(modelId, effort);
+            // LiteLLM 게이트웨이는 provider('openai') 기준으로 파라미터를 검증해 reasoning_effort 를
+            // **업스트림에 닿기 전에** 400 으로 거절한다(라이브 실측 2026-08-23:
+            //   litellm.UnsupportedParamsError: openai does not support parameters: ['reasoning_effort']).
+            // 이 힌트를 함께 보내면 LiteLLM 이 허용 목록에 더해 그대로 전달한다(utils.py allowed_openai_params).
+            // LiteLLM 이 소비하는 필드라 업스트림엔 실리지 않으며, 게이트웨이 없이 vLLM 에 직결된
+            // 배포에서도 알 수 없는 필드로 무시된다(vLLM 0.27 직접 호출 200 확인).
+            result.allowed_openai_params = ['reasoning_effort'];
+        }
     }
 
     const disableThinkingByDefault = (process.env.LLM_DISABLE_THINKING_BY_DEFAULT ?? 'false').toLowerCase() === 'true';


### PR DESCRIPTION
## 무슨 일이 있었나

#584 로 추론 강도 배선을 넣고 운영에서 `LLM_ENABLE_REASONING_EFFORT=true` 로 켰더니 **채팅이 전면 400** 이 됐습니다.

```
400 litellm.UnsupportedParamsError: openai does not support parameters:
    ['reasoning_effort'], for model=qwen3.6-35b-a3b
```

즉시 게이트를 되돌려 복구했고(영향: 오류 3건 전부 제 테스트 요청, 실사용자 영향 0), 원인을 잡았습니다.

## 원인 — 모델이 아니라 게이트웨이 계층

`reasoning_effort` 를 거절한 건 vLLM 이 아니라 **LiteLLM** 입니다. LiteLLM 은 provider(`openai`) 기준으로 파라미터를 검증해서, 지원 목록에 없으면 **업스트림에 닿기도 전에** 400 을 냅니다(`litellm/utils.py:4123`).

앞선 검증에서 이걸 놓친 이유가 명확합니다 — **검증을 vLLM 에 직접 쏴서 했습니다**(`:8002`). 앱은 항상 LiteLLM(`:13401`)을 경유하므로, 직결 테스트는 실제 경로를 대표하지 못했습니다. 이번 건의 진짜 교훈입니다.

## 수정

`reasoning_effort` 를 실을 때 `allowed_openai_params: ['reasoning_effort']` 를 함께 보냅니다. LiteLLM 이 이 힌트를 받아 허용 목록에 더하고 그대로 전달합니다(`utils.py:4138-4139`). 이 필드는 LiteLLM 이 소비하므로(`utils.py:3300` pop) 업스트림 요청엔 실리지 않습니다.

LiteLLM 설정(`litellm.config.yaml` 의 모델별 `allowed_openai_params`)으로 푸는 방법도 있지만, 앱 쪽 처리를 택했습니다 — **게이트웨이 재시작이 필요 없고**(운영 무중단), 모델을 추가할 때마다 config 를 손볼 필요가 없으며, 게이트웨이 없이 vLLM 에 직결된 배포에서도 안전합니다.

## 라이브 실측 (2026-08-23)

| 경로 | 결과 |
|---|---|
| LiteLLM `:13401` · `reasoning_effort` 단독 | **HTTP 400** |
| LiteLLM `:13401` · 힌트 동봉 | **HTTP 200** |
| vLLM 직결 · 힌트 동봉 | HTTP 200 (알 수 없는 필드 무시) |

## 검증

- 회귀 테스트 1건 추가(힌트 동봉 고정) + 게이트 OFF 케이스에 힌트 부재 단언 보강 → reasoning 관련 **15건 통과**
- `npm run lint` 0 errors

## 배포 계획

머지 후 정규 경로(`openmake_llm.sh deploy`)로 배포하고, `LLM_ENABLE_REASONING_EFFORT=true` 로 전환한 뒤 **LiteLLM 경유**로 3단계를 모두 검증합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)