### PR TITLE
fix(deploy): Caddyfile 을 덮어쓰기 전에 caddy validate 로 검증한다

### DIFF
--- a/openmake_llm.sh
+++ b/openmake_llm.sh
@@ -657,20 +657,34 @@ sync_caddyfile() {
         return 0
     fi
 
+    local has_caddy=0
+    command -v caddy >/dev/null 2>&1 && has_caddy=1
+
+    # 운영 파일을 덮어쓰기 *전에* 검증한다. reload 는 잘못된 설정을 거부하므로 지금은 멀쩡해 보여도
+    # (구 설정 유지) 디스크에 깨진 파일이 남아 다음 caddy 기동이 실패한다 — :33000 통째로 중단.
+    if (( has_caddy )); then
+        local verr
+        if ! verr="$(caddy validate --config "$src" --adapter caddyfile 2>&1 | tail -n 1)"; then
+            log_err "Caddyfile 검증 실패 — 운영 파일을 덮어쓰지 않습니다 (기존 설정 유지): $CADDYFILE_SRC_REL"
+            log_err "  $verr"
+            return 0
+        fi
+    fi
+
     if ! cp "$src" "$CADDYFILE_DEST" 2>/dev/null; then
         log_warn "Caddyfile 복사 실패 (권한 확인 필요): $CADDYFILE_DEST"
         return 0
     fi
     log_ok "Caddyfile 갱신 → $CADDYFILE_DEST"
 
-    if ! command -v caddy >/dev/null 2>&1; then
-        log_info "caddy 미설치 — reload 생략 (파일은 갱신됨)"
+    if (( ! has_caddy )); then
+        log_info "caddy 미설치 — 검증·reload 생략 (파일은 갱신됨)"
         return 0
     fi
     if caddy reload --config "$CADDYFILE_DEST" >/dev/null 2>&1; then
         log_ok "Caddy reload 완료 (무중단)"
     else
-        log_warn "Caddy reload 실패 — 미기동 상태일 수 있습니다. 다음 기동 시 반영됩니다"
+        log_warn "Caddy reload 실패 — 설정은 검증을 통과했으므로 caddy 미기동(admin API 무응답)일 가능성이 큽니다. 다음 기동 시 반영됩니다"
     fi
 }
 


### PR DESCRIPTION
## 배경
`/code-review` (bdc6a65d, #661) 에서 나온 결함 1건.

`sync_caddyfile` 이 **cp → caddy reload** 순이라 문법 오류가 있는 Caddyfile 을 deploy 하면:
- reload 는 거부 → 실행 중 caddy 는 구 설정 유지 (당장은 멀쩡)
- 하지만 `/opt/homebrew/etc/Caddyfile` 은 이미 깨진 채 남고, reload 실패는 `log_warn` 뿐이라 deploy 는 "완료"
- 다음 재부팅/재시작 때 caddy 가 :33000 을 못 올려 외부(cloudflared 업스트림)·LAN 전부 중단 — 배포 시점엔 신호 없음

## 변경
- caddy 가 있으면 `caddy validate --config <src> --adapter caddyfile` 을 **덮어쓰기 전에** 실행. 실패 시 운영 파일을 건드리지 않고 `log_err`(마지막 오류 줄 포함) 후 deploy 는 계속 (앱 배포가 프록시 설정에 볼모 잡히지 않도록)
- caddy 미설치 호스트는 종전대로 검증 없이 복사 (fail-open 유지)
- reload 실패 경고를 "검증은 통과했으니 미기동(admin API 무응답) 가능성" 으로 구체화

## 검증
- 함수 추출 하네스 4케이스: 깨진 파일 → 운영본 보존 + `[ERR] ... unrecognized directive` · 유효 파일 → 복사+reload · 동일 내용 → 생략 · caddy 미설치 → 복사만
- `bash -n`, `shellcheck -S warning` 통과

⚠️ 하네스 2번 케이스가 실제 admin API 로 운영 caddy 를 테스트 설정으로 reload 해버려 약 30초간 :33000 라우팅 단순화·:33001 부재가 있었음 → 즉시 운영 Caddyfile 로 reload 복구, 두 포트 200 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3VdjDQR1u9HQxdCMQmXHA
