### PR TITLE
fix(mcp): 전역 서버 /start·/stop 소유자 불일치 500 해소 — /connect 와 registry 경로 공유

### DIFF
--- a/apps/api/src/routes/mcp-catalog.routes.ts
+++ b/apps/api/src/routes/mcp-catalog.routes.ts
@@ -17,6 +17,8 @@ import { McpFromCatalogPayloadSchema } from '../schemas/mcp-catalog.schema';
 import type { McpFromCatalogPayload } from '../schemas/mcp-catalog.schema';
 import { getUnifiedDatabase } from '../data/models/unified-database';
 import { getLifecycleSupervisor } from '../mcp/lifecycle-supervisor';
+import { getUnifiedMCPClient } from '../mcp';
+import { connectGlobalServer } from './mcp-global-connect';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('McpCatalogRoutes');
@@ -162,9 +164,23 @@ mcpCatalogRouter.post('/servers/:id/start', requireAuth, asyncHandler(async (req
         res.status(403).json(forbidden('start 권한 없음'));
         return;
     }
-    // ownerId: user_private/user_shared 는 server.user_id, global 은 actor.id
-    // — supervisor 내부에서 owner 불일치 시 throw
-    const ownerId = server.user_id ?? actor.id;
+    // 전역 서버는 유저풀이 아니라 전역 registry 로 — /connect 와 같은 경로(mcp-global-connect.ts).
+    // 그전엔 `spawnUserServer(actor.id, …)` 로 보내 supervisor 가 `서버 소유자 불일치` 로 throw
+    // → 500 + 전역 서버에 actor 명의 crashed 이력이 남았다(2026-08-25 noapi-google-search 실측).
+    if (server.visibility === 'global') {
+        try {
+            const status = await connectGlobalServer(server.id);
+            logger.info(`start 성공(global) s=${server.id} actor=${actor.id}`);
+            res.status(202).json(success({ status: status?.status ?? 'running' }));
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            logger.error(`start 실패(global) s=${server.id}: ${msg}`);
+            res.status(500).json({ ok: false, error: msg });
+        }
+        return;
+    }
+
+    const ownerId = String(server.user_id);
     const supervisor = getLifecycleSupervisor();
     if (!supervisor) {
         res.status(503).json({ ok: false, error: 'lifecycle-supervisor 미초기화' });
@@ -197,7 +213,14 @@ mcpCatalogRouter.post('/servers/:id/stop', requireAuth, asyncHandler(async (req:
         res.status(403).json(forbidden('stop 권한 없음'));
         return;
     }
-    const ownerId = server.user_id ?? actor.id;
+    // start 와 대칭 — 전역 서버는 registry 에 떠 있으므로 유저풀 kill 은 no-op 이고
+    // actor 명의 'stopped' 이력만 남기던 것을 registry 해제로 바꾼다.
+    if (server.visibility === 'global') {
+        await getUnifiedMCPClient().getServerRegistry().disconnectServer(server.id).catch(() => { /* 미등록이면 무시 */ });
+        res.status(202).json(success({ status: 'stopped' }));
+        return;
+    }
+    const ownerId = String(server.user_id);
     const supervisor = getLifecycleSupervisor();
     if (supervisor) {
         await supervisor.killUserServer(ownerId, server.id).catch(e => {

--- a/apps/api/src/routes/mcp-global-connect.ts
+++ b/apps/api/src/routes/mcp-global-connect.ts
@@ -1,0 +1,41 @@
+/**
+ * 전역(admin 등록, visibility=global) MCP 서버의 수동 연결 — 두 라우트가 공유한다.
+ *
+ *   - POST /api/mcp/servers/:id/connect  (mcp.routes.ts — 커넥터 탭 [연결])
+ *   - POST /api/mcp/servers/:id/start    (mcp-catalog.routes.ts — API 호출용)
+ *
+ * 전역 서버는 유저풀(lifecycle-supervisor)이 아니라 전역 registry 에 띄운다. /start 가 전역도
+ * `spawnUserServer(actor.id, …)` 로 보내 `서버 소유자 불일치` 500 을 내던 결함(2026-08-25 실측)을
+ * 막기 위해 connect 의 전역 분기를 여기로 뽑았다 — 두 경로가 갈라지면 같은 결함이 재발한다.
+ *
+ * ⚠️ `getMcpServerById` 는 DB 원본(암호문 v1:)을 돌려주므로 복호화가 필수다. 빠뜨리면
+ * 서버는 뜨고 도구 목록도 등록되지만 실제 API 호출만 401 로 실패한다.
+ */
+import { getUnifiedMCPClient } from '../mcp';
+import { getUnifiedDatabase } from '../data/models/unified-database';
+import { McpCatalogRepository } from '../data/repositories/mcp-catalog-repository';
+import type { MCPConnectionStatus, MCPTransportType } from '../mcp/types';
+
+/** 연결 후 registry 상태를 돌려준다. 서버 row 가 없으면 null (호출자가 404). */
+export async function connectGlobalServer(id: string): Promise<MCPConnectionStatus | null | undefined> {
+    const db = getUnifiedDatabase();
+    const server = await db.getMcpServerById(id);
+    if (!server) return null;
+
+    const decryptedEnv = await new McpCatalogRepository(db.getPool()).decryptEnvForSpawn(id);
+
+    const registry = getUnifiedMCPClient().getServerRegistry();
+    await registry.connectServer(id, {
+        id: server.id,
+        name: server.name,
+        transport_type: server.transport_type as MCPTransportType,
+        command: server.command || undefined,
+        args: server.args || undefined,
+        env: Object.keys(decryptedEnv).length > 0 ? decryptedEnv : undefined,
+        url: server.url || undefined,
+        enabled: server.enabled,
+        created_at: server.created_at,
+        updated_at: server.updated_at,
+    });
+    return registry.getServerStatus(id);
+}

--- a/apps/api/src/routes/mcp.routes.ts
+++ b/apps/api/src/routes/mcp.routes.ts
@@ -41,6 +41,7 @@ import { mcpToolExecuteSchema, mcpServerCreateSchema, mcpServerEnvUpdateSchema,
 import { McpCatalogRepository } from '../data/repositories/mcp-catalog-repository';
 import { McpOAuthRepository } from '../data/repositories/mcp-oauth-repository';
 import { canRegisterServer, canViewServer, canDeleteServer, canStartStopServer, canUpdateServerEnv } from './mcp-visibility';
+import { connectGlobalServer } from './mcp-global-connect';
 import { getAuditService } from '../services/AuditService';
 import { validateOutboundUrl } from '../security/ssrf-guard';
 
@@ -464,36 +465,12 @@ export const mcpRouter = Router();
           return;
       }
 
-      const db = getUnifiedDatabase();
-      const server = await db.getMcpServerById(id);
-
-      if (!server) {
+      // 전역 서버 — /start 와 공유하는 registry 연결(복호화 포함). mcp-global-connect.ts 참고.
+      const status = await connectGlobalServer(id);
+      if (status === null) {
           res.status(404).json(notFound('서버'));
           return;
       }
-
-      // getMcpServerById 는 DB 원본(암호문 v1:)을 그대로 돌려주므로 복호화가 필수다.
-      // 빠뜨리면 암호문이 그대로 자식 프로세스 env 로 들어가 서버는 뜨고 도구 목록도
-      // 정상 등록되지만(연결 자체는 자격증명을 안 쓴다) 실제 API 호출만 401 로 실패한다.
-      // lifecycle-supervisor.safeSpawn 은 decryptEnvForSpawn 을 쓰므로 자동 spawn 경로는
-      // 정상이고, 수동 [연결] 경로만 갈라져 있었다.
-      const decryptedEnv = await repo.decryptEnvForSpawn(id);
-
-      const registry = getUnifiedMCPClient().getServerRegistry();
-      await registry.connectServer(id, {
-          id: server.id,
-          name: server.name,
-          transport_type: server.transport_type as MCPTransportType,
-          command: server.command || undefined,
-          args: server.args || undefined,
-          env: Object.keys(decryptedEnv).length > 0 ? decryptedEnv : undefined,
-          url: server.url || undefined,
-          enabled: server.enabled,
-          created_at: server.created_at,
-          updated_at: server.updated_at,
-      });
-
-      const status = registry.getServerStatus(id);
       res.json(success({ status }));
   }));
 


### PR DESCRIPTION
## 문제

`POST /api/mcp/servers/:id/start` (`mcp-catalog.routes.ts`) 가 전역(`visibility=global`) 서버도 `supervisor.spawnUserServer(actor.id, …)` 로 보내 supervisor 의 소유자 검증에서 `서버 소유자 불일치: u=3 owner=null` 로 throw → **500** + 전역 서버에 actor 명의 `crashed` 인스턴스 이력이 남았다 (2026-08-25 12:47 noapi-google-search 실측). 커넥터 탭 [연결] 은 `/connect` 를 써서 무영향이었고, API 직접 호출 경로만 깨져 있었다.

## 변경

- `routes/mcp-global-connect.ts` 신설 — `/connect` 의 전역 분기(registry `connectServer` + `decryptEnvForSpawn` 복호화)를 함수로 추출. `/connect` 와 `/start` 가 공유 (경로가 갈라지면 같은 결함이 재발)
- `/start`: 전역이면 `connectGlobalServer`, 아니면 기존 유저풀 spawn (`ownerId=server.user_id`)
- `/stop`: 전역이면 `registry.disconnectServer` (그전엔 유저풀 kill no-op + actor 명의 'stopped' 이력만 남김)

## 검증

- tsc·eslint 통과, MCP 관련 jest 27 스위트 194건 통과
- 라이브: 배포 후 user 3 토큰으로 전역 서버 `/start` → 202 확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)