### PR TITLE
feat(web): 사이드바·로그인 화면에 openmake.cc·bench.openmake.cc 링크

### DIFF
--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { EXTERNAL_LINKS } from "@/lib/external-links";
 import { ArrowRight, LoaderCircle } from "lucide-react";
 import Image from "next/image";
 import { ApiClient, ApiError } from "@/lib/api-client";
@@ -183,6 +184,17 @@ export default function LoginPage() {
             </Link>
           </p>
         </form>
+
+        {/* 자매 서비스 링크 — 비로그인 사용자의 유일한 진입점 (로그인 후엔 사이드바 계정 메뉴) */}
+        <p className="mt-5 text-center text-xs text-faint">
+          <a href={EXTERNAL_LINKS.homepage} target="_blank" rel="noopener noreferrer" className="transition hover:text-fg">
+            {t("homepage")}
+          </a>
+          <span className="mx-2">·</span>
+          <a href={EXTERNAL_LINKS.bench} target="_blank" rel="noopener noreferrer" className="transition hover:text-fg">
+            {t("bench")}
+          </a>
+        </p>
       </div>
     </div>
   );

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -12,6 +12,8 @@ import {
   BarChart3,
   Terminal,
   ChevronsUpDown,
+  Globe,
+  Gauge,
 } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
@@ -19,6 +21,7 @@ import type { ApiSuccess } from "@openmake/shared-types";
 import { useAppStore } from "@/lib/store";
 import type { ChatRole } from "@/lib/store";
 import { visibleNavItems } from "@/lib/nav";
+import { EXTERNAL_LINKS } from "@/lib/external-links";
 import { ApiClient, ApiError } from "@/lib/api-client";
 import { appendAnonSessionId } from "@/lib/anon-session";
 import { syncAuthFromServer, clearHadSession } from "@/lib/auth-sync";
@@ -359,6 +362,28 @@ export function Sidebar() {
               <Terminal className="h-4 w-4" />
               {tNav("items.developer")}
             </Link>
+            <div className="my-1 border-t border-border" />
+            {/* 자매 서비스 — 홈페이지·bench (bench 는 SSO 경로로 로그인 상태 유지) */}
+            <a
+              href={EXTERNAL_LINKS.homepage}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setMenuOpen(false)}
+              className="flex items-center gap-2.5 rounded-md px-2.5 py-2 text-sm text-fg-2 transition hover:bg-surface-3 hover:text-fg"
+            >
+              <Globe className="h-4 w-4" />
+              {t("homepage")}
+            </a>
+            <a
+              href={EXTERNAL_LINKS.benchSso}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setMenuOpen(false)}
+              className="flex items-center gap-2.5 rounded-md px-2.5 py-2 text-sm text-fg-2 transition hover:bg-surface-3 hover:text-fg"
+            >
+              <Gauge className="h-4 w-4" />
+              {t("bench")}
+            </a>
             <div className="my-1 border-t border-border" />
             <button
               type="button"

--- a/apps/web/lib/external-links.ts
+++ b/apps/web/lib/external-links.ts
@@ -1,0 +1,13 @@
+/**
+ * 자매 서비스 외부 링크 — 사이드바 계정 메뉴·로그인 화면에서 공용.
+ *
+ * bench 는 웹 SSO 클라이언트(백엔드 `SSO_CLIENTS.bench`)라 로그인 사용자는 직접 이동 대신
+ * `/api/auth/sso/authorize?client=bench` 로 보내 로그인된 상태로 도착하게 한다.
+ * 비로그인(로그인 화면)에서는 bench 주소로 직접 링크한다.
+ */
+export const EXTERNAL_LINKS = {
+  homepage: "https://openmake.cc",
+  bench: "https://bench.openmake.cc",
+  /** 로그인 사용자용 — 서버 화이트리스트에 등록된 bench redirect URI 로 exchange code 와 함께 이동 */
+  benchSso: "/api/auth/sso/authorize?client=bench",
+} as const;

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -44,6 +44,8 @@
     "viewAll": "View all",
     "noResults": "No results",
     "accountMenu": "Account menu",
+    "homepage": "OpenMake homepage",
+    "bench": "Benchmark",
     "groups": {
       "today": "Today",
       "yesterday": "Yesterday",
@@ -1084,6 +1086,8 @@
   },
   "auth": {
     "login": {
+      "homepage": "OpenMake homepage",
+      "bench": "Benchmark",
       "subtitle": "Sign in to continue",
       "emailLabel": "Email",
       "passwordLabel": "Password",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -44,6 +44,8 @@
     "viewAll": "すべて表示",
     "noResults": "検索結果なし",
     "accountMenu": "アカウントメニュー",
+    "homepage": "OpenMake ホームページ",
+    "bench": "ベンチマーク",
     "groups": {
       "today": "今日",
       "yesterday": "昨日",
@@ -1084,6 +1086,8 @@
   },
   "auth": {
     "login": {
+      "homepage": "OpenMake ホームページ",
+      "bench": "ベンチマーク",
       "subtitle": "ログインして続行",
       "emailLabel": "メールアドレス",
       "passwordLabel": "パスワード",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -44,6 +44,8 @@
     "viewAll": "모두 보기",
     "noResults": "검색 결과 없음",
     "accountMenu": "계정 메뉴",
+    "homepage": "OpenMake 홈페이지",
+    "bench": "벤치마크",
     "groups": {
       "today": "오늘",
       "yesterday": "어제",
@@ -1084,6 +1086,8 @@
   },
   "auth": {
     "login": {
+      "homepage": "OpenMake 홈페이지",
+      "bench": "벤치마크",
       "subtitle": "로그인하고 계속하세요",
       "emailLabel": "이메일",
       "passwordLabel": "비밀번호",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -44,6 +44,8 @@
     "viewAll": "查看全部",
     "noResults": "无搜索结果",
     "accountMenu": "账户菜单",
+    "homepage": "OpenMake 主页",
+    "bench": "基准测试",
     "groups": {
       "today": "今天",
       "yesterday": "昨天",
@@ -1084,6 +1086,8 @@
   },
   "auth": {
     "login": {
+      "homepage": "OpenMake 主页",
+      "bench": "基准测试",
       "subtitle": "登录以继续",
       "emailLabel": "邮箱",
       "passwordLabel": "密码",


### PR DESCRIPTION
## 변경
- `apps/web/lib/external-links.ts` — 홈페이지·bench·bench SSO 경로 상수 (No-Hardcoding)
- 사이드바 계정 메뉴(설정·사용량·개발자 아래)에 **OpenMake 홈페이지**·**벤치마크** 항목. 벤치마크는 `/api/auth/sso/authorize?client=bench` 로 열어 PR #732 웹 SSO 로 로그인 상태 유지. 모바일 드로어는 같은 컴포넌트라 자동 노출
- 로그인 화면 하단에 비로그인 사용자용 직접 링크 한 줄
- i18n ko/en/ja/zh `sidebar`·`auth.login` 에 `homepage`/`bench` 키

## 검증
- `tsc --noEmit` · eslint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)