### PR TITLE
fix(skills): 재작성 제안이 조용히 실패하던 문제 + .claude/ 경로 규칙 정교화

### DIFF
--- a/apps/api/src/agents/git-ingest/__tests__/skill-rewriter.test.ts
+++ b/apps/api/src/agents/git-ingest/__tests__/skill-rewriter.test.ts
@@ -24,20 +24,51 @@ describe('skill-rewriter', () => {
         });
     });
 
+    // 마커 기반 — 본문에 코드블록·백틱·따옴표가 섞여도 이스케이프가 필요 없다
+    // (JSON 형식일 때 정상 종료했는데도 parse 실패하던 실측 사례로 전환, 2026-08-24)
     describe('parseRewriteResponse', () => {
-        it('JSON 파싱', () => {
-            const r = parseRewriteResponse(JSON.stringify({ changed: true, content: 'new', summary: ['a'] }));
-            expect(r).toEqual({ changed: true, content: 'new', summary: ['a'] });
+        it('마커 파싱 (요약 + 본문)', () => {
+            const r = parseRewriteResponse([
+                '===CHANGED=== yes',
+                '===SUMMARY===',
+                '- 도구 이름 교체',
+                '- 경로 조정',
+                '===CONTENT===',
+                '# 제목',
+                '본문입니다.',
+            ].join('\n'));
+            expect(r).toEqual({
+                changed: true,
+                content: '# 제목\n본문입니다.',
+                summary: ['도구 이름 교체', '경로 조정'],
+            });
         });
 
-        it('code fence 감싼 응답', () => {
-            const r = parseRewriteResponse('```json\n{"changed":false,"content":"","summary":[]}\n```');
-            expect(r?.changed).toBe(false);
+        it('changed=no 면 본문 없이 종료', () => {
+            expect(parseRewriteResponse('===CHANGED=== no')).toEqual({ changed: false, content: '', summary: [] });
         });
 
-        it('파싱 불가는 null', () => {
-            expect(parseRewriteResponse('not json')).toBeNull();
+        it('본문의 코드블록·따옴표·백슬래시를 그대로 보존 (이스케이프 불필요)', () => {
+            const body = '```bash\nrm -rf "$dir" \\\n  --force\n```\n\n`Read` 도구를 쓰세요.';
+            const r = parseRewriteResponse(`===CHANGED=== yes\n===SUMMARY===\n- x\n===CONTENT===\n${body}`);
+            expect(r?.content).toBe(body.trimEnd());
+        });
+
+        // 바깥 펜스를 벗기면 본문이 코드블록으로 시작/끝날 때 훼손된다 — 벗기지 않는다
+        it('바깥 펜스는 벗기지 않는다 (본문 파손 방지)', () => {
+            const r = parseRewriteResponse('===CHANGED=== yes\n===CONTENT===\n```\n# 본문\n```');
+            expect(r?.content).toBe('```\n# 본문\n```');
+        });
+
+        it('요약이 없어도 본문만 있으면 유효', () => {
+            const r = parseRewriteResponse('===CHANGED=== yes\n===CONTENT===\n본문');
+            expect(r).toEqual({ changed: true, content: '본문', summary: [] });
+        });
+
+        it('마커 없음·빈 응답·changed=yes 인데 본문 없음 → null', () => {
+            expect(parseRewriteResponse('그냥 텍스트')).toBeNull();
             expect(parseRewriteResponse('')).toBeNull();
+            expect(parseRewriteResponse('===CHANGED=== yes\n===SUMMARY===\n- x')).toBeNull();
         });
     });
 
@@ -67,19 +98,19 @@ describe('skill-rewriter', () => {
 
         it('변경 제안을 반환', async () => {
             const proposed = body.replace(/`Bash`/g, '`bash`');
-            const llm = mockLlm(JSON.stringify({ changed: true, content: proposed, summary: ['도구 이름 교체'] }));
+            const llm = mockLlm(`===CHANGED=== yes\n===SUMMARY===\n- 도구 이름 교체\n===CONTENT===\n${proposed}`);
             const r = await proposeSkillRewrite(llm, { name: 's', content: body, model: 'm' });
-            expect(r?.content).toBe(proposed);
+            expect(r?.content).toBe(proposed.trimEnd());
             expect(r?.summary).toEqual(['도구 이름 교체']);
         });
 
-        it('changed=false 면 제안 없음', async () => {
-            const llm = mockLlm(JSON.stringify({ changed: false, content: '', summary: [] }));
+        it('changed=no 면 제안 없음', async () => {
+            const llm = mockLlm('===CHANGED=== no');
             expect(await proposeSkillRewrite(llm, { name: 's', content: body, model: 'm' })).toBeNull();
         });
 
         it('내용이 급감하면 제안을 버린다', async () => {
-            const llm = mockLlm(JSON.stringify({ changed: true, content: '짧은 요약', summary: [] }));
+            const llm = mockLlm('===CHANGED=== yes\n===CONTENT===\n짧은 요약');
             expect(await proposeSkillRewrite(llm, { name: 's', content: body, model: 'm' })).toBeNull();
         });
 
@@ -89,7 +120,7 @@ describe('skill-rewriter', () => {
         });
 
         it('검사 대상을 경계 태그로 감싸 전달', async () => {
-            const llm = mockLlm(JSON.stringify({ changed: false, content: '', summary: [] }));
+            const llm = mockLlm('===CHANGED=== no');
             await proposeSkillRewrite(llm, { name: 's', content: body, model: 'm' });
             const messages = (llm.chat as jest.Mock).mock.calls[0][0];
             expect(messages[1].content).toContain('<skill_body>');

--- a/apps/api/src/agents/git-ingest/skill-compat.ts
+++ b/apps/api/src/agents/git-ingest/skill-compat.ts
@@ -138,7 +138,10 @@ export function buildCompatNote(mappings: readonly ToolMapping[], markers: reado
         lines.push('- `` !`명령` `` 형태의 자동 셸 주입은 이 환경에 없습니다 — 필요하면 에이전트 작업에서 `bash` 로 직접 실행하세요.');
     }
     if (markers.includes('.claude/')) {
-        lines.push('- `.claude/` · `CLAUDE.md` 경로는 이 환경에 존재하지 않습니다 — 해당 지침은 무시하세요.');
+        // ⚠️ "무시하라"로 뭉뚱그리면 안 된다 — `.claude/` 는 읽을 설정 경로일 때도 있고
+        // 스킬이 만들어내는 산출물 경로일 때도 있다(예: hookify 가 규칙 파일을 생성).
+        // 후자까지 무시시키면 스킬이 아무 결과도 내지 못한다.
+        lines.push('- `.claude/` · `CLAUDE.md` 는 이 환경에 없습니다. **읽으라는 지침이면 건너뛰고**, 스킬이 **만들어내는 파일 경로**면 `.claude/` 를 뗀 작업 디렉토리 기준 경로에 생성하세요 (그 파일이 원래 자동 실행되는 훅·설정이었다면 이 환경에서는 실행되지 않고 참고용으로만 남습니다).');
     }
 
     if (lines.length === 0) return '';

--- a/apps/api/src/agents/git-ingest/skill-rewriter.ts
+++ b/apps/api/src/agents/git-ingest/skill-rewriter.ts
@@ -16,7 +16,13 @@ import type { LLMClient } from '../../llm/client';
 import type { ChatMessage } from '../../llm/types';
 import { createLogger } from '../../utils/logger';
 import { SKILL_REWRITE, CLAUDE_TOOL_ALIASES } from '../../config/skill-compat';
-import { buildSkillRewriteSystemPrompt, buildSkillRewriteUserPrompt } from '../../prompts/skill-rewrite';
+import {
+    buildSkillRewriteSystemPrompt,
+    buildSkillRewriteUserPrompt,
+    REWRITE_CHANGED_MARKER,
+    REWRITE_SUMMARY_MARKER,
+    REWRITE_CONTENT_MARKER,
+} from '../../prompts/skill-rewrite';
 
 const logger = createLogger('SkillRewriter');
 
@@ -40,23 +46,41 @@ export function buildToolMappingHint(body: string): string {
     return lines.join('\n');
 }
 
-/** LLM 응답 텍스트 → 제안 객체. 파싱 불가면 null. */
+/**
+ * LLM 응답 텍스트 → 제안 객체. 파싱 불가면 null.
+ *
+ * 마커 기반 — 본문이 코드블록·백틱·따옴표가 섞인 긴 마크다운이라 JSON 문자열로 받으면
+ * 이스케이프가 깨진다(실측: 정상 종료했는데도 JSON.parse 실패). 마커는 그 문제가 없다.
+ */
 export function parseRewriteResponse(raw: string): { changed: boolean; content: string; summary: string[] } | null {
-    const trimmed = (raw ?? '').trim();
-    if (!trimmed) return null;
-    const fence = trimmed.match(/```(?:json)?\s*([\s\S]+?)\s*```/);
-    const candidate = fence ? fence[1] : trimmed;
-    try {
-        const parsed = JSON.parse(candidate) as { changed?: unknown; content?: unknown; summary?: unknown };
-        const changed = parsed.changed === true;
-        const content = typeof parsed.content === 'string' ? parsed.content : '';
-        const summary = Array.isArray(parsed.summary)
-            ? parsed.summary.filter((s): s is string => typeof s === 'string')
-            : [];
-        return { changed, content, summary };
-    } catch {
-        return null;
-    }
+    const text = (raw ?? '').trim();
+    if (!text) return null;
+
+    const changedIdx = text.indexOf(REWRITE_CHANGED_MARKER);
+    if (changedIdx === -1) return null;
+
+    // "===CHANGED=== yes|no"
+    const changedLineEnd = text.indexOf('\n', changedIdx);
+    const changedLine = (changedLineEnd === -1 ? text.slice(changedIdx) : text.slice(changedIdx, changedLineEnd));
+    const changed = /\b(yes|true)\b/i.test(changedLine.slice(REWRITE_CHANGED_MARKER.length));
+    if (!changed) return { changed: false, content: '', summary: [] };
+
+    const contentIdx = text.indexOf(REWRITE_CONTENT_MARKER);
+    if (contentIdx === -1) return null;   // changed=yes 인데 본문이 없으면 신뢰 불가
+
+    const summaryIdx = text.indexOf(REWRITE_SUMMARY_MARKER);
+    const summary = summaryIdx !== -1 && summaryIdx < contentIdx
+        ? text.slice(summaryIdx + REWRITE_SUMMARY_MARKER.length, contentIdx)
+            .split('\n')
+            .map(l => l.replace(/^\s*[-*]\s*/, '').trim())
+            .filter(Boolean)
+        : [];
+
+    // ⚠️ 바깥 펜스를 벗기지 않는다 — 본문이 코드블록으로 시작/끝나는 경우가 흔해
+    // (```bash … ```) 벗겨내면 본문 자체가 훼손된다. 프롬프트가 "펜스로 감싸지 말 것"을
+    // 지시하며, 설령 감싸더라도 앞뒤에 ``` 가 남는 편이 본문 파손보다 안전하다.
+    const content = text.slice(contentIdx + REWRITE_CONTENT_MARKER.length).replace(/^\r?\n/, '');
+    return { changed: true, content: content.trimEnd(), summary };
 }
 
 /**
@@ -92,7 +116,12 @@ export async function proposeSkillRewrite(
     try {
         const resp = await llm.chat(messages);
         const parsed = parseRewriteResponse(resp.content ?? '');
-        if (!parsed || !parsed.changed) return null;
+        if (!parsed) {
+            // 파싱 실패를 "변경 불필요"와 섞으면 진단이 불가능해진다 (실측 사례)
+            logger.warn(`재작성 응답 파싱 실패 (원문 유지): ${input.name} — 응답 ${(resp.content ?? '').length}자`);
+            return null;
+        }
+        if (!parsed.changed) return null;
         if (!isAcceptableRewrite(body, parsed.content)) {
             logger.warn(`재작성 제안 폐기 (내용 소실 의심): ${input.name} — ${body.length}자 → ${parsed.content.length}자`);
             return null;

--- a/apps/api/src/prompts/skill-rewrite.ts
+++ b/apps/api/src/prompts/skill-rewrite.ts
@@ -17,6 +17,16 @@ export const SKILL_REWRITE_TARGET_OPEN = '<skill_body>';
 export const SKILL_REWRITE_TARGET_CLOSE = '</skill_body>';
 
 /**
+ * 응답 마커 — JSON 대신 쓰는 이유: 스킬 본문은 코드블록·백틱·따옴표·개행이 많은 긴
+ * 마크다운이라, 이를 JSON 문자열에 담게 하면 로컬 모델이 이스케이프를 자주 깨뜨린다
+ * (2026-08-24 실측: finish_reason=stop 으로 정상 종료했는데도 JSON.parse 실패 →
+ * 제안이 조용히 "변경 없음"으로 처리됨). 마커 방식은 이스케이프가 아예 필요 없다.
+ */
+export const REWRITE_CHANGED_MARKER = '===CHANGED===';
+export const REWRITE_SUMMARY_MARKER = '===SUMMARY===';
+export const REWRITE_CONTENT_MARKER = '===CONTENT===';
+
+/**
  * @param toolMapping 이 환경의 도구 대응표 (예: "Read → file_ops")
  */
 export function buildSkillRewriteSystemPrompt(toolMapping: string): string {
@@ -46,20 +56,44 @@ ${toolMapping || '   (대응표 없음 — 도구 이름은 건드리지 마세�
    판단이 애매하면 **바꾸지 않는 쪽**을 택하세요.
 2. **플랫폼 지칭**: "Claude Code", "Claude Desktop", "이 CLI" 등 다른 제품 이름이
    동작을 설명할 때 → "이 환경" 으로. 단순 인용·출처 표기는 그대로 두세요.
-3. **존재하지 않는 경로·기능**: \`.claude/\`, \`CLAUDE.md\`, \`~/.claude/settings.json\`,
-   훅(hooks), 슬래시 명령 등록 절차처럼 이 환경에 없는 것을 지시하는 문장 →
-   그 단계를 건너뛰라는 짧은 안내로 바꾸세요 (문단 전체를 지우지는 마세요).
+3. **이 환경에 없는 경로·기능** — 용도에 따라 다르게 다룹니다. 뭉뚱그려 "건너뛰라"고
+   바꾸면 스킬이 아무 산출물도 못 내므로 아래 셋을 구분하세요:
+
+   (a) **읽어야 할 설정 파일** (\`~/.claude/settings.json\`, \`CLAUDE.md\`, 플러그인 설정 등
+       — 이 환경에 존재하지 않는 것을 읽으라는 지시)
+       → 그 단계를 건너뛰라는 짧은 안내로 바꿉니다.
+
+   (b) **만들어야 할 산출물 경로** (\`.claude/foo.md\` 처럼 스킬이 **생성**하는 파일)
+       → **경로에서 \`.claude/\` 만 떼고** 작업 디렉토리 기준 상대 경로로 바꿉니다.
+         예: \`.claude/hookify.rule.local.md\` → \`hookify.rule.local.md\`,
+             \`mkdir -p .claude\` 단계는 삭제.
+       ⚠️ **파일을 만드는 단계 자체는 없애지 마세요** — 그게 이 스킬의 결과물입니다.
+       그 산출물이 원래 플랫폼에서 자동 실행되는 훅·설정 파일이었다면, 파일은 그대로
+       만들되 "이 환경은 이 파일을 자동으로 실행하지 않습니다 — 내용은 참고용으로
+       남습니다" 같은 한 줄을 그 단계에 덧붙입니다.
+
+   (c) **플랫폼 절차** (훅 등록, 슬래시 명령 등록, 확장 설치 절차 등 이 환경에 대응
+       개념이 없는 조작) → 건너뛰라는 짧은 안내로 바꿉니다 (문단 전체를 지우지는 마세요).
 4. **자리표시자**: \`$ARGUMENTS\`·\`$1\` 은 **그대로 두세요** (호출 시 자동 치환됩니다).
 5. 이미 본문 맨 앞에 \`[openmake 호환 안내]\` blockquote 가 있으면 **그대로 보존**하세요.
 
 ## 응답 형식
-JSON object only. 다른 텍스트 출력 금지.
-{
-  "changed": true | false,
-  "content": "<수정된 전체 본문 (changed=false 면 빈 문자열)>",
-  "summary": ["<무엇을 왜 바꿨는지 한 줄>", "..."]
-}
-content 는 **본문 전체**여야 합니다 — 일부만 돌려주면 나머지가 소실됩니다.`;
+아래 세 줄 마커 형식으로만 답하세요. JSON 을 쓰지 마세요.
+
+\`\`\`
+${REWRITE_CHANGED_MARKER} yes
+${REWRITE_SUMMARY_MARKER}
+- 무엇을 왜 바꿨는지 한 줄
+- (여러 줄 가능)
+${REWRITE_CONTENT_MARKER}
+<여기서부터 끝까지가 수정된 **본문 전체**. 원문 그대로의 마크다운을 쓰고
+이스케이프하지 마세요. 코드블록·백틱·따옴표도 원문 형태 그대로 둡니다.>
+\`\`\`
+
+바꿀 것이 없으면 \`${REWRITE_CHANGED_MARKER} no\` 한 줄만 출력하고 끝내세요.
+\`${REWRITE_CONTENT_MARKER}\` 뒤에는 **본문 전체**가 와야 합니다 — 일부만 쓰면 나머지가 소실됩니다.
+본문 전체를 \`\`\` 코드펜스로 감싸지 마세요 (본문 안의 코드블록은 그대로 두되, 바깥을 추가로
+감싸면 안 됩니다).`;
 }
 
 export function buildSkillRewriteUserPrompt(skillName: string, body: string): string {


### PR DESCRIPTION
## 배경

PR #607(설치 시 적응 Phase 1~3) 머지·배포 후, 운영(chat.openmake.cc)에서 `hookify` 확장을 실제로 설치해 검증하다 발견했다. 설치 적응(Phase 1·2)은 정상 동작했지만 **Phase 3 재작성 제안이 항상 "변경 없음"으로 끝나 사실상 동작하지 않고 있었다.**

## 근본 원인 — JSON 이스케이프 파손

LLM 은 실제로 `changed: true` 와 본문(8.4KB)을 **정상 반환**했다(`finish_reason: stop`, 응답 끝도 `}` 로 닫힘). 그런데 `JSON.parse` 가 실패했다.

스킬 본문은 코드블록·백틱·따옴표·개행이 섞인 긴 마크다운이라, 이를 JSON 문자열 필드에 담게 하면 로컬 모델이 이스케이프를 자주 깨뜨린다. 길이 문제도 잘림도 아니었다.

**수정**: 응답 형식을 이스케이프가 아예 필요 없는 마커로 전환.

```
===CHANGED=== yes
===SUMMARY===
- 무엇을 왜 바꿨는지
===CONTENT===
<본문 전체 — 원문 마크다운 그대로>
```

⚠️ **바깥 펜스는 벗기지 않는다.** 본문이 코드블록으로 시작/끝나는 경우가 흔해 벗기면 본문 자체가 훼손된다(구현 중 실제로 테스트가 잡아냈다). 프롬프트로 "감싸지 말 것"을 지시하고, 감싸더라도 앞뒤에 ``` 가 남는 편이 파손보다 안전하다.

**진단성**: 파싱 실패와 "변경 불필요"를 로그에서 구분한다. 그전엔 둘 다 `→ 변경 없음` 이라 **실패가 정상 동작처럼 보여** 원인 추적이 불가능했다.

## `.claude/` 경로 규칙 정교화

기존 규칙은 "`.claude/`·`CLAUDE.md` 는 이 환경에 없으니 그 단계를 건너뛰라"로 뭉뚱그렸다. 그런데 `.claude/` 가 **산출물 경로**인 스킬이 있다 — `hookify` 는 규칙 파일을 `.claude/hookify.{name}.local.md` 로 **생성**하는 것이 본래 목적이라, 건너뛰게 하면 스킬이 아무 결과도 내지 못한다. (모델이 `changed=false` 를 고른 것이 오히려 합리적이었다.)

용도를 셋으로 분리했다:

| 유형 | 처리 |
|---|---|
| **(a) 읽을 설정 파일** — `~/.claude/settings.json`, `CLAUDE.md` 를 읽으라는 지시 | 그 단계를 건너뛰라는 안내로 |
| **(b) 만들 산출물 경로** — 스킬이 생성하는 파일 | `.claude/` 만 떼고 작업 디렉토리 기준으로. **생성 단계 자체는 유지**하되, 원래 자동 실행되던 훅·설정이면 "이 환경은 자동 실행하지 않음"을 덧붙임 |
| **(c) 플랫폼 절차** — 훅 등록·슬래시 등록 등 | 건너뛰라는 안내로 |

Phase 1 의 안내 노트(`skill-compat.ts`)도 같은 오해("해당 지침은 무시하세요")를 담고 있어 함께 정정했다. 노트 길이는 658자로 상한(1200) 내.

## 라이브 검증 (chat.openmake.cc, `hookify`)

수정 전: 제안 없음(파싱 실패가 "변경 없음"으로 표시) → 수정 후:

```
제안 7299자 | +28 / -57
요약:
  · 도구 이름을 이 환경의 실제 도구(file_ops·bash·str_replace_editor·ask_human …)로 치환
  · "Claude Code"/"Claude Desktop" → "이 환경"
  · .claude/ 경로를 프로젝트 루트 기준으로 조정 + 자동 실행되지 않음 명시
  · 이 환경에 없는 실행 절차를 "건너뜁니다"로 대체

diff:
  - create a `.claude/hookify.{rule-name}.local.md` file
  + create a `hookify.{rule-name}.local.md` file (relative to current working directory)
  - 1. Check if `.claude/` directory exists … mkdir -p .claude
  + Note: Do not create a `.claude/` directory as it is not used by this environment.
```

**설치 자체도 함께 확인** — `hookify`(skills 1 + commands 4 + agents 1 + hooks 6):
- commands 4개 → 스킬 변환, agents 1개 → Custom Agent(즉시 활성)
- `UNSUPPORTED_COMPONENTS: 훅(hooks) 6개` 리포트
- plugin.json `version` 없음 → `0.0.0` 관용 수용
- 승인 후 `/hookify <인자>` 슬래시 호출 → 인자 반영 응답, 로그 `슬래시 명령 적용` 확인
- DB: `skill_manifests` 동기화·checksum 5/5 일치

## 체크리스트

- [x] `npm run lint` 0 errors
- [x] `npm test` 2905 passed (신규/갱신 테스트 포함)
- [x] `npx tsc --noEmit` 통과
- [x] 스키마 변경 없음 · 환경변수 추가 없음
- [x] 운영 배포 후 라이브 실측 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)