### PR TITLE
feat(agent-task): 코딩 고도화 1차 — 도구 결과 접기·grep_code/repo_map·workspace 테스트 게이트

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1169,6 +1169,26 @@ AGENT_TASK_TIMEOUT_MS=600000
 # AGENT_TASK_VERIFY_DELIVERABLE=true
 # AGENT_TASK_VERIFY_DELIVERABLE_MAX_RETRIES=1
 
+# Agent Task — workspace 테스트 게이트 (2026-09-06). 완료 전 레포에 이미 있는 러너(npm test/pytest/go test)를
+# 1회 실행해 실패 출력을 주입하고 수정 턴을 준다. 러너가 없으면 no-op(리포트형 작업 무영향). 기본 ON.
+# AGENT_TASK_WORKSPACE_TEST_GATE=true
+# AGENT_TASK_WORKSPACE_TEST_MAX_RETRIES=2
+# AGENT_TASK_WORKSPACE_TEST_REPORT_MAX_CHARS=3000
+
+# Agent Task — 오래된 도구 결과 접기 (2026-09-06). 최근 KEEP_TURNS 턴보다 오래된 tool 결과 중 MIN_CHARS 초과분을
+# 앞 HEAD_CHARS 만 남긴 스텁으로 치환(재전송 O(n²) 완화, 원문은 스텝 DB 보존). 기본 ON.
+# AGENT_TASK_CONTEXT_FOLD=true
+# AGENT_TASK_CONTEXT_FOLD_KEEP_TURNS=4
+# AGENT_TASK_CONTEXT_FOLD_MIN_CHARS=1500
+# AGENT_TASK_CONTEXT_FOLD_HEAD_CHARS=240
+
+# Task 샌드박스 코드 탐색 도구 grep_code·repo_map 상한 (2026-09-06)
+# TASK_CODE_NAV_GREP_MAX_RESULTS=80
+# TASK_CODE_NAV_GREP_LINE_MAX_CHARS=200
+# TASK_CODE_NAV_GREP_PER_FILE_MAX=20
+# TASK_CODE_NAV_MAP_MAX_FILES=300
+# TASK_CODE_NAV_MAP_MAX_SYMBOLS=200
+
 # Agent Task — 전용 레이트 리밋 (15분 window. Docker 샌드박스 spawn + LLM 루프라 비용 최상급).
 # GET/HEAD 진행 폴링은 제외, 생성(POST /api/agent-tasks)만 CREATE 한도로 별도 제한.
 # RL_AGENT_TASK_IP=60

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1743,6 +1743,25 @@ export const AGENT_TASK_LIMITS = {
     VERIFY_DELIVERABLE_ENABLED: process.env.AGENT_TASK_VERIFY_DELIVERABLE !== 'false',
     /** 산출물 검증 실패 시 자가수정 재시도 최대 횟수 — 초과하면 검증을 건너뛰고 완료(무한루프 방지). */
     VERIFY_DELIVERABLE_MAX_RETRIES: parseInt(process.env.AGENT_TASK_VERIFY_DELIVERABLE_MAX_RETRIES || '1', 10),
+    /** workspace 테스트 게이트(2026-09-06) — 완료 관문에서 workspace 에 **이미 있는** 테스트 러너
+     *  (package.json scripts.test + node_modules · pytest 설정/tests 디렉토리)를 감지하면 1회 실행해
+     *  실패 출력을 주입하고 수정 턴을 준다. 러너가 없으면 아무 것도 하지 않는다(리포트형 작업 무영향).
+     *  실행 grounding 이 self-critique 보다 값싸고 정확하다는 같은 원칙(deliverable-verify).
+     *  AGENT_TASK_WORKSPACE_TEST_GATE=false 로 비활성. */
+    WORKSPACE_TEST_GATE_ENABLED: process.env.AGENT_TASK_WORKSPACE_TEST_GATE !== 'false',
+    /** 테스트 실패 시 수정 턴 최대 횟수 — verifyRetries 카운터를 deliverable 검증과 공유한다. */
+    WORKSPACE_TEST_MAX_RETRIES: parseInt(process.env.AGENT_TASK_WORKSPACE_TEST_MAX_RETRIES || '2', 10),
+    /** 테스트 실패 출력 중 모델에 주입할 최대 글자(끝부분 우선 — 실패 요약은 보통 마지막에 있다). */
+    WORKSPACE_TEST_REPORT_MAX_CHARS: parseInt(process.env.AGENT_TASK_WORKSPACE_TEST_REPORT_MAX_CHARS || '3000', 10),
+    /** 오래된 도구 결과 접기(2026-09-06) — 매 턴 전체 대화를 재전송하므로 비용이 턴 수에 O(n²)로
+     *  붙는다(30일 실측: 완료 작업 평균 43만 토큰, 스텝 본문 총량의 ~18배). 최근 KEEP_TURNS 개
+     *  assistant 턴보다 오래된 tool 메시지 중 MIN_CHARS 를 넘는 것을 앞부분 HEAD_CHARS 만 남긴
+     *  스텁으로 치환한다(원문은 스텝 DB 에 그대로 — 모델은 필요 시 같은 도구를 다시 호출).
+     *  AGENT_TASK_CONTEXT_FOLD=false 로 비활성. */
+    CONTEXT_FOLD_ENABLED: process.env.AGENT_TASK_CONTEXT_FOLD !== 'false',
+    CONTEXT_FOLD_KEEP_TURNS: parseInt(process.env.AGENT_TASK_CONTEXT_FOLD_KEEP_TURNS || '4', 10),
+    CONTEXT_FOLD_MIN_CHARS: parseInt(process.env.AGENT_TASK_CONTEXT_FOLD_MIN_CHARS || '1500', 10),
+    CONTEXT_FOLD_HEAD_CHARS: parseInt(process.env.AGENT_TASK_CONTEXT_FOLD_HEAD_CHARS || '240', 10),
     /** 마무리 턴 본문 채택 임계(글자) — 자원 상한으로 도구를 막은 턴에서 모델이 도구 호출과 본문을
      *  함께 뱉었을 때, 본문이 이 길이 이상이면 최종 답변으로 채택해 완료 관문으로 보낸다.
      *  (미만이면 종전대로 응답을 버리고 다음 턴/턴상한 종료 — "산출물 다 만들고 실패 기록" 방지와
@@ -2074,4 +2093,25 @@ export const MCP_SANDBOX_BOOTSTRAP = {
     ORPHAN_REAP_ENABLED: process.env.MCP_SANDBOX_ORPHAN_REAP !== 'false',
     /** 1회 스윕에서 처리할 최대 컨테이너 수 (폭주 안전판) */
     ORPHAN_REAP_MAX: parseInt(process.env.MCP_SANDBOX_ORPHAN_REAP_MAX || '', 10) || 50,
+} as const;
+
+/**
+ * Task 샌드박스 코드 탐색 도구(grep_code·repo_map, 2026-09-06) 상한.
+ * 30일 실측: bash 호출 444건 중 탐색·읽기(grep/find/ls/cat)가 150건(34%)이고 결과가 통째로 대화에
+ * 들어갔다. 전용 도구는 결과를 파일:줄 형태로 캡을 걸어 돌려준다(읽기 전용, 승인 대상 아님).
+ * ⚠️ 이름에 'search' 를 쓰지 않는다 — AGENT_TASK_LIMITS.SEARCH_TOOL_KEYWORDS 가 웹검색 상한으로 센다.
+ */
+export const TASK_CODE_NAV = {
+    /** grep_code 가 돌려주는 최대 매치 줄 수. TASK_CODE_NAV_GREP_MAX_RESULTS 로 오버라이드. */
+    GREP_MAX_RESULTS: parseInt(process.env.TASK_CODE_NAV_GREP_MAX_RESULTS || '80', 10),
+    /** 매치 줄 한 줄의 최대 글자(미니파이 파일 방어). */
+    GREP_LINE_MAX_CHARS: parseInt(process.env.TASK_CODE_NAV_GREP_LINE_MAX_CHARS || '200', 10),
+    /** 파일당 최대 매치 수(rg -m). */
+    GREP_PER_FILE_MAX: parseInt(process.env.TASK_CODE_NAV_GREP_PER_FILE_MAX || '20', 10),
+    /** repo_map 이 나열하는 최대 파일 수(줄 수 포함). */
+    MAP_MAX_FILES: parseInt(process.env.TASK_CODE_NAV_MAP_MAX_FILES || '300', 10),
+    /** repo_map 심볼 개요 최대 줄 수(function/class/def 선언). */
+    MAP_MAX_SYMBOLS: parseInt(process.env.TASK_CODE_NAV_MAP_MAX_SYMBOLS || '200', 10),
+    /** 탐색에서 제외하는 디렉토리(빌드 산출물·의존성·VCS). */
+    EXCLUDED_DIRS: ['node_modules', '.git', 'dist', 'build', '.next', '__pycache__', '.venv', 'venv', 'coverage', '.openmake'] as readonly string[],
 } as const;

--- a/apps/api/src/config/skill-compat.ts
+++ b/apps/api/src/config/skill-compat.ts
@@ -41,7 +41,7 @@ export const CLAUDE_TOOL_ALIASES: Readonly<Record<string, string | null>> = {
     KillShell: 'bash',
     KillBash: 'bash',
     Glob: 'bash',
-    Grep: 'bash',
+    Grep: 'grep_code',
     LS: 'bash',
     // 웹
     WebFetch: 'web_scrape',

--- a/apps/api/src/prompts/agent-task-prompt.ts
+++ b/apps/api/src/prompts/agent-task-prompt.ts
@@ -110,6 +110,12 @@ export function getTaskSandboxGuidance(): string {
         '- 당신에게는 격리된 가상 컴퓨터가 있습니다: 작업 디렉토리 /workspace + 셸(bash) + python + 브라우저.',
         '- /workspace 의 파일은 단계 간 유지됩니다. 산출물 파일은 여기에 저장하세요.',
         '- bash/python_execute/str_replace_editor/file_ops 로 파일을 만들고 실행하고 편집하세요.',
+        '- 코드 탐색은 grep_code(정규식 → 파일:줄)·repo_map(구조·줄 수·심볼 개요) 를 먼저 쓰세요 — 결과가',
+        '  캡으로 잘려 컨텍스트를 아낍니다. bash 의 cat/grep/find 로 큰 출력을 통째로 받지 마세요.',
+        '- 오래된 도구 결과는 앞부분만 남기고 접힙니다("[접힌 도구 결과]"). 원문이 다시 필요하면 같은 도구를',
+        '  다시 호출하세요(파일 내용은 file_ops read). 편집할 때는 방금 읽은 최신 내용을 기준으로 하세요.',
+        '- workspace 에 테스트 러너(package.json scripts.test·pytest·go test)가 있으면 완료 시 자동 실행됩니다 —',
+        '  실패하면 수정 요청이 오니, 파일을 고친 뒤엔 직접 테스트를 돌려 확인하세요.',
         '- 오피스/PDF 산출물은 python_execute 로 생성·편집하세요(모두 설치됨, 바로 import): Excel(.xlsx)=openpyxl',
         '  (`wb.save(...)`), Word(.docx)=python-docx(`from docx import Document`), PowerPoint(.pptx)=python-pptx',
         '  (`from pptx import Presentation`), PDF 생성=reportlab/fpdf2, PDF 조작(병합/분할/회전/워터마크)=pypdf,',
@@ -264,6 +270,22 @@ export function getAgentTaskApprovalTimeoutNudge(): string {
 }
 
 /** 산출물 문법/컴파일 검사 실패 시 주입(Phase 2-B) — 오류를 근거로 코드 산출물을 1회 자가수정 유도. */
+/**
+ * workspace 테스트 게이트 실패 시 주입 — 레포의 테스트 러너(npm test/pytest/go test) 출력 끝부분.
+ * 산출물 재작성이 아니라 **workspace 파일 수정** 을 요구한다(deliverable nudge 와 다른 점).
+ */
+export function getAgentTaskTestsFailedNudge(runner: string, report: string): string {
+    return [
+        `완료 전에 workspace 의 테스트(${runner})를 실행했더니 실패했습니다:`,
+        '',
+        report,
+        '',
+        '실패 원인을 grep_code·file_ops read 로 확인하고 str_replace_editor 로 workspace 파일을 고친 뒤,',
+        `bash 로 같은 테스트를 다시 실행해 통과를 확인하고 마무리하세요. 이 실패가 당신의 변경과 무관한`,
+        '기존 실패라면 그 근거(어느 테스트가 왜 원래 실패하는지)를 최종 답변에 명시하세요.',
+    ].join('\n');
+}
+
 export function getAgentTaskVerifyFailedNudge(report: string): string {
     return [
         '작성한 코드 산출물에 문법/컴파일 오류가 발견되었습니다:',

--- a/apps/api/src/services/AgentTaskService.ts
+++ b/apps/api/src/services/AgentTaskService.ts
@@ -50,6 +50,7 @@ import { recoverTextToolCalls } from './agent-task/text-tool-calls';
 import { executeTurnToolCalls } from './agent-task/turn-executor';
 import { prepareToolArgs } from './agent-task/tool-args';
 import { assembleAgentTools } from './agent-task/tool-assembly';
+import { foldOldToolResults } from './agent-task/context-fold';
 import { buildAgentTaskSystemContent, resolveSkillToolBindings } from './agent-task/skill-block';
 
 // 기존 import 호환 재노출 — 타입/에러는 services/agent-task/types 로 분리 (파일 크기 가드).
@@ -324,6 +325,15 @@ export class AgentTaskService {
                 // user 메시지로 주입해 방향을 조정한다. 턴 경계 소비라 tool_call_id 매칭이 유지되고
                 // 다음 checkpoint 에 자연 포함된다(resume 안전). 스텝으로 기록해 상세/카드에 노출.
                 stepNumber = await applyPendingSteering(taskId, turn, conversation, stepNumber, emitStep);
+                // 오래된 도구 결과 접기 — 재전송 O(n²) 완화. 원문은 스텝 DB 에 남고 최근 턴은 유지(context-fold).
+                if (AGENT_TASK_LIMITS.CONTEXT_FOLD_ENABLED) {
+                    const fold = foldOldToolResults(conversation, {
+                        keepTurns: AGENT_TASK_LIMITS.CONTEXT_FOLD_KEEP_TURNS,
+                        minChars: AGENT_TASK_LIMITS.CONTEXT_FOLD_MIN_CHARS,
+                        headChars: AGENT_TASK_LIMITS.CONTEXT_FOLD_HEAD_CHARS,
+                    });
+                    if (fold.folded > 0) logger.info(`[AgentTask] 도구 결과 접기: ${taskId} (turn ${turn + 1}, ${fold.folded}건, -${fold.savedChars}자)`);
+                }
 
                 // per-call abort: 작업 잔여 예산을 호출에도 바인딩 — 응답이 hang 되면
                 // 턴 사이 assertWithinLimits 까지 도달하지 못하므로 호출 자체를 끊는다.

--- a/apps/api/src/services/agent-task/context-fold.test.ts
+++ b/apps/api/src/services/agent-task/context-fold.test.ts
@@ -1,0 +1,67 @@
+import { foldOldToolResults, isFoldedToolResult, FOLD_MARKER } from './context-fold';
+import type { ChatMessage } from '../../llm/types';
+
+const OPTS = { keepTurns: 2, minChars: 100, headChars: 40 };
+const big = (tag: string) => `${tag} ` + 'x'.repeat(500);
+
+function conv(turns: number, resultChars = 500): ChatMessage[] {
+    const c: ChatMessage[] = [{ role: 'system', content: 'sys' }, { role: 'user', content: 'goal' }];
+    for (let t = 0; t < turns; t++) {
+        c.push({ role: 'assistant', content: '', tool_calls: [{ id: `c${t}`, type: 'function', function: { name: 'bash', arguments: {} } }] });
+        c.push({ role: 'tool', content: `turn${t} ` + 'y'.repeat(resultChars), tool_name: 'bash', tool_call_id: `c${t}` });
+    }
+    return c;
+}
+
+describe('foldOldToolResults', () => {
+    it('keepTurns 이내 턴은 원문 유지, 그보다 오래된 큰 결과만 접는다', () => {
+        const c = conv(4);
+        const st = foldOldToolResults(c, OPTS);
+        expect(st.folded).toBe(2);
+        expect(st.savedChars).toBeGreaterThan(0);
+        const tools = c.filter((m) => m.role === 'tool');
+        expect(isFoldedToolResult(tools[0].content)).toBe(true);
+        expect(isFoldedToolResult(tools[1].content)).toBe(true);
+        expect(isFoldedToolResult(tools[2].content)).toBe(false);
+        expect(isFoldedToolResult(tools[3].content)).toBe(false);
+        // 스텁은 도구명·원문 길이·앞부분을 담는다(judge 증거창용)
+        expect(tools[0].content).toContain('bash');
+        expect(tools[0].content).toContain('turn0');
+        expect(tools[0].content.startsWith(FOLD_MARKER)).toBe(true);
+    });
+
+    it('아직 keepTurns 를 넘는 턴이 없으면 아무 것도 접지 않는다', () => {
+        const c = conv(2);
+        expect(foldOldToolResults(c, OPTS)).toEqual({ folded: 0, savedChars: 0 });
+        expect(c.filter((m) => m.role === 'tool').every((m) => !isFoldedToolResult(m.content))).toBe(true);
+    });
+
+    it('minChars 이하의 결과는 오래돼도 접지 않는다', () => {
+        const c = conv(4, 50);
+        expect(foldOldToolResults(c, OPTS).folded).toBe(0);
+    });
+
+    it('멱등 — 두 번 호출해도 이미 접힌 스텁은 다시 접지 않는다', () => {
+        const c = conv(5);
+        foldOldToolResults(c, OPTS);
+        const again = foldOldToolResults(c, OPTS);
+        expect(again.folded).toBe(0);
+    });
+
+    it('턴이 늘면 접기 경계가 앞으로 이동한다', () => {
+        const c = conv(3);
+        expect(foldOldToolResults(c, OPTS).folded).toBe(1);
+        c.push({ role: 'assistant', content: '', tool_calls: [{ id: 'c9', type: 'function', function: { name: 'bash', arguments: {} } }] });
+        c.push({ role: 'tool', content: big('turn9'), tool_name: 'bash', tool_call_id: 'c9' });
+        expect(foldOldToolResults(c, OPTS).folded).toBe(1);
+    });
+
+    it('system·user·assistant 메시지는 건드리지 않는다', () => {
+        const c = conv(4);
+        c[1].content = 'goal ' + 'g'.repeat(1000);
+        foldOldToolResults(c, OPTS);
+        expect(c[0].content).toBe('sys');
+        expect(c[1].content.startsWith('goal ')).toBe(true);
+        expect(c[1].content.length).toBe(1005);
+    });
+});

--- a/apps/api/src/services/agent-task/context-fold.ts
+++ b/apps/api/src/services/agent-task/context-fold.ts
@@ -1,0 +1,82 @@
+/**
+ * Agent Task 오래된 도구 결과 접기 (context fold, 2026-09-06).
+ *
+ * 루프는 매 턴 conversation 전체를 다시 보내므로 비용이 턴 수에 O(n²) 로 붙는다. 30일 실측
+ * (완료 44건): 평균 43.5만 토큰인데 스텝 본문 총량은 그 1/18 — 차이가 전부 재전송이다. 도구 결과
+ * 절단(MAX_TOOL_RESULT_CHARS)은 발동률 2.2% 라 상한이 아니라 **누적 재전송**이 병목이다.
+ *
+ * 규칙(결정적, LLM 없음):
+ *  - 최근 KEEP_TURNS 개 assistant 메시지에 속한 tool 결과는 원문 유지(모델이 방금 본 것).
+ *  - 그보다 오래된 tool 결과 중 MIN_CHARS 초과분을 앞부분 HEAD_CHARS + 안내 한 줄의 스텁으로 치환.
+ *  - 이미 접힌 스텁(FOLD_MARKER 로 시작)은 건너뛴다(멱등).
+ *  - 원문은 agent_task_steps.tool_result 에 그대로 남아 있다(사후 분석·UI 무영향).
+ *
+ * ⚠️ 스텁의 앞부분(HEAD_CHARS)을 남기는 이유: goal judge 증거창(buildJudgeToolEvidence)이 최근
+ * tool 결과 8개를 320자씩 읽는다 — 전부 지우면 판정 증거가 사라진다.
+ *
+ * @module services/agent-task/context-fold
+ */
+import type { ChatMessage } from '../../llm/types';
+
+export const FOLD_MARKER = '[접힌 도구 결과]';
+
+export interface FoldOptions {
+    /** 원문을 유지할 최근 assistant 턴 수. */
+    keepTurns: number;
+    /** 이 길이 이하의 결과는 접지 않는다. */
+    minChars: number;
+    /** 스텁에 남기는 앞부분 길이. */
+    headChars: number;
+}
+
+export interface FoldStats {
+    /** 이번 호출에서 새로 접은 메시지 수. */
+    folded: number;
+    /** 새로 접어서 줄어든 글자 수(원문 − 스텁). */
+    savedChars: number;
+}
+
+export function isFoldedToolResult(content: string): boolean {
+    return content.startsWith(FOLD_MARKER);
+}
+
+function buildStub(toolName: string | undefined, original: string, headChars: number): string {
+    const head = original.slice(0, headChars).replace(/\s+$/, '');
+    const ellipsis = original.length > headChars ? '…' : '';
+    return `${FOLD_MARKER} ${toolName ?? 'tool'} 결과 ${original.length}자 — 앞부분만 남김. `
+        + '원문이 다시 필요하면 같은 도구를 다시 호출하세요.\n'
+        + head + ellipsis;
+}
+
+/**
+ * conversation 을 제자리에서 접는다. 반환값은 관측용 통계.
+ * 턴 경계는 assistant 메시지로 센다(도구 결과는 직전 assistant 의 tool_calls 에 속한다).
+ */
+export function foldOldToolResults(conversation: ChatMessage[], opts: FoldOptions): FoldStats {
+    const stats: FoldStats = { folded: 0, savedChars: 0 };
+    if (opts.keepTurns < 0 || conversation.length === 0) return stats;
+
+    // 뒤에서부터 keepTurns 번째 assistant 의 인덱스 — 그 assistant(와 그 턴의 tool 결과)까지는 유지하고,
+    // 그 앞의 tool 메시지가 접기 대상. keepTurns 0 은 경계를 못 잡아 접지 않는다(사실상 비활성).
+    let assistantsSeen = 0;
+    let boundary = conversation.length; // 이 인덱스 미만이 "오래된" 영역
+    for (let i = conversation.length - 1; i >= 0; i--) {
+        if (conversation[i].role !== 'assistant') continue;
+        assistantsSeen++;
+        if (assistantsSeen === opts.keepTurns) { boundary = i; break; }
+    }
+    if (boundary === conversation.length) return stats; // 아직 keepTurns 만큼의 턴이 없다
+
+    for (let i = 0; i < boundary; i++) {
+        const m = conversation[i];
+        if (m.role !== 'tool') continue;
+        const content = typeof m.content === 'string' ? m.content : '';
+        if (content.length <= opts.minChars || isFoldedToolResult(content)) continue;
+        const stub = buildStub(m.tool_name, content, opts.headChars);
+        if (stub.length >= content.length) continue; // 접어서 이득이 없으면 원문 유지
+        m.content = stub;
+        stats.folded++;
+        stats.savedChars += content.length - stub.length;
+    }
+    return stats;
+}

--- a/apps/api/src/services/agent-task/finalize.test.ts
+++ b/apps/api/src/services/agent-task/finalize.test.ts
@@ -21,6 +21,7 @@ jest.mock('./goal-judge', () => ({
     buildJudgeExecutionContext: jest.fn(() => 'ctx'),
 }));
 jest.mock('./deliverable-verify', () => ({ verifyCodeArtifacts: jest.fn(async () => ({ ok: true, report: '' })) }));
+jest.mock('./workspace-test-verify', () => ({ verifyWorkspaceTests: jest.fn(async (_r: unknown, _t: string, _u: unknown, n: number) => ({ ran: false, ok: true, report: '', stepNumber: n })) }));
 jest.mock('./role-client', () => ({ judgeClientFor: jest.fn(async () => ({})) }));
 jest.mock('./task-steps', () => ({
     persistArtifactSteps: jest.fn(async (_t: string, _a: unknown[], n: number) => n + 1),
@@ -32,6 +33,7 @@ import { finalizeTask, type FinalizeInput } from './finalize';
 import { judgeGoal } from './goal-judge';
 import { persistJudgeStep } from './task-steps';
 import { verifyCodeArtifacts } from './deliverable-verify';
+import { verifyWorkspaceTests } from './workspace-test-verify';
 import { AGENT_TASK_INCOMPLETE_MARKER } from '../../prompts/agent-task-prompt';
 import type { TaskRuntime } from '../task-sandbox/runtime';
 import type { TaskSandboxConfig } from '../../config/task-sandbox';
@@ -39,6 +41,7 @@ import type { TaskSandboxConfig } from '../../config/task-sandbox';
 const judgeMock = judgeGoal as jest.MockedFunction<typeof judgeGoal>;
 const judgeStepMock = persistJudgeStep as jest.MockedFunction<typeof persistJudgeStep>;
 const verifyMock = verifyCodeArtifacts as jest.MockedFunction<typeof verifyCodeArtifacts>;
+const testsMock = verifyWorkspaceTests as jest.MockedFunction<typeof verifyWorkspaceTests>;
 
 /** 코드 아티팩트 1개를 담은 최종 응답 — 실제 파서를 통과하는 형태. */
 const WITH_ARTIFACT = '정리했습니다.\n<artifact kind="code" lang="python" title="t">print(1)</artifact>';
@@ -229,5 +232,41 @@ describe('finalizeTask — 완료 관문 단일화(091)', () => {
         await finalizeTask(i);
 
         expect(lastUpdate(i).result).toBe('3개 파일을 생성했습니다.');
+    });
+});
+
+describe('finalizeTask — workspace 테스트 게이트(2026-09-06)', () => {
+    it('테스트 실패면 completed 대신 verify_retry 로 수정 턴을 준다(러너 출력이 nudge 에 실림)', async () => {
+        testsMock.mockResolvedValueOnce({ ran: true, ok: false, runner: 'npm', report: 'FAIL src/x.test.ts\n[exit=1]', stepNumber: 6 });
+        const i = input({ path: 'terminate', terminateSummary: '완료' });
+
+        const out = await finalizeTask(i);
+
+        expect(out.kind).toBe('verify_retry');
+        expect(out.stepNumber).toBe(6);
+        expect((out as { nudge: string }).nudge).toContain('FAIL src/x.test.ts');
+        expect((out as { nudge: string }).nudge).toContain('npm');
+        expect(judgeMock).not.toHaveBeenCalled();
+        expect(lastUpdate(i)).toBeUndefined();
+    });
+
+    it('재시도 상한(WORKSPACE_TEST_MAX_RETRIES)에 닿으면 게이트를 건너뛰고 완료한다', async () => {
+        judgeMock.mockResolvedValue({ achieved: true, reason: 'ok', raw: '' });
+        const i = input({ path: 'terminate', terminateSummary: '완료', verifyRetries: 99 });
+
+        const out = await finalizeTask(i);
+
+        expect(testsMock).not.toHaveBeenCalled();
+        expect(out.kind).toBe('completed');
+    });
+
+    it('러너가 없으면(ran=false) 통과해 종전 흐름 그대로 완료한다', async () => {
+        judgeMock.mockResolvedValue({ achieved: true, reason: 'ok', raw: '' });
+        const i = input({ path: 'terminate', terminateSummary: '완료' });
+
+        const out = await finalizeTask(i);
+
+        expect(testsMock).toHaveBeenCalledTimes(1);
+        expect(out.kind).toBe('completed');
     });
 });

--- a/apps/api/src/services/agent-task/finalize.ts
+++ b/apps/api/src/services/agent-task/finalize.ts
@@ -26,9 +26,10 @@ import type { getUnifiedDatabase } from '../../data/models/unified-database';
 import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
 import { extractAndStripArtifacts } from '../../llm/artifact-parser';
 import { applyReportRender } from '../chat-service/report-block';
-import { AGENT_TASK_INCOMPLETE_MARKER, getAgentTaskVerifyFailedNudge } from '../../prompts/agent-task-prompt';
+import { AGENT_TASK_INCOMPLETE_MARKER, getAgentTaskVerifyFailedNudge, getAgentTaskTestsFailedNudge } from '../../prompts/agent-task-prompt';
 import { judgeGoal, buildJudgeExecutionContext, buildJudgeArtifactSummary } from './goal-judge';
 import { verifyCodeArtifacts } from './deliverable-verify';
+import { verifyWorkspaceTests } from './workspace-test-verify';
 import { persistArtifactSteps, persistJudgeStep } from './task-steps';
 import { maybePersistCodeDiff } from './code-diff';
 import { judgeClientFor } from './role-client';
@@ -123,6 +124,19 @@ export async function finalizeTask(input: FinalizeInput): Promise<FinalizeOutcom
             return { kind: 'verify_retry', stepNumber, nudge: getAgentTaskVerifyFailedNudge(verify.report) };
         }
     }
+    // workspace 테스트 게이트 — 레포에 이미 있는 러너만 1회 실행(없으면 no-op). 파일을 편집한 작업 한정.
+    // 재시도 카운터는 deliverable 검증과 공유(둘 다 verifyRetries++) — 합산 상한으로 무한루프 방지.
+    if (taskRuntime
+        && AGENT_TASK_LIMITS.WORKSPACE_TEST_GATE_ENABLED
+        && input.verifyRetries < AGENT_TASK_LIMITS.WORKSPACE_TEST_MAX_RETRIES) {
+        const tests = await verifyWorkspaceTests(taskRuntime, taskId, usedTools, stepNumber, signal);
+        stepNumber = tests.stepNumber;
+        emitStepIfRan(tests, emitStep);
+        if (tests.ran && !tests.ok) {
+            logger.info(`[AgentTask] 테스트 게이트 실패 → 수정 유도: ${taskId} (${tests.runner}, 재시도 ${input.verifyRetries + 1})`);
+            return { kind: 'verify_retry', stepNumber, nudge: getAgentTaskTestsFailedNudge(tests.runner ?? 'test', tests.report) };
+        }
+    }
 
     // 3. goal judge — 판정을 **적용**하는 대상은 종전 그대로 아티팩트 없는 완료뿐이다.
     //    아티팩트가 있는 완료도 셰도우로 판정만 돌려 기록한다(완료 흐름 불변, fail-open):
@@ -181,4 +195,11 @@ export async function finalizeTask(input: FinalizeInput): Promise<FinalizeOutcom
     });
     logger.info(`[AgentTask] 완료: ${taskId} (${turn + 1} 턴, ${path}, judge=${verdict}, 아티팩트 ${artifacts.length}개)`);
     return { kind: 'completed', stepNumber };
+}
+
+function emitStepIfRan(
+    tests: { ran: boolean; ok: boolean; runner?: string },
+    emitStep: FinalizeInput['emitStep'],
+): void {
+    if (tests.ran) emitStep('test_verify', tests.runner, `테스트 게이트: ${tests.runner} ${tests.ok ? '통과' : '실패'}`);
 }

--- a/apps/api/src/services/agent-task/workspace-test-verify.test.ts
+++ b/apps/api/src/services/agent-task/workspace-test-verify.test.ts
@@ -1,0 +1,85 @@
+jest.mock('../../data/models/unified-database', () => ({
+    getUnifiedDatabase: () => ({ addAgentTaskStep: jest.fn(async () => undefined) }),
+}));
+jest.mock('../../config/runtime-limits', () => {
+    const actual = jest.requireActual('../../config/runtime-limits');
+    return { ...actual, AGENT_TASK_LIMITS: { ...actual.AGENT_TASK_LIMITS, WORKSPACE_TEST_REPORT_MAX_CHARS: 60 } };
+});
+import { verifyWorkspaceTests, detectWorkspaceTestRunner, tailReport, RUNNER_COMMANDS, DETECT_PROBE } from './workspace-test-verify';
+import type { TaskRuntime } from '../task-sandbox/runtime';
+import type { ExecResult } from '../task-sandbox/executor';
+
+function exec(stdout: string, exitCode = 0, stderr = '', timedOut = false): ExecResult {
+    return { stdout, stderr, exitCode, truncated: false, timedOut, durationMs: 3 };
+}
+function runtime(impl: (cmd: string) => ExecResult | Promise<ExecResult>): { rt: TaskRuntime; cmds: string[] } {
+    const cmds: string[] = [];
+    const rt = { execRaw: jest.fn(async (cmd: string) => { cmds.push(cmd); return impl(cmd); }) } as unknown as TaskRuntime;
+    return { rt, cmds };
+}
+const WROTE = new Set(['bash', 'str_replace_editor']);
+
+describe('detectWorkspaceTestRunner', () => {
+    it('프로브 출력 토큰으로 러너를 고른다', async () => {
+        expect(await detectWorkspaceTestRunner(runtime(() => exec('npm\n')).rt)).toBe('npm');
+        expect(await detectWorkspaceTestRunner(runtime(() => exec('pytest')).rt)).toBe('pytest');
+        expect(await detectWorkspaceTestRunner(runtime(() => exec('none')).rt)).toBeNull();
+        expect(await detectWorkspaceTestRunner(runtime(() => exec('')).rt)).toBeNull();
+    });
+    it('프로브는 npm 기본 자리표시자·node_modules 부재를 걸러내는 조건을 담는다', () => {
+        expect(DETECT_PROBE).toContain('no test specified');
+        expect(DETECT_PROBE).toContain('existsSync("node_modules")');
+        expect(DETECT_PROBE).toContain('import pytest');
+    });
+});
+
+describe('verifyWorkspaceTests', () => {
+    it('러너가 없으면 실행하지 않고 통과한다(리포트형 작업 무영향)', async () => {
+        const { rt, cmds } = runtime(() => exec('none'));
+        const r = await verifyWorkspaceTests(rt, 't1', WROTE, 5);
+        expect(r).toEqual({ ran: false, ok: true, report: '', stepNumber: 5 });
+        expect(cmds.length).toBe(1);
+    });
+
+    it('쓰기 도구를 안 쓴 작업은 프로브조차 하지 않는다', async () => {
+        const { rt, cmds } = runtime(() => exec('npm'));
+        const r = await verifyWorkspaceTests(rt, 't1', new Set(['grep_code', 'repo_map']), 5);
+        expect(r.ran).toBe(false);
+        expect(cmds.length).toBe(0);
+    });
+
+    it('러너 통과 → ran=true·ok=true, 스텝 1개 기록', async () => {
+        const { rt, cmds } = runtime((cmd) => cmd === DETECT_PROBE ? exec('pytest') : exec('3 passed'));
+        const r = await verifyWorkspaceTests(rt, 't1', WROTE, 5);
+        expect(r.ran).toBe(true); expect(r.ok).toBe(true); expect(r.runner).toBe('pytest');
+        expect(r.stepNumber).toBe(6);
+        expect(cmds[1]).toBe(RUNNER_COMMANDS.pytest);
+    });
+
+    it('러너 실패 → ok=false 와 끝부분 리포트', async () => {
+        const { rt } = runtime((cmd) => cmd === DETECT_PROBE ? exec('npm') : exec('a'.repeat(100) + '\nFAIL src/x.test.ts', 1));
+        const r = await verifyWorkspaceTests(rt, 't1', WROTE, 0);
+        expect(r.ok).toBe(false);
+        expect(r.report).toContain('FAIL src/x.test.ts');
+        expect(r.report).toContain('[exit=1]');
+        expect(r.report).toContain('생략');
+    });
+
+    it('타임아웃도 실패로 본다', async () => {
+        const { rt } = runtime((cmd) => cmd === DETECT_PROBE ? exec('go') : exec('', 0, '', true));
+        expect((await verifyWorkspaceTests(rt, 't1', WROTE, 0)).ok).toBe(false);
+    });
+
+    it('인프라 오류는 fail-open', async () => {
+        const { rt } = runtime(() => { throw new Error('docker down'); });
+        expect(await verifyWorkspaceTests(rt, 't1', WROTE, 2)).toEqual({ ran: false, ok: true, report: '', stepNumber: 2 });
+    });
+});
+
+describe('tailReport', () => {
+    it('상한 초과 시 끝부분을 남기고 생략 표기', () => {
+        const t = tailReport('x'.repeat(50) + 'END', 10);
+        expect(t.endsWith('END')).toBe(true);
+        expect(t).toContain('생략');
+    });
+});

--- a/apps/api/src/services/agent-task/workspace-test-verify.ts
+++ b/apps/api/src/services/agent-task/workspace-test-verify.ts
@@ -1,0 +1,117 @@
+/**
+ * Agent Task workspace 테스트 게이트 (2026-09-06).
+ *
+ * 완료 관문(finalize)에서 workspace 에 **이미 있는** 테스트 러너를 감지하면 1회 실행하고, 실패하면
+ * 출력 끝부분을 주입해 수정 턴을 준다. deliverable-verify(아티팩트 문법 검사)와 같은 원칙 —
+ * 실행 grounding 이 self-critique 보다 값싸고 정확하다 — 를 **레포 작업**으로 넓힌 것이다.
+ * 30일 실측: 작업 70건 중 55건이 파일을 편집했지만 bash 로 테스트를 돈 것은 2건뿐이었다.
+ *
+ * 설계 원칙:
+ *  - 러너를 설치하지 않는다(LSP 진단과 같은 규칙, 컨테이너는 network none). 감지 조건은
+ *    npm(package.json scripts.test + node_modules) · pytest(설정/tests + import 가능) · go(go.mod + go).
+ *  - 러너가 없으면 `ran=false` 로 조용히 통과 — 리포트형 작업(운영 대부분)에는 영향이 0 이다.
+ *  - 파일을 편집한 작업에만 적용(usedTools 에 쓰기 도구). 읽기만 한 작업의 테스트 실패는 그 작업 탓이 아니다.
+ *  - 전 구간 fail-open: 감지·실행 인프라 오류는 통과(ok=true). 실패는 러너 exit≠0 뿐이다.
+ *  - 코드를 실제로 실행한다 — 컨테이너는 격리(network none·자원 캡)이고, 로컬 브리지에선 exec 가
+ *    디바이스 confirmExec 를 거친다.
+ *
+ * @module services/agent-task/workspace-test-verify
+ */
+import { getUnifiedDatabase } from '../../data/models/unified-database';
+import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
+import { createLogger } from '../../utils/logger';
+import type { TaskRuntime } from '../task-sandbox/runtime';
+
+const logger = createLogger('AgentTaskService');
+
+/** 파일을 바꾸는 도구 — 이 중 하나라도 썼을 때만 게이트가 적용된다. */
+export const WRITE_TOOL_NAMES: readonly string[] = ['str_replace_editor', 'file_ops', 'bash', 'python_execute', 'skill_run'];
+
+export type TestRunner = 'npm' | 'pytest' | 'go';
+
+/** 러너별 실행 명령 — CI=1 로 watch 모드·대화형 프롬프트를 막는다. */
+export const RUNNER_COMMANDS: Record<TestRunner, string> = {
+    npm: 'CI=1 npm test --silent 2>&1',
+    pytest: 'python3 -m pytest -q -x --no-header -p no:cacheprovider 2>&1',
+    go: 'go test ./... 2>&1',
+};
+
+/**
+ * 감지 프로브 — POSIX sh 한 번으로 러너 토큰을 출력한다(로컬 브리지 macOS 호환: GNU 전용 옵션 없음).
+ * npm: scripts.test 가 있고 기본 자리표시자("no test specified")가 아니며, node_modules 가 있거나 `node …` 스크립트여야 한다.
+ * pytest: 설정 파일 또는 tests 디렉토리/루트의 test_*.py 가 있고 pytest 가 import 돼야 한다.
+ */
+export const DETECT_PROBE = [
+    // node_modules 가 없어도 `node --test` 처럼 런타임만으로 도는 스크립트는 허용한다.
+    'if [ -f package.json ] && node -e \'const s=(require("./package.json").scripts||{}).test||"";const ok=s&&!/no test specified/.test(s)&&(require("fs").existsSync("node_modules")||/^node\\b/.test(s));process.exit(ok?0:1)\' 2>/dev/null; then echo npm; exit 0; fi',
+    'if { [ -f pytest.ini ] || [ -f conftest.py ] || { [ -f pyproject.toml ] && grep -q "tool.pytest" pyproject.toml; } || { [ -f setup.cfg ] && grep -q "tool:pytest" setup.cfg; } || [ -d tests ] || ls test_*.py >/dev/null 2>&1; } && python3 -c "import pytest" 2>/dev/null; then echo pytest; exit 0; fi',
+    'if [ -f go.mod ] && command -v go >/dev/null 2>&1; then echo go; exit 0; fi',
+    'echo none',
+].join('; ');
+
+export interface WorkspaceTestResult {
+    /** 러너를 감지해 실제로 실행했는지. */
+    ran: boolean;
+    /** 실행하지 않았거나 통과했으면 true. */
+    ok: boolean;
+    runner?: TestRunner;
+    /** 실패 시 모델에 주입할 출력(끝부분). */
+    report: string;
+}
+
+export function hasWriteTool(usedTools: ReadonlySet<string>): boolean {
+    return WRITE_TOOL_NAMES.some((t) => usedTools.has(t));
+}
+
+export async function detectWorkspaceTestRunner(runtime: TaskRuntime): Promise<TestRunner | null> {
+    const r = await runtime.execRaw(DETECT_PROBE);
+    const token = r.stdout.trim().split('\n').pop()?.trim();
+    return token === 'npm' || token === 'pytest' || token === 'go' ? token : null;
+}
+
+/** 출력 끝부분 우선 절단 — 실패 요약(FAIL/Error/N failed)은 보통 마지막에 있다. */
+export function tailReport(output: string, maxChars: number): string {
+    const t = output.trim();
+    return t.length > maxChars ? `…(앞 ${t.length - maxChars}자 생략)\n${t.slice(-maxChars)}` : t;
+}
+
+/**
+ * 테스트 게이트 본체 — 절대 throw 하지 않는다. 결과는 `test_verify` 스텝으로 남긴다(관측, fail-open).
+ */
+export async function verifyWorkspaceTests(
+    runtime: TaskRuntime,
+    taskId: string,
+    usedTools: ReadonlySet<string>,
+    stepNumber: number,
+    signal?: AbortSignal,
+): Promise<WorkspaceTestResult & { stepNumber: number }> {
+    const skip = { ran: false, ok: true, report: '', stepNumber };
+    try {
+        if (signal?.aborted || !hasWriteTool(usedTools)) return skip;
+        const runner = await detectWorkspaceTestRunner(runtime);
+        if (!runner) return skip;
+        const r = await runtime.execRaw(RUNNER_COMMANDS[runner]);
+        const failed = r.exitCode !== 0 || r.timedOut;
+        const output = `${r.stdout}${r.stderr ? `\n${r.stderr}` : ''}`;
+        const report = failed
+            ? tailReport(`${output}\n[exit=${r.exitCode}${r.timedOut ? ' TIMEOUT' : ''}]`, AGENT_TASK_LIMITS.WORKSPACE_TEST_REPORT_MAX_CHARS)
+            : '';
+        logger.info(`[TestGate] ${taskId}: ${runner} ${failed ? '실패' : '통과'} (exit=${r.exitCode}, ${r.durationMs}ms)`);
+        let next = stepNumber;
+        try {
+            await getUnifiedDatabase().addAgentTaskStep({
+                taskId, stepNumber: next, stepType: 'test_verify', toolName: runner,
+                content: failed
+                    ? `테스트 게이트: ${runner} 실패 (exit=${r.exitCode}) — 수정 턴 부여\n${report}`
+                    : `테스트 게이트: ${runner} 통과 (${r.durationMs}ms)\n${tailReport(output, 600)}`,
+            });
+            next++;
+        } catch (e) {
+            logger.debug(`[TestGate] 스텝 기록 실패(무시): ${e instanceof Error ? e.message : e}`);
+        }
+        return { ran: true, ok: !failed, runner, report, stepNumber: next };
+    } catch (e) {
+        logger.warn(`[TestGate] 게이트 실패 — fail-open: ${e instanceof Error ? e.message : e}`);
+        return skip;
+    }
+}

--- a/apps/api/src/services/task-sandbox/runtime.test.ts
+++ b/apps/api/src/services/task-sandbox/runtime.test.ts
@@ -1,5 +1,5 @@
 // env 파생 상수 고정 — 운영 .env 에서 AGENT_TASK_DISCUSSION 을 켜면 도구가 12종이 되어
-// 아래 base 11종 단언이 깨진다. 기본(OFF) 계약을 검증하는 테스트이므로 env 와 무관하게 고정한다.
+// 아래 base 13종 단언이 깨진다. 기본(OFF) 계약을 검증하는 테스트이므로 env 와 무관하게 고정한다.
 // (start_discussion 노출 자체는 task-tools-discussion.test.ts 가 콜백 주입으로 검증)
 jest.mock('../../config/runtime-limits', () => {
     const actual = jest.requireActual('../../config/runtime-limits');
@@ -35,11 +35,11 @@ describe('TaskRuntime 도구/게이트 (샌드박스 미생성 — 게이트 로
     const cfgAll = { ...getTaskSandboxConfig(), approvalPolicy: 'all' as const };
     const cfgNone = { ...getTaskSandboxConfig(), approvalPolicy: 'none' as const };
 
-    it('getLLMTools 11종 + isTaskTool', () => {
+    it('getLLMTools 13종 + isTaskTool', () => {
         const rt = new TaskRuntime('t1', 'u1', cfgNone);
         // 절차 스킬 도구(skill_save/skill_run)는 AGENT_TASK_PROCEDURAL_SKILLS 플래그 게이트라 제외하고 base 11 검증.
         const names = rt.getLLMTools().map((t) => t.function.name).filter((n) => n !== 'skill_save' && n !== 'skill_run');
-        expect(names).toEqual(['bash', 'python_execute', 'str_replace_editor', 'file_ops', 'browser', 'plan_create', 'plan_update', 'plan_view', 'delegate', 'terminate', 'ask_human']);
+        expect(names).toEqual(['bash', 'python_execute', 'str_replace_editor', 'file_ops', 'grep_code', 'repo_map', 'browser', 'plan_create', 'plan_update', 'plan_view', 'delegate', 'terminate', 'ask_human']);
         expect(rt.isTaskTool('bash')).toBe(true);
         expect(rt.isTaskTool('web_search')).toBe(false);
     });

--- a/apps/api/src/services/task-sandbox/tools-code-nav.test.ts
+++ b/apps/api/src/services/task-sandbox/tools-code-nav.test.ts
@@ -1,0 +1,116 @@
+import { createCodeNavTools, shq, normalizeRelPath } from './tools-code-nav';
+import type { TaskExecutor, ExecResult } from './executor';
+
+function exec(stdout: string, exitCode = 0, stderr = ''): ExecResult {
+    return { stdout, stderr, exitCode, truncated: false, timedOut: false, durationMs: 1 };
+}
+
+function fakeSandbox(impl: (cmd: string) => ExecResult): { sandbox: TaskExecutor; cmds: string[] } {
+    const cmds: string[] = [];
+    const sandbox = {
+        exec: jest.fn(async (cmd: string) => { cmds.push(cmd); return impl(cmd); }),
+    } as unknown as TaskExecutor;
+    return { sandbox, cmds };
+}
+
+const text = (r: { content: { text?: string }[] }) => r.content[0].text ?? '';
+
+describe('shq / normalizeRelPath', () => {
+    it('단일 인용 이스케이프', () => {
+        expect(shq(`a'b`)).toBe(`'a'\\''b'`);
+    });
+    it('절대 경로·상위 탈출은 거절, 상대 경로는 정규화', () => {
+        expect(normalizeRelPath('')).toBe('.');
+        expect(normalizeRelPath('./src')).toBe('src');
+        expect(normalizeRelPath('/etc')).toBeNull();
+        expect(normalizeRelPath('a/../b')).toBeNull();
+    });
+});
+
+describe('grep_code', () => {
+    it('rg 결과를 캡·줄 절단해 돌려주고 node_modules 제외 글롭을 포함한다', async () => {
+        const { sandbox, cmds } = fakeSandbox(() => exec(['a.ts:1:foo', 'b.ts:2:' + 'z'.repeat(400)].join('\n')));
+        const grep = createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!;
+        const r = await grep.handler({ pattern: 'foo', glob: '*.ts' });
+        expect(r.isError).toBeFalsy();
+        expect(text(r)).toContain('a.ts:1:foo');
+        expect(text(r)).toContain('…');
+        expect(cmds[0]).toContain("rg -n");
+        expect(cmds[0]).toContain("-g '!node_modules/**'");
+        expect(cmds[0]).toContain("-g '*.ts'");
+        expect(cmds[0]).toContain("-e 'foo'");
+    });
+
+    it('rg 미설치(127)면 grep 으로 폴백한다', async () => {
+        const { sandbox, cmds } = fakeSandbox((cmd) => cmd.startsWith('rg') ? exec('', 127, 'rg: not found') : exec('x.py:3:def foo'));
+        const grep = createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!;
+        const r = await grep.handler({ pattern: 'def foo' });
+        expect(text(r)).toContain('x.py:3:def foo');
+        expect(text(r)).toContain('grep 사용');
+        expect(cmds[1]).toContain('grep -rnI -E');
+    });
+
+    it('무일치는 오류가 아니다', async () => {
+        const { sandbox } = fakeSandbox(() => exec('', 0));
+        const grep = createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!;
+        const r = await grep.handler({ pattern: 'nothing' });
+        expect(r.isError).toBeFalsy();
+        expect(text(r)).toContain('일치 없음');
+    });
+
+    it('결과가 상한을 넘으면 잘림 안내를 붙인다', async () => {
+        const lines = Array.from({ length: 200 }, (_, i) => `f.ts:${i}:m`).join('\n');
+        const { sandbox } = fakeSandbox(() => exec(lines));
+        const grep = createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!;
+        const r = await grep.handler({ pattern: 'm', max_results: 10 });
+        expect(text(r).split('\n').filter((l) => l.startsWith('f.ts:')).length).toBe(10);
+        expect(text(r)).toContain('잘림');
+    });
+
+    it('절대 경로·빈 패턴은 거절한다', async () => {
+        const { sandbox, cmds } = fakeSandbox(() => exec(''));
+        const grep = createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!;
+        expect((await grep.handler({ pattern: 'x', path: '/etc' })).isError).toBe(true);
+        expect((await grep.handler({ pattern: '  ' })).isError).toBe(true);
+        expect(cmds.length).toBe(0);
+    });
+
+    it('셸 메타문자가 든 패턴은 인용돼 명령으로 새지 않는다', async () => {
+        const { sandbox, cmds } = fakeSandbox(() => exec(''));
+        const grep = createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!;
+        await grep.handler({ pattern: `x'; rm -rf / #` });
+        expect(cmds[0]).toContain(`-e 'x'\\''; rm -rf / #'`);
+    });
+});
+
+describe('repo_map', () => {
+    it('파일 목록을 디렉토리 요약·파일·심볼로 조립한다', async () => {
+        const { sandbox } = fakeSandbox((cmd) => cmd.startsWith('find')
+            ? exec(['12\t./src/a.ts', '30\t./src/b.ts', '5\t./README.md'].join('\n'))
+            : exec('./src/a.ts:1:export function foo() {'));
+        const map = createCodeNavTools(sandbox).find((t) => t.tool.name === 'repo_map')!;
+        const out = text(await map.handler({}));
+        expect(out).toContain('src/  파일 2 · 42줄');
+        expect(out).toContain('(root)  파일 1 · 5줄');
+        expect(out).toContain('src/a.ts (12)');
+        expect(out).toContain('## 심볼 선언');
+        expect(out).toContain('src/a.ts:1:export function foo');
+    });
+
+    it('symbols=false 면 find 한 번만 실행한다', async () => {
+        const { sandbox, cmds } = fakeSandbox(() => exec('1\t./x.py'));
+        const map = createCodeNavTools(sandbox).find((t) => t.tool.name === 'repo_map')!;
+        await map.handler({ symbols: false });
+        expect(cmds.length).toBe(1);
+        expect(cmds[0]).toContain("-name 'node_modules'");
+        expect(cmds[0]).toContain('-prune');
+    });
+
+    it('빈 디렉토리는 오류 없이 안내한다', async () => {
+        const { sandbox } = fakeSandbox(() => exec(''));
+        const map = createCodeNavTools(sandbox).find((t) => t.tool.name === 'repo_map')!;
+        const r = await map.handler({ path: 'empty' });
+        expect(r.isError).toBeFalsy();
+        expect(text(r)).toContain('파일 없음');
+    });
+});

--- a/apps/api/src/services/task-sandbox/tools-code-nav.ts
+++ b/apps/api/src/services/task-sandbox/tools-code-nav.ts
@@ -1,0 +1,177 @@
+/**
+ * Task 샌드박스 코드 탐색 도구 — grep_code · repo_map (2026-09-06).
+ *
+ * 30일 실측: bash 호출 444건 중 34% 가 grep/find/ls/cat 류 탐색이고 결과가 통째로 대화에 들어갔다.
+ * 전용 읽기 도구는 ① 결과를 파일:줄 형태로 캡을 걸어 돌려주고 ② 승인 정책(high-risk=bash) 대상이
+ * 아니라 승인 창 없이 돌며 ③ 이름에 'search' 가 없어 웹검색 상한(SEARCH_TOOL_KEYWORDS)에 안 잡힌다.
+ *
+ * 구현은 sandbox.exec 위의 얇은 래퍼다 — 컨테이너(리눅스, ripgrep 포함)와 로컬 브리지(macOS 가능,
+ * rg 미설치 가능) 양쪽에서 돌도록 rg → grep 폴백을 두고 GNU 전용 옵션(find -printf, xargs -d)은 쓰지
+ * 않는다. 로컬 브리지에선 exec 가 디바이스 confirmExec 를 거친다(읽기 전용이어도 — 프로토콜 추가 전용).
+ *
+ * @module services/task-sandbox/tools-code-nav
+ */
+import type { MCPToolDefinition, MCPToolResult } from '../../mcp/types';
+import type { TaskExecutor, ExecResult } from './executor';
+import { TASK_CODE_NAV } from '../../config/runtime-limits';
+
+const PATTERN_MAX_CHARS = 500;
+const EXIT_NOT_FOUND = 127;
+
+/** 심볼 선언 줄 — TS/JS·Python·Go·Rust·Java/Kotlin 의 최상위 선언을 한 정규식으로. */
+const SYMBOL_REGEX = String.raw`^\s*(export\s+)?(default\s+)?(async\s+)?(function|class|interface|type|enum)\s+\w+|^\s*(def|class)\s+\w+|^\s*(pub(\(crate\))?\s+)?(fn|struct|enum|trait|impl)\s+\w+|^func\s+(\([^)]*\)\s*)?\w+|^\s*(public|private|protected)\s+(static\s+)?(class|interface|\w+\s+\w+\s*\()`;
+
+function textResult(text: string, isError = false): MCPToolResult {
+    return { content: [{ type: 'text', text }], isError };
+}
+
+function str(v: unknown): string { return typeof v === 'string' ? v : ''; }
+
+/** POSIX 셸 단일 인용 — 인용 안의 ' 만 닫고-이스케이프-열기. */
+export function shq(s: string): string {
+    return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/** 상대 경로만 허용(빈 값·"." 은 workspace 루트). 절대 경로·상위 탈출은 거절 — bash 와 달리 승인 없이 도는 도구라 범위를 좁힌다. */
+export function normalizeRelPath(p: string): string | null {
+    const t = p.trim();
+    if (!t || t === '.') return '.';
+    if (t.startsWith('/') || t.split(/[\\/]/).includes('..')) return null;
+    return t.replace(/^\.\//, '');
+}
+
+function excludeGlobsRg(): string {
+    return TASK_CODE_NAV.EXCLUDED_DIRS.map((d) => `-g ${shq(`!${d}/**`)}`).join(' ');
+}
+function excludeDirsGrep(): string {
+    return TASK_CODE_NAV.EXCLUDED_DIRS.map((d) => `--exclude-dir=${shq(d)}`).join(' ');
+}
+function pruneFind(): string {
+    // find <path> \( -name a -o -name b \) -prune -o -type f -print
+    return `\\( ${TASK_CODE_NAV.EXCLUDED_DIRS.map((d) => `-name ${shq(d)}`).join(' -o ')} \\) -prune -o -type f -print`;
+}
+
+function clipLines(out: string, maxLines: number, maxChars: number): { lines: string[]; overflow: boolean } {
+    const all = out.split('\n').filter((l) => l.length > 0);
+    const lines = all.slice(0, maxLines).map((l) => l.replace(/^\.\//, '')).map((l) => (l.length > maxChars ? `${l.slice(0, maxChars)}…` : l));
+    return { lines, overflow: all.length > maxLines };
+}
+
+/** rg 로 먼저 시도하고, 실행 파일이 없으면(127) grep 으로 재시도한다. */
+async function execWithGrepFallback(sandbox: TaskExecutor, rgCmd: string, grepCmd: string): Promise<{ r: ExecResult; via: 'rg' | 'grep' }> {
+    const r = await sandbox.exec(rgCmd);
+    if (r.exitCode !== EXIT_NOT_FOUND) return { r, via: 'rg' };
+    return { r: await sandbox.exec(grepCmd), via: 'grep' };
+}
+
+export function createCodeNavTools(sandbox: TaskExecutor): MCPToolDefinition[] {
+    const grepCode: MCPToolDefinition = {
+        tool: {
+            name: 'grep_code',
+            description: 'workspace 코드를 정규식으로 검색해 "파일:줄번호:내용" 목록을 돌려줍니다(ripgrep, 읽기 전용, '
+                + `최대 ${TASK_CODE_NAV.GREP_MAX_RESULTS}줄). 심볼 정의·사용처·문자열을 찾을 때 bash grep 대신 쓰세요 — `
+                + '결과가 캡으로 잘려 컨텍스트를 아낍니다. node_modules/.git/dist 는 자동 제외.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    pattern: { type: 'string', description: '정규식(rg 문법). 예: "function\\s+render", "TODO"' },
+                    path: { type: 'string', description: 'workspace 상대 경로(파일 또는 디렉토리, 기본 ".")' },
+                    glob: { type: 'string', description: '파일 글롭 필터. 예: "*.ts", "src/**/*.py"' },
+                    ignore_case: { type: 'boolean', description: '대소문자 무시(기본 false)' },
+                    max_results: { type: 'number', description: `최대 결과 줄 수(기본 ${TASK_CODE_NAV.GREP_MAX_RESULTS})` },
+                },
+                required: ['pattern'],
+            },
+        },
+        handler: async (args): Promise<MCPToolResult> => {
+            const pattern = str(args.pattern);
+            if (!pattern.trim()) return textResult('pattern 이 필요합니다.', true);
+            if (pattern.length > PATTERN_MAX_CHARS) return textResult(`pattern 은 ${PATTERN_MAX_CHARS}자 이하여야 합니다.`, true);
+            const rel = normalizeRelPath(str(args.path));
+            if (rel === null) return textResult('path 는 workspace 상대 경로만 허용됩니다(절대 경로·.. 불가).', true);
+            const glob = str(args.glob).trim();
+            const ic = args.ignore_case === true;
+            const max = Math.max(1, Math.min(
+                Number.isFinite(Number(args.max_results)) && Number(args.max_results) > 0 ? Number(args.max_results) : TASK_CODE_NAV.GREP_MAX_RESULTS,
+                TASK_CODE_NAV.GREP_MAX_RESULTS * 4,
+            ));
+            const head = `head -n ${max + 1}`;
+            const rgCmd = `rg -n --no-heading --color never --no-messages -m ${TASK_CODE_NAV.GREP_PER_FILE_MAX}`
+                + `${ic ? ' -i' : ''} ${excludeGlobsRg()}${glob ? ` -g ${shq(glob)}` : ''} -e ${shq(pattern)} -- ${shq(rel)} | ${head}`;
+            const grepCmd = `grep -rnI -E${ic ? 'i' : ''} ${excludeDirsGrep()}${glob ? ` --include=${shq(glob.replace(/^.*\//, ''))}` : ''}`
+                + ` -e ${shq(pattern)} -- ${shq(rel)} | ${head}`;
+            const { r, via } = await execWithGrepFallback(sandbox, rgCmd, grepCmd);
+            if (r.timedOut) return textResult('검색 시간 초과 — path/glob 으로 범위를 좁히세요.', true);
+            // 파이프 종료 코드는 head 의 것이라 rg/grep 의 1(무일치)·2(오류)를 못 본다 → 출력으로 판정.
+            if (!r.stdout.trim()) {
+                const err = r.stderr.trim();
+                return textResult(err ? `검색 실패: ${err.slice(0, 500)}` : `(일치 없음: ${pattern})`, !!err);
+            }
+            const { lines, overflow } = clipLines(r.stdout, max, TASK_CODE_NAV.GREP_LINE_MAX_CHARS);
+            const note = overflow ? `\n… ${max}줄에서 잘림 — pattern/path/glob 으로 좁히세요.` : '';
+            return textResult(`${lines.join('\n')}${note}${via === 'grep' ? '\n(rg 미설치 — grep 사용)' : ''}`);
+        },
+    };
+
+    const repoMap: MCPToolDefinition = {
+        tool: {
+            name: 'repo_map',
+            description: 'workspace 코드 구조 개요를 돌려줍니다: 디렉토리별 파일 수·줄 수와 파일 목록(줄 수 포함), '
+                + '선택적으로 최상위 심볼(function/class/def) 선언 위치. 코드 작업을 시작할 때 1회 호출해 '
+                + '어디를 봐야 하는지 파악한 뒤 grep_code·file_ops read 로 좁혀 들어가세요(읽기 전용).',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    path: { type: 'string', description: 'workspace 상대 경로(기본 ".")' },
+                    symbols: { type: 'boolean', description: '심볼 선언 개요 포함(기본 true)' },
+                },
+            },
+        },
+        handler: async (args): Promise<MCPToolResult> => {
+            const rel = normalizeRelPath(str(args.path));
+            if (rel === null) return textResult('path 는 workspace 상대 경로만 허용됩니다(절대 경로·.. 불가).', true);
+            const withSymbols = args.symbols !== false;
+            const maxFiles = TASK_CODE_NAV.MAP_MAX_FILES;
+            // 파일별 줄 수 — GNU 전용 옵션 없이(find -printf·xargs -d 는 macOS 로컬 브리지에 없다).
+            const listCmd = `find ${shq(rel)} ${pruneFind()} | head -n ${maxFiles + 1} | while IFS= read -r f; do `
+                + `printf '%s\\t%s\\n' "$(wc -l < "$f" 2>/dev/null | tr -d ' ')" "$f"; done`;
+            const list = await sandbox.exec(listCmd);
+            if (list.timedOut) return textResult('구조 수집 시간 초과 — path 로 범위를 좁히세요.', true);
+            const rows = list.stdout.split('\n').filter((l) => l.includes('\t')).map((l) => {
+                const [n, ...rest] = l.split('\t');
+                return { lines: parseInt(n, 10) || 0, path: rest.join('\t').replace(/^\.\//, '') };
+            });
+            if (rows.length === 0) return textResult(`(파일 없음: ${rel})`);
+            const overflow = rows.length > maxFiles;
+            const files = rows.slice(0, maxFiles).sort((a, b) => a.path.localeCompare(b.path));
+
+            const dirs = new Map<string, { files: number; lines: number }>();
+            for (const f of files) {
+                const top = f.path.includes('/') ? f.path.slice(0, f.path.indexOf('/')) + '/' : '(root)';
+                const d = dirs.get(top) ?? { files: 0, lines: 0 };
+                d.files++; d.lines += f.lines; dirs.set(top, d);
+            }
+            const out: string[] = [
+                `## 디렉토리 요약 (${files.length}개 파일${overflow ? `, ${maxFiles}개에서 잘림` : ''})`,
+                ...[...dirs.entries()].sort((a, b) => b[1].lines - a[1].lines)
+                    .map(([d, v]) => `- ${d}  파일 ${v.files} · ${v.lines}줄`),
+                '',
+                '## 파일 (줄 수)',
+                ...files.map((f) => `${f.path} (${f.lines})`),
+            ];
+            if (withSymbols) {
+                const rgCmd = `rg -n --no-heading --color never --no-messages -m 40 ${excludeGlobsRg()} -e ${shq(SYMBOL_REGEX)} -- ${shq(rel)} | head -n ${TASK_CODE_NAV.MAP_MAX_SYMBOLS + 1}`;
+                const grepCmd = `grep -rnI -E ${excludeDirsGrep()} -e ${shq(SYMBOL_REGEX)} -- ${shq(rel)} | head -n ${TASK_CODE_NAV.MAP_MAX_SYMBOLS + 1}`;
+                const { r } = await execWithGrepFallback(sandbox, rgCmd, grepCmd);
+                if (r.stdout.trim()) {
+                    const { lines, overflow: symOverflow } = clipLines(r.stdout, TASK_CODE_NAV.MAP_MAX_SYMBOLS, TASK_CODE_NAV.GREP_LINE_MAX_CHARS);
+                    out.push('', '## 심볼 선언 (파일:줄)', ...lines);
+                    if (symOverflow) out.push(`… ${TASK_CODE_NAV.MAP_MAX_SYMBOLS}줄에서 잘림 — grep_code 로 좁히세요.`);
+                }
+            }
+            return textResult(out.join('\n'));
+        },
+    };
+
+    return [grepCode, repoMap];
+}

--- a/apps/api/src/services/task-sandbox/tools.test.ts
+++ b/apps/api/src/services/task-sandbox/tools.test.ts
@@ -29,9 +29,9 @@ function byName(tools: ReturnType<typeof createTaskTools>, name: string) {
 const txt = (r: MCPToolResult) => r.content[0].text ?? '';
 
 describe('task-sandbox tools', () => {
-    it('11개 도구 제공 (5 sandbox + 3 plan + delegate + terminate + ask_human)', () => {
+    it('13개 도구 제공 (5 sandbox + 2 code-nav + 3 plan + delegate + terminate + ask_human)', () => {
         const names = createTaskTools(fakeSandbox()).map((t) => t.tool.name);
-        expect(names).toEqual(['bash', 'python_execute', 'str_replace_editor', 'file_ops', 'browser', 'plan_create', 'plan_update', 'plan_view', 'delegate', 'terminate', 'ask_human']);
+        expect(names).toEqual(['bash', 'python_execute', 'str_replace_editor', 'file_ops', 'grep_code', 'repo_map', 'browser', 'plan_create', 'plan_update', 'plan_view', 'delegate', 'terminate', 'ask_human']);
     });
 
     describe('delegate', () => {

--- a/apps/api/src/services/task-sandbox/tools.ts
+++ b/apps/api/src/services/task-sandbox/tools.ts
@@ -16,6 +16,7 @@
 import type { MCPToolDefinition, MCPToolResult } from '../../mcp/types';
 import type { TaskExecutor, ExecResult } from './executor';
 import { withDiagnostics } from './diagnostics-attach';
+import { createCodeNavTools } from './tools-code-nav';
 import { TaskPlan, type PlanStepStatus } from './planning';
 import {
     SPAWN_AGENTS_TOOL_NAME,
@@ -579,5 +580,5 @@ export function createTaskTools(
             textResult(`${TASK_ASK_HUMAN_SENTINEL} ${str(args.question)}`),
     };
 
-    return [bash, pythonExecute, strReplaceEditor, fileOps, browser, planCreate, planUpdate, planView, delegateTool, ...(spawn ? [spawnAgentsTool] : []), ...(discuss ? [discussTool] : []), ...(procedural ? [skillSave, skillRun] : []), terminate, askHuman];
+    return [bash, pythonExecute, strReplaceEditor, fileOps, ...createCodeNavTools(sandbox), browser, planCreate, planUpdate, planView, delegateTool, ...(spawn ? [spawnAgentsTool] : []), ...(discuss ? [discussTool] : []), ...(procedural ? [skillSave, skillRun] : []), terminate, askHuman];
 }

--- a/infra/task-runtime/Dockerfile
+++ b/infra/task-runtime/Dockerfile
@@ -57,7 +57,7 @@ RUN chmod -R a+rX /opt/report-template
 RUN uv venv /opt/pyenv \
     && VIRTUAL_ENV=/opt/pyenv uv pip install --no-cache openpyxl reportlab fpdf2 python-docx python-pptx pypdf \
        PyMuPDF pytesseract \
-       pandas pdfplumber olefile requests \
+       pandas pdfplumber olefile requests pytest \
     && chmod -R a+rX /opt/pyenv
 ENV PATH=/opt/pyenv/bin:${PATH}
 


### PR DESCRIPTION
## 요약
에이전트 코딩 고도화 1차. 30일 운영 실측으로 근거를 먼저 잡고 3축만 착수했다.

| 축 | 실측 근거 | 변경 |
|---|---|---|
| 컨텍스트 접기 | 완료 작업 평균 43.5만 토큰 = 스텝 본문의 18배. 절단(G3) 발동률 2.2% → 병목은 재전송 O(n²) | `agent-task/context-fold.ts` — 최근 4턴보다 오래된 1,500자 초과 tool 결과를 앞 240자 스텁으로(원문은 스텝 DB 보존). 루프에서 매 턴 LLM 호출 직전 적용 |
| 코드 탐색 도구 | bash 444건 중 34% 가 grep/find/ls/cat, 결과가 통째로 대화에 | `task-sandbox/tools-code-nav.ts` — `grep_code`(rg→grep 폴백, 파일:줄 캡)·`repo_map`(디렉토리 요약·줄 수·심볼). 읽기 전용·승인 비대상·'search' 미포함 |
| 테스트 게이트 | 파일 편집 55작업 중 테스트 실행 2건 | `agent-task/workspace-test-verify.ts` — finalize 에서 레포의 러너(npm/pytest/go)를 감지해 1회 실행, 실패 시 `verify_retry` 수정 턴(상한 2). 러너 없으면 no-op |

**착수 안 함(근거 미달)**: 편집 실패(old_str 불일치 60일 2건), 동일 호출 반복(30일 2작업·정당한 재실행).

## 검증
- 단위: agent-task + task-sandbox 33 suite 322 passed, finalize 게이트 3건 추가(실패→verify_retry·상한·no-op)
- docker 샌드박스 실통합(ts-node 스크립트, 운영 dist 미접촉): grep_code/repo_map 출력·node_modules 제외·npm 게이트 실패→수정→통과. pytest 는 이미지에 없어 Dockerfile 에 추가(**이미지 재빌드 필요**, 그전엔 pytest 레포는 게이트 미적용)
- tsc 0 · eslint 0 · Gate 3 이내(AgentTaskService 596/600)

## 설정
`AGENT_TASK_CONTEXT_FOLD*` · `AGENT_TASK_WORKSPACE_TEST_*` · `TASK_CODE_NAV_*` (.env.example, 전부 기본 ON/보수값)

## 주의
- 로컬 브리지 실행에선 grep_code/repo_map 도 exec 라 디바이스 confirmExec 를 거친다(프로토콜 추가 전용 — 읽기 kind 추가는 후속).
- 프론트: 새 스텝 `test_verify` 는 기존 generic 렌더 경로로 표시(라벨 맵 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbGa9RXHjXeRfXTn1bonB1