### PR TITLE
fix(llm): 로컬 vLLM 요청당 프롬프트 이미지 총량을 --limit-mm-per-prompt 상한에 맞춤

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1086,8 +1086,10 @@ AGENT_TASK_TIMEOUT_MS=600000
 # PDF 첨부 vision 페이지 주입 (채팅 하이브리드 — 텍스트 추출 + 앞쪽 페이지 이미지, 2026-08-19).
 # pdftoppm(poppler) 필요 — 미설치 시 자동 생략(텍스트 추출만). 특수 모드(딥리서치/이미지생성/토론) 제외.
 # PDF_VISION_ENABLED=true
-# 요청당 프롬프트 이미지 총 상한 — vLLM --limit-mm-per-prompt '{"image": N}' 와 반드시 페어로 조정
-# PDF_VISION_TOTAL_IMAGE_CAP=4
+# 로컬 vLLM 요청당 프롬프트 이미지 총 상한(history 포함) — --limit-mm-per-prompt '{"image": N}' 와 반드시 페어. 초과분은 오래된 이미지부터 제외
+# LLM_PROMPT_IMAGE_CAP=8
+# PDF 페이지 주입이 쓰는 총 상한 — 미설정 시 LLM_PROMPT_IMAGE_CAP 을 따름
+# PDF_VISION_TOTAL_IMAGE_CAP=8
 # PDF_VISION_MAX_PAGES=4
 # PDF_VISION_DPI=120
 # 렌더 이미지 긴 변 픽셀 상한 — 판형이 큰 문서(대형 슬라이드·도면)에서 초대형 이미지가

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -461,6 +461,16 @@ export const DOC_EXTRACT_LIMITS = {
 } as const;
 
 /**
+ * 로컬 vLLM 요청당 프롬프트 이미지 총 상한 (2026-09-03)
+ * vLLM `--limit-mm-per-prompt '{"image": N}'` 와 페어 — 초과 요청은 업스트림 400
+ * ("At most N image(s) may be provided in one prompt"). LLMClient wire 변환 직전
+ * (llm/prompt-image-cap.ts) 이 history 포함 총량을 이 값에 맞춘다. 0 이면 비활성.
+ */
+export const LLM_PROMPT_IMAGE_LIMITS = {
+    MAX_PER_REQUEST: parseInt(process.env.LLM_PROMPT_IMAGE_CAP || '8', 10),
+} as const;
+
+/**
  * PDF 첨부 vision 페이지 주입 한도 (2026-08-19)
  * 채팅 PDF 첨부를 하이브리드로 처리 — 기존 doc-extractor 텍스트 추출에 더해 앞쪽
  * 페이지를 pdftoppm 으로 JPEG 렌더해 vision(images) 채널에 병행 주입한다
@@ -471,9 +481,9 @@ export const DOC_EXTRACT_LIMITS = {
 export const PDF_VISION_LIMITS = {
     /** 기능 on/off (기본 on — 'false' 명시 시에만 비활성) */
     ENABLED: process.env.PDF_VISION_ENABLED !== 'false',
-    /** 요청당 프롬프트 이미지 총 상한 — vLLM `--limit-mm-per-prompt '{"image": N}'` 와 페어.
+    /** 요청당 프롬프트 이미지 총 상한 — 기본은 LLM_PROMPT_IMAGE_LIMITS(vLLM 페어)를 따른다.
      *  사용자 첨부 이미지가 이 값을 채우면 페이지 주입은 잔여분만 사용 */
-    TOTAL_IMAGE_CAP: parseInt(process.env.PDF_VISION_TOTAL_IMAGE_CAP || '4', 10),
+    TOTAL_IMAGE_CAP: parseInt(process.env.PDF_VISION_TOTAL_IMAGE_CAP || String(LLM_PROMPT_IMAGE_LIMITS.MAX_PER_REQUEST), 10),
     /** 요청당 렌더 페이지 최대 수 (PDF 여러 개면 순서대로 예산 소진) */
     MAX_PAGES: parseInt(process.env.PDF_VISION_MAX_PAGES || '4', 10),
     /** 렌더 해상도 dpi — 문서 판독 라이브 실측(2026-08-19) 120 이면 충분, 상향은 비전 토큰 비례 증가 */

--- a/apps/api/src/llm/__tests__/prompt-image-cap.test.ts
+++ b/apps/api/src/llm/__tests__/prompt-image-cap.test.ts
@@ -1,0 +1,55 @@
+import { capPromptImages } from '../prompt-image-cap';
+import type { ChatMessage } from '../types';
+
+const img = (n: number): string[] => Array.from({ length: n }, (_, i) => `img${i}`);
+
+describe('capPromptImages', () => {
+    it('상한 이하면 입력 배열을 그대로 돌려준다', () => {
+        const msgs: ChatMessage[] = [
+            { role: 'user', content: 'a', images: img(3) },
+            { role: 'user', content: 'b', images: img(5) },
+        ];
+        const r = capPromptImages(msgs, 8);
+        expect(r.messages).toBe(msgs);
+        expect(r).toMatchObject({ total: 8, dropped: 0 });
+    });
+
+    it('상한 초과 시 오래된 메시지의 이미지부터 제외하고 최신은 보존한다', () => {
+        const msgs: ChatMessage[] = [
+            { role: 'user', content: 'old', images: img(4) },
+            { role: 'assistant', content: 'r' },
+            { role: 'user', content: 'mid', images: img(3) },
+            { role: 'user', content: 'new', images: img(4) },
+        ];
+        const r = capPromptImages(msgs, 8);
+        expect(r).toMatchObject({ total: 11, dropped: 3 });
+        expect(r.messages[0].images).toEqual(['img3']);        // 4 → 1 (앞쪽부터 제외)
+        expect(r.messages[2].images).toEqual(img(3));          // 그대로
+        expect(r.messages[3].images).toEqual(img(4));          // 최신 보존
+        expect(msgs[0].images).toHaveLength(4);                // 입력 불변
+    });
+
+    it('한 메시지가 상한을 통째로 넘으면 그 메시지 안에서도 최신 첨부를 남긴다', () => {
+        const msgs: ChatMessage[] = [
+            { role: 'user', content: 'old', images: img(2) },
+            { role: 'user', content: 'goal', images: img(12) },
+        ];
+        const r = capPromptImages(msgs, 8);
+        expect(r.messages[0].images).toBeUndefined();          // 전부 제외 → 필드 제거
+        expect(r.messages[1].images).toEqual(img(12).slice(4));
+        expect(r.dropped).toBe(6);
+    });
+
+    it('assistant 메시지의 images 는 wire 에 실리지 않으므로 세지 않는다', () => {
+        const msgs: ChatMessage[] = [
+            { role: 'assistant', content: 'x', images: img(9) },
+            { role: 'user', content: 'y', images: img(2) },
+        ];
+        expect(capPromptImages(msgs, 8).dropped).toBe(0);
+    });
+
+    it('cap <= 0 이면 비활성', () => {
+        const msgs: ChatMessage[] = [{ role: 'user', content: 'a', images: img(30) }];
+        expect(capPromptImages(msgs, 0).messages).toBe(msgs);
+    });
+});

--- a/apps/api/src/llm/prompt-image-cap.ts
+++ b/apps/api/src/llm/prompt-image-cap.ts
@@ -1,0 +1,57 @@
+/**
+ * 로컬 vLLM 요청당 프롬프트 이미지 총량 캡 (2026-09-03).
+ *
+ * vLLM 은 `--limit-mm-per-prompt '{"image": N}'` 를 넘는 요청을 400
+ * ("At most N image(s) may be provided in one prompt") 으로 거절한다. 앱은 현재 턴 첨부만
+ * `FILE_ATTACH_LIMITS.MAX_IMAGES`(20) 로 막고 history 이미지는 합산하지 않아, 한 요청의
+ * 총량이 N 을 넘는 경로가 열려 있었다(라이브 재현: 8장 정상 · 9장 400). 에이전트 작업은
+ * goal 메시지가 절단 앵커로 고정 보존되므로 초과 시 매 턴 400 이 반복된다.
+ *
+ * 이 모듈은 LLMClient(로컬 전용) 의 wire 변환 직전 단일 지점에서 총량을 캡에 맞춘다 —
+ * 가장 오래된 메시지의 이미지부터 제외하고 최신 메시지의 이미지를 최대한 보존한다.
+ * 외부 provider 는 OpenAICompatProvider 가 별도 경로라 영향 없음.
+ *
+ * @module llm/prompt-image-cap
+ */
+import type { ChatMessage } from './types';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('PromptImageCap');
+
+/** wire 변환이 이미지를 싣는 역할 — toOpenAIMessages 와 동일 조건 유지 */
+function carriesImages(m: ChatMessage): boolean {
+    return (m.role === 'user' || m.role === 'system') && Array.isArray(m.images) && m.images.length > 0;
+}
+
+export interface PromptImageCapResult {
+    messages: ChatMessage[];
+    /** 요청 전체 이미지 수 (캡 적용 전) */
+    total: number;
+    /** 제외된 이미지 수 (0 이면 입력 그대로 반환) */
+    dropped: number;
+}
+
+/**
+ * 요청 전체 이미지 수가 `cap` 을 넘으면 오래된 메시지부터 이미지를 제외한다.
+ * `cap <= 0` 이면 비활성(입력 그대로). 입력 배열·메시지 객체는 변경하지 않는다.
+ */
+export function capPromptImages(messages: ChatMessage[], cap: number): PromptImageCapResult {
+    let total = 0;
+    for (const m of messages) if (carriesImages(m)) total += m.images!.length;
+    if (cap <= 0 || total <= cap) return { messages, total, dropped: 0 };
+
+    let toDrop = total - cap;
+    const out = messages.map((m) => {
+        if (toDrop <= 0 || !carriesImages(m)) return m;
+        const imgs = m.images!;
+        const take = Math.max(0, imgs.length - toDrop);
+        toDrop -= imgs.length - take;
+        const rest = { ...m };
+        delete rest.images;
+        // 메시지 안에서도 앞쪽(오래된) 이미지부터 제외 — 마지막 첨부를 우선 보존
+        return take > 0 ? { ...rest, images: imgs.slice(imgs.length - take) } : rest;
+    });
+    const dropped = total - cap;
+    log.warn(`요청 이미지 ${total}장 → 상한 ${cap}장 적용 (오래된 ${dropped}장 제외)`);
+    return { messages: out, total, dropped };
+}

--- a/apps/api/src/llm/stream-parser.ts
+++ b/apps/api/src/llm/stream-parser.ts
@@ -27,6 +27,8 @@ import { ArtifactStreamParser, type ArtifactStreamCallbacks } from './artifact-p
 import { extractCoTFromContent } from './cot-extractor';
 import { PseudoToolCallGate, stripPseudoToolCalls } from './pseudo-tool-call-parser';
 import { createLogger } from '../utils/logger';
+import { capPromptImages } from './prompt-image-cap';
+import { LLM_PROMPT_IMAGE_LIMITS } from '../config/runtime-limits';
 
 const log = createLogger('StreamParser');
 
@@ -106,7 +108,9 @@ export function toResponseFormat(f: FormatOption | undefined): Record<string, un
 }
 
 function toOpenAIMessages(messages: ChatMessage[]): unknown[] {
-    return messages.map((m, idx) => {
+    // 로컬 vLLM `--limit-mm-per-prompt` 페어 — history 포함 총량을 상한에 맞춘다(초과 시 400).
+    const { messages: capped } = capPromptImages(messages, LLM_PROMPT_IMAGE_LIMITS.MAX_PER_REQUEST);
+    return capped.map((m, idx) => {
         if (m.role === 'tool') {
             return {
                 role: 'tool',

--- a/scripts/vllm/litellm.config.yaml
+++ b/scripts/vllm/litellm.config.yaml
@@ -25,14 +25,6 @@ model_list:
       api_base: os.environ/QWEN_VLLM_API_BASE      # http://<VLLM_TAILSCALE_HOST>:8002/v1
       api_key: os.environ/VLLM_API_KEY
 
-  # 호환 alias — 2026-09-02 :8002 실체가 qwen3.8-27b 로 바뀜. vLLM 도 같은 이름을 함께 서빙
-  # (--served-model-name qwen3.8-27b qwen3.6-35b-a3b) 하므로 구 클라이언트·옛 대화 model id 유지용.
-  - model_name: qwen3.6-35b-a3b
-    litellm_params:
-      model: openai/qwen3.6-35b-a3b
-      api_base: os.environ/QWEN_VLLM_API_BASE      # http://<VLLM_TAILSCALE_HOST>:8002/v1
-      api_key: os.environ/VLLM_API_KEY
-
   - model_name: bge-m3
     litellm_params:
       model: openai/bge-m3


### PR DESCRIPTION
## 배경
Qwen3.8-27B 적용 점검(2026-09-03)에서 확인된 실제 장애 경로. vLLM 은 \`--limit-mm-per-prompt '{"image": 8}'\` 를 넘는 요청을 400 으로 거절하는데(라이브 재현: 8장 → "8" 정답 · 9장 → \`At most 8 image(s) may be provided in one prompt\`), 앱은 현재 턴 첨부만 \`FILE_ATTACH_LIMITS.MAX_IMAGES\`(20) 로 막고 history 이미지는 합산하지 않았다. 코드에서 8 이 등장하는 곳은 주석 한 줄뿐이었다.

- WS/REST 채팅 현재 턴 20장, history 이미지 상한 없음, 에이전트 작업 20장 — 모두 8 초과 가능
- 에이전트 작업은 goal 메시지가 컨텍스트 절단 앵커로 고정 보존되어 초과 시 **매 턴 400 반복**

## 변경
- \`llm/prompt-image-cap.ts\` (신규): LLMClient wire 변환 직전(\`toOpenAIMessages\`) 단일 지점에서 요청 전체 이미지 수를 상한에 맞춤. 오래된 메시지의 이미지부터 제외하고 최신 첨부를 보존, warn 로그. 입력 불변. 외부 provider 는 \`OpenAICompatProvider\` 별도 경로라 무영향
- \`config/runtime-limits.ts\`: \`LLM_PROMPT_IMAGE_LIMITS.MAX_PER_REQUEST\` (env \`LLM_PROMPT_IMAGE_CAP\`, 기본 8, 0=비활성). \`PDF_VISION_TOTAL_IMAGE_CAP\` 기본값이 이를 따르도록 페어 정리(운영 .env 는 이미 8)
- \`.env.example\` 갱신
- 동반 chore: \`scripts/vllm/litellm.config.yaml\` 에서 DGX 가 더 이상 서빙하지 않는 \`qwen3.6-35b-a3b\` alias 제거(운영 config 는 같은 날 제거·재시작·검증 완료)

## 검증
- 단위 테스트 5건(상한 이하 불변 · 오래된 것부터 제외 · 단일 메시지 초과 시 최신 첨부 보존 · assistant images 미계수 · cap 0 비활성)
- \`npx jest src/llm src/services/chat-service/__tests__/pdf-vision\` 9 suites / 93 tests 통과
- \`tsc --noEmit\` 오류 0, eslint 신규 경고 0 (runtime-limits max-lines 는 기존)

## 의도적으로 안 한 것
- \`FILE_ATTACH_MAX_IMAGES\`(20)·composer \`MAX_IMAGES\` 는 그대로 — 외부 provider 는 더 많은 이미지를 받을 수 있어 첨부 계약을 로컬 상한에 묶지 않았다. 로컬 초과분은 서버가 잘라 보내고 warn 로그로 관측한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnmAE4r91oMdzncz1ZeiRv