### PR TITLE
fix(providers): 추론 강도 env 맵을 기본값에 merge + deploy 가 .env 를 pm2 --update-env 에 반영

### DIFF
--- a/apps/api/src/config/reasoning-effort.test.ts
+++ b/apps/api/src/config/reasoning-effort.test.ts
@@ -51,6 +51,21 @@ describe('reasoning-effort 정규화', () => {
         expect(normalizeEffort('newmodel-9b', 'medium')).toBe('low');
     });
 
+    it('env override 는 기본값 위에 merge 된다 — 옛 env 가 새 기본 항목을 지우지 못한다 (2026-09-04 B.AI 400)', () => {
+        // pm2 가 물고 있던 stale env: qwen 항목만 있고 bai:glm-5.3 이 없다.
+        process.env.LLM_REASONING_EFFORTS_JSON = JSON.stringify({ 'qwen3.8': ['low', 'medium', 'xhigh'] });
+        resetReasoningEffortCache();
+        expect(supportedEfforts('glm-5.3-flash', 'bai')).toEqual(['low', 'high']);
+        expect(normalizeEffort('glm-5.3-flash', 'medium', 'bai')).toBe('high');
+    });
+
+    it('env 가 같은 키를 주면 그 항목은 env 가 이긴다', () => {
+        process.env.LLM_REASONING_EFFORTS_JSON = JSON.stringify({ 'bai:glm-5.3': ['low'] });
+        resetReasoningEffortCache();
+        expect(supportedEfforts('glm-5.3-flash', 'bai')).toEqual(['low']);
+        expect(supportedEfforts('qwen3.8-27b')).toEqual(['low', 'medium', 'xhigh']); // 기본값 유지
+    });
+
     it('잘못된 env 는 기본 카탈로그로 폴백한다 (부팅 실패 금지)', () => {
         process.env.LLM_REASONING_EFFORTS_JSON = '{"broken": ["ultra"]}';
         resetReasoningEffortCache();

--- a/apps/api/src/config/reasoning-effort.ts
+++ b/apps/api/src/config/reasoning-effort.ts
@@ -21,7 +21,11 @@ const FALLBACK_SUPPORTED: readonly ReasoningEffort[] = ['low', 'medium', 'high']
 /**
  * 모델 id 접두어 → 지원 강도 목록. `matchCapabilityPreset` 과 동일한
  * startsWith-longest 규칙을 쓴다(중간 substring 오매칭 배제).
- * env `LLM_REASONING_EFFORTS_JSON` 으로 통째 override 가능 — 새 모델 도입 시 배포 없이 대응.
+ * env `LLM_REASONING_EFFORTS_JSON` 은 **항목 단위로 기본값 위에 merge** 된다 — 새 모델 도입 시
+ * 배포 없이 대응하되, 기본값에 새로 들어온 항목을 env 가 지우지는 못한다.
+ * (2026-09-04 운영: pm2 가 옛 .env 의 qwen 항목만 든 JSON 을 물고 있어 통째 대체 시
+ *  `bai:glm-5.3` 이 사라지고 FALLBACK 의 medium 이 나가 B.AI 400 — dotenv 는 기존 env 를
+ *  덮어쓰지 않으므로 stale env 는 재시작으로 안 풀린다.)
  */
 const DEFAULT_MODEL_EFFORTS: Readonly<Record<string, readonly ReasoningEffort[]>> = {
     'qwen3.6': ['low', 'medium', 'high', 'xhigh'],
@@ -52,7 +56,7 @@ function getModelEfforts(): Readonly<Record<string, readonly ReasoningEffort[]>>
                 }
             }
             if (Object.keys(out).length > 0) {
-                _cached = out;
+                _cached = { ...DEFAULT_MODEL_EFFORTS, ...out };
                 return _cached;
             }
         } catch { /* 형식 오류는 기본값으로 폴백 */ }

--- a/openmake_llm.sh
+++ b/openmake_llm.sh
@@ -65,6 +65,30 @@ env_line() {
     grep -E "^$1=" "$SCRIPT_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2- | tr -d ' ' || true
 }
 
+# .env 의 KEY=VALUE 를 현재 셸에 export 한다 — `pm2 restart --update-env` 가 .env 편집을 실제로
+# 반영하게 하는 유일한 경로. PM2 는 최초 `pm2 start` 시점의 env 스냅샷을 프로세스에 계속 주입하고
+# 앱의 dotenv 는 이미 있는 값을 덮어쓰지 않으므로, 여기서 export 하지 않으면 .env 를 고쳐도 재시작
+# 뒤에 옛 값이 남는다 (2026-09-04: LLM_REASONING_EFFORTS_JSON 이 하루 넘게 stale → B.AI 400).
+# `source .env` 대신 줄 단위 파싱 — 값의 공백/특수문자에 셸 해석이 걸리지 않는다. 주석·빈 줄은
+# 건너뛰고, 값 전체를 감싼 한 쌍의 따옴표만 벗긴다(dotenv 와 같은 규칙).
+export_dotenv_for_pm2() {
+    local file="$SCRIPT_DIR/.env" line key val
+    [[ -f "$file" ]] || return 0
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line#export }"
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+        [[ "$line" == *=* ]] || continue
+        key="${line%%=*}"
+        val="${line#*=}"
+        [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+        if [[ "$val" =~ ^\"(.*)\"$ ]] || [[ "$val" =~ ^\'(.*)\'$ ]]; then
+            val="${BASH_REMATCH[1]}"
+        fi
+        export "$key=$val"
+    done < "$file"
+}
+
 # 포트 우선순위: 셸 환경변수 > .env > 기본값.
 # .env 를 봐야 하는 이유 — 기본 포트가 이미 점유돼 install.sh --postgres-port 등으로
 # 다른 포트에 띄운 경우, .env 를 무시하면 status/기동대기가 엉뚱한 포트를 본다.
@@ -287,6 +311,7 @@ start_app() {
     # PM2 프로세스 존재 여부 확인
     if pm2 jlist 2>/dev/null | grep -q "\"name\":\"$APP_NAME\""; then
         log_info "$APP_NAME 이미 등록됨 — restart 시도"
+        export_dotenv_for_pm2
         pm2 restart "$APP_NAME" --update-env >/dev/null 2>&1 || {
             log_err "$APP_NAME restart 실패"
             return 2
@@ -450,6 +475,7 @@ cmd_restart() {
 # PM2 미등록 앱은 건너뛴다 (최초 설치 중 빌드 등).
 restart_built_apps() {
     local restarted=0 app
+    export_dotenv_for_pm2
     for app in "$APP_NAME" "$FRONT_APP_NAME"; do
         if pm2 jlist 2>/dev/null | grep -q "\"name\":\"$app\""; then
             if pm2 restart "$app" --update-env >/dev/null 2>&1; then
@@ -612,6 +638,7 @@ cmd_deploy() {
     # 3) 재시작 (앱만)
     log_step "PM2 앱 재시작 (의존성은 그대로 유지)"
     if pm2 jlist 2>/dev/null | grep -q "\"name\":\"$APP_NAME\""; then
+        export_dotenv_for_pm2
         pm2 restart "$APP_NAME" --update-env >/dev/null 2>&1 || {
             log_err "$APP_NAME restart 실패"
             return 2


### PR DESCRIPTION
## 배경
B.AI `glm-5.3-flash` 도구 루프 2턴째 400(`该模型始终思考，不支持关闭思考`) — dist wire 캡처 + B.AI 직접 재생으로 원인 확정.

- 요청 형태(tool_calls·`::` 도구명·stream·60KB 결과·병렬·system/user 후속·response_format·temperature)는 전부 200
- `reasoning_effort` 값만이 변수: **medium 5회 중 2회 400**(라이브와 같은 `invalid_request_error` 문구), high·미지정 5/5 정상
- 앱은 `bai:glm-5.3 → ['low','high']` 로 medium→high 승격이 코드·`.env` 모두에 있었지만, 운영 pm2 프로세스 env 가 09-03 12:41 이전 값 `{"qwen3.6":…,"qwen3.8":…}` 이라 무효였다

## 변경
1. **`config/reasoning-effort.ts`** — env JSON 을 기본값 위에 항목 단위 merge (종전: 통째 대체). stale env 가 새로 추가된 기본 항목을 지우지 못한다. 테스트 +2 (stale env 에서 `glm-5.3-flash` medium→high / 같은 키는 env 우선).
2. **`openmake_llm.sh`** — `export_dotenv_for_pm2()` 를 `pm2 restart --update-env` 3곳 직전에 호출. PM2 는 최초 start 의 env 스냅샷을 계속 주입하고 앱 dotenv 는 기존 값을 덮어쓰지 않으며 `--update-env` 는 셸 env 만 보므로, 이 export 없이는 `.env` 편집이 영구 미반영이었다. `source .env` 대신 줄 단위 파싱(값 무확장, dotenv 따옴표 규칙, 잘못된 키 skip) — 공백·JSON·`=`·`$` 포함 값으로 검증.

## 검증
- jest `reasoning-effort`·`reasoning-adapter.effort` 16건 통과, eslint 통과
- `bash -n` + `shellcheck -S warning` 통과, 헬퍼 기능 테스트(9 케이스)
- 배포 후 확인 포인트: `pm2 env` 의 `LLM_REASONING_EFFORTS_JSON` 이 `.env` 와 일치, glm-5.3-flash "보통" 강도 채팅에서 `reasoning_effort=high` 전송

## 영향
- 코드 기본값과 env 가 같은 키를 주면 종전처럼 env 가 이긴다. 마이그레이션·env 추가 없음.
- deploy 셸에 `.env` 전체가 export 되지만, pm2 프로세스 env 에는 이미 같은 키들이 스냅샷으로 들어가 있어 노출 범위는 동일.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wm1i3ABGHzK2T6kkgeyhJ8
