### PR TITLE
feat(chat): 답변 검증 — judge 모델이 1회 점검하고 지적만 표시 (자동 수정 없음)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -194,6 +194,18 @@ LLM_WEEKLY_TOKEN_LIMIT=5000000
 # 모델별 지원값 차이는 config/reasoning-effort.ts 가 정규화하므로 켜도 400 이 나지 않는다
 # (실측 2026-08-23: qwen3.6 은 low/medium/high/xhigh, qwen3.8 은 high 를 거절 → xhigh 로 승격).
 LLM_ENABLE_REASONING_EFFORT=false
+
+# 답변 검증 (opt-in, 기본 비활성) — 채팅 답변 완료 후 judge role 모델이 **1회** 점검하고
+# 사실·논리 오류만 지적한다(자동 수정 없음, 지적 없으면 UI 에 아무것도 표시하지 않음).
+# 켜면 채팅 composer 의 "답변 검증" 토글이 실제로 동작하며, 켠 요청에만 비용이 발생한다.
+# 근거(2026-08-23 프로토타입): judge 모델이 로컬 답변의 사실오류를 정확히 지적했으나,
+# 수정 왕복은 2건 중 1건에서 답변을 악화시켜 채택하지 않았다.
+ANSWER_VERIFICATION_ENABLED=false
+# ANSWER_VERIFICATION_MIN_CHARS=200          # 이보다 짧은 답변은 검증 생략
+# ANSWER_VERIFICATION_MAX_ANSWER_CHARS=4000  # judge 에 싣는 답변 상한
+# ANSWER_VERIFICATION_TIMEOUT_MS=20000
+# ANSWER_VERIFICATION_MAX_TOKENS=300
+
 # 모델 접두어별 지원 강도 override (JSON). 새 모델 도입 시 배포 없이 대응.
 # 예: {"qwen3.8":["low","medium","xhigh"],"llama-4":["low","medium","high"]}
 # LLM_REASONING_EFFORTS_JSON=

--- a/apps/api/src/prompts/answer-verification.ts
+++ b/apps/api/src/prompts/answer-verification.ts
@@ -1,0 +1,43 @@
+/**
+ * 답변 검증 프롬프트 — 채팅 답변을 judge 모델이 1회 점검한다.
+ *
+ * 설계 근거(2026-08-23 프로토타입 실측): 로컬 모델이 "국민연금 의무가입 상한 없음" 처럼
+ * 사실과 다른 답을 냈을 때 judge 모델이 정확히 반박했다(4회 비평 모두 구체적 지적, 아첨 없음).
+ * 반면 **수정 왕복은 손해**였다 — 2건 중 1건에서 수정본이 원본보다 나빠졌고(본문 소실),
+ * 2건 모두 수렴하지 않았다. 그래서 여기서는 **지적만 하고 고치지 않는다**.
+ *
+ * "없으면 NONE" 규약은 프로토타입에서 잘 작동했다 — 지적할 게 없을 때 억지 비평을 만들지 않는다.
+ *
+ * @module prompts/answer-verification
+ */
+
+/** 오류 없음 신호 — 이 토큰으로 시작하면 사용자에게 아무것도 표시하지 않는다. */
+export const VERIFICATION_NONE = 'NONE';
+
+export function getAnswerVerificationMessages(
+    userMessage: string,
+    answer: string,
+    lang: 'ko' | 'en',
+): { system: string; user: string } {
+    const system = lang === 'ko'
+        ? [
+            '당신은 다른 AI 답변의 오류를 찾는 검증자다.',
+            '사실오류·논리오류·중요한 누락만 지적한다.',
+            '지적할 것이 없으면 첫 줄에 정확히 "NONE" 만 출력한다.',
+            '칭찬·요약·재작성은 하지 않는다. 답변을 고쳐 쓰지 않는다.',
+            '지적은 최대 3개, 각 한 문장. 확신이 없으면 지적하지 않는다.',
+        ].join('\n')
+        : [
+            'You verify another AI answer and report only its errors.',
+            'Report factual errors, logical errors, or critical omissions only.',
+            'If there is nothing to report, output exactly "NONE" on the first line.',
+            'Do not praise, summarize, or rewrite the answer.',
+            'At most 3 points, one sentence each. If unsure, do not report it.',
+        ].join('\n');
+
+    const user = lang === 'ko'
+        ? `[질문]\n${userMessage}\n\n[답변]\n${answer}`
+        : `[Question]\n${userMessage}\n\n[Answer]\n${answer}`;
+
+    return { system, user };
+}

--- a/apps/api/src/services/chat-service/answer-verifier.test.ts
+++ b/apps/api/src/services/chat-service/answer-verifier.test.ts
@@ -1,0 +1,62 @@
+/**
+ * 답변 검증 — 게이트·NONE 규약·fail-open 고정.
+ *
+ * 설계 근거(2026-08-23 프로토타입 실측): judge 모델이 로컬 답변의 사실오류를 정확히 잡았고
+ * "없으면 NONE" 규약도 잘 지켰다. 반면 수정 왕복은 2건 중 1건에서 답변을 악화시켜(본문 소실)
+ * 채택하지 않았다 — 여기서는 지적만 반환한다.
+ */
+const mockChat = jest.fn();
+jest.mock('../model-role-resolver', () => ({
+    resolveRoleClientForUser: jest.fn(async () => ({
+        client: { derive: () => ({ chat: mockChat }) },
+        fullId: 'chatgpt:gpt-5.6-luna',
+    })),
+}));
+
+const LONG = 'x'.repeat(300);
+
+function load(): typeof import('./answer-verifier') {
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return require('./answer-verifier');
+}
+
+describe('verifyAnswer', () => {
+    const saved = process.env.ANSWER_VERIFICATION_ENABLED;
+    beforeEach(() => { mockChat.mockReset(); process.env.ANSWER_VERIFICATION_ENABLED = 'true'; });
+    afterAll(() => {
+        if (saved !== undefined) process.env.ANSWER_VERIFICATION_ENABLED = saved;
+        else delete process.env.ANSWER_VERIFICATION_ENABLED;
+    });
+
+    it('게이트가 꺼져 있으면 LLM 을 호출하지 않는다', async () => {
+        process.env.ANSWER_VERIFICATION_ENABLED = 'false';
+        const { verifyAnswer } = load();
+        expect(await verifyAnswer('q', LONG)).toBeNull();
+        expect(mockChat).not.toHaveBeenCalled();
+    });
+
+    it('짧은 답변은 검증하지 않는다 (인사·단답)', async () => {
+        const { verifyAnswer } = load();
+        expect(await verifyAnswer('q', '네')).toBeNull();
+        expect(mockChat).not.toHaveBeenCalled();
+    });
+
+    it('NONE 응답은 지적 없음으로 처리한다 (사용자에게 아무것도 안 보임)', async () => {
+        mockChat.mockResolvedValue({ content: 'NONE' });
+        const { verifyAnswer } = load();
+        expect(await verifyAnswer('q', LONG)).toBeNull();
+    });
+
+    it('지적이 있으면 그대로 돌려준다 (자동 수정 없음)', async () => {
+        mockChat.mockResolvedValue({ content: '의무가입 상한은 만 60세 미만이다.' });
+        const { verifyAnswer } = load();
+        expect(await verifyAnswer('q', LONG)).toBe('의무가입 상한은 만 60세 미만이다.');
+    });
+
+    it('검증 실패는 답변에 영향을 주지 않는다 (fail-open)', async () => {
+        mockChat.mockRejectedValue(new Error('upstream 500'));
+        const { verifyAnswer } = load();
+        expect(await verifyAnswer('q', LONG)).toBeNull();
+    });
+});

--- a/apps/api/src/services/chat-service/answer-verifier.ts
+++ b/apps/api/src/services/chat-service/answer-verifier.ts
@@ -68,3 +68,17 @@ export async function verifyAnswer(
         return null;
     }
 }
+
+/**
+ * 검증 디스패치 — done 이후 비동기 실행 + 결과 전달까지 한 곳에.
+ * (소켓 핸들러가 커지지 않도록 분리. 실패는 전부 흡수 — 답변 경로에 영향 0.)
+ */
+export function dispatchAnswerVerification(
+    params: { requested: boolean; userMessage: string; answer: string; userId?: string; userLanguage?: string },
+    onIssues: (issues: string) => void,
+): void {
+    if (!params.requested || !ENABLED) return;
+    void verifyAnswer(params.userMessage, params.answer, params.userId, params.userLanguage)
+        .then((issues) => { if (issues) onIssues(issues); })
+        .catch(() => { /* fail-open */ });
+}

--- a/apps/api/src/services/chat-service/answer-verifier.ts
+++ b/apps/api/src/services/chat-service/answer-verifier.ts
@@ -1,0 +1,70 @@
+/**
+ * 답변 검증 — 채팅 답변 완료 후 judge role 모델이 **1회** 점검하고 지적만 돌려준다.
+ *
+ * thinking-summarizer 와 같은 후처리 패턴(별도 role 모델 1회 호출 → WS 이벤트).
+ * 실측 근거와 "고치지 않는" 이유는 prompts/answer-verification 참고.
+ *
+ * 불변식:
+ *   - **fail-open**: 검증 실패·타임아웃은 답변에 영향을 주지 않는다(null 반환).
+ *   - 자동 수정 없음 — 판단은 사용자 몫.
+ *   - ANSWER_VERIFICATION_ENABLED=false 면 LLM 호출 자체가 없다.
+ *
+ * @module services/chat-service/answer-verifier
+ */
+import { resolveRoleClientForUser } from '../model-role-resolver';
+import { getAnswerVerificationMessages, VERIFICATION_NONE } from '../../prompts/answer-verification';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('AnswerVerifier');
+
+const ENABLED = (process.env.ANSWER_VERIFICATION_ENABLED ?? 'false').toLowerCase() === 'true';
+/** 검증 대상 최소 길이 — 짧은 답(인사·단답)은 검증 가치가 없다. */
+const MIN_ANSWER_CHARS = parseInt(process.env.ANSWER_VERIFICATION_MIN_CHARS || '200', 10);
+/** judge 에 싣는 답변/질문 상한 — 긴 답은 앞부분만으로 판단(비용·지연 억제). */
+const MAX_ANSWER_CHARS = parseInt(process.env.ANSWER_VERIFICATION_MAX_ANSWER_CHARS || '4000', 10);
+const MAX_USER_MSG_CHARS = 800;
+const TIMEOUT_MS = parseInt(process.env.ANSWER_VERIFICATION_TIMEOUT_MS || '20000', 10);
+const MAX_OUTPUT_TOKENS = parseInt(process.env.ANSWER_VERIFICATION_MAX_TOKENS || '300', 10);
+
+export function isAnswerVerificationEnabled(): boolean {
+    return ENABLED;
+}
+
+/**
+ * @returns 지적 텍스트(사용자에게 표시) 또는 null (오류 없음·비활성·실패).
+ */
+export async function verifyAnswer(
+    userMessage: string,
+    answer: string,
+    userId?: string,
+    userLanguage?: string,
+): Promise<string | null> {
+    if (!ENABLED) return null;
+    const trimmed = (answer ?? '').trim();
+    if (trimmed.length < MIN_ANSWER_CHARS) return null;
+
+    const lang = (userLanguage || 'ko').toLowerCase().startsWith('ko') ? 'ko' : 'en';
+    try {
+        const resolved = await resolveRoleClientForUser('judge', userId);
+        const client = resolved.client.derive({ timeout: TIMEOUT_MS });
+        const { system, user } = getAnswerVerificationMessages(
+            userMessage.slice(0, MAX_USER_MSG_CHARS),
+            trimmed.slice(0, MAX_ANSWER_CHARS),
+            lang,
+        );
+        const r = await client.chat(
+            [{ role: 'system', content: system }, { role: 'user', content: user }],
+            { num_predict: MAX_OUTPUT_TOKENS },
+            undefined,
+            { think: false },
+        );
+        const out = (r.content ?? '').trim();
+        if (!out || out.toUpperCase().startsWith(VERIFICATION_NONE)) return null;
+        logger.info(`답변 검증 지적 발생 (model=${resolved.fullId}, ${out.length}자)`);
+        return out;
+    } catch (e) {
+        // fail-open — 검증이 답변을 죽이지 않는다.
+        logger.warn(`답변 검증 실패 (생략): ${e instanceof Error ? e.message : e}`);
+        return null;
+    }
+}

--- a/apps/api/src/sockets/ws-chat-completion.ts
+++ b/apps/api/src/sockets/ws-chat-completion.ts
@@ -1,0 +1,33 @@
+/**
+ * 채팅 완료 시점 처리 — done 페이로드의 cleanedContent 계산.
+ *
+ * ws-chat-handler 에서 분리 (파일 크기 가드 600줄). 판정 로직은 그대로 옮겼다.
+ *
+ * @module sockets/ws-chat-completion
+ */
+import { hasScriptMixing } from '../services/chat-service/script-purity';
+import { citationMarkersWereCleaned, mapHtmlWasCleaned } from '../services/chat-service/external-deterministic-append';
+
+/**
+ * done 에 동봉할 cleanedContent.
+ *
+ * 클라이언트가 token 단위로 누적한 raw 본문을 backend 의 최종 본문으로 reset 하기 위함.
+ * 다음 경우에만 값을 반환하고(그 외 undefined = 변경 없음):
+ *   - 아티팩트가 있으면 placeholder 적용 본문으로 교체
+ *   - 스크립트 순수성 교정이 실제로 적용된 턴 (스트리밍 화면엔 한자 혼입이 남아 있다)
+ *   - 죽은 인용 마커 제거가 적용된 턴 ([출처 N] 수집 목록 밖 번호)
+ *   - 지도 환각 HTML 제거가 적용된 턴 (가짜 카카오 이미지 링크가 코드 텍스트로 노출)
+ */
+export function resolveCleanedContent(params: {
+    artifactCount: number;
+    finalResponse: string | undefined;
+    streamedResponse: string;
+}): string | undefined {
+    const { artifactCount, finalResponse, streamedResponse } = params;
+    if (artifactCount > 0) return finalResponse;
+    if (!finalResponse) return undefined;
+    const changed = (hasScriptMixing(streamedResponse) && !hasScriptMixing(finalResponse))
+        || citationMarkersWereCleaned(streamedResponse, finalResponse)
+        || mapHtmlWasCleaned(streamedResponse, finalResponse);
+    return changed ? finalResponse : undefined;
+}

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -7,7 +7,8 @@ import { WebSocket } from 'ws';
 import * as crypto from 'crypto';
 import { ClusterManager } from '../cluster/manager';
 import { selectOptimalModel } from '../chat/model-selector';
-import { verifyAnswer, isAnswerVerificationEnabled } from '../services/chat-service/answer-verifier';
+import { dispatchAnswerVerification } from '../services/chat-service/answer-verifier';
+import { resolveCleanedContent } from './ws-chat-completion';
 import { ChatRequestHandler, ChatRequestError } from '../chat/request-handler';
 import { enqueueDebugCapture, DEBUG_QUEUE_TTL_MS } from '../data/conversation-debug-queue';
 import { QuotaExceededError } from '../errors/quota-exceeded.error';
@@ -25,8 +26,6 @@ import { FILE_ATTACH_LIMITS } from '../config/runtime-limits';
 import { ArtifactStreamParser, type ArtifactInfo } from '../llm/artifact-parser';
 import { buildFileContext, buildUrlContext, getCachedAttachContext, appendCachedAttachContext } from '../services/chat-service/attach-context';
 import type { PdfVisionResult } from '../services/chat-service/pdf-vision';
-import { hasScriptMixing } from '../services/chat-service/script-purity';
-import { citationMarkersWereCleaned, mapHtmlWasCleaned } from '../services/chat-service/external-deterministic-append';
 import { saveAssistantMessage } from '../chat/request-persistence';
 import { buildWebSearchContext } from '../mcp/web-search/build-search-context';
 
@@ -430,24 +429,11 @@ export async function handleChatMessage(
             }
         }
 
-        // Phase 1.F.2 (2026-05-26): cleanedContent 를 done 페이로드에 동봉.
-        // 클라이언트가 token 단위로 누적한 raw 본문을 backend 의 placeholder 적용 본문으로
-        // reset 하기 위함. artifact 가 없으면 undefined — 변경 없음.
-        // 스크립트 순수성 교정(script-purity)이 실제로 적용된 경우에도 본문을 교체한다 —
-        // 스트리밍으로 이미 나간 화면엔 한자 혼입이 남아 있고 최종본만 교정돼 있으므로,
-        // 그 차이가 있을 때만 정확히 겨냥해 reset 한다(그 외 턴은 기존대로 undefined).
-        // 죽은 인용 마커 제거(external-deterministic-append)가 적용된 턴도 동일 패턴으로 교체 —
-        // 스트리밍 화면에 남은 [출처 N](수집 목록 밖 번호) 마커를 완료 시점에 정리한다.
-        // 지도 환각 HTML 제거(stripHallucinatedMapHtml)가 적용된 턴도 동일 — 화면에 코드
-        // 텍스트로 노출된 가짜 카카오 이미지 링크를 완료 시점에 정리한다.
-        const cleanedContent = (result.artifacts && result.artifacts.length > 0)
-            ? result.response
-            : (result.response
-                && ((hasScriptMixing(partialAssistantResponse) && !hasScriptMixing(result.response))
-                    || citationMarkersWereCleaned(partialAssistantResponse, result.response)
-                    || mapHtmlWasCleaned(partialAssistantResponse, result.response))
-                ? result.response
-                : undefined);
+        const cleanedContent = resolveCleanedContent({
+            artifactCount: result.artifacts?.length ?? 0,
+            finalResponse: result.response,
+            streamedResponse: partialAssistantResponse,
+        });
         ws.send(JSON.stringify({
             type: 'done',
             messageId,
@@ -455,22 +441,18 @@ export async function handleChatMessage(
             ...(cleanedContent !== undefined ? { cleanedContent } : {}),
         }));
 
-        // 답변 검증 (선택) — done 이후 judge 모델이 1회 점검하고 **지적만** 보낸다.
-        // done 을 막지 않도록 완료 후 비동기로 돌리며, 실패는 조용히 무시한다(fail-open).
-        // 자동 수정은 하지 않는다 — 프로토타입 실측에서 수정 왕복이 답변을 악화시켰다.
-        if (msg.verifyAnswer === true && isAnswerVerificationEnabled()) {
-            const answerForVerify = cleanedContent ?? result.response ?? partialAssistantResponse;
-            void verifyAnswer(
-                typeof msg.message === 'string' ? msg.message : '',
-                answerForVerify ?? '',
-                extWs._authenticatedUserId ?? undefined,
-                userLangPreference,
-            ).then((issues) => {
-                if (issues && ws.readyState === ws.OPEN) {
-                    ws.send(JSON.stringify({ type: 'answer_verification', issues, messageId }));
-                }
-            }).catch(() => { /* fail-open */ });
-        }
+        // 답변 검증 (선택) — done 이후 judge 모델이 1회 점검하고 **지적만** 보낸다(자동 수정 없음).
+        dispatchAnswerVerification({
+            requested: msg.verifyAnswer === true,
+            userMessage: typeof msg.message === 'string' ? msg.message : '',
+            answer: cleanedContent ?? result.response ?? partialAssistantResponse ?? '',
+            ...(extWs._authenticatedUserId ? { userId: extWs._authenticatedUserId } : {}),
+            ...(userLangPreference ? { userLanguage: userLangPreference } : {}),
+        }, (issues) => {
+            if (ws.readyState === ws.OPEN) {
+                ws.send(JSON.stringify({ type: 'answer_verification', issues, messageId }));
+            }
+        });
 
     } catch (error: unknown) {
         // 중단 컨트롤러 정리

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -7,6 +7,7 @@ import { WebSocket } from 'ws';
 import * as crypto from 'crypto';
 import { ClusterManager } from '../cluster/manager';
 import { selectOptimalModel } from '../chat/model-selector';
+import { verifyAnswer, isAnswerVerificationEnabled } from '../services/chat-service/answer-verifier';
 import { ChatRequestHandler, ChatRequestError } from '../chat/request-handler';
 import { enqueueDebugCapture, DEBUG_QUEUE_TTL_MS } from '../data/conversation-debug-queue';
 import { QuotaExceededError } from '../errors/quota-exceeded.error';
@@ -453,6 +454,23 @@ export async function handleChatMessage(
             metrics: { tokensPerSec, tokenCount },
             ...(cleanedContent !== undefined ? { cleanedContent } : {}),
         }));
+
+        // 답변 검증 (선택) — done 이후 judge 모델이 1회 점검하고 **지적만** 보낸다.
+        // done 을 막지 않도록 완료 후 비동기로 돌리며, 실패는 조용히 무시한다(fail-open).
+        // 자동 수정은 하지 않는다 — 프로토타입 실측에서 수정 왕복이 답변을 악화시켰다.
+        if (msg.verifyAnswer === true && isAnswerVerificationEnabled()) {
+            const answerForVerify = cleanedContent ?? result.response ?? partialAssistantResponse;
+            void verifyAnswer(
+                typeof msg.message === 'string' ? msg.message : '',
+                answerForVerify ?? '',
+                extWs._authenticatedUserId ?? undefined,
+                userLangPreference,
+            ).then((issues) => {
+                if (issues && ws.readyState === ws.OPEN) {
+                    ws.send(JSON.stringify({ type: 'answer_verification', issues, messageId }));
+                }
+            }).catch(() => { /* fail-open */ });
+        }
 
     } catch (error: unknown) {
         // 중단 컨트롤러 정리

--- a/apps/api/src/sockets/ws-types.ts
+++ b/apps/api/src/sockets/ws-types.ts
@@ -34,6 +34,12 @@ export interface WSMessage {
      */
     thinkingLevel?: 'low' | 'medium' | 'high';
     /**
+     * 답변 검증 요청 — done 이후 judge role 모델이 1회 점검하고 지적을 answer_verification
+     * 이벤트로 보낸다. 지적이 없으면 이벤트 자체가 오지 않는다. 서버 게이트는
+     * ANSWER_VERIFICATION_ENABLED.
+     */
+    verifyAnswer?: boolean;
+    /**
      * 메시지 본문을 conversation_messages 에 저장할지 여부.
      * 기본 true (생략 시 저장). false 면 본문은 저장하지 않고
      * conversation_audit_log 에 메타만 기록한다.

--- a/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/Generated/WsModels.swift
+++ b/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/Generated/WsModels.swift
@@ -64,6 +64,7 @@ public struct WsServerEvent: Codable {
     public let type: WsServerEventType
     public let messageID: String?
     public let summary: String?
+    public let issues: String?
     public let sessionID: String?
     public let buildID: String?
     public let message: String?
@@ -103,6 +104,7 @@ public struct WsServerEvent: Codable {
         case type = "type"
         case messageID = "messageId"
         case summary = "summary"
+        case issues = "issues"
         case sessionID = "sessionId"
         case buildID = "buildId"
         case message = "message"
@@ -132,11 +134,12 @@ public struct WsServerEvent: Codable {
         case taskID = "taskId"
     }
 
-    public init(token: String?, type: WsServerEventType, messageID: String?, summary: String?, sessionID: String?, buildID: String?, message: String?, captureID: String?, expiresAt: String?, ttlHours: Double?, payload: Payload?, cleanedContent: String?, metrics: Metrics?, errorType: String?, keysInCooldown: Double?, resetTime: String?, retryAfter: Double?, totalKeys: Double?, data: JSONAny?, agent: Agent?, skillNames: [String]?, toolName: String?, resources: [MCPToolResource]?, progress: ProgressUnion?, artifact: ArtifactMeta?, delta: String?, id: String?, currentTurn: Double?, status: String?, step: Step?, taskID: String?) {
+    public init(token: String?, type: WsServerEventType, messageID: String?, summary: String?, issues: String?, sessionID: String?, buildID: String?, message: String?, captureID: String?, expiresAt: String?, ttlHours: Double?, payload: Payload?, cleanedContent: String?, metrics: Metrics?, errorType: String?, keysInCooldown: Double?, resetTime: String?, retryAfter: Double?, totalKeys: Double?, data: JSONAny?, agent: Agent?, skillNames: [String]?, toolName: String?, resources: [MCPToolResource]?, progress: ProgressUnion?, artifact: ArtifactMeta?, delta: String?, id: String?, currentTurn: Double?, status: String?, step: Step?, taskID: String?) {
         self.token = token
         self.type = type
         self.messageID = messageID
         self.summary = summary
+        self.issues = issues
         self.sessionID = sessionID
         self.buildID = buildID
         self.message = message
@@ -190,6 +193,7 @@ public extension WsServerEvent {
         type: WsServerEventType? = nil,
         messageID: String?? = nil,
         summary: String?? = nil,
+        issues: String?? = nil,
         sessionID: String?? = nil,
         buildID: String?? = nil,
         message: String?? = nil,
@@ -223,6 +227,7 @@ public extension WsServerEvent {
             type: type ?? self.type,
             messageID: messageID ?? self.messageID,
             summary: summary ?? self.summary,
+            issues: issues ?? self.issues,
             sessionID: sessionID ?? self.sessionID,
             buildID: buildID ?? self.buildID,
             message: message ?? self.message,
@@ -772,6 +777,7 @@ public enum WsServerEventType: String, Codable {
     case aborted = "aborted"
     case agentSelected = "agent_selected"
     case agentTaskProgress = "agent_task_progress"
+    case answerVerification = "answer_verification"
     case artifactChunk = "artifact_chunk"
     case artifactEnd = "artifact_end"
     case artifactStart = "artifact_start"

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -21,8 +21,7 @@ import {
   Lock,
   BookOpen,
   Plus,
-  FolderOpen,
-} from "lucide-react";
+  FolderOpen, ShieldCheck } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import type { AttachedFileUI } from "@/lib/use-chat-socket";
@@ -213,6 +212,7 @@ export function Composer() {
     selectedModel,
     style,
     thinkingLevel,
+    answerVerification,
     inputDraft,
     toggle,
     setSelectedModel,
@@ -446,6 +446,7 @@ export function Composer() {
   const TOGGLES = [
     { key: "discussionMode" as const, on: discussionMode, icon: MessagesSquare, label: t("toggle.discussion") },
     { key: "thinkingEnabled" as const, on: thinkingEnabled, icon: Brain, label: t("toggle.thinking") },
+    { key: "answerVerification" as const, on: answerVerification, icon: ShieldCheck, label: t("toggle.verification") },
     { key: "deepResearchMode" as const, on: deepResearchMode, icon: Telescope, label: t("toggle.deepResearch") },
     { key: "webSearchEnabled" as const, on: webSearchEnabled, icon: Globe, label: t("toggle.web") },
     { key: "agentTaskMode" as const, on: agentTaskMode, icon: Sparkles, label: t("toggle.agent") },

--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -702,6 +702,19 @@ export function MessageList() {
                   <span className="ml-0.5 inline-block h-4 w-1.5 animate-pulse bg-accent align-text-bottom" />
                 )}
               </div>
+              {/* 답변 검증 지적 — judge 모델이 1회 점검한 결과. 지적이 있을 때만 나타난다.
+                  자동 수정은 하지 않으므로 판단은 사용자 몫이라는 점을 문구로 드러낸다. */}
+              {m.verificationIssues && !m.streaming && (
+                <div className="mt-2 rounded-md border border-warning/40 bg-warning/10 px-3 py-2">
+                  <div className="mb-1 flex items-center gap-1.5 text-xs font-medium text-warning">
+                    <AlertTriangle className="h-3.5 w-3.5" aria-hidden />
+                    {t("verification.title")}
+                  </div>
+                  <div className="whitespace-pre-wrap text-xs leading-relaxed text-muted">
+                    {m.verificationIssues}
+                  </div>
+                </div>
+              )}
               {!m.streaming && !m.agentTask && !m.structured && m.content.trim().length > 0 && (
                 <div className="mt-1.5 flex items-center gap-1">
                   <MessageActions

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -21,6 +21,11 @@ export interface ChatMessage extends Pick<SharedChatMessage, "role" | "content" 
   reasoning?: string;
   /** 추론 요약 헤드라인 — 생각 종료 시 별도 모델이 생성 (ws thinking_summary, 클로드 웹식) */
   reasoningSummary?: string;
+  /**
+   * 답변 검증 지적 — done 이후 judge 모델이 1회 점검한 결과(ws answer_verification).
+   * 지적이 없으면 이벤트가 오지 않으므로 이 필드도 비어 있다. 자동 수정은 하지 않는다.
+   */
+  verificationIssues?: string;
   /** 구조화 답변 데이터 (structuredMode=true 시 REST /api/chat/structured 응답). 있으면 카드 UI 로 렌더. */
   structured?: StructuredAnswerData;
   /** 에이전트 작업이 승인 대기(paused)일 때 표시할 대기 중 도구 호출 — 채팅 인라인 승인. */
@@ -171,6 +176,8 @@ interface AppState {
   thinkingEnabled: boolean;
   /** 추론 강도 — thinkingEnabled=true 일 때 전송. 모델별 지원값 정규화는 서버 담당. */
   thinkingLevel: ThinkingLevel;
+  /** 답변 검증 — 켜면 done 이후 judge 모델이 1회 점검(비용 발생). 기본 off. */
+  answerVerification: boolean;
   discussionMode: boolean;
   deepResearchMode: boolean;
   webSearchEnabled: boolean;
@@ -209,6 +216,7 @@ interface AppState {
   setModelFallback: (info: { from: string; to: string; reason?: string }) => void;
   appendThinking: (token: string) => void;
   setThinkingSummary: (summary: string) => void;
+  setVerificationIssues: (issues: string) => void;
   setStreaming: (v: boolean) => void;
   setCurrentSessionId: (id: string | null) => void;
   setInputDraft: (t: string) => void;
@@ -239,6 +247,7 @@ interface AppState {
   toggle: (
     key:
       | "thinkingEnabled"
+      | "answerVerification"
       | "discussionMode"
       | "deepResearchMode"
       | "webSearchEnabled"
@@ -315,6 +324,7 @@ export const useAppStore = create<AppState>()(
 
   thinkingEnabled: true, // 기본 ON — tool calling 중 추론(thinking) 과정을 화면에 노출
   thinkingLevel: "medium",
+  answerVerification: false,
   discussionMode: false,
   deepResearchMode: false,
   webSearchEnabled: false,
@@ -389,6 +399,18 @@ export const useAppStore = create<AppState>()(
       } else {
         // thinking 은 보통 답변 토큰보다 먼저 도착 — assistant placeholder 를 생성해 누적
         hist.push({ role: "assistant", content: "", reasoning: token, streaming: true });
+      }
+      return { chatHistory: hist };
+    }),
+  setVerificationIssues: (issues) =>
+    set((s) => {
+      // done 이후 도착 — 마지막 assistant 메시지에 부착.
+      const hist = [...s.chatHistory];
+      for (let i = hist.length - 1; i >= 0; i--) {
+        if (hist[i].role === "assistant") {
+          hist[i] = { ...hist[i], verificationIssues: issues };
+          break;
+        }
       }
       return { chatHistory: hist };
     }),
@@ -517,7 +539,7 @@ export const useAppStore = create<AppState>()(
         typeof window !== "undefined" ? window.localStorage : noopStorage,
       ),
       // 사용자 환경설정만 영속화 — 채팅/아티팩트 등 휘발성 세션 상태는 제외
-      partialize: (s) => ({ selectedModel: s.selectedModel, style: s.style, thinkingLevel: s.thinkingLevel, activeUserAgent: s.activeUserAgent }),
+      partialize: (s) => ({ selectedModel: s.selectedModel, style: s.style, thinkingLevel: s.thinkingLevel, answerVerification: s.answerVerification, activeUserAgent: s.activeUserAgent }),
     },
   ),
 );

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -129,6 +129,7 @@ export function useChatSocket() {
     setModelFallback,
     appendThinking,
     setThinkingSummary,
+    setVerificationIssues,
     setStreaming,
     setCurrentSessionId,
     setActiveAgent,
@@ -233,6 +234,10 @@ export function useChatSocket() {
           break;
         case "thinking_summary":
           if (typeof data.summary === "string" && data.summary) setThinkingSummary(data.summary);
+          break;
+        // 답변 검증 지적 — done 이후 도착. 지적이 없으면 이벤트 자체가 오지 않는다.
+        case "answer_verification":
+          if (typeof data.issues === "string" && data.issues) setVerificationIssues(data.issues);
           break;
         case "session_created":
           if (data.sessionId) setCurrentSessionId(data.sessionId);
@@ -530,6 +535,8 @@ export function useChatSocket() {
         thinkingMode: s.thinkingEnabled,
         // 추론 강도 — 토글이 켜진 경우에만 의미(서버가 thinkingMode=false 면 무시).
         ...(s.thinkingEnabled ? { thinkingLevel: s.thinkingLevel } : {}),
+        // 답변 검증 — 켠 경우에만 요청(서버도 ANSWER_VERIFICATION_ENABLED 로 게이트).
+        ...(s.answerVerification ? { verifyAnswer: true } : {}),
         imageMode: s.imageMode,
         artifactMode: s.artifactMode,
         style: s.style,

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -274,7 +274,8 @@
       "agent": "Agent",
       "image": "Image",
       "artifact": "Artifact",
-      "structured": "Structured"
+      "structured": "Structured",
+      "verification": "Verify answer"
     },
     "slashMenu": {
       "heading": "Invoke skill",
@@ -439,6 +440,9 @@
       "INVALID_API_KEY": "authentication error",
       "MISSING_API_KEY": "authentication error",
       "UPSTREAM_ERROR": "upstream error"
+    },
+    "verification": {
+      "title": "Issues found by verification"
     }
   },
   "artifacts": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -274,7 +274,8 @@
       "agent": "エージェント",
       "image": "画像",
       "artifact": "アーティファクト",
-      "structured": "構造化"
+      "structured": "構造化",
+      "verification": "回答の検証"
     },
     "slashMenu": {
       "heading": "スキルを呼び出す",
@@ -439,6 +440,9 @@
       "INVALID_API_KEY": "認証エラー",
       "MISSING_API_KEY": "認証エラー",
       "UPSTREAM_ERROR": "アップストリームエラー"
+    },
+    "verification": {
+      "title": "検証で指摘された点"
     }
   },
   "artifacts": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -274,7 +274,8 @@
       "agent": "에이전트",
       "image": "이미지",
       "artifact": "아티팩트",
-      "structured": "구조화 답변"
+      "structured": "구조화 답변",
+      "verification": "답변 검증"
     },
     "slashMenu": {
       "heading": "스킬 호출",
@@ -439,6 +440,9 @@
       "INVALID_API_KEY": "인증 오류",
       "MISSING_API_KEY": "인증 오류",
       "UPSTREAM_ERROR": "업스트림 오류"
+    },
+    "verification": {
+      "title": "검증에서 지적된 사항"
     }
   },
   "artifacts": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -274,7 +274,8 @@
       "agent": "智能体",
       "image": "图像",
       "artifact": "工件",
-      "structured": "结构化"
+      "structured": "结构化",
+      "verification": "验证回答"
     },
     "slashMenu": {
       "heading": "调用技能",
@@ -439,6 +440,9 @@
       "INVALID_API_KEY": "认证错误",
       "MISSING_API_KEY": "认证错误",
       "UPSTREAM_ERROR": "上游错误"
+    },
+    "verification": {
+      "title": "验证发现的问题"
     }
   },
   "artifacts": {

--- a/packages/api-contracts/events/ws-chat.v1.schema.json
+++ b/packages/api-contracts/events/ws-chat.v1.schema.json
@@ -306,6 +306,25 @@
           "properties": {
             "type": {
               "type": "string",
+              "const": "answer_verification"
+            },
+            "issues": {
+              "type": "string"
+            },
+            "messageId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "issues"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
               "const": "session_created"
             },
             "sessionId": {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -148,6 +148,8 @@ export type WsServerEvent =
   | { type: "token"; token: string }
   | { type: "thinking"; token: string; messageId?: string }
   | { type: "thinking_summary"; summary: string; messageId?: string }
+  /** 답변 검증 지적 — done 이후 judge 모델 1회 점검 결과. 지적이 없으면 이 이벤트는 오지 않는다. */
+  | { type: "answer_verification"; issues: string; messageId?: string }
   | { type: "session_created"; sessionId: string }
   /** 연결 직후 서버 build id — 클라가 기억해 두고 다른 build 재수신 시 배포로 간주(reload). */
   | { type: "build_id"; buildId: string }


### PR DESCRIPTION
## 프로토타입으로 먼저 재보고 범위를 정했습니다

만들기 전에 로컬 qwen3.6 ↔ `chatgpt:gpt-5.6-luna` 교차대화를 실제 질문 2건에 돌려봤습니다(앱 변경 0).

**① 검증은 유효했습니다.** 로컬이 *"국민연금 의무가입에 상한 연령 제한은 없습니다"* 라고 사실과 다르게 답하자 judge 가 정확히 반박했습니다.

> 국민연금 의무가입 상한은 **만 60세 미만**이므로, "상한 연령 제한이 없다"는 오류다. 60세 이후 계속 근로해도 원칙적으로 의무가입이 유지되지 않으며, 희망할 경우 만 65세까지 임의계속가입할 수 있다.

4회 비평 모두 구체적 지적을 냈고 아첨 루프는 없었습니다. "없으면 NONE" 규약도 잘 지켰습니다.

**② 수정 왕복은 손해였습니다.** 2건 중 1건에서 수정본이 원본보다 나빠졌습니다 — 답변 본문이 통째로 사라지고 아티팩트 플레이스홀더(`[[artifact:...]]`)만 남았습니다. 그리고 2건 모두 2라운드로 수렴하지 않았습니다(R4 에서 새 지적이 또 나옴).

→ 그래서 **검증 1회, 지적만, 자동 수정 없음**으로 좁혔습니다. 측정하지 않았다면 대화 모드를 만들어 ②의 함정에 빠졌을 것입니다.

## 구현

`thinking_summary` 와 **동일한 후처리 패턴**을 따랐습니다(별도 role 모델 1회 호출 → WS 이벤트 → 프론트 표시).

- **`answer-verifier`**: `judge` role 1회 호출. `NONE` 이면 null, 실패는 **fail-open**(검증이 답변을 죽이지 않음)
- **프롬프트**: 오류만 지적 · 최대 3개 · 확신 없으면 미지적 · 재작성 금지
- **`ws-chat-handler`**: `done` **이후** 비동기 실행 → **응답 지연 0**. 지적이 있을 때만 `answer_verification` 이벤트 전송
- **프론트**: composer 에 "답변 검증" 토글(기본 off, 영속), 메시지 아래 경고 배지로 지적 표시. 자동 수정하지 않으므로 판단은 사용자 몫
- 게이트 `ANSWER_VERIFICATION_ENABLED`(기본 false) + 최소 길이·상한·타임아웃 env

## 왜 이 형태인가

이미 있는 `judge` role 은 **에이전트 작업에만** 붙어 있고 일반 채팅에는 없었습니다. 이 PR 은 그 검증을 채팅으로 확장하되, 프로토타입이 위험하다고 보여준 부분(자동 수정·다라운드)은 의도적으로 뺐습니다.

## 검증

- 신규 유닛 **5건** — 게이트 off 시 LLM 미호출, 짧은 답 생략, NONE 처리, 지적 반환, fail-open
- 서비스·라우트·provider·llm·소켓·계약 **778건 통과**, `npm run lint` 0 errors, 백엔드·프론트 `tsc` 통과

⚠️ `mobile-auth-contract` 1건은 로컬 `pgPass` 환경 flake(단독 14/14 통과). 최근 PR 들과 동일 증상이며 그때 CI 는 통과했습니다.

## 배포 노트

기본 `false` 이므로 머지·배포만으로는 동작이 바뀌지 않습니다. 켜려면 운영 `.env` 에 `ANSWER_VERIFICATION_ENABLED=true` 가 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)