### PR TITLE
feat(task-sandbox): 자격증명 파일 — 탐색 제외 + 쓰기 승인 상향

### DIFF
--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -2096,6 +2096,24 @@ export const MCP_SANDBOX_BOOTSTRAP = {
 } as const;
 
 /**
+ * 민감 파일 글롭 — 자격증명·키 파일의 단일 목록 (2026-09-06).
+ *
+ * 두 곳이 이 목록을 쓴다:
+ *  ① 코드 탐색(grep_code·repo_map) 제외 — 승인이 도구 단위라 사용자는 어떤 파일을 읽을지
+ *     보지 못한다. 정책과 무관하게 훑기에서 제외해 자격증명이 대화·스텝 DB 로 쓸려 들어가는
+ *     것을 막는다(봉쇄가 아니라 위생 — 경로를 지목한 file_ops read 는 별도 승인 게이트).
+ *  ② 쓰기 승인 상향(approval-gate) — high-risk 정책에서 이 경로에 쓰는 호출은 승인 대상.
+ *
+ * 디바이스 코어의 CODE_NAV_EXCLUDED_FILES 와 같은 목록으로 유지할 것(양쪽 강제).
+ * 패턴은 파일명(basename) 글롭 — rg -g · grep --exclude · find -name 에 그대로 쓰인다.
+ */
+export const SENSITIVE_FILE_PATTERNS: readonly string[] = [
+    '.env', '.env.*', '*.pem', '*.key', '*.p12', '*.pfx', '*.jks', '*.keystore',
+    'id_rsa', 'id_rsa.*', 'id_ed25519', 'id_ed25519.*', '.npmrc', '.netrc', '.pgpass', '.htpasswd',
+    'credentials', 'credentials.*', 'service-account*.json', '*.kdbx',
+];
+
+/**
  * Task 샌드박스 코드 탐색 도구(grep_code·repo_map, 2026-09-06) 상한.
  * 30일 실측: bash 호출 444건 중 탐색·읽기(grep/find/ls/cat)가 150건(34%)이고 결과가 통째로 대화에
  * 들어갔다. 전용 도구는 결과를 파일:줄 형태로 캡을 걸어 돌려준다(읽기 전용, 승인 대상 아님).
@@ -2114,4 +2132,6 @@ export const TASK_CODE_NAV = {
     MAP_MAX_SYMBOLS: parseInt(process.env.TASK_CODE_NAV_MAP_MAX_SYMBOLS || '200', 10),
     /** 탐색에서 제외하는 디렉토리(빌드 산출물·의존성·VCS). */
     EXCLUDED_DIRS: ['node_modules', '.git', 'dist', 'build', '.next', '__pycache__', '.venv', 'venv', 'coverage', '.openmake'] as readonly string[],
+    /** 탐색에서 제외하는 파일(자격증명) — 위 SENSITIVE_FILE_PATTERNS 단일 목록. */
+    EXCLUDED_FILES: SENSITIVE_FILE_PATTERNS,
 } as const;

--- a/apps/api/src/services/local-bridge/registry.ts
+++ b/apps/api/src/services/local-bridge/registry.ts
@@ -69,6 +69,8 @@ export interface BridgeCodeNavData {
     files?: { path: string; lines: number }[];
     /** 캡·시간 예산에 걸려 잘렸는지. */
     truncated?: boolean;
+    /** 민감 파일 정책으로 건너뛴 파일 수. */
+    skipped?: number;
 }
 
 /** 편집 후 진단 1건 — 디바이스의 컴파일러 출력(코어 BridgeDiagnostic 과 1:1). */

--- a/apps/api/src/services/local-bridge/remote-executor.ts
+++ b/apps/api/src/services/local-bridge/remote-executor.ts
@@ -154,6 +154,7 @@ export class RemoteExecutor implements TaskExecutor {
             ...(r.codeNav.matches ? { matches: r.codeNav.matches.map(strip) } : {}),
             ...(r.codeNav.files ? { files: r.codeNav.files.map((f) => ({ ...f, path: strip(f.path) })) } : {}),
             ...(r.codeNav.truncated ? { truncated: true } : {}),
+            ...(r.codeNav.skipped ? { skipped: r.codeNav.skipped } : {}),
         };
     }
 

--- a/apps/api/src/services/task-sandbox/approval-gate.ts
+++ b/apps/api/src/services/task-sandbox/approval-gate.ts
@@ -15,6 +15,7 @@
  * @module services/task-sandbox/approval-gate
  */
 import type { TaskSandboxApprovalPolicy } from '../../config/task-sandbox';
+import { isSensitivePath } from './sensitive-paths';
 import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('TaskApprovalGate');
@@ -29,6 +30,9 @@ const HIGH_RISK_TOOLS = new Set(['bash', 'browser', 'python_execute', 'skill_run
 const NO_APPROVAL_TOOLS = new Set(['terminate', 'ask_human', 'plan_create', 'plan_update', 'plan_view', 'delegate', 'spawn_agents']);
 /** 고위험으로 보는 file_ops 작업. */
 const HIGH_RISK_FILE_OPS = new Set(['delete']);
+/** 파일을 바꾸는 작업 — 대상이 자격증명 파일이면 high-risk 로 올린다(아래 판정). */
+const FILE_WRITE_OPS = new Set(['write', 'delete']);
+const EDITOR_WRITE_COMMANDS = new Set(['create', 'str_replace', 'insert']);
 /** 디바이스(로컬 브리지)가 실행 직전 자체 확인하는 코드 실행 도구 — 서버 승인 중복이라 skip 대상. */
 const DEVICE_GATED_SHELL = new Set(['bash', 'python_execute']);
 
@@ -51,6 +55,18 @@ export function requiresApproval(
     // high-risk
     if (HIGH_RISK_TOOLS.has(toolName)) return true;
     if (toolName === 'file_ops' && HIGH_RISK_FILE_OPS.has(String(args.op))) return true;
+    // 자격증명 파일 쓰기는 high-risk 로 상향 — 종전엔 file_ops write·str_replace_editor 가
+    // 고위험 목록 밖이라 `.env`·키 파일 덮어쓰기가 **서버 승인도 디바이스 확인도 없이**
+    // 통과했다(로컬 브리지의 write kind 는 confirmExec 대상이 아니다). 차단이 아니라 승인
+    // 상향이므로 사용자가 허용하면 정상 작업(환경변수 추가 등)은 그대로 진행된다.
+    if (isSensitiveWrite(toolName, args)) return true;
+    return false;
+}
+
+/** PURE: 이 호출이 자격증명 파일을 바꾸려 하는가. args 미지({})면 false(보수 판정 — 강등 계산과 동일 계약). */
+export function isSensitiveWrite(toolName: string, args: Record<string, unknown>): boolean {
+    if (toolName === 'file_ops') return FILE_WRITE_OPS.has(String(args.op)) && isSensitivePath(args.path);
+    if (toolName === 'str_replace_editor') return EDITOR_WRITE_COMMANDS.has(String(args.command)) && isSensitivePath(args.path);
     return false;
 }
 

--- a/apps/api/src/services/task-sandbox/executor.ts
+++ b/apps/api/src/services/task-sandbox/executor.ts
@@ -55,6 +55,8 @@ export interface CodeNavData {
     files?: { path: string; lines: number }[];
     /** 실행기 캡에 걸려 잘렸는지. */
     truncated?: boolean;
+    /** 민감 파일 정책으로 건너뛴 파일 수 — 0/미지원이면 생략. */
+    skipped?: number;
 }
 
 export interface TaskExecutor {

--- a/apps/api/src/services/task-sandbox/sensitive-paths.test.ts
+++ b/apps/api/src/services/task-sandbox/sensitive-paths.test.ts
@@ -1,0 +1,88 @@
+/**
+ * 민감 파일 판정 + 쓰기 승인 상향 (2026-09-06).
+ *
+ * 고정하는 계약:
+ *  - 판정은 파일명(basename) 기준이고 디렉토리 위치와 무관하다.
+ *  - high-risk 정책에서 자격증명 파일을 **쓰는** 호출만 승인 대상이 된다(읽기·목록은 아님).
+ *  - all/none 정책의 의미는 바뀌지 않는다.
+ */
+import { isSensitivePath } from './sensitive-paths';
+import { isSensitiveWrite, requiresApproval, stripApprovalGatedTools } from './approval-gate';
+
+describe('isSensitivePath', () => {
+    it('자격증명 파일을 경로 위치와 무관하게 잡는다', () => {
+        for (const p of ['.env', 'apps/api/.env', './.env.production', 'certs/server.pem', 'a/b/app.key',
+            'id_rsa', 'deploy/id_ed25519', '.npmrc', '.pgpass', 'credentials', 'gcp/service-account-prod.json']) {
+            expect(isSensitivePath(p)).toBe(true);
+        }
+    });
+
+    it('일반 소스·문서는 잡지 않는다', () => {
+        for (const p of ['src/env.ts', 'README.md', 'docs/environment.md', 'package.json', 'src/keychain/index.ts']) {
+            expect(isSensitivePath(p)).toBe(false);
+        }
+    });
+
+    it('문자열이 아니거나 빈 경로는 false (판정 불가를 차단 사유로 쓰지 않는다)', () => {
+        expect(isSensitivePath(undefined)).toBe(false);
+        expect(isSensitivePath(123)).toBe(false);
+        expect(isSensitivePath('')).toBe(false);
+        expect(isSensitivePath('/')).toBe(false);
+    });
+});
+
+describe('isSensitiveWrite', () => {
+    it('file_ops 는 write·delete 만, str_replace_editor 는 편집 명령만 해당', () => {
+        expect(isSensitiveWrite('file_ops', { op: 'write', path: '.env' })).toBe(true);
+        expect(isSensitiveWrite('file_ops', { op: 'delete', path: 'certs/a.pem' })).toBe(true);
+        expect(isSensitiveWrite('file_ops', { op: 'read', path: '.env' })).toBe(false);
+        expect(isSensitiveWrite('file_ops', { op: 'list', path: '.' })).toBe(false);
+        expect(isSensitiveWrite('str_replace_editor', { command: 'create', path: '.env.local' })).toBe(true);
+        expect(isSensitiveWrite('str_replace_editor', { command: 'str_replace', path: 'app.key' })).toBe(true);
+        expect(isSensitiveWrite('str_replace_editor', { command: 'view', path: '.env' })).toBe(false);
+        expect(isSensitiveWrite('bash', { command: 'cat .env' })).toBe(false);   // 셸은 별도 게이트
+    });
+
+    it('인자 미지({})는 false — 강등 계산의 보수 판정 계약과 같다', () => {
+        expect(isSensitiveWrite('file_ops', {})).toBe(false);
+        expect(isSensitiveWrite('str_replace_editor', {})).toBe(false);
+    });
+});
+
+describe('requiresApproval — 민감 파일 쓰기 상향', () => {
+    it('high-risk: 자격증명 쓰기는 승인 대상, 일반 파일 쓰기는 아니다', () => {
+        expect(requiresApproval('high-risk', 'file_ops', { op: 'write', path: '.env' })).toBe(true);
+        expect(requiresApproval('high-risk', 'file_ops', { op: 'write', path: 'src/a.ts' })).toBe(false);
+        expect(requiresApproval('high-risk', 'str_replace_editor', { command: 'create', path: 'certs/server.pem' })).toBe(true);
+        expect(requiresApproval('high-risk', 'str_replace_editor', { command: 'create', path: 'src/a.ts' })).toBe(false);
+    });
+
+    it('high-risk: 자격증명 읽기·탐색은 종전대로 승인 불요', () => {
+        expect(requiresApproval('high-risk', 'file_ops', { op: 'read', path: '.env' })).toBe(false);
+        expect(requiresApproval('high-risk', 'grep_code', { pattern: 'API_KEY' })).toBe(false);
+        expect(requiresApproval('high-risk', 'repo_map', {})).toBe(false);
+    });
+
+    it('none 은 무엇도 승인하지 않고, all 은 종전대로 전부 승인한다(정책 의미 불변)', () => {
+        expect(requiresApproval('none', 'file_ops', { op: 'write', path: '.env' })).toBe(false);
+        expect(requiresApproval('all', 'file_ops', { op: 'write', path: 'src/a.ts' })).toBe(true);
+        expect(requiresApproval('all', 'grep_code', { pattern: 'x' })).toBe(true);
+    });
+
+    it('로컬 브리지의 셸 위임(deviceGatesShell)은 영향을 받지 않는다', () => {
+        expect(requiresApproval('high-risk', 'bash', { command: 'echo hi' }, { deviceGatesShell: true })).toBe(false);
+    });
+});
+
+describe('stripApprovalGatedTools — 인자 미지 보수 판정', () => {
+    it('high-risk 에서 파일 도구는 남는다(민감 여부는 호출 시점에 판정)', () => {
+        const tools = [
+            { function: { name: 'file_ops' } },
+            { function: { name: 'str_replace_editor' } },
+            { function: { name: 'bash' } },
+            { function: { name: 'grep_code' } },
+        ];
+        const names = stripApprovalGatedTools(tools, 'high-risk').map((t) => t.function.name);
+        expect(names).toEqual(['file_ops', 'str_replace_editor', 'grep_code']);
+    });
+});

--- a/apps/api/src/services/task-sandbox/sensitive-paths.ts
+++ b/apps/api/src/services/task-sandbox/sensitive-paths.ts
@@ -1,0 +1,38 @@
+/**
+ * 민감 파일 경로 판정 (2026-09-06) — PURE.
+ *
+ * `SENSITIVE_FILE_PATTERNS`(config) 를 파일명 글롭으로 매칭한다. 소비처는 둘:
+ *  ① 승인 게이트 — high-risk 정책에서 이 경로에 **쓰는** 호출을 승인 대상으로 올린다.
+ *  ② 코드 탐색 셸 폴백 — 같은 목록을 rg/grep/find 인자로 넘긴다(디바이스 네이티브 경로는
+ *     local-bridge-core 가 자체 목록으로 강제 — 양쪽 목록을 같게 유지할 것).
+ *
+ * ⚠️ 이것은 봉쇄가 아니다. 경로를 지목한 읽기·셸은 그대로 가능하고 각자의 게이트가 따로 있다.
+ * 여기서 막는 것은 "훑다가 딸려 들어옴"과 "확인 없이 덮어씀" 두 가지다.
+ *
+ * @module services/task-sandbox/sensitive-paths
+ */
+import { SENSITIVE_FILE_PATTERNS } from '../../config/runtime-limits';
+
+/** 파일명 글롭 → 정규식. `*` 는 경로 구분자를 넘지 않는다(basename 매칭이라 실질 무관). */
+function globToRegExp(glob: string): RegExp {
+    let out = '';
+    for (const c of glob) {
+        if (c === '*') out += '[^/]*';
+        else if (c === '?') out += '[^/]';
+        else out += c.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+    }
+    return new RegExp(`^${out}$`);
+}
+
+const RES = SENSITIVE_FILE_PATTERNS.map(globToRegExp);
+
+/**
+ * 경로가 자격증명 파일을 가리키는지 — 디렉토리 부분은 무시하고 파일명만 본다.
+ * 빈 값·경로 아님은 false(보수적으로 "민감하지 않음" — 판정 불가를 차단 사유로 삼지 않는다).
+ */
+export function isSensitivePath(p: unknown): boolean {
+    if (typeof p !== 'string') return false;
+    const name = p.split(/[\\/]/).filter(Boolean).pop();
+    if (!name) return false;
+    return RES.some((re) => re.test(name));
+}

--- a/apps/api/src/services/task-sandbox/tools-code-nav.test.ts
+++ b/apps/api/src/services/task-sandbox/tools-code-nav.test.ts
@@ -185,3 +185,52 @@ describe('네이티브 백엔드(codeNav) 우선 — 로컬 브리지 승인 창
         expect(text(r)).toContain('일치 없음');
     });
 });
+
+describe('민감 파일 제외 (2026-09-06)', () => {
+    it('셸 폴백도 자격증명 파일을 인자로 제외한다 — 네이티브와 같은 목록', async () => {
+        const { sandbox, cmds } = fakeSandbox(() => exec('src/a.ts:1:KEY'));
+        const grep = createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!;
+        await grep.handler({ pattern: 'KEY' });
+        expect(cmds[0]).toContain("-g '!.env'");
+        expect(cmds[0]).toContain("-g '!*.pem'");
+        expect(cmds[0]).toContain("-g '!id_rsa'");
+    });
+
+    it('grep 폴백(--exclude)·find prune 에도 같은 목록이 들어간다', async () => {
+        const { sandbox, cmds } = fakeSandbox((cmd) => cmd.startsWith('rg') ? exec('', 127, 'not found') : exec('x.ts:1:m'));
+        await createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!.handler({ pattern: 'm' });
+        expect(cmds[1]).toContain("--exclude='.env'");
+        const { sandbox: sb2, cmds: cmds2 } = fakeSandbox(() => exec('1\t./x.ts'));
+        await createCodeNavTools(sb2).find((t) => t.tool.name === 'repo_map')!.handler({ symbols: false });
+        expect(cmds2[0]).toContain("-name '.env'");
+        expect(cmds2[0]).toContain("-name '*.pem'");
+    });
+
+    it('건너뛴 파일이 있으면 결과 말미에 알린다 — "없음" 오판 방지', async () => {
+        const { sandbox } = nativeSandbox(() => ({ matches: ['a.ts:1:KEY'], skipped: 2 }));
+        const grep = createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!;
+        const t = text(await grep.handler({ pattern: 'KEY' }));
+        expect(t).toContain('자격증명 파일 2개는 정책상 검색에서 제외');
+        expect(t).toContain('file_ops read');
+    });
+
+    it('무일치여도 건너뛴 것이 있으면 알린다', async () => {
+        const { sandbox } = nativeSandbox(() => ({ matches: [], skipped: 1 }));
+        const grep = createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!;
+        expect(text(await grep.handler({ pattern: 'KEY' }))).toContain('정책상 검색에서 제외');
+    });
+
+    it('repo_map 도 건너뛴 수를 알린다', async () => {
+        const { sandbox } = nativeSandbox((spec) => spec.op === 'files'
+            ? { files: [{ path: 'src/a.ts', lines: 3 }], skipped: 1 }
+            : { matches: [] });
+        const map = createCodeNavTools(sandbox).find((t) => t.tool.name === 'repo_map')!;
+        expect(text(await map.handler({}))).toContain('자격증명 파일 1개');
+    });
+
+    it('건너뛴 것이 없으면 안내를 붙이지 않는다', async () => {
+        const { sandbox } = nativeSandbox(() => ({ matches: ['a.ts:1:x'] }));
+        const grep = createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!;
+        expect(text(await grep.handler({ pattern: 'x' }))).not.toContain('정책상');
+    });
+});

--- a/apps/api/src/services/task-sandbox/tools-code-nav.ts
+++ b/apps/api/src/services/task-sandbox/tools-code-nav.ts
@@ -44,14 +44,29 @@ export function normalizeRelPath(p: string): string | null {
 }
 
 function excludeGlobsRg(): string {
-    return TASK_CODE_NAV.EXCLUDED_DIRS.map((d) => `-g ${shq(`!${d}/**`)}`).join(' ');
+    return [
+        ...TASK_CODE_NAV.EXCLUDED_DIRS.map((d) => `-g ${shq(`!${d}/**`)}`),
+        // 자격증명 파일 — 디바이스 네이티브 경로(local-bridge-core)와 같은 목록으로 강제한다.
+        ...TASK_CODE_NAV.EXCLUDED_FILES.map((f) => `-g ${shq(`!${f}`)}`),
+    ].join(' ');
 }
 function excludeDirsGrep(): string {
-    return TASK_CODE_NAV.EXCLUDED_DIRS.map((d) => `--exclude-dir=${shq(d)}`).join(' ');
+    return [
+        ...TASK_CODE_NAV.EXCLUDED_DIRS.map((d) => `--exclude-dir=${shq(d)}`),
+        ...TASK_CODE_NAV.EXCLUDED_FILES.map((f) => `--exclude=${shq(f)}`),
+    ].join(' ');
 }
 function pruneFind(): string {
     // find <path> \( -name a -o -name b \) -prune -o -type f -print
-    return `\\( ${TASK_CODE_NAV.EXCLUDED_DIRS.map((d) => `-name ${shq(d)}`).join(' -o ')} \\) -prune -o -type f -print`;
+    // 디렉토리·파일 모두 이름 기준 prune — 파일에 걸리면 -o 단락으로 -print 에 닿지 않는다.
+    const names = [...TASK_CODE_NAV.EXCLUDED_DIRS, ...TASK_CODE_NAV.EXCLUDED_FILES]
+        .map((d) => `-name ${shq(d)}`).join(' -o ');
+    return `\\( ${names} \\) -prune -o -type f -print`;
+}
+
+/** 결과 말미 안내 — 정책으로 건너뛴 파일이 있으면 "없음" 오판을 막는다(조용한 실패 방지). */
+function skippedNote(skipped: number | undefined): string {
+    return skipped ? `\n(자격증명 파일 ${skipped}개는 정책상 검색에서 제외됨 — 필요하면 file_ops read 로 경로를 지목하세요)` : '';
 }
 
 function clipLines(out: string, maxLines: number, maxChars: number): { lines: string[]; overflow: boolean } {
@@ -81,6 +96,8 @@ interface GrepOutcome {
     via: 'native' | 'rg' | 'grep';
     /** 실행 실패(오류 문구). 있으면 lines 는 무의미. */
     error?: string;
+    /** 민감 파일 정책으로 건너뛴 수(네이티브 백엔드만 셈). */
+    skipped?: number;
 }
 
 /** grep 한 번 — 네이티브 우선, 아니면 셸(rg→grep). 캡·줄 절단은 이 함수가 단일 적용한다. */
@@ -93,7 +110,7 @@ async function runGrep(sandbox: TaskExecutor, o: {
     });
     if (native?.matches) {
         const { lines, overflow } = clipLines(native.matches.join('\n'), o.max, TASK_CODE_NAV.GREP_LINE_MAX_CHARS);
-        return { lines, overflow: overflow || native.truncated === true, via: 'native' };
+        return { lines, overflow: overflow || native.truncated === true, via: 'native', ...(native.skipped ? { skipped: native.skipped } : {}) };
     }
     const head = `head -n ${o.max + 1}`;
     const ic = o.ignoreCase === true;
@@ -118,7 +135,9 @@ export function createCodeNavTools(sandbox: TaskExecutor): MCPToolDefinition[] {
             name: 'grep_code',
             description: 'workspace 코드를 정규식으로 검색해 "파일:줄번호:내용" 목록을 돌려줍니다(ripgrep, 읽기 전용, '
                 + `최대 ${TASK_CODE_NAV.GREP_MAX_RESULTS}줄). 심볼 정의·사용처·문자열을 찾을 때 bash grep 대신 쓰세요 — `
-                + '결과가 캡으로 잘려 컨텍스트를 아낍니다. node_modules/.git/dist 는 자동 제외.',
+                + '결과가 캡으로 잘려 컨텍스트를 아낍니다. node_modules/.git/dist 는 자동 제외되고, '
+                + '자격증명 파일(.env·*.pem·id_rsa 등)은 정책상 검색되지 않습니다 — 그 내용이 필요하면 '
+                + 'file_ops read 로 경로를 지목하세요(승인이 필요할 수 있습니다).',
             inputSchema: {
                 type: 'object',
                 properties: {
@@ -145,9 +164,9 @@ export function createCodeNavTools(sandbox: TaskExecutor): MCPToolDefinition[] {
             ));
             const out = await runGrep(sandbox, { pattern, rel, max, ...(glob ? { glob } : {}), ...(ic ? { ignoreCase: true } : {}) });
             if (out.error) return textResult(out.error, true);
-            if (out.lines.length === 0) return textResult(`(일치 없음: ${pattern})`);
+            if (out.lines.length === 0) return textResult(`(일치 없음: ${pattern})${skippedNote(out.skipped)}`);
             const note = out.overflow ? `\n… ${max}줄에서 잘림 — pattern/path/glob 으로 좁히세요.` : '';
-            return textResult(`${out.lines.join('\n')}${note}${out.via === 'grep' ? '\n(rg 미설치 — grep 사용)' : ''}`);
+            return textResult(`${out.lines.join('\n')}${note}${skippedNote(out.skipped)}${out.via === 'grep' ? '\n(rg 미설치 — grep 사용)' : ''}`);
         },
     };
 
@@ -173,9 +192,11 @@ export function createCodeNavTools(sandbox: TaskExecutor): MCPToolDefinition[] {
             const native = await tryNative(sandbox, { op: 'files', path: rel });
             let rows: { lines: number; path: string }[];
             let nativeTruncated = false;
+            let nativeSkipped = 0;
             if (native?.files) {
                 rows = native.files.map((f) => ({ lines: f.lines, path: f.path.replace(/^\.\//, '') }));
                 nativeTruncated = native.truncated === true;
+                nativeSkipped = native.skipped ?? 0;
             } else {
                 // 파일별 줄 수 — GNU 전용 옵션 없이(find -printf·xargs -d 는 macOS 로컬 브리지에 없다).
                 const listCmd = `find ${shq(rel)} ${pruneFind()} | head -n ${maxFiles + 1} | while IFS= read -r f; do `
@@ -187,7 +208,7 @@ export function createCodeNavTools(sandbox: TaskExecutor): MCPToolDefinition[] {
                     return { lines: parseInt(n, 10) || 0, path: rest.join('\t').replace(/^\.\//, '') };
                 });
             }
-            if (rows.length === 0) return textResult(`(파일 없음: ${rel})`);
+            if (rows.length === 0) return textResult(`(파일 없음: ${rel})${skippedNote(nativeSkipped)}`);
             const overflow = rows.length > maxFiles || nativeTruncated;
             const files = rows.slice(0, maxFiles).sort((a, b) => a.path.localeCompare(b.path));
 
@@ -212,7 +233,7 @@ export function createCodeNavTools(sandbox: TaskExecutor): MCPToolDefinition[] {
                     if (sym.overflow) out.push(`… ${TASK_CODE_NAV.MAP_MAX_SYMBOLS}줄에서 잘림 — grep_code 로 좁히세요.`);
                 }
             }
-            return textResult(out.join('\n'));
+            return textResult(`${out.join('\n')}${skippedNote(nativeSkipped)}`);
         },
     };
 

--- a/apps/desktop-native/helper/harness.cjs
+++ b/apps/desktop-native/helper/harness.cjs
@@ -170,6 +170,12 @@ const { WebSocketServer } = require('ws');
     assert.deepEqual(filesR.codeNav.files, [{ path: 'src/nav.js', lines: 3 }], 'code_nav files 줄 수');
     assert.equal(events.filter((e) => e.ev === 'confirm').length, navConfirms, 'code_nav 는 승인 창을 띄우지 않는다');
     assert.equal((await execVia(dev1, { kind: 'code_nav', op: 'grep', pattern: 'x', path: '../..' })).ok, false, 'code_nav 스코프 탈출 거부');
+    // 자격증명 파일은 훑지 않는다 — 승인이 도구 단위라 사용자는 어떤 파일을 읽을지 못 본다.
+    fs.writeFileSync(path.join(folder, '.env'), 'API_KEY=harness-secret\n');
+    const secretR = await execVia(dev1, { kind: 'code_nav', op: 'grep', pattern: 'harness-secret' });
+    assert.deepEqual(secretR.codeNav.matches, [], 'code_nav 자격증명 미검색');
+    assert.equal(secretR.codeNav.skipped, 1, 'code_nav 건너뛴 수 보고');
+    assert.ok((await execVia(dev1, { kind: 'read', path: '.env' })).content.includes('harness-secret'), '경로 지목 read 는 그대로 동작');
 
     // ⑤ 다중 루트 — 두 번째 루트 연결: 파생 deviceId 상이, 루트별 스코프 격리, 개별 해제
     send({ cmd: 'connect', folder: folder2 });

--- a/packages/local-bridge-core/src/__tests__/code-nav.test.ts
+++ b/packages/local-bridge-core/src/__tests__/code-nav.test.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { BridgeCore } from '../core';
-import { globToRegExp, runCodeNav, walkFiles } from '../code-nav';
+import { globToRegExp, isSecretFile, runCodeNav, walkFiles } from '../code-nav';
 import type { BridgeResult } from '../types';
 
 let root: string;
@@ -96,6 +96,30 @@ describe('code_nav kind', () => {
         expect(g.codeNav?.matches).toEqual([]);
     });
 
+    it('자격증명 파일은 훑지 않고, 건너뛴 수를 알려준다', async () => {
+        mk('.env', 'API_KEY=super-secret-value\n');
+        mk('.env.local', 'DB_PASSWORD=hunter2\n');
+        mk('certs/server.pem', '-----BEGIN PRIVATE KEY-----\n');
+        mk('src/keep.ts', 'const API_KEY = process.env.API_KEY;\n');
+        const g = await run(core(), { op: 'grep', pattern: 'API_KEY|PASSWORD|PRIVATE KEY' });
+        expect(g.codeNav?.matches).toEqual(['src/keep.ts:1:const API_KEY = process.env.API_KEY;']);
+        expect(g.codeNav?.skipped).toBe(3);
+        const f = await run(core(), { op: 'files' });
+        expect(f.codeNav?.files?.some((x) => x.path.startsWith('.env') || x.path.endsWith('.pem'))).toBe(false);
+        expect(f.codeNav?.skipped).toBe(3);
+    });
+
+    it('민감 파일을 path 로 직접 지목해도 탐색은 거른다(file_ops read 로 가야 한다)', async () => {
+        mk('.env', 'API_KEY=x\n');
+        const g = await run(core(), { op: 'grep', pattern: 'API_KEY', path: '.env' });
+        expect(g.codeNav?.matches).toEqual([]);
+        expect(g.codeNav?.skipped).toBe(1);
+    });
+
+    it('건너뛴 것이 없으면 skipped 를 싣지 않는다', async () => {
+        expect((await run(core(), { op: 'files' })).codeNav?.skipped).toBeUndefined();
+    });
+
     it('바이너리 파일은 grep 대상에서 제외한다', async () => {
         fs.writeFileSync(path.join(root, 'blob.bin'), Buffer.from([0x68, 0x69, 0x00, 0x68, 0x69]));
         const r = await run(core(), { op: 'grep', pattern: 'hi' });
@@ -146,5 +170,19 @@ describe('walkFiles / globToRegExp', () => {
         expect(globToRegExp('src/**/*.py').basenameOnly).toBe(false);
         expect(globToRegExp('src/**/*.py').re.test('src/a/b/x.py')).toBe(true);
         expect(globToRegExp('src/*.py').re.test('src/a/x.py')).toBe(false);
+    });
+});
+
+describe('isSecretFile', () => {
+    it('자격증명 파일명을 잡는다', () => {
+        for (const n of ['.env', '.env.production', 'server.pem', 'app.key', 'id_rsa', 'id_ed25519.pub',
+            '.npmrc', '.netrc', '.pgpass', 'credentials', 'service-account-prod.json', 'vault.kdbx']) {
+            expect(isSecretFile(n)).toBe(true);
+        }
+    });
+    it('일반 소스는 잡지 않는다', () => {
+        for (const n of ['env.ts', 'keychain.md', 'README.md', 'stats.js', 'package.json', 'environment.rb']) {
+            expect(isSecretFile(n)).toBe(false);
+        }
     });
 });

--- a/packages/local-bridge-core/src/code-nav.ts
+++ b/packages/local-bridge-core/src/code-nav.ts
@@ -12,6 +12,8 @@
  *  - 경로는 호출부(core.ts)가 safeFromAsync 로 스코프를 확정한 뒤 넘긴다. walk 는 심링크를
  *    따라가지 않는다(scope 밖 탈출 차단 — listAll 의 walk 와 같은 규칙).
  *  - 폭주 방지는 전적으로 캡이다(승인 게이트가 없으므로): 파일 수·파일 크기·매치 수·시간 예산.
+ *  - 자격증명 파일(CODE_NAV_EXCLUDED_FILES)은 훑지 않는다 — 승인이 도구 단위라 사용자는 어떤
+ *    파일을 읽을지 보지 못한다. 건너뛴 수는 결과에 실어 "없음" 오판을 막는다(조용한 실패 방지).
  *  - ⚠️ 정규식은 모델이 만든 값이라 파국적 백트래킹이 가능하다. 파일 크기 상한과 파일 사이
  *    데드라인 검사로 피해를 한 파일로 묶는다(한 파일 안의 백트래킹은 중단할 수 없다).
  *
@@ -20,7 +22,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import {
-    CODE_NAV_EXCLUDED_DIRS, CODE_NAV_LINE_MAX_CHARS, CODE_NAV_MAX_FILE_BYTES, CODE_NAV_MAX_FILES,
+    CODE_NAV_EXCLUDED_DIRS, CODE_NAV_EXCLUDED_FILES, CODE_NAV_LINE_MAX_CHARS, CODE_NAV_MAX_FILE_BYTES, CODE_NAV_MAX_FILES,
     CODE_NAV_MAX_MATCHES, CODE_NAV_MAX_PER_FILE, CODE_NAV_PATTERN_MAX_CHARS, CODE_NAV_TIMEOUT_MS,
 } from './constants';
 import type { BridgeCodeNav, BridgeMsg } from './types';
@@ -41,6 +43,13 @@ export function globToRegExp(glob: string): { re: RegExp; basenameOnly: boolean 
     return { re: new RegExp(`^${out}$`), basenameOnly };
 }
 
+const SECRET_FILE_RES = CODE_NAV_EXCLUDED_FILES.map((g) => globToRegExp(g).re);
+
+/** 자격증명 파일인지 — 파일명(basename)만 본다. 서버 셸 폴백의 rg -g '!…' 와 같은 패턴. */
+export function isSecretFile(name: string): boolean {
+    return SECRET_FILE_RES.some((re) => re.test(name));
+}
+
 /** 바이너리 추정 — 앞부분에 NUL 이 있으면 텍스트가 아니다(grep -I 과 같은 판정). */
 function looksBinary(buf: Buffer): boolean {
     return buf.subarray(0, 8192).includes(0);
@@ -50,6 +59,8 @@ interface WalkResult {
     /** base 기준 상대경로(POSIX 구분자). */
     files: string[];
     truncated: boolean;
+    /** 민감 파일 정책으로 건너뛴 수. */
+    skipped: number;
 }
 
 /**
@@ -58,12 +69,17 @@ interface WalkResult {
  */
 export async function walkFiles(baseAbs: string, startAbs: string, deadline: number): Promise<WalkResult> {
     const st = await fsp.stat(startAbs).catch(() => null);
-    if (!st) return { files: [], truncated: false };
+    if (!st) return { files: [], truncated: false, skipped: 0 };
     const rel = (abs: string): string => path.relative(baseAbs, abs).split(path.sep).join('/');
-    if (st.isFile()) return { files: [rel(startAbs)], truncated: false };
+    if (st.isFile()) {
+        return isSecretFile(path.basename(startAbs))
+            ? { files: [], truncated: false, skipped: 1 }
+            : { files: [rel(startAbs)], truncated: false, skipped: 0 };
+    }
 
     const files: string[] = [];
     let truncated = false;
+    let skipped = 0;
     const stack: string[] = [startAbs];
     while (stack.length > 0) {
         if (files.length >= CODE_NAV_MAX_FILES || Date.now() > deadline) { truncated = true; break; }
@@ -78,13 +94,14 @@ export async function walkFiles(baseAbs: string, startAbs: string, deadline: num
             if (e.isDirectory()) {
                 stack.push(path.join(dir, e.name));
             } else if (e.isFile()) {
+                if (isSecretFile(e.name)) { skipped++; continue; }   // 자격증명은 훑지 않는다
                 if (files.length >= CODE_NAV_MAX_FILES) { truncated = true; break; }
                 files.push(rel(path.join(dir, e.name)));
             }
         }
     }
     files.sort();
-    return { files, truncated };
+    return { files, truncated, skipped };
 }
 
 /** grep — 파일을 훑어 "상대경로:줄번호:내용" 목록을 만든다. */
@@ -124,7 +141,7 @@ async function grep(baseAbs: string, startAbs: string, m: BridgeMsg, deadline: n
             perFile++;
         }
     }
-    return { matches, truncated };
+    return { matches, truncated, ...(walked.skipped > 0 ? { skipped: walked.skipped } : {}) };
 }
 
 /** files — 파일별 줄 수(구조 개요용). 내용은 돌려주지 않는다. */
@@ -143,7 +160,7 @@ async function files(baseAbs: string, startAbs: string, deadline: number): Promi
         const text = buf.toString('utf8');
         out.push({ path: rel, lines: text === '' ? 0 : text.split('\n').length - (text.endsWith('\n') ? 1 : 0) });
     }
-    return { files: out, truncated };
+    return { files: out, truncated, ...(walked.skipped > 0 ? { skipped: walked.skipped } : {}) };
 }
 
 /**

--- a/packages/local-bridge-core/src/constants.ts
+++ b/packages/local-bridge-core/src/constants.ts
@@ -56,6 +56,19 @@ export const CODE_NAV_MAX_PER_FILE = 20;
 export const CODE_NAV_LINE_MAX_CHARS = 300;
 /** 정규식 소스 길이 상한. */
 export const CODE_NAV_PATTERN_MAX_CHARS = 500;
+/**
+ * 탐색에서 제외하는 **파일** 글롭 — 자격증명이 검색 한 번에 대화·스텝 DB 로 쓸려 들어가는 것을 막는다.
+ * 승인은 도구 단위(“grep_code 를 실행할까요”)라 어떤 파일을 읽을지는 사용자에게 보이지 않으므로,
+ * 정책과 무관하게 여기서 거른다. 봉쇄가 아니라 위생 조치다 — 경로를 지목한 file_ops read 는 그대로
+ * 되고(그쪽은 별도 승인 게이트), 건너뛴 개수는 결과에 실려 모델이 "파일이 없다"로 오판하지 않는다.
+ * 서버 SENSITIVE_FILE_PATTERNS 와 같은 목록(양쪽 강제).
+ */
+export const CODE_NAV_EXCLUDED_FILES: readonly string[] = [
+    '.env', '.env.*', '*.pem', '*.key', '*.p12', '*.pfx', '*.jks', '*.keystore',
+    'id_rsa', 'id_rsa.*', 'id_ed25519', 'id_ed25519.*', '.npmrc', '.netrc', '.pgpass', '.htpasswd',
+    'credentials', 'credentials.*', 'service-account*.json', '*.kdbx',
+];
+
 /** 탐색에서 제외하는 디렉토리 — 서버 TASK_CODE_NAV.EXCLUDED_DIRS 와 같은 목록(양쪽 강제). */
 export const CODE_NAV_EXCLUDED_DIRS: readonly string[] = [
     'node_modules', '.git', 'dist', 'build', '.next', '__pycache__', '.venv', 'venv', 'coverage', '.openmake',

--- a/packages/local-bridge-core/src/types.ts
+++ b/packages/local-bridge-core/src/types.ts
@@ -35,6 +35,8 @@ export interface BridgeCodeNav {
     files?: { path: string; lines: number }[];
     /** 캡·시간 예산에 걸려 결과가 잘렸는지. */
     truncated?: boolean;
+    /** 민감 파일 정책으로 건너뛴 파일 수 — 0 이면 생략. 모델이 "없음"으로 오판하지 않게 노출한다. */
+    skipped?: number;
 }
 
 /** 편집 후 진단 1건 — 컴파일러/언어 서버 출력의 공통 표현. */


### PR DESCRIPTION
## 왜
승인은 **도구 단위**라 사용자는 `grep_code` 한 번이 어떤 파일을 읽을지 보지 못한다. 그리고 `high-risk` 정책에서는 `.env` 덮어쓰기가 **서버 승인도 디바이스 확인도 없이** 통과했다(브리지 `write` kind 는 confirmExec 대상이 아니고, `HIGH_RISK_FILE_OPS` 는 `delete` 만 본다).

봉쇄가 아니라 두 가지를 없앤다: **훑다가 딸려 들어옴**, **확인 없이 덮어씀**. 경로를 지목한 `file_ops read` 와 셸은 각자의 게이트로 그대로 간다.

## 무엇을
**① 탐색 제외** — `grep_code`·`repo_map` 이 자격증명 파일을 훑지 않는다. 단일 목록(`SENSITIVE_FILE_PATTERNS` / 디바이스 `CODE_NAV_EXCLUDED_FILES`)을 파일명 글롭으로 두어 rg `-g`·grep `--exclude`·find `-name`(셸 폴백)과 디바이스 정규식 매칭이 같은 값을 쓴다.

**② 쓰기 승인 상향** — `isSensitiveWrite`(순수)가 `file_ops` write/delete 와 `str_replace_editor` create/str_replace/insert 의 대상 경로를 보고 `high-risk` 에서 승인 대상으로 올린다. 차단이 아니라 상향이라 사용자가 허용하면 "환경변수 추가" 같은 정상 작업은 그대로 된다. `all`·`none` 의 의미는 불변.

| 정책 | `.env` 쓰기 | `.env` 탐색 |
|---|---|---|
| `all` | 승인 (종전과 같음) | 제외 |
| `high-risk` | **승인 (신규)** — 종전 무게이트 | 제외 |
| `none` | 게이트 없음 (종전과 같음) | 제외 |

## 조용한 실패 방지
건너뛴 파일 수를 결과 말미에 싣는다("자격증명 파일 N개는 정책상 검색에서 제외 — 필요하면 `file_ops read` 로 경로를 지목하세요") + 도구 설명에도 명시. 없으면 모델이 ".env 가 없다"로 오판한다.

## 검증
- **되돌리기 3축**: 디바이스 제외 무력화 1건 · 쓰기 상향 무력화 1건 · 셸 플래그 제거 1건 실패 → 복원 후 전부 통과.
- `local-bridge-core` 81 passed, `apps/api` 3,524 passed, tsc·eslint 0.
- 헬퍼 하네스(CI Companion job)에 자격증명 미검색 + `skipped` 보고 + **경로 지목 read 는 그대로 동작** 케이스 추가.

## 배포 주의
디바이스 제외는 헬퍼 번들에 들어가므로 Companion 재빌드·게시가 필요하다. 구 디바이스는 서버 셸 폴백 경로에서만 제외가 적용된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbGa9RXHjXeRfXTn1bonB1