### PR TITLE
feat(metrics): 도구별 실패율·실패 원인 관측 — 분모 있는 도구 헬스 지표 (P0-a PR1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1533,3 +1533,18 @@ CHAT_USER_MCP_SCHEMA_BUDGET_BYTES=16000
 # 재부팅·주기 정리로 사라져 장애 후 원인 로그가 없을 수 있다 — 영속 볼륨 경로를 권장.
 # 변경 반영은 pm2 delete → pm2 start ecosystem.config.js → pm2 save (restart 로는 로그 경로가 안 바뀜).
 # OMK_LOG_DIR=/var/log/openmake
+
+# *******************************************************
+# 도구 헬스 관측 (config/tool-health.ts)
+# *******************************************************
+# GET /api/metrics/tools/health (admin) 의 조회 기본값·상한. 소스는 audit_logs 의
+# mcp_tool_call 행이라 채팅·에이전트 작업 양쪽 도구 호출을 함께 집계한다.
+# ⚠️ 실패율 상위는 조회 창(days)에 따라 뒤집힌다 — 창을 넓히면 이미 해소된 과거 장애가
+#    상위로 올라온다. 진행 중인 문제를 보려면 짧은 창을, 추세를 보려면 긴 창을 쓴다.
+# TOOL_HEALTH_DEFAULT_DAYS=30
+# TOOL_HEALTH_MAX_DAYS=180
+# 목록에 포함할 최소 호출 수 — 1회 호출 1회 실패(100%)가 상위를 점거하는 것을 막는다.
+# TOOL_HEALTH_DEFAULT_MIN_CALLS=3
+# TOOL_HEALTH_MAX_MIN_CALLS=1000
+# TOOL_HEALTH_DEFAULT_LIMIT=30
+# TOOL_HEALTH_MAX_LIMIT=200

--- a/apps/api/src/__tests__/routes/tool-health.routes.test.ts
+++ b/apps/api/src/__tests__/routes/tool-health.routes.test.ts
@@ -1,0 +1,96 @@
+/**
+ * tool-health.routes — 도구 헬스 관측 API 테스트.
+ *
+ * 무DB — repository 는 mock, auth 미들웨어는 role 주입 mock 으로 우회.
+ * 검증 대상은 라우트가 가진 실제 로직: 파라미터 클램프, 실패율 계산, 도구×카테고리 병합.
+ */
+import express, { type Request, type Response, type NextFunction } from 'express';
+import request from 'supertest';
+
+let currentRole: 'admin' | 'user' = 'admin';
+
+jest.mock('../../auth', () => ({
+    requireAuth: (req: Request & { user?: object }, _res: Response, next: NextFunction) => {
+        req.user = { id: 'test-admin', userId: 'test-admin', role: currentRole };
+        next();
+    },
+    requireAdmin: (req: Request & { user?: { role?: string } }, res: Response, next: NextFunction) => {
+        if (req.user?.role === 'admin') next();
+        else res.status(403).json({ success: false, error: 'FORBIDDEN' });
+    },
+}));
+
+const getToolHealth = jest.fn();
+const getErrorCategories = jest.fn();
+const getSummary = jest.fn();
+jest.mock('../../data/repositories/tool-health-repository', () => ({
+    ToolHealthRepository: jest.fn().mockImplementation(() => ({ getToolHealth, getErrorCategories, getSummary })),
+}));
+jest.mock('../../data/models/unified-database', () => ({ getPool: () => ({}) }));
+
+import { toolHealthRouter } from '../../routes/tool-health.routes';
+
+function makeApp() {
+    const app = express();
+    app.use('/api/metrics/tools', toolHealthRouter);
+    return app;
+}
+
+describe('GET /api/metrics/tools/health', () => {
+    beforeEach(() => {
+        currentRole = 'admin';
+        getToolHealth.mockReset().mockResolvedValue([]);
+        getErrorCategories.mockReset().mockResolvedValue([]);
+        getSummary.mockReset().mockResolvedValue({ calls: '0', errors: '0', distinct_tools: '0', failing_tools: '0' });
+    });
+
+    it('비관리자는 403', async () => {
+        currentRole = 'user';
+        await request(makeApp()).get('/api/metrics/tools/health').expect(403);
+    });
+
+    it('실패율을 계산하고 도구별 카테고리를 병합한다', async () => {
+        getSummary.mockResolvedValue({ calls: '100', errors: '25', distinct_tools: '9', failing_tools: '4' });
+        getToolHealth.mockResolvedValue([
+            { tool: 'a::b', server: 'a', calls: '4', errors: '3', last_error_at: new Date('2026-08-20T00:00:00Z'), p50_duration_ms: '12' },
+            { tool: 'c', server: 'builtin', calls: '10', errors: '0', last_error_at: null, p50_duration_ms: null },
+        ]);
+        getErrorCategories.mockResolvedValue([
+            { tool: 'a::b', category: 'timeout', count: '2' },
+            { tool: 'a::b', category: null, count: '1' },
+        ]);
+
+        const res = await request(makeApp()).get('/api/metrics/tools/health').expect(200);
+        const data = res.body.data;
+
+        expect(data.summary.errorRate).toBeCloseTo(0.25);
+        expect(data.tools[0].errorRate).toBeCloseTo(0.75);
+        expect(data.tools[0].p50DurationMs).toBe(12);
+        expect(data.tools[0].lastErrorAt).toBe('2026-08-20T00:00:00.000Z');
+        // 카테고리 미기록 실패는 'unknown' 으로 묶는다 — 키를 비우면 "원인 없음" 과 구분되지 않는다.
+        expect(data.tools[0].byCategory).toEqual({ timeout: 2, unknown: 1 });
+        // 실패 0 인 도구는 빈 맵 + null 안전
+        expect(data.tools[1].errorRate).toBe(0);
+        expect(data.tools[1].byCategory).toEqual({});
+        expect(data.tools[1].p50DurationMs).toBeNull();
+        expect(data.tools[1].lastErrorAt).toBeNull();
+    });
+
+    it('파라미터는 기본값이 아니라 경계로 클램프된다', async () => {
+        await request(makeApp()).get('/api/metrics/tools/health?days=99999&minCalls=0&limit=99999').expect(200);
+        const [days, minCalls, limit] = getToolHealth.mock.calls[0];
+        expect(days).toBe(180);   // MAX_DAYS
+        expect(minCalls).toBe(1); // 하한
+        expect(limit).toBe(200);  // MAX_LIMIT
+    });
+
+    it('숫자가 아닌 파라미터는 기본값', async () => {
+        await request(makeApp()).get('/api/metrics/tools/health?days=abc').expect(200);
+        expect(getToolHealth.mock.calls[0][0]).toBe(30);
+    });
+
+    it('호출 0 이어도 errorRate 는 NaN 이 아닌 0', async () => {
+        const res = await request(makeApp()).get('/api/metrics/tools/health').expect(200);
+        expect(res.body.data.summary.errorRate).toBe(0);
+    });
+});

--- a/apps/api/src/config/tool-health.ts
+++ b/apps/api/src/config/tool-health.ts
@@ -1,0 +1,27 @@
+/**
+ * 도구 헬스 관측 설정 (L2).
+ *
+ * 도구별 실패율 조회의 기본값·상한. 상한은 관리자 UI 가 큰 값을 보내도 집계가 폭주하지
+ * 않게 하는 방어선이다(소스 `audit_logs` 는 전 사용자 도구 호출이 쌓이는 테이블).
+ *
+ * ⚠️ 실패율 상위는 조회 창(days)에 따라 뒤집힌다 — 60일 누계 1위 도구가 30일로는 하위인
+ * 사례가 실측됐다(2026-08-28). 창과 최소 표본을 호출자가 정할 수 있어야 하는 이유.
+ *
+ * @module config/tool-health
+ */
+
+/** 도구 헬스 조회 파라미터 기본값·경계. */
+export const TOOL_HEALTH_QUERY = {
+    /** 기본 조회 기간(일). */
+    DEFAULT_DAYS: parseInt(process.env.TOOL_HEALTH_DEFAULT_DAYS || '30', 10),
+    /** 조회 가능한 최대 기간(일). */
+    MAX_DAYS: parseInt(process.env.TOOL_HEALTH_MAX_DAYS || '180', 10),
+    /** 목록에 포함할 최소 호출 수 — 1회 호출 1회 실패(100%)가 상위를 점거하는 것을 막는다. */
+    DEFAULT_MIN_CALLS: parseInt(process.env.TOOL_HEALTH_DEFAULT_MIN_CALLS || '3', 10),
+    /** minCalls 상한. */
+    MAX_MIN_CALLS: parseInt(process.env.TOOL_HEALTH_MAX_MIN_CALLS || '1000', 10),
+    /** 기본 반환 도구 수. */
+    DEFAULT_LIMIT: parseInt(process.env.TOOL_HEALTH_DEFAULT_LIMIT || '30', 10),
+    /** 반환 도구 수 상한. */
+    MAX_LIMIT: parseInt(process.env.TOOL_HEALTH_MAX_LIMIT || '200', 10),
+} as const;

--- a/apps/api/src/data/repositories/__tests__/tool-health-repository.test.ts
+++ b/apps/api/src/data/repositories/__tests__/tool-health-repository.test.ts
@@ -1,0 +1,61 @@
+import { Pool } from 'pg';
+import { ToolHealthRepository } from '../tool-health-repository';
+
+jest.mock('../../retry-wrapper', () => ({ withRetry: (fn: () => unknown) => fn() }));
+
+function makeMockPool() {
+    return { query: jest.fn() } as unknown as Pool;
+}
+
+describe('ToolHealthRepository', () => {
+    let pool: Pool;
+    let repo: ToolHealthRepository;
+
+    beforeEach(() => {
+        pool = makeMockPool();
+        repo = new ToolHealthRepository(pool);
+    });
+
+    it('getToolHealth: audit_logs 소스 + 분모(COUNT(*)) 포함 + minCalls HAVING', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({
+            rows: [{ tool: 'open-design::list_projects', server: 'open-design', calls: '14', errors: '6', last_error_at: new Date(0), p50_duration_ms: '25' }],
+        });
+        const rows = await repo.getToolHealth(30, 3, 20);
+        expect(rows).toHaveLength(1);
+        const [sql, params] = (pool.query as jest.Mock).mock.calls[0];
+        expect(sql).toMatch(/FROM audit_logs/);
+        expect(sql).toMatch(/action = 'mcp_tool_call'/);
+        // 분모가 이 지표의 존재 이유 — COUNT(*) 가 빠지면 기존 '오류 건수' 지표와 같아진다.
+        expect(sql).toMatch(/COUNT\(\*\) AS calls/);
+        expect(sql).toMatch(/HAVING COUNT\(\*\) >= \$2/);
+        expect(params).toEqual(['30', '3', '20']);
+    });
+
+    it('getToolHealth: durationMs 가 숫자가 아닌 행은 p50 계산에서 제외(캐스팅 실패 방지)', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+        await repo.getToolHealth(7, 1, 5);
+        const [sql] = (pool.query as jest.Mock).mock.calls[0];
+        expect(sql).toMatch(/durationMs' ~ '\^\[0-9\]\+\$'/);
+    });
+
+    it('getErrorCategories: 실패 행만 + 도구×카테고리 GROUP BY', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({
+            rows: [
+                { tool: 'a::b', category: 'timeout', count: '3' },
+                { tool: 'a::b', category: null, count: '1' },
+            ],
+        });
+        const rows = await repo.getErrorCategories(30);
+        expect(rows).toHaveLength(2);
+        const [sql, params] = (pool.query as jest.Mock).mock.calls[0];
+        expect(sql).toMatch(/details->>'isError' = 'true'/);
+        expect(sql).toMatch(/GROUP BY resource_id, details->>'errorCategory'/);
+        expect(params).toEqual(['30']);
+    });
+
+    it('getSummary: 빈 결과 시 0 기본값', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+        const row = await repo.getSummary(7);
+        expect(row).toEqual({ calls: '0', errors: '0', distinct_tools: '0', failing_tools: '0' });
+    });
+});

--- a/apps/api/src/data/repositories/tool-health-repository.ts
+++ b/apps/api/src/data/repositories/tool-health-repository.ts
@@ -1,0 +1,106 @@
+/**
+ * @module data/repositories/tool-health-repository
+ * @description 도구별 실행 건전성(호출·실패·실패율·원인) 읽기 전용 집계 계층
+ *
+ * 소스는 `audit_logs(action='mcp_tool_call')` — `unified-client.auditToolCall` 이 채팅·에이전트
+ * 작업 **양쪽** 경로에서 남기므로, 에이전트 작업만 보는 `agent-task-metrics-repository` 와 달리
+ * 전 경로를 덮는다. 그리고 성공 호출도 행으로 남으므로 **분모(호출 수)** 가 있다 —
+ * 기존 도구 오류 지표는 오류 건수 top N 뿐이라 "6번 호출해 5번 실패한 도구" 가 보이지 않았다.
+ *
+ * ⚠️ 감사 기록은 fire-and-forget(`void`)이라 유실될 수 있다 — 이 집계는 하한이다.
+ * ⚠️ `errorCategory` 는 2026-08-28 이후 호출에만 있다(그 이전 실패는 카테고리 미상).
+ *
+ * 전부 파라미터화 쿼리, read-only. 숫자 파싱(COUNT 는 문자열로 옴)은 응답 조립부에 남긴다.
+ */
+import { BaseRepository } from './base-repository';
+
+/** 도구 단위 집계 행 — 분모(calls) 포함이 이 지표의 존재 이유. */
+export interface ToolHealthRow {
+    tool: string;
+    server: string | null;
+    calls: string;
+    errors: string;
+    last_error_at: Date | null;
+    p50_duration_ms: string | null;
+}
+
+/** 도구 × 실패 카테고리 건수 — 원인별 분해(도구가 고장인지 모델이 틀린 것인지). */
+export interface ToolErrorCategoryRow {
+    tool: string;
+    category: string | null;
+    count: string;
+}
+
+/** 기간 전체 요약 — 도구 단위 목록의 상단 타일. */
+export interface ToolHealthSummaryRow {
+    calls: string;
+    errors: string;
+    distinct_tools: string;
+    failing_tools: string;
+}
+
+export class ToolHealthRepository extends BaseRepository {
+    /**
+     * 도구별 호출/실패/실패율 재료. `minCalls` 미만 표본은 제외한다 —
+     * 1회 호출 1회 실패가 100% 로 상위를 차지하면 목록이 쓸모없어진다.
+     * 정렬은 실패율 desc, 동률이면 호출 수 desc.
+     */
+    async getToolHealth(days: number, minCalls: number, limit: number): Promise<ToolHealthRow[]> {
+        const result = await this.query<ToolHealthRow>(
+            `SELECT resource_id AS tool,
+                    MAX(details->>'server') AS server,
+                    COUNT(*) AS calls,
+                    COUNT(*) FILTER (WHERE details->>'isError' = 'true') AS errors,
+                    MAX(timestamp) FILTER (WHERE details->>'isError' = 'true') AS last_error_at,
+                    percentile_disc(0.5) WITHIN GROUP (
+                        ORDER BY CASE WHEN details->>'durationMs' ~ '^[0-9]+$'
+                                      THEN (details->>'durationMs')::bigint END
+                    ) AS p50_duration_ms
+             FROM audit_logs
+             WHERE action = 'mcp_tool_call'
+               AND resource_id IS NOT NULL
+               AND timestamp >= NOW() - ($1 || ' days')::interval
+             GROUP BY resource_id
+             HAVING COUNT(*) >= $2
+             ORDER BY (COUNT(*) FILTER (WHERE details->>'isError' = 'true'))::numeric / COUNT(*) DESC,
+                      COUNT(*) DESC,
+                      resource_id
+             LIMIT $3`,
+            [String(days), String(minCalls), String(limit)]
+        );
+        return result.rows;
+    }
+
+    /** 도구 × 카테고리 실패 건수 (카테고리 미기록 실패는 category=null 로 묶임). */
+    async getErrorCategories(days: number): Promise<ToolErrorCategoryRow[]> {
+        const result = await this.query<ToolErrorCategoryRow>(
+            `SELECT resource_id AS tool,
+                    details->>'errorCategory' AS category,
+                    COUNT(*) AS count
+             FROM audit_logs
+             WHERE action = 'mcp_tool_call'
+               AND resource_id IS NOT NULL
+               AND details->>'isError' = 'true'
+               AND timestamp >= NOW() - ($1 || ' days')::interval
+             GROUP BY resource_id, details->>'errorCategory'`,
+            [String(days)]
+        );
+        return result.rows;
+    }
+
+    /** 기간 요약 — 총 호출·총 실패·도구 수·실패가 1건이라도 있는 도구 수. */
+    async getSummary(days: number): Promise<ToolHealthSummaryRow> {
+        const result = await this.query<ToolHealthSummaryRow>(
+            `SELECT COUNT(*) AS calls,
+                    COUNT(*) FILTER (WHERE details->>'isError' = 'true') AS errors,
+                    COUNT(DISTINCT resource_id) AS distinct_tools,
+                    COUNT(DISTINCT resource_id) FILTER (WHERE details->>'isError' = 'true') AS failing_tools
+             FROM audit_logs
+             WHERE action = 'mcp_tool_call'
+               AND resource_id IS NOT NULL
+               AND timestamp >= NOW() - ($1 || ' days')::interval`,
+            [String(days)]
+        );
+        return result.rows[0] ?? { calls: '0', errors: '0', distinct_tools: '0', failing_tools: '0' };
+    }
+}

--- a/apps/api/src/mcp/__tests__/tool-error-category-audit.test.ts
+++ b/apps/api/src/mcp/__tests__/tool-error-category-audit.test.ts
@@ -1,0 +1,72 @@
+/**
+ * 실패 분류(errorCategory)의 전달 계약 검증.
+ *
+ * 계약: `ToolRouter.executeTool` 의 fail() 이 분류를 결과에 싣고 →
+ *       `UnifiedMCPClient.executeToolWithContext` 가 감사에 넘긴 뒤 **응답에서 제거**한다.
+ * 제거가 빠지면 내부 전용 필드가 도구 소비자(LLM 루프)에게 새고,
+ * 전달이 빠지면 실패 원인이 다시 문자열 매칭으로 퇴행한다.
+ */
+const logAudit = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../services/AuditService', () => ({ getAuditService: () => ({ logAudit }) }));
+
+import { ToolRouter } from '../tool-router';
+import { UnifiedMCPClient } from '../unified-client';
+
+describe('도구 실패 분류 전달·비노출', () => {
+    beforeEach(() => logAudit.mockClear());
+
+    it('ToolRouter.executeTool: fail() 이 errorCategory/retryable 을 결과에 싣는다', async () => {
+        const router = new ToolRouter();
+        const result = await router.executeTool('definitely_unknown_tool', {});
+        expect(result.isError).toBe(true);
+        expect(result.errorCategory).toBe('not_found');
+        expect(result.retryable).toBe(false);
+    });
+
+    it('UnifiedMCPClient: 분류를 감사에 기록하고 응답에서는 제거한다', async () => {
+        const client = new UnifiedMCPClient();
+        const result = await client.executeToolWithContext(
+            'definitely_unknown_tool',
+            {},
+            { userId: 'guest', role: 'user' } as never,
+        );
+
+        expect(result.isError).toBe(true);
+        // 응답 비노출 — 필드 자체가 없어야 한다(undefined 로 남기면 직렬화에 키가 생길 수 있다).
+        expect('errorCategory' in result).toBe(false);
+        expect('retryable' in result).toBe(false);
+
+        // 감사에는 실렸는가 (fire-and-forget 이라 마이크로태스크 한 바퀴 대기)
+        await new Promise((r) => setImmediate(r));
+        expect(logAudit).toHaveBeenCalledTimes(1);
+        const details = logAudit.mock.calls[0][0].details;
+        expect(details.isError).toBe(true);
+        expect(details.errorCategory).toBe('not_found');
+        expect(details.retryable).toBe(false);
+    });
+
+    it('성공 호출에는 분류 키가 붙지 않는다 (실패에만 카테고리가 생긴다)', async () => {
+        const client = new UnifiedMCPClient();
+        client.getToolRouter().registerExternalTools(
+            'srv-ok',
+            'okserver',
+            [{ name: 'ping', description: 'test', inputSchema: { type: 'object', properties: {} } }],
+            async () => ({ content: [{ type: 'text', text: 'pong' }] }),
+        );
+
+        const result = await client.executeToolWithContext(
+            'okserver::ping',
+            {},
+            { userId: 'guest', role: 'user' } as never,
+        );
+
+        expect(result.isError).toBeFalsy();
+        expect('errorCategory' in result).toBe(false);
+
+        await new Promise((r) => setImmediate(r));
+        const details = logAudit.mock.calls[0][0].details;
+        expect(details.isError).toBe(false);
+        expect(Object.keys(details)).not.toContain('errorCategory');
+        expect(Object.keys(details)).not.toContain('retryable');
+    });
+});

--- a/apps/api/src/mcp/tool-router.ts
+++ b/apps/api/src/mcp/tool-router.ts
@@ -216,7 +216,14 @@ export class ToolRouter {
                 span.setAttribute('tool.error_category', c.category);
                 span.setAttribute('tool.error_retryable', c.retryable);
                 logger.warn(`Tool error [${name}] category=${c.category} retryable=${c.retryable}: ${rawMessage}`);
-                return { content: [{ type: 'text', text: formatToolError(rawMessage, c) }], isError: true };
+                // 분류를 결과에 실어 감사 계층(unified-client.auditToolCall)이 영속하게 한다.
+                // 소비자에게 새 필드가 새지 않도록 그 계층이 기록 직후 제거한다.
+                return {
+                    content: [{ type: 'text', text: formatToolError(rawMessage, c) }],
+                    isError: true,
+                    errorCategory: c.category,
+                    retryable: c.retryable,
+                };
             };
             // 도구가 isError 결과를 반환하면 분류·교정해 정규화, 정상이면 그대로 통과.
             const finalize = (result: MCPToolResult): MCPToolResult => {

--- a/apps/api/src/mcp/types.ts
+++ b/apps/api/src/mcp/types.ts
@@ -15,6 +15,7 @@
  */
 
 import type { UserContext } from './user-sandbox';
+import type { ToolErrorCategory } from './tool-error-classifier';
 
 /**
  * MCP JSON-RPC 2.0 요청 메시지
@@ -144,6 +145,15 @@ export interface MCPToolResult {
     }>;
     /** 에러 발생 여부 (true이면 content에 에러 메시지 포함) */
     isError?: boolean;
+    /**
+     * 실패 분류 — `ToolRouter.executeTool` 의 fail() 이 `classifyToolError` 결과를 실어 보내는
+     * **내부 전용** 필드. 도구 호출 감사(`auditToolCall`)가 읽어 `audit_logs.details` 에 남긴 뒤
+     * 응답에서 제거하므로, 도구 소비자(LLM 루프)에게는 노출되지 않는다.
+     * 종전에는 이 분류가 OTel span 속성으로만 나가 사후 집계가 불가능했다(문자열 매칭에 의존).
+     */
+    errorCategory?: ToolErrorCategory;
+    /** 실패가 재시도로 해소될 수 있는지 — errorCategory 와 같은 경로·같은 수명. */
+    retryable?: boolean;
 }
 
 /**

--- a/apps/api/src/mcp/unified-client.ts
+++ b/apps/api/src/mcp/unified-client.ts
@@ -24,6 +24,7 @@
 
 import { MCPServer, createMCPServer } from './server';
 import { MCPToolResult } from './types';
+import type { ToolErrorCategory } from './tool-error-classifier';
 import { UserSandbox, UserContext } from './user-sandbox';
 import { ToolRouter } from './tool-router';
 import { MCPServerRegistry } from './server-registry';
@@ -206,14 +207,23 @@ export class UnifiedMCPClient {
         // 전달되지 않는다. 에이전트 루프(runTool)와 동일한 canonical 경로.
         const startedAt = Date.now();
         const result = await this.toolRouter.executeTool(toolName, sandboxedArgs, context);
+        // 실패 분류(fail() 이 실어 보낸 내부 전용 필드)를 감사에 넘기고 응답에서는 지운다.
+        // ⚠️ 감사는 fire-and-forget 이라 result 를 나중에 읽는다 — 제거 전에 값을 꺼내 인자로 전달할 것.
+        const errorCategory = result?.errorCategory;
+        const retryable = result?.retryable;
+        if (result) {
+            delete result.errorCategory;
+            delete result.retryable;
+        }
         // tool call 감사 영속화 (fire-and-forget·비차단). 공개 운영 포렌식용.
-        void this.auditToolCall(toolName, context, result, Date.now() - startedAt);
+        void this.auditToolCall(toolName, context, result, Date.now() - startedAt, { errorCategory, retryable });
         return result;
     }
 
     /** MCP tool call 을 audit_logs 에 영속화. action='mcp_tool_call' 은 CRITICAL_ACTIONS 미포함 → 알림 없음. */
     private async auditToolCall(
         toolName: string, context: UserContext, result: MCPToolResult, durationMs: number,
+        classification: { errorCategory?: ToolErrorCategory; retryable?: boolean } = {},
     ): Promise<void> {
         try {
             const { getAuditService } = await import('../services/AuditService');
@@ -232,6 +242,9 @@ export class UnifiedMCPClient {
                     server: isExternal ? toolName.split('::')[0] : 'builtin',
                     role: context.role,
                     actorId: rawUid ?? 'guest',
+                    // 실패 분류 — 도구별 실패 원인 집계(도구 헬스)의 소스. 성공 호출엔 없다.
+                    ...(classification.errorCategory ? { errorCategory: classification.errorCategory } : {}),
+                    ...(classification.retryable !== undefined ? { retryable: classification.retryable } : {}),
                 },
             });
         } catch (e) { logger.debug(`audit 기록 실패(무시): ${e instanceof Error ? e.message : String(e)}`); }

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -19,6 +19,7 @@ export { notebooklmRouter } from './notebooklm.routes';
 export { mcpServerIngestRouter } from './mcp-server-ingest.routes';
 export { mcpCatalogAdminRouter } from './mcp-catalog-admin.routes';
 export { mcpAdminMonitoringRouter } from './mcp-admin-monitoring.routes';
+export { toolHealthRouter } from './tool-health.routes';
 export { adminModelRolesRouter } from './admin-model-roles.routes';
 export { adminSystemSettingsRouter } from './admin-system-settings.routes';
 export { firstRunSetupRouter } from './first-run-setup.routes';

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -42,6 +42,7 @@ import {
     mcpServerIngestRouter,
     mcpCatalogAdminRouter,
     mcpAdminMonitoringRouter,
+    toolHealthRouter,
     adminModelRolesRouter,
     adminSystemSettingsRouter,
     firstRunSetupRouter,
@@ -173,6 +174,8 @@ export function setupApiRoutes(
     setMetricsCluster(cluster);
 
     // 마운트 순서 중요: 구체적인 경로를 먼저, 파라미터 경로를 나중에
+    // 도구 헬스는 metricsRouter 보다 먼저 — 같은 /api/metrics 접두를 공유한다.
+    app.use('/api/metrics/tools', toolHealthRouter);
     app.use('/api/metrics', metricsRouter);
     // 🆕 스킬 라우트 — agentRouter(/:id catch-all) 보다 먼저 마운트 필수
     app.use('/api/agents/skills', skillsRouter);

--- a/apps/api/src/routes/tool-health.routes.ts
+++ b/apps/api/src/routes/tool-health.routes.ts
@@ -1,0 +1,87 @@
+/**
+ * 도구 헬스 관측 라우트 (admin 전용).
+ *
+ * 엔드포인트:
+ *   GET /api/metrics/tools/health?days=N&minCalls=N&limit=N
+ *     — 도구별 호출·실패·**실패율**·주 실패 카테고리·p50 소요·마지막 실패 시각.
+ *
+ * 기존 `GET /api/metrics/agent-tasks/tool-errors` 와의 차이(둘 다 유지):
+ *   ① 소스가 `audit_logs` 라 채팅·에이전트 작업 **양쪽** 경로를 덮는다(그쪽은 작업 스텝만).
+ *   ② 성공 호출도 세므로 **분모가 있다** — 저빈도·고실패 도구가 드러난다.
+ *   ③ 실패 원인이 문자열 시그니처가 아니라 분류 카테고리다.
+ *
+ * `metrics.routes.ts` 에 합치지 않은 이유: 그 파일이 517줄로 600줄 가드에 근접했고,
+ * 서킷 상태 조회·리셋(후속)이 같은 축으로 더 붙는다.
+ *
+ * @module routes/tool-health.routes
+ */
+import { Router, type Request, type Response } from 'express';
+import { requireAuth, requireAdmin } from '../auth';
+import { asyncHandler } from '../utils/error-handler';
+import { success } from '../utils/api-response';
+import { getPool } from '../data/models/unified-database';
+import { ToolHealthRepository } from '../data/repositories/tool-health-repository';
+import { TOOL_HEALTH_QUERY } from '../config/tool-health';
+
+export const toolHealthRouter = Router();
+toolHealthRouter.use(requireAuth, requireAdmin);
+
+/** 정수 쿼리 파라미터 파싱 — 범위를 벗어나면 기본값이 아니라 경계로 클램프. */
+function parseIntParam(raw: unknown, fallback: number, min: number, max: number): number {
+    const n = parseInt(String(raw ?? ''), 10);
+    if (!Number.isFinite(n)) return fallback;
+    return Math.min(Math.max(n, min), max);
+}
+
+toolHealthRouter.get('/health', asyncHandler(async (req: Request, res: Response) => {
+    const days = parseIntParam(req.query.days, TOOL_HEALTH_QUERY.DEFAULT_DAYS, 1, TOOL_HEALTH_QUERY.MAX_DAYS);
+    const minCalls = parseIntParam(req.query.minCalls, TOOL_HEALTH_QUERY.DEFAULT_MIN_CALLS, 1, TOOL_HEALTH_QUERY.MAX_MIN_CALLS);
+    const limit = parseIntParam(req.query.limit, TOOL_HEALTH_QUERY.DEFAULT_LIMIT, 1, TOOL_HEALTH_QUERY.MAX_LIMIT);
+
+    const repo = new ToolHealthRepository(getPool());
+    const [rows, categoryRows, summaryRow] = await Promise.all([
+        repo.getToolHealth(days, minCalls, limit),
+        repo.getErrorCategories(days),
+        repo.getSummary(days),
+    ]);
+
+    // 도구 → {카테고리: 건수}. 카테고리 미기록(2026-08-28 이전 실패)은 'unknown' 으로 묶는다 —
+    // 키를 비우면 프론트에서 "원인 없음" 과 구분되지 않는다.
+    const byCategory = new Map<string, Record<string, number>>();
+    for (const r of categoryRows) {
+        const bucket = byCategory.get(r.tool) ?? {};
+        bucket[r.category ?? 'unknown'] = Number(r.count);
+        byCategory.set(r.tool, bucket);
+    }
+
+    const calls = Number(summaryRow.calls);
+    const errors = Number(summaryRow.errors);
+
+    res.json(success({
+        days,
+        minCalls,
+        summary: {
+            calls,
+            errors,
+            errorRate: calls > 0 ? errors / calls : 0,
+            distinctTools: Number(summaryRow.distinct_tools),
+            failingTools: Number(summaryRow.failing_tools),
+        },
+        tools: rows.map((r) => {
+            const toolCalls = Number(r.calls);
+            const toolErrors = Number(r.errors);
+            return {
+                tool: r.tool,
+                server: r.server ?? null,
+                calls: toolCalls,
+                errors: toolErrors,
+                errorRate: toolCalls > 0 ? toolErrors / toolCalls : 0,
+                p50DurationMs: r.p50_duration_ms === null ? null : Number(r.p50_duration_ms),
+                lastErrorAt: r.last_error_at ? new Date(r.last_error_at).toISOString() : null,
+                byCategory: byCategory.get(r.tool) ?? {},
+            };
+        }),
+    }));
+}));
+
+export default toolHealthRouter;

--- a/apps/web/app/(workspace)/admin/metrics/page.tsx
+++ b/apps/web/app/(workspace)/admin/metrics/page.tsx
@@ -80,6 +80,31 @@ interface ToolErrorData {
   byToolName: { toolName: string; count: number }[];
 }
 
+/* ── 도구 헬스(실패율) 타입 ────────────────────────────────
+ * ToolErrorData 와 별개다: 소스가 audit_logs 라 채팅 경로까지 덮고, 성공 호출도 세므로
+ * 분모(calls)가 있어 "6번 호출해 5번 실패" 같은 저빈도·고실패 도구가 드러난다. */
+interface ToolHealthData {
+  days: number;
+  minCalls: number;
+  summary: {
+    calls: number;
+    errors: number;
+    errorRate: number;
+    distinctTools: number;
+    failingTools: number;
+  };
+  tools: {
+    tool: string;
+    server: string | null;
+    calls: number;
+    errors: number;
+    errorRate: number;
+    p50DurationMs: number | null;
+    lastErrorAt: string | null;
+    byCategory: Record<string, number>;
+  }[];
+}
+
 /* ── 작업 워크플로우 관측 타입 ─────────────────────────────── */
 interface WorkflowData {
   days: number;
@@ -159,6 +184,7 @@ export default function AdminMetricsPage() {
   const [agentSummary, setAgentSummary] = useState<AgentSummary | null>(null);
   const [agentMetrics, setAgentMetrics] = useState<AgentMetric[] | null>(null);
   const [toolErrors, setToolErrors] = useState<ToolErrorData | null>(null);
+  const [toolHealth, setToolHealth] = useState<ToolHealthData | null>(null);
   const [workflow, setWorkflow] = useState<WorkflowData | null>(null);
   const [routingGates, setRoutingGates] = useState<RoutingGatesData | null>(null);
 
@@ -241,6 +267,13 @@ export default function AdminMetricsPage() {
       ).catch(() => null);
       if (toolErrRes?.data) {
         setToolErrors(toolErrRes.data);
+      }
+      // 도구 헬스 로드 (기본 30일·최소 3회 호출)
+      const toolHealthRes = await ApiClient.get<{ data: ToolHealthData }>(
+        "/api/metrics/tools/health",
+      ).catch(() => null);
+      if (toolHealthRes?.data) {
+        setToolHealth(toolHealthRes.data);
       }
       // 작업 워크플로우 관측 로드 (기본 30일)
       const workflowRes = await ApiClient.get<{ data: WorkflowData }>(
@@ -658,6 +691,108 @@ export default function AdminMetricsPage() {
                     </Badge>
                   ))}
                 </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* 도구 헬스 — 실패율 기준(분모 포함). 위 '작업 도구 오류'는 건수 기준이라 저빈도·고실패 도구가 보이지 않는다. */}
+        {toolHealth && (
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle>
+                {t("toolHealth.title", {
+                  days: toolHealth.days,
+                  minCalls: toolHealth.minCalls,
+                })}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+                <StatCard
+                  label={t("toolHealth.errorRate")}
+                  value={`${(toolHealth.summary.errorRate * 100).toFixed(1)}%`}
+                />
+                <StatCard
+                  label={t("toolHealth.calls")}
+                  value={toolHealth.summary.calls.toLocaleString()}
+                />
+                <StatCard
+                  label={t("toolHealth.errors")}
+                  value={toolHealth.summary.errors.toLocaleString()}
+                />
+                <StatCard
+                  label={t("toolHealth.failingTools")}
+                  value={`${toolHealth.summary.failingTools.toLocaleString()} / ${toolHealth.summary.distinctTools.toLocaleString()}`}
+                />
+              </div>
+              {toolHealth.tools.length > 0 ? (
+                <div className="overflow-x-auto">
+                  <Table>
+                    <thead>
+                      <tr>
+                        <Th>{t("toolHealth.th.tool")}</Th>
+                        <Th className="whitespace-nowrap">{t("toolHealth.th.server")}</Th>
+                        <Th className="whitespace-nowrap text-right">{t("toolHealth.th.calls")}</Th>
+                        <Th className="whitespace-nowrap text-right">{t("toolHealth.th.errors")}</Th>
+                        <Th className="whitespace-nowrap text-right">{t("toolHealth.th.errorRate")}</Th>
+                        <Th className="whitespace-nowrap">{t("toolHealth.th.causes")}</Th>
+                        <Th className="whitespace-nowrap">{t("toolHealth.th.lastError")}</Th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {toolHealth.tools.map((row) => {
+                        const causes = Object.entries(row.byCategory).sort(
+                          (a, b) => b[1] - a[1],
+                        );
+                        return (
+                          <tr key={row.tool}>
+                            <Td className="font-mono text-xs" title={row.tool}>
+                              {row.tool}
+                            </Td>
+                            <Td className="whitespace-nowrap text-xs text-fg-2">
+                              {row.server ?? "—"}
+                            </Td>
+                            <Td className="text-right font-mono text-fg-2">
+                              {row.calls.toLocaleString()}
+                            </Td>
+                            <Td className="text-right font-mono text-fg-2">
+                              {row.errors.toLocaleString()}
+                            </Td>
+                            <Td className="text-right">
+                              <Badge
+                                tone={
+                                  row.errorRate >= 0.5
+                                    ? "danger"
+                                    : row.errorRate >= 0.2
+                                      ? "warn"
+                                      : "neutral"
+                                }
+                              >
+                                {(row.errorRate * 100).toFixed(1)}%
+                              </Badge>
+                            </Td>
+                            <Td className="whitespace-nowrap text-xs text-fg-2">
+                              {causes.length > 0
+                                ? causes
+                                    .slice(0, 3)
+                                    .map(([cat, n]) => `${cat} ${n}`)
+                                    .join(" · ")
+                                : "—"}
+                            </Td>
+                            <Td className="whitespace-nowrap text-xs text-fg-2">
+                              {row.lastErrorAt
+                                ? new Date(row.lastErrorAt).toLocaleDateString(locale)
+                                : "—"}
+                            </Td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </Table>
+                </div>
+              ) : (
+                <p className="text-sm text-fg-2">{t("toolHealth.empty")}</p>
               )}
             </CardContent>
           </Card>

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1327,6 +1327,23 @@
         "count": "Count"
       }
     },
+    "toolHealth": {
+      "title": "Tool health — failure rate (last {days}d · min {minCalls} calls)",
+      "errorRate": "Overall failure rate",
+      "calls": "Total calls",
+      "errors": "Total failures",
+      "failingTools": "Tools with failures",
+      "th": {
+        "tool": "Tool",
+        "server": "Server",
+        "calls": "Calls",
+        "errors": "Failures",
+        "errorRate": "Failure rate",
+        "causes": "Top causes",
+        "lastError": "Last failure"
+      },
+      "empty": "No tool has enough samples yet."
+    },
     "workflow": {
       "title": "Task Workflow (last {days} days)",
       "unjudgedRate": "Unjudged Completions",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1327,6 +1327,23 @@
         "count": "件数"
       }
     },
+    "toolHealth": {
+      "title": "ツール健全性 — 失敗率 (直近 {days}日 · 最小 {minCalls}回呼び出し)",
+      "errorRate": "全体の失敗率",
+      "calls": "総呼び出し",
+      "errors": "総失敗",
+      "failingTools": "失敗のあるツール",
+      "th": {
+        "tool": "ツール",
+        "server": "サーバー",
+        "calls": "呼び出し",
+        "errors": "失敗",
+        "errorRate": "失敗率",
+        "causes": "主な原因",
+        "lastError": "最終失敗"
+      },
+      "empty": "十分なサンプルのあるツールがありません。"
+    },
     "workflow": {
       "title": "タスクワークフロー (直近{days}日)",
       "unjudgedRate": "完了時の未判定率",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1327,6 +1327,23 @@
         "count": "건수"
       }
     },
+    "toolHealth": {
+      "title": "도구 헬스 — 실패율 (최근 {days}일 · 최소 {minCalls}회 호출)",
+      "errorRate": "전체 실패율",
+      "calls": "총 호출",
+      "errors": "총 실패",
+      "failingTools": "실패 있는 도구",
+      "th": {
+        "tool": "도구",
+        "server": "서버",
+        "calls": "호출",
+        "errors": "실패",
+        "errorRate": "실패율",
+        "causes": "주요 원인",
+        "lastError": "마지막 실패"
+      },
+      "empty": "표본이 충분한 도구가 없습니다."
+    },
     "workflow": {
       "title": "작업 워크플로우 (최근 {days}일)",
       "unjudgedRate": "완료 무판정 비율",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1327,6 +1327,23 @@
         "count": "次数"
       }
     },
+    "toolHealth": {
+      "title": "工具健康度 — 失败率 (最近 {days} 天 · 至少 {minCalls} 次调用)",
+      "errorRate": "总失败率",
+      "calls": "总调用",
+      "errors": "总失败",
+      "failingTools": "存在失败的工具",
+      "th": {
+        "tool": "工具",
+        "server": "服务器",
+        "calls": "调用",
+        "errors": "失败",
+        "errorRate": "失败率",
+        "causes": "主要原因",
+        "lastError": "最后失败"
+      },
+      "empty": "暂无样本足够的工具。"
+    },
     "workflow": {
       "title": "任务工作流（最近 {days} 天）",
       "unjudgedRate": "完成未判定比例",


### PR DESCRIPTION
## 왜

기존 `GET /api/metrics/agent-tasks/tool-errors` 는 **오류 건수 top10** 만 준다(분모 없음). 그래서 호출이 많은 도구가 상위를 차지하고, **저빈도·고실패 도구가 보이지 않는다**.

운영 `audit_logs` 30일 실측:

| 도구 | 호출 | 실패 | 실패율 | 건수 top10 노출 |
|---|---|---|---|---|
| `mcp-filesystem::read_text_file` | 3 | 3 | 100% | ❌ |
| `open-design::get_active_context` | 6 | 5 | 83% | ❌ |
| `mcp-kakao::find-route` | 7 | 3 | 43% | ❌ |
| `agent_task_get` | 16 | 5 | 31% | ❌ |
| `web_search` | 673 | 7 | **1.0%**(건강) | ✅ 상위 |

에이전트 작업 30일 기준 `tool_result` 1,619건 중 169건(10.4%)이 실패인데, 어떤 도구가 왜 실패하는지는 SQL 을 직접 짜야만 알 수 있었다.

## 무엇을

- **실패 분류 영속** — `classifyToolError` 의 category·retryable 은 `tool-router.ts fail()` 에서 **이미 계산**되고 있었으나 OTel span 으로만 나가 사후 집계가 불가능했다. 이제 결과에 실어 보내고 `auditToolCall` 이 `audit_logs.details` 에 기록한 뒤 **응답에서 제거**한다(내부 전용 필드 — 도구 소비자에게 노출 금지). 스키마 변경 없음.
- **`GET /api/metrics/tools/health?days&minCalls&limit`** (admin) — 도구별 호출·실패·실패율·카테고리 분포·p50·마지막 실패. 소스가 `audit_logs` 라 **채팅·에이전트 작업 양쪽**을 덮는다(기존 지표는 작업 스텝만). `minCalls`(기본 3)로 1회 호출 100% 실패가 상위를 점거하는 것을 막는다.
- **`/admin/metrics` 도구 헬스 표** — 기존 "작업 도구 오류" 섹션은 유지(축이 다르다: 건수·작업 한정 vs 실패율·채팅 포함). i18n 4 locale.
- 조회 기본값·상한은 `config/tool-health.ts`(L2) + env(`.env.example` 문서화).

`metrics.routes.ts` 에 합치지 않은 이유: 517줄로 600줄 가드에 근접했고, 후속 PR2(서킷 상태 조회·리셋)가 같은 축으로 더 붙는다.

## 검증

- 집계 SQL 을 운영 DB 에 직접 대조(위 표가 그 결과).
- 단위 테스트 12건 — 전달·비노출 계약 3(`tool-error-category-audit`), 리포지토리 4, 라우트 5(클램프·카테고리 병합·0 호출 시 NaN 방지).
- 6게이트 로컬 재현: jest **3,093 pass / 0 fail** · tsc(api·web) · 최대 파일 455줄 · lint 0 error · eval:routing 93.3% · eval:response 100%.
- UI 스크린샷: 새 라우트라 **배포·재시작 후에만** 표가 채워진다 — 반영 후 첨부 예정.

## 알려진 한계 (의도)

- 감사 기록은 fire-and-forget(`void`)이라 이 집계는 **하한**이다. 스텝 기반 수치와의 오차는 PR2 임계값 산정 시 함께 기록한다.
- `errorCategory` 는 이 커밋 **이후** 호출에만 있다(그 이전 실패는 `unknown` 으로 묶임).
- **task 도구**(`bash`·`file_ops`·`plan_*`·`python_execute`)는 `task-sandbox/runtime.ts` 경로라 tool-router 를 타지 않아 이 지표에 잡히지 않는다. plan 프로토콜 위반·셸 문법 오류는 별건(P0-c/d).
- 실패율 상위는 조회 창에 따라 뒤집힌다(60일 누계 1위가 30일로는 7.7%). 그래서 창·최소 표본을 호출자가 정하게 했다.

## 다음 (별도 PR)

관측 1주 뒤 임계값을 정해 **도구 헬스 서킷**(연속 실패 도구를 노출에서 제외 + 실행 즉시 거절 + cooldown 복구, 게이트 기본 OFF). `invalid_args` 는 모델 실수라 실패로 세지 않는 것이 설계의 축이다.

## 체크리스트

- [x] `npm run lint` 통과 (0 error)
- [x] `npm test` 통과 (3,093 pass)
- [x] `eval:routing` · `eval:response` 통과
- [x] `.env.example` 업데이트
- [ ] UI 스크린샷 (배포 후)
- [x] DB 스키마 변경 없음
- [x] 보안: admin 가드(requireAuth+requireAdmin), 읽기 전용, 파라미터화 쿼리, 내부 필드 응답 비노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hzHmjGo5uQuisYrxZfCnC
