### PR TITLE
feat(local-bridge): 코드 탐색 전용 kind(code_nav) — grep_code·repo_map 이 승인 창 없이 돈다

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1209,6 +1209,10 @@ AGENT_TASK_TIMEOUT_MS=600000
 # WS_MAX_CONNECTIONS_PER_USER=5                  # 유저당 동시 WS 세션 상한(브리지 디바이스 + 브라우저 탭)
 # BRIDGE_FOLDERS_MAX_ENTRIES=200                 # 폴더 선택(folders) 1회 열거 상한(초과 절단+truncated)
 #
+# 로컬 브리지 코드 탐색(code_nav, 2026-09-06) — grep_code·repo_map 을 디바이스가 셸 없이 처리한다.
+# 읽기 전용이라 confirmExec 승인 창을 띄우지 않으며, 폭주 방지는 디바이스 코어의 캡이 담당한다
+# (파일 4000개·파일당 512KB·매치 400건). 디바이스측 훅: OMK_BRIDGE_CODE_NAV_TIMEOUT_MS=15000
+#
 # worktree 격리 — 연결 폴더가 git 레포면 별도 worktree(디렉토리+브랜치)를 만들어 그 안에서만
 # 작업한다. 사용자의 현재 브랜치·작업 중인 파일이 오염되지 않고, 변경분을 git diff 로 캡처해
 # diff 스텝으로 남긴다(로컬 실행기는 종전에 diff 를 남길 수 없었다). git 레포가 아니거나

--- a/apps/api/src/services/local-bridge/registry.ts
+++ b/apps/api/src/services/local-bridge/registry.ts
@@ -23,10 +23,13 @@ import { createLogger } from '../../utils/logger';
 const logger = createLogger('LocalBridge');
 
 /** 서버→디바이스 도구 요청 종류 — 이 외의 kind 는 존재하지 않는다(임의 RPC 금지). */
-export type BridgeKind = 'exec' | 'read' | 'write' | 'list' | 'listAll' | 'delete' | 'task_end' | 'worktree' | 'folders' | 'lsp_diagnostics';
+export type BridgeKind = 'exec' | 'read' | 'write' | 'list' | 'listAll' | 'delete' | 'task_end' | 'worktree' | 'folders' | 'lsp_diagnostics' | 'code_nav';
 
 /** worktree 연산 — 서버는 op 만 지정하고 git 명령은 디바이스가 고정 인자로 조립한다(명령 주입 차단). */
 export type WorktreeOp = 'add' | 'diff' | 'remove';
+
+/** code_nav 연산 — grep(정규식 매치 줄) · files(파일별 줄 수). 그 외는 디바이스가 거절한다. */
+export type CodeNavOp = 'grep' | 'files';
 
 export interface BridgeRequestPayload {
     kind: BridgeKind;
@@ -34,8 +37,8 @@ export interface BridgeRequestPayload {
     path?: string;
     /** write 전용 — base64 본문 (바이너리 안전). */
     contentB64?: string;
-    /** worktree 전용 — 수행할 연산. */
-    op?: WorktreeOp;
+    /** worktree·code_nav 전용 — 수행할 연산. */
+    op?: WorktreeOp | CodeNavOp;
     /**
      * task 식별자. worktree(디렉토리·브랜치명 파생, 디바이스가 형식 재검증)와 exec·task_end
      * (디바이스의 **작업 단위 일괄 승인** 범위 식별)에 쓰인다.
@@ -51,6 +54,21 @@ export interface BridgeRequestPayload {
     folder?: string;
     /** lsp_diagnostics 전용 — 진단할 파일들(base 기준 상대경로). */
     paths?: string[];
+    /** code_nav grep 전용 — 정규식 소스·글롭·대소문자·매치 상한(디바이스가 캡으로 다시 자른다). */
+    pattern?: string;
+    glob?: string;
+    ignoreCase?: boolean;
+    maxResults?: number;
+}
+
+/** code_nav 결과 — 디바이스 코어 BridgeCodeNav 와 1:1. */
+export interface BridgeCodeNavData {
+    /** grep — "상대경로:줄번호:내용". */
+    matches?: string[];
+    /** files — 파일별 줄 수. */
+    files?: { path: string; lines: number }[];
+    /** 캡·시간 예산에 걸려 잘렸는지. */
+    truncated?: boolean;
 }
 
 /** 편집 후 진단 1건 — 디바이스의 컴파일러 출력(코어 BridgeDiagnostic 과 1:1). */
@@ -88,6 +106,8 @@ export interface BridgeResult {
     diagnostics?: BridgeDiagnostic[];
     /** 어떤 검사기가 돌았는지 — 'none' 이면 지원 도구가 없어 검사하지 않음(진단 0건과 구분). */
     serverKind?: string;
+    /** code_nav 결과 — 없으면 구 디바이스(kind 미지원)로 보고 셸 경로로 폴백한다. */
+    codeNav?: BridgeCodeNavData;
 }
 
 export interface DeviceSession {

--- a/apps/api/src/services/local-bridge/remote-executor.test.ts
+++ b/apps/api/src/services/local-bridge/remote-executor.test.ts
@@ -9,6 +9,36 @@
 import { RemoteExecutor } from './remote-executor';
 import { getLocalBridgeRegistry } from './registry';
 
+describe('RemoteExecutor codeNav (읽기 전용 코드 탐색)', () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    it('code_nav kind 로 요청하고 결과를 그대로 돌려준다', async () => {
+        const spy = jest.spyOn(getLocalBridgeRegistry(), 'request')
+            .mockResolvedValue({ ok: true, codeNav: { matches: ['src/a.ts:1:foo'], truncated: true } });
+        const r = await new RemoteExecutor('task-1', 'user-1').codeNav({ op: 'grep', pattern: 'foo', path: 'src', glob: '*.ts' });
+        expect(r).toEqual({ matches: ['src/a.ts:1:foo'], truncated: true });
+        expect(spy).toHaveBeenCalledWith('user-1',
+            expect.objectContaining({ kind: 'code_nav', op: 'grep', pattern: 'foo', path: 'src', glob: '*.ts' }),
+            undefined, undefined);
+    });
+
+    it('exec(셸)을 쓰지 않는다 — 디바이스 승인 창을 띄우지 않는 것이 이 경로의 목적', async () => {
+        const spy = jest.spyOn(getLocalBridgeRegistry(), 'request').mockResolvedValue({ ok: true, codeNav: { files: [] } });
+        await new RemoteExecutor('task-1', 'user-1').codeNav({ op: 'files' });
+        expect(spy.mock.calls.every(([, payload]) => (payload as { kind: string }).kind !== 'exec')).toBe(true);
+    });
+
+    it('구 디바이스(미지원 kind)·실패는 null → 호출측이 셸로 폴백', async () => {
+        jest.spyOn(getLocalBridgeRegistry(), 'request').mockResolvedValue({ ok: false, error: '지원하지 않는 kind: code_nav' });
+        expect(await new RemoteExecutor('task-1', 'user-1').codeNav({ op: 'files' })).toBeNull();
+    });
+
+    it('codeNav 필드가 없는 응답도 null 로 본다', async () => {
+        jest.spyOn(getLocalBridgeRegistry(), 'request').mockResolvedValue({ ok: true });
+        expect(await new RemoteExecutor('task-1', 'user-1').codeNav({ op: 'grep', pattern: 'x' })).toBeNull();
+    });
+});
+
 describe('RemoteExecutor 브라우저 폐기', () => {
     afterEach(() => jest.restoreAllMocks());
 

--- a/apps/api/src/services/local-bridge/remote-executor.ts
+++ b/apps/api/src/services/local-bridge/remote-executor.ts
@@ -12,7 +12,7 @@
  *
  * @module services/local-bridge/remote-executor
  */
-import type { TaskExecutor, ExecResult } from '../task-sandbox/executor';
+import type { TaskExecutor, ExecResult, CodeNavSpec, CodeNavData } from '../task-sandbox/executor';
 import { getLocalBridgeRegistry, type BridgeResult, type BridgeRequestPayload } from './registry';
 import { LOCAL_BRIDGE } from '../../config/local-bridge';
 import { readFile as fsReadFile, stat } from 'fs/promises';
@@ -125,6 +125,36 @@ export class RemoteExecutor implements TaskExecutor {
             `${strip(d.path)}:${d.line}:${d.col} ${d.severity}${d.code ? ` ${d.code}` : ''}: ${d.message}`);
         const head = `[진단 ${r.diagnostics.length}건${r.truncated ? '+' : ''} — ${r.serverKind}]`;
         return { text: `${head}\n${lines.join('\n')}`, count: r.diagnostics.length };
+    }
+
+    /**
+     * 코드 탐색(grep_code·repo_map) — 디바이스가 셸 없이 파일을 훑어 결과만 돌려준다.
+     * exec 로 내보내면 읽기 전용인데도 confirmExec 승인 창이 매 호출 떠서 실사용이 불가능하다
+     * (lsp_diagnostics 와 같은 취지의 전용 kind). 구 디바이스는 "지원하지 않는 kind" 오류를
+     * 돌려주므로 **null** → 호출측(tools-code-nav)이 셸 경로로 폴백한다.
+     */
+    async codeNav(spec: CodeNavSpec): Promise<CodeNavData | null> {
+        const r = await this.req({
+            kind: 'code_nav',
+            op: spec.op,
+            path: this.scoped(spec.path ?? '.'),
+            ...(spec.pattern ? { pattern: spec.pattern } : {}),
+            ...(spec.glob ? { glob: spec.glob } : {}),
+            ...(spec.ignoreCase ? { ignoreCase: true } : {}),
+            ...(spec.maxResults ? { maxResults: spec.maxResults } : {}),
+        }).catch(() => ({ ok: false }) as BridgeResult);
+        if (!r.ok || !r.codeNav) {
+            logger.info(`[${this.taskId}] code_nav 미지원·실패 — 셸 경로로 폴백: ${r.error ?? 'codeNav 없음'}`);
+            return null;
+        }
+        // worktree prefix 는 모델이 쓰는 상대경로가 아니라 떼어낸다(diagnostics 와 같은 규칙).
+        const strip = (p: string): string =>
+            this.worktreeRel && p.startsWith(`${this.worktreeRel}/`) ? p.slice(this.worktreeRel.length + 1) : p;
+        return {
+            ...(r.codeNav.matches ? { matches: r.codeNav.matches.map(strip) } : {}),
+            ...(r.codeNav.files ? { files: r.codeNav.files.map((f) => ({ ...f, path: strip(f.path) })) } : {}),
+            ...(r.codeNav.truncated ? { truncated: true } : {}),
+        };
     }
 
     /** 파일 경로를 worktree 기준으로 변환. 격리가 없으면 원래 경로 그대로. */

--- a/apps/api/src/services/task-sandbox/executor.ts
+++ b/apps/api/src/services/task-sandbox/executor.ts
@@ -34,6 +34,29 @@ export interface ExecResult {
  * TaskSandbox 의 공개 표면과 1:1 — D0 은 동작 무변경 추출이며,
  * 원격 실행기 특화 요구(디바이스 핸드셰이크 등)는 D1 에서 이 계약 위에 얹는다.
  */
+/** 코드 탐색 요청 — grep(정규식 매치) · files(파일별 줄 수). 경로는 workspace 상대. */
+export interface CodeNavSpec {
+    op: 'grep' | 'files';
+    /** 대상 경로(상대, 기본 '.'). */
+    path?: string;
+    /** grep 전용 — 정규식 소스. */
+    pattern?: string;
+    /** grep 전용 — 파일 글롭('*.ts' 처럼 '/' 가 없으면 파일명에만 적용). */
+    glob?: string;
+    ignoreCase?: boolean;
+    maxResults?: number;
+}
+
+/** 코드 탐색 결과 — 실행기가 캡을 적용한 뒤의 값. */
+export interface CodeNavData {
+    /** grep — "상대경로:줄번호:내용". */
+    matches?: string[];
+    /** files — 파일별 줄 수. */
+    files?: { path: string; lines: number }[];
+    /** 실행기 캡에 걸려 잘렸는지. */
+    truncated?: boolean;
+}
+
 export interface TaskExecutor {
     readonly taskId: string;
 
@@ -93,6 +116,16 @@ export interface TaskExecutor {
      * 도구가 없어 검사하지 못한 경우와 "진단 0건"은 `serverKind` 로 구분한다.
      */
     diagnostics?(relPaths: string[]): Promise<{ text: string; count: number } | null>;
+
+    /**
+     * 코드 탐색(grep_code·repo_map)의 네이티브 백엔드 — 실행기가 지원하면 구현한다.
+     * 미구현이면 도구가 `exec` 로 셸(rg/grep/find)을 돌린다(docker 샌드박스의 기존 경로).
+     *
+     * 로컬 브리지가 이걸 구현하는 이유: exec 로 내보내면 읽기 전용 탐색인데도 디바이스의
+     * confirmExec(비우회 승인 창)이 매번 뜬다. 전용 kind 는 셸을 거치지 않아 승인 없이 돈다.
+     * 실패·구 디바이스(kind 미지원)는 **null** 을 돌려 호출측이 셸 경로로 폴백한다(fail-open).
+     */
+    codeNav?(spec: CodeNavSpec): Promise<CodeNavData | null>;
 
     /** 실행 환경 정리. removeWorkspace=false 면 산출물 회수를 위해 workspace 보존. 멱등. */
     cleanup(removeWorkspace?: boolean): Promise<void>;

--- a/apps/api/src/services/task-sandbox/tools-code-nav.test.ts
+++ b/apps/api/src/services/task-sandbox/tools-code-nav.test.ts
@@ -1,5 +1,5 @@
 import { createCodeNavTools, shq, normalizeRelPath } from './tools-code-nav';
-import type { TaskExecutor, ExecResult } from './executor';
+import type { TaskExecutor, ExecResult, CodeNavSpec, CodeNavData } from './executor';
 
 function exec(stdout: string, exitCode = 0, stderr = ''): ExecResult {
     return { stdout, stderr, exitCode, truncated: false, timedOut: false, durationMs: 1 };
@@ -11,6 +11,19 @@ function fakeSandbox(impl: (cmd: string) => ExecResult): { sandbox: TaskExecutor
         exec: jest.fn(async (cmd: string) => { cmds.push(cmd); return impl(cmd); }),
     } as unknown as TaskExecutor;
     return { sandbox, cmds };
+}
+
+/** 네이티브 탐색(codeNav)을 구현한 실행기 — 로컬 브리지 등가. */
+function nativeSandbox(
+    impl: (spec: CodeNavSpec) => CodeNavData | null | Promise<CodeNavData | null>,
+): { sandbox: TaskExecutor; specs: CodeNavSpec[]; cmds: string[] } {
+    const specs: CodeNavSpec[] = [];
+    const cmds: string[] = [];
+    const sandbox = {
+        exec: jest.fn(async (cmd: string) => { cmds.push(cmd); return exec(''); }),
+        codeNav: jest.fn(async (spec: CodeNavSpec) => { specs.push(spec); return impl(spec); }),
+    } as unknown as TaskExecutor;
+    return { sandbox, specs, cmds };
 }
 
 const text = (r: { content: { text?: string }[] }) => r.content[0].text ?? '';
@@ -112,5 +125,63 @@ describe('repo_map', () => {
         const r = await map.handler({ path: 'empty' });
         expect(r.isError).toBeFalsy();
         expect(text(r)).toContain('파일 없음');
+    });
+});
+
+describe('네이티브 백엔드(codeNav) 우선 — 로컬 브리지 승인 창 회피', () => {
+    it('grep_code 는 codeNav 를 쓰고 셸을 부르지 않는다', async () => {
+        const { sandbox, specs, cmds } = nativeSandbox(() => ({ matches: ['a.ts:1:foo', 'b.ts:2:foo'] }));
+        const grep = createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!;
+        const r = await grep.handler({ pattern: 'foo', glob: '*.ts', ignore_case: true, max_results: 5 });
+        expect(text(r)).toContain('a.ts:1:foo');
+        expect(cmds).toEqual([]);                       // 셸 미사용 = 디바이스 confirmExec 미발동
+        expect(specs[0]).toEqual({ op: 'grep', path: '.', pattern: 'foo', maxResults: 5, glob: '*.ts', ignoreCase: true });
+    });
+
+    it('repo_map 은 files + grep 두 번의 codeNav 로 조립한다', async () => {
+        const { sandbox, specs, cmds } = nativeSandbox((spec) => spec.op === 'files'
+            ? { files: [{ path: 'src/a.ts', lines: 12 }, { path: 'README.md', lines: 5 }] }
+            : { matches: ['src/a.ts:1:export function foo() {'] });
+        const map = createCodeNavTools(sandbox).find((t) => t.tool.name === 'repo_map')!;
+        const out = text(await map.handler({}));
+        expect(out).toContain('src/  파일 1 · 12줄');
+        expect(out).toContain('src/a.ts (12)');
+        expect(out).toContain('## 심볼 선언');
+        expect(out).toContain('src/a.ts:1:export function foo');
+        expect(cmds).toEqual([]);
+        expect(specs.map((s) => s.op)).toEqual(['files', 'grep']);
+    });
+
+    it('구 디바이스(null)면 셸 경로로 폴백한다', async () => {
+        const { sandbox, cmds } = nativeSandbox(() => null);
+        (sandbox as unknown as { exec: jest.Mock }).exec = jest.fn(async (cmd: string) => { cmds.push(cmd); return exec('x.ts:9:foo'); });
+        const grep = createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!;
+        expect(text(await grep.handler({ pattern: 'foo' }))).toContain('x.ts:9:foo');
+        expect(cmds[0]).toContain('rg -n');
+    });
+
+    it('codeNav 가 던져도 셸로 폴백한다(fail-open)', async () => {
+        const cmds: string[] = [];
+        const sandbox = {
+            exec: jest.fn(async (cmd: string) => { cmds.push(cmd); return exec('y.ts:1:foo'); }),
+            codeNav: jest.fn(async () => { throw new Error('bridge down'); }),
+        } as unknown as TaskExecutor;
+        const grep = createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!;
+        expect(text(await grep.handler({ pattern: 'foo' }))).toContain('y.ts:1:foo');
+        expect(cmds.length).toBeGreaterThan(0);
+    });
+
+    it('네이티브 truncated 는 잘림 안내로 노출된다', async () => {
+        const { sandbox } = nativeSandbox(() => ({ matches: ['a.ts:1:foo'], truncated: true }));
+        const grep = createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!;
+        expect(text(await grep.handler({ pattern: 'foo' }))).toContain('잘림');
+    });
+
+    it('네이티브 무일치는 오류가 아니다', async () => {
+        const { sandbox } = nativeSandbox(() => ({ matches: [] }));
+        const grep = createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!;
+        const r = await grep.handler({ pattern: 'nothing' });
+        expect(r.isError).toBeFalsy();
+        expect(text(r)).toContain('일치 없음');
     });
 });

--- a/apps/api/src/services/task-sandbox/tools-code-nav.ts
+++ b/apps/api/src/services/task-sandbox/tools-code-nav.ts
@@ -5,14 +5,17 @@
  * 전용 읽기 도구는 ① 결과를 파일:줄 형태로 캡을 걸어 돌려주고 ② 승인 정책(high-risk=bash) 대상이
  * 아니라 승인 창 없이 돌며 ③ 이름에 'search' 가 없어 웹검색 상한(SEARCH_TOOL_KEYWORDS)에 안 잡힌다.
  *
- * 구현은 sandbox.exec 위의 얇은 래퍼다 — 컨테이너(리눅스, ripgrep 포함)와 로컬 브리지(macOS 가능,
- * rg 미설치 가능) 양쪽에서 돌도록 rg → grep 폴백을 두고 GNU 전용 옵션(find -printf, xargs -d)은 쓰지
- * 않는다. 로컬 브리지에선 exec 가 디바이스 confirmExec 를 거친다(읽기 전용이어도 — 프로토콜 추가 전용).
+ * 백엔드는 둘이다:
+ *  ① 실행기가 `codeNav` 를 구현하면(로컬 브리지) 그 경로 — 디바이스가 셸 없이 파일을 훑는다.
+ *     exec 로 내보내면 읽기 전용인데도 confirmExec 승인 창이 매 호출 떠서 실사용이 불가능했다.
+ *  ② 아니면 sandbox.exec 위의 얇은 셸 래퍼(docker 샌드박스) — 컨테이너(ripgrep 포함)와 rg 없는
+ *     환경 양쪽에서 돌도록 rg → grep 폴백을 두고 GNU 전용 옵션(find -printf·xargs -d)은 안 쓴다.
+ * ①이 실패하거나 구 디바이스라 미지원이면 null 이 와서 ②로 폴백한다(fail-open).
  *
  * @module services/task-sandbox/tools-code-nav
  */
 import type { MCPToolDefinition, MCPToolResult } from '../../mcp/types';
-import type { TaskExecutor, ExecResult } from './executor';
+import type { TaskExecutor, ExecResult, CodeNavSpec } from './executor';
 import { TASK_CODE_NAV } from '../../config/runtime-limits';
 
 const PATTERN_MAX_CHARS = 500;
@@ -64,6 +67,51 @@ async function execWithGrepFallback(sandbox: TaskExecutor, rgCmd: string, grepCm
     return { r: await sandbox.exec(grepCmd), via: 'grep' };
 }
 
+/** 실행기 네이티브 탐색 시도 — 미구현·미지원·오류는 전부 null(호출측이 셸로 폴백). */
+async function tryNative(sandbox: TaskExecutor, spec: CodeNavSpec): ReturnType<NonNullable<TaskExecutor['codeNav']>> {
+    if (!sandbox.codeNav) return null;
+    try { return await sandbox.codeNav(spec); } catch { return null; }
+}
+
+interface GrepOutcome {
+    /** 매치 줄("파일:줄:내용"). 빈 배열 = 일치 없음. */
+    lines: string[];
+    overflow: boolean;
+    /** 어느 백엔드가 돌았는지 — 사용자 안내(rg 부재)용. */
+    via: 'native' | 'rg' | 'grep';
+    /** 실행 실패(오류 문구). 있으면 lines 는 무의미. */
+    error?: string;
+}
+
+/** grep 한 번 — 네이티브 우선, 아니면 셸(rg→grep). 캡·줄 절단은 이 함수가 단일 적용한다. */
+async function runGrep(sandbox: TaskExecutor, o: {
+    pattern: string; rel: string; glob?: string; ignoreCase?: boolean; max: number;
+}): Promise<GrepOutcome> {
+    const native = await tryNative(sandbox, {
+        op: 'grep', path: o.rel, pattern: o.pattern, maxResults: o.max,
+        ...(o.glob ? { glob: o.glob } : {}), ...(o.ignoreCase ? { ignoreCase: true } : {}),
+    });
+    if (native?.matches) {
+        const { lines, overflow } = clipLines(native.matches.join('\n'), o.max, TASK_CODE_NAV.GREP_LINE_MAX_CHARS);
+        return { lines, overflow: overflow || native.truncated === true, via: 'native' };
+    }
+    const head = `head -n ${o.max + 1}`;
+    const ic = o.ignoreCase === true;
+    const rgCmd = `rg -n --no-heading --color never --no-messages -m ${TASK_CODE_NAV.GREP_PER_FILE_MAX}`
+        + `${ic ? ' -i' : ''} ${excludeGlobsRg()}${o.glob ? ` -g ${shq(o.glob)}` : ''} -e ${shq(o.pattern)} -- ${shq(o.rel)} | ${head}`;
+    const grepCmd = `grep -rnI -E${ic ? 'i' : ''} ${excludeDirsGrep()}${o.glob ? ` --include=${shq(o.glob.replace(/^.*\//, ''))}` : ''}`
+        + ` -e ${shq(o.pattern)} -- ${shq(o.rel)} | ${head}`;
+    const { r, via } = await execWithGrepFallback(sandbox, rgCmd, grepCmd);
+    if (r.timedOut) return { lines: [], overflow: false, via, error: '검색 시간 초과 — path/glob 으로 범위를 좁히세요.' };
+    // 파이프 종료 코드는 head 의 것이라 rg/grep 의 1(무일치)·2(오류)를 못 본다 → 출력으로 판정.
+    if (!r.stdout.trim()) {
+        const err = r.stderr.trim();
+        return { lines: [], overflow: false, via, ...(err ? { error: `검색 실패: ${err.slice(0, 500)}` } : {}) };
+    }
+    const { lines, overflow } = clipLines(r.stdout, o.max, TASK_CODE_NAV.GREP_LINE_MAX_CHARS);
+    return { lines, overflow, via };
+}
+
 export function createCodeNavTools(sandbox: TaskExecutor): MCPToolDefinition[] {
     const grepCode: MCPToolDefinition = {
         tool: {
@@ -95,21 +143,11 @@ export function createCodeNavTools(sandbox: TaskExecutor): MCPToolDefinition[] {
                 Number.isFinite(Number(args.max_results)) && Number(args.max_results) > 0 ? Number(args.max_results) : TASK_CODE_NAV.GREP_MAX_RESULTS,
                 TASK_CODE_NAV.GREP_MAX_RESULTS * 4,
             ));
-            const head = `head -n ${max + 1}`;
-            const rgCmd = `rg -n --no-heading --color never --no-messages -m ${TASK_CODE_NAV.GREP_PER_FILE_MAX}`
-                + `${ic ? ' -i' : ''} ${excludeGlobsRg()}${glob ? ` -g ${shq(glob)}` : ''} -e ${shq(pattern)} -- ${shq(rel)} | ${head}`;
-            const grepCmd = `grep -rnI -E${ic ? 'i' : ''} ${excludeDirsGrep()}${glob ? ` --include=${shq(glob.replace(/^.*\//, ''))}` : ''}`
-                + ` -e ${shq(pattern)} -- ${shq(rel)} | ${head}`;
-            const { r, via } = await execWithGrepFallback(sandbox, rgCmd, grepCmd);
-            if (r.timedOut) return textResult('검색 시간 초과 — path/glob 으로 범위를 좁히세요.', true);
-            // 파이프 종료 코드는 head 의 것이라 rg/grep 의 1(무일치)·2(오류)를 못 본다 → 출력으로 판정.
-            if (!r.stdout.trim()) {
-                const err = r.stderr.trim();
-                return textResult(err ? `검색 실패: ${err.slice(0, 500)}` : `(일치 없음: ${pattern})`, !!err);
-            }
-            const { lines, overflow } = clipLines(r.stdout, max, TASK_CODE_NAV.GREP_LINE_MAX_CHARS);
-            const note = overflow ? `\n… ${max}줄에서 잘림 — pattern/path/glob 으로 좁히세요.` : '';
-            return textResult(`${lines.join('\n')}${note}${via === 'grep' ? '\n(rg 미설치 — grep 사용)' : ''}`);
+            const out = await runGrep(sandbox, { pattern, rel, max, ...(glob ? { glob } : {}), ...(ic ? { ignoreCase: true } : {}) });
+            if (out.error) return textResult(out.error, true);
+            if (out.lines.length === 0) return textResult(`(일치 없음: ${pattern})`);
+            const note = out.overflow ? `\n… ${max}줄에서 잘림 — pattern/path/glob 으로 좁히세요.` : '';
+            return textResult(`${out.lines.join('\n')}${note}${out.via === 'grep' ? '\n(rg 미설치 — grep 사용)' : ''}`);
         },
     };
 
@@ -132,17 +170,25 @@ export function createCodeNavTools(sandbox: TaskExecutor): MCPToolDefinition[] {
             if (rel === null) return textResult('path 는 workspace 상대 경로만 허용됩니다(절대 경로·.. 불가).', true);
             const withSymbols = args.symbols !== false;
             const maxFiles = TASK_CODE_NAV.MAP_MAX_FILES;
-            // 파일별 줄 수 — GNU 전용 옵션 없이(find -printf·xargs -d 는 macOS 로컬 브리지에 없다).
-            const listCmd = `find ${shq(rel)} ${pruneFind()} | head -n ${maxFiles + 1} | while IFS= read -r f; do `
-                + `printf '%s\\t%s\\n' "$(wc -l < "$f" 2>/dev/null | tr -d ' ')" "$f"; done`;
-            const list = await sandbox.exec(listCmd);
-            if (list.timedOut) return textResult('구조 수집 시간 초과 — path 로 범위를 좁히세요.', true);
-            const rows = list.stdout.split('\n').filter((l) => l.includes('\t')).map((l) => {
-                const [n, ...rest] = l.split('\t');
-                return { lines: parseInt(n, 10) || 0, path: rest.join('\t').replace(/^\.\//, '') };
-            });
+            const native = await tryNative(sandbox, { op: 'files', path: rel });
+            let rows: { lines: number; path: string }[];
+            let nativeTruncated = false;
+            if (native?.files) {
+                rows = native.files.map((f) => ({ lines: f.lines, path: f.path.replace(/^\.\//, '') }));
+                nativeTruncated = native.truncated === true;
+            } else {
+                // 파일별 줄 수 — GNU 전용 옵션 없이(find -printf·xargs -d 는 macOS 로컬 브리지에 없다).
+                const listCmd = `find ${shq(rel)} ${pruneFind()} | head -n ${maxFiles + 1} | while IFS= read -r f; do `
+                    + `printf '%s\\t%s\\n' "$(wc -l < "$f" 2>/dev/null | tr -d ' ')" "$f"; done`;
+                const list = await sandbox.exec(listCmd);
+                if (list.timedOut) return textResult('구조 수집 시간 초과 — path 로 범위를 좁히세요.', true);
+                rows = list.stdout.split('\n').filter((l) => l.includes('\t')).map((l) => {
+                    const [n, ...rest] = l.split('\t');
+                    return { lines: parseInt(n, 10) || 0, path: rest.join('\t').replace(/^\.\//, '') };
+                });
+            }
             if (rows.length === 0) return textResult(`(파일 없음: ${rel})`);
-            const overflow = rows.length > maxFiles;
+            const overflow = rows.length > maxFiles || nativeTruncated;
             const files = rows.slice(0, maxFiles).sort((a, b) => a.path.localeCompare(b.path));
 
             const dirs = new Map<string, { files: number; lines: number }>();
@@ -160,13 +206,10 @@ export function createCodeNavTools(sandbox: TaskExecutor): MCPToolDefinition[] {
                 ...files.map((f) => `${f.path} (${f.lines})`),
             ];
             if (withSymbols) {
-                const rgCmd = `rg -n --no-heading --color never --no-messages -m 40 ${excludeGlobsRg()} -e ${shq(SYMBOL_REGEX)} -- ${shq(rel)} | head -n ${TASK_CODE_NAV.MAP_MAX_SYMBOLS + 1}`;
-                const grepCmd = `grep -rnI -E ${excludeDirsGrep()} -e ${shq(SYMBOL_REGEX)} -- ${shq(rel)} | head -n ${TASK_CODE_NAV.MAP_MAX_SYMBOLS + 1}`;
-                const { r } = await execWithGrepFallback(sandbox, rgCmd, grepCmd);
-                if (r.stdout.trim()) {
-                    const { lines, overflow: symOverflow } = clipLines(r.stdout, TASK_CODE_NAV.MAP_MAX_SYMBOLS, TASK_CODE_NAV.GREP_LINE_MAX_CHARS);
-                    out.push('', '## 심볼 선언 (파일:줄)', ...lines);
-                    if (symOverflow) out.push(`… ${TASK_CODE_NAV.MAP_MAX_SYMBOLS}줄에서 잘림 — grep_code 로 좁히세요.`);
+                const sym = await runGrep(sandbox, { pattern: SYMBOL_REGEX, rel, max: TASK_CODE_NAV.MAP_MAX_SYMBOLS });
+                if (!sym.error && sym.lines.length > 0) {
+                    out.push('', '## 심볼 선언 (파일:줄)', ...sym.lines);
+                    if (sym.overflow) out.push(`… ${TASK_CODE_NAV.MAP_MAX_SYMBOLS}줄에서 잘림 — grep_code 로 좁히세요.`);
                 }
             }
             return textResult(out.join('\n'));

--- a/apps/desktop-native/helper/harness.cjs
+++ b/apps/desktop-native/helper/harness.cjs
@@ -156,6 +156,21 @@ const { WebSocketServer } = require('ws');
     const diff = await execVia(dev1, { kind: 'worktree', op: 'diff', taskId });
     assert.ok(diff.ok && diff.stdout.includes('diff-me'), 'worktree diff');
 
+    // ④-B code_nav — 읽기 전용 코드 탐색(grep_code·repo_map 백엔드). 셸을 거치지 않으므로
+    //      confirm 이벤트가 발생하면 안 된다(발생하면 실사용에서 탐색마다 승인 창이 뜬다).
+    fs.mkdirSync(path.join(folder, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(folder, 'src/nav.js'), 'function navTarget() {\n  return 1;\n}\n');
+    fs.mkdirSync(path.join(folder, 'node_modules/pkg'), { recursive: true });
+    fs.writeFileSync(path.join(folder, 'node_modules/pkg/i.js'), 'function navTarget() {}\n');
+    const navConfirms = events.filter((e) => e.ev === 'confirm').length;
+    const grepR = await execVia(dev1, { kind: 'code_nav', op: 'grep', pattern: 'function navTarget' });
+    assert.ok(grepR.ok && grepR.codeNav.matches.includes('src/nav.js:1:function navTarget() {'), 'code_nav grep 매치');
+    assert.ok(!grepR.codeNav.matches.some((m) => m.startsWith('node_modules/')), 'code_nav 제외 디렉토리');
+    const filesR = await execVia(dev1, { kind: 'code_nav', op: 'files', path: 'src' });
+    assert.deepEqual(filesR.codeNav.files, [{ path: 'src/nav.js', lines: 3 }], 'code_nav files 줄 수');
+    assert.equal(events.filter((e) => e.ev === 'confirm').length, navConfirms, 'code_nav 는 승인 창을 띄우지 않는다');
+    assert.equal((await execVia(dev1, { kind: 'code_nav', op: 'grep', pattern: 'x', path: '../..' })).ok, false, 'code_nav 스코프 탈출 거부');
+
     // ⑤ 다중 루트 — 두 번째 루트 연결: 파생 deviceId 상이, 루트별 스코프 격리, 개별 해제
     send({ cmd: 'connect', folder: folder2 });
     const hello2 = await waitFor((f) => f.type === 'bridge_hello' && f.folderName === path.basename(folder2));

--- a/packages/local-bridge-core/src/__tests__/code-nav.test.ts
+++ b/packages/local-bridge-core/src/__tests__/code-nav.test.ts
@@ -1,0 +1,142 @@
+/**
+ * code_nav — 읽기 전용 코드 탐색(grep_code·repo_map 백엔드)의 디바이스측 계약.
+ *
+ * 핵심 불변식: ① confirmExec 를 거치지 않는다(읽기 전용) ② 제외 디렉토리·심링크·바이너리를
+ * 건너뛴다 ③ 경로는 연결 폴더 스코프 밖으로 나가지 못한다 ④ 결과는 캡으로 잘린다.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { BridgeCore } from '../core';
+import { globToRegExp, runCodeNav, walkFiles } from '../code-nav';
+import type { BridgeResult } from '../types';
+
+let root: string;
+let confirmCalls = 0;
+
+function mk(rel: string, body = ''): void {
+    const abs = path.join(root, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, body);
+}
+
+function core(): BridgeCore {
+    const c = new BridgeCore({
+        folder: root,
+        confirm: async () => { confirmCalls++; return 'no'; },
+        sandboxProfileDir: fs.mkdtempSync(path.join(os.tmpdir(), 'omk-sb-')),
+    });
+    c.prepare();
+    return c;
+}
+
+const run = (c: BridgeCore, msg: Record<string, unknown>): Promise<BridgeResult> =>
+    new Promise((resolve) => { void c.handleExec({ kind: 'code_nav', ...msg }, resolve); });
+
+beforeEach(() => {
+    confirmCalls = 0;
+    root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'omk-codenav-')));
+    mk('src/util.ts', 'export function add(a: number, b: number) {\n  return a + b;\n}\n');
+    mk('src/util.test.ts', "import { add } from './util';\ntest('add', () => add(1, 2));\n");
+    mk('lib/thing.py', 'def bar():\n    return 1\n');
+    mk('node_modules/junk/index.js', 'function hidden() {}\n');
+    mk('dist/bundle.js', 'function hidden() {}\n');
+    mk('README.md', '# 문서\n');
+});
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe('code_nav kind', () => {
+    it('grep 은 승인(confirmExec) 없이 매치 줄을 돌려준다', async () => {
+        const r = await run(core(), { op: 'grep', pattern: 'function|def ' });
+        expect(r.ok).toBe(true);
+        expect(confirmCalls).toBe(0);           // 읽기 전용 — 승인 창이 뜨면 안 된다
+        expect(r.codeNav?.matches).toEqual(expect.arrayContaining([
+            'src/util.ts:1:export function add(a: number, b: number) {',
+            'lib/thing.py:1:def bar():',
+        ]));
+    });
+
+    it('node_modules·dist 등 제외 디렉토리는 훑지 않는다', async () => {
+        const r = await run(core(), { op: 'grep', pattern: 'hidden' });
+        expect(r.codeNav?.matches).toEqual([]);
+    });
+
+    it('glob 은 "/" 가 없으면 파일명에만 적용된다', async () => {
+        const r = await run(core(), { op: 'grep', pattern: 'add', glob: '*.test.ts' });
+        expect(r.codeNav?.matches?.every((m) => m.startsWith('src/util.test.ts:'))).toBe(true);
+        expect(r.codeNav?.matches?.length).toBeGreaterThan(0);
+    });
+
+    it('ignoreCase 를 지원한다', async () => {
+        expect((await run(core(), { op: 'grep', pattern: 'EXPORT FUNCTION' })).codeNav?.matches).toEqual([]);
+        expect((await run(core(), { op: 'grep', pattern: 'EXPORT FUNCTION', ignoreCase: true })).codeNav?.matches?.length).toBe(1);
+    });
+
+    it('maxResults 를 넘기면 잘리고 truncated 로 알린다', async () => {
+        mk('many.txt', Array.from({ length: 50 }, (_, i) => `hit ${i}`).join('\n'));
+        const r = await run(core(), { op: 'grep', pattern: 'hit', maxResults: 3 });
+        expect(r.codeNav?.matches?.length).toBe(3);
+        expect(r.codeNav?.truncated).toBe(true);
+    });
+
+    it('files 는 파일별 줄 수를 돌려준다(내용 없음)', async () => {
+        const r = await run(core(), { op: 'files' });
+        const f = r.codeNav?.files ?? [];
+        expect(f.find((x) => x.path === 'src/util.ts')?.lines).toBe(3);
+        expect(f.find((x) => x.path === 'lib/thing.py')?.lines).toBe(2);
+        expect(f.some((x) => x.path.startsWith('node_modules/'))).toBe(false);
+        expect(JSON.stringify(f)).not.toContain('return a + b');
+    });
+
+    it('바이너리 파일은 grep 대상에서 제외한다', async () => {
+        fs.writeFileSync(path.join(root, 'blob.bin'), Buffer.from([0x68, 0x69, 0x00, 0x68, 0x69]));
+        const r = await run(core(), { op: 'grep', pattern: 'hi' });
+        expect(r.codeNav?.matches?.some((m) => m.startsWith('blob.bin'))).toBe(false);
+    });
+
+    it('path 로 하위 폴더만 좁힐 수 있다', async () => {
+        const r = await run(core(), { op: 'grep', pattern: 'a', path: 'lib' });
+        expect(r.codeNav?.matches?.every((m) => m.startsWith('lib/'))).toBe(true);
+    });
+
+    it('폴더 밖 경로는 거부한다(스코프 강제)', async () => {
+        await expect(core().handleExec({ kind: 'code_nav', op: 'grep', pattern: 'x', path: '../..' }, () => { /* noop */ }))
+            .rejects.toThrow(/스코프/);
+    });
+
+    it('심링크는 따라가지 않는다', async () => {
+        const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'omk-outside-'));
+        fs.writeFileSync(path.join(outside, 'secret.txt'), 'TOPSECRET\n');
+        fs.symlinkSync(outside, path.join(root, 'linked'));
+        const r = await run(core(), { op: 'grep', pattern: 'TOPSECRET' });
+        expect(r.codeNav?.matches).toEqual([]);
+        fs.rmSync(outside, { recursive: true, force: true });
+    });
+
+    it('알 수 없는 op·잘못된 정규식은 오류로 해소한다', async () => {
+        await expect(runCodeNav(root, root, { op: 'delete' })).rejects.toThrow(/지원하지 않는/);
+        await expect(runCodeNav(root, root, { op: 'grep', pattern: '(' })).rejects.toThrow(/정규식/);
+        await expect(runCodeNav(root, root, { op: 'grep', pattern: '  ' })).rejects.toThrow(/pattern/);
+        await expect(runCodeNav(root, root, { op: 'grep', pattern: 'x'.repeat(600) })).rejects.toThrow(/너무 깁니다/);
+    });
+});
+
+describe('walkFiles / globToRegExp', () => {
+    it('파일 경로를 주면 그 파일만 대상이 된다', async () => {
+        const w = await walkFiles(root, path.join(root, 'README.md'), Date.now() + 5000);
+        expect(w.files).toEqual(['README.md']);
+    });
+
+    it('데드라인이 지나면 truncated 로 끝낸다', async () => {
+        const w = await walkFiles(root, root, Date.now() - 1);
+        expect(w.truncated).toBe(true);
+    });
+
+    it('글롭 변환 — ** 는 경로 전체, * 는 한 세그먼트', () => {
+        expect(globToRegExp('*.ts').basenameOnly).toBe(true);
+        expect(globToRegExp('*.ts').re.test('util.ts')).toBe(true);
+        expect(globToRegExp('src/**/*.py').basenameOnly).toBe(false);
+        expect(globToRegExp('src/**/*.py').re.test('src/a/b/x.py')).toBe(true);
+        expect(globToRegExp('src/*.py').re.test('src/a/x.py')).toBe(false);
+    });
+});

--- a/packages/local-bridge-core/src/code-nav.ts
+++ b/packages/local-bridge-core/src/code-nav.ts
@@ -1,0 +1,155 @@
+/**
+ * 코드 탐색(code_nav) — grep_code·repo_map 의 디바이스측 구현 (2026-09-06).
+ *
+ * 왜 별도 kind 인가: 이 두 도구는 읽기 전용인데 `exec` 로 내보내면 셸 명령이라 confirmExec
+ * (비우회 승인 창)를 매번 띄우고 EXEC_DENYLIST·sandbox-exec 를 거친다. 탐색 한 번에 승인이
+ * 뜨면 실사용이 불가능하다. lsp_diagnostics 와 같은 취지 — **읽기 전용이고 실행 인자를
+ * 디바이스가 고정 조립하면 승인 게이트 없이 처리한다**.
+ *
+ * 구현 원칙:
+ *  - 외부 실행 파일을 쓰지 않는다(ripgrep 미설치 Mac 에서도 동일하게 동작). 셸을 거치지 않으므로
+ *    명령 주입 표면이 없고, 서버가 보내는 값은 정규식·글롭·경로뿐이다.
+ *  - 경로는 호출부(core.ts)가 safeFromAsync 로 스코프를 확정한 뒤 넘긴다. walk 는 심링크를
+ *    따라가지 않는다(scope 밖 탈출 차단 — listAll 의 walk 와 같은 규칙).
+ *  - 폭주 방지는 전적으로 캡이다(승인 게이트가 없으므로): 파일 수·파일 크기·매치 수·시간 예산.
+ *  - ⚠️ 정규식은 모델이 만든 값이라 파국적 백트래킹이 가능하다. 파일 크기 상한과 파일 사이
+ *    데드라인 검사로 피해를 한 파일로 묶는다(한 파일 안의 백트래킹은 중단할 수 없다).
+ *
+ * @module code-nav
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+    CODE_NAV_EXCLUDED_DIRS, CODE_NAV_LINE_MAX_CHARS, CODE_NAV_MAX_FILE_BYTES, CODE_NAV_MAX_FILES,
+    CODE_NAV_MAX_MATCHES, CODE_NAV_MAX_PER_FILE, CODE_NAV_PATTERN_MAX_CHARS, CODE_NAV_TIMEOUT_MS,
+} from './constants';
+import type { BridgeCodeNav, BridgeMsg } from './types';
+
+const fsp = fs.promises;
+
+/** 글롭 → 정규식. '/' 가 없으면 파일명에만 적용한다(grep --include·rg -g 관행). */
+export function globToRegExp(glob: string): { re: RegExp; basenameOnly: boolean } {
+    const basenameOnly = !glob.includes('/');
+    let out = '';
+    for (let i = 0; i < glob.length; i++) {
+        const c = glob[i];
+        if (c === '*') {
+            if (glob[i + 1] === '*') { out += '.*'; i++; if (glob[i + 1] === '/') i++; } else out += '[^/]*';
+        } else if (c === '?') out += '[^/]';
+        else out += c.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+    }
+    return { re: new RegExp(`^${out}$`), basenameOnly };
+}
+
+/** 바이너리 추정 — 앞부분에 NUL 이 있으면 텍스트가 아니다(grep -I 과 같은 판정). */
+function looksBinary(buf: Buffer): boolean {
+    return buf.subarray(0, 8192).includes(0);
+}
+
+interface WalkResult {
+    /** base 기준 상대경로(POSIX 구분자). */
+    files: string[];
+    truncated: boolean;
+}
+
+/**
+ * base 아래 파일을 나열한다. 제외 디렉토리·심링크는 건너뛰고, 파일 수 상한에서 자른다.
+ * startAbs 가 파일이면 그 파일 하나만 대상이 된다(경로로 한 파일을 지목한 경우).
+ */
+export async function walkFiles(baseAbs: string, startAbs: string, deadline: number): Promise<WalkResult> {
+    const st = await fsp.stat(startAbs).catch(() => null);
+    if (!st) return { files: [], truncated: false };
+    const rel = (abs: string): string => path.relative(baseAbs, abs).split(path.sep).join('/');
+    if (st.isFile()) return { files: [rel(startAbs)], truncated: false };
+
+    const files: string[] = [];
+    let truncated = false;
+    const stack: string[] = [startAbs];
+    while (stack.length > 0) {
+        if (files.length >= CODE_NAV_MAX_FILES || Date.now() > deadline) { truncated = true; break; }
+        const dir = stack.pop() as string;
+        const entries = await fsp.readdir(dir, { withFileTypes: true }).catch(() => []);
+        for (const e of entries) {
+            if (e.isSymbolicLink()) continue;                       // 심링크는 따라가지 않는다(스코프 탈출 차단)
+            if (e.isDirectory()) {
+                if (CODE_NAV_EXCLUDED_DIRS.includes(e.name)) continue;
+                stack.push(path.join(dir, e.name));
+            } else if (e.isFile()) {
+                if (files.length >= CODE_NAV_MAX_FILES) { truncated = true; break; }
+                files.push(rel(path.join(dir, e.name)));
+            }
+        }
+    }
+    files.sort();
+    return { files, truncated };
+}
+
+/** grep — 파일을 훑어 "상대경로:줄번호:내용" 목록을 만든다. */
+async function grep(baseAbs: string, startAbs: string, m: BridgeMsg, deadline: number): Promise<BridgeCodeNav> {
+    const src = String(m.pattern ?? '');
+    if (!src.trim()) throw new Error('pattern 이 필요합니다');
+    if (src.length > CODE_NAV_PATTERN_MAX_CHARS) throw new Error(`pattern 이 너무 깁니다 (${CODE_NAV_PATTERN_MAX_CHARS}자 이하)`);
+    let re: RegExp;
+    try { re = new RegExp(src, m.ignoreCase ? 'i' : ''); } catch (e) {
+        throw new Error(`정규식이 올바르지 않습니다: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    const globFilter = m.glob ? globToRegExp(String(m.glob)) : null;
+    const cap = Math.min(
+        Number.isFinite(Number(m.maxResults)) && Number(m.maxResults) > 0 ? Number(m.maxResults) : CODE_NAV_MAX_MATCHES,
+        CODE_NAV_MAX_MATCHES,
+    );
+
+    const walked = await walkFiles(baseAbs, startAbs, deadline);
+    const matches: string[] = [];
+    let truncated = walked.truncated;
+    for (const rel of walked.files) {
+        if (matches.length >= cap || Date.now() > deadline) { truncated = true; break; }
+        if (globFilter && !globFilter.re.test(globFilter.basenameOnly ? path.posix.basename(rel) : rel)) continue;
+        const abs = path.join(baseAbs, rel);
+        const st = await fsp.stat(abs).catch(() => null);
+        if (!st || st.size > CODE_NAV_MAX_FILE_BYTES) continue;
+        const buf = await fsp.readFile(abs).catch(() => null);
+        if (!buf || looksBinary(buf)) continue;
+        const lines = buf.toString('utf8').split('\n');
+        let perFile = 0;
+        for (let i = 0; i < lines.length; i++) {
+            if (perFile >= CODE_NAV_MAX_PER_FILE) { truncated = true; break; }
+            if (matches.length >= cap) { truncated = true; break; }
+            if (!re.test(lines[i])) continue;
+            const text = lines[i].replace(/\r$/, '');
+            matches.push(`${rel}:${i + 1}:${text.length > CODE_NAV_LINE_MAX_CHARS ? `${text.slice(0, CODE_NAV_LINE_MAX_CHARS)}…` : text}`);
+            perFile++;
+        }
+    }
+    return { matches, truncated };
+}
+
+/** files — 파일별 줄 수(구조 개요용). 내용은 돌려주지 않는다. */
+async function files(baseAbs: string, startAbs: string, deadline: number): Promise<BridgeCodeNav> {
+    const walked = await walkFiles(baseAbs, startAbs, deadline);
+    const out: { path: string; lines: number }[] = [];
+    let truncated = walked.truncated;
+    for (const rel of walked.files) {
+        if (Date.now() > deadline) { truncated = true; break; }
+        const abs = path.join(baseAbs, rel);
+        const st = await fsp.stat(abs).catch(() => null);
+        if (!st) continue;
+        if (st.size > CODE_NAV_MAX_FILE_BYTES) { out.push({ path: rel, lines: 0 }); continue; }
+        const buf = await fsp.readFile(abs).catch(() => null);
+        if (!buf || looksBinary(buf)) { out.push({ path: rel, lines: 0 }); continue; }
+        const text = buf.toString('utf8');
+        out.push({ path: rel, lines: text === '' ? 0 : text.split('\n').length - (text.endsWith('\n') ? 1 : 0) });
+    }
+    return { files: out, truncated };
+}
+
+/**
+ * code_nav 진입점. startAbs 는 호출부가 스코프를 확정한 절대경로여야 한다.
+ * op 는 'grep' | 'files' 만 허용한다(그 외는 오류 — 임의 연산 금지).
+ */
+export async function runCodeNav(baseAbs: string, startAbs: string, m: BridgeMsg): Promise<BridgeCodeNav> {
+    const deadline = Date.now() + CODE_NAV_TIMEOUT_MS;
+    if (m.op === 'grep') return grep(baseAbs, startAbs, m, deadline);
+    if (m.op === 'files') return files(baseAbs, startAbs, deadline);
+    throw new Error(`지원하지 않는 code_nav op: ${m.op}`);
+}

--- a/packages/local-bridge-core/src/constants.ts
+++ b/packages/local-bridge-core/src/constants.ts
@@ -40,6 +40,28 @@ export const DIAG_MSG_MAX = 300;
 export const LIST_ALL_MAX = 1000;
 
 /**
+ * 코드 탐색(code_nav) 상한 — 읽기 전용이라 confirmExec 를 거치지 않으므로, 폭주를 막는 것은
+ * 전적으로 이 캡이다. 서버(TASK_CODE_NAV)도 같은 축의 캡을 갖지만 디바이스가 자체 강제한다.
+ */
+export const CODE_NAV_TIMEOUT_MS = Number(process.env.OMK_BRIDGE_CODE_NAV_TIMEOUT_MS || 15000);
+/** 1회 요청에서 훑을 최대 파일 수(대형 레포 보호). 초과하면 truncated. */
+export const CODE_NAV_MAX_FILES = 4000;
+/** 내용을 읽을 파일 크기 상한 — 초과 파일은 건너뛴다(번들·미니파이·데이터 덤프). */
+export const CODE_NAV_MAX_FILE_BYTES = 512 * 1024;
+/** grep 매치 상한(요청이 더 크게 요구해도 이 값으로 자른다). */
+export const CODE_NAV_MAX_MATCHES = 400;
+/** 한 파일에서 가져올 최대 매치 수 — 한 파일이 결과를 독점하지 않게. */
+export const CODE_NAV_MAX_PER_FILE = 20;
+/** 매치 줄 1건 길이 상한. */
+export const CODE_NAV_LINE_MAX_CHARS = 300;
+/** 정규식 소스 길이 상한. */
+export const CODE_NAV_PATTERN_MAX_CHARS = 500;
+/** 탐색에서 제외하는 디렉토리 — 서버 TASK_CODE_NAV.EXCLUDED_DIRS 와 같은 목록(양쪽 강제). */
+export const CODE_NAV_EXCLUDED_DIRS: readonly string[] = [
+    'node_modules', '.git', 'dist', 'build', '.next', '__pycache__', '.venv', 'venv', 'coverage', '.openmake',
+];
+
+/**
  * 파일 kind(read/write/list/listAll/delete/folders) 1회 처리 타임아웃 — OS 가 FS 호출을
  * 무기한 블록하면(외장 볼륨 TCC 권한 미결 실사례, 2026-08-23) 요청을 오류로 해소해
  * 연결(하트비트)을 지킨다. 블록된 호출 자체는 취소할 수 없어 threadpool 스레드는 남는다.

--- a/packages/local-bridge-core/src/core.ts
+++ b/packages/local-bridge-core/src/core.ts
@@ -1,7 +1,7 @@
 /**
  * BridgeCore — 브리지 디바이스의 호스트 비의존 실행 코어.
  *
- * 서버 bridge_exec 요청(kind 화이트리스트 9종)을 처리한다. 데스크톱 bridge.js 와
+ * 서버 bridge_exec 요청(고정 kind 화이트리스트)을 처리한다. 데스크톱 bridge.js 와
  * CLI bridge.ts 에 자구 동일하게 이식돼 있던 로직의 단일화 (2026-08-22, 축2 plan 1단계).
  *
  * 보안 불변식 (양쪽 구현에서 그대로 이관 — 변경 금지):
@@ -20,6 +20,7 @@ import {
     SANDBOX_BIN, SANDBOX_ENABLED,
 } from './constants';
 import { collectDiagnostics } from './diagnostics';
+import { runCodeNav } from './code-nav';
 import { matchDenylist } from './denylist';
 import { resolveExecPath } from './exec-path';
 import { detectGitDir, writeSandboxProfile } from './sandbox';
@@ -205,6 +206,14 @@ export class BridgeCore {
                 if (!this.execPathCache) this.execPathCache = resolveExecPath(this.folderRoot);
                 const r = await collectDiagnostics(base, abs, this.execPathCache);
                 done({ ok: true, ...r }); return;
+            }
+            case 'code_nav': {
+                // 읽기 전용 코드 탐색(grep_code·repo_map) — lsp_diagnostics 와 같은 이유로
+                // confirmExec 대상이 아니다: 셸을 거치지 않고(외부 실행 파일 없음) 경로는
+                // safe() 로 스코프를 확정하며, 폭주는 code-nav.ts 의 캡이 막는다.
+                const startAbs = await safeFromAsync(base, m.path);
+                const codeNav = await this.timedFs('code_nav', () => runCodeNav(base, startAbs, m));
+                done({ ok: true, codeNav }); return;
             }
             case 'worktree':
                 await handleWorktree(m, done, base); return;

--- a/packages/local-bridge-core/src/index.ts
+++ b/packages/local-bridge-core/src/index.ts
@@ -13,5 +13,6 @@ export { safeFrom } from './scope';
 export { detectGitDir, writeSandboxProfile } from './sandbox';
 export { resolveExecPath } from './exec-path';
 export { gitRun, handleWorktree } from './worktree';
+export { runCodeNav, walkFiles, globToRegExp } from './code-nav';
 export { BridgeCore } from './core';
 export { BridgeConnection, type BridgeConnectionOptions } from './connection';

--- a/packages/local-bridge-core/src/types.ts
+++ b/packages/local-bridge-core/src/types.ts
@@ -17,6 +17,24 @@ export interface BridgeMsg {
     folder?: string;
     /** lsp_diagnostics — 진단할 파일들(base 기준 상대경로). */
     paths?: string[];
+    /** code_nav grep — 정규식 소스(디바이스가 길이 검증 후 컴파일). */
+    pattern?: string;
+    /** code_nav grep — 파일 글롭 필터('*.ts' 처럼 '/' 가 없으면 파일명에만 적용). */
+    glob?: string;
+    /** code_nav grep — 대소문자 무시. */
+    ignoreCase?: boolean;
+    /** code_nav grep — 매치 상한(디바이스 캡으로 다시 잘린다). */
+    maxResults?: number;
+}
+
+/** code_nav 결과 — 읽기 전용 코드 탐색(grep/files)의 공통 표현. */
+export interface BridgeCodeNav {
+    /** grep — "상대경로:줄번호:내용" 형태의 매치 줄. */
+    matches?: string[];
+    /** files — 파일별 줄 수(base 기준 상대경로). */
+    files?: { path: string; lines: number }[];
+    /** 캡·시간 예산에 걸려 결과가 잘렸는지. */
+    truncated?: boolean;
 }
 
 /** 편집 후 진단 1건 — 컴파일러/언어 서버 출력의 공통 표현. */
@@ -50,6 +68,8 @@ export interface BridgeResult {
     diagnostics?: BridgeDiagnostic[];
     /** 어떤 검사기가 돌았는지 — 'none' 이면 지원 도구가 없어 검사하지 않았다(진단 없음과 구분). */
     serverKind?: string;
+    /** code_nav 결과. */
+    codeNav?: BridgeCodeNav;
 }
 
 /**


### PR DESCRIPTION
## 문제
#772 의 `grep_code`·`repo_map` 은 `sandbox.exec` 위의 셸 래퍼라, 로컬 브리지 실행(`executor='local'`)에선 **읽기 전용 탐색인데도 디바이스 승인 창(confirmExec)이 매 호출** 떴다. #772 본문에 후속으로 남겨둔 항목.

## 해결
`lsp_diagnostics` 와 같은 취지의 읽기 전용 전용 kind `code_nav` 를 추가했다.

**디바이스** (`packages/local-bridge-core/src/code-nav.ts`)
- `op: 'grep' | 'files'` 둘만. 그 외는 거절.
- 외부 실행 파일·셸 미사용 → ripgrep 없는 Mac 에서도 동작하고 명령 주입 표면이 없다.
- 경로는 기존 `safeFromAsync` 스코프, walk 는 심링크 미추적.
- 승인 게이트가 없으니 캡이 유일한 방어: 파일 4000 · 파일당 512KB · 매치 400 · 파일당 20 · 줄 300자 · 15s 예산.

**서버**
- `TaskExecutor.codeNav?()` — `diagnostics?()` 와 같은 옵셔널 계약. 미구현(docker)·미지원(구 디바이스)·오류는 null → 도구가 셸 경로로 폴백.
- `RemoteExecutor.codeNav` 가 worktree prefix 를 떼어 돌려준다.
- `tools-code-nav` 의 grep 을 `runGrep` 하나로 모아 네이티브/셸 분기 단일화.

## 검증
- **되돌리기 확인**: native 경로 무력화 → 3건 실패 / core 의 `code_nav` case 제거 → 10건 실패 / `codeNav` 항상 null → 1건 실패. 복원 후 전부 통과.
- `local-bridge-core` 75 passed(신규 14), `apps/api` local-bridge + task-sandbox 174 passed, tsc·eslint 0, Gate 3 이내.
- 디바이스 테스트는 실 fs 로 승인 창 미발동(`confirmCalls === 0`)·제외 디렉토리·심링크 미추적·바이너리 제외·스코프 밖 거부를 고정.

## 배포 주의
프로토콜은 **추가 전용**이라 구 디바이스(Companion 0.2.2·기존 CLI)는 "지원하지 않는 kind" 를 돌려주고 서버가 셸 경로로 폴백한다. 새 경로를 실제로 쓰려면 Companion 재빌드·게시(헬퍼 번들 갱신)와 CLI 재빌드가 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbGa9RXHjXeRfXTn1bonB1