### PR TITLE
fix(web): 설정 저장 후 재로그인하면 기본 모델이 초기화되던 결함

### DIFF
--- a/apps/web/app/(workspace)/settings/page.tsx
+++ b/apps/web/app/(workspace)/settings/page.tsx
@@ -209,8 +209,9 @@ export default function SettingsPage() {
   const setPrivacyPrefs = useAppStore((s) => s.setPrivacyPrefs);
   // 게스트(비로그인)는 기본 모델만 사용 가능 — 외부 provider(Ollama/OpenRouter)는 가입 이용자 전용.
   const isGuest = !useAppStore((s) => s.auth.currentUser);
+  const currentUserIdForModels = useAppStore((s) => s.auth.currentUser?.id ?? null);
   const { data: modelsData } = useQuery({
-    queryKey: ["models"],
+    queryKey: ["models", currentUserIdForModels ?? "guest"],
     queryFn: () => fetchModels({ usableOnly: true }),
     staleTime: 60_000,
   });

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -190,8 +190,12 @@ export function Composer() {
 
 
   // 로컬 vLLM + 등록된 외부 LLM(OpenRouter 등) 통합 모델 목록
+  // 외부 provider 모델은 인증 사용자에게만 실리므로 사용자 단위로 캐시한다 — 로그아웃/로그인
+  // 전환 시 게스트 목록(로컬 1개)이 60초간 재사용돼 아래 보정이 저장 선택을 지우던 결함.
+  const currentUserId = useAppStore((s) => s.auth.currentUser?.id ?? null);
+  const authResolved = useAppStore((s) => s.authResolved);
   const { data: modelsData } = useQuery({
-    queryKey: ["models"],
+    queryKey: ["models", currentUserId ?? "guest"],
     queryFn: () => fetchModels({ usableOnly: true }),
     staleTime: 60_000,
   });
@@ -324,14 +328,17 @@ export function Composer() {
   // 모델 목록 로드 시 현재 selectedModel 이 목록에 없으면 defaultModel 로 동기화.
   // 'default'(자동) 는 유효한 센티널 — 백엔드 ws-chat-handler 가 자동 선택으로 처리하므로
   // 구체 모델로 강제 치환하지 않는다 (치환 시 설정의 "자동" 선택이 조용히 풀리는 버그).
+  // ⚠️ 보정은 **인증 확정 + 로그인 사용자의 목록**일 때만. 게스트/미확정 상태의 목록은 외부 모델이
+  // 빠져 있어(서버가 인증 사용자에게만 실음) 저장된 외부 모델 선택을 로컬 기본값으로 덮어쓰고
+  // localStorage 까지 갱신했다 — 설정 저장 후 재로그인하면 모델이 초기화되던 결함(2026-09-08).
   useEffect(() => {
-    if (!modelsData) return;
+    if (!modelsData || !authResolved || !currentUserId) return;
     if (selectedModel !== "default" && !modelsData.models.some((m) => m.modelId === selectedModel)) {
       setSelectedModel(modelsData.defaultModel);
     }
     // selectedModel 변동마다 재실행 불필요 — 목록 로드 시점에만 보정
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [modelsData]);
+  }, [modelsData, authResolved, currentUserId]);
 
   // 재생성 요청(MessageList) 처리 — 소켓은 이 컴포넌트만 보유하므로 여기서 히스토리를
   // fromIndex 이전으로 되돌린 뒤 원 질문을 재전송한다(사용자 말풍선은 sendChat 이 다시 추가).

--- a/apps/web/lib/auth-sync.ts
+++ b/apps/web/lib/auth-sync.ts
@@ -113,6 +113,11 @@ async function syncAuthInner(): Promise<boolean> {
         if (typeof p.saveHistory === "boolean") patch.saveHistory = p.saveHistory;
         if (typeof p.memoryLearning === "boolean") patch.memoryLearning = p.memoryLearning;
         if (Object.keys(patch).length > 0) useAppStore.getState().setPrivacyPrefs(patch);
+        // 기본 모델도 서버가 SoT — 종전엔 설정 페이지를 열 때만 복원돼, 로그아웃 중 컴포저가
+        // 로컬 기본값으로 덮어쓴 selectedModel 이 재로그인 뒤에도 그대로였다(2026-09-08 신고).
+        if (typeof p.defaultModel === "string" && p.defaultModel.length > 0) {
+          useAppStore.getState().setSelectedModel(p.defaultModel);
+        }
       })
       .catch(() => {
         /* 미설정/실패 — 기본값(true) 유지 */


### PR DESCRIPTION
## 증상
설정 → 모델 & 응답에서 외부 모델(예 `bai:qwen3.8-flash`)을 고르고 저장 → 로그아웃 → 재로그인 → 모델이 로컬 기본값으로 초기화.

## 원인 (서버는 정상)
`users.preferences.defaultModel` 은 DB 에 정상 저장돼 있었다(user 3 실측). 손실은 클라이언트 두 겹:
1. **게스트 목록으로 덮어쓰기** — `composer.tsx` 의 "selectedModel 이 목록에 없으면 defaultModel 로 보정" 이 로그아웃/게스트 상태에서도 돌았다. `/api/models` 는 인증 사용자에게만 외부 provider 모델을 싣으므로(게스트 실측: 모델 1개) 저장된 외부 선택이 "목록에 없음" 으로 판정돼 로컬 기본값으로 바뀌고 `openmake-prefs`(localStorage)까지 갱신된다. 이후 설정 저장을 누르면 초기화된 값이 서버로 올라가 영구 손실. 쿼리 키 `["models"]` 가 사용자 무관이라 로그인 직후에도 게스트 응답이 60초간 재사용됐다.
2. **재로그인 시 미복원** — `auth-sync.ts` 가 preferences 에서 `saveHistory`/`memoryLearning` 만 복원하고 `defaultModel` 은 설정 페이지 mount 에서만 복원했다.

## 수정
- composer 보정은 `authResolved && currentUser` 일 때만 실행. models 쿼리 키를 `["models", userId|"guest"]` 로 사용자 스코프(provider-keys 의 prefix 무효화 `["models"]` 는 그대로 동작).
- auth-sync 가 로그인 시 `preferences.defaultModel` 을 `selectedModel` 로 복원(서버 SoT).
- settings 페이지도 같은 스코프 키.

## 검증
- web tsc 0 · eslint 0. 배포 후 chat.openmake.cc 에서 로그아웃 → 재로그인 → 컴포저 모델 표시로 라이브 확인 예정.

## 남긴 것(별건)
- `/api/models?usableOnly=1` 의 20B 이하 제외 필터가 컴포저·설정에도 적용됨(`role-model-filter.ts` 주석은 역할 배정 전용을 의도) — 소형 외부 모델을 고르면 같은 보정에 걸릴 수 있음.
- `model-picker` 가 목록에 없는 값을 "자동" 으로 표시(값은 유지) — 표시 문제.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbGa9RXHjXeRfXTn1bonB1
