### PR TITLE
fix(mcp): 확장 유래 MCP env 자리표시자 입력 + 시크릿 암호화 + status 이중 풀

### DIFF
--- a/apps/api/src/agents/git-ingest/extension-components.ts
+++ b/apps/api/src/agents/git-ingest/extension-components.ts
@@ -22,6 +22,7 @@ import type { GitFetcher } from './git-fetcher';
 import type { GitIngestService } from './git-ingest-service';
 import { commandFileToSkillMarkdown, agentFileToCustomAgent } from './plugin-component-compat';
 import { parseMcpJsonFile, type NormalizedMcpServer } from './extension-manifest-validator';
+import { collectPlaceholderEnvKeys, buildEnvInputHints, type UserConfigEntry } from '../../mcp/env-placeholder';
 import { ConventionChecker, isBlockedByConvention } from './convention-checker';
 import { McpServerDraftRepository } from '../../data/repositories/mcp-server-draft-repository';
 import { UserAgentRepository } from '../../data/repositories/user-agent-repository';
@@ -309,6 +310,7 @@ export async function collectMcpDrafts(
     ctx: ComponentContext,
     manifestServers: NormalizedMcpServer[],
     llmClientFactory: (model: string) => LLMClient,
+    userConfig?: Record<string, UserConfigEntry>,
 ): Promise<McpServerInstallResult[]> {
     let mcpEntries: NormalizedMcpServer[] = manifestServers;
     if (mcpEntries.length === 0) {
@@ -366,6 +368,12 @@ export async function collectMcpDrafts(
                     conventionFindings: conv.findings,
                     blockedByConvention,
                     tokensUsed: conv.tokensUsed,
+                    // 값이 자리표시자인 env 키 — 승인 라우트가 이 목록으로 실제 값 입력을
+                    // 강제한다(REQUIRED_ENV_MISSING). 이게 없으면 `${user_config.api_key}`
+                    // 같은 값이 그대로 승인돼 서버는 뜨지만 인증이 전부 실패한다.
+                    requiredEnv: collectPlaceholderEnvKeys(entry.env),
+                    // 입력 라벨·발급 안내 (plugin.json userConfig 유래, 없으면 키 이름만)
+                    envHints: buildEnvInputHints(entry.env, userConfig),
                 },
             });
             results.push({

--- a/apps/api/src/agents/git-ingest/extension-ingest-service.ts
+++ b/apps/api/src/agents/git-ingest/extension-ingest-service.ts
@@ -316,7 +316,7 @@ export class ExtensionIngestService {
         await collectSkillAssets(componentCtx, skillResults);
 
         // (6-b) MCP servers — plugin.json mcpServers 우선, 없으면 <root>mcp.json / <root>.mcp.json
-        const mcpResults = await collectMcpDrafts(componentCtx, manifest.mcpServers, this.opts.llmClientFactory);
+        const mcpResults = await collectMcpDrafts(componentCtx, manifest.mcpServers, this.opts.llmClientFactory, manifest.userConfig);
 
         // (6-c) agents/<name>.md → Custom Agent (Phase 2)
         const agentResults = await collectPluginAgents(componentCtx);

--- a/apps/api/src/agents/git-ingest/extension-manifest-validator.ts
+++ b/apps/api/src/agents/git-ingest/extension-manifest-validator.ts
@@ -17,6 +17,7 @@
  */
 import { z } from 'zod';
 import { UNSUPPORTED_MCP_FIELDS } from '../../config/skill-compat';
+import type { UserConfigEntry } from '../../mcp/env-placeholder';
 
 const NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
@@ -38,6 +39,17 @@ const pluginManifestSchema = z.object({
     // ⚠️ 항목 검증은 normalizeMcpServers 가 담당 — 여기서 엄격히 보면 무효 항목 하나가
     // 매니페스트 전체를 거절해 유효한 서버까지 버려진다 (항목 단위 관용 파싱).
     mcpServers: z.record(z.string().min(1).max(80), z.unknown()).optional(),
+    // Claude Code 의 사용자 입력 스키마. env 의 `${user_config.X}` 자리표시자가 이 항목을
+    // 가리키며, 승인 화면이 title/description 을 입력 라벨·발급 안내로 쓴다.
+    // 관용 파싱 — 형태가 어긋난 항목은 힌트만 잃고 설치는 계속된다.
+    userConfig: z.record(
+        z.string().min(1).max(80),
+        z.object({
+            title: z.string().max(200).optional(),
+            description: z.string().max(1000).optional(),
+            sensitive: z.boolean().optional(),
+        }).loose(),
+    ).optional(),
 });
 
 export interface NormalizedMcpServer {
@@ -56,6 +68,8 @@ export interface ExtensionManifest {
     mcpServers: NormalizedMcpServer[];
     /** 설치되지 않은 mcpServers 항목의 사유 + 무시된 필드 안내 (설치는 계속 진행) */
     mcpWarnings: string[];
+    /** plugin.json `userConfig` — env 자리표시자의 입력 라벨·발급 안내 출처 */
+    userConfig?: Record<string, UserConfigEntry>;
     /** 원문 (user_extensions.manifest 저장용) */
     raw: Record<string, unknown>;
 }
@@ -148,6 +162,7 @@ export function validateExtensionManifest(jsonText: string): ValidationResult {
             description: result.data.description,
             mcpServers: norm.servers,
             mcpWarnings: [...norm.errors, ...norm.warnings],
+            userConfig: result.data.userConfig as Record<string, UserConfigEntry> | undefined,
             raw: parsed as Record<string, unknown>,
         },
     };

--- a/apps/api/src/data/models/unified-database.types.ts
+++ b/apps/api/src/data/models/unified-database.types.ts
@@ -262,6 +262,14 @@ export interface MCPServerRow {
     updated_at: string;
     /** stdio docker 샌드박스 네트워크 정책 ('full'|'none'). 042 마이그레이션. */
     sandbox_network?: 'full' | 'none' | 'host' | null;
+    /**
+     * 소유자 (NULL=전역 서버).
+     *
+     * ⚠️ 실행 풀이 갈리는 기준이다 — 사용자 소유 서버는 전역 registry 가 아니라
+     * userPool 에 뜨므로, 상태를 registry 만으로 판정하면 연결된 서버도 늘
+     * disconnected 로 보인다. `SELECT *` 로 이미 실려 오던 값의 타입 노출.
+     */
+    user_id?: string | null;
 }
 
 // ============================================

--- a/apps/api/src/data/repositories/mcp-server-draft-repository.ts
+++ b/apps/api/src/data/repositories/mcp-server-draft-repository.ts
@@ -15,6 +15,20 @@
  */
 import * as crypto from 'crypto';
 import { BaseRepository } from './base-repository';
+import { encryptToken } from '../../utils/token-crypto';
+import type { EnvInputHint } from '../../mcp/env-placeholder';
+
+/**
+ * manifest_meta.envHints 에서 시크릿으로 선언된 env 키를 추린다.
+ *
+ * 힌트가 없거나 형태가 어긋난 매니페스트는 빈 집합 — 그 경우 값은 평문 저장되고,
+ * 이는 이 저장소의 기존 동작이다(암호화는 선언된 키에만 적용하는 점증적 강화).
+ */
+function extractSensitiveEnvKeys(manifestMeta: Record<string, unknown> | null): Set<string> {
+    const hints = (manifestMeta as { envHints?: EnvInputHint[] } | null)?.envHints;
+    if (!Array.isArray(hints)) return new Set();
+    return new Set(hints.filter(h => h?.sensitive === true && typeof h.key === 'string').map(h => h.key));
+}
 
 export interface InsertDraftInput {
     name: string;
@@ -125,8 +139,19 @@ export class McpServerDraftRepository extends BaseRepository {
         if (existing.status !== 'draft') return null;
         if (existing.user_id !== input.userId && !input.isAdmin) return null;
 
-        const mergedEnv = input.envOverrides
-            ? { ...(existing.env || {}), ...input.envOverrides }
+        // 승인 화면에서 받은 값 중 **시크릿으로 선언된 키만** 암호화해 저장한다.
+        // 판정 근거는 매니페스트의 `userConfig.<key>.sensitive`(envHints 로 영속됨) —
+        // 카탈로그 경로(mcp-catalog-repository.updateEnv)가 env_schema 의 secret 을
+        // 쓰는 것과 같은 규칙이다. 읽기는 server-registry.decryptEnvValues 가 `v1:`
+        // 접두사를 보고 복호화하므로 평문 값과 섞여 있어도 안전하다.
+        const sensitiveKeys = extractSensitiveEnvKeys(existing.manifest_meta);
+        const encryptedOverrides = input.envOverrides
+            ? Object.fromEntries(Object.entries(input.envOverrides).map(
+                ([k, v]) => [k, sensitiveKeys.has(k) ? encryptToken(v) : v],
+            ))
+            : undefined;
+        const mergedEnv = encryptedOverrides
+            ? { ...(existing.env || {}), ...encryptedOverrides }
             : existing.env;
         const shouldEnable = input.enableImmediately !== false;
 

--- a/apps/api/src/mcp/__tests__/env-placeholder.test.ts
+++ b/apps/api/src/mcp/__tests__/env-placeholder.test.ts
@@ -1,0 +1,85 @@
+/**
+ * MCP env 자리표시자 판정 테스트.
+ *
+ * 회귀 방지 대상: 외부 플러그인의 `"${user_config.api_key}"` 가 자리표시자로 잡히지
+ * 않으면 승인 시 그대로 저장되어 서버는 뜨지만 인증이 전부 실패한다(조용한 실패).
+ */
+import {
+    isEnvPlaceholder,
+    collectPlaceholderEnvKeys,
+    parseUserConfigRef,
+    buildEnvInputHints,
+} from '../env-placeholder';
+
+describe('isEnvPlaceholder', () => {
+    it('빈 값·undefined·null 은 자리표시자', () => {
+        expect(isEnvPlaceholder('')).toBe(true);
+        expect(isEnvPlaceholder(undefined)).toBe(true);
+        expect(isEnvPlaceholder(null)).toBe(true);
+    });
+
+    it('값 전체가 ${...} 이면 자리표시자', () => {
+        expect(isEnvPlaceholder('${API_KEY}')).toBe(true);
+        expect(isEnvPlaceholder('${user_config.api_key}')).toBe(true);
+    });
+
+    it('실제 값은 자리표시자가 아니다', () => {
+        expect(isEnvPlaceholder('honggildong')).toBe(false);
+        expect(isEnvPlaceholder('sk-abc123')).toBe(false);
+    });
+
+    it('부분 치환은 자리표시자로 보지 않는다 — 접두사를 통째로 다시 쓰게 만들지 않기 위해', () => {
+        expect(isEnvPlaceholder('Bearer ${TOKEN}')).toBe(false);
+        expect(isEnvPlaceholder('${HOST}:8080')).toBe(false);
+    });
+});
+
+describe('collectPlaceholderEnvKeys', () => {
+    it('자리표시자인 키만 추린다', () => {
+        expect(collectPlaceholderEnvKeys({
+            LAW_OC: '${user_config.api_key}',
+            LOG_LEVEL: 'info',
+            EMPTY: '',
+        })).toEqual(['LAW_OC', 'EMPTY']);
+    });
+
+    it('env 가 없으면 빈 배열', () => {
+        expect(collectPlaceholderEnvKeys(null)).toEqual([]);
+        expect(collectPlaceholderEnvKeys(undefined)).toEqual([]);
+        expect(collectPlaceholderEnvKeys({})).toEqual([]);
+    });
+});
+
+describe('parseUserConfigRef', () => {
+    it('userConfig 참조에서 키를 뽑는다', () => {
+        expect(parseUserConfigRef('${user_config.api_key}')).toBe('api_key');
+    });
+
+    it('일반 자리표시자나 실제 값은 참조가 아니다', () => {
+        expect(parseUserConfigRef('${API_KEY}')).toBeNull();
+        expect(parseUserConfigRef('honggildong')).toBeNull();
+        expect(parseUserConfigRef(undefined)).toBeNull();
+    });
+});
+
+describe('buildEnvInputHints', () => {
+    it('userConfig 의 title/description/sensitive 를 끌어온다 (korean-law 실사례)', () => {
+        const hints = buildEnvInputHints(
+            { LAW_OC: '${user_config.api_key}' },
+            { api_key: { title: '법제처 API 키 (LAW_OC)', description: '무료 발급', sensitive: true } },
+        );
+        expect(hints).toEqual([
+            { key: 'LAW_OC', title: '법제처 API 키 (LAW_OC)', description: '무료 발급', sensitive: true },
+        ]);
+    });
+
+    it('참조가 아닌 자리표시자는 키 이름만 남긴다', () => {
+        expect(buildEnvInputHints({ API_KEY: '${API_KEY}' }, undefined)).toEqual([
+            { key: 'API_KEY', title: undefined, description: undefined, sensitive: undefined },
+        ]);
+    });
+
+    it('값이 채워진 키는 입력 대상이 아니다', () => {
+        expect(buildEnvInputHints({ LOG_LEVEL: 'info' }, undefined)).toEqual([]);
+    });
+});

--- a/apps/api/src/mcp/env-placeholder.ts
+++ b/apps/api/src/mcp/env-placeholder.ts
@@ -1,0 +1,88 @@
+/**
+ * MCP env 플레이스홀더 판정 (순수 함수).
+ *
+ * 외부 플러그인의 `mcpServers[].env` 는 값을 비워 두고 자리표시자만 적는 관용이 있다:
+ *   - `"${API_KEY}"`              — 셸/환경변수 스타일
+ *   - `"${user_config.api_key}"`  — Claude Code `userConfig` 참조
+ *   - `""`                        — 빈 값
+ *
+ * 이 환경은 그 값을 채워 주는 주입 경로가 없으므로, **자리표시자인 채로 승인되면
+ * 서버는 뜨지만 인증이 전부 실패한다** — 오류도 경고도 없이 도구만 안 되는
+ * 전형적인 조용한 실패다. 승인 화면에서 실제 값을 받기 위해 어떤 키가 비어 있는지
+ * 먼저 알아내는 것이 이 모듈의 역할이다.
+ *
+ * ⚠️ 판정은 **값 전체가** 자리표시자인 경우로 한정한다. `"Bearer ${TOKEN}"` 처럼
+ * 부분 치환이 섞인 값을 필수 입력으로 올리면 이미 의미 있는 접두사를 사용자가
+ * 통째로 다시 써야 한다.
+ *
+ * @module mcp/env-placeholder
+ */
+
+/** 값 전체가 `${...}` 형태이거나 비어 있으면 자리표시자. */
+export function isEnvPlaceholder(value: string | undefined | null): boolean {
+    if (!value) return true;
+    return /^\$\{.+\}$/.test(value);
+}
+
+/**
+ * env record 에서 자리표시자인 키만 추린다 (승인 시 입력받아야 할 키).
+ *
+ * 값이 실제로 채워져 있는 키는 제외한다 — 플러그인이 기본값을 준 경우까지
+ * 입력을 강요하면 승인이 불필요하게 막힌다.
+ */
+export function collectPlaceholderEnvKeys(env: Record<string, string> | null | undefined): string[] {
+    if (!env) return [];
+    return Object.keys(env).filter(k => isEnvPlaceholder(env[k]));
+}
+
+/** `${user_config.api_key}` → `api_key` (Claude Code userConfig 참조 키). */
+export function parseUserConfigRef(value: string | undefined | null): string | null {
+    if (!value) return null;
+    const m = /^\$\{user_config\.([A-Za-z0-9_.-]+)\}$/.exec(value);
+    return m ? m[1] : null;
+}
+
+/** 승인 화면에 보여줄 입력 힌트 (plugin.json `userConfig` 에서 유도). */
+export interface EnvInputHint {
+    /** env 키 (예: LAW_OC) */
+    key: string;
+    /** 사람이 읽는 이름 (userConfig.title) */
+    title?: string;
+    /** 설명·발급 안내 (userConfig.description) */
+    description?: string;
+    /** 시크릿이면 입력 UI 를 마스킹한다 */
+    sensitive?: boolean;
+}
+
+/** plugin.json `userConfig` 스키마 중 이 환경이 쓰는 부분. */
+export interface UserConfigEntry {
+    title?: string;
+    description?: string;
+    sensitive?: boolean;
+}
+
+/**
+ * env 의 자리표시자 키 → 입력 힌트.
+ *
+ * `${user_config.X}` 인 값은 매니페스트 `userConfig.X` 의 title/description 을 끌어와
+ * "법제처 API 키 (LAW_OC)" 처럼 발급처까지 안내할 수 있게 한다. 참조가 아닌 일반
+ * 자리표시자(`${API_KEY}`)는 키 이름만 남긴다.
+ */
+export function buildEnvInputHints(
+    env: Record<string, string> | null | undefined,
+    userConfig: Record<string, UserConfigEntry> | null | undefined,
+): EnvInputHint[] {
+    if (!env) return [];
+    const hints: EnvInputHint[] = [];
+    for (const key of collectPlaceholderEnvKeys(env)) {
+        const ref = parseUserConfigRef(env[key]);
+        const entry = ref && userConfig ? userConfig[ref] : undefined;
+        hints.push({
+            key,
+            title: entry?.title,
+            description: entry?.description,
+            sensitive: entry?.sensitive,
+        });
+    }
+    return hints;
+}

--- a/apps/api/src/routes/mcp-server-ingest.routes.ts
+++ b/apps/api/src/routes/mcp-server-ingest.routes.ts
@@ -30,6 +30,7 @@ import {
 import { McpServerIngestService } from '../agents/git-ingest/mcp-server-ingest-service';
 import { McpServerDraftRepository } from '../data/repositories/mcp-server-draft-repository';
 import { getLifecycleSupervisor } from '../mcp/lifecycle-supervisor';
+import { isEnvPlaceholder } from '../mcp/env-placeholder';
 import { RL_MCP_INGEST } from '../config/rate-limits';
 import { MCP_INGEST } from '../config/constants';
 import { createLogger } from '../utils/logger';
@@ -73,13 +74,8 @@ const mcpIngestLimiter = rateLimit({
     skipFailedRequests: true,
 });
 
-/**
- * Placeholder 검증 — env 값이 `${...}` 형태이거나 빈 문자열이면 placeholder.
- */
-function isPlaceholder(value: string | undefined | null): boolean {
-    if (!value) return true;
-    return /^\$\{.+\}$/.test(value);
-}
+/** Placeholder 검증 — `mcp/env-placeholder` 가 SoT (확장 ingest 경로와 같은 규칙). */
+const isPlaceholder = isEnvPlaceholder;
 
 function extractUserId(req: Request): string | undefined {
     const direct = (req as Request & { userId?: string }).userId;

--- a/apps/api/src/routes/mcp.routes.ts
+++ b/apps/api/src/routes/mcp.routes.ts
@@ -521,27 +521,32 @@ export const mcpRouter = Router();
   mcpRouter.get('/servers/:id/status', requireAuth, asyncHandler(async (req: Request, res: Response) => {
       const { id } = req.params;
       const registry = getUnifiedMCPClient().getServerRegistry();
-      const status = registry.getServerStatus(id);
+      const regStatus = registry.getServerStatus(id);
 
-      if (!status) {
-          // DB에서 서버 존재 확인
-          const db = getUnifiedDatabase();
-          const server = await db.getMcpServerById(id);
-          if (!server) {
-              res.status(404).json(notFound('서버'));
-              return;
-          }
-          // 존재하지만 연결 안 된 상태
-          res.json(success({
-              status: {
-                  serverId: id,
-                  serverName: server.name,
-                  status: 'disconnected',
-                  toolCount: 0,
-              }
-          }));
+      // ⚠️ 사용자 소유 서버는 전역 registry 가 아니라 userPool 에 뜬다 — registry 만 보면
+      // 실제로 연결돼 도구가 등록된 서버도 늘 disconnected/toolCount:0 으로 보고된다
+      // (목록 API 는 이미 supervisor 를 함께 본다. 이중 풀은 양쪽 대칭이 원칙).
+      const db = getUnifiedDatabase();
+      const server = await db.getMcpServerById(id);
+      if (!server) {
+          res.status(404).json(notFound('서버'));
           return;
       }
 
-      res.json(success({ status }));
+      let userStatus: MCPConnectionStatus | undefined;
+      const supervisor = getLifecycleSupervisor();
+      if (server.user_id && supervisor) {
+          const client = supervisor.getUserClient(String(server.user_id), id);
+          if (client) userStatus = client.getStatus();
+      }
+
+      const effective = userStatus || regStatus;
+      res.json(success({
+          status: effective ?? {
+              serverId: id,
+              serverName: server.name,
+              status: 'disconnected',
+              toolCount: 0,
+          },
+      }));
   }));

--- a/apps/web/components/approvals/mcp-drafts.tsx
+++ b/apps/web/components/approvals/mcp-drafts.tsx
@@ -10,13 +10,27 @@
  * ⚠️ 위험 표시(conventionFindings 의 error)는 **정적 룰**만 근거로 한다 — LLM audit 은
  * warn 으로 강등돼 차단하지 않는다(2026-08-24, 오탐으로 정상 플러그인을 막던 문제).
  *
+ * ⚠️ env 자리표시자 입력(2026-08-28): 외부 플러그인은 `"LAW_OC": "${user_config.api_key}"`
+ * 처럼 값을 비워 두고 자리표시자만 적는다. 이 화면이 실제 값을 받지 않으면 서버는 뜨지만
+ * 인증이 전부 실패한다 — 오류도 경고도 없이 도구만 안 되는 조용한 실패라, 그전까지
+ * 빈 body 로 승인하던 것을 `requiredEnv` 기반 입력 폼으로 바꿨다. 백엔드는 같은 목록으로
+ * 422(REQUIRED_ENV_MISSING)를 던지므로 UI 를 건너뛴 승인도 막힌다.
+ *
  * @see app/(workspace)/approvals/page.tsx
+ * @see apps/api/src/mcp/env-placeholder.ts
  */
 import { useCallback, useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
-import { Check, X, Loader2, Server, AlertTriangle } from "lucide-react";
+import { Check, X, Loader2, Server, AlertTriangle, KeyRound } from "lucide-react";
 import { Button, Badge, Card } from "@/components/ui/primitives";
-import { ApiClient } from "@/lib/api-client";
+import { ApiClient, ApiError } from "@/lib/api-client";
+
+interface EnvHint {
+  key: string;
+  title?: string;
+  description?: string;
+  sensitive?: boolean;
+}
 
 interface DraftServer {
   id: string;
@@ -26,6 +40,10 @@ interface DraftServer {
   manifest_meta?: {
     conventionFindings?: { severity: string; rule?: string; message?: string; source?: string }[];
     extensionName?: string;
+    /** 값이 자리표시자라 승인 시 실제 값을 받아야 하는 env 키 */
+    requiredEnv?: string[];
+    /** 입력 라벨·발급 안내 (plugin.json userConfig 유래) */
+    envHints?: EnvHint[];
   };
 }
 
@@ -34,6 +52,8 @@ export function McpDrafts({ onRefreshAction }: { onRefreshAction?: () => void })
   const [drafts, setDrafts] = useState<DraftServer[]>([]);
   const [loading, setLoading] = useState(true);
   const [acting, setActing] = useState<Record<string, boolean>>({});
+  const [envInputs, setEnvInputs] = useState<Record<string, Record<string, string>>>({});
+  const [envErrors, setEnvErrors] = useState<Record<string, string[]>>({});
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -49,14 +69,30 @@ export function McpDrafts({ onRefreshAction }: { onRefreshAction?: () => void })
 
   useEffect(() => { void load(); }, [load]);
 
+  function setEnvValue(draftId: string, key: string, value: string) {
+    setEnvInputs((prev) => ({ ...prev, [draftId]: { ...(prev[draftId] ?? {}), [key]: value } }));
+  }
+
   async function act(id: string, action: "approve" | "reject") {
     setActing((p) => ({ ...p, [id]: true }));
+    setEnvErrors((p) => ({ ...p, [id]: [] }));
     try {
-      await ApiClient.post(`/api/mcp/servers/${id}/${action}`, {});
+      // 승인만 env 를 싣는다 — 거부는 값이 필요 없다.
+      const body = action === "approve" ? { envOverrides: envInputs[id] ?? {} } : {};
+      await ApiClient.post(`/api/mcp/servers/${id}/${action}`, body);
       await load();
       onRefreshAction?.();
     } catch (err) {
-      alert(t("mcp.actionFailed", { error: err instanceof Error ? err.message : "" }));
+      // 백엔드가 비어 있는 키를 알려준다 — 폼에 그대로 표시해 무엇을 채워야 하는지 남긴다
+      const missing =
+        err instanceof ApiError && (err.body as { error?: string; missing?: string[] } | undefined)?.error === "REQUIRED_ENV_MISSING"
+          ? ((err.body as { missing?: string[] }).missing ?? [])
+          : [];
+      if (missing.length > 0) {
+        setEnvErrors((p) => ({ ...p, [id]: missing }));
+      } else {
+        alert(t("mcp.actionFailed", { error: err instanceof Error ? err.message : "" }));
+      }
     } finally {
       setActing((p) => ({ ...p, [id]: false }));
     }
@@ -82,6 +118,9 @@ export function McpDrafts({ onRefreshAction }: { onRefreshAction?: () => void })
           (f) => f.severity === "error" && f.source !== "llm",
         );
         const busy = acting[d.id] ?? false;
+        const requiredEnv = d.manifest_meta?.requiredEnv ?? [];
+        const hints = d.manifest_meta?.envHints ?? [];
+        const missing = envErrors[d.id] ?? [];
         return (
           <Card key={d.id} className="p-4">
             <div className="flex items-start justify-between gap-3">
@@ -115,6 +154,45 @@ export function McpDrafts({ onRefreshAction }: { onRefreshAction?: () => void })
                 </Button>
               </div>
             </div>
+
+            {requiredEnv.length > 0 && (
+              <div className="mt-3 space-y-2 rounded-md border border-border bg-surface-2 p-3">
+                <p className="flex items-center gap-1.5 text-xs font-medium text-fg">
+                  <KeyRound className="h-3.5 w-3.5 text-accent" />
+                  {t("mcp.envRequired")}
+                </p>
+                {requiredEnv.map((key) => {
+                  const hint = hints.find((h) => h.key === key);
+                  const isMissing = missing.includes(key);
+                  return (
+                    <div key={key} className="space-y-1">
+                      <label htmlFor={`${d.id}-${key}`} className="block text-xs text-muted">
+                        <span className="font-mono text-fg">{key}</span>
+                        {hint?.title && <span className="ml-1.5">{hint.title}</span>}
+                      </label>
+                      <input
+                        id={`${d.id}-${key}`}
+                        type={hint?.sensitive ? "password" : "text"}
+                        autoComplete="off"
+                        disabled={busy}
+                        value={envInputs[d.id]?.[key] ?? ""}
+                        onChange={(e) => setEnvValue(d.id, key, e.target.value)}
+                        placeholder={t("mcp.envPlaceholder")}
+                        className={`w-full rounded border bg-surface px-2 py-1.5 font-mono text-xs text-fg outline-none focus:border-accent ${
+                          isMissing ? "border-danger" : "border-border"
+                        }`}
+                      />
+                      {hint?.description && (
+                        <p className="text-xs text-muted">{hint.description}</p>
+                      )}
+                    </div>
+                  );
+                })}
+                {missing.length > 0 && (
+                  <p className="text-xs text-danger">{t("mcp.envMissing", { keys: missing.join(", ") })}</p>
+                )}
+              </div>
+            )}
           </Card>
         );
       })}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1892,7 +1892,10 @@
       "badge": "Pending",
       "risk": "Risky command detected — review before approving",
       "empty": "No MCP servers awaiting approval.",
-      "actionFailed": "Action failed: {error}"
+      "actionFailed": "Action failed: {error}",
+      "envRequired": "Required environment variables — approval needs real values",
+      "envPlaceholder": "Enter value",
+      "envMissing": "Values required: {keys}"
     },
     "agents": {
       "title": "Custom agents",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1892,7 +1892,10 @@
       "badge": "承認待ち",
       "risk": "危険なコマンドを検出 — 確認のうえ承認",
       "empty": "承認待ちのMCPサーバーはありません。",
-      "actionFailed": "処理に失敗しました: {error}"
+      "actionFailed": "処理に失敗しました: {error}",
+      "envRequired": "必須の環境変数 — 実際の値を入力すると承認できます",
+      "envPlaceholder": "値を入力",
+      "envMissing": "値が必要です: {keys}"
     },
     "agents": {
       "title": "カスタムエージェント",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1892,7 +1892,10 @@
       "badge": "승인 대기",
       "risk": "위험 명령 감지 — 검토 후 승인",
       "empty": "승인 대기 중인 MCP 서버가 없습니다.",
-      "actionFailed": "처리 실패: {error}"
+      "actionFailed": "처리 실패: {error}",
+      "envRequired": "필수 환경변수 — 실제 값을 입력해야 승인됩니다",
+      "envPlaceholder": "값 입력",
+      "envMissing": "값이 필요합니다: {keys}"
     },
     "agents": {
       "title": "커스텀 에이전트",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1892,7 +1892,10 @@
       "badge": "待审批",
       "risk": "检测到危险命令 — 请审查后再批准",
       "empty": "没有待审批的 MCP 服务器。",
-      "actionFailed": "操作失败：{error}"
+      "actionFailed": "操作失败：{error}",
+      "envRequired": "必填环境变量 — 输入实际值后方可批准",
+      "envPlaceholder": "输入值",
+      "envMissing": "需要填写: {keys}"
     },
     "agents": {
       "title": "自定义智能体",


### PR DESCRIPTION
`chrisryugj/korean-law-mcp` 설치를 검증하다 드러난 **확장 유래 MCP 경로의 결함 3건**을 고친다. 셋 다 특정 플러그인 문제가 아니라 경로 공통이다.

## 1. env 자리표시자를 실제 값으로 받는다 (본 커밋)

외부 플러그인은 `"LAW_OC": "${user_config.api_key}"` 처럼 값을 비우고 자리표시자만 적는다(Claude Code `userConfig` 관용). 확장 경로에는 그 값을 채울 방법이 없어 **설치·승인·연결이 전부 성공으로 보이는데 도구 호출만 인증 실패**하는 조용한 실패가 났다.

원인 3겹:

| # | 결함 | 증거 |
|---|---|---|
| 1 | `collectMcpDrafts` 가 `manifest_meta.requiredEnv` 를 넣지 않아, 승인 라우트에 **이미 있던** placeholder 검증(422)이 영구 무력 | `requiredEnv: undefined` |
| 2 | 승인 화면이 빈 body 로 POST → env 입력 경로 없음 | `post(..., {})` |
| 3 | `userConfig` 는 참조 0건이고 `UNSUPPORTED_MCP_FIELDS` 에도 없어 경고조차 없음 | `validationWarnings: []` |

`requiredEnv` 를 **MCP 서버 ingest 전용 경로**(`manifest.required_env`)에서만 채우고 **확장 경로에는 그 개념 자체가 없던** 두 ingest 경로의 비대칭이 뿌리다.

- **`apps/api/src/mcp/env-placeholder.ts` 신설** (SoT, 순수 함수) — `isEnvPlaceholder` / `collectPlaceholderEnvKeys` / `parseUserConfigRef` / `buildEnvInputHints`
  - ⚠️ 값 **전체**가 `${...}` 인 경우만 자리표시자로 본다. `"Bearer ${TOKEN}"` 같은 부분 치환을 필수 입력으로 올리면 의미 있는 접두사를 사용자가 통째로 다시 써야 한다.
- 확장 ingest 가 자리표시자 키를 `requiredEnv` 로, `userConfig` 의 title/description/sensitive 를 `envHints` 로 영속
- 승인 화면이 그 힌트로 입력 폼을 그리고 `envOverrides` 전송. 422 의 `missing` 키를 폼에 표시 (UI 를 건너뛴 승인도 백엔드가 같은 목록으로 막는다)
- 라우트의 중복 `isPlaceholder` 를 공용 모듈로 통일

## 2. 시크릿 env 암호화

승인으로 받은 API 키가 `mcp_servers.env` 에 **평문**으로 남았다. 카탈로그 경로(`mcp-catalog-repository.updateEnv`)는 `env_schema` 의 secret 판정으로 이미 `encryptToken` 을 쓰는데 확장 경로만 빠져 있었다.

판정 근거는 위에서 영속한 `envHints[].sensitive`(= `userConfig.<key>.sensitive`). 읽기는 `server-registry.decryptEnvValues` 가 `v1:` 접두사를 보고 복호화하므로 평문과 섞여도 안전하고, 힌트가 없는 매니페스트는 종전대로 평문 저장된다(선언된 키에만 적용하는 점증적 강화).

## 3. status API 이중 풀 대칭

`GET /api/mcp/servers/:id/status` 가 전역 registry 만 조회해, **userPool 에 뜨는 사용자 소유 서버는 실제로 연결돼 도구가 등록돼 있어도 늘 `disconnected`/`toolCount:0`** 으로 보고했다. 목록 API 는 이미 `supervisor.getUserClient` 를 함께 보는데 status 만 누락 — 이중 풀은 양쪽 대칭이 원칙이다.

목록 API 와 같은 순서(`userStatus || regStatus`)로 통일하고, 서버 존재 확인을 앞으로 당겨 404 판정을 한 번만 한다. `MCPServerRow` 에 `user_id` 를 노출한다(`SELECT *` 로 이미 실려 오던 값이고 실행 풀이 갈리는 기준).

## 검증 (chat.openmake.cc 라이브)

- 재설치 → `requiredEnv: ["LAW_OC"]` + `envHints`(제목·발급 URL·마스킹까지 plugin.json 에서 유도) 생성
- 빈 값 승인 → **422 `REQUIRED_ENV_MISSING`** 차단
- 실제 키로 승인 → DB 에 **`v1:` 암호문(85자, 원문과 다름)** 저장
- 연결 성공 → **컨테이너 주입값은 평문 12자** (복호화 정상)
- status API → **`connected` / `toolCount: 10`** (수정 전 동일 서버가 `disconnected`/`0`)
- 법제처 IP 등록 후 실제 조문 조회: `get_law_text(lawId:"001706", jo:"제1조")` → "제1조(법원) 민사에 관하여 법률에 규정이 없으면 관습법에 의하고…"

**테스트**: 신규 11건 + `src/mcp`·`src/agents/git-ingest` 314건 통과 / 타입체크·lint(0 errors)·600줄 게이트 통과

## UI

승인 화면(`/approvals`) MCP 카드 하단에 필수 환경변수 입력 영역 추가 — 키 이름(모노스페이스) + userConfig 제목, `sensitive: true` 면 `type=password`, 설명은 아래 회색 텍스트, 422 로 돌아온 키는 테두리 강조. i18n 4개 locale 동시 추가.

## 범위 밖 (기록)

마켓플레이스 `source` 가 `{source:"github", repo}` 형이면 파서가 `repo` 를 버린다. korean-law 는 마켓플레이스와 대상이 같은 레포라 우연히 루트를 가리켜 문제가 안 됐지만, **다른 레포를 가리키는 `repo` 형은 여전히 미지원**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHPGYoWHVFjp2Qtg4ZJE4T
