### PR TITLE
fix(chat): 이름에 특수문자가 있는 스킬의 슬래시 호출이 조용히 무시되던 문제

### DIFF
--- a/apps/api/src/chat/__tests__/slash-command.test.ts
+++ b/apps/api/src/chat/__tests__/slash-command.test.ts
@@ -1,5 +1,6 @@
 import {
     substituteSkillArguments,
+    buildSlugSearchAttempts,
     parseSlashCommand,
     slugify,
     matchesSlug,
@@ -92,6 +93,42 @@ describe('substituteSkillArguments (외부 스킬 인자 자리표시자)', () =
     it('자리표시자와 금액이 섞여 있으면 자리표시자만 치환', () => {
         const r = substituteSkillArguments('대상: $1 (예산 $1,500)', 'design.fig');
         expect(r.content).toBe('대상: design.fig (예산 $1,500)');
+    });
+});
+
+describe('buildSlugSearchAttempts (DB 검색어 후보)', () => {
+    it('공백 복원 → 원 slug → 첫 토큰(넓게) 순', () => {
+        expect(buildSlugSearchAttempts('nginx-log-error')).toEqual([
+            { search: 'nginx log error', limit: 10 },
+            { search: 'nginx-log-error', limit: 10 },
+            { search: 'nginx', limit: 50 },
+        ]);
+    });
+
+    it('하이픈 없는 slug 는 후보 1개', () => {
+        expect(buildSlugSearchAttempts('billing')).toEqual([{ search: 'billing', limit: 10 }]);
+    });
+});
+
+// 이름에 슬러그화로 사라지는 문자(&·: 등)가 있으면 공백 복원·원 slug 둘 다 ILIKE 실패 →
+// 첫 토큰 폴백이 후보를 넓히고 matchesSlug 가 정확 필터한다 (2026-08-24 실측 결함)
+describe('특수문자 이름 스킬의 슬래시 매칭', () => {
+    it('"A & B" 형태 이름도 첫 토큰 폴백으로 찾는다', async () => {
+        const skill = { name: 'Nginx Log Error Analysis & Reporting', content: '본문' };
+        const findSkillBySlug = jest.fn(async (slug: string) => {
+            for (const { search } of buildSlugSearchAttempts(slug)) {
+                // searchSkills 의 ILIKE 를 흉내 — 이름에 부분 문자열이 있어야 후보에 오름
+                if (skill.name.toLowerCase().includes(search)) {
+                    return matchesSlug(skill.name, slug) ? skill : null;
+                }
+            }
+            return null;
+        });
+        const out = await applySlashCommand('/nginx-log-error-analysis-reporting 4xx 비율', { findSkillBySlug });
+        // 주입 시 이름의 <>"& 는 제거된다(속성 이스케이프) — 매칭이 됐는지가 요점
+        expect(out).toContain('Nginx Log Error Analysis  Reporting');
+        expect(out).toContain('본문');
+        expect(findSkillBySlug).toHaveBeenCalledWith('nginx-log-error-analysis-reporting', undefined);
     });
 });
 

--- a/apps/api/src/chat/slash-command.ts
+++ b/apps/api/src/chat/slash-command.ts
@@ -124,13 +124,31 @@ export function mergeActivatedSkillNames(...groups: string[][]): string[] {
 async function defaultFindSkillBySlug(slug: string, userId?: string): Promise<SlashSkill | null> {
     const { getSkillManager } = await import('../agents/skill-manager');
     const manager = getSkillManager();
-    for (const search of [slug.replace(/-/g, ' '), slug]) {
-        const result = await manager.searchSkills({ search, status: 'active', limit: 10, userId });
+    for (const { search, limit } of buildSlugSearchAttempts(slug)) {
+        const result = await manager.searchSkills({ search, status: 'active', limit, userId });
         const matched = result.skills.find((s) => matchesSlug(s.name, slug));
         if (matched) return { name: matched.name, content: matched.content };
-        if (!slug.includes('-')) break; // 하이픈 없으면 두 검색어가 동일 — 재검색 불필요
     }
     return null;
+}
+
+/**
+ * slug → DB 검색어 후보들 (순서대로 시도, 첫 매치에서 종료).
+ *
+ * `searchSkills` 는 검색어를 **문자열 그대로** ILIKE 하므로, 이름에 슬러그화 과정에서
+ * 사라지는 문자(`&`·`:`·`(` 등)가 있으면 공백 복원도 원 slug 도 매칭되지 않는다
+ * — 예: "Nginx Log Error Analysis **&** Reporting" ↔ "nginx log error analysis reporting"
+ * (2026-08-24 실측: 슬래시 호출이 조용히 무시되고 일반 에이전트가 답했다).
+ * 마지막 폴백으로 **첫 토큰만** 넓게 검색한 뒤 `matchesSlug` 로 정확 필터한다
+ * (필터가 정확 일치라 후보를 넓혀도 오탐이 없다).
+ */
+export function buildSlugSearchAttempts(slug: string): Array<{ search: string; limit: number }> {
+    const spaced = slug.replace(/-/g, ' ');
+    const attempts: Array<{ search: string; limit: number }> = [{ search: spaced, limit: 10 }];
+    if (slug !== spaced) attempts.push({ search: slug, limit: 10 });
+    const firstToken = slug.split('-')[0];
+    if (firstToken && firstToken !== slug) attempts.push({ search: firstToken, limit: 50 });
+    return attempts;
 }
 
 /**


### PR DESCRIPTION
## 배경

chat.openmake.cc 에서 스킬을 만들어 동작을 확인하다 발견했다. 자연어로 생성된 스킬 **"Nginx Log Error Analysis & Reporting"** 을 `/nginx-log-error-analysis-reporting` 으로 호출했더니:

- `skills_activated` 이벤트에 **해당 스킬이 없음** (일반 "DevOps 엔지니어 전문 스킬"만 활성)
- `슬래시 명령 적용` 로그도 없음 → 매칭 자체가 실패
- 응답은 그럴듯해서 **실패를 알아채기 어렵다**

## 원인

`defaultFindSkillBySlug` 가 slug 를 **문자열 그대로** ILIKE 검색한다:

```
이름:      "Nginx Log Error Analysis & Reporting"
검색어 1:  "nginx log error analysis reporting"   → 이름에 " & " 가 껴 있어 불일치
검색어 2:  "nginx-log-error-analysis-reporting"   → 불일치
```

이름에 슬러그화 과정에서 사라지는 문자(`&`·`:`·`(` 등)가 있으면 **후보가 0건**이라, `matchesSlug` 가 `true` 를 낼 수 있는데도 그 단계에 도달하지 못한다.

## 수정

마지막 폴백으로 **첫 토큰만** 넓게 검색(limit 50)한 뒤 `matchesSlug` 로 정확 필터한다.

```ts
buildSlugSearchAttempts('nginx-log-error')
// → [{search:'nginx log error', limit:10},
//    {search:'nginx-log-error', limit:10},
//    {search:'nginx',           limit:50}]   ← 신규 폴백
```

필터가 **정확 일치**라 후보를 넓혀도 오탐이 없고, 슬래시 입력 시에만 도는 경로라 비용도 무해하다. 검색어 후보 산출을 `buildSlugSearchAttempts` 로 분리해 테스트 가능하게 했다.

## 라이브 검증 (chat.openmake.cc)

**수정 전** → `skills_activated: ["DevOps 엔지니어 전문 스킬"]` (내 스킬 없음)

**수정 후** →
```
[skills_activated] {"skillNames":["Nginx Log Error Analysis & Reporting"]}
로그: 슬래시 명령 적용: /nginx-log-error-analysis-reporting → 스킬 "Nginx Log Error Analysis & Reporting"
```

## 체크리스트

- [x] `npm run lint` 0 errors
- [x] `npm test` 2913 passed (회귀 테스트 3건 추가)
- [x] `npx tsc --noEmit` 통과
- [x] 스키마·환경변수 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)