### PR TITLE
fix: 이메일 주소를 openmake.cc 도메인으로 통일

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -487,7 +487,7 @@ DATABASE_URL=postgresql://openmake:your_password@localhost:5432/openmake_llm  # 
 # 미설정이면 계정을 만들지 않는다 (저장소에 고정 자격증명을 두지 않기 위함).
 # ADMIN_INITIAL_PASSWORD=change_me_before_first_boot
 # ADMIN_INITIAL_USERNAME=admin
-# ADMIN_INITIAL_EMAIL=admin@openmake.ai
+# ADMIN_INITIAL_EMAIL=support@openmake.cc
 # docker compose 파일 경로. openmake_llm.sh / docker compose 가 -f 로 참조.
 # 미설정 시 레포의 infra/docker-compose.yml 사용 (openmake_llm.sh 기본값). 절대경로로 override 가능.
 # COMPOSE_FILE=/path/to/docker-compose.yml
@@ -1490,7 +1490,7 @@ FS_READ_MAX_BYTES=100000
 # 미설정 시 푸시 비활성 (앱 정상 동작, 알림만 미발송).
 VAPID_PUBLIC_KEY=
 VAPID_PRIVATE_KEY=
-VAPID_SUBJECT=mailto:admin@openmake.ai
+VAPID_SUBJECT=mailto:support@openmake.cc
 
 # Web Push 구독 endpoint 호스트 허용목록(suffix, 콤마) — 기본: fcm.googleapis.com, android.googleapis.com,
 # push.services.mozilla.com, notify.windows.com, push.apple.com. `*` 면 허용목록 비활성(https·SSRF 가드만).

--- a/apps/api/src/__tests__/contracts/auth-contract.test.ts
+++ b/apps/api/src/__tests__/contracts/auth-contract.test.ts
@@ -12,7 +12,7 @@ import { expectContract, validateContract } from './contract-validator';
 
 const sampleUser: PublicUser = {
     id: 'u1',
-    email: 'riskpw@gmail.com',
+    email: 'riskpw@openmake.cc',
     role: 'user',
     created_at: '2026-08-16T00:00:00.000Z',
     is_active: true,

--- a/apps/api/src/__tests__/contracts/contract-validator.test.ts
+++ b/apps/api/src/__tests__/contracts/contract-validator.test.ts
@@ -7,7 +7,7 @@ import { success } from '../../utils/api-response';
 
 const sampleUser = {
     id: 'u1',
-    email: 'riskpw@gmail.com',
+    email: 'riskpw@openmake.cc',
     role: 'user',
     created_at: '2026-08-16T00:00:00.000Z',
     is_active: true,

--- a/apps/api/src/__tests__/contracts/mobile-auth-contract.test.ts
+++ b/apps/api/src/__tests__/contracts/mobile-auth-contract.test.ts
@@ -12,7 +12,7 @@ import { expectContract } from './contract-validator';
 
 const sampleUser: PublicUser = {
     id: 'u1',
-    email: 'riskpw@gmail.com',
+    email: 'riskpw@openmake.cc',
     role: 'user',
     created_at: '2026-08-16T00:00:00.000Z',
     is_active: true,
@@ -142,7 +142,7 @@ describe('모바일 인증 (iOS 축 2)', () => {
             mockAuthService.login.mockResolvedValue({ success: true, token: 'at', user: sampleUser });
             const r = await request(app)
                 .post('/api/auth/login')
-                .send({ email: 'riskpw@gmail.com', password: 'pw', returnRefreshToken: true });
+                .send({ email: 'riskpw@openmake.cc', password: 'pw', returnRefreshToken: true });
             expect(r.status).toBe(200);
             expect(r.body.data.refreshToken).toBe('new-refresh-token');
             expect(cookieSpies.setTokenCookie).not.toHaveBeenCalled();
@@ -154,7 +154,7 @@ describe('모바일 인증 (iOS 축 2)', () => {
             mockAuthService.login.mockResolvedValue({ success: true, token: 'at', user: sampleUser });
             const r = await request(app)
                 .post('/api/auth/login')
-                .send({ email: 'riskpw@gmail.com', password: 'pw' });
+                .send({ email: 'riskpw@openmake.cc', password: 'pw' });
             expect(r.status).toBe(200);
             expect(r.body.data.refreshToken).toBeUndefined();
             expect(cookieSpies.setTokenCookie).toHaveBeenCalled();

--- a/apps/api/src/__tests__/contracts/sessions-contract.test.ts
+++ b/apps/api/src/__tests__/contracts/sessions-contract.test.ts
@@ -64,7 +64,7 @@ describe('Chat Sessions 응답 계약', () => {
     beforeEach(() => {
         currentUser = {
             id: 'u1',
-            email: 'riskpw@gmail.com',
+            email: 'riskpw@openmake.cc',
             role: 'user',
             created_at: '2026-08-16T00:00:00.000Z',
             is_active: true,

--- a/apps/api/src/__tests__/contracts/sso-client-contract.test.ts
+++ b/apps/api/src/__tests__/contracts/sso-client-contract.test.ts
@@ -11,7 +11,7 @@ import { expectContract } from './contract-validator';
 
 const sampleUser: PublicUser = {
     id: 'u1',
-    email: 'riskpw@gmail.com',
+    email: 'riskpw@openmake.cc',
     role: 'user',
     created_at: '2026-08-16T00:00:00.000Z',
     is_active: true,

--- a/apps/api/src/__tests__/contracts/user-agents-contract.test.ts
+++ b/apps/api/src/__tests__/contracts/user-agents-contract.test.ts
@@ -10,7 +10,7 @@ jest.mock('../../auth/middleware', () => ({
     requireAuth: (req: Request, _res: Response, next: NextFunction) => {
         req.user = {
             id: 'u1',
-            email: 'riskpw@gmail.com',
+            email: 'riskpw@openmake.cc',
             role: 'user',
             created_at: '2026-08-16T00:00:00.000Z',
             is_active: true,

--- a/apps/api/src/__tests__/services/agent-task/share-document.test.ts
+++ b/apps/api/src/__tests__/services/agent-task/share-document.test.ts
@@ -23,7 +23,7 @@ const steps = [
     { step_number: 2, step_type: 'tool_result', tool_name: 'file_ops', content: '기록됨: /private/tmp/openmake-task-workspaces/abc/workspace/src/a.ts' },
     { step_number: 3, step_type: 'plan', content: 'PLAN_SHOULD_NOT_APPEAR' },
     { step_number: 4, step_type: 'steering', content: 'STEERING_SHOULD_NOT_APPEAR' },
-    { step_number: 5, step_type: 'judge', content: '판정: achieved — riskpw@gmail.com 확인' },
+    { step_number: 5, step_type: 'judge', content: '판정: achieved — riskpw@openmake.cc 확인' },
     { step_number: 6, step_type: 'diff', content: 'diff --git a/src/a.ts b/src/a.ts\n+const n: number = 1;' },
     { step_number: 7, step_type: 'artifact', content: '{"id":"rep","kind":"html","title":"주간 리포트","content":"<h1>MARKUP_BODY_SHOULD_NOT_APPEAR</h1>","validation":{"checked":true},"sourceData":{"rows":["SOURCEDATA_SHOULD_NOT_APPEAR"]}}' },
     { step_number: 9, step_type: 'artifact', content: '{"id":"rule","kind":"markdown","title":"pre-commit 규칙","content":"# 규칙\\n커밋 전 테스트를 돌린다."}' },
@@ -43,7 +43,7 @@ describe('buildShareDocument — 선별(allowlist)', () => {
         ['workspace 절대경로', '/private/tmp/openmake-task-workspaces'],
         ['홈 디렉토리', '/Users/openmake_mac'],
         ['자격증명 값', 'sk-abcdef1234567890abcd'],
-        ['이메일', 'riskpw@gmail.com'],
+        ['이메일', 'riskpw@openmake.cc'],
         ['마크업 아티팩트 본문', 'MARKUP_BODY_SHOULD_NOT_APPEAR'],
         ['리포트 sourceData', 'SOURCEDATA_SHOULD_NOT_APPEAR'],
     ])('%s 은 문서 어디에도 없다', (_label, needle) => {

--- a/apps/api/src/__tests__/user-manager-auth-lookup.test.ts
+++ b/apps/api/src/__tests__/user-manager-auth-lookup.test.ts
@@ -28,7 +28,7 @@ const USER_ROW = {
     id: '92',
     username: 'Rocky',
     password_hash: 'hash-placeholder',
-    email: 'rockyhan@iexcello.com',
+    email: 'rockyhan@openmake.cc',
     role: 'user',
     is_active: true,
     created_at: '2026-07-01T00:00:00Z',
@@ -55,12 +55,12 @@ describe('UserManager 계정 조회·비밀번호 변경', () => {
 
     describe('getUserByEmail', () => {
         test('email 일치 + username 폴백으로 조회해야 한다 (username 변경 계정의 OAuth 로그인 차단 방지)', async () => {
-            await manager.getUserByEmail('rockyhan@iexcello.com');
+            await manager.getUserByEmail('rockyhan@openmake.cc');
             const lookup = queries.find(q => q.sql.trimStart().startsWith('SELECT * FROM users'));
             expect(lookup).toBeDefined();
             expect(lookup!.sql).toContain('email = $1');
             expect(lookup!.sql).toContain('username = $1');
-            expect(lookup!.params).toEqual(['rockyhan@iexcello.com']);
+            expect(lookup!.params).toEqual(['rockyhan@openmake.cc']);
         });
 
         test('username 폴백은 email 이 빈 행만 인정하고 결정적으로 1행을 선택해야 한다 (계정 탈취 차단)', async () => {
@@ -74,10 +74,10 @@ describe('UserManager 계정 조회·비밀번호 변경', () => {
         });
 
         test('username≠email 계정도 email 컬럼 값으로 반환해야 한다', async () => {
-            const user = await manager.getUserByEmail('rockyhan@iexcello.com');
+            const user = await manager.getUserByEmail('rockyhan@openmake.cc');
             expect(user).not.toBeNull();
             expect(user!.id).toBe('92');
-            expect(user!.email).toBe('rockyhan@iexcello.com');
+            expect(user!.email).toBe('rockyhan@openmake.cc');
         });
 
         test('email 컬럼이 NULL 인 레거시 행은 username 으로 폴백한다', async () => {

--- a/apps/api/src/__tests__/utils/redact.test.ts
+++ b/apps/api/src/__tests__/utils/redact.test.ts
@@ -68,7 +68,7 @@ describe('redactText — 자격증명', () => {
     });
 
     test('이메일을 가린다', () => {
-        expect(redactText('riskpw@gmail.com 계정')).toBe('<email> 계정');
+        expect(redactText('riskpw@openmake.cc 계정')).toBe('<email> 계정');
     });
 });
 

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -179,7 +179,7 @@ export const envSchema = z
         GITHUB_TOKEN: z.string().default(''),
         VAPID_PUBLIC_KEY: z.string().default(''),
         VAPID_PRIVATE_KEY: z.string().default(''),
-        VAPID_SUBJECT: z.string().default('mailto:admin@openmake.ai'),
+        VAPID_SUBJECT: z.string().default('mailto:support@openmake.cc'),
         APNS_KEY_ID: z.string().default(''),
         APNS_TEAM_ID: z.string().default(''),
         APNS_PRIVATE_KEY: z.string().default(''),

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -244,7 +244,7 @@ const DEFAULT_CONFIG: EnvConfig = {
     // VAPID
     vapidPublicKey: '',
     vapidPrivateKey: '',
-    vapidSubject: 'mailto:admin@openmake.ai',
+    vapidSubject: 'mailto:support@openmake.cc',
     operatorWebhookUrl: '',
     operatorWebhookUrlCritical: '',
     operatorWebhookUrlWarning: '',

--- a/apps/ios/OpenMakeApp/App/LumenComponents.swift
+++ b/apps/ios/OpenMakeApp/App/LumenComponents.swift
@@ -250,7 +250,7 @@ struct DesignSystemShowcase: View {
             if showDrawer {
                 LumenDrawer(
                     sessions: [],
-                    email: "hello@openmake.cc",
+                    email: "support@openmake.cc",
                     onDismiss: { showDrawer = false },
                     onNewChat: { showDrawer = false },
                     onAgentTasks: { showDrawer = false },

--- a/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/ContractRoundTripTests.swift
+++ b/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/ContractRoundTripTests.swift
@@ -21,16 +21,16 @@ final class ContractRoundTripTests: XCTestCase {
 
     func testLoginEnvelopeDecodesDateTimeMeta() throws {
         // meta.timestamp 는 format: date-time → Date 매핑 — OpenMakeJSON 전략 없이는 실패 (PoC 발견 ②)
-        let json = #"{"success":true,"data":{"success":true,"token":"at","user":{"id":"u1","email":"riskpw@gmail.com","role":"user","created_at":"2026-08-16T00:00:00.000Z","is_active":true}},"meta":{"timestamp":"2026-08-16T00:00:00.000Z"}}"#.data(using: .utf8)!
+        let json = #"{"success":true,"data":{"success":true,"token":"at","user":{"id":"u1","email":"riskpw@openmake.cc","role":"user","created_at":"2026-08-16T00:00:00.000Z","is_active":true}},"meta":{"timestamp":"2026-08-16T00:00:00.000Z"}}"#.data(using: .utf8)!
         let login = try OpenMakeJSON.decoder().decode(
             Operations.post_sol_api_sol_auth_sol_login.Output.Ok.Body.jsonPayload.self,
             from: json)
-        XCTAssertEqual(login.data.user?.email, "riskpw@gmail.com")
+        XCTAssertEqual(login.data.user?.email, "riskpw@openmake.cc")
     }
 
     func testMobileExchangeEnvelopeDecodes() throws {
         // 축 2 신설 표면 — POST /api/auth/mobile/exchange 200
-        let json = #"{"success":true,"data":{"token":"at","refreshToken":"rt","user":{"id":"u1","email":"riskpw@gmail.com","role":"user","created_at":"2026-08-16T00:00:00.000Z","is_active":true}},"meta":{"timestamp":"2026-08-16T00:00:00.000Z"}}"#.data(using: .utf8)!
+        let json = #"{"success":true,"data":{"token":"at","refreshToken":"rt","user":{"id":"u1","email":"riskpw@openmake.cc","role":"user","created_at":"2026-08-16T00:00:00.000Z","is_active":true}},"meta":{"timestamp":"2026-08-16T00:00:00.000Z"}}"#.data(using: .utf8)!
         let payload = try OpenMakeJSON.decoder().decode(
             Operations.post_sol_api_sol_auth_sol_mobile_sol_exchange.Output.Ok.Body.jsonPayload.self,
             from: json)

--- a/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/OpenMakeClientTests.swift
+++ b/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/OpenMakeClientTests.swift
@@ -60,7 +60,7 @@ final class OpenMakeClientTests: XCTestCase {
     private var store: InMemoryTokenStore!
     private var client: OpenMakeClient!
 
-    private static let userJSON = #"{"id":"u1","email":"riskpw@gmail.com","role":"user","created_at":"2026-08-16T00:00:00.000Z","is_active":true}"#
+    private static let userJSON = #"{"id":"u1","email":"riskpw@openmake.cc","role":"user","created_at":"2026-08-16T00:00:00.000Z","is_active":true}"#
     private static let meta = #"{"timestamp":"2026-08-16T00:00:00.000Z"}"#
 
     override func setUp() {
@@ -99,8 +99,8 @@ final class OpenMakeClientTests: XCTestCase {
         MockURLProtocol.script("/api/auth/login", .init(status: 200, json:
             #"{"success":true,"data":{"success":true,"token":"at-1","refreshToken":"rt-1","user":\#(Self.userJSON)},"meta":\#(Self.meta)}"#))
 
-        let user = try await client.login(email: "riskpw@gmail.com", password: "pw")
-        XCTAssertEqual(user.email, "riskpw@gmail.com")
+        let user = try await client.login(email: "riskpw@openmake.cc", password: "pw")
+        XCTAssertEqual(user.email, "riskpw@openmake.cc")
         XCTAssertEqual(store.load(), AuthTokens(access: "at-1", refresh: "rt-1"))
 
         // CSRF Double-Submit 규약: 사전 인증 POST 에 부트스트랩 토큰 헤더 동봉

--- a/db/init/004-admin-user.sh
+++ b/db/init/004-admin-user.sh
@@ -9,7 +9,7 @@
 # 필요 환경변수 (infra/docker-compose.yml 이 .env 에서 전달):
 #   ADMIN_INITIAL_PASSWORD   미설정 시 계정을 만들지 않고 건너뛴다
 #   ADMIN_INITIAL_USERNAME   기본 admin
-#   ADMIN_INITIAL_EMAIL      기본 admin@openmake.ai
+#   ADMIN_INITIAL_EMAIL      기본 support@openmake.cc
 set -euo pipefail
 
 if [ -z "${ADMIN_INITIAL_PASSWORD:-}" ]; then
@@ -20,7 +20,7 @@ fi
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" \
   -v username="${ADMIN_INITIAL_USERNAME:-admin}" \
-  -v email="${ADMIN_INITIAL_EMAIL:-admin@openmake.ai}" \
+  -v email="${ADMIN_INITIAL_EMAIL:-support@openmake.cc}" \
   -v password="$ADMIN_INITIAL_PASSWORD" <<'SQL'
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       # 초기 관리자 계정 (004-admin-user.sh). 미설정 시 계정을 만들지 않는다.
       ADMIN_INITIAL_PASSWORD: ${ADMIN_INITIAL_PASSWORD:-}
       ADMIN_INITIAL_USERNAME: ${ADMIN_INITIAL_USERNAME:-admin}
-      ADMIN_INITIAL_EMAIL: ${ADMIN_INITIAL_EMAIL:-admin@openmake.ai}
+      ADMIN_INITIAL_EMAIL: ${ADMIN_INITIAL_EMAIL:-support@openmake.cc}
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:

--- a/install.sh
+++ b/install.sh
@@ -914,7 +914,7 @@ summary() {
     fi
     echo ""
     # 로그인 식별자는 email 이다 (auth.schema.ts loginSchema — username 필드는 없음).
-    echo "  로그인    ${admin_email:-admin@openmake.local}   ← 이메일로 로그인합니다"
+    echo "  로그인    ${admin_email:-support@openmake.cc}   ← 이메일로 로그인합니다"
     echo "  비밀번호  ${admin_pass:-<.env 의 ADMIN_PASSWORD 참조>}"
     printf "  %s첫 로그인 후 비밀번호를 바꾸세요. 비밀번호는 .env 에 평문으로 저장됩니다.%s\n" "$C_DIM" "$C_RESET"
     echo ""

--- a/scripts/setup/gen-env.mjs
+++ b/scripts/setup/gen-env.mjs
@@ -21,7 +21,7 @@
  * 입력(환경변수 — install.sh 가 주입, 미지정 시 기본값):
  *   OMK_PORT(52416) OMK_WEB_PORT(3000) OMK_POSTGRES_PORT(5432) OMK_REDIS_PORT(6379)
  *   OMK_LLM_BASE_URL OMK_LLM_API_KEY OMK_LLM_MODEL
- *   OMK_ADMIN_USERNAME(admin) OMK_ADMIN_EMAIL(admin@openmake.local)
+ *   OMK_ADMIN_USERNAME(admin) OMK_ADMIN_EMAIL(support@openmake.cc)
  *
  * 출력: 마지막 줄에 `GENERATED=1` 또는 `REPAIRED=<n>` 또는 `UNCHANGED=0` (install.sh 파싱용)
  * ==============================================================================
@@ -64,7 +64,7 @@ const WEB_PORT = env('OMK_WEB_PORT', '3000');
 const PG_PORT = env('OMK_POSTGRES_PORT', '5432');
 const REDIS_PORT = env('OMK_REDIS_PORT', '6379');
 const ADMIN_USERNAME = env('OMK_ADMIN_USERNAME', 'admin');
-const ADMIN_EMAIL = env('OMK_ADMIN_EMAIL', 'admin@openmake.local');
+const ADMIN_EMAIL = env('OMK_ADMIN_EMAIL', 'support@openmake.cc');
 const LLM_BASE_URL = env('OMK_LLM_BASE_URL', 'http://localhost:4000');
 const LLM_API_KEY = env('OMK_LLM_API_KEY', 'sk-no-key');
 const LLM_MODEL = env('OMK_LLM_MODEL', 'qwen3.8-27b');


### PR DESCRIPTION
공개 저장소의 테스트 픽스처와 기본 설정에 개인 주소와 미사용 도메인이 섞여 있어 세 주소로 정리합니다.

| 기존 | 변경 | 위치 |
|---|---|---|
| `riskpw@gmail.com` | `riskpw@openmake.cc` | API 계약 테스트 7개, iOS 테스트 2개 |
| `rockyhan@iexcello.com` | `rockyhan@openmake.cc` | `user-manager-auth-lookup.test.ts` |
| `admin@openmake.ai` | `support@openmake.cc` | `ADMIN_INITIAL_EMAIL` 기본값, `VAPID_SUBJECT`, `docker-compose.yml`, `db/init/004-admin-user.sh` |
| `hello@openmake.cc` | `support@openmake.cc` | iOS `LumenComponents.swift` |
| `admin@openmake.local` | `support@openmake.cc` | `gen-env.mjs` 기본값, `install.sh` 안내 문구 |

19개 파일 33곳입니다.

## 일부러 바꾸지 않은 것
- **`agent@openmake.local`** (`services/agent-task/code-diff.ts`): 에이전트 샌드박스 안에서 만드는 커밋의 git 신원입니다. 실제 사람 주소로 바꾸면 에이전트 커밋이 사람이 한 것으로 기록되므로 라우팅되지 않는 주소를 유지합니다.
- **`example@email.com`** (`utility-skills-b.json`): UX 라이팅 스킬 프롬프트 안의 예시 문구입니다.

## 동작에 영향이 있는 변경
새 설치의 초기 관리자 계정 이메일 기본값이 `admin@openmake.ai` → `support@openmake.cc` 로 바뀝니다. 기존 설치는 `.env` 값을 그대로 쓰므로 영향받지 않습니다.

## 검증
영향받은 테스트 9개 파일 77건과 `vapid.test.ts` 5건 통과. 다만 `vapid.test.ts` 는 `getConfig` 을 mock 하므로 `VAPID_SUBJECT` 기본값 변경에 대한 회귀 검증력은 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5f9xfbqpaATar1aTm7M9H