### PR TITLE
feat(providers): B.AI 외부 provider 추가 — 무료 모델 5종 BYOK

### DIFF
--- a/apps/api/src/config/external-providers.ts
+++ b/apps/api/src/config/external-providers.ts
@@ -199,6 +199,32 @@ export const EXTERNAL_PROVIDER_CATALOG: ReadonlyArray<ExternalProviderCatalogEnt
             { id: 'qwen2.5-vl-72b',       displayName: 'Qwen2.5 VL 72B',       isFree: true, capabilities: { streaming: true, toolCalling: false, vision: true,  thinking: false } },
         ],
     },
+    {
+        id: 'bai',
+        displayName: 'B.AI',
+        sdkType: 'openai-compatible',
+        defaultBaseUrl: 'https://api.b.ai/v1',
+        keyPrefixPattern: 'sk-',
+        validatePath: '/models',
+        enabled: true,
+        sortOrder: 70,
+        helpText:
+            'B.AI (https://docs.b.ai/llmservice/api/) 의 API 키(sk-*)를 입력하세요. OpenAI 호환 API 로 ' +
+            'GPT·Claude·Gemini·DeepSeek·Qwen·GLM 등을 크레딧 과금으로 제공합니다. ' +
+            '아래 목록은 2026-09-02 실측 기준 크레딧 잔액 0 인 키로도 호출되는 무료 모델만 수록했습니다 — ' +
+            '그 외 모델은 예치(deposit)·크레딧이 필요해 403/400 이 납니다. 모델 ID 는 "qwen3.8-flash" 처럼 접두사 없는 형식입니다. ' +
+            '연속 호출 시 429 가 잦으니 병렬 사용은 피하세요.',
+        authMethods: ['api_key'] as const,
+        // 2026-09-02 실측(무료 키·잔액 0): 45개 중 5개만 200. tools 는 5개 전부, vision 은 qwen3.8-flash·
+        // glm-5.3-flash·deepseek-v4-flash-vision-exp 만(32px 이상 이미지), 5개 전부 reasoning_content 반환.
+        fallbackModels: [
+            { id: 'qwen3.8-flash',                displayName: 'Qwen3.8 Flash',                 isFree: true, capabilities: { streaming: true, toolCalling: true, vision: true,  thinking: true } },
+            { id: 'glm-5.3-flash',                displayName: 'GLM 5.3 Flash',                 isFree: true, capabilities: { streaming: true, toolCalling: true, vision: true,  thinking: true } },
+            { id: 'deepseek-v4-flash',            displayName: 'DeepSeek V4 Flash',             isFree: true, capabilities: { streaming: true, toolCalling: true, vision: false, thinking: true } },
+            { id: 'deepseek-v4-flash-vision-exp', displayName: 'DeepSeek V4 Flash Vision (exp)', isFree: true, capabilities: { streaming: true, toolCalling: true, vision: true,  thinking: true } },
+            { id: 'hy3',                          displayName: 'Hunyuan 3',                     isFree: true, capabilities: { streaming: true, toolCalling: true, vision: false, thinking: true } },
+        ],
+    },
 ] as const;
 
 /**

--- a/apps/api/src/services/chat-service/provider-gate.ts
+++ b/apps/api/src/services/chat-service/provider-gate.ts
@@ -43,6 +43,7 @@ const KNOWN_FULLID_PREFIXES: readonly string[] = [
     'ollama-cloud',
     'nvidia',
     'hasa',
+    'bai',
 ];
 
 export interface ProviderGateInput {

--- a/apps/web/components/model-picker.tsx
+++ b/apps/web/components/model-picker.tsx
@@ -27,6 +27,7 @@ const EXTERNAL_PROVIDER_LABELS: Record<string, string> = {
   "ollama-cloud": "🌐 Ollama Cloud",
   nvidia: "🌐 NVIDIA NIM",
   hasa: "🌐 Open AI Service Hub",
+  bai: "🌐 B.AI",
 };
 
 export function ModelPicker({


### PR DESCRIPTION
## 배경
https://docs.b.ai/llmservice/api/ 전수 검토 + 라이브 실측(2026-09-02). OpenAI 호환 API(`https://api.b.ai/v1`), Bearer/x-api-key 인증, 크레딧 선불제(1 USD = 1M credits, 문서에 무료 티어 명시 없음).

## 실측 (잔액 0 인 키로 45개 모델 전부 호출)
| 결과 | 모델 |
|---|---|
| 200 (무료) | qwen3.8-flash · glm-5.3-flash · deepseek-v4-flash · deepseek-v4-flash-vision-exp · hy3 |
| 400 insufficient balance | qwen3.8-27b · hy4-preview · mimo-v2.5-pro |
| 403 Deposit required (premium) | GPT-5.x 전부 · Claude 전부 · Gemini 전부 · Kimi · qwen3.8-max · deepseek-v4-pro · glm-5.1/5.2/5.3 · minimax-m3 (27) |
| 503 no channel | mimo-v2.5 |

무료 5종 기능: tools 5/5 · 스트리밍 · vision 은 qwen3.8-flash·glm-5.3-flash·vision-exp(32px 이상) · 5종 전부 `reasoning_content`(thinking). 연속 호출 시 429 잦음.

## 변경
hasa(#701)와 동일한 3파일 패턴 — `external-providers.ts` 카탈로그(`bai`, 무료 5종만 isFree) · `provider-gate.ts` `KNOWN_FULLID_PREFIXES` · `model-picker.tsx` 라벨. LiteLLM 게이트웨이 편입 없이 direct(`createPinnedFetch`) 경로. 키는 코드·env 에 넣지 않고 사용자 BYOK(암호화 저장)로 등록.

## 검증
`tsc` api/web 0, eslint 0, providers·models-contract 관련 9 suites 32건 통과. 배포 후 user 3 BYOK 등록 + WS 채팅 스모크 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019162wSrWoUVHw99eAcctri
