### PR TITLE
feat(mcp): 서버 사용 여부 토글 — 삭제의 되돌릴 수 있는 대안

### DIFF
--- a/apps/api/src/data/repositories/mcp-catalog-repository.ts
+++ b/apps/api/src/data/repositories/mcp-catalog-repository.ts
@@ -397,6 +397,14 @@ export class McpCatalogRepository {
      * ⚠️ 최신 행이 `running` 이면(= 그 뒤 성공적으로 떴다면) 낡은 실패를 보여주지 않도록
      *    제외한다. 안 그러면 지금 잘 도는 서버에 예전 에러가 계속 붙는다.
      */
+    /** 서버 사용 여부 토글 — 설정을 보존한 채 목록에서 치우는 용도(삭제의 되돌릴 수 있는 대안). */
+    async setServerEnabled(serverId: string, enabled: boolean): Promise<void> {
+        await this.pool.query(
+            `UPDATE mcp_servers SET enabled = $2, updated_at = NOW() WHERE id = $1`,
+            [serverId, enabled],
+        );
+    }
+
     async getLatestConnectErrors(
         userId: string,
         serverIds: string[],

--- a/apps/api/src/routes/mcp.routes.ts
+++ b/apps/api/src/routes/mcp.routes.ts
@@ -36,7 +36,8 @@ import { getLifecycleSupervisor } from '../mcp/lifecycle-supervisor';
 import { createLogger } from '../utils/logger';
 import { classifyConnectError, parseConnectError } from '../mcp/connect-error';
 import { validate } from '../middlewares/validation';
-import { mcpToolExecuteSchema, mcpServerCreateSchema, mcpServerEnvUpdateSchema } from '../schemas/mcp.schema';
+import { mcpToolExecuteSchema, mcpServerCreateSchema, mcpServerEnvUpdateSchema,
+    mcpServerEnabledUpdateSchema } from '../schemas/mcp.schema';
 import { McpCatalogRepository } from '../data/repositories/mcp-catalog-repository';
 import { canRegisterServer, canViewServer, canDeleteServer, canStartStopServer, canUpdateServerEnv } from './mcp-visibility';
 import { getAuditService } from '../services/AuditService';
@@ -263,6 +264,47 @@ export const mcpRouter = Router();
   // env(자격증명) 교체 (PATCH) — 소유자 + admin.
   // 로테이션 전용 부분 갱신: 전달한 키만 바뀌고 나머지는 보존된다. secret 값은 저장 시
   // 암호화(v1:)되며 응답에는 마스킹된 env 만 실린다.
+  /**
+   * PATCH /api/mcp/servers/:id/enabled  { enabled }
+   * 서버 사용 여부 토글 — 삭제의 **되돌릴 수 있는** 대안.
+   *
+   * 연결이 구조적으로 불가능한 서버(예: OAuth 를 요구하는 원격 MCP)를 목록에서 치우되
+   * 설정·자격증명은 보존한다. 끄면 살아있는 client 도 함께 정리한다 — 안 그러면 "사용 안 함"
+   * 으로 표시되면서 도구는 계속 제공되는 모순이 생긴다.
+   */
+  mcpRouter.patch('/servers/:id/enabled', requireAuth, validate(mcpServerEnabledUpdateSchema), asyncHandler(async (req: Request, res: Response) => {
+      const userId = String(req.user?.id ?? '');
+      const role = req.user?.role ?? 'user';
+      const actor = { id: userId, role };
+      const { id } = req.params;
+      const { enabled } = req.body as { enabled: boolean };
+
+      const db = getUnifiedDatabase();
+      const repo = new McpCatalogRepository(db.getPool());
+      const server = await repo.getServerById(id);
+      if (!server) {
+          res.status(404).json(notFound('서버'));
+          return;
+      }
+      // 실행 제어와 같은 성격의 권한이라 연결/해제와 동일한 판정을 쓴다.
+      if (!canStartStopServer(actor, server)) {
+          res.status(403).json(forbidden('해당 서버를 변경할 권한이 없습니다'));
+          return;
+      }
+
+      await repo.setServerEnabled(id, enabled);
+
+      if (!enabled && server.user_id) {
+          const supervisor = getLifecycleSupervisor();
+          if (supervisor) {
+              await supervisor.killUserServer(String(server.user_id), id).catch((e: unknown) =>
+                  logger.warn(`사용 안 함 전환 시 정리 실패(전환은 유지): ${id}: ${e instanceof Error ? e.message : String(e)}`));
+          }
+      }
+
+      res.json(success({ id, enabled }));
+  }));
+
   mcpRouter.patch('/servers/:id/env', requireAuth, validate(mcpServerEnvUpdateSchema), asyncHandler(async (req: Request, res: Response) => {
       const userId = String(req.user?.id ?? '');
       const role = req.user?.role ?? 'user';

--- a/apps/api/src/schemas/mcp.schema.ts
+++ b/apps/api/src/schemas/mcp.schema.ts
@@ -74,9 +74,21 @@ export const mcpServerEnvUpdateSchema = z.object({
         .refine((v) => Object.keys(v).length <= 30, { message: '한 번에 최대 30개까지 변경할 수 있습니다' }),
 });
 
+/**
+ * MCP 서버 사용 여부 토글 (PATCH /api/mcp/servers/:id/enabled)
+ *
+ * `enabled=false` 는 "이 서버를 쓰지 않는다"는 사용자 의사표시다 — 삭제와 달리 되돌릴 수
+ * 있어, 연결이 안 되는 서버(예: OAuth 미지원 원격 MCP)를 목록에서 치우되 설정은 보존한다.
+ */
+export const mcpServerEnabledUpdateSchema = z.object({
+    enabled: z.boolean(),
+});
+
 /** MCP 도구 실행 요청 TypeScript 타입 */
 export type McpToolExecuteInput = z.infer<typeof mcpToolExecuteSchema>;
 /** MCP 서버 등록 요청 TypeScript 타입 */
 export type McpServerCreateInput = z.infer<typeof mcpServerCreateSchema>;
 /** MCP 서버 env 교체 요청 TypeScript 타입 */
 export type McpServerEnvUpdateInput = z.infer<typeof mcpServerEnvUpdateSchema>;
+/** MCP 서버 사용 여부 토글 TypeScript 타입 */
+export type McpServerEnabledUpdateInput = z.infer<typeof mcpServerEnabledUpdateSchema>;

--- a/apps/web/components/settings/connectors-section.tsx
+++ b/apps/web/components/settings/connectors-section.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { Server, Boxes, Plus, Loader2, X, KeyRound, ClipboardCheck, AlertTriangle } from "lucide-react";
+import { Server, Boxes, Plus, Loader2, X, KeyRound, ClipboardCheck, AlertTriangle, Power, PowerOff } from "lucide-react";
 import {
   Button,
   Badge,
@@ -36,6 +36,8 @@ interface McpServer {
   transport: Transport;
   toolCount: number;
   status: ConnStatus;
+  /** 사용 여부 — false 면 목록에 남되 "사용 안 함"으로 표시된다(삭제와 달리 되돌릴 수 있다) */
+  enabled: boolean;
   /** 연결 실패 원인 코드 — 없으면 실패한 적이 없거나 현재 연결됨 */
   errorCode: string | null;
   /** 원인 원문 (코드만으로 부족한 진단용 — tooltip) */
@@ -58,6 +60,8 @@ interface ApiMcpServer {
   lastPing?: string | null;
   /** 연결 실패 원인 — 그전엔 백엔드가 내려줘도 프론트가 버려서 화면에 원인이 없었다 */
   connectionError?: string | null;
+  /** 사용 여부 — false 면 사용자가 "쓰지 않음"으로 치워둔 서버 */
+  enabled?: boolean;
   /** 원인 코드(`auth_required` 등) — i18n 문구로 바꿔 보여준다 */
   connectionErrorCode?: string | null;
   /** 백엔드가 마스킹해서 내려주는 env — 암호화된 값은 "***" 로 치환돼 있다(원문 미노출). */
@@ -96,6 +100,7 @@ function mapServer(s: ApiMcpServer, t: Translator): McpServer {
     transport: TRANSPORT_MAP[s.transport_type] ?? "stdio",
     toolCount: s.toolCount ?? 0,
     status: mapStatus(s.connectionStatus),
+    enabled: s.enabled !== false,
     errorCode: s.connectionStatus === "connected" ? null : (s.connectionErrorCode ?? null),
     errorDetail: s.connectionStatus === "connected" ? null : (s.connectionError ?? null),
     // 백엔드는 지연(latency) 수치를 제공하지 않음 — 표시 생략
@@ -319,6 +324,7 @@ function buildMockServers(t: Translator): McpServer[] {
     transport: "stdio",
     toolCount: 8,
     status: "connected",
+    enabled: true,
     errorCode: null,
     errorDetail: null,
     latencyMs: 12,
@@ -332,6 +338,7 @@ function buildMockServers(t: Translator): McpServer[] {
     transport: "HTTP",
     toolCount: 21,
     status: "connected",
+    enabled: true,
     errorCode: null,
     errorDetail: null,
     latencyMs: 184,
@@ -345,6 +352,7 @@ function buildMockServers(t: Translator): McpServer[] {
     transport: "stdio",
     toolCount: 5,
     status: "degraded",
+    enabled: true,
     errorCode: null,
     errorDetail: null,
     latencyMs: 842,
@@ -358,6 +366,7 @@ function buildMockServers(t: Translator): McpServer[] {
     transport: "SSE",
     toolCount: 11,
     status: "connected",
+    enabled: true,
     errorCode: null,
     errorDetail: null,
     latencyMs: 76,
@@ -371,6 +380,7 @@ function buildMockServers(t: Translator): McpServer[] {
     transport: "HTTP",
     toolCount: 3,
     status: "disconnected",
+    enabled: true,
     errorCode: null,
     errorDetail: null,
     latencyMs: null,
@@ -443,6 +453,31 @@ export function ConnectorsSection() {
       );
     } catch {
       /* 실패 시 현상 유지 */
+    } finally {
+      setActionLoading((prev) => ({ ...prev, [id]: false }));
+    }
+  }
+
+  /**
+   * 사용 여부 토글 — 끄면 목록에 남되 "사용 안 함"으로 표시되고 살아있는 연결도 정리된다.
+   * 삭제와 달리 되돌릴 수 있어, 연결이 구조적으로 불가능한 서버를 치우는 데 쓴다.
+   */
+  async function handleToggleEnabled(id: string, next: boolean) {
+    setActionLoading((prev) => ({ ...prev, [id]: true }));
+    try {
+      await ApiClient.patch<ApiEnvelope<{ enabled: boolean }>>(
+        `/api/mcp/servers/${id}/enabled`,
+        { enabled: next },
+      );
+      setServers((prev) =>
+        prev.map((s) =>
+          s.id === id
+            ? { ...s, enabled: next, status: next ? s.status : "disconnected", toolCount: next ? s.toolCount : 0 }
+            : s,
+        ),
+      );
+    } catch (e) {
+      alert(t("toggleFailed", { error: e instanceof Error ? e.message : "" } as never));
     } finally {
       setActionLoading((prev) => ({ ...prev, [id]: false }));
     }
@@ -590,9 +625,13 @@ export function ConnectorsSection() {
                         {s.toolCount}
                       </Td>
                       <Td>
-                        <Badge tone={meta.tone}>{t(meta.labelKey)}</Badge>
+                        {/* 사용 안 함이 연결 상태보다 우선 — 안 쓰기로 한 서버에 "연결 안 됨"만
+                            보이면 고장난 것처럼 읽힌다 */}
+                        <Badge tone={s.enabled ? meta.tone : "neutral"}>
+                          {s.enabled ? t(meta.labelKey) : t("disabledLabel")}
+                        </Badge>
                         {/* 실패 원인 — 없으면 아무것도 그리지 않는다(정상 서버에 잡음 금지) */}
-                        {s.errorCode && (
+                        {s.enabled && s.errorCode && (
                           <div
                             className="mt-1 flex items-start gap-1 text-xs text-warn"
                             title={s.errorDetail ?? undefined}
@@ -618,6 +657,16 @@ export function ConnectorsSection() {
                       <Td className="text-faint">{s.lastChecked}</Td>
                       <Td>
                         <div className="flex items-center gap-1">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={isActing}
+                            onClick={() => void handleToggleEnabled(s.id, !s.enabled)}
+                            title={s.enabled ? t("disableTitle") : t("enableTitle")}
+                          >
+                            {s.enabled ? <PowerOff className="h-3 w-3" /> : <Power className="h-3 w-3" />}
+                            {s.enabled ? t("disable") : t("enable")}
+                          </Button>
                           {s.envKeys.length > 0 && (
                             <Button
                               variant="outline"

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1071,7 +1071,13 @@
       "timeout": "Connection timed out",
       "protocol": "MCP protocol response error",
       "unknown": "Connection failed — hover for details"
-    }
+    },
+    "disabledLabel": "Disabled",
+    "disable": "Disable",
+    "enable": "Enable",
+    "disableTitle": "Mark this server unused (settings kept, reversible anytime)",
+    "enableTitle": "Use this server again",
+    "toggleFailed": "Update failed: {error}"
   },
   "mcpCatalog": {
     "pageTitle": "MCP Catalog",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1071,7 +1071,13 @@
       "timeout": "接続がタイムアウトしました",
       "protocol": "MCP プロトコル応答エラー",
       "unknown": "接続に失敗しました — 詳細はホバーで確認"
-    }
+    },
+    "disabledLabel": "使用しない",
+    "disable": "使用しない",
+    "enable": "使用する",
+    "disableTitle": "このサーバーを使用しないものとして表示（設定は保存、いつでも戻せます）",
+    "enableTitle": "このサーバーを再び使用",
+    "toggleFailed": "変更に失敗しました: {error}"
   },
   "mcpCatalog": {
     "pageTitle": "MCPカタログ",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1071,7 +1071,13 @@
       "timeout": "연결 시간 초과",
       "protocol": "MCP 프로토콜 응답 오류",
       "unknown": "연결 실패 — 자세한 내용은 항목에 마우스를 올려 확인"
-    }
+    },
+    "disabledLabel": "사용 안 함",
+    "disable": "사용 안 함",
+    "enable": "사용",
+    "disableTitle": "이 서버를 쓰지 않음으로 표시 (설정은 보존, 언제든 되돌릴 수 있음)",
+    "enableTitle": "이 서버를 다시 사용",
+    "toggleFailed": "변경 실패: {error}"
   },
   "mcpCatalog": {
     "pageTitle": "MCP 카탈로그",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1071,7 +1071,13 @@
       "timeout": "连接超时",
       "protocol": "MCP 协议响应错误",
       "unknown": "连接失败 — 悬停查看详情"
-    }
+    },
+    "disabledLabel": "未启用",
+    "disable": "停用",
+    "enable": "启用",
+    "disableTitle": "标记为不使用（保留配置，可随时恢复）",
+    "enableTitle": "重新启用该服务器",
+    "toggleFailed": "更新失败：{error}"
   },
   "mcpCatalog": {
     "pageTitle": "MCP 目录",


### PR DESCRIPTION
## 배경

연결이 구조적으로 불가능한 원격 MCP 5종(Linear·Asana·Slack·Figma·Atlassian — 전부 OAuth 필요,
#616 에서 `auth_required` 로 원인 노출)을 정리하려 했는데, `enabled` 를 끌 방법이 없었다.

`mcp_servers.enabled` 컬럼은 있지만:
- 토글 API 없음 (`connect`/`disconnect` 는 살아있는 연결만 다루고 `enabled` 는 안 건드린다)
- 프론트 `mapServer` 가 `enabled` 를 **아예 안 읽는다**

즉 DB 를 직접 `enabled=false` 로 바꿔도 화면·동작이 전혀 달라지지 않는다.
"정리 완료"라고 보고만 하고 실제로는 아무 일도 일어나지 않는 상태여서, 배선부터 했다.

## 변경

- **`PATCH /api/mcp/servers/:id/enabled { enabled }`**
  - 권한은 연결/해제와 동일 판정(`canStartStopServer`) — 실행 제어와 같은 성격이라.
  - 끌 때 **살아있는 client 도 정리**한다. 안 그러면 "사용 안 함"으로 표시되면서 도구는
    계속 제공되는 모순이 생긴다.
- **목록 표시** — 사용 안 함이 연결 상태보다 **우선**. 안 쓰기로 한 서버에 "연결 안 됨"만
  보이면 고장난 것처럼 읽힌다. 이때 실패 원인 줄은 감춘다(해결할 문제가 아니므로).
- **되돌리기** — 삭제와 달리 설정·자격증명이 보존돼 버튼 한 번으로 복구된다.
  `safeSpawn` 은 `enabled` 를 보지 않으므로 [사용] 후 [연결]이 그대로 동작한다.
- i18n 4언어.

## 체크리스트

- [x] `npm run lint` — 에러 0
- [x] `tsc --noEmit` — apps/api, apps/web 통과
- [x] `npm test` — 270 스위트 / 2939 테스트 통과
- [x] Gate 3 (600줄) 로컬 재현 — 위반 0
- [x] DB 스키마 변경 없음 (기존 `mcp_servers.enabled` 재사용)
- [ ] 라이브 확인 (배포 후 design-* 5종 정리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)