### PR TITLE
feat(agent-task): 서브에이전트 활동 기록(109) + 병렬 위임 채택률 셰도우(110)·설명문 조정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1178,6 +1178,10 @@ LOCAL_BRIDGE_LSP_TIMEOUT_MS=10000
 # AGENT_TASK_SUBAGENT_ENABLED=true
 # AGENT_TASK_SUBAGENT_MAX_TURNS=3
 # AGENT_TASK_SUBAGENT_MAX_TOKENS=100000
+# 서브에이전트 활동 기록(109, 2026-08-26) — delegate/spawn 서브가 실제로 한 일(검색어·결과·최종답)을
+# agent_task_subagent_steps 에 남긴다(웹 상세·CLI show --steps·GET /:id/subagents). false 로 끔.
+# AGENT_TASK_SUBAGENT_TRACE_ENABLED=true
+# AGENT_TASK_SUBAGENT_TRACE_CAP=2000
 
 # Agent Task — 동적 도구 선별 방식: keyword(기본) | embedding(bge-m3 코사인, 실패 시 키워드 폴백).
 # AGENT_TASK_DYNAMIC_TOOLS_MODE=keyword

--- a/apps/api/src/__tests__/routes/agent-task-subagent-group.test.ts
+++ b/apps/api/src/__tests__/routes/agent-task-subagent-group.test.ts
@@ -1,0 +1,30 @@
+/** groupSubagentSteps — 행 → 서브에이전트(trace, sub_index) 단위 묶음과 정렬 계약. */
+import { groupSubagentSteps } from '../../routes/agent-task-subagent.routes';
+
+const at = (s: string) => new Date(`2026-08-26T10:00:${s}Z`);
+const row = (trace: string, sub: number, seq: number, type: string, sec: string, tool: string | null = null) => ({
+    id: `${trace}-${sub}-${seq}`, task_id: 't', trace_id: trace, origin: trace === 'd' ? 'delegate' : 'spawn_agents',
+    sub_index: sub, label: null, seq, step_type: type, tool_name: tool, content: `${type}:${seq}`, created_at: at(sec),
+});
+
+describe('groupSubagentSteps', () => {
+    test('같은 fan-out 의 서브들은 sub_index 로 갈리고, 서브 안은 seq 순서다', () => {
+        const rows = [
+            row('s1', 1, 1, 'tool_result', '05'), row('s1', 1, 0, 'tool_call', '04', 'web_search'),
+            row('s1', 0, 0, 'tool_call', '03', 'web_search'), row('s1', 0, 1, 'final', '06'),
+        ];
+        const g = groupSubagentSteps(rows);
+        expect(g.map((t) => t.subIndex)).toEqual([0, 1]);
+        expect(g[1].steps.map((s) => s.seq)).toEqual([1, 0]); // 입력 순서 유지(정렬은 DB 가 한다)
+        expect(g[0].startedAt).toBe(at('03').toISOString());
+    });
+
+    test('delegate 와 spawn 이 섞여도 시작 시각 오름차순', () => {
+        const g = groupSubagentSteps([row('s9', 0, 0, 'final', '30'), row('d', 0, 0, 'final', '10')]);
+        expect(g.map((t) => t.origin)).toEqual(['delegate', 'spawn_agents']);
+    });
+
+    test('빈 입력은 빈 배열', () => {
+        expect(groupSubagentSteps([])).toEqual([]);
+    });
+});

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1690,6 +1690,10 @@ export const AGENT_TASK_LIMITS = {
     SUBAGENT_MAX_TURNS: parseInt(process.env.AGENT_TASK_SUBAGENT_MAX_TURNS || '3', 10),
     /** 서브에이전트 1회 위임당 토큰 상한 — 부모 누적에 합산되어 부모 한도도 함께 적용(기본 100k). */
     SUBAGENT_MAX_TOKENS: parseInt(process.env.AGENT_TASK_SUBAGENT_MAX_TOKENS || '100000', 10),
+    /** 서브에이전트 활동 기록(109) — 기본 on. AGENT_TASK_SUBAGENT_TRACE_ENABLED=false 로 끔. */
+    SUBAGENT_TRACE_ENABLED: process.env.AGENT_TASK_SUBAGENT_TRACE_ENABLED !== 'false',
+    /** 서브 스텝 본문 상한(자) — 도구 결과 전문은 부모 tool_result 에 이미 있으므로 미리보기만. */
+    SUBAGENT_TRACE_CONTENT_CAP: parseInt(process.env.AGENT_TASK_SUBAGENT_TRACE_CAP || '2000', 10),
     /** 동적 도구 선별 방식(Phase 5-4): 'keyword'(기본 — 무-LLM 오버랩) | 'embedding'(bge-m3 코사인,
      *  어휘가 달라도 의미 매칭. 실패 시 키워드 폴백). AGENT_TASK_DYNAMIC_TOOLS_MODE. */
     DYNAMIC_TOOLS_MODE: (process.env.AGENT_TASK_DYNAMIC_TOOLS_MODE === 'embedding' ? 'embedding' : 'keyword') as 'keyword' | 'embedding',

--- a/apps/api/src/data/repositories/__tests__/routing-metrics-repository.test.ts
+++ b/apps/api/src/data/repositories/__tests__/routing-metrics-repository.test.ts
@@ -45,6 +45,8 @@ describe('RoutingMetricsRepository', () => {
             exposed_turns: '0',
             called_turns: '0',
             success_turns: '0',
+            spawn_intent_turns: '0',
+            spawn_called_turns: '0',
         });
     });
 

--- a/apps/api/src/data/repositories/agent-task-subagent-step-repository.ts
+++ b/apps/api/src/data/repositories/agent-task-subagent-step-repository.ts
@@ -1,0 +1,39 @@
+/**
+ * @module data/repositories/agent-task-subagent-step-repository
+ * @description `agent_task_subagent_steps`(109) — delegate/spawn 서브에이전트 활동 기록.
+ * 쓰기는 fire-and-forget(서브 실행을 늦추지 않음), 읽기는 작업 단위 전체.
+ */
+import { BaseRepository } from './base-repository';
+
+export interface SubagentStepRow {
+    id: string;
+    task_id: string;
+    trace_id: string;
+    origin: string;
+    sub_index: number;
+    label: string | null;
+    seq: number;
+    step_type: string;
+    tool_name: string | null;
+    content: string | null;
+    created_at: Date;
+}
+
+export class AgentTaskSubagentStepRepository extends BaseRepository {
+    async add(row: Omit<SubagentStepRow, 'id' | 'created_at'>): Promise<void> {
+        await this.query(
+            `INSERT INTO agent_task_subagent_steps
+                (task_id, trace_id, origin, sub_index, label, seq, step_type, tool_name, content)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+            [row.task_id, row.trace_id, row.origin, row.sub_index, row.label, row.seq, row.step_type, row.tool_name, row.content],
+        );
+    }
+
+    async listByTask(taskId: string): Promise<SubagentStepRow[]> {
+        const r = await this.query<SubagentStepRow>(
+            `SELECT * FROM agent_task_subagent_steps WHERE task_id = $1 ORDER BY trace_id, sub_index, seq`,
+            [taskId],
+        );
+        return r.rows;
+    }
+}

--- a/apps/api/src/data/repositories/routing-metrics-repository.ts
+++ b/apps/api/src/data/repositories/routing-metrics-repository.ts
@@ -23,6 +23,8 @@ export interface OrchestrationDispatchSummaryRow {
     exposed_turns: string;
     called_turns: string;
     success_turns: string;
+    spawn_intent_turns: string;
+    spawn_called_turns: string;
 }
 
 /** 실제 호출된 도구별 턴 수·성공 수 */
@@ -69,7 +71,9 @@ export class RoutingMetricsRepository extends BaseRepository {
                     COUNT(*) FILTER (WHERE discussion_intent OR task_delegate_intent) AS intent_turns,
                     COUNT(*) FILTER (WHERE cardinality(tools_exposed) > 0) AS exposed_turns,
                     COUNT(*) FILTER (WHERE tool_called IS NOT NULL) AS called_turns,
-                    COUNT(*) FILTER (WHERE tool_success = true) AS success_turns
+                    COUNT(*) FILTER (WHERE tool_success = true) AS success_turns,
+                    COUNT(*) FILTER (WHERE spawn_intent) AS spawn_intent_turns,
+                    COUNT(*) FILTER (WHERE spawn_intent AND tool_called = 'spawn_agents') AS spawn_called_turns
              FROM orchestration_dispatch_decisions
              WHERE created_at >= NOW() - ($1 || ' days')::interval`,
             [String(days)]
@@ -80,6 +84,8 @@ export class RoutingMetricsRepository extends BaseRepository {
             exposed_turns: '0',
             called_turns: '0',
             success_turns: '0',
+            spawn_intent_turns: '0',
+            spawn_called_turns: '0',
         };
     }
 

--- a/apps/api/src/routes/agent-task-subagent.routes.ts
+++ b/apps/api/src/routes/agent-task-subagent.routes.ts
@@ -1,0 +1,54 @@
+/**
+ * 서브에이전트 활동 조회 — mount: `/api/agent-tasks` (agentTaskRouter 의 `/:taskId` 보다 먼저).
+ *
+ *   GET /api/agent-tasks/:taskId/subagents
+ *     → { traces: [{ traceId, origin, subIndex, label, startedAt, steps: [{ seq, type, tool, content, at }] }] }
+ *
+ * delegate/spawn 서브에이전트는 부모 스텝 번호 공간 밖에서 돌므로(109 주석) 별도 테이블·별도
+ * 엔드포인트다. 인증은 작업 본 라우트와 같은 축(JWT 또는 bridge API key) — CLI 도 읽는다.
+ *
+ * @module routes/agent-task-subagent.routes
+ */
+import { Router, Request, Response } from 'express';
+import { requireAuthOrApiKeyScope } from '../middlewares/api-key-auth';
+import { API_KEY_SCOPES } from '../config/api-key-scopes';
+import { success } from '../utils/api-response';
+import { asyncHandler } from '../utils/error-handler';
+import { getUnifiedDatabase } from '../data/models/unified-database';
+import { AgentTaskSubagentStepRepository, type SubagentStepRow } from '../data/repositories/agent-task-subagent-step-repository';
+import { loadOwnedTask } from './agent-task.helpers';
+
+export const agentTaskSubagentRouter = Router();
+
+export interface SubagentTraceView {
+    traceId: string;
+    origin: string;
+    subIndex: number;
+    label: string | null;
+    startedAt: string;
+    steps: { seq: number; type: string; tool: string | null; content: string | null; at: string }[];
+}
+
+/** PURE: 행 목록 → trace(=서브에이전트 1개) 단위 묶음. 시작 시각 오름차순. */
+export function groupSubagentSteps(rows: SubagentStepRow[]): SubagentTraceView[] {
+    const map = new Map<string, SubagentTraceView>();
+    for (const r of rows) {
+        const key = `${r.trace_id}:${r.sub_index}`;
+        let v = map.get(key);
+        if (!v) {
+            v = { traceId: r.trace_id, origin: r.origin, subIndex: r.sub_index, label: r.label, startedAt: r.created_at.toISOString(), steps: [] };
+            map.set(key, v);
+        }
+        v.steps.push({ seq: r.seq, type: r.step_type, tool: r.tool_name, content: r.content, at: r.created_at.toISOString() });
+    }
+    return [...map.values()].sort((a, b) => a.startedAt.localeCompare(b.startedAt) || a.subIndex - b.subIndex);
+}
+
+agentTaskSubagentRouter.get('/:taskId/subagents', requireAuthOrApiKeyScope(API_KEY_SCOPES.BRIDGE), asyncHandler(async (req: Request, res: Response) => {
+    const task = await loadOwnedTask(req, res, req.params.taskId);
+    if (!task) return;
+    const rows = await new AgentTaskSubagentStepRepository(getUnifiedDatabase().getPool()).listByTask(req.params.taskId);
+    res.json(success({ traces: groupSubagentSteps(rows) }));
+}));
+
+export default agentTaskSubagentRouter;

--- a/apps/api/src/routes/metrics.routes.ts
+++ b/apps/api/src/routes/metrics.routes.ts
@@ -359,6 +359,11 @@ router.get('/routing/gates', asyncHandler(async (req: Request, res: Response) =>
             successTurns,
             callRate: exposedTurns > 0 ? calledTurns / exposedTurns : 0,
             successRate: calledTurns > 0 ? successTurns / calledTurns : 0,
+            // 병렬 위임 채택률(110) — 의도 매칭 턴 중 spawn_agents 를 실제 호출한 비율.
+            spawnIntentTurns: Number(dispatchRow.spawn_intent_turns),
+            spawnCalledTurns: Number(dispatchRow.spawn_called_turns),
+            spawnAdoptionRate: Number(dispatchRow.spawn_intent_turns) > 0
+                ? Number(dispatchRow.spawn_called_turns) / Number(dispatchRow.spawn_intent_turns) : 0,
             byTool: byToolRows.map((r) => ({
                 tool: r.tool_called,
                 turns: Number(r.turns),

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -12,6 +12,7 @@
 import { Application, Request, Response } from 'express';
 import { agentTaskQueueRouter } from './agent-task-queue.routes';
 import { agentTaskShareRouter } from './agent-task-share.routes';
+import { agentTaskSubagentRouter } from './agent-task-subagent.routes';
 import { mcpOAuthRouter } from './mcp-oauth.routes';
 import { marketplacePublishRouter } from './marketplace-publish.routes';
 import * as path from 'path';
@@ -280,6 +281,7 @@ export function setupApiRoutes(
     app.use('/api/audit', auditRouter);
     app.use('/api/research', researchRouter);
     app.use('/api/agent-tasks', agentTaskQueueRouter);   // /queue/stats — /:id 라우트보다 먼저
+    app.use('/api/agent-tasks', agentTaskSubagentRouter); // /:id/subagents — 서브에이전트 활동(109)
     app.use('/api', agentTaskShareRouter);               // /agent-tasks/:id/share, /shared-tasks/:shareId
     app.use('/api/agent-tasks', agentTaskRouter);
     // 청크 업로드 — Cloudflare 요청당 100MB 상한 우회 (대용량 첨부는 조각으로 수신)

--- a/apps/api/src/services/agent-spawn/spawn-agents.test.ts
+++ b/apps/api/src/services/agent-spawn/spawn-agents.test.ts
@@ -24,6 +24,11 @@ jest.mock('../task-sandbox/approval-gate', () => ({
     getApprovalRegistry: () => ({ isAutoApprove: (id: string) => autoApproveMock(id) }),
 }));
 
+jest.mock('../agent-task/subagent-trace', () => ({
+    newTraceId: () => 'trace-test',
+    SubagentTrace: class { record = jest.fn(); },
+}));
+
 const runSubagentMock = jest.fn();
 jest.mock('../agent-task/subagent', () => ({
     runSubagent: (p: unknown) => runSubagentMock(p),
@@ -302,6 +307,15 @@ describe('buildTaskSpawnFn — 에이전트 작업 경로', () => {
         expect(passed).toEqual(['web_search', 'browser']);
         expect(autoApproveMock).toHaveBeenCalledWith('task-1');
         expect(out).not.toContain('도구 없이 답했습니다');
+    });
+
+    it('작업 경로는 서브에 활동 기록기(trace)를 넘기고, 채팅 경로는 넘기지 않는다', async () => {
+        const spawn = buildTaskSpawnFn(makeFactoryParams('none', ['web_search']));
+        await spawn({ tasks: [{ prompt: 'x' }] });
+        expect(runSubagentMock.mock.calls[0][0].trace).toBeDefined();
+        runSubagentMock.mockClear();
+        await runChatSpawnAgents({ args: { tasks: [{ prompt: 'y' }] }, chatTools: [llmTool('web_search')], userCtx: { userId: 'u1', role: 'user' } as never });
+        expect(runSubagentMock.mock.calls[0][0].trace).toBeUndefined();
     });
 
     it('화이트리스트가 비어 있으면 그 사유가 실린다', async () => {

--- a/apps/api/src/services/agent-spawn/spawn-agents.ts
+++ b/apps/api/src/services/agent-spawn/spawn-agents.ts
@@ -32,6 +32,7 @@ import { routeToAgent } from '../../agents/keyword-router';
 import { getAgentSystemMessage } from '../../agents/system-prompt';
 import { requiresApproval, getApprovalRegistry } from '../task-sandbox/approval-gate';
 import { runSubagent } from '../agent-task/subagent';
+import { SubagentTrace, newTraceId } from '../agent-task/subagent-trace';
 import type { DelegateFactoryParams } from '../agent-task/delegate';
 import { CHAT_DELEGATE_TOOL_NAME } from '../chat-service/chat-delegate';
 import { SPAWN_AGENT_GENERIC_PROMPT } from '../../prompts/spawn-agent-system';
@@ -40,6 +41,9 @@ import { createLogger } from '../../utils/logger';
 const logger = createLogger('AgentSpawn');
 
 export const SPAWN_AGENTS_TOOL_NAME = 'spawn_agents';
+
+/** 채팅 경로의 의사 taskId — 승인 레지스트리 키로만 쓰이며 작업 행이 없으므로 활동 기록은 건너뛴다. */
+export const CHAT_PSEUDO_TASK_ID = '__chat__';
 
 /** 서브에이전트 도구 서브셋에서 제외할 위임 계열 도구 — depth=1 구조 유지(재귀 차단). */
 const SUBAGENT_EXCLUDED_TOOLS = new Set([SPAWN_AGENTS_TOOL_NAME, CHAT_DELEGATE_TOOL_NAME, 'delegate']);
@@ -87,11 +91,16 @@ export function describeArgsShape(raw: unknown): string {
     return `keys=${keys.join('|')}, tasks=${tasksShape}`;
 }
 
+/**
+ * 도구 설명 — **언제 쓰는지**를 먼저 말한다. 종전 문구는 "⚠️ 쓰지 마세요"로 시작해 채택을
+ * 억눌렀다(2026-08-26 자연어 6문항 기준선 실측 → 셰도우 `spawn_intent` 로 효과를 잰다).
+ * 주의 문구는 유지하되 뒤로.
+ */
 export const SPAWN_AGENTS_TOOL_DESCRIPTION =
-    '서로 독립적인 하위 작업 여러 개를 병렬 서브에이전트들에게 분담시켜 동시에 수행합니다. '
-    + '각 태스크는 다른 태스크 결과를 참조할 수 없으므로 자기완결적으로 서술하세요. '
-    + '⚠️ 단순 질문이나 순차 의존적인 작업에는 쓰지 말고 직접 수행하세요 — 독립 하위 작업 2개 이상을 '
-    + '병렬로 나눌 가치가 있을 때만 사용합니다(응답 시간이 늘어납니다). 결과를 받은 뒤 직접 종합하세요.';
+    '서로 독립적인 하위 작업이 2개 이상일 때 각각을 병렬 서브에이전트에게 맡겨 동시에 수행합니다 — '
+    + '예: 여러 주제·대상·출처를 각각 조사해 비교하기, 여러 문서를 각각 요약하기. '
+    + '각 태스크는 다른 태스크 결과를 볼 수 없으므로 자기완결적으로 서술하세요. '
+    + '하나의 순차 작업이나 단순 질문에는 쓰지 말고 직접 수행하세요. 결과를 받은 뒤 직접 종합해 답하세요.';
 
 /** 시스템 프롬프트 주입 가이드 — SPAWN_INTENT_PATTERNS 매칭 턴에만 주입한다(상시 주입 금지).
  *  description 의 보수적 경고가 과작동해 자발 채택이 0 이던 갭 보완: 병렬 의도가 명시된
@@ -253,6 +262,8 @@ export async function runSpawnAgents(p: SpawnAgentsParams): Promise<string> {
         : '';
     if (subTools.length === 0) logger.warn(`[AgentSpawn] 서브 도구 0개 — ${p.noToolsReason ?? '전달된 도구 없음'}`);
 
+    // 활동 기록(109) — 에이전트 작업 경로만(채팅은 작업 행이 없다). fan-out 1회 = trace 1개.
+    const traceId = p.taskId !== CHAT_PSEUDO_TASK_ID ? newTraceId() : null;
     let results: Array<string | null>;
     try {
         results = await parallelBatch(
@@ -263,7 +274,11 @@ export async function runSpawnAgents(p: SpawnAgentsParams): Promise<string> {
                     if (exec.modelNote) {
                         logger.info(`[AgentSpawn] 태스크 ${idx + 1} custom agent 모델: ${exec.modelNote}`);
                     }
+                    const trace = traceId
+                        ? new SubagentTrace(p.taskId, traceId, 'spawn_agents', idx, task.role ?? task.agentId ?? null)
+                        : undefined;
                     return await runSubagent({
+                        ...(trace ? { trace } : {}),
                         client: exec.client,
                         personaPrompt: exec.persona,
                         subgoal: task.prompt,
@@ -328,7 +343,7 @@ export async function runChatSpawnAgents(params: {
         client: resolved.client,
         tools: filterChatSubTools(params.chatTools),
         userCtx: params.userCtx,
-        taskId: '__chat__', // 정책 'none' 이라 승인 레지스트리 미사용 — 식별용 문자열일 뿐
+        taskId: CHAT_PSEUDO_TASK_ID, // 정책 'none' 이라 승인 레지스트리 미사용 — 식별용 문자열일 뿐
         sandboxCfg: { approvalPolicy: 'none', approvalTimeoutMs: 0 },
         ...(params.signal ? { signal: params.signal } : {}),
         onTokens: (n) => logger.debug(`[AgentSpawn] 채팅 서브 토큰 +${n}`),

--- a/apps/api/src/services/agent-task/delegate.ts
+++ b/apps/api/src/services/agent-task/delegate.ts
@@ -17,6 +17,7 @@ import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
 import { routeToAgent } from '../../agents/keyword-router';
 import { getAgentSystemMessage } from '../../agents/system-prompt';
 import { runSubagent } from './subagent';
+import { SubagentTrace, newTraceId } from './subagent-trace';
 
 export interface DelegateFactoryParams {
     client: LLMClient;
@@ -44,6 +45,7 @@ export function buildDelegateFn(p: DelegateFactoryParams): DelegateFn {
                 .map((n) => p.mcpTools.find((t) => t.function.name === n))
                 .filter((t): t is ToolDefinition => !!t);
             return runSubagent({
+                trace: new SubagentTrace(p.taskId, newTraceId(), 'delegate', 0, role ?? selection.primaryAgent ?? null),
                 client: p.client, personaPrompt: prompt, subgoal,
                 tools: subTools, userCtx: p.userCtx, taskId: p.taskId,
                 sandboxCfg: p.sandboxCfg, signal: p.signal,

--- a/apps/api/src/services/agent-task/subagent-trace.ts
+++ b/apps/api/src/services/agent-task/subagent-trace.ts
@@ -1,0 +1,48 @@
+/**
+ * 서브에이전트 활동 기록기 — runSubagent 가 턴마다 부른다(선택 인자, 없으면 무기록).
+ *
+ * 실패해도 서브를 죽이지 않는다(fail-open) — 기록은 관측이지 실행의 일부가 아니다. 대신
+ * 실패는 warn 으로 남겨 "기록이 없는데 정상"과 구분한다.
+ *
+ * @module services/agent-task/subagent-trace
+ */
+import { randomUUID } from 'crypto';
+import { getUnifiedDatabase } from '../../data/models/unified-database';
+import { AgentTaskSubagentStepRepository } from '../../data/repositories/agent-task-subagent-step-repository';
+import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('SubagentTrace');
+
+export type SubagentOrigin = 'spawn_agents' | 'delegate';
+export type SubagentStepType = 'tool_call' | 'tool_result' | 'final' | 'error';
+
+/** fan-out/위임 1회를 묶는 id — 같은 fan-out 의 서브들은 trace_id 를 공유하고 sub_index 로 갈린다. */
+export function newTraceId(): string {
+    return randomUUID();
+}
+
+export class SubagentTrace {
+    private seq = 0;
+    private readonly repo = new AgentTaskSubagentStepRepository(getUnifiedDatabase().getPool());
+
+    constructor(
+        private readonly taskId: string,
+        private readonly traceId: string,
+        private readonly origin: SubagentOrigin,
+        private readonly subIndex: number,
+        private readonly label: string | null,
+    ) {}
+
+    /** 기록(비동기, 대기하지 않음). 본문은 상한으로 자른다 — 도구 결과 전문이 두 번 저장되는 것 방지. */
+    record(stepType: SubagentStepType, content: string, toolName?: string): void {
+        if (!AGENT_TASK_LIMITS.SUBAGENT_TRACE_ENABLED) return;
+        const cap = AGENT_TASK_LIMITS.SUBAGENT_TRACE_CONTENT_CAP;
+        const text = content.length > cap ? `${content.slice(0, cap)}\n...[${content.length}자 중 앞부분]` : content;
+        const seq = this.seq++;
+        void this.repo.add({
+            task_id: this.taskId, trace_id: this.traceId, origin: this.origin, sub_index: this.subIndex,
+            label: this.label, seq, step_type: stepType, tool_name: toolName ?? null, content: text,
+        }).catch((e) => logger.warn(`서브에이전트 스텝 기록 실패 (${this.taskId}/${this.subIndex}#${seq}): ${e instanceof Error ? e.message : e}`));
+    }
+}

--- a/apps/api/src/services/agent-task/subagent.ts
+++ b/apps/api/src/services/agent-task/subagent.ts
@@ -23,6 +23,7 @@ import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
 import { requiresApproval, getApprovalRegistry } from '../task-sandbox/approval-gate';
 import { runTool } from './task-steps';
 import { prefetchReadOnlyCalls } from '../tool-parallel';
+import type { SubagentTrace } from './subagent-trace';
 import { createLogger } from '../../utils/logger';
 import { buildSubagentDelegationRules, SUBAGENT_FINAL_TURN_NOTICE } from '../../prompts/subagent-system';
 
@@ -51,6 +52,8 @@ export interface SubagentParams {
     onTokens?: (n: number) => void;
     /** 승인 대기 시간을 부모 pausedMs 에 합산(4-1 pause-aware 일관). */
     onPausedMs?: (ms: number) => void;
+    /** 활동 기록(109) — 에이전트 작업 경로만 넘긴다. 채팅 경로는 작업 행이 없어 무기록. */
+    trace?: SubagentTrace;
 }
 
 /**
@@ -88,6 +91,7 @@ export async function runSubagent(p: SubagentParams): Promise<string> {
             p.onTokens?.(used);
             if (tokens > AGENT_TASK_LIMITS.SUBAGENT_MAX_TOKENS) {
                 logger.warn(`[Subagent] 토큰 상한 초과 — 조기 종료 (${tokens})`);
+                p.trace?.record('final', `[토큰 상한 ${tokens}] ${result.content || '(부분 결과 없음)'}`);
                 return result.content || '(서브에이전트 토큰 상한 도달 — 부분 결과 없음)';
             }
 
@@ -98,7 +102,11 @@ export async function runSubagent(p: SubagentParams): Promise<string> {
             });
             if (!result.tool_calls || result.tool_calls.length === 0) {
                 const finalText = stripRawToolCallXml(result.content || '');
+                p.trace?.record('final', finalText || '(빈 응답)');
                 return finalText || '(서브에이전트가 빈 응답을 반환했습니다)';
+            }
+            for (const tc of result.tool_calls) {
+                p.trace?.record('tool_call', JSON.stringify(tc.function.arguments ?? {}), tc.function.name);
             }
 
             // 읽기 전용 도구 병렬 선실행 — 승인 필요 호출은 자동 승인 작업에서만(부모 루프와 같은 규칙).
@@ -126,6 +134,7 @@ export async function runSubagent(p: SubagentParams): Promise<string> {
                 const args = (tc.function.arguments ?? {}) as Record<string, unknown>;
                 const pre = tc.id !== undefined ? prefetched.get(tc.id) : undefined;
                 if (pre !== undefined) {
+                    p.trace?.record('tool_result', pre, name);
                     conversation.push({ role: 'tool', content: pre, tool_name: name, tool_call_id: tc.id });
                     continue;
                 }
@@ -142,14 +151,18 @@ export async function runSubagent(p: SubagentParams): Promise<string> {
                 const toolResult = approved
                     ? await runTool(mcp, name, args, p.userCtx)
                     : `Error: 사용자가 도구 실행을 승인하지 않았습니다 (${name}).`;
+                p.trace?.record('tool_result', toolResult, name);
                 conversation.push({ role: 'tool', content: toolResult, tool_name: name, tool_call_id: tc.id });
             }
         }
         // 턴 소진 — 마지막 assistant 내용 반환.
         const last = [...conversation].reverse().find((m) => m.role === 'assistant');
-        return stripRawToolCallXml((last?.content as string) || '') || '(서브에이전트가 턴 상한에 도달했습니다)';
+        const exhausted = stripRawToolCallXml((last?.content as string) || '') || '(서브에이전트가 턴 상한에 도달했습니다)';
+        p.trace?.record('final', `[턴 상한 도달] ${exhausted}`);
+        return exhausted;
     } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
+        p.trace?.record('error', msg);
         logger.warn(`[Subagent] 실행 실패: ${msg}`);
         return `Error: 서브에이전트 실행 실패 — ${msg}`;
     }

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -13,6 +13,7 @@
  * @module services/chat-service/external-provider
  */
 import { createLogger } from '../../utils/logger';
+import { SPAWN_AGENTS_TOOL_NAME } from '../agent-spawn/spawn-agents';
 import { LOOP_DETECTION, AGENT_LOOP_LIMITS, MAP_INTENT_PATTERNS, SPAWN_INTENT_PATTERNS, EXTERNAL_LLM_INPUT_TOKEN_BUDGET } from '../../config/runtime-limits';
 import { estimateMessageTokens, truncateMessagesPreservingSystem } from '../../llm/model-pool';
 import { AGENT_SPAWN } from '../../config/runtime-limits';
@@ -134,11 +135,15 @@ export async function runExternalStream(
         ...(deps.skillRequiredToolNames ? { skillRequiredToolNames: deps.skillRequiredToolNames } : {}),
     });
     // Stage 2 셰도우 계측 — 의도 매칭 턴만 텔레메트리를 초기화(호출 시 아래 루프가 갱신).
-    if (orchestration.discussion || orchestration.taskDelegate) {
+    // 병렬 위임(spawn) 의도 턴도 적재 — 노출→채택률을 재야 설명문·가이드 조정의 효과를 안다(110).
+    if (orchestration.discussion || orchestration.taskDelegate || wantsSpawn) {
         ctx.orchestrationTelemetry = {
             discussionIntent: orchestration.discussion,
             taskDelegateIntent: orchestration.taskDelegate,
-            exposed: tools.filter((t) => isOrchestrationTool(t.function.name)).map((t) => t.function.name),
+            spawnIntent: wantsSpawn,
+            exposed: tools
+                .filter((t) => isOrchestrationTool(t.function.name) || t.function.name === SPAWN_AGENTS_TOOL_NAME)
+                .map((t) => t.function.name),
         };
     }
 

--- a/apps/api/src/services/chat-service/external-tool-batch.ts
+++ b/apps/api/src/services/chat-service/external-tool-batch.ts
@@ -151,6 +151,11 @@ export async function runToolCallBatch(params: {
                     userCtx: deps.currentUserContext ?? { userId: 'guest', role: 'guest' },
                     ...(req.abortSignal ? { signal: req.abortSignal } : {}),
                 });
+            // 셰도우 계측(110) — 이 턴에서 처음 호출된 오케스트레이션류 도구로 기록.
+            if (ctx.orchestrationTelemetry && !ctx.orchestrationTelemetry.called) {
+                ctx.orchestrationTelemetry.called = tc.name;
+                ctx.orchestrationTelemetry.success = !toolResult.startsWith('Error');
+            }
         } else if (isOrchestrationTool(tc.name)) {
             // 오케스트레이션 자동 배정 — 토론 인라인 실행 / 백그라운드 작업 위임.
             deps.mcpToolStartCallback?.({ toolName: tc.name });

--- a/apps/api/src/services/chat-service/orchestration-shadow-recorder.ts
+++ b/apps/api/src/services/chat-service/orchestration-shadow-recorder.ts
@@ -19,6 +19,8 @@ const logger = createLogger('OrchestrationShadow');
 export interface OrchestrationTelemetry {
     discussionIntent: boolean;
     taskDelegateIntent: boolean;
+    /** 병렬 위임 의도(SPAWN_INTENT_PATTERNS) — 110. 미지정=false(토글 셰도우 등). */
+    spawnIntent?: boolean;
     /** 이 턴에 노출된 오케스트레이션 도구 이름들 (미노출 = 빈 배열) */
     exposed: string[];
     /** 모델이 실제 호출한 도구 (미호출 = undefined — 모델 재량 직접 답변) */
@@ -60,8 +62,8 @@ export function recordOrchestrationDispatch(params: {
             await pool.query(
                 `INSERT INTO orchestration_dispatch_decisions
                    (request_id, user_id, query_length, discussion_intent, task_delegate_intent,
-                    tools_exposed, tool_called, tool_success, user_mode, query_preview)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+                    tools_exposed, tool_called, tool_success, user_mode, query_preview, spawn_intent)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
                 [
                     requestId ?? null,
                     userId && userId !== 'guest' ? userId : null,
@@ -73,6 +75,7 @@ export function recordOrchestrationDispatch(params: {
                     telemetry.success ?? null,
                     userMode,
                     preview,
+                    telemetry.spawnIntent ?? false,
                 ],
             );
         } catch (e) {

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -52,6 +52,15 @@ export interface ShareState {
     path: string;
 }
 
+export interface SubagentTraceView {
+    traceId: string;
+    origin: string;
+    subIndex: number;
+    label: string | null;
+    startedAt: string;
+    steps: { seq: number; type: string; tool: string | null; content: string | null; at: string }[];
+}
+
 export interface PendingApproval {
     approvalId: string;
     taskId: string;
@@ -102,6 +111,10 @@ export class ApiClient {
     /** 작업 스텝(진행 기록) — show 가 요약·diff·판정을 뽑는 원본. */
     listSteps(taskId: string): Promise<{ steps: ApiTaskStep[]; total: number }> {
         return this.req('GET', `/api/agent-tasks/${taskId}/steps`);
+    }
+    /** 서브에이전트 활동(109) — delegate/spawn 서브가 실제로 한 일. 없으면 빈 목록. */
+    listSubagents(taskId: string): Promise<{ traces: SubagentTraceView[] }> {
+        return this.req('GET', `/api/agent-tasks/${taskId}/subagents`);
     }
     /** checkpoint 재개 — 서버가 상태·checkpoint·디바이스 연결을 검증한다(실패 사유는 400 메시지). */
     resumeTask(taskId: string): Promise<{ message?: string; queued?: boolean }> {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -284,6 +284,19 @@ async function cmdShow(taskId: string, opts: { steps: boolean; diff: boolean }):
         console.log('\n\x1b[1m진행 기록\x1b[0m');
         const lines = steps.map(stepLine).filter((l): l is string => l !== null);
         console.log(lines.length ? lines.join('\n') : '  (표시할 기록 없음)');
+        // 서브에이전트 활동(109) — 부모 기록엔 결과만 남으므로 따로 보여준다.
+        const { traces } = await api.listSubagents(taskId).catch(() => ({ traces: [] as import('./api').SubagentTraceView[] }));
+        if (traces.length) {
+            console.log(`\n\x1b[1m서브에이전트 활동\x1b[0m (${traces.length}건)`);
+            for (const tr of traces) {
+                const head = tr.origin === 'spawn_agents' ? `병렬 서브 #${tr.subIndex + 1}` : '전문가 위임';
+                console.log(`  \x1b[36m${head}\x1b[0m${tr.label ? ` · ${tr.label}` : ''} (${tr.steps.length}단계)`);
+                for (const st of tr.steps) {
+                    const tone = st.type === 'error' ? '\x1b[31m' : st.type === 'final' ? '\x1b[32m' : '\x1b[2m';
+                    console.log(`    ${tone}${st.tool ?? st.type}\x1b[0m: ${(st.content ?? '').replace(/\s+/g, ' ').slice(0, 120)}`);
+                }
+            }
+        }
     }
     if (opts.diff) {
         console.log('\n\x1b[1m변경분\x1b[0m');

--- a/apps/web/app/(workspace)/admin/metrics/page.tsx
+++ b/apps/web/app/(workspace)/admin/metrics/page.tsx
@@ -120,6 +120,10 @@ interface RoutingGatesData {
     successTurns: number;
     callRate: number;
     successRate: number;
+    /** 병렬 위임 채택률(110) */
+    spawnIntentTurns?: number;
+    spawnCalledTurns?: number;
+    spawnAdoptionRate?: number;
     byTool: { tool: string; turns: number; successTurns: number }[];
     toggles: {
       userMode: string;
@@ -491,7 +495,7 @@ export default function AdminMetricsPage() {
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+              <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
                 <StatCard
                   label={t("routing.callRate")}
                   value={`${(routingGates.orchestration.callRate * 100).toFixed(1)}%`}
@@ -506,6 +510,14 @@ export default function AdminMetricsPage() {
                   delta={t("routing.ofCalled", {
                     success: routingGates.orchestration.successTurns.toLocaleString(),
                     called: routingGates.orchestration.calledTurns.toLocaleString(),
+                  })}
+                />
+                <StatCard
+                  label={t("routing.spawnAdoption")}
+                  value={`${((routingGates.orchestration.spawnAdoptionRate ?? 0) * 100).toFixed(1)}%`}
+                  delta={t("routing.ofSpawnIntent", {
+                    called: (routingGates.orchestration.spawnCalledTurns ?? 0).toLocaleString(),
+                    intent: (routingGates.orchestration.spawnIntentTurns ?? 0).toLocaleString(),
                   })}
                 />
                 <StatCard

--- a/apps/web/app/(workspace)/agent-tasks/page.tsx
+++ b/apps/web/app/(workspace)/agent-tasks/page.tsx
@@ -120,6 +120,16 @@ interface ApiTaskStep {
 
 type AgentTasksResponse = ApiSuccess<{ tasks: ApiAgentTask[]; total: number }>;
 type AgentTaskDetailResponse = ApiSuccess<{ task: ApiAgentTask; steps: ApiTaskStep[] }>;
+/** 서브에이전트 활동(109) — delegate/spawn 서브 1개 = trace 1개 */
+interface SubagentTraceView {
+  traceId: string;
+  origin: string;
+  subIndex: number;
+  label: string | null;
+  startedAt: string;
+  steps: { seq: number; type: string; tool: string | null; content: string | null; at: string }[];
+}
+type SubagentsResponse = ApiSuccess<{ traces: SubagentTraceView[] }>;
 
 /* ── 유틸 ────────────────────────────────────────────────── */
 function mapStatus(s: ApiTaskStatus): TaskStatus {
@@ -258,6 +268,7 @@ function TaskDetailModal({
   const t = useTranslations("agentTasks");
   const [detail, setDetail] = useState<{ task: ApiAgentTask; steps: ApiTaskStep[] } | null>(null);
   const [files, setFiles] = useState<string[]>([]);
+  const [subagents, setSubagents] = useState<SubagentTraceView[]>([]);
   const [loading, setLoading] = useState(true);
 
   // 라이브 폴링: 실행 중(running/paused)이면 주기적으로 갱신 — "컴퓨터" 패널 실시간성.
@@ -270,6 +281,11 @@ function TaskDetailModal({
         if (cancelled) return;
         setDetail(res?.data ?? null);
         const st = res?.data?.task?.status;
+        // 서브에이전트 활동(109) — 위임/fan-out 이 있던 작업만 값이 있다. 실패는 빈 목록.
+        try {
+          const sa = await ApiClient.get<SubagentsResponse>(`/api/agent-tasks/${taskId}/subagents`);
+          if (!cancelled) setSubagents(sa?.data?.traces ?? []);
+        } catch { /* ignore */ }
         // 완료 task 의 산출물 파일 목록(보존된 workspace).
         if (st === "completed") {
           try {
@@ -399,6 +415,34 @@ function TaskDetailModal({
                   </li>
                 ))}
               </ul>
+            </div>
+          )}
+
+          {/* 서브에이전트 활동(109) — delegate/spawn 서브가 실제로 무엇을 했는지. 부모 스텝에는 결과만 남는다. */}
+          {subagents.length > 0 && (
+            <div className="rounded-md border border-border bg-surface-1 p-3">
+              <p className="mb-2 text-xs font-medium text-fg-2">{t("subagents.title", { count: subagents.length })}</p>
+              <div className="max-h-72 space-y-3 overflow-y-auto pr-1">
+                {subagents.map((tr) => (
+                  <div key={`${tr.traceId}:${tr.subIndex}`} className="space-y-1">
+                    <div className="flex flex-wrap items-center gap-2 text-xs">
+                      <Badge tone="accent">{tr.origin === "spawn_agents" ? t("subagents.originSpawn", { n: tr.subIndex + 1 }) : t("subagents.originDelegate")}</Badge>
+                      {tr.label && <span className="text-muted">{tr.label}</span>}
+                      <span className="text-faint">{t("subagents.stepCount", { count: tr.steps.length })}</span>
+                    </div>
+                    <ul className="space-y-0.5 pl-2">
+                      {tr.steps.map((st) => (
+                        <li key={st.seq} className="flex gap-2 text-[11px]">
+                          <span className={cn("shrink-0 font-mono", st.type === "error" ? "text-danger" : st.type === "final" ? "text-success" : "text-faint")}>
+                            {st.tool ?? st.type}
+                          </span>
+                          <span className="min-w-0 flex-1 truncate text-muted" title={st.content ?? ""}>{st.content}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
             </div>
           )}
 

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -820,6 +820,12 @@
       "includeArtifacts": "Include outputs",
       "artifactLabel": "Output:",
       "bodyOmitted": "body excluded"
+    },
+    "subagents": {
+      "title": "Sub-agent activity ({count})",
+      "originSpawn": "Parallel sub #{n}",
+      "originDelegate": "Expert delegate",
+      "stepCount": "{count} steps"
     }
   },
   "customAgents": {
@@ -1360,7 +1366,9 @@
         "turns": "Turns",
         "discussionHits": "Discussion Intent Hits",
         "delegateHits": "Delegate Intent Hits"
-      }
+      },
+      "spawnAdoption": "Parallel delegation adoption",
+      "ofSpawnIntent": "{called} of {intent} intent turns called it"
     },
     "noNodes": "No cluster nodes reported."
   },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -820,6 +820,12 @@
       "includeArtifacts": "成果物を含める",
       "artifactLabel": "成果物:",
       "bodyOmitted": "本文は除外"
+    },
+    "subagents": {
+      "title": "サブエージェント活動 {count}件",
+      "originSpawn": "並列サブ #{n}",
+      "originDelegate": "専門家委任",
+      "stepCount": "{count}ステップ"
     }
   },
   "customAgents": {
@@ -1360,7 +1366,9 @@
         "turns": "ターン数",
         "discussionHits": "討論意図の的中",
         "delegateHits": "委任意図の的中"
-      }
+      },
+      "spawnAdoption": "並列委任の採用率",
+      "ofSpawnIntent": "意図一致 {intent}ターン中 {called}ターンで呼び出し"
     },
     "noNodes": "報告されたクラスタノードはありません。"
   },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -820,6 +820,12 @@
       "includeArtifacts": "산출물 포함",
       "artifactLabel": "산출물:",
       "bodyOmitted": "본문 제외"
+    },
+    "subagents": {
+      "title": "서브에이전트 활동 {count}건",
+      "originSpawn": "병렬 서브 #{n}",
+      "originDelegate": "전문가 위임",
+      "stepCount": "{count}단계"
     }
   },
   "customAgents": {
@@ -1360,7 +1366,9 @@
         "turns": "턴 수",
         "discussionHits": "토론 의도 적중",
         "delegateHits": "위임 의도 적중"
-      }
+      },
+      "spawnAdoption": "병렬 위임 채택률",
+      "ofSpawnIntent": "의도 매칭 {intent}턴 중 {called}턴 호출"
     },
     "noNodes": "보고된 클러스터 노드가 없습니다."
   },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -820,6 +820,12 @@
       "includeArtifacts": "包含产出物",
       "artifactLabel": "产出物:",
       "bodyOmitted": "不含正文"
+    },
+    "subagents": {
+      "title": "子代理活动 {count} 条",
+      "originSpawn": "并行子代理 #{n}",
+      "originDelegate": "专家委托",
+      "stepCount": "{count} 步"
     }
   },
   "customAgents": {
@@ -1360,7 +1366,9 @@
         "turns": "轮次数",
         "discussionHits": "讨论意图命中",
         "delegateHits": "委派意图命中"
-      }
+      },
+      "spawnAdoption": "并行委托采用率",
+      "ofSpawnIntent": "{intent} 个意图轮次中 {called} 个调用"
     },
     "noNodes": "没有上报的集群节点。"
   },

--- a/db/migrations/109_agent_task_subagent_steps.sql
+++ b/db/migrations/109_agent_task_subagent_steps.sql
@@ -1,0 +1,29 @@
+-- Migration 109 — 서브에이전트 활동 기록 (2026-08-26)
+--
+-- delegate / spawn_agents 로 만들어진 서브에이전트는 부모 작업의 한 턴 안에서 도는 프로세스 내
+-- 루프라 agent_task_steps 에 아무것도 남지 않았다(fan-out 이 스텝 1개로 뭉쳐 보이고, 서브가 뭘
+-- 검색했는지·어디서 실패했는지는 로그에만). 역대 유일한 spawn 실패(2026-08-02)가 원인 추적
+-- 불가였던 이유이자, 2026-08-26 "도구 0개로 답 날조" 결함이 오래 안 보였던 이유다.
+--
+-- 별도 테이블인 이유: agent_task_steps 는 (task_id, step_number) UNIQUE 로 부모 루프가 번호를
+-- 순차 배정한다. 서브는 부모 턴 도중에 여러 개가 동시에 돌므로 그 번호 공간에 끼워 넣을 수 없다.
+-- trace_id = 위임/fan-out 1회, sub_index = fan-out 안의 몇 번째 서브, seq = 서브 안 순서.
+--
+-- 멱등 (IF NOT EXISTS).
+
+CREATE TABLE IF NOT EXISTS agent_task_subagent_steps (
+    id          BIGSERIAL PRIMARY KEY,
+    task_id     TEXT NOT NULL REFERENCES agent_tasks(id) ON DELETE CASCADE,
+    trace_id    TEXT NOT NULL,
+    origin      TEXT NOT NULL,            -- 'spawn_agents' | 'delegate'
+    sub_index   INTEGER NOT NULL DEFAULT 0,
+    label       TEXT,                     -- role / 페르소나 요약
+    seq         INTEGER NOT NULL,
+    step_type   TEXT NOT NULL,            -- 'tool_call' | 'tool_result' | 'final' | 'error'
+    tool_name   TEXT,
+    content     TEXT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_task_subagent_steps_task
+    ON agent_task_subagent_steps (task_id, created_at);

--- a/db/migrations/110_orchestration_spawn_intent.sql
+++ b/db/migrations/110_orchestration_spawn_intent.sql
@@ -1,0 +1,10 @@
+-- Migration 110 — 오케스트레이션 셰도우에 병렬 위임(spawn_agents) 의도 열 추가 (2026-08-26)
+--
+-- 086 은 토론·작업 위임 의도만 기록해 spawn_agents 의 노출→채택률을 잴 지표가 없었다
+-- (실측: 자연어 "각각 조사해서" 에 qwen 이 직접 검색을 택해도 어디에도 남지 않음).
+-- 설명문·가이드 조정의 효과는 이 열로 잰다.
+--
+-- 멱등 (IF NOT EXISTS).
+
+ALTER TABLE orchestration_dispatch_decisions
+    ADD COLUMN IF NOT EXISTS spawn_intent BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
남은 항목 2·3 — 둘 다 "무슨 일이 있었는지 알 수 없어서 결함이 오래 숨었던" 관측 공백이다.

## 3. 서브에이전트 활동 기록 (마이그레이션 109)

delegate/spawn 서브에이전트는 부모 턴 안에서 도는 프로세스 내 루프라 **어디에도 남지 않았다**. fan-out 이 스텝 1개로 뭉쳐 보이고 서브가 뭘 검색했는지·어디서 실패했는지는 로그뿐 — 역대 유일한 spawn 실패(08-02)를 추적 못 한 이유이자, "도구 0개로 답 날조"(#645)가 오래 안 보였던 이유.

| | |
|---|---|
| 저장 | 별도 테이블 `agent_task_subagent_steps`. `agent_task_steps` 는 (task_id, step_number) UNIQUE 로 부모가 번호를 순차 배정하는데, 서브는 부모 턴 도중 여러 개가 **동시에** 돌아 그 번호 공간에 끼울 수 없다. `trace_id`(위임/fan-out 1회) · `sub_index` · `seq` |
| 기록 | `SubagentTrace.record()` fire-and-forget(fail-open, 실패는 warn). 본문 2000자 캡. 채팅 경로(작업 행 없음)는 무기록 |
| 노출 | `GET /api/agent-tasks/:id/subagents`(JWT·bridge key) · 웹 상세 모달 "서브에이전트 활동" · CLI `show --steps` |

라이브(sandbox, spawn 2건): 서브별 `web_search` 검색어 → 결과 → 최종답 5단계씩 API·웹·CLI 에 동일 표시.

## 2. 병렬 위임 채택률 셰도우 (마이그레이션 110) + 설명문

셰도우 테이블은 토론·작업위임 의도만 기록해 spawn 의 **노출→채택률을 잴 지표가 없었다**. `spawn_intent` 열 + 의도 턴 텔레메트리 + spawn 호출 기록 + 관리자 지표 타일.

도구 설명문을 "⚠️ 쓰지 마세요"로 시작하던 것에서 "언제 쓰는지"를 먼저 말하도록 바꿨다. 자연어 6문항(도구명·'검색' 단어 없음, qwen) 실측:

| | 채택 |
|---|---|
| 옛 설명문 | **0 / 6** |
| 새 설명문 | **1 / 6** |

n=6 라 유의를 주장하지 않는다 — 그래서 셰도우 지표를 붙였고 실트래픽에서 잰다. 부수 관찰: 비관련 도구(`agent_task_get` 연타, `load_skill`)로 새는 턴이 있다 — 도구 34종 노출의 distractor 비용, 별도 주제.

단위: 그룹핑 3건·spawn trace 배선 1건 신규, 관련 스위트 119건 통과. `.env.example` 갱신.