### PR TITLE
feat(chat): 도구 결과 언어 리마인더 + 답변 언어 가드 관측 (한국어 질문→영어 답변 드리프트)

### DIFF
--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1214,6 +1214,23 @@ export const EXTERNAL_CHAT_FALLBACK = {
         .split(',').map((s) => s.trim()).filter(Boolean),
 } as const;
 
+/**
+ * 도구 결과 언어 리마인더 + 답변 언어 가드 관측 (2026-09-05).
+ * 실측(90일 한국어 질문 140쌍): 영어 답변 15건(10.7%) 이 사실상 전부 **도구 결과 직후 턴**
+ * (파일 조작 결과·영문 문서 인용 뒤 모델이 결과 언어로 드리프트). 시스템 프롬프트의 언어 지시만으론
+ * 긴 영문 도구 결과 뒤에 유지되지 않아, 도구 결과 말미에 결정적 한 줄을 붙인다(LLM 왕복 0, B형).
+ */
+export const TOOL_RESULT_LANGUAGE_NOTE = {
+    /** 끄려면 TOOL_RESULT_LANGUAGE_NOTE=false */
+    ENABLED: process.env.TOOL_RESULT_LANGUAGE_NOTE !== 'false',
+    /** 이 길이 미만의 도구 결과엔 붙이지 않는다(짧은 ok/JSON 은 드리프트 원인이 아님) */
+    MIN_RESULT_CHARS: 300,
+    /** 도구 결과의 대상 언어 문자 비율이 이 값 이하면 "다른 언어" 로 본다 */
+    MAX_TARGET_SCRIPT_RATIO: 0.15,
+    /** 답변 언어 가드 로그: 이 길이 이상의 최종 답변만 판정(코드블록·URL·아티팩트 참조 제외 후) */
+    GUARD_MIN_ANSWER_CHARS: 80,
+} as const;
+
 export const EXTERNAL_LLM_TOOL_BLACKLIST: readonly string[] = [
     'vision_ocr',
     'analyze_image',

--- a/apps/api/src/prompts/tool-result-language-note.ts
+++ b/apps/api/src/prompts/tool-result-language-note.ts
@@ -1,0 +1,14 @@
+/**
+ * 도구 결과 말미에 붙이는 응답 언어 리마인더 (2026-09-05).
+ * 대상 언어로 써야 효과가 있으므로 한국어는 한국어, 그 외는 영어+언어명.
+ * @module prompts/tool-result-language-note
+ */
+import { LANGUAGE_DISPLAY_NAMES, resolvePromptLocale, type SupportedLanguageCode } from '../chat/language-policy';
+
+export function toolResultLanguageNote(langCode: string): string {
+    if (resolvePromptLocale(langCode) === 'ko') {
+        return '[시스템] 위 도구 결과는 다른 언어로 작성돼 있습니다. 최종 답변은 반드시 한국어로 작성하고, 인용·코드 설명도 한국어로 옮기세요(코드 자체는 그대로).';
+    }
+    const name = LANGUAGE_DISPLAY_NAMES[langCode as SupportedLanguageCode] || langCode;
+    return `[system] The tool output above is in a different language. Write the final answer in ${name}, translating quotes and explanations (code itself stays as-is).`;
+}

--- a/apps/api/src/services/chat-service/__tests__/tool-result-language.test.ts
+++ b/apps/api/src/services/chat-service/__tests__/tool-result-language.test.ts
@@ -1,0 +1,64 @@
+/** 도구 결과 언어 리마인더·답변 언어 가드 — 순수 함수 회귀 (2026-09-05) */
+import { targetScriptRatio, shouldAppendLanguageNote, withLanguageNote, detectAnswerLanguageMismatch, scriptKeyFor } from '../tool-result-language';
+import { TOOL_RESULT_LANGUAGE_NOTE } from '../../../config/runtime-limits';
+
+const EN_DOC = ('Route Handlers allow you to create custom request handlers for a given route using the Web Request and Response APIs. ').repeat(4);
+const KO_DOC = ('라우트 핸들러는 웹 요청과 응답 객체를 사용해 특정 경로의 요청 처리기를 만듭니다. 파일 위치는 앱 폴더 아래이며 내보내기 함수 이름이 메서드가 됩니다. ').repeat(4);
+
+describe('scriptKeyFor', () => {
+    it('ko/ja/zh 는 고유 문자 체계, 라틴 계열은 latin', () => {
+        expect(scriptKeyFor('ko')).toBe('ko');
+        expect(scriptKeyFor('ja-JP')).toBe('ja');
+        expect(scriptKeyFor('en')).toBe('latin');
+        expect(scriptKeyFor('de')).toBe('latin');
+    });
+});
+
+describe('targetScriptRatio', () => {
+    it('한국어 본문의 ko 비율은 높고, 영문 본문의 ko 비율은 0 에 가깝다', () => {
+        expect(targetScriptRatio(KO_DOC, 'ko')!).toBeGreaterThan(0.7);
+        expect(targetScriptRatio(EN_DOC, 'ko')!).toBeLessThan(0.05);
+    });
+    it('코드블록·URL·아티팩트 참조는 판정에서 제외한다', () => {
+        const mixed = '결과입니다.\n```ts\nexport async function GET() { return Response.json({ ok: true }) }\n```\nhttps://example.com/docs [[artifact:auto-1]]';
+        expect(targetScriptRatio(mixed, 'ko')!).toBeGreaterThan(0.9);
+    });
+    it('판정 가능한 글자가 없으면 null', () => {
+        expect(targetScriptRatio('123 ... !!!', 'ko')).toBeNull();
+    });
+});
+
+describe('shouldAppendLanguageNote / withLanguageNote', () => {
+    it('긴 영문 도구 결과 + 대상 ko → 리마인더 부착', () => {
+        expect(shouldAppendLanguageNote(EN_DOC, 'ko')).toBe(true);
+        expect(withLanguageNote(EN_DOC, 'ko')).toContain('반드시 한국어로');
+    });
+    it('한국어 도구 결과엔 붙이지 않는다', () => {
+        expect(shouldAppendLanguageNote(KO_DOC, 'ko')).toBe(false);
+        expect(withLanguageNote(KO_DOC, 'ko')).toBe(KO_DOC);
+    });
+    it(`MIN_RESULT_CHARS(${TOOL_RESULT_LANGUAGE_NOTE.MIN_RESULT_CHARS}) 미만의 짧은 영문 결과(ok/JSON)엔 붙이지 않는다`, () => {
+        expect(shouldAppendLanguageNote('{"ok":true,"path":"nim-test.txt"}', 'ko')).toBe(false);
+    });
+    it('대상 언어 미지정이면 원문 그대로', () => {
+        expect(withLanguageNote(EN_DOC, undefined)).toBe(EN_DOC);
+    });
+    it('대상이 영어면 한국어 도구 결과에 영어 리마인더', () => {
+        expect(withLanguageNote(KO_DOC, 'en')).toContain('Write the final answer in English');
+    });
+});
+
+describe('detectAnswerLanguageMismatch', () => {
+    it('한국어 질문(target ko)에 영어 답변 → true', () => {
+        expect(detectAnswerLanguageMismatch(EN_DOC, 'ko')).toBe(true);
+    });
+    it('한국어 답변 → false, 짧은 답변 → false, target 미지정 → false', () => {
+        expect(detectAnswerLanguageMismatch(KO_DOC, 'ko')).toBe(false);
+        expect(detectAnswerLanguageMismatch('OK done.', 'ko')).toBe(false);
+        expect(detectAnswerLanguageMismatch(EN_DOC, undefined)).toBe(false);
+    });
+    it('코드 위주 한국어 답변은 코드블록 제외 후 판정 → false', () => {
+        const a = '아래 예제를 참고하세요. 핸들러는 app/api/hello/route.ts 에 두고 GET 을 내보내면 됩니다. 응답은 JSON 입니다.\n```ts\n' + 'export async function GET() { return Response.json({ message: "Hello World" }) }\n'.repeat(5) + '```';
+        expect(detectAnswerLanguageMismatch(a, 'ko')).toBe(false);
+    });
+});

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -36,6 +36,7 @@ const logger = createLogger('ChatExternalProvider');
 // 공개 타입은 external-provider-types 로 분리(600줄 CI 가드) — 기존 import 경로 호환 재노출.
 export type { ExternalProviderDeps, ChatTimings, StreamFromExternalContext } from './external-provider-types';
 import type { ExternalProviderDeps, ChatTimings, StreamFromExternalContext } from './external-provider-types';
+import { detectAnswerLanguageMismatch } from './tool-result-language';
 
 
 /**
@@ -387,6 +388,15 @@ export async function runExternalStream(
         req,
         ctx,
     });
+
+    // 답변 언어 가드 — 관측만(재생성 없음). 도구 결과 리마인더의 효과를 이 로그로 재측정한다.
+    try {
+        const guardLang = ctx.resolvedLanguage || req.userLanguagePreference;
+        if (detectAnswerLanguageMismatch(finalContent, guardLang)) {
+            const toolTurns = messages.filter((m) => m.role === 'tool').length;
+            logger.warn(`[LanguageGuard] 답변 문자 체계 불일치: target=${guardLang} model=${resolved.fullId} toolResults=${toolTurns} len=${finalContent.length}`);
+        }
+    } catch { /* 관측 실패는 무시 */ }
 
     return finalContent;
 }

--- a/apps/api/src/services/chat-service/external-tool-batch.ts
+++ b/apps/api/src/services/chat-service/external-tool-batch.ts
@@ -24,6 +24,7 @@ import type { ChatMessage, ToolDefinition } from '../../llm';
 import type { ChatMessageRequest } from '../chat-service-types';
 import type { ChatStreamResult } from '../../providers/i-provider';
 import type { ExternalProviderDeps, StreamFromExternalContext } from './external-provider-types';
+import { withLanguageNote } from './tool-result-language';
 
 const logger = createLogger('ChatExternalProvider');
 
@@ -220,9 +221,12 @@ export async function runToolCallBatch(params: {
         const modelFacingResult = toolResult
             .replace(/\[지도 표시용[^\]]*\]\s*/g, '')
             .replace(/```kakaomap\s*\n[\s\S]*?```/g, '');
+        // 도구 결과가 대상 언어와 다른 문자 체계(영문 문서·파일 조작 결과 등)면 말미에 언어 리마인더 —
+        // 시스템 프롬프트 지시만으론 긴 영문 결과 뒤 답변이 영어로 드리프트(90일 실측 10.7%).
+        const langCode = ctx.resolvedLanguage || req.userLanguagePreference;
         messages.push({
             role: 'tool',
-            content: modelFacingResult,
+            content: withLanguageNote(modelFacingResult, langCode),
             tool_name: tc.name,
             tool_call_id: tc.id,
         });

--- a/apps/api/src/services/chat-service/tool-result-language.ts
+++ b/apps/api/src/services/chat-service/tool-result-language.ts
@@ -1,0 +1,67 @@
+/**
+ * 도구 결과·최종 답변의 문자 체계(script) 비율로 언어 드리프트를 판정하는 순수 함수들 (2026-09-05).
+ *
+ * - `shouldAppendLanguageNote`: 도구 결과가 대상 언어와 다른 문자 체계면 true → external-tool-batch 가
+ *   결과 말미에 리마인더를 붙인다(결정적, LLM 왕복 0).
+ * - `detectAnswerLanguageMismatch`: 최종 답변이 대상 언어 문자 체계가 아니면 true → 관측 로그만
+ *   (재생성 없음, measure-first).
+ * 라틴 문자 언어(en/es/de/fr…)끼리는 문자 체계가 같아 구분하지 않는다 — 이 모듈이 잡는 것은
+ * 한국어↔영어 같은 **문자 체계** 드리프트다(실측된 실패 형태).
+ *
+ * @module services/chat-service/tool-result-language
+ */
+import { LANGUAGE_PATTERNS } from '../../chat/language-policy';
+import { TOOL_RESULT_LANGUAGE_NOTE } from '../../config/runtime-limits';
+import { toolResultLanguageNote } from '../../prompts/tool-result-language-note';
+
+const SCRIPT_KEYS = ['ko', 'ja', 'zh', 'ar', 'hi', 'th', 'ru'] as const;
+type ScriptKey = (typeof SCRIPT_KEYS)[number] | 'latin';
+
+/** 언어 코드 → 문자 체계 키 (라틴 계열은 전부 'latin') */
+export function scriptKeyFor(langCode: string): ScriptKey {
+    const base = (langCode || '').toLowerCase().split(/[-_]/)[0];
+    return (SCRIPT_KEYS as readonly string[]).includes(base) ? (base as ScriptKey) : 'latin';
+}
+
+/** 판정 대상 문자만 남긴다 — 코드블록·URL·아티팩트 참조·공백·숫자·구두점 제외 */
+export function stripForScriptRatio(text: string): string {
+    return (text || '')
+        .replace(/```[\s\S]*?```/g, '')
+        .replace(/https?:\/\/\S+/g, '')
+        .replace(/\[\[artifact:[^\]]+\]\]/g, '')
+        .replace(/[\s\d\p{P}\p{S}]/gu, '');
+}
+
+/** text 안에서 대상 언어 문자 체계가 차지하는 비율 (판정 가능한 글자가 없으면 null) */
+export function targetScriptRatio(text: string, langCode: string): number | null {
+    const letters = stripForScriptRatio(text);
+    if (letters.length === 0) return null;
+    const key = scriptKeyFor(langCode);
+    const pattern = LANGUAGE_PATTERNS[key];
+    const hits = (letters.match(pattern) || []).length;
+    return hits / letters.length;
+}
+
+/** 도구 결과에 언어 리마인더를 붙여야 하는가 */
+export function shouldAppendLanguageNote(toolResult: string, langCode: string | undefined): boolean {
+    if (!TOOL_RESULT_LANGUAGE_NOTE.ENABLED || !langCode) return false;
+    if ((toolResult || '').length < TOOL_RESULT_LANGUAGE_NOTE.MIN_RESULT_CHARS) return false;
+    const ratio = targetScriptRatio(toolResult, langCode);
+    return ratio !== null && ratio <= TOOL_RESULT_LANGUAGE_NOTE.MAX_TARGET_SCRIPT_RATIO;
+}
+
+/** 리마인더를 붙인 도구 결과 (조건 미충족이면 원문 그대로) */
+export function withLanguageNote(toolResult: string, langCode: string | undefined): string {
+    return shouldAppendLanguageNote(toolResult, langCode) && langCode
+        ? `${toolResult}\n\n${toolResultLanguageNote(langCode)}`
+        : toolResult;
+}
+
+/** 최종 답변이 대상 언어 문자 체계가 아닌가 (관측용) */
+export function detectAnswerLanguageMismatch(answer: string, langCode: string | undefined): boolean {
+    if (!langCode) return false;
+    const letters = stripForScriptRatio(answer);
+    if (letters.length < TOOL_RESULT_LANGUAGE_NOTE.GUARD_MIN_ANSWER_CHARS) return false;
+    const ratio = targetScriptRatio(answer, langCode);
+    return ratio !== null && ratio <= TOOL_RESULT_LANGUAGE_NOTE.MAX_TARGET_SCRIPT_RATIO;
+}


### PR DESCRIPTION
## 배경
Context7 재테스트에서 한국어 질문에 영어로 답한 건을 별건 조사. 운영 90일 한국어 질문 140쌍(번역 요청·아티팩트 전용 제외) 중 영어 답변 15건(10.7%)이 사실상 전부 **도구 결과 직후 턴**(파일 조작 결과 "The file … has been created", 영문 문서 인용). 시스템 프롬프트의 `[필수] 응답 언어: 한국어` 지시가 긴 영문 도구 결과 뒤에 유지되지 않는다.

## 변경 (B형 — 결정적, LLM 왕복 0)
- `services/chat-service/tool-result-language.ts`(순수): 문자 체계 비율(코드블록·URL·`[[artifact]]` 제외)로 판정
  - `withLanguageNote`: 도구 결과 ≥300자 & 대상 문자 비율 ≤0.15 → 말미에 리마인더(`prompts/tool-result-language-note.ts`, ko / 그 외 영어+언어명)
  - `detectAnswerLanguageMismatch`: 최종 답변 판정(관측용)
- `external-tool-batch.ts`: tool 메시지 content 에 적용 (`ctx.resolvedLanguage || req.userLanguagePreference`)
- `external-provider.ts`: 불일치 시 `[LanguageGuard]` warn 로그만 (재생성 없음 — 리마인더 효과를 이 로그로 재측정)
- `TOOL_RESULT_LANGUAGE_NOTE` 게이트(기본 on)·임계값은 `runtime-limits.ts`

## 범위 밖
라틴 문자 언어끼리(en↔de) 구분 없음 — 실측 실패 형태가 ko↔en 문자 체계 드리프트라 그 범위만.

## 검증
- tsc 0 · jest 12(신규) + external-provider 기존 suite 통과 · lint 오류 0
- 라이브 재테스트는 배포 후 Context7 동일 질의로 확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeQPXhmHMo2XXQKxgR1xpt