### PR TITLE
fix(web): 세션 만료 시 store 를 게스트로 되돌려 배지 폴링을 멈춘다

### DIFF
--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -27,7 +27,9 @@ function AuthSync() {
     if (!isLoggedIn) return;
     const timer = setInterval(() => {
       void ApiClient.post("/api/auth/refresh", undefined, { redirectOnUnauthorized: false }).catch(() => {
-        /* refresh 실패(세션 만료 등) — 다음 REST 401 인터셉트/리다이렉트 흐름에 위임 */
+        // refresh 실패(세션 수명 종료) — 서버 판정으로 store 를 갱신한다(게스트면 currentUser 해제 →
+        // 배지 폴링 등 로그인 전제 타이머가 멈춘다). 종전엔 무시해 만료 탭이 영원히 폴링했다.
+        void syncAuthFromServer();
       });
     }, CLIENT_TIMING.TOKEN_REFRESH_INTERVAL_MS);
     return () => clearInterval(timer);

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -19,9 +19,9 @@ import type { ApiSuccess } from "@openmake/shared-types";
 import { useAppStore } from "@/lib/store";
 import type { ChatRole } from "@/lib/store";
 import { visibleNavItems } from "@/lib/nav";
-import { ApiClient } from "@/lib/api-client";
+import { ApiClient, ApiError } from "@/lib/api-client";
 import { appendAnonSessionId } from "@/lib/anon-session";
-import { clearHadSession } from "@/lib/auth-sync";
+import { syncAuthFromServer, clearHadSession } from "@/lib/auth-sync";
 import Image from "next/image";
 import { ThemeToggle } from "./theme-toggle";
 import { cn } from "@/lib/utils";
@@ -75,8 +75,16 @@ export function Sidebar() {
     if (!user) { setPendingApprovals(0); return; }
     let alive = true;
     const opts = { redirectOnUnauthorized: false } as const;
-    // 한 축이 실패해도 나머지 합계는 보이도록 개별 fallback 을 둔다
-    const count = async (fn: () => Promise<number>) => { try { return await fn(); } catch { return 0; } };
+    // 한 축이 실패해도 나머지 합계는 보이도록 개별 fallback 을 둔다.
+    // 401 은 삼키지 않는다 — 세션이 죽은 신호라 서버 판정으로 store 를 갱신해(게스트면 user=null)
+    // 이 effect 자체가 정리되게 한다. 삼키면 만료 탭이 30초마다 4요청을 영원히 보낸다.
+    let unauthorized = false;
+    const count = async (fn: () => Promise<number>) => {
+      try { return await fn(); } catch (e) {
+        if (e instanceof ApiError && e.status === 401) unauthorized = true;
+        return 0;
+      }
+    };
     const poll = async () => {
       const [hitl, skills, mcp, agents] = await Promise.all([
         count(async () => {
@@ -100,7 +108,9 @@ export function Sidebar() {
           return r.data?.total ?? r.data?.drafts?.length ?? 0;
         }),
       ]);
-      if (alive) setPendingApprovals(hitl + skills + mcp + agents);
+      if (!alive) return;
+      if (unauthorized) { unauthorized = false; void syncAuthFromServer(); return; }
+      setPendingApprovals(hitl + skills + mcp + agents);
     };
     void poll();
     const timer = setInterval(poll, 30_000);

--- a/apps/web/lib/auth-sync.ts
+++ b/apps/web/lib/auth-sync.ts
@@ -1,5 +1,5 @@
 import type { ApiSuccess, MePayload } from "@openmake/shared-types";
-import { ApiClient, csrfHeaders } from "./api-client";
+import { ApiClient, ApiError, csrfHeaders } from "./api-client";
 import { getAnonSessionId } from "./anon-session";
 import { flushOAuthLoginPending, gaSetVisitor } from "./analytics";
 import { useAppStore } from "./store";
@@ -118,8 +118,14 @@ async function syncAuthInner(): Promise<boolean> {
         /* 미설정/실패 — 기본값(true) 유지 */
       });
     return true;
-  } catch {
-    /* 비로그인(401) — 게스트 유지 */
+  } catch (e) {
+    // `/api/auth/me` 가 만료 토큰에 **401** 을 돌려주는 경우(서버가 쿠키를 정리하기 전) — 게스트
+    // (200, user:null)와 같은 뜻이다. 종전엔 라벨만 바꾸고 store 를 두어 만료 탭이 한 사이클 더
+    // 폴링했다(2026-08-27 라이브: 401 → 30초 뒤 폴링 → 그때야 200 게스트로 정리).
+    if (e instanceof ApiError && e.status === 401) {
+      clearHadSession();
+      if (useAppStore.getState().auth.currentUser) useAppStore.getState().setAuth({ currentUser: null, isGuestMode: true });
+    }
     gaSetVisitor(null, "guest");
     return false;
   }

--- a/apps/web/lib/auth-sync.ts
+++ b/apps/web/lib/auth-sync.ts
@@ -79,6 +79,11 @@ async function syncAuthInner(): Promise<boolean> {
     }
     if (!u) {
       // 비로그인은 200 + user:null 로 온다(401 아님) — 게스트 라벨링은 이 분기가 본선.
+      // ⚠️ store 도 게스트로 되돌린다. 종전엔 라벨만 바꾸고 currentUser 를 남겨서, 세션이 만료된
+      // 탭이 "로그인 상태"로 보이는 채 사이드바 배지가 30초마다 4개 요청을 만료 토큰으로
+      // 영원히 두드렸다(2026-08-27 실측: 24h `jwt expired` 5,471건).
+      const cur = useAppStore.getState().auth;
+      if (cur.currentUser) useAppStore.getState().setAuth({ currentUser: null, isGuestMode: true });
       gaSetVisitor(null, "guest");
       return false;
     }


### PR DESCRIPTION
운영 점검(2026-08-27) 1번 항목. 24시간에 `jwt expired` **5,471건**, 새벽 4시간에 4,830건.

## 원인
사이드바 승인 배지가 30초마다 4개 엔드포인트를 `redirectOnUnauthorized:false` 로 치고 실패를 삼키는데, refresh 가 죽어도 `auth.currentUser` 가 남아 **탭이 열려 있는 한 만료 토큰으로 영원히** 두드렸다. 화면도 "로그인 상태"로 남아 요청만 조용히 실패하는 UX 결함이 같이 있었다.

## 수정
- `auth-sync`: `/api/auth/me` 가 게스트(200 user:null)**또는 401**을 돌려주면 store 를 게스트로 되돌린다(종전엔 GA 라벨만)
- `providers`: 주기 refresh 실패를 무시하지 않고 서버 판정으로 store 를 갱신
- `sidebar`: 배지 폴링에서 401 을 삼키지 않고 서버 판정을 트리거 → `user=null` 이면 effect 정리로 타이머 정지

## 라이브 검증 (45초 만료 토큰, chat.openmake.cc)

| | 만료 후 폴링 |
|---|---|
| 수정 전 | 401 배치 후에도 30초마다 계속 |
| 1차 수정 | 401 → `/auth/me` **401** → store 유지 → 30초 뒤 한 번 더 → 그때야 200 게스트로 정리 |
| 최종 | 401 배치 → refresh 401 → `/auth/me` 401 → 게스트 → **이후 폴링 0건**(2주기 관찰), UI 도 게스트 |

부수 관찰: 로드 후 두 번째 폴링 배치가 매번 `net::ERR_CONNECTION_CLOSED`(엣지 keep-alive 유휴 종료로 보임) — 배지가 그 사이클만 0 으로 보이는 정도라 별도.