### PR TITLE
fix: HWP 첨부가 깨진 채 전송되던 문제 + 컨텍스트 초과 오안내 (두 겹)

### DIFF
--- a/apps/api/src/providers/provider-errors.ts
+++ b/apps/api/src/providers/provider-errors.ts
@@ -33,6 +33,8 @@ export type ProviderErrorCode =
     | 'MODEL_NOT_FOUND'
     | 'NOT_SUPPORTED'
     | 'UPSTREAM_ERROR'
+    /** 프롬프트가 모델 컨텍스트 한도를 넘음 — 재시도해도 같으므로 UPSTREAM_ERROR 와 분리한다. */
+    | 'CONTEXT_TOO_LARGE'
     | 'INVALID_MODEL_ID';
 
 /**

--- a/apps/api/src/services/chat-service/__tests__/context-too-large-classify.test.ts
+++ b/apps/api/src/services/chat-service/__tests__/context-too-large-classify.test.ts
@@ -1,0 +1,48 @@
+/**
+ * 컨텍스트 초과를 UPSTREAM_ERROR 로 오분류하지 않는다 (2026-08-31).
+ *
+ * 실측: HWP 첨부가 깨진 텍스트로 전송돼 프롬프트가 262,145 토큰이 되자 vLLM 이 400
+ * `ContextWindowExceededError` 를 냈는데, upstream 이 `code` 를 주지 않아 UPSTREAM_ERROR
+ * ("일시적인 오류 — 잠시 후 다시 시도") 로 안내됐다. 재시도해도 같은 실패라 오안내다.
+ *
+ * 분류는 external-provider 의 catch 에 있고 스트리밍 의존이 커서, 여기서는 그 판정에 쓰는
+ * 패턴 자체를 고정한다(구현이 바뀌어도 이 형태들은 계속 걸려야 한다).
+ */
+import { WS_PROVIDER_ERROR_MESSAGES } from '../../../sockets/ws-chat-locales';
+
+/** external-provider.ts 의 판정과 동일한 패턴 — 바뀌면 두 곳을 함께 고쳐야 한다. */
+const CONTEXT_PATTERN = /ContextWindowExceeded|maximum context length|context_length_exceeded|too many tokens/i;
+
+describe('컨텍스트 초과 분류', () => {
+    it('LiteLLM / OpenAI 호환 / vLLM 의 실제 문구를 모두 잡는다', () => {
+        const samples = [
+            'litellm.ContextWindowExceededError: litellm.BadRequestError: ContextWindowExceededError: OpenAIException',
+            "This model's maximum context length is 262144 tokens. However, you requested 0 output tokens and your prompt contains at least 262145 input tokens",
+            'Error code: 400 - context_length_exceeded',
+            'Request contains too many tokens',
+        ];
+        for (const s of samples) expect(CONTEXT_PATTERN.test(s)).toBe(true);
+    });
+
+    it('무관한 upstream 오류는 걸리지 않는다 (오탐 방지)', () => {
+        const samples = [
+            'InternalServerError: OpenAIException - Connection error.',
+            'Rate limit exceeded',
+            'invalid api key',
+            '502 Bad Gateway',
+        ];
+        for (const s of samples) expect(CONTEXT_PATTERN.test(s)).toBe(false);
+    });
+
+    it('모든 로케일에 CONTEXT_TOO_LARGE 안내가 있고 재시도를 권하지 않는다', () => {
+        const locales = Object.keys(WS_PROVIDER_ERROR_MESSAGES) as Array<keyof typeof WS_PROVIDER_ERROR_MESSAGES>;
+        expect(locales.length).toBeGreaterThanOrEqual(5);
+        for (const loc of locales) {
+            const msg = WS_PROVIDER_ERROR_MESSAGES[loc].CONTEXT_TOO_LARGE;
+            expect(typeof msg).toBe('string');
+            expect(msg.length).toBeGreaterThan(10);
+            // "잠시 후 다시" 류의 재시도 권유가 들어가면 오안내가 재발한다.
+            expect(msg).not.toMatch(/잠시 후|try again later|später erneut|plus tard|稍后重试|しばらくして/i);
+        }
+    });
+});

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -333,9 +333,15 @@ export async function runExternalStream(
             );
         }
     } catch (err) {
+        // 컨텍스트 초과는 **재시도해도 같다** — UPSTREAM_ERROR("잠시 후 다시 시도") 로 안내하면
+        // 사용자가 같은 실패를 반복한다. upstream 이 code 를 주지 않으므로 메시지로 판정한다
+        // (LiteLLM: `ContextWindowExceededError` / OpenAI 호환: `maximum context length`).
+        const rawMsg = err instanceof Error ? err.message : String(err ?? '');
         errorCode = err && typeof err === 'object' && 'code' in err
             ? String((err as { code: unknown }).code)
-            : 'UPSTREAM_ERROR';
+            : /ContextWindowExceeded|maximum context length|context_length_exceeded|too many tokens/i.test(rawMsg)
+                ? 'CONTEXT_TOO_LARGE'
+                : 'UPSTREAM_ERROR';
         // 접근 불가 판정 자동 학습 — provider 카탈로그에는 있으나 이 계정으로는 못 쓰는
         // 모델(Ollama Cloud 구독 전용 403, NVIDIA 계정별 404 등)을 목록에서 걸러내기 위해
         // 실패를 영속화한다. fire-and-forget — 기록 실패가 채팅 오류를 덮지 않는다.

--- a/apps/api/src/sockets/ws-chat-locales.ts
+++ b/apps/api/src/sockets/ws-chat-locales.ts
@@ -52,6 +52,7 @@ export const WS_PROVIDER_ERROR_MESSAGES: Record<string, Record<ProviderErrorCode
         MODEL_NOT_FOUND: '선택한 모델을 외부 LLM 제공자에서 찾을 수 없습니다. 모델 목록을 새로고침하거나 다른 모델을 선택하세요.',
         NOT_SUPPORTED: '선택한 모델이 이 기능을 지원하지 않습니다. 다른 모델을 시도해주세요.',
         UPSTREAM_ERROR: '외부 LLM 제공자에서 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+        CONTEXT_TOO_LARGE: '입력이 모델의 최대 길이를 초과했습니다. 첨부 파일을 줄이거나 대화를 새로 시작한 뒤 다시 시도해주세요.',
         INVALID_MODEL_ID: '모델 식별자 형식이 올바르지 않습니다. 모델 목록에서 다시 선택해주세요.',
     },
     en: {
@@ -64,6 +65,7 @@ export const WS_PROVIDER_ERROR_MESSAGES: Record<string, Record<ProviderErrorCode
         MODEL_NOT_FOUND: 'The selected model was not found at the external LLM provider. Please refresh the model list or select a different model.',
         NOT_SUPPORTED: 'The selected model does not support this feature. Please try a different model.',
         UPSTREAM_ERROR: 'A temporary error occurred at the external LLM provider. Please try again later.',
+        CONTEXT_TOO_LARGE: 'The input exceeds the model context limit. Reduce attachments or start a new conversation, then try again.',
         INVALID_MODEL_ID: 'The model identifier format is invalid. Please reselect from the model list.',
     },
     ja: {
@@ -76,6 +78,7 @@ export const WS_PROVIDER_ERROR_MESSAGES: Record<string, Record<ProviderErrorCode
         MODEL_NOT_FOUND: '選択したモデルが外部LLMプロバイダーで見つかりません。モデル一覧を更新するか、別のモデルを選択してください。',
         NOT_SUPPORTED: '選択したモデルはこの機能をサポートしていません。別のモデルをお試しください。',
         UPSTREAM_ERROR: '外部LLMプロバイダーで一時的なエラーが発生しました。しばらくしてから再度お試しください。',
+        CONTEXT_TOO_LARGE: '入力がモデルの最大長を超えました。添付を減らすか、新しい会話を開始してから再度お試しください。',
         INVALID_MODEL_ID: 'モデル識別子の形式が正しくありません。モデル一覧から再選択してください。',
     },
     zh: {
@@ -88,6 +91,7 @@ export const WS_PROVIDER_ERROR_MESSAGES: Record<string, Record<ProviderErrorCode
         MODEL_NOT_FOUND: '外部LLM提供商找不到所选模型。请刷新模型列表或选择其他模型。',
         NOT_SUPPORTED: '所选模型不支持此功能。请尝试其他模型。',
         UPSTREAM_ERROR: '外部LLM提供商发生临时错误。请稍后重试。',
+        CONTEXT_TOO_LARGE: '输入超出模型的最大长度。请减少附件或开始新对话后重试。',
         INVALID_MODEL_ID: '模型标识符格式无效。请从模型列表中重新选择。',
     },
     es: {
@@ -100,6 +104,7 @@ export const WS_PROVIDER_ERROR_MESSAGES: Record<string, Record<ProviderErrorCode
         MODEL_NOT_FOUND: 'El modelo seleccionado no se encontró en el proveedor LLM externo. Por favor, actualice la lista de modelos o seleccione un modelo diferente.',
         NOT_SUPPORTED: 'El modelo seleccionado no admite esta función. Por favor, pruebe un modelo diferente.',
         UPSTREAM_ERROR: 'Se produjo un error temporal en el proveedor LLM externo. Por favor, inténtelo de nuevo más tarde.',
+        CONTEXT_TOO_LARGE: 'La entrada supera el límite de contexto del modelo. Reduzca los archivos adjuntos o inicie una nueva conversación e inténtelo de nuevo.',
         INVALID_MODEL_ID: 'El formato del identificador del modelo no es válido. Por favor, vuelva a seleccionar de la lista de modelos.',
     },
     de: {
@@ -112,6 +117,7 @@ export const WS_PROVIDER_ERROR_MESSAGES: Record<string, Record<ProviderErrorCode
         MODEL_NOT_FOUND: 'Das ausgewählte Modell wurde beim externen LLM-Anbieter nicht gefunden. Bitte aktualisieren Sie die Modellliste oder wählen Sie ein anderes Modell.',
         NOT_SUPPORTED: 'Das ausgewählte Modell unterstützt diese Funktion nicht. Bitte versuchen Sie ein anderes Modell.',
         UPSTREAM_ERROR: 'Beim externen LLM-Anbieter ist ein vorübergehender Fehler aufgetreten. Bitte versuchen Sie es später erneut.',
+        CONTEXT_TOO_LARGE: 'Die Eingabe überschreitet das Kontextlimit des Modells. Reduzieren Sie die Anhänge oder starten Sie eine neue Unterhaltung und versuchen Sie es erneut.',
         INVALID_MODEL_ID: 'Das Format der Modellkennung ist ungültig. Bitte wählen Sie aus der Modellliste neu aus.',
     },
     fr: {
@@ -124,6 +130,7 @@ export const WS_PROVIDER_ERROR_MESSAGES: Record<string, Record<ProviderErrorCode
         MODEL_NOT_FOUND: 'Le modèle sélectionné est introuvable chez le fournisseur LLM externe. Veuillez actualiser la liste des modèles ou sélectionner un autre modèle.',
         NOT_SUPPORTED: 'Le modèle sélectionné ne prend pas en charge cette fonctionnalité. Veuillez essayer un autre modèle.',
         UPSTREAM_ERROR: 'Une erreur temporaire s\'est produite chez le fournisseur LLM externe. Veuillez réessayer plus tard.',
+        CONTEXT_TOO_LARGE: 'L\'entrée dépasse la limite de contexte du modèle. Réduisez les pièces jointes ou démarrez une nouvelle conversation, puis réessayez.',
         INVALID_MODEL_ID: 'Le format de l\'identifiant du modèle est invalide. Veuillez resélectionner dans la liste des modèles.',
     },
 };

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -52,7 +52,11 @@ const MAX_INLINE_DOC_BYTES = 30 * 1024 * 1024;
 //  - 이미지(image/*) → base64 data URL → vision 채널(images)
 //  - 문서(EXTRACT_EXTS: PDF/Word/Excel/PowerPoint 등) → base64 원본(data) → 백엔드가 텍스트 추출
 //  - 그 외 → 텍스트로 읽어 content (바이너리는 깨질 수 있으나 백엔드가 메타로 처리)
-const EXTRACT_EXTS = ["pdf", "docx", "xlsx", "pptx", "odt", "odp", "ods", "rtf"];
+// 백엔드가 추출하는 형식 — 이 목록에 없으면 readAsText 로 읽혀 **깨진 바이너리가 content 로**
+// 전송되고, 서버는 "이미 content 있음" 으로 추출을 건너뛴다(조용한 실패). hwp/hwpx/hml 은
+// kordoc 경로가 생겼는데 여기 누락돼 363KB 문서가 140K 토큰 쓰레기로 들어갔다(2026-08-31 실측).
+// ⚠️ 백엔드 DOC_EXTRACT_LIMITS 의 PDF_EXTS·OFFICE_EXTS·HWP_EXTS 와 한 쌍으로 유지할 것.
+const EXTRACT_EXTS = ["pdf", "docx", "xlsx", "pptx", "odt", "odp", "ods", "rtf", "hwp", "hwpx", "hml"];
 
 const extOf = (name: string): string => {
   const i = name.lastIndexOf(".");


### PR DESCRIPTION
## 왜 — 한 사건의 두 겹

실제 363KB HWP 5.x 파일을 chat.openmake.cc 에 첨부해 검증하다 드러났습니다.

### 겹 1 — 백엔드는 고쳤는데 프론트가 막고 있었다

#683 으로 백엔드에 kordoc HWP 추출을 넣었지만, `composer.tsx` 의 목록에 hwp 계열이 빠져 있었습니다:

```ts
const EXTRACT_EXTS = ["pdf", "docx", "xlsx", "pptx", "odt", "odp", "ods", "rtf"];  // hwp 없음
```

이 목록에 없으면 `readAsText` 로 읽습니다 →

1. `.hwp` 가 **깨진 바이너리 텍스트로 `content` 에 담겨** 전송
2. 서버 `extractAttachedDocuments` 는 `if (typeof f.content === 'string') continue` 로 **추출을 건너뜀**(DocExtract 로그가 안 남아 조용한 실패)
3. 363KB 가 그대로 들어가 프롬프트 **262,145 토큰** → vLLM 400

**같은 파일을 서버측에서 직접 넣으면 정상**입니다 — `detectFormat=hwp`, 11페이지, **13,859자를 17ms** 에 추출(표·문단 보존). 백엔드 파싱은 처음부터 정상이었고 입구만 막혀 있었습니다.

### 겹 2 — 그 실패가 "일시적 오류"로 안내됐다

upstream 이 `err.code` 를 주지 않아 전부 `UPSTREAM_ERROR` 로 떨어졌고, 사용자에게는 **"일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요."** 가 나갔습니다. 재시도해도 같은 실패라 오안내이고, 실제로 같은 첨부로 반복 실패가 관측됐습니다(06:57 · 06:58 · 07:03).

⚠️ 부수 확인: 우리 로그의 토큰 추정은 `input=~140,586` 으로 **실제(262,145)의 53%** 였습니다. `estimateTokens` 가 U+FFFD(치환문자)를 0.5 토큰으로 세는데 실제 토크나이저는 2~3 토큰을 씁니다 — 그래서 context-fit 안전망도 발동하지 않았습니다. 겹 1 이 고쳐지면 이 입력 자체가 사라지므로 추정기 보정은 별건으로 둡니다.

## 무엇을

| 커밋 | 내용 |
|---|---|
| `bf564b5d` | `EXTRACT_EXTS` 에 `hwp`·`hwpx`·`hml` 추가. ⚠️ 이 목록은 백엔드 `DOC_EXTRACT_LIMITS`(`PDF_EXTS`·`OFFICE_EXTS`·`HWP_EXTS`)와 **한 쌍** — 주석으로 명시 |
| `105f6c9a` | `ProviderErrorCode` 에 **`CONTEXT_TOO_LARGE`** 추가 + `external-provider` 에서 upstream 메시지로 판정 + **7개 로케일** 안내("첨부를 줄이거나 대화를 새로 시작하세요") |

## 검증

- **테스트 3건 신규** — 실제 upstream 문구 4종(LiteLLM·OpenAI 호환·vLLM 원문)을 모두 잡고, 무관한 오류(연결 실패·rate limit·인증·502)는 걸리지 않으며, **모든 로케일이 재시도를 권하지 않는지** 강제
- jest **3,207 pass** · api·web tsc · lint **0 error** · `eval:routing` 93.3% · `eval:response` 100%
- (`rate-limiter-isolation` 1건은 전체 실행에서만 깨지는 기존 flaky — 단독 실행 시 5/5 통과, 이 변경과 무관)

## 배포 후 재검증 예정

같은 HWP 파일을 웹에서 다시 첨부해 ① DocExtract 로그가 남고 ② 본문이 마크다운으로 들어가며 ③ 정상 답변이 오는지 확인합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbneZrk96Ct3eQHzVVPZve