### PR TITLE
feat(cli): openmake-code tasks/resume/--resume — 로컬 작업 이어하기 (+취소 작업 resume 결함 수정)

### DIFF
--- a/apps/api/src/__tests__/routes/agent-task.helpers.filter.test.ts
+++ b/apps/api/src/__tests__/routes/agent-task.helpers.filter.test.ts
@@ -1,8 +1,9 @@
 /**
  * filterTaskList — GET /api/agent-tasks 의 CLI 용 부가 필터(executor/deviceId/status).
- * 순수 함수라 DB 없이 검증한다.
+ * toPublicTask.resumable — resume 라우트 허용 범위(failed/cancelled + checkpoint)와 일치.
+ * 둘 다 순수 함수라 DB 없이 검증한다.
  */
-import { filterTaskList } from '../../routes/agent-task.helpers';
+import { filterTaskList, toPublicTask } from '../../routes/agent-task.helpers';
 
 const rows = [
     { id: 'a', executor: 'local', device_id: 'dev-1', status: 'failed' },
@@ -30,5 +31,20 @@ describe('filterTaskList', () => {
 
     test('빈 문자열·비문자열 쿼리는 필터로 취급하지 않는다', () => {
         expect(filterTaskList(rows, { executor: '', deviceId: ['x'], status: 42 }).length).toBe(4);
+    });
+});
+
+
+describe('toPublicTask.resumable', () => {
+    const cp = { conversation: [{ role: 'user', content: 'x' }], completedTurn: 1 };
+    test('failed + checkpoint → resumable', () => {
+        expect(toPublicTask({ id: 't', status: 'failed', checkpoint: cp }).resumable).toBe(true);
+    });
+    test('cancelled + checkpoint → resumable (resume 라우트 허용 범위와 일치)', () => {
+        expect(toPublicTask({ id: 't', status: 'cancelled', checkpoint: cp }).resumable).toBe(true);
+    });
+    test('checkpoint 없음 / completed → 불가', () => {
+        expect(toPublicTask({ id: 't', status: 'failed', checkpoint: null }).resumable).toBe(false);
+        expect(toPublicTask({ id: 't', status: 'completed', checkpoint: cp }).resumable).toBe(false);
     });
 });

--- a/apps/api/src/__tests__/routes/agent-task.helpers.filter.test.ts
+++ b/apps/api/src/__tests__/routes/agent-task.helpers.filter.test.ts
@@ -1,0 +1,34 @@
+/**
+ * filterTaskList — GET /api/agent-tasks 의 CLI 용 부가 필터(executor/deviceId/status).
+ * 순수 함수라 DB 없이 검증한다.
+ */
+import { filterTaskList } from '../../routes/agent-task.helpers';
+
+const rows = [
+    { id: 'a', executor: 'local', device_id: 'dev-1', status: 'failed' },
+    { id: 'b', executor: 'local', device_id: 'dev-2', status: 'completed' },
+    { id: 'c', executor: null, device_id: null, status: 'failed' },
+    { id: 'd', executor: 'local', device_id: 'dev-1', status: 'cancelled' },
+];
+
+describe('filterTaskList', () => {
+    test('필터 없음 → 전부 통과', () => {
+        expect(filterTaskList(rows, {}).map(r => r.id)).toEqual(['a', 'b', 'c', 'd']);
+    });
+
+    test('executor=local 은 샌드박스(executor null) 작업을 뺀다', () => {
+        expect(filterTaskList(rows, { executor: 'local' }).map(r => r.id)).toEqual(['a', 'b', 'd']);
+    });
+
+    test('deviceId 는 그 디바이스 작업만', () => {
+        expect(filterTaskList(rows, { executor: 'local', deviceId: 'dev-1' }).map(r => r.id)).toEqual(['a', 'd']);
+    });
+
+    test('status 는 콤마 목록', () => {
+        expect(filterTaskList(rows, { status: 'failed,cancelled' }).map(r => r.id)).toEqual(['a', 'c', 'd']);
+    });
+
+    test('빈 문자열·비문자열 쿼리는 필터로 취급하지 않는다', () => {
+        expect(filterTaskList(rows, { executor: '', deviceId: ['x'], status: 42 }).length).toBe(4);
+    });
+});

--- a/apps/api/src/routes/agent-task.helpers.ts
+++ b/apps/api/src/routes/agent-task.helpers.ts
@@ -75,7 +75,13 @@ export function toPublicTask(t: Record<string, unknown>) {
     const fileMetas = Array.isArray(input_files)
         ? (input_files as AgentTaskInputFile[]).map((f) => ({ name: f?.name, type: f?.type, size: f?.size }))
         : undefined;
-    return { ...rest, ...(fileMetas ? { input_files: fileMetas } : {}), resumable: !!checkpoint && t.status === 'failed' };
+    // resume 라우트가 허용하는 범위와 일치 — failed/cancelled + checkpoint. (웹 Resume 버튼은 여기에
+    // RESUMABLE_ERROR_CODES 를 추가로 거르므로 cancelled 포함이 웹 노출을 바꾸지 않는다.)
+    return {
+        ...rest,
+        ...(fileMetas ? { input_files: fileMetas } : {}),
+        resumable: !!checkpoint && (t.status === 'failed' || t.status === 'cancelled'),
+    };
 }
 
 /**

--- a/apps/api/src/routes/agent-task.helpers.ts
+++ b/apps/api/src/routes/agent-task.helpers.ts
@@ -47,6 +47,28 @@ export async function loadOwnedTask(req: Request, res: Response, taskId: string)
 
 /** 응답용 변환: 큰 checkpoint/input_files/input_images 본문 제거 + resumable 플래그(중단된 작업에 체크포인트 존재).
  *  input_files 는 내용(content/data)을 뺀 메타(name/type/size)만 노출 — 목록/상세 응답 팽창 방지. */
+/**
+ * 목록 필터 — CLI `openmake-code tasks` 가 "이 디바이스의 로컬 작업"만 보게 하려고 둔 부가 필터.
+ * 본인(또는 admin viewAll) 범위 안에서만 거르므로 권한 변화가 없다. 값이 없으면 통과.
+ * PURE: 라우트 밖에서 단위테스트 대상.
+ */
+export function filterTaskList<T extends { executor?: string | null; device_id?: string | null; status?: string }>(
+    tasks: T[],
+    q: { executor?: unknown; deviceId?: unknown; status?: unknown },
+): T[] {
+    const executor = typeof q.executor === 'string' && q.executor ? q.executor : null;
+    const deviceId = typeof q.deviceId === 'string' && q.deviceId ? q.deviceId : null;
+    // status 는 콤마 목록 허용 (예: failed,cancelled)
+    const statuses = typeof q.status === 'string' && q.status
+        ? new Set(q.status.split(',').map(s => s.trim()).filter(Boolean))
+        : null;
+    return tasks.filter(t =>
+        (!executor || t.executor === executor) &&
+        (!deviceId || t.device_id === deviceId) &&
+        (!statuses || (t.status !== undefined && statuses.has(t.status))),
+    );
+}
+
 export function toPublicTask(t: Record<string, unknown>) {
     const { checkpoint, input_files, input_images, ...rest } = t;
     void input_images; // dataURL 배열 — 응답에서 제외(팽창 방지)

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -51,7 +51,7 @@ import {
 } from '../services/agent-task/upload-store';
 import { claimUploadsAsInputFiles, ChunkStoreError } from '../services/agent-task/chunk-store';
 import { resolveDefaultMaxTurns } from '../services/agent-task/task-inputs';
-import { auditLocalTaskCreate, loadOwnedTask, toPublicTask, validateLocalExecutorInput } from './agent-task.helpers';
+import { auditLocalTaskCreate, filterTaskList, loadOwnedTask, toPublicTask, validateLocalExecutorInput } from './agent-task.helpers';
 import { isAdminRole } from '../data/user-manager';
 
 const logger = createLogger('AgentTaskRoutes');
@@ -252,9 +252,11 @@ router.get('/', asyncHandler(async (req: Request, res: Response) => {
         viewAll: req.query.viewAll === 'true',
         userId,
     });
-    const tasks = scope === 'all'
+    const fetched = scope === 'all'
         ? await db.getAllAgentTasks(AGENT_TASK_LIMITS.LIST_ALL_DEFAULT)
         : await db.getUserAgentTasks(userId);
+    // ?executor=local&deviceId=…&status=failed,cancelled — CLI 목록용 부가 필터(권한 범위 무변경)
+    const tasks = filterTaskList(fetched, req.query);
     res.json(success({ tasks: tasks.map(t => toPublicTask(t as unknown as Record<string, unknown>)), total: tasks.length }));
 }));
 

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -162,8 +162,11 @@ export class AgentTaskService {
         AgentTaskService.running.set(taskId, this);
         try {
             // 레지스트리 등록 전(detached 스케줄링 창)에 접수된 취소는 DB 에만 기록됨 — 시작 전 존중.
+            // 단 resume 은 "취소됐던 작업을 이어가는 것" 자체라 영속 상태 cancelled 를 취소 요청으로
+            // 읽으면 안 된다 — 그전엔 취소 작업 재개가 202 직후 곧바로 다시 aborted 로 끝났다
+            // (2026-08-26 CLI resume E2E 실측). AbortController 는 인스턴스별로 새것이라 signal 만 본다.
             const preTask = await db.getAgentTask(taskId);
-            if (signal.aborted || preTask?.status === 'cancelled') throw new AgentTaskAbort('aborted');
+            if (signal.aborted || (!input.resume && preTask?.status === 'cancelled')) throw new AgentTaskAbort('aborted');
             // resume: 이전 실행분 토큰을 이어서 누적(4-4) — runaway 토큰 가드도 통산 기준으로 동작.
             if (input.resume) totalTokens = Number(preTask?.total_tokens ?? 0);
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -60,7 +60,18 @@ openmake-code login              # 서버 URL·API key 저장 (~/.openmake/confi
 openmake-code connect [dir]      # 폴더 상주 연결 — 웹에서 작업을 시작할 수 있게 된다
 openmake-code status             # 연결 상태·디바이스 조회
 openmake-code "목표" [--dir .] [--yes]   # 로컬 에이전트 작업 1회 실행
+openmake-code tasks [--all]      # 이 디바이스의 로컬 작업 목록 (종료 작업은 --all)
+openmake-code resume <taskId> [--dir .] [--yes]   # checkpoint 에서 이어하기
+openmake-code "목표" --resume    # 재개 가능한 최근 작업이 있으면 그것을 이어감
 ```
+### 이어하기 (resume)
+- 서버가 작업(`agent_tasks`)과 checkpoint 를 보존하므로, 실패한 작업은 **`resume <taskId>`** 로 같은
+  대화·같은 worktree(`omk-task/<id>` 브랜치)에서 이어간다. `tasks` 목록의 `[resume 가능]` 표시가 대상.
+- 재개도 **디바이스가 연결돼 있어야** 한다 — `resume` 이 `--dir`(기본 cwd)로 폴더를 먼저 연결한다.
+  서버는 하위 폴더(상대경로)만 기억하고 루트는 디바이스만 알기 때문에, 원래 작업을 시작한
+  **같은 루트 폴더에서** 실행해야 한다.
+- 진행 중(`running`/`paused`)인 작업에 `resume` 을 하면 재실행하지 않고 진행만 따라간다.
+- 재개가 거부되는 경우는 서버 메시지를 그대로 보여준다(이미 완료·checkpoint 없음·디바이스 미연결).
 
 - `connect` 는 **전경 데몬**이다. 종료는 `Ctrl+C`.
 - 디바이스당 폴더는 **하나**다. 여러 폴더가 필요하면 터미널을 여러 개 띄워 각각 `connect` 한다.

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -10,6 +10,13 @@ export interface ApiTask {
     error?: string;
     executor?: string;
     device_id?: string;
+    goal?: string;
+    /** 연결 루트 기준 상대 폴더(웹에서 고른 하위 폴더). 루트 자체는 디바이스만 안다. */
+    folder_rel?: string | null;
+    created_at?: string;
+    updated_at?: string;
+    /** 서버 판정: failed + checkpoint 보유 → `resume` 가능 */
+    resumable?: boolean;
 }
 
 export interface PendingApproval {
@@ -51,6 +58,17 @@ export class ApiClient {
     }
     executeTask(taskId: string): Promise<unknown> {
         return this.req('POST', `/api/agent-tasks/${taskId}/execute`, {});
+    }
+    /** 이 디바이스의 로컬 작업 목록 — 서버 부가 필터(executor/deviceId/status)로 샌드박스 작업을 섞지 않는다. */
+    listTasks(opts: { deviceId?: string; status?: string } = {}): Promise<{ tasks: ApiTask[]; total: number }> {
+        const q = new URLSearchParams({ executor: 'local' });
+        if (opts.deviceId) q.set('deviceId', opts.deviceId);
+        if (opts.status) q.set('status', opts.status);
+        return this.req('GET', `/api/agent-tasks?${q.toString()}`);
+    }
+    /** checkpoint 재개 — 서버가 상태·checkpoint·디바이스 연결을 검증한다(실패 사유는 400 메시지). */
+    resumeTask(taskId: string): Promise<{ message?: string; queued?: boolean }> {
+        return this.req('POST', `/api/agent-tasks/${taskId}/resume`, {});
     }
     /** 작업 단위 서버 승인 자동화 (데스크톱 일괄 승인과 동등) — 헤드리스/CI 실행용. */
     setAutoApprove(taskId: string, enabled: boolean): Promise<unknown> {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -8,6 +8,9 @@
  *   connect [dir]          폴더 상주 연결(데몬 전경 실행, 단일 폴더)
  *   status                 연결 상태·디바이스 조회
  *   "목표" [--dir .]        cwd(또는 --dir)에서 로컬 에이전트 작업 1회 실행
+ *   tasks [--all]          이 디바이스의 로컬 작업 목록 (기본: 미종료·재개 가능만)
+ *   resume <taskId> [--dir .]  checkpoint 에서 이어하기 (서버 재개 API + 같은 worktree 재부착)
+ *   "목표" --resume        마지막 재개 가능 작업이 있으면 그것을 이어한다
  */
 import * as fs from 'fs';
 import * as path from 'path';
@@ -100,17 +103,17 @@ function taskOf(r: { task?: ApiTask } | ApiTask): ApiTask {
     return (r as { task?: ApiTask }).task ?? (r as ApiTask);
 }
 
-async function cmdRun(goal: string, dir: string, autoApprove: boolean): Promise<void> {
-    const cfg = requireConfig();
-    const folder = path.resolve(dir);
-    const api = new ApiClient(cfg.serverUrl, cfg.apiKey);
+/** 서버 승인 자동화 여부 — --yes 또는 비대화형(비-TTY). 셸 확인은 별개(디바이스 confirmExec). */
+function shouldAutoApprove(autoApprove: boolean): boolean {
     // --yes 또는 비대화형(비-TTY)이면 서버 승인을 작업 단위로 자동화한다 — 그렇지 않으면
     // 파일 쓰기류 서버 HITL 이 매번 y/N 을 요구해 헤드리스/CI 실행이 막힌다. 셸/파이썬은
     // 별도로 디바이스 confirmExec 이 게이트하므로(OMK_BRIDGE_AUTO_APPROVE), 이 플래그는 서버측만.
-    const serverAutoApprove = autoApprove || !process.stdin.isTTY;
-    const bridge = connectBridge(cfg, folder);
+    return autoApprove || !process.stdin.isTTY;
+}
 
-    // 브리지 등록 대기 (서버가 이 디바이스를 인지할 때까지 최대 ~10s).
+/** 폴더를 브리지로 연결하고 서버가 이 디바이스를 인지할 때까지 대기(최대 ~10s). 실패 시 종료. */
+async function connectAndRegister(cfg: { serverUrl: string; apiKey: string }, api: ApiClient, folder: string): Promise<CliBridge> {
+    const bridge = connectBridge(cfg, folder);
     const myId = deviceId();
     let registered = false;
     for (let i = 0; i < 20; i++) {
@@ -122,9 +125,18 @@ async function cmdRun(goal: string, dir: string, autoApprove: boolean): Promise<
         } catch { /* 재시도 */ }
     }
     if (!registered) { console.error('브리지 연결에 실패했습니다.'); bridge.disconnect(); process.exit(1); }
+    return bridge;
+}
+
+async function cmdRun(goal: string, dir: string, autoApprove: boolean): Promise<void> {
+    const cfg = requireConfig();
+    const folder = path.resolve(dir);
+    const api = new ApiClient(cfg.serverUrl, cfg.apiKey);
+    const serverAutoApprove = shouldAutoApprove(autoApprove);
+    const bridge = await connectAndRegister(cfg, api, folder);
 
     console.log(`\x1b[32m✓ 연결됨\x1b[0m — 작업을 생성합니다.`);
-    const created = taskOf(await api.createTask(goal, myId));
+    const created = taskOf(await api.createTask(goal, deviceId()));
     const taskId = created.id;
     if (serverAutoApprove) {
         await api.setAutoApprove(taskId, true);
@@ -132,8 +144,14 @@ async function cmdRun(goal: string, dir: string, autoApprove: boolean): Promise<
     }
     await api.executeTask(taskId);
     console.log(`\x1b[36m작업 ${taskId} 실행 중…\x1b[0m (Ctrl+C 로 CLI 종료)`);
+    await followTask(api, bridge, taskId);
+}
 
-    // 진행 폴링 — 승인 대기(pending)는 터미널에서 즉시 처리, 상태는 변할 때만 출력.
+/**
+ * 진행 폴링 — run/resume 공용. 승인 대기(pending)는 터미널에서 즉시 처리, 상태는 변할 때만 출력.
+ * 종료 상태에 도달하면 브리지를 끊고 프로세스를 종료한다(completed=0, 그 외 1).
+ */
+async function followTask(api: ApiClient, bridge: CliBridge, taskId: string): Promise<never> {
     let lastStatus = '';
     let lastProgress = -1;
     const seenApprovals = new Set<string>();
@@ -176,12 +194,87 @@ async function cmdRun(goal: string, dir: string, autoApprove: boolean): Promise<
     }
 }
 
+function shortId(id: string): string { return id.length > 12 ? `${id.slice(0, 8)}…` : id; }
+function fmtWhen(iso?: string): string {
+    if (!iso) return '-';
+    const d = new Date(iso);
+    return Number.isNaN(d.getTime()) ? '-' : `${d.getMonth() + 1}/${d.getDate()} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}
+/** 목록 기본값: 종료(completed) 는 --all 일 때만. failed/cancelled 는 재개 후보라 항상 보여준다. */
+function isListedByDefault(t: ApiTask): boolean { return t.status !== 'completed'; }
+
+async function cmdTasks(all: boolean): Promise<void> {
+    const cfg = requireConfig();
+    const api = new ApiClient(cfg.serverUrl, cfg.apiKey);
+    const { tasks } = await api.listTasks({ deviceId: deviceId() });
+    const rows = all ? tasks : tasks.filter(isListedByDefault);
+    if (rows.length === 0) {
+        console.log(all ? '이 디바이스의 로컬 작업이 없습니다.' : '미종료·재개 가능한 로컬 작업이 없습니다. (`--all` 로 종료 작업 포함)');
+        return;
+    }
+    console.log(`이 디바이스(${deviceId().slice(0, 8)}…)의 로컬 작업 ${rows.length}건${all ? '' : ' — 종료 작업은 --all'}:`);
+    for (const t of rows) {
+        const flag = t.resumable ? ' \x1b[32m[resume 가능]\x1b[0m' : (t.status === 'running' || t.status === 'paused' || t.status === 'queued') ? ' \x1b[36m[진행 중]\x1b[0m' : '';
+        const folder = t.folder_rel ? ` · 폴더 ${t.folder_rel}` : '';
+        console.log(`  ${shortId(t.id).padEnd(10)} ${t.status.padEnd(9)} ${String(Math.round(t.progress ?? 0)).padStart(3)}%  ${fmtWhen(t.created_at)}  omk-task/${t.id.slice(0, 8)}${folder}${flag}`);
+        if (t.goal) console.log(`             ${t.goal.replace(/\s+/g, ' ').slice(0, 60)}`);
+    }
+}
+
+/** 재개 대상 선택 — 이 디바이스의 최근 `resumable`(failed+checkpoint) 작업. 진행 중이면 재개 대신 follow 대상. */
+async function pickResumeTarget(api: ApiClient): Promise<{ task: ApiTask; followOnly: boolean } | null> {
+    const { tasks } = await api.listTasks({ deviceId: deviceId() });
+    const live = tasks.find((t) => t.status === 'running' || t.status === 'paused' || t.status === 'queued');
+    if (live) return { task: live, followOnly: true };
+    const cand = tasks.find((t) => t.resumable);
+    return cand ? { task: cand, followOnly: false } : null;
+}
+
+async function cmdResume(taskId: string, dir: string, autoApprove: boolean): Promise<void> {
+    const cfg = requireConfig();
+    const folder = path.resolve(dir);
+    const api = new ApiClient(cfg.serverUrl, cfg.apiKey);
+    // 서버는 folder_rel(상대경로)만 안다 — 루트는 --dir/cwd 로 사용자가 준 것만 쓴다(디바이스 발원 원칙).
+    const task = taskOf(await api.getTask(taskId));
+    if (task.executor !== 'local') { console.error('로컬 실행 작업이 아닙니다 — 웹에서 이어하세요.'); process.exit(1); }
+    if (task.device_id && task.device_id !== deviceId()) {
+        console.error(`이 작업은 다른 디바이스(${task.device_id.slice(0, 8)}…)에서 만든 것입니다. 그 디바이스에서 resume 하세요.`);
+        process.exit(1);
+    }
+    const bridge = await connectAndRegister(cfg, api, folder);
+    if (task.status === 'running' || task.status === 'paused' || task.status === 'queued') {
+        console.log(`\x1b[36m작업 ${taskId} 는 진행 중 — 재개 대신 진행을 따라갑니다.\x1b[0m`);
+        await followTask(api, bridge, taskId);
+    }
+    if (shouldAutoApprove(autoApprove)) {
+        await api.setAutoApprove(taskId, true);
+        console.log('\x1b[2m서버 승인 자동화 활성(--yes/비대화형)\x1b[0m');
+    }
+    try {
+        const r = await api.resumeTask(taskId);
+        console.log(`\x1b[32m✓ ${r.message ?? '작업을 이어서 시작했습니다.'}\x1b[0m (${taskId}${task.folder_rel ? `, 폴더 ${task.folder_rel}` : ''})`);
+    } catch (e) {
+        // 서버 400 사유(디바이스 미연결·checkpoint 없음·이미 완료 등)를 그대로 보여준다
+        console.error(`\x1b[31m재개 실패: ${(e as Error).message}\x1b[0m`);
+        bridge.disconnect();
+        process.exit(1);
+    }
+    await followTask(api, bridge, taskId);
+}
+
 async function main(): Promise<void> {
     const argv = process.argv.slice(2);
     const cmd = argv[0];
     if (cmd === 'login') return cmdLogin();
     if (cmd === 'status') return cmdStatus();
     if (cmd === 'connect') return cmdConnect(argv.slice(1));
+    if (cmd === 'tasks') return cmdTasks(argv.includes('--all'));
+    if (cmd === 'resume') {
+        const taskId = argv[1];
+        if (!taskId || taskId.startsWith('--')) { console.error('사용법: openmake-code resume <taskId> [--dir .] [--yes]'); process.exit(1); }
+        const di = argv.indexOf('--dir');
+        return cmdResume(taskId, di >= 0 ? argv[di + 1] ?? '.' : '.', argv.includes('--yes') || argv.includes('-y'));
+    }
     if (!cmd || cmd === 'help' || cmd === '--help' || cmd === '-h') {
         console.log(`OpenMake Code — 로컬 코딩 에이전트 CLI
 
@@ -190,16 +283,31 @@ async function main(): Promise<void> {
   openmake-code connect [dir]      폴더 상주 연결 (웹에서 작업을 시작할 수 있게 됨)
   openmake-code status             연결 상태·디바이스 조회
   openmake-code "목표" [--dir .] [--yes]   로컬 에이전트 작업 1회 실행
-                                   (--yes: 파일 쓰기류 서버 승인 자동화. 셸은 별도 확인)`);
+                                   (--yes: 파일 쓰기류 서버 승인 자동화. 셸은 별도 확인)
+  openmake-code tasks [--all]      이 디바이스의 로컬 작업 목록 (종료 작업은 --all)
+  openmake-code resume <taskId> [--dir .] [--yes]   checkpoint 에서 이어하기 (같은 worktree 재부착)
+  openmake-code "목표" --resume    재개 가능한 최근 작업이 있으면 그것을 이어감 (없으면 새 작업)`);
         return;
     }
     // 나머지는 목표 실행 — "목표" [--dir path]
     const dirIdx = argv.indexOf('--dir');
     const dir = dirIdx >= 0 ? argv[dirIdx + 1] ?? '.' : '.';
     const autoApprove = argv.includes('--yes') || argv.includes('-y');
+    const wantResume = argv.includes('--resume');
     const goal = argv
-        .filter((a, i) => a !== '--dir' && i !== dirIdx + 1 && a !== '--yes' && a !== '-y')
+        .filter((a, i) => a !== '--dir' && i !== dirIdx + 1 && a !== '--yes' && a !== '-y' && a !== '--resume')
         .join(' ').trim();
+    if (wantResume) {
+        const cfg = requireConfig();
+        const api = new ApiClient(cfg.serverUrl, cfg.apiKey);
+        const target = await pickResumeTarget(api);
+        if (target) {
+            console.log(`\x1b[2m--resume: ${target.followOnly ? '진행 중인' : '재개 가능한'} 작업 ${shortId(target.task.id)} 을 ${target.followOnly ? '따라갑니다' : '이어합니다'}${goal ? ' (입력한 목표는 무시)' : ''}\x1b[0m`);
+            return cmdResume(target.task.id, dir, autoApprove);
+        }
+        if (!goal) { console.error('재개 가능한 작업이 없고 새 목표도 없습니다.'); process.exit(1); }
+        console.log('\x1b[2m--resume: 재개 가능한 작업이 없어 새 작업을 만듭니다.\x1b[0m');
+    }
     if (!goal) { console.error('목표를 입력하세요. `openmake-code help` 참고.'); process.exit(1); }
     return cmdRun(goal, dir, autoApprove);
 }


### PR DESCRIPTION
## 배경
plan `proposals/2026-08-26-openmake-code-resume-cli-plan.md`(private docs #2) 구현. 서버 재개(checkpoint·worktree 보존·디바이스 연결 필수)는 이미 있어 **CLI 명령만 추가**하는 것이 원칙이었고, E2E 중 서버 결함 1건을 찾아 함께 고쳤다.

## CLI (`apps/cli`)
- `tasks [--all]` — 이 디바이스의 로컬 작업 목록(종료 작업은 `--all`), `[resume 가능]`/`[진행 중]` 표시
- `resume <taskId> [--dir .] [--yes]` — `--dir`(기본 cwd)로 루트를 다시 연결(폴더 발원지는 디바이스, 서버는 `folder_rel` 만 앎) → 서버 재개 → 진행 follow. 진행 중이면 재실행 대신 follow. 서버 400 사유는 그대로 표시
- `"목표" --resume` — 최근 resumable 작업을 이어감(진행 중이면 follow), 없으면 새 작업
- `cmdRun` 의 등록 대기·폴링 루프를 `connectAndRegister`/`followTask` 로 추출해 run/resume 공유

## 서버
- `GET /api/agent-tasks?executor=local&deviceId=…&status=a,b` 부가 필터(`filterTaskList`, 본인 범위 안에서만 — 권한 무변경)
- **결함 수정**: `AgentTaskService.execute` 의 취소 레이스 가드가 영속 `cancelled` 를 취소 요청으로 읽어, `cancelled+checkpoint` 재개(라우트가 허용)가 202 직후 곧바로 다시 aborted 로 끝났다 → resume 이면 가드 건너뜀
- `toPublicTask.resumable` = failed **또는 cancelled** + checkpoint (라우트 허용 범위와 일치; 웹 Resume 버튼은 `RESUMABLE_ERROR_CODES` 로 추가 필터라 노출 무변경)

## 검증
- 단위: `filterTaskList` 5건 + `resumable` 3건, agent-task 스위트 25/197 통과, tsc·eslint(신규 경고 0)
- 라이브(chat.openmake.cc, user 3, 실 CLI 빌드): `tasks` 목록 렌더 ✓ · 취소 작업(`a26e7d97`, checkpoint 6msg, worktree `omk-task/a26e7d97` 에 NOTES.md·a1.md 보존) `resume` → 202 수신 ✓ → **서버가 즉시 재-abort(위 결함)** — 수정본은 배포 후 같은 작업으로 재검증 예정(worktree 재부착 멱등은 코어 `worktree add` 가 기존 디렉토리 재사용으로 이미 보장)
- ⚠️ goal_incomplete 실패는 finalize 가 checkpoint 를 지우므로 재개 대상이 아니다(설계) — 재개 대상은 중단(cancel)·턴 오류·재시작 실패

🤖 Generated with [Claude Code](https://claude.com/claude-code)