### PR TITLE
fix(tools): 없는 도구 이름 호출에 교정 후보를 붙인다 (P0-b, 축소 채택)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1589,3 +1589,15 @@ CHAT_USER_MCP_SCHEMA_BUDGET_BYTES=16000
 # not_found=대상 부재, output_truncated=결과는 나옴. 이걸 세면 정상 도구가 차단된다.
 # TOOL_HEALTH_CIRCUIT_EXCLUDED_CATEGORIES=invalid_args,not_found,output_truncated
 # TOOL_HEALTH_CIRCUIT_MAX_TRACKED=500
+
+# ── 도구 이름 교정 (P0-b) ─────────────────────────────────────────────
+# 모델이 없는 도구 이름을 부르면 오류 메시지에 후보를 붙여 다음 턴에 자가 교정하게 한다.
+# 결정적 교정만 한다 — 별칭표(config/skill-compat) + 정규화 + 편집거리, LLM 호출 없음.
+# TOOL_NAME_SUGGEST_ENABLED=true
+# TOOL_NAME_SUGGEST_MAX=3
+# 편집거리 상한. 실제 상한은 min(이 값, floor(이름길이/3)) — 짧은 이름일수록 좁혀 오탐을 막는다.
+# TOOL_NAME_SUGGEST_MAX_DISTANCE=3
+# TOOL_NAME_SUGGEST_MAX_CANDIDATES=400
+# bash 출력에 `sh: 1: web_search: not found` 처럼 도구를 셸 명령으로 실행한 흔적이 있으면
+# 결과 끝에 "이건 도구다, tool_calls 로 불러라" 안내를 덧붙인다.
+# TOOL_NAME_SHELL_HINT_ENABLED=true

--- a/apps/api/src/__tests__/agent-task-input-files.test.ts
+++ b/apps/api/src/__tests__/agent-task-input-files.test.ts
@@ -64,6 +64,7 @@ jest.mock('../services/task-sandbox/runtime', () => ({
         writeWorkspaceFile,
         getLLMTools: () => [],
         isTaskTool: () => false,
+        setKnownToolNames: jest.fn(),
         getPlanSnapshot: () => [],
         executeTaskTool: jest.fn(),
     })),

--- a/apps/api/src/config/tool-name-suggest.ts
+++ b/apps/api/src/config/tool-name-suggest.ts
@@ -1,0 +1,30 @@
+/**
+ * 도구 이름 교정(P0-b) 설정.
+ *
+ * 모델이 존재하지 않는 도구 이름을 부르면 지금까지는 "도구를 찾을 수 없습니다: X" 만
+ * 돌려줬다. 이름이 왜 틀렸는지(구분자·대소문자·다른 생태계 이름)를 알려주지 않으므로
+ * 모델은 같은 이름을 다시 부르거나 엉뚱한 대안으로 새는 데 턴을 쓴다.
+ *
+ * 교정은 **결정적**이다 — 별칭 테이블(config/skill-compat.ts) + 문자열 거리만 쓰고
+ * LLM 을 부르지 않는다(판단 경계 A형 금지).
+ *
+ * @module config/tool-name-suggest
+ */
+export const TOOL_NAME_SUGGEST = {
+    /** 기능 게이트 — off 면 종전 오류 메시지 그대로. */
+    enabled: process.env.TOOL_NAME_SUGGEST_ENABLED !== 'false',
+    /** 오류 메시지에 붙일 최대 후보 수. */
+    maxSuggestions: parseInt(process.env.TOOL_NAME_SUGGEST_MAX || '3', 10),
+    /**
+     * 편집거리 상한. 이름이 짧을수록 좁혀야 오탐이 없다 —
+     * 실제 상한은 min(maxDistance, floor(len/3)) 이다.
+     */
+    maxDistance: parseInt(process.env.TOOL_NAME_SUGGEST_MAX_DISTANCE || '3', 10),
+    /** 후보를 계산할 도구 목록 상한(비용 가드). */
+    maxCandidates: parseInt(process.env.TOOL_NAME_SUGGEST_MAX_CANDIDATES || '400', 10),
+    /**
+     * 셸에서 도구 이름을 명령으로 실행했을 때(`sh: 1: web_search: not found`)
+     * 결과 끝에 교정 안내를 덧붙인다.
+     */
+    shellHintEnabled: process.env.TOOL_NAME_SHELL_HINT_ENABLED !== 'false',
+} as const;

--- a/apps/api/src/mcp/__tests__/tool-name-suggest.test.ts
+++ b/apps/api/src/mcp/__tests__/tool-name-suggest.test.ts
@@ -1,0 +1,116 @@
+/**
+ * 도구 이름 교정(P0-b) — 순수 함수 테스트.
+ *
+ * 케이스는 운영 DB 에서 실제로 관측된 오류 형태를 그대로 옮겼다:
+ * `web_url_read`(구 이름) · `Python REPL::repl_run_code`(구분자·대소문자) ·
+ * `sh: 1: web_search: not found`(도구를 셸 명령으로 실행).
+ */
+import {
+    normalizeToolName,
+    suggestToolNames,
+    withToolNameSuggestions,
+    detectShellToolMisuse,
+    formatShellToolMisuseHint,
+} from '../tool-name-suggest';
+
+const AVAILABLE = [
+    'bash', 'file_ops', 'str_replace_editor', 'python_execute', 'plan_create', 'plan_update',
+    'web_search', 'web_scrape', 'extract_webpage', 'generate_image', 'delegate',
+    'python-repl::repl_run_code', 'mcp-kakao::search-web',
+];
+
+describe('normalizeToolName', () => {
+    it('대소문자·구분자를 지운다', () => {
+        expect(normalizeToolName('Python REPL::repl_run_code')).toBe('pythonreplreplruncode');
+        expect(normalizeToolName('web-search')).toBe(normalizeToolName('web_search'));
+    });
+});
+
+describe('suggestToolNames', () => {
+    it('Claude Code 별칭을 이 환경 도구로 교정한다', () => {
+        expect(suggestToolNames('Read', AVAILABLE)[0]).toBe('file_ops');
+        expect(suggestToolNames('WebFetch', AVAILABLE)[0]).toBe('web_scrape');
+        expect(suggestToolNames('Bash', AVAILABLE)[0]).toBe('bash');
+    });
+
+    it('구분자·대소문자만 다른 이름을 찾는다 (실측: Python REPL::repl_run_code)', () => {
+        expect(suggestToolNames('Python REPL::repl_run_code', AVAILABLE)).toContain('python-repl::repl_run_code');
+        expect(suggestToolNames('web-search', AVAILABLE)).toContain('web_search');
+    });
+
+    it('server::tool 의 도구 부분만 맞아도 후보로 낸다', () => {
+        expect(suggestToolNames('kakao::search-web', AVAILABLE)).toContain('mcp-kakao::search-web');
+    });
+
+    it('오타를 편집거리로 교정한다', () => {
+        expect(suggestToolNames('web_serch', AVAILABLE)).toContain('web_search');
+    });
+
+    it('무관한 이름에는 후보를 내지 않는다 (오탐 방지)', () => {
+        expect(suggestToolNames('zzzzzzzzzzzz', AVAILABLE)).toEqual([]);
+    });
+
+    it('자기 자신은 후보에서 제외한다', () => {
+        expect(suggestToolNames('bash', AVAILABLE)).not.toContain('bash');
+    });
+
+    it('빈 입력·빈 목록은 빈 배열', () => {
+        expect(suggestToolNames('', AVAILABLE)).toEqual([]);
+        expect(suggestToolNames('web_search', [])).toEqual([]);
+    });
+
+    it('maxSuggestions 상한을 지킨다', () => {
+        expect(suggestToolNames('plan_creat', AVAILABLE, { maxSuggestions: 1 }).length).toBeLessThanOrEqual(1);
+    });
+});
+
+describe('withToolNameSuggestions', () => {
+    it('후보가 있으면 원문 뒤에 덧붙인다', () => {
+        const msg = withToolNameSuggestions('도구를 찾을 수 없습니다: Read', 'Read', AVAILABLE);
+        expect(msg).toContain('도구를 찾을 수 없습니다: Read');
+        expect(msg).toContain('file_ops');
+    });
+
+    it('후보가 없으면 원문 그대로 (fail-open)', () => {
+        const base = '도구를 찾을 수 없습니다: zzzzzzzzzzzz';
+        expect(withToolNameSuggestions(base, 'zzzzzzzzzzzz', AVAILABLE)).toBe(base);
+    });
+});
+
+describe('detectShellToolMisuse', () => {
+    it('도구를 셸 명령으로 실행한 흔적을 찾는다 (실측 형태)', () => {
+        const out = '[stderr]\nsh: 1: web_search: not found\n \n[exit=127 12ms]';
+        expect(detectShellToolMisuse(out, AVAILABLE)).toEqual(['web_search']);
+    });
+
+    it('bash line 형식도 인식한다', () => {
+        const out = 'bash: line 2: file_ops: command not found';
+        expect(detectShellToolMisuse(out, AVAILABLE)).toEqual(['file_ops']);
+    });
+
+    it('도구가 아닌 명령은 무시한다', () => {
+        expect(detectShellToolMisuse('sh: 1: jq: not found', AVAILABLE)).toEqual([]);
+    });
+
+    it('여러 번 나와도 중복 없이 모은다', () => {
+        const out = 'sh: 1: web_search: not found\nsh: 2: web_search: not found\nsh: 3: web_scrape: not found';
+        expect(detectShellToolMisuse(out, AVAILABLE)).toEqual(['web_search', 'web_scrape']);
+    });
+
+    it('빈 출력·빈 목록은 빈 배열', () => {
+        expect(detectShellToolMisuse('', AVAILABLE)).toEqual([]);
+        expect(detectShellToolMisuse('sh: 1: web_search: not found', [])).toEqual([]);
+    });
+});
+
+describe('formatShellToolMisuseHint', () => {
+    it('이름이 없으면 빈 문자열', () => {
+        expect(formatShellToolMisuseHint([])).toBe('');
+    });
+
+    it('도구 호출로 부르라고 안내한다', () => {
+        const hint = formatShellToolMisuseHint(['web_search']);
+        expect(hint).toContain('web_search');
+        expect(hint).toContain('tool_calls');
+    });
+});

--- a/apps/api/src/mcp/tool-name-suggest.ts
+++ b/apps/api/src/mcp/tool-name-suggest.ts
@@ -1,0 +1,161 @@
+/**
+ * ============================================================
+ * 도구 이름 교정 (P0-b) — 결정적 후보 제안
+ * ============================================================
+ *
+ * 모델이 존재하지 않는 도구 이름을 부를 때, 오류 메시지에 **무엇을 부르려던 것인지**
+ * 후보를 붙여 다음 턴에 자가 교정하게 한다. 관측된 형태는 셋이다:
+ *
+ * 1. 다른 생태계 이름 — Claude Code 의 `Read`/`WebFetch` 등 (스킬 본문에서 옮아온다)
+ * 2. 구분자·대소문자 차이 — `Python REPL::repl_run_code` vs `python-repl::repl_run_code`
+ * 3. 오타·구 이름 — `web_url_read` vs `web_scrape`
+ *
+ * **LLM 을 부르지 않는다** — 별칭 테이블(config/skill-compat) + 정규화 + 편집거리뿐이다
+ * (판단 경계 A형 금지). 후보가 없으면 종전 메시지 그대로다(fail-open).
+ *
+ * @module mcp/tool-name-suggest
+ */
+import { CLAUDE_TOOL_ALIASES } from '../config/skill-compat';
+import { TOOL_NAME_SUGGEST } from '../config/tool-name-suggest';
+
+/** 대소문자·구분자(`_`,`-`,`::`,공백)를 지운 비교용 키. */
+export function normalizeToolName(name: string): string {
+    return name.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+/** 별칭 테이블을 대소문자 무시로 조회하기 위한 사전(모듈 1회 구축). */
+const ALIAS_BY_NORMALIZED = new Map<string, string>();
+for (const [from, to] of Object.entries(CLAUDE_TOOL_ALIASES)) {
+    if (to) ALIAS_BY_NORMALIZED.set(normalizeToolName(from), to);
+}
+
+/** 표준 Levenshtein 거리 (두 행 롤링 — 도구 이름 길이라 충분하다). */
+function levenshtein(a: string, b: string): number {
+    if (a === b) return 0;
+    if (!a.length) return b.length;
+    if (!b.length) return a.length;
+    let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+    for (let i = 1; i <= a.length; i++) {
+        const cur = [i];
+        for (let j = 1; j <= b.length; j++) {
+            cur[j] = Math.min(
+                prev[j] + 1,
+                cur[j - 1] + 1,
+                prev[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1),
+            );
+        }
+        prev = cur;
+    }
+    return prev[b.length];
+}
+
+export interface SuggestToolNamesOpts {
+    maxSuggestions?: number;
+    maxDistance?: number;
+}
+
+/**
+ * PURE: 알 수 없는 도구 이름에 대한 후보를 우선순위대로 돌려준다.
+ *
+ * 우선순위 — ① 생태계 별칭(`Read`→`file_ops`) ② 정규화 완전 일치(구분자·대소문자만 다름)
+ * ③ `server::tool` 의 도구 부분 일치 ④ 편집거리 근접.
+ *
+ * 짧은 이름은 거리 상한을 좁힌다(`floor(len/3)`) — `bash`(4자)에 거리 3 을 허용하면
+ * 무관한 이름이 후보로 올라와 오히려 모델을 헷갈리게 한다.
+ */
+export function suggestToolNames(
+    unknown: string,
+    available: readonly string[],
+    opts: SuggestToolNamesOpts = {},
+): string[] {
+    if (!unknown || available.length === 0) return [];
+    const maxSuggestions = opts.maxSuggestions ?? TOOL_NAME_SUGGEST.maxSuggestions;
+    const maxDistance = opts.maxDistance ?? TOOL_NAME_SUGGEST.maxDistance;
+    if (maxSuggestions <= 0) return [];
+
+    const pool = available.slice(0, TOOL_NAME_SUGGEST.maxCandidates);
+    const target = normalizeToolName(unknown);
+    if (!target) return [];
+    const out: string[] = [];
+    const push = (name: string) => {
+        if (name && name !== unknown && !out.includes(name)) out.push(name);
+    };
+
+    // ① 생태계 별칭 — 이름이 그대로 있으면 가장 확실한 교정이다.
+    const alias = ALIAS_BY_NORMALIZED.get(target);
+    if (alias) {
+        const hit = pool.find((n) => normalizeToolName(n) === normalizeToolName(alias));
+        if (hit) push(hit);
+    }
+
+    // ② 정규화 완전 일치 — 구분자/대소문자만 다른 경우.
+    for (const n of pool) if (normalizeToolName(n) === target) push(n);
+
+    // ③ `server::tool` 의 도구 부분(마지막 세그먼트) 일치.
+    const tail = normalizeToolName(unknown.split('::').pop() ?? '');
+    if (tail && tail !== target) {
+        for (const n of pool) {
+            if (normalizeToolName(n.split('::').pop() ?? '') === tail) push(n);
+        }
+    }
+
+    // ④ 편집거리 근접 — 짧은 이름일수록 좁게.
+    if (out.length < maxSuggestions) {
+        const limit = Math.max(1, Math.min(maxDistance, Math.floor(target.length / 3)));
+        const scored: Array<{ name: string; d: number }> = [];
+        for (const n of pool) {
+            if (out.includes(n)) continue;
+            const d = levenshtein(target, normalizeToolName(n));
+            if (d <= limit) scored.push({ name: n, d });
+        }
+        scored.sort((a, b) => a.d - b.d || a.name.localeCompare(b.name));
+        for (const s of scored) push(s.name);
+    }
+
+    return out.slice(0, maxSuggestions);
+}
+
+/**
+ * PURE: "도구를 찾을 수 없습니다" 계열 메시지에 후보를 덧붙인다.
+ * 후보가 없으면 원문 그대로 (fail-open).
+ */
+export function withToolNameSuggestions(
+    baseMessage: string,
+    unknown: string,
+    available: readonly string[],
+    opts: SuggestToolNamesOpts = {},
+): string {
+    if (!TOOL_NAME_SUGGEST.enabled) return baseMessage;
+    const names = suggestToolNames(unknown, available, opts);
+    if (names.length === 0) return baseMessage;
+    return `${baseMessage} — 다음 이름을 의도한 것 같습니다: ${names.join(', ')}. 정확한 이름으로 다시 호출하세요.`;
+}
+
+/** `sh: 1: web_search: not found` / `bash: line 2: foo: command not found` 양식. */
+const SHELL_NOT_FOUND_RE = /(?:^|\n)\s*(?:\/bin\/)?(?:sh|bash|zsh)(?::[^:\n]*)?:\s*([A-Za-z_][\w.:-]*):\s*(?:command )?not found/g;
+
+/**
+ * PURE: 셸 출력에서 "도구 이름을 셸 명령으로 실행한" 흔적을 찾는다.
+ *
+ * 실측(운영 30일 5건): 모델이 `web_search "질의"` 처럼 도구를 bash 안에서 부른다.
+ * 셸에는 그런 명령이 없으므로 `not found` 로 끝나고, 모델은 원인을 모른 채 재시도한다.
+ */
+export function detectShellToolMisuse(output: string, knownTools: readonly string[]): string[] {
+    if (!TOOL_NAME_SUGGEST.shellHintEnabled || !output || knownTools.length === 0) return [];
+    const known = new Set(knownTools.map(normalizeToolName));
+    const found: string[] = [];
+    SHELL_NOT_FOUND_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = SHELL_NOT_FOUND_RE.exec(output)) !== null) {
+        const name = m[1];
+        if (known.has(normalizeToolName(name)) && !found.includes(name)) found.push(name);
+    }
+    return found;
+}
+
+/** PURE: 셸 오용 안내 문구. 호출부가 도구 결과 끝에 덧붙인다. */
+export function formatShellToolMisuseHint(names: readonly string[]): string {
+    if (names.length === 0) return '';
+    const list = names.join(', ');
+    return `\n\n⚠️ ${list} 는 셸 명령이 아니라 **도구**입니다. bash 안에서는 실행할 수 없으니, 셸 대신 도구 호출(tool_calls)로 직접 부르세요.`;
+}

--- a/apps/api/src/mcp/tool-router.ts
+++ b/apps/api/src/mcp/tool-router.ts
@@ -37,6 +37,7 @@ import { createLogger } from '../utils/logger';
 import { MCP_EXTERNAL_TOOL_LIMITS } from '../config/timeouts';
 import { withSpan } from '../observability/otel';
 import { classifyToolError, formatToolError } from './tool-error-classifier';
+import { withToolNameSuggestions } from './tool-name-suggest';
 import { isToolCircuitOpen, recordToolResult } from './tool-health';
 import type { UserMCPPool } from './user-pool';
 import { collectUserPoolTools } from './user-pool-tools';
@@ -199,6 +200,24 @@ export class ToolRouter {
     }
 
     /**
+     * 오류 경로 전용 — 지금 이 사용자에게 실제로 열려 있는 도구 이름을 모은다.
+     * 이름 교정 후보 계산에만 쓰이며, 사용자 풀 조회가 실패해도 내장·전역만으로 진행한다.
+     */
+    private async knownToolNamesFor(userId?: string): Promise<string[]> {
+        const names: string[] = builtInTools.map((d: MCPToolDefinition) => d.tool.name);
+        for (const key of this.externalTools.keys()) names.push(key);
+        if (userId) {
+            try {
+                const { getUserMCPPool } = await import('./user-pool');
+                for (const e of collectUserPoolTools(getUserMCPPool(), userId)) names.push(e.tool.name);
+            } catch {
+                /* 사용자 풀을 못 읽어도 후보 없이 종전 메시지로 진행 (fail-open) */
+            }
+        }
+        return names;
+    }
+
+    /**
      * 도구 실행 — 내장이면 직접 handler, 외부면 ExternalMCPClient로 라우팅
      * 
      * ⚙️ Phase 3: UserContext 전달 추가 (2026-02-07)
@@ -304,7 +323,7 @@ export class ToolRouter {
                 // 1b. 전역 externalTools (visibility=global) fallback
                 const externalEntry = this.externalTools.get(name);
                 if (!externalEntry) {
-                    return fail(`외부 도구를 찾을 수 없습니다: ${name}`);
+                    return fail(withToolNameSuggestions(`외부 도구를 찾을 수 없습니다: ${name}`, name, await this.knownToolNamesFor(context?.userId ? String(context.userId) : undefined)));
                 }
 
                 const executor = this.externalExecutors.get(externalEntry.serverId);
@@ -350,7 +369,7 @@ export class ToolRouter {
                 }
             }
 
-            return fail(`도구를 찾을 수 없습니다: ${name}`);
+            return fail(withToolNameSuggestions(`도구를 찾을 수 없습니다: ${name}`, name, await this.knownToolNamesFor(context?.userId ? String(context.userId) : undefined)));
         });
     }
 

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -223,6 +223,14 @@ export class AgentTaskService {
                         })
                         : undefined;
                     taskRuntime = new TaskRuntime(taskId, userId, sandboxCfg, delegateFn, spawnFn, remoteExecutor, goal);
+                    // 이름 교정(P0-b) — 모델에 실제 노출된 도구 이름을 런타임에 알려, 잘못된 이름 호출과
+                    // "도구를 셸 명령으로 실행" 을 그 자리에서 교정 안내한다. 오류 메시지 품질을 위한
+                    // 부가 기능이므로 여기서 실패해도 샌드박스 경로 전체를 죽이지 않는다(fail-open).
+                    try {
+                        taskRuntime.setKnownToolNames(mcpTools.map((t) => t.function.name));
+                    } catch (e) {
+                        logger.warn(`[${taskId}] 도구 이름 교정 목록 주입 실패(무시): ${e instanceof Error ? e.message : String(e)}`);
+                    }
                     await taskRuntime.create();
                     await db.updateAgentTask(taskId, {
                         sandboxContainerId: taskRuntime.containerName,

--- a/apps/api/src/services/task-sandbox/runtime.test.ts
+++ b/apps/api/src/services/task-sandbox/runtime.test.ts
@@ -91,3 +91,27 @@ describe('TaskRuntime 도구/게이트 (샌드박스 미생성 — 게이트 로
         expect(out).toContain('거절');
     });
 });
+
+describe('도구 이름 교정 (P0-b)', () => {
+    const cfgNone = { ...getTaskSandboxConfig(), approvalPolicy: 'none' as const };
+
+    it('알 수 없는 도구 이름에 후보를 붙인다 — Claude Code 별칭', async () => {
+        const rt = new TaskRuntime('t-alias', 'u1', cfgNone);
+        const out = await rt.executeTaskTool('Read', {});
+        expect(out).toContain('알 수 없는 task 도구 Read');
+        expect(out).toContain('file_ops');
+    });
+
+    it('노출 도구 목록을 주입하면 MCP·내장 도구도 후보가 된다', async () => {
+        const rt = new TaskRuntime('t-known', 'u1', cfgNone);
+        rt.setKnownToolNames(['web_search', 'extract_webpage']);
+        const out = await rt.executeTaskTool('web-search', {});
+        expect(out).toContain('web_search');
+    });
+
+    it('후보가 없으면 종전 메시지 그대로 (fail-open)', async () => {
+        const rt = new TaskRuntime('t-none', 'u1', cfgNone);
+        const out = await rt.executeTaskTool('zzzzzzzzzzzz', {});
+        expect(out).toBe('Error: 알 수 없는 task 도구 zzzzzzzzzzzz');
+    });
+});

--- a/apps/api/src/services/task-sandbox/runtime.ts
+++ b/apps/api/src/services/task-sandbox/runtime.ts
@@ -20,6 +20,7 @@ import { recordToolResultTruncation } from '../tool-result-truncation-recorder';
 import { saveProceduralSkill, resolveProceduralSpec } from '../agent-task/procedural-skill';
 import { TaskPlan, parseGoalPlanSteps, type PlanStep } from './planning';
 import { requiresApproval, getApprovalRegistry, type PendingApproval, type ApprovalRejectReason } from './approval-gate';
+import { withToolNameSuggestions, detectShellToolMisuse, formatShellToolMisuseHint } from '../../mcp/tool-name-suggest';
 import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('TaskRuntime');
@@ -61,6 +62,8 @@ export class TaskRuntime {
     private readonly plan = new TaskPlan({ autoAdvance: AGENT_TASK_LIMITS.PLAN_AUTO_ADVANCE });
     private readonly handlers = new Map<string, MCPToolDefinition['handler']>();
     private readonly defs: MCPToolDefinition[];
+    /** 이 작업에 실제로 노출된 도구 이름(task + MCP + 내장). 이름 교정·셸 오용 감지에만 쓴다. */
+    private knownToolNames: string[] = [];
 
     constructor(
         taskId: string,
@@ -177,6 +180,25 @@ export class TaskRuntime {
     isTaskTool(name: string): boolean { return this.handlers.has(name); }
 
     /**
+     * 모델에 실제로 노출된 전체 도구 이름을 알려준다(AgentTaskService 가 도구 목록 확정 후 1회).
+     * task 도구만으로는 `web_search` 처럼 MCP·내장 도구를 셸에서 부른 경우를 알아볼 수 없다.
+     */
+    setKnownToolNames(names: readonly string[]): void {
+        this.knownToolNames = Array.from(new Set([...this.handlers.keys(), ...names]));
+    }
+
+
+    /**
+     * 셸 출력에 "도구 이름을 명령으로 실행" 한 흔적이 있으면 결과 끝에 교정 안내를 덧붙인다.
+     * 실측(30일 5건): 모델이 `web_search "질의"` 를 bash 로 실행해 `not found` 만 보고 헤맸다.
+     */
+    private appendShellToolHint(toolName: string, output: string): string {
+        if (toolName !== 'bash') return output;
+        const known = this.knownToolNames.length > 0 ? this.knownToolNames : Array.from(this.handlers.keys());
+        const misused = detectShellToolMisuse(output, known);
+        return misused.length > 0 ? output + formatShellToolMisuseHint(misused) : output;
+    }
+    /**
      * 도구 실행 — 승인 정책 적용 후 핸들러 실행. 거절 시 도구 결과로 거절 메시지 반환
      * (루프는 정상 진행 — LLM 이 거절을 보고 대안을 모색).
      */
@@ -186,7 +208,10 @@ export class TaskRuntime {
         opts: ExecuteTaskToolOpts = {},
     ): Promise<string> {
         const handler = this.handlers.get(name);
-        if (!handler) return `Error: 알 수 없는 task 도구 ${name}`;
+        if (!handler) {
+            const known = this.knownToolNames.length > 0 ? this.knownToolNames : Array.from(this.handlers.keys());
+            return withToolNameSuggestions(`Error: 알 수 없는 task 도구 ${name}`, name, known);
+        }
 
         // ask_human 은 승인 정책·자동승인과 무관하게 항상 사용자 응답을 대기한다 — 도구의 목적
         // 자체가 HITL 이므로 승인 레지스트리(pause + push + REST approve/reject/answer)를 응답 채널로 사용.
@@ -233,7 +258,7 @@ export class TaskRuntime {
                 rawChars: typed.content.map((c) => c.text ?? '').join('\n').length,
                 capChars: MAX_TOOL_RESULT_CHARS,
             });
-            return resultToString(typed);
+            return this.appendShellToolHint(name, resultToString(typed));
         } catch (e) {
             const msg = e instanceof Error ? e.message : String(e);
             logger.warn(`[${this.taskId}] task 도구 실행 실패 (${name}): ${msg}`);


### PR DESCRIPTION
## 왜

모델이 존재하지 않는 도구 이름을 부르면 `도구를 찾을 수 없습니다: X` 만 돌아온다. **무엇을 부르려던 것인지** 알려주지 않으므로 모델은 같은 이름을 다시 부르거나 엉뚱한 대안으로 새는 데 턴을 쓴다.

## 착수하며 계획 전제를 재확인한 결과 (중요)

계획 문서 §6 이 별건으로 넘긴 P0-b 를 착수하며 근거를 운영 DB 로 대조했더니 **수치가 재현되지 않았다.**

| 계획의 근거 | 실측 (전체 기간, `agent_task_steps`) |
|---|---|
| "없는 도구명 호출 12건" | `Error: 알 수 없는 task 도구` **0건** |

실제 관측된 이름 오류는 task 도구 경로가 아니라 **tool-router 경로**에 있었고 형태가 셋이다:

| 형태 | 실측 | 예 |
|---|---|---|
| 구 이름·오타 | 3건 (마지막 07-11) | `web_url_read` |
| 구분자·대소문자 | 3건 (마지막 06-10) | `Python REPL::repl_run_code` |
| **도구를 셸 명령으로 실행** | **5건 (최근 30일)** | `sh: 1: web_search: not found` |

- `str_replace_editor` 는 **실제 등록된 task 도구**(`tools.ts:144`)다 — 승인 거절 3건은 별칭 오류가 아니었다.
- 앞의 두 형태는 최근 30일 0건이라 단독 구현 근거가 못 되지만, 오류 메시지에 후보를 붙이는 비용이 사실상 0(오류 경로에서만 실행, LLM 없음)이고 **세 형태를 한 함수로 덮는다**. 그래서 축소 채택.

**같은 검증에서 P0-d(write→run 유도)는 반려**했다 — "셸 heredoc 문법 40건" 의 근거인 `unexpected end of file` 이 **0건**이고, 문법 오류 15건은 python `SyntaxError`(9) 등 생성 코드 자체의 오류라 write→run 으로 바꿔도 같은 자리에서 실패한다. 근거·판단은 계획 문서 §7 에 기록했다.

## 무엇을

- **`mcp/tool-name-suggest.ts`**(순수, 신규) — 별칭표(`CLAUDE_TOOL_ALIASES`) → 정규화 완전 일치 → `server::tool` 꼬리 일치 → 편집거리 순으로 후보. 짧은 이름은 거리 상한을 `floor(len/3)` 로 좁혀 오탐을 막는다. **LLM 호출 없음**(판단 경계 A형 금지).
- 적용 3곳 — `tool-router` 의 `외부 도구를 찾을 수 없습니다`·`도구를 찾을 수 없습니다`, `TaskRuntime` 의 `알 수 없는 task 도구`. 후보가 없으면 **종전 메시지 그대로**(fail-open).
- bash 결과에 `not found` 로 끝난 토큰이 실제 도구 이름이면 "셸 명령이 아니라 도구다, `tool_calls` 로 불러라" 안내를 덧붙인다.
- 게이트 `TOOL_NAME_SUGGEST_ENABLED`(기본 on) · `TOOL_NAME_SHELL_HINT_ENABLED`(기본 on).

### 하지 않은 것

이름을 **자동 치환해 실행**하는 것. 별칭이 1:1 이 아니고(`Edit`·`MultiEdit` → `str_replace_editor`) 인자 스키마가 달라 그대로 넘기면 다른 실패로 바뀐다. 교정은 모델이 다음 턴에 한다.

## 부수 수정 — 부가 기능이 샌드박스를 조용히 끄던 형태

`setKnownToolNames` 주입을 try/catch 로 감쌌다. 이 호출은 샌드박스 생성 try 블록 안에 있어, 실패하면 graceful degrade 로 **샌드박스 전체가 꺼진 채 작업이 진행된다**. `agent-task-input-files` 테스트가 정확히 이 형태로 깨져(파일 기록 0회) 드러났다 — 오류는 어디에도 안 보이고 결과만 달라진다.

## 검증

- 단위 **21건 신규** — 순수 함수 18(별칭·정규화·꼬리 일치·오타·오탐 방지·상한·fail-open, 셸 오용 감지 5) + TaskRuntime 회귀 3(별칭 후보·주입 목록 반영·후보 없을 때 원문 유지).
- 6게이트: jest **3,201 pass / 0 fail** · tsc(api) · lint **0 error** · 최대 파일 580줄 · `eval:routing` 93.3% · `eval:response` 100%.

## 체크리스트

- [x] `npm run lint` 통과 (0 error)
- [x] `npm test` 통과 (3,201 pass)
- [x] `eval:routing` · `eval:response` 통과
- [x] `.env.example` 업데이트 (설정 5종)
- [x] DB 스키마 변경 없음
- [x] 되돌리기: env 한 줄(`TOOL_NAME_SUGGEST_ENABLED=false`) + 재시작 — 오류 메시지만 종전으로 복귀
- [x] 보안: 읽기 전용 문자열 처리, 외부 입력 실행 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbneZrk96Ct3eQHzVVPZve