### PR TITLE
refactor(web): 401/실패 시 목업 폴백 6곳 제거 + /admin/* 페이지 role 가드

### DIFF
--- a/apps/web/app/(workspace)/admin/layout.tsx
+++ b/apps/web/app/(workspace)/admin/layout.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+/**
+ * /admin/* 공통 role 가드.
+ *
+ * 그전엔 관리자 페이지에 페이지 수준 가드가 없어 비관리자도 URL 로 도달했고, 막는 것은
+ * 관리자 API 의 401 뿐이었다(→ 빈 화면 또는 과거엔 목업이 실렌더). 여기서 역할을 판정해
+ * 비관리자에겐 안내만 보여준다.
+ *
+ * auth 는 마운트 후 /api/auth/me 로 비동기 동기화되므로 `authResolved` 전엔 판정을 미룬다 —
+ * 미루지 않으면 새로고침 직후 관리자에게도 "권한 없음"이 번쩍인다.
+ */
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { Loader2, ShieldOff } from "lucide-react";
+import { useAppStore } from "@/lib/store";
+import { Card } from "@/components/ui/primitives";
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const t = useTranslations("admin.guard");
+  const authResolved = useAppStore((s) => s.authResolved);
+  const role = useAppStore((s) => s.auth.currentUser?.role);
+
+  if (!authResolved) {
+    return (
+      <div className="grid h-full place-items-center text-muted">
+        <Loader2 className="h-5 w-5 animate-spin" />
+      </div>
+    );
+  }
+
+  if (role !== "admin") {
+    return (
+      <div className="grid h-full place-items-center p-6">
+        <Card className="max-w-md p-6 text-center">
+          <ShieldOff className="mx-auto mb-3 h-8 w-8 text-faint" />
+          <p className="text-sm font-medium text-fg">{t("denied")}</p>
+          <p className="mt-1 text-xs text-muted">{t("deniedDescription")}</p>
+          <Link href="/" className="mt-4 inline-block text-xs font-medium text-accent hover:underline">
+            {t("home")}
+          </Link>
+        </Card>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/app/(workspace)/admin/mcp-monitoring/page.tsx
+++ b/apps/web/app/(workspace)/admin/mcp-monitoring/page.tsx
@@ -35,7 +35,6 @@ interface ApiMonitoringSummary {
 interface SummaryView {
   activeServers: string;
   totalCalls: string;
-  avgLatency: string;
   errorRate: string;
 }
 
@@ -69,19 +68,6 @@ interface ToolLog {
   durationMs: number;
   status: LogStatus;
 }
-
-/* ── 목업 데이터 ──────────────────────────────────────────
- * 요약 StatCard 4개 중 "활성 서버"·"총 spawn(=총 도구 호출 칸)"·"에러율" 은
- * GET /api/admin/mcp/monitoring/summary 로 실연동. "평균 지연" 은 백엔드에
- * 해당 메트릭이 없어 목업 유지. 서버별 호출 분포·도구 실행 로그는 백엔드에
- * per-call/per-tool 집계 엔드포인트가 없어 목업 유지. (아래 주석 참조)
- */
-const SUMMARY: SummaryView = {
-  activeServers: "4",
-  totalCalls: "12,840",
-  avgLatency: "186ms",
-  errorRate: "1.4%",
-};
 
 /** 감사 로그의 mcp_tool_call 항목으로 서버별 호출 분포 + 최근 실행 로그를 구성한다(실데이터).
  *  백엔드에 전용 집계 엔드포인트가 없어 목업을 쓰던 것을 실 감사 데이터로 대체. */
@@ -143,7 +129,7 @@ async function fetchToolActivity(
   }
 }
 
-/** 요약 통계 조회 — 실패(401/네트워크) 시 null 반환하여 호출측이 목업 유지. */
+/** 요약 통계 조회 — 실패(401/네트워크) 시 null 반환(호출측은 "—" 유지). */
 async function fetchSummaryView(locale: string): Promise<SummaryView | null> {
   try {
     const res = await ApiClient.get<
@@ -155,13 +141,11 @@ async function fetchSummaryView(locale: string): Promise<SummaryView | null> {
       activeServers: String(s.currentRunning),
       // 백엔드엔 "총 도구 호출" 메트릭이 없어 누적 spawn 수로 대체 표시
       totalCalls: s.totalSpawned.toLocaleString(locale),
-      // 평균 지연 메트릭 없음 — 목업 값 유지
-      avgLatency: SUMMARY.avgLatency,
       errorRate:
         s.crashRate24hPct != null ? `${s.crashRate24hPct.toFixed(1)}%` : "—",
     };
   } catch {
-    // 401(비admin)·실패 → null (목업 유지)
+    // 401(비admin)·실패 → null
     return null;
   }
 }
@@ -169,7 +153,8 @@ async function fetchSummaryView(locale: string): Promise<SummaryView | null> {
 export default function McpMonitoringPage() {
   const t = useTranslations("mcpMonitoring");
   const locale = toBcp47(useLocale());
-  const [summary, setSummary] = useState<SummaryView>(SUMMARY);
+  // 실데이터만 — 그전엔 고정 목업(4·12,840·186ms·1.4%)이 실렌더됐고 "평균 지연"은 백엔드 메트릭이 없어 항상 목업이라 타일 자체를 뺐다
+  const [summary, setSummary] = useState<SummaryView>({ activeServers: "—", totalCalls: "—", errorRate: "—" });
   const [topCrashed, setTopCrashed] = useState<TopCrashedItem[]>([]);
   const [crashTrend, setCrashTrend] = useState<CrashTrendItem[]>([]);
   const [serverUsage, setServerUsage] = useState<ServerUsage[]>([]);
@@ -242,7 +227,6 @@ export default function McpMonitoringPage() {
             delta={t("activeServersDelta")}
           />
           <StatCard label={t("totalCalls")} value={summary.totalCalls} />
-          <StatCard label={t("avgLatency")} value={summary.avgLatency} />
           <StatCard
             label={t("errorRate")}
             value={summary.errorRate}

--- a/apps/web/app/(workspace)/agent-tasks/page.tsx
+++ b/apps/web/app/(workspace)/agent-tasks/page.tsx
@@ -52,7 +52,7 @@ interface AgentTask {
   rawStatus: ApiTaskStatus;
   model: string;
   elapsed: string;
-  /** 시작(생성) 시각 ISO — 목록에서 경과시간과 함께 표시. 목업 데이터는 생략 가능. */
+  /** 시작(생성) 시각 ISO — 목록에서 경과시간과 함께 표시. */
   startedAt?: string;
   currentTurn: number;
   maxTurns: number;
@@ -197,59 +197,6 @@ function errorReasonLabel(tr: TFn, error: string): string {
   return KNOWN_ERROR_CODES.has(error)
     ? tr(`errorReason.${error}`)
     : error.length > 48 ? `${error.slice(0, 48)}…` : error;
-}
-
-/* ── 목업 폴백 ─────────────────────────────────────────────── */
-function buildTaskFallback(t: TFn): AgentTask[] {
-  return [
-  {
-    id: "t1",
-    goal: t("mock.t1Goal"),
-    status: "running",
-    rawStatus: "running",
-    model: "Pro",
-    elapsed: t("elapsedMinSec", { m: 2, s: "41" }),
-    currentTurn: 3,
-    maxTurns: 8,
-    progress: 60,
-    checklist: [
-      { label: t("mock.t1Step1"), done: true },
-      { label: t("mock.t1Step2"), done: true },
-      { label: t("mock.t1Step3"), done: true },
-      { label: t("mock.t1Step4"), done: false },
-      { label: t("mock.t1Step5"), done: false },
-    ],
-  },
-  {
-    id: "t2",
-    goal: t("mock.t2Goal"),
-    status: "completed",
-    rawStatus: "completed",
-    model: "Default",
-    elapsed: t("elapsedMinSec", { m: 5, s: "08" }),
-    currentTurn: 6,
-    maxTurns: 6,
-    progress: 100,
-    checklist: [
-      { label: t("mock.t2Step1"), done: true },
-      { label: t("mock.t2Step2"), done: true },
-      { label: t("mock.t2Step3"), done: true },
-      { label: t("mock.t2Step4"), done: true },
-    ],
-  },
-  {
-    id: "t3",
-    goal: t("mock.t3Goal"),
-    status: "pending",
-    rawStatus: "pending",
-    model: "Fast",
-    elapsed: "—",
-    currentTurn: 0,
-    maxTurns: 5,
-    progress: 0,
-    checklist: [],
-  },
-  ];
 }
 
 const STATUS_META: Record<TaskStatus, { labelKey: string; tone: "accent" | "success" | "neutral" }> = {
@@ -761,7 +708,8 @@ export default function AgentTasksPage() {
   const t = useTranslations("agentTasks");
   const locale = useLocale();
   const router = useRouter();
-  const [tasks, setTasks] = useState<AgentTask[]>(() => buildTaskFallback(t));
+  // 실데이터만 — 그전엔 목업 작업 3건(Pro/Default/Fast)이 401 시 실렌더됐다
+  const [tasks, setTasks] = useState<AgentTask[]>([]);
   const [loading, setLoading] = useState(true);
   const [detailTaskId, setDetailTaskId] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null); // taskId being acted on
@@ -779,7 +727,7 @@ export default function AgentTasksPage() {
       );
       setTasks((res?.data?.tasks ?? []).map((task) => mapTask(t, task)));
     } catch {
-      // 401·네트워크 실패: 목업 폴백 유지
+      // 401·네트워크 실패: 빈 상태 유지
     } finally {
       setLoading(false);
     }

--- a/apps/web/app/(workspace)/developer/page.tsx
+++ b/apps/web/app/(workspace)/developer/page.tsx
@@ -80,7 +80,7 @@ export default function DeveloperPage() {
           setSteps(payload.steps);
         }
       } catch {
-        /* 기본 목업 유지 */
+        /* API 실패 시 정적 기본 문서 유지 — 데이터가 아니라 문서라 폴백이 정당하다 */
       }
     })();
     return () => {

--- a/apps/web/app/(workspace)/history/page.tsx
+++ b/apps/web/app/(workspace)/history/page.tsx
@@ -129,16 +129,6 @@ function mapAgentTask(a: ApiAgentTask, tChat: TFn, locale: string): Session {
   };
 }
 
-/* ── 목업 데이터 — 미인증/네트워크 실패 시 폴백 (라벨은 t() 로 렌더 시 해석) ─── */
-const MOCK_META: Array<{ id: string; model: string; group: DateGroup }> = [
-  { id: "c1", model: "Pro", group: "today" },
-  { id: "c2", model: "Default", group: "today" },
-  { id: "c3", model: "Fast", group: "yesterday" },
-  { id: "c4", model: "Think", group: "yesterday" },
-  { id: "c5", model: "Code", group: "week" },
-  { id: "c6", model: "Vision", group: "week" },
-];
-
 const GROUP_ORDER: DateGroup[] = ["today", "yesterday", "week", "older"];
 
 export default function HistoryPage() {
@@ -149,19 +139,8 @@ export default function HistoryPage() {
   const queryClient = useQueryClient();
   const { setChatHistory, setCurrentSessionId, setArtifacts, clearChat, auth } = useAppStore();
   const currentSessionId = useAppStore((s) => s.currentSessionId);
-  const mockSessions = useMemo<Session[]>(
-    () =>
-      MOCK_META.map((m) => ({
-        ...m,
-        kind: "chat" as const,
-        title: t(`mock.${m.id}.title`),
-        preview: t(`mock.${m.id}.preview`),
-        time: t(`mock.${m.id}.time`),
-        ts: 0,
-      })),
-    [t],
-  );
-  const [sessions, setSessions] = useState<Session[]>(mockSessions);
+  // 실데이터만 — 그전엔 폐기된 brand profile(Pro/Think/Vision) 이름을 단 목업 6건이 401 시 실렌더됐다
+  const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
   const [query, setQuery] = useState("");
   // admin 전체 보기 — 대화·작업 목록 모두 ?viewAll=true 로 조회(비관리자는 서버가 무시).
@@ -241,7 +220,7 @@ export default function HistoryPage() {
           ...taskItems.map((a) => mapAgentTask(a, tChat, locale)),
         ]);
       }
-      // 둘 다 실패(401·네트워크): 목업 폴백 유지 (초기 state 그대로)
+      // 둘 다 실패(401·네트워크): 빈 상태 유지
       setLoading(false);
     })();
     return () => {

--- a/apps/web/app/(workspace)/research/page.tsx
+++ b/apps/web/app/(workspace)/research/page.tsx
@@ -117,25 +117,25 @@ function urlToSource(raw: string, idx: number): Source {
   return { id: String(idx), title: raw, domain, verified: true };
 }
 
-/* ── 목업 데이터 — 미인증/네트워크 실패/세션 없음 시 폴백 ─────── */
+/* ── 진행 단계 템플릿 — 세션이 없을 때의 초기 stepper(전부 pending). 실제 상태는 deriveStages 가 채운다 ── */
 const STAGES: Stage[] = [
   {
     key: "decompose",
     labelKey: "stages.decompose.label",
     descKey: "stages.decompose.desc",
-    status: "done",
+    status: "pending",
   },
   {
     key: "collect",
     labelKey: "stages.collect.label",
     descKey: "stages.collect.desc",
-    status: "done",
+    status: "pending",
   },
   {
     key: "verify",
     labelKey: "stages.verify.label",
     descKey: "stages.verify.desc",
-    status: "running",
+    status: "pending",
   },
   {
     key: "synthesize",
@@ -143,52 +143,6 @@ const STAGES: Stage[] = [
     descKey: "stages.synthesize.desc",
     status: "pending",
   },
-];
-
-const SOURCES: Source[] = [
-  {
-    id: "1",
-    title: "",
-    titleKey: "mock.source1",
-    domain: "research.example.com",
-    verified: true,
-  },
-  {
-    id: "2",
-    title: "",
-    titleKey: "mock.source2",
-    domain: "arxiv.org",
-    verified: true,
-  },
-  {
-    id: "3",
-    title: "",
-    titleKey: "mock.source3",
-    domain: "techblog.example.io",
-    verified: true,
-  },
-  {
-    id: "4",
-    title: "",
-    titleKey: "mock.source4",
-    domain: "safety.example.org",
-    verified: false,
-  },
-  {
-    id: "5",
-    title: "",
-    titleKey: "mock.source5",
-    domain: "benchmark.example.dev",
-    verified: true,
-  },
-];
-
-const METRICS: Metric[] = [
-  { labelKey: "metrics.sources", value: "5" },
-  { labelKey: "mock.verifiedClaims", value: "23" },
-  { labelKey: "mock.conflicts", value: "2", tone: "warn" },
-  { labelKey: "mock.tokensUsed", value: "48.2K" },
-  { labelKey: "mock.elapsed", value: "", valueKey: "mock.elapsedValue" },
 ];
 
 const STAGE_ICON: Record<StageStatus, typeof Circle> = {
@@ -226,10 +180,10 @@ export default function ResearchPage() {
   const t = useTranslations("research");
   const router = useRouter();
   const [sourcesOpen, setSourcesOpen] = useState(false);
-  // 최신 세션이 있으면 그것으로 진행/소스/메트릭 표시. 없거나 실패 시 목업 폴백.
+  // 최신 세션이 있으면 그것으로 진행/소스/메트릭 표시. 없거나 실패 시 빈 상태(그전엔 목업 소스 5개·가짜 메트릭이 실렌더됐다).
   const [stages, setStages] = useState<Stage[]>(STAGES);
-  const [sources, setSources] = useState<Source[]>(SOURCES);
-  const [metrics, setMetrics] = useState<Metric[]>(METRICS);
+  const [sources, setSources] = useState<Source[]>([]);
+  const [metrics, setMetrics] = useState<Metric[]>([]);
   const [status, setStatus] = useState<ApiResearchStatus | null>(null);
   const [sessionList, setSessionList] = useState<ApiResearchSession[]>([]);
   const [activeSession, setActiveSession] = useState<ApiResearchSession | null>(null);
@@ -310,7 +264,7 @@ export default function ResearchPage() {
         applySession(latest);
         if (!TERMINAL.includes(latest.status)) poll(latest.id); // 진행 중이면 이어서 폴링
       } catch {
-        // 401·네트워크 실패: 목업 폴백 유지
+        // 401·네트워크 실패: 빈 상태 유지
       }
     })();
     return () => {

--- a/apps/web/app/(workspace)/usage/page.tsx
+++ b/apps/web/app/(workspace)/usage/page.tsx
@@ -498,30 +498,14 @@ function SystemTokenMonitor() {
   );
 }
 
-/* ── 목업 (비로그인/오류 폴백) ──────────────────────────── */
-function mockDaily(): DailyRow[] {
-  const today = new Date();
-  return Array.from({ length: 14 }, (_, i) => {
-    const d = new Date(today);
-    d.setDate(d.getDate() - (13 - i));
-    const base = 40 + Math.round(Math.sin(i / 2) * 25 + i * 6);
-    return {
-      date: d.toISOString().slice(0, 10),
-      totalRequests: base,
-      totalTokens: base * 1180,
-      totalErrors: i % 5 === 0 ? 1 : 0,
-      avgResponseTime: 600 + (i % 4) * 90,
-    };
-  });
-}
-
 export default function UsagePage() {
   const t = useTranslations("usage");
   const locale = toBcp47(useLocale());
   const [summary, setSummary] = useState<UsageSummary | null>(null);
   const [daily, setDaily] = useState<DailyRow[]>([]);
   const [loading, setLoading] = useState(true);
-  const [usingMock, setUsingMock] = useState(false);
+  // 로드 실패(401·네트워크) 표시 — 그전엔 사인파 목업 14일치가 실렌더됐다
+  const [loadError, setLoadError] = useState(false);
   const [updatedAt, setUpdatedAt] = useState<string>("-");
 
   const load = useCallback(async () => {
@@ -535,29 +519,11 @@ export default function UsagePage() {
       ]);
       setSummary(usageRes?.data ?? null);
       setDaily(dailyRes?.data?.daily ?? []);
-      setUsingMock(false);
+      setLoadError(false);
     } catch {
-      // TODO: API 연동 — 비로그인/오류 시 목업
-      const md = mockDaily();
-      setDaily(md);
-      const month = md.reduce(
-        (acc, r) => ({
-          totalTokens: acc.totalTokens + (r.totalTokens ?? 0),
-          totalRequests: acc.totalRequests + (r.totalRequests ?? 0),
-          totalErrors: acc.totalErrors + (r.totalErrors ?? 0),
-          avgResponseTime: acc.avgResponseTime,
-        }),
-        { totalTokens: 0, totalRequests: 0, totalErrors: 0, avgResponseTime: 712 },
-      );
-      setSummary({
-        today: { ...month, modelUsage: {} },
-        weekly: { ...month, modelUsage: {} },
-        allTime: {
-          ...month,
-          modelUsage: { default: 5200, pro: 2100, fast: 1800, code: 1100 },
-        },
-      });
-      setUsingMock(true);
+      setSummary(null);
+      setDaily([]);
+      setLoadError(true);
     } finally {
       setUpdatedAt(new Date().toLocaleTimeString(locale));
       setLoading(false);
@@ -581,7 +547,7 @@ export default function UsagePage() {
         actions={
           <div className="flex items-center gap-3">
             <span className="text-xs text-muted">
-              {usingMock ? t("mockData") : t("updatedAt", { time: updatedAt })}
+              {loadError ? t("loadFailed") : t("updatedAt", { time: updatedAt })}
             </span>
             <Button variant="outline" size="sm" onClick={() => void load()}>
               <RefreshCw className="h-4 w-4" />

--- a/apps/web/lib/auth-sync.ts
+++ b/apps/web/lib/auth-sync.ts
@@ -50,6 +50,15 @@ function fetchMe(): Promise<ApiSuccess<MePayload>> {
  */
 export async function syncAuthFromServer(): Promise<boolean> {
   try {
+    return await syncAuthInner();
+  } finally {
+    // 성공·게스트·실패 어느 경로든 "판정 끝" — /admin 가드가 이 플래그를 기다린다
+    useAppStore.getState().setAuthResolved(true);
+  }
+}
+
+async function syncAuthInner(): Promise<boolean> {
+  try {
     let res = await fetchMe();
     let u = res?.data?.user;
     if (!u && hadSession()) {

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -207,6 +207,8 @@ interface AppState {
 
   // 인증
   auth: { currentUser: AuthUser | null; isGuestMode: boolean };
+  /** /api/auth/me 1회 동기화가 끝났는가 — 끝나기 전엔 게스트로 보이므로 role 가드가 판정을 미룬다 */
+  authResolved: boolean;
 
   // actions
   setChatHistory: (fn: (prev: ChatMessage[]) => ChatMessage[]) => void;
@@ -266,6 +268,7 @@ interface AppState {
   cycleThinkingLevel: () => void;
   setThinkingLevel: (v: ThinkingLevel) => void;
   setAuth: (auth: AppState["auth"]) => void;
+  setAuthResolved: (v: boolean) => void;
 }
 
 const STYLE_ORDER: ChatStyle[] = ["default", "concise", "verbose"];
@@ -345,6 +348,7 @@ export const useAppStore = create<AppState>()(
   style: "default",
 
   auth: { currentUser: null, isGuestMode: true },
+  authResolved: false,
 
   setPrivacyPrefs: (patch) => set(() => ({ ...patch })),
   finalizeLastAssistant: (messageId, cleanedContent) =>
@@ -532,6 +536,7 @@ export const useAppStore = create<AppState>()(
     })),
   setThinkingLevel: (v) => set({ thinkingLevel: v }),
   setAuth: (auth) => set({ auth }),
+  setAuthResolved: (v) => set({ authResolved: v }),
     }),
     {
       name: "openmake-prefs",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -551,38 +551,6 @@
       "noResults": "No results found.",
       "hint": "Start a new conversation and it will appear here."
     },
-    "mock": {
-      "c1": {
-        "title": "Next.js 16 App Router migration",
-        "preview": "What should I watch out for when moving from the pages router to the app router...",
-        "time": "2:14 PM"
-      },
-      "c2": {
-        "title": "PostgreSQL index tuning",
-        "preview": "Explain how composite index order affects the query plan",
-        "time": "11:02 AM"
-      },
-      "c3": {
-        "title": "Marketing campaign copy brainstorming",
-        "preview": "Create 5 variations of social media ad copy targeting people in their 20s",
-        "time": "6:47 PM"
-      },
-      "c4": {
-        "title": "Structuring a research report",
-        "preview": "Suggest a table of contents for an enterprise LLM adoption report",
-        "time": "3:20 PM"
-      },
-      "c5": {
-        "title": "TypeScript generic type guards",
-        "preview": "How can I safely narrow a discriminated union?",
-        "time": "Monday"
-      },
-      "c6": {
-        "title": "Image analysis prompt",
-        "preview": "Read the key trends from the attached chart",
-        "time": "Sunday"
-      }
-    },
     "viewAllToggle": "All users",
     "ownerBadge": "User {id}"
   },
@@ -801,20 +769,6 @@
     "deleteFailed": "Deletion failed: {message}",
     "elapsedSec": "{s}s",
     "elapsedMinSec": "{m}m {s}s",
-    "mock": {
-      "t1Goal": "Analyze pricing on 3 competitor websites and compile a comparison table",
-      "t1Step1": "Confirm target site list",
-      "t1Step2": "Scrape each site's pricing page",
-      "t1Step3": "Normalize price data",
-      "t1Step4": "Build comparison table",
-      "t1Step5": "Write summary report",
-      "t2Goal": "Analyze monthly sales CSV and generate a report",
-      "t2Step1": "Load and validate data",
-      "t2Step2": "Aggregate by month and product",
-      "t2Step3": "Generate trend charts",
-      "t2Step4": "Export PDF report",
-      "t3Goal": "Summarize 5 recent AI papers and extract key points"
-    },
     "autoApprove": "Approve rest",
     "autoApproveHint": "Run remaining tool calls of this task without approval (questions excluded)",
     "tokensUsed": "{count} tokens",
@@ -962,18 +916,6 @@
       "progress": "Progress",
       "depth": "Depth"
     },
-    "mock": {
-      "verifiedClaims": "Claims Verified",
-      "conflicts": "Conflicts Found",
-      "tokensUsed": "Tokens Used",
-      "elapsed": "Elapsed Time",
-      "elapsedValue": "3m 12s",
-      "source1": "2026 AI Agent Market Trends Report",
-      "source2": "Multi-Agent Orchestration Architecture Analysis",
-      "source3": "Enterprise LLM Adoption Case Study",
-      "source4": "Autonomous Agent Safety Guidelines",
-      "source5": "RAG vs Long-Context Comparison Benchmark"
-    },
     "viewAllToggle": "All users",
     "ownerBadge": "User {id}"
   },
@@ -1073,7 +1015,6 @@
     "activeServers": "Active servers",
     "activeServersDelta": "of 5 total",
     "totalCalls": "Total tool calls",
-    "avgLatency": "Avg latency",
     "errorRate": "Error rate",
     "serverDistribution": "Calls by server",
     "callCount": "{count} calls",
@@ -1212,7 +1153,12 @@
       "edit": "Edit",
       "delete": "Delete"
     },
-    "empty": "No users to display."
+    "empty": "No users to display.",
+    "guard": {
+      "denied": "Admin access required",
+      "deniedDescription": "Only administrator accounts can view this page.",
+      "home": "Back to chat"
+    }
   },
   "adminAnalytics": {
     "title": "Analytics",
@@ -1690,7 +1636,6 @@
   "usage": {
     "title": "Usage",
     "description": "Token and request usage for your account.",
-    "mockData": "Mock data",
     "updatedAt": "Updated {time}",
     "refresh": "Refresh",
     "loading": "Loading...",
@@ -1744,7 +1689,8 @@
     "quotaResetAt": "Resets at {time}",
     "quotaExceeded": "You have used up the hourly quota. You can send requests again after the reset time.",
     "globalQuotaTitle": "Global quota usage (server-wide)",
-    "globalQuotaNote": "Server-wide observation that resets on process restart — separate from your personal quota"
+    "globalQuotaNote": "Server-wide observation that resets on process restart — separate from your personal quota",
+    "loadFailed": "Could not load usage"
   },
   "developer": {
     "pageTitle": "Developer Docs",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -551,38 +551,6 @@
       "noResults": "検索結果がありません。",
       "hint": "新しい会話を始めるとここに表示されます。"
     },
-    "mock": {
-      "c1": {
-        "title": "Next.js 16 App Router 移行",
-        "preview": "既存の pages ルーターから app ルーターへ移行する際の注意点は...",
-        "time": "午後2:14"
-      },
-      "c2": {
-        "title": "PostgreSQL インデックスチューニング",
-        "preview": "複合インデックスの順序がクエリプランに与える影響を説明して",
-        "time": "午前11:02"
-      },
-      "c3": {
-        "title": "マーケティングキャンペーンのコピー ブレインストーミング",
-        "preview": "20代向けのSNS広告コピーを5パターン作って",
-        "time": "午後6:47"
-      },
-      "c4": {
-        "title": "リサーチレポートの構成づくり",
-        "preview": "エンタープライズLLM導入レポートの目次を提案して",
-        "time": "午後3:20"
-      },
-      "c5": {
-        "title": "TypeScript ジェネリック型ガード",
-        "preview": "Discriminated union を安全に絞り込む方法は？",
-        "time": "月曜日"
-      },
-      "c6": {
-        "title": "画像分析プロンプト",
-        "preview": "添付したチャートから主要なトレンドを読み取って",
-        "time": "日曜日"
-      }
-    },
     "viewAllToggle": "全ユーザー",
     "ownerBadge": "ユーザー {id}"
   },
@@ -801,20 +769,6 @@
     "deleteFailed": "削除に失敗しました: {message}",
     "elapsedSec": "{s}秒",
     "elapsedMinSec": "{m}分{s}秒",
-    "mock": {
-      "t1Goal": "競合サイト3件の価格戦略を分析し比較表にまとめる",
-      "t1Step1": "対象サイト一覧の確認",
-      "t1Step2": "各サイトの価格ページを取得",
-      "t1Step3": "価格データの正規化",
-      "t1Step4": "比較表の作成",
-      "t1Step5": "要約レポートの作成",
-      "t2Goal": "月次売上CSVを分析しレポートを生成",
-      "t2Step1": "データの読み込みと検証",
-      "t2Step2": "月別・製品別の集計",
-      "t2Step3": "推移チャートの生成",
-      "t2Step4": "PDFレポートの出力",
-      "t3Goal": "最新AI論文5本を要約し要点を整理"
-    },
     "autoApprove": "残りをすべて承認",
     "autoApproveHint": "このタスクの以降のツール実行を承認なしで進めます（質問は除く）",
     "tokensUsed": "{count} トークン",
@@ -962,18 +916,6 @@
       "progress": "進捗率",
       "depth": "深さ"
     },
-    "mock": {
-      "verifiedClaims": "検証済みの主張",
-      "conflicts": "検出された矛盾",
-      "tokensUsed": "使用トークン",
-      "elapsed": "経過時間",
-      "elapsedValue": "3分12秒",
-      "source1": "2026年AIエージェント市場動向レポート",
-      "source2": "マルチエージェントオーケストレーションアーキテクチャ分析",
-      "source3": "エンタープライズLLM導入事例研究",
-      "source4": "自律エージェント安全性ガイドライン",
-      "source5": "RAG対ロングコンテキスト比較ベンチマーク"
-    },
     "viewAllToggle": "全ユーザー",
     "ownerBadge": "ユーザー {id}"
   },
@@ -1073,7 +1015,6 @@
     "activeServers": "アクティブサーバー",
     "activeServersDelta": "全 5 件中",
     "totalCalls": "総ツール呼び出し",
-    "avgLatency": "平均遅延",
     "errorRate": "エラー率",
     "serverDistribution": "サーバー別呼び出し分布",
     "callCount": "{count}回",
@@ -1212,7 +1153,12 @@
       "edit": "編集",
       "delete": "削除"
     },
-    "empty": "表示するユーザーがありません。"
+    "empty": "表示するユーザーがありません。",
+    "guard": {
+      "denied": "管理者権限が必要です",
+      "deniedDescription": "このページは管理者アカウントのみ閲覧できます。",
+      "home": "チャットに戻る"
+    }
   },
   "adminAnalytics": {
     "title": "アナリティクス",
@@ -1690,7 +1636,6 @@
   "usage": {
     "title": "使用量",
     "description": "アカウント単位のトークン・リクエスト使用量です。",
-    "mockData": "モックデータ",
     "updatedAt": "更新 {time}",
     "refresh": "更新",
     "loading": "読み込み中...",
@@ -1744,7 +1689,8 @@
     "quotaResetAt": "{time} にリセット",
     "quotaExceeded": "1時間あたりのクォータを使い切りました。リセット時刻以降に再度リクエストできます。",
     "globalQuotaTitle": "グローバルクォータ消費率 (サーバー全体)",
-    "globalQuotaNote": "プロセス再起動でリセットされる全体観測値 — 個人クォータとは別"
+    "globalQuotaNote": "プロセス再起動でリセットされる全体観測値 — 個人クォータとは別",
+    "loadFailed": "使用量を読み込めませんでした"
   },
   "developer": {
     "pageTitle": "開発者ドキュメント",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -551,38 +551,6 @@
       "noResults": "검색 결과가 없습니다.",
       "hint": "새 대화를 시작하면 여기에 표시됩니다."
     },
-    "mock": {
-      "c1": {
-        "title": "Next.js 16 App Router 마이그레이션",
-        "preview": "기존 pages 라우터에서 app 라우터로 옮길 때 주의할 점은...",
-        "time": "오후 2:14"
-      },
-      "c2": {
-        "title": "PostgreSQL 인덱스 튜닝",
-        "preview": "복합 인덱스 순서가 쿼리 플랜에 미치는 영향을 설명해줘",
-        "time": "오전 11:02"
-      },
-      "c3": {
-        "title": "마케팅 캠페인 카피 브레인스토밍",
-        "preview": "20대 타겟의 SNS 광고 카피 5개 변형을 만들어줘",
-        "time": "오후 6:47"
-      },
-      "c4": {
-        "title": "리서치 보고서 구조 잡기",
-        "preview": "엔터프라이즈 LLM 도입 보고서의 목차를 제안해줘",
-        "time": "오후 3:20"
-      },
-      "c5": {
-        "title": "TypeScript 제네릭 타입 가드",
-        "preview": "Discriminated union 을 안전하게 좁히는 방법은?",
-        "time": "월요일"
-      },
-      "c6": {
-        "title": "이미지 분석 프롬프트",
-        "preview": "첨부한 차트에서 주요 트렌드를 읽어줘",
-        "time": "일요일"
-      }
-    },
     "viewAllToggle": "모든 사용자",
     "ownerBadge": "사용자 {id}"
   },
@@ -801,20 +769,6 @@
     "deleteFailed": "삭제 실패: {message}",
     "elapsedSec": "{s}초",
     "elapsedMinSec": "{m}분 {s}초",
-    "mock": {
-      "t1Goal": "경쟁사 웹사이트 3곳의 가격 정책을 분석해 비교표로 정리",
-      "t1Step1": "대상 사이트 목록 확인",
-      "t1Step2": "각 사이트 가격 페이지 스크래핑",
-      "t1Step3": "가격 데이터 정규화",
-      "t1Step4": "비교표 생성",
-      "t1Step5": "요약 리포트 작성",
-      "t2Goal": "월간 매출 CSV를 분석해 리포트 생성",
-      "t2Step1": "데이터 로드 및 검증",
-      "t2Step2": "월별·제품별 집계",
-      "t2Step3": "추이 차트 생성",
-      "t2Step4": "PDF 리포트 내보내기",
-      "t3Goal": "최신 AI 논문 5편을 요약해 핵심 정리"
-    },
     "autoApprove": "나머지 모두 승인",
     "autoApproveHint": "이 작업의 이후 도구 실행을 승인 없이 진행합니다 (질문 제외)",
     "tokensUsed": "{count} 토큰",
@@ -962,18 +916,6 @@
       "progress": "진행률",
       "depth": "깊이"
     },
-    "mock": {
-      "verifiedClaims": "검증 주장",
-      "conflicts": "상충 발견",
-      "tokensUsed": "사용 토큰",
-      "elapsed": "경과 시간",
-      "elapsedValue": "3분 12초",
-      "source1": "2026 AI 에이전트 시장 동향 보고서",
-      "source2": "멀티 에이전트 오케스트레이션 아키텍처 분석",
-      "source3": "엔터프라이즈 LLM 도입 사례 연구",
-      "source4": "자율 에이전트 안전성 가이드라인",
-      "source5": "RAG vs 장기 컨텍스트 비교 벤치마크"
-    },
     "viewAllToggle": "모든 사용자",
     "ownerBadge": "사용자 {id}"
   },
@@ -1073,7 +1015,6 @@
     "activeServers": "활성 서버",
     "activeServersDelta": "전체 5개 중",
     "totalCalls": "총 도구 호출",
-    "avgLatency": "평균 지연",
     "errorRate": "에러율",
     "serverDistribution": "서버별 호출 분포",
     "callCount": "{count}회",
@@ -1212,7 +1153,12 @@
       "edit": "편집",
       "delete": "삭제"
     },
-    "empty": "표시할 사용자가 없습니다."
+    "empty": "표시할 사용자가 없습니다.",
+    "guard": {
+      "denied": "관리자 권한이 필요합니다",
+      "deniedDescription": "이 페이지는 관리자 계정만 볼 수 있습니다.",
+      "home": "채팅으로 돌아가기"
+    }
   },
   "adminAnalytics": {
     "title": "애널리틱스",
@@ -1690,7 +1636,6 @@
   "usage": {
     "title": "사용량",
     "description": "내 계정 기준 토큰·요청 사용량입니다.",
-    "mockData": "목업 데이터",
     "updatedAt": "갱신 {time}",
     "refresh": "새로고침",
     "loading": "불러오는 중...",
@@ -1744,7 +1689,8 @@
     "quotaResetAt": "{time}에 초기화",
     "quotaExceeded": "시간당 쿼터를 모두 사용했습니다. 초기화 시각 이후 다시 요청할 수 있습니다.",
     "globalQuotaTitle": "전역 쿼터 소진율 (서버 전체)",
-    "globalQuotaNote": "프로세스 재시작 시 초기화되는 전역 관측치 — 개인 쿼터와 별개"
+    "globalQuotaNote": "프로세스 재시작 시 초기화되는 전역 관측치 — 개인 쿼터와 별개",
+    "loadFailed": "사용량을 불러오지 못했습니다"
   },
   "developer": {
     "pageTitle": "개발자 문서",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -551,38 +551,6 @@
       "noResults": "没有搜索结果。",
       "hint": "开始新对话后将显示在此处。"
     },
-    "mock": {
-      "c1": {
-        "title": "Next.js 16 App Router 迁移",
-        "preview": "从现有的 pages 路由迁移到 app 路由时需要注意什么...",
-        "time": "下午2:14"
-      },
-      "c2": {
-        "title": "PostgreSQL 索引调优",
-        "preview": "解释复合索引的顺序对查询计划的影响",
-        "time": "上午11:02"
-      },
-      "c3": {
-        "title": "营销活动文案头脑风暴",
-        "preview": "为面向20多岁人群制作5个社交媒体广告文案变体",
-        "time": "下午6:47"
-      },
-      "c4": {
-        "title": "搭建研究报告结构",
-        "preview": "为企业 LLM 采用报告提议一个目录",
-        "time": "下午3:20"
-      },
-      "c5": {
-        "title": "TypeScript 泛型类型守卫",
-        "preview": "如何安全地收窄可辨识联合类型？",
-        "time": "周一"
-      },
-      "c6": {
-        "title": "图像分析提示词",
-        "preview": "从附加的图表中解读主要趋势",
-        "time": "周日"
-      }
-    },
     "viewAllToggle": "所有用户",
     "ownerBadge": "用户 {id}"
   },
@@ -801,20 +769,6 @@
     "deleteFailed": "删除失败：{message}",
     "elapsedSec": "{s}秒",
     "elapsedMinSec": "{m}分{s}秒",
-    "mock": {
-      "t1Goal": "分析3个竞品网站的价格策略并整理成对比表",
-      "t1Step1": "确认目标网站列表",
-      "t1Step2": "抓取各网站价格页面",
-      "t1Step3": "规范化价格数据",
-      "t1Step4": "生成对比表",
-      "t1Step5": "撰写摘要报告",
-      "t2Goal": "分析月度销售CSV并生成报告",
-      "t2Step1": "加载并校验数据",
-      "t2Step2": "按月份和产品汇总",
-      "t2Step3": "生成趋势图表",
-      "t2Step4": "导出PDF报告",
-      "t3Goal": "总结5篇最新AI论文并提炼要点"
-    },
     "autoApprove": "批准其余全部",
     "autoApproveHint": "此任务后续的工具调用将无需批准直接执行（提问除外）",
     "tokensUsed": "{count} 令牌",
@@ -962,18 +916,6 @@
       "progress": "进度",
       "depth": "深度"
     },
-    "mock": {
-      "verifiedClaims": "已验证主张",
-      "conflicts": "发现的冲突",
-      "tokensUsed": "已用令牌",
-      "elapsed": "耗时",
-      "elapsedValue": "3分12秒",
-      "source1": "2026 AI 智能体市场趋势报告",
-      "source2": "多智能体编排架构分析",
-      "source3": "企业级 LLM 采用案例研究",
-      "source4": "自主智能体安全指南",
-      "source5": "RAG 与长上下文对比基准"
-    },
     "viewAllToggle": "所有用户",
     "ownerBadge": "用户 {id}"
   },
@@ -1073,7 +1015,6 @@
     "activeServers": "活跃服务器",
     "activeServersDelta": "共 5 个",
     "totalCalls": "工具调用总数",
-    "avgLatency": "平均延迟",
     "errorRate": "错误率",
     "serverDistribution": "各服务器调用分布",
     "callCount": "{count}次",
@@ -1212,7 +1153,12 @@
       "edit": "编辑",
       "delete": "删除"
     },
-    "empty": "没有可显示的用户。"
+    "empty": "没有可显示的用户。",
+    "guard": {
+      "denied": "需要管理员权限",
+      "deniedDescription": "只有管理员账号可以查看此页面。",
+      "home": "返回聊天"
+    }
   },
   "adminAnalytics": {
     "title": "分析",
@@ -1690,7 +1636,6 @@
   "usage": {
     "title": "使用量",
     "description": "按账户统计的令牌与请求使用量。",
-    "mockData": "模拟数据",
     "updatedAt": "更新于 {time}",
     "refresh": "刷新",
     "loading": "加载中...",
@@ -1744,7 +1689,8 @@
     "quotaResetAt": "{time} 重置",
     "quotaExceeded": "每小时配额已用尽。请在重置时间之后重新发送请求。",
     "globalQuotaTitle": "全局配额消耗 (服务器整体)",
-    "globalQuotaNote": "进程重启即重置的全局观测值 — 与个人配额无关"
+    "globalQuotaNote": "进程重启即重置的全局观测值 — 与个人配额无关",
+    "loadFailed": "无法加载用量"
   },
   "developer": {
     "pageTitle": "开发者文档",


### PR DESCRIPTION
## 목업 폴백 제거

| 페이지 | 그전 | 조치 |
|---|---|---|
| `/research` | 목업 소스 5개 + 메트릭(검증 주장 23·48.2K 토큰…) — 메트릭은 **세션이 있어도 항상 목업** | 소스·메트릭 빈 상태, 진행 단계 템플릿은 전부 pending 에서 시작 |
| `/history` | 폐기 brand profile(Pro/Think/Vision…) 이름을 단 대화 6건 | 빈 상태 |
| `/agent-tasks` | 작업 3건(Pro/Default/Fast) | 빈 상태 |
| `/usage` | 사인파 14일치 + 가짜 월 합계(modelUsage default/pro/fast/code) | 실패 시 "사용량을 불러오지 못했습니다" |
| `/admin/mcp-monitoring` | 고정 요약(활성 4·호출 12,840·186ms·1.4%), "평균 지연"은 백엔드 메트릭 없음 | "—" 초기값, 평균 지연 타일 제거 |
| `/developer` | 정적 Quick Start 기본값 | **유지** — 데이터가 아니라 문서(API 도 인라인 JSON 문서)라 폴백이 정당. 주석만 정정 |

고아 i18n 42건(4 locale) 삭제.

## `/admin/*` role 가드

`app/(workspace)/admin/layout.tsx` — `store.authResolved`(신규: `/api/auth/me` 1회 동기화 완료 플래그, `auth-sync` 의 성공·게스트·실패 모든 경로에서 `finally` 로 set)를 기다린 뒤 `role !== 'admin'` 이면 "관리자 권한이 필요합니다" 카드만 렌더. 플래그 없이 판정하면 새로고침 직후 관리자에게도 거부 화면이 번쩍인다.

## 검증 (로컬 next dev)

- 게스트: `/admin`·`/admin/analytics` → 거부 카드(통계 미렌더). 다른 페이지는 기존 401 인터셉트로 로그인 페이지 — 목업이 나올 경로 자체가 없음
- 관리자: `/admin` 대시보드 정상, `/admin/mcp-monitoring` 실값(활성 12·호출 3,041·9.2%)·평균 지연 타일 없음, `/usage`·`/research`·`/history` 실데이터

tsc·eslint 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)