### PR TITLE
fix(providers): 휴리스틱 추정 capability 캐시가 config 실측값을 가리지 않게

### DIFF
--- a/apps/api/src/providers/i-provider.ts
+++ b/apps/api/src/providers/i-provider.ts
@@ -60,6 +60,14 @@ export interface ProviderModel {
     outputLimit: number;
     /** 모델별 지원 능력 */
     capabilities: ProviderCapabilities;
+    /**
+     * capabilities 가 provider 응답이 아니라 모델 ID 휴리스틱(inferCapabilitiesFromModelId)으로
+     * 추정된 값이면 true. 라이브 카탈로그 캐시에 함께 저장되어, 실행 시 capability 해석이
+     * 추정값을 "provider 가 보고한 값"으로 오신뢰하지 않게 한다(2026-09-03 B.AI 실측 —
+     * 추정 vision/thinking=false 가 config 실측값을 가려 이미지 요청 거절·추론 비활성).
+     * undefined 는 레거시 캐시 행 — 추정으로 간주한다.
+     */
+    capabilitiesInferred?: boolean;
     /** 1M 토큰당 USD 단가 (선택, cloud provider 전용) */
     pricing?: { input: number; output: number };
     /**

--- a/apps/api/src/providers/openai-compat-provider.ts
+++ b/apps/api/src/providers/openai-compat-provider.ts
@@ -252,6 +252,7 @@ export class OpenAICompatProvider implements IProvider {
                 contextWindow: FALLBACK_CONTEXT_WINDOW_TOKENS,
                 outputLimit: FALLBACK_OUTPUT_LIMIT_TOKENS,
                 capabilities: inferCapabilitiesFromModelId(this.id, m.id),
+                capabilitiesInferred: true,
             }));
         } catch (err) {
             logger.warn(`OpenAI 호환 모델 목록 조회 실패 (${this.baseUrl}): ${err}`);
@@ -317,6 +318,7 @@ export class OpenAICompatProvider implements IProvider {
                         vision: inputModalities.includes('image'),
                         thinking: hasReasoningParam || m.pricing?.internal_reasoning != null,
                     },
+                    capabilitiesInferred: false,
                     pricing: {
                         input: promptUsd * PER_TOKEN_TO_PER_MILLION,
                         output: completionUsd * PER_TOKEN_TO_PER_MILLION,

--- a/apps/api/src/services/chat-service/__tests__/model-capabilities.test.ts
+++ b/apps/api/src/services/chat-service/__tests__/model-capabilities.test.ts
@@ -43,13 +43,41 @@ describe('resolveModelCapabilities', () => {
         expect(r.caps).toEqual(HEURISTIC);
     });
 
-    it('라이브 카탈로그 캐시가 있으면 최우선 채택한다 (source=catalog)', async () => {
+    it('provider 가 보고한 라이브 카탈로그 캐시는 최우선 채택한다 (source=catalog)', async () => {
         const repo = makeRepo([
-            { id: 'meta/llama-4-maverick', capabilities: { vision: true, toolCalling: true, streaming: true, thinking: false } },
+            { id: 'meta/llama-4-maverick', capabilitiesInferred: false, capabilities: { vision: true, toolCalling: true, streaming: true, thinking: false } },
         ]);
         const r = await resolveModelCapabilities(makeResolved('nvidia', 'meta/llama-4-maverick'), 'u1', repo);
         expect(r.source).toBe('catalog');
         expect(r.caps.vision).toBe(true); // 휴리스틱은 false 였음
+    });
+
+    it('휴리스틱 추정 캐시(capabilitiesInferred=true)는 config 실측값을 가리지 못한다 (2026-09-03 B.AI)', async () => {
+        // B.AI /models 는 capability 를 안 주므로 listModels 가 휴리스틱(vision/thinking=false)으로 채워 캐시한다.
+        const repo = makeRepo([
+            { id: 'qwen3.8-flash', capabilitiesInferred: true, capabilities: { vision: false, toolCalling: true, streaming: true, thinking: false } },
+        ]);
+        const r = await resolveModelCapabilities(makeResolved('bai', 'qwen3.8-flash'), 'u1', repo);
+        expect(r.source).toBe('config');
+        expect(r.caps.vision).toBe(true);
+        expect(r.caps.thinking).toBe(true);
+    });
+
+    it('레거시 캐시 행(capabilitiesInferred 없음)도 추정으로 간주해 config 를 우선한다', async () => {
+        const repo = makeRepo([
+            { id: 'qwen3.8-flash', capabilities: { vision: false, toolCalling: true, streaming: true, thinking: false } },
+        ]);
+        const r = await resolveModelCapabilities(makeResolved('bai', 'qwen3.8-flash'), 'u1', repo);
+        expect(r.source).toBe('config');
+        expect(r.caps.vision).toBe(true);
+    });
+
+    it('추정 캐시 + config 미등록 모델은 휴리스틱으로 수렴한다', async () => {
+        const repo = makeRepo([
+            { id: 'unknown-model-x', capabilitiesInferred: true, capabilities: { vision: false, toolCalling: true, streaming: true, thinking: false } },
+        ]);
+        const r = await resolveModelCapabilities(makeResolved('bai', 'unknown-model-x'), 'u1', repo);
+        expect(r.source).toBe('heuristic');
     });
 
     it('캐시 미스면 config 카탈로그(fallbackModels)를 쓴다 (source=config)', async () => {

--- a/apps/api/src/services/chat-service/model-capabilities.ts
+++ b/apps/api/src/services/chat-service/model-capabilities.ts
@@ -47,6 +47,8 @@ type CachedModelEntry = {
     id?: string;
     fullId?: string;
     capabilities?: Partial<ProviderCapabilities>;
+    /** listModels 가 휴리스틱으로 채운 값이면 true (undefined = 레거시 행, 추정으로 간주) */
+    capabilitiesInferred?: boolean;
 };
 
 function fromPartial(
@@ -77,7 +79,10 @@ export async function resolveModelCapabilities(
         return { caps: heuristic, source: 'local' };
     }
 
-    // ② 사용자별 라이브 카탈로그 캐시 (provider API 응답 기반 — 가장 정확)
+    // ② 사용자별 라이브 카탈로그 캐시 — provider 가 **보고한** capability 만 신뢰한다.
+    //    listModels 가 모델 ID 휴리스틱으로 채운 값(capabilitiesInferred, 레거시 행은 undefined)은
+    //    ③ config 실측값보다 못하므로 건너뛴다. (종전엔 추정값이 'catalog' 로 승격돼 B.AI
+    //    qwen3.8-flash 의 vision/thinking 실측 true 를 가렸다 — 2026-09-03)
     if (userId && repo) {
         try {
             const cached = (await repo.getCachedModels(
@@ -86,7 +91,7 @@ export async function resolveModelCapabilities(
             const hit = cached?.find(
                 (m) => m.id === resolved.modelId || m.fullId === resolved.fullId,
             );
-            if (hit?.capabilities) {
+            if (hit?.capabilities && hit.capabilitiesInferred === false) {
                 return { caps: fromPartial(hit.capabilities, heuristic), source: 'catalog' };
             }
         } catch (e) {
@@ -94,7 +99,7 @@ export async function resolveModelCapabilities(
         }
     }
 
-    // ③ 운영자 큐레이션 카탈로그 (config)
+    // ③ 운영자 큐레이션 카탈로그 (config — 실측 기반)
     const entry = getProviderCatalogEntry(resolved.providerId);
     const known = entry?.fallbackModels?.find((m) => m.id === resolved.modelId);
     if (known?.capabilities) {


### PR DESCRIPTION
## 배경
2026-09-03 B.AI `qwen3.8-flash` 를 chat.openmake.cc 에서 Playwright 로 라이브 점검하다 발견.
- 이미지 첨부 → `Model 'bai:qwen3.8-flash' does not support vision input (capabilities.vision=false, source=catalog)` 로 턴 실패
- Thinking ON → `thinking 미지원(capabilities.thinking=false, source=catalog)` 로 추론 없이 처리

실제 모델은 둘 다 지원(실측)하고 config 카탈로그에도 true 로 등록돼 있다.

## 원인
`openai-compat-provider.listModels` 가 `/models` 응답(capability 정보 없음)에 모델 ID 휴리스틱으로 capabilities 를 채워 `external_provider_models_cache` 에 저장하고, `resolveModelCapabilities` 가 그 캐시를 "provider 가 보고한 값"으로 최우선 채택해 config(③)에 닿지 못했다. hasa·nvidia 등 `/models` 에 capability 가 없는 모든 provider 에 같은 문제가 있다(openrouter 만 실보고).

## 수정
- `ProviderModel.capabilitiesInferred` — 휴리스틱 경로 `true`, openrouter 실보고 `false`. 캐시 JSON 에 그대로 실린다.
- `resolveModelCapabilities` ② 는 `capabilitiesInferred === false` 인 행만 채택. 추정·레거시(undefined) 행은 ③ config → 휴리스틱. 운영의 기존 캐시 행은 플래그가 없어 배포 즉시 config 가 우선된다.

## 검증
- 테스트 4건 추가(추정 캐시+config → config, 레거시 행 → config, 추정+미등록 → heuristic, 실보고 → catalog), 기존 케이스 1건은 실보고 플래그 명시로 갱신. 6 suites 70건 통과, `tsc` 0, eslint 0(기존 경고만).
- 배포 후 라이브: 같은 이미지 첨부·Thinking 턴 재실행 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019162wSrWoUVHw99eAcctri
