### PR TITLE
fix(agent-task): 재시작 시 'queued' 작업이 영구 고아가 되던 문제 + 큐 관측 엔드포인트

### DIFF
--- a/apps/api/src/data/repositories/agent-task-repository.ts
+++ b/apps/api/src/data/repositories/agent-task-repository.ts
@@ -237,11 +237,15 @@ export class AgentTaskRepository extends BaseRepository {
      * 실제 대상은 대부분 ②다: ①잔존 running/paused(마킹 실패 대비) ②restart 마킹 + 최근 window 내
      * (과거 재시작이 남긴 오래된 failed 는 자동 resume 하지 않음 — 수동 resume 대상).
      * 오래된 것부터 복구(updated_at ASC).
+     *
+     * 'queued' 도 포함한다 — 큐(3-B)는 인메모리라 재시작하면 대기열이 증발하는데, DB 행은
+     * 'queued' 로 남아 UI 가 영구 '대기 중' 을 그리고 아무도 실행하지 않았다(2026-08-25 발견).
+     * queued 는 시작한 적이 없으므로 checkpoint 없이 처음부터 다시 디스패치한다.
      */
     async getInterruptedAgentTasks(windowMs: number): Promise<AgentTask[]> {
         const result = await this.query<AgentTask>(
             `SELECT * FROM agent_tasks
-             WHERE status IN ('running', 'paused')
+             WHERE status IN ('running', 'paused', 'queued')
                 OR (status = 'failed' AND error = 'server restarted'
                     AND completed_at > NOW() - make_interval(secs => $1))
              ORDER BY updated_at ASC`,
@@ -260,11 +264,24 @@ export class AgentTaskRepository extends BaseRepository {
         const result = await this.query(
             `UPDATE agent_tasks
              SET status = 'pending', error = NULL, completed_at = NULL, updated_at = NOW()
-             WHERE id = $1 AND (status IN ('running', 'paused')
+             WHERE id = $1 AND (status IN ('running', 'paused', 'queued')
                 OR (status = 'failed' AND error = 'server restarted'))`,
             [taskId]
         );
         return (result.rowCount ?? 0) > 0;
+    }
+
+    /** 활성 상태별 건수 — 큐 관측(/queue/stats) 용. 인메모리 큐 스냅샷과 대조해 재시작 고아를 드러낸다. */
+    async countActiveAgentTasksByStatus(): Promise<Record<'queued' | 'running' | 'paused' | 'pending', number>> {
+        const r = await this.query<{ status: string; n: string }>(
+            `SELECT status, COUNT(*)::text AS n FROM agent_tasks
+              WHERE status IN ('queued', 'running', 'paused', 'pending') GROUP BY status`,
+        );
+        const out = { queued: 0, running: 0, paused: 0, pending: 0 };
+        for (const row of r.rows) {
+            if (row.status in out) out[row.status as keyof typeof out] = parseInt(row.n, 10);
+        }
+        return out;
     }
 
     async deleteAgentTaskWithSteps(taskId: string): Promise<void> {

--- a/apps/api/src/routes/agent-task-queue.routes.ts
+++ b/apps/api/src/routes/agent-task-queue.routes.ts
@@ -1,0 +1,34 @@
+/**
+ * Agent Task 큐 관측 — mount: `/api/agent-tasks` (agentTaskRouter **앞**에 마운트해야
+ * `/:id` 파라미터 라우트에 `queue` 가 삼켜지지 않는다).
+ *
+ *   GET /api/agent-tasks/queue/stats  (admin)
+ *
+ * 큐(3-B)는 인메모리라 지금까지 상태를 볼 곳이 없었다 — 대기가 쌓이는지, 상한이 맞는지,
+ * 재시작 후 'queued' 고아가 남았는지를 여기서 본다. 인메모리 스냅샷과 DB 상태 집계를 나란히
+ * 돌려주므로 둘이 어긋나면(DB queued > 메모리 pending) 고아가 있다는 뜻이다(부팅 복구가 회수).
+ *
+ * @module routes/agent-task-queue.routes
+ */
+import { Router, type Request, type Response } from 'express';
+import { requireAuth, requireAdmin } from '../auth';
+import { asyncHandler } from '../utils/error-handler';
+import { success } from '../utils/api-response';
+import { getPool } from '../data/models/unified-database';
+import { AgentTaskRepository } from '../data/repositories/agent-task-repository';
+import { getAgentTaskQueue } from '../services/agent-task/task-queue';
+import { AGENT_TASK_LIMITS } from '../config/runtime-limits';
+
+export const agentTaskQueueRouter = Router();
+
+agentTaskQueueRouter.get('/queue/stats', requireAuth, requireAdmin, asyncHandler(async (_req: Request, res: Response) => {
+    const memory = getAgentTaskQueue().stats();
+    const db = await new AgentTaskRepository(getPool()).countActiveAgentTasksByStatus();
+    res.json(success({
+        enabled: AGENT_TASK_LIMITS.QUEUE_ENABLED,
+        limits: { globalMax: AGENT_TASK_LIMITS.QUEUE_GLOBAL_MAX, userMax: AGENT_TASK_LIMITS.QUEUE_USER_MAX },
+        memory,
+        db,
+        orphanedQueued: Math.max(0, db.queued - memory.pending),
+    }));
+}));

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -10,6 +10,7 @@
  */
 
 import { Application, Request, Response } from 'express';
+import { agentTaskQueueRouter } from './agent-task-queue.routes';
 import * as path from 'path';
 import * as fs from 'fs';
 
@@ -273,6 +274,7 @@ export function setupApiRoutes(
     app.use('/api/agents-monitoring', agentsMonitoringRouter);
     app.use('/api/audit', auditRouter);
     app.use('/api/research', researchRouter);
+    app.use('/api/agent-tasks', agentTaskQueueRouter);   // /queue/stats — /:id 라우트보다 먼저
     app.use('/api/agent-tasks', agentTaskRouter);
     // 청크 업로드 — Cloudflare 요청당 100MB 상한 우회 (대용량 첨부는 조각으로 수신)
     app.use('/api/agent-task-uploads', agentTaskUploadRouter);

--- a/apps/api/src/services/agent-task/boot-recovery.test.ts
+++ b/apps/api/src/services/agent-task/boot-recovery.test.ts
@@ -1,0 +1,81 @@
+/**
+ * 부팅 복구 — 'queued' 고아 회수.
+ *
+ * 큐(3-B)는 인메모리라 재시작하면 대기열이 증발하는데 DB 행은 'queued' 로 남았다. 종전 복구는
+ * running/paused/restart-마킹만 봐서 이 행은 영원히 '대기 중' 이었다(2026-08-25 발견).
+ * queued 는 시작한 적이 없으므로 checkpoint 없이 처음부터 다시 디스패치되어야 한다.
+ */
+const updateAgentTask = jest.fn(async () => undefined);
+const getAgentTaskSteps = jest.fn(async () => []);
+const getUserById = jest.fn(async () => ({ role: 'user' }));
+const claim = jest.fn(async () => true);
+const interrupted: unknown[] = [];
+
+jest.mock('../../data/models/unified-database', () => ({
+    getUnifiedDatabase: () => ({ updateAgentTask, getAgentTaskSteps, getUserById }),
+    getPool: () => ({}),
+}));
+jest.mock('../../data/repositories/agent-task-repository', () => ({
+    AgentTaskRepository: jest.fn().mockImplementation(() => ({
+        getInterruptedAgentTasks: async () => interrupted,
+        claimAgentTaskForRecovery: claim,
+    })),
+}));
+jest.mock('../../config/runtime-limits', () => ({
+    AGENT_TASK_LIMITS: { BOOT_RECOVERY_ENABLED: true, BOOT_RECOVERY_WINDOW_MS: 60_000 },
+}));
+const execute = jest.fn(async () => undefined);
+jest.mock('../AgentTaskService', () => ({ AgentTaskService: jest.fn().mockImplementation(() => ({ execute })) }));
+const dispatch = jest.fn(async (entry: { run: () => Promise<void> }) => { await entry.run(); return 'started'; });
+jest.mock('./task-queue', () => ({ dispatchAgentTask: (e: never) => dispatch(e) }));
+
+import { recoverInterruptedAgentTasks } from './boot-recovery';
+
+beforeEach(() => { interrupted.length = 0; jest.clearAllMocks(); });
+
+const base = { id: 't1', user_id: 'u1', goal: '목표', max_turns: 10, executor: 'server', input_files: null, input_images: null };
+
+describe('recoverInterruptedAgentTasks — queued 고아', () => {
+    it('queued 는 checkpoint 없이도 처음부터 재디스패치된다', async () => {
+        interrupted.push({ ...base, status: 'queued', checkpoint: null });
+        const r = await recoverInterruptedAgentTasks();
+        expect(r).toEqual({ resumed: 1, failed: 0 });
+        expect(claim).toHaveBeenCalledWith('t1');
+        expect(execute).toHaveBeenCalledTimes(1);
+        const input = (execute.mock.calls[0] as unknown[])[0] as Record<string, unknown>;
+        expect(input.resume).toBeUndefined();          // 처음부터
+        expect(input.goal).toBe('목표');
+        expect(updateAgentTask).not.toHaveBeenCalled(); // failed 로 정리하지 않는다
+    });
+
+    it('running 인데 checkpoint 가 없으면 종전대로 failed(interrupted)', async () => {
+        interrupted.push({ ...base, status: 'running', checkpoint: null });
+        const r = await recoverInterruptedAgentTasks();
+        expect(r).toEqual({ resumed: 0, failed: 1 });
+        expect(updateAgentTask).toHaveBeenCalledWith('t1', expect.objectContaining({ status: 'failed', error: 'interrupted' }));
+        expect(execute).not.toHaveBeenCalled();
+    });
+
+    it('checkpoint 가 있으면 resume 으로 재개된다 (기존 동작 보존)', async () => {
+        interrupted.push({ ...base, status: 'failed', checkpoint: { conversation: [{ role: 'user', content: 'x' }], completedTurn: 2 } });
+        const r = await recoverInterruptedAgentTasks();
+        expect(r.resumed).toBe(1);
+        const input = (execute.mock.calls[0] as unknown[])[0] as Record<string, { fromTurn: number }>;
+        expect(input.resume.fromTurn).toBe(3);
+    });
+
+    it('queued 라도 로컬 실행 작업은 디바이스 미연결이라 failed 로 보류한다', async () => {
+        interrupted.push({ ...base, status: 'queued', executor: 'local', checkpoint: null });
+        const r = await recoverInterruptedAgentTasks();
+        expect(r).toEqual({ resumed: 0, failed: 1 });
+        expect(updateAgentTask).toHaveBeenCalledWith('t1', expect.objectContaining({ error: 'interrupted_local_device' }));
+    });
+
+    it('claim 에 실패하면(다른 프로세스가 선점) 건너뛴다', async () => {
+        claim.mockResolvedValueOnce(false);
+        interrupted.push({ ...base, status: 'queued', checkpoint: null });
+        const r = await recoverInterruptedAgentTasks();
+        expect(r).toEqual({ resumed: 0, failed: 0 });
+        expect(execute).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/services/agent-task/boot-recovery.ts
+++ b/apps/api/src/services/agent-task/boot-recovery.ts
@@ -52,8 +52,10 @@ export async function recoverInterruptedAgentTasks(): Promise<{ resumed: number;
         try {
             const cp = task.checkpoint as { conversation?: unknown[]; completedTurn?: number } | null | undefined;
             const hasCheckpoint = !!cp && Array.isArray(cp.conversation) && cp.conversation.length > 0;
-
-            if (!hasCheckpoint) {
+            // 'queued' 는 인메모리 대기열에 있다가 재시작으로 증발한 것 — 시작한 적이 없으니
+            // checkpoint 도 없다. 처음부터 다시 디스패치한다(로컬 실행은 아래 규칙대로 보류).
+            const wasQueued = task.status === 'queued';
+            if (!hasCheckpoint && !wasQueued) {
                 // 재개 지점이 없음. restart 마킹(failed)은 이미 정리된 상태이므로 건드리지 않고,
                 // 잔존 running/paused 만 실패(interrupted)로 정리(완료 오표시·영구 polling 방지).
                 if (task.status === 'running' || task.status === 'paused') {
@@ -69,7 +71,7 @@ export async function recoverInterruptedAgentTasks(): Promise<{ resumed: number;
             // 미연결로 실패한다. 상태만 failed(interrupted)로 정리해 완료 오표시·영구 polling 을
             // 막고, 사용자가 디바이스 재연결 후 /resume 으로 수동 재개하게 한다.
             if (task.executor === 'local') {
-                if (task.status === 'running' || task.status === 'paused') {
+                if (task.status === 'running' || task.status === 'paused' || wasQueued) {
                     await db.updateAgentTask(task.id, { status: 'failed', error: 'interrupted_local_device' });
                     failed++;
                     logger.info(`[BootRecovery] 로컬 실행 작업 자동재개 보류 → failed(디바이스 재연결 후 수동 resume): ${task.id}`);
@@ -97,15 +99,19 @@ export async function recoverInterruptedAgentTasks(): Promise<{ resumed: number;
                     maxTurns: task.max_turns,
                     files: Array.isArray(task.input_files) ? task.input_files as AgentTaskInputFile[] : undefined,
                     images: Array.isArray(task.input_images) ? task.input_images as string[] : undefined,
-                    resume: {
-                        conversation: cp!.conversation as ChatMessage[],
-                        fromTurn: (cp!.completedTurn ?? 0) + 1,
-                        fromStep: steps.length,
-                    },
+                    ...(hasCheckpoint ? {
+                        resume: {
+                            conversation: cp!.conversation as ChatMessage[],
+                            fromTurn: (cp!.completedTurn ?? 0) + 1,
+                            fromStep: steps.length,
+                        },
+                    } : {}),
                 }),
             });
             resumed++;
-            logger.info(`[BootRecovery] 자동 재개: ${task.id} (turn ${(cp!.completedTurn ?? 0) + 1})`);
+            logger.info(hasCheckpoint
+                ? `[BootRecovery] 자동 재개: ${task.id} (turn ${(cp!.completedTurn ?? 0) + 1})`
+                : `[BootRecovery] 대기열 증발분 재디스패치: ${task.id}`);
         } catch (e) {
             logger.warn(`[BootRecovery] task 복구 실패(건너뜀): ${task.id} — ${e instanceof Error ? e.message : e}`);
         }


### PR DESCRIPTION
## 배경 — Task Queue "부분" 판정의 실체

점검해 보니 동시성 큐(`AgentTaskQueue`, 전역 4/유저 2)와 checkpoint 자동 재개(boot-recovery)는
**이미 있고 운영 ON** 이었다(`AGENT_TASK_QUEUE_ENABLED=true`). 남아 있던 실제 구멍은 아래다.

## 결함

큐는 인메모리다. 상한을 넘겨 `queued` 로 대기하던 작업은 재시작하면 대기열과 함께 증발하는데
DB 행은 `queued` 로 남는다.

| 부팅 단계 | 보는 상태 | `queued` |
|---|---|---|
| schema-initializer 재시작 마킹 | running · paused | ✗ |
| boot-recovery | running · paused · failed('server restarted') | ✗ |

→ 아무도 집지 않아 UI 는 영구 '대기 중'(활성 취급, 폴링 지속).

## 변경

- `getInterruptedAgentTasks` · `claimAgentTaskForRecovery` 에 `'queued'` 포함
- boot-recovery: queued 는 시작한 적이 없으니 **checkpoint 없이 처음부터 재디스패치**. 로컬 실행 작업은 기존 규칙(디바이스 재연결까지 보류) 유지
- **`GET /api/agent-tasks/queue/stats`** (admin) — 인메모리 스냅샷 + DB 집계 + `orphanedQueued`. 큐 상태를 볼 곳이 없었다. `agent-task.routes.ts` 가 594줄이라 별도 파일, `/:id` 보다 먼저 마운트

## 하지 않은 것 (의도)

- **SIGTERM 시 abort** — abort 는 `cancelled` 를 만들어 자동 재개에서 빠진다. 프로세스 종료 → 다음 부팅 `failed('server restarted')` 마킹 → checkpoint 재개가 durability 에 더 맞다.
- **분산 큐(Redis/BullMQ)** — 범위 밖. 단일 프로세스 전제는 모듈 헤더에 이미 명시.

## 실측

운영 DB(2026-08-25): `queued` 고아 **0건** — 예방 수정. 상한이 실제로 걸린 상태에서 재시작이 겹치면 재현된다.

## 체크리스트

- [x] 테스트 5건 (queued 재디스패치 / running 무checkpoint→failed / checkpoint 재개 보존 / 로컬 보류 / claim 실패 skip)
- [x] `npm test` 2,964건 통과, lint 에러 0 (routes 의 직접 SQL 금지 룰 → repository 경유로 수정), Gate 3 위반 0
- [ ] 배포 후 `/queue/stats` 라이브 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)