### PR TITLE
fix(skills): 배정된 스킬이 주입되지 않던 2겹 결함 — manifest 동반 생성·백필 + 명시 배정은 카테고리 무관

### DIFF
--- a/apps/api/src/agents/__tests__/manifest-injection-filter.test.ts
+++ b/apps/api/src/agents/__tests__/manifest-injection-filter.test.ts
@@ -1,0 +1,32 @@
+import { shouldInjectManifestSkill, dedupeById, manifestCategory, GLOBAL_ASSIGNMENT_ID } from '../manifest-injection-filter';
+
+const yaml = (cat: string, triggers?: string) => `---\nname: x\ndescription: d\ncategory: ${cat}\n${triggers ? `triggers: ${triggers}\n` : ''}---\n`;
+const ctx = { agentId: 'backend-developer', agentCategory: 'technology' };
+
+// 2026-08-29: 명시 배정(에이전트/개인)은 카테고리 무관 — 종전 필터가 user 3 의 ecc 스킬을 걸러
+// 배정돼 있어도 한 번도 주입되지 않았다. __global__ 만 카테고리 필터를 유지한다.
+describe('manifest-injection-filter', () => {
+    it('에이전트에 명시 배정된 스킬은 카테고리가 달라도 주입 (ecc → technology 에이전트)', () => {
+        expect(shouldInjectManifestSkill({ id: 'skill-1784-a', manifestYaml: yaml('ecc'), assignedTo: 'backend-developer' }, ctx)).toBe(true);
+    });
+    it('개인 배정(user:<id>)도 카테고리 무관', () => {
+        expect(shouldInjectManifestSkill({ id: 'skill-x', manifestYaml: yaml('design'), assignedTo: 'user:3' }, ctx)).toBe(true);
+    });
+    it('__global__ 배정은 카테고리 일치 또는 user- 접두 id 만 (종전 규칙)', () => {
+        expect(shouldInjectManifestSkill({ id: 'system-skill-a', manifestYaml: yaml('technology'), assignedTo: GLOBAL_ASSIGNMENT_ID }, ctx)).toBe(true);
+        expect(shouldInjectManifestSkill({ id: 'system-skill-a', manifestYaml: yaml('finance'), assignedTo: GLOBAL_ASSIGNMENT_ID }, ctx)).toBe(false);
+        expect(shouldInjectManifestSkill({ id: 'user-skill-1', manifestYaml: yaml('finance'), assignedTo: GLOBAL_ASSIGNMENT_ID }, ctx)).toBe(true);
+        // 에이전트 카테고리를 모르면 필터 없음
+        expect(shouldInjectManifestSkill({ id: 'system-skill-a', manifestYaml: yaml('finance'), assignedTo: GLOBAL_ASSIGNMENT_ID }, { agentId: 'x' })).toBe(true);
+    });
+    it('triggers 선언 스킬은 배정 종류와 무관하게 질의가 맞아야 주입', () => {
+        const c = { id: 'skill-t', manifestYaml: yaml('ecc', '["세금", "환급"]'), assignedTo: 'backend-developer' };
+        expect(shouldInjectManifestSkill(c, { ...ctx, query: '환급 절차 알려줘' })).toBe(true);
+        expect(shouldInjectManifestSkill(c, { ...ctx, query: '오늘 날씨' })).toBe(false);
+    });
+    it('manifestCategory / dedupeById', () => {
+        expect(manifestCategory(yaml("'ecc'"))).toBe('ecc');
+        expect(manifestCategory('---\nname: x\n---\n')).toBeUndefined();
+        expect(dedupeById([{ id: 'a' }, { id: 'b' }, { id: 'a' }])).toEqual([{ id: 'a' }, { id: 'b' }]);
+    });
+});

--- a/apps/api/src/agents/manifest-injection-filter.ts
+++ b/apps/api/src/agents/manifest-injection-filter.ts
@@ -1,0 +1,47 @@
+/**
+ * manifest 스킬 주입 필터 (순수) — skill-manager.buildManifestPrompt 가 사용.
+ *
+ * 규칙 (2026-08-29 정정):
+ *   - triggers 를 선언한 스킬은 질의가 트리거에 맞을 때만 (종전 동작)
+ *   - **에이전트에 명시 배정**(assigned_to = 이 agentId) 또는 **개인 배정**(user:<id>) 스킬은
+ *     카테고리와 무관하게 주입 — 배정 자체가 의도다. 종전엔 `__global__` 용 카테고리 필터가
+ *     명시 배정까지 걸러 user 3 의 ecc 스킬 14건이 배정돼 있어도 한 번도 주입되지 않았다
+ *     (skill_audit_log 첫 기록에서 inject 누락으로 드러남)
+ *   - `__global__` 배정은 종전대로: manifest category 가 에이전트 category 와 같거나
+ *     `user-` 접두 id(개인 manifest)일 때만 — 무관한 스킬의 프롬프트 오염 방지
+ *
+ * @module agents/manifest-injection-filter
+ */
+import { matchesSkillTriggers, parseManifestTriggers } from './skill-triggers';
+
+export const GLOBAL_ASSIGNMENT_ID = '__global__';
+
+export interface InjectionCandidate {
+    id: string;
+    manifestYaml: string;
+    /** agent_skill_assignments.agent_id — 이 행이 어느 배정으로 조회됐는지 */
+    assignedTo: string;
+}
+
+export function manifestCategory(manifestYaml: string): string | undefined {
+    const m = /^category:\s*([^\n]+)/m.exec(manifestYaml);
+    return m?.[1]?.trim().replace(/^['"]|['"]$/g, '') || undefined;
+}
+
+export function shouldInjectManifestSkill(
+    c: InjectionCandidate,
+    ctx: { agentId: string; agentCategory?: string; query?: string },
+): boolean {
+    if (!matchesSkillTriggers(parseManifestTriggers(c.manifestYaml), ctx.query)) return false;
+    if (c.assignedTo !== GLOBAL_ASSIGNMENT_ID) return true;   // 명시 배정(에이전트/개인)은 카테고리 무관
+    if (!ctx.agentCategory) return true;
+    if (c.id.startsWith('user-')) return true;
+    const cat = manifestCategory(c.manifestYaml);
+    return !cat || cat === ctx.agentCategory;
+}
+
+/** 같은 스킬이 여러 배정(에이전트 + __global__)으로 중복 조회되면 첫 행만 남긴다 */
+export function dedupeById<T extends { id: string }>(rows: T[]): T[] {
+    const seen = new Set<string>();
+    return rows.filter(r => (seen.has(r.id) ? false : (seen.add(r.id), true)));
+}

--- a/apps/api/src/agents/skill-creator.ts
+++ b/apps/api/src/agents/skill-creator.ts
@@ -6,6 +6,7 @@
  * @module agents/skill-creator
  */
 
+import { upsertSkillManifest } from '../data/repositories/skill-manifest-sync';
 import * as crypto from 'crypto';
 import { v4 as uuidv4 } from 'uuid';
 import type { Pool } from 'pg';
@@ -144,6 +145,16 @@ export class SkillCreatorService {
             ]
         );
 
+        // manifest 동시 생성 — 승인 후 배정돼도 manifest 가 없으면 주입되지 않는다 (2026-08-29)
+        try {
+            await upsertSkillManifest((sql, params) => this.opts.pool.query(sql, params), {
+                id: skillId, name: manifest.name, description: manifest.description, category: manifest.category,
+                content: manifest.content, createdBy: effectiveTarget === 'system' ? null : input.userId,
+                isPublic: effectiveTarget === 'system',
+            });
+        } catch (e) {
+            logger.warn(`skill_manifests 생성 실패 (fail-soft): ${skillId}`, e);
+        }
         logger.info(`Draft created: ${skillId} (target=${effectiveTarget}, model=${modelUsed})`);
 
         return {

--- a/apps/api/src/agents/skill-manager.ts
+++ b/apps/api/src/agents/skill-manager.ts
@@ -48,6 +48,7 @@ import type {
 } from '../data/repositories/skill-repository';
 import { slugify } from '../chat/slash-command';
 import { recordSkillUsage } from './skill-usage-log';
+import { shouldInjectManifestSkill, dedupeById } from './manifest-injection-filter';
 
 const logger = createLogger('SkillManager');
 
@@ -436,7 +437,7 @@ export class SkillManager {
         // 스킬의 잔존 manifest 가 주입되지 않게 막는다. 할당된 manifest 는 전부
         // agent_skills 행을 가진다(ManifestImporter placeholder·git-ingest 동시 INSERT).
         const sql = `
-            SELECT sm.id, sm.version, sm.prompt_md, sm.manifest_yaml
+            SELECT sm.id, sm.version, sm.prompt_md, sm.manifest_yaml, asa.agent_id AS assigned_to
             FROM skill_manifests sm
             INNER JOIN agent_skill_assignments asa ON asa.skill_id = sm.id
             INNER JOIN agent_skills ags ON ags.id = sm.id AND ags.status = 'active'
@@ -447,27 +448,23 @@ export class SkillManager {
             ORDER BY asa.priority DESC NULLS LAST, sm.id ASC
             LIMIT 15
         `;
-        let rows: Array<{ id: string; version: string; prompt_md: string; manifest_yaml: string }>;
+        let rows: Array<{ id: string; version: string; prompt_md: string; manifest_yaml: string; assigned_to: string }>;
         try {
-            const result = await pool.query<{ id: string; version: string; prompt_md: string; manifest_yaml: string }>(sql, params);
-            rows = result.rows;
+            const result = await pool.query<{ id: string; version: string; prompt_md: string; manifest_yaml: string; assigned_to: string }>(sql, params);
+            rows = dedupeById(result.rows);
         } catch (e) {
             logger.debug('skill_manifests 조회 실패 (021 마이그레이션 미적용?) — null', e);
             return null;
         }
         if (rows.length === 0) return null;
 
-        // agentCategory 필터: manifest_yaml 의 category 가 agent.category 와 일치하거나
-        // user-* prefix (사용자 개인 manifest) 인 경우만 포함 — 무관한 skill 의 프롬프트 오염 방지.
-        const filtered = rows.filter(r => {
-            // triggers 선언 스킬은 관련 턴에만 주입 — 개인 스킬의 카테고리 우회(아래)와
-            // 결합돼 무관한 질의까지 오염시키던 경로를 막는다. 미선언 스킬은 종전 동작.
-            if (!matchesSkillTriggers(parseManifestTriggers(r.manifest_yaml), query)) return false;
-            if (!agentCategory) return true;
-            if (r.id.startsWith('user-')) return true;
-            const cat = /^---[\s\S]*?\bcategory:\s*([^\n]+)/.exec(r.manifest_yaml);
-            return !cat || cat[1]?.trim().replace(/^['"]|['"]$/g, '') === agentCategory;
-        });
+        // 주입 필터 — manifest-injection-filter.ts (순수): triggers 게이트 + `__global__` 배정만
+        // 카테고리 필터. 에이전트/개인 명시 배정은 카테고리와 무관하게 주입한다 (2026-08-29 정정 —
+        // 종전엔 명시 배정도 걸러 user 3 의 ecc 스킬이 배정돼 있어도 한 번도 주입되지 않았다).
+        const filtered = rows.filter(r => shouldInjectManifestSkill(
+            { id: r.id, manifestYaml: r.manifest_yaml, assignedTo: r.assigned_to },
+            { agentId, agentCategory, query },
+        ));
         if (filtered.length === 0) return null;
 
         const blocks = filtered.map(r => {

--- a/apps/api/src/data/repositories/__tests__/skill-manifest-sync.test.ts
+++ b/apps/api/src/data/repositories/__tests__/skill-manifest-sync.test.ts
@@ -1,0 +1,32 @@
+import { buildManifestYaml, skillContentChecksum, upsertSkillManifest, DEFAULT_SKILL_MANIFEST_VERSION } from '../skill-manifest-sync';
+
+// 2026-08-29: createSkill/upsertSystemSkill/skill-creator 가 manifest 를 안 만들어 배정돼도
+// 주입되지 않던 갭 — 모든 생성 경로가 이 헬퍼로 manifest 를 동반한다.
+describe('skill-manifest-sync', () => {
+    it('buildManifestYaml — 022/111 과 같은 fence 형식, 개행은 공백으로, category 기본 general', () => {
+        const y = buildManifestYaml({ name: 'API 설계', description: '첫 줄\n둘째 줄', category: undefined });
+        expect(y).toBe('---\nname: API 설계\ndescription: 첫 줄 둘째 줄\ncategory: general\n---\n');
+        // 소비처(buildManifestPrompt)가 읽는 멀티라인 정규식과 호환
+        expect(/^name:\s*([^\n]+)/m.exec(y)?.[1]).toBe('API 설계');
+        expect(/^category:\s*([^\n]+)/m.exec(y)?.[1]).toBe('general');
+    });
+
+    it('upsertSkillManifest — (id,version) 충돌 시 본문·yaml·checksum 갱신, 기본 version 1.0.0', async () => {
+        const query = jest.fn().mockResolvedValue({ rows: [] });
+        await upsertSkillManifest(query, { id: 's1', name: 'n', description: 'd', category: 'ecc', content: 'body', createdBy: 'u3', isPublic: false });
+        expect(query).toHaveBeenCalledTimes(1);
+        const [sql, params] = query.mock.calls[0];
+        expect(String(sql)).toContain('INSERT INTO skill_manifests');
+        expect(String(sql)).toContain('ON CONFLICT (id, version) DO UPDATE');
+        expect(params).toEqual(['s1', DEFAULT_SKILL_MANIFEST_VERSION, buildManifestYaml({ name: 'n', description: 'd', category: 'ecc' }), 'body', skillContentChecksum('body'), 'u3', false]);
+        expect(skillContentChecksum('body')).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('version 을 주면 그 버전을 갱신 (updateSkill 이 최신 version 을 넘긴다)', async () => {
+        const query = jest.fn().mockResolvedValue({ rows: [] });
+        await upsertSkillManifest(query, { id: 's1', name: 'n', content: 'c', version: '2.0.0' });
+        expect(query.mock.calls[0][1][1]).toBe('2.0.0');
+        expect(query.mock.calls[0][1][5]).toBeNull();
+        expect(query.mock.calls[0][1][6]).toBe(false);
+    });
+});

--- a/apps/api/src/data/repositories/skill-manifest-sync.ts
+++ b/apps/api/src/data/repositories/skill-manifest-sync.ts
@@ -1,0 +1,64 @@
+/**
+ * agent_skills ↔ skill_manifests 동기화 헬퍼 (2026-08-29).
+ *
+ * 시스템 프롬프트 주입의 SoT 는 `skill_manifests` (skill-manager.buildManifestPrompt JOIN) 라
+ * agent_skills 행만 만들면 배정해도 주입되지 않는다. git-ingest 는 2026-08-16 부터 manifest 를
+ * 함께 만들었지만 `SkillRepository.createSkill`·`upsertSystemSkill`·skill-creator 는 아니어서
+ * 21건이 누락돼 있었다(111 마이그레이션이 백필). 앞으로는 모든 생성/갱신 경로가 이 헬퍼를 탄다.
+ *
+ * fail-soft: 호출측이 try/catch 로 감싼다 — manifest 실패가 스킬 생성 자체를 되돌리지 않는다.
+ *
+ * @module data/repositories/skill-manifest-sync
+ */
+import { createHash } from 'crypto';
+
+export const DEFAULT_SKILL_MANIFEST_VERSION = '1.0.0';
+
+export interface SkillManifestRow {
+    id: string;
+    name: string;
+    description?: string | null;
+    category?: string | null;
+    content: string;
+    version?: string;
+    createdBy?: string | null;
+    isPublic?: boolean;
+}
+
+type QueryFn = (sql: string, params: unknown[]) => Promise<unknown>;
+
+/** 022/111 과 같은 fence 형식 — 소비처(buildManifestPrompt)는 `^name:`·`^category:` 멀티라인 정규식만 읽는다 */
+export function buildManifestYaml(row: Pick<SkillManifestRow, 'name' | 'description' | 'category'>): string {
+    const line = (v: string | null | undefined) => (v ?? '').replace(/\r?\n/g, ' ');
+    return `---\nname: ${line(row.name)}\ndescription: ${line(row.description)}\ncategory: ${row.category || 'general'}\n---\n`;
+}
+
+export function skillContentChecksum(content: string): string {
+    return createHash('sha256').update(content).digest('hex');
+}
+
+/**
+ * manifest 행 upsert — (id, version) 충돌 시 본문·yaml·checksum 을 갱신한다.
+ * 갱신 대상 version 은 호출측이 정한다(기본 1.0.0 — 이 환경은 버전을 올리지 않고 덮어쓴다).
+ */
+export async function upsertSkillManifest(query: QueryFn, row: SkillManifestRow): Promise<void> {
+    await query(
+        `INSERT INTO skill_manifests
+           (id, version, manifest_yaml, prompt_md, checksum, signature, created_by, is_public, created_at)
+         VALUES ($1, $2, $3, $4, $5, NULL, $6, $7, NOW())
+         ON CONFLICT (id, version) DO UPDATE
+           SET manifest_yaml = EXCLUDED.manifest_yaml,
+               prompt_md = EXCLUDED.prompt_md,
+               checksum = EXCLUDED.checksum,
+               is_public = EXCLUDED.is_public`,
+        [
+            row.id,
+            row.version || DEFAULT_SKILL_MANIFEST_VERSION,
+            buildManifestYaml(row),
+            row.content,
+            skillContentChecksum(row.content),
+            row.createdBy ?? null,
+            row.isPublic ?? false,
+        ],
+    );
+}

--- a/apps/api/src/data/repositories/skill-repository.ts
+++ b/apps/api/src/data/repositories/skill-repository.ts
@@ -9,12 +9,15 @@
  * @module data/repositories/skill-repository
  */
 
+import { createLogger } from '../../utils/logger';
+import { upsertSkillManifest, type SkillManifestRow } from './skill-manifest-sync';
 import { BaseRepository, QueryParam } from './base-repository';
-import { createHash } from 'crypto';
 import { assertResourceOwnerOrAdmin } from '../../auth/ownership';
 import { rowToSkill } from './skill-row-mapper';
 import { buildDraftQuery } from './skill-draft-query';
 import { SkillAssignmentRepository } from './skill-assignment-repository';
+
+const logger = createLogger('SkillRepository');
 
 export interface AgentSkill {
     id: string;
@@ -118,6 +121,15 @@ export interface ActorContext {
 }
 
 export class SkillRepository extends BaseRepository {
+    /** agent_skills ↔ skill_manifests 동기화 (fail-soft — 스킬 행은 이미 커밋됨) */
+    private async syncManifest(row: SkillManifestRow): Promise<void> {
+        try {
+            await upsertSkillManifest((sql, params) => this.query(sql, params as QueryParam[]), row);
+        } catch (e) {
+            logger.warn(`skill_manifests 동기화 실패 (fail-soft): ${row.id} — ${e instanceof Error ? e.message : String(e)}`);
+        }
+    }
+
     async createSkill(input: CreateSkillInput): Promise<AgentSkill> {
         const id = `skill-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         const now = new Date();
@@ -140,6 +152,9 @@ export class SkillRepository extends BaseRepository {
                 input.sourcePath ?? null,
             ]
         );
+
+        await this.syncManifest({ id, name: input.name, description: input.description, category: input.category ?? 'general',
+            content: input.content, createdBy: input.createdBy ?? null, isPublic: input.isPublic ?? false });
 
         const created = await this.getSkillById(id);
         return created ?? {
@@ -196,13 +211,16 @@ export class SkillRepository extends BaseRepository {
 
         // ⚠️ 시스템 프롬프트 주입의 SoT 는 skill_manifests.prompt_md (buildManifestPrompt JOIN)이다.
         // agent_skills.content 만 바꾸면 실제 주입은 옛 내용 그대로라 "수정했는데 그대로"가 된다.
-        // manifest 행이 없는 스킬(레거시)은 0 row 영향으로 no-op.
+        // 2026-08-29: UPDATE 가 아니라 upsert — manifest 가 없던 레거시 스킬도 갱신 시점에 생긴다.
         if (input.content !== undefined && input.content !== existing.content) {
-            const checksum = createHash('sha256').update(input.content).digest('hex');
-            await this.query(
-                `UPDATE skill_manifests SET prompt_md = $2, checksum = $3 WHERE id = $1`,
-                [id, input.content, checksum]
+            const versions = await this.query<{ version: string }>(
+                `SELECT version FROM skill_manifests WHERE id = $1 ORDER BY version DESC LIMIT 1`, [id]
             );
+            await this.syncManifest({
+                id, name: params[0] as string, description: params[1] as string | null, category: params[3] as string,
+                content: input.content, createdBy: existing.createdBy ?? null, isPublic: params[4] as boolean,
+                version: versions.rows[0]?.version,
+            });
         }
 
         return this.getSkillById(id);
@@ -371,6 +389,8 @@ export class SkillRepository extends BaseRepository {
                 input.sourcePath ?? null,
             ]
         );
+        await this.syncManifest({ id, name: input.name, description: input.description, category: input.category ?? 'general',
+            content: input.content, createdBy: input.createdBy ?? null, isPublic: input.isPublic ?? true });
         if (result.rows.length > 0) {
             return rowToSkill(result.rows[0]);
         }

--- a/db/migrations/111_backfill_skill_manifests.sql
+++ b/db/migrations/111_backfill_skill_manifests.sql
@@ -1,0 +1,28 @@
+-- Migration 111 — skill_manifests 백필 (manifest 없는 active 스킬)
+--
+-- 2026-08-29. 시스템 프롬프트 주입의 SoT 는 skill_manifests (skill-manager.buildManifestPrompt JOIN)
+-- 인데, 022 이후 만들어진 스킬 중 manifest 를 안 만드는 생성 경로(SkillRepository.createSkill·
+-- upsertSystemSkill·skill-creator)로 들어온 21건은 에이전트에 배정돼 있어도 한 번도 주입되지
+-- 않았다 (user 3 ecc 14건 실측 — skill_audit_log 첫 기록에서 inject 누락으로 드러남).
+-- 022 와 같은 형식으로 v1.0.0 manifest 를 만든다. signature='backfill-111' 이 롤백 마커.
+--
+-- 멱등: 이미 manifest 가 있는 스킬은 건너뛴다 (NOT EXISTS + ON CONFLICT DO NOTHING).
+
+INSERT INTO skill_manifests (id, version, manifest_yaml, prompt_md, checksum, signature, created_by, is_public, created_at)
+SELECT
+    s.id,
+    '1.0.0' AS version,
+    format(E'---\nname: %s\ndescription: %s\ncategory: %s\n---\n',
+           replace(s.name, E'\n', ' '),
+           replace(COALESCE(s.description, ''), E'\n', ' '),
+           COALESCE(s.category, 'general')) AS manifest_yaml,
+    s.content AS prompt_md,
+    encode(sha256(convert_to(s.content, 'UTF8')), 'hex') AS checksum,
+    'backfill-111' AS signature,
+    s.created_by,
+    COALESCE(s.is_public, FALSE),
+    COALESCE(s.created_at, NOW())
+FROM agent_skills s
+WHERE s.status = 'active'
+  AND NOT EXISTS (SELECT 1 FROM skill_manifests m WHERE m.id = s.id)
+ON CONFLICT (id, version) DO NOTHING;

--- a/db/migrations/rollbacks/111_backfill_skill_manifests.sql
+++ b/db/migrations/rollbacks/111_backfill_skill_manifests.sql
@@ -1,0 +1,2 @@
+-- Rollback 111 — 백필로 만든 manifest 만 제거 (signature 마커 기준)
+DELETE FROM skill_manifests WHERE signature = 'backfill-111';


### PR DESCRIPTION
## 배경
#671 의 첫 `skill_audit_log` 기록에서 backend-developer 에 **배정된** `api-design` 의 `inject` 가 찍히지 않았다. 추적 결과 2겹:

1. **manifest 부재** — `SkillRepository.createSkill`·`upsertSystemSkill`·`skill-creator` 가 `skill_manifests` 를 만들지 않는다(git-ingest 만 08-16 부터 동반). 주입 SoT 가 `skill_manifests` JOIN 이라 active 스킬 **21건**이 배정돼 있어도 한 번도 주입되지 않았다 — user 3 ecc 14(07-17 배정)·시스템 4(`system-skill-author-guide`, superpowers 유틸 3)·auto-llm 2·user 11 1.
2. **카테고리 필터가 명시 배정까지 걸러냄** — `buildManifestPrompt` 는 manifest category ≠ 에이전트 category 면 제외(`user-` 접두 id 만 예외). 에이전트에 직접 배정한 ecc 스킬(`skill-…` id)은 manifest 가 생겨도 걸러진다.

## 변경
- `data/repositories/skill-manifest-sync.ts` `upsertSkillManifest()` — 022/111 과 같은 yaml, sha256 checksum, `ON CONFLICT (id,version) DO UPDATE`. `createSkill`/`upsertSystemSkill`/skill-creator 가 호출(fail-soft), `updateSkill` 은 UPDATE→upsert(레거시 스킬도 갱신 시점에 manifest 가 생김).
- `db/migrations/111_backfill_skill_manifests.sql` — manifest 없는 active 스킬 백필. `signature='backfill-111'` 이 롤백 마커(`rollbacks/111`). **운영 DB 트랜잭션 드라이런: 21건 삽입·checksum 일치·잔여 0 (롤백함)**.
- `agents/manifest-injection-filter.ts`(순수) — 명시 배정(에이전트/`user:<id>`)은 카테고리 무관, `__global__` 만 종전 카테고리 필터, triggers 게이트 유지, 중복 배정 dedupe. `buildManifestPrompt` 가 `asa.agent_id AS assigned_to` 를 SELECT 해 사용.

## 검증
- 신규 테스트 8건(manifest-sync 3·injection-filter 5), 관련 46 스위트 397 테스트 통과, `tsc`·eslint 통과
- 배포 후: 부팅 자동 마이그레이션이 21건 백필 → backend-developer 로 라우팅되는 질문 1회 → `GET /api/agents/skills/usage/summary?days=1` 에 `api-design`·`backend-patterns`·`postgres-patterns` 의 `inject` 확인 예정

## ⚠️ 동작 변화
07-17 에 배정해 둔 ecc 스킬(본문 2~12KB)이 이제 실제로 주입된다 — backend-developer 는 턴당 약 28K 자(api-design·backend-patterns·postgres-patterns) 가 더 들어간다(manifest 블록은 `MAX_SKILL_CONTENT_LENGTH` 절단 대상이 아님). 원치 않는 배정은 풀면 되고, `inject` 로그로 실제 주입을 관측할 수 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3VdjDQR1u9HQxdCMQmXHA
