### PR TITLE
fix(agent-task): goal 의 번호 절차를 초기 계획으로 심는다 — plan 프로토콜 오류 제거 (P0-c)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -991,6 +991,17 @@ AGENT_TASK_TIMEOUT_MS=600000
 # Agent Task — 플랜 자동 진행. 단계 완료/차단 후 in_progress 가 없으면 첫 not_started 를
 # 자동 승격(모델이 [~] 마킹을 생략해도 스텝→노드 귀속·진행 표시가 비지 않게). 기본 ON.
 # AGENT_TASK_PLAN_AUTO_ADVANCE=true
+# goal 의 번호 절차(`[절차] 1) … 7)`)를 작업 시작 시 초기 계획으로 심는다(기본 on).
+# 모델은 goal 에 적힌 번호를 계획으로 인식해 plan_create 없이 plan_update(step:N) 부터 부른다 —
+# 그때 계획이 비어 있으면 "아직 계획이 없습니다"/"범위를 벗어났습니다" 로 턴을 버렸다
+# (실측 2026-08-28: plan 프로토콜 오류 28건 중 20건). 실패 인자가 {step,status} 뿐이라
+# 빈 계획을 만들어줘도 그 단계가 무엇인지 알 수 없어, goal 의 번호를 그대로 심어 일치시킨다.
+# 결정적 파싱(LLM 없음) — 절차가 없는 goal 에는 아무 일도 하지 않는다.
+# AGENT_TASK_PLAN_FROM_GOAL=true
+# 번호 항목이 이 수 미만이면 절차 목록이 아니라고 본다(오탐 방지).
+# AGENT_TASK_PLAN_FROM_GOAL_MIN_ITEMS=3
+# AGENT_TASK_PLAN_FROM_GOAL_MAX_ITEMS=20
+# AGENT_TASK_PLAN_FROM_GOAL_MAX_TEXT_CHARS=160
 
 # Agent Task — HITL 무응답 강등. 승인 무응답(timeout, 명시 거절 아님)이 이 횟수에 달하면
 # 이후 턴에서 승인 필요 도구(+ask_human)를 제거하고 확보한 정보로 최종 산출물 작성을 유도.

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1523,6 +1523,19 @@ export const AGENT_TASK_LIMITS = {
      *  스텝→노드 귀속(plan_step_index)·진행 표시가 비지 않게 한다. 모델의 명시 마킹이 우선.
      *  AGENT_TASK_PLAN_AUTO_ADVANCE=false 로 비활성(기본 on). */
     PLAN_AUTO_ADVANCE: process.env.AGENT_TASK_PLAN_AUTO_ADVANCE !== 'false',
+    /** goal 의 번호 절차(`[절차] 1) … 7)`)를 작업 시작 시 초기 계획으로 심는다.
+     *  근거: 모델은 goal 의 번호를 계획으로 인식해 plan_create 없이 plan_update(step:N) 부터
+     *  부른다 — 실측(2026-08-28) plan 프로토콜 오류 28건 중 20건이 이 형태. 실패 인자가
+     *  `{step,status}` 뿐이라 빈 계획을 만들어줘도 그 단계가 무엇인지 알 수 없어, goal 의
+     *  번호를 그대로 심어 번호 체계를 일치시킨다. 결정적 파싱(LLM 없음).
+     *  AGENT_TASK_PLAN_FROM_GOAL=false 로 비활성(기본 on — 절차가 없는 goal 엔 no-op). */
+    PLAN_FROM_GOAL: process.env.AGENT_TASK_PLAN_FROM_GOAL !== 'false',
+    /** 번호 항목이 이 수 미만이면 절차 목록이 아니라고 보고 심지 않는다(오탐 방지). */
+    PLAN_FROM_GOAL_MIN_ITEMS: parseInt(process.env.AGENT_TASK_PLAN_FROM_GOAL_MIN_ITEMS || '3', 10),
+    /** 초기 계획으로 심을 최대 단계 수. */
+    PLAN_FROM_GOAL_MAX_ITEMS: parseInt(process.env.AGENT_TASK_PLAN_FROM_GOAL_MAX_ITEMS || '20', 10),
+    /** 단계 텍스트 상한(초과분은 잘라냄) — goal 의 한 항목이 길어도 계획 표시가 무너지지 않게. */
+    PLAN_FROM_GOAL_MAX_TEXT_CHARS: parseInt(process.env.AGENT_TASK_PLAN_FROM_GOAL_MAX_TEXT_CHARS || '160', 10),
     /** HITL 무응답 강등 — 승인 무응답(timeout, 명시 거절 아님)이 이 횟수에 달하면 이후 턴에서
      *  승인 필요 도구(+ask_human)를 제거하고 확보한 정보로 마무리를 유도한다. 후향 실측: 방치
      *  task 가 승인 대기(30분)×N 반복으로 예산만 소진하고 산출물 0 으로 종결되던 패턴 차단.

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -222,7 +222,7 @@ export class AgentTaskService {
                             onPausedMs: (ms) => { pausedMs += ms; },
                         })
                         : undefined;
-                    taskRuntime = new TaskRuntime(taskId, userId, sandboxCfg, delegateFn, spawnFn, remoteExecutor);
+                    taskRuntime = new TaskRuntime(taskId, userId, sandboxCfg, delegateFn, spawnFn, remoteExecutor, goal);
                     await taskRuntime.create();
                     await db.updateAgentTask(taskId, {
                         sandboxContainerId: taskRuntime.containerName,

--- a/apps/api/src/services/task-sandbox/__tests__/plan-from-goal.test.ts
+++ b/apps/api/src/services/task-sandbox/__tests__/plan-from-goal.test.ts
@@ -1,0 +1,84 @@
+/**
+ * goal 번호 절차 → 초기 계획 파싱.
+ *
+ * 실측 배경(2026-08-28): plan 프로토콜 오류 28건 중 20건이 "goal 에 `[절차] 1)…7)` 이 있고
+ * 모델이 그 번호로 plan_update 를 부르는데 TaskPlan 은 비어 있는" 형태였다. 실패 인자는
+ * 대부분 `{step, status}` 뿐이라 빈 계획으로는 복구가 안 된다 — 번호를 그대로 심어야 한다.
+ *
+ * 오탐(절차가 아닌 번호를 계획으로 심는 것)이 이 기능의 실패 모드라 그 경계를 함께 고정한다.
+ */
+import { parseGoalPlanSteps } from '../planning';
+
+const OPTS = { minItems: 3, maxItems: 20, maxTextChars: 160 };
+
+/** 실패를 반복하던 실제 goal 의 구조(AI 트렌드 리포트 예약 작업). */
+const REAL_GOAL = [
+    '국내·국외 AI 트렌드 데일리 리포트를 "고정 디자인 템플릿"으로 생성한다.',
+    '[규칙]',
+    '- 검색은 web_search 도구를 사용하라. 스크래퍼 파이썬 파일 만들지 마라.',
+    '- RUN_DATE 는 실제 실행일 날짜(YYYY-MM-DD)로 기입하라.',
+    '[절차]',
+    '1) 검색: 최근 24h 국내(한국)/국외(글로벌) AI 뉴스 — 투자/제품출시/정책·규제/인재.',
+    '2) 검증: fact_check 로 핵심 사실 교차확인.',
+    '3) 분석: 투자자·경영자·창업자 3관점으로 해석.',
+    '4) 채울 키 확인: bash 로 `python3 /opt/report-template/render_report.py --keys` 실행.',
+    '5) data.json 작성: file_ops(op=write, path=data.json)로 키를 모두 채운다. 값 규칙:',
+    '  news = [{"region":"국내","src":출처}] — 국내·국외 각 3건 이상.',
+    '6) 렌더: bash 로 `python3 /opt/report-template/render_report.py data.json report.html` 실행.',
+    '7) 확인: 렌더러 출력에 "경고 —" 줄이 없어야 한다.',
+].join('\n');
+
+describe('parseGoalPlanSteps', () => {
+    it('실제 실패 goal 의 [절차] 7단계를 순서대로 뽑는다', () => {
+        const steps = parseGoalPlanSteps(REAL_GOAL, OPTS);
+        expect(steps).toHaveLength(7);
+        expect(steps[0]).toContain('검색');
+        expect(steps[1]).toContain('fact_check');
+        expect(steps[6]).toContain('확인');
+        // 5) 의 하위 들여쓰기 줄은 앞 단계의 연속이라 별도 단계가 되면 안 된다.
+        expect(steps.some((s) => s.startsWith('news ='))).toBe(false);
+    });
+
+    it('[규칙] 의 `-` 불릿은 단계로 세지 않는다', () => {
+        const steps = parseGoalPlanSteps(REAL_GOAL, OPTS);
+        expect(steps.some((s) => s.includes('스크래퍼'))).toBe(false);
+    });
+
+    it('`N.` 과 `N-` 형식도 인식한다', () => {
+        expect(parseGoalPlanSteps('1. 하나\n2. 둘\n3. 셋', OPTS)).toEqual(['하나', '둘', '셋']);
+        expect(parseGoalPlanSteps('1- 하나\n2- 둘\n3- 셋', OPTS)).toEqual(['하나', '둘', '셋']);
+    });
+
+    it('연속되지 않으면 거기까지만 — 번호가 튀는 목록을 통째로 삼키지 않는다', () => {
+        expect(parseGoalPlanSteps('1) 하나\n2) 둘\n5) 다섯\n6) 여섯', OPTS)).toEqual([]);
+        expect(parseGoalPlanSteps('1) 하나\n2) 둘\n3) 셋\n7) 일곱', OPTS)).toEqual(['하나', '둘', '셋']);
+    });
+
+    it('minItems 미만이면 절차가 아니라고 보고 심지 않는다 (오탐 방지)', () => {
+        expect(parseGoalPlanSteps('1) 사과\n2) 배', OPTS)).toEqual([]);
+    });
+
+    it('인라인 번호는 단계가 아니다 — 줄 머리만 인정', () => {
+        expect(parseGoalPlanSteps('다음을 비교해줘: 1) 사과 2) 배 3) 감', OPTS)).toEqual([]);
+    });
+
+    it('번호가 없는 평범한 goal 은 no-op', () => {
+        expect(parseGoalPlanSteps('워크스페이스에 파일을 만들고 한 줄 써줘', OPTS)).toEqual([]);
+        expect(parseGoalPlanSteps('', OPTS)).toEqual([]);
+    });
+
+    it('maxItems 로 자르고, 긴 단계 텍스트는 상한에서 잘라낸다', () => {
+        const many = Array.from({ length: 30 }, (_, i) => `${i + 1}) 단계${i + 1}`).join('\n');
+        expect(parseGoalPlanSteps(many, { ...OPTS, maxItems: 5 })).toHaveLength(5);
+
+        const long = `1) ${'가'.repeat(300)}\n2) 둘\n3) 셋`;
+        const steps = parseGoalPlanSteps(long, { ...OPTS, maxTextChars: 20 });
+        expect(steps[0]).toHaveLength(21); // 20자 + '…'
+        expect(steps[0].endsWith('…')).toBe(true);
+    });
+
+    it('목록이 1 로 다시 시작하면 새 목록으로 본다 (앞의 짧은 열은 버림)', () => {
+        const g = '1) 예시\n\n[절차]\n1) 진짜1\n2) 진짜2\n3) 진짜3';
+        expect(parseGoalPlanSteps(g, OPTS)).toEqual(['진짜1', '진짜2', '진짜3']);
+    });
+});

--- a/apps/api/src/services/task-sandbox/__tests__/runtime-plan-seed.test.ts
+++ b/apps/api/src/services/task-sandbox/__tests__/runtime-plan-seed.test.ts
@@ -1,0 +1,58 @@
+/**
+ * TaskRuntime 초기 계획 심기 — 실제 결함이 사라졌는지 런타임 레벨로 고정.
+ *
+ * 결함(실측 2026-08-28): goal 에 `[절차] 1)…7)` 이 있으면 모델이 plan_create 없이
+ * `plan_update(step:2, status:'in_progress')` 를 부르고 "아직 계획이 없습니다" 로 턴을 버렸다.
+ * plan 프로토콜 오류 28건 중 20건이 이 형태.
+ */
+import { TaskRuntime } from '../runtime';
+import { getTaskSandboxConfig } from '../../../config/task-sandbox';
+
+// 승인 게이트가 개입하지 않는 정책으로 고정(plan_* 는 원래 승인 불요지만 명시).
+const cfg = { ...getTaskSandboxConfig(), approvalPolicy: 'none' as const };
+
+const GOAL_WITH_STEPS = [
+    'AI 트렌드 리포트를 생성한다.',
+    '[절차]',
+    '1) 검색: 최근 24h 뉴스.',
+    '2) 검증: fact_check 로 교차확인.',
+    '3) 분석: 3관점으로 해석.',
+].join('\n');
+
+describe('TaskRuntime 초기 계획 심기', () => {
+    it('goal 절차가 있으면 plan_create 없이 plan_update(step:2) 가 성공한다 (회귀 고정)', async () => {
+        const rt = new TaskRuntime('t-seed', 'u1', cfg, undefined, undefined, undefined, GOAL_WITH_STEPS);
+        const res = await rt.executeTaskTool('plan_update', { step: 2, status: 'in_progress' });
+        expect(res).not.toContain('아직 계획이 없습니다');
+        expect(res).not.toContain('범위를 벗어');
+    });
+
+    it('심어진 계획이 goal 의 단계 텍스트를 담는다', async () => {
+        const rt = new TaskRuntime('t-seed2', 'u1', cfg, undefined, undefined, undefined, GOAL_WITH_STEPS);
+        const view = await rt.executeTaskTool('plan_view', {});
+        expect(view).toContain('검색');
+        expect(view).toContain('fact_check');
+        expect(view).toContain('3관점');
+    });
+
+    it('goal 이 없거나 절차가 없으면 종전 동작 — 계획 없음 오류가 그대로 난다', async () => {
+        const rt = new TaskRuntime('t-noseed', 'u1', cfg, undefined, undefined, undefined, '파일 하나 만들어줘');
+        const res = await rt.executeTaskTool('plan_update', { step: 2, status: 'in_progress' });
+        expect(res).toContain('계획이 없습니다');
+
+        const rt2 = new TaskRuntime('t-nogoal', 'u1', cfg);
+        const res2 = await rt2.executeTaskTool('plan_update', { step: 1, status: 'in_progress' });
+        expect(res2).toContain('계획이 없습니다');
+    });
+
+    it('모델이 plan_create 를 부르면 기존 상태 보존 병합이 받는다 (심은 계획을 덮어쓰지 않음)', async () => {
+        const rt = new TaskRuntime('t-seed3', 'u1', cfg, undefined, undefined, undefined, GOAL_WITH_STEPS);
+        await rt.executeTaskTool('plan_update', { step: 1, status: 'completed' });
+        // 같은 텍스트로 재생성 — 1단계의 completed 가 보존되어야 한다.
+        await rt.executeTaskTool('plan_create', {
+            steps: ['검색: 최근 24h 뉴스.', '검증: fact_check 로 교차확인.', '분석: 3관점으로 해석.'],
+        });
+        const view = await rt.executeTaskTool('plan_view', {});
+        expect(view).toContain('[x]');
+    });
+});

--- a/apps/api/src/services/task-sandbox/planning.ts
+++ b/apps/api/src/services/task-sandbox/planning.ts
@@ -36,6 +36,47 @@ export function currentPlanStepIndex(steps: PlanStep[]): number | undefined {
     return i < 0 ? undefined : i;
 }
 
+/**
+ * PURE: goal 본문의 번호 절차를 초기 계획 단계로 파싱.
+ *
+ * 왜 필요한가 — goal 에 `[절차] 1) … 7)` 처럼 번호가 적혀 있으면 모델은 **그 번호를 계획으로
+ * 인식**해 `plan_create` 없이 `plan_update(step:2)` 부터 부른다. TaskPlan 은 비어 있으므로
+ * "아직 계획이 없습니다"/"단계 N 이 범위를 벗어났습니다" 오류가 난다. 실측(2026-08-28):
+ * plan 프로토콜 오류 28건 중 20건이 이 형태였고, 실패 인자는 대부분 `{step, status}` 뿐이라
+ * **빈 계획을 만들어줘도 그 단계가 무엇인지 알 수 없다**. goal 의 번호를 그대로 계획으로
+ * 심어야 모델의 번호와 TaskPlan 의 번호가 일치한다.
+ *
+ * 결정적 파싱(LLM 없음) — 판단 경계 A형(앞단 LLM 판단) 도입이 아니다.
+ *
+ * 규칙: 줄 머리의 `N)` `N.` `N-` 만 인정(인라인 번호 제외), **1 부터 시작해 1 씩 증가하는
+ * 연속열**만 취한다(중간에 끊기면 거기까지). 하위 들여쓰기 줄은 앞 단계의 연속이므로 버린다.
+ * 항목이 `minItems` 미만이면 절차가 아니라고 보고 빈 배열(no-op).
+ */
+export function parseGoalPlanSteps(
+    goal: string,
+    opts: { minItems: number; maxItems: number; maxTextChars: number },
+): string[] {
+    if (!goal) return [];
+    const steps: string[] = [];
+    let expected = 1;
+    for (const rawLine of goal.split('\n')) {
+        // 들여쓰기된 줄은 앞 항목의 연속 — 번호처럼 보여도 새 단계로 세지 않는다.
+        if (/^\s/.test(rawLine)) continue;
+        const m = /^(\d{1,2})\s*[).\-]\s+(\S.*)$/.exec(rawLine.trim());
+        if (!m) continue;
+        if (Number(m[1]) !== expected) {
+            // 1 로 다시 시작하면 새 목록의 시작으로 본다(앞의 짧은 열은 버린다).
+            if (Number(m[1]) === 1) { steps.length = 0; expected = 2; steps.push(m[2].trim()); }
+            continue;
+        }
+        steps.push(m[2].trim());
+        expected++;
+        if (steps.length >= opts.maxItems) break;
+    }
+    if (steps.length < opts.minItems) return [];
+    return steps.map((t) => (t.length > opts.maxTextChars ? t.slice(0, opts.maxTextChars) + '…' : t));
+}
+
 /** task 실행 계획. 단계 목록 + 상태. 순수 로직(유닛테스트 대상). */
 export class TaskPlan {
     private steps: PlanStep[] = [];

--- a/apps/api/src/services/task-sandbox/runtime.ts
+++ b/apps/api/src/services/task-sandbox/runtime.ts
@@ -18,7 +18,7 @@ import { recordBrowserMetric } from './browser-metrics';
 import { AGENT_TASK_LIMITS, ORCHESTRATION_DISPATCH, MAX_TOOL_RESULT_CHARS } from '../../config/runtime-limits';
 import { recordToolResultTruncation } from '../tool-result-truncation-recorder';
 import { saveProceduralSkill, resolveProceduralSpec } from '../agent-task/procedural-skill';
-import { TaskPlan, type PlanStep } from './planning';
+import { TaskPlan, parseGoalPlanSteps, type PlanStep } from './planning';
 import { requiresApproval, getApprovalRegistry, type PendingApproval, type ApprovalRejectReason } from './approval-gate';
 import { createLogger } from '../../utils/logger';
 
@@ -70,11 +70,14 @@ export class TaskRuntime {
         spawn?: SpawnFn,
         /** 실행 백엔드 주입(D1 원격 실행기용). 미지정 시 현행 Docker 샌드박스. */
         executor?: TaskExecutor,
+        /** 작업 목표 — 번호 절차가 있으면 초기 계획으로 심는다(아래 seedPlanFromGoal). */
+        goal?: string,
     ) {
         this.taskId = taskId;
         this.userId = userId;
         this.cfg = cfg;
         this.executor = executor ?? new TaskSandbox(taskId, cfg);
+        this.seedPlanFromGoal(goal);
         // #1 절차 스킬: 저장/조회 훅을 userId 로 바인딩(재생 실행은 tools.ts 가 sandbox 로 수행). 플래그 OFF 면 미노출.
         const procedural: ProceduralHooks | undefined = AGENT_TASK_LIMITS.PROCEDURAL_SKILLS_ENABLED
             ? {
@@ -147,6 +150,26 @@ export class TaskRuntime {
     /** 내부 검증용 원시 exec — 승인 게이트 우회(에이전트 도구 호출이 아닌 시스템 산출물 검증).
      *  컨테이너는 격리(network none·자원 캡)이고 문법/컴파일 검사는 코드를 실행하지 않아 안전. */
     async execRaw(command: string): Promise<ExecResult> { return this.executor.exec(command); }
+
+    /**
+     * goal 의 번호 절차를 초기 계획으로 심는다.
+     *
+     * 모델은 goal 에 적힌 `1) … 7)` 을 계획으로 인식해 plan_create 없이 plan_update(step:N)
+     * 부터 부른다 — 그때 TaskPlan 이 비어 있으면 "계획이 없습니다"/"범위를 벗어났습니다" 로
+     * 턴을 버린다(실측 28건 중 20건). 번호를 미리 심어 두 번호 체계를 일치시킨다.
+     * 절차가 없는 goal 엔 no-op 이고, 모델이 plan_create 를 부르면 기존 상태 보존 병합이 받는다.
+     */
+    private seedPlanFromGoal(goal?: string): void {
+        if (!AGENT_TASK_LIMITS.PLAN_FROM_GOAL || !goal) return;
+        const steps = parseGoalPlanSteps(goal, {
+            minItems: AGENT_TASK_LIMITS.PLAN_FROM_GOAL_MIN_ITEMS,
+            maxItems: AGENT_TASK_LIMITS.PLAN_FROM_GOAL_MAX_ITEMS,
+            maxTextChars: AGENT_TASK_LIMITS.PLAN_FROM_GOAL_MAX_TEXT_CHARS,
+        });
+        if (steps.length === 0) return;
+        this.plan.create(steps);
+        logger.info(`[${this.taskId}] goal 절차 ${steps.length}단계를 초기 계획으로 심음`);
+    }
 
     /** task-scoped 도구를 LLM 형식으로. AgentTaskService 가 effectiveTools 에 합류. */
     getLLMTools(): ToolDefinition[] { return this.defs.map(toLLMTool); }


### PR DESCRIPTION
## 왜

goal 에 `[절차] 1) … 7)` 이 적혀 있으면 모델은 **그 번호를 계획으로 인식**해 `plan_create` 없이 `plan_update(step:2)` 부터 부른다. `TaskPlan` 은 비어 있으므로 이런 오류로 턴을 버린다:

```
Error: 아직 계획이 없습니다 — 먼저 plan_create 로 단계를 세우세요.
Error: 단계 2 가 범위를 벗어났습니다 — 현재 계획은 1단계입니다(유효 step: 1..1).
```

모델의 실수가 아니라 **goal 의 번호 체계와 TaskPlan 의 단계 번호가 별개**라서 생기는 구조적 혼동이고, 프롬프트로 막기 어렵다.

### 실측 (2026-08-28)

- plan 프로토콜 오류 **28건 중 20건(71%)** 이 AI 트렌드 리포트 예약 작업 **하나**에서 났다(10개 작업, 최근 8/26까지 진행 중).
- 실패한 호출의 인자는 대부분 `{"step": 2, "status": "in_progress"}` — **계획 텍스트를 만들 재료가 없다.**
- 오류를 본 모델이 `plan_create` 로 자기 교정하는 경우도 많지만, `plan_update → plan_view → plan_update` 로 헛도는 케이스도 있다.

당초 계획은 "`plan_update` 선행 실패 시 빈 계획 자동 부트스트랩" 이었는데, 위 인자 분포가 그 전제를 깼다 — 빈 계획을 만들어줘도 "단계 2" 가 무엇인지 모르는 상태는 그대로다. **goal 의 번호를 그대로 심어야** 두 번호가 일치한다.

## 무엇을

- **`parseGoalPlanSteps()`** (`task-sandbox/planning.ts`, 순수 함수) — 줄 머리의 `N)`·`N.`·`N-` 만 인정(인라인 번호 제외), **1 부터 1 씩 증가하는 연속열**만 취하고, 들여쓰기된 하위 줄은 앞 단계의 연속으로 버린다. 항목이 `minItems` 미만이면 절차가 아니라고 보고 no-op.
  - **결정적 파싱(LLM 없음)** — 판단 경계 A형(앞단 LLM 판단) 도입이 아니다.
- **`TaskRuntime.seedPlanFromGoal()`** — 작업 시작 시 초기 계획으로 심는다. `AgentTaskService` 가 생성자에 `goal` 을 전달. 모델이 `plan_create` 를 부르면 기존 **상태 보존 병합**이 받는다(심은 계획을 덮어쓰지 않음).
- 설정: `AGENT_TASK_PLAN_FROM_GOAL`(기본 on) · `_MIN_ITEMS`(3) · `_MAX_ITEMS`(20) · `_MAX_TEXT_CHARS`(160).

### 부수 효과 (개선 방향)

`getPlanSnapshot()` 은 매 턴 진행률 계산·`agent_tasks.plan` 저장·`plan_step_index` 귀속에 쓰인다. 따라서 초기 계획이 **첫 턴부터** 반영된다 — 종전에는 모델이 `plan_create` 를 부를 때까지 비어 있었다.

## 검증

**파서 9건** — 실제로 실패하던 goal 구조를 그대로 테스트에 넣었다:
- `[절차]` 7단계를 순서대로 추출, `5)` 아래 들여쓰기된 `news = [...]` 줄은 단계로 세지 않음
- `[규칙]` 의 `-` 불릿을 단계로 오인하지 않음
- 오탐 경계: 번호가 튀는 목록(`1,2,5,6`) → 빈 배열, 인라인 번호(`1) 사과 2) 배`) → 빈 배열, 2개짜리 목록 → 빈 배열
- `maxItems` 절단, 긴 텍스트 상한 절단, 목록이 `1` 로 재시작하면 새 목록으로 인식

**런타임 회귀 4건** — 결함이 실제로 사라졌는지:
- goal 절차가 있으면 `plan_create` 없이 `plan_update(step:2)` 성공 (회귀 고정)
- 심어진 계획이 goal 의 단계 텍스트를 담음
- **절차 없는 goal·goal 없음은 종전 동작 유지**("계획이 없습니다" 오류 그대로)
- `plan_create` 재호출 시 기존 상태(`[x]`) 보존

전체 jest **3,106 pass** · tsc · 최대 572줄 · lint 0 error · eval:routing 93.3% · eval:response 100%.

## 남는 것

이 발견은 **P0-c 와 P1(반복 워크플로우 결정성)이 같은 작업의 같은 증상**임을 보여준다. 그 예약 작업은 `goal_incomplete` 실패의 대부분이기도 하다 — 이 PR 은 plan 오류만 없애고, 그 작업이 매번 20~30턴을 새로 탐색하는 문제 자체는 P1 몫이다.

## 체크리스트

- [x] `npm run lint` 0 error
- [x] `npm test` 3,106 pass
- [x] `eval:routing` · `eval:response`
- [x] `.env.example` 업데이트
- [x] DB 스키마 변경 없음
- [x] UI 변경 없음(백엔드만 — 계획이 첫 턴부터 채워지는 표시 변화는 기존 렌더 경로 그대로)
- [x] 되돌리기: `AGENT_TASK_PLAN_FROM_GOAL=false` + 재시작

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hzHmjGo5uQuisYrxZfCnC
