### PR TITLE
feat(compare): 모델 비교 모드에 Thinking 토글 추가

### DIFF
--- a/apps/web/components/chat/compare-view.tsx
+++ b/apps/web/components/chat/compare-view.tsx
@@ -10,7 +10,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
-import { RotateCcw, Send, Square } from "lucide-react";
+import { Brain, RotateCcw, Send, Square } from "lucide-react";
 import { ModelPicker, type PickerModel } from "@/components/model-picker";
 import { Markdown } from "@/components/chat/markdown";
 import { fetchModels } from "@/lib/models-api";
@@ -214,6 +214,8 @@ export function CompareView() {
   }, [modelA, modelB]);
 
   const [text, setText] = useState("");
+  // Thinking 토글 — 두 레인에 같은 값으로 실린다(모델 차이만 비교되도록 다른 변수는 고정).
+  const [thinking, setThinking] = useState(false);
   const taRef = useRef<HTMLTextAreaElement | null>(null);
 
   const anyStreaming = laneA.streaming || laneB.streaming;
@@ -224,8 +226,8 @@ export function CompareView() {
     const prompt = text.trim();
     if (!prompt || !bothConnected || anyStreaming) return;
     // 같은 틱에 두 레인으로 — 서버는 lane 접미사로 스트림을 분리해 서로를 끊지 않는다.
-    laneA.send(prompt, modelA);
-    laneB.send(prompt, modelB);
+    laneA.send(prompt, modelA, { thinking });
+    laneB.send(prompt, modelB, { thinking });
     setText("");
     const ta = taRef.current;
     if (ta) ta.style.height = "auto";
@@ -284,14 +286,30 @@ export function CompareView() {
             className="block w-full resize-none bg-transparent px-4 pt-2.5 text-sm text-fg outline-none placeholder:text-muted"
           />
           <div className="flex items-center justify-between gap-2 px-2.5 pb-2.5 pt-1">
-            <button
-              type="button"
-              onClick={reset}
-              className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs text-muted transition hover:bg-surface-2 hover:text-fg"
-            >
-              <RotateCcw className="h-3.5 w-3.5" aria-hidden />
-              {t("reset")}
-            </button>
+            <div className="flex items-center gap-1.5">
+              <button
+                type="button"
+                onClick={reset}
+                className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs text-muted transition hover:bg-surface-2 hover:text-fg"
+              >
+                <RotateCcw className="h-3.5 w-3.5" aria-hidden />
+                {t("reset")}
+              </button>
+              {/* Thinking 토글 — 컴포저의 모드 칩과 같은 시각 언어(켜짐=accent 테두리). */}
+              <button
+                type="button"
+                onClick={() => setThinking((v) => !v)}
+                aria-pressed={thinking}
+                title={thinking ? t("thinkingOff") : t("thinkingOn")}
+                className={cn(
+                  "inline-flex shrink-0 items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium transition hover:opacity-80",
+                  thinking ? "border-accent bg-accent-soft text-accent" : "border-border text-muted",
+                )}
+              >
+                <Brain className="h-3.5 w-3.5" aria-hidden />
+                {t("thinkingToggle")}
+              </button>
+            </div>
             <div className="flex items-center gap-1.5">
               {/* 같은 모델을 고른 경우(목록이 하나뿐일 때 포함) — 비교가 성립하지 않음을 알린다. */}
               {modelA === modelB && (

--- a/apps/web/lib/use-compare-lane.ts
+++ b/apps/web/lib/use-compare-lane.ts
@@ -33,12 +33,18 @@ export interface CompareMessage {
   metrics?: { tokensPerSec: string; tokenCount: number };
 }
 
+/** 전송 옵션 — 모델 외 변수는 기본 고정이고, 여기 있는 것만 사용자가 켤 수 있다. */
+export interface CompareSendOptions {
+  /** Thinking(추론) — 켜면 store 의 thinkingLevel 을 함께 실어 메인 채팅과 같은 강도로 돈다. */
+  thinking?: boolean;
+}
+
 export interface CompareLane {
   messages: CompareMessage[];
   sessionId: string | null;
   connected: boolean;
   streaming: boolean;
-  send: (prompt: string, model: string) => void;
+  send: (prompt: string, model: string, opts?: CompareSendOptions) => void;
   abort: () => void;
   reset: () => void;
 }
@@ -268,7 +274,7 @@ export function useCompareLane(lane: CompareLaneId): CompareLane {
   }, [connect]);
 
   const send = useCallback(
-    (prompt: string, model: string) => {
+    (prompt: string, model: string, opts?: CompareSendOptions) => {
       const message = prompt.trim();
       if (!message || streamingRef.current) return;
 
@@ -311,7 +317,9 @@ export function useCompareLane(lane: CompareLaneId): CompareLane {
         files: [],
         deepResearchMode: false,
         discussionMode: false,
-        thinkingMode: false,
+        thinkingMode: opts?.thinking === true,
+        // 추론 강도 — 토글이 켜진 경우에만 의미(서버가 thinkingMode=false 면 무시). 메인 훅과 동일.
+        ...(opts?.thinking ? { thinkingLevel: s.thinkingLevel } : {}),
         style: s.style,
         enabledTools: s.mcpToolsEnabled,
         // 비교 모드는 서버에 남기지 않는다 — 레인마다 세션이 하나씩 생겨 사이드바에 "반쪽 대화"가

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -457,7 +457,10 @@
     "emptyPane": "No answer yet.",
     "tokensPerSec": "{value} tok/s",
     "sameModelHint": "Both panes use the same model. Pick a different one to compare.",
-    "thinking": "Reasoning"
+    "thinking": "Reasoning",
+    "thinkingToggle": "Thinking",
+    "thinkingOn": "Turn Thinking on",
+    "thinkingOff": "Turn Thinking off"
   },
   "artifacts": {
     "exec": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -457,7 +457,10 @@
     "emptyPane": "まだ回答がありません。",
     "tokensPerSec": "{value} tok/s",
     "sameModelHint": "両パネルが同じモデルです。比較するには別のモデルを選んでください。",
-    "thinking": "推論の過程"
+    "thinking": "推論の過程",
+    "thinkingToggle": "思考",
+    "thinkingOn": "思考をオン",
+    "thinkingOff": "思考をオフ"
   },
   "artifacts": {
     "exec": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -457,7 +457,10 @@
     "emptyPane": "아직 답변이 없습니다.",
     "tokensPerSec": "{value} tok/s",
     "sameModelHint": "두 패널이 같은 모델입니다 — 다른 모델을 골라야 비교가 됩니다.",
-    "thinking": "추론 과정"
+    "thinking": "추론 과정",
+    "thinkingToggle": "Thinking",
+    "thinkingOn": "Thinking 켜기",
+    "thinkingOff": "Thinking 끄기"
   },
   "artifacts": {
     "exec": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -457,7 +457,10 @@
     "emptyPane": "暂无回答。",
     "tokensPerSec": "{value} tok/s",
     "sameModelHint": "两个面板使用同一模型，请选择不同模型以进行比较。",
-    "thinking": "推理过程"
+    "thinking": "推理过程",
+    "thinkingToggle": "思考",
+    "thinkingOn": "开启思考",
+    "thinkingOff": "关闭思考"
   },
   "artifacts": {
     "exec": {


### PR DESCRIPTION
## 요약
- `/compare` 입력창에 **Thinking 칩** 추가 — 켜면 두 레인 모두 `thinkingMode:true` + store 의 `thinkingLevel` 을 실어 보낸다(메인 채팅 훅과 같은 규약). 기본 꺼짐.
- `useCompareLane.send(prompt, model, opts?)` 에 `CompareSendOptions { thinking? }` 추가.
- i18n 4 locale `compare.thinkingToggle/thinkingOn/thinkingOff`.

## 넣지 않은 것
- **웹검색 토글** — #648(2026-08-27, 자동 발동 기능은 채팅 토글에서 제외) 결정과 충돌. 비교 모드도 같은 백엔드 경로라 `web_search` 는 이미 의도 감지로 자동 발동한다.

## 검증
- `apps/web` tsc 0 · eslint 0
- 백엔드 변경 없음(계약 필드 기존 `thinkingMode`/`thinkingLevel` 사용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4t1YsscLf9Doss8vahfwY