### PR TITLE
perf(chat): 프롬프트 다이어트 1차 — MCP 비참조 서버 미노출·저빈도 도구 의도 게이팅·스킬 주입 상한

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,11 @@ LLM_TIMEOUT=120000                              # HTTP 요청 타임아웃 (ms)
 # WS_STREAM_DETACH_GRACE_MS=300000
 # WS_STREAM_RESULT_RETENTION_MS=120000
 # WS_DETACHED_STREAM_BUFFER_MAX_BYTES=4194304
+
+# 프롬프트 다이어트 (2026-09-05) — 채팅 첫 턴 입력 17K 토큰 중 도구·스킬 비중 축소
+# CHAT_USER_MCP_BREADTH_SLOTS=0        # 서버 언급 없는 턴에 비참조 MCP 서버를 round-robin 노출하는 슬롯 수 (0=언급된 서버만, 종전=CHAT_USER_MCP_TOOL_CAP)
+# CHAT_TOOL_INTENT_GATE_ENABLED=true   # agent_task_list/get·spawn_agents 를 의도 정규식 턴에만 노출 (false=종전 상시)
+# SKILL_MANIFEST_INJECT_MAX_CHARS=12000 # 에이전트 1턴 스킬 manifest 주입 합계 문자 상한 (첫 스킬은 항상 주입)
 # LiteLLM 통합 게이트웨이로 inference 를 라우팅할 외부 provider id 콤마 목록.
 # 빈값/미설정 = 전부 direct 호출. provider별 롤백은 목록에서 제거 + 재시작.
 # ollama-local(사용자별 endpoint)·chatgpt(OAuth) 는 목록과 무관하게 direct 유지.

--- a/apps/api/src/agents/__tests__/skill-inject-cap.test.ts
+++ b/apps/api/src/agents/__tests__/skill-inject-cap.test.ts
@@ -1,0 +1,54 @@
+/**
+ * buildManifestPrompt — 주입 합계 상한 (프롬프트 다이어트, 2026-09-05).
+ *
+ * 실측: backend-developer 는 배정 4개 합계 30.7K 자(≈9K 토큰)가 매 턴 실렸다.
+ * priority 순으로 담다가 SKILL_MANIFEST_INJECT_MAX_CHARS 를 넘으면 나머지를 건너뛰되,
+ * 첫 스킬은 상한과 무관하게 항상 주입한다.
+ */
+import { SkillManager } from '../skill-manager';
+
+jest.mock('../../config/runtime-limits', () => ({
+    ...jest.requireActual('../../config/runtime-limits'),
+    SKILL_MANIFEST_INJECT_MAX_CHARS: 1000,
+}));
+
+const row = (id: string, chars: number) => ({
+    id, version: '1.0.0', assigned_to: 'backend-developer',
+    prompt_md: `${id.toUpperCase()}:` + 'x'.repeat(chars),
+    manifest_yaml: `name: ${id}\ncategory: technology`,
+});
+
+let rows: ReturnType<typeof row>[] = [];
+jest.mock('../../data/models/unified-database', () => ({
+    getUnifiedDatabase: () => ({ getPool: () => ({ query: async () => ({ rows }) }) }),
+}));
+
+function manager(): SkillManager {
+    const mgr = new SkillManager();
+    (mgr as unknown as { repo: unknown }).repo = { getUserSkills: async () => [] };
+    return mgr;
+}
+
+describe('buildManifestPrompt — 주입 합계 상한', () => {
+    it('상한을 넘는 뒤쪽 스킬은 건너뛰고 skillNames 도 주입분만 남긴다', async () => {
+        rows = [row('ecc-a', 600), row('ecc-b', 300), row('ecc-c', 300), row('sys', 50)];
+        const out = await manager().buildManifestPrompt('backend-developer', undefined, 'technology');
+        expect(out).not.toBeNull();
+        // a(600)+b(300)=900 ≤ 1000, c 는 1200 초과로 건너뜀, sys(50) 는 950 이라 담김
+        expect(out!.skillNames).toEqual(['ecc-a', 'ecc-b', 'sys']);
+        expect(out!.prompt).toContain('ECC-A:');
+        expect(out!.prompt).not.toContain('ECC-C:');
+    });
+
+    it('첫 스킬이 상한보다 커도 항상 주입한다', async () => {
+        rows = [row('huge', 5000), row('small', 10)];
+        const out = await manager().buildManifestPrompt('backend-developer', undefined, 'technology');
+        expect(out!.skillNames).toEqual(['huge']);
+    });
+
+    it('합계가 상한 이내면 전부 주입한다', async () => {
+        rows = [row('a', 100), row('b', 100), row('c', 100)];
+        const out = await manager().buildManifestPrompt('backend-developer', undefined, 'technology');
+        expect(out!.skillNames).toEqual(['a', 'b', 'c']);
+    });
+});

--- a/apps/api/src/agents/skill-manager.ts
+++ b/apps/api/src/agents/skill-manager.ts
@@ -50,6 +50,7 @@ import { slugify } from '../chat/slash-command';
 import { recordSkillUsage } from './skill-usage-log';
 import { shouldInjectManifestSkill } from './manifest-injection-filter';
 import { SKILL_VERSION_LATEST_ORDER_SQL } from '../data/repositories/skill-manifest-sync';
+import { SKILL_MANIFEST_INJECT_MAX_CHARS } from '../config/runtime-limits';
 
 const logger = createLogger('SkillManager');
 
@@ -480,20 +481,31 @@ export class SkillManager {
         ));
         if (filtered.length === 0) return null;
 
-        const blocks = filtered.map(r => {
+        // 주입 합계 상한 (프롬프트 다이어트 2026-09-05): priority 순으로 담다가 SKILL_MANIFEST_INJECT_MAX_CHARS
+        // 초과분은 건너뛴다(첫 스킬은 항상). 실측 backend-developer 4개 30.7K 자(≈9K 토큰)가 매 턴 실렸다.
+        const injectedRows: typeof filtered = [];
+        const skipped: string[] = [];
+        let injectedChars = 0;
+        for (const r of filtered) {
+            if (injectedRows.length > 0 && injectedChars + r.prompt_md.length > SKILL_MANIFEST_INJECT_MAX_CHARS) { skipped.push(r.id); continue; }
+            injectedRows.push(r);
+            injectedChars += r.prompt_md.length;
+        }
+        if (skipped.length > 0) logger.info(`manifest 주입 상한(${SKILL_MANIFEST_INJECT_MAX_CHARS}자) — agent=${agentId} 주입 ${injectedRows.length}개(${injectedChars}자), 건너뜀: ${skipped.join(', ')}`);
+        const blocks = injectedRows.map(r => {
             const safeId = r.id.replace(/[<>"&]/g, '');
             return `<skill_context name="${safeId}">\n${r.prompt_md}\n</skill_context>`;
         });
         // 표시용 이름 — manifest_yaml 의 name 을 쓰고, 없으면 id 로 대체.
         // 저장된 manifest_yaml 은 fence('---') 없는 순수 yaml 이라 '^---' 전제 정규식은
         // 항상 실패해 uuid id 가 그대로 표시되던 결함 수정 — 최상위 name: 키를 multiline 매칭.
-        const skillNames = filtered.map(r => {
+        const skillNames = injectedRows.map(r => {
             const m = /^name:\s*([^\n]+)/m.exec(r.manifest_yaml);
             return m?.[1]?.trim().replace(/^['"]|['"]$/g, '') || r.id;
         });
 
         // 사용 기록 — 주입된 스킬 id/version (개인 union 분은 아래서 추가)
-        const injected: Array<{ skillId: string; skillVersion?: string }> = filtered.map(r => ({ skillId: r.id, skillVersion: r.version }));
+        const injected: Array<{ skillId: string; skillVersion?: string }> = injectedRows.map(r => ({ skillId: r.id, skillVersion: r.version }));
 
         // 개인 지정(user-assign) 스킬 중 manifest 미보유분 union — 확장 설치 스킬 등은
         // agent_skills 에만 존재하는데, manifest 스킬이 하나라도 있으면 legacy fallback 이

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1270,6 +1270,43 @@ export const CHAT_USER_MCP_SCHEMA_BUDGET_BYTES = parseInt(
 );
 
 /**
+ * 메시지가 어느 서버도 언급하지 않았을 때 비참조 서버에 round-robin 으로 배정하는 자동 노출
+ * 슬롯 수 (프롬프트 다이어트, 2026-09-05). 종전엔 cap 까지 채워 매 턴 14개/16KB(≈4.3K 토큰)가
+ * 의도와 무관하게 실렸다 — 7일 실측에서 그렇게 노출된 도구의 호출은 서버명 언급 없이 거의 없었다.
+ * 기본 0 = 언급된 서버(depth)만 노출. 밀려난 서버는 mcp_list_tools/mcp_call(진행적 공개)로
+ * on-demand 접근한다. 종전 동작으로 되돌리려면 CHAT_USER_MCP_TOOL_CAP 과 같은 값으로.
+ */
+export const CHAT_USER_MCP_BREADTH_SLOTS = parseInt(
+    process.env.CHAT_USER_MCP_BREADTH_SLOTS || '0',
+    10,
+);
+
+/**
+ * 저빈도 내장 도구 의도 게이팅 (프롬프트 다이어트, 2026-09-05) — always-on 이던 agent_task_list/
+ * agent_task_get 과 상시 노출이던 spawn_agents 를 아래 의도 정규식이 맞는 턴에만 노출한다.
+ * 7일 실측 호출 0~2회인데 매 턴 ≈830 토큰을 차지했다. false 면 종전(상시 노출).
+ */
+export const CHAT_TOOL_INTENT_GATE_ENABLED = process.env.CHAT_TOOL_INTENT_GATE_ENABLED !== 'false';
+
+/**
+ * 에이전트 1턴에 주입하는 스킬 manifest(prompt_md) 합계 문자 상한 (프롬프트 다이어트, 2026-09-05).
+ * priority 순으로 담고 넘치면 나머지를 건너뛴다(첫 스킬은 항상 주입). 실측: backend-developer
+ * 30.7K 자·software-engineer 18.2K 자가 매 턴 실렸고 대부분 에이전트는 2.5K 자.
+ */
+export const SKILL_MANIFEST_INJECT_MAX_CHARS = parseInt(
+    process.env.SKILL_MANIFEST_INJECT_MAX_CHARS || '12000',
+    10,
+);
+
+/** agent_task_list / agent_task_get 노출 의도 — 에이전트 작업의 상태·결과·목록을 묻는 턴. */
+export const AGENT_TASK_INTENT_PATTERNS: readonly RegExp[] = [
+    /(에이전트|agent)\s*(작업|task)/i,
+    /(작업|task)[^\n]{0,12}(상태|진행|결과|목록|리스트|확인|어떻게|어디까지|끝났|완료)/i,
+    /(status|progress|result)\s+of\s+(the\s+)?(task|job)/i,
+    /agent_task_(list|get)/i,
+];
+
+/**
  * MCP 진행적 공개(progressive disclosure) — mcp_list_tools / mcp_call 메타 도구를 채팅에
  * always-on 노출할지. ON 이면 다(多)서버 사용자가 cap 밖으로 밀린 서버 도구도 on-demand 로
  * 발견·호출 가능(함수 스키마 슬롯 1~2개만 사용). **기본 ON** — 라이브 E2E 검증 완료로 운영

--- a/apps/api/src/services/ChatService.ts
+++ b/apps/api/src/services/ChatService.ts
@@ -27,7 +27,7 @@ import type { UserContext } from '../mcp/user-sandbox';
 import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { CHAT_ALWAYS_ON_TOOL_NAMES } from '../mcp/agent-task-tools';
 import { MCP_META_TOOL_NAMES } from '../mcp/mcp-meta-tools';
-import { CHAT_USER_MCP_TOOL_CAP, CHAT_USER_MCP_SCHEMA_BUDGET_BYTES, MCP_PROGRESSIVE_DISCLOSURE_ENABLED, MAP_INTENT_PATTERNS, ROUTE_INTENT_PATTERNS, WEB_SEARCH_INTENT_PATTERNS, PLAN_INTENT_PATTERNS, EXTENSION_IMPORT_INTENT_PATTERNS } from '../config/runtime-limits';
+import { CHAT_USER_MCP_TOOL_CAP, CHAT_USER_MCP_SCHEMA_BUDGET_BYTES, MCP_PROGRESSIVE_DISCLOSURE_ENABLED, MAP_INTENT_PATTERNS, ROUTE_INTENT_PATTERNS, WEB_SEARCH_INTENT_PATTERNS, PLAN_INTENT_PATTERNS, EXTENSION_IMPORT_INTENT_PATTERNS, CHAT_USER_MCP_BREADTH_SLOTS, CHAT_TOOL_INTENT_GATE_ENABLED, AGENT_TASK_INTENT_PATTERNS } from '../config/runtime-limits';
 import { applySkillCatalog as applySkillCatalogShared } from './skill-catalog-tool';
 import { LLMClient } from '../llm';
 import { type ToolDefinition } from '../llm';
@@ -176,7 +176,7 @@ export class ChatService {
         // 프리픽스는 LLM 전용 enhancedMessage 에만 실리므로(reqCtx.message 는 원문)
         // depth 매칭 힌트를 여기서 보강한다.
         const mcpSelectMessage = reqCtx.notebook ? `${reqCtx.message ?? ''} notebooklm` : reqCtx.message;
-        const userMcpAutoOn = selectUserMcpAutoOn(allTools, toolGroups, enabledToggles, CHAT_USER_MCP_TOOL_CAP, CHAT_USER_MCP_SCHEMA_BUDGET_BYTES, mcpSelectMessage);
+        const userMcpAutoOn = selectUserMcpAutoOn(allTools, toolGroups, enabledToggles, CHAT_USER_MCP_TOOL_CAP, CHAT_USER_MCP_SCHEMA_BUDGET_BYTES, mcpSelectMessage, CHAT_USER_MCP_BREADTH_SLOTS);
 
         // 사용자가 명시적으로 활성화한 도구만 추출
         const userToggled = allTools.filter(t => enabledToggles[t.function.name] === true);
@@ -198,8 +198,15 @@ export class ChatService {
         });
 
         // 토글 없이 항상 제공: 에이전트 작업 조회 + (플래그 ON 시) MCP 진행적 공개 메타 도구.
+        // 프롬프트 다이어트(2026-09-05): agent_task_list/get 은 작업 상태를 묻는 턴에만 —
+        // 7일 실측 호출 0회인데 매 턴 ≈470 토큰. 게이트 OFF 면 종전(상시).
+        const agentTaskWanted = !CHAT_TOOL_INTENT_GATE_ENABLED
+            || AGENT_TASK_INTENT_PATTERNS.some((re) => re.test(reqCtx.message ?? ''));
+        const baseAlwaysOn = agentTaskWanted
+            ? CHAT_ALWAYS_ON_TOOL_NAMES
+            : CHAT_ALWAYS_ON_TOOL_NAMES.filter((n) => !n.startsWith('agent_task_'));
         const alwaysOnNames: string[] = MCP_PROGRESSIVE_DISCLOSURE_ENABLED
-            ? [...CHAT_ALWAYS_ON_TOOL_NAMES, ...MCP_META_TOOL_NAMES] : CHAT_ALWAYS_ON_TOOL_NAMES;
+            ? [...baseAlwaysOn, ...MCP_META_TOOL_NAMES] : baseAlwaysOn;
         const alwaysOn = allTools.filter(t =>
             alwaysOnNames.includes(t.function.name) && !merged.some(m => m.function.name === t.function.name));
         // merged ∪ alwaysOn ∪ userMcpAutoOn — 이름 기준 중복 제거.

--- a/apps/api/src/services/chat-service/__tests__/plan-spawn-intent.test.ts
+++ b/apps/api/src/services/chat-service/__tests__/plan-spawn-intent.test.ts
@@ -103,3 +103,37 @@ describe('buildExternalSystemPrompt — spawn 가이드 주입', () => {
         expect(build(false)).not.toContain('[병렬 위임]');
     });
 });
+
+describe('buildExternalToolPlan — spawn_agents 의도 게이팅 (프롬프트 다이어트 2026-09-05)', () => {
+    const base = {
+        allowedTools: [] as ToolDefinition[],
+        toolCalling: true,
+        wantsMap: false,
+        orchestration: { discussion: false, taskDelegate: false },
+    };
+    const names = (msg: string) => buildExternalToolPlan({ ...base, req: { message: msg } as ChatMessageRequest })
+        .tools.map((t) => t.function.name);
+
+    it('병렬 위임 의도 턴에만 spawn_agents 를 노출한다', () => {
+        // AGENT_SPAWN.ENABLED 가 꺼진 환경이면 양쪽 다 미노출 — 게이트 자체는 "의도 없으면 없다"로 고정
+        expect(names('안녕하세요')).not.toContain('spawn_agents');
+        const withIntent = names('세 가지 주제를 병렬로 조사해줘');
+        const { AGENT_SPAWN } = jest.requireActual('../../../config/runtime-limits');
+        if (AGENT_SPAWN.ENABLED) expect(withIntent).toContain('spawn_agents');
+    });
+});
+
+describe('AGENT_TASK_INTENT_PATTERNS', () => {
+    const { AGENT_TASK_INTENT_PATTERNS } = jest.requireActual('../../../config/runtime-limits');
+    it.each([
+        '아까 시킨 에이전트 작업 상태 어때?',
+        '작업 결과 보여줘',
+        'agent task 진행 확인',
+        'what is the status of the task?',
+    ])('작업 상태 질의 매칭: %s', (msg) => {
+        expect(matchesAny(AGENT_TASK_INTENT_PATTERNS, msg)).toBe(true);
+    });
+    it.each(['오늘 날씨 알려줘', 'TypeScript 제네릭 설명해줘', '작업복 추천해줘'])('일반 질의 미매칭: %s', (msg) => {
+        expect(matchesAny(AGENT_TASK_INTENT_PATTERNS, msg)).toBe(false);
+    });
+});

--- a/apps/api/src/services/chat-service/__tests__/tool-merger-cap.test.ts
+++ b/apps/api/src/services/chat-service/__tests__/tool-merger-cap.test.ts
@@ -89,3 +89,32 @@ describe('selectUserMcpAutoOn', () => {
         expect(picked.map(t => t.function.name)).toEqual(['a_0', 'a_2']);
     });
 });
+
+describe('selectUserMcpAutoOn — breadthSlots (프롬프트 다이어트 2026-09-05)', () => {
+    const groups = [
+        makeGroup('notebooklm', ['nb_a', 'nb_b', 'nb_c'], ['notebook']),
+        makeGroup('open-design', ['od_a', 'od_b'], ['artifact']),
+        makeGroup('tavily', ['tv_a'], ['tavily_search']),
+    ];
+    const all = groups.flatMap((g) => g.tools.map((n) => makeTool(n))) as unknown as Parameters<typeof selectUserMcpAutoOn>[0];
+
+    it('breadthSlots=0 이고 서버 언급이 없으면 아무것도 노출하지 않는다', () => {
+        const picked = selectUserMcpAutoOn(all, groups, {}, 20, 16000, '오늘 날씨 알려줘', 0);
+        expect(picked).toHaveLength(0);
+    });
+
+    it('breadthSlots=0 이어도 언급된 서버(depth)는 전부 노출한다', () => {
+        const picked = selectUserMcpAutoOn(all, groups, {}, 20, 16000, 'notebooklm 에서 찾아줘', 0);
+        expect(picked.map((t) => t.function.name)).toEqual(['nb_a', 'nb_b', 'nb_c']);
+    });
+
+    it('breadthSlots=N 이면 비참조 서버에 N개까지만 round-robin 한다', () => {
+        const picked = selectUserMcpAutoOn(all, groups, {}, 20, 16000, '아무 말', 2);
+        expect(picked.map((t) => t.function.name)).toEqual(['nb_a', 'od_a']);
+    });
+
+    it('breadthSlots 미지정은 종전 동작(cap 까지 round-robin)', () => {
+        const picked = selectUserMcpAutoOn(all, groups, {}, 20, 16000, '아무 말');
+        expect(picked).toHaveLength(6);
+    });
+});

--- a/apps/api/src/services/chat-service/external-tool-plan.ts
+++ b/apps/api/src/services/chat-service/external-tool-plan.ts
@@ -18,6 +18,7 @@ import {
     EXTERNAL_LLM_TOOL_BLACKLIST, ARTIFACT_REQUEST_SUPPRESSED_TOOLS, ARTIFACT_INTENT_PATTERNS,
     ROUTE_INTENT_PATTERNS, WEB_SEARCH_INTENT_PATTERNS, REPORT_PIPELINE, REPORT_INTENT_PATTERNS,
     CHAT_SUBAGENT, AGENT_SPAWN, ORCHESTRATION_DISPATCH, DISCUSSION_INTENT_PATTERNS, TASK_DELEGATE_INTENT_PATTERNS,
+    SPAWN_INTENT_PATTERNS, CHAT_TOOL_INTENT_GATE_ENABLED,
     PLAN_INTENT_PATTERNS,
 } from '../../config/runtime-limits';
 import { buildChatDelegateTool } from './chat-delegate';
@@ -93,7 +94,10 @@ export function buildExternalToolPlan(params: {
         tools.push(buildChatDelegateTool());
     }
     // 병렬 서브에이전트 fan-out(spawn_agents): 독립 하위 작업 N개 병렬 위임 — agent-spawn 공용 모듈.
-    if (AGENT_SPAWN.ENABLED && toolCalling) {
+    // spawn_agents 는 병렬 위임 의도(SPAWN_INTENT_PATTERNS) 턴에만 — 가이드 주입과 같은 게이트.
+    // 게이트 OFF(CHAT_TOOL_INTENT_GATE_ENABLED=false) 면 종전대로 상시 노출.
+    if (AGENT_SPAWN.ENABLED && toolCalling
+        && (!CHAT_TOOL_INTENT_GATE_ENABLED || SPAWN_INTENT_PATTERNS.some((re) => re.test(req.message ?? '')))) {
         tools.push(buildSpawnAgentsTool());
     }
     // 오케스트레이션 자동 배정(Stage 1): 의도 프리필터 매칭 턴에만 노출.

--- a/apps/api/src/services/chat-service/tool-merger.ts
+++ b/apps/api/src/services/chat-service/tool-merger.ts
@@ -50,6 +50,8 @@ export function selectUserMcpAutoOn(
     cap: number,
     schemaBudget: number,
     message = '',
+    /** 비참조 서버 round-robin 슬롯 상한 — 기본 cap(종전 동작). 0 이면 언급된 서버만 노출. */
+    breadthSlots: number = cap,
 ): ToolDefinition[] {
     const lookup = new Map(allTools.map(t => [t.function.name, t]));
     const groups = toolGroups
@@ -75,15 +77,18 @@ export function selectUserMcpAutoOn(
     const referenced = groups.filter(g => isServerReferenced(g, message));
     for (const g of referenced) for (const n of g.tools) add(n);
 
-    // 2. breadth: 남은 서버 round-robin (참조 서버는 이미 소진)
+    // 2. breadth: 남은 서버 round-robin (참조 서버는 이미 소진). breadthSlots 만큼만 —
+    //    0 이면 언급된 서버만 노출하고 나머지는 mcp_list_tools/mcp_call 로 on-demand.
     const rest = groups.filter(g => !referenced.includes(g));
     const maxLen = rest.reduce((m, g) => Math.max(m, g.tools.length), 0);
-    for (let round = 0; round < maxLen && picked.length < cap; round++) {
-        for (const g of rest) if (round < g.tools.length) add(g.tools[round]);
+    const breadthLimit = Math.min(cap, picked.length + Math.max(0, breadthSlots));
+    for (let round = 0; round < maxLen && picked.length < breadthLimit; round++) {
+        for (const g of rest) if (round < g.tools.length && picked.length < breadthLimit) add(g.tools[round]);
     }
 
     if (totalEligible > picked.length) {
-        const mode = referenced.length ? `의도 depth(${referenced.map(g => g.displayName).join(',')}) + round-robin` : 'round-robin';
+        const breadth = breadthSlots > 0 ? 'round-robin' : '비참조 서버 미노출(진행적 공개로 접근)';
+        const mode = referenced.length ? `의도 depth(${referenced.map(g => g.displayName).join(',')}) + ${breadth}` : breadth;
         const limit = budgetHit ? `스키마 budget(${Math.round(schemaBudget / 1000)}KB)` : `cap=${cap}`;
         logger.warn(
             `user MCP 자동 노출: ${totalEligible}개 중 ${picked.length}개(${Math.round(bytes / 1000)}KB) 노출 ` +


### PR DESCRIPTION
## 실측 (8/30~9/5 운영 로그 + dist 계측 + DGX vLLM metrics)
- 로컬 qwen3.8-27b **첫 턴 입력 17.2K 토큰**: 사용자 MCP 자동 노출 14개/16KB ≈ **4.3K**(의도 무관 round-robin) · 아티팩트 가이드 3.7K · 가드/지시 1.5K · agent_task·spawn 등 저빈도 도구 ≈ **0.8K** · 스킬 manifest 0.1K~**9.4K**(backend-developer 30.7K 자).
- 7일 도구 실호출: 채팅 81턴 중 41% — web_search 116·extract_webpage 41·context7 15·open-design 14. round-robin 으로 노출된 비참조 MCP 도구와 agent_task_*·spawn_agents 는 0~2회.
- TTFC 는 도구 개수 구간과 무관(7.6s p50)하고 **prefix cache 적중 여부**로 5s/19s 이분(vLLM hit 80.7%, block 1584 토큰, KV 587K). 다이어트는 miss 시 프리필량·캐시 점유 축소가 목표.

## 변경
1. **MCP 비참조 서버 미노출** — `CHAT_USER_MCP_BREADTH_SLOTS`(기본 0). 서버명/도구명 언급(depth)은 종전대로 전부 노출, 나머지는 `mcp_list_tools`/`mcp_call` 로 on-demand. 종전 복귀는 `CHAT_USER_MCP_TOOL_CAP` 과 같은 값.
2. **저빈도 도구 의도 게이팅** — `agent_task_list/get` 은 `AGENT_TASK_INTENT_PATTERNS`, `spawn_agents` 는 `SPAWN_INTENT_PATTERNS` 턴에만. `CHAT_TOOL_INTENT_GATE_ENABLED=false` 로 종전 복귀.
3. **스킬 주입 상한** — `SKILL_MANIFEST_INJECT_MAX_CHARS`(12000). priority 순 누적, 초과분 건너뛰고 로그. 첫 스킬은 항상.

기대: 일반 턴 17K → 약 12K(-30%), backend-developer 류는 -6K 추가. 배포 후 `호출 완료 (in=…)`·`[TTFC]` 로그로 전후 비교.

## 검증
- 신규 테스트 15건(tool-merger breadth 4·skill-inject-cap 3·spawn 게이트/agent_task 의도 8), agents+chat-service 63 suites 529 passed, tsc 0, lint 0, skill-manager 595줄.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SgTTLYHPXq1meVB4MqM3g