### PR TITLE
fix(chatgpt): 추론 강도가 ChatGPT 경로에서만 무시되던 문제

### DIFF
--- a/apps/api/src/providers/chatgpt-oauth/provider.ts
+++ b/apps/api/src/providers/chatgpt-oauth/provider.ts
@@ -38,6 +38,7 @@ import {
     isSessionExpired,
     refreshSession,
 } from './session';
+import type { ReasoningEffort } from '../../config/reasoning-effort';
 import {
     toResponsesInput,
     toResponsesTools,
@@ -110,6 +111,20 @@ export interface ChatGPTOAuthProviderOptions {
     persistSession?: (session: ChatGPTOAuthSessionPayload) => Promise<void>;
     /** 테스트 전용 — core transport 대체 주입 */
     transportFactory?: TransportFactory;
+}
+
+/**
+ * `thinking`(추론 강도) → Responses API 의 `reasoning.effort`.
+ *
+ * Codex 카탈로그는 전부 GPT-5 계열 reasoning 모델이라 강도 조절이 의미가 있는데,
+ * 이 값을 전달하지 않아 채팅 UI 의 추론 강도 토글이 ChatGPT 경로에서만 무시됐다.
+ * boolean(단순 on/off)은 강도를 특정하지 못하므로 모델 기본값에 맡긴다.
+ */
+function toResponsesReasoning(
+    thinking?: boolean | ReasoningEffort | { budget: number },
+): { reasoning: { effort: ReasoningEffort } } | undefined {
+    if (typeof thinking !== 'string') return undefined;
+    return { reasoning: { effort: thinking } };
 }
 
 /**
@@ -283,6 +298,7 @@ export class ChatGPTOAuthProvider implements IProvider {
                     : {}),
                 // temperature / max_output_tokens 미전달 — Codex 백엔드 거부 회피
                 ...(toResponsesTextFormat(opts.responseFormat) ?? {}),
+                ...(toResponsesReasoning(opts.thinking) ?? {}),
             };
 
             const stream = await this.client.responses.create(


### PR DESCRIPTION
## 증상

채팅 UI 의 **추론 강도**(low/medium/high/xhigh) 토글이 ChatGPT 모델에서 아무 효과가 없었습니다.

## 원인

`ChatGPTOAuthProvider.streamChat` 이 `opts.thinking` 을 요청에 싣지 않습니다. Codex 는 Responses API 라 강도를 `reasoning.effort` 로 받는데, 그 매핑이 없었습니다.

## 수정

`thinking` 이 강도 문자열이면 `reasoning: { effort }` 로 전달합니다. boolean(단순 on/off)은 강도를 특정하지 못하므로 모델 기본값에 맡깁니다.

## 검증 (라이브, 2026-08-24 · gpt-5.6-luna)

추론이 필요한 동일 프롬프트에서:

| effort | 소요 |
|---|---|
| low | 12초 |
| xhigh | 26초 |

수용만 되는 게 아니라 실제로 반영됩니다. 유닛 38개 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)