### PR TITLE
feat(install): 기본 설치 위치 ~/.openmake/chat + --instance NAME 병행 설치 + --public-url + db-dump/db-restore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -895,6 +895,18 @@ LANGUAGE_FALLBACK_LANGUAGE=en
 # 사용자 신고 보존 TTL (ms, 기본값: 7일 = 604800000)
 # OMK_DEBUG_QUEUE_USER_REPORT_TTL_MS=604800000
 
+# ── 인스턴스 병행 (선택 — install.sh --instance NAME 이 기록) ──────────
+# 같은 호스트에 설치본 여러 개를 나란히 띄울 때의 이름표. PM2 앱이 openmake-llm-NAME /
+# openmake-next-NAME, docker 컨테이너·볼륨이 openmake-NAME-postgres / openmake-NAME_pgdata 가 된다
+# (scripts/resolve-ports.cjs · infra/docker-compose.yml). 미설정 = 기본 인스턴스(접미사 없음).
+# COMPOSE_PROJECT_NAME 은 compose 프로젝트 분리용 — 두 설치본이 같은 프로젝트(infra)로 잡히면
+# compose 가 상대 컨테이너를 재생성한다. OMK_INSTANCE 와 항상 짝으로 둔다.
+# OMK_INSTANCE=test
+# COMPOSE_PROJECT_NAME=openmake-test
+# 웹(Next) 포트. 미설정 시 OMK_APP_URL 끝의 포트, 그것도 없으면 3000 — 공개 주소에 포트가
+# 없는 배포(https://chat.example.com)에서 3000 이 아닌 포트를 쓰면 반드시 명시한다.
+# OMK_WEB_PORT=3010
+
 # ── OpenRouter attribution headers (선택) ─────────────────────────────
 # OpenRouter rankings (https://openrouter.ai/rankings) 에 본 앱이 노출되도록
 # OpenAICompatProvider constructor (openai-compat-provider.ts:280-313) 가

--- a/README.ja.md
+++ b/README.ja.md
@@ -195,7 +195,7 @@ curl -fsSL https://raw.githubusercontent.com/openmake/openmake_llm/main/install.
 ```
 
 クローンは不要です。インストーラーはリポジトリ外で実行されていることを検出すると、
-ソースを `~/openmake_llm` に取得し(`OMK_HOME=...` で上書き、`OMK_REF=...` でブランチや
+ソースを `~/.openmake/chat` に取得し(同一ホストに 2 つ目を並べるなら `--instance NAME` → `~/.openmake/chat-NAME`)(`OMK_HOME=...` で上書き、`OMK_REF=...` でブランチや
 タグを選択)、そこで自身を再実行します。パイプ実行でも `/dev/tty` 経由で対話的に
 プロンプトが表示されます。非ターミナルのコンテキスト(CI)ではプロンプトは自動承認されます。
 従来の方法がお好みですか。これまでどおり動作します:

--- a/README.ko.md
+++ b/README.ko.md
@@ -195,8 +195,11 @@ curl -fsSL https://raw.githubusercontent.com/openmake/openmake_llm/main/install.
 ```
 
 클론이 필요 없다 — 설치 스크립트가 리포지토리 밖에서 실행되고 있음을 감지하면 소스를
-`~/openmake_llm`으로 가져오고(재정의는 `OMK_HOME=...`; `OMK_REF=...`로 브랜치나 태그 선택)
-그곳에서 스스로를 다시 실행한다. 파이프로 실행해도 `/dev/tty`를 통해 대화형으로 프롬프트가
+`~/.openmake/chat`으로 가져오고(재정의는 `OMK_HOME=...`; `OMK_REF=...`로 브랜치나 태그 선택)
+그곳에서 스스로를 다시 실행한다. 같은 호스트에 설치본을 하나 더 두려면 `--instance NAME`을
+붙인다(`... | bash -s -- --instance NAME`) — `~/.openmake/chat-NAME`에 별도 포트(52417/3010)·DB·Redis·PM2
+이름(`openmake-llm-NAME`)으로 설치된다. `--public-url https://chat.example.com`은 공개 주소를
+`.env`에 반영하고 HTTPS면 secure cookie로 전환한다. 파이프로 실행해도 `/dev/tty`를 통해 대화형으로 프롬프트가
 뜨며, 터미널이 아닌 환경(CI)에서는 프롬프트가 자동 승인된다. 고전적인 방식이 더 좋다면
 예전 그대로 동작한다:
 

--- a/README.md
+++ b/README.md
@@ -192,8 +192,12 @@ curl -fsSL https://raw.githubusercontent.com/openmake/openmake_llm/main/install.
 ```
 
 No clone needed — when the installer detects it is running outside the repo, it fetches
-the source into `~/openmake_llm` (override with `OMK_HOME=...`; `OMK_REF=...` picks a
-branch or tag) and re-enters itself there. Piped runs still prompt you interactively via
+the source into `~/.openmake/chat` (override with `OMK_HOME=...`; `OMK_REF=...` picks a
+branch or tag) and re-enters itself there. To run a second copy next to it on the same
+host, add `--instance NAME` (`... | bash -s -- --instance NAME`): it installs into
+`~/.openmake/chat-NAME` with its own ports (52417/3010), database, Redis and PM2 names
+(`openmake-llm-NAME`). `--public-url https://chat.example.com` writes the public address
+into `.env` and switches to secure cookies when it is HTTPS. Piped runs still prompt you interactively via
 `/dev/tty`; in a non-terminal context (CI) prompts are auto-approved. Prefer the classic
 way? It works exactly as before:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -196,7 +196,7 @@ OpenMake 把**策略**（决定*如何*回答）与**执行**（真正调用模�
 curl -fsSL https://raw.githubusercontent.com/openmake/openmake_llm/main/install.sh | bash
 ```
 
-无需克隆 —— 当安装脚本检测到自己运行在仓库之外时，会把源码拉取到 `~/openmake_llm`（用 `OMK_HOME=...` 覆盖；`OMK_REF=...` 指定分支或标签）并在那里重新进入自身。通过管道运行时仍会经由 `/dev/tty` 交互式地向你提问；在非终端环境（CI）中，提示会自动批准。更喜欢经典方式？它的用法与以前完全一致：
+无需克隆 —— 当安装脚本检测到自己运行在仓库之外时，会把源码拉取到 `~/.openmake/chat`（同一主机上并行部署第二份请加 `--instance NAME` → `~/.openmake/chat-NAME`；用 `OMK_HOME=...` 覆盖；`OMK_REF=...` 指定分支或标签）并在那里重新进入自身。通过管道运行时仍会经由 `/dev/tty` 交互式地向你提问；在非终端环境（CI）中，提示会自动批准。更喜欢经典方式？它的用法与以前完全一致：
 
 ```bash
 git clone https://github.com/openmake/openmake_llm.git

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -17,6 +17,15 @@
 # 선행: .env 에 POSTGRES_PASSWORD 를 DATABASE_URL 의 비밀번호와 동일하게 설정.
 #   (DATABASE_URL=postgresql://openmake:<PW>@127.0.0.1:5432/openmake_llm ↔ POSTGRES_PASSWORD=<PW>)
 #
+# 인스턴스 병행 (install.sh --instance NAME):
+#   .env 의 OMK_INSTANCE=NAME 이 컨테이너·볼륨 이름에 "-NAME" 을 붙인다
+#   (openmake-NAME-postgres / openmake-NAME_pgdata). 미설정(기본 인스턴스)이면 기존 이름
+#   openmake-postgres / openmake_pgdata 그대로 — 기존 설치본은 아무것도 바뀌지 않는다.
+#   COMPOSE_PROJECT_NAME=openmake-NAME 도 .env 에 함께 둔다 — 두 설치본이 같은 프로젝트 이름
+#   (디렉터리명 infra)으로 잡히면 compose 가 상대 컨테이너를 자기 것으로 보고 재생성해 버린다.
+#   (컨테이너 이름에 COMPOSE_PROJECT_NAME 을 쓰지 않는 이유: compose 가 해석된 프로젝트 이름을
+#    보간 변수로도 노출해 기본 설치본이 infra-postgres 로 바뀐다.)
+#
 # 초기화: 빈 볼륨 첫 기동 시 db/init/*.sql(001→002→003) 자동 실행.
 #   단 db/migrations/ 는 자동 적용 안 됨 → 기동 후:
 #     npx ts-node apps/api/src/data/migrations/cli.ts migrate
@@ -24,7 +33,7 @@
 services:
   postgres:
     image: postgres:16
-    container_name: openmake-postgres
+    container_name: openmake${OMK_INSTANCE:+-${OMK_INSTANCE}}-postgres
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-openmake}
@@ -49,7 +58,7 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: openmake-redis
+    container_name: openmake${OMK_INSTANCE:+-${OMK_INSTANCE}}-redis
     restart: unless-stopped
     command: ["redis-server", "--appendonly", "yes"]
     ports:
@@ -64,6 +73,6 @@ services:
 
 volumes:
   openmake_pgdata:
-    name: openmake_pgdata
+    name: openmake${OMK_INSTANCE:+-${OMK_INSTANCE}}_pgdata
   openmake_redisdata:
-    name: openmake_redisdata
+    name: openmake${OMK_INSTANCE:+-${OMK_INSTANCE}}_redisdata

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
 #
 # 사용:
 #   # curl 원라이너 — 클론 없이 한 줄. 레포 밖 실행을 감지하면 소스를
-#   # $HOME/openmake_llm 으로 받아온 뒤 자동으로 재진입한다. 터미널에서
+#   # $HOME/.openmake/chat 으로 받아온 뒤 자동으로 재진입한다. 터미널에서
 #   # 실행하면 파이프여도 /dev/tty 로 질문한다 (CI 등 tty 없으면 자동 승인).
 #   curl -fsSL https://raw.githubusercontent.com/openmake/openmake_llm/main/install.sh | bash
 #   curl -fsSL https://raw.githubusercontent.com/openmake/openmake_llm/main/install.sh | bash -s -- --yes
@@ -23,9 +23,12 @@
 #   ./install.sh --yes               # 비대화형 (기본값으로 진행, 프롬프트 없음)
 #   ./install.sh --llm-base-url https://openrouter.ai/api/v1 \
 #                --llm-api-key sk-or-... --llm-model qwen/qwen3-235b-a22b --yes
+#   ./install.sh --instance NAME     # 두 번째 인스턴스 — 기본 설치본과 같은 호스트에 나란히 뜬다
+#                                    #   ($HOME/.openmake/chat-NAME · 포트 52417/3010 · DB/Redis/PM2 분리)
+#   ./install.sh --public-url https://chat.example.com   # 공개 주소 (https 면 secure cookie 로 전환)
 #
 # 부트스트랩 환경변수 (curl 원라이너일 때만 의미 있음):
-#   OMK_HOME       소스를 받을 위치 (기본 $HOME/openmake_llm)
+#   OMK_HOME       소스를 받을 위치 (기본 $HOME/.openmake/chat, --instance NAME 은 $HOME/.openmake/chat-NAME)
 #   OMK_REPO_URL   클론할 레포 (기본 https://github.com/openmake/openmake_llm.git)
 #   OMK_REF        브랜치/태그 (기본 main)
 #
@@ -38,6 +41,14 @@
 #   --port / --web-port  API(52416) / 웹(3000) 포트 변경
 #   --postgres-port      PostgreSQL 포트 변경 (기본 5432 가 이미 점유된 경우)
 #   --redis-port         Redis 포트 변경 (기본 6379)
+#   --instance NAME      이름 있는 인스턴스 — PM2 앱·docker 컨테이너·볼륨에 "-NAME" 접미사,
+#                        .env 의 OMK_INSTANCE 로 고정. 기본 인스턴스와 같은 호스트에 나란히 뜬다.
+#                        기본 포트 52417/3010/5433/6380 (점유 시 자동으로 빈 포트로 이동)
+#   --public-url URL     외부 공개 주소 — OMK_APP_URL/CORS_ORIGINS 반영, https 면 COOKIE_SECURE=true
+#
+# 인스턴스 이름 규칙 (기본 인스턴스는 접미사 없음 — 기존 설치본과 동일):
+#   PM2      openmake-llm[-NAME] / openmake-next[-NAME]
+#   docker   openmake[-NAME]-postgres / openmake[-NAME]-redis, 볼륨 openmake[-NAME]_pgdata
 #
 # 재실행 안전(idempotent): 이미 된 단계는 건너뛰거나 갱신만 한다.
 #
@@ -58,10 +69,17 @@ readonly TOOLCHAIN_ENV="$TOOLCHAIN_DIR/toolchain.env"
 readonly HEALTH_RETRIES=45
 readonly HEALTH_INTERVAL=2
 
-APP_PORT="${OMK_PORT:-52416}"
-WEB_PORT="${OMK_WEB_PORT:-3000}"
-PG_PORT="${OMK_POSTGRES_PORT:-5432}"
-RD_PORT="${OMK_REDIS_PORT:-6379}"
+# 포트 — 빈 값이면 인스턴스별 기본값(resolve_instance)이 채운다. 셸 환경변수·플래그가 우선.
+APP_PORT="${OMK_PORT:-}"
+WEB_PORT="${OMK_WEB_PORT:-}"
+PG_PORT="${OMK_POSTGRES_PORT:-}"
+RD_PORT="${OMK_REDIS_PORT:-}"
+
+# 인스턴스 — 같은 호스트에 설치본 여러 개를 나란히 띄우기 위한 이름표. 빈 값 = 기본 인스턴스.
+# PM2 앱·docker 컨테이너·볼륨 이름에 "-$INSTANCE" 접미사가 붙고 .env 의 OMK_INSTANCE 로 고정된다.
+INSTANCE="${OMK_INSTANCE:-}"
+PUBLIC_URL=""
+APP_NAME=""; FRONT_APP_NAME=""; PG_CONTAINER=""; RD_CONTAINER=""
 
 ASSUME_YES=0
 SKIP_DOCKER=0
@@ -133,7 +151,13 @@ bootstrap_source() {
 
     local repo_url="${OMK_REPO_URL:-$DEFAULT_REPO_URL}"
     local ref="${OMK_REF:-main}"
-    local target="${OMK_HOME:-$HOME/openmake_llm}"
+    # --instance 는 parse_args 전이라 여기서 미리 훑는다 — 기본 설치 위치가 인스턴스별로 다르다.
+    local inst="$INSTANCE" prev="" a
+    for a in "$@"; do
+        [[ "$prev" == "--instance" ]] && inst="$a"
+        prev="$a"
+    done
+    local target="${OMK_HOME:-$HOME/.openmake/chat${inst:+-$inst}}"
 
     log_step "부트스트랩 — 소스 다운로드"
     log_info "설치 위치: $target  (변경: OMK_HOME / 레포: OMK_REPO_URL / 브랜치·태그: OMK_REF)"
@@ -178,11 +202,88 @@ parse_args() {
             --web-port)      WEB_PORT="${2:-}"; shift ;;
             --postgres-port) PG_PORT="${2:-}"; shift ;;
             --redis-port)    RD_PORT="${2:-}"; shift ;;
+            --instance)      INSTANCE="${2:-}"; shift ;;
+            --public-url)    PUBLIC_URL="${2:-}"; shift ;;
             -h|--help)       usage; exit 0 ;;
             *) log_err "알 수 없는 옵션: $1"; echo ""; usage; exit 1 ;;
         esac
         shift
     done
+}
+
+# ── 인스턴스 확정 ────────────────────────────────────────────────────────────
+# 재실행이면 .env 의 OMK_INSTANCE 가 진실 — 플래그와 다르면 다른 인스턴스를 같은 디렉터리에
+# 덮어쓰려는 것이므로 막는다. 확정 뒤 PM2 앱·컨테이너 이름과 인스턴스별 기본 포트를 정한다.
+resolve_instance() {
+    local from_env
+    from_env="$(env_value OMK_INSTANCE)"
+    if [[ -n "$from_env" ]]; then
+        if [[ -n "$INSTANCE" && "$INSTANCE" != "$from_env" ]]; then
+            die "이 디렉터리는 '$from_env' 인스턴스입니다 (.env OMK_INSTANCE) — '--instance $INSTANCE' 로 덮어쓸 수 없습니다. 다른 디렉터리(OMK_HOME)에 설치하세요."
+        fi
+        INSTANCE="$from_env"
+    fi
+    if [[ -n "$INSTANCE" ]] && ! [[ "$INSTANCE" =~ ^[a-z0-9][a-z0-9-]{0,31}$ ]]; then
+        die "인스턴스 이름은 소문자·숫자·하이픈만 가능합니다 (예: test): '$INSTANCE'"
+    fi
+    local suffix="${INSTANCE:+-$INSTANCE}"
+    APP_NAME="openmake-llm$suffix"
+    FRONT_APP_NAME="openmake-next$suffix"
+    # infra/docker-compose.yml 의 openmake${OMK_INSTANCE:+-…}-postgres 규칙과 같다.
+    PG_CONTAINER="openmake$suffix-postgres"
+    RD_CONTAINER="openmake$suffix-redis"
+
+    # 인스턴스별 기본 포트 — 기본 인스턴스는 기존 값 그대로, 이름 있는 인스턴스는 한 칸 옆.
+    # (점유돼 있으면 ensure_ports 가 빈 포트로 옮긴다.)
+    if [[ -n "$INSTANCE" ]]; then
+        : "${APP_PORT:=52417}" "${WEB_PORT:=3010}" "${PG_PORT:=5433}" "${RD_PORT:=6380}"
+        log_ok "인스턴스: $INSTANCE (PM2 $APP_NAME / $FRONT_APP_NAME · docker $PG_CONTAINER / $RD_CONTAINER)"
+    else
+        : "${APP_PORT:=52416}" "${WEB_PORT:=3000}" "${PG_PORT:=5432}" "${RD_PORT:=6379}"
+    fi
+}
+
+# .env 에 인스턴스 키가 없으면 붙인다 — 이름 있는 인스턴스인데 예전 .env 를 재사용하는 경우.
+# (신규 생성은 gen-env.mjs 가 같은 키를 쓴다.) 없으면 PM2/compose 가 접미사 없는 이름으로 떠서
+# 같은 호스트의 기본 인스턴스와 충돌한다.
+ensure_env_instance_keys() {
+    [[ -n "$INSTANCE" ]] || return 0
+    local envf="$SCRIPT_DIR/.env"
+    if [[ -z "$(env_value OMK_INSTANCE)" ]]; then
+        printf '\n# 인스턴스 — PM2 앱·컨테이너·볼륨 이름 접미사 (install.sh --instance)\nOMK_INSTANCE=%s\n' "$INSTANCE" >> "$envf"
+    fi
+    if [[ -z "$(env_value COMPOSE_PROJECT_NAME)" ]]; then
+        printf 'COMPOSE_PROJECT_NAME=openmake-%s\n' "$INSTANCE" >> "$envf"
+    fi
+}
+
+# 공개 주소를 .env 에 반영한다 — OMK_APP_URL 교체, CORS_ORIGINS 에 추가, OMK_WEB_PORT 명시
+# (주소에 포트가 없으면 resolve-ports 가 웹 포트를 역산할 수 없다), https 면 secure cookie 로.
+set_env_public_url() {
+    local url="${1%/}" envf="$SCRIPT_DIR/.env" tmp
+    [[ "$url" =~ ^https?://[^/[:space:]]+$ ]] \
+        || die "--public-url 은 스킴+호스트[:포트] 형식이어야 합니다 (예: https://chat.example.com): $url"
+    tmp="$(mktemp)"
+    sed -E "s|^OMK_APP_URL=.*|OMK_APP_URL=${url}|" "$envf" > "$tmp" && mv "$tmp" "$envf"
+    if ! env_value CORS_ORIGINS | tr ',' '\n' | grep -qxF "$url"; then
+        tmp="$(mktemp)"
+        sed -E "s|^CORS_ORIGINS=(.*)|CORS_ORIGINS=\1,${url}|" "$envf" > "$tmp" && mv "$tmp" "$envf"
+    fi
+    if grep -qE '^OMK_WEB_PORT=' "$envf"; then
+        tmp="$(mktemp)"
+        sed -E "s|^OMK_WEB_PORT=.*|OMK_WEB_PORT=${WEB_PORT}|" "$envf" > "$tmp" && mv "$tmp" "$envf"
+    else
+        printf '\n# 웹(Next) 포트 — 공개 주소에 포트가 없으므로 명시 (scripts/resolve-ports.cjs)\nOMK_WEB_PORT=%s\n' "$WEB_PORT" >> "$envf"
+    fi
+    if [[ "$url" == https://* ]]; then
+        tmp="$(mktemp)"
+        sed -E 's|^COOKIE_SECURE=.*|COOKIE_SECURE=true|; s|^ALLOW_INSECURE_COOKIES=.*|ALLOW_INSECURE_COOKIES=false|' \
+            "$envf" > "$tmp" && mv "$tmp" "$envf"
+        log_ok "공개 주소 $url — HTTPS 이므로 COOKIE_SECURE=true / ALLOW_INSECURE_COOKIES=false"
+        log_warn "TLS 를 종단하는 프록시(Cloudflare/Caddy 등) 뒤에서만 로그인이 됩니다 — http://localhost:$WEB_PORT 직접 접속은 쿠키가 저장되지 않습니다."
+    else
+        log_ok "공개 주소 $url 반영"
+    fi
 }
 
 # ── 플랫폼 감지 ──────────────────────────────────────────────────────────────
@@ -642,17 +743,19 @@ ensure_ports() {
 
     # 앱(API)/웹 포트 — PM2 로 도는 호스트 프로세스라 소유 판정은 PM2 등록 여부로 한다.
     v="$(env_value PORT)"; [[ -n "$v" ]] && APP_PORT="$v"
-    v="$(env_value OMK_APP_URL | sed -nE 's|.*:([0-9]+)/?$|\1|p')"; [[ -n "$v" ]] && WEB_PORT="$v"
+    v="$(env_value OMK_WEB_PORT)"
+    [[ -n "$v" ]] || v="$(env_value OMK_APP_URL | sed -nE 's|.*:([0-9]+)/?$|\1|p')"
+    [[ -n "$v" ]] && WEB_PORT="$v"
 
     local alt
-    if port_in_use "$APP_PORT" && ! pm2_has_app openmake-llm; then
+    if port_in_use "$APP_PORT" && ! pm2_has_app "$APP_NAME"; then
         alt="$(find_free_port $((APP_PORT + 1)))" \
             || die "API 대체 포트 탐색 실패 — --port 로 직접 지정하세요."
         log_warn "호스트 포트 $APP_PORT 을 다른 프로세스가 사용 중 — API 를 $alt 로 대체합니다."
         update_env_app_port "$APP_PORT" "$alt"
         APP_PORT="$alt"
     fi
-    if port_in_use "$WEB_PORT" && ! pm2_has_app openmake-next; then
+    if port_in_use "$WEB_PORT" && ! pm2_has_app "$FRONT_APP_NAME"; then
         alt="$(find_free_port 13000)" \
             || die "웹 대체 포트 탐색 실패 (13000~) — --web-port 로 직접 지정하세요."
         log_warn "호스트 포트 $WEB_PORT 을 다른 프로세스가 사용 중 — 웹 UI 를 $alt 로 대체합니다."
@@ -660,14 +763,14 @@ ensure_ports() {
         WEB_PORT="$alt"
     fi
 
-    if port_in_use "$PG_PORT" && ! port_owned_by openmake-postgres "$PG_PORT"; then
+    if port_in_use "$PG_PORT" && ! port_owned_by "$PG_CONTAINER" "$PG_PORT"; then
         alt="$(find_free_port 15432)" \
             || die "PostgreSQL 대체 포트 탐색 실패 (15432~) — --postgres-port 로 직접 지정하세요."
         log_warn "호스트 포트 $PG_PORT 을 다른 프로세스가 사용 중 (기존 PostgreSQL?) — $alt 로 대체합니다."
         PG_PORT="$alt"
         update_env_port POSTGRES_PORT "$alt"
     fi
-    if port_in_use "$RD_PORT" && ! port_owned_by openmake-redis "$RD_PORT"; then
+    if port_in_use "$RD_PORT" && ! port_owned_by "$RD_CONTAINER" "$RD_PORT"; then
         alt="$(find_free_port 16379)" \
             || die "Redis 대체 포트 탐색 실패 (16379~) — --redis-port 로 직접 지정하세요."
         log_warn "호스트 포트 $RD_PORT 을 다른 프로세스가 사용 중 (기존 Redis?) — $alt 로 대체합니다."
@@ -732,12 +835,18 @@ setup_env() {
         [[ -n "$LLM_BASE_URL" ]] && export OMK_LLM_BASE_URL="$LLM_BASE_URL"
         [[ -n "$LLM_API_KEY"  ]] && export OMK_LLM_API_KEY="$LLM_API_KEY"
         [[ -n "$LLM_MODEL"    ]] && export OMK_LLM_MODEL="$LLM_MODEL"
+        [[ -n "$INSTANCE"     ]] && export OMK_INSTANCE="$INSTANCE"
         if [[ $FORCE_ENV -eq 1 ]]; then
             node "$SCRIPT_DIR/scripts/setup/gen-env.mjs" --force >/dev/null
         else
             node "$SCRIPT_DIR/scripts/setup/gen-env.mjs" >/dev/null
         fi
     ) || die ".env 생성 실패"
+    ensure_env_instance_keys
+    if [[ -n "$PUBLIC_URL" ]]; then
+        set_env_public_url "$PUBLIC_URL"
+        EXTERNAL_URL="$PUBLIC_URL"
+    fi
 
     log_ok ".env 준비 완료"
 }
@@ -774,18 +883,18 @@ compose_up() {
     log_info "PostgreSQL 준비 대기"
     local i
     for ((i = 1; i <= HEALTH_RETRIES; i++)); do
-        if docker exec openmake-postgres pg_isready -U "$(env_value POSTGRES_USER)" \
+        if docker exec "$PG_CONTAINER" pg_isready -U "$(env_value POSTGRES_USER)" \
              -d "$(env_value POSTGRES_DB)" >/dev/null 2>&1; then
             log_ok "PostgreSQL 준비 완료 (~$((i * HEALTH_INTERVAL))s)"
             break
         fi
-        [[ $i -eq $HEALTH_RETRIES ]] && die "PostgreSQL 기동 실패 — docker logs openmake-postgres 확인"
+        [[ $i -eq $HEALTH_RETRIES ]] && die "PostgreSQL 기동 실패 — docker logs $PG_CONTAINER 확인"
         sleep "$HEALTH_INTERVAL"
     done
 
-    docker exec openmake-redis redis-cli ping >/dev/null 2>&1 \
+    docker exec "$RD_CONTAINER" redis-cli ping >/dev/null 2>&1 \
         && log_ok "Redis 준비 완료" \
-        || log_warn "Redis ping 실패 — docker logs openmake-redis 확인"
+        || log_warn "Redis ping 실패 — docker logs $RD_CONTAINER 확인"
 }
 
 run_migrations() {
@@ -842,7 +951,7 @@ start_app() {
     done
 
     log_err "health check 실패 — 최근 로그 50줄:"
-    "$PM2_BIN" logs openmake-llm --lines 50 --nostream 2>/dev/null || true
+    "$PM2_BIN" logs "$APP_NAME" --lines 50 --nostream 2>/dev/null || true
     exit 3
 }
 
@@ -861,6 +970,8 @@ detect_lan_ip() {
 }
 
 prompt_external_access() {
+    # --public-url 로 이미 정했으면 묻지 않는다.
+    [[ -n "$PUBLIC_URL" ]] && return 0
     # 비대화형(--yes / tty 없음)은 로컬 전용으로 두고, 방법만 summary 에서 안내.
     [[ $ASSUME_YES -eq 1 || -z "$TTY_DEV" ]] && return 0
     echo ""
@@ -877,18 +988,17 @@ prompt_external_access() {
 
     local web_origin="http://${host}:${WEB_PORT}" api_origin="http://${host}:${APP_PORT}"
     local envf="$SCRIPT_DIR/.env" tmp
-    tmp="$(mktemp)"
-    sed -E "s|^OMK_APP_URL=.*|OMK_APP_URL=${web_origin}|" "$envf" > "$tmp" && mv "$tmp" "$envf"
-    if ! grep -qE "^CORS_ORIGINS=.*${web_origin}" "$envf"; then
+    set_env_public_url "$web_origin"
+    if ! env_value CORS_ORIGINS | tr ',' '\n' | grep -qxF "$api_origin"; then
         tmp="$(mktemp)"
-        sed -E "s|^CORS_ORIGINS=(.*)|CORS_ORIGINS=\1,${web_origin},${api_origin}|" "$envf" > "$tmp" && mv "$tmp" "$envf"
+        sed -E "s|^CORS_ORIGINS=(.*)|CORS_ORIGINS=\1,${api_origin}|" "$envf" > "$tmp" && mv "$tmp" "$envf"
     fi
     EXTERNAL_URL="$web_origin"
 
     if [[ $NO_START -eq 0 ]]; then
         log_info "설정 반영을 위해 API 재시작"
-        "${PM2_BIN:-pm2}" restart openmake-llm --update-env >/dev/null 2>&1 \
-            || log_warn "재시작 실패 — 수동으로: pm2 restart openmake-llm"
+        "${PM2_BIN:-pm2}" restart "$APP_NAME" --update-env >/dev/null 2>&1 \
+            || log_warn "재시작 실패 — 수동으로: pm2 restart $APP_NAME"
     fi
     log_ok "외부 접속 설정 완료 — $web_origin"
     log_warn "HTTP 평문 통신입니다. 인터넷에 공개한다면 HTTPS(Caddy 등)를 앞에 두고 .env 의 COOKIE_SECURE=true / ALLOW_INSECURE_COOKIES=false 로 바꾸세요."
@@ -905,6 +1015,10 @@ summary() {
     printf "%s  OpenMake LLM 설치 완료%s\n" "$C_OK" "$C_RESET"
     printf "%s══════════════════════════════════════════════════════%s\n\n" "$C_OK" "$C_RESET"
 
+    if [[ -n "$INSTANCE" ]]; then
+        echo "  인스턴스  $INSTANCE   ($SCRIPT_DIR)"
+        echo "  PM2       $APP_NAME / $FRONT_APP_NAME   docker: $PG_CONTAINER / $RD_CONTAINER"
+    fi
     echo "  웹 UI     http://localhost:$WEB_PORT"
     echo "  API       http://localhost:$APP_PORT   (health: /health)"
     if [[ -n "$EXTERNAL_URL" ]]; then
@@ -943,6 +1057,7 @@ main() {
     bootstrap_source "$@"
 
     parse_args "$@"
+    resolve_instance
 
     printf "\n%s╔══════════════════════════════════════════════════╗%s\n" "$C_INFO" "$C_RESET"
     printf "%s║   OpenMake LLM — 원샷 설치 (macOS/Linux/WSL2)     ║%s\n" "$C_INFO" "$C_RESET"

--- a/openmake_llm.sh
+++ b/openmake_llm.sh
@@ -24,6 +24,12 @@
 #   ./openmake_llm.sh status     # 모든 계층 상태 확인
 #   ./openmake_llm.sh logs       # OpenMake LLM 실시간 로그
 #   ./openmake_llm.sh health     # /health 엔드포인트 응답 확인
+#   ./openmake_llm.sh db-dump [파일]     # DB 전체 덤프 (pg_dump -Fc) — 다른 호스트로 옮길 때
+#   ./openmake_llm.sh db-restore <파일>  # 덤프를 이 인스턴스 DB 에 복원 → 마이그레이션 → 앱 재시작
+#
+# 인스턴스: .env 의 OMK_INSTANCE(install.sh --instance NAME)가 있으면 PM2 앱 이름이
+#   openmake-llm-<이름>/openmake-next-<이름>, 컨테이너가 openmake-<이름>-postgres 가 된다.
+#   이 스크립트는 자기 디렉터리의 .env 만 보므로 설치본 각각의 디렉터리에서 실행하면 된다.
 #
 # 환경 가정 (Linux / macOS 공통):
 #   - PostgreSQL/Redis는 docker compose 로 관리 (2026-06-21 brew postgresql@16 제거 → docker 단독)
@@ -47,8 +53,20 @@ readonly SCRIPT_DIR
 # shellcheck source=/dev/null
 [[ -f "$SCRIPT_DIR/.openmake/toolchain.env" ]] && . "$SCRIPT_DIR/.openmake/toolchain.env"
 
-readonly APP_NAME="openmake-llm"
-readonly FRONT_APP_NAME="openmake-next"
+# .env 에서 키 하나만 추출한다 (전체 source 안 함 — 값에 공백/특수문자가 있어도 안전).
+# `|| true` 필수: 키가 없으면 grep 이 1 로 끝나고 pipefail+set -e 가 스크립트를 즉시 종료시킨다.
+env_line() {
+    [[ -f "$SCRIPT_DIR/.env" ]] || return 0
+    grep -E "^$1=" "$SCRIPT_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2- | tr -d ' ' || true
+}
+
+# 인스턴스 접미사 — ecosystem.config.js(resolve-ports.cjs)·infra/docker-compose.yml 과 같은 규칙으로
+# PM2 앱·docker 컨테이너 이름을 만든다 (.env 의 OMK_INSTANCE 하나가 단일 출처).
+_instance="$(env_line OMK_INSTANCE)"
+readonly INSTANCE="$_instance"
+readonly APP_NAME="openmake-llm${INSTANCE:+-$INSTANCE}"
+readonly FRONT_APP_NAME="openmake-next${INSTANCE:+-$INSTANCE}"
+readonly PG_CONTAINER="openmake${INSTANCE:+-$INSTANCE}-postgres"
 
 # Caddy 리버스 프록시 설정 — 이 레포가 SoT.
 #
@@ -57,13 +75,6 @@ readonly FRONT_APP_NAME="openmake-next"
 # 교체했다. 그래서 레포 변경이 더는 자동 반영되지 않는다 — 배포마다 여기서 복사한다.
 readonly CADDYFILE_SRC_REL="scripts/caddy/Caddyfile"
 CADDYFILE_DEST="${CADDYFILE_DEST:-/opt/homebrew/etc/Caddyfile}"
-
-# .env 에서 키 하나만 추출한다 (전체 source 안 함 — 값에 공백/특수문자가 있어도 안전).
-# `|| true` 필수: 키가 없으면 grep 이 1 로 끝나고 pipefail+set -e 가 스크립트를 즉시 종료시킨다.
-env_line() {
-    [[ -f "$SCRIPT_DIR/.env" ]] || return 0
-    grep -E "^$1=" "$SCRIPT_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2- | tr -d ' ' || true
-}
 
 # .env 의 KEY=VALUE 를 현재 셸에 export 한다 — `pm2 restart --update-env` 가 .env 편집을 실제로
 # 반영하게 하는 유일한 경로. PM2 는 최초 `pm2 start` 시점의 env 스냅샷을 프로세스에 계속 주입하고
@@ -686,6 +697,12 @@ cmd_deploy() {
 sync_caddyfile() {
     local src="$SCRIPT_DIR/$CADDYFILE_SRC_REL"
 
+    # 호스트의 Caddyfile 은 하나뿐이다 — 이름 있는 인스턴스가 기본 인스턴스의 설정을 덮어쓰지 않게 한다.
+    if [[ -n "$INSTANCE" ]]; then
+        log_info "인스턴스 '$INSTANCE' — 호스트 Caddyfile 동기화 생략 (기본 인스턴스만 반영)"
+        return 0
+    fi
+
     [[ -f "$src" ]] || { log_info "Caddyfile 소스 없음 — 동기화 생략 ($CADDYFILE_SRC_REL)"; return 0; }
     [[ -d "$(dirname "$CADDYFILE_DEST")" ]] || { log_info "Caddy 설정 경로 없음 — 동기화 생략 ($CADDYFILE_DEST)"; return 0; }
 
@@ -723,6 +740,88 @@ sync_caddyfile() {
     else
         log_warn "Caddy reload 실패 — 설정은 검증을 통과했으므로 caddy 미기동(admin API 무응답)일 가능성이 큽니다. 다음 기동 시 반영됩니다"
     fi
+}
+
+# ── db-dump / db-restore: 인스턴스 DB 이관 ────────────────────────────────────
+# 운영 중인 다른 호스트의 DB 를 이 설치본으로 옮기는 표준 경로:
+#   원본:  ./openmake_llm.sh db-dump chat.dump          (pg_dump -Fc, 컨테이너 안에서 실행)
+#   대상:  ./openmake_llm.sh db-restore chat.dump       (앱 정지 → pg_restore → migrate → 재시작)
+#
+# ⚠ 복원 전에 원본 .env 의 시크릿을 대상 .env 로 옮겨야 한다 — DB 안의 값이 그 키로 묶여 있다:
+#   TOKEN_ENCRYPTION_KEY (외부 provider 자격증명 복호화), API_KEY_PEPPER (발급된 API 키 검증),
+#   JWT_SECRET (기존 세션 유지, 선택). ADMIN_* 는 DB 의 관리자 계정이 그대로 오므로 원본 값으로.
+#   업로드/생성 파일(apps/api 의 uploads·generated 디렉터리)은 DB 밖이라 rsync 로 따로 옮긴다.
+db_container_ready() {
+    docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "$PG_CONTAINER" \
+        || { log_err "PostgreSQL 컨테이너($PG_CONTAINER)가 떠 있지 않습니다 — './openmake_llm.sh start' 또는 docker 확인"; return 2; }
+}
+
+cmd_db_dump() {
+    preflight
+    db_container_ready || return 2
+    local user db out
+    user="$(env_line POSTGRES_USER)"; user="${user:-openmake}"
+    db="$(env_line POSTGRES_DB)";     db="${db:-openmake_llm}"
+    out="${1:-$SCRIPT_DIR/${db}${INSTANCE:+-$INSTANCE}-$(date +%Y%m%d-%H%M%S).dump}"
+    log_step "DB 덤프: $PG_CONTAINER/$db → $out (pg_dump -Fc)"
+    if ! docker exec "$PG_CONTAINER" pg_dump -U "$user" -Fc "$db" > "$out"; then
+        rm -f "$out"; log_err "pg_dump 실패"; return 2
+    fi
+    log_ok "덤프 완료: $out ($(du -h "$out" | cut -f1))"
+    echo "  복원: 대상 설치본에서  ./openmake_llm.sh db-restore $(basename "$out")"
+    echo "  (복원 전 원본 .env 의 TOKEN_ENCRYPTION_KEY / API_KEY_PEPPER / JWT_SECRET 을 대상 .env 로 옮길 것)"
+}
+
+cmd_db_restore() {
+    local file="${1:-}" yes=0
+    [[ "${2:-}" == "--yes" || "${1:-}" == "--yes" ]] && yes=1
+    [[ "$file" == "--yes" ]] && file="${2:-}"
+    [[ -n "$file" && -f "$file" ]] || { log_err "사용법: $0 db-restore <덤프파일> [--yes]"; return 1; }
+    preflight
+    db_container_ready || return 2
+    local user db
+    user="$(env_line POSTGRES_USER)"; user="${user:-openmake}"
+    db="$(env_line POSTGRES_DB)";     db="${db:-openmake_llm}"
+
+    log_step "DB 복원: $file → $PG_CONTAINER/$db"
+    log_warn "현재 '$db' 의 모든 데이터가 덤프 내용으로 대체됩니다 (인스턴스: ${INSTANCE:-기본})."
+    DEPLOY_YES=$yes
+    confirm_or_exit "계속하시겠습니까?"
+
+    # 앱이 붙어 있으면 DROP 이 막힌다 — 복원 동안 API 만 내린다 (프론트는 무관).
+    if pm2 jlist 2>/dev/null | grep -q "\"name\":\"$APP_NAME\""; then
+        pm2 stop "$APP_NAME" >/dev/null 2>&1 && log_info "$APP_NAME 정지 (복원 동안)"
+    fi
+
+    # 남은 세션을 끊고 통째로 다시 만든다 — --clean 보다 잔재(마이그레이션 표·enum 등)가 안 남는다.
+    docker exec "$PG_CONTAINER" psql -U "$user" -d postgres -v ON_ERROR_STOP=1 -q \
+        -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='$db' AND pid<>pg_backend_pid();" \
+        -c "DROP DATABASE IF EXISTS \"$db\";" -c "CREATE DATABASE \"$db\" OWNER \"$user\";" >/dev/null \
+        || { log_err "DB 재생성 실패"; return 2; }
+
+    # -Fc(custom) 덤프는 pg_restore, 평문 .sql 은 psql. 확장(extension) 소유권 경고는 무시 가능.
+    local rc=0
+    if head -c 5 "$file" | grep -q '^PGDMP'; then
+        docker exec -i "$PG_CONTAINER" pg_restore -U "$user" -d "$db" --no-owner --no-acl --exit-on-error < "$file" || rc=$?
+    else
+        docker exec -i "$PG_CONTAINER" psql -U "$user" -d "$db" -v ON_ERROR_STOP=1 -q < "$file" || rc=$?
+    fi
+    if [[ $rc -ne 0 ]]; then
+        log_err "복원 실패 (exit $rc) — DB 는 비어 있을 수 있습니다. 덤프 파일과 PostgreSQL 버전을 확인하세요."
+        return 2
+    fi
+    log_ok "복원 완료"
+
+    # 원본이 구버전이면 스키마를 이 코드에 맞춘다.
+    cmd_migrate || return 2
+
+    if pm2 jlist 2>/dev/null | grep -q "\"name\":\"$APP_NAME\""; then
+        export_dotenv_for_pm2
+        pm2 restart "$APP_NAME" --update-env >/dev/null 2>&1 && log_ok "$APP_NAME 재시작" \
+            || log_warn "$APP_NAME 재시작 실패 — 'pm2 restart $APP_NAME' 수동 확인"
+        wait_for_app_with_logs "$APP_PORT" "OpenMake LLM" || true
+    fi
+    log_ok "DB 이관 완료 — 원본 .env 의 TOKEN_ENCRYPTION_KEY / API_KEY_PEPPER 가 대상 .env 와 같은지 확인하세요."
 }
 
 cmd_install() {
@@ -766,6 +865,15 @@ OpenMake LLM 통합 서비스 매니저
   health    /health 엔드포인트 호출 확인
   logs      OpenMake LLM 실시간 로그 (PM2)
 
+DB 이관 (다른 호스트/인스턴스로 옮길 때):
+  db-dump [파일]        이 인스턴스 DB 전체 덤프 (pg_dump -Fc, 기본 파일명 자동)
+  db-restore <파일>     덤프를 이 인스턴스 DB 에 복원 (앱 정지 → DROP/CREATE → 복원 → migrate → 재시작)
+                        옵션: --yes. 복원 전 원본 .env 의 TOKEN_ENCRYPTION_KEY / API_KEY_PEPPER /
+                        JWT_SECRET 을 이쪽 .env 로 옮길 것 (DB 안의 암호화 값·API 키가 그 키에 묶임)
+
+인스턴스 (현재: ${INSTANCE:-기본}):
+  .env 의 OMK_INSTANCE 에 따라 PM2 앱 $APP_NAME / $FRONT_APP_NAME, 컨테이너 $PG_CONTAINER 를 다룬다.
+
 환경 가정:
   - Linux / macOS (DB/Redis 는 docker compose, 앱은 PM2 로 관리)
   - PM2 설치 (npm i -g pm2 — install.sh 가 자동 처리)
@@ -799,6 +907,8 @@ main() {
         status)   show_status ;;
         health)   show_health ;;
         logs)     show_logs ;;
+        db-dump)  cmd_db_dump "$@" ;;
+        db-restore) cmd_db_restore "$@" ;;
         ""|-h|--help|help) usage ;;
         *)
             log_err "알 수 없는 명령: $cmd"

--- a/scripts/setup/gen-env.mjs
+++ b/scripts/setup/gen-env.mjs
@@ -22,6 +22,7 @@
  *   OMK_PORT(52416) OMK_WEB_PORT(3000) OMK_POSTGRES_PORT(5432) OMK_REDIS_PORT(6379)
  *   OMK_LLM_BASE_URL OMK_LLM_API_KEY OMK_LLM_MODEL
  *   OMK_ADMIN_USERNAME(admin) OMK_ADMIN_EMAIL(support@openmake.cc)
+ *   OMK_INSTANCE(없음)  — install.sh --instance NAME. 있으면 OMK_INSTANCE·COMPOSE_PROJECT_NAME 기록
  *
  * 출력: 마지막 줄에 `GENERATED=1` 또는 `REPAIRED=<n>` 또는 `UNCHANGED=0` (install.sh 파싱용)
  * ==============================================================================
@@ -68,6 +69,11 @@ const ADMIN_EMAIL = env('OMK_ADMIN_EMAIL', 'support@openmake.cc');
 const LLM_BASE_URL = env('OMK_LLM_BASE_URL', 'http://localhost:4000');
 const LLM_API_KEY = env('OMK_LLM_API_KEY', 'sk-no-key');
 const LLM_MODEL = env('OMK_LLM_MODEL', 'qwen3.8-27b');
+const INSTANCE = env('OMK_INSTANCE', '');
+if (INSTANCE && !/^[a-z0-9][a-z0-9-]{0,31}$/.test(INSTANCE)) {
+    process.stderr.write(`OMK_INSTANCE 는 소문자·숫자·하이픈만 가능합니다: '${INSTANCE}'\n`);
+    process.exit(1);
+}
 
 const PG_USER = 'openmake';
 const PG_DB = 'openmake_llm';
@@ -91,6 +97,19 @@ function buildEntries() {
         ['server', 'COOKIE_SECURE', 'false', 'HTTPS 로 서비스하면 true 로 바꾸세요'],
         ['server', 'ALLOW_INSECURE_COOKIES', 'true',
             'HTTP 로컬 실행 허용(위 COOKIE_SECURE=false 의 명시적 opt-out). HTTPS 배포 시 false'],
+
+        // 'instance' 섹션은 신규 생성 때만 쓴다 — 보수 모드에서 기존 설치본에 OMK_WEB_PORT 기본값을
+        // 덧붙이면 OMK_APP_URL 로 옮겨 둔 웹 포트를 덮어쓴다 (resolve-ports 는 OMK_WEB_PORT 를 우선).
+        ['instance', 'OMK_WEB_PORT', WEB_PORT, '웹(Next) 포트 — scripts/resolve-ports.cjs 가 PM2 기동·Next 빌드에 주입'],
+        ...(INSTANCE ? [
+            ['instance', 'OMK_INSTANCE', INSTANCE,
+                '인스턴스 이름 — PM2 앱(openmake-llm-*)·컨테이너·볼륨 이름 접미사. 같은 호스트 병행 설치용'],
+        ] : []),
+        // 프로젝트 이름을 고정한다 — 미설정이면 compose 파일의 디렉터리명(infra)이 되어, 같은 호스트의
+        // 다른 compose 프로젝트(다른 설치본·다른 앱의 infra/)와 서비스 이름이 겹치면 상대 컨테이너를
+        // 자기 것으로 보고 재생성해 버린다.
+        ['instance', 'COMPOSE_PROJECT_NAME', `openmake${INSTANCE ? `-${INSTANCE}` : ''}`,
+            'docker compose 프로젝트 이름 — 다른 compose 프로젝트(infra/)와 컨테이너가 섞이지 않게 고정'],
 
         ['secret', 'JWT_SECRET', hex32(), '세션 서명 키 — 바꾸면 모든 로그인 세션이 무효화됨'],
         ['secret', 'API_KEY_PEPPER', hex32(), 'API Key 해시 pepper'],
@@ -120,6 +139,7 @@ function buildEntries() {
 
 const SECTION_TITLES = {
     server: '서버 / 네트워크',
+    instance: '인스턴스 (install.sh --instance NAME)',
     secret: '시크릿 (자동 생성됨 — 유출 금지, 재생성 시 세션·저장된 키가 무효화됨)',
     admin: '관리자 계정',
     infra: 'PostgreSQL / Redis (infra/docker-compose.yml 과 공유)',
@@ -189,7 +209,8 @@ function main() {
     // ── 보수 모드: 빠진 필수 키만 덧붙인다 ──────────────────────────────────
     const text = fs.readFileSync(ENV_PATH, 'utf8');
     const present = declaredKeys(text);
-    const missing = buildEntries().filter(([, key]) => !present.has(key));
+    // 'instance' 섹션은 부팅 필수가 아니라 보수 대상에서 제외한다 (위 buildEntries 주석 참고).
+    const missing = buildEntries().filter(([section, key]) => section !== 'instance' && !present.has(key));
 
     if (missing.length === 0) {
         say('.env 에 필수 키가 모두 있습니다 — 변경 없음');

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -27,6 +27,13 @@ log_warn() { printf "%s[WARN]%s  %s\n" "$C_WARN" "$C_RESET" "$*"; }
 log_step() { printf "\n%s━━ %s ━━%s\n" "$C_INFO" "$*" "$C_RESET"; }
 has() { command -v "$1" >/dev/null 2>&1; }
 
+# 인스턴스 이름 — install.sh --instance NAME 이 .env 에 남긴 OMK_INSTANCE. 없으면 기본 이름.
+env_line() { [[ -f "$SCRIPT_DIR/.env" ]] && grep -E "^$1=" "$SCRIPT_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2- | tr -d ' ' || true; }
+_inst="$(env_line OMK_INSTANCE)"; _pfx="openmake${_inst:+-$_inst}"
+readonly APP_NAME="openmake-llm${_inst:+-$_inst}" FRONT_APP_NAME="openmake-next${_inst:+-$_inst}"
+readonly PG_CONTAINER="$_pfx-postgres" RD_CONTAINER="$_pfx-redis"
+readonly PG_VOLUME="${_pfx}_pgdata" RD_VOLUME="${_pfx}_redisdata"
+
 ASSUME_YES=0; KEEP_DATA=0; KEEP_SOURCE=0
 for arg in "$@"; do
     case "$arg" in
@@ -49,7 +56,7 @@ confirm() {
 # ── 1. PM2 앱 ────────────────────────────────────────────────────────────────
 log_step "1/3 PM2 앱 정지·삭제"
 if has pm2; then
-    for app in openmake-llm openmake-next; do
+    for app in "$APP_NAME" "$FRONT_APP_NAME"; do
         if pm2 describe "$app" >/dev/null 2>&1; then
             pm2 delete "$app" >/dev/null 2>&1 && log_ok "$app 삭제" || log_warn "$app 삭제 실패"
         else
@@ -64,7 +71,7 @@ fi
 # ── 2. Docker 컨테이너·볼륨 ──────────────────────────────────────────────────
 log_step "2/3 Docker 컨테이너·볼륨"
 if has docker && docker info >/dev/null 2>&1; then
-    for c in openmake-postgres openmake-redis; do
+    for c in "$PG_CONTAINER" "$RD_CONTAINER"; do
         if docker ps -a --format '{{.Names}}' | grep -qx "$c"; then
             docker rm -f "$c" >/dev/null && log_ok "$c 컨테이너 제거"
         else
@@ -72,9 +79,9 @@ if has docker && docker info >/dev/null 2>&1; then
         fi
     done
     if [[ $KEEP_DATA -eq 1 ]]; then
-        log_info "--keep-data — 볼륨(openmake_pgdata, openmake_redisdata)은 남깁니다."
+        log_info "--keep-data — 볼륨($PG_VOLUME, $RD_VOLUME)은 남깁니다."
     elif confirm "DB 데이터 볼륨을 삭제할까요? (모든 사용자·채팅 데이터가 사라집니다)"; then
-        for v in openmake_pgdata openmake_redisdata; do
+        for v in "$PG_VOLUME" "$RD_VOLUME"; do
             docker volume rm "$v" >/dev/null 2>&1 && log_ok "$v 볼륨 삭제" || log_info "$v — 없음"
         done
     else
@@ -82,8 +89,8 @@ if has docker && docker info >/dev/null 2>&1; then
     fi
 else
     log_warn "docker 미실행 — 컨테이너/볼륨은 Docker 기동 후 직접 제거하세요:"
-    echo "    docker rm -f openmake-postgres openmake-redis"
-    echo "    docker volume rm openmake_pgdata openmake_redisdata"
+    echo "    docker rm -f $PG_CONTAINER $RD_CONTAINER"
+    echo "    docker volume rm $PG_VOLUME $RD_VOLUME"
 fi
 
 # ── 3. 소스 디렉터리 ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## 요약

한 호스트에 설치본을 여러 개 나란히 띄울 수 있게 install.sh / 운영 스크립트를 인스턴스 인식으로 바꾸고, 기본 설치 위치를 `~/.openmake/chat`으로 옮겼다. 다른 호스트에서 운영 중인 DB를 새 설치본으로 옮기는 `db-dump` / `db-restore` 경로를 추가했다.

## 변경

- **install.sh**
  - curl 부트스트랩 기본 위치 `$HOME/openmake_llm` → `$HOME/.openmake/chat` (`OMK_HOME`으로 재정의 가능).
  - `--instance NAME`: `$HOME/.openmake/chat-NAME`에 별도 인스턴스 설치. PM2 앱(`openmake-llm-NAME` / `openmake-next-NAME`), docker 컨테이너·볼륨(`openmake-NAME-postgres` / `openmake-NAME_pgdata`), 기본 포트(52417/3010/5433/6380)를 분리하고 `.env`의 `OMK_INSTANCE`로 고정. 재실행 시 `.env`의 인스턴스와 플래그가 다르면 중단.
  - `--public-url URL`: `OMK_APP_URL` / `CORS_ORIGINS` / `OMK_WEB_PORT` 반영, https면 `COOKIE_SECURE=true` / `ALLOW_INSECURE_COOKIES=false`. 지정 시 외부 접속 프롬프트 생략.
  - 포트 충돌 회피·컨테이너 대기·PM2 로그가 모두 인스턴스 이름을 쓴다.
- **scripts/setup/gen-env.mjs**: `OMK_INSTANCE` 입력. 신규 생성 시 `OMK_WEB_PORT` · `COMPOSE_PROJECT_NAME`(· `OMK_INSTANCE`) 기록. 보수 모드에서는 이 키들을 덧붙이지 않는다 — 기존 설치본이 `OMK_APP_URL`로 옮겨 둔 웹 포트를 기본값으로 덮어쓰지 않도록.
- **infra/docker-compose.yml**: `container_name` / 볼륨 `name`에 `openmake${OMK_INSTANCE:+-…}` 보간. 미설정이면 기존 이름 그대로. `COMPOSE_PROJECT_NAME`을 컨테이너 이름에 쓰지 않은 이유는 compose가 해석된 프로젝트 이름을 보간 변수로도 노출해 기본 설치본이 `infra-postgres`로 바뀌기 때문 (compose 5.3.1에서 확인).
- **openmake_llm.sh**: `.env`의 `OMK_INSTANCE`로 PM2·컨테이너 이름 도출. 이름 있는 인스턴스는 호스트 Caddyfile 동기화 생략. `db-dump [파일]` / `db-restore <파일> [--yes]` 추가 (앱 정지 → DROP/CREATE → `pg_restore` → migrate → 재시작). 복원 전 원본 `.env`의 `TOKEN_ENCRYPTION_KEY` / `API_KEY_PEPPER` / `JWT_SECRET`을 옮겨야 함을 안내.
- **uninstall.sh**: 인스턴스 이름으로 PM2·컨테이너·볼륨 제거.
- README(ko/en/ja/zh-CN) · `.env.example` 반영.

## 호환

- 인스턴스 미지정(기본) 설치본은 PM2 이름·컨테이너·볼륨 이름이 그대로다. 기존 `.env`에 새 키를 덧붙이지 않는다.
- 신규 기본 설치본은 `COMPOSE_PROJECT_NAME=openmake`가 `.env`에 들어간다 (예전엔 디렉터리명 `infra`). 새 볼륨이라 영향 없음.

## 검증

- `bash -n` / `node --check` 통과. `docker compose config`로 기본·인스턴스 두 경우의 컨테이너·볼륨·프로젝트 이름 확인.
- 실제 호스트(macOS arm64, colima)에서 `install.sh --yes --instance staging --public-url https://…` 원샷 설치 → compose 기동 → 마이그레이션 → 빌드 → health OK. Caddy 뒤에서 CSRF 토큰 → 관리자 로그인 200 → `/api/auth/me` 200 확인.
- 기본 인스턴스 설치는 같은 호스트의 옛 `openmake-postgres` 컨테이너와 이름이 겹쳐 compose 단계에서 중단됨 — 기본 인스턴스는 한 호스트에 하나만 가능하다는 기존 제약 그대로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LywYLujZ418FXHkoPZN5MU
