### PR TITLE
feat(marketplace): 발행형 — 내가 만든 스킬·Custom Agent·MCP 설정을 플러그인 번들로 게시 (PR)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1505,3 +1505,11 @@ CHAT_USER_MCP_SCHEMA_BUDGET_BYTES=16000
 # OAUTH_REDIRECT_URI 의 origin(운영 https://chat.openmake.cc)에서 유도한다. 다른 origin 을
 # 써야 할 때만 아래를 지정한다. 값이 바뀌면 기존 동적 등록은 무효(재로그인 시 자동 재등록).
 # MCP_OAUTH_REDIRECT_BASE=https://chat.openmake.cc
+
+# *******************************************************
+# 마켓플레이스 게시 (config/marketplace-publish.ts)
+# *******************************************************
+# 사용자가 만든 스킬·Custom Agent·MCP 설정을 플러그인 번들로 묶어 마켓플레이스 레포에 PR 로 올린다.
+# 토큰은 요청 body.accessToken 이 우선이고, 아래는 그 폴백이다 (repo 쓰기 권한 필요).
+# MARKETPLACE_REPO=openmake/openmake-marketplace
+# MARKETPLACE_PUBLISH_TOKEN=

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -92,6 +92,10 @@ export const envSchema = z
         OAUTH_REDIRECT_URI: z.string().default(`http://localhost:${SERVER_CONFIG.DEFAULT_PORT}/api/auth/callback/google`),
         /** 원격 MCP OAuth 콜백 origin 강제 (선택) — config/mcp-oauth.ts */
         MCP_OAUTH_REDIRECT_BASE: z.string().url().optional(),
+        /** 마켓플레이스 게시 대상 레포 owner/repo (config/marketplace-publish.ts) */
+        MARKETPLACE_REPO: z.string().regex(/^[\w.-]+\/[\w.-]+$/).optional(),
+        /** 마켓플레이스 게시용 GitHub 토큰 — 요청 body.accessToken 이 없을 때의 폴백 */
+        MARKETPLACE_PUBLISH_TOKEN: z.string().max(200).optional(),
 
         // CORS
         CORS_ORIGINS: z.string().default(`http://localhost:${SERVER_CONFIG.DEFAULT_PORT}`),

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -48,6 +48,10 @@ export interface EnvConfig {
     oauthRedirectUri: string;
     /** 원격 MCP OAuth 콜백의 origin 강제 (선택). 미설정 시 OAUTH_REDIRECT_URI 의 origin 에서 유도 */
     mcpOAuthRedirectBase?: string;
+    /** 마켓플레이스 게시 레포 (owner/repo). 미설정 시 openmake/openmake-marketplace */
+    marketplaceRepo?: string;
+    /** 마켓플레이스 게시 GitHub 토큰 폴백 (body.accessToken 우선) */
+    marketplacePublishToken?: string;
 
     // CORS
     corsOrigins: string;
@@ -334,6 +338,8 @@ export function loadConfig(): EnvConfig {
         KAKAO_CLIENT_SECRET: env('KAKAO_CLIENT_SECRET'),
         OAUTH_REDIRECT_URI: env('OAUTH_REDIRECT_URI'),
         MCP_OAUTH_REDIRECT_BASE: env('MCP_OAUTH_REDIRECT_BASE'),
+        MARKETPLACE_REPO: env('MARKETPLACE_REPO'),
+        MARKETPLACE_PUBLISH_TOKEN: env('MARKETPLACE_PUBLISH_TOKEN'),
         DB_POOL_MAX: env('DB_POOL_MAX'),
         DB_POOL_MIN: env('DB_POOL_MIN'),
         CORS_ORIGINS: env('CORS_ORIGINS'),
@@ -447,6 +453,8 @@ export function loadConfig(): EnvConfig {
         kakaoClientSecret: parsed.KAKAO_CLIENT_SECRET ?? DEFAULT_CONFIG.kakaoClientSecret,
         oauthRedirectUri: parsed.OAUTH_REDIRECT_URI ?? DEFAULT_CONFIG.oauthRedirectUri,
         mcpOAuthRedirectBase: parsed.MCP_OAUTH_REDIRECT_BASE || undefined,
+        marketplaceRepo: parsed.MARKETPLACE_REPO || undefined,
+        marketplacePublishToken: parsed.MARKETPLACE_PUBLISH_TOKEN || undefined,
 
         // CORS
         corsOrigins: parsed.CORS_ORIGINS ?? DEFAULT_CONFIG.corsOrigins,

--- a/apps/api/src/config/marketplace-publish.ts
+++ b/apps/api/src/config/marketplace-publish.ts
@@ -1,0 +1,41 @@
+/**
+ * 마켓플레이스 게시(발행형 (b)) 설정 — L2 config.
+ *
+ * 사용자가 만든 스킬·Custom Agent·MCP 설정을 플러그인 번들(`plugins/<name>/…`)로 묶어
+ * `openmake/openmake-marketplace` 에 **PR 로** 올린다. main 직접 push 는 하지 않는다 —
+ * 그 레포의 규칙("재검증 후 커밋")과 같은 승인 게이트를 사람이 PR 리뷰로 잡는다.
+ *
+ * @module config/marketplace-publish
+ */
+import { getConfig } from './env';
+
+/** 기본 게시 대상 레포 (owner/repo). env MARKETPLACE_REPO 로 오버라이드 */
+export const MARKETPLACE_DEFAULT_REPO = 'openmake/openmake-marketplace';
+
+/** 레포 안 경로 규칙 — marketplace.json 의 상대경로 엔트리(`./plugins/<name>`)와 한 쌍 */
+export const MARKETPLACE_PATHS = {
+    index: '.claude-plugin/marketplace.json',
+    pluginsDir: 'plugins',
+    branchPrefix: 'publish/',
+} as const;
+
+/** 한 번에 묶을 수 있는 구성요소 상한 — PR 리뷰 가능한 크기로 제한 */
+export const MARKETPLACE_PUBLISH_LIMITS = {
+    maxSkills: 30,
+    maxAgents: 20,
+    maxMcpServers: 10,
+    /** 스킬 번들 파일(scripts/·references/) 개당·합계 상한 */
+    maxAssetBytes: 256 * 1024,
+    maxTotalBytes: 4 * 1024 * 1024,
+    pluginNameMax: 80,
+} as const;
+
+/** 게시자 정보 — plugin.json author */
+export const MARKETPLACE_AUTHOR = { name: 'OpenMake', url: 'https://github.com/openmake' } as const;
+
+export function resolveMarketplaceRepo(): { owner: string; repo: string } {
+    const raw = getConfig().marketplaceRepo || MARKETPLACE_DEFAULT_REPO;
+    const [owner, repo] = raw.split('/');
+    if (!owner || !repo) throw new Error(`MARKETPLACE_REPO 형식 오류 (owner/repo): ${raw}`);
+    return { owner, repo };
+}

--- a/apps/api/src/config/system-settings-registry.ts
+++ b/apps/api/src/config/system-settings-registry.ts
@@ -64,6 +64,7 @@ export const SYSTEM_SETTINGS_REGISTRY: SystemSettingDef[] = [
     // ── OAuth (소셜 로그인) — 미설정 시 해당 provider 로그인 비활성 ──
     { key: 'GOOGLE_CLIENT_ID', group: 'oauth', secret: false, requiresRestart: false, validate: nonEmpty, issueUrl: ISSUE_URLS.googleCloud },
     { key: 'GOOGLE_CLIENT_SECRET', group: 'oauth', secret: true, requiresRestart: false, validate: nonEmpty, issueUrl: ISSUE_URLS.googleCloud },
+    { key: 'MARKETPLACE_PUBLISH_TOKEN', group: 'oauth', secret: true, requiresRestart: false, validate: nonEmpty },
     { key: 'OAUTH_REDIRECT_URI', group: 'oauth', secret: false, requiresRestart: false, validate: httpUrl },
     { key: 'GITHUB_CLIENT_ID', group: 'oauth', secret: false, requiresRestart: false, validate: nonEmpty, issueUrl: ISSUE_URLS.github },
     { key: 'GITHUB_CLIENT_SECRET', group: 'oauth', secret: true, requiresRestart: false, validate: nonEmpty, issueUrl: ISSUE_URLS.github },

--- a/apps/api/src/data/repositories/marketplace-export-repository.ts
+++ b/apps/api/src/data/repositories/marketplace-export-repository.ts
@@ -1,0 +1,91 @@
+/**
+ * 마켓플레이스 게시용 읽기 저장소 — 사용자가 **직접 만든** 구성요소만 내보낸다.
+ *
+ * 확장에서 설치된 것(extension_id IS NOT NULL)은 상류가 따로 있으니 재배포하지 않는다(라이선스·
+ * 중복). MCP 는 env **키만** 읽는다 — 값(자격증명)은 어떤 경로로도 레포에 나가면 안 된다.
+ *
+ * @module data/repositories/marketplace-export-repository
+ */
+import type { Pool } from 'pg';
+
+export interface ExportSkill {
+    id: string;
+    name: string;
+    description: string | null;
+    content: string;
+    category: string | null;
+    manifest_meta: Record<string, unknown> | null;
+}
+export interface ExportSkillAsset { skill_id: string; rel_path: string; content_type: string | null; content: Buffer }
+export interface ExportAgent { id: string; name: string; description: string | null; system_prompt: string; model: string | null }
+export interface ExportMcpServer {
+    id: string;
+    name: string;
+    transport_type: 'stdio' | 'sse' | 'streamable-http';
+    command: string | null;
+    args: unknown[] | null;
+    url: string | null;
+    /** env 키 목록만 — 값은 절대 읽지 않는다 */
+    env_keys: string[];
+}
+
+export class MarketplaceExportRepository {
+    constructor(private readonly pool: Pool) {}
+
+    /** 게시 후보 목록 (소유자 한정, 확장 유래 제외) */
+    async listCandidates(userId: string): Promise<{ skills: Omit<ExportSkill, 'content' | 'manifest_meta'>[]; agents: Omit<ExportAgent, 'system_prompt'>[]; mcpServers: ExportMcpServer[] }> {
+        const [s, a, m] = await Promise.all([
+            this.pool.query<Omit<ExportSkill, 'content' | 'manifest_meta'>>(
+                `SELECT id, name, description, category FROM agent_skills
+                  WHERE created_by = $1 AND status = 'active' AND extension_id IS NULL ORDER BY updated_at DESC`, [userId]),
+            this.pool.query<Omit<ExportAgent, 'system_prompt'>>(
+                `SELECT id, name, description, model FROM user_agents
+                  WHERE user_id = $1 AND is_active = TRUE AND extension_id IS NULL ORDER BY updated_at DESC`, [userId]),
+            this.pool.query<ExportMcpServer>(
+                `SELECT id, name, transport_type, command, args, url,
+                        COALESCE((SELECT array_agg(k ORDER BY k) FROM jsonb_object_keys(COALESCE(env, '{}'::jsonb)) k), '{}') AS env_keys
+                   FROM mcp_servers
+                  WHERE user_id = $1 AND status IS DISTINCT FROM 'draft' AND extension_id IS NULL ORDER BY name`, [userId]),
+        ]);
+        return { skills: s.rows, agents: a.rows, mcpServers: m.rows };
+    }
+
+    /** listCandidates 의 fail-open 판 — 한 축의 조회 실패가 목록 전체를 죽이지 않게 */
+    async getCandidatesSafe(userId: string): Promise<Awaited<ReturnType<MarketplaceExportRepository['listCandidates']>>> {
+        try { return await this.listCandidates(userId); }
+        catch { return { skills: [], agents: [], mcpServers: [] }; }
+    }
+
+    async getSkills(userId: string, ids: string[]): Promise<ExportSkill[]> {
+        if (ids.length === 0) return [];
+        const r = await this.pool.query<ExportSkill>(
+            `SELECT id, name, description, content, category, manifest_meta FROM agent_skills
+              WHERE created_by = $1 AND id = ANY($2::text[]) AND status = 'active' AND extension_id IS NULL`, [userId, ids]);
+        return r.rows;
+    }
+
+    async getSkillAssets(skillIds: string[]): Promise<ExportSkillAsset[]> {
+        if (skillIds.length === 0) return [];
+        const r = await this.pool.query<ExportSkillAsset>(
+            `SELECT skill_id, rel_path, content_type, content FROM skill_assets WHERE skill_id = ANY($1::text[]) ORDER BY skill_id, rel_path`, [skillIds]);
+        return r.rows;
+    }
+
+    async getAgents(userId: string, ids: string[]): Promise<ExportAgent[]> {
+        if (ids.length === 0) return [];
+        const r = await this.pool.query<ExportAgent>(
+            `SELECT id, name, description, system_prompt, model FROM user_agents
+              WHERE user_id = $1 AND id = ANY($2::text[]) AND is_active = TRUE AND extension_id IS NULL`, [userId, ids]);
+        return r.rows;
+    }
+
+    async getMcpServers(userId: string, ids: string[]): Promise<ExportMcpServer[]> {
+        if (ids.length === 0) return [];
+        const r = await this.pool.query<ExportMcpServer>(
+            `SELECT id, name, transport_type, command, args, url,
+                    COALESCE((SELECT array_agg(k ORDER BY k) FROM jsonb_object_keys(COALESCE(env, '{}'::jsonb)) k), '{}') AS env_keys
+               FROM mcp_servers
+              WHERE user_id = $1 AND id = ANY($2::text[]) AND status IS DISTINCT FROM 'draft' AND extension_id IS NULL`, [userId, ids]);
+        return r.rows;
+    }
+}

--- a/apps/api/src/routes/marketplace-publish.routes.ts
+++ b/apps/api/src/routes/marketplace-publish.routes.ts
@@ -1,0 +1,79 @@
+/**
+ * 마켓플레이스 게시 (발행형 (b)) — mount: `/api/marketplace`
+ *
+ *   GET  /publish/candidates   내가 만든 스킬·Custom Agent·MCP (확장 유래 제외)
+ *   POST /publish              (admin) 번들 → 새 브랜치 커밋 → PR. { prUrl, branch, files }
+ *
+ * 공개 레포에 쓰는 행위라 admin 한정. 구성요소는 요청자 소유만 묶인다(저장소 쿼리가 강제).
+ * 토큰: body.accessToken > MARKETPLACE_PUBLISH_TOKEN. MCP 자격증명 값은 절대 나가지 않는다(키만).
+ *
+ * @module routes/marketplace-publish.routes
+ */
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+import { requireAuth, requireAdmin } from '../auth';
+import { validate } from '../middlewares/validation';
+import { asyncHandler } from '../utils/error-handler';
+import { success, badRequest } from '../utils/api-response';
+import { getPool } from '../data/models/unified-database';
+import { getConfig } from '../config/env';
+import { MarketplaceExportRepository } from '../data/repositories/marketplace-export-repository';
+import { buildPluginBundle, validatePluginName } from '../services/marketplace/plugin-bundle-builder';
+import { GithubPublisher } from '../services/marketplace/github-publisher';
+import { MARKETPLACE_PATHS, MARKETPLACE_PUBLISH_LIMITS, resolveMarketplaceRepo } from '../config/marketplace-publish';
+import { getAuditService } from '../services/AuditService';
+
+export const marketplacePublishRouter = Router();
+
+const publishSchema = z.object({
+    pluginName: z.string().min(1).max(MARKETPLACE_PUBLISH_LIMITS.pluginNameMax),
+    description: z.string().max(500).optional(),
+    version: z.string().regex(/^\d+\.\d+\.\d+$/).optional(),
+    category: z.string().max(60).optional(),
+    skillIds: z.array(z.string().max(80)).max(MARKETPLACE_PUBLISH_LIMITS.maxSkills).default([]),
+    agentIds: z.array(z.string().max(80)).max(MARKETPLACE_PUBLISH_LIMITS.maxAgents).default([]),
+    mcpServerIds: z.array(z.string().max(80)).max(MARKETPLACE_PUBLISH_LIMITS.maxMcpServers).default([]),
+    accessToken: z.string().max(200).optional(),
+});
+
+marketplacePublishRouter.get('/publish/candidates', requireAuth, asyncHandler(async (req: Request, res: Response) => {
+    const userId = String(req.user?.id ?? '');
+    const repo = new MarketplaceExportRepository(getPool());
+    res.json(success({ ...(await repo.getCandidatesSafe(userId)), repo: resolveMarketplaceRepo() }));
+}));
+
+marketplacePublishRouter.post('/publish', requireAuth, requireAdmin, validate(publishSchema), asyncHandler(async (req: Request, res: Response) => {
+    const userId = String(req.user?.id ?? '');
+    const body = req.body as z.infer<typeof publishSchema>;
+    const nameErr = validatePluginName(body.pluginName);
+    if (nameErr) { res.status(400).json(badRequest(nameErr)); return; }
+    const token = body.accessToken || getConfig().marketplacePublishToken;
+    if (!token) { res.status(400).json(badRequest('GitHub 토큰이 필요합니다 (accessToken 또는 MARKETPLACE_PUBLISH_TOKEN)')); return; }
+
+    const repo = new MarketplaceExportRepository(getPool());
+    const [skills, agents, mcpServers] = await Promise.all([
+        repo.getSkills(userId, body.skillIds), repo.getAgents(userId, body.agentIds), repo.getMcpServers(userId, body.mcpServerIds),
+    ]);
+    // 요청한 id 가 소유·활성 조건을 못 넘으면 조용히 빠진다 — 그 사실을 응답에 드러낸다
+    const missing = {
+        skills: body.skillIds.filter((id) => !skills.some((s) => s.id === id)),
+        agents: body.agentIds.filter((id) => !agents.some((a) => a.id === id)),
+        mcpServers: body.mcpServerIds.filter((id) => !mcpServers.some((m) => m.id === id)),
+    };
+    const assets = await repo.getSkillAssets(skills.map((s) => s.id));
+    const bundle = buildPluginBundle({ pluginName: body.pluginName, description: body.description, version: body.version, category: body.category, skills, assets, agents, mcpServers });
+
+    const { owner, repo: repoName } = resolveMarketplaceRepo();
+    const stamp = new Date().toISOString().replace(/[-:]/g, '').slice(0, 13).replace('T', '-');
+    const summary = `skills ${skills.length} · agents ${agents.length} · mcp ${mcpServers.length}`;
+    const result = await new GithubPublisher(token).publish({
+        owner, repo: repoName, files: bundle.files, marketplaceEntry: bundle.marketplaceEntry, token,
+        branchName: `${MARKETPLACE_PATHS.branchPrefix}${body.pluginName}-${stamp}`,
+        commitMessage: `feat(plugins): publish ${body.pluginName} from openmake_llm (${summary})`,
+        prTitle: `publish: ${body.pluginName} (${summary})`,
+        prBody: `openmake_llm 에서 게시한 플러그인 번들입니다.\n\n- ${summary}\n- 경로: \`${bundle.pluginDir}\`\n- MCP env 는 자리표시자(\`\${KEY}\`)만 포함됩니다.\n\n리뷰 후 머지하면 카탈로그 재동기화 시 설치 가능해집니다.`,
+    });
+
+    getAuditService().logAudit({ userId, action: 'marketplace.publish', resourceType: 'marketplace', resourceId: `${owner}/${repoName}`, details: { plugin: body.pluginName, prUrl: result.prUrl, missing } }).catch(() => { /* noop */ });
+    res.json(success({ ...result, plugin: body.pluginName, bytes: bundle.totalBytes, missing }));
+}));

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -12,6 +12,7 @@
 import { Application, Request, Response } from 'express';
 import { agentTaskQueueRouter } from './agent-task-queue.routes';
 import { mcpOAuthRouter } from './mcp-oauth.routes';
+import { marketplacePublishRouter } from './marketplace-publish.routes';
 import * as path from 'path';
 import * as fs from 'fs';
 
@@ -177,6 +178,7 @@ export function setupApiRoutes(
     app.use('/api/monitoring', tokenMonitoringRouter);
     app.use('/api/mcp', mcpRouter);
     app.use('/api/mcp', mcpOAuthRouter);   // 원격 MCP OAuth (start/callback/logout)
+    app.use('/api/marketplace', marketplacePublishRouter);   // 마켓플레이스 게시 (발행형)
     app.use('/api/mcp', mcpCatalogRouter);
     app.use('/api/mcp', notebooklmRouter);
     const e2eMcpMock = process.env.MCP_INGEST_E2E_MOCK === 'true';

--- a/apps/api/src/services/marketplace/github-publisher.ts
+++ b/apps/api/src/services/marketplace/github-publisher.ts
@@ -1,0 +1,93 @@
+/**
+ * GitHub 게시자 — 번들 파일을 새 브랜치에 커밋하고 PR 을 연다 (Git Data API).
+ *
+ * main 에 직접 push 하지 않는다. 마켓플레이스 레포의 규칙("재검증 후 커밋")을 사람이 PR 리뷰로
+ * 잡는다. marketplace.json 은 base 커밋의 것을 읽어 엔트리를 merge 한 뒤 같은 커밋에 넣는다
+ * (같은 이름이 있으면 교체 — 재게시 = 갱신).
+ *
+ * 외부 호출은 전부 `createPinnedFetch`(SSRF 가드). 토큰은 호출자가 넘긴다(요청 body 우선, env 폴백).
+ *
+ * @module services/marketplace/github-publisher
+ */
+import { createPinnedFetch } from '../../security/ssrf-guard';
+import { MARKETPLACE_PATHS } from '../../config/marketplace-publish';
+import type { BundleFile } from './plugin-bundle-builder';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('GithubPublisher');
+const API = 'https://api.github.com';
+
+export interface PublishInput {
+    owner: string;
+    repo: string;
+    token: string;
+    files: BundleFile[];
+    marketplaceEntry: { name: string; description: string; category: string; source: string };
+    branchName: string;
+    commitMessage: string;
+    prTitle: string;
+    prBody: string;
+    baseBranch?: string;
+}
+
+export interface PublishResult { branch: string; commitSha: string; prUrl: string; prNumber: number; files: string[] }
+
+export class GithubPublisher {
+    private readonly fetch = createPinnedFetch();
+
+    constructor(private readonly token: string) {}
+
+    private async api<T>(method: string, path: string, body?: unknown): Promise<T> {
+        const res = await this.fetch(`${API}${path}`, {
+            method,
+            headers: {
+                Authorization: `Bearer ${this.token}`,
+                Accept: 'application/vnd.github+json',
+                'User-Agent': 'openmake-llm-marketplace-publisher',
+                ...(body ? { 'Content-Type': 'application/json' } : {}),
+            },
+            body: body ? JSON.stringify(body) : undefined,
+        });
+        if (!res.ok) {
+            const text = (await res.text()).slice(0, 300);
+            throw new Error(`GitHub ${method} ${path} → ${res.status}: ${text}`);
+        }
+        return res.json() as Promise<T>;
+    }
+
+    async publish(input: PublishInput): Promise<PublishResult> {
+        const { owner, repo } = input;
+        const base = input.baseBranch ?? (await this.api<{ default_branch: string }>('GET', `/repos/${owner}/${repo}`)).default_branch;
+        const ref = await this.api<{ object: { sha: string } }>('GET', `/repos/${owner}/${repo}/git/ref/heads/${encodeURIComponent(base)}`);
+        const baseSha = ref.object.sha;
+        const baseCommit = await this.api<{ tree: { sha: string } }>('GET', `/repos/${owner}/${repo}/git/commits/${baseSha}`);
+
+        // marketplace.json merge — base 시점 내용을 읽어 같은 이름은 교체
+        const idxPath = MARKETPLACE_PATHS.index;
+        const idxRes = await this.api<{ content: string; encoding: string }>('GET', `/repos/${owner}/${repo}/contents/${idxPath}?ref=${baseSha}`);
+        const index = JSON.parse(Buffer.from(idxRes.content, 'base64').toString('utf8')) as { plugins: Array<{ name: string }> };
+        const plugins = index.plugins.filter((p) => p.name !== input.marketplaceEntry.name);
+        plugins.push(input.marketplaceEntry);
+        const indexText = JSON.stringify({ ...index, plugins }, null, 2) + '\n';
+
+        // blobs → tree → commit → ref → PR
+        const allFiles: BundleFile[] = [...input.files, { path: idxPath, content: indexText }];
+        const treeEntries = [];
+        for (const f of allFiles) {
+            const isBuf = Buffer.isBuffer(f.content);
+            const blob = await this.api<{ sha: string }>('POST', `/repos/${owner}/${repo}/git/blobs`, {
+                content: isBuf ? (f.content as Buffer).toString('base64') : f.content,
+                encoding: isBuf ? 'base64' : 'utf-8',
+            });
+            treeEntries.push({ path: f.path, mode: '100644', type: 'blob', sha: blob.sha });
+        }
+        const tree = await this.api<{ sha: string }>('POST', `/repos/${owner}/${repo}/git/trees`, { base_tree: baseCommit.tree.sha, tree: treeEntries });
+        const commit = await this.api<{ sha: string }>('POST', `/repos/${owner}/${repo}/git/commits`, { message: input.commitMessage, tree: tree.sha, parents: [baseSha] });
+        await this.api('POST', `/repos/${owner}/${repo}/git/refs`, { ref: `refs/heads/${input.branchName}`, sha: commit.sha });
+        const pr = await this.api<{ html_url: string; number: number }>('POST', `/repos/${owner}/${repo}/pulls`, {
+            title: input.prTitle, head: input.branchName, base, body: input.prBody,
+        });
+        logger.info(`게시 PR 생성: ${pr.html_url} (${allFiles.length} files)`);
+        return { branch: input.branchName, commitSha: commit.sha, prUrl: pr.html_url, prNumber: pr.number, files: allFiles.map((f) => f.path) };
+    }
+}

--- a/apps/api/src/services/marketplace/plugin-bundle-builder.test.ts
+++ b/apps/api/src/services/marketplace/plugin-bundle-builder.test.ts
@@ -1,0 +1,81 @@
+/**
+ * 번들 빌더 라운드트립 — 내보낸 파일을 **우리 ingest 파서가 그대로 읽어야** 한다.
+ * (내보내기만 되고 재설치가 안 되면 마켓플레이스에 올려도 쓸 수 없다.)
+ */
+import { buildPluginBundle, validatePluginName } from './plugin-bundle-builder';
+import { parseSkillFile } from '../../agents/manifest-validator';
+import { validateExtensionManifest, parseMcpJsonFile, parseMarketplaceFile } from '../../agents/git-ingest/extension-manifest-validator';
+import { agentFileToCustomAgent } from '../../agents/git-ingest/plugin-component-compat';
+
+const skills = [
+    { id: 's1', name: 'Nginx Log Error Analysis & Reporting', description: 'Nginx 로그 분석', content: '---\nname: old\n---\n**역할**\n분석한다.', category: 'technology', manifest_meta: { version: '1.0', tags: ['devops', 7] } },
+    { id: 's2', name: 'CSV 결측치 분석', description: '', content: '# Role\n결측치를 찾는다.', category: null, manifest_meta: null },
+];
+const assets = [
+    { skill_id: 's1', rel_path: 'scripts/parse.sh', content_type: 'text/x-sh', content: Buffer.from('#!/bin/sh\necho hi\n') },
+    { skill_id: 's1', rel_path: '../escape.sh', content_type: null, content: Buffer.from('x') },
+];
+const agents = [{ id: 'a1', name: 'Security Lead', description: null, system_prompt: 'You are the Security Lead.', model: null }];
+const mcp = [
+    { id: 'm1', name: 'my-stdio', transport_type: 'stdio' as const, command: 'uvx', args: ['duckduckgo-mcp-server'], url: null, env_keys: ['API_KEY'] },
+    { id: 'm2', name: 'my-remote', transport_type: 'streamable-http' as const, command: null, args: null, url: 'https://mcp.example.com/mcp', env_keys: [] },
+];
+const text = (files: { path: string; content: string | Buffer }[], p: string) => {
+    const f = files.find((x) => x.path === p); if (!f) throw new Error('없음: ' + p);
+    return typeof f.content === 'string' ? f.content : f.content.toString('utf8');
+};
+
+describe('buildPluginBundle 라운드트립', () => {
+    const b = buildPluginBundle({ pluginName: 'my-devops-pack', description: 'DevOps 묶음', skills, assets, agents, mcpServers: mcp });
+
+    it('plugin.json 이 우리 validator 를 통과한다', () => {
+        const r = validateExtensionManifest(text(b.files, 'plugins/my-devops-pack/.claude-plugin/plugin.json'));
+        expect(r.ok).toBe(true);
+    });
+
+    it('SKILL.md 는 정규 frontmatter 하나만 갖고 파서를 통과한다 (기존 frontmatter 제거·category 폴백·version 정규화)', () => {
+        const md = text(b.files, 'plugins/my-devops-pack/skills/nginx-log-error-analysis-reporting/SKILL.md');
+        expect(md.split('\n---\n').length).toBe(2);                 // frontmatter 한 벌
+        const parsed = parseSkillFile(md);
+        expect(parsed.frontmatter.name).toBe('Nginx Log Error Analysis & Reporting');
+        expect(parsed.frontmatter.category).toBe('technology');
+        expect(parsed.frontmatter.version).toBe('1.0.0');          // '1.0' 은 semver 아님 → 폴백
+        expect((parsed.frontmatter as { tags?: unknown[] }).tags).toEqual(['devops']);
+        expect(parsed.prompt_md).toContain('**역할**');
+        expect(parsed.prompt_md).not.toContain('name: old');
+        const csv = parseSkillFile(text(b.files, 'plugins/my-devops-pack/skills/csv-결측치-분석/SKILL.md'));
+        expect(csv.frontmatter.category).toBe('general');           // null → 기본
+        expect(csv.frontmatter.description).toBe('CSV 결측치 분석'); // 빈 설명 → 이름
+    });
+
+    it('번들 파일은 원본 바이트로 실리고 path traversal 은 건너뛴다', () => {
+        expect(text(b.files, 'plugins/my-devops-pack/skills/nginx-log-error-analysis-reporting/scripts/parse.sh')).toContain('echo hi');
+        expect(b.files.some((f) => f.path.includes('escape.sh'))).toBe(false);
+    });
+
+    it('agents/<slug>.md 는 Custom Agent 로 되읽힌다', () => {
+        const a = agentFileToCustomAgent('agents/security-lead.md', text(b.files, 'plugins/my-devops-pack/agents/security-lead.md'));
+        expect(a.name).toBe('Security Lead');
+        expect(a.systemPrompt.trim()).toBe('You are the Security Lead.');
+    });
+
+    it('.mcp.json 은 env 값 없이 자리표시자만 담고 우리 파서를 통과한다', () => {
+        const raw = text(b.files, 'plugins/my-devops-pack/.mcp.json');
+        expect(raw).toContain('${API_KEY}');
+        const r = parseMcpJsonFile(raw);
+        expect(r.servers.map((s) => s.name).sort()).toEqual(['my-remote', 'my-stdio']);
+        expect(r.servers.find((s) => s.name === 'my-remote')?.transportType).toBe('streamable-http');
+    });
+
+    it('marketplace 엔트리는 상대경로형이고 인덱스 파서를 통과한다', () => {
+        expect(b.marketplaceEntry.source).toBe('./plugins/my-devops-pack');
+        const idx = parseMarketplaceFile(JSON.stringify({ name: 'x', plugins: [b.marketplaceEntry] }));
+        expect(idx.ok && idx.marketplace.plugins[0].path).toBe('plugins/my-devops-pack');
+    });
+
+    it('이름 규칙·빈 번들·상한을 거부한다', () => {
+        expect(validatePluginName('My Pack')).not.toBeNull();
+        expect(validatePluginName('my-pack')).toBeNull();
+        expect(() => buildPluginBundle({ pluginName: 'empty', skills: [], assets: [], agents: [], mcpServers: [] })).toThrow(/없습니다/);
+    });
+});

--- a/apps/api/src/services/marketplace/plugin-bundle-builder.ts
+++ b/apps/api/src/services/marketplace/plugin-bundle-builder.ts
@@ -1,0 +1,159 @@
+/**
+ * 플러그인 번들 빌더 (순수) — DB 행 → 레포 파일 목록.
+ *
+ * 만드는 것은 Claude Code 플러그인 규격 그대로라 **우리 ingest 가 다시 읽을 수 있고**
+ * Claude Code 도 설치할 수 있다:
+ *
+ *   plugins/<name>/.claude-plugin/plugin.json   name · version · description · author
+ *   plugins/<name>/skills/<slug>/SKILL.md       frontmatter(name/description/category/version) + 본문
+ *   plugins/<name>/skills/<slug>/<rel_path>     스킬 번들 파일(scripts/·references/·assets/) 원본 바이트
+ *   plugins/<name>/agents/<slug>.md             frontmatter(name/description) + system_prompt
+ *   plugins/<name>/.mcp.json                    mcpServers — env 는 `${KEY}` 자리표시자만
+ *
+ * 그리고 marketplace.json 에 넣을 상대경로 엔트리(`./plugins/<name>`)를 함께 돌려준다.
+ *
+ * ⚠️ 자격증명은 어떤 형태로도 나가지 않는다 — MCP env 는 키만 받아 자리표시자로 쓴다.
+ *
+ * @module services/marketplace/plugin-bundle-builder
+ */
+import yaml from 'js-yaml';
+import { slugify } from '../../chat/slash-command';
+import { MARKETPLACE_AUTHOR, MARKETPLACE_PATHS, MARKETPLACE_PUBLISH_LIMITS } from '../../config/marketplace-publish';
+import type { ExportAgent, ExportMcpServer, ExportSkill, ExportSkillAsset } from '../../data/repositories/marketplace-export-repository';
+
+export interface BundleFile { path: string; content: string | Buffer }
+
+export interface BundleInput {
+    pluginName: string;
+    description?: string;
+    version?: string;
+    category?: string;
+    skills: ExportSkill[];
+    assets: ExportSkillAsset[];
+    agents: ExportAgent[];
+    mcpServers: ExportMcpServer[];
+}
+
+export interface BundleResult {
+    pluginDir: string;
+    files: BundleFile[];
+    /** marketplace.json plugins[] 엔트리 */
+    marketplaceEntry: { name: string; description: string; category: string; source: string };
+    totalBytes: number;
+}
+
+const PLUGIN_NAME_RE = /^[a-z0-9][a-z0-9-]{0,79}$/;
+
+export function validatePluginName(name: string): string | null {
+    if (!PLUGIN_NAME_RE.test(name)) return 'plugin 이름은 소문자/숫자/대시(kebab-case), 80자 이하';
+    if (name.length > MARKETPLACE_PUBLISH_LIMITS.pluginNameMax) return `plugin 이름은 ${MARKETPLACE_PUBLISH_LIMITS.pluginNameMax}자 이하`;
+    return null;
+}
+
+/** 스킬 본문 앞의 기존 frontmatter 는 벗긴다 — 우리가 정규 frontmatter 를 다시 씌우므로 이중이 되면 파서가 첫 것만 읽는다 */
+function stripFrontmatter(md: string): string {
+    const m = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/.exec(md);
+    return m ? md.slice(m[0].length) : md;
+}
+
+function frontmatter(obj: Record<string, unknown>): string {
+    return `---\n${yaml.dump(obj, { lineWidth: -1, noRefs: true }).trimEnd()}\n---\n`;
+}
+
+/** 이름 충돌 시 -2, -3 … 을 붙여 유일하게 */
+function uniqueSlug(base: string, taken: Set<string>): string {
+    let s = base || 'item';
+    let i = 2;
+    while (taken.has(s)) s = `${base}-${i++}`;
+    taken.add(s);
+    return s;
+}
+
+export function buildPluginBundle(input: BundleInput): BundleResult {
+    const nameErr = validatePluginName(input.pluginName);
+    if (nameErr) throw new Error(nameErr);
+    const L = MARKETPLACE_PUBLISH_LIMITS;
+    if (input.skills.length > L.maxSkills) throw new Error(`스킬은 최대 ${L.maxSkills}개`);
+    if (input.agents.length > L.maxAgents) throw new Error(`에이전트는 최대 ${L.maxAgents}개`);
+    if (input.mcpServers.length > L.maxMcpServers) throw new Error(`MCP 서버는 최대 ${L.maxMcpServers}개`);
+    if (input.skills.length + input.agents.length + input.mcpServers.length === 0) throw new Error('내보낼 구성요소가 없습니다');
+
+    const dir = `${MARKETPLACE_PATHS.pluginsDir}/${input.pluginName}`;
+    const files: BundleFile[] = [];
+    let totalBytes = 0;
+    const push = (path: string, content: string | Buffer) => {
+        const bytes = typeof content === 'string' ? Buffer.byteLength(content) : content.length;
+        totalBytes += bytes;
+        if (totalBytes > L.maxTotalBytes) throw new Error(`번들 합계가 ${L.maxTotalBytes} 바이트를 넘습니다`);
+        files.push({ path: `${dir}/${path}`, content });
+    };
+
+    // plugin.json
+    push('.claude-plugin/plugin.json', JSON.stringify({
+        name: input.pluginName,
+        version: input.version ?? '1.0.0',
+        description: input.description ?? '',
+        author: MARKETPLACE_AUTHOR,
+    }, null, 2) + '\n');
+
+    // skills
+    const skillSlugs = new Set<string>();
+    const assetsBySkill = new Map<string, ExportSkillAsset[]>();
+    for (const a of input.assets) {
+        if (!assetsBySkill.has(a.skill_id)) assetsBySkill.set(a.skill_id, []);
+        assetsBySkill.get(a.skill_id)!.push(a);
+    }
+    for (const s of input.skills) {
+        const slug = uniqueSlug(slugify(s.name), skillSlugs);
+        const meta = (s.manifest_meta ?? {}) as { version?: unknown; tags?: unknown };
+        const fm: Record<string, unknown> = {
+            name: s.name,
+            description: (s.description ?? '').trim() || s.name,
+            category: s.category || 'general',
+            version: typeof meta.version === 'string' && /^\d+\.\d+\.\d+$/.test(meta.version) ? meta.version : '1.0.0',
+        };
+        if (Array.isArray(meta.tags) && meta.tags.length) fm.tags = meta.tags.filter((t): t is string => typeof t === 'string').slice(0, 20);
+        push(`skills/${slug}/SKILL.md`, frontmatter(fm) + '\n' + stripFrontmatter(s.content).trim() + '\n');
+        for (const a of assetsBySkill.get(s.id) ?? []) {
+            const rel = a.rel_path.replace(/^\.?\//, '');
+            if (rel.includes('..') || rel.startsWith('/')) continue;  // path traversal 차단
+            if (a.content.length > L.maxAssetBytes) continue;          // 상한 초과분은 건너뜀(본문 안내는 SKILL.md 에 이미 있음)
+            push(`skills/${slug}/${rel}`, a.content);
+        }
+    }
+
+    // agents — Claude Code agents/<name>.md 규격 (frontmatter + 본문 = system prompt)
+    const agentSlugs = new Set<string>();
+    for (const ag of input.agents) {
+        const slug = uniqueSlug(slugify(ag.name), agentSlugs);
+        const fm: Record<string, unknown> = { name: ag.name, description: (ag.description ?? '').trim() || `${ag.name} 에이전트` };
+        if (ag.model) fm.model = ag.model;
+        push(`agents/${slug}.md`, frontmatter(fm) + '\n' + ag.system_prompt.trim() + '\n');
+    }
+
+    // .mcp.json — env 는 자리표시자만
+    if (input.mcpServers.length > 0) {
+        const mcpServers: Record<string, Record<string, unknown>> = {};
+        for (const m of input.mcpServers) {
+            const env = Object.fromEntries(m.env_keys.map((k) => [k, `\${${k}}`]));
+            const entry: Record<string, unknown> = m.transport_type === 'stdio'
+                ? { command: m.command, args: Array.isArray(m.args) ? m.args : [] }
+                : { type: 'http', url: m.url };
+            if (m.env_keys.length) entry.env = env;
+            mcpServers[m.name] = entry;
+        }
+        push('.mcp.json', JSON.stringify({ mcpServers }, null, 2) + '\n');
+    }
+
+    return {
+        pluginDir: dir,
+        files,
+        marketplaceEntry: {
+            name: input.pluginName,
+            description: input.description ?? '',
+            category: input.category ?? 'custom',
+            source: `./${dir}`,
+        },
+        totalBytes,
+    };
+}

--- a/apps/web/components/settings/extensions-section.tsx
+++ b/apps/web/components/settings/extensions-section.tsx
@@ -6,6 +6,7 @@ import { Package, Trash2, Loader2, ChevronDown, ChevronLeft, ChevronRight, Puzzl
 import { Button, Card, CardHeader, CardTitle, CardContent } from "@/components/ui/primitives";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { ApiClient } from "@/lib/api-client";
+import { MarketplacePublishSection } from "@/components/settings/marketplace-publish-section";
 import { useAppStore } from "@/lib/store";
 
 interface UserExtension {
@@ -750,6 +751,7 @@ export function ExtensionsSection() {
           )}
         </div>
       </CardContent>
+      <MarketplacePublishSection />
     </Card>
   );
 }

--- a/apps/web/components/settings/marketplace-publish-section.tsx
+++ b/apps/web/components/settings/marketplace-publish-section.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+/**
+ * 마켓플레이스 게시 (발행형) — 내가 만든 스킬·Custom Agent·MCP 설정을 플러그인 번들로 묶어
+ * openmake 마켓플레이스 레포에 PR 로 올린다. 확장에서 설치된 것은 후보에서 빠진다(상류가 따로 있음).
+ *
+ * 게시는 admin 만 — 공개 레포에 쓰는 행위라서. 토큰은 서버 설정(MARKETPLACE_PUBLISH_TOKEN)이
+ * 없을 때만 입력란이 뜬다.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { UploadCloud, Loader2, ExternalLink } from "lucide-react";
+import { Button, Card, CardHeader, CardTitle, CardContent, Badge } from "@/components/ui/primitives";
+import { ApiClient } from "@/lib/api-client";
+import type { ApiSuccess } from "@openmake/shared-types";
+import { useAppStore } from "@/lib/store";
+
+interface Candidates {
+  skills: { id: string; name: string; description: string | null; category: string | null }[];
+  agents: { id: string; name: string; description: string | null }[];
+  mcpServers: { id: string; name: string; transport_type: string; env_keys: string[] }[];
+  repo: { owner: string; repo: string };
+}
+interface PublishResult { prUrl: string; branch: string; files: string[]; bytes: number; missing: { skills: string[]; agents: string[]; mcpServers: string[] } }
+
+export function MarketplacePublishSection() {
+  const t = useTranslations("marketplacePublish");
+  const isAdmin = useAppStore((s) => s.auth.currentUser?.role === "admin");
+  const [cands, setCands] = useState<Candidates | null>(null);
+  const [sel, setSel] = useState<{ skills: Set<string>; agents: Set<string>; mcp: Set<string> }>({ skills: new Set(), agents: new Set(), mcp: new Set() });
+  const [pluginName, setPluginName] = useState("");
+  const [description, setDescription] = useState("");
+  const [accessToken, setAccessToken] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<PublishResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const r = await ApiClient.get<ApiSuccess<Candidates>>("/api/marketplace/publish/candidates");
+      setCands(r.data);
+    } catch { setCands({ skills: [], agents: [], mcpServers: [], repo: { owner: "", repo: "" } }); }
+  }, []);
+  useEffect(() => { void load(); }, [load]);
+
+  const toggle = (kind: "skills" | "agents" | "mcp", id: string) =>
+    setSel((p) => { const n = new Set(p[kind]); n.has(id) ? n.delete(id) : n.add(id); return { ...p, [kind]: n }; });
+  const total = sel.skills.size + sel.agents.size + sel.mcp.size;
+
+  async function publish() {
+    setBusy(true); setError(null); setResult(null);
+    try {
+      const r = await ApiClient.post<ApiSuccess<PublishResult>>("/api/marketplace/publish", {
+        pluginName: pluginName.trim(), description: description.trim() || undefined,
+        skillIds: [...sel.skills], agentIds: [...sel.agents], mcpServerIds: [...sel.mcp],
+        ...(accessToken.trim() ? { accessToken: accessToken.trim() } : {}),
+      });
+      setResult(r.data);
+    } catch (e) { setError(e instanceof Error ? e.message : String(e)); }
+    finally { setBusy(false); }
+  }
+
+  if (!cands) return null;
+  const list = <T extends { id: string; name: string }>(kind: "skills" | "agents" | "mcp", items: T[], label: string, extra?: (x: T) => string) => (
+    <div>
+      <p className="mb-1 text-xs font-medium text-muted">{label} ({items.length})</p>
+      {items.length === 0 ? <p className="text-xs text-faint">{t("none")}</p> : (
+        <ul className="max-h-40 space-y-1 overflow-y-auto rounded-md border border-border p-2">
+          {items.map((x) => (
+            <li key={x.id}>
+              <label className="flex cursor-pointer items-center gap-2 text-sm text-fg">
+                <input type="checkbox" checked={sel[kind].has(x.id)} onChange={() => toggle(kind, x.id)} />
+                <span className="truncate">{x.name}</span>
+                {extra && <span className="ml-auto text-xs text-faint">{extra(x)}</span>}
+              </label>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+
+  return (
+    <Card className="mt-6">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2"><UploadCloud className="h-4 w-4 text-accent" />{t("title")}</CardTitle>
+        <p className="mt-0.5 text-xs text-muted">{t("description", { repo: `${cands.repo.owner}/${cands.repo.repo}` })}</p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 sm:grid-cols-2">
+          <input value={pluginName} onChange={(e) => setPluginName(e.target.value)} placeholder={t("namePlaceholder")}
+            className="rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none focus:border-accent" />
+          <input value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t("descPlaceholder")}
+            className="rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none focus:border-accent" />
+        </div>
+        <div className="grid gap-4 sm:grid-cols-3">
+          {list("skills", cands.skills, t("skills"), (s) => s.category ?? "")}
+          {list("agents", cands.agents, t("agents"))}
+          {list("mcp", cands.mcpServers, t("mcp"), (m) => m.env_keys.length ? t("envPlaceholders", { n: m.env_keys.length }) : m.transport_type)}
+        </div>
+        <p className="text-xs text-muted">{t("secretNote")}</p>
+        {isAdmin ? (
+          <div className="flex flex-wrap items-center gap-2">
+            <input type="password" value={accessToken} onChange={(e) => setAccessToken(e.target.value)} placeholder={t("tokenPlaceholder")}
+              className="min-w-[16rem] rounded-md border border-border bg-surface px-3 py-2 text-xs text-fg outline-none focus:border-accent" />
+            <Button size="sm" disabled={busy || total === 0 || !pluginName.trim()} onClick={() => void publish()}>
+              {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <UploadCloud className="h-3.5 w-3.5" />}
+              {t("publish", { n: total })}
+            </Button>
+          </div>
+        ) : <Badge tone="neutral">{t("adminOnly")}</Badge>}
+        {error && <p className="text-sm text-danger">{error}</p>}
+        {result && (
+          <div className="rounded-md border border-success/40 bg-success-soft p-3 text-sm">
+            <a href={result.prUrl} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 font-medium text-accent hover:underline">
+              {t("prCreated")} <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+            <p className="mt-1 text-xs text-muted">{t("prDetail", { branch: result.branch, files: result.files.length })}</p>
+            {(result.missing.skills.length + result.missing.agents.length + result.missing.mcpServers.length) > 0 && (
+              <p className="mt-1 text-xs text-warn">{t("missing")}</p>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2058,5 +2058,23 @@
       "sendAnswer": "Send answer",
       "actionFailed": "Action failed: {error}"
     }
+  },
+  "marketplacePublish": {
+    "title": "Publish to marketplace",
+    "description": "Bundle your own skills, agents and MCP settings into a plugin and open a PR on {repo}. Once reviewed and merged it becomes installable from the catalog.",
+    "namePlaceholder": "Plugin name (lowercase, digits, dashes — e.g. my-devops-pack)",
+    "descPlaceholder": "One-line description",
+    "skills": "Skills",
+    "agents": "Custom agents",
+    "mcp": "MCP servers",
+    "none": "No candidates (items installed from extensions are excluded)",
+    "envPlaceholders": "{n} env keys → placeholders",
+    "secretNote": "MCP credential values are never exported — only key names as ${KEY} placeholders.",
+    "tokenPlaceholder": "GitHub token (leave empty if configured on the server)",
+    "publish": "Create PR ({n})",
+    "adminOnly": "Only admins can publish",
+    "prCreated": "PR created — open",
+    "prDetail": "branch {branch} · {files} files",
+    "missing": "Some items were skipped (not owned or not active)."
   }
 }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2058,5 +2058,23 @@
       "sendAnswer": "回答を送信",
       "actionFailed": "処理に失敗しました: {error}"
     }
+  },
+  "marketplacePublish": {
+    "title": "マーケットプレイスに公開",
+    "description": "自作のスキル・エージェント・MCP 設定をプラグインにまとめ {repo} に PR を作成します。レビュー後にマージされるとカタログからインストールできます。",
+    "namePlaceholder": "プラグイン名（小文字・数字・ダッシュ、例: my-devops-pack）",
+    "descPlaceholder": "一行説明",
+    "skills": "スキル",
+    "agents": "カスタムエージェント",
+    "mcp": "MCP サーバー",
+    "none": "候補なし（拡張からインストールした項目は除外）",
+    "envPlaceholders": "env {n}件 → プレースホルダー",
+    "secretNote": "MCP の認証情報は出力しません — キー名のみ ${KEY} プレースホルダーとして含まれます。",
+    "tokenPlaceholder": "GitHub トークン（サーバー設定があれば空でも可）",
+    "publish": "PR を作成（{n}件）",
+    "adminOnly": "公開は管理者のみ",
+    "prCreated": "PR を作成しました — 開く",
+    "prDetail": "ブランチ {branch} · ファイル {files}件",
+    "missing": "一部の項目は所有・有効条件を満たさずスキップされました。"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2058,5 +2058,23 @@
       "sendAnswer": "답변 보내기",
       "actionFailed": "처리 실패: {error}"
     }
+  },
+  "marketplacePublish": {
+    "title": "마켓플레이스에 게시",
+    "description": "내가 만든 스킬·에이전트·MCP 설정을 플러그인으로 묶어 {repo} 에 PR 로 올립니다. 리뷰 후 머지되면 카탈로그에서 설치할 수 있습니다.",
+    "namePlaceholder": "플러그인 이름 (소문자·숫자·대시, 예: my-devops-pack)",
+    "descPlaceholder": "한 줄 설명",
+    "skills": "스킬",
+    "agents": "커스텀 에이전트",
+    "mcp": "MCP 서버",
+    "none": "후보 없음 (확장에서 설치한 항목은 제외)",
+    "envPlaceholders": "env {n}개 → 자리표시자",
+    "secretNote": "MCP 자격증명 값은 내보내지 않습니다 — 키 이름만 ${KEY} 자리표시자로 실립니다.",
+    "tokenPlaceholder": "GitHub 토큰 (서버 설정이 있으면 비워도 됨)",
+    "publish": "PR 만들기 ({n}개)",
+    "adminOnly": "게시는 관리자만 가능합니다",
+    "prCreated": "PR 이 생성되었습니다 — 열기",
+    "prDetail": "브랜치 {branch} · 파일 {files}개",
+    "missing": "일부 항목은 소유·활성 조건을 넘지 못해 빠졌습니다."
   }
 }

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2058,5 +2058,23 @@
       "sendAnswer": "发送回复",
       "actionFailed": "操作失败：{error}"
     }
+  },
+  "marketplacePublish": {
+    "title": "发布到市场",
+    "description": "将你自己创建的技能、智能体和 MCP 配置打包为插件，并在 {repo} 上创建 PR。审核合并后即可从目录安装。",
+    "namePlaceholder": "插件名称（小写、数字、连字符，例如 my-devops-pack）",
+    "descPlaceholder": "一句话描述",
+    "skills": "技能",
+    "agents": "自定义智能体",
+    "mcp": "MCP 服务器",
+    "none": "没有候选项（从扩展安装的项目已排除）",
+    "envPlaceholders": "{n} 个 env → 占位符",
+    "secretNote": "不会导出 MCP 凭据值 — 仅以 ${KEY} 占位符形式包含键名。",
+    "tokenPlaceholder": "GitHub 令牌（服务器已配置则可留空）",
+    "publish": "创建 PR（{n} 项）",
+    "adminOnly": "仅管理员可发布",
+    "prCreated": "已创建 PR — 打开",
+    "prDetail": "分支 {branch} · {files} 个文件",
+    "missing": "部分项目因不满足所有权或激活条件被跳过。"
   }
 }


### PR DESCRIPTION
## 무엇

(a) 큐레이션 레포 `openmake/openmake-marketplace` 위에 **(b) 발행형**을 얹는다 — 사용자가 이 앱에서 만든
스킬·Custom Agent·MCP 설정을 Claude Code 플러그인 규격 번들로 묶어 마켓플레이스 레포에 **PR 로** 올린다.

```
설정 → 확장 → [마켓플레이스에 게시]
  GET  /api/marketplace/publish/candidates   내 스킬·에이전트·MCP (확장 유래 제외)
  POST /api/marketplace/publish (admin)      번들 → blob/tree/commit → 새 브랜치 → PR
                                             marketplace.json 엔트리 merge (같은 이름은 교체)
```

## 번들 형태 (우리 ingest 가 되읽고 Claude Code 도 설치 가능)

| 파일 | 출처 |
|---|---|
| `plugins/<name>/.claude-plugin/plugin.json` | name/version/description/author |
| `skills/<slug>/SKILL.md` + `scripts/…` `references/…` | `agent_skills` + `skill_assets`(원본 바이트) |
| `agents/<slug>.md` | `user_agents.system_prompt` |
| `.mcp.json` | `mcp_servers` — env 는 **키만** `${KEY}` 자리표시자 |
| `.claude-plugin/marketplace.json` | 상대경로 엔트리 `./plugins/<name>` merge |

## 보안·설계

- **자격증명 불출** — 저장소 쿼리가 `jsonb_object_keys` 로 키만 읽는다. 값을 읽는 코드 경로 자체가 없다.
- **소유자·활성·확장 유래 아님**만 내보낸다. 조건에 걸려 빠진 id 는 `missing` 으로 응답에 드러낸다.
- 게시는 **admin** — 공개 레포 쓰기. main 직접 push 없음, PR 리뷰가 승인 게이트.
- 토큰: `body.accessToken` > `MARKETPLACE_PUBLISH_TOKEN`(시스템 설정 registry, secret). 외부 fetch 는 `createPinnedFetch`.
- 기존 frontmatter 는 벗기고 정규 frontmatter 로 재작성(이중이면 파서가 첫 것만 읽음). category 없으면 `general`, version 비-semver → `1.0.0`.

## 테스트

라운드트립 7건 — 내보낸 파일이 `parseSkillFile` · `validateExtensionManifest` · `parseMcpJsonFile` ·
`agentFileToCustomAgent` · `parseMarketplaceFile` 을 전부 통과. path traversal 차단·빈 번들 거부·이름 규칙.

- [x] lint 에러 0 · `npm test` 2,971건 · Gate 3 위반 0 · tsc web/api
- [ ] 배포 후 실제 게시 1건 → PR 파일 확인 → 머지 → 카탈로그 재동기화로 설치 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)