### PR TITLE
feat(providers): OpenAI 호환 외부 provider 에 추론 강도(reasoning_effort) 전송

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -222,6 +222,7 @@ ANSWER_VERIFICATION_ENABLED=false
 # 모델 접두어별 지원 강도 override (JSON). 새 모델 도입 시 배포 없이 대응.
 # 예: {"qwen3.8":["low","medium","xhigh"],"llama-4":["low","medium","high"]}
 # LLM_REASONING_EFFORTS_JSON=
+#   외부 provider 는 "<providerId>:<model prefix>" 키만 매칭 (예 {"bai:glm-5.3":["low","high"]}), 없으면 low/medium/high (2026-09-03)
 
 # Tail 라우팅 셰도우 모드. true 면 채팅 요청마다 tail 게이트 결정(errorScore·verifiability·isTail)을
 # 계산해 routing_shadow_decisions 테이블에 적재만 한다(실행 경로 무변경, 사용자 영향 0).

--- a/apps/api/src/config/reasoning-effort.test.ts
+++ b/apps/api/src/config/reasoning-effort.test.ts
@@ -56,4 +56,20 @@ describe('reasoning-effort 정규화', () => {
         resetReasoningEffortCache();
         expect(supportedEfforts('qwen3.8-27b')).not.toContain('high');
     });
+
+    it('providerId 가 외부면 provider 한정 키만 보고, 없으면 표준 3단 (bare 로컬 키가 새지 않음)', () => {
+        expect(supportedEfforts('qwen3.8-flash', 'bai')).toEqual(['low', 'medium', 'high']);
+        expect(normalizeEffort('qwen3.8-flash', 'xhigh', 'bai')).toBe('high');
+        // 로컬은 종전과 동일
+        expect(supportedEfforts('qwen3.8-27b', 'local-llm')).toContain('xhigh');
+    });
+
+    it('env 에 provider 한정 키를 주면 외부 모델도 개별 맵을 쓴다', () => {
+        process.env.LLM_REASONING_EFFORTS_JSON = JSON.stringify({ 'bai:glm-5.3': ['low', 'high'] });
+        resetReasoningEffortCache();
+        expect(supportedEfforts('glm-5.3-flash', 'bai')).toEqual(['low', 'high']);
+        expect(normalizeEffort('glm-5.3-flash', 'medium', 'bai')).toBe('high');
+        // 같은 키가 로컬 조회엔 안 잡힌다
+        expect(supportedEfforts('glm-5.3-flash')).toEqual(['low', 'medium', 'high']);
+    });
 });

--- a/apps/api/src/config/reasoning-effort.ts
+++ b/apps/api/src/config/reasoning-effort.ts
@@ -62,13 +62,23 @@ export function resetReasoningEffortCache(): void {
     _cached = null;
 }
 
-/** 모델이 받는 강도 목록 (미등록 모델은 보수적 기본값). */
-export function supportedEfforts(modelId: string | undefined): readonly ReasoningEffort[] {
+/**
+ * 모델이 받는 강도 목록 (미등록 모델은 보수적 기본값).
+ *
+ * `providerId` 가 로컬이 아니면 **provider 한정 키**(`"<providerId>:<model prefix>"`, 예 `"bai:glm-5.3"`)만
+ * 찾고, 없으면 OpenAI 표준 3단으로 폴백한다 — 로컬용 bare prefix(`qwen3.8` → xhigh 포함)가
+ * 외부의 같은 이름 모델(B.AI `qwen3.8-flash`)에 새어 나가 검증되지 않은 값(xhigh)을 보내지 않게.
+ * (2026-09-03 라이브: B.AI glm/qwen 은 low·medium·high 를 모두 200 으로 받는다.)
+ */
+export function supportedEfforts(modelId: string | undefined, providerId?: string): readonly ReasoningEffort[] {
     if (!modelId) return FALLBACK_SUPPORTED;
-    const lower = modelId.toLowerCase();
+    const external = !!providerId && providerId !== 'local-llm';
+    const lower = (external ? `${providerId}:${modelId}` : modelId).toLowerCase();
     let best: readonly ReasoningEffort[] | null = null;
     let bestLen = -1;
     for (const [prefix, list] of Object.entries(getModelEfforts())) {
+        // 외부는 provider 한정 키만, 로컬은 bare 키만 매칭 — 서로 새어 나가지 않는다.
+        if (external !== prefix.includes(':')) continue;
         if (lower.startsWith(prefix) && prefix.length > bestLen) {
             best = list;
             bestLen = prefix.length;
@@ -85,8 +95,9 @@ export function supportedEfforts(modelId: string | undefined): readonly Reasonin
 export function normalizeEffort(
     modelId: string | undefined,
     requested: ReasoningEffort,
+    providerId?: string,
 ): ReasoningEffort {
-    const supported = supportedEfforts(modelId);
+    const supported = supportedEfforts(modelId, providerId);
     if (supported.includes(requested)) return requested;
     const want = REASONING_EFFORT_LADDER.indexOf(requested);
     let best = supported[0];

--- a/apps/api/src/providers/__tests__/openai-compat-reasoning.test.ts
+++ b/apps/api/src/providers/__tests__/openai-compat-reasoning.test.ts
@@ -1,0 +1,27 @@
+import { buildReasoningEffortParams } from '../openai-compat-reasoning';
+
+describe('buildReasoningEffortParams', () => {
+    it('thinking 미지정/false 면 아무 파라미터도 싣지 않는다 (기존 요청과 동일)', () => {
+        expect(buildReasoningEffortParams(undefined, 'glm-5.3-flash', 'bai', false)).toEqual({});
+        expect(buildReasoningEffortParams(false, 'glm-5.3-flash', 'bai', false)).toEqual({});
+    });
+
+    it('직결 provider: reasoning_effort 만, 게이트웨이 힌트 없음', () => {
+        expect(buildReasoningEffortParams('low', 'glm-5.3-flash', 'bai', false)).toEqual({ reasoning_effort: 'low' });
+    });
+
+    it('게이트웨이 경유: LiteLLM 통과용 allowed_openai_params 동반', () => {
+        expect(buildReasoningEffortParams('high', 'gpt-oss-20b', 'hasa', true)).toEqual({
+            reasoning_effort: 'high', allowed_openai_params: ['reasoning_effort'],
+        });
+    });
+
+    it('레벨 미지정(true·budget 객체)은 medium 으로 해석', () => {
+        expect(buildReasoningEffortParams(true, 'x', 'hasa', true).reasoning_effort).toBe('medium');
+        expect(buildReasoningEffortParams({ budget: 1024 }, 'x', 'bai', false).reasoning_effort).toBe('medium');
+    });
+
+    it('외부 provider 의 같은 이름 모델에 로컬 xhigh 맵이 새지 않는다 — B.AI qwen3.8-flash high 는 high 그대로', () => {
+        expect(buildReasoningEffortParams('high', 'qwen3.8-flash', 'bai', false).reasoning_effort).toBe('high');
+    });
+});

--- a/apps/api/src/providers/openai-compat-provider.ts
+++ b/apps/api/src/providers/openai-compat-provider.ts
@@ -29,6 +29,7 @@ import {
 import { ProviderError } from './provider-errors';
 import type { ChatMessage, ToolDefinition, UsageMetrics } from '../llm';
 import { createLogger } from '../utils/logger';
+import { buildReasoningEffortParams } from './openai-compat-reasoning';
 import { createPinnedFetch } from '../security/ssrf-guard';
 import { needsExplicitPromptCache, toOpenAIMessages, toOpenAITools } from './openai-compat-mapping';
 import { PseudoToolCallGate } from '../llm/pseudo-tool-call-parser';
@@ -395,6 +396,8 @@ export class OpenAICompatProvider implements IProvider {
                 ...(opts.responseFormat ? { response_format: opts.responseFormat } : {}),
                 ...openRouterProvider,
                 ...geminiThinkingDisable,
+                // 추론 강도(UI 낮음·보통·높음) — Gemini 는 위 leak 차단으로 항상 OFF 라 제외.
+                ...(isGemini ? {} : buildReasoningEffortParams(opts.thinking, opts.modelId, this.id, !!this.modelPrefix)),
             };
 
             const stream = await this.client.chat.completions.create(

--- a/apps/api/src/providers/openai-compat-reasoning.ts
+++ b/apps/api/src/providers/openai-compat-reasoning.ts
@@ -1,0 +1,39 @@
+/**
+ * OpenAI 호환 외부 provider 의 추론 강도 파라미터 조립 (2026-09-03).
+ *
+ * 배경: `OpenAICompatProvider.chatStream` 은 `opts.thinking` 을 Gemini 추론 끄기에만 썼고 레벨을
+ * 전송하지 않아, UI 의 낮음·보통·높음이 외부 모델(hasa·B.AI·nvidia·ollama-cloud·openrouter)에서는
+ * 무시되고 모델 기본 강도로 돌았다(B.AI glm 이 항상 최대 추론으로 5분을 쓴 원인의 한 축).
+ *
+ * 라이브 프로브(2026-09-03, user 3 BYOK):
+ *   - B.AI 직결: `reasoning_effort` low/medium/high 모두 200
+ *   - LiteLLM 게이트웨이 경유(hasa·nvidia·ollama-cloud·openrouter): `reasoning_effort` 만 보내면 LiteLLM 이
+ *     provider 파라미터 검증에서 400(UnsupportedParamsError) — `allowed_openai_params:['reasoning_effort']`
+ *     힌트를 함께 보내면 통과하고 추론 토큰이 실제로 준다(gpt-oss 264→61, 204→19, 223→20; ling 58→14).
+ *     로컬 경로(llm/reasoning-adapter)와 같은 계약이다.
+ *
+ * 순수 함수 — provider 인스턴스 없이 테스트 가능.
+ * @module providers/openai-compat-reasoning
+ */
+import { normalizeEffort, type ReasoningEffort } from '../config/reasoning-effort';
+
+/** 외부 provider 로 보낼 추론 강도 파라미터 (없으면 빈 객체 — 기존 요청과 동일) */
+/** IProvider ChatOptions.thinking 과 동일 형태 */
+export type ProviderThinkingOption = boolean | ReasoningEffort | { budget: number };
+
+export function buildReasoningEffortParams(
+    thinking: ProviderThinkingOption | undefined,
+    modelId: string,
+    providerId: string,
+    viaGateway: boolean,
+): { reasoning_effort?: ReasoningEffort; allowed_openai_params?: string[] } {
+    if (thinking === undefined || thinking === false) return {};
+    // 레벨 미지정(true / budget 객체)은 로컬과 같은 해석 — 보통(medium). 외부는 xhigh 가 표준이 아니다.
+    const requested: ReasoningEffort = typeof thinking === 'string' ? thinking : 'medium';
+    const effort = normalizeEffort(modelId, requested, providerId);
+    return {
+        reasoning_effort: effort,
+        // LiteLLM 이 소비하는 힌트 — 직결 provider 엔 보내지 않는다(모르는 필드로 거절할 수 있음).
+        ...(viaGateway ? { allowed_openai_params: ['reasoning_effort'] } : {}),
+    };
+}


### PR DESCRIPTION
## 배경
Qwen3.8 적용 점검(2026-09-03) 후속 — 사용자 질문 "채팅창의 추론 낮음·보통·높음이 로컬 모델에만 맞춰져 있다". 코드 확인 결과 `openai-compat-provider.ts` 는 `opts.thinking` 을 Gemini 추론 끄기에만 쓰고 **레벨을 전송하지 않았다**. hasa·B.AI·nvidia·ollama-cloud·openrouter 모델은 토글과 무관하게 모델 기본 강도로 돌았고(B.AI glm 이 항상 최대 추론으로 5분을 쓰던 원인의 한 축), UI 3단은 로컬·ChatGPT OAuth 에서만 유효했다.

## 라이브 프로브 (user 3 BYOK, 2026-09-03)
| provider | 경로 | `reasoning_effort` 만 | + `allowed_openai_params` | 효과 |
|---|---|---|---|---|
| B.AI glm-5.3-flash / qwen3.8-flash | 직결 | low/medium/high/max 전부 200 | — | 수용 |
| hasa gpt-oss-20b | LiteLLM | 400 UnsupportedParamsError | 200 | reasoning 264→61 |
| nvidia openai/gpt-oss-20b | LiteLLM | 400 | 200 | 204→19 |
| ollama-cloud gpt-oss:20b | LiteLLM | 400 | 200 | 223→20 |
| openrouter ling-3.0-flash-fin:free | LiteLLM | 400 | 200 | 58→14 |

게이트웨이 경유는 로컬 경로(`llm/reasoning-adapter`)와 같은 힌트 계약이 필요하다.

## 변경
- **`providers/openai-compat-reasoning.ts`** (순수): `thinking` 레벨 → `reasoning_effort`. 레벨 미지정(true/budget)은 medium. 게이트웨이 경유면 `allowed_openai_params:['reasoning_effort']` 동반, 직결 provider 엔 보내지 않음. `thinking` 미지정/false 면 빈 객체 → 기존 요청과 동일
- **`openai-compat-provider.ts`**: requestParams 에 한 줄 spread. Gemini 는 기존 leak 차단(항상 OFF) 유지
- **`config/reasoning-effort.ts`**: `supportedEfforts`/`normalizeEffort` 에 `providerId` — 외부는 `"<provider>:<model prefix>"` 키만 매칭, 없으면 low/medium/high. 로컬 bare 키(`qwen3.8` → xhigh)가 외부의 같은 이름 모델(B.AI `qwen3.8-flash`)에 새지 않는다. env `LLM_REASONING_EFFORTS_JSON` 에 provider 한정 키를 넣으면 개별 맵 사용
- 모델이 thinking 을 지원하지 않으면 `resolveThinking` 이 이미 false 를 돌려주므로 비추론 모델엔 아무것도 실리지 않는다

## 검증
- 단위 테스트 7건(미지정/false 무전송·직결·게이트웨이 힌트·미지정 medium·외부 xhigh 누수 차단·provider 한정 env 키)
- 관련 29 suites / 255 tests 통과, `tsc --noEmit` 0, eslint 신규 0

## 다음
- 이 배선이 들어가면 모델×레벨 실측(추론 토큰·지연·정답률)으로 레벨 세분화를 검토할 수 있다(별건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnmAE4r91oMdzncz1ZeiRv
