### PR TITLE
fix(agent-spawn): 승인 정책 all 에서 서브에이전트가 도구 없이 답을 지어내던 것 + 인자 오류 진단

### DIFF
--- a/apps/api/src/services/agent-spawn/spawn-agents.test.ts
+++ b/apps/api/src/services/agent-spawn/spawn-agents.test.ts
@@ -18,6 +18,12 @@ jest.mock('../../config/runtime-limits', () => ({
     },
 }));
 
+const autoApproveMock = jest.fn((_taskId: string) => false);
+jest.mock('../task-sandbox/approval-gate', () => ({
+    ...jest.requireActual('../task-sandbox/approval-gate'),
+    getApprovalRegistry: () => ({ isAutoApprove: (id: string) => autoApproveMock(id) }),
+}));
+
 const runSubagentMock = jest.fn();
 jest.mock('../agent-task/subagent', () => ({
     runSubagent: (p: unknown) => runSubagentMock(p),
@@ -49,6 +55,7 @@ import {
     runChatSpawnAgents,
     buildTaskSpawnFn,
     normalizeSpawnArgs,
+    describeArgsShape,
 } from './spawn-agents';
 import { SPAWN_AGENT_GENERIC_PROMPT } from '../../prompts/spawn-agent-system';
 
@@ -69,16 +76,26 @@ const baseParams = {
 
 beforeEach(() => {
     jest.clearAllMocks();
+    autoApproveMock.mockReturnValue(false);
     runSubagentMock.mockImplementation(async (p: { subgoal: string }) => `RESULT<${p.subgoal}>`);
     routeToAgentMock.mockResolvedValue({ agentId: 'finance' });
     getAgentSystemMessageMock.mockResolvedValue({ prompt: 'PERSONA_PROMPT' });
 });
 
 describe('spawnAgentsArgsSchema / runSpawnAgents 인자 검증', () => {
-    it('tasks 누락이면 Error 문자열을 반환한다', async () => {
+    it('tasks 누락이면 Error 문자열을 반환한다 — 받은 형태를 함께 알린다', async () => {
         const out = await runSpawnAgents({ ...baseParams, args: {} });
         expect(out).toMatch(/^Error: tasks/);
+        expect(out).toContain('빈 객체');           // {} 는 인자 JSON 절단 의심 신호
         expect(runSubagentMock).not.toHaveBeenCalled();
+        const out2 = await runSpawnAgents({ ...baseParams, args: { tasks: 'a, b' } });
+        expect(out2).toContain('tasks=string');
+        const out3 = await runSpawnAgents({ ...baseParams, args: { tasks: [{ task: 'x' }] } });
+        expect(out3).toContain('keys=task');       // prompt 대신 다른 키를 쓴 경우가 보인다
+    });
+
+    it('describeArgsShape 는 값을 싣지 않는다', () => {
+        expect(describeArgsShape({ tasks: [{ prompt: 'SECRET_PROMPT_TEXT' }] })).not.toContain('SECRET_PROMPT_TEXT');
     });
 
     it('빈 배열·빈 prompt 도 거부한다', async () => {
@@ -267,10 +284,30 @@ describe('buildTaskSpawnFn — 에이전트 작업 경로', () => {
         expect(passed).toEqual(['web_search', 'browser']);
     });
 
-    it("정책 'all' 이면 승인 필요 도구가 전부 배제된다 (HITL fan-in 회피)", async () => {
+    it("정책 'all' + 수동 승인이면 승인 필요 도구가 전부 배제되고, 결과에 그 사실이 실린다", async () => {
         const spawn = buildTaskSpawnFn(makeFactoryParams('all', ['web_search', 'browser']));
-        await spawn({ tasks: [{ prompt: 'x' }] });
+        const out = await spawn({ tasks: [{ prompt: 'x' }] });
         expect(runSubagentMock.mock.calls[0][0].tools).toEqual([]);
+        // 조용한 성공 금지 — 도구 없이 답한 결과는 그렇게 표시돼야 한다
+        expect(out).toContain('도구 없이 답했습니다');
+        expect(out).toContain("승인 정책 'all'");
+        expect(out).toContain('자동 승인');
+    });
+
+    it("정책 'all' 이라도 작업이 자동 승인 상태면 도구를 그대로 전달한다 (fan-in 없음)", async () => {
+        autoApproveMock.mockReturnValue(true);
+        const spawn = buildTaskSpawnFn(makeFactoryParams('all', ['web_search', 'browser']));
+        const out = await spawn({ tasks: [{ prompt: 'x' }] });
+        const passed = runSubagentMock.mock.calls[0][0].tools.map((t: ToolDefinition) => t.function.name);
+        expect(passed).toEqual(['web_search', 'browser']);
+        expect(autoApproveMock).toHaveBeenCalledWith('task-1');
+        expect(out).not.toContain('도구 없이 답했습니다');
+    });
+
+    it('화이트리스트가 비어 있으면 그 사유가 실린다', async () => {
+        const spawn = buildTaskSpawnFn(makeFactoryParams('none', []));
+        const out = await spawn({ tasks: [{ prompt: 'x' }] });
+        expect(out).toContain('TASK_SANDBOX_EXTRA_TOOLS');
     });
 
     it("정책 'high-risk' 면 고위험 도구(browser)만 배제된다", async () => {

--- a/apps/api/src/services/agent-spawn/spawn-agents.ts
+++ b/apps/api/src/services/agent-spawn/spawn-agents.ts
@@ -30,7 +30,7 @@ import { resolveRoleClientForUser } from '../model-role-resolver';
 import { parallelBatch } from '../../workflow/graph-engine';
 import { routeToAgent } from '../../agents/keyword-router';
 import { getAgentSystemMessage } from '../../agents/system-prompt';
-import { requiresApproval } from '../task-sandbox/approval-gate';
+import { requiresApproval, getApprovalRegistry } from '../task-sandbox/approval-gate';
 import { runSubagent } from '../agent-task/subagent';
 import type { DelegateFactoryParams } from '../agent-task/delegate';
 import { CHAT_DELEGATE_TOOL_NAME } from '../chat-service/chat-delegate';
@@ -72,6 +72,19 @@ export function normalizeSpawnArgs(raw: unknown): unknown {
         return { tasks: [o] };
     }
     return raw;
+}
+
+/** PURE: 인자 형태 요약(키·타입만, 값 없음) — 스키마 거부 사유를 다음에 추적할 수 있게. */
+export function describeArgsShape(raw: unknown): string {
+    if (!raw || typeof raw !== 'object') return `${raw === null ? 'null' : typeof raw}`;
+    const o = raw as Record<string, unknown>;
+    const keys = Object.keys(o);
+    if (keys.length === 0) return '빈 객체 {} (인자 JSON 절단·파싱 실패 가능성 — 서버 로그 "파싱 실패" 확인)';
+    const t = o.tasks;
+    const tasksShape = t === undefined ? '없음'
+        : Array.isArray(t) ? `배열[${t.length}](첫 항목 ${t[0] === undefined ? '없음' : typeof t[0] === 'object' && t[0] !== null ? 'keys=' + Object.keys(t[0] as object).join('|') : typeof t[0]})`
+        : typeof t;
+    return `keys=${keys.join('|')}, tasks=${tasksShape}`;
 }
 
 export const SPAWN_AGENTS_TOOL_DESCRIPTION =
@@ -146,6 +159,12 @@ export function filterChatSubTools(parentTools: ToolDefinition[]): ToolDefinitio
 }
 
 export interface SpawnAgentsParams {
+    /**
+     * 서브 도구가 0개가 된 **이유**(있으면). 결과 머리에 그대로 실어 부모 모델·타임라인이
+     * "조사한 결과"로 오인하지 않게 한다 — 도구 없는 서브는 기억으로 답을 지어낸다
+     * (2026-08-26 라이브: 승인 정책 all 로 도구 전부 제외 → 기준금리를 "미확정"으로 날조).
+     */
+    noToolsReason?: string;
     /** 도구 호출 인자(raw) — 내부에서 Zod 검증. */
     args: Record<string, unknown>;
     client: LLMClient;
@@ -215,7 +234,9 @@ async function resolveTaskExecution(
 export async function runSpawnAgents(p: SpawnAgentsParams): Promise<string> {
     const parsed = spawnAgentsArgsSchema.safeParse(normalizeSpawnArgs(p.args));
     if (!parsed.success) {
-        return 'Error: tasks 배열([{prompt, role?}, ...], 최소 1개)이 필요합니다.';
+        // 받은 형태를 함께 남긴다 — 2026-08-02 실패는 인자 원문이 어디에도 남지 않아 원인 추적이
+        // 불가능했다(커밋 6a019d18 의 사후 분석으로만 "단일 객체" 로 추정). 값은 싣지 않는다.
+        return `Error: tasks 배열([{prompt, role?}, ...], 최소 1개)이 필요합니다. 받은 인자: ${describeArgsShape(p.args)}`;
     }
     const requested = parsed.data.tasks;
     const tasks = requested.slice(0, AGENT_SPAWN.MAX_TASKS_PER_CALL);
@@ -225,6 +246,12 @@ export async function runSpawnAgents(p: SpawnAgentsParams): Promise<string> {
     const started = Date.now();
     logger.info(`[AgentSpawn] fan-out 시작: tasks=${tasks.length} (요청 ${requested.length}), `
         + `parallel=${AGENT_SPAWN.MAX_PARALLEL}, subTools=${subTools.length}`);
+    // 도구 없는 fan-out 은 "병렬 조사"가 아니라 "병렬 기억 인출"이다 — 조용히 성공처럼 보이면 안 된다.
+    const noToolsNotice = subTools.length === 0
+        ? `⚠️ 서브에이전트가 도구 없이 답했습니다(${p.noToolsReason ?? '전달된 도구 없음'}) — `
+            + '아래 내용은 검색·조회 없이 모델 기억만으로 작성된 것이라 사실 확인이 필요합니다.\n\n'
+        : '';
+    if (subTools.length === 0) logger.warn(`[AgentSpawn] 서브 도구 0개 — ${p.noToolsReason ?? '전달된 도구 없음'}`);
 
     let results: Array<string | null>;
     try {
@@ -277,7 +304,7 @@ export async function runSpawnAgents(p: SpawnAgentsParams): Promise<string> {
     // 턴 예산을 소진해 최종 종합 턴이 사라짐. 도구 결과 말미의 결정적 지시로 차단.
     const synthesisNudge = '\n\n지시: 위 서브에이전트 결과만으로 지금 바로 최종 답변을 종합해 작성하세요. '
         + '같은 주제를 다시 검색하거나 추가 도구를 호출하지 마세요.';
-    return `[병렬 서브에이전트 결과 — ${tasks.length}개 태스크]\n\n${sections.join('\n\n')}${truncationNote}${synthesisNudge}`;
+    return `[병렬 서브에이전트 결과 — ${tasks.length}개 태스크]\n\n${noToolsNotice}${sections.join('\n\n')}${truncationNote}${synthesisNudge}`;
 }
 
 /**
@@ -318,12 +345,25 @@ export type SpawnFn = (args: Record<string, unknown>) => Promise<string>;
  */
 export function buildTaskSpawnFn(p: DelegateFactoryParams): SpawnFn {
     return async (args: Record<string, unknown>): Promise<string> => {
-        const subTools = p.sandboxCfg.extraTools
+        const whitelisted = p.sandboxCfg.extraTools
             .map((n) => p.mcpTools.find((t) => t.function.name === n))
-            .filter((t): t is ToolDefinition => !!t)
-            .filter((t) => !requiresApproval(p.sandboxCfg.approvalPolicy, t.function.name, {}));
+            .filter((t): t is ToolDefinition => !!t);
+        // 자동 승인 작업이면 HITL fan-in 이 없으므로 배제할 이유가 없다 — 호출 시점에 판정한다
+        // (자동 승인은 실행 중에도 켜진다). 운영 정책 all 에서 이 판정이 없으면 도구가 전부
+        // 걷혀 서브가 기억으로만 답한다(2026-08-26 라이브 실측).
+        const autoApproved = getApprovalRegistry().isAutoApprove(p.taskId);
+        const subTools = autoApproved
+            ? whitelisted
+            : whitelisted.filter((t) => !requiresApproval(p.sandboxCfg.approvalPolicy, t.function.name, {}));
+        const stripped = whitelisted.length - subTools.length;
+        const noToolsReason = subTools.length === 0
+            ? (whitelisted.length === 0
+                ? '작업 호스트 도구 화이트리스트(TASK_SANDBOX_EXTRA_TOOLS)가 비어 있음'
+                : `승인 정책 '${p.sandboxCfg.approvalPolicy}' 로 도구 ${stripped}개 제외 — 작업의 자동 승인을 켜면 서브에이전트도 검색할 수 있습니다`)
+            : undefined;
         return runSpawnAgents({
             args,
+            ...(noToolsReason ? { noToolsReason } : {}),
             client: p.client,
             tools: subTools,
             userCtx: p.userCtx,


### PR DESCRIPTION
## 배경 — "spawn_agents 스키마 오류" 추적 결과

역대 유일한 호출(2026-08-02, user 11)이 `tasks 배열이 필요합니다` 로 실패했다.

| | 결론 |
|---|---|
| 원인 | 모델이 `tasks` 를 배열이 아닌 **단일 객체**로 넘김 |
| 상태 | **08-07 커밋 `6a019d18` 의 관용 래핑(`normalizeSpawnArgs`)으로 이미 닫힘** — 오늘 채팅·작업 두 경로 재현 모두 인자 정상 |
| 남은 갭 | 당시 인자 원문이 어디에도 남지 않아 사후 분석으로만 추정 → 거부 사유에 받은 **형태**(키·타입만, 값 없음)를 싣는다. `{}` 는 "인자 JSON 절단 의심"으로 구분 |

## 재현 중 드러난 실결함 (더 나쁜 쪽)

운영 `TASK_SANDBOX_APPROVAL_POLICY=all` 에서 `buildTaskSpawnFn` 의 "승인 필요 도구 배제(HITL fan-in 회피)" 가 **모든** 도구를 걷어내 서브에이전트가 도구 0개로 돈다(로그 `subTools=0`). 서브는 검색 없이 기억으로 답을 지어내고("2026년 8월 기준금리는 미확정"), 부모는 그것을 조사 결과로 종합했다 — 조용한 실패.

## 수정

- 작업이 **자동 승인** 상태면 fan-in 이 없으므로 도구를 그대로 준다(호출 시점 판정 — 자동 승인은 실행 중에도 켜진다). 서브는 원래 부모와 같은 승인 게이트(`runSubagent`)를 타므로 정책 우회가 아니다
- 도구가 0개가 되면 결과 머리에 **사유와 해법**을 싣는다: `⚠️ 서브에이전트가 도구 없이 답했습니다(승인 정책 'all' 로 도구 2개 제외 — 작업의 자동 승인을 켜면 서브에이전트도 검색할 수 있습니다) — … 사실 확인이 필요합니다`

## 검증 (chat.openmake.cc, user 3)

| 경우 | subTools | 결과 |
|---|---|---|
| 자동 승인 OFF | 0 | 경고 문구 포함 (로그 `서브 도구 0개 — 승인 정책 'all' …`) |
| 자동 승인 ON | 2 | 서브가 실제 `web_search` 호출(로그 19:55:26~32), 경고 없음, 8/25 기준 2.75% 인용 |
| 채팅(명시 요청) | 4 | fan-out 2건 10초 정상 |

단위 24건 — 신규: 자동 승인 시 도구 유지 · 배제 시 사유 · 화이트리스트 공백 사유 · 인자 형태 진단(`{}`/문자열/다른 키) · 진단 문구에 값 미노출.

## 관찰 (범위 밖, 별도)

- 자연어("A 와 B 를 각각 조사해서")로는 qwen 이 spawn 대신 직접 `web_search` 2회를 택한다 — 가이드는 주입되나 채택은 모델 판단. 도구 34종 노출 상태
- 서브에이전트 턴은 여전히 타임라인에 기록되지 않는다(관측 공백) — 앞서 제안한 다음 항목