### PR TITLE
fix(memory): memoryLearning 설정 조회 실패 시 fail-closed

### DIFF
--- a/apps/api/src/services/chat-service/memory-policy.test.ts
+++ b/apps/api/src/services/chat-service/memory-policy.test.ts
@@ -37,9 +37,10 @@ describe('resolveMemoryLearning', () => {
         expect(await resolveMemoryLearning('u1')).toBe(true);
         expect(await resolveMemoryLearning('u1', false)).toBe(false);
     });
-    it('조회 실패는 fail-open (클라이언트 플래그 기준)', async () => {
+    it('조회 실패는 fail-closed — 클라이언트가 true 를 보내도 OFF (설정 장애가 끈 메모리를 다시 켜지 않는다)', async () => {
         getPreferences.mockRejectedValue(new Error('db down'));
-        expect(await resolveMemoryLearning('u1')).toBe(true);
+        expect(await resolveMemoryLearning('u1')).toBe(false);
+        expect(await resolveMemoryLearning('u1', true)).toBe(false);
         expect(await resolveMemoryLearning('u1', false)).toBe(false);
     });
 });

--- a/apps/api/src/services/chat-service/memory-policy.ts
+++ b/apps/api/src/services/chat-service/memory-policy.ts
@@ -8,7 +8,9 @@
  *
  * 규칙: 서버 설정 false 면 무조건 OFF. 서버 설정이 없거나 true 면 클라이언트 플래그가
  * 명시 false 일 때만 OFF(클라이언트는 더 제한할 수만 있고 켤 수는 없다). 조회 실패는
- * fail-open(클라이언트 플래그 기준) — 설정 조회 장애가 채팅을 막지 않는다.
+ * **fail-closed(OFF)** — 프라이버시 토글은 값을 모를 때 켜지면 안 된다(2026-09-08 외부 리뷰
+ * 지적 반영: 종전엔 클라이언트 플래그로 폴백해 설정 조회 장애가 사용자가 끈 메모리를 다시
+ * 켰다). OFF 는 이 턴의 메모리 주입·자동 저장만 건너뛰고 채팅 자체는 막지 않는다.
  *
  * @module services/chat-service/memory-policy
  */
@@ -34,7 +36,7 @@ export async function resolveMemoryLearning(userId: string | undefined, clientFl
         const prefs = await new UserRepository(getPool()).getPreferences(userId);
         return effectiveMemoryLearning(prefs.memoryLearning, clientFlag);
     } catch (e) {
-        logger.warn('memoryLearning 설정 조회 실패 — 클라이언트 플래그로 폴백:', e);
-        return effectiveMemoryLearning(undefined, clientFlag);
+        logger.warn('memoryLearning 설정 조회 실패 — 이 턴은 메모리 OFF(fail-closed):', e);
+        return false;
     }
 }


### PR DESCRIPTION
## 배경
외부 리뷰(Agent Memory Atlas 3차) 지적 중 유일하게 남은 실질 항목. `resolveMemoryLearning` 이 `users.preferences` 조회 예외에서 **클라이언트 플래그로 폴백**해, WS 가 플래그를 안 보내면 사용자가 꺼 둔 메모리가 그 턴에 다시 켜졌다.

## 수정
- 조회 실패 → `false`(fail-closed). 이 턴의 메모리 주입·자동 저장만 건너뛰고 채팅은 진행.
- 테스트: 조회 실패 시 클라이언트 true/미지정/false 전부 OFF — 수정을 되돌리면 1건 실패 확인.

## 검증
- jest memory-policy 6 · memory-extraction 19 통과, tsc 0, eslint 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrpsyFfLjMcNyrffUdCVmL