### PR TITLE
chore(gateway): hasa/* LiteLLM 게이트웨이 편입

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,7 +63,7 @@ LLM_TIMEOUT=120000                              # HTTP 요청 타임아웃 (ms)
 # LiteLLM 통합 게이트웨이로 inference 를 라우팅할 외부 provider id 콤마 목록.
 # 빈값/미설정 = 전부 direct 호출. provider별 롤백은 목록에서 제거 + 재시작.
 # ollama-local(사용자별 endpoint)·chatgpt(OAuth) 는 목록과 무관하게 direct 유지.
-# LLM_GATEWAY_PROVIDERS=openrouter,ollama-cloud,nvidia
+# LLM_GATEWAY_PROVIDERS=openrouter,ollama-cloud,nvidia,hasa
 # 오케스트레이션 자동 배정 (Stage 1) — 모델이 토론(start_discussion)·백그라운드 작업
 # (delegate_agent_task)을 도구로 직접 배정. 의도 프리필터 매칭 턴에만 도구 노출.
 # ORCHESTRATION_AUTO_DISPATCH=true

--- a/scripts/vllm/litellm.config.yaml
+++ b/scripts/vllm/litellm.config.yaml
@@ -7,7 +7,7 @@
 # 토폴로지:
 #   앱(LLM_BASE_URL=http://127.0.0.1:13401) → 이 게이트웨이
 #     ├─ 로컬: Tailscale → DGX vLLM (:8002 qwen / :8003 bge / :8005 flux)
-#     └─ 외부: openrouter/* · ollama-cloud/* · nvidia/* wildcard (사용자 BYOK 는 요청 헤더)
+#     └─ 외부: openrouter/* · ollama-cloud/* · nvidia/* · hasa/* wildcard (사용자 BYOK 는 요청 헤더)
 #
 # 헤더 계약 (LiteLLM 1.89.4 라이브 검증):
 #   Authorization: Bearer <LITELLM_MASTER_KEY>  → 게이트웨이 인증 (upstream 미전달)
@@ -64,6 +64,12 @@ model_list:
   - model_name: nvidia/*
     litellm_params:
       model: nvidia_nim/*
+      api_key: os.environ/DUMMY_UPSTREAM_KEY
+
+  - model_name: hasa/*
+    litellm_params:
+      model: openai/*
+      api_base: https://open.hasa.re.kr/v1
       api_key: os.environ/DUMMY_UPSTREAM_KEY
 
 general_settings:


### PR DESCRIPTION
## 요약
- \`scripts/vllm/litellm.config.yaml\` 에 \`hasa/*\` wildcard deployment (ollama-cloud 패턴: \`openai/*\` + \`api_base\`)
- \`.env.example\` 의 \`LLM_GATEWAY_PROVIDERS\` 예시에 hasa 추가
- 코드 변경 0 — \`resolveGatewayRoute\` 가 목록 기반으로 분기 (PR #701 후속)

## 운영 반영
- 운영 \`/Volumes/MAC_APP/litellm/litellm.config.yaml\` 동일 블록 추가 + \`pm2 restart litellm\`
- 운영 \`.env\` \`LLM_GATEWAY_PROVIDERS=openrouter,ollama-cloud,nvidia,hasa\` + openmake-llm delete→start→save (restart 는 .env 미반영)

## 검증
- 게이트웨이 직접 호출 \`hasa/qwen3-coder\` (master key + x-api-key BYOK) 200
- [ ] 배포 후 chat.openmake.cc 채팅이 127.0.0.1:13401 경유하는지 usage/로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtAjkS2BAQ7JxMsidkdYQD