### PR TITLE
fix(agent-task): goal judge 사유 영속 + 증거 창에서 terminate/plan 제외 + 부분 계획 비율 제외

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1056,6 +1056,8 @@ AGENT_TASK_TIMEOUT_MS=600000
 # AGENT_TASK_GOAL_JUDGE_MAX_CHARS=6000   # judge 에 넘기는 최종 답변 최대 글자 수
 # AGENT_TASK_GOAL_JUDGE_EVIDENCE_MAX_ITEMS=5   # judge 에 싣는 최근 도구 결과 수(false negative 완화)
 # AGENT_TASK_GOAL_JUDGE_EVIDENCE_ITEM_CHARS=160 # 도구 결과 항목당 글자 캡
+# AGENT_TASK_GOAL_JUDGE_REASON_MAX_CHARS=600   # judge 사유 스텝에 남길 reason 최대 글자
+# AGENT_TASK_GOAL_JUDGE_RAW_KEEP_CHARS=400     # 파싱 실패 시 남길 raw 응답 앞부분
 
 # Agent Task — 도구 호출 인자 영속 (스텝에 마스킹된 args 기록, 사후 원인 분석용). 기본 ON.
 # AGENT_TASK_TOOL_ARGS_PERSIST=true

--- a/.env.example
+++ b/.env.example
@@ -1054,8 +1054,8 @@ AGENT_TASK_TIMEOUT_MS=600000
 # 판정 결과는 agent_tasks.judge_verdict, 완료 출구는 completion_path 로 영속(091).
 # AGENT_TASK_GOAL_JUDGE=true
 # AGENT_TASK_GOAL_JUDGE_MAX_CHARS=6000   # judge 에 넘기는 최종 답변 최대 글자 수
-# AGENT_TASK_GOAL_JUDGE_EVIDENCE_MAX_ITEMS=5   # judge 에 싣는 최근 도구 결과 수(false negative 완화)
-# AGENT_TASK_GOAL_JUDGE_EVIDENCE_ITEM_CHARS=160 # 도구 결과 항목당 글자 캡
+# AGENT_TASK_GOAL_JUDGE_EVIDENCE_MAX_ITEMS=8   # judge 에 싣는 최근 도구 결과 수 (terminate/plan_* 결과는 제외됨)
+# AGENT_TASK_GOAL_JUDGE_EVIDENCE_ITEM_CHARS=320 # 도구 결과 항목당 글자 캡
 # AGENT_TASK_GOAL_JUDGE_REASON_MAX_CHARS=600   # judge 사유 스텝에 남길 reason 최대 글자
 # AGENT_TASK_GOAL_JUDGE_RAW_KEEP_CHARS=400     # 파싱 실패 시 남길 raw 응답 앞부분
 

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -606,6 +606,12 @@ export const ROUTER_CONFIDENCE_FALLBACK = 0.85;
  * 언어 감지 임계값
  * chat/language-policy.ts에서 참조
  */
+/**
+ * goal judge 증거 창에서 제외할 도구 — 결과가 ANSWER(terminate) 나 계획 스냅샷(plan_*) 과 중복이라
+ * 마지막 N개 창을 차지하면 실제 수행 증거가 밀려난다. (goal-judge.ts buildJudgeToolEvidence)
+ */
+export const JUDGE_EVIDENCE_EXCLUDED_TOOLS: ReadonlySet<string> = new Set(['terminate', 'plan_create', 'plan_update', 'plan_view']);
+
 export const LANGUAGE_THRESHOLDS = {
     /** 비라틴 알파벳 비율 임계값 */
     NON_LATIN_RATIO: 0.3,
@@ -1532,9 +1538,12 @@ export const AGENT_TASK_LIMITS = {
     GOAL_JUDGE_MAX_ANSWER_CHARS: parseInt(process.env.AGENT_TASK_GOAL_JUDGE_MAX_CHARS || '6000', 10),
     /** judge 실행 컨텍스트에 싣는 최근 도구 결과 수 — 성공 증거 부재로 완수 작업을 미달성
      *  판정하던 false negative(2026-08-09 예약리포트·2026-08-15 로컬실행, 실측 2회) 완화. */
-    GOAL_JUDGE_EVIDENCE_MAX_ITEMS: parseInt(process.env.AGENT_TASK_GOAL_JUDGE_EVIDENCE_MAX_ITEMS || '5', 10),
+    GOAL_JUDGE_EVIDENCE_MAX_ITEMS: parseInt(process.env.AGENT_TASK_GOAL_JUDGE_EVIDENCE_MAX_ITEMS || '8', 10),
     /** judge 도구 결과 항목당 글자 캡 (프롬프트 팽창 방지) */
-    GOAL_JUDGE_EVIDENCE_ITEM_CHARS: parseInt(process.env.AGENT_TASK_GOAL_JUDGE_EVIDENCE_ITEM_CHARS || '160', 10),
+    GOAL_JUDGE_EVIDENCE_ITEM_CHARS: parseInt(process.env.AGENT_TASK_GOAL_JUDGE_EVIDENCE_ITEM_CHARS || '320', 10),
+    /** judge 사유 스텝에 남길 reason 최대 글자 (파싱 실패 시 raw 응답 앞부분도 같이 남긴다) */
+    GOAL_JUDGE_REASON_MAX_CHARS: parseInt(process.env.AGENT_TASK_GOAL_JUDGE_REASON_MAX_CHARS || '600', 10),
+    GOAL_JUDGE_RAW_KEEP_CHARS: parseInt(process.env.AGENT_TASK_GOAL_JUDGE_RAW_KEEP_CHARS || '400', 10),
     /** 부팅 자동 복구 — 프로세스 재시작으로 중단된 task 를 부팅 시 자동 resume 한다.
      *  주의: schema-initializer 가 부팅 시 running/paused 를 failed('server restarted') 로 먼저
      *  마킹하므로, 복구 대상은 ①잔존 running/paused(마킹 실패 대비) + ②restart 마킹 + checkpoint

--- a/apps/api/src/services/agent-task/__tests__/goal-judge.test.ts
+++ b/apps/api/src/services/agent-task/__tests__/goal-judge.test.ts
@@ -6,7 +6,7 @@
  * 종료는 호출자(AgentTaskService)가 담당하며 agent-task-input-files.test.ts 가 통합 커버한다.
  * 여기서는 judge 가 false 를 돌려주는 경로(계약의 goal-judge 쪽 절반)와 fail-open 을 고정한다.
  */
-import { judgeGoalAchieved, buildJudgeExecutionContext, buildJudgeToolEvidence } from '../goal-judge';
+import { judgeGoalAchieved, buildJudgeExecutionContext, buildJudgeToolEvidence,  judgeGoal } from '../goal-judge';
 import { AGENT_TASK_LIMITS } from '../../../config/runtime-limits';
 import type { LLMClient } from '../../../llm';
 
@@ -103,7 +103,13 @@ describe('buildJudgeExecutionContext', () => {
         );
         expect(ctx).toContain('사용 도구: web_search, python_execute');
         expect(ctx).toContain('턴 수: 3');
-        expect(ctx).toContain('계획: 2/3 단계 완료');
+        // 부분 완료(2/3)는 싣지 않는다 — 모델이 마킹을 ~60% 생략해 "1/7" 이 미달성의 거짓 근거로 작동했다
+        expect(ctx).not.toContain('계획:');
+    });
+
+    it('계획이 전부 완료일 때만 계획 줄을 싣는다 (긍정 증거 전용)', () => {
+        const ctx = buildJudgeExecutionContext(new Set(['bash']), 2, [{ status: 'completed' }, { status: 'completed' }]);
+        expect(ctx).toContain('계획: 2/2 단계 완료');
     });
 
     it('도구 미사용이면 "(없음 — 도구 미사용)" 로 표기한다', () => {
@@ -168,5 +174,41 @@ describe('buildJudgeToolEvidence', () => {
 
     it('tool 메시지가 없으면 빈 문자열을 반환한다(EXECUTION 블록 미첨부)', () => {
         expect(buildJudgeToolEvidence([{ role: 'user', content: 'x' }])).toBe('');
+    });
+});
+
+describe('judgeGoal — 사유 동반 판정', () => {
+    const mk = (content: string | null) => ({ chat: jest.fn().mockResolvedValue({ content }) }) as never;
+    it('achieved 와 reason 을 함께 돌려준다', async () => {
+        const r = await judgeGoal(mk('{"achieved": false, "reason": "필요한 파일이 \\"없음\\""}'), 'g', 'a', new AbortController().signal);
+        expect(r.achieved).toBe(false);
+        expect(r.reason).toBe('필요한 파일이 "없음"');
+    });
+    it('파싱 불가면 achieved=null 이고 raw 에 응답 앞부분이 남는다', async () => {
+        const r = await judgeGoal(mk('판정하기 어렵습니다.'), 'g', 'a', new AbortController().signal);
+        expect(r.achieved).toBeNull();
+        expect(r.raw).toContain('판정하기');
+    });
+    it('호출 실패도 throw 없이 null + error raw', async () => {
+        const c = { chat: jest.fn().mockRejectedValue(new Error('boom')) } as never;
+        const r = await judgeGoal(c, 'g', 'a', new AbortController().signal);
+        expect(r.achieved).toBeNull();
+        expect(r.raw).toContain('boom');
+    });
+});
+
+describe('buildJudgeToolEvidence — terminate/plan 결과는 증거 창에서 제외', () => {
+    it('terminate·plan_update 가 마지막 N개를 차지해도 실제 수행 증거가 남는다 (81b954b7 / 4185ca15 오판 재현)', () => {
+        const conv = [
+            { role: 'tool', tool_name: 'python_execute', content: 'render ok — 치환 56개·미치환 0개·경고 없음' },
+            { role: 'tool', tool_name: 'file_ops', content: 'data.json report.html' },
+            ...Array.from({ length: AGENT_TASK_LIMITS.GOAL_JUDGE_EVIDENCE_MAX_ITEMS }, () => ({ role: 'tool', tool_name: 'plan_update', content: '## 계획 (1/7 완료)' })),
+            { role: 'tool', tool_name: 'terminate', content: '__TASK_TERMINATE__ success: 리포트 생성 완료' },
+        ];
+        const ev = buildJudgeToolEvidence(conv);
+        expect(ev).toContain('render ok');
+        expect(ev).toContain('data.json report.html');
+        expect(ev).not.toContain('계획 (1/7');
+        expect(ev).not.toContain('__TASK_TERMINATE__');
     });
 });

--- a/apps/api/src/services/agent-task/finalize.test.ts
+++ b/apps/api/src/services/agent-task/finalize.test.ts
@@ -12,22 +12,28 @@ jest.mock('../../config/runtime-limits', () => {
     };
 });
 jest.mock('./goal-judge', () => ({
+    judgeGoal: jest.fn(),
     judgeGoalAchieved: jest.fn(),
     buildJudgeExecutionContext: jest.fn(() => 'ctx'),
 }));
 jest.mock('./deliverable-verify', () => ({ verifyCodeArtifacts: jest.fn(async () => ({ ok: true, report: '' })) }));
 jest.mock('./role-client', () => ({ judgeClientFor: jest.fn(async () => ({})) }));
-jest.mock('./task-steps', () => ({ persistArtifactSteps: jest.fn(async (_t: string, _a: unknown[], n: number) => n + 1) }));
+jest.mock('./task-steps', () => ({
+    persistArtifactSteps: jest.fn(async (_t: string, _a: unknown[], n: number) => n + 1),
+    persistJudgeStep: jest.fn(async (_t: string, n: number) => n + 1),
+}));
 jest.mock('./code-diff', () => ({ maybePersistCodeDiff: jest.fn(async (_r: unknown, _c: unknown, _t: string, n: number) => n) }));
 
 import { finalizeTask, type FinalizeInput } from './finalize';
-import { judgeGoalAchieved } from './goal-judge';
+import { judgeGoal } from './goal-judge';
+import { persistJudgeStep } from './task-steps';
 import { verifyCodeArtifacts } from './deliverable-verify';
 import { AGENT_TASK_INCOMPLETE_MARKER } from '../../prompts/agent-task-prompt';
 import type { TaskRuntime } from '../task-sandbox/runtime';
 import type { TaskSandboxConfig } from '../../config/task-sandbox';
 
-const judgeMock = judgeGoalAchieved as jest.MockedFunction<typeof judgeGoalAchieved>;
+const judgeMock = judgeGoal as jest.MockedFunction<typeof judgeGoal>;
+const judgeStepMock = persistJudgeStep as jest.MockedFunction<typeof persistJudgeStep>;
 const verifyMock = verifyCodeArtifacts as jest.MockedFunction<typeof verifyCodeArtifacts>;
 
 /** 코드 아티팩트 1개를 담은 최종 응답 — 실제 파서를 통과하는 형태. */
@@ -68,7 +74,7 @@ beforeEach(() => {
 
 describe('finalizeTask — 완료 관문 단일화(091)', () => {
     it('terminate 경로도 goal judge 를 거친다 (종전엔 우회)', async () => {
-        judgeMock.mockResolvedValue(true);
+        judgeMock.mockResolvedValue({ achieved: true, reason: '파일이 생성됨', raw: '' });
         const i = input({ path: 'terminate', terminateSummary: '완료했습니다.' });
 
         const out = await finalizeTask(i);
@@ -81,7 +87,7 @@ describe('finalizeTask — 완료 관문 단일화(091)', () => {
     });
 
     it('terminate 인데 목표 미달성이면 completed 가 아니라 failed(goal_incomplete)', async () => {
-        judgeMock.mockResolvedValue(false);
+        judgeMock.mockResolvedValue({ achieved: false, reason: '자료 없음', raw: '' });
         const i = input({ path: 'terminate', terminateSummary: '' });
 
         const out = await finalizeTask(i);
@@ -93,13 +99,23 @@ describe('finalizeTask — 완료 관문 단일화(091)', () => {
     });
 
     it('judge 판정 불가는 fail-open — 완료 유지하되 verdict=unknown 으로 남긴다', async () => {
-        judgeMock.mockResolvedValue(null);
+        judgeMock.mockResolvedValue({ achieved: null, reason: '', raw: '판정 불가' });
         const i = input();
 
         const out = await finalizeTask(i);
 
         expect(out.kind).toBe('completed');
         expect(lastUpdate(i)).toMatchObject({ status: 'completed', judgeVerdict: 'unknown' });
+    });
+
+    it('judge 판정·사유는 스텝으로 영속되고 WS 로도 나간다 (오판 사후 규명용)', async () => {
+        judgeMock.mockResolvedValue({ achieved: false, reason: '입력 파일이 없음', raw: '' });
+        const emit = jest.fn();
+        const i = input({ path: 'terminate', terminateSummary: '', emitStep: emit });
+        await finalizeTask(i);
+        expect(judgeStepMock).toHaveBeenCalledWith(expect.any(String), expect.any(Number), 'not_achieved', '입력 파일이 없음', '', 'ctx');
+        const emitted = emit.mock.calls.find((c: unknown[]) => c[0] === 'judge');
+        expect(emitted?.[2]).toContain('입력 파일이 없음');
     });
 
     it('아티팩트가 있으면 judge 를 생략하고 verdict=skipped (발동 조건 유지)', async () => {
@@ -148,7 +164,7 @@ describe('finalizeTask — 완료 관문 단일화(091)', () => {
     });
 
     it('terminate summary 가 결과 본문이 된다', async () => {
-        judgeMock.mockResolvedValue(true);
+        judgeMock.mockResolvedValue({ achieved: true, reason: '파일이 생성됨', raw: '' });
         const i = input({ path: 'terminate', terminateSummary: '3개 파일을 생성했습니다.', rawContent: '' });
 
         await finalizeTask(i);

--- a/apps/api/src/services/agent-task/finalize.ts
+++ b/apps/api/src/services/agent-task/finalize.ts
@@ -24,9 +24,9 @@ import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
 import { extractAndStripArtifacts } from '../../llm/artifact-parser';
 import { applyReportRender } from '../chat-service/report-block';
 import { AGENT_TASK_INCOMPLETE_MARKER, getAgentTaskVerifyFailedNudge } from '../../prompts/agent-task-prompt';
-import { judgeGoalAchieved, buildJudgeExecutionContext } from './goal-judge';
+import { judgeGoal, buildJudgeExecutionContext } from './goal-judge';
 import { verifyCodeArtifacts } from './deliverable-verify';
-import { persistArtifactSteps } from './task-steps';
+import { persistArtifactSteps, persistJudgeStep } from './task-steps';
 import { maybePersistCodeDiff } from './code-diff';
 import { judgeClientFor } from './role-client';
 import { createLogger } from '../../utils/logger';
@@ -125,9 +125,13 @@ export async function finalizeTask(input: FinalizeInput): Promise<FinalizeOutcom
     let verdict: JudgeVerdict = 'skipped';
     if (artifacts.length === 0 && AGENT_TASK_LIMITS.GOAL_JUDGE_ENABLED) {
         const execCtx = buildJudgeExecutionContext(usedTools, turn + 1, taskRuntime?.getPlanSnapshot() ?? [], toolEvidence);
-        const achieved = await judgeGoalAchieved(
+        const outcome = await judgeGoal(
             await judgeClientFor(userId), goal, body ?? '', signal, execCtx);
+        const achieved = outcome.achieved;
         verdict = achieved === null ? 'unknown' : achieved ? 'achieved' : 'not_achieved';
+        // 판정·사유·입력 요약을 스텝으로 남긴다 — 오판 사후 규명용(관측 전용, fail-open).
+        stepNumber = await persistJudgeStep(taskId, stepNumber, verdict, outcome.reason, outcome.raw, execCtx);
+        emitStep('judge', undefined, `판정: ${verdict}${outcome.reason ? ` — ${outcome.reason}` : ''}`);
         if (achieved === false) {
             await update({
                 status: 'failed',

--- a/apps/api/src/services/agent-task/goal-judge.ts
+++ b/apps/api/src/services/agent-task/goal-judge.ts
@@ -4,7 +4,7 @@
  */
 import type { LLMClient } from '../../llm';
 import { getAgentTaskGoalJudgeMessages } from '../../prompts/agent-task-prompt';
-import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
+import { AGENT_TASK_LIMITS, JUDGE_EVIDENCE_EXCLUDED_TOOLS } from '../../config/runtime-limits';
 import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('AgentTaskService');
@@ -19,6 +19,10 @@ export function buildJudgeToolEvidence(
 ): string {
     const items = conversation
         .filter((m) => m.role === 'tool' && typeof m.content === 'string' && m.content.trim().length > 0)
+        // terminate 결과는 곧 ANSWER 이고 plan_* 결과는 계획 스냅샷과 중복이다 — 마지막 N개 창에서
+        // 이 둘이 자리를 차지하면 실제 수행 증거(파일 목록·렌더 검증 로그)가 밀려난다(2026-08-19 81b954b7,
+        // 2026-08-25 4185ca15 오판의 직접 원인). 증거 창은 실행 도구 결과만으로 채운다.
+        .filter((m) => !JUDGE_EVIDENCE_EXCLUDED_TOOLS.has(m.tool_name ?? '') && !(m.content as string).startsWith('__TASK_TERMINATE__'))
         .slice(-AGENT_TASK_LIMITS.GOAL_JUDGE_EVIDENCE_MAX_ITEMS)
         .map((m) => {
             const oneLine = (m.content as string).replace(/\s+/g, ' ').trim()
@@ -41,7 +45,9 @@ export function buildJudgeExecutionContext(
         `턴 수: ${turnCount}`,
         // 계획 완료 수는 완료>0 일 때만 싣는다(긍정 증거 전용). 모델이 완료 마킹을 자주
         // 생략(실측 ~60%)해 "0/N 완료"가 미달성의 거짓 근거로 작동했다(2026-08-15 실측).
-        ...(planSteps.length > 0 && completed > 0
+        // 전부 완료일 때만 싣는다(긍정 증거 전용). "0/N" 은 물론 "1/7" 도 마킹 누락 탓에
+        // 미달성의 거짓 근거로 작동했다(2026-08-15, 2026-08-19/25 실측).
+        ...(planSteps.length > 0 && completed === planSteps.length
             ? [`계획: ${completed}/${planSteps.length} 단계 완료`]
             : []),
         ...(toolEvidence ? [`최근 도구 실행 결과:\n${toolEvidence}`] : []),
@@ -52,14 +58,21 @@ export function buildJudgeExecutionContext(
  * 목표 달성 judge — 판정 전용 LLM 1회 호출. true=달성, false=미달성,
  * null=판정 불가(호출 실패/파싱 실패) → 호출자가 fail-open(완료 유지) 처리.
  */
-export async function judgeGoalAchieved(
+/** judge 판정 + 사유. `achieved: null` 은 판정 불가(fail-open). `raw` 는 파싱 실패 규명용 응답 앞부분 */
+export interface JudgeOutcome { achieved: boolean | null; reason: string; raw: string }
+
+/**
+ * judge 호출 — 판정과 **사유를 함께** 돌려준다.
+ * 종전엔 `"achieved"` 만 정규식으로 뽑고 사유를 버려, 오판이 나도 사후 규명이 불가능했다
+ * (judge_verdict 컬럼엔 라벨만 남음). 호출부는 사유를 스텝으로 영속한다.
+ */
+export async function judgeGoal(
     client: LLMClient,
     goal: string,
     answer: string,
     signal: AbortSignal,
-    /** 5-3(b): 실행 컨텍스트(계획 상태·사용 도구·턴수) — 판정 정확도 보강. */
     executionContext?: string,
-): Promise<boolean | null> {
+): Promise<JudgeOutcome> {
     try {
         const { system, user } = getAgentTaskGoalJudgeMessages(
             goal,
@@ -70,14 +83,30 @@ export async function judgeGoalAchieved(
             [{ role: 'system', content: system }, { role: 'user', content: user }],
             undefined, undefined, { think: false, signal },
         );
-        const m = (r.content ?? '').match(/"achieved"\s*:\s*(true|false)/);
+        const content = r.content ?? '';
+        const raw = content.slice(0, AGENT_TASK_LIMITS.GOAL_JUDGE_RAW_KEEP_CHARS);
+        const m = content.match(/"achieved"\s*:\s*(true|false)/);
+        const reasonMatch = content.match(/"reason"\s*:\s*"((?:[^"\\]|\\.)*)"/);
+        const reason = reasonMatch ? reasonMatch[1].replace(/\\"/g, '"').slice(0, AGENT_TASK_LIMITS.GOAL_JUDGE_REASON_MAX_CHARS) : '';
         if (!m) {
-            logger.debug(`[AgentTask] judge 응답 파싱 불가 — fail-open: ${(r.content ?? '').slice(0, 200)}`);
-            return null;
+            logger.debug(`[AgentTask] judge 응답 파싱 불가 — fail-open: ${raw.slice(0, 200)}`);
+            return { achieved: null, reason, raw };
         }
-        return m[1] === 'true';
+        return { achieved: m[1] === 'true', reason, raw };
     } catch (e) {
-        logger.warn(`[AgentTask] judge 호출 실패 — fail-open: ${e instanceof Error ? e.message : e}`);
-        return null;
+        const msg = e instanceof Error ? e.message : String(e);
+        logger.warn(`[AgentTask] judge 호출 실패 — fail-open: ${msg}`);
+        return { achieved: null, reason: '', raw: `error: ${msg.slice(0, 200)}` };
     }
+}
+
+/** 호환 래퍼 — 판정 결과만. 신규 호출부는 judgeGoal 을 쓴다. */
+export async function judgeGoalAchieved(
+    client: LLMClient,
+    goal: string,
+    answer: string,
+    signal: AbortSignal,
+    executionContext?: string,
+): Promise<boolean | null> {
+    return (await judgeGoal(client, goal, answer, signal, executionContext)).achieved;
 }

--- a/apps/api/src/services/agent-task/task-steps.ts
+++ b/apps/api/src/services/agent-task/task-steps.ts
@@ -76,3 +76,29 @@ export async function runTool(
         return `Error: ${msg}`;
     }
 }
+
+/**
+ * judge 판정을 스텝으로 영속 — 사후 규명용. 종전엔 라벨(judge_verdict)만 남아 오판 원인을
+ * 복원할 수 없었다. 실패해도 완료 흐름을 막지 않는다(fail-open, 관측 전용).
+ */
+export async function persistJudgeStep(
+    taskId: string,
+    stepNumber: number,
+    verdict: string,
+    reason: string,
+    raw: string,
+    executionContext: string,
+): Promise<number> {
+    const content = [
+        `판정: ${verdict}`,
+        reason ? `사유: ${reason}` : `사유: (파싱 실패) ${raw}`,
+        `입력 요약:\n${executionContext}`,
+    ].join('\n');
+    try {
+        await getUnifiedDatabase().addAgentTaskStep({ taskId, stepNumber, stepType: 'judge', content });
+        return stepNumber + 1;
+    } catch (e) {
+        logger.warn(`[AgentTask] judge 스텝 영속 실패(무시): ${taskId} — ${e instanceof Error ? e.message : e}`);
+        return stepNumber;
+    }
+}


### PR DESCRIPTION
## 실측

not_achieved 9건(60일) 전수 확인 → **오판 3건(33%)**: `4185ca15`·`81b954b7`(리포트 실제 생성·렌더 검증 통과·terminate success), `63c2f891`("기록됨: summary.txt").

## 원인 (코드 확인)

| # | 결함 | 수정 |
|---|---|---|
| ① | `"achieved"` 만 정규식으로 뽑고 **reason 은 버림** → `judge_verdict` 에 라벨만, 사후 규명 불가 | `judgeGoal()` → `{achieved, reason, raw}`, finalize 가 `judge` 스텝으로 영속(판정·사유·입력 요약) + WS. 관측 전용·fail-open |
| ② | 증거 창(최근 5개×160자)을 **terminate 결과(=ANSWER 중복)·plan_update 결과(=계획 스냅샷 중복)** 가 차지해 파일 목록·렌더 로그가 밀려남 | 제외 목록 `JUDGE_EVIDENCE_EXCLUDED_TOOLS` + 창 5→8, 항목 160→320자 (env 오버라이드 유지) |
| ③ | `계획: 1/7 단계 완료` 가 부정 신호 — 완료>0 규칙은 "0/N" 만 막음, 모델은 마킹을 ~60% 생략 | 계획 줄은 **전부 완료일 때만** (긍정 증거 전용) |

## 바꾸지 않은 것

판정 강도·발동 조건(아티팩트 0)·judge 모델. measure-first — 사유가 쌓인 뒤 오판율을 재측정하고 다음을 정한다.

## 테스트

judge 사유 파싱 3 · 증거 제외 재현 1(81b954b7/4185ca15 형태) · 부분 계획 제외 2 · finalize 사유 영속 1.
`npm test` 2,982건, lint 에러 0, Gate 3 위반 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)