### PR TITLE
fix(skills): manifest 주입 dedupe 를 SQL 로 — 이중 배정 시 비-global 우선 + LIMIT 은 dedupe 뒤에

### DIFF
--- a/apps/api/src/agents/__tests__/manifest-injection-filter.test.ts
+++ b/apps/api/src/agents/__tests__/manifest-injection-filter.test.ts
@@ -1,4 +1,4 @@
-import { shouldInjectManifestSkill, dedupeById, manifestCategory, GLOBAL_ASSIGNMENT_ID } from '../manifest-injection-filter';
+import { shouldInjectManifestSkill, manifestCategory, GLOBAL_ASSIGNMENT_ID } from '../manifest-injection-filter';
 
 const yaml = (cat: string, triggers?: string) => `---\nname: x\ndescription: d\ncategory: ${cat}\n${triggers ? `triggers: ${triggers}\n` : ''}---\n`;
 const ctx = { agentId: 'backend-developer', agentCategory: 'technology' };
@@ -24,9 +24,8 @@ describe('manifest-injection-filter', () => {
         expect(shouldInjectManifestSkill(c, { ...ctx, query: '환급 절차 알려줘' })).toBe(true);
         expect(shouldInjectManifestSkill(c, { ...ctx, query: '오늘 날씨' })).toBe(false);
     });
-    it('manifestCategory / dedupeById', () => {
+    it('manifestCategory', () => {
         expect(manifestCategory(yaml("'ecc'"))).toBe('ecc');
         expect(manifestCategory('---\nname: x\n---\n')).toBeUndefined();
-        expect(dedupeById([{ id: 'a' }, { id: 'b' }, { id: 'a' }])).toEqual([{ id: 'a' }, { id: 'b' }]);
     });
 });

--- a/apps/api/src/agents/__tests__/skill-manifest-union.test.ts
+++ b/apps/api/src/agents/__tests__/skill-manifest-union.test.ts
@@ -83,4 +83,16 @@ describe('buildManifestPrompt — 개인 지정 스킬 union', () => {
         const manifestSql = capturedSql.find((q) => q.includes('FROM skill_manifests'));
         expect(manifestSql).toContain("ags.status = 'active'");
     });
+
+    it('중복 배정 dedupe 는 SQL 에서 비-global 우선으로, LIMIT 은 dedupe 뒤에 — 이중 배정 스킬의 명시 배정이 global 행에 가려지지 않는다', async () => {
+        const mgr = managerWithUserSkills([]);
+        await mgr.buildManifestPrompt('ui-ux-designer', '3', 'design');
+        const manifestSql = capturedSql.find((q) => q.includes('FROM skill_manifests'))!;
+        expect(manifestSql).toContain('DISTINCT ON (sm.id)');
+        // 스킬 내 정렬: id → global 여부(false 먼저) → priority
+        expect(manifestSql).toMatch(/ORDER BY sm\.id, \(asa\.agent_id = \$2\) ASC, asa\.priority DESC NULLS LAST/);
+        // LIMIT 은 바깥(dedupe 후) 쿼리에만
+        expect(manifestSql.indexOf('LIMIT 15')).toBeGreaterThan(manifestSql.indexOf(') dedup'));
+        expect(manifestSql.match(/LIMIT 15/g)).toHaveLength(1);
+    });
 });

--- a/apps/api/src/agents/manifest-injection-filter.ts
+++ b/apps/api/src/agents/manifest-injection-filter.ts
@@ -39,9 +39,3 @@ export function shouldInjectManifestSkill(
     const cat = manifestCategory(c.manifestYaml);
     return !cat || cat === ctx.agentCategory;
 }
-
-/** 같은 스킬이 여러 배정(에이전트 + __global__)으로 중복 조회되면 첫 행만 남긴다 */
-export function dedupeById<T extends { id: string }>(rows: T[]): T[] {
-    const seen = new Set<string>();
-    return rows.filter(r => (seen.has(r.id) ? false : (seen.add(r.id), true)));
-}

--- a/apps/api/src/agents/skill-manager.ts
+++ b/apps/api/src/agents/skill-manager.ts
@@ -48,7 +48,7 @@ import type {
 } from '../data/repositories/skill-repository';
 import { slugify } from '../chat/slash-command';
 import { recordSkillUsage } from './skill-usage-log';
-import { shouldInjectManifestSkill, dedupeById } from './manifest-injection-filter';
+import { shouldInjectManifestSkill } from './manifest-injection-filter';
 
 const logger = createLogger('SkillManager');
 
@@ -436,22 +436,33 @@ export class SkillManager {
         // 만들므로(2026-08-16 근본 개선) 승인 전 draft·확장 제거/업데이트로 archived 된
         // 스킬의 잔존 manifest 가 주입되지 않게 막는다. 할당된 manifest 는 전부
         // agent_skills 행을 가진다(ManifestImporter placeholder·git-ingest 동시 INSERT).
+        //
+        // 같은 스킬이 여러 배정(에이전트 + __global__ + user:)으로 중복 조회되면 DISTINCT ON 으로
+        // 스킬당 1행만 남기되 **비-global 배정 행을 우선**한다 — global 행이 남으면 카테고리
+        // 필터가 다시 걸려 명시 배정이 무시된다. LIMIT 은 dedupe 뒤에 걸어 중복 행이 15 슬롯을
+        // 소모하지 않게 한다 (2026-08-30 — 종전엔 JS dedupe 가 priority 순 첫 행을 남겼고 LIMIT 이 먼저였다).
         const sql = `
-            SELECT sm.id, sm.version, sm.prompt_md, sm.manifest_yaml, asa.agent_id AS assigned_to
-            FROM skill_manifests sm
-            INNER JOIN agent_skill_assignments asa ON asa.skill_id = sm.id
-            INNER JOIN agent_skills ags ON ags.id = sm.id AND ags.status = 'active'
-            WHERE (asa.agent_id = $1 OR asa.agent_id = $2${userClause})
-              AND sm.version = (
-                  SELECT MAX(version) FROM skill_manifests WHERE id = sm.id
-              )
-            ORDER BY asa.priority DESC NULLS LAST, sm.id ASC
+            SELECT id, version, prompt_md, manifest_yaml, assigned_to
+            FROM (
+                SELECT DISTINCT ON (sm.id)
+                    sm.id, sm.version, sm.prompt_md, sm.manifest_yaml,
+                    asa.agent_id AS assigned_to, asa.priority
+                FROM skill_manifests sm
+                INNER JOIN agent_skill_assignments asa ON asa.skill_id = sm.id
+                INNER JOIN agent_skills ags ON ags.id = sm.id AND ags.status = 'active'
+                WHERE (asa.agent_id = $1 OR asa.agent_id = $2${userClause})
+                  AND sm.version = (
+                      SELECT MAX(version) FROM skill_manifests WHERE id = sm.id
+                  )
+                ORDER BY sm.id, (asa.agent_id = $2) ASC, asa.priority DESC NULLS LAST
+            ) dedup
+            ORDER BY priority DESC NULLS LAST, id ASC
             LIMIT 15
         `;
         let rows: Array<{ id: string; version: string; prompt_md: string; manifest_yaml: string; assigned_to: string }>;
         try {
             const result = await pool.query<{ id: string; version: string; prompt_md: string; manifest_yaml: string; assigned_to: string }>(sql, params);
-            rows = dedupeById(result.rows);
+            rows = result.rows;
         } catch (e) {
             logger.debug('skill_manifests 조회 실패 (021 마이그레이션 미적용?) — null', e);
             return null;


### PR DESCRIPTION
## 배경
#672 의 `/code-review` 후속. `buildManifestPrompt` 의 중복 배정 처리 2건.

## 문제
1. 같은 스킬이 에이전트 + `__global__` 에 이중 배정되면 JS `dedupeById` 가 `priority DESC` 첫 행을 남기는데, global 행이 먼저 오면 `assigned_to='__global__'` 로 카테고리 필터가 다시 걸려 **명시 배정이 무시**된다 (#672 가 고치려던 증상이 이 케이스에서 재현, priority 동률 NULL 이면 비결정적).
2. `LIMIT 15` 가 dedupe 전 SQL 에서 걸려 중복 행이 슬롯을 소모 → 실제 주입 수가 15 미만으로 조용히 줄어든다.

## 수정
- `DISTINCT ON (sm.id)` + `ORDER BY sm.id, (asa.agent_id = '__global__') ASC, asa.priority DESC NULLS LAST` 로 스킬당 **비-global 배정 행을 우선** 보존, 바깥 쿼리에서 priority 정렬 + `LIMIT 15`
- 고아가 된 `dedupeById` 제거 (`manifest-injection-filter.ts`)
- 회귀 테스트 추가 (`skill-manifest-union.test.ts`)

## 검증
- jest 2파일 11/11 통과, `tsc --noEmit` 통과, eslint 통과
- 운영 DB **읽기 전용** 확인: 새 쿼리 정상 실행(backend-developer/user 3 → 6행), 현재 `__global__` + 다른 배정 이중 배정 **0건** → 예방적 수정(동작 변화 없음)
- 정렬 의미 VALUES 검증: `(global p10, agent p5)` → agent 유지, `(global NULL, user:3 NULL)` → user:3 유지

## 미반영 (별도)
- `skill-repository.ts` `ORDER BY version DESC` 의 TEXT 사전순 정렬 — 잠복(현재 1.0.0 고정), `MAX(version)` 과 일관되므로 멀티 버저닝 도입 시 함께 처리

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbneZrk96Ct3eQHzVVPZve