### PR TITLE
feat(chat): 토론·딥리서치 명시 외부 모델 오류 계약 + 프론트 안내 정정

### DIFF
--- a/apps/api/src/services/chat-service/__tests__/mode-external-client.test.ts
+++ b/apps/api/src/services/chat-service/__tests__/mode-external-client.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Discussion·Deep Research 모드의 실행 모델 해석(mode-external-client) 단위 테스트.
+ *
+ * 검증:
+ *  - 해석 우선순위 3케이스 (① research role 외부 > ② 컴포저 명시 외부 > 로컬)
+ *  - 외부 어댑터 주입 경로 (명시 외부 선택 → resolveAssignedModelClient 로 외부 client 주입)
+ *  - 오류 계약 (명시 외부 선택인데 BYOK 키 미등록 → ProviderError, 로컬 조용한 폴백 금지)
+ */
+import type { ResolvedProvider } from '../../../providers/provider-router';
+import { ProviderError } from '../../../providers/provider-errors';
+
+// ── 모델 해석기 mock (동적 import 대상) ──
+const resolveRoleClientForUser = jest.fn();
+const resolveAssignedModelClient = jest.fn();
+jest.mock('../../model-role-resolver', () => ({
+    resolveRoleClientForUser: (...a: unknown[]) => resolveRoleClientForUser(...a),
+    resolveAssignedModelClient: (...a: unknown[]) => resolveAssignedModelClient(...a),
+}));
+
+// ── 카탈로그 mock (결정적) ──
+jest.mock('../../../config/external-providers', () => ({
+    EXTERNAL_PROVIDER_CATALOG: [
+        { id: 'bai', sdkType: 'openai-compatible' },
+        { id: 'hasa', sdkType: 'openai-compatible' },
+        { id: 'legacy-anthropic', sdkType: 'anthropic' },
+    ],
+}));
+
+// ── BYOK 키 저장소 mock ──
+let keyRowResult: unknown = { isActive: true };
+const getByUserAndProvider = jest.fn(async (..._a: unknown[]) => keyRowResult);
+jest.mock('../../../data/repositories/external-keys-repo', () => ({
+    ExternalKeysRepository: class {
+        getByUserAndProvider(...a: unknown[]) { return getByUserAndProvider(...a); }
+    },
+}));
+jest.mock('../../../data/models/unified-database', () => ({
+    getPool: () => ({}),
+}));
+
+import { resolveModeExternalClient } from '../mode-external-client';
+
+function makeResolved(providerId: string, modelId: string): ResolvedProvider {
+    return { providerId, modelId, fullId: `${providerId}:${modelId}` } as unknown as ResolvedProvider;
+}
+
+const externalClientSentinel = { __external: true };
+const localClientSentinel = { __local: true };
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    keyRowResult = { isActive: true };
+    resolveRoleClientForUser.mockResolvedValue({ providerId: 'local-llm', fullId: 'local-llm:x', source: 'default' });
+    resolveAssignedModelClient.mockResolvedValue({ client: externalClientSentinel, fullId: 'bai:qwen3.8-flash' });
+});
+
+describe('resolveModeExternalClient — 해석 우선순위', () => {
+    it('guest/userId 없음 → undefined (로컬)', async () => {
+        expect(await resolveModeExternalClient(makeResolved('bai', 'q'), undefined, 'Discussion')).toBeUndefined();
+        expect(await resolveModeExternalClient(makeResolved('bai', 'q'), 'guest', 'Discussion')).toBeUndefined();
+        expect(resolveAssignedModelClient).not.toHaveBeenCalled();
+    });
+
+    it('① DeepResearch + research role 이 외부 → role client 우선 (컴포저 선택 무시)', async () => {
+        resolveRoleClientForUser.mockResolvedValue({
+            client: { __role: true }, providerId: 'hasa', fullId: 'hasa:qwen3-coder', source: 'user',
+        });
+        const out = await resolveModeExternalClient(makeResolved('bai', 'q'), 'u1', 'DeepResearch');
+        expect(out).toEqual({ __role: true });
+        // role 이 채택됐으므로 컴포저 선택 해석은 호출되지 않는다.
+        expect(resolveAssignedModelClient).not.toHaveBeenCalled();
+    });
+
+    it('② Discussion + 컴포저 명시 외부 선택 → resolveAssignedModelClient 로 외부 client 주입', async () => {
+        const out = await resolveModeExternalClient(makeResolved('bai', 'qwen3.8-flash'), 'u1', 'Discussion');
+        expect(out).toBe(externalClientSentinel);
+        expect(resolveAssignedModelClient).toHaveBeenCalledWith('bai:qwen3.8-flash', 'u1');
+        // Discussion 은 role 경로 없음
+        expect(resolveRoleClientForUser).not.toHaveBeenCalled();
+    });
+
+    it('② DeepResearch + research role 로컬/미배정 → 컴포저 외부 선택으로 폴백', async () => {
+        // role 은 로컬(default)로 해석 → 컴포저 선택(bai) 채택
+        const out = await resolveModeExternalClient(makeResolved('bai', 'qwen3.8-flash'), 'u1', 'DeepResearch');
+        expect(out).toBe(externalClientSentinel);
+        expect(resolveRoleClientForUser).toHaveBeenCalledWith('research', 'u1');
+        expect(resolveAssignedModelClient).toHaveBeenCalledWith('bai:qwen3.8-flash', 'u1');
+    });
+
+    it('로컬 선택(local-llm:*) → 단언 없이 그대로 해석 (회귀 0, throw 없음)', async () => {
+        resolveAssignedModelClient.mockResolvedValue({ client: localClientSentinel, fullId: 'local-llm:qwen3.8-27b' });
+        const out = await resolveModeExternalClient(makeResolved('local-llm', 'qwen3.8-27b'), 'u1', 'Discussion');
+        expect(out).toBe(localClientSentinel);
+        expect(getByUserAndProvider).not.toHaveBeenCalled();
+    });
+});
+
+describe('resolveModeExternalClient — 오류 계약 (명시 외부 선택)', () => {
+    it('BYOK 키 미등록/비활성 → ProviderError(MISSING_API_KEY), 로컬 폴백 금지', async () => {
+        keyRowResult = null;
+        await expect(resolveModeExternalClient(makeResolved('bai', 'qwen3.8-flash'), 'u1', 'Discussion'))
+            .rejects.toBeInstanceOf(ProviderError);
+        await expect(resolveModeExternalClient(makeResolved('bai', 'qwen3.8-flash'), 'u1', 'Discussion'))
+            .rejects.toMatchObject({ code: 'MISSING_API_KEY' });
+        expect(resolveAssignedModelClient).not.toHaveBeenCalled();
+    });
+
+    it('카탈로그에 없는 provider → ProviderError(MODEL_NOT_FOUND)', async () => {
+        await expect(resolveModeExternalClient(makeResolved('bogus', 'm'), 'u1', 'Discussion'))
+            .rejects.toMatchObject({ code: 'MODEL_NOT_FOUND' });
+    });
+
+    it('openai-compatible 아닌 provider → ProviderError(NOT_SUPPORTED)', async () => {
+        await expect(resolveModeExternalClient(makeResolved('legacy-anthropic', 'm'), 'u1', 'Discussion'))
+            .rejects.toMatchObject({ code: 'NOT_SUPPORTED' });
+    });
+
+    it('키 조회 인프라 오류 → 단언 생략, 후단 fail-open (throw 없음)', async () => {
+        getByUserAndProvider.mockRejectedValueOnce(new Error('pool down'));
+        const out = await resolveModeExternalClient(makeResolved('bai', 'qwen3.8-flash'), 'u1', 'Discussion');
+        expect(out).toBe(externalClientSentinel);
+    });
+});

--- a/apps/api/src/services/chat-service/mode-external-client.ts
+++ b/apps/api/src/services/chat-service/mode-external-client.ts
@@ -6,7 +6,12 @@
  *   ① Deep Research → 'research' role 배정이 외부로 해석되면 그 모델 (REST /api/research 와 일치)
  *   ② 그 외(Discussion 전부 / role 미배정·로컬 해석) → 컴포저에서 선택한 모델(externalResolved)
  *
- * 어느 쪽도 해석되지 않으면 undefined 를 반환해 호출부가 로컬 svc.client 로 fail-open 한다.
+ * 어느 쪽도 외부로 해석되지 않으면 undefined 를 반환해 호출부가 로컬 svc.client 로 fail-open 한다.
+ *
+ * 오류 계약 — ②(사용자가 컴포저에서 명시 선택한 외부 모델)에서 그 모델이 실행 불가
+ * (BYOK 키 미등록·provider 미지원 등)하면 로컬로 조용히 폴백하지 않고 ProviderError 를
+ * throw 해 프론트에 사유를 노출한다("실패가 성공처럼 보이는 패턴" 차단). 반면 ①(research
+ * role 배정)의 실패는 운영/설정 단위라 기존대로 fail-open(컴포저 선택 → 로컬 순으로 폴백).
  *
  * @module services/chat-service/mode-external-client
  */
@@ -47,6 +52,13 @@ export async function resolveModeExternalClient(
     //    ('local-llm:<tag>')로 채우므로, 로컬 모델을 여러 개 운영하는 클러스터에서
     //    사용자가 고른 태그를 잃지 않도록 그대로 해석한다.
     if (!externalResolved) return undefined;
+
+    // 명시 외부 선택이면 실행 가능성을 먼저 단언한다 — 불가하면 ProviderError 로 노출(로컬 폴백 금지).
+    // (로컬 선택 'local-llm:*' 은 단언 없이 통과 → 회귀 0.)
+    if (externalResolved.providerId !== 'local-llm') {
+        await assertExternalModelUsable(externalResolved.providerId, String(userId));
+    }
+
     try {
         const { resolveAssignedModelClient } = await import('../model-role-resolver');
         const resolved = await resolveAssignedModelClient(externalResolved.fullId, String(userId));
@@ -59,5 +71,41 @@ export async function resolveModeExternalClient(
     } catch (e) {
         logger.warn('[Mode] 선택 모델 해석 실패 (로컬 폴백):', e);
         return undefined;
+    }
+}
+
+/**
+ * 명시 선택된 외부 모델이 이 사용자에게 실행 가능한지 단언한다.
+ * 실행 불가 사유가 명확하면 대응 ProviderError 를 throw(호출부가 로컬로 폴백하지 않게),
+ * 인프라 오류(pool 미초기화 등)는 삼켜서 후단 resolveAssignedModelClient 의 fail-open 에 맡긴다.
+ *
+ * getByUserAndProvider 는 is_active=TRUE 만 반환하므로 미등록·비활성이 모두 null →
+ * MISSING_API_KEY 로 통합한다(사용자 액션은 동일: 키 등록/재활성 또는 다른 모델 선택).
+ */
+async function assertExternalModelUsable(providerId: string, userId: string): Promise<void> {
+    const { ProviderError } = await import('../../providers/provider-errors');
+    const { EXTERNAL_PROVIDER_CATALOG } = await import('../../config/external-providers');
+
+    const entry = EXTERNAL_PROVIDER_CATALOG.find((p) => p.id === providerId);
+    if (!entry) {
+        throw new ProviderError('MODEL_NOT_FOUND', `카탈로그에 없는 provider '${providerId}'`);
+    }
+    // role/mode 실행 클라이언트는 OpenAI 호환 endpoint 만 지원(model-role-resolver 와 동일 제약).
+    if (entry.sdkType !== 'openai-compatible') {
+        throw new ProviderError('NOT_SUPPORTED', `provider '${providerId}' sdkType '${entry.sdkType}' 은 이 모드에서 미지원`);
+    }
+
+    let keyRow: unknown;
+    try {
+        const { ExternalKeysRepository } = await import('../../data/repositories/external-keys-repo');
+        const { getPool } = await import('../../data/models/unified-database');
+        keyRow = await new ExternalKeysRepository(getPool()).getByUserAndProvider(userId, providerId);
+    } catch (e) {
+        // 인프라 오류는 단언하지 않는다 — 후단 fail-open 에 위임(오탐 차단보다 가용성 우선).
+        logger.warn(`[Mode] 외부 키 조회 실패 — 단언 생략 (${providerId}):`, e);
+        return;
+    }
+    if (!keyRow) {
+        throw new ProviderError('MISSING_API_KEY', `'${providerId}' BYOK 키 미등록 또는 비활성`);
     }
 }

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -466,8 +466,9 @@ export function Composer() {
     if (entry) return entry.provider !== "local-llm";
     return selectedModel.includes(":") && !selectedModel.startsWith("local-llm:");
   })();
-  // 토론·딥 리서치는 전용 파이프라인이라 외부 모델을 무시하고 로컬 모델로 강제 실행된다.
-  const externalLocalModeNotice = selectedModelIsExternal && (discussionMode || deepResearchMode);
+  // 토론·딥 리서치도 선택한 외부 모델로 실행된다(백엔드 mode-external-client). 지정 모델로
+  // 돈다는 사실만 안내한다 — 로컬 강제 아님.
+  const externalModeNotice = selectedModelIsExternal && (discussionMode || deepResearchMode);
 
   return (
     <div className="mx-auto w-full max-w-3xl px-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
@@ -617,10 +618,10 @@ export function Composer() {
           })}
         </div>
 
-        {/* 외부 모델 + 토론/딥리서치 조합 안내 — 이 모드는 로컬 모델로 강제 실행됨. */}
-        {externalLocalModeNotice && (
-          <p className="px-3 pt-2 text-[11px] text-warn">
-            {t("externalLocalModeNotice")}
+        {/* 외부 모델 + 토론/딥리서치 조합 안내 — 이 모드는 선택한 외부 모델로 실행됨. */}
+        {externalModeNotice && (
+          <p className="px-3 pt-2 text-[11px] text-muted">
+            {t("externalModeNotice")}
           </p>
         )}
 

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -258,7 +258,7 @@
     "send": "Send",
     "disclaimer": "OpenMake can make mistakes. Verify important information.",
     "suppressedTag": "(not applied)",
-    "externalLocalModeNotice": "Discussion and Deep Research run on the local model (the selected external model is not used).",
+    "externalModeNotice": "Discussion and Deep Research will run on the selected external model.",
     "toggle": {
       "discussion": "Discussion",
       "thinking": "Thinking",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -258,7 +258,7 @@
     "send": "送信",
     "disclaimer": "OpenMake は誤ることがあります。重要な情報は確認してください。",
     "suppressedTag": "(未適用)",
-    "externalLocalModeNotice": "ディスカッション・ディープリサーチはローカルモデルで実行されます（選択した外部モデルは使用されません）。",
+    "externalModeNotice": "ディスカッション・ディープリサーチは選択した外部モデルで実行されます。",
     "toggle": {
       "discussion": "ディスカッション",
       "thinking": "思考",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -258,7 +258,7 @@
     "send": "전송",
     "disclaimer": "OpenMake 는 실수할 수 있습니다. 중요한 정보는 확인하세요.",
     "suppressedTag": "(미적용)",
-    "externalLocalModeNotice": "토론·딥 리서치 모드는 로컬 모델로 실행됩니다 (선택한 외부 모델은 사용되지 않음).",
+    "externalModeNotice": "토론·딥 리서치가 선택한 외부 모델로 실행됩니다.",
     "toggle": {
       "discussion": "토론",
       "thinking": "Thinking",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -258,7 +258,7 @@
     "send": "发送",
     "disclaimer": "OpenMake 可能会出错，请核实重要信息。",
     "suppressedTag": "(未应用)",
-    "externalLocalModeNotice": "讨论和深度研究将使用本地模型运行（不会使用所选的外部模型）。",
+    "externalModeNotice": "讨论和深度研究将使用所选的外部模型运行。",
     "toggle": {
       "discussion": "讨论",
       "thinking": "思考",


### PR DESCRIPTION
## 배경
"토론·딥리서치가 로컬 LLM 에 국한된다"는 전제로 재설계를 착수했으나, 분석 결과 **백엔드는 이미 외부 모델을 배선**하고 있었다(커밋 7b6a9695, #346 research role): `message-pipeline.resolveModeExternalClient` → `ChatService.processMessageWith{Discussion,DeepResearch}(…, externalClient)` → DiscussionEngine/DeepResearchService 가 주입 client 로 전 단계를 호출. 남아 있던 두 겹만 닫는다.

## 변경
- **오류 계약** (`mode-external-client.ts`): 컴포저에서 **명시 선택한 외부 모델**이 실행 불가(BYOK 키 미등록·비활성 → `MISSING_API_KEY`, 카탈로그 미존재 → `MODEL_NOT_FOUND`, openai-compatible 아님 → `NOT_SUPPORTED`)이면 로컬로 조용히 폴백하지 않고 `ProviderError` 를 던져 프론트가 사유를 표시한다(ws-chat-handler 기존 코드 매핑 재사용). `research` role 배정·인프라 오류는 종전대로 fail-open. 로컬 선택(`local-llm:*`)은 단언 없이 통과 → 회귀 0. OAuth(chatgpt)도 `getByUserAndProvider` 행이 있으면 통과.
- **프론트 안내 정정** (`composer.tsx`, 4 로케일): "로컬 모델로 실행됩니다(외부 모델 무시)" → "선택한 외부 모델로 실행됩니다". 실제 동작과 모순되던 문구.
- 해석 우선순위(변경 없음, 문서화): ① DeepResearch=`research` role 외부 배정 > ② 컴포저 명시 모델 > 로컬.

## 검증
- 신규 테스트 9건(`mode-external-client.test.ts`: 우선순위·오류 3종·로컬 통과·인프라 오류 fail-open) + `model-role-resolver`·`external-local-fallback` 기존 통과(3 suites 37건). API/Web `tsc` 0, eslint 0.
- 라이브(운영, PR 전 백엔드 기준): 별도 보고.

## 행동 변화(의도)
외부 모델을 골라둔 채 키가 만료·삭제된 사용자는 토론/딥리서치가 로컬로 조용히 돌지 않고 명시 오류를 받는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019162wSrWoUVHw99eAcctri
