### PR TITLE
perf(skills): manifest 스킬 1개 주입 상한(8000자) — 큰 스킬이 system 스킬을 밀어내던 실측 정정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,7 @@ LLM_TIMEOUT=120000                              # HTTP 요청 타임아웃 (ms)
 # CHAT_USER_MCP_BREADTH_SLOTS=0        # 서버 언급 없는 턴에 비참조 MCP 서버를 round-robin 노출하는 슬롯 수 (0=언급된 서버만, 종전=CHAT_USER_MCP_TOOL_CAP)
 # CHAT_TOOL_INTENT_GATE_ENABLED=true   # agent_task_list/get·spawn_agents 를 의도 정규식 턴에만 노출 (false=종전 상시)
 # SKILL_MANIFEST_INJECT_MAX_CHARS=12000 # 에이전트 1턴 스킬 manifest 주입 합계 문자 상한 (첫 스킬은 항상 주입)
+# SKILL_MANIFEST_PER_SKILL_MAX_CHARS=8000 # 스킬 1개 주입 문자 상한 — 큰 스킬이 합계를 독점해 system 스킬을 밀어내지 않게 절단
 # LiteLLM 통합 게이트웨이로 inference 를 라우팅할 외부 provider id 콤마 목록.
 # 빈값/미설정 = 전부 direct 호출. provider별 롤백은 목록에서 제거 + 재시작.
 # ollama-local(사용자별 endpoint)·chatgpt(OAuth) 는 목록과 무관하게 direct 유지.

--- a/apps/api/src/agents/__tests__/skill-inject-cap.test.ts
+++ b/apps/api/src/agents/__tests__/skill-inject-cap.test.ts
@@ -10,6 +10,7 @@ import { SkillManager } from '../skill-manager';
 jest.mock('../../config/runtime-limits', () => ({
     ...jest.requireActual('../../config/runtime-limits'),
     SKILL_MANIFEST_INJECT_MAX_CHARS: 1000,
+    SKILL_MANIFEST_PER_SKILL_MAX_CHARS: 700,
 }));
 
 const row = (id: string, chars: number) => ({
@@ -40,10 +41,12 @@ describe('buildManifestPrompt — 주입 합계 상한', () => {
         expect(out!.prompt).not.toContain('ECC-C:');
     });
 
-    it('첫 스킬이 상한보다 커도 항상 주입한다', async () => {
-        rows = [row('huge', 5000), row('small', 10)];
+    it('큰 스킬은 개별 상한으로 절단돼 뒤의 system 스킬이 밀려나지 않는다', async () => {
+        rows = [row('huge', 5000), row('system-skill-backend', 100)];
         const out = await manager().buildManifestPrompt('backend-developer', undefined, 'technology');
-        expect(out!.skillNames).toEqual(['huge']);
+        expect(out!.skillNames).toEqual(['huge', 'system-skill-backend']);
+        expect(out!.prompt).toContain('... (truncated)');
+        expect(out!.prompt).toContain('SYSTEM-SKILL-BACKEND:');
     });
 
     it('합계가 상한 이내면 전부 주입한다', async () => {

--- a/apps/api/src/agents/skill-manager.ts
+++ b/apps/api/src/agents/skill-manager.ts
@@ -50,7 +50,7 @@ import { slugify } from '../chat/slash-command';
 import { recordSkillUsage } from './skill-usage-log';
 import { shouldInjectManifestSkill } from './manifest-injection-filter';
 import { SKILL_VERSION_LATEST_ORDER_SQL } from '../data/repositories/skill-manifest-sync';
-import { SKILL_MANIFEST_INJECT_MAX_CHARS } from '../config/runtime-limits';
+import { SKILL_MANIFEST_INJECT_MAX_CHARS, SKILL_MANIFEST_PER_SKILL_MAX_CHARS } from '../config/runtime-limits';
 
 const logger = createLogger('SkillManager');
 
@@ -487,9 +487,11 @@ export class SkillManager {
         const skipped: string[] = [];
         let injectedChars = 0;
         for (const r of filtered) {
-            if (injectedRows.length > 0 && injectedChars + r.prompt_md.length > SKILL_MANIFEST_INJECT_MAX_CHARS) { skipped.push(r.id); continue; }
-            injectedRows.push(r);
-            injectedChars += r.prompt_md.length;
+            const body = r.prompt_md.length > SKILL_MANIFEST_PER_SKILL_MAX_CHARS
+                ? r.prompt_md.slice(0, SKILL_MANIFEST_PER_SKILL_MAX_CHARS) + '\n... (truncated)' : r.prompt_md;
+            if (injectedRows.length > 0 && injectedChars + body.length > SKILL_MANIFEST_INJECT_MAX_CHARS) { skipped.push(r.id); continue; }
+            injectedRows.push({ ...r, prompt_md: body });
+            injectedChars += body.length;
         }
         if (skipped.length > 0) logger.info(`manifest 주입 상한(${SKILL_MANIFEST_INJECT_MAX_CHARS}자) — agent=${agentId} 주입 ${injectedRows.length}개(${injectedChars}자), 건너뜀: ${skipped.join(', ')}`);
         const blocks = injectedRows.map(r => {

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1298,6 +1298,16 @@ export const SKILL_MANIFEST_INJECT_MAX_CHARS = parseInt(
     10,
 );
 
+/**
+ * 스킬 manifest 1개의 주입 문자 상한. 합계 상한보다 큰 스킬 하나가 슬롯을 독점해 뒤의
+ * system 스킬(페르소나 규칙, ~2.5K 자)까지 밀어내는 것을 막는다 — 배포 첫 실측에서
+ * backend-developer 의 ecc 스킬 12,154자 하나가 들어가고 system-skill 이 건너뛰어졌다.
+ */
+export const SKILL_MANIFEST_PER_SKILL_MAX_CHARS = parseInt(
+    process.env.SKILL_MANIFEST_PER_SKILL_MAX_CHARS || '8000',
+    10,
+);
+
 /** agent_task_list / agent_task_get 노출 의도 — 에이전트 작업의 상태·결과·목록을 묻는 턴. */
 export const AGENT_TASK_INTENT_PATTERNS: readonly RegExp[] = [
     /(에이전트|agent)\s*(작업|task)/i,


### PR DESCRIPTION
#755 배포 직후 실측: backend-developer 턴에서 `manifest 주입 상한(12000자) — 주입 1개(12154자), 건너뜀: …, system-skill-backend-developer`. ecc 스킬 하나가 합계를 독점해 페르소나 규칙(system 스킬 2.4K자)이 빠졌다.

- `SKILL_MANIFEST_PER_SKILL_MAX_CHARS`(기본 8000) 로 스킬 1개를 절단(`... (truncated)`)한 뒤 합계(12000)에 누적 → 8000 + 2400 으로 system 스킬이 남는다.
- 테스트: skill-inject-cap 갱신(절단 + system 스킬 잔존), skill-* 14 passed, tsc 0, skill-manager 597줄.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SgTTLYHPXq1meVB4MqM3g