### PR TITLE
fix(web): 기본 모델 목록 20B 컷 미적용(chatOnly) + 피커의 목록 밖 저장값 표시

### DIFF
--- a/apps/api/src/config/role-model-filter.test.ts
+++ b/apps/api/src/config/role-model-filter.test.ts
@@ -1,4 +1,4 @@
-import { parseModelParamsB, isRoleAssignableModel, ROLE_MODEL_MIN_PARAMS_B } from './role-model-filter';
+import { parseModelParamsB, isRoleAssignableModel, ROLE_MODEL_MIN_PARAMS_B, isChatCapableModel } from './role-model-filter';
 
 describe('parseModelParamsB', () => {
     it('총 파라미터 우선 (35b-a3b → 35)', () => {
@@ -52,5 +52,17 @@ describe('isRoleAssignableModel', () => {
         expect(isRoleAssignableModel(m('local-llm:flux2-klein'))).toBe(false);
         expect(isRoleAssignableModel(m('nvidia:nvidia/nv-embed-v1'))).toBe(false);
         expect(isRoleAssignableModel(m('openrouter:some/whisper-large'))).toBe(false);
+    });
+});
+
+describe('isChatCapableModel (chatOnly — 컴포저/설정 기본 모델 목록)', () => {
+    it('임베딩/이미지/음성은 제외', () => {
+        expect(isChatCapableModel({ modelId: 'local-llm:bge-m3' })).toBe(false);
+        expect(isChatCapableModel({ modelId: 'x:flux-2' })).toBe(false);
+        expect(isChatCapableModel({ modelId: 'openrouter:openai/whisper-1' })).toBe(false);
+    });
+    it('20B 이하 소형 채팅 모델은 유지 — usableOnly 와 다른 점', () => {
+        expect(isChatCapableModel({ modelId: 'openrouter:meta-llama/llama-3.2-1b-instruct' })).toBe(true);
+        expect(isChatCapableModel({ modelId: 'bai:qwen3.8-flash' })).toBe(true);
     });
 });

--- a/apps/api/src/config/role-model-filter.ts
+++ b/apps/api/src/config/role-model-filter.ts
@@ -43,6 +43,16 @@ export function parseModelParamsB(idOrName: string): number | null {
 }
 
 /**
+ * 채팅 가능한 모델인지 판정 — 축 ① 만(임베딩/이미지/음성/리랭커 제외). 컴포저·설정의 기본 모델
+ * 선택은 이 판정만 쓴다(`/api/models?chatOnly=1`, 2026-09-08). 종전엔 usableOnly(20B 컷 포함)를
+ * 같이 써서 소형 외부 모델(예: 8b)이 목록에서 빠지고, 컴포저의 "목록에 없으면 기본값" 보정에 걸렸다.
+ */
+export function isChatCapableModel(model: { modelId: string; name?: string }): boolean {
+    const hay = `${model.modelId} ${model.name ?? ''}`.toLowerCase();
+    return !ROLE_MODEL_EXCLUDE_PATTERNS.some((p) => hay.includes(p));
+}
+
+/**
  * 역할 배정에 노출할 모델인지 판정.
  * @param model modelId(fullId)·name·capabilities 를 가진 목록 항목
  */
@@ -51,10 +61,8 @@ export function isRoleAssignableModel(model: {
     name?: string;
     capabilities?: { streaming?: boolean; toolCalling?: boolean; vision?: boolean };
 }): boolean {
+    if (!isChatCapableModel(model)) return false;
     const hay = `${model.modelId} ${model.name ?? ''}`.toLowerCase();
-
-    // ① 채팅 불가 모델(임베딩/이미지/음성 등) 제외
-    if (ROLE_MODEL_EXCLUDE_PATTERNS.some((p) => hay.includes(p))) return false;
 
     // ② 20B 이하 제외 (파싱 불가 = 대형 프론티어 모델로 간주해 유지)
     const params = parseModelParamsB(hay);

--- a/apps/api/src/routes/model.routes.ts
+++ b/apps/api/src/routes/model.routes.ts
@@ -26,7 +26,7 @@ import { ExternalKeysRepository } from '../data/repositories/external-keys-repo'
 import { getPool } from '../data/models/unified-database';
 import { buildFullModelId } from '../providers/i-provider';
 import { getProviderCatalogEntry } from '../config/external-providers';
-import { isRoleAssignableModel } from '../config/role-model-filter';
+import { isRoleAssignableModel, isChatCapableModel } from '../config/role-model-filter';
 import { resolveExternalModels } from '../services/external-models-catalog';
 
 const router = Router();
@@ -175,13 +175,18 @@ router.get('/models', optionalAuth, asyncHandler(async (req: Request, res: Respo
     // UI 는 이 값으로 "이미지 생성 가능" 표시만 한다 (채팅 셀렉터 옵션 아님). 미설정 시 null.
     const imageModel = process.env.IMAGE_GEN_MODEL?.trim() || null;
 
-    // 사용 가능 모델 필터 — 채팅 불가(임베딩/이미지) + 20B 이하 제외.
-    // 역할 배정 드롭다운·기본 모델 선택(설정/컴포저)에서 usableOnly=1 로 호출.
-    // (forRoleAssignment 는 하위호환 별칭)
+    // 목록 필터 2종 —
+    //   usableOnly=1 (역할 배정 드롭다운·커스텀 에이전트): 채팅 불가(임베딩/이미지) + 20B 이하 제외.
+    //   chatOnly=1   (컴포저·설정의 기본 모델 선택): 채팅 불가만 제외 — 20B 컷을 여기 적용하면
+    //                소형 외부 모델 선택이 목록에서 빠져 컴포저 보정이 기본값으로 되돌린다(2026-09-08).
+    // (forRoleAssignment 는 usableOnly 의 하위호환 별칭)
     const usableOnly = req.query.usableOnly === '1' || req.query.forRoleAssignment === '1';
+    const chatOnly = req.query.chatOnly === '1';
     const outModels = usableOnly
         ? models.filter((m) => isRoleAssignableModel({ modelId: m.modelId, name: m.name, capabilities: m.capabilities as { streaming?: boolean; toolCalling?: boolean; vision?: boolean } }))
-        : models;
+        : chatOnly
+            ? models.filter((m) => isChatCapableModel({ modelId: m.modelId, name: m.name }))
+            : models;
 
     res.json(success({
         defaultModel: buildFullModelId('local-llm', defaultChat),

--- a/apps/web/app/(workspace)/settings/page.tsx
+++ b/apps/web/app/(workspace)/settings/page.tsx
@@ -211,8 +211,8 @@ export default function SettingsPage() {
   const isGuest = !useAppStore((s) => s.auth.currentUser);
   const currentUserIdForModels = useAppStore((s) => s.auth.currentUser?.id ?? null);
   const { data: modelsData } = useQuery({
-    queryKey: ["models", currentUserIdForModels ?? "guest"],
-    queryFn: () => fetchModels({ usableOnly: true }),
+    queryKey: ["models", "chat", currentUserIdForModels ?? "guest"],
+    queryFn: () => fetchModels({ chatOnly: true }),
     staleTime: 60_000,
   });
   // 기본 모델은 2단계 선택(provider → model)으로 노출 — components/model-picker.tsx 공용

--- a/apps/web/components/chat/composer.tsx
+++ b/apps/web/components/chat/composer.tsx
@@ -195,8 +195,8 @@ export function Composer() {
   const currentUserId = useAppStore((s) => s.auth.currentUser?.id ?? null);
   const authResolved = useAppStore((s) => s.authResolved);
   const { data: modelsData } = useQuery({
-    queryKey: ["models", currentUserId ?? "guest"],
-    queryFn: () => fetchModels({ usableOnly: true }),
+    queryKey: ["models", "chat", currentUserId ?? "guest"],
+    queryFn: () => fetchModels({ chatOnly: true }),
     staleTime: 60_000,
   });
   const {

--- a/apps/web/components/model-picker.tsx
+++ b/apps/web/components/model-picker.tsx
@@ -48,26 +48,37 @@ export function ModelPicker({
       ? t("modelGroup.local")
       : (EXTERNAL_PROVIDER_LABELS[provider] ?? `🌐 ${provider}`);
 
+  // 저장값이 목록에 없는 경우(키 삭제·목록 로딩 전·provider 일시 실패) — 종전엔 "자동" 으로
+  // 표시돼 값이 바뀐 것처럼 보였고, provider 를 다시 고르면 onChange('default') 로 실제 초기화됐다.
+  // 값은 SoT 로 보존하고 `provider:model` 접두어에서 provider 를 유도해 "목록에 없음" 항목으로 보인다.
+  const orphan = useMemo(() => {
+    if (!value || value === "default" || models.some((m) => m.modelId === value)) return null;
+    const idx = value.indexOf(":");
+    const provider = idx > 0 ? value.slice(0, idx) : "local-llm";
+    return { modelId: value, provider, name: `${value} ${t("modelPicker.notInList")}` } as PickerModel;
+  }, [models, value, t]);
+  const allModels = useMemo(() => (orphan ? [...models, orphan] : models), [models, orphan]);
+
   // provider 목록 — local-llm 우선, 외부는 응답 등장 순서 유지
   const providers = useMemo(() => {
     const seen: string[] = [];
-    for (const m of models) if (!seen.includes(m.provider)) seen.push(m.provider);
+    for (const m of allModels) if (!seen.includes(m.provider)) seen.push(m.provider);
     return seen.sort((a, b) => (a === "local-llm" ? -1 : b === "local-llm" ? 1 : 0));
-  }, [models]);
+  }, [allModels]);
 
   const currentProvider = useMemo(() => {
     if (!value || value === "default") return PROVIDER_AUTO;
-    return models.find((m) => m.modelId === value)?.provider ?? PROVIDER_AUTO;
-  }, [models, value]);
+    return allModels.find((m) => m.modelId === value)?.provider ?? PROVIDER_AUTO;
+  }, [allModels, value]);
 
   // 현재 provider 의 모델 목록 (무료 우선 안정 정렬)
   const providerModels = useMemo(() => {
     if (currentProvider === PROVIDER_AUTO) return [];
-    return models
+    return allModels
       .filter((m) => m.provider === currentProvider)
       .slice()
       .sort((a, b) => (b.isFree ? 1 : 0) - (a.isFree ? 1 : 0));
-  }, [models, currentProvider]);
+  }, [allModels, currentProvider]);
 
   const searchable = providerModels.length > MODEL_SEARCH_THRESHOLD;
   const q = filter.trim().toLowerCase();
@@ -90,7 +101,7 @@ export function ModelPicker({
       return;
     }
     // 해당 provider 의 첫 모델(무료 우선)로 즉시 전환 — value 가 SoT 라 2단계도 동기화됨
-    const first = models
+    const first = allModels
       .filter((m) => m.provider === p)
       .slice()
       .sort((a, b) => (b.isFree ? 1 : 0) - (a.isFree ? 1 : 0))[0];

--- a/apps/web/lib/models-api.ts
+++ b/apps/web/lib/models-api.ts
@@ -22,10 +22,10 @@ export interface ModelsPayload {
  * GET /api/models — 로컬 vLLM 모델 + 인증 사용자가 등록한 외부 LLM(OpenRouter 등 openai-compatible)
  * provider 의 모델을 합산한 통합 목록. (legacy models-api.js 대응)
  */
-export async function fetchModels(opts?: { usableOnly?: boolean }): Promise<ModelsPayload> {
-  // usableOnly: 서버가 채팅 불가(임베딩/이미지)·20B 이하 모델을 제외한 목록을 반환.
-  // 기본 모델 선택·역할/에이전트 모델 배정 드롭다운에서 사용.
-  const qs = opts?.usableOnly ? "?usableOnly=1" : "";
+export async function fetchModels(opts?: { usableOnly?: boolean; chatOnly?: boolean }): Promise<ModelsPayload> {
+  // usableOnly: 채팅 불가(임베딩/이미지)·20B 이하 제외 — 역할/에이전트 모델 배정 드롭다운.
+  // chatOnly:   채팅 불가만 제외 — 컴포저·설정의 기본 모델 선택(소형 외부 모델도 선택 가능해야 함).
+  const qs = opts?.usableOnly ? "?usableOnly=1" : opts?.chatOnly ? "?chatOnly=1" : "";
   const res = await ApiClient.get<{ success: boolean; data: ModelsPayload }>(
     `/api/models${qs}`,
   );

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -159,7 +159,8 @@
       "modelAria": "Select model",
       "searchPlaceholder": "Search models…",
       "count": "Showing {shown}/{total}",
-      "noMatch": "No matches"
+      "noMatch": "No matches",
+      "notInList": "(not in list)"
     },
     "dataExport": {
       "title": "Export my data",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -159,7 +159,8 @@
       "modelAria": "モデルを選択",
       "searchPlaceholder": "モデルを検索…",
       "count": "{shown}/{total}件を表示",
-      "noMatch": "該当なし"
+      "noMatch": "該当なし",
+      "notInList": "（一覧にありません）"
     },
     "dataExport": {
       "title": "データをエクスポート",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -159,7 +159,8 @@
       "modelAria": "모델 선택",
       "searchPlaceholder": "모델 검색…",
       "count": "{shown}/{total}개 표시",
-      "noMatch": "검색 결과 없음"
+      "noMatch": "검색 결과 없음",
+      "notInList": "(목록에 없음)"
     },
     "dataExport": {
       "title": "내 데이터 내보내기",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -159,7 +159,8 @@
       "modelAria": "选择模型",
       "searchPlaceholder": "搜索模型…",
       "count": "显示 {shown}/{total} 个",
-      "noMatch": "无匹配结果"
+      "noMatch": "无匹配结果",
+      "notInList": "（不在列表中）"
     },
     "dataExport": {
       "title": "导出我的数据",


### PR DESCRIPTION
## 요약
PR #789(재로그인 시 기본 모델 초기화) 에서 별건으로 남긴 2건.

1. **`/api/models?chatOnly=1`** — 채팅 불가(임베딩/이미지/음성)만 제외. 컴포저·설정의 기본 모델 선택이 `usableOnly`(20B 이하 제외 포함)를 쓰고 있어 `role-model-filter.ts` 의 의도("컴포저/기본 모델 선택에는 적용하지 않는다")와 어긋났고, 소형 외부 모델을 고르면 목록에서 빠져 컴포저 보정에 걸렸다. 역할 배정·커스텀 에이전트는 `usableOnly` 유지. `isChatCapableModel` 분리 + 테스트.
2. **model-picker** — 저장값이 목록에 없으면 "자동" 으로 보이고, provider 를 다시 고르면 `onChange('default')` 로 실제 초기화됐다. 값은 보존하고 `provider:model` 접두어로 provider 를 유도해 "(목록에 없음)" 항목으로 표시(ko/en/ja/zh).
3. 컴포저/설정 쿼리 키 `["models","chat",uid]` 로 usableOnly 캐시와 분리.

## 검증
- api tsc 0 · filter 테스트 10 passed · web tsc 0 · web eslint 0.
- 배포 후 `/api/models?chatOnly=1` 응답과 설정 피커 표시 라이브 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbGa9RXHjXeRfXTn1bonB1
