### PR TITLE
feat(mcp): 샌드박스 고아 컨테이너 라벨 + 부팅 스윕

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1388,6 +1388,9 @@ MCP_SANDBOX_ENABLED=true
 # MCP_SANDBOX_USER=1000:1000                           # 컨테이너 실행 uid:gid (이미지 mcp 유저)
 # MCP_SANDBOX_READONLY=false                           # read-only rootfs + tmpfs(opt-in, 일부 서버 호환성 주의)
 # MCP_SANDBOX_DOCKER_PROBE_TIMEOUT_MS=5000           # 셋업 시 docker image inspect 프로브 timeout(VM 정지 대비)
+# MCP_SANDBOX_ORPHAN_REAP=true                        # 부팅 시 소유 프로세스가 죽은 샌드박스 컨테이너 정리(라벨 pid 기준, fail-open)
+# MCP_SANDBOX_DOCKER_STOP_TIMEOUT_MS=20000            # 고아 스윕 docker stop timeout
+# MCP_SANDBOX_ORPHAN_REAP_MAX=50                       # 1회 스윕 최대 처리 수
 # 캐시 볼륨은 서버별로 분리됨(openmake-mcp-cache-<serverId>) — 컨테이너 간 캐시 오염 차단.
 # add-host(host.docker.internal)는 127.0.0.1/localhost 참조 서버에만 부여(내부 서비스 over-grant 차단).
 #

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1959,4 +1959,13 @@ export const MCP_SANDBOX_BOOTSTRAP = {
      * MCP_SANDBOX_DOCKER_PROBE_TIMEOUT_MS
      */
     DOCKER_PROBE_TIMEOUT_MS: parseInt(process.env.MCP_SANDBOX_DOCKER_PROBE_TIMEOUT_MS || '', 10) || 5000,
+    /**
+     * 고아 컨테이너 스윕의 `docker stop` timeout(ms) — stop 은 grace 10s 후 KILL 이라
+     * 프로브보다 길게. MCP_SANDBOX_DOCKER_STOP_TIMEOUT_MS
+     */
+    DOCKER_STOP_TIMEOUT_MS: parseInt(process.env.MCP_SANDBOX_DOCKER_STOP_TIMEOUT_MS || '', 10) || 20000,
+    /** 부팅 고아 스윕 게이트 — MCP_SANDBOX_ORPHAN_REAP=false 로 해제 (기본 on) */
+    ORPHAN_REAP_ENABLED: process.env.MCP_SANDBOX_ORPHAN_REAP !== 'false',
+    /** 1회 스윕에서 처리할 최대 컨테이너 수 (폭주 안전판) */
+    ORPHAN_REAP_MAX: parseInt(process.env.MCP_SANDBOX_ORPHAN_REAP_MAX || '', 10) || 50,
 } as const;

--- a/apps/api/src/mcp/__tests__/sandbox-bootstrap.test.ts
+++ b/apps/api/src/mcp/__tests__/sandbox-bootstrap.test.ts
@@ -19,6 +19,7 @@ function cfg(overrides: Partial<SandboxConfig>): SandboxConfig {
         cpus: '1.0',
         user: '1000:1000',
         readonly: false,
+        ownerPid: 12345,
         ...overrides,
     };
 }
@@ -118,5 +119,70 @@ describe('ensureSandboxDefaultOnSetup', () => {
         });
         expect(result).toEqual({ applied: false, reason: 'persist-failed' });
         expect(process.env.MCP_SANDBOX_ENABLED).toBeUndefined();
+    });
+});
+
+describe('reapOrphanSandboxContainers', () => {
+    const { reapOrphanSandboxContainers } = require('../sandbox-bootstrap');
+    const docker = '/usr/local/bin/docker';
+
+    function fakeDocker(containers: Array<{ id: string; pid: string }>, stopped: string[]) {
+        return (_d: string, args: string[], _t: number): string => {
+            if (args[0] === 'ps') return containers.map((c) => c.id).join('\n') + '\n';
+            if (args[0] === 'inspect') {
+                const c = containers.find((x) => x.id === args[3]);
+                return (c?.pid ?? '') + '\n';
+            }
+            if (args[0] === 'stop') { stopped.push(args[1]); return args[1]; }
+            throw new Error(`unexpected: ${args.join(' ')}`);
+        };
+    }
+
+    it('죽은 pid 소속만 정리하고 생존 pid·판정불가는 남긴다', () => {
+        const stopped: string[] = [];
+        const result = reapOrphanSandboxContainers({
+            resolveDockerPath: () => docker,
+            dockerExec: fakeDocker(
+                [
+                    { id: 'dead1', pid: '99991' },
+                    { id: 'alive', pid: '11111' },
+                    { id: 'nolab', pid: '<no value>' }, // 라벨 없음 → 보류
+                ],
+                stopped,
+            ),
+            pidAlive: (pid: number) => pid === 11111,
+        });
+        expect(stopped).toEqual(['dead1']);
+        expect(result).toEqual({ scanned: 3, reaped: 1, skipped: 1, errors: [] });
+    });
+
+    it('docker 부재 → no-op (fail-open)', () => {
+        const result = reapOrphanSandboxContainers({ resolveDockerPath: () => null });
+        expect(result).toEqual({ scanned: 0, reaped: 0, skipped: 0, errors: [] });
+    });
+
+    it('ps 실패 → 오류만 기록하고 throw 하지 않는다', () => {
+        const result = reapOrphanSandboxContainers({
+            resolveDockerPath: () => docker,
+            dockerExec: () => { throw new Error('daemon hang'); },
+        });
+        expect(result.errors.length).toBe(1);
+        expect(result.reaped).toBe(0);
+    });
+
+    it('개별 stop 실패는 그 컨테이너만 오류로 남기고 계속 진행한다', () => {
+        const stopped: string[] = [];
+        const base = fakeDocker([{ id: 'dead1', pid: '99991' }, { id: 'dead2', pid: '99992' }], stopped);
+        const result = reapOrphanSandboxContainers({
+            resolveDockerPath: () => docker,
+            dockerExec: (d: string, args: string[], t: number) => {
+                if (args[0] === 'stop' && args[1] === 'dead1') throw new Error('stop failed');
+                return base(d, args, t);
+            },
+            pidAlive: () => false,
+        });
+        expect(stopped).toEqual(['dead2']);
+        expect(result.reaped).toBe(1);
+        expect(result.errors.length).toBe(1);
     });
 });

--- a/apps/api/src/mcp/__tests__/sandbox-docker.test.ts
+++ b/apps/api/src/mcp/__tests__/sandbox-docker.test.ts
@@ -13,6 +13,7 @@ const cfg = (over: Partial<SandboxConfig> = {}): SandboxConfig => ({
     cpus: '1.0',
     user: '1000:1000',
     readonly: false,
+    ownerPid: 12345,
     ...over,
 });
 
@@ -41,6 +42,10 @@ describe('buildDockerArgs (pure)', () => {
         expect(s).toContain('-v openmake-mcp-cache-s1:/home/node/.cache');
         // uvx 도구 venv 를 캐시 볼륨으로 — 없으면 readonly rootfs 에서 uvx 서버 전멸 (2026-09-01 실측)
         expect(s).toContain('-e UV_TOOL_DIR=/home/node/.cache/uv-tools');
+        // 고아 스윕 식별 라벨 — role(스코프)·pid(생존 판정)·serverId(진단)
+        expect(s).toContain('--label openmake.role=mcp-sandbox');
+        expect(s).toContain('--label openmake.pid=12345');
+        expect(s).toContain('--label openmake.serverId=s1');
         // loopback 미참조 서버엔 add-host 미부여 (over-grant 차단)
         expect(s).not.toContain('--add-host');
         // 이미지 뒤에 원본 command

--- a/apps/api/src/mcp/sandbox-bootstrap.ts
+++ b/apps/api/src/mcp/sandbox-bootstrap.ts
@@ -23,7 +23,10 @@
  */
 import * as fs from 'fs';
 import { execFileSync } from 'child_process';
-import { defaultSandboxConfig, resolveDocker, type SandboxConfig } from './sandbox-docker';
+import {
+    defaultSandboxConfig, resolveDocker, type SandboxConfig,
+    MCP_SANDBOX_ROLE_LABEL, MCP_SANDBOX_PID_LABEL_KEY,
+} from './sandbox-docker';
 import { MCP_SANDBOX_BOOTSTRAP } from '../config/runtime-limits';
 
 /** ENABLED=false 상태에서도 docker 를 탐색해야 하므로 resolver 를 분리 (테스트 주입 가능) */
@@ -118,4 +121,89 @@ export function ensureSandboxDefaultOnSetup(
     // defaultSandboxConfig 가 spawn 마다 process.env 를 읽으므로 재시작 없이 즉시 반영된다
     process.env.MCP_SANDBOX_ENABLED = 'true';
     return { applied: true, reason: 'applied' };
+}
+
+// ── 고아 컨테이너 부팅 스윕 ──────────────────────────────────────────────
+// 실사례(2026-09-01): close() 의 SIGKILL 이 docker CLI 만 죽이고, stdin EOF 를
+// 무시하는 서버(mcp-python-repl)가 컨테이너로 이틀간 잔존(앱 재시작 3회 생존).
+// 판정은 결정적 — 라벨의 소유 pid 가 죽었으면 그 컨테이너의 stdio 상대는 이미
+// 없으므로 어떤 경우에도 쓸모없다. ⚠️ 라벨 스코핑 필수: task-sandbox 는 재시작을
+// 넘어 살아있는 것이 정상(작업 재개용)이라 이미지 기준 무차별 스윕은 금지.
+
+export interface OrphanReapResult {
+    scanned: number;
+    reaped: number;
+    /** 판정 불가(라벨 pid 없음/파싱 실패)로 건너뛴 수 — 안전측: 모르면 건드리지 않는다 */
+    skipped: number;
+    errors: string[];
+}
+
+/** 테스트 주입용 — 미지정 시 실제 docker/kill(pid,0) 사용 */
+export interface OrphanReapDeps {
+    resolveDockerPath?: () => string | null;
+    /** docker 하위명령 실행 → stdout (실패 시 throw) */
+    dockerExec?: (dockerPath: string, args: string[], timeoutMs: number) => string;
+    pidAlive?: (pid: number) => boolean;
+}
+
+function defaultDockerExec(dockerPath: string, args: string[], timeoutMs: number): string {
+    return execFileSync(dockerPath, args, { encoding: 'utf-8', timeout: timeoutMs, stdio: ['ignore', 'pipe', 'ignore'] });
+}
+
+/** ESRCH 만 사망으로 판정 — EPERM 등 그 외는 생존 취급(fail-open, 오살 방지) */
+function defaultPidAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch (err) {
+        return (err as NodeJS.ErrnoException).code !== 'ESRCH';
+    }
+}
+
+/**
+ * 소유 프로세스가 죽은 MCP 샌드박스 컨테이너를 정리한다. 부팅 시 1회 호출.
+ * 전 경로 fail-open — docker 부재/정지(hang 은 timeout)·개별 실패가 부팅을 막지 않는다.
+ */
+export function reapOrphanSandboxContainers(deps: OrphanReapDeps = {}): OrphanReapResult {
+    const result: OrphanReapResult = { scanned: 0, reaped: 0, skipped: 0, errors: [] };
+    if (!MCP_SANDBOX_BOOTSTRAP.ORPHAN_REAP_ENABLED) return result;
+
+    const dockerPath = (deps.resolveDockerPath ?? resolveConfiguredDocker)();
+    if (!dockerPath) return result;
+
+    const exec = deps.dockerExec ?? defaultDockerExec;
+    const alive = deps.pidAlive ?? defaultPidAlive;
+    const probeMs = MCP_SANDBOX_BOOTSTRAP.DOCKER_PROBE_TIMEOUT_MS;
+
+    let ids: string[];
+    try {
+        ids = exec(dockerPath, ['ps', '-q', '--filter', `label=${MCP_SANDBOX_ROLE_LABEL}`], probeMs)
+            .split('\n').map((s) => s.trim()).filter(Boolean)
+            .slice(0, MCP_SANDBOX_BOOTSTRAP.ORPHAN_REAP_MAX);
+    } catch (err) {
+        result.errors.push(`ps: ${err instanceof Error ? err.message : String(err)}`);
+        return result;
+    }
+
+    for (const id of ids) {
+        result.scanned += 1;
+        try {
+            const raw = exec(
+                dockerPath,
+                ['inspect', '-f', `{{index .Config.Labels "${MCP_SANDBOX_PID_LABEL_KEY}"}}`, id],
+                probeMs,
+            ).trim();
+            const pid = parseInt(raw, 10);
+            if (!Number.isFinite(pid) || pid <= 0) {
+                result.skipped += 1; // 판정 불가 — 건드리지 않는다
+                continue;
+            }
+            if (alive(pid)) continue; // 소유 프로세스 생존 — 정상 컨테이너
+            exec(dockerPath, ['stop', id], MCP_SANDBOX_BOOTSTRAP.DOCKER_STOP_TIMEOUT_MS); // --rm 이라 stop = 제거
+            result.reaped += 1;
+        } catch (err) {
+            result.errors.push(`${id}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    return result;
 }

--- a/apps/api/src/mcp/sandbox-docker.ts
+++ b/apps/api/src/mcp/sandbox-docker.ts
@@ -67,7 +67,16 @@ export interface SandboxConfig {
     user: string;
     /** read-only rootfs + tmpfs (opt-in — 일부 서버가 home 외 쓰기 시 깨질 수 있어 기본 off) */
     readonly: boolean;
+    /**
+     * 컨테이너 라벨(openmake.pid)에 새길 소유 프로세스 pid — 부팅 고아 스윕
+     * (sandbox-bootstrap reapOrphanSandboxContainers)의 생존 판정 기준.
+     */
+    ownerPid: number;
 }
+
+/** MCP 샌드박스 컨테이너 식별 라벨 — ⚠️ task-sandbox(영속)·artifact-exec 와 절대 겹치면 안 됨 */
+export const MCP_SANDBOX_ROLE_LABEL = 'openmake.role=mcp-sandbox';
+export const MCP_SANDBOX_PID_LABEL_KEY = 'openmake.pid';
 
 let dockerCache: { key: string; value: string | null } | null = null;
 /** PATH 또는 절대경로에서 docker 바이너리 탐색 (memoize). 아티팩트 실행 서비스도 재사용. */
@@ -108,6 +117,7 @@ export function defaultSandboxConfig(): SandboxConfig {
         cpus: process.env.MCP_SANDBOX_CPUS || '1.0',
         user: process.env.MCP_SANDBOX_USER || '1000:1000',
         readonly: process.env.MCP_SANDBOX_READONLY === 'true',
+        ownerPid: process.pid,
     };
 }
 
@@ -153,6 +163,11 @@ export function buildDockerArgs(input: SandboxInput, cfg: SandboxConfig): string
     // --memory-swap = --memory 로 swap 차단(미설정 시 swap 으로 메모리 상한 우회 가능).
     a.push('--pids-limit', String(cfg.pidsLimit), '--memory', cfg.memory, '--memory-swap', cfg.memory, '--cpus', cfg.cpus);
     a.push('--user', cfg.user);
+    // 고아 식별 라벨 — 소유 프로세스가 죽은 컨테이너를 부팅 스윕이 결정적으로 판정한다
+    // (실사례: SIGKILL 이 docker CLI 만 죽이고 stdin EOF 를 무시하는 서버가 컨테이너로 잔존).
+    a.push('--label', MCP_SANDBOX_ROLE_LABEL);
+    a.push('--label', `${MCP_SANDBOX_PID_LABEL_KEY}=${cfg.ownerPid}`);
+    a.push('--label', `openmake.serverId=${sanitizeId(input.serverId)}`);
     if (cfg.readonly) a.push('--read-only', '--tmpfs', '/tmp:rw,exec', '--tmpfs', '/run:rw');
     a.push('-v', `${cacheVol}:/home/node/.cache`);
     if (referencesLoopback) a.push('--add-host', 'host.docker.internal:host-gateway');

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -244,9 +244,14 @@ export class DashboardServer {
             await getUnifiedMCPClient().initializeExternalServers(getUnifiedDatabase());
             console.log('[Server] 외부 MCP 서버 초기화 완료');
             // 샌드박스 자세 관측(1회) — OFF+docker 가용(격리 권장) / ON+docker 부재(fail-closed 조기 경보)
-            const { sandboxBootAdvisory } = await import('./mcp/sandbox-bootstrap');
+            const { sandboxBootAdvisory, reapOrphanSandboxContainers } = await import('./mcp/sandbox-bootstrap');
             const advisory = sandboxBootAdvisory();
             if (advisory) console.warn(`[Server] ${advisory}`);
+            // 소유 프로세스가 죽은 MCP 샌드박스 컨테이너 정리 (라벨 pid 기준, fail-open)
+            const reap = reapOrphanSandboxContainers();
+            if (reap.reaped > 0 || reap.errors.length > 0) {
+                console.warn(`[Server] MCP 샌드박스 고아 스윕: 검사 ${reap.scanned}, 정리 ${reap.reaped}, 보류 ${reap.skipped}, 오류 ${reap.errors.length}`);
+            }
         } catch (err) {
             console.error('[Server] 외부 MCP 서버 초기화 실패 (서비스 계속):', err);
         }


### PR DESCRIPTION
## 배경

2026-09-01 실사례: `close()` 의 SIGKILL 이 docker CLI 만 죽이고, stdin EOF 를 무시하는 서버(mcp-python-repl)가 컨테이너로 **이틀간 잔존**(앱 재시작 3회 생존, non-readonly 로 남아 보안 자세도 어긋남). 식별 라벨이 없어 생성 시각·수동 프로세스 대조로만 고아 판정이 가능했다. 사용자 승인 하에 재발 대비 구조화.

## 변경

- **라벨 3개** (`buildDockerArgs`): `openmake.role=mcp-sandbox`(스윕 스코프) · `openmake.pid=<소유 프로세스>`(생존 판정) · `openmake.serverId`(진단)
- **부팅 1회 스윕** `reapOrphanSandboxContainers()` (`mcp/sandbox-bootstrap.ts`): role 라벨 필터 → pid 라벨 프로세스 사망 시에만 stop (`--rm` 이라 stop=제거)
  - 판정 결정적: 죽은 프로세스의 stdio 상대 컨테이너는 어떤 경우에도 쓸모없음
  - **오살 방지**: ESRCH 만 사망 취급(EPERM 등은 생존), 라벨 없는 컨테이너는 보류(`skipped`)
  - 전 docker 호출 timeout + fail-open (Docker VM 정지 실사례 대비 — 스윕이 부팅을 막지 않음)
  - 게이트 `MCP_SANDBOX_ORPHAN_REAP`(기본 on), 1회 상한 50
- server.ts 부팅 배선: 정리/오류 발생 시에만 로그 1줄 (586줄, Gate 3 < 600)

## 설계 제약 (핵심)

⚠️ **라벨 스코핑 필수** — `task-sandbox` 는 `docker run -d --name` **영속 컨테이너**로 재시작을 넘어 살아있는 것이 정상(작업 재개용). 이미지 기준(`ancestor=`) 무차별 스윕은 재개 대기 작업을 죽인다. 주기 스윕은 도입하지 않음(실측 1건 — 부팅 1회가 "재시작 생존" 부류를 정확히 덮음, 빈도 확인 시 추가).

## 검증

- [x] 신규 테스트 4건: 죽은 pid 만 정리·생존/판정불가 보류·ps 실패 fail-open·개별 stop 실패 격리 + 라벨 인자 assertion
- [x] 전체 jest **3242 passed** / `tsc --noEmit` 0 / eslint 신규 오류 0 (runtime-limits max-lines 는 기존 경고)
- [x] 환경변수 3종 `.env.example` 반영
- 배포 후 라이브 검증 예정: 신규 컨테이너 라벨 확인 + 스윕 로그

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5rXygFJzGGrPEJB58SuwS