### PR TITLE
chore(providers): ollama-local 제거 — 게이트웨이 우회 direct 경로 정리

### DIFF
--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -141,7 +141,7 @@ export const envSchema = z
         /**
          * LiteLLM 통합 게이트웨이로 inference 를 라우팅할 외부 provider id 콤마 목록
          * (예: 'openrouter,ollama-cloud,nvidia'). 빈값(기본) = 전부 direct.
-         * ollama-local·OAuth provider 는 목록과 무관하게 direct 유지.
+         * OAuth provider(chatgpt)는 목록과 무관하게 direct 유지.
          */
         LLM_GATEWAY_PROVIDERS: z.string().optional(),
         /**

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -77,8 +77,8 @@ export interface EnvConfig {
     /**
      * LiteLLM 통합 게이트웨이로 inference 를 라우팅할 외부 provider id 목록
      * (콤마 구분). 빈값(기본) = 전부 direct 호출. provider별 롤백은 목록에서
-     * 해당 id 제거 + 재시작. ollama-local(사용자별 동적 endpoint)·OAuth(chatgpt)
-     * 는 목록에 있어도 direct 유지 (게이트웨이 이전 ADR — ollama-local 은 동적 endpoint, chatgpt 는 OAuth 격리 때문).
+     * 해당 id 제거 + 재시작. OAuth(chatgpt)는 목록에 있어도 direct 유지
+     * (게이트웨이 이전 ADR — LiteLLM 의 공용 device 인증으로는 사용자별 격리 불가).
      */
     llmGatewayProviders: string[];
 

--- a/apps/api/src/config/external-providers.ts
+++ b/apps/api/src/config/external-providers.ts
@@ -6,7 +6,7 @@
  * 기본 base URL, 검증 endpoint 등을 정의합니다.
  *
  * 활성: 로컬 LLM (vLLM via LiteLLM, 키 불필요) + BYO key provider 4종 —
- * openrouter / ollama-local / ollama-cloud / nvidia (모두 OpenAI 호환 endpoint).
+ * openrouter / ollama-cloud / nvidia (모두 OpenAI 호환 endpoint).
  * 2026-05-08 마이그레이션 018 로 openrouter 만 남겼다가, ollama 2종은 2026-07-04,
  * nvidia 는 2026-07-14 에 재도입됨 (018 은 기존 키 행 정리용 — 스키마는 유지).
  *
@@ -129,27 +129,6 @@ export const EXTERNAL_PROVIDER_CATALOG: ReadonlyArray<ExternalProviderCatalogEnt
             { id: 'gpt-5.4',      displayName: 'GPT-5.4 (ChatGPT)',      isFree: false, capabilities: { streaming: true, toolCalling: true, vision: true, thinking: true } },
             { id: 'gpt-5.4-mini', displayName: 'GPT-5.4 Mini (ChatGPT)', isFree: false, capabilities: { streaming: true, toolCalling: true, vision: true, thinking: true } },
         ],
-    },
-    {
-        id: 'ollama-local',
-        displayName: 'Ollama (Local)',
-        sdkType: 'openai-compatible',
-        // Ollama 의 OpenAI 호환 endpoint 는 /v1. 실제 주소는 사용자가 base URL 로 입력
-        // (예: http://192.168.x.x:11434/v1). LAN IP 는 SSRF 가드에 걸리므로 운영자가
-        // .env SSRF_ALLOWED_HOSTS 에 해당 호스트를 등록해야 함 (fail-closed opt-in).
-        defaultBaseUrl: 'http://localhost:11434/v1',
-        validatePath: '/models',
-        enabled: true,
-        sortOrder: 30,
-        helpText:
-            '자체 서빙 중인 Ollama 서버의 OpenAI 호환 endpoint 를 입력하세요 ' +
-            '(예: http://<서버IP>:11434/v1). Ollama 는 API 키가 없으므로 임의 문자열 ' +
-            '8자 이상(예: ollama-no-key)을 입력하면 됩니다. LAN/사설 IP 는 서버 .env 의 ' +
-            'SSRF_ALLOWED_HOSTS 허용목록 등록이 필요합니다. 모델 목록은 해당 서버에 ' +
-            'pull 되어 있는 모델이 자동 표시됩니다.',
-        authMethods: ['api_key'] as const,
-        // 로컬 Ollama 는 설치 모델이 전부 — /v1/models 실패 시 보여줄 공통 모델이 없음
-        fallbackModels: [],
     },
     {
         id: 'ollama-cloud',

--- a/apps/api/src/providers/__tests__/gateway-routing.test.ts
+++ b/apps/api/src/providers/__tests__/gateway-routing.test.ts
@@ -4,7 +4,7 @@
  * 2026-07-31 LiteLLM Mac 이전 계약:
  * - 목록에 있는 API key provider → inference client 가 게이트웨이(baseURL=llmBaseUrl/v1)
  *   + x-litellm-api-key 헤더 + model prefix
- * - 목록에 없거나 ollama-local → 기존 direct 동작 무변경
+ * - 목록에 없는 provider → 기존 direct 동작 무변경
  * - 카탈로그/검증 client 는 게이트웨이 여부와 무관하게 provider endpoint direct
  */
 import { createExternalProviderInstance } from '../provider-router';
@@ -19,7 +19,7 @@ jest.mock('../../config', () => {
             ...actual.getConfig(),
             llmBaseUrl: 'http://127.0.0.1:13401',
             llmApiKey: 'sk-test-master',
-            llmGatewayProviders: ['openrouter', 'ollama-cloud', 'nvidia', 'ollama-local'],
+            llmGatewayProviders: ['openrouter', 'ollama-cloud', 'nvidia'],
         }),
     };
 });
@@ -95,13 +95,4 @@ describe('LLM_GATEWAY_PROVIDERS 게이트웨이 라우팅', () => {
         expect(p.modelPrefix).toBeUndefined();
     });
 
-    it('ollama-local 은 목록에 있어도 direct 유지 (사용자별 동적 endpoint)', () => {
-        const provider = createExternalProviderInstance(
-            makeKeyRow({ providerId: 'ollama-local', baseUrl: 'http://192.168.0.10:11434/v1' }),
-            'ollama-no-key',
-        );
-        const p = inner(provider as OpenAICompatProvider);
-        expect(p.client).toBe(p.catalogClient);
-        expect(p.modelPrefix).toBeUndefined();
-    });
 });

--- a/apps/api/src/providers/provider-router.ts
+++ b/apps/api/src/providers/provider-router.ts
@@ -58,19 +58,18 @@ export interface ExternalProviderInstanceDeps {
 }
 
 /**
- * 게이트웨이 라우팅 제외 provider — LLM_GATEWAY_PROVIDERS 에 있어도 direct 유지.
- * ollama-local: 사용자별 동적 endpoint 라 정적 게이트웨이 deployment 로 표현 불가
- * (게이트웨이 api_base 는 서버 통제 값만 허용 — SSRF 우회 방지).
- */
-const GATEWAY_EXCLUDED_PROVIDERS = new Set(['ollama-local']);
-
-/**
  * providerId 가 LiteLLM 게이트웨이 경유 대상이면 GatewayRouteOptions 반환.
- * OAuth 행(chatgpt)은 사용자별 세션 격리 미해결로 항상 direct (LiteLLM 의 공용 device 인증 구조로는 사용자별 격리 불가 — 2026-07-31 스파이크 No-Go).
+ *
+ * OAuth 행(chatgpt)은 사용자별 세션 격리 미해결로 항상 direct — LiteLLM 의 공용 device 인증
+ * 구조로는 사용자별 격리가 불가하다(2026-07-31 스파이크 No-Go).
+ *
+ * ⚠️ 불변식: 게이트웨이 `api_base` 는 **서버 통제 값**만 쓴다(SSRF 우회 방지). 사용자별 동적
+ * endpoint 를 받는 provider 는 게이트웨이로 표현할 수 없다 — 구 ollama-local 이 이 이유로
+ * 예외 목록에 있었고, 그 provider 폐기(2026-08-23)로 목록 자체가 비어 제거됐다. 같은 성격의
+ * provider 를 다시 도입한다면 여기서 direct 로 분기시켜야 한다.
  */
 function resolveGatewayRoute(providerId: string, authMethod: string): GatewayRouteOptions | undefined {
     if (authMethod === 'oauth') return undefined;
-    if (GATEWAY_EXCLUDED_PROVIDERS.has(providerId)) return undefined;
     const cfg = getConfig();
     if (!cfg.llmGatewayProviders.includes(providerId)) return undefined;
     return {

--- a/apps/api/src/services/chat-service/provider-gate.ts
+++ b/apps/api/src/services/chat-service/provider-gate.ts
@@ -40,7 +40,6 @@ const KNOWN_FULLID_PREFIXES: readonly string[] = [
     'local-llm',
     'openrouter',
     'chatgpt',
-    'ollama-local',
     'ollama-cloud',
     'nvidia',
 ];

--- a/apps/web/components/model-picker.tsx
+++ b/apps/web/components/model-picker.tsx
@@ -24,7 +24,6 @@ export type PickerModel = {
 /** provider id → 1단계 표시 라벨 (신규 provider 는 일반 처리 `🌐 {id}`) */
 const EXTERNAL_PROVIDER_LABELS: Record<string, string> = {
   openrouter: "🌐 OpenRouter",
-  "ollama-local": "🌐 Ollama (Local)",
   "ollama-cloud": "🌐 Ollama Cloud",
   nvidia: "🌐 NVIDIA NIM",
 };


### PR DESCRIPTION
## 배경

`ollama-local` 은 사용자 자기 PC 의 Ollama 서버에 붙는 provider 입니다. **사용자별 동적 endpoint** 라 정적 LiteLLM deployment 로 표현할 수 없어, `GATEWAY_EXCLUDED_PROVIDERS` 에 등록된 유일한 direct 예외였습니다.

경유시키려면 게이트웨이가 **사용자가 준 임의 URL 로 나가야** 하는데, 현재 불변식은 "게이트웨이 `api_base` 는 서버 통제 값만 허용"(SSRF 우회 방지)입니다. 즉 이관 자체가 보안 방어를 깨는 방향이라 **폐기**를 택합니다.

실사용도 사실상 없습니다.
- `user_external_api_keys` 에 ollama-local 행 **0건** (등록한 사용자 없음)
- `external_provider_usage` 30건은 과거 기록 — 이력 테이블이라 그대로 보존
- 사용하려면 LAN IP 를 서버 `.env` `SSRF_ALLOWED_HOSTS` 에 운영자가 등록해야 해서 진입 장벽도 높았습니다

## 변경

- `EXTERNAL_PROVIDER_CATALOG` 엔트리 삭제
- `provider-gate` 의 `KNOWN_FULLID_PREFIXES` 에서 제거 — 이제 이 접두어가 들어오면 로컬 모델 태그로 폴백합니다(모르는 model id → default fallback, 기존 계약)
- **`GATEWAY_EXCLUDED_PROVIDERS` Set 제거** — 유일 원소가 빠져 빈 껍데기가 됐습니다. 다만 "사용자별 동적 endpoint provider 는 게이트웨이로 표현할 수 없다"는 **보안 불변식은 `resolveGatewayRoute` 주석으로 옮겨 보존**했습니다. 같은 성격의 provider 를 다시 도입하면 거기서 direct 로 분기시켜야 한다는 안내까지 남겼습니다
- 프론트 `model-picker` 라벨, `env.ts`/`env.schema.ts` 의 예외 서술 정리
- `gateway-routing` 테스트에서 해당 케이스 제거

## 남는 direct 경로

`chatgpt`(OAuth) 하나입니다. LiteLLM 의 device 인증이 프로세스 공용이라 사용자별 세션 격리가 불가하고(2026-07-31 스파이크 No-Go), 실사용 407회로 가장 활발한 외부 provider 입니다. 구조적 예외로 유지합니다.

이로써 **direct 경로는 anthropic(#587) → ollama-local(이 PR) 순으로 정리되어 chatgpt 만 남습니다.**

## 검증

- API 전체 유닛 **2,788건 통과**
- `npm run lint` 0 errors, 백엔드·프론트 `tsc --noEmit` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)