### PR TITLE
fix(web): 설정 표 전수 점검 — 모델 탭 API 키 표 열 깨짐 수정

### DIFF
--- a/apps/web/app/(workspace)/settings/page.tsx
+++ b/apps/web/app/(workspace)/settings/page.tsx
@@ -42,6 +42,9 @@ import { ExtensionsSection } from "@/components/settings/extensions-section";
 /* ── 탭 정의 ────────────────────────────────────────────── */
 type TabId = "general" | "model" | "interface" | "notifications" | "memory" | "extensions" | "connectors" | "privacy" | "security";
 
+/** 넓은 표를 품은 탭 — 본문 폭을 6xl 로 넓힌다(그 외 탭은 4xl 유지). */
+const TABLE_TABS = new Set<TabId>(["connectors", "model"]);
+
 const TABS: { id: TabId; labelKey: string; icon: LucideIcon }[] = [
   { id: "general", labelKey: "tabs.general", icon: Settings },
   { id: "model", labelKey: "tabs.model", icon: Bot },
@@ -532,8 +535,9 @@ export default function SettingsPage() {
       />
 
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
-        {/* 커넥터 탭은 7열 표(+액션 버튼 3개)라 4xl(896px) 안에선 열이 글자 단위로 꺾인다 — 그 탭만 넓힌다 */}
-        <div className={cn("mx-auto flex flex-col gap-6 lg:flex-row", tab === "connectors" ? "max-w-6xl" : "max-w-4xl")}>
+        {/* 표가 있는 탭(커넥터=서버 6열, 모델=API 키 6열)은 4xl(896px) 안에서 좌측 탭 내비와 폭을
+            나누면 열이 글자 단위로 꺾인다 — 그 탭만 넓힌다 */}
+        <div className={cn("mx-auto flex flex-col gap-6 lg:flex-row", TABLE_TABS.has(tab) ? "max-w-6xl" : "max-w-4xl")}>
           {/* 좌측 세로 탭 */}
           <nav className="flex shrink-0 gap-1 overflow-x-auto lg:w-48 lg:flex-col">
             {TABS.map((t) => {

--- a/apps/web/components/settings/provider-keys-section.tsx
+++ b/apps/web/components/settings/provider-keys-section.tsx
@@ -253,7 +253,8 @@ export function ProviderKeysSection() {
               ) : (
                 <Table>
                   <thead>
-                    <tr>
+                    {/* 헤더 글자가 세로로 꺾이던 것 — 줄바꿈 대신 가로 스크롤 */}
+                    <tr className="whitespace-nowrap">
                       <Th>{t("col.provider")}</Th>
                       <Th>{t("col.name")}</Th>
                       <Th>{t("col.key")}</Th>
@@ -285,13 +286,15 @@ export function ProviderKeysSection() {
                               </div>
                             )}
                           </Td>
-                          <Td>{k.display_name}</Td>
-                          <Td className="font-mono text-xs">
+                          <Td className="whitespace-nowrap">{k.display_name}</Td>
+                          <Td className="whitespace-nowrap font-mono text-xs">
                             {k.key_prefix}
                             {"•".repeat(12)}
                           </Td>
-                          <Td>{formatDate(k.created_at, locale)}</Td>
-                          <Td>
+                          {/* 날짜·상태·작업은 폭이 모자라도 글자를 꺾지 않는다 — "2026. 05. 08." 이 3줄로
+                              쪼개지던 것(1440px 실측). 모자라면 Table 의 가로 스크롤에 맡긴다 */}
+                          <Td className="whitespace-nowrap">{formatDate(k.created_at, locale)}</Td>
+                          <Td className="whitespace-nowrap">
                             {ok === false ? (
                               <Badge tone="danger">
                                 {t("status.validationFailed")}
@@ -304,8 +307,8 @@ export function ProviderKeysSection() {
                               </Badge>
                             )}
                           </Td>
-                          <Td className="text-right">
-                            <div className="flex items-center justify-end gap-1">
+                          <Td className="whitespace-nowrap text-right">
+                            <div className="flex flex-wrap items-center justify-end gap-1">
                               <Button
                                 variant="ghost"
                                 size="sm"


### PR DESCRIPTION
## 점검 범위

설정 9개 탭(일반·모델·인터페이스·알림·메모리·확장·커넥터·개인정보·보안) × 3 뷰포트(1440 / 1024 / 390px)를 자동 측정했다. 커넥터의 "인스턴스 상태" 하위 탭 포함.

**표가 있는 곳은 3개뿐**: 모델(API 키), 커넥터(서버 목록), 커넥터→인스턴스 상태. 나머지 6개 탭은 표가 없어 가로 깨짐이 발생할 수 없다.

## 발견 및 수정

| 위치 | 1440px 실측 | 조치 |
|---|---|---|
| 커넥터 서버 목록 | (#630 에서 해소) 넘침 0 | — |
| 커넥터 → 인스턴스 상태 | 넘침 0, 헤더 1줄 | 문제 없음 |
| **모델 → API 키** | 표 678px, 생성일 "2026. 05. 08." **3줄**, 상태 "활성"·작업 "검증" 세로 꺾임 | **이 PR** |

- `TABLE_TABS` 상수(`connectors`·`model`)로 본문 폭 `max-w-6xl` 적용 — #630 의 커넥터 전용 분기를 일반화
- `provider-keys-section`: 헤더·이름·키·생성일·상태·작업 `whitespace-nowrap`(모자라면 `Table` 의 가로 스크롤), 작업 버튼 `flex-wrap`

tsc·eslint 통과. 1024/390px 는 표 내부 가로 스크롤만 발생하고 본문 가로 스크롤은 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)