### PR TITLE
fix(chat): 구조화 답변 500 복구 — strict 스키마 재적용 + 길이 잘림 자동 회복

### DIFF
--- a/apps/api/src/llm/stream-parser.ts
+++ b/apps/api/src/llm/stream-parser.ts
@@ -95,6 +95,10 @@ export function toResponseFormat(f: FormatOption | undefined): Record<string, un
                 type: 'object',
                 properties: f.properties,
                 ...(f.required && { required: f.required }),
+                // strict 모드 필수 — 누락하면 OpenAI 계열이 스키마를 강제하지 않는다(실측 2026-08-24).
+                ...(f.additionalProperties !== undefined
+                    ? { additionalProperties: f.additionalProperties }
+                    : {}),
             },
             strict: true,
         },

--- a/apps/api/src/llm/types.ts
+++ b/apps/api/src/llm/types.ts
@@ -202,6 +202,12 @@ export type FormatOption = 'json' | {
     type: 'object';
     properties: Record<string, unknown>;
     required?: string[];
+    /**
+     * OpenAI strict json_schema 규격 — strict 모드는 모든 object 에 이 값이 false 여야 하고
+     * required 가 모든 property 를 나열해야 한다. 누락 시 OpenAI 계열에서 스키마가 강제되지
+     * 않는다(실측 2026-08-24). vLLM guided decoding 은 더 관대해 이 위반이 드러나지 않았다.
+     */
+    additionalProperties?: boolean;
 };
 
 /**

--- a/apps/api/src/prompts/answer-composer-system.ts
+++ b/apps/api/src/prompts/answer-composer-system.ts
@@ -65,6 +65,21 @@ export function buildAnswerComposerSystemPrompt(intent: AnswerIntent, userLangua
 }
 
 /** Validator 실패 시 1회 재시도에 덧붙이는 교정 지시. */
+/**
+ * 출력이 토큰 상한에 걸려 잘렸을 때의 교정 힌트.
+ *
+ * 스키마를 못 지킨 게 아니라 **길이** 때문이므로, 스키마 재안내 대신 "짧게 쓰라"고 지시한다
+ * (실측 2026-08-24: strict 규격이 8개 필드를 모두 채우게 해 출력이 길어져 잘렸다).
+ */
+export function getLengthRepairHint(userLanguage: string): string {
+    const lang = userLanguage.toLowerCase().startsWith('ko') ? 'ko' : 'en';
+    return lang === 'ko'
+        ? '직전 출력이 길이 제한에 걸려 잘렸습니다. 같은 스키마를 지키되 **훨씬 짧게** 쓰세요 — '
+          + 'sections 는 최대 2개, 각 body 는 2문장 이내, bullets·risks·action_items 는 비우거나 null 로 두세요.'
+        : 'The previous output was cut off by the length limit. Keep the same schema but be MUCH shorter — '
+          + 'at most 2 sections, each body within 2 sentences, and leave bullets/risks/action_items empty or null.';
+}
+
 export function getRepairHint(userLanguage: string): string {
     const lang = userLanguage.toLowerCase().startsWith('ko') ? 'ko' : 'en';
     return lang === 'ko'

--- a/apps/api/src/providers/openai-compat-format.test.ts
+++ b/apps/api/src/providers/openai-compat-format.test.ts
@@ -22,6 +22,31 @@ describe('구조화 응답 포맷 변환', () => {
         );
     });
 
+    it('OpenAI strict 규격을 지킨다 — required=전체 property + additionalProperties:false', () => {
+        // 실측 2026-08-24: 이 규격을 어기면 OpenAI 계열(ChatGPT·OpenRouter)이 스키마를 강제하지
+        // 않아 모델이 intent 를 빠뜨렸다. 로컬 vLLM 은 관대해 드러나지 않던 위반이다.
+        const rf = toResponseFormat(STRUCTURED_ANSWER_FORMAT) as {
+            json_schema: { schema: { properties: Record<string, unknown>; required: string[]; additionalProperties: boolean } };
+        };
+        const { properties, required, additionalProperties } = rf.json_schema.schema;
+        expect(additionalProperties).toBe(false);
+        expect([...required].sort()).toEqual(Object.keys(properties).sort());
+    });
+
+    it('중첩 object(sections·table)도 같은 규격을 지킨다', () => {
+        const sec = (STRUCTURED_ANSWER_FORMAT as { properties: Record<string, { items?: Record<string, unknown> }> })
+            .properties.sections.items as { properties: Record<string, unknown>; required: string[]; additionalProperties: boolean };
+        expect(sec.additionalProperties).toBe(false);
+        expect([...sec.required].sort()).toEqual(Object.keys(sec.properties).sort());
+    });
+
+    it('선택 필드는 null 을 허용해 required 에 넣을 수 있게 한다', () => {
+        const props = (STRUCTURED_ANSWER_FORMAT as { properties: Record<string, { type: unknown }> }).properties;
+        for (const k of ['summary', 'risks', 'action_items']) {
+            expect(props[k].type).toEqual(expect.arrayContaining(['null']));
+        }
+    });
+
     it("'json' 단축형은 json_object 로", () => {
         expect(toResponseFormat('json')).toEqual({ type: 'json_object' });
     });

--- a/apps/api/src/routes/chat.routes.ts
+++ b/apps/api/src/routes/chat.routes.ts
@@ -310,7 +310,7 @@ router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncH
                 undefined,
                 { format, signal: abortController.signal },
             );
-            return result.content ?? '';
+            return { text: result.content ?? '', truncated: result.metrics?.finish_reason === 'length' };
         };
     } else {
         // 외부 provider(OpenRouter/ChatGPT 등) — streamChat 을 집계(비스트리밍)하되
@@ -337,7 +337,7 @@ router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncH
                 },
                 {}, // 토큰 콜백 불필요 — 누적 결과(content)만 사용
             );
-            return result.content ?? '';
+            return { text: result.content ?? '', truncated: result.finishReason === 'length' };
         };
     }
 

--- a/apps/api/src/routes/chat.routes.ts
+++ b/apps/api/src/routes/chat.routes.ts
@@ -37,6 +37,12 @@ import { ExternalKeysRepository } from '../data/repositories/external-keys-repo'
 import { getPool } from '../data/models/unified-database';
 import { composeStructuredAnswer, type StructuredChatFn } from '../services/answer-composer';
 import { toResponseFormat } from '../llm/stream-parser';
+
+/**
+ * 구조화 답변 1회 출력 토큰 상한. strict json_schema 가 모든 필드를 채우게 해 출력이 길다 —
+ * 상한이 낮으면 finish_reason=length 로 잘려 JSON 파싱이 실패한다(실측 2026-08-24: 1200 부족).
+ */
+const STRUCTURED_MAX_OUTPUT_TOKENS = parseInt(process.env.STRUCTURED_MAX_OUTPUT_TOKENS || '4096', 10);
 import { buildWebSearchContext } from '../mcp/web-search/build-search-context';
 import { detectLanguage } from '../chat/language-policy';
 import { getCurrentDate } from '../utils/datetime';
@@ -296,10 +302,14 @@ router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncH
         });
         usedModel = client.model;
         chat = async (messages, format) => {
-            const result = await client.chat(messages, undefined, undefined, {
-                format,
-                signal: abortController.signal,
-            });
+            const result = await client.chat(
+                messages,
+                // strict json_schema 는 모든 필드를 채우게 하므로 출력이 길다 — 기본값으로는
+                // finish_reason=length 로 잘려 JSON 파싱이 실패한다(실측 2026-08-24).
+                { num_predict: STRUCTURED_MAX_OUTPUT_TOKENS },
+                undefined,
+                { format, signal: abortController.signal },
+            );
             return result.content ?? '';
         };
     } else {
@@ -321,6 +331,7 @@ router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncH
                 {
                     messages,
                     modelId: resolved.modelId,
+                    maxTokens: STRUCTURED_MAX_OUTPUT_TOKENS,
                     abortSignal: abortController.signal,
                     ...(responseFormat ? { responseFormat } : {}),
                 },

--- a/apps/api/src/schemas/structured-answer.schema.ts
+++ b/apps/api/src/schemas/structured-answer.schema.ts
@@ -33,6 +33,12 @@ export const ANSWER_INTENTS = [
 
 export type AnswerIntent = (typeof ANSWER_INTENTS)[number];
 
+/**
+ * strict json_schema 는 모든 키를 required 로 요구하므로 모델이 "값 없음"을 null 로 보낸다.
+ * 그 null 을 미지정(undefined)과 동일하게 취급한다 — 기존 출력 타입(optional)은 그대로 유지.
+ */
+const nullToUndefined = (v: unknown): unknown => (v === null ? undefined : v);
+
 const TableSchema = z.object({
     headers: z.array(z.string()),
     rows: z.array(z.array(z.string())),
@@ -41,8 +47,8 @@ const TableSchema = z.object({
 const SectionSchema = z.object({
     heading: z.string(),
     body: z.string(),
-    bullets: z.array(z.string()).optional(),
-    table: TableSchema.optional(),
+    bullets: z.preprocess(nullToUndefined, z.array(z.string()).optional()),
+    table: z.preprocess(nullToUndefined, TableSchema.optional()),
 });
 
 /**
@@ -52,48 +58,65 @@ export const StructuredAnswerSchema = z.object({
     intent: z.enum(ANSWER_INTENTS),
     title: z.string(),
     conclusion: z.string(),
-    summary: z.string().optional().default(''),
+    // 선택 필드는 null 도 수용한다 — OpenAI strict json_schema 는 모든 키를 required 로 요구하므로
+    // 모델이 "값 없음"을 null 로 표현한다(아래 STRUCTURED_ANSWER_FORMAT 주석 참고).
+    summary: z.preprocess(nullToUndefined, z.string().optional().default('')),
     sections: z.array(SectionSchema),
-    risks: z.array(z.string()).optional(),
-    action_items: z.array(z.string()).optional(),
+    risks: z.preprocess(nullToUndefined, z.array(z.string()).optional()),
+    action_items: z.preprocess(nullToUndefined, z.array(z.string()).optional()),
     confidence: z.enum(['high', 'medium', 'low']),
 });
 
 export type StructuredAnswer = z.infer<typeof StructuredAnswerSchema>;
 
 /**
- * LLMClient `advancedOptions.format` 으로 전달할 JSON Schema (vLLM json_schema, strict).
- * stream-parser.toResponseFormat 가 { type:'json_schema', json_schema:{ schema:{ type:'object', properties, required } } } 로 변환.
+ * LLMClient `advancedOptions.format` 으로 전달할 JSON Schema (json_schema, strict).
+ *
+ * ⚠️ **OpenAI strict 규격 준수 필수** (실측 2026-08-24): strict 모드는
+ *   ① 모든 object 에 `additionalProperties: false`
+ *   ② `required` 가 **모든** property 를 나열 (부분집합 불가)
+ * 를 요구한다. 이를 어기면 OpenAI 계열(ChatGPT·OpenRouter)에서 스키마가 **강제되지 않고**
+ * 모델이 필드를 빠뜨린다 — 실제로 `intent` 하나가 누락돼 검증 2회 실패 → degrade 했다.
+ * (로컬 vLLM 의 guided decoding 은 더 관대해 이 위반이 드러나지 않았다.)
+ *
+ * 그래서 값이 선택적인 필드도 required 에 넣되 **null 을 허용**하고, Zod 쪽에서
+ * null 을 미지정으로 정규화한다(위 nullToUndefined).
  */
+const TABLE_SCHEMA = {
+    type: ['object', 'null'],
+    properties: {
+        headers: { type: 'array', items: { type: 'string' } },
+        rows: { type: 'array', items: { type: 'array', items: { type: 'string' } } },
+    },
+    required: ['headers', 'rows'],
+    additionalProperties: false,
+};
+
+const SECTION_SCHEMA = {
+    type: 'object',
+    properties: {
+        heading: { type: 'string' },
+        body: { type: 'string' },
+        bullets: { type: ['array', 'null'], items: { type: 'string' } },
+        table: TABLE_SCHEMA,
+    },
+    required: ['heading', 'body', 'bullets', 'table'],
+    additionalProperties: false,
+};
+
 export const STRUCTURED_ANSWER_FORMAT: FormatOption = {
     type: 'object',
     properties: {
         intent: { type: 'string', enum: [...ANSWER_INTENTS] },
         title: { type: 'string' },
         conclusion: { type: 'string' },
-        summary: { type: 'string' },
-        sections: {
-            type: 'array',
-            items: {
-                type: 'object',
-                properties: {
-                    heading: { type: 'string' },
-                    body: { type: 'string' },
-                    bullets: { type: 'array', items: { type: 'string' } },
-                    table: {
-                        type: 'object',
-                        properties: {
-                            headers: { type: 'array', items: { type: 'string' } },
-                            rows: { type: 'array', items: { type: 'array', items: { type: 'string' } } },
-                        },
-                    },
-                },
-                required: ['heading', 'body'],
-            },
-        },
-        risks: { type: 'array', items: { type: 'string' } },
-        action_items: { type: 'array', items: { type: 'string' } },
+        summary: { type: ['string', 'null'] },
+        sections: { type: 'array', items: SECTION_SCHEMA },
+        risks: { type: ['array', 'null'], items: { type: 'string' } },
+        action_items: { type: ['array', 'null'], items: { type: 'string' } },
         confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
     },
-    required: ['intent', 'title', 'conclusion', 'sections', 'confidence'],
+    // strict 규격: 모든 property 를 나열해야 한다 (선택 필드는 위에서 null 허용).
+    required: ['intent', 'title', 'conclusion', 'summary', 'sections', 'risks', 'action_items', 'confidence'],
+    additionalProperties: false,
 };

--- a/apps/api/src/services/answer-composer.degrade.test.ts
+++ b/apps/api/src/services/answer-composer.degrade.test.ts
@@ -56,6 +56,29 @@ describe('composeStructuredAnswer — degrade', () => {
         expect(retry[0].role).toBe('system');
     });
 
+    it('길이 상한으로 잘리면 스키마 재안내 대신 "짧게 쓰라"고 재시도한다', async () => {
+        // 잘린 출력에 스키마를 다시 설명해봐야 소용없다 — 더 짧게 쓰게 해야 회복된다.
+        const hints: string[] = [];
+        let n = 0;
+        const r = await composeStructuredAnswer({
+            message: 'q',
+            chat: async (msgs) => {
+                const last = msgs[msgs.length - 1];
+                if (n++ === 0) return { text: '{"intent":"expla', truncated: true };
+                hints.push(String(last.content));
+                return {
+                    text: JSON.stringify({
+                        intent: 'explanation', title: 't', conclusion: 'c',
+                        summary: 's', sections: [], confidence: 'high',
+                    }),
+                    truncated: false,
+                };
+            },
+        });
+        expect(r.degraded).toBeUndefined();
+        expect(hints[0]).toMatch(/짧게/);
+    });
+
     it('2회 스키마 실패 후 평문을 최소 구조로 감싸 반환한다 (schema_invalid)', async () => {
         let n = 0;
         const r = await composeStructuredAnswer({

--- a/apps/api/src/services/answer-composer.degrade.test.ts
+++ b/apps/api/src/services/answer-composer.degrade.test.ts
@@ -41,6 +41,21 @@ describe('composeStructuredAnswer — degrade', () => {
         })).rejects.toThrow(/ECONNREFUSED/);
     });
 
+    it('교정 재시도는 system 이 아니라 user 로 덧붙인다 (chat_template 400 회귀)', async () => {
+        // 일부 chat_template(qwen 등)은 system 이 맨 앞에만 오는 것을 강제한다 —
+        // 뒤에 붙이면 400 "System message must be at the beginning" 이 나고 500 으로 샌다.
+        const seen: Array<Array<{ role: string }>> = [];
+        await composeStructuredAnswer({
+            message: 'q',
+            chat: async (msgs) => { seen.push(msgs as Array<{ role: string }>); return 'not json'; },
+        }).catch(() => { /* degrade 결과는 여기서 관심 없음 */ });
+        const retry = seen[1];
+        expect(retry[retry.length - 1].role).toBe('user');
+        // system 은 맨 앞 1개만 유지된다.
+        expect(retry.filter((m) => m.role === 'system')).toHaveLength(1);
+        expect(retry[0].role).toBe('system');
+    });
+
     it('2회 스키마 실패 후 평문을 최소 구조로 감싸 반환한다 (schema_invalid)', async () => {
         let n = 0;
         const r = await composeStructuredAnswer({

--- a/apps/api/src/services/answer-composer.test.ts
+++ b/apps/api/src/services/answer-composer.test.ts
@@ -193,3 +193,20 @@ describe('answer-composer: composeStructuredAnswer', () => {
         expect(r.structured.confidence).toBe('low');
     });
 });
+
+describe('StructuredAnswerSchema — strict 스키마의 null 수용', () => {
+    it('선택 필드가 null 로 와도 통과하고 미지정과 동일하게 정규화된다', () => {
+        // strict json_schema 는 모든 키를 required 로 요구하므로 모델이 "값 없음"을 null 로 보낸다.
+        const parsed = StructuredAnswerSchema.parse({
+            intent: 'explanation', title: 'T', conclusion: 'C',
+            summary: null, risks: null, action_items: null,
+            sections: [{ heading: 'H', body: 'B', bullets: null, table: null }],
+            confidence: 'high',
+        });
+        expect(parsed.summary).toBe('');
+        expect(parsed.risks).toBeUndefined();
+        expect(parsed.action_items).toBeUndefined();
+        expect(parsed.sections[0].bullets).toBeUndefined();
+        expect(parsed.sections[0].table).toBeUndefined();
+    });
+});

--- a/apps/api/src/services/answer-composer.ts
+++ b/apps/api/src/services/answer-composer.ts
@@ -27,7 +27,7 @@ import {
     type AnswerIntent,
 } from '../schemas/structured-answer.schema';
 import { classifyAnswerIntent } from '../chat/answer-planner';
-import { buildAnswerComposerSystemPrompt, getRepairHint } from '../prompts/answer-composer-system';
+import { buildAnswerComposerSystemPrompt, getRepairHint, getLengthRepairHint } from '../prompts/answer-composer-system';
 import type { ChatMessage, FormatOption } from '../llm/types';
 
 const logger = createLogger('AnswerComposer');
@@ -37,7 +37,10 @@ const logger = createLogger('AnswerComposer');
  * 구조화 답변용 1회 LLM 호출. `format` 이 undefined 면 **스키마 강제 없이** 호출한다
  * (guided decoding 미지원 백엔드로의 degrade 경로 — 외부 provider 경로는 원래 format 을 무시한다).
  */
-export type StructuredChatFn = (messages: ChatMessage[], format?: FormatOption) => Promise<string>;
+export type StructuredChatFn = (
+    messages: ChatMessage[],
+    format?: FormatOption,
+) => Promise<string | { text: string; truncated: boolean }>;
 
 /**
  * StructuredAnswer → 일정한 마크다운 (제안서 8절 formatAnswer 정확 구현).
@@ -162,21 +165,28 @@ export async function composeStructuredAnswer(opts: {
      * 한 번 더 호출한다 — 외부 provider 경로가 원래 그렇게 동작하므로 프롬프트만으로도
      * 유효 JSON 이 나올 수 있다. 이 경로를 타면 degraded 사유를 남긴다.
      */
+    const asText = (r: Awaited<ReturnType<StructuredChatFn>>) =>
+        typeof r === 'string' ? { text: r, truncated: false } : r;
+
+    /** 직전 시도가 **길이 상한**에 걸려 잘렸는지 — 재시도 힌트를 고르는 데 쓴다. */
+    let lastTruncated = false;
+
     const attempt = async (msgs: ChatMessage[]): Promise<StructuredAnswer | null> => {
-        let raw: string;
+        let raw: { text: string; truncated: boolean };
         try {
-            raw = await opts.chat(msgs, STRUCTURED_ANSWER_FORMAT);
+            raw = asText(await opts.chat(msgs, STRUCTURED_ANSWER_FORMAT));
         } catch (e) {
             if (!isFormatUnsupportedError(e)) throw e;
             logger.warn(`백엔드가 json_schema 를 거절 — 스키마 없이 재시도: ${errText(e).slice(0, 160)}`);
             degraded = 'format_unsupported';
-            raw = await opts.chat(msgs);
+            raw = asText(await opts.chat(msgs));
         }
+        lastTruncated = raw.truncated;
         let parsed: unknown;
         try {
-            parsed = parseStructured(raw);
+            parsed = parseStructured(raw.text);
         } catch {
-            logger.warn('구조화 출력 JSON 파싱 실패');
+            logger.warn(`구조화 출력 JSON 파싱 실패${raw.truncated ? ' (길이 상한으로 잘림)' : ''}`);
             return null;
         }
         const result = StructuredAnswerSchema.safeParse(parsed);
@@ -185,14 +195,14 @@ export async function composeStructuredAnswer(opts: {
 
     let structured = await attempt(messages);
     if (!structured) {
-        // 1회 재시도 — 교정 힌트 추가.
-        // 교정 힌트는 **user** 로 덧붙인다 — 일부 chat_template(qwen 등)은 system 이 맨 앞에만
+        // 1회 재시도 — 실패 원인에 맞는 힌트를 고른다.
+        //  · 길이 상한으로 잘렸으면 스키마를 다시 설명해봐야 소용없다 → **짧게 쓰라**고 지시한다.
+        //  · 그 외(스키마 불일치)는 기존 교정 힌트.
+        // 힌트는 **user** 로 덧붙인다 — 일부 chat_template(qwen 등)은 system 이 맨 앞에만
         // 오는 것을 강제해, 뒤에 붙이면 400 "System message must be at the beginning" 이 난다
         // (실측 2026-08-24: 이 경로가 500 으로 새어나갔다).
-        structured = await attempt([
-            ...messages,
-            { role: 'user', content: getRepairHint(lang) },
-        ]);
+        const hint = lastTruncated ? getLengthRepairHint(lang) : getRepairHint(lang);
+        structured = await attempt([...messages, { role: 'user', content: hint }]);
     }
 
     if (!structured) {
@@ -200,7 +210,7 @@ export async function composeStructuredAnswer(opts: {
         // 최소 구조로 감싼다(confidence=low: 구조 검증을 통과하지 못했음을 정직하게 표기).
         // 여기서도 내용이 없을 때만 422 로 실패한다.
         logger.warn('구조화 2회 실패 — 평문 답변으로 degrade');
-        const plain = (await opts.chat(messages)).trim();
+        const plain = asText(await opts.chat(messages)).text.trim();
         if (!plain) {
             throw new AppError('구조화 답변 검증 실패 (스키마 불일치)', 422, true, 'STRUCTURED_OUTPUT_INVALID');
         }

--- a/apps/api/src/services/answer-composer.ts
+++ b/apps/api/src/services/answer-composer.ts
@@ -186,9 +186,12 @@ export async function composeStructuredAnswer(opts: {
     let structured = await attempt(messages);
     if (!structured) {
         // 1회 재시도 — 교정 힌트 추가.
+        // 교정 힌트는 **user** 로 덧붙인다 — 일부 chat_template(qwen 등)은 system 이 맨 앞에만
+        // 오는 것을 강제해, 뒤에 붙이면 400 "System message must be at the beginning" 이 난다
+        // (실측 2026-08-24: 이 경로가 500 으로 새어나갔다).
         structured = await attempt([
             ...messages,
-            { role: 'system', content: getRepairHint(lang) },
+            { role: 'user', content: getRepairHint(lang) },
         ]);
     }
 


### PR DESCRIPTION
#601 로 되돌린 strict 스키마를, 500 을 유발했던 두 원인을 함께 고쳐 **다시** 올립니다.

## 무엇이 문제였나

1. **출력 잘림** — strict 규격이 8개 필드를 모두 채우게 해 출력이 길어졌는데 토큰 상한이 낮아 `finish_reason=length` 로 JSON 이 잘렸다.
2. **교정 재시도의 system 위치** — 잘림 후 재시도가 메시지 **끝에 system** 을 붙여, qwen chat_template 이 `400 System message must be at the beginning` 을 반환 → 500 전파.

## 무엇을 고쳤나

- 구조화 호출의 출력 상한을 `STRUCTURED_MAX_OUTPUT_TOKENS`(4096)로 명시 — 로컬·외부 경로 양쪽.
- 교정 힌트를 **user** 로 덧붙인다 (system 은 맨 앞 1개 유지).
- **잘렸을 때는 스키마를 다시 설명하지 않고 "짧게 쓰라"고 지시한다** — 원인이 스키마가 아니라 길이이므로. sections 2개·body 2문장 이내로 줄이도록 유도.

## 검증 (LiteLLM 라이브, 2026-08-24)

| 조건 | 결과 |
|---|---|
| 정상 상한(4096), 일반 질의 | degrade 없음, 4 섹션 |
| 정상 상한, 일부러 긴 질의 | degrade 없음, 16 섹션·9.4KB — 잘리지 않음 |
| 상한 700 으로 **강제 잘림** | 두 질의 모두 재시도 1회로 회복, degrade 없음 |

유닛 31개 통과(잘림 회복·재시도 role 회귀 테스트 포함).

🤖 Generated with [Claude Code](https://claude.com/claude-code)