### PR TITLE
docs: README 를 한국어·일본어·중국어 완역본과 함께 현행화

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -437,6 +437,15 @@ CI はすべての push と pull request で単一の **CI Gate**(Test → Build
 
 ---
 
+## お問い合わせ
+
+| | |
+|---|---|
+| 一般のお問い合わせ・セルフホスティング支援 | support@openmake.cc |
+| メンテナー | riskpw@openmake.cc · rockyhan@openmake.cc |
+
+---
+
 ## ライセンス
 
 **MIT ライセンス** の下でリリースされています — 詳細は [LICENSE](LICENSE) を参照してください。

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,442 @@
+<h1 align="center">OpenMake LLM</h1>
+
+<p align="center">
+  <strong>オープンウェイトモデルと BYOK モデルのための、オープンソース・ローカルファースト・セルフホスト型 AI ワークスペース。</strong><br/>
+  vLLM/LiteLLM 推論 · 自律型 AI エージェント · MCP ツール · ディープリサーチ · Docker サンドボックス。
+</p>
+
+<p align="center">
+  <a href="https://github.com/openmake/openmake_llm/actions/workflows/ci.yml"><img src="https://github.com/openmake/openmake_llm/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
+  <img src="https://img.shields.io/github/package-json/v/openmake/openmake_llm?label=version&color=green" alt="Version" />
+  <img src="https://img.shields.io/badge/node-%3E%3D24%20%3C25-brightgreen.svg" alt="Node >=24 <25" />
+  <img src="https://img.shields.io/badge/TypeScript-strict-3178c6.svg" alt="TypeScript strict" />
+  <img src="https://img.shields.io/badge/Next.js-16-black.svg" alt="Next.js 16" />
+</p>
+
+<p align="center">
+  <a href="https://openmake.cc/ja/">ホームページ</a> ·
+  <a href="https://chat.openmake.cc">ライブデモ</a> ·
+  <a href="https://bench.openmake.cc">Bench</a> ·
+  <a href="https://openmake.cc/ja/docs/">セルフホスティングガイド</a><br/>
+  <a href="README.md">English</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <strong>日本語</strong> ·
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+---
+
+> 本書は英語版 [README.md](README.md) の日本語訳です。内容が異なる場合は英語版とコードを正とします。
+
+## 概要
+
+**OpenMake LLM** は、自分のハードウェア上で動かすセルフホスト型 AI アシスタントです。ローカルモデルを **vLLM** で提供し、その前段に **LiteLLM プロキシ**(OpenAI 互換)を置きます。そして *同じ* 抽象化のまま、自分のキーで登録した外部プロバイダー(**OpenRouter、NVIDIA NIM、Ollama** のローカル/クラウド。いずれも OpenAI 互換で、Anthropic アダプターも組み込み済み)へルーティングします。これにより、データはデフォルトで自分のマシンに留まります。
+
+すべてのリクエストは軽量な **メッセージパイプライン** を通り、プロバイダーゲート、セキュリティおよび言語ポリシー、プロンプト/ツールの組み立てを、追加の LLM ルーティング往復 *なしで* 適用します。その後、ローカルモデルと外部モデルは同じ実行パスと常時オンのツールループを共有します。現在の **`ExecutionPlanBuilder`** は意図的に狭く設計されており、選択されたときに認可済みのカスタムエージェントを読み込むだけです。挙動は不透明なプリセットではなく、直交する軸だけで制御します。すなわち **モデル · スタイル · モードトグル · カスタムエージェント** です。パワーユーザーはさらに **ロールベースのモデルオーケストレーション** に踏み込めます。各機能ロール(エージェント、ジャッジ、リサーチ、並列サブエージェント、レビュー、思考サマリー)ごとに、異なるモデル(ローカルまたは外部)を割り当てられます。チャットにとどまらず、自律型エージェント、ディープリサーチのパイプライン、MCP ツールシステムを備え、いずれも JWT 認証とロールベースのアクセス制御の背後で動作します。
+
+> **シングルホスト設計:** アプリケーション(API + Web)は **PM2** の下で動作し、ステートフルな依存関係(PostgreSQL / Redis)とサンドボックス化されたエージェント / MCP / アーティファクトのプロセスは、隔離のため **Docker** で動作します。
+
+**ひと目でわかる特徴**
+
+| | |
+|---|---|
+| 🧠 **1 つのローカルモデルを、リクエストごとにルーティング** | `qwen3.8-27b` を vLLM + LiteLLM で提供。262K のコンテキスト適合セーフティネット付き |
+| 🎛️ **ロールベースのモデルオーケストレーション** | 機能ロールごとに異なるモデル(ローカルまたは BYOK 外部)を割り当て。ユーザーごと + 管理者グローバルのマッピング、トークン予算付きのサーバー共有キー |
+| 🤖 **自律型エージェント** | 永続的な Docker サンドボックス(シェル · Python · ブラウザ · ファイル)内で動く Manus スタイルのマルチターンエージェント。ヒューマン・イン・ザ・ループの承認付き |
+| 🔬 **ディープリサーチ** | ファンアウト型のウェブ検索 → ソース取得 → 主張の検証 → 出典付きの統合 |
+| 📊 **レポートパイプライン** | レポート意図のクエリでは、モデルが生成したデータを固定のデザインテンプレートを通して HTML アーティファクトにレンダリング。**PDF/DOCX** へエクスポート可能 |
+| 📓 **NotebookLM グラウンディング** | 自分の Google NotebookLM ノートブックの 1 つを会話コンテキストとしてピン留め。コンポーザーから直接操作 |
+| 🧩 **22 個の組み込み MCP ツール** + 外部 MCP サーバー | 各外部サーバーは Docker 内で隔離(`--cap-drop ALL`、非 root、ネットワークポリシー) |
+| 👤 **カスタムエージェントとスキル** | プロジェクトスコープのペルソナ(エージェントごとにモデルを任意指定可)+ 自動選択可能なスキルライブラリ + 18 の業種別エージェント(100 名のスペシャリスト) |
+| 💬 **Discord ゲートウェイボット** | Discord メッセージを OpenAI 互換 API へ中継する任意のワークスペース。ロール/メンションによるアクセス制御付き |
+| 🖥️ **ネイティブクライアント** | ローカルフォルダーでのエージェント作業向けの **OpenMake Companion**(SwiftUI メニューバーアプリ、macOS Apple Silicon)、**OpenMake Code** CLI(ローカルブリッジ)、開発中の SwiftUI iOS クライアント。チャット本体は Web アプリに残ります |
+| 📊 **OpenMake Bench** | [bench.openmake.cc](https://bench.openmake.cc):ブラインドのペアワイズモデル比較とハードウェア適合スコア。Web SSO クライアント経由でサインイン。ここで選んだモデルは自分のモデルロールに適用されます |
+| 🌐 **4 言語 UI** | 한국어 · English · 日本語 · 简体中文(`next-intl`、Cookie ロケール、ブラウザー自動判定) |
+| 🔒 **セキュリティファースト** | JWT(HttpOnly)、Google OAuth 2.0、RBAC、ルートごとのレート制限、SSRF ガード、監査 ↔ アラート |
+
+---
+
+## スクリーンショット
+
+> 会話タイトル、ノートブック名、アカウントのメールアドレスはぼかしています。それ以外はすべて実際に動作しているアプリです。
+
+**チャットワークスペース** — 5 項目のワークスペースナビ、モデルセレクター、応答スタイル、スラッシュで呼び出すスキル:
+
+<p align="center">
+  <img src="assets/screenshot-chat.png" alt="Chat workspace" width="920" />
+</p>
+
+| モードメニュー — Discussion / Thinking / Deep Research / Web / Agent / Image / Artifact / Structured | NotebookLM ピッカー — ノートブックを会話コンテキストとしてピン留め |
+|---|---|
+| ![Composer mode menu](assets/screenshot-composer-modes.png) | ![NotebookLM notebook picker](assets/screenshot-notebook-picker.png) |
+
+**エージェントタスク** — ライブ進捗、トークン集計、繰り返しスケジュール、再利用可能なタスクテンプレートを備えた自律型マルチターン実行:
+
+<p align="center">
+  <img src="assets/screenshot-agent-tasks.png" alt="Agent task management" width="920" />
+</p>
+
+| コネクター — 外部 MCP サーバー、それぞれ Docker で隔離 | モデルロール管理 — グローバルなロール→モデルのマッピング |
+|---|---|
+| ![Settings → Connectors](assets/screenshot-settings.png) | ![Model roles admin](assets/screenshot-model-roles.png) |
+
+**スキルライブラリ** — ツールバインディングを備えた再利用可能なマニフェスト。Git からインポート、またはモデルによる生成:
+
+<p align="center">
+  <img src="assets/screenshot-skill-library.png" alt="Skill Library" width="920" />
+</p>
+
+**多言語 UI(한국어 · English · 日本語 · 简体中文)** — インターフェース言語は設定で切り替えるか、ブラウザー(`Accept-Language`)に追従させられます。AI の応答言語は、それとは独立してメッセージの言語に追従します:
+
+<p align="center">
+  <img src="assets/i18n-demo.gif" alt="Interface language switching demo (ko / en / ja / zh)" width="920" />
+</p>
+
+---
+
+## アーキテクチャ
+
+OpenMake は **ポリシー**(*どう* 答えるかを決める)と **実行**(実際にモデルを呼び出す)を分離します。SQL のプランナー/エグゼキューター分割になぞらえた設計です。この 2 層は意図的に独立して保たれています。
+
+```
+                          WebSocket / REST
+                                  │
+                    ┌─────────────▼─────────────┐
+  Query ───────────►│      message-pipeline     │  request processing
+                    │                           │  · provider gate
+                    └─────────────┬─────────────┘  · security & language policy
+                                  │                · prompt & tool assembly
+                                  │                · authorized custom-agent load
+                    ┌─────────────▼─────────────┐
+                    │ streamFromExternalProvider│  single path — local & external alike
+                    │   (always-on tool loop)   │  · 5 tool turns max
+                    └─────────────┬─────────────┘  · special modes intercept earlier
+                                  │
+                    ┌─────────────▼─────────────┐
+                    │       LLMClient.chat      │  execution — per call
+                    │  (context-fit safety net) │  · token estimate → truncate → cap
+                    └─────────────┬─────────────┘  · overflow → 413 + audit + alert
+                                  │
+           vLLM serve → LiteLLM proxy (OpenAI-compatible endpoint)
+```
+
+- **単一の実行パス** — かつての戦略ごとの層(generate-verify、agent-loop、thinking、direct)は廃止されました。`message-pipeline` は、常時オンの MCP ツールループを備えた単一の `streamFromExternalProvider` ディスパッチを通じて、ローカルモデルと外部モデルを送出します。`ExecutionPlanBuilder` は現在、認可済みのカスタムエージェントを読み込むだけです。Discussion と Deep Research は、ディスパッチ前にインターセプトされる独立したモードとして残っています。
+- **コンテキスト適合セーフティネット** — 入口で、プロンプトのトークン数(画像を含む)を推定します。実効的な **262K** のウィンドウを超える場合、入力を切り詰め → `max_tokens` を削減 → 極端な場合は `ContextOverflowError` が **HTTP 413** を返し、監査レコードと自動的な Webhook アラートを伴います。
+- **ユーザーカスタマイズ(4 つの直交する軸)** — **モデル**(セレクター)· **スタイル**(Concise / Default / Verbose)· **モード**(Discussion / Thinking / Deep Research / Web / Agent Task)· **カスタムインストラクションとエージェント**。システムプロンプトの組み立て順序は `memory + custom-instructions + style` です。
+- **ロールベースのモデルオーケストレーション** — LLM を呼び出すすべてのサブシステムは、フェイルオープンのフォールバックチェーンを持つ単一のロールレジストリを通じてモデルを解決します。ユーザーごとのマッピング → 管理者が設定したグローバル(DB)→ グローバル env → ローカルデフォルト、の順です。ロールごとの外部モデルは、ユーザーの BYOK キー、またはグローバルロール向けのサーバー共有オペレーターキー(日次/月次のトークン予算付き)で動作します。カスタムエージェントも独自のモデルをピン留めできます。
+- **会話をまたぐメモリー** — 明示的な長期メモリーがシステムプロンプトに注入されます。プライバシートグルにより、ユーザーはセッションごとにそれらを除外できます。
+- **思考表示(Claude Web スタイル)** — Thinking モードがオンのとき、推論ストリームはライブのタイムラインとしてレンダリングされます。専用の `summary` ロールのモデルが 1 行の見出し(暫定をストリーミング → 最終)を生成し、推論と見出しの両方が永続化されるため、会話を再度開くとタイムラインが復元されます。
+
+---
+
+## 機能
+
+**▸ モデルとルーティング**
+- ローカルモデルと外部モデルは、プロバイダーゲート付きの `message-pipeline` とツールループを共有します。挙動は直交する軸(モデル · スタイル · モード · カスタムエージェント)で制御されます。
+- セルフホストの vLLM + LiteLLM(デフォルトは `qwen3.8-27b`)。出力トークンを保護し、オーバーフロー時に緩やかに劣化するコンテキスト適合セーフティネット付き。
+- 外部キーの持ち込み(BYOK)— **OpenRouter、NVIDIA NIM、Ollama**(ローカル + クラウド)。いずれも OpenAI 互換(Anthropic アダプターはプロバイダー抽象化に組み込み済み)で、保存時に AES-256-GCM で暗号化されます。**ゲストはデフォルトのローカルモデルのみ利用可能** で、外部プロバイダーにはサインインが必要です。
+- **ロールベースのモデルオーケストレーション** — 各機能ロール(`agent`、`judge`、`research`、`spawn`、`review`、`summary`)に異なるモデル(ローカルまたは BYOK 外部)を設定から割り当てられます。管理者は組織全体のデフォルトを設定し、キーごとのトークン予算付きでサーバー共有の外部キーを管理コンソールで登録します。解決はフェイルオープンです(いかなる失敗でもローカルデフォルトにフォールバックします)。モデル一覧は、実際に到達可能でロール対応のものだけに絞り込まれます。
+- **外部プロバイダーのスロットリング** — プロバイダーごとの同時実行数制限と、429 時の指数バックオフ(`Retry-After` を尊重)により、Discussion や Deep Research のファンアウトのバーストで BYOK キーがレート制限されるのを防ぎます。UI の推論エフォート設定(low / medium / high)は、OpenAI 互換の外部プロバイダーへ `reasoning_effort` として転送されます。ローカルモデルには思考の ON/OFF 用のサンプリングプリセットが適用されます。
+- **テールルーティング(オプトイン、デフォルトはオフ)** — 軽量なゲートが各クエリの誤答可能性をスコアリングします。クエリを *事実的テール*(誤って答えられやすく、外部から検証可能)と判断したとき、最初のターンで `web_search` を決定論的に強制します。挙動を変えずにゲートの判断を記録するシャドウモード(`TAIL_ROUTING_SHADOW_ENABLED`)を同梱しており、`TAIL_ROUTING_STAGE2B_ENABLED` をオンにする前に、実トラフィックでしきい値を調整できます。
+
+**▸ エージェントとリサーチ**
+- **自律型エージェントタスク** — Manus スタイルのエージェントが、**永続的な Docker サンドボックス**(シェル、Python、ブラウザ、ファイル、プランニングのツール)の中で、複数のツール呼び出しターンをまたいでゴールを追求します。ヒューマン・イン・ザ・ループの承認付きです。ファイル添付を記録し、ビジョンチャネル経由で画像を注入し、**Excel(.xlsx)** や **PDF**(韓国語/CJK フォント対応)を含む成果物を生成します。そして、偽って「完了」とマークするのではなく、未達成を正直に報告します(`[GOAL_INCOMPLETE]` マーカー + ゴールジャッジ)。タスクは **再利用可能なテンプレート** として保存したり、**繰り返しスケジュール** に載せたりできます。
+- **ディープリサーチ** — ファンアウト型のウェブ検索 → ソース取得 → 主張の検証 → 出典付きの統合。
+- **レポートパイプライン** — レポート意図のクエリ(「X を調査してレポートを書いて」)では、モデルは **データ(JSON)のみ** を生成し、サーバーが固定のデザインテンプレートを通してそれを HTML アーティファクトにレンダリングします(*デザインはレンダラーが所有* — 一貫した編集レイアウト、KPI タイル、テーブル、依存関係なしの SVG チャート、出典付きソース。モデルの文字列はすべてエスケープ)。自己完結型のリサーチ形式のレポート要求は、より多くのリサーチターンのために自動でエージェントタスクへ委譲され、同じコントラクトがエージェントタスクの成果物にも適用されます。失敗はフェイルオープンで、有効なデータブロックがなければ、応答は通常のチャットとしてストリーミングされます。
+- **カスタムエージェントとスキル** — プロジェクトスコープのエージェント(claude.ai の Projects 相当)をコンポーザーから直接選択でき、それぞれ独自のモデルを任意でピン留めできます。加えて、自動選択可能なスキルライブラリと、18 個の組み込み業種別エージェント(100 名のスペシャリスト)を備えます。
+
+**▸ ツールと拡張性**
+- **MCP ツールシステム** — 22 個の組み込みツール(ウェブ検索、ファクトチェック、ウェブのスクレイプ/マップ/クロール、画像解析、エージェントタスク制御、スキル/エージェント/MCP の git 取り込み、など)に加え、外部 MCP サーバーを備えます。各サーバーは Docker 内で隔離されます(`--cap-drop ALL`、非 root、`--memory`+`--memory-swap`、ネットワークポリシー、realpath でガードされたマウント)。**設定 → コネクター** の MCP カタログからサーバーをインストールできます(Tavily、Sentry、Context7 などを初期登録済み。`{{env.KEY}}` のシークレットはシェル変数参照として渡され、argv に焼き込まれることはありません)。カタログレベルの **ツール許可リスト** により、チャットへの自動公開が絞られます(39 ツールのサーバーが 39 個のスキーマをすべてのプロンプトに投入する必要はありません)。一方で、REST 実行と明示的なツールピッカーはフルアクセスを維持します。
+- **NotebookLM グラウンディング** — 自分の Google セッション Cookie(AES-256-GCM で暗号化され、スポーン時のみ注入)で NotebookLM コネクターをインストールし、コンポーザーからノートブックをピン留めします。グラウンディングのプレフィックスは LLM 専用チャネルに乗るため、保存されるメッセージやサイドバーのタイトルはクリーンに保たれ、ピンは 1 つの会話にスコープされます。
+- **アーティファクト** — ライブのサンドボックス化された iframe レンダリング、任意の Docker コード実行(Python / JS)、リサイズ可能なサイドパネル、そして公開用の別オリジンで厳格な CSP を持つ共有ビューアー。OpenAI 互換 API はアーティファクトを `message.artifacts` 拡張として返し、`publish_artifacts: true` により、サーバーは自力で公開できない API キークライアントのために共有リンクを発行します。
+- **PDF / DOCX エクスポート** — 任意の HTML アーティファクト(チャットまたはエージェントタスクの成果物)は、ヘッドレス Chromium の印刷経由で **PDF** にエクスポートできます(CJK フォント込み)。レポートアーティファクトは構造化されたソースデータ(`artifacts.source_data`)を保持し、`python-docx` による高忠実度の **DOCX** 生成を可能にします。どちらの変換も、オーナースコープのレート制限付きエンドポイントの背後で、Docker サンドボックス(`--network none`、`--cap-drop ALL`、メモリー/pids の上限)内でワンショット実行されます。
+- **メモリーとインストラクション** — 永続的な会話をまたぐメモリー(セッションごとの利用トグル付き)と、常時オンのカスタムインストラクション。
+- **思考表示** — Claude Web スタイルの推論タイムライン。ライブの 1 行見出し(専用のサマリーモデルが生成)付きで、永続化され、再オープン時に復元されます。
+- **多言語 UI** — 韓国語、英語、日本語、簡体字中国語を `next-intl` で対応(Cookie ベースのロケール、ブラウザー自動判定、ロケール対応の日付/数値フォーマット)。
+
+**▸ 統合**
+- **Discord ゲートウェイボット**(`apps/discord-bot`)— Discord メッセージを `/api/v1/chat/completions` へ中継する任意のスタンドアロンワークスペース。ユーザーごとのセッション分離(`/reset`)、ロール/メンションによるアクセス制御、API キー認証を備えます。生成された画像やアーティファクトは実際の Discord ファイル添付(共有リンク付き)として返ります。Discord は API の相対パスやプレースホルダーをレンダリングできないためです。自身の PM2 プロセスとして動作します。
+- **OpenMake Bench** — [bench.openmake.cc](https://bench.openmake.cc) は API の Web SSO クライアント経由でサインインし、ライブ更新される `/v1/models` 一覧を読み取ります。OpenAI 互換 API は、ベンチマーククライアント向けの raw モードも提供します。
+- **ネイティブクライアント** — `apps/desktop-native`(OpenMake Companion、SwiftUI メニューバー:フォルダーリンク、デバイスステータス、実行承認、タスク完了通知、Web ディープリンク)、`apps/cli`(OpenMake Code。サーバーサンドボックスの代わりに自分のマシンでエージェントのツール呼び出しを実行するローカルブリッジ)、`apps/ios`(SwiftUI クライアント、開発中)。3 つとも、Web アプリと Instrument デザイントークンを共有します。
+- **NotebookLM** — `GET /api/mcp/notebooklm/notebooks` がコンポーザーのピッカーを支えます(ユーザーごとのキャッシュ。上流の失敗は `502 NOTEBOOKLM_UPSTREAM` に収束するため、Google Cookie が期限切れになったとき UI が再接続を促せます)。
+
+**▸ セキュリティ**
+- HttpOnly Cookie 内の JWT、Google OAuth 2.0、RBAC、ユーザーごと・ルートごとのレート制限、SSRF ガード、Helmet ヘッダー、そして統合された監査 ↔ アラートのパイプライン。
+
+---
+
+## 技術スタック
+
+| レイヤー | 技術 |
+|---|---|
+| **バックエンド** | Node.js(≥24)、Express 5、TypeScript(strict、CommonJS)、Zod、Winston |
+| **フロントエンド** | Next.js 16、React 19、Zustand 5、Tailwind CSS 4、`next-intl`;Instrument デザインシステム(コバルトプライマリ · シアンセカンダリ、IBM Plex Mono) |
+| **データベース** | `pg` 経由の PostgreSQL — 生のパラメータ化 SQL(ORM なし) |
+| **リアルタイム** | ストリーム切断/再開に対応した WebSocket(`ws`)ストリーミングチャット — バックグラウンドのタブやアプリが応答を失わずに再接続 |
+| **LLM バックエンド** | vLLM + LiteLLM(OpenAI 互換);外部プロバイダー向けに `@anthropic-ai/sdk`、`openai` |
+| **エージェント / ツール** | Model Context Protocol(`@modelcontextprotocol/sdk`)、Docker で隔離されたサンドボックス |
+| **統合** | Discord ゲートウェイボット(`discord.js`)— 任意のスタンドアロンワークスペース;Web SSO 経由の OpenMake Bench |
+| **ネイティブクライアント** | SwiftUI(macOS Companion、iOS)、`packages/local-bridge-core` を共有する Node CLI(`apps/cli`) |
+| **認証 / セキュリティ** | `jsonwebtoken`、Google OAuth 2.0、Helmet、AES-256-GCM |
+| **インフラ** | PM2(API · web · Discord ボット)+ Docker(PostgreSQL/Redis、MCP / エージェント / アーティファクトのサンドボックス) |
+| **テスト / CI** | Jest/ts-jest、Playwright、ESLint、GitHub Actions(CI Gate) |
+
+---
+
+## はじめに
+
+対応プラットフォーム:**Linux** と **macOS**(Intel & Apple Silicon)。
+
+### インストール(1 コマンド)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/openmake/openmake_llm/main/install.sh | bash
+```
+
+クローンは不要です。インストーラーはリポジトリ外で実行されていることを検出すると、
+ソースを `~/openmake_llm` に取得し(`OMK_HOME=...` で上書き、`OMK_REF=...` でブランチや
+タグを選択)、そこで自身を再実行します。パイプ実行でも `/dev/tty` 経由で対話的に
+プロンプトが表示されます。非ターミナルのコンテキスト(CI)ではプロンプトは自動承認されます。
+従来の方法がお好みですか。これまでどおり動作します:
+
+```bash
+git clone https://github.com/openmake/openmake_llm.git
+cd openmake_llm
+./install.sh
+```
+
+**Windows** では、同じワンライナーを **WSL2**(Ubuntu)の中で実行してください。インストーラーは
+ネイティブの Windows シェルを検出し、代わりに WSL2 のセットアップ手順を表示します。
+
+これで完了です。インストーラーはツールチェーン(Node 24、Docker、PM2 — 不足分は可能な限り
+`sudo` なしでインストール)をチェックし、新しくランダムなシークレットを含む `.env` を生成し、
+依存関係をインストールし、PostgreSQL + Redis を起動し、すべてのマイグレーションを適用し、両アプリを
+ビルドし、PM2 の下で起動し、`/health` を待ちます。最後に Web URL と生成された管理者パスワードを
+表示します。
+
+質問は 1 つだけ — どの OpenAI 互換 LLM エンドポイントを使うか(Ollama / OpenRouter /
+カスタム / 後で決める)です。すべてのプロンプトをスキップするには:
+
+```bash
+# フラグはワンライナーにもそのまま渡せます:
+curl -fsSL https://raw.githubusercontent.com/openmake/openmake_llm/main/install.sh | bash -s -- --yes
+
+./install.sh --yes                                    # プレースホルダー LLM、あとで .env を埋める
+./install.sh --yes \
+  --llm-base-url https://openrouter.ai/api/v1 \
+  --llm-api-key  sk-or-... \
+  --llm-model    qwen/qwen3-235b-a22b
+```
+
+`./install.sh` の再実行は安全です — 上書きではなく修復を行います。便利なフラグ:
+`--skip-docker`(Postgres/Redis を自分で動かす)、`--skip-build`、`--no-start`、
+`--force-env`、および下記のポート上書き。詳しくは `./install.sh --help` を参照してください。
+
+すでに Postgres や Redis をデフォルトポートで動かしていますか。5432/6379 を奪い合うのではなく、
+コンテナ側を移動してください — ポートは `.env` に書き込まれ、`openmake_llm.sh` がそれを読み戻します:
+
+```bash
+./install.sh --yes --postgres-port 55432 --redis-port 56379
+```
+
+macOS では、インストーラーは Docker Desktop、OrbStack、または **Colima**
+(`brew install colima docker docker-compose` — ヘッドレス、GUI なし)で動作します。Homebrew の
+compose プラグインが docker CLI に登録されていない場合、インストーラーが `~/.docker/config.json`
+に `cliPluginsExtraDirs` を追加してくれます。
+
+### インストール済みインスタンスの更新
+
+```bash
+./openmake_llm.sh update            # git pull (ff-only) → build → migrate → restart
+./openmake_llm.sh update --yes      # マイグレーション確認をスキップ(非対話)
+```
+
+`update` は、コミットされていない変更や乖離したローカルコミットがあるツリーには触れることを
+拒否します — あなたの編集を上書きすることはありません。新しく pull するものがなければ、
+再デプロイをスキップします(それでも再デプロイするには `--force`)。tarball インストール
+(git なし)は代わりに `install.sh` を再実行してください。これはその場で修復します。
+
+インストールを `main` ではなくリリースに固定するには、ワンライナーで `OMK_REF` を設定します:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/openmake/openmake_llm/main/install.sh \
+  | OMK_REF=v1.31.1 bash -s -- --yes
+```
+
+### 前提条件(インストーラーが処理)
+
+- **git** — まっさらな macOS では、最初の `git clone` が Xcode Command Line Tools の
+  インストールダイアログをトリガーします。一度だけ承認してください(あるいはソースを zip として
+  ダウンロードします)。`install.sh` 自体は git の欠如を許容します(ビルドメタデータは
+  `unknown` にフォールバックします)
+- **Node.js** `>=24 <25` — `mise`/`fnm`/`nvm`、Homebrew、またはそれらがなければローカルの
+  `~/.openmake/node` tarball 経由でプロビジョニングされます
+- **Docker** — PostgreSQL/Redis と MCP/エージェントのサンドボックスに必要です。Linux では
+  インストーラーが公式の `get.docker.com` スクリプトの実行を提案します。macOS では
+  Docker Desktop または OrbStack が必要です。注意:Docker Desktop の **初回起動** は GUI の
+  承認(特権ヘルパー)を求めることがあり、インストーラーの約 60 秒のデーモン待機を超える場合が
+  あります。その場合は Docker の起動完了を待ってから `./install.sh` を再実行してください
+  (繰り返し実行は安全です)
+- OpenAI 互換の LLM エンドポイント:ローカルの **vLLM + LiteLLM** スタック、**Ollama**、
+  または外部プロバイダーのキー
+
+### 手動セットアップ
+
+自分で組み立てたい場合、`install.sh` は次の手順を読める形で記述したものです:
+
+```bash
+npm install
+node scripts/setup/gen-env.mjs        # 生成されたシークレット付きの最小 .env
+docker compose --env-file .env -f infra/docker-compose.yml up -d postgres redis
+npx ts-node apps/api/src/data/migrations/cli.ts migrate
+npm run build && pm2 start ecosystem.config.js
+```
+
+> `--env-file .env` は省略できません:Compose はデフォルトの `.env` を compose ファイルの
+> ディレクトリ(`infra/`)を基準に解決するため、これがないと `POSTGRES_PASSWORD` が空になり
+> 起動が失敗します。
+
+`gen-env.mjs` は起動に必要なキーだけを書き込みます。`.env.example` が完全なリファレンスです —
+必要に応じて、そこから任意ブロック(OAuth、ウェブ検索、MCP サンドボックス、Discord ボット)を
+コピーしてください:
+
+| 変数 | 用途 |
+|---|---|
+| `PORT` | API ポート(デフォルト `52416`) |
+| `DATABASE_URL` | PostgreSQL 接続文字列(パスワードは `POSTGRES_PASSWORD` と一致する必要があります) |
+| `JWT_SECRET` | JWT 署名シークレット(≥32 文字) |
+| `API_KEY_PEPPER` | API キーのハッシュ用ペッパー — 本番で必須 |
+| `TOKEN_ENCRYPTION_KEY` | 外部プロバイダー資格情報の AES-256-GCM キー(正確に 64 桁の 16 進) |
+| `ADMIN_PASSWORD` | ブートストラップ管理者アカウントのパスワード — 本番で必須 |
+| `LLM_BASE_URL` / `LLM_API_KEY` / `LLM_DEFAULT_MODEL` | LiteLLM プロキシのエンドポイント、マスターキー、デフォルトモデル |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth(任意) |
+
+### 実行
+
+日々の運用は `openmake_llm.sh` を通します。これは Linux と macOS の両方で 3 つの層
+(PostgreSQL → Redis → アプリ)を順に立ち上げます:
+
+```bash
+./openmake_llm.sh start     # すべて起動し、ログをストリーム
+./openmake_llm.sh status    # 各層のポート + docker + PM2 の状態
+./openmake_llm.sh logs      # ライブの PM2 ログ
+./openmake_llm.sh health    # GET /health
+./openmake_llm.sh deploy    # ビルド + マイグレーション + 再起動(コード変更を適用)
+./openmake_llm.sh stop      # 逆順でシャットダウン
+```
+
+または各部分を直接操作します:
+
+```bash
+# 開発
+npm run dev                 # API + フロントエンドを同時に
+npm run dev:api             # バックエンドのみ(ts-node)
+npm run dev:frontend-next   # フロントエンドのみ(next dev)
+
+# 本番
+npm run build               # バックエンド + フロントエンド
+npm start                   # node apps/api/dist/server.js
+```
+
+再起動後も生き残らせるには、PM2 を init システムに登録します — `pm2 startup`(実行すべき
+コマンドを表示:macOS では `launchd`、Linux では `systemd`)を実行し、続いて `pm2 save`。
+
+### テストと lint
+
+```bash
+npm test                    # Jest ユニットテスト(apps/api)
+npm run test:e2e            # Playwright(chromium + webkit)
+npm run lint                # ESLint
+```
+
+> `apps/api` のユニットテストは git 管理外(ローカル専用)のため、まっさらなクローンでは
+> `npm test` が「0 matches」と報告します — これは想定どおりであり、壊れたインストールでは
+> ありません。CI も同様にゲートをスキップします。
+
+### データベースマイグレーション
+
+`db/migrations/` 内のファイルは **起動時に自動適用** されます — `db/init/` のベースラインスキーマの
+あと、保留中のマイグレーションが PostgreSQL のアドバイザリーロック(複数インスタンスの起動を
+直列化)の下で実行され、失敗は即座にフェイルします。オプトアウトして CLI で手動実行するには
+`DB_AUTO_MIGRATE=false` を設定します:
+
+```bash
+npx ts-node apps/api/src/data/migrations/cli.ts status    # 保留中を表示
+npx ts-node apps/api/src/data/migrations/cli.ts migrate   # 適用
+```
+
+ロールバックスクリプトは `db/migrations/rollbacks/` 配下にあります(前進マイグレーションの
+スキャン対象から除外されています)。
+
+---
+
+## プロジェクト構成
+
+```
+openmake_llm/
+├── apps/
+│   ├── api/          # Express 5 + TypeScript API server (strict, CommonJS)
+│   │   └── src/
+│   │       ├── routes/ controllers/ services/   # REST + business logic
+│   │       ├── chat/                            # ExecutionPlanBuilder, classifiers, prompts
+│   │       ├── agents/                          # 18 industry agents, router, discussion engine
+│   │       ├── llm/ providers/ cluster/         # LLM client, provider abstraction, node routing
+│   │       ├── mcp/                             # MCP tool router, external client, Docker sandbox
+│   │       ├── sockets/                         # WebSocket chat handler
+│   │       ├── auth/ security/ middlewares/     # JWT/OAuth, SSRF guard, rate limiting
+│   │       └── data/                            # PostgreSQL (raw SQL), migrations, repositories
+│   ├── web/          # Next.js + React frontend (the operating UI)
+│   ├── cli/          # OpenMake Code — local bridge CLI (run agent tasks in your own folder)
+│   │                 # private workspace: build from source, see apps/cli/README.md
+│   ├── desktop-native/ # OpenMake Companion — SwiftUI menu-bar app (macOS Apple Silicon)
+│   ├── ios/          # SwiftUI iOS client (in progress)
+│   ├── discord-bot/  # Optional Discord gateway bot (relays to /api/v1/chat/completions)
+│   └── legacy-web/   # Static asset host (e.g. /generated) — legacy SPA retired
+├── db/               # init schema + migrations (+ rollbacks/) — read at runtime
+├── packages/         # shared-types, api-contracts, config, api-client, local-bridge-core (shared workspaces)
+├── infra/            # Dockerfiles & compose (mcp-runtime, task-runtime, artifact-viewer, egress-proxy)
+├── scripts/          # setup/ (gen-env.mjs) + host setup for the LLM backend — vLLM/LiteLLM
+│                     # systemd units, serve scripts, litellm.config.yaml, Caddyfile, diagnostics
+├── tests/            # Playwright E2E
+├── install.sh        # one-shot installer (Linux/macOS): toolchain → .env → DB → build → PM2
+├── openmake_llm.sh   # service manager: start/stop/restart/deploy/status/logs/health
+└── ecosystem.config.js  # PM2 process definitions (API, Next frontend, optional Discord bot)
+```
+
+**動作中のサーバーが実際に必要とするもの:** ビルド済みの `apps/api/dist` + `apps/web/.next`、
+`db/`(起動パスが `db/init/` を適用し、マイグレーション CLI が作業ディレクトリから
+`db/migrations/` を解決)、そして Docker で隔離されたサンドボックス向けの `infra/`。`scripts/` と
+`tests/` はどのランタイムコードからも読み込まれません — ただし `scripts/vllm/` と `scripts/caddy/`
+は、推論バックエンドを立ち上げたり再構築したりする際に GPU ホストへコピーするデプロイ成果物
+なので、リポジトリと一緒に保管してください。
+
+ビルド、マイグレーション、CI のエントリーポイントは別の場所にあります:ビルドは各ワークスペースの
+`package.json`、マイグレーションは `apps/api/src/data/migrations/cli.ts`、CI は
+`.github/workflows/`。
+
+---
+
+## コントリビューション
+
+コントリビューションを歓迎します。以下をお願いします:
+
+- [Conventional Commits](https://www.conventionalcommits.org/) を使用してください — `feat`、`fix`、`refactor`、`docs`、`test`、`chore`。
+- feature/fix ブランチで作業し、`main` に対して PR を開いてください。
+- コード規約に従ってください:TypeScript strict モード、入力検証には Zod、ロギングには Winston、**生のパラメータ化 SQL のみ**(ORM なし)、そして外部化された設定(ハードコードされたモデル、マジックナンバー、インラインプロンプトなし)。
+
+**PR を開く前に:**
+
+- [ ] `npm run lint` が通る
+- [ ] `npm test` が通る
+- [ ] DB スキーマ変更にはマイグレーションファイルを含める(シーケンス競合なし)
+- [ ] 新しい env 変数を `.env.example` に記載する
+- [ ] UI 変更にはスクリーンショットを含める;セキュリティ変更にはその影響を記述する
+
+CI はすべての push と pull request で単一の **CI Gate**(Test → Build → Size → Lint)を実行します。
+
+---
+
+## ライセンス
+
+**MIT ライセンス** の下でリリースされています — 詳細は [LICENSE](LICENSE) を参照してください。

--- a/README.ko.md
+++ b/README.ko.md
@@ -424,6 +424,15 @@ CI는 모든 푸시와 풀 리퀘스트에서 단일 **CI Gate**(Test → Build 
 
 ---
 
+## 문의
+
+| | |
+|---|---|
+| 일반 문의·셀프호스팅 도움 | support@openmake.cc |
+| 메인테이너 | riskpw@openmake.cc · rockyhan@openmake.cc |
+
+---
+
 ## 라이선스
 
 **MIT License**로 배포된다 — 자세한 내용은 [LICENSE](LICENSE)를 참고한다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,429 @@
+<h1 align="center">OpenMake LLM</h1>
+
+<p align="center">
+  <strong>오픈 웨이트 모델과 BYOK 모델을 위한, 오픈소스·로컬 우선·셀프 호스팅 AI 워크스페이스.</strong><br/>
+  vLLM/LiteLLM 추론 · 자율 AI 에이전트 · MCP 도구 · 딥 리서치 · Docker 샌드박스.
+</p>
+
+<p align="center">
+  <a href="https://github.com/openmake/openmake_llm/actions/workflows/ci.yml"><img src="https://github.com/openmake/openmake_llm/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
+  <img src="https://img.shields.io/github/package-json/v/openmake/openmake_llm?label=version&color=green" alt="Version" />
+  <img src="https://img.shields.io/badge/node-%3E%3D24%20%3C25-brightgreen.svg" alt="Node >=24 <25" />
+  <img src="https://img.shields.io/badge/TypeScript-strict-3178c6.svg" alt="TypeScript strict" />
+  <img src="https://img.shields.io/badge/Next.js-16-black.svg" alt="Next.js 16" />
+</p>
+
+<p align="center">
+  <a href="https://openmake.cc/ko/">홈페이지</a> ·
+  <a href="https://chat.openmake.cc">라이브 데모</a> ·
+  <a href="https://bench.openmake.cc">Bench</a> ·
+  <a href="https://openmake.cc/ko/docs/">셀프호스팅 가이드</a><br/>
+  <a href="README.md">English</a> ·
+  <strong>한국어</strong> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+---
+
+> 이 문서는 영어 [README.md](README.md)의 한국어 번역입니다. 내용이 다르면 영어판과 코드가 기준입니다.
+
+## 개요
+
+**OpenMake LLM**은 사용자 자신의 하드웨어에서 직접 운영하는 셀프 호스팅 AI 어시스턴트다. **vLLM**으로 로컬 모델을 서빙하고 그 앞단에 **LiteLLM 프록시**(OpenAI 호환)를 두며, *동일한* 추상화를 통해 사용자가 자신의 키로 등록한 외부 프로바이더(**OpenRouter, NVIDIA NIM, Ollama** 로컬/클라우드 — 모두 OpenAI 호환이며, Anthropic 어댑터도 기본 내장)로 라우팅한다. 따라서 기본적으로 데이터는 사용자 머신에 그대로 머문다.
+
+모든 요청은 경량 **메시지 파이프라인**을 거치며, 이 파이프라인은 프로바이더 게이트, 보안·언어 정책, 프롬프트/도구 조립을 *추가 LLM 라우팅 왕복 없이* 적용한다. 이후 로컬 모델과 외부 모델은 동일한 실행 경로와 상시 도구 루프를 공유한다. 현재의 **`ExecutionPlanBuilder`**는 의도적으로 좁게 설계되어, 선택된 인가된 커스텀 에이전트가 있으면 그것을 로드하는 역할만 한다. 동작은 불투명한 프리셋이 아니라 **모델 · 스타일 · 모드 토글 · 커스텀 에이전트**라는 직교 축으로만 제어된다. 고급 사용자는 **역할별 모델 오케스트레이션**으로 한 단계 더 나아갈 수 있다. 즉 각 기능 역할(에이전트, 심판, 리서치, 병렬 서브 에이전트, 리뷰, 사고 요약)마다 서로 다른 모델(로컬 또는 외부)을 배정한다. 채팅을 넘어, 자율 에이전트·딥 리서치 파이프라인·MCP 도구 시스템을 더하며, 이 모두는 JWT 인증과 역할 기반 접근 제어 뒤에서 동작한다.
+
+> **단일 호스트 설계:** 애플리케이션(API + 웹)은 **PM2**로 실행되고, 상태를 갖는 의존성(PostgreSQL / Redis)과 샌드박스화된 에이전트 / MCP / 산출물 프로세스는 격리를 위해 **Docker**에서 실행된다.
+
+**한눈에 보기**
+
+| | |
+|---|---|
+| 🧠 **로컬 모델 1개, 요청별 라우팅** | vLLM + LiteLLM으로 서빙되는 `qwen3.8-27b`, 262K 컨텍스트 적합 안전망 포함 |
+| 🎛️ **역할별 모델 오케스트레이션** | 기능 역할마다 서로 다른 모델(로컬 또는 BYOK 외부) 배정. 사용자별 + 관리자 전역 매핑, 토큰 예산이 걸린 서버 공유 키 |
+| 🤖 **자율 에이전트** | 영속 Docker 샌드박스(셸 · Python · 브라우저 · 파일) 안에서 동작하는 Manus 스타일 멀티턴 에이전트, 사람 개입(human-in-the-loop) 승인 포함 |
+| 🔬 **딥 리서치** | 팬아웃 웹 검색 → 출처 수집 → 주장 검증 → 출처 표기 종합 |
+| 📊 **리포트 파이프라인** | 리포트 의도 질의는 모델이 생성한 데이터를 고정된 디자인 템플릿을 통해 HTML 산출물로 렌더링 — **PDF/DOCX**로 내보내기 가능 |
+| 📓 **NotebookLM 그라운딩** | 사용자의 Google NotebookLM 노트북 하나를 대화 컨텍스트로 고정, 컴포저에서 바로 |
+| 🧩 **내장 MCP 도구 22종** + 외부 MCP 서버 | 각 외부 서버는 Docker로 격리(`--cap-drop ALL`, 비루트, 네트워크 정책) |
+| 👤 **커스텀 에이전트 & 스킬** | 프로젝트 범위 페르소나(선택적 에이전트별 모델 포함) + 자동 선택 가능한 스킬 라이브러리 + 18개 산업 에이전트(전문가 100명) |
+| 💬 **Discord 게이트웨이 봇** | Discord 메시지를 OpenAI 호환 API로 중계하는 선택적 워크스페이스, 역할/멘션 접근 제어 포함 |
+| 🖥️ **네이티브 클라이언트** | 로컬 폴더 에이전트 작업용 **OpenMake Companion**(SwiftUI 메뉴바 앱, macOS Apple Silicon), **OpenMake Code** CLI(로컬 브리지), 진행 중인 SwiftUI iOS 클라이언트 — 채팅 자체는 웹 앱에 머문다 |
+| 📊 **OpenMake Bench** | [bench.openmake.cc](https://bench.openmake.cc): 블라인드 쌍대 모델 비교와 하드웨어 적합도 점수, 웹 SSO 클라이언트로 로그인. 여기서 고른 모델은 사용자의 모델 역할에 적용된다 |
+| 🌐 **4개 언어 UI** | 한국어 · English · 日本語 · 简体中文 (`next-intl`, 쿠키 로케일, 브라우저 자동 감지) |
+| 🔒 **보안 우선** | JWT (HttpOnly), Google OAuth 2.0, RBAC, 라우트별 속도 제한, SSRF 가드, 감사 ↔ 알림 |
+
+---
+
+## 스크린샷
+
+> 대화 제목, 노트북 이름, 계정 이메일은 흐림 처리했다. 그 외 모든 것은 실행 중인 앱이다.
+
+**채팅 워크스페이스** — 5개 항목의 워크스페이스 내비게이션, 모델 선택기, 응답 스타일, 슬래시로 호출하는 스킬:
+
+<p align="center">
+  <img src="assets/screenshot-chat.png" alt="Chat workspace" width="920" />
+</p>
+
+| 모드 메뉴 — 토론 / 사고 / 딥 리서치 / 웹 / 에이전트 / 이미지 / 산출물 / 구조화 | NotebookLM 선택기 — 노트북을 대화 컨텍스트로 고정 |
+|---|---|
+| ![Composer mode menu](assets/screenshot-composer-modes.png) | ![NotebookLM notebook picker](assets/screenshot-notebook-picker.png) |
+
+**에이전트 작업** — 실시간 진행 상황, 토큰 집계, 반복 스케줄, 재사용 가능한 작업 템플릿을 갖춘 자율 멀티턴 실행:
+
+<p align="center">
+  <img src="assets/screenshot-agent-tasks.png" alt="Agent task management" width="920" />
+</p>
+
+| 커넥터 — 외부 MCP 서버, 각각 Docker로 격리 | 모델 역할 관리 — 전역 역할→모델 매핑 |
+|---|---|
+| ![Settings → Connectors](assets/screenshot-settings.png) | ![Model roles admin](assets/screenshot-model-roles.png) |
+
+**스킬 라이브러리** — 도구 바인딩을 갖춘 재사용 가능한 매니페스트, Git에서 임포트하거나 모델이 생성:
+
+<p align="center">
+  <img src="assets/screenshot-skill-library.png" alt="Skill Library" width="920" />
+</p>
+
+**다국어 UI (한국어 · English · 日本語 · 简体中文)** — 설정에서 인터페이스 언어를 전환하거나, 브라우저(`Accept-Language`)를 따르게 둔다. AI 응답 언어는 메시지 언어를 독립적으로 따른다:
+
+<p align="center">
+  <img src="assets/i18n-demo.gif" alt="Interface language switching demo (ko / en / ja / zh)" width="920" />
+</p>
+
+---
+
+## 아키텍처
+
+OpenMake는 **정책**(*어떻게* 답할지 결정)과 **실행**(실제로 모델을 호출)을 분리한다 — SQL의 플래너/실행기 분리와 같다. 두 계층은 의도적으로 독립을 유지한다.
+
+```
+                          WebSocket / REST
+                                  │
+                    ┌─────────────▼─────────────┐
+  Query ───────────►│      message-pipeline     │  request processing
+                    │                           │  · provider gate
+                    └─────────────┬─────────────┘  · security & language policy
+                                  │                · prompt & tool assembly
+                                  │                · authorized custom-agent load
+                    ┌─────────────▼─────────────┐
+                    │ streamFromExternalProvider│  single path — local & external alike
+                    │   (always-on tool loop)   │  · 5 tool turns max
+                    └─────────────┬─────────────┘  · special modes intercept earlier
+                                  │
+                    ┌─────────────▼─────────────┐
+                    │       LLMClient.chat      │  execution — per call
+                    │  (context-fit safety net) │  · token estimate → truncate → cap
+                    └─────────────┬─────────────┘  · overflow → 413 + audit + alert
+                                  │
+           vLLM serve → LiteLLM proxy (OpenAI-compatible endpoint)
+```
+
+- **단일 실행 경로** — 과거의 전략별 계층(생성-검증, 에이전트 루프, 사고, 다이렉트)은 폐기되었다. `message-pipeline`은 로컬 모델과 외부 모델을 상시 MCP 도구 루프를 갖춘 단일 `streamFromExternalProvider` 디스패치로 보낸다. `ExecutionPlanBuilder`는 이제 인가된 커스텀 에이전트만 로드한다. 토론과 딥 리서치는 디스패치 전에 가로채는 별도 모드로 남아 있다.
+- **컨텍스트 적합 안전망** — 진입 시 프롬프트 토큰(이미지 포함)을 추정한다. 유효 **262K** 윈도를 초과하면 입력을 잘라내고 → `max_tokens`를 줄이며 → 극단적인 경우 `ContextOverflowError`가 **HTTP 413**을 반환하며 감사 기록과 자동 웹훅 알림을 남긴다.
+- **사용자 커스터마이즈(4개 직교 축)** — **모델**(선택기) · **스타일**(간결 / 기본 / 상세) · **모드**(토론 / 사고 / 딥 리서치 / 웹 / 에이전트 작업) · **커스텀 지시 & 에이전트**. 시스템 프롬프트 조립 순서: `memory + custom-instructions + style`.
+- **역할별 모델 오케스트레이션** — LLM을 호출하는 모든 하위 시스템은 단일 역할 레지스트리를 통해 모델을 해석하며, 페일오픈 폴백 체인을 갖는다: 사용자별 매핑 → 관리자 설정 전역(DB) → 전역 env → 로컬 기본. 역할별 외부 모델은 사용자의 BYOK 키로 실행되거나, 전역 역할의 경우 서버 공유 운영자 키(일/월 토큰 예산 포함)로 실행된다. 커스텀 에이전트도 자신의 모델을 고정할 수 있다.
+- **대화 간 메모리** — 명시적 장기 메모리는 시스템 프롬프트에 주입되며, 프라이버시 토글로 사용자가 세션별로 이를 제외할 수 있다.
+- **사고 표시(Claude 웹 스타일)** — 사고 모드가 켜지면 추론 스트림이 실시간 타임라인으로 렌더링된다. 전용 `summary` 역할 모델이 한 줄 헤드라인(중간 스트리밍 → 최종)을 생성하고, 추론과 헤드라인이 모두 영속화되어 대화를 다시 열면 타임라인이 복원된다.
+
+---
+
+## 기능
+
+**▸ 모델 & 라우팅**
+- 로컬 모델과 외부 모델은 프로바이더 게이트가 걸린 `message-pipeline`과 도구 루프를 공유한다. 동작은 직교 축(모델 · 스타일 · 모드 · 커스텀 에이전트)으로 제어된다.
+- 셀프 호스팅 vLLM + LiteLLM(기본 `qwen3.8-27b`)과 출력 토큰을 보호하고 오버플로 시 우아하게 저하되는 컨텍스트 적합 안전망.
+- 외부 키 직접 등록(BYOK) — **OpenRouter, NVIDIA NIM, Ollama**(로컬 + 클라우드), 모두 OpenAI 호환(Anthropic 어댑터는 프로바이더 추상화에 내장) — 저장 시 AES-256-GCM으로 암호화. **게스트는 기본 로컬 모델만 사용**하며, 외부 프로바이더는 로그인이 필요하다.
+- **역할별 모델 오케스트레이션** — 설정을 통해 각 기능 역할(`agent`, `judge`, `research`, `spawn`, `review`, `summary`)에 서로 다른 모델(로컬 또는 BYOK 외부)을 배정한다. 관리자는 조직 전역 기본값을 설정하고, 관리자 콘솔에서 키별 토큰 예산이 걸린 서버 공유 외부 키를 등록한다. 해석은 페일오픈이다(어떤 실패에서든 로컬 기본값으로 폴백). 모델 목록은 실제로 도달 가능하고 역할 수행이 가능한 것만 필터링해 보여준다.
+- **외부 프로바이더 스로틀링** — 프로바이더별 동시성 제한과 429 시 지수 백오프(`Retry-After` 존중)로, 토론이나 딥 리서치 팬아웃이 몰려도 BYOK 키가 속도 제한에 걸리지 않게 한다. UI의 추론 노력 설정(낮음 / 중간 / 높음)은 OpenAI 호환 외부 프로바이더에 `reasoning_effort`로 전달되고, 로컬 모델은 사고 ON/OFF에 맞는 샘플링 프리셋을 받는다.
+- **테일 라우팅(옵트인, 기본 꺼짐)** — 경량 게이트가 각 질의의 오답 가능성을 채점한다. 질의를 *사실성 테일*(오답 가능성이 높고 외부 검증이 가능)로 판단하면, 첫 턴에 `web_search`가 결정적으로 강제된다. 게이트 결정을 동작 변경 없이 기록하는 섀도 모드(`TAIL_ROUTING_SHADOW_ENABLED`)를 함께 제공하므로, `TAIL_ROUTING_STAGE2B_ENABLED`를 켜기 전에 실제 트래픽에서 임계값을 튜닝할 수 있다.
+
+**▸ 에이전트 & 리서치**
+- **자율 에이전트 작업** — Manus 스타일 에이전트가 **영속 Docker 샌드박스**(셸, Python, 브라우저, 파일, 계획 도구) 안에서 여러 도구 호출 턴에 걸쳐 목표를 추구하며, 사람 개입 승인을 거친다. 파일 첨부를 기록하고, 비전 채널로 이미지를 주입하며, **Excel(.xlsx)**과 **PDF**(한국어/CJK 폰트 포함)를 포함한 산출물을 생성하고, 거짓으로 "완료" 표시를 하는 대신 미달성을 정직하게 보고한다(`[GOAL_INCOMPLETE]` 마커 + 목표 심판). 작업은 **재사용 가능한 템플릿**으로 저장하거나 **반복 스케줄**에 올릴 수 있다.
+- **딥 리서치** — 팬아웃 웹 검색 → 출처 수집 → 주장 검증 → 출처 표기 종합.
+- **리포트 파이프라인** — 리포트 의도 질의("X를 조사해 리포트를 작성해")에서 모델은 **데이터(JSON)만** 생성하고, 서버가 이를 고정된 디자인 템플릿을 통해 HTML 산출물로 렌더링한다(*렌더러가 디자인을 소유* — 일관된 편집 레이아웃, KPI 타일, 표, 의존성 없는 SVG 차트, 출처 표기. 모든 모델 문자열은 이스케이프된다). 독립적인 리서치형 리포트 요청은 더 많은 리서치 턴을 위해 자동으로 에이전트 작업에 위임되며, 동일한 계약이 에이전트 작업 산출물에도 적용된다. 실패는 페일오픈이다. 유효한 데이터 블록이 없으면 응답은 일반 채팅으로 스트리밍된다.
+- **커스텀 에이전트 & 스킬** — 컴포저에서 바로 선택 가능한 프로젝트 범위 에이전트(claude.ai Projects 대응)로, 각각 선택적으로 자신의 모델에 고정할 수 있으며, 자동 선택 가능한 스킬 라이브러리와 내장 산업 에이전트 18개(전문가 100명)를 더한다.
+
+**▸ 도구 & 확장성**
+- **MCP 도구 시스템** — 내장 도구 22종(웹 검색, 팩트 체크, 웹 스크레이프/맵/크롤, 이미지 분석, 에이전트 작업 제어, 스킬/에이전트/MCP git 인제스트 등)에 더해 외부 MCP 서버를 지원하며, 각각 Docker로 격리된다(`--cap-drop ALL`, 비루트, `--memory`+`--memory-swap`, 네트워크 정책, realpath로 가드된 마운트). **설정 → 커넥터**의 MCP 카탈로그에서 서버를 설치한다(Tavily, Sentry, Context7 등이 시드로 제공. `{{env.KEY}}` 시크릿은 셸 변수 참조로 전달되며 argv에 절대 구워 넣지 않는다). 카탈로그 수준의 **도구 허용 목록**은 채팅 자동 노출을 집중시키는데(도구 39개짜리 서버가 모든 프롬프트에 39개 스키마를 쏟아낼 필요는 없다), REST 실행과 명시적 도구 선택기는 전체 접근을 유지한다.
+- **NotebookLM 그라운딩** — 사용자의 Google 세션 쿠키(AES-256-GCM 암호화, 스폰 시에만 주입)로 NotebookLM 커넥터를 설치한 뒤, 컴포저에서 노트북을 고정한다. 그라운딩 프리픽스는 LLM 전용 채널을 타므로 저장 메시지와 사이드바 제목은 깔끔하게 유지되며, 고정은 한 대화로 범위가 한정된다.
+- **산출물(Artifacts)** — 실시간 샌드박스 iframe 렌더링, 선택적 Docker 코드 실행(Python / JS), 크기 조절 가능한 사이드 패널, 그리고 게시용의 별도 오리진 엄격 CSP 공유 뷰어. OpenAI 호환 API는 산출물을 `message.artifacts` 확장으로 반환하며, `publish_artifacts: true`를 주면 스스로 게시할 수 없는 API 키 클라이언트를 위해 서버가 공유 링크를 발행한다.
+- **PDF / DOCX 내보내기** — 모든 HTML 산출물(채팅 또는 에이전트 작업 산출물)은 헤드리스 Chromium 인쇄로 **PDF**로 내보낸다(CJK 폰트 포함). 리포트 산출물은 구조화된 원본 데이터(`artifacts.source_data`)를 유지하여 `python-docx`로 고충실도 **DOCX** 생성을 가능하게 한다. 두 변환 모두 소유자 범위의 속도 제한 엔드포인트 뒤에서 Docker 샌드박스(`--network none`, `--cap-drop ALL`, 메모리/pids 상한) 안에서 일회성으로 실행된다.
+- **메모리 & 지시** — 영속적인 대화 간 메모리(세션별 사용 토글 포함)와 상시 커스텀 지시.
+- **사고 표시** — 전용 요약 모델이 생성하는 실시간 한 줄 헤드라인을 갖춘 Claude 웹 스타일 추론 타임라인. 영속화되어 다시 열면 복원된다.
+- **다국어 UI** — `next-intl`을 통한 한국어, 영어, 일본어, 중국어 간체(쿠키 기반 로케일, 브라우저 자동 감지, 로케일 인식 날짜/숫자 서식).
+
+**▸ 통합**
+- **Discord 게이트웨이 봇**(`apps/discord-bot`) — Discord 메시지를 `/api/v1/chat/completions`로 중계하는 선택적 독립 워크스페이스로, 사용자별 세션 격리(`/reset`), 역할/멘션 접근 제어, API 키 인증을 갖는다. 생성된 이미지와 산출물은 실제 Discord 파일 첨부(공유 링크 포함)로 돌아온다. Discord는 API의 상대 경로나 플레이스홀더를 렌더링하지 못하기 때문이다. 자체 PM2 프로세스로 실행된다.
+- **OpenMake Bench** — [bench.openmake.cc](https://bench.openmake.cc)는 API의 웹 SSO 클라이언트로 로그인하고 실시간 갱신되는 `/v1/models` 목록을 읽는다. OpenAI 호환 API는 벤치마크 클라이언트를 위한 로 모드(raw mode)도 제공한다.
+- **네이티브 클라이언트** — `apps/desktop-native`(OpenMake Companion, SwiftUI 메뉴바: 폴더 연결, 기기 상태, 실행 승인, 작업 완료 알림, 웹 딥 링크), `apps/cli`(OpenMake Code, 서버 샌드박스 대신 사용자 머신에서 에이전트 도구 호출을 실행하는 로컬 브리지), `apps/ios`(SwiftUI 클라이언트, 진행 중). 셋 모두 웹 앱과 Instrument 디자인 토큰을 공유한다.
+- **NotebookLM** — `GET /api/mcp/notebooklm/notebooks`가 컴포저 선택기를 뒷받침한다(사용자별 캐시, 업스트림 실패는 `502 NOTEBOOKLM_UPSTREAM`으로 수렴시켜 Google 쿠키 만료 시 UI가 재연결을 유도할 수 있게 한다).
+
+**▸ 보안**
+- HttpOnly 쿠키의 JWT, Google OAuth 2.0, RBAC, 사용자별·라우트별 속도 제한, SSRF 가드, Helmet 헤더, 그리고 통합된 감사 ↔ 알림 파이프라인.
+
+---
+
+## 기술 스택
+
+| 계층 | 기술 |
+|---|---|
+| **백엔드** | Node.js (≥24), Express 5, TypeScript (strict, CommonJS), Zod, Winston |
+| **프런트엔드** | Next.js 16, React 19, Zustand 5, Tailwind CSS 4, `next-intl`; Instrument 디자인 시스템(코발트 프라이머리 · 시안 보조, IBM Plex Mono) |
+| **데이터베이스** | `pg`를 통한 PostgreSQL — 로(raw), 파라미터화 SQL(ORM 없음) |
+| **실시간** | 스트림 분리/재개를 갖춘 WebSocket(`ws`) 스트리밍 채팅 — 백그라운드로 넘어간 탭이나 앱이 응답을 잃지 않고 재연결 |
+| **LLM 백엔드** | vLLM + LiteLLM(OpenAI 호환); 외부 프로바이더용 `@anthropic-ai/sdk`, `openai` |
+| **에이전트 / 도구** | Model Context Protocol(`@modelcontextprotocol/sdk`), Docker 격리 샌드박스 |
+| **통합** | Discord 게이트웨이 봇(`discord.js`) — 선택적 독립 워크스페이스; 웹 SSO를 통한 OpenMake Bench |
+| **네이티브 클라이언트** | SwiftUI(macOS Companion, iOS), `packages/local-bridge-core`를 공유하는 Node CLI(`apps/cli`) |
+| **인증 / 보안** | `jsonwebtoken`, Google OAuth 2.0, Helmet, AES-256-GCM |
+| **인프라** | PM2(API · 웹 · Discord 봇) + Docker(PostgreSQL/Redis, MCP / 에이전트 / 산출물 샌드박스) |
+| **테스트 / CI** | Jest/ts-jest, Playwright, ESLint, GitHub Actions(CI Gate) |
+
+---
+
+## 시작하기
+
+지원 플랫폼: **Linux**와 **macOS**(Intel & Apple Silicon).
+
+### 설치(한 줄 명령)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/openmake/openmake_llm/main/install.sh | bash
+```
+
+클론이 필요 없다 — 설치 스크립트가 리포지토리 밖에서 실행되고 있음을 감지하면 소스를
+`~/openmake_llm`으로 가져오고(재정의는 `OMK_HOME=...`; `OMK_REF=...`로 브랜치나 태그 선택)
+그곳에서 스스로를 다시 실행한다. 파이프로 실행해도 `/dev/tty`를 통해 대화형으로 프롬프트가
+뜨며, 터미널이 아닌 환경(CI)에서는 프롬프트가 자동 승인된다. 고전적인 방식이 더 좋다면
+예전 그대로 동작한다:
+
+```bash
+git clone https://github.com/openmake/openmake_llm.git
+cd openmake_llm
+./install.sh
+```
+
+**Windows**에서는 동일한 한 줄 명령을 **WSL2**(Ubuntu) 안에서 실행한다 — 설치 스크립트가
+네이티브 Windows 셸을 감지하면 대신 WSL2 설정 단계를 출력한다.
+
+이게 전부다. 설치 스크립트는 툴체인(Node 24, Docker, PM2 — 없는 것은 가능한 한 `sudo` 없이
+설치)을 점검하고, 새로 무작위 생성한 시크릿으로 `.env`를 만들며, 의존성을 설치하고,
+PostgreSQL + Redis를 시작하고, 모든 마이그레이션을 적용하고, 두 앱을 빌드하고, PM2로 실행한
+뒤 `/health`를 기다린다. 마지막에 웹 URL과 생성된 관리자 비밀번호를 출력한다.
+
+질문은 하나뿐이다 — 어떤 OpenAI 호환 LLM 엔드포인트를 쓸지(Ollama / OpenRouter / 커스텀 /
+나중에 결정). 모든 프롬프트를 건너뛰려면:
+
+```bash
+# 플래그는 한 줄 명령을 통해서도 그대로 전달된다:
+curl -fsSL https://raw.githubusercontent.com/openmake/openmake_llm/main/install.sh | bash -s -- --yes
+
+./install.sh --yes                                    # 플레이스홀더 LLM, .env는 나중에 채움
+./install.sh --yes \
+  --llm-base-url https://openrouter.ai/api/v1 \
+  --llm-api-key  sk-or-... \
+  --llm-model    qwen/qwen3-235b-a22b
+```
+
+`./install.sh`를 다시 실행해도 안전하다 — 덮어쓰지 않고 복구한다. 유용한 플래그:
+`--skip-docker`(Postgres/Redis를 직접 운영), `--skip-build`, `--no-start`,
+`--force-env`, 그리고 아래의 포트 재정의. `./install.sh --help`를 참고한다.
+
+이미 기본 포트에서 Postgres나 Redis를 운영 중인가? 5432/6379를 두고 다투는 대신 컨테이너를
+옮겨라 — 포트는 `.env`에 기록되고, `openmake_llm.sh`가 그것을 다시 읽는다:
+
+```bash
+./install.sh --yes --postgres-port 55432 --redis-port 56379
+```
+
+macOS에서 설치 스크립트는 Docker Desktop, OrbStack, 또는 **Colima**와 함께 동작한다
+(`brew install colima docker docker-compose` — 헤드리스, GUI 없음). Homebrew의 compose
+플러그인이 docker CLI에 등록되어 있지 않으면, 설치 스크립트가 `~/.docker/config.json`에
+`cliPluginsExtraDirs`를 대신 추가해 준다.
+
+### 설치된 인스턴스 업데이트
+
+```bash
+./openmake_llm.sh update            # git pull (ff-only) → build → migrate → restart
+./openmake_llm.sh update --yes      # 마이그레이션 확인을 건너뜀(비대화형)
+```
+
+`update`는 커밋되지 않은 변경이나 로컬 커밋이 갈라진 트리는 건드리기를 거부한다 — 사용자의
+편집을 절대 덮어쓰지 않는다. 새로 받아온 것이 없으면 재배포를 건너뛴다(그래도 재배포하려면
+`--force`). 타르볼 설치(git 없음)는 대신 `install.sh`를 다시 실행해야 하며, 이는 제자리에서
+복구한다.
+
+설치를 `main` 대신 릴리스로 고정하려면 한 줄 명령에 `OMK_REF`를 설정한다:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/openmake/openmake_llm/main/install.sh \
+  | OMK_REF=v1.31.1 bash -s -- --yes
+```
+
+### 사전 요구사항(설치 스크립트가 처리)
+
+- **git** — 새 macOS에서는 맨 처음 `git clone`이 Xcode Command Line Tools 설치
+  대화상자를 띄운다. 한 번 승인하면 된다(또는 소스를 zip으로 대신 내려받는다).
+  `install.sh` 자체는 git이 없어도 견딘다(빌드 메타데이터가 `unknown`으로 폴백)
+- **Node.js** `>=24 <25` — `mise`/`fnm`/`nvm`, Homebrew, 또는 이들 중 아무것도 없으면
+  로컬 `~/.openmake/node` 타르볼로 프로비저닝
+- **Docker** — PostgreSQL/Redis와 MCP/에이전트 샌드박스에 필요하다. Linux에서는 설치
+  스크립트가 공식 `get.docker.com` 스크립트 실행을 제안한다. macOS에서는 Docker Desktop
+  이나 OrbStack이 필요하다. 참고: Docker Desktop의 **첫 실행**은 GUI 승인(권한 헬퍼)을
+  요구할 수 있고 설치 스크립트의 약 60초 데몬 대기를 넘길 수 있다 — 그런 경우 Docker가
+  시작을 마칠 때까지 기다렸다가 `./install.sh`를 다시 실행한다(반복해도 안전)
+- OpenAI 호환 LLM 엔드포인트: 로컬 **vLLM + LiteLLM** 스택, **Ollama**, 또는 외부
+  프로바이더 키
+
+### 수동 설정
+
+직접 배선하고 싶다면, `install.sh`는 다음 단계들의 읽기 쉬운 기록이다:
+
+```bash
+npm install
+node scripts/setup/gen-env.mjs        # 생성된 시크릿을 갖춘 최소 .env
+docker compose --env-file .env -f infra/docker-compose.yml up -d postgres redis
+npx ts-node apps/api/src/data/migrations/cli.ts migrate
+npm run build && pm2 start ecosystem.config.js
+```
+
+> `--env-file .env`는 선택 사항이 아니다: Compose는 기본 `.env`를 compose 파일의 디렉터리
+> (`infra/`) 기준으로 해석하므로, 이것이 없으면 `POSTGRES_PASSWORD`가 비어 시작이 실패한다.
+
+`gen-env.mjs`는 부팅에 필요한 키만 기록한다. `.env.example`이 전체 레퍼런스다 —
+필요에 따라 그곳에서 선택 블록(OAuth, 웹 검색, MCP 샌드박스, Discord 봇)을 복사해 온다:
+
+| 변수 | 용도 |
+|---|---|
+| `PORT` | API 포트(기본 `52416`) |
+| `DATABASE_URL` | PostgreSQL 연결 문자열(비밀번호는 `POSTGRES_PASSWORD`와 일치해야 함) |
+| `JWT_SECRET` | JWT 서명 시크릿(≥32자) |
+| `API_KEY_PEPPER` | API 키 해싱 페퍼 — 프로덕션에서 필수 |
+| `TOKEN_ENCRYPTION_KEY` | 외부 프로바이더 자격 증명용 AES-256-GCM 키(정확히 64 hex) |
+| `ADMIN_PASSWORD` | 부트스트랩 관리자 계정 비밀번호 — 프로덕션에서 필수 |
+| `LLM_BASE_URL` / `LLM_API_KEY` / `LLM_DEFAULT_MODEL` | LiteLLM 프록시 엔드포인트, 마스터 키, 기본 모델 |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth(선택) |
+
+### 실행
+
+일상 운영은 `openmake_llm.sh`를 통하며, 이 스크립트는 세 계층(PostgreSQL → Redis → 앱)을
+Linux와 macOS 양쪽에서 순서대로 처리한다:
+
+```bash
+./openmake_llm.sh start     # 전부 올린 뒤 로그를 스트리밍
+./openmake_llm.sh status    # 계층별 포트 + docker + PM2 상태
+./openmake_llm.sh logs      # 실시간 PM2 로그
+./openmake_llm.sh health    # GET /health
+./openmake_llm.sh deploy    # build + migrate + restart(코드 변경 적용)
+./openmake_llm.sh stop      # 역순 종료
+```
+
+또는 각 조각을 직접 다룬다:
+
+```bash
+# 개발
+npm run dev                 # API + 프런트엔드 함께
+npm run dev:api             # 백엔드만(ts-node)
+npm run dev:frontend-next   # 프런트엔드만(next dev)
+
+# 프로덕션
+npm run build               # 백엔드 + 프런트엔드
+npm start                   # node apps/api/dist/server.js
+```
+
+재부팅에서 살아남으려면 PM2를 init 시스템에 등록한다 — `pm2 startup`(실행할 명령을 출력:
+macOS는 `launchd`, Linux는 `systemd`), 그다음 `pm2 save`.
+
+### 테스트 & 린트
+
+```bash
+npm test                    # Jest 단위 테스트(apps/api)
+npm run test:e2e            # Playwright(chromium + webkit)
+npm run lint                # ESLint
+```
+
+> `apps/api` 단위 테스트는 git에서 무시된다(로컬 전용). 따라서 갓 클론한 상태에서는 `npm
+> test`가 "0 matches"를 보고한다 — 이는 정상이며, 설치가 깨진 것이 아니다. CI도 같은 방식으로
+> 게이트를 건너뛴다.
+
+### 데이터베이스 마이그레이션
+
+`db/migrations/`의 파일은 **부팅 시 자동으로 적용**된다 — `db/init/` 베이스라인 스키마 이후,
+대기 중인 마이그레이션이 PostgreSQL 어드바이저리 락(다중 인스턴스 시작을 직렬화) 아래에서
+실행되며 실패는 빠르게 실패한다(fail fast). 옵트아웃하려면 `DB_AUTO_MIGRATE=false`를 설정하고
+CLI로 수동 실행한다:
+
+```bash
+npx ts-node apps/api/src/data/migrations/cli.ts status    # 대기 중 표시
+npx ts-node apps/api/src/data/migrations/cli.ts migrate   # 적용
+```
+
+롤백 스크립트는 `db/migrations/rollbacks/` 아래에 있다(정방향 마이그레이션 스캔에서 제외).
+
+---
+
+## 프로젝트 구조
+
+```
+openmake_llm/
+├── apps/
+│   ├── api/          # Express 5 + TypeScript API server (strict, CommonJS)
+│   │   └── src/
+│   │       ├── routes/ controllers/ services/   # REST + business logic
+│   │       ├── chat/                            # ExecutionPlanBuilder, classifiers, prompts
+│   │       ├── agents/                          # 18 industry agents, router, discussion engine
+│   │       ├── llm/ providers/ cluster/         # LLM client, provider abstraction, node routing
+│   │       ├── mcp/                             # MCP tool router, external client, Docker sandbox
+│   │       ├── sockets/                         # WebSocket chat handler
+│   │       ├── auth/ security/ middlewares/     # JWT/OAuth, SSRF guard, rate limiting
+│   │       └── data/                            # PostgreSQL (raw SQL), migrations, repositories
+│   ├── web/          # Next.js + React frontend (the operating UI)
+│   ├── cli/          # OpenMake Code — local bridge CLI (run agent tasks in your own folder)
+│   │                 # private workspace: build from source, see apps/cli/README.md
+│   ├── desktop-native/ # OpenMake Companion — SwiftUI menu-bar app (macOS Apple Silicon)
+│   ├── ios/          # SwiftUI iOS client (in progress)
+│   ├── discord-bot/  # Optional Discord gateway bot (relays to /api/v1/chat/completions)
+│   └── legacy-web/   # Static asset host (e.g. /generated) — legacy SPA retired
+├── db/               # init schema + migrations (+ rollbacks/) — read at runtime
+├── packages/         # shared-types, api-contracts, config, api-client, local-bridge-core (shared workspaces)
+├── infra/            # Dockerfiles & compose (mcp-runtime, task-runtime, artifact-viewer, egress-proxy)
+├── scripts/          # setup/ (gen-env.mjs) + host setup for the LLM backend — vLLM/LiteLLM
+│                     # systemd units, serve scripts, litellm.config.yaml, Caddyfile, diagnostics
+├── tests/            # Playwright E2E
+├── install.sh        # one-shot installer (Linux/macOS): toolchain → .env → DB → build → PM2
+├── openmake_llm.sh   # service manager: start/stop/restart/deploy/status/logs/health
+└── ecosystem.config.js  # PM2 process definitions (API, Next frontend, optional Discord bot)
+```
+
+**실행 중인 서버가 실제로 필요로 하는 것:** 빌드된 `apps/api/dist` + `apps/web/.next`, `db/`(부팅 경로가 `db/init/`를 적용하고, 마이그레이션 CLI가 작업 디렉터리에서 `db/migrations/`를 해석), 그리고 Docker 격리 샌드박스를 위한 `infra/`. `scripts/`와 `tests/`는 어떤 런타임 코드에도 로드되지 *않는다* — 다만 `scripts/vllm/`와 `scripts/caddy/`는 추론 백엔드를 세우거나 재구축할 때 GPU 호스트로 복사하는 배포 산출물이므로 리포지토리와 함께 보관한다.
+
+빌드, 마이그레이션, CI 진입점은 다른 곳에 있다: 빌드는 각 워크스페이스의 `package.json`에, 마이그레이션은 `apps/api/src/data/migrations/cli.ts`에, CI는 `.github/workflows/`에 있다.
+
+---
+
+## 기여
+
+기여를 환영한다. 다음을 지켜주기 바란다:
+
+- [Conventional Commits](https://www.conventionalcommits.org/)를 사용한다 — `feat`, `fix`, `refactor`, `docs`, `test`, `chore`.
+- 기능/수정 브랜치에서 작업하고 `main`을 대상으로 PR을 연다.
+- 코드 컨벤션을 따른다: TypeScript strict 모드, 입력 검증에 Zod, 로깅에 Winston, **로 파라미터화 SQL만**(ORM 없음), 그리고 외부화된 설정(하드코딩된 모델, 매직 넘버, 인라인 프롬프트 없음).
+
+**PR을 열기 전에:**
+
+- [ ] `npm run lint` 통과
+- [ ] `npm test` 통과
+- [ ] DB 스키마 변경에는 마이그레이션 파일 포함(시퀀스 충돌 없음)
+- [ ] 새 env 변수는 `.env.example`에 문서화
+- [ ] UI 변경에는 스크린샷 포함, 보안 변경에는 그 영향 설명
+
+CI는 모든 푸시와 풀 리퀘스트에서 단일 **CI Gate**(Test → Build → Size → Lint)를 실행한다.
+
+---
+
+## 라이선스
+
+**MIT License**로 배포된다 — 자세한 내용은 [LICENSE](LICENSE)를 참고한다.

--- a/README.md
+++ b/README.md
@@ -419,6 +419,15 @@ CI runs a single **CI Gate** (Test → Build → Size → Lint) on every push an
 
 ---
 
+## Contact
+
+| | |
+|---|---|
+| General questions & self-hosting help | support@openmake.cc |
+| Maintainers | riskpw@openmake.cc · rockyhan@openmake.cc |
+
+---
+
 ## License
 
 Released under the **MIT License** — see [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@
   <a href="https://chat.openmake.cc">Live demo</a> ·
   <a href="https://openmake.cc/en/docs/">Self-hosting guide</a> ·
   <a href="https://openmake.cc/ko/">한국어</a> ·
-  <a href="https://openmake.cc/ja/">日本語</a>
+  <a href="https://openmake.cc/ja/">日本語</a> ·
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@
 <p align="center">
   <a href="https://openmake.cc/en/">Homepage</a> ·
   <a href="https://chat.openmake.cc">Live demo</a> ·
-  <a href="https://openmake.cc/en/docs/">Self-hosting guide</a> ·
-  <a href="https://openmake.cc/ko/">한국어</a> ·
-  <a href="https://openmake.cc/ja/">日本語</a> ·
+  <a href="https://bench.openmake.cc">Bench</a> ·
+  <a href="https://openmake.cc/en/docs/">Self-hosting guide</a><br/>
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.ja.md">日本語</a> ·
   <a href="README.zh-CN.md">简体中文</a>
 </p>
 
@@ -37,7 +38,7 @@ Every request flows through a lightweight **message pipeline** that applies the 
 
 | | |
 |---|---|
-| 🧠 **1 local model, routed per request** | `qwen3.6-35b-a3b` served via vLLM + LiteLLM, with a 262K context-fit safety net |
+| 🧠 **1 local model, routed per request** | `qwen3.8-27b` served via vLLM + LiteLLM, with a 262K context-fit safety net |
 | 🎛️ **Role-based model orchestration** | Assign a different model (local or BYOK external) per functional role; per-user + admin-global mappings, server-shared keys with token budgets |
 | 🤖 **Autonomous agents** | Manus-style multi-turn agent in a persistent Docker sandbox (shell · Python · browser · files), with human-in-the-loop approval |
 | 🔬 **Deep research** | Fan-out web search → source fetch → claim verification → cited synthesis |
@@ -46,6 +47,8 @@ Every request flows through a lightweight **message pipeline** that applies the 
 | 🧩 **22 built-in MCP tools** + external MCP servers | Each external server isolated in Docker (`--cap-drop ALL`, non-root, network policy) |
 | 👤 **Custom agents & skills** | Project-scoped personas (with optional per-agent model) + an auto-selectable skill library + 18 industry agents (100 specialists) |
 | 💬 **Discord gateway bot** | Optional workspace relaying Discord messages to the OpenAI-compatible API, with role/mention access control |
+| 🖥️ **Native clients** | **OpenMake Companion** (SwiftUI menu-bar app, macOS Apple Silicon) for local-folder agent work, **OpenMake Code** CLI (local bridge), and a SwiftUI iOS client in progress — chat itself stays in the web app |
+| 📊 **OpenMake Bench** | [bench.openmake.cc](https://bench.openmake.cc): blind pairwise model comparisons and a hardware fit score, signed in through the web SSO client; a model picked there applies to your model roles |
 | 🌐 **4-language UI** | 한국어 · English · 日本語 · 简体中文 (`next-intl`, cookie locale, browser auto-detect) |
 | 🔒 **Security-first** | JWT (HttpOnly), Google OAuth 2.0, RBAC, per-route rate limiting, SSRF guard, Audit ↔ Alert |
 
@@ -128,9 +131,10 @@ OpenMake separates **policy** (deciding *how* to answer) from **execution** (act
 
 **▸ Models & routing**
 - Local and external models share the provider-gated `message-pipeline` and tool loop; behavior is controlled by orthogonal axes (Model · Style · Mode · Custom Agent).
-- Self-hosted vLLM + LiteLLM (default `qwen3.6-35b-a3b`) with a context-fit safety net that protects output tokens and degrades gracefully on overflow.
+- Self-hosted vLLM + LiteLLM (default `qwen3.8-27b`) with a context-fit safety net that protects output tokens and degrades gracefully on overflow.
 - Bring-your-own external keys — **OpenRouter, NVIDIA NIM, Ollama** (local + cloud), all OpenAI-compatible (an Anthropic adapter is built into the provider abstraction) — AES-256-GCM encrypted at rest. **Guests use the default local model only** — external providers require sign-in.
 - **Role-based model orchestration** — assign a different model (local or BYOK external) to each functional role (`agent`, `judge`, `research`, `spawn`, `review`, `summary`) via Settings; admins set org-wide defaults and register server-shared external keys with per-key token budgets in an admin console. Resolution is fail-open (falls back to the local default on any failure). Model lists filter down to what is actually reachable and role-capable.
+- **External provider throttling** — per-provider concurrency limits with exponential back-off on 429 (honouring `Retry-After`), so a burst of Discussion or Deep Research fan-out does not get a BYOK key rate-limited. The UI's reasoning-effort setting (low / medium / high) is forwarded to OpenAI-compatible external providers as `reasoning_effort`; local models get sampling presets for thinking ON/OFF.
 - **Tail routing (opt-in, off by default)** — a lightweight gate scores each query's error likelihood; when it judges a query as *factual tail* (likely to be answered wrong, externally verifiable), `web_search` is deterministically forced on the first turn. Ships with a shadow mode (`TAIL_ROUTING_SHADOW_ENABLED`) that records gate decisions without changing behavior, so thresholds can be tuned on real traffic before `TAIL_ROUTING_STAGE2B_ENABLED` is switched on.
 
 **▸ Agents & research**
@@ -140,7 +144,7 @@ OpenMake separates **policy** (deciding *how* to answer) from **execution** (act
 - **Custom agents & skills** — project-scoped agents (claude.ai Projects equivalent) selectable directly from the composer, each optionally pinned to its own model, plus an auto-selectable skill library and 18 built-in industry agents (100 specialists).
 
 **▸ Tools & extensibility**
-- **MCP tool system** — 22 built-in tools (web search, fact-check, web scrape/map/crawl, image analysis, agent-task control, skill/agent/MCP git-ingest, …) plus external MCP servers, each isolated in Docker (`--cap-drop ALL`, non-root, `--memory`+`--memory-swap`, network policy, realpath-guarded mounts). Install servers from the MCP catalog in **Settings → Connectors**; a catalog-level **tool allowlist** keeps chat auto-exposure focused (a 39-tool server need not dump 39 schemas into every prompt) while REST execution and the explicit tool picker keep full access.
+- **MCP tool system** — 22 built-in tools (web search, fact-check, web scrape/map/crawl, image analysis, agent-task control, skill/agent/MCP git-ingest, …) plus external MCP servers, each isolated in Docker (`--cap-drop ALL`, non-root, `--memory`+`--memory-swap`, network policy, realpath-guarded mounts). Install servers from the MCP catalog in **Settings → Connectors** (seeded with Tavily, Sentry, Context7 and more; `{{env.KEY}}` secrets are passed as shell variable references, never baked into argv); a catalog-level **tool allowlist** keeps chat auto-exposure focused (a 39-tool server need not dump 39 schemas into every prompt) while REST execution and the explicit tool picker keep full access.
 - **NotebookLM grounding** — install the NotebookLM connector with your own Google session cookie (AES-256-GCM encrypted, injected only at spawn), then pin a notebook from the composer. The grounding prefix rides an LLM-only channel, so stored messages and sidebar titles stay clean, and the pin is scoped to one conversation.
 - **Artifacts** — live sandboxed iframe rendering, optional Docker code execution (Python / JS), a resizable side panel, and a separate-origin strict-CSP shared viewer for publishing. The OpenAI-compatible API returns artifacts as a `message.artifacts` extension, and `publish_artifacts: true` makes the server mint share links for API-key clients that cannot publish themselves.
 - **PDF / DOCX export** — any HTML artifact (chat or agent-task deliverable) exports to **PDF** via headless Chromium print (CJK fonts included); report artifacts keep their structured source data (`artifacts.source_data`), enabling high-fidelity **DOCX** generation with `python-docx`. Both conversions run one-shot in the Docker sandbox (`--network none`, `--cap-drop ALL`, memory/pids caps) behind owner-scoped rate-limited endpoints.
@@ -150,6 +154,8 @@ OpenMake separates **policy** (deciding *how* to answer) from **execution** (act
 
 **▸ Integrations**
 - **Discord gateway bot** (`apps/discord-bot`) — an optional standalone workspace that relays Discord messages to `/api/v1/chat/completions`, with per-user session isolation (`/reset`), role/mention access control, and API-key auth. Generated images and artifacts come back as real Discord file attachments (with share links), since Discord cannot render the API's relative paths or placeholders. Runs as its own PM2 process.
+- **OpenMake Bench** — [bench.openmake.cc](https://bench.openmake.cc) signs in through the API's web SSO client and reads the live-refreshed `/v1/models` list; the OpenAI-compatible API also offers a raw mode for benchmark clients.
+- **Native clients** — `apps/desktop-native` (OpenMake Companion, SwiftUI menu bar: folder linking, device status, exec approval, task-finished notifications, web deep links), `apps/cli` (OpenMake Code, the local bridge that runs agent tool calls on your own machine instead of the server sandbox), and `apps/ios` (SwiftUI client, in progress). All three share the Instrument design tokens with the web app.
 - **NotebookLM** — `GET /api/mcp/notebooklm/notebooks` backs the composer picker (per-user cache, upstream failures converged to `502 NOTEBOOKLM_UPSTREAM` so the UI can prompt a reconnect when the Google cookie expires).
 
 **▸ Security**
@@ -162,12 +168,13 @@ OpenMake separates **policy** (deciding *how* to answer) from **execution** (act
 | Layer | Technologies |
 |---|---|
 | **Backend** | Node.js (≥24), Express 5, TypeScript (strict, CommonJS), Zod, Winston |
-| **Frontend** | Next.js 16, React 19, Zustand 5, Tailwind CSS 4, `next-intl` |
+| **Frontend** | Next.js 16, React 19, Zustand 5, Tailwind CSS 4, `next-intl`; Instrument design system (cobalt primary · cyan secondary, IBM Plex Mono) |
 | **Database** | PostgreSQL via `pg` — raw, parameterized SQL (no ORM) |
-| **Realtime** | WebSocket (`ws`) streaming chat |
+| **Realtime** | WebSocket (`ws`) streaming chat with stream detach/resume — a backgrounded tab or app reconnects without losing the response |
 | **LLM backend** | vLLM + LiteLLM (OpenAI-compatible); `@anthropic-ai/sdk`, `openai` for external providers |
 | **Agents / Tools** | Model Context Protocol (`@modelcontextprotocol/sdk`), Docker-isolated sandboxes |
-| **Integrations** | Discord gateway bot (`discord.js`) — optional standalone workspace |
+| **Integrations** | Discord gateway bot (`discord.js`) — optional standalone workspace; OpenMake Bench via web SSO |
+| **Native clients** | SwiftUI (macOS Companion, iOS), Node CLI (`apps/cli`) sharing `packages/local-bridge-core` |
 | **Auth / Security** | `jsonwebtoken`, Google OAuth 2.0, Helmet, AES-256-GCM |
 | **Infra** | PM2 (API · web · Discord bot) + Docker (PostgreSQL/Redis, MCP / agent / artifact sandboxes) |
 | **Testing / CI** | Jest/ts-jest, Playwright, ESLint, GitHub Actions (CI Gate) |
@@ -371,10 +378,12 @@ openmake_llm/
 │   ├── web/          # Next.js + React frontend (the operating UI)
 │   ├── cli/          # OpenMake Code — local bridge CLI (run agent tasks in your own folder)
 │   │                 # private workspace: build from source, see apps/cli/README.md
+│   ├── desktop-native/ # OpenMake Companion — SwiftUI menu-bar app (macOS Apple Silicon)
+│   ├── ios/          # SwiftUI iOS client (in progress)
 │   ├── discord-bot/  # Optional Discord gateway bot (relays to /api/v1/chat/completions)
 │   └── legacy-web/   # Static asset host (e.g. /generated) — legacy SPA retired
 ├── db/               # init schema + migrations (+ rollbacks/) — read at runtime
-├── packages/         # shared-types, config, api-client (shared workspaces)
+├── packages/         # shared-types, api-contracts, config, api-client, local-bridge-core (shared workspaces)
 ├── infra/            # Dockerfiles & compose (mcp-runtime, task-runtime, artifact-viewer, egress-proxy)
 ├── scripts/          # setup/ (gen-env.mjs) + host setup for the LLM backend — vLLM/LiteLLM
 │                     # systemd units, serve scripts, litellm.config.yaml, Caddyfile, diagnostics

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,146 @@
+<h1 align="center">OpenMake LLM</h1>
+
+<p align="center">
+  <strong>面向开源权重模型与自带密钥（BYOK）模型的开源、本地优先、自托管 AI 工作台。</strong><br/>
+  vLLM/LiteLLM 推理 · 自主 AI 智能体 · MCP 工具 · 深度研究 · Docker 沙箱
+</p>
+
+<p align="center">
+  <a href="https://github.com/openmake/openmake_llm/actions/workflows/ci.yml"><img src="https://github.com/openmake/openmake_llm/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
+  <img src="https://img.shields.io/github/package-json/v/openmake/openmake_llm?label=version&color=green" alt="Version" />
+  <img src="https://img.shields.io/badge/node-%3E%3D24%20%3C25-brightgreen.svg" alt="Node >=24 <25" />
+  <img src="https://img.shields.io/badge/TypeScript-strict-3178c6.svg" alt="TypeScript strict" />
+  <img src="https://img.shields.io/badge/Next.js-16-black.svg" alt="Next.js 16" />
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="https://openmake.cc/en/">官网</a> ·
+  <a href="https://chat.openmake.cc">在线演示</a> ·
+  <a href="https://bench.openmake.cc">模型评测（Bench）</a> ·
+  <a href="https://openmake.cc/en/docs/">自托管指南</a>
+</p>
+
+> 本文是英文 [README.md](README.md) 的简体中文摘要。以英文版为准；若两者不一致，以代码为准。
+> 官网与自托管指南目前提供英语、韩语、日语；应用界面已内置简体中文。
+
+---
+
+## 概览
+
+**OpenMake LLM** 是一个运行在你自己硬件上的自托管 AI 助手。它通过 **vLLM** 提供本地模型，前置 **LiteLLM 代理**（OpenAI 兼容接口），并把*同一套*抽象路由到你用自己密钥注册的外部服务商（**OpenRouter、NVIDIA NIM、Ollama** 本地/云端，均为 OpenAI 兼容；同时内置 Anthropic 适配器）。默认情况下，数据不会离开你的机器。
+
+每个请求都经过一条轻量的**消息管线**：服务商门控、安全与语言策略、提示词与工具组装，全程不需要额外的 LLM 路由往返。本地模型与外部模型共用同一条执行路径和常开的工具循环。行为只由正交的几个维度控制：**模型 · 风格 · 模式开关 · 自定义智能体**，而不是不透明的预设。进阶用户可以启用**按角色的模型编排**，为每个功能角色（智能体、评审、研究、并行子智能体、复审、思考摘要）分别指定本地或外部模型。在聊天之外，它还提供自主智能体、深度研究管线和 MCP 工具系统，全部置于 JWT 认证与基于角色的访问控制之后。
+
+> **单机设计：**应用（API + Web）由 **PM2** 运行；有状态依赖（PostgreSQL / Redis）以及被沙箱化的智能体 / MCP / 产物进程运行在 **Docker** 中以实现隔离。
+
+默认模型是通过 vLLM 提供的 Qwen3（`qwen3.8-27b`，上下文 262K）。任何 OpenAI 兼容端点都可以接入：Ollama、vLLM、LiteLLM，以及遵循同一接口的国内模型 API。
+
+**一览**
+
+| | |
+|---|---|
+| 🧠 **1 个本地模型，按请求路由** | `qwen3.8-27b` 经 vLLM + LiteLLM 提供，带 262K 上下文适配保护 |
+| 🎛️ **按角色的模型编排** | 为每个功能角色指定不同模型（本地或 BYOK 外部）；支持按用户与管理员全局映射、带令牌预算的服务器共享密钥 |
+| 🤖 **自主智能体** | Manus 风格的多轮智能体运行在持久化 Docker 沙箱中（shell · Python · 浏览器 · 文件），高风险步骤需人工批准 |
+| 🔬 **深度研究** | 扇出式网页搜索 → 抓取来源 → 声明核验 → 带引用的综合 |
+| 📊 **报告管线** | 报告类请求由模型只产出数据，服务端按固定设计模板渲染为 HTML 产物，可导出 **PDF/DOCX** |
+| 📓 **NotebookLM 接地** | 直接在输入框中把你的 Google NotebookLM 笔记本固定为对话上下文 |
+| 🧩 **22 个内置 MCP 工具** + 外部 MCP 服务器 | 每个外部服务器在 Docker 中隔离运行（`--cap-drop ALL`、非 root、网络策略） |
+| 👤 **自定义智能体与技能** | 项目级人设（可为每个智能体单独指定模型）+ 自动选取的技能库 + 18 个行业智能体（100 位专家） |
+| 💬 **Discord 网关机器人** | 可选工作区，把 Discord 消息转发到 OpenAI 兼容 API，支持角色/提及访问控制 |
+| 🌐 **4 种界面语言** | 한국어 · English · 日本語 · 简体中文（`next-intl`，Cookie 记录语言，浏览器自动检测） |
+| 🔒 **安全优先** | JWT（HttpOnly）、Google OAuth 2.0、RBAC、按路由限流、SSRF 防护、审计 ↔ 告警 |
+
+---
+
+## 主要特性
+
+**▸ 模型与路由**
+- 本地与外部模型共用带服务商门控的消息管线与工具循环。
+- 自托管 vLLM + LiteLLM，带上下文适配保护：溢出时先裁剪输入、再降低输出上限，仍不够则返回 HTTP 413 并记录审计与告警，而不是静默截断。
+- 自带外部密钥（OpenRouter、NVIDIA NIM、Ollama），静态存储使用 AES-256-GCM 加密。**访客只能使用默认本地模型**，外部服务商需要登录。
+- **按角色的模型编排**：在设置中为 `agent`、`judge`、`research`、`spawn`、`review`、`summary` 分别指定模型；管理员可设置组织默认值并注册带预算的共享密钥。解析失败时回退到本地默认模型。
+
+**▸ 智能体与研究**
+- **自主智能体任务**：在持久化 Docker 沙箱中跨多轮工具调用完成目标，高风险步骤等待人工批准；可产出 Excel（.xlsx）与 PDF（含 CJK 字体）；无法完成时如实标记 `[GOAL_INCOMPLETE]`，而不是假装完成。任务可保存为模板或设为定期执行。
+- **深度研究**：分解问题、抓取来源、交叉核验声明、输出带引用的报告，管线运行过程全程可见。
+- **讨论模式（Discussion）**：按主题挑选两个以上专家智能体，给予相同证据并行运行后综合。默认关闭，按消息开启。
+- **自定义智能体与技能**：项目级智能体可直接从输入框选择，每个可绑定自己的模型；另有自动选取的技能库和 18 个内置行业智能体。
+
+**▸ 工具与扩展**
+- **MCP 工具系统**：22 个内置工具（网页搜索、事实核查、网页抓取/映射/爬取、图像分析、智能体任务控制等）加外部 MCP 服务器，每个服务器在 Docker 中隔离运行。在 **设置 → 连接器** 中从目录安装；目录级工具白名单避免把几十个 schema 全部塞进每个提示词。
+- **产物（Artifacts）**：沙箱 iframe 实时渲染、可选的 Docker 代码执行（Python / JS）、独立源且严格 CSP 的共享查看器。
+- **PDF / DOCX 导出**：任何 HTML 产物可经无头 Chromium 导出 PDF（含 CJK 字体）；报告产物保留结构化数据，可用 `python-docx` 生成高保真 DOCX。转换在 `--network none` 的一次性沙箱中完成。
+- **记忆与指令**、**思考过程时间线**、**多语言界面**（韩、英、日、简中）。
+
+**▸ 集成**
+- **Discord 网关机器人**（`apps/discord-bot`）：把 Discord 消息转发到 `/api/v1/chat/completions`，按用户隔离会话，生成的图片与产物作为真实附件返回。
+- **NotebookLM**：输入框中的笔记本选择器，Google Cookie 过期时提示重新连接。
+
+**▸ 安全**
+- HttpOnly Cookie 中的 JWT、Google OAuth 2.0、RBAC、按用户与按路由限流、SSRF 防护、Helmet 头，以及统一的审计 ↔ 告警管线。
+
+---
+
+## 快速开始
+
+支持平台：**Linux** 与 **macOS**（Intel 与 Apple Silicon）。Windows 请在 **WSL2**（Ubuntu）中运行同一条命令。
+
+### 一键安装
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/openmake/openmake_llm/main/install.sh | bash
+```
+
+无需事先克隆。安装脚本检测到自己不在仓库内时，会把源码拉取到 `~/openmake_llm`（可用 `OMK_HOME=...` 覆盖，`OMK_REF=...` 指定分支或标签）并在那里继续执行。也可以用传统方式：
+
+```bash
+git clone https://github.com/openmake/openmake_llm.git
+cd openmake_llm
+./install.sh
+```
+
+安装脚本会检查工具链（Node 24、Docker、PM2，缺失的会尽量在不使用 `sudo` 的情况下安装），生成带随机密钥的 `.env`，安装依赖，启动 PostgreSQL + Redis，应用全部迁移，构建两个应用，用 PM2 启动并等待 `/health`。结束时会打印 Web 地址和生成的管理员密码。
+
+它只会问一个问题：使用哪个 OpenAI 兼容的 LLM 端点（Ollama / OpenRouter / 自定义 / 稍后决定）。要跳过全部提示：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/openmake/openmake_llm/main/install.sh | bash -s -- --yes
+
+./install.sh --yes                                    # 先用占位 LLM，稍后在 .env 中填写
+./install.sh --yes \
+  --llm-base-url https://openrouter.ai/api/v1 \
+  --llm-api-key  sk-or-... \
+  --llm-model    qwen/qwen3-235b-a22b
+```
+
+重复运行 `./install.sh` 是安全的，它会修复而不是覆盖。常用参数：`--skip-docker`（自行运行 Postgres/Redis）、`--skip-build`、`--no-start`、`--force-env`，以及端口覆盖：
+
+```bash
+./install.sh --yes --postgres-port 55432 --redis-port 56379
+```
+
+> 从中国大陆访问 GitHub 与在线演示可能较慢。推荐以自托管为主要路径；安装脚本只依赖 GitHub 与 npm。
+
+### 前置条件
+
+Node.js 24、Docker、PostgreSQL、Redis，以及一个 OpenAI 兼容的模型端点。安装脚本会处理前三项。手动安装步骤、更新已安装实例、测试与数据库迁移，请参阅英文 README 的 [Getting Started](README.md#getting-started)。
+
+---
+
+## 相关链接
+
+- 在线演示：https://chat.openmake.cc（访客只能使用一个本地模型）
+- 模型评测 Bench：https://bench.openmake.cc（盲测成对比较模型，并给出与你硬件的适配分数；与演示共用账号，目前仅提供托管版本，源码尚未公开）
+- 自托管指南：https://openmake.cc/en/docs/
+- 每周开发日志（含出问题的那几周）：https://openmake.cc/en/blog/
+
+## 参与贡献
+
+欢迎贡献。请使用 [Conventional Commits](https://www.conventionalcommits.org/)，在功能/修复分支上工作并向 `main` 提交 PR，遵循 TypeScript strict、Zod 输入校验、Winston 日志、**仅使用参数化原生 SQL**（不用 ORM）以及配置外置的约定。提交 PR 前请确认 `npm run lint` 与 `npm test` 通过，数据库变更附带迁移文件，新环境变量写入 `.env.example`。详见英文 README 的 [Contributing](README.md#contributing)。
+
+## 许可证
+
+基于 **MIT 许可证** 发布，详见 [LICENSE](LICENSE)。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -391,6 +391,15 @@ CI 在每次推送和 pull request 上运行单一的 **CI Gate**（Test → Bui
 
 ---
 
+## 联系我们
+
+| | |
+|---|---|
+| 一般咨询与自托管支持 | support@openmake.cc |
+| 维护者 | riskpw@openmake.cc · rockyhan@openmake.cc |
+
+---
+
 ## 许可证
 
 基于 **MIT 许可证** 发布 —— 详见 [LICENSE](LICENSE)。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <strong>面向开源权重模型与自带密钥（BYOK）模型的开源、本地优先、自托管 AI 工作台。</strong><br/>
-  vLLM/LiteLLM 推理 · 自主 AI 智能体 · MCP 工具 · 深度研究 · Docker 沙箱
+  vLLM/LiteLLM 推理 · 自主 AI 智能体 · MCP 工具 · 深度研究 · Docker 沙箱。
 </p>
 
 <p align="center">
@@ -15,27 +15,27 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> ·
   <a href="https://openmake.cc/en/">官网</a> ·
   <a href="https://chat.openmake.cc">在线演示</a> ·
-  <a href="https://bench.openmake.cc">模型评测（Bench）</a> ·
-  <a href="https://openmake.cc/en/docs/">自托管指南</a>
+  <a href="https://bench.openmake.cc">Bench</a> ·
+  <a href="https://openmake.cc/en/docs/">自托管指南</a><br/>
+  <a href="README.md">English</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <strong>简体中文</strong>
 </p>
-
-> 本文是英文 [README.md](README.md) 的简体中文摘要。以英文版为准；若两者不一致，以代码为准。
-> 官网与自托管指南目前提供英语、韩语、日语；应用界面已内置简体中文。
 
 ---
 
+> 本文是英文 [README.md](README.md) 的简体中文翻译。若内容不一致，以英文版和代码为准。
+
 ## 概览
 
-**OpenMake LLM** 是一个运行在你自己硬件上的自托管 AI 助手。它通过 **vLLM** 提供本地模型，前置 **LiteLLM 代理**（OpenAI 兼容接口），并把*同一套*抽象路由到你用自己密钥注册的外部服务商（**OpenRouter、NVIDIA NIM、Ollama** 本地/云端，均为 OpenAI 兼容；同时内置 Anthropic 适配器）。默认情况下，数据不会离开你的机器。
+**OpenMake LLM** 是一个运行在你自己硬件上的自托管 AI 助手。它通过 **vLLM** 提供本地模型，前置 **LiteLLM 代理**（OpenAI 兼容），并把*同一套*抽象路由到你用自己密钥注册的外部服务商（**OpenRouter、NVIDIA NIM、Ollama** 本地/云端，均为 OpenAI 兼容；同时内置 Anthropic 适配器）。因此默认情况下，你的数据始终留在自己的机器上。
 
-每个请求都经过一条轻量的**消息管线**：服务商门控、安全与语言策略、提示词与工具组装，全程不需要额外的 LLM 路由往返。本地模型与外部模型共用同一条执行路径和常开的工具循环。行为只由正交的几个维度控制：**模型 · 风格 · 模式开关 · 自定义智能体**，而不是不透明的预设。进阶用户可以启用**按角色的模型编排**，为每个功能角色（智能体、评审、研究、并行子智能体、复审、思考摘要）分别指定本地或外部模型。在聊天之外，它还提供自主智能体、深度研究管线和 MCP 工具系统，全部置于 JWT 认证与基于角色的访问控制之后。
+每个请求都流经一条轻量的**消息管线**，它完成服务商门控、安全与语言策略、提示词与工具组装，全程*无需*额外的 LLM 路由往返。随后本地模型与外部模型共用同一条执行路径和常开的工具循环。当前的 **`ExecutionPlanBuilder`** 有意保持精简：当选中了某个已授权的自定义智能体时，它才加载该智能体。行为只由正交的几个维度控制——**模型 · 风格 · 模式开关 · 自定义智能体**，而不是不透明的预设。进阶用户还可以更进一步，启用**按角色的模型编排**——为每个功能角色（智能体、评审、研究、并行子智能体、复审、思考摘要）分别指定本地或外部模型。除了聊天之外，它还加入了自主智能体、深度研究管线以及 MCP 工具系统，全部置于 JWT 认证与基于角色的访问控制之后。
 
-> **单机设计：**应用（API + Web）由 **PM2** 运行；有状态依赖（PostgreSQL / Redis）以及被沙箱化的智能体 / MCP / 产物进程运行在 **Docker** 中以实现隔离。
-
-默认模型是通过 vLLM 提供的 Qwen3（`qwen3.8-27b`，上下文 262K）。任何 OpenAI 兼容端点都可以接入：Ollama、vLLM、LiteLLM，以及遵循同一接口的国内模型 API。
+> **单机设计：**应用（API + Web）由 **PM2** 运行，而有状态依赖（PostgreSQL / Redis）以及被沙箱化的智能体 / MCP / 产物进程运行在 **Docker** 中以实现隔离。
 
 **一览**
 
@@ -45,56 +45,158 @@
 | 🎛️ **按角色的模型编排** | 为每个功能角色指定不同模型（本地或 BYOK 外部）；支持按用户与管理员全局映射、带令牌预算的服务器共享密钥 |
 | 🤖 **自主智能体** | Manus 风格的多轮智能体运行在持久化 Docker 沙箱中（shell · Python · 浏览器 · 文件），高风险步骤需人工批准 |
 | 🔬 **深度研究** | 扇出式网页搜索 → 抓取来源 → 声明核验 → 带引用的综合 |
-| 📊 **报告管线** | 报告类请求由模型只产出数据，服务端按固定设计模板渲染为 HTML 产物，可导出 **PDF/DOCX** |
-| 📓 **NotebookLM 接地** | 直接在输入框中把你的 Google NotebookLM 笔记本固定为对话上下文 |
+| 📊 **报告管线** | 报告类请求由模型产出数据，服务端通过固定设计模板把它渲染为 HTML 产物，可导出 **PDF/DOCX** |
+| 📓 **NotebookLM 接地** | 直接在输入框中把你的某个 Google NotebookLM 笔记本固定为对话上下文 |
 | 🧩 **22 个内置 MCP 工具** + 外部 MCP 服务器 | 每个外部服务器在 Docker 中隔离运行（`--cap-drop ALL`、非 root、网络策略） |
 | 👤 **自定义智能体与技能** | 项目级人设（可为每个智能体单独指定模型）+ 自动选取的技能库 + 18 个行业智能体（100 位专家） |
 | 💬 **Discord 网关机器人** | 可选工作区，把 Discord 消息转发到 OpenAI 兼容 API，支持角色/提及访问控制 |
+| 🖥️ **原生客户端** | **OpenMake Companion**（SwiftUI 菜单栏应用，macOS Apple Silicon）用于本地文件夹的智能体工作、**OpenMake Code** CLI（本地桥接），以及开发中的 SwiftUI iOS 客户端——聊天本身仍留在 Web 应用中 |
+| 📊 **OpenMake Bench** | [bench.openmake.cc](https://bench.openmake.cc)：盲测成对比较模型并给出硬件适配分数，通过 Web SSO 客户端登录；在此选定的模型会应用到你的模型角色 |
 | 🌐 **4 种界面语言** | 한국어 · English · 日本語 · 简体中文（`next-intl`，Cookie 记录语言，浏览器自动检测） |
 | 🔒 **安全优先** | JWT（HttpOnly）、Google OAuth 2.0、RBAC、按路由限流、SSRF 防护、审计 ↔ 告警 |
+
+---
+
+## 界面截图
+
+> 对话标题、笔记本名称和账户邮箱已做模糊处理，其余全部是运行中的真实应用。
+
+**聊天工作台** —— 五项工作区导航、模型选择器、响应风格，以及通过斜杠调用的技能：
+
+<p align="center">
+  <img src="assets/screenshot-chat.png" alt="Chat workspace" width="920" />
+</p>
+
+| 模式菜单 —— 讨论 / 思考 / 深度研究 / 网页 / 智能体 / 图像 / 产物 / 结构化 | NotebookLM 选择器 —— 把某个笔记本固定为对话上下文 |
+|---|---|
+| ![Composer mode menu](assets/screenshot-composer-modes.png) | ![NotebookLM notebook picker](assets/screenshot-notebook-picker.png) |
+
+**智能体任务** —— 自主多轮运行，带实时进度、令牌计量、定期计划和可复用的任务模板：
+
+<p align="center">
+  <img src="assets/screenshot-agent-tasks.png" alt="Agent task management" width="920" />
+</p>
+
+| 连接器 —— 外部 MCP 服务器，每个都在 Docker 中隔离 | 模型角色管理 —— 全局的角色→模型映射 |
+|---|---|
+| ![Settings → Connectors](assets/screenshot-settings.png) | ![Model roles admin](assets/screenshot-model-roles.png) |
+
+**技能库** —— 带工具绑定的可复用清单，可从 Git 导入或由模型生成：
+
+<p align="center">
+  <img src="assets/screenshot-skill-library.png" alt="Skill Library" width="920" />
+</p>
+
+**多语言界面（한국어 · English · 日本語 · 简体中文）** —— 在设置中切换界面语言，或让它跟随你的浏览器（`Accept-Language`）。AI 的响应语言则独立地跟随消息本身的语言：
+
+<p align="center">
+  <img src="assets/i18n-demo.gif" alt="Interface language switching demo (ko / en / ja / zh)" width="920" />
+</p>
+
+---
+
+## 架构
+
+OpenMake 把**策略**（决定*如何*回答）与**执行**（真正调用模型）分离开来——类似 SQL 的规划器/执行器分层。这两层被刻意保持相互独立。
+
+```
+                          WebSocket / REST
+                                  │
+                    ┌─────────────▼─────────────┐
+  Query ───────────►│      message-pipeline     │  请求处理
+                    │                           │  · 服务商门控
+                    └─────────────┬─────────────┘  · 安全与语言策略
+                                  │                · 提示词与工具组装
+                                  │                · 加载已授权的自定义智能体
+                    ┌─────────────▼─────────────┐
+                    │ streamFromExternalProvider│  单一路径——本地与外部一视同仁
+                    │   (always-on tool loop)   │  · 最多 5 轮工具调用
+                    └─────────────┬─────────────┘  · 特殊模式在更早阶段拦截
+                                  │
+                    ┌─────────────▼─────────────┐
+                    │       LLMClient.chat      │  执行——逐次调用
+                    │  (context-fit safety net) │  · 令牌估算 → 裁剪 → 上限
+                    └─────────────┬─────────────┘  · 溢出 → 413 + 审计 + 告警
+                                  │
+           vLLM serve → LiteLLM proxy (OpenAI-compatible endpoint)
+```
+
+- **单一执行路径** —— 原先按策略划分的一层（generate-verify、agent-loop、thinking、direct）已被移除：`message-pipeline` 把本地与外部模型统一送入一条 `streamFromExternalProvider` 分发路径，并带一个常开的 MCP 工具循环。`ExecutionPlanBuilder` 现在只负责加载已授权的自定义智能体。讨论（Discussion）与深度研究（Deep Research）仍是在分发前被拦截的独立模式。
+- **上下文适配保护** —— 进入时会估算提示词令牌（含图像）；若超出有效的 **262K** 窗口，则先裁剪输入 → 再调低 `max_tokens` → 极端情况下抛出 `ContextOverflowError`，返回 **HTTP 413**，并附带一条审计记录和一条自动 webhook 告警。
+- **用户自定义（4 个正交维度）** —— **模型**（选择器） · **风格**（Concise / Default / Verbose） · **模式**（讨论 / 思考 / 深度研究 / 网页 / 智能体任务） · **自定义指令与智能体**。系统提示词的组装顺序为：`memory + custom-instructions + style`。
+- **按角色的模型编排** —— 每个会调用 LLM 的子系统都通过单一的角色注册表解析其模型，并带一条 fail-open 的回退链：按用户映射 → 管理员设置的全局值（DB） → 全局环境变量 → 本地默认。按角色的外部模型运行在用户自己的 BYOK 密钥上，或（对全局角色）运行在服务器共享的运营密钥上（带每日/每月令牌预算）。自定义智能体也可以绑定自己的模型。
+- **跨对话记忆** —— 明确保存的长期记忆会被注入系统提示词；一个隐私开关允许用户在单个会话中排除它们。
+- **思考展示（Claude 网页版风格）** —— 开启思考模式时，推理流会渲染为一条实时时间线；一个专门的 `summary` 角色模型生成一行标题（流式的临时版 → 最终版），推理内容与标题都会被持久化，因此重新打开对话时时间线会被还原。
 
 ---
 
 ## 主要特性
 
 **▸ 模型与路由**
-- 本地与外部模型共用带服务商门控的消息管线与工具循环。
-- 自托管 vLLM + LiteLLM，带上下文适配保护：溢出时先裁剪输入、再降低输出上限，仍不够则返回 HTTP 413 并记录审计与告警，而不是静默截断。
-- 自带外部密钥（OpenRouter、NVIDIA NIM、Ollama），静态存储使用 AES-256-GCM 加密。**访客只能使用默认本地模型**，外部服务商需要登录。
-- **按角色的模型编排**：在设置中为 `agent`、`judge`、`research`、`spawn`、`review`、`summary` 分别指定模型；管理员可设置组织默认值并注册带预算的共享密钥。解析失败时回退到本地默认模型。
+- 本地与外部模型共用带服务商门控的 `message-pipeline` 与工具循环；行为由正交的几个维度控制（模型 · 风格 · 模式 · 自定义智能体）。
+- 自托管 vLLM + LiteLLM（默认 `qwen3.8-27b`），带上下文适配保护：保护输出令牌，并在溢出时优雅降级。
+- 自带外部密钥 —— **OpenRouter、NVIDIA NIM、Ollama**（本地 + 云端），均为 OpenAI 兼容（Anthropic 适配器已内置于服务商抽象中）—— 静态存储使用 AES-256-GCM 加密。**访客只能使用默认本地模型**，外部服务商需要登录。
+- **按角色的模型编排** —— 在设置中为每个功能角色（`agent`、`judge`、`research`、`spawn`、`review`、`summary`）指定不同模型（本地或 BYOK 外部）；管理员在管理控制台中设置组织级默认值，并注册带按密钥令牌预算的服务器共享外部密钥。解析是 fail-open 的（任何失败都回退到本地默认）。模型列表会筛减到实际可达且具备角色能力的那些。
+- **外部服务商限流** —— 按服务商设置并发上限，遇到 429 时指数退避（并遵循 `Retry-After`），使得讨论或深度研究扇出的突发流量不会导致某个 BYOK 密钥被限流。界面的推理强度设置（low / medium / high）会作为 `reasoning_effort` 转发给 OpenAI 兼容的外部服务商；本地模型则针对思考开/关获得采样预设。
+- **尾部路由（可选，默认关闭）** —— 一个轻量门控为每个请求评估出错概率；当它判定某请求属于*事实性尾部*（很可能被答错、且可外部验证）时，会在第一轮确定性地强制开启 `web_search`。它自带一个影子模式（`TAIL_ROUTING_SHADOW_ENABLED`），只记录门控决策而不改变行为，因此可以在真实流量上先调好阈值，再打开 `TAIL_ROUTING_STAGE2B_ENABLED`。
 
 **▸ 智能体与研究**
-- **自主智能体任务**：在持久化 Docker 沙箱中跨多轮工具调用完成目标，高风险步骤等待人工批准；可产出 Excel（.xlsx）与 PDF（含 CJK 字体）；无法完成时如实标记 `[GOAL_INCOMPLETE]`，而不是假装完成。任务可保存为模板或设为定期执行。
-- **深度研究**：分解问题、抓取来源、交叉核验声明、输出带引用的报告，管线运行过程全程可见。
-- **讨论模式（Discussion）**：按主题挑选两个以上专家智能体，给予相同证据并行运行后综合。默认关闭，按消息开启。
-- **自定义智能体与技能**：项目级智能体可直接从输入框选择，每个可绑定自己的模型；另有自动选取的技能库和 18 个内置行业智能体。
+- **自主智能体任务** —— 一个 Manus 风格的智能体在**持久化 Docker 沙箱**中跨多轮工具调用（shell、Python、浏览器、文件、规划工具）追求某个目标，高风险步骤需人工批准。它会记录文件附件、通过视觉通道注入图像、产出包括 **Excel（.xlsx）** 和 **PDF**（含韩文/CJK 字体）在内的交付物，并在未达成时如实上报（`[GOAL_INCOMPLETE]` 标记 + 目标评审），而不是虚假地标为“完成”。任务可保存为**可复用模板**或设为**定期计划**。
+- **深度研究** —— 扇出式网页搜索 → 抓取来源 → 声明核验 → 带引用的综合。
+- **报告管线** —— 对于报告类请求（“研究 X 并写一份报告”），模型**只产出数据（JSON）**；服务端通过固定设计模板把它渲染为 HTML 产物（*由渲染器掌控设计*——一致的编排式版面、KPI 卡片、表格、无依赖 SVG 图表、带引用的来源；所有模型字符串都被转义）。自成一体的研究型报告请求会自动委派给智能体任务以获得更多研究轮次，同一约定也适用于智能体任务的交付物。失败时是 fail-open 的：没有有效数据块时，回复会以普通聊天的形式流式返回。
+- **自定义智能体与技能** —— 项目级智能体（相当于 claude.ai 的 Projects）可直接从输入框选择，每个都可选择性地绑定自己的模型，另有一个可自动选取的技能库和 18 个内置行业智能体（100 位专家）。
 
 **▸ 工具与扩展**
-- **MCP 工具系统**：22 个内置工具（网页搜索、事实核查、网页抓取/映射/爬取、图像分析、智能体任务控制等）加外部 MCP 服务器，每个服务器在 Docker 中隔离运行。在 **设置 → 连接器** 中从目录安装；目录级工具白名单避免把几十个 schema 全部塞进每个提示词。
-- **产物（Artifacts）**：沙箱 iframe 实时渲染、可选的 Docker 代码执行（Python / JS）、独立源且严格 CSP 的共享查看器。
-- **PDF / DOCX 导出**：任何 HTML 产物可经无头 Chromium 导出 PDF（含 CJK 字体）；报告产物保留结构化数据，可用 `python-docx` 生成高保真 DOCX。转换在 `--network none` 的一次性沙箱中完成。
-- **记忆与指令**、**思考过程时间线**、**多语言界面**（韩、英、日、简中）。
+- **MCP 工具系统** —— 22 个内置工具（网页搜索、事实核查、网页抓取/映射/爬取、图像分析、智能体任务控制、技能/智能体/MCP 的 git 摄取等）加上外部 MCP 服务器，每个都在 Docker 中隔离运行（`--cap-drop ALL`、非 root、`--memory`+`--memory-swap`、网络策略、经 realpath 守护的挂载）。在 **设置 → 连接器** 中从 MCP 目录安装服务器（已预置 Tavily、Sentry、Context7 等；`{{env.KEY}}` 形式的密钥以 shell 变量引用方式传入，绝不写死进 argv）；目录级的**工具白名单**让聊天中的自动暴露保持聚焦（一个含 39 个工具的服务器无需把 39 份 schema 塞进每个提示词），而 REST 执行和显式工具选择器仍保留完整访问权。
+- **NotebookLM 接地** —— 用你自己的 Google 会话 Cookie 安装 NotebookLM 连接器（AES-256-GCM 加密，仅在启动时注入），随后在输入框中固定某个笔记本。接地前缀只走一条 LLM 专用通道，因此存储的消息和侧栏标题保持干净，且该固定只作用于单个对话。
+- **产物（Artifacts）** —— 沙箱化 iframe 实时渲染、可选的 Docker 代码执行（Python / JS）、可调整大小的侧栏面板，以及一个用于发布的独立源、严格 CSP 的共享查看器。OpenAI 兼容 API 以 `message.artifacts` 扩展返回产物，`publish_artifacts: true` 会让服务端为那些自身无法发布的 API-key 客户端铸造分享链接。
+- **PDF / DOCX 导出** —— 任何 HTML 产物（聊天或智能体任务交付物）都可经无头 Chromium 打印导出为 **PDF**（含 CJK 字体）；报告产物保留其结构化源数据（`artifacts.source_data`），从而可用 `python-docx` 生成高保真 **DOCX**。两种转换都在 Docker 沙箱中一次性运行（`--network none`、`--cap-drop ALL`、内存/pids 上限），位于按所有者限流的端点之后。
+- **记忆与指令** —— 持久的跨对话记忆（带按会话的启用开关）以及常开的自定义指令。
+- **思考展示** —— Claude 网页版风格的推理时间线，带一行实时标题（由专门的摘要模型生成），并在重新打开时持久化还原。
+- **多语言界面** —— 韩语、英语、日语、简体中文，基于 `next-intl`（Cookie 记录语言、浏览器自动检测、按语言的日期/数字格式化）。
 
 **▸ 集成**
-- **Discord 网关机器人**（`apps/discord-bot`）：把 Discord 消息转发到 `/api/v1/chat/completions`，按用户隔离会话，生成的图片与产物作为真实附件返回。
-- **NotebookLM**：输入框中的笔记本选择器，Google Cookie 过期时提示重新连接。
+- **Discord 网关机器人**（`apps/discord-bot`）—— 一个可选的独立工作区，把 Discord 消息转发到 `/api/v1/chat/completions`，带按用户的会话隔离（`/reset`）、角色/提及访问控制和 API-key 认证。生成的图片与产物会作为真实的 Discord 文件附件返回（并带分享链接），因为 Discord 无法渲染该 API 的相对路径或占位符。它作为自己独立的 PM2 进程运行。
+- **OpenMake Bench** —— [bench.openmake.cc](https://bench.openmake.cc) 通过该 API 的 Web SSO 客户端登录，并读取实时刷新的 `/v1/models` 列表；OpenAI 兼容 API 还为基准测试客户端提供了一个 raw 模式。
+- **原生客户端** —— `apps/desktop-native`（OpenMake Companion，SwiftUI 菜单栏：文件夹链接、设备状态、执行批准、任务完成通知、Web 深链）、`apps/cli`（OpenMake Code，本地桥接，在你自己的机器上而非服务器沙箱中运行智能体的工具调用），以及 `apps/ios`（SwiftUI 客户端，开发中）。三者都与 Web 应用共享 Instrument 设计令牌。
+- **NotebookLM** —— `GET /api/mcp/notebooklm/notebooks` 支撑输入框中的选择器（按用户缓存，上游失败统一收敛为 `502 NOTEBOOKLM_UPSTREAM`，因此当 Google Cookie 过期时界面可以提示重新连接）。
 
 **▸ 安全**
 - HttpOnly Cookie 中的 JWT、Google OAuth 2.0、RBAC、按用户与按路由限流、SSRF 防护、Helmet 头，以及统一的审计 ↔ 告警管线。
 
 ---
 
+## 技术栈
+
+| 层 | 技术 |
+|---|---|
+| **后端** | Node.js（≥24）、Express 5、TypeScript（strict、CommonJS）、Zod、Winston |
+| **前端** | Next.js 16、React 19、Zustand 5、Tailwind CSS 4、`next-intl`；Instrument 设计系统（钴蓝主色 · 青色辅色，IBM Plex Mono） |
+| **数据库** | 经 `pg` 使用 PostgreSQL —— 原生、参数化 SQL（无 ORM） |
+| **实时** | WebSocket（`ws`）流式聊天，支持流的分离/恢复 —— 被切到后台的标签页或应用重连后不会丢失响应 |
+| **LLM 后端** | vLLM + LiteLLM（OpenAI 兼容）；外部服务商使用 `@anthropic-ai/sdk`、`openai` |
+| **智能体 / 工具** | Model Context Protocol（`@modelcontextprotocol/sdk`）、Docker 隔离沙箱 |
+| **集成** | Discord 网关机器人（`discord.js`）—— 可选的独立工作区；经 Web SSO 的 OpenMake Bench |
+| **原生客户端** | SwiftUI（macOS Companion、iOS）、Node CLI（`apps/cli`），共用 `packages/local-bridge-core` |
+| **认证 / 安全** | `jsonwebtoken`、Google OAuth 2.0、Helmet、AES-256-GCM |
+| **基础设施** | PM2（API · web · Discord bot） + Docker（PostgreSQL/Redis，MCP / 智能体 / 产物沙箱） |
+| **测试 / CI** | Jest/ts-jest、Playwright、ESLint、GitHub Actions（CI Gate） |
+
+---
+
 ## 快速开始
 
-支持平台：**Linux** 与 **macOS**（Intel 与 Apple Silicon）。Windows 请在 **WSL2**（Ubuntu）中运行同一条命令。
+支持平台：**Linux** 与 **macOS**（Intel 与 Apple Silicon）。
 
-### 一键安装
+> 从中国大陆访问 GitHub 与在线演示可能较慢。推荐以自托管为主要路径；安装脚本只依赖 GitHub 与 npm。
+
+### 安装（一条命令）
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/openmake/openmake_llm/main/install.sh | bash
 ```
 
-无需事先克隆。安装脚本检测到自己不在仓库内时，会把源码拉取到 `~/openmake_llm`（可用 `OMK_HOME=...` 覆盖，`OMK_REF=...` 指定分支或标签）并在那里继续执行。也可以用传统方式：
+无需克隆 —— 当安装脚本检测到自己运行在仓库之外时，会把源码拉取到 `~/openmake_llm`（用 `OMK_HOME=...` 覆盖；`OMK_REF=...` 指定分支或标签）并在那里重新进入自身。通过管道运行时仍会经由 `/dev/tty` 交互式地向你提问；在非终端环境（CI）中，提示会自动批准。更喜欢经典方式？它的用法与以前完全一致：
 
 ```bash
 git clone https://github.com/openmake/openmake_llm.git
@@ -102,11 +204,14 @@ cd openmake_llm
 ./install.sh
 ```
 
-安装脚本会检查工具链（Node 24、Docker、PM2，缺失的会尽量在不使用 `sudo` 的情况下安装），生成带随机密钥的 `.env`，安装依赖，启动 PostgreSQL + Redis，应用全部迁移，构建两个应用，用 PM2 启动并等待 `/health`。结束时会打印 Web 地址和生成的管理员密码。
+在 **Windows** 上，请在 **WSL2**（Ubuntu）里运行同一条命令 —— 安装脚本会检测到原生 Windows shell，并转而打印 WSL2 的安装步骤。
 
-它只会问一个问题：使用哪个 OpenAI 兼容的 LLM 端点（Ollama / OpenRouter / 自定义 / 稍后决定）。要跳过全部提示：
+就这样。安装脚本会检查你的工具链（Node 24、Docker、PM2 —— 缺什么装什么，并尽量不使用 `sudo`），生成一份带全新随机密钥的 `.env`，安装依赖，启动 PostgreSQL + Redis，应用全部迁移，构建两个应用，用 PM2 启动它们，并等待 `/health`。最后它会打印你的 Web 地址和生成的管理员密码。
+
+它只问一个问题 —— 使用哪个 OpenAI 兼容的 LLM 端点（Ollama / OpenRouter / 自定义 / 稍后决定）。要跳过所有提示：
 
 ```bash
+# 参数也可以直接透传给这条一键命令：
 curl -fsSL https://raw.githubusercontent.com/openmake/openmake_llm/main/install.sh | bash -s -- --yes
 
 ./install.sh --yes                                    # 先用占位 LLM，稍后在 .env 中填写
@@ -116,31 +221,176 @@ curl -fsSL https://raw.githubusercontent.com/openmake/openmake_llm/main/install.
   --llm-model    qwen/qwen3-235b-a22b
 ```
 
-重复运行 `./install.sh` 是安全的，它会修复而不是覆盖。常用参数：`--skip-docker`（自行运行 Postgres/Redis）、`--skip-build`、`--no-start`、`--force-env`，以及端口覆盖：
+重复运行 `./install.sh` 是安全的 —— 它会修复而不是覆盖。常用参数：`--skip-docker`（你自己运行 Postgres/Redis）、`--skip-build`、`--no-start`、`--force-env`，以及下面的端口覆盖。参见 `./install.sh --help`。
+
+已经在默认端口上运行着 Postgres 或 Redis？把容器挪开，而不是去争抢 5432/6379 —— 这些端口会写入 `.env`，`openmake_llm.sh` 也会把它们读回来：
 
 ```bash
 ./install.sh --yes --postgres-port 55432 --redis-port 56379
 ```
 
-> 从中国大陆访问 GitHub 与在线演示可能较慢。推荐以自托管为主要路径；安装脚本只依赖 GitHub 与 npm。
+在 macOS 上，安装脚本可与 Docker Desktop、OrbStack 或 **Colima**（`brew install colima docker docker-compose` —— 无界面、无 GUI）配合工作。如果 Homebrew 的 compose 插件没有向 docker CLI 注册，安装脚本会替你把 `cliPluginsExtraDirs` 加进 `~/.docker/config.json`。
 
-### 前置条件
+### 更新已安装的实例
 
-Node.js 24、Docker、PostgreSQL、Redis，以及一个 OpenAI 兼容的模型端点。安装脚本会处理前三项。手动安装步骤、更新已安装实例、测试与数据库迁移，请参阅英文 README 的 [Getting Started](README.md#getting-started)。
+```bash
+./openmake_llm.sh update            # git pull（仅 ff）→ 构建 → 迁移 → 重启
+./openmake_llm.sh update --yes      # 跳过迁移确认（非交互）
+```
+
+`update` 会拒绝去动一个含未提交改动或本地提交已分叉的工作树 —— 它绝不覆盖你的修改。如果没有拉到任何新内容，它会跳过重新部署（用 `--force` 强制重新部署）。以 tarball 方式安装（无 git）的实例应改为重新运行 `install.sh`，它会就地修复。
+
+要把安装固定到某个发行版而不是 `main`，在一键命令上设置 `OMK_REF`：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/openmake/openmake_llm/main/install.sh \
+  | OMK_REF=v1.31.1 bash -s -- --yes
+```
+
+### 前置条件（由安装脚本处理）
+
+- **git** —— 在全新的 macOS 上，第一次 `git clone` 会触发 Xcode Command Line Tools 的安装对话框；批准它一次即可（或者改为把源码下载为 zip）。`install.sh` 本身能容忍缺失 git（构建元数据会回退为 `unknown`）
+- **Node.js** `>=24 <25` —— 通过 `mise`/`fnm`/`nvm`、Homebrew，或在都不存在时通过本地的 `~/.openmake/node` tarball 来提供
+- **Docker** —— PostgreSQL/Redis 以及 MCP/智能体沙箱所必需。在 Linux 上安装脚本会提议运行官方的 `get.docker.com` 脚本；在 macOS 上你需要 Docker Desktop 或 OrbStack。注意：Docker Desktop 的**首次启动**可能会请求 GUI 批准（特权助手），并可能超出安装脚本约 60 秒的守护进程等待时间 —— 若如此，请等 Docker 完成启动，然后重新运行 `./install.sh`（可安全重复）
+- 一个 OpenAI 兼容的 LLM 端点：本地的 **vLLM + LiteLLM** 栈、**Ollama**，或某个外部服务商密钥
+
+### 手动搭建
+
+如果你更愿意自己动手连线，`install.sh` 就是这些步骤的一份可读记录：
+
+```bash
+npm install
+node scripts/setup/gen-env.mjs        # 生成含随机密钥的最小化 .env
+docker compose --env-file .env -f infra/docker-compose.yml up -d postgres redis
+npx ts-node apps/api/src/data/migrations/cli.ts migrate
+npm run build && pm2 start ecosystem.config.js
+```
+
+> `--env-file .env` 不是可选的：Compose 会相对于 compose 文件所在目录（`infra/`）来解析它默认的 `.env`，因此不加它，`POSTGRES_PASSWORD` 就会为空并导致启动失败。
+
+`gen-env.mjs` 只写入启动所需的键。`.env.example` 才是完整参考 —— 需要时从中复制可选区块（OAuth、网页搜索、MCP 沙箱、Discord 机器人）：
+
+| 变量 | 用途 |
+|---|---|
+| `PORT` | API 端口（默认 `52416`） |
+| `DATABASE_URL` | PostgreSQL 连接字符串（密码必须与 `POSTGRES_PASSWORD` 一致） |
+| `JWT_SECRET` | JWT 签名密钥（≥32 字符） |
+| `API_KEY_PEPPER` | API-key 哈希 pepper —— 生产环境必需 |
+| `TOKEN_ENCRYPTION_KEY` | 用于外部服务商凭据的 AES-256-GCM 密钥（恰好 64 位十六进制） |
+| `ADMIN_PASSWORD` | 引导管理员账户的密码 —— 生产环境必需 |
+| `LLM_BASE_URL` / `LLM_API_KEY` / `LLM_DEFAULT_MODEL` | LiteLLM 代理端点、主密钥、默认模型 |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth（可选） |
+
+### 运行
+
+日常运维通过 `openmake_llm.sh` 进行，它会在 Linux 和 macOS 上依次拉起三层（PostgreSQL → Redis → 应用）：
+
+```bash
+./openmake_llm.sh start     # 全部启动，然后流式输出日志
+./openmake_llm.sh status    # 每一层的端口 + docker + PM2 状态
+./openmake_llm.sh logs      # 实时 PM2 日志
+./openmake_llm.sh health    # GET /health
+./openmake_llm.sh deploy    # 构建 + 迁移 + 重启（应用代码改动）
+./openmake_llm.sh stop      # 反序关停
+```
+
+或者直接驱动各个部件：
+
+```bash
+# 开发
+npm run dev                 # API + 前端一起
+npm run dev:api             # 仅后端（ts-node）
+npm run dev:frontend-next   # 仅前端（next dev）
+
+# 生产
+npm run build               # 后端 + 前端
+npm start                   # node apps/api/dist/server.js
+```
+
+要在重启后依然存活，请把 PM2 注册到你的 init 系统 —— `pm2 startup`（会打印一条待运行的命令：macOS 上是 `launchd`，Linux 上是 `systemd`），然后 `pm2 save`。
+
+### 测试与 lint
+
+```bash
+npm test                    # Jest 单元测试（apps/api）
+npm run test:e2e            # Playwright（chromium + webkit）
+npm run lint                # ESLint
+```
+
+> `apps/api` 的单元测试被 git 忽略（仅本地存在），因此在全新克隆上 `npm test` 会报告 “0 matches” —— 这是预期行为，而非安装损坏。CI 也以同样的方式跳过这道关。
+
+### 数据库迁移
+
+`db/migrations/` 中的文件会在**启动时自动应用** —— 在 `db/init/` 基线 schema 之后，待应用的迁移会在一把 PostgreSQL advisory lock 下运行（对多实例启动进行串行化），失败则快速失败。设置 `DB_AUTO_MIGRATE=false` 可退出该行为，改用 CLI 手动运行：
+
+```bash
+npx ts-node apps/api/src/data/migrations/cli.ts status    # 显示待应用项
+npx ts-node apps/api/src/data/migrations/cli.ts migrate   # 应用
+```
+
+回滚脚本位于 `db/migrations/rollbacks/`（不在正向迁移的扫描范围内）。
 
 ---
 
-## 相关链接
+## 项目结构
 
-- 在线演示：https://chat.openmake.cc（访客只能使用一个本地模型）
-- 模型评测 Bench：https://bench.openmake.cc（盲测成对比较模型，并给出与你硬件的适配分数；与演示共用账号，目前仅提供托管版本，源码尚未公开）
-- 自托管指南：https://openmake.cc/en/docs/
-- 每周开发日志（含出问题的那几周）：https://openmake.cc/en/blog/
+```
+openmake_llm/
+├── apps/
+│   ├── api/          # Express 5 + TypeScript API 服务器（strict、CommonJS）
+│   │   └── src/
+│   │       ├── routes/ controllers/ services/   # REST + 业务逻辑
+│   │       ├── chat/                            # ExecutionPlanBuilder、分类器、提示词
+│   │       ├── agents/                          # 18 个行业智能体、路由器、讨论引擎
+│   │       ├── llm/ providers/ cluster/         # LLM 客户端、服务商抽象、节点路由
+│   │       ├── mcp/                             # MCP 工具路由器、外部客户端、Docker 沙箱
+│   │       ├── sockets/                         # WebSocket 聊天处理器
+│   │       ├── auth/ security/ middlewares/     # JWT/OAuth、SSRF 防护、限流
+│   │       └── data/                            # PostgreSQL（原生 SQL）、迁移、仓储
+│   ├── web/          # Next.js + React 前端（实际操作界面）
+│   ├── cli/          # OpenMake Code —— 本地桥接 CLI（在你自己的文件夹中运行智能体任务）
+│   │                 # 私有工作区：从源码构建，参见 apps/cli/README.md
+│   ├── desktop-native/ # OpenMake Companion —— SwiftUI 菜单栏应用（macOS Apple Silicon）
+│   ├── ios/          # SwiftUI iOS 客户端（开发中）
+│   ├── discord-bot/  # 可选的 Discord 网关机器人（转发到 /api/v1/chat/completions）
+│   └── legacy-web/   # 静态资源宿主（例如 /generated）—— 旧版 SPA 已退役
+├── db/               # init schema + migrations（+ rollbacks/）—— 运行时读取
+├── packages/         # shared-types、api-contracts、config、api-client、local-bridge-core（共享工作区）
+├── infra/            # Dockerfile 与 compose（mcp-runtime、task-runtime、artifact-viewer、egress-proxy）
+├── scripts/          # setup/（gen-env.mjs） + LLM 后端的主机搭建 —— vLLM/LiteLLM
+│                     # systemd units、serve 脚本、litellm.config.yaml、Caddyfile、诊断
+├── tests/            # Playwright E2E
+├── install.sh        # 一键安装脚本（Linux/macOS）：工具链 → .env → DB → 构建 → PM2
+├── openmake_llm.sh   # 服务管理器：start/stop/restart/deploy/status/logs/health
+└── ecosystem.config.js  # PM2 进程定义（API、Next 前端、可选 Discord 机器人）
+```
+
+**运行中的服务器实际需要什么：**构建好的 `apps/api/dist` + `apps/web/.next`、`db/`（启动路径会应用 `db/init/`，迁移 CLI 会相对工作目录解析 `db/migrations/`），以及供 Docker 隔离沙箱使用的 `infra/`。`scripts/` 和 `tests/` *不会*被任何运行时代码加载 —— 但 `scripts/vllm/` 和 `scripts/caddy/` 是你在搭建或重建推理后端时拷贝到 GPU 主机上的部署产物，所以请把它们随仓库一起保留。
+
+构建、迁移和 CI 的入口位于别处：构建在每个工作区的 `package.json` 中，迁移在 `apps/api/src/data/migrations/cli.ts` 中，CI 在 `.github/workflows/` 中。
+
+---
 
 ## 参与贡献
 
-欢迎贡献。请使用 [Conventional Commits](https://www.conventionalcommits.org/)，在功能/修复分支上工作并向 `main` 提交 PR，遵循 TypeScript strict、Zod 输入校验、Winston 日志、**仅使用参数化原生 SQL**（不用 ORM）以及配置外置的约定。提交 PR 前请确认 `npm run lint` 与 `npm test` 通过，数据库变更附带迁移文件，新环境变量写入 `.env.example`。详见英文 README 的 [Contributing](README.md#contributing)。
+欢迎贡献。请：
+
+- 使用 [Conventional Commits](https://www.conventionalcommits.org/) —— `feat`、`fix`、`refactor`、`docs`、`test`、`chore`。
+- 在功能/修复分支上工作，并向 `main` 提交 PR。
+- 遵循代码约定：TypeScript strict 模式、用 Zod 做输入校验、用 Winston 记日志、**仅使用参数化的原生 SQL**（不用 ORM），以及配置外置（不硬编码模型、魔法数字或内联提示词）。
+
+**提交 PR 之前：**
+
+- [ ] `npm run lint` 通过
+- [ ] `npm test` 通过
+- [ ] 数据库 schema 变更附带迁移文件（无序号冲突）
+- [ ] 新的环境变量已记入 `.env.example`
+- [ ] 界面改动附带截图；安全改动说明其影响
+
+CI 在每次推送和 pull request 上运行单一的 **CI Gate**（Test → Build → Size → Lint）。
+
+---
 
 ## 许可证
 
-基于 **MIT 许可证** 发布，详见 [LICENSE](LICENSE)。
+基于 **MIT 许可证** 发布 —— 详见 [LICENSE](LICENSE)。


### PR DESCRIPTION
영어 README 를 1.44.0 기준으로 보완하고, 같은 내용을 세 언어 완역본으로 추가합니다.

## 영어 README 보완
- 기본 로컬 모델명 `qwen3.6-35b-a3b` → `qwen3.8-27b` (2026-09-02 교체분, #759 와 동일)
- **네이티브 클라이언트** 항목 신설 — Companion(SwiftUI 메뉴바, macOS Apple Silicon), OpenMake Code CLI(로컬 브리지), iOS(진행 중)
- **OpenMake Bench** 를 한눈에 보기·통합 절에 반영 — 웹 SSO 클라이언트로 로그인, `/v1/models` 라이브 갱신, 선택한 모델을 역할 설정에 적용
- 외부 provider 동시성 스로틀·429 백오프·`reasoning_effort` 전달 (#717 #723 #725)
- MCP 카탈로그 시드(Tavily·Sentry·Context7)와 `{{env.KEY}}` 비밀 전달 방식 (#714 #737 #741)
- WebSocket 스트림 detach/resume (#754), Instrument 디자인 시스템 (#746), `packages/local-bridge-core`·`api-contracts`
- 상단 링크에 Bench 와 3개 언어 README 추가

## 신규 파일
`README.ko.md` · `README.ja.md` · `README.zh-CN.md`

- 절·표·코드 블록 구조가 영어판과 동일합니다 (h2 9개, h3 7개, 표 39행, 코드 26블록).
- 각 문서 상단에 영어판과 코드가 기준이라고 명시했습니다.
- 헤더 링크는 각 언어 사이트(`/ko/`, `/ja/`)를 가리키며 200 응답을 확인했습니다.

#759 와 모델명 수정이 겹칩니다. #759 를 먼저 머지하면 이 브랜치를 리베이스하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5f9xfbqpaATar1aTm7M9H