### PR TITLE
fix(eval): 실패 케이스 응답 앞부분을 결과·[FAIL] 로그에 남긴다

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -273,6 +273,9 @@ LLM_DISABLE_THINKING_BY_DEFAULT=true
 
 # 운영 지표 내장 도구 ops_metrics (관리자 전용, 읽기 전용, 운영 질의 의도 턴에만 노출 — 2026-09-07). 'false' 로 끄면 노출·실행 모두 차단
 # OPS_METRICS_TOOL_ENABLED=true
+
+# eval:response --real 실패 케이스 결과에 남기는 응답 앞부분 길이 (2026-09-08). nightly 실패 원인 사후 분석용
+# OMK_EVAL_RESPONSE_PREVIEW_CHARS=600
 # LLM_SAMPLING_THINKING_TEMP=1.0
 # LLM_SAMPLING_THINKING_TOP_P=0.95
 # LLM_SAMPLING_THINKING_TOP_K=20

--- a/apps/api/src/evaluation/__tests__/response-evaluator.test.ts
+++ b/apps/api/src/evaluation/__tests__/response-evaluator.test.ts
@@ -1,0 +1,40 @@
+/**
+ * 응답 평가기 — 실패 케이스는 응답 앞부분(responsePreview)을 결과에 남긴다.
+ * 2026-09-04~07 nightly 에서 response-003/012 가 반복 실패했는데 결과 파일엔 길이만 있어
+ * 원인(모델 편차 vs 게이트 결함)을 사후에 가를 수 없었다.
+ */
+import { evaluateResponseCase } from '../response-evaluator';
+import type { GoldenCase } from '../types';
+
+const base: GoldenCase = {
+    id: 'response-012',
+    category: 'response-pattern',
+    query: 'Python으로 hello world 예제 보여줘',
+    mustContainAny: ['Python', '파이썬', 'print('],
+    language: 'ko',
+} as GoldenCase;
+
+describe('evaluateResponseCase', () => {
+    it('통과 케이스는 길이만 남기고 preview 를 싣지 않는다', async () => {
+        const r = await evaluateResponseCase(base, async () => '```python\nprint("Hello, world!")\n```');
+        expect(r.passed).toBe(true);
+        expect(r.actual?.responseLength).toBe(36);
+        expect(r.actual).not.toHaveProperty('responsePreview');
+    });
+
+    it('실패 케이스는 원문(정규화 전) 앞부분을 responsePreview 로 남긴다', async () => {
+        const long = 'Hello World 를 출력하는 예제는 다음과 같습니다. ' + 'x'.repeat(1000);
+        const r = await evaluateResponseCase(base, async () => long);
+        expect(r.passed).toBe(false);
+        expect(r.failureReason).toContain('OR 후보 substring 모두 누락');
+        const preview = r.actual?.responsePreview as string;
+        expect(preview.startsWith('Hello World 를 출력하는')).toBe(true);
+        expect(preview.length).toBe(600);
+    });
+
+    it('대소문자·아포스트로피 정규화는 종전대로 동작한다', async () => {
+        const c: GoldenCase = { ...base, id: 'x', mustContain: ["can't", 'Python'], mustContainAny: undefined } as GoldenCase;
+        const r = await evaluateResponseCase(c, async () => 'I can’t run PYTHON here.');
+        expect(r.passed).toBe(true);
+    });
+});

--- a/apps/api/src/evaluation/response-evaluator.ts
+++ b/apps/api/src/evaluation/response-evaluator.ts
@@ -23,6 +23,11 @@ const logger = createLogger('ResponseEvaluator');
  */
 export type ResponseGenerator = (query: string, language?: string) => Promise<string>;
 
+/** 실패 케이스 결과에 남기는 응답 앞부분 길이 (env OMK_EVAL_RESPONSE_PREVIEW_CHARS, 기본 600). */
+const RESPONSE_PREVIEW_CHARS = Number(process.env.OMK_EVAL_RESPONSE_PREVIEW_CHARS ?? '600');
+/** [FAIL] 로그 한 줄에 싣는 응답 길이 — 리포트에서 바로 읽기 위한 짧은 미리보기. */
+const FAIL_LOG_PREVIEW_CHARS = 160;
+
 /**
  * 단일 response-pattern 케이스 평가
  *
@@ -64,7 +69,13 @@ export async function evaluateResponseCase(
             category: goldenCase.category,
             passed,
             failureReason,
-            actual: { responseLength: response.length, missing, forbidden },
+            // 실패 케이스는 응답 앞부분을 남긴다 — 길이만 저장하면 nightly 실패(2026-09-04~07
+            // response-003/012 반복)의 원인을 사후에 알 수 없었다(라이브 재현은 통과 → 모델 편차인지
+            // 게이트 결함인지 구분 불가). 통과 케이스는 종전대로 길이만.
+            actual: {
+                responseLength: response.length, missing, forbidden,
+                ...(passed ? {} : { responsePreview: rawResponse.slice(0, RESPONSE_PREVIEW_CHARS) }),
+            },
             expected: {
                 mustContain: goldenCase.mustContain ?? [],
                 mustContainAny: anyList,
@@ -103,7 +114,9 @@ export async function runResponseEvaluation(
         const result = await evaluateResponseCase(c, generator);
         results.push(result);
         if (!result.passed) {
-            logger.warn(`[FAIL] ${c.id}: ${result.failureReason}`);
+            const preview = typeof result.actual?.responsePreview === 'string'
+                ? ` | 응답=${JSON.stringify(result.actual.responsePreview.slice(0, FAIL_LOG_PREVIEW_CHARS))}` : '';
+            logger.warn(`[FAIL] ${c.id}: ${result.failureReason}${preview}`);
         }
     }
 


### PR DESCRIPTION
## 요약
nightly eval(`eval:response --real`)이 2026-09-04~07 나흘간 `response-003`(Klingon 언어 폴백)·`response-012`(Python hello world)를 반복 실패시켰는데, 결과 JSON 의 `actual` 이 `{responseLength, missing, forbidden}` 뿐이라 **응답이 무엇이었는지 사후에 알 수 없었다**(길이 7·32·574 만 남음). 같은 질의를 chat.openmake.cc 에서 라이브 재현하면 둘 다 통과(코드 블록 36자 / 영어로 거절)해 모델 편차로 추정되지만, 결과 파일만으로는 게이트 결함과 구분이 안 된다.

## 변경
- 실패 케이스에만 `actual.responsePreview`(원문 앞 600자, `OMK_EVAL_RESPONSE_PREVIEW_CHARS`) 저장. 통과 케이스는 종전대로 길이만.
- `[FAIL]` warn 로그에 응답 160자 미리보기 동반 → `logs/eval-reports/*.txt` 에서 바로 읽힌다.
- `.env.example` 항목 추가.

## 검증
- 단위 3건(통과=preview 없음 · 실패=원문 앞 600자 · 대소문자/아포스트로피 정규화 유지), tsc 0, eslint 0.
- 다음 nightly(03:40 KST) 결과 파일에서 실패 케이스 본문을 확인할 수 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbGa9RXHjXeRfXTn1bonB1
