### PR TITLE
fix(ops): 라우팅·TTFT 일일 집계가 로그를 못 찾던 문제 — OMK_LOG_DIR 반영

### DIFF
--- a/scripts/analyze-agent-routing.sh
+++ b/scripts/analyze-agent-routing.sh
@@ -17,7 +17,9 @@
 #   LLM 발동 14건 = 키워드와 동일 5건(낭비) / 개선 4건 / 헛짚음 5건 → 64%가 무익.
 set -euo pipefail
 
-LOG="${1:-/tmp/openmake-llm-out.log}"
+# 로그 위치는 pm2 의 OMK_LOG_DIR 을 따른다(#650 으로 /tmp 에서 영속 볼륨으로 이전).
+# 기본값을 /tmp 로 고정해 두면 이전 이후 매일 "로그 없음" 으로 집계가 조용히 실패한다.
+LOG="${1:-${OMK_LOG_DIR:-/tmp}/openmake-llm-out.log}"
 [ -f "$LOG" ] || { echo "로그 없음: $LOG"; exit 1; }
 echo "로그: $LOG"
 

--- a/scripts/analyze-chat-timing.sh
+++ b/scripts/analyze-chat-timing.sh
@@ -14,7 +14,9 @@
 #   [ChatTiming] prep=23ms ttfc=5676ms tool=2955ms turns=4 total=27135ms model=...
 set -euo pipefail
 
-LOG="${1:-/tmp/openmake-llm-out.log}"
+# 로그 위치는 pm2 의 OMK_LOG_DIR 을 따른다(#650 으로 /tmp 에서 영속 볼륨으로 이전).
+# 기본값을 /tmp 로 고정해 두면 이전 이후 매일 "로그 없음" 으로 집계가 조용히 실패한다.
+LOG="${1:-${OMK_LOG_DIR:-/tmp}/openmake-llm-out.log}"
 [ -f "$LOG" ] || { echo "로그 없음: $LOG"; exit 1; }
 
 echo "로그: $LOG"

--- a/scripts/daily-routing-report.sh
+++ b/scripts/daily-routing-report.sh
@@ -18,6 +18,10 @@
 set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# 로그 디렉터리는 .env 의 OMK_LOG_DIR 을 따른다 — pm2 cron 은 앱 env 를 상속하지 않으므로
+# 여기서 직접 읽는다(미설정이면 종전 /tmp).
+OMK_LOG_DIR="${OMK_LOG_DIR:-$(grep -E "^OMK_LOG_DIR=" "$REPO/.env" 2>/dev/null | tail -1 | cut -d= -f2- | tr -d '"')}"
+export OMK_LOG_DIR="${OMK_LOG_DIR:-/tmp}"
 OUT_DIR="$REPO/logs/routing-reports"          # logs/ 는 .gitignore 대상
 mkdir -p "$OUT_DIR"
 OUT="$OUT_DIR/$(date +%Y-%m-%d).txt"


### PR DESCRIPTION
## 왜

품질 플라이휠 Stage 3 의 판정 대상 4개를 진행하다 발견했습니다.

`#650` 이 pm2 로그를 `/tmp` 에서 영속 볼륨(`OMK_LOG_DIR`, 운영 `/Volumes/MAC_APP/logs`)으로 옮겼는데 분석 스크립트 기본값은 `/tmp/openmake-llm-out.log` 로 남았습니다. 그 이후 pm2 cron `routing-report`(매일 09:17)가 매번 이렇게 끝났습니다:

```
로그 없음: /tmp/openmake-llm-out.log
(라우팅 집계 실패)
(TTFT 집계 실패)
```

**조용히 빈 리포트만 쌓였고**(2026-08-30 리포트 실측), 이 집계는 **agent-resolver 게이트**(임계 `OMK_AGENT_KEYWORD_PRECLASSIFY_CONFIDENCE` 0.7→0.35 조정 효과)의 **유일한 데이터 소스**라 판정 대상 하나가 관측 불가 상태였습니다.

## 무엇을

- `analyze-agent-routing.sh` · `analyze-chat-timing.sh` — 기본 로그 경로를 `${OMK_LOG_DIR:-/tmp}/openmake-llm-out.log` 로. 인자로 넘기는 우선순위는 그대로입니다.
- `daily-routing-report.sh` — **pm2 cron 은 앱 env 를 상속하지 않으므로** `.env` 의 `OMK_LOG_DIR` 을 직접 읽어 export (미설정이면 종전 `/tmp` 동작).

## 검증

- 실행 시 `로그: /Volumes/MAC_APP/logs/openmake-llm-out.log` 로 **파일을 찾습니다**(종전엔 파일 자체를 못 찾음)
- `bash -n` 3개 통과. CI 의 shellcheck 게이트는 `install.sh`·`openmake_llm.sh` 대상이라 범위 밖입니다
- 표본은 채팅 트래픽이 쌓이면 채워집니다 — pm2-logrotate 가 자정에 회전하므로 09:17 집계는 그날 0시 이후분을 봅니다

## 체크리스트

- [x] `bash -n` 문법 통과
- [x] 실제 실행으로 경로 해결 확인
- [x] 코드(TS) 변경 없음 · DB 스키마 변경 없음 · `.env.example` 변경 없음
- [x] 되돌리기: revert 1커밋

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbneZrk96Ct3eQHzVVPZve