### PR TITLE
feat(settings): 모델&응답 API 키 — 공급자 로고 스트립 + 키 발급/인증 페이지 링크

### DIFF
--- a/apps/api/src/__tests__/external-providers-catalog-links.test.ts
+++ b/apps/api/src/__tests__/external-providers-catalog-links.test.ts
@@ -1,0 +1,29 @@
+/**
+ * config/external-providers — 설정 화면 "이런 AI를 연결합니다" 스트립이 쓰는 공급자 메타
+ * (homepage · keyUrl · logo). 로고 파일은 apps/web/public 에 있어야 하고(없으면 화면에 깨진
+ * 이미지), 링크는 https 여야 한다. OAuth 전용 공급자는 앱 안의 디바이스 플로우가 인증 경로라
+ * keyUrl 을 두지 않는다(homepage 폴백).
+ */
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+import { EXTERNAL_PROVIDER_CATALOG } from '../config/external-providers';
+
+const WEB_PUBLIC = resolve(__dirname, '../../../web/public');
+
+describe('EXTERNAL_PROVIDER_CATALOG 연결 메타', () => {
+    test('모든 공급자에 https homepage 와 apps/web/public 에 실재하는 로고가 있다', () => {
+        for (const e of EXTERNAL_PROVIDER_CATALOG) {
+            expect(e.homepage).toMatch(/^https:\/\//);
+            expect(e.logo).toMatch(/^\/images\/providers\/[a-z0-9-]+\.svg$/);
+            expect(existsSync(resolve(WEB_PUBLIC, `.${e.logo}`))).toBe(true);
+        }
+    });
+
+    test('keyUrl 은 https 이고, OAuth 전용 공급자는 keyUrl 없이 homepage 로 폴백한다', () => {
+        for (const e of EXTERNAL_PROVIDER_CATALOG) {
+            const oauthOnly = e.authMethods.includes('oauth') && !e.authMethods.includes('api_key');
+            if (oauthOnly) expect(e.keyUrl).toBeUndefined();
+            else expect(e.keyUrl).toMatch(/^https:\/\//);
+        }
+    });
+});

--- a/apps/api/src/config/external-providers.ts
+++ b/apps/api/src/config/external-providers.ts
@@ -40,6 +40,15 @@ export interface ExternalProviderCatalogEntry {
     sortOrder: number;
     /** 키 등록 안내 — UI 도움말 텍스트 */
     helpText: string;
+    /** 공급자 홈페이지 — 설정 화면 로고/이름 클릭 목적지 폴백 */
+    homepage: string;
+    /**
+     * API 키 발급(또는 로그인) 페이지 — 설정 화면 "키 발급" 링크. OAuth 전용 provider 는
+     * 앱 안의 디바이스 플로우가 인증 경로라 생략(homepage 로 폴백).
+     */
+    keyUrl?: string;
+    /** apps/web public 의 로고 경로(www 와 같은 자산, 48×48 viewBox 단색 마크) */
+    logo: string;
     /**
      * 지원 인증 방식. Phase 1: 모두 ['api_key'].
      * Phase 2 에서 ['api_key', 'oauth'] 로 확장 가능 (OpenAI ChatGPT Plus/Pro 등).
@@ -104,6 +113,9 @@ export const EXTERNAL_PROVIDER_CATALOG: ReadonlyArray<ExternalProviderCatalogEnt
             '300+ 모델(GPT, Claude, Gemini, Llama 등)을 단일 endpoint 로 라우팅합니다. ' +
             '모델 ID 는 "openai/gpt-5", "anthropic/claude-opus-4.5", "google/gemini-2.5-pro" 등 ' +
             'OpenRouter 의 namespaced 형식을 그대로 사용합니다.',
+        homepage: 'https://openrouter.ai',
+        keyUrl: 'https://openrouter.ai/settings/keys',
+        logo: '/images/providers/openrouter.svg',
         authMethods: ['api_key'] as const,
         fallbackModels: [
             { id: 'openai/gpt-5',                      displayName: 'GPT-5',                       isFree: false, capabilities: { streaming: true, toolCalling: true, vision: true,  thinking: false } },
@@ -130,6 +142,8 @@ export const EXTERNAL_PROVIDER_CATALOG: ReadonlyArray<ExternalProviderCatalogEnt
             '표시되는 코드를 OpenAI 인증 페이지에 입력하세요. ' +
             '⚠️ 비공식 통합: 반드시 본인 계정만 사용해야 하며, OpenAI 정책 변경 시 ' +
             '중단될 수 있습니다.',
+        homepage: 'https://chatgpt.com',
+        logo: '/images/providers/chatgpt.svg',
         authMethods: ['oauth'] as const,
         // Codex 카탈로그 조회 실패 시 폴백 — 계정 플랜에 따라 실제 목록은 다를 수 있음.
         fallbackModels: [
@@ -149,6 +163,9 @@ export const EXTERNAL_PROVIDER_CATALOG: ReadonlyArray<ExternalProviderCatalogEnt
             'Ollama Cloud (https://ollama.com/settings/keys) 의 API 키를 입력하세요. ' +
             '클라우드 호스팅 대형 모델을 OpenAI 호환 API 로 사용합니다. ' +
             '모델 ID 는 "deepseek-v3.1:671b-cloud" 처럼 :cloud 태그 형식입니다.',
+        homepage: 'https://ollama.com',
+        keyUrl: 'https://ollama.com/settings/keys',
+        logo: '/images/providers/ollama-cloud.svg',
         authMethods: ['api_key'] as const,
         fallbackModels: [
             { id: 'deepseek-v3.1:671b-cloud', displayName: 'DeepSeek V3.1 671B (Cloud)', isFree: false, capabilities: { streaming: true, toolCalling: true, vision: false, thinking: true } },
@@ -170,6 +187,9 @@ export const EXTERNAL_PROVIDER_CATALOG: ReadonlyArray<ExternalProviderCatalogEnt
             'NVIDIA GPU 클라우드가 서빙하는 오픈소스 모델(Llama, Qwen, Nemotron 등)을 ' +
             'OpenAI 호환 API 로 사용합니다. 모델 ID 는 "meta/llama-3.3-70b-instruct" 형식입니다. ' +
             '주의: NVIDIA 의 모델 목록 API 는 인증이 없어 키 유효성은 첫 채팅에서 확인됩니다.',
+        homepage: 'https://build.nvidia.com',
+        keyUrl: 'https://build.nvidia.com/settings/api-keys',
+        logo: '/images/providers/nvidia-nim.svg',
         authMethods: ['api_key'] as const,
         // 2026-09-05 공개 /v1/models(81개) 대조 — llama-3.3-70b·qwen3-next-80b 는 410 end-of-life,
         // llama-4-maverick 은 목록 부재라 제거. 아래는 목록에 살아 있는 채팅용 모델만.
@@ -201,6 +221,9 @@ export const EXTERNAL_PROVIDER_CATALOG: ReadonlyArray<ExternalProviderCatalogEnt
             'OpenAI 호환 API 로 사용합니다. 모델 ID 는 "qwen3-coder" 처럼 접두사 없는 형식입니다. ' +
             '주의: 모델 목록 API 는 인증이 없어 키 유효성은 첫 채팅에서 확인됩니다. ' +
             '개발키는 분당 요청·일일 토큰 한도가 낮아(초과 시 429) 체험·검증 용도입니다.',
+        homepage: 'https://open.hasa.re.kr',
+        keyUrl: 'https://open.hasa.re.kr/account/dev-keys',
+        logo: '/images/providers/hasa.svg',
         authMethods: ['api_key'] as const,
         // 2026-09-02 공개 카탈로그(/api/catalog) 기준 — 개발키 허용 + 채팅 모달리티만 수록.
         fallbackModels: [
@@ -230,6 +253,9 @@ export const EXTERNAL_PROVIDER_CATALOG: ReadonlyArray<ExternalProviderCatalogEnt
             '무료 표시(isFree) 모델은 2026-09-04 실측 기준 크레딧 잔액 0 인 키로도 호출되는 것만 남겼습니다 — ' +
             '그 외 모델은 예치(deposit)·크레딧이 필요해 403/400 이 납니다. 모델 ID 는 "qwen3.8-flash" 처럼 접두사 없는 형식입니다. ' +
             '연속 호출 시 429 가 잦으니 병렬 사용은 피하세요.',
+        homepage: 'https://b.ai',
+        keyUrl: 'https://b.ai',
+        logo: '/images/providers/bai.svg',
         authMethods: ['api_key'] as const,
         // 2026-09-02 실측(무료 키·잔액 0): 45개 중 5개만 200. tools 는 5개 전부, vision 은 qwen3.8-flash·
         // glm-5.3-flash·deepseek-v4-flash-vision-exp 만(32px 이상 이미지), 5개 전부 reasoning_content 반환.

--- a/apps/api/src/routes/external-keys.routes.ts
+++ b/apps/api/src/routes/external-keys.routes.ts
@@ -102,6 +102,9 @@ router.get('/',
                 enabled: entry.enabled,
                 sort_order: entry.sortOrder,
                 help_text: entry.helpText,
+                homepage: entry.homepage,
+                key_url: entry.keyUrl ?? null,
+                logo: entry.logo,
                 user_key: userKey
                     ? {
                           display_name: userKey.displayName,

--- a/apps/web/components/settings/provider-keys-section.tsx
+++ b/apps/web/components/settings/provider-keys-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import Image from "next/image";
 import { useQueryClient } from "@tanstack/react-query";
 import { useLocale, useTranslations } from "next-intl";
 import {
@@ -12,6 +13,7 @@ import {
   Save,
   AlertTriangle,
   ShieldCheck,
+  ExternalLink,
 } from "lucide-react";
 import {
   Button,
@@ -49,6 +51,10 @@ interface ProviderEntry {
   auth_methods?: Array<"api_key" | "oauth">;
   default_base_url: string | null;
   help_text?: string;
+  /** 공급자 홈페이지 · API 키 발급(또는 로그인) 페이지 · 로고 — 백엔드 카탈로그(external-providers.ts) 제공 */
+  homepage?: string;
+  key_url?: string | null;
+  logo?: string;
   user_key: UserKey | null;
 }
 
@@ -105,6 +111,8 @@ export function ProviderKeysSection() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showForm, setShowForm] = useState(false);
+  /** 연결 스트립에서 고른 공급자 — 폼을 그 공급자로 열어 준다(키 입력 또는 OAuth 로그인) */
+  const [formProviderId, setFormProviderId] = useState<string | null>(null);
   const [usage, setUsage] = useState<Record<string, ProviderUsage>>({});
   const [usageDays, setUsageDays] = useState(30);
   const [validating, setValidating] = useState<Record<string, boolean>>({});
@@ -204,9 +212,24 @@ export function ProviderKeysSection() {
 
   return (
     <div className="space-y-6">
+      {/* 연결 가능한 공급자 스트립 — www 의 "이런 AI를 연결합니다" 와 같은 로고·이름.
+          칩을 누르면 그 공급자로 키 입력(OAuth 는 로그인) 폼이 열리고, 옆 링크는 공급자의
+          키 발급/인증 페이지로 간다(key_url, 없으면 homepage). */}
+      {!loading && providers.length > 0 && (
+        <ProviderStrip
+          providers={providers}
+          onConnect={(id) => {
+            setFormProviderId(id);
+            setShowForm(true);
+          }}
+        />
+      )}
+
       {showForm && (
         <AddKeyForm
+          key={formProviderId ?? "default"}
           providers={providers}
+          initialProviderId={formProviderId}
           onClose={() => setShowForm(false)}
           onSaved={async () => {
             setShowForm(false);
@@ -272,7 +295,13 @@ export function ProviderKeysSection() {
                       return (
                         <tr key={p.provider_id}>
                           <Td className="text-fg">
-                            <div className="font-medium">{p.display_name}</div>
+                            <div className="flex items-center gap-2 font-medium">
+                              {p.logo && (
+                                <Image src={p.logo} alt="" width={20} height={20} className="h-5 w-5 shrink-0" />
+                              )}
+                              <span>{p.display_name}</span>
+                              <ProviderSiteLink provider={p} />
+                            </div>
                             <div className="text-xs text-faint">
                               {t(SDK_LABEL_KEY[p.sdk_type])}
                             </div>
@@ -358,16 +387,19 @@ export function ProviderKeysSection() {
 /* ── 인라인 키 추가 폼 ──────────────────────────────────── */
 function AddKeyForm({
   providers,
+  initialProviderId,
   onClose,
   onSaved,
 }: {
   providers: ProviderEntry[];
+  /** 연결 스트립에서 고른 공급자(없으면 첫 항목) */
+  initialProviderId?: string | null;
   onClose: () => void;
   onSaved: () => void | Promise<void>;
 }) {
   const t = useTranslations("apiKeys");
   const [providerId, setProviderId] = useState(
-    providers[0]?.provider_id ?? "anthropic",
+    initialProviderId ?? providers[0]?.provider_id ?? "anthropic",
   );
   const [displayName, setDisplayName] = useState("");
   const [apiKey, setApiKey] = useState("");
@@ -456,6 +488,11 @@ function AddKeyForm({
                   </option>
                 ))}
               </select>
+              {selected && (
+                <span className="mt-1 block">
+                  <ProviderSiteLink provider={selected} withLabel />
+                </span>
+              )}
               {selected?.help_text && (
                 <span className="mt-1 block text-xs leading-relaxed text-muted">
                   {selected.help_text}
@@ -650,6 +687,91 @@ function OAuthConnect({
         {t("oauthLogin")}
       </Button>
       {oauthError && <p className="text-xs text-danger">{oauthError}</p>}
+    </div>
+  );
+}
+
+/* ── 공급자 사이트 링크 (키 발급 페이지 > 홈페이지) ─────────── */
+function ProviderSiteLink({
+  provider,
+  withLabel = false,
+}: {
+  provider: ProviderEntry;
+  withLabel?: boolean;
+}) {
+  const pt = useTranslations("providerKeys");
+  const href = provider.key_url || provider.homepage;
+  if (!href) return null;
+  const isOAuth =
+    !!provider.auth_methods?.includes("oauth") &&
+    !provider.auth_methods.includes("api_key");
+  const label = isOAuth ? pt("signInPage") : provider.key_url ? pt("keyPage") : pt("homepage");
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={label}
+      aria-label={`${provider.display_name} — ${label}`}
+      className="inline-flex items-center gap-1 text-xs font-normal text-accent hover:underline"
+      onClick={(e) => e.stopPropagation()}
+    >
+      {withLabel && label}
+      <ExternalLink className="h-3.5 w-3.5" />
+    </a>
+  );
+}
+
+/* ── 연결 가능한 공급자 스트립 ────────────────────────────── */
+function ProviderStrip({
+  providers,
+  onConnect,
+}: {
+  providers: ProviderEntry[];
+  onConnect: (providerId: string) => void;
+}) {
+  const pt = useTranslations("providerKeys");
+  return (
+    <div>
+      <p className="mb-2 font-mono text-[11px] uppercase tracking-[0.14em] text-muted">
+        {pt("stripLabel")}
+      </p>
+      <ul className="flex flex-wrap gap-2">
+        {providers.map((p) => {
+          const connected = !!p.user_key;
+          const isOAuth =
+            !!p.auth_methods?.includes("oauth") && !p.auth_methods.includes("api_key");
+          return (
+            <li key={p.provider_id}>
+              <div
+                className={`flex items-center gap-2 rounded-lg border px-3 py-2 ${
+                  connected ? "border-accent/40 bg-accent/5" : "border-border bg-surface"
+                }`}
+              >
+                <button
+                  type="button"
+                  onClick={() => onConnect(p.provider_id)}
+                  title={isOAuth ? pt("connectOAuth") : pt("connect")}
+                  className="flex items-center gap-2 text-left"
+                >
+                  {p.logo && (
+                    <Image src={p.logo} alt="" width={24} height={24} className="h-6 w-6 shrink-0" />
+                  )}
+                  <span className="text-sm font-medium text-fg">{p.display_name}</span>
+                  {connected ? (
+                    <Badge tone="success">{pt("connected")}</Badge>
+                  ) : (
+                    <span className="text-xs text-muted">
+                      {isOAuth ? pt("connectOAuth") : pt("connect")}
+                    </span>
+                  )}
+                </button>
+                <ProviderSiteLink provider={p} />
+              </div>
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1483,7 +1483,14 @@
     "validateOk": "Verification succeeded",
     "validateFailed": "Verification failed: {error}",
     "usageSummary": "Last {days}d · {calls} calls · {tokens} tokens",
-    "error": "Error"
+    "error": "Error",
+    "stripLabel": "Works with",
+    "connect": "Connect",
+    "connectOAuth": "Connect with sign-in",
+    "connected": "Connected",
+    "keyPage": "API key page",
+    "signInPage": "Sign-in page",
+    "homepage": "Homepage"
   },
   "apiKeys": {
     "title": "API Keys",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1483,7 +1483,14 @@
     "validateOk": "検証に成功しました",
     "validateFailed": "検証に失敗しました: {error}",
     "usageSummary": "直近{days}日 · {calls}回呼び出し · {tokens}トークン",
-    "error": "エラー"
+    "error": "エラー",
+    "stripLabel": "つながるAI",
+    "connect": "接続",
+    "connectOAuth": "ログインで接続",
+    "connected": "接続済み",
+    "keyPage": "APIキー発行ページ",
+    "signInPage": "認証ページ",
+    "homepage": "ホームページ"
   },
   "apiKeys": {
     "title": "APIキー",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1483,7 +1483,14 @@
     "validateOk": "검증 성공",
     "validateFailed": "검증 실패: {error}",
     "usageSummary": "최근 {days}일 · {calls}회 호출 · {tokens} 토큰",
-    "error": "오류"
+    "error": "오류",
+    "stripLabel": "이런 AI를 연결합니다",
+    "connect": "연결",
+    "connectOAuth": "로그인으로 연결",
+    "connected": "연결됨",
+    "keyPage": "API 키 발급 페이지",
+    "signInPage": "인증 페이지",
+    "homepage": "홈페이지"
   },
   "apiKeys": {
     "title": "API 키",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1483,7 +1483,14 @@
     "validateOk": "验证成功",
     "validateFailed": "验证失败：{error}",
     "usageSummary": "近{days}天 · {calls}次调用 · {tokens} 令牌",
-    "error": "错误"
+    "error": "错误",
+    "stripLabel": "可以接入",
+    "connect": "连接",
+    "connectOAuth": "登录连接",
+    "connected": "已连接",
+    "keyPage": "API 密钥页面",
+    "signInPage": "认证页面",
+    "homepage": "官网"
   },
   "apiKeys": {
     "title": "API 密钥",

--- a/apps/web/public/images/providers/bai.svg
+++ b/apps/web/public/images/providers/bai.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" role="img" aria-label="B.AI">
+  <rect x="5.5" y="5.5" width="37" height="37" rx="10.5" fill="none" stroke="#FF6A3D" stroke-width="3"/>
+  <path d="M17.5 14.5h6a4.75 4.75 0 0 1 0 9.5h-6Zm0 9.5h7a4.75 4.75 0 0 1 0 9.5h-7Z" fill="none" stroke="#FF6A3D" stroke-width="3" stroke-linejoin="round"/>
+</svg>

--- a/apps/web/public/images/providers/chatgpt.svg
+++ b/apps/web/public/images/providers/chatgpt.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" role="img" aria-label="ChatGPT subscription sign-in">
+  <path d="M9 10h30a3 3 0 0 1 3 3v18a3 3 0 0 1-3 3H23l-9 7v-7H9a3 3 0 0 1-3-3V13a3 3 0 0 1 3-3Z" fill="none" stroke="#12A37E" stroke-width="2.6" stroke-linejoin="round"/>
+  <g fill="none" stroke="#12A37E" stroke-width="2.6" stroke-linecap="round">
+    <circle cx="20" cy="21" r="4.5"/>
+    <path d="M24.5 21H34M31 21v4M34 21v3.5"/>
+  </g>
+</svg>

--- a/apps/web/public/images/providers/hasa.svg
+++ b/apps/web/public/images/providers/hasa.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" role="img" aria-label="Open AI Service Hub">
+  <g fill="none" stroke="#0E9AA7" stroke-width="3" stroke-linecap="round">
+    <path d="M24 18V10M24 30v8M18 24h-8M30 24h8"/>
+  </g>
+  <circle cx="24" cy="24" r="6" fill="none" stroke="#0E9AA7" stroke-width="3"/>
+  <g fill="#0E9AA7">
+    <circle cx="24" cy="8" r="3.2"/><circle cx="24" cy="40" r="3.2"/>
+    <circle cx="8" cy="24" r="3.2"/><circle cx="40" cy="24" r="3.2"/>
+  </g>
+</svg>

--- a/apps/web/public/images/providers/nvidia-nim.svg
+++ b/apps/web/public/images/providers/nvidia-nim.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" role="img" aria-label="NVIDIA NIM">
+  <path d="M24 5.5 39 14v17L24 39.5 9 31V14Z" fill="none" stroke="#79B900" stroke-width="2.6" stroke-linejoin="round"/>
+  <path d="M18.5 29.5v-12l11 12v-12" fill="none" stroke="#79B900" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/apps/web/public/images/providers/ollama-cloud.svg
+++ b/apps/web/public/images/providers/ollama-cloud.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" role="img" aria-label="Ollama Cloud">
+  <path d="M15.5 33a8 8 0 0 1-.7-15.97 10 10 0 0 1 19.02 2.2A7.4 7.4 0 0 1 33 33Z" fill="none" stroke="#5B6778" stroke-width="3" stroke-linejoin="round"/>
+  <g fill="none" stroke="#5B6778" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <path d="m19 41 3.5-3.5L19 34"/>
+    <path d="M27 41h5"/>
+  </g>
+</svg>

--- a/apps/web/public/images/providers/openrouter.svg
+++ b/apps/web/public/images/providers/openrouter.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" role="img" aria-label="OpenRouter">
+  <g fill="none" stroke="#5B62F0" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M6 24h7c3 0 4.5-4 7.5-4h6"/>
+    <path d="M6 24h7c3 0 4.5 8 7.5 8h6"/>
+    <path d="M26.5 20h6"/>
+    <path d="M33 16.5 37.5 20 33 23.5"/>
+    <path d="M33 28.5 37.5 32 33 35.5"/>
+  </g>
+  <circle cx="6" cy="24" r="3.4" fill="#5B62F0"/>
+</svg>


### PR DESCRIPTION
## 요약
설정 → 모델&응답 → API 키에 www.openmake.cc 의 "이런 AI를 연결합니다" 와 같은 **공급자 로고 스트립**을 넣고, 각 공급자를 **API 키 발급 페이지(또는 인증 페이지)** 로 바로 연결한다.

- **백엔드**: 카탈로그(`config/external-providers.ts`)에 `homepage`·`keyUrl`·`logo` 메타(L2 config, 프론트 하드코딩 없음). `GET /api/external-keys` 가 `homepage`/`key_url`/`logo` 노출.
  | 공급자 | 링크 |
  |---|---|
  | OpenRouter | https://openrouter.ai/settings/keys |
  | ChatGPT | OAuth 전용 → keyUrl 없음, 앱 안 디바이스 로그인(homepage 폴백) |
  | Ollama Cloud | https://ollama.com/settings/keys |
  | NVIDIA NIM | https://build.nvidia.com/settings/api-keys |
  | Open AI Service Hub | https://open.hasa.re.kr/account/dev-keys |
  | B.AI | https://b.ai (키 페이지 미공개 — 문서에도 없음) |
- **프론트**: 스트립 칩 클릭 → 그 공급자로 키 입력 폼(OAuth 는 로그인 버튼) 열림, 옆 ↗ 아이콘은 키 발급/인증 페이지 새 탭. 등록 표의 공급자 열과 폼의 공급자 선택 아래에도 로고·링크. 연결된 공급자는 "연결됨" 배지.
- 로고 SVG 6종은 www 와 같은 자산을 `apps/web/public/images/providers/` 로 복사, `next/image` 렌더. i18n 4 locale.
- 테스트: 카탈로그 전 항목 https homepage + 로고 파일 실재 + OAuth 전용은 keyUrl 없음.

## 검증
- api/web `tsc` 0 · eslint 0 error · jest 신규 2건
- 로컬 `next dev`(:3100) + Playwright(user 3): 로고 11개 로드, 외부 링크 11개 정확, ChatGPT 칩 → OAuth 로그인 폼, NVIDIA 칩 → 키 폼 preselect. 백엔드 새 필드는 운영 API 미배포라 route 주입으로 확인 — 배포 후 실응답 재확인 필요.
- 스크린샷은 세션에 첨부.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mAMGPdenUaxVgpfPb4dfo