### PR TITLE
feat(llm): 외부 provider 실행 클라이언트 스로틀 — provider 별 동시성 + 429 지수 백오프

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -694,6 +694,14 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # DISCUSSION_ABORT_CHECK_INTERVAL=100
 # Discussion 라운드 내 동시 에이전트 LLM 호출 상한 (fan-out 보호, 기본 5)
 # DISCUSSION_MAX_PARALLEL_AGENTS=5
+
+# 외부 provider 스로틀 (llm/external-throttle) — 토론·딥리서치·역할 클라이언트가 외부 BYOK 모델을
+# 병렬 호출할 때 provider 별 동시 요청 수 제한(카탈로그 maxConcurrentRequests 우선: bai=1, hasa=2)
+# + 429 지수 백오프 재시도(Retry-After 헤더 우선). 무료/개발 키 rate limit 전멸 방지.
+# EXTERNAL_PROVIDER_DEFAULT_CONCURRENCY=3
+# EXTERNAL_PROVIDER_RETRY_429_MAX=3
+# EXTERNAL_PROVIDER_RETRY_429_BASE_MS=2000
+# EXTERNAL_PROVIDER_RETRY_429_MAX_MS=20000
 # Deep Research 인용 커버리지 목표 (0.0~1.0, 기본 0.95)
 # DEEP_RESEARCH_CITATION_TARGET=0.95
 # Deep Research 인용 enforce 모드 (true=미달 시 메타 플래그, 기본 false=측정만)

--- a/apps/api/src/config/external-providers.ts
+++ b/apps/api/src/config/external-providers.ts
@@ -46,6 +46,13 @@ export interface ExternalProviderCatalogEntry {
      */
     authMethods: ReadonlyArray<'api_key' | 'oauth'>;
     /**
+     * 이 provider 에 동시에 보낼 수 있는 요청 수 힌트 — 토론(전문가 병렬)·딥리서치(fan-out)처럼
+     * 병렬 호출하는 모드가 무료/개발 키의 rate limit(429)에 전멸하지 않도록 실행 클라이언트가
+     * 세마포어로 직렬화한다(llm/external-throttle). 미지정 시 EXTERNAL_PROVIDER_THROTTLE.DEFAULT_CONCURRENCY.
+     * (2026-09-03 라이브 실측: B.AI 무료 키는 동시 2건부터 429, hasa 개발키는 5건 병렬에서 3건 429)
+     */
+    maxConcurrentRequests?: number;
+    /**
      * OAuth 흐름 메타데이터 — authMethods 에 'oauth' 포함 시에만 활용.
      * Phase 1: 모든 entry 에서 undefined.
      */
@@ -175,6 +182,7 @@ export const EXTERNAL_PROVIDER_CATALOG: ReadonlyArray<ExternalProviderCatalogEnt
         id: 'hasa',
         displayName: 'Open AI Service Hub (HASA)',
         sdkType: 'openai-compatible',
+        maxConcurrentRequests: 2,
         defaultBaseUrl: 'https://open.hasa.re.kr/v1',
         keyPrefixPattern: 'sk-',
         validatePath: '/models',
@@ -203,6 +211,7 @@ export const EXTERNAL_PROVIDER_CATALOG: ReadonlyArray<ExternalProviderCatalogEnt
         id: 'bai',
         displayName: 'B.AI',
         sdkType: 'openai-compatible',
+        maxConcurrentRequests: 1,
         defaultBaseUrl: 'https://api.b.ai/v1',
         keyPrefixPattern: 'sk-',
         validatePath: '/models',

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -354,6 +354,20 @@ export const DISCUSSION_FACTCHECK = {
  */
 export const DISCUSSION_MIN_PROPOSERS = parseInt(process.env.DISCUSSION_MIN_PROPOSERS || '2', 10);
 
+/**
+ * 외부 provider 실행 클라이언트 스로틀 (llm/external-throttle) — 토론·딥리서치·역할 클라이언트가
+ * 외부 BYOK 모델을 병렬 호출할 때 provider 별 동시 요청 수를 제한하고 429 를 지수 백오프로 재시도.
+ * provider 별 동시성은 카탈로그 maxConcurrentRequests 가 우선, 없으면 DEFAULT_CONCURRENCY.
+ */
+export const EXTERNAL_PROVIDER_THROTTLE = {
+    DEFAULT_CONCURRENCY: parseInt(process.env.EXTERNAL_PROVIDER_DEFAULT_CONCURRENCY || '3', 10),
+    /** 429 재시도 횟수 (OpenAI SDK 자체 재시도와 별개 — SDK 는 짧은 백오프라 무료 키 분당 한도를 못 넘김) */
+    RETRY_429_MAX: parseInt(process.env.EXTERNAL_PROVIDER_RETRY_429_MAX || '3', 10),
+    /** 첫 백오프 ms (2^n 지수 + 지터, Retry-After 헤더가 있으면 그 값 우선) */
+    RETRY_429_BASE_MS: parseInt(process.env.EXTERNAL_PROVIDER_RETRY_429_BASE_MS || '2000', 10),
+    RETRY_429_MAX_MS: parseInt(process.env.EXTERNAL_PROVIDER_RETRY_429_MAX_MS || '20000', 10),
+} as const;
+
 export const DISCUSSION_CONCURRENCY = {
     /** 라운드 내 동시 에이전트 LLM 호출 최대 수 */
     MAX_PARALLEL_AGENTS: parseInt(process.env.DISCUSSION_MAX_PARALLEL_AGENTS || '5', 10),

--- a/apps/api/src/llm/__tests__/external-throttle.test.ts
+++ b/apps/api/src/llm/__tests__/external-throttle.test.ts
@@ -1,0 +1,80 @@
+/** 외부 provider 스로틀 — provider 별 동시성 세마포어 + 429 지수 백오프 (2026-09-03) */
+import { EXTERNAL_PROVIDER_THROTTLE } from '../../config/runtime-limits';
+import { throttleExternalClient, providerConcurrency, __resetExternalThrottleForTest, is429 } from '../external-throttle';
+import type { LLMClient } from '../client';
+
+const mutable = EXTERNAL_PROVIDER_THROTTLE as unknown as Record<string, unknown>;
+const original = { ...EXTERNAL_PROVIDER_THROTTLE };
+
+function fakeClient(impl: (...a: unknown[]) => Promise<unknown>): LLMClient {
+    return { chat: impl, generate: impl, model: 'm', other: 42, helper(this: { model: string }) { return this.model; } } as unknown as LLMClient;
+}
+
+describe('throttleExternalClient', () => {
+    beforeEach(() => { __resetExternalThrottleForTest(); Object.assign(mutable, original, { RETRY_429_BASE_MS: 5, RETRY_429_MAX_MS: 20, RETRY_429_MAX: 3 }); });
+    afterEach(() => Object.assign(mutable, original));
+
+    it('카탈로그 힌트가 동시성을 정한다 (bai=1, hasa=2, 미지정=DEFAULT)', () => {
+        expect(providerConcurrency('bai')).toBe(1);
+        expect(providerConcurrency('hasa')).toBe(2);
+        expect(providerConcurrency('nvidia')).toBe(EXTERNAL_PROVIDER_THROTTLE.DEFAULT_CONCURRENCY);
+    });
+
+    it('bai 는 5개 병렬 호출을 1개씩 직렬화한다 (동시 in-flight 최대 1)', async () => {
+        let inFlight = 0, peak = 0;
+        const client = throttleExternalClient(fakeClient(async () => { inFlight++; peak = Math.max(peak, inFlight); await new Promise((r) => setTimeout(r, 10)); inFlight--; return 'ok'; }), 'bai');
+        const results = await Promise.all(Array.from({ length: 5 }, () => client.chat([], undefined)));
+        expect(results).toEqual(['ok', 'ok', 'ok', 'ok', 'ok']);
+        expect(peak).toBe(1);
+    });
+
+    it('hasa 는 동시 2개까지', async () => {
+        let inFlight = 0, peak = 0;
+        const client = throttleExternalClient(fakeClient(async () => { inFlight++; peak = Math.max(peak, inFlight); await new Promise((r) => setTimeout(r, 10)); inFlight--; return 'ok'; }), 'hasa');
+        await Promise.all(Array.from({ length: 5 }, () => client.chat([], undefined)));
+        expect(peak).toBe(2);
+    });
+
+    it('429 는 백오프 후 재시도해 성공을 돌려준다', async () => {
+        let calls = 0;
+        const client = throttleExternalClient(fakeClient(async () => { calls++; if (calls < 3) throw Object.assign(new Error('429 status code (no body)'), { status: 429 }); return 'done'; }), 'bai');
+        await expect(client.chat([], undefined)).resolves.toBe('done');
+        expect(calls).toBe(3);
+    });
+
+    it('재시도 상한을 넘기면 마지막 429 를 그대로 던진다', async () => {
+        const client = throttleExternalClient(fakeClient(async () => { throw Object.assign(new Error('429 status code (no body)'), { status: 429 }); }), 'bai');
+        await expect(client.chat([], undefined)).rejects.toThrow(/429/);
+    });
+
+    it('429 가 아닌 오류는 재시도 없이 즉시 전파', async () => {
+        let calls = 0;
+        const client = throttleExternalClient(fakeClient(async () => { calls++; throw Object.assign(new Error('boom'), { status: 500 }); }), 'bai');
+        await expect(client.chat([], undefined)).rejects.toThrow('boom');
+        expect(calls).toBe(1);
+    });
+
+    it('abort 된 signal 이면 백오프 대기 없이 중단', async () => {
+        const ac = new AbortController();
+        let calls = 0;
+        const client = throttleExternalClient(fakeClient(async () => { calls++; ac.abort(); throw Object.assign(new Error('429'), { status: 429 }); }), 'bai');
+        await expect(client.chat([], undefined, undefined, { signal: ac.signal })).rejects.toThrow();
+        expect(calls).toBe(1);
+    });
+
+    it('로컬(local-llm)은 원본 그대로, 다른 속성/메서드는 원본에 위임(this 보존)', () => {
+        const raw = fakeClient(async () => 'x');
+        expect(throttleExternalClient(raw, 'local-llm')).toBe(raw);
+        const wrapped = throttleExternalClient(raw, 'bai') as unknown as { other: number; helper: () => string; model: string };
+        expect(wrapped.other).toBe(42);
+        expect(wrapped.helper()).toBe('m');
+    });
+
+    it('is429 는 status/statusCode/메시지 어느 쪽이든 인식', () => {
+        expect(is429({ status: 429 })).toBe(true);
+        expect(is429({ statusCode: 429 })).toBe(true);
+        expect(is429(new Error('429 status code (no body)'))).toBe(true);
+        expect(is429(new Error('500'))).toBe(false);
+        expect(is429(null)).toBe(false);
+    });
+});

--- a/apps/api/src/llm/external-throttle.ts
+++ b/apps/api/src/llm/external-throttle.ts
@@ -1,0 +1,134 @@
+/**
+ * 외부 provider 실행 클라이언트 스로틀 — provider 별 동시 요청 세마포어 + 429 지수 백오프.
+ *
+ * 왜: 토론(전문가 5명 병렬)·딥리서치(검색/종합 fan-out)가 외부 BYOK 모델로 돌면 무료/개발 키의
+ * 분당 한도에 걸려 전문가가 전멸하거나(B.AI 5/5 429) 절반이 빠진다(hasa 3/5 429) — 2026-09-03 실측.
+ * OpenAI SDK 의 내장 재시도(짧은 백오프)만으론 부족하다. 호출부(토론 엔진·딥리서치·역할 클라이언트)는
+ * 그대로 두고 model-role-resolver 가 만드는 외부 LLMClient 를 이 프록시로 감싼다 — 로컬 vLLM 은 무관.
+ *
+ * 세마포어는 프로세스 전역·provider 단위(rate limit 은 키 단위지만 배포당 키가 사실상 1개).
+ */
+import type { LLMClient } from './client';
+import { EXTERNAL_PROVIDER_THROTTLE } from '../config/runtime-limits';
+import { getProviderCatalogEntry } from '../config/external-providers';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('ExternalThrottle');
+
+class Semaphore {
+    private active = 0;
+    private readonly queue: Array<() => void> = [];
+    constructor(readonly limit: number) {}
+    async acquire(): Promise<() => void> {
+        if (this.active < this.limit) { this.active++; return () => this.release(); }
+        await new Promise<void>((resolve) => this.queue.push(resolve));
+        this.active++;
+        return () => this.release();
+    }
+    private release(): void {
+        this.active--;
+        const next = this.queue.shift();
+        if (next) next();
+    }
+    get inFlight(): number { return this.active; }
+    get waiting(): number { return this.queue.length; }
+}
+
+const semaphores = new Map<string, Semaphore>();
+
+export function providerConcurrency(providerId: string): number {
+    const hint = getProviderCatalogEntry(providerId)?.maxConcurrentRequests;
+    const n = hint ?? EXTERNAL_PROVIDER_THROTTLE.DEFAULT_CONCURRENCY;
+    return Number.isFinite(n) && n > 0 ? Math.floor(n) : 1;
+}
+
+function semaphoreFor(providerId: string): Semaphore {
+    let s = semaphores.get(providerId);
+    const limit = providerConcurrency(providerId);
+    if (!s || s.limit !== limit) { s = new Semaphore(limit); semaphores.set(providerId, s); }
+    return s;
+}
+
+/** 테스트용 — 세마포어 상태 초기화 */
+export function __resetExternalThrottleForTest(): void { semaphores.clear(); }
+
+export function is429(err: unknown): boolean {
+    const e = err as { status?: unknown; statusCode?: unknown; message?: unknown } | null;
+    if (!e || typeof e !== 'object') return false;
+    if (e.status === 429 || e.statusCode === 429) return true;
+    return typeof e.message === 'string' && /\b429\b/.test(e.message);
+}
+
+/** Retry-After(초 또는 HTTP-date) → ms. 없거나 파싱 불가면 undefined */
+function retryAfterMs(err: unknown): number | undefined {
+    const headers = (err as { headers?: Record<string, string> | { get?: (k: string) => string | null } } | null)?.headers;
+    if (!headers) return undefined;
+    const raw = typeof (headers as { get?: unknown }).get === 'function'
+        ? (headers as { get: (k: string) => string | null }).get('retry-after')
+        : (headers as Record<string, string>)['retry-after'];
+    if (!raw) return undefined;
+    const secs = Number(raw);
+    if (Number.isFinite(secs)) return Math.max(0, secs * 1000);
+    const at = Date.parse(raw);
+    return Number.isNaN(at) ? undefined : Math.max(0, at - Date.now());
+}
+
+function backoffMs(attempt: number, err: unknown): number {
+    const { RETRY_429_BASE_MS, RETRY_429_MAX_MS } = EXTERNAL_PROVIDER_THROTTLE;
+    const fromHeader = retryAfterMs(err);
+    const exp = RETRY_429_BASE_MS * 2 ** attempt;
+    const jitter = Math.floor(Math.random() * RETRY_429_BASE_MS * 0.25);
+    return Math.min(RETRY_429_MAX_MS, Math.max(fromHeader ?? 0, exp + jitter));
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+    return new Promise((resolve, reject) => {
+        if (signal?.aborted) { reject(new Error('aborted')); return; }
+        const t = setTimeout(() => { signal?.removeEventListener('abort', onAbort); resolve(); }, ms);
+        const onAbort = () => { clearTimeout(t); reject(new Error('aborted')); };
+        signal?.addEventListener('abort', onAbort, { once: true });
+    });
+}
+
+/** LLMClient.chat 의 advancedOptions.signal 위치(4번째 인자) */
+function signalOf(args: unknown[]): AbortSignal | undefined {
+    const adv = args[3] as { signal?: AbortSignal } | undefined;
+    return adv?.signal;
+}
+
+/**
+ * 외부 provider 용 LLMClient 를 세마포어+429 재시도 프록시로 감싼다.
+ * `chat`·`generate` 만 가로채고 나머지 속성/메서드는 원본에 그대로 위임(this 는 원본 인스턴스).
+ */
+export function throttleExternalClient<T extends LLMClient>(client: T, providerId: string): T {
+    if (providerId === 'local-llm') return client;
+    const sem = semaphoreFor(providerId);
+    const { RETRY_429_MAX } = EXTERNAL_PROVIDER_THROTTLE;
+
+    const wrap = (method: 'chat' | 'generate') => async (...args: unknown[]) => {
+        const signal = signalOf(args);
+        const release = await sem.acquire();
+        try {
+            for (let attempt = 0; ; attempt++) {
+                try {
+                    return await (client[method] as (...a: unknown[]) => Promise<unknown>).apply(client, args);
+                } catch (err) {
+                    if (!is429(err) || attempt >= RETRY_429_MAX || signal?.aborted) throw err;
+                    const wait = backoffMs(attempt, err);
+                    logger.warn(`[${providerId}] 429 — ${wait}ms 후 재시도 (${attempt + 1}/${RETRY_429_MAX}, 대기열 ${sem.waiting})`);
+                    await sleep(wait, signal);
+                }
+            }
+        } finally {
+            release();
+        }
+    };
+
+    return new Proxy(client, {
+        get(target, prop) {
+            if (prop === 'chat' || prop === 'generate') return wrap(prop);
+            const v = Reflect.get(target, prop, target);
+            return typeof v === 'function' ? v.bind(target) : v;
+        },
+    }) as T;
+}

--- a/apps/api/src/services/model-role-resolver.ts
+++ b/apps/api/src/services/model-role-resolver.ts
@@ -42,6 +42,7 @@ import {
 } from '../config/model-roles';
 import { EXTERNAL_PROVIDER_CATALOG } from '../config/external-providers';
 import { createClient, LLMClient } from '../llm';
+import { throttleExternalClient } from '../llm/external-throttle';
 import {
     createExternalProviderInstance,
     buildOAuthSessionPersist,
@@ -206,7 +207,7 @@ async function tryBuildExternalResolution(
 
     const baseUrl = keyRow.baseUrl || entry.defaultBaseUrl;
     return {
-        client: createClient({
+        client: throttleExternalClient(createClient({
             baseUrl, apiKey: plaintextKey, model: modelId, userId,
             // 외부 BYOK 는 로컬 vLLM 용량을 쓰지 않으므로 토큰 쿼터 면제 (정책: LLMConfig.quotaExempt)
             quotaExempt: true,
@@ -215,7 +216,7 @@ async function tryBuildExternalResolution(
                 userId, providerId, modelId: u.model,
                 inputTokens: u.promptTokens, outputTokens: u.completionTokens,
             }).catch(() => { /* 관측 실패 무시 */ }),
-        }),
+        }), providerId),
         role,
         fullId,
         providerId,
@@ -259,7 +260,7 @@ async function tryBuildServerKeyResolution(
 
     const baseUrl = row.baseUrl || entry.defaultBaseUrl;
     return {
-        client: createClient({
+        client: throttleExternalClient(createClient({
             baseUrl, apiKey: plaintextKey, model: modelId, userId,
             // 외부 provider — 로컬 쿼터 면제 (서버 키 자체 상한은 recordServerKeyUsage 가 별도 관리)
             quotaExempt: true,
@@ -271,7 +272,7 @@ async function tryBuildServerKeyResolution(
                 });
                 void recordServerKeyUsage(providerId, u.promptTokens + u.completionTokens, Date.now());
             },
-        }),
+        }), providerId),
         role,
         fullId,
         providerId,


### PR DESCRIPTION
## 배경
토론·딥리서치는 이미 컴포저에서 선택한 외부 모델로 실행되지만(#716 참고), 라이브 실측(2026-09-03)에서 전문가 5명 병렬 호출이 **B.AI 무료 키 5/5 429(토론 실패)**, **hasa 개발키 3/5 429(참여자 2명)** 로 끝났다. 무료/개발 키의 분당 한도가 병렬 fan-out 을 못 받는다. OpenAI SDK 내장 재시도는 백오프가 짧아 부족.

## 변경
- `llm/external-throttle.ts` — `model-role-resolver` 가 만드는 외부 `LLMClient` 를 Proxy 로 감싸 `chat`/`generate` 에 **provider 별 세마포어**(카탈로그 `maxConcurrentRequests`: bai=1, hasa=2, 기본 `EXTERNAL_PROVIDER_DEFAULT_CONCURRENCY`=3) + **429 지수 백오프 재시도**(Retry-After 헤더 우선, 기본 3회·2s·최대 20s, abort signal 존중). 로컬은 무변경.
- 호출부(토론 엔진·딥리서치·역할 클라이언트)는 그대로 — 실행 클라이언트 생성 지점 2곳(BYOK·서버 키)만 래핑.
- `.env.example` 에 4개 env 문서화.

## 검증
- 테스트 9건(동시성 힌트, bai 직렬화 peak 1·hasa peak 2, 429 재시도 성공/상한/비-429 즉시 전파/abort, 로컬 passthrough·프록시 위임, is429). `model-role-resolver` 기존 18건 통과. `tsc` 0, eslint 0(기존 max-lines 경고만).
- 배포 후 라이브: `bai:qwen3.8-flash` + 토론 재실행으로 전문가 전원 완주 확인 예정.

## 트레이드오프
bai 로 토론하면 전문가 5명이 직렬로 돌아 느려진다(실측 턴당 3~6s → 토론 30s+). 정확성 우선.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019162wSrWoUVHw99eAcctri
