### PR TITLE
fix(web): 모바일 입력 16px + 터치 아이콘 버튼 히트 영역 36px

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -203,6 +203,30 @@ h4 {
   letter-spacing: var(--ls-heading);
 }
 
+/* =========================================================================
+   모바일·터치 대응 (unlayered 라 Tailwind 유틸리티보다 우선)
+   - 입력 16px 미만이면 iOS 가 포커스 시 화면을 확대한다 → 모바일 폭에서 16px 고정
+   - 터치 포인터에서는 24/28px 아이콘 버튼의 히트 영역을 36px 로 키운다
+   ========================================================================= */
+@media (max-width: 767px) {
+  input:not([type="checkbox"]):not([type="radio"]):not([type="range"]),
+  select,
+  textarea {
+    font-size: 16px;
+  }
+}
+@media (pointer: coarse) {
+  button.h-6,
+  button.h-7,
+  a.h-6,
+  a.h-7,
+  [role="button"].h-6,
+  [role="button"].h-7 {
+    min-height: 2.25rem;
+    min-width: 2.25rem;
+  }
+}
+
 /* 모노 라벨 (uppercase 메타·섹션 킥커) — 기준안 label 규격 */
 .label-mono {
   font-family: var(--mono);


### PR DESCRIPTION
## 요약
- 375px 실측(12 페이지): 가로 오버플로 0, `viewport-fit=cover`·`dvh`·하단 탭바 safe-area 는 이미 적용돼 있었음.
- 남은 결함 2종을 `globals.css` unlayered 규칙으로 해소:
  - ≤767px 에서 `input/select/textarea` 16px — 14px 이하 입력은 iOS 가 포커스 시 화면을 확대함(컴포저 텍스트영역 포함)
  - `pointer: coarse` 에서 `h-6`/`h-7` 아이콘 버튼·링크 최소 36×36 (아티팩트 공유·에이전트 작업 액션 28px 버튼 등 27+9곳)
- 데스크톱·마우스 환경은 무변경.

## 검증
- `tsc` + `next build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeQPXhmHMo2XXQKxgR1xpt