### PR TITLE
feat(agent-task): 병렬 에이전트 진행을 실시간 상태로 노출

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1301,6 +1301,8 @@ LOCAL_BRIDGE_LSP_TIMEOUT_MS=10000
 # agent_task_subagent_steps 에 남긴다(웹 상세·CLI show --steps·GET /:id/subagents). false 로 끔.
 # AGENT_TASK_SUBAGENT_TRACE_ENABLED=true
 # AGENT_TASK_SUBAGENT_TRACE_CAP=2000
+# 진행 화면의 서브에이전트 라벨 상한(자) — role/agentId 가 없을 때 서브목표 앞부분을 라벨로 쓴다.
+# AGENT_TASK_SUBAGENT_LABEL_MAX=60
 
 # Agent Task — 동적 도구 선별 방식: keyword(기본) | embedding(bge-m3 코사인, 실패 시 키워드 폴백).
 # AGENT_TASK_DYNAMIC_TOOLS_MODE=keyword

--- a/apps/api/src/__tests__/routes/agent-task-subagent-group.test.ts
+++ b/apps/api/src/__tests__/routes/agent-task-subagent-group.test.ts
@@ -1,5 +1,5 @@
 /** groupSubagentSteps — 행 → 서브에이전트(trace, sub_index) 단위 묶음과 정렬 계약. */
-import { groupSubagentSteps } from '../../routes/agent-task-subagent.routes';
+import { groupSubagentSteps, deriveSubagentStatus } from '../../routes/agent-task-subagent.routes';
 
 const at = (s: string) => new Date(`2026-08-26T10:00:${s}Z`);
 const row = (trace: string, sub: number, seq: number, type: string, sec: string, tool: string | null = null) => ({
@@ -26,5 +26,49 @@ describe('groupSubagentSteps', () => {
 
     test('빈 입력은 빈 배열', () => {
         expect(groupSubagentSteps([])).toEqual([]);
+    });
+});
+
+describe('deriveSubagentStatus', () => {
+    test('등록만 된 서브는 대기 중 — 실행 슬롯을 기다리는 동안에도 목록에 보여야 한다', () => {
+        expect(deriveSubagentStatus(['queued'])).toBe('queued');
+    });
+
+    test('실행 진입/활동이 있으면 running, 마무리가 있으면 그 결과가 이긴다', () => {
+        expect(deriveSubagentStatus(['queued', 'started'])).toBe('running');
+        expect(deriveSubagentStatus(['queued', 'started', 'tool_call'])).toBe('running');
+        expect(deriveSubagentStatus(['queued', 'started', 'final'])).toBe('completed');
+        expect(deriveSubagentStatus(['queued', 'started', 'error'])).toBe('failed');
+        expect(deriveSubagentStatus(['queued', 'started', 'final', 'error'])).toBe('failed');
+    });
+
+    test('queued/started 마킹 이전 기록(tool_call 로 시작)도 대기 중으로 오판하지 않는다', () => {
+        expect(deriveSubagentStatus(['tool_call', 'tool_result'])).toBe('running');
+        expect(deriveSubagentStatus(['tool_call', 'final'])).toBe('completed');
+    });
+});
+
+describe('groupSubagentSteps — 상태·종료 시각', () => {
+    test('상태와 finishedAt 이 스텝에서 파생된다', () => {
+        const g = groupSubagentSteps([
+            row('s1', 0, 0, 'queued', '01'), row('s1', 0, 1, 'started', '02'), row('s1', 0, 2, 'final', '09'),
+            row('s1', 1, 0, 'queued', '01'),
+        ]);
+        expect(g[0].status).toBe('completed');
+        expect(g[0].finishedAt).toBe(at('09').toISOString());
+        expect(g[1].status).toBe('queued');
+        expect(g[1].finishedAt).toBeNull();
+    });
+
+    test('부모 작업이 끝났는데 마무리 기록이 없으면 중단으로 — 영원한 "실행 중" 차단', () => {
+        const rows = [row('s1', 0, 0, 'queued', '01'), row('s1', 0, 1, 'started', '02')];
+        expect(groupSubagentSteps(rows, 'running')[0].status).toBe('running');
+        expect(groupSubagentSteps(rows, 'cancelled')[0].status).toBe('interrupted');
+        expect(groupSubagentSteps(rows, 'failed')[0].status).toBe('interrupted');
+    });
+
+    test('부모가 끝나도 이미 마무리된 서브의 상태는 바뀌지 않는다', () => {
+        const g = groupSubagentSteps([row('s1', 0, 0, 'final', '05')], 'completed');
+        expect(g[0].status).toBe('completed');
     });
 });

--- a/apps/api/src/config/runtime-limits.ts
+++ b/apps/api/src/config/runtime-limits.ts
@@ -1863,6 +1863,9 @@ export const AGENT_TASK_LIMITS = {
     SUBAGENT_TRACE_ENABLED: process.env.AGENT_TASK_SUBAGENT_TRACE_ENABLED !== 'false',
     /** 서브 스텝 본문 상한(자) — 도구 결과 전문은 부모 tool_result 에 이미 있으므로 미리보기만. */
     SUBAGENT_TRACE_CONTENT_CAP: parseInt(process.env.AGENT_TASK_SUBAGENT_TRACE_CAP || '2000', 10),
+    /** 서브에이전트 라벨 상한(자) — role/agentId 가 없을 때 서브목표 앞부분을 라벨로 쓴다.
+     *  진행 목록에서 한 줄로 읽히는 길이. AGENT_TASK_SUBAGENT_LABEL_MAX. */
+    SUBAGENT_LABEL_MAX_CHARS: parseInt(process.env.AGENT_TASK_SUBAGENT_LABEL_MAX || '60', 10),
     /** 동적 도구 선별 방식(Phase 5-4): 'keyword'(기본 — 무-LLM 오버랩) | 'embedding'(bge-m3 코사인,
      *  어휘가 달라도 의미 매칭. 실패 시 키워드 폴백). AGENT_TASK_DYNAMIC_TOOLS_MODE. */
     DYNAMIC_TOOLS_MODE: (process.env.AGENT_TASK_DYNAMIC_TOOLS_MODE === 'embedding' ? 'embedding' : 'keyword') as 'keyword' | 'embedding',

--- a/apps/api/src/routes/agent-task-subagent.routes.ts
+++ b/apps/api/src/routes/agent-task-subagent.routes.ts
@@ -2,7 +2,7 @@
  * 서브에이전트 활동 조회 — mount: `/api/agent-tasks` (agentTaskRouter 의 `/:taskId` 보다 먼저).
  *
  *   GET /api/agent-tasks/:taskId/subagents
- *     → { traces: [{ traceId, origin, subIndex, label, startedAt, steps: [{ seq, type, tool, content, at }] }] }
+ *     → { traces: [{ traceId, origin, subIndex, label, status, startedAt, finishedAt, steps: [...] }] }
  *
  * delegate/spawn 서브에이전트는 부모 스텝 번호 공간 밖에서 돌므로(109 주석) 별도 테이블·별도
  * 엔드포인트다. 인증은 작업 본 라우트와 같은 축(JWT 또는 bridge API key) — CLI 도 읽는다.
@@ -20,26 +20,60 @@ import { loadOwnedTask } from './agent-task.helpers';
 
 export const agentTaskSubagentRouter = Router();
 
+/** 부모 작업이 이 상태면 더 이상 서브가 진행될 수 없다 — 미완 서브는 중단으로 읽는다. */
+const TERMINAL_TASK_STATUSES = new Set(['completed', 'failed', 'cancelled']);
+
+/** 서브에이전트 1개의 진행 상태. `interrupted` 는 부모가 끝났는데 마무리 기록이 없는 경우. */
+export type SubagentStatus = 'queued' | 'running' | 'completed' | 'failed' | 'interrupted';
+
 export interface SubagentTraceView {
     traceId: string;
     origin: string;
     subIndex: number;
     label: string | null;
+    status: SubagentStatus;
+    /** 첫 기록 시각 — 등록(queued) 이 있으면 등록 시각, 없는 옛 기록은 첫 활동 시각. */
     startedAt: string;
+    /** 종료(final/error) 시각 — 진행 중이면 null. */
+    finishedAt: string | null;
     steps: { seq: number; type: string; tool: string | null; content: string | null; at: string }[];
 }
 
+/**
+ * PURE: 스텝 종류 목록 → 진행 상태.
+ *
+ * `queued`/`started` 마킹 이전(109 초기)에 쌓인 기록은 tool_call 로 시작하므로, queued 외의
+ * 활동이 하나라도 있으면 실행된 것으로 본다 — 옛 행이 전부 "대기 중"으로 보이지 않게.
+ */
+export function deriveSubagentStatus(stepTypes: string[]): SubagentStatus {
+    if (stepTypes.includes('error')) return 'failed';
+    if (stepTypes.includes('final')) return 'completed';
+    if (stepTypes.some((t) => t !== 'queued')) return 'running';
+    return 'queued';
+}
+
 /** PURE: 행 목록 → trace(=서브에이전트 1개) 단위 묶음. 시작 시각 오름차순. */
-export function groupSubagentSteps(rows: SubagentStepRow[]): SubagentTraceView[] {
+export function groupSubagentSteps(rows: SubagentStepRow[], taskStatus?: string): SubagentTraceView[] {
     const map = new Map<string, SubagentTraceView>();
     for (const r of rows) {
         const key = `${r.trace_id}:${r.sub_index}`;
         let v = map.get(key);
         if (!v) {
-            v = { traceId: r.trace_id, origin: r.origin, subIndex: r.sub_index, label: r.label, startedAt: r.created_at.toISOString(), steps: [] };
+            v = {
+                traceId: r.trace_id, origin: r.origin, subIndex: r.sub_index, label: r.label,
+                status: 'queued', startedAt: r.created_at.toISOString(), finishedAt: null, steps: [],
+            };
             map.set(key, v);
         }
         v.steps.push({ seq: r.seq, type: r.step_type, tool: r.tool_name, content: r.content, at: r.created_at.toISOString() });
+    }
+    const parentDone = taskStatus !== undefined && TERMINAL_TASK_STATUSES.has(taskStatus);
+    for (const v of map.values()) {
+        v.status = deriveSubagentStatus(v.steps.map((s) => s.type));
+        const end = v.steps.find((s) => s.type === 'final' || s.type === 'error');
+        v.finishedAt = end ? end.at : null;
+        // 부모가 끝났는데 마무리 기록이 없으면 그 서브는 되살아나지 않는다 — 영원한 "실행 중" 차단.
+        if (parentDone && (v.status === 'running' || v.status === 'queued')) v.status = 'interrupted';
     }
     return [...map.values()].sort((a, b) => a.startedAt.localeCompare(b.startedAt) || a.subIndex - b.subIndex);
 }
@@ -48,7 +82,7 @@ agentTaskSubagentRouter.get('/:taskId/subagents', requireAuthOrApiKeyScope(API_K
     const task = await loadOwnedTask(req, res, req.params.taskId);
     if (!task) return;
     const rows = await new AgentTaskSubagentStepRepository(getUnifiedDatabase().getPool()).listByTask(req.params.taskId);
-    res.json(success({ traces: groupSubagentSteps(rows) }));
+    res.json(success({ traces: groupSubagentSteps(rows, task.status) }));
 }));
 
 export default agentTaskSubagentRouter;

--- a/apps/api/src/services/agent-spawn/spawn-agents.test.ts
+++ b/apps/api/src/services/agent-spawn/spawn-agents.test.ts
@@ -24,9 +24,20 @@ jest.mock('../task-sandbox/approval-gate', () => ({
     getApprovalRegistry: () => ({ isAutoApprove: (id: string) => autoApproveMock(id) }),
 }));
 
+/** 서브 수명 마킹 관측 — `${subIndex}:${event}` 순서로 쌓는다. */
+const mockTraceEvents: string[] = [];
 jest.mock('../agent-task/subagent-trace', () => ({
+    ...jest.requireActual('../agent-task/subagent-trace'),
     newTraceId: () => 'trace-test',
-    SubagentTrace: class { record = jest.fn(); },
+    SubagentTrace: class {
+        constructor(
+            public taskId: string, public traceId: string, public origin: string,
+            public subIndex: number, public label: string | null,
+        ) {}
+        record = jest.fn((type: string) => { mockTraceEvents.push(`${this.subIndex}:${type}`); });
+        queued = jest.fn(() => { mockTraceEvents.push(`${this.subIndex}:queued(${this.label})`); });
+        started = jest.fn(() => { mockTraceEvents.push(`${this.subIndex}:started`); });
+    },
 }));
 
 const runSubagentMock = jest.fn();
@@ -81,6 +92,7 @@ const baseParams = {
 
 beforeEach(() => {
     jest.clearAllMocks();
+    mockTraceEvents.length = 0;
     autoApproveMock.mockReturnValue(false);
     runSubagentMock.mockImplementation(async (p: { subgoal: string }) => `RESULT<${p.subgoal}>`);
     routeToAgentMock.mockResolvedValue({ agentId: 'finance' });
@@ -329,5 +341,43 @@ describe('buildTaskSpawnFn — 에이전트 작업 경로', () => {
         await spawn({ tasks: [{ prompt: 'x' }] });
         const passed = runSubagentMock.mock.calls[0][0].tools.map((t: ToolDefinition) => t.function.name);
         expect(passed).toEqual(['web_search']);
+    });
+});
+
+describe('runSpawnAgents 수명 마킹(진행 화면 근거)', () => {
+    test('실행 전에 전원이 등록된다 — 동시성 상한(2) 때문에 아직 못 뜬 서브도 목록에 보여야 한다', async () => {
+        // 3개 태스크 · MAX_PARALLEL=2 → 세 번째는 슬롯을 기다린다. 등록이 실행보다 먼저여야
+        // 그 대기 구간이 화면에 "대기 중"으로 나타난다.
+        await runSpawnAgents({
+            ...baseParams,
+            args: { tasks: [{ prompt: 'a' }, { prompt: 'b' }, { prompt: 'c' }] },
+        });
+        const queuedAt = mockTraceEvents.findIndex((e) => e === '2:queued(c)');
+        const firstStart = mockTraceEvents.findIndex((e) => e.endsWith(':started'));
+        expect(queuedAt).toBeGreaterThanOrEqual(0);
+        expect(queuedAt).toBeLessThan(firstStart);
+        expect(mockTraceEvents.filter((e) => e.includes('queued'))).toHaveLength(3);
+    });
+
+    test('role 이 없으면 서브목표가 라벨이 된다 — "서브 1·2·3" 만 남지 않게', async () => {
+        await runSpawnAgents({ ...baseParams, args: { tasks: [{ prompt: 'GB10 아키텍처 조사' }] } });
+        expect(mockTraceEvents).toContain('0:queued(GB10 아키텍처 조사)');
+    });
+
+    test('role 이 있으면 그것을 라벨로 쓴다', async () => {
+        await runSpawnAgents({ ...baseParams, args: { tasks: [{ prompt: 'x', role: 'finance' }] } });
+        expect(mockTraceEvents).toContain('0:queued(finance)');
+    });
+
+    test('서브 실행이 던지면 error 로 마감된다 — 영원한 "실행 중" 방지', async () => {
+        runSubagentMock.mockRejectedValueOnce(new Error('boom'));
+        const out = await runSpawnAgents({ ...baseParams, args: { tasks: [{ prompt: 'a' }] } });
+        expect(out).toMatch(/boom/);
+        expect(mockTraceEvents).toEqual(['0:queued(a)', '0:started', '0:error']);
+    });
+
+    test('채팅 경로(작업 행 없음)는 기록하지 않는다', async () => {
+        await runSpawnAgents({ ...baseParams, taskId: '__chat__', args: { tasks: [{ prompt: 'a' }] } });
+        expect(mockTraceEvents).toEqual([]);
     });
 });

--- a/apps/api/src/services/agent-spawn/spawn-agents.ts
+++ b/apps/api/src/services/agent-spawn/spawn-agents.ts
@@ -32,7 +32,7 @@ import { routeToAgent } from '../../agents/keyword-router';
 import { getAgentSystemMessage } from '../../agents/system-prompt';
 import { requiresApproval, getApprovalRegistry } from '../task-sandbox/approval-gate';
 import { runSubagent } from '../agent-task/subagent';
-import { SubagentTrace, newTraceId } from '../agent-task/subagent-trace';
+import { SubagentTrace, newTraceId, subagentLabel } from '../agent-task/subagent-trace';
 import type { DelegateFactoryParams } from '../agent-task/delegate';
 import { CHAT_DELEGATE_TOOL_NAME } from '../chat-service/chat-delegate';
 import { SPAWN_AGENT_GENERIC_PROMPT } from '../../prompts/spawn-agent-system';
@@ -264,19 +264,28 @@ export async function runSpawnAgents(p: SpawnAgentsParams): Promise<string> {
 
     // 활동 기록(109) — 에이전트 작업 경로만(채팅은 작업 행이 없다). fan-out 1회 = trace 1개.
     const traceId = p.taskId !== CHAT_PSEUDO_TASK_ID ? newTraceId() : null;
+    // 전원을 실행 전에 등록한다 — 동시성 상한에 걸려 슬롯을 기다리는 서브도 진행 화면에 보여야
+    // fan-out 이 몇 갈래인지 알 수 있다(첫 도구 호출 때 만들면 대기 중 서브는 유령이 된다).
+    const traces = traceId
+        ? tasks.map((task, idx) => {
+            const tr = new SubagentTrace(p.taskId, traceId, 'spawn_agents', idx,
+                subagentLabel(task.role ?? task.agentId, task.prompt));
+            tr.queued(task.prompt);
+            return tr;
+        })
+        : null;
     let results: Array<string | null>;
     try {
         results = await parallelBatch(
             tasks,
             async (task, idx) => {
+                const trace = traces?.[idx];
+                trace?.started();
                 try {
                     const exec = await resolveTaskExecution(task, userId, p.client);
                     if (exec.modelNote) {
                         logger.info(`[AgentSpawn] 태스크 ${idx + 1} custom agent 모델: ${exec.modelNote}`);
                     }
-                    const trace = traceId
-                        ? new SubagentTrace(p.taskId, traceId, 'spawn_agents', idx, task.role ?? task.agentId ?? null)
-                        : undefined;
                     return await runSubagent({
                         ...(trace ? { trace } : {}),
                         client: exec.client,
@@ -293,6 +302,9 @@ export async function runSpawnAgents(p: SpawnAgentsParams): Promise<string> {
                 } catch (e) {
                     const msg = e instanceof Error ? e.message : String(e);
                     logger.warn(`[AgentSpawn] 태스크 ${idx + 1} 실패: ${msg}`);
+                    // runSubagent 안에서 죽으면 그쪽이 기록하지만, 모델 해석(resolveTaskExecution)
+                    // 단계 실패는 여기서만 보인다 — 안 남기면 그 서브가 영영 "실행 중"으로 남는다.
+                    trace?.record('error', msg);
                     return `Error: 서브에이전트 실패 — ${msg}`;
                 }
             },

--- a/apps/api/src/services/agent-task/delegate.ts
+++ b/apps/api/src/services/agent-task/delegate.ts
@@ -17,7 +17,7 @@ import { AGENT_TASK_LIMITS } from '../../config/runtime-limits';
 import { routeToAgent } from '../../agents/keyword-router';
 import { getAgentSystemMessage } from '../../agents/system-prompt';
 import { runSubagent } from './subagent';
-import { SubagentTrace, newTraceId } from './subagent-trace';
+import { SubagentTrace, newTraceId, subagentLabel } from './subagent-trace';
 
 export interface DelegateFactoryParams {
     client: LLMClient;
@@ -44,8 +44,12 @@ export function buildDelegateFn(p: DelegateFactoryParams): DelegateFn {
             const subTools = p.sandboxCfg.extraTools
                 .map((n) => p.mcpTools.find((t) => t.function.name === n))
                 .filter((t): t is ToolDefinition => !!t);
+            const trace = new SubagentTrace(p.taskId, newTraceId(), 'delegate', 0,
+                subagentLabel(role ?? selection.primaryAgent, subgoal));
+            trace.queued(subgoal);
+            trace.started();
             return runSubagent({
-                trace: new SubagentTrace(p.taskId, newTraceId(), 'delegate', 0, role ?? selection.primaryAgent ?? null),
+                trace,
                 client: p.client, personaPrompt: prompt, subgoal,
                 tools: subTools, userCtx: p.userCtx, taskId: p.taskId,
                 sandboxCfg: p.sandboxCfg, signal: p.signal,

--- a/apps/api/src/services/agent-task/subagent-trace.ts
+++ b/apps/api/src/services/agent-task/subagent-trace.ts
@@ -15,7 +15,9 @@ import { createLogger } from '../../utils/logger';
 const logger = createLogger('SubagentTrace');
 
 export type SubagentOrigin = 'spawn_agents' | 'delegate';
-export type SubagentStepType = 'tool_call' | 'tool_result' | 'final' | 'error';
+/** `queued`/`started` 는 수명 마킹(활동 아님) — 이 둘이 없으면 아직 첫 도구를 부르지 않은 서브는
+ *  테이블에 행이 없어 진행 화면에 존재조차 하지 않는다("대기 중"·"실행 중"을 표현할 수 없음). */
+export type SubagentStepType = 'queued' | 'started' | 'tool_call' | 'tool_result' | 'final' | 'error';
 
 /** fan-out/위임 1회를 묶는 id — 같은 fan-out 의 서브들은 trace_id 를 공유하고 sub_index 로 갈린다. */
 export function newTraceId(): string {
@@ -45,4 +47,25 @@ export class SubagentTrace {
             label: this.label, seq, step_type: stepType, tool_name: toolName ?? null, content: text,
         }).catch((e) => logger.warn(`서브에이전트 스텝 기록 실패 (${this.taskId}/${this.subIndex}#${seq}): ${e instanceof Error ? e.message : e}`));
     }
+
+    /** fan-out 등록 — 실행 슬롯을 기다리는 동안에도 목록에 보이도록 서브목표를 남긴다. */
+    queued(subgoal: string): void {
+        this.record('queued', subgoal);
+    }
+
+    /** 실행 진입 — queued 와 갈라져야 "대기 중"과 "실행 중"이 구분된다. */
+    started(): void {
+        this.record('started', '');
+    }
+}
+
+/** PURE: 서브에이전트 표시 라벨 — role/agentId 가 없으면 서브목표 앞부분으로 대신한다.
+ *  (라벨이 비면 진행 목록이 "서브 1·서브 2"로만 남아 무엇을 시키는지 알 수 없다.) */
+export function subagentLabel(explicit: string | null | undefined, subgoal: string): string | null {
+    const named = explicit?.trim();
+    if (named) return named;
+    const text = subgoal.trim().replace(/\s+/g, ' ');
+    if (!text) return null;
+    const max = AGENT_TASK_LIMITS.SUBAGENT_LABEL_MAX_CHARS;
+    return text.length > max ? `${text.slice(0, max)}…` : text;
 }

--- a/apps/web/app/(workspace)/agent-tasks/page.tsx
+++ b/apps/web/app/(workspace)/agent-tasks/page.tsx
@@ -27,6 +27,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { ArtifactFrame } from "@/components/chat/artifact-frame";
+import { SubagentPanel, type SubagentTraceView } from "@/components/agent-tasks/subagent-panel";
 import {
   Button,
   Badge,
@@ -126,15 +127,6 @@ interface ApiTaskStep {
 
 type AgentTasksResponse = ApiSuccess<{ tasks: ApiAgentTask[]; total: number }>;
 type AgentTaskDetailResponse = ApiSuccess<{ task: ApiAgentTask; steps: ApiTaskStep[] }>;
-/** 서브에이전트 활동(109) — delegate/spawn 서브 1개 = trace 1개 */
-interface SubagentTraceView {
-  traceId: string;
-  origin: string;
-  subIndex: number;
-  label: string | null;
-  startedAt: string;
-  steps: { seq: number; type: string; tool: string | null; content: string | null; at: string }[];
-}
 type SubagentsResponse = ApiSuccess<{ traces: SubagentTraceView[] }>;
 
 /* ── 유틸 ────────────────────────────────────────────────── */
@@ -727,33 +719,8 @@ function TaskDetailModal({
             </div>
           )}
 
-          {/* 서브에이전트 활동(109) — delegate/spawn 서브가 실제로 무엇을 했는지. 부모 스텝에는 결과만 남는다. */}
-          {subagents.length > 0 && (
-            <div className="rounded-md border border-border bg-surface-1 p-3">
-              <p className="mb-2 text-xs font-medium text-fg-2">{t("subagents.title", { count: subagents.length })}</p>
-              <div className="max-h-72 space-y-3 overflow-y-auto pr-1">
-                {subagents.map((tr) => (
-                  <div key={`${tr.traceId}:${tr.subIndex}`} className="space-y-1">
-                    <div className="flex flex-wrap items-center gap-2 text-xs">
-                      <Badge tone="accent">{tr.origin === "spawn_agents" ? t("subagents.originSpawn", { n: tr.subIndex + 1 }) : t("subagents.originDelegate")}</Badge>
-                      {tr.label && <span className="text-muted">{tr.label}</span>}
-                      <span className="text-faint">{t("subagents.stepCount", { count: tr.steps.length })}</span>
-                    </div>
-                    <ul className="space-y-0.5 pl-2">
-                      {tr.steps.map((st) => (
-                        <li key={st.seq} className="flex gap-2 text-[11px]">
-                          <span className={cn("shrink-0 font-mono", st.type === "error" ? "text-danger" : st.type === "final" ? "text-success" : "text-faint")}>
-                            {st.tool ?? st.type}
-                          </span>
-                          <span className="min-w-0 flex-1 truncate text-muted" title={st.content ?? ""}>{st.content}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
+          {/* 병렬 에이전트(109 + 수명 마킹) — fan-out 갈래별 진행 상태. */}
+          <SubagentPanel traces={subagents} />
 
           {/* 실행 스텝 — 터미널 스타일(도구 출력 전문) */}
           {detail.steps.length === 0 ? (

--- a/apps/web/components/agent-tasks/subagent-panel.tsx
+++ b/apps/web/components/agent-tasks/subagent-panel.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+/**
+ * 병렬 에이전트 패널 — fan-out(spawn_agents)·위임(delegate) 서브에이전트의 진행 상태.
+ *
+ * 서버가 서브 하나마다 수명(queued→started→…→final/error)을 남기므로(109 + 수명 마킹),
+ * 실행 중에도 "몇 갈래가 돌고 있고 각각 어디까지 왔는지"를 그대로 보여준다. 스텝 전문은
+ * 기본으로 접고 최근 활동 한 줄만 노출한다 — 서브가 여럿이면 스텝이 화면을 덮어
+ * 정작 알고 싶은 갈래별 상태가 묻힌다.
+ */
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Circle, CircleCheck, CircleX, CircleDot, CircleMinus, ChevronRight, type LucideIcon } from "lucide-react";
+import { Badge } from "@/components/ui/primitives";
+import { ApiClient } from "@/lib/api-client";
+import type { ApiSuccess } from "@openmake/shared-types";
+import { cn } from "@/lib/utils";
+
+/** 진행 중 갱신 주기(ms) — 작업 상세 폴링과 같은 리듬. */
+const LIVE_POLL_MS = 2500;
+
+export type SubagentStatus = "queued" | "running" | "completed" | "failed" | "interrupted";
+
+/** 서브에이전트 활동(109) — delegate/spawn 서브 1개 = trace 1개 */
+export interface SubagentTraceView {
+  traceId: string;
+  origin: string;
+  subIndex: number;
+  label: string | null;
+  status: SubagentStatus;
+  startedAt: string;
+  finishedAt: string | null;
+  steps: { seq: number; type: string; tool: string | null; content: string | null; at: string }[];
+}
+
+const STATUS_ICON: Record<SubagentStatus, LucideIcon> = {
+  queued: Circle,
+  running: CircleDot,
+  completed: CircleCheck,
+  failed: CircleX,
+  interrupted: CircleMinus,
+};
+
+const STATUS_TONE: Record<SubagentStatus, "neutral" | "accent" | "success" | "danger" | "warn"> = {
+  queued: "neutral",
+  running: "accent",
+  completed: "success",
+  failed: "danger",
+  interrupted: "warn",
+};
+
+const STATUS_COLOR: Record<SubagentStatus, string> = {
+  queued: "text-faint",
+  running: "text-accent",
+  completed: "text-success",
+  failed: "text-danger",
+  interrupted: "text-warn",
+};
+
+/** 접힌 상태에서 보여줄 최근 활동 — 진행 중인 서브가 살아 있음을 한 줄로 알린다. */
+function lastActivity(tr: SubagentTraceView): { tool: string | null; text: string } | null {
+  for (let i = tr.steps.length - 1; i >= 0; i--) {
+    const s = tr.steps[i];
+    if (s.type === "queued" || s.type === "started") continue;
+    return { tool: s.tool, text: (s.content ?? "").replace(/\s+/g, " ").trim() };
+  }
+  return null;
+}
+
+export function SubagentPanel({ traces }: { traces: SubagentTraceView[] }) {
+  const t = useTranslations("agentTasks");
+  const [open, setOpen] = useState<Set<string>>(new Set());
+  if (traces.length === 0) return null;
+
+  const done = traces.filter((tr) => tr.status === "completed").length;
+  const running = traces.filter((tr) => tr.status === "running").length;
+  const toggle = (key: string) =>
+    setOpen((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+
+  return (
+    <div className="rounded-md border border-border bg-surface-1 p-3">
+      <div className="mb-2 flex flex-wrap items-center gap-2">
+        <p className="text-xs font-medium text-fg-2">{t("subagents.title", { count: traces.length })}</p>
+        <span className="font-mono text-[11px] text-faint">
+          {t("subagents.summary", { done, total: traces.length })}
+          {running > 0 ? ` · ${t("subagents.runningCount", { count: running })}` : ""}
+        </span>
+      </div>
+
+      {/* 좌측 세로선 = fan-out 한 갈래씩. 실행 스텝 타임라인과 같은 시각 언어를 쓴다. */}
+      <ul className="space-y-1 border-l border-border pl-3">
+        {traces.map((tr) => {
+          const key = `${tr.traceId}:${tr.subIndex}`;
+          const expanded = open.has(key);
+          const Icon = STATUS_ICON[tr.status];
+          const activity = lastActivity(tr);
+          const name = tr.label
+            ?? (tr.origin === "spawn_agents" ? t("subagents.originSpawn", { n: tr.subIndex + 1 }) : t("subagents.originDelegate"));
+          return (
+            <li key={key}>
+              <button
+                type="button"
+                onClick={() => toggle(key)}
+                aria-expanded={expanded}
+                className="flex w-full items-start gap-2 rounded px-1 py-1 text-left transition hover:bg-surface-2"
+              >
+                <Icon
+                  className={cn("mt-0.5 h-3.5 w-3.5 shrink-0", STATUS_COLOR[tr.status], tr.status === "running" && "animate-pulse")}
+                  aria-label={tr.status}
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="flex flex-wrap items-center gap-1.5">
+                    <span className="truncate text-xs text-fg-2">{name}</span>
+                    <Badge tone={STATUS_TONE[tr.status]}>{t(`subagents.status.${tr.status}`)}</Badge>
+                    {tr.steps.length > 0 && (
+                      <span className="font-mono text-[11px] text-faint">{t("subagents.stepCount", { count: tr.steps.length })}</span>
+                    )}
+                  </span>
+                  {/* 접혀 있어도 지금 무엇을 하는 중인지는 보인다. */}
+                  {!expanded && activity && (
+                    <span className="mt-0.5 flex gap-1.5 text-[11px] text-muted">
+                      {activity.tool && <span className="shrink-0 font-mono text-faint">{activity.tool}</span>}
+                      <span className="min-w-0 flex-1 truncate">{activity.text}</span>
+                    </span>
+                  )}
+                </span>
+                <ChevronRight className={cn("mt-0.5 h-3.5 w-3.5 shrink-0 text-faint transition", expanded && "rotate-90")} />
+              </button>
+
+              {expanded && (
+                <ul className="space-y-0.5 py-1 pl-6">
+                  {tr.steps.map((st) => (
+                    <li key={st.seq} className="flex gap-2 text-[11px]">
+                      <span className={cn(
+                        "shrink-0 font-mono",
+                        st.type === "error" ? "text-danger" : st.type === "final" ? "text-success" : "text-faint",
+                      )}>
+                        {st.tool ?? st.type}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate text-muted" title={st.content ?? ""}>{st.content}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+type SubagentsResponse = ApiSuccess<{ traces: SubagentTraceView[] }>;
+
+/**
+ * 채팅 인라인용 — 작업 id 로 직접 조회한다. 채팅이 에이전트 작업의 주 진입점이라, 여기서
+ * fan-out 이 안 보이면 병렬로 돌고 있다는 사실 자체를 사용자가 알 수 없다.
+ * 조회 실패·fan-out 없음은 조용히 아무것도 그리지 않는다(부가 정보라 본 카드를 방해하지 않음).
+ */
+export function LiveSubagentPanel({ taskId, active }: { taskId: string; active: boolean }) {
+  const [traces, setTraces] = useState<SubagentTraceView[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const load = async () => {
+      try {
+        const r = await ApiClient.get<SubagentsResponse>(`/api/agent-tasks/${taskId}/subagents`);
+        if (!cancelled) setTraces(r?.data?.traces ?? []);
+      } catch { /* 부가 정보 — 실패해도 카드는 그대로 */ }
+      if (!cancelled && active) timer = setTimeout(load, LIVE_POLL_MS);
+    };
+    void load();
+    return () => { cancelled = true; if (timer) clearTimeout(timer); };
+  }, [taskId, active]);
+
+  return <SubagentPanel traces={traces} />;
+}

--- a/apps/web/components/chat/message-list.tsx
+++ b/apps/web/components/chat/message-list.tsx
@@ -10,6 +10,7 @@ import { SteeringInput } from "@/components/chat/steering-input";
 import { DiffView } from "@/components/chat/diff-view";
 import { useAppStore, type PendingApproval, type AgentTaskState } from "@/lib/store";
 import { ApiClient } from "@/lib/api-client";
+import { LiveSubagentPanel } from "@/components/agent-tasks/subagent-panel";
 import { Markdown } from "./markdown";
 import { StructuredAnswer } from "./structured-answer";
 import { McpResourceCard, decodeMcpResources } from "@/components/chat/mcp-resource-card";
@@ -330,6 +331,8 @@ function AgentTaskCard({ task, approvals, taskId }: { task: AgentTaskState; appr
             {task.lastStep.preview ? ` · ${task.lastStep.preview.slice(0, 80)}` : ""}
           </p>
         )}
+        {/* 병렬 에이전트(fan-out) — 작업 화면에 들어가지 않아도 갈래별 진행이 채팅에서 보인다. */}
+        {taskId && <LiveSubagentPanel taskId={taskId} active={showProgress} />}
         {task.result && (task.status === "completed" || task.status === "failed") && (
           <div className="border-t border-border pt-2.5 text-[13px] leading-relaxed text-fg-2">
             {/* AssistantContent 가 [[artifact:id]] placeholder 를 클릭 칩으로 변환(일반 채팅과 동일). */}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -848,10 +848,19 @@
       "bodyOmitted": "body excluded"
     },
     "subagents": {
-      "title": "Sub-agent activity ({count})",
-      "originSpawn": "Parallel sub #{n}",
-      "originDelegate": "Expert delegate",
-      "stepCount": "{count} steps"
+      "title": "Parallel agents ({count})",
+      "originSpawn": "Sub #{n}",
+      "originDelegate": "Expert delegation",
+      "stepCount": "{count} steps",
+      "summary": "{done}/{total} done",
+      "runningCount": "{count} running",
+      "status": {
+        "queued": "Queued",
+        "running": "Running",
+        "completed": "Completed",
+        "failed": "Failed",
+        "interrupted": "Interrupted"
+      }
     },
     "artifactSize": "{chars} chars",
     "artifactOpen": "Open in new tab",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -848,10 +848,19 @@
       "bodyOmitted": "本文は除外"
     },
     "subagents": {
-      "title": "サブエージェント活動 {count}件",
+      "title": "並列エージェント {count}件",
       "originSpawn": "並列サブ #{n}",
-      "originDelegate": "専門家委任",
-      "stepCount": "{count}ステップ"
+      "originDelegate": "専門家への委任",
+      "stepCount": "{count}ステップ",
+      "summary": "{done}/{total} 完了",
+      "runningCount": "{count}件 実行中",
+      "status": {
+        "queued": "待機中",
+        "running": "実行中",
+        "completed": "完了",
+        "failed": "失敗",
+        "interrupted": "中断"
+      }
     },
     "artifactSize": "{chars}文字",
     "artifactOpen": "新しいタブで開く",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -848,10 +848,19 @@
       "bodyOmitted": "본문 제외"
     },
     "subagents": {
-      "title": "서브에이전트 활동 {count}건",
+      "title": "병렬 에이전트 {count}개",
       "originSpawn": "병렬 서브 #{n}",
       "originDelegate": "전문가 위임",
-      "stepCount": "{count}단계"
+      "stepCount": "{count}단계",
+      "summary": "{done}/{total} 완료",
+      "runningCount": "{count}개 실행 중",
+      "status": {
+        "queued": "대기 중",
+        "running": "실행 중",
+        "completed": "완료",
+        "failed": "실패",
+        "interrupted": "중단됨"
+      }
     },
     "artifactSize": "{chars}자",
     "artifactOpen": "새 탭에서 열기",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -848,10 +848,19 @@
       "bodyOmitted": "不含正文"
     },
     "subagents": {
-      "title": "子代理活动 {count} 条",
-      "originSpawn": "并行子代理 #{n}",
-      "originDelegate": "专家委托",
-      "stepCount": "{count} 步"
+      "title": "并行智能体 {count} 个",
+      "originSpawn": "并行子任务 #{n}",
+      "originDelegate": "专家委派",
+      "stepCount": "{count} 步",
+      "summary": "{done}/{total} 已完成",
+      "runningCount": "{count} 个运行中",
+      "status": {
+        "queued": "等待中",
+        "running": "运行中",
+        "completed": "已完成",
+        "failed": "失败",
+        "interrupted": "已中断"
+      }
     },
     "artifactSize": "{chars} 字",
     "artifactOpen": "在新标签页打开",


### PR DESCRIPTION
## 배경

fan-out(`spawn_agents`)·위임(`delegate`)은 이미 병렬로 돌고 폴링도 2.5초로 이미 돌지만, **화면에서 병렬이라는 사실이 보이지 않았다.** 원인은 UI 가 아니라 기록 구조였다.

| 갭 | 실태 |
|---|---|
| 아직 시작 못 한 서브가 유령 | 기록이 첫 `tool_call` 때 생겨서, 슬롯을 기다리는 서브는 테이블에 행이 없음 → "몇 갈래인지" 알 수 없음 |
| 상태 개념 부재 | 완료/실패/대기 구분 없음. 스텝 목록만 나열 |
| 라벨 대부분 null | `role ?? agentId` 뿐이라 목록이 "병렬 서브 #1·#2"로만 남음 |
| 채팅에서 안 보임 | 작업의 주 진입점인 채팅 인라인 카드에 fan-out 표시 없음 |

## 변경

**서버**
- `SubagentTrace.queued()` / `.started()` — fan-out **등록 시점에 전원** 기록하고 실행 진입에서 갈라진다. 대기/실행이 구분되는 근거.
- `subagentLabel()` (PURE) — role/agentId 가 없으면 서브목표 앞부분(`AGENT_TASK_SUBAGENT_LABEL_MAX`, 60자).
- `deriveSubagentStatus()` (PURE) — `queued | running | completed | failed`. 부모 작업이 종료됐는데 마무리 기록이 없으면 `interrupted` (영원한 "실행 중" 차단).
- `resolveTaskExecution` 단계 실패도 `error` 로 마감 — 종전엔 여기서 죽으면 그 서브가 계속 실행 중으로 보였다.
- 응답에 `status`·`finishedAt` 추가(추가 전용 — CLI 무영향).

**프론트**
- `components/agent-tasks/subagent-panel.tsx` — 갈래별 상태 배지 + 접힘 상태의 최근 활동 한 줄(펼치면 스텝 전문). 서브가 여럿일 때 스텝이 화면을 덮어 정작 갈래별 상태가 묻히던 문제도 같이 해소.
- 채팅 인라인 작업 카드에 같은 패널(`LiveSubagentPanel`) — 진행 중이면 폴링, 실패는 조용히 무시(부가 정보).
- i18n 4 locale.

## 검증

- 단위 39건(상태 파생 9 · spawn 수명 마킹 5 포함), 관련 스위트 **231 passed**.
- **되돌리기 확인**: `tr.queued()` 를 실행 안으로 되돌리면 4건 실패 → 테스트가 분기를 실제로 가른다.
- **운영 실데이터 하위호환**: `queued`/`started` 마킹 이전에 쌓인 3서브(tool_call 로 시작)가 전부 정확히 `completed` 로 파생 — "대기 중" 오판 없음.
- `tsc --noEmit` (api·web) · `npm run lint` 0 errors.

## 체크리스트

- [x] `npm run lint` 통과
- [x] 관련 유닛 테스트 통과 (231)
- [ ] 라이브 검증 (chat.openmake.cc — 배포 후)
- [x] 환경변수 추가 → `.env.example` 갱신 (`AGENT_TASK_SUBAGENT_LABEL_MAX`)
- [x] DB 스키마 변경 없음 — `step_type` 에 CHECK 제약이 없어 값 추가만으로 충분
- 라우팅/응답 변경 없음 → eval 불요

## 범위 밖

채팅에서 **작업을 거치지 않고** 직접 `spawn_agents` 를 부른 경우(`CHAT_PSEUDO_TASK_ID`)는 작업 행이 없어 DB 기록 자체가 없다 — WS 이벤트 축이라 별건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZBoHf9iS6UWwg9maLqWWN