### PR TITLE
fix(chatgpt): 구조화 모드에서 ChatGPT 가 스키마를 무시하던 문제

### DIFF
--- a/apps/api/src/providers/chatgpt-oauth/provider.ts
+++ b/apps/api/src/providers/chatgpt-oauth/provider.ts
@@ -112,6 +112,31 @@ export interface ChatGPTOAuthProviderOptions {
     transportFactory?: TransportFactory;
 }
 
+/**
+ * chat/completions 의 `response_format`(json_schema) → Responses API 의 `text.format`.
+ *
+ * Codex 백엔드는 chat/completions 계열 파라미터를 받지 않으므로, 구조화 요청이
+ * 그대로 전달되면 **조용히 무시**되어 스키마가 강제되지 않는다(실측 2026-08-24:
+ * intent 누락 → 컴포저가 평문 degrade → 원본 JSON 이 본문에 노출).
+ */
+function toResponsesTextFormat(
+    responseFormat?: Record<string, unknown>,
+): { text: { format: Record<string, unknown> } } | undefined {
+    if (!responseFormat || responseFormat.type !== 'json_schema') return undefined;
+    const js = responseFormat.json_schema as Record<string, unknown> | undefined;
+    if (!js?.schema) return undefined;
+    return {
+        text: {
+            format: {
+                type: 'json_schema',
+                name: typeof js.name === 'string' ? js.name : 'response',
+                schema: js.schema,
+                ...(js.strict !== undefined ? { strict: js.strict } : {}),
+            },
+        },
+    };
+}
+
 export class ChatGPTOAuthProvider implements IProvider {
     readonly id = CHATGPT_PROVIDER_ID;
     readonly sdkType: SdkType = 'openai-compatible';
@@ -257,6 +282,7 @@ export class ChatGPTOAuthProvider implements IProvider {
                     ? { tool_choice: toResponsesToolChoice(opts.tool_choice, codec) }
                     : {}),
                 // temperature / max_output_tokens 미전달 — Codex 백엔드 거부 회피
+                ...(toResponsesTextFormat(opts.responseFormat) ?? {}),
             };
 
             const stream = await this.client.responses.create(

--- a/apps/api/src/services/answer-composer.degrade.test.ts
+++ b/apps/api/src/services/answer-composer.degrade.test.ts
@@ -56,6 +56,21 @@ describe('composeStructuredAnswer — degrade', () => {
         expect(retry[0].role).toBe('system');
     });
 
+    it('degrade 폴백이 스키마 모양 JSON 이면 raw JSON 대신 필드를 살린다', async () => {
+        // 실측 2026-08-24(ChatGPT 경로): 필수 필드(intent)가 빠진 JSON 이 그대로 conclusion 에
+        // 들어가 사용자에게 raw JSON 이 노출됐다.
+        const json = JSON.stringify({
+            title: '광합성', conclusion: '빛으로 양분을 만든다',
+            sections: [{ heading: '개요', body: '엽록체에서 일어난다' }],
+        });
+        const r = await composeStructuredAnswer({ message: 'q', chat: async () => json });
+        expect(r.degraded).toBe('schema_invalid');
+        expect(r.structured.conclusion).toBe('빛으로 양분을 만든다');
+        expect(r.structured.title).toBe('광합성');
+        expect(r.structured.sections).toHaveLength(1);
+        expect(r.markdown).not.toContain('"conclusion"');
+    });
+
     it('길이 상한으로 잘리면 스키마 재안내 대신 "짧게 쓰라"고 재시도한다', async () => {
         // 잘린 출력에 스키마를 다시 설명해봐야 소용없다 — 더 짧게 쓰게 해야 회복된다.
         const hints: string[] = [];

--- a/apps/api/src/services/answer-composer.ts
+++ b/apps/api/src/services/answer-composer.ts
@@ -132,6 +132,48 @@ export interface ComposeResult {
 }
 
 /**
+ * degrade 폴백의 본문 구성.
+ *
+ * 평문 호출 결과가 **스키마 모양의 JSON** 인 경우가 있다 — 모델이 프롬프트만 보고 JSON 을
+ * 뱉었지만 필수 필드(intent 등)가 빠져 검증에 실패한 경우다. 이때 원문을 그대로 conclusion 에
+ * 넣으면 사용자에게 raw JSON 이 노출된다(실측 2026-08-24: ChatGPT 경로). 살릴 수 있는 필드는
+ * 살리고, JSON 이 아니면 기존대로 평문을 conclusion 으로 쓴다.
+ */
+function salvageStructured(
+    plain: string,
+    intent: StructuredAnswer['intent'],
+    message: string,
+): Omit<StructuredAnswer, 'confidence'> {
+    const fallbackTitle = message.slice(0, MAX_FALLBACK_TITLE_CHARS);
+    let obj: Record<string, unknown> | undefined;
+    try {
+        const parsed = parseStructured(plain);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            obj = parsed as Record<string, unknown>;
+        }
+    } catch {
+        // JSON 이 아니면 평문 그대로 — 정상 경로.
+    }
+    if (!obj || typeof obj.conclusion !== 'string' || !obj.conclusion.trim()) {
+        return { intent, title: fallbackTitle, conclusion: plain, summary: '', sections: [] };
+    }
+    const str = (v: unknown) => (typeof v === 'string' ? v : '');
+    const sections = Array.isArray(obj.sections)
+        ? obj.sections
+              .filter((x): x is Record<string, unknown> => !!x && typeof x === 'object')
+              .map((x) => ({ heading: str(x.heading), body: str(x.body) }))
+              .filter((x) => x.heading || x.body)
+        : [];
+    return {
+        intent,
+        title: str(obj.title) || fallbackTitle,
+        conclusion: obj.conclusion,
+        summary: str(obj.summary),
+        sections,
+    };
+}
+
+/**
  * 구조화 답변 합성. Answer Planner → Generator → Validator → Response Formatter.
  * Validator 실패 시 교정 힌트로 1회 재시도, 그래도 실패면 422.
  */
@@ -215,14 +257,7 @@ export async function composeStructuredAnswer(opts: {
             throw new AppError('구조화 답변 검증 실패 (스키마 불일치)', 422, true, 'STRUCTURED_OUTPUT_INVALID');
         }
         degraded = 'schema_invalid';
-        structured = {
-            intent,
-            title: opts.message.slice(0, MAX_FALLBACK_TITLE_CHARS),
-            conclusion: plain,
-            summary: '',
-            sections: [],
-            confidence: 'low',
-        };
+        structured = { ...salvageStructured(plain, intent, opts.message), confidence: 'low' };
     }
 
     const finalAnswer: StructuredAnswer = structured;


### PR DESCRIPTION
## 증상

chat.openmake.cc 구조화 답변 모드 + ChatGPT 모델(`gpt-5.4-mini`)에서 답변 카드에 **raw JSON 이 그대로** 표시되고 "확신 낮음"으로 degrade 됐습니다.

## 원인

`ChatGPTOAuthProvider.streamChat` 이 `opts.responseFormat` 을 **아무 데도 쓰지 않습니다**. Codex 백엔드는 Responses API 라 `response_format`(chat/completions 계열)을 받지 않으므로, 구조화 요청이 조용히 무시되고 모델은 프롬프트만 보고 JSON 을 뱉습니다. `intent` 가 빠져 검증 2회 실패 → 평문 degrade 인데, 그 평문이 JSON 이라 원문이 conclusion 에 통째로 들어갔습니다.

## 수정

1. `response_format`(json_schema) → Responses API `text.format` 변환 후 전달.
2. degrade 폴백이 스키마 모양 JSON 을 받으면 `title`/`conclusion`/`sections` 를 살려 렌더 — provider 무관하게 raw JSON 노출 차단.

## 검증 (라이브, 2026-08-24)

| 조건 | 결과 |
|---|---|
| 수정 전, `chatgpt:gpt-5.4-mini` + json_schema | 스키마 무시 — 평문 산문 반환 |
| 수정 후, 동일 조건 | `{"intent":"explanation","title":...}` 스키마 준수 JSON |

유닛 67개 통과(살리기 회귀 테스트 포함).

## 참고 — 이번 수정 범위 밖

`chatgpt:gpt-5.6-luna` 는 구조화 응답이 100초를 넘겨 **Cloudflare 524** 가 납니다. 구조화 엔드포인트가 비스트리밍이라 CF 무료 플랜의 100초 상한에 걸리는 인프라 제약이며, 별도 과제입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)