### PR TITLE
feat(llm): 로컬 모델 자동 발견 — 게이트웨이 /model/info 로 카탈로그 갱신

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -166,6 +166,10 @@ LLM_WEEKLY_TOKEN_LIMIT=5000000
 # 입력 + 예상 출력 합산이 effective 262K 초과 시 input truncate → max_tokens 축소 → 극단 시 413.
 # (2026-06-15: 1M 노드 제거 — 262K↔1M proactive routing 폐기.)
 # LLM_POOL_ENABLED=true                            # false 시 안전망 비활성 (원본 그대로 전송)
+# 로컬 모델 자동 발견 (2026-09-02) — 부팅·주기 프로브가 게이트웨이 /model/info 에서 로컬 모델을 읽어
+# 카탈로그를 갱신한다 (DGX 모델 교체 시 재배포 불필요). false 면 config/local-models.ts 정적 목록만 사용.
+# LLM_LOCAL_MODELS_JSON 이 설정돼 있으면 그것이 우선(명시 override).
+# LLM_LOCAL_MODELS_DISCOVERY=true
 # LLM_POOL_DEFAULT_MODEL=qwen3.8-27b              # chat 모델 id
 # 유효 컨텍스트 상한. **미지정이 권장** — 미지정이면 부팅 프로브가 백엔드에서 실측한다
 # (불가능한 max_tokens 요청의 오류 메시지에서 max_model_len 을 읽음). 값을 명시하면

--- a/apps/api/src/config/local-models-discovery.test.ts
+++ b/apps/api/src/config/local-models-discovery.test.ts
@@ -1,0 +1,67 @@
+/**
+ * 로컬 모델 자동 발견 — 게이트웨이 /model/info 선별 규칙 (순수 함수).
+ * 샘플은 2026-09-02 운영 LiteLLM 응답 형태 그대로.
+ */
+import { selectLocalEntriesFromModelInfo, type GatewayModelInfoEntry } from './local-models-discovery';
+import type { LocalModelEntry } from './local-models';
+
+const QWEN_BASE = 'http://vllm-host:8002/v1';
+const LIVE_SAMPLE: GatewayModelInfoEntry[] = [
+    { model_name: 'qwen3.8-27b', litellm_params: { model: 'openai/qwen3.8-27b', api_base: QWEN_BASE }, model_info: {} },
+    { model_name: 'qwen3.6-35b-a3b', litellm_params: { model: 'openai/qwen3.6-35b-a3b', api_base: QWEN_BASE }, model_info: {} },
+    { model_name: 'bge-m3', litellm_params: { model: 'openai/bge-m3', api_base: 'http://vllm-host:8003/v1' }, model_info: {} },
+    { model_name: 'gpt-3.5-turbo', litellm_params: { model: 'openai/qwen3.8-27b', api_base: QWEN_BASE }, model_info: {} },
+    { model_name: 'flux2-klein', litellm_params: { model: 'openai/flux2-klein', api_base: 'http://vllm-host:8005/v1' }, model_info: { mode: 'image_generation' } },
+    { model_name: 'openrouter/*', litellm_params: { model: 'openrouter/*' }, model_info: {} },
+    { model_name: 'hasa/*', litellm_params: { model: 'openai/*', api_base: 'https://open.hasa.re.kr/v1' }, model_info: {} },
+];
+
+describe('selectLocalEntriesFromModelInfo', () => {
+    it('provider prefix 항목·이미지 모델 제외, alias(gpt-3.5-turbo→qwen3.8-27b) 는 정식 이름 하나로 접는다', () => {
+        const ids = selectLocalEntriesFromModelInfo(LIVE_SAMPLE).map((m) => `${m.id}:${m.role}`);
+        expect(ids).toEqual(['qwen3.8-27b:chat', 'qwen3.6-35b-a3b:chat', 'bge-m3:embedding']);
+    });
+
+    it('vLLM 이 두 이름을 서빙해도 LiteLLM upstream 이 다르면 별개 항목 — 접는 기준은 upstream 동일성', () => {
+        // qwen3.6-35b-a3b 는 upstream 이름도 다르므로(vLLM 측 alias) 게이트웨이 정보만으로는 합칠 수 없다.
+        const out = selectLocalEntriesFromModelInfo(LIVE_SAMPLE);
+        expect(out.find((m) => m.id === 'qwen3.6-35b-a3b')).toBeDefined();
+        expect(out.find((m) => m.id === 'gpt-3.5-turbo')).toBeUndefined();
+    });
+
+    it('정식 이름이 없는 alias 그룹은 첫 항목을 대표로 쓴다', () => {
+        const out = selectLocalEntriesFromModelInfo([
+            { model_name: 'chat-default', litellm_params: { model: 'openai/some-upstream', api_base: QWEN_BASE } },
+            { model_name: 'chat-alias', litellm_params: { model: 'openai/some-upstream', api_base: QWEN_BASE } },
+        ]);
+        expect(out.map((m) => m.id)).toEqual(['chat-default']);
+    });
+
+    it('mode 가 비어 있어도 id 패턴으로 임베딩/비채팅을 가른다', () => {
+        const out = selectLocalEntriesFromModelInfo([
+            { model_name: 'nomic-embed-text', litellm_params: { model: 'openai/nomic-embed-text', api_base: QWEN_BASE } },
+            { model_name: 'whisper-large', litellm_params: { model: 'openai/whisper-large', api_base: QWEN_BASE } },
+            { model_name: 'llama-x', litellm_params: { model: 'openai/llama-x', api_base: QWEN_BASE } },
+        ]);
+        expect(out.map((m) => `${m.id}:${m.role}`)).toEqual(['nomic-embed-text:embedding', 'llama-x:chat']);
+    });
+
+    it('이전 카탈로그의 프로브 실측치(가용성·능력·컨텍스트)를 같은 id 에 보존한다', () => {
+        const prev: LocalModelEntry[] = [{
+            id: 'qwen3.8-27b', displayName: 'qwen3.8-27b', description: 'd', role: 'chat',
+            contextLength: 262144, contextLengthProbed: true, available: true,
+            probedCapabilities: { toolCalling: true },
+        }];
+        const out = selectLocalEntriesFromModelInfo(LIVE_SAMPLE, prev);
+        const q = out.find((m) => m.id === 'qwen3.8-27b')!;
+        expect(q.contextLength).toBe(262144);
+        expect(q.contextLengthProbed).toBe(true);
+        expect(q.available).toBe(true);
+        expect(q.probedCapabilities).toEqual({ toolCalling: true });
+        expect(q.description).toBe('d');
+    });
+
+    it('빈 응답이면 빈 배열 (호출부가 카탈로그를 유지한다)', () => {
+        expect(selectLocalEntriesFromModelInfo([])).toEqual([]);
+    });
+});

--- a/apps/api/src/config/local-models-discovery.ts
+++ b/apps/api/src/config/local-models-discovery.ts
@@ -1,0 +1,104 @@
+/**
+ * 로컬 모델 자동 발견 — 게이트웨이 `/model/info` 선별 규칙 (순수 함수 + fetch).
+ *
+ * 카탈로그 상태(_cached)는 `config/local-models.ts` 가 소유하고, 이 모듈은 상태를 갖지 않는다
+ * (파일 크기 게이트로 분리). 규칙·배경은 local-models.ts 헤더 "모델 발견" 참고.
+ *
+ * @module config/local-models-discovery
+ */
+import type { LocalModelEntry } from './local-models';
+
+/** 게이트웨이 `/model/info` 한 항목 — 발견에 필요한 필드만 */
+export interface GatewayModelInfoEntry {
+    model_name: string;
+    litellm_params?: { model?: string; api_base?: string };
+    model_info?: { mode?: string };
+}
+
+/** 채팅 목록에서 제외하는 LiteLLM `model_info.mode` */
+const NON_CHAT_MODES: ReadonlySet<string> = new Set([
+    'image_generation', 'embedding', 'rerank', 'audio_transcription', 'audio_speech', 'moderation',
+]);
+
+/** id 패턴만으로 역할을 정하는 안전망 — `/model/info` 가 mode 를 비워 두는 커스텀 배포용 */
+const EMBEDDING_ID_PATTERNS = ['bge', 'embed', 'embedding'];
+const NON_CHAT_ID_PATTERNS = ['rerank', 'flux', 'sdxl', 'stable-diffusion', 'dall-e', 'dalle', 'whisper', 'tts', 'clip'];
+
+function upstreamBasename(model: string | undefined): string | undefined {
+    if (!model) return undefined;
+    const i = model.indexOf('/');
+    return i >= 0 ? model.slice(i + 1) : model;
+}
+
+/**
+ * `/model/info` 응답에서 로컬 카탈로그 엔트리를 고른다 (순수 함수).
+ *   - provider prefix(`openrouter/*` 등) 가 있는 항목 제외 → 로컬만
+ *   - `mode` 또는 id 패턴이 비채팅이면 제외 (임베딩은 role='embedding' 으로 유지)
+ *   - 같은 upstream(`litellm_params.model` + `api_base`) 을 가리키는 alias 는 하나로 접는다.
+ *     정식 이름 = upstream 모델명과 같은 model_name (없으면 첫 항목)
+ *   - `prev` 에 같은 id 가 있으면 프로브 실측치(가용성·능력·컨텍스트)를 보존한다
+ *     (호출부가 현재 카탈로그 + 정적 기본 카탈로그를 합쳐 넘긴다)
+ */
+export function selectLocalEntriesFromModelInfo(
+    data: ReadonlyArray<GatewayModelInfoEntry>,
+    prev: ReadonlyArray<LocalModelEntry> = [],
+): LocalModelEntry[] {
+    const groups = new Map<string, GatewayModelInfoEntry[]>();
+    for (const e of data) {
+        const name = e.model_name;
+        if (!name || name.includes('/')) continue;
+        const mode = e.model_info?.mode;
+        if (mode && NON_CHAT_MODES.has(mode) && mode !== 'embedding') continue;
+        const lower = name.toLowerCase();
+        if (NON_CHAT_ID_PATTERNS.some((p) => lower.includes(p))) continue;
+        const key = `${e.litellm_params?.model ?? name}|${e.litellm_params?.api_base ?? ''}`;
+        const g = groups.get(key);
+        if (g) g.push(e); else groups.set(key, [e]);
+    }
+    const out: LocalModelEntry[] = [];
+    for (const g of groups.values()) {
+        const canonical = g.find((e) => e.model_name === upstreamBasename(e.litellm_params?.model)) ?? g[0];
+        const id = canonical.model_name;
+        const lower = id.toLowerCase();
+        const isEmbedding = canonical.model_info?.mode === 'embedding'
+            || EMBEDDING_ID_PATTERNS.some((p) => lower.includes(p));
+        const old = prev.find((m) => m.id === id);
+        out.push({
+            id,
+            displayName: id,
+            description: old?.description ?? `로컬 vLLM (${id})`,
+            role: isEmbedding ? 'embedding' : 'chat',
+            contextLength: old?.contextLength,
+            contextLengthProbed: old?.contextLengthProbed,
+            available: old?.available,
+            unavailableReason: old?.unavailableReason,
+            probedCapabilities: old?.probedCapabilities,
+        });
+    }
+    return out;
+}
+
+
+/** 게이트웨이 `/model/info` 조회 — 실패는 throw 하지 않고 undefined (호출부 fail-open) */
+export async function fetchGatewayModelInfo(
+    llmBaseUrl: string,
+    apiKey: string | undefined,
+    timeoutMs: number,
+): Promise<{ ok: true; data: GatewayModelInfoEntry[] } | { ok: false; reason: string }> {
+    const url = llmBaseUrl.replace(/\/$/, '') + '/model/info';
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        const res = await fetch(url, {
+            headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+            signal: controller.signal,
+        });
+        if (!res.ok) return { ok: false, reason: `${url} → ${res.status}` };
+        const json = await res.json() as { data?: GatewayModelInfoEntry[] };
+        return { ok: true, data: json.data ?? [] };
+    } catch (e) {
+        return { ok: false, reason: e instanceof Error ? e.message : String(e) };
+    } finally {
+        clearTimeout(timer);
+    }
+}

--- a/apps/api/src/config/local-models.ts
+++ b/apps/api/src/config/local-models.ts
@@ -15,15 +15,25 @@
  *   - 본 파일이 기본 카탈로그 (개발자 튜닝)
  *   - 환경변수 override: `LLM_LOCAL_MODELS_JSON` (runtime tweaking)
  *
+ * 모델 발견 (2026-09-02, 동적):
+ *   부팅·주기 프로브가 게이트웨이 `/model/info` 를 읽어 로컬(provider prefix 없는) 모델을
+ *   **자동 발견**한다 — alias(`gpt-3.5-turbo` → 같은 upstream) 는 하나로 접고, `mode` 가
+ *   이미지/임베딩 등인 항목은 채팅 목록에서 뺀다. DGX 에서 모델을 교체하면 재배포 없이
+ *   다음 프로브에 반영된다. 아래 DEFAULT_LOCAL_MODELS 는 게이트웨이에 닿지 못했을 때의
+ *   폴백일 뿐이다 (배경: :8002 가 qwen3.8 로 바뀐 뒤 앱이 옛 이름을 계속 표시하던 사고).
+ *   끄기: `LLM_LOCAL_MODELS_DISCOVERY=false` (그러면 정적 카탈로그만 사용).
+ *   `LLM_LOCAL_MODELS_JSON` 이 있으면 명시 override 라 발견 결과보다 우선한다.
+ *
  * 새 모델 추가 가이드:
- *   1. 서버 PC 의 vLLM 에 모델 띄움
- *   2. 본 카탈로그에 entry 추가 + 클라이언트 PC PM2 reload
- *   3. (선택) MODEL_CAPABILITY_PRESETS (model-defaults.ts) 에 capability 추가
+ *   1. 서버 PC 의 vLLM 에 모델 띄움 (+ LiteLLM model_list 등록) → 다음 프로브에 자동 반영
+ *   2. (선택) MODEL_CAPABILITY_PRESETS (model-defaults.ts) 에 capability 추가
+ *   3. 기본 모델을 바꾸려면 `LLM_DEFAULT_MODEL` — 발견 목록에 없으면 부팅 로그가 경고한다
  *
  * @module config/local-models
  */
 import { createLogger } from '../utils/logger';
 import { MODEL_PROBE } from './model-defaults';
+import { fetchGatewayModelInfo, selectLocalEntriesFromModelInfo } from './local-models-discovery';
 
 const logger = createLogger('LocalModels');
 
@@ -109,6 +119,49 @@ export function getLocalModels(): LocalModelEntry[] {
 
     _cached = DEFAULT_LOCAL_MODELS;
     return _cached;
+}
+
+/**
+ * 게이트웨이 `/model/info` 로 로컬 모델을 발견해 카탈로그를 갱신한다 (fail-open).
+ *   - `LLM_LOCAL_MODELS_JSON`(명시 override) 또는 `LLM_LOCAL_MODELS_DISCOVERY=false` 면 no-op
+ *   - 호출 실패·빈 결과면 기존 카탈로그 유지 (정적 폴백 또는 직전 발견 결과)
+ *   - `LLM_DEFAULT_MODEL` 이 발견 목록에 없으면 경고 — 기본 모델이 실체와 어긋난 신호
+ * @returns 발견해 반영했으면 true
+ */
+export async function discoverLocalModels(
+    llmBaseUrl: string,
+    apiKey: string | undefined,
+    timeoutMs: number = 5000,
+): Promise<boolean> {
+    if (process.env.LLM_LOCAL_MODELS_JSON) return false;
+    if (process.env.LLM_LOCAL_MODELS_DISCOVERY === 'false') return false;
+    const r = await fetchGatewayModelInfo(llmBaseUrl, apiKey, timeoutMs);
+    if (!r.ok) {
+        logger.warn(`모델 발견 실패 — 카탈로그 유지: ${r.reason}`);
+        return false;
+    }
+    const current = getLocalModels();
+    const entries = selectLocalEntriesFromModelInfo(r.data, [...current, ...DEFAULT_LOCAL_MODELS]);
+    if (entries.length === 0) {
+        logger.warn('모델 발견: 로컬 모델 0개 — 카탈로그 유지');
+        return false;
+    }
+    const before = current.map((m) => m.id).join(',');
+    _cached = entries;
+    const after = entries.map((m) => `${m.id}(${m.role})`).join(',');
+    if (before !== entries.map((m) => m.id).join(',')) {
+        logger.info(`모델 발견: 카탈로그 갱신 [${before}] → [${after}]`);
+    } else {
+        logger.debug(`모델 발견: 변경 없음 [${after}]`);
+    }
+    const def = process.env.LLM_DEFAULT_MODEL?.trim();
+    if (def && !entries.some((m) => m.id === def && m.role === 'chat')) {
+        logger.warn(
+            `LLM_DEFAULT_MODEL=${def} 이 게이트웨이 로컬 chat 모델에 없음 — 발견된 모델: ` +
+            `[${entries.filter((m) => m.role === 'chat').map((m) => m.id).join(',')}]. .env 를 확인할 것`,
+        );
+    }
+    return true;
 }
 
 /** id 로 카탈로그 엔트리 조회 (프로브 실측치 참조용). 미등록이면 undefined. */
@@ -369,6 +422,9 @@ export async function probeLocalModelAvailability(
     apiKey: string | undefined,
     timeoutMs: number = 8000,
 ): Promise<{ probed: boolean; available: string[]; missing: string[]; skipped: string[] }> {
+    // Stage 0: 게이트웨이에서 로컬 모델 발견 — 정적 카탈로그는 폴백 (실패해도 진행)
+    await discoverLocalModels(llmBaseUrl, apiKey, Math.min(timeoutMs, 5000));
+
     // Stage 1: /v1/models 빠른 fail
     const modelsUrl = llmBaseUrl.replace(/\/$/, '') + '/v1/models';
     const stage1Controller = new AbortController();


### PR DESCRIPTION
## 배경
로컬 모델 목록의 유일한 출처가 \`config/local-models.ts\` 의 정적 카탈로그 한 줄이라, DGX 에서 모델을 교체해도(qwen3.6→3.8, PR #704) 앱은 옛 이름을 계속 표시했다. 게이트웨이 \`/v1/models\` 대조는 가용/불가 표시에만 쓰였다.

## 변경
- \`config/local-models-discovery.ts\` (신규, 순수 선별 + fetch): provider prefix 항목 제외 → 로컬만, \`model_info.mode\`/id 패턴으로 이미지·음성 제외·임베딩은 \`role=embedding\`, 같은 upstream 을 가리키는 alias(\`gpt-3.5-turbo\`) 는 정식 이름 하나로 접음, 이전 카탈로그의 프로브 실측치(가용성·능력·컨텍스트) 보존
- \`local-models.ts\`: \`discoverLocalModels()\` 가 카탈로그를 갱신, \`probeLocalModelAvailability\` 앞단(Stage 0)에 배선 → 부팅 + 주기 프로브에서 재발견. \`LLM_LOCAL_MODELS_JSON\` 은 명시 override 로 우선, \`LLM_LOCAL_MODELS_DISCOVERY=false\` 로 끔. \`LLM_DEFAULT_MODEL\` 이 발견 목록에 없으면 경고
- 정적 \`DEFAULT_LOCAL_MODELS\` 는 게이트웨이 불달 시 폴백으로만 잔존
- 단위 테스트 6건 (운영 \`/model/info\` 응답 형태 그대로)

## 검증
- 운영 게이트웨이에 선별 로직 실행: \`raw 10 → qwen3.8-27b(chat), qwen3.6-35b-a3b(chat), bge-m3(embedding)\` (alias·flux·wildcard 제외)
- tsc·eslint 통과, 관련 jest 19 passed, \`local-models.ts\` 582줄(Gate 3 600 이내)
- [ ] 배포 후 부팅 로그 \`모델 발견:\` 확인 + \`/api/models\` 로컬 목록 확인

## 참고
vLLM 측 alias(\`--served-model-name\` 두 번째 이름 \`qwen3.6-35b-a3b\`)는 LiteLLM upstream 이름이 달라 게이트웨이 정보만으로는 접지 못한다 — DGX \`env/chat.env\` 에서 제거하면 자연히 사라진다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtAjkS2BAQ7JxMsidkdYQD