### PR TITLE
feat(mcp): Context7 MCP 서버를 카탈로그에 시드 (114)

### DIFF
--- a/db/migrations/114_mcp_context7_catalog.sql
+++ b/db/migrations/114_mcp_context7_catalog.sql
@@ -1,0 +1,33 @@
+-- ============================================================
+-- 114_mcp_context7_catalog.sql — Context7 MCP 서버를 mcp_server_catalog 에 시드
+-- ============================================================
+-- 목적: Upstash Context7(https://github.com/upstash/context7) 공식 MCP 서버
+--       (@upstash/context7-mcp)를 카탈로그에 추가한다. 라이브러리·프레임워크의 **최신 버전
+--       문서·코드 예제**를 질의 시점에 가져와 학습 데이터의 낡은 API 로 인한 환각을 줄인다.
+--       도구 2종 — resolve-library-id(이름 → Context7 라이브러리 ID)·query-docs(ID + 질문 → 문서).
+--
+-- 인증: CONTEXT7_API_KEY (선택). 없어도 동작하나 rate limit 이 낮다. context7.com/dashboard 에서
+--       무료 발급. env_schema secret=true 라 입력 시 AES-256-GCM 암호화 저장.
+--       ⚠️ CLI `--api-key` 인자는 쓰지 않는다 — ps 노출. env 만.
+--
+-- 전송: stdio. mcp-runtime 이미지의 npx 로 spawn(버전 고정 4.0.5). 외부 context7.com 호출이라
+--       sandbox_network 기본값('full'). 원격 https://mcp.context7.com/mcp 는 Bearer 헤더가 필요한데
+--       이 배포의 원격 MCP 는 헤더 주입 미지원 → stdio.
+--
+-- 멱등: ON CONFLICT (id) DO NOTHING.
+-- ============================================================
+
+INSERT INTO mcp_server_catalog (
+    id, display_name, description, transport_type, command_template,
+    args_schema, env_schema, is_enabled
+) VALUES (
+    'mcp-context7',
+    'Context7 (라이브러리 최신 문서)',
+    '라이브러리·프레임워크의 최신 버전 문서와 코드 예제를 질의 시점에 조회(resolve-library-id → query-docs). 코딩 질문의 낡은 API 환각 방지. API 키 선택(없으면 rate limit 낮음).',
+    'stdio',
+    'npx -y @upstash/context7-mcp@4.0.5',
+    '{}'::jsonb,
+    '{"type": "object", "required": [], "properties": {"CONTEXT7_API_KEY": {"type": "string", "title": "Context7 API Key (선택)", "secret": true, "description": "context7.com/dashboard 에서 무료 발급. 없어도 동작하지만 rate limit 이 낮음"}}}'::jsonb,
+    TRUE
+)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## 내용
[upstash/context7](https://github.com/upstash/context7) 를 `mcp_server_catalog` 템플릿 `mcp-context7` 로 추가 (Tavily #737 과 같은 패턴). 이 레포에서 openmake_llm 에 해당하는 부분은 MCP 서버뿐이며, 문서 인덱싱 플랫폼 자체는 Context7 SaaS 가 담당.

- `npx -y @upstash/context7-mcp@4.0.5` (stdio, 버전 고정). 도구 2종: `resolve-library-id` · `query-docs`
- `env_schema`: `CONTEXT7_API_KEY`(선택, secret) — 없어도 동작, rate limit 만 낮음
- CLI `--api-key` 배제(ps 노출), 원격 `mcp.context7.com`(Bearer 헤더 필요) 대신 stdio

## 운영 반영·검증
- admin API 선등록 201, user 3 from-catalog 설치 → readonly docker 샌드박스 6s 연결·2 tools
- REST `context7::resolve-library-id`(next.js → `/vercel/next.js`)·`context7::query-docs` 200
- chat.openmake.cc 채팅: 모델이 `resolve-library-id` → `query-docs` 순으로 실호출, Zustand v5.0.12 persist 예제 아티팩트 반환

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeQPXhmHMo2XXQKxgR1xpt