### PR TITLE
fix(web-search): 언어 미지정 호출은 질의에서 감지 — 한국어 web_search 에 네이버·다음 복원

### DIFF
--- a/apps/api/src/mcp/web-search/__tests__/search-language.test.ts
+++ b/apps/api/src/mcp/web-search/__tests__/search-language.test.ts
@@ -1,0 +1,21 @@
+import { resolveSearchLanguage } from '../search-language';
+
+describe('resolveSearchLanguage', () => {
+    it('명시 언어가 있으면 그대로 쓴다', () => {
+        expect(resolveSearchLanguage('AI 기본법 시행령 2026', 'en')).toBe('en');
+        expect(resolveSearchLanguage('AI policy 2026', 'ko')).toBe('ko');
+    });
+
+    it('한국어 질의는 ko 로 감지한다 — 네이버·다음 provider 가 실행되는 조건', () => {
+        expect(resolveSearchLanguage('AI 기본법 시행령 2026')).toBe('ko');
+        expect(resolveSearchLanguage('제조업 AI 파운데이션 모델 한국 2026')).toBe('ko');
+    });
+
+    it('영어 질의는 en 이다', () => {
+        expect(resolveSearchLanguage('Obsidian app download growth stats 2025')).toBe('en');
+    });
+
+    it('빈 문자열은 en 폴백', () => {
+        expect(resolveSearchLanguage('')).toBe('en');
+    });
+});

--- a/apps/api/src/mcp/web-search/search-language.ts
+++ b/apps/api/src/mcp/web-search/search-language.ts
@@ -1,0 +1,17 @@
+/**
+ * 웹 검색 언어 결정 — 호출자가 언어를 명시하지 않으면 질의 문자에서 감지한다.
+ *
+ * 배경(2026-08-29 실측): `performWebSearch` 의 language 기본값이 'en' 이라, 모델이 부르는
+ * web_search/fact_check 도구·REST 경로처럼 언어를 안 넘기는 호출은 한국어 질의여도 네이버(뉴스·
+ * 웹문서·백과)·다음 웹문서 4개 provider 가 아예 실행되지 않았다(2일 53건 중 47건 Naver:0).
+ * 사전 검색(build-search-context)·deep-research 만 사용자 언어를 넘겨 정상이었다.
+ *
+ * @module mcp/web-search/search-language
+ */
+import { detectLanguage } from '../../chat/language-policy';
+
+/** 명시 언어가 있으면 그대로, 없으면 질의에서 감지(한글 → 'ko', 라틴 텍스트는 'en' 폴백). */
+export function resolveSearchLanguage(query: string, explicit?: string): string {
+    if (explicit) return explicit;
+    return detectLanguage(query).language;
+}

--- a/apps/api/src/mcp/web-search/search-orchestrator.ts
+++ b/apps/api/src/mcp/web-search/search-orchestrator.ts
@@ -24,6 +24,7 @@ import { searchExa } from './external-search-apis';
 import { createLogger } from '../../utils/logger';
 import { SEARCH_ESCALATION, SEARCH_RELIABILITY, SEARXNG_CATEGORY_SCOPE, WEB_SEARCH_INJECTION } from '../../config/runtime-limits';
 import { formatSearchSources } from './format-sources';
+import { resolveSearchLanguage } from './search-language';
 import { getConfig } from '../../config/env';
 import { logSemanticRerankShadow, rerankBySemantics } from './semantic-reranker';
 
@@ -38,7 +39,7 @@ const logger = createLogger('WebSearch');
  * @param query - 검색 쿼리
  * @param options.maxResults - 최대 결과 수 (기본값: 30)
  * @param options.globalSearch - 전세계 검색 여부 (기본값: true)
- * @param options.language - 검색 언어 (기본값: 'en')
+ * @param options.language - 검색 언어 (미지정 시 질의에서 감지 — search-language.ts)
  * @returns 중복 제거된 SearchResult 배열
  */
 /**
@@ -98,7 +99,8 @@ function computeTermRelevance(terms: string[], result: SearchResult): number {
 }
 
 export async function performWebSearch(query: string, options: { maxResults?: number; globalSearch?: boolean; language?: string; signal?: AbortSignal; preferRecent?: boolean } = {}): Promise<SearchResult[]> {
-    const { maxResults = 30, globalSearch = true, language = 'en', signal, preferRecent = false } = options;
+    const { maxResults = 30, globalSearch = true, signal, preferRecent = false } = options;
+    const language = resolveSearchLanguage(query, options.language);
 
     // 쿼리 길이 캡 — 장문 프롬프트 전체가 쿼리로 흘러오면 provider URI 한도에 걸린다
     // (네이버 hub·Daum 414, 2026-08-21 라이브). 단어 경계에서 절단해 실효 질의만 남긴다.
@@ -113,7 +115,7 @@ export async function performWebSearch(query: string, options: { maxResults?: nu
     // 고볼륨 모드: maxResults > 15이면 모든 소스에서 병렬 수집 (Deep Research 용)
     const highVolumeMode = maxResults > 15;
 
-    logger.info(`쿼리: ${query} (maxResults: ${maxResults}, highVolume: ${highVolumeMode})`);
+    logger.info(`쿼리: ${query} (maxResults: ${maxResults}, highVolume: ${highVolumeMode}, lang: ${language})`);
 
     // 모든 소스에서 병렬 검색 — 각 provider 는 자체 fetch timeout + 외부 abort signal 로
     // hang 을 방지하므로 Promise.all 이 무한정 멈추지 않는다.


### PR DESCRIPTION
## 문제
`performWebSearch` 의 `language` 기본값이 `'en'` 이라, 언어를 안 넘기는 호출(모델이 부르는 `web_search`/`fact_check` 도구 `mcp/web-search/tools.ts`, `llm/web-search-adapter.ts`, `routes/web-search.routes.ts`)은 **한국어 질의여도 네이버 뉴스·웹문서·백과 + 다음 웹문서 4개 provider 가 실행되지 않았다** (`search-orchestrator.ts` 의 `language === 'ko'` 게이트). 사전 검색(`build-search-context`, `userLang`)·deep-research(`config.language`)만 정상.

라이브 실측(2026-08-29, 최근 2일 로그): 검색 53건 중 **47건 `Naver:0`** — 3차 테스트 `web_search("AI 기본법 시행령 2026")` 도 `Naver:0`, 예약 리포트의 한국어 질의도 전부 0. `Naver>0` 6건은 모두 사전 검색 경로. 네이버 자체는 정상(HUB 키 설정, 401/429 0건).

## 변경
- `mcp/web-search/search-language.ts` — `resolveSearchLanguage(query, explicit?)`: 명시 언어 우선, 없으면 `chat/language-policy` `detectLanguage` 로 질의에서 감지
- `performWebSearch` 가 이를 기본값으로 사용 + 쿼리 로그에 `lang:` 표기
- 호출부는 무변경 (기본값 경로에서 해소). 부수 효과: 같은 호출들의 Google/Wikipedia/News 로케일도 질의 언어를 따른다 (`getSearchLocale` 은 미지원 언어 → en 폴백)

## 검증
- 단위 4건 추가(`search-language.test.ts`), web-search 스위트 40/40, tsc·eslint 통과
- 배포 후 라이브: 3차 테스트 재실행으로 `Naver:>0` 확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3VdjDQR1u9HQxdCMQmXHA
