### PR TITLE
fix(mcp): 연결 실패 원인을 화면에 드러낸다 (401 이 원인 없는 "연결 안 됨"으로 보이던 문제)

### DIFF
--- a/apps/api/src/config/mcp-connect-errors.ts
+++ b/apps/api/src/config/mcp-connect-errors.ts
@@ -1,0 +1,40 @@
+/**
+ * MCP 연결 실패 원인 분류표 (L2 config).
+ *
+ * 배경 — 원격 MCP 서버(streamable-http/sse)가 OAuth 를 요구하면 연결이 401 로 실패하는데,
+ * 실패한 client 는 풀에 등록되지 않아 목록 API 가 `connectionError: null` 을 돌려주고
+ * 화면에는 그냥 "연결 안 됨"으로만 보였다. 승인은 성공했는데 도구가 영원히 0개인 상태를
+ * 사용자가 알아챌 방법이 없었다 (2026-08-25 라이브 확인: Linear·Asana·Slack·Figma·Atlassian).
+ *
+ * 여기서는 **패턴 → 코드** 대응만 둔다. 문구는 프론트 i18n(`mcpServers.connectError.*`)이
+ * 담당한다 — 백엔드가 한국어 문장을 만들면 다국어에서 다시 갈라진다.
+ *
+ * @module config/mcp-connect-errors
+ */
+
+/** 연결 실패 원인 코드 — 프론트 i18n 키와 1:1 대응한다. */
+export type McpConnectErrorCode =
+    | 'auth_required'
+    | 'not_found'
+    | 'unreachable'
+    | 'timeout'
+    | 'protocol'
+    | 'unknown';
+
+/**
+ * 판정 규칙 — **위에서부터 먼저 맞는 것**을 채택한다(순서가 곧 우선순위).
+ *
+ * 원문 메시지는 SDK/fetch/Node 가 만들어 형태가 제각각이라 정규식으로 본다.
+ * 401/403 을 최우선에 두는 이유: 인증 문제는 사용자가 할 수 있는 조치가 명확한데
+ * "연결 실패"로 뭉뚱그리면 재시도만 반복하게 된다.
+ */
+export const MCP_CONNECT_ERROR_RULES: readonly { code: McpConnectErrorCode; pattern: RegExp }[] = [
+    { code: 'auth_required', pattern: /\b(401|403)\b|unauthorized|forbidden|invalid_token|missing_token|access token|authorization header/i },
+    { code: 'not_found', pattern: /\b404\b|not found/i },
+    { code: 'timeout', pattern: /timeout|timed out|ETIMEDOUT|ESOCKETTIMEDOUT/i },
+    { code: 'unreachable', pattern: /ECONNREFUSED|ENOTFOUND|EHOSTUNREACH|ENETUNREACH|ECONNRESET|fetch failed|socket hang up/i },
+    { code: 'protocol', pattern: /jsonrpc|protocol|invalid.*(response|message)|unexpected token|parse/i },
+];
+
+/** 원문 메시지를 화면에 실어 보낼 때의 길이 상한 — 스택/HTML 본문이 통째로 새는 것을 막는다. */
+export const MCP_CONNECT_ERROR_MAX_CHARS = 300;

--- a/apps/api/src/data/repositories/mcp-catalog-repository.ts
+++ b/apps/api/src/data/repositories/mcp-catalog-repository.ts
@@ -387,6 +387,36 @@ export class McpCatalogRepository {
         };
     }
 
+    /**
+     * 서버별 **최근 실패 원인**을 한 번에 조회 (목록 API 용).
+     *
+     * 연결에 실패한 client 는 풀에 남지 않으므로 메모리 상태만으로는 원인을 알 수 없다.
+     * `mcp_server_instances` 는 이력 테이블이라 서버당 행이 여러 개 — `DISTINCT ON` 으로
+     * 서버별 최신 crashed 행 하나만 뽑는다.
+     *
+     * ⚠️ 최신 행이 `running` 이면(= 그 뒤 성공적으로 떴다면) 낡은 실패를 보여주지 않도록
+     *    제외한다. 안 그러면 지금 잘 도는 서버에 예전 에러가 계속 붙는다.
+     */
+    async getLatestConnectErrors(
+        userId: string,
+        serverIds: string[],
+    ): Promise<Map<string, { message: string; at: string }>> {
+        const out = new Map<string, { message: string; at: string }>();
+        if (serverIds.length === 0) return out;
+        const r = await this.pool.query<{ mcp_server_id: string; status: string; last_error: string | null; started_at: string }>(
+            `SELECT DISTINCT ON (mcp_server_id) mcp_server_id, status, last_error, started_at::text
+               FROM mcp_server_instances
+              WHERE user_id = $1 AND mcp_server_id = ANY($2::text[])
+              ORDER BY mcp_server_id, started_at DESC`,
+            [userId, serverIds],
+        );
+        for (const row of r.rows) {
+            if (row.status !== 'crashed' || !row.last_error) continue;
+            out.set(row.mcp_server_id, { message: row.last_error, at: row.started_at });
+        }
+        return out;
+    }
+
     async recordInstanceTransition(
         serverId: string,
         userId: string,

--- a/apps/api/src/mcp/connect-error.test.ts
+++ b/apps/api/src/mcp/connect-error.test.ts
@@ -1,0 +1,66 @@
+/**
+ * MCP 연결 실패 분류기 테스트.
+ *
+ * 고정 케이스는 **2026-08-25 라이브에서 실제로 받은 응답**이다 — Linear·Asana·Slack 의
+ * 원격 MCP 엔드포인트가 OAuth 없이 접근하면 401 을 준다. 이 셋이 `auth_required` 로
+ * 분류되지 않으면 화면에 다시 원인 없는 "연결 안 됨"만 남는다.
+ */
+import { classifyConnectError, serializeConnectError, parseConnectError } from './connect-error';
+
+describe('classifyConnectError', () => {
+    it.each([
+        ['{"error":"invalid_token","error_description":"Missing or invalid access token"}', 'auth_required'],
+        ['{"error":"invalid_request","error_description":"Authorization header is required for MCP V2 access"}', 'auth_required'],
+        ['{"jsonrpc":"2.0","id":null,"error":{"code":-32001,"message":"missing_token"}}', 'auth_required'],
+        ['Error POSTing to endpoint (HTTP 401): Unauthorized', 'auth_required'],
+        ['HTTP 403 Forbidden', 'auth_required'],
+    ])('401/403 계열은 auth_required 로 분류한다: %s', (msg, expected) => {
+        expect(classifyConnectError(new Error(msg)).code).toBe(expected);
+    });
+
+    it('404 는 not_found', () => {
+        expect(classifyConnectError(new Error('HTTP 404 Not Found')).code).toBe('not_found');
+    });
+
+    it('연결 거부/DNS 실패는 unreachable', () => {
+        expect(classifyConnectError(new Error('connect ECONNREFUSED 127.0.0.1:9999')).code).toBe('unreachable');
+        expect(classifyConnectError(new Error('getaddrinfo ENOTFOUND mcp.example.invalid')).code).toBe('unreachable');
+    });
+
+    it('타임아웃은 timeout — unreachable 보다 먼저 잡는다', () => {
+        expect(classifyConnectError(new Error('Request timed out after 30000ms')).code).toBe('timeout');
+    });
+
+    it('분류 불가는 unknown 이되 원문을 버리지 않는다', () => {
+        const r = classifyConnectError(new Error('something entirely unexpected'));
+        expect(r.code).toBe('unknown');
+        expect(r.message).toBe('something entirely unexpected');
+    });
+
+    it('Error 가 아닌 값도 처리한다', () => {
+        expect(classifyConnectError('missing_token').code).toBe('auth_required');
+        expect(classifyConnectError(null).code).toBe('unknown');
+    });
+
+    it('원문이 길어도 상한을 넘기지 않는다 (HTML 본문 통째 유출 방지)', () => {
+        const r = classifyConnectError(new Error('x'.repeat(5000)));
+        expect(r.message.length).toBe(300);
+    });
+});
+
+describe('serialize/parse 라운드트립', () => {
+    it('코드와 원문이 보존된다', () => {
+        const original = classifyConnectError(new Error('HTTP 401 invalid_token'));
+        const parsed = parseConnectError(serializeConnectError(original));
+        expect(parsed).toEqual(original);
+    });
+
+    it('접두 코드가 없는 구 데이터는 unknown 으로 읽는다', () => {
+        expect(parseConnectError('legacy raw message')).toEqual({ code: 'unknown', message: 'legacy raw message' });
+    });
+
+    it('빈 값은 null — "원인 없음"과 구분된다', () => {
+        expect(parseConnectError(null)).toBeNull();
+        expect(parseConnectError('')).toBeNull();
+    });
+});

--- a/apps/api/src/mcp/connect-error.ts
+++ b/apps/api/src/mcp/connect-error.ts
@@ -1,0 +1,48 @@
+/**
+ * MCP 연결 실패 메시지 → 원인 코드 분류 (순수 함수).
+ *
+ * 규칙표는 `config/mcp-connect-errors.ts`(L2). 여기는 판정만 한다.
+ *
+ * @module mcp/connect-error
+ */
+import {
+    MCP_CONNECT_ERROR_RULES,
+    MCP_CONNECT_ERROR_MAX_CHARS,
+    type McpConnectErrorCode,
+} from '../config/mcp-connect-errors';
+
+export interface ClassifiedConnectError {
+    /** 원인 코드 — 프론트 i18n 키로 쓰인다 */
+    code: McpConnectErrorCode;
+    /** 원문 메시지(상한 적용) — 코드만으로 부족한 진단을 위해 함께 남긴다 */
+    message: string;
+}
+
+/**
+ * 연결 실패 원인을 분류한다.
+ *
+ * 어떤 규칙에도 걸리지 않으면 `unknown` — **원문은 그대로 남긴다**. 분류 실패를
+ * 빈 값으로 만들면 "원인 없음"과 구분되지 않아, 지금 고치려는 조용한 실패가 그대로 재현된다.
+ */
+export function classifyConnectError(error: unknown): ClassifiedConnectError {
+    const raw = error instanceof Error ? error.message : String(error ?? '');
+    const message = raw.trim().slice(0, MCP_CONNECT_ERROR_MAX_CHARS);
+    const rule = MCP_CONNECT_ERROR_RULES.find((r) => r.pattern.test(raw));
+    return { code: rule?.code ?? 'unknown', message };
+}
+
+/**
+ * 영속 저장용 직렬화 — `mcp_server_instances.last_error` 한 컬럼에 코드와 원문을 함께 담는다.
+ * 전용 컬럼을 추가하면 마이그레이션이 필요한데, 이 값은 진단용이라 컬럼을 늘릴 이유가 없다.
+ */
+export function serializeConnectError(e: ClassifiedConnectError): string {
+    return `[${e.code}] ${e.message}`;
+}
+
+/** 위 직렬화의 역변환 — 접두 코드가 없으면 `unknown` 으로 본다(구 데이터 호환). */
+export function parseConnectError(stored: string | null | undefined): ClassifiedConnectError | null {
+    if (!stored) return null;
+    const m = /^\[([a-z_]+)\]\s?([\s\S]*)$/.exec(stored);
+    if (!m) return { code: 'unknown', message: stored.slice(0, MCP_CONNECT_ERROR_MAX_CHARS) };
+    return { code: m[1] as McpConnectErrorCode, message: m[2] };
+}

--- a/apps/api/src/mcp/lifecycle-supervisor.ts
+++ b/apps/api/src/mcp/lifecycle-supervisor.ts
@@ -17,6 +17,7 @@ import type { UserMCPPool } from './user-pool';
 import type { ExternalMCPClient } from './external-client';
 import type { McpCatalogRepository, UserMcpServerRow } from '../data/repositories/mcp-catalog-repository';
 import { createLogger } from '../utils/logger';
+import { classifyConnectError, serializeConnectError } from './connect-error';
 
 const logger = createLogger('LifecycleSupervisor');
 
@@ -251,7 +252,19 @@ export class MCPLifecycleSupervisor implements LifecycleSupervisor {
         client.on?.('exit', onExit);
         client.on?.('error', (err: unknown) => onExit(undefined, null, String(err)));
 
-        await client.connect();
+        // 연결 실패를 **영속화**한 뒤 rethrow — 실패한 client 는 풀에 등록되지 않으므로
+        // 기록하지 않으면 목록 API 가 `connectionError: null` 을 돌려주고, 화면에는 원인
+        // 없는 "연결 안 됨"만 남는다(승인은 됐는데 도구가 영영 0개인 상태를 알아챌 수 없다).
+        try {
+            await client.connect();
+        } catch (e) {
+            const classified = classifyConnectError(e);
+            logger.warn(`connect 실패 u=${userId} s=${serverId} code=${classified.code}: ${classified.message}`);
+            await this.repo
+                .recordInstanceTransition(serverId, userId, 'crashed', undefined, serializeConnectError(classified))
+                .catch(() => { /* 기록 실패가 원인 전파를 막지 않게 한다 */ });
+            throw e;
+        }
         this.userPool.add(userId, serverId, client);
         // pid 를 함께 남긴다 — 이게 없어서 운영 instance 행이 전부 pid NULL 이었고,
         // 헬스체크(verifyRunningInstancesByPid)가 항상 missingPid 만 반환해

--- a/apps/api/src/routes/mcp.routes.ts
+++ b/apps/api/src/routes/mcp.routes.ts
@@ -34,6 +34,7 @@ import { getUnifiedDatabase } from '../data/models/unified-database';
 import type { MCPTransportType, MCPConnectionStatus } from '../mcp/types';
 import { getLifecycleSupervisor } from '../mcp/lifecycle-supervisor';
 import { createLogger } from '../utils/logger';
+import { classifyConnectError, parseConnectError } from '../mcp/connect-error';
 import { validate } from '../middlewares/validation';
 import { mcpToolExecuteSchema, mcpServerCreateSchema, mcpServerEnvUpdateSchema } from '../schemas/mcp.schema';
 import { McpCatalogRepository } from '../data/repositories/mcp-catalog-repository';
@@ -121,6 +122,14 @@ export const mcpRouter = Router();
       const registry = getUnifiedMCPClient().getServerRegistry();
       const statuses = registry.getAllStatuses();
       const supervisor = getLifecycleSupervisor();
+
+      // 연결에 실패한 client 는 풀에 남지 않아 메모리 상태가 비어 있다 — 그때 화면에
+      // 원인 없는 "연결 안 됨"만 뜨던 것을 막기 위해 영속된 마지막 실패를 함께 싣는다.
+      // 조회 실패는 무시(fail-open) — 부가 정보가 목록 자체를 죽이면 안 된다.
+      const persistedErrors = await repo
+          .getLatestConnectErrors(userId, filtered.map(s => s.id))
+          .catch(() => new Map<string, { message: string; at: string }>());
+
       const serversWithStatus = filtered.map(server => {
           const regStatus = statuses.find(s => s.serverId === server.id);
           let userStatus: MCPConnectionStatus | undefined;
@@ -129,12 +138,20 @@ export const mcpRouter = Router();
               if (client) userStatus = client.getStatus();
           }
           const effective = userStatus || regStatus;
+          // 살아있는 client 의 에러가 우선. 없을 때만 영속된 마지막 실패로 폴백한다
+          // (연결된 서버에는 낡은 실패를 붙이지 않는다 — repo 쪽에서 이미 제외).
+          const live = effective?.error ? classifyConnectError(new Error(effective.error)) : null;
+          const stored = live ? null : parseConnectError(persistedErrors.get(server.id)?.message);
+          const failure = live ?? stored;
           return {
               ...server,
               connectionStatus: effective?.status || 'disconnected',
               toolCount: effective?.toolCount || 0,
               lastPing: effective?.lastPing || null,
-              connectionError: effective?.error || null,
+              connectionError: failure?.message ?? null,
+              /** 원인 코드 — 프론트가 i18n 문구로 바꿔 보여준다 (`auth_required` 등) */
+              connectionErrorCode: failure?.code ?? null,
+              connectionErrorAt: live ? null : (persistedErrors.get(server.id)?.at ?? null),
           };
       });
 

--- a/apps/web/components/settings/connectors-section.tsx
+++ b/apps/web/components/settings/connectors-section.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { Server, Boxes, Plus, Loader2, X, KeyRound, ClipboardCheck } from "lucide-react";
+import { Server, Boxes, Plus, Loader2, X, KeyRound, ClipboardCheck, AlertTriangle } from "lucide-react";
 import {
   Button,
   Badge,
@@ -36,6 +36,10 @@ interface McpServer {
   transport: Transport;
   toolCount: number;
   status: ConnStatus;
+  /** 연결 실패 원인 코드 — 없으면 실패한 적이 없거나 현재 연결됨 */
+  errorCode: string | null;
+  /** 원인 원문 (코드만으로 부족한 진단용 — tooltip) */
+  errorDetail: string | null;
   latencyMs: number | null;
   lastChecked: string;
   /** 편집 가능한 env 키 목록 (값은 서버가 마스킹하므로 키만 다룬다) */
@@ -52,6 +56,10 @@ interface ApiMcpServer {
   connectionStatus?: string;
   toolCount?: number;
   lastPing?: string | null;
+  /** 연결 실패 원인 — 그전엔 백엔드가 내려줘도 프론트가 버려서 화면에 원인이 없었다 */
+  connectionError?: string | null;
+  /** 원인 코드(`auth_required` 등) — i18n 문구로 바꿔 보여준다 */
+  connectionErrorCode?: string | null;
   /** 백엔드가 마스킹해서 내려주는 env — 암호화된 값은 "***" 로 치환돼 있다(원문 미노출). */
   env?: Record<string, string> | null;
 }
@@ -88,6 +96,8 @@ function mapServer(s: ApiMcpServer, t: Translator): McpServer {
     transport: TRANSPORT_MAP[s.transport_type] ?? "stdio",
     toolCount: s.toolCount ?? 0,
     status: mapStatus(s.connectionStatus),
+    errorCode: s.connectionStatus === "connected" ? null : (s.connectionErrorCode ?? null),
+    errorDetail: s.connectionStatus === "connected" ? null : (s.connectionError ?? null),
     // 백엔드는 지연(latency) 수치를 제공하지 않음 — 표시 생략
     latencyMs: null,
     lastChecked: relativeTime(s.lastPing, t),
@@ -309,6 +319,8 @@ function buildMockServers(t: Translator): McpServer[] {
     transport: "stdio",
     toolCount: 8,
     status: "connected",
+    errorCode: null,
+    errorDetail: null,
     latencyMs: 12,
     lastChecked: t("justNow"),
     envKeys: [],
@@ -320,6 +332,8 @@ function buildMockServers(t: Translator): McpServer[] {
     transport: "HTTP",
     toolCount: 21,
     status: "connected",
+    errorCode: null,
+    errorDetail: null,
     latencyMs: 184,
     lastChecked: t("minutesAgo", { count: 1 }),
     envKeys: [],
@@ -331,6 +345,8 @@ function buildMockServers(t: Translator): McpServer[] {
     transport: "stdio",
     toolCount: 5,
     status: "degraded",
+    errorCode: null,
+    errorDetail: null,
     latencyMs: 842,
     lastChecked: t("minutesAgo", { count: 2 }),
     envKeys: [],
@@ -342,6 +358,8 @@ function buildMockServers(t: Translator): McpServer[] {
     transport: "SSE",
     toolCount: 11,
     status: "connected",
+    errorCode: null,
+    errorDetail: null,
     latencyMs: 76,
     lastChecked: t("minutesAgo", { count: 3 }),
     envKeys: [],
@@ -353,6 +371,8 @@ function buildMockServers(t: Translator): McpServer[] {
     transport: "HTTP",
     toolCount: 3,
     status: "disconnected",
+    errorCode: null,
+    errorDetail: null,
     latencyMs: null,
     lastChecked: t("minutesAgo", { count: 12 }),
     envKeys: [],
@@ -571,6 +591,16 @@ export function ConnectorsSection() {
                       </Td>
                       <Td>
                         <Badge tone={meta.tone}>{t(meta.labelKey)}</Badge>
+                        {/* 실패 원인 — 없으면 아무것도 그리지 않는다(정상 서버에 잡음 금지) */}
+                        {s.errorCode && (
+                          <div
+                            className="mt-1 flex items-start gap-1 text-xs text-warn"
+                            title={s.errorDetail ?? undefined}
+                          >
+                            <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+                            <span>{t(`connectError.${s.errorCode}`)}</span>
+                          </div>
+                        )}
                       </Td>
                       <Td className="text-right font-mono">
                         {s.latencyMs == null ? (

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1063,7 +1063,15 @@
     "envSavedRespawn": "Credentials updated. The existing connection was closed; the new values apply once it reconnects.",
     "envUpdateError": "Failed to update credentials",
     "tabInstances": "Instances",
-    "pendingApprovals": "Approvals"
+    "pendingApprovals": "Approvals",
+    "connectError": {
+      "auth_required": "Authentication required — this server needs OAuth login (not supported yet)",
+      "not_found": "Endpoint not found (404)",
+      "unreachable": "Cannot reach the server",
+      "timeout": "Connection timed out",
+      "protocol": "MCP protocol response error",
+      "unknown": "Connection failed — hover for details"
+    }
   },
   "mcpCatalog": {
     "pageTitle": "MCP Catalog",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1063,7 +1063,15 @@
     "envSavedRespawn": "認証情報を変更しました。既存の接続は終了し、再接続時に新しい値が適用されます。",
     "envUpdateError": "認証情報の変更に失敗しました",
     "tabInstances": "インスタンス状態",
-    "pendingApprovals": "承認待ち"
+    "pendingApprovals": "承認待ち",
+    "connectError": {
+      "auth_required": "認証が必要 — このサーバーは OAuth ログインを要求します（現在未対応）",
+      "not_found": "エンドポイントが見つかりません (404)",
+      "unreachable": "サーバーに接続できません",
+      "timeout": "接続がタイムアウトしました",
+      "protocol": "MCP プロトコル応答エラー",
+      "unknown": "接続に失敗しました — 詳細はホバーで確認"
+    }
   },
   "mcpCatalog": {
     "pageTitle": "MCPカタログ",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1063,7 +1063,15 @@
     "envSavedRespawn": "자격증명을 변경했습니다. 기존 연결이 종료되었으며, 다시 연결되면 새 값이 적용됩니다.",
     "envUpdateError": "자격증명 변경에 실패했습니다",
     "tabInstances": "인스턴스 상태",
-    "pendingApprovals": "승인 대기"
+    "pendingApprovals": "승인 대기",
+    "connectError": {
+      "auth_required": "인증 필요 — 이 서버는 OAuth 로그인을 요구합니다(현재 미지원)",
+      "not_found": "엔드포인트를 찾을 수 없음 (404)",
+      "unreachable": "서버에 연결할 수 없음",
+      "timeout": "연결 시간 초과",
+      "protocol": "MCP 프로토콜 응답 오류",
+      "unknown": "연결 실패 — 자세한 내용은 항목에 마우스를 올려 확인"
+    }
   },
   "mcpCatalog": {
     "pageTitle": "MCP 카탈로그",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1063,7 +1063,15 @@
     "envSavedRespawn": "凭据已更新。现有连接已关闭，重新连接后将使用新值。",
     "envUpdateError": "更新凭据失败",
     "tabInstances": "实例状态",
-    "pendingApprovals": "待审批"
+    "pendingApprovals": "待审批",
+    "connectError": {
+      "auth_required": "需要认证 — 该服务器要求 OAuth 登录（当前不支持）",
+      "not_found": "找不到端点 (404)",
+      "unreachable": "无法连接到服务器",
+      "timeout": "连接超时",
+      "protocol": "MCP 协议响应错误",
+      "unknown": "连接失败 — 悬停查看详情"
+    }
   },
   "mcpCatalog": {
     "pageTitle": "MCP 目录",


### PR DESCRIPTION
## 배경

확장으로 설치한 원격 MCP 5개(Linear·Asana·Slack·Figma·Atlassian)를 `/approvals` 에서 승인했더니
`enabled=true` 인데 `toolCount=0`, `connectionError=null` 이었다. 직접 찔러보니 전부 OAuth 를 요구한다:

```
https://mcp.linear.app/mcp   → 401 {"error":"invalid_token","error_description":"Missing or invalid access token"}
https://mcp.asana.com/v2/mcp → 401 {"error":"invalid_request","error_description":"Authorization header is required for MCP V2 access"}
https://mcp.slack.com/mcp    → 401 {"jsonrpc":"2.0","id":null,"error":{"code":-32001,"message":"missing_token"}}
```

승인은 성공하는데 도구는 영영 0개고, 화면에는 원인 없는 "연결 안 됨"만 남는다.

## 원인 (두 군데가 겹침)

| # | 위치 | 문제 |
|---|---|---|
| 1 | `lifecycle-supervisor.ts` `safeSpawn` | `client.connect()` 실패 시 그대로 throw → client 가 풀에 등록되지 않음 → 목록 API 가 메모리 상태만 보므로 `connectionError: null`. `mcp_server_instances` 엔 `starting` 행만 남음 |
| 2 | `connectors-section.tsx` `mapServer` | `connectionStatus` 만 읽고 `connectionError` 를 **통째로 무시** |

## 변경

- **분류** — `config/mcp-connect-errors.ts`(L2 패턴표) + `mcp/connect-error.ts`(순수 함수).
  401/403 최우선. 사용자가 할 조치가 명확한데 "연결 실패"로 뭉뚱그리면 재시도만 반복하게 된다.
  `unknown` 도 **원문을 버리지 않는다** — 빈 값으로 만들면 "원인 없음"과 구분되지 않아
  지금 고치려는 조용한 실패가 그대로 재현된다.
- **영속** — 연결 실패를 `crashed` + 직렬화된 원인(`[code] message`)으로 기록 후 rethrow.
  전용 컬럼 대신 기존 `last_error` 를 쓴다(진단용이라 마이그레이션 불필요).
- **조회** — `getLatestConnectErrors`: 이력 테이블이라 `DISTINCT ON` 으로 서버당 최신 1행.
  최신 행이 `running` 이면 제외해 **지금 잘 도는 서버에 낡은 에러가 붙지 않게** 한다.
- **목록 API** — 살아있는 client 의 에러 우선, 없을 때만 영속값 폴백. 조회 실패는 fail-open.
- **UI** — 상태 배지 아래 원인 한 줄(원문은 tooltip). 정상 서버엔 아무것도 그리지 않는다.
- **i18n 4언어** — `auth_required` = "인증 필요 — 이 서버는 OAuth 로그인을 요구합니다(현재 미지원)".

## 테스트

`connect-error.test.ts` 14케이스 — 고정 입력은 **위 라이브 401 응답 원문 그대로**다.
이 셋이 `auth_required` 로 분류되지 않으면 화면에 다시 원인이 사라진다.

## 체크리스트

- [x] `npm run lint` — 에러 0
- [x] `tsc --noEmit` — apps/api, apps/web 통과
- [x] `npm test` — 270 스위트 / 2939 테스트 통과
- [x] Gate 3 (600줄) 로컬 재현 — 위반 0
- [x] DB 스키마 변경 없음 (기존 `mcp_server_instances.last_error` 재사용)
- [ ] 라이브 확인 (배포 후)

## 범위 밖

원격 MCP 의 **OAuth 지원 자체**는 별개 작업이다(SDK `authProvider` + 토큰 저장 + 브라우저 인증).
이 PR 은 "왜 안 되는지 보이게" 만드는 데까지다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)