### PR TITLE
docs(changelog): 1.37.1 에 누락된 #697 항목 보정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### 🐛 버그 수정
 
 * **eval:** response-023 라벨 결함 — 거절문 자연 표현을 금지어로 오지정 ([#695](https://github.com/openmake/openmake_llm/issues/695)) ([2464985](https://github.com/openmake/openmake_llm/commit/24649850e3eb7dead8f903ed0f47f66c30e72f61))
+* **agents,eval:** 라우팅 백로그 27건 해소 + real eval 구 케이스 3건 — 골든셋 게이트 100% ([#697](https://github.com/openmake/openmake_llm/issues/697)) ([11c1bc0](https://github.com/openmake/openmake_llm/commit/11c1bc0d0a19a4677de745835866a11bd52196b0))
 
 ## [1.37.0](https://github.com/openmake/openmake_llm/compare/v1.36.0...v1.37.0) (2026-09-01)
 


### PR DESCRIPTION
## 배경

릴리스 PR #696 을 release-please 의 #697 반영 갱신 **전에** 머지해, 1.37.1 CHANGELOG 에서 #697(라우팅 백로그 해소)이 빠졌다. 코드는 v1.37.1 태그에 정상 포함 — 노트만 누락이며, release-please 는 새 태그 이후 커밋만 집계하므로 그대로 두면 영구 누락된다.

## 변경

1.37.1 버그 수정 섹션에 #697 한 줄 추가 (기존 포맷 그대로). CHANGELOG 만 변경 — 코드 무변경, 배포 불요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5rXygFJzGGrPEJB58SuwS