### PR TITLE
fix(llm): 긴 텍스트를 JSON 으로 받는 경로 하드닝 (전수 조사 후속)

### DIFF
--- a/apps/api/src/agents/skill-creator.ts
+++ b/apps/api/src/agents/skill-creator.ts
@@ -250,7 +250,11 @@ export class SkillCreatorService {
 
             try {
                 const client = this.opts.llmClientFactory(modelUsed);
-                const resp = await client.chat(messages);
+                // ⚠️ 구조화 출력 강제 — 생성 결과의 `content` 는 200자~20KB 마크다운이라,
+                // 강제 없이 자유 텍스트로 JSON 을 요청하면 모델이 코드블록·백틱·따옴표
+                // 이스케이프를 깨뜨려 정상 종료한 응답이 JSON.parse 에서 죽는다
+                // (2026-08-24 skill-rewriter 실측). 백엔드(vLLM)가 문법을 보장하게 한다.
+                const resp = await client.chat(messages, undefined, undefined, { format: 'json' });
                 const raw = resp.content ?? '';
                 const tokensUsed = resp.metrics?.completion_tokens ?? 0;
 

--- a/apps/api/src/services/code-review/__tests__/reviewer.test.ts
+++ b/apps/api/src/services/code-review/__tests__/reviewer.test.ts
@@ -35,6 +35,19 @@ describe('parseReviewFindings', () => {
         expect(parseReviewFindings('```json\n{"findings":[{"dimension":"bug"}]}\n```').findings).toHaveLength(1);
         expect(parseReviewFindings('garbage').findings).toEqual([]);
     });
+    // ⚠️ 파싱 실패를 "발견 0건"과 구분한다 — 실패가 "문제 없음"으로 읽히면 안 된다
+    // (2026-08-24: skill-rewriter 에서 같은 패턴이 기능을 통째로 죽이고 있었다)
+    it('파싱 실패는 parseFailed=true 로 구분한다', () => {
+        expect(parseReviewFindings('전혀 JSON 이 아님').parseFailed).toBe(true);
+        expect(parseReviewFindings('{"summary": 깨진 json').parseFailed).toBe(true);
+    });
+
+    it('정상 파싱은 parseFailed 를 세우지 않는다 (findings 가 비어도)', () => {
+        const r = parseReviewFindings('{"summary":"이상 없음","findings":[]}');
+        expect(r.parseFailed).toBeUndefined();
+        expect(r.findings).toEqual([]);
+    });
+
 });
 
 describe('postProcessReview', () => {

--- a/apps/api/src/services/code-review/reviewer.ts
+++ b/apps/api/src/services/code-review/reviewer.ts
@@ -57,12 +57,22 @@ export function isReviewNoise(f: { title?: unknown; description?: unknown; sugge
 }
 
 /** LLM raw 출력에서 findings 관대 파싱 */
-export function parseReviewFindings(raw: string): { summary: string; findings: unknown[] } {
+/**
+ * LLM 응답 → 리뷰 결과. 파싱 실패는 `parseFailed` 로 **구분해서** 알린다.
+ *
+ * ⚠️ 실패를 조용히 `findings: []` 로 돌려주면 "리뷰했는데 지적 사항 없음"과 구별되지
+ * 않아, 실제로는 분석이 실패했는데 사용자는 "문제 없음"으로 읽는다(2026-08-24 실측 —
+ * skill-rewriter 에서 같은 패턴이 기능을 통째로 죽이고 있었다).
+ */
+export function parseReviewFindings(raw: string): { summary: string; findings: unknown[]; parseFailed?: boolean } {
     if (!raw || !raw.trim()) return { summary: '', findings: [] };
     let text = raw.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '');
     const start = text.indexOf('{');
     const end = text.lastIndexOf('}');
-    if (start === -1 || end === -1 || end <= start) return { summary: '', findings: [] };
+    if (start === -1 || end === -1 || end <= start) {
+        logger.warn(`코드 리뷰 응답에서 JSON 을 찾지 못함 (${raw.length}자)`);
+        return { summary: '', findings: [], parseFailed: true };
+    }
     text = text.slice(start, end + 1);
     try {
         const obj = JSON.parse(text) as { summary?: unknown; findings?: unknown };
@@ -70,8 +80,9 @@ export function parseReviewFindings(raw: string): { summary: string; findings: u
             summary: typeof obj.summary === 'string' ? obj.summary : '',
             findings: Array.isArray(obj.findings) ? obj.findings : [],
         };
-    } catch {
-        return { summary: '', findings: [] };
+    } catch (e) {
+        logger.warn(`코드 리뷰 응답 JSON 파싱 실패 (${raw.length}자): ${e instanceof Error ? e.message : String(e)}`);
+        return { summary: '', findings: [], parseFailed: true };
     }
 }
 
@@ -168,5 +179,9 @@ export async function reviewCode(input: ReviewInput): Promise<CodeReviewResult> 
         minConfidence: CODE_REVIEW_CONFIG.minConfidence,
         maxFindings: CODE_REVIEW_CONFIG.maxFindings,
     });
-    return { summary: parsed.summary, findings, stats };
+    // 파싱 실패를 "지적 사항 없음"으로 보이게 두지 않는다 — summary 로 명시한다
+    const summary = parsed.parseFailed
+        ? '리뷰 결과를 해석하지 못했습니다 (모델 응답 형식 오류) — 지적 사항이 없다는 뜻이 아닙니다.'
+        : parsed.summary;
+    return { summary, findings, stats };
 }

--- a/apps/api/src/services/security-review/__tests__/analyzer.test.ts
+++ b/apps/api/src/services/security-review/__tests__/analyzer.test.ts
@@ -47,6 +47,19 @@ describe('parseSecurityFindings', () => {
     it('빈 입력 → 빈 결과', () => {
         expect(parseSecurityFindings('').findings).toEqual([]);
     });
+    // ⚠️ 파싱 실패를 "발견 0건"과 구분한다 — 실패가 "문제 없음"으로 읽히면 안 된다
+    // (2026-08-24: skill-rewriter 에서 같은 패턴이 기능을 통째로 죽이고 있었다)
+    it('파싱 실패는 parseFailed=true 로 구분한다', () => {
+        expect(parseSecurityFindings('전혀 JSON 이 아님').parseFailed).toBe(true);
+        expect(parseSecurityFindings('{"summary": 깨진 json').parseFailed).toBe(true);
+    });
+
+    it('정상 파싱은 parseFailed 를 세우지 않는다 (findings 가 비어도)', () => {
+        const r = parseSecurityFindings('{"summary":"이상 없음","findings":[]}');
+        expect(r.parseFailed).toBeUndefined();
+        expect(r.findings).toEqual([]);
+    });
+
 });
 
 describe('postProcessFindings', () => {

--- a/apps/api/src/services/security-review/analyzer.ts
+++ b/apps/api/src/services/security-review/analyzer.ts
@@ -68,7 +68,13 @@ export function isFalsePositive(f: { category?: unknown; title?: unknown; descri
  * LLM raw 출력에서 finding 배열을 관대하게 파싱.
  * 코드펜스/머리말이 섞여도 첫 JSON 객체를 추출. 실패 시 {summary:'', findings:[]}.
  */
-export function parseSecurityFindings(raw: string): { summary: string; findings: unknown[] } {
+/**
+ * LLM 응답 → 보안 검토 결과. 파싱 실패는 `parseFailed` 로 **구분해서** 알린다.
+ *
+ * ⚠️ 실패를 조용히 `findings: []` 로 돌려주면 "취약점 없음"으로 읽힌다 — 보안 검토에서
+ * 가장 위험한 오해다. 실패는 반드시 드러나야 한다.
+ */
+export function parseSecurityFindings(raw: string): { summary: string; findings: unknown[]; parseFailed?: boolean } {
     if (!raw || !raw.trim()) return { summary: '', findings: [] };
     let text = raw.trim();
     // 코드펜스 제거
@@ -76,15 +82,19 @@ export function parseSecurityFindings(raw: string): { summary: string; findings:
     // 첫 { ... 마지막 } 추출 (관대)
     const start = text.indexOf('{');
     const end = text.lastIndexOf('}');
-    if (start === -1 || end === -1 || end <= start) return { summary: '', findings: [] };
+    if (start === -1 || end === -1 || end <= start) {
+        logger.warn(`보안 검토 응답에서 JSON 을 찾지 못함 (${raw.length}자)`);
+        return { summary: '', findings: [], parseFailed: true };
+    }
     const slice = text.slice(start, end + 1);
     try {
         const obj = JSON.parse(slice) as { summary?: unknown; findings?: unknown };
         const summary = typeof obj.summary === 'string' ? obj.summary : '';
         const findings = Array.isArray(obj.findings) ? obj.findings : [];
         return { summary, findings };
-    } catch {
-        return { summary: '', findings: [] };
+    } catch (e) {
+        logger.warn(`보안 검토 응답 JSON 파싱 실패 (${raw.length}자): ${e instanceof Error ? e.message : String(e)}`);
+        return { summary: '', findings: [], parseFailed: true };
     }
 }
 
@@ -198,5 +208,9 @@ export async function analyzeCode(input: AnalyzeInput): Promise<SecurityReviewRe
         maxFindings: SECURITY_REVIEW_CONFIG.maxFindings,
     });
 
-    return { summary: parsed.summary, findings, stats };
+    // ⚠️ 파싱 실패를 "취약점 없음"으로 보이게 두지 않는다 (보안 검토의 최악 오해)
+    const summary = parsed.parseFailed
+        ? '보안 검토 결과를 해석하지 못했습니다 (모델 응답 형식 오류) — 취약점이 없다는 뜻이 아닙니다. 다시 실행해 주세요.'
+        : parsed.summary;
+    return { summary, findings, stats };
 }


### PR DESCRIPTION
## 배경

PR #610 에서 스킬 재작성 제안이 **정상 응답인데 `JSON.parse` 실패로 조용히 죽어** Phase 3 가 사실상 미동작하던 것을 고쳤다. 원인은 코드블록·백틱·따옴표가 섞인 긴 마크다운을 JSON 문자열 필드로 받게 한 것.

**같은 잠복 결함이 다른 곳에도 있는지 전수 조사**했다 (`JSON.parse` 가 LLM 응답에 적용되는 지점 전부 + 각 스키마의 긴 텍스트 필드 유무 + 실패 시 동작 + 로그 구분 여부).

## 수정 (3건)

### 1. `skill-creator` — 위험 (skill-rewriter 와 동일 구조)

자연어 → 스킬 생성이 `{"content": "<200자~20KB 마크다운>"}` 을 **구조화 출력 강제 없이** 받고 있었다. 스킬 본문에 예시 코드블록이 들어가면 동일하게 파손된다.

→ `{ format: 'json' }` 적용. 백엔드(vLLM)가 JSON 문법을 보장하므로 이스케이프가 정확해진다. `code-review`·`security-review` 가 이미 쓰는 방식이라 마커 전환 없이 최소 변경으로 해결.

*(실패가 `LLM_PARSE_FAIL` 로 드러나고 재시도·fallback 이 있어 조용히 죽지는 않았지만, 기능 자체가 실패했다.)*

### 2·3. `code-review` / `security-review` — 경계 (조용한 실패)

파싱 실패를 `{summary:'', findings:[]}` 로 삼켜 **"지적 사항 없음"·"취약점 없음"과 구별되지 않았다.** 보안 검토에서 가장 위험한 오해다.

→ `parseFailed` 플래그로 구분 + warn 로그 + summary 에 명시:
```
"보안 검토 결과를 해석하지 못했습니다 (모델 응답 형식 오류)
 — 취약점이 없다는 뜻이 아닙니다. 다시 실행해 주세요."
```

## 조사했으나 수정하지 않은 것

| 경로 | 판단 |
|---|---|
| `report-block` | 이미 warn + fail-open, 실패해도 **원문이 그대로 보존**됨. 채팅 응답 인라인이라 구조화 강제 적용 불가 |
| `catalog-translator` | 짧은 라벨 배열 + 개수 불일치 검증 + fail-open(원문 fallback) |
| `answer-composer` | `json_schema` strict(guided decoding) 로 **이미 안전** — 긴 텍스트를 다루는 모범 선례 |
| `goal-judge`, `answer-verifier` | JSON 을 아예 쓰지 않음(정규식 boolean / 평문) |
| `llm-router`, `discussion-engine`, `topic-decomposer`, `plan-mode`, `convention-checker` | 짧은 필드만 반환, fail-open + 로그 |
| 툴콜 인자 파싱 (stream-parser 등) | 벤더 프로토콜 소관, 인자는 대체로 짧음 |

## 체크리스트

- [x] `npm run lint` 0 errors
- [x] `npm test` 2909 passed (회귀 테스트 4건 추가 — 파싱 실패 ↔ 빈 결과 구분)
- [x] `npx tsc --noEmit` 통과
- [x] 스키마·환경변수 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)