### PR TITLE
feat(agent-task-share): 공유 산출물을 격리 오리진 뷰어로 열람

### DIFF
--- a/apps/api/src/__tests__/services/agent-task/share-artifact-viewer.test.ts
+++ b/apps/api/src/__tests__/services/agent-task/share-artifact-viewer.test.ts
@@ -1,0 +1,54 @@
+/**
+ * 공유 산출물 뷰어 — pubId 유도·역파싱과 **인덱스 정렬**의 회귀 고정.
+ *
+ * 인덱스가 어긋나면 A 산출물 링크로 B 본문이 열린다(공유 범위 밖 노출은 아니지만
+ * 사용자가 보는 것이 달라진다) — 그래서 문서와 뷰어 콘텐츠는 같은 선별 함수를 봐야 한다.
+ */
+import { shareViewerPubId, parseShareViewerPubId } from '../../../services/agent-task/share-artifact-viewer';
+import { buildShareDocument, extractArtifactViewerContents } from '../../../services/agent-task/share-document';
+
+const SHARE_ID = '66ba7287-b48c-44f8-98ed-37b0e60a951c';
+
+describe('shareViewerPubId', () => {
+    test('nginx 경로 패턴([A-Za-z0-9-]+)을 만족한다', () => {
+        expect(shareViewerPubId(SHARE_ID, 0)).toMatch(/^[A-Za-z0-9-]+$/);
+    });
+
+    test('왕복한다', () => {
+        expect(parseShareViewerPubId(shareViewerPubId(SHARE_ID, 3))).toEqual({ shareId: SHARE_ID, index: 3 });
+    });
+
+    test('다른 게시본 id 는 이 경로 소관이 아니다', () => {
+        expect(parseShareViewerPubId('c0ffee00-1111-2222-3333-444455556666')).toBeNull();
+        expect(parseShareViewerPubId('share-')).toBeNull();
+        expect(parseShareViewerPubId('share-abc')).toBeNull();       // index 없음
+        expect(parseShareViewerPubId('share-abc-x')).toBeNull();     // index 가 수가 아님
+    });
+});
+
+describe('문서 artifacts ↔ 뷰어 콘텐츠 인덱스 정렬', () => {
+    const steps = [
+        { step_number: 0, step_type: 'tool_result', content: '무관' },
+        { step_number: 1, step_type: 'artifact', content: '{"id":"a","kind":"html","title":"리포트","content":"<h1>A</h1>"}' },
+        { step_number: 2, step_type: 'artifact', content: '깨진 JSON' },
+        { step_number: 3, step_type: 'artifact', content: '{"id":"c","kind":"markdown","title":"규칙","content":"# C"}' },
+    ];
+
+    test('제목 없는/깨진 산출물이 있어도 자리가 밀리지 않는다', () => {
+        const doc = buildShareDocument({ id: 't' }, steps);
+        const contents = extractArtifactViewerContents(steps);
+        expect(doc.artifacts).toHaveLength(3);
+        expect(contents).toHaveLength(3);
+        expect(doc.artifacts[0].title).toBe('리포트');
+        expect(contents[0]).toBe('<h1>A</h1>');
+        expect(contents[1]).toBeNull();          // 깨진 JSON — 뷰어 없음
+        expect(doc.artifacts[2].title).toBe('규칙');
+        expect(contents[2]).toBe('# C');
+    });
+
+    test('마크업 본문은 문서엔 없고 뷰어 콘텐츠에만 있다', () => {
+        const doc = buildShareDocument({ id: 't' }, steps);
+        expect(JSON.stringify(doc)).not.toContain('<h1>A</h1>');
+        expect(extractArtifactViewerContents(steps)[0]).toContain('<h1>A</h1>');
+    });
+});

--- a/apps/api/src/routes/agent-task-share.routes.ts
+++ b/apps/api/src/routes/agent-task-share.routes.ts
@@ -19,6 +19,7 @@
 import { Router, Request, Response } from 'express';
 import { randomUUID, randomBytes, timingSafeEqual } from 'crypto';
 import { optionalAuth } from '../auth';
+import { optionalApiKey } from '../middlewares/api-key-auth';
 import { requireAuthOrApiKeyScope } from '../middlewares/api-key-auth';
 import { API_KEY_SCOPES } from '../config/api-key-scopes';
 import { success, badRequest, notFound } from '../utils/api-response';
@@ -208,7 +209,7 @@ agentTaskShareRouter.delete('/agent-tasks/:taskId/share', requireOwner, asyncHan
  *   link          : `?token` 이 share_token 과 일치하면 비인증도 허용
  * 존재 여부 자체를 숨기기 위해 권한 실패는 **404** 로 응답한다(403 이면 "그 작업은 있다"가 샌다).
  */
-agentTaskShareRouter.get('/shared-tasks/:shareId', optionalAuth, asyncHandler(async (req: Request, res: Response) => {
+agentTaskShareRouter.get('/shared-tasks/:shareId', optionalApiKey, optionalAuth, asyncHandler(async (req: Request, res: Response) => {
     const share = await repo().getByShareId(req.params.shareId);
     if (!share) {
         res.status(404).json(notFound('공유된 작업'));
@@ -235,7 +236,7 @@ agentTaskShareRouter.get('/shared-tasks/:shareId', optionalAuth, asyncHandler(as
  * 공유 문서를 한 번 본 사람이 인가와 무관하게 영구 URL 을 갖게 된다. 여기서 발급하는
  * 접근토큰은 TTL 이 있고, 공유를 해제하면 export 자체가 사라져 404 다.
  */
-agentTaskShareRouter.get('/shared-tasks/:shareId/artifacts/:index/open', optionalAuth, asyncHandler(async (req: Request, res: Response) => {
+agentTaskShareRouter.get('/shared-tasks/:shareId/artifacts/:index/open', optionalApiKey, optionalAuth, asyncHandler(async (req: Request, res: Response) => {
     const share = await repo().getByShareId(req.params.shareId);
     if (!share || !isShareViewerAllowed(req, share)) {
         res.status(404).json(notFound('공유된 작업'));

--- a/apps/api/src/routes/agent-task-share.routes.ts
+++ b/apps/api/src/routes/agent-task-share.routes.ts
@@ -25,7 +25,10 @@ import { success, badRequest, notFound } from '../utils/api-response';
 import { asyncHandler } from '../utils/error-handler';
 import { getUnifiedDatabase } from '../data/models/unified-database';
 import { AgentTaskShareRepository, type ShareVisibility } from '../data/repositories/agent-task-share-repository';
-import { buildShareDocument, type ShareStepInput, type ShareTaskInput } from '../services/agent-task/share-document';
+import { buildShareDocument, extractArtifactViewerContents, type ShareDocument, type ShareStepInput, type ShareTaskInput } from '../services/agent-task/share-document';
+import { exportShareArtifactViewers, removeShareArtifactViewers } from '../services/agent-task/share-artifact-viewer';
+import { ARTIFACT_VIEWER } from '../config/artifact-viewer';
+import { mintAccessToken } from '../services/artifact-viewer-service';
 import { loadOwnedTask } from './agent-task.helpers';
 import { createLogger } from '../utils/logger';
 
@@ -55,9 +58,15 @@ function repo(): AgentTaskShareRepository {
 }
 
 /** 작업 + 스텝을 읽어 공유 문서를 만든다(게시/미리보기 공용). */
-async function buildFor(taskId: string, task: ShareTaskInput, opts: ShareToggles) {
+async function buildFor(taskId: string, task: ShareTaskInput, opts: ShareToggles): Promise<ShareDocument> {
     const steps = await getUnifiedDatabase().getAgentTaskSteps(taskId);
     return buildShareDocument(task, steps as unknown as ShareStepInput[], opts);
+}
+
+/** 뷰어 export 용 산출물 원본 — 문서의 artifacts 와 인덱스 정렬된다. */
+async function artifactContentsFor(taskId: string): Promise<(string | null)[]> {
+    const steps = await getUnifiedDatabase().getAgentTaskSteps(taskId);
+    return extractArtifactViewerContents(steps as unknown as ShareStepInput[]);
 }
 
 interface ShareToggles { includeSteps: boolean; includeDiff: boolean; includeArtifacts: boolean }
@@ -70,6 +79,18 @@ function readToggles(body: unknown): ShareToggles {
         includeDiff: b.includeDiff !== false,
         includeArtifacts: b.includeArtifacts !== false,
     };
+}
+
+/**
+ * 조회 인가 — 소유자 / authenticated(로그인) / link(토큰 일치). 조회와 산출물 열람이
+ * **같은 규칙**을 쓰도록 한 곳에 둔다(둘이 어긋나면 산출물이 공유보다 넓게 열린다).
+ */
+function isShareViewerAllowed(req: Request, share: { owner_user_id: string; visibility: ShareVisibility; share_token: string | null }): boolean {
+    const viewerId = req.user?.id ? String(req.user.id) : null;
+    if (viewerId !== null && viewerId === share.owner_user_id) return true;
+    if (share.visibility === 'authenticated') return viewerId !== null;
+    if (share.visibility === 'link') return safeTokenEqual(String(req.query.token ?? ''), share.share_token);
+    return false;
 }
 
 /** 공유 링크 경로 — 응답 3곳(게시·조회·CLI)이 같은 형태를 쓰도록 한 곳에서 만든다. */
@@ -136,6 +157,16 @@ agentTaskShareRouter.post('/agent-tasks/:taskId/share', requireOwner, asyncHandl
         ? (existing?.visibility === 'link' && existing.share_token ? existing.share_token : randomBytes(24).toString('base64url'))
         : null;
 
+    // 재게시면 이전 export 를 먼저 지운다(산출물 수가 줄면 옛 페이지가 남는다).
+    if (existing) {
+        const prev = (existing.snapshot as ShareDocument | null)?.artifacts?.length ?? 0;
+        await removeShareArtifactViewers(shareId, prev);
+    }
+    // 격리 오리진에 산출물 뷰어를 export 하고 viewerId 를 스냅샷에 심는다(fail-open).
+    if (toggles.includeArtifacts && snapshot.artifacts.length > 0) {
+        await exportShareArtifactViewers(shareId, String(req.user!.id), snapshot.artifacts, await artifactContentsFor(req.params.taskId));
+    }
+
     const row = await repo().upsert({
         shareId,
         taskId: req.params.taskId,
@@ -161,6 +192,10 @@ agentTaskShareRouter.post('/agent-tasks/:taskId/share', requireOwner, asyncHandl
 agentTaskShareRouter.delete('/agent-tasks/:taskId/share', requireOwner, asyncHandler(async (req: Request, res: Response) => {
     const task = await loadOwnedTask(req, res, req.params.taskId);
     if (!task) return;
+    const existing = await repo().getByTaskId(req.params.taskId);
+    if (existing) {
+        await removeShareArtifactViewers(existing.share_id, (existing.snapshot as ShareDocument | null)?.artifacts?.length ?? 0);
+    }
     const deleted = await repo().deleteByTaskId(req.params.taskId);
     logger.info(`작업 공유 해제: ${req.params.taskId} (${deleted ? '삭제됨' : '없음'})`);
     res.json(success({ unshared: deleted }));
@@ -180,14 +215,7 @@ agentTaskShareRouter.get('/shared-tasks/:shareId', optionalAuth, asyncHandler(as
         return;
     }
 
-    const viewerId = req.user?.id ? String(req.user.id) : null;
-    const isOwner = viewerId !== null && viewerId === share.owner_user_id;
-    let allowed = isOwner;
-    if (!allowed) {
-        if (share.visibility === 'authenticated') allowed = viewerId !== null;
-        else if (share.visibility === 'link') allowed = safeTokenEqual(String(req.query.token ?? ''), share.share_token);
-    }
-    if (!allowed) {
+    if (!isShareViewerAllowed(req, share)) {
         res.status(404).json(notFound('공유된 작업'));
         return;
     }
@@ -198,6 +226,33 @@ agentTaskShareRouter.get('/shared-tasks/:shareId', optionalAuth, asyncHandler(as
         sharedAt: share.updated_at,
         document: share.snapshot,
     }));
+}));
+
+/**
+ * 산출물 열람 URL 발급 — 공유와 **같은 인가**를 통과한 뒤에만 격리 오리진 접근토큰을 준다.
+ *
+ * 토큰을 스냅샷에 박아두지 않는 이유: 스냅샷은 조회 응답으로 그대로 나가므로, 박아두면
+ * 공유 문서를 한 번 본 사람이 인가와 무관하게 영구 URL 을 갖게 된다. 여기서 발급하는
+ * 접근토큰은 TTL 이 있고, 공유를 해제하면 export 자체가 사라져 404 다.
+ */
+agentTaskShareRouter.get('/shared-tasks/:shareId/artifacts/:index/open', optionalAuth, asyncHandler(async (req: Request, res: Response) => {
+    const share = await repo().getByShareId(req.params.shareId);
+    if (!share || !isShareViewerAllowed(req, share)) {
+        res.status(404).json(notFound('공유된 작업'));
+        return;
+    }
+    const doc = share.snapshot as ShareDocument | null;
+    const artifact = doc?.artifacts?.[Number(req.params.index)];
+    if (!artifact?.viewerId) {
+        res.status(404).json(notFound('산출물'));
+        return;
+    }
+    const token = mintAccessToken(artifact.viewerId);
+    if (!token) {
+        res.status(404).json(notFound('산출물 뷰어'));
+        return;
+    }
+    res.json(success({ url: `${ARTIFACT_VIEWER.origin}/a/${artifact.viewerId}/?k=${encodeURIComponent(token)}` }));
 }));
 
 export default agentTaskShareRouter;

--- a/apps/api/src/routes/artifact-publication.routes.ts
+++ b/apps/api/src/routes/artifact-publication.routes.ts
@@ -31,7 +31,9 @@ import {
     resolveAuthorLabel,
     exportPublicationViewer,
     composeShareUrl,
+    verifyAccessToken,
 } from '../services/artifact-viewer-service';
+import { parseShareViewerPubId } from '../services/agent-task/share-artifact-viewer';
 import { getAuditService } from '../services/AuditService';
 import { isAdminRole } from '../data/user-manager';
 
@@ -198,6 +200,12 @@ router.get('/viewer-authz', asyncHandler(async (req: Request, res: Response) => 
         token = km ? decodeURIComponent(km[1]) : '';
     }
     if (!pubId) { res.status(403).end(); return; }
+    // 작업 공유 산출물(`share-<shareId>-<n>`)은 게시 행이 없다 — 공유 인가를 통과한 뒤
+    // `/shared-tasks/:id/artifacts/:n/open` 이 발급한 서명 접근토큰만으로 판정한다.
+    if (parseShareViewerPubId(pubId)) {
+        res.status(verifyAccessToken(pubId, token) ? 200 : 403).end();
+        return;
+    }
     const pubRepo = new ArtifactPublicationRepository(getPool());
     const pub = await pubRepo.getByPublicationId(pubId);
     if (!pub) { res.status(403).end(); return; }

--- a/apps/api/src/services/agent-task/share-artifact-viewer.ts
+++ b/apps/api/src/services/agent-task/share-artifact-viewer.ts
@@ -1,0 +1,96 @@
+/**
+ * 공유된 작업의 산출물 뷰어 — 격리 오리진(artifacts.openmake.cc)에 정적 페이지로 export.
+ *
+ * 왜 채팅 아티팩트 게시(`artifact_publications`)를 재사용하지 않는가:
+ *   작업 아티팩트는 `agent_task_steps(step_type='artifact')` JSON 으로만 남고 `artifacts`
+ *   테이블에 들어가지 않는다(운영 실측 27개 id → 매칭 0건). 두 테이블 모두 `session_id` 가
+ *   `conversation_sessions` 를 FK 로 걸고 있어 작업에는 붙일 세션이 없다(`agent_tasks` 에
+ *   session 컬럼 자체가 없다). 합성 세션 행을 만드는 방법은 세션 정리(오래된 세션 prune)가
+ *   CASCADE 로 게시본을 지워버려 위험하다.
+ *
+ * 그래서 **공유의 일부로** 다룬다: pubId 를 shareId 에서 유도하고, 인가는 공유 자체의
+ * 규칙(link 토큰·로그인·소유자)으로 판정한 뒤 서명 접근토큰을 발급한다. 공유 해제 시
+ * export 를 지우므로 토큰이 남아 있어도 404 다.
+ *
+ * HTML·SVG 산출물이 이 경로의 핵심이다 — 공유 문서 본문에는 담지 않고(텍스트만 렌더),
+ * 격리 오리진에서만 실행시킨다. 그 격리가 아티팩트 뷰어를 별도 오리진에 둔 이유다.
+ *
+ * @module services/agent-task/share-artifact-viewer
+ */
+import { ARTIFACT_VIEWER } from '../../config/artifact-viewer';
+import { exportPublication, removePublication, resolveAuthorLabel } from '../artifact-viewer-service';
+import type { ShareArtifact } from './share-document';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('ShareArtifactViewer');
+
+/** pubId 접두사 — viewer-authz 가 이 접두사로 "작업 공유 산출물" 분기를 판정한다. */
+export const SHARE_VIEWER_PREFIX = 'share-';
+
+/**
+ * 산출물 뷰어 pubId. nginx 의 `^/a/[A-Za-z0-9-]+/` 를 만족해야 하므로 하이픈만 쓴다
+ * (shareId 는 UUID). index 는 스냅샷 배열 순서 — 재게시해도 같은 순서면 같은 URL 이다.
+ */
+export function shareViewerPubId(shareId: string, index: number): string {
+    return `${SHARE_VIEWER_PREFIX}${shareId}-${index}`;
+}
+
+/** pubId → shareId. 형식이 아니면 null(= 이 경로 소관이 아님). */
+export function parseShareViewerPubId(pubId: string): { shareId: string; index: number } | null {
+    if (!pubId.startsWith(SHARE_VIEWER_PREFIX)) return null;
+    const rest = pubId.slice(SHARE_VIEWER_PREFIX.length);
+    const cut = rest.lastIndexOf('-');
+    if (cut <= 0) return null;
+    const index = Number(rest.slice(cut + 1));
+    if (!Number.isInteger(index) || index < 0) return null;
+    return { shareId: rest.slice(0, cut), index };
+}
+
+/**
+ * 게시(재게시 포함) — 산출물마다 정적 뷰어를 export 하고 스냅샷에 `viewerId` 를 심는다.
+ * 뷰어가 꺼져 있으면 아무것도 하지 않는다(URL 없음 → 웹은 본문만 보여준다).
+ * export 실패는 공유 자체를 죽이지 않는다(fail-open — 산출물 열람만 빠진다).
+ */
+export async function exportShareArtifactViewers(
+    shareId: string,
+    ownerUserId: string,
+    artifacts: ShareArtifact[],
+    /** `extractArtifactViewerContents` 결과 — artifacts 와 인덱스 정렬 */
+    contents: (string | null)[],
+): Promise<void> {
+    if (!ARTIFACT_VIEWER.enabled || artifacts.length === 0) return;
+    const author = await resolveAuthorLabel(ownerUserId);
+    for (const [i, a] of artifacts.entries()) {
+        // 본문이 없으면 보여줄 것이 없다(파싱 실패 등) — viewerId 도 심지 않는다.
+        const content = contents[i];
+        if (!content) continue;
+        const pubId = shareViewerPubId(shareId, i);
+        try {
+            await exportPublication({
+                pubId,
+                kind: a.kind,
+                lang: null,
+                content,
+                title: a.title,
+                icon: null,
+                author,
+                version: 1,
+            });
+            a.viewerId = pubId;
+        } catch (e) {
+            logger.warn(`산출물 뷰어 export 실패: ${pubId} — ${e}`);
+        }
+    }
+}
+
+/** 해제·재게시 전 정리 — 남겨두면 해제 후에도 옛 산출물이 열린다. */
+export async function removeShareArtifactViewers(shareId: string, count: number): Promise<void> {
+    if (!ARTIFACT_VIEWER.enabled) return;
+    for (let i = 0; i < count; i++) {
+        try {
+            await removePublication(shareViewerPubId(shareId, i));
+        } catch (e) {
+            logger.warn(`산출물 뷰어 제거 실패: ${shareViewerPubId(shareId, i)} — ${e}`);
+        }
+    }
+}

--- a/apps/api/src/services/agent-task/share-document.ts
+++ b/apps/api/src/services/agent-task/share-document.ts
@@ -80,6 +80,11 @@ export interface ShareArtifact {
     /** 본문 — 텍스트 계열만. 담지 않은 경우 null 이고 omitted 에 사유가 있다 */
     body: string | null;
     omitted?: 'markup' | 'unparsable';
+    /**
+     * 격리 오리진 뷰어 id — 게시 시 export 에 성공한 산출물에만 붙는다(라우트가 채운다).
+     * 본문(특히 html)은 여기서만 실행되고 공유 문서에는 담기지 않는다.
+     */
+    viewerId?: string;
 }
 
 export interface BuildShareOptions {
@@ -98,6 +103,32 @@ function iso(v: string | Date | null | undefined): string | null {
  * 공유 문서를 만든다. 게시 시점에 1회 실행해 **스냅샷으로 저장**한다 — 라이브 조인하면
  * 이후 resume·재실행으로 생긴 새 민감 정보가 자동 노출된다(plan §4).
  */
+
+/**
+ * 산출물 스텝 선별 — **문서와 뷰어 export 가 같은 순서를 봐야** 한다(viewerId 는 배열
+ * 인덱스로 매긴다). 그래서 순서·상한을 이 함수 하나로만 정한다.
+ */
+function selectArtifactSteps(steps: ShareStepInput[]): ShareStepInput[] {
+    return steps
+        .filter((s) => s.step_type === 'artifact')
+        .slice(0, SHARE_LIMITS.MAX_ARTIFACTS);
+}
+
+/**
+ * 뷰어 export 용 원본 본문 — 문서의 `artifacts` 와 **인덱스 정렬**된다. 마크업 포함 전 종류를
+ * 담는다(격리 오리진에서만 렌더). 파싱 실패·본문 없음은 null.
+ */
+export function extractArtifactViewerContents(steps: ShareStepInput[]): (string | null)[] {
+    return selectArtifactSteps(steps).map((s) => {
+        try {
+            const a = JSON.parse(s.content ?? '') as { content?: string };
+            const body = typeof a.content === 'string' ? a.content : '';
+            return body.length > 0 ? body : null;
+        } catch {
+            return null;
+        }
+    });
+}
 
 /**
  * `artifact` 스텝 → 공유용 산출물. content 는 `{id,kind,title,content,validation,sourceData}`
@@ -160,11 +191,12 @@ export function buildShareDocument(
         }))
         .filter((s) => s.text.length > 0);
 
-    const artifacts = !includeArtifacts ? [] : shared
-        .filter((s) => s.step_type === 'artifact')
-        .slice(0, SHARE_LIMITS.MAX_ARTIFACTS)
-        .map((s) => toShareArtifact(s.content ?? '', r))
-        .filter((a): a is ShareArtifact => a !== null);
+    // ⚠️ null(제목 없는 산출물)을 걸러내면 뷰어 콘텐츠 배열과 인덱스가 어긋난다 —
+    //    자리를 유지하기 위해 제목을 채워 넣는다.
+    const artifacts = !includeArtifacts ? [] : selectArtifactSteps(shared)
+        .map((s, i) => toShareArtifact(s.content ?? '', r) ?? {
+            id: '', title: `(제목 없는 산출물 ${i + 1})`, kind: 'unknown', body: null, omitted: 'unparsable' as const,
+        });
 
     const diffs = !includeDiff ? [] : shared
         .filter((s) => s.step_type === 'diff')

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -36,7 +36,7 @@ export interface ShareDocument {
     summary: { turns: number; toolCalls: number; retries: number; diffs: number; artifacts: number };
     steps: { n: number; type: string; tool?: string; text: string }[];
     diffs: string[];
-    artifacts: { id: string; title: string; kind: string; body: string | null; omitted?: string }[];
+    artifacts: { id: string; title: string; kind: string; body: string | null; omitted?: string; viewerId?: string }[];
     createdAt: string | null;
     completedAt: string | null;
 }
@@ -127,6 +127,14 @@ export class ApiClient {
     }
     publishShare(taskId: string, opts: { visibility: string; includeSteps: boolean; includeDiff: boolean; includeArtifacts: boolean }): Promise<ShareState> {
         return this.req('POST', `/api/agent-tasks/${taskId}/share`, opts);
+    }
+    /** 공유 문서 조회 — link 공유면 토큰이 필요하지만, 소유자 API key 로도 읽힌다. */
+    getSharedTask(shareId: string, token: string | null): Promise<{ document: ShareDocument }> {
+        return this.req('GET', `/api/shared-tasks/${shareId}${token ? `?token=${encodeURIComponent(token)}` : ''}`);
+    }
+    /** 산출물 열람 URL — 공유와 같은 인가를 통과한 뒤 발급되는 TTL 토큰이 붙는다. */
+    openSharedArtifact(shareId: string, index: number, token: string | null): Promise<{ url: string }> {
+        return this.req('GET', `/api/shared-tasks/${shareId}/artifacts/${index}/open${token ? `?token=${encodeURIComponent(token)}` : ''}`);
     }
     unshare(taskId: string): Promise<{ unshared: boolean }> {
         return this.req('DELETE', `/api/agent-tasks/${taskId}/share`);

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -323,7 +323,8 @@ function printSharePreview(doc: ShareDocument): void {
  * 미리보기를 먼저 출력하고, TTY 면 y/N 확인, 비대화형이면 `--yes` 를 요구한다.
  */
 async function cmdShare(taskId: string, opts: {
-    link: boolean; steps: boolean; diff: boolean; artifacts: boolean; off: boolean; previewOnly: boolean; republish: boolean; yes: boolean;
+    link: boolean; steps: boolean; diff: boolean; artifacts: boolean; off: boolean;
+    previewOnly: boolean; republish: boolean; openArtifacts: boolean; yes: boolean;
 }): Promise<void> {
     const cfg = requireConfig();
     const api = new ApiClient(cfg.serverUrl, cfg.apiKey);
@@ -335,11 +336,32 @@ async function cmdShare(taskId: string, opts: {
     }
 
     const { share } = await api.getShare(taskId).catch(() => ({ share: null }));
+
+    if (opts.openArtifacts) {
+        if (!share) { console.error('공유 중이 아닙니다 — 먼저 `openmake-code share <taskId>` 로 게시하세요.'); process.exit(1); }
+        const { document } = await api.getSharedTask(share.shareId, share.shareToken);
+        if (!document.artifacts.length) { console.log('산출물이 없습니다.'); return; }
+        console.log(`\x1b[1m산출물 열람 URL\x1b[0m \x1b[2m(발급 토큰은 유효기간이 있습니다)\x1b[0m`);
+        for (const [i, a] of document.artifacts.entries()) {
+            if (!a.viewerId) {
+                // 뷰어가 없는 경우(뷰어 기능 off·본문 없음) — 본문이 문서에 있으면 그걸로 대신한다.
+                console.log(`  ${i}. ${a.title} \x1b[2m(${a.kind} — 뷰어 없음${a.body ? `, 본문 ${a.body.length}자는 공유 페이지에서` : ''})\x1b[0m`);
+                continue;
+            }
+            try {
+                const { url } = await api.openSharedArtifact(share.shareId, i, share.shareToken);
+                console.log(`  ${i}. ${a.title} \x1b[2m(${a.kind})\x1b[0m\n     ${url}`);
+            } catch (e) {
+                console.log(`  ${i}. ${a.title} \x1b[31m— URL 발급 실패: ${(e as Error).message}\x1b[0m`);
+            }
+        }
+        return;
+    }
     if (share && !opts.previewOnly && !opts.republish) {
         // 이미 공유 중 — 링크만 다시 보여준다(재게시는 내용 변경이므로 명시적으로).
         console.log(`\x1b[32m이미 공유 중\x1b[0m (${share.visibility}${share.includeDiff ? ', diff 포함' : ''})`);
         console.log(`  ${cfg.serverUrl}${share.path}`);
-        console.log('\x1b[2m최신 내용으로 다시 게시: `--republish` (미리보기 후 확인) · 해제: `--off`\x1b[0m');
+        console.log('\x1b[2m산출물 열람: `--open` · 최신 내용으로 다시 게시: `--republish` · 해제: `--off`\x1b[0m');
         return;
     }
 
@@ -365,6 +387,7 @@ async function cmdShare(taskId: string, opts: {
     const r = await api.publishShare(taskId, { visibility, ...toggles });
     console.log(`\x1b[32m✓ 공유됨\x1b[0m (${scope})`);
     console.log(`  ${cfg.serverUrl}${r.path}`);
+    if (preview.artifacts.length) console.log(`\x1b[2m산출물 ${preview.artifacts.length}건 열람 URL: openmake-code share ${taskId} --open\x1b[0m`);
     console.log('\x1b[2m해제: openmake-code share ' + taskId + ' --off\x1b[0m');
 }
 
@@ -415,7 +438,7 @@ async function main(): Promise<void> {
     if (cmd === 'share') {
         const taskId = argv[1];
         if (!taskId || taskId.startsWith('--')) {
-            console.error('사용법: openmake-code share <taskId> [--link] [--no-steps] [--no-diff] [--no-artifacts] [--preview] [--republish] [--off] [--yes]');
+            console.error('사용법: openmake-code share <taskId> [--link] [--no-steps] [--no-diff] [--no-artifacts] [--preview] [--republish] [--open] [--off] [--yes]');
             process.exit(1);
         }
         return cmdShare(taskId, {
@@ -425,6 +448,7 @@ async function main(): Promise<void> {
             artifacts: !argv.includes('--no-artifacts'),
             off: argv.includes('--off'),
             previewOnly: argv.includes('--preview'),
+            openArtifacts: argv.includes('--open'),
             republish: argv.includes('--republish'),
             yes: argv.includes('--yes') || argv.includes('-y'),
         });
@@ -449,7 +473,8 @@ async function main(): Promise<void> {
   openmake-code resume <taskId> [--dir .] [--yes]   checkpoint 에서 이어하기 (같은 worktree 재부착)
   openmake-code share <taskId> [--link] [--preview] [--off]   결과를 읽기 전용 링크로 공유
                                    (미리보기 출력 → 확인 후 게시. 기본 공개 범위는 로그인 사용자,
-                                    --link 는 링크를 아는 누구나. --no-steps/--no-diff/--no-artifacts 로 범위 축소)
+                                    --link 는 링크를 아는 누구나. --no-steps/--no-diff/--no-artifacts 로 범위 축소,
+                                    --open 은 공유된 산출물의 열람 URL 발급)
   openmake-code "목표" --resume    재개 가능한 최근 작업이 있으면 그것을 이어감 (없으면 새 작업)`);
         return;
     }

--- a/apps/web/app/shared/task/[shareId]/viewer.tsx
+++ b/apps/web/app/shared/task/[shareId]/viewer.tsx
@@ -10,10 +10,10 @@ import { useEffect, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { LoaderCircle, Lock } from "lucide-react";
+import { ExternalLink, LoaderCircle, Lock } from "lucide-react";
 import { Badge, Card, CardContent } from "@/components/ui/primitives";
 import { DiffView } from "@/components/chat/diff-view";
-import { getSharedTask, type ShareDocument } from "@/lib/share-task";
+import { getSharedTask, openSharedArtifact, type ShareDocument } from "@/lib/share-task";
 import { cn } from "@/lib/utils";
 
 const STATUS_TONE: Record<string, "success" | "danger" | "accent" | "neutral"> = {
@@ -28,6 +28,25 @@ export function SharedTaskViewer({ shareId, token }: { shareId: string; token: s
   const [doc, setDoc] = useState<ShareDocument | null>(null);
   const [sharedAt, setSharedAt] = useState<string | null>(null);
   const [state, setState] = useState<"loading" | "ok" | "denied">("loading");
+  const [opening, setOpening] = useState<number | null>(null);
+
+  // 산출물 열기 — 토큰은 여기서 발급받는다(스냅샷에 없다). 새 탭은 클릭 직후에 열어야
+  // 팝업 차단에 걸리지 않으므로, 먼저 열고 URL 을 받은 뒤 이동시킨다.
+  const openArtifact = async (index: number) => {
+    setOpening(index);
+    const tab = window.open("", "_blank", "noopener");
+    try {
+      const res = await openSharedArtifact(shareId, index, token);
+      const url = res?.data?.url;
+      if (!url) throw new Error("no url");
+      if (tab) tab.location.href = url;
+      else window.location.href = url;
+    } catch {
+      tab?.close();
+    } finally {
+      setOpening(null);
+    }
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -99,12 +118,25 @@ export function SharedTaskViewer({ shareId, token }: { shareId: string; token: s
             {doc.artifacts.length > 0 && (
               <section className="space-y-2">
                 <h2 className="text-xs font-medium text-fg-2">{t("artifacts", { count: doc.artifacts.length })}</h2>
-                {doc.artifacts.map((a) => (
-                  <Card key={a.id || a.title}>
+                {doc.artifacts.map((a, i) => (
+                  <Card key={a.id || `${a.title}-${i}`}>
                     <CardContent className="space-y-2 pt-4">
                       <p className="flex flex-wrap items-center gap-2 text-sm text-fg">
                         {a.title}
                         <Badge tone="neutral">{a.kind}</Badge>
+                        {a.viewerId && (
+                          <button
+                            type="button"
+                            onClick={() => void openArtifact(i)}
+                            disabled={opening === i}
+                            className="inline-flex items-center gap-1 text-xs text-accent hover:underline disabled:opacity-60"
+                          >
+                            {opening === i
+                              ? <LoaderCircle className="h-3 w-3 animate-spin" />
+                              : <ExternalLink className="h-3 w-3" />}
+                            {t("openArtifact")}
+                          </button>
+                        )}
                       </p>
                       {/* 본문은 항상 텍스트로만 — 마크업 렌더는 별도 오리진·CSP 격리가 필요하다 */}
                       {a.body ? (
@@ -112,7 +144,11 @@ export function SharedTaskViewer({ shareId, token }: { shareId: string; token: s
                           {a.body}
                         </pre>
                       ) : (
-                        <p className="text-xs text-faint">{t(a.omitted === "markup" ? "artifactMarkupOmitted" : "artifactUnavailable")}</p>
+                        <p className="text-xs text-faint">
+                          {a.viewerId
+                            ? t("artifactViewerOnly")
+                            : t(a.omitted === "markup" ? "artifactMarkupOmitted" : "artifactUnavailable")}
+                        </p>
                       )}
                     </CardContent>
                   </Card>

--- a/apps/web/lib/auth-sync.ts
+++ b/apps/web/lib/auth-sync.ts
@@ -37,8 +37,14 @@ async function tryRefresh(): Promise<boolean> {
   }
 }
 
+/**
+ * ⚠️ `redirectOnUnauthorized: false` 필수 — 이건 "누구세요"를 묻는 **탐침**이지 사용자가
+ * 요청한 동작이 아니다. 기본값(리다이렉트)이면 만료 쿠키를 가진 방문자가 **공개 페이지**
+ * (`/shared/task/...`)를 열 때 로그인 화면으로 튕긴다(2026-08-26 실측 — 한 번 로그인한 적
+ * 있는 동료에게 공유 링크가 안 열렸다). 401 은 여기선 그냥 "게스트"다.
+ */
 function fetchMe(): Promise<ApiSuccess<MePayload>> {
-  return ApiClient.get<ApiSuccess<MePayload>>("/api/auth/me");
+  return ApiClient.get<ApiSuccess<MePayload>>("/api/auth/me", { redirectOnUnauthorized: false });
 }
 
 /**

--- a/apps/web/lib/share-task.ts
+++ b/apps/web/lib/share-task.ts
@@ -20,7 +20,12 @@ export interface ShareDocument {
   summary: { turns: number; toolCalls: number; retries: number; diffs: number; artifacts: number };
   steps: { n: number; type: string; tool?: string; text: string }[];
   diffs: string[];
-  artifacts: { id: string; title: string; kind: string; body: string | null; omitted?: "markup" | "unparsable" }[];
+  artifacts: {
+    id: string; title: string; kind: string; body: string | null;
+    omitted?: "markup" | "unparsable";
+    /** 격리 오리진 뷰어가 있는 산출물 — URL 은 열 때 발급받는다(스냅샷에 토큰을 담지 않는다) */
+    viewerId?: string;
+  }[];
   createdAt: string | null;
   completedAt: string | null;
 }
@@ -53,6 +58,16 @@ export const publishShare = (taskId: string, body: ShareToggles & { visibility: 
 
 export const unshareTask = (taskId: string) =>
   ApiClient.del<ApiSuccess<{ unshared: boolean }>>(`/api/agent-tasks/${taskId}/share`);
+
+/**
+ * 산출물 열람 URL 발급 — 공유와 같은 인가를 통과해야 받는다. 토큰 TTL 이 있어
+ * 스냅샷에 박아두지 않는다(한 번 본 사람이 영구 URL 을 갖지 않도록).
+ */
+export const openSharedArtifact = (shareId: string, index: number, token: string | null) =>
+  ApiClient.get<ApiSuccess<{ url: string }>>(
+    `/api/shared-tasks/${shareId}/artifacts/${index}/open${token ? `?token=${encodeURIComponent(token)}` : ""}`,
+    { redirectOnUnauthorized: false },
+  );
 
 /**
  * 공개 조회 — 비로그인 방문자가 대상이므로 401 리다이렉트를 끈다.

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1920,6 +1920,8 @@
     "snapshotNote": "A snapshot from when it was published — continuing the task does not change this page.",
     "artifacts": "Outputs ({count})",
     "artifactMarkupOmitted": "HTML/SVG outputs are not included — a shared page shows text only.",
-    "artifactUnavailable": "The body could not be read."
+    "artifactUnavailable": "The body could not be read.",
+    "openArtifact": "Open",
+    "artifactViewerOnly": "The body opens in an isolated viewer — press Open."
   }
 }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1920,6 +1920,8 @@
     "snapshotNote": "公開時点の記録です — タスクを続行してもこの画面は変わりません。",
     "artifacts": "成果物 {count} 件",
     "artifactMarkupOmitted": "HTML・SVG の成果物は本文を含めません — 共有ページはテキストのみ表示します。",
-    "artifactUnavailable": "本文を読み取れません。"
+    "artifactUnavailable": "本文を読み取れません。",
+    "openArtifact": "開く",
+    "artifactViewerOnly": "本文は隔離されたビューアで開きます — [開く] を押してください。"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1920,6 +1920,8 @@
     "snapshotNote": "게시 시점 기록입니다 — 이후 작업이 이어져도 이 화면은 바뀌지 않습니다.",
     "artifacts": "산출물 {count}건",
     "artifactMarkupOmitted": "HTML·SVG 산출물은 본문을 담지 않습니다 — 공유 문서는 텍스트만 보여줍니다.",
-    "artifactUnavailable": "본문을 읽을 수 없습니다."
+    "artifactUnavailable": "본문을 읽을 수 없습니다.",
+    "openArtifact": "열기",
+    "artifactViewerOnly": "본문은 격리된 뷰어에서 열립니다 — [열기] 를 누르세요."
   }
 }

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1920,6 +1920,8 @@
     "snapshotNote": "这是发布时的快照 — 继续执行任务不会改变此页面。",
     "artifacts": "产出物 {count} 项",
     "artifactMarkupOmitted": "HTML/SVG 产出物不包含正文 — 共享页面只显示文本。",
-    "artifactUnavailable": "无法读取正文。"
+    "artifactUnavailable": "无法读取正文。",
+    "openArtifact": "打开",
+    "artifactViewerOnly": "正文在隔离查看器中打开 — 请点击\"打开\"。"
   }
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -79,6 +79,16 @@ function refreshOnce(): Promise<boolean> {
   return refreshInFlight;
 }
 
+/**
+ * 로그인 없이 보라고 만든 경로 — 여기서는 401 이 나도 로그인 화면으로 보내지 않는다.
+ * (공유된 작업 뷰어 등. 튕겨보내면 링크를 받은 사람이 내용을 볼 수 없다.)
+ */
+const PUBLIC_PATH_PREFIXES = ["/shared/"];
+
+function isPublicPath(pathname: string): boolean {
+  return PUBLIC_PATH_PREFIXES.some((p) => pathname.startsWith(p));
+}
+
 async function request<T>(endpoint: string, options: ApiRequestOptions = {}, _isRetry = false): Promise<T> {
   const { redirectOnUnauthorized = true, ...fetchOptions } = options;
   const method = (fetchOptions.method || "GET").toUpperCase();
@@ -114,7 +124,8 @@ async function request<T>(endpoint: string, options: ApiRequestOptions = {}, _is
       if (refreshed) {
         return request<T>(endpoint, options, true);
       }
-      if (redirectOnUnauthorized && typeof window !== "undefined" && window.location.pathname !== "/login") {
+      if (redirectOnUnauthorized && typeof window !== "undefined"
+        && window.location.pathname !== "/login" && !isPublicPath(window.location.pathname)) {
         window.location.href = "/login";
       }
     }


### PR DESCRIPTION
#642 에서 미구현으로 남긴 plan §2 "아티팩트는 링크로".

## 왜 기존 아티팩트 게시를 재사용하지 않았나 (실측)

작업 아티팩트는 `agent_task_steps(step_type='artifact')` JSON 으로만 남는다 — 운영 표본 27개 id 를 조회한 결과 `artifacts` 매칭 **0건**, `artifact_publications` 매칭 **0건**. 두 테이블 모두 `session_id` 가 `conversation_sessions` 를 FK 로 걸고 있는데 **`agent_tasks` 에는 session 컬럼이 없다**. 합성 세션 행을 만드는 우회는 세션 prune(오래된 세션 삭제)의 CASCADE 가 게시본을 지워버려 위험하다.

## 설계 — 공유의 일부로 다룬다

| | 방식 |
|---|---|
| export | 게시 시 산출물마다 정적 뷰어 생성. pubId = `share-<shareId>-<n>` (nginx `^/a/[A-Za-z0-9-]+/` 만족) |
| **마크업** | html·svg 본문은 공유 문서에 담지 않고 **격리 오리진에서만** 렌더 — 그 격리가 아티팩트 뷰어를 별도 오리진에 둔 이유다 |
| 인가 | 공유와 **같은 규칙**(소유자·로그인·link 토큰) 통과 후 서명 접근토큰 발급: `GET /shared-tasks/:shareId/artifacts/:index/open` |
| 토큰 위치 | 스냅샷에 박지 **않는다** — 스냅샷은 조회 응답으로 그대로 나가므로, 박으면 한 번 본 사람이 영구 URL 을 갖는다. 발급 토큰은 TTL |
| authz 분기 | `viewer-authz` 에 `share-*` 추가(게시 행이 없으니 서명 토큰만으로 판정) |
| 수명 | 해제·재게시 시 export 삭제 — 토큰이 살아 있어도 파일이 없어 404 |

조회 인가와 열람 인가가 어긋나면 산출물이 공유보다 넓게 열리므로 판정을 한 함수로 합쳤다.

## 동반 수정 — 공개 페이지가 로그인으로 튕기던 것

`fetchMe()` 가 기본 옵션(401 → `/login` 리다이렉트)으로 `/api/auth/me` 를 부른다. 이건 "누구세요"를 묻는 **탐침**이지 사용자가 요청한 동작이 아니라서, **만료 쿠키를 가진 방문자가 공유 링크를 열면 로그인 화면으로 튕겼다**(실측 — 한 번 로그인한 적 있는 동료에게 링크가 안 열린다). 탐침을 non-redirect 로 바꾸고, api-client 에 공개 경로(`/shared/`) 예외를 뒀다.

## 검증 (chat.openmake.cc)

- html 산출물 16,554자: 공유 문서에 본문 **없음**(`omitted=markup`, `<html`/`<div`/`<script` 부재) · 뷰어에서 200 렌더 · 본문 실제 포함 확인
- 인가: 토큰 없이 뷰어 직접 403 · 위조 토큰 403 · 공유 토큰 없이 열람요청 404 · 해제 후 404 + export 디렉토리 0개
- 브라우저: 만료 쿠키로도 공유 페이지 유지, [열기] → `artifacts.openmake.cc/a/share-…?k=…` 새 탭
- 단위 57건 — 신규 5건은 **인덱스 정렬** 회귀 고정(문서 artifacts ↔ 뷰어 콘텐츠 순서가 어긋나면 A 링크로 B 본문이 열린다)