### PR TITLE
docs(caddy): 운영 Caddyfile 심링크 표기를 실파일·deploy 동기화로 정정

### DIFF
--- a/scripts/caddy/Caddyfile
+++ b/scripts/caddy/Caddyfile
@@ -20,7 +20,9 @@
 #   brew install caddy
 #   caddy run --config /Volumes/MAC_APP/openmake_llm/scripts/caddy/Caddyfile
 #   # 또는 백그라운드: brew services 로 등록하거나 `caddy start`
-#   (운영: /opt/homebrew/etc/Caddyfile 이 이 파일로의 심링크 — 이 파일이 SoT)
+#   (운영: /opt/homebrew/etc/Caddyfile 은 심링크가 아니라 실파일 — launchd 가 외장 볼륨을
+#    읽지 못해 교체함. 이 파일이 SoT 이며 `openmake_llm.sh deploy` 가 validate → 복사 → reload
+#    로 동기화한다. 운영 파일을 직접 고치면 다음 deploy 에 덮어써진다)
 #
 # 주의:
 #   - Caddy reverse_proxy 는 X-Forwarded-Host/Proto/For 를 자동 전달 →


### PR DESCRIPTION
`scripts/caddy/Caddyfile` 헤더 주석의 "`/opt/homebrew/etc/Caddyfile` 이 이 파일로의 심링크" 표기가 실제와 다름 — 운영 파일은 launchd 외장 볼륨 읽기 불가로 **실파일**로 교체됐고(`openmake_llm.sh` L55 주석), 동기화는 `openmake_llm.sh deploy` 의 `sync_caddyfile`(validate → 복사 → reload, #662)이 담당한다. 주석만 정정, 설정 무변경 (`caddy validate` 통과).

참고: 이 변경이 배포되면 레포본≠운영본이 되어 #662 의 validate → 복사 → reload 경로가 운영에서 처음 실제로 실행된다(주석만 달라 reload 는 동작 무변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3VdjDQR1u9HQxdCMQmXHA
