### PR TITLE
feat(mcp): 원격 MCP 서버 OAuth 로그인 (Authorization Code + PKCE + 동적 등록)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1496,3 +1496,12 @@ CHAT_USER_MCP_SCHEMA_BUDGET_BYTES=16000
 # ── 세션 (사용자별 격리, /reset 슬래시 명령으로 초기화) ──
 # 세션당 보관 최대 대화 턴 수
 # DISCORD_SESSION_MAX_TURNS=20
+
+# *******************************************************
+# 원격 MCP OAuth (config/mcp-oauth.ts)
+# *******************************************************
+# 원격 MCP 서버(Linear·Asana·Slack 등)가 401 을 돌려주면 앱이 OAuth 로그인 흐름을 시작한다.
+# 인가 서버에 등록되는 콜백은 <origin>/api/mcp/oauth/callback 이며 origin 은 기본적으로
+# OAUTH_REDIRECT_URI 의 origin(운영 https://chat.openmake.cc)에서 유도한다. 다른 origin 을
+# 써야 할 때만 아래를 지정한다. 값이 바뀌면 기존 동적 등록은 무효(재로그인 시 자동 재등록).
+# MCP_OAUTH_REDIRECT_BASE=https://chat.openmake.cc

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -90,6 +90,8 @@ export const envSchema = z
         KAKAO_CLIENT_ID: z.string().default(''),
         KAKAO_CLIENT_SECRET: z.string().default(''),
         OAUTH_REDIRECT_URI: z.string().default(`http://localhost:${SERVER_CONFIG.DEFAULT_PORT}/api/auth/callback/google`),
+        /** 원격 MCP OAuth 콜백 origin 강제 (선택) — config/mcp-oauth.ts */
+        MCP_OAUTH_REDIRECT_BASE: z.string().url().optional(),
 
         // CORS
         CORS_ORIGINS: z.string().default(`http://localhost:${SERVER_CONFIG.DEFAULT_PORT}`),

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -46,6 +46,8 @@ export interface EnvConfig {
     kakaoClientId: string;
     kakaoClientSecret: string;
     oauthRedirectUri: string;
+    /** 원격 MCP OAuth 콜백의 origin 강제 (선택). 미설정 시 OAUTH_REDIRECT_URI 의 origin 에서 유도 */
+    mcpOAuthRedirectBase?: string;
 
     // CORS
     corsOrigins: string;
@@ -331,6 +333,7 @@ export function loadConfig(): EnvConfig {
         KAKAO_CLIENT_ID: env('KAKAO_CLIENT_ID'),
         KAKAO_CLIENT_SECRET: env('KAKAO_CLIENT_SECRET'),
         OAUTH_REDIRECT_URI: env('OAUTH_REDIRECT_URI'),
+        MCP_OAUTH_REDIRECT_BASE: env('MCP_OAUTH_REDIRECT_BASE'),
         DB_POOL_MAX: env('DB_POOL_MAX'),
         DB_POOL_MIN: env('DB_POOL_MIN'),
         CORS_ORIGINS: env('CORS_ORIGINS'),
@@ -443,6 +446,7 @@ export function loadConfig(): EnvConfig {
         kakaoClientId: parsed.KAKAO_CLIENT_ID ?? DEFAULT_CONFIG.kakaoClientId,
         kakaoClientSecret: parsed.KAKAO_CLIENT_SECRET ?? DEFAULT_CONFIG.kakaoClientSecret,
         oauthRedirectUri: parsed.OAUTH_REDIRECT_URI ?? DEFAULT_CONFIG.oauthRedirectUri,
+        mcpOAuthRedirectBase: parsed.MCP_OAUTH_REDIRECT_BASE || undefined,
 
         // CORS
         corsOrigins: parsed.CORS_ORIGINS ?? DEFAULT_CONFIG.corsOrigins,

--- a/apps/api/src/config/mcp-oauth.ts
+++ b/apps/api/src/config/mcp-oauth.ts
@@ -1,0 +1,46 @@
+/**
+ * 원격 MCP 서버 OAuth 설정 (L2 config).
+ *
+ * 원격 MCP(streamable-http/sse)가 401 을 돌려주면 SDK 가 `authProvider` 로 Authorization Code +
+ * PKCE 흐름을 시작한다(RFC 9728 리소스 메타데이터 발견 → RFC 8414 AS 메타데이터 → RFC 7591
+ * 동적 클라이언트 등록 → 인가 → 토큰 교환). 여기는 그 흐름에서 이 앱이 정하는 값만 둔다.
+ *
+ * @module config/mcp-oauth
+ */
+import { getConfig } from './env';
+
+/** 인가 완료 후 브라우저가 돌아올 콜백 경로 — `routes/mcp-oauth.routes.ts` 와 한 쌍 */
+export const MCP_OAUTH_CALLBACK_PATH = '/api/mcp/oauth/callback';
+
+/** 인가 흐름 중간값(state · PKCE verifier) 수명 — 브라우저 왕복 시간이면 충분하다 */
+export const MCP_OAUTH_FLOW_TTL_MS = 10 * 60 * 1000;
+
+/** KV 키 접두 — state 는 전역 유일, verifier 는 사용자×서버 단위 */
+export const MCP_OAUTH_KV_PREFIX = {
+    state: 'mcp-oauth:state:',
+    verifier: 'mcp-oauth:verifier:',
+} as const;
+
+/** 동적 클라이언트 등록 시 AS 에 보내는 우리 클라이언트 정보 */
+export const MCP_OAUTH_CLIENT_NAME = 'OpenMake LLM';
+
+/** 콜백 후 사용자를 돌려보낼 프론트 경로 (커넥터 탭). 결과는 쿼리 `mcpOauth=ok|error` 로 전달 */
+export const MCP_OAUTH_RETURN_PATH = '/settings?tab=connectors';
+
+/**
+ * 인가 서버에 등록할 redirect URL 의 origin.
+ *
+ * 브라우저 요청이 없는 spawn 시점에도 필요하므로 요청 헤더가 아니라 설정에서 유도한다:
+ * `MCP_OAUTH_REDIRECT_BASE` > `OAUTH_REDIRECT_URI` 의 origin(운영: https://chat.openmake.cc)
+ * > `http://localhost:<port>`. 동적 등록은 redirect_uri 를 등록 시점에 고정하므로, 값이 바뀌면
+ * 기존 client 등록은 무효가 된다(재로그인 시 SDK 가 invalid_client 로 재등록).
+ */
+export function resolveMcpOAuthRedirectUrl(): string {
+    const cfg = getConfig();
+    if (cfg.mcpOAuthRedirectBase) return new URL(MCP_OAUTH_CALLBACK_PATH, cfg.mcpOAuthRedirectBase).toString();
+    try {
+        const origin = new URL(cfg.oauthRedirectUri).origin;
+        if (!origin.includes('localhost')) return `${origin}${MCP_OAUTH_CALLBACK_PATH}`;
+    } catch { /* 형식 오류 → 로컬 폴백 */ }
+    return `http://localhost:${cfg.port}${MCP_OAUTH_CALLBACK_PATH}`;
+}

--- a/apps/api/src/data/repositories/mcp-oauth-repository.ts
+++ b/apps/api/src/data/repositories/mcp-oauth-repository.ts
@@ -1,0 +1,102 @@
+/**
+ * 원격 MCP OAuth 자격증명 저장소 (mcp_oauth_credentials, 마이그레이션 104).
+ *
+ * 사용자×서버 단위. 토큰·client_secret 은 AES-256-GCM(`utils/token-crypto`) 으로 암호화해
+ * 저장하고 읽을 때 복호화한다 — 외부 provider BYOK 키와 같은 방식이다.
+ *
+ * ⚠️ `decryptToken` 은 fail-open 이다(복호화 실패 시 입력을 그대로 돌려줌). 토큰 JSON 파싱이
+ *    실패하면 "토큰 없음" 으로 취급해 SDK 가 새 인가 흐름을 시작하게 한다 — 깨진 암호문을
+ *    Bearer 로 보내는 것보다 재로그인이 낫다.
+ *
+ * @module data/repositories/mcp-oauth-repository
+ */
+import type { Pool } from 'pg';
+import type { OAuthTokens, OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
+import { encryptToken, decryptToken } from '../../utils/token-crypto';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('McpOAuthRepository');
+
+interface Row {
+    client_info: Record<string, unknown> | null;
+    client_secret_enc: string | null;
+    tokens_enc: string | null;
+}
+
+export class McpOAuthRepository {
+    constructor(private readonly pool: Pool) {}
+
+    async getClientInformation(serverId: string, userId: string): Promise<OAuthClientInformationFull | undefined> {
+        const r = await this.pool.query<Row>(
+            `SELECT client_info, client_secret_enc FROM mcp_oauth_credentials WHERE mcp_server_id = $1 AND user_id = $2`,
+            [serverId, userId],
+        );
+        const row = r.rows[0];
+        if (!row?.client_info || typeof row.client_info.client_id !== 'string') return undefined;
+        const info = { ...row.client_info } as OAuthClientInformationFull;
+        if (row.client_secret_enc) info.client_secret = decryptToken(row.client_secret_enc);
+        return info;
+    }
+
+    async saveClientInformation(serverId: string, userId: string, info: OAuthClientInformationFull): Promise<void> {
+        const { client_secret, ...rest } = info;
+        await this.pool.query(
+            `INSERT INTO mcp_oauth_credentials (mcp_server_id, user_id, client_info, client_secret_enc)
+             VALUES ($1, $2, $3::jsonb, $4)
+             ON CONFLICT (mcp_server_id, user_id) DO UPDATE
+                SET client_info = EXCLUDED.client_info, client_secret_enc = EXCLUDED.client_secret_enc, updated_at = NOW()`,
+            [serverId, userId, JSON.stringify(rest), client_secret ? encryptToken(client_secret) : null],
+        );
+    }
+
+    async getTokens(serverId: string, userId: string): Promise<OAuthTokens | undefined> {
+        const r = await this.pool.query<Row>(
+            `SELECT tokens_enc FROM mcp_oauth_credentials WHERE mcp_server_id = $1 AND user_id = $2`,
+            [serverId, userId],
+        );
+        const enc = r.rows[0]?.tokens_enc;
+        if (!enc) return undefined;
+        try {
+            return JSON.parse(decryptToken(enc)) as OAuthTokens;
+        } catch (e) {
+            logger.warn(`토큰 복호화/파싱 실패 → 재인가 유도 s=${serverId} u=${userId}: ${e instanceof Error ? e.message : String(e)}`);
+            return undefined;
+        }
+    }
+
+    async saveTokens(serverId: string, userId: string, tokens: OAuthTokens): Promise<void> {
+        const expiresAt = typeof tokens.expires_in === 'number' ? new Date(Date.now() + tokens.expires_in * 1000) : null;
+        await this.pool.query(
+            `INSERT INTO mcp_oauth_credentials (mcp_server_id, user_id, tokens_enc, token_expires_at)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT (mcp_server_id, user_id) DO UPDATE
+                SET tokens_enc = EXCLUDED.tokens_enc, token_expires_at = EXCLUDED.token_expires_at, updated_at = NOW()`,
+            [serverId, userId, encryptToken(JSON.stringify(tokens)), expiresAt],
+        );
+    }
+
+    /** 토큰만 지운다(client 등록은 보존) — SDK invalidateCredentials('tokens') 대응 */
+    async clearTokens(serverId: string, userId: string): Promise<void> {
+        await this.pool.query(
+            `UPDATE mcp_oauth_credentials SET tokens_enc = NULL, token_expires_at = NULL, updated_at = NOW()
+              WHERE mcp_server_id = $1 AND user_id = $2`,
+            [serverId, userId],
+        );
+    }
+
+    /** 전부 지운다(로그아웃 / invalidateCredentials('all')) */
+    async clearAll(serverId: string, userId: string): Promise<void> {
+        await this.pool.query(`DELETE FROM mcp_oauth_credentials WHERE mcp_server_id = $1 AND user_id = $2`, [serverId, userId]);
+    }
+
+    /** 목록 API 용 — 토큰을 가진 서버 id 집합 (복호화 없이 존재 여부만) */
+    async listConnectedServerIds(userId: string, serverIds: string[]): Promise<Set<string>> {
+        if (serverIds.length === 0) return new Set();
+        const r = await this.pool.query<{ mcp_server_id: string }>(
+            `SELECT mcp_server_id FROM mcp_oauth_credentials
+              WHERE user_id = $1 AND mcp_server_id = ANY($2::text[]) AND tokens_enc IS NOT NULL`,
+            [userId, serverIds],
+        );
+        return new Set(r.rows.map(x => x.mcp_server_id));
+    }
+}

--- a/apps/api/src/mcp/connect-error.test.ts
+++ b/apps/api/src/mcp/connect-error.test.ts
@@ -18,6 +18,13 @@ describe('classifyConnectError', () => {
         expect(classifyConnectError(new Error(msg)).code).toBe(expected);
     });
 
+    it('SDK UnauthorizedError 는 메시지가 비어도 auth_required (authProvider REDIRECT 경로)', () => {
+        const e = new Error(''); e.name = 'UnauthorizedError';
+        const r = classifyConnectError(e);
+        expect(r.code).toBe('auth_required');
+        expect(r.message.length).toBeGreaterThan(0); // 원문이 비면 안내문으로 채운다
+    });
+
     it('404 는 not_found', () => {
         expect(classifyConnectError(new Error('HTTP 404 Not Found')).code).toBe('not_found');
     });

--- a/apps/api/src/mcp/connect-error.ts
+++ b/apps/api/src/mcp/connect-error.ts
@@ -26,6 +26,11 @@ export interface ClassifiedConnectError {
  */
 export function classifyConnectError(error: unknown): ClassifiedConnectError {
     const raw = error instanceof Error ? error.message : String(error ?? '');
+    // SDK 의 UnauthorizedError 는 메시지가 빈 문자열일 수 있다(authProvider 가 REDIRECT 를 돌려준 경우)
+    // — 패턴표로는 못 잡으므로 이름으로 먼저 본다.
+    if (error instanceof Error && error.name === 'UnauthorizedError') {
+        return { code: 'auth_required', message: (raw.trim() || 'OAuth 로그인이 필요합니다').slice(0, MCP_CONNECT_ERROR_MAX_CHARS) };
+    }
     const message = raw.trim().slice(0, MCP_CONNECT_ERROR_MAX_CHARS);
     const rule = MCP_CONNECT_ERROR_RULES.find((r) => r.pattern.test(raw));
     return { code: rule?.code ?? 'unknown', message };

--- a/apps/api/src/mcp/external-client.ts
+++ b/apps/api/src/mcp/external-client.ts
@@ -101,6 +101,7 @@ type TransportInstance = StdioClientTransport | StreamableHTTPClientTransport | 
  * @class ExternalMCPClient
  */
 import { EventEmitter } from 'events';
+import { McpOAuthProvider } from './oauth-provider';
 
 export class ExternalMCPClient extends EventEmitter {
     /** SDK 클라이언트 인스턴스 */
@@ -323,6 +324,16 @@ export class ExternalMCPClient extends EventEmitter {
      * @returns 생성된 Transport 인스턴스
      * @throws {Error} 필수 설정 누락 또는 알 수 없는 transport_type
      */
+    /**
+     * 원격 transport 용 OAuth provider — 사용자 소유 서버에만 붙는다.
+     * 401 이면 SDK 가 저장된 토큰(갱신 포함)을 쓰고, 없으면 인가 URL 만 붙잡아 둔 채
+     * UnauthorizedError 를 던진다 → `auth_required` 로 분류돼 화면에 [로그인] 이 뜬다.
+     */
+    private createAuthProvider(): McpOAuthProvider | undefined {
+        if (!this.config.user_id) return undefined;
+        return new McpOAuthProvider({ serverId: this.config.id, userId: this.config.user_id });
+    }
+
     private createTransport(): TransportInstance {
         switch (this.config.transport_type) {
             case 'stdio': {
@@ -362,13 +373,13 @@ export class ExternalMCPClient extends EventEmitter {
                 }
                 // 🔒 SSRF: URL 은 등록 시 1회만 검증되므로, 런타임 network 는 매번 재검증 + resolved IP
                 //   고정하는 fetch 로 DNS Rebinding(TOCTOU)을 차단한다.
-                return new SSEClientTransport(new URL(this.config.url), { fetch: createPinnedFetch() });
+                return new SSEClientTransport(new URL(this.config.url), { fetch: createPinnedFetch(), authProvider: this.createAuthProvider() });
             }
             case 'streamable-http': {
                 if (!this.config.url) {
                     throw new Error(`streamable-http transport requires "url" for server "${this.config.name}"`);
                 }
-                return new StreamableHTTPClientTransport(new URL(this.config.url), { fetch: createPinnedFetch() });
+                return new StreamableHTTPClientTransport(new URL(this.config.url), { fetch: createPinnedFetch(), authProvider: this.createAuthProvider() });
             }
             default:
                 throw new Error(`Unknown transport type: ${this.config.transport_type}`);

--- a/apps/api/src/mcp/oauth-provider.test.ts
+++ b/apps/api/src/mcp/oauth-provider.test.ts
@@ -1,0 +1,82 @@
+/**
+ * McpOAuthProvider — SDK 계약(OAuthClientProvider) 위에서 저장/조회가 맞물리는지.
+ *
+ * DB 는 가짜 repo, KV 는 인메모리 Map 으로 대체한다. 실제 인가 서버 왕복은 SDK 몫이라 여기서
+ * 검증하지 않는다 — 우리가 책임지는 것은 ① state 가 사용자·서버로 되돌아오고 1회용인지
+ * ② PKCE verifier 가 사용자×서버 키로 격리되는지 ③ redirect 가 URL 을 붙잡아 두기만 하는지.
+ */
+const kv = new Map<string, unknown>();
+jest.mock('../storage', () => ({
+    getKeyValueStore: () => ({
+        get: async (k: string) => (kv.has(k) ? kv.get(k) : null),
+        set: async (k: string, v: unknown) => { kv.set(k, v); },
+        del: async (k: string) => { kv.delete(k); },
+    }),
+}));
+jest.mock('../data/models/unified-database', () => ({ getUnifiedDatabase: () => ({ getPool: () => ({}) }) }));
+jest.mock('../config/env', () => ({
+    getConfig: () => ({ oauthRedirectUri: 'https://chat.example.com/api/auth/callback/google', port: 52416 }),
+}));
+
+import { McpOAuthProvider, consumeMcpOAuthState } from './oauth-provider';
+import type { McpOAuthRepository } from '../data/repositories/mcp-oauth-repository';
+
+function fakeRepo() {
+    const store: Record<string, unknown> = {};
+    return {
+        getClientInformation: async () => store.client as never,
+        saveClientInformation: async (_s: string, _u: string, info: unknown) => { store.client = info; },
+        getTokens: async () => store.tokens as never,
+        saveTokens: async (_s: string, _u: string, t: unknown) => { store.tokens = t; },
+        clearTokens: async () => { delete store.tokens; },
+        clearAll: async () => { delete store.tokens; delete store.client; },
+        listConnectedServerIds: async () => new Set<string>(),
+        _store: store,
+    } as unknown as McpOAuthRepository & { _store: Record<string, unknown> };
+}
+
+beforeEach(() => kv.clear());
+
+describe('McpOAuthProvider', () => {
+    it('redirect URL 은 OAUTH_REDIRECT_URI 의 origin + 고정 콜백 경로', () => {
+        const p = new McpOAuthProvider({ serverId: 's1', userId: 'u1', repo: fakeRepo() });
+        expect(p.redirectUrl).toBe('https://chat.example.com/api/mcp/oauth/callback');
+        expect(p.clientMetadata.redirect_uris).toEqual([p.redirectUrl]);
+        expect(p.clientMetadata.token_endpoint_auth_method).toBe('none'); // PKCE 공개 클라이언트
+    });
+
+    it('state 는 사용자·서버로 되돌아오고 1회용이다', async () => {
+        const p = new McpOAuthProvider({ serverId: 's1', userId: 'u1', repo: fakeRepo() });
+        const state = await p.state();
+        expect(state.length).toBeGreaterThanOrEqual(24);
+        expect(await consumeMcpOAuthState(state)).toEqual({ userId: 'u1', serverId: 's1' });
+        expect(await consumeMcpOAuthState(state)).toBeNull(); // 재사용 차단
+    });
+
+    it('PKCE verifier 는 사용자×서버 단위로 격리된다', async () => {
+        const a = new McpOAuthProvider({ serverId: 's1', userId: 'u1', repo: fakeRepo() });
+        const b = new McpOAuthProvider({ serverId: 's1', userId: 'u2', repo: fakeRepo() });
+        await a.saveCodeVerifier('verifier-a');
+        expect(await a.codeVerifier()).toBe('verifier-a');
+        await expect(b.codeVerifier()).rejects.toThrow(/만료/);
+    });
+
+    it('redirectToAuthorization 은 이동하지 않고 URL 만 붙잡아 둔다', () => {
+        const p = new McpOAuthProvider({ serverId: 's1', userId: 'u1', repo: fakeRepo() });
+        p.redirectToAuthorization(new URL('https://as.example.com/authorize?x=1'));
+        expect(p.capturedAuthorizationUrl?.toString()).toBe('https://as.example.com/authorize?x=1');
+    });
+
+    it('토큰/클라이언트 저장은 repo 로 위임되고 invalidate 범위가 맞다', async () => {
+        const repo = fakeRepo();
+        const p = new McpOAuthProvider({ serverId: 's1', userId: 'u1', repo });
+        await p.saveClientInformation({ client_id: 'cid', redirect_uris: [p.redirectUrl] } as never);
+        await p.saveTokens({ access_token: 'at', token_type: 'bearer', refresh_token: 'rt' } as never);
+        expect((await p.tokens())?.access_token).toBe('at');
+        await p.invalidateCredentials('tokens');
+        expect(await p.tokens()).toBeUndefined();
+        expect(await p.clientInformation()).toBeDefined();
+        await p.invalidateCredentials('all');
+        expect(await p.clientInformation()).toBeUndefined();
+    });
+});

--- a/apps/api/src/mcp/oauth-provider.ts
+++ b/apps/api/src/mcp/oauth-provider.ts
@@ -1,0 +1,122 @@
+/**
+ * 원격 MCP 서버용 OAuthClientProvider 구현.
+ *
+ * SDK(`@modelcontextprotocol/sdk` client/auth) 가 401 을 만나면 이 provider 로
+ * Authorization Code + PKCE(+ RFC 7591 동적 등록) 흐름을 돌린다. 이 클래스는 **저장만** 담당한다:
+ *   - client 정보·토큰 → DB(`McpOAuthRepository`, 암호화)
+ *   - state · PKCE verifier → KV(`storage/`, 10분 TTL)
+ *
+ * 브라우저를 열 수 있는 주체는 서버가 아니라 사용자라, `redirectToAuthorization` 은 **URL 을
+ * 붙잡아 둘 뿐** 실제 이동은 하지 않는다. spawn 경로에서는 그대로 UnauthorizedError 가 되어
+ * `auth_required` 로 분류되고, `/oauth/start` 라우트가 같은 provider 로 `auth()` 를 호출한 뒤
+ * 붙잡힌 URL 을 프론트에 돌려준다. 콜백은 `auth({ authorizationCode })` 로 토큰을 교환한다.
+ *
+ * @module mcp/oauth-provider
+ */
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
+import type { OAuthClientInformationMixed, OAuthClientMetadata, OAuthTokens } from '@modelcontextprotocol/sdk/shared/auth.js';
+import { randomBytes } from 'crypto';
+import { getKeyValueStore } from '../storage';
+import { McpOAuthRepository } from '../data/repositories/mcp-oauth-repository';
+import { getUnifiedDatabase } from '../data/models/unified-database';
+import {
+    MCP_OAUTH_CLIENT_NAME,
+    MCP_OAUTH_FLOW_TTL_MS,
+    MCP_OAUTH_KV_PREFIX,
+    resolveMcpOAuthRedirectUrl,
+} from '../config/mcp-oauth';
+
+export interface McpOAuthProviderOptions {
+    serverId: string;
+    userId: string;
+    /** 테스트 주입용 — 미지정 시 운영 DB */
+    repo?: McpOAuthRepository;
+}
+
+/** state → 사용자·서버 귀속 (콜백에서 조회) */
+export interface McpOAuthStateRecord {
+    userId: string;
+    serverId: string;
+}
+
+export class McpOAuthProvider implements OAuthClientProvider {
+    private readonly repo: McpOAuthRepository;
+    /** `redirectToAuthorization` 이 받은 URL — 라우트가 꺼내 간다 */
+    public capturedAuthorizationUrl: URL | undefined;
+
+    constructor(private readonly opts: McpOAuthProviderOptions) {
+        this.repo = opts.repo ?? new McpOAuthRepository(getUnifiedDatabase().getPool());
+    }
+
+    get redirectUrl(): string {
+        return resolveMcpOAuthRedirectUrl();
+    }
+
+    get clientMetadata(): OAuthClientMetadata {
+        return {
+            client_name: MCP_OAUTH_CLIENT_NAME,
+            redirect_uris: [this.redirectUrl],
+            grant_types: ['authorization_code', 'refresh_token'],
+            response_types: ['code'],
+            token_endpoint_auth_method: 'none',
+        };
+    }
+
+    /** 콜백에서 사용자·서버를 되찾는 열쇠. 예측 불가 + TTL 로 재사용 차단 */
+    async state(): Promise<string> {
+        const state = randomBytes(24).toString('base64url');
+        const record: McpOAuthStateRecord = { userId: this.opts.userId, serverId: this.opts.serverId };
+        await getKeyValueStore().set(`${MCP_OAUTH_KV_PREFIX.state}${state}`, record, MCP_OAUTH_FLOW_TTL_MS);
+        return state;
+    }
+
+    clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
+        return this.repo.getClientInformation(this.opts.serverId, this.opts.userId);
+    }
+
+    async saveClientInformation(info: OAuthClientInformationMixed): Promise<void> {
+        await this.repo.saveClientInformation(this.opts.serverId, this.opts.userId, info as never);
+    }
+
+    tokens(): Promise<OAuthTokens | undefined> {
+        return this.repo.getTokens(this.opts.serverId, this.opts.userId);
+    }
+
+    saveTokens(tokens: OAuthTokens): Promise<void> {
+        return this.repo.saveTokens(this.opts.serverId, this.opts.userId, tokens);
+    }
+
+    /** 서버 프로세스는 브라우저를 못 연다 — URL 만 붙잡아 둔다 */
+    redirectToAuthorization(url: URL): void {
+        this.capturedAuthorizationUrl = url;
+    }
+
+    private verifierKey(): string {
+        return `${MCP_OAUTH_KV_PREFIX.verifier}${this.opts.userId}:${this.opts.serverId}`;
+    }
+
+    async saveCodeVerifier(verifier: string): Promise<void> {
+        await getKeyValueStore().set(this.verifierKey(), verifier, MCP_OAUTH_FLOW_TTL_MS);
+    }
+
+    async codeVerifier(): Promise<string> {
+        const v = await getKeyValueStore().get<string>(this.verifierKey());
+        if (!v) throw new Error('OAuth 인가 흐름이 만료되었습니다 — 다시 로그인해 주세요.');
+        return v;
+    }
+
+    async invalidateCredentials(scope: 'all' | 'client' | 'tokens' | 'verifier' | 'discovery'): Promise<void> {
+        if (scope === 'all' || scope === 'client') await this.repo.clearAll(this.opts.serverId, this.opts.userId);
+        else if (scope === 'tokens') await this.repo.clearTokens(this.opts.serverId, this.opts.userId);
+        else if (scope === 'verifier') await getKeyValueStore().del(this.verifierKey());
+        // 'discovery' 는 캐시가 없어 no-op
+    }
+}
+
+/** 콜백의 state 를 사용자·서버로 되돌린다. 1회용 — 읽자마자 지운다 */
+export async function consumeMcpOAuthState(state: string): Promise<McpOAuthStateRecord | null> {
+    const key = `${MCP_OAUTH_KV_PREFIX.state}${state}`;
+    const record = await getKeyValueStore().get<McpOAuthStateRecord>(key);
+    if (record) await getKeyValueStore().del(key);
+    return record;
+}

--- a/apps/api/src/mcp/types.ts
+++ b/apps/api/src/mcp/types.ts
@@ -264,6 +264,8 @@ export interface MCPServerConfig {
     sandbox_network?: 'full' | 'none' | 'host';
     /** 채팅 자동 노출 도구 화이트리스트(순서=우선순위, 카탈로그 tool_allowlist 유래). 미정의=전체 노출. REST 직접 실행 미적용 */
     tool_allowlist?: string[];
+    /** 소유 사용자 — 있으면 원격 transport 에 사용자×서버 단위 OAuth provider 를 붙인다(전역 서버는 없음) */
+    user_id?: string;
 }
 
 /**

--- a/apps/api/src/routes/mcp-oauth.routes.ts
+++ b/apps/api/src/routes/mcp-oauth.routes.ts
@@ -1,0 +1,125 @@
+/**
+ * 원격 MCP 서버 OAuth 라우트 — mount: `/api/mcp`
+ *
+ *   POST   /servers/:id/oauth/start   → { authorizationUrl }  (프론트가 브라우저를 이동)
+ *   GET    /oauth/callback?code&state → 토큰 교환 → 서버 재연결 → 커넥터 탭으로 리디렉트
+ *   DELETE /servers/:id/oauth         → 토큰·등록 삭제(로그아웃) + 연결 정리
+ *
+ * SDK `auth()` 를 그대로 쓴다 — 리소스 메타데이터 발견(RFC 9728) → AS 메타데이터(RFC 8414) →
+ * 동적 등록(RFC 7591) → PKCE 인가 URL 생성까지 SDK 가 하고, 이 라우트는 provider 가 붙잡은
+ * URL 을 돌려주거나(start) code 를 넘겨 토큰을 받는다(callback).
+ *
+ * 🔒 콜백은 `requireAuth` 다 — 인가 서버가 브라우저를 돌려보내므로 우리 쿠키가 따라온다.
+ *    state 는 KV 1회용이고 그 안의 userId 가 요청 사용자와 같아야 한다(타인 세션에 토큰 심기 차단).
+ *    외부로 나가는 fetch 는 전부 `createPinnedFetch`(SSRF 가드) 를 쓴다.
+ *
+ * @module routes/mcp-oauth.routes
+ */
+import { Router, type Request, type Response } from 'express';
+import { auth } from '@modelcontextprotocol/sdk/client/auth.js';
+import { requireAuth } from '../auth';
+import { asyncHandler } from '../utils/error-handler';
+import { success, badRequest, notFound, forbidden, internalError } from '../utils/api-response';
+import { getUnifiedDatabase } from '../data/models/unified-database';
+import { McpCatalogRepository } from '../data/repositories/mcp-catalog-repository';
+import { McpOAuthRepository } from '../data/repositories/mcp-oauth-repository';
+import { McpOAuthProvider, consumeMcpOAuthState } from '../mcp/oauth-provider';
+import { getLifecycleSupervisor } from '../mcp/lifecycle-supervisor';
+import { createPinnedFetch } from '../security/ssrf-guard';
+import { canStartStopServer } from './mcp-visibility';
+import { MCP_OAUTH_RETURN_PATH } from '../config/mcp-oauth';
+import { classifyConnectError } from '../mcp/connect-error';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('McpOAuthRoutes');
+export const mcpOAuthRouter = Router();
+
+/** 리디렉트 목적지 — 결과와 서버명을 쿼리로 싣는다 (상대경로라 open-redirect 없음) */
+function returnTo(result: 'ok' | 'error', extra: Record<string, string> = {}): string {
+    const q = new URLSearchParams({ mcpOauth: result, ...extra });
+    return `${MCP_OAUTH_RETURN_PATH}&${q.toString()}`;
+}
+
+/** 원격 transport 인 사용자 소유 서버만 OAuth 대상이다 */
+async function loadOAuthTarget(req: Request, res: Response) {
+    const userId = String(req.user?.id ?? '');
+    const actor = { id: userId, role: req.user?.role ?? 'user' };
+    const repo = new McpCatalogRepository(getUnifiedDatabase().getPool());
+    const server = await repo.getServerById(req.params.id);
+    if (!server) { res.status(404).json(notFound('서버')); return null; }
+    if (!canStartStopServer(actor, server)) { res.status(403).json(forbidden('해당 서버를 변경할 권한이 없습니다')); return null; }
+    if (server.transport_type === 'stdio' || !server.url) {
+        res.status(400).json(badRequest('원격(sse/streamable-http) 서버만 OAuth 로그인을 지원합니다'));
+        return null;
+    }
+    return { server, userId, ownerId: String(server.user_id ?? userId) };
+}
+
+/** 인가 URL 발급 — provider 가 redirectToAuthorization 으로 붙잡은 URL 을 돌려준다 */
+mcpOAuthRouter.post('/servers/:id/oauth/start', requireAuth, asyncHandler(async (req: Request, res: Response) => {
+    const target = await loadOAuthTarget(req, res);
+    if (!target) return;
+    const provider = new McpOAuthProvider({ serverId: target.server.id, userId: target.ownerId });
+    // 기존 토큰이 있으면 SDK 가 갱신을 시도해 AUTHORIZED 를 돌려줄 수 있다 — 그 경우 로그인 불필요.
+    // 재로그인을 강제하려면 먼저 DELETE 로 지운다.
+    const result = await auth(provider, { serverUrl: target.server.url as string, fetchFn: createPinnedFetch() });
+    if (result === 'AUTHORIZED') {
+        res.json(success({ authorized: true, authorizationUrl: null }));
+        return;
+    }
+    if (!provider.capturedAuthorizationUrl) {
+        res.status(500).json(internalError('인가 URL 을 만들지 못했습니다'));
+        return;
+    }
+    logger.info(`OAuth start s=${target.server.id} u=${target.ownerId} → ${provider.capturedAuthorizationUrl.origin}`);
+    res.json(success({ authorized: false, authorizationUrl: provider.capturedAuthorizationUrl.toString() }));
+}));
+
+/** 인가 콜백 — code 를 토큰으로 바꾸고 서버를 다시 띄운 뒤 커넥터 탭으로 돌려보낸다 */
+mcpOAuthRouter.get('/oauth/callback', requireAuth, asyncHandler(async (req: Request, res: Response) => {
+    const code = typeof req.query.code === 'string' ? req.query.code : '';
+    const state = typeof req.query.state === 'string' ? req.query.state : '';
+    const providerError = typeof req.query.error === 'string' ? req.query.error : '';
+    if (providerError) { res.redirect(returnTo('error', { reason: providerError.slice(0, 64) })); return; }
+    if (!code || !state) { res.redirect(returnTo('error', { reason: 'missing_code_or_state' })); return; }
+
+    const record = await consumeMcpOAuthState(state);
+    if (!record) { res.redirect(returnTo('error', { reason: 'state_expired' })); return; }
+    // 🔒 state 를 만든 사용자만 콜백을 완료할 수 있다
+    if (record.userId !== String(req.user?.id ?? '')) { res.redirect(returnTo('error', { reason: 'state_user_mismatch' })); return; }
+
+    const repo = new McpCatalogRepository(getUnifiedDatabase().getPool());
+    const server = await repo.getServerById(record.serverId);
+    if (!server?.url) { res.redirect(returnTo('error', { reason: 'server_not_found' })); return; }
+
+    try {
+        const provider = new McpOAuthProvider({ serverId: server.id, userId: record.userId });
+        const result = await auth(provider, { serverUrl: server.url, authorizationCode: code, fetchFn: createPinnedFetch() });
+        if (result !== 'AUTHORIZED') throw new Error(`unexpected auth result: ${result}`);
+        await provider.invalidateCredentials('verifier');
+        logger.info(`OAuth 완료 s=${server.id} u=${record.userId}`);
+
+        // 토큰이 생겼으니 곧바로 연결해 본다 — 실패해도 로그인 자체는 성공이라 리디렉트는 ok
+        const supervisor = getLifecycleSupervisor();
+        if (supervisor) {
+            await supervisor.killUserServer(record.userId, server.id).catch(() => { /* 없으면 무시 */ });
+            await supervisor.spawnUserServer(record.userId, server.id).catch((e: unknown) =>
+                logger.warn(`OAuth 후 재연결 실패 s=${server.id}: ${classifyConnectError(e).message}`));
+        }
+        res.redirect(returnTo('ok', { server: server.name }));
+    } catch (e) {
+        const c = classifyConnectError(e);
+        logger.warn(`OAuth 토큰 교환 실패 s=${server.id} u=${record.userId} [${c.code}] ${c.message}`);
+        res.redirect(returnTo('error', { reason: 'token_exchange_failed', server: server.name }));
+    }
+}));
+
+/** 로그아웃 — 토큰·동적 등록을 지우고 살아있는 연결을 정리한다 */
+mcpOAuthRouter.delete('/servers/:id/oauth', requireAuth, asyncHandler(async (req: Request, res: Response) => {
+    const target = await loadOAuthTarget(req, res);
+    if (!target) return;
+    await new McpOAuthRepository(getUnifiedDatabase().getPool()).clearAll(target.server.id, target.ownerId);
+    const supervisor = getLifecycleSupervisor();
+    if (supervisor) await supervisor.killUserServer(target.ownerId, target.server.id).catch(() => { /* 없으면 무시 */ });
+    res.json(success({ id: target.server.id, loggedOut: true }));
+}));

--- a/apps/api/src/routes/mcp.routes.ts
+++ b/apps/api/src/routes/mcp.routes.ts
@@ -39,6 +39,7 @@ import { validate } from '../middlewares/validation';
 import { mcpToolExecuteSchema, mcpServerCreateSchema, mcpServerEnvUpdateSchema,
     mcpServerEnabledUpdateSchema } from '../schemas/mcp.schema';
 import { McpCatalogRepository } from '../data/repositories/mcp-catalog-repository';
+import { McpOAuthRepository } from '../data/repositories/mcp-oauth-repository';
 import { canRegisterServer, canViewServer, canDeleteServer, canStartStopServer, canUpdateServerEnv } from './mcp-visibility';
 import { getAuditService } from '../services/AuditService';
 import { validateOutboundUrl } from '../security/ssrf-guard';
@@ -130,6 +131,10 @@ export const mcpRouter = Router();
       const persistedErrors = await repo
           .getLatestConnectErrors(userId, filtered.map(s => s.id))
           .catch(() => new Map<string, { message: string; at: string }>());
+      // OAuth 토큰 보유 여부 — 화면의 [로그인]/[로그아웃] 분기용. 조회 실패는 fail-open.
+      const oauthConnected = await new McpOAuthRepository(getUnifiedDatabase().getPool())
+          .listConnectedServerIds(userId, filtered.map(s => s.id))
+          .catch(() => new Set<string>());
 
       const serversWithStatus = filtered.map(server => {
           const regStatus = statuses.find(s => s.serverId === server.id);
@@ -153,6 +158,8 @@ export const mcpRouter = Router();
               /** 원인 코드 — 프론트가 i18n 문구로 바꿔 보여준다 (`auth_required` 등) */
               connectionErrorCode: failure?.code ?? null,
               connectionErrorAt: live ? null : (persistedErrors.get(server.id)?.at ?? null),
+              /** 원격 서버에 OAuth 토큰이 저장돼 있는가 (stdio 는 항상 false) */
+              oauthConnected: oauthConnected.has(server.id),
           };
       });
 

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -10,6 +10,7 @@
  */
 
 import { Application, Request, Response } from 'express';
+import { mcpOAuthRouter } from './mcp-oauth.routes';
 import * as path from 'path';
 import * as fs from 'fs';
 
@@ -174,6 +175,7 @@ export function setupApiRoutes(
     app.use('/api/agents', agentRouter);
     app.use('/api/monitoring', tokenMonitoringRouter);
     app.use('/api/mcp', mcpRouter);
+    app.use('/api/mcp', mcpOAuthRouter);   // 원격 MCP OAuth (start/callback/logout)
     app.use('/api/mcp', mcpCatalogRouter);
     app.use('/api/mcp', notebooklmRouter);
     const e2eMcpMock = process.env.MCP_INGEST_E2E_MOCK === 'true';

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -361,6 +361,7 @@ export class DashboardServer {
                     catalog_template_id: config.catalog_template_id ?? undefined,
                     sandbox_network: config.sandbox_network ?? 'full',
                     tool_allowlist: config.tool_allowlist,
+                    user_id: config.user_id,
                 }),
             });
             setLifecycleSupervisor(supervisor);
@@ -551,6 +552,7 @@ if (require.main === module) {
                         catalog_template_id: config.catalog_template_id ?? undefined,
                         sandbox_network: config.sandbox_network ?? 'full',
                         tool_allowlist: config.tool_allowlist,
+                        user_id: config.user_id,
                     }),
                 });
                 setLifecycleSupervisor(supervisor);

--- a/apps/web/components/settings/connectors-section.tsx
+++ b/apps/web/components/settings/connectors-section.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { Server, Boxes, Plus, Loader2, X, KeyRound, ClipboardCheck, AlertTriangle, Power, PowerOff } from "lucide-react";
+import { Server, Boxes, Plus, Loader2, X, KeyRound, ClipboardCheck, AlertTriangle, Power, PowerOff, LogIn, LogOut } from "lucide-react";
 import {
   Button,
   Badge,
@@ -38,6 +38,8 @@ interface McpServer {
   status: ConnStatus;
   /** 사용 여부 — false 면 목록에 남되 "사용 안 함"으로 표시된다(삭제와 달리 되돌릴 수 있다) */
   enabled: boolean;
+  /** OAuth 토큰 보유 — 로그아웃 버튼 노출 기준 */
+  oauthConnected: boolean;
   /** 연결 실패 원인 코드 — 없으면 실패한 적이 없거나 현재 연결됨 */
   errorCode: string | null;
   /** 원인 원문 (코드만으로 부족한 진단용 — tooltip) */
@@ -62,6 +64,8 @@ interface ApiMcpServer {
   connectionError?: string | null;
   /** 사용 여부 — false 면 사용자가 "쓰지 않음"으로 치워둔 서버 */
   enabled?: boolean;
+  /** 원격 서버에 OAuth 토큰이 저장돼 있는가 */
+  oauthConnected?: boolean;
   /** 원인 코드(`auth_required` 등) — i18n 문구로 바꿔 보여준다 */
   connectionErrorCode?: string | null;
   /** 백엔드가 마스킹해서 내려주는 env — 암호화된 값은 "***" 로 치환돼 있다(원문 미노출). */
@@ -101,6 +105,7 @@ function mapServer(s: ApiMcpServer, t: Translator): McpServer {
     toolCount: s.toolCount ?? 0,
     status: mapStatus(s.connectionStatus),
     enabled: s.enabled !== false,
+    oauthConnected: s.oauthConnected === true,
     errorCode: s.connectionStatus === "connected" ? null : (s.connectionErrorCode ?? null),
     errorDetail: s.connectionStatus === "connected" ? null : (s.connectionError ?? null),
     // 백엔드는 지연(latency) 수치를 제공하지 않음 — 표시 생략
@@ -325,6 +330,7 @@ function buildMockServers(t: Translator): McpServer[] {
     toolCount: 8,
     status: "connected",
     enabled: true,
+    oauthConnected: false,
     errorCode: null,
     errorDetail: null,
     latencyMs: 12,
@@ -339,6 +345,7 @@ function buildMockServers(t: Translator): McpServer[] {
     toolCount: 21,
     status: "connected",
     enabled: true,
+    oauthConnected: false,
     errorCode: null,
     errorDetail: null,
     latencyMs: 184,
@@ -353,6 +360,7 @@ function buildMockServers(t: Translator): McpServer[] {
     toolCount: 5,
     status: "degraded",
     enabled: true,
+    oauthConnected: false,
     errorCode: null,
     errorDetail: null,
     latencyMs: 842,
@@ -367,6 +375,7 @@ function buildMockServers(t: Translator): McpServer[] {
     toolCount: 11,
     status: "connected",
     enabled: true,
+    oauthConnected: false,
     errorCode: null,
     errorDetail: null,
     latencyMs: 76,
@@ -381,6 +390,7 @@ function buildMockServers(t: Translator): McpServer[] {
     toolCount: 3,
     status: "disconnected",
     enabled: true,
+    oauthConnected: false,
     errorCode: null,
     errorDetail: null,
     latencyMs: null,
@@ -419,6 +429,17 @@ export function ConnectorsSection() {
   const [actionLoading, setActionLoading] = useState<Record<string, boolean>>({});
   const [envEditTarget, setEnvEditTarget] = useState<McpServer | null>(null);
   const [envNotice, setEnvNotice] = useState<string | null>(null);
+  // OAuth 콜백 착지 — 결과를 알리고 목록을 다시 읽는다(토큰이 생겨 연결됐을 수 있다)
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const result = params.get("mcpOauth");
+    if (!result) return;
+    const server = params.get("server") ?? "";
+    setEnvNotice(result === "ok" ? t("oauthOk", { server } as never) : t("oauthFailed", { server, reason: params.get("reason") ?? "" } as never));
+    params.delete("mcpOauth"); params.delete("server"); params.delete("reason");
+    window.history.replaceState(null, "", `${window.location.pathname}?${params.toString()}`);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // env 교체 성공 — 백엔드가 기존 컨테이너를 정리했으므로(stale env 방지) 재연결 안내.
   function handleEnvUpdated(respawnRequired: boolean) {
@@ -453,6 +474,40 @@ export function ConnectorsSection() {
       );
     } catch {
       /* 실패 시 현상 유지 */
+    } finally {
+      setActionLoading((prev) => ({ ...prev, [id]: false }));
+    }
+  }
+
+  /**
+   * 원격 MCP OAuth 로그인 — 백엔드가 인가 URL 을 만들어 주면 브라우저를 그리로 보낸다.
+   * 콜백이 끝나면 커넥터 탭으로 돌아오며 ?mcpOauth=ok|error 로 결과를 알린다.
+   */
+  async function handleOAuthLogin(id: string) {
+    setActionLoading((prev) => ({ ...prev, [id]: true }));
+    try {
+      const r = await ApiClient.post<ApiEnvelope<{ authorized: boolean; authorizationUrl: string | null }>>(
+        `/api/mcp/servers/${id}/oauth/start`, {});
+      if (r.data?.authorizationUrl) {
+        window.location.assign(r.data.authorizationUrl);
+        return; // 페이지를 떠난다 — 로딩 상태는 그대로 두어 중복 클릭을 막는다
+      }
+      // 이미 유효한 토큰이 있어 갱신만 됐다 → 바로 연결
+      await handleConnect(id);
+    } catch (e) {
+      alert(t("oauthStartFailed", { error: e instanceof Error ? e.message : "" } as never));
+    } finally {
+      setActionLoading((prev) => ({ ...prev, [id]: false }));
+    }
+  }
+
+  async function handleOAuthLogout(id: string) {
+    setActionLoading((prev) => ({ ...prev, [id]: true }));
+    try {
+      await ApiClient.del(`/api/mcp/servers/${id}/oauth`);
+      setServers((prev) => prev.map((s) => (s.id === id ? { ...s, oauthConnected: false, status: "disconnected", toolCount: 0 } : s)));
+    } catch (e) {
+      alert(t("oauthStartFailed", { error: e instanceof Error ? e.message : "" } as never));
     } finally {
       setActionLoading((prev) => ({ ...prev, [id]: false }));
     }
@@ -638,6 +693,16 @@ export function ConnectorsSection() {
                           >
                             <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
                             <span>{t(`connectError.${s.errorCode}`)}</span>
+                            {s.errorCode === "auth_required" && (
+                              <button
+                                type="button"
+                                disabled={isActing}
+                                onClick={() => void handleOAuthLogin(s.id)}
+                                className="ml-1 inline-flex items-center gap-1 font-medium text-accent hover:underline disabled:opacity-50"
+                              >
+                                <LogIn className="h-3 w-3" />{t("oauthLogin")}
+                              </button>
+                            )}
                           </div>
                         )}
                       </Td>
@@ -667,6 +732,18 @@ export function ConnectorsSection() {
                             {s.enabled ? <PowerOff className="h-3 w-3" /> : <Power className="h-3 w-3" />}
                             {s.enabled ? t("disable") : t("enable")}
                           </Button>
+                          {s.oauthConnected && (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              disabled={isActing}
+                              onClick={() => void handleOAuthLogout(s.id)}
+                              title={t("oauthLogoutTitle")}
+                            >
+                              <LogOut className="h-3 w-3" />
+                              {t("oauthLogout")}
+                            </Button>
+                          )}
                           {s.envKeys.length > 0 && (
                             <Button
                               variant="outline"

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1065,7 +1065,7 @@
     "tabInstances": "Instances",
     "pendingApprovals": "Approvals",
     "connectError": {
-      "auth_required": "Authentication required — this server needs OAuth login (not supported yet)",
+      "auth_required": "Authentication required — this server needs OAuth sign-in",
       "not_found": "Endpoint not found (404)",
       "unreachable": "Cannot reach the server",
       "timeout": "Connection timed out",
@@ -1077,7 +1077,13 @@
     "enable": "Enable",
     "disableTitle": "Mark this server unused (settings kept, reversible anytime)",
     "enableTitle": "Use this server again",
-    "toggleFailed": "Update failed: {error}"
+    "toggleFailed": "Update failed: {error}",
+    "oauthLogin": "Sign in",
+    "oauthLogout": "Sign out",
+    "oauthLogoutTitle": "Remove the stored OAuth token and disconnect",
+    "oauthStartFailed": "Could not start OAuth sign-in: {error}",
+    "oauthOk": "Signed in to {server} — connecting",
+    "oauthFailed": "Sign-in to {server} failed ({reason})"
   },
   "mcpCatalog": {
     "pageTitle": "MCP Catalog",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1065,7 +1065,7 @@
     "tabInstances": "インスタンス状態",
     "pendingApprovals": "承認待ち",
     "connectError": {
-      "auth_required": "認証が必要 — このサーバーは OAuth ログインを要求します（現在未対応）",
+      "auth_required": "認証が必要 — このサーバーは OAuth ログインを要求します",
       "not_found": "エンドポイントが見つかりません (404)",
       "unreachable": "サーバーに接続できません",
       "timeout": "接続がタイムアウトしました",
@@ -1077,7 +1077,13 @@
     "enable": "使用する",
     "disableTitle": "このサーバーを使用しないものとして表示（設定は保存、いつでも戻せます）",
     "enableTitle": "このサーバーを再び使用",
-    "toggleFailed": "変更に失敗しました: {error}"
+    "toggleFailed": "変更に失敗しました: {error}",
+    "oauthLogin": "ログイン",
+    "oauthLogout": "ログアウト",
+    "oauthLogoutTitle": "保存された OAuth トークンを削除して接続を切ります",
+    "oauthStartFailed": "OAuth ログインを開始できません: {error}",
+    "oauthOk": "{server} にログインしました — 接続します",
+    "oauthFailed": "{server} へのログインに失敗しました ({reason})"
   },
   "mcpCatalog": {
     "pageTitle": "MCPカタログ",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1065,7 +1065,7 @@
     "tabInstances": "인스턴스 상태",
     "pendingApprovals": "승인 대기",
     "connectError": {
-      "auth_required": "인증 필요 — 이 서버는 OAuth 로그인을 요구합니다(현재 미지원)",
+      "auth_required": "인증 필요 — 이 서버는 OAuth 로그인을 요구합니다",
       "not_found": "엔드포인트를 찾을 수 없음 (404)",
       "unreachable": "서버에 연결할 수 없음",
       "timeout": "연결 시간 초과",
@@ -1077,7 +1077,13 @@
     "enable": "사용",
     "disableTitle": "이 서버를 쓰지 않음으로 표시 (설정은 보존, 언제든 되돌릴 수 있음)",
     "enableTitle": "이 서버를 다시 사용",
-    "toggleFailed": "변경 실패: {error}"
+    "toggleFailed": "변경 실패: {error}",
+    "oauthLogin": "로그인",
+    "oauthLogout": "로그아웃",
+    "oauthLogoutTitle": "저장된 OAuth 토큰을 지우고 연결을 끊습니다",
+    "oauthStartFailed": "OAuth 로그인 시작 실패: {error}",
+    "oauthOk": "{server} 로그인 완료 — 연결을 시도합니다",
+    "oauthFailed": "{server} 로그인 실패 ({reason})"
   },
   "mcpCatalog": {
     "pageTitle": "MCP 카탈로그",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1065,7 +1065,7 @@
     "tabInstances": "实例状态",
     "pendingApprovals": "待审批",
     "connectError": {
-      "auth_required": "需要认证 — 该服务器要求 OAuth 登录（当前不支持）",
+      "auth_required": "需要认证 — 该服务器要求 OAuth 登录",
       "not_found": "找不到端点 (404)",
       "unreachable": "无法连接到服务器",
       "timeout": "连接超时",
@@ -1077,7 +1077,13 @@
     "enable": "启用",
     "disableTitle": "标记为不使用（保留配置，可随时恢复）",
     "enableTitle": "重新启用该服务器",
-    "toggleFailed": "更新失败：{error}"
+    "toggleFailed": "更新失败：{error}",
+    "oauthLogin": "登录",
+    "oauthLogout": "退出登录",
+    "oauthLogoutTitle": "删除已保存的 OAuth 令牌并断开连接",
+    "oauthStartFailed": "无法启动 OAuth 登录：{error}",
+    "oauthOk": "已登录 {server} — 正在连接",
+    "oauthFailed": "登录 {server} 失败（{reason}）"
   },
   "mcpCatalog": {
     "pageTitle": "MCP 目录",

--- a/db/migrations/104_mcp_oauth_credentials.sql
+++ b/db/migrations/104_mcp_oauth_credentials.sql
@@ -1,0 +1,28 @@
+-- Migration 104 — 원격 MCP 서버 OAuth 자격증명 (2026-08-25)
+--
+-- 확장으로 설치되는 원격 MCP(Linear·Asana·Slack·Figma·Atlassian 등)는 전부 OAuth 를
+-- 요구한다(401 invalid_token / missing_token). SDK 는 `authProvider` 로 Authorization Code +
+-- PKCE + 동적 클라이언트 등록(RFC 7591)을 지원하지만 이 레포는 배선한 적이 없어, 승인해도
+-- 영영 도구 0개였다 (#616 에서 원인만 노출).
+--
+-- 사용자×서버 단위로 ① 동적 등록된 client 정보 ② 토큰을 보관한다. 토큰·client_secret 은
+-- AES-256-GCM(utils/token-crypto, `v1:` 접두) 으로 암호화해 컬럼에 담는다 — 외부 provider
+-- BYOK 키와 같은 방식. state·PKCE verifier 는 수명이 분 단위라 KV(storage/) 에 두고 여기엔 없다.
+--
+-- 멱등 (IF NOT EXISTS + DO/EXCEPTION 제약 가드).
+
+CREATE TABLE IF NOT EXISTS mcp_oauth_credentials (
+    mcp_server_id     TEXT NOT NULL REFERENCES mcp_servers(id) ON DELETE CASCADE,
+    user_id           TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    -- RFC 7591 동적 등록 결과 (client_id 등). client_secret 은 별도 암호화 컬럼.
+    client_info       JSONB,
+    client_secret_enc TEXT,
+    -- OAuthTokens JSON 전체를 암호화한 문자열 (access/refresh/scope/expires_in)
+    tokens_enc        TEXT,
+    -- 만료 판정용 (expires_in 을 저장 시각 기준으로 절대시각화). 조회 편의 — 진실은 tokens_enc.
+    token_expires_at  TIMESTAMPTZ,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (mcp_server_id, user_id)
+);
+CREATE INDEX IF NOT EXISTS idx_mcp_oauth_credentials_user ON mcp_oauth_credentials (user_id);

--- a/db/migrations/rollbacks/104_mcp_oauth_credentials.sql
+++ b/db/migrations/rollbacks/104_mcp_oauth_credentials.sql
@@ -1,0 +1,2 @@
+-- Rollback 104 — 원격 MCP OAuth 자격증명 테이블 제거
+DROP TABLE IF EXISTS mcp_oauth_credentials;


### PR DESCRIPTION
## 배경

확장으로 설치되는 원격 MCP(Linear·Asana·Slack·Figma·Atlassian)는 전부 OAuth 를 요구한다.
#616 에서 원인(`auth_required`)만 노출하고 #617 로 치워뒀던 것을 실제로 쓸 수 있게 만든다.

## 흐름

```
[커넥터] 인증 필요 → [로그인] 클릭
  POST /api/mcp/servers/:id/oauth/start
    SDK auth(): 리소스 메타데이터(RFC 9728) → AS 메타데이터(RFC 8414)
                → 동적 등록(RFC 7591, 최초 1회) → PKCE 인가 URL
    provider.redirectToAuthorization(url)  ← 이동하지 않고 URL 만 붙잡아 둠
  ← { authorizationUrl }  → 브라우저 이동
[인가 서버 로그인/동의]
  GET /api/mcp/oauth/callback?code&state
    state → KV 1회용, 발급 사용자 == 요청 사용자 검증
    SDK auth({ authorizationCode }) → 토큰 교환 → DB 암호화 저장
    killUserServer → spawnUserServer  (토큰으로 재연결)
  → /settings?tab=connectors&mcpOauth=ok&server=…
```

이후 spawn 은 provider 가 저장된 토큰을 SDK 에 주고, 만료 시 refresh 까지 SDK 가 한다.

## 변경

| 영역 | 파일 |
|---|---|
| 스키마 | `104_mcp_oauth_credentials.sql` — 사용자×서버 PK, `client_secret_enc`·`tokens_enc` AES-256-GCM |
| 저장소 | `data/repositories/mcp-oauth-repository.ts` |
| provider | `mcp/oauth-provider.ts` — SDK `OAuthClientProvider`, state/verifier 는 KV 10분 |
| 배선 | `external-client.ts` sse/streamable-http 에 `authProvider`, `MCPServerConfig.user_id`, `server.ts` factory 2곳 |
| 분류 | `connect-error.ts` — SDK `UnauthorizedError` 는 메시지가 비어 이름으로 판정 |
| 라우트 | `routes/mcp-oauth.routes.ts` (start/callback/logout), `setup.ts` 마운트, 목록 API `oauthConnected` |
| 설정 | `config/mcp-oauth.ts`, `MCP_OAUTH_REDIRECT_BASE`(선택) |
| 프론트 | 커넥터: `auth_required` 옆 [로그인], 토큰 있으면 [로그아웃], 콜백 결과 배너. i18n 4언어 |

## 보안

- 콜백은 `requireAuth` + state 의 userId 가 요청 사용자와 일치해야 함 (타인 세션에 토큰 심기 차단)
- state 24바이트 random, 1회용, 10분 TTL. verifier 는 사용자×서버 키
- 외부 fetch 전부 `createPinnedFetch` (DNS rebinding·loopback 차단)
- 토큰·client_secret 은 외부 provider BYOK 와 같은 암호화. 복호화 실패는 "토큰 없음"으로 → 재로그인 (깨진 암호문을 Bearer 로 보내지 않음)
- 공개 클라이언트(`token_endpoint_auth_method: none`) + PKCE

## 테스트

- provider 5건 — state 1회용·verifier 사용자 격리·URL 포획·invalidate 범위·redirect URL 유도
- `UnauthorizedError` 분류 1건
- 전체 2,959건 통과, lint 에러 0, Gate 3 위반 0

## 라이브 확인 계획 (배포 후)

1. `POST /servers/<design-linear>/oauth/start` → 인가 URL 이 `linear.app` 이고 `code_challenge`·`state`·`redirect_uri=https://chat.openmake.cc/api/mcp/oauth/callback` 을 담는지
2. 실제 로그인은 사람이 브라우저에서 완료 → 콜백 후 커넥터에서 도구 수 > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)