### PR TITLE
fix(model-roles): 외부 provider 역할 배정 — B.AI 프로브 max_tokens 하한 + 목록 밖 배정값 표시

### DIFF
--- a/apps/api/src/config/model-defaults.ts
+++ b/apps/api/src/config/model-defaults.ts
@@ -82,7 +82,13 @@ export const MODEL_CAPABILITY_PRESETS: Readonly<Record<string, ModelCapabilities
  */
 /** 모델 가용성/자격 프로브 공통 상수 — 과금·부하 최소화를 위한 1토큰 최소 호출 */
 export const MODEL_PROBE = {
-    MAX_TOKENS: 1,
+    /**
+     * 프로브(가용성·역할 배정 검증·로컬 도구/thinking 프로브) 1회 출력 상한.
+     * ⚠️ 1 로 두면 B.AI 가 `max_tokens must be greater than 2` 400 을 돌려줘 가용성 프로브는
+     * 영구 '보류', 역할 배정은 항상 거절됐다(2026-09-08 라이브 — 같은 모델이 채팅에선 정상).
+     * 8 은 실측(B.AI·NVIDIA·hasa) 전부 200 이고 비용 차이는 무시할 수준.
+     */
+    MAX_TOKENS: 8,
 } as const;
 
 export const FALLBACK_CAPABILITIES: ModelCapabilities = {

--- a/apps/api/src/config/model-probe.test.ts
+++ b/apps/api/src/config/model-probe.test.ts
@@ -1,0 +1,12 @@
+/**
+ * MODEL_PROBE.MAX_TOKENS 회귀 가드 — 1 이면 B.AI 가 `max_tokens must be greater than 2` 400 을
+ * 돌려줘 가용성 프로브는 영구 '보류', 역할 배정은 항상 거절된다(2026-09-08 라이브 실측).
+ */
+import { MODEL_PROBE } from './model-defaults';
+
+describe('MODEL_PROBE', () => {
+    test('프로브 max_tokens 는 B.AI 하한(>2)을 넘고 비용을 위해 소량으로 유지한다', () => {
+        expect(MODEL_PROBE.MAX_TOKENS).toBeGreaterThan(2);
+        expect(MODEL_PROBE.MAX_TOKENS).toBeLessThanOrEqual(16);
+    });
+});

--- a/apps/web/components/settings/model-roles-section.tsx
+++ b/apps/web/components/settings/model-roles-section.tsx
@@ -153,6 +153,16 @@ export function ModelRolesSection() {
                       onChange={(e) => void handleChange(role, e.target.value)}
                     >
                       <option value={DEFAULT_VALUE}>{t("defaultOption")}</option>
+                      {/* 저장된 배정이 usableOnly 목록(20B 이하·채팅 불가 제외) 밖이면 — 예: 요약 역할에
+                          gpt-oss-20b 를 배정한 뒤 — <select> 가 첫 옵션 "기본(자동)" 을 보여 배정이 없는
+                          것처럼 오인된다(2026-09-08 라이브: 배정됨 배지는 뜨는데 값은 기본). 값을 보존하는
+                          옵션을 덧붙여 실제 배정을 표시한다(model-picker 의 "(목록에 없음)" 과 같은 규칙). */}
+                      {current !== DEFAULT_VALUE &&
+                        !models.some((m) => m.modelId === current) && (
+                          <option value={current}>
+                            {current} {t("notInList")}
+                          </option>
+                        )}
                       {models.map((m) => (
                         <option key={m.modelId} value={m.modelId}>
                           {m.name}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1578,7 +1578,8 @@
         "label": "Thinking Summary",
         "description": "Model that generates thinking headline summaries"
       }
-    }
+    },
+    "notInList": "(not in list)"
   },
   "adminModelRoles": {
     "title": "Model Roles Admin",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1578,7 +1578,8 @@
         "label": "思考要約",
         "description": "思考プロセスのヘッドラインを生成するモデル"
       }
-    }
+    },
+    "notInList": "（一覧にない）"
   },
   "adminModelRoles": {
     "title": "ロールモデル管理",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1578,7 +1578,8 @@
         "label": "생각 요약",
         "description": "생각 과정 헤드라인을 생성하는 모델"
       }
-    }
+    },
+    "notInList": "(목록에 없음)"
   },
   "adminModelRoles": {
     "title": "역할 모델 관리",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1578,7 +1578,8 @@
         "label": "思考摘要",
         "description": "生成思考过程标题摘要的模型"
       }
-    }
+    },
+    "notInList": "（不在列表中）"
   },
   "adminModelRoles": {
     "title": "角色模型管理",


### PR DESCRIPTION
## 점검 결과 (설정 → 모델&응답 → 역할별 모델 배정, user 3 라이브)

**정상**
- `agent=hasa:qwen3-coder` 배정 → 에이전트 작업 3턴 완주, 로그 `agent role 외부 모델 사용: hasa:qwen3-coder`, `external_provider_usage` 에 hasa 3행 귀속
- `summary=hasa:gpt-oss-20b` 배정 → thinking 채팅에서 헤드라인 요약이 hasa gpt-oss-20b 로 호출(usage 1행)
- 검증 거절: 키 미등록(`chatgpt:gpt-5.4`)·존재하지 않는 모델(openrouter)·계정에서 404 인 모델(`nvidia/nemotron-nano-3-30b-a3b`) 전부 400

**결함 2건 (이 PR)**
1. **B.AI 모델은 배정이 항상 거절** — 프로브 `max_tokens: 1` 에 B.AI 가 `max_tokens must be greater than 2` 400. 같은 이유로 가용성 프로브도 영구 '보류'. 직결 실측 1→400, 8→200(NVIDIA·hasa 는 1·8·64 전부 200) → `MODEL_PROBE.MAX_TOKENS` 1→8 + 회귀 테스트.
2. **목록 밖 배정값이 "기본(자동)" 으로 표시** — usableOnly 목록이 20B 이하를 제외해 `hasa:gpt-oss-20b` 같은 배정이 select 에 없고, 배정됨 배지만 뜬 채 값은 기본으로 보였다(스크린샷). "(목록에 없음)" 옵션으로 값 보존·표시(#791 model-picker 규칙).

## 검증
- api/web tsc 0 · eslint 0 · jest(config 13 suites 105 + 신규 1)
- 테스트 배정·세션·작업은 전부 원복/삭제(user 3 매핑 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mAMGPdenUaxVgpfPb4dfo