### PR TITLE
chore(mcp): 존재하지 않는 searxng MCP 브리지(127.0.0.1:8889) 참조 제거

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -757,7 +757,7 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # 항목에 `:port` 를 붙이면 그 포트로 향하는 요청만 허용한다 (최소 권한). 로컬 streamable-http
 # MCP 처럼 loopback 의 특정 서비스만 열고 DB(5432)·Redis(6379)·LLM 게이트웨이(13401) 등
 # 나머지 내부 포트는 계속 막고 싶을 때 사용. 포트 생략 시 종전대로 전 포트 허용.
-# SSRF_ALLOWED_HOSTS=rag.internal,192.168.0.45,10.1.0.0/16,127.0.0.1:8889
+# SSRF_ALLOWED_HOSTS=rag.internal,192.168.0.45,10.1.0.0/16,127.0.0.1:9100
 
 # *******************************************************
 # 첨부 컨텍스트 세션 캐시 (config/runtime-limits ATTACH_CACHE_LIMITS)

--- a/apps/api/src/__tests__/ssrf-allowlist-port.test.ts
+++ b/apps/api/src/__tests__/ssrf-allowlist-port.test.ts
@@ -1,7 +1,7 @@
 /**
  * SSRF allowlist 의 `host:port` 최소 권한 형태.
  *
- * 로컬 streamable-http MCP(예: searxng 127.0.0.1:8889)를 쓰려면 loopback 을 열어야 하는데,
+ * 사용자가 loopback 에 띄운 streamable-http MCP 를 쓰려면 127.x 를 열어야 하는데,
  * 호스트 단위로 열면 DB·Redis·LLM 게이트웨이 등 다른 내부 포트까지 함께 뚫린다.
  * 포트를 명시하면 그 포트만 허용된다 (2026-08-18).
  */
@@ -16,8 +16,8 @@ afterEach(() => {
 
 describe('SSRF allowlist host:port', () => {
     it('명시한 포트만 허용하고 다른 내부 포트는 계속 막는다', () => {
-        process.env.SSRF_ALLOWED_HOSTS = '127.0.0.1:8889';
-        expect(isAllowlistedHost('127.0.0.1', '127.0.0.1', '8889')).toBe(true);
+        process.env.SSRF_ALLOWED_HOSTS = '127.0.0.1:9100';
+        expect(isAllowlistedHost('127.0.0.1', '127.0.0.1', '9100')).toBe(true);
         expect(isAllowlistedHost('127.0.0.1', '127.0.0.1', '5432')).toBe(false); // DB
         expect(isAllowlistedHost('127.0.0.1', '127.0.0.1', '13401')).toBe(false); // LLM 게이트웨이
         expect(isAllowlistedHost('127.0.0.1', '127.0.0.1', undefined)).toBe(false);
@@ -42,12 +42,12 @@ describe('SSRF allowlist host:port', () => {
 
     it('미설정이면 여전히 fail-closed', () => {
         process.env.SSRF_ALLOWED_HOSTS = '';
-        expect(isAllowlistedHost('127.0.0.1', '127.0.0.1', '8889')).toBe(false);
+        expect(isAllowlistedHost('127.0.0.1', '127.0.0.1', '9100')).toBe(false);
     });
 
     it('effectivePort 는 스킴 기본 포트를 채운다', () => {
         expect(effectivePort(new URL('http://a.test/x'))).toBe('80');
         expect(effectivePort(new URL('https://a.test/x'))).toBe('443');
-        expect(effectivePort(new URL('http://a.test:8889/mcp'))).toBe('8889');
+        expect(effectivePort(new URL('http://a.test:9100/mcp'))).toBe('9100');
     });
 });

--- a/apps/api/src/security/ssrf-guard.ts
+++ b/apps/api/src/security/ssrf-guard.ts
@@ -213,7 +213,7 @@ export function isBlockedIP(address: string): boolean {
  * 허용목록에 있으면 통과시킨다.
  *
  * 형식: 콤마 구분. 각 항목은 ① hostname(정확 일치) ② IPv4 ③ IPv4 CIDR ④ ①·②에 `:port` 부착.
- *   예) SSRF_ALLOWED_HOSTS=rag.internal,192.168.0.45,10.1.0.0/16,127.0.0.1:8889
+ *   예) SSRF_ALLOWED_HOSTS=rag.internal,192.168.0.45,10.1.0.0/16,127.0.0.1:9100
  *
  * `:port` 를 붙이면 그 포트로 향하는 요청만 허용한다 — loopback 의 특정 로컬 서비스
  * (예: 사용자가 띄운 streamable-http MCP)만 열고 나머지 내부 포트(DB·Redis·게이트웨이)는


### PR DESCRIPTION
## 배경

`/approvals` 통합 후 연결 실패 원인 노출(#616)을 붙이자 `searxng` MCP 서버가
`SSRF blocked: resolved to blocked IP range: 127.0.0.1` 로 실패하고 있는 게 드러났다. 점검 결과:

| 확인 항목 | 결과 |
|---|---|
| `127.0.0.1:8889` | **아무것도 리스닝하지 않음** — MCP 브리지가 배포된 적 없음 |
| `127.0.0.1:8888` | SearXNG 컨테이너(`openmake-searxng`) 정상 가동. 단 `/mcp` → **404** (검색 엔진이지 MCP 서버가 아님) |
| SSRF 가드 | `SSRF_ALLOWED_HOSTS=192.168.0.45` 뿐 — loopback 미허용이라 브리지를 띄워도 차단 |

그런데 **SearXNG 연동은 이미 잘 되고 있다**. `SEARXNG_URL=http://127.0.0.1:8888` 로
`web-search/providers.ts` 가 직접 호출하며 MCP 를 안 거친다. 라이브 확인:

```
[WebSearch] SearXNG: 15개
[WebSearch] 총 29개 (SearXNG:15, Google:0, Wiki:5, News:10, DDG:0, Naver:0)
```

즉 MCP 항목은 처음부터 잉여였고, 승인해도 영영 도구 0개인 죽은 항목이었다.

## 변경

레포에 남은 8889 참조만 정리한다 (전수 grep 후 0건 확인).

- `ssrf-guard.ts` · `.env.example` 주석 예시 포트를 중립값으로
- `ssrf-allowlist-port.test.ts` 의 searxng 언급 제거 + fixture 포트 중립화

**`:port` 단위 SSRF 허용목록 기능과 테스트는 그대로 둔다** — 그 기능 자체는 유효하고
(LAN vLLM·사내 RAG 용) searxng 와 무관하다. 다만 존재하지 않는 서비스를 예시로 들면
다음 사람이 없는 브리지를 세팅하려 든다.

## DB 정리 (별도, API 경유 — 이 PR 범위 밖)

- `mcp_server_catalog` 의 `searxng` 템플릿 삭제
- user 3 의 설치본 1건 삭제

시더/마이그레이션에 없는 항목이라(관리자 UI 로 등록됨) 부팅 시 재생성되지 않는다 — 확인함.

## 체크리스트

- [x] `npm run lint` — 에러 0
- [x] `npm test` — 2939 테스트 통과 (`ssrf-allowlist-port` 6케이스 포함)
- [x] 삭제 후 8888 경로 정상 재확인 — 웹검색 24건 반환
- [x] 레포 내 `8889` 참조 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)