### PR TITLE
feat(memory): 자동 추출 메모리 출처 배지 + 개수 cap 폐기 로그

### DIFF
--- a/apps/api/src/services/chat-service/memory-backfill.ts
+++ b/apps/api/src/services/chat-service/memory-backfill.ts
@@ -77,6 +77,7 @@ export async function backfillUserMemories(
             saved += 1;
         }
         logger.info(`[Backfill] user ${userId}: ${saved} 저장 (세션 ${sessions.length}, 후보 ${candidates.length}, 중복 ${skippedDup})`);
+        if (fresh.length > saved) logger.warn(`[Backfill] cap ${MEMORY_EXTRACTION.maxCount} 도달 — 후보 ${fresh.length - saved}건 폐기 (user ${userId})`);
     }
 
     return { sessionsProcessed: sessions.length, candidateCount: candidates.length, fresh, saved, skippedDup, dryRun };

--- a/apps/api/src/services/chat-service/memory-extraction.ts
+++ b/apps/api/src/services/chat-service/memory-extraction.ts
@@ -87,8 +87,9 @@ export async function autoFormMemories(params: { userId?: string; message: strin
         ]);
         let count = count0;
         let saved = 0;
+        let droppedAtCap = 0;
         for (const c of candidates) {
-            if (count >= MEMORY_EXTRACTION.maxCount) break;
+            if (count >= MEMORY_EXTRACTION.maxCount) { droppedAtCap += 1; continue; }
             if (isDuplicateMemory(c, contents)) continue;
             // 034 스키마 정의대로: 휴리스틱("기억해줘" 명시 의도)=explicit, LLM 감지=candidate. batch 는 백필 전용.
             const source = heur.includes(c) ? 'explicit' : 'candidate';
@@ -98,6 +99,8 @@ export async function autoFormMemories(params: { userId?: string; message: strin
             saved += 1;
         }
         if (saved > 0) logger.info(`[MemoryExtract] 자동 저장 ${saved}건 (user ${userId}, heur ${heur.length}/llm ${llm.length})`);
+        // cap 도달로 버린 후보는 조용히 사라지지 않게 남긴다 — memory-report.sh 가 집계(퇴출 정책 도입 게이트).
+        if (droppedAtCap > 0) logger.warn(`[MemoryExtract] cap ${MEMORY_EXTRACTION.maxCount} 도달 — 후보 ${droppedAtCap}건 폐기 (user ${userId})`);
     } catch (e) {
         logger.debug(`[MemoryExtract] 실패 — 무시: ${e instanceof Error ? e.message : e}`);
     }

--- a/apps/web/components/settings/memory-section.tsx
+++ b/apps/web/components/settings/memory-section.tsx
@@ -10,6 +10,8 @@ import { ApiClient } from "@/lib/api-client";
 interface Memory {
   id: string;
   content: string;
+  /** explicit=직접 입력 · candidate=자동 감지(LLM) · batch=백필. 직접 입력이 아니면 배지로 구분한다. */
+  source?: "explicit" | "candidate" | "batch";
   created_at?: string;
 }
 
@@ -139,7 +141,14 @@ export function MemorySection() {
               <li key={m.id}>
                 <div className="flex items-start gap-3 rounded-lg border border-border p-3.5">
                   <Brain className="mt-0.5 h-4 w-4 shrink-0 text-accent" />
-                  <p className="min-w-0 flex-1 whitespace-pre-wrap break-words text-sm text-fg">{m.content}</p>
+                  <div className="min-w-0 flex-1">
+                    <p className="whitespace-pre-wrap break-words text-sm text-fg">{m.content}</p>
+                    {m.source && m.source !== "explicit" && (
+                      <span className="mt-1 inline-block rounded border border-border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-muted">
+                        {m.source === "candidate" ? t("sourceCandidate") : t("sourceBatch")}
+                      </span>
+                    )}
+                  </div>
                   <Button variant="ghost" size="icon" aria-label={t("deleteAria")} onClick={() => void remove(m.id)}>
                     <Trash2 className="h-4 w-4" />
                   </Button>

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1802,6 +1802,8 @@
     "clearAll": "Clear all",
     "clearConfirm": "Delete all memories? This cannot be undone.",
     "deleteAria": "Delete memory",
+    "sourceCandidate": "Auto-detected",
+    "sourceBatch": "Backfilled",
     "limitReached": "You can save up to {max} memories."
   },
   "pageTabs": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1802,6 +1802,8 @@
     "clearAll": "すべて削除",
     "clearConfirm": "すべてのメモリを削除しますか？元に戻せません。",
     "deleteAria": "メモリを削除",
+    "sourceCandidate": "自動検出",
+    "sourceBatch": "バックフィル",
     "limitReached": "最大{max}件まで保存できます。"
   },
   "pageTabs": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1802,6 +1802,8 @@
     "clearAll": "전체 삭제",
     "clearConfirm": "모든 메모리를 삭제할까요? 되돌릴 수 없습니다.",
     "deleteAria": "메모리 삭제",
+    "sourceCandidate": "자동 감지",
+    "sourceBatch": "백필",
     "limitReached": "최대 {max}개까지 저장할 수 있습니다."
   },
   "pageTabs": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1802,6 +1802,8 @@
     "clearAll": "全部删除",
     "clearConfirm": "删除所有记忆吗？此操作无法撤销。",
     "deleteAria": "删除记忆",
+    "sourceCandidate": "自动识别",
+    "sourceBatch": "回填",
     "limitReached": "最多可保存 {max} 条记忆。"
   },
   "pageTabs": {


### PR DESCRIPTION
## 배경
#762·#763 후속. Atlas 의 "human review 없음"(자동 추출 행이 바로 active) 과 "51번째 후보 조용한 폐기" 지적에 대한 최소 조치.

## 변경
- **출처 배지**: 설정 → 메모리 탭에서 `source !== 'explicit'` 행에 "자동 감지"(candidate) / "백필"(batch) 배지. API 는 이미 `source` 를 돌려주고 있었고 프론트 타입이 안 읽고 있었다. 사용자가 보고 지우면 #762 의 tombstone 이 되어 재생성되지 않으므로, 별도 승인 큐 없이 검토·거절이 가능하다(승인 창구 `/approvals` 에 새 대상을 추가하지 않는 이유 — 자동 추출은 기본 OFF 이고 운영 0행이라 대기열을 만들 근거가 아직 없다).
- **cap 폐기 로그**: `autoFormMemories`·백필이 개수 cap(50) 도달로 버린 후보 수를 warn 으로 남긴다. #763 의 `memory-report.sh` 가 집계한다(퇴출 정책 도입 게이트).

## 검증
- web `tsc --noEmit` 0 · eslint 0 · i18n 4 로케일 JSON 유효, 키는 최상위 `memory` 블록에만
- api tsc 0 · memory-extraction 테스트 13 통과
- 동작 변경 없음(표시·로그만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPP1bSUFuQBZLQPgHGwA6E
