### PR TITLE
fix(marketplace): 번들 디렉토리 슬러그를 ASCII 로 고정 + 재게시 시 낡은 파일 정리

### DIFF
--- a/apps/api/src/routes/marketplace-publish.routes.ts
+++ b/apps/api/src/routes/marketplace-publish.routes.ts
@@ -67,11 +67,11 @@ marketplacePublishRouter.post('/publish', requireAuth, requireAdmin, validate(pu
     const stamp = new Date().toISOString().replace(/[-:]/g, '').slice(0, 13).replace('T', '-');
     const summary = `skills ${skills.length} · agents ${agents.length} · mcp ${mcpServers.length}`;
     const result = await new GithubPublisher(token).publish({
-        owner, repo: repoName, files: bundle.files, marketplaceEntry: bundle.marketplaceEntry, token,
+        owner, repo: repoName, files: bundle.files, marketplaceEntry: bundle.marketplaceEntry, pluginDir: bundle.pluginDir, token,
         branchName: `${MARKETPLACE_PATHS.branchPrefix}${body.pluginName}-${stamp}`,
         commitMessage: `feat(plugins): publish ${body.pluginName} from openmake_llm (${summary})`,
         prTitle: `publish: ${body.pluginName} (${summary})`,
-        prBody: `openmake_llm 에서 게시한 플러그인 번들입니다.\n\n- ${summary}\n- 경로: \`${bundle.pluginDir}\`\n- MCP env 는 자리표시자(\`\${KEY}\`)만 포함됩니다.\n\n리뷰 후 머지하면 카탈로그 재동기화 시 설치 가능해집니다.`,
+        prBody: `openmake_llm 에서 게시한 플러그인 번들입니다.\n\n- ${summary}\n- 경로: \`${bundle.pluginDir}\`\n- MCP env 는 자리표시자(\`\${KEY}\`)만 포함됩니다.\n- 같은 플러그인 디렉토리의 이전 파일은 이번 번들 기준으로 정리(삭제)됩니다.\n\n리뷰 후 머지하면 카탈로그 재동기화 시 설치 가능해집니다.`,
     });
 
     getAuditService().logAudit({ userId, action: 'marketplace.publish', resourceType: 'marketplace', resourceId: `${owner}/${repoName}`, details: { plugin: body.pluginName, prUrl: result.prUrl, missing } }).catch(() => { /* noop */ });

--- a/apps/api/src/services/marketplace/github-publisher.ts
+++ b/apps/api/src/services/marketplace/github-publisher.ts
@@ -23,6 +23,8 @@ export interface PublishInput {
     token: string;
     files: BundleFile[];
     marketplaceEntry: { name: string; description: string; category: string; source: string };
+    /** plugins/<name> — 재게시 시 이 아래의 낡은 파일을 삭제한다 */
+    pluginDir: string;
     branchName: string;
     commitMessage: string;
     prTitle: string;
@@ -30,7 +32,7 @@ export interface PublishInput {
     baseBranch?: string;
 }
 
-export interface PublishResult { branch: string; commitSha: string; prUrl: string; prNumber: number; files: string[] }
+export interface PublishResult { branch: string; commitSha: string; prUrl: string; prNumber: number; files: string[]; removed: string[] }
 
 export class GithubPublisher {
     private readonly fetch = createPinnedFetch();
@@ -70,9 +72,20 @@ export class GithubPublisher {
         plugins.push(input.marketplaceEntry);
         const indexText = JSON.stringify({ ...index, plugins }, null, 2) + '\n';
 
+        // 재게시 = 갱신: 같은 plugins/<name>/ 아래 있던 파일 중 이번 번들에 없는 것은 삭제한다.
+        // 안 그러면 슬러그가 바뀐 스킬 디렉토리가 둘 다 남아 설치 시 이중으로 들어간다.
+        const pluginDir = input.pluginDir;
+        const baseTree = await this.api<{ tree: Array<{ path: string; type: string }>; truncated: boolean }>(
+            'GET', `/repos/${owner}/${repo}/git/trees/${baseCommit.tree.sha}?recursive=1`);
+        if (baseTree.truncated) throw new Error('레포 트리가 너무 커서 낡은 파일 정리를 보장할 수 없습니다');
+        const newPaths = new Set(input.files.map((f) => f.path));
+        const stale = baseTree.tree
+            .filter((t) => t.type === 'blob' && t.path.startsWith(`${pluginDir}/`) && !newPaths.has(t.path))
+            .map((t) => t.path);
+
         // blobs → tree → commit → ref → PR
         const allFiles: BundleFile[] = [...input.files, { path: idxPath, content: indexText }];
-        const treeEntries = [];
+        const treeEntries: Array<{ path: string; mode: string; type: string; sha: string | null }> = stale.map((path) => ({ path, mode: '100644', type: 'blob', sha: null }));
         for (const f of allFiles) {
             const isBuf = Buffer.isBuffer(f.content);
             const blob = await this.api<{ sha: string }>('POST', `/repos/${owner}/${repo}/git/blobs`, {
@@ -87,7 +100,7 @@ export class GithubPublisher {
         const pr = await this.api<{ html_url: string; number: number }>('POST', `/repos/${owner}/${repo}/pulls`, {
             title: input.prTitle, head: input.branchName, base, body: input.prBody,
         });
-        logger.info(`게시 PR 생성: ${pr.html_url} (${allFiles.length} files)`);
-        return { branch: input.branchName, commitSha: commit.sha, prUrl: pr.html_url, prNumber: pr.number, files: allFiles.map((f) => f.path) };
+        logger.info(`게시 PR 생성: ${pr.html_url} (${allFiles.length} files, ${stale.length} removed)`);
+        return { branch: input.branchName, commitSha: commit.sha, prUrl: pr.html_url, prNumber: pr.number, files: allFiles.map((f) => f.path), removed: stale };
     }
 }

--- a/apps/api/src/services/marketplace/plugin-bundle-builder.test.ts
+++ b/apps/api/src/services/marketplace/plugin-bundle-builder.test.ts
@@ -2,7 +2,7 @@
  * 번들 빌더 라운드트립 — 내보낸 파일을 **우리 ingest 파서가 그대로 읽어야** 한다.
  * (내보내기만 되고 재설치가 안 되면 마켓플레이스에 올려도 쓸 수 없다.)
  */
-import { buildPluginBundle, validatePluginName } from './plugin-bundle-builder';
+import { buildPluginBundle, validatePluginName, asciiSlug } from './plugin-bundle-builder';
 import { parseSkillFile } from '../../agents/manifest-validator';
 import { validateExtensionManifest, parseMcpJsonFile, parseMarketplaceFile } from '../../agents/git-ingest/extension-manifest-validator';
 import { agentFileToCustomAgent } from '../../agents/git-ingest/plugin-component-compat';
@@ -43,7 +43,7 @@ describe('buildPluginBundle 라운드트립', () => {
         expect((parsed.frontmatter as { tags?: unknown[] }).tags).toEqual(['devops']);
         expect(parsed.prompt_md).toContain('**역할**');
         expect(parsed.prompt_md).not.toContain('name: old');
-        const csv = parseSkillFile(text(b.files, 'plugins/my-devops-pack/skills/csv-결측치-분석/SKILL.md'));
+        const csv = parseSkillFile(text(b.files, 'plugins/my-devops-pack/skills/csv/SKILL.md')); // ASCII 부분만 남는다
         expect(csv.frontmatter.category).toBe('general');           // null → 기본
         expect(csv.frontmatter.description).toBe('CSV 결측치 분석'); // 빈 설명 → 이름
     });
@@ -71,6 +71,16 @@ describe('buildPluginBundle 라운드트립', () => {
         expect(b.marketplaceEntry.source).toBe('./plugins/my-devops-pack');
         const idx = parseMarketplaceFile(JSON.stringify({ name: 'x', plugins: [b.marketplaceEntry] }));
         expect(idx.ok && idx.marketplace.plugins[0].path).toBe('plugins/my-devops-pack');
+    });
+
+    it('디렉토리 슬러그는 ASCII 만 — 비ASCII 는 버리고, 남는 게 없으면 이름 해시', () => {
+        expect(asciiSlug('Nginx Log Error Analysis & Reporting', 'skill')).toBe('nginx-log-error-analysis-reporting');
+        expect(asciiSlug('CSV 결측치 분석', 'skill')).toBe('csv');
+        const k = asciiSlug('결측치 분석', 'skill');
+        expect(k).toMatch(/^skill-[0-9a-f]{8}$/);
+        expect(asciiSlug('결측치 분석', 'skill')).toBe(k);
+        expect(b.files.every((f) => /^[\x20-\x7e]+$/.test(f.path))).toBe(true);
+        expect(parseSkillFile(text(b.files, 'plugins/my-devops-pack/skills/csv/SKILL.md')).frontmatter.name).toBe('CSV 결측치 분석');
     });
 
     it('이름 규칙·빈 번들·상한을 거부한다', () => {

--- a/apps/api/src/services/marketplace/plugin-bundle-builder.ts
+++ b/apps/api/src/services/marketplace/plugin-bundle-builder.ts
@@ -17,7 +17,7 @@
  * @module services/marketplace/plugin-bundle-builder
  */
 import yaml from 'js-yaml';
-import { slugify } from '../../chat/slash-command';
+import { createHash } from 'crypto';
 import { MARKETPLACE_AUTHOR, MARKETPLACE_PATHS, MARKETPLACE_PUBLISH_LIMITS } from '../../config/marketplace-publish';
 import type { ExportAgent, ExportMcpServer, ExportSkill, ExportSkillAsset } from '../../data/repositories/marketplace-export-repository';
 
@@ -58,6 +58,18 @@ function stripFrontmatter(md: string): string {
 
 function frontmatter(obj: Record<string, unknown>): string {
     return `---\n${yaml.dump(obj, { lineWidth: -1, noRefs: true }).trimEnd()}\n---\n`;
+}
+
+/**
+ * 디렉토리용 ASCII 슬러그 — 한글 등 비ASCII 는 버리고, 남는 게 없으면 이름 해시로 만든다.
+ * 앱 내부 슬러그(`chat/slash-command.slugify`)는 유니코드를 보존하지만, 레포 경로는 Claude Code
+ * 설치·다른 OS 파일시스템 호환을 위해 ASCII 로 고정한다. 원래 이름은 frontmatter `name` 에 그대로 남는다.
+ */
+export function asciiSlug(name: string, prefix: string): string {
+    const base = name.toLowerCase().normalize('NFKD').replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+    if (base.length >= 3) return base.slice(0, 64);
+    const hash = createHash('sha1').update(name).digest('hex').slice(0, 8);
+    return base ? `${base}-${hash}` : `${prefix}-${hash}`;
 }
 
 /** 이름 충돌 시 -2, -3 … 을 붙여 유일하게 */
@@ -104,7 +116,7 @@ export function buildPluginBundle(input: BundleInput): BundleResult {
         assetsBySkill.get(a.skill_id)!.push(a);
     }
     for (const s of input.skills) {
-        const slug = uniqueSlug(slugify(s.name), skillSlugs);
+        const slug = uniqueSlug(asciiSlug(s.name, 'skill'), skillSlugs);
         const meta = (s.manifest_meta ?? {}) as { version?: unknown; tags?: unknown };
         const fm: Record<string, unknown> = {
             name: s.name,
@@ -125,7 +137,7 @@ export function buildPluginBundle(input: BundleInput): BundleResult {
     // agents — Claude Code agents/<name>.md 규격 (frontmatter + 본문 = system prompt)
     const agentSlugs = new Set<string>();
     for (const ag of input.agents) {
-        const slug = uniqueSlug(slugify(ag.name), agentSlugs);
+        const slug = uniqueSlug(asciiSlug(ag.name, 'agent'), agentSlugs);
         const fm: Record<string, unknown> = { name: ag.name, description: (ag.description ?? '').trim() || `${ag.name} 에이전트` };
         if (ag.model) fm.model = ag.model;
         push(`agents/${slug}.md`, frontmatter(fm) + '\n' + ag.system_prompt.trim() + '\n');


### PR DESCRIPTION
## 배경

첫 라이브 게시에서 한글 스킬 이름이 `skills/csv-결측치-분석-및-보고서-작성/` 유니코드 디렉토리가 됐다.
우리 ingest 는 읽지만 Claude Code 설치·타 OS 파일시스템 호환은 보장이 없다.

## 변경

- **`asciiSlug`** — 비ASCII 제거, 남는 게 3자 미만이면 이름 sha1 8자로 `skill-<hash>` (결정적). 원래 이름은 frontmatter `name` 에 그대로.
- **재게시 시 낡은 파일 정리** — 슬러그가 바뀌면 이전 디렉토리가 남아 재설치 시 스킬이 **이중**으로 들어간다. 게시자가 base 트리(recursive)에서 `plugins/<name>/` 아래 이번 번들에 없는 blob 을 `sha: null` 로 같은 커밋에서 삭제. 응답 `removed[]`. 트리 truncated 면 실패(정리 보장 불가).

## 검증

- 테스트 8건 통과, `npm test` 2,972건, lint 에러 0, Gate 3 위반 0
- [ ] 배포 후 `openmake-log-analysis` 재게시 → PR 에서 한글 디렉토리 삭제 + `skills/csv/` 추가 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)