### PR TITLE
fix(task-sandbox): 자격증명 가드 리뷰 반영 — 목록 단일 출처·디렉토리 정합·셸 폴백 건너뛴 수

### DIFF
--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -2096,22 +2096,13 @@ export const MCP_SANDBOX_BOOTSTRAP = {
 } as const;
 
 /**
- * 민감 파일 글롭 — 자격증명·키 파일의 단일 목록 (2026-09-06).
- *
- * 두 곳이 이 목록을 쓴다:
+ * 민감 파일 글롭 — 단일 출처는 @openmake/config (디바이스 코어와 공유). 두 소비처:
  *  ① 코드 탐색(grep_code·repo_map) 제외 — 승인이 도구 단위라 사용자는 어떤 파일을 읽을지
- *     보지 못한다. 정책과 무관하게 훑기에서 제외해 자격증명이 대화·스텝 DB 로 쓸려 들어가는
- *     것을 막는다(봉쇄가 아니라 위생 — 경로를 지목한 file_ops read 는 별도 승인 게이트).
+ *     보지 못한다. 정책과 무관하게 훑기에서 제외한다(봉쇄가 아니라 위생 — file_ops read 는 별도 게이트).
  *  ② 쓰기 승인 상향(approval-gate) — high-risk 정책에서 이 경로에 쓰는 호출은 승인 대상.
- *
- * 디바이스 코어의 CODE_NAV_EXCLUDED_FILES 와 같은 목록으로 유지할 것(양쪽 강제).
- * 패턴은 파일명(basename) 글롭 — rg -g · grep --exclude · find -name 에 그대로 쓰인다.
  */
-export const SENSITIVE_FILE_PATTERNS: readonly string[] = [
-    '.env', '.env.*', '*.pem', '*.key', '*.p12', '*.pfx', '*.jks', '*.keystore',
-    'id_rsa', 'id_rsa.*', 'id_ed25519', 'id_ed25519.*', '.npmrc', '.netrc', '.pgpass', '.htpasswd',
-    'credentials', 'credentials.*', 'service-account*.json', '*.kdbx',
-];
+export { SENSITIVE_FILE_PATTERNS } from '@openmake/config';
+import { SENSITIVE_FILE_PATTERNS } from '@openmake/config';
 
 /**
  * Task 샌드박스 코드 탐색 도구(grep_code·repo_map, 2026-09-06) 상한.

--- a/apps/api/src/services/task-sandbox/tools-code-nav.test.ts
+++ b/apps/api/src/services/task-sandbox/tools-code-nav.test.ts
@@ -210,7 +210,7 @@ describe('민감 파일 제외 (2026-09-06)', () => {
         const { sandbox } = nativeSandbox(() => ({ matches: ['a.ts:1:KEY'], skipped: 2 }));
         const grep = createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!;
         const t = text(await grep.handler({ pattern: 'KEY' }));
-        expect(t).toContain('자격증명 파일 2개는 정책상 검색에서 제외');
+        expect(t).toContain('자격증명 파일·폴더 2개는 정책상 검색에서 제외');
         expect(t).toContain('file_ops read');
     });
 
@@ -225,7 +225,52 @@ describe('민감 파일 제외 (2026-09-06)', () => {
             ? { files: [{ path: 'src/a.ts', lines: 3 }], skipped: 1 }
             : { matches: [] });
         const map = createCodeNavTools(sandbox).find((t) => t.tool.name === 'repo_map')!;
-        expect(text(await map.handler({}))).toContain('자격증명 파일 1개');
+        expect(text(await map.handler({}))).toContain('자격증명 파일·폴더 1개');
+    });
+
+    it('셸 폴백도 sentinel 로 건너뛴 수를 세어 안내한다 — docker 기본 경로의 조용한 실패 방지(리뷰 지적)', async () => {
+        const { sandbox, cmds } = fakeSandbox(() => exec('src/a.ts:1:KEY\n\n__OMK_SKIPPED__ 3\n'));
+        const grep = createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!;
+        const t = text(await grep.handler({ pattern: 'KEY' }));
+        expect(t).toContain('src/a.ts:1:KEY');
+        expect(t).not.toContain('__OMK_SKIPPED__');
+        expect(t).toContain('자격증명 파일·폴더 3개는 정책상 검색에서 제외');
+        expect(cmds[0]).toContain("printf '\\n__OMK_SKIPPED__ %s\\n'");
+        expect(cmds[0]).toContain("-name '.env'");
+    });
+
+    it('셸 폴백: 무일치 + 건너뛴 수만 있으면 안내가 붙고 오류가 아니다', async () => {
+        const { sandbox } = fakeSandbox(() => exec('\n__OMK_SKIPPED__ 1\n'));
+        const grep = createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!;
+        const r = await grep.handler({ pattern: 'KEY' });
+        expect(r.isError).toBeFalsy();
+        expect(text(r)).toContain('일치 없음');
+        expect(text(r)).toContain('정책상 검색에서 제외');
+    });
+
+    it('repo_map 셸 폴백도 sentinel 을 떼어내고 건너뛴 수를 안내한다', async () => {
+        const { sandbox } = fakeSandbox((cmd) => cmd.startsWith('find') ? exec('3\t./src/a.ts\n\n__OMK_SKIPPED__ 2\n') : exec(''));
+        const map = createCodeNavTools(sandbox).find((t) => t.tool.name === 'repo_map')!;
+        const t = text(await map.handler({ symbols: false }));
+        expect(t).toContain('src/a.ts (3)');
+        expect(t).not.toContain('__OMK_SKIPPED__');
+        expect(t).toContain('자격증명 파일·폴더 2개');
+    });
+
+    it('grep 폴백은 자격증명 이름을 디렉토리에도 적용한다(--exclude-dir)', async () => {
+        const { sandbox, cmds } = fakeSandbox((cmd) => cmd.startsWith('rg') ? exec('', 127, 'rg: not found') : exec(''));
+        await createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!.handler({ pattern: 'x' });
+        expect(cmds[1]).toContain("--exclude-dir='credentials'");
+    });
+
+    it('rg 부재는 sentinel 때문에 종료코드가 0 이어도 stderr 로 판정해 grep 으로 폴백한다', async () => {
+        const { sandbox, cmds } = fakeSandbox((cmd) => cmd.startsWith('rg')
+            ? exec('\n__OMK_SKIPPED__ 0\n', 0, 'sh: 1: rg: not found')
+            : exec('y.ts:2:x\n\n__OMK_SKIPPED__ 0\n'));
+        const t = text(await createCodeNavTools(sandbox).find((t) => t.tool.name === 'grep_code')!.handler({ pattern: 'x' }));
+        expect(t).toContain('y.ts:2:x');
+        expect(t).toContain('grep 사용');
+        expect(cmds.length).toBe(2);
     });
 
     it('건너뛴 것이 없으면 안내를 붙이지 않는다', async () => {

--- a/apps/api/src/services/task-sandbox/tools-code-nav.ts
+++ b/apps/api/src/services/task-sandbox/tools-code-nav.ts
@@ -53,8 +53,25 @@ function excludeGlobsRg(): string {
 function excludeDirsGrep(): string {
     return [
         ...TASK_CODE_NAV.EXCLUDED_DIRS.map((d) => `--exclude-dir=${shq(d)}`),
+        // 자격증명 글롭은 파일·디렉토리 양쪽에 — rg -g / find -name / 디바이스 순회와 같은 규칙.
         ...TASK_CODE_NAV.EXCLUDED_FILES.map((f) => `--exclude=${shq(f)}`),
+        ...TASK_CODE_NAV.EXCLUDED_FILES.map((f) => `--exclude-dir=${shq(f)}`),
     ].join(' ');
+}
+
+/** 셸 폴백은 결과를 세지 못하므로 sentinel 한 줄로 건너뛴 자격증명 항목 수를 붙인다(파싱 후 제거). */
+const SKIPPED_SENTINEL = '__OMK_SKIPPED__';
+function countSkippedShell(rel: string): string {
+    const dirs = TASK_CODE_NAV.EXCLUDED_DIRS.map((d) => `-name ${shq(d)}`).join(' -o ');
+    const secrets = TASK_CODE_NAV.EXCLUDED_FILES.map((f) => `-name ${shq(f)}`).join(' -o ');
+    // 제외 디렉토리 안은 세지 않고, 자격증명 이름은 파일·디렉토리 모두 1건으로 센다(디렉토리는 내려가지 않음).
+    return `printf '\\n${SKIPPED_SENTINEL} %s\\n' "$(find ${shq(rel)} \\( ${dirs} \\) -prune -o \\( ${secrets} \\) -prune -print 2>/dev/null | head -n 10000 | wc -l | tr -d ' ')"`;
+}
+/** stdout 에서 sentinel 을 떼어내고 건너뛴 수를 돌려준다. 없으면 0(캡으로 잘린 경우 등 — 안내 생략). */
+function splitSkipped(stdout: string): { body: string; skipped: number } {
+    const m = stdout.match(new RegExp(`\\n?${SKIPPED_SENTINEL} (\\d+)\\n?$`));
+    if (!m) return { body: stdout, skipped: 0 };
+    return { body: stdout.slice(0, m.index), skipped: parseInt(m[1], 10) || 0 };
 }
 function pruneFind(): string {
     // find <path> \( -name a -o -name b \) -prune -o -type f -print
@@ -66,7 +83,7 @@ function pruneFind(): string {
 
 /** 결과 말미 안내 — 정책으로 건너뛴 파일이 있으면 "없음" 오판을 막는다(조용한 실패 방지). */
 function skippedNote(skipped: number | undefined): string {
-    return skipped ? `\n(자격증명 파일 ${skipped}개는 정책상 검색에서 제외됨 — 필요하면 file_ops read 로 경로를 지목하세요)` : '';
+    return skipped ? `\n(자격증명 파일·폴더 ${skipped}개는 정책상 검색에서 제외됨 — 필요하면 file_ops read 로 경로를 지목하세요)` : '';
 }
 
 function clipLines(out: string, maxLines: number, maxChars: number): { lines: string[]; overflow: boolean } {
@@ -78,7 +95,9 @@ function clipLines(out: string, maxLines: number, maxChars: number): { lines: st
 /** rg 로 먼저 시도하고, 실행 파일이 없으면(127) grep 으로 재시도한다. */
 async function execWithGrepFallback(sandbox: TaskExecutor, rgCmd: string, grepCmd: string): Promise<{ r: ExecResult; via: 'rg' | 'grep' }> {
     const r = await sandbox.exec(rgCmd);
-    if (r.exitCode !== EXIT_NOT_FOUND) return { r, via: 'rg' };
+    // sentinel 명령이 뒤에 붙으면 종료코드가 그것의 0 이 되므로 127 만으로는 rg 부재를 못 본다 → stderr 도 본다.
+    const rgMissing = r.exitCode === EXIT_NOT_FOUND || /\brg\b.*(not found|command not found)/i.test(r.stderr);
+    if (!rgMissing) return { r, via: 'rg' };
     return { r: await sandbox.exec(grepCmd), via: 'grep' };
 }
 
@@ -96,7 +115,7 @@ interface GrepOutcome {
     via: 'native' | 'rg' | 'grep';
     /** 실행 실패(오류 문구). 있으면 lines 는 무의미. */
     error?: string;
-    /** 민감 파일 정책으로 건너뛴 수(네이티브 백엔드만 셈). */
+    /** 민감 파일 정책으로 건너뛴 수(네이티브는 순회에서, 셸은 sentinel find 로 셈). */
     skipped?: number;
 }
 
@@ -114,19 +133,22 @@ async function runGrep(sandbox: TaskExecutor, o: {
     }
     const head = `head -n ${o.max + 1}`;
     const ic = o.ignoreCase === true;
+    const tail = `; ${countSkippedShell(o.rel)}`;
     const rgCmd = `rg -n --no-heading --color never --no-messages -m ${TASK_CODE_NAV.GREP_PER_FILE_MAX}`
-        + `${ic ? ' -i' : ''} ${excludeGlobsRg()}${o.glob ? ` -g ${shq(o.glob)}` : ''} -e ${shq(o.pattern)} -- ${shq(o.rel)} | ${head}`;
+        + `${ic ? ' -i' : ''} ${excludeGlobsRg()}${o.glob ? ` -g ${shq(o.glob)}` : ''} -e ${shq(o.pattern)} -- ${shq(o.rel)} | ${head}${tail}`;
     const grepCmd = `grep -rnI -E${ic ? 'i' : ''} ${excludeDirsGrep()}${o.glob ? ` --include=${shq(o.glob.replace(/^.*\//, ''))}` : ''}`
-        + ` -e ${shq(o.pattern)} -- ${shq(o.rel)} | ${head}`;
+        + ` -e ${shq(o.pattern)} -- ${shq(o.rel)} | ${head}${tail}`;
     const { r, via } = await execWithGrepFallback(sandbox, rgCmd, grepCmd);
     if (r.timedOut) return { lines: [], overflow: false, via, error: '검색 시간 초과 — path/glob 으로 범위를 좁히세요.' };
+    const { body, skipped } = splitSkipped(r.stdout);
+    const skippedField = skipped ? { skipped } : {};
     // 파이프 종료 코드는 head 의 것이라 rg/grep 의 1(무일치)·2(오류)를 못 본다 → 출력으로 판정.
-    if (!r.stdout.trim()) {
+    if (!body.trim()) {
         const err = r.stderr.trim();
-        return { lines: [], overflow: false, via, ...(err ? { error: `검색 실패: ${err.slice(0, 500)}` } : {}) };
+        return { lines: [], overflow: false, via, ...skippedField, ...(err ? { error: `검색 실패: ${err.slice(0, 500)}` } : {}) };
     }
-    const { lines, overflow } = clipLines(r.stdout, o.max, TASK_CODE_NAV.GREP_LINE_MAX_CHARS);
-    return { lines, overflow, via };
+    const { lines, overflow } = clipLines(body, o.max, TASK_CODE_NAV.GREP_LINE_MAX_CHARS);
+    return { lines, overflow, via, ...skippedField };
 }
 
 export function createCodeNavTools(sandbox: TaskExecutor): MCPToolDefinition[] {
@@ -200,10 +222,12 @@ export function createCodeNavTools(sandbox: TaskExecutor): MCPToolDefinition[] {
             } else {
                 // 파일별 줄 수 — GNU 전용 옵션 없이(find -printf·xargs -d 는 macOS 로컬 브리지에 없다).
                 const listCmd = `find ${shq(rel)} ${pruneFind()} | head -n ${maxFiles + 1} | while IFS= read -r f; do `
-                    + `printf '%s\\t%s\\n' "$(wc -l < "$f" 2>/dev/null | tr -d ' ')" "$f"; done`;
+                    + `printf '%s\\t%s\\n' "$(wc -l < "$f" 2>/dev/null | tr -d ' ')" "$f"; done; ${countSkippedShell(rel)}`;
                 const list = await sandbox.exec(listCmd);
                 if (list.timedOut) return textResult('구조 수집 시간 초과 — path 로 범위를 좁히세요.', true);
-                rows = list.stdout.split('\n').filter((l) => l.includes('\t')).map((l) => {
+                const split = splitSkipped(list.stdout);
+                nativeSkipped = split.skipped;
+                rows = split.body.split('\n').filter((l) => l.includes('\t')).map((l) => {
                     const [n, ...rest] = l.split('\t');
                     return { lines: parseInt(n, 10) || 0, path: rest.join('\t').replace(/^\.\//, '') };
                 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         },
         "apps/api": {
             "name": "openmake-api",
-            "version": "1.35.1",
+            "version": "1.48.0",
             "dependencies": {
                 "@modelcontextprotocol/client": "^2.0.0",
                 "@mozilla/readability": "^0.6.0",
@@ -171,7 +171,7 @@
         },
         "apps/discord-bot": {
             "name": "openmake-discord-bot",
-            "version": "1.35.1",
+            "version": "1.48.0",
             "dependencies": {
                 "discord.js": "^14.16.3",
                 "dotenv": "^16.4.5"
@@ -198,7 +198,7 @@
         },
         "apps/web": {
             "name": "@openmake/web",
-            "version": "1.35.1",
+            "version": "1.48.0",
             "dependencies": {
                 "@openmake/api-client": "*",
                 "@openmake/config": "*",
@@ -20391,7 +20391,7 @@
         },
         "packages/api-client": {
             "name": "@openmake/api-client",
-            "version": "1.35.1",
+            "version": "1.48.0",
             "dependencies": {
                 "@openmake/config": "*",
                 "@openmake/shared-types": "*"
@@ -20403,12 +20403,13 @@
         },
         "packages/config": {
             "name": "@openmake/config",
-            "version": "1.35.1"
+            "version": "1.48.0"
         },
         "packages/local-bridge-core": {
             "name": "@openmake/local-bridge-core",
             "version": "1.31.1",
             "dependencies": {
+                "@openmake/config": "*",
                 "ws": "^8.18.0"
             },
             "devDependencies": {
@@ -20417,7 +20418,7 @@
         },
         "packages/shared-types": {
             "name": "@openmake/shared-types",
-            "version": "1.35.1"
+            "version": "1.48.0"
         }
     }
 }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -29,3 +29,16 @@ export const MUTATING_METHODS = ["POST", "PUT", "PATCH", "DELETE"] as const;
 
 /** 아티팩트 코드 실행 가능성 판정 (샌드박스 표준 라이브러리 기준). */
 export { checkRunnable, type RunnableVerdict } from "./artifact-runnable";
+
+/**
+ * 자격증명 파일 글롭 — 코드 탐색 제외(grep_code·repo_map)와 쓰기 승인 상향(approval-gate)의
+ * **단일 출처**. 서버(apps/api)와 디바이스 코어(local-bridge-core) 양쪽이 여기서 읽는다 — 목록을
+ * 두 곳에 복제하면 한쪽만 고쳐져 제외가 조용히 약해진다(2026-09-07 코드 리뷰 지적).
+ * 파일명(basename) 글롭이며 디렉토리 이름에도 적용된다: rg -g · grep --exclude/--exclude-dir ·
+ * find -name 에 그대로 쓰이고, 디바이스는 같은 글롭을 정규식으로 매칭한다.
+ */
+export const SENSITIVE_FILE_PATTERNS: readonly string[] = [
+  ".env", ".env.*", "*.pem", "*.key", "*.p12", "*.pfx", "*.jks", "*.keystore",
+  "id_rsa", "id_rsa.*", "id_ed25519", "id_ed25519.*", ".npmrc", ".netrc", ".pgpass", ".htpasswd",
+  "credentials", "credentials.*", "service-account*.json", "*.kdbx",
+];

--- a/packages/local-bridge-core/package.json
+++ b/packages/local-bridge-core/package.json
@@ -16,6 +16,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@openmake/config": "*",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/packages/local-bridge-core/src/__tests__/code-nav.test.ts
+++ b/packages/local-bridge-core/src/__tests__/code-nav.test.ts
@@ -109,6 +109,16 @@ describe('code_nav kind', () => {
         expect(f.codeNav?.skipped).toBe(3);
     });
 
+    it('자격증명 이름의 디렉토리도 건너뛴다(항목 1건) — 셸 find -prune·rg -g 와 같은 결과', async () => {
+        mk('credentials/aws.json', '{"secret":"dir-secret"}\n');
+        mk('credentials/nested/gcp.json', '{"secret":"dir-secret"}\n');
+        const g = await run(core(), { op: 'grep', pattern: 'dir-secret' });
+        expect(g.codeNav?.matches).toEqual([]);
+        expect(g.codeNav?.skipped).toBe(1);
+        const f = await run(core(), { op: 'files' });
+        expect(f.codeNav?.files?.some((x) => x.path.startsWith('credentials/'))).toBe(false);
+    });
+
     it('민감 파일을 path 로 직접 지목해도 탐색은 거른다(file_ops read 로 가야 한다)', async () => {
         mk('.env', 'API_KEY=x\n');
         const g = await run(core(), { op: 'grep', pattern: 'API_KEY', path: '.env' });

--- a/packages/local-bridge-core/src/code-nav.ts
+++ b/packages/local-bridge-core/src/code-nav.ts
@@ -91,10 +91,12 @@ export async function walkFiles(baseAbs: string, startAbs: string, deadline: num
             // gitdir 포인터 **파일**이라, 디렉토리만 걸러내면 목록에 섞여 들어온다(라이브 실측).
             // 셸 폴백의 find -prune 은 이미 이름 기준이라 이렇게 해야 두 백엔드가 같은 결과를 낸다.
             if (CODE_NAV_EXCLUDED_DIRS.includes(e.name)) continue;
+            // 자격증명 이름은 파일·디렉토리 모두 건너뛴다(항목 1건으로 셈) — 셸 폴백의 find -prune·
+            // rg -g '!name' 도 디렉토리를 자르므로, 파일에만 걸면 두 백엔드 결과가 갈린다(리뷰 지적).
+            if (isSecretFile(e.name)) { skipped++; continue; }
             if (e.isDirectory()) {
                 stack.push(path.join(dir, e.name));
             } else if (e.isFile()) {
-                if (isSecretFile(e.name)) { skipped++; continue; }   // 자격증명은 훑지 않는다
                 if (files.length >= CODE_NAV_MAX_FILES) { truncated = true; break; }
                 files.push(rel(path.join(dir, e.name)));
             }

--- a/packages/local-bridge-core/src/constants.ts
+++ b/packages/local-bridge-core/src/constants.ts
@@ -57,17 +57,13 @@ export const CODE_NAV_LINE_MAX_CHARS = 300;
 /** 정규식 소스 길이 상한. */
 export const CODE_NAV_PATTERN_MAX_CHARS = 500;
 /**
- * 탐색에서 제외하는 **파일** 글롭 — 자격증명이 검색 한 번에 대화·스텝 DB 로 쓸려 들어가는 것을 막는다.
- * 승인은 도구 단위(“grep_code 를 실행할까요”)라 어떤 파일을 읽을지는 사용자에게 보이지 않으므로,
- * 정책과 무관하게 여기서 거른다. 봉쇄가 아니라 위생 조치다 — 경로를 지목한 file_ops read 는 그대로
- * 되고(그쪽은 별도 승인 게이트), 건너뛴 개수는 결과에 실려 모델이 "파일이 없다"로 오판하지 않는다.
- * 서버 SENSITIVE_FILE_PATTERNS 와 같은 목록(양쪽 강제).
+ * 탐색에서 제외하는 자격증명 글롭 — 단일 출처는 @openmake/config 의 SENSITIVE_FILE_PATTERNS
+ * (서버 approval-gate·셸 폴백과 같은 목록). 승인은 도구 단위라 어떤 파일을 읽을지 사용자에게
+ * 보이지 않으므로 정책과 무관하게 거른다. 봉쇄가 아니라 위생 — 경로를 지목한 read 는 그대로
+ * 되고, 건너뛴 개수는 결과에 실려 모델이 "파일이 없다"로 오판하지 않는다.
+ * 파일뿐 아니라 **같은 이름의 디렉토리도** 건너뛴다(셸 find -prune·rg -g 와 결과를 맞추기 위해).
  */
-export const CODE_NAV_EXCLUDED_FILES: readonly string[] = [
-    '.env', '.env.*', '*.pem', '*.key', '*.p12', '*.pfx', '*.jks', '*.keystore',
-    'id_rsa', 'id_rsa.*', 'id_ed25519', 'id_ed25519.*', '.npmrc', '.netrc', '.pgpass', '.htpasswd',
-    'credentials', 'credentials.*', 'service-account*.json', '*.kdbx',
-];
+export { SENSITIVE_FILE_PATTERNS as CODE_NAV_EXCLUDED_FILES } from '@openmake/config';
 
 /** 탐색에서 제외하는 디렉토리 — 서버 TASK_CODE_NAV.EXCLUDED_DIRS 와 같은 목록(양쪽 강제). */
 export const CODE_NAV_EXCLUDED_DIRS: readonly string[] = [


### PR DESCRIPTION
## 배경
#777 에 대한 `/code-review` 지적 3건. 전부 타당해 반영했다.

## 변경
| 지적 | 수정 |
|---|---|
| 패턴 목록이 두 패키지에 복제 | `@openmake/config` `SENSITIVE_FILE_PATTERNS` 단일 출처, 양쪽은 재노출 |
| 네이티브는 파일만, 셸은 디렉토리도 제외 → `credentials/` 에서 결과 불일치 | 이름 매치는 파일·디렉토리 모두 건너뛰고 항목 1건으로 셈. grep 폴백 `--exclude-dir` 동반 |
| 셸 폴백은 건너뛴 수를 안 세어 **docker 기본 경로에 안내가 없음** | 같은 exec 끝에 sentinel(`__OMK_SKIPPED__ N`) 한 줄을 붙여 파싱 후 제거. rg 부재는 stderr 로도 판정(sentinel 때문에 종료코드가 0 이 되므로) |

## 검증
- docker 샌드박스 실통합: `.env`·`deploy.pem`·`credentials/` → 결과 미노출 + "자격증명 파일·폴더 3개는 정책상 검색에서 제외" 안내, 유출 표식 0.
- 헬퍼 하네스 통과(번들이 `@openmake/config` 를 포함), CLI 빌드 0.
- 되돌리기: 디렉토리 정합 되돌리면 1건, sentinel 파싱 되돌리면 2건 실패 → 복원 후 코어 82·task-sandbox/local-bridge 195 passed.

## 배포 주의
디바이스 코어가 바뀌었으므로 Companion 재빌드·게시 필요(0.2.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbGa9RXHjXeRfXTn1bonB1