### PR TITLE
fix(llm): 해결 불가 $ref 로 죽던 도구 요청 + 작업 경로 병렬 분담 유도

### DIFF
--- a/apps/api/src/llm/__tests__/tool-strict.test.ts
+++ b/apps/api/src/llm/__tests__/tool-strict.test.ts
@@ -14,7 +14,7 @@ function load(value?: string) {
     jest.resetModules();
     const mod = require('../tool-strict') as typeof import('../tool-strict');
     const sp = require('../stream-parser') as typeof import('../stream-parser');
-    return { apply: mod.applyLocalToolStrict, toOpenAITools: sp.toOpenAITools };
+    return { apply: mod.applyLocalToolStrict, strip: mod.stripUnresolvableRefs, toOpenAITools: sp.toOpenAITools };
 }
 
 const tool = (name: string, strict?: boolean): ToolDefinition => ({
@@ -76,5 +76,85 @@ describe('applyLocalToolStrict', () => {
         expect(out).not.toBe(input);
         expect(input[0].function.strict).toBeUndefined();
         expect(out?.[0].function.parameters).toBe(input[0].function.parameters);
+    });
+});
+
+/** 해결 불가 $ref — 남겨두면 문법 강제 시 upstream 이 요청 전체를 거부한다(2026-09-10 라이브 재현). */
+describe('stripUnresolvableRefs', () => {
+    it('definitions 가 없는 $ref 는 제거하고 나머지 키는 남긴다', () => {
+        const { strip } = load();
+        const out = strip({
+            type: 'object',
+            properties: { from: { description: 'start', $ref: '#/definitions/Timestamp' } },
+        }) as { properties: { from: Record<string, unknown> } };
+        expect(out.properties.from).toEqual({ description: 'start' });
+    });
+
+    it('가리키는 정의가 실재하면 건드리지 않는다(null)', () => {
+        const { strip } = load();
+        expect(strip({
+            type: 'object',
+            definitions: { Timestamp: { type: 'string' } },
+            properties: { from: { $ref: '#/definitions/Timestamp' } },
+        })).toBeNull();
+        expect(strip({ $defs: { T: { type: 'string' } }, properties: { a: { $ref: '#/$defs/T' } } })).toBeNull();
+    });
+
+    it('배열 안쪽·중첩도 따라간다', () => {
+        const { strip } = load();
+        const out = strip({
+            properties: { list: { type: 'array', items: { $ref: '#/$defs/Missing' } } },
+        }) as { properties: { list: { items: Record<string, unknown> } } };
+        expect(out.properties.list.items).toEqual({});
+    });
+
+    it('외부 문서 참조와 anchor 형태도 제거 대상', () => {
+        const { strip } = load();
+        expect(strip({ properties: { a: { $ref: 'https://example.com/s.json' } } })).not.toBeNull();
+        expect(strip({ properties: { a: { $ref: '#Timestamp' } } })).not.toBeNull();
+    });
+
+    it('$ref 가 없으면 null, 순환 객체에서도 멈춘다', () => {
+        const { strip } = load();
+        expect(strip({ type: 'object', properties: { a: { type: 'string' } } })).toBeNull();
+        const cyclic: Record<string, unknown> = { type: 'object' };
+        cyclic.self = cyclic;
+        expect(strip(cyclic)).toBeNull();
+    });
+
+    it('원본을 변경하지 않는다', () => {
+        const { strip } = load();
+        const input = { properties: { from: { $ref: '#/definitions/Missing' } } };
+        strip(input);
+        expect(input.properties.from.$ref).toBe('#/definitions/Missing');
+    });
+});
+
+describe('applyLocalToolStrict — 해결 불가 $ref 도구', () => {
+    const refTool = (name: string): ToolDefinition => ({
+        type: 'function',
+        function: {
+            name,
+            description: 'd',
+            parameters: {
+                type: 'object',
+                properties: { from: { $ref: '#/definitions/Timestamp' } },
+                required: ['from'],
+            } as unknown as ToolDefinition['function']['parameters'],
+        },
+    });
+
+    it('참조를 지운 스키마로 strict 를 유지한다 — 도구별 해제로는 요청이 살지 않는다', () => {
+        const { apply } = load();
+        const out = apply([refTool('bad'), tool('good')]);
+        expect(out?.[0].function.strict).toBe(true);
+        expect(JSON.stringify(out?.[0].function.parameters)).not.toContain('$ref');
+        expect(JSON.stringify(out?.[0].function.parameters)).toContain('required');
+        expect(out?.[1].function.strict).toBe(true);
+    });
+
+    it('도구는 그대로 노출된다(제거하지 않는다)', () => {
+        const { apply } = load();
+        expect(apply([refTool('bad')])).toHaveLength(1);
     });
 });

--- a/apps/api/src/llm/tool-strict.ts
+++ b/apps/api/src/llm/tool-strict.ts
@@ -1,9 +1,62 @@
 import type { ToolDefinition } from './types';
 import { LOCAL_TOOL_STRICT_ENABLED } from '../config/llm-parameters';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('ToolStrict');
 
 export interface ToolStrictContext {
     /** 외부 provider 클라이언트(quotaExempt) — OpenAI strict 규격이 달라 건너뛴다 */
     external?: boolean;
+}
+
+/** 한 번 경고한 도구는 다시 알리지 않는다 — 턴마다 같은 줄이 쌓이는 것을 막되 존재는 남긴다. */
+const warned = new Set<string>();
+
+/** PURE: `#/a/b` JSON Pointer 가 이 문서 안에서 실제로 풀리는지. */
+function resolves(root: unknown, ref: string): boolean {
+    if (ref === '#') return true;
+    if (!ref.startsWith('#/')) return false;   // 외부 문서(`http…`)·anchor(`#Foo`) 는 못 푼다
+    let cur: unknown = root;
+    for (const raw of ref.slice(2).split('/')) {
+        const key = decodeURIComponent(raw).replace(/~1/g, '/').replace(/~0/g, '~');
+        if (!cur || typeof cur !== 'object') return false;
+        cur = (cur as Record<string, unknown>)[key];
+        if (cur === undefined) return false;
+    }
+    return true;
+}
+
+/**
+ * PURE: 해결할 수 없는 `$ref` 키만 걷어낸 스키마 사본. 없으면 `null`(호출부가 원본을 그대로 쓴다).
+ *
+ * MCP 서버가 `{"$ref": "#/definitions/Timestamp"}` 를 주면서 정작 `definitions` 를 함께 보내지
+ * 않는 경우가 실재한다(2026-09-10 라이브: apollo graphos 의 GetTopOperations·GetOperationMetrics·
+ * GetSubgraphMetrics). strict 가 켜지면 vLLM 이 이 참조를 풀지 못해 문법 컴파일에 실패하고
+ * **요청 전체가 500** 이 된다.
+ *
+ * ⚠️ 그 도구만 strict 에서 빼는 것으로는 낫지 않는다 — vLLM 은 strict 도구가 **하나라도** 있으면
+ * 요청의 **모든** 도구 스키마를 문법으로 만든다(`_any_tool_strict`). 라이브에서 실제로 재현했다.
+ * 그래서 참조를 지워 스키마 자체를 유효하게 만든다. 애초에 정의가 없어 검증할 수 없던 필드이므로
+ * 잃는 제약은 없고, `description` 등 나머지 키와 다른 도구의 strict 강제는 그대로 남는다.
+ * 해결되는 `$ref` 는 건드리지 않는다(vLLM 이 처리한다).
+ */
+export function stripUnresolvableRefs(schema: unknown): unknown | null {
+    let changed = false;
+    const seen = new WeakSet<object>();
+    const walk = (node: unknown): unknown => {
+        if (!node || typeof node !== 'object') return node;
+        if (seen.has(node as object)) return node;    // 순환 방어 — 그 가지는 원본을 그대로 둔다
+        seen.add(node as object);
+        if (Array.isArray(node)) return node.map(walk);
+        const out: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+            if (k === '$ref' && typeof v === 'string' && !resolves(schema, v)) { changed = true; continue; }
+            out[k] = walk(v);
+        }
+        return out;
+    };
+    const result = walk(schema);
+    return changed ? result : null;
 }
 
 /**
@@ -16,9 +69,21 @@ export function applyLocalToolStrict(
     ctx: ToolStrictContext = {},
 ): ToolDefinition[] | undefined {
     if (!tools || !LOCAL_TOOL_STRICT_ENABLED || ctx.external) return tools;
-    return tools.map((t) => (
-        t.function.strict === undefined
-            ? { ...t, function: { ...t.function, strict: true } }
-            : t
-    ));
+    return tools.map((t) => {
+        if (t.function.strict !== undefined) return t;
+        const cleaned = stripUnresolvableRefs(t.function.parameters);
+        if (cleaned && !warned.has(t.function.name)) {
+            warned.add(t.function.name);
+            logger.warn(`${t.function.name}: 스키마의 해결 불가 $ref 를 제거했습니다 — `
+                + '그대로 두면 문법 강제 시 upstream 이 요청 전체를 거부합니다.');
+        }
+        return {
+            ...t,
+            function: {
+                ...t.function,
+                ...(cleaned ? { parameters: cleaned as ToolDefinition['function']['parameters'] } : {}),
+                strict: true,
+            },
+        };
+    });
 }

--- a/apps/api/src/prompts/agent-task-prompt.ts
+++ b/apps/api/src/prompts/agent-task-prompt.ts
@@ -77,6 +77,27 @@ export function getAgentTaskSystemPrompt(): string {
 }
 
 /**
+ * 병렬 분담 안내 — `spawn_agents` 가 도구 목록에 실릴 때만 붙인다(`AGENT_SPAWN.ENABLED`).
+ *
+ * 도구는 작업 경로에서 이미 상시 노출되는데 시스템 프롬프트에 병렬 위임 언급이 전혀 없어,
+ * 모델이 존재를 알면서도 고르지 않았다(운영 실측: 30일 호출 0건, 반면 유도 문구가 있는 채팅
+ * 경로는 노출 20턴 중 6턴 호출·성공률 100%). 판단은 그대로 모델이 같은 턴에 하고
+ * (`tool_choice:auto`), 이 블록은 "쓸 수 있다"는 사실과 남용 경계만 알린다.
+ */
+export function getAgentTaskParallelGuide(): string {
+    return [
+        '',
+        'PARALLEL SUBTASKS (spawn_agents):',
+        '- If the goal breaks into 2+ INDEPENDENT subtasks — different topics, sources, regions,',
+        '  files, or targets whose results do not depend on each other — call spawn_agents ONCE',
+        '  with all of them so they run at the same time, then synthesize the results yourself.',
+        '- Write each task prompt self-contained: subagents cannot see your context or each other.',
+        '- If the steps depend on each other in sequence, do NOT use it — just do them yourself.',
+        '',
+    ].join('\n');
+}
+
+/**
  * 턴 0 계획-만 응답 가드용 재촉 메시지 — 도구 호출도 deliverable 도 없이 계획만 쓰고
  * 멈춘 경우 루프가 이 메시지를 넣고 한 턴 더 진행한다 (AgentTaskService).
  */

--- a/apps/api/src/services/agent-task/__tests__/parallel-guide.test.ts
+++ b/apps/api/src/services/agent-task/__tests__/parallel-guide.test.ts
@@ -1,0 +1,58 @@
+/**
+ * 병렬 분담 안내 — 도구가 실릴 때만 시스템 프롬프트에 붙는지.
+ *
+ * `AGENT_SPAWN.ENABLED` 는 env 파생이라 모듈을 격리 로드한다(운영 .env 가 섞이지 않게).
+ */
+export {};
+
+const ENV_KEY = 'AGENT_SPAWN_ENABLED';
+let saved: string | undefined;
+
+beforeAll(() => { saved = process.env[ENV_KEY]; });
+afterAll(() => {
+    if (saved === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = saved;
+    jest.resetModules();
+});
+
+function loadPrompt() {
+    jest.resetModules();
+    return require('../../../prompts/agent-task-prompt') as typeof import('../../../prompts/agent-task-prompt');
+}
+
+describe('getAgentTaskParallelGuide', () => {
+    it('도구 이름과 독립/순차 경계를 함께 알린다', () => {
+        const g = loadPrompt().getAgentTaskParallelGuide();
+        expect(g).toContain('spawn_agents');
+        expect(g).toMatch(/INDEPENDENT/);
+        // 남용 경계가 빠지면 순차 작업까지 병렬로 쪼개려 든다.
+        expect(g).toMatch(/depend on each other in sequence/);
+        // 서브는 부모 컨텍스트를 못 보므로 자기완결 지시가 필수라는 사실.
+        expect(g).toMatch(/self-contained/);
+    });
+});
+
+describe('작업 시스템 프롬프트 조립 — 게이트 연동', () => {
+    /** skill-block 은 DB 의존 블록을 포함하므로, 게이트 분기만 좁게 확인한다. */
+    function assembled(enabled: boolean): string {
+        if (enabled) process.env[ENV_KEY] = 'true';
+        else delete process.env[ENV_KEY];
+        jest.resetModules();
+        const { AGENT_SPAWN } = require('../../../config/runtime-limits') as typeof import('../../../config/runtime-limits');
+        const prompt = require('../../../prompts/agent-task-prompt') as typeof import('../../../prompts/agent-task-prompt');
+        return prompt.getAgentTaskSystemPrompt() + (AGENT_SPAWN.ENABLED ? prompt.getAgentTaskParallelGuide() : '');
+    }
+
+    it('게이트 ON 이면 안내가 붙는다', () => {
+        expect(assembled(true)).toContain('PARALLEL SUBTASKS');
+    });
+
+    it('게이트 OFF 면 붙지 않는다 — 없는 도구를 권하지 않는다', () => {
+        expect(assembled(false)).not.toContain('PARALLEL SUBTASKS');
+    });
+
+    it('기본 프롬프트 자체에는 병렬 언급이 없다(안내는 조건부 블록으로만)', () => {
+        const base = loadPrompt().getAgentTaskSystemPrompt();
+        expect(base).not.toContain('spawn_agents');
+    });
+});

--- a/apps/api/src/services/agent-task/skill-block.ts
+++ b/apps/api/src/services/agent-task/skill-block.ts
@@ -5,9 +5,9 @@
 import { getSkillManager, type ActiveSkillBinding } from '../../agents/skill-manager';
 import type { ToolDefinition } from '../../llm/types';
 import { mergeToolsWithSkills } from '../chat-service/tool-merger';
-import { getAgentTaskSystemPrompt } from '../../prompts/agent-task-prompt';
+import { getAgentTaskSystemPrompt, getAgentTaskParallelGuide } from '../../prompts/agent-task-prompt';
 import { getReportGuideForTask } from '../../prompts/report-guide';
-import { REPORT_PIPELINE, REPORT_INTENT_PATTERNS } from '../../config/runtime-limits';
+import { REPORT_PIPELINE, REPORT_INTENT_PATTERNS, AGENT_SPAWN } from '../../config/runtime-limits';
 import { buildLearningBlock } from './task-learning';
 import { buildProceduralSkillBlock } from './procedural-skill';
 import { buildUserMemoryBlock } from '../chat-service/user-context-blocks';
@@ -59,7 +59,10 @@ export async function buildAgentTaskSystemContent(userId: string, goal: string, 
     // 시멘틱 마크업·반응형)이 에이전트 작업 산출물에는 적용되지 않았다.
     // 사용자의 artifacts_enabled=false 는 buildArtifactGuideBlock 이 ''를 반환해 그대로 존중된다.
     const artifactGuide = await buildArtifactGuideBlock(userId, goalLang);
+    // 병렬 분담 안내는 도구가 실제로 실릴 때만 — 없는 도구를 권하면 모델이 헛호출한다.
+    const parallelGuide = AGENT_SPAWN.ENABLED ? getAgentTaskParallelGuide() : '';
     return getAgentTaskSystemPrompt()
+        + parallelGuide
         + artifactGuide
         + reportGuide
         + memory


### PR DESCRIPTION
두 건은 같은 뿌리에서 나왔다 — "조사형 에이전트 작업이 첫 턴부터 실패"를 파다가 500의 원인을 찾았고, 그 과정에서 병렬 분담이 왜 한 번도 안 쓰였는지가 드러났다.

## 1. 해결 불가 `$ref` → 요청 전체 500

MCP 서버가 `{"$ref": "#/definitions/Timestamp"}` 를 주면서 `definitions` 를 **함께 보내지 않는** 경우가 있다(apollo graphos 3종). `strict:true`(#781)가 켜지면 vLLM이 참조를 풀지 못해 문법 컴파일에 실패하고 **요청 전체가 500**이 된다.

라이브 인과 확정:

| 조건 | 결과 |
|---|---|
| strict + dangling `$ref` | **500** |
| strict 없음 | 200 |
| `$ref` 제거 + strict | 200 |
| **문제 도구만 strict 제외** + 다른 strict 도구 동석 | **500** ← 도구 단위 해제로는 안 낫는다 |

vLLM은 strict 도구가 **하나라도** 있으면 요청의 **모든** 도구 스키마를 문법으로 만든다(`_any_tool_strict`). 그래서 `stripUnresolvableRefs()` 로 참조 자체를 지운다 — 애초에 정의가 없어 검증할 수 없던 필드라 잃는 제약이 없고, `description` 등 나머지 키와 다른 도구의 strict 강제는 그대로 남는다. 해결되는 `$ref`(`definitions`/`$defs` 실재)는 건드리지 않는다.

**검증**: 운영 MCP 도구 **225개 전체 → 200**(수정 전 전체 500·개별 500 3건), 개별 프로브 500 잔존 0.

**영향 범위**: `agent_tasks` 120일 집계에서 `InternalServerError` 는 1건(6월)뿐이라 상시 장애는 아니었다 — apollo 도구가 동적 선별에 뽑힐 때만 터졌고, 뽑히면 그 작업은 재시도 2회까지 전부 실패했다.

## 2. 작업 경로에 병렬 분담 안내가 없었다

에이전트 작업은 `AGENT_SPAWN.ENABLED` 면 `spawn_agents` 를 **항상** 도구 목록에 싣는데, 시스템 프롬프트에는 병렬 위임 언급이 **한 줄도 없었다**. 도구가 있는 줄 모르는 모델은 고르지 않는다.

| 경로 | 노출 조건 | 유도 문구 | 실측 |
|---|---|---|---|
| 채팅 | `SPAWN_INTENT_PATTERNS` 매칭 시 | `SPAWN_PROMPT_GUIDE` **있음** | 60일 노출 20턴 → 호출 6 → 성공 6(100%) |
| 에이전트 작업 | 게이트 ON이면 **항상** | **없음** | 30일 호출 **0건** |

도구가 실제로 실릴 때만 475자 안내를 붙인다. 판단은 그대로 모델이 같은 턴에 `tool_choice:auto` 로 한다(앞단 LLM 호출 없음 — 판단 경계 B형). 남용 방지로 "순차 의존이면 쓰지 말 것"·"서브는 컨텍스트를 못 보므로 자기완결적으로" 를 함께 명시.

**채팅 프리필터 확대는 반려**: 60일 실사용 질의를 훑으니 병렬형 자체가 희소하고, 이미 노출된 20턴에서도 채택이 30%라 노출을 늘리는 것이 호출로 이어진다는 근거가 없다.

## 검증

- 단위 19건 신규(`stripUnresolvableRefs` 7 · strict 적용 2 · 병렬 안내 4 · 기존 6)
- **되돌리기 확인**: 각 수정을 되돌리면 1건씩 실패
- `tsc --noEmit` · `npm run lint` 0 errors
- 라이브(게이트웨이 직접): 225개 도구 전체 200

## 체크리스트

- [x] `npm run lint` 통과
- [x] 신규/관련 유닛 테스트 통과
- [ ] 라이브 검증 (배포 후 — 조사형 작업 500 해소 + 병렬 미언급 goal 자동 호출)
- [x] DB 스키마·환경변수 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZBoHf9iS6UWwg9maLqWWN