### PR TITLE
fix(agent-task): 빈 배열 인자로 도구 호출이 무한 반복되던 문제 + 병렬 안내 실측 반영

### DIFF
--- a/apps/api/src/prompts/agent-task-prompt.ts
+++ b/apps/api/src/prompts/agent-task-prompt.ts
@@ -82,17 +82,24 @@ export function getAgentTaskSystemPrompt(): string {
  * 도구는 작업 경로에서 이미 상시 노출되는데 시스템 프롬프트에 병렬 위임 언급이 전혀 없어,
  * 모델이 존재를 알면서도 고르지 않았다(운영 실측: 30일 호출 0건, 반면 유도 문구가 있는 채팅
  * 경로는 노출 20턴 중 6턴 호출·성공률 100%). 판단은 그대로 모델이 같은 턴에 하고
- * (`tool_choice:auto`), 이 블록은 "쓸 수 있다"는 사실과 남용 경계만 알린다.
+ * (`tool_choice:auto`), 이 블록은 "쓸 수 있다"는 사실과 경계만 알린다.
+ *
+ * ⚠️ 병렬 tool_calls 를 먼저 권한다. 3사 비교 goal 로 6회 재생했을 때 모델은 spawn 을 한 번도
+ * 고르지 않고 `web_search` 3개를 한 턴에 냈는데, 독립 단발 조회에는 그쪽이 실제로 더 싸다
+ * (서브에이전트는 별도 컨텍스트·프롬프트·종합 비용이 붙는다). spawn 의 이득은 갈래마다
+ * 여러 턴이 필요할 때 생기므로 그 경계를 문구에 명시한다.
  */
 export function getAgentTaskParallelGuide(): string {
     return [
         '',
-        'PARALLEL SUBTASKS (spawn_agents):',
-        '- If the goal breaks into 2+ INDEPENDENT subtasks — different topics, sources, regions,',
-        '  files, or targets whose results do not depend on each other — call spawn_agents ONCE',
-        '  with all of them so they run at the same time, then synthesize the results yourself.',
-        '- Write each task prompt self-contained: subagents cannot see your context or each other.',
-        '- If the steps depend on each other in sequence, do NOT use it — just do them yourself.',
+        'PARALLEL WORK:',
+        '- Independent lookups: issue several tool calls in ONE turn (e.g. three web_search calls',
+        '  for three companies). This is the cheapest way to parallelize — prefer it.',
+        '- spawn_agents: use it when each branch needs MULTIPLE steps of its own (search, then read,',
+        '  then summarize) and the branches do not depend on each other. Call it ONCE with all',
+        '  branches, then synthesize the results yourself.',
+        '- Write each branch prompt self-contained: subagents cannot see your context or each other.',
+        '- If the steps depend on each other in sequence, do NOT split — just do them yourself.',
         '',
     ].join('\n');
 }

--- a/apps/api/src/services/agent-spawn/spawn-agents.ts
+++ b/apps/api/src/services/agent-spawn/spawn-agents.ts
@@ -122,6 +122,7 @@ export const SPAWN_AGENTS_PARAMETERS_SCHEMA: {
     properties: {
         tasks: {
             type: 'array',
+            minItems: 1,
             description: '병렬 수행할 독립 하위 작업 목록 (2개 이상 권장)',
             items: {
                 type: 'object',

--- a/apps/api/src/services/agent-task/__tests__/parallel-guide.test.ts
+++ b/apps/api/src/services/agent-task/__tests__/parallel-guide.test.ts
@@ -21,10 +21,19 @@ function loadPrompt() {
 }
 
 describe('getAgentTaskParallelGuide', () => {
-    it('도구 이름과 독립/순차 경계를 함께 알린다', () => {
+    it('더 싼 병렬 수단(한 턴 다중 도구 호출)을 먼저 권한다', () => {
+        const g = loadPrompt().getAgentTaskParallelGuide();
+        // 실측: 독립 단발 조회 3건에서 모델은 spawn 대신 web_search 3개를 한 턴에 냈고 그쪽이 싸다.
+        const cheap = g.indexOf('ONE turn');
+        const spawn = g.indexOf('spawn_agents');
+        expect(cheap).toBeGreaterThanOrEqual(0);
+        expect(spawn).toBeGreaterThan(cheap);
+    });
+
+    it('spawn 의 이득 경계(갈래마다 여러 턴)를 명시한다', () => {
         const g = loadPrompt().getAgentTaskParallelGuide();
         expect(g).toContain('spawn_agents');
-        expect(g).toMatch(/INDEPENDENT/);
+        expect(g).toMatch(/MULTIPLE steps/);
         // 남용 경계가 빠지면 순차 작업까지 병렬로 쪼개려 든다.
         expect(g).toMatch(/depend on each other in sequence/);
         // 서브는 부모 컨텍스트를 못 보므로 자기완결 지시가 필수라는 사실.
@@ -44,11 +53,11 @@ describe('작업 시스템 프롬프트 조립 — 게이트 연동', () => {
     }
 
     it('게이트 ON 이면 안내가 붙는다', () => {
-        expect(assembled(true)).toContain('PARALLEL SUBTASKS');
+        expect(assembled(true)).toContain('PARALLEL WORK');
     });
 
     it('게이트 OFF 면 붙지 않는다 — 없는 도구를 권하지 않는다', () => {
-        expect(assembled(false)).not.toContain('PARALLEL SUBTASKS');
+        expect(assembled(false)).not.toContain('PARALLEL WORK');
     });
 
     it('기본 프롬프트 자체에는 병렬 언급이 없다(안내는 조건부 블록으로만)', () => {

--- a/apps/api/src/services/task-sandbox/tools.test.ts
+++ b/apps/api/src/services/task-sandbox/tools.test.ts
@@ -200,6 +200,23 @@ describe('task-sandbox tools', () => {
             const r = await byName(createTaskTools(fakeSandbox()), 'plan_create').handler({ steps: [] });
             expect(r.isError).toBe(true);
         });
+        it('plan_create: 빈 배열과 누락을 다르게 알린다 — 같은 오류가 반복되지 않게', async () => {
+            // 라이브에서 모델이 {"steps": []} 를 62회 반복했다. "배열이 필요하다"고만 답하면
+            // 배열은 보냈다고 여겨 같은 호출을 되풀이한다.
+            const tools = createTaskTools(fakeSandbox());
+            const empty = txt(await byName(tools, 'plan_create').handler({ steps: [] }));
+            const missing = txt(await byName(tools, 'plan_create').handler({}));
+            expect(empty).toContain('빈 배열');
+            expect(missing).not.toContain('빈 배열');
+            expect(empty).not.toBe(missing);
+        });
+        it('browser: 빈 actions 도 같은 방식으로 구분한다', async () => {
+            const tools = createTaskTools(fakeSandbox());
+            const empty = txt(await byName(tools, 'browser').handler({ actions: [] }));
+            const missing = txt(await byName(tools, 'browser').handler({}));
+            expect(empty).toContain('빈 배열');
+            expect(empty).not.toBe(missing);
+        });
         it('plan_update: 계획 없을 때 안내 메시지', async () => {
             const r = await byName(createTaskTools(fakeSandbox()), 'plan_update').handler({ step: 1, status: 'completed' });
             expect(r.isError).toBe(true);

--- a/apps/api/src/services/task-sandbox/tools.ts
+++ b/apps/api/src/services/task-sandbox/tools.ts
@@ -272,7 +272,10 @@ export function createTaskTools(
                 : (args.actions && typeof args.actions === 'object' ? [args.actions] : null);
             if (!actions || actions.length === 0) {
                 return textResult(
-                    'actions 배열이 필요합니다 — 예: [{"type":"goto","url":"https://example.com"},{"type":"extractText"}].',
+                    Array.isArray(args.actions)
+                        ? 'actions 가 빈 배열입니다 — 실제 액션 객체를 최소 1개 넣으세요. '
+                            + '예: [{"type":"goto","url":"https://example.com"},{"type":"extractText"}].'
+                        : 'actions 배열이 필요합니다 — 예: [{"type":"goto","url":"https://example.com"},{"type":"extractText"}].',
                     true,
                 );
             }
@@ -302,7 +305,7 @@ export function createTaskTools(
                 '복잡한 작업은 먼저 이 도구로 계획하고, 진행하며 plan_update 로 상태를 갱신하세요.',
             inputSchema: {
                 type: 'object',
-                properties: { steps: { type: 'array', description: '단계 설명 문자열 배열' } },
+                properties: { steps: { type: 'array', items: { type: 'string' }, description: '단계 설명 문자열 배열(최소 1개)' } },
                 required: ['steps'],
             },
         },
@@ -312,7 +315,12 @@ export function createTaskTools(
                 ? args.steps
                 : (typeof args.steps === 'string' && args.steps.trim() ? [args.steps] : null);
             if (!steps || steps.length === 0) {
-                return textResult('steps 배열이 필요합니다 — 예: {"steps":["자료 조사","초안 작성","검토"]}.', true);
+                // 빈 배열을 "배열이 필요하다"고 되돌려주면 모델은 배열을 보냈다고 여겨 같은 호출을
+                // 반복한다(라이브: 한 작업에서 62회). 무엇이 잘못됐는지 그대로 말한다.
+                return textResult(Array.isArray(args.steps)
+                    ? 'steps 가 빈 배열입니다 — 실제 단계 문자열을 최소 1개 넣으세요. '
+                        + '예: {"steps":["자료 조사","초안 작성","검토"]}. 계획 없이 진행하려면 이 도구를 부르지 말고 바로 작업하세요.'
+                    : 'steps 배열이 필요합니다 — 예: {"steps":["자료 조사","초안 작성","검토"]}.', true);
             }
             plan.create(steps.map(String));
             return textResult(plan.render());

--- a/apps/api/src/services/task-sandbox/tools.ts
+++ b/apps/api/src/services/task-sandbox/tools.ts
@@ -252,6 +252,8 @@ export function createTaskTools(
                 properties: {
                     actions: {
                         type: 'array',
+                        items: { type: 'object' },
+                        minItems: 1,
                         description: '액션 객체 배열. 예: [{"type":"goto","url":"https://example.com"},{"type":"extractText"}]',
                     },
                     allowlist: {
@@ -305,7 +307,7 @@ export function createTaskTools(
                 '복잡한 작업은 먼저 이 도구로 계획하고, 진행하며 plan_update 로 상태를 갱신하세요.',
             inputSchema: {
                 type: 'object',
-                properties: { steps: { type: 'array', items: { type: 'string' }, description: '단계 설명 문자열 배열(최소 1개)' } },
+                properties: { steps: { type: 'array', items: { type: 'string' }, minItems: 1, description: '단계 설명 문자열 배열(최소 1개)' } },
                 required: ['steps'],
             },
         },
@@ -317,6 +319,7 @@ export function createTaskTools(
             if (!steps || steps.length === 0) {
                 // 빈 배열을 "배열이 필요하다"고 되돌려주면 모델은 배열을 보냈다고 여겨 같은 호출을
                 // 반복한다(라이브: 한 작업에서 62회). 무엇이 잘못됐는지 그대로 말한다.
+                // 스키마의 items+minItems 가 1차 방어이고 이 메시지는 그것을 뚫었을 때의 2차다.
                 return textResult(Array.isArray(args.steps)
                     ? 'steps 가 빈 배열입니다 — 실제 단계 문자열을 최소 1개 넣으세요. '
                         + '예: {"steps":["자료 조사","초안 작성","검토"]}. 계획 없이 진행하려면 이 도구를 부르지 말고 바로 작업하세요.'


### PR DESCRIPTION
#815 의 라이브 검증 중 드러난 별건 결함이다. 병렬 자동 호출을 확인하려던 작업 2건이 모두 이것 때문에 좌초했다.

## 증상

한 작업이 `plan_create{"steps": []}` 를 **62회 반복**하다 턴을 다 쓰고 `goal_incomplete` 로 끝났다. 다른 작업은 `browser{actions: []}` 로 같은 패턴.

## 원인 두 겹

| 겹 | 내용 |
|---|---|
| 스키마 | `steps` 에 `items` 타입이 없어 문법 강제(strict)가 요소를 만들 근거가 없다 — 빈 배열이 가장 쉬운 유효값 |
| 메시지 | "steps 배열이 필요합니다" → 모델은 **배열을 보냈다고 여겨** 같은 호출을 되풀이한다 |

## 수정 — 스키마 변형 실측으로 결정

정상 goal 로 3회씩 재생한 결과:

| 스키마 | 결과 |
|---|---|
| `items` 없음 (현행) | 빈 배열 2 · 미호출 1 → **정상 0/3** |
| `items:string` | 정상 2 · 미호출 1 |
| **`items` + `minItems:1`** | **정상 3/3** ← 채택 |

- `plan_create.steps` 에 `items:{type:'string'}` + `minItems:1`
- 같은 형태인 `browser.actions`(items 없음)·`spawn_agents.tasks` 에도 적용
- 거절 메시지는 빈 배열과 누락을 **구분**해 알린다 — 문법을 뚫었을 때의 2차 방어

⚠️ 처음엔 `minItems` 를 뺐었다. "빈 배열로 호출해" 라는 **적대적 지시**에서 모델이 `{}`(required 위반)를 냈기 때문인데, 그건 현실 상황이 아니었다. 정상 지시 재생으로 뒤집었다.

## 병렬 안내 문구 정정 (#815 후속)

3사 비교 goal 로 6회 재생(안내 유무 A/B):

| 조건 | spawn_agents | 실제 선택 |
|---|---|---|
| 안내 없음 3회 | 0회 | `web_search` ×3 한 턴 / `plan_create{steps:[]}` ×2 |
| 안내 있음 3회 | 0회 | `web_search` ×3 한 턴 / `plan_create{steps:[]}` ×2 |

모델이 spawn 을 안 고른 것은 **합리적 판단**이었다 — 독립 단발 조회 3건에는 서브에이전트(별도 컨텍스트·프롬프트·종합 비용)보다 한 턴 다중 도구 호출이 싸다. 그래서 안내를 실측에 맞게 고쳤다: **"독립 조회는 한 턴에 여러 도구 호출을 먼저 쓰고, spawn 은 갈래마다 여러 단계가 필요할 때"**.

A/B 는 빈 배열 결함이 **#815 와 무관한 기존 문제**임도 확인해준다(안내 없이도 동일 발생). 장기 추이로도 8월 96호출 중 7건.

## 검증

- 단위: 신규 4건 포함 57건 통과(`tools.test.ts` · `parallel-guide.test.ts` · `spawn-agents.test.ts`)
- **되돌리기 확인**: 메시지 구분을 되돌리면 1건, 안내 문구를 되돌리면 2건 실패
- `tsc --noEmit` · `npm run lint` 0 errors

## 체크리스트

- [x] `npm run lint` 통과
- [x] 유닛 테스트 통과
- [ ] 라이브 검증 (배포 후 — 빈 배열 반복 해소 + 다단계 goal 에서 spawn 자동 호출)
- [x] DB 스키마·환경변수 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZBoHf9iS6UWwg9maLqWWN