### PR TITLE
perf(skills): system 스킬을 먼저 주입해 합계 상한에 밀려나지 않게

### DIFF
--- a/apps/api/src/agents/__tests__/skill-inject-cap.test.ts
+++ b/apps/api/src/agents/__tests__/skill-inject-cap.test.ts
@@ -35,7 +35,7 @@ describe('buildManifestPrompt — 주입 합계 상한', () => {
         rows = [row('ecc-a', 600), row('ecc-b', 300), row('ecc-c', 300), row('sys', 50)];
         const out = await manager().buildManifestPrompt('backend-developer', undefined, 'technology');
         expect(out).not.toBeNull();
-        // a(600)+b(300)=900 ≤ 1000, c 는 1200 초과로 건너뜀, sys(50) 는 950 이라 담김
+        // a(600)+b(300)=900 ≤ 1000, c 는 1200 초과로 건너뜀, sys(50) 는 950 이라 담김 (system 이 아닌 'sys' 는 priority 순)
         expect(out!.skillNames).toEqual(['ecc-a', 'ecc-b', 'sys']);
         expect(out!.prompt).toContain('ECC-A:');
         expect(out!.prompt).not.toContain('ECC-C:');
@@ -44,9 +44,15 @@ describe('buildManifestPrompt — 주입 합계 상한', () => {
     it('큰 스킬은 개별 상한으로 절단돼 뒤의 system 스킬이 밀려나지 않는다', async () => {
         rows = [row('huge', 5000), row('system-skill-backend', 100)];
         const out = await manager().buildManifestPrompt('backend-developer', undefined, 'technology');
-        expect(out!.skillNames).toEqual(['huge', 'system-skill-backend']);
+        expect(out!.skillNames).toEqual(['system-skill-backend', 'huge']);
         expect(out!.prompt).toContain('... (truncated)');
         expect(out!.prompt).toContain('SYSTEM-SKILL-BACKEND:');
+    });
+
+    it('system 스킬은 priority 가 낮아도 먼저 담겨 상한에 밀려나지 않는다', async () => {
+        rows = [row('ecc-a', 600), row('ecc-b', 350), row('system-skill-backend', 100)];
+        const out = await manager().buildManifestPrompt('backend-developer', undefined, 'technology');
+        expect(out!.skillNames).toEqual(['system-skill-backend', 'ecc-a']);
     });
 
     it('합계가 상한 이내면 전부 주입한다', async () => {

--- a/apps/api/src/agents/skill-manager.ts
+++ b/apps/api/src/agents/skill-manager.ts
@@ -486,7 +486,9 @@ export class SkillManager {
         const injectedRows: typeof filtered = [];
         const skipped: string[] = [];
         let injectedChars = 0;
-        for (const r of filtered) {
+        // system 스킬(페르소나 규칙, 작음)을 먼저 담아 상한에 밀려나지 않게 한다 — 나머지는 priority 순 유지.
+        const ordered = [...filtered].sort((a, b) => Number(b.id.startsWith('system-skill-')) - Number(a.id.startsWith('system-skill-')));
+        for (const r of ordered) {
             const body = r.prompt_md.length > SKILL_MANIFEST_PER_SKILL_MAX_CHARS
                 ? r.prompt_md.slice(0, SKILL_MANIFEST_PER_SKILL_MAX_CHARS) + '\n... (truncated)' : r.prompt_md;
             if (injectedRows.length > 0 && injectedChars + body.length > SKILL_MANIFEST_INJECT_MAX_CHARS) { skipped.push(r.id); continue; }


### PR DESCRIPTION
#757 배포 후 실측: `manifest 주입 상한(12000자) — agent=backend-developer 주입 2개(11626자), 건너뜀: …, system-skill-backend-developer`. system 스킬은 priority 가 가장 낮아 마지막 순번이라 상한에 밀렸다.

- 주입 순서를 `system-skill-*` 우선(안정 정렬, 나머지는 priority 순 유지)으로 변경.
- 테스트: skill-inject-cap 에 회귀 케이스 추가, skill-* 18 passed, tsc·lint 0, skill-manager 599줄.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SgTTLYHPXq1meVB4MqM3g