### PR TITLE
fix(llm): 문자 기반 토큰 추정의 과소추정 — 임계 근처에서만 실제 토크나이저로 재계산

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -176,6 +176,15 @@ LLM_WEEKLY_TOKEN_LIMIT=5000000
 # LLM_POOL_MIN_OUTPUT_TOKENS=4096                 # 안전망 최소 출력 보장
 # LLM_POOL_TOKENS_PER_IMAGE=1500                  # vision 이미지 1장당 토큰 추정치 (overflow 방지)
 
+# --- 정확 토큰 재계산 (문자 추정 과소추정 보정) ---
+# 문자 기반 추정은 BPE 병합률을 몰라 고엔트로피 입력(바이너리 as-text·base64·hex·JSON 로그)에서
+# 실제의 30~61% 로 과소추정한다 → 안전망을 통과해 upstream 400. 아래를 설정하면 문자 추정이
+# 임계 비율을 넘을 때만 모델 자신의 토크나이저로 정확히 재계산한다 (미설정 시 기능 off, 종전 동작).
+# LLM_TOKENIZE_URL=http://<vllm-host>:8002/tokenize  # vLLM /tokenize endpoint (게이트웨이 아님)
+# LLM_TOKENIZE_API_KEY=                              # 미설정 시 LLM_API_KEY 재사용
+# LLM_POOL_TOKENIZE_EXACT_RATIO=0.5                  # 유효 컨텍스트 대비 이 비율 초과 시에만 호출
+# LLM_POOL_TOKENIZE_TIMEOUT_MS=3000                  # 초과 시 fail-open (문자 추정 유지)
+
 # ChatGPT OAuth (구독 로그인, provider 'chatgpt') — 기본값은 코드 내 상수.
 # ⚠️ Codex CLI 차용 비공식 endpoint — OpenAI 변경 시 아래로 무중단 오버라이드.
 # CHATGPT_OAUTH_CLIENT_ID=app_EMoamEEZ73f0CkXaXp7hrann

--- a/apps/api/src/__tests__/exact-tokenizer.test.ts
+++ b/apps/api/src/__tests__/exact-tokenizer.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Exact Tokenizer + 보정 계수 안전망 테스트.
+ *
+ * 배경(2026-08-31 실측): 문자 추정은 고엔트로피 입력에서 실제의 30~61% 로 과소추정해
+ * 안전망을 그대로 통과시킨다. 임계 근처에서만 모델 토크나이저로 재계산하고, 그 비를
+ * 절단 예산에 적용해 두 척도를 정합시킨다. 전 구간 fail-open.
+ */
+import type { ChatMessage } from '../llm/types';
+
+const ORIGINAL_ENV = { ...process.env };
+
+/** env 를 바꾼 뒤 config/llm 모듈을 새로 로드한다 (모듈 로드 시점에 env 를 읽으므로). */
+function loadWithEnv(env: Record<string, string | undefined>) {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV, ...env };
+    return {
+        tokenizer: require('../llm/exact-tokenizer') as typeof import('../llm/exact-tokenizer'),
+        pool: require('../llm/model-pool') as typeof import('../llm/model-pool'),
+    };
+}
+
+afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    jest.resetModules();
+    jest.restoreAllMocks();
+});
+
+describe('isExactTokenizeEnabled', () => {
+    it('LLM_TOKENIZE_URL 미설정 → off (기존 동작 유지)', () => {
+        const { tokenizer } = loadWithEnv({ LLM_TOKENIZE_URL: undefined });
+        expect(tokenizer.isExactTokenizeEnabled()).toBe(false);
+    });
+
+    it('LLM_TOKENIZE_URL 설정 → on', () => {
+        const { tokenizer } = loadWithEnv({ LLM_TOKENIZE_URL: 'http://vllm:8002/tokenize' });
+        expect(tokenizer.isExactTokenizeEnabled()).toBe(true);
+    });
+});
+
+describe('countExactTokens', () => {
+    const msgs: ChatMessage[] = [{ role: 'user', content: 'hello' }];
+
+    it('off 상태면 호출 없이 null', async () => {
+        const { tokenizer } = loadWithEnv({ LLM_TOKENIZE_URL: undefined });
+        const spy = jest.spyOn(global, 'fetch' as never);
+        expect(await tokenizer.countExactTokens(msgs, 'm')).toBeNull();
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('count 를 그대로 반환하고 이미지 토큰을 가산', async () => {
+        const { tokenizer } = loadWithEnv({
+            LLM_TOKENIZE_URL: 'http://vllm:8002/tokenize',
+            LLM_POOL_TOKENS_PER_IMAGE: '1500',
+        });
+        jest.spyOn(global, 'fetch' as never).mockResolvedValue({
+            ok: true, json: async () => ({ count: 100 }),
+        } as never);
+        const withImage: ChatMessage[] = [{ role: 'user', content: 'hi', images: ['b64'] }];
+        expect(await tokenizer.countExactTokens(withImage, 'm')).toBe(100 + 1500);
+    });
+
+    it('assistant.tool_calls 의 함수명·인자를 payload 에 포함 (도구 루프 과소추정 방지)', async () => {
+        const { tokenizer } = loadWithEnv({ LLM_TOKENIZE_URL: 'http://vllm:8002/tokenize' });
+        const spy = jest.spyOn(global, 'fetch' as never).mockResolvedValue({
+            ok: true, json: async () => ({ count: 10 }),
+        } as never);
+        await tokenizer.countExactTokens(
+            [{
+                role: 'assistant', content: '',
+                tool_calls: [{ id: 'c1', type: 'function' as const, function: { name: 'web_search', arguments: { q: 'x' } } }],
+            }],
+            'm',
+        );
+        const body = JSON.parse((spy.mock.calls[0][1] as RequestInit).body as string);
+        expect(body.messages[0].content).toContain('web_search');
+        expect(body.messages[0].content).toContain('{"q":"x"}');  // Record → JSON 직렬화
+    });
+
+    it.each([
+        ['HTTP 실패', { ok: false, status: 500 }],
+        ['count 필드 없음', { ok: true, json: async () => ({}) }],
+    ])('%s → null (fail-open)', async (_label, response) => {
+        const { tokenizer } = loadWithEnv({ LLM_TOKENIZE_URL: 'http://vllm:8002/tokenize' });
+        jest.spyOn(global, 'fetch' as never).mockResolvedValue(response as never);
+        expect(await tokenizer.countExactTokens(msgs, 'm')).toBeNull();
+    });
+
+    it('네트워크 예외 → null (fail-open)', async () => {
+        const { tokenizer } = loadWithEnv({ LLM_TOKENIZE_URL: 'http://vllm:8002/tokenize' });
+        jest.spyOn(global, 'fetch' as never).mockRejectedValue(new Error('ECONNREFUSED') as never);
+        expect(await tokenizer.countExactTokens(msgs, 'm')).toBeNull();
+    });
+});
+
+describe('selectModelByCapacityExact — 보정 계수', () => {
+    /** 문자 추정 ~26K(임계 미달) / ~210K(임계 초과) 를 만드는 한국어 본문. */
+    const small: ChatMessage[] = [{ role: 'user', content: '가'.repeat(25_000) }];
+    /** 3개로 나눠 절단 여지를 둔다 (단일 메시지는 잘라낼 수 없어 overflow 가 정답). */
+    const large: ChatMessage[] = Array.from({ length: 3 }, () => ({
+        role: 'user' as const, content: '가'.repeat(70_000),
+    }));
+
+    it('임계 미달이면 tokenize 를 호출하지 않는다 (평상시 TTFT 무영향)', async () => {
+        const { pool } = loadWithEnv({ LLM_TOKENIZE_URL: 'http://vllm:8002/tokenize' });
+        const spy = jest.spyOn(global, 'fetch' as never);
+        const d = await pool.selectModelByCapacityExact(small, { num_predict: 1000 });
+        expect(spy).not.toHaveBeenCalled();
+        expect(d.source).toBe('auto');
+    });
+
+    it('임계 초과 + 실제가 추정보다 크면 절단이 더 공격적으로 적용된다', async () => {
+        const { pool } = loadWithEnv({ LLM_TOKENIZE_URL: 'http://vllm:8002/tokenize' });
+        const rough = pool.estimateMessageTokens(large);
+        // 실측 최악(base64/hex ≈ 추정의 3배) 재현
+        jest.spyOn(global, 'fetch' as never).mockResolvedValue({
+            ok: true, json: async () => ({ count: rough * 3 }),
+        } as never);
+        const d = await pool.selectModelByCapacityExact(large, { num_predict: 8192 });
+        expect(d.source).toMatch(/auto_trimmed/);
+        // 보정 없이 문자 추정만 쓰면 이 입력은 그대로 통과했다(= upstream 400).
+        const uncalibrated = pool.selectModelByCapacity(large, { num_predict: 8192 });
+        expect(uncalibrated.source).toBe('auto');
+    });
+
+    it('tokenize 실패 시 문자 추정 그대로 (fail-open — 종전 판정과 동일)', async () => {
+        const { pool } = loadWithEnv({ LLM_TOKENIZE_URL: 'http://vllm:8002/tokenize' });
+        jest.spyOn(global, 'fetch' as never).mockRejectedValue(new Error('timeout') as never);
+        const d = await pool.selectModelByCapacityExact(large, { num_predict: 8192 });
+        expect(d).toEqual(pool.selectModelByCapacity(large, { num_predict: 8192 }));
+    });
+
+    it('options.model 명시 → manual 우회 (tokenize 호출 없음)', async () => {
+        const { pool } = loadWithEnv({ LLM_TOKENIZE_URL: 'http://vllm:8002/tokenize' });
+        const spy = jest.spyOn(global, 'fetch' as never);
+        const d = await pool.selectModelByCapacityExact(large, { model: 'x', num_predict: 100 });
+        expect(d.source).toBe('manual');
+        expect(spy).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/config/model-pool.ts
+++ b/apps/api/src/config/model-pool.ts
@@ -16,6 +16,13 @@ function parseIntEnv(key: string, defaultValue: number): number {
     return Number.isFinite(n) ? n : defaultValue;
 }
 
+function parseFloatEnv(key: string, defaultValue: number): number {
+    const v = process.env[key];
+    if (v === undefined) return defaultValue;
+    const n = parseFloat(v);
+    return Number.isFinite(n) ? n : defaultValue;
+}
+
 function parseBoolEnv(key: string, defaultValue: boolean): boolean {
     const v = process.env[key];
     if (v === undefined) return defaultValue;
@@ -35,6 +42,23 @@ const minOutputTokens = parseIntEnv('LLM_POOL_MIN_OUTPUT_TOKENS', 4096);
 //  방지를 위해 보수적 고정값 사용. base64 텍스트 길이가 아닌 디코딩 후 토큰 기준.)
 const tokensPerImage = parseIntEnv('LLM_POOL_TOKENS_PER_IMAGE', 1500);
 
+// --- 정확 토큰 재계산 (exact tokenize) ---
+// 문자 기반 추정은 BPE 병합률을 모른다 — 2026-08-31 실측(qwen3.6, vLLM /tokenize):
+// 산문 101~123%(보수적)인 반면 JSON 로그 61%, 바이너리 as-text 40~50%,
+// base64 36%, hex 30% 로 **과소추정**한다(고엔트로피·구두점 밀집 텍스트에서 BPE 가
+// 병합하지 못해 문자당 실제 비용이 0.25 가 아니라 0.4~0.97 토큰). 문자 클래스 가중치로는
+// 덮이지 않는다(제어문자 필요 가중치가 구간별 1.22~3.99 로 흔들리고, base64/hex 는
+// 제어문자가 0개인데도 30%대). 그래서 **임계 근처에서만** 모델 자신의 토크나이저로
+// 정확히 재계산한다 — 평상시 산문 요청은 임계에 못 닿아 추가 호출이 없다.
+/** vLLM `/tokenize` endpoint (예: http://<vllm-host>:8002/tokenize). 미설정 시 기능 off. */
+const tokenizeUrl = process.env.LLM_TOKENIZE_URL ?? '';
+/** tokenize endpoint 인증 키 (미설정 시 LLM_API_KEY 재사용). */
+const tokenizeApiKey = process.env.LLM_TOKENIZE_API_KEY ?? process.env.LLM_API_KEY ?? '';
+/** 문자 추정이 유효 컨텍스트의 이 비율을 넘을 때만 정확 재계산 (0~1). */
+const tokenizeExactRatio = parseFloatEnv('LLM_POOL_TOKENIZE_EXACT_RATIO', 0.5);
+/** tokenize 호출 타임아웃 — 초과 시 fail-open(문자 추정 유지). */
+const tokenizeTimeoutMs = parseIntEnv('LLM_POOL_TOKENIZE_TIMEOUT_MS', 3000);
+
 export const MODEL_POOL_CONFIG = {
     enabled,
     defaultModel,
@@ -43,6 +67,10 @@ export const MODEL_POOL_CONFIG = {
     routingMaxTokensDefault,
     minOutputTokens,
     tokensPerImage,
+    tokenizeUrl,
+    tokenizeApiKey,
+    tokenizeExactRatio,
+    tokenizeTimeoutMs,
     // derived effective capacity (nominal * (1 - margin/100))
     /** @deprecated 모델 무관 고정값 — 안전망은 resolveEffectiveContext(modelId) 를 쓴다. 진단·표시용으로만 잔존. */
     effectiveDefault: Math.floor(defaultCtx * (1 - defaultMarginPct / 100)),

--- a/apps/api/src/llm/client.ts
+++ b/apps/api/src/llm/client.ts
@@ -25,7 +25,7 @@ import { getApiUsageTracker } from './usage-tracker';
 import { checkUserQuota, recordUserUsage } from './user-quota';
 import { streamChat, nonStreamChat } from './stream-parser';
 import { buildExtraBody } from './reasoning-adapter';
-import { selectModelByCapacity } from './model-pool';
+import { selectModelByCapacityExact } from './model-pool';
 import { MODEL_POOL_CONFIG } from '../config/model-pool';
 import {
     webSearch as webSearchAdapter,
@@ -122,7 +122,7 @@ export class LLMClient {
         // 다른 model 로 인스턴스화 됐으면 manual 우회 (사용자 명시 모델 존중).
         const isDefaultModel = this.config.model === MODEL_POOL_CONFIG.defaultModel;
         const poolDecision = isDefaultModel
-            ? selectModelByCapacity(messages, { num_predict: options?.num_predict })
+            ? await selectModelByCapacityExact(messages, { num_predict: options?.num_predict })
             : { model: this.config.model, source: 'manual' as const };
 
         if (poolDecision.source !== 'manual') {

--- a/apps/api/src/llm/exact-tokenizer.ts
+++ b/apps/api/src/llm/exact-tokenizer.ts
@@ -1,0 +1,98 @@
+/**
+ * Exact Tokenizer — 모델 자신의 토크나이저로 입력 토큰을 정확히 센다.
+ *
+ * 왜 필요한가: `estimateTokens` 는 문자 클래스 가중치라 BPE 병합률을 모른다.
+ * 2026-08-31 실측(qwen3.6, vLLM `/tokenize`) — 추정/실제 비율:
+ *   산문 101~123% · TS 코드 106% (보수적, 문제 없음)
+ *   JSON 로그 61% · 바이너리 as-text 40~50% · base64 36% · hex 30% (과소추정)
+ * 고엔트로피·구두점 밀집 텍스트는 BPE 가 병합하지 못해 문자당 실제 비용이
+ * 0.25 가 아니라 0.4~0.97 토큰이다. 과소추정은 안전망을 통과시켜 upstream 400
+ * (ContextWindowExceeded) 으로 이어지므로, 임계 근처에서만 이 모듈로 재계산한다.
+ *
+ * 게이트웨이(LiteLLM) 의 `/utils/token_counter` 는 쓰지 않는다 — openai_tokenizer(cl100k)
+ * 기반이라 같은 실측에서 한국어 157%(과대) · hex 64%(과소) 로 어긋났다.
+ *
+ * 전 구간 fail-open: 미설정·실패·타임아웃은 null 을 돌려 문자 추정을 그대로 쓴다.
+ *
+ * @module llm/exact-tokenizer
+ */
+import { MODEL_POOL_CONFIG } from '../config/model-pool';
+import { createLogger } from '../utils/logger';
+import type { ChatMessage } from './types';
+
+const logger = createLogger('ExactTokenizer');
+
+/** tokenize 대상 payload — 이미지는 base64 라 보내지 않고 별도 가산한다. */
+interface TokenizePayloadMessage {
+    role: string;
+    content: string;
+}
+
+/** 설정이 갖춰졌는지 — 미설정이면 기능 off (기존 동작 유지). */
+export function isExactTokenizeEnabled(): boolean {
+    return MODEL_POOL_CONFIG.tokenizeUrl.length > 0;
+}
+
+/**
+ * assistant.tool_calls / tool 메시지는 content 가 비어 있어도 실제 payload 에는
+ * 함수명·인자 JSON 이 실린다. 누락하면 도구 루프에서 과소추정이 되므로 직렬화해 합친다.
+ */
+function toPayloadMessage(m: ChatMessage): TokenizePayloadMessage {
+    let content = m.content || '';
+    if (m.tool_calls?.length) {
+        // arguments 는 Record 라 템플릿 연결 시 "[object Object]" 가 된다 — 직렬화 필수.
+        content += m.tool_calls
+            .map((tc) => `${tc.function?.name ?? ''}${JSON.stringify(tc.function?.arguments ?? {})}`)
+            .join('');
+    }
+    return { role: m.role, content };
+}
+
+/**
+ * 실제 입력 토큰 수 — 챗 템플릿 오버헤드 포함. 실패 시 null (fail-open).
+ *
+ * 이미지는 payload 에서 제외하고 `tokensPerImage` 로 가산한다 (추정기와 동일 규약).
+ */
+export async function countExactTokens(
+    messages: ChatMessage[],
+    model: string,
+): Promise<number | null> {
+    if (!isExactTokenizeEnabled()) return null;
+
+    const imageTokens = messages.reduce(
+        (sum, m) => sum + (m.images?.length ?? 0) * MODEL_POOL_CONFIG.tokensPerImage,
+        0,
+    );
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), MODEL_POOL_CONFIG.tokenizeTimeoutMs);
+    try {
+        const res = await fetch(MODEL_POOL_CONFIG.tokenizeUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                ...(MODEL_POOL_CONFIG.tokenizeApiKey
+                    ? { Authorization: `Bearer ${MODEL_POOL_CONFIG.tokenizeApiKey}` }
+                    : {}),
+            },
+            body: JSON.stringify({ model, messages: messages.map(toPayloadMessage) }),
+            signal: controller.signal,
+        });
+        if (!res.ok) {
+            logger.warn(`[ExactTokenize] HTTP ${res.status} — 문자 추정 유지 (fail-open)`);
+            return null;
+        }
+        const data = (await res.json()) as { count?: number };
+        if (typeof data.count !== 'number' || !Number.isFinite(data.count)) {
+            logger.warn('[ExactTokenize] count 필드 없음 — 문자 추정 유지 (fail-open)');
+            return null;
+        }
+        return data.count + imageTokens;
+    } catch (err) {
+        const reason = err instanceof Error && err.name === 'AbortError' ? 'timeout' : String(err);
+        logger.warn(`[ExactTokenize] 실패 (${reason}) — 문자 추정 유지 (fail-open)`);
+        return null;
+    } finally {
+        clearTimeout(timer);
+    }
+}

--- a/apps/api/src/llm/model-pool.ts
+++ b/apps/api/src/llm/model-pool.ts
@@ -12,10 +12,14 @@
  */
 import { MODEL_POOL_CONFIG, resolveEffectiveContext } from '../config/model-pool';
 import { ContextOverflowError } from '../errors/context-overflow.error';
+import { countExactTokens, isExactTokenizeEnabled } from './exact-tokenizer';
+import { createLogger } from '../utils/logger';
 import type { ChatMessage, ModelOptions } from './types';
 
 /** tokenizer overhead 안전 마진 — system prompt boilerplate 등 */
 const SAFETY_BUFFER = 256;
+
+const logger = createLogger('ModelPool');
 
 export interface ModelPoolDecision {
     /** 사용할 model ID (LLMClient.chat 에 body.model 로 전달) */
@@ -139,6 +143,11 @@ export function truncateMessagesPreservingSystem(
 export function reduceToFit(
     messages: ChatMessage[],
     options: Pick<ModelOptions, 'num_predict'>,
+    /**
+     * 문자 추정 보정 계수 (실제 토큰 / 문자 추정). 1 = 보정 없음.
+     * 절단 판정은 문자 추정으로 하되 예산을 이 계수로 나눠 실제 토큰 기준과 맞춘다.
+     */
+    scale = 1,
 ): ModelPoolDecision {
     const requested = options.num_predict ?? MODEL_POOL_CONFIG.routingMaxTokensDefault;
     const model = MODEL_POOL_CONFIG.defaultModel;
@@ -147,9 +156,10 @@ export function reduceToFit(
     const minOutput = MODEL_POOL_CONFIG.minOutputTokens;
 
     // 1단계: input truncate
-    const inputBudget = effective - requested - SAFETY_BUFFER;
+    // truncate 는 문자 추정으로 누적하므로 예산을 보정 계수로 나눠 실제 토큰 기준과 맞춘다.
+    const inputBudget = Math.floor((effective - requested - SAFETY_BUFFER) / scale);
     const trimmed = truncateMessagesPreservingSystem(messages, inputBudget);
-    const newInputTokens = estimateMessageTokens(trimmed);
+    const newInputTokens = Math.ceil(estimateMessageTokens(trimmed) * scale);
 
     if (newInputTokens + requested <= effective) {
         return {
@@ -221,4 +231,54 @@ export function selectModelByCapacity(
     }
 
     return reduceToFit(messages, options);
+}
+
+/**
+ * 정확 토큰 보정을 적용한 context-fit — `LLMClient.chat()` 이 쓰는 진입점.
+ *
+ * 문자 추정이 유효 컨텍스트의 `tokenizeExactRatio` 를 넘을 때만 모델 자신의 토크나이저로
+ * 실제 토큰을 재계산하고, 그 비(scale)로 추정을 보정한다. 평상시 산문 요청은 임계에
+ * 닿지 않아 추가 호출이 없다(TTFT 무영향).
+ *
+ * 왜 "치환"이 아니라 "보정 계수"인가: 절단(truncateMessagesPreservingSystem)은 메시지마다
+ * 문자 추정을 누적한다. 총합만 실제값으로 바꾸면 절단 루프와 판정이 서로 다른 척도를 쓰게 돼
+ * 여전히 과소절단한다. 계수를 쓰면 두 척도가 한 번에 정합된다.
+ *
+ * 전 구간 fail-open — tokenize 실패는 종전(문자 추정) 동작으로 되돌아간다.
+ */
+export async function selectModelByCapacityExact(
+    messages: ChatMessage[],
+    options: Pick<ModelOptions, 'num_predict'> & { model?: string },
+): Promise<ModelPoolDecision> {
+    if (options.model) {
+        return { model: options.model, source: 'manual' };
+    }
+    if (!MODEL_POOL_CONFIG.enabled) {
+        return { model: MODEL_POOL_CONFIG.defaultModel, source: 'pool_disabled' };
+    }
+
+    const model = MODEL_POOL_CONFIG.defaultModel;
+    const effective = resolveEffectiveContext(model);
+    const rough = estimateMessageTokens(messages);
+
+    let scale = 1;
+    if (isExactTokenizeEnabled() && rough > effective * MODEL_POOL_CONFIG.tokenizeExactRatio) {
+        const exact = await countExactTokens(messages, model);
+        if (exact !== null && rough > 0) {
+            scale = exact / rough;
+            logger.info(
+                `[ModelPool] exact tokenize: rough=~${rough} exact=${exact}` +
+                ` scale=${scale.toFixed(2)}`,
+            );
+        }
+    }
+
+    const inputTokens = Math.ceil(rough * scale);
+    const estimatedOutput = options.num_predict ?? MODEL_POOL_CONFIG.routingMaxTokensDefault;
+
+    if (inputTokens + estimatedOutput <= effective) {
+        return { model, source: 'auto', inputTokens };
+    }
+
+    return reduceToFit(messages, options, scale);
 }


### PR DESCRIPTION
## 배경

#685(HWP 첨부)에서 남긴 관찰 "estimateTokens 가 실제의 53%" 를 착수하며 **기록된 원인이 틀렸음을 실측으로 확인**했다.

- 기록: "U+FFFD 를 0.5 토큰으로 세는데 실제 토크나이저는 2~3 토큰"
- 실측: U+FFFD 의 **한계비용은 0.63 토큰** — 현행 가중치 0.5 와 거의 같아 무관하다.

진짜 원인은 **BPE 가 병합하지 못하는 고엔트로피·구두점 밀집 텍스트**이고, 범위도 바이너리에 국한되지 않는다.

## 실측 (qwen3.6, vLLM `/tokenize` 대조)

| 샘플 | 추정/실제 | 실제 tok/byte |
|---|---|---|
| 한국어 산문 | 123% | 0.261 |
| 영문 / TS 코드 / 혼합 | 101~106% | 0.26~0.28 |
| **JSON 로그** | **61%** | 0.431 |
| 바이너리 as-text | 40~50% | 0.41~0.53 |
| base64 / hex | 36% / 30% | 0.73 / 0.88 |

산문은 보수적(문제 없음)이나 나머지는 **과소추정** → 안전망을 그대로 통과해 upstream 400.

## 왜 가중치 조정이 아닌가

- 제어문자에 필요한 가중치가 파일 구간별로 **1.22~3.99** 로 흔들린다(고정 가중치 불가).
- **base64/hex 는 제어문자가 0개**인데도 30%대다.
- 공백비율·zlib 압축률도 **JSON 로그(61%)를 정상 텍스트와 분리하지 못했다**.
- 실제 tok/byte 가 0.26~0.88 이라 "바이트 수 = 상한"은 항상 안전하지만 산문에서 4배 과대 → 정상 대화가 잘린다.

## 변경

- **`llm/exact-tokenizer.ts` (신규)** — vLLM `/tokenize` 로 실제 입력 토큰을 센다. 전 구간 fail-open(미설정·HTTP 실패·타임아웃·형식 이상 → null → 문자 추정 유지).
- **`selectModelByCapacityExact`** — 문자 추정이 유효 컨텍스트의 `LLM_POOL_TOKENIZE_EXACT_RATIO`(0.5)를 넘을 때만 재계산. 평상시 산문 요청은 임계에 닿지 않아 **추가 호출 0**(TTFT 무영향).
- ⚠️ **총합 치환이 아니라 보정 계수(scale = 실제/추정)** — 절단(`truncateMessagesPreservingSystem`)이 메시지마다 문자 추정을 누적하므로, 총합만 실제값으로 바꾸면 판정과 절단이 다른 척도를 써 **여전히 과소절단**한다. 계수를 쓰면 두 척도가 한 번에 정합된다.
- ⚠️ **게이트웨이(LiteLLM)는 쓸 수 없다** — `/tokenize` 를 프록시하지 않고(404), `/utils/token_counter` 는 cl100k 라 같은 실측에서 **한국어 157%(과대)·hex 64%(과소)**. `LLM_TOKENIZE_URL` 로 vLLM 을 직접 가리킨다(추론이 아니라 토크나이저 조회).
- ⚠️ 구현 중 발견 — `ToolCall.function.arguments` 는 `Record` 라 템플릿 연결 시 `[object Object]` 가 된다 → payload 조립에서 `JSON.stringify` 필수(도구 루프 과소추정 방지).

## 라이브 검증 (실제 363KB HWP 를 `readAsText` 로 읽은 입력)

| 시나리오 | 보정 전 | 보정 후 |
|---|---|---|
| 단일 메시지 | `auto` 135,048 → 그대로 전송 = **upstream 400** | `ContextOverflowError` 290,746 → **413 `CONTEXT_TOO_LARGE`** |
| 여러 턴 분할 | `auto` 135,061 | `auto_trimmed` 217,396 (1개 드롭) |
| 정상 한국어 대화 34,845 | — | 임계 미달 → **tokenize 호출 0** |

로그: `[ModelPool] exact tokenize: rough=~135048 exact=290746 scale=2.15`

## 체크리스트

- [x] `npm run lint` 통과 (에러 0, 경고 32건은 모두 기존 파일)
- [x] `npm test` 통과 — 신규 12건 포함 **3,220건 전량**, 회귀 0
- [x] 환경변수 추가 → `.env.example` 갱신 (`LLM_TOKENIZE_URL`·`LLM_TOKENIZE_API_KEY`·`LLM_POOL_TOKENIZE_EXACT_RATIO`·`LLM_POOL_TOKENIZE_TIMEOUT_MS`)
- [x] DB 스키마 변경 없음 / UI 변경 없음
- [x] 보안: tokenize endpoint 는 설정으로만 지정되는 내부 주소이며 사용자 입력이 URL 에 관여하지 않는다. 키는 env(`LLM_TOKENIZE_API_KEY`, 미설정 시 `LLM_API_KEY` 재사용).

## 롤백

`.env` 에서 `LLM_TOKENIZE_URL` 을 지우고 pm2 `delete → start` (restart 로는 `.env` 미반영). 미설정이면 기능 off 로 종전 동작이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3js5WoiroS8QMAJH4f6B4
