### PR TITLE
fix(providers): openai-compat 경로에 도구 이름 코덱 적용 — `server::tool` 을 provider 가 400 거절하던 결함

### DIFF
--- a/apps/api/src/providers/__tests__/openai-compat-tool-name-codec.test.ts
+++ b/apps/api/src/providers/__tests__/openai-compat-tool-name-codec.test.ts
@@ -1,0 +1,87 @@
+/**
+ * openai-compat 경로 도구 이름 코덱 — `server::tool` 네임스페이스를 provider 경계에서 인코딩/복원.
+ *
+ * 실측(2026-09-04·06): NVIDIA NIM 이 `Function at index 1 has an invalid name` 으로 요청 전체를
+ * 400 거절 → UPSTREAM_ERROR 로 뭉개져 로컬 폴백(사용자가 고른 모델이 조용히 바뀜). 코덱 부재가 원인.
+ */
+import { OpenAICompatProvider, mapOpenAIError } from '../openai-compat-provider';
+import { toOpenAIMessages, toOpenAITools } from '../openai-compat-mapping';
+import { OPENAI_TOOL_NAME_PATTERN, ToolNameCodec } from '../tool-name-codec';
+import { EXTERNAL_CHAT_FALLBACK } from '../../config/runtime-limits';
+import type { ChatMessage, ToolDefinition } from '../../llm';
+
+const tool = (name: string): ToolDefinition => ({
+    type: 'function',
+    function: { name, description: `desc ${name}`, parameters: { type: 'object', properties: {} } },
+});
+
+describe('openai-compat 매핑 — 도구 이름 인코딩', () => {
+    it('tools 의 `server::tool`·공백·괄호 이름이 전부 OpenAI 규약을 만족하고 원본은 복원된다', () => {
+        const codec = new ToolNameCodec();
+        const names = ['context7::query-docs', 'Python REPL (abc123)::repl_run_code', 'web_search'];
+        const out = toOpenAITools(names.map(tool), codec);
+        for (const t of out) expect(t.function.name).toMatch(OPENAI_TOOL_NAME_PATTERN);
+        expect(out.map((t) => codec.restore(t.function.name))).toEqual(names);
+        expect(out[2].function.name).toBe('web_search'); // 규약 안 이름은 그대로
+    });
+
+    it('히스토리 assistant.tool_calls 도 tools 와 같은 이름으로 인코딩된다', () => {
+        const codec = new ToolNameCodec();
+        const [encoded] = toOpenAITools([tool('tavily::tavily_search')], codec);
+        const history: ChatMessage[] = [
+            { role: 'assistant', content: '', tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'tavily::tavily_search', arguments: { q: 'x' } } }] },
+            { role: 'tool', content: 'ok', tool_call_id: 'call_1' },
+        ];
+        const msgs = toOpenAIMessages(history, { codec }) as Array<{ tool_calls?: Array<{ function: { name: string } }> }>;
+        expect(msgs[0].tool_calls?.[0].function.name).toBe(encoded.function.name);
+    });
+
+    it('codec 미전달이면 종전과 동일하게 이름을 그대로 둔다 (로컬 경로 호환)', () => {
+        expect(toOpenAITools([tool('a::b')])[0].function.name).toBe('a::b');
+    });
+});
+
+describe('OpenAICompatProvider.streamChat — 요청 인코딩·응답 복원 왕복', () => {
+    function makeProvider() {
+        return new OpenAICompatProvider({ providerId: 'nvidia', apiKey: 'nvapi-test', baseUrl: 'https://integrate.api.nvidia.com/v1' });
+    }
+
+    it('요청 tools 는 규약 이름으로 나가고, 응답 tool_call 은 `::` 원본 이름으로 돌아온다', async () => {
+        const provider = makeProvider();
+        const create = jest.fn(async (params: { tools?: Array<{ function: { name: string } }> }) => {
+            const sent = params.tools?.[0].function.name ?? '';
+            async function* gen() {
+                yield { choices: [{ delta: { tool_calls: [{ index: 0, id: 'call_x', function: { name: sent, arguments: '{"q":"기준금리"}' } }] } }] };
+                yield { choices: [{ delta: {} }], usage: { prompt_tokens: 10, completion_tokens: 5 } };
+            }
+            return gen();
+        });
+        (provider as unknown as { client: { chat: { completions: { create: jest.Mock } } } }).client = { chat: { completions: { create } } };
+
+        const result = await provider.streamChat(
+            { messages: [{ role: 'user', content: '금리' }], modelId: 'moonshotai/kimi-k3', tools: [tool('tavily::tavily_search'), tool('web_search')] },
+            {},
+        );
+        const sentTools = create.mock.calls[0][0].tools as Array<{ function: { name: string } }>;
+        expect(sentTools.map((t) => t.function.name)).toEqual(['tavily__tavily_search', 'web_search']);
+        expect(result.toolCalls?.[0]).toMatchObject({ id: 'call_x', name: 'tavily::tavily_search', args: { q: '기준금리' } });
+    });
+});
+
+describe('mapOpenAIError — provider 의 도구 정의 거절(400)', () => {
+    const httpErr = (status: number, message: string) => Object.assign(new Error(message), { status });
+
+    it('NVIDIA NIM "Function at index N has an invalid name" → NOT_SUPPORTED (UPSTREAM_ERROR 아님)', () => {
+        const e = mapOpenAIError(httpErr(400, 'litellm.BadRequestError: Nvidia_nimException - Validation: Function at index 1 has an invalid name:'));
+        expect(e.code).toBe('NOT_SUPPORTED');
+    });
+
+    it('OpenAI 원본 "Invalid \'tools[0].function.name\': string does not match pattern" → NOT_SUPPORTED', () => {
+        const e = mapOpenAIError(httpErr(400, "Invalid 'tools[0].function.name': string does not match pattern. Expected a string that matches the pattern '^[a-zA-Z0-9_-]+$'."));
+        expect(e.code).toBe('NOT_SUPPORTED');
+    });
+
+    it('그 코드는 로컬 폴백 대상(RETRYABLE_CODES)에 들어 있지 않다 — 조용한 모델 교체 차단', () => {
+        expect(EXTERNAL_CHAT_FALLBACK.RETRYABLE_CODES).not.toContain('NOT_SUPPORTED');
+    });
+});

--- a/apps/api/src/providers/chatgpt-oauth/responses-mapping.ts
+++ b/apps/api/src/providers/chatgpt-oauth/responses-mapping.ts
@@ -16,61 +16,11 @@ import { inferImageMime } from '../../utils/image-mime';
 
 /* ── 도구 이름 정규화 ──────────────────────────────────────── */
 
-/**
- * Codex 백엔드가 허용하는 도구 이름 패턴 — Chat Completions 보다 엄격하다.
- * (라이브 E2E 에서 확인: 위반 시 400 "string does not match pattern".)
- */
-const CODEX_TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
-/** 보수적 길이 상한 — OpenAI function name 관례 */
-const CODEX_TOOL_NAME_MAX = 64;
-
-/**
- * 도구 이름 정규화 코덱.
- *
- * MCP 서버가 등록하는 도구 이름에는 Codex 가 거부하는 문자(공백·점·콜론 등)가
- * 섞일 수 있다. 요청 방향으로는 안전한 이름으로 치환하고, 응답의 tool call 은
- * 원래 이름으로 되돌려 도구 실행 계층(이름으로 dispatch)이 그대로 동작하게 한다.
- */
-export class ToolNameCodec {
-    private readonly toSanitized = new Map<string, string>();
-    private readonly toOriginal = new Map<string, string>();
-
-    /** 원래 이름 → Codex 안전 이름 (멱등, 충돌 시 suffix 부여) */
-    register(original: string): string {
-        const existing = this.toSanitized.get(original);
-        if (existing) return existing;
-
-        let candidate = original
-            .replace(/[^a-zA-Z0-9_-]/g, '_')
-            .slice(0, CODEX_TOOL_NAME_MAX);
-        if (!candidate || !CODEX_TOOL_NAME_PATTERN.test(candidate)) {
-            candidate = `tool_${this.toSanitized.size}`;
-        }
-        // 서로 다른 원본이 같은 안전 이름으로 접히면 dispatch 가 깨진다 — suffix 로 분리
-        let unique = candidate;
-        let n = 1;
-        while (this.toOriginal.has(unique) && this.toOriginal.get(unique) !== original) {
-            const suffix = `_${n++}`;
-            unique = `${candidate.slice(0, CODEX_TOOL_NAME_MAX - suffix.length)}${suffix}`;
-        }
-
-        this.toSanitized.set(original, unique);
-        this.toOriginal.set(unique, original);
-        return unique;
-    }
-
-    /** Codex 안전 이름 → 원래 이름 (미등록 이름은 그대로 통과) */
-    restore(sanitized: string): string {
-        return this.toOriginal.get(sanitized) ?? sanitized;
-    }
-
-    /** 정규화가 실제로 일어난 항목 (관측/로깅용) */
-    renamed(): Array<{ from: string; to: string }> {
-        return [...this.toSanitized.entries()]
-            .filter(([from, to]) => from !== to)
-            .map(([from, to]) => ({ from, to }));
-    }
-}
+// ToolNameCodec 은 provider 중립 모듈로 이전했다(openai-compat 경로와 공유, 2026-09-06).
+// Codex 가 "Chat Completions 보다 엄격하다" 던 종전 전제는 NVIDIA NIM 실측으로 반증됐다 —
+// OpenAI 함수 이름 규약을 그대로 검증하는 Chat Completions 호환 endpoint 가 있다.
+import { ToolNameCodec } from '../tool-name-codec';
+export { ToolNameCodec };
 
 /* ── 요청 변환 ─────────────────────────────────────────────── */
 

--- a/apps/api/src/providers/openai-compat-mapping.ts
+++ b/apps/api/src/providers/openai-compat-mapping.ts
@@ -9,6 +9,7 @@
  * @module providers/openai-compat-mapping
  */
 import type { ChatMessage, ToolDefinition } from '../llm';
+import type { ToolNameCodec } from './tool-name-codec';
 
 /**
  * OpenAI 형식 메시지로 변환.
@@ -65,8 +66,9 @@ import { inferImageMime } from '../utils/image-mime';
 
 export function toOpenAIMessages(
     messages: ChatMessage[],
-    opts?: { cacheSystemPrompt?: boolean },
+    opts?: { cacheSystemPrompt?: boolean; codec?: ToolNameCodec },
 ): OpenAIMessage[] {
+    const codec = opts?.codec;
     return messages.map((msg, idx): OpenAIMessage => {
         if (msg.role === 'tool') {
             return {
@@ -108,7 +110,8 @@ export function toOpenAIMessages(
                     id: tc.id ?? `call_${tc.function.name}_${i}`,
                     type: 'function' as const,
                     function: {
-                        name: tc.function.name,
+                        // 히스토리의 tool_calls 도 요청 방향이라 tools 와 같은 이름으로 내보낸다.
+                        name: codec ? codec.register(tc.function.name) : tc.function.name,
                         arguments: JSON.stringify(tc.function.arguments),
                     },
                 })),
@@ -119,14 +122,15 @@ export function toOpenAIMessages(
     });
 }
 
-export function toOpenAITools(tools: ToolDefinition[]): Array<{
+export function toOpenAITools(tools: ToolDefinition[], codec?: ToolNameCodec): Array<{
     type: 'function';
     function: { name: string; description: string; parameters: unknown };
 }> {
     return tools.map((t) => ({
         type: 'function' as const,
         function: {
-            name: t.function.name,
+            // `server::tool` 등 OpenAI 함수 이름 규약 밖 문자는 provider 경계에서만 인코딩
+            name: codec ? codec.register(t.function.name) : t.function.name,
             description: t.function.description,
             parameters: t.function.parameters,
         },

--- a/apps/api/src/providers/openai-compat-provider.ts
+++ b/apps/api/src/providers/openai-compat-provider.ts
@@ -32,6 +32,7 @@ import { createLogger } from '../utils/logger';
 import { buildReasoningEffortParams } from './openai-compat-reasoning';
 import { createPinnedFetch } from '../security/ssrf-guard';
 import { needsExplicitPromptCache, toOpenAIMessages, toOpenAITools } from './openai-compat-mapping';
+import { ToolNameCodec } from './tool-name-codec';
 import { PseudoToolCallGate } from '../llm/pseudo-tool-call-parser';
 
 const logger = createLogger('OpenAICompatProvider');
@@ -128,6 +129,14 @@ const INSUFFICIENT_CREDIT_PATTERN = /insufficient[_ ]user[_ ]quota|insufficient 
  */
 const MODEL_ACCESS_RESTRICTED_PATTERN = /only available (on|to|for|via)|not available (on|to|for|via) (this|your)/i;
 
+/**
+ * 400 중 우리가 보낸 도구 정의(함수 이름 규약)를 provider 가 거절한 응답 (2026-09-04·06 NVIDIA NIM 실측):
+ *   `Nvidia_nimException - Validation: Function at index 1 has an invalid name:`
+ *   OpenAI 원본: `Invalid 'tools[0].function.name': string does not match pattern`
+ * 재시도해도 같고, 로컬 폴백을 타면 사용자가 고른 모델이 조용히 바뀌므로 UPSTREAM_ERROR 와 분리한다.
+ */
+const INVALID_TOOL_NAME_PATTERN = /(function|tool)[^\n]{0,80}(invalid name|does not match pattern)|invalid '?tools\[/i;
+
 export function mapOpenAIError(err: unknown): ProviderError {
     const message = err instanceof Error ? err.message : String(err);
     if (err && typeof err === 'object' && 'status' in err) {
@@ -155,6 +164,10 @@ export function mapOpenAIError(err: unknown): ProviderError {
         }
         if (status === 404) {
             return new ProviderError('MODEL_NOT_FOUND', `모델 미발견: ${message}`, err);
+        }
+        if (status === 400 && INVALID_TOOL_NAME_PATTERN.test(message)) {
+            // 코덱이 있어도 신규 provider 가 다른 제약을 걸 수 있다 — 폴백 대상(RETRYABLE_CODES) 밖 코드로 드러낸다.
+            return new ProviderError('NOT_SUPPORTED', `provider 가 도구 정의를 거절: ${message}`, err);
         }
     }
     return new ProviderError('UPSTREAM_ERROR', `OpenAI 호환 호출 실패: ${message}`, err);
@@ -374,8 +387,15 @@ export class OpenAICompatProvider implements IProvider {
         callbacks: ChatStreamCallbacks,
     ): Promise<ChatStreamResult> {
         const cacheSystemPrompt = needsExplicitPromptCache(this.id, opts.modelId);
-        const messages = toOpenAIMessages(opts.messages, { cacheSystemPrompt });
-        const tools = opts.tools && opts.tools.length > 0 ? toOpenAITools(opts.tools) : undefined;
+        // `server::tool` 네임스페이스는 OpenAI 함수 이름 규약 밖 — provider 경계에서만 인코딩하고
+        // 응답 tool call 을 원래 이름으로 복원한다(NVIDIA NIM 이 요청 전체를 400 거절하던 실측).
+        const codec = new ToolNameCodec();
+        const tools = opts.tools && opts.tools.length > 0 ? toOpenAITools(opts.tools, codec) : undefined;
+        const messages = toOpenAIMessages(opts.messages, { cacheSystemPrompt, codec });
+        const renamed = codec.renamed();
+        if (renamed.length > 0) {
+            logger.debug(`${this.id} 도구명 정규화 ${renamed.length}건: ${renamed.slice(0, 5).map((r) => `${r.from}→${r.to}`).join(', ')}`);
+        }
 
         let aborted = false;
         opts.abortSignal?.addEventListener('abort', () => { aborted = true; });
@@ -511,7 +531,7 @@ export class OpenAICompatProvider implements IProvider {
                 } catch (parseErr) {
                     logger.warn(`tool_call arguments 파싱 실패 — {} 로 강등: tool=${buf.name} raw=${buf.jsonBuffer.slice(0, 200)} (${parseErr})`);
                 }
-                const call = { id: buf.id, name: buf.name, args };
+                const call = { id: buf.id, name: codec.restore(buf.name), args };
                 toolCalls.push(call);
                 callbacks.onToolCall?.(call);
             }
@@ -520,7 +540,7 @@ export class OpenAICompatProvider implements IProvider {
                 logger.warn(`[PseudoToolCall] 텍스트로 새어나온 툴콜 ${pseudoFlush.toolCalls.length}건 복구 — `
                     + `tools=${pseudoFlush.toolCalls.map((c) => c.name).join(',')}`);
                 for (const c of pseudoFlush.toolCalls) {
-                    const call = { id: c.id, name: c.name, args: c.args as unknown };
+                    const call = { id: c.id, name: codec.restore(c.name), args: c.args as unknown };
                     toolCalls.push(call);
                     callbacks.onToolCall?.(call);
                 }

--- a/apps/api/src/providers/tool-name-codec.ts
+++ b/apps/api/src/providers/tool-name-codec.ts
@@ -1,0 +1,71 @@
+/**
+ * ============================================================
+ * 도구 이름 코덱 — provider 경계에서만 이름을 인코딩/복원
+ * ============================================================
+ *
+ * 내부 도구 이름은 `server::tool` 네임스페이스(`MCP_NAMESPACE_SEPARATOR`)를 쓰고,
+ * 역할 게이트·병렬 판정·헬스 서킷이 그 구분자를 전제로 한다. 반면 OpenAI 함수 이름
+ * 규약(`^[a-zA-Z0-9_-]{1,64}$`)을 그대로 검증하는 provider 가 있어(Codex, NVIDIA NIM
+ * 2026-09-04·06 실측 `Function at index 1 has an invalid name`) `::` 가 섞이면 요청
+ * 전체가 400 으로 거절된다. 그래서 내부 표현은 유지하고, 요청 방향으로만 안전한 이름으로
+ * 치환한 뒤 응답 tool call 을 원래 이름으로 되돌린다(dispatch 는 원래 이름으로 동작).
+ *
+ * 원래 `providers/chatgpt-oauth/responses-mapping.ts` 에 Codex 전용으로 있던 것을
+ * openai-compat 경로와 공유하기 위해 provider 중립 모듈로 옮겼다 (2026-09-06).
+ *
+ * @module providers/tool-name-codec
+ */
+
+/** OpenAI 함수 이름 규약 — Codex·NVIDIA NIM 등이 그대로 검증한다. */
+export const OPENAI_TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+/** OpenAI 함수 이름 길이 상한 */
+export const OPENAI_TOOL_NAME_MAX = 64;
+
+/**
+ * 도구 이름 정규화 코덱.
+ *
+ * MCP 서버가 등록하는 도구 이름에는 provider 가 거부하는 문자(공백·점·콜론 등)가
+ * 섞일 수 있다. 요청 방향으로는 안전한 이름으로 치환하고, 응답의 tool call 은
+ * 원래 이름으로 되돌려 도구 실행 계층(이름으로 dispatch)이 그대로 동작하게 한다.
+ * 인스턴스는 요청 1회 단위로 만든다(등록 순서에 따라 충돌 suffix 가 달라질 수 있음).
+ */
+export class ToolNameCodec {
+    private readonly toSanitized = new Map<string, string>();
+    private readonly toOriginal = new Map<string, string>();
+
+    /** 원래 이름 → 안전 이름 (멱등, 충돌 시 suffix 부여) */
+    register(original: string): string {
+        const existing = this.toSanitized.get(original);
+        if (existing) return existing;
+
+        let candidate = original
+            .replace(/[^a-zA-Z0-9_-]/g, '_')
+            .slice(0, OPENAI_TOOL_NAME_MAX);
+        if (!candidate || !OPENAI_TOOL_NAME_PATTERN.test(candidate)) {
+            candidate = `tool_${this.toSanitized.size}`;
+        }
+        // 서로 다른 원본이 같은 안전 이름으로 접히면 dispatch 가 깨진다 — suffix 로 분리
+        let unique = candidate;
+        let n = 1;
+        while (this.toOriginal.has(unique) && this.toOriginal.get(unique) !== original) {
+            const suffix = `_${n++}`;
+            unique = `${candidate.slice(0, OPENAI_TOOL_NAME_MAX - suffix.length)}${suffix}`;
+        }
+
+        this.toSanitized.set(original, unique);
+        this.toOriginal.set(unique, original);
+        return unique;
+    }
+
+    /** 안전 이름 → 원래 이름 (미등록 이름은 그대로 통과) */
+    restore(sanitized: string): string {
+        return this.toOriginal.get(sanitized) ?? sanitized;
+    }
+
+    /** 정규화가 실제로 일어난 항목 (관측/로깅용) */
+    renamed(): Array<{ from: string; to: string }> {
+        return [...this.toSanitized.entries()]
+            .filter(([from, to]) => from !== to)
+            .map(([from, to]) => ({ from, to }));
+    }
+}


### PR DESCRIPTION
## 배경
NVIDIA NIM 이 `Function at index 1 has an invalid name` 으로 요청 전체를 400 거절한 것이 운영 로그에 2건(09-04·09-06). 내장 도구명은 전부 OpenAI 함수 이름 규약(`^[a-zA-Z0-9_-]{1,64}$`)을 만족하므로 원인은 MCP `server::tool` 네임스페이스뿐이다. 그 400 이 `UPSTREAM_ERROR` 로 분류돼 로컬 폴백을 타면서 사용자가 고른 모델(kimi-k3)이 qwen 으로 조용히 바뀌고, 배지는 "업스트림 오류" 로 오안내됐다.

## 변경
- `providers/tool-name-codec.ts` 신설 — Codex 전용이던 `ToolNameCodec` 을 provider 중립으로 이전(`responses-mapping.ts` 는 re-export). Codex 가 "Chat Completions 보다 엄격하다" 던 주석 전제는 실측으로 반증돼 정정.
- `openai-compat-mapping.ts`: `toOpenAITools`·`toOpenAIMessages` 가 codec 을 받아 tools 와 히스토리 `assistant.tool_calls` 이름을 요청 방향에서 인코딩.
- `openai-compat-provider.ts`: 요청당 codec 1개, 응답 tool_call(네이티브·pseudo 복구분)은 원본 이름으로 복원. `mapOpenAIError` 가 도구 정의 거절 400 을 `NOT_SUPPORTED` 로 분류 — `RETRYABLE_CODES` 밖이라 조용한 폴백 대신 사용자에게 드러난다.
- `::` 내부 규약은 그대로 둔다(역할 게이트·병렬 판정·헬스 서킷 6곳이 전제, 역할 게이트는 `::` 없으면 통과라 구분자 교체가 오히려 우회를 만든다).

## 검증
- 신규 테스트 7건(인코딩·히스토리·왕복 복원·400 분류·폴백 집합) + 기존 Codex 코덱 테스트 유지. provider 코덱 배선을 되돌리면 3건 실패 확인.
- providers·chat-service suite 291 passed, tsc 0, 대상 파일 lint 0.
- 라이브: 배포 후 chat.openmake.cc 에서 nvidia 모델 + MCP 도구 노출 턴으로 `invalid name` 400·폴백 0 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbGa9RXHjXeRfXTn1bonB1