### PR TITLE
fix(security): 보안 리뷰 P0 low 4건 — CSV 수식 인젝션·MCP status 가시성·소유권 빈값·셋업 락

### DIFF
--- a/apps/api/src/__tests__/ownership.test.ts
+++ b/apps/api/src/__tests__/ownership.test.ts
@@ -42,8 +42,12 @@ describe('assertResourceOwnerOrAdmin', () => {
         expect(() => assertResourceOwnerOrAdmin('owner', 'requester', 'guest')).toThrow(AuthorizationError);
     });
 
-    test('empty string IDs match and pass for non-admin', () => {
-        expect(() => assertResourceOwnerOrAdmin('', '', 'user')).not.toThrow();
+    // 2026-09-02 보안 리뷰 L4: 빈값끼리의 동등 비교('undefined'==='undefined')로 통과하던 것을 차단
+    test.each([
+        ['', ''], ['undefined', 'undefined'], ['null', 'null'],
+        [undefined, undefined], [null, null], ['u1', undefined],
+    ])('empty/nullish ID pair (%j, %j) throws for non-admin even when equal', (owner, requester) => {
+        expect(() => assertResourceOwnerOrAdmin(owner as unknown as string, requester as unknown as string, 'user')).toThrow(AuthorizationError);
     });
 
     test('empty owner ID with non-empty request ID throws for non-admin', () => {

--- a/apps/api/src/__tests__/routes/first-run-setup.routes.test.ts
+++ b/apps/api/src/__tests__/routes/first-run-setup.routes.test.ts
@@ -16,6 +16,9 @@ jest.mock('../../data/user-manager', () => ({
 }));
 
 const settingsUpdate = jest.fn(async () => ({ requiresRestart: [] }));
+// advisory lock 은 DB 세션이 필요하므로 단위 테스트에선 통과시키고 호출 사실만 기록
+const withAdvisoryLock = jest.fn(async (_key: number, fn: () => Promise<unknown>) => fn());
+jest.mock('../../data/advisory-lock', () => ({ withAdvisoryLock: (k: number, f: () => Promise<unknown>) => withAdvisoryLock(k, f) }));
 jest.mock('../../services/system-settings-service', () => ({
     getSystemSettingsService: () => ({ update: settingsUpdate }),
 }));

--- a/apps/api/src/auth/ownership.ts
+++ b/apps/api/src/auth/ownership.ts
@@ -1,5 +1,12 @@
 import { AuthorizationError } from '../utils/error-handler';
 
+const EMPTY_ID_STRINGS = new Set(['', 'undefined', 'null']);
+
+/** 호출처가 String(null)/String(undefined) 로 넘긴 값도 빈값으로 본다 */
+function isEmptyId(id: unknown): boolean {
+    return id === null || id === undefined || EMPTY_ID_STRINGS.has(String(id).trim());
+}
+
 /**
  * Asserts that the request user owns the resource, or is an admin.
  * Throws AuthorizationError (403) if access is denied.
@@ -15,6 +22,10 @@ export function assertResourceOwnerOrAdmin(
     userRole: string
 ): void {
     if (userRole === 'admin') return;
+    // 빈값끼리의 동등 비교('undefined'==='undefined')로 통과하지 않도록 양쪽 모두 실값일 때만 소유자 판정
+    if (isEmptyId(resourceOwnerId) || isEmptyId(requestUserId)) {
+        throw new AuthorizationError('접근 권한이 없습니다');
+    }
     if (String(resourceOwnerId) === String(requestUserId)) return;
     throw new AuthorizationError('접근 권한이 없습니다');
 }

--- a/apps/api/src/config/constants.ts
+++ b/apps/api/src/config/constants.ts
@@ -302,3 +302,9 @@ export const SKILL_USAGE_LOG = {
 // ============================================
 
 // 모델 식별은 `getModelForRole('chat')` 또는 `getConfig().llmDefaultModel` 사용.
+
+/**
+ * 첫 실행 셋업(POST /api/setup) 의 admin 확인→생성 직렬화용 pg advisory lock 키.
+ * 마이그레이션 락(runner.ts MIGRATION_ADVISORY_LOCK_KEY 0x6f6d6c6d)과 겹치지 않는 값.
+ */
+export const FIRST_RUN_SETUP_ADVISORY_LOCK_KEY = 0x6f6d7365;

--- a/apps/api/src/controllers/admin-alerts.controller.ts
+++ b/apps/api/src/controllers/admin-alerts.controller.ts
@@ -9,6 +9,7 @@
  * @module controllers/admin-alerts.controller
  */
 import { Request, Response } from 'express';
+import { csvCell } from '../utils/csv';
 import { success, badRequest, internalError } from '../utils/api-response';
 import { createLogger } from '../utils/logger';
 
@@ -252,12 +253,8 @@ export async function exportAlertHistoryCsv(req: Request, res: Response): Promis
             [...params, maxRows],
         );
 
-        // RFC 4180: 모든 필드를 "" 로 감싸고 내부 " 를 "" 로 escape
-        const esc = (v: unknown): string => {
-            if (v === null || v === undefined) return '""';
-            const s = typeof v === 'string' ? v : (v instanceof Date ? v.toISOString() : JSON.stringify(v));
-            return `"${s.replace(/"/g, '""')}"`;
-        };
+        // RFC 4180 + 수식 인젝션 무력화 (utils/csv)
+        const esc = csvCell;
 
         const header = ['id', 'created_at', 'type', 'severity', 'title', 'message', 'acknowledged', 'acknowledged_by', 'acknowledged_at', 'data'].join(',');
         const rows = (r.rows as Array<Record<string, unknown>>).map(row => [

--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -6,6 +6,7 @@
  */
 
 import { Request, Response, Router } from 'express';
+import { csvCell } from '../utils/csv';
 import { getUserManager, UserRole, USER_ROLES, isUserRole } from '../data/user-manager';
 import { getPool } from '../data/models/unified-database';
 import { requireAuth, requireAdmin } from '../auth';
@@ -217,10 +218,7 @@ export class AdminController {
                 const csvLines = [
                     headers.join(','),
                     ...result.rows.map((row: Record<string, unknown>) =>
-                        headers.map(h => {
-                            const val = String(row[h] ?? '').replace(/"/g, '""');
-                            return `"${val}"`;
-                        }).join(',')
+                        headers.map(h => csvCell(row[h] instanceof Date ? row[h] : (row[h] === null || row[h] === undefined ? '' : String(row[h])))).join(',')
                     )
                 ];
                 res.setHeader('Content-Type', 'text/csv; charset=utf-8');

--- a/apps/api/src/data/advisory-lock.ts
+++ b/apps/api/src/data/advisory-lock.ts
@@ -1,0 +1,22 @@
+/**
+ * pg advisory lock 으로 임계 구역을 직렬화하는 공용 헬퍼.
+ *
+ * 세션 락이라 전용 client 를 잡아 lock → fn → unlock → release 순으로 처리한다
+ * (마이그레이션 runner 의 applyPendingWithLock 과 같은 형태). 키는 config/constants 에
+ * 서로 겹치지 않게 정의한다.
+ */
+import { getPool } from './models/unified-database';
+
+export async function withAdvisoryLock<T>(key: number, fn: () => Promise<T>): Promise<T> {
+    const lockClient = await getPool().connect();
+    try {
+        await lockClient.query('SELECT pg_advisory_lock($1)', [key]);
+        try {
+            return await fn();
+        } finally {
+            await lockClient.query('SELECT pg_advisory_unlock($1)', [key]);
+        }
+    } finally {
+        lockClient.release();
+    }
+}

--- a/apps/api/src/routes/first-run-setup.routes.ts
+++ b/apps/api/src/routes/first-run-setup.routes.ts
@@ -17,6 +17,8 @@ import { validate } from '../middlewares/validation';
 import { asyncHandler } from '../utils/error-handler';
 import { success, badRequest, forbidden } from '../utils/api-response';
 import { getUserManager } from '../data/user-manager';
+import { withAdvisoryLock } from '../data/advisory-lock';
+import { FIRST_RUN_SETUP_ADVISORY_LOCK_KEY } from '../config/constants';
 import { getSystemSettingsService } from '../services/system-settings-service';
 import { SETTING_DEFS_BY_KEY } from '../config/system-settings-registry';
 import { getAuditService } from '../services/AuditService';
@@ -55,6 +57,12 @@ firstRunSetupRouter.get('/status', asyncHandler(async (_req: Request, res: Respo
 }));
 
 firstRunSetupRouter.post('/', validate(setupSchema), asyncHandler(async (req: Request, res: Response) => {
+    // admin 존재 확인 → 생성 사이를 advisory lock 으로 직렬화 — 동시 요청이 각각 "admin 없음"을 보고
+    // 복수 관리자를 만드는 경합 차단 (2026-09-02 보안 리뷰 L5). 세션 락이라 전용 client 로 잡는다.
+    await withAdvisoryLock(FIRST_RUN_SETUP_ADVISORY_LOCK_KEY, () => runSetup(req, res));
+}));
+
+async function runSetup(req: Request, res: Response): Promise<void> {
     if (await adminExists()) {
         res.status(403).json(forbidden('셋업이 이미 완료되었습니다 (관리자 계정 존재)'));
         return;
@@ -111,4 +119,4 @@ firstRunSetupRouter.post('/', validate(setupSchema), asyncHandler(async (req: Re
 
     logger.info(`첫 실행 셋업 완료 — 관리자 ${body.adminEmail} 생성`);
     res.json(success({ completed: true }));
-}));
+}

--- a/apps/api/src/routes/mcp.routes.ts
+++ b/apps/api/src/routes/mcp.routes.ts
@@ -530,9 +530,10 @@ export const mcpRouter = Router();
       // ⚠️ 사용자 소유 서버는 전역 registry 가 아니라 userPool 에 뜬다 — registry 만 보면
       // 실제로 연결돼 도구가 등록된 서버도 늘 disconnected/toolCount:0 으로 보고된다
       // (목록 API 는 이미 supervisor 를 함께 본다. 이중 풀은 양쪽 대칭이 원칙).
-      const db = getUnifiedDatabase();
-      const server = await db.getMcpServerById(id);
-      if (!server) {
+      // 목록 API 와 동일한 visibility 게이트 — 타인 user_private 서버는 존재 자체를 숨긴다(404)
+      const actor = { id: String(req.user?.id ?? ''), role: req.user?.role ?? 'user' };
+      const server = await new McpCatalogRepository(getUnifiedDatabase().getPool()).getServerById(id);
+      if (!server || !canViewServer(actor, server)) {
           res.status(404).json(notFound('서버'));
           return;
       }

--- a/apps/api/src/utils/__tests__/csv.test.ts
+++ b/apps/api/src/utils/__tests__/csv.test.ts
@@ -1,0 +1,27 @@
+/** CSV 수식 인젝션 무력화 (2026-09-02 보안 리뷰 L2) */
+import { csvCell } from '../csv';
+
+describe('csvCell', () => {
+    it.each(['=cmd|"/c calc"!A1', '+1+1', '-2+3', '@SUM(A1)', '\tx', '\rx'])('수식 접두 %j 는 작은따옴표로 텍스트 고정', (v) => {
+        const cell = csvCell(v);
+        expect(cell.startsWith(`"'`)).toBe(true);
+    });
+    it('일반 문자열은 접두 없이 따옴표만', () => {
+        expect(csvCell('hello')).toBe('"hello"');
+    });
+    it('내부 따옴표는 이중화', () => {
+        expect(csvCell('a"b')).toBe('"a""b"');
+    });
+    it('null/undefined 는 빈 셀', () => {
+        expect(csvCell(null)).toBe('""');
+        expect(csvCell(undefined)).toBe('""');
+    });
+    it('숫자·불리언·객체는 수식 접두를 붙이지 않는다', () => {
+        expect(csvCell(-5)).toBe('"-5"');
+        expect(csvCell(true)).toBe('"true"');
+        expect(csvCell({ a: 1 })).toBe('"{""a"":1}"');
+    });
+    it('Date 는 ISO 문자열', () => {
+        expect(csvCell(new Date('2026-09-02T00:00:00Z'))).toBe('"2026-09-02T00:00:00.000Z"');
+    });
+});

--- a/apps/api/src/utils/csv.ts
+++ b/apps/api/src/utils/csv.ts
@@ -1,0 +1,24 @@
+/**
+ * CSV 셀 인코딩 (RFC 4180 + 수식 인젝션 무력화)
+ *
+ * 관리자 export CSV 를 Excel 등에서 열 때 셀 선행 문자 `= + - @ \t \r` 는 수식으로 해석돼
+ * 외부 호출·명령 실행이 가능하다(2026-09-02 보안 리뷰 L2). 문자열 값이 그 문자로 시작하면
+ * 작은따옴표를 앞에 붙여 텍스트로 고정한다(OWASP CSV Injection 권고). 숫자·불리언 등
+ * 비문자열은 원래 수식이 될 수 없으므로 접두만 이스케이프한다.
+ */
+const FORMULA_PREFIX = /^[=+\-@\t\r]/;
+
+export function csvCell(value: unknown): string {
+    if (value === null || value === undefined) return '""';
+    let s: string;
+    if (typeof value === 'string') {
+        s = FORMULA_PREFIX.test(value) ? `'${value}` : value;
+    } else if (value instanceof Date) {
+        s = value.toISOString();
+    } else if (typeof value === 'object') {
+        s = JSON.stringify(value);
+    } else {
+        s = String(value);
+    }
+    return `"${s.replace(/"/g, '""')}"`;
+}


### PR DESCRIPTION
## 배경
2026-09-02 apps/api 보안 리뷰 P0(B1~B4) 의 low 4건 묶음. 리포트: private docs `ops/reports/2026-09-02-api-security-review-p0.md`. high 는 #706·#707.

## 수정
- **L2 CSV 수식 인젝션** — 관리자 대화 export·알림 이력 export 가 `"` 만 이스케이프해 사용자 채팅 본문의 선행 `= + - @ \t \r` 가 Excel 에서 수식 실행됐다. `utils/csv.ts` `csvCell`(문자열 셀에만 `'` 접두, 숫자/객체는 무영향) 을 두 곳 공용.
- **L3 타인 MCP 서버 status 조회** — `GET /api/mcp/servers/:id/status` 에 `canViewServer` 미적용(목록 API 는 적용). 같은 게이트 + 미통과 404.
- **L4 `assertResourceOwnerOrAdmin` 빈값 통과** — `'undefined'==='undefined'` 로 소유권 통과하던 잠복 결함. 양쪽 실값일 때만 판정. 기존 테스트의 "빈 문자열 쌍은 통과" 기대는 이 결함을 문서화한 것이라 차단으로 갱신.
- **L5 첫 실행 셋업 복수 admin 경합** — admin 확인→생성을 pg advisory lock 으로 직렬화. `data/advisory-lock.ts` `withAdvisoryLock`(라우트에서 pool 직접 사용 금지 lint 준수, runner 와 같은 형태), 키는 `config/constants`.

## 검증
- csv 6 케이스 · ownership 빈값 쌍 6 케이스(수정 되돌리면 5 실패 확인) · 셋업 라우트 기존 5 케이스(lock 통과 mock).
- `tsc --noEmit` 0, eslint 0, 관련 41 suites 326건 통과.

## 영향 범위
- CSV: 수식 접두 문자열 셀에 `'` 가 붙는다(Excel 표시상 텍스트). 
- L4: 호출처 15곳 전부 `req.user.id` 를 넘겨 정상 경로 무변경. 소유자가 NULL 인 리소스는 종전에도 문자열 `'null'` 불일치로 거부됐다.
- L5: 셋업 POST 에 DB client 1개 추가 점유(요청 동안만).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1P3hSryADjr6uvGXzYZpa
