### PR TITLE
fix(agent-task): 재개로 완료된 작업에 이전 실패 사유(error)가 남던 문제

### DIFF
--- a/apps/api/src/data/repositories/agent-task-repository.ts
+++ b/apps/api/src/data/repositories/agent-task-repository.ts
@@ -71,7 +71,8 @@ export class AgentTaskRepository extends BaseRepository {
         progress?: number;
         currentTurn?: number;
         result?: string;
-        error?: string;
+        /** null = 이전 시도의 실패 사유 제거(재개/재실행으로 완료된 작업). undefined = 변경 없음. */
+        error?: string | null;
         checkpoint?: unknown;
         sandboxContainerId?: string;
         workspacePath?: string;

--- a/apps/api/src/services/agent-task/finalize.ts
+++ b/apps/api/src/services/agent-task/finalize.ts
@@ -153,6 +153,9 @@ export async function finalizeTask(input: FinalizeInput): Promise<FinalizeOutcom
         status: 'completed',
         progress: 100,
         result: body,
+        // 이전 시도의 실패 사유를 지운다 — resume/재실행으로 완료된 작업에 'aborted'·'goal_incomplete'
+        // 가 남아 목록·CLI 가 성공을 실패처럼 보여줬다(2026-08-26 resume E2E 에서 실측).
+        error: null,
         checkpoint: null, // 완료 작업은 재개 대상 아님 — checkpoint 잔존 시 resume 허용·저장 팽창
         completionPath: path,
         judgeVerdict: verdict,


### PR DESCRIPTION
## 문제
`finalize` 성공 경로가 `error` 를 지우지 않아, **재개·재실행으로 완료된 작업이 `status=completed` 인데 `error='aborted'`(또는 `goal_incomplete`)를 그대로 유지**한다.

2026-08-26 resume E2E 실측(`a26e7d97`): 취소됐던 작업을 `openmake-code resume` 으로 이어 완료 → `status=completed, progress=100` 인데 `error=aborted` 가 남아 CLI 가 결과 뒤에 빨간 `aborted` 를 출력했다. 웹 목록·히스토리도 같은 값을 읽는다.

## 수정
- `finalize` 완료 시 `error: null`
- `updateAgentTask` 의 `error` 타입을 `string | null` 로 확장 — `undefined`(변경 없음)와 `null`(제거)을 구분. 리포지토리는 이미 `!== undefined` 로 분기하므로 `null` 이 그대로 SQL NULL 로 저장된다

## 검증
tsc·eslint 통과, agent-task 스위트 25/197 통과. 배포 후 재개 완료 작업의 `error` 가 비는지 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)