### PR TITLE
feat(models): 컨텍스트 길이 부팅 실측 — 262K 고정 임계 제거

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -167,6 +167,9 @@ LLM_WEEKLY_TOKEN_LIMIT=5000000
 # (2026-06-15: 1M 노드 제거 — 262K↔1M proactive routing 폐기.)
 # LLM_POOL_ENABLED=true                            # false 시 안전망 비활성 (원본 그대로 전송)
 # LLM_POOL_DEFAULT_MODEL=qwen3.6-35b-a3b          # chat 모델 id
+# 유효 컨텍스트 상한. **미지정이 권장** — 미지정이면 부팅 프로브가 백엔드에서 실측한다
+# (불가능한 max_tokens 요청의 오류 메시지에서 max_model_len 을 읽음). 값을 명시하면
+# 실측치를 무시하고 이 값을 쓰므로, 모델 교체 시 임계가 어긋날 수 있다.
 # LLM_POOL_DEFAULT_CTX=262144                     # 모델 nominal context
 # LLM_POOL_DEFAULT_MARGIN_PCT=10                  # safety margin %
 # LLM_POOL_ROUTING_MAX_TOKENS_DEFAULT=16384       # max_tokens 미지정 시 계산용

--- a/apps/api/src/config/context-resolution.test.ts
+++ b/apps/api/src/config/context-resolution.test.ts
@@ -1,0 +1,68 @@
+/**
+ * 유효 컨텍스트 해석 — 262K 고정으로 인해 모델 교체 시 안전망이 무력화되던 문제 회귀.
+ *
+ * 과거 구조: `MODEL_POOL_CONFIG.effectiveDefault` = 262144 * 0.9 고정.
+ * 컨텍스트가 더 짧은 모델(예: 32K)로 교체하면 임계에 영영 못 닿아 그대로 전송 → upstream 400,
+ * 더 긴 모델이면 불필요하게 잘라냈다. 이제 부팅 프로브 실측치를 쓴다.
+ */
+import type { LocalModelEntry } from './local-models';
+
+const mockEntries: LocalModelEntry[] = [];
+jest.mock('./local-models', () => ({
+    findLocalModel: (id: string) => mockEntries.find((m) => m.id === id),
+}));
+
+describe('resolveEffectiveContext', () => {
+    const savedCtx = process.env.LLM_POOL_DEFAULT_CTX;
+    const savedMargin = process.env.LLM_POOL_DEFAULT_MARGIN_PCT;
+
+    function load(): typeof import('./model-pool') {
+        jest.resetModules();
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        return require('./model-pool');
+    }
+
+    beforeEach(() => {
+        mockEntries.length = 0;
+        delete process.env.LLM_POOL_DEFAULT_CTX;
+        delete process.env.LLM_POOL_DEFAULT_MARGIN_PCT;
+    });
+    afterAll(() => {
+        if (savedCtx !== undefined) process.env.LLM_POOL_DEFAULT_CTX = savedCtx;
+        if (savedMargin !== undefined) process.env.LLM_POOL_DEFAULT_MARGIN_PCT = savedMargin;
+    });
+
+    it('실측치가 없으면 기본값 262144 에 마진 10% (기존 동작)', () => {
+        expect(load().resolveEffectiveContext('unknown-model')).toBe(235929);
+    });
+
+    it('부팅 프로브 실측치를 반영한다 — 짧은 모델 (핵심 회귀)', () => {
+        mockEntries.push({
+            id: 'short-model', displayName: 's', description: '', role: 'chat',
+            contextLength: 32768, contextLengthProbed: true,
+        });
+        // 32768 * 0.9 = 29491 — 262144 고정이었다면 임계에 못 닿아 안전망이 죽었다.
+        expect(load().resolveEffectiveContext('short-model')).toBe(29491);
+    });
+
+    it('부팅 프로브 실측치를 반영한다 — 긴 모델 (불필요한 절단 방지)', () => {
+        mockEntries.push({
+            id: 'long-model', displayName: 'l', description: '', role: 'chat',
+            contextLength: 1_048_576, contextLengthProbed: true,
+        });
+        expect(load().resolveEffectiveContext('long-model')).toBe(943718);
+    });
+
+    it('env 명시값이 실측치를 이긴다 (운영자 override 우선)', () => {
+        process.env.LLM_POOL_DEFAULT_CTX = '65536';
+        mockEntries.push({
+            id: 'short-model', displayName: 's', description: '', role: 'chat',
+            contextLength: 32768, contextLengthProbed: true,
+        });
+        expect(load().resolveEffectiveContext('short-model')).toBe(58982);
+    });
+
+    it('modelId 미지정이면 기본값을 쓴다', () => {
+        expect(load().resolveEffectiveContext()).toBe(235929);
+    });
+});

--- a/apps/api/src/config/local-models.ts
+++ b/apps/api/src/config/local-models.ts
@@ -50,6 +50,11 @@ export interface LocalModelEntry {
      * `config/model-defaults.resolveModelCapabilities` 참고. 프로브 미실행/실패 시 undefined.
      */
     probedCapabilities?: { toolCalling?: boolean };
+    /**
+     * `contextLength` 가 부팅 프로브로 **실측**된 값이면 true. 카탈로그 기본값(추정)과
+     * 구분해 로그·진단에서 신뢰도를 드러낸다.
+     */
+    contextLengthProbed?: boolean;
 }
 
 /**
@@ -157,9 +162,64 @@ export function resetLocalModelsCache(): void {
  * (일시 오류로 능력을 잘못 낮추지 않는다).
  */
 /**
+ * 컨텍스트 길이 실측 — 불가능한 max_tokens 를 요청해 백엔드가 돌려주는 상한을 읽는다.
+ *
+ * 근거(라이브 실측 2026-08-23, LiteLLM 경유):
+ *   400 "max_tokens=99999999 cannot be greater than max_model_len=max_total_tokens=262144"
+ * 즉 오류 메시지에 모델의 실제 컨텍스트가 들어온다. 게이트웨이 `/v1/models`·`/model/info`
+ * 는 커스텀 배포에 대해 이 값을 노출하지 않아(둘 다 null 확인) 이 방법을 쓴다.
+ *
+ * 목적: `LLM_POOL_DEFAULT_CTX` 기본값 262144 가 모델과 무관하게 고정돼 있어, 컨텍스트가
+ * 더 짧은 모델로 교체하면 안전망 임계에 영영 못 닿아 그대로 전송 → upstream 400 이 되고,
+ * 더 긴 모델이면 불필요하게 잘라내던 문제를 없앤다.
+ *
+ * 판정 불가(패턴 불일치·네트워크 오류 등)는 undefined — 호출부가 기존 값을 유지한다.
+ */
+async function probeContextLength(
+    baseUrl: string,
+    apiKey: string | undefined,
+    modelId: string,
+    timeoutMs: number,
+): Promise<number | undefined> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        const res = await fetch(baseUrl.replace(/\/$/, '') + '/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+            },
+            body: JSON.stringify({
+                model: modelId,
+                messages: [{ role: 'user', content: 'hi' }],
+                max_tokens: CONTEXT_PROBE_MAX_TOKENS,
+                stream: false,
+                chat_template_kwargs: { enable_thinking: false },
+            }),
+            signal: controller.signal,
+        });
+        // 200 이면 상한을 알 수 없다(요청이 그대로 수용됨) — 판정 보류.
+        if (res.ok) return undefined;
+        const body = await res.text();
+        const m = body.match(/max_model_len=(?:max_total_tokens=)?(\d+)/)
+            ?? body.match(/maximum context length is (\d+)/i);
+        const n = m ? parseInt(m[1], 10) : NaN;
+        return Number.isFinite(n) && n > 0 ? n : undefined;
+    } catch {
+        return undefined;
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+/**
  * 도구 지원 프로브용 더미 도구 — 모델이 호출할 이유가 없는 최소 스키마.
  * (실제 호출 여부가 아니라 **요청이 수용되는지**만 본다.)
  */
+/** 컨텍스트 프로브용 max_tokens — 어떤 모델도 수용하지 못할 값이어야 상한이 오류로 드러난다. */
+const CONTEXT_PROBE_MAX_TOKENS = 99_999_999;
+
 const TOOL_PROBE_DEFINITION = {
     type: 'function' as const,
     function: {
@@ -356,10 +416,17 @@ export async function probeLocalModelAvailability(
             return { model: m, result: await pingEmbeddingModel(llmBaseUrl, apiKey, m.id, timeoutMs) };
         }
         const result = await pingChatModel(llmBaseUrl, apiKey, m.id, timeoutMs);
-        // 살아 있는 chat 모델만 도구 지원을 실측 — 죽은 모델에 추가 요청을 낭비하지 않는다.
+        // 살아 있는 chat 모델만 능력·컨텍스트를 실측 — 죽은 모델에 추가 요청을 낭비하지 않는다.
         if (result.ok) {
-            const toolCalling = await probeToolCalling(llmBaseUrl, apiKey, m.id, timeoutMs);
+            const [toolCalling, ctx] = await Promise.all([
+                probeToolCalling(llmBaseUrl, apiKey, m.id, timeoutMs),
+                probeContextLength(llmBaseUrl, apiKey, m.id, timeoutMs),
+            ]);
             if (toolCalling !== undefined) m.probedCapabilities = { toolCalling };
+            if (ctx !== undefined) {
+                m.contextLength = ctx;
+                m.contextLengthProbed = true;
+            }
         }
         return { model: m, result };
     }));
@@ -378,8 +445,13 @@ export async function probeLocalModelAvailability(
         }
     }
     const toolProbe = pingTargets
-        .filter(m => m.probedCapabilities?.toolCalling !== undefined)
-        .map(m => `${m.id}:tools=${m.probedCapabilities?.toolCalling}`);
+        .filter(m => m.probedCapabilities?.toolCalling !== undefined || m.contextLengthProbed)
+        .map(m => {
+            const parts: string[] = [];
+            if (m.probedCapabilities?.toolCalling !== undefined) parts.push(`tools=${m.probedCapabilities.toolCalling}`);
+            if (m.contextLengthProbed) parts.push(`ctx=${m.contextLength}`);
+            return `${m.id}:${parts.join(',')}`;
+        });
     logger.info(
         `probe 완료: available=${available.length} [${available.join(',')}] ` +
         `missing=${missing.length} [${missing.join(' | ')}] ` +

--- a/apps/api/src/config/model-pool.ts
+++ b/apps/api/src/config/model-pool.ts
@@ -25,6 +25,8 @@ function parseBoolEnv(key: string, defaultValue: boolean): boolean {
 const enabled = parseBoolEnv('LLM_POOL_ENABLED', true);
 const defaultModel = process.env.LLM_POOL_DEFAULT_MODEL ?? 'qwen3.6-35b-a3b';
 const defaultCtx = parseIntEnv('LLM_POOL_DEFAULT_CTX', 262144);
+/** env 로 **명시**됐는지 — 명시값은 프로브 실측보다 우선한다(운영자 의도 존중). */
+const ctxExplicit = process.env.LLM_POOL_DEFAULT_CTX !== undefined && process.env.LLM_POOL_DEFAULT_CTX !== '';
 const defaultMarginPct = parseIntEnv('LLM_POOL_DEFAULT_MARGIN_PCT', 10);
 const routingMaxTokensDefault = parseIntEnv('LLM_POOL_ROUTING_MAX_TOKENS_DEFAULT', 16384);
 const minOutputTokens = parseIntEnv('LLM_POOL_MIN_OUTPUT_TOKENS', 4096);
@@ -42,5 +44,36 @@ export const MODEL_POOL_CONFIG = {
     minOutputTokens,
     tokensPerImage,
     // derived effective capacity (nominal * (1 - margin/100))
+    /** @deprecated 모델 무관 고정값 — 안전망은 resolveEffectiveContext(modelId) 를 쓴다. 진단·표시용으로만 잔존. */
     effectiveDefault: Math.floor(defaultCtx * (1 - defaultMarginPct / 100)),
 } as const;
+
+/**
+ * 대상 모델의 **유효 컨텍스트**(마진 적용 후) 해석 — 안전망 임계값의 SoT.
+ *
+ * 해석 순서:
+ *   ① env `LLM_POOL_DEFAULT_CTX` 명시 — 운영자 override (최우선)
+ *   ② 부팅 프로브 실측 (`LocalModelEntry.contextLength`, contextLengthProbed=true)
+ *   ③ 카탈로그 선언값 → ④ 코드 기본값(262144)
+ *
+ * 배경: ②가 없던 시절엔 262144 고정이라 컨텍스트가 더 짧은 모델로 교체하면 임계에 영영
+ * 못 닿아 그대로 전송 → upstream 400, 더 긴 모델이면 불필요하게 잘라냈다.
+ */
+export function resolveEffectiveContext(modelId?: string): number {
+    const nominal = resolveNominalContext(modelId);
+    return Math.floor(nominal * (1 - defaultMarginPct / 100));
+}
+
+/** 마진 적용 전 컨텍스트(진단·로그용). */
+export function resolveNominalContext(modelId?: string): number {
+    if (ctxExplicit) return defaultCtx;
+    if (modelId) {
+        // 순환 import 방지를 위해 지연 로드 (local-models 는 config 계층 내부 모듈).
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { findLocalModel } = require('./local-models') as typeof import('./local-models');
+        const entry = findLocalModel(modelId);
+        if (entry?.contextLength && entry.contextLength > 0) return entry.contextLength;
+    }
+    return defaultCtx;
+}
+

--- a/apps/api/src/llm/model-pool.ts
+++ b/apps/api/src/llm/model-pool.ts
@@ -10,7 +10,7 @@
  *
  * @module llm/model-pool
  */
-import { MODEL_POOL_CONFIG } from '../config/model-pool';
+import { MODEL_POOL_CONFIG, resolveEffectiveContext } from '../config/model-pool';
 import { ContextOverflowError } from '../errors/context-overflow.error';
 import type { ChatMessage, ModelOptions } from './types';
 
@@ -120,16 +120,17 @@ export function truncateMessagesPreservingSystem(
  *   2단계: max_tokens 축소 (최소 MIN_OUTPUT_TOKENS 보장)
  *   3단계: 극단 (system 단독으로도 초과) — ContextOverflowError throw
  *
- * (호출 시점에 input + requested 가 effectiveDefault 를 이미 초과한 상태.)
+ * (호출 시점에 input + requested 가 유효 컨텍스트를 이미 초과한 상태.)
  */
 export function reduceToFit(
     messages: ChatMessage[],
     options: Pick<ModelOptions, 'num_predict'>,
 ): ModelPoolDecision {
     const requested = options.num_predict ?? MODEL_POOL_CONFIG.routingMaxTokensDefault;
-    const effective = MODEL_POOL_CONFIG.effectiveDefault;
-    const minOutput = MODEL_POOL_CONFIG.minOutputTokens;
     const model = MODEL_POOL_CONFIG.defaultModel;
+    // 임계값은 대상 모델 기준 — env 명시 > 부팅 프로브 실측 > 카탈로그 > 기본값.
+    const effective = resolveEffectiveContext(model);
+    const minOutput = MODEL_POOL_CONFIG.minOutputTokens;
 
     // 1단계: input truncate
     const inputBudget = effective - requested - SAFETY_BUFFER;
@@ -162,7 +163,7 @@ export function reduceToFit(
 
     // 3단계: 극단
     throw new ContextOverflowError(
-        `메시지가 262K 토큰 한계 초과 (input=${newInputTokens}, limit=${effective}). 입력을 줄여주세요.`,
+        `메시지가 모델 컨텍스트 한계를 초과했습니다 (input=${newInputTokens}, limit=${effective}). 입력을 줄여주세요.`,
         newInputTokens,
         effective,
     );
@@ -197,7 +198,7 @@ export function selectModelByCapacity(
     const estimatedOutput = options.num_predict ?? MODEL_POOL_CONFIG.routingMaxTokensDefault;
     const required = inputTokens + estimatedOutput;
 
-    if (required <= MODEL_POOL_CONFIG.effectiveDefault) {
+    if (required <= resolveEffectiveContext(MODEL_POOL_CONFIG.defaultModel)) {
         return {
             model: MODEL_POOL_CONFIG.defaultModel,
             source: 'auto',


### PR DESCRIPTION
## 고치는 문제

context-fit 안전망의 임계가 `LLM_POOL_DEFAULT_CTX ?? 262144` 로 **모델과 무관하게 고정**돼 있었습니다. 안전망이 사실상 현행 모델 전용이었던 셈입니다.

- **컨텍스트가 더 짧은 모델(예: 32K)로 교체** → 임계(약 236K)에 영영 못 닿아 초과 입력이 그대로 전송 → **upstream 400**. 방어가 있어야 할 자리에서 방어가 죽습니다
- **더 긴 모델(1M)** → 236K 에서 불필요하게 잘라내 컨텍스트를 낭비

## 어떻게 실측하나

게이트웨이는 이 값을 알려주지 않습니다 — `/v1/models` 는 `{id, object, created, owned_by}` 뿐이고 `/model/info` 의 `max_input_tokens`·`max_tokens` 도 커스텀 배포는 **전부 null** 입니다(라이브 확인).

대신 **오류 메시지에 실제 값이 들어옵니다.**

```
400 max_tokens=99999999 cannot be greater than max_model_len=max_total_tokens=262144
```

그래서 `probeContextLength` 는 불가능한 `max_tokens` 를 한 번 요청해 이 상한을 읽습니다. 200 응답(상한 미도달)이나 패턴 불일치는 **판정 보류**로 기존 값을 유지합니다. 라이브에서 정규식이 `262144` 를 정확히 추출하는 것을 확인했습니다.

## 해석 순서

`resolveEffectiveContext(modelId)` 를 SoT 로 신설했습니다.

1. env `LLM_POOL_DEFAULT_CTX` **명시** — 운영자 override (최우선)
2. **부팅 프로브 실측** ← 이번에 추가
3. 카탈로그 선언값
4. 기본값 262144

여기에 마진(`LLM_POOL_DEFAULT_MARGIN_PCT`, 기본 10%)을 적용한 값이 안전망 임계가 됩니다. `reduceToFit`·`selectModelByCapacity` 가 이 함수를 씁니다.

## 그 외

- `MODEL_POOL_CONFIG.effectiveDefault` 는 `@deprecated` 로 두고 진단·표시용으로만 잔존(기존 테스트 계약 유지)
- `ContextOverflowError` 메시지의 `"262K"` 하드코딩 제거 — 실제 limit 을 표기
- 부팅 로그에 실측치 노출: `능력 실측 [qwen3.6-35b-a3b:tools=true,ctx=262144]`
- `.env.example`: `LLM_POOL_DEFAULT_CTX` 는 **미지정 권장**임을 명시(값을 쓰면 실측을 덮어써 모델 교체 시 임계가 어긋남)

`.env` 에 이 값이 설정돼 있지 않으므로 운영은 배포 즉시 실측 경로를 탑니다.

## 검증

- 신규 유닛 **5건** — 짧은 모델(32K→29491)·긴 모델(1M→943718) 실측 반영, env 명시 우선, modelId 미지정 폴백
- API 전체 **2,800건 통과**, `npm run lint` 0 errors
- 라이브: 정규식이 실제 400 응답에서 262144 추출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)