### PR TITLE
test(llm): reasoning-adapter.effort 테스트의 운영 .env 미격리 수정

### DIFF
--- a/apps/api/src/llm/reasoning-adapter.effort.test.ts
+++ b/apps/api/src/llm/reasoning-adapter.effort.test.ts
@@ -6,9 +6,17 @@ import { buildExtraBody } from './reasoning-adapter';
 
 describe('buildExtraBody — reasoning_effort 정규화', () => {
     const saved = process.env.LLM_ENABLE_REASONING_EFFORT;
+    // 운영 .env 의 모델별 지원 강도 override 가 정규화 기대값을 바꾼다
+    // (실사례: qwen3.6 에 'high' 제외 → 'xhigh' 로 정규화되어 실패). 기본 맵으로 고정.
+    const savedEffortsJson = process.env.LLM_REASONING_EFFORTS_JSON;
+    beforeAll(() => {
+        delete process.env.LLM_REASONING_EFFORTS_JSON;
+    });
     afterAll(() => {
         if (saved !== undefined) process.env.LLM_ENABLE_REASONING_EFFORT = saved;
         else delete process.env.LLM_ENABLE_REASONING_EFFORT;
+        if (savedEffortsJson !== undefined) process.env.LLM_REASONING_EFFORTS_JSON = savedEffortsJson;
+        else delete process.env.LLM_REASONING_EFFORTS_JSON;
     });
 
     it('게이트가 꺼져 있으면 reasoning_effort 를 보내지 않는다 (기존 동작)', () => {


### PR DESCRIPTION
## 배경

PR #689 검증 중 발견한 기존 결함. `reasoning-adapter.effort.test.ts` 가 `LLM_REASONING_EFFORTS_JSON` 을 격리하지 않아, 이 값이 설정된 환경(운영 `.env`: qwen3.6 지원 강도에 `high` 제외)에서 `'high'→'xhigh'` 정규화로 2건이 실패한다. **로컬에서만 깨지고 CI 는 `.env` 부재로 초록**인 부류 (기존 `LLM_ENABLE_REASONING_EFFORT` 는 이미 격리하고 있었으나 이 키만 누락).

## 변경

옆 파일 `config/reasoning-effort.test.ts` 와 동일한 save/delete/restore 패턴으로 기본 맵에 고정 (테스트 파일만 변경, 프로덕션 코드 무변경).

## 검증

- [x] 운영 `.env` 가 로드된 로컬에서 두 suite 11건 전부 통과 (수정 전 2건 실패 재현 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5rXygFJzGGrPEJB58SuwS