### PR TITLE
fix(llm): 로컬 도구 루프에서 assistant reasoning 을 다음 턴에 보존 + vLLM tool_call id 보존

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -254,6 +254,8 @@ LLM_DISABLE_THINKING_BY_DEFAULT=true
 # 공식 권장값을 채운다 (Qwen3.8: 추론 T1.0/top_p0.95/presence0 · 비추론 T0.7/top_p0.8/presence1.5, repetition 1.0).
 # 외부 provider 클라이언트·temperature 를 명시한 호출(딥리서치 등)은 무영향. 'false' 로 끄면 종전처럼 서버 기본값.
 # LLM_LOCAL_SAMPLING_PRESET_ENABLED=true
+# 로컬 도구 루프에서 assistant 의 reasoning 을 다음 턴에 되돌려 보냄 (Qwen3.8 preserve_thinking 활용, 2026-09-03). 'false' 로 끄면 종전처럼 미전송
+# LLM_PRESERVE_THINKING=true
 # LLM_SAMPLING_THINKING_TEMP=1.0
 # LLM_SAMPLING_THINKING_TOP_P=0.95
 # LLM_SAMPLING_THINKING_TOP_K=20

--- a/apps/api/src/config/llm-parameters.ts
+++ b/apps/api/src/config/llm-parameters.ts
@@ -92,6 +92,15 @@ const samplingNum = (key: string, fallback: number): number => {
     const v = Number(process.env[key]);
     return Number.isFinite(v) && process.env[key] !== undefined && process.env[key] !== '' ? v : fallback;
 };
+/**
+ * 로컬 도구 루프에서 assistant 의 reasoning(thinking) 을 다음 턴 프롬프트에 되돌려 보낸다 (2026-09-03).
+ * Qwen3.8 chat template 은 `preserve_thinking` 이 기본 true 라 assistant 메시지의 `reasoning_content` 를
+ * 재주입한다 — 없으면 도구 호출 5턴 동안 매 라운드 직전 추론을 잃고 다시 생각한다(공식 권고 이탈).
+ * 로컬(LLMClient) wire 에만 적용 — 외부 provider 는 별도 변환(OpenAICompatProvider)이라 무영향
+ * (DeepSeek 등은 입력 reasoning_content 를 400 으로 거절한다).
+ */
+export const LOCAL_PRESERVE_THINKING_ENABLED = process.env.LLM_PRESERVE_THINKING !== 'false';
+
 export const LOCAL_SAMPLING_PRESETS = {
     ENABLED: process.env.LLM_LOCAL_SAMPLING_PRESET_ENABLED !== 'false',
     THINKING: {

--- a/apps/api/src/llm/__tests__/tool-loop-reasoning.test.ts
+++ b/apps/api/src/llm/__tests__/tool-loop-reasoning.test.ts
@@ -1,0 +1,43 @@
+/**
+ * 도구 루프 reasoning 보존 — env 게이트에 의존하므로 모듈을 격리 로드한다.
+ */
+export {};
+
+import type { ChatMessage } from '../types';
+
+function load(preserve: string | undefined) {
+    if (preserve === undefined) delete process.env.LLM_PRESERVE_THINKING; else process.env.LLM_PRESERVE_THINKING = preserve;
+    jest.resetModules();
+    const sp = require('../stream-parser') as typeof import('../stream-parser');
+    return sp.toOpenAIMessages;
+}
+const saved = process.env.LLM_PRESERVE_THINKING;
+afterAll(() => { if (saved === undefined) delete process.env.LLM_PRESERVE_THINKING; else process.env.LLM_PRESERVE_THINKING = saved; });
+
+const toolTurn: ChatMessage = {
+    role: 'assistant', content: '', thinking: '먼저 검색이 필요하다',
+    tool_calls: [{ id: 'chatcmpl-tool-1', type: 'function', function: { name: 'web_search', arguments: { q: 'x' } } }],
+};
+
+describe('toOpenAIMessages — reasoning 보존', () => {
+    it('assistant thinking 이 있으면 reasoning_content 로 싣는다 (tool_calls 턴·일반 턴 모두)', () => {
+        const convert = load(undefined);
+        const out = convert([toolTurn, { role: 'assistant', content: '답', thinking: '정리' }]) as Array<Record<string, unknown>>;
+        expect(out[0]).toMatchObject({ role: 'assistant', reasoning_content: '먼저 검색이 필요하다' });
+        expect((out[0].tool_calls as Array<{ id: string }>)[0].id).toBe('chatcmpl-tool-1');
+        expect(out[1]).toEqual({ role: 'assistant', content: '답', reasoning_content: '정리' });
+    });
+
+    it('thinking 이 없으면 필드 자체를 싣지 않는다 (기존 wire 와 동일)', () => {
+        const convert = load(undefined);
+        const out = convert([{ role: 'assistant', content: '답' }, { role: 'user', content: 'q' }]) as Array<Record<string, unknown>>;
+        expect(out[0]).toEqual({ role: 'assistant', content: '답' });
+        expect(out[1]).toEqual({ role: 'user', content: 'q' });
+    });
+
+    it('LLM_PRESERVE_THINKING=false 면 싣지 않는다', () => {
+        const convert = load('false');
+        const out = convert([toolTurn]) as Array<Record<string, unknown>>;
+        expect(out[0]).not.toHaveProperty('reasoning_content');
+    });
+});

--- a/apps/api/src/llm/stream-parser.ts
+++ b/apps/api/src/llm/stream-parser.ts
@@ -29,6 +29,7 @@ import { PseudoToolCallGate, stripPseudoToolCalls } from './pseudo-tool-call-par
 import { createLogger } from '../utils/logger';
 import { capPromptImages } from './prompt-image-cap';
 import { LLM_PROMPT_IMAGE_LIMITS } from '../config/runtime-limits';
+import { LOCAL_PRESERVE_THINKING_ENABLED } from '../config/llm-parameters';
 
 const log = createLogger('StreamParser');
 
@@ -107,7 +108,7 @@ export function toResponseFormat(f: FormatOption | undefined): Record<string, un
     };
 }
 
-function toOpenAIMessages(messages: ChatMessage[]): unknown[] {
+export function toOpenAIMessages(messages: ChatMessage[]): unknown[] {
     // 로컬 vLLM `--limit-mm-per-prompt` 페어 — history 포함 총량을 상한에 맞춘다(초과 시 400).
     const { messages: capped } = capPromptImages(messages, LLM_PROMPT_IMAGE_LIMITS.MAX_PER_REQUEST);
     return capped.map((m, idx) => {
@@ -131,10 +132,14 @@ function toOpenAIMessages(messages: ChatMessage[]): unknown[] {
             }
             return { role: m.role, content: blocks };
         }
+        // 도구 루프 reasoning 보존 — Qwen3.8 template(preserve_thinking) 이 다음 턴에 재주입한다.
+        const reasoning = LOCAL_PRESERVE_THINKING_ENABLED && m.role === 'assistant' && m.thinking
+            ? { reasoning_content: m.thinking } : {};
         if (m.role === 'assistant' && m.tool_calls && m.tool_calls.length > 0) {
             return {
                 role: 'assistant',
                 content: m.content || '',
+                ...reasoning,
                 tool_calls: m.tool_calls.map((tc, i) => ({
                     // 진짜 id (vLLM 발급) 우선, 누락 시에만 합성 fallback.
                     id: tc.id ?? `call_${tc.function.name}_${i}`,
@@ -146,7 +151,7 @@ function toOpenAIMessages(messages: ChatMessage[]): unknown[] {
                 })),
             };
         }
-        return { role: m.role, content: m.content };
+        return { role: m.role, content: m.content, ...reasoning };
     });
 }
 

--- a/apps/api/src/providers/local-llm-provider.ts
+++ b/apps/api/src/providers/local-llm-provider.ts
@@ -232,7 +232,8 @@ export class LocalLLMProvider implements IProvider {
 
             // tool_calls 정규화: ToolCall (function-shape) → IProvider {id, name, args}
             const toolCalls = (result.tool_calls ?? []).map((tc: ToolCall, idx: number) => ({
-                id: `local-llm-tool-${Date.now()}-${idx}`,
+                // vLLM 발급 id 를 보존한다 — 업스트림 로그와의 상관 추적 + 같은 ms 병렬 배치 충돌 방지.
+                id: tc.id ?? `local-llm-tool-${Date.now()}-${idx}`,
                 name: tc.function.name,
                 args: tc.function.arguments,
             }));

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -271,6 +271,8 @@ export async function runExternalStream(
             messages.push({
                 role: 'assistant',
                 content: result.content || '',
+                // 직전 추론을 다음 턴에 보존 — 로컬 wire(toOpenAIMessages)만 reasoning_content 로 싣는다.
+                ...(result.thinking ? { thinking: result.thinking } : {}),
                 tool_calls: result.toolCalls.map((tc) => ({
                     type: 'function' as const,
                     id: tc.id,


### PR DESCRIPTION
## 배경
Qwen3.8-27B 점검(2026-09-03) 3-3·4-6 후속. Qwen3.8 chat template 은 `preserve_thinking` 기본 true 라 assistant 메시지의 `reasoning_content` 를 다음 턴 프롬프트에 재주입하는데, 앱의 always-on 도구 루프는 assistant tool_calls 메시지를 `content + tool_calls` 만으로 push 하고 `toOpenAIMessages` 도 `reasoning_content` 를 싣지 않았다. thinking ON 채팅에서 도구 호출 5턴 동안 매 라운드 직전 추론을 잃고 다시 생각해 추론 토큰이 중복 소모됐다.

## 변경
- `llm/stream-parser.ts` `toOpenAIMessages`: assistant 의 `thinking` 이 있으면 `reasoning_content` 로 동반(tool_calls 턴·일반 턴). 없으면 필드 자체를 싣지 않아 기존 wire 와 동일. **로컬(LLMClient) wire 전용** — 외부 provider 는 `OpenAICompatProvider` 별도 변환이라 무영향(DeepSeek 등은 입력 `reasoning_content` 를 400 으로 거절한다). 게이트 `LLM_PRESERVE_THINKING`(기본 true)
- `services/chat-service/external-provider.ts`: 도구 루프 push 에 `result.thinking` 동반
- `providers/local-llm-provider.ts`: vLLM 발급 tool_call id 를 `local-llm-tool-${Date.now()}-${idx}` 로 덮지 않고 보존 — 같은 ms 병렬 배치 id 충돌 방지 + 업스트림 로그 상관 추적
- `.env.example`

## 검증
- 단위 테스트 3건(reasoning_content 동반·미존재 시 필드 없음·게이트 OFF)
- 관련 40 suites / 383 tests, `tsc --noEmit` 0, eslint 신규 0
- 라이브(LiteLLM 경유 vLLM): assistant `reasoning_content` + tool_calls + tool 결과 history 를 200 으로 수용

## 머지
- 사용자 지시에 따라 백로그 4건이 모두 끝난 뒤 순차 머지 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCNXFhzLDLLRdw3Xp6i4zy