### PR TITLE
revert: #599 구조화 strict 스키마 되돌리기 — 운영 500 긴급 복구

### DIFF
--- a/apps/api/src/llm/stream-parser.ts
+++ b/apps/api/src/llm/stream-parser.ts
@@ -95,10 +95,6 @@ export function toResponseFormat(f: FormatOption | undefined): Record<string, un
                 type: 'object',
                 properties: f.properties,
                 ...(f.required && { required: f.required }),
-                // strict 모드 필수 — 누락하면 OpenAI 계열이 스키마를 강제하지 않는다(실측 2026-08-24).
-                ...(f.additionalProperties !== undefined
-                    ? { additionalProperties: f.additionalProperties }
-                    : {}),
             },
             strict: true,
         },

--- a/apps/api/src/llm/types.ts
+++ b/apps/api/src/llm/types.ts
@@ -202,12 +202,6 @@ export type FormatOption = 'json' | {
     type: 'object';
     properties: Record<string, unknown>;
     required?: string[];
-    /**
-     * OpenAI strict json_schema 규격 — strict 모드는 모든 object 에 이 값이 false 여야 하고
-     * required 가 모든 property 를 나열해야 한다. 누락 시 OpenAI 계열에서 스키마가 강제되지
-     * 않는다(실측 2026-08-24). vLLM guided decoding 은 더 관대해 이 위반이 드러나지 않았다.
-     */
-    additionalProperties?: boolean;
 };
 
 /**

--- a/apps/api/src/providers/openai-compat-format.test.ts
+++ b/apps/api/src/providers/openai-compat-format.test.ts
@@ -22,31 +22,6 @@ describe('구조화 응답 포맷 변환', () => {
         );
     });
 
-    it('OpenAI strict 규격을 지킨다 — required=전체 property + additionalProperties:false', () => {
-        // 실측 2026-08-24: 이 규격을 어기면 OpenAI 계열(ChatGPT·OpenRouter)이 스키마를 강제하지
-        // 않아 모델이 intent 를 빠뜨렸다. 로컬 vLLM 은 관대해 드러나지 않던 위반이다.
-        const rf = toResponseFormat(STRUCTURED_ANSWER_FORMAT) as {
-            json_schema: { schema: { properties: Record<string, unknown>; required: string[]; additionalProperties: boolean } };
-        };
-        const { properties, required, additionalProperties } = rf.json_schema.schema;
-        expect(additionalProperties).toBe(false);
-        expect([...required].sort()).toEqual(Object.keys(properties).sort());
-    });
-
-    it('중첩 object(sections·table)도 같은 규격을 지킨다', () => {
-        const sec = (STRUCTURED_ANSWER_FORMAT as { properties: Record<string, { items?: Record<string, unknown> }> })
-            .properties.sections.items as { properties: Record<string, unknown>; required: string[]; additionalProperties: boolean };
-        expect(sec.additionalProperties).toBe(false);
-        expect([...sec.required].sort()).toEqual(Object.keys(sec.properties).sort());
-    });
-
-    it('선택 필드는 null 을 허용해 required 에 넣을 수 있게 한다', () => {
-        const props = (STRUCTURED_ANSWER_FORMAT as { properties: Record<string, { type: unknown }> }).properties;
-        for (const k of ['summary', 'risks', 'action_items']) {
-            expect(props[k].type).toEqual(expect.arrayContaining(['null']));
-        }
-    });
-
     it("'json' 단축형은 json_object 로", () => {
         expect(toResponseFormat('json')).toEqual({ type: 'json_object' });
     });

--- a/apps/api/src/schemas/structured-answer.schema.ts
+++ b/apps/api/src/schemas/structured-answer.schema.ts
@@ -33,12 +33,6 @@ export const ANSWER_INTENTS = [
 
 export type AnswerIntent = (typeof ANSWER_INTENTS)[number];
 
-/**
- * strict json_schema 는 모든 키를 required 로 요구하므로 모델이 "값 없음"을 null 로 보낸다.
- * 그 null 을 미지정(undefined)과 동일하게 취급한다 — 기존 출력 타입(optional)은 그대로 유지.
- */
-const nullToUndefined = (v: unknown): unknown => (v === null ? undefined : v);
-
 const TableSchema = z.object({
     headers: z.array(z.string()),
     rows: z.array(z.array(z.string())),
@@ -47,8 +41,8 @@ const TableSchema = z.object({
 const SectionSchema = z.object({
     heading: z.string(),
     body: z.string(),
-    bullets: z.preprocess(nullToUndefined, z.array(z.string()).optional()),
-    table: z.preprocess(nullToUndefined, TableSchema.optional()),
+    bullets: z.array(z.string()).optional(),
+    table: TableSchema.optional(),
 });
 
 /**
@@ -58,65 +52,48 @@ export const StructuredAnswerSchema = z.object({
     intent: z.enum(ANSWER_INTENTS),
     title: z.string(),
     conclusion: z.string(),
-    // 선택 필드는 null 도 수용한다 — OpenAI strict json_schema 는 모든 키를 required 로 요구하므로
-    // 모델이 "값 없음"을 null 로 표현한다(아래 STRUCTURED_ANSWER_FORMAT 주석 참고).
-    summary: z.preprocess(nullToUndefined, z.string().optional().default('')),
+    summary: z.string().optional().default(''),
     sections: z.array(SectionSchema),
-    risks: z.preprocess(nullToUndefined, z.array(z.string()).optional()),
-    action_items: z.preprocess(nullToUndefined, z.array(z.string()).optional()),
+    risks: z.array(z.string()).optional(),
+    action_items: z.array(z.string()).optional(),
     confidence: z.enum(['high', 'medium', 'low']),
 });
 
 export type StructuredAnswer = z.infer<typeof StructuredAnswerSchema>;
 
 /**
- * LLMClient `advancedOptions.format` 으로 전달할 JSON Schema (json_schema, strict).
- *
- * ⚠️ **OpenAI strict 규격 준수 필수** (실측 2026-08-24): strict 모드는
- *   ① 모든 object 에 `additionalProperties: false`
- *   ② `required` 가 **모든** property 를 나열 (부분집합 불가)
- * 를 요구한다. 이를 어기면 OpenAI 계열(ChatGPT·OpenRouter)에서 스키마가 **강제되지 않고**
- * 모델이 필드를 빠뜨린다 — 실제로 `intent` 하나가 누락돼 검증 2회 실패 → degrade 했다.
- * (로컬 vLLM 의 guided decoding 은 더 관대해 이 위반이 드러나지 않았다.)
- *
- * 그래서 값이 선택적인 필드도 required 에 넣되 **null 을 허용**하고, Zod 쪽에서
- * null 을 미지정으로 정규화한다(위 nullToUndefined).
+ * LLMClient `advancedOptions.format` 으로 전달할 JSON Schema (vLLM json_schema, strict).
+ * stream-parser.toResponseFormat 가 { type:'json_schema', json_schema:{ schema:{ type:'object', properties, required } } } 로 변환.
  */
-const TABLE_SCHEMA = {
-    type: ['object', 'null'],
-    properties: {
-        headers: { type: 'array', items: { type: 'string' } },
-        rows: { type: 'array', items: { type: 'array', items: { type: 'string' } } },
-    },
-    required: ['headers', 'rows'],
-    additionalProperties: false,
-};
-
-const SECTION_SCHEMA = {
-    type: 'object',
-    properties: {
-        heading: { type: 'string' },
-        body: { type: 'string' },
-        bullets: { type: ['array', 'null'], items: { type: 'string' } },
-        table: TABLE_SCHEMA,
-    },
-    required: ['heading', 'body', 'bullets', 'table'],
-    additionalProperties: false,
-};
-
 export const STRUCTURED_ANSWER_FORMAT: FormatOption = {
     type: 'object',
     properties: {
         intent: { type: 'string', enum: [...ANSWER_INTENTS] },
         title: { type: 'string' },
         conclusion: { type: 'string' },
-        summary: { type: ['string', 'null'] },
-        sections: { type: 'array', items: SECTION_SCHEMA },
-        risks: { type: ['array', 'null'], items: { type: 'string' } },
-        action_items: { type: ['array', 'null'], items: { type: 'string' } },
+        summary: { type: 'string' },
+        sections: {
+            type: 'array',
+            items: {
+                type: 'object',
+                properties: {
+                    heading: { type: 'string' },
+                    body: { type: 'string' },
+                    bullets: { type: 'array', items: { type: 'string' } },
+                    table: {
+                        type: 'object',
+                        properties: {
+                            headers: { type: 'array', items: { type: 'string' } },
+                            rows: { type: 'array', items: { type: 'array', items: { type: 'string' } } },
+                        },
+                    },
+                },
+                required: ['heading', 'body'],
+            },
+        },
+        risks: { type: 'array', items: { type: 'string' } },
+        action_items: { type: 'array', items: { type: 'string' } },
         confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
     },
-    // strict 규격: 모든 property 를 나열해야 한다 (선택 필드는 위에서 null 허용).
-    required: ['intent', 'title', 'conclusion', 'summary', 'sections', 'risks', 'action_items', 'confidence'],
-    additionalProperties: false,
+    required: ['intent', 'title', 'conclusion', 'sections', 'confidence'],
 };

--- a/apps/api/src/services/answer-composer.test.ts
+++ b/apps/api/src/services/answer-composer.test.ts
@@ -193,20 +193,3 @@ describe('answer-composer: composeStructuredAnswer', () => {
         expect(r.structured.confidence).toBe('low');
     });
 });
-
-describe('StructuredAnswerSchema — strict 스키마의 null 수용', () => {
-    it('선택 필드가 null 로 와도 통과하고 미지정과 동일하게 정규화된다', () => {
-        // strict json_schema 는 모든 키를 required 로 요구하므로 모델이 "값 없음"을 null 로 보낸다.
-        const parsed = StructuredAnswerSchema.parse({
-            intent: 'explanation', title: 'T', conclusion: 'C',
-            summary: null, risks: null, action_items: null,
-            sections: [{ heading: 'H', body: 'B', bullets: null, table: null }],
-            confidence: 'high',
-        });
-        expect(parsed.summary).toBe('');
-        expect(parsed.risks).toBeUndefined();
-        expect(parsed.action_items).toBeUndefined();
-        expect(parsed.sections[0].bullets).toBeUndefined();
-        expect(parsed.sections[0].table).toBeUndefined();
-    });
-});


### PR DESCRIPTION
## 왜 되돌리는가

#599 배포 후 `POST /api/chat/structured` 가 **500** 이 됐습니다. 원인은 확인됐지만(#600) 복구를 먼저 합니다.

- strict 규격이 8개 필드를 모두 채우게 해 출력이 길어짐 → `finish_reason: length` 로 JSON 잘림 → 파싱 실패
- 그 다음 교정 재시도가 메시지 **끝에 system 을 붙여** `400 System message must be at the beginning` → 500 전파

영향 범위는 구조화 엔드포인트 한 곳이며 일반 채팅·스트리밍은 정상입니다.

## 되돌린 뒤

수정은 **#600 에서 따로** 올립니다. 재적용 시에는 출력 길이 문제까지 함께 해결한 뒤 배포합니다(출력 상한 명시 + 길어질 때 스스로 줄이도록).

🤖 Generated with [Claude Code](https://claude.com/claude-code)