### PR TITLE
feat(llm): 로컬 기본 채팅 모델 qwen3.8-27b 반영

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,7 +41,7 @@
 # OpenMake LLM 백엔드는 OpenAI 호환 API 만 사용합니다.
 # 운영 권장 토폴로지 (운영 서버 실측 기준):
 #   [OpenMake API] → [LiteLLM proxy :13401] → [vLLM 인스턴스
-#       qwen3.6-35b-a3b :8002 (262K) / bge-m3 :8003 (embedding)]
+#       qwen3.8-27b :8002 (262K, 호환 alias qwen3.6-35b-a3b) / bge-m3 :8003 (embedding)]
 #
 # 운영자 배포 가이드: docs/superpowers/plans/2026-05-20-vllm-server-setup.md
 #
@@ -58,7 +58,7 @@
 LLM_BASE_URL=http://localhost:4000              # 서버 PC 의 vLLM/LiteLLM proxy endpoint
                                                   # 운영 예: http://<llm-host>:13401
 LLM_API_KEY=sk-litellm-master-key               # LiteLLM master key (또는 vLLM --api-key)
-LLM_DEFAULT_MODEL=qwen3.6-35b-a3b               # proxy 가 라우팅하는 model 명 (chat 기본)
+LLM_DEFAULT_MODEL=qwen3.8-27b                   # proxy 가 라우팅하는 model 명 (chat 기본, 2026-09-02 qwen3.6→3.8)
 LLM_TIMEOUT=120000                              # HTTP 요청 타임아웃 (ms)
 # LiteLLM 통합 게이트웨이로 inference 를 라우팅할 외부 provider id 콤마 목록.
 # 빈값/미설정 = 전부 direct 호출. provider별 롤백은 목록에서 제거 + 재시작.
@@ -101,7 +101,7 @@ LLM_TIMEOUT=120000                              # HTTP 요청 타임아웃 (ms)
 # 운영 환경에서 모델 추가/제거 시 본 환경변수로 override (JSON 배열):
 #
 #   LLM_LOCAL_MODELS_JSON='[
-#     {"id":"qwen3.6-35b-a3b","displayName":"Qwen 3.6","description":"기본","role":"chat","contextLength":262144},
+#     {"id":"qwen3.8-27b","displayName":"Qwen 3.8","description":"기본","role":"chat","contextLength":262144},
 #     {"id":"gpt-3.5-turbo","displayName":"GPT-3.5 alias","description":"OpenAI 호환","role":"chat"},
 #     {"id":"bge-m3","displayName":"BGE-M3","description":"Embedding","role":"embedding"}
 #   ]'
@@ -166,7 +166,7 @@ LLM_WEEKLY_TOKEN_LIMIT=5000000
 # 입력 + 예상 출력 합산이 effective 262K 초과 시 input truncate → max_tokens 축소 → 극단 시 413.
 # (2026-06-15: 1M 노드 제거 — 262K↔1M proactive routing 폐기.)
 # LLM_POOL_ENABLED=true                            # false 시 안전망 비활성 (원본 그대로 전송)
-# LLM_POOL_DEFAULT_MODEL=qwen3.6-35b-a3b          # chat 모델 id
+# LLM_POOL_DEFAULT_MODEL=qwen3.8-27b              # chat 모델 id
 # 유효 컨텍스트 상한. **미지정이 권장** — 미지정이면 부팅 프로브가 백엔드에서 실측한다
 # (불가능한 max_tokens 요청의 오류 메시지에서 max_model_len 을 읽음). 값을 명시하면
 # 실측치를 무시하고 이 값을 쓰므로, 모델 교체 시 임계가 어긋날 수 있다.

--- a/apps/api/src/__tests__/model-pool.test.ts
+++ b/apps/api/src/__tests__/model-pool.test.ts
@@ -39,7 +39,7 @@ describe('MODEL_POOL_CONFIG', () => {
         jest.resetModules();
         const { MODEL_POOL_CONFIG } = require('../config/model-pool');
         expect(MODEL_POOL_CONFIG.enabled).toBe(true);
-        expect(MODEL_POOL_CONFIG.defaultModel).toBe('qwen3.6-35b-a3b');
+        expect(MODEL_POOL_CONFIG.defaultModel).toBe('qwen3.8-27b');
         expect(MODEL_POOL_CONFIG.defaultCtx).toBe(262144);
         expect(MODEL_POOL_CONFIG.routingMaxTokensDefault).toBe(16384);
         expect(MODEL_POOL_CONFIG.minOutputTokens).toBe(4096);
@@ -208,7 +208,7 @@ describe('reduceToFit', () => {
             { role: 'user' as const, content: '가'.repeat(150_000) },   // ~157K tokens (최근 보존)
         ];
         const decision = reduceToFit(messages, { num_predict: 8192 });
-        expect(decision.model).toBe('qwen3.6-35b-a3b');
+        expect(decision.model).toBe('qwen3.8-27b');
         expect(decision.source).toBe('auto_trimmed');
         expect(decision.droppedMessages).toBeGreaterThan(0);
         expect(decision.adjustedMaxTokens).toBe(8192);
@@ -218,7 +218,7 @@ describe('reduceToFit', () => {
         // 작은 input + 거대 num_predict → truncate 무효, 출력 토큰만 축소
         const messages = [{ role: 'user' as const, content: 'hi' }];
         const decision = reduceToFit(messages, { num_predict: 250_000 });
-        expect(decision.model).toBe('qwen3.6-35b-a3b');
+        expect(decision.model).toBe('qwen3.8-27b');
         expect(decision.source).toBe('auto_trimmed_reduced');
         expect(decision.adjustedMaxTokens).toBeLessThan(250_000);
         expect(decision.adjustedMaxTokens).toBeGreaterThanOrEqual(4096);
@@ -248,7 +248,7 @@ describe('selectModelByCapacity', () => {
             [{ role: 'user' as const, content: 'hello' }],
             { num_predict: 1000 },
         );
-        expect(decision.model).toBe('qwen3.6-35b-a3b');
+        expect(decision.model).toBe('qwen3.8-27b');
         expect(decision.source).toBe('auto');
     });
 
@@ -260,7 +260,7 @@ describe('selectModelByCapacity', () => {
             ],
             { num_predict: 8192 },
         );
-        expect(decision.model).toBe('qwen3.6-35b-a3b');
+        expect(decision.model).toBe('qwen3.8-27b');
         expect(decision.source).toMatch(/auto_trimmed/);
     });
 
@@ -269,7 +269,7 @@ describe('selectModelByCapacity', () => {
             [{ role: 'user' as const, content: 'hi' }],
             { num_predict: 250_000 },
         );
-        expect(decision.model).toBe('qwen3.6-35b-a3b');
+        expect(decision.model).toBe('qwen3.8-27b');
         expect(decision.source).toBe('auto_trimmed_reduced');
     });
 

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -99,7 +99,7 @@ export const envSchema = z
         // LLM Backend (vLLM via LiteLLM proxy)
         LLM_BASE_URL: z.url().default('http://localhost:4000'),
         LLM_API_KEY: z.string().default('sk-no-key'),
-        LLM_DEFAULT_MODEL: z.string().min(1).default('qwen3.6-35b-a3b'),
+        LLM_DEFAULT_MODEL: z.string().min(1).default('qwen3.8-27b'),
         LLM_TIMEOUT: positiveIntWithDefault(120000).refine((value) => value <= 600000, {
             message: 'LLM_TIMEOUT must be between 1 and 600000 milliseconds',
         }),

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -199,7 +199,7 @@ const DEFAULT_CONFIG: EnvConfig = {
     // LLM Backend (vLLM via LiteLLM proxy)
     llmBaseUrl: 'http://localhost:4000',
     llmApiKey: 'sk-no-key',
-    llmDefaultModel: 'qwen3.6-35b-a3b',
+    llmDefaultModel: 'qwen3.8-27b',
     llmTimeout: 120000,
     llmWarmupTimeoutMs: 10000,
     llmHourlyTokenLimit: 300000,

--- a/apps/api/src/config/local-models.ts
+++ b/apps/api/src/config/local-models.ts
@@ -58,7 +58,9 @@ export interface LocalModelEntry {
 }
 
 /**
- * 기본 카탈로그 — 로컬 채팅 모델은 실질적으로 **단일** (qwen3.6-35b-a3b, 262K).
+ * 기본 카탈로그 — 로컬 채팅 모델은 실질적으로 **단일** (qwen3.8-27b, 262K).
+ * 2026-09-02: DGX :8002 가 qwen3.8-27b-fp8 로 교체됨(`--served-model-name qwen3.8-27b qwen3.6-35b-a3b`
+ * — 구 이름은 같은 가중치를 가리키는 호환 alias 라 옛 대화의 model id 도 계속 라우팅된다).
  * UI 표시명은 실제 모델명을 그대로 사용한다 (2026-07-04: 구 'Local LLM' 브랜딩 표기는
  * 멀티 provider 모델 칩/2단계 picker 도입으로 "어느 모델인지" 를 가려서 폐기).
  *
@@ -73,9 +75,9 @@ export interface LocalModelEntry {
  */
 const DEFAULT_LOCAL_MODELS: LocalModelEntry[] = [
     {
-        id: 'qwen3.6-35b-a3b',
-        displayName: 'qwen3.6-35b-a3b',
-        description: '로컬 vLLM (Qwen 3.6, 35B-A3B)',
+        id: 'qwen3.8-27b',
+        displayName: 'qwen3.8-27b',
+        description: '로컬 vLLM (Qwen 3.8, 27B dense FP8)',
         role: 'chat',
         contextLength: 262144,
     },

--- a/apps/api/src/config/model-defaults.ts
+++ b/apps/api/src/config/model-defaults.ts
@@ -1,5 +1,5 @@
 /**
- * 모델 기본값 — 로컬 모델 capability 프리셋 (기본 채팅 qwen3.6-35b-a3b)
+ * 모델 기본값 — 로컬 모델 capability 프리셋 (기본 채팅 qwen3.8-27b, 2026-09-02 교체)
  *
  * @module config/model-defaults
  */
@@ -52,7 +52,19 @@ export const MODEL_CAPABILITY_PRESETS: Readonly<Record<string, ModelCapabilities
         streaming: true,
     },
     /**
-     * OpenAI 호환 alias — proxy 가 qwen3.6-35b-a3b 으로 라우팅.
+     * Qwen 3.8 27B (dense, FP8) — 2026-09-02 부터 DGX :8002 의 실체.
+     * vLLM `--reasoning-parser qwen3 --tool-call-parser qwen3_coder --limit-mm-per-prompt image=8`
+     * 로 구동 — thinking·toolCalling·vision 모두 라이브 실측(도구 호출 tool_calls, 1px PNG 200).
+     * reasoning_effort 는 high 거절(xhigh/medium/low) — config/reasoning-effort.ts 가 정규화.
+     */
+    'qwen3.8-27b': {
+        toolCalling: true,
+        thinking: true,
+        vision: true,
+        streaming: true,
+    },
+    /**
+     * OpenAI 호환 alias — proxy 가 qwen3.8-27b 으로 라우팅.
      * 외부 도구 / OpenAI SDK 호환 클라이언트가 표준 model ID 로 호출 가능.
      */
     'gpt-3.5-turbo': {

--- a/apps/api/src/config/model-pool.ts
+++ b/apps/api/src/config/model-pool.ts
@@ -30,7 +30,7 @@ function parseBoolEnv(key: string, defaultValue: boolean): boolean {
 }
 
 const enabled = parseBoolEnv('LLM_POOL_ENABLED', true);
-const defaultModel = process.env.LLM_POOL_DEFAULT_MODEL ?? 'qwen3.6-35b-a3b';
+const defaultModel = process.env.LLM_POOL_DEFAULT_MODEL ?? 'qwen3.8-27b';
 const defaultCtx = parseIntEnv('LLM_POOL_DEFAULT_CTX', 262144);
 /** env 로 **명시**됐는지 — 명시값은 프로브 실측보다 우선한다(운영자 의도 존중). */
 const ctxExplicit = process.env.LLM_POOL_DEFAULT_CTX !== undefined && process.env.LLM_POOL_DEFAULT_CTX !== '';

--- a/scripts/setup/gen-env.mjs
+++ b/scripts/setup/gen-env.mjs
@@ -67,7 +67,7 @@ const ADMIN_USERNAME = env('OMK_ADMIN_USERNAME', 'admin');
 const ADMIN_EMAIL = env('OMK_ADMIN_EMAIL', 'admin@openmake.local');
 const LLM_BASE_URL = env('OMK_LLM_BASE_URL', 'http://localhost:4000');
 const LLM_API_KEY = env('OMK_LLM_API_KEY', 'sk-no-key');
-const LLM_MODEL = env('OMK_LLM_MODEL', 'qwen3.6-35b-a3b');
+const LLM_MODEL = env('OMK_LLM_MODEL', 'qwen3.8-27b');
 
 const PG_USER = 'openmake';
 const PG_DB = 'openmake_llm';

--- a/scripts/vllm/litellm.config.yaml
+++ b/scripts/vllm/litellm.config.yaml
@@ -19,6 +19,14 @@
 
 model_list:
   # ---------- 로컬 (DGX vLLM inference plane) — 모델명 무프리픽스 유지 (앱 콜사이트 변경 0) ----------
+  - model_name: qwen3.8-27b
+    litellm_params:
+      model: openai/qwen3.8-27b
+      api_base: os.environ/QWEN_VLLM_API_BASE      # http://<VLLM_TAILSCALE_HOST>:8002/v1
+      api_key: os.environ/VLLM_API_KEY
+
+  # 호환 alias — 2026-09-02 :8002 실체가 qwen3.8-27b 로 바뀜. vLLM 도 같은 이름을 함께 서빙
+  # (--served-model-name qwen3.8-27b qwen3.6-35b-a3b) 하므로 구 클라이언트·옛 대화 model id 유지용.
   - model_name: qwen3.6-35b-a3b
     litellm_params:
       model: openai/qwen3.6-35b-a3b
@@ -31,10 +39,10 @@ model_list:
       api_base: os.environ/BGE_VLLM_API_BASE       # http://<VLLM_TAILSCALE_HOST>:8003/v1
       api_key: os.environ/VLLM_API_KEY
 
-  # OpenAI 호환 alias — 표준 model ID 로 호출 시 qwen3.6 라우팅
+  # OpenAI 호환 alias — 표준 model ID 로 호출 시 qwen3.8 라우팅
   - model_name: gpt-3.5-turbo
     litellm_params:
-      model: openai/qwen3.6-35b-a3b
+      model: openai/qwen3.8-27b
       api_base: os.environ/QWEN_VLLM_API_BASE
       api_key: os.environ/VLLM_API_KEY
 

--- a/scripts/vllm/qwen-serve.sh
+++ b/scripts/vllm/qwen-serve.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 # ============================================================
-# qwen3.6-35b-a3b — 기본 채팅 (262K context) @ :8002
+# qwen3.8-27b — 기본 채팅 (262K context) @ :8002
 # ============================================================
+# ⚠️ 2026-09-02 동기화: DGX :8002 실체가 qwen3.8-27b-fp8(dense, MTP) 로 교체됐고(DGX 측 2026-08-31)
+#   `--served-model-name qwen3.8-27b qwen3.6-35b-a3b` 로 구 이름을 호환 alias 로 함께 서빙한다.
+#   실행 주체도 바뀜 — PM2 가 아니라 DGX `/home/smith/vllm`(git: openmake/openmake_vllm) 의
+#   docker compose (`vllm-chat` 컨테이너, `bin/vllm-launch.sh chat` + `env/chat.env`, 2026-08-20 컷오버).
+#   이 파일은 레포 참조본이며 실제 SoT 는 openmake_vllm 의 env/chat.env 다.
 # DGX 실측 serve 명령 기준 (2026-08-19 동기화 — --limit-mm-per-prompt image 4→8:
 # 채팅 PDF 하이브리드(pdf-vision 페이지 주입, PDF_VISION_TOTAL_IMAGE_CAP=8 페어) 지원.
 # 2026-08-02 prefix caching 추가).
@@ -15,8 +20,8 @@
 #   `Prefix cache hit rate` 지표는 0.0% 로 표시된다(SSM 레이어는 KV 캐시가 없음).
 #   앱 실측(표본 4건)은 3건 개선·1건 악화로 유의성 미확보 — [ChatTiming] 로그 축적 후 재판단.
 #   문제 시 이 플래그만 제거하면 종전 동작으로 복귀한다.
-# 실행 주체: DGX 의 PM2 (`pm2-<user>.service` 아래 vllm-chat) — systemd 개별 유닛 아님.
-# venv: /home/smith/vllm/rebuild/vllm_env.023 (qwen3.6 지원 rebuild)
+# 실행 주체: (구) DGX PM2 vllm-chat → (현) docker compose `vllm-chat` — 위 2026-09-02 주석 참고.
+# venv: /home/smith/vllm_data/rebuild/vllm_env.0271 (vLLM 0.27.1 — Qwen3.8 dense+MTP 레지스트리 포함)
 #
 # 보안:
 # - API key 는 CLI 인자 금지(ps 노출) — 0600 env 파일의 VLLM_API_KEY 를 vLLM 이 직접 인식
@@ -24,7 +29,7 @@
 #   tailscaled 기동 전 부팅 경쟁은 아래 대기 루프로 방어.
 set -euo pipefail
 
-MODEL_DIR="${QWEN_MODEL_DIR:-/home/smith/models/qwen3.6-35b-a3b-fp8}"
+MODEL_DIR="${QWEN_MODEL_DIR:-/home/smith/models/qwen3.8-27b-fp8}"
 
 # vLLM API key — env 파일(0600) 주입 (VLLM_API_KEY)
 set -a; [ -f /home/smith/vllm/vllm.env ] && . /home/smith/vllm/vllm.env; set +a
@@ -42,7 +47,7 @@ exec vllm serve "$MODEL_DIR" \
   --host "$VLLM_BIND_HOST" \
   --tensor-parallel-size 1 \
   --dtype auto \
-  --served-model-name qwen3.6-35b-a3b \
+  --served-model-name qwen3.8-27b qwen3.6-35b-a3b \
   --max-model-len 262144 \
   --gpu-memory-utilization 0.47 \
   --max-num-batched-tokens 8192 \


### PR DESCRIPTION
## 배경
DGX \`:8002\` 가 \`qwen3.8-27b-fp8\` 로 교체돼 있었고(\`--served-model-name qwen3.8-27b qwen3.6-35b-a3b\`), 앱은 구 이름 \`qwen3.6-35b-a3b\` 에만 묶여 있어 UI·카탈로그·capability 가 실체와 달랐다.

## 변경
- 기본값 \`qwen3.8-27b\`: \`env.ts\` · \`env.schema.ts\` · \`model-pool.ts\`
- 로컬 카탈로그 \`local-models.ts\`, capability 프리셋 \`model-defaults.ts\` (+\`qwen3.8-27b\`)
- LiteLLM 참조 config: \`qwen3.8-27b\` 추가, \`gpt-3.5-turbo\` → 3.8, 구 이름은 호환 alias 유지
- \`.env.example\` · \`gen-env.mjs\` · \`qwen-serve.sh\` 참조본 동기화
- \`model-pool.test.ts\` 기본값 갱신

## 라이브 실측 (DGX 직접)
- 도구 호출 \`tool_calls\` 정상, vision(1px PNG 색 인식) 정상, \`reasoning_effort=high\` 400 → 기존 \`qwen3.8\` 정규화 맵이 처리
- 디코드 약 10.7 tok/s (구 MoE 58 tok/s)
- 운영 LiteLLM 에 \`qwen3.8-27b\` 추가 후 게이트웨이 경유 200

## 검증
- api tsc·eslint(신규 경고 0) 통과, jest 3236 passed
- [ ] 배포 + openmake-llm delete→start (\`.env\` LLM_DEFAULT_MODEL) 후 chat.openmake.cc 기본 모델 표시·채팅 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtAjkS2BAQ7JxMsidkdYQD