### PR TITLE
fix(llm): 코드펜스를 먼저 벗겨 JSON 안의 코드블록을 잡던 파서 결함

### DIFF
--- a/apps/api/src/agents/git-ingest/__tests__/convention-checker.test.ts
+++ b/apps/api/src/agents/git-ingest/__tests__/convention-checker.test.ts
@@ -103,4 +103,22 @@ describe('ConventionChecker', () => {
         expect(r.findings).toHaveLength(1);
         expect(r.findings[0].rule).toBe('x');
     });
+    // ⚠️ 펜스를 먼저 벗기면 JSON **안의** 코드블록을 잡아 깨진다 — 전체 파싱이 먼저다
+    // (2026-08-24 skill-creator 실측: `Unexpected token 'p', "python..."`)
+    it('findings 안에 코드펜스가 있어도 정상 파싱 (전체 파싱 우선)', async () => {
+        const payload = JSON.stringify({
+            findings: [{
+                severity: 'warn', rule: 'x',
+                message: '예시: ```python\nimport os\n``` 를 쓰지 마세요',
+            }],
+        });
+        (mockLLM.chat as jest.Mock).mockResolvedValueOnce({
+            content: payload, metrics: { completion_tokens: 10 },
+        });
+        const c = new ConventionChecker(mockLLM as LLMClient);
+        const r = await c.check('m', 'p');
+        expect(r.findings).toHaveLength(1);
+        expect(r.findings[0].rule).toBe('x');
+    });
+
 });

--- a/apps/api/src/agents/git-ingest/catalog-translator.ts
+++ b/apps/api/src/agents/git-ingest/catalog-translator.ts
@@ -17,6 +17,17 @@ import { CATALOG_TRANSLATOR_SYSTEM_PROMPT } from '../../prompts/catalog-translat
 
 const logger = createLogger('CatalogTranslator');
 
+/** LLM 응답 → JSON. 전체 파싱 먼저, 실패 시에만 코드펜스를 벗긴다. */
+function parseJsonLoose(raw: string): unknown {
+    try {
+        return JSON.parse(raw);
+    } catch {
+        const fence = raw.match(/```(?:json)?\s*([\s\S]+?)\s*```/);
+        if (!fence) throw new Error('응답에서 JSON 을 찾지 못함');
+        return JSON.parse(fence[1]);
+    }
+}
+
 const SYSTEM_PROMPT = CATALOG_TRANSLATOR_SYSTEM_PROMPT;
 
 /** 이전 스냅샷 번역 재사용 키 */
@@ -59,8 +70,9 @@ export async function translateCatalogDescriptions(
             ];
             const resp = await llm.chat(messages);
             const raw = (resp.content ?? '').trim();
-            const fence = raw.match(/```(?:json)?\s*([\s\S]+?)\s*```/);
-            const parsed = JSON.parse(fence ? fence[1] : raw) as { translations?: unknown };
+            // ⚠️ 전체 파싱 먼저 — 펜스 우선이면 번역문 안의 코드블록을 잡아 깨진다
+            // (skill-creator 에서 실측된 결함, 2026-08-24)
+            const parsed = parseJsonLoose(raw) as { translations?: unknown };
             const arr = Array.isArray(parsed.translations) ? parsed.translations : null;
             if (!arr || arr.length !== batch.length) {
                 throw new Error(`번역 개수 불일치: ${arr?.length ?? 'null'} != ${batch.length}`);

--- a/apps/api/src/agents/git-ingest/convention-checker.ts
+++ b/apps/api/src/agents/git-ingest/convention-checker.ts
@@ -28,6 +28,21 @@ import {
 
 const logger = createLogger('ConventionChecker');
 
+/**
+ * LLM 응답 → JSON. **전체 파싱을 먼저** 시도하고, 실패할 때만 코드펜스를 벗긴다.
+ * 펜스를 먼저 벗기면 JSON 안에 들어 있는 코드블록을 정규식이 잡아 엉뚱한 조각을
+ * 파싱한다 (2026-08-24 skill-creator 실측).
+ */
+function parseJsonLoose(raw: string): unknown {
+    try {
+        return JSON.parse(raw);
+    } catch {
+        const fence = raw.match(/```(?:json)?\s*([\s\S]+?)\s*```/);
+        if (!fence) throw new Error('응답에서 JSON 을 찾지 못함');
+        return JSON.parse(fence[1]);
+    }
+}
+
 export interface ConventionFinding {
     severity: 'info' | 'warn' | 'error';
     rule: string;
@@ -100,9 +115,8 @@ export class ConventionChecker {
             const resp = await this.llm.chat(messages);
             const tokensUsed = resp.metrics?.completion_tokens ?? 0;
             const raw = (resp.content ?? '').trim();
-            const fence = raw.match(/```(?:json)?\s*([\s\S]+?)\s*```/);
-            const candidate = fence ? fence[1] : raw;
-            const parsed = JSON.parse(candidate) as { findings?: ConventionFinding[] };
+            // ⚠️ 전체 파싱 먼저 — 펜스를 먼저 벗기면 findings 안의 코드블록을 잡아 깨진다
+            const parsed = parseJsonLoose(raw) as { findings?: ConventionFinding[] };
             const findings = (Array.isArray(parsed.findings) ? parsed.findings : []).map(demoteLlmFinding);
             return { findings, tokensUsed };
         } catch (e) {

--- a/apps/api/src/agents/skill-creator.ts
+++ b/apps/api/src/agents/skill-creator.ts
@@ -287,11 +287,23 @@ export class SkillCreatorService {
         return parts.join('\n');
     }
 
+    /**
+     * LLM 응답 → JSON. **전체 파싱을 먼저 시도**하고, 실패할 때만 코드펜스를 벗긴다.
+     *
+     * ⚠️ 순서가 중요하다. 펜스를 먼저 벗기면 JSON **안에 들어 있는** 코드블록
+     * (예: content 필드의 python 코드펜스)을 정규식이 먼저 잡아 엉뚱한 조각을 파싱한다
+     * — `format:'json'` 으로 문법을 강제해도 이 파서가 그 이점을 무효화한다
+     * (2026-08-24 실측: 스킬 생성이 `Unexpected token 'p', "python..."` 로 실패).
+     */
     private extractJson(raw: string): unknown {
         const trimmed = raw.trim();
-        const fence = trimmed.match(/```(?:json)?\s*([\s\S]+?)\s*```/);
-        const candidate = fence ? fence[1] : trimmed;
-        return JSON.parse(candidate);
+        try {
+            return JSON.parse(trimmed);
+        } catch {
+            const fence = trimmed.match(/```(?:json)?\s*([\s\S]+?)\s*```/);
+            if (!fence) throw new Error('응답에서 JSON 을 찾지 못함');
+            return JSON.parse(fence[1]);
+        }
     }
 
     private buildResult(


### PR DESCRIPTION
## 배경

PR #611 에서 `skill-creator` 에 `{ format: 'json' }`(구조화 출력 강제)을 적용했는데, 배포 후 라이브 검증에서 **여전히 실패**했다:

```
[SkillCreator] LLM attempt 1 failed: Unexpected token 'p', "python\nim"... is not valid JSON
[SkillCreator] LLM attempt 2 failed: Unexpected token 'p', "python\nim"... is not valid JSON
```

## 원인 — 파서 순서

`extractJson` 이 **코드펜스를 먼저 벗긴다**:

```ts
const fence = trimmed.match(/```(?:json)?\s*([\s\S]+?)\s*```/);
const candidate = fence ? fence[1] : trimmed;
return JSON.parse(candidate);
```

응답이 `{"content": "... ```python\nimport os\n``` ..."}` 처럼 **JSON 안에 코드블록을 담고** 있으면, 정규식이 그 내부 펜스를 먼저 잡아 `python\nimport os` 조각을 파싱하려 든다.

즉 응답 전체가 유효한 JSON 이어도(`format:'json'` 이 문법을 보장해도) **파서가 그 이점을 무효화**하고 있었다. 스킬 본문에 예시 코드가 들어가면 항상 실패하는 구조다.

## 수정

**전체 `JSON.parse` 를 먼저 시도**하고, 실패할 때만 펜스를 벗겨 재시도한다. 같은 패턴이던 3곳을 함께 고쳤다:

| 파일 | 영향 |
|---|---|
| `agents/skill-creator.ts` | 스킬 본문(`content`)에 코드블록이 있으면 생성 실패 |
| `agents/git-ingest/convention-checker.ts` | `findings[].message`·`snippet` 에 코드가 있으면 audit 결과 소실 |
| `agents/git-ingest/catalog-translator.ts` | 번역문에 코드가 있으면 배치 실패 |

`utils/json-parser.ts` 는 `{` 로 시작하는 블록만 매칭하고 greedy/non-greedy 폴백 체인이 있어 동일 결함이 없다 — 미변경.

## 라이브 검증

수정 전: 재시도 2회 모두 실패 → 수정 후: **코드블록을 포함한 4642자 스킬을 한 번에 생성**(HTTP 201).

```
CSV 결측치 분석 및 보고서 작성 | draft | 4642자 | has_codeblock=t
```

## 체크리스트

- [x] `npm run lint` 0 errors
- [x] `npm test` 2910 passed (회귀 테스트 추가 — findings 안에 코드펜스가 있어도 정상 파싱)
- [x] `npx tsc --noEmit` 통과
- [x] 스키마·환경변수 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)