### PR TITLE
feat(chat): 구조화 답변 degrade — json_schema 미지원·스키마 불일치에 422 로 죽지 않게

### DIFF
--- a/apps/api/src/routes/chat.routes.ts
+++ b/apps/api/src/routes/chat.routes.ts
@@ -370,11 +370,16 @@ router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncH
             logger.warn(`[structured] 대화 기록 저장 실패 (continue): ${persistErr instanceof Error ? persistErr.message : persistErr}`);
         }
 
+        if (composed.degraded) {
+            logger.warn(`[structured] degrade 응답 (${composed.degraded}) — model=${usedModel}`);
+        }
         res.json(success({
             intent: composed.intent,
             structured: composed.structured,
             markdown: composed.markdown,
             model: usedModel,
+            // 정상 경로가 아니면 사유를 함께 노출 — 클라이언트가 신뢰도를 판단할 수 있게.
+            ...(composed.degraded ? { degraded: composed.degraded } : {}),
             ...(savedSessionId ? { sessionId: savedSessionId } : {}),
         }));
     } catch (err) {

--- a/apps/api/src/services/answer-composer.degrade.test.ts
+++ b/apps/api/src/services/answer-composer.degrade.test.ts
@@ -1,0 +1,62 @@
+/**
+ * 구조화 답변 degrade 경로 — json_schema 미지원·스키마 불일치에서 422 로 죽지 않게 한다.
+ *
+ * 배경: 이전엔 ① 백엔드가 response_format 을 거절하면 예외가 그대로 전파되고
+ * ② 2회 시도 후 스키마가 어긋나면 무조건 422 였다. 모델/백엔드를 바꾸면 구조화 엔드포인트가
+ * 통째로 죽는 셈이라, 답을 주는 쪽으로 degrade 한다(사유는 결과에 표기).
+ */
+import { composeStructuredAnswer } from './answer-composer';
+
+const VALID = JSON.stringify({
+    intent: 'explanation', title: 'T', conclusion: 'C', summary: 'S',
+    sections: [{ heading: 'H', body: 'B' }], confidence: 'high',
+});
+
+describe('composeStructuredAnswer — degrade', () => {
+    it('정상 경로는 degraded 를 남기지 않는다', async () => {
+        const r = await composeStructuredAnswer({ message: '설명해줘', chat: async () => VALID });
+        expect(r.structured.title).toBe('T');
+        expect(r.degraded).toBeUndefined();
+    });
+
+    it('백엔드가 json_schema 를 거절하면 스키마 없이 재시도한다 (format_unsupported)', async () => {
+        const calls: Array<boolean> = [];
+        const r = await composeStructuredAnswer({
+            message: '설명해줘',
+            chat: async (_m, format) => {
+                calls.push(!!format);
+                if (format) throw new Error('400 BadRequestError: response_format json_schema is not supported');
+                return VALID;
+            },
+        });
+        expect(calls).toEqual([true, false]);   // 포맷 시도 → 포맷 없이 재호출
+        expect(r.degraded).toBe('format_unsupported');
+        expect(r.structured.title).toBe('T');
+    });
+
+    it('포맷과 무관한 오류는 그대로 전파한다 (오진 방지)', async () => {
+        await expect(composeStructuredAnswer({
+            message: '설명해줘',
+            chat: async () => { throw new Error('ECONNREFUSED upstream down'); },
+        })).rejects.toThrow(/ECONNREFUSED/);
+    });
+
+    it('2회 스키마 실패 후 평문을 최소 구조로 감싸 반환한다 (schema_invalid)', async () => {
+        let n = 0;
+        const r = await composeStructuredAnswer({
+            message: '서울 인구를 알려줘',
+            chat: async () => { n += 1; return n <= 2 ? '이건 JSON 이 아님' : '서울 인구는 약 940만 명입니다.'; },
+        });
+        expect(n).toBe(3);                       // 시도 2회 + 평문 1회
+        expect(r.degraded).toBe('schema_invalid');
+        expect(r.structured.conclusion).toContain('940만');
+        expect(r.structured.confidence).toBe('low');   // 검증 미통과를 정직하게 표기
+        expect(r.markdown).toContain('940만');
+    });
+
+    it('평문 fallback 마저 비어 있으면 422 로 실패한다', async () => {
+        await expect(composeStructuredAnswer({
+            message: 'x', chat: async () => '  ',
+        })).rejects.toMatchObject({ statusCode: 422 });
+    });
+});

--- a/apps/api/src/services/answer-composer.test.ts
+++ b/apps/api/src/services/answer-composer.test.ts
@@ -182,8 +182,14 @@ describe('answer-composer: composeStructuredAnswer', () => {
         expect(r.structured.intent).toBe('decision');
     });
 
-    it('계속 실패 → 422 throw', async () => {
+    // 2026-08-23 계약 변경: 스키마를 못 맞춰도 422 로 죽지 않고 평문을 최소 구조로 감싸
+    // degrade 한다(모델/백엔드 교체 시 구조화 엔드포인트가 통째로 죽는 것을 막기 위함).
+    // 내용조차 비었을 때만 422 — 그 케이스는 answer-composer.degrade.test.ts 가 고정한다.
+    it('계속 스키마 실패 → 422 대신 평문 degrade', async () => {
         const chat: StructuredChatFn = async () => 'not json at all';
-        await expect(composeStructuredAnswer({ message: 'x', chat })).rejects.toMatchObject({ statusCode: 422 });
+        const r = await composeStructuredAnswer({ message: 'x', chat });
+        expect(r.degraded).toBe('schema_invalid');
+        expect(r.structured.conclusion).toBe('not json at all');
+        expect(r.structured.confidence).toBe('low');
     });
 });

--- a/apps/api/src/services/answer-composer.ts
+++ b/apps/api/src/services/answer-composer.ts
@@ -33,7 +33,11 @@ import type { ChatMessage, FormatOption } from '../llm/types';
 const logger = createLogger('AnswerComposer');
 
 /** 주입되는 LLM 호출 함수 — (messages, json_schema) → raw content. 비스트리밍. */
-export type StructuredChatFn = (messages: ChatMessage[], format: FormatOption) => Promise<string>;
+/**
+ * 구조화 답변용 1회 LLM 호출. `format` 이 undefined 면 **스키마 강제 없이** 호출한다
+ * (guided decoding 미지원 백엔드로의 degrade 경로 — 외부 provider 경로는 원래 format 을 무시한다).
+ */
+export type StructuredChatFn = (messages: ChatMessage[], format?: FormatOption) => Promise<string>;
 
 /**
  * StructuredAnswer → 일정한 마크다운 (제안서 8절 formatAnswer 정확 구현).
@@ -89,6 +93,24 @@ function renderTable(headers: string[], rows: string[][]): string {
 }
 
 /** json_schema 출력에서 객체를 안전 파싱 (혹시 모를 마크다운 펜스 제거). */
+/** degrade 시 title 로 쓸 원 질문 길이 상한 — 제목이 본문처럼 길어지지 않게. */
+const MAX_FALLBACK_TITLE_CHARS = 80;
+
+function errText(e: unknown): string {
+    return e instanceof Error ? e.message : String(e);
+}
+
+/**
+ * 백엔드가 response_format(json_schema/guided decoding)을 거절한 오류인가.
+ * 백엔드마다 문구가 달라 보수적으로 키워드 매칭한다 — 오탐이 나도 스키마 없이 한 번 더
+ * 호출할 뿐이라 손해가 작고, 미탐이면 기존처럼 예외가 그대로 전파된다.
+ */
+function isFormatUnsupportedError(e: unknown): boolean {
+    const msg = errText(e).toLowerCase();
+    if (!/\b(400|422|unsupported|not support|invalid[_ ]request)\b/.test(msg)) return false;
+    return /response_format|json_schema|guided|structured output|schema/.test(msg);
+}
+
 function parseStructured(raw: string): unknown {
     const trimmed = raw.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '');
     return JSON.parse(trimmed);
@@ -98,6 +120,12 @@ export interface ComposeResult {
     intent: AnswerIntent;
     structured: StructuredAnswer;
     markdown: string;
+    /**
+     * 정상 경로가 아니면 그 사유. 관측·로그용이며 응답은 정상 반환된다.
+     *  - `format_unsupported`: 백엔드가 json_schema(guided decoding)를 거절 → 스키마 없이 재시도
+     *  - `schema_invalid`: 2회 시도 후에도 스키마 불일치 → 평문 답변을 최소 구조로 감싸 반환
+     */
+    degraded?: 'format_unsupported' | 'schema_invalid';
 }
 
 /**
@@ -127,8 +155,23 @@ export async function composeStructuredAnswer(opts: {
         { role: 'user', content: userContent },
     ];
 
+    let degraded: ComposeResult['degraded'];
+
+    /**
+     * 1회 시도. 백엔드가 json_schema 를 거절하면(guided decoding 미지원) **스키마 없이**
+     * 한 번 더 호출한다 — 외부 provider 경로가 원래 그렇게 동작하므로 프롬프트만으로도
+     * 유효 JSON 이 나올 수 있다. 이 경로를 타면 degraded 사유를 남긴다.
+     */
     const attempt = async (msgs: ChatMessage[]): Promise<StructuredAnswer | null> => {
-        const raw = await opts.chat(msgs, STRUCTURED_ANSWER_FORMAT);
+        let raw: string;
+        try {
+            raw = await opts.chat(msgs, STRUCTURED_ANSWER_FORMAT);
+        } catch (e) {
+            if (!isFormatUnsupportedError(e)) throw e;
+            logger.warn(`백엔드가 json_schema 를 거절 — 스키마 없이 재시도: ${errText(e).slice(0, 160)}`);
+            degraded = 'format_unsupported';
+            raw = await opts.chat(msgs);
+        }
         let parsed: unknown;
         try {
             parsed = parseStructured(raw);
@@ -148,9 +191,33 @@ export async function composeStructuredAnswer(opts: {
             { role: 'system', content: getRepairHint(lang) },
         ]);
     }
+
     if (!structured) {
-        throw new AppError('구조화 답변 검증 실패 (스키마 불일치)', 422, true, 'STRUCTURED_OUTPUT_INVALID');
+        // 최후 degrade — 스키마를 못 맞추는 모델이라도 **답은 준다**. 평문 1회 호출 결과를
+        // 최소 구조로 감싼다(confidence=low: 구조 검증을 통과하지 못했음을 정직하게 표기).
+        // 여기서도 내용이 없을 때만 422 로 실패한다.
+        logger.warn('구조화 2회 실패 — 평문 답변으로 degrade');
+        const plain = (await opts.chat(messages)).trim();
+        if (!plain) {
+            throw new AppError('구조화 답변 검증 실패 (스키마 불일치)', 422, true, 'STRUCTURED_OUTPUT_INVALID');
+        }
+        degraded = 'schema_invalid';
+        structured = {
+            intent,
+            title: opts.message.slice(0, MAX_FALLBACK_TITLE_CHARS),
+            conclusion: plain,
+            summary: '',
+            sections: [],
+            confidence: 'low',
+        };
     }
 
-    return { intent, structured, markdown: formatAnswer(structured, lang) };
+    const finalAnswer: StructuredAnswer = structured;
+
+    return {
+        intent,
+        structured: finalAnswer,
+        markdown: formatAnswer(finalAnswer, lang),
+        ...(degraded ? { degraded } : {}),
+    };
 }


### PR DESCRIPTION
## 고치는 문제

구조화 엔드포인트(`POST /api/chat/structured`)가 두 지점에서 fail-closed 였습니다.

1. 백엔드가 `response_format`(json_schema / guided decoding)을 거절하면 예외가 그대로 전파 → 요청 실패
2. 2회 시도 후에도 스키마가 어긋나면 무조건 **422 `STRUCTURED_OUTPUT_INVALID`**

모델이나 백엔드를 바꾸면 이 엔드포인트가 통째로 죽는 구조입니다. 참고로 현행 게이트웨이는 json_schema strict 를 정상 지원하는 것을 라이브로 확인했으므로, 이건 **교체 내성** 문제입니다.

## 변경 — 답을 주는 쪽으로 degrade

**① json_schema 거절 → 스키마 없이 1회 재호출.** 외부 provider 경로는 원래 `format` 을 무시하고 프롬프트만으로 JSON 을 받고 있으므로 같은 방식으로 수렴합니다. 판정은 보수적 키워드 매칭(`400|422|unsupported…` × `response_format|json_schema|guided|schema`)이고, **오탐이면 포맷 없이 한 번 더 호출할 뿐**, 미탐이면 기존처럼 예외가 전파됩니다. `ECONNREFUSED` 같은 무관한 오류가 degrade 로 오인되지 않는 것을 테스트로 고정했습니다.

**② 2회 스키마 실패 → 평문 1회 호출 결과를 최소 구조로 감쌉니다.** `confidence: 'low'` 로 표기해 구조 검증을 통과하지 못했음을 정직하게 드러냅니다. **내용조차 비었을 때만 422** 로 실패합니다.

**관측**: `ComposeResult.degraded`(`format_unsupported` | `schema_invalid`)를 추가해 라우트가 warn 로그를 남기고 응답에도 함께 노출합니다 — 클라이언트가 신뢰도를 판단할 수 있고, 조용한 품질 저하가 되지 않습니다.

## 계약 변경

기존 테스트 `'계속 실패 → 422 throw'` 는 이 변경으로 무효가 되어 degrade 검증으로 갱신했습니다. 422 자체가 사라진 것은 아니고 **"내용이 아예 없을 때"** 로 조건이 좁아졌습니다.

## 검증

- 신규 유닛 **5건** — 정상 경로 무영향, format 거절 시 재시도 순서(`[true, false]`), 무관한 오류 전파, 평문 degrade 내용·confidence, 빈 응답 422
- 서비스·라우트·계약 **625건 통과**, `npm run lint` 0 errors, `tsc` 통과

⚠️ 로컬 전체 병렬 실행은 `TypeError: pgPass is not a function` 환경 flake 로 막혔습니다. #593 과 동일 증상이고 그때 CI 는 통과했습니다. 본 변경은 DB 경로를 건드리지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)