### PR TITLE
refactor(web): 채팅 모드 메뉴에서 자동 발동 토글 4개 제거 (웹·이미지·아티팩트·구조화 답변)

### DIFF
--- a/apps/web/app/shared/task/[shareId]/viewer.tsx
+++ b/apps/web/app/shared/task/[shareId]/viewer.tsx
@@ -39,8 +39,9 @@ export function SharedTaskViewer({ shareId, token }: { shareId: string; token: s
       const res = await openSharedArtifact(shareId, index, token);
       const url = res?.data?.url;
       if (!url) throw new Error("no url");
-      if (tab) tab.location.href = url;
-      else window.location.href = url;
+      // React Compiler 린트: window.open 결과의 프로퍼티 대입을 "불변 값 수정"으로 잡는다 — 메서드 호출로.
+      if (tab) tab.location.assign(url);
+      else window.location.assign(url);
     } catch {
       tab?.close();
     } finally {

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -4,15 +4,11 @@ import { useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   ArrowUp,
-  Globe,
   MessagesSquare,
   Sparkles,
   Square,
   Telescope,
   Brain,
-  Image as ImageIcon,
-  FileCode2,
-  LayoutList,
   SlidersHorizontal,
   Check,
   Paperclip,
@@ -100,7 +96,7 @@ function readFileBase64(file: File): Promise<string> {
 export function Composer() {
   const t = useTranslations("composer");
   const tSettings = useTranslations("settings");
-  const { sendChat, abort, startAgentTask, sendStructured } = useChatSocket();
+  const { sendChat, abort, startAgentTask } = useChatSocket();
   const router = useRouter();
   const [text, setText] = useState("");
   const [files, setFiles] = useState<AttachedFileUI[]>([]);
@@ -200,15 +196,11 @@ export function Composer() {
     thinkingEnabled,
     discussionMode,
     deepResearchMode,
-    webSearchEnabled,
     agentTaskMode,
     agentApprovalMode,
     agentLocalExecutor,
     agentLocalDeviceId,
     agentLocalFolderRel,
-    imageMode,
-    artifactMode,
-    structuredMode,
     selectedModel,
     style,
     thinkingLevel,
@@ -370,11 +362,8 @@ export function Composer() {
         agentLocalExecutor ? (selectedBridgeDevice?.deviceId ?? null) : null,
         agentLocalExecutor ? agentLocalFolderRel : null,
       );
-    } else if (structuredMode) {
-      // 구조화 답변 토글 ON — REST /api/chat/structured (비스트리밍, 카드 렌더). 첨부는 미지원.
-      void sendStructured(text.trim());
     } else if (
-      !discussionMode && !deepResearchMode && !imageMode &&
+      !discussionMode && !deepResearchMode &&
       files.length > 0 && detectFileTaskIntent(text) && !detectPresentationChatIntent(text)
     ) {
       // 발표자료 제작 요청은 위임하지 않고 채팅 유지 — presentation-designer 스킬
@@ -394,7 +383,7 @@ export function Composer() {
         delegationApproval,
       );
     } else if (
-      !discussionMode && !deepResearchMode && !imageMode &&
+      !discussionMode && !deepResearchMode &&
       files.length === 0 && images.length === 0 && detectReportTaskIntent(text)
     ) {
       // 조사형 보고서 자동 위임(P1 Phase 2) — "X를 조사해서 보고서로" 류 self-contained
@@ -405,8 +394,8 @@ export function Composer() {
       void startAgentTask(text.trim(), undefined, undefined, reportApproval);
     } else {
       // NotebookLM 컨텍스트 — grounding 프리픽스는 백엔드(prompts/notebook-context)가 주입.
-      // 가로채기 모드(토론/딥리서치/이미지)는 도구를 우회하므로 미전송 — 칩은 흐림 표시로 안내.
-      const nbApplies = !discussionMode && !deepResearchMode && !imageMode;
+      // 가로채기 모드(토론/딥리서치)는 도구를 우회하므로 미전송 — 칩은 흐림 표시로 안내.
+      const nbApplies = !discussionMode && !deepResearchMode;
       sendChat(
         text.trim(),
         images.length ? images.map((i) => i.dataUrl) : undefined,
@@ -448,11 +437,7 @@ export function Composer() {
     { key: "thinkingEnabled" as const, on: thinkingEnabled, icon: Brain, label: t("toggle.thinking") },
     { key: "answerVerification" as const, on: answerVerification, icon: ShieldCheck, label: t("toggle.verification") },
     { key: "deepResearchMode" as const, on: deepResearchMode, icon: Telescope, label: t("toggle.deepResearch") },
-    { key: "webSearchEnabled" as const, on: webSearchEnabled, icon: Globe, label: t("toggle.web") },
     { key: "agentTaskMode" as const, on: agentTaskMode, icon: Sparkles, label: t("toggle.agent") },
-    { key: "imageMode" as const, on: imageMode, icon: ImageIcon, label: t("toggle.image") },
-    { key: "artifactMode" as const, on: artifactMode, icon: FileCode2, label: t("toggle.artifact") },
-    { key: "structuredMode" as const, on: structuredMode, icon: LayoutList, label: t("toggle.structured") },
   ];
   const activeModeCount = TOGGLES.filter((m) => m.on).length;
 
@@ -463,9 +448,10 @@ export function Composer() {
     { v: "none" as const, label: t("approvalMode.skip"), hint: t("approvalMode.skipHint") },
   ];
 
-  // 가로채기(bypass) 모드: 켜지면 백엔드가 웹·아티팩트 modifier 를 무시(전용 파이프라인).
+  // 가로채기(bypass) 모드: 켜지면 백엔드가 전용 파이프라인을 타며 일반 도구·아티팩트를 무시.
+  // (2026-08-27: 웹·이미지·아티팩트·구조화 답변 토글은 제거 — 모델이 질의에 따라 자동으로
+  //  web_search·generate_image·<artifact>·구조 가드를 쓰므로 수동 토글이 이중이었다.)
   const INTERCEPT_KEYS = new Set<string>(INTERCEPT_MODE_KEYS);
-  const MODIFIER_KEYS = new Set<string>(["webSearchEnabled", "artifactMode"]);
   const interceptActive = TOGGLES.some((m) => m.on && INTERCEPT_KEYS.has(m.key));
 
   // 외부 provider 모델 판별 — 모델 목록의 provider 필드가 SoT('local-llm' 이 로컬).
@@ -526,26 +512,20 @@ export function Composer() {
               </p>
               {TOGGLES.map((m) => {
                 const isIntercept = INTERCEPT_KEYS.has(m.key);
-                // 가로채기 모드가 켜져 있으면 웹·아티팩트 modifier 는 무시되므로 흐리게 + "(미적용)".
-                const suppressed = interceptActive && MODIFIER_KEYS.has(m.key);
                 const onColor = isIntercept ? "text-warn" : "text-accent";
                 return (
                   <button
                     key={m.key}
                     type="button"
                     onClick={() => toggle(m.key)}
-                    title={suppressed ? t("modifierSuppressed", { label: m.label }) : undefined}
                     className={cn(
                       "flex min-h-[44px] w-full items-center gap-3 rounded-lg px-3 text-sm transition",
-                      m.on ? onColor : suppressed ? "text-faint" : "text-fg-2 hover:bg-surface-3",
+                      m.on ? onColor : "text-fg-2 hover:bg-surface-3",
                     )}
                   >
                     <m.icon className="h-[18px] w-[18px] shrink-0" />
                     <span className="flex-1 text-left">
                       {m.label}
-                      {suppressed && (
-                        <span className="ml-1.5 text-[11px] text-faint">{t("suppressedTag")}</span>
-                      )}
                     </span>
                     {m.on && <Check className={cn("h-4 w-4 shrink-0", onColor)} />}
                   </button>
@@ -606,7 +586,7 @@ export function Composer() {
             onChange={setNotebook}
             open={notebookPickerOpen}
             onOpenChange={setNotebookPickerOpen}
-            suppressed={interceptActive || agentTaskMode || structuredMode}
+            suppressed={interceptActive || agentTaskMode}
           />
 
           {TOGGLES.filter((m) => m.on).map((m) => {

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -180,7 +180,6 @@ interface AppState {
   answerVerification: boolean;
   discussionMode: boolean;
   deepResearchMode: boolean;
-  webSearchEnabled: boolean;
   agentTaskMode: boolean;
   /** 에이전트 작업 승인 3모드 — all=Manual(전부 승인·기본)·high-risk=Auto(고위험만)·none=Skip(전부 자동). */
   agentApprovalMode: "all" | "high-risk" | "none";
@@ -191,10 +190,6 @@ interface AppState {
   agentLocalDeviceId: string | null;
   /** 폴더 선택(102): 로컬 실행 폴더 — 연결 루트 기준 상대경로. null 은 루트. */
   agentLocalFolderRel: string | null;
-  imageMode: boolean;
-  artifactMode: boolean;
-  /** 구조화 답변 모드 — ON 시 메시지를 REST /api/chat/structured 로 보내 카드 UI 로 렌더(비스트리밍). */
-  structuredMode: boolean;
   mcpToolsEnabled: Record<string, boolean>;
 
   // 개인정보 설정 (설정 페이지 · 서버 preferences 영속) — 채팅 WS 메시지로 전송돼 백엔드가 존중.
@@ -252,11 +247,7 @@ interface AppState {
       | "answerVerification"
       | "discussionMode"
       | "deepResearchMode"
-      | "webSearchEnabled"
-      | "agentTaskMode"
-      | "imageMode"
-      | "artifactMode"
-      | "structuredMode",
+      | "agentTaskMode",
   ) => void;
   setSelectedModel: (m: string) => void;
   setAgentApprovalMode: (m: "all" | "high-risk" | "none") => void;
@@ -283,9 +274,7 @@ const THINKING_LEVEL_ORDER: ThinkingLevel[] = ["low", "medium", "high"];
 export const PRIMARY_MODE_KEYS = [
   "discussionMode",
   "deepResearchMode",
-  "imageMode",
   "agentTaskMode",
-  "structuredMode",
 ] as const;
 
 /**
@@ -295,7 +284,6 @@ export const PRIMARY_MODE_KEYS = [
 export const INTERCEPT_MODE_KEYS = [
   "discussionMode",
   "deepResearchMode",
-  "imageMode",
 ] as const;
 
 /** SSR(서버 평가) 시 localStorage 부재로 인한 ReferenceError 방지 — 클라에서만 실제 저장소 사용. */
@@ -330,15 +318,11 @@ export const useAppStore = create<AppState>()(
   answerVerification: false,
   discussionMode: false,
   deepResearchMode: false,
-  webSearchEnabled: false,
   agentTaskMode: false,
   agentApprovalMode: "all",
   agentLocalExecutor: false,
   agentLocalDeviceId: null,
   agentLocalFolderRel: null,
-  imageMode: false,
-  artifactMode: false,
-  structuredMode: false,
   mcpToolsEnabled: {},
 
   saveHistory: true,
@@ -505,7 +489,7 @@ export const useAppStore = create<AppState>()(
     set((s) => {
       const next = !s[key];
       // primary 모드를 켤 때만 나머지 primary 모드를 자동 off (상호배타).
-      // 끄는 경우·비-primary(thinking·web·artifact) 토글은 단순 flip.
+      // 끄는 경우·비-primary(thinking·답변 검증) 토글은 단순 flip.
       if (next && (PRIMARY_MODE_KEYS as readonly string[]).includes(key)) {
         const cleared: Record<string, boolean> = {};
         for (const k of PRIMARY_MODE_KEYS) {

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import type { WsChatRequest, WsServerEvent, WsAttachedFile } from "@openmake/shared-types";
-import { useAppStore, type StructuredAnswerData, type PendingApproval, type AgentTaskState } from "./store";
+import { useAppStore, type PendingApproval, type AgentTaskState } from "./store";
 import { ApiClient, csrfHeaders } from "./api-client";
 
 import { gaEvent, GA_EVENTS } from "./analytics";
@@ -115,7 +115,6 @@ export function useChatSocket() {
   const connectRef = useRef<() => void>(() => {});
   // 에이전트 작업 taskId → 목표(goal) — agent_task_progress 렌더에 사용
   // 구조화 답변(REST) 진행 중 AbortController — abort() 가 취소할 수 있게 보관
-  const structuredAbortRef = useRef<AbortController | null>(null);
   // token_warning 갱신이 스트리밍 중 도착하면 스트림 종료 후 재연결하기 위한 예약 플래그.
   const reconnectAfterRefreshRef = useRef(false);
   // MCP 도구 결과 resource — 스트리밍 중 append 하면 응답이 조각나므로(appendToken 이 카드를
@@ -529,7 +528,6 @@ export function useChatSocket() {
         images: images ?? [],
         // rawFile(브라우저 File)은 WS 직렬화 불가 — 계약 필드만 전송
         files: (files ?? []).map(toWireFile),
-        webSearch: s.webSearchEnabled,
         deepResearchMode: s.deepResearchMode,
         discussionMode: s.discussionMode,
         thinkingMode: s.thinkingEnabled,
@@ -537,8 +535,6 @@ export function useChatSocket() {
         ...(s.thinkingEnabled ? { thinkingLevel: s.thinkingLevel } : {}),
         // 답변 검증 — 켠 경우에만 요청(서버도 ANSWER_VERIFICATION_ENABLED 로 게이트).
         ...(s.answerVerification ? { verifyAnswer: true } : {}),
-        imageMode: s.imageMode,
-        artifactMode: s.artifactMode,
         style: s.style,
         enabledTools: s.mcpToolsEnabled,
         // NotebookLM 컨텍스트 — grounding 프리픽스 주입은 백엔드(prompts/notebook-context) 담당
@@ -553,23 +549,20 @@ export function useChatSocket() {
 
       // GA4 핵심 인게이지먼트 — 방문자의 채팅 사용을 모드/모델 차원으로 계측(PII 없음).
       gaEvent(GA_EVENTS.chatMessageSent, {
-        chat_mode: s.imageMode
-          ? "image"
-          : s.deepResearchMode
-            ? "deep_research"
-            : s.discussionMode
-              ? "discussion"
-              : s.thinkingEnabled
-                ? "thinking"
-                : "default",
+        chat_mode: s.deepResearchMode
+          ? "deep_research"
+          : s.discussionMode
+            ? "discussion"
+            : s.thinkingEnabled
+              ? "thinking"
+              : "default",
         model_id: s.selectedModel,
-        web_search: s.webSearchEnabled ? "on" : "off",
         with_attachment: hasFiles || (images?.length ?? 0) > 0 ? "yes" : "no",
       });
 
       // 가로채기(bypass) 모드가 켜져 있으면 도구·아티팩트가 이번 응답에 적용되지 않으므로,
       // 스트리밍 직전에 표시 전용 안내를 삽입한다(notice: true → history payload 제외).
-      if (s.discussionMode || s.deepResearchMode || s.imageMode) {
+      if (s.discussionMode || s.deepResearchMode) {
         appendMessage({ role: "system", content: tRef.current("interceptNotice"), notice: true });
       }
       return true;
@@ -579,8 +572,6 @@ export function useChatSocket() {
 
   const abort = useCallback(() => {
     wsRef.current?.send(JSON.stringify({ type: "abort" }));
-    // 구조화 답변(REST) 진행 중이면 fetch 도 취소
-    structuredAbortRef.current?.abort();
   }, []);
 
   // 에이전트 토글 ON: 메시지를 목표(goal)로 자율 에이전트 작업을 생성·실행한다.
@@ -695,59 +686,5 @@ export function useChatSocket() {
     [appendMessage],
   );
 
-  // 구조화 답변 모드 — WebSocket 스트리밍 대신 REST /api/chat/structured 호출(비스트리밍).
-  // 백엔드가 Answer Planner → JSON Schema → Validator → formatAnswer 파이프라인으로
-  // { intent, structured, markdown } 을 반환. structured 는 카드 UI(StructuredAnswer)로 렌더.
-  const sendStructured = useCallback(
-    async (message: string) => {
-      const msg = message.trim();
-      const s = useAppStore.getState();
-      if (!msg || s.isGenerating) return;
-      appendMessage({ role: "user", content: msg });
-      setStreaming(true);
-      const controller = new AbortController();
-      structuredAbortRef.current = controller;
-      try {
-        const res = await ApiClient.post<{
-          data: { intent: string; structured: StructuredAnswerData; markdown: string };
-        }>(
-          "/api/chat/structured",
-          {
-            message: msg,
-            model: s.selectedModel,
-            anonSessionId: getAnonSessionId(),
-            // 웹 기능 토글을 구조화 모드에도 전달 — 백엔드가 시사 질의 시 웹검색 수행.
-            webSearch: s.webSearchEnabled,
-            enabledTools: s.mcpToolsEnabled,
-            // userLanguage 는 보내지 않는다 — 백엔드가 메시지 내용으로 언어를 감지(WS 채팅과 동일).
-            // navigator.language(브라우저 로케일)에 의존하면 en-* 브라우저의 한국어 사용자가
-            // 한국어 질문에도 영어 답변을 받는 회귀가 발생했다.
-          },
-          { signal: controller.signal },
-        );
-        const data = res?.data;
-        appendMessage({
-          role: "assistant",
-          content: data?.markdown ?? "",
-          structured: data?.structured,
-        });
-      } catch (e) {
-        const aborted = e instanceof DOMException && e.name === "AbortError";
-        appendMessage({
-          role: "assistant",
-          content: aborted
-            ? tRef.current("structuredAborted")
-            : tRef.current("structuredFailed", {
-                message: e instanceof Error ? e.message : String(e),
-              }),
-        });
-      } finally {
-        structuredAbortRef.current = null;
-        setStreaming(false);
-      }
-    },
-    [appendMessage, setStreaming],
-  );
-
-  return { connected, sendChat, abort, startAgentTask, sendStructured };
+  return { connected, sendChat, abort, startAgentTask };
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -258,17 +258,12 @@
     "send": "Send",
     "disclaimer": "OpenMake can make mistakes. Verify important information.",
     "suppressedTag": "(not applied)",
-    "modifierSuppressed": "{label} is not applied while an intercept mode is on",
     "externalLocalModeNotice": "Discussion and Deep Research run on the local model (the selected external model is not used).",
     "toggle": {
       "discussion": "Discussion",
       "thinking": "Thinking",
       "deepResearch": "Deep Research",
-      "web": "Web",
       "agent": "Agent",
-      "image": "Image",
-      "artifact": "Artifact",
-      "structured": "Structured",
       "verification": "Verify answer"
     },
     "slashMenu": {
@@ -558,9 +553,7 @@
     "unknownError": "Unknown error",
     "disconnected": "_(Disconnected from the server. Reconnecting — please try sending again shortly.)_",
     "taskIdMissing": "No taskId in the task creation response",
-    "agentTaskStartFailed": "Failed to start the agent task: {message}",
-    "structuredAborted": "_(Structured answer generation was stopped.)_",
-    "structuredFailed": "Failed to generate a structured answer: {message}"
+    "agentTaskStartFailed": "Failed to start the agent task: {message}"
   },
   "skillLibrary": {
     "cancel": "Cancel",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -258,17 +258,12 @@
     "send": "送信",
     "disclaimer": "OpenMake は誤ることがあります。重要な情報は確認してください。",
     "suppressedTag": "(未適用)",
-    "modifierSuppressed": "{label} はインターセプトモード中は適用されません",
     "externalLocalModeNotice": "ディスカッション・ディープリサーチはローカルモデルで実行されます（選択した外部モデルは使用されません）。",
     "toggle": {
       "discussion": "ディスカッション",
       "thinking": "思考",
       "deepResearch": "ディープリサーチ",
-      "web": "ウェブ",
       "agent": "エージェント",
-      "image": "画像",
-      "artifact": "アーティファクト",
-      "structured": "構造化",
       "verification": "回答の検証"
     },
     "slashMenu": {
@@ -558,9 +553,7 @@
     "unknownError": "不明なエラー",
     "disconnected": "_(サーバーとの接続が切れました。再接続中です。しばらくして再送信してください。)_",
     "taskIdMissing": "タスク作成レスポンスに taskId がありません",
-    "agentTaskStartFailed": "エージェントタスクを開始できませんでした: {message}",
-    "structuredAborted": "_(構造化回答の生成を中止しました。)_",
-    "structuredFailed": "構造化回答を生成できませんでした: {message}"
+    "agentTaskStartFailed": "エージェントタスクを開始できませんでした: {message}"
   },
   "skillLibrary": {
     "cancel": "キャンセル",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -258,17 +258,12 @@
     "send": "전송",
     "disclaimer": "OpenMake 는 실수할 수 있습니다. 중요한 정보는 확인하세요.",
     "suppressedTag": "(미적용)",
-    "modifierSuppressed": "{label} 은(는) 가로채기 모드에서 적용되지 않습니다",
     "externalLocalModeNotice": "토론·딥 리서치 모드는 로컬 모델로 실행됩니다 (선택한 외부 모델은 사용되지 않음).",
     "toggle": {
       "discussion": "토론",
       "thinking": "Thinking",
       "deepResearch": "딥 리서치",
-      "web": "웹",
       "agent": "에이전트",
-      "image": "이미지",
-      "artifact": "아티팩트",
-      "structured": "구조화 답변",
       "verification": "답변 검증"
     },
     "slashMenu": {
@@ -558,9 +553,7 @@
     "unknownError": "알 수 없는 오류",
     "disconnected": "_(서버와 연결이 끊겼습니다. 재연결 중이니 잠시 후 다시 전송해 주세요.)_",
     "taskIdMissing": "작업 생성 응답에 taskId 가 없습니다",
-    "agentTaskStartFailed": "에이전트 작업을 시작하지 못했습니다: {message}",
-    "structuredAborted": "_(구조화 답변 생성을 중단했습니다.)_",
-    "structuredFailed": "구조화 답변을 생성하지 못했습니다: {message}"
+    "agentTaskStartFailed": "에이전트 작업을 시작하지 못했습니다: {message}"
   },
   "skillLibrary": {
     "cancel": "취소",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -258,17 +258,12 @@
     "send": "发送",
     "disclaimer": "OpenMake 可能会出错，请核实重要信息。",
     "suppressedTag": "(未应用)",
-    "modifierSuppressed": "{label} 在拦截模式下不会应用",
     "externalLocalModeNotice": "讨论和深度研究将使用本地模型运行（不会使用所选的外部模型）。",
     "toggle": {
       "discussion": "讨论",
       "thinking": "思考",
       "deepResearch": "深度研究",
-      "web": "网络",
       "agent": "智能体",
-      "image": "图像",
-      "artifact": "工件",
-      "structured": "结构化",
       "verification": "验证回答"
     },
     "slashMenu": {
@@ -558,9 +553,7 @@
     "unknownError": "未知错误",
     "disconnected": "_(与服务器的连接已断开。正在重新连接，请稍后重新发送。)_",
     "taskIdMissing": "任务创建响应中缺少 taskId",
-    "agentTaskStartFailed": "无法启动智能体任务：{message}",
-    "structuredAborted": "_(已停止生成结构化回答。)_",
-    "structuredFailed": "无法生成结构化回答：{message}"
+    "agentTaskStartFailed": "无法启动智能体任务：{message}"
   },
   "skillLibrary": {
     "cancel": "取消",


### PR DESCRIPTION
사용자 요청: 모델이 질의에 따라 자동으로 발동하는 기능은 채팅 UI 토글에서 뺀다.

## 토글별 실제 동작 (코드 확인, 2026-08-27)

| 토글 | 자동 발동 | 토글이 하던 일 |
|---|---|---|
| 웹 | ✅ `web_search` 도구 항상 노출, 명시 문구면 첫 턴 강제 | 사전 검색 컨텍스트 주입 |
| 이미지 | ✅ `generate_image` 항상 노출 | 이미지 전용 조기 분기 |
| 아티팩트 | ✅ 모델이 `<artifact>` 로 냄 | "명시 요청" 취급 → 방해 도구 억제 (`ARTIFACT_INTENT_PATTERNS` 가 이미 같은 판정) |
| 구조화 답변 | ✅ 질의 유형으로 구조 가드 자동 | 별도 REST `/api/chat/structured` 카드 경로 |

→ 위 4개 제거. **토론·Thinking·답변 검증·딥 리서치·에이전트**는 수동 의미가 남아 유지(토론·에이전트는 의도 프리필터 턴에만 모델이 도구로 고르는 부분 자동 경로가 따로 있음).

## 변경 범위

프론트만. 백엔드 계약(`webSearch`/`imageMode`/`artifactMode` 필드, `/api/chat/structured`)은 그대로 두고 프론트가 보내지 않는다(서버 기본 false). 카드형 구조화 답변은 과거 메시지 렌더만 유지. 상태·전송 필드·GA 차원·i18n 키 정리.

동반: `/shared/task` 뷰어의 React Compiler 린트 오류(`window.open` 결과 프로퍼티 대입 → `location.assign`) 수정 — apps/web lint 를 기준선(기존 `global-error` 1건)으로.

## 잃는 것 (명시)

- **이미지 토글의 결정적 경로**: 토글은 LLM 판단 없이 바로 그렸다("일부 모델이 이미지를 안 그리는 문제 회피"가 도입 사유). 이제 모델이 `generate_image` 를 골라야 한다.
- **구조화 답변 카드 UI**: 토글 전용 REST 경로였다. 스트리밍 경로의 구조 가드(마크다운)는 그대로.

검증: tsc·i18n 정합(4 locale 1500키)·lint 기준선, 빌드·재배포 후 브라우저에서 메뉴 항목 확인.