### PR TITLE
fix(chat): 슬래시 스킬 확장문이 사전 웹검색·URL 분석으로 새던 문제

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -757,7 +757,7 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # 항목에 `:port` 를 붙이면 그 포트로 향하는 요청만 허용한다 (최소 권한). 로컬 streamable-http
 # MCP 처럼 loopback 의 특정 서비스만 열고 DB(5432)·Redis(6379)·LLM 게이트웨이(13401) 등
 # 나머지 내부 포트는 계속 막고 싶을 때 사용. 포트 생략 시 종전대로 전 포트 허용.
-# SSRF_ALLOWED_HOSTS=rag.internal,192.168.0.45,10.1.0.0/16,127.0.0.1:8889
+# SSRF_ALLOWED_HOSTS=rag.internal,192.168.0.45,10.1.0.0/16,127.0.0.1:9100
 
 # *******************************************************
 # 첨부 컨텍스트 세션 캐시 (config/runtime-limits ATTACH_CACHE_LIMITS)

--- a/apps/api/src/__tests__/slash-expansion-not-search-query.test.ts
+++ b/apps/api/src/__tests__/slash-expansion-not-search-query.test.ts
@@ -1,0 +1,95 @@
+/**
+ * 슬래시 스킬 확장문이 **사전 웹검색의 입력으로 새지 않는지** 검증.
+ *
+ * 실측 배경 (2026-08-25, SearXNG 컨테이너 로그) — `/nginx-log-error-analysis-reporting`
+ * 호출 시 다음이 그대로 검색어로 나갔다:
+ *
+ *     GET https://www.mojeek.com/search?q=[슬래시 명령: 스킬 "Nginx Log Error Analysis
+ *     Reporting" 적용] <skill_context name="..."> **역할 / 전문성** 당신은 고성능 웹 서버인 ...
+ *
+ * 원인은 두 겹이다.
+ *  (a) 시사 질의 감지가 **확장문**을 본다 — 스킬 본문 6,065자 안의 "최근"·"실시간" 같은
+ *      단어가 걸려 사용자가 웹검색을 켜지 않았는데도 검색이 돈다.
+ *  (b) 검색어도 **확장문**이다 — `cleanSearchQuery` 는 대화체 지시문만 걷어내고 개행을
+ *      공백으로 눌러버려, 스킬 프롬프트 전체가 한 줄짜리 쿼리가 된다.
+ *
+ * 스킬 컨텍스트는 모델에게 주는 **지시**이지 사용자의 질문이 아니다. 검색 대상은 언제나
+ * 사용자가 실제로 친 문장이어야 한다.
+ */
+import { buildWebSearchContext } from '../mcp/web-search/build-search-context';
+import { cleanSearchQuery } from '../mcp/web-search/query-cleaner';
+import { stripSlashEnvelope } from '../chat/slash-command';
+
+jest.mock('../mcp/web-search/search-orchestrator', () => ({
+    performWebSearch: jest.fn(async () => []),
+}));
+
+import { performWebSearch } from '../mcp/web-search/search-orchestrator';
+
+/** 실제 결함을 낸 형태 그대로 — slash-command.ts 의 증강 포맷 */
+const SKILL_BODY = [
+    '**역할 / 전문성**',
+    '당신은 고성능 웹 서버인 Nginx의 로그 데이터를 분석하고 시스템 안정성을 높이는 데 특화된 DevOps 전문가입니다.',
+    '최근 발생한 오류를 실시간으로 집계해 보고서를 만듭니다.',
+].join('\n');
+
+const EXPANDED = `[슬래시 명령: 스킬 "Nginx Log Error Analysis Reporting" 적용]\n<skill_context name="Nginx Log Error Analysis Reporting">\n${SKILL_BODY}\n</skill_context>\n\n어제 로그 좀 정리해줘`;
+
+const RAW = '어제 로그 좀 정리해줘';
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('슬래시 확장문은 검색 입력이 아니다', () => {
+    it('확장문에는 시사 키워드가 섞여 있다 (결함의 전제)', () => {
+        // 스킬 본문이 "최근"을 포함 → 확장문을 감지에 쓰면 오검출된다
+        expect(EXPANDED).toContain('최근');
+        expect(RAW).not.toContain('최근');
+    });
+
+    it('원문 기준이면 웹검색이 트리거되지 않는다', async () => {
+        const r = await buildWebSearchContext({
+            message: RAW,
+            userLang: 'ko',
+            webSearchEnabled: false,
+        });
+        expect(r.isCurrentEventsQuery).toBe(false);
+        expect(performWebSearch).not.toHaveBeenCalled();
+    });
+
+    it('확장문을 넘기면 사용자가 끄지 않았는데도 검색이 돈다 (회귀 가드)', async () => {
+        const r = await buildWebSearchContext({
+            message: EXPANDED,
+            userLang: 'ko',
+            webSearchEnabled: false,
+        });
+        // 이 단언은 "확장문을 넘기면 이렇게 잘못된다"를 고정한다 —
+        // 호출부가 원문을 넘기도록 유지하는 것이 방어선이다.
+        expect(r.isCurrentEventsQuery).toBe(true);
+        expect(performWebSearch).toHaveBeenCalled();
+    });
+
+    it('2차 방어선 — 확장문이 새더라도 검색어에서는 봉투가 걷힌다', () => {
+        const q = cleanSearchQuery(EXPANDED);
+        expect(q).not.toContain('skill_context');   // 마크업 제거
+        expect(q).not.toContain('슬래시 명령');       // 접두 마커 제거
+        expect(q).not.toContain('당신은 고성능');      // 스킬 본문 제거
+        expect(q).toContain('어제 로그');             // 사용자가 쓴 부분은 보존
+        expect(q.length).toBeLessThan(50);
+    });
+
+    it('봉투가 없는 평범한 메시지는 손대지 않는다', () => {
+        expect(stripSlashEnvelope('nginx 로그 분석해줘')).toBe('nginx 로그 분석해줘');
+    });
+
+    it('본문에 <skill_context> 라는 말이 나오는 정상 질문은 살아남는다', () => {
+        // 닫는 태그가 없으면 블록 패턴이 걸리지 않는다 — 과잉 제거 방지
+        const q = cleanSearchQuery('skill_context 태그가 뭐야');
+        expect(q).toContain('skill_context');
+    });
+
+    it('원문은 정제 후에도 짧고 온전하다', () => {
+        const q = cleanSearchQuery(RAW);
+        expect(q).not.toContain('skill_context');
+        expect(q.length).toBeLessThan(50);
+    });
+});

--- a/apps/api/src/__tests__/ssrf-allowlist-port.test.ts
+++ b/apps/api/src/__tests__/ssrf-allowlist-port.test.ts
@@ -1,7 +1,7 @@
 /**
  * SSRF allowlist 의 `host:port` 최소 권한 형태.
  *
- * 로컬 streamable-http MCP(예: searxng 127.0.0.1:8889)를 쓰려면 loopback 을 열어야 하는데,
+ * 사용자가 loopback 에 띄운 streamable-http MCP 를 쓰려면 127.x 를 열어야 하는데,
  * 호스트 단위로 열면 DB·Redis·LLM 게이트웨이 등 다른 내부 포트까지 함께 뚫린다.
  * 포트를 명시하면 그 포트만 허용된다 (2026-08-18).
  */
@@ -16,8 +16,8 @@ afterEach(() => {
 
 describe('SSRF allowlist host:port', () => {
     it('명시한 포트만 허용하고 다른 내부 포트는 계속 막는다', () => {
-        process.env.SSRF_ALLOWED_HOSTS = '127.0.0.1:8889';
-        expect(isAllowlistedHost('127.0.0.1', '127.0.0.1', '8889')).toBe(true);
+        process.env.SSRF_ALLOWED_HOSTS = '127.0.0.1:9100';
+        expect(isAllowlistedHost('127.0.0.1', '127.0.0.1', '9100')).toBe(true);
         expect(isAllowlistedHost('127.0.0.1', '127.0.0.1', '5432')).toBe(false); // DB
         expect(isAllowlistedHost('127.0.0.1', '127.0.0.1', '13401')).toBe(false); // LLM 게이트웨이
         expect(isAllowlistedHost('127.0.0.1', '127.0.0.1', undefined)).toBe(false);
@@ -42,12 +42,12 @@ describe('SSRF allowlist host:port', () => {
 
     it('미설정이면 여전히 fail-closed', () => {
         process.env.SSRF_ALLOWED_HOSTS = '';
-        expect(isAllowlistedHost('127.0.0.1', '127.0.0.1', '8889')).toBe(false);
+        expect(isAllowlistedHost('127.0.0.1', '127.0.0.1', '9100')).toBe(false);
     });
 
     it('effectivePort 는 스킴 기본 포트를 채운다', () => {
         expect(effectivePort(new URL('http://a.test/x'))).toBe('80');
         expect(effectivePort(new URL('https://a.test/x'))).toBe('443');
-        expect(effectivePort(new URL('http://a.test:8889/mcp'))).toBe('8889');
+        expect(effectivePort(new URL('http://a.test:9100/mcp'))).toBe('9100');
     });
 });

--- a/apps/api/src/chat/slash-command.ts
+++ b/apps/api/src/chat/slash-command.ts
@@ -89,6 +89,26 @@ export function substituteSkillArguments(content: string, rest: string): { conte
 }
 
 /** 스킬 + 나머지 텍스트 → 증강 메시지 (순수) */
+/**
+ * `buildAugmentedMessage` 가 씌우는 **봉투**를 벗겨내는 정규식.
+ *
+ * 확장문은 모델에게 주는 지시라, 사용자의 질문을 입력으로 받는 하류(예: 사전 웹검색 쿼리)에
+ * 새면 안 된다. 호출부가 원문을 넘기는 것이 1차 방어선이고, 이건 2차 방어선이다 —
+ * 실측으로 스킬 본문 6,065자가 통째로 검색어가 되어 상류가 400/403 을 돌려준 적이 있다
+ * (2026-08-25). 형식이 바뀌면 여기도 함께 고쳐야 하므로 조립부 바로 옆에 둔다.
+ */
+export const SLASH_ENVELOPE_PATTERNS: readonly RegExp[] = [
+    /^\[슬래시 명령:[^\]]*\]\s*/,
+    /<skill_context\b[^>]*>[\s\S]*?<\/skill_context>/g,
+];
+
+/** 확장 봉투를 제거해 사용자가 실제로 쓴 부분만 남긴다 (순수). 봉투가 없으면 원문 그대로. */
+export function stripSlashEnvelope(text: string): string {
+    let out = text || '';
+    for (const re of SLASH_ENVELOPE_PATTERNS) out = out.replace(re, ' ');
+    return out.replace(/\s+/g, ' ').trim();
+}
+
 export function buildAugmentedMessage(skill: SlashSkill, rest: string): string {
     const safeName = skill.name.replace(/[<>"&]/g, '');
     // 외부 스킬의 `$ARGUMENTS`/`$1` 을 실제 인자로 치환 — 치환됐으면 본문 뒤 중복 첨부는 생략

--- a/apps/api/src/mcp/web-search/query-cleaner.ts
+++ b/apps/api/src/mcp/web-search/query-cleaner.ts
@@ -9,6 +9,7 @@
  *
  * @module mcp/web-search/query-cleaner
  */
+import { stripSlashEnvelope } from '../../chat/slash-command';
 
 /** 제거 대상 대화체 지시 문구 패턴 (한국어 중심). 보수적으로만 — 핵심 명사는 보존. */
 const INSTRUCTION_NOISE: readonly RegExp[] = [
@@ -27,7 +28,9 @@ const INSTRUCTION_NOISE: readonly RegExp[] = [
  * 과잉 제거로 빈 문자열이 되면 원문을 그대로 반환(안전망).
  */
 export function cleanSearchQuery(raw: string): string {
-    const original = (raw || '').trim();
+    // 슬래시 스킬 확장 봉투를 먼저 벗긴다 — 호출부가 원문을 넘기는 것이 1차 방어선이지만,
+    // 새더라도 스킬 프롬프트 수천 자가 검색어가 되지 않도록 여기서 한 번 더 막는다.
+    const original = stripSlashEnvelope((raw || '').trim());
     let q = original;
     for (const re of INSTRUCTION_NOISE) q = q.replace(re, ' ');
     q = q

--- a/apps/api/src/security/ssrf-guard.ts
+++ b/apps/api/src/security/ssrf-guard.ts
@@ -213,7 +213,7 @@ export function isBlockedIP(address: string): boolean {
  * 허용목록에 있으면 통과시킨다.
  *
  * 형식: 콤마 구분. 각 항목은 ① hostname(정확 일치) ② IPv4 ③ IPv4 CIDR ④ ①·②에 `:port` 부착.
- *   예) SSRF_ALLOWED_HOSTS=rag.internal,192.168.0.45,10.1.0.0/16,127.0.0.1:8889
+ *   예) SSRF_ALLOWED_HOSTS=rag.internal,192.168.0.45,10.1.0.0/16,127.0.0.1:9100
  *
  * `:port` 를 붙이면 그 포트로 향하는 요청만 허용한다 — loopback 의 특정 로컬 서비스
  * (예: 사용자가 띄운 streamable-http MCP)만 열고 나머지 내부 포트(DB·Redis·게이트웨이)는

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -71,11 +71,7 @@ export async function handleChatMessage(
     // 비슬래시/미매칭/비활성은 원문 그대로(무영향·무비용), 오류는 graceful(원문 유지).
     const slashUserId = extWs._authenticatedUserId !== undefined ? String(extWs._authenticatedUserId) : undefined;
     const explicitSkillNames: string[] = [];
-    // ⚠️ 원문을 따로 보존한다 — 확장문은 모델에게 주는 **지시**이지 사용자의 질문이 아니다.
-    //    사전 웹검색·URL 분석처럼 "사용자가 무엇을 물었나"를 입력으로 받는 곳은 반드시
-    //    rawMessage 를 쓴다. (실측: 스킬 본문 6,065자가 통째로 검색어로 나가 상류가 400/403 을
-    //    돌려주고, 본문 속 "최근" 때문에 웹검색이 켜지지도 않았는데 돌았다 — 2026-08-25)
-    const rawMessage = (msg.message ?? '').trim();
+    const rawMessage = (msg.message ?? '').trim(); // 사전 웹검색·URL 분석용 원문 — slash-expansion-not-search-query.test.ts
     const message = await applySlashCommand(rawMessage, {
         userId: slashUserId,
         onSkillApplied: (skillName) => explicitSkillNames.push(skillName),
@@ -177,7 +173,6 @@ export async function handleChatMessage(
         // 구조화(/structured) 경로와 동일 헬퍼를 공유해 "한 경로만 검색되는" 분기 누락·로직 드리프트를 방지한다.
         // (WS 는 기존 동작 보존을 위해 signal 미전달 — 중단 시 진행 중 검색은 메인 LLM 루프에서 정리.)
         const { webSearchContext } = await buildWebSearchContext({
-            // 확장문이 아니라 원문 — 시사 질의 감지와 검색어 둘 다에 쓰인다.
             message: rawMessage,
             userLang,
             webSearchEnabled: msg.webSearch === true,

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -71,7 +71,12 @@ export async function handleChatMessage(
     // 비슬래시/미매칭/비활성은 원문 그대로(무영향·무비용), 오류는 graceful(원문 유지).
     const slashUserId = extWs._authenticatedUserId !== undefined ? String(extWs._authenticatedUserId) : undefined;
     const explicitSkillNames: string[] = [];
-    const message = await applySlashCommand((msg.message ?? '').trim(), {
+    // ⚠️ 원문을 따로 보존한다 — 확장문은 모델에게 주는 **지시**이지 사용자의 질문이 아니다.
+    //    사전 웹검색·URL 분석처럼 "사용자가 무엇을 물었나"를 입력으로 받는 곳은 반드시
+    //    rawMessage 를 쓴다. (실측: 스킬 본문 6,065자가 통째로 검색어로 나가 상류가 400/403 을
+    //    돌려주고, 본문 속 "최근" 때문에 웹검색이 켜지지도 않았는데 돌았다 — 2026-08-25)
+    const rawMessage = (msg.message ?? '').trim();
+    const message = await applySlashCommand(rawMessage, {
         userId: slashUserId,
         onSkillApplied: (skillName) => explicitSkillNames.push(skillName),
     });
@@ -166,13 +171,14 @@ export async function handleChatMessage(
         // 딥 리서치는 자체 검색·스크래핑 파이프라인이 URL 을 다루므로 사전 분석 생략.
         const urlContextPromise = msg.deepResearchMode === true
             ? Promise.resolve('')
-            : buildUrlContext(message);
+            : buildUrlContext(rawMessage);
 
         // 웹 검색: 사용자가 명시적으로 활성화했거나, 시사 관련 질문이 감지된 경우 수행.
         // 구조화(/structured) 경로와 동일 헬퍼를 공유해 "한 경로만 검색되는" 분기 누락·로직 드리프트를 방지한다.
         // (WS 는 기존 동작 보존을 위해 signal 미전달 — 중단 시 진행 중 검색은 메인 LLM 루프에서 정리.)
         const { webSearchContext } = await buildWebSearchContext({
-            message,
+            // 확장문이 아니라 원문 — 시사 질의 감지와 검색어 둘 다에 쓰인다.
+            message: rawMessage,
             userLang,
             webSearchEnabled: msg.webSearch === true,
             explicitlyDisabled: msg.enabledTools?.web_search === false,


### PR DESCRIPTION
## 발견 경위

SearXNG 컨테이너 점검 중 로그에서 발견. `/nginx-log-error-analysis-reporting` 호출 시
스킬 프롬프트가 통째로 검색어로 나가고 있었다.

```
GET https://www.mojeek.com/search?q=[슬래시 명령: 스킬 "Nginx Log Error Analysis Reporting" 적용]
    <skill_context name="..."> **역할 / 전문성** 당신은 고성능 웹 서버인 Nginx의 로그 데이터를 ...
```

## 원인

`ws-chat-handler.ts:74` 가 `message` 를 슬래시 확장문으로 **덮어쓴 뒤**, 그 변수를 사전
웹검색·URL 분석에 그대로 넘긴다. 스킬 컨텍스트는 모델에게 주는 **지시**이지 사용자의 질문이 아니다.

| # | 증상 | 원인 |
|---|---|---|
| (a) | 웹검색을 켜지 않았는데 검색이 돎 | 시사 질의 감지가 **확장문**을 봄. 스킬 본문 6,065자 안의 `최근` 이 `CURRENT_EVENTS_KEYWORDS.ko` 에 걸림 |
| (b) | 검색어가 프롬프트 통째 | 검색어도 확장문. `cleanSearchQuery` 는 대화체 지시문만 걷어내고 `\s+`→`' '` 로 개행을 눌러 6,230자가 한 줄 쿼리가 됨 |

상류가 `mojeek 403` · `ko.wikipedia 400` 을 돌려주고 결과는 무의미했다.

## 변경

- **1차 방어** — `rawMessage` 를 따로 보존해 `buildWebSearchContext` · `buildUrlContext` 에 원문 전달.
  URL 사전 분석도 같은 결함이었다(스킬 지시문 안의 URL 을 자동으로 긁고 있었음).
- **2차 방어** — `stripSlashEnvelope` 를 조립부(`slash-command.ts`) 옆에 두고 `cleanSearchQuery` 가
  먼저 호출. 다시 새더라도 6천 자가 나가지 않는다. 형식이 바뀌면 함께 고치도록 조립부에 붙였다.

## 실측 검증 (운영 DB 의 실제 스킬 본문)

```
── (a) 시사 질의 오검출 ──
  확장문 매칭: [최근] → 검색 트리거(결함 재현)
  원문   매칭: []     → 검색 안 함 ✔

── (b) 검색어 ──
  수정 전  : 5,817자  "[슬래시 명령: 스킬 "Nginx Log Error…" 적용] <skill_context name=…"
  1차 경로 :     7자  "어제 로그 좀"        ← 실제로 나가는 값
  2차 방어 :    32자
  잔존검사 : skill_context=false / 슬래시마커=false / 스킬본문=false

── 과잉 제거 회귀 없음 ──
  "nginx 로그 분석해줘" / "skill_context 태그가 뭐야" / "<skill_context> 이거 뭐임" → 모두 원문 보존
```

2차 방어선이 만드는 32자 쿼리는 이상적이지 않다(`$ARGUMENTS` 치환 시 붙는 마무리 문장이 남음).
역할이 "6천 자를 막는다"이고 실제로 나가는 값은 1차 경로라 이대로 둔다.

## 범위 밖 (의도적으로 남김)

- `detectLanguage(message)` 도 확장문을 본다 — 영어 스킬을 한국어로 호출하면 답변 언어가 뒤집힐 수 있다.
  원문으로 바꾸면 `/slug` 만 친 경우 ASCII 슬러그를 보고 영어로 판정하는 **반대 위험**이 있어 별건.
- `selectOptimalModel(message)` — 확장문이 곧 처리 대상이라 그대로 둔다.
- REST `/api/chat/structured` 는 슬래시 확장을 적용하지 않아 무관.

## 체크리스트

- [x] `npm run lint` — 에러 0
- [x] `npm test` — 2,946건 통과 (재현 테스트 7케이스 포함)
- [x] 실제 스킬 본문으로 (a)·(b) 각각 실측
- [ ] 라이브 확인 (배포 후 SearXNG 로그에서 쿼리 재확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)