### PR TITLE
chore(pm2): 로그 위치를 .env 의 OMK_LOG_DIR 로 읽어 영속 볼륨으로 이동

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1526,3 +1526,7 @@ CHAT_USER_MCP_SCHEMA_BUDGET_BYTES=16000
 # 써야 할 때만 아래를 지정한다. 값이 바뀌면 기존 동적 등록은 무효(재로그인 시 자동 재등록).
 # MCP_OAUTH_REDIRECT_BASE=https://chat.openmake.cc
 
+# PM2 로그 디렉토리 (ecosystem.config.js 가 .env 에서 직접 읽음, 2026-08-27). 기본 /tmp 는
+# 재부팅·주기 정리로 사라져 장애 후 원인 로그가 없을 수 있다 — 영속 볼륨 경로를 권장.
+# 변경 반영은 pm2 delete → pm2 start ecosystem.config.js → pm2 save (restart 로는 로그 경로가 안 바뀜).
+# OMK_LOG_DIR=/var/log/openmake

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -29,6 +29,10 @@ const WEB_PORT = process.env.OMK_WEB_PORT || '3000';
  * 로그 디렉터리. 기본은 기존 동작 유지(/tmp)지만, 여러 사용자가 쓰는 리눅스 호스트에서는
  * /tmp/openmake-*.log 소유자 충돌로 PM2 가 EACCES 로 죽는다 → OMK_LOG_DIR 로 분리 가능.
  */
+// .env 의 OMK_LOG_DIR 를 존중한다 — `pm2 start` 를 호출한 셸이 .env 를 export 하지 않으므로
+// (openmake_llm.sh 도 안 함) 여기서 직접 읽지 않으면 설정이 있어도 /tmp 로 떨어진다.
+// /tmp 는 재부팅·주기 정리로 사라져 장애 후 원인 로그가 없을 수 있다(2026-08-27 점검).
+try { require('dotenv').config({ path: path.join(__dirname, '.env'), quiet: true }); } catch { /* dotenv 없으면 셸 env 만 */ }
 const LOG_DIR = process.env.OMK_LOG_DIR || '/tmp';
 const logFile = (name) => path.join(LOG_DIR, name);
 


### PR DESCRIPTION
운영 점검(2026-08-27) 3번. PM2 로그가 `/tmp` 에 있고 로테이션이 없었다(7시간에 7.7MB ≈ 25MB/일). `/tmp` 는 재부팅·주기 정리로 사라져 **장애 후 원인 로그가 없을 수 있다.**

## 변경
`ecosystem.config.js` 는 `OMK_LOG_DIR` 를 `process.env` 에서만 읽는데, `pm2 start` 를 호출하는 셸(`openmake_llm.sh` 포함)이 `.env` 를 export 하지 않아 **설정이 있어도 `/tmp` 로 떨어졌다** → dotenv 로 `.env` 를 직접 읽는다. 실제 경로는 `.env` 에만 두고 리포엔 `.env.example` 예시만.

## 운영 반영 (완료)
- `.env` 에 `OMK_LOG_DIR` 설정, `pm2 delete → start → save` (api 약 10초 중단), 3개 앱 모두 새 경로에서 기록 확인, api/web 200
- `pm2-logrotate@3.0.0` 설치 — 50M · 14일 보관 · gzip · 매일 0시

⚠️ `pm2 restart` 로는 로그 경로가 바뀌지 않는다 — `delete → start` 가 필요(`.env.example` 에 명시).