### PR TITLE
feat(mcp): 반복 실패 도구 서킷 차단 — 노출 제외 + 실행 거절 (P0-a PR2, 기본 OFF)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1548,3 +1548,25 @@ CHAT_USER_MCP_SCHEMA_BUDGET_BYTES=16000
 # TOOL_HEALTH_MAX_MIN_CALLS=1000
 # TOOL_HEALTH_DEFAULT_LIMIT=30
 # TOOL_HEALTH_MAX_LIMIT=200
+
+# ── 도구 서킷 브레이커 (반복 실패 도구 일시 차단) ──
+# 기본 OFF. 위 /api/metrics/tools/health 로 1~2주 관측해 임계값을 확인한 뒤 켠다.
+# 오탐(정상 도구가 사라짐)이 이 기능의 최악 실패 모드라 되돌릴 수단(관리자 [해제] 버튼)과
+# 함께 쓴다. 끄려면 값을 지우고 재시작하면 즉시 원상복구된다(상태는 인메모리).
+# TOOL_HEALTH_CIRCUIT_ENABLED=false
+# 대상 범위: external=네임스페이스 외부 도구만(기본), all=내장 도구 포함.
+# 내장(web_search 등)은 실패해도 빼지 않는다 — 핵심 경로 손실이 크고 대개 인자 오류다.
+# TOOL_HEALTH_CIRCUIT_SCOPE=external
+# 창(WINDOW_MS) 안 실패가 이 수에 도달하면 차단. ⚠️ 연결 사망 self-heal(evict→respawn)보다
+# 크게 잡을 것 — self-heal 로 고쳐질 실패에 서킷이 먼저 열리면 복구를 방해한다.
+# TOOL_HEALTH_CIRCUIT_FAILURE_THRESHOLD=5
+# TOOL_HEALTH_CIRCUIT_WINDOW_MS=600000
+# TOOL_HEALTH_CIRCUIT_MIN_CALLS=3
+# 최초 차단 시간·재차단 상한·배수 (재차단마다 OPEN_MS × BACKOFF, MAX 까지)
+# TOOL_HEALTH_CIRCUIT_OPEN_MS=300000
+# TOOL_HEALTH_CIRCUIT_OPEN_MS_MAX=1800000
+# TOOL_HEALTH_CIRCUIT_BACKOFF_FACTOR=2
+# 실패로 세지 않는 분류 — 도구 고장이 아닌 것들. invalid_args=모델이 인자를 틀림,
+# not_found=대상 부재, output_truncated=결과는 나옴. 이걸 세면 정상 도구가 차단된다.
+# TOOL_HEALTH_CIRCUIT_EXCLUDED_CATEGORIES=invalid_args,not_found,output_truncated
+# TOOL_HEALTH_CIRCUIT_MAX_TRACKED=500

--- a/apps/api/src/__tests__/routes/tool-health.routes.test.ts
+++ b/apps/api/src/__tests__/routes/tool-health.routes.test.ts
@@ -28,10 +28,19 @@ jest.mock('../../data/repositories/tool-health-repository', () => ({
 }));
 jest.mock('../../data/models/unified-database', () => ({ getPool: () => ({}) }));
 
+const logAudit = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../services/AuditService', () => ({ getAuditService: () => ({ logAudit }) }));
+
 import { toolHealthRouter } from '../../routes/tool-health.routes';
+import { TOOL_CIRCUIT } from '../../config/tool-health';
+import { recordToolResult, __resetCircuitsForTest } from '../../mcp/tool-health';
+
+const mutableCircuit = TOOL_CIRCUIT as unknown as Record<string, unknown>;
+const originalCircuit = { ...TOOL_CIRCUIT };
 
 function makeApp() {
     const app = express();
+    app.use(express.json());
     app.use('/api/metrics/tools', toolHealthRouter);
     return app;
 }
@@ -92,5 +101,49 @@ describe('GET /api/metrics/tools/health', () => {
     it('호출 0 이어도 errorRate 는 NaN 이 아닌 0', async () => {
         const res = await request(makeApp()).get('/api/metrics/tools/health').expect(200);
         expect(res.body.data.summary.errorRate).toBe(0);
+    });
+});
+
+describe('서킷 조회·해제', () => {
+    beforeEach(() => {
+        currentRole = 'admin';
+        logAudit.mockClear();
+        __resetCircuitsForTest();
+        Object.assign(mutableCircuit, originalCircuit, { ENABLED: true, FAILURE_THRESHOLD: 2, MIN_CALLS: 2 });
+    });
+    afterEach(() => Object.assign(mutableCircuit, originalCircuit));
+
+    it('GET /circuit: 설정과 현재 상태를 함께 준다', async () => {
+        recordToolResult('srv::x', false, 'provider');
+        recordToolResult('srv::x', false, 'provider');
+
+        const res = await request(makeApp()).get('/api/metrics/tools/circuit').expect(200);
+        expect(res.body.data.config.enabled).toBe(true);
+        expect(res.body.data.config.excludedCategories).toContain('invalid_args');
+        expect(res.body.data.circuits[0]).toMatchObject({ tool: 'srv::x', state: 'open' });
+        expect(res.body.data.circuits[0].opensInMs).toBeGreaterThan(0);
+    });
+
+    it('POST /circuit/reset: 해제 + 감사 기록', async () => {
+        recordToolResult('srv::x', false, 'provider');
+        recordToolResult('srv::x', false, 'provider');
+
+        await request(makeApp()).post('/api/metrics/tools/circuit/reset').send({ tool: 'srv::x' }).expect(200);
+        const after = await request(makeApp()).get('/api/metrics/tools/circuit').expect(200);
+        expect(after.body.data.circuits).toHaveLength(0);
+        expect(logAudit).toHaveBeenCalledTimes(1);
+        expect(logAudit.mock.calls[0][0].action).toBe('tool_circuit_reset');
+    });
+
+    it('POST /circuit/reset: tool 누락 400, 추적 없는 도구 404', async () => {
+        await request(makeApp()).post('/api/metrics/tools/circuit/reset').send({}).expect(400);
+        await request(makeApp()).post('/api/metrics/tools/circuit/reset').send({ tool: 'srv::none' }).expect(404);
+        expect(logAudit).not.toHaveBeenCalled();
+    });
+
+    it('비관리자는 서킷 조회·해제 모두 403', async () => {
+        currentRole = 'user';
+        await request(makeApp()).get('/api/metrics/tools/circuit').expect(403);
+        await request(makeApp()).post('/api/metrics/tools/circuit/reset').send({ tool: 'srv::x' }).expect(403);
     });
 });

--- a/apps/api/src/config/tool-health.ts
+++ b/apps/api/src/config/tool-health.ts
@@ -25,3 +25,47 @@ export const TOOL_HEALTH_QUERY = {
     /** 반환 도구 수 상한. */
     MAX_LIMIT: parseInt(process.env.TOOL_HEALTH_MAX_LIMIT || '200', 10),
 } as const;
+
+/**
+ * 도구 서킷 브레이커 설정.
+ *
+ * 반복 실패하는 도구를 일정 시간 노출에서 빼고, 호출되더라도 즉시 거절해 대체 경로를
+ * 안내한다. 서버가 `crashed` 면 user-pool 에 없어 자동 제외되지만, **서버는 살아 있는데
+ * 도구만 실패하는 경우**(헤드리스 브라우저 런처 실패·인증 만료 등)는 계속 노출된다.
+ *
+ * 설계에서 가장 중요한 두 결정:
+ *  ① `EXCLUDED_CATEGORIES` — `invalid_args`(모델이 인자를 틀림)·`not_found`(대상 부재)·
+ *     `output_truncated`(결과는 나왔다)는 **도구 고장이 아니다**. 이걸 세면 정상 도구가
+ *     차단된다(오탐이 이 기능의 최악 실패 모드).
+ *  ② `SCOPE='external'` — 내장 도구는 실패해도 노출에서 빼지 않는다. `web_search` 같은
+ *     핵심 경로가 사라지는 손실이 크고, 내장 도구 실패는 대개 인자·사용자 오류다.
+ *     서킷의 실제 동기는 죽은 외부 MCP 서버의 도구다.
+ *
+ * ⚠️ `FAILURE_THRESHOLD` 는 연결 사망 self-heal(`external-client` 의 evict → respawn)보다
+ * 크게 잡는다 — self-heal 로 고쳐질 실패에 서킷이 먼저 열리면 복구를 방해한다.
+ * ⚠️ 상태는 프로세스 메모리다(단일 API 인스턴스 전제). 재시작 시 리셋되는 편이
+ * "서버를 고쳤는데 여전히 차단"보다 안전하다.
+ */
+export const TOOL_CIRCUIT = {
+    /** 기능 게이트 — 기본 OFF. 관측(PR1) 데이터로 임계값을 확정한 뒤 켠다. */
+    ENABLED: process.env.TOOL_HEALTH_CIRCUIT_ENABLED === 'true',
+    /** 대상 범위: 'external'=네임스페이스 외부 도구만, 'all'=내장 포함. */
+    SCOPE: (process.env.TOOL_HEALTH_CIRCUIT_SCOPE === 'all' ? 'all' : 'external') as 'external' | 'all',
+    /** 창 안 실패가 이 수에 도달하면 OPEN. self-heal 재시도보다 크게. */
+    FAILURE_THRESHOLD: parseInt(process.env.TOOL_HEALTH_CIRCUIT_FAILURE_THRESHOLD || '5', 10),
+    /** 실패·호출 집계 창(ms). 창을 벗어난 기록은 버린다. */
+    WINDOW_MS: parseInt(process.env.TOOL_HEALTH_CIRCUIT_WINDOW_MS || '600000', 10),
+    /** 창 안 최소 호출 수 — 표본이 적으면 열지 않는다. */
+    MIN_CALLS: parseInt(process.env.TOOL_HEALTH_CIRCUIT_MIN_CALLS || '3', 10),
+    /** 최초 차단 시간(ms). */
+    OPEN_MS: parseInt(process.env.TOOL_HEALTH_CIRCUIT_OPEN_MS || '300000', 10),
+    /** 재차단 시 차단 시간 상한(ms) — 무한 증가 방지. */
+    OPEN_MS_MAX: parseInt(process.env.TOOL_HEALTH_CIRCUIT_OPEN_MS_MAX || '1800000', 10),
+    /** HALF_OPEN 에서 다시 실패했을 때 차단 시간 배수. */
+    OPEN_BACKOFF_FACTOR: parseInt(process.env.TOOL_HEALTH_CIRCUIT_BACKOFF_FACTOR || '2', 10),
+    /** 실패로 세지 않는 분류 — 도구 고장이 아닌 것들(위 ① 참고). */
+    EXCLUDED_CATEGORIES: (process.env.TOOL_HEALTH_CIRCUIT_EXCLUDED_CATEGORIES
+        || 'invalid_args,not_found,output_truncated').split(',').map((s) => s.trim()).filter(Boolean),
+    /** 추적 도구 수 상한 — 오래된 항목부터 버린다(메모리 무한 증가 방지). */
+    MAX_TRACKED_TOOLS: parseInt(process.env.TOOL_HEALTH_CIRCUIT_MAX_TRACKED || '500', 10),
+} as const;

--- a/apps/api/src/mcp/__tests__/tool-health-circuit.test.ts
+++ b/apps/api/src/mcp/__tests__/tool-health-circuit.test.ts
@@ -21,7 +21,10 @@ function failN(n: number, category = 'provider'): void {
 describe('도구 서킷 브레이커', () => {
     beforeEach(() => {
         __resetCircuitsForTest();
-        Object.assign(mutable, original, { ENABLED: true, FAILURE_THRESHOLD: 3, MIN_CALLS: 3, OPEN_MS: 1000 });
+        // ⚠️ OPEN_MS 는 넉넉히 — 짧게 두면 느린 러너에서 차단 직후 판정 사이에 cooldown 이
+        // 지나 half-open 으로 전이되고 isToolCircuitOpen 이 false 를 돌려준다(CI 실측 flaky).
+        // cooldown 경과를 실제로 검증하는 테스트만 아래에서 1000ms 로 낮춘다.
+        Object.assign(mutable, original, { ENABLED: true, FAILURE_THRESHOLD: 3, MIN_CALLS: 3, OPEN_MS: 60_000 });
     });
     afterEach(() => Object.assign(mutable, original));
 
@@ -71,6 +74,7 @@ describe('도구 서킷 브레이커', () => {
     });
 
     it('cooldown 경과 후 half-open 으로 통과시키고, 성공하면 closed 로 복구', async () => {
+        Object.assign(mutable, { OPEN_MS: 1000 });
         failN(3);
         expect(isToolCircuitOpen(TOOL)).toBe(true);
         await new Promise((r) => setTimeout(r, 1100)); // OPEN_MS=1000
@@ -81,6 +85,7 @@ describe('도구 서킷 브레이커', () => {
     });
 
     it('half-open 에서 실패하면 재차단 + cooldown 이 배수로 늘어난다', async () => {
+        Object.assign(mutable, { OPEN_MS: 1000 });
         failN(3);
         await new Promise((r) => setTimeout(r, 1100));
         isToolCircuitOpen(TOOL); // half-open 전이

--- a/apps/api/src/mcp/__tests__/tool-health-circuit.test.ts
+++ b/apps/api/src/mcp/__tests__/tool-health-circuit.test.ts
@@ -1,0 +1,121 @@
+/**
+ * 도구 서킷 브레이커 — 상태 전이·제외 규칙·메모리 관리 검증.
+ *
+ * 이 기능의 최악 실패 모드는 **오탐 차단**(정상 도구가 사라져 기능이 없어진 것처럼 보임)이라,
+ * "열려야 할 때 열리는가" 만큼 "열리면 안 될 때 안 열리는가" 를 같은 비중으로 고정한다.
+ */
+import { TOOL_CIRCUIT } from '../../config/tool-health';
+
+// 게이트는 운영 기본 OFF — 테스트에서는 켠 상태의 동작을 검증한다.
+const mutable = TOOL_CIRCUIT as unknown as Record<string, unknown>;
+const original = { ...TOOL_CIRCUIT };
+
+import { isToolCircuitOpen, recordToolResult, getCircuitSnapshot, resetToolCircuit, __resetCircuitsForTest } from '../tool-health';
+
+const TOOL = 'srv::flaky';
+
+function failN(n: number, category = 'provider'): void {
+    for (let i = 0; i < n; i++) recordToolResult(TOOL, false, category);
+}
+
+describe('도구 서킷 브레이커', () => {
+    beforeEach(() => {
+        __resetCircuitsForTest();
+        Object.assign(mutable, original, { ENABLED: true, FAILURE_THRESHOLD: 3, MIN_CALLS: 3, OPEN_MS: 1000 });
+    });
+    afterEach(() => Object.assign(mutable, original));
+
+    it('게이트 OFF 면 아무 것도 하지 않는다', () => {
+        Object.assign(mutable, { ENABLED: false });
+        failN(10);
+        expect(isToolCircuitOpen(TOOL)).toBe(false);
+        expect(getCircuitSnapshot()).toHaveLength(0);
+    });
+
+    it('임계 도달 시 OPEN — 노출·실행 판정이 true 로 바뀐다', () => {
+        failN(2);
+        expect(isToolCircuitOpen(TOOL)).toBe(false); // 임계 미만
+        failN(1);
+        expect(isToolCircuitOpen(TOOL)).toBe(true);
+    });
+
+    it('invalid_args 는 세지 않는다 — 모델이 인자를 틀린 것이지 도구 고장이 아니다', () => {
+        failN(10, 'invalid_args');
+        expect(isToolCircuitOpen(TOOL)).toBe(false);
+    });
+
+    it('not_found·output_truncated 도 제외 대상', () => {
+        failN(5, 'not_found');
+        failN(5, 'output_truncated');
+        expect(isToolCircuitOpen(TOOL)).toBe(false);
+    });
+
+    it('내장 도구는 기본 범위(external) 밖 — 핵심 경로가 사라지지 않는다', () => {
+        failN(20);
+        for (let i = 0; i < 20; i++) recordToolResult('web_search', false, 'provider');
+        expect(isToolCircuitOpen('web_search')).toBe(false);
+        expect(isToolCircuitOpen(TOOL)).toBe(true);
+    });
+
+    it('SCOPE=all 이면 내장 도구도 대상', () => {
+        Object.assign(mutable, { SCOPE: 'all' });
+        for (let i = 0; i < 3; i++) recordToolResult('web_search', false, 'provider');
+        expect(isToolCircuitOpen('web_search')).toBe(true);
+    });
+
+    it('성공은 실패 카운터를 리셋한다', () => {
+        failN(2);
+        recordToolResult(TOOL, true);
+        failN(2);
+        expect(isToolCircuitOpen(TOOL)).toBe(false);
+    });
+
+    it('cooldown 경과 후 half-open 으로 통과시키고, 성공하면 closed 로 복구', async () => {
+        failN(3);
+        expect(isToolCircuitOpen(TOOL)).toBe(true);
+        await new Promise((r) => setTimeout(r, 1100)); // OPEN_MS=1000
+        expect(isToolCircuitOpen(TOOL)).toBe(false);   // half-open 전이
+        expect(getCircuitSnapshot()[0].state).toBe('half_open');
+        recordToolResult(TOOL, true);
+        expect(getCircuitSnapshot()[0].state).toBe('closed');
+    });
+
+    it('half-open 에서 실패하면 재차단 + cooldown 이 배수로 늘어난다', async () => {
+        failN(3);
+        await new Promise((r) => setTimeout(r, 1100));
+        isToolCircuitOpen(TOOL); // half-open 전이
+        recordToolResult(TOOL, false, 'provider');
+        const snap = getCircuitSnapshot()[0];
+        expect(snap.state).toBe('open');
+        expect(snap.openMs).toBe(2000); // 1000 × BACKOFF_FACTOR(2)
+        expect(isToolCircuitOpen(TOOL)).toBe(true);
+    });
+
+    it('cooldown 은 상한을 넘지 않는다', async () => {
+        Object.assign(mutable, { OPEN_MS: 1000, OPEN_MS_MAX: 1500 });
+        failN(3);
+        await new Promise((r) => setTimeout(r, 1100));
+        isToolCircuitOpen(TOOL);
+        recordToolResult(TOOL, false, 'provider');
+        expect(getCircuitSnapshot()[0].openMs).toBe(1500);
+    });
+
+    it('정상 도구는 엔트리를 만들지 않는다 (메모리 무한 증가 방지)', () => {
+        for (let i = 0; i < 50; i++) recordToolResult(`srv::ok${i}`, true);
+        expect(getCircuitSnapshot()).toHaveLength(0);
+    });
+
+    it('추적 도구 수 상한 초과 시 가장 오래된 항목을 버린다', () => {
+        Object.assign(mutable, { MAX_TRACKED_TOOLS: 3 });
+        for (let i = 0; i < 6; i++) recordToolResult(`srv::t${i}`, false, 'provider');
+        expect(getCircuitSnapshot().length).toBeLessThanOrEqual(3);
+    });
+
+    it('수동 리셋으로 즉시 해제된다 (오탐 되돌리기 수단)', () => {
+        failN(3);
+        expect(isToolCircuitOpen(TOOL)).toBe(true);
+        expect(resetToolCircuit(TOOL)).toBe(true);
+        expect(isToolCircuitOpen(TOOL)).toBe(false);
+        expect(resetToolCircuit('srv::none')).toBe(false);
+    });
+});

--- a/apps/api/src/mcp/__tests__/tool-router-circuit.test.ts
+++ b/apps/api/src/mcp/__tests__/tool-router-circuit.test.ts
@@ -1,0 +1,80 @@
+/**
+ * ToolRouter × 서킷 통합 — 노출 필터와 실행 거절이 실제로 걸리는지.
+ *
+ * 계약 셋:
+ *  ① 반복 실패한 외부 도구는 `getAllTools` 결과에서 빠진다(채팅·작업·딥리서치 공통 소스).
+ *  ② 노출에서 빠져도 이름으로 호출되면 즉시 거절된다(모델이 이름을 기억하는 경우의 2차 방어).
+ *  ③ 그 거절은 실패로 세지 않는다 — 세면 차단이 스스로를 무한 연장한다.
+ */
+import { TOOL_CIRCUIT } from '../../config/tool-health';
+import { ToolRouter } from '../tool-router';
+import { getCircuitSnapshot, __resetCircuitsForTest } from '../tool-health';
+
+const mutable = TOOL_CIRCUIT as unknown as Record<string, unknown>;
+const original = { ...TOOL_CIRCUIT };
+
+function makeRouter(fail: boolean): ToolRouter {
+    const router = new ToolRouter();
+    router.registerExternalTools(
+        'srv-1',
+        'srv',
+        [{ name: 'flaky', description: 'test', inputSchema: { type: 'object', properties: {} } }],
+        async () => {
+            if (fail) throw new Error('upstream 502 bad gateway');
+            return { content: [{ type: 'text', text: 'ok' }] };
+        },
+    );
+    return router;
+}
+
+describe('ToolRouter 서킷 통합', () => {
+    beforeEach(() => {
+        __resetCircuitsForTest();
+        Object.assign(mutable, original, { ENABLED: true, FAILURE_THRESHOLD: 3, MIN_CALLS: 3, OPEN_MS: 60000 });
+    });
+    afterEach(() => Object.assign(mutable, original));
+
+    it('반복 실패한 도구는 노출 목록에서 빠진다', async () => {
+        const router = makeRouter(true);
+        const before = await router.getAllTools();
+        expect(before.some((t) => t.name === 'srv::flaky')).toBe(true);
+
+        for (let i = 0; i < 3; i++) await router.executeTool('srv::flaky', {});
+
+        const after = await router.getAllTools();
+        expect(after.some((t) => t.name === 'srv::flaky')).toBe(false);
+        // 다른 도구는 그대로 — 차단은 해당 도구에만 국소적이어야 한다.
+        expect(after.length).toBe(before.length - 1);
+    });
+
+    it('차단 후 호출은 즉시 거절되고, 그 거절은 실패로 세지 않는다', async () => {
+        const router = makeRouter(true);
+        for (let i = 0; i < 3; i++) await router.executeTool('srv::flaky', {});
+        const failuresWhenOpened = getCircuitSnapshot()[0].failuresInWindow;
+
+        const rejected = await router.executeTool('srv::flaky', {});
+        expect(rejected.isError).toBe(true);
+        expect((rejected.content[0] as { text: string }).text).toContain('일시 비활성화');
+
+        // 거절이 카운트되면 failuresInWindow 가 늘어난다 → 차단이 스스로를 연장한다.
+        expect(getCircuitSnapshot()[0].failuresInWindow).toBe(failuresWhenOpened);
+    });
+
+    it('게이트 OFF 면 반복 실패해도 노출·실행이 그대로다', async () => {
+        Object.assign(mutable, { ENABLED: false });
+        const router = makeRouter(true);
+        for (let i = 0; i < 10; i++) await router.executeTool('srv::flaky', {});
+        const tools = await router.getAllTools();
+        expect(tools.some((t) => t.name === 'srv::flaky')).toBe(true);
+        const result = await router.executeTool('srv::flaky', {});
+        expect((result.content[0] as { text: string }).text).not.toContain('일시 비활성화');
+    });
+
+    it('성공하는 도구는 아무리 호출해도 차단되지 않는다', async () => {
+        const router = makeRouter(false);
+        for (let i = 0; i < 10; i++) await router.executeTool('srv::flaky', {});
+        const tools = await router.getAllTools();
+        expect(tools.some((t) => t.name === 'srv::flaky')).toBe(true);
+        expect(getCircuitSnapshot()).toHaveLength(0);
+    });
+});

--- a/apps/api/src/mcp/tool-health.ts
+++ b/apps/api/src/mcp/tool-health.ts
@@ -1,0 +1,174 @@
+/**
+ * 도구 서킷 브레이커 — 반복 실패하는 도구를 노출·실행에서 일시 차단한다.
+ *
+ * 상태: CLOSED → (창 안 실패 임계 도달) → OPEN → (cooldown 경과) → HALF_OPEN
+ *       → 성공이면 CLOSED, 실패면 다시 OPEN(cooldown ×backoff, 상한까지).
+ *
+ * `cluster/circuit-breaker.ts` 를 재사용하지 않은 이유: 그 클래스는 `CircuitOpenError` 를
+ * **던지는 실행 래퍼**라 목적이 다르다(여기서는 노출 필터가 주 효과이고, 실행 거절은
+ * 모델이 기억한 이름으로 호출할 때의 2차 방어다). 상태 전이 규칙만 참조했다.
+ *
+ * 메모리 관리: **실패만 엔트리를 만든다**. 성공은 기존 엔트리가 있을 때만 갱신하므로,
+ * 정상 도구가 Map 을 채우지 않는다. 상한 도달 시 가장 오래 손대지 않은 항목을 버린다.
+ *
+ * @module mcp/tool-health
+ */
+import { TOOL_CIRCUIT } from '../config/tool-health';
+import { MCP_NAMESPACE_SEPARATOR } from './types';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('ToolCircuit');
+
+export type ToolCircuitState = 'closed' | 'open' | 'half_open';
+
+interface CircuitEntry {
+    /** 창 안 실패 시각(ms). 창을 벗어나면 잘라낸다. */
+    failures: number[];
+    /** 창 안 호출 시각(ms) — MIN_CALLS 판정용. */
+    calls: number[];
+    state: ToolCircuitState;
+    /** OPEN 이 된 시각. */
+    openedAt: number;
+    /** 이번 OPEN 의 차단 시간(ms) — 재차단마다 backoff 로 늘어난다. */
+    openMs: number;
+    /** 마지막 접근 시각 — 상한 초과 시 축출 기준. */
+    touchedAt: number;
+    /** 마지막 실패 분류(관측용). */
+    lastCategory?: string;
+}
+
+const entries = new Map<string, CircuitEntry>();
+
+/** 이 도구가 서킷 대상인지 — 범위 설정(내장 제외)이 여기서만 적용된다. */
+function inScope(tool: string): boolean {
+    if (TOOL_CIRCUIT.SCOPE === 'all') return true;
+    return tool.includes(MCP_NAMESPACE_SEPARATOR);
+}
+
+function trim(list: number[], now: number): number[] {
+    const cutoff = now - TOOL_CIRCUIT.WINDOW_MS;
+    return list.filter((t) => t > cutoff);
+}
+
+function evictIfNeeded(): void {
+    if (entries.size <= TOOL_CIRCUIT.MAX_TRACKED_TOOLS) return;
+    let oldestKey: string | null = null;
+    let oldest = Infinity;
+    for (const [k, v] of entries) {
+        if (v.touchedAt < oldest) { oldest = v.touchedAt; oldestKey = k; }
+    }
+    if (oldestKey) entries.delete(oldestKey);
+}
+
+/**
+ * 도구가 현재 차단 상태인지. cooldown 이 지났으면 HALF_OPEN 으로 전이시키고 통과시킨다
+ * (한 번의 실제 호출로 복구 여부를 판정 — 그 결과는 recordToolResult 가 받는다).
+ */
+export function isToolCircuitOpen(tool: string): boolean {
+    if (!TOOL_CIRCUIT.ENABLED || !inScope(tool)) return false;
+    const e = entries.get(tool);
+    if (!e || e.state === 'closed') return false;
+
+    const now = Date.now();
+    e.touchedAt = now;
+    if (e.state === 'open' && now - e.openedAt >= e.openMs) {
+        e.state = 'half_open';
+        logger.info(`[circuit] half-open 전이 — ${tool} (차단 ${Math.round(e.openMs / 1000)}s 경과)`);
+        return false;
+    }
+    return e.state === 'open';
+}
+
+/**
+ * 도구 실행 결과 기록. 실패 분류가 제외 목록(모델 실수·대상 부재 등)이면 세지 않는다 —
+ * 도구 고장이 아닌 실패로 정상 도구를 차단하는 것이 이 기능의 최악 실패 모드다.
+ */
+export function recordToolResult(tool: string, ok: boolean, category?: string): void {
+    if (!TOOL_CIRCUIT.ENABLED || !inScope(tool)) return;
+    const now = Date.now();
+
+    if (ok) {
+        const e = entries.get(tool);
+        if (!e) return; // 정상 도구는 엔트리를 만들지 않는다(메모리 무한 증가 방지).
+        e.touchedAt = now;
+        e.calls = [...trim(e.calls, now), now];
+        e.failures = trim(e.failures, now);
+        if (e.state !== 'closed') {
+            logger.info(`[circuit] 복구 — ${tool} (${e.state} → closed)`);
+        }
+        e.state = 'closed';
+        e.failures = [];
+        return;
+    }
+
+    if (category && TOOL_CIRCUIT.EXCLUDED_CATEGORIES.includes(category)) {
+        // 실패지만 도구 탓이 아니다. 엔트리가 없으면 만들지도 않는다.
+        const existing = entries.get(tool);
+        if (existing) { existing.touchedAt = now; existing.calls = [...trim(existing.calls, now), now]; }
+        return;
+    }
+
+    const e = entries.get(tool) ?? {
+        failures: [], calls: [], state: 'closed' as ToolCircuitState,
+        openedAt: 0, openMs: TOOL_CIRCUIT.OPEN_MS, touchedAt: now,
+    };
+    e.touchedAt = now;
+    e.lastCategory = category;
+    e.calls = [...trim(e.calls, now), now];
+    e.failures = [...trim(e.failures, now), now];
+
+    const wasHalfOpen = e.state === 'half_open';
+    if (wasHalfOpen) {
+        // 복구 시도가 다시 실패 — 차단 시간을 늘려 재차단.
+        e.openMs = Math.min(e.openMs * TOOL_CIRCUIT.OPEN_BACKOFF_FACTOR, TOOL_CIRCUIT.OPEN_MS_MAX);
+        e.state = 'open';
+        e.openedAt = now;
+        logger.warn(`[circuit] 재차단 — ${tool} (${Math.round(e.openMs / 1000)}s, 분류=${category ?? 'unknown'})`);
+    } else if (
+        e.state === 'closed'
+        && e.failures.length >= TOOL_CIRCUIT.FAILURE_THRESHOLD
+        && e.calls.length >= TOOL_CIRCUIT.MIN_CALLS
+    ) {
+        e.state = 'open';
+        e.openedAt = now;
+        logger.warn(`[circuit] 차단 — ${tool} (창 내 실패 ${e.failures.length}/${e.calls.length}회, ${Math.round(e.openMs / 1000)}s, 분류=${category ?? 'unknown'})`);
+    }
+
+    entries.set(tool, e);
+    evictIfNeeded();
+}
+
+/** 관측용 스냅샷 — closed 로 돌아온 엔트리도 최근 실패 이력을 보여주기 위해 포함한다. */
+export function getCircuitSnapshot(): Array<{
+    tool: string;
+    state: ToolCircuitState;
+    failuresInWindow: number;
+    callsInWindow: number;
+    openMs: number;
+    opensInMs: number | null;
+    lastCategory?: string;
+}> {
+    const now = Date.now();
+    return [...entries.entries()]
+        .map(([tool, e]) => ({
+            tool,
+            state: e.state,
+            failuresInWindow: trim(e.failures, now).length,
+            callsInWindow: trim(e.calls, now).length,
+            openMs: e.openMs,
+            // OPEN 이면 해제까지 남은 시간(ms), 아니면 null.
+            opensInMs: e.state === 'open' ? Math.max(0, e.openMs - (now - e.openedAt)) : null,
+            lastCategory: e.lastCategory,
+        }))
+        .sort((a, b) => (a.state === b.state ? b.failuresInWindow - a.failuresInWindow : a.state === 'open' ? -1 : 1));
+}
+
+/** 수동 리셋 — 오탐 차단을 즉시 되돌릴 수단이 없으면 이 기능은 켤 수 없다. */
+export function resetToolCircuit(tool: string): boolean {
+    return entries.delete(tool);
+}
+
+/** 테스트 전용 — 모듈 레벨 상태 초기화. */
+export function __resetCircuitsForTest(): void {
+    entries.clear();
+}

--- a/apps/api/src/mcp/tool-router.ts
+++ b/apps/api/src/mcp/tool-router.ts
@@ -37,6 +37,7 @@ import { createLogger } from '../utils/logger';
 import { MCP_EXTERNAL_TOOL_LIMITS } from '../config/timeouts';
 import { withSpan } from '../observability/otel';
 import { classifyToolError, formatToolError } from './tool-error-classifier';
+import { isToolCircuitOpen, recordToolResult } from './tool-health';
 import type { UserMCPPool } from './user-pool';
 import { collectUserPoolTools } from './user-pool-tools';
 
@@ -140,6 +141,15 @@ export class ToolRouter {
             for (const entry of userEntries) tools.push(entry.tool);
         }
 
+        // 서킷 차단 도구는 노출하지 않는다. 이 함수가 채팅·에이전트 작업·딥리서치의
+        // 공통 소스이므로 필터가 여기 한 곳이면 전 경로에 적용된다(게이트 OFF 면 no-op).
+        const open = tools.filter((t) => isToolCircuitOpen(t.name));
+        if (open.length > 0) {
+            logger.info(`[circuit] 노출 제외 ${open.length}개: ${open.map((t) => t.name).join(', ')}`);
+            const blocked = new Set(open.map((t) => t.name));
+            return tools.filter((t) => !blocked.has(t.name));
+        }
+
         return tools;
     }
 
@@ -207,10 +217,13 @@ export class ToolRouter {
             const ok = (result: MCPToolResult): MCPToolResult => {
                 span.setAttribute('tool.duration_ms', Date.now() - startedAt);
                 span.setAttribute('tool.success', true);
+                recordToolResult(name, true);
                 return result;
             };
-            const fail = (rawMessage: string): MCPToolResult => {
+            /** `record:false` 는 서킷 자신이 낸 거절 — 세면 차단이 스스로를 연장한다. */
+            const fail = (rawMessage: string, opts: { record?: boolean } = {}): MCPToolResult => {
                 const c = classifyToolError(rawMessage);
+                if (opts.record !== false) recordToolResult(name, false, c.category);
                 span.setAttribute('tool.duration_ms', Date.now() - startedAt);
                 span.setAttribute('tool.success', false);
                 span.setAttribute('tool.error_category', c.category);
@@ -236,6 +249,15 @@ export class ToolRouter {
                 }
                 return ok(result);
             };
+            // 서킷 차단 도구는 실행하지 않고 즉시 거절한다. 노출에서 빠져도 모델이 이름을
+            // 기억해 호출할 수 있으므로 2차 방어가 필요하다(그리고 죽은 서버를 두드리지 않는다).
+            if (isToolCircuitOpen(name)) {
+                return fail(
+                    `도구 "${name}" 은 반복 실패로 일시 비활성화되었습니다. 잠시 후 자동으로 재시도되며, 지금은 다른 도구나 방법을 사용하세요.`,
+                    { record: false },
+                );
+            }
+
             // 외부 도구 출력 크기 제한(MAX_OUTPUT_SIZE, 1MB) — user-pool(1a)·전역(1b) 두 경로 공통.
             // 누락 시 대용량 도구 결과가 통째로 LLM 컨텍스트에 주입돼 토큰 예산 폭주/context-fit 조기 발동.
             const capOutput = (result: MCPToolResult): MCPToolResult => {

--- a/apps/api/src/routes/tool-health.routes.ts
+++ b/apps/api/src/routes/tool-health.routes.ts
@@ -2,8 +2,10 @@
  * 도구 헬스 관측 라우트 (admin 전용).
  *
  * 엔드포인트:
- *   GET /api/metrics/tools/health?days=N&minCalls=N&limit=N
+ *   GET  /api/metrics/tools/health?days=N&minCalls=N&limit=N
  *     — 도구별 호출·실패·**실패율**·주 실패 카테고리·p50 소요·마지막 실패 시각.
+ *   GET  /api/metrics/tools/circuit        — 서킷 현재 상태(인메모리 스냅샷) + 설정.
+ *   POST /api/metrics/tools/circuit/reset  — 서킷 수동 해제(오탐 즉시 되돌리기).
  *
  * 기존 `GET /api/metrics/agent-tasks/tool-errors` 와의 차이(둘 다 유지):
  *   ① 소스가 `audit_logs` 라 채팅·에이전트 작업 **양쪽** 경로를 덮는다(그쪽은 작업 스텝만).
@@ -21,7 +23,13 @@ import { asyncHandler } from '../utils/error-handler';
 import { success } from '../utils/api-response';
 import { getPool } from '../data/models/unified-database';
 import { ToolHealthRepository } from '../data/repositories/tool-health-repository';
-import { TOOL_HEALTH_QUERY } from '../config/tool-health';
+import { TOOL_HEALTH_QUERY, TOOL_CIRCUIT } from '../config/tool-health';
+import { getCircuitSnapshot, resetToolCircuit } from '../mcp/tool-health';
+import { getAuditService } from '../services/AuditService';
+import { badRequest, notFound } from '../utils/api-response';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('ToolHealthRoutes');
 
 export const toolHealthRouter = Router();
 toolHealthRouter.use(requireAuth, requireAdmin);
@@ -82,6 +90,54 @@ toolHealthRouter.get('/health', asyncHandler(async (req: Request, res: Response)
             };
         }),
     }));
+}));
+
+/**
+ * 서킷 현재 상태. 인메모리라 프로세스 재시작 시 비어 있는 것이 정상이다
+ * (재시작 리셋이 "서버를 고쳤는데 여전히 차단"보다 안전하다는 설계).
+ */
+toolHealthRouter.get('/circuit', asyncHandler(async (_req: Request, res: Response) => {
+    res.json(success({
+        config: {
+            enabled: TOOL_CIRCUIT.ENABLED,
+            scope: TOOL_CIRCUIT.SCOPE,
+            failureThreshold: TOOL_CIRCUIT.FAILURE_THRESHOLD,
+            windowMs: TOOL_CIRCUIT.WINDOW_MS,
+            minCalls: TOOL_CIRCUIT.MIN_CALLS,
+            openMs: TOOL_CIRCUIT.OPEN_MS,
+            excludedCategories: TOOL_CIRCUIT.EXCLUDED_CATEGORIES,
+        },
+        circuits: getCircuitSnapshot(),
+    }));
+}));
+
+/**
+ * 서킷 수동 해제. 오탐 차단을 즉시 되돌릴 수단 없이는 이 기능을 켤 수 없다.
+ * 도구 이름에 `::` 가 들어가므로 path param 대신 body 로 받는다.
+ */
+toolHealthRouter.post('/circuit/reset', asyncHandler(async (req: Request, res: Response) => {
+    const tool = typeof req.body?.tool === 'string' ? req.body.tool.trim() : '';
+    if (!tool) {
+        res.status(400).json(badRequest('tool 이 필요합니다.'));
+        return;
+    }
+    const cleared = resetToolCircuit(tool);
+    if (!cleared) {
+        res.status(404).json(notFound(`추적 중인 서킷(${tool})`));
+        return;
+    }
+    try {
+        await getAuditService().logAudit({
+            action: 'tool_circuit_reset',
+            userId: (req as Request & { user?: { id?: string } }).user?.id,
+            resourceType: 'tool_circuit',
+            resourceId: tool,
+        });
+    } catch (e) {
+        // 감사 실패가 해제를 되돌리진 않는다 — 애플리케이션 로그로 복원 가능하게 남긴다.
+        logger.warn(`서킷 해제 감사 기록 실패(무시): ${tool} — ${e instanceof Error ? e.message : e}`);
+    }
+    res.json(success({ tool, reset: true }));
 }));
 
 export default toolHealthRouter;

--- a/apps/web/app/(workspace)/admin/metrics/page.tsx
+++ b/apps/web/app/(workspace)/admin/metrics/page.tsx
@@ -105,6 +105,29 @@ interface ToolHealthData {
   }[];
 }
 
+/* ── 서킷 상태 타입 ────────────────────────────────────────
+ * 인메모리라 프로세스 재시작 시 비는 것이 정상이다(재시작 리셋이 "고쳤는데 여전히 차단"보다 안전). */
+interface CircuitData {
+  config: {
+    enabled: boolean;
+    scope: string;
+    failureThreshold: number;
+    windowMs: number;
+    minCalls: number;
+    openMs: number;
+    excludedCategories: string[];
+  };
+  circuits: {
+    tool: string;
+    state: "closed" | "open" | "half_open";
+    failuresInWindow: number;
+    callsInWindow: number;
+    openMs: number;
+    opensInMs: number | null;
+    lastCategory?: string;
+  }[];
+}
+
 /* ── 작업 워크플로우 관측 타입 ─────────────────────────────── */
 interface WorkflowData {
   days: number;
@@ -185,6 +208,7 @@ export default function AdminMetricsPage() {
   const [agentMetrics, setAgentMetrics] = useState<AgentMetric[] | null>(null);
   const [toolErrors, setToolErrors] = useState<ToolErrorData | null>(null);
   const [toolHealth, setToolHealth] = useState<ToolHealthData | null>(null);
+  const [circuit, setCircuit] = useState<CircuitData | null>(null);
   const [workflow, setWorkflow] = useState<WorkflowData | null>(null);
   const [routingGates, setRoutingGates] = useState<RoutingGatesData | null>(null);
 
@@ -275,6 +299,13 @@ export default function AdminMetricsPage() {
       if (toolHealthRes?.data) {
         setToolHealth(toolHealthRes.data);
       }
+      // 서킷 상태 (게이트 OFF 면 circuits 는 빈 배열)
+      const circuitRes = await ApiClient.get<{ data: CircuitData }>(
+        "/api/metrics/tools/circuit",
+      ).catch(() => null);
+      if (circuitRes?.data) {
+        setCircuit(circuitRes.data);
+      }
       // 작업 워크플로우 관측 로드 (기본 30일)
       const workflowRes = await ApiClient.get<{ data: WorkflowData }>(
         "/api/metrics/agent-tasks/workflow",
@@ -302,6 +333,15 @@ export default function AdminMetricsPage() {
     setUpdated(new Date().toLocaleTimeString(locale));
     void load();
   };
+
+  // 서킷 수동 해제 — 오탐 차단을 즉시 되돌리는 수단. 해제 후 목록을 다시 읽는다.
+  const onResetCircuit = async (tool: string) => {
+    await ApiClient.post("/api/metrics/tools/circuit/reset", { tool }).catch(() => null);
+    void load();
+  };
+
+  // 도구 → 서킷 상태. 게이트 OFF 거나 추적 항목이 없으면 빈 Map.
+  const circuitByTool = new Map((circuit?.circuits ?? []).map((c) => [c.tool, c]));
 
   return (
     <>
@@ -700,11 +740,18 @@ export default function AdminMetricsPage() {
         {toolHealth && (
           <Card className="mt-6">
             <CardHeader>
-              <CardTitle>
+              <CardTitle className="flex flex-wrap items-center gap-2">
                 {t("toolHealth.title", {
                   days: toolHealth.days,
                   minCalls: toolHealth.minCalls,
                 })}
+                {circuit && (
+                  <Badge tone={circuit.config.enabled ? "success" : "neutral"}>
+                    {circuit.config.enabled
+                      ? t("toolHealth.circuit.enabled", { n: circuit.config.failureThreshold })
+                      : t("toolHealth.circuit.disabled")}
+                  </Badge>
+                )}
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
@@ -738,6 +785,7 @@ export default function AdminMetricsPage() {
                         <Th className="whitespace-nowrap text-right">{t("toolHealth.th.errorRate")}</Th>
                         <Th className="whitespace-nowrap">{t("toolHealth.th.causes")}</Th>
                         <Th className="whitespace-nowrap">{t("toolHealth.th.lastError")}</Th>
+                        <Th className="whitespace-nowrap">{t("toolHealth.th.circuit")}</Th>
                       </tr>
                     </thead>
                     <tbody>
@@ -784,6 +832,26 @@ export default function AdminMetricsPage() {
                               {row.lastErrorAt
                                 ? new Date(row.lastErrorAt).toLocaleDateString(locale)
                                 : "—"}
+                            </Td>
+                            <Td className="whitespace-nowrap">
+                              {(() => {
+                                const c = circuitByTool.get(row.tool);
+                                if (!c || c.state === "closed") return <span className="text-xs text-fg-3">—</span>;
+                                return (
+                                  <span className="flex items-center gap-2">
+                                    <Badge tone={c.state === "open" ? "danger" : "warn"}>
+                                      {t(`toolHealth.circuit.${c.state}`)}
+                                    </Badge>
+                                    <Button
+                                      variant="outline"
+                                      size="sm"
+                                      onClick={() => void onResetCircuit(row.tool)}
+                                    >
+                                      {t("toolHealth.circuit.reset")}
+                                    </Button>
+                                  </span>
+                                );
+                              })()}
                             </Td>
                           </tr>
                         );

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1340,9 +1340,17 @@
         "errors": "Failures",
         "errorRate": "Failure rate",
         "causes": "Top causes",
-        "lastError": "Last failure"
+        "lastError": "Last failure",
+        "circuit": "Circuit"
       },
-      "empty": "No tool has enough samples yet."
+      "empty": "No tool has enough samples yet.",
+      "circuit": {
+        "open": "Blocked",
+        "half_open": "Probing",
+        "reset": "Reset",
+        "enabled": "Circuit on ({n} failures)",
+        "disabled": "Circuit off"
+      }
     },
     "workflow": {
       "title": "Task Workflow (last {days} days)",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1340,9 +1340,17 @@
         "errors": "失敗",
         "errorRate": "失敗率",
         "causes": "主な原因",
-        "lastError": "最終失敗"
+        "lastError": "最終失敗",
+        "circuit": "遮断"
       },
-      "empty": "十分なサンプルのあるツールがありません。"
+      "empty": "十分なサンプルのあるツールがありません。",
+      "circuit": {
+        "open": "遮断中",
+        "half_open": "復旧試行",
+        "reset": "解除",
+        "enabled": "サーキット有効 (連続失敗 {n}回)",
+        "disabled": "サーキット無効"
+      }
     },
     "workflow": {
       "title": "タスクワークフロー (直近{days}日)",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1340,9 +1340,17 @@
         "errors": "실패",
         "errorRate": "실패율",
         "causes": "주요 원인",
-        "lastError": "마지막 실패"
+        "lastError": "마지막 실패",
+        "circuit": "차단"
       },
-      "empty": "표본이 충분한 도구가 없습니다."
+      "empty": "표본이 충분한 도구가 없습니다.",
+      "circuit": {
+        "open": "차단됨",
+        "half_open": "복구 시도",
+        "reset": "해제",
+        "enabled": "서킷 켜짐 (연속 실패 {n}회)",
+        "disabled": "서킷 꺼짐"
+      }
     },
     "workflow": {
       "title": "작업 워크플로우 (최근 {days}일)",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1340,9 +1340,17 @@
         "errors": "失败",
         "errorRate": "失败率",
         "causes": "主要原因",
-        "lastError": "最后失败"
+        "lastError": "最后失败",
+        "circuit": "熔断"
       },
-      "empty": "暂无样本足够的工具。"
+      "empty": "暂无样本足够的工具。",
+      "circuit": {
+        "open": "已阻断",
+        "half_open": "试探恢复",
+        "reset": "解除",
+        "enabled": "熔断已开启 (连续失败 {n} 次)",
+        "disabled": "熔断已关闭"
+      }
     },
     "workflow": {
       "title": "任务工作流（最近 {days} 天）",


### PR DESCRIPTION
> ⚠️ **Stacked PR** — base 가 `feat/tool-health-observability`(#655) 다. #655 를 먼저 머지한 뒤 base 를 `main` 으로 바꾸거나 자동 전환되게 둔다. #655 가 도입한 `errorCategory` 계약에 의존한다.

## 왜

서버가 `crashed` 면 user-pool 에 없어 도구가 자동 제외된다. 문제는 **서버는 살아 있는데 도구만 실패하는 경우** — 헤드리스 브라우저 런처 실패, 인증 만료 등. 이때 도구는 계속 노출되고 모델은 계속 호출한다.

실측(60일): `noapi-google-search::google_news` 55호출 26실패, `google_search` 45호출 21실패 — 서버가 살아 있는 채로 두 도구가 100회 중 47회 실패하는 동안 한 번도 노출에서 빠지지 않았다.

## 무엇을

- **`mcp/tool-health.ts`** — 창 기반 실패 집계 + `CLOSED → OPEN → HALF_OPEN` 전이. cooldown 이 지나면 half-open 으로 1회 통과시켜 복구를 판정하고, 재실패하면 차단 시간을 배수로(상한까지) 늘린다.
- **노출 필터** — `ToolRouter.getAllTools()` 한 곳. 채팅·에이전트 작업·딥리서치의 공통 소스라 전 경로에 적용된다.
- **실행 거절** — `executeTool()` 이 차단 도구를 실행하지 않고 즉시 거절한다. 모델이 이름을 기억해 호출하는 경우의 2차 방어이자, 죽은 서버를 계속 두드리지 않는 효과.
- **admin** — `GET /api/metrics/tools/circuit`(상태+설정) · `POST /circuit/reset`(수동 해제, 감사 기록) + 도구 헬스 표의 차단 배지·[해제] 버튼.
- 설정 12종은 `config/tool-health.ts`(L2) + env. **게이트 `TOOL_HEALTH_CIRCUIT_ENABLED` 기본 OFF.**

## 계획 대비 조정 3건

| # | 조정 | 근거 |
|---|---|---|
| ① | `not_found` 를 카운트 **제외**로 이동 (계획은 "가중치 높게") | 분류기 패턴이 `찾을 수 없습니다\|ENOENT\|404` 라 **대상 리소스 부재**까지 잡는다. 도구 고장이 아닌 실패로 정상 도구를 차단하고, 없는 도구 이름을 호출할 때마다 추적 Map 이 무한히 커진다 |
| ② | 범위를 외부 도구(`::`)로 제한 (`SCOPE=external`, `all` 로 변경 가능) | 내장 도구를 빼면 `web_search` 같은 핵심 경로가 사라지는 손실이 크고, 내장 실패는 대개 인자·사용자 오류다. 서킷의 동기는 죽은 외부 MCP 서버다 |
| ③ | 프론트 [해제] 버튼 추가 (계획은 API 만) | 오탐을 되돌릴 수단이 curl 뿐이면 이 게이트를 켤 수 없다 |

## 설계에서 중요한 두 가지

1. **서킷이 낸 거절은 실패로 세지 않는다** (`fail(..., {record:false})`). 세면 차단이 스스로를 무한 연장한다. 테스트로 고정했다.
2. **`FAILURE_THRESHOLD`(5)는 self-heal 보다 크게** 잡았다. `external-client` 는 연결 사망(`Not connected`/`Session not found`)을 감지하면 status 를 `error` 로 내려 evict → respawn 을 유도한다. 서킷이 먼저 열리면 그 복구 기회를 뺏는다.

## 검증

- 서킷 단위 **13건** — 상태 전이, `invalid_args`/`not_found`/`output_truncated` 미카운트, 내장 도구 범위 밖, 성공 시 리셋, half-open 복구·재차단 backoff·상한, 정상 도구는 엔트리 미생성(메모리), 추적 상한 축출, 수동 리셋.
- 라우터 통합 **4건** — 노출 제외(다른 도구는 그대로), 거절 미카운트, 게이트 OFF no-op, 성공 도구 무차단.
- 라우트 **4건** — 상태 조회, 해제+감사, 400/404, 비관리자 403.
- 전체 jest **3,114 pass** · tsc(api·web) · 최대 477줄 · lint 0 error · eval:routing 93.3% · eval:response 100%.

## 활성화 전 필요한 것 (이 PR 범위 밖)

임계값은 관측 데이터가 쌓이기 전의 **잠정값**이다. #655 배포 후 1~2주 도구 헬스를 보고 확정한 뒤 `TOOL_HEALTH_CIRCUIT_ENABLED=true`. 라이브 검증 시나리오는 죽은 외부 서버의 도구를 연속 호출 → 차단 확인 → 노출에서 사라짐 확인 → 서버 복구 → cooldown 후 자동 복귀.

## 알려진 한계 (의도)

- 상태는 **프로세스 메모리**(단일 API 인스턴스 전제). 재시작 시 리셋되는 편이 "서버를 고쳤는데 여전히 차단"보다 안전하다. 멀티 인스턴스로 가면 KVStore 로 승격.
- task 도구(`bash`·`file_ops`·`plan_*`)는 tool-router 를 타지 않아 대상이 아니다.

## 체크리스트

- [x] `npm run lint` 0 error
- [x] `npm test` 3,114 pass
- [x] `eval:routing` · `eval:response`
- [x] `.env.example` (설정 12종 + 활성화 전 주의)
- [ ] UI 스크린샷 (배포 후)
- [x] DB 스키마 변경 없음
- [x] 되돌리기: env 한 줄 + 재시작으로 즉시 원상복구(상태 인메모리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hzHmjGo5uQuisYrxZfCnC
