### PR TITLE
feat(mcp): 운영 지표 내장 도구 ops_metrics — 관리자 전용·읽기 전용·의도 게이트

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -270,6 +270,9 @@ LLM_DISABLE_THINKING_BY_DEFAULT=true
 # LLM_PRESERVE_THINKING=true
 # 로컬 도구 정의에 strict:true 를 채워 vLLM 이 인자 스키마(enum·타입·배열·required)를 디코딩 단계에서 강제 (2026-09-07). 외부 provider 무영향. 'false' 로 끄면 종전처럼 미전송
 # LLM_LOCAL_TOOL_STRICT=true
+
+# 운영 지표 내장 도구 ops_metrics (관리자 전용, 읽기 전용, 운영 질의 의도 턴에만 노출 — 2026-09-07). 'false' 로 끄면 노출·실행 모두 차단
+# OPS_METRICS_TOOL_ENABLED=true
 # LLM_SAMPLING_THINKING_TEMP=1.0
 # LLM_SAMPLING_THINKING_TOP_P=0.95
 # LLM_SAMPLING_THINKING_TOP_K=20

--- a/apps/api/src/config/ops-metrics.ts
+++ b/apps/api/src/config/ops-metrics.ts
@@ -1,0 +1,57 @@
+/**
+ * @module config/ops-metrics
+ * @description 운영 지표 내장 도구 `ops_metrics` 설정 (2026-09-07, Phase 1)
+ *
+ * 외부 리뷰("Langfuse MCP 로 Monitoring Agent")를 실측 대조한 결과 — 관측 데이터는 이미
+ * `agent_tasks`·`agent_task_steps`·`audit_logs(mcp_tool_call)`·`external_provider_usage` 에
+ * 있고 없는 것은 **모델이 이 표를 질의할 도구 표면**뿐이었다(판정서
+ * openmake_llm-docs/proposals/2026-09-07-agent-observability-mcp-verdict.md).
+ * 새 백엔드(Langfuse/Phoenix) 없이 읽기 전용 명명 질의 1 도구로 시작하고, 실사용은
+ * `audit_logs WHERE action='mcp_tool_call' AND resource_id='ops_metrics'` 로 센다.
+ *
+ * 노출은 **관리자 + 운영 질의 의도 턴에만**(프롬프트 다이어트 원칙 — 상시 노출 금지),
+ * 실행은 `tool-role-gate` 가 `BUILTIN_TOOL_REQUIRED_ROLE` 로 2차 차단한다.
+ */
+
+/** 게이트 — 'false' 로 끄면 노출도 실행도 되지 않는다(기본 on). */
+export const OPS_METRICS_TOOL_ENABLED = process.env.OPS_METRICS_TOOL_ENABLED !== 'false';
+
+/**
+ * 내장 도구별 최소 역할. `tool-role-gate.isToolRestrictedForRole` 가 네임스페이스(`::`) 없는
+ * 이름에 대해 이 표를 본다 — 노출(filterRestrictedTools)과 실행(ToolRouter.executeTool)
+ * 양쪽이 같은 표를 쓰므로 프롬프트 인젝션·REST 직접 호출로 이름을 지목해도 실행되지 않는다.
+ * (종전엔 내장 도구에 선언적 게이트가 없어 핸들러 안 `isAdminRole` 분기뿐이었다.)
+ */
+export const BUILTIN_TOOL_REQUIRED_ROLE: Readonly<Record<string, 'admin' | 'user'>> = {
+    ops_metrics: 'admin',
+};
+
+/** 운영 지표 질의 의도 — 실패/느린 작업, 도구 오류, 토큰·비용, 목표 미달, 운영 현황을 묻는 턴. */
+export const OPS_METRICS_INTENT_PATTERNS: readonly RegExp[] = [
+    /(실패|느린|오래\s*걸린|지연)[^\n]{0,10}(작업|task|에이전트|agent|run)/i,
+    /(작업|task|에이전트|agent)[^\n]{0,10}(실패|성공률|오류율|에러율|지연|느려|얼마나\s*걸)/i,
+    /(도구|tool|mcp|playwright|서버)[^\n]{0,12}(오류|에러|실패|error|fail)/i,
+    /(토큰|token|비용|cost)[^\n]{0,10}(사용|소비|usage|많이|얼마)/i,
+    /(목표\s*미달|goal_incomplete|judge|판정)[^\n]{0,10}(비율|건수|rate|현황)/i,
+    /(운영|ops)\s*(지표|현황|상태|metrics|status)/i,
+    /(지난|최근|오늘|today|last)\s*[0-9]*\s*(시간|hour|일|day|주|week)[^\n]{0,16}(작업|task|도구|tool|오류|error|토큰|token)/i,
+    /ops_metrics/i,
+];
+
+/** 기간 창 → 시간. 도구 인자 `window` 의 enum 이자 SQL interval 의 단일 출처. */
+export const OPS_METRICS_WINDOWS: Readonly<Record<string, number>> = {
+    '1h': 1,
+    '6h': 6,
+    '24h': 24,
+    '7d': 24 * 7,
+    '30d': 24 * 30,
+};
+
+export const OPS_METRICS_LIMITS = {
+    DEFAULT_WINDOW: '24h',
+    DEFAULT_LIMIT: 10,
+    MAX_LIMIT: 50,
+    /** goal/error 스니펫 길이 — 결과는 MAX_TOOL_RESULT_CHARS(8000) 로 잘리므로 행당 예산을 둔다 */
+    GOAL_SNIPPET_CHARS: 100,
+    ERROR_SNIPPET_CHARS: 160,
+} as const;

--- a/apps/api/src/data/repositories/ops-metrics-repository.ts
+++ b/apps/api/src/data/repositories/ops-metrics-repository.ts
@@ -1,0 +1,190 @@
+/**
+ * @module data/repositories/ops-metrics-repository
+ * @description `ops_metrics` 내장 도구용 읽기 전용 집계 (2026-09-07)
+ *
+ * 기존 저장소가 덮지 않는 그레인만 둔다 — 도구 단위 건전성은 `tool-health-repository`,
+ * 판정 분포·실패 사유는 `agent-task-metrics-repository` 를 재사용한다(도구 핸들러가 조립).
+ * 기간은 **시간** 단위(`hours`) — 기존 저장소의 `days` 와 달리 "지난 1시간" 을 표현해야 한다.
+ * 전부 파라미터화·read-only. COUNT/SUM 은 문자열로 온다(파싱은 조립부).
+ */
+import { BaseRepository } from './base-repository';
+
+export interface OpsRunRow {
+    id: string;
+    user_id: string;
+    status: string;
+    model: string | null;
+    goal: string;
+    error: string | null;
+    judge_verdict: string | null;
+    duration_s: string | null;
+    total_tokens: number | null;
+    created_at: Date;
+}
+
+export interface OpsRunsSummaryRow {
+    status: string;
+    runs: string;
+    avg_duration_s: string | null;
+    avg_tokens: string | null;
+    goal_incomplete: string;
+}
+
+export interface OpsRunsByModelRow {
+    model: string | null;
+    runs: string;
+    failed: string;
+    avg_duration_s: string | null;
+    avg_tokens: string | null;
+}
+
+export interface OpsToolServerRow {
+    server: string | null;
+    calls: string;
+    errors: string;
+    p50_duration_ms: string | null;
+    last_error_at: Date | null;
+}
+
+export interface OpsProviderUsageRow {
+    provider_id: string;
+    model_id: string;
+    requests: string;
+    input_tokens: string | null;
+    output_tokens: string | null;
+    cost_usd_micros: string | null;
+    avg_duration_ms: string | null;
+    errors: string;
+}
+
+export interface OpsTaskTokensByUserRow {
+    user_id: string;
+    runs: string;
+    total_tokens: string | null;
+}
+
+const WINDOW = `NOW() - ($1 || ' hours')::interval`;
+const DURATION = `EXTRACT(EPOCH FROM (COALESCE(completed_at, updated_at) - created_at))`;
+
+export class OpsMetricsRepository extends BaseRepository {
+    /** 실패 작업 목록(최신순) — error 첫 줄·goal 앞부분만. */
+    async getFailedRuns(hours: number, limit: number, goalChars: number, errorChars: number): Promise<OpsRunRow[]> {
+        const r = await this.query<OpsRunRow>(
+            `SELECT id, user_id, status, model,
+                    LEFT(goal, $3::int) AS goal,
+                    LEFT(split_part(COALESCE(error, ''), E'\\n', 1), $4::int) AS error,
+                    judge_verdict,
+                    ROUND(${DURATION})::text AS duration_s,
+                    total_tokens, created_at
+             FROM agent_tasks
+             WHERE status = 'failed' AND created_at >= ${WINDOW}
+             ORDER BY created_at DESC
+             LIMIT $2`,
+            [String(hours), String(limit), String(goalChars), String(errorChars)],
+        );
+        return r.rows;
+    }
+
+    /** 가장 오래 걸린 작업(완료·실패 포함). */
+    async getSlowestRuns(hours: number, limit: number, goalChars: number, errorChars: number): Promise<OpsRunRow[]> {
+        const r = await this.query<OpsRunRow>(
+            `SELECT id, user_id, status, model,
+                    LEFT(goal, $3::int) AS goal,
+                    LEFT(split_part(COALESCE(error, ''), E'\\n', 1), $4::int) AS error,
+                    judge_verdict,
+                    ROUND(${DURATION})::text AS duration_s,
+                    total_tokens, created_at
+             FROM agent_tasks
+             WHERE created_at >= ${WINDOW} AND status IN ('completed', 'failed')
+             ORDER BY ${DURATION} DESC NULLS LAST
+             LIMIT $2`,
+            [String(hours), String(limit), String(goalChars), String(errorChars)],
+        );
+        return r.rows;
+    }
+
+    /** 상태별 건수·평균 소요·평균 토큰 + 목표 미달(goal_incomplete / not_achieved) 건수. */
+    async getRunsSummary(hours: number): Promise<OpsRunsSummaryRow[]> {
+        const r = await this.query<OpsRunsSummaryRow>(
+            `SELECT status, COUNT(*) AS runs,
+                    ROUND(AVG(${DURATION}))::text AS avg_duration_s,
+                    ROUND(AVG(total_tokens))::text AS avg_tokens,
+                    COUNT(*) FILTER (WHERE error = 'goal_incomplete' OR judge_verdict = 'not_achieved') AS goal_incomplete
+             FROM agent_tasks
+             WHERE created_at >= ${WINDOW}
+             GROUP BY status
+             ORDER BY runs DESC`,
+            [String(hours)],
+        );
+        return r.rows;
+    }
+
+    /** 모델별 작업 수·실패·평균 소요·평균 토큰. */
+    async getRunsByModel(hours: number): Promise<OpsRunsByModelRow[]> {
+        const r = await this.query<OpsRunsByModelRow>(
+            `SELECT model, COUNT(*) AS runs,
+                    COUNT(*) FILTER (WHERE status = 'failed') AS failed,
+                    ROUND(AVG(${DURATION}))::text AS avg_duration_s,
+                    ROUND(AVG(total_tokens))::text AS avg_tokens
+             FROM agent_tasks
+             WHERE created_at >= ${WINDOW} AND status IN ('completed', 'failed')
+             GROUP BY model
+             ORDER BY runs DESC`,
+            [String(hours)],
+        );
+        return r.rows;
+    }
+
+    /** MCP 서버(내장 포함) 단위 호출·오류·p50 — 채팅·작업 양쪽 경로(audit_logs). */
+    async getToolCallsByServer(hours: number): Promise<OpsToolServerRow[]> {
+        const r = await this.query<OpsToolServerRow>(
+            `SELECT details->>'server' AS server,
+                    COUNT(*) AS calls,
+                    COUNT(*) FILTER (WHERE details->>'isError' = 'true') AS errors,
+                    percentile_disc(0.5) WITHIN GROUP (
+                        ORDER BY CASE WHEN details->>'durationMs' ~ '^[0-9]+$'
+                                      THEN (details->>'durationMs')::bigint END
+                    )::text AS p50_duration_ms,
+                    MAX(timestamp) FILTER (WHERE details->>'isError' = 'true') AS last_error_at
+             FROM audit_logs
+             WHERE action = 'mcp_tool_call' AND timestamp >= ${WINDOW}
+             GROUP BY details->>'server'
+             ORDER BY errors DESC, calls DESC`,
+            [String(hours)],
+        );
+        return r.rows;
+    }
+
+    /** 외부 provider 사용량(토큰·비용·오류) — provider×model. */
+    async getProviderUsage(hours: number, limit: number): Promise<OpsProviderUsageRow[]> {
+        const r = await this.query<OpsProviderUsageRow>(
+            `SELECT provider_id, model_id, COUNT(*) AS requests,
+                    SUM(input_tokens)::text AS input_tokens,
+                    SUM(output_tokens)::text AS output_tokens,
+                    SUM(cost_usd_micros)::text AS cost_usd_micros,
+                    ROUND(AVG(duration_ms))::text AS avg_duration_ms,
+                    COUNT(*) FILTER (WHERE error_code IS NOT NULL) AS errors
+             FROM external_provider_usage
+             WHERE occurred_at >= ${WINDOW}
+             GROUP BY provider_id, model_id
+             ORDER BY requests DESC
+             LIMIT $2`,
+            [String(hours), String(limit)],
+        );
+        return r.rows;
+    }
+
+    /** 에이전트 작업 토큰 상위 사용자. */
+    async getTaskTokensByUser(hours: number, limit: number): Promise<OpsTaskTokensByUserRow[]> {
+        const r = await this.query<OpsTaskTokensByUserRow>(
+            `SELECT user_id, COUNT(*) AS runs, SUM(total_tokens)::text AS total_tokens
+             FROM agent_tasks
+             WHERE created_at >= ${WINDOW}
+             GROUP BY user_id
+             ORDER BY SUM(total_tokens) DESC NULLS LAST
+             LIMIT $2`,
+            [String(hours), String(limit)],
+        );
+        return r.rows;
+    }
+}

--- a/apps/api/src/mcp/__tests__/ops-metrics-tool.test.ts
+++ b/apps/api/src/mcp/__tests__/ops-metrics-tool.test.ts
@@ -1,0 +1,106 @@
+/**
+ * ops_metrics 내장 도구 — 역할·인자 가드(순수)와 질의 디스패치(저장소 mock).
+ */
+const mockQuery = jest.fn();
+jest.mock('../../data/models/unified-database', () => ({
+    getPool: () => ({ query: mockQuery }),
+    getUnifiedDatabase: () => ({ getPool: () => ({ query: mockQuery }) }),
+}));
+jest.mock('../../data/retry-wrapper', () => ({ withRetry: (fn: () => unknown) => fn() }));
+
+import { opsMetricsTool, OPS_METRICS_QUERIES } from '../ops-metrics-tool';
+import { isToolRestrictedForRole } from '../tool-role-gate';
+import { filterRestrictedTools } from '../../services/chat-service/tool-restrictions';
+
+const text = (r: { content: Array<{ text?: string }> }) => r.content[0]?.text ?? '';
+const admin = { userId: '3', role: 'admin' as const };
+
+beforeEach(() => { mockQuery.mockReset(); mockQuery.mockResolvedValue({ rows: [] }); });
+
+describe('ops_metrics 가드', () => {
+    it('도구 메타 — 이름·필수 인자·query enum', () => {
+        expect(opsMetricsTool.tool.name).toBe('ops_metrics');
+        expect(opsMetricsTool.tool.inputSchema.required).toEqual(['query']);
+        const q = opsMetricsTool.tool.inputSchema.properties.query as { enum: string[] };
+        expect(q.enum).toEqual([...OPS_METRICS_QUERIES]);
+    });
+
+    it('비관리자·컨텍스트 없음은 거절(DB 접근 없음)', async () => {
+        for (const ctx of [undefined, { userId: 'u', role: 'user' as const }, { userId: 'g', role: 'guest' as const }]) {
+            const r = await opsMetricsTool.handler({ query: 'summary' }, ctx);
+            expect(r.isError).toBe(true);
+            expect(text(r)).toContain('관리자 전용');
+        }
+        expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it('알 수 없는 query / window 는 거절', async () => {
+        const r1 = await opsMetricsTool.handler({ query: 'drop_table' }, admin);
+        expect(r1.isError).toBe(true);
+        expect(text(r1)).toContain('알 수 없는 query');
+        const r2 = await opsMetricsTool.handler({ query: 'summary', window: '99y' }, admin);
+        expect(r2.isError).toBe(true);
+        expect(text(r2)).toContain('알 수 없는 window');
+        expect(mockQuery).not.toHaveBeenCalled();
+    });
+});
+
+describe('ops_metrics 질의 디스패치', () => {
+    it('summary — 기본 창 24h 로 agent_tasks·audit_logs 를 시간 단위 파라미터로 조회', async () => {
+        const r = await opsMetricsTool.handler({ query: 'summary' }, admin);
+        expect(r.isError).toBe(false);
+        const body = JSON.parse(text(r));
+        expect(body.window).toBe('24h');
+        expect(body.data).toEqual({ runs: [], tool_calls_by_server: [] });
+        const sqls = mockQuery.mock.calls.map((c) => String(c[0]));
+        expect(sqls.some((s) => /FROM agent_tasks/.test(s))).toBe(true);
+        expect(sqls.some((s) => /FROM audit_logs/.test(s) && /mcp_tool_call/.test(s))).toBe(true);
+        for (const c of mockQuery.mock.calls) expect(c[1][0]).toBe('24');
+    });
+
+    it('failed_runs — window 1h·limit 상한(50) 적용, 실패 상태만', async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: 't1', status: 'failed', error: 'goal_incomplete' }] });
+        const r = await opsMetricsTool.handler({ query: 'failed_runs', window: '1h', limit: 999 }, admin);
+        const body = JSON.parse(text(r));
+        expect(body.limit).toBe(50);
+        expect(body.data.runs[0].id).toBe('t1');
+        const [sql, params] = mockQuery.mock.calls[0];
+        expect(String(sql)).toMatch(/status = 'failed'/);
+        expect(params).toEqual(['1', '50', '100', '160']);
+    });
+
+    it('tool_errors / goal_incomplete — 기존 저장소(tool-health·agent-task-metrics)를 일(day) 환산으로 재사용', async () => {
+        await opsMetricsTool.handler({ query: 'tool_errors', window: '7d' }, admin);
+        const sqls = mockQuery.mock.calls.map((c) => [String(c[0]), c[1]] as const);
+        expect(sqls.some(([s, p]) => /resource_id AS tool/.test(s) && p[0] === '7')).toBe(true);
+        mockQuery.mockClear();
+        await opsMetricsTool.handler({ query: 'goal_incomplete', window: '30d' }, admin);
+        const sqls2 = mockQuery.mock.calls.map((c) => String(c[0]));
+        expect(sqls2.some((s) => /judge_verdict/.test(s) && /completion_path/.test(s))).toBe(true);
+    });
+
+    it('저장소 오류는 isError 결과로 흡수(채팅을 죽이지 않음)', async () => {
+        mockQuery.mockRejectedValue(new Error('relation missing'));
+        const r = await opsMetricsTool.handler({ query: 'runs_by_model' }, admin);
+        expect(r.isError).toBe(true);
+        expect(text(r)).toContain('relation missing');
+    });
+});
+
+describe('내장 도구 역할 게이트 (BUILTIN_TOOL_REQUIRED_ROLE)', () => {
+    const def = (name: string) => ({ type: 'function' as const, function: { name, description: '', parameters: { type: 'object' as const, properties: {} } } });
+
+    it('ops_metrics 는 admin 만 통과, 다른 내장 도구는 영향 없음', () => {
+        expect(isToolRestrictedForRole('ops_metrics', 'user')).toBe(true);
+        expect(isToolRestrictedForRole('ops_metrics', 'guest')).toBe(true);
+        expect(isToolRestrictedForRole('ops_metrics', undefined)).toBe(true);
+        expect(isToolRestrictedForRole('ops_metrics', 'admin')).toBe(false);
+        expect(isToolRestrictedForRole('web_search', 'guest')).toBe(false);
+    });
+
+    it('노출 필터가 비관리자에게서 ops_metrics 를 제거한다', () => {
+        const tools = [def('web_search'), def('ops_metrics')];
+        expect(filterRestrictedTools(tools, 'user').map((t) => t.function.name)).toEqual(['web_search']);
+        expect(filterRestrictedTools(tools, 'admin').map((t) => t.function.name)).toEqual(['web_search', 'ops_metrics']);
+    });
+});

--- a/apps/api/src/mcp/ops-metrics-tool.ts
+++ b/apps/api/src/mcp/ops-metrics-tool.ts
@@ -1,0 +1,148 @@
+/**
+ * @module mcp/ops-metrics-tool
+ * @description 운영 지표 읽기 전용 내장 도구 `ops_metrics` (2026-09-07, Phase 1)
+ *
+ * 관리자가 채팅에서 "지난 24시간 실패한 작업", "Playwright 오류 늘었어?" 처럼 물으면 모델이
+ * 운영 DB 집계를 근거로 답하게 한다. 자유 SQL 은 받지 않고 **명명 질의 enum + 기간 창 + limit**
+ * 만 받는다. 데이터 소스·근거는 `config/ops-metrics.ts` 참고.
+ *
+ * 역할: 노출·실행 게이트는 `BUILTIN_TOOL_REQUIRED_ROLE`(tool-role-gate) 가 맡고, 여기서는
+ * 핸들러 안에서 한 번 더 확인한다(기존 ingest 도구와 같은 심층 방어).
+ */
+import { MCPToolDefinition, MCPToolResult } from './types';
+import { isAdminRole } from '../data/user-manager';
+import {
+    OPS_METRICS_LIMITS, OPS_METRICS_TOOL_ENABLED, OPS_METRICS_WINDOWS,
+} from '../config/ops-metrics';
+import { TOOL_HEALTH_QUERY } from '../config/tool-health';
+
+export const OPS_METRICS_QUERIES = [
+    'summary', 'failed_runs', 'slowest_runs', 'runs_by_model',
+    'tool_errors', 'token_usage', 'goal_incomplete',
+] as const;
+export type OpsMetricsQuery = (typeof OPS_METRICS_QUERIES)[number];
+
+interface OpsMetricsArgs extends Record<string, unknown> {
+    query?: string;
+    window?: string;
+    limit?: number;
+}
+
+function textResult(text: string, isError = false): MCPToolResult {
+    return { content: [{ type: 'text', text }], isError };
+}
+
+function resolveWindowHours(window: unknown): { key: string; hours: number } | null {
+    const key = typeof window === 'string' && window ? window : OPS_METRICS_LIMITS.DEFAULT_WINDOW;
+    const hours = OPS_METRICS_WINDOWS[key];
+    return hours ? { key, hours } : null;
+}
+
+function resolveLimit(limit: unknown): number {
+    const n = Number(limit);
+    if (!Number.isFinite(n) || n <= 0) return OPS_METRICS_LIMITS.DEFAULT_LIMIT;
+    return Math.min(Math.floor(n), OPS_METRICS_LIMITS.MAX_LIMIT);
+}
+
+/**
+ * 질의 실행 — 저장소는 지연 import(부팅 시 DB 결합 회피, 기존 ingest 도구 패턴).
+ * 도구 단위 건전성·판정 분포·실패 사유는 기존 저장소를 재사용한다.
+ */
+export async function runOpsMetricsQuery(query: OpsMetricsQuery, hours: number, limit: number): Promise<unknown> {
+    const { getPool } = await import('../data/models/unified-database');
+    const { OpsMetricsRepository } = await import('../data/repositories/ops-metrics-repository');
+    const pool = getPool();
+    const ops = new OpsMetricsRepository(pool);
+    const { GOAL_SNIPPET_CHARS, ERROR_SNIPPET_CHARS } = OPS_METRICS_LIMITS;
+    const days = hours / 24;
+
+    switch (query) {
+        case 'summary': {
+            const [runs, servers] = await Promise.all([ops.getRunsSummary(hours), ops.getToolCallsByServer(hours)]);
+            return { runs, tool_calls_by_server: servers };
+        }
+        case 'failed_runs':
+            return { runs: await ops.getFailedRuns(hours, limit, GOAL_SNIPPET_CHARS, ERROR_SNIPPET_CHARS) };
+        case 'slowest_runs':
+            return { runs: await ops.getSlowestRuns(hours, limit, GOAL_SNIPPET_CHARS, ERROR_SNIPPET_CHARS) };
+        case 'runs_by_model':
+            return { models: await ops.getRunsByModel(hours) };
+        case 'tool_errors': {
+            const { ToolHealthRepository } = await import('../data/repositories/tool-health-repository');
+            const th = new ToolHealthRepository(pool);
+            const [servers, tools, categories] = await Promise.all([
+                ops.getToolCallsByServer(hours),
+                th.getToolHealth(days, TOOL_HEALTH_QUERY.DEFAULT_MIN_CALLS, limit),
+                th.getErrorCategories(days),
+            ]);
+            return { by_server: servers, failing_tools: tools, error_categories: categories };
+        }
+        case 'token_usage': {
+            const [byUser, providers] = await Promise.all([
+                ops.getTaskTokensByUser(hours, limit), ops.getProviderUsage(hours, limit),
+            ]);
+            return { agent_task_tokens_by_user: byUser, external_provider_usage: providers };
+        }
+        case 'goal_incomplete': {
+            const { AgentTaskMetricsRepository } = await import('../data/repositories/agent-task-metrics-repository');
+            const atm = new AgentTaskMetricsRepository(pool);
+            const [verdicts, reasons, summary] = await Promise.all([
+                atm.getCompletionVerdictDistribution(days), atm.getFailureReasons(days, limit), ops.getRunsSummary(hours),
+            ]);
+            return { completion_verdicts: verdicts, failure_reasons: reasons, runs: summary };
+        }
+        default: {
+            const never: never = query;
+            throw new Error(`unknown query ${String(never)}`);
+        }
+    }
+}
+
+export const opsMetricsTool: MCPToolDefinition<OpsMetricsArgs> = {
+    tool: {
+        name: 'ops_metrics',
+        description:
+            '[관리자 전용] 이 배포의 운영 지표를 DB 에서 집계해 돌려줍니다 — 에이전트 작업 실패/느린 작업/모델별, ' +
+            'MCP·내장 도구 호출·오류율(서버·도구·원인 카테고리), 토큰·외부 provider 사용량·비용, 목표 미달(goal judge) 분포. ' +
+            '"지난 24시간 실패한 작업", "Playwright 오류 많아?", "이번 주 토큰 많이 쓴 작업" 같은 운영 질문에 이 도구 결과를 근거로 답하세요. ' +
+            '읽기 전용이며 자유 SQL 은 받지 않습니다. 숫자 필드는 문자열로 올 수 있습니다.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                query: {
+                    type: 'string',
+                    enum: [...OPS_METRICS_QUERIES],
+                    description: 'summary=상태별 작업 요약+서버별 도구 호출 · failed_runs=실패 작업 목록 · slowest_runs=오래 걸린 작업 · '
+                        + 'runs_by_model=모델별 작업 · tool_errors=서버/도구/원인별 오류 · token_usage=토큰·비용 · goal_incomplete=목표 미달 판정 분포·실패 사유',
+                },
+                window: {
+                    type: 'string',
+                    enum: Object.keys(OPS_METRICS_WINDOWS),
+                    description: `집계 기간 (기본 ${OPS_METRICS_LIMITS.DEFAULT_WINDOW})`,
+                },
+                limit: { type: 'number', description: `목록 최대 행 수 (기본 ${OPS_METRICS_LIMITS.DEFAULT_LIMIT}, 최대 ${OPS_METRICS_LIMITS.MAX_LIMIT})` },
+            },
+            required: ['query'],
+        },
+    },
+    handler: async (args, context): Promise<MCPToolResult> => {
+        if (!OPS_METRICS_TOOL_ENABLED) return textResult('ops_metrics 도구가 비활성화되어 있습니다(OPS_METRICS_TOOL_ENABLED=false).', true);
+        if (!context?.userId || !isAdminRole(context.role)) {
+            return textResult('ops_metrics 는 관리자 전용 도구입니다.', true);
+        }
+        const query = String(args.query ?? '') as OpsMetricsQuery;
+        if (!OPS_METRICS_QUERIES.includes(query)) {
+            return textResult(`알 수 없는 query: ${query} — 가능한 값: ${OPS_METRICS_QUERIES.join(', ')}`, true);
+        }
+        const win = resolveWindowHours(args.window);
+        if (!win) return textResult(`알 수 없는 window: ${String(args.window)} — 가능한 값: ${Object.keys(OPS_METRICS_WINDOWS).join(', ')}`, true);
+        const limit = resolveLimit(args.limit);
+        try {
+            const data = await runOpsMetricsQuery(query, win.hours, limit);
+            return textResult(JSON.stringify({ query, window: win.key, limit, generated_at: new Date().toISOString(), data }));
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            return textResult(`운영 지표 조회 실패 (${query}): ${message}`, true);
+        }
+    },
+};

--- a/apps/api/src/mcp/tool-role-gate.ts
+++ b/apps/api/src/mcp/tool-role-gate.ts
@@ -10,6 +10,7 @@
  */
 import { isAdminRole } from '../data/user-manager';
 import { MCP_NAMESPACE_SEPARATOR } from './types';
+import { BUILTIN_TOOL_REQUIRED_ROLE } from '../config/ops-metrics';
 
 export const DEFAULT_RESTRICTED_SERVERS = 'Python REPL:admin,Playwright Browser:user';
 
@@ -32,9 +33,17 @@ export function parseRestrictedServers(): Map<string, number> {
     return m;
 }
 
-/** 네임스페이스 도구 이름("서버명::도구")이 역할 미달로 제한되면 true. */
+/**
+ * 도구 이름이 역할 미달로 제한되면 true.
+ * - "서버명::도구"(외부 MCP): `MCP_RESTRICTED_SERVERS` 서버 단위.
+ * - 네임스페이스 없는 내장 도구: `BUILTIN_TOOL_REQUIRED_ROLE`(config/ops-metrics) 선언 — 2026-09-07 추가.
+ *   종전엔 내장 도구에 선언적 게이트가 없어 핸들러 안 분기뿐이었다.
+ */
 export function isToolRestrictedForRole(toolName: string, role?: string): boolean {
-    if (!toolName.includes(MCP_NAMESPACE_SEPARATOR)) return false;
+    if (!toolName.includes(MCP_NAMESPACE_SEPARATOR)) {
+        const required = BUILTIN_TOOL_REQUIRED_ROLE[toolName];
+        return required !== undefined && roleLevel(role) < roleLevel(required);
+    }
     const restricted = parseRestrictedServers();
     if (restricted.size === 0) return false;
     const userLevel = roleLevel(role);

--- a/apps/api/src/mcp/tools.ts
+++ b/apps/api/src/mcp/tools.ts
@@ -140,6 +140,8 @@ import { codeReviewTool } from './code-review-tool';
 import { loadSkillTool } from './load-skill-tool';
 // MCP 진행적 공개 메타 도구 (B) — 노출은 getAllowedTools 가 플래그로 게이트, 등록은 실행 라우팅용
 import { mcpMetaTools } from './mcp-meta-tools';
+// 운영 지표 (관리자 전용, 읽기 전용) — 노출은 getAllowedTools 가 관리자+의도 턴에만, 실행은 tool-role-gate
+import { opsMetricsTool } from './ops-metrics-tool';
 
 /**
  * 전체 내장 도구 배열
@@ -171,4 +173,5 @@ export const builtInTools: MCPToolDefinition[] = [
     codeReviewTool,
     loadSkillTool as MCPToolDefinition,
     ...mcpMetaTools,
+    opsMetricsTool as MCPToolDefinition,
 ];

--- a/apps/api/src/services/ChatService.ts
+++ b/apps/api/src/services/ChatService.ts
@@ -26,6 +26,7 @@ import type { ExecutionPlan } from '../chat/profile-resolver';
 import type { UserContext } from '../mcp/user-sandbox';
 import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { CHAT_ALWAYS_ON_TOOL_NAMES } from '../mcp/agent-task-tools';
+import { OPS_METRICS_TOOL_ENABLED, OPS_METRICS_INTENT_PATTERNS } from '../config/ops-metrics';
 import { MCP_META_TOOL_NAMES } from '../mcp/mcp-meta-tools';
 import { CHAT_USER_MCP_TOOL_CAP, CHAT_USER_MCP_SCHEMA_BUDGET_BYTES, MCP_PROGRESSIVE_DISCLOSURE_ENABLED, MAP_INTENT_PATTERNS, ROUTE_INTENT_PATTERNS, WEB_SEARCH_INTENT_PATTERNS, PLAN_INTENT_PATTERNS, EXTENSION_IMPORT_INTENT_PATTERNS, CHAT_USER_MCP_BREADTH_SLOTS, CHAT_TOOL_INTENT_GATE_ENABLED, AGENT_TASK_INTENT_PATTERNS } from '../config/runtime-limits';
 import { applySkillCatalog as applySkillCatalogShared } from './skill-catalog-tool';
@@ -266,6 +267,15 @@ export class ChatService {
             if (ie && !finalCombined.some((x) => x.function.name === ie.function.name)) {
                 finalCombined = [...finalCombined, ie];
                 logger.info('[Extension] 확장 설치 의도 — import_extension_from_git 강제 포함');
+            }
+        }
+        // 운영 지표 도구는 관리자 + 운영 질의 의도 턴에만(상시 노출 금지 — 프롬프트 다이어트).
+        // allTools 는 이미 역할 필터를 지났으므로 비관리자에겐 애초에 없다(2차 방어는 실행 게이트).
+        if (OPS_METRICS_TOOL_ENABLED && OPS_METRICS_INTENT_PATTERNS.some((re) => re.test(reqCtx.message ?? ''))) {
+            const om = allTools.find((x) => x.function.name === 'ops_metrics');
+            if (om && !finalCombined.some((x) => x.function.name === om.function.name)) {
+                finalCombined = [...finalCombined, om];
+                logger.info('[OpsMetrics] 운영 질의 의도 — ops_metrics 포함');
             }
         }
         return this.applySkillCatalog(finalCombined, allTools, reqCtx);


### PR DESCRIPTION
## 요약
외부 리뷰("Langfuse v4 + Langfuse MCP 로 Monitoring Agent")를 소스·운영 DB·호스트 자원으로 대조한 판정(private docs `proposals/2026-09-07-agent-observability-mcp-verdict.md`)의 **Phase 1**. 관측 데이터는 이미 DB 에 있고 없는 것은 모델이 질의할 도구 표면뿐이므로, 새 백엔드 없이 읽기 전용 내장 도구 1개를 추가한다.

## 변경
- **`ops_metrics` 내장 도구** (`mcp/ops-metrics-tool.ts`): `query` enum 7종(summary·failed_runs·slowest_runs·runs_by_model·tool_errors·token_usage·goal_incomplete) + `window`(1h/6h/24h/7d/30d) + `limit`. 자유 SQL 없음. `tool_errors`·`goal_incomplete` 는 기존 `tool-health-repository`·`agent-task-metrics-repository` 재사용.
- **`ops-metrics-repository.ts`**: 시간 단위 창의 작업 요약/실패·느린 작업/모델별/서버별 도구 호출/provider 사용량/사용자별 토큰. 전부 파라미터화·read-only.
- **내장 도구 선언적 역할 게이트**: `BUILTIN_TOOL_REQUIRED_ROLE`(`config/ops-metrics.ts`) 을 `tool-role-gate.isToolRestrictedForRole` 이 네임스페이스 없는 이름에 적용 → 노출(`filterRestrictedTools`)·실행(`ToolRouter.executeTool`) 양쪽 동일 정책. 종전엔 내장 도구에 선언적 게이트가 없었다(핸들러 안 분기뿐). 핸들러도 `isAdminRole` 재확인.
- **노출**: `ChatService.getAllowedTools` 가 관리자 + `OPS_METRICS_INTENT_PATTERNS` 매칭 턴에만 포함(상시 노출 금지). 다른 턴엔 프롬프트 영향 0.
- 게이트 `OPS_METRICS_TOOL_ENABLED`(기본 true), `.env.example`. 실사용은 `audit_logs` `resource_id='ops_metrics'` 로 센다(추가 코드 없음).

## 검증
- 단위 14건: 비관리자/컨텍스트 없음 거절(DB 미접근), 알 수 없는 query/window 거절, 디스패치 SQL·파라미터(시간 창·limit 상한), 기존 저장소 재사용, 저장소 오류 흡수, 역할 게이트·노출 필터.
- mcp + chat-service 스위트 61 suites / 466 passed, tsc 0, eslint 0.
- 새 SQL 은 운영 DB 에서 읽기 전용으로 실행해 결과 확인(7일 completed 20·failed 5·goal_incomplete 3, 서버별 도구 오류, provider 사용량). 분수 일(`0.0417 days`) interval 도 정상.
- 배포 후 chat.openmake.cc 관리자 채팅으로 라이브 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbGa9RXHjXeRfXTn1bonB1
