### PR TITLE
feat(skills): draft 확장별 묶음 + 일괄 승인·거부

### DIFF
--- a/apps/api/src/__tests__/schemas/skills.schema.test.ts
+++ b/apps/api/src/__tests__/schemas/skills.schema.test.ts
@@ -1,0 +1,27 @@
+import { bulkDraftActionSchema } from '../../schemas/skills.schema';
+
+describe('bulkDraftActionSchema (일괄 draft 처리)', () => {
+    it('정상 입력', () => {
+        const r = bulkDraftActionSchema.safeParse({ skillIds: ['a', 'b'], action: 'approve' });
+        expect(r.success).toBe(true);
+    });
+
+    it('action 은 approve/reject 만', () => {
+        expect(bulkDraftActionSchema.safeParse({ skillIds: ['a'], action: 'delete' }).success).toBe(false);
+    });
+
+    it('빈 목록 거부 (실수로 전체 처리되는 것 방지)', () => {
+        expect(bulkDraftActionSchema.safeParse({ skillIds: [], action: 'reject' }).success).toBe(false);
+    });
+
+    it('상한 50개 초과 거부', () => {
+        const ids = Array.from({ length: 51 }, (_, i) => `s${i}`);
+        expect(bulkDraftActionSchema.safeParse({ skillIds: ids, action: 'approve' }).success).toBe(false);
+        expect(bulkDraftActionSchema.safeParse({ skillIds: ids.slice(0, 50), action: 'approve' }).success).toBe(true);
+    });
+
+    it('id 타입/길이 검증', () => {
+        expect(bulkDraftActionSchema.safeParse({ skillIds: [''], action: 'approve' }).success).toBe(false);
+        expect(bulkDraftActionSchema.safeParse({ skillIds: [123], action: 'approve' }).success).toBe(false);
+    });
+});

--- a/apps/api/src/data/repositories/__tests__/skill-draft-query.test.ts
+++ b/apps/api/src/data/repositories/__tests__/skill-draft-query.test.ts
@@ -1,0 +1,48 @@
+import { buildDraftQuery } from '../skill-draft-query';
+
+describe('buildDraftQuery', () => {
+    it('target=user — created_by 조건 + userId 파라미터', () => {
+        const q = buildDraftQuery({ target: 'user', userId: 'u1' });
+        expect(q.countSql).toContain("status = 'draft'");
+        expect(q.countSql).toContain('created_by = $1');
+        expect(q.params).toEqual(['u1']);
+        expect(q.dataParams).toEqual(['u1', 50, 0]);
+    });
+
+    it('target=user 인데 userId 없으면 throw (남의 draft 노출 방지)', () => {
+        expect(() => buildDraftQuery({ target: 'user' })).toThrow('userId 필수');
+    });
+
+    it('target=system — created_by IS NULL, 파라미터 없음', () => {
+        const q = buildDraftQuery({ target: 'system' });
+        expect(q.countSql).toContain('created_by IS NULL');
+        expect(q.params).toEqual([]);
+        expect(q.dataParams).toEqual([100 - 50, 0]);  // limit 기본 50, offset 0
+    });
+
+    it('target=all — status 조건만', () => {
+        const q = buildDraftQuery({ target: 'all' });
+        expect(q.countSql).toContain("status = 'draft'");
+        expect(q.countSql).not.toContain('created_by');
+    });
+
+    // 확장별 묶음을 위해 목록 쿼리만 JOIN 한다 (count 는 JOIN 불필요)
+    it('목록 쿼리는 확장 이름을 LEFT JOIN 으로 싣는다', () => {
+        const q = buildDraftQuery({ target: 'all' });
+        expect(q.dataSql).toContain('LEFT JOIN user_extensions');
+        expect(q.dataSql).toContain('e.name AS extension_name');
+        expect(q.dataSql).toContain('s.extension_id');
+        expect(q.countSql).not.toContain('JOIN');
+    });
+
+    it('JOIN 쿼리의 WHERE 는 별칭이 붙는다 (컬럼 모호성 방지)', () => {
+        const q = buildDraftQuery({ target: 'user', userId: 'u1' });
+        expect(q.dataSql).toContain("s.status = 'draft'");
+        expect(q.dataSql).toContain('s.created_by = $1');
+    });
+
+    it('limit 상한 100, offset 음수 방지', () => {
+        expect(buildDraftQuery({ target: 'all', limit: 500 }).limit).toBe(100);
+        expect(buildDraftQuery({ target: 'all', offset: -10 }).offset).toBe(0);
+    });
+});

--- a/apps/api/src/data/repositories/skill-draft-query.ts
+++ b/apps/api/src/data/repositories/skill-draft-query.ts
@@ -1,0 +1,81 @@
+/**
+ * draft 목록 쿼리 빌더 — SkillRepository 에서 분리 (파일 크기 가드).
+ *
+ * SQL 조립만 담당하는 순수 함수라 DB 없이 단위 테스트할 수 있다.
+ *
+ * @module data/repositories/skill-draft-query
+ */
+import type { QueryParam } from './base-repository';
+
+export interface DraftQueryOptions {
+    target?: 'user' | 'system' | 'all';
+    userId?: string;
+    limit?: number;
+    offset?: number;
+}
+
+export interface DraftQuery {
+    /** 총 개수 SQL (WHERE 만, JOIN 없음) */
+    countSql: string;
+    /** 목록 SQL (확장 LEFT JOIN 포함) */
+    dataSql: string;
+    /** countSql 용 파라미터 */
+    params: QueryParam[];
+    /** dataSql 용 파라미터 (params + limit + offset) */
+    dataParams: QueryParam[];
+    limit: number;
+    offset: number;
+}
+
+/** 한 번에 가져올 수 있는 최대 개수 */
+const MAX_LIMIT = 100;
+const DEFAULT_LIMIT = 50;
+
+/**
+ * draft 목록 SQL 조립.
+ *
+ * 목록 쿼리는 `user_extensions` 를 LEFT JOIN 해 **확장 이름을 함께 싣는다** — draft
+ * 화면이 확장별로 묶어 일괄 승인/거부할 수 있게 하기 위함이다. LEFT 라 확장 유래가
+ * 아닌 draft 도 그대로 나온다.
+ */
+export function buildDraftQuery(options: DraftQueryOptions): DraftQuery {
+    const conditions: string[] = [`status = 'draft'`];
+    const params: QueryParam[] = [];
+    let paramIdx = 1;
+
+    const target = options.target ?? 'user';
+    if (target === 'user') {
+        if (!options.userId) {
+            throw new Error('listDrafts: target=user 는 userId 필수');
+        }
+        conditions.push(`created_by = $${paramIdx}`);
+        params.push(options.userId);
+        paramIdx += 1;
+    } else if (target === 'system') {
+        conditions.push(`created_by IS NULL`);
+    }
+    // target === 'all' → 추가 조건 없음
+
+    const whereClause = `WHERE ${conditions.join(' AND ')}`;
+    const limit = Math.min(options.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+    const offset = Math.max(0, options.offset ?? 0);
+
+    // JOIN 쿼리에서는 컬럼이 모호해지므로 별칭을 붙인다
+    const scopedWhere = whereClause.replace(/\b(status|created_by)\b/g, 's.$1');
+
+    return {
+        countSql: `SELECT COUNT(*) AS total FROM agent_skills ${whereClause}`,
+        dataSql: `SELECT s.id, s.name, s.description, s.content, s.category, s.is_public, s.created_by,
+                    s.created_at, s.updated_at, s.source_repo, s.source_path, s.status, s.manifest_meta,
+                    s.extension_id, e.name AS extension_name
+             FROM agent_skills s
+             LEFT JOIN user_extensions e ON e.id = s.extension_id
+             ${scopedWhere}
+             ORDER BY s.created_at DESC, s.id ASC
+             LIMIT $${paramIdx} OFFSET $${paramIdx + 1}`,
+        params,
+        dataParams: [...params, limit, offset],
+        limit,
+        offset,
+    };
+}

--- a/apps/api/src/data/repositories/skill-repository.ts
+++ b/apps/api/src/data/repositories/skill-repository.ts
@@ -13,6 +13,7 @@ import { BaseRepository, QueryParam } from './base-repository';
 import { createHash } from 'crypto';
 import { assertResourceOwnerOrAdmin } from '../../auth/ownership';
 import { rowToSkill } from './skill-row-mapper';
+import { buildDraftQuery } from './skill-draft-query';
 import { SkillAssignmentRepository } from './skill-assignment-repository';
 
 export interface AgentSkill {
@@ -29,6 +30,10 @@ export interface AgentSkill {
     sourcePath?: string;
     status?: 'draft' | 'active' | 'archived';
     manifestMeta?: Record<string, unknown>;
+    /** 확장 번들 설치분이면 그 확장 id (093) — draft 화면의 확장별 묶음에 쓰인다 */
+    extensionId?: string;
+    /** 확장 이름 (listDrafts 가 JOIN 으로 채움. 확장 유래가 아니면 undefined) */
+    extensionName?: string;
 }
 
 export type SkillStatus = 'draft' | 'active' | 'archived';
@@ -446,47 +451,14 @@ export class SkillRepository extends BaseRepository {
      * 'all' → admin 이 전체 draft (소유자 무관).
      */
     async listDrafts(options: DraftListOptions): Promise<DraftListResult> {
-        const conditions: string[] = [`status = 'draft'`];
-        const params: QueryParam[] = [];
-        let paramIdx = 1;
-
-        const target = options.target ?? 'user';
-        if (target === 'user') {
-            if (!options.userId) {
-                throw new Error('listDrafts: target=user 는 userId 필수');
-            }
-            conditions.push(`created_by = $${paramIdx}`);
-            params.push(options.userId);
-            paramIdx += 1;
-        } else if (target === 'system') {
-            conditions.push(`created_by IS NULL`);
-        }
-        // target === 'all' → 추가 조건 없음
-
-        const whereClause = `WHERE ${conditions.join(' AND ')}`;
-        const limit = Math.min(options.limit ?? 50, 100);
-        const offset = Math.max(0, options.offset ?? 0);
-
-        const countResult = await this.query<CountRow>(
-            `SELECT COUNT(*) AS total FROM agent_skills ${whereClause}`,
-            params
-        );
-
-        const dataParams: QueryParam[] = [...params, limit, offset];
-        const dataResult = await this.query(
-            `SELECT id, name, description, content, category, is_public, created_by, created_at, updated_at, source_repo, source_path, status, manifest_meta
-             FROM agent_skills
-             ${whereClause}
-             ORDER BY created_at DESC, id ASC
-             LIMIT $${paramIdx} OFFSET $${paramIdx + 1}`,
-            dataParams
-        );
-
+        const q = buildDraftQuery(options);
+        const countResult = await this.query<CountRow>(q.countSql, q.params);
+        const dataResult = await this.query(q.dataSql, q.dataParams);
         return {
             drafts: dataResult.rows.map((row) => rowToSkill(row)),
             total: parseInt(countResult.rows[0]?.total ?? '0', 10),
-            limit,
-            offset,
+            limit: q.limit,
+            offset: q.offset,
         };
     }
 

--- a/apps/api/src/data/repositories/skill-row-mapper.ts
+++ b/apps/api/src/data/repositories/skill-row-mapper.ts
@@ -30,6 +30,8 @@ export function rowToSkill(row: Record<string, unknown>): AgentSkill {
     const sourcePath = row.source_path;
     const status = row.status;
     const manifestMeta = row.manifest_meta;
+    const extensionId = row.extension_id;
+    const extensionName = row.extension_name;
 
     return {
         id: toStringValue(row.id),
@@ -45,5 +47,7 @@ export function rowToSkill(row: Record<string, unknown>): AgentSkill {
         sourcePath: typeof sourcePath === 'string' ? sourcePath : undefined,
         status: status === 'draft' || status === 'active' || status === 'archived' ? status : undefined,
         manifestMeta: manifestMeta && typeof manifestMeta === 'object' ? manifestMeta as Record<string, unknown> : undefined,
+        extensionId: typeof extensionId === 'string' ? extensionId : undefined,
+        extensionName: typeof extensionName === 'string' ? extensionName : undefined,
     };
 }

--- a/apps/api/src/routes/skills-drafts.routes.ts
+++ b/apps/api/src/routes/skills-drafts.routes.ts
@@ -6,7 +6,8 @@
  * skills.routes.ts 에서 추출. mount path: `/api/agents/skills` 의 sub-router.
  *
  * 엔드포인트:
- *   GET  /drafts                — target=user/system/all 별 draft 목록
+ *   GET  /drafts                — target=user/system/all 별 draft 목록 (확장 이름 포함)
+ *   POST /drafts/bulk           — 여러 draft 를 한 번에 approve/reject (부분 성공 허용)
  *   POST /:skillId/approve      — draft → active (소유자/admin)
  *   POST /:skillId/reject       — draft → archived (소유자/admin)
  *
@@ -14,10 +15,10 @@
  */
 import { Router, type Request, type Response } from 'express';
 import { requireAuth } from '../auth';
-import { validateQuery } from '../middlewares/validation';
+import { validate, validateQuery } from '../middlewares/validation';
 import { asyncHandler } from '../utils/error-handler';
 import { success, notFound, unauthorized } from '../utils/api-response';
-import { draftsQuerySchema } from '../schemas/skills.schema';
+import { draftsQuerySchema, bulkDraftActionSchema } from '../schemas/skills.schema';
 import { getSkillManager } from '../agents/skill-manager';
 import { createLogger } from '../utils/logger';
 import { isAdminRole } from '../data/user-manager';
@@ -60,6 +61,64 @@ router.get('/drafts', requireAuth, validateQuery(draftsQuerySchema), asyncHandle
  * POST /api/agents/skills/:skillId/approve
  * draft → active 전환. 소유자 또는 admin 만 가능. 시스템 스킬(createdBy=null) 은 admin 만.
  */
+/**
+ * POST /api/agents/skills/drafts/bulk
+ *
+ * 여러 draft 를 한 번에 승인/거부한다. 확장 하나가 스킬 8개를 만들기도 해서(plugin-dev)
+ * 하나씩 누르는 부담이 컸다.
+ *
+ * 계약:
+ *   - 개별 실패가 전체를 되돌리지 않는다 (부분 성공 허용) — 결과 배열로 건별 사유를 돌려준다.
+ *   - 권한·상태 검증은 개별 경로와 **동일**하게 updateStatus(actor) 가 담당한다
+ *     (일괄이라고 우회하지 않는다).
+ *   - 상한 BULK_MAX 로 한 요청 크기를 제한한다.
+ *
+ * ⚠️ 라우트 등록 순서: '/drafts/bulk' 가 '/:skillId/approve' 보다 **먼저** 와야 한다
+ *     (Express 순차 매칭 — 뒤에 두면 skillId='drafts' 로 잡힌다).
+ */
+const BULK_MAX = 50;
+
+router.post('/drafts/bulk', requireAuth, validate(bulkDraftActionSchema), asyncHandler(async (req: Request, res: Response) => {
+    const userId = extractUserId(req);
+    if (!userId) {
+        res.status(401).json(unauthorized('인증 필요'));
+        return;
+    }
+    const { skillIds, action } = req.body as { skillIds: string[]; action: 'approve' | 'reject' };
+    if (skillIds.length > BULK_MAX) {
+        res.status(400).json({ error: 'TOO_MANY', detail: `한 번에 최대 ${BULK_MAX}개까지 처리할 수 있습니다 (요청 ${skillIds.length}개)` });
+        return;
+    }
+
+    const nextStatus = action === 'approve' ? 'active' : 'archived';
+    const actor = { userId: String(userId), userRole: req.user?.role || 'user' };
+    const manager = getSkillManager();
+    const results: Array<{ skillId: string; ok: boolean; error?: string }> = [];
+
+    for (const skillId of skillIds) {
+        try {
+            const existing = await manager.getSkillById(skillId);
+            if (!existing) {
+                results.push({ skillId, ok: false, error: 'NOT_FOUND' });
+                continue;
+            }
+            if (existing.status !== 'draft') {
+                results.push({ skillId, ok: false, error: `NOT_DRAFT (status=${existing.status ?? 'unknown'})` });
+                continue;
+            }
+            await manager.updateStatus(skillId, nextStatus, actor);
+            results.push({ skillId, ok: true });
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            results.push({ skillId, ok: false, error: msg.includes('소유자') || msg.includes('ADMIN_REQUIRED') ? 'FORBIDDEN' : msg });
+        }
+    }
+
+    const okCount = results.filter(r => r.ok).length;
+    logger.info(`draft bulk ${action}: ${okCount}/${skillIds.length} by ${userId}`);
+    res.json(success({ action, requested: skillIds.length, succeeded: okCount, results }));
+}));
+
 router.post('/:skillId/approve', requireAuth, asyncHandler(async (req: Request, res: Response) => {
     const { skillId } = req.params;
     const userId = extractUserId(req);

--- a/apps/api/src/schemas/skills.schema.ts
+++ b/apps/api/src/schemas/skills.schema.ts
@@ -69,6 +69,12 @@ export const autoCreateSkillSchema = z.object({
 
 export type AutoCreateSkillInput = z.infer<typeof autoCreateSkillSchema>;
 
+/** 일괄 draft 처리 — 한 요청에서 여러 스킬을 승인/거부 (부분 성공 허용) */
+export const bulkDraftActionSchema = z.object({
+    skillIds: z.array(z.string().min(1).max(128)).min(1).max(50),
+    action: z.enum(['approve', 'reject']),
+});
+
 export const draftsQuerySchema = z.object({
     target: z.enum(['user', 'system', 'all']).default('user'),
     limit: z.coerce.number().int().positive().max(100).default(50),

--- a/apps/web/app/(workspace)/skill-library/page.tsx
+++ b/apps/web/app/(workspace)/skill-library/page.tsx
@@ -52,6 +52,8 @@ interface Skill {
   status?: string;
   content?: string;
   createdBy?: string | null;
+  /** 확장 번들 설치분이면 그 확장 이름 (draft 화면의 묶음 단위) */
+  extensionName?: string;
 }
 
 interface ApiSkill {
@@ -62,6 +64,8 @@ interface ApiSkill {
   status?: string;
   content?: string;
   createdBy?: string | null;
+  extensionId?: string;
+  extensionName?: string;
 }
 
 type SkillsResponse = ApiSuccess<{
@@ -98,6 +102,7 @@ function mapSkill(s: ApiSkill): Skill {
     status: s.status,
     content: s.content,
     createdBy: s.createdBy,
+    extensionName: s.extensionName,
   };
 }
 
@@ -668,6 +673,9 @@ function DraftTab({ onRefresh }: { onRefresh: () => void }) {
   const [loading, setLoading] = useState(true);
   // 설치 시 적응 Phase 3 — 재작성 제안은 diff 를 확인하고 명시 적용할 때만 반영된다
   const [rewrites, setRewrites] = useState<Record<string, RewriteState>>({});
+  // 일괄 처리 — 확장 하나가 스킬 8개를 만들기도 해서 하나씩 누르는 부담이 컸다
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkBusy, setBulkBusy] = useState(false);
 
   const loadDrafts = useCallback(async () => {
     setLoading(true);
@@ -682,6 +690,67 @@ function DraftTab({ onRefresh }: { onRefresh: () => void }) {
   }, []);
 
   useEffect(() => { void loadDrafts(); }, [loadDrafts]);
+
+  // 확장별 묶음 — 확장 유래가 아닌 draft 는 마지막 '기타' 그룹으로
+  const groups = (() => {
+    const byExt = new Map<string, Skill[]>();
+    for (const d of drafts) {
+      const key = d.extensionName ?? "";
+      const list = byExt.get(key);
+      if (list) list.push(d);
+      else byExt.set(key, [d]);
+    }
+    return [...byExt.entries()]
+      .sort((a, b) => (a[0] === "" ? 1 : b[0] === "" ? -1 : a[0].localeCompare(b[0])))
+      .map(([name, items]) => ({ name, items }));
+  })();
+
+  function toggleOne(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleGroup(items: Skill[]) {
+    const ids = items.map((i) => i.id);
+    const allOn = ids.every((id) => selected.has(id));
+    setSelected((prev) => {
+      const next = new Set(prev);
+      for (const id of ids) {
+        if (allOn) next.delete(id);
+        else next.add(id);
+      }
+      return next;
+    });
+  }
+
+  async function handleBulk(action: "approve" | "reject") {
+    const skillIds = [...selected];
+    if (skillIds.length === 0) return;
+    if (!window.confirm(t(action === "approve" ? "draft.bulk.approveConfirm" : "draft.bulk.rejectConfirm", { count: skillIds.length }))) return;
+    setBulkBusy(true);
+    try {
+      const res = await ApiClient.post<{ data?: { succeeded: number; requested: number } }>(
+        "/api/agents/skills/drafts/bulk",
+        { skillIds, action },
+      );
+      const d = res?.data;
+      // 부분 성공을 그대로 알린다 — 전부 됐다고 뭉뚱그리지 않는다
+      if (d && d.succeeded < d.requested) {
+        alert(t("draft.bulk.partial", { ok: d.succeeded, total: d.requested }));
+      }
+      setSelected(new Set());
+      await loadDrafts();
+      onRefresh();
+    } catch (err) {
+      alert(t("draft.bulk.failed", { error: err instanceof Error ? err.message : t("genericError") }));
+    } finally {
+      setBulkBusy(false);
+    }
+  }
 
   async function handleApprove(skillId: string) {
     try {
@@ -760,47 +829,102 @@ function DraftTab({ onRefresh }: { onRefresh: () => void }) {
     );
   }
 
+  const allIds = drafts.map((d) => d.id);
+  const allSelected = allIds.length > 0 && allIds.every((id) => selected.has(id));
+
   return (
     <div className="space-y-3">
-      {drafts.map((d) => (
-        <Card key={d.id} className="p-4">
-          <div className="flex items-start justify-between gap-3">
-            <div className="flex-1 min-w-0">
-              <div className="mb-1 flex items-center gap-2">
-                <Badge tone="warn">Draft</Badge>
-                <Badge tone="neutral">{categoryLabel(t, d.category)}</Badge>
-              </div>
-              <h3 className="text-sm font-semibold text-fg">{d.name}</h3>
-              <p className="mt-1 text-xs text-muted line-clamp-2">{d.description}</p>
-            </div>
-            <div className="flex gap-2 shrink-0">
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={rewrites[d.id]?.state === "loading" || rewrites[d.id]?.state === "applying"}
-                onClick={() => void requestRewrite(d.id)}
-              >
-                {rewrites[d.id]?.state === "loading" ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                ) : (
-                  <Wand2 className="h-3.5 w-3.5" />
-                )}
-                {t("draft.rewrite.button")}
-              </Button>
-              <Button size="sm" onClick={() => void handleApprove(d.id)}>
-                <Check className="h-3.5 w-3.5" />{t("draft.approve")}
-              </Button>
-              <Button variant="outline" size="sm" onClick={() => void handleReject(d.id)}>
-                <X className="h-3.5 w-3.5" />{t("draft.reject")}
-              </Button>
-            </div>
-          </div>
-          <RewritePanel
-            state={rewrites[d.id]}
-            onApply={(content) => void applyRewrite(d.id, content)}
-            onDismiss={() => dismissRewrite(d.id)}
+      {/* 일괄 처리 바 — 선택이 있을 때만 액션을 노출해 오조작을 줄인다 */}
+      <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-surface-2 px-3 py-2">
+        <label className="flex cursor-pointer items-center gap-2 text-xs text-fg-2">
+          <input
+            type="checkbox"
+            className="h-3.5 w-3.5 accent-[var(--accent)]"
+            checked={allSelected}
+            onChange={() => setSelected(allSelected ? new Set() : new Set(allIds))}
           />
-        </Card>
+          {t("draft.bulk.selectAll", { count: drafts.length })}
+        </label>
+        <span className="text-xs text-muted">{t("draft.bulk.selected", { count: selected.size })}</span>
+        <div className="ml-auto flex gap-2">
+          <Button size="sm" disabled={selected.size === 0 || bulkBusy} onClick={() => void handleBulk("approve")}>
+            {bulkBusy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
+            {t("draft.bulk.approve")}
+          </Button>
+          <Button variant="outline" size="sm" disabled={selected.size === 0 || bulkBusy} onClick={() => void handleBulk("reject")}>
+            <X className="h-3.5 w-3.5" />{t("draft.bulk.reject")}
+          </Button>
+        </div>
+      </div>
+
+      {groups.map((g) => (
+        <div key={g.name || "__other__"} className="space-y-2">
+          {/* 확장별 묶음 — 한 확장이 스킬 여러 개를 만들어 함께 처리할 일이 많다 */}
+          <div className="flex items-center gap-2 px-1">
+            <label className="flex cursor-pointer items-center gap-2 text-xs font-medium text-fg-2">
+              <input
+                type="checkbox"
+                className="h-3.5 w-3.5 accent-[var(--accent)]"
+                checked={g.items.every((i) => selected.has(i.id))}
+                onChange={() => toggleGroup(g.items)}
+              />
+              {g.name ? (
+                <><Package className="h-3.5 w-3.5 text-accent" />{g.name}</>
+              ) : (
+                t("draft.bulk.otherGroup")
+              )}
+            </label>
+            <span className="text-xs text-muted">({g.items.length})</span>
+          </div>
+
+          {g.items.map((d) => (
+            <Card key={d.id} className="p-4">
+              <div className="flex items-start justify-between gap-3">
+                <input
+                  type="checkbox"
+                  className="mt-1 h-3.5 w-3.5 shrink-0 accent-[var(--accent)]"
+                  checked={selected.has(d.id)}
+                  onChange={() => toggleOne(d.id)}
+                  aria-label={d.name}
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="mb-1 flex items-center gap-2">
+                    <Badge tone="warn">Draft</Badge>
+                    <Badge tone="neutral">{categoryLabel(t, d.category)}</Badge>
+                  </div>
+                  <h3 className="text-sm font-semibold text-fg">{d.name}</h3>
+                  <p className="mt-1 text-xs text-muted line-clamp-2">{d.description}</p>
+                </div>
+                <div className="flex gap-2 shrink-0">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={rewrites[d.id]?.state === "loading" || rewrites[d.id]?.state === "applying"}
+                    onClick={() => void requestRewrite(d.id)}
+                  >
+                    {rewrites[d.id]?.state === "loading" ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <Wand2 className="h-3.5 w-3.5" />
+                    )}
+                    {t("draft.rewrite.button")}
+                  </Button>
+                  <Button size="sm" onClick={() => void handleApprove(d.id)}>
+                    <Check className="h-3.5 w-3.5" />{t("draft.approve")}
+                  </Button>
+                  <Button variant="outline" size="sm" onClick={() => void handleReject(d.id)}>
+                    <X className="h-3.5 w-3.5" />{t("draft.reject")}
+                  </Button>
+                </div>
+              </div>
+              <RewritePanel
+                state={rewrites[d.id]}
+                onApply={(content) => void applyRewrite(d.id, content)}
+                onDismiss={() => dismissRewrite(d.id)}
+              />
+            </Card>
+          ))}
+        </div>
       ))}
     </div>
   );

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -740,6 +740,17 @@
         "discard": "Discard",
         "dismiss": "Dismiss",
         "applyFailed": "Failed to apply: {error}"
+      },
+      "bulk": {
+        "selectAll": "Select all ({count})",
+        "selected": "{count} selected",
+        "approve": "Approve selected",
+        "reject": "Reject selected",
+        "otherGroup": "Not from an extension",
+        "approveConfirm": "Approve {count} selected? They become usable in chat immediately.",
+        "rejectConfirm": "Reject {count} selected? They are archived, not deleted.",
+        "partial": "Processed {ok} of {total}. The rest were already handled or not permitted.",
+        "failed": "Bulk action failed: {error}"
       }
     }
   },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -740,6 +740,17 @@
         "discard": "破棄",
         "dismiss": "閉じる",
         "applyFailed": "適用に失敗しました: {error}"
+      },
+      "bulk": {
+        "selectAll": "すべて選択 ({count})",
+        "selected": "{count}件選択中",
+        "approve": "選択を承認",
+        "reject": "選択を却下",
+        "otherGroup": "拡張以外のスキル",
+        "approveConfirm": "選択した{count}件を承認しますか？承認後すぐにチャットで使用されます。",
+        "rejectConfirm": "選択した{count}件を却下しますか？アーカイブされ、削除はされません。",
+        "partial": "{total}件中{ok}件のみ処理されました。残りは処理済みか権限がありません。",
+        "failed": "一括処理に失敗しました: {error}"
       }
     }
   },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -740,6 +740,17 @@
         "discard": "버리기",
         "dismiss": "닫기",
         "applyFailed": "적용 실패: {error}"
+      },
+      "bulk": {
+        "selectAll": "전체 선택 ({count})",
+        "selected": "{count}개 선택됨",
+        "approve": "선택 승인",
+        "reject": "선택 거부",
+        "otherGroup": "확장 외 스킬",
+        "approveConfirm": "선택한 {count}개를 승인할까요? 승인 즉시 채팅에서 사용됩니다.",
+        "rejectConfirm": "선택한 {count}개를 거부할까요? 보관 처리되며 삭제되지는 않습니다.",
+        "partial": "{total}개 중 {ok}개만 처리됐습니다. 나머지는 이미 처리됐거나 권한이 없습니다.",
+        "failed": "일괄 처리 실패: {error}"
       }
     }
   },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -740,6 +740,17 @@
         "discard": "放弃",
         "dismiss": "关闭",
         "applyFailed": "应用失败：{error}"
+      },
+      "bulk": {
+        "selectAll": "全选 ({count})",
+        "selected": "已选 {count} 项",
+        "approve": "批准所选",
+        "reject": "拒绝所选",
+        "otherGroup": "非扩展技能",
+        "approveConfirm": "批准所选 {count} 项？批准后立即可在聊天中使用。",
+        "rejectConfirm": "拒绝所选 {count} 项？将归档，不会删除。",
+        "partial": "{total} 项中仅处理了 {ok} 项，其余已处理或无权限。",
+        "failed": "批量操作失败：{error}"
       }
     }
   },


### PR DESCRIPTION
## 배경

확장 하나가 스킬을 여러 개 만든다 — `plugin-dev` 8개, `cli-power-skills` 7개, `hookify` 4개. 그런데 승인은 **하나씩만** 가능해서, 설치 직후 draft 24개를 개별 클릭해야 했다. 어느 draft 가 어느 확장에서 왔는지도 화면에 표시되지 않았다.

## 변경

### 백엔드

**`POST /api/agents/skills/drafts/bulk`** (신규)
```jsonc
{ "skillIds": ["...", "..."], "action": "approve" | "reject" }
→ { "action", "requested", "succeeded", "results": [{ skillId, ok, error? }] }
```
- **부분 성공 허용** — 개별 실패가 전체를 되돌리지 않고 건별 사유를 돌려준다(`NOT_DRAFT`/`NOT_FOUND`/`FORBIDDEN`)
- 권한·상태 검증은 개별 경로와 **동일하게** `updateStatus(actor)` 가 담당 — 일괄이라고 우회하지 않는다
- 한 요청 상한 50개
- ⚠️ 라우트 등록 순서: `/drafts/bulk` 가 `/:skillId/approve` 보다 **먼저** 와야 한다(Express 순차 매칭 — 뒤에 두면 `skillId='drafts'` 로 잡힌다)

**`listDrafts` 에 확장 JOIN** — `user_extensions` 를 LEFT JOIN 해 `extensionId`·`extensionName` 을 함께 싣는다. 그전에는 응답에 확장 정보가 없어 프론트가 묶을 수 없었다(LEFT 라 확장 유래가 아닌 draft 도 그대로 나온다).

### 프론트 (skill-library draft 탭)

- **확장별 그룹 헤더** + 그룹 체크박스 / 전체 선택
- **일괄 승인·거부 바** — 선택이 있을 때만 활성화해 오조작을 줄임
- 부분 성공은 `"N개 중 M개만 처리됐습니다"` 로 **그대로 알린다**(뭉뚱그리지 않음)
- 기존 개별 승인·거부·재작성 제안(`RewritePanel`)은 그대로 유지
- i18n 4언어(`skillLibrary.draft.bulk.*`)

### 동반 분할

JOIN 추가로 `skill-repository.ts` 가 405줄이 되어 `max-lines` 경고가 났다. `listDrafts` 의 SQL 조립을 **`skill-draft-query.ts`(순수 함수)** 로 분리 → 483줄(경고 해소)이자 **DB 없이 테스트 가능**해졌다.

## 라이브 검증 (chat.openmake.cc)

| 항목 | 결과 |
|---|---|
| draft 목록에 확장 이름 | plugin-dev 8 · cli-power-skills 7 · hookify 4 · claude-security 1 … 정상 그룹핑 |
| 일괄 승인 | `hookify` draft 4개 → **4/4 성공**, 확장 스킬 5개 전부 active |
| 부분 실패 경로 | 이미 active + 없는 id + 정상 혼합 → **1/3** + 건별 사유(`NOT_DRAFT (status=active)`, `NOT_FOUND`) |
| 화면 렌더 | "전체 선택"·"선택 승인"·"선택 거부"·"확장 외 스킬" 한국어 문구 노출 확인 |

## 체크리스트

- [x] `npm run lint` 0 errors (warning 은 작업 전 수준 29개로 복귀)
- [x] `npm test` 2925 passed (신규 12건 — 스키마 5 + 쿼리 빌더 7)
- [x] `npx tsc --noEmit` 통과 (백엔드·프론트)
- [x] 스키마·환경변수 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)