### PR TITLE
fix(web): 역할별 모델 배정 select 흰 배경·회색 글자 — 미정의 색 클래스 교체

### DIFF
--- a/apps/web/app/(workspace)/admin/model-roles/page.tsx
+++ b/apps/web/app/(workspace)/admin/model-roles/page.tsx
@@ -105,8 +105,8 @@ function ServerKeyForm({ providers, onSaved }: {
           {t("keyForm.save")}
         </Button>
       </div>
-      <p className="text-xs text-muted-foreground">{t("keyForm.dailyLimitHelp")}</p>
-      {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
+      <p className="text-xs text-muted">{t("keyForm.dailyLimitHelp")}</p>
+      {error && <p className="text-sm text-danger" role="alert">{error}</p>}
     </div>
   );
 }
@@ -179,7 +179,7 @@ export default function AdminModelRolesPage() {
       <PageHeader title={t("title")} description={t("description")} />
 
       <AdminTabs />
-      {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
+      {error && <p className="text-sm text-danger" role="alert">{error}</p>}
 
       <Card>
         <CardHeader>
@@ -189,7 +189,7 @@ export default function AdminModelRolesPage() {
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <p className="text-sm text-muted-foreground">{t("serverKeys.description")}</p>
+          <p className="text-sm text-muted">{t("serverKeys.description")}</p>
           {serverKeys && serverKeys.keys.length > 0 && (
             <Table>
               <thead>
@@ -233,7 +233,7 @@ export default function AdminModelRolesPage() {
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
-          <p className="text-sm text-muted-foreground">{t("globalRoles.description")}</p>
+          <p className="text-sm text-muted">{t("globalRoles.description")}</p>
           {(roles?.roles ?? []).map((role) => (
             <div key={role} className="flex flex-col gap-2 rounded-lg border p-3 sm:flex-row sm:items-center">
               <div className="flex min-w-36 items-center gap-2">
@@ -254,7 +254,7 @@ export default function AdminModelRolesPage() {
               </Button>
             </div>
           ))}
-          <p className="text-xs text-muted-foreground">{t("globalRoles.cacheNote")}</p>
+          <p className="text-xs text-muted">{t("globalRoles.cacheNote")}</p>
         </CardContent>
       </Card>
     </div>

--- a/apps/web/app/(workspace)/admin/schedules/page.tsx
+++ b/apps/web/app/(workspace)/admin/schedules/page.tsx
@@ -86,7 +86,7 @@ export default function AdminSchedulesPage() {
       <PageHeader title={t("title")} description={t("description")} />
 
       <AdminTabs />
-      {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
+      {error && <p className="text-sm text-danger" role="alert">{error}</p>}
 
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
@@ -103,7 +103,7 @@ export default function AdminSchedulesPage() {
         </CardHeader>
         <CardContent>
           {schedules.length === 0 && !loading ? (
-            <p className="py-8 text-center text-sm text-muted-foreground">{t("empty")}</p>
+            <p className="py-8 text-center text-sm text-muted">{t("empty")}</p>
           ) : (
             <Table>
               <thead>

--- a/apps/web/app/(workspace)/admin/system-settings/page.tsx
+++ b/apps/web/app/(workspace)/admin/system-settings/page.tsx
@@ -200,7 +200,7 @@ export default function AdminSystemSettingsPage() {
           (admin/alerts 등과 동일 관용구 — 누락 시 뷰포트 아래 내용 접근 불가) */}
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
         <div className="space-y-6">
-      {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
+      {error && <p className="text-sm text-danger" role="alert">{error}</p>}
       {restartKeys.length > 0 && (
         <div className="flex items-start gap-2 rounded-lg border border-warn/40 bg-warn-soft p-3 text-sm" role="status">
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warn" aria-hidden />
@@ -221,7 +221,7 @@ export default function AdminSystemSettingsPage() {
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">
-              <p className="text-sm text-muted-foreground">{t(`groups.${group}.description`)}</p>
+              <p className="text-sm text-muted">{t(`groups.${group}.description`)}</p>
               {items.map((s) => (
                 <SettingRow key={s.key} setting={s} busy={busyKey === s.key} onSave={save} onReset={reset} />
               ))}
@@ -230,7 +230,7 @@ export default function AdminSystemSettingsPage() {
         );
       })}
 
-      <p className="text-xs text-muted-foreground">{t("priorityNote")}</p>
+      <p className="text-xs text-muted">{t("priorityNote")}</p>
         </div>
       </div>
     </>

--- a/apps/web/components/settings/model-roles-section.tsx
+++ b/apps/web/components/settings/model-roles-section.tsx
@@ -102,17 +102,17 @@ export function ModelRolesSection() {
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <p className="text-sm text-muted-foreground">{t("description")}</p>
-        <p className="text-xs text-muted-foreground">{t("externalNote")}</p>
+        <p className="text-sm text-muted">{t("description")}</p>
+        <p className="text-xs text-muted">{t("externalNote")}</p>
 
         {error && (
-          <p className="text-sm text-destructive" role="alert">
+          <p className="text-sm text-danger" role="alert">
             {error}
           </p>
         )}
 
         {loading ? (
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <div className="flex items-center gap-2 text-sm text-muted">
             <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
             {t("loading")}
           </div>
@@ -137,16 +137,16 @@ export function ModelRolesSection() {
                         </Badge>
                       )}
                     </div>
-                    <p className="text-xs text-muted-foreground">
+                    <p className="text-xs text-muted">
                       {t(`roles.${role}.description`)}
                     </p>
                   </div>
                   <div className="flex shrink-0 items-center gap-2">
                     {saving && (
-                      <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" aria-hidden />
+                      <Loader2 className="h-4 w-4 animate-spin text-muted" aria-hidden />
                     )}
                     <select
-                      className="h-9 min-w-52 rounded-md border bg-background px-2 text-sm"
+                      className="h-9 min-w-52 rounded-md border border-border-strong bg-surface px-2 text-sm text-fg outline-none focus:border-accent"
                       value={current}
                       disabled={saving}
                       aria-label={t(`roles.${role}.label`)}
@@ -186,7 +186,7 @@ export function ModelRolesSection() {
               );
             })}
             {roles.length === 0 && !error && (
-              <p className="text-sm text-muted-foreground">{t("empty")}</p>
+              <p className="text-sm text-muted">{t("empty")}</p>
             )}
           </div>
         )}


### PR DESCRIPTION
## 원인
`model-roles-section` 의 select 가 `bg-background`(+ `text-muted-foreground`·`text-destructive`)를 쓰는데, 이 앱의 Instrument 토큰(`@theme`)엔 `background`/`muted-foreground`/`destructive` 가 없어 클래스가 아무 스타일도 내지 않았다. 배경·글자색이 비어 네이티브 드롭다운이 **흰 배경·회색 글자**로 열렸고(다크 테마에서 글자 안 보임), 오류 문구도 빨간색이 아니었다.

## 수정
- select → `border-border-strong bg-surface text-fg focus:border-accent`(provider-keys-section 과 동일)
- `text-muted-foreground`→`text-muted`, `text-destructive`→`text-danger` — 같은 미정의 클래스를 쓰던 admin model-roles·schedules·system-settings 페이지 포함(앱 전체 잔존 0)

## 검증
- web tsc 0 · eslint 0
- 로컬 next dev(다크) 실측: select `rgb(18,21,26)` 배경 · `rgb(231,234,239)` 글자, option 글자 동일(스크린샷 세션 첨부)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mAMGPdenUaxVgpfPb4dfo