### PR TITLE
fix(llm): 외부 스로틀 클라이언트의 SDK 타임아웃을 배수 적용 + SDK 재시도 0

### DIFF
--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -374,6 +374,8 @@ export const EXTERNAL_PROVIDER_THROTTLE = {
      * (2026-09-03 실측: 청크 6/6 전부 abort → 합성 중단).
      */
     TIMEOUT_MULTIPLIER: parseFloat(process.env.EXTERNAL_PROVIDER_TIMEOUT_MULTIPLIER || '3'),
+    /** 배수를 곱할 기준 타임아웃 — 호출측이 넘긴 값이 유효하지 않을 때의 폴백 (LLM_TIMEOUT 과 동일 기본) */
+    BASE_TIMEOUT_FALLBACK_MS: parseInt(process.env.LLM_TIMEOUT || '120000', 10),
 } as const;
 
 export const DISCUSSION_CONCURRENCY = {

--- a/apps/api/src/llm/__tests__/external-throttle.test.ts
+++ b/apps/api/src/llm/__tests__/external-throttle.test.ts
@@ -107,3 +107,15 @@ describe('ExternalClientHints', () => {
         expect(getExternalClientHints(throttleExternalClient(raw, 'local-llm'))).toBeNull();
     });
 });
+
+describe('externalClientTiming', () => {
+    it('LLM_TIMEOUT × 배수, maxRetries 0', () => {
+        const { externalClientTiming } = require('../external-throttle') as typeof import('../external-throttle');
+        const mutable2 = EXTERNAL_PROVIDER_THROTTLE as unknown as Record<string, unknown>;
+        const orig = EXTERNAL_PROVIDER_THROTTLE.TIMEOUT_MULTIPLIER;
+        Object.assign(mutable2, { TIMEOUT_MULTIPLIER: 6 });
+        try {
+            expect(externalClientTiming(120000)).toEqual({ timeout: 720000, maxRetries: 0 });
+        } finally { Object.assign(mutable2, { TIMEOUT_MULTIPLIER: orig }); }
+    });
+});

--- a/apps/api/src/llm/client.ts
+++ b/apps/api/src/llm/client.ts
@@ -66,6 +66,7 @@ export class LLMClient {
             baseURL: this.config.baseUrl,
             apiKey: this.config.apiKey && this.config.apiKey.length > 0 ? this.config.apiKey : 'sk-no-key',
             timeout: this.config.timeout,
+            ...(this.config.maxRetries !== undefined && { maxRetries: this.config.maxRetries }),
         });
         logger.debug(`LLMClient init: chat=${this.config.baseUrl} (model=${this.config.model})`);
     }

--- a/apps/api/src/llm/external-throttle.ts
+++ b/apps/api/src/llm/external-throttle.ts
@@ -36,6 +36,20 @@ class Semaphore {
 
 const semaphores = new Map<string, Semaphore>();
 
+/**
+ * 외부 스로틀 클라이언트의 SDK 타이밍 설정 — model-role-resolver 가 createClient 에 펼친다.
+ * - timeout: 로컬 기준 LLM_TIMEOUT × TIMEOUT_MULTIPLIER. 긴 추론 모델(glm-5.3-flash 청크 요약 ~5분)은
+ *   로컬 120s 에 걸린다(2026-09-03 실측: chat-with-timeout 배수를 올려도 SDK 타임아웃 120s×재시도 3회
+ *   = 360s 에서 "Request timed out").
+ * - maxRetries 0: 429 는 이 모듈이 백오프로 처리하고, 타임아웃을 SDK 가 맹목 재시도하면 세마포어 슬롯을
+ *   3배로 점유한다.
+ */
+export function externalClientTiming(baseTimeoutMs: number): { timeout: number; maxRetries: number } {
+    const mult = Math.max(1, EXTERNAL_PROVIDER_THROTTLE.TIMEOUT_MULTIPLIER || 1);
+    const base = Number.isFinite(baseTimeoutMs) && baseTimeoutMs > 0 ? baseTimeoutMs : EXTERNAL_PROVIDER_THROTTLE.BASE_TIMEOUT_FALLBACK_MS;
+    return { timeout: Math.round(base * mult), maxRetries: 0 };
+}
+
 export function providerConcurrency(providerId: string): number {
     const hint = getProviderCatalogEntry(providerId)?.maxConcurrentRequests;
     const n = hint ?? EXTERNAL_PROVIDER_THROTTLE.DEFAULT_CONCURRENCY;

--- a/apps/api/src/llm/types.ts
+++ b/apps/api/src/llm/types.ts
@@ -24,6 +24,8 @@ export interface LLMConfig {
     model: string;
     /** HTTP 요청 타임아웃 (밀리초) */
     timeout: number;
+    /** OpenAI SDK 자체 재시도 횟수 (미지정=SDK 기본 2). 외부 스로틀 클라이언트는 0 — 429 는 external-throttle 이, 타임아웃은 재시도하지 않는다 */
+    maxRetries?: number;
     /** 요청 사용자 ID — per-user 토큰 쿼터 enforcement 용 (미설정 시 enforcement skip) */
     userId?: string;
     /**

--- a/apps/api/src/services/__tests__/model-role-resolver.test.ts
+++ b/apps/api/src/services/__tests__/model-role-resolver.test.ts
@@ -131,6 +131,11 @@ describe('resolveRoleClient — 3단 폴백', () => {
             model: 'openai/gpt-5',
             userId: 'u1',
         });
+        // 외부 클라이언트는 SDK 타임아웃 배수·재시도 0 (external-throttle.externalClientTiming, 2026-09-03)
+        const ext = createdClients[createdClients.length - 1];
+        expect(ext.maxRetries).toBe(0);
+        expect(typeof ext.timeout).toBe('number');
+        expect(ext.timeout as number).toBeGreaterThanOrEqual(120000);
     });
 
     it('keyRow.baseUrl 없으면 카탈로그 defaultBaseUrl 사용', async () => {

--- a/apps/api/src/services/model-role-resolver.ts
+++ b/apps/api/src/services/model-role-resolver.ts
@@ -42,7 +42,7 @@ import {
 } from '../config/model-roles';
 import { EXTERNAL_PROVIDER_CATALOG } from '../config/external-providers';
 import { createClient, LLMClient } from '../llm';
-import { throttleExternalClient } from '../llm/external-throttle';
+import { throttleExternalClient, externalClientTiming } from '../llm/external-throttle';
 import {
     createExternalProviderInstance,
     buildOAuthSessionPersist,
@@ -209,6 +209,7 @@ async function tryBuildExternalResolution(
     return {
         client: throttleExternalClient(createClient({
             baseUrl, apiKey: plaintextKey, model: modelId, userId,
+            ...externalClientTiming(getConfig().llmTimeout),
             // 외부 BYOK 는 로컬 vLLM 용량을 쓰지 않으므로 토큰 쿼터 면제 (정책: LLMConfig.quotaExempt)
             quotaExempt: true,
             // BYOK 사용량 귀속 — 비용 대시보드(external_provider_usage) 반영 (fire-and-forget)
@@ -262,6 +263,7 @@ async function tryBuildServerKeyResolution(
     return {
         client: throttleExternalClient(createClient({
             baseUrl, apiKey: plaintextKey, model: modelId, userId,
+            ...externalClientTiming(getConfig().llmTimeout),
             // 외부 provider — 로컬 쿼터 면제 (서버 키 자체 상한은 recordServerKeyUsage 가 별도 관리)
             quotaExempt: true,
             // 서버 키 사용량 귀속(운영자 비용 뷰) + 상한 카운터 누적


### PR DESCRIPTION
## 배경
#720 배포 후 bai glm-5.3-flash 딥리서치 재실행: 청크 요약이 정확히 **360초마다 "Request timed out."** — `chat-with-timeout` 배수(720s)보다 **OpenAI SDK 요청 타임아웃(LLM_TIMEOUT 120s) × SDK 기본 재시도 2회** 가 먼저 걸린다. glm 은 분석형 프롬프트에서 추론 8천 토큰·약 5분(실측 277s, `reasoning_effort: low` 도 280s 초과, 끄기는 400 "该模型始终思考").

## 변경
- `LLMConfig.maxRetries` → `LLMClient` 가 OpenAI 생성자에 전달.
- `external-throttle.externalClientTiming(base)` — `timeout = base × EXTERNAL_PROVIDER_TIMEOUT_MULTIPLIER`, `maxRetries: 0`(429 는 스로틀이 백오프로 처리, 타임아웃 맹목 재시도는 세마포어 슬롯 3배 점유). base 무효 시 `LLM_TIMEOUT` 기본 폴백.
- `model-role-resolver` 외부 createClient 2곳(BYOK·서버 키)에 펼침. 로컬 경로 무변경.

## 검증
- 테스트: 타이밍 헬퍼(120000×6 → 720000/0), 외부 해석 client 의 `maxRetries 0`·`timeout ≥ 120000`. external-throttle·model-role-resolver 31건 통과, `tsc` 0, eslint 0.
- 운영 `.env` 에 `EXTERNAL_PROVIDER_TIMEOUT_MULTIPLIER=6` 적용됨 → 배포 후 bai glm-5.3-flash 딥리서치 재실행 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019162wSrWoUVHw99eAcctri
