### PR TITLE
feat: 유실 브랜치의 나머지 8커밋 전량 재이식 (다중 인스턴스·작업 결과 UI·포트 SSOT 등)

### DIFF
--- a/apps/api/src/__tests__/lifecycle-supervisor.test.ts
+++ b/apps/api/src/__tests__/lifecycle-supervisor.test.ts
@@ -7,6 +7,8 @@ interface MockRepo {
     decryptEnvForSpawn: jest.Mock;
     recordInstanceTransition: jest.Mock;
     getCatalogToolAllowlist: jest.Mock;
+    listAutoSpawnUserIds: jest.Mock;
+    closeOrphanInstances: jest.Mock;
 }
 
 function mkRepo(): MockRepo {
@@ -16,6 +18,8 @@ function mkRepo(): MockRepo {
         decryptEnvForSpawn: jest.fn().mockResolvedValue({}),
         recordInstanceTransition: jest.fn().mockResolvedValue(undefined),
         getCatalogToolAllowlist: jest.fn().mockResolvedValue(null),
+        listAutoSpawnUserIds: jest.fn().mockResolvedValue([]),
+        closeOrphanInstances: jest.fn().mockResolvedValue(0),
     };
 }
 

--- a/apps/api/src/data/repositories/mcp-catalog-repository.ts
+++ b/apps/api/src/data/repositories/mcp-catalog-repository.ts
@@ -173,6 +173,21 @@ export class McpCatalogRepository {
      *
      * @throws {Error} 허용되지 않은 키가 patch 에 포함된 경우 (라우터가 400 으로 변환)
      */
+    /**
+     * 서버 이름(=도구 네임스페이스) 변경. 소유자 검증은 라우터 책임.
+     * 같은 사용자 안에서 이름은 유일해야 한다(uniq_mcp_servers_user_name) — 충돌은 그대로
+     * throw 해 라우터가 409 로 변환한다.
+     */
+    async updateName(id: string, name: string): Promise<UserMcpServerRow | null> {
+        const r = await this.pool.query<UserMcpServerRow>(
+            `UPDATE mcp_servers SET name = $2, updated_at = NOW() WHERE id = $1
+             RETURNING id, user_id, name, transport_type, command, args, env, url,
+                       visibility, catalog_template_id, enabled, auto_spawn, created_at, updated_at`,
+            [id, name],
+        );
+        return r.rows[0] ? this.maskEnv(r.rows[0]) : null;
+    }
+
     async updateEnv(
         serverId: string,
         patch: Record<string, string>,
@@ -428,6 +443,33 @@ export class McpCatalogRepository {
             out.set(row.mcp_server_id, { message: row.last_error, at: row.started_at });
         }
         return out;
+    }
+
+    /**
+     * 프로세스 재시작 후 풀이 비어 있으므로, 이 사용자들의 서버를 다시 띄운다.
+     */
+    async listAutoSpawnUserIds(): Promise<string[]> {
+        const r = await this.pool.query<{ user_id: string }>(
+            `SELECT DISTINCT user_id FROM mcp_servers
+              WHERE user_id IS NOT NULL AND enabled = TRUE AND auto_spawn = TRUE`,
+        );
+        return r.rows.map(x => x.user_id);
+    }
+
+    /**
+     * 고아 instance 행 정리 — 프로세스가 죽으면 running/starting 행이 그대로 남는다
+     * (shutdownAll 은 풀만 닫고 전이를 기록하지 않으며, 강제 종료 시엔 그마저 못 남긴다).
+     * 부팅 시 1회 호출해 "직전 프로세스의 살아있던 인스턴스"를 stopped 로 마감한다.
+     * @returns 마감한 행 수
+     */
+    async closeOrphanInstances(): Promise<number> {
+        const r = await this.pool.query(
+            `UPDATE mcp_server_instances
+                SET status = 'stopped', stopped_at = NOW(),
+                    last_error = COALESCE(last_error, 'process restart')
+              WHERE status IN ('running', 'starting')`,
+        );
+        return r.rowCount ?? 0;
     }
 
     async recordInstanceTransition(

--- a/apps/api/src/mcp/lifecycle-supervisor.ts
+++ b/apps/api/src/mcp/lifecycle-supervisor.ts
@@ -43,7 +43,7 @@ export type ClientFactory = (config: ServerSpawnConfig) => ExternalMCPClient;
 
 export interface SupervisorDeps {
     userPool: UserMCPPool;
-    repo: Pick<McpCatalogRepository, 'listUserServers' | 'getServerById' | 'decryptEnvForSpawn' | 'recordInstanceTransition' | 'getCatalogToolAllowlist'>;
+    repo: Pick<McpCatalogRepository, 'listUserServers' | 'getServerById' | 'decryptEnvForSpawn' | 'recordInstanceTransition' | 'getCatalogToolAllowlist' | 'listAutoSpawnUserIds' | 'closeOrphanInstances'>;
     clientFactory: ClientFactory;
 }
 
@@ -56,6 +56,7 @@ export interface LifecycleSupervisor {
     spawnUserServer(userId: string, serverId: string): Promise<ExternalMCPClient>;
     killUserServer(userId: string, serverId: string): Promise<void>;
     getUserClient(userId: string, serverId: string): ExternalMCPClient | undefined;
+    restoreOnBoot(): Promise<void>;
     shutdownAll(): Promise<void>;
 }
 
@@ -184,8 +185,48 @@ export class MCPLifecycleSupervisor implements LifecycleSupervisor {
         return this.userPool.get(userId, serverId);
     }
 
+    /**
+     * 부팅 시 자동 복원 — 프로세스 재시작 후 user MCP 풀은 비어 있다. 종전에는 복원 경로가
+     * 없어 채팅 시작(onChatStart)·로그인 전까지 서버가 뜨지 않았고, 설정 화면이 계속
+     * "연결 끊김"으로 보였다(enabled/auto_spawn 은 저장돼 있는데도).
+     *
+     * 먼저 직전 프로세스의 고아 instance 행을 stopped 로 마감한 뒤, enabled+auto_spawn
+     * 서버를 가진 사용자별로 ensureUserServers 를 돌린다(멱등).
+     *
+     * MCP_RESTORE_ON_BOOT=false 로 끌 수 있다 — 사용자가 많아 부팅 시 자식 프로세스가
+     * 과도해지는 환경을 위한 opt-out. 실패는 기동을 막지 않는다.
+     */
+    async restoreOnBoot(): Promise<void> {
+        if (process.env.MCP_RESTORE_ON_BOOT === 'false') {
+            logger.info('restoreOnBoot: MCP_RESTORE_ON_BOOT=false — 건너뜀');
+            return;
+        }
+        try {
+            const closed = await this.repo.closeOrphanInstances();
+            if (closed > 0) logger.info(`restoreOnBoot: 고아 instance ${closed}건 stopped 로 마감`);
+
+            const userIds = await this.repo.listAutoSpawnUserIds();
+            if (userIds.length === 0) {
+                logger.info('restoreOnBoot: 복원 대상 사용자 없음');
+                return;
+            }
+            logger.info(`restoreOnBoot: 사용자 ${userIds.length}명 복원 시작`);
+            // 사용자별 순차 — 동시에 몰면 부팅 직후 자식 프로세스가 한꺼번에 뜬다.
+            for (const userId of userIds) {
+                await this.ensureUserServers(userId, 'boot').catch(e =>
+                    logger.warn(`restoreOnBoot 실패 u=${userId}: ${e instanceof Error ? e.message : String(e)}`));
+            }
+            logger.info('restoreOnBoot: 복원 완료');
+        } catch (e) {
+            logger.warn(`restoreOnBoot 실패(기동은 계속): ${e instanceof Error ? e.message : String(e)}`);
+        }
+    }
+
     async shutdownAll(): Promise<void> {
         logger.info(`shutdownAll: 전체 풀 정리 (size=${this.userPool.size()})`);
+        // 풀만 닫으면 instance 행이 running 인 채로 남아 이력이 거짓이 된다 —
+        // 다음 부팅의 closeOrphanInstances 가 보완하지만, graceful 종료에선 여기서 마감한다.
+        await this.repo.closeOrphanInstances().catch(() => { /* 이력 실패는 종료를 막지 않는다 */ });
         await this.userPool.closeAll();
     }
 

--- a/apps/api/src/prompts/agent-task-prompt.ts
+++ b/apps/api/src/prompts/agent-task-prompt.ts
@@ -46,11 +46,17 @@ export function getAgentTaskSystemPrompt(): string {
         '  document, draft, or code) — never a summary of what you did, a description of the',
         '  deliverable, or a promise to produce it.',
         '- Wrap the deliverable in an <artifact> tag so the user can view and download it:',
-        '  <artifact id="kebab-case-id" kind="markdown" title="Deliverable title">',
+        '  <artifact id="kebab-case-id" kind="KIND" title="Deliverable title">',
         '  ...full content here...',
         '  </artifact>',
-        '- kind: "markdown" for reports/documents/guides (default), "code" with lang="..."',
-        '  for source code, "html" for a standalone web page.',
+        // ⚠️ 예시의 kind 를 구체값으로 두지 말 것 — 예전에 kind="markdown" 을 하드코딩하고
+        //    "markdown ... (default)" 라고 적어두자, 사용자가 "html 로 보고서" 를 요청해도
+        //    모델이 그 기본값을 따라 markdown 아티팩트를 냈다. 형식 우선순위를 명시한다.
+        '- kind: "markdown" for reports/documents/guides, "code" with lang="..." for source',
+        '  code, "html" for a standalone web page.',
+        '- FORMAT PRIORITY: if the GOAL asks for a specific output format (e.g. "as HTML",',
+        '  "html 로", "make it a web page"), you MUST use that kind — it overrides the',
+        '  defaults above. Fall back to "markdown" only when the goal says nothing about format.',
         '- For kind="html": produce a self-contained semantic HTML5 page (inline <style>/<script>,',
         '  :root CSS-variable design tokens, responsive Flexbox/Grid layout, hover/focus states,',
         '  accessibility) with a deliberate design concept that fits the content.',

--- a/apps/api/src/routes/mcp-server-rename.ts
+++ b/apps/api/src/routes/mcp-server-rename.ts
@@ -1,0 +1,92 @@
+/**
+ * MCP 서버 이름 변경 핸들러 — `PATCH /api/mcp/servers/:id`.
+ *
+ * 이름은 곧 **도구 네임스페이스**(`name::tool`)이자 tool-merger 의 의도 매칭 키다. 같은
+ * 카탈로그 템플릿을 여러 접속처(예: 앱 DB용 / 분석 DB용 postgres)에 설치할 때 서로 구분하는
+ * 유일한 수단이라, 설치 후에도 바꿀 수 있어야 한다.
+ *
+ * `mcp.routes.ts` 가 600줄 가드에 닿아 라우트 본문만 여기로 분리했다(등록은 그쪽).
+ *
+ * ⚠️ 네임스페이스는 **spawn 시점에 굳는다** — 이름만 바꾸고 떠 있는 클라이언트를 두면 구
+ * 이름으로 도구가 계속 노출된다. 그래서 env 변경과 같은 이유로 풀/registry 에서 내려
+ * 다음 ensureUserServers 가 새 이름으로 respawn 하게 한다(`respawnRequired`).
+ *
+ * @module routes/mcp-server-rename
+ */
+import type { Request, Response } from 'express';
+import { getUnifiedDatabase } from '../data/models/unified-database';
+import { McpCatalogRepository } from '../data/repositories/mcp-catalog-repository';
+import { getUnifiedMCPClient } from '../mcp';
+import { getLifecycleSupervisor } from '../mcp/lifecycle-supervisor';
+import { getAuditService } from '../services/AuditService';
+import { canUpdateServerEnv } from './mcp-visibility';
+import { success, notFound, forbidden, badRequest } from '../utils/api-response';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('McpServerRename');
+
+/** 소유자 + admin 만 변경 가능(env 변경과 동일 기준 — 공유 대상자는 바꿀 수 없다). */
+export async function renameMcpServer(req: Request, res: Response): Promise<void> {
+    const userId = String(req.user?.id ?? '');
+    const role = req.user?.role ?? 'user';
+    const actor = { id: userId, role };
+    const { id } = req.params;
+    const { name } = req.body as { name: string };
+
+    const db = getUnifiedDatabase();
+    const repo = new McpCatalogRepository(db.getPool());
+    const server = await repo.getServerById(id);
+    if (!server) {
+        res.status(404).json(notFound('서버'));
+        return;
+    }
+    if (!canUpdateServerEnv(actor, server)) {
+        res.status(403).json(forbidden('해당 서버의 이름을 변경할 권한이 없습니다'));
+        return;
+    }
+    if (server.name === name) {
+        res.json(success({ server, respawnRequired: false }));
+        return;
+    }
+
+    let updated;
+    try {
+        updated = await repo.updateName(id, name);
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        // uniq_mcp_servers_user_name / uniq_mcp_servers_global_name 위반.
+        if (/duplicate key|unique/i.test(msg)) {
+            res.status(409).json(badRequest(`이미 "${name}" 이름의 서버가 있습니다`));
+            return;
+        }
+        throw e;
+    }
+    if (!updated) {
+        res.status(404).json(notFound('서버'));
+        return;
+    }
+
+    let respawnRequired = false;
+    if (server.user_id) {
+        const supervisor = getLifecycleSupervisor();
+        if (supervisor) {
+            respawnRequired = true;
+            await supervisor.killUserServer(String(server.user_id), id).catch((e: unknown) =>
+                logger.warn(`이름 변경 후 유저풀 정리 실패(변경은 유지): ${id}: ${e instanceof Error ? e.message : String(e)}`));
+        }
+    } else {
+        respawnRequired = true;
+        await getUnifiedMCPClient().getServerRegistry().disconnectServer(id).catch((e: unknown) =>
+            logger.warn(`이름 변경 후 전역 registry 정리 실패(변경은 유지): ${id}: ${e instanceof Error ? e.message : String(e)}`));
+    }
+
+    void getAuditService().logAudit({
+        action: 'mcp_server_rename',
+        userId,
+        resourceType: 'mcp_server',
+        resourceId: id,
+        details: { from: server.name, to: name },
+    }).catch(() => { /* audit 실패는 응답에 영향 없음 */ });
+
+    res.json(success({ server: updated, respawnRequired }));
+}

--- a/apps/api/src/routes/mcp.routes.ts
+++ b/apps/api/src/routes/mcp.routes.ts
@@ -37,7 +37,7 @@ import { createLogger } from '../utils/logger';
 import { classifyConnectError, parseConnectError } from '../mcp/connect-error';
 import { validate } from '../middlewares/validation';
 import { mcpToolExecuteSchema, mcpServerCreateSchema, mcpServerEnvUpdateSchema,
-    mcpServerEnabledUpdateSchema, mcpServerAutoSpawnUpdateSchema } from '../schemas/mcp.schema';
+    mcpServerEnabledUpdateSchema, mcpServerAutoSpawnUpdateSchema, mcpServerRenameSchema } from '../schemas/mcp.schema';
 import { McpCatalogRepository } from '../data/repositories/mcp-catalog-repository';
 import { McpOAuthRepository } from '../data/repositories/mcp-oauth-repository';
 import { canRegisterServer, canViewServer, canDeleteServer, canStartStopServer, canUpdateServerEnv } from './mcp-visibility';
@@ -271,6 +271,79 @@ export const mcpRouter = Router();
       const registry = getUnifiedMCPClient().getServerRegistry();
       await registry.unregisterServer(id, db);
       res.json(success({ deleted: true }));
+  }));
+
+  // 서버 이름 변경 (PATCH) — 소유자 + admin.
+  //
+  // 이름은 도구 네임스페이스(name::tool)이자 tool-merger 의 의도 매칭 키다. 같은 카탈로그
+  // 템플릿을 여러 접속처(예: 앱 DB용 / 분석 DB용 postgres)에 설치할 때 서로 구분하는 유일한
+  // 수단이라, 설치 후에도 바꿀 수 있어야 한다.
+  mcpRouter.patch('/servers/:id', requireAuth, validate(mcpServerRenameSchema), asyncHandler(async (req: Request, res: Response) => {
+      const userId = String(req.user?.id ?? '');
+      const role = req.user?.role ?? 'user';
+      const actor = { id: userId, role };
+      const { id } = req.params;
+      const { name } = req.body as { name: string };
+
+      const db = getUnifiedDatabase();
+      const repo = new McpCatalogRepository(db.getPool());
+      const server = await repo.getServerById(id);
+      if (!server) {
+          res.status(404).json(notFound('서버'));
+          return;
+      }
+      // 이름 변경 권한은 env 변경과 동일 기준(소유자 + admin) — 공유 대상자는 바꿀 수 없다.
+      if (!canUpdateServerEnv(actor, server)) {
+          res.status(403).json(forbidden('해당 서버의 이름을 변경할 권한이 없습니다'));
+          return;
+      }
+      if (server.name === name) {
+          res.json(success({ server, respawnRequired: false }));
+          return;
+      }
+
+      let updated;
+      try {
+          updated = await repo.updateName(id, name);
+      } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          // uniq_mcp_servers_user_name / uniq_mcp_servers_global_name 위반.
+          if (/duplicate key|unique/i.test(msg)) {
+              res.status(409).json(badRequest(`이미 "${name}" 이름의 서버가 있습니다`));
+              return;
+          }
+          throw e;
+      }
+      if (!updated) {
+          res.status(404).json(notFound('서버'));
+          return;
+      }
+
+      // 떠 있는 클라이언트는 구 이름으로 도구를 노출한다(네임스페이스가 spawn 시점에 굳는다).
+      // env 변경과 같은 이유로 풀에서 내려 다음 ensureUserServers 가 새 이름으로 respawn 하게 한다.
+      let respawnRequired = false;
+      if (server.user_id) {
+          const supervisor = getLifecycleSupervisor();
+          if (supervisor) {
+              respawnRequired = true;
+              await supervisor.killUserServer(String(server.user_id), id).catch((e: unknown) =>
+                  logger.warn(`이름 변경 후 유저풀 정리 실패(변경은 유지): ${id}: ${e instanceof Error ? e.message : String(e)}`));
+          }
+      } else {
+          respawnRequired = true;
+          await getUnifiedMCPClient().getServerRegistry().disconnectServer(id).catch((e: unknown) =>
+              logger.warn(`이름 변경 후 전역 registry 정리 실패(변경은 유지): ${id}: ${e instanceof Error ? e.message : String(e)}`));
+      }
+
+      void getAuditService().logAudit({
+          action: 'mcp_server_rename',
+          userId,
+          resourceType: 'mcp_server',
+          resourceId: id,
+          details: { from: server.name, to: name },
+      }).catch(() => { /* audit 실패는 응답에 영향 없음 */ });
+
+      res.json(success({ server: updated, respawnRequired }));
   }));
 
   // env(자격증명) 교체 (PATCH) — 소유자 + admin.

--- a/apps/api/src/routes/mcp.routes.ts
+++ b/apps/api/src/routes/mcp.routes.ts
@@ -42,6 +42,7 @@ import { McpCatalogRepository } from '../data/repositories/mcp-catalog-repositor
 import { McpOAuthRepository } from '../data/repositories/mcp-oauth-repository';
 import { canRegisterServer, canViewServer, canDeleteServer, canStartStopServer, canUpdateServerEnv } from './mcp-visibility';
 import { connectGlobalServer } from './mcp-global-connect';
+import { renameMcpServer } from './mcp-server-rename';
 import { getAuditService } from '../services/AuditService';
 import { validateOutboundUrl } from '../security/ssrf-guard';
 
@@ -273,78 +274,8 @@ export const mcpRouter = Router();
       res.json(success({ deleted: true }));
   }));
 
-  // 서버 이름 변경 (PATCH) — 소유자 + admin.
-  //
-  // 이름은 도구 네임스페이스(name::tool)이자 tool-merger 의 의도 매칭 키다. 같은 카탈로그
-  // 템플릿을 여러 접속처(예: 앱 DB용 / 분석 DB용 postgres)에 설치할 때 서로 구분하는 유일한
-  // 수단이라, 설치 후에도 바꿀 수 있어야 한다.
-  mcpRouter.patch('/servers/:id', requireAuth, validate(mcpServerRenameSchema), asyncHandler(async (req: Request, res: Response) => {
-      const userId = String(req.user?.id ?? '');
-      const role = req.user?.role ?? 'user';
-      const actor = { id: userId, role };
-      const { id } = req.params;
-      const { name } = req.body as { name: string };
-
-      const db = getUnifiedDatabase();
-      const repo = new McpCatalogRepository(db.getPool());
-      const server = await repo.getServerById(id);
-      if (!server) {
-          res.status(404).json(notFound('서버'));
-          return;
-      }
-      // 이름 변경 권한은 env 변경과 동일 기준(소유자 + admin) — 공유 대상자는 바꿀 수 없다.
-      if (!canUpdateServerEnv(actor, server)) {
-          res.status(403).json(forbidden('해당 서버의 이름을 변경할 권한이 없습니다'));
-          return;
-      }
-      if (server.name === name) {
-          res.json(success({ server, respawnRequired: false }));
-          return;
-      }
-
-      let updated;
-      try {
-          updated = await repo.updateName(id, name);
-      } catch (e) {
-          const msg = e instanceof Error ? e.message : String(e);
-          // uniq_mcp_servers_user_name / uniq_mcp_servers_global_name 위반.
-          if (/duplicate key|unique/i.test(msg)) {
-              res.status(409).json(badRequest(`이미 "${name}" 이름의 서버가 있습니다`));
-              return;
-          }
-          throw e;
-      }
-      if (!updated) {
-          res.status(404).json(notFound('서버'));
-          return;
-      }
-
-      // 떠 있는 클라이언트는 구 이름으로 도구를 노출한다(네임스페이스가 spawn 시점에 굳는다).
-      // env 변경과 같은 이유로 풀에서 내려 다음 ensureUserServers 가 새 이름으로 respawn 하게 한다.
-      let respawnRequired = false;
-      if (server.user_id) {
-          const supervisor = getLifecycleSupervisor();
-          if (supervisor) {
-              respawnRequired = true;
-              await supervisor.killUserServer(String(server.user_id), id).catch((e: unknown) =>
-                  logger.warn(`이름 변경 후 유저풀 정리 실패(변경은 유지): ${id}: ${e instanceof Error ? e.message : String(e)}`));
-          }
-      } else {
-          respawnRequired = true;
-          await getUnifiedMCPClient().getServerRegistry().disconnectServer(id).catch((e: unknown) =>
-              logger.warn(`이름 변경 후 전역 registry 정리 실패(변경은 유지): ${id}: ${e instanceof Error ? e.message : String(e)}`));
-      }
-
-      void getAuditService().logAudit({
-          action: 'mcp_server_rename',
-          userId,
-          resourceType: 'mcp_server',
-          resourceId: id,
-          details: { from: server.name, to: name },
-      }).catch(() => { /* audit 실패는 응답에 영향 없음 */ });
-
-      res.json(success({ server: updated, respawnRequired }));
-  }));
+  // 서버 이름 변경 (PATCH) — 소유자 + admin. 본문은 mcp-server-rename.ts (600줄 가드로 분리).
+  mcpRouter.patch('/servers/:id', requireAuth, validate(mcpServerRenameSchema), asyncHandler(renameMcpServer));
 
   // env(자격증명) 교체 (PATCH) — 소유자 + admin.
   // 로테이션 전용 부분 갱신: 전달한 키만 바뀌고 나머지는 보존된다. secret 값은 저장 시

--- a/apps/api/src/schemas/mcp.schema.ts
+++ b/apps/api/src/schemas/mcp.schema.ts
@@ -94,6 +94,23 @@ export const mcpServerAutoSpawnUpdateSchema = z.object({
     auto_spawn: z.boolean(),
 });
 
+/**
+ * 서버 이름 변경 요청 스키마.
+ *
+ * 이름은 곧 **도구 네임스페이스**(displayName::tool)이자 tool-merger 의 의도 매칭 키다.
+ * 같은 카탈로그 템플릿을 여러 접속처에 설치할 때 서로 구분하는 유일한 수단이라, 설치 후에도
+ * 바꿀 수 있어야 한다. 문자 집합은 from-catalog 의 name 과 동일하게 제한한다 —
+ * 네임스페이스 구분자·셸 인자 오염을 막기 위함.
+ */
+export const mcpServerRenameSchema = z.object({
+    name: z.string().min(1).max(128).regex(/^[a-zA-Z0-9_-]+$/, {
+        message: 'name 은 영숫자/언더스코어/하이픈만 허용',
+    }),
+});
+
+/** MCP 서버 이름 변경 요청 TypeScript 타입 */
+export type McpServerRenameInput = z.infer<typeof mcpServerRenameSchema>;
+
 /** MCP 도구 실행 요청 TypeScript 타입 */
 export type McpToolExecuteInput = z.infer<typeof mcpToolExecuteSchema>;
 /** MCP 서버 등록 요청 TypeScript 타입 */

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -369,6 +369,9 @@ export class DashboardServer {
             });
             setLifecycleSupervisor(supervisor);
             console.log('✅ MCP Lifecycle Supervisor 초기화 완료');
+            // 재시작 후 user MCP 풀은 비어 있다 — enabled+auto_spawn 서버를 다시 띄운다.
+            // 기동을 막지 않도록 await 하지 않는다(자식 프로세스 spawn 이 수 초 걸린다).
+            void supervisor.restoreOnBoot();
         } catch (err) {
             console.error('⚠️  MCP Lifecycle Supervisor 초기화 실패 (graceful skip):', err);
         }

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -547,7 +547,7 @@ export class AgentTaskService {
             const lastAssistant = [...conversation].reverse().find((m) => m.role === 'assistant');
             const lastRaw = (lastAssistant?.content as string) || '(최대 턴에 도달하여 종료되었습니다.)';
             const lastExtracted = extractAndStripArtifacts(applyReportRender(lastRaw));
-            stepNumber = await persistArtifactSteps(taskId, lastExtracted.artifacts, stepNumber);
+            stepNumber = await persistArtifactSteps(taskId, lastExtracted.artifacts, stepNumber, userId);
             stepNumber = await maybePersistCodeDiff(taskRuntime, sandboxCfg, taskId, stepNumber, emitStep);
             await update({
                 status: 'failed',

--- a/apps/api/src/services/agent-task/finalize.ts
+++ b/apps/api/src/services/agent-task/finalize.ts
@@ -166,7 +166,7 @@ export async function finalizeTask(input: FinalizeInput): Promise<FinalizeOutcom
     }
 
     // 4. 산출물 영속 후 완료.
-    stepNumber = await persistArtifactSteps(taskId, artifacts, stepNumber);
+    stepNumber = await persistArtifactSteps(taskId, artifacts, stepNumber, userId);
     stepNumber = await maybePersistCodeDiff(taskRuntime, sandboxCfg, taskId, stepNumber, emitStep);
     await update({
         status: 'completed',

--- a/apps/api/src/services/agent-task/skill-block.ts
+++ b/apps/api/src/services/agent-task/skill-block.ts
@@ -11,6 +11,7 @@ import { REPORT_PIPELINE, REPORT_INTENT_PATTERNS } from '../../config/runtime-li
 import { buildLearningBlock } from './task-learning';
 import { buildProceduralSkillBlock } from './procedural-skill';
 import { buildUserMemoryBlock } from '../chat-service/user-context-blocks';
+import { buildArtifactGuideBlock } from '../chat-service/artifact-guide-block';
 import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('AgentTaskService');
@@ -46,11 +47,18 @@ export async function buildAgentTaskSystemContent(userId: string, goal: string, 
     const memory = userId && userId !== 'guest' ? await buildUserMemoryBlock(userId) : '';
     // 보고서 파이프라인 (P1 Phase 2): goal 이 보고서 의도면 reportdata 계약 가이드를 주입한다.
     // 최종 답변의 reportdata 블록은 AgentTaskService 가 applyReportRender 로 렌더해 아티팩트화.
+    const goalLang = /[가-힣]/.test(goal) ? 'ko' : 'en';
     const reportGuide = REPORT_PIPELINE.ENABLED && REPORT_INTENT_PATTERNS.some((re) => re.test(goal))
-        ? getReportGuideForTask(/[가-힣]/.test(goal) ? 'ko' : 'en')
+        ? getReportGuideForTask(goalLang)
         : '';
     if (reportGuide) logger.info(`[AgentTask] 보고서 의도 goal — reportdata 계약 가이드 주입: ${taskId}`);
+    // 아티팩트 가이드 — 채팅 경로(message-pipeline)와 동일한 블록을 공유한다.
+    // 이전에는 agent-task-prompt 의 짧은 요약 규칙만 받아, html 디자인 규칙(디자인 토큰·
+    // 시멘틱 마크업·반응형)이 에이전트 작업 산출물에는 적용되지 않았다.
+    // 사용자의 artifacts_enabled=false 는 buildArtifactGuideBlock 이 ''를 반환해 그대로 존중된다.
+    const artifactGuide = await buildArtifactGuideBlock(userId, goalLang);
     return getAgentTaskSystemPrompt()
+        + artifactGuide
         + reportGuide
         + memory
         + (await buildSkillPromptBlock(userId))

--- a/apps/api/src/services/agent-task/task-steps.ts
+++ b/apps/api/src/services/agent-task/task-steps.ts
@@ -6,6 +6,7 @@ import { getUnifiedDatabase } from '../../data/models/unified-database';
 import { getUnifiedMCPClient } from '../../mcp/unified-client';
 import type { UserContext } from '../../mcp/user-sandbox';
 import type { ExtractedArtifact } from '../../llm/artifact-parser';
+import type { ArtifactKind } from '../../data/repositories/artifact-repository';
 import { takeReportSource } from '../chat-service/report-block';
 import { MAX_TOOL_RESULT_CHARS, AGENT_TASK_LIMITS } from '../../config/runtime-limits';
 import { recordToolResultTruncation } from '../tool-result-truncation-recorder';
@@ -20,22 +21,40 @@ export function isSearchTool(name: string): boolean {
 }
 
 /**
- * 최종 답변에서 추출한 deliverable 아티팩트를 step_type='artifact' 행으로 영속화.
- * content 는 ExtractedArtifact JSON (id/kind/title/lang/content) — 프론트 상세 모달이 파싱해 렌더.
- * 저장 실패는 작업을 실패시키지 않는다 (result 본문은 이미 보존됨).
+ * Agent Task 아티팩트의 합성 session_id — 채팅 세션과 네임스페이스를 분리한다.
+ * artifacts 테이블은 session_id NOT NULL 이고 (session_id, artifact_id, version) 이 유니크라,
+ * task 별로 고유한 값을 주면 스키마 변경 없이 같은 저장소를 공유할 수 있다.
+ */
+export function taskArtifactSessionId(taskId: string): string {
+    return `task:${taskId}`;
+}
+
+/**
+ * 최종 답변에서 추출한 deliverable 아티팩트를 영속화한다 — 두 곳에 저장한다:
+ *
+ *   1. agent_task_steps(step_type='artifact') — 작업 타임라인 표시용(기존 동작).
+ *   2. artifacts 테이블 — 채팅 산출물과 같은 아티팩트 갤러리에 노출.
+ *
+ * 2가 없던 동안 에이전트 작업 산출물은 갤러리에 아예 나타나지 않아, 작업 상세 모달의
+ * 스텝 타임라인에서 원시 JSON 을 4,000자만 잘라 보는 것 외에는 확인할 방법이 없었다.
+ * listLatestByUser 가 user_id 기준이라 합성 session_id 로도 갤러리에 정상 노출된다.
+ *
+ * 저장 실패는 작업을 실패시키지 않는다 (result 본문은 이미 보존됨). 두 저장은 서로
+ * 독립적으로 try 한다 — 갤러리 저장이 실패해도 타임라인 스텝은 남는다.
  */
 export async function persistArtifactSteps(
     taskId: string,
     artifacts: ExtractedArtifact[],
-    stepNumber: number
+    stepNumber: number,
+    userId?: string,
 ): Promise<number> {
     const db = getUnifiedDatabase();
     for (const artifact of artifacts) {
+        // 보고서 아티팩트면 reportdata 원본을 함께 보존 — docx 등 구조 기반 export 용.
+        // take 는 1회 회수(렌더 대기열 pendingReportSources 정리를 겸함)라 루프 선두에서
+        // 한 번만 꺼내 스텝 JSON 과 갤러리 row 양쪽에 쓴다.
+        const sourceData = takeReportSource(artifact.id);
         try {
-            // 보고서 아티팩트면 reportdata 원본을 스텝 JSON 에 동봉 — task 아티팩트의
-            // docx export 용(채팅 경로의 artifacts.source_data 대응물). 회수(take)로
-            // 렌더 대기열(pendingReportSources)의 잔존도 함께 정리된다.
-            const sourceData = takeReportSource(artifact.id);
             await db.addAgentTaskStep({
                 taskId,
                 stepNumber: stepNumber++,
@@ -45,6 +64,33 @@ export async function persistArtifactSteps(
             });
         } catch (e) {
             logger.warn(`[AgentTask] 아티팩트 스텝 저장 실패: ${taskId} — ${e}`);
+        }
+
+        // 갤러리 노출용 — 스텝 저장과 독립. 20MB 초과(ArtifactSizeError) 등은 warn 만 남긴다.
+        try {
+            const { ArtifactRepository } = await import('../../data/repositories/artifact-repository');
+            const { getPool } = await import('../../data/models/unified-database');
+            // artifacts.session_id 는 conversation_sessions(id) 를 참조하는 FK 다 — 합성 세션 행을
+            // 먼저 만들어 두지 않으면 insert 가 통째로 실패한다. 메시지가 없는 세션이라
+            // 채팅 목록에는 뜨지 않는다(getSessionsByUserId 가 conversation_messages EXISTS 로 거른다).
+            await getPool().query(
+                `INSERT INTO conversation_sessions (id, user_id, title)
+                 VALUES ($1, $2, $3) ON CONFLICT (id) DO NOTHING`,
+                [taskArtifactSessionId(taskId), userId ?? null, `[task] ${artifact.title}`.slice(0, 200)],
+            );
+            await new ArtifactRepository(getPool()).insertArtifact({
+                artifactId: artifact.id,
+                sessionId: taskArtifactSessionId(taskId),
+                userId: userId ?? null,
+                // 채팅 경로(request-handler)와 동일 — 파서의 kind 는 string 이라 캐스팅한다.
+                kind: artifact.kind as ArtifactKind,
+                title: artifact.title,
+                language: artifact.lang ?? null,
+                content: artifact.content,
+                ...(sourceData ? { sourceData } : {}),
+            });
+        } catch (e) {
+            logger.warn(`[AgentTask] 아티팩트 갤러리 저장 실패: ${taskId} — ${e}`);
         }
     }
     return stepNumber;

--- a/apps/web/app/(workspace)/admin/mcp-catalog/page.tsx
+++ b/apps/web/app/(workspace)/admin/mcp-catalog/page.tsx
@@ -24,10 +24,10 @@ interface CatalogTemplate {
   display_name: string;
   description?: string;
   transport_type: TransportType;
-  command?: string;
-  args?: string[];
-  env?: Record<string, string>;
-  url?: string;
+  command_template?: string | null;
+  args_schema?: Record<string, unknown>;
+  env_schema?: Record<string, unknown>;
+  url_template?: string | null;
   is_enabled: boolean;
 }
 
@@ -82,8 +82,8 @@ function TemplateFormModal({ initial, onClose, onSaved }: TemplateFormProps) {
   const [displayName, setDisplayName] = useState(initial?.display_name ?? "");
   const [description, setDescription] = useState(initial?.description ?? "");
   const [transportType, setTransportType] = useState<TransportType>(initial?.transport_type ?? "stdio");
-  const [command, setCommand] = useState(initial?.command ?? "");
-  const [url, setUrl] = useState(initial?.url ?? "");
+  const [command, setCommand] = useState(initial?.command_template ?? "");
+  const [url, setUrl] = useState(initial?.url_template ?? "");
   const [isEnabled, setIsEnabled] = useState(initial?.is_enabled ?? true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
@@ -97,8 +97,8 @@ function TemplateFormModal({ initial, onClose, onSaved }: TemplateFormProps) {
         display_name: displayName,
         description: description || undefined,
         transport_type: transportType,
-        command: command || undefined,
-        url: url || undefined,
+        command_template: command || undefined,
+        url_template: url || undefined,
         is_enabled: isEnabled,
       };
       if (isEdit && initial) {
@@ -130,6 +130,9 @@ function TemplateFormModal({ initial, onClose, onSaved }: TemplateFormProps) {
               value={id}
               onChange={(e) => setId(e.target.value)}
               placeholder="mcp-my-server"
+              /* 서버 스키마(createCatalogTemplateSchema)와 동일한 제약 — 어긋나면 400 */
+              pattern="mcp-[a-z0-9][a-z0-9-]*"
+              title='"mcp-" 로 시작하는 소문자/숫자/하이픈만 허용'
             />
           </div>
         )}

--- a/apps/web/app/(workspace)/agent-tasks/page.tsx
+++ b/apps/web/app/(workspace)/agent-tasks/page.tsx
@@ -21,8 +21,12 @@ import {
   CircleDot,
   CircleCheck,
   CircleX,
+  Download,
+  ExternalLink,
+  Eye,
   type LucideIcon,
 } from "lucide-react";
+import { ArtifactFrame } from "@/components/chat/artifact-frame";
 import {
   Button,
   Badge,
@@ -98,6 +102,8 @@ interface ApiAgentTask {
   folder_rel?: string | null;
   /** 실패 사유 (toPublicTask 가 노출하는 error 컬럼) */
   error?: string;
+  /** 최종 답변 본문 — toPublicTask 가 ...rest 로 그대로 노출한다(취소 작업은 null). */
+  result?: string | null;
   /** 소유자 (toPublicTask 가 user_id 그대로 노출 — admin viewAll 에서 소유자 뱃지용) */
   user_id?: string | number;
 }
@@ -199,7 +205,9 @@ function mapTask(tr: TFn, t: ApiAgentTask): AgentTask {
 }
 
 /** 실패 사유 코드 — i18n 번역 대상. 그 외 값은 자유 텍스트로 원문 표시. */
-const KNOWN_ERROR_CODES = new Set(["goal_incomplete", "max_turns_exhausted", "interrupted"]);
+// "aborted" 는 사용자 취소 시 error 컬럼에 들어간다 — 번역 대상에 없어 원문이 그대로
+// 노출되고 있었다(결과 블록이 취소 사유를 표시하면서 드러남).
+const KNOWN_ERROR_CODES = new Set(["goal_incomplete", "max_turns_exhausted", "interrupted", "aborted"]);
 /** 재개 가능한 사유 — resume 버튼과 시각적으로 연결. */
 const RESUMABLE_ERROR_CODES = new Set(["max_turns_exhausted", "interrupted"]);
 
@@ -248,6 +256,304 @@ function Modal({
         </div>
         <div className="p-5">{children}</div>
       </div>
+    </div>
+  );
+}
+
+/* ── 아티팩트 스텝 뷰 ──────────────────────────────────────
+ * 에이전트 작업의 산출물은 step_type='artifact' 스텝에 ExtractedArtifact JSON 으로 실려 온다.
+ * 일반 스텝과 같이 4,000자로 잘라 원시 JSON 을 보여주면 산출물을 확인할 수 없어(실측 16KB
+ * HTML 이 1/4 지점에서 절단) 전용 뷰로 분리한다 — 제목·종류 헤더 + 본문 전체 + 다운로드/열기.
+ */
+interface StepArtifact {
+  id: string;
+  kind: string;
+  title: string;
+  lang?: string | null;
+  content: string;
+}
+
+/** 스텝 content(JSON 문자열)를 아티팩트로 파싱 — 형식이 다르면 null(일반 스텝으로 폴백). */
+function parseStepArtifact(raw: string): StepArtifact | null {
+  try {
+    const o = JSON.parse(raw) as Partial<StepArtifact>;
+    if (typeof o?.content !== "string" || typeof o?.kind !== "string") return null;
+    return {
+      id: typeof o.id === "string" ? o.id : "artifact",
+      kind: o.kind,
+      title: typeof o.title === "string" ? o.title : "artifact",
+      lang: o.lang ?? null,
+      content: o.content,
+    };
+  } catch {
+    return null;
+  }
+}
+
+const ARTIFACT_MIME: Record<string, string> = {
+  html: "text/html",
+  svg: "image/svg+xml",
+  markdown: "text/markdown",
+  csv: "text/csv",
+};
+
+function ArtifactStepView({ artifact }: { artifact: StepArtifact }) {
+  const t = useTranslations("agentTasks");
+  const [open, setOpen] = useState(false);
+  const mime = ARTIFACT_MIME[artifact.kind] ?? "text/plain";
+  const ext = artifact.kind === "markdown" ? "md" : artifact.kind === "code" ? (artifact.lang || "txt") : artifact.kind;
+
+  // Blob URL 은 클릭 시점에만 만들고 즉시 해제 — 모달 수명 동안 누수되지 않게 한다.
+  const withBlobUrl = (fn: (url: string) => void) => {
+    const url = URL.createObjectURL(new Blob([artifact.content], { type: `${mime};charset=utf-8` }));
+    fn(url);
+    setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  };
+  const download = () => withBlobUrl((url) => {
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${artifact.id}.${ext}`;
+    a.click();
+  });
+  const openTab = () => withBlobUrl((url) => window.open(url, "_blank", "noopener"));
+
+  return (
+    <div className="mt-1 rounded-md border border-accent/40 bg-surface-2">
+      <div className="flex flex-wrap items-center gap-2 border-b border-border px-2 py-1.5">
+        <Badge tone="accent">{artifact.kind}</Badge>
+        <span className="min-w-0 flex-1 truncate text-xs font-medium text-fg">{artifact.title}</span>
+        <span className="text-[11px] text-muted">
+          {t("artifactSize", { chars: artifact.content.length })}
+        </span>
+        {(artifact.kind === "html" || artifact.kind === "svg") && (
+          <Button size="sm" variant="outline" onClick={openTab} title={t("artifactOpen")}>
+            <ExternalLink className="h-3.5 w-3.5" />
+          </Button>
+        )}
+        <Button size="sm" variant="outline" onClick={download} title={t("artifactDownload")}>
+          <Download className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      {/* 본문은 잘리지 않는다 — 기본은 접어 두고 토글로 전체를 연다. */}
+      <pre
+        className={`overflow-auto whitespace-pre-wrap break-words px-2 py-1.5 font-mono text-[11px] leading-relaxed text-muted ${
+          open ? "max-h-[32rem]" : "max-h-32"
+        }`}
+      >
+        {artifact.content}
+      </pre>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full border-t border-border px-2 py-1 text-[11px] text-accent hover:bg-surface"
+      >
+        {open ? t("templates.collapse") : t("templates.expand")}
+      </button>
+    </div>
+  );
+}
+
+/* ── 프롬프트(goal) 블록 ───────────────────────────────────
+ * goal 은 역할·절차·제약이 담긴 여러 줄 프롬프트다(실측 96줄). 일반 <p> 로 렌더하면
+ * HTML 이 줄바꿈을 공백으로 접어 한 문단이 되어 구조를 읽을 수 없다 → 줄바꿈을 보존하되
+ * 기본은 접어 두고 토글로 전체를 연다.
+ */
+function GoalBlock({ goal }: { goal: string }) {
+  const t = useTranslations("agentTasks");
+  const [open, setOpen] = useState(false);
+  const multiline = goal.includes("\n") || goal.length > 200;
+  return (
+    <>
+      <pre
+        className={`whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-fg ${
+          open ? "max-h-[28rem] overflow-auto" : "line-clamp-4"
+        }`}
+      >
+        {goal}
+      </pre>
+      {multiline && (
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="mt-1 text-[11px] text-accent hover:underline"
+        >
+          {open ? t("templates.collapse") : t("templates.expand")}
+        </button>
+      )}
+    </>
+  );
+}
+
+/* ── 산출물 미리보기 모달 ──────────────────────────────────
+ * 이력 카드에서 상세 모달·타임라인을 거치지 않고 산출물만 바로 확인한다.
+ * 아티팩트는 갤러리와 같은 저장소(artifacts, session_id='task:<id>')에서 읽으므로
+ * 채팅 산출물과 동일한 엔드포인트를 그대로 쓴다.
+ */
+interface ApiArtifactRow {
+  artifact_id: string;
+  version: number;
+  kind: string;
+  title: string;
+  language: string | null;
+  content: string;
+}
+type SessionArtifactsResponse = ApiSuccess<{ artifacts: ApiArtifactRow[]; total: number }>;
+
+/** html·svg 는 라이브 렌더, 그 외는 원문 텍스트. */
+const RENDERABLE_KINDS = new Set(["html", "svg"]);
+
+function PreviewModal({ taskId, onClose }: { taskId: string; onClose: () => void }) {
+  const t = useTranslations("agentTasks");
+  const [rows, setRows] = useState<ApiArtifactRow[] | null>(null);
+  const [sel, setSel] = useState(0);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const sid = encodeURIComponent(`task:${taskId}`);
+        const r = await ApiClient.get<SessionArtifactsResponse>(`/api/sessions/${sid}/artifacts`);
+        if (!cancelled) setRows(r?.data?.artifacts ?? []);
+      } catch {
+        if (!cancelled) { setRows([]); setFailed(true); }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [taskId]);
+
+  const cur = rows?.[sel];
+  return (
+    <Modal open onClose={onClose} title={t("previewTitle")}>
+      {rows === null ? (
+        <div className="flex justify-center py-10"><LoaderCircle className="h-5 w-5 animate-spin text-muted" /></div>
+      ) : rows.length === 0 ? (
+        <p className="py-8 text-center text-sm text-muted">
+          {failed ? t("previewLoadError") : t("previewEmpty")}
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {/* 산출물이 여러 개면 탭으로 전환 */}
+          {rows.length > 1 && (
+            <div className="flex flex-wrap gap-1">
+              {rows.map((a, i) => (
+                <button
+                  key={`${a.artifact_id}-${i}`}
+                  type="button"
+                  onClick={() => setSel(i)}
+                  className={`rounded-md border px-2 py-1 text-xs ${
+                    i === sel ? "border-accent bg-accent-soft text-accent" : "border-border text-muted hover:bg-surface-2"
+                  }`}
+                >
+                  {a.title}
+                </button>
+              ))}
+            </div>
+          )}
+          {cur && (
+            <>
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge tone="accent">{cur.kind}</Badge>
+                <span className="min-w-0 flex-1 truncate text-sm font-medium text-fg">{cur.title}</span>
+                <span className="text-[11px] text-muted">{t("artifactSize", { chars: cur.content.length })}</span>
+              </div>
+              {RENDERABLE_KINDS.has(cur.kind) ? (
+                // ArtifactFrame: sandbox="allow-scripts" (allow-same-origin 없음) 로 격리 렌더.
+                <div className="h-[70vh] overflow-hidden rounded-md border border-border">
+                  <ArtifactFrame srcDoc={cur.content} title={cur.title} />
+                </div>
+              ) : (
+                <pre className="max-h-[70vh] overflow-auto whitespace-pre-wrap break-words rounded-md border border-border bg-surface-2 p-3 font-mono text-xs leading-relaxed text-fg-2">
+                  {cur.content}
+                </pre>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+/* ── 결과 블록 ─────────────────────────────────────────────
+ * 종료된 작업(완료/실패/취소)의 결말을 모달 상단에 모아 보여준다. 예전에는 결말이
+ * 스텝 타임라인 맨 아래에 원시 텍스트로 섞여 있어, 성공했는지·왜 끝났는지·산출물이
+ * 무엇인지 확인하려면 수십 개 스텝을 스크롤해야 했다.
+ *   - 완료      → success 뱃지 + 최종 답변 + 산출물(아티팩트) 카드
+ *   - 취소/실패 → warn/danger 뱃지 + 종료 사유 + 남은 본문(있으면)
+ */
+function ResultBlock({ task, steps }: { task: ApiAgentTask; steps: ApiTaskStep[] }) {
+  const t = useTranslations("agentTasks");
+  const [open, setOpen] = useState(false);
+
+  const terminal = task.status === "completed" || task.status === "failed" || task.status === "cancelled";
+  if (!terminal) return null;
+
+  const tone = task.status === "completed" ? "success" : task.status === "cancelled" ? "warn" : "danger";
+  const labelKey = task.status === "completed" ? "status.completed"
+    : task.status === "cancelled" ? "cancelledTag" : "failedTag";
+
+  // 타임라인의 아티팩트 스텝을 결과 영역으로 끌어올린다 — 산출물이 결말의 핵심이다.
+  const artifacts = steps
+    .filter((st) => (st.step_type ?? st.type) === "artifact")
+    .map((st) => parseStepArtifact(st.tool_output || st.content || ""))
+    .filter((a): a is StepArtifact => a !== null);
+
+  const body = (task.result ?? "").trim();
+
+  return (
+    <div className="rounded-md border border-border bg-surface-1 p-3">
+      <div className="mb-2 flex flex-wrap items-center gap-2">
+        <Badge tone={tone}>{t(labelKey)}</Badge>
+        <span className="text-xs font-medium text-fg-2">{t("resultLabel")}</span>
+        {/* 종료 사유는 실패뿐 아니라 취소(aborted)에도 있다. */}
+        {task.error && (
+          <span
+            className={`inline-flex items-center rounded-md border px-2 py-0.5 text-[11px] font-medium ${
+              task.status === "cancelled"
+                ? "border-warn/40 bg-warn-soft text-warn"
+                : "border-danger/40 bg-danger-soft text-danger"
+            }`}
+            title={task.error}
+          >
+            {errorReasonLabel(t, task.error)}
+          </span>
+        )}
+      </div>
+
+      {body ? (
+        <>
+          <pre
+            className={`whitespace-pre-wrap break-words text-xs leading-relaxed text-fg-2 ${
+              open ? "max-h-[28rem] overflow-auto" : "line-clamp-6"
+            }`}
+          >
+            {body}
+          </pre>
+          {(body.includes("\n") || body.length > 300) && (
+            <button
+              type="button"
+              onClick={() => setOpen((v) => !v)}
+              className="mt-1 text-[11px] text-accent hover:underline"
+            >
+              {open ? t("templates.collapse") : t("templates.expand")}
+            </button>
+          )}
+        </>
+      ) : (
+        <p className="text-xs text-muted">{t("noResultBody")}</p>
+      )}
+
+      {artifacts.length > 0 && (
+        <div className="mt-3">
+          <p className="mb-1 text-xs font-medium text-fg-2">
+            {t("outputsLabel", { count: artifacts.length })}
+          </p>
+          <div className="space-y-2">
+            {artifacts.map((a, i) => <ArtifactStepView key={`${a.id}-${i}`} artifact={a} />)}
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -322,7 +628,7 @@ function TaskDetailModal({
         <>
           <div className="rounded-md border border-border bg-surface-2 p-4">
             <p className="mb-1 text-xs font-medium text-muted">{t("goalLabel")}</p>
-            <p className="text-sm text-fg">{detail.task.goal}</p>
+            <GoalBlock goal={detail.task.goal} />
             {detail.task.executor === "local" && (
               <span className="mt-2 inline-flex items-center rounded-full border border-accent bg-accent-soft px-2 py-0.5 text-[10px] font-medium text-accent">
                 {t("localBadge")}{detail.task.folder_rel ? ` · ${detail.task.folder_rel}` : ""}
@@ -353,6 +659,9 @@ function TaskDetailModal({
               </div>
             )}
           </div>
+
+          {/* 종료된 작업의 결말 — 계획·타임라인보다 위에 둔다. */}
+          <ResultBlock task={detail.task} steps={detail.steps} />
 
           {/* 공유 — 종료된 작업만(스냅샷 고정이라 진행 중 게시는 반쪽 기록이 굳는다). */}
           {(detail.task.status === "completed" || detail.task.status === "failed" || detail.task.status === "cancelled") && (
@@ -457,7 +766,9 @@ function TaskDetailModal({
                   const body = step.tool_output || step.content || "";
                   const stepType = step.step_type ?? step.type;
                   const isDiff = stepType === "diff";
-                  const isTool = stepType === "tool_result" || !!step.tool_name;
+                  // 아티팩트 스텝은 전용 뷰 — 파싱 실패 시 null 이라 일반 스텝으로 자연 폴백된다.
+                  const artifact = stepType === "artifact" ? parseStepArtifact(body) : null;
+                  const isTool = !artifact && (stepType === "tool_result" || !!step.tool_name);
                   return (
                     <div key={step.id} className="flex gap-3">
                       <div className="flex flex-col items-center">
@@ -474,7 +785,9 @@ function TaskDetailModal({
                           )}
                           {step.tool_name && <span className="font-mono">{step.tool_name}</span>}
                         </div>
-                        {body && (isDiff ? (
+                        {body && (artifact ? (
+                          <ArtifactStepView artifact={artifact} />
+                        ) : isDiff ? (
                           <DiffView text={body.slice(0, 20000)} />
                         ) : (
                           <pre className={cn(
@@ -626,7 +939,7 @@ function SchedulesPanel() {
           {schedules.map((s) => (
             <div key={s.id} className="flex items-center justify-between gap-3 rounded-md border border-line bg-bg-1 p-2">
               <div className="min-w-0">
-                <p className="truncate text-xs font-medium text-fg-1">{s.goal}</p>
+                <p className="line-clamp-2 whitespace-pre-line text-xs font-medium text-fg-1" title={s.goal}>{s.goal}</p>
                 <p className="text-xs text-muted">
                   <span className="font-mono">{timingLabel(s)}</span>
                   {" · "}
@@ -663,6 +976,11 @@ interface ApiTemplate {
 }
 type TemplatesResponse = ApiSuccess<{ templates: ApiTemplate[]; total: number }>;
 
+/** 접기 UI 를 붙일지 판단 — 3줄(line-clamp-3) 을 넘거나 한 줄이라도 길면 true. */
+function isMultiline(text: string): boolean {
+  return text.includes("\n") || text.length > 120;
+}
+
 function TemplatesPanel() {
   const t = useTranslations("agentTasks");
   const [templates, setTemplates] = useState<ApiTemplate[]>([]);
@@ -670,6 +988,7 @@ function TemplatesPanel() {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
   const [goal, setGoal] = useState("");
+  const [expanded, setExpanded] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -718,10 +1037,15 @@ function TemplatesPanel() {
             value={goal}
             onChange={(e) => setGoal(e.target.value)}
             placeholder={t("templates.goalPlaceholder")}
-            rows={2}
-            className="w-full resize-y rounded-md border border-line bg-bg-2 p-2 text-sm text-fg-1"
+            rows={10}
+            // 줄바꿈은 그대로 저장된다(서버 sanitize 의 allowNewLines 기본 true) —
+            // 여러 줄 목표를 편집할 수 있도록 충분한 높이를 준다.
+            className="w-full resize-y whitespace-pre-wrap rounded-md border border-line bg-bg-2 p-2 font-mono text-xs leading-relaxed text-fg-1"
           />
-          <div className="flex justify-end">
+          <div className="flex items-center justify-between">
+            <span className="text-[11px] text-muted">
+              {t("templates.lineCount", { lines: goal ? goal.split("\n").length : 0, chars: goal.length })}
+            </span>
             <Button size="sm" disabled={busy === "new" || !name.trim() || !goal.trim()} onClick={create}>
               {t("templates.add")}
             </Button>
@@ -733,10 +1057,28 @@ function TemplatesPanel() {
       ) : (
         <div className="space-y-2">
           {templates.map((tp) => (
-            <div key={tp.id} className="flex items-center justify-between gap-3 rounded-md border border-line bg-bg-1 p-2">
-              <div className="min-w-0">
+            <div key={tp.id} className="flex items-start justify-between gap-3 rounded-md border border-line bg-bg-1 p-2">
+              <div className="min-w-0 flex-1">
                 <p className="truncate text-xs font-medium text-fg-1">{tp.name}</p>
-                <p className="truncate text-xs text-muted">{tp.goal_template}</p>
+                {/* goal_template 은 여러 줄이 그대로 저장된다(실측 96줄 사례). 예전에는
+                    truncate 로 한 줄로 뭉개져 내용을 확인할 수 없었다 → 줄바꿈을 보존하되
+                    기본은 3줄로 접고, 넘칠 때만 펼치기 토글을 노출한다. */}
+                <pre
+                  className={`mt-0.5 whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-muted ${
+                    expanded === tp.id ? "" : "line-clamp-3"
+                  }`}
+                >
+                  {tp.goal_template}
+                </pre>
+                {isMultiline(tp.goal_template) && (
+                  <button
+                    type="button"
+                    onClick={() => setExpanded(expanded === tp.id ? null : tp.id)}
+                    className="mt-1 text-[11px] text-accent hover:underline"
+                  >
+                    {expanded === tp.id ? t("templates.collapse") : t("templates.expand")}
+                  </button>
+                )}
               </div>
               <div className="flex shrink-0 gap-1">
                 <Button size="sm" variant="outline" disabled={busy === tp.id} onClick={() => instantiate(tp)} title={t("templates.run")}>
@@ -762,6 +1104,7 @@ export default function AgentTasksPage() {
   const [tasks, setTasks] = useState<AgentTask[]>([]);
   const [loading, setLoading] = useState(true);
   const [detailTaskId, setDetailTaskId] = useState<string | null>(null);
+  const [previewTaskId, setPreviewTaskId] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null); // taskId being acted on
 
   // admin 전체 보기 — 백엔드 ?viewAll=true 재사용 (비관리자의 viewAll 은 서버가 무시).
@@ -933,7 +1276,14 @@ export default function AgentTasksPage() {
                   {/* 1) 정체성 — 상태·소유자·실행기 배지 + 상세 진입. 턴은 진행률 줄로 내렸다. */}
                   <div className="mb-3 flex items-start justify-between gap-2">
                     <span className="flex flex-wrap items-center gap-1.5">
-                      <Badge tone={meta.tone}>
+                      {/* mapStatus 는 completed/failed/cancelled 를 모두 "completed" 로 접으므로
+                          STATUS_META 만 쓰면 취소·실패도 초록(success)으로 보인다 — 성공이 아닌
+                          종료는 톤을 분리한다: 취소=warn(노랑), 실패=danger. */}
+                      <Badge tone={
+                        task.rawStatus === "cancelled" ? "warn"
+                          : task.rawStatus === "failed" ? "danger"
+                            : meta.tone
+                      }>
                         {task.status === "running" && (
                           <LoaderCircle className="h-3 w-3 animate-spin" />
                         )}
@@ -972,9 +1322,13 @@ export default function AgentTasksPage() {
                     </div>
                   )}
 
+                  {/* whitespace-pre-line: 줄바꿈을 살려 clamp 2줄이 프롬프트의 첫 두 줄이
+                      되게 한다(예전엔 전체가 한 줄로 접혀 의미 없는 앞부분만 보였다).
+                      전체 프롬프트는 hover title 과 상세 모달에서 확인. */}
                   <h3
-                    className="mb-4 line-clamp-2 cursor-pointer text-sm font-semibold leading-snug text-fg hover:underline"
+                    className="mb-4 line-clamp-2 cursor-pointer whitespace-pre-line text-sm font-semibold leading-snug text-fg hover:underline"
                     onClick={() => setDetailTaskId(task.id)}
+                    title={task.goal}
                   >
                     {task.goal}
                   </h3>
@@ -1047,6 +1401,16 @@ export default function AgentTasksPage() {
                   {/* 4) 액션 — 종전엔 메타와 한 줄을 다퉈 좁은 카드에서 넘쳤다. 별도 줄로 내리고 우측 정렬. */}
                   <div className="mt-3 flex items-center justify-end gap-1">
                     <div className="flex items-center gap-1">
+                      {/* 산출물 미리보기 — 상세 모달·타임라인을 거치지 않고 결과만 바로 본다.
+                          종료된 작업에만 노출(실행 중엔 산출물이 아직 없다). */}
+                      {(task.rawStatus === "completed" || task.rawStatus === "failed" || task.rawStatus === "cancelled") && (
+                        <button
+                          onClick={() => setPreviewTaskId(task.id)}
+                          title={t("previewTitle")}
+                          className="flex h-7 w-7 items-center justify-center rounded-md text-faint transition hover:bg-accent-soft hover:text-accent">
+                          <Eye className="h-3.5 w-3.5" />
+                        </button>
+                      )}
                       {/* Resume (failed + resumable) */}
                       {task.rawStatus === "failed" && task.resumable && (
                         <button
@@ -1099,6 +1463,9 @@ export default function AgentTasksPage() {
         <Modal open={!!detailTaskId} onClose={() => setDetailTaskId(null)} title={t("modalTitle")}>
           <TaskDetailModal taskId={detailTaskId} />
         </Modal>
+      )}
+      {previewTaskId && (
+        <PreviewModal taskId={previewTaskId} onClose={() => setPreviewTaskId(null)} />
       )}
     </>
   );

--- a/apps/web/app/(workspace)/mcp-catalog/page.tsx
+++ b/apps/web/app/(workspace)/mcp-catalog/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Search, Boxes, Download, Loader2, Server } from "lucide-react";
@@ -90,6 +90,18 @@ export default function McpCatalogPage() {
   // 설치 전 자격증명(env) 입력이 필요한 항목의 인라인 폼 상태.
   const [configuringId, setConfiguringId] = useState<string | null>(null);
   const [envDraft, setEnvDraft] = useState<Record<string, string>>({});
+  // 설치 이름 — 같은 템플릿을 여러 접속처에 설치할 수 있으므로 인스턴스마다 이름을 받는다.
+  const [nameDraft, setNameDraft] = useState("");
+  // 이미 설치된 인스턴스 이름 — 기본 이름 제안 시 충돌 회피에 쓴다.
+  const [installedNames, setInstalledNames] = useState<string[]>([]);
+
+  const loadInstalled = useCallback(async () => {
+    try {
+      const r = await ApiClient.get<ApiEnvelope<{ servers: { name: string }[] }>>("/api/mcp/servers");
+      setInstalledNames((r?.data?.servers ?? []).map((x) => x.name));
+    } catch { /* 401·미배포: 제안 이름만 단순해진다 */ }
+  }, []);
+  useEffect(() => { void loadInstalled(); }, [loadInstalled]);
 
   useEffect(() => {
     let cancelled = false;
@@ -112,18 +124,31 @@ export default function McpCatalogPage() {
     };
   }, []);
 
-  // 설치 시작: 필수 env 필드가 있으면 인라인 폼을 열고, 없으면 즉시 설치.
-  function beginInstall(e: CatalogEntry) {
-    setInstallError((prev) => ({ ...prev, [e.id]: "" }));
-    if (e.envFields.length > 0) {
-      setConfiguringId(e.id);
-      setEnvDraft(Object.fromEntries(e.envFields.map((f) => [f.key, ""])));
-      return;
+  /**
+   * 이미 쓰고 있는 이름을 피해 기본 이름을 제안한다 — 같은 템플릿을 두 번째로 설치할 때
+   * `mcp-postgres-2` 처럼. 이름은 (user_id, name) 유니크라 충돌하면 서버가 409 를 낸다.
+   */
+  function suggestName(e: CatalogEntry): string {
+    const base = e.id.replace(/[^a-zA-Z0-9_-]/g, "-");
+    const used = new Set(installedNames);
+    if (!used.has(base)) return base;
+    for (let i = 2; i < 100; i += 1) {
+      if (!used.has(`${base}-${i}`)) return `${base}-${i}`;
     }
-    void doInstall(e, {});
+    return base;
   }
 
-  async function doInstall(e: CatalogEntry, env: Record<string, string>) {
+  // 설치 시작: 이름(필수) + 자격증명(있으면)을 받는 인라인 폼을 연다.
+  // 종전에는 env 가 없으면 곧장 설치하면서 이름을 템플릿 id 로 고정해, 같은 템플릿을
+  // 두 번 설치할 수 없었다(두 번째가 유니크 제약에 걸림).
+  function beginInstall(e: CatalogEntry) {
+    setInstallError((prev) => ({ ...prev, [e.id]: "" }));
+    setConfiguringId(e.id);
+    setNameDraft(suggestName(e));
+    setEnvDraft(Object.fromEntries(e.envFields.map((f) => [f.key, ""])));
+  }
+
+  async function doInstall(e: CatalogEntry, env: Record<string, string>, name: string) {
     setInstalling((prev) => ({ ...prev, [e.id]: true }));
     setInstallError((prev) => ({ ...prev, [e.id]: "" }));
     try {
@@ -132,7 +157,7 @@ export default function McpCatalogPage() {
       // env 의 secret 필드는 백엔드 createFromCatalog 가 AES-256-GCM 으로 암호화 저장.
       await ApiClient.post("/api/mcp/servers/from-catalog", {
         template_id: e.id,
-        name: e.id.replace(/[^a-zA-Z0-9_-]/g, "-"), // name 은 영숫자/_/- 만 허용
+        name, // 인스턴스 이름 = 도구 네임스페이스. 영숫자/_/- 만 허용.
         ...(Object.keys(env).length > 0 ? { env } : {}),
       });
       setEntries((prev) =>
@@ -140,6 +165,7 @@ export default function McpCatalogPage() {
           item.id === e.id ? { ...item, installed: true } : item,
         ),
       );
+      void loadInstalled(); // 다음 추가 설치의 기본 이름 제안이 새 이름을 피하도록
       setConfiguringId((cur) => (cur === e.id ? null : cur));
     } catch {
       setInstallError((prev) => ({
@@ -226,32 +252,42 @@ export default function McpCatalogPage() {
                       <Badge tone="neutral">
                         <span className="font-mono">{e.provider}</span>
                       </Badge>
-                      {e.installed ? (
-                        <Button variant="outline" size="sm" disabled>
-                          {t("installed")}
-                        </Button>
-                      ) : (
-                        <Button
-                          size="sm"
-                          disabled={installing[e.id]}
-                          onClick={() => beginInstall(e)}
-                        >
-                          {installing[e.id] ? (
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                          ) : (
-                            <Download className="h-4 w-4" />
-                          )}
-                          {t("install")}
-                        </Button>
-                      )}
+                      {/* 설치 여부와 무관하게 추가 설치를 허용한다 — 같은 템플릿을 서로 다른
+                          접속처(예: 앱 DB용 / 분석 DB용 postgres)에 이름만 달리해 여러 개 둘 수 있다.
+                          종전에는 설치되면 버튼이 잠겨 두 번째 인스턴스를 만들 수 없었다. */}
+                      {e.installed && <Badge tone="success">{t("installed")}</Badge>}
+                      <Button
+                        size="sm"
+                        variant={e.installed ? "outline" : "default"}
+                        disabled={installing[e.id]}
+                        onClick={() => beginInstall(e)}
+                      >
+                        {installing[e.id] ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Download className="h-4 w-4" />
+                        )}
+                        {e.installed ? t("installAnother") : t("install")}
+                      </Button>
                     </div>
 
                     {/* 필수 자격증명 입력 폼 — env_schema.required 가 있는 서버(Notion·GitHub 등) */}
                     {configuringId === e.id && (
                       <div className="flex flex-col gap-2 rounded-md border border-border bg-surface-2 p-3">
                         <p className="text-xs font-medium text-fg">
-                          {t("credentialsTitle")}
+                          {e.envFields.length > 0 ? t("credentialsTitle") : t("installFormTitle")}
                         </p>
+                        <label className="flex flex-col gap-1">
+                          <span className="text-xs text-fg-2">{t("nameLabel")}</span>
+                          <input
+                            value={nameDraft}
+                            onChange={(ev) => setNameDraft(ev.target.value)}
+                            pattern="[A-Za-z0-9_-]+"
+                            placeholder="mcp-postgres-analytics"
+                            className="h-8 w-full rounded-md border border-border bg-surface px-2 font-mono text-xs text-fg placeholder:text-muted focus:border-accent focus:outline-none"
+                          />
+                          <span className="text-[11px] text-muted">{t("nameHint")}</span>
+                        </label>
                         {e.envFields.map((f) => (
                           <label key={f.key} className="flex flex-col gap-1">
                             <span className="text-xs text-fg-2">{f.title}</span>
@@ -282,9 +318,10 @@ export default function McpCatalogPage() {
                             size="sm"
                             disabled={
                               installing[e.id] ||
+                              !/^[A-Za-z0-9_-]+$/.test(nameDraft) ||
                               e.envFields.some((f) => !envDraft[f.key]?.trim())
                             }
-                            onClick={() => doInstall(e, envDraft)}
+                            onClick={() => doInstall(e, envDraft, nameDraft)}
                           >
                             {installing[e.id] ? (
                               <Loader2 className="h-4 w-4 animate-spin" />

--- a/apps/web/components/settings/connectors-section.tsx
+++ b/apps/web/components/settings/connectors-section.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { Server, Boxes, Plus, Loader2, X, KeyRound, Pencil, ClipboardCheck, AlertTriangle, Power, PowerOff, LogIn, LogOut, Zap, ZapOff } from "lucide-react";
+import { Server, Boxes, Plus, Loader2, X, KeyRound, Pencil, Trash2, ClipboardCheck, AlertTriangle, Power, PowerOff, LogIn, LogOut, Zap, ZapOff } from "lucide-react";
 import {
   Button,
   Badge,
@@ -19,6 +19,7 @@ import type { ApiSuccess as ApiEnvelope } from "@openmake/shared-types";
 import { ApiClient } from "@/lib/api-client";
 import { cn } from "@/lib/utils";
 import { McpInstancesPanel } from "@/components/settings/mcp-instances-panel";
+import { useAppStore } from "@/lib/store";
 
 /**
  * MCP 서버(커넥터) 관리 — 구 /mcp-servers 페이지 본문을 설정 '커넥터' 탭으로 흡수한 것
@@ -53,6 +54,9 @@ interface McpServer {
   envKeys: string[];
   /** 그중 암호화 저장된(민감) 키 — 입력 시 password 필드로 렌더 */
   secretKeys: string[];
+  /** 소유자 — 삭제/이름변경 권한 판정용(백엔드 canDeleteServer 와 같은 기준: 소유자 + admin).
+   *  global 서버는 null 이라 admin 만 지울 수 있다. */
+  ownerId: string | null;
 }
 
 /* ── 백엔드 응답 타입 (GET /api/mcp/servers) ──────────────── */
@@ -76,6 +80,8 @@ interface ApiMcpServer {
   connectionErrorCode?: string | null;
   /** 백엔드가 마스킹해서 내려주는 env — 암호화된 값은 "***" 로 치환돼 있다(원문 미노출). */
   env?: Record<string, string> | null;
+  /** 소유자 id — global 카탈로그 서버는 null. 삭제 권한 판정에 쓴다. */
+  user_id?: string | null;
 }
 
 const TRANSPORT_MAP: Record<ApiMcpServer["transport_type"], Transport> = {
@@ -121,6 +127,7 @@ function mapServer(s: ApiMcpServer, t: Translator): McpServer {
     secretKeys: Object.entries(s.env ?? {})
       .filter(([, v]) => v === "***")
       .map(([k]) => k),
+    ownerId: s.user_id ?? null,
   };
 }
 
@@ -195,6 +202,70 @@ function RenameModal({
             </Button>
           </div>
         </form>
+      </div>
+    </div>
+  );
+}
+
+/* ── 삭제 확인 모달 ─────────────────────────────────────────
+ * 연결해제(disconnect)와 다르다: disconnect 는 런타임 연결만 끊고 등록은 남기지만,
+ * 삭제는 등록 자체를 지운다(DELETE /api/mcp/servers/:id). 백엔드가 유저풀에 spawn 된
+ * 샌드박스 컨테이너까지 정리하므로, 여기서는 확인만 받고 목록을 다시 읽으면 된다.
+ * 되돌릴 수 없고 저장된 자격증명(env)도 함께 사라지므로 확인을 한 번 거친다.
+ */
+function DeleteServerModal({
+  server,
+  onClose,
+  onSuccess,
+}: {
+  server: McpServer | null;
+  onClose: () => void;
+  onSuccess: (notice: string) => void;
+}) {
+  const t = useTranslations("mcpServers");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => { setError(null); }, [server?.id]);
+  if (!server) return null;
+
+  async function handleDelete() {
+    if (!server) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await ApiClient.del(`/api/mcp/servers/${server.id}`);
+      onSuccess(t("deleteDone", { name: server.name }));
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("deleteError"));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="w-full max-w-md rounded-xl border border-border bg-surface p-6 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-base font-semibold text-fg">{t("deleteTitle")}</h2>
+          <button type="button" onClick={onClose} className="rounded p-1 text-muted hover:bg-surface-2 hover:text-fg">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <p className="mb-1 text-sm text-fg-2">{t("deleteConfirm")}</p>
+        <p className="mb-3 font-mono text-sm font-medium text-fg">{server.name}</p>
+        <p className="mb-4 rounded-md bg-surface-2 px-3 py-2 text-xs text-fg-2">{t("deleteHint")}</p>
+        {error && <p className="mb-3 rounded-md bg-danger-soft px-3 py-2 text-xs text-danger">{error}</p>}
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" size="sm" onClick={onClose} disabled={submitting}>
+            {t("cancel")}
+          </Button>
+          <Button variant="danger" size="sm" onClick={() => void handleDelete()} disabled={submitting}>
+            {submitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            {t("delete")}
+          </Button>
+        </div>
       </div>
     </div>
   );
@@ -429,6 +500,7 @@ export function ConnectorsSection() {
   const [actionLoading, setActionLoading] = useState<Record<string, boolean>>({});
   const [envEditTarget, setEnvEditTarget] = useState<McpServer | null>(null);
   const [renameTarget, setRenameTarget] = useState<McpServer | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<McpServer | null>(null);
   const [envNotice, setEnvNotice] = useState<string | null>(null);
   // OAuth 콜백 착지 — 결과를 알리고 목록을 다시 읽는다(토큰이 생겨 연결됐을 수 있다)
   useEffect(() => {
@@ -441,6 +513,12 @@ export function ConnectorsSection() {
     window.history.replaceState(null, "", `${window.location.pathname}?${params.toString()}`);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // 삭제 권한은 백엔드 canDeleteServer 와 같은 기준(소유자 + admin)으로 클라이언트에서도 판정한다.
+  // 게이팅이 없으면 모두에게 보이는 global 서버에 삭제 버튼이 떠서 누를 때마다 403 이 난다.
+  const currentUser = useAppStore((st) => st.auth.currentUser);
+  const canDelete = (s: McpServer) =>
+    currentUser != null && (currentUser.role === "admin" || s.ownerId === currentUser.id);
 
   // env 교체 성공 — 백엔드가 기존 컨테이너를 정리했으므로(stale env 방지) 재연결 안내.
   function handleEnvUpdated(respawnRequired: boolean) {
@@ -616,6 +694,11 @@ export function ConnectorsSection() {
         server={envEditTarget}
         onClose={() => setEnvEditTarget(null)}
         onSuccess={handleEnvUpdated}
+      />
+      <DeleteServerModal
+        server={deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onSuccess={(notice) => { setEnvNotice(notice); void loadServers(); }}
       />
       <CardHeader className="flex flex-wrap items-center justify-between gap-2">
         <div>
@@ -851,6 +934,20 @@ export function ConnectorsSection() {
                             >
                               {isActing && <Loader2 className="h-3 w-3 animate-spin" />}
                               {t("connect")}
+                            </Button>
+                          )}
+                          {/* 삭제는 연결 상태와 무관하게 노출 — 연결이 끊긴 서버야말로
+                              지우고 싶은 대상이다. 되돌릴 수 없어 확인 모달을 거친다. */}
+                          {canDelete(s) && (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              disabled={isActing}
+                              onClick={() => setDeleteTarget(s)}
+                              title={t("deleteTitle")}
+                              className="text-danger hover:bg-danger-soft"
+                            >
+                              <Trash2 className="h-3 w-3" />
                             </Button>
                           )}
                         </div>

--- a/apps/web/components/settings/connectors-section.tsx
+++ b/apps/web/components/settings/connectors-section.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { Server, Boxes, Plus, Loader2, X, KeyRound, ClipboardCheck, AlertTriangle, Power, PowerOff, LogIn, LogOut, Zap, ZapOff } from "lucide-react";
+import { Server, Boxes, Plus, Loader2, X, KeyRound, Pencil, ClipboardCheck, AlertTriangle, Power, PowerOff, LogIn, LogOut, Zap, ZapOff } from "lucide-react";
 import {
   Button,
   Badge,
@@ -125,6 +125,81 @@ function mapServer(s: ApiMcpServer, t: Translator): McpServer {
 }
 
 /* ── 자격증명(env) 변경 모달 ────────────────────────────────── */
+/* ── 이름 변경 모달 ─────────────────────────────────────────
+ * 서버 이름은 도구 네임스페이스(name::tool)라, 같은 카탈로그 템플릿을 여러 접속처에
+ * 설치했을 때 서로 구분하는 유일한 수단이다. 설치 후에도 바꿀 수 있어야 한다.
+ * 변경 후에는 respawn 이 필요하다(네임스페이스가 spawn 시점에 굳는다).
+ */
+function RenameModal({
+  server,
+  onClose,
+  onSuccess,
+}: {
+  server: McpServer | null;
+  onClose: () => void;
+  onSuccess: (notice: string) => void;
+}) {
+  const t = useTranslations("mcpServers");
+  const [name, setName] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => { setName(server?.name ?? ""); setError(null); }, [server]);
+  if (!server) return null;
+
+  const valid = /^[A-Za-z0-9_-]+$/.test(name);
+
+  async function submit(ev: React.SubmitEvent<HTMLFormElement>) {
+    ev.preventDefault();
+    if (!server) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await ApiClient.patch(`/api/mcp/servers/${server.id}`, { name });
+      onSuccess(t("renameDone", { name }));
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("renameError"));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="w-full max-w-md rounded-xl border border-border bg-surface p-6 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-base font-semibold text-fg">{t("renameTitle")}</h2>
+          <button type="button" onClick={onClose} className="rounded p-1 text-muted hover:bg-surface-2 hover:text-fg">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <form onSubmit={(e) => void submit(e)} className="space-y-3">
+          <div>
+            <label className="mb-1 block text-xs font-medium text-fg-2">{t("renameLabel")}</label>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              pattern="[A-Za-z0-9_-]+"
+              required
+              className="h-9 w-full rounded-md border border-border-strong bg-app px-3 font-mono text-sm text-fg outline-none transition focus:border-accent"
+            />
+            <p className="mt-1 text-[11px] text-muted">{t("renameHint")}</p>
+          </div>
+          {error && <p className="rounded-md bg-danger-soft px-3 py-2 text-xs text-danger">{error}</p>}
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" size="sm" onClick={onClose}>{t("cancel")}</Button>
+            <Button type="submit" size="sm" disabled={submitting || !valid || name === server.name}>
+              {submitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+              {t("save")}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
 function EnvEditModal({
   server,
   onClose,
@@ -353,6 +428,7 @@ export function ConnectorsSection() {
   const [loading, setLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState<Record<string, boolean>>({});
   const [envEditTarget, setEnvEditTarget] = useState<McpServer | null>(null);
+  const [renameTarget, setRenameTarget] = useState<McpServer | null>(null);
   const [envNotice, setEnvNotice] = useState<string | null>(null);
   // OAuth 콜백 착지 — 결과를 알리고 목록을 다시 읽는다(토큰이 생겨 연결됐을 수 있다)
   useEffect(() => {
@@ -482,6 +558,20 @@ export function ConnectorsSection() {
       alert(t("toggleFailed", { error: e instanceof Error ? e.message : "" } as never));
     } finally {
       setActionLoading((prev) => ({ ...prev, [id]: false }));
+
+  /** 이름 변경 등 목록을 다시 읽어야 하는 동작을 위한 재조회 — 실패 시 빈 목록(목업 폴백 금지). */
+  async function loadServers() {
+    try {
+      const res = await ApiClient.get<ApiEnvelope<{ servers: ApiMcpServer[] }>>(
+        "/api/mcp/servers",
+      );
+      setServers((res?.data?.servers ?? []).map((s) => mapServer(s, t)));
+    } catch {
+      // 401·네트워크 실패 등 → 목록 유지(재조회 실패는 화면을 비우지 않는다)
+    } finally {
+      setLoading(false);
+    }
+  }
     }
   }
 
@@ -516,6 +606,11 @@ export function ConnectorsSection() {
           // 설치분은 draft 로 들어가며 승인해야 연결된다 — 단일 승인 창구로 보낸다
           router.push("/approvals");
         }}
+      />
+      <RenameModal
+        server={renameTarget}
+        onClose={() => setRenameTarget(null)}
+        onSuccess={(notice) => { setEnvNotice(notice); void loadServers(); }}
       />
       <EnvEditModal
         server={envEditTarget}
@@ -665,6 +760,14 @@ export function ConnectorsSection() {
                       <Td className="whitespace-nowrap">
                         {/* 폭이 모자라면 버튼 글자를 꺾는 대신 버튼 단위로 다음 줄에 감싼다 */}
                         <div className="flex flex-wrap items-center gap-1">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setRenameTarget(s)}
+                            title={t("renameTitle")}
+                          >
+                            <Pencil className="h-3 w-3" />
+                          </Button>
                           <Button
                             variant="outline"
                             size="sm"

--- a/apps/web/components/settings/connectors-section.tsx
+++ b/apps/web/components/settings/connectors-section.tsx
@@ -636,8 +636,11 @@ export function ConnectorsSection() {
       alert(t("toggleFailed", { error: e instanceof Error ? e.message : "" } as never));
     } finally {
       setActionLoading((prev) => ({ ...prev, [id]: false }));
+    }
+  }
 
-  /** 이름 변경 등 목록을 다시 읽어야 하는 동작을 위한 재조회 — 실패 시 빈 목록(목업 폴백 금지). */
+  /** 이름 변경·삭제 등 목록을 다시 읽어야 하는 동작을 위한 재조회.
+   *  실패해도 화면을 비우지 않는다 — 목업 폴백은 두지 않는다(PR #634 이후 금지 패턴). */
   async function loadServers() {
     try {
       const res = await ApiClient.get<ApiEnvelope<{ servers: ApiMcpServer[] }>>(
@@ -645,11 +648,9 @@ export function ConnectorsSection() {
       );
       setServers((res?.data?.servers ?? []).map((s) => mapServer(s, t)));
     } catch {
-      // 401·네트워크 실패 등 → 목록 유지(재조회 실패는 화면을 비우지 않는다)
+      // 401·네트워크 실패 등 → 기존 목록 유지
     } finally {
       setLoading(false);
-    }
-  }
     }
   }
 

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1025,7 +1025,13 @@
     "oauthLogoutTitle": "Remove the stored OAuth token and disconnect",
     "oauthStartFailed": "Could not start OAuth sign-in: {error}",
     "oauthOk": "Signed in to {server} — connecting",
-    "oauthFailed": "Sign-in to {server} failed ({reason})"
+    "oauthFailed": "Sign-in to {server} failed ({reason})",
+    "renameTitle": "Rename",
+    "renameLabel": "Server name",
+    "renameHint": "Prefixes tool names (e.g. mcp-postgres::query). Takes effect after the server reconnects.",
+    "renameDone": "Renamed to \"{name}\". It applies on the next connection.",
+    "renameError": "Rename failed",
+    "save": "Save"
   },
   "mcpCatalog": {
     "pageTitle": "MCP Catalog",
@@ -1040,7 +1046,11 @@
     "install": "Install",
     "installError": "Installation failed. Please try again.",
     "credentialsTitle": "Enter credentials to install",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "installAnother": "Install another",
+    "installFormTitle": "Install settings",
+    "nameLabel": "Server name",
+    "nameHint": "Prefixes tool names (e.g. mcp-postgres::query). Letters, digits, _ and - only."
   },
   "mcpMonitoring": {
     "title": "MCP Monitoring",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -738,7 +738,7 @@
     "stateLabel": "Status:",
     "turnLabel": "Turn:",
     "planLabel": "Plan ({completed}/{total})",
-    "outputsLabel": "Outputs ({count})",
+    "outputsLabel": "{count} output(s)",
     "noSteps": "No step records.",
     "stepsLabel": "Steps ({count})",
     "reject": "Reject",
@@ -773,7 +773,10 @@
       "empty": "No templates yet.",
       "run": "Run from this template",
       "delete": "Delete",
-      "started": "Task started from template."
+      "started": "Task started from template.",
+      "expand": "Show all",
+      "collapse": "Collapse",
+      "lineCount": "{lines} lines · {chars} chars"
     },
     "downloadFailed": "Download failed: {error}",
     "localBadge": "Local folder run",
@@ -782,7 +785,8 @@
       "goal_incomplete": "Goal not met",
       "max_turns_exhausted": "Turn/resource limit reached",
       "interrupted": "Interrupted by server restart",
-      "resumableHint": "Can be resumed"
+      "resumableHint": "Can be resumed",
+      "aborted": "Cancelled by user"
     },
     "planNode": "Step {n}",
     "startedLabel": "Started",
@@ -819,7 +823,15 @@
       "originSpawn": "Parallel sub #{n}",
       "originDelegate": "Expert delegate",
       "stepCount": "{count} steps"
-    }
+    },
+    "artifactSize": "{chars} chars",
+    "artifactOpen": "Open in new tab",
+    "artifactDownload": "Download",
+    "resultLabel": "Result",
+    "noResultBody": "No final answer was saved. See the execution timeline below for what happened.",
+    "previewTitle": "Output preview",
+    "previewEmpty": "This task has no saved output.",
+    "previewLoadError": "Could not load the output."
   },
   "customAgents": {
     "pageTitle": "Custom Agents",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1031,7 +1031,13 @@
     "renameHint": "Prefixes tool names (e.g. mcp-postgres::query). Takes effect after the server reconnects.",
     "renameDone": "Renamed to \"{name}\". It applies on the next connection.",
     "renameError": "Rename failed",
-    "save": "Save"
+    "save": "Save",
+    "delete": "Delete",
+    "deleteTitle": "Delete server",
+    "deleteConfirm": "Delete this MCP server registration?",
+    "deleteHint": "This cannot be undone. Stored credentials (env) are deleted too, and any running instance is stopped. To use it again you must reinstall it from the catalog.",
+    "deleteDone": "Deleted server \"{name}\".",
+    "deleteError": "Failed to delete"
   },
   "mcpCatalog": {
     "pageTitle": "MCP Catalog",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1025,7 +1025,13 @@
     "oauthLogoutTitle": "保存された OAuth トークンを削除して接続を切ります",
     "oauthStartFailed": "OAuth ログインを開始できません: {error}",
     "oauthOk": "{server} にログインしました — 接続します",
-    "oauthFailed": "{server} へのログインに失敗しました ({reason})"
+    "oauthFailed": "{server} へのログインに失敗しました ({reason})",
+    "renameTitle": "名前の変更",
+    "renameLabel": "サーバー名",
+    "renameHint": "ツール名の接頭辞になります(例: mcp-postgres::query)。再接続後に反映されます。",
+    "renameDone": "名前を「{name}」に変更しました。次回の接続から反映されます。",
+    "renameError": "名前の変更に失敗しました",
+    "save": "保存"
   },
   "mcpCatalog": {
     "pageTitle": "MCPカタログ",
@@ -1040,7 +1046,11 @@
     "install": "インストール",
     "installError": "インストールに失敗しました。もう一度お試しください。",
     "credentialsTitle": "インストールするには認証情報を入力してください",
-    "cancel": "キャンセル"
+    "cancel": "キャンセル",
+    "installAnother": "追加インストール",
+    "installFormTitle": "インストール設定",
+    "nameLabel": "サーバー名",
+    "nameHint": "ツール名の接頭辞になります(例: mcp-postgres::query)。英数字・_・- のみ。"
   },
   "mcpMonitoring": {
     "title": "MCP モニタリング",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -738,7 +738,7 @@
     "stateLabel": "ステータス:",
     "turnLabel": "ターン:",
     "planLabel": "計画 ({completed}/{total})",
-    "outputsLabel": "成果物 ({count})",
+    "outputsLabel": "成果物 {count}件",
     "noSteps": "ステップ記録がありません。",
     "stepsLabel": "実行ステップ ({count})",
     "reject": "却下",
@@ -773,7 +773,10 @@
       "empty": "テンプレートはありません。",
       "run": "このテンプレートで実行",
       "delete": "削除",
-      "started": "テンプレートからタスクを開始しました。"
+      "started": "テンプレートからタスクを開始しました。",
+      "expand": "全体を表示",
+      "collapse": "折りたたむ",
+      "lineCount": "{lines}行 · {chars}文字"
     },
     "downloadFailed": "ダウンロードに失敗しました: {error}",
     "localBadge": "ローカルフォルダ実行",
@@ -782,7 +785,8 @@
       "goal_incomplete": "目標未達成",
       "max_turns_exhausted": "ターン・リソース上限に到達",
       "interrupted": "サーバー再起動により中断",
-      "resumableHint": "再開できます"
+      "resumableHint": "再開できます",
+      "aborted": "ユーザーによる取り消し"
     },
     "planNode": "ステップ{n}",
     "startedLabel": "開始",
@@ -819,7 +823,15 @@
       "originSpawn": "並列サブ #{n}",
       "originDelegate": "専門家委任",
       "stepCount": "{count}ステップ"
-    }
+    },
+    "artifactSize": "{chars}文字",
+    "artifactOpen": "新しいタブで開く",
+    "artifactDownload": "ダウンロード",
+    "resultLabel": "結果",
+    "noResultBody": "保存された最終回答はありません。下の実行タイムラインで経過を確認してください。",
+    "previewTitle": "成果物プレビュー",
+    "previewEmpty": "このタスクに保存された成果物はありません。",
+    "previewLoadError": "成果物を読み込めませんでした。"
   },
   "customAgents": {
     "pageTitle": "カスタムエージェント",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1031,7 +1031,13 @@
     "renameHint": "ツール名の接頭辞になります(例: mcp-postgres::query)。再接続後に反映されます。",
     "renameDone": "名前を「{name}」に変更しました。次回の接続から反映されます。",
     "renameError": "名前の変更に失敗しました",
-    "save": "保存"
+    "save": "保存",
+    "delete": "削除",
+    "deleteTitle": "サーバーを削除",
+    "deleteConfirm": "この MCP サーバーの登録を削除しますか？",
+    "deleteHint": "元に戻せません。保存された認証情報（env）も削除され、実行中のインスタンスは停止します。再度使うにはカタログから再インストールが必要です。",
+    "deleteDone": "サーバー「{name}」を削除しました。",
+    "deleteError": "削除に失敗しました"
   },
   "mcpCatalog": {
     "pageTitle": "MCPカタログ",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1031,7 +1031,13 @@
     "renameHint": "도구 이름 앞에 붙습니다(예: mcp-postgres::query). 변경 후 재연결되어야 적용됩니다.",
     "renameDone": "이름을 \"{name}\" 로 바꿨습니다. 다음 연결부터 적용됩니다.",
     "renameError": "이름 변경에 실패했습니다",
-    "save": "저장"
+    "save": "저장",
+    "delete": "삭제",
+    "deleteTitle": "서버 삭제",
+    "deleteConfirm": "이 MCP 서버 등록을 삭제할까요?",
+    "deleteHint": "되돌릴 수 없습니다. 저장된 자격증명(env)도 함께 삭제되며, 실행 중인 인스턴스가 있으면 종료됩니다. 다시 쓰려면 카탈로그에서 새로 설치해야 합니다.",
+    "deleteDone": "\"{name}\" 서버를 삭제했습니다.",
+    "deleteError": "삭제에 실패했습니다"
   },
   "mcpCatalog": {
     "pageTitle": "MCP 카탈로그",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -738,7 +738,7 @@
     "stateLabel": "상태:",
     "turnLabel": "턴:",
     "planLabel": "계획 ({completed}/{total})",
-    "outputsLabel": "산출물 ({count})",
+    "outputsLabel": "산출물 {count}개",
     "noSteps": "스텝 기록이 없습니다.",
     "stepsLabel": "실행 스텝 ({count})",
     "reject": "거절",
@@ -773,7 +773,10 @@
       "empty": "등록된 템플릿이 없습니다.",
       "run": "이 템플릿으로 실행",
       "delete": "삭제",
-      "started": "템플릿으로 작업을 시작했습니다."
+      "started": "템플릿으로 작업을 시작했습니다.",
+      "expand": "전체 보기",
+      "collapse": "접기",
+      "lineCount": "{lines}줄 · {chars}자"
     },
     "downloadFailed": "다운로드 실패: {error}",
     "localBadge": "로컬 폴더 실행",
@@ -782,7 +785,8 @@
       "goal_incomplete": "목표 미달성",
       "max_turns_exhausted": "턴·자원 상한 소진",
       "interrupted": "서버 재시작으로 중단",
-      "resumableHint": "이어하기로 재개할 수 있습니다"
+      "resumableHint": "이어하기로 재개할 수 있습니다",
+      "aborted": "사용자 취소"
     },
     "planNode": "{n}단계",
     "startedLabel": "시작",
@@ -819,7 +823,15 @@
       "originSpawn": "병렬 서브 #{n}",
       "originDelegate": "전문가 위임",
       "stepCount": "{count}단계"
-    }
+    },
+    "artifactSize": "{chars}자",
+    "artifactOpen": "새 탭에서 열기",
+    "artifactDownload": "다운로드",
+    "resultLabel": "결과",
+    "noResultBody": "저장된 최종 답변이 없습니다. 아래 실행 타임라인에서 진행 내역을 확인하세요.",
+    "previewTitle": "산출물 미리보기",
+    "previewEmpty": "이 작업에는 저장된 산출물이 없습니다.",
+    "previewLoadError": "산출물을 불러오지 못했습니다."
   },
   "customAgents": {
     "pageTitle": "커스텀 에이전트",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1025,7 +1025,13 @@
     "oauthLogoutTitle": "저장된 OAuth 토큰을 지우고 연결을 끊습니다",
     "oauthStartFailed": "OAuth 로그인 시작 실패: {error}",
     "oauthOk": "{server} 로그인 완료 — 연결을 시도합니다",
-    "oauthFailed": "{server} 로그인 실패 ({reason})"
+    "oauthFailed": "{server} 로그인 실패 ({reason})",
+    "renameTitle": "이름 변경",
+    "renameLabel": "서버 이름",
+    "renameHint": "도구 이름 앞에 붙습니다(예: mcp-postgres::query). 변경 후 재연결되어야 적용됩니다.",
+    "renameDone": "이름을 \"{name}\" 로 바꿨습니다. 다음 연결부터 적용됩니다.",
+    "renameError": "이름 변경에 실패했습니다",
+    "save": "저장"
   },
   "mcpCatalog": {
     "pageTitle": "MCP 카탈로그",
@@ -1040,7 +1046,11 @@
     "install": "설치",
     "installError": "설치 실패. 다시 시도해 주세요.",
     "credentialsTitle": "설치하려면 자격 증명을 입력하세요",
-    "cancel": "취소"
+    "cancel": "취소",
+    "installAnother": "추가 설치",
+    "installFormTitle": "설치 설정",
+    "nameLabel": "서버 이름",
+    "nameHint": "도구 이름 앞에 붙습니다(예: mcp-postgres::query). 영숫자·_·- 만 사용."
   },
   "mcpMonitoring": {
     "title": "MCP 모니터링",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1025,7 +1025,13 @@
     "oauthLogoutTitle": "删除已保存的 OAuth 令牌并断开连接",
     "oauthStartFailed": "无法启动 OAuth 登录：{error}",
     "oauthOk": "已登录 {server} — 正在连接",
-    "oauthFailed": "登录 {server} 失败（{reason}）"
+    "oauthFailed": "登录 {server} 失败（{reason}）",
+    "renameTitle": "重命名",
+    "renameLabel": "服务器名称",
+    "renameHint": "作为工具名前缀(如 mcp-postgres::query)。重新连接后生效。",
+    "renameDone": "已重命名为“{name}”。下次连接时生效。",
+    "renameError": "重命名失败",
+    "save": "保存"
   },
   "mcpCatalog": {
     "pageTitle": "MCP 目录",
@@ -1040,7 +1046,11 @@
     "install": "安装",
     "installError": "安装失败，请重试。",
     "credentialsTitle": "请输入凭据以安装",
-    "cancel": "取消"
+    "cancel": "取消",
+    "installAnother": "再次安装",
+    "installFormTitle": "安装设置",
+    "nameLabel": "服务器名称",
+    "nameHint": "作为工具名前缀(如 mcp-postgres::query)。仅限字母、数字、_ 和 -。"
   },
   "mcpMonitoring": {
     "title": "MCP 监控",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -738,7 +738,7 @@
     "stateLabel": "状态:",
     "turnLabel": "回合:",
     "planLabel": "计划 ({completed}/{total})",
-    "outputsLabel": "产出物 ({count})",
+    "outputsLabel": "{count} 个产出",
     "noSteps": "暂无步骤记录。",
     "stepsLabel": "执行步骤 ({count})",
     "reject": "拒绝",
@@ -773,7 +773,10 @@
       "empty": "暂无模板。",
       "run": "使用此模板运行",
       "delete": "删除",
-      "started": "已从模板启动任务。"
+      "started": "已从模板启动任务。",
+      "expand": "显示全部",
+      "collapse": "收起",
+      "lineCount": "{lines} 行 · {chars} 字"
     },
     "downloadFailed": "下载失败: {error}",
     "localBadge": "本地文件夹执行",
@@ -782,7 +785,8 @@
       "goal_incomplete": "目标未达成",
       "max_turns_exhausted": "已达轮次/资源上限",
       "interrupted": "因服务器重启而中断",
-      "resumableHint": "可继续执行"
+      "resumableHint": "可继续执行",
+      "aborted": "用户已取消"
     },
     "planNode": "步骤{n}",
     "startedLabel": "开始",
@@ -819,7 +823,15 @@
       "originSpawn": "并行子代理 #{n}",
       "originDelegate": "专家委托",
       "stepCount": "{count} 步"
-    }
+    },
+    "artifactSize": "{chars} 字",
+    "artifactOpen": "在新标签页打开",
+    "artifactDownload": "下载",
+    "resultLabel": "结果",
+    "noResultBody": "没有保存的最终答复。请查看下方执行时间线了解经过。",
+    "previewTitle": "产出预览",
+    "previewEmpty": "该任务没有已保存的产出。",
+    "previewLoadError": "无法加载产出。"
   },
   "customAgents": {
     "pageTitle": "自定义智能体",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1031,7 +1031,13 @@
     "renameHint": "作为工具名前缀(如 mcp-postgres::query)。重新连接后生效。",
     "renameDone": "已重命名为“{name}”。下次连接时生效。",
     "renameError": "重命名失败",
-    "save": "保存"
+    "save": "保存",
+    "delete": "删除",
+    "deleteTitle": "删除服务器",
+    "deleteConfirm": "确定删除此 MCP 服务器注册吗？",
+    "deleteHint": "此操作不可撤销。已保存的凭据（env）会一并删除，正在运行的实例将被终止。如需再次使用，请从目录重新安装。",
+    "deleteDone": "已删除服务器“{name}”。",
+    "deleteError": "删除失败"
   },
   "mcpCatalog": {
     "pageTitle": "MCP 目录",

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,5 +1,17 @@
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
+import { createRequire } from "node:module";
+
+/**
+ * 포트 단일 출처 — 루트 scripts/resolve-ports.cjs (우선순위: 셸 환경 > 루트 .env > 기본값).
+ * NEXT_PUBLIC_* 는 빌드 시점에 번들로 인라인되고 런타임 .env 로는 보정할 수 없다. 예전에는
+ * 빌드 명령에 `NEXT_PUBLIC_WEB_PORT=… NEXT_PUBLIC_WS_PORT=…` 를 직접 붙여야만 했고, 한 번만
+ * 빠뜨려도 기본 포트가 굳어 채팅 WS 가 엉뚱한 포트로 붙었다("서버와 연결이 끊겼습니다").
+ * 아래 env 로 주입해 맨 `npm run build` 로도 항상 옳은 값이 들어가게 한다.
+ */
+const { apiPort, webPort } = createRequire(import.meta.url)(
+  "../../scripts/resolve-ports.cjs",
+) as { apiPort: string; webPort: string };
 
 /**
  * 백엔드(Express + WS, 기본 :52416)와의 연동.
@@ -14,6 +26,12 @@ import createNextIntlPlugin from "next-intl/plugin";
 const API_PROXY_TARGET = process.env.API_PROXY_TARGET || "http://localhost:52416";
 
 const nextConfig: NextConfig = {
+  // 클라이언트 번들로 인라인될 공개 설정 — 위 주석 참고. 셸에서 직접 지정한 값이 있으면
+  // resolve-ports 가 그쪽을 우선하므로 install.sh 의 기존 주입도 그대로 유효하다.
+  env: {
+    NEXT_PUBLIC_WEB_PORT: webPort,
+    NEXT_PUBLIC_WS_PORT: apiPort,
+  },
   // 워크스페이스 공통 패키지(.ts 소스)를 Next 가 트랜스파일하도록 지정.
   transpilePackages: [
     "@openmake/shared-types",

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -22,9 +22,15 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-/** 포트/로그 위치는 .env 나 셸 환경으로 덮어쓸 수 있다 (No-Hardcoding). */
-const API_PORT = process.env.PORT || '52416';
-const WEB_PORT = process.env.OMK_WEB_PORT || '3000';
+/**
+ * 포트/로그 위치는 .env 나 셸 환경으로 덮어쓸 수 있다 (No-Hardcoding).
+ *
+ * 포트는 scripts/resolve-ports.cjs 가 단일 출처 — PM2 는 이 파일을 평가하는 시점의 셸 환경만
+ * 보므로, 예전처럼 `process.env` 만 읽으면 `PORT=… OMK_WEB_PORT=… pm2 start` 로 주입하지 않는 한
+ * 기본값(3000)으로 떨어져 다른 서비스와 EADDRINUSE 로 충돌했다. 이제 .env 를 직접 읽어
+ * 어떤 셸에서 `pm2 start ecosystem.config.js` 를 해도 같은 포트로 뜬다.
+ */
+const { apiPort: API_PORT, webPort: WEB_PORT } = require('./scripts/resolve-ports.cjs');
 /**
  * 로그 디렉터리. 기본은 기존 동작 유지(/tmp)지만, 여러 사용자가 쓰는 리눅스 호스트에서는
  * /tmp/openmake-*.log 소유자 충돌로 PM2 가 EACCES 로 죽는다 → OMK_LOG_DIR 로 분리 가능.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,9 @@ export default [
       "jest.config.js",
       "ecosystem.config.js",
       "scripts/build-info.js",
+      // .env 를 읽어 포트를 해석하는 부팅 전 스크립트 — pm2/next 설정이 require 로 로드한다.
+      // build-info.js 와 동일 취급(앱 소스 아님).
+      "scripts/resolve-ports.cjs",
       // CommonJS 로 dist 를 직접 로드하는 운영 스크립트(빌드 산출물 require 필요) —
       // build-info.js 와 동일 취급. 앱 소스가 아니라 lint 대상에서 제외한다.
       "scripts/eval/*.js",

--- a/scripts/resolve-ports.cjs
+++ b/scripts/resolve-ports.cjs
@@ -1,0 +1,56 @@
+/**
+ * 포트 해석 단일 출처(SSOT).
+ *
+ * 왜 필요한가 — PM2 와 Next 는 둘 다 "설정 파일을 평가하는 시점의 셸 환경"에서 포트를 읽는다.
+ * 앱의 dotenv 로딩보다 앞서므로 .env 에 적어도 반영되지 않고, 기동/빌드 명령에 매번
+ * `PORT=… OMK_WEB_PORT=…` 를 붙여야만 정상 동작했다. 그 주입을 한 번이라도 빠뜨리면:
+ *   - PM2  : 웹이 기본 3000 으로 떨어져 다른 서비스와 EADDRINUSE 충돌
+ *   - Next : NEXT_PUBLIC_* 가 기본값으로 번들에 인라인 → 채팅 WS 가 엉뚱한 포트로 붙어
+ *            "서버와 연결이 끊겼습니다" 가 지속 (런타임 .env 로 보정 불가)
+ * 이 모듈을 ecosystem.config.js 와 apps/web/next.config.ts 가 함께 써서, 호출자가
+ * 환경변수 주입을 잊어도 .env 만으로 정답이 나오게 한다.
+ *
+ * 우선순위: 셸 환경변수 > 루트 .env > 기본값 (기존 규칙 유지).
+ *
+ * ⚠️ process.env 를 오염시키지 않는다 — .env 전체를 빌드/PM2 프로세스에 주입하면
+ *    빌드 환경에 불필요한 비밀값이 노출되므로 parse 만 하고 필요한 키만 읽는다.
+ */
+const fs = require('fs');
+const path = require('path');
+const dotenv = require('dotenv');
+
+const ENV_PATH = path.resolve(__dirname, '..', '.env');
+
+/** 루트 .env 를 파싱한다. 파일이 없거나 읽기 실패해도 기동을 막지 않는다(전부 기본값). */
+function parseEnvFile() {
+    try {
+        return dotenv.parse(fs.readFileSync(ENV_PATH));
+    } catch {
+        return {};
+    }
+}
+
+const fileEnv = parseEnvFile();
+
+/** 셸 환경 > .env 순으로 첫 비어있지 않은 값. */
+function pick(key) {
+    return process.env[key] || fileEnv[key] || '';
+}
+
+/**
+ * 웹 포트. install.sh 는 웹 포트를 .env 에 별도 키로 남기지 않고 OMK_APP_URL 에만 담으므로,
+ * OMK_WEB_PORT 가 없으면 그 URL 끝 포트에서 역산한다 (install.sh 와 동일 규칙).
+ */
+function resolveWebPort() {
+    const explicit = pick('OMK_WEB_PORT');
+    if (explicit) return explicit;
+    const fromUrl = /:(\d+)\/?$/.exec(pick('OMK_APP_URL'));
+    return fromUrl ? fromUrl[1] : '3000';
+}
+
+/** 백엔드(Express + WS) 포트. */
+const apiPort = pick('PORT') || '52416';
+/** 프론트(Next) 포트. */
+const webPort = resolveWebPort();
+
+module.exports = { apiPort, webPort };


### PR DESCRIPTION
## 왜

`origin/feat/mcp-server-delete-button`(2026-08-21~26, PR 없이 방치)의 10커밋 중 결함 2건은 #677 로 회수했고, **나머지 8커밋을 전량 재이식**한다. main 대비 158 커밋 뒤처진 상태라 충돌을 하나씩 해소했으며, **main 이 그 사이 내린 결정을 되돌리지 않는 것**을 병합 원칙으로 삼았다.

## 재이식한 8커밋

| 커밋 | 내용 |
|---|---|
| `676a8185` | **포트 해석 SSOT** — `scripts/resolve-ports.cjs`(셸 환경 > 루트 `.env` > 기본값)를 `ecosystem.config.js`·`next.config.ts` 가 공유. PM2/Next 는 설정 평가 시점의 셸만 보므로 `PORT=… OMK_WEB_PORT=… pm2 start` 주입을 한 번만 빠뜨려도 웹이 3000 으로 떨어져 충돌하거나, `NEXT_PUBLIC_*` 가 기본값으로 번들에 굳어 WS 가 엉뚱한 포트로 붙었다 |
| `dbce28cf` | 관리자 MCP 카탈로그가 **API 가 실제로 받는 필드**만 보내도록 정정 |
| `6aac779a` | 에이전트 작업이 **목표가 요구한 출력 형식**을 지키도록 프롬프트·스킬 블록 보정 |
| `af4c5730` | 산출물을 `step_type='artifact'` 에 더해 **아티팩트 갤러리에도 영속** |
| `5f292977` | **템플릿당 다중 명명 인스턴스** + 부팅 시 복원(`listAutoSpawnUserIds`·`closeOrphanInstances`) + `PATCH /servers/:id` rename |
| `7fbcb655` | **에이전트 작업 결과 가독성** — 결말 블록(산출물·결과·미리보기) |
| `b3be2d68` | 설치 시 **인스턴스 이름 지정**·설치 후 이름 변경 |
| `4c638549` | 커넥터 목록에서 **MCP 등록 삭제**(권한 게이팅 `canDelete` 포함) |

## 충돌 해소 원칙 — main 의 결정을 되살리지 않는다

병합하며 **브랜치가 되돌리려던 main 의 개선을 그대로 지켰다**:

| 충돌 | 판단 |
|---|---|
| 카탈로그 `toolCount` 배지 | **main 유지(제거)** — 브랜치의 `showToolCount` 는 정의가 없고 `toolCount: 0` 고정이다(목업 잔재, PR #633 에서 제거된 것). **다중 인스턴스 설치 허용 버튼만** 채택 |
| `loadServers` 의 `catch { /* 목업 유지 (데모) */ }` | **목업 폴백 제거** — PR #634 이후 금지 패턴. 재조회 실패는 기존 목록 유지로 |
| `buildMockServers` 5종 | **되살리지 않음** — 브랜치 시점엔 있었으나 main 이 이미 제거 |
| 커넥터 Draft 탭 함수(`loadDrafts`·`handleApproveDraft`·`handleRejectDraft`) | **되살리지 않음** — `/approvals` 로 이관됨(PR #632). 같은 충돌 블록의 **`canDelete` 권한 판정만** 채택 |
| 표 액션 셀 | **main 유지**(`flex-wrap`·`whitespace-nowrap` = PR #630 표 깨짐 수정) + rename/삭제 버튼 삽입 |
| OAuth 로그인·`enabled`/`auto-spawn` 토글 | 전부 유지하고 브랜치 기능을 더함 |

## 재이식 정합 (마지막 커밋)

- `mcp.routes.ts` 가 rename 라우트로 **625줄 → Gate 3 위반** → 본문을 `routes/mcp-server-rename.ts` 로 분리(556줄). `mcp-global-connect.ts` 와 같은 패턴.
- `loadServers` 가 `handleToggleAutoSpawn` **안에 중첩**돼 스코프 밖 참조 불가였다(HEAD 블록의 닫는 중괄호가 충돌 범위 밖) → 함수 경계 복원.
- `scripts/resolve-ports.cjs` 를 eslint ignores 에 추가(`build-info.js`·`eval/*.js` 와 동일 취급).

## 운영 영향 확인 (포트 변경이라 실측)

| 값 | 변경 전 | 변경 후 | 운영 실측 |
|---|---|---|---|
| API 포트 | `process.env.PORT \|\| '52416'` | resolve-ports → **52416** | `:52416` LISTEN ✅ |
| 웹 포트 | `process.env.OMK_WEB_PORT \|\| '3000'` | resolve-ports → **3000** | `:3000` LISTEN ✅ |

`NEXT_PUBLIC_WEB_PORT`/`NEXT_PUBLIC_WS_PORT` 는 `use-chat-socket.ts` 가 이미 같은 기본값으로 읽고 있고 `.env.local` 에 해당 키가 없어 **주입 전후 동작이 같다**. 견고성만 오른다.

## 검증

- jest **3,201 pass / 0 fail** · api tsc · **web tsc** · **`npm run build:frontend-next` 성공** · lint **0 error** · Gate 3 통과(최대 580줄) · `eval:routing` 93.3% · `eval:response` 100%.

## 체크리스트

- [x] `npm run lint` (0 error) · `npm test` (3,201) · `eval:routing`/`eval:response`
- [x] 프론트 타입·프로덕션 빌드 통과
- [x] DB 스키마 변경 없음
- [x] 원저자 커밋(`iexcellodx`) 저작 정보 보존
- [x] 보안: 삭제/이름변경 모두 백엔드 권한 검사(`canDeleteServer`/`canUpdateServerEnv`) 유지, 프론트 게이팅은 UX 용

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbneZrk96Ct3eQHzVVPZve