### PR TITLE
fix(memory): 메모리 학습 토글 서버 authoritative·삭제 tombstone·source 라벨·감사 기록 (P0 4건)

### DIFF
--- a/apps/api/src/controllers/__tests__/user-memories.controller.test.ts
+++ b/apps/api/src/controllers/__tests__/user-memories.controller.test.ts
@@ -1,0 +1,78 @@
+/** /api/users/me/memories — 인증·cap·소유권·audit. requireAuth/repo/audit 를 mock, supertest 로 HTTP 계약 검증. */
+import express from 'express';
+import request from 'supertest';
+
+let currentUser: { userId: string } | null = { userId: 'u1' };
+jest.mock('../../auth/middleware', () => ({
+    requireAuth: (req: express.Request, res: express.Response, next: express.NextFunction) => {
+        if (!currentUser) { res.status(401).json({ error: 'UNAUTHORIZED' }); return; }
+        (req as unknown as { user: unknown }).user = currentUser; next();
+    },
+}));
+const repoMock = { listActiveByUser: jest.fn(), countActiveByUser: jest.fn(), create: jest.fn(), softDeleteForUser: jest.fn(), deleteAllForUser: jest.fn() };
+jest.mock('../../data/repositories/user-memory-repository', () => ({
+    UserMemoryRepository: jest.fn().mockImplementation(() => repoMock),
+}));
+jest.mock('../../data/models/unified-database', () => ({ getPool: () => ({}) }));
+const logAudit = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../services/AuditService', () => ({ getAuditService: () => ({ logAudit }) }));
+
+import { createUserMemoriesController } from '../user-memories.controller';
+
+const app = express();
+app.use(express.json());
+app.use('/api/users/me/memories', createUserMemoriesController());
+const flush = () => new Promise((r) => setImmediate(r));
+
+beforeEach(() => { currentUser = { userId: 'u1' }; Object.values(repoMock).forEach((m) => m.mockReset()); logAudit.mockClear(); });
+
+describe('user-memories controller', () => {
+    it('미인증은 401', async () => {
+        currentUser = null;
+        await request(app).get('/api/users/me/memories').expect(401);
+        await request(app).post('/api/users/me/memories').send({ content: 'x' }).expect(401);
+        expect(repoMock.create).not.toHaveBeenCalled();
+    });
+
+    it('목록은 세션 userId 로만 조회한다', async () => {
+        repoMock.listActiveByUser.mockResolvedValue([]);
+        await request(app).get('/api/users/me/memories').expect(200);
+        expect(repoMock.listActiveByUser.mock.calls[0][0]).toBe('u1');
+    });
+
+    it('cap 초과 시 400, 생성 없음', async () => {
+        repoMock.countActiveByUser.mockResolvedValue(50);
+        await request(app).post('/api/users/me/memories').send({ content: '나는 TS 를 선호' }).expect(400);
+        expect(repoMock.create).not.toHaveBeenCalled();
+    });
+
+    it('빈 content 는 400 (zod)', async () => {
+        await request(app).post('/api/users/me/memories').send({ content: '' }).expect(400);
+    });
+
+    it('생성은 세션 userId 로 저장하고 memory.created 감사 기록', async () => {
+        repoMock.countActiveByUser.mockResolvedValue(0);
+        repoMock.create.mockResolvedValue({ id: 'm1', user_id: 'u1', content: '나는 TS 를 선호', source: 'explicit' });
+        await request(app).post('/api/users/me/memories').send({ content: '  나는 TS 를 선호  ' }).expect(200);
+        expect(repoMock.create.mock.calls[0].slice(1, 3)).toEqual(['u1', '나는 TS 를 선호']);
+        await flush();
+        expect(logAudit).toHaveBeenCalledWith(expect.objectContaining({ action: 'memory.created', userId: 'u1', resourceId: 'm1' }));
+    });
+
+    it('삭제는 (id, 세션 userId) 로만 — 타인 행은 404, 감사 기록 없음', async () => {
+        repoMock.softDeleteForUser.mockResolvedValue(false);
+        await request(app).delete('/api/users/me/memories/m-other').expect(404);
+        expect(repoMock.softDeleteForUser).toHaveBeenCalledWith('m-other', 'u1');
+        await flush();
+        expect(logAudit).not.toHaveBeenCalled();
+    });
+
+    it('삭제 성공·전체 삭제는 감사 기록', async () => {
+        repoMock.softDeleteForUser.mockResolvedValue(true);
+        repoMock.deleteAllForUser.mockResolvedValue(3);
+        await request(app).delete('/api/users/me/memories/m1').expect(200);
+        await request(app).delete('/api/users/me/memories').expect(200);
+        await flush();
+        expect(logAudit.mock.calls.map((c) => c[0].action)).toEqual(['memory.deleted', 'memory.deleted_all']);
+    });
+});

--- a/apps/api/src/controllers/user-memories.controller.ts
+++ b/apps/api/src/controllers/user-memories.controller.ts
@@ -29,6 +29,23 @@ import { success, internalError, unauthorized, badRequest, notFound } from '../u
 const log = createLogger('UserMemoriesController');
 
 const MAX_COUNT = Number(process.env.USER_MEMORY_MAX_COUNT || '50');
+
+/**
+ * 메모리 변경 감사 기록 — AuditService 가 SoT(CRITICAL_ACTIONS 매칭 시 알림은 서비스가 담당).
+ * fire-and-forget·fail-open: 기록 실패가 요청을 막지 않는다. (2026-09-06 — 그전엔 winston 로그만 남았다.)
+ */
+function auditMemory(req: Request, action: 'memory.created' | 'memory.deleted' | 'memory.deleted_all', userId: string, details: Record<string, unknown>): void {
+    void (async () => {
+        try {
+            const { getAuditService } = await import('../services/AuditService');
+            await getAuditService().logAudit({
+                action, userId, resourceType: 'user_memory',
+                resourceId: typeof details.id === 'string' ? details.id : undefined,
+                details, ipAddress: req.ip, userAgent: req.headers['user-agent'],
+            });
+        } catch (e) { log.warn(`[audit] ${action} 기록 실패:`, e); }
+    })();
+}
 const MAX_CONTENT = Number(process.env.USER_MEMORY_MAX_CONTENT_CHARS || '2000');
 
 const createSchema = z.object({
@@ -73,6 +90,7 @@ export function createUserMemoriesController(): Router {
             }
             const memory = await repo.create(uuidv4(), userId, content.trim());
             log.info(`memory 생성: userId=${userId} id=${memory.id} len=${memory.content.length}`);
+            auditMemory(req, 'memory.created', userId, { id: memory.id, source: memory.source, length: memory.content.length });
             res.json(success({ memory }));
         } catch (err) {
             log.error('create 실패:', err);
@@ -87,6 +105,7 @@ export function createUserMemoriesController(): Router {
             const repo = new UserMemoryRepository(getPool());
             const deleted = await repo.softDeleteForUser(req.params.id, userId);
             if (!deleted) { res.status(404).json(notFound('memory 없음')); return; }
+            auditMemory(req, 'memory.deleted', userId, { id: req.params.id });
             res.json(success({ deleted: true }));
         } catch (err) {
             log.error('delete 실패:', err);
@@ -101,6 +120,7 @@ export function createUserMemoriesController(): Router {
             const repo = new UserMemoryRepository(getPool());
             const count = await repo.deleteAllForUser(userId);
             log.info(`memory 전체 삭제: userId=${userId} count=${count}`);
+            auditMemory(req, 'memory.deleted_all', userId, { count });
             res.json(success({ deleted: count }));
         } catch (err) {
             log.error('deleteAll 실패:', err);

--- a/apps/api/src/data/repositories/user-memory-repository.test.ts
+++ b/apps/api/src/data/repositories/user-memory-repository.test.ts
@@ -1,0 +1,55 @@
+/** user_memories 쿼리 — 사용자 격리(user_id 술어) + tombstone 조회 + soft delete. fake pool 로 SQL 검증. */
+import type { Pool } from 'pg';
+import { UserMemoryRepository } from './user-memory-repository';
+
+function fakePool(rows: unknown[] = [], rowCount = 0) {
+    const calls: Array<{ sql: string; params?: unknown[] }> = [];
+    const pool = {
+        query: jest.fn(async (sql: string, params?: unknown[]) => { calls.push({ sql, params }); return { rows, rowCount }; }),
+    } as unknown as Pool;
+    return { pool, calls };
+}
+
+describe('UserMemoryRepository — 사용자 격리', () => {
+    it.each([
+        ['listActiveByUser', (r: UserMemoryRepository) => r.listActiveByUser('u1')],
+        ['listKnownContentsByUser', (r: UserMemoryRepository) => r.listKnownContentsByUser('u1')],
+        ['countActiveByUser', (r: UserMemoryRepository) => r.countActiveByUser('u1')],
+        ['softDeleteForUser', (r: UserMemoryRepository) => r.softDeleteForUser('m1', 'u1')],
+        ['deleteAllForUser', (r: UserMemoryRepository) => r.deleteAllForUser('u1')],
+    ])('%s 는 user_id 술어와 userId 파라미터를 가진다', async (_name, run) => {
+        const { pool, calls } = fakePool([{ count: '0' }]);
+        await run(new UserMemoryRepository(pool));
+        expect(calls).toHaveLength(1);
+        expect(calls[0].sql).toMatch(/user_id\s*=\s*\$\d/);
+        expect(calls[0].params).toContain('u1');
+    });
+
+    it('create 는 userId 를 INSERT 컬럼으로 넘긴다', async () => {
+        const { pool, calls } = fakePool([{ id: 'm1', user_id: 'u1' }]);
+        await new UserMemoryRepository(pool).create('m1', 'u1', 'hello');
+        expect(calls[0].sql).toMatch(/INSERT INTO user_memories/);
+        expect(calls[0].params).toEqual(['m1', 'u1', 'hello', 'explicit']);
+    });
+});
+
+describe('UserMemoryRepository — tombstone / soft delete', () => {
+    it('listKnownContentsByUser 는 is_active 필터가 없다 (삭제 행 포함)', async () => {
+        const { pool, calls } = fakePool([{ content: 'a' }, { content: 'b' }]);
+        const r = await new UserMemoryRepository(pool).listKnownContentsByUser('u1');
+        expect(r).toEqual(['a', 'b']);
+        expect(calls[0].sql).not.toMatch(/is_active/);
+    });
+    it('listActiveByUser 는 is_active = TRUE 만', async () => {
+        const { pool, calls } = fakePool();
+        await new UserMemoryRepository(pool).listActiveByUser('u1');
+        expect(calls[0].sql).toMatch(/is_active\s*=\s*TRUE/);
+    });
+    it('softDeleteForUser 는 DELETE 가 아니라 is_active=FALSE UPDATE 이고, 타인 행은 0건', async () => {
+        const { pool, calls } = fakePool([], 0);
+        const ok = await new UserMemoryRepository(pool).softDeleteForUser('m1', 'other');
+        expect(ok).toBe(false);
+        expect(calls[0].sql).toMatch(/^\s*UPDATE user_memories SET is_active = FALSE/);
+        expect(calls[0].sql).not.toMatch(/DELETE FROM/);
+    });
+});

--- a/apps/api/src/data/repositories/user-memory-repository.ts
+++ b/apps/api/src/data/repositories/user-memory-repository.ts
@@ -4,8 +4,18 @@
  *
  * 도입 (2026-05-26): mainstream gap closure Phase 3-A.
  * 사용자가 REST `POST /api/users/me/memories` 로 저장한 항목을 다음 대화의
- * system prompt 에 prepend. auto-extraction 없음 (vLLM 부담 0).
- * ⚠️ 채팅 입력 `/remember` 슬래시 명령은 미구현(slash-command.ts 는 스킬 매칭 전용).
+ * system prompt 에 주입(정적 헌법 뒤 DYNAMIC BOUNDARY — prefix cache 보존).
+ * 자동 형성은 2026-07-22 추가(memory-extraction.ts, env 게이트 기본 OFF) + CLI 백필.
+ * ⚠️ 채팅 입력 `/remember` 슬래시 명령은 미구현(slash-command.ts 는 스킬 매칭 전용) —
+ * 입력 경로는 설정 탭(REST POST /api/users/me/memories)·자동 추출·백필 셋뿐.
+ *
+ * source 의미(034 스키마 정의와 일치시킬 것):
+ *   explicit  — 사용자 명시(설정 탭 입력, "기억해줘" 류 휴리스틱 패턴)
+ *   candidate — 모델 감지(메시지당 LLM 추출)
+ *   batch     — 일괄 추출(CLI 백필)
+ *
+ * 삭제는 soft(is_active=false)이며 삭제 행은 tombstone 으로 남는다 — 자동 추출·백필의
+ * 중복 판정은 listKnownContentsByUser(비활성 포함)를 쓴다(삭제한 문장이 되살아나지 않게).
  *
  * @see db/migrations/034_user_memories.sql
  */
@@ -42,6 +52,21 @@ export class UserMemoryRepository extends BaseRepository {
             [userId, limit],
         );
         return result.rows as UserMemory[];
+    }
+
+    /**
+     * 중복 판정용 — 비활성(삭제) 행 포함 전체 content. 삭제한 문장을 자동 추출이 다시 만들지
+     * 않도록 tombstone 역할(2026-09-06). 최근 순 상한(limit).
+     */
+    async listKnownContentsByUser(userId: string, limit = 500): Promise<string[]> {
+        const result = await this.query<{ content: string }>(
+            `SELECT content FROM user_memories
+             WHERE user_id = $1
+             ORDER BY created_at DESC
+             LIMIT $2`,
+            [userId, limit],
+        );
+        return result.rows.map((r) => r.content);
     }
 
     async countActiveByUser(userId: string): Promise<number> {

--- a/apps/api/src/services/agent-task/skill-block.ts
+++ b/apps/api/src/services/agent-task/skill-block.ts
@@ -11,6 +11,7 @@ import { REPORT_PIPELINE, REPORT_INTENT_PATTERNS } from '../../config/runtime-li
 import { buildLearningBlock } from './task-learning';
 import { buildProceduralSkillBlock } from './procedural-skill';
 import { buildUserMemoryBlock } from '../chat-service/user-context-blocks';
+import { resolveMemoryLearning } from '../chat-service/memory-policy';
 import { buildArtifactGuideBlock } from '../chat-service/artifact-guide-block';
 import { createLogger } from '../../utils/logger';
 
@@ -44,7 +45,8 @@ export async function buildSkillPromptBlock(userId: string): Promise<string> {
  * 각 블록은 실패 시 '' 라 조립을 막지 않는다. (resume 은 old system 유지)
  */
 export async function buildAgentTaskSystemContent(userId: string, goal: string, taskId: string): Promise<string> {
-    const memory = userId && userId !== 'guest' ? await buildUserMemoryBlock(userId) : '';
+    // 설정 "장기 기억" OFF 는 에이전트 작업에도 적용(memory-policy — 그전엔 채팅 경로만 게이팅).
+    const memory = (await resolveMemoryLearning(userId)) ? await buildUserMemoryBlock(userId) : '';
     // 보고서 파이프라인 (P1 Phase 2): goal 이 보고서 의도면 reportdata 계약 가이드를 주입한다.
     // 최종 답변의 reportdata 블록은 AgentTaskService 가 applyReportRender 로 렌더해 아티팩트화.
     const goalLang = /[가-힣]/.test(goal) ? 'ko' : 'en';

--- a/apps/api/src/services/chat-service/memory-backfill.ts
+++ b/apps/api/src/services/chat-service/memory-backfill.ts
@@ -57,18 +57,19 @@ export async function backfillUserMemories(
     const candidates = [...new Set((perSession.flat().filter(Boolean) as string[]))];
 
     const repo = new UserMemoryRepository(pool);
-    const existing = (await repo.listActiveByUser(userId, MEMORY_EXTRACTION.maxCount)).map((m) => m.content);
+    // 중복 판정은 삭제(비활성) 행 포함(tombstone) — 사용자가 지운 사실을 백필이 되살리지 않는다.
+    const known = await repo.listKnownContentsByUser(userId);
     const fresh: string[] = [];
     let skippedDup = 0;
     for (const c of candidates) {
-        if (isDuplicateMemory(c, [...existing, ...fresh])) { skippedDup += 1; continue; }
+        if (isDuplicateMemory(c, [...known, ...fresh])) { skippedDup += 1; continue; }
         fresh.push(c);
     }
 
     let saved = 0;
     if (!dryRun && fresh.length > 0) {
         const { randomUUID } = await import('node:crypto');
-        let count = existing.length;
+        let count = await repo.countActiveByUser(userId);
         for (const c of fresh) {
             if (count >= MEMORY_EXTRACTION.maxCount) break;
             await repo.create(randomUUID(), userId, c, 'batch');

--- a/apps/api/src/services/chat-service/memory-extraction.test.ts
+++ b/apps/api/src/services/chat-service/memory-extraction.test.ts
@@ -39,3 +39,57 @@ describe('isDuplicateMemory', () => {
         expect(isDuplicateMemory('자바를 선호', ['나는 파이썬을 선호해'])).toBe(false);
     });
 });
+
+/* ── autoFormMemories: tombstone dedup + source 라벨 (repo/DB mock) ── */
+const repoMock = {
+    // 구 코드(listActiveByUser 만 비교)가 그대로 돌게 두어야 tombstone 테스트가 공허하게 통과하지 않는다.
+    listActiveByUser: jest.fn().mockResolvedValue([]),
+    countActiveByUser: jest.fn(),
+    listKnownContentsByUser: jest.fn(),
+    create: jest.fn(),
+};
+jest.mock('../../data/repositories/user-memory-repository', () => ({
+    UserMemoryRepository: jest.fn().mockImplementation(() => repoMock),
+}));
+jest.mock('../../data/models/unified-database', () => ({ getPool: () => ({}) }));
+jest.mock('../../config/memory-extraction', () => {
+    const actual = jest.requireActual('../../config/memory-extraction');
+    return { ...actual, MEMORY_EXTRACTION: { ...actual.MEMORY_EXTRACTION, heuristicEnabled: true, llmEnabled: false, maxCount: 50 } };
+});
+
+const { autoFormMemories } = require('./memory-extraction') as typeof import('./memory-extraction');
+
+describe('autoFormMemories — tombstone + source', () => {
+    beforeEach(() => { repoMock.countActiveByUser.mockReset(); repoMock.listKnownContentsByUser.mockReset(); repoMock.create.mockReset(); });
+
+    it('휴리스틱 추출은 source=explicit 으로 저장한다 (034 정의 — 그전엔 candidate 로 역전)', async () => {
+        repoMock.countActiveByUser.mockResolvedValue(0);
+        repoMock.listKnownContentsByUser.mockResolvedValue([]);
+        await autoFormMemories({ userId: 'u1', message: '내 생일은 3월 5일이야 기억해줘' });
+        expect(repoMock.create).toHaveBeenCalledTimes(1);
+        expect(repoMock.create.mock.calls[0][3]).toBe('explicit');
+    });
+
+    it('삭제(비활성)된 문장은 다시 만들지 않는다 — 중복 판정이 비활성 행을 포함', async () => {
+        repoMock.countActiveByUser.mockResolvedValue(0); // active 0 = 사용자가 지움
+        repoMock.listKnownContentsByUser.mockResolvedValue(['내 생일은 3월 5일이야']); // tombstone
+        await autoFormMemories({ userId: 'u1', message: '내 생일은 3월 5일이야 기억해줘' });
+        expect(repoMock.create).not.toHaveBeenCalled();
+    });
+
+    it('active cap 은 활성 개수 기준 (tombstone 은 cap 을 소모하지 않음)', async () => {
+        repoMock.countActiveByUser.mockResolvedValue(50);
+        repoMock.listKnownContentsByUser.mockResolvedValue([]);
+        await autoFormMemories({ userId: 'u1', message: '내 생일은 3월 5일이야 기억해줘' });
+        expect(repoMock.create).not.toHaveBeenCalled();
+        repoMock.countActiveByUser.mockResolvedValue(3);
+        repoMock.listKnownContentsByUser.mockResolvedValue(new Array(400).fill('삭제된 옛 문장'));
+        await autoFormMemories({ userId: 'u1', message: '내 생일은 3월 5일이야 기억해줘' });
+        expect(repoMock.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('guest 는 저장하지 않는다', async () => {
+        await autoFormMemories({ userId: 'guest', message: '내 생일은 3월 5일이야 기억해줘' });
+        expect(repoMock.create).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/services/chat-service/memory-extraction.ts
+++ b/apps/api/src/services/chat-service/memory-extraction.ts
@@ -80,14 +80,18 @@ export async function autoFormMemories(params: { userId?: string; message: strin
         const { UserMemoryRepository } = await import('../../data/repositories/user-memory-repository');
         const { getPool } = await import('../../data/models/unified-database');
         const repo = new UserMemoryRepository(getPool());
-        const existing = await repo.listActiveByUser(userId, MEMORY_EXTRACTION.maxCount);
-        const contents = existing.map((m) => m.content);
-        let count = existing.length;
+        // 개수 cap 은 active 기준, 중복 판정은 삭제(비활성) 행 포함 — 삭제한 문장의 재생성 차단(tombstone).
+        const [count0, contents] = await Promise.all([
+            repo.countActiveByUser(userId),
+            repo.listKnownContentsByUser(userId),
+        ]);
+        let count = count0;
         let saved = 0;
         for (const c of candidates) {
             if (count >= MEMORY_EXTRACTION.maxCount) break;
             if (isDuplicateMemory(c, contents)) continue;
-            const source = heur.includes(c) ? 'candidate' : 'batch';
+            // 034 스키마 정의대로: 휴리스틱("기억해줘" 명시 의도)=explicit, LLM 감지=candidate. batch 는 백필 전용.
+            const source = heur.includes(c) ? 'explicit' : 'candidate';
             await repo.create(randomUUID(), userId, c, source);
             contents.push(c);
             count += 1;

--- a/apps/api/src/services/chat-service/memory-policy.test.ts
+++ b/apps/api/src/services/chat-service/memory-policy.test.ts
@@ -1,0 +1,45 @@
+/** memoryLearning 정책 — 서버 저장 설정이 authority, 클라이언트는 더 제한만 가능. */
+const getPreferences = jest.fn();
+jest.mock('../../data/repositories/user-repository', () => ({
+    UserRepository: jest.fn().mockImplementation(() => ({ getPreferences })),
+}));
+jest.mock('../../data/models/unified-database', () => ({ getPool: () => ({}) }));
+
+import { effectiveMemoryLearning, resolveMemoryLearning } from './memory-policy';
+
+describe('effectiveMemoryLearning (pure)', () => {
+    it('서버 false 면 클라이언트가 true 를 보내도 OFF (위조 불가)', () => {
+        expect(effectiveMemoryLearning(false, true)).toBe(false);
+        expect(effectiveMemoryLearning(false, undefined)).toBe(false);
+    });
+    it('서버 미설정/true 면 클라이언트 명시 false 만 OFF', () => {
+        expect(effectiveMemoryLearning(undefined, undefined)).toBe(true);
+        expect(effectiveMemoryLearning(true, undefined)).toBe(true);
+        expect(effectiveMemoryLearning(true, false)).toBe(false);
+        expect(effectiveMemoryLearning(undefined, false)).toBe(false);
+    });
+});
+
+describe('resolveMemoryLearning', () => {
+    beforeEach(() => getPreferences.mockReset());
+    it('guest 는 항상 false (DB 조회 없음)', async () => {
+        expect(await resolveMemoryLearning('guest')).toBe(false);
+        expect(await resolveMemoryLearning(undefined)).toBe(false);
+        expect(getPreferences).not.toHaveBeenCalled();
+    });
+    it('서버 설정 false → REST(플래그 없음)·WS(true 위조) 모두 OFF', async () => {
+        getPreferences.mockResolvedValue({ memoryLearning: false });
+        expect(await resolveMemoryLearning('u1')).toBe(false);
+        expect(await resolveMemoryLearning('u1', true)).toBe(false);
+    });
+    it('서버 설정 없음 → 기본 ON, 클라이언트 false 는 존중', async () => {
+        getPreferences.mockResolvedValue({});
+        expect(await resolveMemoryLearning('u1')).toBe(true);
+        expect(await resolveMemoryLearning('u1', false)).toBe(false);
+    });
+    it('조회 실패는 fail-open (클라이언트 플래그 기준)', async () => {
+        getPreferences.mockRejectedValue(new Error('db down'));
+        expect(await resolveMemoryLearning('u1')).toBe(true);
+        expect(await resolveMemoryLearning('u1', false)).toBe(false);
+    });
+});

--- a/apps/api/src/services/chat-service/memory-policy.ts
+++ b/apps/api/src/services/chat-service/memory-policy.ts
@@ -1,0 +1,40 @@
+/**
+ * 메모리 학습(memoryLearning) 정책 판정 — 서버 저장 설정이 authority.
+ *
+ * 배경 (2026-09-06): 설정 → 개인정보 "장기 기억" 토글은 `users.preferences.memoryLearning` 에
+ * 저장되지만, 채팅 경로는 클라이언트가 메시지에 실어 보낸 플래그만 봤다(WS 는 신뢰,
+ * REST 는 안 읽어 항상 ON, 에이전트 작업은 토글 자체를 안 봄). 사용자가 껐는데 REST·
+ * 에이전트 작업에서 메모리 주입·자동 저장이 계속되는 프라이버시 결함.
+ *
+ * 규칙: 서버 설정 false 면 무조건 OFF. 서버 설정이 없거나 true 면 클라이언트 플래그가
+ * 명시 false 일 때만 OFF(클라이언트는 더 제한할 수만 있고 켤 수는 없다). 조회 실패는
+ * fail-open(클라이언트 플래그 기준) — 설정 조회 장애가 채팅을 막지 않는다.
+ *
+ * @module services/chat-service/memory-policy
+ */
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('MemoryPolicy');
+
+/** PURE: 서버 저장값 + 클라이언트 플래그 → 유효 memoryLearning. */
+export function effectiveMemoryLearning(serverPref: unknown, clientFlag?: boolean): boolean {
+    if (serverPref === false) return false;
+    return clientFlag !== false;
+}
+
+/**
+ * userId 의 저장 설정을 읽어 유효 memoryLearning 을 돌려준다. guest 는 항상 false
+ * (메모리 자체가 인증 사용자 전용).
+ */
+export async function resolveMemoryLearning(userId: string | undefined, clientFlag?: boolean): Promise<boolean> {
+    if (!userId || userId === 'guest') return false;
+    try {
+        const { UserRepository } = await import('../../data/repositories/user-repository');
+        const { getPool } = await import('../../data/models/unified-database');
+        const prefs = await new UserRepository(getPool()).getPreferences(userId);
+        return effectiveMemoryLearning(prefs.memoryLearning, clientFlag);
+    } catch (e) {
+        logger.warn('memoryLearning 설정 조회 실패 — 클라이언트 플래그로 폴백:', e);
+        return effectiveMemoryLearning(undefined, clientFlag);
+    }
+}

--- a/apps/api/src/services/chat-service/message-pipeline.ts
+++ b/apps/api/src/services/chat-service/message-pipeline.ts
@@ -34,6 +34,7 @@ import { applyAgentModelOverride } from './agent-model-override';
 import { resolveModeExternalClient } from './mode-external-client';
 import { buildUserContextBlocks } from './user-context-blocks';
 import { autoFormMemories } from './memory-extraction';
+import { resolveMemoryLearning } from './memory-policy';
 import type { RequestContext } from './request-context';
 import { recordOrchestrationDispatch } from './orchestration-shadow-recorder';
 import { detectOrchestrationIntents } from './external-tool-plan';
@@ -348,13 +349,15 @@ export async function runMessagePipeline(svc: ChatService,
     await svc.loadSkillBindings(selectedAgent.id, reqCtx);
 
     // Memory + Custom Instructions 주입 (claude.ai Memory/CI 동등).
+    // memoryLearning 은 서버 저장 설정이 authority(memory-policy) — 클라이언트 플래그는 더 제한할 수만 있다.
+    const memoryLearning = await resolveMemoryLearning(userId, req.memoryLearning);
     const { memoryBlock: extMemoryBlock, customInstructionsBlock: extCustomInstructionsBlock } =
-        await buildUserContextBlocks(userId, req.memoryLearning !== false);
+        await buildUserContextBlocks(userId, memoryLearning);
 
     // 자동 기억형성(#3 b) — user 메시지에서 지속적 사실 추출→저장. fire-and-forget(응답 무영향, 플래그 OFF 면 no-op).
-    // memoryLearning 토글은 "주입"(293행)뿐 아니라 "형성/저장"도 게이팅한다 — OFF 인데 저장이 계속되면
+    // memoryLearning 토글은 "주입"뿐 아니라 "형성/저장"도 게이팅한다 — OFF 인데 저장이 계속되면
     // 사용자가 끈 것과 반대로 동작하는 프라이버시 이슈.
-    if (req.memoryLearning !== false) {
+    if (memoryLearning) {
         void autoFormMemories({ userId, message: req.message, client: svc.client });
     }
 

--- a/db/migrations/034_user_memories.sql
+++ b/db/migrations/034_user_memories.sql
@@ -1,17 +1,17 @@
 -- Migration 034 — user_memories 테이블
 --
 -- 사용자별 cross-conversation memory (claude.ai Memory / ChatGPT Memory 동등).
--- explicit 명령 (/remember) 으로 저장된 사실을 다음 대화의 system prompt 에
--- prepend.
+-- 설정 탭(REST POST /api/users/me/memories) 으로 저장된 사실을 다음 대화의 system
+-- prompt 에 주입. (초기 설계의 채팅 `/remember` 슬래시 명령은 구현되지 않았다.)
 --
 -- 도입 배경 (2026-05-26): mainstream gap closure Phase 3-A. 2026-05-19 폐기된
 -- MemoryService 의 lightweight 재도입 — auto-extraction 없이 explicit 만.
 -- vLLM 부담 0 (추가 LLM 호출 없음).
 --
 -- 저장 방식:
---   - source='explicit' — 사용자가 직접 입력
---   - source='candidate' — 모델 응답의 <memory-candidate> tag (Phase K, 미래)
---   - source='batch' — 일괄 추출 (Phase 3-C, 미래)
+--   - source='explicit' — 사용자 명시(설정 탭 입력, "기억해줘" 휴리스틱 패턴 — 2026-07-22)
+--   - source='candidate' — 모델 감지(메시지당 LLM 추출 — 2026-07-22. 초기 구상의 <memory-candidate> tag 는 미구현)
+--   - source='batch' — 일괄 추출(CLI backfill-memories — 2026-07-22)
 --
 -- max-per-user 정책은 application layer (env USER_MEMORY_MAX_COUNT, default 50)
 --


### PR DESCRIPTION
## 배경
[Agent Memory Atlas](https://neoneye.github.io/agent-memory-atlas/systems/openmake-llm/) 의 `user_memories` 정적 리뷰(2026-09-06, `ed74251e` 대상)를 소스·운영 DB 로 대조해 확정한 P0 4건. 운영 `user_memories` 는 0행이라 전부 **잠복 결함**이다(메모리가 생기는 순간 발현).

## 변경
| # | 결함 | 수정 |
|---|---|---|
| 1 | 설정 "장기 기억" OFF 가 WS(클라이언트 값 신뢰)·REST(안 읽음→항상 ON)·에이전트 작업(토글 미확인)에서 무시됨 | `services/chat-service/memory-policy.ts` — 서버 `users.preferences.memoryLearning` 이 authority, 클라이언트 플래그는 더 제한만 가능. `message-pipeline`·`agent-task/skill-block` 배선 |
| 2 | 삭제(is_active=false)한 문장을 자동 추출·백필이 다시 만듦 | dedup 을 `listKnownContentsByUser`(비활성 포함, tombstone)로. cap 은 active 기준 유지 |
| 3 | `source` 라벨 역전(regex→candidate, LLM→batch) | 034 정의대로 휴리스틱=explicit, LLM=candidate, batch 는 백필 전용 |
| 4 | 생성·삭제 감사 기록 없음 | `AuditService.logAudit`(memory.created / deleted / deleted_all), fail-open |

주석 정정: 레포 헤더 "auto-extraction 없음", 034 의 미구현 `/remember` 서술.

## 검증
- tsc 0 · eslint 0 · 신규/확장 테스트 35건 통과 (정책 순수함수+DB mock, 저장소 user_id 격리·tombstone·soft delete, 컨트롤러 401/cap/소유권/audit via supertest, 추출 라벨·tombstone·cap)
- **되돌리기 검증**: src 3파일을 stash 하고 돌리면 추출 테스트 3건 실패 → 테스트가 분기를 실제로 가른다
- 관련 스위트(agent-task·message-pipeline) 29 suites 251 passed
- 파일 크기 게이트: message-pipeline 491줄

## 의도적으로 안 한 것 (별건 판정)
- 하이브리드 검색·Top-K, workspace/project scope, supersede·confidence·bi-temporal — 0행 테이블에 대한 시기상조. 재개 조건은 cap 발동 로그 또는 활성 메모리 p50 > 20.
- WS 핸들러 주석 무변경(600줄 게이트 근접).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPP1bSUFuQBZLQPgHGwA6E
