### PR TITLE
feat(agent-task): goal judge 셰도우 확대 — 아티팩트 있는 완료도 판정만 기록

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1053,6 +1053,7 @@ AGENT_TASK_TIMEOUT_MS=600000
 # 미달성이면 completed 대신 failed(goal_incomplete)). 기본 ON. 'false' 로 비활성.
 # 판정 결과는 agent_tasks.judge_verdict, 완료 출구는 completion_path 로 영속(091).
 # AGENT_TASK_GOAL_JUDGE=true
+# AGENT_TASK_GOAL_JUDGE_SHADOW=true  # 아티팩트가 있는 완료도 판정만 돌려 기록(적용 안 함, step_type='judge_shadow') — 발동 조건 확대 판단용 표본
 # AGENT_TASK_GOAL_JUDGE_MAX_CHARS=6000   # judge 에 넘기는 최종 답변 최대 글자 수
 # AGENT_TASK_GOAL_JUDGE_EVIDENCE_MAX_ITEMS=8   # judge 에 싣는 최근 도구 결과 수 (terminate/plan_* 결과는 제외됨)
 # AGENT_TASK_GOAL_JUDGE_EVIDENCE_ITEM_CHARS=320 # 도구 결과 항목당 글자 캡

--- a/apps/api/src/__tests__/agent-task-input-files.test.ts
+++ b/apps/api/src/__tests__/agent-task-input-files.test.ts
@@ -221,11 +221,16 @@ describe('AgentTaskService 입력 첨부 파일', () => {
         expect(updateAgentTask.mock.calls.some((c) => c[1]?.status === 'failed')).toBe(false);
     });
 
-    it('아티팩트가 있는 최종 답변은 judge 를 생략하고 completed', async () => {
-        chatContent = '<artifact id="report" kind="markdown" title="보고서">본문</artifact> 보고서를 작성했습니다.';
+    it('아티팩트가 있는 최종 답변은 판정을 적용하지 않고 completed — 셰도우는 기록만', async () => {
+        chatQueue = [
+            '<artifact id="report" kind="markdown" title="보고서">본문</artifact> 보고서를 작성했습니다.',
+            // 셰도우 판정이 미달성이어도 완료를 뒤집지 않는다(적용 조건은 아티팩트 0 그대로).
+            '{"achieved": false, "reason": "목표와 무관한 산출물"}',
+        ];
         await new AgentTaskService().execute(baseInput);
 
-        expect(mockChat).toHaveBeenCalledTimes(1); // judge 호출 없음
+        expect(mockChat).toHaveBeenCalledTimes(2); // 본 루프 1회 + 셰도우 judge 1회
         expect(updateAgentTask).toHaveBeenCalledWith('t1', expect.objectContaining({ status: 'completed' }));
+        expect(updateAgentTask.mock.calls.some((c) => c[1]?.status === 'failed')).toBe(false);
     });
 });

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1569,6 +1569,12 @@ export const AGENT_TASK_LIMITS = {
      *  여부를 검증(마커 미준수 보완). 미달성 판정 시 completed 대신 failed(goal_incomplete).
      *  판정 실패/파싱 불가는 fail-open(완료 유지). AGENT_TASK_GOAL_JUDGE=false 로 비활성. */
     GOAL_JUDGE_ENABLED: process.env.AGENT_TASK_GOAL_JUDGE !== 'false',
+    /** judge 셰도우 계측 — 아티팩트가 **있는** 완료에서도 판정을 돌리되 **적용하지 않고 기록만**
+     *  한다(step_type='judge_shadow'). 발동 조건 확대의 게이트인 오판율을 재려면 표본이 필요한데,
+     *  현행 조건(아티팩트 0)으로는 completed 의 18% 만 판정을 거쳐 표본이 쌓이지 않는다
+     *  (2026-08-27 실측 30일: completed 120건 중 achieved 22 · skipped 43 · 미판정 55).
+     *  완료 흐름은 불변이며 실패해도 fail-open. AGENT_TASK_GOAL_JUDGE_SHADOW=false 로 비활성. */
+    GOAL_JUDGE_SHADOW_ENABLED: process.env.AGENT_TASK_GOAL_JUDGE_SHADOW !== 'false',
     /** judge 에 넘기는 최종 답변 최대 글자 수 (프롬프트 팽창 방지) */
     GOAL_JUDGE_MAX_ANSWER_CHARS: parseInt(process.env.AGENT_TASK_GOAL_JUDGE_MAX_CHARS || '6000', 10),
     /** judge 실행 컨텍스트에 싣는 최근 도구 결과 수 — 성공 증거 부재로 완수 작업을 미달성

--- a/apps/api/src/services/agent-task/finalize.test.ts
+++ b/apps/api/src/services/agent-task/finalize.test.ts
@@ -6,6 +6,7 @@ jest.mock('../../config/runtime-limits', () => {
         AGENT_TASK_LIMITS: {
             ...actual.AGENT_TASK_LIMITS,
             GOAL_JUDGE_ENABLED: true,
+            GOAL_JUDGE_SHADOW_ENABLED: true,
             VERIFY_DELIVERABLE_ENABLED: true,
             VERIFY_DELIVERABLE_MAX_RETRIES: 1,
         },
@@ -113,19 +114,52 @@ describe('finalizeTask — 완료 관문 단일화(091)', () => {
         const emit = jest.fn();
         const i = input({ path: 'terminate', terminateSummary: '', emitStep: emit });
         await finalizeTask(i);
-        expect(judgeStepMock).toHaveBeenCalledWith(expect.any(String), expect.any(Number), 'not_achieved', '입력 파일이 없음', '', 'ctx');
+        expect(judgeStepMock).toHaveBeenCalledWith(expect.any(String), expect.any(Number), 'not_achieved', '입력 파일이 없음', '', 'ctx', { shadow: false });
         const emitted = emit.mock.calls.find((c: unknown[]) => c[0] === 'judge');
         expect(emitted?.[2]).toContain('입력 파일이 없음');
     });
 
-    it('아티팩트가 있으면 judge 를 생략하고 verdict=skipped (발동 조건 유지)', async () => {
+    it('아티팩트가 있으면 판정을 적용하지 않는다 — verdict=skipped, 완료 유지', async () => {
+        judgeMock.mockResolvedValue({ achieved: true, reason: '산출물 확인', raw: '' });
         const i = input({ rawContent: WITH_ARTIFACT });
 
         const out = await finalizeTask(i);
 
-        expect(judgeMock).not.toHaveBeenCalled();
+        expect(out.kind).toBe('completed');
+        // 적용 조건은 종전 그대로 — 컬럼에는 셰도우 판정이 새지 않는다.
+        expect(lastUpdate(i)).toMatchObject({ status: 'completed', judgeVerdict: 'skipped' });
+    });
+
+    it('아티팩트가 있어도 셰도우로 판정만 돌려 기록한다 (표본 확보)', async () => {
+        judgeMock.mockResolvedValue({ achieved: true, reason: '산출물 확인', raw: '' });
+        const i = input({ rawContent: WITH_ARTIFACT });
+
+        await finalizeTask(i);
+
+        expect(judgeMock).toHaveBeenCalledTimes(1);
+        // 마지막 인자로 shadow:true 가 넘어가 step_type='judge_shadow' 로 갈린다.
+        expect(judgeStepMock).toHaveBeenCalledWith(
+            'task-1', expect.any(Number), 'achieved', '산출물 확인', '', 'ctx', { shadow: true });
+    });
+
+    it('셰도우 판정이 미달성이어도 완료를 뒤집지 않는다 (fail-open 계약)', async () => {
+        judgeMock.mockResolvedValue({ achieved: false, reason: '목표와 무관한 산출물', raw: '' });
+        const i = input({ rawContent: WITH_ARTIFACT });
+
+        const out = await finalizeTask(i);
+
         expect(out.kind).toBe('completed');
         expect(lastUpdate(i)).toMatchObject({ status: 'completed', judgeVerdict: 'skipped' });
+    });
+
+    it('적용 판정에는 shadow 플래그가 붙지 않는다', async () => {
+        judgeMock.mockResolvedValue({ achieved: true, reason: '파일 생성', raw: '' });
+        const i = input({ rawContent: '작업을 마쳤습니다.' });
+
+        await finalizeTask(i);
+
+        expect(judgeStepMock).toHaveBeenCalledWith(
+            'task-1', expect.any(Number), 'achieved', '파일 생성', '', 'ctx', { shadow: false });
     });
 
     it('미달성 마커는 judge 없이 failed(goal_incomplete) — 마커는 결과 본문에서 제거', async () => {

--- a/apps/api/src/services/agent-task/finalize.ts
+++ b/apps/api/src/services/agent-task/finalize.ts
@@ -15,7 +15,10 @@
  *   3. goal judge(LLM 1회) → 미달성 확정 시 failed(goal_incomplete), 판정 실패는 fail-open
  *   4. 아티팩트·코드 diff 영속 → completed
  *
- * judge 발동 조건(아티팩트 0)은 종전 그대로다 — 확대는 judge_verdict 전향 데이터를 본 뒤.
+ * judge **적용** 조건(아티팩트 0)은 종전 그대로다. 다만 아티팩트가 있는 완료도 2026-08-27 부터
+ * 셰도우로 판정만 돌려 기록한다(`judge_shadow` 스텝) — 확대 여부를 가를 오판율을 재려면
+ * 표본이 필요하고, 적용 조건으로는 completed 의 18% 만 판정을 거치기 때문이다. 적용 확대는
+ * 그 표본으로 오판율을 재측정한 뒤 결정한다.
  *
  * @module services/agent-task/finalize
  */
@@ -121,28 +124,42 @@ export async function finalizeTask(input: FinalizeInput): Promise<FinalizeOutcom
         }
     }
 
-    // 3. goal judge — 아티팩트 없는 완료만 LLM 1회 검증(마커 미준수 보완). 결과는 관측 컬럼에 남긴다.
+    // 3. goal judge — 판정을 **적용**하는 대상은 종전 그대로 아티팩트 없는 완료뿐이다.
+    //    아티팩트가 있는 완료도 셰도우로 판정만 돌려 기록한다(완료 흐름 불변, fail-open):
+    //    발동 조건 확대의 게이트가 judge 오판율인데, 현행 조건으로는 completed 의 18% 만
+    //    판정을 거쳐 잴 표본이 쌓이지 않는다(2026-08-27 실측 30일: 120건 중 achieved 22 ·
+    //    skipped 43 · 미판정 55, 그중 34건이 아티팩트 보유로 우회).
     let verdict: JudgeVerdict = 'skipped';
-    if (artifacts.length === 0 && AGENT_TASK_LIMITS.GOAL_JUDGE_ENABLED) {
+    const judgeApplies = artifacts.length === 0;
+    if (AGENT_TASK_LIMITS.GOAL_JUDGE_ENABLED
+        && (judgeApplies || AGENT_TASK_LIMITS.GOAL_JUDGE_SHADOW_ENABLED)) {
         const execCtx = buildJudgeExecutionContext(usedTools, turn + 1, taskRuntime?.getPlanSnapshot() ?? [], toolEvidence);
         const outcome = await judgeGoal(
             await judgeClientFor(userId), goal, body ?? '', signal, execCtx);
         const achieved = outcome.achieved;
-        verdict = achieved === null ? 'unknown' : achieved ? 'achieved' : 'not_achieved';
+        const judged: JudgeVerdict = achieved === null ? 'unknown' : achieved ? 'achieved' : 'not_achieved';
         // 판정·사유·입력 요약을 스텝으로 남긴다 — 오판 사후 규명용(관측 전용, fail-open).
-        stepNumber = await persistJudgeStep(taskId, stepNumber, verdict, outcome.reason, outcome.raw, execCtx);
-        emitStep('judge', undefined, `판정: ${verdict}${outcome.reason ? ` — ${outcome.reason}` : ''}`);
-        if (achieved === false) {
-            await update({
-                status: 'failed',
-                error: 'goal_incomplete',
-                result: body,
-                checkpoint: null,
-                completionPath: path,
-                judgeVerdict: verdict,
-            });
-            logger.info(`[AgentTask] judge 목표 미달성 종료: ${taskId} (turn ${turn + 1}, ${path})`);
-            return { kind: 'goal_incomplete', stepNumber };
+        stepNumber = await persistJudgeStep(
+            taskId, stepNumber, judged, outcome.reason, outcome.raw, execCtx, { shadow: !judgeApplies });
+        emitStep(judgeApplies ? 'judge' : 'judge_shadow', undefined,
+            `${judgeApplies ? '' : '[셰도우] '}판정: ${judged}${outcome.reason ? ` — ${outcome.reason}` : ''}`);
+        // 셰도우는 여기까지. `judge_verdict` 컬럼은 'skipped' 로 둔다 — 적용된 판정만 담는
+        // 컬럼이라, 셰도우 값을 넣으면 not_achieved 인데 completed 인 행이 생겨 기존 집계가
+        // 깨진다(셰도우 표본은 step_type='judge_shadow' 로 읽는다).
+        if (judgeApplies) {
+            verdict = judged;
+            if (achieved === false) {
+                await update({
+                    status: 'failed',
+                    error: 'goal_incomplete',
+                    result: body,
+                    checkpoint: null,
+                    completionPath: path,
+                    judgeVerdict: verdict,
+                });
+                logger.info(`[AgentTask] judge 목표 미달성 종료: ${taskId} (turn ${turn + 1}, ${path})`);
+                return { kind: 'goal_incomplete', stepNumber };
+            }
         }
     }
 

--- a/apps/api/src/services/agent-task/task-steps.ts
+++ b/apps/api/src/services/agent-task/task-steps.ts
@@ -80,6 +80,10 @@ export async function runTool(
 /**
  * judge 판정을 스텝으로 영속 — 사후 규명용. 종전엔 라벨(judge_verdict)만 남아 오판 원인을
  * 복원할 수 없었다. 실패해도 완료 흐름을 막지 않는다(fail-open, 관측 전용).
+ *
+ * `opts.shadow` 는 **적용되지 않은** 판정(아티팩트가 있어 완료가 이미 확정된 경우)이다.
+ * step_type 을 'judge_shadow' 로 갈라 집계에서 섞이지 않게 하고, 본문 첫 줄에 반영되지
+ * 않았음을 명시한다 — 상세 화면에 그대로 보이므로 "미달성인데 완료" 로 읽히면 안 된다.
  */
 export async function persistJudgeStep(
     taskId: string,
@@ -88,14 +92,18 @@ export async function persistJudgeStep(
     reason: string,
     raw: string,
     executionContext: string,
+    opts: { shadow?: boolean } = {},
 ): Promise<number> {
     const content = [
+        ...(opts.shadow ? ['[셰도우 계측 — 완료 여부에 반영되지 않음]'] : []),
         `판정: ${verdict}`,
         reason ? `사유: ${reason}` : `사유: (파싱 실패) ${raw}`,
         `입력 요약:\n${executionContext}`,
     ].join('\n');
     try {
-        await getUnifiedDatabase().addAgentTaskStep({ taskId, stepNumber, stepType: 'judge', content });
+        await getUnifiedDatabase().addAgentTaskStep({
+            taskId, stepNumber, stepType: opts.shadow ? 'judge_shadow' : 'judge', content,
+        });
         return stepNumber + 1;
     } catch (e) {
         logger.warn(`[AgentTask] judge 스텝 영속 실패(무시): ${taskId} — ${e instanceof Error ? e.message : e}`);


### PR DESCRIPTION
## 배경

judge 발동 조건(아티팩트 0) 확대의 게이트는 오판율인데, **그 오판율을 잴 표본이 쌓이지 않는 것**이 먼저 문제였다.

2026-08-27 실측 (30일, completed 120건):

| verdict | n |
|---|---|
| (미판정) | 55 (그중 **34건이 아티팩트 보유로 우회**) |
| skipped | 43 |
| achieved | 22 |

판정을 실제로 거친 건 **18%**다. 9/8 재측정 잡이 예약돼 있지만 이 속도면 그날도 표본은 20여 건에 그친다.

## 변경

`finalize.ts` 의 `artifacts.length === 0` 을 판정 **적용**에만 남기고, 아티팩트가 있는 완료도 판정은 돌려 기록한다(`step_type='judge_shadow'`). 완료 흐름은 불변, 판정 실패는 종전대로 fail-open.

- **셰도우 판정을 `judge_verdict` 컬럼에 넣지 않는다** — 적용된 판정만 담는 컬럼이라, 넣으면 `not_achieved` 인데 `completed` 인 행이 생겨 기존 집계가 깨진다. 셰도우 표본은 `step_type` 으로 읽는다.
- 스텝 본문 첫 줄에 `[셰도우 계측 — 완료 여부에 반영되지 않음]` 명시 — 상세 화면에 그대로 보이므로 "미달성인데 완료"로 읽히면 안 된다.
- 게이트 `AGENT_TASK_GOAL_JUDGE_SHADOW` (기본 on).
- 완료 경로에 LLM 1회가 추가돼 완료가 수 초 늦다. `await` 인 이유는 fire-and-forget 시 `step_number` 유니크(054) 충돌 위험 때문.

## 검증

- agent-task 유닛 테스트 **150건 통과**(18 스위트) — 셰도우 3건 신규, 기존 "아티팩트 있으면 judge 생략" 1건은 "적용하지 않는다"로 의미 갱신
- `tsc --noEmit` · lint 통과
- 프론트 정합성: `agent-tasks/page.tsx` 는 `diff`/`tool_result` 만 분기하고 나머지는 배지+본문 기본 렌더 → `judge_shadow` 그대로 표시, 깨지지 않음

## 후속

9/8 오판율 재측정 스크립트(`openmake_llm-docs/ops/judge-remeasure.cjs`, 별도 리포)에 **"적용했다면 실패로 뒤집혔을 완료"** 섹션을 추가했다 — 그 목록에 실제 완수 건이 섞인 비율이 곧 확대 시 오판율이고, 적용 확대는 그것으로 판단한다. `--dry-run` 검증 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)