### PR TITLE
fix(agent-task): judge 에 제출 산출물을 싣는다 — 셰도우 표본 오염 차단

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1059,6 +1059,8 @@ AGENT_TASK_TIMEOUT_MS=600000
 # AGENT_TASK_GOAL_JUDGE_EVIDENCE_ITEM_CHARS=320 # 도구 결과 항목당 글자 캡
 # AGENT_TASK_GOAL_JUDGE_REASON_MAX_CHARS=600   # judge 사유 스텝에 남길 reason 최대 글자
 # AGENT_TASK_GOAL_JUDGE_RAW_KEEP_CHARS=400     # 파싱 실패 시 남길 raw 응답 앞부분
+# AGENT_TASK_GOAL_JUDGE_ARTIFACT_MAX_ITEMS=5   # judge 에 싣는 제출 산출물 최대 개수(셰도우 판정용)
+# AGENT_TASK_GOAL_JUDGE_ARTIFACT_ITEM_CHARS=400 # 산출물 항목당 본문 글자 캡
 
 # Agent Task — 도구 호출 인자 영속 (스텝에 마스킹된 args 기록, 사후 원인 분석용). 기본 ON.
 # AGENT_TASK_TOOL_ARGS_PERSIST=true

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1585,6 +1585,11 @@ export const AGENT_TASK_LIMITS = {
     /** judge 사유 스텝에 남길 reason 최대 글자 (파싱 실패 시 raw 응답 앞부분도 같이 남긴다) */
     GOAL_JUDGE_REASON_MAX_CHARS: parseInt(process.env.AGENT_TASK_GOAL_JUDGE_REASON_MAX_CHARS || '600', 10),
     GOAL_JUDGE_RAW_KEEP_CHARS: parseInt(process.env.AGENT_TASK_GOAL_JUDGE_RAW_KEEP_CHARS || '400', 10),
+    /** judge 에 싣는 제출 산출물(아티팩트) 최대 개수 — 셰도우 확대(2026-08-27)로 아티팩트가 있는
+     *  완료도 판정하게 되면서 필요해졌다. 종전엔 발동 조건이 아티팩트 0 이라 실을 것이 없었다. */
+    GOAL_JUDGE_ARTIFACT_MAX_ITEMS: parseInt(process.env.AGENT_TASK_GOAL_JUDGE_ARTIFACT_MAX_ITEMS || '5', 10),
+    /** 산출물 항목당 본문 글자 캡 (프롬프트 팽창 방지 — 목표 수행 여부 판단엔 앞부분으로 충분) */
+    GOAL_JUDGE_ARTIFACT_ITEM_CHARS: parseInt(process.env.AGENT_TASK_GOAL_JUDGE_ARTIFACT_ITEM_CHARS || '400', 10),
     /** 부팅 자동 복구 — 프로세스 재시작으로 중단된 task 를 부팅 시 자동 resume 한다.
      *  주의: schema-initializer 가 부팅 시 running/paused 를 failed('server restarted') 로 먼저
      *  마킹하므로, 복구 대상은 ①잔존 running/paused(마킹 실패 대비) + ②restart 마킹 + checkpoint

--- a/apps/api/src/prompts/agent-task-prompt.ts
+++ b/apps/api/src/prompts/agent-task-prompt.ts
@@ -155,7 +155,7 @@ export function getAgentTaskUploadedFilesNote(fileLines: string[]): string {
 }
 
 /**
- * 목표 달성 judge 프롬프트 — 아티팩트 없는 최종 답변이 목표를 실제로 수행했는지 판정.
+ * 목표 달성 judge 프롬프트 — 최종 답변이 목표를 실제로 수행했는지 판정.
  * 보수적 기준: 답변이 "수행하지 못했음"(입력 부재·불가·되묻기만)을 드러낼 때만 미달성.
  * 품질 평가가 아니다 — 부실해도 목표를 수행한 답변은 달성으로 본다(오탐 방지).
  */
@@ -164,6 +164,8 @@ export function getAgentTaskGoalJudgeMessages(
     answer: string,
     /** 5-3(b): 실행 컨텍스트(계획 상태·사용 도구·턴수) — 판정 정확도 보강. 없으면 기존 동작. */
     executionContext?: string,
+    /** 제출 산출물 렌더 — ANSWER 는 아티팩트가 제거된 본문이라 이것 없이는 산출물을 못 본다. */
+    artifactSummary?: string,
 ): { system: string; user: string } {
     return {
         system: [
@@ -177,11 +179,15 @@ export function getAgentTaskGoalJudgeMessages(
             '  달성입니다 — 답변이 짧은 완료 보고여도 도구 결과 자체가 수행 증거입니다.',
             '- 계획 완료 단계 수가 낮거나 없는 것은 상태 표시 누락일 수 있으니 그것만으로 미달성',
             '  판정하지 마세요.',
+            '- 산출물(ARTIFACTS)이 주어지면 그것이 에이전트가 제출한 결과물입니다. ANSWER 에는',
+            '  산출물 본문이 빠져 있고 그것을 가리키는 문장만 남아 있을 수 있으니, 산출물이',
+            '  목표에 부합하면 ANSWER 가 짧더라도 달성입니다.',
             '- 품질은 평가하지 마세요 — 내용이 부실하더라도 목표를 수행한 답변이면 달성(achieved=true)입니다.',
             '- 확신이 없으면 달성(true)으로 판정하세요.',
             '다른 설명 없이 JSON 한 줄만 출력: {"achieved": true|false, "reason": "한 문장 근거"}',
         ].join('\n'),
         user: `## GOAL\n${goal}\n\n## ANSWER\n${answer}`
+            + (artifactSummary ? `\n\n## ARTIFACTS\n${artifactSummary}` : '')
             + (executionContext ? `\n\n## EXECUTION\n${executionContext}` : '')
             + '\n\n판정 JSON 을 출력하세요.',
     };

--- a/apps/api/src/services/agent-task/__tests__/goal-judge.test.ts
+++ b/apps/api/src/services/agent-task/__tests__/goal-judge.test.ts
@@ -6,7 +6,7 @@
  * 종료는 호출자(AgentTaskService)가 담당하며 agent-task-input-files.test.ts 가 통합 커버한다.
  * 여기서는 judge 가 false 를 돌려주는 경로(계약의 goal-judge 쪽 절반)와 fail-open 을 고정한다.
  */
-import { judgeGoalAchieved, buildJudgeExecutionContext, buildJudgeToolEvidence,  judgeGoal } from '../goal-judge';
+import { judgeGoalAchieved, buildJudgeExecutionContext, buildJudgeToolEvidence,  judgeGoal, buildJudgeArtifactSummary } from '../goal-judge';
 import { AGENT_TASK_LIMITS } from '../../../config/runtime-limits';
 import type { LLMClient } from '../../../llm';
 
@@ -210,5 +210,39 @@ describe('buildJudgeToolEvidence — terminate/plan 결과는 증거 창에서 �
         expect(ev).toContain('data.json report.html');
         expect(ev).not.toContain('계획 (1/7');
         expect(ev).not.toContain('__TASK_TERMINATE__');
+    });
+});
+
+describe('buildJudgeArtifactSummary — ANSWER 에서 떨어져 나간 산출물을 되돌려준다', () => {
+    const art = (over = {}) => ({ kind: 'code', title: '변환 함수', lang: 'python', content: 'def f():\n    return 1', ...over });
+
+    it('종류·제목·본문 앞부분을 싣는다', () => {
+        const out = buildJudgeArtifactSummary([art()]);
+        expect(out).toContain('[code/python]');
+        expect(out).toContain('변환 함수');
+        expect(out).toContain('def f()');
+    });
+
+    it('lang 이 없으면 kind 만 표기하고, 제목이 비면 표식으로 대체', () => {
+        const out = buildJudgeArtifactSummary([art({ kind: 'markdown', lang: null, title: '' })]);
+        expect(out).toContain('[markdown]');
+        expect(out).toContain('(제목 없음)');
+    });
+
+    it('본문은 항목당 캡으로 자른다', () => {
+        const out = buildJudgeArtifactSummary([art({ content: 'x'.repeat(5000) })]);
+        expect(out.length).toBeLessThan(AGENT_TASK_LIMITS.GOAL_JUDGE_ARTIFACT_ITEM_CHARS + 200);
+    });
+
+    it('개수 상한을 넘는 산출물은 앞에서부터만 싣는다', () => {
+        const many = Array.from({ length: AGENT_TASK_LIMITS.GOAL_JUDGE_ARTIFACT_MAX_ITEMS + 3 },
+            (_, i) => art({ title: `t${i}` }));
+        const out = buildJudgeArtifactSummary(many);
+        expect(out).toContain('t0');
+        expect(out).not.toContain(`t${AGENT_TASK_LIMITS.GOAL_JUDGE_ARTIFACT_MAX_ITEMS}`);
+    });
+
+    it('산출물이 없으면 빈 문자열 (프롬프트에 ARTIFACTS 섹션이 붙지 않는다)', () => {
+        expect(buildJudgeArtifactSummary([])).toBe('');
     });
 });

--- a/apps/api/src/services/agent-task/finalize.test.ts
+++ b/apps/api/src/services/agent-task/finalize.test.ts
@@ -12,7 +12,10 @@ jest.mock('../../config/runtime-limits', () => {
         },
     };
 });
+// 산출물 렌더(buildJudgeArtifactSummary)는 실제 구현을 쓴다 — judge 에 실제로 무엇이
+// 도달하는지가 검증 대상이라 mock 으로 대체하면 의미가 없다.
 jest.mock('./goal-judge', () => ({
+    ...jest.requireActual('./goal-judge'),
     judgeGoal: jest.fn(),
     judgeGoalAchieved: jest.fn(),
     buildJudgeExecutionContext: jest.fn(() => 'ctx'),
@@ -140,6 +143,28 @@ describe('finalizeTask — 완료 관문 단일화(091)', () => {
         // 마지막 인자로 shadow:true 가 넘어가 step_type='judge_shadow' 로 갈린다.
         expect(judgeStepMock).toHaveBeenCalledWith(
             'task-1', expect.any(Number), 'achieved', '산출물 확인', '', 'ctx', { shadow: true });
+    });
+
+    it('셰도우 판정에는 산출물 본문을 함께 싣는다 (ANSWER 에서 떨어져 나가므로)', async () => {
+        judgeMock.mockResolvedValue({ achieved: true, reason: '산출물 확인', raw: '' });
+        const i = input({ rawContent: WITH_ARTIFACT });
+
+        await finalizeTask(i);
+
+        // 6번째 인자 = 산출물 렌더. 실제 코드 본문이 judge 에 도달해야 한다
+        // (2026-08-27 첫 셰도우 표본 오판: "코드가 제출되지 않고 아티팩트 참조만 있습니다").
+        const summary = judgeMock.mock.calls[0][5];
+        expect(summary).toContain('print(1)');
+        expect(summary).toContain('[code/python]');
+    });
+
+    it('적용 경로(아티팩트 0)는 산출물 인자가 없다', async () => {
+        judgeMock.mockResolvedValue({ achieved: true, reason: '수행 확인', raw: '' });
+        const i = input({ rawContent: '작업을 마쳤습니다.' });
+
+        await finalizeTask(i);
+
+        expect(judgeMock.mock.calls[0][5]).toBeUndefined();
     });
 
     it('셰도우 판정이 미달성이어도 완료를 뒤집지 않는다 (fail-open 계약)', async () => {

--- a/apps/api/src/services/agent-task/finalize.ts
+++ b/apps/api/src/services/agent-task/finalize.ts
@@ -27,7 +27,7 @@ import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
 import { extractAndStripArtifacts } from '../../llm/artifact-parser';
 import { applyReportRender } from '../chat-service/report-block';
 import { AGENT_TASK_INCOMPLETE_MARKER, getAgentTaskVerifyFailedNudge } from '../../prompts/agent-task-prompt';
-import { judgeGoal, buildJudgeExecutionContext } from './goal-judge';
+import { judgeGoal, buildJudgeExecutionContext, buildJudgeArtifactSummary } from './goal-judge';
 import { verifyCodeArtifacts } from './deliverable-verify';
 import { persistArtifactSteps, persistJudgeStep } from './task-steps';
 import { maybePersistCodeDiff } from './code-diff';
@@ -134,8 +134,10 @@ export async function finalizeTask(input: FinalizeInput): Promise<FinalizeOutcom
     if (AGENT_TASK_LIMITS.GOAL_JUDGE_ENABLED
         && (judgeApplies || AGENT_TASK_LIMITS.GOAL_JUDGE_SHADOW_ENABLED)) {
         const execCtx = buildJudgeExecutionContext(usedTools, turn + 1, taskRuntime?.getPlanSnapshot() ?? [], toolEvidence);
+        // 셰도우 경로에선 ANSWER 에서 떨어져 나간 산출물을 함께 싣는다(적용 경로는 아티팩트 0 이라 빈 값).
         const outcome = await judgeGoal(
-            await judgeClientFor(userId), goal, body ?? '', signal, execCtx);
+            await judgeClientFor(userId), goal, body ?? '', signal, execCtx,
+            artifacts.length > 0 ? buildJudgeArtifactSummary(artifacts) : undefined);
         const achieved = outcome.achieved;
         const judged: JudgeVerdict = achieved === null ? 'unknown' : achieved ? 'achieved' : 'not_achieved';
         // 판정·사유·입력 요약을 스텝으로 남긴다 — 오판 사후 규명용(관측 전용, fail-open).

--- a/apps/api/src/services/agent-task/goal-judge.ts
+++ b/apps/api/src/services/agent-task/goal-judge.ts
@@ -32,6 +32,29 @@ export function buildJudgeToolEvidence(
     return items.join('\n');
 }
 
+/**
+ * judge 에 실을 **제출 산출물** 렌더 — 종류·제목·본문 앞부분.
+ *
+ * `finalize` 가 judge 에 넘기는 ANSWER 는 `extractAndStripArtifacts` 를 거친 본문이라
+ * 아티팩트가 **떨어져 나가 있다**. 발동 조건이 아티팩트 0 이던 동안엔 실을 것이 없어 문제가
+ * 드러나지 않았지만, 셰도우 확대(2026-08-27) 첫 표본이 바로 이 갭에 걸렸다 — 코드 아티팩트를
+ * 정상 제출한 작업에 judge 가 "실제 코드가 제출되지 않고 아티팩트 참조만 있습니다"로
+ * 미달성 판정했다(본문은 artifact 스텝에 멀쩡히 있었다). 산출물을 못 보고 내리는 판정은
+ * 표본으로 쓸 수 없으므로 여기서 함께 싣는다.
+ */
+export function buildJudgeArtifactSummary(
+    artifacts: ReadonlyArray<{ kind: string; title: string; lang: string | null; content: string }>,
+): string {
+    return artifacts
+        .slice(0, AGENT_TASK_LIMITS.GOAL_JUDGE_ARTIFACT_MAX_ITEMS)
+        .map((a, i) => {
+            const head = a.content.trim().slice(0, AGENT_TASK_LIMITS.GOAL_JUDGE_ARTIFACT_ITEM_CHARS);
+            const type = a.lang ? `${a.kind}/${a.lang}` : a.kind;
+            return `${i + 1}. [${type}] ${a.title || '(제목 없음)'}\n${head}`;
+        })
+        .join('\n\n');
+}
+
 /** 5-3(b): judge 에 제공할 실행 컨텍스트(수행 흔적) 렌더 — 사용 도구·턴수·계획 상태·도구 결과. */
 export function buildJudgeExecutionContext(
     usedTools: ReadonlySet<string>,
@@ -72,12 +95,15 @@ export async function judgeGoal(
     answer: string,
     signal: AbortSignal,
     executionContext?: string,
+    /** 제출 산출물 렌더(buildJudgeArtifactSummary) — ANSWER 에서 떨어져 나간 아티팩트를 되돌려준다. */
+    artifactSummary?: string,
 ): Promise<JudgeOutcome> {
     try {
         const { system, user } = getAgentTaskGoalJudgeMessages(
             goal,
             answer.slice(0, AGENT_TASK_LIMITS.GOAL_JUDGE_MAX_ANSWER_CHARS),
             executionContext,
+            artifactSummary,
         );
         const r = await client.chat(
             [{ role: 'system', content: system }, { role: 'user', content: user }],


### PR DESCRIPTION
## 배경 — 셰도우(#653) 첫 라이브 표본이 즉시 갭을 드러냈다

코드 아티팩트를 **정상 제출한** 작업에 judge 가 이렇게 판정했다:

> `not_achieved` — "실제 파이썬 함수 코드가 제출되지 않고 **아티팩트 참조만** 있습니다"

그런데 artifact 스텝에는 `def celsius_to_fahrenheit(...)` 본문이 멀쩡히 있었다.

원인은 `finalize.ts:99` — judge 에 넘기는 `body` 는 `extractAndStripArtifacts` 를 거친 본문이라 **아티팩트가 떨어져 나가 있다**. 실행 컨텍스트에도 산출물 정보가 없다. 발동 조건이 `artifacts.length===0` 이던 동안엔 실을 것이 없어 이 갭이 **구조적으로 은폐**돼 있었다.

이대로 표본을 쌓으면 아티팩트 작업이 전부 `not_achieved` 로 쌓여 **9/8 오판율 재측정이 무의미**해진다. 셰도우가 도는 건 아티팩트를 내는 작업뿐이고(예약 리포트는 산출물이 workspace 파일이라 적용 경로로 간다) 실측상 하루 2~3건이라, 9/8 까지 25~35건이 오염된 채 쌓인다.

## 변경

- `buildJudgeArtifactSummary` — 종류·제목·본문 앞부분 렌더 (상한 `GOAL_JUDGE_ARTIFACT_MAX_ITEMS` 5 · `_ITEM_CHARS` 400)
- judge 프롬프트에 `## ARTIFACTS` 섹션 + system 지침 3줄("산출물이 목표에 부합하면 ANSWER 가 짧더라도 달성")
- `finalize` 가 아티팩트가 있을 때만 전달 — **적용 경로(아티팩트 0)는 실을 것이 없어 무영향**, 위험은 셰도우에 한정

## 검증

- 전체 유닛 **3,081건 통과**(283 스위트) · `tsc --noEmit` · lint 통과
- 신규 테스트: 산출물 렌더 5건(형식·lang null·본문 캡·개수 상한·빈 배열), finalize 2건(셰도우엔 실제 본문 `print(1)` 도달 / 적용 경로는 `undefined`)
- `finalize.test.ts` 의 `goal-judge` mock 을 `requireActual` 기반으로 바꿔 **실제 렌더가 judge 에 도달하는지**를 검증 — mock 으로 대체하면 이 PR 의 검증 대상이 사라진다

배포 후 같은 goal 로 재실행해 판정이 뒤집히는지 확인한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)