### PR TITLE
fix(llm): 컨텍스트 잘림 시 첫 user 메시지(=에이전트 작업 goal) 를 앵커로 보호

### DIFF
--- a/apps/api/src/__tests__/model-pool.test.ts
+++ b/apps/api/src/__tests__/model-pool.test.ts
@@ -17,6 +17,7 @@ import {
     selectModelByCapacity,
 } from '../llm/model-pool';
 import { ContextOverflowError } from '../errors/context-overflow.error';
+import type { ChatMessage } from '../llm/types';
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -148,6 +149,54 @@ describe('truncateMessagesPreservingSystem', () => {
         ];
         const result = truncateMessagesPreservingSystem(messages, 100);  // 매우 작음
         expect(result).toHaveLength(2);
+    });
+});
+
+describe('truncateMessagesPreservingSystem — 앵커(첫 user=goal) 보호', () => {
+    const sys = { role: 'system' as const, content: '가'.repeat(50) };
+    const goal = { role: 'user' as const, content: '목표: 리포트를 만들어라' };
+    const mid = (n: number) => Array.from({ length: n }, (_, i) => [
+        { role: 'assistant' as const, content: `턴${i} ` + '나'.repeat(120) },
+        { role: 'user' as const, content: `결과${i} ` + '다'.repeat(120) },
+    ]).flat();
+
+    it('오래된 턴을 버려도 앵커(goal)는 system 바로 뒤에 남는다', () => {
+        const messages = [sys, goal, ...mid(6)];
+        const full = estimateMessageTokens(messages);
+        const result = truncateMessagesPreservingSystem(messages, Math.floor(full / 2));
+        expect(result.length).toBeLessThan(messages.length);
+        expect(result[0]).toBe(sys);
+        expect(result[1]).toBe(goal);
+        expect(result[result.length - 1]).toBe(messages[messages.length - 1]);
+    });
+
+    it('예산이 앵커+최근 1개도 못 담으면 종전대로 최근 것만 남긴다 (최소 보장 우선)', () => {
+        const messages = [sys, goal, ...mid(2)];
+        const last = messages[messages.length - 1];
+        const result = truncateMessagesPreservingSystem(messages, estimateMessageTokens([sys, last]) + 1);
+        expect(result[0]).toBe(sys);
+        expect(result[result.length - 1]).toBe(last);
+        expect(result).not.toContain(goal);
+    });
+
+    it('첫 메시지가 user 가 아니면(assistant 선두) 앵커 없음 — 종전 동작', () => {
+        const lead = { role: 'assistant' as const, content: '선두' };
+        const messages = [sys, lead, ...mid(3)];
+        const result = truncateMessagesPreservingSystem(messages, estimateMessageTokens(messages) - 60);
+        expect(result[0]).toBe(sys);
+        expect(result).not.toContain(lead);
+    });
+
+    it('앵커 보호 후에도 선두 고아 tool 메시지는 제거된다', () => {
+        const messages: ChatMessage[] = [sys, goal,
+            { role: 'assistant', content: '', tool_calls: [{ id: 't1', type: 'function', function: { name: 'x', arguments: {} } }] },
+            { role: 'tool' as const, content: '결과'.repeat(80), tool_call_id: 't1' },
+            { role: 'assistant' as const, content: '마무리' },
+        ];
+        const budget = estimateMessageTokens([sys, goal, messages[4]]) + 5;
+        const result = truncateMessagesPreservingSystem(messages, budget);
+        expect(result[0]).toBe(sys); expect(result[1]).toBe(goal);
+        expect(result.some((m) => m.role === 'tool')).toBe(false);
     });
 });
 

--- a/apps/api/src/llm/model-pool.ts
+++ b/apps/api/src/llm/model-pool.ts
@@ -71,7 +71,7 @@ export function estimateMessageTokens(messages: ChatMessage[]): number {
 }
 
 /**
- * Token budget 안에서 messages 를 자르되 system + 최근 user/assistant 는 보존.
+ * Token budget 안에서 messages 를 자르되 system + 첫 user(앵커=목표) + 최근 user/assistant 는 보존.
  *
  * 알고리즘:
  *   1. system message (index 0 인 경우만) 항상 유지
@@ -91,13 +91,27 @@ export function truncateMessagesPreservingSystem(
     // 이미지 토큰까지 포함해야 overflow 판정(estimateMessageTokens)과 대칭 — vision 요청 과소절단 방지
     const systemTokens = systemMsg ? estimateMessageTokens([systemMsg]) : 0;
 
+    // 앵커: system 바로 다음의 첫 user 메시지는 대화의 목표다 — 에이전트 작업에선 `goal` 이
+    // 여기 있다(system 은 프롬프트 규약만 담는다). 오래된 순으로 버리면 가장 먼저 사라져
+    // 모델이 목표 없이 도구 결과만 보고 "마무리"하게 되고, 에러는 나지 않는다(조용한 실패).
+    // 예산이 허락하면 system 과 함께 고정하고, 예산이 없으면 종전대로 버린다(최소 보장 우선).
+    const anchor = rest.length > 1 && rest[0].role === 'user' ? rest[0] : null;
+    const anchorTokens = anchor ? estimateMessageTokens([anchor]) : 0;
     const kept: ChatMessage[] = [];
     let used = systemTokens;
     for (let i = rest.length - 1; i >= 0; i--) {
+        if (anchor && i === 0) break;  // 앵커는 아래에서 별도 판정
         const tokens = estimateMessageTokens([rest[i]]);
-        if (used + tokens > budgetTokens && kept.length > 0) break;
+        // 앵커 자리를 남겨 둔 채 최근 것부터 채운다(단 최근 1개는 항상 보장)
+        const reserve = anchor && kept.length > 0 ? anchorTokens : 0;
+        if (used + tokens + reserve > budgetTokens && kept.length > 0) break;
         kept.unshift(rest[i]);
         used += tokens;
+    }
+    if (anchor) {
+        if (kept.length === 0) { kept.push(rest[rest.length - 1]); used += estimateMessageTokens([rest[rest.length - 1]]); }
+        // 앵커 + 최근분이 예산 안이면 고정, 아니면 종전 동작(앵커 포기)
+        if (used + anchorTokens <= budgetTokens) kept.unshift(anchor);
     }
 
     if (rest.length > 0 && kept.length === 0) {


### PR DESCRIPTION
## 결함

`truncateMessagesPreservingSystem` 은 system + 최근만 남기고 오래된 순으로 버린다. 에이전트 작업은
`[system(규약), user(goal), 턴…]` 이라 컨텍스트가 넘치면 **goal 이 가장 먼저 사라진다**. 모델은 목표 없이
도구 결과만 보고 마무리하고 에러는 없다 — 조용한 실패.

실측: 60일간 발동 0건(`input truncate` 로그 0, 컨텍스트 초과 실패 0). 262K + 도구 결과 캡 덕분이지 보호 때문이 아니다.

## 변경

- system 바로 다음 **첫 user 메시지를 앵커로 고정**. 예산이 앵커+최근 1개도 못 담으면 종전 동작(최소 보장 우선).
- 채팅 경로(external-provider)도 같은 함수 — 대화의 첫 질문이 남는 효과, 무해.
- 고아 tool 페어 방어는 그대로 뒤에서 적용.

## 테스트

앵커 보존 · 예산 부족 시 포기 · assistant 선두면 앵커 없음 · 고아 tool 제거 병행 — 4건 추가, 기존 26건 유지.
`npm test` 2,976건, lint 에러 0, Gate 3 위반 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)