### PR TITLE
fix(security): 보안 리뷰 후속 3건 — REST images 상한·push 호스트 허용목록·user-sandbox realpath

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1449,6 +1449,10 @@ VAPID_PUBLIC_KEY=
 VAPID_PRIVATE_KEY=
 VAPID_SUBJECT=mailto:admin@openmake.ai
 
+# Web Push 구독 endpoint 호스트 허용목록(suffix, 콤마) — 기본: fcm.googleapis.com, android.googleapis.com,
+# push.services.mozilla.com, notify.windows.com, push.apple.com. `*` 면 허용목록 비활성(https·SSRF 가드만).
+# PUSH_ENDPOINT_HOST_ALLOWLIST=
+
 # iOS APNs — Apple Developer Program의 Push Notifications capability와 .p8 키 필요
 # 개인 개발 팀에서는 비워 두면 웹 푸시만 동작하며, iOS 앱은 로컬 완료 알림을 사용합니다.
 APNS_KEY_ID=

--- a/apps/api/src/config/__tests__/push-endpoint-hosts.test.ts
+++ b/apps/api/src/config/__tests__/push-endpoint-hosts.test.ts
@@ -1,0 +1,28 @@
+/** push endpoint 호스트 허용목록 (2026-09-02 보안 리뷰 B7-02 후속) */
+import { isPushEndpointHostAllowed, getPushEndpointHostAllowlist, DEFAULT_PUSH_ENDPOINT_HOSTS } from '../push-endpoint-hosts';
+
+const ORIG = process.env.PUSH_ENDPOINT_HOST_ALLOWLIST;
+afterEach(() => { if (ORIG === undefined) delete process.env.PUSH_ENDPOINT_HOST_ALLOWLIST; else process.env.PUSH_ENDPOINT_HOST_ALLOWLIST = ORIG; });
+
+describe('isPushEndpointHostAllowed', () => {
+    it.each(['fcm.googleapis.com', 'updates.push.services.mozilla.com', 'wns2-by3p.notify.windows.com', 'web.push.apple.com'])('기본 허용목록: %s 통과', (h) => {
+        delete process.env.PUSH_ENDPOINT_HOST_ALLOWLIST;
+        expect(isPushEndpointHostAllowed(h)).toBe(true);
+    });
+    it('기본 허용목록 밖(공격자 도메인·유사 접두)은 거부', () => {
+        delete process.env.PUSH_ENDPOINT_HOST_ALLOWLIST;
+        expect(isPushEndpointHostAllowed('evil.example')).toBe(false);
+        expect(isPushEndpointHostAllowed('fcm.googleapis.com.evil.example')).toBe(false);
+        expect(isPushEndpointHostAllowed('notfcm.googleapis.com')).toBe(false);
+    });
+    it('env 로 교체·비활성(*) 가능', () => {
+        process.env.PUSH_ENDPOINT_HOST_ALLOWLIST = 'push.corp.internal, Other.Example';
+        expect(getPushEndpointHostAllowlist()).toEqual(['push.corp.internal', 'other.example']);
+        expect(isPushEndpointHostAllowed('a.push.corp.internal')).toBe(true);
+        expect(isPushEndpointHostAllowed('fcm.googleapis.com')).toBe(false);
+        process.env.PUSH_ENDPOINT_HOST_ALLOWLIST = '*';
+        expect(getPushEndpointHostAllowlist()).toBeNull();
+        expect(isPushEndpointHostAllowed('anything.example')).toBe(true);
+    });
+    it('기본 목록은 비어 있지 않다', () => { expect(DEFAULT_PUSH_ENDPOINT_HOSTS.length).toBeGreaterThan(3); });
+});

--- a/apps/api/src/config/push-endpoint-hosts.ts
+++ b/apps/api/src/config/push-endpoint-hosts.ts
@@ -1,0 +1,30 @@
+/**
+ * Web Push 구독 endpoint 호스트 허용목록 (L2, env override).
+ *
+ * 등록 시 SSRF 가드(사설/loopback 차단)만으로는 발송 시점 DNS rebinding 창이 남는다
+ * (web-push 라이브러리 내부 fetch 라 pinned fetch 불가 — 2026-09-02 보안 리뷰 B7-02).
+ * 브라우저 push 서비스는 소수의 알려진 호스트뿐이므로 suffix 허용목록으로 표면을 좁힌다.
+ *
+ * env `PUSH_ENDPOINT_HOST_ALLOWLIST`: 콤마 구분 호스트 suffix. `*` 는 허용목록 비활성(모든 https 허용).
+ */
+export const DEFAULT_PUSH_ENDPOINT_HOSTS: readonly string[] = [
+    'fcm.googleapis.com',            // Chrome/Android (FCM)
+    'android.googleapis.com',        // 구 GCM endpoint
+    'push.services.mozilla.com',     // Firefox autopush (updates.push.services.mozilla.com 포함)
+    'notify.windows.com',            // Edge (WNS, wns2-*.notify.windows.com)
+    'push.apple.com',                // Safari (web.push.apple.com)
+];
+
+export function getPushEndpointHostAllowlist(): readonly string[] | null {
+    const raw = process.env.PUSH_ENDPOINT_HOST_ALLOWLIST;
+    if (raw === undefined || raw.trim() === '') return DEFAULT_PUSH_ENDPOINT_HOSTS;
+    if (raw.trim() === '*') return null;
+    return raw.split(',').map((h) => h.trim().toLowerCase()).filter(Boolean);
+}
+
+/** hostname 이 허용목록 항목과 같거나 그 하위 도메인이면 true. 허용목록 비활성(null)이면 항상 true. */
+export function isPushEndpointHostAllowed(hostname: string, allowlist: readonly string[] | null = getPushEndpointHostAllowlist()): boolean {
+    if (allowlist === null) return true;
+    const h = hostname.toLowerCase();
+    return allowlist.some((a) => h === a || h.endsWith(`.${a}`));
+}

--- a/apps/api/src/mcp/__tests__/user-sandbox-realpath.test.ts
+++ b/apps/api/src/mcp/__tests__/user-sandbox-realpath.test.ts
@@ -1,0 +1,35 @@
+/** UserSandbox.validatePath 심링크 탈출 차단 (2026-09-02 보안 리뷰 B5 NV 후속) */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'omk-sandbox-'));
+jest.mock('../../config/env', () => ({ getConfig: () => ({ userDataPath: root }) }));
+
+import { UserSandbox } from '../user-sandbox';
+
+describe('UserSandbox.validatePath realpath', () => {
+    const userRoot = path.join(root, 'u1');
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'omk-outside-'));
+    beforeAll(() => {
+        fs.mkdirSync(path.join(userRoot, 'workspace'), { recursive: true });
+        fs.writeFileSync(path.join(userRoot, 'workspace', 'ok.txt'), 'x');
+        fs.writeFileSync(path.join(outside, 'secret.txt'), 's');
+        fs.symlinkSync(outside, path.join(userRoot, 'workspace', 'escape'));
+    });
+    afterAll(() => { fs.rmSync(root, { recursive: true, force: true }); fs.rmSync(outside, { recursive: true, force: true }); });
+
+    it('루트 안 실재 파일은 허용', () => {
+        expect(UserSandbox.validatePath('u1', path.join(userRoot, 'workspace', 'ok.txt'))).toBe(true);
+    });
+    it('아직 없는 하위 경로도 허용(조상만 검사)', () => {
+        expect(UserSandbox.validatePath('u1', path.join(userRoot, 'workspace', 'new', 'file.txt'))).toBe(true);
+    });
+    it('어휘적으로는 루트 안이지만 심링크가 밖을 가리키면 거부', () => {
+        expect(UserSandbox.validatePath('u1', path.join(userRoot, 'workspace', 'escape', 'secret.txt'))).toBe(false);
+        expect(UserSandbox.validatePath('u1', path.join(userRoot, 'workspace', 'escape'))).toBe(false);
+    });
+    it('어휘적 탈출(..)은 종전대로 거부', () => {
+        expect(UserSandbox.validatePath('u1', path.join(userRoot, '..', 'u2', 'x'))).toBe(false);
+    });
+});

--- a/apps/api/src/mcp/user-sandbox.ts
+++ b/apps/api/src/mcp/user-sandbox.ts
@@ -138,7 +138,39 @@ export class UserSandbox {
             return false;
         }
 
+        // 🔒 심링크 탈출 차단 (2026-09-02 보안 리뷰 B5 NV): 어휘적 검사는 사용자 루트 안의 심링크가
+        // 루트 밖을 가리키는 경우를 못 막는다. 존재하는 가장 깊은 조상의 realpath 가 루트 realpath 안에
+        // 있어야 한다(아직 없는 경로는 조상만 검사 — 생성 자체는 허용). realpath 실패는 거부(fail-closed).
+        if (!this.realPathStaysInside(resolvedPath, userRoot)) {
+            logger.warn(`⚠️ 경로 접근 거부(심링크 탈출): ${resolvedPath} (사용자: ${userId})`);
+            return false;
+        }
+
         return true;
+    }
+
+    /** resolvedPath 의 존재하는 가장 깊은 조상을 realpath 로 풀어 userRoot(realpath) 안에 있는지 */
+    private static realPathStaysInside(resolvedPath: string, userRoot: string): boolean {
+        let rootReal: string;
+        try {
+            rootReal = fs.existsSync(userRoot) ? fs.realpathSync(userRoot) : userRoot;
+        } catch {
+            return false;
+        }
+        let probe = resolvedPath;
+        for (;;) {
+            if (fs.existsSync(probe)) break;
+            const parent = path.dirname(probe);
+            if (parent === probe) return true; // 파일시스템 루트까지 아무것도 없음 — 루트 자체가 미생성
+            probe = parent;
+        }
+        let real: string;
+        try {
+            real = fs.realpathSync(probe);
+        } catch {
+            return false;
+        }
+        return real === rootReal || (real + path.sep).startsWith(rootReal + path.sep);
     }
 
     /**

--- a/apps/api/src/schemas/chat.schema.ts
+++ b/apps/api/src/schemas/chat.schema.ts
@@ -10,6 +10,7 @@
  */
 import { z } from 'zod';
 import { secureOptionalTextSchema, secureTextSchema } from './security.schema';
+import { FILE_ATTACH_LIMITS } from '../config/runtime-limits';
 
 /**
  * OpenAI 호환 tool_call 스키마 (히스토리 메시지 내 assistant의 tool_calls)
@@ -108,7 +109,8 @@ export const chatRequestSchema = z.object({
     sessionId: secureOptionalTextSchema({ maxLength: 500, fieldName: 'sessionId', allowNewLines: false, detectMaliciousPatterns: false }),
     anonSessionId: secureOptionalTextSchema({ maxLength: 500, fieldName: 'anonSessionId', allowNewLines: false, detectMaliciousPatterns: false }),
     docId: secureOptionalTextSchema({ maxLength: 500, fieldName: 'docId', allowNewLines: false, detectMaliciousPatterns: false }),
-    images: z.array(z.string()).optional(),
+    // 개수·개별 dataURL 길이 상한 — WS 경로(ws-chat-handler FILE_ATTACH_LIMITS 캡)와 대칭 (2026-09-02 보안 리뷰 B4 NV)
+    images: z.array(z.string().max(FILE_ATTACH_LIMITS.MAX_IMAGE_DATAURL_CHARS)).max(FILE_ATTACH_LIMITS.MAX_IMAGES).optional(),
     discussionMode: z.boolean().optional(),
     thinkingMode: z.boolean().optional(),
     thinkingLevel: z.enum(['low', 'medium', 'high']).optional(),

--- a/apps/api/src/services/push-endpoint-guard.ts
+++ b/apps/api/src/services/push-endpoint-guard.ts
@@ -7,6 +7,7 @@
  */
 import { validateOutboundUrl, type DnsResolver } from '../security/ssrf-guard';
 import { ValidationError } from '../utils/error-handler';
+import { isPushEndpointHostAllowed } from '../config/push-endpoint-hosts';
 
 export async function assertPushEndpointAllowed(endpoint: string, resolver?: DnsResolver): Promise<void> {
     let url: URL;
@@ -17,6 +18,10 @@ export async function assertPushEndpointAllowed(endpoint: string, resolver?: Dns
     }
     if (url.protocol !== 'https:') {
         throw new ValidationError('endpoint는 https URL이어야 합니다');
+    }
+    // 알려진 push 서비스 호스트만 — 발송 시점 DNS rebinding 표면 축소 (PUSH_ENDPOINT_HOST_ALLOWLIST)
+    if (!isPushEndpointHostAllowed(url.hostname)) {
+        throw new ValidationError('허용되지 않는 push 서비스 호스트입니다');
     }
     try {
         await (resolver ? validateOutboundUrl(endpoint, resolver) : validateOutboundUrl(endpoint));


### PR DESCRIPTION
## 배경
2026-09-02 apps/api 보안 리뷰 P1/P2 리포트의 후속 후보 4건 중 3건(심층방어). 나머지 1건(MCP `{{env.KEY}}` 위치 인자 비밀)은 #714.

## 변경
- **REST `/api/chat` images 상한** — `z.array(z.string())` 에 개수(`FILE_ATTACH_LIMITS.MAX_IMAGES`)·개별 dataURL 길이(`MAX_IMAGE_DATAURL_CHARS`) 상한. WS 경로 캡과 대칭.
- **push endpoint 호스트 허용목록** — `config/push-endpoint-hosts.ts`(FCM·GCM·Mozilla autopush·WNS·APNs web suffix)를 등록 시 강제해 발송 시점 DNS rebinding 표면 축소. `PUSH_ENDPOINT_HOST_ALLOWLIST` 로 교체, `*` 로 비활성(`.env.example` 문서화).
- **`UserSandbox.validatePath` realpath** — 루트 안 심링크가 밖을 가리키는 경우를 realpath 로 차단(존재하는 가장 깊은 조상 기준, 미생성 경로는 조상만, realpath 실패는 fail-closed).

## 검증
- 테스트: 허용목록 통과 4·거부 3·env 교체/비활성, realpath 실재/미생성/심링크 탈출 거부/`..` 거부, push 스키마·가드 기존 케이스. 4 suites 21건 통과. `tsc` 0, eslint 0.

## 영향 범위
- 브라우저 표준 push 서비스(Chrome/Firefox/Edge/Safari)는 허용목록 안. 사설 push 서버 배포는 env 로 추가.
- user MCP 파일도구는 심링크 생성 primitive 가 없어 현재 도달 불가 경로였음(심층방어).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019162wSrWoUVHw99eAcctri
