### PR TITLE
fix(security): 보안 리뷰 P1 — 내부 번들 스코프·역할 게이트 실행 강제·argv 비밀 예외 명시

### DIFF
--- a/apps/api/src/controllers/user-extensions.controller.ts
+++ b/apps/api/src/controllers/user-extensions.controller.ts
@@ -27,6 +27,7 @@
  * @see data/repositories/extension-catalog-repository
  */
 import { Router, Request } from 'express';
+import { isAdminRole } from '../data/user-manager';
 import { z } from 'zod';
 import { requireAuth, requireAdmin } from '../auth/middleware';
 import { validate } from '../middlewares/validation';
@@ -79,7 +80,7 @@ function toPublic(row: UserExtensionRow) {
 }
 
 /** ExtensionIngestService 조립 (동적 import — update-check/gallery install 공용). */
-async function buildIngestService() {
+async function buildIngestService(scope?: { userId: string; isAdmin: boolean }) {
     const { ExtensionIngestService } = await import('../agents/git-ingest/extension-ingest-service');
     const { GitFetcher } = await import('../agents/git-ingest/git-fetcher');
     const { LLMClient } = await import('../llm/client');
@@ -89,8 +90,12 @@ async function buildIngestService() {
         pool: getPool(),
         llmClientFactory: (model: string) => new LLMClient(model ? { model } : {}),
         fetcherFactory: (opts) => new GitFetcher({ accessToken: opts.accessToken, timeoutMs: SKILL_CREATOR.gitFetchTimeout }),
-        // 갤러리에 게시된 내부 번들(internal://bundle/<id>) 설치 — DB 에서 파일을 읽는다
-        internalBundleLoader: (id) => new MarketplaceBundleRepository(getPool()).load(id),
+        // 갤러리에 게시된 내부 번들(internal://bundle/<id>) 설치 — DB 에서 파일을 읽는다.
+        // scope 가 있으면 요청자 스코프(본인 소유 또는 shared 게시분)로만 읽는다 (B9-01 심층방어)
+        internalBundleLoader: (id) => {
+            const repo = new MarketplaceBundleRepository(getPool());
+            return scope && !scope.isAdmin ? repo.loadForUser(id, scope.userId) : repo.load(id);
+        },
     });
 }
 
@@ -146,7 +151,7 @@ export function createUserExtensionsController(): Router {
             if (!shared) { res.status(404).json(notFound('공유 확장 없음')); return; }
 
             const body = req.body as z.infer<typeof galleryInstallSchema>;
-            const service = await buildIngestService();
+            const service = await buildIngestService({ userId, isAdmin: isAdminRole(req.user?.role) });
             // 설치자 본인 계정으로 동일 소스 ingest 재실행 — 구성요소는 본인 소유 draft 로 생성
             const result = await service.import({
                 userId,
@@ -344,7 +349,7 @@ export function createUserExtensionsController(): Router {
             const row = await repo.getByIdForUser(req.params.id, userId, false);
             if (!row || row.status !== 'active') { res.status(404).json(notFound('확장 없음')); return; }
 
-            const service = await buildIngestService();
+            const service = await buildIngestService({ userId, isAdmin: isAdminRole(req.user?.role) });
             const body = req.body as z.infer<typeof updateCheckSchema>;
             const result = await service.checkForUpdate({
                 sourceUrl: row.source_url,

--- a/apps/api/src/data/repositories/__tests__/marketplace-bundle-scope.test.ts
+++ b/apps/api/src/data/repositories/__tests__/marketplace-bundle-scope.test.ts
@@ -1,0 +1,39 @@
+/**
+ * MarketplaceBundleRepository.loadForUser — 요청자 스코프 (2026-09-02 보안 리뷰 B9-01)
+ * 무스코프 load 와 달리 소유자 또는 shared 게시 조건이 SQL 에 실리고 userId 가 바인딩되는지 고정한다.
+ */
+import { Pool } from 'pg';
+import { MarketplaceBundleRepository } from '../marketplace-bundle-repository';
+import { INTERNAL_BUNDLE_PREFIX } from '../../../agents/git-ingest/internal-bundle-fetcher';
+
+function makePool(rows: unknown[]) {
+    return { query: jest.fn().mockResolvedValue({ rows }) } as unknown as Pool;
+}
+
+describe('MarketplaceBundleRepository.loadForUser', () => {
+    it('owner_id 또는 shared 게시 조건을 SQL 에 싣고 [id, userId, prefix] 를 바인딩한다', async () => {
+        const pool = makePool([{ sha: 'abc', files: [{ path: 'SKILL.md', encoding: 'utf8', content: '# x' }] }]);
+        const repo = new MarketplaceBundleRepository(pool);
+        const loaded = await repo.loadForUser('bundle-1', 'user-7');
+        const [sql, params] = (pool.query as jest.Mock).mock.calls[0];
+        expect(sql).toMatch(/owner_id\s*=\s*\$2/);
+        expect(sql).toMatch(/visibility\s*=\s*'shared'/);
+        expect(sql).toMatch(/status\s*=\s*'active'/);
+        expect(params).toEqual(['bundle-1', 'user-7', INTERNAL_BUNDLE_PREFIX]);
+        expect(loaded?.sha).toBe('abc');
+        expect(new TextDecoder().decode(loaded!.files.get('SKILL.md')!)).toBe('# x');
+    });
+
+    it('조건 불일치(행 없음)면 null', async () => {
+        const repo = new MarketplaceBundleRepository(makePool([]));
+        await expect(repo.loadForUser('bundle-1', 'stranger')).resolves.toBeNull();
+    });
+
+    it('무스코프 load 는 userId 를 받지 않는다 (admin/내부 전용)', async () => {
+        const pool = makePool([]);
+        await new MarketplaceBundleRepository(pool).load('bundle-1');
+        const [sql, params] = (pool.query as jest.Mock).mock.calls[0];
+        expect(sql).not.toMatch(/owner_id/);
+        expect(params).toEqual(['bundle-1']);
+    });
+});

--- a/apps/api/src/data/repositories/marketplace-bundle-repository.ts
+++ b/apps/api/src/data/repositories/marketplace-bundle-repository.ts
@@ -7,6 +7,7 @@
  * @module data/repositories/marketplace-bundle-repository
  */
 import type { Pool } from 'pg';
+import { INTERNAL_BUNDLE_PREFIX } from '../../agents/git-ingest/internal-bundle-fetcher';
 import { createHash, randomUUID } from 'crypto';
 import type { LoadedBundle } from '../../agents/git-ingest/internal-bundle-fetcher';
 
@@ -62,12 +63,34 @@ export class MarketplaceBundleRepository {
         const r = await this.pool.query<{ sha: string; files: BundleFileRecord[] }>(
             `SELECT sha, files FROM marketplace_bundles WHERE id = $1`, [id]);
         const row = r.rows[0];
-        if (!row) return null;
+        return row ? this.toLoadedBundle(row) : null;
+    }
+
+    private toLoadedBundle(row: { sha: string; files: BundleFileRecord[] }): LoadedBundle {
         const files = new Map<string, Uint8Array>();
         for (const f of row.files) {
             files.set(f.path, f.encoding === 'base64' ? new Uint8Array(Buffer.from(f.content, 'base64')) : new Uint8Array(Buffer.from(f.content, 'utf8')));
         }
         return { sha: row.sha, files };
+    }
+
+    /**
+     * 요청자 스코프 로더 — 본인 소유이거나 갤러리에 shared 로 게시된(user_extensions.source_url 이
+     * 이 번들을 가리키고 visibility='shared'·active) 번들만 돌려준다. 2026-09-02 보안 리뷰 B9-01:
+     * 채팅 도구 import_extension_from_git 가 internal://bundle/<id> 를 무스코프 load 로 설치해
+     * 타인의 private 번들 내용을 id 만 알면 가져올 수 있었다(갤러리 경로만 getInstallableById 게이트).
+     */
+    async loadForUser(id: string, userId: string): Promise<LoadedBundle | null> {
+        const r = await this.pool.query<{ sha: string; files: BundleFileRecord[] }>(
+            `SELECT b.sha, b.files FROM marketplace_bundles b
+              WHERE b.id = $1
+                AND (b.owner_id = $2
+                     OR EXISTS (SELECT 1 FROM user_extensions ue
+                                 WHERE ue.source_url = $3 || b.id
+                                   AND ue.visibility = 'shared' AND ue.status = 'active'))`,
+            [id, userId, INTERNAL_BUNDLE_PREFIX]);
+        const row = r.rows[0];
+        return row ? this.toLoadedBundle(row) : null;
     }
 
     async getByOwnerAndName(ownerId: string, name: string): Promise<MarketplaceBundleRow | null> {

--- a/apps/api/src/mcp/__tests__/tool-router-role-gate.test.ts
+++ b/apps/api/src/mcp/__tests__/tool-router-role-gate.test.ts
@@ -1,0 +1,58 @@
+/**
+ * ToolRouter × 역할 게이트 2차 방어 (2026-09-02 보안 리뷰 B7-01)
+ * 노출 필터에서 빠진 고위험 서버 도구를 이름으로 직접 호출해도 역할 미달이면 실행되지 않는다.
+ */
+import { ToolRouter } from '../tool-router';
+import { filterRestrictedTools } from '../../services/chat-service/tool-restrictions';
+
+const ORIGINAL = process.env.MCP_RESTRICTED_SERVERS;
+
+function makeRouter(exec: jest.Mock): ToolRouter {
+    const router = new ToolRouter();
+    router.registerExternalTools(
+        'srv-py', 'Python REPL',
+        [{ name: 'run_code', description: 'exec', inputSchema: { type: 'object', properties: {} } }],
+        exec,
+    );
+    return router;
+}
+
+describe('ToolRouter 역할 게이트', () => {
+    beforeEach(() => { process.env.MCP_RESTRICTED_SERVERS = 'Python REPL:admin'; });
+    afterEach(() => { if (ORIGINAL === undefined) delete process.env.MCP_RESTRICTED_SERVERS; else process.env.MCP_RESTRICTED_SERVERS = ORIGINAL; });
+
+    it('user 역할이 이름으로 직접 호출하면 실행 없이 거절', async () => {
+        const exec = jest.fn(async () => ({ content: [{ type: 'text' as const, text: 'ran' }] }));
+        const r = await makeRouter(exec).executeTool('Python REPL::run_code', {}, { userId: 'u1', role: 'user' });
+        expect(r.isError).toBe(true);
+        expect(exec).not.toHaveBeenCalled();
+    });
+
+    it('guest 도 거절', async () => {
+        const exec = jest.fn(async () => ({ content: [{ type: 'text' as const, text: 'ran' }] }));
+        const r = await makeRouter(exec).executeTool('Python REPL::run_code', {}, { userId: 'g', role: 'guest' });
+        expect(r.isError).toBe(true);
+        expect(exec).not.toHaveBeenCalled();
+    });
+
+    it('admin 은 실행', async () => {
+        const exec = jest.fn(async () => ({ content: [{ type: 'text' as const, text: 'ran' }] }));
+        const r = await makeRouter(exec).executeTool('Python REPL::run_code', {}, { userId: 'a', role: 'admin' });
+        expect(r.isError).toBeFalsy();
+        expect(exec).toHaveBeenCalledTimes(1);
+    });
+
+    it('제한 목록이 비면 user 도 실행', async () => {
+        process.env.MCP_RESTRICTED_SERVERS = '';
+        const exec = jest.fn(async () => ({ content: [{ type: 'text' as const, text: 'ran' }] }));
+        const r = await makeRouter(exec).executeTool('Python REPL::run_code', {}, { userId: 'u1', role: 'user' });
+        expect(r.isError).toBeFalsy();
+        expect(exec).toHaveBeenCalledTimes(1);
+    });
+
+    it('노출 필터와 같은 정책을 본다', () => {
+        const tools = [{ type: 'function' as const, function: { name: 'Python REPL::run_code', description: '', parameters: { type: 'object' as const, properties: {} } } }];
+        expect(filterRestrictedTools(tools, 'user')).toHaveLength(0);
+        expect(filterRestrictedTools(tools, 'admin')).toHaveLength(1);
+    });
+});

--- a/apps/api/src/mcp/extension-ingest-tool.ts
+++ b/apps/api/src/mcp/extension-ingest-tool.ts
@@ -88,7 +88,11 @@ export const importExtensionFromGitTool: MCPToolDefinition<ImportExtensionFromGi
                 pool: getUnifiedDatabase().getPool(),
                 llmClientFactory: (model: string) => new LLMClient(model ? { model } : {}),
                 fetcherFactory: (opts) => new GitFetcher({ accessToken: opts.accessToken, timeoutMs: SKILL_CREATOR.gitFetchTimeout }),
-                internalBundleLoader: (id) => new MarketplaceBundleRepository(getPool()).load(id),
+                // 내부 번들은 요청자 스코프(본인 소유 또는 shared 게시분)로만 — 무스코프 load 는 IDOR (B9-01)
+                internalBundleLoader: (id) => {
+                    const repo = new MarketplaceBundleRepository(getPool());
+                    return isAdmin ? repo.load(id) : repo.loadForUser(id, userId);
+                },
             });
 
             const result = await service.import({

--- a/apps/api/src/mcp/sandbox-docker.ts
+++ b/apps/api/src/mcp/sandbox-docker.ts
@@ -47,7 +47,11 @@ export interface SandboxResult {
     sandboxed: boolean;
     /**
      * sandboxed=true 일 때 docker 프로세스에 넘길 env — 컨테이너는 `-e KEY`(이름만) 로
-     * 여기서 값을 상속받는다. 값이 인자에 없으므로 `ps` 에 비밀이 노출되지 않는다.
+     * 여기서 값을 상속받는다. env 값은 인자에 없으므로 `ps` 에 노출되지 않는다.
+     * ⚠️ 예외: 서버 config 가 `{{env.KEY}}` 를 command/args 에 치환해 쓰면(lifecycle-supervisor
+     * substituteEnvPlaceholders — 카탈로그 server-postgres 템플릿의 DATABASE_URL 위치 인자) 그 값은
+     * `docker run` argv 에 실려 같은 호스트의 다른 로컬 계정이 볼 수 있다(2026-09-02 보안 리뷰 B5-01).
+     * 위치 인자로만 비밀을 받는 서버에 한정된, 문서화된 트레이드오프.
      */
     env?: Record<string, string>;
 }

--- a/apps/api/src/mcp/tool-role-gate.ts
+++ b/apps/api/src/mcp/tool-role-gate.ts
@@ -1,0 +1,45 @@
+/**
+ * 고위험 MCP 서버 도구의 역할 게이트 — 노출(filterRestrictedTools)과 실행(ToolRouter.executeTool)
+ * 이 같은 정책을 본다. env `MCP_RESTRICTED_SERVERS`("서버명:역할,..") 로 외부화.
+ *
+ * 기본: Python REPL(임의코드)=admin, Playwright Browser=user. (open registration 이라
+ * authenticated 는 약해 arbitrary code 는 admin 기본.)
+ *
+ * 2026-09-02 보안 리뷰 B7-01: 종전엔 노출 시점에만 걸러 프롬프트 인젝션·REST 직접 호출로
+ * 이름을 지목하면 실행됐다. 서킷 차단과 같은 2차 방어를 실행 진입점에 둔다.
+ */
+import { isAdminRole } from '../data/user-manager';
+import { MCP_NAMESPACE_SEPARATOR } from './types';
+
+export const DEFAULT_RESTRICTED_SERVERS = 'Python REPL:admin,Playwright Browser:user';
+
+/** 역할 레벨 (게스트<일반<관리자). */
+export function roleLevel(role?: string): number {
+    return isAdminRole(role) ? 2 : role === 'user' ? 1 : 0;
+}
+
+/** 고위험 MCP 서버별 최소 역할 파싱. */
+export function parseRestrictedServers(): Map<string, number> {
+    const raw = process.env.MCP_RESTRICTED_SERVERS ?? DEFAULT_RESTRICTED_SERVERS;
+    const m = new Map<string, number>();
+    for (const part of raw.split(',')) {
+        const idx = part.lastIndexOf(':');
+        if (idx <= 0) continue;
+        const name = part.slice(0, idx).trim();
+        const role = part.slice(idx + 1).trim();
+        if (name) m.set(name, roleLevel(role));
+    }
+    return m;
+}
+
+/** 네임스페이스 도구 이름("서버명::도구")이 역할 미달로 제한되면 true. */
+export function isToolRestrictedForRole(toolName: string, role?: string): boolean {
+    if (!toolName.includes(MCP_NAMESPACE_SEPARATOR)) return false;
+    const restricted = parseRestrictedServers();
+    if (restricted.size === 0) return false;
+    const userLevel = roleLevel(role);
+    for (const [serverName, minLevel] of restricted) {
+        if (toolName.startsWith(`${serverName}${MCP_NAMESPACE_SEPARATOR}`) && userLevel < minLevel) return true;
+    }
+    return false;
+}

--- a/apps/api/src/mcp/tool-router.ts
+++ b/apps/api/src/mcp/tool-router.ts
@@ -29,6 +29,7 @@
  */
 
 import type { MCPTool, MCPToolResult, ExternalToolEntry } from './types';
+import { isToolRestrictedForRole } from './tool-role-gate';
 import { MCP_NAMESPACE_SEPARATOR } from './types';
 import type { MCPToolDefinition } from './types';
 import { builtInTools } from './tools';
@@ -275,6 +276,13 @@ export class ToolRouter {
                     `도구 "${name}" 은 반복 실패로 일시 비활성화되었습니다. 잠시 후 자동으로 재시도되며, 지금은 다른 도구나 방법을 사용하세요.`,
                     { record: false },
                 );
+            }
+
+            // 역할 게이트 2차 방어 — 노출 필터(filterRestrictedTools)에서 빠진 고위험 서버 도구를
+            // 프롬프트 인젝션·REST 직접 호출로 지목해도 실행하지 않는다(B7-01). context 없는
+            // 호출은 서버 내부 신뢰 경계라 종전대로 통과.
+            if (context && isToolRestrictedForRole(name, context.role)) {
+                return fail(`도구 "${name}" 은 현재 역할(${context.role})로 실행할 수 없습니다.`, { record: false });
             }
 
             // 외부 도구 출력 크기 제한(MAX_OUTPUT_SIZE, 1MB) — user-pool(1a)·전역(1b) 두 경로 공통.

--- a/apps/api/src/services/chat-service/tool-restrictions.ts
+++ b/apps/api/src/services/chat-service/tool-restrictions.ts
@@ -2,48 +2,17 @@
  * 고위험 MCP 서버 도구 역할 게이팅 — ChatService 에서 분리 (파일 크기 가드).
  *
  * 외부 공개 인스턴스에서 게스트·저권한 사용자에게 위험 도구(임의 코드 실행 등)가
- * 과노출되는 것을 차단한다. env `MCP_RESTRICTED_SERVERS`("서버명:역할,..")로 정책 외부화.
+ * 과노출되는 것을 차단한다. 정책·판정은 mcp/tool-role-gate 가 SoT(실행 경로와 공용).
  *
  * @module services/chat-service/tool-restrictions
  */
 import { type ToolDefinition } from '../../llm';
-import { isAdminRole } from '../../data/user-manager';
-
-/** 역할 레벨 (게스트<일반<관리자). */
-function roleLevel(role?: string): number {
-    return isAdminRole(role) ? 2 : role === 'user' ? 1 : 0;
-}
-
-/**
- * 고위험 MCP 서버별 최소 역할 파싱 — env `MCP_RESTRICTED_SERVERS` ("서버명:역할,..").
- * 기본: Python REPL(임의코드)=admin, Playwright Browser=user. (open registration 이라
- * authenticated 는 약해 arbitrary code 는 admin 기본.)
- */
-function parseRestrictedServers(): Map<string, number> {
-    const raw = process.env.MCP_RESTRICTED_SERVERS ?? 'Python REPL:admin,Playwright Browser:user';
-    const m = new Map<string, number>();
-    for (const part of raw.split(',')) {
-        const idx = part.lastIndexOf(':');
-        if (idx <= 0) continue;
-        const name = part.slice(0, idx).trim();
-        const role = part.slice(idx + 1).trim();
-        if (name) m.set(name, roleLevel(role));
-    }
-    return m;
-}
+import { isToolRestrictedForRole } from '../../mcp/tool-role-gate';
 
 /**
  * 고위험 서버 도구(네임스페이스 "서버명::도구")를 역할 미달 사용자에게서 제거.
  * 외부 공개 인스턴스에서 게스트·저권한 사용자의 위험도구 과노출 차단.
  */
 export function filterRestrictedTools(tools: ToolDefinition[], role?: string): ToolDefinition[] {
-    const restricted = parseRestrictedServers();
-    if (restricted.size === 0) return tools;
-    const userLevel = roleLevel(role);
-    return tools.filter((t) => {
-        for (const [serverName, minLevel] of restricted) {
-            if (t.function.name.startsWith(`${serverName}::`) && userLevel < minLevel) return false;
-        }
-        return true;
-    });
+    return tools.filter((t) => !isToolRestrictedForRole(t.function.name, role));
 }


### PR DESCRIPTION
## 배경
2026-09-02 apps/api 보안 리뷰 P1(B5 mcp · B6 샌드박스 · B7 services · B8 data · B9 agents) 확정 finding. B6·B8 은 0건. 리포트: private docs `ops/reports/2026-09-02-api-security-review-p1.md`.

## 수정
- **B9-01 (medium, IDOR)** — 채팅 도구 `import_extension_from_git` 가 `internal://bundle/<id>` 를 소유자·공개 여부 검사 없이 설치했다. `MarketplaceBundleRepository.loadForUser(id, userId)`(본인 소유 또는 shared·active 게시분) 를 두고 도구 경로는 비관리자에게 이를 쓴다. 컨트롤러 갤러리 설치·update-check 에도 대칭 적용.
- **B7-01 (medium, 역할 게이트 우회)** — `MCP_RESTRICTED_SERVERS` 가 노출 시점에만 걸려 프롬프트 인젝션·`POST /api/mcp/tools/:name/execute` 로 이름을 지목하면 역할 미달 사용자도 실행됐다. `mcp/tool-role-gate.ts` 를 정책 SoT 로 분리하고 `ToolRouter.executeTool` 진입에서 거절(서킷 차단과 같은 2차 방어, 실패로 세지 않음).
- **B5-01 (low)** — 샌드박스 "ps 미노출" 주석에 `{{env.KEY}}` 위치 인자 치환 예외(카탈로그 postgres MCP 의 DATABASE_URL)를 명시. 동작 변경 없음.

## 검증
- `loadForUser` 3건, 역할 게이트 5건(user/guest 거절+실행 0회, admin 실행, 빈 목록 통과, 노출 필터 동일 정책). **되돌리면 실패 확인**. 관련 suites 전부 통과, `tsc` 0, eslint 0.

## 영향 범위
- shared 번들·본인 번들 설치 무변경. 타인 private 번들 id 로의 도구 설치만 실패.
- 관리자·역할 충족 사용자의 도구 실행 무변경. Python REPL 을 비관리자가 직접 호출하던 경로만 거절(노출 필터와 일치).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1P3hSryADjr6uvGXzYZpa
