### PR TITLE
fix(security): 시스템 스킬 수정·삭제와 공유 에이전트 스킬 배정에 관리자 게이트

### DIFF
--- a/apps/api/src/data/repositories/__tests__/skill-repository-authz.test.ts
+++ b/apps/api/src/data/repositories/__tests__/skill-repository-authz.test.ts
@@ -1,0 +1,89 @@
+/**
+ * 스킬 본문 변경/삭제 권한 회귀 테스트 (2026-09-02 보안 리뷰 H1)
+ *
+ * 시스템 스킬(created_by NULL)은 skill_manifests.prompt_md 를 통해 전 사용자 프롬프트에 주입되므로
+ * 관리자만 수정/삭제할 수 있어야 한다. 종전엔 아무 인증 사용자가 통과했다.
+ */
+import { Pool } from 'pg';
+import { SkillRepository } from '../skill-repository';
+import { assertSkillMutationAllowed } from '../skill-authz';
+import { AuthorizationError } from '../../../utils/error-handler';
+
+jest.mock('../../retry-wrapper', () => ({
+    withRetry: (fn: () => unknown) => fn(),
+}));
+
+function makeMockPool() {
+    return { query: jest.fn() } as unknown as Pool;
+}
+
+function skillRow(overrides: Partial<Record<string, unknown>> = {}) {
+    return {
+        id: 'skill-1', name: 'Test', description: 'd', content: 'c', category: 'general',
+        is_public: false, created_by: null, created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(), source_repo: null, source_path: null,
+        status: 'active', manifest_meta: null, ...overrides,
+    };
+}
+
+const user = { userId: 'user-1', userRole: 'user' };
+const other = { userId: 'user-2', userRole: 'user' };
+const admin = { userId: 'admin-1', userRole: 'admin' };
+
+describe('assertSkillMutationAllowed', () => {
+    it('시스템 스킬 — 일반 사용자는 403', () => {
+        expect(() => assertSkillMutationAllowed(null, user)).toThrow(AuthorizationError);
+        expect(() => assertSkillMutationAllowed(undefined, user)).toThrow(AuthorizationError);
+    });
+    it('시스템 스킬 — 관리자는 허용', () => {
+        expect(() => assertSkillMutationAllowed(null, admin)).not.toThrow();
+    });
+    it('사용자 스킬 — 소유자·관리자 허용, 타인 403', () => {
+        expect(() => assertSkillMutationAllowed('user-1', user)).not.toThrow();
+        expect(() => assertSkillMutationAllowed('user-1', admin)).not.toThrow();
+        expect(() => assertSkillMutationAllowed('user-1', other)).toThrow(AuthorizationError);
+    });
+});
+
+describe('SkillRepository update/delete 권한 게이트', () => {
+    let pool: Pool;
+    let repo: SkillRepository;
+
+    beforeEach(() => {
+        pool = makeMockPool();
+        repo = new SkillRepository(pool);
+    });
+
+    it('updateSkill — 일반 사용자가 시스템 스킬을 수정하면 403 이고 UPDATE 가 실행되지 않는다', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [skillRow({ created_by: null })] }); // getSkillById
+        await expect(repo.updateSkill('skill-1', { content: 'evil' }, user)).rejects.toThrow(AuthorizationError);
+        const sqls = (pool.query as jest.Mock).mock.calls.map((c) => String(c[0]));
+        expect(sqls.some((q) => /UPDATE\s+agent_skills/i.test(q))).toBe(false);
+    });
+
+    it('deleteSkill — 일반 사용자가 시스템 스킬을 삭제하면 403 이고 DELETE 가 실행되지 않는다', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [skillRow({ created_by: null })] }); // getSkillById
+        await expect(repo.deleteSkill('skill-1', user)).rejects.toThrow(AuthorizationError);
+        const sqls = (pool.query as jest.Mock).mock.calls.map((c) => String(c[0]));
+        expect(sqls.some((q) => /DELETE\s+FROM\s+agent_skills/i.test(q))).toBe(false);
+    });
+
+    it('deleteSkill — 관리자는 시스템 스킬을 삭제할 수 있다', async () => {
+        (pool.query as jest.Mock)
+            .mockResolvedValueOnce({ rows: [skillRow({ created_by: null })] }) // getSkillById
+            .mockResolvedValue({ rows: [], rowCount: 1 }); // DELETE + 이후
+        await expect(repo.deleteSkill('skill-1', admin)).resolves.toBe(true);
+    });
+
+    it('deleteSkill — 타인 사용자 스킬은 403', async () => {
+        (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [skillRow({ created_by: 'user-1' })] });
+        await expect(repo.deleteSkill('skill-1', other)).rejects.toThrow(AuthorizationError);
+    });
+
+    it('updateSkill — actor 미전달(내부 시더 경로)은 종전대로 게이트 없음', async () => {
+        (pool.query as jest.Mock)
+            .mockResolvedValueOnce({ rows: [skillRow({ created_by: null })] }) // getSkillById
+            .mockResolvedValue({ rows: [skillRow({ created_by: null, content: 'x' })], rowCount: 1 });
+        await expect(repo.updateSkill('skill-1', { content: 'x' })).resolves.not.toBeNull();
+    });
+});

--- a/apps/api/src/data/repositories/skill-authz.ts
+++ b/apps/api/src/data/repositories/skill-authz.ts
@@ -1,0 +1,20 @@
+/**
+ * 스킬 본문 변경/삭제 권한 — 사용자 스킬은 소유자 또는 관리자, 시스템 스킬(createdBy NULL)은 관리자만.
+ *
+ * skill_manifests.prompt_md 가 전 사용자 시스템 프롬프트 주입의 SoT 라 시스템 스킬 본문 변경은
+ * 저장형 프롬프트 인젝션과 같다. (2026-09-02 보안 리뷰 H1: 종전엔 아무 인증 사용자가 통과했다)
+ */
+import { assertResourceOwnerOrAdmin } from '../../auth/ownership';
+import { AuthorizationError } from '../../utils/error-handler';
+
+export interface SkillActor { userId: string; userRole: string }
+
+export function assertSkillMutationAllowed(createdBy: string | null | undefined, actor: SkillActor): void {
+    if (createdBy) {
+        assertResourceOwnerOrAdmin(createdBy, actor.userId, actor.userRole);
+        return;
+    }
+    if (actor.userRole !== 'admin') {
+        throw new AuthorizationError('시스템 스킬 변경은 관리자만 가능합니다');
+    }
+}

--- a/apps/api/src/data/repositories/skill-repository.ts
+++ b/apps/api/src/data/repositories/skill-repository.ts
@@ -13,6 +13,7 @@ import { createLogger } from '../../utils/logger';
 import { upsertSkillManifest, SKILL_VERSION_LATEST_ORDER_SQL, type SkillManifestRow } from './skill-manifest-sync';
 import { BaseRepository, QueryParam } from './base-repository';
 import { assertResourceOwnerOrAdmin } from '../../auth/ownership';
+import { assertSkillMutationAllowed } from './skill-authz';
 import { rowToSkill } from './skill-row-mapper';
 import { buildDraftQuery } from './skill-draft-query';
 import { SkillAssignmentRepository } from './skill-assignment-repository';
@@ -120,6 +121,7 @@ export interface ActorContext {
     userRole: string;
 }
 
+
 export class SkillRepository extends BaseRepository {
     /** agent_skills ↔ skill_manifests 동기화 (fail-soft — 스킬 행은 이미 커밋됨) */
     private async syncManifest(row: SkillManifestRow): Promise<void> {
@@ -185,9 +187,10 @@ export class SkillRepository extends BaseRepository {
             return null;
         }
 
-        // 소유권 검증: 사용자 스킬(createdBy 존재)이면 소유자 또는 관리자만 수정 가능
-        if (actor && existing.createdBy) {
-            assertResourceOwnerOrAdmin(existing.createdBy, actor.userId, actor.userRole);
+        // 소유권 검증: 사용자 스킬은 소유자/관리자, 시스템 스킬(createdBy NULL)은 관리자만.
+        // skill_manifests.prompt_md 가 전 사용자 프롬프트 주입 SoT 라 시스템 스킬 본문 변경은 admin 한정
+        if (actor) {
+            assertSkillMutationAllowed(existing.createdBy, actor);
         }
 
         const now = new Date();
@@ -233,11 +236,11 @@ export class SkillRepository extends BaseRepository {
      * @param actor - (선택) 요청자 컨텍스트 (userId + userRole)
      */
     async deleteSkill(id: string, actor?: ActorContext): Promise<boolean> {
-        // 소유권 검증
+        // 소유권 검증 (updateSkill 과 동일 규칙 — 시스템 스킬 삭제는 관리자만)
         if (actor) {
             const existing = await this.getSkillById(id);
-            if (existing && existing.createdBy) {
-                assertResourceOwnerOrAdmin(existing.createdBy, actor.userId, actor.userRole);
+            if (existing) {
+                assertSkillMutationAllowed(existing.createdBy, actor);
             }
         }
 

--- a/apps/api/src/routes/__tests__/agents-skill-assign-admin-gate.test.ts
+++ b/apps/api/src/routes/__tests__/agents-skill-assign-admin-gate.test.ts
@@ -1,0 +1,24 @@
+/**
+ * POST/DELETE /api/agents/:agentId/skills/:skillId 관리자 게이트 회귀 테스트 (2026-09-02 보안 리뷰 H2)
+ * 라우터 스택을 직접 검사해 requireAdmin 이 두 라우트에 배선돼 있는지 확인한다.
+ */
+import agentsRouter from '../agents.routes';
+import { requireAdmin } from '../../auth';
+
+interface Layer { route?: { path: string; methods: Record<string, boolean>; stack: Array<{ handle: unknown }> } }
+
+function handlersFor(method: 'post' | 'delete', path: string): unknown[] {
+    const layers = (agentsRouter as unknown as { stack: Layer[] }).stack;
+    const layer = layers.find((l) => l.route && l.route.path === path && l.route.methods[method]);
+    if (!layer?.route) throw new Error(`route not found: ${method.toUpperCase()} ${path}`);
+    return layer.route.stack.map((s) => s.handle);
+}
+
+describe('공유 에이전트 스킬 배정은 관리자만', () => {
+    test('POST /:agentId/skills/:skillId 에 requireAdmin 배선', () => {
+        expect(handlersFor('post', '/:agentId/skills/:skillId')).toContain(requireAdmin);
+    });
+    test('DELETE /:agentId/skills/:skillId 에 requireAdmin 배선', () => {
+        expect(handlersFor('delete', '/:agentId/skills/:skillId')).toContain(requireAdmin);
+    });
+});

--- a/apps/api/src/routes/agents.routes.ts
+++ b/apps/api/src/routes/agents.routes.ts
@@ -17,7 +17,7 @@ import { getCustomAgentBuilder } from '../agents/custom-builder';
 import { success, notFound } from '../utils/api-response';
 import { asyncHandler } from '../utils/error-handler';
 import { getSkillManager } from '../agents/skill-manager';
-import { requireAuth } from '../auth';
+import { requireAuth, requireAdmin } from '../auth';
 import { unauthorized } from '../utils/api-response';
 import { validate } from '../middlewares/validation';
 import {
@@ -213,9 +213,11 @@ router.get('/:agentId/skills', requireAuth, asyncHandler(async (req: Request, re
 
 /**
  * POST /api/agents/:agentId/skills/:skillId
- * 에이전트에 스킬 연결
+ * 에이전트에 스킬 연결 — 공유(산업) 에이전트 배정은 관리자만 (2026-09-02 보안 리뷰 H2:
+ * 종전엔 아무 인증 사용자가 자기 스킬을 공유 에이전트에 배정해 전 사용자 프롬프트에 주입 가능했다).
+ * 개인 배정은 /api/agents/skills/:skillId/user-assign 을 쓴다.
  */
-router.post('/:agentId/skills/:skillId', requireAuth, validate(assignSkillSchema), asyncHandler(async (req: Request, res: Response) => {
+router.post('/:agentId/skills/:skillId', requireAuth, requireAdmin, validate(assignSkillSchema), asyncHandler(async (req: Request, res: Response) => {
     const { agentId, skillId } = req.params;
     // status 가드: 활성 스킬만 할당 허용 (draft/archived 차단)
     const skill = await getSkillManager().getSkillById(skillId);
@@ -236,7 +238,7 @@ router.post('/:agentId/skills/:skillId', requireAuth, validate(assignSkillSchema
  * DELETE /api/agents/:agentId/skills/:skillId
  * 에이전트에서 스킬 해제
  */
-router.delete('/:agentId/skills/:skillId', requireAuth, asyncHandler(async (req: Request, res: Response) => {
+router.delete('/:agentId/skills/:skillId', requireAuth, requireAdmin, asyncHandler(async (req: Request, res: Response) => {
     const { agentId, skillId } = req.params;
     await getSkillManager().removeSkillFromAgent(agentId, skillId);
     res.json(success({ removed: true }));

--- a/apps/api/src/routes/skills.routes.ts
+++ b/apps/api/src/routes/skills.routes.ts
@@ -502,13 +502,13 @@ router.put('/:skillId', requireAuth, validate(updateSkillSchema), asyncHandler(a
     const { skillId } = req.params;
     const userId = (req.user && 'userId' in req.user ? (req.user as { userId: string }).userId : req.user?.id?.toString());
 
-    // 소유권 검증: 본인이 만든 스킬 또는 시스템 스킬 수정 가능
+    // 소유권 검증
     const skill = await getSkillManager().getSkillById(skillId);
     if (!skill) {
         res.status(404).json(notFound('스킬'));
         return;
     }
-    // 시스템 스킬(createdBy=null)은 누구나 수정 가능, 사용자 스킬은 소유자만 수정 가능
+    // 사용자 스킬은 소유자만 — 시스템 스킬(createdBy=null)은 repo 계층에서 관리자 한정 (assertSkillMutationAllowed)
     if (skill.createdBy) {
         assertResourceOwnerOrAdmin(
             String(skill.createdBy),
@@ -538,13 +538,13 @@ router.delete('/:skillId', requireAuth, asyncHandler(async (req: Request, res: R
     const { skillId } = req.params;
     const userId = (req.user && 'userId' in req.user ? (req.user as { userId: string }).userId : req.user?.id?.toString());
 
-    // 소유권 검증: 본인이 만든 스킬 또는 시스템 스킬 삭제 가능
+    // 소유권 검증
     const skill = await getSkillManager().getSkillById(skillId);
     if (!skill) {
         res.status(404).json(notFound('스킬'));
         return;
     }
-    // 시스템 스킬(createdBy=null)은 누구나 삭제 가능, 사용자 스킬은 소유자만 삭제 가능
+    // 사용자 스킬은 소유자만 — 시스템 스킬(createdBy=null)은 repo 계층에서 관리자 한정 (assertSkillMutationAllowed)
     if (skill.createdBy) {
         assertResourceOwnerOrAdmin(
             String(skill.createdBy),


### PR DESCRIPTION
## 배경
2026-09-02 apps/api 보안 리뷰 P0(B1~B4) 에서 확정된 high 2건. 리뷰 리포트는 private docs 리포 `ops/reports/2026-09-02-api-security-review-p0.md`.

## 수정
- **H1 시스템 스킬 무단 수정·삭제 → 전 사용자 프롬프트 인젝션**: `PUT/DELETE /api/agents/skills/:id` 와 repo 계층이 `created_by NULL`(시스템 스킬)이면 소유권 검사를 건너뛰었다. `skill_manifests.prompt_md` 가 시스템 프롬프트 주입 SoT 라 본문 교체가 곧 저장형 인젝션. `data/repositories/skill-authz.ts` 의 `assertSkillMutationAllowed` 를 `updateSkill`/`deleteSkill` 에 적용 — 사용자 스킬은 소유자/관리자, 시스템 스킬은 관리자만(`updateStatus` 와 동일 규칙). 라우트 변경 없음(모든 호출 경로를 repo 에서 막음).
- **H2 공유 에이전트 스킬 배정 무단 변경**: `POST/DELETE /api/agents/:agentId/skills/:skillId` 에 `requireAdmin` 추가. 개인 배정은 `/api/agents/skills/:id/user-assign` 이 따로 있고 apps/web 에 이 라우트 호출처는 없다.

## 검증
- 회귀 테스트 2파일: 시스템 스킬 user → 403 + UPDATE/DELETE 미실행, admin 허용, 타인 스킬 403, actor 미전달(시더) 경로 무변경 / 라우터 스택에 `requireAdmin` 배선. **수정을 되돌리면 실패하는 것을 확인**.
- `tsc --noEmit` 0 오류, eslint 0 오류(skills.routes.ts max-lines 경고는 기존), skill 관련 24 suites 177건 통과.

## 영향 범위
- 일반 사용자가 시스템 스킬을 수정/삭제하거나 산업 에이전트 배정을 바꾸던 경로가 403 이 된다. 정상 UI 흐름(스킬 라이브러리의 내 스킬 편집·개인 배정, 승인 화면)은 소유자 경로라 무영향.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1P3hSryADjr6uvGXzYZpa
