### PR TITLE
fix(export): skill_manifests·custom_agents 옛 컬럼 참조 수정 (#783 관측이 드러낸 조용한 실패 2건)

### DIFF
--- a/apps/api/src/controllers/export.controller.ts
+++ b/apps/api/src/controllers/export.controller.ts
@@ -104,7 +104,8 @@ async function collectUserData(userId: string): Promise<Record<string, unknown>>
              FROM conversation_sessions s WHERE s.user_id = $1 ORDER BY s.created_at DESC LIMIT 500`,
             [userId]),
         safeQuery<Record<string, unknown>>('skill_manifests',
-            `SELECT id, version, manifest_yaml, prompt_md, checksum, is_public, created_by, created_at, updated_at
+            // skill_manifests 에는 updated_at 이 없다(#783 배포 후 failedCategories 로 드러난 옛 컬럼 참조).
+            `SELECT id, version, manifest_yaml, prompt_md, examples_md, checksum, is_public, created_by, created_at
              FROM skill_manifests WHERE created_by = $1 ORDER BY created_at DESC`,
             [userId]),
         safeQuery<Record<string, unknown>>('agent_skills',
@@ -112,7 +113,8 @@ async function collectUserData(userId: string): Promise<Record<string, unknown>>
              FROM agent_skills WHERE created_by = $1 ORDER BY created_at DESC`,
             [userId]),
         safeQuery<Record<string, unknown>>('custom_agents',
-            `SELECT id, name, description, system_prompt, model, temperature, max_tokens, created_by, status, created_at, updated_at
+            // custom_agents 에는 model 컬럼이 없다(같은 배포에서 드러남) — 실제 컬럼(keywords/category/emoji/enabled)으로.
+            `SELECT id, name, description, system_prompt, keywords, category, emoji, temperature, max_tokens, enabled, created_by, status, created_at, updated_at
              FROM custom_agents WHERE created_by = $1 ORDER BY created_at DESC`,
             [userId]),
         safeQuery<Record<string, unknown>>('user_memories',


### PR DESCRIPTION
## 배경

#783 을 배포하고 `GET /api/users/me/export` 로 라이브 검증하니 새로 넣은 `_meta.failedCategories` 가 즉시 **2건을 더** 드러냈다:

```
[Export] skill_manifests 조회 실패 — column "updated_at" does not exist
[Export] custom_agents 조회 실패 — column "model" does not exist
```

`user_memories` 와 같은 부류 — 스키마가 바뀐 뒤 export 컨트롤러만 옛 컬럼을 들고 있었고 `safeQuery` 가 `[]` 로 바꿔 왔다. 즉 GDPR export 5 카테고리 중 **3개가 조용히 실패**하고 있었다(sessions·agent_skills 만 정상).

## 변경

- `skill_manifests`: `updated_at` 제거(컬럼 없음), `examples_md` 추가
- `custom_agents`: `model` 제거(컬럼 없음), 실제 컬럼 `keywords/category/emoji/enabled` 추가

## 검증

- 새 SELECT 두 문장을 운영 DB(`information_schema` 대조)에 직접 실행해 컬럼 존재 확인
- tsc 0 · export 컨트롤러 테스트 3 passed · lint clean
- 재발 방어: #783 이 넣은 e2e `gdpr-export.spec.ts` 의 `_meta.failedCategories` 가 `[]` 여야 통과(라이브 DB 기준)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXehveAHGFpnyMjxPo2ui1
