### PR TITLE
feat(providers): Open AI Service Hub(hasa) 외부 provider 추가

### DIFF
--- a/apps/api/src/config/external-providers.ts
+++ b/apps/api/src/config/external-providers.ts
@@ -171,6 +171,34 @@ export const EXTERNAL_PROVIDER_CATALOG: ReadonlyArray<ExternalProviderCatalogEnt
             { id: 'mistralai/mistral-nemotron',              displayName: 'Mistral Nemotron',     isFree: false, capabilities: { streaming: true, toolCalling: true, vision: false, thinking: false } },
         ],
     },
+    {
+        id: 'hasa',
+        displayName: 'Open AI Service Hub (HASA)',
+        sdkType: 'openai-compatible',
+        defaultBaseUrl: 'https://open.hasa.re.kr/v1',
+        keyPrefixPattern: 'sk-',
+        validatePath: '/models',
+        enabled: true,
+        sortOrder: 60,
+        helpText:
+            'Open AI Service Hub (https://open.hasa.re.kr) 의 개발키(sk-dev-*) 또는 운영키(sk-ops-*)를 입력하세요. ' +
+            '공공 GPU 팜이 서빙하는 오픈소스·국산 모델(Qwen3 Coder, EXAONE, HyperCLOVA X, Kanana 등)을 ' +
+            'OpenAI 호환 API 로 사용합니다. 모델 ID 는 "qwen3-coder" 처럼 접두사 없는 형식입니다. ' +
+            '주의: 모델 목록 API 는 인증이 없어 키 유효성은 첫 채팅에서 확인됩니다. ' +
+            '개발키는 분당 요청·일일 토큰 한도가 낮아(초과 시 429) 체험·검증 용도입니다.',
+        authMethods: ['api_key'] as const,
+        // 2026-09-02 공개 카탈로그(/api/catalog) 기준 — 개발키 허용 + 채팅 모달리티만 수록.
+        fallbackModels: [
+            { id: 'qwen3-coder',          displayName: 'Qwen3 Coder 30B A3B',  isFree: true, capabilities: { streaming: true, toolCalling: true,  vision: false, thinking: false } },
+            { id: 'exaone-4.0-32b',       displayName: 'EXAONE 4.0 32B',       isFree: true, capabilities: { streaming: true, toolCalling: true,  vision: false, thinking: false } },
+            { id: 'llama-3.3-70b',        displayName: 'Llama 3.3 70B',        isFree: true, capabilities: { streaming: true, toolCalling: true,  vision: false, thinking: false } },
+            { id: 'gpt-oss-20b',          displayName: 'GPT-OSS 20B',          isFree: true, capabilities: { streaming: true, toolCalling: true,  vision: false, thinking: true  } },
+            { id: 'gpt-oss-120b',         displayName: 'GPT-OSS 120B',         isFree: true, capabilities: { streaming: true, toolCalling: true,  vision: false, thinking: true  } },
+            { id: 'hyperclovax-seed-32b', displayName: 'HyperCLOVA X SEED 32B', isFree: true, capabilities: { streaming: true, toolCalling: false, vision: false, thinking: true  } },
+            { id: 'kanana-2-30b-a3b',     displayName: 'Kanana 2 30B A3B',     isFree: true, capabilities: { streaming: true, toolCalling: false, vision: false, thinking: false } },
+            { id: 'qwen2.5-vl-72b',       displayName: 'Qwen2.5 VL 72B',       isFree: true, capabilities: { streaming: true, toolCalling: false, vision: true,  thinking: false } },
+        ],
+    },
 ] as const;
 
 /**

--- a/apps/api/src/services/chat-service/provider-gate.ts
+++ b/apps/api/src/services/chat-service/provider-gate.ts
@@ -42,6 +42,7 @@ const KNOWN_FULLID_PREFIXES: readonly string[] = [
     'chatgpt',
     'ollama-cloud',
     'nvidia',
+    'hasa',
 ];
 
 export interface ProviderGateInput {

--- a/apps/web/components/model-picker.tsx
+++ b/apps/web/components/model-picker.tsx
@@ -26,6 +26,7 @@ const EXTERNAL_PROVIDER_LABELS: Record<string, string> = {
   openrouter: "🌐 OpenRouter",
   "ollama-cloud": "🌐 Ollama Cloud",
   nvidia: "🌐 NVIDIA NIM",
+  hasa: "🌐 Open AI Service Hub",
 };
 
 export function ModelPicker({


### PR DESCRIPTION
## 요약
- https://open.hasa.re.kr (Open AI Service Hub) OpenAI 호환 게이트웨이를 사용자 BYOK 외부 provider `hasa` 로 추가
- nvidia 추가(52efc8b0)와 동일 범위: 카탈로그 entry · `KNOWN_FULLID_PREFIXES` · picker 라벨 3파일
- 게이트웨이(LiteLLM) 편입은 direct 동작 확인 후 별도 (설정 2줄)

## 문서 검토 요지
- Bearer `sk-dev-*`/`sk-ops-*`, `/v1/chat/completions` SSE, OpenAI `tools` 지원(5개 모델), 모델 ID 접두사 없음
- `/v1/models` 무인증 → 등록 검증 항상 통과 (helpText 안내)
- 개발키 한도: RPM 기본 약 10 · 동시 제한 · 일 토큰 상한 → 429 + Retry-After
- 무키/무효키 호출은 IP 단위 누적 차단(10회 초과 시 1→32분)

## 라이브 실측 (2026-09-02, 개발키)
- `qwen3-coder` 비스트림 200, `system_fingerprint: vllm-0.24.0`
- 스트리밍 + tools: `delta.tool_calls` 표준 청크, `get_weather({"city":"서울"})`

## 검증
- `tsc --noEmit` api/web 통과, eslint 통과
- jest providers · chat-service · admin-provider-key-sync 258 passed
- [ ] 배포 후 user 3 키 등록 → chat.openmake.cc 에서 `hasa:qwen3-coder` 채팅·도구 호출

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtAjkS2BAQ7JxMsidkdYQD