### PR TITLE
feat(tools): 한 턴 안의 읽기 전용 도구 호출을 병렬 실행 (채팅·작업·서브에이전트)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1415,6 +1415,15 @@ IMAGE_GEN_TIMEOUT_MS=180000
 # IMAGE_GEN_PARALLEL_MAX=3
 # 루프 wall-clock 예산에서 공제할 이미지 생성 소요시간 상한 ms (기본 180000)
 # IMAGE_GEN_CREDIT_MAX_MS=180000
+
+# 턴 내 읽기 전용 도구 병렬 실행 (2026-08-26) — 한 턴에 web_search·extract_webpage 등 조회 도구가
+# 2개 이상이면 동시에 실행(결과는 원래 순서로 배치). 부작용 도구는 항상 순차. false 로 순차 복귀.
+# READ_ONLY_TOOL_PARALLEL_ENABLED=true
+# READ_ONLY_TOOL_PARALLEL_MAX=4
+# READ_ONLY_TOOL_PARALLEL_TOOLS=web_search,extract_webpage,web_scrape,web_map,web_crawl,fact_check,analyze_image
+# 외부 MCP 도구(server::tool) 판정 키워드 — 조회 키워드 포함 ∧ 쓰기 키워드 미포함일 때만 병렬
+# READ_ONLY_TOOL_PARALLEL_MCP_KEYWORDS=search,news,fetch,scrape,crawl,extract,lookup
+# READ_ONLY_TOOL_PARALLEL_MCP_WRITE_KEYWORDS=write,replace,delete,remove,create,update,set,post,send,upload,insert,save,edit,move,rename
 # MAX_TOOL_RESULT_CHARS=8000               # 도구 결과를 LLM 컨텍스트로 주입 시 단일 결과 최대 문자수
 
 # ────────────────────────────────────────────────────────────

--- a/apps/api/src/__tests__/services/tool-parallel.test.ts
+++ b/apps/api/src/__tests__/services/tool-parallel.test.ts
@@ -1,0 +1,82 @@
+/**
+ * 턴 내 읽기 전용 도구 병렬 선실행 — 계약 고정.
+ *
+ * 핵심은 ① 읽기 전용 목록 밖은 절대 병렬하지 않는다 ② 결과는 id 로만 매핑되어 호출측의
+ * 순서 계약을 건드리지 않는다 ③ 개별 실패가 다른 호출을 죽이지 않는다 ④ 동시 상한을 지킨다.
+ */
+jest.mock('../../config/runtime-limits', () => ({
+    ...jest.requireActual('../../config/runtime-limits'),
+    READ_ONLY_TOOL_PARALLEL: {
+        ENABLED: true,
+        MAX_CONCURRENT: 2,
+        TOOL_NAMES: ['web_search', 'extract_webpage'],
+        MCP_READ_KEYWORDS: ['search', 'news', 'fetch'],
+        MCP_WRITE_KEYWORDS: ['write', 'replace', 'delete', 'create'],
+    },
+}));
+
+import { prefetchReadOnlyCalls, isReadOnlyTool } from '../../services/tool-parallel';
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('prefetchReadOnlyCalls', () => {
+    test('읽기 전용 2건 이상만 동시에 실행하고 id 로 결과를 돌려준다', async () => {
+        const calls = [
+            { id: 'a', name: 'web_search' },
+            { id: 'b', name: 'bash' },          // 부작용 도구 — 절대 병렬 안 됨
+            { id: 'c', name: 'web_search' },
+        ];
+        const started: string[] = [];
+        const res = await prefetchReadOnlyCalls(calls, () => true, async (c) => { started.push(c.id!); await sleep(20); return `R:${c.id}`; }, { path: 'test' });
+        expect([...res.keys()].sort()).toEqual(['a', 'c']);
+        expect(res.get('a')).toBe('R:a');
+        expect(started).not.toContain('b');
+    });
+
+    test('1건뿐이면 아무것도 하지 않는다(순차와 같다)', async () => {
+        const exec = jest.fn(async () => 'x');
+        const res = await prefetchReadOnlyCalls([{ id: 'a', name: 'web_search' }, { id: 'b', name: 'bash' }], () => true, exec, { path: 'test' });
+        expect(res.size).toBe(0);
+        expect(exec).not.toHaveBeenCalled();
+    });
+
+    test('호출측 판정(isEligible)이 false 면 제외한다 — 승인 게이트 등', async () => {
+        const calls = [{ id: 'a', name: 'web_search' }, { id: 'b', name: 'web_search' }, { id: 'c', name: 'web_search' }];
+        const res = await prefetchReadOnlyCalls(calls, (c) => c.id !== 'b', async (c) => c.id!, { path: 'test' });
+        expect([...res.keys()].sort()).toEqual(['a', 'c']);
+    });
+
+    test('실제로 겹쳐서 실행되고 동시 상한(2)을 넘지 않는다', async () => {
+        let running = 0, peak = 0;
+        const calls = ['a', 'b', 'c', 'd'].map((id) => ({ id, name: 'web_search' }));
+        await prefetchReadOnlyCalls(calls, () => true, async () => {
+            running++; peak = Math.max(peak, running);
+            await sleep(30);
+            running--; return 'ok';
+        }, { path: 'test' });
+        expect(peak).toBe(2);   // 1 이면 병렬이 아니고, 3 이상이면 상한을 어긴 것
+    });
+
+    test('개별 실패는 그 호출의 Error 결과로만 남고 나머지는 정상', async () => {
+        const calls = [{ id: 'a', name: 'web_search' }, { id: 'b', name: 'extract_webpage' }];
+        const res = await prefetchReadOnlyCalls(calls, () => true, async (c) => { if (c.id === 'b') throw new Error('boom'); return 'ok'; }, { path: 'test' });
+        expect(res.get('a')).toBe('ok');
+        expect(res.get('b')).toMatch(/^Error: boom/);
+    });
+
+    test('id 가 없는 호출은 제외한다(결과 매핑 불가)', async () => {
+        const res = await prefetchReadOnlyCalls([{ id: undefined, name: 'web_search' }, { id: 'b', name: 'web_search' }], () => true, async () => 'ok', { path: 'test' });
+        expect(res.size).toBe(0);
+    });
+
+    test('isReadOnlyTool — 빌트인은 정확 이름, MCP 는 조회 키워드 ∧ ¬쓰기 키워드', () => {
+        expect(isReadOnlyTool('web_search')).toBe(true);
+        expect(isReadOnlyTool('file_ops')).toBe(false);
+        expect(isReadOnlyTool('mcp-kakao::search-web')).toBe(true);          // 라이브에서 qwen 이 고른 도구
+        expect(isReadOnlyTool('noapi-google-search::google_news')).toBe(true);
+        expect(isReadOnlyTool('some-mcp::search_and_replace')).toBe(false);   // 조회 키워드가 있어도 쓰기면 제외
+        expect(isReadOnlyTool('some-mcp::create_issue')).toBe(false);
+        expect(isReadOnlyTool('some-mcp::unknown_tool')).toBe(false);        // 모르면 순차
+        expect(isReadOnlyTool('search')).toBe(false);                        // '::' 없는 미등록 이름은 목록 기준
+    });
+});

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1279,6 +1279,41 @@ export const OD_ARTIFACT_ECHO = {
  * 시간이 장수에 비례해 늘던 것을 1장 수준으로 줄인다. 다른 도구는 순차 유지(부수효과·
  * 메시지 순서 보존), 결과는 원래 호출 순서대로 tool 메시지에 배치된다.
  */
+/**
+ * 한 턴 안의 **읽기 전용** 도구 호출 병렬 실행 (2026-08-26).
+ *
+ * 실측(최근 30일 에이전트 작업, 도구 턴 585개): 한 턴에 2개 이상 호출 20%(118턴), 그중
+ * 61%(72턴)가 전부 읽기 전용(web_search ×N · extract_webpage ×N). 모델은 이미 "독립"이라
+ * 판단해 한 턴에 4개씩 던지는데 하나씩 실행해 검색 4개 턴이 12초(1개 ≈ 3초)였다.
+ *
+ * 부작용 도구(bash·file_ops write 등)는 순서가 의미를 갖고 승인 게이트도 타므로 **여기 목록에
+ * 있는 이름만** 병렬한다. 결과는 원래 호출 순서로 대화에 배치된다(generate_image 선례와 동일).
+ * 채팅·에이전트 작업·서브에이전트 3경로 공용(services/tool-parallel).
+ */
+export const READ_ONLY_TOOL_PARALLEL = {
+    /** 기본 ON — READ_ONLY_TOOL_PARALLEL_ENABLED=false 로 순차 복귀. */
+    ENABLED: process.env.READ_ONLY_TOOL_PARALLEL_ENABLED !== 'false',
+    /** 동시 실행 상한(기본 4) — 검색 백엔드(SearXNG 등) 과점유 방지. */
+    MAX_CONCURRENT: parseInt(process.env.READ_ONLY_TOOL_PARALLEL_MAX || '4', 10),
+    /** 병렬 허용 도구 이름(CSV) — 부작용 없는 조회 도구만. 목록 밖은 종전대로 순차. */
+    TOOL_NAMES: (process.env.READ_ONLY_TOOL_PARALLEL_TOOLS
+        || 'web_search,extract_webpage,web_scrape,web_map,web_crawl,fact_check,analyze_image')
+        .split(',').map((s) => s.trim()).filter(Boolean),
+    /**
+     * 외부 MCP 도구(`server::tool`) 판정 — 이름에 조회 키워드가 있고 쓰기 키워드가 없으면 읽기 전용.
+     * 라이브 실측(2026-08-26): qwen 이 한 턴에 4개를 내면서 `web_search` 대신
+     * `mcp-kakao::search-web` 를 골라 정확 이름 목록만으로는 병렬이 한 번도 걸리지 않았다.
+     * 예약 리포트의 `noapi-google-search::google_news`(59회) 도 같은 부류.
+     */
+    MCP_READ_KEYWORDS: (process.env.READ_ONLY_TOOL_PARALLEL_MCP_KEYWORDS
+        || 'search,news,fetch,scrape,crawl,extract,lookup')
+        .split(',').map((s) => s.trim().toLowerCase()).filter(Boolean),
+    /** 이 키워드가 이름에 있으면 조회 키워드가 있어도 제외(예: search_and_replace). */
+    MCP_WRITE_KEYWORDS: (process.env.READ_ONLY_TOOL_PARALLEL_MCP_WRITE_KEYWORDS
+        || 'write,replace,delete,remove,create,update,set,post,send,upload,insert,save,edit,move,rename')
+        .split(',').map((s) => s.trim().toLowerCase()).filter(Boolean),
+} as const;
+
 export const IMAGE_GEN_PARALLEL = {
     /** 기본 ON — IMAGE_GEN_PARALLEL_ENABLED=false 로 비활성화(순차 복귀). */
     ENABLED: process.env.IMAGE_GEN_PARALLEL_ENABLED !== 'false',

--- a/apps/api/src/services/agent-task/subagent.ts
+++ b/apps/api/src/services/agent-task/subagent.ts
@@ -22,6 +22,7 @@ import type { TaskSandboxConfig } from '../../config/task-sandbox';
 import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
 import { requiresApproval, getApprovalRegistry } from '../task-sandbox/approval-gate';
 import { runTool } from './task-steps';
+import { prefetchReadOnlyCalls } from '../tool-parallel';
 import { createLogger } from '../../utils/logger';
 import { buildSubagentDelegationRules, SUBAGENT_FINAL_TURN_NOTICE } from '../../prompts/subagent-system';
 
@@ -100,9 +101,34 @@ export async function runSubagent(p: SubagentParams): Promise<string> {
                 return finalText || '(서브에이전트가 빈 응답을 반환했습니다)';
             }
 
+            // 읽기 전용 도구 병렬 선실행 — 승인 필요 호출은 자동 승인 작업에서만(부모 루프와 같은 규칙).
+            const prefetched = await prefetchReadOnlyCalls(
+                result.tool_calls.map((tc) => ({ id: tc.id, name: tc.function.name, tc })),
+                ({ name, tc }) => !requiresApproval(p.sandboxCfg.approvalPolicy, name,
+                    (tc.function.arguments ?? {}) as Record<string, unknown>, { deviceGatesShell: p.sandboxCfg.deviceGatesShell })
+                    || getApprovalRegistry().isAutoApprove(p.taskId),
+                async ({ name, tc }) => {
+                    const args = (tc.function.arguments ?? {}) as Record<string, unknown>;
+                    if (requiresApproval(p.sandboxCfg.approvalPolicy, name, args, { deviceGatesShell: p.sandboxCfg.deviceGatesShell })) {
+                        const r = await getApprovalRegistry().request(
+                            { taskId: p.taskId, userId: String(p.userCtx.userId), toolName: name, args },
+                            { timeoutMs: p.sandboxCfg.approvalTimeoutMs, signal: p.signal },
+                        );
+                        p.onPausedMs?.(r.waitedMs);
+                        if (r.decision !== 'approved') return `Error: 사용자가 도구 실행을 승인하지 않았습니다 (${name}).`;
+                    }
+                    return runTool(mcp, name, args, p.userCtx);
+                },
+                { path: 'subagent', ...(p.signal ? { signal: p.signal } : {}) },
+            );
             for (const tc of result.tool_calls) {
                 const name = tc.function.name;
                 const args = (tc.function.arguments ?? {}) as Record<string, unknown>;
+                const pre = tc.id !== undefined ? prefetched.get(tc.id) : undefined;
+                if (pre !== undefined) {
+                    conversation.push({ role: 'tool', content: pre, tool_name: name, tool_call_id: tc.id });
+                    continue;
+                }
                 // 부모와 동일한 승인 게이트 — 정책 우회 없음(자동승인 task 면 즉시 approved).
                 let approved = true;
                 if (requiresApproval(p.sandboxCfg.approvalPolicy, name, args, { deviceGatesShell: p.sandboxCfg.deviceGatesShell })) {

--- a/apps/api/src/services/agent-task/turn-executor.ts
+++ b/apps/api/src/services/agent-task/turn-executor.ts
@@ -16,6 +16,7 @@ import { requiresApproval, getApprovalRegistry } from '../task-sandbox/approval-
 import { currentPlanStepIndex } from '../task-sandbox/planning';
 import { runTool, isSearchTool } from './task-steps';
 import { prepareToolArgs } from './tool-args';
+import { prefetchReadOnlyCalls } from '../tool-parallel';
 import { AgentTaskAbort } from './types';
 import type { TaskRuntime } from '../task-sandbox/runtime';
 import type { TaskSandboxConfig } from '../../config/task-sandbox';
@@ -92,6 +93,29 @@ export async function executeTurnToolCalls(input: TurnToolExecInput): Promise<Tu
             url: '/agent-tasks',
         }).catch(() => { /* noop */ });
     };
+    // 읽기 전용 extra 도구(web_search 등) 병렬 선실행. 승인이 필요한 호출은 **자동 승인 작업에서만**
+    // 포함한다 — 아니면 승인 창이 동시에 N개 뜬다(HITL fan-in). 결과·스텝 영속은 아래 루프가
+    // 원래 순서로 처리하므로 체크포인트 계약은 그대로다.
+    const prefetched = await prefetchReadOnlyCalls(
+        toolCalls.map((tc) => ({ id: tc.id, name: tc.function.name, tc })),
+        ({ name, tc }) => !taskRuntime?.isTaskTool(name)
+            && (!requiresApproval(sandboxCfg.approvalPolicy, name, (tc.function.arguments ?? {}) as Record<string, unknown>)
+                || getApprovalRegistry().isAutoApprove(taskId)),
+        async ({ name, tc }) => {
+            const args = (tc.function.arguments ?? {}) as Record<string, unknown>;
+            if (extraToolNames.has(name) && requiresApproval(sandboxCfg.approvalPolicy, name, args)) {
+                // 자동 승인 작업만 여기 온다 — 감사·집계를 위해 같은 레지스트리를 거친다(즉시 approved).
+                const r = await getApprovalRegistry().request(
+                    { taskId, userId, toolName: name, args },
+                    { timeoutMs: sandboxCfg.approvalTimeoutMs, signal },
+                );
+                pausedMs += r.waitedMs;
+                if (r.decision !== 'approved') return `Error: 사용자가 도구 실행을 승인하지 않았습니다 (${name}).`;
+            }
+            return runTool(mcp, name, args, userCtx);
+        },
+        { signal, path: 'agent-task' },
+    );
     for (const tc of toolCalls) {
         if (signal.aborted) throw new AgentTaskAbort('aborted');
         const name = tc.function.name;
@@ -100,7 +124,10 @@ export async function executeTurnToolCalls(input: TurnToolExecInput): Promise<Tu
         if (name === 'browser') browserCalls++;
         const args = (tc.function.arguments ?? {}) as Record<string, unknown>;
         let toolResult: string;
-        if (taskRuntime?.isTaskTool(name)) {
+        const pre = tc.id !== undefined ? prefetched.get(tc.id) : undefined;
+        if (pre !== undefined) {
+            toolResult = pre;
+        } else if (taskRuntime?.isTaskTool(name)) {
             // task 도구 — 승인 게이트 통과 후 영속 샌드박스에서 실행.
             // onApprovalWaited: 승인 대기 시간을 pausedMs 로 누적(4-1 pause-aware 타임아웃).
             toolResult = await taskRuntime.executeTaskTool(name, args, {

--- a/apps/api/src/services/chat-service/external-tool-batch.ts
+++ b/apps/api/src/services/chat-service/external-tool-batch.ts
@@ -19,6 +19,7 @@ import { executeExternalTool } from './external-tool-exec';
 import { captureOdArtifactHtml, normalizeOdToolCall, type OdArtifactCapture } from './external-deterministic-append';
 import { extractDiscussionSources } from '../../agents/discussion-sources';
 import { parallelBatch } from '../../workflow/graph-engine';
+import { prefetchReadOnlyCalls } from '../tool-parallel';
 import type { ChatMessage, ToolDefinition } from '../../llm';
 import type { ChatMessageRequest } from '../chat-service-types';
 import type { ChatStreamResult } from '../../providers/i-provider';
@@ -116,6 +117,14 @@ export async function runToolCallBatch(params: {
             IMAGE_GEN_PARALLEL.WALL_CLOCK_CREDIT_MAX_MS,
         );
     }
+    // 읽기 전용 도구(web_search·extract_webpage …) 2건 이상이면 동시에 선실행 — 결과는 아래
+    // 순차 루프가 원래 호출 순서대로 배치한다(이미지 병렬과 같은 계약). 채팅은 승인 게이트가 없다.
+    const parallelReadOnlyResults = await prefetchReadOnlyCalls(
+        toolCalls,
+        () => true,
+        (tc) => executeExternalTool(deps, tc.name, tc.args as Record<string, unknown>),
+        { path: 'chat', ...(req.abortSignal ? { signal: req.abortSignal } : {}) },
+    );
     for (const tc of toolCalls) {
         let toolResult: string;
         if (tc.name === CHAT_DELEGATE_TOOL_NAME) {
@@ -166,6 +175,7 @@ export async function runToolCallBatch(params: {
             const singleImageStartedAt = tc.name === 'generate_image' && !parallelImageResults.has(tc.id)
                 ? Date.now() : 0;
             toolResult = parallelImageResults.get(tc.id)
+                ?? parallelReadOnlyResults.get(tc.id)
                 ?? await executeExternalTool(deps, tc.name, tc.args as Record<string, unknown>);
             if (singleImageStartedAt > 0) {
                 state.imageGenCreditMs = Math.min(

--- a/apps/api/src/services/tool-parallel.ts
+++ b/apps/api/src/services/tool-parallel.ts
@@ -1,0 +1,73 @@
+/**
+ * 턴 내 읽기 전용 도구 병렬 선실행 — 채팅·에이전트 작업·서브에이전트 공용.
+ *
+ * 패턴(generate_image 선례): 호출 목록에서 병렬 가능한 것을 골라 **먼저 동시에 실행**해 결과를
+ * id → 텍스트 맵에 담고, 기존 순차 루프는 그 맵을 먼저 보고 없을 때만 직접 실행한다. 그래서
+ * 대화 메시지·스텝 영속·체크포인트의 **순서 계약은 그대로**다.
+ *
+ * 병렬 대상 판정은 호출측이 `isEligible` 로 준다 — 이름이 읽기 전용 목록에 있는 것 외에,
+ * 작업 경로는 승인 게이트(HITL fan-in 회피)도 봐야 하기 때문.
+ *
+ * @module services/tool-parallel
+ */
+import { READ_ONLY_TOOL_PARALLEL } from '../config/runtime-limits';
+import { parallelBatch } from '../workflow/graph-engine';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('ToolParallel');
+
+/**
+ * 읽기 전용(부작용 없음) 도구인가.
+ *  - 빌트인: 설정의 정확한 이름 목록.
+ *  - 외부 MCP(`server::tool`): 도구 부분에 조회 키워드가 있고 쓰기 키워드가 없을 때만.
+ *    모르는 도구는 기본 **순차**(false) — 병렬이 잘못되면 부작용 순서가 깨지므로 보수적으로 판정.
+ */
+export function isReadOnlyTool(name: string): boolean {
+    if ((READ_ONLY_TOOL_PARALLEL.TOOL_NAMES as readonly string[]).includes(name)) return true;
+    const sep = name.indexOf('::');
+    if (sep < 0) return false;
+    const tool = name.slice(sep + 2).toLowerCase();
+    const reads = READ_ONLY_TOOL_PARALLEL.MCP_READ_KEYWORDS.some((k) => tool.includes(k));
+    const writes = READ_ONLY_TOOL_PARALLEL.MCP_WRITE_KEYWORDS.some((k) => tool.includes(k));
+    return reads && !writes;
+}
+
+export interface ParallelCall {
+    /** 없으면 결과를 매핑할 수 없어 병렬 대상에서 제외한다(순차 실행). */
+    id: string | undefined;
+    name: string;
+}
+
+/**
+ * 병렬 가능한 호출을 골라 동시에 실행한다. **2건 이상일 때만** 동작한다(1건은 순차와 같다).
+ * 실패는 개별 결과(`Error: …` 문자열)로 흡수해 다른 호출을 죽이지 않는다 — abort 만 전파.
+ * 반환 맵에 없는 id 는 호출측이 종전대로 순차 실행한다.
+ */
+export async function prefetchReadOnlyCalls<T extends ParallelCall>(
+    calls: T[],
+    isEligible: (call: T) => boolean,
+    exec: (call: T) => Promise<string>,
+    opts: { signal?: AbortSignal; path: string } ,
+): Promise<Map<string, string>> {
+    const results = new Map<string, string>();
+    if (!READ_ONLY_TOOL_PARALLEL.ENABLED) return results;
+    const eligible = calls.filter((c) => c.id !== undefined && isReadOnlyTool(c.name) && isEligible(c));
+    if (eligible.length < 2) return results;
+
+    const started = Date.now();
+    await parallelBatch(
+        eligible,
+        async (call) => {
+            try {
+                results.set(call.id as string, await exec(call));
+            } catch (e) {
+                // 개별 실패는 그 호출의 결과로만 남긴다 — 순차 실행 때와 같은 표면.
+                results.set(call.id as string, `Error: ${e instanceof Error ? e.message : String(e)}`);
+            }
+        },
+        { concurrency: READ_ONLY_TOOL_PARALLEL.MAX_CONCURRENT, ...(opts.signal ? { signal: opts.signal } : {}) },
+    );
+    logger.info(`[ToolParallel] ${opts.path}: 읽기 전용 ${eligible.length}건 병렬 실행 `
+        + `(${[...new Set(eligible.map((c) => c.name))].join(',')}, 동시 상한 ${READ_ONLY_TOOL_PARALLEL.MAX_CONCURRENT}, ${Date.now() - started}ms)`);
+    return results;
+}


### PR DESCRIPTION
## 근거 (최근 30일 에이전트 작업, 도구 턴 585개)

- 한 턴에 도구 **2개 이상**: 118턴(20%) · 그중 **전부 읽기 전용** 72턴(61%) — `web_search ×N`, `extract_webpage ×N`, 4개짜리 턴 31건
- 모델은 이미 독립이라 판단해 한 턴에 4개씩 던지는데 루프가 **하나씩** 실행 → 검색 4개 턴 ≈ 12초(1건 ≈ 3초)
- 주 발생원: 매일 07시 예약 데일리 리포트(로컬 qwen)

## 설계

`generate_image` 병렬 선례와 같은 계약: 병렬 가능한 호출을 **먼저 동시에 실행**해 id→결과 맵에 담고, 기존 순차 루프는 맵을 먼저 본다. 대화 메시지·스텝 영속·체크포인트의 **순서 계약은 그대로**. 공용 헬퍼 `services/tool-parallel.ts` 를 채팅·작업·서브에이전트 3경로가 쓴다.

| 규칙 | 내용 |
|---|---|
| 대상 한정 | 빌트인은 정확 이름 목록, 외부 MCP(`server::tool`)는 조회 키워드 ∧ ¬쓰기 키워드. **모르는 도구는 순차** |
| 승인 게이트 | 작업·서브 경로에서 승인이 필요한 호출은 **자동 승인 작업에서만** 병렬(아니면 승인 창 N개 동시 — HITL fan-in). 자동 승인이어도 같은 레지스트리를 거쳐 감사·집계 유지 |
| 실패 격리 | 개별 실패는 그 호출의 `Error:` 결과로만, abort 만 전파 |
| 게이트 | `READ_ONLY_TOOL_PARALLEL_ENABLED`(기본 on) · 동시 상한 4 · 목록/키워드 env |

⚠️ 정확 이름 목록만으로는 라이브에서 한 번도 안 걸렸다 — qwen 이 한 턴에 4개를 내면서 `web_search` 대신 **`mcp-kakao::search-web`** 를 골랐다. MCP 키워드 판정을 추가한 이유.

## 라이브 (chat.openmake.cc, qwen3.6)

```
20:15:29  🛠️ 외부 LLM tool calls (turn 1): 4개
20:15:29  web_search ×4 — 전부 같은 초에 시작
20:15:32  [ToolParallel] chat: 읽기 전용 4건 병렬 실행 (web_search, 동시 상한 4, 3136ms)
```
순차였던 직전 실행은 건당 3초 간격(20:10:37 → :40 → :43). **4건 12초 → 3.1초.**

단위 7건(대상 한정·상한 준수·실패 격리·id 없음 제외·MCP 판정) + 관련 스위트 306건 통과. `.env.example` 갱신.