### PR TITLE
feat(web): 승인 창구를 `/approvals` 한 곳으로 통합

### DIFF
--- a/apps/web/app/(workspace)/approvals/page.tsx
+++ b/apps/web/app/(workspace)/approvals/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+/**
+ * 승인 대기 — **설치된 확장 구성요소를 승인하는 단일 창구**.
+ *
+ * 배경: 확장을 설치하면 스킬·MCP 가 draft 로 들어오는데, 승인 화면이 스킬은
+ * `/skill-library` 의 탭, MCP 는 `설정 → 커넥터` 의 서브탭으로 나뉘어 있었고 둘 다
+ * 사이드바에 없었다. 실제 사용자가 "어디서 승인하는지 정말 모르겠다"고 막힌 지점이라
+ * 한 페이지로 통합하고 사이드바에 노출한다(대기 건수 뱃지 포함).
+ *
+ * Custom Agent 는 승인 개념이 없다(실행 권한 없이 명시 선택 시에만 적용되는 페르소나라
+ * 설치 즉시 활성) — 그 사실을 화면에서 알려 "왜 여기 없지"를 없앤다.
+ */
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+import { Puzzle, Server, Bot, ExternalLink, ShieldQuestion } from "lucide-react";
+import { PageHeader, Card } from "@/components/ui/primitives";
+import { SkillDrafts } from "@/components/approvals/skill-drafts";
+import { McpDrafts } from "@/components/approvals/mcp-drafts";
+import { TaskApprovals } from "@/components/approvals/task-approvals";
+
+export default function ApprovalsPage() {
+  const t = useTranslations("approvals");
+  // 한쪽에서 승인하면 다른 섹션의 개수 표시도 갱신되도록 공용 리프레시 키를 쓴다
+  const [, setTick] = useState(0);
+  const refresh = () => setTick((n) => n + 1);
+
+  return (
+    <div className="flex h-full flex-col">
+      <PageHeader title={t("title")} description={t("description")} />
+
+      <div className="min-h-0 flex-1 space-y-6 overflow-y-auto p-6">
+        {/* 에이전트 작업 HITL — 작업이 실제로 멈춰 대기 중이라 맨 위에 둔다 */}
+        <section className="space-y-3">
+          <h2 className="flex items-center gap-2 text-sm font-semibold text-fg">
+            <ShieldQuestion className="h-4 w-4 text-accent" />
+            {t("tasks.title")}
+          </h2>
+          <p className="text-xs text-muted">{t("tasks.hint")}</p>
+          <TaskApprovals onRefreshAction={refresh} />
+        </section>
+
+        {/* 스킬 — 확장별로 묶여 나오며 일괄 승인 가능 */}
+        <section className="space-y-3 border-t border-border pt-6">
+          <h2 className="flex items-center gap-2 text-sm font-semibold text-fg">
+            <Puzzle className="h-4 w-4 text-accent" />
+            {t("skills.title")}
+          </h2>
+          <p className="text-xs text-muted">{t("skills.hint")}</p>
+          <SkillDrafts onRefreshAction={refresh} />
+        </section>
+
+        {/* MCP 서버 — 승인 후 연결되어야 채팅에서 도구로 쓰인다 */}
+        <section className="space-y-3 border-t border-border pt-6">
+          <h2 className="flex items-center gap-2 text-sm font-semibold text-fg">
+            <Server className="h-4 w-4 text-accent" />
+            {t("mcp.title")}
+          </h2>
+          <p className="text-xs text-muted">{t("mcp.hint")}</p>
+          <McpDrafts onRefreshAction={refresh} />
+        </section>
+
+        {/* Custom Agent — 승인 절차가 없다는 사실 자체를 알린다 */}
+        <section className="space-y-2 border-t border-border pt-6">
+          <h2 className="flex items-center gap-2 text-sm font-semibold text-fg">
+            <Bot className="h-4 w-4 text-accent" />
+            {t("agents.title")}
+          </h2>
+          <Card className="flex flex-wrap items-center justify-between gap-3 p-4">
+            <p className="text-xs text-muted">{t("agents.hint")}</p>
+            <Link
+              href="/custom-agents"
+              className="inline-flex items-center gap-1 text-xs font-medium text-accent hover:underline"
+            >
+              {t("agents.link")}
+              <ExternalLink className="h-3.5 w-3.5" />
+            </Link>
+          </Card>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(workspace)/skill-library/page.tsx
+++ b/apps/web/app/(workspace)/skill-library/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import {
   Library,
@@ -17,6 +18,7 @@ import {
   Check,
   Download,
   Wand2,
+  ClipboardCheck,
 } from "lucide-react";
 import {
   Button,
@@ -29,18 +31,9 @@ import { DiffView } from "@/components/chat/diff-view";
 import { cn } from "@/lib/utils";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { ApiClient, csrfHeaders } from "@/lib/api-client";
+import { CATEGORY_KEYS, type Translate } from "@/lib/skill-categories";
 
 /* ── 카테고리 라벨 (id → i18n 키) ──────────────────────────── */
-const CATEGORY_KEYS: Record<string, string> = {
-  productivity: "categories.productivity",
-  technology: "categories.technology",
-  creative: "categories.creative",
-  business: "categories.business",
-  science: "categories.science",
-  communication: "categories.communication",
-  finance: "categories.finance",
-  education: "categories.education",
-};
 
 /* ── 타입 ─────────────────────────────────────────────────── */
 interface Skill {
@@ -81,7 +74,6 @@ type DraftsResponse = ApiSuccess<{
 }>;
 
 /* ── 목업 폴백 ─────────────────────────────────────────────── */
-type Translate = (key: string) => string;
 
 function buildFallback(t: Translate): Skill[] {
   return [
@@ -114,7 +106,6 @@ function categoryLabel(t: Translate, id: string): string {
 
 const ALL = "all";
 const TAB_ACTIVE = "active";
-const TAB_DRAFT = "draft";
 
 /* ── 오버레이 모달 컴포넌트 ──────────────────────────────── */
 function Modal({
@@ -652,364 +643,10 @@ function SkillCard({
 }
 
 /* ── Draft 탭 ─────────────────────────────────────────────── */
-interface RewriteProposal {
-  content: string;
-  summary: string[];
-  model: string;
-  diff: string;
-  stats: { additions: number; deletions: number };
-}
-
-type RewriteState =
-  | { state: "loading" }
-  | { state: "none" }
-  | { state: "ready"; proposal: RewriteProposal }
-  | { state: "applying" }
-  | { state: "failed" };
-
-function DraftTab({ onRefresh }: { onRefresh: () => void }) {
-  const t = useTranslations("skillLibrary");
-  const [drafts, setDrafts] = useState<Skill[]>([]);
-  const [loading, setLoading] = useState(true);
-  // 설치 시 적응 Phase 3 — 재작성 제안은 diff 를 확인하고 명시 적용할 때만 반영된다
-  const [rewrites, setRewrites] = useState<Record<string, RewriteState>>({});
-  // 일괄 처리 — 확장 하나가 스킬 8개를 만들기도 해서 하나씩 누르는 부담이 컸다
-  const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [bulkBusy, setBulkBusy] = useState(false);
-
-  const loadDrafts = useCallback(async () => {
-    setLoading(true);
-    try {
-      const res = await ApiClient.get<DraftsResponse>("/api/agents/skills/drafts?target=user");
-      setDrafts((res?.data?.drafts ?? []).map(mapSkill));
-    } catch {
-      setDrafts([]);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => { void loadDrafts(); }, [loadDrafts]);
-
-  // 확장별 묶음 — 확장 유래가 아닌 draft 는 마지막 '기타' 그룹으로
-  const groups = (() => {
-    const byExt = new Map<string, Skill[]>();
-    for (const d of drafts) {
-      const key = d.extensionName ?? "";
-      const list = byExt.get(key);
-      if (list) list.push(d);
-      else byExt.set(key, [d]);
-    }
-    return [...byExt.entries()]
-      .sort((a, b) => (a[0] === "" ? 1 : b[0] === "" ? -1 : a[0].localeCompare(b[0])))
-      .map(([name, items]) => ({ name, items }));
-  })();
-
-  function toggleOne(id: string) {
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  }
-
-  function toggleGroup(items: Skill[]) {
-    const ids = items.map((i) => i.id);
-    const allOn = ids.every((id) => selected.has(id));
-    setSelected((prev) => {
-      const next = new Set(prev);
-      for (const id of ids) {
-        if (allOn) next.delete(id);
-        else next.add(id);
-      }
-      return next;
-    });
-  }
-
-  async function handleBulk(action: "approve" | "reject") {
-    const skillIds = [...selected];
-    if (skillIds.length === 0) return;
-    if (!window.confirm(t(action === "approve" ? "draft.bulk.approveConfirm" : "draft.bulk.rejectConfirm", { count: skillIds.length }))) return;
-    setBulkBusy(true);
-    try {
-      const res = await ApiClient.post<{ data?: { succeeded: number; requested: number } }>(
-        "/api/agents/skills/drafts/bulk",
-        { skillIds, action },
-      );
-      const d = res?.data;
-      // 부분 성공을 그대로 알린다 — 전부 됐다고 뭉뚱그리지 않는다
-      if (d && d.succeeded < d.requested) {
-        alert(t("draft.bulk.partial", { ok: d.succeeded, total: d.requested }));
-      }
-      setSelected(new Set());
-      await loadDrafts();
-      onRefresh();
-    } catch (err) {
-      alert(t("draft.bulk.failed", { error: err instanceof Error ? err.message : t("genericError") }));
-    } finally {
-      setBulkBusy(false);
-    }
-  }
-
-  async function handleApprove(skillId: string) {
-    try {
-      await ApiClient.post(`/api/agents/skills/${skillId}/approve`, {});
-      await loadDrafts();
-      onRefresh();
-    } catch (err) {
-      alert(t("draft.approveFailed", { error: err instanceof Error ? err.message : t("genericError") }));
-    }
-  }
-
-  async function requestRewrite(skillId: string) {
-    setRewrites((m) => ({ ...m, [skillId]: { state: "loading" } }));
-    try {
-      const res = await ApiClient.post<{ data?: { proposal: RewriteProposal | null } }>(
-        `/api/agents/skills/${skillId}/rewrite-proposal`,
-        {},
-      );
-      const proposal = res?.data?.proposal ?? null;
-      setRewrites((m) => ({ ...m, [skillId]: proposal ? { state: "ready", proposal } : { state: "none" } }));
-    } catch {
-      setRewrites((m) => ({ ...m, [skillId]: { state: "failed" } }));
-    }
-  }
-
-  async function applyRewrite(skillId: string, content: string) {
-    setRewrites((m) => ({ ...m, [skillId]: { state: "applying" } }));
-    try {
-      await ApiClient.put(`/api/agents/skills/${skillId}`, { content });
-      setRewrites((m) => {
-        const next = { ...m };
-        delete next[skillId];
-        return next;
-      });
-      await loadDrafts();
-    } catch (err) {
-      setRewrites((m) => ({ ...m, [skillId]: { state: "failed" } }));
-      alert(t("draft.rewrite.applyFailed", { error: err instanceof Error ? err.message : t("genericError") }));
-    }
-  }
-
-  function dismissRewrite(skillId: string) {
-    setRewrites((m) => {
-      const next = { ...m };
-      delete next[skillId];
-      return next;
-    });
-  }
-
-  async function handleReject(skillId: string) {
-    if (!window.confirm(t("draft.rejectConfirm"))) return;
-    try {
-      await ApiClient.post(`/api/agents/skills/${skillId}/reject`, {});
-      await loadDrafts();
-    } catch (err) {
-      alert(t("draft.rejectFailed", { error: err instanceof Error ? err.message : t("genericError") }));
-    }
-  }
-
-  if (loading) {
-    return (
-      <div className="grid place-items-center py-16 text-center">
-        <Loader2 className="mb-3 h-6 w-6 animate-spin text-faint" />
-        <p className="text-sm text-muted">{t("draft.loading")}</p>
-      </div>
-    );
-  }
-
-  if (drafts.length === 0) {
-    return (
-      <div className="grid place-items-center py-16 text-center">
-        <Library className="mb-3 h-8 w-8 text-faint" />
-        <p className="text-sm font-medium text-fg-2">{t("draft.emptyTitle")}</p>
-        <p className="mt-1 text-sm text-muted">{t("draft.emptyDesc")}</p>
-      </div>
-    );
-  }
-
-  const allIds = drafts.map((d) => d.id);
-  const allSelected = allIds.length > 0 && allIds.every((id) => selected.has(id));
-
-  return (
-    <div className="space-y-3">
-      {/* 일괄 처리 바 — 선택이 있을 때만 액션을 노출해 오조작을 줄인다 */}
-      <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-surface-2 px-3 py-2">
-        <label className="flex cursor-pointer items-center gap-2 text-xs text-fg-2">
-          <input
-            type="checkbox"
-            className="h-3.5 w-3.5 accent-[var(--accent)]"
-            checked={allSelected}
-            onChange={() => setSelected(allSelected ? new Set() : new Set(allIds))}
-          />
-          {t("draft.bulk.selectAll", { count: drafts.length })}
-        </label>
-        <span className="text-xs text-muted">{t("draft.bulk.selected", { count: selected.size })}</span>
-        <div className="ml-auto flex gap-2">
-          <Button size="sm" disabled={selected.size === 0 || bulkBusy} onClick={() => void handleBulk("approve")}>
-            {bulkBusy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
-            {t("draft.bulk.approve")}
-          </Button>
-          <Button variant="outline" size="sm" disabled={selected.size === 0 || bulkBusy} onClick={() => void handleBulk("reject")}>
-            <X className="h-3.5 w-3.5" />{t("draft.bulk.reject")}
-          </Button>
-        </div>
-      </div>
-
-      {groups.map((g) => (
-        <div key={g.name || "__other__"} className="space-y-2">
-          {/* 확장별 묶음 — 한 확장이 스킬 여러 개를 만들어 함께 처리할 일이 많다 */}
-          <div className="flex items-center gap-2 px-1">
-            <label className="flex cursor-pointer items-center gap-2 text-xs font-medium text-fg-2">
-              <input
-                type="checkbox"
-                className="h-3.5 w-3.5 accent-[var(--accent)]"
-                checked={g.items.every((i) => selected.has(i.id))}
-                onChange={() => toggleGroup(g.items)}
-              />
-              {g.name ? (
-                <><Package className="h-3.5 w-3.5 text-accent" />{g.name}</>
-              ) : (
-                t("draft.bulk.otherGroup")
-              )}
-            </label>
-            <span className="text-xs text-muted">({g.items.length})</span>
-          </div>
-
-          {g.items.map((d) => (
-            <Card key={d.id} className="p-4">
-              <div className="flex items-start justify-between gap-3">
-                <input
-                  type="checkbox"
-                  className="mt-1 h-3.5 w-3.5 shrink-0 accent-[var(--accent)]"
-                  checked={selected.has(d.id)}
-                  onChange={() => toggleOne(d.id)}
-                  aria-label={d.name}
-                />
-                <div className="flex-1 min-w-0">
-                  <div className="mb-1 flex items-center gap-2">
-                    <Badge tone="warn">Draft</Badge>
-                    <Badge tone="neutral">{categoryLabel(t, d.category)}</Badge>
-                  </div>
-                  <h3 className="text-sm font-semibold text-fg">{d.name}</h3>
-                  <p className="mt-1 text-xs text-muted line-clamp-2">{d.description}</p>
-                </div>
-                <div className="flex gap-2 shrink-0">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={rewrites[d.id]?.state === "loading" || rewrites[d.id]?.state === "applying"}
-                    onClick={() => void requestRewrite(d.id)}
-                  >
-                    {rewrites[d.id]?.state === "loading" ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    ) : (
-                      <Wand2 className="h-3.5 w-3.5" />
-                    )}
-                    {t("draft.rewrite.button")}
-                  </Button>
-                  <Button size="sm" onClick={() => void handleApprove(d.id)}>
-                    <Check className="h-3.5 w-3.5" />{t("draft.approve")}
-                  </Button>
-                  <Button variant="outline" size="sm" onClick={() => void handleReject(d.id)}>
-                    <X className="h-3.5 w-3.5" />{t("draft.reject")}
-                  </Button>
-                </div>
-              </div>
-              <RewritePanel
-                state={rewrites[d.id]}
-                onApply={(content) => void applyRewrite(d.id, content)}
-                onDismiss={() => dismissRewrite(d.id)}
-              />
-            </Card>
-          ))}
-        </div>
-      ))}
-    </div>
-  );
-}
-
-/**
- * 재작성 제안 패널 — 적용 전 diff 를 반드시 보여준다 (LLM 재작성의 자동 적용 금지).
- * 기존 채팅 diff 뷰어(components/chat/diff-view.tsx)를 그대로 재사용한다.
- */
-function RewritePanel({
-  state,
-  onApply,
-  onDismiss,
-}: {
-  state?: RewriteState;
-  onApply: (content: string) => void;
-  onDismiss: () => void;
-}) {
-  const t = useTranslations("skillLibrary");
-  if (!state) return null;
-
-  if (state.state === "loading" || state.state === "applying") {
-    return (
-      <div className="mt-3 flex items-center gap-2 border-t border-border pt-3 text-xs text-muted">
-        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-        {state.state === "loading" ? t("draft.rewrite.analyzing") : t("draft.rewrite.applying")}
-      </div>
-    );
-  }
-  if (state.state === "none") {
-    return (
-      <div className="mt-3 flex items-center justify-between gap-2 border-t border-border pt-3 text-xs text-muted">
-        <span>{t("draft.rewrite.noChange")}</span>
-        <button type="button" className="text-accent hover:underline" onClick={onDismiss}>
-          {t("draft.rewrite.dismiss")}
-        </button>
-      </div>
-    );
-  }
-  if (state.state === "failed") {
-    return (
-      <div className="mt-3 flex items-center justify-between gap-2 border-t border-border pt-3 text-xs text-warn">
-        <span>{t("draft.rewrite.failed")}</span>
-        <button type="button" className="text-accent hover:underline" onClick={onDismiss}>
-          {t("draft.rewrite.dismiss")}
-        </button>
-      </div>
-    );
-  }
-
-  const { proposal } = state;
-  return (
-    <div className="mt-3 space-y-2 border-t border-border pt-3">
-      <div className="flex flex-wrap items-center gap-2 text-xs">
-        <span className="font-medium text-fg-2">{t("draft.rewrite.proposalTitle")}</span>
-        <span className="text-success">+{proposal.stats.additions}</span>
-        <span className="text-danger">−{proposal.stats.deletions}</span>
-        <span className="font-mono text-faint">{proposal.model}</span>
-      </div>
-      {proposal.summary.length > 0 && (
-        <ul className="space-y-0.5 text-xs text-muted">
-          {proposal.summary.map((line, i) => (
-            <li key={i}>· {line}</li>
-          ))}
-        </ul>
-      )}
-      <div className="max-h-80 overflow-auto">
-        <DiffView text={proposal.diff} />
-      </div>
-      <p className="text-[11px] text-muted">{t("draft.rewrite.reviewHint")}</p>
-      <div className="flex gap-2">
-        <Button size="sm" onClick={() => onApply(proposal.content)}>
-          <Check className="h-3.5 w-3.5" />{t("draft.rewrite.apply")}
-        </Button>
-        <Button variant="outline" size="sm" onClick={onDismiss}>
-          <X className="h-3.5 w-3.5" />{t("draft.rewrite.discard")}
-        </Button>
-      </div>
-    </div>
-  );
-}
-
 /* ── 메인 페이지 ──────────────────────────────────────────── */
 export default function SkillLibraryPage() {
   const t = useTranslations("skillLibrary");
+  const router = useRouter();
   const [skills, setSkills] = useState<Skill[]>(() => buildFallback(t));
   const [loading, setLoading] = useState(true);
   const [active, setActive] = useState<string>(ALL);
@@ -1105,6 +742,10 @@ export default function SkillLibraryPage() {
         description={t("pageDescription")}
         actions={
           <>
+            {/* 구 Draft 탭 자리 — 승인은 /approvals 한 곳으로 모았다 (2026-08-25) */}
+            <Button variant="outline" size="sm" onClick={() => router.push("/approvals")}>
+              <ClipboardCheck className="h-4 w-4" />{t("approvalsButton")}
+            </Button>
             <Button variant="outline" size="sm" onClick={() => setShowUpload(true)}>
               <Upload className="h-4 w-4" />{t("uploadButton")}
             </Button>
@@ -1124,7 +765,7 @@ export default function SkillLibraryPage() {
 
       {/* 탭 */}
       <div className="flex gap-4 border-b border-border px-6 pt-3">
-        {[{ id: TAB_ACTIVE, label: t("tabs.active") }, { id: TAB_DRAFT, label: t("tabs.draft") }].map((tabItem) => (
+        {[{ id: TAB_ACTIVE, label: t("tabs.active") }].map((tabItem) => (
           <button key={tabItem.id} onClick={() => setTab(tabItem.id)}
             className={cn(
               "pb-2 text-sm font-medium transition border-b-2",
@@ -1138,9 +779,7 @@ export default function SkillLibraryPage() {
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
-        {tab === TAB_DRAFT ? (
-          <DraftTab onRefresh={loadSkills} />
-        ) : (
+        {(
           <>
             {/* 카테고리 필터 */}
             <div className="mb-5 flex flex-wrap gap-2">

--- a/apps/web/components/approvals/mcp-drafts.tsx
+++ b/apps/web/components/approvals/mcp-drafts.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+/**
+ * MCP 서버 승인 대기 목록.
+ *
+ * 원래 설정 → 커넥터 → Draft 탭에만 있었다. 스킬 승인(/skill-library)과 위치가 달라
+ * 사용자가 "어디서 승인하는지 모르겠다"고 하던 문제가 있어, 승인 창구를 `/approvals`
+ * 한 곳으로 모으면서 이 컴포넌트로 분리했다.
+ *
+ * ⚠️ 위험 표시(conventionFindings 의 error)는 **정적 룰**만 근거로 한다 — LLM audit 은
+ * warn 으로 강등돼 차단하지 않는다(2026-08-24, 오탐으로 정상 플러그인을 막던 문제).
+ *
+ * @see app/(workspace)/approvals/page.tsx
+ */
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Check, X, Loader2, Server, AlertTriangle } from "lucide-react";
+import { Button, Badge, Card } from "@/components/ui/primitives";
+import { ApiClient } from "@/lib/api-client";
+
+interface DraftServer {
+  id: string;
+  name?: string;
+  git_url?: string;
+  status: string;
+  manifest_meta?: {
+    conventionFindings?: { severity: string; rule?: string; message?: string; source?: string }[];
+    extensionName?: string;
+  };
+}
+
+export function McpDrafts({ onRefreshAction }: { onRefreshAction?: () => void }) {
+  const t = useTranslations("approvals");
+  const [drafts, setDrafts] = useState<DraftServer[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [acting, setActing] = useState<Record<string, boolean>>({});
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await ApiClient.get<{ data: DraftServer[] }>("/api/mcp/servers/drafts");
+      setDrafts(res?.data ?? []);
+    } catch {
+      setDrafts([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  async function act(id: string, action: "approve" | "reject") {
+    setActing((p) => ({ ...p, [id]: true }));
+    try {
+      await ApiClient.post(`/api/mcp/servers/${id}/${action}`, {});
+      await load();
+      onRefreshAction?.();
+    } catch (err) {
+      alert(t("mcp.actionFailed", { error: err instanceof Error ? err.message : "" }));
+    } finally {
+      setActing((p) => ({ ...p, [id]: false }));
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="grid place-items-center py-10 text-muted">
+        <Loader2 className="h-5 w-5 animate-spin" />
+      </div>
+    );
+  }
+
+  if (drafts.length === 0) {
+    return <p className="py-6 text-center text-sm text-muted">{t("mcp.empty")}</p>;
+  }
+
+  return (
+    <div className="space-y-2">
+      {drafts.map((d) => {
+        // 정적 룰의 error 만 실제 차단 사유다 (LLM findings 는 warn 강등)
+        const risky = d.manifest_meta?.conventionFindings?.some(
+          (f) => f.severity === "error" && f.source !== "llm",
+        );
+        const busy = acting[d.id] ?? false;
+        return (
+          <Card key={d.id} className="p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 flex-1">
+                <div className="mb-1 flex flex-wrap items-center gap-2">
+                  <Badge tone="warn">{t("mcp.badge")}</Badge>
+                  {d.manifest_meta?.extensionName && (
+                    <Badge tone="neutral">{d.manifest_meta.extensionName}</Badge>
+                  )}
+                  {risky && (
+                    <span className="inline-flex items-center gap-1 text-xs text-danger">
+                      <AlertTriangle className="h-3.5 w-3.5" />{t("mcp.risk")}
+                    </span>
+                  )}
+                </div>
+                <h3 className="flex items-center gap-1.5 text-sm font-semibold text-fg">
+                  <Server className="h-3.5 w-3.5 text-accent" />
+                  {d.name ?? d.id.slice(0, 8)}
+                </h3>
+                {d.git_url && (
+                  <p className="mt-1 truncate font-mono text-xs text-muted">{d.git_url}</p>
+                )}
+              </div>
+              <div className="flex shrink-0 gap-2">
+                <Button size="sm" disabled={busy} onClick={() => void act(d.id, "approve")}>
+                  {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
+                  {t("approve")}
+                </Button>
+                <Button variant="outline" size="sm" disabled={busy} onClick={() => void act(d.id, "reject")}>
+                  <X className="h-3.5 w-3.5" />{t("reject")}
+                </Button>
+              </div>
+            </div>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/approvals/skill-drafts.tsx
+++ b/apps/web/components/approvals/skill-drafts.tsx
@@ -1,0 +1,411 @@
+"use client";
+
+/**
+ * 스킬 승인 대기 목록 — 확장별 묶음 + 일괄 승인·거부 + 호환 재작성 제안.
+ *
+ * 원래 skill-library 의 "Draft 검토" 탭에 있었으나, 승인 위치가 스킬(/skill-library)과
+ * MCP(설정→커넥터)로 나뉘어 있어 사용자가 찾지 못하는 문제가 있었다. 승인 창구를
+ * `/approvals` 한 곳으로 통합하면서 이 컴포넌트로 추출했다.
+ *
+ * @see app/(workspace)/approvals/page.tsx
+ */
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Check, X, Loader2, Wand2, Package, Library } from "lucide-react";
+import { Button, Badge, Card } from "@/components/ui/primitives";
+import { ApiClient } from "@/lib/api-client";
+import { DiffView } from "@/components/chat/diff-view";
+import { CATEGORY_KEYS, type Translate } from "@/lib/skill-categories";
+
+interface Skill {
+  id: string;
+  name: string;
+  category: string;
+  description: string;
+  status?: string;
+  extensionName?: string;
+}
+
+interface ApiSkill {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  status?: string;
+  extensionId?: string;
+  extensionName?: string;
+}
+
+type DraftsResponse = { data?: { drafts: ApiSkill[] } };
+
+function mapSkill(s: ApiSkill): Skill {
+  return {
+    id: s.id,
+    name: s.name,
+    category: s.category || "general",
+    description: s.description || "",
+    status: s.status,
+    extensionName: s.extensionName,
+  };
+}
+
+function categoryLabel(t: Translate, id: string): string {
+  const key = CATEGORY_KEYS[id];
+  return key ? t(key) : id;
+}
+
+interface RewriteProposal {
+  content: string;
+  summary: string[];
+  model: string;
+  diff: string;
+  stats: { additions: number; deletions: number };
+}
+
+type RewriteState =
+  | { state: "loading" }
+  | { state: "none" }
+  | { state: "ready"; proposal: RewriteProposal }
+  | { state: "applying" }
+  | { state: "failed" };
+
+export function SkillDrafts({ onRefreshAction }: { onRefreshAction?: () => void }) {
+  const t = useTranslations("skillLibrary");
+  const [drafts, setDrafts] = useState<Skill[]>([]);
+  const [loading, setLoading] = useState(true);
+  // 설치 시 적응 Phase 3 — 재작성 제안은 diff 를 확인하고 명시 적용할 때만 반영된다
+  const [rewrites, setRewrites] = useState<Record<string, RewriteState>>({});
+  // 일괄 처리 — 확장 하나가 스킬 8개를 만들기도 해서 하나씩 누르는 부담이 컸다
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkBusy, setBulkBusy] = useState(false);
+
+  const loadDrafts = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await ApiClient.get<DraftsResponse>("/api/agents/skills/drafts?target=user");
+      setDrafts((res?.data?.drafts ?? []).map(mapSkill));
+    } catch {
+      setDrafts([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void loadDrafts(); }, [loadDrafts]);
+
+  // 확장별 묶음 — 확장 유래가 아닌 draft 는 마지막 '기타' 그룹으로
+  const groups = (() => {
+    const byExt = new Map<string, Skill[]>();
+    for (const d of drafts) {
+      const key = d.extensionName ?? "";
+      const list = byExt.get(key);
+      if (list) list.push(d);
+      else byExt.set(key, [d]);
+    }
+    return [...byExt.entries()]
+      .sort((a, b) => (a[0] === "" ? 1 : b[0] === "" ? -1 : a[0].localeCompare(b[0])))
+      .map(([name, items]) => ({ name, items }));
+  })();
+
+  function toggleOne(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleGroup(items: Skill[]) {
+    const ids = items.map((i) => i.id);
+    const allOn = ids.every((id) => selected.has(id));
+    setSelected((prev) => {
+      const next = new Set(prev);
+      for (const id of ids) {
+        if (allOn) next.delete(id);
+        else next.add(id);
+      }
+      return next;
+    });
+  }
+
+  async function handleBulk(action: "approve" | "reject") {
+    const skillIds = [...selected];
+    if (skillIds.length === 0) return;
+    if (!window.confirm(t(action === "approve" ? "draft.bulk.approveConfirm" : "draft.bulk.rejectConfirm", { count: skillIds.length }))) return;
+    setBulkBusy(true);
+    try {
+      const res = await ApiClient.post<{ data?: { succeeded: number; requested: number } }>(
+        "/api/agents/skills/drafts/bulk",
+        { skillIds, action },
+      );
+      const d = res?.data;
+      // 부분 성공을 그대로 알린다 — 전부 됐다고 뭉뚱그리지 않는다
+      if (d && d.succeeded < d.requested) {
+        alert(t("draft.bulk.partial", { ok: d.succeeded, total: d.requested }));
+      }
+      setSelected(new Set());
+      await loadDrafts();
+      onRefreshAction?.();
+    } catch (err) {
+      alert(t("draft.bulk.failed", { error: err instanceof Error ? err.message : t("genericError") }));
+    } finally {
+      setBulkBusy(false);
+    }
+  }
+
+  async function handleApprove(skillId: string) {
+    try {
+      await ApiClient.post(`/api/agents/skills/${skillId}/approve`, {});
+      await loadDrafts();
+      onRefreshAction?.();
+    } catch (err) {
+      alert(t("draft.approveFailed", { error: err instanceof Error ? err.message : t("genericError") }));
+    }
+  }
+
+  async function requestRewrite(skillId: string) {
+    setRewrites((m) => ({ ...m, [skillId]: { state: "loading" } }));
+    try {
+      const res = await ApiClient.post<{ data?: { proposal: RewriteProposal | null } }>(
+        `/api/agents/skills/${skillId}/rewrite-proposal`,
+        {},
+      );
+      const proposal = res?.data?.proposal ?? null;
+      setRewrites((m) => ({ ...m, [skillId]: proposal ? { state: "ready", proposal } : { state: "none" } }));
+    } catch {
+      setRewrites((m) => ({ ...m, [skillId]: { state: "failed" } }));
+    }
+  }
+
+  async function applyRewrite(skillId: string, content: string) {
+    setRewrites((m) => ({ ...m, [skillId]: { state: "applying" } }));
+    try {
+      await ApiClient.put(`/api/agents/skills/${skillId}`, { content });
+      setRewrites((m) => {
+        const next = { ...m };
+        delete next[skillId];
+        return next;
+      });
+      await loadDrafts();
+    } catch (err) {
+      setRewrites((m) => ({ ...m, [skillId]: { state: "failed" } }));
+      alert(t("draft.rewrite.applyFailed", { error: err instanceof Error ? err.message : t("genericError") }));
+    }
+  }
+
+  function dismissRewrite(skillId: string) {
+    setRewrites((m) => {
+      const next = { ...m };
+      delete next[skillId];
+      return next;
+    });
+  }
+
+  async function handleReject(skillId: string) {
+    if (!window.confirm(t("draft.rejectConfirm"))) return;
+    try {
+      await ApiClient.post(`/api/agents/skills/${skillId}/reject`, {});
+      await loadDrafts();
+    } catch (err) {
+      alert(t("draft.rejectFailed", { error: err instanceof Error ? err.message : t("genericError") }));
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="grid place-items-center py-16 text-center">
+        <Loader2 className="mb-3 h-6 w-6 animate-spin text-faint" />
+        <p className="text-sm text-muted">{t("draft.loading")}</p>
+      </div>
+    );
+  }
+
+  if (drafts.length === 0) {
+    return (
+      <div className="grid place-items-center py-16 text-center">
+        <Library className="mb-3 h-8 w-8 text-faint" />
+        <p className="text-sm font-medium text-fg-2">{t("draft.emptyTitle")}</p>
+        <p className="mt-1 text-sm text-muted">{t("draft.emptyDesc")}</p>
+      </div>
+    );
+  }
+
+  const allIds = drafts.map((d) => d.id);
+  const allSelected = allIds.length > 0 && allIds.every((id) => selected.has(id));
+
+  return (
+    <div className="space-y-3">
+      {/* 일괄 처리 바 — 선택이 있을 때만 액션을 노출해 오조작을 줄인다 */}
+      <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-surface-2 px-3 py-2">
+        <label className="flex cursor-pointer items-center gap-2 text-xs text-fg-2">
+          <input
+            type="checkbox"
+            className="h-3.5 w-3.5 accent-[var(--accent)]"
+            checked={allSelected}
+            onChange={() => setSelected(allSelected ? new Set() : new Set(allIds))}
+          />
+          {t("draft.bulk.selectAll", { count: drafts.length })}
+        </label>
+        <span className="text-xs text-muted">{t("draft.bulk.selected", { count: selected.size })}</span>
+        <div className="ml-auto flex gap-2">
+          <Button size="sm" disabled={selected.size === 0 || bulkBusy} onClick={() => void handleBulk("approve")}>
+            {bulkBusy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
+            {t("draft.bulk.approve")}
+          </Button>
+          <Button variant="outline" size="sm" disabled={selected.size === 0 || bulkBusy} onClick={() => void handleBulk("reject")}>
+            <X className="h-3.5 w-3.5" />{t("draft.bulk.reject")}
+          </Button>
+        </div>
+      </div>
+
+      {groups.map((g) => (
+        <div key={g.name || "__other__"} className="space-y-2">
+          {/* 확장별 묶음 — 한 확장이 스킬 여러 개를 만들어 함께 처리할 일이 많다 */}
+          <div className="flex items-center gap-2 px-1">
+            <label className="flex cursor-pointer items-center gap-2 text-xs font-medium text-fg-2">
+              <input
+                type="checkbox"
+                className="h-3.5 w-3.5 accent-[var(--accent)]"
+                checked={g.items.every((i) => selected.has(i.id))}
+                onChange={() => toggleGroup(g.items)}
+              />
+              {g.name ? (
+                <><Package className="h-3.5 w-3.5 text-accent" />{g.name}</>
+              ) : (
+                t("draft.bulk.otherGroup")
+              )}
+            </label>
+            <span className="text-xs text-muted">({g.items.length})</span>
+          </div>
+
+          {g.items.map((d) => (
+            <Card key={d.id} className="p-4">
+              <div className="flex items-start justify-between gap-3">
+                <input
+                  type="checkbox"
+                  className="mt-1 h-3.5 w-3.5 shrink-0 accent-[var(--accent)]"
+                  checked={selected.has(d.id)}
+                  onChange={() => toggleOne(d.id)}
+                  aria-label={d.name}
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="mb-1 flex items-center gap-2">
+                    <Badge tone="warn">Draft</Badge>
+                    <Badge tone="neutral">{categoryLabel(t, d.category)}</Badge>
+                  </div>
+                  <h3 className="text-sm font-semibold text-fg">{d.name}</h3>
+                  <p className="mt-1 text-xs text-muted line-clamp-2">{d.description}</p>
+                </div>
+                <div className="flex gap-2 shrink-0">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={rewrites[d.id]?.state === "loading" || rewrites[d.id]?.state === "applying"}
+                    onClick={() => void requestRewrite(d.id)}
+                  >
+                    {rewrites[d.id]?.state === "loading" ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <Wand2 className="h-3.5 w-3.5" />
+                    )}
+                    {t("draft.rewrite.button")}
+                  </Button>
+                  <Button size="sm" onClick={() => void handleApprove(d.id)}>
+                    <Check className="h-3.5 w-3.5" />{t("draft.approve")}
+                  </Button>
+                  <Button variant="outline" size="sm" onClick={() => void handleReject(d.id)}>
+                    <X className="h-3.5 w-3.5" />{t("draft.reject")}
+                  </Button>
+                </div>
+              </div>
+              <RewritePanel
+                state={rewrites[d.id]}
+                onApply={(content) => void applyRewrite(d.id, content)}
+                onDismiss={() => dismissRewrite(d.id)}
+              />
+            </Card>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * 재작성 제안 패널 — 적용 전 diff 를 반드시 보여준다 (LLM 재작성의 자동 적용 금지).
+ * 기존 채팅 diff 뷰어(components/chat/diff-view.tsx)를 그대로 재사용한다.
+ */
+function RewritePanel({
+  state,
+  onApply,
+  onDismiss,
+}: {
+  state?: RewriteState;
+  onApply: (content: string) => void;
+  onDismiss: () => void;
+}) {
+  const t = useTranslations("skillLibrary");
+  if (!state) return null;
+
+  if (state.state === "loading" || state.state === "applying") {
+    return (
+      <div className="mt-3 flex items-center gap-2 border-t border-border pt-3 text-xs text-muted">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        {state.state === "loading" ? t("draft.rewrite.analyzing") : t("draft.rewrite.applying")}
+      </div>
+    );
+  }
+  if (state.state === "none") {
+    return (
+      <div className="mt-3 flex items-center justify-between gap-2 border-t border-border pt-3 text-xs text-muted">
+        <span>{t("draft.rewrite.noChange")}</span>
+        <button type="button" className="text-accent hover:underline" onClick={onDismiss}>
+          {t("draft.rewrite.dismiss")}
+        </button>
+      </div>
+    );
+  }
+  if (state.state === "failed") {
+    return (
+      <div className="mt-3 flex items-center justify-between gap-2 border-t border-border pt-3 text-xs text-warn">
+        <span>{t("draft.rewrite.failed")}</span>
+        <button type="button" className="text-accent hover:underline" onClick={onDismiss}>
+          {t("draft.rewrite.dismiss")}
+        </button>
+      </div>
+    );
+  }
+
+  const { proposal } = state;
+  return (
+    <div className="mt-3 space-y-2 border-t border-border pt-3">
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        <span className="font-medium text-fg-2">{t("draft.rewrite.proposalTitle")}</span>
+        <span className="text-success">+{proposal.stats.additions}</span>
+        <span className="text-danger">−{proposal.stats.deletions}</span>
+        <span className="font-mono text-faint">{proposal.model}</span>
+      </div>
+      {proposal.summary.length > 0 && (
+        <ul className="space-y-0.5 text-xs text-muted">
+          {proposal.summary.map((line, i) => (
+            <li key={i}>· {line}</li>
+          ))}
+        </ul>
+      )}
+      <div className="max-h-80 overflow-auto">
+        <DiffView text={proposal.diff} />
+      </div>
+      <p className="text-[11px] text-muted">{t("draft.rewrite.reviewHint")}</p>
+      <div className="flex gap-2">
+        <Button size="sm" onClick={() => onApply(proposal.content)}>
+          <Check className="h-3.5 w-3.5" />{t("draft.rewrite.apply")}
+        </Button>
+        <Button variant="outline" size="sm" onClick={onDismiss}>
+          <X className="h-3.5 w-3.5" />{t("draft.rewrite.discard")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/web/components/approvals/task-approvals.tsx
+++ b/apps/web/components/approvals/task-approvals.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+/**
+ * 에이전트 작업 승인 대기(HITL) — 고위험 도구 호출 · `ask_human` 질문.
+ *
+ * 채팅 인라인(`chat/message-list.tsx` InlineApprovals)에도 같은 승인 UI 가 있다. 그쪽은
+ * 대화 흐름 안에서 즉시 답하는 용도라 그대로 두고, 여기서는 **작업을 떠나 있어도**
+ * 대기 중인 승인을 찾을 수 있게 한다 — 승인 창구를 `/approvals` 한 곳으로 모으는 목적.
+ *
+ * ⚠️ 이 목록은 **인메모리 레지스트리**(`task-sandbox/approval-gate.ts`)라 서버 재시작 시
+ * 사라진다. 없어진 항목에 응답하면 404 가 나므로 실패 시 목록을 다시 읽는다.
+ *
+ * @see app/(workspace)/approvals/page.tsx
+ */
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+import { Check, X, Loader2, MessageCircleQuestion, Wrench, ExternalLink } from "lucide-react";
+import { Button, Badge, Card } from "@/components/ui/primitives";
+import { ApiClient } from "@/lib/api-client";
+
+interface PendingItem {
+  approvalId: string;
+  taskId: string;
+  toolName: string;
+  args?: Record<string, unknown>;
+}
+
+/** 인자 요약 — 어떤 작업을 승인하는지 한 줄로 보인다(장문은 잘라낸다). */
+function summarizeArgs(args?: Record<string, unknown>): string {
+  if (!args) return "";
+  const raw =
+    typeof args.question === "string"
+      ? args.question
+      : typeof args.command === "string"
+        ? args.command
+        : JSON.stringify(args);
+  return raw.length > 300 ? `${raw.slice(0, 300)}…` : raw;
+}
+
+export function TaskApprovals({ onRefreshAction }: { onRefreshAction?: () => void }) {
+  const t = useTranslations("approvals");
+  const [items, setItems] = useState<PendingItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await ApiClient.get<{ data: { pending: PendingItem[] } }>(
+        "/api/agent-tasks/approvals/pending",
+      );
+      setItems(res?.data?.pending ?? []);
+    } catch {
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function run(id: string, fn: () => Promise<unknown>) {
+    setBusy(id);
+    try {
+      await fn();
+    } catch (err) {
+      alert(t("tasks.actionFailed", { error: err instanceof Error ? err.message : "" }));
+    } finally {
+      setBusy(null);
+      await load(); // 성공/실패(만료 404) 모두 서버 상태로 재동기화
+      onRefreshAction?.();
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="grid place-items-center py-10 text-muted">
+        <Loader2 className="h-5 w-5 animate-spin" />
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return <p className="py-6 text-center text-sm text-muted">{t("tasks.empty")}</p>;
+  }
+
+  return (
+    <div className="space-y-2">
+      {items.map((a) => {
+        const isQuestion = a.toolName === "ask_human";
+        const acting = busy === a.approvalId;
+        return (
+          <Card key={a.approvalId} className="p-4">
+            <div className="mb-2 flex flex-wrap items-center gap-2">
+              <Badge tone={isQuestion ? "accent" : "warn"}>
+                {isQuestion ? t("tasks.question") : t("tasks.tool")}
+              </Badge>
+              <span className="inline-flex items-center gap-1 font-mono text-xs text-muted">
+                {isQuestion ? (
+                  <MessageCircleQuestion className="h-3.5 w-3.5" />
+                ) : (
+                  <Wrench className="h-3.5 w-3.5" />
+                )}
+                {a.toolName}
+              </span>
+              <Link
+                href={`/agent-tasks/${a.taskId}`}
+                className="inline-flex items-center gap-1 text-xs text-accent hover:underline"
+              >
+                {t("tasks.openTask")}
+                <ExternalLink className="h-3 w-3" />
+              </Link>
+            </div>
+
+            <p className="whitespace-pre-wrap break-words text-sm text-fg">{summarizeArgs(a.args)}</p>
+
+            {isQuestion && (
+              <input
+                value={answers[a.approvalId] ?? ""}
+                onChange={(e) => setAnswers((p) => ({ ...p, [a.approvalId]: e.target.value }))}
+                placeholder={t("tasks.answerPlaceholder")}
+                className="mt-3 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none focus:border-accent"
+              />
+            )}
+
+            <div className="mt-3 flex flex-wrap gap-2">
+              {isQuestion && (
+                <Button
+                  size="sm"
+                  disabled={acting || !(answers[a.approvalId] ?? "").trim()}
+                  onClick={() =>
+                    void run(a.approvalId, () =>
+                      ApiClient.post(`/api/agent-tasks/approvals/${a.approvalId}/answer`, {
+                        text: answers[a.approvalId] ?? "",
+                      }),
+                    )
+                  }
+                >
+                  {acting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
+                  {t("tasks.sendAnswer")}
+                </Button>
+              )}
+              {!isQuestion && (
+                <Button
+                  size="sm"
+                  disabled={acting}
+                  onClick={() =>
+                    void run(a.approvalId, () =>
+                      ApiClient.post(`/api/agent-tasks/approvals/${a.approvalId}/approve`, {}),
+                    )
+                  }
+                >
+                  {acting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
+                  {t("approve")}
+                </Button>
+              )}
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={acting}
+                onClick={() =>
+                  void run(a.approvalId, () =>
+                    ApiClient.post(`/api/agent-tasks/approvals/${a.approvalId}/reject`, {}),
+                  )
+                }
+              >
+                <X className="h-3.5 w-3.5" />
+                {t("reject")}
+              </Button>
+            </div>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/settings/connectors-section.tsx
+++ b/apps/web/components/settings/connectors-section.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { Server, Boxes, Plus, Loader2, X, KeyRound } from "lucide-react";
+import { Server, Boxes, Plus, Loader2, X, KeyRound, ClipboardCheck } from "lucide-react";
 import {
   Button,
   Badge,
@@ -95,17 +95,6 @@ function mapServer(s: ApiMcpServer, t: Translator): McpServer {
     secretKeys: Object.entries(s.env ?? {})
       .filter(([, v]) => v === "***")
       .map(([k]) => k),
-  };
-}
-
-/* ── Draft 타입 ─────────────────────────────────────────────── */
-interface DraftServer {
-  id: string;
-  name?: string;
-  git_url?: string;
-  status: string;
-  manifest_meta?: {
-    conventionFindings?: { severity: string }[];
   };
 }
 
@@ -387,7 +376,8 @@ const TRANSPORT_TONE: Record<Transport, "accent" | "neutral"> = {
   HTTP: "accent",
 };
 
-type TabId = "servers" | "drafts" | "instances";
+/** Draft(승인 대기) 탭은 `/approvals` 로 이관됨 — 아래 주석 참고 (2026-08-25). */
+type TabId = "servers" | "instances";
 
 export function ConnectorsSection() {
   const t = useTranslations("mcpServers");
@@ -397,49 +387,8 @@ export function ConnectorsSection() {
   const [servers, setServers] = useState<McpServer[]>(() => buildMockServers(t));
   const [loading, setLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState<Record<string, boolean>>({});
-  const [drafts, setDrafts] = useState<DraftServer[]>([]);
-  const [draftsLoading, setDraftsLoading] = useState(false);
-  const [draftActionLoading, setDraftActionLoading] = useState<Record<string, boolean>>({});
   const [envEditTarget, setEnvEditTarget] = useState<McpServer | null>(null);
   const [envNotice, setEnvNotice] = useState<string | null>(null);
-
-  async function loadDrafts() {
-    setDraftsLoading(true);
-    try {
-      const res = await ApiClient.get<{ success: boolean; data: DraftServer[] }>(
-        "/api/mcp/servers/drafts",
-      );
-      setDrafts(res?.data ?? []);
-    } catch {
-      /* 실패 시 빈 목록 유지 */
-    } finally {
-      setDraftsLoading(false);
-    }
-  }
-
-  async function handleApproveDraft(id: string) {
-    setDraftActionLoading((prev) => ({ ...prev, [id]: true }));
-    try {
-      await ApiClient.post(`/api/mcp/servers/${id}/approve`, {});
-      await loadDrafts();
-    } catch {
-      /* 실패 시 현상 유지 */
-    } finally {
-      setDraftActionLoading((prev) => ({ ...prev, [id]: false }));
-    }
-  }
-
-  async function handleRejectDraft(id: string) {
-    setDraftActionLoading((prev) => ({ ...prev, [id]: true }));
-    try {
-      await ApiClient.post(`/api/mcp/servers/${id}/reject`, {});
-      await loadDrafts();
-    } catch {
-      /* 실패 시 현상 유지 */
-    } finally {
-      setDraftActionLoading((prev) => ({ ...prev, [id]: false }));
-    }
-  }
 
   // env 교체 성공 — 백엔드가 기존 컨테이너를 정리했으므로(stale env 방지) 재연결 안내.
   function handleEnvUpdated(respawnRequired: boolean) {
@@ -501,20 +450,14 @@ export function ConnectorsSection() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
-    if (tab === "drafts") {
-      void loadDrafts();
-    }
-  }, [tab]);
-
   return (
     <Card>
       <GitImportModal
         open={modalOpen}
         onClose={() => setModalOpen(false)}
         onSuccess={() => {
-          setTab("drafts");
-          void loadDrafts();
+          // 설치분은 draft 로 들어가며 승인해야 연결된다 — 단일 승인 창구로 보낸다
+          router.push("/approvals");
         }}
       />
       <EnvEditModal
@@ -528,6 +471,11 @@ export function ConnectorsSection() {
           <p className="mt-0.5 text-xs text-muted">{t("description")}</p>
         </div>
         <div className="flex items-center gap-2">
+          {/* 구 Draft 탭 자리 — 승인은 /approvals 한 곳으로 모았다 (2026-08-25) */}
+          <Button variant="outline" size="sm" onClick={() => router.push("/approvals")}>
+            <ClipboardCheck className="h-4 w-4" />
+            {t("pendingApprovals")}
+          </Button>
           <Button variant="outline" size="sm" onClick={() => router.push("/mcp-catalog")}>
             <Boxes className="h-4 w-4" />
             {t("catalog")}
@@ -554,7 +502,7 @@ export function ConnectorsSection() {
         )}
         {/* 탭 */}
         <div className="mb-4 inline-flex rounded-pill border border-border bg-surface-2 p-1">
-          {(["servers", "drafts", "instances"] as TabId[]).map((tabId) => (
+          {(["servers", "instances"] as TabId[]).map((tabId) => (
             <button
               key={tabId}
               type="button"
@@ -566,7 +514,7 @@ export function ConnectorsSection() {
                   : "text-muted hover:text-fg",
               )}
             >
-              {tabId === "servers" ? t("tabServers") : tabId === "drafts" ? "Draft" : t("tabInstances")}
+              {tabId === "servers" ? t("tabServers") : t("tabInstances")}
             </button>
           ))}
         </div>
@@ -699,95 +647,6 @@ export function ConnectorsSection() {
             </tbody>
           </Table>
         </div>
-        )}
-
-        {/* Draft 탭 */}
-        {tab === "drafts" && (
-          <div className="overflow-x-auto rounded-lg border border-border">
-            <Table>
-              <thead>
-                <tr>
-                  <Th>ID</Th>
-                  <Th>Git URL</Th>
-                  <Th>{t("colName")}</Th>
-                  <Th>{t("colStatus")}</Th>
-                  <Th>{t("draftColRisk")}</Th>
-                  <Th>{t("colAction")}</Th>
-                </tr>
-              </thead>
-              <tbody>
-                {draftsLoading ? (
-                  <tr>
-                    <Td colSpan={6}>
-                      <div className="py-12 text-center text-muted">{t("loading")}</div>
-                    </Td>
-                  </tr>
-                ) : drafts.length === 0 ? (
-                  <tr>
-                    <Td colSpan={6}>
-                      <div className="py-12 text-center text-muted">
-                        {t("emptyDrafts")}
-                      </div>
-                    </Td>
-                  </tr>
-                ) : (
-                  drafts.map((d) => {
-                    const hasError = d.manifest_meta?.conventionFindings?.some(
-                      (f) => f.severity === "error",
-                    );
-                    const isActing = draftActionLoading[d.id] ?? false;
-                    return (
-                      <tr key={d.id} className="transition hover:bg-surface-2">
-                        <Td className="font-mono text-xs text-fg-2">
-                          {d.id.slice(0, 8)}
-                        </Td>
-                        <Td className="max-w-xs truncate text-xs text-fg-2">
-                          {d.git_url ?? "—"}
-                        </Td>
-                        <Td className="text-sm text-fg">{d.name ?? "—"}</Td>
-                        <Td>
-                          <Badge tone={d.status === "approved" ? "success" : d.status === "rejected" ? "danger" : "neutral"}>
-                            {d.status}
-                          </Badge>
-                        </Td>
-                        <Td>
-                          {hasError ? (
-                            <span className="text-sm text-danger">{t("riskWarning")}</span>
-                          ) : (
-                            <span className="text-faint">—</span>
-                          )}
-                        </Td>
-                        <Td>
-                          {d.status === "pending" && (
-                            <div className="flex items-center gap-1">
-                              <Button
-                                size="sm"
-                                disabled={isActing}
-                                onClick={() => void handleApproveDraft(d.id)}
-                              >
-                                {isActing && (
-                                  <Loader2 className="h-3 w-3 animate-spin" />
-                                )}
-                                {t("approve")}
-                              </Button>
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                disabled={isActing}
-                                onClick={() => void handleRejectDraft(d.id)}
-                              >
-                                {t("reject")}
-                              </Button>
-                            </div>
-                          )}
-                        </Td>
-                      </tr>
-                    );
-                  })
-                )}
-              </tbody>
-            </Table>
-          </div>
         )}
 
         {/* 인스턴스 상태 탭 — 프로세스 lifecycle(시작·중지·pid 헬스체크) */}

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -65,23 +65,36 @@ export function Sidebar() {
   const [query, setQuery] = useState("");
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
-  // 승인 대기 배지 — 위임된 작업이 HITL 승인에서 멈춘 것을 어느 화면/재접속 후에도 발견할 수 있게
-  // (WS 인라인 프롬프트는 연결 끊김·세션 이동 시 유실 — 2026-08-08 대형 PDF "인식 못함" 오인 사례).
+  // 승인 대기 배지 — 승인이 필요한 **세 종류를 합산**해 `/approvals` 에 표시한다.
+  // ① 에이전트 작업 HITL: 위임된 작업이 승인에서 멈춘 것을 어느 화면/재접속 후에도 발견할 수
+  //    있게 (WS 인라인 프롬프트는 연결 끊김·세션 이동 시 유실 — 2026-08-08 대형 PDF "인식 못함"
+  //    오인 사례) ② 확장 설치분 스킬 draft ③ 확장 설치분 MCP draft.
+  // ②③ 은 승인 화면이 서브탭에 숨어 있어 사용자가 찾지 못했다 — 배지가 진입점이 된다(2026-08-25).
   const [pendingApprovals, setPendingApprovals] = useState(0);
   useEffect(() => {
     if (!user) { setPendingApprovals(0); return; }
     let alive = true;
+    const opts = { redirectOnUnauthorized: false } as const;
+    // 한 축이 실패해도 나머지 합계는 보이도록 개별 fallback 을 둔다
+    const count = async (fn: () => Promise<number>) => { try { return await fn(); } catch { return 0; } };
     const poll = async () => {
-      try {
-        const r = await ApiClient.get<{ data: { pending: unknown[] } }>(
-          "/api/agent-tasks/approvals/pending",
-          { redirectOnUnauthorized: false },
-        );
-        if (alive) setPendingApprovals(r.data?.pending?.length ?? 0);
-      } catch {
-        /* 미인증/일시 오류 — 배지 유지 안 함 */
-        if (alive) setPendingApprovals(0);
-      }
+      const [hitl, skills, mcp] = await Promise.all([
+        count(async () => {
+          const r = await ApiClient.get<{ data: { pending: unknown[] } }>(
+            "/api/agent-tasks/approvals/pending", opts);
+          return r.data?.pending?.length ?? 0;
+        }),
+        count(async () => {
+          const r = await ApiClient.get<{ data: { total?: number; drafts?: unknown[] } }>(
+            "/api/agents/skills/drafts?target=user&limit=1", opts);
+          return r.data?.total ?? r.data?.drafts?.length ?? 0;
+        }),
+        count(async () => {
+          const r = await ApiClient.get<{ data: unknown[] }>("/api/mcp/servers/drafts", opts);
+          return r.data?.length ?? 0;
+        }),
+      ]);
+      if (alive) setPendingApprovals(hitl + skills + mcp);
     };
     void poll();
     const timer = setInterval(poll, 30_000);
@@ -232,7 +245,7 @@ export function Sidebar() {
               >
                 <item.icon className="h-[18px] w-[18px]" />
                 {tNav(item.labelKey)}
-                {item.href === "/agent-tasks" && pendingApprovals > 0 && (
+                {item.href === "/approvals" && pendingApprovals > 0 && (
                   <span
                     className="ml-auto inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-amber-500 px-1.5 text-[11px] font-semibold text-white"
                     title={tNav("pendingApprovals", { count: pendingApprovals })}

--- a/apps/web/lib/nav.ts
+++ b/apps/web/lib/nav.ts
@@ -1,4 +1,5 @@
 import {
+  ClipboardCheck,
   Bot,
   LayoutGrid,
   MessageSquare,
@@ -35,6 +36,9 @@ export const NAV_ITEMS: NavItem[] = [
   { labelKey: "items.chat", href: "/", icon: MessageSquare, minRole: "guest" },
   { labelKey: "items.agentTasks", href: "/agent-tasks", icon: Sparkles },
   { labelKey: "items.customAgents", href: "/custom-agents", icon: Bot },
+  // 확장 설치분(스킬·MCP)의 단일 승인 창구 — 그전엔 스킬/MCP 승인이 서로 다른 화면의
+  // 서브탭에만 있고 사이드바에 없어 사용자가 찾지 못했다 (2026-08-25).
+  { labelKey: "items.approvals", href: "/approvals", icon: ClipboardCheck },
   { labelKey: "items.artifacts", href: "/artifacts", icon: LayoutGrid },
   { labelKey: "items.admin", href: "/admin", icon: Shield, minRole: "admin" },
 ];

--- a/apps/web/lib/skill-categories.ts
+++ b/apps/web/lib/skill-categories.ts
@@ -1,0 +1,17 @@
+/**
+ * 스킬 카테고리 라벨 키 — 스킬 라이브러리와 승인 화면이 공유한다.
+ *
+ * @module lib/skill-categories
+ */
+export const CATEGORY_KEYS: Record<string, string> = {
+  productivity: "categories.productivity",
+  technology: "categories.technology",
+  creative: "categories.creative",
+  business: "categories.business",
+  science: "categories.science",
+  communication: "categories.communication",
+  finance: "categories.finance",
+  education: "categories.education",
+};
+
+export type Translate = (key: string) => string;

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -25,7 +25,8 @@
       "systemSettingsAdmin": "System Settings",
       "developer": "Developer",
       "schedulesAdmin": "Task Schedules",
-      "agentSuggestionsAdmin": "Prompt suggestions"
+      "agentSuggestionsAdmin": "Prompt suggestions",
+      "approvals": "Approvals"
     },
     "pendingApprovals": "{count} pending approval(s) — agent tasks are waiting for your approval"
   },
@@ -752,7 +753,8 @@
         "partial": "Processed {ok} of {total}. The rest were already handled or not permitted.",
         "failed": "Bulk action failed: {error}"
       }
-    }
+    },
+    "approvalsButton": "Approvals"
   },
   "agentTasks": {
     "loading": "Loading...",
@@ -1060,7 +1062,8 @@
     "envSaved": "Credentials updated.",
     "envSavedRespawn": "Credentials updated. The existing connection was closed; the new values apply once it reconnects.",
     "envUpdateError": "Failed to update credentials",
-    "tabInstances": "Instances"
+    "tabInstances": "Instances",
+    "pendingApprovals": "Approvals"
   },
   "mcpCatalog": {
     "pageTitle": "MCP Catalog",
@@ -2001,5 +2004,39 @@
     "colStarted": "Started",
     "colStopped": "Stopped",
     "colError": "Error"
+  },
+  "approvals": {
+    "title": "Pending approvals",
+    "description": "Approve skills and MCP servers from installed extensions here to start using them in chat.",
+    "approve": "Approve",
+    "reject": "Reject",
+    "skills": {
+      "title": "Skills",
+      "hint": "Once approved, call them with `/skill-name` or let them apply automatically on related questions."
+    },
+    "mcp": {
+      "title": "MCP servers",
+      "hint": "Once approved the server connects, and the model calls its tools automatically in chat.",
+      "badge": "Pending",
+      "risk": "Risky command detected — review before approving",
+      "empty": "No MCP servers awaiting approval.",
+      "actionFailed": "Action failed: {error}"
+    },
+    "agents": {
+      "title": "Custom agents",
+      "hint": "Agents need no approval — they are usable as soon as they are installed.",
+      "link": "Open agent list"
+    },
+    "tasks": {
+      "title": "Agent task approvals",
+      "hint": "High-risk tool runs and agent questions need approval before the task continues. You can also answer inline in chat.",
+      "empty": "No agent tasks awaiting approval.",
+      "question": "Question",
+      "tool": "Tool run",
+      "openTask": "Open task",
+      "answerPlaceholder": "Type your answer",
+      "sendAnswer": "Send answer",
+      "actionFailed": "Action failed: {error}"
+    }
   }
 }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -25,7 +25,8 @@
       "systemSettingsAdmin": "システム設定",
       "developer": "開発者",
       "schedulesAdmin": "タスクスケジュール",
-      "agentSuggestionsAdmin": "プロンプト提案"
+      "agentSuggestionsAdmin": "プロンプト提案",
+      "approvals": "承認待ち"
     },
     "pendingApprovals": "承認待ち {count}件 — エージェント作業がユーザーの承認を待っています"
   },
@@ -752,7 +753,8 @@
         "partial": "{total}件中{ok}件のみ処理されました。残りは処理済みか権限がありません。",
         "failed": "一括処理に失敗しました: {error}"
       }
-    }
+    },
+    "approvalsButton": "承認待ち"
   },
   "agentTasks": {
     "loading": "読み込み中...",
@@ -1060,7 +1062,8 @@
     "envSaved": "認証情報を変更しました。",
     "envSavedRespawn": "認証情報を変更しました。既存の接続は終了し、再接続時に新しい値が適用されます。",
     "envUpdateError": "認証情報の変更に失敗しました",
-    "tabInstances": "インスタンス状態"
+    "tabInstances": "インスタンス状態",
+    "pendingApprovals": "承認待ち"
   },
   "mcpCatalog": {
     "pageTitle": "MCPカタログ",
@@ -2001,5 +2004,39 @@
     "colStarted": "開始",
     "colStopped": "終了",
     "colError": "エラー"
+  },
+  "approvals": {
+    "title": "承認待ち",
+    "description": "インストールした拡張のスキル・MCPサーバーをここで承認すると、チャットですぐ使えます。",
+    "approve": "承認",
+    "reject": "却下",
+    "skills": {
+      "title": "スキル",
+      "hint": "承認すると `/スキル名` で呼び出せ、関連する質問では自動的に適用されます。"
+    },
+    "mcp": {
+      "title": "MCPサーバー",
+      "hint": "承認するとサーバーが接続され、チャットでモデルがそのツールを自動的に呼び出します。",
+      "badge": "承認待ち",
+      "risk": "危険なコマンドを検出 — 確認のうえ承認",
+      "empty": "承認待ちのMCPサーバーはありません。",
+      "actionFailed": "処理に失敗しました: {error}"
+    },
+    "agents": {
+      "title": "カスタムエージェント",
+      "hint": "エージェントは承認不要です — インストール後すぐ使用できます。",
+      "link": "エージェント一覧を開く"
+    },
+    "tasks": {
+      "title": "エージェント作業の承認",
+      "hint": "高リスクなツール実行とエージェントからの質問は、承認しないと作業が進みません。チャット内でも回答できます。",
+      "empty": "承認待ちの作業はありません。",
+      "question": "質問",
+      "tool": "ツール実行",
+      "openTask": "作業を開く",
+      "answerPlaceholder": "回答を入力してください",
+      "sendAnswer": "回答を送信",
+      "actionFailed": "処理に失敗しました: {error}"
+    }
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -25,7 +25,8 @@
       "systemSettingsAdmin": "시스템 설정",
       "developer": "개발자",
       "schedulesAdmin": "작업 스케줄",
-      "agentSuggestionsAdmin": "프롬프트 제안"
+      "agentSuggestionsAdmin": "프롬프트 제안",
+      "approvals": "승인 대기"
     },
     "pendingApprovals": "승인 대기 {count}건 — 에이전트 작업이 사용자 승인을 기다리고 있습니다"
   },
@@ -752,7 +753,8 @@
         "partial": "{total}개 중 {ok}개만 처리됐습니다. 나머지는 이미 처리됐거나 권한이 없습니다.",
         "failed": "일괄 처리 실패: {error}"
       }
-    }
+    },
+    "approvalsButton": "승인 대기"
   },
   "agentTasks": {
     "loading": "불러오는 중...",
@@ -1060,7 +1062,8 @@
     "envSaved": "자격증명을 변경했습니다.",
     "envSavedRespawn": "자격증명을 변경했습니다. 기존 연결이 종료되었으며, 다시 연결되면 새 값이 적용됩니다.",
     "envUpdateError": "자격증명 변경에 실패했습니다",
-    "tabInstances": "인스턴스 상태"
+    "tabInstances": "인스턴스 상태",
+    "pendingApprovals": "승인 대기"
   },
   "mcpCatalog": {
     "pageTitle": "MCP 카탈로그",
@@ -2001,5 +2004,39 @@
     "colStarted": "시작",
     "colStopped": "종료",
     "colError": "오류"
+  },
+  "approvals": {
+    "title": "승인 대기",
+    "description": "설치한 확장의 스킬·MCP 서버를 여기서 승인하면 채팅에서 바로 쓸 수 있습니다.",
+    "approve": "승인",
+    "reject": "거부",
+    "skills": {
+      "title": "스킬",
+      "hint": "승인하면 채팅에서 `/스킬이름` 으로 부르거나, 관련 질문 시 자동으로 적용됩니다."
+    },
+    "mcp": {
+      "title": "MCP 서버",
+      "hint": "승인하면 서버가 연결되고, 채팅에서 모델이 그 도구를 자동으로 호출합니다.",
+      "badge": "승인 대기",
+      "risk": "위험 명령 감지 — 검토 후 승인",
+      "empty": "승인 대기 중인 MCP 서버가 없습니다.",
+      "actionFailed": "처리 실패: {error}"
+    },
+    "agents": {
+      "title": "커스텀 에이전트",
+      "hint": "에이전트는 승인이 필요 없습니다 — 설치 즉시 사용할 수 있습니다.",
+      "link": "에이전트 목록 열기"
+    },
+    "tasks": {
+      "title": "에이전트 작업 승인",
+      "hint": "고위험 도구 실행과 에이전트의 질문은 승인해야 작업이 이어집니다. 채팅 안에서도 바로 답할 수 있습니다.",
+      "empty": "승인 대기 중인 작업이 없습니다.",
+      "question": "질문",
+      "tool": "도구 실행",
+      "openTask": "작업 열기",
+      "answerPlaceholder": "답변을 입력하세요",
+      "sendAnswer": "답변 보내기",
+      "actionFailed": "처리 실패: {error}"
+    }
   }
 }

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -25,7 +25,8 @@
       "systemSettingsAdmin": "系统设置",
       "developer": "开发者",
       "schedulesAdmin": "任务计划",
-      "agentSuggestionsAdmin": "提示词建议"
+      "agentSuggestionsAdmin": "提示词建议",
+      "approvals": "待审批"
     },
     "pendingApprovals": "{count} 个待批准 — 代理任务正在等待您的批准"
   },
@@ -752,7 +753,8 @@
         "partial": "{total} 项中仅处理了 {ok} 项，其余已处理或无权限。",
         "failed": "批量操作失败：{error}"
       }
-    }
+    },
+    "approvalsButton": "待审批"
   },
   "agentTasks": {
     "loading": "加载中...",
@@ -1060,7 +1062,8 @@
     "envSaved": "凭据已更新。",
     "envSavedRespawn": "凭据已更新。现有连接已关闭，重新连接后将使用新值。",
     "envUpdateError": "更新凭据失败",
-    "tabInstances": "实例状态"
+    "tabInstances": "实例状态",
+    "pendingApprovals": "待审批"
   },
   "mcpCatalog": {
     "pageTitle": "MCP 目录",
@@ -2001,5 +2004,39 @@
     "colStarted": "启动",
     "colStopped": "结束",
     "colError": "错误"
+  },
+  "approvals": {
+    "title": "待审批",
+    "description": "在此批准已安装扩展的技能和 MCP 服务器后，即可在聊天中使用。",
+    "approve": "批准",
+    "reject": "拒绝",
+    "skills": {
+      "title": "技能",
+      "hint": "批准后可用 `/技能名` 调用，相关提问时也会自动应用。"
+    },
+    "mcp": {
+      "title": "MCP 服务器",
+      "hint": "批准后服务器将连接，模型会在聊天中自动调用其工具。",
+      "badge": "待审批",
+      "risk": "检测到危险命令 — 请审查后再批准",
+      "empty": "没有待审批的 MCP 服务器。",
+      "actionFailed": "操作失败：{error}"
+    },
+    "agents": {
+      "title": "自定义智能体",
+      "hint": "智能体无需批准 — 安装后即可使用。",
+      "link": "打开智能体列表"
+    },
+    "tasks": {
+      "title": "代理任务审批",
+      "hint": "高风险工具执行和代理提问需经批准后任务才会继续。也可以直接在聊天中回复。",
+      "empty": "没有待审批的代理任务。",
+      "question": "提问",
+      "tool": "工具执行",
+      "openTask": "打开任务",
+      "answerPlaceholder": "请输入回复",
+      "sendAnswer": "发送回复",
+      "actionFailed": "操作失败：{error}"
+    }
   }
 }


### PR DESCRIPTION
## 배경

승인이 필요한 것이 **세 종류**인데 화면이 전부 흩어져 있었고 셋 다 사이드바에 없었다.

| 승인 대상 | 기존 위치 | 사이드바 |
|---|---|---|
| 에이전트 작업 HITL | 채팅 인라인 (연결 끊기면 유실) | 배지만 `/agent-tasks` 에 |
| 스킬 draft | `/skill-library` 서브탭 | ✗ |
| MCP draft | 설정 → 커넥터 서브탭 | ✗ |

실제 사용자가 "승인을 어디에서 해야할 지를 모르겠어"에서 막혔다.

## 변경

- **신규 `/approvals`** — 세 종류를 한 페이지에. HITL 은 작업이 실제로 멈춰 대기 중이라 맨 위.
  Custom Agent 는 승인 개념이 없다는 사실을 명시(설치 즉시 활성) — "왜 여기 없지"를 없앤다.
- **사이드바 항목 + 배지를 세 종류 합산으로** 변경 (기존엔 HITL 만 세어 `/agent-tasks` 에 붙어 있었다).
  축 하나가 실패해도 나머지 합계는 보이도록 개별 fallback.
- **구 진입점은 링크로 대체** — `/skill-library` Draft 탭 제거, 커넥터 Draft 탭 제거,
  Git import 성공 시 `/approvals` 로 이동.

## ⚠️ 부수 수정 (기존 결함)

커넥터 Draft 탭은 `d.status === "pending"` 일 때만 승인 버튼을 렌더했는데,
`GET /api/mcp/servers/drafts` 는 `WHERE status='draft'` 로만 조회한다
(`mcp-server-draft-repository.ts:93`). 조건이 **영구 거짓**이라 그 화면에서 승인 버튼이
한 번도 보인 적이 없다. 탭을 걷어내며 해소됐고, 새 `McpDrafts` 는 상태 필터 없이 버튼을 단다.

위험 표시는 정적 룰의 error 만 근거로 한다 — LLM audit findings 는 warn 강등이라 차단
근거가 아니다 (2026-08-24 오탐 수정과 정합).

## 체크리스트

- [x] `npm run lint` — 에러 0 (기존 warning 29건만)
- [x] `tsc --noEmit` — apps/web, apps/api 모두 통과
- [x] `npm test` — 269 스위트 / 2925 테스트 통과
- [x] Gate 3 (600줄, apps/api/src) 로컬 재현 — 위반 0
- [x] i18n 4언어 (ko/en/ja/zh) — `approvals.*`, `nav.items.approvals`, 버튼 라벨
- [ ] 라이브 확인 (배포 후 chat.openmake.cc)

백엔드 변경 없음 (프론트 + i18n 전용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)