### PR TITLE
docs(cli): bridge.ts 설명을 local-bridge-core 어댑터 사실로 정정

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -5,7 +5,8 @@
 서버 샌드박스(Docker) 대신 **사용자 머신에서 직접** 도구를 실행한다. 턴 오케스트레이션은
 서버(`AgentTaskService` 하네스)가 하고, 이 CLI 는 **도구 실행 + 터미널 렌더**만 담당한다
 (자체 에이전트 루프 없음). 데스크톱 컴패니언(`apps/desktop-native`)과 같은 브리지 프로토콜을 쓰며,
-`src/bridge.ts` 는 데스크톱 `bridge.js` 의 호스트 비의존 코어를 이식한 것이다.
+`src/bridge.ts` 는 공용 브리지 코어 `packages/local-bridge-core` 의 CLI 어댑터다 — 프로토콜·경로
+스코프·exec 방어·worktree 로직은 패키지에 단일화돼 있고, 어댑터는 인증·confirm UI 만 가진다.
 
 ---
 


### PR DESCRIPTION
## 배경

`apps/cli/README.md:8` 이 브리지 코어 단일화(2026-08-22, `packages/local-bridge-core`) **이전**의 문장 — "`src/bridge.ts` 는 데스크톱 `bridge.js` 의 호스트 비의존 코어를 이식한 것이다" — 를 유지하고 있었다.

2026-09-01 외부 아키텍처 리뷰가 정확히 이 문장 하나를 근거로 "CLI/데스크톱 간 로직 복제가 시작됐으니 executor-core 패키지로 통합해야 한다"는 (이미 완료된 작업의) 제안에 도달했다. 공개 리포의 stale 문서가 외부 판단을 실제로 오도한 사례.

## 변경

- README 8행을 실제 구조로 정정: 코어는 `packages/local-bridge-core` 에 단일화, `bridge.ts` 는 CLI 어댑터(인증·confirm UI만) — `bridge.ts` 자체 헤더 주석과 일치.

## 검증

- `grep -rn "bridge\.js\|이식" apps/cli/README.md` → 0건
- 문서만 변경 (코드 무변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5rXygFJzGGrPEJB58SuwS