### PR TITLE
feat(local-bridge): 편집 후 진단(LSP diagnostics-first 1단계)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1113,6 +1113,11 @@ AGENT_TASK_TIMEOUT_MS=600000
 # diff 스텝으로 남긴다(로컬 실행기는 종전에 diff 를 남길 수 없었다). git 레포가 아니거나
 # 생성 실패면 기존 동작으로 폴백. 기본 ON('false' 로 비활성).
 # LOCAL_BRIDGE_WORKTREE=true
+# 편집 후 진단(LSP diagnostics-first) — 파일 쓰기 도구 결과에 tsc/py_compile 진단을 덧붙인다.
+# 디바이스(CLI·데스크톱)에서 실행되며 모델에 새 도구를 노출하지 않는다. 기본 off(셰도우 측정 후 on).
+LOCAL_BRIDGE_LSP_ENABLED=false
+# 진단 1회 대기 상한(ms) — 초과 시 조용히 생략(fail-open)
+LOCAL_BRIDGE_LSP_TIMEOUT_MS=10000
 #
 # (구 LOCAL_BRIDGE_BROWSER_* — 로컬 에이전트 브라우저(Cowork D3)는 2026-08-23 폐기.
 #  Electron 데스크톱 셸만 구현하던 기능이라 그 앱 제거와 함께 사라졌다. 로컬 실행 작업에서

--- a/apps/api/src/config/local-bridge.ts
+++ b/apps/api/src/config/local-bridge.ts
@@ -34,4 +34,15 @@ export const LOCAL_BRIDGE = {
      * 기본 ON — LOCAL_EXECUTOR_ENABLED 자체가 기본 OFF 라 이 값만으로 동작이 바뀌지 않는다.
      */
     WORKTREE_ENABLED: process.env.LOCAL_BRIDGE_WORKTREE !== 'false',
+
+    /**
+     * 편집 후 진단(LSP diagnostics-first) — 파일 쓰기 도구가 성공한 직후 디바이스에서 컴파일러
+     * 진단을 받아 도구 결과에 덧붙인다. 모델에 새 도구를 노출하지 않으므로 도구폭주 축과 무관하고,
+     * 실패·타임아웃·미지원 디바이스는 조용히 생략(fail-open)한다.
+     * 기본 OFF — 셰도우 측정(tool-errors·workflow 지표) 후 켠다.
+     */
+    LSP_ENABLED: process.env.LOCAL_BRIDGE_LSP_ENABLED === 'true',
+
+    /** 진단 1회 대기 상한(ms) — 초과 시 생략. 디바이스측 DIAG_TIMEOUT_MS 보다 짧게 잡는다. */
+    LSP_TIMEOUT_MS: parseInt(process.env.LOCAL_BRIDGE_LSP_TIMEOUT_MS || '10000', 10),
 } as const;

--- a/apps/api/src/services/local-bridge/registry.ts
+++ b/apps/api/src/services/local-bridge/registry.ts
@@ -23,7 +23,7 @@ import { createLogger } from '../../utils/logger';
 const logger = createLogger('LocalBridge');
 
 /** 서버→디바이스 도구 요청 종류 — 이 외의 kind 는 존재하지 않는다(임의 RPC 금지). */
-export type BridgeKind = 'exec' | 'read' | 'write' | 'list' | 'listAll' | 'delete' | 'task_end' | 'worktree' | 'folders';
+export type BridgeKind = 'exec' | 'read' | 'write' | 'list' | 'listAll' | 'delete' | 'task_end' | 'worktree' | 'folders' | 'lsp_diagnostics';
 
 /** worktree 연산 — 서버는 op 만 지정하고 git 명령은 디바이스가 고정 인자로 조립한다(명령 주입 차단). */
 export type WorktreeOp = 'add' | 'diff' | 'remove';
@@ -49,6 +49,19 @@ export interface BridgeRequestPayload {
      * 디바이스가 기존 safe()(realpath, 루트 탈출 차단)로 항상 재검증한다. 미지정=루트.
      */
     folder?: string;
+    /** lsp_diagnostics 전용 — 진단할 파일들(base 기준 상대경로). */
+    paths?: string[];
+}
+
+/** 편집 후 진단 1건 — 디바이스의 컴파일러 출력(코어 BridgeDiagnostic 과 1:1). */
+export interface BridgeDiagnostic {
+    path: string;
+    line: number;
+    col: number;
+    severity: 'error' | 'warning';
+    code?: string;
+    message: string;
+    source: string;
 }
 
 /** 디바이스가 돌려주는 결과 (bridge_result). */
@@ -71,6 +84,10 @@ export interface BridgeResult {
     kept?: boolean;
     /** folders 결과 — 열거 상한 초과로 목록이 절단됐으면 true. */
     truncated?: boolean;
+    /** lsp_diagnostics 결과 — 빈 배열은 "검사했고 문제 없음". */
+    diagnostics?: BridgeDiagnostic[];
+    /** 어떤 검사기가 돌았는지 — 'none' 이면 지원 도구가 없어 검사하지 않음(진단 0건과 구분). */
+    serverKind?: string;
 }
 
 export interface DeviceSession {

--- a/apps/api/src/services/local-bridge/remote-executor.ts
+++ b/apps/api/src/services/local-bridge/remote-executor.ts
@@ -96,9 +96,35 @@ export class RemoteExecutor implements TaskExecutor {
         }
     }
 
-    private req(payload: BridgeRequestPayload): Promise<BridgeResult> {
+    private req(payload: BridgeRequestPayload, timeoutMs?: number): Promise<BridgeResult> {
         const withFolder = this.folderRel ? { ...payload, folder: this.folderRel } : payload;
-        return getLocalBridgeRegistry().request(this.userId, withFolder, undefined, this.deviceId);
+        return getLocalBridgeRegistry().request(this.userId, withFolder, timeoutMs, this.deviceId);
+    }
+
+    /**
+     * 편집 후 진단 — 디바이스에서 컴파일러(tsc/py_compile)를 돌려 방금 고친 파일의 오류를 받는다.
+     * 모델에 새 도구를 노출하지 않고 write 계열 도구 결과에 덧붙이는 용도(plan 1단계).
+     *
+     * 다음은 모두 **null**(호출측이 조용히 생략, fail-open):
+     *   게이트 OFF · 구 디바이스(kind 미지원) · 타임아웃/오류 · 지원 도구 없음(serverKind='none')
+     * 진단 0건은 null 이 아니라 "진단 없음" 텍스트로 돌려준다 — 모델이 검사 결과를 신뢰할 수 있게.
+     */
+    async diagnostics(relPaths: string[]): Promise<{ text: string; count: number } | null> {
+        if (!LOCAL_BRIDGE.LSP_ENABLED || relPaths.length === 0) return null;
+        const r = await this.req(
+            { kind: 'lsp_diagnostics', paths: relPaths.map((p) => this.scoped(p)) },
+            LOCAL_BRIDGE.LSP_TIMEOUT_MS,
+        ).catch(() => ({ ok: false }) as BridgeResult);
+        if (!r.ok || !Array.isArray(r.diagnostics)) return null;      // 미지원·실패 → 생략
+        if (r.serverKind === 'none') return null;                     // 검사 도구 없음 → 생략
+        if (r.diagnostics.length === 0) return { text: '[진단 없음]', count: 0 };
+        // worktree prefix 는 모델이 쓰는 상대경로가 아니므로 떼어낸다(도구 인자와 표기 일치).
+        const strip = (p: string): string =>
+            this.worktreeRel && p.startsWith(`${this.worktreeRel}/`) ? p.slice(this.worktreeRel.length + 1) : p;
+        const lines = r.diagnostics.map((d) =>
+            `${strip(d.path)}:${d.line}:${d.col} ${d.severity}${d.code ? ` ${d.code}` : ''}: ${d.message}`);
+        const head = `[진단 ${r.diagnostics.length}건${r.truncated ? '+' : ''} — ${r.serverKind}]`;
+        return { text: `${head}\n${lines.join('\n')}`, count: r.diagnostics.length };
     }
 
     /** 파일 경로를 worktree 기준으로 변환. 격리가 없으면 원래 경로 그대로. */

--- a/apps/api/src/services/task-sandbox/diagnostics-attach.ts
+++ b/apps/api/src/services/task-sandbox/diagnostics-attach.ts
@@ -1,0 +1,41 @@
+/**
+ * 편집 후 진단 부착 — 파일 쓰기 도구가 성공한 직후 실행기 진단을 결과에 덧붙인다.
+ *
+ * LSP diagnostics-first 1단계(plan `2026-08-26-openmake-code-lsp-diagnostics-plan.md`):
+ * 그전까지 로컬 작업의 품질 신호는 셸 실행 결과(tsc/테스트)뿐이라 모델이 편집만 하고
+ * "고쳤다"고 끝내는 실패가 남았다. 편집 직후 컴파일러 진단을 같은 tool_result 로 돌려주면
+ * 하네스가 **같은 턴에** 고칠 수 있다.
+ *
+ * 설계상 중요한 두 가지:
+ *   - **모델에 새 도구를 노출하지 않는다** — 기존 write 결과에 텍스트만 얹으므로 도구 수가
+ *     늘지 않고, 로컬 qwen 의 도구폭주 hang 축과 무관하다.
+ *   - **fail-open** — 실행기 미지원(샌드박스·구 디바이스)·게이트 OFF·타임아웃·예외는 모두
+ *     원문 그대로 돌려준다. 진단 실패가 편집 결과를 가리지 않는다.
+ *
+ * @module services/task-sandbox/diagnostics-attach
+ */
+import type { TaskExecutor } from './executor';
+import type { MCPToolResult } from '../../mcp/types';
+
+function textResult(text: string): MCPToolResult {
+    return { content: [{ type: 'text', text }], isError: false };
+}
+
+/**
+ * @param sandbox 실행 백엔드 — `diagnostics` 를 구현한 실행기(로컬 브리지)만 진단을 붙인다.
+ * @param relPath 방금 편집한 workspace 상대경로
+ * @param text 원래 도구 결과 문구(`기록됨: a.ts` 등)
+ */
+export async function withDiagnostics(
+    sandbox: TaskExecutor,
+    relPath: string,
+    text: string,
+): Promise<MCPToolResult> {
+    if (!sandbox.diagnostics) return textResult(text);
+    try {
+        const d = await sandbox.diagnostics([relPath]);
+        return textResult(d ? `${text}\n${d.text}` : text);
+    } catch {
+        return textResult(text);
+    }
+}

--- a/apps/api/src/services/task-sandbox/executor.ts
+++ b/apps/api/src/services/task-sandbox/executor.ts
@@ -87,6 +87,13 @@ export interface TaskExecutor {
     /** workspace 파일/디렉토리 삭제. 루트 삭제 금지. */
     deleteFile(relPath: string): Promise<void>;
 
+    /**
+     * 편집 후 진단 — 실행기가 지원하면 구현한다(로컬 브리지: 디바이스의 tsc/py_compile).
+     * 미구현이거나 실패·미지원이면 null 을 돌려 호출측이 조용히 생략한다(fail-open).
+     * 도구가 없어 검사하지 못한 경우와 "진단 0건"은 `serverKind` 로 구분한다.
+     */
+    diagnostics?(relPaths: string[]): Promise<{ text: string; count: number } | null>;
+
     /** 실행 환경 정리. removeWorkspace=false 면 산출물 회수를 위해 workspace 보존. 멱등. */
     cleanup(removeWorkspace?: boolean): Promise<void>;
 }

--- a/apps/api/src/services/task-sandbox/tools.test.ts
+++ b/apps/api/src/services/task-sandbox/tools.test.ts
@@ -74,6 +74,53 @@ describe('task-sandbox tools', () => {
         expect(okSub.isError).toBeFalsy();
     });
 
+    describe('편집 후 진단 부착(LSP diagnostics-first)', () => {
+        /** 진단을 지원하는 가짜 실행기 — 로컬 브리지 RemoteExecutor 자리. */
+        function sandboxWithDiag(result: { text: string; count: number } | null | (() => never)) {
+            const sb = fakeSandbox() as unknown as Record<string, unknown> & { diagCalls: string[][] };
+            sb.diagCalls = [];
+            sb.diagnostics = async (paths: string[]) => {
+                sb.diagCalls.push(paths);
+                if (typeof result === 'function') result();
+                return result;
+            };
+            return sb as unknown as TaskSandbox & { diagCalls: string[][] };
+        }
+
+        it('write 성공 결과에 진단을 덧붙이고, 편집한 경로만 넘긴다', async () => {
+            const sb = sandboxWithDiag({ text: '[진단 1건 — tsc]\na.ts:1:7 error TS2322: bad', count: 1 });
+            const r = await byName(createTaskTools(sb), 'file_ops').handler({ op: 'write', path: 'a.ts', content: 'x' });
+            expect(txt(r)).toBe('기록됨: a.ts\n[진단 1건 — tsc]\na.ts:1:7 error TS2322: bad');
+            expect((sb as unknown as { diagCalls: string[][] }).diagCalls).toEqual([['a.ts']]);
+        });
+
+        it('str_replace_editor create/str_replace/insert 에도 붙는다', async () => {
+            const sb = sandboxWithDiag({ text: '[진단 없음]', count: 0 });
+            const ed = byName(createTaskTools(sb), 'str_replace_editor');
+            expect(txt(await ed.handler({ command: 'create', path: 'a.ts', file_text: 'a' }))).toContain('[진단 없음]');
+            expect(txt(await ed.handler({ command: 'str_replace', path: 'a.ts', old_str: 'a', new_str: 'b' }))).toContain('[진단 없음]');
+            expect(txt(await ed.handler({ command: 'insert', path: 'a.ts', insert_line: 0, new_str: 'c' }))).toContain('[진단 없음]');
+        });
+
+        it('null(게이트 OFF·미지원·타임아웃)이면 원문 그대로', async () => {
+            const sb = sandboxWithDiag(null);
+            const r = await byName(createTaskTools(sb), 'file_ops').handler({ op: 'write', path: 'a.ts', content: 'x' });
+            expect(txt(r)).toBe('기록됨: a.ts');
+        });
+
+        it('진단 조회가 던져도 편집 결과를 가리지 않는다(fail-open)', async () => {
+            const sb = sandboxWithDiag(() => { throw new Error('boom'); });
+            const r = await byName(createTaskTools(sb), 'file_ops').handler({ op: 'write', path: 'a.ts', content: 'x' });
+            expect(txt(r)).toBe('기록됨: a.ts');
+            expect(r.isError).toBeFalsy();
+        });
+
+        it('진단 미지원 실행기(샌드박스)는 종전과 동일', async () => {
+            const r = await byName(createTaskTools(fakeSandbox()), 'file_ops').handler({ op: 'write', path: 'a.ts', content: 'x' });
+            expect(txt(r)).toBe('기록됨: a.ts');
+        });
+    });
+
     describe('str_replace_editor', () => {
         it('create → view 왕복', async () => {
             const sb = fakeSandbox();

--- a/apps/api/src/services/task-sandbox/tools.ts
+++ b/apps/api/src/services/task-sandbox/tools.ts
@@ -15,6 +15,7 @@
  */
 import type { MCPToolDefinition, MCPToolResult } from '../../mcp/types';
 import type { TaskExecutor, ExecResult } from './executor';
+import { withDiagnostics } from './diagnostics-attach';
 import { TaskPlan, type PlanStepStatus } from './planning';
 import {
     SPAWN_AGENTS_TOOL_NAME,
@@ -163,7 +164,7 @@ export function createTaskTools(
             try {
                 if (command === 'create') {
                     await sandbox.writeFile(path, str(args.file_text));
-                    return textResult(`생성됨: ${path}`);
+                    return withDiagnostics(sandbox, path, `생성됨: ${path}`);
                 }
                 if (command === 'view') {
                     const content = await sandbox.readFile(path);
@@ -177,7 +178,7 @@ export function createTaskTools(
                     if (count === 0) return textResult(`old_str 를 찾을 수 없습니다: ${path} — old_str 는 공백·들여쓰기까지 파일 내용과 정확히 일치해야 합니다. command:view 로 현재 내용을 확인한 뒤 그대로 복사해 쓰세요.`, true);
                     if (count > 1) return textResult(`old_str 가 ${count}회 중복 — 유일해야 합니다.`, true);
                     await sandbox.writeFile(path, content.replace(oldStr, str(args.new_str)));
-                    return textResult(`치환 완료: ${path}`);
+                    return withDiagnostics(sandbox, path, `치환 완료: ${path}`);
                 }
                 if (command === 'insert') {
                     const content = await sandbox.readFile(path);
@@ -185,7 +186,7 @@ export function createTaskTools(
                     const at = Math.max(0, Math.min(lines.length, Number(args.insert_line) || 0));
                     lines.splice(at, 0, str(args.new_str));
                     await sandbox.writeFile(path, lines.join('\n'));
-                    return textResult(`삽입 완료: ${path}:${at}`);
+                    return withDiagnostics(sandbox, path, `삽입 완료: ${path}:${at}`);
                 }
                 return textResult(`알 수 없는 command: ${command}`, true);
             } catch (e) {
@@ -216,7 +217,7 @@ export function createTaskTools(
             const path = str(args.path);
             try {
                 if (op === 'read') return textResult(await sandbox.readFile(path));
-                if (op === 'write') { await sandbox.writeFile(path, str(args.content)); return textResult(`기록됨: ${path}`); }
+                if (op === 'write') { await sandbox.writeFile(path, str(args.content)); return withDiagnostics(sandbox, path, `기록됨: ${path}`); }
                 if (op === 'list') return textResult((await sandbox.listDir(path || '.')).join('\n') || '(빈 디렉토리)');
                 if (op === 'tree') {
                     // 하위 폴더 포함 전체 목록 — list 로 한 단계씩 파고들다 폴더를 놓치는

--- a/packages/local-bridge-core/src/__tests__/diagnostics.test.ts
+++ b/packages/local-bridge-core/src/__tests__/diagnostics.test.ts
@@ -1,0 +1,92 @@
+/**
+ * 편집 후 진단(collectDiagnostics) — 1단계 폴백(tsc/py_compile) 동작·캡·미지원 처리.
+ *
+ * 실제 컴파일러를 돌리므로 임시 레포를 만들고, 레포 로컬 tsc(node_modules/.bin/tsc)를
+ * 이 워크스페이스의 것으로 심링크해 "레포에 설치된 도구만 쓴다"는 규칙을 그대로 검증한다.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { collectDiagnostics } from '../diagnostics';
+import { DIAG_MAX_TOTAL } from '../constants';
+
+const repoTsc = path.resolve(__dirname, '../../../../node_modules/.bin/tsc');
+const hasTsc = fs.existsSync(repoTsc);
+
+let base = '';
+
+beforeEach(() => {
+    base = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'omk-diag-')));
+});
+afterEach(() => { fs.rmSync(base, { recursive: true, force: true }); });
+
+function writeTsProject(files: Record<string, string>): void {
+    fs.writeFileSync(path.join(base, 'tsconfig.json'), JSON.stringify({
+        compilerOptions: { strict: true, noEmit: true, target: 'ES2022', module: 'commonjs', skipLibCheck: true },
+        include: ['*.ts'],
+    }));
+    for (const [name, content] of Object.entries(files)) fs.writeFileSync(path.join(base, name), content);
+    // 레포 로컬 tsc 만 사용한다 — 전역 설치에 의존하지 않는 규칙을 그대로 만족시킨다.
+    const binDir = path.join(base, 'node_modules', '.bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.symlinkSync(repoTsc, path.join(binDir, 'tsc'));
+}
+
+(hasTsc ? describe : describe.skip)('collectDiagnostics — TypeScript', () => {
+    test('타입 오류를 파일·라인·코드와 함께 돌려준다', async () => {
+        writeTsProject({ 'a.ts': 'const n: number = "not a number";\n' });
+        const r = await collectDiagnostics(base, [path.join(base, 'a.ts')]);
+        expect(r.serverKind).toBe('tsc');
+        expect(r.diagnostics.length).toBeGreaterThan(0);
+        const d = r.diagnostics[0];
+        expect(d.path).toBe('a.ts');
+        expect(d.line).toBe(1);
+        expect(d.severity).toBe('error');
+        expect(d.code).toMatch(/^TS\d+$/);
+        expect(d.source).toBe('tsc');
+    }, 60000);
+
+    test('정상 코드는 진단 0건 — serverKind 로 "검사함"을 구분할 수 있다', async () => {
+        writeTsProject({ 'ok.ts': 'export const n: number = 1;\n' });
+        const r = await collectDiagnostics(base, [path.join(base, 'ok.ts')]);
+        expect(r.serverKind).toBe('tsc');
+        expect(r.diagnostics).toEqual([]);
+        expect(r.truncated).toBe(false);
+    }, 60000);
+
+    test('tsc 가 없으면 실행하지 않는다(serverKind=none) — 설치 시도 금지', async () => {
+        fs.writeFileSync(path.join(base, 'tsconfig.json'), '{}');
+        fs.writeFileSync(path.join(base, 'a.ts'), 'const n: number = "x";\n');
+        const r = await collectDiagnostics(base, [path.join(base, 'a.ts')]);
+        expect(r.serverKind).toBe('none');
+        expect(r.diagnostics).toEqual([]);
+    }, 30000);
+});
+
+describe('collectDiagnostics — 공통', () => {
+    test('지원하지 않는 확장자는 no-op', async () => {
+        fs.writeFileSync(path.join(base, 'a.txt'), 'hello');
+        const r = await collectDiagnostics(base, [path.join(base, 'a.txt')]);
+        expect(r).toEqual({ diagnostics: [], truncated: false, serverKind: 'none' });
+    });
+
+    test('빈 목록도 안전하다', async () => {
+        const r = await collectDiagnostics(base, []);
+        expect(r.serverKind).toBe('none');
+    });
+
+    test('Python 문법 오류를 잡는다', async () => {
+        fs.writeFileSync(path.join(base, 'bad.py'), 'def f(:\n');
+        const r = await collectDiagnostics(base, [path.join(base, 'bad.py')]);
+        // python3 가 없는 환경이면 진단 없이 넘어간다(no-op) — 있으면 error 1건.
+        if (r.serverKind === 'py_compile' && r.diagnostics.length > 0) {
+            expect(r.diagnostics[0].path).toBe('bad.py');
+            expect(r.diagnostics[0].severity).toBe('error');
+            expect(r.diagnostics[0].source).toBe('py_compile');
+        }
+    }, 30000);
+
+    test('전체 상한 상수가 캡 계약과 일치한다', () => {
+        expect(DIAG_MAX_TOTAL).toBeGreaterThan(0);
+    });
+});

--- a/packages/local-bridge-core/src/constants.ts
+++ b/packages/local-bridge-core/src/constants.ts
@@ -23,6 +23,19 @@ export const TASK_ID_RE = /^[a-zA-Z0-9-]{8,64}$/;
 /** folders(하위 폴더 열거) 1회 상한 — 서버 BRIDGE_FOLDERS_MAX_ENTRIES 와 같은 축(디바이스측 강제). */
 export const FOLDERS_MAX_ENTRIES = 200;
 
+/**
+ * 편집 후 진단(lsp_diagnostics) — 1회 실행 타임아웃과 결과 캡.
+ * 콜드 스타트(대형 TS 레포의 첫 tsc)를 고려해 exec 보다 짧고 FS 보다 길게 잡는다.
+ * 서버측(LOCAL_BRIDGE.LSP_TIMEOUT_MS)이 더 짧으면 서버가 먼저 포기한다 — 그쪽이 fail-open 이라 무해.
+ */
+export const DIAG_TIMEOUT_MS = Number(process.env.OMK_BRIDGE_DIAG_TIMEOUT_MS || 15000);
+/** 파일당 진단 상한 — 한 파일의 연쇄 오류가 결과를 독점하지 않게. */
+export const DIAG_MAX_PER_FILE = 20;
+/** 전체 진단 상한 — tool_result 팽창 방지(MAX_TOOL_RESULT_CHARS 절단과 이중). */
+export const DIAG_MAX_TOTAL = 60;
+/** 진단 메시지 1건 길이 상한. */
+export const DIAG_MSG_MAX = 300;
+
 /** listAll 재귀 나열 상한. */
 export const LIST_ALL_MAX = 1000;
 

--- a/packages/local-bridge-core/src/core.ts
+++ b/packages/local-bridge-core/src/core.ts
@@ -16,9 +16,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execFile } from 'child_process';
 import {
-    EXEC_TIMEOUT_MS, FOLDERS_MAX_ENTRIES, FS_OP_TIMEOUT_MS, LIST_ALL_MAX, MAX_BUFFER,
+    DIAG_MAX_TOTAL, EXEC_TIMEOUT_MS, FOLDERS_MAX_ENTRIES, FS_OP_TIMEOUT_MS, LIST_ALL_MAX, MAX_BUFFER,
     SANDBOX_BIN, SANDBOX_ENABLED,
 } from './constants';
+import { collectDiagnostics } from './diagnostics';
 import { matchDenylist } from './denylist';
 import { resolveExecPath } from './exec-path';
 import { detectGitDir, writeSandboxProfile } from './sandbox';
@@ -193,6 +194,16 @@ export class BridgeCore {
                     }
                     return { entries, truncated };
                 });
+                done({ ok: true, ...r }); return;
+            }
+            case 'lsp_diagnostics': {
+                // 읽기 전용 검사라 confirmExec 대상이 아니다 — 실행 파일·인자는 코어가 고정 조립하고
+                // (모델/서버 입력이 명령줄에 들어가지 않음) 경로는 safe() 로 스코프를 확정한 뒤 넘긴다.
+                const rel = Array.isArray(m.paths) ? m.paths.slice(0, DIAG_MAX_TOTAL) : [];
+                const abs: string[] = [];
+                for (const p of rel) abs.push(await safeFromAsync(base, p));
+                if (!this.execPathCache) this.execPathCache = resolveExecPath(this.folderRoot);
+                const r = await collectDiagnostics(base, abs, this.execPathCache);
                 done({ ok: true, ...r }); return;
             }
             case 'worktree':

--- a/packages/local-bridge-core/src/diagnostics.ts
+++ b/packages/local-bridge-core/src/diagnostics.ts
@@ -1,0 +1,160 @@
+/**
+ * 편집 후 진단(LSP diagnostics-first, 1단계) — 디바이스에서 실행한다.
+ *
+ * 목적: 로컬 작업에서 파일을 고친 직후 컴파일러 진단을 도구 결과에 붙여, 하네스가 **같은 턴에**
+ * 고치게 한다. 그전까지 품질 신호는 셸 실행 결과(tsc/테스트 출력)뿐이라 모델이 "고쳤다"고 하고
+ * 끝나는 실패가 남았다(plan `2026-08-26-openmake-code-lsp-diagnostics-plan.md`).
+ *
+ * 1단계는 **언어 서버 없이도 도는 폴백만** 쓴다 — 프로젝트에 이미 있는 도구만 쓰므로 사용자가
+ * 무엇도 설치할 필요가 없다:
+ *   - TS/JS : 레포의 `node_modules/.bin/tsc --noEmit -p <가장 가까운 tsconfig>`
+ *   - Python: `python3 -m py_compile <file>`
+ *   - 그 외 : no-op(`serverKind:'none'`) — 조용히 빈 결과
+ * 도구가 없으면 실행하지 않는다(설치 시도 금지). 결과는 캡·타임아웃으로 제한하고, 실패는
+ * 호출측에서 fail-open 으로 흡수한다.
+ *
+ * 보안: 실행 파일·인자는 **코어가 고정 조립**한다(모델·서버 입력이 명령줄에 들어가지 않는다).
+ * 경로는 호출측이 `safeFromAsync` 로 스코프를 확정한 절대경로만 넘긴다.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFile } from 'child_process';
+import { DIAG_MAX_PER_FILE, DIAG_MAX_TOTAL, DIAG_MSG_MAX, DIAG_TIMEOUT_MS, MAX_BUFFER } from './constants';
+import type { BridgeDiagnostic } from './types';
+
+const TS_EXT = new Set(['.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs']);
+const PY_EXT = new Set(['.py']);
+
+function run(file: string, args: string[], cwd: string, extraPath?: string): Promise<{ stdout: string; stderr: string }> {
+    return new Promise((resolve) => {
+        execFile(
+            file, args,
+            {
+                cwd,
+                timeout: DIAG_TIMEOUT_MS,
+                maxBuffer: MAX_BUFFER,
+                encoding: 'utf8',
+                env: extraPath ? { ...process.env, PATH: extraPath } : process.env,
+            },
+            (_err, stdout, stderr) => resolve({ stdout: String(stdout ?? ''), stderr: String(stderr ?? '') }),
+        );
+    });
+}
+
+/** 파일에서 위로 올라가며 가장 가까운 tsconfig.json — 없으면 null. base 밖으로는 나가지 않는다. */
+function nearestTsconfig(fileAbs: string, base: string): string | null {
+    let dir = path.dirname(fileAbs);
+    for (;;) {
+        const candidate = path.join(dir, 'tsconfig.json');
+        if (fs.existsSync(candidate)) return candidate;
+        if (dir === base || dir === path.dirname(dir)) return null;
+        dir = path.dirname(dir);
+    }
+}
+
+/** 레포에 설치된 tsc — 파일 위치부터 base 까지 node_modules/.bin/tsc 를 찾는다(전역 설치는 쓰지 않는다). */
+function findLocalTsc(fileAbs: string, base: string): string | null {
+    let dir = path.dirname(fileAbs);
+    for (;;) {
+        const bin = path.join(dir, 'node_modules', '.bin', 'tsc');
+        if (fs.existsSync(bin)) return bin;
+        if (dir === base || dir === path.dirname(dir)) return null;
+        dir = path.dirname(dir);
+    }
+}
+
+/** `path/to/a.ts(12,5): error TS2322: msg` (tsc 기본 포맷, --pretty false 로 강제) */
+const TSC_LINE = /^(.+?)\((\d+),(\d+)\):\s+(error|warning)\s+([A-Z]+\d+):\s+(.*)$/;
+
+function parseTsc(out: string, base: string, cwd: string): BridgeDiagnostic[] {
+    const diags: BridgeDiagnostic[] = [];
+    for (const raw of out.split('\n')) {
+        const m = TSC_LINE.exec(raw.trim());
+        if (!m) continue;
+        const abs = path.resolve(cwd, m[1]);
+        diags.push({
+            path: path.relative(base, abs).split(path.sep).join('/'),
+            line: Number(m[2]),
+            col: Number(m[3]),
+            severity: m[4] === 'warning' ? 'warning' : 'error',
+            code: m[5],
+            message: m[6].slice(0, DIAG_MSG_MAX),
+            source: 'tsc',
+        });
+    }
+    return diags;
+}
+
+/** `File "/abs/a.py", line 3` + 마지막 줄이 메시지 (py_compile 표준 오류 포맷) */
+function parsePyCompile(out: string, base: string, fileAbs: string): BridgeDiagnostic[] {
+    if (!out.trim()) return [];
+    const lineM = /line (\d+)/.exec(out);
+    const lines = out.trim().split('\n').filter(Boolean);
+    const message = (lines[lines.length - 1] ?? out).trim().slice(0, DIAG_MSG_MAX);
+    return [{
+        path: path.relative(base, fileAbs).split(path.sep).join('/'),
+        line: lineM ? Number(lineM[1]) : 1,
+        col: 1,
+        severity: 'error',
+        message,
+        source: 'py_compile',
+    }];
+}
+
+/** 파일당 상한 → 전체 상한 순으로 자른다. 잘렸으면 truncated. */
+function capDiagnostics(all: BridgeDiagnostic[]): { diagnostics: BridgeDiagnostic[]; truncated: boolean } {
+    const perFile = new Map<string, number>();
+    const kept: BridgeDiagnostic[] = [];
+    let truncated = false;
+    for (const d of all) {
+        const n = perFile.get(d.path) ?? 0;
+        if (n >= DIAG_MAX_PER_FILE) { truncated = true; continue; }
+        if (kept.length >= DIAG_MAX_TOTAL) { truncated = true; break; }
+        perFile.set(d.path, n + 1);
+        kept.push(d);
+    }
+    return { diagnostics: kept, truncated };
+}
+
+/**
+ * 지정한 파일들의 진단을 모은다. 실행할 도구가 없으면 빈 결과 + `serverKind:'none'`.
+ * @param base 스코프 루트(연결/선택 폴더의 실경로)
+ * @param absPaths 이미 스코프 검증된 절대경로들
+ */
+export async function collectDiagnostics(
+    base: string,
+    absPaths: string[],
+    execPath?: string,
+): Promise<{ diagnostics: BridgeDiagnostic[]; truncated: boolean; serverKind: string }> {
+    const ts = absPaths.filter((p) => TS_EXT.has(path.extname(p)));
+    const py = absPaths.filter((p) => PY_EXT.has(path.extname(p)));
+    const all: BridgeDiagnostic[] = [];
+    const kinds: string[] = [];
+
+    // TS/JS — tsconfig 단위로 1회만 실행(같은 프로젝트의 여러 파일을 한 번에 검사).
+    if (ts.length > 0) {
+        const byProject = new Map<string, string>(); // tsconfig → tsc 실행파일
+        for (const f of ts) {
+            const cfg = nearestTsconfig(f, base);
+            const tsc = findLocalTsc(f, base);
+            if (cfg && tsc && !byProject.has(cfg)) byProject.set(cfg, tsc);
+        }
+        for (const [cfg, tsc] of byProject) {
+            const cwd = path.dirname(cfg);
+            const { stdout, stderr } = await run(tsc, ['--noEmit', '--pretty', 'false', '-p', cfg], cwd, execPath);
+            all.push(...parseTsc(`${stdout}\n${stderr}`, base, cwd));
+            kinds.push('tsc');
+        }
+    }
+
+    // Python — 파일 단위 문법 검사(py_compile 은 표준 라이브러리라 별도 설치가 없다).
+    for (const f of py) {
+        const { stdout, stderr } = await run('python3', ['-m', 'py_compile', f], base, execPath);
+        const out = `${stdout}\n${stderr}`;
+        if (/Error|error/.test(out)) all.push(...parsePyCompile(out, base, f));
+        kinds.push('py_compile');
+    }
+
+    const { diagnostics, truncated } = capDiagnostics(all);
+    return { diagnostics, truncated, serverKind: kinds.length ? [...new Set(kinds)].join('+') : 'none' };
+}

--- a/packages/local-bridge-core/src/types.ts
+++ b/packages/local-bridge-core/src/types.ts
@@ -15,6 +15,22 @@ export interface BridgeMsg {
     message?: string;
     /** 폴더 선택 — 연결 루트 기준 상대경로. exec cwd·파일 경로·worktree base 재지정. */
     folder?: string;
+    /** lsp_diagnostics — 진단할 파일들(base 기준 상대경로). */
+    paths?: string[];
+}
+
+/** 편집 후 진단 1건 — 컴파일러/언어 서버 출력의 공통 표현. */
+export interface BridgeDiagnostic {
+    /** base 기준 상대경로(POSIX 구분자). */
+    path: string;
+    line: number;
+    col: number;
+    severity: 'error' | 'warning';
+    /** 진단 코드(TS2322 등) — 있으면. */
+    code?: string;
+    message: string;
+    /** 어느 도구가 냈는지 — 'tsc' | 'py_compile' … */
+    source: string;
 }
 
 export interface BridgeResult {
@@ -30,6 +46,10 @@ export interface BridgeResult {
     branch?: string;
     kept?: boolean;
     truncated?: boolean;
+    /** lsp_diagnostics 결과. 빈 배열 = 진단 없음(도구가 돌았고 문제가 없었다). */
+    diagnostics?: BridgeDiagnostic[];
+    /** 어떤 검사기가 돌았는지 — 'none' 이면 지원 도구가 없어 검사하지 않았다(진단 없음과 구분). */
+    serverKind?: string;
 }
 
 /**


### PR DESCRIPTION
## 배경
plan `proposals/2026-08-26-openmake-code-lsp-diagnostics-plan.md`(private docs #2) 1단계. 로컬 작업의 품질 신호가 셸 실행 결과뿐이라 모델이 편집만 하고 "고쳤다"고 끝나는 실패가 남았다 — 파일 쓰기 직후 컴파일러 진단을 같은 tool_result 로 돌려주면 하네스가 **같은 턴에** 고친다.

## 디바이스 (`packages/local-bridge-core`)
- kind **`lsp_diagnostics`** 추가 — 추가 전용이라 구 디바이스는 미지원 오류 → 서버가 폴백
- `diagnostics.ts`: **언어 서버 없이도 도는 폴백만** 사용
  - TS/JS: **레포 로컬** `node_modules/.bin/tsc --noEmit`(가장 가까운 tsconfig 단위로 1회) — 전역 설치 사용 안 함
  - Python: `python3 -m py_compile`
  - 그 외/도구 없음: 실행하지 않고 `serverKind:'none'` (설치 시도 금지)
- 캡 파일당 20 · 전체 60 · 메시지 300자, 타임아웃 15s
- 보안: 실행 파일·인자를 **코어가 고정 조립**(모델·서버 입력이 명령줄에 안 들어감), 경로는 `safeFromAsync` 로 스코프 확정. 읽기 전용이라 `confirmExec` 대상 아님

## 서버
- 게이트 `LOCAL_BRIDGE_LSP_ENABLED`(**기본 off**) + `LOCAL_BRIDGE_LSP_TIMEOUT_MS`(10s), `.env.example` 문서화
- `TaskExecutor.diagnostics?()` 선택 메서드 + `RemoteExecutor` 구현 — 미지원·실패·타임아웃·`serverKind='none'` 은 **null(생략)**, 진단 0건은 `[진단 없음]` 으로 구분(모델이 "검사했다"를 신뢰할 수 있게). worktree prefix 는 떼어 모델이 쓰는 상대경로와 표기 일치
- `diagnostics-attach.ts` 의 `withDiagnostics` 가 write 계열 4곳에 부착(`str_replace_editor` create/str_replace/insert, `file_ops write`)
- **모델 노출 도구 0개** — 기존 결과에 텍스트만 얹으므로 도구폭주 hang 축과 무관
- 헬퍼를 별도 파일로 둔 이유: `tools.ts` 가 CI Gate 3(600줄)에 근접(598)했다

## 검증
- 코어 7건 — 실제 `tsc` 로 TS2322 를 line/col/code 와 함께 잡는지, 정상 코드 0건+`serverKind='tsc'`, tsc 없으면 `none`, 미지원 확장자 no-op, `py_compile`
- 도구 5건 — 4개 write 경로 부착·편집 경로만 전달·null 생략·예외 fail-open·미지원 실행기 무변경
- 코어 61 / API 333 통과, tsc·eslint 신규 경고 0

## 다음 (이 PR 범위 밖)
게이트 off 로 배포 → `/api/metrics/agent-tasks/tool-errors`·`/workflow` 로 셰도우 측정 후 on. 2단계(정의/참조/rename, 단일 `code_lookup` + regex 프리필터)는 지표 통과가 게이트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)