### PR TITLE
chore(mcp): @modelcontextprotocol/sdk ^1.30.0 범프 (v1 최종선, MCP 2.0 이전 폐기)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,7 +21,7 @@
         "eval:all": "npm run eval:routing && npm run eval:response && npm run eval:citation"
     },
     "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.3",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@mozilla/readability": "^0.6.0",
         "@openai-oauth/core": "^2.0.0",
         "@opendataloader/pdf": "^2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,9 +47,9 @@
         },
         "apps/api": {
             "name": "openmake-api",
-            "version": "1.32.1",
+            "version": "1.33.1",
             "dependencies": {
-                "@modelcontextprotocol/sdk": "^1.25.3",
+                "@modelcontextprotocol/sdk": "^1.30.0",
                 "@mozilla/readability": "^0.6.0",
                 "@openai-oauth/core": "^2.0.0",
                 "@opendataloader/pdf": "^2.5.0",
@@ -139,7 +139,7 @@
         },
         "apps/discord-bot": {
             "name": "openmake-discord-bot",
-            "version": "1.32.1",
+            "version": "1.33.1",
             "dependencies": {
                 "discord.js": "^14.16.3",
                 "dotenv": "^16.4.5"
@@ -166,7 +166,7 @@
         },
         "apps/web": {
             "name": "@openmake/web",
-            "version": "1.32.1",
+            "version": "1.33.1",
             "dependencies": {
                 "@openmake/api-client": "*",
                 "@openmake/config": "*",
@@ -2932,12 +2932,12 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/@modelcontextprotocol/sdk": {
-            "version": "1.29.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-            "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+            "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
             "license": "MIT",
             "dependencies": {
-                "@hono/node-server": "^1.19.9",
+                "@hono/node-server": "^1.19.9 || ^2.0.5",
                 "ajv": "^8.17.1",
                 "ajv-formats": "^3.0.1",
                 "content-type": "^1.0.5",
@@ -17474,7 +17474,7 @@
         },
         "packages/api-client": {
             "name": "@openmake/api-client",
-            "version": "1.32.1",
+            "version": "1.33.1",
             "dependencies": {
                 "@openmake/config": "*",
                 "@openmake/shared-types": "*"
@@ -17486,7 +17486,7 @@
         },
         "packages/config": {
             "name": "@openmake/config",
-            "version": "1.32.1"
+            "version": "1.33.1"
         },
         "packages/local-bridge-core": {
             "name": "@openmake/local-bridge-core",
@@ -17500,7 +17500,7 @@
         },
         "packages/shared-types": {
             "name": "@openmake/shared-types",
-            "version": "1.32.1"
+            "version": "1.33.1"
         }
     }
 }


### PR DESCRIPTION
## 배경
MCP 2026-07-28('2.0') 클라이언트 이전은 사용자 결정으로 폐기. v1 라인 최신 1.30.0 으로만 맞춘다.

## 영향 검토
- 1.30.0 = 버그픽스 릴리스(2026-07-27): zod 3.25 method literal · Content-Type 을 parsed media type 으로 판정 · **stdio ReadBuffer 상한 10MB 신설**(`STDIO_DEFAULT_MAX_BUFFER_SIZE`, 단일 JSON-RPC 메시지 기준 — 우리 도구 결과는 `MAX_TOOL_RESULT_CHARS` 로 훨씬 아래) · Streamable HTTP 서버 SSE keep-alive(서버 측, 우리는 클라이언트만) · `@hono/node-server` 보안 범위
- peer 의존 1.29 와 동일(`zod ^3.25 || ^4.0`, 설치 4.3.6; `@cfworker/json-schema` optional)
- 우리 사용 표면(`Client`·Stdio/SSE/StreamableHTTP 전송·`OAuthClientProvider`) API 변경 없음

## 검증
- `tsc` 통과, MCP 관련 jest 27 스위트 194건 통과
- 같은 날 운영 DB 에서 npx 핀 적용(코드 무관): 서버 행 `mcp-filesystem@2026.7.10`, 카탈로그 `mcp-filesystem@2026.7.10`·`mcp-notion@2.5.1`·`mcp-github@2025.4.8`. 핀된 filesystem 서버 라이브 재연결 → 도구 14개 정상
- ⚠️ `@modelcontextprotocol/server-github` 는 npm deprecated("no longer supported") — 카탈로그 잔존 여부는 별도 판단

🤖 Generated with [Claude Code](https://claude.com/claude-code)