### PR TITLE
fix(extensions): git 심링크 SKILL.md 를 카탈로그 판정·설치 탐지에서 제외

### DIFF
--- a/apps/api/src/agents/git-ingest/__tests__/extension-discovery.test.ts
+++ b/apps/api/src/agents/git-ingest/__tests__/extension-discovery.test.ts
@@ -8,6 +8,7 @@ import {
     synthesizedManifestPath,
     isSynthesizedManifestPath,
     rootOfSynthesizedPath,
+    symlinkedSkillPaths,
 } from '../extension-discovery';
 
 // 카탈로그 판정과 설치가 공유하는 탐지 규칙 — 2026-08-29 드라이런(815건)에서 드러난 레이아웃을 고정한다.
@@ -95,6 +96,18 @@ describe('extension-discovery', () => {
             expect(findMcpConfigPath([e('.mcp.json')], '', './missing.json')).toBeUndefined();   // kobiton 실사례
             expect(findMcpConfigPath([e('mcp.json'), e('.mcp.json')], '')).toBe('mcp.json');
             expect(findMcpConfigPath([e('README.md')], '')).toBeUndefined();
+        });
+    });
+
+    describe('git 심링크 제외 (postiz skills/postiz/SKILL.md 실사례)', () => {
+        const sym = (path: string) => ({ path, symlink: true });
+        it('심링크 SKILL.md/mcp.json 은 어느 탐지에도 안 잡히고, 판정도 false', () => {
+            expect(discoverSkillPaths([sym('skills/postiz/SKILL.md')], '')).toEqual([]);
+            expect(discoverSkillPaths([sym('skills/postiz/SKILL.md'), e('skills/real/SKILL.md')], '')).toEqual(['skills/real/SKILL.md']);
+            expect(findMcpConfigPath([sym('.mcp.json')], '')).toBeUndefined();
+            expect(findExtensionManifestPath([sym('plugin.json')], '')).toBeUndefined();
+            expect(hasInstallableComponents([sym('skills/postiz/SKILL.md'), e('.claude-plugin/plugin.json')], '', null)).toBe(false);
+            expect(symlinkedSkillPaths([sym('skills/postiz/SKILL.md'), e('skills/real/SKILL.md')], '')).toEqual(['skills/postiz/SKILL.md']);
         });
     });
 

--- a/apps/api/src/agents/git-ingest/__tests__/git-fetcher.test.ts
+++ b/apps/api/src/agents/git-ingest/__tests__/git-fetcher.test.ts
@@ -45,6 +45,8 @@ describe('GitFetcher', () => {
                     { path: 'README.md', sha: 'b1', type: 'blob', size: 100 },
                     { path: 'skills/legal.SKILL.md', sha: 'b2', type: 'blob', size: 500 },
                     { path: 'skills', sha: 't1', type: 'tree' },
+                    // git 심링크 (postiz skills/postiz/SKILL.md 실사례) — symlink 플래그로 보존
+                    { path: 'skills/link/SKILL.md', sha: 'b3', type: 'blob', size: 14, mode: '120000' },
                 ],
                 truncated: false,
             }),
@@ -52,8 +54,10 @@ describe('GitFetcher', () => {
         });
         const f = new GitFetcher();
         const tree = await f.listTree('foo', 'bar', 'abc123');
-        expect(tree.entries).toHaveLength(2);
+        expect(tree.entries).toHaveLength(3);
         expect(tree.entries[0].path).toBe('README.md');
+        expect(tree.entries[0].symlink).toBeUndefined();
+        expect(tree.entries[2]).toMatchObject({ path: 'skills/link/SKILL.md', symlink: true });
         expect(tree.rateLimitRemaining).toBe(4998);
     });
 

--- a/apps/api/src/agents/git-ingest/extension-discovery.ts
+++ b/apps/api/src/agents/git-ingest/extension-discovery.ts
@@ -11,13 +11,26 @@
  *   - `skills`: 기본 `skills/<dir>/SKILL.md` + plugin.json `skills` 경로 필드(문자열/배열) +
  *     둘 다 없으면 루트 직하 `<dir>/SKILL.md` (마켓 path 가 스킬 컨테이너 자체인 amd/coursera).
  *   - `mcpServers`: 객체 또는 **파일 경로 문자열**(`"./.mcp.json"`), 없으면 루트 mcp.json/.mcp.json.
+ *   - git 심링크(TreeEntry.symlink) 는 어느 탐지에서도 제외 — raw 내용이 대상 경로 문자열이라
+ *     설치가 반드시 실패한다 (postiz). 판정도 같은 필터를 타므로 UI 에 노출되지 않는다.
  *
  * @module agents/git-ingest/extension-discovery
  */
 import type { ExtensionManifest } from './extension-manifest-validator';
 
 /** tree 엔트리 최소 형태 — git-fetcher 의 TreeEntry 와 extension-components 의 TreeLike 둘 다 만족 */
-export type PathEntry = { path: string };
+export type PathEntry = { path: string; symlink?: boolean };
+
+/** 심링크 제외 — 모든 탐지 함수의 공통 전처리 */
+function realFiles(entries: readonly PathEntry[]): readonly PathEntry[] {
+    return entries.some(e => e.symlink) ? entries.filter(e => !e.symlink) : entries;
+}
+
+/** 심링크인 SKILL.md 경로 — 설치 리포트 경고용 (탐지에선 이미 제외됨) */
+export function symlinkedSkillPaths(entries: readonly PathEntry[], root: string): string[] {
+    const pattern = new RegExp(`^${escapeRegExp(root)}.*SKILL\\.md$`, 'i');
+    return entries.filter(e => e.symlink && pattern.test(e.path)).map(e => e.path);
+}
 
 /**
  * 합성 매니페스트의 가상 경로 basename — 실제 파일이 없다. `user_extensions.source_path` 에
@@ -40,7 +53,8 @@ export function rootOfSynthesizedPath(path: string): string {
 }
 
 /** 확장 루트(prefix, '' 또는 'dir/') 의 매니페스트 경로 — 우선순위 고정. 없으면 undefined. */
-export function findExtensionManifestPath(entries: readonly PathEntry[], root: string): string | undefined {
+export function findExtensionManifestPath(allEntries: readonly PathEntry[], root: string): string | undefined {
+    const entries = realFiles(allEntries);
     for (const candidate of [`${root}.claude-plugin/plugin.json`, `${root}plugin.json`, `${root}gemini-extension.json`]) {
         if (entries.some(e => e.path === candidate)) return candidate;
     }
@@ -75,7 +89,8 @@ export function resolveUnderRoot(root: string, relative: string): string | null 
  * SKILL.md 경로 탐지 — 기본 레이아웃 + plugin.json `skills` 필드 + 루트 컨테이너 폴백.
  * 순서 보존·중복 제거. 상한(maxSkillsPerExtension) 적용은 호출측.
  */
-export function discoverSkillPaths(entries: readonly PathEntry[], root: string, skillPathsField: string[] = []): string[] {
+export function discoverSkillPaths(allEntries: readonly PathEntry[], root: string, skillPathsField: string[] = []): string[] {
+    const entries = realFiles(allEntries);
     const found: string[] = [];
     const defaultPattern = buildSkillDiscoveryPattern(root);
     for (const e of entries) if (defaultPattern.test(e.path)) found.push(e.path);
@@ -101,11 +116,12 @@ export function discoverSkillPaths(entries: readonly PathEntry[], root: string, 
  * `<root><dir>/**.md` (1단계 중첩까지) + 매니페스트 경로 필드. commands/·agents/ 공용.
  */
 export function discoverMarkdownComponents(
-    entries: readonly PathEntry[],
+    allEntries: readonly PathEntry[],
     root: string,
     dirName: string,
     fieldPaths: string[] = [],
 ): string[] {
+    const entries = realFiles(allEntries);
     const pattern = new RegExp(`^${escapeRegExp(root)}${dirName}/(?:[^/]+/)?[^/]+\\.md$`, 'i');
     const found = entries.filter(e => pattern.test(e.path)).map(e => e.path);
     for (const field of fieldPaths) {
@@ -125,7 +141,8 @@ export function discoverMarkdownComponents(
  * MCP 설정 파일 경로 — plugin.json `mcpServers` 가 문자열이면 그 경로, 아니면 루트 mcp.json/.mcp.json.
  * 파일이 tree 에 없으면 undefined (문자열 경로가 가리키는 파일이 상류에 없는 kobiton 실사례 포함).
  */
-export function findMcpConfigPath(entries: readonly PathEntry[], root: string, mcpServersPath?: string): string | undefined {
+export function findMcpConfigPath(allEntries: readonly PathEntry[], root: string, mcpServersPath?: string): string | undefined {
+    const entries = realFiles(allEntries);
     if (mcpServersPath) {
         const resolved = resolveUnderRoot(root, mcpServersPath);
         return resolved && entries.some(e => e.path === resolved) ? resolved : undefined;

--- a/apps/api/src/agents/git-ingest/extension-ingest-service.ts
+++ b/apps/api/src/agents/git-ingest/extension-ingest-service.ts
@@ -36,6 +36,7 @@ import { validateExtensionManifest, parseMarketplaceFile } from './extension-man
 import {
     findExtensionManifestPath,
     discoverSkillPaths,
+    symlinkedSkillPaths,
     synthesizedManifestPath,
     isSynthesizedManifestPath,
     rootOfSynthesizedPath,
@@ -285,6 +286,10 @@ export class ExtensionIngestService {
 
         // (6-a) skills — 기본 레이아웃 + plugin.json `skills` 경로 필드 + 루트 컨테이너 폴백 (extension-discovery)
         let skillPaths = discoverSkillPaths(tree.entries, root, manifest.skillPaths);
+        const symlinked = symlinkedSkillPaths(tree.entries, root);
+        if (symlinked.length > 0) {
+            warnings.push(`SKILL_SYMLINK_SKIPPED: git 심링크라 설치 불가 — ${symlinked.join(', ')}`);
+        }
         if (skillPaths.length > EXTENSION_INGEST.maxSkillsPerExtension) {
             warnings.push(`SKILLS_TRUNCATED: ${skillPaths.length}개 중 ${EXTENSION_INGEST.maxSkillsPerExtension}개만 설치`);
             skillPaths = skillPaths.slice(0, EXTENSION_INGEST.maxSkillsPerExtension);

--- a/apps/api/src/agents/git-ingest/git-fetcher.ts
+++ b/apps/api/src/agents/git-ingest/git-fetcher.ts
@@ -9,11 +9,16 @@
  */
 const GITHUB_API = 'https://api.github.com';
 
+/** git tree mode — 심링크 blob. 내용이 본문이 아니라 대상 경로라 raw fetch 로 설치할 수 없다. */
+export const GIT_SYMLINK_MODE = '120000';
+
 export interface TreeEntry {
     path: string;
     sha: string;
     size: number;
     type: 'blob' | 'tree';
+    /** git 심링크(mode 120000) — 탐지에서 제외한다 (postiz `skills/postiz/SKILL.md` 실사례, 2026-08-29) */
+    symlink?: boolean;
 }
 
 export interface TreeResult {
@@ -99,14 +104,14 @@ export class GitFetcher {
      */
     async listTree(owner: string, repo: string, sha: string, maxEntries: number = 10_000): Promise<TreeResult> {
         const res = await this.req(`/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/git/trees/${encodeURIComponent(sha)}?recursive=1`);
-        const data = await res.json() as { sha: string; tree: Array<{ path: string; sha: string; size?: number; type: string }>; truncated: boolean };
+        const data = await res.json() as { sha: string; tree: Array<{ path: string; sha: string; size?: number; type: string; mode?: string }>; truncated: boolean };
         // GitHub 가 거대 tree(>100k entries / >7MB)에 truncated=true 를 주므로, 불완전+거대 tree 는 거부.
         if (data.truncated) {
             throw new Error(`REPO_TOO_LARGE: tree truncated by GitHub (${owner}/${repo}@${sha})`);
         }
         const entries: TreeEntry[] = (data.tree || [])
             .filter(e => e.type === 'blob')
-            .map(e => ({ path: e.path, sha: e.sha, size: e.size ?? 0, type: 'blob' as const }));
+            .map(e => ({ path: e.path, sha: e.sha, size: e.size ?? 0, type: 'blob' as const, ...(e.mode === GIT_SYMLINK_MODE ? { symlink: true } : {}) }));
         if (entries.length > maxEntries) {
             throw new Error(`REPO_TOO_LARGE: ${entries.length} blobs > ${maxEntries} (${owner}/${repo})`);
         }


### PR DESCRIPTION
## 배경
#668 이후 드라이런 잔존 8건 중 마지막 2건(postiz, 공식·knowledge-work 양쪽) — `skills/postiz/SKILL.md` 가 **git 심링크(mode 120000)** 라 raw 내용이 `../../SKILL.md` 문자열뿐이다. tree 기반 판정은 `installable=true` 로 노출하고 설치는 "frontmatter 없음" 으로 실패했다.

## 변경
- `GitFetcher.listTree` 가 tree API `mode` 를 읽어 `TreeEntry.symlink` 로 보존 (일반 파일은 키 없음 — 기존 equality 테스트 무영향)
- `extension-discovery` 의 모든 탐지(매니페스트·스킬·commands/agents·MCP 설정 파일)가 심링크를 제외 → **판정과 설치가 같은 필터** 로 걸러진다 (#668 원칙 유지)
- 설치 리포트에 `SKILL_SYMLINK_SKIPPED: <경로>` 경고 — 조용한 제외 방지

## 검증
- git-ingest 14 스위트 172 테스트 통과 (신규: fetcher mode 120000 파싱, discovery 심링크 제외·판정 false·경고 경로)
- 상류 확인: `gitroomhq/postiz-agent@77d09c6` tree → `120000 blob 14 skills/postiz/SKILL.md`

## 배포 후
- 공식 마켓·knowledge-work 재동기화 → postiz 2건이 `installable=false` 로 숨겨짐

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3VdjDQR1u9HQxdCMQmXHA
