### PR TITLE
fix(providers): B.AI deepseek 2종 무료 해제 + 잔액 부족 응답 INSUFFICIENT_CREDIT 분류

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,7 +63,7 @@ LLM_TIMEOUT=120000                              # HTTP 요청 타임아웃 (ms)
 # LiteLLM 통합 게이트웨이로 inference 를 라우팅할 외부 provider id 콤마 목록.
 # 빈값/미설정 = 전부 direct 호출. provider별 롤백은 목록에서 제거 + 재시작.
 # ollama-local(사용자별 endpoint)·chatgpt(OAuth) 는 목록과 무관하게 direct 유지.
-# LLM_GATEWAY_PROVIDERS=openrouter,ollama-cloud,nvidia,hasa
+# LLM_GATEWAY_PROVIDERS=openrouter,ollama-cloud,nvidia,hasa,bai
 # 오케스트레이션 자동 배정 (Stage 1) — 모델이 토론(start_discussion)·백그라운드 작업
 # (delegate_agent_task)을 도구로 직접 배정. 의도 프리필터 매칭 턴에만 도구 노출.
 # ORCHESTRATION_AUTO_DISPATCH=true

--- a/apps/api/src/config/external-providers.ts
+++ b/apps/api/src/config/external-providers.ts
@@ -220,17 +220,20 @@ export const EXTERNAL_PROVIDER_CATALOG: ReadonlyArray<ExternalProviderCatalogEnt
         helpText:
             'B.AI (https://docs.b.ai/llmservice/api/) 의 API 키(sk-*)를 입력하세요. OpenAI 호환 API 로 ' +
             'GPT·Claude·Gemini·DeepSeek·Qwen·GLM 등을 크레딧 과금으로 제공합니다. ' +
-            '아래 목록은 2026-09-02 실측 기준 크레딧 잔액 0 인 키로도 호출되는 무료 모델만 수록했습니다 — ' +
+            '무료 표시(isFree) 모델은 2026-09-04 실측 기준 크레딧 잔액 0 인 키로도 호출되는 것만 남겼습니다 — ' +
             '그 외 모델은 예치(deposit)·크레딧이 필요해 403/400 이 납니다. 모델 ID 는 "qwen3.8-flash" 처럼 접두사 없는 형식입니다. ' +
             '연속 호출 시 429 가 잦으니 병렬 사용은 피하세요.',
         authMethods: ['api_key'] as const,
         // 2026-09-02 실측(무료 키·잔액 0): 45개 중 5개만 200. tools 는 5개 전부, vision 은 qwen3.8-flash·
         // glm-5.3-flash·deepseek-v4-flash-vision-exp 만(32px 이상 이미지), 5개 전부 reasoning_content 반환.
+        // 2026-09-04 재실측: deepseek-v4-flash·vision-exp 는 B.AI 측이 유료로 전환 — 빈 프롬프트도
+        //   400 "credit insufficient balance: balance=0 required=18"(insufficient_user_quota). capability 는
+        //   실측값이라 항목은 남기고 isFree 만 내린다(무료 목록은 B.AI 정책에 따라 수시로 바뀐다).
         fallbackModels: [
             { id: 'qwen3.8-flash',                displayName: 'Qwen3.8 Flash',                 isFree: true, capabilities: { streaming: true, toolCalling: true, vision: true,  thinking: true } },
             { id: 'glm-5.3-flash',                displayName: 'GLM 5.3 Flash',                 isFree: true, capabilities: { streaming: true, toolCalling: true, vision: true,  thinking: true } },
-            { id: 'deepseek-v4-flash',            displayName: 'DeepSeek V4 Flash',             isFree: true, capabilities: { streaming: true, toolCalling: true, vision: false, thinking: true } },
-            { id: 'deepseek-v4-flash-vision-exp', displayName: 'DeepSeek V4 Flash Vision (exp)', isFree: true, capabilities: { streaming: true, toolCalling: true, vision: true,  thinking: true } },
+            { id: 'deepseek-v4-flash',            displayName: 'DeepSeek V4 Flash',             isFree: false, capabilities: { streaming: true, toolCalling: true, vision: false, thinking: true } },
+            { id: 'deepseek-v4-flash-vision-exp', displayName: 'DeepSeek V4 Flash Vision (exp)', isFree: false, capabilities: { streaming: true, toolCalling: true, vision: true,  thinking: true } },
             { id: 'hy3',                          displayName: 'Hunyuan 3',                     isFree: true, capabilities: { streaming: true, toolCalling: true, vision: false, thinking: true } },
         ],
     },

--- a/apps/api/src/providers/__tests__/openai-compat-error-map.test.ts
+++ b/apps/api/src/providers/__tests__/openai-compat-error-map.test.ts
@@ -1,0 +1,36 @@
+/**
+ * mapOpenAIError — 잔액 부족 응답 분류 (2026-09-04 B.AI 실측)
+ *
+ * B.AI 는 402 가 아니라 400(insufficient_user_quota)·403("Deposit required") 로 잔액 부족을 알린다.
+ * 종전엔 각각 UPSTREAM_ERROR·INVALID_API_KEY 가 되어 폴백 배지가 "업스트림 오류"/"인증 오류"로 오안내됐다.
+ */
+import { mapOpenAIError } from '../openai-compat-provider';
+
+function httpErr(status: number, message: string): Error & { status: number } {
+    return Object.assign(new Error(message), { status });
+}
+
+describe('mapOpenAIError — 잔액 부족 분류', () => {
+    it('400 insufficient_user_quota (B.AI) → INSUFFICIENT_CREDIT', () => {
+        const e = mapOpenAIError(httpErr(400, 'litellm.BadRequestError: OpenAIException - credit insufficient balance: balance=0 required=18'));
+        expect(e.code).toBe('INSUFFICIENT_CREDIT');
+    });
+
+    it('403 "Deposit required" (B.AI premium) → INSUFFICIENT_CREDIT (인증 오류 아님)', () => {
+        const e = mapOpenAIError(httpErr(403, 'Access restricted. Deposit required to unlock premium models.'));
+        expect(e.code).toBe('INSUFFICIENT_CREDIT');
+    });
+
+    it('402 → INSUFFICIENT_CREDIT (종전 동작 유지)', () => {
+        expect(mapOpenAIError(httpErr(402, 'Payment required')).code).toBe('INSUFFICIENT_CREDIT');
+    });
+
+    it('일반 400 은 여전히 UPSTREAM_ERROR', () => {
+        expect(mapOpenAIError(httpErr(400, 'The request is invalid: unsupported parameter')).code).toBe('UPSTREAM_ERROR');
+    });
+
+    it('403 구독 문구는 여전히 SUBSCRIPTION_REQUIRED, 일반 403 은 INVALID_API_KEY', () => {
+        expect(mapOpenAIError(httpErr(403, 'this model requires a subscription, upgrade for access')).code).toBe('SUBSCRIPTION_REQUIRED');
+        expect(mapOpenAIError(httpErr(403, 'forbidden')).code).toBe('INVALID_API_KEY');
+    });
+});

--- a/apps/api/src/providers/openai-compat-provider.ts
+++ b/apps/api/src/providers/openai-compat-provider.ts
@@ -114,10 +114,21 @@ function inferCapabilitiesFromModelId(
     return caps;
 }
 
-function mapOpenAIError(err: unknown): ProviderError {
+/**
+ * 402 가 아닌 status 로 오는 잔액 부족 응답 (2026-09-04 B.AI 실측):
+ *   400 `{"code":"insufficient_user_quota","message":"credit insufficient balance: balance=0 required=18"}`
+ *   403 `"Access restricted. Deposit required to unlock premium models."`
+ * 인증 오류·업스트림 오류로 분류하면 사용자에게 "인증 오류"/"업스트림 오류"로 오안내된다.
+ */
+const INSUFFICIENT_CREDIT_PATTERN = /insufficient[_ ]user[_ ]quota|insufficient balance|deposit required/i;
+
+export function mapOpenAIError(err: unknown): ProviderError {
     const message = err instanceof Error ? err.message : String(err);
     if (err && typeof err === 'object' && 'status' in err) {
         const status = (err as { status?: number }).status;
+        if ((status === 400 || status === 402 || status === 403) && INSUFFICIENT_CREDIT_PATTERN.test(message)) {
+            return new ProviderError('INSUFFICIENT_CREDIT', `잔액 부족: ${message}`, err);
+        }
         if (status === 401 || status === 403) {
             // 403 중 구독/플랜 미달 응답은 키 문제가 아님 — 별도 코드로 분기
             // (예: Ollama Cloud "this model requires a subscription, upgrade for access")

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -427,6 +427,7 @@
     "modelFallbackNotice": "The selected model ({from}) did not respond, so the default model ({to}) answered instead.",
     "modelFallbackReasons": {
       "QUOTA_EXCEEDED": "usage limit reached",
+      "INSUFFICIENT_CREDIT": "insufficient credit",
       "SUBSCRIPTION_REQUIRED": "subscription required",
       "INVALID_API_KEY": "authentication error",
       "MISSING_API_KEY": "authentication error",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -427,6 +427,7 @@
     "modelFallbackNotice": "選択したモデル({from})が応答しなかったため、既定のモデル({to})が回答しました。",
     "modelFallbackReasons": {
       "QUOTA_EXCEEDED": "利用上限に到達",
+      "INSUFFICIENT_CREDIT": "クレジット不足",
       "SUBSCRIPTION_REQUIRED": "サブスクリプションが必要",
       "INVALID_API_KEY": "認証エラー",
       "MISSING_API_KEY": "認証エラー",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -427,6 +427,7 @@
     "modelFallbackNotice": "선택한 모델({from})이 응답하지 않아 기본 모델({to})로 답변했습니다.",
     "modelFallbackReasons": {
       "QUOTA_EXCEEDED": "사용량 한도 초과",
+      "INSUFFICIENT_CREDIT": "크레딧 부족",
       "SUBSCRIPTION_REQUIRED": "구독 필요",
       "INVALID_API_KEY": "인증 오류",
       "MISSING_API_KEY": "인증 오류",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -427,6 +427,7 @@
     "modelFallbackNotice": "所选模型（{from}）未响应，已由默认模型（{to}）作答。",
     "modelFallbackReasons": {
       "QUOTA_EXCEEDED": "已达使用上限",
+      "INSUFFICIENT_CREDIT": "积分不足",
       "SUBSCRIPTION_REQUIRED": "需要订阅",
       "INVALID_API_KEY": "认证错误",
       "MISSING_API_KEY": "认证错误",

--- a/scripts/vllm/litellm.config.yaml
+++ b/scripts/vllm/litellm.config.yaml
@@ -7,7 +7,7 @@
 # 토폴로지:
 #   앱(LLM_BASE_URL=http://127.0.0.1:13401) → 이 게이트웨이
 #     ├─ 로컬: Tailscale → DGX vLLM (:8002 qwen / :8003 bge / :8005 flux)
-#     └─ 외부: openrouter/* · ollama-cloud/* · nvidia/* · hasa/* wildcard (사용자 BYOK 는 요청 헤더)
+#     └─ 외부: openrouter/* · ollama-cloud/* · nvidia/* · hasa/* · bai/* wildcard (사용자 BYOK 는 요청 헤더)
 #
 # 헤더 계약 (LiteLLM 1.89.4 라이브 검증):
 #   Authorization: Bearer <LITELLM_MASTER_KEY>  → 게이트웨이 인증 (upstream 미전달)
@@ -70,6 +70,12 @@ model_list:
     litellm_params:
       model: openai/*
       api_base: https://open.hasa.re.kr/v1
+      api_key: os.environ/DUMMY_UPSTREAM_KEY
+
+  - model_name: bai/*
+    litellm_params:
+      model: openai/*
+      api_base: https://api.b.ai/v1
       api_key: os.environ/DUMMY_UPSTREAM_KEY
 
 general_settings:


### PR DESCRIPTION
## 증상
B.AI 모델 선택 시 `선택한 모델(bai:deepseek-v4-flash)이 응답하지 않아 기본 모델(local-llm:qwen3.8-27b)로 답변했습니다. (업스트림 오류)`

## 원인 (직접 재현)
- B.AI 가 09-04 부터 `deepseek-v4-flash`·`deepseek-v4-flash-vision-exp` 를 유료 전환 — 빈 프롬프트도 400 `credit insufficient balance: balance=0 required=18` (`insufficient_user_quota`). 09-02 실측 기준 카탈로그가 stale.
- 나머지 무료 3종(`qwen3.8-flash`·`glm-5.3-flash`·`hy3`)은 직결·LiteLLM 게이트웨이(effort none/low/medium/high)·chat.openmake.cc WS 라이브 전부 200.
- 부수: 400/403 잔액 부족 응답이 `UPSTREAM_ERROR`/`INVALID_API_KEY` 로 분류돼 폴백 배지가 "업스트림 오류"/"인증 오류"로 오안내.

## 변경
- `external-providers.ts`: deepseek 2종 `isFree:false` (capability 실측값 유지)
- `openai-compat-provider.ts`: `insufficient_user_quota` / `insufficient balance` / `deposit required` (400·402·403) → `INSUFFICIENT_CREDIT`. `mapOpenAIError` export + 테스트 5건
- `apps/web/messages/*` 4 locale: `modelFallbackReasons.INSUFFICIENT_CREDIT`
- `.env.example`·`scripts/vllm/litellm.config.yaml`: 09-04 운영 반영된 `bai/*` 게이트웨이 편입 참조본 동기화

## 검증
- `tsc --noEmit` 0, 관련 jest 4 suite 44 passed
- 라이브 WS(user 3): 5종 호출 → 3종 정답·폴백 없음 / deepseek 2종 폴백(잔액 부족)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeQPXhmHMo2XXQKxgR1xpt