### PR TITLE
fix(memory): GDPR export user_memories 조회 결함 + 부분 export 관측 + 자동 추출·백필 audit + 주입 격리 테스트

### DIFF
--- a/apps/api/src/controllers/__tests__/export.controller.test.ts
+++ b/apps/api/src/controllers/__tests__/export.controller.test.ts
@@ -1,0 +1,83 @@
+/**
+ * GDPR export — user_memories 가 현행 034 스키마 컬럼으로 조회되는지 + 카테고리 조회 실패가
+ * 빈 배열로 위장되지 않고 `_meta.failedCategories` 로 드러나는지.
+ * 배경: 2026-05-26 ~ 2026-09-07 user_memories 쿼리가 DROP 된 옛 컬럼을 조회해 매번 실패했고
+ * catch 가 `[]` 로 바꿔 counts 0 으로 나갔다(조용한 실패). requireAuth/pool/audit mock, supertest.
+ */
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('../../auth/middleware', () => ({
+    requireAuth: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+        (req as unknown as { user: unknown }).user = { userId: 'u1', role: 'user' }; next();
+    },
+}));
+jest.mock('../../data/user-manager', () => ({ isAdminRole: () => false }));
+const query = jest.fn();
+jest.mock('../../data/models/unified-database', () => ({ getPool: () => ({ query }) }));
+jest.mock('../../services/AuditService', () => ({ getAuditService: () => ({ logAudit: jest.fn().mockResolvedValue(undefined) }) }));
+
+import { createExportController } from '../export.controller';
+
+const app = express();
+app.use('/api/users/me/export', createExportController());
+
+const MEMORY_ROWS = [
+    { id: 'm1', user_id: 'u1', content: '사용자는 TypeScript 를 선호한다', source: 'candidate', is_active: true },
+    { id: 'm2', user_id: 'u1', content: '삭제된 기억', source: 'explicit', is_active: false },
+];
+
+/** 테이블별 응답 — failTable 에 해당하는 쿼리는 throw. */
+function armPool(failTable?: string) {
+    query.mockImplementation(async (sql: string) => {
+        if (failTable && sql.includes(`FROM ${failTable}`)) throw new Error(`column does not exist (${failTable})`);
+        if (sql.includes('FROM user_memories')) return { rows: MEMORY_ROWS };
+        if (sql.includes('FROM users ')) return { rows: [{ id: 'u1', email: 'u1@x' }] };
+        return { rows: [] };
+    });
+}
+
+beforeEach(() => query.mockReset());
+
+describe('export controller — user_memories', () => {
+    it('034 스키마 컬럼(content/source/is_active)으로 조회하고 옛 컬럼을 참조하지 않는다', async () => {
+        armPool();
+        const res = await request(app).get('/api/users/me/export').expect(200);
+        const call = query.mock.calls.find(([sql]) => String(sql).includes('FROM user_memories'));
+        expect(call).toBeDefined();
+        const [sql, params] = call as [string, unknown[]];
+        expect(sql).toMatch(/content/);
+        expect(sql).toMatch(/source/);
+        expect(sql).toMatch(/is_active/);
+        expect(sql).not.toMatch(/\b(category|key|value|importance)\b/);
+        expect(sql).toMatch(/user_id\s*=\s*\$1/);
+        expect(params).toEqual(['u1']);
+
+        const body = JSON.parse(res.text);
+        expect(body.userMemories).toHaveLength(2);
+        expect(body._meta.counts.userMemories).toBe(2);
+        expect(body._meta.failedCategories).toEqual([]);
+        expect(body._meta.partial).toBe(false);
+    });
+
+    it('한 카테고리 조회가 실패하면 빈 배열로 계속하되 _meta 에 실패를 드러낸다', async () => {
+        armPool('custom_agents');
+        const res = await request(app).get('/api/users/me/export').expect(200);
+        const body = JSON.parse(res.text);
+        expect(body.customAgents).toEqual([]);
+        expect(body._meta.failedCategories).toEqual(['custom_agents']);
+        expect(body._meta.partial).toBe(true);
+        // 다른 카테고리는 영향 없음
+        expect(body.userMemories).toHaveLength(2);
+    });
+
+    it('user_memories 조회 실패도 조용히 0 으로 위장되지 않는다', async () => {
+        armPool('user_memories');
+        const res = await request(app).get('/api/users/me/export').expect(200);
+        const body = JSON.parse(res.text);
+        expect(body.userMemories).toEqual([]);
+        expect(body._meta.counts.userMemories).toBe(0);
+        expect(body._meta.failedCategories).toContain('user_memories');
+        expect(body._meta.partial).toBe(true);
+    });
+});

--- a/apps/api/src/controllers/export.controller.ts
+++ b/apps/api/src/controllers/export.controller.ts
@@ -70,16 +70,24 @@ const exportLimiter = rateLimit({
 /**
  * 5개 카테고리 병렬 조회. 각 query 실패는 개별 catch 로 빈 배열 반환 (export 자체는
  * 계속 — 사용자가 부분 데이터라도 받을 수 있게).
+ *
+ * ⚠️ 실패는 조용히 삼키지 않는다 — `_meta.failedCategories` 에 라벨을 싣고 error 로그를 남긴다.
+ * 배경(2026-09-07): user_memories 쿼리가 034 마이그레이션(2026-05-26)에서 DROP 된 옛 컬럼
+ * (category/key/value/importance)을 조회해 넉 달간 매번 실패했는데, 이 catch 가 `[]` 로
+ * 바꿔 `counts.userMemories: 0` 으로 나가 "메모리 없음" 처럼 보였다(Agent Memory Atlas 지적).
+ * 사용자가 부분 export 인지 알 수 있어야 GDPR 20조 취지에 맞는다.
  */
 async function collectUserData(userId: string): Promise<Record<string, unknown>> {
     const pool = getPool();
+    const failed: string[] = [];
 
     const safeQuery = async <T extends QueryResultRow>(label: string, sql: string, params: unknown[]): Promise<T[]> => {
         try {
             const r = await pool.query<T>(sql, params);
             return r.rows;
         } catch (err) {
-            log.warn(`[Export] ${label} 조회 실패 (continue):`, err);
+            failed.push(label);
+            log.error(`[Export] ${label} 조회 실패 — 부분 export 로 계속:`, err);
             return [];
         }
     };
@@ -108,7 +116,8 @@ async function collectUserData(userId: string): Promise<Record<string, unknown>>
              FROM custom_agents WHERE created_by = $1 ORDER BY created_at DESC`,
             [userId]),
         safeQuery<Record<string, unknown>>('user_memories',
-            `SELECT id, user_id, category, key, value, importance, created_at, updated_at
+            // 034 스키마(content/source/is_active). 삭제(tombstone) 행도 본인 데이터라 is_active 로 구분해 포함.
+            `SELECT id, user_id, content, source, is_active, accessed_at, created_at, updated_at
              FROM user_memories WHERE user_id = $1 ORDER BY created_at DESC`,
             [userId]),
     ]);
@@ -130,6 +139,9 @@ async function collectUserData(userId: string): Promise<Record<string, unknown>>
                 customAgents: customAgents.length,
                 userMemories: memories.length,
             },
+            /** 조회에 실패해 빈 배열로 대체된 카테고리 — 비어 있지 않으면 부분 export. */
+            failedCategories: failed,
+            partial: failed.length > 0,
             note: 'GDPR Article 20 right to data portability. consent_logs, api_keys (암호화) 는 보안상 미포함.',
         },
     };

--- a/apps/api/src/services/chat-service/memory-backfill.test.ts
+++ b/apps/api/src/services/chat-service/memory-backfill.test.ts
@@ -1,0 +1,47 @@
+/**
+ * backfillUserMemories — 저장 후 memory.backfilled audit 을 **await** 하는지(CLI 가 반환 직후
+ * process.exit 하므로 fire-and-forget 이면 행이 유실된다). pool/LLM/audit 전부 mock.
+ */
+const repoMock = {
+    listKnownContentsByUser: jest.fn().mockResolvedValue([]),
+    countActiveByUser: jest.fn().mockResolvedValue(0),
+    create: jest.fn(async (id: string, userId: string, content: string, source: string) => ({ id, user_id: userId, content, source })),
+};
+jest.mock('../../data/repositories/user-memory-repository', () => ({ UserMemoryRepository: jest.fn().mockImplementation(() => repoMock) }));
+jest.mock('../../data/models/unified-database', () => ({
+    getPool: () => ({ query: jest.fn().mockResolvedValue({ rows: [{ id: 's1', user_text: '나는 파이썬을 선호해. '.repeat(4) }] }) }),
+}));
+jest.mock('../../llm/client', () => ({ createClient: () => ({}) }));
+jest.mock('./memory-extraction', () => ({
+    ...jest.requireActual('./memory-extraction'),
+    extractLLMMemories: jest.fn().mockResolvedValue(['사용자는 파이썬을 선호한다']),
+}));
+let auditSettled = false;
+const logAudit = jest.fn(() => new Promise<void>((r) => setTimeout(() => { auditSettled = true; r(); }, 20)));
+jest.mock('../AuditService', () => ({ getAuditService: () => ({ logAudit }) }));
+
+import { backfillUserMemories } from './memory-backfill';
+
+beforeEach(() => { auditSettled = false; logAudit.mockClear(); repoMock.create.mockClear(); });
+
+describe('backfillUserMemories — audit', () => {
+    it('저장 후 memory.backfilled audit 이 완료된 뒤에 반환한다', async () => {
+        const r = await backfillUserMemories('u1', { maxSessions: 1, minChars: 1 });
+        expect(r.saved).toBe(1);
+        expect(logAudit).toHaveBeenCalledTimes(1);
+        expect(auditSettled).toBe(true); // 반환 시점에 이미 flush 됨 — process.exit 안전
+        const input = (logAudit.mock.calls[0] as unknown[])[0] as { action: string; userId: string; details: Record<string, unknown> };
+        expect(input.action).toBe('memory.backfilled');
+        expect(input.userId).toBe('u1');
+        expect(input.details.count).toBe(1);
+        expect(JSON.stringify(input.details)).not.toContain('파이썬');
+    });
+
+    it('dryRun 은 저장·audit 모두 없음', async () => {
+        const r = await backfillUserMemories('u1', { dryRun: true, maxSessions: 1, minChars: 1 });
+        expect(r.dryRun).toBe(true);
+        expect(r.fresh).toHaveLength(1);
+        expect(repoMock.create).not.toHaveBeenCalled();
+        expect(logAudit).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/services/chat-service/memory-backfill.ts
+++ b/apps/api/src/services/chat-service/memory-backfill.ts
@@ -9,7 +9,7 @@
 import { getPool } from '../../data/models/unified-database';
 import { UserMemoryRepository } from '../../data/repositories/user-memory-repository';
 import { createClient } from '../../llm/client';
-import { extractLLMMemories, isDuplicateMemory } from './memory-extraction';
+import { extractLLMMemories, isDuplicateMemory, auditMemoryWrite } from './memory-extraction';
 import { MEMORY_EXTRACTION } from '../../config/memory-extraction';
 import { parallelBatch } from '../../workflow/graph-engine';
 import { createLogger } from '../../utils/logger';
@@ -70,13 +70,16 @@ export async function backfillUserMemories(
     if (!dryRun && fresh.length > 0) {
         const { randomUUID } = await import('node:crypto');
         let count = await repo.countActiveByUser(userId);
+        const savedIds: string[] = [];
         for (const c of fresh) {
             if (count >= MEMORY_EXTRACTION.maxCount) break;
-            await repo.create(randomUUID(), userId, c, 'batch');
+            const row = await repo.create(randomUUID(), userId, c, 'batch');
             count += 1;
             saved += 1;
+            savedIds.push(row.id);
         }
         logger.info(`[Backfill] user ${userId}: ${saved} 저장 (세션 ${sessions.length}, 후보 ${candidates.length}, 중복 ${skippedDup})`);
+        if (saved > 0) auditMemoryWrite('memory.backfilled', userId, { count: saved, ids: savedIds, sessions: sessions.length, candidates: candidates.length, skippedDup });
         if (fresh.length > saved) logger.warn(`[Backfill] cap ${MEMORY_EXTRACTION.maxCount} 도달 — 후보 ${fresh.length - saved}건 폐기 (user ${userId})`);
     }
 

--- a/apps/api/src/services/chat-service/memory-backfill.ts
+++ b/apps/api/src/services/chat-service/memory-backfill.ts
@@ -79,7 +79,8 @@ export async function backfillUserMemories(
             savedIds.push(row.id);
         }
         logger.info(`[Backfill] user ${userId}: ${saved} 저장 (세션 ${sessions.length}, 후보 ${candidates.length}, 중복 ${skippedDup})`);
-        if (saved > 0) auditMemoryWrite('memory.backfilled', userId, { count: saved, ids: savedIds, sessions: sessions.length, candidates: candidates.length, skippedDup });
+        // CLI 가 반환 직후 process.exit 하므로 await 필수(fire-and-forget 이면 audit 행이 유실된다).
+        if (saved > 0) await auditMemoryWrite('memory.backfilled', userId, { count: saved, ids: savedIds, sessions: sessions.length, candidates: candidates.length, skippedDup });
         if (fresh.length > saved) logger.warn(`[Backfill] cap ${MEMORY_EXTRACTION.maxCount} 도달 — 후보 ${fresh.length - saved}건 폐기 (user ${userId})`);
     }
 

--- a/apps/api/src/services/chat-service/memory-extraction.audit.test.ts
+++ b/apps/api/src/services/chat-service/memory-extraction.audit.test.ts
@@ -1,0 +1,75 @@
+/**
+ * autoFormMemories — 자동 저장 행이 audit(memory.auto_created)에 남는지, 본문은 싣지 않는지,
+ * 저장이 없으면 audit 도 없는지. 게이트 env 는 모듈 로드 시 읽히므로 require 전에 켠다.
+ */
+const repoMock = {
+    countActiveByUser: jest.fn().mockResolvedValue(0),
+    listKnownContentsByUser: jest.fn().mockResolvedValue([]),
+    create: jest.fn(async (id: string, userId: string, content: string, source: string) => ({ id, user_id: userId, content, source })),
+};
+jest.mock('../../data/repositories/user-memory-repository', () => ({
+    UserMemoryRepository: jest.fn().mockImplementation(() => repoMock),
+}));
+jest.mock('../../data/models/unified-database', () => ({ getPool: () => ({}) }));
+const logAudit = jest.fn().mockResolvedValue(undefined);
+jest.mock('../AuditService', () => ({ getAuditService: () => ({ logAudit }) }));
+
+type Mod = typeof import('./memory-extraction');
+let mod: Mod;
+const saved = { auto: process.env.USER_MEMORY_AUTO_EXTRACT, llm: process.env.USER_MEMORY_LLM_EXTRACT };
+const flush = () => new Promise((r) => setImmediate(r));
+
+beforeAll(() => {
+    process.env.USER_MEMORY_AUTO_EXTRACT = 'true';
+    delete process.env.USER_MEMORY_LLM_EXTRACT;
+    jest.resetModules();
+    mod = require('./memory-extraction') as Mod;
+});
+afterAll(() => {
+    if (saved.auto === undefined) delete process.env.USER_MEMORY_AUTO_EXTRACT; else process.env.USER_MEMORY_AUTO_EXTRACT = saved.auto;
+    if (saved.llm === undefined) delete process.env.USER_MEMORY_LLM_EXTRACT; else process.env.USER_MEMORY_LLM_EXTRACT = saved.llm;
+});
+beforeEach(() => {
+    repoMock.create.mockClear();
+    repoMock.listKnownContentsByUser.mockResolvedValue([]);
+    logAudit.mockClear();
+});
+
+describe('autoFormMemories — audit', () => {
+    it('저장된 행을 memory.auto_created 로 감사하고 본문은 싣지 않는다', async () => {
+        await mod.autoFormMemories({ userId: 'u1', message: '내 이름은 김철수야 기억해줘' });
+        await flush();
+        expect(repoMock.create).toHaveBeenCalledTimes(1);
+        expect(repoMock.create.mock.calls[0][3]).toBe('explicit');
+        expect(logAudit).toHaveBeenCalledTimes(1);
+        const input = logAudit.mock.calls[0][0];
+        expect(input.action).toBe('memory.auto_created');
+        expect(input.userId).toBe('u1');
+        expect(input.resourceType).toBe('user_memory');
+        expect(input.details.count).toBe(1);
+        expect(input.details.rows[0]).toEqual(expect.objectContaining({ id: expect.any(String), source: 'explicit' }));
+        expect(JSON.stringify(input.details)).not.toContain('김철수');
+    });
+
+    it('중복(tombstone 포함)으로 저장이 없으면 audit 도 없다', async () => {
+        repoMock.listKnownContentsByUser.mockResolvedValue(['내 이름은 김철수야']);
+        await mod.autoFormMemories({ userId: 'u1', message: '내 이름은 김철수야 기억해줘' });
+        await flush();
+        expect(repoMock.create).not.toHaveBeenCalled();
+        expect(logAudit).not.toHaveBeenCalled();
+    });
+
+    it('guest 는 저장·audit 모두 없음', async () => {
+        await mod.autoFormMemories({ userId: 'guest', message: '내 이름은 김철수야 기억해줘' });
+        await flush();
+        expect(repoMock.create).not.toHaveBeenCalled();
+        expect(logAudit).not.toHaveBeenCalled();
+    });
+
+    it('audit 실패는 저장을 되돌리지 않고 throw 도 없다(fail-open)', async () => {
+        logAudit.mockRejectedValueOnce(new Error('audit down'));
+        await expect(mod.autoFormMemories({ userId: 'u1', message: '나는 파이썬을 선호해' })).resolves.toBeUndefined();
+        await flush();
+        expect(repoMock.create).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/api/src/services/chat-service/memory-extraction.ts
+++ b/apps/api/src/services/chat-service/memory-extraction.ts
@@ -53,21 +53,21 @@ export async function extractLLMMemories(client: LLMClient, text: string): Promi
 /**
  * 자동 형성·백필의 audit 기록 — AuditService 가 SoT. 컨트롤러(설정 탭)만 감사하고 이 두 경로는
  * 빠져 있던 갭(Agent Memory Atlas 지적, 2026-09-07). 액션은 `memory.*` 접두를 유지해
- * scripts/memory-report.sh 의 `LIKE 'memory.%'` 집계에 그대로 잡힌다. fire-and-forget·fail-open.
+ * scripts/memory-report.sh 의 `LIKE 'memory.%'` 집계에 그대로 잡힌다. fail-open — 절대 reject 하지 않는다.
+ * 반환 Promise 를 서버 경로(autoFormMemories)는 버려도 되지만, **CLI 백필은 반드시 await** 해야 한다 —
+ * cli.ts 가 반환 직후 `process.exit(0)` 을 호출해 미완 INSERT 가 통째로 사라진다(/code-review 지적, 2026-09-07).
  */
-export function auditMemoryWrite(
+export async function auditMemoryWrite(
     action: 'memory.auto_created' | 'memory.backfilled',
     userId: string,
     details: Record<string, unknown>,
-): void {
-    void (async () => {
-        try {
-            const { getAuditService } = await import('../AuditService');
-            await getAuditService().logAudit({ action, userId, resourceType: 'user_memory', details });
-        } catch (e) {
-            logger.warn(`[audit] ${action} 기록 실패:`, e);
-        }
-    })();
+): Promise<void> {
+    try {
+        const { getAuditService } = await import('../AuditService');
+        await getAuditService().logAudit({ action, userId, resourceType: 'user_memory', details });
+    } catch (e) {
+        logger.warn(`[audit] ${action} 기록 실패:`, e);
+    }
 }
 
 /** PURE: 정규화 문자열. */
@@ -156,7 +156,7 @@ export async function autoFormMemories(params: { userId?: string; message: strin
         if (saved > 0) {
             logger.info(`[MemoryExtract] 자동 저장 ${saved}건 (user ${userId}, heur ${heur.length}/llm ${llm.length})`);
             // 컨트롤러 경로(memory.created)와 대칭 — 자동 생성 행도 감사에 남긴다(본문은 싣지 않음).
-            auditMemoryWrite('memory.auto_created', userId, { count: saved, rows: savedRows, heuristic: heur.length, llm: llm.length });
+            void auditMemoryWrite('memory.auto_created', userId, { count: saved, rows: savedRows, heuristic: heur.length, llm: llm.length });
         }
         // cap 도달로 버린 후보는 조용히 사라지지 않게 남긴다 — memory-report.sh 가 집계(퇴출 정책 도입 게이트).
         if (droppedAtCap > 0) logger.warn(`[MemoryExtract] cap ${MEMORY_EXTRACTION.maxCount} 도달 — 후보 ${droppedAtCap}건 폐기 (user ${userId})`);

--- a/apps/api/src/services/chat-service/memory-extraction.ts
+++ b/apps/api/src/services/chat-service/memory-extraction.ts
@@ -50,6 +50,26 @@ export async function extractLLMMemories(client: LLMClient, text: string): Promi
     }
 }
 
+/**
+ * 자동 형성·백필의 audit 기록 — AuditService 가 SoT. 컨트롤러(설정 탭)만 감사하고 이 두 경로는
+ * 빠져 있던 갭(Agent Memory Atlas 지적, 2026-09-07). 액션은 `memory.*` 접두를 유지해
+ * scripts/memory-report.sh 의 `LIKE 'memory.%'` 집계에 그대로 잡힌다. fire-and-forget·fail-open.
+ */
+export function auditMemoryWrite(
+    action: 'memory.auto_created' | 'memory.backfilled',
+    userId: string,
+    details: Record<string, unknown>,
+): void {
+    void (async () => {
+        try {
+            const { getAuditService } = await import('../AuditService');
+            await getAuditService().logAudit({ action, userId, resourceType: 'user_memory', details });
+        } catch (e) {
+            logger.warn(`[audit] ${action} 기록 실패:`, e);
+        }
+    })();
+}
+
 /** PURE: 정규화 문자열. */
 function norm(s: string): string {
     return s.toLowerCase().replace(/[.,!?~]/g, '').replace(/\s+/g, ' ').trim();
@@ -121,17 +141,23 @@ export async function autoFormMemories(params: { userId?: string; message: strin
         let count = count0;
         let saved = 0;
         let droppedAtCap = 0;
+        const savedRows: Array<{ id: string; source: string; length: number }> = [];
         for (const c of candidates) {
             if (count >= MEMORY_EXTRACTION.maxCount) { droppedAtCap += 1; continue; }
             if (isDuplicateMemory(c, contents)) continue;
             // 034 스키마 정의대로: 휴리스틱("기억해줘" 명시 의도)=explicit, LLM 감지=candidate. batch 는 백필 전용.
             const source = heur.includes(c) ? 'explicit' : 'candidate';
-            await repo.create(randomUUID(), userId, c, source);
+            const row = await repo.create(randomUUID(), userId, c, source);
             contents.push(c);
             count += 1;
             saved += 1;
+            savedRows.push({ id: row.id, source, length: c.length });
         }
-        if (saved > 0) logger.info(`[MemoryExtract] 자동 저장 ${saved}건 (user ${userId}, heur ${heur.length}/llm ${llm.length})`);
+        if (saved > 0) {
+            logger.info(`[MemoryExtract] 자동 저장 ${saved}건 (user ${userId}, heur ${heur.length}/llm ${llm.length})`);
+            // 컨트롤러 경로(memory.created)와 대칭 — 자동 생성 행도 감사에 남긴다(본문은 싣지 않음).
+            auditMemoryWrite('memory.auto_created', userId, { count: saved, rows: savedRows, heuristic: heur.length, llm: llm.length });
+        }
         // cap 도달로 버린 후보는 조용히 사라지지 않게 남긴다 — memory-report.sh 가 집계(퇴출 정책 도입 게이트).
         if (droppedAtCap > 0) logger.warn(`[MemoryExtract] cap ${MEMORY_EXTRACTION.maxCount} 도달 — 후보 ${droppedAtCap}건 폐기 (user ${userId})`);
     } catch (e) {

--- a/apps/api/src/services/chat-service/user-context-blocks.test.ts
+++ b/apps/api/src/services/chat-service/user-context-blocks.test.ts
@@ -1,0 +1,90 @@
+/**
+ * 메모리 주입 블록 — 사용자 격리(요청 userId 의 행만 프롬프트에 도달)·토큰 cap·touchAccessed·
+ * 토글 OFF/guest 미조회·조회 실패 graceful. 저장소 레벨 격리 테스트(user-memory-repository.test)와
+ * 별개로 **프롬프트에 닿는 마지막 경로**를 고정한다(Agent Memory Atlas 지적, 2026-09-07).
+ */
+const repoMock = { listActiveByUser: jest.fn(), touchAccessed: jest.fn().mockResolvedValue(undefined) };
+jest.mock('../../data/repositories/user-memory-repository', () => ({
+    UserMemoryRepository: jest.fn().mockImplementation(() => repoMock),
+}));
+jest.mock('../../data/repositories/user-repository', () => ({
+    UserRepository: jest.fn().mockImplementation(() => ({ getCustomInstructions: jest.fn().mockResolvedValue('') })),
+}));
+jest.mock('../../data/models/unified-database', () => ({ getPool: () => ({}) }));
+
+import { buildUserMemoryBlock, buildUserContextBlocks } from './user-context-blocks';
+import { USER_CONTEXT_LIMITS } from '../../config/runtime-limits';
+
+const ROWS: Record<string, Array<{ id: string; content: string }>> = {
+    u1: [{ id: 'a1', content: '사용자는 TypeScript 를 선호한다' }],
+    u2: [{ id: 'b1', content: '사용자의 이름은 김영희다' }],
+};
+
+beforeEach(() => {
+    repoMock.listActiveByUser.mockReset();
+    repoMock.touchAccessed.mockClear();
+    repoMock.listActiveByUser.mockImplementation(async (userId: string) => ROWS[userId] ?? []);
+});
+
+describe('buildUserMemoryBlock — 격리', () => {
+    it('요청 userId 로만 조회하고 그 사용자의 행만 블록에 싣는다', async () => {
+        const b1 = await buildUserMemoryBlock('u1');
+        expect(repoMock.listActiveByUser).toHaveBeenCalledWith('u1', expect.any(Number));
+        expect(b1).toContain('TypeScript');
+        expect(b1).not.toContain('김영희');
+
+        const b2 = await buildUserMemoryBlock('u2');
+        expect(repoMock.listActiveByUser).toHaveBeenLastCalledWith('u2', expect.any(Number));
+        expect(b2).toContain('김영희');
+        expect(b2).not.toContain('TypeScript');
+    });
+
+    it('주입한 행만 touchAccessed 한다', async () => {
+        await buildUserMemoryBlock('u1');
+        expect(repoMock.touchAccessed).toHaveBeenCalledWith(['a1']);
+    });
+
+    it('행이 없으면 빈 문자열이고 touchAccessed 도 없다', async () => {
+        expect(await buildUserMemoryBlock('nobody')).toBe('');
+        expect(repoMock.touchAccessed).not.toHaveBeenCalled();
+    });
+
+    it('토큰 cap 초과 시 앞(최신)부터 남기고 나머지는 주입·touch 모두 제외', async () => {
+        // 300자 라틴 × 40행 — 어떤 가중치로도 MAX_MEMORY_TOKENS(2000) 를 넘긴다.
+        const many = Array.from({ length: 40 }, (_, i) => ({ id: `m${i}`, content: `row${i} ` + 'x'.repeat(300) }));
+        repoMock.listActiveByUser.mockResolvedValue(many);
+        const block = await buildUserMemoryBlock('u1');
+        const touched = repoMock.touchAccessed.mock.calls[0][0] as string[];
+        expect(touched.length).toBeGreaterThan(0);
+        expect(touched.length).toBeLessThan(many.length);
+        expect(block).toContain('row0 ');
+        expect(block).not.toContain('row39 ');
+        expect(USER_CONTEXT_LIMITS.MAX_MEMORY_TOKENS).toBeGreaterThan(0);
+    });
+
+    it('조회 실패는 빈 블록으로 graceful', async () => {
+        repoMock.listActiveByUser.mockRejectedValue(new Error('db down'));
+        expect(await buildUserMemoryBlock('u1')).toBe('');
+    });
+});
+
+describe('buildUserContextBlocks — 토글·guest', () => {
+    it('includeMemory=false 면 메모리를 조회조차 하지 않는다', async () => {
+        const r = await buildUserContextBlocks('u1', false);
+        expect(r.memoryBlock).toBe('');
+        expect(repoMock.listActiveByUser).not.toHaveBeenCalled();
+    });
+
+    it('guest·미인증은 두 블록 모두 빈 문자열, 조회 없음', async () => {
+        for (const uid of ['guest', undefined]) {
+            const r = await buildUserContextBlocks(uid, true);
+            expect(r).toEqual({ memoryBlock: '', customInstructionsBlock: '' });
+        }
+        expect(repoMock.listActiveByUser).not.toHaveBeenCalled();
+    });
+
+    it('includeMemory=true 면 메모리 블록이 실린다', async () => {
+        const r = await buildUserContextBlocks('u1', true);
+        expect(r.memoryBlock).toContain('TypeScript');
+    });
+});

--- a/tests/e2e/gdpr-export.spec.ts
+++ b/tests/e2e/gdpr-export.spec.ts
@@ -62,6 +62,10 @@ test.describe('GDPR data export (Article 20)', () => {
         // _meta.counts 일치
         expect(json._meta.counts.conversationSessions).toBe(json.conversationSessions.length);
         expect(json._meta.counts.skillManifests).toBe(json.skillManifests.length);
+        expect(json._meta.counts.userMemories).toBe(json.userMemories.length);
+        // 조회 실패가 빈 배열로 위장되지 않는지 — 2026-09-07 전까지 user_memories 가 넉 달간 조용히 실패했다.
+        expect(json._meta.failedCategories).toEqual([]);
+        expect(json._meta.partial).toBe(false);
     });
 
     test('RL_GDPR_EXPORT free=2 → 3번째 429', async ({ request }) => {


### PR DESCRIPTION
## 배경

[Agent Memory Atlas](https://neoneye.github.io/agent-memory-atlas/systems/openmake-llm/) 재평가(커밋 `bca0967b` 기준)의 지적을 소스·운영 DB 로 대조해 **사실로 확인된 4건**을 닫는다. 그중 export 항목은 2026-09-06 판정서가 "틀림" 으로 기각했던 것인데, 파일 존재만 확인하고 쿼리 본문을 안 본 **우리 오판**이었다.

## 변경

| # | 내용 | 파일 |
|---|---|---|
| 1 | **export 의 user_memories SELECT 가 넉 달간 매번 실패** — 034(2026-05-26)에서 DROP 된 `category/key/value/importance` 를 조회. 라이브 재현 `ERROR: column "category" does not exist`. `safeQuery` 가 `[]` 로 바꿔 `counts.userMemories: 0` 으로 나가 "메모리 없음" 처럼 보였다 → 현행 컬럼으로 수정 | `controllers/export.controller.ts` |
| 2 | **조용한 실패 차단** — 실패 라벨을 `_meta.failedCategories` + `_meta.partial` 로 응답에 싣고 error 로그. fail-open 은 유지(부분 데이터라도 받게)하되 사용자가 부분 export 임을 알 수 있게 | 같은 파일 + `tests/e2e/gdpr-export.spec.ts` 단언 |
| 3 | **자동 추출·백필 audit 배선** — `memory.auto_created` / `memory.backfilled`(본문 미포함, id·source·개수). #762 는 컨트롤러 경로만 감사했다. `memory.%` 접두라 `memory-report.sh` 집계에 자동 포함, CRITICAL_ACTIONS 미등록 → 알림 없음 | `memory-extraction.ts`, `memory-backfill.ts` |
| 4 | **주입 경로 격리 테스트** — `buildUserMemoryBlock` 이 요청 userId 의 행만 프롬프트 블록에 싣는지, 토큰 cap 시 touchAccessed 도 남긴 행만인지, 토글 OFF/guest 는 조회조차 없는지 | `user-context-blocks.test.ts`(신규) |

## 검증

- tsc 0 · 관련 7 suite **56 passed**
- **수정을 되돌리면 실패 확인**: SELECT 를 옛 컬럼으로 → export 테스트 1건 실패 / audit 호출 주석 → audit 테스트 1건 실패
- 프론트(`settings/page.tsx`)는 export 를 blob 다운로드만 하므로 응답 필드 추가 무영향
- Atlas 의 "사용자 격리 테스트 없음" 은 절반만 맞았다 — 저장소 레벨(`user-memory-repository.test.ts`)은 있었고 프롬프트 주입 레벨이 없었다 → 4번으로 보강

## 하지 않은 것

- 승인 계층(memory candidate inbox) — 운영 `user_memories` 0행이라 데이터 게이트 유지, 별건
- 정책 읽기 fail-open → fail-closed 전환 — 의도된 설계(`memory-policy.ts` 주석). 프라이버시 관점 재고는 별건

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXehveAHGFpnyMjxPo2ui1
