### PR TITLE
feat(models): 모델 능력 해석 SoT + 도구 호출 부팅 프로브 — 교체 시 도구 무력화 차단

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,6 +114,12 @@ LLM_TIMEOUT=120000                              # HTTP 요청 타임아웃 (ms)
 # 모델 capability 매핑은 backend/api/src/config/model-defaults.ts 의
 # MODEL_CAPABILITY_PRESETS prefix 매칭 (longest match). 새 model prefix 가 매칭 안 되면
 # 보수적 default (toolCalling: true / thinking: false / vision: false / streaming: true).
+# 로컬 모델 능력 override (JSON) — 모델 접두어 → capability. 배포 없이 신규 모델 대응.
+# 해석 순서: 이 env > MODEL_CAPABILITY_PRESETS(코드) > 부팅 프로브 실측(toolCalling) > 보수적 기본값.
+# vision·thinking 은 실측하지 않으므로(비용·신뢰도) 새 모델에서 켜려면 여기서 지정한다.
+# 예: {"llama-4":{"toolCalling":true,"vision":true}}
+# LLM_MODEL_CAPABILITIES_JSON=
+
 # LLM_LOCAL_MODELS_JSON=
 #
 # 가용성 처리:

--- a/apps/api/src/__tests__/contracts/models-contract.test.ts
+++ b/apps/api/src/__tests__/contracts/models-contract.test.ts
@@ -15,14 +15,18 @@ jest.mock('../../auth', () => ({
 jest.mock('../../config/model-roles', () => ({
     getModelForRole: () => 'test-model',
 }));
+const LOCAL_ENTRIES = [
+    { id: 'test-model', displayName: 'Test Model', description: '테스트 로컬 모델', contextLength: 262144 },
+    { id: 'down-model', displayName: 'Down', description: '비가용', available: false, unavailableReason: 'probe 실패' },
+];
 jest.mock('../../config/local-models', () => ({
-    getLocalChatModels: () => [
-        { id: 'test-model', displayName: 'Test Model', description: '테스트 로컬 모델', contextLength: 262144 },
-        { id: 'down-model', displayName: 'Down', description: '비가용', available: false, unavailableReason: 'probe 실패' },
-    ],
+    getLocalChatModels: () => LOCAL_ENTRIES,
+    // 능력 해석이 프로브 실측치를 참조하므로 라우트가 이 조회를 함께 쓴다.
+    findLocalModel: (id: string) => LOCAL_ENTRIES.find((m) => m.id === id),
 }));
 const caps = { thinking: true, vision: true, toolCalling: true, streaming: true };
 jest.mock('../../config/model-defaults', () => ({
+    resolveLocalCapabilities: () => caps,
     matchCapabilityPreset: () => caps,
     FALLBACK_CAPABILITIES: caps,
 }));

--- a/apps/api/src/chat/model-selector.ts
+++ b/apps/api/src/chat/model-selector.ts
@@ -27,7 +27,8 @@ import { MODEL_CONTEXT_DEFAULTS } from '../config/runtime-limits';
 import { QUERY_TYPE_PARAMS, LLM_TOP_P } from '../config/llm-parameters';
 import { recommendTokenBudget } from './complexity-assessor';
 import { getModelPresets } from '../config/model-presets';
-import { matchCapabilityPreset } from '../config/model-defaults';
+import { matchCapabilityPreset, resolveLocalCapabilities } from '../config/model-defaults';
+import { findLocalModel } from '../config/local-models';
 
 const logger = createLogger('ModelSelector');
 
@@ -133,12 +134,12 @@ export function checkModelCapability(
 ): boolean {
     const lowerModel = modelName.toLowerCase();
 
-    // 1차: 모델별 정확한 프리셋 (preset-authoritative — startsWith-longest 공유 매처).
-    // 카탈로그 모델의 실제 capability 가 generic profile 보다 우선한다. 이로써
-    // checkModelCapability 가 게이팅 경로(getCapabilities)와 동일한 SoT 를 따른다.
-    const presetCaps = matchCapabilityPreset(lowerModel);
-    if (presetCaps) {
-        return presetCaps[capability];
+    // 1차: 게이팅 경로(local-llm-provider.getCapabilities)와 **동일한 SoT** —
+    // env override → 프리셋 → 부팅 프로브 실측. 프리셋 미등록 모델도 여기서 실측이 반영된다.
+    const preset = matchCapabilityPreset(lowerModel);
+    const probed = findLocalModel(modelName)?.probedCapabilities;
+    if (preset || probed) {
+        return resolveLocalCapabilities(lowerModel, probed)[capability];
     }
 
     // 2차: profile fallback (generic 'local-llm' 프리셋) — preset 미등록이나

--- a/apps/api/src/config/capability-resolution.test.ts
+++ b/apps/api/src/config/capability-resolution.test.ts
@@ -1,0 +1,69 @@
+/**
+ * 로컬 모델 능력 해석 SoT — 프리셋 미등록 모델에서 도구가 조용히 꺼지던 문제 회귀.
+ *
+ * 과거 사고: `matchCapabilityPreset` 이 null 이면 FALLBACK(toolCalling=false)으로 떨어지고
+ * external-tool-plan 이 도구 목록을 통째로 비워, 모델 교체 시 채팅 도구가 전면 불능이 됐다.
+ * (model-defaults.ts 주석에 기록된 실제 사례.) 이제 부팅 프로브 실측이 그 공백을 메운다.
+ */
+import {
+    FALLBACK_CAPABILITIES,
+    resetCapabilityOverrideCache,
+    resolveLocalCapabilities,
+} from './model-defaults';
+
+describe('resolveLocalCapabilities', () => {
+    const saved = process.env.LLM_MODEL_CAPABILITIES_JSON;
+    beforeEach(() => {
+        delete process.env.LLM_MODEL_CAPABILITIES_JSON;
+        resetCapabilityOverrideCache();
+    });
+    afterAll(() => {
+        if (saved !== undefined) process.env.LLM_MODEL_CAPABILITIES_JSON = saved;
+        else delete process.env.LLM_MODEL_CAPABILITIES_JSON;
+        resetCapabilityOverrideCache();
+    });
+
+    it('프리셋이 있으면 그대로 쓴다 (기존 동작 보존)', () => {
+        const caps = resolveLocalCapabilities('qwen3.6-35b-a3b');
+        expect(caps).toMatchObject({ toolCalling: true, thinking: true, vision: true });
+    });
+
+    it('프리셋 미등록 + 프로브 없음 → 보수적 기본값 (기존과 동일)', () => {
+        expect(resolveLocalCapabilities('llama-3.3-70b-instruct')).toEqual(FALLBACK_CAPABILITIES);
+    });
+
+    it('프리셋 미등록이어도 프로브가 도구 지원을 확인하면 도구를 켠다 (핵심 회귀)', () => {
+        const caps = resolveLocalCapabilities('llama-3.3-70b-instruct', { toolCalling: true });
+        expect(caps.toolCalling).toBe(true);
+        // 실측하지 않은 축은 보수적으로 유지 — 잘못 켜면 upstream 400 이다.
+        expect(caps.vision).toBe(false);
+        expect(caps.thinking).toBe(false);
+    });
+
+    it('프로브가 미지원으로 판정하면 도구를 끈다', () => {
+        expect(resolveLocalCapabilities('some-model', { toolCalling: false }).toolCalling).toBe(false);
+    });
+
+    it('프리셋이 있으면 프로브보다 우선한다 (실측 확정 지식 보존)', () => {
+        expect(resolveLocalCapabilities('qwen3.6-35b-a3b', { toolCalling: false }).toolCalling).toBe(true);
+    });
+
+    it('env override 가 프리셋·프로브를 모두 이긴다', () => {
+        process.env.LLM_MODEL_CAPABILITIES_JSON = JSON.stringify({
+            'qwen3.6': { vision: false },
+            'llama-4': { toolCalling: true, vision: true },
+        });
+        resetCapabilityOverrideCache();
+        expect(resolveLocalCapabilities('qwen3.6-35b-a3b').vision).toBe(false);
+        expect(resolveLocalCapabilities('qwen3.6-35b-a3b').toolCalling).toBe(true); // 미지정 축은 프리셋 유지
+        expect(resolveLocalCapabilities('llama-4-scout', { toolCalling: false })).toMatchObject({
+            toolCalling: true, vision: true,
+        });
+    });
+
+    it('잘못된 env 는 무시하고 프리셋으로 진행한다 (부팅 실패 금지)', () => {
+        process.env.LLM_MODEL_CAPABILITIES_JSON = '{"qwen3.6": {"toolCalling": "yes"}}';
+        resetCapabilityOverrideCache();
+        expect(resolveLocalCapabilities('qwen3.6-35b-a3b').toolCalling).toBe(true);
+    });
+});

--- a/apps/api/src/config/local-models.ts
+++ b/apps/api/src/config/local-models.ts
@@ -44,6 +44,12 @@ export interface LocalModelEntry {
     available?: boolean;
     /** 가용성 실패 사유 — UI tooltip 표시용 */
     unavailableReason?: string;
+    /**
+     * 부팅 프로브로 **실측한** 능력 (현재 toolCalling 만). 프리셋에 없는 모델로 교체해도
+     * 도구가 조용히 전부 꺼지지 않도록 하는 안전망 — 해석 우선순위는
+     * `config/model-defaults.resolveModelCapabilities` 참고. 프로브 미실행/실패 시 undefined.
+     */
+    probedCapabilities?: { toolCalling?: boolean };
 }
 
 /**
@@ -98,6 +104,12 @@ export function getLocalModels(): LocalModelEntry[] {
     return _cached;
 }
 
+/** id 로 카탈로그 엔트리 조회 (프로브 실측치 참조용). 미등록이면 undefined. */
+export function findLocalModel(modelId: string): LocalModelEntry | undefined {
+    return getLocalModels().find((m) => m.id === modelId);
+}
+
+
 /**
  * chat 역할 모델 반환.
  * @param opts.includeUnavailable true 면 available=false 모델도 포함 (UI dimmed 표시용)
@@ -134,6 +146,66 @@ export function resetLocalModelsCache(): void {
  * 200 응답 + completion content/reasoning 있으면 가용.
  * 500 / timeout / connection error 면 미가용.
  */
+/**
+ * 도구 호출 지원 실측 — 더미 도구 1개를 붙여 1-token 요청을 보낸다.
+ *
+ * 목적: 모델을 교체했을 때 `MODEL_CAPABILITY_PRESETS` 접두어에 안 걸리면 보수적 기본값
+ * (toolCalling=false)으로 떨어져 **채팅의 MCP 도구가 통째로 사라지던** 문제(과거 실사고)를
+ * 자동으로 막는다. 200 이면 지원, 도구 관련 4xx 면 미지원으로 본다.
+ *
+ * 판정 불가(네트워크 오류·타임아웃·5xx)는 `undefined` — 호출부가 프리셋/기본값을 유지한다
+ * (일시 오류로 능력을 잘못 낮추지 않는다).
+ */
+/**
+ * 도구 지원 프로브용 더미 도구 — 모델이 호출할 이유가 없는 최소 스키마.
+ * (실제 호출 여부가 아니라 **요청이 수용되는지**만 본다.)
+ */
+const TOOL_PROBE_DEFINITION = {
+    type: 'function' as const,
+    function: {
+        name: 'omk_capability_probe',
+        description: 'internal capability probe — do not call',
+        parameters: { type: 'object', properties: {}, additionalProperties: false },
+    },
+};
+
+async function probeToolCalling(
+    baseUrl: string,
+    apiKey: string | undefined,
+    modelId: string,
+    timeoutMs: number,
+): Promise<boolean | undefined> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        const res = await fetch(baseUrl.replace(/\/$/, '') + '/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+            },
+            body: JSON.stringify({
+                model: modelId,
+                messages: [{ role: 'user', content: 'hi' }],
+                max_tokens: MODEL_PROBE.MAX_TOKENS,
+                stream: false,
+                chat_template_kwargs: { enable_thinking: false },
+                tools: [TOOL_PROBE_DEFINITION],
+                tool_choice: 'auto',
+            }),
+            signal: controller.signal,
+        });
+        if (res.ok) return true;
+        // 4xx = 요청 형태 거절 → 도구 미지원으로 판정. 5xx/기타는 판정 보류.
+        if (res.status >= 400 && res.status < 500) return false;
+        return undefined;
+    } catch {
+        return undefined;
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
 async function pingChatModel(
     baseUrl: string,
     apiKey: string | undefined,
@@ -280,10 +352,16 @@ export async function probeLocalModelAvailability(
     }
 
     const pingResults = await Promise.all(pingTargets.map(async m => {
-        const r = m.role === 'embedding'
-            ? await pingEmbeddingModel(llmBaseUrl, apiKey, m.id, timeoutMs)
-            : await pingChatModel(llmBaseUrl, apiKey, m.id, timeoutMs);
-        return { model: m, result: r };
+        if (m.role === 'embedding') {
+            return { model: m, result: await pingEmbeddingModel(llmBaseUrl, apiKey, m.id, timeoutMs) };
+        }
+        const result = await pingChatModel(llmBaseUrl, apiKey, m.id, timeoutMs);
+        // 살아 있는 chat 모델만 도구 지원을 실측 — 죽은 모델에 추가 요청을 낭비하지 않는다.
+        if (result.ok) {
+            const toolCalling = await probeToolCalling(llmBaseUrl, apiKey, m.id, timeoutMs);
+            if (toolCalling !== undefined) m.probedCapabilities = { toolCalling };
+        }
+        return { model: m, result };
     }));
 
     const available: string[] = [];
@@ -299,10 +377,14 @@ export async function probeLocalModelAvailability(
             missing.push(`${model.id} (${result.reason})`);
         }
     }
+    const toolProbe = pingTargets
+        .filter(m => m.probedCapabilities?.toolCalling !== undefined)
+        .map(m => `${m.id}:tools=${m.probedCapabilities?.toolCalling}`);
     logger.info(
         `probe 완료: available=${available.length} [${available.join(',')}] ` +
         `missing=${missing.length} [${missing.join(' | ')}] ` +
-        `skipped=${skipped.length} [${skipped.join(',')}]`,
+        `skipped=${skipped.length} [${skipped.join(',')}]` +
+        (toolProbe.length ? ` | 능력 실측 [${toolProbe.join(',')}]` : ''),
     );
     return { probed: true, available, missing, skipped };
 }

--- a/apps/api/src/config/model-defaults.ts
+++ b/apps/api/src/config/model-defaults.ts
@@ -98,3 +98,87 @@ export function matchCapabilityPreset(modelId: string): ModelCapabilities | null
     }
     return best;
 }
+
+/**
+ * ============================================================
+ * 로컬 모델 능력 해석 (SoT)
+ * ============================================================
+ *
+ * 배경: 능력을 **모델명 접두어 프리셋**으로만 판정하다 보니, 프리셋에 없는 모델로 교체하면
+ * `FALLBACK_CAPABILITIES`(toolCalling=false)로 떨어져 채팅의 MCP 도구가 통째로 사라졌다.
+ * 에러가 아니라 조용한 축소라 알아채기 어렵다(코드 주석에 과거 사고가 기록돼 있다).
+ *
+ * 해석 순서 (앞이 이길수록 신뢰도 높음):
+ *   ① env `LLM_MODEL_CAPABILITIES_JSON` — 운영자 명시 override (배포 없이 대응)
+ *   ② `MODEL_CAPABILITY_PRESETS` — 실측으로 확정한 모델별 프리셋
+ *   ③ 부팅 프로브 실측 (`probedCapabilities`, 현재 toolCalling 만) — 미등록 모델 안전망
+ *   ④ `FALLBACK_CAPABILITIES` — 전부 보수적 false
+ *
+ * vision·thinking 은 프로브 비용/신뢰도 문제로 실측하지 않는다(이미지 필요, reasoning 은
+ * 출력 형식 의존). 이 둘은 ①②만 반영되며 미상이면 보수적으로 꺼진 채 남는다 —
+ * 잘못 켜면 400 이지만, 꺼져 있으면 기능 축소에 그친다.
+ */
+export interface ProbedCapabilities {
+    toolCalling?: boolean;
+}
+
+let _capsOverride: Readonly<Record<string, Partial<ModelCapabilities>>> | null = null;
+
+/** 테스트 훅 — env 변경 후 캐시 리셋. */
+export function resetCapabilityOverrideCache(): void {
+    _capsOverride = null;
+}
+
+function getCapabilityOverrides(): Readonly<Record<string, Partial<ModelCapabilities>>> {
+    if (_capsOverride) return _capsOverride;
+    const raw = process.env.LLM_MODEL_CAPABILITIES_JSON;
+    const out: Record<string, Partial<ModelCapabilities>> = {};
+    if (raw) {
+        try {
+            const parsed = JSON.parse(raw) as Record<string, Record<string, unknown>>;
+            for (const [prefix, caps] of Object.entries(parsed)) {
+                const picked: Partial<ModelCapabilities> = {};
+                for (const k of ['toolCalling', 'thinking', 'vision', 'streaming'] as const) {
+                    if (typeof caps?.[k] === 'boolean') picked[k] = caps[k] as boolean;
+                }
+                if (Object.keys(picked).length > 0) out[prefix.toLowerCase()] = picked;
+            }
+        } catch { /* 형식 오류는 무시 — 프리셋/프로브로 진행 */ }
+    }
+    _capsOverride = out;
+    return _capsOverride;
+}
+
+/** override 접두어 매칭 — 프리셋과 동일한 startsWith-longest 규칙. */
+function matchOverride(modelId: string): Partial<ModelCapabilities> | null {
+    const lower = modelId.toLowerCase();
+    let best: Partial<ModelCapabilities> | null = null;
+    let bestLen = -1;
+    for (const [prefix, caps] of Object.entries(getCapabilityOverrides())) {
+        if (lower.startsWith(prefix) && prefix.length > bestLen) {
+            best = caps;
+            bestLen = prefix.length;
+        }
+    }
+    return best;
+}
+
+/**
+ * 로컬 모델의 최종 능력. 위 해석 순서를 한 곳에서 적용한다.
+ * @param probed 부팅 프로브 실측치 (`LocalModelEntry.probedCapabilities`)
+ */
+export function resolveLocalCapabilities(
+    modelId: string,
+    probed?: ProbedCapabilities,
+): ModelCapabilities {
+    const preset = matchCapabilityPreset(modelId);
+    const base: ModelCapabilities = preset
+        ? { ...preset }
+        : {
+            ...FALLBACK_CAPABILITIES,
+            // 프리셋 미등록 — 실측이 있으면 그것으로 도구 지원을 결정한다(조용한 무력화 차단).
+            ...(probed?.toolCalling !== undefined ? { toolCalling: probed.toolCalling } : {}),
+        };
+    const override = matchOverride(modelId);
+    return override ? { ...base, ...override } : base;
+}

--- a/apps/api/src/providers/local-llm-provider.ts
+++ b/apps/api/src/providers/local-llm-provider.ts
@@ -32,7 +32,8 @@ import {
 import { ProviderError } from './provider-errors';
 import type { LLMClient } from '../llm';
 import type { ToolCall, UsageMetrics } from '../llm';
-import { matchCapabilityPreset, FALLBACK_CAPABILITIES } from '../config/model-defaults';
+import { findLocalModel } from '../config/local-models';
+import { resolveLocalCapabilities } from '../config/model-defaults';
 import { LLM_ANTI_DEGENERATION_FREQUENCY_PENALTY } from '../config/llm-parameters';
 import { LLM_TIMEOUTS } from '../config/timeouts';
 import { estimateMessageTokens } from '../llm/model-pool';
@@ -71,10 +72,13 @@ export class LocalLLMProvider implements IProvider {
 
     constructor(private client: LLMClient) {}
 
-    /** modelId 를 공유 매처(startsWith-longest)로 룩업; 미정의 시 보수적 FALLBACK. */
+    /**
+     * 능력 해석은 `resolveLocalCapabilities` 단일 SoT 를 따른다
+     * (env override → 프리셋 → 부팅 프로브 실측 → 보수적 기본값).
+     * 프리셋에 없는 모델로 교체해도 도구가 조용히 전부 꺼지지 않는다.
+     */
     getCapabilities(modelId: string): ProviderCapabilities {
-        const caps = matchCapabilityPreset(modelId);
-        return caps ? { ...caps } : { ...FALLBACK_CAPABILITIES };
+        return resolveLocalCapabilities(modelId, findLocalModel(modelId)?.probedCapabilities);
     }
 
     async listModels(): Promise<ProviderModel[]> {

--- a/apps/api/src/routes/model.routes.ts
+++ b/apps/api/src/routes/model.routes.ts
@@ -18,8 +18,8 @@ import { success } from '../utils/api-response';
 import { asyncHandler } from '../utils/error-handler';
 import { createLogger } from '../utils/logger';
 import { getModelForRole } from '../config/model-roles';
-import { matchCapabilityPreset, FALLBACK_CAPABILITIES } from '../config/model-defaults';
-import { getLocalChatModels } from '../config/local-models';
+import { resolveLocalCapabilities } from '../config/model-defaults';
+import { getLocalChatModels, findLocalModel } from '../config/local-models';
 import { requireAuth, requireAdmin, optionalAuth } from '../auth';
 import { getModelHealthMonitor } from '../services/model-health-monitor';
 import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
@@ -98,9 +98,12 @@ router.get('/models', optionalAuth, asyncHandler(async (req: Request, res: Respo
         pricing?: { input: number; output: number };
     };
 
-    /** model id → 공유 매처(startsWith-longest)로 capability 조회; 미정의 시 보수적 FALLBACK. */
+    /**
+     * model id → capability. 실행 경로(local-llm-provider)와 **같은 SoT** 를 쓴다 —
+     * UI 표기와 실제 게이팅이 어긋나지 않게 하기 위함(env override·프리셋·부팅 프로브 실측).
+     */
     function capsFor(modelId: string) {
-        return matchCapabilityPreset(modelId) ?? FALLBACK_CAPABILITIES;
+        return resolveLocalCapabilities(modelId, findLocalModel(modelId)?.probedCapabilities);
     }
 
     // Local models catalog — config/local-models.ts (서버 proxy 가 model 명으로 라우팅)


### PR DESCRIPTION
## 고치는 문제

능력을 **모델명 접두어 프리셋**으로만 판정하다 보니, 프리셋에 없는 모델로 교체하면 `FALLBACK_CAPABILITIES`(toolCalling=false)로 떨어지고 `external-tool-plan.ts:84` 가 도구 목록을 통째로 비웁니다. 에러가 아니라 **조용한 축소**라 알아채기 어렵습니다. `model-defaults.ts` 주석에 과거 같은 사고("tools=0 전면 불능")가 이미 기록돼 있습니다.

빌드본으로 실행해 재현했습니다.

```
qwen3.6-35b-a3b          프리셋 매칭      | tools=true  vision=true  thinking=true
llama-3.3-70b-instruct   미매칭→FALLBACK  | tools=false vision=false thinking=false
mistral-large            미매칭→FALLBACK  | tools=false ...
gpt-oss-120b             미매칭→FALLBACK  | tools=false ...
qwen3.8-27b              미매칭→FALLBACK  | tools=false ...
```

교체 후보로 실측까지 했던 `qwen3.8-27b` 조차 여기서 걸립니다.

## 접근

게이트웨이 메타데이터(`/model/info` 의 `supports_*`)를 먼저 검토했지만, LiteLLM 은 자체 가격표에 있는 모델만 채우고 **커스텀 `openai/*` 배포는 전부 null** 이라 지금은 쓸 수 없었습니다(라이브 확인). 그래서 **실측 프로브**로 갑니다.

**`resolveLocalCapabilities` 단일 SoT** 신설 — 해석 순서:

1. env `LLM_MODEL_CAPABILITIES_JSON` (운영자 명시 override, 배포 없이 대응)
2. `MODEL_CAPABILITY_PRESETS` (실측으로 확정한 지식)
3. **부팅 프로브 실측** (`probedCapabilities.toolCalling`) ← 이번에 추가
4. `FALLBACK_CAPABILITIES` (보수적 false)

**도구 호출 부팅 프로브** (`probeToolCalling`): 살아 있는 chat 모델에 더미 도구 1개를 붙여 1-token 요청을 보냅니다. `200` = 지원, `4xx` = 미지원, `5xx`·타임아웃 = **판정 보류**(일시 오류로 능력을 잘못 낮추지 않습니다). 기존 `probeLocalModelAvailability` 안에서 ping 성공 모델에만 1회 추가되므로 부팅 비용은 요청 1개입니다.

라이브 검증(게이트웨이 경유):

| 요청 | 결과 |
|---|---|
| qwen3.6 + 더미 도구 | HTTP 200 → toolCalling=true |
| 존재하지 않는 모델 | HTTP 400 → 미지원 판정 경로 정상 |

## vision·thinking 을 실측하지 않는 이유

vision 은 프로브에 이미지가 필요하고, thinking 은 출력 형식 의존이라 판정이 흔들립니다. 게다가 **잘못 켜면 upstream 400** 이지만 꺼져 있으면 기능 축소에 그칩니다. 그래서 이 둘은 프리셋·env 만 반영하고 미상이면 보수적으로 둡니다 — 새 모델에서 켜려면 `LLM_MODEL_CAPABILITIES_JSON` 으로 지정합니다.

## 그 외

- 소비 지점 3곳(`local-llm-provider.getCapabilities`·`model.routes.capsFor`·`model-selector.checkModelCapability`)을 같은 SoT 로 통일 — **UI 표기와 실제 게이팅이 어긋나지 않습니다**
- `models-contract` 테스트 mock 을 새 모듈 계약에 맞춤(이 변경으로 500 이 나던 2건 수정)

## 검증

- 신규 유닛 **7건**(프리셋 우선·프로브 반영·env override·잘못된 env 폴백·미실측 축 보수 유지)
- API 전체 **2,795건 통과**, `npm run lint` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)