### PR TITLE
chore(research): #740 잔여 데드코드 제거 + deploy 빌드 전 태그 fetch

### DIFF
--- a/apps/api/src/__tests__/deep-research-strategy.test.ts
+++ b/apps/api/src/__tests__/deep-research-strategy.test.ts
@@ -134,7 +134,6 @@ describe('DeepResearchStrategy', () => {
             expect(MockDeepResearchService).toHaveBeenCalledWith(
                 expect.objectContaining({
                     maxLoops: RESEARCH_STRATEGY_PARAMS.MAX_LOOPS,
-                    searchApi: 'all',
                     language: 'ko',
                     chunkSize: RESEARCH_STRATEGY_PARAMS.CHUNK_SIZE,
                 }),

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -210,8 +210,6 @@ export const RESEARCH_DEFAULTS = {
 export const RESEARCH_STRATEGY_PARAMS = {
     /** 최대 반복 루프 수 */
     MAX_LOOPS: 5,
-    /** 검색 API 종류 */
-    SEARCH_API: 'all' as const,
     /** 최대 검색 결과 수 */
     MAX_SEARCH_RESULTS: 360,
     /** 최대 전체 소스 수 — 합성·보고서 입력 규모를 좌우(과다 시 보고서 생성 지연). env override 가능. */

--- a/apps/api/src/mcp/deep-research.ts
+++ b/apps/api/src/mcp/deep-research.ts
@@ -329,7 +329,6 @@ export const getResearchStatusTool: MCPToolDefinition = {
  *
  * @param args.maxLoops - 최대 반복 횟수 (1-10)
  * @param args.llmModel - LLM 모델명
- * @param args.searchApi - 검색 API 선택
  * @param args.maxSearchResults - 최대 검색 결과 수 (5-200)
  * @param args.language - 출력 언어 (ko/en/ja/zh/es/de)
  * @returns 업데이트된 설정 (JSON)
@@ -349,11 +348,6 @@ export const configureResearchTool: MCPToolDefinition = {
                     type: 'string',
                     description: '사용할 LLM 모델 이름'
                 },
-                searchApi: {
-                    type: 'string',
-                    enum: ['google', 'all'],
-                    description: '웹 검색 API 선택'
-                },
                 maxSearchResults: {
                     type: 'number',
                     description: '검색 결과 최대 수 (5-200)'
@@ -371,9 +365,6 @@ export const configureResearchTool: MCPToolDefinition = {
             // 타입 캐스팅
             const maxLoops = args.maxLoops as number | undefined;
             const llmModel = args.llmModel as string | undefined;
-            const rawSearchApi = args.searchApi as string | undefined;
-            const searchApi: 'google' | 'all' | undefined =
-                (rawSearchApi === 'google' || rawSearchApi === 'all') ? rawSearchApi : undefined;
             const maxSearchResults = args.maxSearchResults as number | undefined;
             const language = args.language as string | undefined;
 
@@ -398,10 +389,6 @@ export const configureResearchTool: MCPToolDefinition = {
 
             if (llmModel !== undefined) {
                 updates.llmModel = llmModel;
-            }
-
-            if (searchApi !== undefined) {
-                updates.searchApi = searchApi;
             }
 
             if (maxSearchResults !== undefined) {

--- a/apps/api/src/services/DeepResearchService.ts
+++ b/apps/api/src/services/DeepResearchService.ts
@@ -25,8 +25,7 @@ import {
     ResearchConfig,
     ResearchProgress,
     ResearchResult,
-    globalConfig,
-    setGlobalConfig
+    DEFAULT_CONFIG,
 } from './deep-research-types';
 
 import { deduplicateSources, getLoopProgressRange, computeResearchMetrics } from './deep-research-utils';
@@ -56,7 +55,7 @@ export class DeepResearchService {
     private abortController: AbortController | null = null;
 
     constructor(config?: Partial<ResearchConfig>, client?: LLMClient) {
-        this.config = { ...globalConfig, ...config };
+        this.config = { ...DEFAULT_CONFIG, ...config };
         if (client) {
             // 'research' role 해석 클라이언트 주입 (외부 BYOK endpoint 포함) — research.routes 경로
             this.client = client;
@@ -472,23 +471,6 @@ export class DeepResearchService {
 // ============================================================
 // 모듈 API
 // ============================================================
-
-/**
- * 전역 설정 가져오기
- */
-export function getResearchConfig(): ResearchConfig {
-    return { ...globalConfig };
-}
-
-/**
- * 전역 설정 업데이트
- */
-export function configureResearch(config: Partial<ResearchConfig>): ResearchConfig {
-    const updated = { ...globalConfig, ...config };
-    setGlobalConfig(updated);
-    logger.info(`[DeepResearch] 설정 업데이트: ${JSON.stringify(updated)}`);
-    return { ...updated };
-}
 
 /**
  * 서비스 인스턴스 생성

--- a/apps/api/src/services/chat-strategies/deep-research-strategy.ts
+++ b/apps/api/src/services/chat-strategies/deep-research-strategy.ts
@@ -60,7 +60,6 @@ export class DeepResearchStrategy implements ChatStrategy<DeepResearchStrategyCo
         // 재생성해 외부 모델이 로컬 endpoint 로 404 나던 문제 해소.
         const researchService = new DeepResearchService({
             maxLoops: RESEARCH_STRATEGY_PARAMS.MAX_LOOPS,
-            searchApi: RESEARCH_STRATEGY_PARAMS.SEARCH_API,
             maxSearchResults: RESEARCH_STRATEGY_PARAMS.MAX_SEARCH_RESULTS,
             language: detectLanguage(message).language,
             maxTotalSources: RESEARCH_STRATEGY_PARAMS.MAX_TOTAL_SOURCES,

--- a/apps/api/src/services/deep-research-types.ts
+++ b/apps/api/src/services/deep-research-types.ts
@@ -20,7 +20,6 @@ import { RESEARCH_DEFAULTS } from '../config/runtime-limits';
 export interface ResearchConfig {
     maxLoops: number;            // 최대 반복 횟수 (기본: 5)
     llmModel: string;            // 사용할 LLM 모델
-    searchApi: 'google' | 'all'; // 검색 API
     maxSearchResults: number;    // 검색 결과 예산 (기본: 360)
     language: string;              // 출력 언어 (ISO 639-1 코드, 예: 'ko', 'en', 'ja')
     maxTotalSources: number;     // 목표 고유 소스 수 (기본: 80)
@@ -75,7 +74,6 @@ export interface SynthesisResult {
 export const DEFAULT_CONFIG: ResearchConfig = {
     maxLoops: 5,
     llmModel: '',
-    searchApi: 'all',
     maxSearchResults: RESEARCH_DEFAULTS.MAX_SEARCH_RESULTS,
     language: 'en',
     maxTotalSources: RESEARCH_DEFAULTS.MAX_TOTAL_SOURCES,
@@ -85,13 +83,3 @@ export const DEFAULT_CONFIG: ResearchConfig = {
     chunkSize: RESEARCH_DEFAULTS.CHUNK_SIZE
 };
 
-// 전역 설정 (configure로 변경 가능)
-export let globalConfig: ResearchConfig = { ...DEFAULT_CONFIG };
-
-/**
- * Update the global config reference.
- * Used by configureResearch() in DeepResearchService.
- */
-export function setGlobalConfig(config: ResearchConfig): void {
-    globalConfig = config;
-}

--- a/openmake_llm.sh
+++ b/openmake_llm.sh
@@ -630,6 +630,10 @@ cmd_deploy() {
 
     log_step "Deploy: build → migrate → restart"
 
+    # 0) 태그 동기화(fail-open) — build-info.json 의 gitTag 는 로컬 태그(`git describe`)라
+    #    release-please 태그를 fetch 하지 않으면 한 단계 낮게 찍힌다(v1.41.0 배포에서 실측).
+    git -C "$SCRIPT_DIR" fetch --tags --quiet 2>/dev/null || log_warn "git fetch --tags 실패 — build-info gitTag 가 stale 일 수 있음"
+
     # 1) 빌드 (재시작은 마이그레이션 뒤 3) 단계에서 일괄 수행)
     cmd_build --no-restart
 


### PR DESCRIPTION
## 변경
- **데드코드**: #740 이 `configure_research` 를 userId 격리로 바꾼 뒤 참조 0 이 된 `getResearchConfig`/`configureResearch`(DeepResearchService)·`globalConfig`/`setGlobalConfig`(deep-research-types) 삭제. 생성자는 `DEFAULT_CONFIG` 직접 사용.
- **write-only 필드**: `ResearchConfig.searchApi` 는 세 곳이 쓰기만 하고 읽는 곳이 0 → 필드·`RESEARCH_STRATEGY_PARAMS.SEARCH_API`·`configure_research` 인자·strategy 전달·테스트 기대값 제거.
- **deploy**: `cmd_deploy` 가 빌드 전 `git fetch --tags --quiet`(fail-open). `build-info.json.gitTag` 는 로컬 `git describe` 라 release-please 태그 미fetch 시 한 단계 낮게 찍혔다(v1.41.0 빌드에 `v1.40.1` 실측).

## 검증
- `tsc --noEmit` 0 · deep-research 관련 jest 52 passed · lint 오류 0 · `bash -n` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeQPXhmHMo2XXQKxgR1xpt