### PR TITLE
feat(mcp): 샌드박스 secure-by-default 보강 — 부팅 자세 관측 + 셋업 자동 활성화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1374,7 +1374,11 @@ TASK_SANDBOX_ENABLED=false
 # AGENT_TASK_FINAL_TURN_NUDGE=true                     # 자원 상한 임박 시 마지막 턴의 도구를 제거하고 종합 답변을 유도(기본 on). 상한에서 그냥 끊으면 산출물을 만든 작업도 사족에서 절단됨
 # AGENT_TASK_TOKEN_SOFT_RATIO=0.7                      # 마무리 턴 전환 토큰 비율(AGENT_MAX_TOTAL_TOKENS 대비). 여유가 모델 컨텍스트(262K)보다 커야 마무리 턴이 상한 안에 들어옴
 
-MCP_SANDBOX_ENABLED=false
+# 🔒 외부 MCP 컨테이너 격리 — 권장 기본 true (secure-by-default). docker + 런타임 이미지 필요:
+#   docker build -t openmake-mcp-runtime:latest infra/mcp-runtime
+#   true 인데 docker 부재 시 외부 MCP spawn 을 거부한다(fail-closed — 비격리로 조용히 돌리지 않음).
+#   docker 를 쓰지 않는 배포만 false 로 명시 해제 (신뢰 서버 개별 opt-out 은 sandbox_network=host).
+MCP_SANDBOX_ENABLED=true
 # MCP_SANDBOX_DOCKER_PATH=docker                       # docker 바이너리(기본 PATH 탐색 + Desktop 경로)
 # MCP_SANDBOX_IMAGE=openmake-mcp-runtime:latest        # 런타임 이미지
 # MCP_SANDBOX_CACHE_VOLUME=openmake-mcp-cache          # npx/uvx 캐시 named volume
@@ -1383,6 +1387,7 @@ MCP_SANDBOX_ENABLED=false
 # MCP_SANDBOX_CPUS=1.0                                 # 컨테이너 CPU 상한(CPU DoS 방어)
 # MCP_SANDBOX_USER=1000:1000                           # 컨테이너 실행 uid:gid (이미지 mcp 유저)
 # MCP_SANDBOX_READONLY=false                           # read-only rootfs + tmpfs(opt-in, 일부 서버 호환성 주의)
+# MCP_SANDBOX_DOCKER_PROBE_TIMEOUT_MS=5000           # 셋업 시 docker image inspect 프로브 timeout(VM 정지 대비)
 # 캐시 볼륨은 서버별로 분리됨(openmake-mcp-cache-<serverId>) — 컨테이너 간 캐시 오염 차단.
 # add-host(host.docker.internal)는 127.0.0.1/localhost 참조 서버에만 부여(내부 서비스 over-grant 차단).
 #

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1948,3 +1948,15 @@ export const GATE_REPORT = {
     /** 날짜·요일 판정 기준 TZ. GATE_REPORT_TZ(기본 Asia/Seoul). */
     TZ: process.env.GATE_REPORT_TZ || 'Asia/Seoul',
 } as const;
+
+/**
+ * MCP 샌드박스 부트스트랩 (mcp/sandbox-bootstrap.ts) — 부팅 자세 점검 + 셋업 기본 활성화.
+ */
+export const MCP_SANDBOX_BOOTSTRAP = {
+    /**
+     * `docker image inspect` 프로브 timeout(ms) — Docker VM 스토리지 정지 시 exec 는 되는데
+     * 조회가 hang 하는 실사례가 있어(2026-08 EINTR 다운) 셋업 요청을 물고 늘어지지 않게 제한.
+     * MCP_SANDBOX_DOCKER_PROBE_TIMEOUT_MS
+     */
+    DOCKER_PROBE_TIMEOUT_MS: parseInt(process.env.MCP_SANDBOX_DOCKER_PROBE_TIMEOUT_MS || '', 10) || 5000,
+} as const;

--- a/apps/api/src/mcp/__tests__/sandbox-bootstrap.test.ts
+++ b/apps/api/src/mcp/__tests__/sandbox-bootstrap.test.ts
@@ -1,0 +1,122 @@
+/**
+ * mcp/sandbox-bootstrap 단위 테스트 — 부팅 자세 점검 + 셋업 secure-by-default.
+ * docker/파일시스템은 주입/임시디렉토리로 대체 (실제 docker 불요).
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { sandboxBootAdvisory, ensureSandboxDefaultOnSetup } from '../sandbox-bootstrap';
+import type { SandboxConfig } from '../sandbox-docker';
+
+function cfg(overrides: Partial<SandboxConfig>): SandboxConfig {
+    return {
+        enabled: false,
+        dockerPath: null,
+        image: 'openmake-mcp-runtime:latest',
+        cacheVolume: 'openmake-mcp-cache',
+        memory: '512m',
+        pidsLimit: 256,
+        cpus: '1.0',
+        user: '1000:1000',
+        readonly: false,
+        ...overrides,
+    };
+}
+
+describe('sandboxBootAdvisory', () => {
+    it('ON + docker 가용 → 경고 없음(null)', () => {
+        expect(sandboxBootAdvisory(cfg({ enabled: true, dockerPath: '/usr/local/bin/docker' }))).toBeNull();
+    });
+
+    it('ON + docker 부재 → fail-closed 조기 경보', () => {
+        const msg = sandboxBootAdvisory(cfg({ enabled: true, dockerPath: null }));
+        expect(msg).toContain('거부');
+        expect(msg).toContain('fail-closed');
+    });
+
+    it('OFF + docker 가용 → 격리 권장 안내', () => {
+        const msg = sandboxBootAdvisory(cfg({ enabled: false }), () => '/usr/local/bin/docker');
+        expect(msg).toContain('MCP_SANDBOX_ENABLED=true');
+        expect(msg).toContain('infra/mcp-runtime');
+    });
+
+    it('OFF + docker 부재 → 안내 무의미(null)', () => {
+        expect(sandboxBootAdvisory(cfg({ enabled: false }), () => null)).toBeNull();
+    });
+});
+
+describe('ensureSandboxDefaultOnSetup', () => {
+    let tmpDir: string;
+    let envPath: string;
+    const savedEnabled = process.env.MCP_SANDBOX_ENABLED;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sandbox-bootstrap-'));
+        envPath = path.join(tmpDir, '.env');
+        delete process.env.MCP_SANDBOX_ENABLED;
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        if (savedEnabled === undefined) delete process.env.MCP_SANDBOX_ENABLED;
+        else process.env.MCP_SANDBOX_ENABLED = savedEnabled;
+    });
+
+    it('명시 설정(false 포함)은 존중 — 덮어쓰지 않는다', () => {
+        process.env.MCP_SANDBOX_ENABLED = 'false';
+        const result = ensureSandboxDefaultOnSetup(envPath, {
+            resolveDockerPath: () => '/usr/local/bin/docker',
+            imageExists: () => true,
+        });
+        expect(result).toEqual({ applied: false, reason: 'explicit' });
+        expect(fs.existsSync(envPath)).toBe(false);
+        expect(process.env.MCP_SANDBOX_ENABLED).toBe('false');
+    });
+
+    it('docker 부재 → no-docker (미적용)', () => {
+        const result = ensureSandboxDefaultOnSetup(envPath, { resolveDockerPath: () => null });
+        expect(result).toEqual({ applied: false, reason: 'no-docker' });
+        expect(process.env.MCP_SANDBOX_ENABLED).toBeUndefined();
+    });
+
+    it('docker 는 있는데 런타임 이미지 부재 → no-image (켜면 spawn 이 깨지므로 미적용)', () => {
+        const result = ensureSandboxDefaultOnSetup(envPath, {
+            resolveDockerPath: () => '/usr/local/bin/docker',
+            imageExists: () => false,
+        });
+        expect(result).toEqual({ applied: false, reason: 'no-image' });
+        expect(process.env.MCP_SANDBOX_ENABLED).toBeUndefined();
+    });
+
+    it('docker + 이미지 가용 → .env 영속(기존 파일 append) + process.env 즉시 반영', () => {
+        fs.writeFileSync(envPath, 'PORT=52416\n', 'utf-8');
+        const result = ensureSandboxDefaultOnSetup(envPath, {
+            resolveDockerPath: () => '/usr/local/bin/docker',
+            imageExists: () => true,
+        });
+        expect(result).toEqual({ applied: true, reason: 'applied' });
+        const persisted = fs.readFileSync(envPath, 'utf-8');
+        expect(persisted).toContain('PORT=52416'); // 기존 내용 보존
+        expect(persisted).toContain('MCP_SANDBOX_ENABLED=true');
+        expect(process.env.MCP_SANDBOX_ENABLED).toBe('true');
+    });
+
+    it('.env 부재 시 새로 생성한다', () => {
+        const result = ensureSandboxDefaultOnSetup(envPath, {
+            resolveDockerPath: () => '/usr/local/bin/docker',
+            imageExists: () => true,
+        });
+        expect(result.applied).toBe(true);
+        expect(fs.readFileSync(envPath, 'utf-8')).toContain('MCP_SANDBOX_ENABLED=true');
+    });
+
+    it('영속 실패 → persist-failed (fail-open, throw 하지 않음 + env 미주입)', () => {
+        const badPath = path.join(tmpDir, 'no-such-dir', '.env'); // 부모 디렉토리 부재 → 쓰기 실패
+        const result = ensureSandboxDefaultOnSetup(badPath, {
+            resolveDockerPath: () => '/usr/local/bin/docker',
+            imageExists: () => true,
+        });
+        expect(result).toEqual({ applied: false, reason: 'persist-failed' });
+        expect(process.env.MCP_SANDBOX_ENABLED).toBeUndefined();
+    });
+});

--- a/apps/api/src/mcp/sandbox-bootstrap.ts
+++ b/apps/api/src/mcp/sandbox-bootstrap.ts
@@ -1,0 +1,121 @@
+/**
+ * ============================================================
+ * MCP Sandbox Bootstrap — 샌드박스 자세(posture) 관측 + 셋업 시 secure-by-default
+ * ============================================================
+ *
+ * 두 가지만 한다 (spawn 경로는 건드리지 않는다 — 그건 sandbox-docker.ts):
+ *
+ * 1. sandboxBootAdvisory — 부팅 시 1회 자세 점검 (관측 전용, 동작 무변경):
+ *    - OFF 인데 docker 가용 → 격리 권장 안내
+ *    - ON 인데 docker 부재 → 외부 MCP spawn 이 전부 fail-closed 거부될 것을 조기 경보
+ *      (그전엔 첫 spawn 실패에서야 드러났다 — 조용한 실패 방지)
+ *
+ * 2. ensureSandboxDefaultOnSetup — 첫 실행 셋업 마법사에서 호출:
+ *    MCP_SANDBOX_ENABLED 미설정 + docker + 런타임 이미지 모두 가용일 때만
+ *    `.env` 에 true 를 영속하고 process.env 에 주입한다 (boot/ensure-secrets 와 같은 패턴).
+ *    - 명시 설정(true/false)은 존중 — 덮어쓰지 않는다.
+ *    - ⚠️ docker 바이너리 존재 ≠ 이미지 존재: 이미지(openmake-mcp-runtime) 없이 켜면
+ *      모든 외부 MCP spawn 이 이미지 pull 실패로 깨진다. 반드시 둘 다 확인.
+ *    - 실패는 전부 fail-open (셋업을 죽이지 않음) — 미적용 사유를 반환하고,
+ *      다음 부팅의 sandboxBootAdvisory 가 OFF 상태를 다시 드러낸다 (알아챌 경로 확보).
+ *
+ * @module mcp/sandbox-bootstrap
+ */
+import * as fs from 'fs';
+import { execFileSync } from 'child_process';
+import { defaultSandboxConfig, resolveDocker, type SandboxConfig } from './sandbox-docker';
+import { MCP_SANDBOX_BOOTSTRAP } from '../config/runtime-limits';
+
+/** ENABLED=false 상태에서도 docker 를 탐색해야 하므로 resolver 를 분리 (테스트 주입 가능) */
+function resolveConfiguredDocker(): string | null {
+    return resolveDocker(process.env.MCP_SANDBOX_DOCKER_PATH || 'docker');
+}
+
+/**
+ * 부팅 시 샌드박스 자세 점검 — 경고할 것이 있으면 메시지, 정상이면 null.
+ * 관측 전용: 어떤 상태도 바꾸지 않는다.
+ */
+export function sandboxBootAdvisory(
+    cfg: SandboxConfig = defaultSandboxConfig(),
+    resolveDockerFn: () => string | null = resolveConfiguredDocker,
+): string | null {
+    if (cfg.enabled) {
+        if (cfg.dockerPath) return null;
+        return (
+            'MCP 샌드박스가 활성(MCP_SANDBOX_ENABLED=true)인데 docker 바이너리를 찾을 수 없습니다 — ' +
+            '외부 MCP 서버 spawn 이 전부 거부됩니다(fail-closed). Docker 설치/실행을 확인하거나 ' +
+            'MCP_SANDBOX_ENABLED=false 로 명시 해제하세요.'
+        );
+    }
+    const dockerPath = resolveDockerFn();
+    if (!dockerPath) return null; // docker 없는 배포 — 샌드박스 불가, 안내 무의미
+    return (
+        'MCP 샌드박스가 꺼져 있는데 docker 가 가용합니다 — 외부 MCP 서버가 호스트에서 비격리로 실행됩니다. ' +
+        'MCP_SANDBOX_ENABLED=true + 런타임 이미지 빌드(docker build -t openmake-mcp-runtime:latest infra/mcp-runtime)를 권장합니다.'
+    );
+}
+
+export interface SandboxDefaultResult {
+    /** true = .env 영속 + process.env 주입 완료 */
+    applied: boolean;
+    /** 미적용 사유: explicit(명시 설정 존중) | no-docker | no-image | persist-failed */
+    reason: 'applied' | 'explicit' | 'no-docker' | 'no-image' | 'persist-failed';
+}
+
+/** 테스트 주입용 의존성 — 미지정 시 실제 docker 를 조회한다 */
+export interface SandboxDefaultDeps {
+    resolveDockerPath?: () => string | null;
+    imageExists?: (dockerPath: string, image: string) => boolean;
+}
+
+/** `docker image inspect` 로 런타임 이미지 존재 확인 — 데몬 정지 대비 timeout 필수 */
+function dockerImageExists(dockerPath: string, image: string): boolean {
+    try {
+        execFileSync(dockerPath, ['image', 'inspect', image], {
+            stdio: 'ignore',
+            timeout: MCP_SANDBOX_BOOTSTRAP.DOCKER_PROBE_TIMEOUT_MS,
+        });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * 첫 실행 셋업에서 MCP 샌드박스 기본 활성화 시도.
+ * 전 경로 fail-open — 어떤 실패도 throw 하지 않고 사유를 반환한다.
+ */
+export function ensureSandboxDefaultOnSetup(
+    envPath: string,
+    deps: SandboxDefaultDeps = {},
+): SandboxDefaultResult {
+    // 명시 설정(true/false 무엇이든)은 운영자 선택 — 덮어쓰지 않는다
+    if (process.env.MCP_SANDBOX_ENABLED !== undefined && process.env.MCP_SANDBOX_ENABLED !== '') {
+        return { applied: false, reason: 'explicit' };
+    }
+
+    const dockerPath = (deps.resolveDockerPath ?? resolveConfiguredDocker)();
+    if (!dockerPath) return { applied: false, reason: 'no-docker' };
+
+    const image = defaultSandboxConfig().image;
+    const hasImage = (deps.imageExists ?? dockerImageExists)(dockerPath, image);
+    if (!hasImage) return { applied: false, reason: 'no-image' };
+
+    const block =
+        `\n# ── 첫 실행 셋업 자동 설정 (${new Date().toISOString()}) ──\n` +
+        `# docker + 런타임 이미지(${image}) 감지 → 외부 MCP 컨테이너 격리를 기본 활성화.\n` +
+        `MCP_SANDBOX_ENABLED=true\n`;
+    try {
+        if (fs.existsSync(envPath)) {
+            fs.appendFileSync(envPath, block, 'utf-8');
+        } else {
+            fs.writeFileSync(envPath, block, { encoding: 'utf-8', mode: 0o600 });
+        }
+    } catch {
+        return { applied: false, reason: 'persist-failed' };
+    }
+
+    // defaultSandboxConfig 가 spawn 마다 process.env 를 읽으므로 재시작 없이 즉시 반영된다
+    process.env.MCP_SANDBOX_ENABLED = 'true';
+    return { applied: true, reason: 'applied' };
+}

--- a/apps/api/src/routes/first-run-setup.routes.ts
+++ b/apps/api/src/routes/first-run-setup.routes.ts
@@ -11,6 +11,7 @@
  * @see docs/superpowers/plans/2026-08-12-first-run-setup.md §B
  */
 import { Router, type Request, type Response } from 'express';
+import * as path from 'path';
 import { z } from 'zod';
 import { validate } from '../middlewares/validation';
 import { asyncHandler } from '../utils/error-handler';
@@ -19,6 +20,7 @@ import { getUserManager } from '../data/user-manager';
 import { getSystemSettingsService } from '../services/system-settings-service';
 import { SETTING_DEFS_BY_KEY } from '../config/system-settings-registry';
 import { getAuditService } from '../services/AuditService';
+import { ensureSandboxDefaultOnSetup } from '../mcp/sandbox-bootstrap';
 import { getConfig } from '../config/env';
 import { createLogger } from '../utils/logger';
 
@@ -84,6 +86,16 @@ firstRunSetupRouter.post('/', validate(setupSchema), asyncHandler(async (req: Re
 
     if (Object.keys(llmEntries).length > 0) {
         await getSystemSettingsService().update(llmEntries, String(admin.id));
+    }
+
+    // MCP 샌드박스 secure-by-default — MCP_SANDBOX_ENABLED 미설정 + docker·런타임 이미지
+    // 가용일 때만 .env 영속 + 즉시 반영. 전 경로 fail-open(셋업을 죽이지 않음) — 미적용이면
+    // 다음 부팅의 sandboxBootAdvisory 경고가 OFF 상태를 다시 드러낸다.
+    const sandboxDefault = ensureSandboxDefaultOnSetup(path.resolve(__dirname, '../../../../.env'));
+    if (sandboxDefault.applied) {
+        logger.info('MCP 샌드박스 기본 활성화 (docker + 런타임 이미지 감지 → MCP_SANDBOX_ENABLED=true 영속)');
+    } else if (sandboxDefault.reason !== 'explicit') {
+        logger.info(`MCP 샌드박스 자동 활성화 건너뜀: ${sandboxDefault.reason}`);
     }
 
     try {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -243,6 +243,10 @@ export class DashboardServer {
             const { getUnifiedDatabase } = await import('./data/models/unified-database');
             await getUnifiedMCPClient().initializeExternalServers(getUnifiedDatabase());
             console.log('[Server] 외부 MCP 서버 초기화 완료');
+            // 샌드박스 자세 관측(1회) — OFF+docker 가용(격리 권장) / ON+docker 부재(fail-closed 조기 경보)
+            const { sandboxBootAdvisory } = await import('./mcp/sandbox-bootstrap');
+            const advisory = sandboxBootAdvisory();
+            if (advisory) console.warn(`[Server] ${advisory}`);
         } catch (err) {
             console.error('[Server] 외부 MCP 서버 초기화 실패 (서비스 계속):', err);
         }


### PR DESCRIPTION
## 배경

외부 아키텍처 리뷰(2026-09-01)의 "MCP sandbox default-secure" 제안 채택분. 검증 결과 운영 `.env` 는 이미 `MCP_SANDBOX_ENABLED=true` 라 실제 갭은 둘뿐이다:

1. 신규 배포의 코드/템플릿 기본값이 OFF
2. 샌드박스 자세(ON/OFF ↔ docker 가용성)의 불일치가 첫 spawn 실패 전까지 안 드러남

## 변경

- **`.env.example`**: `MCP_SANDBOX_ENABLED` false → **true** + docker/런타임 이미지 전제·fail-closed 동작·opt-out 방법 문서화
- **`mcp/sandbox-bootstrap.ts` 신설**
  - `sandboxBootAdvisory()` — 부팅 1회 관측 전용 점검: OFF+docker 가용 → 격리 권장 / ON+docker 부재 → fail-closed spawn 거부 조기 경보 (server.ts 외부 MCP 초기화 직후 1줄)
  - `ensureSandboxDefaultOnSetup()` — 첫 실행 셋업(`POST /api/setup`)에서 `MCP_SANDBOX_ENABLED` **미설정** + docker + 런타임 이미지 모두 가용일 때만 `.env` 영속 + `process.env` 즉시 반영 (`boot/ensure-secrets` 와 같은 패턴). 명시 설정(true/false)은 존중. 전 경로 fail-open — 미적용 시 다음 부팅 advisory 가 상태를 다시 드러낸다 (조용한 실패 방지 설계)
- **`config/runtime-limits.ts`**: `MCP_SANDBOX_BOOTSTRAP.DOCKER_PROBE_TIMEOUT_MS` (Docker VM 정지 시 inspect hang 실사례 대비)

## 의도적으로 하지 않은 것

- **코드 기본값 자체의 ON 전환** — docker 없는 배포에서 외부 MCP 전체가 fail-closed 거부되는 조용한 전멸이 되므로, 관측(advisory)+셋업 경로로만 달성
- **docker 존재만으로 활성화** — 이미지(`openmake-mcp-runtime`) 없이 켜면 모든 spawn 이 pull 실패로 깨진다 → `docker image inspect` 동반 확인
- **system_settings registry 등록** — `defaultSandboxConfig()` 가 spawn 마다 `process.env` 를 직접 읽어 DB overlay 가 도달하지 않고(도달시키려면 envSchema 편입 리팩터), 프론트 설정 그룹 신설 + i18n 4로케일 파급 대비 이득 없음
- **운영 `MCP_SANDBOX_READONLY=true` 전환** — 코드 변경이 아니라 운영 절차: 연결 서버 10종 spawn·도구 호출 회귀 확인 후 별도 적용

## 검증

- [x] `tsc --noEmit` 0 / 변경 파일 eslint 클린 / server.ts 581줄 (Gate 3 < 600)
- [x] 신규 단위 테스트 10건 (advisory 4 + 셋업 6 — docker/이미지/fs 주입, 실제 docker 불요)
- [x] 전체 jest: **3236 passed** / 실패 1건은 기존 결함 — `reasoning-adapter.effort.test.ts` 가 운영 `.env` 의 `LLM_REASONING_EFFORTS_JSON` 을 격리하지 않음 (본 변경 import 그래프 밖, CI 는 운영 .env 부재로 초록). 별도 PR 로 수정
- [x] 환경변수 추가분 `.env.example` 반영 (`MCP_SANDBOX_DOCKER_PROBE_TIMEOUT_MS`)
- 기존 배포 무영향: 운영 env 는 이미 true(→ advisory null·셋업 explicit skip), 보안 영향 범위는 신규 배포의 기본 자세 강화만

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5rXygFJzGGrPEJB58SuwS