### PR TITLE
fix(skills): load_skill 카탈로그에서 에이전트 페르소나 스킬 제외 + 상한 초과 경고

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1414,6 +1414,8 @@ SKILL_AUTO_SELECT_ENABLED=false
 SKILL_AUTO_SELECT_TOP_K=3
 SKILL_CATALOG_MAX_ITEMS=200
 SKILL_CATALOG_DESC_MAX=120
+# 에이전트 페르소나 스킬("○○ 전문 스킬")은 그 에이전트에 이미 자동 주입되므로 카탈로그에서 제외(기본 true).
+SKILL_CATALOG_EXCLUDE_PERSONAS=true
 # 외부 MCP stdio 서버 OS 격리 (Docker) — 외부 MCP 서버를 `docker run` 컨테이너로 격리.
 # 호스트 FS·비밀·네트워크 접근 차단. macOS(Docker Desktop) 포함 docker 있는 모든 호스트에서 동작.
 # 기본 OFF. docker 부재 시 graceful no-op(비격리 실행 + 경고).

--- a/apps/api/src/agents/__tests__/skill-catalog-personas.test.ts
+++ b/apps/api/src/agents/__tests__/skill-catalog-personas.test.ts
@@ -1,0 +1,80 @@
+/**
+ * load_skill 카탈로그 — 페르소나 제외·상한 초과 경고 (2026-09-11).
+ *
+ * 페르소나 스킬("○○ 전문 스킬")은 자기 에이전트에 이미 자동 주입되는데 카탈로그에도 실려 매 턴
+ * ~2.2K 토큰(101줄)을 먹었다. 카탈로그는 이름순 상한(200)에 199 로 닿아 있어, 초과분이 경고 없이
+ * 빠질 참이었다.
+ */
+jest.mock('../../utils/logger', () => {
+    const shared = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+    return { createLogger: () => shared, __shared: shared };
+});
+
+import { SkillManager } from '../skill-manager';
+import type { AgentSkill } from '../../data/repositories/skill-repository';
+
+const logger = (jest.requireMock('../../utils/logger') as { __shared: { warn: jest.Mock } }).__shared;
+
+function skill(id: string, name: string): AgentSkill {
+    return {
+        id, name, description: 'd', content: 'C', category: 'general',
+        isPublic: true, createdBy: 'owner1', status: 'active',
+        createdAt: new Date(0), updatedAt: new Date(0),
+    } as unknown as AgentSkill;
+}
+
+function managerWith(Manager: typeof SkillManager, skills: AgentSkill[], total = skills.length) {
+    const searchSkills = jest.fn(async () => ({ skills, total, limit: 200, offset: 0 }));
+    const mgr = new Manager();
+    // private repo 주입 — ensureInitialized 가 DB 초기화를 건너뛴다
+    (mgr as unknown as { repo: unknown }).repo = { searchSkills };
+    return { mgr, searchSkills };
+}
+
+describe('카탈로그 페르소나 제외', () => {
+    it('카탈로그와 load_skill 조회가 같은 조건(페르소나 제외)으로 검색한다', async () => {
+        const { mgr, searchSkills } = managerWith(SkillManager, [skill('s1', 'A')]);
+        await mgr.buildSkillCatalog({ userId: 'u3' });
+        await mgr.buildSkillPromptForNames(['A'], 'u3');
+
+        expect(searchSkills).toHaveBeenCalledTimes(2);
+        for (const call of searchSkills.mock.calls as unknown as Array<[Record<string, unknown>]>) {
+            expect(call[0]).toEqual(expect.objectContaining({ excludeAgentPersonas: true }));
+        }
+    });
+
+    it("SKILL_CATALOG_EXCLUDE_PERSONAS='false' 면 종전처럼 페르소나도 싣는다 (롤백 경로)", async () => {
+        const prev = process.env.SKILL_CATALOG_EXCLUDE_PERSONAS;
+        process.env.SKILL_CATALOG_EXCLUDE_PERSONAS = 'false';
+        let Isolated!: typeof SkillManager;
+        jest.isolateModules(() => {
+            Isolated = jest.requireActual<typeof import('../skill-manager')>('../skill-manager').SkillManager;
+        });
+        if (prev === undefined) delete process.env.SKILL_CATALOG_EXCLUDE_PERSONAS;
+        else process.env.SKILL_CATALOG_EXCLUDE_PERSONAS = prev;
+
+        const { mgr, searchSkills } = managerWith(Isolated, []);
+        await mgr.buildSkillCatalog();
+        expect(searchSkills).toHaveBeenCalledWith(expect.objectContaining({ excludeAgentPersonas: false }));
+    });
+});
+
+describe('카탈로그 상한 초과 경고', () => {
+    const capWarnings = () => logger.warn.mock.calls.map((c) => String(c[0])).filter((m) => m.includes('카탈로그 상한'));
+    beforeEach(() => logger.warn.mockClear());
+
+    it('상한을 넘으면 빠진 개수를 경고하고, 같은 대상 수로는 반복하지 않는다', async () => {
+        const { mgr } = managerWith(SkillManager, [skill('s1', 'A'), skill('s2', 'B')], 205);
+        await mgr.buildSkillCatalog();
+        await mgr.buildSkillCatalog();
+
+        expect(capWarnings()).toHaveLength(1);
+        expect(capWarnings()[0]).toContain('203개');
+    });
+
+    it('상한 안이면 경고하지 않는다', async () => {
+        const { mgr } = managerWith(SkillManager, [skill('s1', 'A')], 1);
+        await mgr.buildSkillCatalog();
+        expect(capWarnings()).toHaveLength(0);
+    });
+});

--- a/apps/api/src/agents/skill-catalog.ts
+++ b/apps/api/src/agents/skill-catalog.ts
@@ -1,0 +1,36 @@
+/**
+ * load_skill 카탈로그 — 설정·직렬화·상한 경고.
+ * skill-manager.ts 가 Gate 3(600줄)에 닿아 분리했다 (2026-09-11). 조회는 SkillManager.buildSkillCatalog 가 한다.
+ */
+import type { AgentSkill, SkillSearchResult } from '../data/repositories/skill-repository';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('SkillCatalog');
+
+/** 카탈로그/선택 조회 상한 — env override (No-Hardcoding). searchSkills 가 200 으로 클램프한다. */
+export const SKILL_CATALOG_MAX_ITEMS = Number(process.env.SKILL_CATALOG_MAX_ITEMS) || 200;
+const SKILL_CATALOG_DESC_MAX = Number(process.env.SKILL_CATALOG_DESC_MAX) || 120;
+/** 페르소나 스킬("○○ 전문 스킬")을 카탈로그·load_skill 대상에서 제외 — 기본 on, 'false' 면 종전 동작(롤백용). */
+export const SKILL_CATALOG_EXCLUDE_PERSONAS = process.env.SKILL_CATALOG_EXCLUDE_PERSONAS !== 'false';
+
+/** 상한 초과 경고는 대상 수가 같으면 한 번만 (매 턴 반복 방지) */
+const truncationWarned = new Set<number>();
+
+/** 상한을 넘은 스킬은 이름순 뒤쪽부터 조용히 빠진다 — 알아챌 수 있게 경고 (2026-09-11: 200 한도에 199 였다). */
+export function warnIfCatalogTruncated(result: SkillSearchResult): void {
+    if (result.total <= result.skills.length || truncationWarned.has(result.total)) return;
+    truncationWarned.add(result.total);
+    logger.warn(`스킬 카탈로그 상한(${result.limit}) 초과 — 대상 ${result.total}개 중 ${result.total - result.skills.length}개가 이름순으로 빠짐. 스킬을 정리하거나 SKILL_CATALOG_MAX_ITEMS(최대 200) 조정`);
+}
+
+/** active 스킬을 "- 이름: 설명" 한 줄씩 직렬화 — excludeIds(이미 주입된 바인딩 스킬)는 뺀다(dedup). */
+export function formatSkillCatalog(skills: AgentSkill[], excludeIds?: ReadonlySet<string>): { catalog: string; count: number } {
+    const lines: string[] = [];
+    for (const s of skills) {
+        if (excludeIds?.has(s.id)) continue;
+        const safeName = s.name.replace(/[<>"&]/g, '');
+        const desc = (s.description ?? '').replace(/\s+/g, ' ').trim().slice(0, SKILL_CATALOG_DESC_MAX);
+        lines.push(desc ? `- ${safeName}: ${desc}` : `- ${safeName}`);
+    }
+    return { catalog: lines.join('\n'), count: lines.length };
+}

--- a/apps/api/src/agents/skill-manager.ts
+++ b/apps/api/src/agents/skill-manager.ts
@@ -51,6 +51,7 @@ import { recordSkillUsage } from './skill-usage-log';
 import { shouldInjectManifestSkill } from './manifest-injection-filter';
 import { SKILL_VERSION_LATEST_ORDER_SQL } from '../data/repositories/skill-manifest-sync';
 import { SKILL_MANIFEST_INJECT_MAX_CHARS, SKILL_MANIFEST_PER_SKILL_MAX_CHARS } from '../config/runtime-limits';
+import { SKILL_CATALOG_MAX_ITEMS, SKILL_CATALOG_EXCLUDE_PERSONAS, formatSkillCatalog, warnIfCatalogTruncated } from './skill-catalog';
 
 const logger = createLogger('SkillManager');
 
@@ -64,9 +65,7 @@ const MAX_SKILL_CONTENT_LENGTH = 10_000;
 const SKILL_OVERLOAD_MAX_ACTIVE = Number(process.env.SKILL_OVERLOAD_MAX_ACTIVE) || 12;
 const SKILL_OVERLOAD_MAX_TOTAL_CHARS = Number(process.env.SKILL_OVERLOAD_MAX_TOTAL_CHARS) || 50_000;
 
-/** 스킬 자동 호출(LLM self-select) 카탈로그/선택 상한 — env override (No-Hardcoding). */
-const SKILL_CATALOG_MAX_ITEMS = Number(process.env.SKILL_CATALOG_MAX_ITEMS) || 200;
-const SKILL_CATALOG_DESC_MAX = Number(process.env.SKILL_CATALOG_DESC_MAX) || 120;
+/** 스킬 자동 호출(LLM self-select) 선택 상한 — env override (No-Hardcoding). 카탈로그 설정은 skill-catalog.ts. */
 const SKILL_AUTO_SELECT_TOP_K = Number(process.env.SKILL_AUTO_SELECT_TOP_K) || 3;
 
 /**
@@ -314,15 +313,12 @@ export class SkillManager {
         const repo = await this.ensureInitialized();
         // userId 전달 시 본인 소유 비공개 스킬 포함(public OR own) — 미전달이면 public 전용.
         // 확장 설치 스킬(전부 비공개)이 카탈로그에 안 실려 자동 호출이 불가능하던 갭 (2026-08-16).
-        const result = await repo.searchSkills({ status: 'active', sortBy: 'name', limit: SKILL_CATALOG_MAX_ITEMS, userId: opts.userId });
-        const lines: string[] = [];
-        for (const s of result.skills) {
-            if (opts.excludeIds?.has(s.id)) continue;
-            const safeName = s.name.replace(/[<>"&]/g, '');
-            const desc = (s.description ?? '').replace(/\s+/g, ' ').trim().slice(0, SKILL_CATALOG_DESC_MAX);
-            lines.push(desc ? `- ${safeName}: ${desc}` : `- ${safeName}`);
-        }
-        return { catalog: lines.join('\n'), count: lines.length };
+        const result = await repo.searchSkills({
+            status: 'active', sortBy: 'name', limit: SKILL_CATALOG_MAX_ITEMS, userId: opts.userId,
+            excludeAgentPersonas: SKILL_CATALOG_EXCLUDE_PERSONAS,
+        });
+        warnIfCatalogTruncated(result);
+        return formatSkillCatalog(result.skills, opts.excludeIds);
     }
 
     /**
@@ -336,7 +332,10 @@ export class SkillManager {
         if (!Array.isArray(names) || names.length === 0) return { prompt: '', matched: [], matchedIds: [] };
         const repo = await this.ensureInitialized();
         // userId 전달로 본인 소유 비공개 스킬도 검색 대상에 포함 — 아래 visible 필터와 동일 규칙.
-        const result = await repo.searchSkills({ status: 'active', limit: SKILL_CATALOG_MAX_ITEMS, userId });
+        // 페르소나 제외도 카탈로그와 같게 둔다 — 카탈로그에 보이는 스킬이 상한(200)에 밀려 못 불러오는 일이 없게.
+        const result = await repo.searchSkills({
+            status: 'active', limit: SKILL_CATALOG_MAX_ITEMS, userId, excludeAgentPersonas: SKILL_CATALOG_EXCLUDE_PERSONAS,
+        });
         const wanted = names.slice(0, Math.max(1, topK)).map((n) => String(n).toLowerCase().trim()).filter(Boolean);
         const seen = new Set<string>();
         const picked: AgentSkill[] = [];

--- a/apps/api/src/data/repositories/__tests__/skill-repository-search.test.ts
+++ b/apps/api/src/data/repositories/__tests__/skill-repository-search.test.ts
@@ -1,0 +1,42 @@
+/**
+ * SkillRepository.searchSkills — excludeAgentPersonas 조건 (2026-09-11).
+ * 페르소나 스킬은 skill-seeder 가 `system-skill-{agentId}` 로 만들어 그 에이전트에 배정한다.
+ * count·data 두 쿼리가 같은 WHERE 를 써야 total 로 카탈로그 상한 초과를 판정할 수 있다.
+ */
+import { Pool } from 'pg';
+import { SkillRepository, AGENT_PERSONA_SKILL_ID_PREFIX } from '../skill-repository';
+
+jest.mock('../../retry-wrapper', () => ({
+    withRetry: (fn: () => unknown) => fn(),
+}));
+
+function setup() {
+    const query = jest.fn()
+        .mockResolvedValueOnce({ rows: [{ total: '0' }] })
+        .mockResolvedValueOnce({ rows: [] });
+    return { query, repo: new SkillRepository({ query } as unknown as Pool) };
+}
+
+describe('SkillRepository.searchSkills excludeAgentPersonas', () => {
+    it('켜면 count·data 쿼리 모두 자기 에이전트에 배정된 페르소나를 제외한다', async () => {
+        const { query, repo } = setup();
+        await repo.searchSkills({ status: 'active', userId: 'u3', excludeAgentPersonas: true });
+
+        expect(query).toHaveBeenCalledTimes(2);
+        for (const [sql, params] of query.mock.calls) {
+            expect(sql).toMatch(/NOT EXISTS \(SELECT 1 FROM agent_skill_assignments asa/);
+            // userId $1 · status $2 다음 자리
+            expect(sql).toMatch(/agent_skills\.id = \$3::text \|\| asa\.agent_id/);
+            expect(params[2]).toBe(AGENT_PERSONA_SKILL_ID_PREFIX);
+        }
+    });
+
+    it('지정하지 않으면 조건을 붙이지 않는다', async () => {
+        const { query, repo } = setup();
+        await repo.searchSkills({ status: 'active', userId: 'u3' });
+
+        for (const [sql] of query.mock.calls) {
+            expect(sql).not.toMatch(/agent_skill_assignments/);
+        }
+    });
+});

--- a/apps/api/src/data/repositories/skill-repository.ts
+++ b/apps/api/src/data/repositories/skill-repository.ts
@@ -82,6 +82,12 @@ export interface UpdateSkillInput {
     isPublic?: boolean;
 }
 
+/**
+ * 산업 에이전트 페르소나 스킬 id 접두사 — skill-seeder 가 `system-skill-{agentId}` 로 만들어 그 에이전트에
+ * 배정한다. `excludeAgentPersonas` 판정이 이 규칙과 한 쌍이다.
+ */
+export const AGENT_PERSONA_SKILL_ID_PREFIX = 'system-skill-';
+
 export interface SkillSearchOptions {
     userId?: string;
     search?: string;
@@ -92,6 +98,11 @@ export interface SkillSearchOptions {
     offset?: number;
     /** 'draft' | 'active' | 'all'. 기본값 'active' — 일반 라이브러리에는 draft 노출 금지. */
     status?: 'draft' | 'active' | 'all';
+    /**
+     * 자기 에이전트에 배정된 페르소나 스킬(id = 접두사 + 배정 agent_id) 제외. 그 에이전트 턴에는 이미
+     * 자동 주입되므로 load_skill 카탈로그에 실으면 중복이다 (2026-09-11 실측: 101줄 ≈ 2.2K 토큰/턴).
+     */
+    excludeAgentPersonas?: boolean;
 }
 
 export interface SkillSearchResult {
@@ -299,6 +310,12 @@ export class SkillRepository extends BaseRepository {
         if (statusFilter !== 'all') {
             conditions.push(`status = $${paramIdx}`);
             params.push(statusFilter);
+            paramIdx += 1;
+        }
+
+        if (options.excludeAgentPersonas) {
+            conditions.push(`NOT EXISTS (SELECT 1 FROM agent_skill_assignments asa WHERE asa.skill_id = agent_skills.id AND agent_skills.id = $${paramIdx}::text || asa.agent_id)`);
+            params.push(AGENT_PERSONA_SKILL_ID_PREFIX);
             paramIdx += 1;
         }
 


### PR DESCRIPTION
## 요약
`load_skill` 카탈로그는 채팅 턴마다 도구 설명에 실립니다. 2026-09-11 실측(운영 dist 로 `buildSkillCatalog` 재현 + vLLM `/tokenize`) 결과 user 3 기준 **199줄 4,783 토큰**, 게스트 160줄 3,525 토큰(게스트 첫 턴 입력의 ~40%)이었습니다. 그중 "○○ 전문 스킬" 페르소나 101줄(~2.2K 토큰)은 자기 에이전트 턴에 이미 자동 주입되는 스킬이라 카탈로그에선 중복입니다. 9/4 이후 `load_skill` 호출은 8회였습니다.

- `searchSkills({ excludeAgentPersonas })`: id 가 `system-skill-{agent_id}` 이면서 그 에이전트에 배정된 스킬 제외. count·data 쿼리가 같은 WHERE 를 써서 `total` 로 상한 초과를 판정할 수 있습니다
- 카탈로그와 `load_skill` 이름 조회가 같은 조건으로 검색 — 카탈로그에 보이는 스킬이 조회 상한(200)에 밀려 못 불러오는 불일치 방지
- 상한 초과 시 빠진 개수를 경고(대상 수당 1회). 종전엔 이름순 뒤쪽이 경고 없이 빠졌고, 200 한도에 199 로 닿아 있었습니다
- 게이트 `SKILL_CATALOG_EXCLUDE_PERSONAS`(기본 true, `'false'` 면 종전 동작) — `.env.example` 반영
- `skill-manager.ts` 가 Gate 3(600줄)을 넘게 되어 카탈로그 설정·직렬화를 `agents/skill-catalog.ts` 로 분리 (598줄)

## 함께 한 데이터 변경 (PR 외, 운영 DB)
이 환경에서 동작할 수 없는 Claude Code 플러그인 개발용 스킬 14개(plugin-dev 8 · hookify 5 · endor 1, 전부 user 3 소유)를 `status='archived'` 로 보관 처리했습니다. 확장 자체와 그 Custom Agent 는 건드리지 않았고, `active` 로 되돌리면 복구됩니다.

## 테스트
- [x] 신규 `skill-catalog-personas.test.ts`(4) · `skill-repository-search.test.ts`(2) + 관련 5 suite — 45 passed
- [x] 수정을 되돌리면 신규 테스트 4건 실패 확인
- [x] 새 SQL 조건을 운영 DB 에서 `PREPARE`/`EXECUTE` 로 검증 — user 3 대상 199 → 98
- [x] `tsc --noEmit` 0 · eslint 0
- [ ] 배포 후 운영 코드 재현으로 카탈로그 토큰 재측정 + chat.openmake.cc 실채팅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Kmw1CDfo4Eouse77o5PVh