### PR TITLE
feat(api): 웹 SSO 클라이언트(bench)·/v1/models 캐시 라이브 갱신·OpenAI 호환 raw 모드

### DIFF
--- a/apps/api/src/__tests__/contracts/sso-client-contract.test.ts
+++ b/apps/api/src/__tests__/contracts/sso-client-contract.test.ts
@@ -1,0 +1,162 @@
+/**
+ * 웹 SSO 클라이언트(config/security.ts SSO_CLIENTS, 예: bench) — 동작 테스트.
+ *
+ * mobile-auth-contract 와 같은 무DB 구성. optionalAuth 모의는 x-test-user 헤더로 로그인 상태를 흉내낸다.
+ */
+import express, { type Request, type Response, type NextFunction } from 'express';
+import request from 'supertest';
+import cookieParser from 'cookie-parser';
+import type { PublicUser } from '../../data/user-manager';
+import { expectContract } from './contract-validator';
+
+const sampleUser: PublicUser = {
+    id: 'u1',
+    email: 'riskpw@gmail.com',
+    role: 'user',
+    created_at: '2026-08-16T00:00:00.000Z',
+    is_active: true,
+};
+
+const cookieSpies = {
+    setTokenCookie: jest.fn(),
+    setRefreshTokenCookie: jest.fn(),
+};
+
+jest.mock('../../auth', () => ({
+    requireAuth: (req: Request, _res: Response, next: NextFunction) => {
+        req.user = sampleUser;
+        next();
+    },
+    optionalAuth: (req: Request, _res: Response, next: NextFunction) => {
+        const h = req.headers['x-test-user'];
+        if (h === 'user') req.user = sampleUser;
+        if (h === 'guest') req.user = { ...sampleUser, id: 'g1', role: 'guest' };
+        next();
+    },
+    extractToken: () => null,
+    blacklistToken: jest.fn(),
+    setTokenCookie: (...args: unknown[]) => cookieSpies.setTokenCookie(...args),
+    clearTokenCookie: jest.fn(),
+    setRefreshTokenCookie: (...args: unknown[]) => cookieSpies.setRefreshTokenCookie(...args),
+    generateRefreshToken: () => 'new-refresh-token',
+    generateToken: () => 'new-access-token',
+    verifyRefreshToken: jest.fn(),
+    removeSessionFromMap: jest.fn(),
+}));
+
+const mockAuthService = {
+    login: jest.fn(),
+    getAvailableProviders: () => ['google'],
+};
+jest.mock('../../services/AuthService', () => ({
+    getAuthService: () => mockAuthService,
+}));
+
+const mockUserManager = { getUserById: jest.fn() };
+jest.mock('../../data/user-manager', () => ({
+    getUserManager: () => mockUserManager,
+}));
+
+jest.mock('../../services/AuditService', () => ({
+    getAuditService: () => ({ logAudit: jest.fn().mockResolvedValue(undefined) }),
+}));
+
+// 무DB — helpers 의 oauth_states 접근은 전부 인메모리 폴백으로 유도
+jest.mock('../../data/models/unified-database', () => ({
+    getPool: () => {
+        throw new Error('no db in test');
+    },
+}));
+
+jest.mock('../../middlewares/rate-limiters', () => ({
+    authLimiter: (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+jest.mock('../../mcp/lifecycle-hooks', () => ({
+    emitUserLogout: jest.fn(),
+}));
+
+const testConfig = {
+    port: 0,
+    cookieSecure: false,
+    csrfProtection: 'off',
+    storageBackend: 'memory',
+    googleClientId: 'gid',
+    googleClientSecret: 'gsecret',
+    oauthRedirectUri: '',
+};
+jest.mock('../../config/env', () => ({ getConfig: () => testConfig }));
+jest.mock('../../config', () => ({ getConfig: () => testConfig }));
+
+import { createAuthController } from '../../controllers/auth.controller';
+import { generateSecureState, validateAndConsumeState } from '../../controllers/auth-oauth-helpers';
+import { SSO_CLIENTS } from '../../config/security';
+
+describe('웹 SSO 클라이언트 (sso/authorize)', () => {
+    let app: express.Express;
+
+    beforeAll(() => {
+        app = express();
+        app.use(cookieParser());
+        app.use(express.json());
+        app.use('/api/auth', createAuthController(0));
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUserManager.getUserById.mockResolvedValue(sampleUser);
+    });
+
+    test('알 수 없는 client → 400', async () => {
+        const r = await request(app).get('/api/auth/sso/authorize?client=evil');
+        expect(r.status).toBe(400);
+    });
+
+    test('client 누락 → 400', async () => {
+        const r = await request(app).get('/api/auth/sso/authorize');
+        expect(r.status).toBe(400);
+    });
+
+    test('로그인 안 됨 → /login?client=bench 로 리다이렉트', async () => {
+        const r = await request(app).get('/api/auth/sso/authorize?client=bench');
+        expect(r.status).toBe(302);
+        expect(r.headers.location).toBe('/login?client=bench');
+    });
+
+    test('게스트 세션 → /login 으로 (게스트는 SSO 불가)', async () => {
+        const r = await request(app).get('/api/auth/sso/authorize?client=bench').set('x-test-user', 'guest');
+        expect(r.status).toBe(302);
+        expect(r.headers.location).toBe('/login?client=bench');
+    });
+
+    test('로그인 됨 → 등록된 redirect URI 로 code 전달, code 는 exchange 에서 일회성', async () => {
+        const r = await request(app).get('/api/auth/sso/authorize?client=bench').set('x-test-user', 'user');
+        expect(r.status).toBe(302);
+        const loc = new URL(r.headers.location);
+        expect(`${loc.origin}${loc.pathname}`).toBe(SSO_CLIENTS.bench.redirectUri);
+        const code = loc.searchParams.get('code');
+        expect(code).toMatch(/^[0-9a-f]{64}$/);
+
+        const ex = await request(app).post('/api/auth/mobile/exchange').send({ code });
+        expect(ex.status).toBe(200);
+        expect(ex.body.data.user.id).toBe('u1');
+        expect(ex.body.data.token).toBe('new-access-token');
+
+        const again = await request(app).post('/api/auth/mobile/exchange').send({ code });
+        expect(again.status).toBe(401);
+    });
+
+    test('OAuth 시작 ?client=bench → state 에 sso:bench 귀속 (콜백 분기용)', async () => {
+        const r = await request(app).get('/api/auth/login/google?client=bench');
+        expect(r.status).toBe(302);
+        const state = new URL(r.headers.location).searchParams.get('state');
+        expect(state).toBeTruthy();
+        const consumed = await validateAndConsumeState(state as string, 'google');
+        expect(consumed).toEqual({ valid: true, client: 'sso:bench' });
+    });
+
+    test('OAuth 시작 client 미지정 → 웹(null) 유지', async () => {
+        const state = await generateSecureState('google');
+        expect(await validateAndConsumeState(state, 'google')).toEqual({ valid: true, client: null });
+    });
+});

--- a/apps/api/src/__tests__/external-models-catalog.test.ts
+++ b/apps/api/src/__tests__/external-models-catalog.test.ts
@@ -1,0 +1,75 @@
+/**
+ * services/external-models-catalog — 캐시(TTL) → 라이브 조회(+캐시 저장) → fallback 규칙.
+ */
+const listModels = jest.fn();
+jest.mock('../providers/provider-router', () => ({
+    createExternalProviderInstance: () => ({ listModels }),
+    buildOAuthSessionPersist: () => undefined,
+}));
+jest.mock('../providers/i-provider', () => ({ buildFullModelId: (p: string, id: string) => `${p}:${id}` }));
+jest.mock('../config/external-providers', () => ({
+    getProviderCatalogEntry: (id: string) => id === 'hasa'
+        ? { fallbackModels: [{ id: 'fb-1', displayName: 'FB 1', capabilities: {} }] }
+        : undefined,
+}));
+jest.mock('../services/chat-service/model-capabilities', () => ({
+    toCachedModelEntry: (m: { id: string }) => ({ id: m.id, fullId: `hasa:${m.id}`, displayName: m.id, capabilities: {} }),
+}));
+
+import { resolveExternalModels } from '../services/external-models-catalog';
+import type { ExternalKeysRepository, ExternalApiKeyRow } from '../data/repositories/external-keys-repo';
+
+const keyRow = { providerId: 'hasa', sdkType: 'openai-compatible', baseUrl: 'https://x/v1', authMethod: 'api_key' } as unknown as ExternalApiKeyRow;
+
+function repoWith(cached: unknown[] | null) {
+    return {
+        getCachedModels: jest.fn().mockResolvedValue(cached),
+        decryptKey: jest.fn().mockResolvedValue('sk-plain'),
+        putCachedModels: jest.fn().mockResolvedValue(undefined),
+    } as unknown as ExternalKeysRepository & { putCachedModels: jest.Mock; decryptKey: jest.Mock };
+}
+
+describe('resolveExternalModels', () => {
+    beforeEach(() => listModels.mockReset());
+
+    test('캐시가 살아 있으면 라이브 조회 없이 그대로', async () => {
+        const repo = repoWith([{ id: 'c1', fullId: 'hasa:c1' }]);
+        const r = await resolveExternalModels(repo, 'u1', keyRow);
+        expect(r?.map((m) => m.fullId)).toEqual(['hasa:c1']);
+        expect(listModels).not.toHaveBeenCalled();
+    });
+
+    test('캐시 만료 → provider 라이브 조회 → 캐시 저장', async () => {
+        const repo = repoWith(null);
+        listModels.mockResolvedValue([{ id: 'live-1' }, { id: 'live-2' }]);
+        const r = await resolveExternalModels(repo, 'u1', keyRow);
+        expect(r?.map((m) => m.fullId)).toEqual(['hasa:live-1', 'hasa:live-2']);
+        expect(repo.putCachedModels).toHaveBeenCalledWith('u1', 'hasa', expect.any(Array));
+    });
+
+    test('라이브가 빈 배열이면 fallback, 캐싱 안 함', async () => {
+        const repo = repoWith(null);
+        listModels.mockResolvedValue([]);
+        const r = await resolveExternalModels(repo, 'u1', keyRow);
+        expect(r?.map((m) => m.fullId)).toEqual(['hasa:fb-1']);
+        expect(repo.putCachedModels).not.toHaveBeenCalled();
+    });
+
+    test('라이브 불가 키(baseUrl 없음)는 캐시 없으면 fallback', async () => {
+        const repo = repoWith(null);
+        const r = await resolveExternalModels(repo, 'u1', { ...keyRow, baseUrl: null } as unknown as ExternalApiKeyRow);
+        expect(r?.map((m) => m.fullId)).toEqual(['hasa:fb-1']);
+        expect(listModels).not.toHaveBeenCalled();
+    });
+
+    test('복호화 키가 없으면 null', async () => {
+        const repo = repoWith(null); repo.decryptKey.mockResolvedValue(null);
+        expect(await resolveExternalModels(repo, 'u1', keyRow)).toBeNull();
+    });
+
+    test('라이브 조회 예외는 그대로 던진다 (호출부가 격리)', async () => {
+        const repo = repoWith(null);
+        listModels.mockRejectedValue(new Error('boom'));
+        await expect(resolveExternalModels(repo, 'u1', keyRow)).rejects.toThrow('boom');
+    });
+});

--- a/apps/api/src/__tests__/openai-compat-raw.test.ts
+++ b/apps/api/src/__tests__/openai-compat-raw.test.ts
@@ -1,0 +1,109 @@
+/**
+ * routes/openai-compat-raw — 원본 호출 모드: 파이프라인 없이 모델만 부르고 OpenAI 형식으로 답한다.
+ */
+import express, { type Request, type Response, type NextFunction } from 'express';
+import request from 'supertest';
+
+const streamChat = jest.fn();
+const localChat = jest.fn();
+jest.mock('../providers/provider-router', () => ({
+    createExternalProviderInstance: () => ({ streamChat }),
+    buildOAuthSessionPersist: () => undefined,
+}));
+jest.mock('../providers/i-provider', () => ({
+    parseFullModelId: (s: string) => { const i = s.indexOf(':'); return { providerId: s.slice(0, i), modelId: s.slice(i + 1) }; },
+}));
+jest.mock('../config/external-providers', () => ({ getProviderCatalogEntry: (id: string) => (id === 'hasa' ? { id } : undefined) }));
+jest.mock('../llm/client', () => ({ createClient: () => ({ chat: localChat }) }));
+const repo = { getByUserAndProvider: jest.fn(), decryptKey: jest.fn() };
+jest.mock('../data/repositories/external-keys-repo', () => ({ ExternalKeysRepository: function () { return repo; } }));
+jest.mock('../data/models/unified-database', () => ({ getPool: () => ({}) }));
+
+import { handleRawCompletion, isRawRequest, resolveRawTarget, toChatMessages } from '../routes/openai-compat-raw';
+
+function appWith(userId: string | null) {
+    const app = express();
+    app.use(express.json());
+    app.post('/v1/chat/completions', (req: Request, res: Response, next: NextFunction) => {
+        handleRawCompletion(req, res, req.body, { userId }).catch(next);
+    });
+    return app;
+}
+
+describe('raw 판정·해석', () => {
+    test('헤더 또는 body.openmake.raw', () => {
+        const get = (h: string) => (h === 'x-openmake-raw' ? '1' : undefined);
+        expect(isRawRequest({ get } as unknown as Request, {})).toBe(true);
+        expect(isRawRequest({ get: () => undefined } as unknown as Request, { openmake: { raw: true } })).toBe(true);
+        expect(isRawRequest({ get: () => undefined } as unknown as Request, {})).toBe(false);
+    });
+    test('모델 문자열 → 대상', () => {
+        expect(resolveRawTarget('qwen3.8-27b')).toEqual({ kind: 'local', modelId: 'qwen3.8-27b' });
+        expect(resolveRawTarget('local-llm:qwen3.8-27b')).toEqual({ kind: 'local', modelId: 'qwen3.8-27b' });
+        expect(resolveRawTarget('hasa:solar-open-100b')).toEqual({ kind: 'external', providerId: 'hasa', modelId: 'solar-open-100b' });
+        expect(resolveRawTarget('unknown:x')).toEqual({ kind: 'local', modelId: 'unknown:x' });
+    });
+    test('content-part 배열은 text 만 이어 붙인다', () => {
+        const m = toChatMessages([{ role: 'user', content: [{ type: 'text', text: 'a' }, { type: 'image_url', image_url: { url: 'x' } }, { type: 'text', text: 'b' }] as never }]);
+        expect(m).toEqual([{ role: 'user', content: 'ab' }]);
+    });
+});
+
+describe('handleRawCompletion', () => {
+    beforeEach(() => {
+        streamChat.mockReset(); localChat.mockReset();
+        repo.getByUserAndProvider.mockResolvedValue({ providerId: 'hasa', authMethod: 'api_key' });
+        repo.decryptKey.mockResolvedValue('sk-plain');
+    });
+
+    test('외부 provider: 사용자 키로 streamChat, 메시지·도구만 전달, usage 는 provider 값', async () => {
+        streamChat.mockImplementation(async (opts: { messages: unknown[] }, cb: { onToken: (t: string) => void }) => {
+            cb.onToken('안'); cb.onToken('녕');
+            return { content: '안녕', usage: { prompt_tokens: 7, completion_tokens: 2 }, finishReason: 'stop' };
+        });
+        const r = await request(appWith('11')).post('/v1/chat/completions')
+            .send({ model: 'hasa:solar-open-100b', messages: [{ role: 'user', content: 'hi' }], max_tokens: 50, temperature: 0 });
+        expect(r.status).toBe(200);
+        expect(r.body.choices[0].message.content).toBe('안녕');
+        expect(r.body.usage).toEqual({ prompt_tokens: 7, completion_tokens: 2, total_tokens: 9 });
+        const opts = streamChat.mock.calls[0][0];
+        expect(opts.modelId).toBe('solar-open-100b');
+        expect(opts.messages).toEqual([{ role: 'user', content: 'hi' }]); // 시스템 프롬프트·페르소나 없음
+        expect(opts.maxTokens).toBe(50);
+        expect(opts.tools).toBeUndefined();
+    });
+
+    test('스트리밍: 토큰 delta 뒤 마지막 청크에 usage 와 finish_reason', async () => {
+        streamChat.mockImplementation(async (_o: unknown, cb: { onToken: (t: string) => void }) => {
+            cb.onToken('x');
+            return { content: 'x', usage: { prompt_tokens: 3, completion_tokens: 1 }, finishReason: 'stop' };
+        });
+        const r = await request(appWith('11')).post('/v1/chat/completions')
+            .send({ model: 'hasa:solar-open-100b', messages: [{ role: 'user', content: 'hi' }], stream: true });
+        expect(r.status).toBe(200);
+        const events = r.text.split('\n\n').filter((l) => l.startsWith('data: ')).map((l) => l.slice(6));
+        expect(events[events.length - 1]).toBe('[DONE]');
+        const last = JSON.parse(events[events.length - 2]);
+        expect(last.choices[0].finish_reason).toBe('stop');
+        expect(last.usage.total_tokens).toBe(4);
+        expect(events.some((e) => e.includes('"content":"x"'))).toBe(true);
+    });
+
+    test('외부 실패는 폴백 없이 502', async () => {
+        streamChat.mockRejectedValue(new Error('upstream 404'));
+        const r = await request(appWith('11')).post('/v1/chat/completions')
+            .send({ model: 'hasa:solar-open-100b', messages: [{ role: 'user', content: 'hi' }] });
+        expect(r.status).toBe(502);
+        expect(r.body.error.message).toContain('upstream 404');
+    });
+
+    test('로컬 모델: LLMClient.chat 직접 호출, 도구 호출은 OpenAI 형식', async () => {
+        localChat.mockResolvedValue({ role: 'assistant', content: '', tool_calls: [{ id: 'c1', function: { name: 'get_weather', arguments: { city: '서울' } } }], metrics: { prompt_tokens: 5, completion_tokens: 9 } });
+        const r = await request(appWith('11')).post('/v1/chat/completions')
+            .send({ model: 'qwen3.8-27b', messages: [{ role: 'user', content: '날씨' }], tools: [{ type: 'function', function: { name: 'get_weather', description: 'd', parameters: {} } }] });
+        expect(r.status).toBe(200);
+        expect(r.body.choices[0].finish_reason).toBe('tool_calls');
+        expect(r.body.choices[0].message.tool_calls[0].function).toEqual({ name: 'get_weather', arguments: '{"city":"서울"}' });
+        expect(localChat.mock.calls[0][0]).toEqual([{ role: 'user', content: '날씨' }]);
+    });
+});

--- a/apps/api/src/config/security.ts
+++ b/apps/api/src/config/security.ts
@@ -185,3 +185,16 @@ export const MOBILE_AUTH = {
     /** 허용 클라이언트 식별자 화이트리스트 (`?client=`) */
     ALLOWED_CLIENTS: ['ios'],
 } as const;
+
+/**
+ * 웹 SSO 클라이언트 (다른 호스트명의 자매 서비스가 openmake 로그인을 그대로 쓰는 경우)
+ *
+ * 쿠키는 호스트 단위라 bench.openmake.cc 같은 별도 오리진은 chat.openmake.cc 의 세션 쿠키를
+ * 받지 못한다. 대신 `GET /api/auth/sso/authorize?client=<id>` 가 로그인된 사용자에게 일회성
+ * exchange code(MOBILE_AUTH 와 같은 저장소·TTL)를 발급해 등록된 redirect URI 로 보내고,
+ * 클라이언트 서버가 `POST /api/auth/mobile/exchange` 로 교환한다. redirect URI 는 여기 등록된
+ * 값만 쓰며 요청 파라미터로 받지 않는다 (open redirect 차단).
+ */
+export const SSO_CLIENTS: Readonly<Record<string, { redirectUri: string }>> = {
+    bench: { redirectUri: process.env.SSO_BENCH_REDIRECT_URI || 'https://bench.openmake.cc/api/auth/callback' },
+};

--- a/apps/api/src/controllers/auth-oauth-helpers.ts
+++ b/apps/api/src/controllers/auth-oauth-helpers.ts
@@ -10,7 +10,7 @@ import { Request, Response } from 'express';
 import * as crypto from 'crypto';
 import { createLogger } from '../utils/logger';
 import { getConfig } from '../config/env';
-import { MOBILE_AUTH } from '../config/security';
+import { MOBILE_AUTH, SSO_CLIENTS } from '../config/security';
 
 const log = createLogger('AuthOAuthHelpers');
 
@@ -252,6 +252,28 @@ export function buildRedirectUri(req: Request, provider: 'google' | 'github' | '
  * (config/security.ts MOBILE_AUTH 참고 — iOS 축 2)
  */
 export async function issueMobileExchangeRedirect(res: Response, userId: string, provider: string): Promise<void> {
+    const code = await createExchangeCode(userId, provider);
+    const target = `${MOBILE_AUTH.APP_SCHEME}://${MOBILE_AUTH.CALLBACK_HOST_PATH}?code=${code}`;
+    log.info(`[OAuth] 모바일 exchange code 발급 (provider=${provider}, user=${userId})`);
+    res.redirect(target);
+}
+
+/**
+ * 웹 SSO 클라이언트(config/security.ts SSO_CLIENTS) 완료 — 일회성 exchange code 를 등록된
+ * redirect URI 로 전달한다. 코드 저장소·TTL·교환 엔드포인트는 모바일과 같다.
+ */
+export async function issueSsoExchangeRedirect(res: Response, userId: string, client: string, provider: string): Promise<void> {
+    const target = SSO_CLIENTS[client]?.redirectUri;
+    if (!target) {
+        res.status(400).type('text').send('unknown sso client');
+        return;
+    }
+    const code = await createExchangeCode(userId, `sso:${client}:${provider}`);
+    log.info(`[OAuth] SSO exchange code 발급 (client=${client}, provider=${provider}, user=${userId})`);
+    res.redirect(`${target}?code=${code}`);
+}
+
+async function createExchangeCode(userId: string, provider: string): Promise<string> {
     const { getKeyValueStore } = await import('../storage');
     const code = crypto.randomBytes(MOBILE_AUTH.EXCHANGE_CODE_BYTES).toString('hex');
     await getKeyValueStore().set(
@@ -259,9 +281,7 @@ export async function issueMobileExchangeRedirect(res: Response, userId: string,
         { userId, provider },
         MOBILE_AUTH.EXCHANGE_CODE_TTL_MS,
     );
-    const target = `${MOBILE_AUTH.APP_SCHEME}://${MOBILE_AUTH.CALLBACK_HOST_PATH}?code=${code}`;
-    log.info(`[OAuth] 모바일 exchange code 발급 (provider=${provider}, user=${userId})`);
-    res.redirect(target);
+    return code;
 }
 
 /**

--- a/apps/api/src/controllers/auth-oauth.controller.ts
+++ b/apps/api/src/controllers/auth-oauth.controller.ts
@@ -11,13 +11,13 @@
 import { Request, Response, Router } from 'express';
 import { getAuthService } from '../services/AuthService';
 import type { OAuthTokenResponse, GoogleUserInfo, GitHubUser, GitHubEmail, KakaoUserInfo } from '../auth/types';
-import { setTokenCookie, setRefreshTokenCookie, generateRefreshToken, generateToken } from '../auth';
+import { setTokenCookie, setRefreshTokenCookie, generateRefreshToken, generateToken, optionalAuth } from '../auth';
 import { getUserManager } from '../data/user-manager';
 import { createLogger } from '../utils/logger';
 import { success, badRequest, unauthorized, serviceUnavailable, internalError } from '../utils/api-response';
 import { getConfig } from '../config/env';
 import { APP_USER_AGENT } from '../config/constants';
-import { MOBILE_AUTH } from '../config/security';
+import { MOBILE_AUTH, SSO_CLIENTS } from '../config/security';
 import { GOOGLE_OAUTH, GITHUB_OAUTH, GITHUB_API, KAKAO_OAUTH } from '../config/external-services';
 import { authLimiter } from '../middlewares/rate-limiters';
 import { validate } from '../middlewares/validation';
@@ -28,6 +28,7 @@ import {
     buildRedirectUri,
     sendOAuthSuccessRedirect,
     issueMobileExchangeRedirect,
+    issueSsoExchangeRedirect,
     consumeMobileExchangeCode,
 } from './auth-oauth-helpers';
 
@@ -72,6 +73,44 @@ export class AuthOAuthController {
         this.router.get('/callback/kakao', this.kakaoCallback.bind(this));
         // 모바일(iOS) 전용: OAuth exchange code → 토큰 교환 (사전 인증 POST — CSRF 부트스트랩 대상)
         this.router.post('/mobile/exchange', authLimiter, validate(mobileExchangeSchema), this.mobileExchange.bind(this));
+        // 웹 SSO 클라이언트(bench 등): 로그인돼 있으면 exchange code 를 등록된 redirect URI 로, 아니면 /login 으로
+        this.router.get('/sso/authorize', optionalAuth, this.ssoAuthorize.bind(this));
+    }
+
+    /**
+     * `?client=` 를 SSO_CLIENTS 화이트리스트로 해석 — 허용 목록 외 값은 undefined
+     */
+    private resolveSsoClient(req: Request): string | undefined {
+        const client = req.query.client;
+        return typeof client === 'string' && Object.hasOwn(SSO_CLIENTS, client) ? client : undefined;
+    }
+
+    /**
+     * OAuth 시작 시 state 에 귀속할 client — 모바일('ios') 또는 웹 SSO('sso:bench'). 콜백에서 분기.
+     */
+    private resolveStateClient(req: Request): string | undefined {
+        const sso = this.resolveSsoClient(req);
+        return sso ? `sso:${sso}` : this.resolveMobileClient(req);
+    }
+
+    /**
+     * GET /api/auth/sso/authorize?client=bench — 웹 SSO 진입점
+     *
+     * 세션 쿠키가 있으면(게스트 제외) 일회성 exchange code 를 등록된 redirect URI 로 보낸다.
+     * 없으면 /login?client= 로 보내 로그인 뒤 다시 여기로 오게 한다 (로그인 페이지가 처리).
+     */
+    private async ssoAuthorize(req: Request, res: Response): Promise<void> {
+        const client = this.resolveSsoClient(req);
+        if (!client) {
+            res.status(400).json(badRequest('알 수 없는 SSO 클라이언트입니다'));
+            return;
+        }
+        const user = req.user as { id?: string | number; role?: string } | undefined;
+        if (!user?.id || user.role === 'guest') {
+            res.redirect(`/login?client=${encodeURIComponent(client)}`);
+            return;
+        }
+        await issueSsoExchangeRedirect(res, String(user.id), client, 'session');
     }
 
     /**
@@ -160,7 +199,7 @@ export class AuthOAuthController {
         }
 
         // 🔒 Phase 2 보안 패치: 암호학적으로 안전한 state 생성 (?client=ios 는 state 에 귀속 — 콜백 분기용)
-        const state = await generateSecureState('google', this.resolveMobileClient(req));
+        const state = await generateSecureState('google', this.resolveStateClient(req));
         const authUrl = new URL(GOOGLE_OAUTH.AUTH_URL);
         authUrl.searchParams.set('client_id', clientId);
         authUrl.searchParams.set('redirect_uri', redirectUri);
@@ -187,7 +226,7 @@ export class AuthOAuthController {
         }
 
         // 🔒 Phase 2 보안 패치: 암호학적으로 안전한 state 생성 (?client=ios 는 state 에 귀속 — 콜백 분기용)
-        const state = await generateSecureState('github', this.resolveMobileClient(req));
+        const state = await generateSecureState('github', this.resolveStateClient(req));
         const authUrl = new URL(GITHUB_OAUTH.AUTH_URL);
         authUrl.searchParams.set('client_id', clientId);
         authUrl.searchParams.set('redirect_uri', redirectUri);
@@ -266,6 +305,11 @@ export class AuthOAuthController {
 
             if (!result.success || !result.token || !result.user) throw new Error(result.error || '인증 실패');
 
+            if (stateResult.client?.startsWith('sso:')) {
+                // 웹 SSO 클라이언트(bench 등): exchange code 를 등록된 redirect URI 로 전달
+                await issueSsoExchangeRedirect(res, String(result.user.id), stateResult.client.slice(4), 'google');
+                return;
+            }
             if (stateResult.client) {
                 // 모바일: 쿠키 대신 일회성 exchange code 를 app scheme 으로 전달 (iOS 축 2)
                 await issueMobileExchangeRedirect(res, String(result.user.id), 'google');
@@ -369,6 +413,11 @@ export class AuthOAuthController {
 
             if (!result.success || !result.token || !result.user) throw new Error(result.error || '인증 실패');
 
+            if (stateResult.client?.startsWith('sso:')) {
+                // 웹 SSO 클라이언트(bench 등): exchange code 를 등록된 redirect URI 로 전달
+                await issueSsoExchangeRedirect(res, String(result.user.id), stateResult.client.slice(4), 'github');
+                return;
+            }
             if (stateResult.client) {
                 // 모바일: 쿠키 대신 일회성 exchange code 를 app scheme 으로 전달 (iOS 축 2)
                 await issueMobileExchangeRedirect(res, String(result.user.id), 'github');
@@ -396,7 +445,7 @@ export class AuthOAuthController {
         }
 
         // 🔒 암호학적으로 안전한 state 생성 (CSRF 방어, ?client=ios 는 state 에 귀속 — 콜백 분기용)
-        const state = await generateSecureState('kakao', this.resolveMobileClient(req));
+        const state = await generateSecureState('kakao', this.resolveStateClient(req));
         const authUrl = new URL(KAKAO_OAUTH.AUTH_URL);
         authUrl.searchParams.set('client_id', clientId);
         authUrl.searchParams.set('redirect_uri', redirectUri);
@@ -488,6 +537,11 @@ export class AuthOAuthController {
 
             if (!result.success || !result.token || !result.user) throw new Error(result.error || '인증 실패');
 
+            if (stateResult.client?.startsWith('sso:')) {
+                // 웹 SSO 클라이언트(bench 등): exchange code 를 등록된 redirect URI 로 전달
+                await issueSsoExchangeRedirect(res, String(result.user.id), stateResult.client.slice(4), 'kakao');
+                return;
+            }
             if (stateResult.client) {
                 // 모바일: 쿠키 대신 일회성 exchange code 를 app scheme 으로 전달 (iOS 축 2)
                 await issueMobileExchangeRedirect(res, String(result.user.id), 'kakao');

--- a/apps/api/src/routes/model.routes.ts
+++ b/apps/api/src/routes/model.routes.ts
@@ -24,38 +24,13 @@ import { requireAuth, requireAdmin, optionalAuth } from '../auth';
 import { getModelHealthMonitor } from '../services/model-health-monitor';
 import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
 import { getPool } from '../data/models/unified-database';
-import {
-    createExternalProviderInstance,
-    buildOAuthSessionPersist,
-} from '../providers/provider-router';
 import { buildFullModelId } from '../providers/i-provider';
 import { getProviderCatalogEntry } from '../config/external-providers';
 import { isRoleAssignableModel } from '../config/role-model-filter';
-import { toCachedModelEntry, type CachedModelRow } from '../services/chat-service/model-capabilities';
+import { resolveExternalModels } from '../services/external-models-catalog';
 
 const router = Router();
 const logger = createLogger('ModelRoutes');
-
-/**
- * Provider 별 fallback 모델 목록 — `/v1/models` API 호출 실패 또는 빈 배열 반환 시
- * 사용자가 채팅을 시작할 수 있도록 제공하는 known 모델 카탈로그.
- *
- * 모델 카탈로그는 No-Hardcoding 정책에 따라 `config/external-providers.ts` 의
- * `EXTERNAL_PROVIDER_CATALOG[].fallbackModels` 에 외부화되어 있습니다.
- */
-function getProviderFallbackModels(
-    providerId: string,
-): CachedModelRow[] {
-    const entry = getProviderCatalogEntry(providerId);
-    if (!entry?.fallbackModels?.length) return [];
-    return entry.fallbackModels.map(m => ({
-        id: m.id,
-        fullId: buildFullModelId(providerId, m.id),
-        displayName: m.displayName,
-        capabilities: m.capabilities,
-        isFree: m.isFree ?? false,
-    }));
-}
 
 /**
  * GET /model
@@ -161,39 +136,8 @@ router.get('/models', optionalAuth, asyncHandler(async (req: Request, res: Respo
                 // openai-compatible 분기: provider 의 /v1/models 호출 (TTL 캐시 + 실패 격리)
                 if (keyRow.sdkType === 'openai-compatible' && keyRow.baseUrl) {
                     try {
-                        // 캐시 우선 조회 (EXTERNAL_MODELS_CACHE_TTL_MS, 기본 1h)
-                        const cacheTtlMs = parseInt(
-                            process.env.EXTERNAL_MODELS_CACHE_TTL_MS ?? '3600000',
-                            10,
-                        );
-                        const cached = await repo.getCachedModels(userId, keyRow.providerId, cacheTtlMs);
-                        let list: CachedModelRow[] | null = cached as CachedModelRow[] | null;
-
-                        if (!list || list.length === 0) {
-                            const plaintextKey = await repo.decryptKey(userId, keyRow.providerId);
-                            if (!plaintextKey) continue;
-                            // 공용 팩토리 사용 — OAuth 행(chatgpt)은 Codex transport 기반
-                            // ChatGPTOAuthProvider 로 분기된다 (refresh 시 세션 영속화 포함).
-                            const provider = createExternalProviderInstance(
-                                keyRow,
-                                plaintextKey,
-                                keyRow.authMethod === 'oauth'
-                                    ? buildOAuthSessionPersist(repo, userId, keyRow.providerId)
-                                    : undefined,
-                            );
-                            const fresh = await provider.listModels();
-                            // 캐시 행 형태는 model-capabilities 의 단일점을 쓴다(capabilitiesInferred 유실 방지)
-                            list = fresh.map(toCachedModelEntry);
-                            // 빈 배열은 캐싱 안 함 (stale 영구화 방지) + provider별 fallback 모델 보강
-                            if (list.length === 0) {
-                                list = getProviderFallbackModels(keyRow.providerId);
-                                if (list.length > 0) {
-                                    logger.warn(`${keyRow.providerId} /v1/models 빈 배열 — fallback ${list.length}개 사용 (캐싱 skip)`);
-                                }
-                            } else {
-                                await repo.putCachedModels(userId, keyRow.providerId, list);
-                            }
-                        }
+                        // 캐시(TTL) → 라이브 조회 → fallback (services/external-models-catalog, v1 과 공용)
+                        const list = await resolveExternalModels(repo, userId, keyRow);
 
                         const catalogDisplay = getProviderCatalogEntry(keyRow.providerId)?.displayName ?? keyRow.providerId;
                         if (!list) continue;

--- a/apps/api/src/routes/openai-compat-raw.ts
+++ b/apps/api/src/routes/openai-compat-raw.ts
@@ -1,0 +1,241 @@
+/**
+ * OpenAI 호환 `/api/v1/chat/completions` 의 **원본 호출 모드** (raw).
+ *
+ * 헤더 `X-OpenMake-Raw: 1`(또는 body.openmake.raw=true) 이면 채팅 파이프라인(에이전트 라우터·
+ * 페르소나 시스템 프롬프트·내장 도구·thinking 요약·세션·로컬 폴백)을 전부 건너뛰고 요청한
+ * 모델만 그대로 부른다. 벤치마크(openmake_bench)처럼 "모델 자체"를 재야 하는 클라이언트용이다.
+ *
+ * - 외부 provider fullId(`hasa:solar-open-100b`): 요청 사용자의 BYO 키로 provider 어댑터를 만들어 streamChat
+ * - 로컬 모델(`qwen3.8-27b`, `local-llm:*`): LLMClient 로 직접 호출
+ * - 요청의 messages·tools·temperature·max_tokens 만 전달하고 다른 것은 붙이지 않는다
+ * - 실패해도 다른 모델로 폴백하지 않는다 (벤치는 실패를 실패로 봐야 한다)
+ * - API 키 인증·rate limit 은 v1 라우터 미들웨어가 이미 적용한 상태
+ *
+ * @module routes/openai-compat-raw
+ */
+
+import type { Request, Response } from 'express';
+import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
+import { getPool } from '../data/models/unified-database';
+import { createExternalProviderInstance, buildOAuthSessionPersist } from '../providers/provider-router';
+import { parseFullModelId } from '../providers/i-provider';
+import { getProviderCatalogEntry } from '../config/external-providers';
+import { createClient } from '../llm/client';
+import type { ChatMessage, ToolDefinition, UsageMetrics } from '../llm/types';
+import { OpenAICompatService, type OpenAIChatCompletionRequest, type OpenAIMessage } from '../services/OpenAICompatService';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('OpenAICompatRaw');
+
+export const RAW_HEADER = 'x-openmake-raw';
+
+/** raw 모드 요청인가 — 헤더 `X-OpenMake-Raw: 1|true` 또는 body.openmake.raw === true */
+export function isRawRequest(req: Pick<Request, 'get'>, body: unknown): boolean {
+    const h = req.get(RAW_HEADER);
+    if (h && ['1', 'true', 'yes'].includes(h.trim().toLowerCase())) return true;
+    const ext = (body as { openmake?: { raw?: unknown } } | null)?.openmake;
+    return ext?.raw === true;
+}
+
+/** OpenAI 메시지 → 내부 ChatMessage (텍스트만. content-part 배열은 text 를 이어 붙인다) */
+export function toChatMessages(messages: OpenAIMessage[]): ChatMessage[] {
+    return messages.map((m) => {
+        const content = typeof m.content === 'string'
+            ? m.content
+            : Array.isArray(m.content)
+                ? m.content.map((p) => (p as { type?: string; text?: string }).type === 'text' ? ((p as { text?: string }).text ?? '') : '').join('')
+                : '';
+        const out: ChatMessage = { role: m.role, content };
+        if (m.tool_calls?.length) {
+            out.tool_calls = m.tool_calls.map((t) => ({
+                id: t.id,
+                type: 'function',
+                function: { name: t.function.name, arguments: safeJson(t.function.arguments) },
+            })) as unknown as ChatMessage['tool_calls'];
+        }
+        const tcid = (m as { tool_call_id?: string }).tool_call_id;
+        if (tcid) out.tool_call_id = tcid;
+        return out;
+    });
+}
+
+function safeJson(s: string): Record<string, unknown> {
+    try { const v = JSON.parse(s) as unknown; return v && typeof v === 'object' ? v as Record<string, unknown> : {}; } catch { return {}; }
+}
+
+type OpenAIToolCall = { id: string; type: 'function'; function: { name: string; arguments: string } };
+
+interface RawResult {
+    content: string;
+    thinking?: string;
+    toolCalls: OpenAIToolCall[];
+    usage: UsageMetrics;
+    finishReason: 'stop' | 'length' | 'tool_calls' | 'error';
+}
+
+export interface RawTarget {
+    kind: 'external' | 'local';
+    providerId?: string;
+    modelId: string;
+}
+
+/** 요청 모델 문자열을 호출 대상으로 해석. 알 수 없는 fullId 접두어는 로컬 이름으로 취급 */
+export function resolveRawTarget(model: string): RawTarget {
+    if (model.includes(':')) {
+        try {
+            const p = parseFullModelId(model);
+            if (p.providerId === 'local-llm') return { kind: 'local', modelId: p.modelId };
+            if (getProviderCatalogEntry(p.providerId)) return { kind: 'external', providerId: p.providerId, modelId: p.modelId };
+        } catch { /* fullId 형식 아님 → 로컬 이름 */ }
+    }
+    return { kind: 'local', modelId: model };
+}
+
+/**
+ * raw 호출을 수행해 OpenAI 형식으로 응답한다 (stream / non-stream 모두).
+ * 호출 전 검증(model 존재·외부 키 등록)은 호출부(openai-compat.routes)가 끝낸 상태여야 한다.
+ */
+export async function handleRawCompletion(
+    req: Request,
+    res: Response,
+    body: OpenAIChatCompletionRequest,
+    opts: { userId: string | null; tools?: ToolDefinition[] },
+): Promise<void> {
+    const target = resolveRawTarget(body.model);
+    const completionId = OpenAICompatService.generateCompletionId();
+    const messages = toChatMessages(body.messages);
+    const abort = new AbortController();
+    // 클라이언트가 응답을 다 받기 전에 끊으면 upstream 도 중단. (req 'close' 는 본문 소비 직후에도 나므로 res 기준)
+    res.on('close', () => { if (!res.writableEnded) abort.abort(); });
+    const startedAt = Date.now();
+
+    const writeChunk = (delta: { role?: string; content?: string; tool_calls?: unknown[] }, finishReason: string | null, extra?: Record<string, unknown>) => {
+        const chunk = OpenAICompatService.buildStreamChunk({ id: completionId, model: body.model, delta, finishReason });
+        res.write(`data: ${JSON.stringify(extra ? { ...chunk, ...extra } : chunk)}\n\n`);
+    };
+
+    if (body.stream === true) {
+        res.setHeader('Content-Type', 'text/event-stream');
+        res.setHeader('Cache-Control', 'no-cache');
+        res.setHeader('Connection', 'keep-alive');
+        res.setHeader('X-Accel-Buffering', 'no');
+        res.flushHeaders();
+        writeChunk({ role: 'assistant' }, null);
+    }
+
+    let result: RawResult;
+    try {
+        result = await callTarget(target, messages, body, opts, abort.signal, (token) => {
+            if (body.stream === true && !abort.signal.aborted) writeChunk({ content: token }, null);
+        });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn(`raw 호출 실패 (${body.model}): ${message}`);
+        if (body.stream === true) {
+            if (!abort.signal.aborted) {
+                res.write(`data: ${JSON.stringify({ error: { message, type: 'upstream_error' } })}\n\n`);
+                res.write(OpenAICompatService.buildDoneEvent());
+            }
+            res.end();
+        } else {
+            res.status(502).json({ error: { message, type: 'upstream_error', code: 'raw_upstream_failed' } });
+        }
+        return;
+    }
+
+    const promptTokens = result.usage.prompt_tokens ?? OpenAICompatService.estimateTokens(messages.map((m) => m.content).join('\n'));
+    const completionTokens = result.usage.completion_tokens ?? OpenAICompatService.estimateTokens(result.content);
+    const usage = { prompt_tokens: promptTokens, completion_tokens: completionTokens, total_tokens: promptTokens + completionTokens };
+    const finish = result.toolCalls.length > 0 ? 'tool_calls' : result.finishReason === 'length' ? 'length' : 'stop';
+    log.info(`raw ${target.kind} ${body.model} ${Date.now() - startedAt}ms in=${promptTokens} out=${completionTokens} finish=${finish}`);
+
+    if (body.stream === true) {
+        if (abort.signal.aborted) { res.end(); return; }
+        if (result.toolCalls.length > 0) writeChunk({ tool_calls: result.toolCalls }, null);
+        // 마지막 청크에 usage 동봉 (stream_options.include_usage 와 같은 위치) — 벤치가 정확 토큰 수를 읽는다
+        writeChunk({}, finish, { usage });
+        res.write(OpenAICompatService.buildDoneEvent());
+        res.end();
+        return;
+    }
+
+    const response = OpenAICompatService.buildResponse({
+        id: completionId,
+        model: body.model,
+        content: result.content,
+        finishReason: finish === 'tool_calls' ? 'tool_calls' : 'stop',
+        promptTokens,
+        completionTokens,
+        toolCalls: result.toolCalls.length > 0 ? result.toolCalls : undefined,
+    });
+    res.json(finish === 'length' ? { ...response, choices: response.choices.map((c) => ({ ...c, finish_reason: 'length' })) } : response);
+}
+
+async function callTarget(
+    target: RawTarget,
+    messages: ChatMessage[],
+    body: OpenAIChatCompletionRequest,
+    opts: { userId: string | null; tools?: ToolDefinition[] },
+    signal: AbortSignal,
+    onToken: (token: string) => void,
+): Promise<RawResult> {
+    if (target.kind === 'external') {
+        if (!opts.userId) throw new Error('external provider requires an API-key user');
+        const repo = new ExternalKeysRepository(getPool());
+        const keyRow = await repo.getByUserAndProvider(opts.userId, target.providerId!);
+        if (!keyRow) throw new Error(`no '${target.providerId}' key registered for this account`);
+        const plaintextKey = await repo.decryptKey(opts.userId, target.providerId!);
+        if (!plaintextKey) throw new Error(`cannot decrypt '${target.providerId}' key`);
+        const provider = createExternalProviderInstance(
+            keyRow,
+            plaintextKey,
+            keyRow.authMethod === 'oauth' ? buildOAuthSessionPersist(repo, opts.userId, target.providerId!) : undefined,
+        );
+        let thinking = '';
+        const r = await provider.streamChat(
+            {
+                messages,
+                modelId: target.modelId,
+                temperature: body.temperature,
+                maxTokens: body.max_tokens,
+                tools: opts.tools,
+                tool_choice: body.tool_choice,
+                abortSignal: signal,
+            },
+            { onToken, onThinking: (t) => { thinking += t; } },
+        );
+        return {
+            content: r.content,
+            thinking: r.thinking ?? (thinking || undefined),
+            toolCalls: (r.toolCalls ?? []).map((t) => ({ id: t.id, type: 'function', function: { name: t.name, arguments: JSON.stringify(t.args ?? {}) } })),
+            usage: r.usage ?? {},
+            finishReason: r.finishReason === 'length' ? 'length' : r.finishReason === 'tool_calls' ? 'tool_calls' : r.finishReason === 'error' ? 'error' : 'stop',
+        };
+    }
+
+    // 로컬 (vLLM/LiteLLM) — 모델을 명시했으므로 ModelPool 자동 라우팅은 우회된다 (client.ts: manual)
+    const client = createClient({ model: target.modelId, userId: opts.userId ?? undefined });
+    const r = await client.chat(
+        messages,
+        { temperature: body.temperature, num_predict: body.max_tokens, top_p: body.top_p, stop: body.stop },
+        (token) => { if (token) onToken(token); },
+        { tools: opts.tools, tool_choice: body.tool_choice, signal },
+    );
+    const toolCalls: OpenAIToolCall[] = (r.tool_calls ?? []).map((t, i) => {
+        const tc = t as unknown as { id?: string; function?: { name?: string; arguments?: unknown } };
+        const args = tc.function?.arguments;
+        return {
+            id: tc.id ?? `call_${i}`,
+            type: 'function',
+            function: { name: tc.function?.name ?? '', arguments: typeof args === 'string' ? args : JSON.stringify(args ?? {}) },
+        };
+    });
+    const fr = r.metrics?.finish_reason;
+    return {
+        content: r.content ?? '',
+        thinking: r.thinking,
+        toolCalls,
+        usage: r.metrics ?? {},
+        finishReason: fr === 'length' ? 'length' : toolCalls.length > 0 ? 'tool_calls' : 'stop',
+    };
+}

--- a/apps/api/src/routes/openai-compat.routes.ts
+++ b/apps/api/src/routes/openai-compat.routes.ts
@@ -15,6 +15,7 @@ import { getProviderCatalogEntry } from '../config/external-providers';
 import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
 import { OpenAICompatSessionRepository } from '../data/repositories/oaicompat-session-repo';
 import { getPool } from '../data/models/unified-database';
+import { handleRawCompletion, isRawRequest } from './openai-compat-raw';
 import { OPENAI_COMPAT_SESSION } from '../config/openai-compat';
 import { createLogger } from '../utils/logger';
 
@@ -273,6 +274,15 @@ openaiCompatRouter.post('/chat/completions', asyncHandler(async (req: Request, r
 
     if (!clusterManager) {
         openaiError(res, 503, 'Cluster manager not initialized');
+        return;
+    }
+
+    // 원본 호출 모드 (X-OpenMake-Raw: 1) — 파이프라인 없이 모델만 부른다. 위의 모델·키 검증은 이미 통과한 상태.
+    if (isRawRequest(req, body)) {
+        await handleRawCompletion(req, res, body, {
+            userId: req.apiKeyRecord?.user_id?.toString() || null,
+            tools: convertTools(body),
+        });
         return;
     }
 

--- a/apps/api/src/routes/v1/index.ts
+++ b/apps/api/src/routes/v1/index.ts
@@ -41,7 +41,10 @@ import openaiCompatRouter from '../openai-compat.routes';
 import { listAvailableModels } from '../../chat/profile-resolver';
 import { ExternalKeysRepository } from '../../data/repositories/external-keys-repo';
 import { getPool } from '../../data/models/unified-database';
-import { getProviderCatalogEntry } from '../../config/external-providers';
+import { getProviderFallbackModels, resolveExternalModels } from '../../services/external-models-catalog';
+import { createLogger } from '../../utils/logger';
+
+const v1Log = createLogger('V1Models');
 import { buildFullModelId } from '../../providers/i-provider';
 import { success, unauthorized } from '../../utils/api-response';
 import { requireApiKey, requireScope } from '../../middlewares/api-key-auth';
@@ -170,31 +173,30 @@ v1Router.get('/models', asyncHandler(async (req, res) => {
     // 외부 provider 모델 노출 (Phase 2, 2026-07-26): API 키 사용자가 등록한
     // BYO/OAuth provider 의 모델을 fullId 로 나열 — CLI/서드파티 클라이언트가
     // /v1/models 디스커버리만으로 'chatgpt:*' 등을 선택할 수 있게 한다.
-    // 라이브 호출 없이 캐시(external_provider_models_cache) → 카탈로그 fallback 순.
+    // 캐시(external_provider_models_cache, TTL) → 만료 시 provider 라이브 조회(+캐시 갱신) → fallback.
+    // 웹 /api/models 와 같은 규칙(services/external-models-catalog). provider 하나의 실패는 fallback 으로 격리.
     const apiUserId = req.apiKeyRecord?.user_id?.toString() || null;
     if (apiUserId) {
         try {
             const repo = new ExternalKeysRepository(getPool());
-            const cacheTtlMs = parseInt(process.env.EXTERNAL_MODELS_CACHE_TTL_MS ?? '3600000', 10);
             const keys = await repo.listByUser(apiUserId);
             // 실사용 불가 모델 제외 (083) — /api/models 와 동일 규칙
             const unusable = await repo.listUnusableModels(apiUserId).catch(() => new Set<string>());
             for (const keyRow of keys) {
-                const cached = await repo.getCachedModels(apiUserId, keyRow.providerId, cacheTtlMs) as
-                    | Array<{ id?: string; fullId?: string }>
-                    | null;
-                const entries = (cached && cached.length > 0)
-                    ? cached.map((m) => ({
-                        fullId: m.fullId ?? buildFullModelId(keyRow.providerId, m.id ?? ''),
-                    }))
-                    : (getProviderCatalogEntry(keyRow.providerId)?.fallbackModels ?? []).map((m) => ({
-                        fullId: buildFullModelId(keyRow.providerId, m.id),
-                    }));
-                for (const m of entries) {
-                    if (!m.fullId) continue;
-                    if (unusable.has(m.fullId)) continue;
+                let list: Array<{ id?: string; fullId?: string }> | null;
+                try {
+                    list = await resolveExternalModels(repo, apiUserId, keyRow);
+                } catch (err) {
+                    v1Log.warn(`${keyRow.providerId} 모델 조회 실패 — fallback 사용: ${err instanceof Error ? err.message : err}`);
+                    list = getProviderFallbackModels(keyRow.providerId);
+                }
+                if (!list) continue;
+                for (const m of list) {
+                    const fullId = m.fullId ?? buildFullModelId(keyRow.providerId, m.id ?? '');
+                    if (!fullId) continue;
+                    if (unusable.has(fullId)) continue;
                     data.push({
-                        id: m.fullId,
+                        id: fullId,
                         object: 'model',
                         created,
                         owned_by: keyRow.providerId,

--- a/apps/api/src/services/external-models-catalog.ts
+++ b/apps/api/src/services/external-models-catalog.ts
@@ -1,0 +1,86 @@
+/**
+ * 외부 provider(BYO key) 모델 카탈로그 — 캐시(TTL) → 라이브 조회(+캐시 저장) → fallback.
+ *
+ * 웹 `/api/models`(model.routes) 와 API 키용 `/api/v1/models`(routes/v1) 가 같은 규칙을 쓴다.
+ * 예전에는 v1 이 캐시가 만료되면 라이브 조회 없이 작은 fallback 목록으로 떨어져, 웹 화면을
+ * 한 번 열기 전까지 API 클라이언트(bench 등)에 모델이 거의 안 보이는 문제가 있었다 (2026-09-04).
+ *
+ * @module services/external-models-catalog
+ */
+
+import type { ExternalKeysRepository, ExternalApiKeyRow } from '../data/repositories/external-keys-repo';
+import { createExternalProviderInstance, buildOAuthSessionPersist } from '../providers/provider-router';
+import { buildFullModelId } from '../providers/i-provider';
+import { getProviderCatalogEntry } from '../config/external-providers';
+import { toCachedModelEntry, type CachedModelRow } from './chat-service/model-capabilities';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('ExternalModelsCatalog');
+
+/** 캐시 TTL (EXTERNAL_MODELS_CACHE_TTL_MS, 기본 1h) */
+export function externalModelsCacheTtlMs(): number {
+    return parseInt(process.env.EXTERNAL_MODELS_CACHE_TTL_MS ?? '3600000', 10);
+}
+
+/**
+ * Provider 별 fallback 모델 목록 — 라이브 조회 실패 또는 빈 배열 반환 시
+ * 사용자가 채팅을 시작할 수 있도록 제공하는 known 모델 카탈로그.
+ *
+ * 모델 카탈로그는 No-Hardcoding 정책에 따라 `config/external-providers.ts` 의
+ * `EXTERNAL_PROVIDER_CATALOG[].fallbackModels` 에 외부화되어 있습니다.
+ */
+export function getProviderFallbackModels(providerId: string): CachedModelRow[] {
+    const entry = getProviderCatalogEntry(providerId);
+    if (!entry?.fallbackModels?.length) return [];
+    return entry.fallbackModels.map(m => ({
+        id: m.id,
+        fullId: buildFullModelId(providerId, m.id),
+        displayName: m.displayName,
+        capabilities: m.capabilities,
+        isFree: m.isFree ?? false,
+    }));
+}
+
+/**
+ * 한 provider 키의 모델 목록.
+ * 1. 캐시가 살아 있으면 그대로
+ * 2. openai-compatible + baseUrl 이면 provider `/v1/models` 라이브 조회 → 비어 있지 않으면 캐시 저장
+ * 3. 그 외(라이브 불가·빈 배열) → fallback 목록
+ *
+ * 라이브 조회 예외는 그대로 던진다 — 호출부가 provider 단위로 격리(warn + skip 또는 fallback)한다.
+ * 복호화된 키가 없으면 null (호출부는 건너뛴다).
+ */
+export async function resolveExternalModels(
+    repo: ExternalKeysRepository,
+    userId: string,
+    keyRow: ExternalApiKeyRow,
+): Promise<CachedModelRow[] | null> {
+    const cached = await repo.getCachedModels(userId, keyRow.providerId, externalModelsCacheTtlMs()) as CachedModelRow[] | null;
+    if (cached && cached.length > 0) return cached;
+
+    const liveCapable = keyRow.sdkType === 'openai-compatible' && !!keyRow.baseUrl;
+    if (!liveCapable) return getProviderFallbackModels(keyRow.providerId);
+
+    const plaintextKey = await repo.decryptKey(userId, keyRow.providerId);
+    if (!plaintextKey) return null;
+    // 공용 팩토리 사용 — OAuth 행(chatgpt)은 Codex transport 기반 ChatGPTOAuthProvider 로 분기된다
+    // (refresh 시 세션 영속화 포함).
+    const provider = createExternalProviderInstance(
+        keyRow,
+        plaintextKey,
+        keyRow.authMethod === 'oauth' ? buildOAuthSessionPersist(repo, userId, keyRow.providerId) : undefined,
+    );
+    const fresh = await provider.listModels();
+    // 캐시 행 형태는 model-capabilities 의 단일점을 쓴다(capabilitiesInferred 유실 방지)
+    const list = fresh.map(toCachedModelEntry);
+    // 빈 배열은 캐싱 안 함 (stale 영구화 방지) + provider별 fallback 모델 보강
+    if (list.length === 0) {
+        const fallback = getProviderFallbackModels(keyRow.providerId);
+        if (fallback.length > 0) {
+            logger.warn(`${keyRow.providerId} /v1/models 빈 배열 — fallback ${fallback.length}개 사용 (캐싱 skip)`);
+        }
+        return fallback;
+    }
+    await repo.putCachedModels(userId, keyRow.providerId, list);
+    return list;
+}

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -18,6 +18,18 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // 웹 SSO 클라이언트(bench 등)에서 온 로그인: 성공 후 /api/auth/sso/authorize 로 돌아가 exchange code 를 받는다.
+  // 마운트 후에 읽어 hydration 불일치를 피한다. 식별자만 허용 (redirect 목적지는 서버 화이트리스트).
+  const [ssoClient, setSsoClient] = useState<string | null>(null);
+  useEffect(() => {
+    const c = new URLSearchParams(window.location.search).get("client");
+    setSsoClient(c && /^[a-z][a-z0-9_-]{0,31}$/.test(c) ? c : null);
+  }, []);
+  const ssoQuery = ssoClient ? `?client=${encodeURIComponent(ssoClient)}` : "";
+  const afterLogin = () => {
+    if (ssoClient) window.location.assign(`/api/auth/sso/authorize${ssoQuery}`);
+    else router.push("/");
+  };
 
   // 첫 실행(admin 0명)이면 셋업 마법사로 유도 — 실패 시 로그인 폼 그대로 (fail-open)
   useEffect(() => {
@@ -40,7 +52,7 @@ export default function LoginPage() {
       // router.push 는 remount 가 없어 AuthSync(마운트 1회)가 다시 돌지 않는다 —
       // 로그인 직후 store 동기화(+익명 세션 이관)를 직접 수행해야 사이드바가 즉시 반영.
       await syncAuthFromServer();
-      router.push("/");
+      afterLogin();
     } catch (err) {
       setError(err instanceof ApiError ? err.message : t("loginFailed"));
     } finally {
@@ -133,21 +145,21 @@ export default function LoginPage() {
 
           <div className="grid grid-cols-3 gap-2">
             <a
-              href="/api/auth/login/google"
+              href={`/api/auth/login/google${ssoQuery}`}
               onClick={() => markOAuthLoginPending("google")}
               className="inline-flex h-9 items-center justify-center rounded-md border border-border-strong bg-surface text-sm font-medium text-fg transition hover:bg-surface-2"
             >
               Google
             </a>
             <a
-              href="/api/auth/login/github"
+              href={`/api/auth/login/github${ssoQuery}`}
               onClick={() => markOAuthLoginPending("github")}
               className="inline-flex h-9 items-center justify-center rounded-md border border-border-strong bg-surface text-sm font-medium text-fg transition hover:bg-surface-2"
             >
               GitHub
             </a>
             <a
-              href="/api/auth/login/kakao"
+              href={`/api/auth/login/kakao${ssoQuery}`}
               onClick={() => markOAuthLoginPending("kakao")}
               className="inline-flex h-9 items-center justify-center rounded-md border border-border-strong bg-[#FEE500] text-sm font-medium text-[#191600] transition hover:brightness-95"
             >


### PR DESCRIPTION
## 변경
- **웹 SSO 클라이언트(bench)**: `GET /api/auth/sso/authorize?client=bench` — 로그인된 사용자에게 일회성 exchange code 를 `SSO_CLIENTS` 에 등록된 redirect URI 로 전달(미로그인은 `/login?client=`). OAuth 시작·콜백도 state 의 `sso:<client>` 로 같은 분기. 로그인 페이지는 `?client=` 를 받아 비밀번호 로그인 뒤 authorize 로 돌아가고 OAuth 링크에 client 를 붙인다.
- **`/api/v1/models` 외부 모델 캐시 라이브 갱신**: 캐시 만료 시 provider 라이브 조회 후 캐시 갱신 — 웹 `/api/models` 와 `services/external-models-catalog` 공용. 종전엔 만료되면 작은 fallback 목록만 나왔다. (#729 의 `toCachedModelEntry` 단일점을 그대로 사용해 `capabilitiesInferred` 보존)
- **OpenAI 호환 raw 모드**: `/api/v1/chat/completions` 에 `X-OpenMake-Raw: 1`(또는 `body.openmake.raw=true`) 이면 에이전트 라우터·페르소나·도구·요약·세션·로컬 폴백 없이 요청 모델(사용자 BYOK 또는 로컬)만 호출, usage 는 provider 값.

## 테스트
- `sso-client-contract.test.ts`(162줄) · `external-models-catalog.test.ts`(75줄) · `openai-compat-raw.test.ts`(109줄) 신규

## 비고
- 원래 #731 브랜치에 함께 올라갔던 커밋을 분리한 것 (`origin/main` 위 cherry-pick, 작성자·메시지 유지).
- 12파일 +817/−89, 마이그레이션 없음. `SSO_CLIENTS` 는 `config/security.ts` 참고.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
