### PR TITLE
fix(skills): skill_manifests 최신 version 선택을 사전순 MAX(version) 에서 semver 정렬 키로

### DIFF
--- a/apps/api/src/agents/__tests__/skill-manifest-union.test.ts
+++ b/apps/api/src/agents/__tests__/skill-manifest-union.test.ts
@@ -7,6 +7,7 @@
  */
 import { SkillManager } from '../skill-manager';
 import type { AgentSkill } from '../../data/repositories/skill-repository';
+import { SKILL_VERSION_LATEST_ORDER_SQL } from '../../data/repositories/skill-manifest-sync';
 
 const MANIFEST_ROWS = [{
     id: 'user-3-presentation-designer',
@@ -94,5 +95,13 @@ describe('buildManifestPrompt — 개인 지정 스킬 union', () => {
         // LIMIT 은 바깥(dedupe 후) 쿼리에만
         expect(manifestSql.indexOf('LIMIT 15')).toBeGreaterThan(manifestSql.indexOf(') dedup'));
         expect(manifestSql.match(/LIMIT 15/g)).toHaveLength(1);
+    });
+
+    it("최신 version 선택은 사전순 MAX(version) 이 아니라 semver 정렬 키 — '1.30.0' 이 '1.4.0' 아래로 밀리지 않는다", async () => {
+        const mgr = managerWithUserSkills([]);
+        await mgr.buildManifestPrompt('ui-ux-designer', '3', 'design');
+        const manifestSql = capturedSql.find((q) => q.includes('FROM skill_manifests'))!;
+        expect(manifestSql).not.toContain('MAX(version)');
+        expect(manifestSql).toContain(`ORDER BY ${SKILL_VERSION_LATEST_ORDER_SQL} LIMIT 1`);
     });
 });

--- a/apps/api/src/agents/skill-manager.ts
+++ b/apps/api/src/agents/skill-manager.ts
@@ -49,6 +49,7 @@ import type {
 import { slugify } from '../chat/slash-command';
 import { recordSkillUsage } from './skill-usage-log';
 import { shouldInjectManifestSkill } from './manifest-injection-filter';
+import { SKILL_VERSION_LATEST_ORDER_SQL } from '../data/repositories/skill-manifest-sync';
 
 const logger = createLogger('SkillManager');
 
@@ -452,7 +453,8 @@ export class SkillManager {
                 INNER JOIN agent_skills ags ON ags.id = sm.id AND ags.status = 'active'
                 WHERE (asa.agent_id = $1 OR asa.agent_id = $2${userClause})
                   AND sm.version = (
-                      SELECT MAX(version) FROM skill_manifests WHERE id = sm.id
+                      SELECT version FROM skill_manifests WHERE id = sm.id
+                      ORDER BY ${SKILL_VERSION_LATEST_ORDER_SQL} LIMIT 1
                   )
                 ORDER BY sm.id, (asa.agent_id = $2) ASC, asa.priority DESC NULLS LAST
             ) dedup

--- a/apps/api/src/data/repositories/__tests__/skill-manifest-sync.test.ts
+++ b/apps/api/src/data/repositories/__tests__/skill-manifest-sync.test.ts
@@ -1,8 +1,15 @@
-import { buildManifestYaml, skillContentChecksum, upsertSkillManifest, DEFAULT_SKILL_MANIFEST_VERSION } from '../skill-manifest-sync';
+import { buildManifestYaml, skillContentChecksum, upsertSkillManifest, DEFAULT_SKILL_MANIFEST_VERSION, SKILL_VERSION_LATEST_ORDER_SQL } from '../skill-manifest-sync';
 
 // 2026-08-29: createSkill/upsertSystemSkill/skill-creator 가 manifest 를 안 만들어 배정돼도
 // 주입되지 않던 갭 — 모든 생성 경로가 이 헬퍼로 manifest 를 동반한다.
 describe('skill-manifest-sync', () => {
+    it('SKILL_VERSION_LATEST_ORDER_SQL — 숫자 토큰 int[] 우선, 정식 릴리스 > prerelease, 원문은 마지막 tiebreak (사전순 MAX(version) 대체)', () => {
+        // 실제 정렬 결과는 운영 PG 에서 VALUES 로 검증: 10.0.0 > 2.0.0 > 1.36.0 > 1.30.0 > 1.4.0 > v1.2.3 > 1.0.0 > 1.0.0-beta > ''
+        expect(SKILL_VERSION_LATEST_ORDER_SQL).toMatch(/^ARRAY\(SELECT m\[1\]::int FROM regexp_matches\(split_part\(version, '-', 1\), '\\d\+', 'g'\) AS m\) DESC, /);
+        expect(SKILL_VERSION_LATEST_ORDER_SQL).toContain("(split_part(version, '-', 2) = '') DESC");
+        expect(SKILL_VERSION_LATEST_ORDER_SQL.endsWith('version DESC')).toBe(true);
+    });
+
     it('buildManifestYaml — 022/111 과 같은 fence 형식, 개행은 공백으로, category 기본 general', () => {
         const y = buildManifestYaml({ name: 'API 설계', description: '첫 줄\n둘째 줄', category: undefined });
         expect(y).toBe('---\nname: API 설계\ndescription: 첫 줄 둘째 줄\ncategory: general\n---\n');

--- a/apps/api/src/data/repositories/skill-manifest-sync.ts
+++ b/apps/api/src/data/repositories/skill-manifest-sync.ts
@@ -14,6 +14,18 @@ import { createHash } from 'crypto';
 
 export const DEFAULT_SKILL_MANIFEST_VERSION = '1.0.0';
 
+/**
+ * `skill_manifests.version`(TEXT) 의 **최신 버전 정렬 키** (`ORDER BY` 절에 그대로 붙인다).
+ *
+ * `MAX(version)` / `ORDER BY version DESC` 는 사전순이라 '10.0.0' < '2.0.0', '1.30.0' < '1.4.0' 으로
+ * 뒤집힌다 (운영엔 이미 1.26.0·1.30.0·1.36.0 과 4버전 스킬이 있다). 숫자 토큰 int[] 비교
+ * ('v' 접두·비숫자 무시, 빈 문자열은 `{}`) → 정식 릴리스가 prerelease('-' 뒤) 보다 우선 → 원문 순.
+ * 컬럼 참조는 bare `version` 이라 `FROM skill_manifests` 단독/상관 서브쿼리 안에서만 쓴다.
+ */
+export const SKILL_VERSION_LATEST_ORDER_SQL =
+    "ARRAY(SELECT m[1]::int FROM regexp_matches(split_part(version, '-', 1), '\\d+', 'g') AS m) DESC, " +
+    "(split_part(version, '-', 2) = '') DESC, version DESC";
+
 export interface SkillManifestRow {
     id: string;
     name: string;

--- a/apps/api/src/data/repositories/skill-repository.ts
+++ b/apps/api/src/data/repositories/skill-repository.ts
@@ -10,7 +10,7 @@
  */
 
 import { createLogger } from '../../utils/logger';
-import { upsertSkillManifest, type SkillManifestRow } from './skill-manifest-sync';
+import { upsertSkillManifest, SKILL_VERSION_LATEST_ORDER_SQL, type SkillManifestRow } from './skill-manifest-sync';
 import { BaseRepository, QueryParam } from './base-repository';
 import { assertResourceOwnerOrAdmin } from '../../auth/ownership';
 import { rowToSkill } from './skill-row-mapper';
@@ -214,7 +214,7 @@ export class SkillRepository extends BaseRepository {
         // 2026-08-29: UPDATE 가 아니라 upsert — manifest 가 없던 레거시 스킬도 갱신 시점에 생긴다.
         if (input.content !== undefined && input.content !== existing.content) {
             const versions = await this.query<{ version: string }>(
-                `SELECT version FROM skill_manifests WHERE id = $1 ORDER BY version DESC LIMIT 1`, [id]
+                `SELECT version FROM skill_manifests WHERE id = $1 ORDER BY ${SKILL_VERSION_LATEST_ORDER_SQL} LIMIT 1`, [id]
             );
             await this.syncManifest({
                 id, name: params[0] as string, description: params[1] as string | null, category: params[3] as string,


### PR DESCRIPTION
## 배경
#673 `/code-review` 잔여 1건(PLAUSIBLE → 실측으로 실현 가능 확인).

## 문제
`skill_manifests.version` 은 TEXT 라 `buildManifestPrompt` 의 `MAX(version)` 과 `updateSkill` 의 `ORDER BY version DESC` 가 **사전순**으로 최신을 고른다 — `'10.0.0' < '2.0.0'`, `'1.30.0' < '1.4.0'`. 운영 DB 에 이미 `1.26.0`·`1.30.0`·`1.36.0` 과 4버전 스킬(`1.0.0`~`1.0.3`)이 있어 잠복이 아니라 실현 가능한 결함(주입은 옛 버전 본문, `updateSkill` 은 옛 버전 행을 갱신).

## 수정
- `SKILL_VERSION_LATEST_ORDER_SQL` (`data/repositories/skill-manifest-sync.ts`) — `ORDER BY` 절 상수: 숫자 토큰 `int[]` DESC(`v` 접두·비숫자 무시) → 정식 릴리스가 prerelease(`-` 뒤) 보다 우선 → 원문 DESC
- `skill-manager.ts` `MAX(version)` 서브쿼리 → `ORDER BY <키> LIMIT 1`, `skill-repository.ts` `updateSkill` 동일 상수 사용
- 회귀 테스트 2건(union·sync)

## 검증
- jest 16/16 · `tsc --noEmit` · eslint 통과, skill-manager 583줄(600 게이트 내)
- 운영 PG **읽기 전용** VALUES 검증: `10.0.0 > 2.0.0 > 1.36.0 > 1.30.0 > 1.4.0 > v1.2.3 > 1.0.0 > 1.0.0-beta > ''`
- 운영 다중 버전 스킬(`user-3-presentation-designer`)의 선택 결과 종전과 동일(`1.0.3`) → 배포 시 동작 변화 없음

## 범위 밖
- `artifacts.version` 은 INTEGER, `prompt_templates` 는 별도 versions 테이블 — 해당 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbneZrk96Ct3eQHzVVPZve