### PR TITLE
fix(llm): 로컬 모델 프로브 demote 영구 고착 해소 + 외부 모델 캐시 capabilitiesInferred 유실 수정

### DIFF
--- a/apps/api/src/__tests__/probe-sticky-down.test.ts
+++ b/apps/api/src/__tests__/probe-sticky-down.test.ts
@@ -1,0 +1,100 @@
+/**
+ * probeLocalModelAvailability — demote 된 모델의 회복(up) 회귀 테스트.
+ *
+ * 2026-09-03 운영 실측: ping 1회 abort 로 demote 된 qwen3.8-27b 를 다음 주기 프로브가
+ * `available === false` = "명시 비활성" 으로 보고 건너뛰어, 재시작 전까지 6시간 `skipped` 로 남았다.
+ * 건너뛰는 것은 카탈로그 명시 비활성(사유 없음 / EXPLICIT_DISABLED_REASON)뿐이어야 한다.
+ */
+import {
+    probeLocalModelAvailability,
+    getLocalModels,
+    EXPLICIT_DISABLED_REASON,
+} from '../config/local-models';
+
+type LocalModelEntry = ReturnType<typeof getLocalModels>[number];
+
+const originalFetch = global.fetch;
+let chatPingedModels: string[] = [];
+
+beforeEach(() => {
+    chatPingedModels = [];
+    global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? JSON.parse(String(init.body)) : {};
+        if (url.endsWith('/v1/models')) {
+            return { ok: true, status: 200, json: async () => ({ data: getLocalModels().map(m => ({ id: m.id })) }) } as Response;
+        }
+        if (url.endsWith('/v1/chat/completions')) {
+            chatPingedModels.push(body.model);
+            return { ok: true, status: 200, json: async () => ({ choices: [{ message: { content: 'x' } }] }) } as Response;
+        }
+        if (url.endsWith('/v1/embeddings')) {
+            return { ok: true, status: 200, json: async () => ({ data: [{ embedding: [0] }] }) } as Response;
+        }
+        // /model/info(발견)·기타 실측 호출은 실패로 — 카탈로그 변경 없음
+        return { ok: false, status: 404, json: async () => ({}) } as Response;
+    }) as typeof fetch;
+});
+
+afterEach(() => {
+    global.fetch = originalFetch;
+});
+
+describe('probeLocalModelAvailability — demote 회복', () => {
+    let snapshot: LocalModelEntry[];
+    beforeEach(() => { snapshot = getLocalModels().map(m => ({ ...m })); });
+    afterEach(() => {
+        const live = getLocalModels();
+        for (let i = 0; i < live.length; i++) Object.assign(live[i], snapshot[i]);
+    });
+
+    test('직전 ping 실패로 demote 된 모델은 다음 프로브에서 다시 ping 해 회복한다', async () => {
+        const chat = getLocalModels().find(m => m.role === 'chat');
+        if (!chat) return;
+        chat.available = false;
+        chat.unavailableReason = 'This operation was aborted';
+
+        const r = await probeLocalModelAvailability('http://test', 'sk-test', 1000);
+        expect(r.probed).toBe(true);
+        expect(chatPingedModels).toContain(chat.id);
+        expect(r.available).toContain(chat.id);
+        expect(r.skipped).not.toContain(chat.id);
+        expect(chat.available).toBe(true);
+        expect(chat.unavailableReason).toBeUndefined();
+    });
+
+    test('런타임 fallback 이 demote 한 모델(runtime: …)도 다시 ping 한다', async () => {
+        const chat = getLocalModels().find(m => m.role === 'chat');
+        if (!chat) return;
+        chat.available = false;
+        chat.unavailableReason = 'runtime: fast-fail-timeout';
+
+        const r = await probeLocalModelAvailability('http://test', 'sk-test', 1000);
+        expect(chatPingedModels).toContain(chat.id);
+        expect(r.available).toContain(chat.id);
+    });
+
+    test('카탈로그 명시 비활성(사유 없음)은 ping 하지 않고 사유를 고정한다', async () => {
+        const chat = getLocalModels().find(m => m.role === 'chat');
+        if (!chat) return;
+        chat.available = false;
+        chat.unavailableReason = undefined;
+
+        const r = await probeLocalModelAvailability('http://test', 'sk-test', 1000);
+        expect(chatPingedModels).not.toContain(chat.id);
+        expect(r.skipped).toContain(chat.id);
+        expect(chat.available).toBe(false);
+        expect(chat.unavailableReason).toBe(EXPLICIT_DISABLED_REASON);
+    });
+
+    test('명시 비활성은 두 번째 프로브에서도 계속 건너뛴다', async () => {
+        const chat = getLocalModels().find(m => m.role === 'chat');
+        if (!chat) return;
+        chat.available = false;
+        chat.unavailableReason = EXPLICIT_DISABLED_REASON;
+
+        const r = await probeLocalModelAvailability('http://test', 'sk-test', 1000);
+        expect(chatPingedModels).not.toContain(chat.id);
+        expect(r.skipped).toContain(chat.id);
+    });
+});

--- a/apps/api/src/config/local-models.ts
+++ b/apps/api/src/config/local-models.ts
@@ -37,6 +37,9 @@ import { fetchGatewayModelInfo, selectLocalEntriesFromModelInfo } from './local-
 
 const logger = createLogger('LocalModels');
 
+/** 카탈로그(또는 LLM_LOCAL_MODELS_JSON)가 명시적으로 비활성한 모델의 사유 — 프로브가 ping 을 건너뛰는 유일한 조건 */
+export const EXPLICIT_DISABLED_REASON = 'explicit disabled';
+
 export type LocalModelRole = 'chat' | 'embedding';
 
 export interface LocalModelEntry {
@@ -410,7 +413,7 @@ async function pingEmbeddingModel(
  *
  * 동작:
  *   - probe 미가용 (네트워크 timeout, proxy 미가용): 카탈로그 그대로 유지 (보수적)
- *   - Stage 2 ping 실패한 모델: available=false (demote)
+ *   - Stage 2 ping 실패한 모델: available=false (demote) — 다음 주기에 다시 ping 해 회복(up) 가능
  *   - 카탈로그의 explicit available=false 모델: ping 시도조차 안 함 (운영자가 명시적 비활성)
  *
  * @param llmBaseUrl proxy base URL (예: http://<llm-host>:13401)
@@ -453,8 +456,11 @@ export async function probeLocalModelAvailability(
     const skipped: string[] = [];
     const pingTargets: LocalModelEntry[] = [];
     for (const m of list) {
-        if (m.available === false) {
-            if (!m.unavailableReason) m.unavailableReason = 'explicit disabled';
+        // 건너뛰는 것은 카탈로그가 **명시적으로** 비활성한 모델뿐이다. 직전 프로브·런타임 fallback 이
+        // demote 한 모델(사유가 있음)은 매 주기 다시 ping 해야 회복된다 — 그렇지 않으면 일시 abort 1회로
+        // 재시작 전까지 영구 '사용 불가' 가 된다(2026-09-03 qwen3.8-27b 6시간 실측).
+        if (m.available === false && (!m.unavailableReason || m.unavailableReason === EXPLICIT_DISABLED_REASON)) {
+            m.unavailableReason = EXPLICIT_DISABLED_REASON;
             skipped.push(m.id);
             continue;
         }

--- a/apps/api/src/routes/model.routes.ts
+++ b/apps/api/src/routes/model.routes.ts
@@ -31,6 +31,7 @@ import {
 import { buildFullModelId } from '../providers/i-provider';
 import { getProviderCatalogEntry } from '../config/external-providers';
 import { isRoleAssignableModel } from '../config/role-model-filter';
+import { toCachedModelEntry, type CachedModelRow } from '../services/chat-service/model-capabilities';
 
 const router = Router();
 const logger = createLogger('ModelRoutes');
@@ -44,7 +45,7 @@ const logger = createLogger('ModelRoutes');
  */
 function getProviderFallbackModels(
     providerId: string,
-): Array<{ id: string; fullId: string; displayName: string; capabilities: Record<string, boolean>; isFree?: boolean }> {
+): CachedModelRow[] {
     const entry = getProviderCatalogEntry(providerId);
     if (!entry?.fallbackModels?.length) return [];
     return entry.fallbackModels.map(m => ({
@@ -165,16 +166,8 @@ router.get('/models', optionalAuth, asyncHandler(async (req: Request, res: Respo
                             process.env.EXTERNAL_MODELS_CACHE_TTL_MS ?? '3600000',
                             10,
                         );
-                        type CachedModel = {
-                            id: string;
-                            fullId: string;
-                            displayName: string;
-                            capabilities: Record<string, boolean>;
-                            isFree?: boolean;
-                            pricing?: { input: number; output: number };
-                        };
                         const cached = await repo.getCachedModels(userId, keyRow.providerId, cacheTtlMs);
-                        let list: CachedModel[] | null = cached as CachedModel[] | null;
+                        let list: CachedModelRow[] | null = cached as CachedModelRow[] | null;
 
                         if (!list || list.length === 0) {
                             const plaintextKey = await repo.decryptKey(userId, keyRow.providerId);
@@ -189,14 +182,8 @@ router.get('/models', optionalAuth, asyncHandler(async (req: Request, res: Respo
                                     : undefined,
                             );
                             const fresh = await provider.listModels();
-                            list = fresh.map((m) => ({
-                                id: m.id,
-                                fullId: m.fullId,
-                                displayName: m.displayName,
-                                capabilities: m.capabilities as unknown as Record<string, boolean>,
-                                isFree: m.isFree,
-                                pricing: m.pricing,
-                            }));
+                            // 캐시 행 형태는 model-capabilities 의 단일점을 쓴다(capabilitiesInferred 유실 방지)
+                            list = fresh.map(toCachedModelEntry);
                             // 빈 배열은 캐싱 안 함 (stale 영구화 방지) + provider별 fallback 모델 보강
                             if (list.length === 0) {
                                 list = getProviderFallbackModels(keyRow.providerId);

--- a/apps/api/src/services/chat-service/__tests__/model-capabilities.test.ts
+++ b/apps/api/src/services/chat-service/__tests__/model-capabilities.test.ts
@@ -5,7 +5,8 @@
  * 진짜 비전 모델(meta/llama-4-maverick…)을 vision:false 로 오판 → 이미지 요청이
  * 400 으로 조기 차단됐다. 카탈로그 우선 해석과 출처 표기를 고정한다.
  */
-import { resolveModelCapabilities } from '../model-capabilities';
+import { resolveModelCapabilities, toCachedModelEntry } from '../model-capabilities';
+import type { ProviderModel } from '../../../providers/i-provider';
 import type { ResolvedProvider } from '../../../providers/provider-router';
 import type { ProviderCapabilities } from '../../../providers/i-provider';
 
@@ -107,5 +108,41 @@ describe('resolveModelCapabilities', () => {
         const r = await resolveModelCapabilities(makeResolved('chatgpt', 'gpt-5.4'));
         expect(r.source).toBe('config'); // chatgpt 카탈로그에 gpt-5.4 등록됨
         expect(r.caps.vision).toBe(true);
+    });
+});
+
+describe('toCachedModelEntry — 캐시 쓰기 형태가 읽기 채택 조건을 보존한다', () => {
+    // 2026-09-04 운영 실측: model.routes 가 필드를 손으로 골라 복사하다 capabilitiesInferred 를 떨어뜨려
+    // 캐시 전 행이 undefined → ② 의 `=== false` 채택이 영구 거짓(#713 무력, B.AI vision 거절 재현).
+    function makeModel(over: Partial<ProviderModel>): ProviderModel {
+        return {
+            id: 'm', fullId: 'p:m', displayName: 'M', contextWindow: 1, outputLimit: 1,
+            capabilities: { vision: true, toolCalling: true, streaming: true, thinking: false },
+            ...over,
+        } as ProviderModel;
+    }
+
+    it('capabilitiesInferred=false 를 보존해 실보고 행이 catalog 로 채택된다', async () => {
+        const row = toCachedModelEntry(makeModel({ id: 'meta/llama-4-maverick', capabilitiesInferred: false }));
+        expect(row.capabilitiesInferred).toBe(false);
+        const r = await resolveModelCapabilities(makeResolved('nvidia', 'meta/llama-4-maverick'), 'u1', makeRepo([row]));
+        expect(r.source).toBe('catalog');
+        expect(r.caps.vision).toBe(true);
+    });
+
+    it('capabilitiesInferred=true 를 보존해 휴리스틱 행이 config 를 가리지 않는다', async () => {
+        const row = toCachedModelEntry(makeModel({
+            id: 'qwen3.8-flash', capabilitiesInferred: true,
+            capabilities: { vision: false, toolCalling: true, streaming: true, thinking: false },
+        }));
+        expect(row.capabilitiesInferred).toBe(true);
+        const r = await resolveModelCapabilities(makeResolved('bai', 'qwen3.8-flash'), 'u1', makeRepo([row]));
+        expect(r.source).toBe('config');
+        expect(r.caps.vision).toBe(true);
+    });
+
+    it('응답에 필요한 표시 필드(displayName·isFree·pricing)도 함께 남긴다', () => {
+        const row = toCachedModelEntry(makeModel({ isFree: true, pricing: { input: 1, output: 2 } }));
+        expect(row).toMatchObject({ id: 'm', fullId: 'p:m', displayName: 'M', isFree: true, pricing: { input: 1, output: 2 } });
     });
 });

--- a/apps/api/src/services/chat-service/model-capabilities.ts
+++ b/apps/api/src/services/chat-service/model-capabilities.ts
@@ -22,7 +22,7 @@
  *
  * @module services/chat-service/model-capabilities
  */
-import type { ProviderCapabilities } from '../../providers/i-provider';
+import type { ProviderCapabilities, ProviderModel } from '../../providers/i-provider';
 import type { ResolvedProvider } from '../../providers/provider-router';
 import type { ExternalKeysRepository } from '../../data/repositories/external-keys-repo';
 import { getProviderCatalogEntry } from '../../config/external-providers';
@@ -43,13 +43,37 @@ function cacheTtlMs(): number {
     return parseInt(process.env.EXTERNAL_MODELS_CACHE_TTL_MS ?? '3600000', 10);
 }
 
-type CachedModelEntry = {
-    id?: string;
-    fullId?: string;
-    capabilities?: Partial<ProviderCapabilities>;
+/** `external_provider_models_cache.models_json` 의 항목 — 쓰기 시 형태 */
+export type CachedModelRow = {
+    id: string;
+    fullId: string;
+    displayName: string;
+    capabilities: Partial<ProviderCapabilities>;
     /** listModels 가 휴리스틱으로 채운 값이면 true (undefined = 레거시 행, 추정으로 간주) */
     capabilitiesInferred?: boolean;
+    isFree?: boolean;
+    pricing?: { input: number; output: number };
 };
+
+/** 읽기 시 형태 — 레거시 행은 어떤 필드도 비어 있을 수 있다 */
+type CachedModelEntry = Partial<CachedModelRow>;
+
+/**
+ * listModels 결과 → `external_provider_models_cache` 행 항목. 쓰기(model.routes)와 읽기(②)가
+ * 같은 형태를 쓰게 하는 단일점 — 종전엔 라우트가 필드를 손으로 골라 복사하다 `capabilitiesInferred`
+ * 를 떨어뜨려 ② 의 `=== false` 채택 조건이 영구 거짓이었다(2026-09-04 운영 캐시 전 행 undefined).
+ */
+export function toCachedModelEntry(m: ProviderModel): CachedModelRow {
+    return {
+        id: m.id,
+        fullId: m.fullId,
+        displayName: m.displayName,
+        capabilities: m.capabilities,
+        capabilitiesInferred: m.capabilitiesInferred,
+        isFree: m.isFree,
+        pricing: m.pricing,
+    };
+}
 
 function fromPartial(
     partial: Partial<ProviderCapabilities>,


### PR DESCRIPTION
## 배경
2026-09-04 안정화 검토에서 로그·DB 실측으로 확인한 결함 2건.

## 변경
1. **프로브 sticky-down** — `config/local-models.ts` `probeLocalModelAvailability`
   - 종전: `available === false` 면 전부 "명시 비활성"으로 ping 건너뜀 → 직전 프로브가 abort 로 demote 한 모델이 재시작 전까지 영구 `skipped`. 09-03 실측 `DOWN: qwen3.8-27b` 13:46 → 20:27 배포 재시작까지 6시간 회복 0, 재시작 뒤 재발.
   - 이후: 사유 없음 / `EXPLICIT_DISABLED_REASON` 만 건너뛰고, demote(ping 실패·`runtime:` fallback)는 매 주기 재핑 → `[LocalModelProbe] UP` 전환이 실제로 발생 가능.
2. **외부 모델 캐시 `capabilitiesInferred` 유실** — `routes/model.routes.ts` · `services/chat-service/model-capabilities.ts`
   - 종전: 라우트가 필드를 손으로 골라 캐시에 저장하며 플래그를 떨어뜨림 → 운영 `external_provider_models_cache` 전 행 `undefined` → ② 의 `=== false` 채택 조건 영구 거짓(#713 무력, OpenRouter 실보고도 미채택). 09-04 04:18 `bai:qwen3.8-flash` vision 거절(source=catalog) 라이브 재현.
   - 이후: `toCachedModelEntry`(쓰기)와 `CachedModelRow`(읽기) 단일점. 기존 캐시 행은 TTL(1h) 만료 후 자연 갱신되므로 백필 불필요.

## 테스트
- `__tests__/probe-sticky-down.test.ts` 4건 — 수정을 되돌리면 회복 2건이 실패하는 것을 확인
- `model-capabilities.test.ts` +3건 — 캐시 쓰기→읽기 라운드트립에서 inferred false/true 가 각각 catalog 채택/config 폴백
- 관련 5 스위트 29건 통과, tsc·eslint 통과

## 영향
- 채팅 경로 무변경(availability 는 모델 목록·fallback 후보에만 사용). 마이그레이션·env 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wm1i3ABGHzK2T6kkgeyhJ8
