### PR TITLE
feat(llm): 로컬 도구 정의에 strict:true — vLLM 인자 스키마 디코딩 강제

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -268,6 +268,8 @@ LLM_DISABLE_THINKING_BY_DEFAULT=true
 # LLM_LOCAL_SAMPLING_PRESET_ENABLED=true
 # 로컬 도구 루프에서 assistant 의 reasoning 을 다음 턴에 되돌려 보냄 (Qwen3.8 preserve_thinking 활용, 2026-09-03). 'false' 로 끄면 종전처럼 미전송
 # LLM_PRESERVE_THINKING=true
+# 로컬 도구 정의에 strict:true 를 채워 vLLM 이 인자 스키마(enum·타입·배열·required)를 디코딩 단계에서 강제 (2026-09-07). 외부 provider 무영향. 'false' 로 끄면 종전처럼 미전송
+# LLM_LOCAL_TOOL_STRICT=true
 # LLM_SAMPLING_THINKING_TEMP=1.0
 # LLM_SAMPLING_THINKING_TOP_P=0.95
 # LLM_SAMPLING_THINKING_TOP_K=20

--- a/apps/api/src/config/llm-parameters.ts
+++ b/apps/api/src/config/llm-parameters.ts
@@ -101,6 +101,20 @@ const samplingNum = (key: string, fallback: number): number => {
  */
 export const LOCAL_PRESERVE_THINKING_ENABLED = process.env.LLM_PRESERVE_THINKING !== 'false';
 
+/**
+ * 로컬 도구 정의에 `strict: true` 를 채운다 (2026-09-07).
+ * vLLM 0.27.1 은 strict 도구가 하나라도 있으면 `tool_choice:auto` 에서도 xgrammar 구조화 태그로
+ * 도구 호출 문법 + 인자 JSON 스키마(enum·타입·배열·required)를 디코딩 단계에서 강제한다
+ * (`tool_parsers/structural_tag_registry.py` `_any_tool_strict`, 파서 qwen3_coder → `qwen_3_coder` 태그,
+ * `VLLM_ENFORCE_STRICT_TOOL_CALLING` 기본 True). 라이브 실측(LiteLLM 경유): 위반 지시(enum 밖 값·문자열
+ * 정수·문자열 배열·미선언 키)가 strict 없으면 그대로 통과, strict 면 스키마대로 교정. 병리적 스키마
+ * 21종($ref·anyOf·format·pattern·긴 enum 등)·도구 60개 모두 200, TTFC 변화 없음. 자유 텍스트 답변도 그대로 가능.
+ * 로컬(LLMClient, quotaExempt 아닌) wire 에만 적용 — 외부 OpenAI 호환 provider 는 strict 에 "전 속성 required +
+ * additionalProperties:false" 를 요구해(OpenAI 규격) 선택 인자가 있는 도구가 400 이 되므로 보내지 않는다.
+ * env: LLM_LOCAL_TOOL_STRICT(기본 true). 'false' 로 끄면 종전처럼 strict 미전송.
+ */
+export const LOCAL_TOOL_STRICT_ENABLED = process.env.LLM_LOCAL_TOOL_STRICT !== 'false';
+
 export const LOCAL_SAMPLING_PRESETS = {
     ENABLED: process.env.LLM_LOCAL_SAMPLING_PRESET_ENABLED !== 'false',
     THINKING: {

--- a/apps/api/src/llm/__tests__/tool-strict.test.ts
+++ b/apps/api/src/llm/__tests__/tool-strict.test.ts
@@ -1,0 +1,80 @@
+/**
+ * 로컬 도구 strict — env 게이트에 의존하므로 모듈을 격리 로드한다(운영 .env 값이 섞이지 않게).
+ */
+export {};
+
+import type { ToolDefinition } from '../types';
+
+const ENV_KEY = 'LLM_LOCAL_TOOL_STRICT';
+let saved: string | undefined;
+
+function load(value?: string) {
+    delete process.env[ENV_KEY];
+    if (value !== undefined) process.env[ENV_KEY] = value;
+    jest.resetModules();
+    const mod = require('../tool-strict') as typeof import('../tool-strict');
+    const sp = require('../stream-parser') as typeof import('../stream-parser');
+    return { apply: mod.applyLocalToolStrict, toOpenAITools: sp.toOpenAITools };
+}
+
+const tool = (name: string, strict?: boolean): ToolDefinition => ({
+    type: 'function',
+    function: {
+        name,
+        description: 'd',
+        parameters: { type: 'object', properties: { q: { type: 'string' } }, required: ['q'] },
+        ...(strict !== undefined && { strict }),
+    },
+});
+
+beforeAll(() => { saved = process.env[ENV_KEY]; });
+afterAll(() => { if (saved === undefined) delete process.env[ENV_KEY]; else process.env[ENV_KEY] = saved; });
+
+describe('applyLocalToolStrict', () => {
+    it('기본(게이트 on) → 로컬 도구에 strict:true 를 채운다', () => {
+        const { apply } = load();
+        const out = apply([tool('a'), tool('b')]);
+        expect(out?.map((t) => t.function.strict)).toEqual([true, true]);
+    });
+
+    it('호출자가 strict 를 명시한 도구는 덮어쓰지 않는다', () => {
+        const { apply } = load();
+        const out = apply([tool('a', false), tool('b')]);
+        expect(out?.map((t) => t.function.strict)).toEqual([false, true]);
+    });
+
+    it('외부 클라이언트(quotaExempt) 는 입력 그대로 — OpenAI strict 규격이 달라 400 위험', () => {
+        const { apply } = load();
+        const input = [tool('a')];
+        expect(apply(input, { external: true })).toBe(input);
+        expect(input[0].function.strict).toBeUndefined();
+    });
+
+    it("LLM_LOCAL_TOOL_STRICT=false → 종전처럼 미전송", () => {
+        const { apply } = load('false');
+        const input = [tool('a')];
+        expect(apply(input)).toBe(input);
+    });
+
+    it('wire 변환이 strict 를 그대로 싣고, 없으면 키 자체를 내지 않는다', () => {
+        const { apply, toOpenAITools } = load();
+        const wire = toOpenAITools(apply([tool('a')]) ?? []) as Array<{ function: Record<string, unknown> }>;
+        expect(wire[0].function.strict).toBe(true);
+        const plain = toOpenAITools([tool('b')]) as Array<{ function: Record<string, unknown> }>;
+        expect('strict' in plain[0].function).toBe(false);
+    });
+
+    it('undefined 입력은 undefined', () => {
+        const { apply } = load();
+        expect(apply(undefined)).toBeUndefined();
+    });
+
+    it('입력 배열·객체를 변경하지 않는다(순수)', () => {
+        const { apply } = load();
+        const input = [tool('a')];
+        const out = apply(input);
+        expect(out).not.toBe(input);
+        expect(input[0].function.strict).toBeUndefined();
+        expect(out?.[0].function.parameters).toBe(input[0].function.parameters);
+    });
+});

--- a/apps/api/src/llm/client.ts
+++ b/apps/api/src/llm/client.ts
@@ -26,6 +26,7 @@ import { checkUserQuota, recordUserUsage } from './user-quota';
 import { streamChat, nonStreamChat } from './stream-parser';
 import { buildExtraBody } from './reasoning-adapter';
 import { applyLocalSamplingPreset } from './sampling-preset';
+import { applyLocalToolStrict } from './tool-strict';
 import { selectModelByCapacityExact } from './model-pool';
 import { MODEL_POOL_CONFIG } from '../config/model-pool';
 import {
@@ -180,7 +181,8 @@ export class LLMClient {
             // `[]` 가 그대로 실려 요청 자체가 실패하므로 length 로 판정한다. tool_choice 도 함께
             // 생략 — 도구 없는 요청에 tool_choice 만 남으면 같은 계열의 거절을 부른다.
             ...(advancedOptions?.tools?.length && {
-                tools: advancedOptions.tools,
+                // 로컬 도구엔 strict 를 채워 vLLM 이 인자 스키마를 디코딩 단계에서 강제하게 한다(외부는 skip).
+                tools: applyLocalToolStrict(advancedOptions.tools, { external: this.config.quotaExempt === true }),
                 ...(advancedOptions.tool_choice !== undefined && { tool_choice: advancedOptions.tool_choice }),
             }),
         };

--- a/apps/api/src/llm/stream-parser.ts
+++ b/apps/api/src/llm/stream-parser.ts
@@ -155,13 +155,14 @@ export function toOpenAIMessages(messages: ChatMessage[]): unknown[] {
     });
 }
 
-function toOpenAITools(tools: ToolDefinition[]): unknown[] {
+export function toOpenAITools(tools: ToolDefinition[]): unknown[] {
     return tools.map((t) => ({
         type: 'function',
         function: {
             name: t.function.name,
             description: t.function.description,
             parameters: t.function.parameters,
+            ...(t.function.strict !== undefined && { strict: t.function.strict }),
         },
     }));
 }

--- a/apps/api/src/llm/tool-strict.ts
+++ b/apps/api/src/llm/tool-strict.ts
@@ -1,0 +1,24 @@
+import type { ToolDefinition } from './types';
+import { LOCAL_TOOL_STRICT_ENABLED } from '../config/llm-parameters';
+
+export interface ToolStrictContext {
+    /** 외부 provider 클라이언트(quotaExempt) — OpenAI strict 규격이 달라 건너뛴다 */
+    external?: boolean;
+}
+
+/**
+ * 로컬 vLLM 요청의 도구 정의에 `strict: true` 를 채운다.
+ * 게이트 OFF·외부 클라이언트·호출자가 strict 를 명시한 도구는 입력 그대로.
+ * 근거·실측은 `config/llm-parameters.ts` `LOCAL_TOOL_STRICT_ENABLED` 주석 참고.
+ */
+export function applyLocalToolStrict(
+    tools: ToolDefinition[] | undefined,
+    ctx: ToolStrictContext = {},
+): ToolDefinition[] | undefined {
+    if (!tools || !LOCAL_TOOL_STRICT_ENABLED || ctx.external) return tools;
+    return tools.map((t) => (
+        t.function.strict === undefined
+            ? { ...t, function: { ...t.function, strict: true } }
+            : t
+    ));
+}

--- a/apps/api/src/llm/types.ts
+++ b/apps/api/src/llm/types.ts
@@ -152,6 +152,12 @@ export interface ToolDefinition {
             /** 필수 파라미터 이름 목록 */
             required?: string[];
         };
+        /**
+         * OpenAI `strict` — vLLM(0.27+, `VLLM_ENFORCE_STRICT_TOOL_CALLING` 기본 on)은 strict 도구가
+         * 하나라도 있으면 `tool_choice:auto` 에서도 xgrammar 구조화 태그로 호출 문법·인자 스키마를
+         * 강제한다. 로컬 wire 에서만 채운다(`llm/tool-strict.ts`) — 외부 provider 변환은 이 필드를 읽지 않는다.
+         */
+        strict?: boolean;
     };
 }
 


### PR DESCRIPTION
## 요약
Qwen3.8 점검 백로그의 마지막 항목(strict 도구 스키마). 로컬 vLLM 요청의 도구 정의에 `strict: true` 를 채워, vLLM 0.27.1 이 `tool_choice:auto` 에서도 xgrammar 구조화 태그로 도구 호출 문법과 인자 JSON 스키마(enum·타입·배열·required)를 디코딩 단계에서 강제하게 한다. DGX 변경 없음(`VLLM_ENFORCE_STRICT_TOOL_CALLING` 기본 True, 파서 `qwen3_coder` 가 `qwen_3_coder` 태그 지원).

## 근거(운영 실측)
- 30일 builtin 도구 호출 966건 중 `invalid_args` 7건 — 전부 필수 인자 누락(`web_search.query`, `mcp_call.server/tool`, `extract_webpage.url`).
- 에이전트 작업에서 `plan_create/plan_update` 의 `steps` 배열을 문자열 하나로 보낸 사례 10건(90일).
- 앱은 JSON 스키마 검증이 없다 — `tool-router` 의 required 존재 검사만, 인자 JSON 파싱 실패는 `{}` 로 강등. 모델이 다음 턴에 자가 교정하는 구조라 턴이 낭비된다.

## vLLM 실측(LiteLLM 경유)
- 위반 지시(enum 밖 값·문자열 정수·문자열 배열·미선언 키): `strict:false` → 그대로 통과 / `strict:true` → `{"state":"open","count":3,"steps":["a","b","c"]}` 로 교정.
- 병리적 스키마 21종(`$ref`·`anyOf`·`oneOf`·`format`·`pattern`·`patternProperties`·긴 enum 300·재귀 `$ref` 등) 전부 200. 도구 60개 8.5s(프리필 지배).
- 실제 builtin 23종: TTFC 8.9s → 9.4s(잡음 범위), thinking ON 도 정상. 자유 텍스트 답변도 그대로 가능.

## 변경
- `llm/tool-strict.ts` `applyLocalToolStrict` — 게이트 on · 로컬(quotaExempt 아님) · 호출자 미지정 도구에만 `strict:true`.
- `ToolDefinition.function.strict` 추가, `toOpenAITools` 가 있을 때만 싣는다.
- **외부 provider 는 의도적으로 제외** — OpenAI 규격 strict 는 전 속성 required + `additionalProperties:false` 를 요구해, 선택 인자가 있는 도구(45개 중 34개)가 400 이 된다. openai-compat 변환은 이 필드를 읽지 않는다.
- 게이트 `LLM_LOCAL_TOOL_STRICT`(기본 true), `.env.example`.

## 검증
- 단위 7건(게이트·외부 skip·명시값 보존·순수성·wire 키 유무), llm 디렉토리 107 passed, tsc 0.
- 스크래치 dist 로 LLMClient wire 캡처: 로컬 `[a,true]` / quotaExempt `[a,undefined]`.
- 배포 후 chat.openmake.cc 도구 호출 라이브 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbGa9RXHjXeRfXTn1bonB1
