### PR TITLE
fix(ws): 탭 전환·앱 백그라운드로 소켓이 끊겨도 응답을 잃지 않게 — 스트림 detach/resume

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,12 @@ LLM_BASE_URL=http://localhost:4000              # 서버 PC 의 vLLM/LiteLLM pro
 LLM_API_KEY=sk-litellm-master-key               # LiteLLM master key (또는 vLLM --api-key)
 LLM_DEFAULT_MODEL=qwen3.8-27b                   # proxy 가 라우팅하는 model 명 (chat 기본, 2026-09-02 qwen3.6→3.8)
 LLM_TIMEOUT=120000                              # HTTP 요청 타임아웃 (ms)
+
+# WebSocket 채팅 이어받기 — 탭 백그라운드·앱 전환으로 소켓이 끊겨도 생성을 유지하는 유예(ms, 기본 5분),
+# detach 상태로 끝난 결과 스냅샷 보관(ms, 기본 2분), detach 중 이벤트 버퍼 상한(bytes, 기본 4MB)
+# WS_STREAM_DETACH_GRACE_MS=300000
+# WS_STREAM_RESULT_RETENTION_MS=120000
+# WS_DETACHED_STREAM_BUFFER_MAX_BYTES=4194304
 # LiteLLM 통합 게이트웨이로 inference 를 라우팅할 외부 provider id 콤마 목록.
 # 빈값/미설정 = 전부 direct 호출. provider별 롤백은 목록에서 제거 + 재시작.
 # ollama-local(사용자별 endpoint)·chatgpt(OAuth) 는 목록과 무관하게 direct 유지.

--- a/apps/api/src/config/timeouts.ts
+++ b/apps/api/src/config/timeouts.ts
@@ -165,6 +165,13 @@ export const ALERT_THRESHOLDS = {
 export const WEBSOCKET_TIMEOUTS = {
     /** 하트비트 주기 (ms) — 30초 */
     HEARTBEAT_INTERVAL_MS: 30000,
+    /**
+     * 소켓이 끊긴 뒤 진행 중 생성을 유지하는 유예 (ms) — 기본 5분.
+     * 탭 백그라운드·앱 전환으로 끊긴 클라이언트가 이 안에 `resume` 하면 이어받고, 없으면 abort.
+     */
+    STREAM_DETACH_GRACE_MS: Number(process.env.WS_STREAM_DETACH_GRACE_MS) || 5 * 60 * 1000,
+    /** detach 상태에서 생성이 끝났을 때 결과 스냅샷을 보관하는 시간 (ms) — 늦은 재연결용, 기본 2분 */
+    STREAM_RESULT_RETENTION_MS: Number(process.env.WS_STREAM_RESULT_RETENTION_MS) || 2 * 60 * 1000,
 } as const;
 
 // ============================================
@@ -192,6 +199,8 @@ export const WS_LIMITS = {
      * 대용량 텍스트 첨부를 수용한다(최종 컨텍스트 적합화는 LLMClient context-fit 안전망이 담당).
      */
     MAX_MESSAGE_CHARS: parseInt(process.env.WS_MAX_MESSAGE_CHARS || String(64 * 1024 * 1024), 10),
+    /** detach 된 스트림이 재생용으로 쌓아 두는 비-토큰 이벤트 버퍼 상한 (bytes) — 기본 4MB */
+    DETACHED_STREAM_BUFFER_MAX_BYTES: Number(process.env.WS_DETACHED_STREAM_BUFFER_MAX_BYTES) || 4 * 1024 * 1024,
     /** 사용자당 최대 동시 WebSocket 연결 수 */
     MAX_CONNECTIONS_PER_USER: Number(process.env.WS_MAX_CONNECTIONS_PER_USER) || 5,
     /** 연결 속도 제한 윈도우 (ms) — 기본 60초 */

--- a/apps/api/src/sockets/__tests__/ws-stream-registry.test.ts
+++ b/apps/api/src/sockets/__tests__/ws-stream-registry.test.ts
@@ -1,0 +1,146 @@
+/**
+ * ws-stream-registry — 소켓이 끊겨도 생성을 이어 가고 재연결 시 이어받는 규약 검증.
+ * 회귀 대상: "탭 전환/앱 백그라운드 → 응답 없음" (2026-09-05).
+ */
+import { InFlightStreamRegistry, resolveStreamKey } from '../ws-stream-registry';
+import type { ExtendedWebSocket } from '../ws-types';
+
+function fakeWs(userId: string | null = 'u1'): ExtendedWebSocket & { sent: unknown[] } {
+    const sent: unknown[] = [];
+    return {
+        OPEN: 1,
+        readyState: 1,
+        send: (raw: string) => { sent.push(JSON.parse(raw)); },
+        sent,
+        _authenticatedUserId: userId,
+        _authenticatedUserRole: 'user',
+        _abortController: null,
+        _isAlive: true,
+    } as unknown as ExtendedWebSocket & { sent: unknown[] };
+}
+
+describe('InFlightStreamRegistry', () => {
+    beforeEach(() => { jest.useFakeTimers(); });
+    afterEach(() => { jest.useRealTimers(); });
+
+    it('attached 상태에서는 소켓으로 바로 보낸다', () => {
+        const reg = new InFlightStreamRegistry(1000, 500, 1024);
+        const ws = fakeWs();
+        const entry = reg.open('u:u1', ws, new AbortController());
+        reg.send(entry, { type: 'token', token: 'ab', messageId: 'm1' });
+        expect(ws.sent).toEqual([{ type: 'token', token: 'ab', messageId: 'm1' }]);
+        expect(entry.content).toBe('ab');
+    });
+
+    it('소켓 종료 후에도 abort 하지 않고 버퍼에 쌓았다가 재연결 소켓에 스냅샷+재생한다', () => {
+        const reg = new InFlightStreamRegistry(1000, 500, 4096);
+        const ws1 = fakeWs();
+        const ac = new AbortController();
+        const entry = reg.open('u:u1', ws1, ac);
+        reg.send(entry, { type: 'token', token: '안녕', messageId: 'm1' });
+
+        expect(reg.detach(ws1)).toBe(true);
+        reg.send(entry, { type: 'token', token: '하세요' });
+        reg.send(entry, { type: 'session_created', sessionId: 's1' });
+        reg.send(entry, { type: 'artifact_start', artifact: { id: 'a1' } });
+        expect(ac.signal.aborted).toBe(false);
+
+        const ws2 = fakeWs();
+        expect(reg.attach('u:u1', ws2)).toBe(true);
+        expect(ws2.sent[0]).toEqual({
+            type: 'stream_resume', messageId: 'm1', sessionId: 's1', content: '안녕하세요', finished: false,
+        });
+        expect(ws2.sent.slice(1)).toEqual([
+            { type: 'session_created', sessionId: 's1' },
+            { type: 'artifact_start', artifact: { id: 'a1' } },
+        ]);
+        expect(ws2._abortController).toBe(ac);
+
+        // 이어서 오는 이벤트는 새 소켓으로
+        reg.send(entry, { type: 'done', messageId: 'm1' });
+        expect(ws2.sent.at(-1)).toEqual({ type: 'done', messageId: 'm1' });
+    });
+
+    it('유예 안에 재연결이 없으면 그때 abort 한다', () => {
+        const reg = new InFlightStreamRegistry(1000, 500, 4096);
+        const ws = fakeWs();
+        const ac = new AbortController();
+        reg.open('u:u1', ws, ac);
+        reg.detach(ws);
+        jest.advanceTimersByTime(999);
+        expect(ac.signal.aborted).toBe(false);
+        jest.advanceTimersByTime(1);
+        expect(ac.signal.aborted).toBe(true);
+        expect(reg.attach('u:u1', fakeWs())).toBe(false);
+    });
+
+    it('detach 중 끝난 스트림은 보관 시간 동안 늦은 재연결에도 스냅샷+done 을 준다', () => {
+        const reg = new InFlightStreamRegistry(1000, 500, 4096);
+        const ws = fakeWs();
+        const entry = reg.open('u:u1', ws, new AbortController());
+        reg.detach(ws);
+        reg.send(entry, { type: 'token', token: '결과' });
+        reg.send(entry, { type: 'done', messageId: 'm1', metrics: { tokenCount: 1 } });
+        reg.close(entry);
+
+        jest.advanceTimersByTime(400);
+        const ws2 = fakeWs();
+        expect(reg.attach('u:u1', ws2)).toBe(true);
+        expect(ws2.sent[0]).toMatchObject({ type: 'stream_resume', content: '결과', finished: true });
+        expect(ws2.sent[1]).toMatchObject({ type: 'done', messageId: 'm1' });
+        expect(ws2._abortController).toBeNull();
+        expect(reg.size).toBe(0);
+    });
+
+    it('보관 시간이 지나면 이어받을 것이 없다', () => {
+        const reg = new InFlightStreamRegistry(1000, 500, 4096);
+        const ws = fakeWs();
+        const entry = reg.open('u:u1', ws, new AbortController());
+        reg.detach(ws);
+        reg.send(entry, { type: 'done' });
+        reg.close(entry);
+        jest.advanceTimersByTime(500);
+        expect(reg.attach('u:u1', fakeWs())).toBe(false);
+    });
+
+    it('같은 키로 새 채팅을 열면 detach 된 이전 스트림은 abort 된다', () => {
+        const reg = new InFlightStreamRegistry(1000, 500, 4096);
+        const ws1 = fakeWs();
+        const ac1 = new AbortController();
+        reg.open('u:u1', ws1, ac1);
+        reg.detach(ws1);
+        const ws2 = fakeWs();
+        reg.open('u:u1', ws2, new AbortController());
+        expect(ac1.signal.aborted).toBe(true);
+        expect(reg.size).toBe(1);
+    });
+
+    it('명시적 abort 는 즉시 버린다', () => {
+        const reg = new InFlightStreamRegistry(1000, 500, 4096);
+        const ws = fakeWs();
+        const ac = new AbortController();
+        reg.open('u:u1', ws, ac);
+        expect(reg.abortByWs(ws)).toBe(true);
+        expect(ac.signal.aborted).toBe(true);
+        expect(reg.size).toBe(0);
+    });
+
+    it('버퍼 상한을 넘으면 비종료 이벤트는 버리고 종료 이벤트는 남긴다', () => {
+        const reg = new InFlightStreamRegistry(1000, 500, 100);
+        const ws = fakeWs();
+        const entry = reg.open('u:u1', ws, new AbortController());
+        reg.detach(ws);
+        reg.send(entry, { type: 'artifact_chunk', id: 'a', delta: 'x'.repeat(40) });
+        reg.send(entry, { type: 'artifact_chunk', id: 'a', delta: 'y'.repeat(40) });
+        reg.send(entry, { type: 'done' });
+        expect(entry.overflowed).toBe(true);
+        expect(entry.buffered.map((r) => (JSON.parse(r) as { type: string }).type)).toEqual(['artifact_chunk', 'done']);
+    });
+
+    it('resolveStreamKey — 인증 사용자 > 게스트 anonSessionId > 없음', () => {
+        expect(resolveStreamKey(fakeWs('7'), 'anon')).toBe('u:7');
+        expect(resolveStreamKey(fakeWs(null), 'anon-1')).toBe('a:anon-1');
+        expect(resolveStreamKey(fakeWs(null), '  ')).toBeNull();
+        expect(resolveStreamKey(fakeWs(null))).toBeNull();
+    });
+});

--- a/apps/api/src/sockets/handler.ts
+++ b/apps/api/src/sockets/handler.ts
@@ -45,6 +45,7 @@ import { WEBSOCKET_TIMEOUTS, WS_LIMITS } from '../config/timeouts';
 import { WS_SECURITY } from '../config/security';
 import { getBuildId } from '../config/build-id';
 import { handleChatMessage } from './ws-chat-handler';
+import { getInFlightStreamRegistry, resolveStreamKey } from './ws-stream-registry';
 import { handleRequestAgents } from './ws-agents-handler';
 import { getLocalBridgeRegistry } from '../services/local-bridge/registry';
 import { handleBridgeMessage } from './ws-bridge-handler';
@@ -228,8 +229,9 @@ export class WebSocketHandler {
                 this.unregisterConnection(ws);
                 // Local Bridge: 이 소켓이 등록한 로컬 실행기 세션 해제(pending 요청 reject).
                 getLocalBridgeRegistry().unregister(ws);
-                // 🔒 Phase 2 보안 패치: 연결 종료 시 진행 중인 AI 생성 중단
-                // GPU/CPU 리소스 해제 및 불필요한 토큰 생성 방지
+                // 진행 중 생성은 즉시 끊지 않는다 — 탭 백그라운드·앱 전환으로 끊긴 소켓이 유예 안에
+                // resume 하면 이어받는다(ws-stream-registry). 이어받기 대상이 아닌 연결만 종전대로 abort.
+                if (getInFlightStreamRegistry().detach(extWs)) return;
                 if (extWs._abortController) {
                     extWs._abortController.abort();
                     extWs._abortController = null;
@@ -318,7 +320,7 @@ export class WebSocketHandler {
             return;
         }
 
-        const validTypes: WSMessage['type'][] = ['refresh', 'request_agents', 'chat', 'abort'];
+        const validTypes: WSMessage['type'][] = ['refresh', 'request_agents', 'chat', 'abort', 'resume'];
         if (!validTypes.includes(typedMsg.type)) {
             log.debug(`[WS] 알 수 없는 메시지 타입: ${typedMsg.type}`);
             return;
@@ -351,6 +353,11 @@ export class WebSocketHandler {
                 case 'abort':
                     // 현재 진행 중인 채팅 중단
                     this.handleAbort(ws);
+                    break;
+
+                case 'resume':
+                    // 재연결 후 끊겼던 스트림 이어받기 — 없으면 resume_none
+                    this.handleResume(ws, typedMsg);
                     break;
             }
         });
@@ -399,10 +406,22 @@ export class WebSocketHandler {
             log.info('[WS] 채팅 중단 요청 수신');
             extWs._abortController.abort();
             extWs._abortController = null;
+            getInFlightStreamRegistry().abortByWs(extWs);
             ws.send(JSON.stringify({ type: 'aborted', message: '응답 생성이 중단되었습니다.' }));
         } else {
             log.debug('[WS] 중단할 진행 중인 채팅 없음');
         }
+    }
+
+    /**
+     * 끊겼던 스트림 이어받기 — 인증 사용자는 userId, 게스트는 anonSessionId 로 찾는다.
+     * 스트림이 없으면(이미 끝나 보관도 만료·애초에 없음) resume_none 으로 답해 클라이언트가 대기를 푼다.
+     */
+    private handleResume(ws: WebSocket, msg: WSMessage): void {
+        const extWs = ws as ExtendedWebSocket;
+        const key = resolveStreamKey(extWs, msg.anonSessionId);
+        const attached = key ? getInFlightStreamRegistry().attach(key, extWs) : false;
+        if (!attached) ws.send(JSON.stringify({ type: 'resume_none' }));
     }
 
     /**
@@ -433,8 +452,8 @@ export class WebSocketHandler {
                 log.info(reason === 'token_expired'
                     ? `[WS] 인증 토큰 만료 → 연결 종료: userId=${extWs._authenticatedUserId || 'anonymous'}`
                     : `[WS] 하트비트 미응답 → 연결 종료: userId=${extWs._authenticatedUserId || 'anonymous'}`);
-                // 진행 중인 AI 생성도 중단
-                if (extWs._abortController) {
+                // 진행 중 생성은 detach(유예 후 abort) — 이어받기 대상이 아니면 즉시 중단
+                if (!getInFlightStreamRegistry().detach(extWs) && extWs._abortController) {
                     extWs._abortController.abort();
                     extWs._abortController = null;
                 }

--- a/apps/api/src/sockets/ws-chat-handler.ts
+++ b/apps/api/src/sockets/ws-chat-handler.ts
@@ -28,6 +28,7 @@ import { buildFileContext, buildUrlContext, getCachedAttachContext, appendCached
 import type { PdfVisionResult } from '../services/chat-service/pdf-vision';
 import { saveAssistantMessage } from '../chat/request-persistence';
 import { buildWebSearchContext } from '../mcp/web-search/build-search-context';
+import { getInFlightStreamRegistry, resolveStreamKey } from './ws-stream-registry';
 
 /**
  * AI 채팅 메시지를 처리합니다.
@@ -90,9 +91,17 @@ export async function handleChatMessage(
         ? { id: nb.id.trim().slice(0, 64), title: nb.title }
         : undefined;
 
-    // 중단 컨트롤러 생성
+    // 중단 컨트롤러 생성 + 이어받기 레지스트리 등록 — 소켓이 끊겨도 생성은 계속되고(유예),
+    // 이후 모든 클라이언트 이벤트는 out() 을 거쳐 attached 소켓으로 가거나 detach 버퍼에 쌓인다.
     const abortController = new AbortController();
     extWs._abortController = abortController;
+    const streamRegistry = getInFlightStreamRegistry();
+    const streamKey = resolveStreamKey(extWs, anonSessionId);
+    const streamEntry = streamKey ? streamRegistry.open(streamKey, extWs, abortController) : null;
+    const out = (payload: Record<string, unknown>): void => {
+        if (streamEntry) streamRegistry.send(streamEntry, payload);
+        else if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(payload));
+    };
 
     // Phase 7 lifecycle hook — per_chat MCP 서버 spawn.
     // chatId 식별자: 우선 sessionId, 없으면 anonSessionId, 없으면 timestamp.
@@ -136,7 +145,7 @@ export async function handleChatMessage(
             extWs._clientIp,
         );
         if (rateLimitError) {
-            ws.send(JSON.stringify({ type: 'error', message: rateLimitError }));
+            out({ type: 'error', message: rateLimitError });
             return;
         }
         // 첨부 파일(이미지 외) → LLM 주입용 컨텍스트 (transient — DB 미저장, webSearchContext 와 동급 채널)
@@ -158,7 +167,7 @@ export async function handleChatMessage(
         // 딥 리서치 파이프라인은 fileContext 를 소비하지 않음 (research 전략은 message 만 사용).
         // 무음 폐기 대신 명시 거부 — 첨부가 반영된 것처럼 보이는 UX 기만 방지 (2026-06-13)
         if (msg.deepResearchMode === true && fileContext) {
-            ws.send(JSON.stringify({ type: 'error', message: '딥 리서치 모드에서는 파일 첨부를 지원하지 않습니다. 첨부를 제거하거나 일반 채팅으로 질문해 주세요.' }));
+            out({ type: 'error', message: '딥 리서치 모드에서는 파일 첨부를 지원하지 않습니다. 첨부를 제거하거나 일반 채팅으로 질문해 주세요.' });
             return;
         }
 
@@ -223,23 +232,17 @@ export async function handleChatMessage(
         const flushArtifactChunk = (id: string) => {
             const buf = chunkBuffers.get(id);
             if (!buf || !buf.delta) return;
-            if (ws.readyState === ws.OPEN) {
-                ws.send(JSON.stringify({ type: 'artifact_chunk', id, delta: buf.delta, messageId }));
-            }
+            out({ type: 'artifact_chunk', id, delta: buf.delta, messageId });
             buf.delta = '';
             if (buf.timer) { clearTimeout(buf.timer); buf.timer = null; }
         };
         const artifactStreamParser = new ArtifactStreamParser({
             onContent: (delta) => {
-                if (ws.readyState === ws.OPEN) {
-                    ws.send(JSON.stringify({ type: 'token', token: delta, messageId }));
-                }
+                out({ type: 'token', token: delta, messageId });
             },
             onArtifactStart: (info: ArtifactInfo) => {
                 streamedArtifactIds.add(info.id);
-                if (ws.readyState === ws.OPEN) {
-                    ws.send(JSON.stringify({ type: 'artifact_start', artifact: info, messageId }));
-                }
+                out({ type: 'artifact_start', artifact: info, messageId });
             },
             onArtifactChunk: (id, delta) => {
                 // throttle: 50ms 윈도우에 도착하는 delta 를 합쳐서 한 번에 dispatch
@@ -254,9 +257,7 @@ export async function handleChatMessage(
                 // end 전 미flush 잔여 강제 dispatch
                 flushArtifactChunk(id);
                 chunkBuffers.delete(id);
-                if (ws.readyState === ws.OPEN) {
-                    ws.send(JSON.stringify({ type: 'artifact_end', id, messageId }));
-                }
+                out({ type: 'artifact_end', id, messageId });
             },
         });
 
@@ -279,7 +280,7 @@ export async function handleChatMessage(
         };
 
         if (explicitSkillNames.length > 0) {
-            ws.send(JSON.stringify({ type: 'skills_activated', skillNames: explicitSkillNames }));
+            out({ type: 'skills_activated', skillNames: explicitSkillNames });
         }
 
         // ChatRequestHandler.processChat으로 통합 처리
@@ -328,63 +329,55 @@ export async function handleChatMessage(
             onToken: tokenCallback,
             onThinking: (thinking) => {
                 if (abortController.signal.aborted) throw new Error('ABORTED');
-                ws.send(JSON.stringify({ type: 'thinking', token: thinking, messageId }));
+                out({ type: 'thinking', token: thinking, messageId });
             },
             // 생각 요약 헤드라인 (중간·최종) — request-handler 의 요약 세션이 발행
             onThinkingSummary: (summary) => {
-                if (ws.readyState === ws.OPEN) {
-                    ws.send(JSON.stringify({ type: 'thinking_summary', summary, messageId }));
-                }
+                out({ type: 'thinking_summary', summary, messageId });
             },
             format: msg.format as import('../llm').FormatOption,
-            onAgentSelected: (agent) => ws.send(JSON.stringify({ type: 'agent_selected', agent })),
-            onDiscussionProgress: (progress) => ws.send(JSON.stringify({ type: 'discussion_progress', progress })),
-            onResearchProgress: (progress) => ws.send(JSON.stringify({ type: 'research_progress', progress })),
-            onSkillsActivated: (skillNames) => ws.send(JSON.stringify({
+            onAgentSelected: (agent) => out({ type: 'agent_selected', agent }),
+            onDiscussionProgress: (progress) => out({ type: 'discussion_progress', progress }),
+            onResearchProgress: (progress) => out({ type: 'research_progress', progress }),
+            onSkillsActivated: (skillNames) => out({
                 type: 'skills_activated',
                 skillNames: mergeActivatedSkillNames(explicitSkillNames, skillNames),
-            })),
+            }),
             // MCP tool 호출 결과의 resource content 를 frontend 로 emit
             // (예: create_skill → openmake://skill-draft/{id} → chat.js 가 인라인 카드 렌더)
             onMcpToolResult: (event) => {
-                if (ws.readyState === ws.OPEN) {
-                    ws.send(JSON.stringify({
-                        type: 'mcp_tool_result',
-                        toolName: event.toolName,
-                        resources: event.resources,
-                        messageId,
-                    }));
-                }
+                out({
+                    type: 'mcp_tool_result',
+                    toolName: event.toolName,
+                    resources: event.resources,
+                    messageId,
+                });
             },
             // MCP tool 호출 시작 알림 — frontend "🔍 {도구} 실행 중" 진행 표시
             // (도구 실행 중 "생각 중..." 이 멈춘 듯 보이는 혼선 해소)
             onMcpToolStart: (event) => {
-                if (ws.readyState === ws.OPEN) {
-                    ws.send(JSON.stringify({
-                        type: 'mcp_tool_start',
-                        toolName: event.toolName,
-                        messageId,
-                    }));
-                }
+                out({
+                    type: 'mcp_tool_start',
+                    toolName: event.toolName,
+                    messageId,
+                });
             },
             // 시스템 이벤트 (자동 토론 활성화 등 메타 알림) — UI 토스트 분리 표시
             onSystemEvent: (event) => {
-                if (ws.readyState === ws.OPEN) {
-                    ws.send(JSON.stringify({
-                        type: 'system_event',
-                        payload: {
-                            type: event.type,
-                            message: event.message,
-                            metadata: event.metadata,
-                        },
-                    }));
-                }
+                out({
+                    type: 'system_event',
+                    payload: {
+                        type: event.type,
+                        message: event.message,
+                        metadata: event.metadata,
+                    },
+                });
             },
         });
 
         // WS 고유: 새 세션 생성 알림
         if (!validSessionId) {
-            ws.send(JSON.stringify({ type: 'session_created', sessionId: result.sessionId }));
+            out({ type: 'session_created', sessionId: result.sessionId });
         }
 
         // 이번 턴의 새 첨부 컨텍스트를 세션 캐시에 누적 — 첫 턴은 result.sessionId 로
@@ -418,15 +411,15 @@ export async function handleChatMessage(
         // 후처리에서 추출됐을 수 있음 — request-handler 의 result.artifacts 를 WS 로 발행.
         // 명시적 <artifact> 는 위 스트리밍 parser 가 이미 보냈으므로 중복 replay 하지 않음.
         // 클라이언트는 동일한 artifact_start/chunk/end 시퀀스로 패널 자동 오픈.
-        if (result.artifacts && result.artifacts.length > 0 && ws.readyState === ws.OPEN) {
+        if (result.artifacts && result.artifacts.length > 0) {
             for (const a of result.artifacts.filter((artifact) => !streamedArtifactIds.has(artifact.id))) {
-                ws.send(JSON.stringify({
+                out({
                     type: 'artifact_start',
                     artifact: { id: a.id, kind: a.kind, title: a.title, lang: a.lang },
                     messageId,
-                }));
-                ws.send(JSON.stringify({ type: 'artifact_chunk', id: a.id, delta: a.content, messageId }));
-                ws.send(JSON.stringify({ type: 'artifact_end', id: a.id, messageId }));
+                });
+                out({ type: 'artifact_chunk', id: a.id, delta: a.content, messageId });
+                out({ type: 'artifact_end', id: a.id, messageId });
             }
         }
 
@@ -435,12 +428,12 @@ export async function handleChatMessage(
             finalResponse: result.response,
             streamedResponse: partialAssistantResponse,
         });
-        ws.send(JSON.stringify({
+        out({
             type: 'done',
             messageId,
             metrics: { tokensPerSec, tokenCount },
             ...(cleanedContent !== undefined ? { cleanedContent } : {}),
-        }));
+        });
 
         // 답변 검증 (선택) — done 이후 judge 모델이 1회 점검하고 **지적만** 보낸다(자동 수정 없음).
         dispatchAnswerVerification({
@@ -450,9 +443,7 @@ export async function handleChatMessage(
             ...(extWs._authenticatedUserId ? { userId: extWs._authenticatedUserId } : {}),
             ...(userLangPreference ? { userLanguage: userLangPreference } : {}),
         }, (issues) => {
-            if (ws.readyState === ws.OPEN) {
-                ws.send(JSON.stringify({ type: 'answer_verification', issues, messageId }));
-            }
+            out({ type: 'answer_verification', issues, messageId });
         });
 
     } catch (error: unknown) {
@@ -505,15 +496,7 @@ export async function handleChatMessage(
             keysInCooldown?: number;
         }
 
-        const safeSend = (data: ChatWSErrorPayload) => {
-            if (ws.readyState === ws.OPEN) {
-                try {
-                    ws.send(JSON.stringify(data));
-                } catch (e) {
-                    log.warn('[Chat] WebSocket send failed:', e);
-                }
-            }
-        };
+        const safeSend = (data: ChatWSErrorPayload) => out({ ...data });
 
         if (error instanceof ChatRequestError) {
             log.warn('[Chat] 요청 처리 에러:', error.message);
@@ -577,19 +560,20 @@ export async function handleChatMessage(
                     if (capture) {
                         // 사용자에게 보존 사실 + 만료 시각 알림 (선택적 신뢰 회복)
                         const expiresInMs = DEBUG_QUEUE_TTL_MS['auto-error'];
-                        ws.send(JSON.stringify({
+                        out({
                             type: 'debug_retained',
                             captureId: capture.id,
                             expiresAt: capture.expiresAt.toISOString(),
                             ttlHours: Math.round(expiresInMs / 3600000),
-                        }));
+                        });
                     }
                 }).catch(() => {/* 디버그 큐 실패는 사용자 흐름 안 막음 */});
             }
         }
     } finally {
-        // 중단 컨트롤러 정리
+        // 중단 컨트롤러 정리 + 레지스트리 정리(detach 로 끝났으면 결과 스냅샷 보존)
         extWs._abortController = null;
+        if (streamEntry) streamRegistry.close(streamEntry);
 
         // Phase 7 lifecycle hook — per_chat MCP 서버 graceful kill.
         // try/finally 안 보장 — 에러 발생해도 누락 없이 정리 (P7-D4).

--- a/apps/api/src/sockets/ws-stream-registry.ts
+++ b/apps/api/src/sockets/ws-stream-registry.ts
@@ -1,0 +1,217 @@
+/**
+ * 진행 중 채팅 스트림 레지스트리 — 소켓이 끊겨도 생성을 이어 가고, 재연결 시 이어받게 한다.
+ *
+ * 배경 (2026-09-05): 탭을 백그라운드로 보내거나(모바일 Safari·iOS 앱) 잠시 다른 페이지를
+ * 열면 OS 가 WebSocket 을 끊는다. 종전엔 handler.ts 의 close 핸들러가 그 즉시 생성을 abort
+ * 해 답변이 통째로 사라졌다("질문했는데 응답이 없다"). 이제 소켓과 생성의 수명을 분리한다:
+ *  - detach: 소켓이 닫히면 생성은 계속하고 출력은 여기 버퍼에 쌓는다. 유예(STREAM_DETACH_GRACE_MS)
+ *    안에 재연결이 없으면 그때 abort (GPU 절약 의도 유지).
+ *  - attach: 같은 사용자(또는 게스트 anonSessionId)가 `{type:'resume'}` 을 보내면 새 소켓에
+ *    `stream_resume`(본문 스냅샷) + 밀린 이벤트를 재생하고 그대로 이어서 스트리밍한다.
+ *  - 생성이 detach 상태에서 끝나면 답변은 request-handler 가 히스토리에 저장하며, 결과 스냅샷을
+ *    STREAM_RESULT_RETENTION_MS 동안 보관해 늦은 재연결도 화면에 이어받게 한다.
+ *
+ * 사용자(키)당 1개 — 새 채팅을 시작하면 detach 된 이전 스트림은 abort 한다(사용자가 넘어감).
+ * @module sockets/ws-stream-registry
+ */
+import { createLogger } from '../utils/logger';
+import { WEBSOCKET_TIMEOUTS, WS_LIMITS } from '../config/timeouts';
+import type { ExtendedWebSocket } from './ws-types';
+
+const log = createLogger('WsStreamRegistry');
+
+/** 본문 스냅샷으로 접히는 이벤트 — 재생하지 않고 stream_resume.content/thinking 에 합친다. */
+const SNAPSHOT_EVENT_TYPES = new Set(['token', 'thinking']);
+/** 스트림 종료 이벤트 — 이 뒤로는 새 이벤트가 오지 않는다. */
+const TERMINAL_EVENT_TYPES = new Set(['done', 'error', 'aborted']);
+
+export interface StreamEntry {
+    key: string;
+    abortController: AbortController;
+    messageId?: string;
+    sessionId?: string;
+    /** 'token' 누적 — 재부착 시 클라이언트가 마지막 assistant 본문을 이 값으로 되돌린다. */
+    content: string;
+    thinking: string;
+    /** detach 동안 밀린 비-토큰 이벤트(JSON 직렬화). 재부착 시 순서대로 재생. */
+    buffered: string[];
+    bufferedBytes: number;
+    /** 버퍼 상한을 넘어 artifact_chunk 를 버렸는지 — 재생 시 chunk 순서가 깨질 수 있어 로그로 남긴다. */
+    overflowed: boolean;
+    ws: ExtendedWebSocket | null;
+    timer: ReturnType<typeof setTimeout> | null;
+    finished: boolean;
+    startedAt: number;
+}
+
+/** 재부착 대상 키 — 인증 사용자는 userId, 게스트는 anonSessionId. 둘 다 없으면 이어받기 불가. */
+export function resolveStreamKey(extWs: ExtendedWebSocket, anonSessionId?: string): string | null {
+    if (extWs._authenticatedUserId) return `u:${extWs._authenticatedUserId}`;
+    if (typeof anonSessionId === 'string' && anonSessionId.trim()) return `a:${anonSessionId.trim()}`;
+    return null;
+}
+
+export class InFlightStreamRegistry {
+    private readonly entries = new Map<string, StreamEntry>();
+    private readonly byWs = new WeakMap<ExtendedWebSocket, StreamEntry>();
+
+    constructor(
+        private readonly graceMs: number = WEBSOCKET_TIMEOUTS.STREAM_DETACH_GRACE_MS,
+        private readonly retentionMs: number = WEBSOCKET_TIMEOUTS.STREAM_RESULT_RETENTION_MS,
+        private readonly bufferMaxBytes: number = WS_LIMITS.DETACHED_STREAM_BUFFER_MAX_BYTES,
+    ) {}
+
+    get size(): number { return this.entries.size; }
+
+    /** 새 스트림 등록. 같은 키의 이전 스트림은 사용자가 넘어간 것이므로 abort 하고 버린다. */
+    open(key: string, ws: ExtendedWebSocket, abortController: AbortController): StreamEntry {
+        const previous = this.entries.get(key);
+        if (previous) {
+            log.info(`[WsStream] 같은 키의 이전 스트림 폐기: key=${key} finished=${previous.finished}`);
+            this.dispose(previous, !previous.finished);
+        }
+        const entry: StreamEntry = {
+            key, abortController, content: '', thinking: '', buffered: [], bufferedBytes: 0,
+            overflowed: false, ws, timer: null, finished: false, startedAt: Date.now(),
+        };
+        this.entries.set(key, entry);
+        this.byWs.set(ws, entry);
+        return entry;
+    }
+
+    /** 소켓에 보내거나(attached) 버퍼에 쌓는다(detached). 종료 이벤트면 finished 표시. */
+    send(entry: StreamEntry, payload: Record<string, unknown>): void {
+        const type = String(payload.type);
+        if (type === 'session_created' && typeof payload.sessionId === 'string') entry.sessionId = payload.sessionId;
+        if (typeof payload.messageId === 'string' && !entry.messageId) entry.messageId = payload.messageId;
+        if (type === 'token' && typeof payload.token === 'string') entry.content += payload.token;
+        if (type === 'thinking' && typeof payload.token === 'string') entry.thinking += payload.token;
+        if (TERMINAL_EVENT_TYPES.has(type)) entry.finished = true;
+
+        const ws = entry.ws;
+        if (ws && ws.readyState === ws.OPEN) {
+            try { ws.send(JSON.stringify(payload)); } catch (e) { log.warn('[WsStream] send 실패:', e); }
+            return;
+        }
+        if (SNAPSHOT_EVENT_TYPES.has(type)) return; // 스냅샷으로 대체
+        const serialized = JSON.stringify(payload);
+        if (entry.bufferedBytes + serialized.length > this.bufferMaxBytes && !TERMINAL_EVENT_TYPES.has(type)) {
+            if (!entry.overflowed) {
+                entry.overflowed = true;
+                log.warn(`[WsStream] detach 버퍼 상한 초과 — 이후 비종료 이벤트 폐기: key=${entry.key}`);
+            }
+            return;
+        }
+        entry.buffered.push(serialized);
+        entry.bufferedBytes += serialized.length;
+    }
+
+    /** 소켓 종료 — 스트림이 있으면 detach 후 유예 타이머. 없으면 false(호출자가 종전 abort 경로). */
+    detach(ws: ExtendedWebSocket): boolean {
+        const entry = this.byWs.get(ws);
+        if (!entry || entry.ws !== ws) return false;
+        this.byWs.delete(ws);
+        entry.ws = null;
+        ws._abortController = null;
+        if (entry.finished) {
+            this.scheduleRetention(entry);
+            return true;
+        }
+        this.clearTimer(entry);
+        entry.timer = setTimeout(() => {
+            log.info(`[WsStream] 재연결 없이 유예 만료 → 생성 중단: key=${entry.key} elapsed=${Date.now() - entry.startedAt}ms`);
+            this.dispose(entry, true);
+        }, this.graceMs);
+        entry.timer.unref?.();
+        log.info(`[WsStream] 소켓 종료, 생성 계속(유예 ${this.graceMs}ms): key=${entry.key}`);
+        return true;
+    }
+
+    /**
+     * 재연결한 소켓에 스트림을 다시 붙인다. 스냅샷(stream_resume) → 밀린 이벤트 재생 순.
+     * 스트림이 없으면 false — 호출자가 resume_none 을 보낸다.
+     */
+    attach(key: string, ws: ExtendedWebSocket): boolean {
+        const entry = this.entries.get(key);
+        if (!entry) return false;
+        if (entry.ws && entry.ws !== ws && entry.ws.readyState === entry.ws.OPEN) {
+            // 다른 탭이 이미 받고 있음 — 새 탭으로 옮긴다(마지막 접속이 이긴다).
+            this.byWs.delete(entry.ws);
+            entry.ws._abortController = null;
+        }
+        this.clearTimer(entry);
+        entry.ws = ws;
+        this.byWs.set(ws, entry);
+        ws._abortController = entry.finished ? null : entry.abortController;
+        const snapshot = {
+            type: 'stream_resume',
+            ...(entry.messageId ? { messageId: entry.messageId } : {}),
+            ...(entry.sessionId ? { sessionId: entry.sessionId } : {}),
+            content: entry.content,
+            ...(entry.thinking ? { thinking: entry.thinking } : {}),
+            finished: entry.finished,
+        };
+        try {
+            ws.send(JSON.stringify(snapshot));
+            for (const raw of entry.buffered) ws.send(raw);
+        } catch (e) {
+            log.warn('[WsStream] 재생 send 실패:', e);
+        }
+        log.info(`[WsStream] 스트림 재부착: key=${key} replayed=${entry.buffered.length} content=${entry.content.length}자 finished=${entry.finished}`);
+        entry.buffered = [];
+        entry.bufferedBytes = 0;
+        if (entry.finished) this.dispose(entry, false);
+        return true;
+    }
+
+    /** 명시적 중단(사용자 abort 버튼) — 즉시 abort 하고 버린다. */
+    abortByWs(ws: ExtendedWebSocket): boolean {
+        const entry = this.byWs.get(ws);
+        if (!entry) return false;
+        this.dispose(entry, true);
+        return true;
+    }
+
+    /**
+     * 핸들러 종료 시 호출. attached 면 즉시 정리, detached 로 끝났으면 결과 스냅샷을
+     * 보존 시간 동안 남겨 늦은 재연결이 이어받게 한다.
+     */
+    close(entry: StreamEntry): void {
+        if (this.entries.get(entry.key) !== entry) return;
+        entry.finished = true;
+        if (entry.ws) {
+            this.dispose(entry, false);
+            return;
+        }
+        this.scheduleRetention(entry);
+    }
+
+    private scheduleRetention(entry: StreamEntry): void {
+        this.clearTimer(entry);
+        entry.timer = setTimeout(() => this.dispose(entry, false), this.retentionMs);
+        entry.timer.unref?.();
+    }
+
+    private dispose(entry: StreamEntry, abort: boolean): void {
+        this.clearTimer(entry);
+        if (abort && !entry.abortController.signal.aborted) entry.abortController.abort();
+        if (entry.ws) {
+            this.byWs.delete(entry.ws);
+            if (entry.ws._abortController === entry.abortController) entry.ws._abortController = null;
+        }
+        entry.ws = null;
+        entry.buffered = [];
+        entry.bufferedBytes = 0;
+        if (this.entries.get(entry.key) === entry) this.entries.delete(entry.key);
+    }
+
+    private clearTimer(entry: StreamEntry): void {
+        if (entry.timer) { clearTimeout(entry.timer); entry.timer = null; }
+    }
+}
+
+let singleton: InFlightStreamRegistry | null = null;
+export function getInFlightStreamRegistry(): InFlightStreamRegistry {
+    if (!singleton) singleton = new InFlightStreamRegistry();
+    return singleton;
+}

--- a/apps/ios/OpenMakeApp/Features/Conversations/ChatSessionModel.swift
+++ b/apps/ios/OpenMakeApp/Features/Conversations/ChatSessionModel.swift
@@ -87,7 +87,7 @@ final class ChatSessionModel {
                 return
             }
             // 연결이 없으면 (재)연결 — 스트림 종료 시 다음 send 에서 재연결 (plan: 재연결+이력 재조회 단순화)
-            let events: AsyncStream<WsServerEvent>
+            var events: AsyncStream<WsServerEvent>
             if await socket.isConnected, let current = currentEvents {
                 events = current
             } else {
@@ -115,19 +115,40 @@ final class ChatSessionModel {
                 userAgentId: userAgentId,
                 userLocation: userLocation))
 
-            for await event in events {
-                state.apply(event)
-                apply(state)
-                if let sid = state.sessionId { sessionId = sid }
-                if state.needsTokenRefresh {
-                    // 웹과 동일 규약: REST refresh — 다음 재연결이 새 토큰 사용
-                    Task { try? await client.refresh() }
+            // 앱 전환·백그라운드로 소켓이 끊기면 스트림이 done 없이 끝난다. 서버는 유예 동안 생성을
+            // 계속하므로 재연결 후 resume 으로 이어받는다(웹 use-chat-socket 과 같은 규약).
+            var resumeAttempts = 0
+            streamLoop: while true {
+                for await event in events {
+                    state.apply(event)
+                    apply(state)
+                    if let sid = state.sessionId { sessionId = sid }
+                    if state.needsTokenRefresh {
+                        // 웹과 동일 규약: REST refresh — 다음 재연결이 새 토큰 사용
+                        Task { try? await client.refresh() }
+                    }
+                    if state.isDone { break streamLoop }
                 }
-                if state.isDone { break }
+                guard resumeAttempts < Self.maxResumeAttempts else { break }
+                resumeAttempts += 1
+                statusText = "연결을 복구하고 있어요"
+                try? await Task.sleep(for: .seconds(resumeAttempts))
+                guard let bearer = await client.accessToken else { break }
+                do {
+                    events = try await socket.connect(bearer: bearer)
+                    currentEvents = events
+                    await socket.resume()
+                } catch {
+                    continue
+                }
             }
 
             if let error = state.errorMessage {
                 errorMessage = error
+            } else if state.resumeUnavailable {
+                noticeText = streamingText.isEmpty
+                    ? "연결이 끊긴 사이 응답이 끝났어요. 대화 기록에서 확인해 주세요."
+                    : "여기까지 받았고, 나머지는 대화 기록에 저장돼 있어요."
             } else if state.wasAborted {
                 noticeText = streamingText.isEmpty
                     ? "응답을 중단했어요"
@@ -164,6 +185,8 @@ final class ChatSessionModel {
         Task { [socket] in await socket.disconnect() }
     }
 
+    /// done 없이 스트림이 끝났을 때 재연결+resume 시도 횟수 상한
+    private static let maxResumeAttempts = 3
     private var currentEvents: AsyncStream<WsServerEvent>?
     private var agentPollTask: Task<Void, Never>?
 

--- a/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/ChatStreamState.swift
+++ b/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/ChatStreamState.swift
@@ -69,6 +69,8 @@ public struct ChatStreamState: Sendable {
     public private(set) var errorMessage: String?
     /// 인증 토큰 만료 임박 — 호출자는 REST refresh 후 재연결 (웹과 동일 규약)
     public private(set) var needsTokenRefresh = false
+    /// resume 요청에 이어받을 스트림이 없었음 — 답변이 끝났다면 서버 히스토리에 있다
+    public private(set) var resumeUnavailable = false
     /// 진행 상태 한 줄 (도구 실행·리서치/토론 진행 등) — token 수신 시 자동 해제
     public private(set) var statusText: String?
     public private(set) var activityKind: ChatActivityKind?
@@ -179,6 +181,19 @@ public struct ChatStreamState: Sendable {
             activityKind = nil
         case .tokenWarning:
             needsTokenRefresh = true
+        case .streamResume:
+            // 끊긴 사이 서버가 계속 만든 답변 스냅샷 — 본문을 통째로 되돌리고 스트리밍 상태로 복귀.
+            // 뒤따르는 token/done 이 그대로 이어진다(웹 use-chat-socket 과 같은 규약).
+            streamingText = event.content ?? streamingText
+            isThinking = false
+            isDone = false
+            setActivity(streamingText.isEmpty ? "답변을 이어받고 있어요" : Self.writingText, kind: .finalizing)
+        case .resumeNone:
+            resumeUnavailable = true
+            isDone = true
+            isThinking = false
+            statusText = nil
+            activityKind = nil
         default:
             break
         }

--- a/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/Generated/WsModels.swift
+++ b/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/Generated/WsModels.swift
@@ -76,6 +76,9 @@ public struct WsServerEvent: Codable {
     public let cleanedContent: String?
     /// 백엔드 실제 페이로드(ws-chat-handler): 스트리밍 완료 시 토큰 메트릭. tokensPerSec 는 toFixed(2) 문자열.
     public let metrics: Metrics?
+    public let content: String?
+    public let finished: Bool?
+    public let thinking: String?
     /// 에러 분류(quota_exceeded / api_keys_exhausted / provider code 등)
     public let errorType: String?
     public let keysInCooldown: Double?
@@ -114,6 +117,9 @@ public struct WsServerEvent: Codable {
         case payload = "payload"
         case cleanedContent = "cleanedContent"
         case metrics = "metrics"
+        case content = "content"
+        case finished = "finished"
+        case thinking = "thinking"
         case errorType = "errorType"
         case keysInCooldown = "keysInCooldown"
         case resetTime = "resetTime"
@@ -134,7 +140,7 @@ public struct WsServerEvent: Codable {
         case taskID = "taskId"
     }
 
-    public init(token: String?, type: WsServerEventType, messageID: String?, summary: String?, issues: String?, sessionID: String?, buildID: String?, message: String?, captureID: String?, expiresAt: String?, ttlHours: Double?, payload: Payload?, cleanedContent: String?, metrics: Metrics?, errorType: String?, keysInCooldown: Double?, resetTime: String?, retryAfter: Double?, totalKeys: Double?, data: JSONAny?, agent: Agent?, skillNames: [String]?, toolName: String?, resources: [MCPToolResource]?, progress: ProgressUnion?, artifact: ArtifactMeta?, delta: String?, id: String?, currentTurn: Double?, status: String?, step: Step?, taskID: String?) {
+    public init(token: String?, type: WsServerEventType, messageID: String?, summary: String?, issues: String?, sessionID: String?, buildID: String?, message: String?, captureID: String?, expiresAt: String?, ttlHours: Double?, payload: Payload?, cleanedContent: String?, metrics: Metrics?, content: String?, finished: Bool?, thinking: String?, errorType: String?, keysInCooldown: Double?, resetTime: String?, retryAfter: Double?, totalKeys: Double?, data: JSONAny?, agent: Agent?, skillNames: [String]?, toolName: String?, resources: [MCPToolResource]?, progress: ProgressUnion?, artifact: ArtifactMeta?, delta: String?, id: String?, currentTurn: Double?, status: String?, step: Step?, taskID: String?) {
         self.token = token
         self.type = type
         self.messageID = messageID
@@ -149,6 +155,9 @@ public struct WsServerEvent: Codable {
         self.payload = payload
         self.cleanedContent = cleanedContent
         self.metrics = metrics
+        self.content = content
+        self.finished = finished
+        self.thinking = thinking
         self.errorType = errorType
         self.keysInCooldown = keysInCooldown
         self.resetTime = resetTime
@@ -203,6 +212,9 @@ public extension WsServerEvent {
         payload: Payload?? = nil,
         cleanedContent: String?? = nil,
         metrics: Metrics?? = nil,
+        content: String?? = nil,
+        finished: Bool?? = nil,
+        thinking: String?? = nil,
         errorType: String?? = nil,
         keysInCooldown: Double?? = nil,
         resetTime: String?? = nil,
@@ -237,6 +249,9 @@ public extension WsServerEvent {
             payload: payload ?? self.payload,
             cleanedContent: cleanedContent ?? self.cleanedContent,
             metrics: metrics ?? self.metrics,
+            content: content ?? self.content,
+            finished: finished ?? self.finished,
+            thinking: thinking ?? self.thinking,
             errorType: errorType ?? self.errorType,
             keysInCooldown: keysInCooldown ?? self.keysInCooldown,
             resetTime: resetTime ?? self.resetTime,
@@ -789,8 +804,10 @@ public enum WsServerEventType: String, Codable {
     case mcpToolResult = "mcp_tool_result"
     case mcpToolStart = "mcp_tool_start"
     case researchProgress = "research_progress"
+    case resumeNone = "resume_none"
     case sessionCreated = "session_created"
     case skillsActivated = "skills_activated"
+    case streamResume = "stream_resume"
     case systemEvent = "system_event"
     case thinking = "thinking"
     case thinkingSummary = "thinking_summary"

--- a/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/WsChatSocket.swift
+++ b/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/WsChatSocket.swift
@@ -79,6 +79,13 @@ public actor WsChatSocket {
         try? await task.send(.string(#"{"type":"abort"}"#))
     }
 
+    /// 재연결 후 끊겼던 스트림 이어받기 요청 — 서버(ws-stream-registry)가 stream_resume(본문 스냅샷)
+    /// 뒤 후속 이벤트를 이어서 보내거나, 없으면 resume_none 으로 답한다.
+    public func resume() async {
+        guard let task else { return }
+        try? await task.send(.string(#"{"type":"resume"}"#))
+    }
+
     public func disconnect() {
         task?.cancel(with: .normalClosure, reason: nil)
         task = nil

--- a/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/ChatStreamStateTests.swift
+++ b/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/ChatStreamStateTests.swift
@@ -61,6 +61,29 @@ final class ChatStreamStateTests: XCTestCase {
         XCTAssertEqual(state.errorMessage, "백엔드 오류")
     }
 
+    func testStreamResumeReplacesTextAndReopensStream() {
+        var state = ChatStreamState()
+        state.begin()
+        state.apply(event(#"{"type":"token","token":"안녕"}"#))
+        state.apply(event(#"{"type":"stream_resume","messageId":"m1","sessionId":"s1","content":"안녕하세요, 이어서","finished":false}"#))
+        XCTAssertEqual(state.streamingText, "안녕하세요, 이어서")
+        XCTAssertEqual(state.sessionId, nil) // sessionId 는 session_created 재생이 담당
+        XCTAssertFalse(state.isDone)
+        state.apply(event(#"{"type":"token","token":" 답합니다"}"#))
+        state.apply(event(#"{"type":"done","messageId":"m1"}"#))
+        XCTAssertEqual(state.streamingText, "안녕하세요, 이어서 답합니다")
+        XCTAssertTrue(state.isDone)
+    }
+
+    func testResumeNoneEndsStreamWithFlag() {
+        var state = ChatStreamState()
+        state.begin()
+        state.apply(event(#"{"type":"resume_none"}"#))
+        XCTAssertTrue(state.isDone)
+        XCTAssertTrue(state.resumeUnavailable)
+        XCTAssertNil(state.errorMessage)
+    }
+
     func testAbortedEndsStream() {
         var state = ChatStreamState()
         state.apply(event(#"{"type":"aborted"}"#))

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -209,6 +209,8 @@ interface AppState {
   setChatHistory: (fn: (prev: ChatMessage[]) => ChatMessage[]) => void;
   appendMessage: (m: ChatMessage) => void;
   appendToken: (token: string) => void;
+  /** 재연결 이어받기 — 마지막 assistant 본문을 서버 스냅샷으로 되돌리고 스트리밍 상태로 복귀 */
+  resumeAssistant: (content: string, reasoning?: string) => void;
   /** 진행 중(또는 마지막) assistant 메시지에 모델 폴백 고지를 부착 */
   setModelFallback: (info: { from: string; to: string; reason?: string }) => void;
   appendThinking: (token: string) => void;
@@ -377,6 +379,22 @@ export const useAppStore = create<AppState>()(
         hist.push({ role: "assistant", content: token, streaming: true });
       }
       return { chatHistory: hist };
+    }),
+  resumeAssistant: (content, reasoning) =>
+    set((s) => {
+      const hist = [...s.chatHistory];
+      const last = hist[hist.length - 1];
+      if (last && last.role === "assistant") {
+        hist[hist.length - 1] = {
+          ...last,
+          content,
+          ...(reasoning ? { reasoning } : {}),
+          streaming: true,
+        };
+      } else {
+        hist.push({ role: "assistant", content, ...(reasoning ? { reasoning } : {}), streaming: true });
+      }
+      return { chatHistory: hist, isGenerating: true };
     }),
   appendThinking: (token) =>
     set((s) => {

--- a/apps/web/lib/use-chat-socket.ts
+++ b/apps/web/lib/use-chat-socket.ts
@@ -117,6 +117,9 @@ export function useChatSocket() {
   // 구조화 답변(REST) 진행 중 AbortController — abort() 가 취소할 수 있게 보관
   // token_warning 갱신이 스트리밍 중 도착하면 스트림 종료 후 재연결하기 위한 예약 플래그.
   const reconnectAfterRefreshRef = useRef(false);
+  // 스트리밍 도중 소켓이 끊겼음(탭 백그라운드·절전 등) — 재연결 직후 서버에 resume 을 보내
+  // 서버가 계속 생성해 둔 답변을 이어받는다(서버 ws-stream-registry 와 페어).
+  const pendingResumeRef = useRef(false);
   // MCP 도구 결과 resource — 스트리밍 중 append 하면 응답이 조각나므로(appendToken 이 카드를
   // 마지막 메시지로 오인) 버퍼에 모았다가 스트림 종료 시 flush 한다.
   const pendingMcpResourcesRef = useRef<McpResourcePayload[]>([]);
@@ -125,6 +128,7 @@ export function useChatSocket() {
     appendMessage,
     setChatHistory,
     appendToken,
+    resumeAssistant,
     setModelFallback,
     appendThinking,
     setThinkingSummary,
@@ -159,6 +163,10 @@ export function useChatSocket() {
       }
       setConnected(true);
       reconnectRef.current = 0;
+      if (pendingResumeRef.current) {
+        pendingResumeRef.current = false;
+        ws.send(JSON.stringify({ type: "resume", anonSessionId: getAnonSessionId() }));
+      }
     };
 
     // 버퍼에 모인 MCP resource 를 system(notice) 메시지로 flush — 스트림 종료 후에만 호출.
@@ -240,6 +248,16 @@ export function useChatSocket() {
           break;
         case "session_created":
           if (data.sessionId) setCurrentSessionId(data.sessionId);
+          break;
+        case "stream_resume":
+          // 끊긴 사이 서버가 계속 생성한 답변 스냅샷 — 마지막 assistant 본문을 통째로 되돌리고
+          // 다시 스트리밍 상태로 둔다(후속 token/done 이 그대로 이어진다).
+          if (data.sessionId) setCurrentSessionId(data.sessionId);
+          resumeAssistant(data.content, data.thinking);
+          break;
+        case "resume_none":
+          // 이어받을 스트림 없음(보관 만료 등) — 답변은 히스토리에 저장돼 있으니 안내만 남긴다.
+          appendMessage({ role: "system", notice: true, content: tRef.current("resumeNone") });
           break;
         case "done":
           // sessionId 는 session_created 이벤트가 담당(done 페이로드엔 없음).
@@ -456,6 +474,8 @@ export function useChatSocket() {
 
     ws.onclose = () => {
       setConnected(false);
+      // 생성 중에 끊겼으면 재연결 후 이어받기 대상으로 표시(서버는 유예 동안 계속 생성한다).
+      if (useAppStore.getState().isGenerating) pendingResumeRef.current = true;
       setStreaming(false);
       if (unmountedRef.current) return;
       // 지수 백오프 재연결 (최대 10회) — 타이머 핸들을 저장해 언마운트 시 취소 가능하게.

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -556,6 +556,7 @@
     "error": "Error: {message}",
     "unknownError": "Unknown error",
     "disconnected": "_(Disconnected from the server. Reconnecting — please try sending again shortly.)_",
+    "resumeNone": "_(No response to resume. If it finished, it is saved in the conversation history.)_",
     "taskIdMissing": "No taskId in the task creation response",
     "agentTaskStartFailed": "Failed to start the agent task: {message}"
   },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -556,6 +556,7 @@
     "error": "エラー: {message}",
     "unknownError": "不明なエラー",
     "disconnected": "_(サーバーとの接続が切れました。再接続中です。しばらくして再送信してください。)_",
+    "resumeNone": "_(再開できる応答がありません。完了していれば会話履歴に保存されています。)_",
     "taskIdMissing": "タスク作成レスポンスに taskId がありません",
     "agentTaskStartFailed": "エージェントタスクを開始できませんでした: {message}"
   },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -556,6 +556,7 @@
     "error": "오류: {message}",
     "unknownError": "알 수 없는 오류",
     "disconnected": "_(서버와 연결이 끊겼습니다. 재연결 중이니 잠시 후 다시 전송해 주세요.)_",
+    "resumeNone": "_(이어받을 응답이 없습니다. 답변이 완료됐다면 대화 기록에 저장돼 있습니다.)_",
     "taskIdMissing": "작업 생성 응답에 taskId 가 없습니다",
     "agentTaskStartFailed": "에이전트 작업을 시작하지 못했습니다: {message}"
   },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -556,6 +556,7 @@
     "error": "错误：{message}",
     "unknownError": "未知错误",
     "disconnected": "_(与服务器的连接已断开。正在重新连接，请稍后重新发送。)_",
+    "resumeNone": "_(没有可继续接收的回复。若已完成，则已保存在对话记录中。)_",
     "taskIdMissing": "任务创建响应中缺少 taskId",
     "agentTaskStartFailed": "无法启动智能体任务：{message}"
   },

--- a/packages/api-contracts/events/ws-chat.v1.schema.json
+++ b/packages/api-contracts/events/ws-chat.v1.schema.json
@@ -479,6 +479,47 @@
           "properties": {
             "type": {
               "type": "string",
+              "const": "stream_resume"
+            },
+            "messageId": {
+              "type": "string"
+            },
+            "sessionId": {
+              "type": "string"
+            },
+            "content": {
+              "type": "string"
+            },
+            "thinking": {
+              "type": "string"
+            },
+            "finished": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "type",
+            "content",
+            "finished"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "resume_none"
+            }
+          },
+          "required": [
+            "type"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
               "const": "error"
             },
             "message": {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -177,6 +177,15 @@ export type WsServerEvent =
       cleanedContent?: string;
     }
   | { type: "aborted"; message?: string }
+  /**
+   * 끊겼던 스트림 이어받기 (2026-09-05). 클라이언트가 재연결 후 `{type:"resume", anonSessionId?}` 를
+   * 보내면 서버가 진행 중(또는 방금 끝난) 스트림의 본문 스냅샷을 주고 이어서 스트리밍한다.
+   * content 는 지금까지의 답변 전체 — 클라는 마지막 assistant 본문을 이 값으로 되돌린 뒤 후속
+   * token 을 이어 붙인다. finished=true 면 뒤따르는 done/error 로 곧 끝난다.
+   */
+  | { type: "stream_resume"; messageId?: string; sessionId?: string; content: string; thinking?: string; finished: boolean }
+  /** resume 요청에 이어받을 스트림이 없음 — 클라는 대기 상태를 풀면 된다. */
+  | { type: "resume_none" }
   | {
       type: "error";
       message: string;


### PR DESCRIPTION
## 문제
chat.openmake.cc 에서 질문 후 다른 탭/앱으로 전환하면 응답이 오지 않는다. 웹·iPhone 앱 동일.

## 원인
`sockets/handler.ts` 의 close 핸들러가 소켓이 닫히는 즉시 진행 중 생성을 abort 했다. 모바일 Safari 탭 백그라운드·iOS 앱 전환은 OS 가 WebSocket 을 끊으므로 답변이 통째로 사라졌고, 저장 경로도 타지 않았다. 클라이언트 결함이 아니라 서버 정책이라 두 클라이언트가 같은 증상.

## 수정
- **`sockets/ws-stream-registry.ts`(신규)**: 사용자당 진행 중 스트림 1개. 소켓 close → detach(생성 계속, 이벤트 버퍼) → 유예 `WS_STREAM_DETACH_GRACE_MS`(5분) 안에 `{type:'resume'}` 이 오면 `stream_resume`(본문 스냅샷) + 밀린 이벤트 재생 후 이어서 스트리밍. 유예 초과 시 abort(GPU 절약 의도 유지). detach 중 끝난 답변은 히스토리에 저장되고 스냅샷을 `WS_STREAM_RESULT_RETENTION_MS`(2분) 보관.
- `ws-chat-handler.ts` 는 모든 이벤트를 레지스트리로 라우팅(600줄 → 584줄), `handler.ts` 는 close/하트비트에서 detach 우선 + `resume` 처리. 명시적 [중단] 은 종전대로 즉시.
- 계약: `WsServerEvent` 에 `stream_resume` / `resume_none` 추가(추가 전용, 구 클라이언트 무시). api-contracts 재export·iOS Kit 재생성.
- 웹 `use-chat-socket.ts`: 생성 중 끊기면 재연결 직후 resume, `store.resumeAssistant` 로 본문 복원. iOS: `WsChatSocket.resume()` + `ChatStreamState` + `ChatSessionModel` 재연결 3회.

## 검증
- 단위: `ws-stream-registry.test.ts` 9건, Kit `ChatStreamStateTests` 2건 추가. sockets/ws-chat/contracts 65 passed, api·web tsc 0, iOS 시뮬 빌드 성공.
- 라이브: 배포 후 WS 하네스(첫 토큰 뒤 소켓 강제 종료 → 4s 후 재연결 → resume → stream_resume + done)로 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SgTTLYHPXq1meVB4MqM3g