### PR TITLE
feat(mcp): OpenDART 전자공시 MCP 카탈로그 시드(115) + env_schema default + 동시 spawn dedupe

### DIFF
--- a/apps/api/src/__tests__/lifecycle-supervisor.test.ts
+++ b/apps/api/src/__tests__/lifecycle-supervisor.test.ts
@@ -63,6 +63,37 @@ const mkRow = (overrides: Record<string, unknown>) => ({
 });
 
 describe('MCPLifecycleSupervisor', () => {
+
+    test('safeSpawn: 같은 서버 동시 spawn 은 1회만 기동하고 같은 client 를 돌려준다 (from-catalog 즉시 spawn + ensureUserServers 경합)', async () => {
+        const userPool = new UserMCPPool();
+        const repo = mkRepo();
+        repo.getServerById.mockImplementation(async (id: string) => mkRow({ id, lifecycle: 'per_session' }));
+        const { factory, created } = mkClientFactory();
+        // connect 를 늦춰 두 호출이 모두 "풀에 없음" 상태에서 진입하게 한다
+        factory.mockImplementation((config: { id: string }) => {
+            const client = {
+                connect: jest.fn(() => new Promise<void>(r => setTimeout(r, 20))),
+                disconnect: jest.fn().mockResolvedValue(undefined),
+                listTools: jest.fn().mockResolvedValue({ tools: [] }),
+                callTool: jest.fn(),
+                on: jest.fn(),
+                getPid: jest.fn().mockReturnValue(MOCK_PID),
+            };
+            created.push({ serverId: config.id, client });
+            return client;
+        });
+        const sv = new MCPLifecycleSupervisor({ userPool, repo, clientFactory: factory });
+
+        const [a, b] = await Promise.all([sv.spawnUserServer('u-1', 's-1'), sv.spawnUserServer('u-1', 's-1')]);
+
+        expect(factory).toHaveBeenCalledTimes(1);
+        expect(a).toBe(b);
+        expect(userPool.has('u-1', 's-1')).toBe(true);
+        // 완료 후엔 in-flight 가 비워져 stale evict → respawn 경로가 막히지 않는다
+        await sv.killUserServer('u-1', 's-1');
+        await sv.spawnUserServer('u-1', 's-1');
+        expect(factory).toHaveBeenCalledTimes(2);
+    });
     test('onUserLogin: auto_spawn=true + lifecycle=per_session 만 spawn', async () => {
         const userPool = new UserMCPPool();
         const repo = mkRepo();

--- a/apps/api/src/data/repositories/__tests__/mcp-catalog-repository.test.ts
+++ b/apps/api/src/data/repositories/__tests__/mcp-catalog-repository.test.ts
@@ -113,3 +113,49 @@ describe('McpCatalogRepository.decryptEnvForSpawn', () => {
         await expect(repoWith(null).decryptEnvForSpawn('s1')).resolves.toEqual({});
     });
 });
+
+describe('McpCatalogRepository.createFromCatalog — env_schema default', () => {
+    const template = {
+        id: 'mcp-korean-dart',
+        transport_type: 'stdio',
+        command_template: 'npx -y korean-dart-mcp@0.10.1',
+        args_schema: {},
+        env_schema: {
+            required: ['DART_API_KEY'],
+            properties: {
+                DART_API_KEY: { secret: true },
+                HOME: { default: '/home/node/.cache/korean-dart' },
+            },
+        },
+        is_enabled: true,
+    } as never;
+    const payload = (env: Record<string, string>) =>
+        ({ template_id: 'mcp-korean-dart', name: 'dart', visibility: 'user_private', args: {}, env, auto_spawn: true }) as never;
+    const makePool = () => {
+        const queryMock = jest.fn().mockImplementation((_sql: string, params: unknown[]) =>
+            Promise.resolve({ rows: [{ id: String(params[0]), env: JSON.parse(String(params[6])) }] }));
+        return { queryMock, pool: { query: queryMock } as unknown as Pool };
+    };
+
+    it('미입력 키에 default 를 채우고 secret 은 암호화한다', async () => {
+        const { queryMock, pool } = makePool();
+        await new McpCatalogRepository(pool).createFromCatalog(payload({ DART_API_KEY: 'k' }), template, '3');
+        const saved = JSON.parse(String(queryMock.mock.calls[0]![1]![6]));
+        expect(saved.HOME).toBe('/home/node/.cache/korean-dart');
+        expect(decryptToken(saved.DART_API_KEY)).toBe('k');
+    });
+
+    it('사용자가 명시한 값은 default 로 덮지 않는다', async () => {
+        const { queryMock, pool } = makePool();
+        await new McpCatalogRepository(pool).createFromCatalog(payload({ DART_API_KEY: 'k', HOME: '/home/node/.cache/x' }), template, '3');
+        const saved = JSON.parse(String(queryMock.mock.calls[0]![1]![6]));
+        expect(saved.HOME).toBe('/home/node/.cache/x');
+    });
+
+    it('default 가 없는 템플릿은 입력 env 만 저장한다 (기존 동작)', async () => {
+        const { queryMock, pool } = makePool();
+        const plain = { ...(template as object), env_schema: { required: [], properties: { X: { secret: false } } } } as never;
+        await new McpCatalogRepository(pool).createFromCatalog(payload({}), plain, '3');
+        expect(JSON.parse(String(queryMock.mock.calls[0]![1]![6]))).toEqual({});
+    });
+});

--- a/apps/api/src/data/repositories/mcp-catalog-repository.ts
+++ b/apps/api/src/data/repositories/mcp-catalog-repository.ts
@@ -119,7 +119,7 @@ export class McpCatalogRepository {
     ): Promise<UserMcpServerRow> {
         const id = `mcp_${userId}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
         const args = this.renderArgs(template, payload.args);
-        const env = this.encryptEnv(template, payload.env);
+        const env = this.encryptEnv(template, this.applyEnvDefaults(template, payload.env));
         const url = this.renderUrl(template, payload.args);
         // command_template 의 첫 토큰만 command 컬럼에 저장 (예: "npx -y firecrawl-mcp" → "npx").
         // 나머지 토큰은 renderArgs 가 args 로 분리. child_process.spawn 은 command 가 단일 실행파일이어야 함.
@@ -542,6 +542,21 @@ export class McpCatalogRepository {
             url = url.replace(`{${k}}`, encodeURIComponent(String(v)));
         }
         return url || null;
+    }
+
+    /**
+     * env_schema properties 의 `default` 를 미입력 키에 채운다 (설치 시 1회, 값은 평문 그대로).
+     * 설치 폼은 `required` 키만 입력받으므로, 서버가 동작하는 데 필요하지만 사용자가 알 필요 없는
+     * 고정 env(예: readonly 샌드박스에서 SQLite 캐시 경로를 캐시 볼륨으로 돌리는 HOME)를 카탈로그가
+     * 선언할 수 있다. 사용자가 명시한 값이 우선한다.
+     */
+    private applyEnvDefaults(template: McpCatalogTemplate, env: Record<string, string>): Record<string, string> {
+        const props = (template.env_schema as { properties?: Record<string, { default?: unknown }> }).properties ?? {};
+        const merged: Record<string, string> = { ...env };
+        for (const [k, p] of Object.entries(props)) {
+            if (merged[k] === undefined && typeof p?.default === 'string') merged[k] = p.default;
+        }
+        return merged;
     }
 
     private encryptEnv(template: McpCatalogTemplate, env: Record<string, string>): Record<string, string> {

--- a/apps/api/src/mcp/lifecycle-supervisor.ts
+++ b/apps/api/src/mcp/lifecycle-supervisor.ts
@@ -75,6 +75,8 @@ export class MCPLifecycleSupervisor implements LifecycleSupervisor {
     private readonly repo: SupervisorDeps['repo'];
     private readonly clientFactory: ClientFactory;
     private readonly chatOwners = new Map<string, string>();
+    /** 진행 중 spawn(user:server) — 동시 호출이 같은 Promise 를 공유해 컨테이너 이중 기동을 막는다 */
+    private readonly inFlightSpawns = new Map<string, Promise<ExternalMCPClient>>();
 
     constructor(deps: SupervisorDeps) {
         this.userPool = deps.userPool;
@@ -226,7 +228,23 @@ export class MCPLifecycleSupervisor implements LifecycleSupervisor {
         await this.userPool.closeAll();
     }
 
-    private async safeSpawn(userId: string, serverId: string): Promise<ExternalMCPClient> {
+    /**
+     * 동시 호출 dedupe — from-catalog 즉시 spawn 과 채팅의 ensureUserServers 가 같은 서버를
+     * 동시에 spawn 하면 둘 다 풀 검사(get)를 통과해 컨테이너 2개가 뜨고, userPool.add 가
+     * 먼저 등록된 client 를 disconnect 없이 덮어써 프로세스가 누수됐다(2026-09-08 운영 실측 —
+     * 같은 serverId 로 `spawn 완료` 2줄, pid 2개). 진행 중 Promise 를 키(user:server)로
+     * 공유해 두 번째 호출자가 같은 client 를 받게 한다.
+     */
+    private safeSpawn(userId: string, serverId: string): Promise<ExternalMCPClient> {
+        const key = `${userId}:${serverId}`;
+        const pending = this.inFlightSpawns.get(key);
+        if (pending) return pending;
+        const p = this.doSpawn(userId, serverId).finally(() => { this.inFlightSpawns.delete(key); });
+        this.inFlightSpawns.set(key, p);
+        return p;
+    }
+
+    private async doSpawn(userId: string, serverId: string): Promise<ExternalMCPClient> {
         // 멱등 가드 — 이미 풀에 "살아있는" 클라이언트가 있으면 재spawn 하지 않는다
         // (로그인 반복 시 자식 프로세스 중복 생성/누수 방지).
         // self-heal: transport 가 exit/error 로 죽었다고 표시된(status!=='connected')

--- a/db/migrations/115_mcp_opendart_catalog.sql
+++ b/db/migrations/115_mcp_opendart_catalog.sql
@@ -1,0 +1,48 @@
+-- ============================================================
+-- 115_mcp_opendart_catalog.sql — OpenDART(금융감독원 전자공시) MCP 서버를 mcp_server_catalog 에 시드
+-- ============================================================
+-- 목적: 금융/경제·비즈니스 에이전트가 상장기업 공시·재무제표를 1차 자료(DART)로 인용할 수 있게
+--       opendart-mcp(PyPI, https://github.com/RealYoungk/opendart-mcp)를 카탈로그에 추가한다.
+--       OpenDART Open API 83개를 도구 1:1 로 노출(공시검색·기업개황·정기보고서 주요사항·
+--       재무제표(XBRL 주요계정/전체/지표)·지분공시·주요사항보고서·증권신고서).
+--
+-- 후보 비교(2026-09-08, 운영과 같은 readonly·512m 샌드박스 실측):
+--   · korean-dart-mcp(npm, 회사명→corp_code 변환 포함) — 첫 기동에 corpCode 전체 XML(11.9만사)을
+--     DOM 으로 파싱해 **RSS 1.75GiB**(V8 heap 기본 512MB 초과로 abort, 512m 캡에선 OOM kill).
+--     4GiB Docker VM 의 사용자별 샌드박스엔 부적합 → 제외.
+--   · @vertical-mcp/dart-mcp(도구 3) — 기능 빈약. korea-stock-mcp — 샌드박스에서 무응답.
+--   · opendart-mcp — 기동 수 초·메모리 소폭, 83 도구 정상. 단 **회사명→고유번호 변환 도구가 없다**
+--     (get_corp_code 는 전체 ZIP base64). 라이브 채팅에서 코드를 아는 회사(삼성전자)는 정상 조회,
+--     모르는 회사는 모델이 corp_code 를 사용자에게 되묻는다(날조 없음). 알려진 제약으로 기록.
+--
+-- 노출 제한: tool_allowlist 8종 — 채팅 자동 노출 상한(CHAT_USER_MCP_TOOL_CAP=8)에 맞춘 핵심 도구.
+--       나머지 75개는 mcp_list_tools/mcp_call 진행적 공개와 REST 직접 실행으로 도달 가능
+--       (allowlist 는 채팅 자동 노출 그룹에만 적용 — tool-router.getUserPoolToolGroups 참고).
+--
+-- 인증: OPENDART_API_KEY (필수). opendart.fss.or.kr 「인증키 신청/관리」에서 즉시 무료 발급(40자 hex),
+--       일 20,000건. env_schema secret=true → AES-256-GCM 암호화 저장. CLI 인자 전달 없음(ps 노출 방지).
+--
+-- 전송: stdio. mcp-runtime 이미지의 uvx 로 spawn(버전 고정 0.1.0). 외부 opendart.fss.or.kr 호출이라
+--       sandbox_network 기본값('full').
+--       ⚠️ `--with mcp<2` 필수 — 패키지가 `mcp[cli]>=1.0.0` 으로 상한을 안 잡아 mcp 2.x 에서
+--          `mcp.server.fastmcp` import 로 즉사한다(실측, noapi-google-search 와 같은 패턴).
+--          command_template 은 공백 split 이라 따옴표 없이 `mcp<2` 한 토큰으로 쓴다.
+--
+-- 멱등: ON CONFLICT (id) DO NOTHING — 기존 row(admin 수정 포함)를 덮어쓰지 않음.
+-- ============================================================
+
+INSERT INTO mcp_server_catalog (
+    id, display_name, description, transport_type, command_template,
+    args_schema, env_schema, tool_allowlist, is_enabled
+) VALUES (
+    'mcp-opendart',
+    'OpenDART (금융감독원 전자공시)',
+    '상장기업 공시 검색·기업개황·재무제표(XBRL 주요계정/전체/재무지표)·배당·최대주주·대량보유 등 OpenDART API 83종. 조회는 corp_code(8자리 고유번호) 기준 — 회사명 검색은 미지원(dart.fss.or.kr 에서 확인). OpenDART 인증키 필요(무료, 일 20,000건).',
+    'stdio',
+    'uvx --with mcp<2 opendart-mcp==0.1.0',
+    '{}'::jsonb,
+    '{"type": "object", "required": ["OPENDART_API_KEY"], "properties": {"OPENDART_API_KEY": {"type": "string", "title": "OpenDART API Key", "secret": true, "description": "opendart.fss.or.kr 「인증키 신청/관리」에서 무료 발급(40자). 일 20,000건"}}}'::jsonb,
+    '["search_disclosure","get_company_info","get_single_company_accounts","get_single_financial_index","get_full_financial_statement","get_dividend_info","get_largest_shareholder","get_major_stockholding"]'::jsonb,
+    TRUE
+)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## 요약
- **115 마이그레이션**: `opendart-mcp`(PyPI 0.1.0, OpenDART API 83종 1:1)를 카탈로그에 시드. `uvx --with mcp<2`(상한 미고정 → mcp 2.x 에서 import 즉사 실측), `OPENDART_API_KEY` secret, `tool_allowlist` 8종(채팅 노출 캡 8).
- **env_schema `default`**: `createFromCatalog` 가 미입력 키에 `properties.<k>.default` 를 채움(사용자 명시값 우선). 설치 폼은 `required` 만 받으므로 카탈로그가 고정 env 를 선언할 수 있음. 테스트 3건(수정 되돌리면 1건 실패 확인).
- **동시 spawn dedupe**: from-catalog 즉시 spawn 과 채팅 `ensureUserServers` 가 같은 서버를 동시에 spawn → 컨테이너 2개 + `userPool.add` 덮어쓰기로 프로세스 누수(운영 로그: 같은 serverId `spawn 완료` 2줄, pid 2개). in-flight Promise 공유로 1회만 기동. 테스트 1건(가드 제거 시 실패 확인).

## 후보 비교 (운영과 같은 readonly·512m 샌드박스 실측)
| 패키지 | 결과 |
|---|---|
| `opendart-mcp` (채택) | 기동 수 초, 83 도구, REST·채팅 실데이터 정상 |
| `korean-dart-mcp` | 회사명→corp_code 변환은 있으나 첫 기동 corpCode DOM 파싱으로 **RSS 1.75GiB**(512m OOM, 1g 에서도 V8 heap abort) → 제외 |
| `@vertical-mcp/dart-mcp` | 도구 3개, 기능 빈약 |
| `korea-stock-mcp` | 샌드박스에서 무응답 |

알려진 제약: 회사명→고유번호 변환 도구가 없어 모르는 회사는 모델이 corp_code 를 되묻는다(날조 없음). 설명문에 명시.

## 라이브 검증 (chat.openmake.cc, user 3)
- 설치 10s 내 83 도구 연결, REST execute 실데이터(삼성전자 개황·2025 재무지표·최대주주 27행)
- WS 채팅: `get_dividend_info`(주당 1,668원·수익률 1.50%)·`get_single_financial_index`(수익성지표 표) 정확 답변
- 관찰: `get_largest_shareholder`(11.5K 자 결과) 턴에서 로컬 qwen3.8-27b 가 2/2 중국어·역할 누출로 degenerate — MCP 무관한 모델 출력 문제, 별건 기록

## 체크
- [x] tsc 0 · eslint(경고는 기존 max-lines) · jest 33 suites 242 passed
- [x] 마이그레이션 115(순번 충돌 없음, 멱등)
- [ ] 환경변수 추가 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mAMGPdenUaxVgpfPb4dfo