### PR TITLE
fix(rate-limit): 리미터 간 카운터 공유·프록시 IP 단일 집계 — 무관한 429 제거

### DIFF
--- a/apps/api/src/__tests__/rate-limiter-isolation.test.ts
+++ b/apps/api/src/__tests__/rate-limiter-isolation.test.ts
@@ -1,0 +1,84 @@
+/**
+ * 레이트리밋 격리 — 2026-08-26 운영 실측으로 드러난 3가지 결함의 회귀 고정.
+ *
+ * ① 리미터끼리 카운터를 공유해 무관한 트래픽이 남의 예산을 먹었다
+ * ② API key 클라이언트(CLI·데스크톱)가 프록시 IP 버킷에 섞여 남의 요청으로 429 를 맞았다
+ * ③ 프록시 뒤에서 실 클라이언트 IP 가 사라져 외부 사용자 전원이 한 버킷을 썼다
+ */
+jest.mock('../config', () => ({
+    getConfig: () => ({ storageBackend: 'memory', redisUrl: '', trustedProxies: [] }),
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { resetKeyValueStoreForTests } from '../storage';
+import { RL_CHAT, RL_AGENT_TASK } from '../config/rate-limits';
+
+const { chatLimiter, agentTaskLimiter } = require('../middlewares/rate-limiters');
+
+function makeApp() {
+    const app = express();
+    app.set('trust proxy', true);
+    app.use('/api/chat', chatLimiter);
+    app.use('/api/agent-tasks', agentTaskLimiter);
+    app.post('/api/chat', (_req, res) => res.json({ ok: true }));
+    app.post('/api/agent-tasks/x/share', (_req, res) => res.json({ ok: true }));
+    return app;
+}
+
+describe('레이트리밋 격리', () => {
+    beforeEach(() => resetKeyValueStoreForTests());
+
+    test('한 리미터를 소진해도 다른 리미터 예산은 남는다', async () => {
+        const app = makeApp();
+        const ip = '203.0.113.200';
+        for (let i = 0; i < RL_CHAT.ipLimit + 2; i++) {
+            await request(app).post('/api/chat').set('X-Forwarded-For', ip).send({});
+        }
+        expect((await request(app).post('/api/chat').set('X-Forwarded-For', ip).send({})).status).toBe(429);
+
+        // 같은 IP·같은 창이지만 에이전트 작업 리미터는 독립 카운터를 써야 한다
+        const other = await request(app).post('/api/agent-tasks/x/share').set('X-Forwarded-For', ip).send({});
+        expect(other.status).toBe(200);
+    });
+
+    test('API key 클라이언트는 IP 버킷과 분리된다', async () => {
+        const app = makeApp();
+        const proxyIp = '::1'; // 프록시 뒤 — 모든 익명 트래픽이 여기로 모인다
+        for (let i = 0; i < RL_AGENT_TASK.ipLimit + 2; i++) {
+            await request(app).post('/api/agent-tasks/x/share').set('X-Forwarded-For', proxyIp).send({});
+        }
+        expect((await request(app).post('/api/agent-tasks/x/share').set('X-Forwarded-For', proxyIp).send({})).status).toBe(429);
+
+        // 같은 경로·같은 IP 라도 API key 는 자기 키 해시로 센다
+        const cli = await request(app).post('/api/agent-tasks/x/share')
+            .set('X-Forwarded-For', proxyIp).set('X-API-Key', 'omk_live_testkey_a').send({});
+        expect(cli.status).toBe(200);
+    });
+
+    test('서로 다른 API key 는 서로의 예산을 먹지 않는다', async () => {
+        const app = makeApp();
+        for (let i = 0; i < RL_AGENT_TASK.ipLimit + 2; i++) {
+            await request(app).post('/api/agent-tasks/x/share').set('X-API-Key', 'omk_live_key_one').send({});
+        }
+        expect((await request(app).post('/api/agent-tasks/x/share').set('X-API-Key', 'omk_live_key_one').send({})).status).toBe(429);
+        expect((await request(app).post('/api/agent-tasks/x/share').set('X-API-Key', 'omk_live_key_two').send({})).status).toBe(200);
+    });
+
+    test('루프백 peer 에서는 CF-Connecting-IP 로 클라이언트를 구분한다', async () => {
+        const app = makeApp();
+        // supertest 는 루프백에서 연결한다 — XFF 없이 CF 헤더만 준다
+        for (let i = 0; i < RL_CHAT.ipLimit + 2; i++) {
+            await request(app).post('/api/chat').set('CF-Connecting-IP', '198.51.100.7').send({});
+        }
+        expect((await request(app).post('/api/chat').set('CF-Connecting-IP', '198.51.100.7').send({})).status).toBe(429);
+        // 다른 방문자는 영향 없다 — 이것이 안 되면 외부 사용자 전원이 한 버킷을 쓴다
+        expect((await request(app).post('/api/chat').set('CF-Connecting-IP', '198.51.100.8').send({})).status).toBe(200);
+    });
+
+    test('IP 형태가 아닌 CF 헤더는 무시한다(헤더 원문이 키가 되지 않게)', async () => {
+        const app = makeApp();
+        const res = await request(app).post('/api/chat').set('CF-Connecting-IP', 'not-an-ip; drop table').send({});
+        expect(res.status).toBe(200);
+    });
+});

--- a/apps/api/src/middlewares/rate-limiters.ts
+++ b/apps/api/src/middlewares/rate-limiters.ts
@@ -10,6 +10,7 @@ import {
     RL_WEB_SEARCH, RL_MEMORY, RL_MCP, RL_API_KEY_MGMT, RL_PUSH, RL_ADMIN,
     RL_AGENT_TASK,
 } from '../config/rate-limits';
+import { createHash } from 'crypto';
 import { getKeyValueStore } from '../storage';
 import { STORAGE_POLICY, RATE_LIMIT_POLICY, AUTH_COOKIES } from '../config/security';
 import { ARTIFACT_EXEC } from '../config/artifact-exec';
@@ -38,6 +39,12 @@ interface AdvancedRateLimiterOptions {
     ipLimit: number;
     userLimit?: number;
     endpointRules?: EndpointRule[];
+    /**
+     * 리미터 식별자 — 카운터 키 네임스페이스. **필수**: 없으면 windowMs 가 같은 리미터끼리
+     * 같은 액터 카운터를 공유해, 예컨대 채팅 POST 가 에이전트 작업 예산을 먹어버린다
+     * (2026-08-26 운영 실측: 사이트 전체 POST 가 한 카운터에 쌓여 CLI 가 상시 429).
+     */
+    name: string;
     message: string;
     /** true 를 반환하면 이 요청은 카운트/차단하지 않고 통과 (예: 비용 리미터에서 read-only GET 제외) */
     skip?: (req: Request) => boolean;
@@ -60,8 +67,48 @@ function makeStorageKey(counterKey: string): string {
     return STORAGE_POLICY.KEY_PREFIX + STORAGE_POLICY.RATE_LIMIT_PREFIX + counterKey;
 }
 
+/** 키로 쓸 수 있는 IP 형태인지 — 헤더 원문을 그대로 키에 넣지 않기 위한 최소 검증. */
+function isPlausibleIP(v: string): boolean {
+    return v.length > 0 && v.length <= 45 && /^[0-9a-fA-F:.]+$/.test(v);
+}
+
+function isLoopbackPeer(ip: string): boolean {
+    return ip === '::1' || ip === '127.0.0.1' || ip.startsWith('::ffff:127.');
+}
+
+/**
+ * 레이트리밋 키로 쓸 클라이언트 IP.
+ *
+ * ⚠️ 운영 실측(2026-08-26): Cloudflare Tunnel → cloudflared → Caddy → Express 경로에서
+ * `req.ip` 가 항상 루프백(`::1`)이라 **외부 사용자 전원이 IP 버킷 하나를 공유**했다
+ * (X-Forwarded-For 를 넣어도 무시됨 — Caddy 가 신뢰하지 않는 peer 의 XFF 를 덮어쓴다).
+ * Cloudflare 가 붙이는 `CF-Connecting-IP` 는 그 경로에서 살아남으므로, **peer 가 루프백일
+ * 때만** 이 헤더를 채택한다. 외부 클라이언트는 Cloudflare 가 값을 덮어쓰므로 위조할 수 없고,
+ * LAN 직결(:33000)만 위조 여지가 있는데 그 경로는 내부 전용이다.
+ */
 function getRequestIP(req: Request): string {
-    return req.ip || 'unknown';
+    const peer = req.ip || 'unknown';
+    if (isLoopbackPeer(peer)) {
+        const raw = req.headers['cf-connecting-ip'] ?? req.headers['true-client-ip'];
+        const cf = (Array.isArray(raw) ? raw[0] : raw)?.trim();
+        if (cf && isPlausibleIP(cf)) return cf;
+    }
+    return peer;
+}
+
+/**
+ * 액터 키 — "이 요청을 누구 몫으로 셀 것인가".
+ *
+ * JWT 사용자 > API key > IP 순. **API key 를 IP 로 세면 안 된다**: 프록시 뒤에서는 CLI·
+ * 데스크톱 클라이언트가 사이트 전체 트래픽과 한 버킷을 쓰게 되어, 남의 요청 때문에 429 를
+ * 맞는다(실측). 키 원문은 넣지 않고 해시 앞부분만 쓴다.
+ */
+function resolveActorKey(req: Request, userId: string | null, ip: string): string {
+    if (userId) return `user:${userId}`;
+    const raw = req.headers['x-api-key'];
+    const apiKey = (Array.isArray(raw) ? raw[0] : raw)?.trim();
+    if (apiKey) return `key:${createHash('sha256').update(apiKey).digest('hex').slice(0, 16)}`;
+    return `ip:${ip}`;
 }
 
 /**
@@ -253,7 +300,7 @@ export function createAdvancedRateLimiter(options: AdvancedRateLimiterOptions) {
         const ip = getRequestIP(req);
         const identity = await resolveLimiterIdentity(req);
         const userKey = identity?.userId ?? null;
-        const actorKey = userKey ? `user:${userKey}` : `ip:${ip}`;
+        const actorKey = resolveActorKey(req, userKey, ip);
 
         // Admin은 높은 배수의 제한 적용 (완전 우회 방지)
         const effectiveIpLimit = isAdminRole(identity?.role) ? options.ipLimit * RATE_LIMIT_POLICY.ADMIN_MULTIPLIER : options.ipLimit;
@@ -261,20 +308,19 @@ export function createAdvancedRateLimiter(options: AdvancedRateLimiterOptions) {
         const endpointSpecificLimit = getEndpointSpecificLimit(options.endpointRules, req);
         const perEndpointLimit = endpointSpecificLimit ?? effectiveIpLimit;
 
+        // 액터 예산 1개 + 엔드포인트 예산 1개. 식별된 액터(JWT·API key)는 IP 차원을 타지
+        // 않는다 — 프록시 뒤에서 IP 는 전원이 공유하는 값이라 남의 트래픽으로 막힌다.
+        const actorBudget = userKey && options.userLimit !== undefined ? options.userLimit : effectiveIpLimit;
         const dimensions: Array<{ key: string; limit: number }> = [
-            { key: `ip:${ip}`, limit: effectiveIpLimit },
+            { key: actorKey, limit: actorBudget },
             { key: `endpoint:${actorKey}:${getEndpointKey(req)}`, limit: perEndpointLimit },
         ];
-
-        if (userKey && options.userLimit !== undefined) {
-            dimensions.push({ key: `user:${userKey}`, limit: options.userLimit });
-        }
 
         let strictestResult: RateLimitDecision | null = null;
 
         for (const dimension of dimensions) {
             const result = await evaluateAndIncrement(
-                `${dimension.key}:${options.windowMs}`,
+                `${options.name}:${dimension.key}:${options.windowMs}`,
                 dimension.limit,
                 options.windowMs,
                 now
@@ -312,6 +358,7 @@ export function createAdvancedRateLimiter(options: AdvancedRateLimiterOptions) {
  * 일반 API 레이트 리미터
  */
 export const generalLimiter = createAdvancedRateLimiter({
+    name: 'general',
     windowMs: RL_GENERAL.windowMs,
     ipLimit: RL_GENERAL.ipLimit,
     userLimit: RL_GENERAL.userLimit,
@@ -328,6 +375,7 @@ export const generalLimiter = createAdvancedRateLimiter({
  * 인증 관련 레이트 리미터
  */
 export const authLimiter = createAdvancedRateLimiter({
+    name: 'auth',
     windowMs: RL_AUTH.windowMs,
     ipLimit: RL_AUTH.ipLimit,
     endpointRules: [
@@ -343,6 +391,7 @@ export const authLimiter = createAdvancedRateLimiter({
  * 채팅 API 레이트 리미터
  */
 export const chatLimiter = createAdvancedRateLimiter({
+    name: 'chat',
     windowMs: RL_CHAT.windowMs,
     ipLimit: RL_CHAT.ipLimit,
     userLimit: RL_CHAT.userLimit,
@@ -357,6 +406,7 @@ export const chatLimiter = createAdvancedRateLimiter({
  * Research API 레이트 리미터 (LLM 멀티스텝 호출 -- 비용 높음)
  */
 export const researchLimiter = createAdvancedRateLimiter({
+    name: 'research',
     windowMs: RL_RESEARCH.windowMs,
     ipLimit: RL_RESEARCH.ipLimit,
     userLimit: RL_RESEARCH.userLimit,
@@ -376,6 +426,7 @@ export const researchLimiter = createAdvancedRateLimiter({
  * 실행 비용은 생성(POST)에서 발생 — 진행 폴링(GET/HEAD)은 제외 (research 와 동일 정책).
  */
 export const agentTaskLimiter = createAdvancedRateLimiter({
+    name: 'agent-task',
     windowMs: RL_AGENT_TASK.windowMs,
     ipLimit: RL_AGENT_TASK.ipLimit,
     userLimit: RL_AGENT_TASK.userLimit,
@@ -390,6 +441,7 @@ export const agentTaskLimiter = createAdvancedRateLimiter({
  * 대용량 업로드 (OCR/PDF) 레이트 리미터
  */
 export const uploadLimiter = createAdvancedRateLimiter({
+    name: 'upload',
     windowMs: RL_UPLOAD.windowMs,
     ipLimit: RL_UPLOAD.ipLimit,
     userLimit: RL_UPLOAD.userLimit,
@@ -404,6 +456,7 @@ export const uploadLimiter = createAdvancedRateLimiter({
  * 나뉘어 도착하므로 uploadLimiter(30/15분)와 별도로 높은 상한을 갖는다.
  */
 export const chunkUploadLimiter = createAdvancedRateLimiter({
+    name: 'chunk-upload',
     windowMs: RL_CHUNK_UPLOAD.windowMs,
     ipLimit: RL_CHUNK_UPLOAD.ipLimit,
     userLimit: RL_CHUNK_UPLOAD.userLimit,
@@ -414,6 +467,7 @@ export const chunkUploadLimiter = createAdvancedRateLimiter({
  * 웹 검색 레이트 리미터 (외부 검색 API 호출 -- 비용 높음)
  */
 export const webSearchLimiter = createAdvancedRateLimiter({
+    name: 'web-search',
     windowMs: RL_WEB_SEARCH.windowMs,
     ipLimit: RL_WEB_SEARCH.ipLimit,
     userLimit: RL_WEB_SEARCH.userLimit,
@@ -427,6 +481,7 @@ export const webSearchLimiter = createAdvancedRateLimiter({
  * 메모리 API 레이트 리미터 (DB 중심 메모리 CRUD)
  */
 export const memoryLimiter = createAdvancedRateLimiter({
+    name: 'memory',
     windowMs: RL_MEMORY.windowMs,
     ipLimit: RL_MEMORY.ipLimit,
     userLimit: RL_MEMORY.userLimit,
@@ -441,6 +496,7 @@ export const memoryLimiter = createAdvancedRateLimiter({
  * MCP 레이트 리미터 (MCP 도구 호출 -- AI 비용 높음)
  */
 export const mcpLimiter = createAdvancedRateLimiter({
+    name: 'mcp',
     windowMs: RL_MCP.windowMs,
     ipLimit: RL_MCP.ipLimit,
     userLimit: RL_MCP.userLimit,
@@ -455,6 +511,7 @@ export const mcpLimiter = createAdvancedRateLimiter({
  * API 키 관리 레이트 리미터 (API Key CRUD -- 스크래핑 방지)
  */
 export const apiKeyManagementLimiter = createAdvancedRateLimiter({
+    name: 'api-key-mgmt',
     windowMs: RL_API_KEY_MGMT.windowMs,
     ipLimit: RL_API_KEY_MGMT.ipLimit,
     userLimit: RL_API_KEY_MGMT.userLimit,
@@ -472,6 +529,7 @@ export const apiKeyManagementLimiter = createAdvancedRateLimiter({
  * 푸시 알림 레이트 리미터 (구독/발송 제한)
  */
 export const pushLimiter = createAdvancedRateLimiter({
+    name: 'push',
     windowMs: RL_PUSH.windowMs,
     ipLimit: RL_PUSH.ipLimit,
     userLimit: RL_PUSH.userLimit,
@@ -485,6 +543,7 @@ export const pushLimiter = createAdvancedRateLimiter({
  * Admin API 레이트 리미터
  */
 export const adminLimiter = createAdvancedRateLimiter({
+    name: 'admin',
     windowMs: RL_ADMIN.windowMs,
     ipLimit: RL_ADMIN.ipLimit,
     userLimit: RL_ADMIN.userLimit,
@@ -495,6 +554,7 @@ export const adminLimiter = createAdvancedRateLimiter({
  * 아티팩트 코드 실행 레이트 리미터 — 컨테이너 실행은 비용이 커 보수적으로 제한.
  */
 export const artifactExecLimiter = createAdvancedRateLimiter({
+    name: 'artifact-exec',
     windowMs: ARTIFACT_EXEC.rateWindowMs,
     ipLimit: ARTIFACT_EXEC.rateIpLimit,
     userLimit: ARTIFACT_EXEC.rateUserLimit,
@@ -505,6 +565,7 @@ export const artifactExecLimiter = createAdvancedRateLimiter({
  * 아티팩트 export(pdf/docx) 레이트 리미터 — 컨테이너 변환은 비용이 커 보수적으로 제한.
  */
 export const artifactExportLimiter = createAdvancedRateLimiter({
+    name: 'artifact-export',
     windowMs: ARTIFACT_EXPORT.rateWindowMs,
     ipLimit: ARTIFACT_EXPORT.rateIpLimit,
     userLimit: ARTIFACT_EXPORT.rateUserLimit,


### PR DESCRIPTION
CLI(`openmake-code`)가 상시 429 를 맞는 현상을 추적하다 찾은 결함 3개. 모두 **"내 요청이 아닌 것 때문에 막힌다"** 부류이고, 서로 겹쳐 있어 하나만 고치면 증상이 그대로 남는다.

## 무엇이 잘못돼 있었나 (운영 실측)

| # | 결함 | 증거 |
|---|---|---|
| ① | **리미터끼리 카운터 공유** — 키가 `ip:<ip>:<windowMs>` 라 리미터 이름이 없다. windowMs 15분 리미터 전부(auth·chat·mcp·agent-task…)가 한 카운터를 올리고 각자 자기 상한으로 판정 | 레디스에 `omk:rl:ip:::1:900000` 단 하나 |
| ② | **API key 요청이 IP 로 집계** — 리미터는 auth 미들웨어보다 먼저 돌아 JWT 만 해석한다. API key 는 신원 미상 → IP. 프록시 뒤 IP 는 전원 공용이라 CLI·데스크톱이 남의 트래픽에 막힌다 | 같은 시각 JWT 요청 200(사용자 버킷 120), API key 429(IP 버킷 60/0) |
| ③ | **프록시 뒤 실 클라이언트 IP 소실** — `req.ip` 가 항상 `::1`. XFF 를 넣어도 무시된다(Caddy 가 신뢰하지 않는 peer 의 XFF 를 덮어씀) | 외부 요청 1건 → `omk:rl:ip:::1` 카운터 +1 (before/after 대조), `X-Forwarded-For: 9.9.9.9` 로는 키 미생성 |

③ 때문에 **외부 사용자 전원이 IP 버킷 하나를 공유**하고 있었다. 관리자는 `ADMIN_MULTIPLIER` 덕에 티가 안 났고, 일반 사용자·API key 클라이언트에서만 드러난다.

## 수정

- 카운터 키에 리미터 `name` 네임스페이스(옵션 **필수** 필드 — 빠뜨리면 같은 문제가 재발한다. 15개 전부 부여)
- API key 요청의 액터 = 키 해시(sha256 앞 16자). 키 원문은 저장하지 않는다
- peer 가 루프백일 때만 `CF-Connecting-IP`(대안 `True-Client-IP`) 채택 — 외부에서는 Cloudflare 가 값을 덮어쓰므로 위조 불가, LAN 직결(:33000)만 여지가 있는데 그 경로는 내부 전용. IP 형태 검증을 거쳐 헤더 원문이 키가 되지 않게 한다
- **식별된 액터(JWT·API key)는 IP 차원을 타지 않는다** — 프록시 뒤 IP 는 전원이 공유하는 값이라, ①②만 고치고 이 차원을 남기면 같은 이유로 계속 막힌다. 익명 요청은 종전대로 IP 기준

## 검증

- 기존 behavior 테스트 4건 유지(익명 IP 한도·429 헤더·IP 독립·성공 헤더)
- 격리 테스트 5건 신규: 리미터 간 독립 · API key 와 IP 버킷 분리 · 키별 독립 · `CF-Connecting-IP` 로 방문자 구분 · IP 형태가 아닌 헤더 무시
- 배포 후 라이브로 ③(외부 요청이 실제 클라이언트 IP 키를 만드는지) 확인 — 헤더가 안 오면 종전 동작으로 폴백이라 회귀는 없다

⚠️ 배포 시 기존 카운터는 키가 바뀌어 한 번 리셋된다(TTL 로 소멸).