### PR TITLE
fix(mcp): {{env.KEY}} 위치 인자 비밀을 argv 에 박지 않고 sh 변수 참조로 전달

### DIFF
--- a/apps/api/src/mcp/__tests__/env-placeholder-shell.test.ts
+++ b/apps/api/src/mcp/__tests__/env-placeholder-shell.test.ts
@@ -1,0 +1,33 @@
+/** {{env.KEY}} 위치 인자 비밀 → sh 변수 참조 (2026-09-02 보안 리뷰 B5-01) */
+import { wrapEnvPlaceholdersAsShellRefs } from '../env-placeholder-shell';
+import { execFileSync } from 'child_process';
+
+describe('wrapEnvPlaceholdersAsShellRefs', () => {
+    it('자리표시자가 없으면 원본 그대로 (wrapped=false)', () => {
+        const r = wrapEnvPlaceholdersAsShellRefs('npx', ['-y', 'pkg', '--flag']);
+        expect(r).toEqual({ command: 'npx', args: ['-y', 'pkg', '--flag'], wrapped: false, keys: [] });
+    });
+
+    it('카탈로그 server-postgres 템플릿 — 값 대신 "$DATABASE_URL" 참조, 나머지는 positional', () => {
+        const r = wrapEnvPlaceholdersAsShellRefs('npx', ['-y', '@modelcontextprotocol/server-postgres', '{{env.DATABASE_URL}}']);
+        expect(r.wrapped).toBe(true);
+        expect(r.keys).toEqual(['DATABASE_URL']);
+        expect(r.command).toBe('sh');
+        expect(r.args).toEqual(['-c', 'exec "$1" "$2" "$3" "$DATABASE_URL"', 'sh', 'npx', '-y', '@modelcontextprotocol/server-postgres']);
+        // argv 어디에도 비밀 값이 들어갈 자리가 없다
+        expect(r.args.join(' ')).not.toContain('postgres://');
+    });
+
+    it('리터럴과 자리표시자가 섞인 토큰은 작은따옴표 리터럴 + "$KEY" 로 이어 붙인다 (따옴표 이스케이프 포함)', () => {
+        const r = wrapEnvPlaceholdersAsShellRefs('cmd', ["postgres://u:{{env.PW}}@h/db?o='x'", '{{env.A}}{{env.B}}']);
+        expect(r.args[1]).toBe(`exec "$1" 'postgres://u:'"$PW"'@h/db?o='\\''x'\\''' "$A""$B"`);
+        expect(r.keys).toEqual(['PW', 'A', 'B']);
+    });
+
+    it('실제 sh 로 전개하면 env 값이 인자에 정확히 들어간다 (argv 엔 참조만)', () => {
+        const r = wrapEnvPlaceholdersAsShellRefs('printf', ['%s|%s|%s\\n', 'plain arg', "pre-{{env.SECRET}}-post'q", '{{env.SECRET}}']);
+        const out = execFileSync(r.command, r.args, { env: { PATH: process.env.PATH ?? '/usr/bin:/bin', SECRET: 's3cr3t value' }, encoding: 'utf8' });
+        expect(out.trim()).toBe("plain arg|pre-s3cr3t value-post'q|s3cr3t value");
+        expect(r.args.some((a) => a.includes('s3cr3t'))).toBe(false);
+    });
+});

--- a/apps/api/src/mcp/env-placeholder-shell.ts
+++ b/apps/api/src/mcp/env-placeholder-shell.ts
@@ -1,0 +1,67 @@
+/**
+ * `{{env.KEY}}` 자리표시자를 값으로 치환하지 않고 **셸 변수 참조**로 바꿔 spawn 한다.
+ *
+ * 종전(lifecycle-supervisor.substituteEnvPlaceholders)엔 복호화된 비밀이 command/args 에
+ * 그대로 들어가 `docker run … <값>` / `npx … <값>` argv 로 실려, 같은 호스트의 다른 로컬 계정이
+ * `ps` 로 읽을 수 있었다(2026-09-02 보안 리뷰 B5-01 — 카탈로그 server-postgres 의
+ * `{{env.DATABASE_URL}}` 위치 인자). 값은 이미 env(-e KEY / StdioClientTransport env)로
+ * 프로세스에 도달하므로 argv 엔 `"$KEY"` 참조만 싣고 sh 가 실행 직전에 전개하게 한다.
+ *
+ * 변환 규칙(결정적·인용 안전):
+ *   command/args 에 자리표시자가 하나도 없으면 원본 그대로.
+ *   있으면 command='sh', args=['-c', <script>, 'sh', ...positional]
+ *   - 자리표시자가 없는 토큰은 positional 로 넘기고 script 에서 "$N" 으로 참조(인용 문제 없음)
+ *   - 자리표시자가 있는 토큰은 리터럴 조각을 작은따옴표로, `{{env.KEY}}` 를 "$KEY" 로 이어 붙인다
+ *   - script 는 `exec <cmd> <args...>` — 컨테이너/호스트 모두 sh 가 있다(node·uv 런타임 이미지 포함)
+ */
+export const ENV_PLACEHOLDER_RE = /\{\{env\.(\w+)\}\}/g;
+
+export interface ShellWrapped {
+    command: string;
+    args: string[];
+    /** 자리표시자가 있어 sh 로 감쌌는지 */
+    wrapped: boolean;
+    /** 참조된 env 키 (호출측이 env 에 실렸는지 확인·로그용) */
+    keys: string[];
+}
+
+function shellQuoteLiteral(s: string): string {
+    return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/** 토큰 하나를 셸 표현식으로 — 리터럴은 작은따옴표, 자리표시자는 "$KEY" */
+function tokenToShellExpr(token: string, keys: Set<string>): string {
+    let out = '';
+    let last = 0;
+    // ⚠️ 전역 regex 는 lastIndex 상태를 가지므로 매번 새 인스턴스로 순회한다
+    for (const m of token.matchAll(new RegExp(ENV_PLACEHOLDER_RE.source, 'g'))) {
+        const idx = m.index ?? 0;
+        if (idx > last) out += shellQuoteLiteral(token.slice(last, idx));
+        out += `"$${m[1]}"`;
+        keys.add(m[1]);
+        last = idx + m[0].length;
+    }
+    if (last < token.length) out += shellQuoteLiteral(token.slice(last));
+    return out || "''";
+}
+
+export function wrapEnvPlaceholdersAsShellRefs(command: string, args: readonly unknown[]): ShellWrapped {
+    const strArgs = args.map((a) => String(a));
+    const hasPlaceholder = (s: string) => new RegExp(ENV_PLACEHOLDER_RE.source).test(s);
+    if (!hasPlaceholder(command) && !strArgs.some(hasPlaceholder)) {
+        return { command, args: strArgs, wrapped: false, keys: [] };
+    }
+    const keys = new Set<string>();
+    const positional: string[] = [];
+    const parts: string[] = [];
+    for (const token of [command, ...strArgs]) {
+        if (hasPlaceholder(token)) {
+            parts.push(tokenToShellExpr(token, keys));
+        } else {
+            positional.push(token);
+            parts.push(`"$${positional.length}"`);
+        }
+    }
+    const script = `exec ${parts.join(' ')}`;
+    return { command: 'sh', args: ['-c', script, 'sh', ...positional], wrapped: true, keys: [...keys] };
+}

--- a/apps/api/src/mcp/lifecycle-supervisor.ts
+++ b/apps/api/src/mcp/lifecycle-supervisor.ts
@@ -14,6 +14,7 @@
  *
  */
 import type { UserMCPPool } from './user-pool';
+import { wrapEnvPlaceholdersAsShellRefs } from './env-placeholder-shell';
 import type { ExternalMCPClient } from './external-client';
 import type { McpCatalogRepository, UserMcpServerRow } from '../data/repositories/mcp-catalog-repository';
 import { createLogger } from '../utils/logger';
@@ -69,11 +70,6 @@ type ServerWithLifecycle = UserMcpServerRow & { lifecycle?: McpLifecycle };
  * 전달해야 하는 MCP 서버(예: @modelcontextprotocol/server-postgres 는 URL 을 argv 로
  * 받음)를 지원한다 — 평문을 args(미암호화) 에 저장하지 않고 spawn 시점에만 주입.
  */
-const ENV_PLACEHOLDER_RE = /\{\{env\.(\w+)\}\}/g;
-function substituteEnvPlaceholders(value: string, env: Record<string, string>): string {
-    return value.replace(ENV_PLACEHOLDER_RE, (_m, key: string) => env[key] ?? '');
-}
-
 export class MCPLifecycleSupervisor implements LifecycleSupervisor {
     private readonly userPool: UserMCPPool;
     private readonly repo: SupervisorDeps['repo'];
@@ -262,16 +258,22 @@ export class MCPLifecycleSupervisor implements LifecycleSupervisor {
             }
         }
 
+        const shellWrapped = server.command
+            ? wrapEnvPlaceholdersAsShellRefs(server.command, Array.isArray(server.args) ? server.args : [])
+            : { command: server.command, args: server.args, wrapped: false, keys: [] as string[] };
+        if (shellWrapped.wrapped) {
+            const missing = shellWrapped.keys.filter((k) => !(k in env));
+            if (missing.length) logger.warn(`{{env.*}} 참조 키가 env 에 없음 (빈값으로 전개) s=${serverId}: ${missing.join(',')}`);
+        }
         const config: ServerSpawnConfig = {
             id: server.id,
             user_id: userId,
             name: server.name,
             transport_type: server.transport_type,
-            // {{env.KEY}} placeholder 를 복호화 env 로 치환 (위치 인자 secret 주입 지원).
-            command: server.command ? substituteEnvPlaceholders(server.command, env) : server.command,
-            args: Array.isArray(server.args)
-                ? server.args.map(a => typeof a === 'string' ? substituteEnvPlaceholders(a, env) : a)
-                : server.args,
+            // {{env.KEY}} 자리표시자(위치 인자 secret)는 값을 argv 에 박지 않고 sh 변수 참조로 감싼다
+            // (env-placeholder-shell — ps 노출 차단, 2026-09-03). 값은 env 로만 전달.
+            command: shellWrapped.command,
+            args: shellWrapped.args,
             env,
             url: server.url,
             lifecycle,


### PR DESCRIPTION
## 배경
2026-09-02 보안 리뷰 B5-01(low) 후속. `{{env.KEY}}` 자리표시자를 복호화 값으로 치환해 command/args 에 넣으면 `docker run … <값>` / `npx … <값>` argv 로 실려 같은 호스트의 다른 로컬 계정이 `ps` 로 읽을 수 있었다. 실사례: 카탈로그 server-postgres 템플릿의 `{{env.DATABASE_URL}}` 위치 인자(비밀번호 포함 접속 문자열).

## 변경
- `mcp/env-placeholder-shell.ts` `wrapEnvPlaceholdersAsShellRefs(command, args)` — 자리표시자가 있을 때만 `sh -c 'exec "$1" … "$KEY"' sh <positional…>` 로 감싼다. 값은 종전대로 env(`-e KEY` / transport env)로만 전달되고 sh 가 실행 직전에 전개한다. 자리표시자 없는 서버는 원본 그대로.
- `lifecycle-supervisor` 가 `substituteEnvPlaceholders` 대신 이를 사용. 참조 키가 env 에 없으면 경고 로그.
- sandbox-docker 의 주석(#710 에서 "예외" 명시)은 이제 예외가 아니게 됨 — 이 PR 에선 주석 그대로 두고 배포 검증 후 정리.

## 검증
- 테스트 4건: 무변환 / postgres 템플릿 argv 에 값 자리 없음 / 혼합 토큰(`'` 이스케이프) / **실제 `sh` 실행**으로 env 값이 인자에 정확히 전개되고 argv 엔 참조만 남음. mcp lifecycle·sandbox 관련 3 suites 21건 통과, `tsc` 0, eslint 0.
- 배포 후: postgres MCP 재spawn 시 `ps` 에 DATABASE_URL 값 미노출 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019162wSrWoUVHw99eAcctri
