### PR TITLE
chore(mcp): notebooklm-mcp-cli 0.9.13 → 0.9.14

### DIFF
--- a/infra/mcp-runtime/Dockerfile
+++ b/infra/mcp-runtime/Dockerfile
@@ -65,7 +65,7 @@ ENV PATH=/home/node/.local/bin:${PATH}
 # 불필요 — 인증은 NOTEBOOKLM_COOKIES env(-e 주입)만으로 초기화된다.
 # 카탈로그(db/migrations/075_mcp_notebooklm_catalog.sql)는 `notebooklm-mcp` 로 실행.
 # 런타임 uvx-fetch 없이 즉시 spawn 하도록 사전설치(버전 고정).
-RUN uv tool install notebooklm-mcp-cli==0.9.13
+RUN uv tool install notebooklm-mcp-cli==0.9.14
 
 # ── Kakao(Map/Search) MCP 서버 — 이미지에 baked ─────────────────────────────
 # 벤더링된 수정 소스(vendor/kakao-api-mcp-server: deps 정정 + bin/shebang, ATTRIBUTION.md


### PR DESCRIPTION
## 배경
2026-08-26 MCP 검토 보고서(private docs `proposals/2026-08-26-mcp-v2-upgrade-review.md`) **Phase 0 의 마지막 잔여 항목**. 나머지(SDK 1.30 범프·중복 서버 8종 삭제·카탈로그 정리·npx 핀)는 이미 완료.

## 변경
`infra/mcp-runtime/Dockerfile` 의 핀 한 줄: `notebooklm-mcp-cli==0.9.13` → `==0.9.14`

0.9.14(2026-08-20) 주요 내용:
- **소스 많은 노트북의 쿼리 타임아웃 수정(#298)** — 설정 타임아웃이 준비 단계(노트북·대화 조회)까지 포함한 전체 쿼리를 관장하고, 타임아웃이 구조화된 재시도 가능 오류로 매핑된다(기본 120s, 소스 많으면 180s 권장)
- 네이티브 NotebookLM 컬렉션 관리(#303) — CLI·MCP 에서 컬렉션 생성/목록/편집/삭제/이모지
- Windows Chromium 인증(#302) — 이 배포(macOS)와 무관

## 검증 (라이브)
- 이미지 재빌드 후 `uv tool list` → `notebooklm-mcp-cli v0.9.14`
- 서버 `stop` 202 → `start` 202 → 목록에서 **connected, 도구 48개**(이전 43개 — 컬렉션 도구 5종 추가와 일치)
- 채팅 도구 노출은 `CHAT_USER_MCP_TOOL_CAP`(=8)로 따로 잘리므로 도구 증가의 영향 없음

⚠️ 인증은 쿠키 env 가 아니라 **프로필 파일** 방식이라 이번 범프와 무관하게 그대로 동작한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)