### PR TITLE
fix(agent-task): 서브에이전트가 120초 타임아웃 3회 재시도로 죽던 문제

### DIFF
--- a/apps/api/src/llm/client.ts
+++ b/apps/api/src/llm/client.ts
@@ -77,6 +77,11 @@ export class LLMClient {
         return this.config.model;
     }
 
+    /** 현재 SDK 요청 타임아웃(ms) — 파생 시 "더 짧게 만들지 않기" 판단에 쓴다. */
+    get requestTimeout(): number {
+        return this.config.timeout;
+    }
+
     /**
      * 현재 설정(baseUrl/apiKey/model/userId 포함)을 유지한 채 일부만 덮어쓴
      * 파생 클라이언트를 만든다. role 해석된 외부 endpoint 클라이언트에

--- a/apps/api/src/services/agent-task/__tests__/subagent-timeout.test.ts
+++ b/apps/api/src/services/agent-task/__tests__/subagent-timeout.test.ts
@@ -1,0 +1,75 @@
+/**
+ * 서브에이전트 LLM 호출의 SDK 타임아웃·재시도 배선 회귀 테스트.
+ *
+ * 배경(2026-09-10 실측): 서브는 부모 턴(role-client.ts)과 달리 derive 없이 호출해
+ * 기본 LLM_TIMEOUT(120s) + SDK 기본 maxRetries=2 = 실효 360s 에서 죽었다.
+ * 운영 로그에서 fan-out 시작 후 423s/527s 에 서브 3개가 전부
+ * "Request timed out." 로 실패한 것이 이 배선 때문이었다.
+ */
+import { AGENT_TASK_LIMITS } from '../../../config/runtime-limits';
+
+jest.mock('../../../mcp/unified-client', () => ({
+    getUnifiedMCPClient: () => ({}),
+}));
+jest.mock('../task-steps', () => ({ runTool: jest.fn() }));
+jest.mock('../../tool-parallel', () => ({ prefetchReadOnlyCalls: jest.fn() }));
+jest.mock('../../task-sandbox/approval-gate', () => ({
+    requiresApproval: () => false,
+    getApprovalRegistry: () => ({}),
+}));
+
+import { runSubagent } from '../subagent';
+
+/** derive 호출 인자를 포착하는 최소 LLMClient 스텁. */
+function makeClient(requestTimeout: number) {
+    const chat = jest.fn().mockResolvedValue({ content: '완료', metrics: {} });
+    const derive = jest.fn().mockImplementation(() => ({ chat }));
+    return { client: { requestTimeout, derive, chat: jest.fn() }, derive, chat };
+}
+
+function params(client: unknown) {
+    return {
+        client,
+        personaPrompt: 'persona',
+        subgoal: '하위 목표',
+        tools: [],
+        userCtx: { userId: '3' },
+        taskId: 'task-1',
+        sandboxCfg: { approvalPolicy: 'none', approvalTimeoutMs: 0 },
+    } as never;
+}
+
+describe('서브에이전트 SDK 타임아웃 배선', () => {
+    it('로컬 기본 타임아웃(120s)을 작업 예산까지 끌어올린다', async () => {
+        const { client, derive } = makeClient(120_000);
+        await runSubagent(params(client));
+
+        expect(derive).toHaveBeenCalledTimes(1);
+        expect(derive.mock.calls[0][0].timeout)
+            .toBe(AGENT_TASK_LIMITS.SCHEDULE_TOTAL_TIMEOUT_MS);
+        expect(AGENT_TASK_LIMITS.SCHEDULE_TOTAL_TIMEOUT_MS).toBeGreaterThan(120_000);
+    });
+
+    it('타임아웃 맹목 재시도를 끈다 — 슬롯 3배 점유 방지', async () => {
+        const { client, derive } = makeClient(120_000);
+        await runSubagent(params(client));
+
+        expect(derive.mock.calls[0][0].maxRetries).toBe(0);
+    });
+
+    it('외부 role 클라이언트의 더 긴 타임아웃은 줄이지 않는다', async () => {
+        const longer = AGENT_TASK_LIMITS.SCHEDULE_TOTAL_TIMEOUT_MS + 60_000;
+        const { client, derive } = makeClient(longer);
+        await runSubagent(params(client));
+
+        expect(derive.mock.calls[0][0].timeout).toBe(longer);
+    });
+
+    it('LLM 호출은 원본이 아니라 파생 클라이언트로 나간다', async () => {
+        const { client, chat } = makeClient(120_000);
+        await runSubagent(params(client));
+
+        expect(chat).toHaveBeenCalledTimes(1);
+        expect((client as { chat: jest.Mock }).chat).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/services/agent-task/subagent.ts
+++ b/apps/api/src/services/agent-task/subagent.ts
@@ -64,6 +64,18 @@ export async function runSubagent(p: SubagentParams): Promise<string> {
     const mcp = getUnifiedMCPClient();
     let tokens = 0;
 
+    // role-client.ts 의 부모 턴과 같은 이유 — 기본 LLM_TIMEOUT(120s)은 채팅용이라,
+    // 서브의 마지막 턴(도구 없이 장문 최종 답변)이 넘기면 "Request timed out" 으로 죽는다.
+    // 실제 한계는 p.signal(상위 잔여 예산)이 governor 다.
+    // maxRetries 0: 타임아웃을 SDK 가 맹목 재시도하면 같은 조건에서 또 실패하면서
+    // 모델 슬롯만 3배로 점유해 동시 실행 중인 다른 서브까지 함께 느려진다
+    // (external-throttle.ts 가 외부 provider 에 같은 이유로 0 을 쓴다).
+    // 외부 role 클라이언트가 이미 더 긴 timeout 을 들고 있으면 그쪽을 존중한다.
+    const client = p.client.derive({
+        timeout: Math.max(p.client.requestTimeout, AGENT_TASK_LIMITS.SCHEDULE_TOTAL_TIMEOUT_MS),
+        maxRetries: 0,
+    });
+
     const conversation: ChatMessage[] = [
         {
             role: 'system',
@@ -81,7 +93,7 @@ export async function runSubagent(p: SubagentParams): Promise<string> {
             if (lastTurn && turn > 0 && p.tools.length > 0) {
                 conversation.push({ role: 'user', content: SUBAGENT_FINAL_TURN_NOTICE });
             }
-            const result = await p.client.chat(conversation, undefined, undefined, {
+            const result = await client.chat(conversation, undefined, undefined, {
                 tools: lastTurn || p.tools.length === 0 ? undefined : p.tools,
                 signal: p.signal,
                 think: false,


### PR DESCRIPTION
## 문제

3갈래 fan-out 작업에서 서브에이전트 3개가 전부 `Request timed out.` 으로 실패하고 작업이 `failed(timeout)` 으로 끝났습니다.

원인은 성능이 아니라 **배선**입니다. 서브의 LLM 호출이 부모 턴과 달리 `derive` 없이 나가면서 채팅용 기본 `LLM_TIMEOUT`(120s)과 SDK 기본 `maxRetries=2` 를 그대로 썼습니다 — 실효 **360초**.

## 실측 근거 (운영 로그, 2026-09-10)

| 시각 | 사건 |
|---|---|
| 07:17:44 | fan-out 시작 (tasks=3, parallel=4) |
| 07:18:22~07:20:29 | 서브들이 `web_search` 정상 실행 — 배선 자체는 동작 |
| 07:24:47 | 서브1 `Request timed out.` |
| 07:26:31 | 서브2·3 실패 = `07:20:29 + 362s` (120s × 3회와 초 단위 일치) |
| 07:31:44 | 작업 `failed(timeout)` |

## 같은 결함이 두 번 고쳐졌는데 서브만 빠졌습니다

| 경로 | 타임아웃 | 재시도 |
|---|---|---|
| 부모 턴 `role-client.ts` | `derive({ SCHEDULE_TOTAL_TIMEOUT_MS })` | — |
| 외부 provider `external-throttle.ts` | `LLM_TIMEOUT × 배수` | **0** |
| **서브 `subagent.ts`** (수정 전) | **기본 120s** | **2 (SDK 기본)** |

두 곳 모두 주석에 이유가 적혀 있습니다. `external-throttle.ts` 는 *"타임아웃을 SDK 가 맹목 재시도하면 세마포어 슬롯을 3배로 점유한다"* 고 명시합니다 — 서브2·3이 동시에 죽은 것이 그 증상으로 보입니다.

## 수정

```ts
const client = p.client.derive({
    timeout: Math.max(p.client.requestTimeout, AGENT_TASK_LIMITS.SCHEDULE_TOTAL_TIMEOUT_MS),
    maxRetries: 0,
});
```

- **타임아웃**은 부모와 같은 상수를 재사용합니다. "실제 governor 는 `signal`(상위 잔여 예산)" 이라는 기존 규약을 그대로 따르므로 새 튜닝 노브를 만들지 않았습니다.
- **`Math.max`** — 서브가 외부 role 클라이언트를 받는 경로가 실재하고(Custom Agent 모델 배정, spawn role 해석) 그쪽은 이미 `externalClientTiming` 으로 조정돼 있어 덮어쓰면 안 됩니다. 올리기만 합니다.
- 파생은 턴 루프 **밖에서 1회**만 합니다.
- `LLMClient.requestTimeout` getter 는 이 판단에 필요한 최소 추가입니다(`model` getter 선례).

## 검증

- 신규 `subagent-timeout.test.ts` 4건 — **수정을 되돌리면 4건 전부 실패** 확인
- `tsc --noEmit` 0 errors / `npm run lint` 0 errors
- 관련 36 스위트 346건 통과
- 라이브 재현은 배포 후 진행합니다

## 함께 검토하지 않은 것

`AGENT_SPAWN_MAX_PARALLEL` 은 운영이 4(코드 기본 2)인데 4로 올린 벤치 기록을 찾지 못했습니다. 다만 360초 제약이 풀리면 4갈래도 완주할 수 있어, 이 수정의 효과를 먼저 본 뒤 판단하는 것이 순서라고 봅니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BmTWodtzDDfSvVnZSupVL