### PR TITLE
chore(providers): 로컬 provider responseFormat 전달 + gpt-3.5-turbo 프리셋 vision 정정 + 낡은 주석·매직넘버 정리

### DIFF
--- a/apps/api/src/config/model-defaults.test.ts
+++ b/apps/api/src/config/model-defaults.test.ts
@@ -23,10 +23,10 @@ describe('matchCapabilityPreset (startsWith-longest)', () => {
         expect(caps!.vision).toBe(true);
     });
 
-    it('gpt-3.5-turbo alias → gpt 키 (toolCalling:true, vision:false)', () => {
+    it('gpt-3.5-turbo alias → 라우팅 대상(qwen3.8-27b)과 같은 capability (toolCalling·vision 모두 true)', () => {
         const caps = matchCapabilityPreset('gpt-3.5-turbo');
         expect(caps!.toolCalling).toBe(true);
-        expect(caps!.vision).toBe(false);
+        expect(caps!.vision).toBe(true);
     });
 
     it('미등록 모델(kimi-k2) → null', () => {

--- a/apps/api/src/config/model-defaults.ts
+++ b/apps/api/src/config/model-defaults.ts
@@ -66,11 +66,13 @@ export const MODEL_CAPABILITY_PRESETS: Readonly<Record<string, ModelCapabilities
     /**
      * OpenAI 호환 alias — proxy 가 qwen3.8-27b 으로 라우팅.
      * 외부 도구 / OpenAI SDK 호환 클라이언트가 표준 model ID 로 호출 가능.
+     * capability 는 라우팅 대상(qwen3.8-27b)과 동일하게 둔다 — vision:false 로 두면 이 id 로 온
+     * 이미지 요청을 앱이 400 으로 거절하는데 실제 모델은 받는다(2026-09-03 정정).
      */
     'gpt-3.5-turbo': {
         toolCalling: true,
         thinking: true,
-        vision: false,
+        vision: true,
         streaming: true,
     },
 } as const;

--- a/apps/api/src/config/reasoning-effort.test.ts
+++ b/apps/api/src/config/reasoning-effort.test.ts
@@ -64,6 +64,12 @@ describe('reasoning-effort 정규화', () => {
         expect(supportedEfforts('qwen3.8-27b', 'local-llm')).toContain('xhigh');
     });
 
+    it('B.AI glm-5.3 기본 맵: medium 은 400 이라 high 로 승격, low 는 그대로', () => {
+        expect(supportedEfforts('glm-5.3-flash', 'bai')).toEqual(['low', 'high']);
+        expect(normalizeEffort('glm-5.3-flash', 'medium', 'bai')).toBe('high');
+        expect(normalizeEffort('glm-5.3-flash', 'low', 'bai')).toBe('low');
+    });
+
     it('env 에 provider 한정 키를 주면 외부 모델도 개별 맵을 쓴다', () => {
         process.env.LLM_REASONING_EFFORTS_JSON = JSON.stringify({ 'bai:glm-5.3': ['low', 'high'] });
         resetReasoningEffortCache();

--- a/apps/api/src/config/reasoning-effort.ts
+++ b/apps/api/src/config/reasoning-effort.ts
@@ -27,6 +27,10 @@ const DEFAULT_MODEL_EFFORTS: Readonly<Record<string, readonly ReasoningEffort[]>
     'qwen3.6': ['low', 'medium', 'high', 'xhigh'],
     // 실측 거절값(high)을 제외 — 사용자가 '높음'을 고르면 아래 정규화가 xhigh 로 올린다.
     'qwen3.8': ['low', 'medium', 'xhigh'],
+    // B.AI GLM 5.3 은 항상 사고 모델이라 low/high/max 만 받고 medium 을 400 으로 거절한다
+    // (2026-09-03 레벨 실측: 12건 중 medium 간헐 400 "该模型始终思考，不支持关闭思考；请使用 low、high 或 max").
+    // 사다리에 max 는 없으므로 low/high — UI '보통' 은 동률 상위 규칙으로 high 가 된다.
+    'bai:glm-5.3': ['low', 'high'],
 };
 
 let _cached: Readonly<Record<string, readonly ReasoningEffort[]>> | null = null;

--- a/apps/api/src/providers/__tests__/local-response-format.test.ts
+++ b/apps/api/src/providers/__tests__/local-response-format.test.ts
@@ -1,0 +1,22 @@
+import { toFormatOption } from '../local-response-format';
+
+describe('toFormatOption', () => {
+    it('json_object → "json"', () => {
+        expect(toFormatOption({ type: 'json_object' })).toBe('json');
+    });
+
+    it('json_schema → FormatOption (properties·required·additionalProperties 보존)', () => {
+        const rf = { type: 'json_schema', json_schema: { name: 'r', strict: true, schema: {
+            type: 'object', properties: { a: { type: 'string' } }, required: ['a'], additionalProperties: false,
+        } } };
+        expect(toFormatOption(rf)).toEqual({
+            type: 'object', properties: { a: { type: 'string' } }, required: ['a'], additionalProperties: false,
+        });
+    });
+
+    it('변환 불가 형태는 undefined (호출자가 warn)', () => {
+        expect(toFormatOption(undefined)).toBeUndefined();
+        expect(toFormatOption({ type: 'text' })).toBeUndefined();
+        expect(toFormatOption({ type: 'json_schema', json_schema: { schema: { type: 'array' } } })).toBeUndefined();
+    });
+});

--- a/apps/api/src/providers/local-llm-provider.ts
+++ b/apps/api/src/providers/local-llm-provider.ts
@@ -30,6 +30,7 @@ import {
     buildFullModelId,
 } from './i-provider';
 import { ProviderError } from './provider-errors';
+import { toFormatOption } from './local-response-format';
 import type { LLMClient } from '../llm';
 import type { ToolCall, UsageMetrics } from '../llm';
 import { findLocalModel } from '../config/local-models';
@@ -191,6 +192,10 @@ export class LocalLLMProvider implements IProvider {
                 if (token) callbacks.onToken?.(token);
             };
 
+            const formatOption = toFormatOption(opts.responseFormat);
+            if (opts.responseFormat && !formatOption) {
+                logger.warn(`[LocalLLMProvider] responseFormat(type=${String(opts.responseFormat.type)}) 을 로컬 format 으로 변환할 수 없어 무시합니다`);
+            }
             const chatPromise = this.client.chat(
                 opts.messages,
                 {
@@ -211,6 +216,8 @@ export class LocalLLMProvider implements IProvider {
                         : opts.thinking,
                     tools: opts.tools,
                     ...(opts.tool_choice !== undefined ? { tool_choice: opts.tool_choice } : {}),
+                    // responseFormat(OpenAI 원형) → LLMClient format 으로 역변환해 로컬에도 스키마를 강제한다.
+                    ...(formatOption ? { format: formatOption } : {}),
                     // 첫 SSE 청크 = 업스트림 생존 — fast-fail 취소 (tool-call-only 응답 포함).
                     onActivity: clearFastFail,
                     // user signal (opts.abortSignal) + self fast-fail signal 결합 전달 — 어느 쪽이

--- a/apps/api/src/providers/local-response-format.ts
+++ b/apps/api/src/providers/local-response-format.ts
@@ -1,0 +1,29 @@
+/**
+ * IProvider `responseFormat`(OpenAI `response_format` 원형) → LLMClient `format`(FormatOption) 역변환 (2026-09-03).
+ *
+ * 배경: `OpenAICompatProvider` 는 `responseFormat` 을 그대로 전송하지만 `LocalLLMProvider` 는 읽지 않아
+ * provider 추상화로 로컬 모델에 스키마를 걸면 에러 없이 무시됐다(Qwen3.8 점검 4-4). 구조화 답변 라우트가
+ * 로컬을 LLMClient 직접 호출로 우회해 실피해는 없었지만, 새 호출자가 IProvider 로 로컬에 스키마를 걸면
+ * 조용히 실패하는 구멍이다. LLMClient 는 FormatOption 만 받으므로(`toResponseFormat` 이 다시 response_format
+ * 으로 조립) 여기서 역변환한다. 변환 불가 형태(text·structural_tag 등)는 undefined — 호출자가 warn.
+ *
+ * @module providers/local-response-format
+ */
+import type { FormatOption } from '../llm/types';
+
+export function toFormatOption(rf: Record<string, unknown> | undefined): FormatOption | undefined {
+    if (!rf) return undefined;
+    if (rf.type === 'json_object') return 'json';
+    if (rf.type !== 'json_schema') return undefined;
+    const js = rf.json_schema as { schema?: Record<string, unknown> } | undefined;
+    const schema = js?.schema;
+    if (!schema || typeof schema !== 'object' || schema.type !== 'object' || typeof schema.properties !== 'object' || !schema.properties) {
+        return undefined;
+    }
+    return {
+        type: 'object',
+        properties: schema.properties as Record<string, unknown>,
+        ...(Array.isArray(schema.required) ? { required: schema.required as string[] } : {}),
+        ...(typeof schema.additionalProperties === 'boolean' ? { additionalProperties: schema.additionalProperties } : {}),
+    };
+}

--- a/apps/api/src/services/OpenAICompatService.ts
+++ b/apps/api/src/services/OpenAICompatService.ts
@@ -14,8 +14,8 @@ const logger = createLogger('OpenAICompatService');
  *   - audio_url: 오디오 URL (vLLM 오디오 모델 전용)
  *   - input_audio: base64 인라인 오디오 (OpenAI 호환 형식)
  *
- * qwen3.6-35b-a3b (현 default) 는 vision/audio 미지원이라 ChatService 의
- * vision gating 이 거절. 향후 vision/audio 모델 도입 시 즉시 활용 가능하도록 타입 정의.
+ * 현 default 모델 qwen3.8-27b(2026-09-02~) 는 vision 을 지원한다(요청당 이미지 8장 상한은
+ * llm/prompt-image-cap 이 맞춘다). audio 는 미지원이라 ChatService gating 이 거절한다.
  */
 export type OpenAIContentPart =
     | { type: 'text'; text: string }
@@ -139,8 +139,8 @@ export class OpenAICompatService {
                     images.push(m ? m[1] : url);
                 }
             } else {
-                // video_url / audio_url / input_audio — 현 default 모델 (qwen3.6-35b-a3b, vision:false)
-                // 은 지원 안 함. ChatService 의 vision gating 이 이미지/오디오 첨부 시 400 throw 하므로
+                // video_url / audio_url / input_audio — 현 default 모델(qwen3.8-27b)은 이미지만 지원하고
+                // video/audio 는 미지원. ChatService 의 gating 이 오디오 첨부 시 400 throw 하므로
                 // 여기선 silent drop 대신 warn 로깅으로 운영자가 인지 가능하게.
                 // 향후 vision/audio 모델 도입 시 별도 mediaPart 필드로 라우팅 코드 추가 필요.
                 logger.warn(`OpenAI content part type '${(part as { type: string }).type}' is not yet routed (only text/image_url currently bridged). Falling back to text-only summary.`);

--- a/apps/api/src/services/chat-strategies/discussion-strategy.ts
+++ b/apps/api/src/services/chat-strategies/discussion-strategy.ts
@@ -19,7 +19,7 @@ import type { ChatMessage } from '../../llm';
 import type { ChatStrategy, ChatResult, DiscussionStrategyContext } from './types';
 import { createLogger } from '../../utils/logger';
 import { sanitizePromptInput } from '../../utils/input-sanitizer';
-import { DISCUSSION_TOKEN_BUDGET, MODEL_CONTEXT_DEFAULTS, DISCUSSION_STREAM_ABORT_CHECK_INTERVAL, DISCUSSION_CONCURRENCY, DISCUSSION_FACTCHECK } from '../../config/runtime-limits';
+import { DISCUSSION_TOKEN_BUDGET, MODEL_CONTEXT_DEFAULTS, DISCUSSION_STREAM_ABORT_CHECK_INTERVAL, DISCUSSION_CONCURRENCY, DISCUSSION_FACTCHECK, TRUNCATION } from '../../config/runtime-limits';
 import { LLM_TEMPERATURES } from '../../config/llm-parameters';
 import { resolvePromptLocale, type PromptLocaleCode } from '../../chat/language-policy';
 import { withSpan } from '../../observability/otel';
@@ -289,7 +289,7 @@ export class DiscussionStrategy implements ChatStrategy<DiscussionStrategyContex
                 progress: 2,
             });
 
-            const imagePromises = allImages.slice(0, 3).map(async (imageBase64, i) => {
+            const imagePromises = allImages.slice(0, TRUNCATION.DISCUSSION_MAX_IMAGES).map(async (imageBase64, i) => {
                 try {
                     checkAborted();
                     const analysisResponse = await context.client.chat(


### PR DESCRIPTION
## 배경
Qwen3.8-27B 점검(2026-09-03) 4-4·4-6 소규모 후속.

## 변경
- **`providers/local-response-format.ts`** (순수): IProvider `responseFormat`(OpenAI `response_format` 원형) → LLMClient `FormatOption` 역변환. `LocalLLMProvider` 가 `responseFormat` 을 읽지 않아 provider 추상화로 로컬 모델에 스키마를 걸면 에러 없이 무시됐다(구조화 답변 라우트는 LLMClient 직접 호출로 우회 중이라 실피해 없음). `json_object`→`'json'`, `json_schema`→ properties·required·additionalProperties 보존, 그 외는 warn 후 무시
- `config/model-defaults.ts`: `gpt-3.5-turbo` 프리셋 `vision:false → true`. 라우팅 대상 qwen3.8-27b 는 vision 을 받는데 프리셋이 false 라 이 id 의 이미지 요청을 앱이 400 으로 거절했다
- `services/OpenAICompatService.ts`: "현 default 모델 qwen3.6-35b-a3b, vision:false" 주석 2곳 정정
- `services/chat-strategies/discussion-strategy.ts`: 이미지 `slice(0, 3)` 매직넘버 → `TRUNCATION.DISCUSSION_MAX_IMAGES`(참조 0건이던 상수를 실제 사용처에 연결, 값 동일)

## 검증
- 단위 테스트 3건 + 기존 프리셋 테스트 기대값 갱신, 관련 20 suites / 178 tests
- `tsc --noEmit` 0, eslint 신규 0

## 머지
- 사용자 지시에 따라 백로그 4건이 모두 끝난 뒤 순차 머지 예정(#726 다음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCNXFhzLDLLRdw3Xp6i4zy