### PR TITLE
fix(deploy): export_dotenv_for_pm2 가 스크립트 readonly 상수와 겹치는 .env 키를 건너뜀

### DIFF
--- a/openmake_llm.sh
+++ b/openmake_llm.sh
@@ -85,6 +85,12 @@ export_dotenv_for_pm2() {
         if [[ "$val" =~ ^\"(.*)\"$ ]] || [[ "$val" =~ ^\'(.*)\'$ ]]; then
             val="${BASH_REMATCH[1]}"
         fi
+        # 이 스크립트가 readonly 로 선언한 이름(COMPOSE_FILE·APP_NAME 등)은 export 가 실패하고
+        # set -e 가 deploy 를 재시작 직전에 조용히 끝낸다(2026-09-04 실사고: 빌드·마이그레이션만 되고
+        # pm2 미재시작). 그런 키는 건너뛴다 — 스크립트 내부 상수라 pm2 에 넘길 대상도 아니다.
+        if readonly -p 2>/dev/null | grep -q " $key="; then
+            continue
+        fi
         export "$key=$val"
     done < "$file"
 }


### PR DESCRIPTION
## 배경
#731 의 `export_dotenv_for_pm2` 첫 실전 배포에서 `.env` 의 `COMPOSE_FILE` 이 스크립트의 `readonly COMPOSE_FILE` 과 충돌 → `export` 실패 → `set -e` 가 deploy 를 **pm2 재시작 직전에 조용히 종료**. 빌드·마이그레이션만 반영되고 프로세스는 옛 것이 남았다(출력 필터로 가려져 있었음).

## 변경
- `readonly -p` 에 있는 이름은 export 를 건너뛴다(스크립트 내부 상수라 pm2 에 넘길 대상도 아님).

## 검증
- `set -euo pipefail` + `readonly COMPOSE_FILE` 조건에서 헬퍼 정상 종료, `bash -n` + `shellcheck -S warning` 통과
- 패치본으로 실제 deploy 재실행: pm2 env 의 `LLM_REASONING_EFFORTS_JSON` 이 `.env` 값(`bai:glm-5.3` 포함)으로 갱신, chat.openmake.cc 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
