### PR TITLE
fix: 보안 리뷰 잔여 3건 — 전역 MCP env 래핑·REST history images·dangling 심링크

### DIFF
--- a/apps/api/src/mcp/__tests__/server-registry-env-placeholder.test.ts
+++ b/apps/api/src/mcp/__tests__/server-registry-env-placeholder.test.ts
@@ -1,0 +1,43 @@
+/**
+ * 전역 registry 경로(부팅 initializeFromDB·수동 connect)도 `{{env.KEY}}` 자리표시자를 sh 변수 참조로
+ * 감싼다 — 유저풀(lifecycle-supervisor)만 감싸고 전역은 리터럴이 argv 로 내려가던 갭(2026-09-06).
+ */
+const clientCtor = jest.fn().mockImplementation(() => ({
+    connect: jest.fn().mockResolvedValue(undefined),
+    getTools: jest.fn().mockReturnValue([]),
+    disconnect: jest.fn().mockResolvedValue(undefined),
+    callTool: jest.fn(),
+}));
+jest.mock('../external-client', () => ({ ExternalMCPClient: clientCtor }));
+
+import { MCPServerRegistry } from '../server-registry';
+import type { MCPServerConfig } from '../types';
+
+const base = (over: Partial<MCPServerConfig>): MCPServerConfig => ({
+    id: 'srv1', name: 'pg', transport_type: 'stdio', enabled: true,
+    created_at: '2026-01-01', updated_at: '2026-01-01', ...over,
+} as MCPServerConfig);
+
+describe('MCPServerRegistry.connectServer — env 자리표시자 래핑', () => {
+    const registry = new MCPServerRegistry({ registerExternalTools: jest.fn(), unregisterExternalTools: jest.fn() } as never);
+    beforeEach(() => clientCtor.mockClear());
+
+    it('{{env.DATABASE_URL}} 위치 인자는 값 대신 "$DATABASE_URL" 셸 참조로 spawn 된다', async () => {
+        await registry.connectServer('srv1', base({
+            command: 'npx', args: ['-y', '@modelcontextprotocol/server-postgres', '{{env.DATABASE_URL}}'],
+            env: { DATABASE_URL: 'postgres://u:secret@h/db' },
+        }));
+        const cfg = clientCtor.mock.calls[0][0] as MCPServerConfig;
+        expect(cfg.command).toBe('sh');
+        expect(cfg.args?.join(' ')).toContain('"$DATABASE_URL"');
+        expect(JSON.stringify(cfg.args)).not.toContain('{{env.');
+        expect(JSON.stringify(cfg.args)).not.toContain('secret');
+    });
+
+    it('자리표시자가 없으면 command/args 원본 그대로', async () => {
+        await registry.connectServer('srv1', base({ command: 'npx', args: ['-y', 'pkg'] }));
+        const cfg = clientCtor.mock.calls[0][0] as MCPServerConfig;
+        expect(cfg.command).toBe('npx');
+        expect(cfg.args).toEqual(['-y', 'pkg']);
+    });
+});

--- a/apps/api/src/mcp/__tests__/user-sandbox-realpath.test.ts
+++ b/apps/api/src/mcp/__tests__/user-sandbox-realpath.test.ts
@@ -16,6 +16,8 @@ describe('UserSandbox.validatePath realpath', () => {
         fs.writeFileSync(path.join(userRoot, 'workspace', 'ok.txt'), 'x');
         fs.writeFileSync(path.join(outside, 'secret.txt'), 's');
         fs.symlinkSync(outside, path.join(userRoot, 'workspace', 'escape'));
+        // 대상이 없는(dangling) 심링크 — existsSync 는 false 라 부모만 검사하고 통과시키던 갭
+        fs.symlinkSync(path.join(outside, 'not-yet.txt'), path.join(userRoot, 'workspace', 'dangling'));
     });
     afterAll(() => { fs.rmSync(root, { recursive: true, force: true }); fs.rmSync(outside, { recursive: true, force: true }); });
 
@@ -28,6 +30,9 @@ describe('UserSandbox.validatePath realpath', () => {
     it('어휘적으로는 루트 안이지만 심링크가 밖을 가리키면 거부', () => {
         expect(UserSandbox.validatePath('u1', path.join(userRoot, 'workspace', 'escape', 'secret.txt'))).toBe(false);
         expect(UserSandbox.validatePath('u1', path.join(userRoot, 'workspace', 'escape'))).toBe(false);
+    });
+    it('대상이 없는 심링크(dangling)도 거부 — 쓰기가 링크를 따라 밖에 파일을 만드는 경로', () => {
+        expect(UserSandbox.validatePath('u1', path.join(userRoot, 'workspace', 'dangling'))).toBe(false);
     });
     it('어휘적 탈출(..)은 종전대로 거부', () => {
         expect(UserSandbox.validatePath('u1', path.join(userRoot, '..', 'u2', 'x'))).toBe(false);

--- a/apps/api/src/mcp/server-registry.ts
+++ b/apps/api/src/mcp/server-registry.ts
@@ -21,6 +21,7 @@
  */
 
 import { ExternalMCPClient } from './external-client';
+import { wrapEnvPlaceholdersAsShellRefs } from './env-placeholder-shell';
 import { ToolRouter } from './tool-router';
 import type { MCPServerConfig, MCPConnectionStatus } from './types';
 import type { UnifiedDatabase, MCPServerRow } from '../data/models/unified-database';
@@ -211,7 +212,20 @@ export class MCPServerRegistry {
             await this.disconnectServer(serverId);
         }
 
-        const client = new ExternalMCPClient(config);
+        // {{env.KEY}} 자리표시자는 값을 argv 에 박지 않고 sh 변수 참조로 감싼다(env-placeholder-shell).
+        // 유저풀(lifecycle-supervisor)만 감싸고 전역 경로(부팅 initializeFromDB·수동 connect)는 리터럴이
+        // 그대로 argv 로 내려가 spawn 이 실패하던 갭 — 2026-09-06. 자리표시자가 없으면 원본 그대로(멱등).
+        const shellWrapped = config.command
+            ? wrapEnvPlaceholdersAsShellRefs(config.command, Array.isArray(config.args) ? config.args : [])
+            : null;
+        const effective: MCPServerConfig = shellWrapped?.wrapped
+            ? { ...config, command: shellWrapped.command, args: shellWrapped.args }
+            : config;
+        if (shellWrapped?.wrapped) {
+            const missing = shellWrapped.keys.filter((k) => !(k in (config.env ?? {})));
+            if (missing.length) logger.warn(`{{env.*}} 참조 키가 env 에 없음 (빈값으로 전개) s=${serverId}: ${missing.join(',')}`);
+        }
+        const client = new ExternalMCPClient(effective);
         this.connections.set(serverId, client);
 
         await client.connect();

--- a/apps/api/src/mcp/user-sandbox.ts
+++ b/apps/api/src/mcp/user-sandbox.ts
@@ -157,9 +157,13 @@ export class UserSandbox {
         } catch {
             return false;
         }
+        // ⚠️ existsSync 는 심링크를 따라가므로 대상이 없는(dangling) 심링크를 "미존재" 로 봐 부모만
+        // 검사하고 통과시킨다 — 이후 writeFile 이 그 심링크를 따라 루트 밖에 파일을 만든다. lstat 로
+        // 링크 자체의 존재를 보고, dangling 이면 realpath 가 실패해 fail-closed 로 거부된다(2026-09-06).
+        const existsNoFollow = (p: string): boolean => { try { fs.lstatSync(p); return true; } catch { return false; } };
         let probe = resolvedPath;
         for (;;) {
-            if (fs.existsSync(probe)) break;
+            if (existsNoFollow(probe)) break;
             const parent = path.dirname(probe);
             if (parent === probe) return true; // 파일시스템 루트까지 아무것도 없음 — 루트 자체가 미생성
             probe = parent;

--- a/apps/api/src/schemas/__tests__/chat-history-images.test.ts
+++ b/apps/api/src/schemas/__tests__/chat-history-images.test.ts
@@ -1,0 +1,19 @@
+/**
+ * REST /api/chat 히스토리 메시지의 images 보존 — chatMessageSchema 에 키가 없으면 zod strip 으로
+ * validate 가 조용히 지워 멀티턴 vision 이 REST 에서만 끊겼다(2026-09-06).
+ */
+import { chatRequestSchema } from '../chat.schema';
+import { FILE_ATTACH_LIMITS } from '../../config/runtime-limits';
+
+const img = 'data:image/png;base64,iVBORw0KGgo=';
+
+describe('chatRequestSchema.history[].images', () => {
+    it('히스토리 user 메시지의 images 가 파싱 결과에 남는다', () => {
+        const r = chatRequestSchema.parse({ message: '이 그림은?', history: [{ role: 'user', content: '앞선 그림', images: [img] }] });
+        expect((r.history?.[0] as unknown as { images?: string[] }).images).toEqual([img]);
+    });
+    it('개수 상한은 현재 턴 images 와 동일', () => {
+        const many = Array.from({ length: FILE_ATTACH_LIMITS.MAX_IMAGES + 1 }, () => img);
+        expect(() => chatRequestSchema.parse({ message: 'x', history: [{ role: 'user', content: '', images: many }] })).toThrow();
+    });
+});

--- a/apps/api/src/schemas/chat.schema.ts
+++ b/apps/api/src/schemas/chat.schema.ts
@@ -39,6 +39,9 @@ const chatMessageSchema = z.object({
     content: secureTextSchema({ maxLength: 100000, fieldName: 'content', allowHtmlLikeContent: true, detectMaliciousPatterns: false }).or(z.null()).optional().default(''),
     tool_calls: z.array(toolCallInMessageSchema).optional(),
     tool_call_id: secureOptionalTextSchema({ maxLength: 200, fieldName: 'tool_call_id', allowNewLines: false, detectMaliciousPatterns: false }),
+    // 히스토리 vision 이미지 — zod 기본 strip 이라 키가 없으면 validate 가 조용히 지워 WS/openai-compat
+    // 경로와 달리 REST 만 멀티턴 vision 이 끊겼다(2026-09-06). 상한은 현재 턴 images 와 동일.
+    images: z.array(z.string().max(FILE_ATTACH_LIMITS.MAX_IMAGE_DATAURL_CHARS)).max(FILE_ATTACH_LIMITS.MAX_IMAGES).optional(),
 });
 
 /**

--- a/apps/api/src/services/task-sandbox/sandbox.test.ts
+++ b/apps/api/src/services/task-sandbox/sandbox.test.ts
@@ -69,6 +69,8 @@ describe('task-sandbox pure functions', () => {
             await symlink(outside, join(ws, 'leakdir'));
             // 내부 심링크: ws/alias → ws/inner (workspace 안에서 안으로 — 허용)
             await symlink(join(ws, 'inner'), join(ws, 'alias'));
+            // 대상이 없는(dangling) 심링크: realpath ENOENT 를 "미실존" 으로 넘기면 통과하던 갭
+            await symlink(join(outside, 'not-yet.txt'), join(ws, 'dangling'));
         });
         afterAll(async () => {
             await rm(base, { recursive: true, force: true });
@@ -80,6 +82,9 @@ describe('task-sandbox pure functions', () => {
         it('workspace 밖을 가리키는 디렉토리 심링크 경유 차단 (실존/미실존 꼬리 모두)', async () => {
             await expect(safeRealWorkspacePath(ws, 'leakdir/secret.txt')).rejects.toThrow('symlink');
             await expect(safeRealWorkspacePath(ws, 'leakdir/newfile.txt')).rejects.toThrow('symlink');
+        });
+        it('대상이 없는 심링크(dangling)는 차단 — 쓰기가 링크를 따라 밖에 파일을 만드는 경로', async () => {
+            await expect(safeRealWorkspacePath(ws, 'dangling')).rejects.toThrow('symlink');
         });
         it('내부 → 내부 심링크는 허용 (대상 실경로 반환)', async () => {
             const p = await safeRealWorkspacePath(ws, 'alias/x.txt');

--- a/apps/api/src/services/task-sandbox/sandbox.ts
+++ b/apps/api/src/services/task-sandbox/sandbox.ts
@@ -15,7 +15,7 @@
  * @module services/task-sandbox/sandbox
  */
 import { spawn } from 'child_process';
-import { mkdir, rm, writeFile as fsWriteFile, readFile as fsReadFile, readdir, stat, realpath, copyFile as fsCopyFile } from 'fs/promises';
+import { mkdir, rm, writeFile as fsWriteFile, readFile as fsReadFile, readdir, stat, lstat, realpath, copyFile as fsCopyFile } from 'fs/promises';
 import { resolve, sep, join, dirname, basename, relative } from 'path';
 import { getTaskSandboxConfig, type TaskSandboxConfig } from '../../config/task-sandbox';
 import type { TaskExecutor, ExecResult } from './executor';
@@ -135,6 +135,11 @@ export async function safeRealWorkspacePath(hostWorkdir: string, userPath: strin
             real = await realpath(probe);
         } catch (e) {
             if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e;
+            // realpath ENOENT 는 "경로 없음" 과 "대상이 없는 심링크" 를 구분하지 못한다. 후자를 미실존으로
+            // 넘기면 부모 실경로 + 이름으로 통과해 writeFile 이 링크를 따라 밖에 파일을 만든다(2026-09-06).
+            if (await lstat(probe).then(() => true, () => false)) {
+                throw new Error(`workspace 경로 탈출 차단(symlink): ${userPath}`);
+            }
             const parent = dirname(probe);
             if (parent === probe) throw e; // 파일시스템 루트까지 미실존 — 비정상
             rest = rest ? join(basename(probe), rest) : basename(probe);


### PR DESCRIPTION
## 배경
2026-09-02 보안 리뷰 후속 후보 4건을 재검증한 결과(2026-09-06) 원 후보는 전부 이미 해결돼 있었고, 대신 위생 수준 잔여 3건이 남아 별건으로 닫는다. 운영 영향은 현재 0(전역 서버에 자리표시자 없음·심링크 프리미티브 없음)이라 예방적 수정이다.

## 변경 (커밋 3개)
1. **전역 MCP registry 경로 `{{env.KEY}}` 래핑** — `ServerRegistry.connectServer` 가 `wrapEnvPlaceholdersAsShellRefs` 를 거치게 해 부팅·수동 connect 도 유저풀과 같은 규칙(값은 env, argv 엔 `"$KEY"`). 자리표시자 없으면 원본 그대로.
2. **REST `/api/chat` history images** — `chatMessageSchema` 에 `images`(현재 턴과 같은 상한) 추가. zod strip 으로 조용히 지워져 REST 만 멀티턴 vision 이 끊기던 기능 불일치.
3. **dangling 심링크** — `UserSandbox.validatePath` 는 `lstat` 기반 존재 판정, `safeRealWorkspacePath` 는 realpath ENOENT 시 `lstat` 로 링크 실존을 확인해 차단. 양쪽 공통 갭.

## 검증
- 신규/보강 테스트 6건, 관련 5 suite 39 passed. **파일별로 수정을 되돌리면 각 1건씩 실패** 확인(스키마는 런타임 실패로 보강).
- tsc 0, 대상 파일 lint 0, Gate 3(600줄) 여유.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbGa9RXHjXeRfXTn1bonB1