### PR TITLE
fix(schema): 구조화 스키마를 OpenAI strict 규격으로 — 외부 모델이 필드를 빠뜨리던 원인

### DIFF
--- a/apps/api/src/llm/stream-parser.ts
+++ b/apps/api/src/llm/stream-parser.ts
@@ -95,6 +95,10 @@ export function toResponseFormat(f: FormatOption | undefined): Record<string, un
                 type: 'object',
                 properties: f.properties,
                 ...(f.required && { required: f.required }),
+                // strict 모드 필수 — 누락하면 OpenAI 계열이 스키마를 강제하지 않는다(실측 2026-08-24).
+                ...(f.additionalProperties !== undefined
+                    ? { additionalProperties: f.additionalProperties }
+                    : {}),
             },
             strict: true,
         },

--- a/apps/api/src/llm/types.ts
+++ b/apps/api/src/llm/types.ts
@@ -202,6 +202,12 @@ export type FormatOption = 'json' | {
     type: 'object';
     properties: Record<string, unknown>;
     required?: string[];
+    /**
+     * OpenAI strict json_schema 규격 — strict 모드는 모든 object 에 이 값이 false 여야 하고
+     * required 가 모든 property 를 나열해야 한다. 누락 시 OpenAI 계열에서 스키마가 강제되지
+     * 않는다(실측 2026-08-24). vLLM guided decoding 은 더 관대해 이 위반이 드러나지 않았다.
+     */
+    additionalProperties?: boolean;
 };
 
 /**

--- a/apps/api/src/providers/openai-compat-format.test.ts
+++ b/apps/api/src/providers/openai-compat-format.test.ts
@@ -22,6 +22,31 @@ describe('구조화 응답 포맷 변환', () => {
         );
     });
 
+    it('OpenAI strict 규격을 지킨다 — required=전체 property + additionalProperties:false', () => {
+        // 실측 2026-08-24: 이 규격을 어기면 OpenAI 계열(ChatGPT·OpenRouter)이 스키마를 강제하지
+        // 않아 모델이 intent 를 빠뜨렸다. 로컬 vLLM 은 관대해 드러나지 않던 위반이다.
+        const rf = toResponseFormat(STRUCTURED_ANSWER_FORMAT) as {
+            json_schema: { schema: { properties: Record<string, unknown>; required: string[]; additionalProperties: boolean } };
+        };
+        const { properties, required, additionalProperties } = rf.json_schema.schema;
+        expect(additionalProperties).toBe(false);
+        expect([...required].sort()).toEqual(Object.keys(properties).sort());
+    });
+
+    it('중첩 object(sections·table)도 같은 규격을 지킨다', () => {
+        const sec = (STRUCTURED_ANSWER_FORMAT as { properties: Record<string, { items?: Record<string, unknown> }> })
+            .properties.sections.items as { properties: Record<string, unknown>; required: string[]; additionalProperties: boolean };
+        expect(sec.additionalProperties).toBe(false);
+        expect([...sec.required].sort()).toEqual(Object.keys(sec.properties).sort());
+    });
+
+    it('선택 필드는 null 을 허용해 required 에 넣을 수 있게 한다', () => {
+        const props = (STRUCTURED_ANSWER_FORMAT as { properties: Record<string, { type: unknown }> }).properties;
+        for (const k of ['summary', 'risks', 'action_items']) {
+            expect(props[k].type).toEqual(expect.arrayContaining(['null']));
+        }
+    });
+
     it("'json' 단축형은 json_object 로", () => {
         expect(toResponseFormat('json')).toEqual({ type: 'json_object' });
     });

--- a/apps/api/src/schemas/structured-answer.schema.ts
+++ b/apps/api/src/schemas/structured-answer.schema.ts
@@ -33,6 +33,12 @@ export const ANSWER_INTENTS = [
 
 export type AnswerIntent = (typeof ANSWER_INTENTS)[number];
 
+/**
+ * strict json_schema 는 모든 키를 required 로 요구하므로 모델이 "값 없음"을 null 로 보낸다.
+ * 그 null 을 미지정(undefined)과 동일하게 취급한다 — 기존 출력 타입(optional)은 그대로 유지.
+ */
+const nullToUndefined = (v: unknown): unknown => (v === null ? undefined : v);
+
 const TableSchema = z.object({
     headers: z.array(z.string()),
     rows: z.array(z.array(z.string())),
@@ -41,8 +47,8 @@ const TableSchema = z.object({
 const SectionSchema = z.object({
     heading: z.string(),
     body: z.string(),
-    bullets: z.array(z.string()).optional(),
-    table: TableSchema.optional(),
+    bullets: z.preprocess(nullToUndefined, z.array(z.string()).optional()),
+    table: z.preprocess(nullToUndefined, TableSchema.optional()),
 });
 
 /**
@@ -52,48 +58,65 @@ export const StructuredAnswerSchema = z.object({
     intent: z.enum(ANSWER_INTENTS),
     title: z.string(),
     conclusion: z.string(),
-    summary: z.string().optional().default(''),
+    // 선택 필드는 null 도 수용한다 — OpenAI strict json_schema 는 모든 키를 required 로 요구하므로
+    // 모델이 "값 없음"을 null 로 표현한다(아래 STRUCTURED_ANSWER_FORMAT 주석 참고).
+    summary: z.preprocess(nullToUndefined, z.string().optional().default('')),
     sections: z.array(SectionSchema),
-    risks: z.array(z.string()).optional(),
-    action_items: z.array(z.string()).optional(),
+    risks: z.preprocess(nullToUndefined, z.array(z.string()).optional()),
+    action_items: z.preprocess(nullToUndefined, z.array(z.string()).optional()),
     confidence: z.enum(['high', 'medium', 'low']),
 });
 
 export type StructuredAnswer = z.infer<typeof StructuredAnswerSchema>;
 
 /**
- * LLMClient `advancedOptions.format` 으로 전달할 JSON Schema (vLLM json_schema, strict).
- * stream-parser.toResponseFormat 가 { type:'json_schema', json_schema:{ schema:{ type:'object', properties, required } } } 로 변환.
+ * LLMClient `advancedOptions.format` 으로 전달할 JSON Schema (json_schema, strict).
+ *
+ * ⚠️ **OpenAI strict 규격 준수 필수** (실측 2026-08-24): strict 모드는
+ *   ① 모든 object 에 `additionalProperties: false`
+ *   ② `required` 가 **모든** property 를 나열 (부분집합 불가)
+ * 를 요구한다. 이를 어기면 OpenAI 계열(ChatGPT·OpenRouter)에서 스키마가 **강제되지 않고**
+ * 모델이 필드를 빠뜨린다 — 실제로 `intent` 하나가 누락돼 검증 2회 실패 → degrade 했다.
+ * (로컬 vLLM 의 guided decoding 은 더 관대해 이 위반이 드러나지 않았다.)
+ *
+ * 그래서 값이 선택적인 필드도 required 에 넣되 **null 을 허용**하고, Zod 쪽에서
+ * null 을 미지정으로 정규화한다(위 nullToUndefined).
  */
+const TABLE_SCHEMA = {
+    type: ['object', 'null'],
+    properties: {
+        headers: { type: 'array', items: { type: 'string' } },
+        rows: { type: 'array', items: { type: 'array', items: { type: 'string' } } },
+    },
+    required: ['headers', 'rows'],
+    additionalProperties: false,
+};
+
+const SECTION_SCHEMA = {
+    type: 'object',
+    properties: {
+        heading: { type: 'string' },
+        body: { type: 'string' },
+        bullets: { type: ['array', 'null'], items: { type: 'string' } },
+        table: TABLE_SCHEMA,
+    },
+    required: ['heading', 'body', 'bullets', 'table'],
+    additionalProperties: false,
+};
+
 export const STRUCTURED_ANSWER_FORMAT: FormatOption = {
     type: 'object',
     properties: {
         intent: { type: 'string', enum: [...ANSWER_INTENTS] },
         title: { type: 'string' },
         conclusion: { type: 'string' },
-        summary: { type: 'string' },
-        sections: {
-            type: 'array',
-            items: {
-                type: 'object',
-                properties: {
-                    heading: { type: 'string' },
-                    body: { type: 'string' },
-                    bullets: { type: 'array', items: { type: 'string' } },
-                    table: {
-                        type: 'object',
-                        properties: {
-                            headers: { type: 'array', items: { type: 'string' } },
-                            rows: { type: 'array', items: { type: 'array', items: { type: 'string' } } },
-                        },
-                    },
-                },
-                required: ['heading', 'body'],
-            },
-        },
-        risks: { type: 'array', items: { type: 'string' } },
-        action_items: { type: 'array', items: { type: 'string' } },
+        summary: { type: ['string', 'null'] },
+        sections: { type: 'array', items: SECTION_SCHEMA },
+        risks: { type: ['array', 'null'], items: { type: 'string' } },
+        action_items: { type: ['array', 'null'], items: { type: 'string' } },
         confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
     },
-    required: ['intent', 'title', 'conclusion', 'sections', 'confidence'],
+    // strict 규격: 모든 property 를 나열해야 한다 (선택 필드는 위에서 null 허용).
+    required: ['intent', 'title', 'conclusion', 'summary', 'sections', 'risks', 'action_items', 'confidence'],
+    additionalProperties: false,
 };

--- a/apps/api/src/services/answer-composer.test.ts
+++ b/apps/api/src/services/answer-composer.test.ts
@@ -193,3 +193,20 @@ describe('answer-composer: composeStructuredAnswer', () => {
         expect(r.structured.confidence).toBe('low');
     });
 });
+
+describe('StructuredAnswerSchema — strict 스키마의 null 수용', () => {
+    it('선택 필드가 null 로 와도 통과하고 미지정과 동일하게 정규화된다', () => {
+        // strict json_schema 는 모든 키를 required 로 요구하므로 모델이 "값 없음"을 null 로 보낸다.
+        const parsed = StructuredAnswerSchema.parse({
+            intent: 'explanation', title: 'T', conclusion: 'C',
+            summary: null, risks: null, action_items: null,
+            sections: [{ heading: 'H', body: 'B', bullets: null, table: null }],
+            confidence: 'high',
+        });
+        expect(parsed.summary).toBe('');
+        expect(parsed.risks).toBeUndefined();
+        expect(parsed.action_items).toBeUndefined();
+        expect(parsed.sections[0].bullets).toBeUndefined();
+        expect(parsed.sections[0].table).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## 증상

#597 로 외부 provider 에 `json_schema` 를 넘기게 했는데도 **ChatGPT·OpenRouter 양쪽에서 여전히 `degraded: schema_invalid`** 였습니다. 배포본에 전송 코드가 들어간 것은 확인했는데도 효과가 없었습니다.

## 원인

모델이 실제로 반환한 키를 뜯어보니 답이 나왔습니다.

```
반환: title · conclusion · sections · action_items · risks · confidence
누락: intent  ← 이거 하나
```

스키마가 **전달은 됐지만 강제되지 않았다**는 뜻입니다. 그리고 이유는 우리 스키마가 **OpenAI strict 규격을 어겨서**입니다. strict 모드는 두 가지를 요구합니다.

1. 모든 object 에 `additionalProperties: false`
2. `required` 가 **모든** property 를 나열 (부분집합 불가)

기존 스키마는 `required` 가 8개 중 5개뿐이고 `additionalProperties` 선언이 없었습니다. **로컬 vLLM 의 guided decoding 은 이보다 관대해서 이 위반이 드러나지 않았습니다** — 로컬로만 검증했다면 영원히 못 봤을 문제입니다.

거기에 `toResponseFormat` 이 `additionalProperties` 를 아예 버리고 있었습니다.

## 변경

- **`STRUCTURED_ANSWER_FORMAT`**: 모든 property 를 `required` 에 넣고 `additionalProperties: false`. 값이 선택적인 필드(`summary`·`risks`·`action_items`·`bullets`·`table`)는 `type: [..., 'null']` 로 null 을 허용해 required 에 넣을 수 있게 함
- 중첩 object(`sections`·`table`)에도 동일 규격 적용
- `toResponseFormat` 이 `additionalProperties` 를 전달하도록 수정 (`FormatOption` 타입 확장)
- **Zod**: null 을 미지정으로 정규화(`preprocess`) — 출력 타입은 기존 optional 그대로라 소비처 변경 없음

## 검증

- 신규 유닛 **4건** — strict 규격 고정(`required` == 전체 property, `additionalProperties: false`), 중첩 object 규격, 선택 필드 null 허용, Zod 의 null 수용
- schemas·services·providers·llm **760건 통과**, `npm run lint` 0 errors, `tsc` 통과

## 배포 후 확인 계획

로컬(vLLM) 구조화 응답이 새 스키마에서도 정상인지 먼저 보고, 그다음 OpenRouter **무료 모델**로 외부 경로를 확인합니다. 혹시 새 스키마가 어느 백엔드에서 거부되더라도 #594 의 degrade 가 받아내므로 요청이 죽지는 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)