### PR TITLE
feat(cli): openmake-code show <taskId> — 작업 결과 재출력

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -61,9 +61,18 @@ openmake-code connect [dir]      # 폴더 상주 연결 — 웹에서 작업을 
 openmake-code status             # 연결 상태·디바이스 조회
 openmake-code "목표" [--dir .] [--yes]   # 로컬 에이전트 작업 1회 실행
 openmake-code tasks [--all]      # 이 디바이스의 로컬 작업 목록 (종료 작업은 --all)
+openmake-code show <taskId> [--steps] [--diff]     # 작업 결과 다시 보기 (조회 전용)
 openmake-code resume <taskId> [--dir .] [--yes]   # checkpoint 에서 이어하기
 openmake-code "목표" --resume    # 재개 가능한 최근 작업이 있으면 그것을 이어감
 ```
+### 결과 다시 보기 (show)
+`show` 는 **조회 전용**이라 실행하지 않고, 디바이스 연결도 폴더 지정도 필요 없다(서버에 남은 기록만 읽는다).
+- 기본: 상태·목표·폴더·작업 브랜치 + 진행 요약(스텝/도구 호출/재시도/diff 수) + 결과 본문
+- `--steps`: 도구 결과·판정·재시도·지시 추가·아티팩트를 시간순 한 줄 요약으로
+- `--diff`: worktree 변경분(작업 중 서버가 캡처한 `git diff`)
+- ⚠️ `completed` 인데 `(이전 시도 사유: …)` 가 흐리게 보이면 2026-08-26 이전에 만들어진 작업이다
+  (그전엔 재개로 완료해도 이전 실패 사유가 남았다 — 지금은 완료 시 지운다).
+
 ### 이어하기 (resume)
 - 서버가 작업(`agent_tasks`)과 checkpoint 를 보존하므로, 실패한 작업은 **`resume <taskId>`** 로 같은
   대화·같은 worktree(`omk-task/<id>` 브랜치)에서 이어간다. `tasks` 목록의 `[resume 가능]` 표시가 대상.

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -19,6 +19,14 @@ export interface ApiTask {
     resumable?: boolean;
 }
 
+export interface ApiTaskStep {
+    step_number: number;
+    step_type: string;
+    tool_name?: string | null;
+    content?: string | null;
+    created_at?: string;
+}
+
 export interface PendingApproval {
     approvalId: string;
     taskId: string;
@@ -65,6 +73,10 @@ export class ApiClient {
         if (opts.deviceId) q.set('deviceId', opts.deviceId);
         if (opts.status) q.set('status', opts.status);
         return this.req('GET', `/api/agent-tasks?${q.toString()}`);
+    }
+    /** 작업 스텝(진행 기록) — show 가 요약·diff·판정을 뽑는 원본. */
+    listSteps(taskId: string): Promise<{ steps: ApiTaskStep[]; total: number }> {
+        return this.req('GET', `/api/agent-tasks/${taskId}/steps`);
     }
     /** checkpoint 재개 — 서버가 상태·checkpoint·디바이스 연결을 검증한다(실패 사유는 400 메시지). */
     resumeTask(taskId: string): Promise<{ message?: string; queued?: boolean }> {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -9,6 +9,7 @@
  *   status                 연결 상태·디바이스 조회
  *   "목표" [--dir .]        cwd(또는 --dir)에서 로컬 에이전트 작업 1회 실행
  *   tasks [--all]          이 디바이스의 로컬 작업 목록 (기본: 미종료·재개 가능만)
+ *   show <taskId>          작업 결과·진행 기록·변경분 재출력 (조회 전용)
  *   resume <taskId> [--dir .]  checkpoint 에서 이어하기 (서버 재개 API + 같은 worktree 재부착)
  *   "목표" --resume        마지막 재개 가능 작업이 있으면 그것을 이어한다
  */
@@ -17,7 +18,7 @@ import * as path from 'path';
 import * as readline from 'readline';
 import { loadConfig, saveConfig, deviceId } from './config';
 import { CliBridge, type ConfirmFn } from './bridge';
-import { ApiClient, type ApiTask } from './api';
+import { ApiClient, type ApiTask, type ApiTaskStep } from './api';
 
 function prompt(q: string): Promise<string> {
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
@@ -230,6 +231,68 @@ async function pickResumeTarget(api: ApiClient): Promise<{ task: ApiTask; follow
     return cand ? { task: cand, followOnly: false } : null;
 }
 
+/** 스텝 요약 한 줄 — 도구 결과·진단·판정을 사람이 읽는 형태로 압축. */
+function stepLine(s: ApiTaskStep): string | null {
+    const c = (s.content ?? '').replace(/\s+/g, ' ').trim();
+    switch (s.step_type) {
+        case 'tool_result': return c ? `  ${s.tool_name ?? 'tool'}: ${c.slice(0, 100)}` : null;
+        case 'judge': return `  \x1b[35m판정\x1b[0m: ${c.slice(0, 140)}`;
+        case 'retry': return `  \x1b[33m재시도\x1b[0m: ${c.slice(0, 100)}`;
+        case 'hitl_degrade': return `  \x1b[33m승인 무응답 강등\x1b[0m`;
+        case 'steering': return `  \x1b[36m지시 추가\x1b[0m: ${c.slice(0, 100)}`;
+        case 'artifact': return `  \x1b[32m아티팩트\x1b[0m: ${c.slice(0, 100)}`;
+        default: return null; // assistant_tool_call/plan/assistant/diff 는 별도 집계·출력
+    }
+}
+
+/**
+ * 완료·실패한 작업의 결과를 다시 본다. 실행 없이 조회만 하므로 디바이스 연결이 필요 없다
+ * (resume 과 달리 폴더도 필요 없다 — 서버에 남은 기록만 읽는다).
+ */
+async function cmdShow(taskId: string, opts: { steps: boolean; diff: boolean }): Promise<void> {
+    const cfg = requireConfig();
+    const api = new ApiClient(cfg.serverUrl, cfg.apiKey);
+    const task = taskOf(await api.getTask(taskId));
+    const { steps } = await api.listSteps(taskId).catch(() => ({ steps: [] as ApiTaskStep[] }));
+
+    const tone = task.status === 'completed' ? '\x1b[32m' : task.status === 'running' ? '\x1b[36m' : '\x1b[31m';
+    console.log(`\x1b[1m${shortId(task.id)}\x1b[0m  ${tone}${task.status}\x1b[0m ${Math.round(task.progress ?? 0)}%  ${fmtWhen(task.created_at)}`);
+    if (task.goal) {
+        const g = task.goal.replace(/\s+/g, ' ');
+        console.log(`목표: ${g.length > 200 ? `${g.slice(0, 200)}… (${g.length}자)` : g}`);
+    }
+    if (task.folder_rel) console.log(`폴더: ${task.folder_rel}`);
+    if (task.executor === 'local') console.log(`브랜치: omk-task/${task.id.slice(0, 8)}`);
+
+    // 진행 요약 — 도구 호출 수·턴·재시도는 한 줄로.
+    const calls = steps.filter((s) => s.step_type === 'assistant_tool_call').length;
+    const retries = steps.filter((s) => s.step_type === 'retry').length;
+    const diffs = steps.filter((s) => s.step_type === 'diff');
+    console.log(`\x1b[2m스텝 ${steps.length}개 · 도구 호출 ${calls}회${retries ? ` · 재시도 ${retries}회` : ''}${diffs.length ? ` · diff ${diffs.length}건` : ''}\x1b[0m`);
+
+    if (task.result) console.log(`\n\x1b[1m결과\x1b[0m\n${task.result}`);
+    // completed 인데 error 가 남은 행은 2026-08-26 이전 데이터다(PR #638 이 완료 시 error 를
+    // 지우기 전). 성공을 실패처럼 보이지 않게 흐리게 "이전 시도"로 표기한다.
+    if (task.error) {
+        console.log(task.status === 'completed'
+            ? `\n\x1b[2m(이전 시도 사유: ${task.error})\x1b[0m`
+            : `\n\x1b[31m오류: ${task.error}\x1b[0m`);
+    }
+
+    if (opts.steps) {
+        console.log('\n\x1b[1m진행 기록\x1b[0m');
+        const lines = steps.map(stepLine).filter((l): l is string => l !== null);
+        console.log(lines.length ? lines.join('\n') : '  (표시할 기록 없음)');
+    }
+    if (opts.diff) {
+        console.log('\n\x1b[1m변경분\x1b[0m');
+        console.log(diffs.length ? diffs.map((d) => d.content ?? '').join('\n') : '  (변경분 없음 — worktree 격리가 없었거나 변경이 없었다)');
+    }
+    if (!opts.steps && !opts.diff && (steps.length > 0 || diffs.length > 0)) {
+        console.log(`\n\x1b[2m--steps 로 진행 기록, --diff 로 변경분을 볼 수 있습니다.\x1b[0m`);
+    }
+}
+
 async function cmdResume(taskId: string, dir: string, autoApprove: boolean): Promise<void> {
     const cfg = requireConfig();
     const folder = path.resolve(dir);
@@ -269,6 +332,11 @@ async function main(): Promise<void> {
     if (cmd === 'status') return cmdStatus();
     if (cmd === 'connect') return cmdConnect(argv.slice(1));
     if (cmd === 'tasks') return cmdTasks(argv.includes('--all'));
+    if (cmd === 'show') {
+        const taskId = argv[1];
+        if (!taskId || taskId.startsWith('--')) { console.error('사용법: openmake-code show <taskId> [--steps] [--diff]'); process.exit(1); }
+        return cmdShow(taskId, { steps: argv.includes('--steps'), diff: argv.includes('--diff') });
+    }
     if (cmd === 'resume') {
         const taskId = argv[1];
         if (!taskId || taskId.startsWith('--')) { console.error('사용법: openmake-code resume <taskId> [--dir .] [--yes]'); process.exit(1); }
@@ -285,6 +353,7 @@ async function main(): Promise<void> {
   openmake-code "목표" [--dir .] [--yes]   로컬 에이전트 작업 1회 실행
                                    (--yes: 파일 쓰기류 서버 승인 자동화. 셸은 별도 확인)
   openmake-code tasks [--all]      이 디바이스의 로컬 작업 목록 (종료 작업은 --all)
+  openmake-code show <taskId> [--steps] [--diff]   작업 결과 다시 보기 (실행 없음·연결 불필요)
   openmake-code resume <taskId> [--dir .] [--yes]   checkpoint 에서 이어하기 (같은 worktree 재부착)
   openmake-code "목표" --resume    재개 가능한 최근 작업이 있으면 그것을 이어감 (없으면 새 작업)`);
         return;


### PR DESCRIPTION
## 배경
resume plan(private docs `proposals/2026-08-26-openmake-code-resume-cli-plan.md`)에서 **범위 밖으로 미뤄둔 조회 명령**. 완료·실패한 작업의 결과를 CLI 에서 다시 보려면 웹으로 가야 했다.

## 변경 (CLI 만 — 서버 변경 0)
서버에 이미 있는 `GET /api/agent-tasks/:id` + `/steps` 만 읽는다. **실행이 없어 디바이스 연결·폴더 지정이 필요 없다**(resume 과 다른 점).

```
openmake-code show <taskId> [--steps] [--diff]
```
- **기본**: 상태·목표(200자 초과 시 절단 + 원문 길이)·폴더·작업 브랜치 + 진행 요약(스텝/도구 호출/재시도/diff 수) + 결과 본문
- **`--steps`**: `tool_result`·`judge`·`retry`·`hitl_degrade`·`steering`·`artifact` 를 시간순 한 줄 요약 (`assistant_tool_call`/`plan`/`assistant` 는 집계로만 — 한 줄씩 찍으면 노이즈)
- **`--diff`**: `diff` 스텝(작업 중 서버가 캡처한 worktree `git diff`)

## UX 판단 하나
`completed` 인데 `error` 가 남은 **과거 행**(PR #638 이 완료 시 error 를 지우기 전 데이터)은 빨간 "오류" 대신 흐린 `(이전 시도 사유: …)` 로 표기한다 — 성공한 작업을 실패처럼 보여주지 않기 위해서다.

## 검증
실제 완료 작업(`81c8b42e`, diff 1건·스텝 10개)으로 3개 모드 출력 확인. eslint 통과, 서버 무변경이라 테스트 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)