### PR TITLE
fix(local-bridge): code_nav 제외 목록을 이름 기준으로 — worktree 의 .git 은 파일이라 새어 들어왔다

### DIFF
--- a/packages/local-bridge-core/src/__tests__/code-nav.test.ts
+++ b/packages/local-bridge-core/src/__tests__/code-nav.test.ts
@@ -88,6 +88,14 @@ describe('code_nav kind', () => {
         expect(JSON.stringify(f)).not.toContain('return a + b');
     });
 
+    it('제외 이름은 파일이어도 건너뛴다 — worktree 의 .git 은 디렉토리가 아니라 파일이다', async () => {
+        fs.writeFileSync(path.join(root, '.git'), 'gitdir: /elsewhere/.git/worktrees/x\n');
+        const r = await run(core(), { op: 'files' });
+        expect(r.codeNav?.files?.some((f) => f.path === '.git')).toBe(false);
+        const g = await run(core(), { op: 'grep', pattern: 'gitdir' });
+        expect(g.codeNav?.matches).toEqual([]);
+    });
+
     it('바이너리 파일은 grep 대상에서 제외한다', async () => {
         fs.writeFileSync(path.join(root, 'blob.bin'), Buffer.from([0x68, 0x69, 0x00, 0x68, 0x69]));
         const r = await run(core(), { op: 'grep', pattern: 'hi' });

--- a/packages/local-bridge-core/src/code-nav.ts
+++ b/packages/local-bridge-core/src/code-nav.ts
@@ -71,8 +71,11 @@ export async function walkFiles(baseAbs: string, startAbs: string, deadline: num
         const entries = await fsp.readdir(dir, { withFileTypes: true }).catch(() => []);
         for (const e of entries) {
             if (e.isSymbolicLink()) continue;                       // 심링크는 따라가지 않는다(스코프 탈출 차단)
+            // 제외 이름은 종류를 가리지 않는다 — git worktree 의 `.git` 은 디렉토리가 아니라
+            // gitdir 포인터 **파일**이라, 디렉토리만 걸러내면 목록에 섞여 들어온다(라이브 실측).
+            // 셸 폴백의 find -prune 은 이미 이름 기준이라 이렇게 해야 두 백엔드가 같은 결과를 낸다.
+            if (CODE_NAV_EXCLUDED_DIRS.includes(e.name)) continue;
             if (e.isDirectory()) {
-                if (CODE_NAV_EXCLUDED_DIRS.includes(e.name)) continue;
                 stack.push(path.join(dir, e.name));
             } else if (e.isFile()) {
                 if (files.length >= CODE_NAV_MAX_FILES) { truncated = true; break; }


### PR DESCRIPTION
## 발견 경로
#774 배포 후 **로컬 브리지 라이브 E2E**(CLI 디바이스 + `executor='local'`)에서 `repo_map` 출력에 `.git (1)` 이 파일로 섞여 나왔다.

## 원인
worktree 격리가 걸린 폴더의 `.git` 은 디렉토리가 아니라 gitdir 포인터 **파일**이다. 네이티브 walk 는 제외 목록을 `isDirectory()` 분기 안에서만 검사해 이 파일을 그대로 나열했다. 셸 폴백(`find \( -name .git \) -prune`)은 이름 기준이라 이미 제외하고 있었으므로 **두 백엔드가 다른 결과**를 내고 있었다.

## 수정
제외 검사를 종류와 무관하게 이름 기준으로 올린다(1줄). 되돌리면 신규 테스트 1건이 실패하는 것을 확인했다.

## 검증
- `local-bridge-core` 76 passed(신규 1), Companion 헬퍼 하네스 통과.
- 라이브(수정 전): 로컬 실행 작업 3턴 32초 완료 · 승인 창 0회 · judge achieved — `.git` 혼입만 결함이었다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbGa9RXHjXeRfXTn1bonB1