### PR TITLE
fix(agent-task): 턴 예산 판정에서 HWP 확장자 누락 (잠복)

### DIFF
--- a/apps/api/src/services/agent-task/__tests__/resolve-default-max-turns.test.ts
+++ b/apps/api/src/services/agent-task/__tests__/resolve-default-max-turns.test.ts
@@ -22,4 +22,49 @@ describe('resolveDefaultMaxTurns', () => {
         expect(resolveDefaultMaxTurns(undefined, [bigFile] as never))
             .toBeGreaterThanOrEqual(AGENT_TASK_LIMITS.DEFAULT_MAX_TURNS);
     });
+
+    /**
+     * 추출 텍스트를 확보하지 못한 문서는 샌드박스에서 직접 파싱해야 하므로 턴 예산을 올린다.
+     * 이 판정은 PDF·office·HWP 세 목록을 모두 봐야 하는데 HWP 만 빠져 있었다(2026-08-31).
+     *
+     * ⚠️ 기본 설정(DEFAULT 32 > LARGE_INPUT 20)에서는 Math.max 가 양쪽 다 32 를 내므로
+     * 두 분기를 구분할 수 없다 — 그래서 여기서만 env 를 역전시켜(LARGE_INPUT > DEFAULT)
+     * 판정 자체를 관측한다. 역전은 실제로 가능한 운영 설정이며, 그때 이 결함이 드러난다.
+     */
+    describe('추출 실패 문서 판정 — 확장자 목록 전체를 본다 (env 역전 조건)', () => {
+        const ORIGINAL_ENV = { ...process.env };
+        const DEFAULT = 8;
+        const LARGE = 24;
+
+        const load = () => {
+            jest.resetModules();
+            process.env = {
+                ...ORIGINAL_ENV,
+                AGENT_TASK_DEFAULT_MAX_TURNS: String(DEFAULT),
+                AGENT_TASK_LARGE_INPUT_MAX_TURNS: String(LARGE),
+            };
+            return (require('../task-inputs') as typeof import('../task-inputs')).resolveDefaultMaxTurns;
+        };
+
+        afterEach(() => {
+            process.env = { ...ORIGINAL_ENV };
+            jest.resetModules();
+        });
+
+        it.each(['scan.pdf', 'sheet.xlsx', 'doc.docx', '공문.hwp', '공문.hwpx', '공문.hml'])(
+            '%s — 추출 텍스트가 없으면 샌드박스 파싱 예산',
+            (name) => {
+                expect(load()(undefined, [{ name, size: 1024 }] as never)).toBe(LARGE);
+            },
+        );
+
+        it('추출에 성공한 HWP 는 기본값 (대다수 경로 — 불필요한 예산 상향 방지)', () => {
+            expect(load()(undefined, [{ name: '공문.hwp', size: 1024, content: '본문' }] as never))
+                .toBe(DEFAULT);
+        });
+
+        it('추출 대상이 아닌 확장자는 기본값', () => {
+            expect(load()(undefined, [{ name: 'memo.txt', size: 1024 }] as never)).toBe(DEFAULT);
+        });
+    });
 });

--- a/apps/api/src/services/agent-task/task-inputs.ts
+++ b/apps/api/src/services/agent-task/task-inputs.ts
@@ -25,7 +25,11 @@ export function resolveDefaultMaxTurns(
     const needsSandboxParsing = (files ?? []).some((f) => {
         if ((f.size ?? 0) > DOC_EXTRACT_LIMITS.MAX_BYTES_PER_FILE) return true;
         const ext = (f.name ?? '').toLowerCase().split('.').pop() ?? '';
-        const isDoc = DOC_EXTRACT_LIMITS.PDF_EXTS.includes(ext) || DOC_EXTRACT_LIMITS.OFFICE_EXTS.includes(ext);
+        // HWP_EXTS 포함 필수 — 한국 공문서도 샌드박스에서 kordoc 으로 직접 파싱해야 하므로
+        // 같은 턴 예산이 필요하다 (2026-08-31 점검에서 이 목록만 누락돼 있었다).
+        const isDoc = DOC_EXTRACT_LIMITS.PDF_EXTS.includes(ext)
+            || DOC_EXTRACT_LIMITS.OFFICE_EXTS.includes(ext)
+            || DOC_EXTRACT_LIMITS.HWP_EXTS.includes(ext);
         return isDoc && typeof f.content !== 'string';
     });
     // LARGE_INPUT 은 기본값 "상향"이 목적이므로 기본보다 낮아지면 안 된다 — 둘 다 env 로 조정


### PR DESCRIPTION
## 배경

#683·#685·#686 으로 마무리된 HWP 축을 전수 점검하다 찾은 마지막 비대칭입니다. `HWP_EXTS` 를 참조해야 할 곳 3군데 중 **여기 한 곳만** 빠져 있었습니다.

```
apps/api/src/services/chat-service/doc-extractor.ts:233   ✓ isHwp
apps/web/components/chat/composer.tsx:58                  ✓ 주석으로 한 쌍 명시
apps/api/src/services/agent-task/task-inputs.ts:28        ✗ 누락
```

`resolveDefaultMaxTurns` 의 `needsSandboxParsing` 은 "추출 텍스트를 확보하지 못한 문서는 샌드박스에서 직접 파싱해야 하니 턴 예산을 올린다"는 규칙입니다. 한국 공문서도 #683 으로 샌드박스에 전역 설치된 kordoc 으로 직접 파싱해야 하므로 같은 대상인데, 목록에서 빠져 예산이 오르지 않았습니다.

HWP 가 이 조건에 걸리는 경우: **30MB 초과**로 생성 시 추출을 건너뛴 경우 · **kordoc 추출 타임아웃**(`DOC_EXTRACT_HWP_TIMEOUT_MS`, 기본 30s) · **스캔본이라 텍스트가 0자**인 경우.

## ⚠️ 현재 영향은 0 — 잠복 결함입니다

기본 설정에서는 두 분기가 같은 값을 냅니다:

```
DEFAULT_MAX_TURNS      = 32
LARGE_INPUT_MAX_TURNS  = 20
Math.max(20, 32) = 32 = DEFAULT   ← 판정 결과와 무관하게 32
```

2026-08-19 기본값 10→32 상향으로 생긴 역전이며, `runtime-limits.ts:1508` 주석이 이미 지적하고 있습니다. 따라서 이 PR 은 **잠복 제거**이고, 운영자가 `AGENT_TASK_LARGE_INPUT_MAX_TURNS` 를 `DEFAULT` 보다 크게 잡는 순간 결함이 드러납니다.

(점검 시점에 "영향은 제한적"으로 봤다가, 테스트가 수정을 되돌려도 통과하는 것을 보고 실제로는 0임을 확인해 정정했습니다.)

## 테스트

같은 이유로 **기본 설정에서는 테스트도 두 분기를 구분하지 못합니다**. 첫 작성분이 수정을 되돌려도 통과해서, 해당 `describe` 안에서만 env 를 역전시켜(`DEFAULT 8 < LARGE 24`) 판정 자체를 관측하도록 다시 썼습니다.

실효성 확인 — 수정을 되돌리면:

```
Tests: 3 failed, 8 passed   ← 공문.hwp · 공문.hwpx · 공문.hml
수정 복원 후: 11 passed
```

추출에 성공한 HWP(대다수 경로)가 기본값을 유지하는 것, 추출 대상이 아닌 확장자가 기본값인 것도 함께 고정했습니다.

## 함께 확인한 것 (HWP 축 전수 점검, 모두 정상)

| 축 | 결과 |
|---|---|
| 3형식 추출 | `.hwp` 13,859자 · `.hwpx` · `.hml` 전부 실제 `extractAttachedDocuments` 통과 (**hwpx/hml 은 이번이 첫 검증** — 그동안 `.hwp` 만 라이브 확인) |
| 프론트↔백엔드 목록 | `EXTRACT_EXTS` 11종 ↔ `PDF/OFFICE/HWP_EXTS` 정합 |
| 업로드 화이트리스트 | `.hwp/.hwpx/.hml` 등재 |
| 에이전트 작업 추출 | 라우트·chunk-store 모두 같은 `extractAttachedDocuments` 사용 → 정상 |
| 샌드박스 | `--network none` 컨테이너에서 `kordoc 4.12.0` 실행 확인 |
| 에이전트 프롬프트 | kordoc 4개 서브커맨드 안내됨 |
| 카탈로그 | 소스 enabled·동기화됨, 확장 1건 active |
| env 문서화 | `DOC_EXTRACT_HWP_TIMEOUT_MS` 기재됨 |

`ALLOWED_DOCUMENT_MIME_TYPES` 는 운영 소비처가 없어(테스트만 참조) `application/x-hwp` 하나뿐인 것이 hwpx 를 막지 않습니다 — HWP 와 무관한 기존 사안이라 이 PR 에서 건드리지 않았습니다.

## 체크리스트

- [x] `npm run lint` 통과 (변경 파일 경고 0)
- [x] `npm test` 통과 — **3,228건**(신규 8건 포함), 회귀 0
- [x] `tsc --noEmit` 통과
- [x] DB 스키마·환경변수·UI 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3js5WoiroS8QMAJH4f6B4
