### PR TITLE
fix(llm): repeat_penalty 가 전송되지 않던 매핑 버그 — vLLM 이름으로 정정

### DIFF
--- a/apps/api/src/llm/sampling-params.test.ts
+++ b/apps/api/src/llm/sampling-params.test.ts
@@ -1,0 +1,45 @@
+/**
+ * 샘플링 파라미터 매핑 회귀.
+ *
+ * 배경(라이브 실측 2026-08-23): 내부 옵션 이름 `repeat_penalty` 는 Ollama 시절 유산이라
+ * vLLM 이 모르는 필드다. 그대로 보내도 조용히 무시되고(같은 프롬프트에서 출력이 기본값과
+ * 완전히 동일), 애초에 요청 매핑에 없어 전송조차 되지 않았다. vLLM 이 받는 이름은
+ * `repetition_penalty` 이며 이 값으로 보내면 출력이 실제로 달라진다.
+ */
+import { applyOptionsToRequest } from './stream-parser';
+
+describe('applyOptionsToRequest — 샘플링 파라미터 매핑', () => {
+    it('repeat_penalty 를 vLLM 이름(repetition_penalty)으로 매핑한다 (핵심 회귀)', () => {
+        const p = applyOptionsToRequest({ repeat_penalty: 1.15 });
+        expect(p.repetition_penalty).toBe(1.15);
+        // 내부 이름은 전송하지 않는다 — vLLM 이 무시하므로 노이즈일 뿐이다.
+        expect(p.repeat_penalty).toBeUndefined();
+    });
+
+    it('미지정이면 아무 penalty 도 싣지 않는다 (서버 기본값 위임)', () => {
+        expect(applyOptionsToRequest({ temperature: 0.7 })).toEqual({ temperature: 0.7 });
+        expect(applyOptionsToRequest(undefined)).toEqual({});
+    });
+
+    it('표준 파라미터는 그대로 전달한다', () => {
+        const p = applyOptionsToRequest({
+            temperature: 0.3, top_p: 0.9, num_predict: 512, seed: 7, stop: ['x'],
+            presence_penalty: 0.1, frequency_penalty: 0.2,
+        });
+        expect(p).toMatchObject({
+            temperature: 0.3, top_p: 0.9, max_tokens: 512, seed: 7, stop: ['x'],
+            presence_penalty: 0.1, frequency_penalty: 0.2,
+        });
+    });
+
+    it('top_k 는 vLLM 확장으로 그대로 전달된다 (게이트웨이 수용 확인됨)', () => {
+        expect(applyOptionsToRequest({ top_k: 40 }).top_k).toBe(40);
+    });
+
+    it('0 같은 falsy 값도 누락하지 않는다', () => {
+        const p = applyOptionsToRequest({ temperature: 0, frequency_penalty: 0, repeat_penalty: 0 });
+        expect(p.temperature).toBe(0);
+        expect(p.frequency_penalty).toBe(0);
+        expect(p.repetition_penalty).toBe(0);
+    });
+});

--- a/apps/api/src/llm/stream-parser.ts
+++ b/apps/api/src/llm/stream-parser.ts
@@ -153,7 +153,18 @@ function toOpenAITools(tools: ToolDefinition[]): unknown[] {
     }));
 }
 
-function applyOptionsToRequest(options?: ChatRequest['options']): Record<string, unknown> {
+/**
+ * ModelOptions → OpenAI 호환 요청 파라미터.
+ *
+ * ⚠️ 이름 매핑 주의 (라이브 실측 2026-08-23, LiteLLM 게이트웨이 경유):
+ *   - `repeat_penalty`(내부 이름, Ollama 시절 유산)는 vLLM 이 **모르는 필드**라 그대로
+ *     보내면 조용히 무시된다. 반복 억제를 켜려면 `repetition_penalty` 로 보내야 한다.
+ *     실증: 같은 프롬프트에 repetition_penalty=2.0 은 출력이 바뀌고, repeat_penalty=2.0 은
+ *     기본값과 **완전히 동일**했다. 그동안 이 옵션은 매핑 자체가 없어 전송되지도 않았다.
+ *   - `top_k`·`repetition_penalty` 는 OpenAI 표준이 아닌 vLLM 확장이다. 운영 게이트웨이는
+ *     둘 다 수용(200 확인)하지만, 표준만 받는 백엔드로 바꾸면 400 이 날 수 있다.
+ */
+export function applyOptionsToRequest(options?: ChatRequest['options']): Record<string, unknown> {
     if (!options) return {};
     const params: Record<string, unknown> = {};
     if (options.temperature !== undefined) params.temperature = options.temperature;
@@ -165,6 +176,8 @@ function applyOptionsToRequest(options?: ChatRequest['options']): Record<string,
     // OpenAI/vLLM native penalty 파라미터 (presence_penalty / frequency_penalty).
     if (options.presence_penalty !== undefined) params.presence_penalty = options.presence_penalty;
     if (options.frequency_penalty !== undefined) params.frequency_penalty = options.frequency_penalty;
+    // 내부 repeat_penalty → vLLM repetition_penalty (위 주석 참고).
+    if (options.repeat_penalty !== undefined) params.repetition_penalty = options.repeat_penalty;
     return params;
 }
 


### PR DESCRIPTION
## 버그

내부 옵션 `repeat_penalty` 는 Ollama 시절 이름이라 vLLM 이 모르는 필드입니다. 게다가 `applyOptionsToRequest` 매핑 목록에 **아예 없어서 전송조차 되지 않았습니다** — 호출부가 값을 넣어도 조용히 사라집니다.

라이브 실측(LiteLLM 게이트웨이 경유, 동일 프롬프트·`temperature=0`):

| 요청 | 출력 |
|---|---|
| 기본 | `ㄱㄱㄱㄱㄱㄱ…` |
| `repetition_penalty=2.0` | `가 가 гa a gа а га ga ag…` ← 반복 억제 적용됨 |
| `repeat_penalty=2.0` | `ㄱㄱㄱㄱㄱㄱ…` ← **기본과 완전히 동일 = 무시됨** |

## 수정

- `repeat_penalty` → **`repetition_penalty`** 매핑 추가. 내부 이름은 전송하지 않습니다(vLLM 이 무시하므로 노이즈)
- `top_k`·`repetition_penalty` 가 OpenAI 표준이 아닌 **vLLM 확장**임을 주석에 명시했습니다. 운영 게이트웨이는 둘 다 200 으로 수용하는 것을 확인했지만, 표준만 받는 백엔드로 교체하면 400 이 날 수 있는 지점입니다
- 테스트를 위해 `applyOptionsToRequest` 를 export 하고 회귀 5건 추가 — 매핑, 미지정 시 미전송(서버 기본값 위임), 표준 파라미터 통과, `top_k` 전달, `0` 같은 falsy 값 누락 방지

## 조사 중 발견한 더 큰 문제 (이 PR 범위 밖)

이 매핑을 고쳐도 **채팅 경로의 샘플링 튜닝은 여전히 동작하지 않습니다.** 별개의 결함이라 분리해 보고합니다.

`selectOptimalModel()`(`chat/model-selector.ts`)은 질의 유형별로 `temperature`·`top_p`·`top_k`·`repeat_penalty` 를 계산해 `options` 로 반환하는데, 유일한 소비자인 `ws-chat-handler.ts:118` 이 **`.model` 만 꺼내 쓰고 `.options` 는 버립니다.**

```ts
const optimalModel = await selectOptimalModel(message);
selectedModel = optimalModel.model;   // options 는 사용되지 않음
```

실제로 채팅 경로(`local-llm-provider.streamChat`)가 보내는 것은 `temperature`(외부에서 미설정 → undefined)·`num_predict`·`frequency_penalty` 뿐입니다. 즉 `QUERY_TYPE_PARAMS` 의 유형별 튜닝(코드/창작/수학/번역별 temperature·penalty)과 `adjustOptionsForModel()` 전체가 **채팅에서 죽은 코드**이고, 샘플링은 vLLM 서버 기본값에 위임되고 있습니다.

선택지는 두 가지입니다.
1. **배선 연결** — 유형별 튜닝을 실제로 적용. 운영 샘플링 동작이 바뀌므로 A/B 실측이 선행돼야 합니다
2. **죽은 코드 제거** — `adjustOptionsForModel` 과 반환 타입의 `options`, 관련 `QUERY_TYPE_PARAMS` 항목 정리

이 레포의 관행(measure-first, 죽은 계층 제거)상 2번이 자연스러워 보이지만, 판단이 필요한 사안이라 이번 PR 에 넣지 않았습니다.

## 검증

- 신규 유닛 **5건** + API 전체 **2,805건 통과**, `npm run lint` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)