### PR TITLE
chore(mcp): v1 SDK(@modelcontextprotocol/sdk) 제거 — v2 이전 마무리

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,7 +22,6 @@
     },
     "dependencies": {
         "@modelcontextprotocol/client": "^2.0.0",
-        "@modelcontextprotocol/sdk": "^1.30.0",
         "@mozilla/readability": "^0.6.0",
         "@openai-oauth/core": "^2.0.0",
         "@opendataloader/pdf": "^2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,10 +47,9 @@
         },
         "apps/api": {
             "name": "openmake-api",
-            "version": "1.33.1",
+            "version": "1.35.0",
             "dependencies": {
                 "@modelcontextprotocol/client": "^2.0.0",
-                "@modelcontextprotocol/sdk": "^1.30.0",
                 "@mozilla/readability": "^0.6.0",
                 "@openai-oauth/core": "^2.0.0",
                 "@opendataloader/pdf": "^2.5.0",
@@ -171,7 +170,7 @@
         },
         "apps/discord-bot": {
             "name": "openmake-discord-bot",
-            "version": "1.33.1",
+            "version": "1.35.0",
             "dependencies": {
                 "discord.js": "^14.16.3",
                 "dotenv": "^16.4.5"
@@ -198,7 +197,7 @@
         },
         "apps/web": {
             "name": "@openmake/web",
-            "version": "1.33.1",
+            "version": "1.35.0",
             "dependencies": {
                 "@openmake/api-client": "*",
                 "@openmake/config": "*",
@@ -1761,18 +1760,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/@hono/node-server": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
-            "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=20"
-            },
-            "peerDependencies": {
-                "hono": "^4"
-            }
-        },
         "node_modules/@humanfs/core": {
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -3028,66 +3015,6 @@
             "engines": {
                 "node": ">=20"
             }
-        },
-        "node_modules/@modelcontextprotocol/sdk": {
-            "version": "1.30.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
-            "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
-            "license": "MIT",
-            "dependencies": {
-                "@hono/node-server": "^1.19.9 || ^2.0.5",
-                "ajv": "^8.17.1",
-                "ajv-formats": "^3.0.1",
-                "content-type": "^1.0.5",
-                "cors": "^2.8.5",
-                "cross-spawn": "^7.0.5",
-                "eventsource": "^3.0.2",
-                "eventsource-parser": "^3.0.0",
-                "express": "^5.2.1",
-                "express-rate-limit": "^8.2.1",
-                "hono": "^4.11.4",
-                "jose": "^6.1.3",
-                "json-schema-typed": "^8.0.2",
-                "pkce-challenge": "^5.0.0",
-                "raw-body": "^3.0.0",
-                "zod": "^3.25 || ^4.0",
-                "zod-to-json-schema": "^3.25.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@cfworker/json-schema": "^4.1.1",
-                "zod": "^3.25 || ^4.0"
-            },
-            "peerDependenciesMeta": {
-                "@cfworker/json-schema": {
-                    "optional": true
-                },
-                "zod": {
-                    "optional": false
-                }
-            }
-        },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "license": "MIT"
         },
         "node_modules/@mozilla/readability": {
             "version": "0.6.0",
@@ -7856,41 +7783,6 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/ajv-formats": {
-            "version": "3.0.1",
-            "license": "MIT",
-            "dependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "ajv": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/ajv-formats/node_modules/ajv": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "license": "MIT"
-        },
         "node_modules/ansi-escapes": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -8965,17 +8857,6 @@
             "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/cors": {
-            "version": "2.8.5",
-            "license": "MIT",
-            "dependencies": {
-                "object-assign": "^4",
-                "vary": "^1"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
         },
         "node_modules/create-require": {
             "version": "1.1.1",
@@ -10384,22 +10265,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/fast-uri": {
-            "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
-            "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "BSD-3-Clause"
-        },
         "node_modules/fastq": {
             "version": "1.20.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -11113,15 +10978,6 @@
             "license": "MIT",
             "dependencies": {
                 "hermes-estree": "0.25.1"
-            }
-        },
-        "node_modules/hono": {
-            "version": "4.13.5",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
-            "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=16.9.0"
             }
         },
         "node_modules/html-encoding-sniffer": {
@@ -12977,10 +12833,6 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/json-schema-typed": {
-            "version": "8.0.2",
-            "license": "BSD-2-Clause"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -15033,6 +14885,7 @@
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -18889,13 +18742,6 @@
                 "url": "https://github.com/sponsors/colinhacks"
             }
         },
-        "node_modules/zod-to-json-schema": {
-            "version": "3.25.1",
-            "license": "ISC",
-            "peerDependencies": {
-                "zod": "^3.25 || ^4"
-            }
-        },
         "node_modules/zod-validation-error": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
@@ -18950,7 +18796,7 @@
         },
         "packages/api-client": {
             "name": "@openmake/api-client",
-            "version": "1.33.1",
+            "version": "1.35.0",
             "dependencies": {
                 "@openmake/config": "*",
                 "@openmake/shared-types": "*"
@@ -18962,7 +18808,7 @@
         },
         "packages/config": {
             "name": "@openmake/config",
-            "version": "1.33.1"
+            "version": "1.35.0"
         },
         "packages/local-bridge-core": {
             "name": "@openmake/local-bridge-core",
@@ -18976,7 +18822,7 @@
         },
         "packages/shared-types": {
             "name": "@openmake/shared-types",
-            "version": "1.33.1"
+            "version": "1.35.0"
         }
     }
 }


### PR DESCRIPTION
## 왜

PR #676(클라이언트 v2 이전)이 v1 SDK 를 **일부러 남겼습니다** — "운영 `dist` 가 아직 v1 을 require 하므로 배포 전에 의존성만 사라지면 pm2 재시작이 즉사한다"는 이유였습니다. 그 조건이 해소됐습니다.

| 확인 | 결과 |
|---|---|
| 소스 import | **0건** |
| **배포된 `dist` 의 v1 참조** | **0건** (v2 `@modelcontextprotocol/client` 5파일 사용) |
| 다른 패키지 의존 | 없음 (`apps/api` 직접 의존만) |
| 라이브 재연결 검증 | **완료** — 10/16 연결·도구 195개 |

지금은 순수한 미사용 의존성입니다.

## 무엇을

`@modelcontextprotocol/sdk` 의존성 제거뿐입니다. **코드 변경 0** — 협상 모드도 종전대로 legacy 기본이라 동작 변경이 없습니다.

## 검증

- 제거 후 `ExternalMCPClient` 로 **실제 stdio 서버 연결 재확인**(운영과 분리된 독립 프로세스): 도구 9개 발견 → `callTool` → `disconnect` 정상
- jest **3,201 pass / 0 fail** · tsc · lint **0 error** · `eval:routing` 93.3% · `eval:response` 100%

## 되돌리기

`npm i @modelcontextprotocol/sdk@^1.30.0 -w apps/api` — 코드 변경이 없어 의존성만 되돌리면 끝입니다.

## 체크리스트

- [x] `npm run lint` (0 error) · `npm test` (3,201) · `eval:routing`/`eval:response`
- [x] DB 스키마 변경 없음 · `.env.example` 변경 없음
- [x] 보안: 전송 계층·SSRF pinned fetch·docker 샌드박스 후킹 무변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbneZrk96Ct3eQHzVVPZve