### PR TITLE
fix(security): push 구독 소유자를 req.user 로 고정 + endpoint SSRF 가드

### DIFF
--- a/apps/api/src/routes/push.routes.ts
+++ b/apps/api/src/routes/push.routes.ts
@@ -30,6 +30,7 @@ import {
 } from '../schemas/push.schema';
 import { getPushService, PushSubscription } from '../services/PushService';
 import { getNativePushService } from '../services/NativePushService';
+import { assertPushEndpointAllowed } from '../services/push-endpoint-guard';
 
 const logger = createLogger('PushRoutes');
 
@@ -75,12 +76,14 @@ router.get('/vapid-key', asyncHandler(async (req: Request, res: Response) => {
  */
 router.post('/subscribe', requireAuth, validate(pushSubscribeSchema), asyncHandler(async (req: Request, res: Response) => {
     await warmCacheIfNeeded();
-    const { endpoint, keys, userId } = req.body as {
+    const { endpoint, keys } = req.body as {
         endpoint: string;
         keys: { p256dh: string; auth: string };
-        userId?: string;
     };
-    
+    // 소유자는 인증 주체뿐 — body 의 userId 는 스키마에서 제거됨 (다른 핸들러와 동일)
+    const userId = String(req.user!.id);
+    await assertPushEndpointAllowed(endpoint);
+
     const subscription: PushSubscription = {
         endpoint,
         keys: { p256dh: keys.p256dh, auth: keys.auth },
@@ -93,7 +96,7 @@ router.post('/subscribe', requireAuth, validate(pushSubscribeSchema), asyncHandl
     logger.info(`[Push] 구독 등록: ${endpoint.substring(0, 50)}... (총 ${pushSubscriptions.size}개)`);
 
     // Async DB insert (fire-and-forget)
-    void pushService.subscribe(userId || '', subscription).catch(err => logger.error('[Push] DB 구독 저장 실패:', err));
+    void pushService.subscribe(userId, subscription).catch(err => logger.error('[Push] DB 구독 저장 실패:', err));
     
     res.json(success({ message: 'Push 구독이 등록되었습니다.' }));
 }));

--- a/apps/api/src/schemas/__tests__/push-schema.test.ts
+++ b/apps/api/src/schemas/__tests__/push-schema.test.ts
@@ -1,0 +1,22 @@
+/**
+ * pushSubscribeSchema — body.userId 미수용 + https URL 강제 (2026-09-02 보안 리뷰 H3/L1)
+ */
+import { pushSubscribeSchema } from '../push.schema';
+
+const keys = { p256dh: 'p', auth: 'a' };
+
+describe('pushSubscribeSchema', () => {
+    it('body.userId 는 파싱 결과에서 제거된다 (타인 userId 로 구독 등록 불가)', () => {
+        const parsed = pushSubscribeSchema.parse({ endpoint: 'https://push.example/s/1', keys, userId: 'victim' });
+        expect(parsed).not.toHaveProperty('userId');
+    });
+    it('http endpoint 거부', () => {
+        expect(() => pushSubscribeSchema.parse({ endpoint: 'http://push.example/s/1', keys })).toThrow();
+    });
+    it('URL 아님 거부', () => {
+        expect(() => pushSubscribeSchema.parse({ endpoint: 'push', keys })).toThrow();
+    });
+    it('정상 https endpoint 통과', () => {
+        expect(pushSubscribeSchema.parse({ endpoint: 'https://fcm.googleapis.com/fcm/send/x', keys }).endpoint).toContain('https://');
+    });
+});

--- a/apps/api/src/schemas/push.schema.ts
+++ b/apps/api/src/schemas/push.schema.ts
@@ -16,15 +16,17 @@ import { z } from 'zod';
  * @property {object} keys - VAPID 암호화 키 (필수)
  * @property {string} keys.p256dh - P-256 Diffie-Hellman 공개키 (필수)
  * @property {string} keys.auth - 인증 시크릿 (필수)
- * @property {string} [userId] - 사용자 ID (선택)
  */
 export const pushSubscribeSchema = z.object({
-    endpoint: z.string().min(1, 'endpoint는 필수입니다').max(2048),
+    // 구독 소유자는 항상 req.user — body 의 userId 는 받지 않는다 (2026-09-02 보안 리뷰 H3:
+    // 종전엔 body.userId 로 타인 userId 에 공격자 endpoint 를 등록해 알림 사본을 받을 수 있었다).
+    // endpoint 는 https URL 만 — 사설/loopback 대역 차단은 라우트의 assertPushEndpointAllowed(DNS 해석 필요).
+    endpoint: z.string().min(1, 'endpoint는 필수입니다').max(2048).url('endpoint는 URL이어야 합니다')
+        .refine((u) => u.startsWith('https://'), { message: 'endpoint는 https URL이어야 합니다' }),
     keys: z.object({
         p256dh: z.string().min(1, 'keys.p256dh는 필수입니다'),
         auth: z.string().min(1, 'keys.auth는 필수입니다')
     }),
-    userId: z.string().optional()
 });
 
 /**

--- a/apps/api/src/services/__tests__/push-endpoint-guard.test.ts
+++ b/apps/api/src/services/__tests__/push-endpoint-guard.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Web Push endpoint 아웃바운드 검증 (2026-09-02 보안 리뷰 L1 — blind SSRF 차단)
+ */
+import { assertPushEndpointAllowed } from '../push-endpoint-guard';
+import { ValidationError } from '../../utils/error-handler';
+
+const resolveTo = (address: string) => async () => ({ address });
+
+describe('assertPushEndpointAllowed', () => {
+    it('loopback 으로 풀리는 endpoint 는 거부', async () => {
+        await expect(assertPushEndpointAllowed('https://evil.example/x', resolveTo('127.0.0.1'))).rejects.toThrow(ValidationError);
+    });
+    it('link-local(메타데이터) 으로 풀리는 endpoint 는 거부', async () => {
+        await expect(assertPushEndpointAllowed('https://evil.example/x', resolveTo('169.254.169.254'))).rejects.toThrow(ValidationError);
+    });
+    it('사설 대역으로 풀리는 endpoint 는 거부', async () => {
+        await expect(assertPushEndpointAllowed('https://evil.example/x', resolveTo('10.0.0.5'))).rejects.toThrow(ValidationError);
+    });
+    it('http 스킴은 거부 (DNS 조회 전)', async () => {
+        const resolver = jest.fn(resolveTo('1.2.3.4'));
+        await expect(assertPushEndpointAllowed('http://fcm.googleapis.com/x', resolver)).rejects.toThrow(ValidationError);
+        expect(resolver).not.toHaveBeenCalled();
+    });
+    it('URL 이 아니면 거부', async () => {
+        await expect(assertPushEndpointAllowed('not a url', resolveTo('1.2.3.4'))).rejects.toThrow(ValidationError);
+    });
+    it('공인 IP 로 풀리는 https endpoint 는 통과', async () => {
+        await expect(assertPushEndpointAllowed('https://fcm.googleapis.com/fcm/send/abc', resolveTo('142.250.0.1'))).resolves.toBeUndefined();
+    });
+});

--- a/apps/api/src/services/push-endpoint-guard.ts
+++ b/apps/api/src/services/push-endpoint-guard.ts
@@ -1,0 +1,26 @@
+/**
+ * Web Push 구독 endpoint 아웃바운드 검증 (2026-09-02 보안 리뷰 L1)
+ *
+ * PushService 는 저장된 endpoint 로 서버측 POST(webPush.sendNotification) 를 보내므로
+ * 등록 시점에 SSRF 가드를 통과시킨다 — 사설·loopback·link-local 대역이나 http 스킴은 거부.
+ * 발송 경로는 web-push 라이브러리 내부 fetch 라 pinned fetch 를 끼울 수 없어 등록 시 검증이 유일한 관문이다.
+ */
+import { validateOutboundUrl, type DnsResolver } from '../security/ssrf-guard';
+import { ValidationError } from '../utils/error-handler';
+
+export async function assertPushEndpointAllowed(endpoint: string, resolver?: DnsResolver): Promise<void> {
+    let url: URL;
+    try {
+        url = new URL(endpoint);
+    } catch {
+        throw new ValidationError('endpoint는 URL이어야 합니다');
+    }
+    if (url.protocol !== 'https:') {
+        throw new ValidationError('endpoint는 https URL이어야 합니다');
+    }
+    try {
+        await (resolver ? validateOutboundUrl(endpoint, resolver) : validateOutboundUrl(endpoint));
+    } catch {
+        throw new ValidationError('허용되지 않는 push endpoint 입니다');
+    }
+}


### PR DESCRIPTION
## 배경
2026-09-02 apps/api 보안 리뷰 P0(B1·B4) 의 H3(high)·L1(low). 같은 파일이라 한 PR. 리포트: private docs `ops/reports/2026-09-02-api-security-review-p0.md`.

## 수정
- **H3 타인 알림 가로채기**: `POST /api/push/subscribe` 가 body 의 `userId` 로 구독을 저장했다. 인증 사용자가 피해자 userId 로 자기 endpoint 를 등록하면 피해자에게 가는 web push(작업 완료·채팅 알림 본문) 사본을 받는다. 스키마에서 `userId` 필드 제거, 핸들러는 `req.user.id` 만 사용(같은 파일 다른 3 핸들러와 동일).
- **L1 blind SSRF**: endpoint 가 검증 없이 저장되고 `PushService` 가 `webPush.sendNotification` 으로 그 URL 에 서버측 POST 를 보냈다. `services/push-endpoint-guard.ts` `assertPushEndpointAllowed`(https 강제 + `validateOutboundUrl`) 를 등록 시 적용. 발송 경로는 web-push 라이브러리 내부라 등록 시 검증이 유일한 관문.

## 부수 발견
프론트(`settings/page.tsx`)는 `userId` 를 보낸 적이 없어 지금까지의 웹 구독 행은 `user_id NULL`(`user_key ':endpoint'`) 로 저장됐고, 발송 조회(`WHERE user_id=$1`)에 잡히지 않았다. 즉 **웹 push 가 실제로 전달된 적이 없던** 기능 결함도 함께 닫힌다. 옛 NULL 행은 무해하며 설정에서 알림을 다시 켜면 새 행이 생긴다.

## 검증
- 스키마 테스트 4건(userId 제거, http/비URL 거부), 가드 테스트 6건(loopback·link-local·사설 대역·http·비URL 거부, 공인 IP 통과 — resolver 주입). **수정 되돌리면 실패 확인**.
- `tsc --noEmit` 0, eslint 0, push 관련 3 suites 12건 통과.

## 영향 범위
정상 브라우저 구독(FCM/Mozilla/Apple 등 https 공인 endpoint)은 통과. 사설망 push 서버를 쓰는 배포는 `SSRF_ALLOWED_HOSTS` 허용목록으로 열 수 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1P3hSryADjr6uvGXzYZpa
