### PR TITLE
fix(research): 딥리서치 정합성 결함 6건 (depth 표·needsMore·REST 취소·CAPACITY·configure_research 격리·schema default)

### DIFF
--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -143,10 +143,8 @@ export const CAPACITY = {
     RESEARCH_MAX_SEARCH_QUERIES: 3,
     /** Deep Research 쿼리당 소스 최대 수 */
     RESEARCH_MAX_SOURCES_PER_QUERY: 10,
-    /** Deep Research 전체 소스 최대 수 */
-    RESEARCH_MAX_TOTAL_SOURCES: 15,
-    /** Deep Research 결과 상위 N개 (유틸) */
-    RESEARCH_TOP_RESULTS: 20,
+    /** Deep Research 서브토픽 최대 수 (분해 결과 상위 N개 — 구 RESEARCH_MAX_TOTAL_SOURCES 는 이름과 달리 이 용도였다, 2026-09-05 정정) */
+    RESEARCH_MAX_SUBTOPICS: 15,
     /** 검색 결과 응답 미리보기 최대 항목 */
     SEARCH_RESULT_MAX_DISPLAY: 10,
     /** Admin 대화 내보내기 SQL LIMIT */
@@ -189,6 +187,12 @@ export const RESEARCH_DEFAULTS = {
      * 이제 1개라도 유효하면 모델의 분해를 존중한다(템플릿은 파싱 실패·0개일 때만).
      */
     MIN_SUBTOPICS: 1,
+    /**
+     * 추가 탐색 필요 여부(needsMore) LLM 판정을 건너뛰고 무조건 계속하는 소스 비율 —
+     * 누적 소스 < config.maxTotalSources × 이 값 이면 LLM 을 묻지 않는다.
+     * (2026-09-05 정정: 종전엔 config 가 아니라 이 모듈 상수 MAX_TOTAL_SOURCES 에 곱해 호출자 override 가 무시됐다)
+     */
+    NEED_MORE_SKIP_RATIO: 0.6,
     /** 계층적 병합 전환 임계값 (청크 요약 수가 이 값 초과 시 재귀 병합) */
     MAP_REDUCE_THRESHOLD: 8,
     /** 계층적 병합 최대 깊이 (비용/지연 제어) */

--- a/apps/api/src/mcp/deep-research.ts
+++ b/apps/api/src/mcp/deep-research.ts
@@ -15,7 +15,6 @@ import { MCPToolDefinition, MCPToolResult } from './types';
 import { getUnifiedDatabase } from '../data/models/unified-database';
 import {
     createDeepResearchService,
-    configureResearch as configureResearchGlobal,
     getResearchMessage,
     ResearchConfig,
     ResearchProgress
@@ -25,6 +24,7 @@ import { createLogger } from '../utils/logger';
 import { isPersistableUserId } from '../utils/user-id-validation';
 import { detectLanguage } from '../chat/language-policy';
 import { CLEANUP_INTERVALS } from '../config/timeouts';
+import { RESEARCH_DEPTH_LOOPS, RESEARCH_DEFAULTS } from '../config/runtime-limits';
 
 const logger = createLogger('DeepResearchMCP');
 
@@ -45,6 +45,23 @@ const activeResearches = new Map<string, {
     progress: ResearchProgress;
     startTime: number;
 }>();
+
+/**
+ * configure_research 의 사용자별 설정 override (프로세스 메모리).
+ * 2026-09-05 정정: 종전엔 DeepResearchService 의 전역 config 를 바꿔 한 사용자의 호출이
+ * 이후 모든 사용자의 리서치에 적용됐다. 이제 userId 키로 격리하고 research 도구가 자기 것만 합친다.
+ */
+const userResearchOverrides = new Map<string, Partial<ResearchConfig>>();
+const OVERRIDE_KEY_ANONYMOUS = 'anonymous';
+
+function overrideKey(userId: unknown): string {
+    return typeof userId === 'string' && userId.trim() ? userId : OVERRIDE_KEY_ANONYMOUS;
+}
+
+/** 테스트·research 도구용 — 해당 사용자의 override 사본 */
+export function getUserResearchOverrides(userId: unknown): Partial<ResearchConfig> {
+    return { ...(userResearchOverrides.get(overrideKey(userId)) ?? {}) };
+}
 
 // ============================================================
 // research 도구
@@ -119,7 +136,7 @@ export const researchTool: MCPToolDefinition = {
                     sessionId,
                     status: 'running',
                     currentLoop: 0,
-                    totalLoops: depth === 'quick' ? 1 : depth === 'standard' ? 3 : 5,
+                    totalLoops: RESEARCH_DEPTH_LOOPS[depth],
                     currentStep: 'starting',
                     progress: 0,
                     message: getResearchMessage('init', language)
@@ -127,11 +144,12 @@ export const researchTool: MCPToolDefinition = {
                 startTime: Date.now()
             });
 
-            // depth에 따른 maxLoops 설정
-            const maxLoops = depth === 'quick' ? 1 : depth === 'standard' ? 3 : 5;
+            // depth → 루프 수는 REST 와 같은 단일 표(RESEARCH_DEPTH_LOOPS). 사용자 configure_research 의 maxLoops 가 있으면 우선.
+            const overrides = getUserResearchOverrides(userId);
+            const maxLoops = overrides.maxLoops ?? RESEARCH_DEPTH_LOOPS[depth];
 
             // 비동기로 리서치 실행 (블로킹하지 않음)
-            const service = createDeepResearchService({ maxLoops, language });
+            const service = createDeepResearchService({ ...overrides, maxLoops, language });
             
             // 백그라운드 실행
             service.executeResearch(sessionId, topic, (progress) => {
@@ -236,7 +254,7 @@ export const getResearchStatusTool: MCPToolDefinition = {
                 sessionId,
                 status: session.status,
                 currentLoop: 0,
-                totalLoops: session.depth === 'quick' ? 1 : session.depth === 'standard' ? 3 : 5,
+                totalLoops: RESEARCH_DEPTH_LOOPS[session.depth as keyof typeof RESEARCH_DEPTH_LOOPS] ?? RESEARCH_DEPTH_LOOPS.standard,
                 currentStep: session.status,
                 progress: session.progress || 0,
                 message: session.status === 'completed' ? '리서치 완료' : session.status === 'failed' ? '리서치 실패' : '상태 확인 중'
@@ -312,7 +330,7 @@ export const getResearchStatusTool: MCPToolDefinition = {
  * @param args.maxLoops - 최대 반복 횟수 (1-10)
  * @param args.llmModel - LLM 모델명
  * @param args.searchApi - 검색 API 선택
- * @param args.maxSearchResults - 최대 검색 결과 수 (5-50)
+ * @param args.maxSearchResults - 최대 검색 결과 수 (5-200)
  * @param args.language - 출력 언어 (ko/en/ja/zh/es/de)
  * @returns 업데이트된 설정 (JSON)
  */
@@ -338,7 +356,7 @@ export const configureResearchTool: MCPToolDefinition = {
                 },
                 maxSearchResults: {
                     type: 'number',
-                    description: '검색 결과 최대 수 (5-50)'
+                    description: '검색 결과 최대 수 (5-200)'
                 },
                 language: {
                     type: 'string',
@@ -387,13 +405,14 @@ export const configureResearchTool: MCPToolDefinition = {
             }
 
             if (maxSearchResults !== undefined) {
-                if (maxSearchResults < 5 || maxSearchResults > 50) {
+                // 상한은 기본값(RESEARCH_DEFAULTS.MAX_SEARCH_RESULTS)까지 — 종전 50 은 기본 200 보다 작아 실제 값을 표현할 수 없었다
+                if (maxSearchResults < 5 || maxSearchResults > RESEARCH_DEFAULTS.MAX_SEARCH_RESULTS) {
                     return {
                         content: [{
                             type: 'text',
                             text: JSON.stringify({
                                 success: false,
-                                error: 'maxSearchResults는 5-50 사이여야 합니다.'
+                                error: `maxSearchResults는 5-${RESEARCH_DEFAULTS.MAX_SEARCH_RESULTS} 사이여야 합니다.`
                             }, null, 2)
                         }],
                         isError: true
@@ -406,10 +425,12 @@ export const configureResearchTool: MCPToolDefinition = {
                 updates.language = language;
             }
 
-            // 설정 업데이트
-            const newConfig = configureResearchGlobal(updates);
+            // 사용자별 override 갱신 (전역 config 는 건드리지 않는다)
+            const key = overrideKey(args.userId);
+            const newConfig = { ...(userResearchOverrides.get(key) ?? {}), ...updates };
+            userResearchOverrides.set(key, newConfig);
 
-            logger.info(`[DeepResearch MCP] 설정 변경: ${JSON.stringify(updates)}`);
+            logger.info(`[DeepResearch MCP] 설정 변경(user=${key}): ${JSON.stringify(updates)}`);
 
             return {
                 content: [{

--- a/apps/api/src/routes/research.routes.ts
+++ b/apps/api/src/routes/research.routes.ts
@@ -36,6 +36,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { createDeepResearchService } from '../services/DeepResearchService';
 import { resolveRoleClientForUser } from '../services/model-role-resolver';
 import { detectLanguage } from '../chat/language-policy';
+import { registerActiveRun, unregisterActiveRun, abortActiveRun } from '../services/deep-research/active-runs';
 import { RESEARCH_DEPTH_LOOPS, RESEARCH_SESSION_LIST_ALL_DEFAULT } from '../config/runtime-limits';
 import { isAdminRole } from '../data/user-manager';
 import {
@@ -268,10 +269,13 @@ router.post('/sessions/:sessionId/execute', validate(executeResearchSchema), asy
         resolved.client,
     );
 
-    // 백그라운드 실행 (응답은 즉시 반환)
-    service.executeResearch(sessionId, session.topic).catch((error) => {
-        logger.error(`[ResearchRoutes] 리서치 실행 실패: ${error}`);
-    });
+    // 백그라운드 실행 (응답은 즉시 반환). abort 는 레지스트리로 배선 — cancel/DELETE 가 중단한다.
+    const controller = registerActiveRun(sessionId);
+    service.executeResearch(sessionId, session.topic, undefined, controller.signal)
+        .catch((error) => {
+            logger.error(`[ResearchRoutes] 리서치 실행 실패: ${error}`);
+        })
+        .finally(() => unregisterActiveRun(sessionId, controller));
 
     logger.info(`[ResearchRoutes] 리서치 실행 시작: ${sessionId}`);
 
@@ -285,8 +289,29 @@ router.post('/sessions/:sessionId/execute', validate(executeResearchSchema), asy
 }));
 
 /**
+ * POST /api/research/sessions/:sessionId/cancel
+ * 실행 중인 리서치 중단 (이 프로세스에서 실행 중일 때만 유효)
+ */
+router.post('/sessions/:sessionId/cancel', requireAuth, asyncHandler(async (req: Request, res: Response) => {
+    const { sessionId } = req.params;
+    const db = getUnifiedDatabase();
+    const session = await db.getResearchSession(sessionId);
+    if (!session) {
+        return res.status(404).json(notFound('리서치 세션을 찾을 수 없습니다.'));
+    }
+    assertResourceOwnerOrAdmin(String(session.user_id), String(req.user!.id), req.user!.role || 'user');
+
+    const aborted = abortActiveRun(sessionId);
+    if (!aborted) {
+        return res.status(409).json(badRequest('이 프로세스에서 실행 중인 리서치가 아닙니다.'));
+    }
+    logger.info(`[ResearchRoutes] 리서치 중단 요청: ${sessionId}`);
+    res.json(success({ message: '리서치 중단을 요청했습니다.', sessionId }));
+}));
+
+/**
  * DELETE /api/research/sessions/:sessionId
- * 리서치 세션 삭제
+ * 리서치 세션 삭제 (실행 중이면 먼저 중단)
  */
 router.delete('/sessions/:sessionId', requireAuth, asyncHandler(async (req: Request, res: Response) => {
     const { sessionId } = req.params;
@@ -304,6 +329,7 @@ router.delete('/sessions/:sessionId', requireAuth, asyncHandler(async (req: Requ
         req.user!.role || 'user'
     );
 
+    abortActiveRun(sessionId);
     await db.deleteResearchSession(sessionId);
 
     res.json(success({ message: '리서치 세션이 삭제되었습니다.' }));

--- a/apps/api/src/schemas/research.schema.ts
+++ b/apps/api/src/schemas/research.schema.ts
@@ -58,7 +58,8 @@ export const updateResearchSessionSchema = z.object({
  * @property {number} [maxLoops] - 최대 반복 횟수 (1~10, 기본값: 5)
  */
 export const executeResearchSchema = z.object({
-    maxLoops: z.number().int().min(1).max(10).optional().default(5)
+    // default 를 두지 않는다 — 두면 세션 depth(RESEARCH_DEPTH_LOOPS) 가 영원히 무시된다(2026-09-05 정정: 종전 default(5))
+    maxLoops: z.number().int().min(1).max(10).optional()
 });
 
 /** 리서치 세션 생성 요청 TypeScript 타입 */

--- a/apps/api/src/services/deep-research/__tests__/active-runs.test.ts
+++ b/apps/api/src/services/deep-research/__tests__/active-runs.test.ts
@@ -1,0 +1,34 @@
+/** REST 리서치 취소 레지스트리 — 2026-09-05 (REST execute abort 미배선 결함 수정) */
+import { registerActiveRun, unregisterActiveRun, abortActiveRun, isActiveRun } from '../active-runs';
+
+describe('active-runs', () => {
+    it('등록 → abort 시 signal 이 aborted 되고 레지스트리에서 제거된다', () => {
+        const c = registerActiveRun('s1');
+        expect(isActiveRun('s1')).toBe(true);
+        expect(abortActiveRun('s1')).toBe(true);
+        expect(c.signal.aborted).toBe(true);
+        expect(isActiveRun('s1')).toBe(false);
+    });
+
+    it('미등록 세션 abort 는 false (다른 프로세스에서 실행 중일 수 있어 404 아님)', () => {
+        expect(abortActiveRun('nope')).toBe(false);
+    });
+
+    it('같은 세션 재등록은 이전 컨트롤러를 abort 한다', () => {
+        const a = registerActiveRun('s2');
+        const b = registerActiveRun('s2');
+        expect(a.signal.aborted).toBe(true);
+        expect(b.signal.aborted).toBe(false);
+        unregisterActiveRun('s2', b);
+        expect(isActiveRun('s2')).toBe(false);
+    });
+
+    it('unregister 는 등록된 컨트롤러와 다르면 무시한다 (늦게 끝난 구 실행이 새 실행을 지우지 않음)', () => {
+        const old = registerActiveRun('s3');
+        const fresh = registerActiveRun('s3');
+        unregisterActiveRun('s3', old);
+        expect(isActiveRun('s3')).toBe(true);
+        unregisterActiveRun('s3', fresh);
+        expect(isActiveRun('s3')).toBe(false);
+    });
+});

--- a/apps/api/src/services/deep-research/__tests__/needs-more-config.test.ts
+++ b/apps/api/src/services/deep-research/__tests__/needs-more-config.test.ts
@@ -1,0 +1,30 @@
+/** checkNeedsMoreInfo 가 모듈 상수가 아니라 config.maxTotalSources 를 기준으로 삼는지 — 2026-09-05 */
+const chatMock = jest.fn();
+jest.mock('../chat-with-timeout', () => ({ chatWithAbortTimeout: (...a: unknown[]) => chatMock(...a) }));
+jest.mock('../../../data/models/unified-database', () => ({ getUnifiedDatabase: () => ({ addResearchStep: jest.fn() }) }));
+
+import { checkNeedsMoreInfo } from '../findings-synthesizer';
+import { RESEARCH_DEFAULTS } from '../../../config/runtime-limits';
+import type { ResearchConfig } from '../../deep-research-types';
+
+const base = { client: {} as never, topic: 'T', currentFindings: [], throwIfAborted: () => undefined };
+
+describe('checkNeedsMoreInfo — 판정 생략 임계는 config 기준', () => {
+    beforeEach(() => chatMock.mockReset());
+
+    it('maxTotalSources=10 이면 소스 6개부터 LLM 에 묻는다 (상수 50 기준이면 30 미만이라 묻지 않았음)', async () => {
+        chatMock.mockResolvedValue({ content: 'no' });
+        const config = { maxTotalSources: 10, language: 'ko' } as ResearchConfig;
+        const r = await checkNeedsMoreInfo({ ...base, config, sourceCount: 6 });
+        expect(chatMock).toHaveBeenCalledTimes(1);
+        expect(r).toBe(false);
+    });
+
+    it('임계 미만이면 LLM 호출 없이 true', async () => {
+        const config = { maxTotalSources: 10, language: 'ko' } as ResearchConfig;
+        const below = Math.floor(10 * RESEARCH_DEFAULTS.NEED_MORE_SKIP_RATIO) - 1;
+        const r = await checkNeedsMoreInfo({ ...base, config, sourceCount: below });
+        expect(chatMock).not.toHaveBeenCalled();
+        expect(r).toBe(true);
+    });
+});

--- a/apps/api/src/services/deep-research/active-runs.ts
+++ b/apps/api/src/services/deep-research/active-runs.ts
@@ -1,0 +1,40 @@
+/**
+ * Deep Research — REST 경로 실행 중 세션의 AbortController 레지스트리 (프로세스 메모리).
+ *
+ * 2026-09-05: `POST /sessions/:id/execute` 가 abort signal 을 배선하지 않아 REST 로 시작한
+ * 리서치는 취소할 수 없었다(채팅 경로만 WS disconnect 로 중단). 실행 시 등록하고
+ * `POST /sessions/:id/cancel`·`DELETE` 가 abort 한다. 다중 인스턴스 환경이면 같은 프로세스가
+ * 아닐 수 있어 "이 프로세스에서 실행 중이 아님" 은 404 가 아니라 false 로 돌려준다.
+ *
+ * @module services/deep-research/active-runs
+ */
+
+const controllers = new Map<string, AbortController>();
+
+/** 실행 시작 — 같은 세션이 이미 있으면 기존 것을 abort 하고 교체 */
+export function registerActiveRun(sessionId: string): AbortController {
+    const prev = controllers.get(sessionId);
+    if (prev) prev.abort();
+    const controller = new AbortController();
+    controllers.set(sessionId, controller);
+    return controller;
+}
+
+/** 실행 종료(성공·실패·취소 모두) — 등록된 컨트롤러와 동일할 때만 제거 */
+export function unregisterActiveRun(sessionId: string, controller?: AbortController): void {
+    if (controller && controllers.get(sessionId) !== controller) return;
+    controllers.delete(sessionId);
+}
+
+/** 취소 요청 — 이 프로세스에서 실행 중이면 abort 후 true */
+export function abortActiveRun(sessionId: string): boolean {
+    const controller = controllers.get(sessionId);
+    if (!controller) return false;
+    controller.abort();
+    controllers.delete(sessionId);
+    return true;
+}
+
+export function isActiveRun(sessionId: string): boolean {
+    return controllers.has(sessionId);
+}

--- a/apps/api/src/services/deep-research/findings-synthesizer.ts
+++ b/apps/api/src/services/deep-research/findings-synthesizer.ts
@@ -290,7 +290,7 @@ export async function checkNeedsMoreInfo(params: {
     const { client, config, topic, currentFindings, sourceCount, abortSignal, throwIfAborted } = params;
 
     throwIfAborted();
-    if (sourceCount < RESEARCH_DEFAULTS.MAX_TOTAL_SOURCES * 0.6) {
+    if (sourceCount < config.maxTotalSources * RESEARCH_DEFAULTS.NEED_MORE_SKIP_RATIO) {
         return true;
     }
 

--- a/apps/api/src/services/deep-research/topic-decomposer.ts
+++ b/apps/api/src/services/deep-research/topic-decomposer.ts
@@ -79,7 +79,7 @@ export async function decomposeTopics(params: {
             })
             .filter((item): item is SubTopic => item !== null)
             .sort((a, b) => b.importance - a.importance)
-            .slice(0, CAPACITY.RESEARCH_MAX_TOTAL_SOURCES);
+            .slice(0, CAPACITY.RESEARCH_MAX_SUBTOPICS);
 
         // 유효 서브토픽이 최소치 이상이면 모델 결과를 채택, 아니면(파싱은 됐지만 전부 무효) 템플릿 폴백
         const useModelResult = normalized.length >= RESEARCH_DEFAULTS.MIN_SUBTOPICS;


### PR DESCRIPTION
## 배경
gpt-researcher 대조 인벤토리(2026-09-05)에서 드러난 **기존 결함**을 별건으로 수정. gpt-researcher 도입과 무관.

## 수정
| # | 결함 | 수정 |
|---|---|---|
| 1 | `mcp/deep-research.ts` depth→loops 인라인 `1/3/5` 3곳이 `RESEARCH_DEPTH_LOOPS`(1/2/4)와 불일치 | 단일 표 사용 |
| 2 | `checkNeedsMoreInfo` 가 `config.maxTotalSources` 대신 모듈 상수 `MAX_TOTAL_SOURCES*0.6` | `config.maxTotalSources × RESEARCH_DEFAULTS.NEED_MORE_SKIP_RATIO` |
| 3 | REST `execute` 가 abort signal 미배선 → 취소 불가 | `services/deep-research/active-runs.ts` 레지스트리 + `POST /api/research/sessions/:id/cancel`(409 = 이 프로세스 실행 아님) + `DELETE` 시 abort |
| 4 | `CAPACITY.RESEARCH_MAX_TOTAL_SOURCES`(15) 는 실제 서브토픽 캡, `RESEARCH_TOP_RESULTS` 참조 0 | `RESEARCH_MAX_SUBTOPICS` 개명, dead 상수 삭제 |
| 5 | `configure_research` 가 전역 config 변경 → 사용자 간 누수. `maxSearchResults` 상한 50 < 기본 200 | userId 키 in-memory override, `research` 도구가 자기 것만 merge. 상한 `RESEARCH_DEFAULTS.MAX_SEARCH_RESULTS` |
| 6 | **추가 발견** `executeResearchSchema.maxLoops` `default(5)` → REST 는 세션 depth 를 영원히 무시 | default 제거 |

## 영향
- REST 클라이언트가 `maxLoops` 를 안 보내면 이제 depth 표대로 돈다(종전 항상 5). 웹 프론트는 `/research` 페이지가 REST execute 를 쓰지 않는 것으로 확인(아래 grep 0건 시).
- MCP `research`/`configure_research` 도구는 `builtInTools` 에 없어 현재 도구 루프에서 도달 불가 — 동작 변경은 잠복 결함 정정

## 검증
- `tsc --noEmit` 0, jest 6 passed(active-runs 4·needsMore 2), lint 오류 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeQPXhmHMo2XXQKxgR1xpt