### PR TITLE
fix(llm): 로컬 모델 샘플링 프리셋(thinking ON/OFF) + 메타 호출 think:false 명시 + thinking 기본 레벨 medium

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -249,6 +249,21 @@ SEARCH_SEMANTIC_RERANK_ENABLED=false
 # GB10 하드웨어 (Grace Blackwell, 컴퓨트 한계) 권장: 'true' — TTFB 8.2s → 3.1s 단축.
 LLM_DISABLE_THINKING_BY_DEFAULT=true
 
+# 로컬 모델 샘플링 프리셋 (2026-09-03) — 호출자가 샘플링을 지정하지 않은 로컬 요청에 thinking ON/OFF 별
+# 공식 권장값을 채운다 (Qwen3.8: 추론 T1.0/top_p0.95/presence0 · 비추론 T0.7/top_p0.8/presence1.5, repetition 1.0).
+# 외부 provider 클라이언트·temperature 를 명시한 호출(딥리서치 등)은 무영향. 'false' 로 끄면 종전처럼 서버 기본값.
+# LLM_LOCAL_SAMPLING_PRESET_ENABLED=true
+# LLM_SAMPLING_THINKING_TEMP=1.0
+# LLM_SAMPLING_THINKING_TOP_P=0.95
+# LLM_SAMPLING_THINKING_TOP_K=20
+# LLM_SAMPLING_THINKING_PRESENCE=0.0
+# LLM_SAMPLING_THINKING_REPETITION=1.0
+# LLM_SAMPLING_INSTRUCT_TEMP=0.7
+# LLM_SAMPLING_INSTRUCT_TOP_P=0.8
+# LLM_SAMPLING_INSTRUCT_TOP_K=20
+# LLM_SAMPLING_INSTRUCT_PRESENCE=1.5
+# LLM_SAMPLING_INSTRUCT_REPETITION=1.0
+
 # *******************************************************
 # 🔐 서버 및 보안 설정
 # *******************************************************

--- a/apps/api/src/agents/git-ingest/catalog-translator.ts
+++ b/apps/api/src/agents/git-ingest/catalog-translator.ts
@@ -68,7 +68,7 @@ export async function translateCatalogDescriptions(
                 { role: 'system', content: SYSTEM_PROMPT },
                 { role: 'user', content: JSON.stringify(batch.map(p => p.description)) },
             ];
-            const resp = await llm.chat(messages);
+            const resp = await llm.chat(messages, undefined, undefined, { think: false });
             const raw = (resp.content ?? '').trim();
             // ⚠️ 전체 파싱 먼저 — 펜스 우선이면 번역문 안의 코드블록을 잡아 깨진다
             // (skill-creator 에서 실측된 결함, 2026-08-24)

--- a/apps/api/src/agents/git-ingest/convention-checker.ts
+++ b/apps/api/src/agents/git-ingest/convention-checker.ts
@@ -112,7 +112,7 @@ export class ConventionChecker {
             { role: 'user', content: userContent },
         ];
         try {
-            const resp = await this.llm.chat(messages);
+            const resp = await this.llm.chat(messages, undefined, undefined, { think: false });
             const tokensUsed = resp.metrics?.completion_tokens ?? 0;
             const raw = (resp.content ?? '').trim();
             // ⚠️ 전체 파싱 먼저 — 펜스를 먼저 벗기면 findings 안의 코드블록을 잡아 깨진다

--- a/apps/api/src/agents/git-ingest/skill-rewriter.ts
+++ b/apps/api/src/agents/git-ingest/skill-rewriter.ts
@@ -114,7 +114,7 @@ export async function proposeSkillRewrite(
         { role: 'user', content: buildSkillRewriteUserPrompt(input.name, body) },
     ];
     try {
-        const resp = await llm.chat(messages);
+        const resp = await llm.chat(messages, undefined, undefined, { think: false });
         const parsed = parseRewriteResponse(resp.content ?? '');
         if (!parsed) {
             // 파싱 실패를 "변경 불필요"와 섞으면 진단이 불가능해진다 (실측 사례)

--- a/apps/api/src/agents/skill-creator.ts
+++ b/apps/api/src/agents/skill-creator.ts
@@ -265,7 +265,7 @@ export class SkillCreatorService {
                 // 강제 없이 자유 텍스트로 JSON 을 요청하면 모델이 코드블록·백틱·따옴표
                 // 이스케이프를 깨뜨려 정상 종료한 응답이 JSON.parse 에서 죽는다
                 // (2026-08-24 skill-rewriter 실측). 백엔드(vLLM)가 문법을 보장하게 한다.
-                const resp = await client.chat(messages, undefined, undefined, { format: 'json' });
+                const resp = await client.chat(messages, undefined, undefined, { format: 'json', think: false });
                 const raw = resp.content ?? '';
                 const tokensUsed = resp.metrics?.completion_tokens ?? 0;
 

--- a/apps/api/src/chat/external-tool-calling.ts
+++ b/apps/api/src/chat/external-tool-calling.ts
@@ -177,7 +177,9 @@ export async function processExternalToolCalling(params: {
     let fullContent = '';
     const llmResponse = await client.chat(
         messages,
-        promptConfig.options,
+        // 샘플링은 지정하지 않는다 — 구 promptConfig.options(Gemini/GPT-OSS 시절 프리셋: top_k·repeat_penalty)
+        // 가 로컬 Qwen 에 그대로 실리던 것을 제거. LLMClient 가 thinking 상태별 로컬 프리셋을 채운다.
+        undefined,
         (token: string) => {
             // tool_calls JSON 토큰은 스트리밍에서 필터링
             if (!token.includes('tool_calls')) {

--- a/apps/api/src/chat/request-handler.ts
+++ b/apps/api/src/chat/request-handler.ts
@@ -329,7 +329,7 @@ export class ChatRequestHandler {
         //   3. 그 외 → OFF
         const fastPath = detectFastPath(message);
         const mergedThinkingMode = !fastPath.matched && thinkingMode === true;
-        const mergedThinkingLevel = mergedThinkingMode ? (thinkingLevel || 'high') : undefined;
+        const mergedThinkingLevel = mergedThinkingMode ? (thinkingLevel || 'medium') : undefined;
         if (fastPath.matched && thinkingMode === true) {
             log.info(`[RequestHandler] Fast-path 감지(${fastPath.reason}) — 사용자 thinking 토글 무시하고 OFF`);
         }

--- a/apps/api/src/config/llm-parameters.ts
+++ b/apps/api/src/config/llm-parameters.ts
@@ -79,6 +79,37 @@ export const LLM_TEMPERATURES = {
     THINKING_DEFAULT: Number(process.env.LLM_TEMP_THINKING_DEFAULT) || 0.5,
 } as const;
 
+/**
+ * 로컬 모델 샘플링 프리셋 — thinking ON/OFF 별 공식 권장값 (Qwen3.8 모델 카드 기준, 2026-09-03).
+ * llm/sampling-preset.ts 가 "호출자가 샘플링을 지정하지 않은 로컬 요청"에만 채운다.
+ *   THINKING : T 1.0 · top_p 0.95 · top_k 20 · presence 0.0 · repetition 1.0
+ *   INSTRUCT : T 0.7 · top_p 0.80 · top_k 20 · presence 1.5 · repetition 1.0
+ * repetition 1.0 은 서버 `--override-generation-config` 의 1.05 를 요청 단위로 되돌린다 —
+ * 비추론 모드의 반복 억제는 공식 권장대로 presence_penalty 가 맡는다.
+ * env: LLM_LOCAL_SAMPLING_PRESET_ENABLED(기본 true), LLM_SAMPLING_{THINKING,INSTRUCT}_{TEMP,TOP_P,TOP_K,PRESENCE,REPETITION}
+ */
+const samplingNum = (key: string, fallback: number): number => {
+    const v = Number(process.env[key]);
+    return Number.isFinite(v) && process.env[key] !== undefined && process.env[key] !== '' ? v : fallback;
+};
+export const LOCAL_SAMPLING_PRESETS = {
+    ENABLED: process.env.LLM_LOCAL_SAMPLING_PRESET_ENABLED !== 'false',
+    THINKING: {
+        temperature: samplingNum('LLM_SAMPLING_THINKING_TEMP', 1.0),
+        top_p: samplingNum('LLM_SAMPLING_THINKING_TOP_P', 0.95),
+        top_k: samplingNum('LLM_SAMPLING_THINKING_TOP_K', 20),
+        presence_penalty: samplingNum('LLM_SAMPLING_THINKING_PRESENCE', 0.0),
+        repeat_penalty: samplingNum('LLM_SAMPLING_THINKING_REPETITION', 1.0),
+    },
+    INSTRUCT: {
+        temperature: samplingNum('LLM_SAMPLING_INSTRUCT_TEMP', 0.7),
+        top_p: samplingNum('LLM_SAMPLING_INSTRUCT_TOP_P', 0.8),
+        top_k: samplingNum('LLM_SAMPLING_INSTRUCT_TOP_K', 20),
+        presence_penalty: samplingNum('LLM_SAMPLING_INSTRUCT_PRESENCE', 1.5),
+        repeat_penalty: samplingNum('LLM_SAMPLING_INSTRUCT_REPETITION', 1.0),
+    },
+} as const;
+
 // ============================================
 // Top-p / 기타 샘플링 파라미터
 // ============================================

--- a/apps/api/src/llm/__tests__/sampling-preset.test.ts
+++ b/apps/api/src/llm/__tests__/sampling-preset.test.ts
@@ -1,0 +1,77 @@
+/**
+ * 로컬 샘플링 프리셋 — env 에 의존하므로 모듈을 격리 로드한다(운영 .env 의 값이 섞이지 않게).
+ */
+export {};
+
+const ENV_KEYS = [
+    'LLM_LOCAL_SAMPLING_PRESET_ENABLED', 'LLM_DISABLE_THINKING_BY_DEFAULT',
+    'LLM_SAMPLING_THINKING_TEMP', 'LLM_SAMPLING_INSTRUCT_TEMP', 'LLM_SAMPLING_INSTRUCT_PRESENCE',
+];
+const saved: Record<string, string | undefined> = {};
+
+function load(env: Record<string, string | undefined>) {
+    for (const k of ENV_KEYS) delete process.env[k];
+    for (const [k, v] of Object.entries(env)) if (v !== undefined) process.env[k] = v;
+    jest.resetModules();
+    const mod = require('../sampling-preset') as typeof import('../sampling-preset');
+    const ra = require('../reasoning-adapter') as typeof import('../reasoning-adapter');
+    return { applyPreset: mod.applyLocalSamplingPreset, isThinkingEnabled: ra.isThinkingEnabled };
+}
+
+beforeAll(() => { for (const k of ENV_KEYS) saved[k] = process.env[k]; });
+afterAll(() => { for (const k of ENV_KEYS) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; } });
+
+describe('applyLocalSamplingPreset', () => {
+    it('thinking OFF(명시) → INSTRUCT 프리셋 (공식 비추론 권장값)', () => {
+        const { applyPreset } = load({});
+        expect(applyPreset(undefined, false)).toEqual({
+            temperature: 0.7, top_p: 0.8, top_k: 20, presence_penalty: 1.5, repeat_penalty: 1.0,
+        });
+    });
+
+    it('thinking ON(레벨) → THINKING 프리셋, 기존 num_predict 는 보존', () => {
+        const { applyPreset } = load({});
+        expect(applyPreset({ num_predict: 4096 }, 'medium')).toEqual({
+            num_predict: 4096, temperature: 1.0, top_p: 0.95, top_k: 20, presence_penalty: 0, repeat_penalty: 1.0,
+        });
+    });
+
+    it('think 미지정: env 기본 OFF 면 INSTRUCT, 아니면 THINKING(서버 기본 ON)', () => {
+        expect(load({ LLM_DISABLE_THINKING_BY_DEFAULT: 'true' }).applyPreset(undefined, undefined)?.temperature).toBe(0.7);
+        expect(load({ LLM_DISABLE_THINKING_BY_DEFAULT: 'false' }).applyPreset(undefined, undefined)?.temperature).toBe(1.0);
+    });
+
+    it('호출자가 샘플링을 하나라도 지정하면 그대로 (메타 호출 temperature 보호)', () => {
+        const { applyPreset } = load({});
+        const o = { temperature: 0.1, num_predict: 150 };
+        expect(applyPreset(o, false)).toBe(o);
+        const p = { top_p: 0.5 };
+        expect(applyPreset(p, false)).toBe(p);
+    });
+
+    it('외부 provider 클라이언트는 건너뛴다', () => {
+        const { applyPreset } = load({});
+        expect(applyPreset(undefined, false, { external: true })).toBeUndefined();
+    });
+
+    it('게이트 OFF 면 입력 그대로', () => {
+        const { applyPreset } = load({ LLM_LOCAL_SAMPLING_PRESET_ENABLED: 'false' });
+        expect(applyPreset(undefined, false)).toBeUndefined();
+    });
+
+    it('env 로 개별 값 오버라이드', () => {
+        const { applyPreset } = load({ LLM_SAMPLING_INSTRUCT_TEMP: '0.5', LLM_SAMPLING_INSTRUCT_PRESENCE: '1.2' });
+        expect(applyPreset(undefined, false)).toMatchObject({ temperature: 0.5, presence_penalty: 1.2, top_p: 0.8 });
+    });
+});
+
+describe('isThinkingEnabled', () => {
+    it('false → off, 레벨/true → on, undefined → env', () => {
+        const a = load({ LLM_DISABLE_THINKING_BY_DEFAULT: 'true' });
+        expect(a.isThinkingEnabled(false)).toBe(false);
+        expect(a.isThinkingEnabled(true)).toBe(true);
+        expect(a.isThinkingEnabled('low')).toBe(true);
+        expect(a.isThinkingEnabled(undefined)).toBe(false);
+        expect(load({}).isThinkingEnabled(undefined)).toBe(true);
+    });
+});

--- a/apps/api/src/llm/client.ts
+++ b/apps/api/src/llm/client.ts
@@ -25,6 +25,7 @@ import { getApiUsageTracker } from './usage-tracker';
 import { checkUserQuota, recordUserUsage } from './user-quota';
 import { streamChat, nonStreamChat } from './stream-parser';
 import { buildExtraBody } from './reasoning-adapter';
+import { applyLocalSamplingPreset } from './sampling-preset';
 import { selectModelByCapacityExact } from './model-pool';
 import { MODEL_POOL_CONFIG } from '../config/model-pool';
 import {
@@ -157,9 +158,14 @@ export class LLMClient {
         })();
 
         const effectiveMessages = poolDecision.adjustedMessages ?? messages;
-        const effectiveOptions: ModelOptions | undefined = poolDecision.adjustedMaxTokens !== undefined
+        const fitOptions: ModelOptions | undefined = poolDecision.adjustedMaxTokens !== undefined
             ? { ...(options ?? {}), num_predict: poolDecision.adjustedMaxTokens }
             : options;
+        // 로컬 모델 샘플링 프리셋 — 호출자가 샘플링을 지정하지 않았을 때만 thinking ON/OFF 권장값을 채운다.
+        // 외부 provider 클라이언트(quotaExempt)는 각자 기본값을 쓰므로 건너뛴다.
+        const effectiveOptions = applyLocalSamplingPreset(
+            fitOptions, advancedOptions?.think, { external: this.config.quotaExempt === true },
+        );
 
         const request: ChatRequest = {
             model: poolDecision.model,

--- a/apps/api/src/llm/reasoning-adapter.ts
+++ b/apps/api/src/llm/reasoning-adapter.ts
@@ -26,6 +26,17 @@ export function thinkToReasoningEffort(t: ThinkOption | undefined): ReasoningEff
 }
 
 /**
+ * 이 요청에서 모델의 thinking 이 실제로 켜지는지 — buildExtraBody 의 enable_thinking 결정 규칙과 동일.
+ * `undefined` 는 env `LLM_DISABLE_THINKING_BY_DEFAULT` 가 true 면 OFF, 아니면 서버 기본(reasoning 모델은 ON).
+ * 샘플링 프리셋(llm/sampling-preset.ts) 선택에 쓴다.
+ */
+export function isThinkingEnabled(t: ThinkOption | undefined): boolean {
+    if (t === false) return false;
+    if (t !== undefined) return true;
+    return (process.env.LLM_DISABLE_THINKING_BY_DEFAULT ?? 'false').toLowerCase() !== 'true';
+}
+
+/**
  * think 옵션을 OpenAI SDK extra_body 로 변환.
  *
  * 두 가지 extra_body 키를 지원:

--- a/apps/api/src/llm/sampling-preset.ts
+++ b/apps/api/src/llm/sampling-preset.ts
@@ -1,0 +1,42 @@
+/**
+ * 로컬 모델 샘플링 프리셋 적용 — thinking ON/OFF 에 맞는 공식 권장값을 채운다 (2026-09-03).
+ *
+ * 배경: 채팅 본선·에이전트 턴 등 대부분의 로컬 호출은 temperature 를 넘기지 않아 vLLM 의
+ * `generation_config.json` 기본값(Qwen3.8: T 1.0 · top_p 0.95 — **추론 모드** 권장값)이 적용됐다.
+ * 그런데 앱 기본은 thinking OFF 라, 공식 비추론 권장(T 0.7 · top_p 0.8 · presence 1.5)과 어긋났다.
+ * 이 모듈은 LLMClient.chat 단일 지점에서 "호출자가 샘플링을 전혀 지정하지 않은" 로컬 요청에만
+ * 모드별 프리셋을 채운다. 호출자가 temperature 를 하나라도 지정했으면(메타 호출 0.1~0.4 등) 손대지
+ * 않고, 외부 provider 클라이언트(quotaExempt)는 건너뛴다 — 외부 모델은 각자 기본값이 맞다.
+ *
+ * @module llm/sampling-preset
+ */
+import { LOCAL_SAMPLING_PRESETS } from '../config/llm-parameters';
+import { isThinkingEnabled } from './reasoning-adapter';
+import type { ModelOptions, ThinkOption } from './types';
+
+export interface SamplingPresetContext {
+    /** 외부 provider 클라이언트(LLMConfig.quotaExempt) — 프리셋 미적용 */
+    external?: boolean;
+}
+
+/** 호출자가 샘플링 파라미터를 하나라도 지정했는지 — 지정했으면 프리셋을 덮지 않는다 */
+function hasCallerSampling(o: ModelOptions | undefined): boolean {
+    return !!o && (
+        o.temperature !== undefined || o.top_p !== undefined || o.top_k !== undefined
+        || o.presence_penalty !== undefined || o.repeat_penalty !== undefined || o.min_p !== undefined
+    );
+}
+
+/**
+ * thinking 상태에 맞는 프리셋을 채운 options 를 돌려준다.
+ * 게이트 OFF·외부 클라이언트·호출자 지정 샘플링이 있으면 입력 그대로.
+ */
+export function applyLocalSamplingPreset(
+    options: ModelOptions | undefined,
+    think: ThinkOption | undefined,
+    ctx: SamplingPresetContext = {},
+): ModelOptions | undefined {
+    if (!LOCAL_SAMPLING_PRESETS.ENABLED || ctx.external || hasCallerSampling(options)) return options;
+    const preset = isThinkingEnabled(think) ? LOCAL_SAMPLING_PRESETS.THINKING : LOCAL_SAMPLING_PRESETS.INSTRUCT;
+    return { ...(options ?? {}), ...preset };
+}

--- a/apps/api/src/routes/chat.routes.ts
+++ b/apps/api/src/routes/chat.routes.ts
@@ -308,7 +308,8 @@ router.post('/structured', optionalApiKey, optionalAuth, chatRateLimiter, asyncH
                 // finish_reason=length 로 잘려 JSON 파싱이 실패한다(실측 2026-08-24).
                 { num_predict: STRUCTURED_MAX_OUTPUT_TOKENS },
                 undefined,
-                { format, signal: abortController.signal },
+                // 구조화 출력은 thinking 을 명시적으로 끈다 — 추론 토큰이 strict 스키마 출력 예산을 잠식하지 않게.
+                { format, signal: abortController.signal, think: false },
             );
             return { text: result.content ?? '', truncated: result.metrics?.finish_reason === 'length' };
         };

--- a/apps/api/src/services/chat-strategies/discussion-strategy.ts
+++ b/apps/api/src/services/chat-strategies/discussion-strategy.ts
@@ -343,7 +343,8 @@ export class DiscussionStrategy implements ChatStrategy<DiscussionStrategyContex
                 }
                 // 토큰 콜백마다 abort 체크 → 클라이언트 단절 시 다음 토큰 직전에 stream 중단
                 checkAborted();
-            });
+            // 참가자 발언은 thinking 을 쓰지 않는다(위에서 thinking 토큰을 버리고 있었음) — env 기본값에 기대지 않고 명시
+            }, { think: false });
 
             return response;
         };

--- a/apps/api/src/services/deep-research/chat-with-timeout.ts
+++ b/apps/api/src/services/deep-research/chat-with-timeout.ts
@@ -42,5 +42,7 @@ export async function chatWithAbortTimeout(
     const signal = externalSignal
         ? AbortSignal.any([externalSignal, timeoutSignal])
         : timeoutSignal;
-    return client.chat(messages, options, undefined, { signal });
+    // 딥리서치 하위 호출은 모델 네이티브 thinking 을 쓰지 않는다 — 추론은 파이프라인(분해→검색→요약→병합→검증)이
+    // 담당한다. env 기본값에 기대지 않고 명시한다(추론 기본 ON 모델에서 청크 요약이 예산을 소진하던 실패 차단).
+    return client.chat(messages, options, undefined, { signal, think: false });
 }

--- a/apps/api/src/services/deep-research/report-generator.ts
+++ b/apps/api/src/services/deep-research/report-generator.ts
@@ -185,6 +185,7 @@ export async function generateReport(params: {
                 accumulatedChars += token.length;
                 onReportProgress?.(accumulatedChars);
             },
+            { think: false },
         );
         throwIfAborted();
 

--- a/apps/api/src/services/semantic-compactor.ts
+++ b/apps/api/src/services/semantic-compactor.ts
@@ -49,6 +49,9 @@ export async function semanticCompact(toolName: string, content: string): Promis
                 temperature: LLM_TEMPERATURES.SEMANTIC_COMPACTION,
                 num_predict: TOOL_RESULT_COMPACTION.SEMANTIC_MAX_TOKENS,
             },
+            undefined,
+            // 요약 예산이 작아(SEMANTIC_MAX_TOKENS) thinking 이 켜지면 본문이 비어 나온다 — 명시 OFF
+            { think: false },
         );
 
         const summary = result.content?.trim();

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -297,7 +297,7 @@ export async function handleChatMessage(
             imageMode: msg.imageMode === true,
             artifactMode: msg.artifactMode === true,
             thinkingMode: msg.thinkingMode === true,
-            thinkingLevel: (msg.thinkingLevel || 'high') as 'low' | 'medium' | 'high',
+            thinkingLevel: (msg.thinkingLevel || 'medium') as 'low' | 'medium' | 'high',
             style: msg.style,
             userAgentId: msg.userAgentId,
             // 이 턴에 발급한 스트리밍 messageId — assistant 행에 남겨 피드백 신호를


### PR DESCRIPTION
## 배경
Qwen3.8-27B 적용 점검(2026-09-03, 보고서 3-2·3-4·4-2·4-3) 후속.

- 로컬 호출 대부분(채팅 본선·에이전트 턴·REST)이 temperature 를 넘기지 않아 vLLM `generation_config.json` 기본값(T 1.0 · top_p 0.95 — **추론 모드** 권장값)이 적용됐다. 앱 기본은 thinking OFF 인데 공식 비추론 권장은 T 0.7 · top_p 0.8 · presence 1.5 다.
- 메타 호출 16곳의 thinking OFF 가 `LLM_DISABLE_THINKING_BY_DEFAULT` 한 줄에만 기대고 있었다. 그 env 가 바뀌거나 추론 기본 ON 모델을 붙이면 max_tokens 가 작은 요약·검증 호출이 추론만으로 예산을 소진해 빈 응답이 된다(B.AI glm 딥리서치 청크 요약 abort 와 같은 부류).
- REST `/api/chat` + `tools` 경로는 Gemini/GPT-OSS 시절 `PROMPT_TYPE_PRESETS`(top_k 10~20·repeat_penalty 1.05~1.15)를 로컬 Qwen 에 그대로 보냈다.
- thinking 토글에 레벨이 없으면 `high` → qwen3.8 정규화로 `xhigh`(최대 추론)가 됐다.

## 변경
- **`llm/sampling-preset.ts` + `LOCAL_SAMPLING_PRESETS`(config/llm-parameters.ts)**: `LLMClient.chat` 단일 지점에서 **호출자가 샘플링을 하나도 지정하지 않은 로컬 요청에만** thinking ON/OFF 별 프리셋을 채운다. THINKING T1.0/top_p0.95/top_k20/presence0/repetition1.0 · INSTRUCT T0.7/top_p0.8/top_k20/presence1.5/repetition1.0. 게이트 `LLM_LOCAL_SAMPLING_PRESET_ENABLED`(기본 true), 값별 env 오버라이드.
  - **외부 provider 클라이언트(`quotaExempt`)는 건너뛴다** — 외부 모델은 각자 기본값. 토론·딥리서치가 외부 모델로 돌 때 무영향
  - temperature 를 명시한 호출(딥리서치 0.1~0.4, 메모리 추출 0.1 등)은 그대로
  - repetition 1.0 은 서버 `--override-generation-config 1.05` 를 요청 단위로 되돌린다 — 비추론 반복 억제는 공식대로 presence_penalty 가 맡는다
- **`reasoning-adapter.isThinkingEnabled`**: `buildExtraBody` 와 같은 규칙으로 실효 thinking 판정
- **REST tools 경로**(`chat/external-tool-calling.ts`): `promptConfig.options` 전달 제거 → 로컬 프리셋으로 통일. (`promptConfig.enableThinking` 이 `think` 로 안 넘어가는 죽은 값은 그대로 — 별건)
- **메타 호출 `think:false` 명시 10곳**: 딥리서치 하위 호출(`chat-with-timeout` 단일점)·최종 보고서·토론 참가자·구조화 답변·semantic-compactor·카탈로그 번역·스킬 재작성·convention-checker·skill-creator. 사용자 원칙 "딥리서치 자체가 추론형 에이전트" 를 코드에 고정
- **thinking 레벨 폴백 high→medium**(WS·REST). 프론트 기본이 medium 이라 UI 경로는 무변화, API 클라이언트만 영향

## 검증
- 단위 테스트 8건(INSTRUCT/THINKING 선택·env 기본 OFF/ON·호출자 지정 보호·외부 skip·게이트 OFF·env 오버라이드·isThinkingEnabled)
- 관련 40 suites / 346 tests 통과, `tsc --noEmit` 오류 0, eslint 0
- 라이브(LiteLLM 경유 vLLM): 두 프리셋 5개 파라미터 모두 200 — INSTRUCT reasoning 0자, THINKING reasoning 201자

## 의도적으로 안 한 것
- `TOKEN_BUDGETS.THINKING_MIN_TOKENS` 상향 — 참조 0건(죽은 상수)이고 채팅 본선은 max_tokens 를 보내지 않아 무의미
- 프리셋 레벨 상수화(`'medium'` 리터럴) — 기존 스타일 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnmAE4r91oMdzncz1ZeiRv
