### PR TITLE
fix(agent-task): 로컬 실행에서 명시한 승인 정책이 'all' 로 덮어써지던 결함 수정

### DIFF
--- a/apps/api/src/services/agent-task/__tests__/executor-select.test.ts
+++ b/apps/api/src/services/agent-task/__tests__/executor-select.test.ts
@@ -1,0 +1,41 @@
+/**
+ * resolveExecutorPlan — 로컬 실행기의 승인 정책 결정.
+ * 회귀 고정: 로컬 실행에서 호출자가 명시한 approvalPolicy 가 'all' 로 덮어써지지 않아야 한다
+ * (웹 컴포저 "건너뜀" 이 무시되던 결함, 2026-09-05).
+ */
+jest.mock('../../../config/local-bridge', () => ({ LOCAL_BRIDGE: { ENABLED: true } }));
+jest.mock('../../../config/task-sandbox', () => ({
+    getTaskSandboxConfig: () => ({ enabled: false, approvalPolicy: 'high-risk' }),
+}));
+jest.mock('../../local-bridge/remote-executor', () => ({
+    RemoteExecutor: jest.fn().mockImplementation(() => ({})),
+}));
+
+import { resolveExecutorPlan } from '../executor-select';
+
+describe('resolveExecutorPlan — 로컬 실행 승인 정책', () => {
+    it('명시한 none 은 그대로 적용된다', () => {
+        const plan = resolveExecutorPlan({ executor: 'local', approvalPolicy: 'none' }, 't1', 'u1');
+        expect(plan.sandboxCfg.approvalPolicy).toBe('none');
+        expect(plan.sandboxCfg.deviceGatesShell).toBe(true);
+        expect(plan.remoteExecutor).toBeDefined();
+    });
+
+    it('명시한 high-risk 도 그대로 적용된다', () => {
+        const plan = resolveExecutorPlan({ executor: 'local', approvalPolicy: 'high-risk' }, 't1', 'u1');
+        expect(plan.sandboxCfg.approvalPolicy).toBe('high-risk');
+    });
+
+    it('미지정이면 전역 기본값이 아니라 all 로 보수적으로 둔다', () => {
+        const plan = resolveExecutorPlan({ executor: 'local' }, 't1', 'u1');
+        expect(plan.sandboxCfg.approvalPolicy).toBe('all');
+        expect(plan.runtimeEnabled).toBe(true);
+    });
+
+    it('샌드박스 실행은 종전대로 — 미지정이면 전역 기본값', () => {
+        const plan = resolveExecutorPlan({ executor: 'sandbox' }, 't1', 'u1');
+        expect(plan.sandboxCfg.approvalPolicy).toBe('high-risk');
+        expect(plan.sandboxCfg.deviceGatesShell).toBeUndefined();
+        expect(plan.remoteExecutor).toBeUndefined();
+    });
+});

--- a/apps/api/src/services/agent-task/executor-select.ts
+++ b/apps/api/src/services/agent-task/executor-select.ts
@@ -1,8 +1,11 @@
 /**
  * 실행 백엔드/승인 정책 결정 (Cowork D1a) — AgentTaskService 에서 분리(파일 크기 가드).
  *
- * - executor='local' + 게이트 ON → RemoteExecutor(로컬 브리지) + 승인 'all' 강제
- *   (docker 격리가 없으므로 전건 승인. input.approvalPolicy 보다 우선.)
+ * - executor='local' + 게이트 ON → RemoteExecutor(로컬 브리지). 승인 정책은 호출자가 명시한
+ *   input.approvalPolicy 를 그대로 쓰고, **미지정일 때만 'all'** 로 둔다(전역 기본값보다 보수적 —
+ *   docker 격리가 없으므로). 과거엔 명시값도 'all' 로 덮어써 웹 컴포저의 "건너뜀/자동" 이 로컬
+ *   실행에서 조용히 무시됐다(2026-09-05 라이브 관찰). CLI 는 이미 `--yes` 로 서버 승인을 전부
+ *   건너뛰므로 웹만 막는 것은 비대칭이었다. 코드 실행은 정책과 무관하게 디바이스 confirmExec 가 게이트.
  * - 그 외 → 현행 docker 샌드박스, input.approvalPolicy 는 이 실행에 한해 override.
  * - 게이트 OFF 면 sandbox 로 폴백(생성 시점에 이미 검증되나 방어).
  *
@@ -30,7 +33,7 @@ export function resolveExecutorPlan(
     // 로컬: 파일/기타 도구는 서버 승인 유지(디바이스는 파일에 다이얼로그 없음)하되, 코드 실행
     // (bash/python_execute)은 디바이스 confirmExec 가 게이트하므로 deviceGatesShell 로 서버 승인 skip.
     const sandboxCfg = isLocal
-        ? { ...getTaskSandboxConfig(), approvalPolicy: 'all' as const, deviceGatesShell: true }
+        ? { ...getTaskSandboxConfig(), approvalPolicy: input.approvalPolicy ?? ('all' as const), deviceGatesShell: true }
         : input.approvalPolicy
             ? { ...getTaskSandboxConfig(), approvalPolicy: input.approvalPolicy }
             : getTaskSandboxConfig();

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -584,7 +584,7 @@ export function useChatSocket() {
       files?: AttachedFileUI[],
       images?: string[],
       approvalPolicy?: "all" | "high-risk" | "none",
-      /** Cowork D2: true 면 데스크톱 브리지가 연결한 로컬 폴더에서 실행 (승인은 서버가 'all' 강제) */
+      /** Cowork D2: true 면 데스크톱 브리지가 연결한 로컬 폴더에서 실행 (승인 정책은 그대로 적용, 미지정 시 서버가 'all') */
       localExecutor?: boolean,
       /** 다중 디바이스(101): 로컬 실행 대상 디바이스 id — 미지정은 최근 접속 디바이스 */
       localDeviceId?: string | null,


### PR DESCRIPTION
## 문제
웹 컴포저에서 에이전트 모드 + 로컬 실행(OpenMake Companion/CLI 브리지)으로 승인 정책을 **건너뜀/자동** 으로 골라도 첫 `file_ops` 부터 인라인 승인 대기가 떴다 (2026-09-05 chat.openmake.cc 라이브 관찰).

## 원인
`services/agent-task/executor-select.ts` `resolveExecutorPlan` 이 `executor='local'` 이면 호출자 정책을 무시하고 `approvalPolicy:'all'` 을 강제 (#353 Cowork D1a 설계). 프론트는 `POST /execute` 에 정책을 정상 전송하고 있었다. CLI 는 `--yes` 로 서버 승인을 전부 건너뛸 수 있어 웹만 막힌 비대칭 상태였다.

## 수정
- 로컬 실행도 명시한 정책을 그대로 적용, **미지정일 때만 `'all'`** (전역 기본값보다 보수적 유지).
- 코드 실행(bash/python_execute)은 정책과 무관하게 디바이스 `confirmExec` 가 게이트 (`deviceGatesShell` 유지).
- 프론트 주석 정정 (`use-chat-socket.ts`, 코드 무변경).

## 검증
- 회귀 테스트 `executor-select.test.ts` 4건 — 수정을 되돌리면 2건 실패 확인.
- `tsc --noEmit` 0, eslint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01At54y6JzdVPTpepNAGEydW
