### PR TITLE
feat(chat): 외부 provider 구조화 요청에 json_schema 전달 — 프롬프트만으로는 필드 누락

### DIFF
--- a/apps/api/src/llm/stream-parser.ts
+++ b/apps/api/src/llm/stream-parser.ts
@@ -84,7 +84,7 @@ type OpenAIChatResponse = {
  * FormatOption → vLLM/OpenAI response_format 변환.
  * vLLM 지원 타입: json_object | json_schema | structural_tag | text (docs.vllm.ai 2026-03 기준).
  */
-function toResponseFormat(f: FormatOption | undefined): Record<string, unknown> | undefined {
+export function toResponseFormat(f: FormatOption | undefined): Record<string, unknown> | undefined {
     if (!f) return undefined;
     if (f === 'json') return { type: 'json_object' };
     return {

--- a/apps/api/src/providers/i-provider.ts
+++ b/apps/api/src/providers/i-provider.ts
@@ -122,6 +122,13 @@ export interface ChatStreamOptions {
     thinking?: boolean | ReasoningEffort | { budget: number };
     /** 사용 가능한 도구 목록 */
     tools?: ToolDefinition[];
+    /**
+     * 응답 포맷 강제 (OpenAI `response_format` 원본 형태). 구조화 답변 경로에서 json_schema 를
+     * 넘겨 스키마를 **모델에 강제**한다 — 프롬프트만으로는 required 필드가 누락된다(실측:
+     * chatgpt:gpt-5.6-luna 가 intent·sections 를 빠뜨려 검증 2회 실패 → degrade).
+     * 지원하지 않는 provider 는 400 을 낼 수 있으나, answer-composer 가 포맷 없이 1회 재시도한다.
+     */
+    responseFormat?: Record<string, unknown>;
     /** 도구 선택 강제 — 특정 도구를 반드시 호출하게 하거나(function) 도구 사용을 강제/차단. vLLM tool_choice 시맨틱. */
     tool_choice?: 'auto' | 'none' | 'required' | { type: 'function'; function: { name: string } };
     /** 호출 취소 신호 (사용자 중단/타임아웃) */

--- a/apps/api/src/providers/openai-compat-format.test.ts
+++ b/apps/api/src/providers/openai-compat-format.test.ts
@@ -1,0 +1,32 @@
+/**
+ * 외부 provider 구조화 요청 — json_schema 를 실제로 실어 보내는지 고정.
+ *
+ * 배경(실측 2026-08-23): 외부 경로가 format 을 무시해 프롬프트만으로 JSON 을 받았고,
+ * chatgpt:gpt-5.6-luna 가 required 필드(intent·sections)를 빠뜨려 검증 2회 실패 → degrade 했다.
+ * 스키마를 모델에 강제해야 한다.
+ */
+import { toResponseFormat } from '../llm/stream-parser';
+import { STRUCTURED_ANSWER_FORMAT } from '../schemas/structured-answer.schema';
+
+describe('구조화 응답 포맷 변환', () => {
+    it('FormatOption → OpenAI response_format(json_schema, strict)', () => {
+        const rf = toResponseFormat(STRUCTURED_ANSWER_FORMAT) as {
+            type: string;
+            json_schema: { strict: boolean; schema: { required: string[] } };
+        };
+        expect(rf.type).toBe('json_schema');
+        expect(rf.json_schema.strict).toBe(true);
+        // required 가 실려야 모델이 intent·sections 를 빠뜨리지 않는다.
+        expect(rf.json_schema.schema.required).toEqual(
+            expect.arrayContaining(['intent', 'title', 'conclusion', 'sections', 'confidence']),
+        );
+    });
+
+    it("'json' 단축형은 json_object 로", () => {
+        expect(toResponseFormat('json')).toEqual({ type: 'json_object' });
+    });
+
+    it('미지정이면 undefined — 요청 body 에 response_format 을 넣지 않는다', () => {
+        expect(toResponseFormat(undefined)).toBeUndefined();
+    });
+});

--- a/apps/api/src/providers/openai-compat-provider.ts
+++ b/apps/api/src/providers/openai-compat-provider.ts
@@ -390,6 +390,7 @@ export class OpenAICompatProvider implements IProvider {
                 max_tokens: opts.maxTokens ?? DEFAULT_MAX_TOKENS,
                 ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
                 ...(tools ? { tools } : {}),
+                ...(opts.responseFormat ? { response_format: opts.responseFormat } : {}),
                 ...openRouterProvider,
                 ...geminiThinkingDisable,
             };

--- a/apps/api/src/routes/chat.routes.ts
+++ b/apps/api/src/routes/chat.routes.ts
@@ -36,6 +36,7 @@ import { LocalLLMProvider } from '../providers/local-llm-provider';
 import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
 import { getPool } from '../data/models/unified-database';
 import { composeStructuredAnswer, type StructuredChatFn } from '../services/answer-composer';
+import { toResponseFormat } from '../llm/stream-parser';
 import { buildWebSearchContext } from '../mcp/web-search/build-search-context';
 import { detectLanguage } from '../chat/language-policy';
 import { getCurrentDate } from '../utils/datetime';
@@ -302,8 +303,10 @@ router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncH
             return result.content ?? '';
         };
     } else {
-        // 외부 provider(Anthropic/OpenRouter 등) — provider 추상화는 json_schema 미지원이라
-        // streamChat 을 집계(비스트리밍)하고 JSON 은 프롬프트 + Validator/재시도로 받는다.
+        // 외부 provider(OpenRouter/ChatGPT 등) — streamChat 을 집계(비스트리밍)하되
+        // json_schema 를 함께 넘겨 스키마를 모델에 강제한다. 프롬프트만으로는 required 필드가
+        // 누락된다(실측 2026-08-23: chatgpt:gpt-5.6-luna 가 intent·sections 를 빠뜨려 검증 2회
+        // 실패 → degrade). 포맷을 거절하는 provider 는 answer-composer 가 포맷 없이 재시도한다.
         const localProvider = new LocalLLMProvider(createClient());
         const providerRouter = new ProviderRouter({
             localProvider,
@@ -312,9 +315,15 @@ router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncH
         // 외부 키는 실제(영속) user id 로만 조회 — 게스트(anon)는 ctxUserId=undefined → GUEST_NOT_ALLOWED.
         const resolved = await providerRouter.resolve(fullId as string, { userId: ctxUserId });
         usedModel = resolved.fullId;
-        chat = async (messages) => {
+        chat = async (messages, format) => {
+            const responseFormat = toResponseFormat(format);
             const result = await resolved.provider.streamChat(
-                { messages, modelId: resolved.modelId, abortSignal: abortController.signal },
+                {
+                    messages,
+                    modelId: resolved.modelId,
+                    abortSignal: abortController.signal,
+                    ...(responseFormat ? { responseFormat } : {}),
+                },
                 {}, // 토큰 콜백 불필요 — 누적 결과(content)만 사용
             );
             return result.content ?? '';


### PR DESCRIPTION
## 어떻게 발견했나

라이브에서 ChatGPT 모델로 구조화 요청을 해 보다가 #594 의 degrade 가 **실제로 처음 발동**했습니다.

```
POST /api/chat/structured  (model=chatgpt:gpt-5.6-luna)
→ degraded: schema_invalid
```

로그를 보니 `구조화 출력 JSON 파싱 실패` 경고는 **없었습니다.** 즉 JSON 파싱은 성공했고 **Zod 검증**에서 걸린 것입니다. 모델이 돌려준 객체에 required 필드인 `intent` 와 `sections` 가 빠져 있었습니다.

## 근본 원인

외부 provider 경로가 **json_schema 를 아예 보내지 않습니다.**

```ts
// chat.routes.ts (기존)
// 외부 provider — provider 추상화는 json_schema 미지원이라
// streamChat 을 집계하고 JSON 은 프롬프트 + Validator/재시도로 받는다.
chat = async (messages) => { ... }   // format 인자를 받지도 않음
```

`IProvider.streamChat` 에 응답 포맷을 넘길 자리가 없어서, 외부 모델에는 "JSON 으로 답해줘"라는 **프롬프트만** 갔습니다. 모델이 required 필드를 지킬 이유가 없었던 겁니다. 로컬 경로는 `LLMClient` 가 `format` 을 받아 처리하므로 이 문제가 없었습니다.

## 변경

- `IProvider.StreamChatOptions` 에 `responseFormat` 추가 (OpenAI `response_format` 원본 형태)
- `openai-compat-provider` 가 요청 body 에 실어 보냄
- `chat.routes` 외부 분기가 `toResponseFormat(format)` 으로 변환해 전달 (기존엔 무시)
- `toResponseFormat` export — 로컬 경로가 쓰던 변환기를 외부 경로도 공유

## 왜 안전한가

포맷을 거절하는 provider 가 있어도 문제없습니다. **#594 의 degrade 가 포맷 없이 1회 재시도**하기 때문입니다. 즉 이 변경은 "지원하면 스키마 강제, 안 하면 기존 동작"으로 수렴합니다 — 어제였다면 이 시도가 위험했겠지만, 오늘 degrade 를 깔아둔 덕에 안전하게 켤 수 있습니다.

## 검증

- 신규 유닛 **3건** — `FormatOption` → `json_schema(strict)` 변환에 required 5개가 실리는지, `'json'` 단축형, 미지정 시 body 미포함
- 서비스·라우트·provider·llm·계약 **773건 통과**, `npm run lint` 0 errors, `tsc` 통과

⚠️ `workspace-reap` 1건은 로컬 `pgPass` 환경 flake 입니다(단독 3/3 통과, 본 변경은 DB 경로 미접촉). #593·#594 와 동일 증상이며 그때 CI 는 통과했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)