### PR TITLE
fix(mcp): uvx 도구 venv 를 캐시 볼륨으로 — readonly rootfs 에서 uvx 서버 전멸 해소

### DIFF
--- a/apps/api/src/mcp/__tests__/sandbox-docker.test.ts
+++ b/apps/api/src/mcp/__tests__/sandbox-docker.test.ts
@@ -39,6 +39,8 @@ describe('buildDockerArgs (pure)', () => {
         expect(s).toContain('--user 1000:1000');
         // per-server 캐시 격리 (볼륨에 serverId suffix)
         expect(s).toContain('-v openmake-mcp-cache-s1:/home/node/.cache');
+        // uvx 도구 venv 를 캐시 볼륨으로 — 없으면 readonly rootfs 에서 uvx 서버 전멸 (2026-09-01 실측)
+        expect(s).toContain('-e UV_TOOL_DIR=/home/node/.cache/uv-tools');
         // loopback 미참조 서버엔 add-host 미부여 (over-grant 차단)
         expect(s).not.toContain('--add-host');
         // 이미지 뒤에 원본 command

--- a/apps/api/src/mcp/sandbox-docker.ts
+++ b/apps/api/src/mcp/sandbox-docker.ts
@@ -160,6 +160,11 @@ export function buildDockerArgs(input: SandboxInput, cfg: SandboxConfig): string
     a.push('-e', 'HOME=/home/node');
     a.push('-e', 'NPM_CONFIG_CACHE=/home/node/.cache/npm');
     a.push('-e', 'UV_CACHE_DIR=/home/node/.cache/uv');
+    // uvx 는 도구 venv 를 UV_CACHE_DIR 이 아니라 ~/.local/share/uv/tools 에 만든다 —
+    // readonly rootfs 에서 "Could not create temporary file (os error 30)" 로 전멸
+    // (2026-09-01 운영 실측: uvx 서버 2종만 실패, npx 계열은 전부 생존). 캐시 볼륨으로
+    // 재지정하면 readonly 호환 + 재spawn 시 도구 venv 재사용(설치 생략) 이득도 있다.
+    a.push('-e', 'UV_TOOL_DIR=/home/node/.cache/uv-tools');
     // 서버 config.env 만 컨테이너에 주입 (호스트 env 미상속).
     // 🔒 값은 인자에 넣지 않는다 — `-e KEY`(이름만) 형태면 docker 가 호출 프로세스의 env 에서
     //    값을 읽어 컨테이너로 전달하므로, `ps` 로 읽히는 커맨드라인에 비밀이 남지 않는다.


### PR DESCRIPTION
## 배경

PR #689 후속. `MCP_SANDBOX_READONLY=true` 운영 전환(1차 시도, 2026-09-01)에서 **uvx 기반 서버 2종만**(noapi-google-search·qwen-mm-plugins-core) `Connection closed` 로 전멸 — npx 계열 6종은 전부 생존. 컨테이너 수동 재현으로 원인 확정:

```
error: Could not create temporary file
  Caused by: Read-only file system (os error 30) at path "/home/node/.local/share/uv/tools/.tmp9eDFFa"
```

uvx 는 도구 venv 를 `UV_CACHE_DIR` 이 아니라 `~/.local/share/uv/tools` 에 만든다 — read-only rootfs 가 막는다.

## 변경

`buildDockerArgs` 에 `-e UV_TOOL_DIR=/home/node/.cache/uv-tools` 추가 (캐시 볼륨은 readonly 에서도 쓰기 가능). readonly 여부와 무관하게 무조건 적용 — 재spawn 시 도구 venv 재사용(재설치 생략) 이득 동반.

## 검증

- [x] 수동 재현: 같은 readonly 조건 + `UV_TOOL_DIR` 로 `uvx --with "mcp<2" noapi-google-search-mcp==0.3.2` **50개 패키지 설치 성공**
- [x] sandbox-docker 단위 테스트 11건 통과 (인자 assertion 추가)
- [x] `tsc --noEmit` 0
- 운영 READONLY 는 원복해 둔 상태(전 서버 정상 복구 확인) — 본 수정 배포 후 재전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5rXygFJzGGrPEJB58SuwS