### PR TITLE
fix(agent-task): 재시작 후 첫 작업이 user MCP 도구 0개로 돌던 결함 + 쿼터 단위 오표시 (유실 브랜치 회수)

### DIFF
--- a/apps/api/src/errors/quota-exceeded.error.ts
+++ b/apps/api/src/errors/quota-exceeded.error.ts
@@ -20,7 +20,10 @@ export class QuotaExceededError extends Error {
     public readonly retryAfterSeconds: number;
 
     constructor(quotaType: 'hourly' | 'weekly' | 'both', used: number, limit: number) {
-        const message = `API quota exceeded (${quotaType}): ${used}/${limit} requests used`;
+        // 단위는 **토큰** — user-quota.ts 가 llmHourlyTokenLimit/llmWeeklyTokenLimit(토큰 수)로
+        // 검사한다. 예전 문구가 "requests used" 라 요청 수로 읽혀, 업스트림 프로바이더의
+        // 요청 쿼터 초과로 오진하기 쉬웠다.
+        const message = `API quota exceeded (${quotaType}): ${used}/${limit} tokens used`;
         super(message);
         this.name = 'QuotaExceededError';
         this.quotaType = quotaType;

--- a/apps/api/src/mcp/lifecycle-hooks.ts
+++ b/apps/api/src/mcp/lifecycle-hooks.ts
@@ -32,6 +32,23 @@ export async function emitChatStart(userId: string, chatId: string): Promise<voi
     catch (e) { logger.warn(`onChatStart hook 실패 u=${userId} c=${chatId}`, e); }
 }
 
+/**
+ * Agent Task 실행 직전 user MCP 풀 보장.
+ *
+ * 채팅 경로(emitChatStart)와 달리 **반드시 await 해야 한다** — 에이전트 작업은 일회성이라
+ * 도구 목록을 모으는 시점에 풀이 비어 있으면 그 실행 내내 user MCP 도구가 없는 상태로
+ * 진행된다. 실제로 mcp_list_tools 가 "설치된 외부 MCP 서버가 없습니다" 를 반환해 모델이
+ * 서버 미설치로 오판하고 작업을 포기했다(채팅을 먼저 한 뒤 실행하면 우연히 성공하던 이유).
+ *
+ * ensureUserServers 는 safeSpawn 멱등 가드가 있어 이미 살아있는 클라이언트는 재spawn 하지 않는다.
+ */
+export async function ensureUserMcpForTask(userId: string, taskId: string): Promise<void> {
+    const sv = getLifecycleSupervisor();
+    if (!sv) return;
+    try { await sv.ensureUserServers(userId, `task=${taskId}`); }
+    catch (e) { logger.warn(`ensureUserMcpForTask 실패 u=${userId} t=${taskId}`, e); }
+}
+
 export async function emitChatEnd(userId: string, chatId: string): Promise<void> {
     const sv = getLifecycleSupervisor();
     if (!sv) return;

--- a/apps/api/src/mcp/mcp-meta-tools.ts
+++ b/apps/api/src/mcp/mcp-meta-tools.ts
@@ -42,7 +42,26 @@ export const mcpListToolsTool: MCPToolDefinition = {
         const groups = router.getUserPoolToolGroups(userId);
         // "없습니다"만 반환하면 모델이 "검색/도구 불가 환경"으로 오일반화해 내장 도구까지
         // 안 쓰는 환각을 확증시킨다(2026-07-17 Discord 사례) — 내장 도구 가용을 함께 명시.
+        //
+        // 빈 그룹은 "미설치"와 "이번 실행에서 풀이 아직 안 채워짐"을 구분하지 못한다. 후자를
+        // 미설치로 단정하자 모델이 설치돼 있는 서버를 두고 작업을 포기했다. DB 기준 설치 여부를
+        // 확인해 두 경우를 다르게 안내한다. 조회 실패는 기존 문구로 폴백(graceful).
         if (groups.length === 0) {
+            let installed: string[] = [];
+            try {
+                const { McpCatalogRepository } = await import('../data/repositories/mcp-catalog-repository');
+                const { getUnifiedDatabase } = await import('../data/models/unified-database');
+                const rows = await new McpCatalogRepository(getUnifiedDatabase().getPool()).listUserServers(userId);
+                installed = rows.filter(r => r.enabled).map(r => r.name);
+            } catch { /* 조회 실패 — 아래 기본 문구 */ }
+
+            if (installed.length > 0) {
+                return text(
+                    `설치된 MCP 서버(${installed.join(', ')})가 이번 실행에서 아직 준비되지 않았습니다. `
+                    + '미설치가 아니므로 "서버가 없다"고 단정하지 마세요. 현재 도구 목록에 해당 서버 도구가 '
+                    + '보이면 그대로 호출하고, 보이지 않으면 잠시 후 다시 이 도구로 확인하거나 내장 도구로 진행하세요.',
+                );
+            }
             return text(
                 '설치된 외부 MCP 서버가 없습니다. 단, 기본 내장 도구(현재 도구 목록의 web_search 등)는 '
                 + 'MCP 설치와 무관하게 지금 바로 사용할 수 있습니다. 웹 검색이 필요하면 web_search 도구를 직접 호출하세요.',

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -18,6 +18,7 @@ import { type LLMClient } from '../llm';
 import type { ChatMessage, ToolDefinition } from '../llm/types';
 import { initAgentRoleState, chatTurnWithRoleFallback, defaultAgentClient } from './agent-task/role-client';
 import { getUnifiedMCPClient } from '../mcp/unified-client';
+import { ensureUserMcpForTask } from '../mcp/lifecycle-hooks';
 import { getUnifiedDatabase } from '../data/models/unified-database';
 import { AGENT_TASK_LIMITS, AGENT_SPAWN } from '../config/runtime-limits';
 import { emitAgentTaskProgress } from '../utils/event-bus';
@@ -189,6 +190,11 @@ export class AgentTaskService {
             // fresh 재실행(실패/취소 작업을 처음부터): 이전 시도의 스텝을 비워
             // stepNumber 0 재시작으로 인한 (task_id, step_number) 중복·표시 혼선을 방지.
             if (!input.resume) await db.deleteAgentTaskSteps(taskId);
+
+            // user MCP 풀 보장 — 도구를 모으기 **전에** await 해야 한다. 채팅 경로만 풀을 채우던
+            // 탓에, 프로세스 재시작 후 채팅 없이 바로 실행한 작업은 user MCP 도구가 0개인 채로
+            // 돌아 모델이 "MCP 서버 미설치"로 오판하고 포기했다. 멱등이라 재실행 비용은 없다.
+            await ensureUserMcpForTask(userId, taskId);
 
             // 역할 게이팅(채팅 경로와 동일) — 고위험 전역 도구(Python REPL 등)를 역할 미달 user 에게서 제거.
             const allTools = filterRestrictedTools((await mcp.getToolRouter().getLLMTools({


### PR DESCRIPTION
## 왜 — 유실된 브랜치에서 건져낸 실제 결함 2건

`origin/feat/mcp-server-delete-button`(2026-08-21~26, PR 없이 방치, main 대비 **158 커밋 뒤처짐**)의 10커밋을 main 과 대조한 결과 대부분이 **미반영**이었다. 그중 **지금도 운영에 살아 있는 결함 2건**을 충돌 없이 cherry-pick 했다.

### 1. 재시작 후 첫 에이전트 작업이 user MCP 도구 0개로 돈다 (`2bec2a84`)

`ensureUserServers` 를 부르는 곳이 **채팅 시작·로그인·도구 picker 뿐**이라, 프로세스 재시작 후 채팅 없이 바로 실행한 작업은 빈 풀 위에서 `getLLMTools` 를 호출했다. 그 결과 `mcp_list_tools` 가 "설치된 외부 MCP 서버가 없습니다" 를 반환하고, 모델은 **설치돼 있는 서버를 두고** "MCP 서버가 모두 설치되어 있지 않습니다" 라며 작업을 포기했다. 채팅을 먼저 한 뒤 실행하면 우연히 성공하던 이유가 이것이다.

**오늘 배포 직후 이 상태가 그대로 재현됐다** — 재시작 후 로그인 이벤트가 없어 user 서버 7종이 spawn 되지 않은 채였고, 수동 `/start` 로만 채워졌다.

- 도구를 모으기 **전에** `ensureUserMcpForTask` 를 **await** 한다. 채팅 경로(`emitChatStart`)는 fire-and-forget 이어도 다음 메시지에서 자연히 복구되지만, **일회성인 작업은 그 순간 비어 있으면 실행 내내 도구가 없다.** `safeSpawn` 멱등 가드가 있어 재실행 비용은 없다.
- `mcp_list_tools` 가 빈 풀을 "미설치" 로 **단정하지 않게** 한다. DB 기준 설치 여부를 확인해 "이번 실행에서 아직 준비되지 않았다" 와 "정말 없다" 를 구분해 안내한다(조회 실패는 기존 문구로 폴백).

### 2. 쿼터 초과 메시지가 단위를 틀리게 말한다 (`71c339a5`)

`user-quota.ts` 는 `LLM_HOURLY_TOKEN_LIMIT`/`LLM_WEEKLY_TOKEN_LIMIT`(**토큰 수**)로 검사하는데 에러 문구는 `... requests used` 였다. 요청 수 초과로 읽혀 **업스트림 프로바이더의 요청 쿼터 초과로 오진하기 쉬웠다.**

## 이 PR 에 넣지 않은 것 (같은 브랜치의 나머지 8커밋)

| 커밋 | 내용 | 판정 |
|---|---|---|
| `4c638549` | 커넥터 목록에서 MCP 등록 삭제 | **불필요** — main 이 `enabled` 토글(PR #617)로 이미 대체 |
| `7fbcb655` | 에이전트 작업 결과 가독성 UI (+393줄) | 규모가 커 별도 판단 필요 |
| `5f292977`·`b3be2d68` | 템플릿당 다중 명명 인스턴스 + 부팅 복원, 인스턴스 이름 지정/변경 | 스키마·라우트·UI 동반, 별도 판단 |
| `af4c5730` | 산출물을 아티팩트 갤러리에도 영속 | main 은 `step_type='artifact'` 까지만 — 부분 미반영 |
| `676a8185`·`dbce28cf`·`6aac779a` | .env 기반 포트 해석, 카탈로그 필드, 목표의 출력 형식 준수 | 미반영, 별도 판단 |

브랜치는 **삭제하지 않았다** — 위 8커밋이 유일한 사본이다.

## 검증

- jest **3,201 pass / 0 fail** · tsc · lint **0 error** · `eval:routing` 93.3% · `eval:response` 100%.
- cherry-pick 2건 모두 충돌 없음(158 커밋 차이에도 접점이 좁다).

## 체크리스트

- [x] `npm run lint` 통과 (0 error)
- [x] `npm test` 통과 (3,201 pass)
- [x] `eval:routing` · `eval:response` 통과
- [x] DB 스키마 변경 없음 · `.env.example` 변경 없음
- [x] 원저자 커밋(`iexcellodx`) 저작 정보 보존
- [x] 보안: 권한 경로 무변경 — `ensureUserServers` 는 해당 userId 의 서버만 spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbneZrk96Ct3eQHzVVPZve