### PR TITLE
fix(skills): 스킬 본문 저장 시 들여쓰기 소실 + 트리거 보존 + 주입 순서 정정

### DIFF
--- a/apps/api/src/__tests__/validation-preserve-formatting.test.ts
+++ b/apps/api/src/__tests__/validation-preserve-formatting.test.ts
@@ -1,0 +1,36 @@
+/**
+ * validate 정제 — 서식 보존 필드 (2026-09-11).
+ *
+ * 기본 정제(sanitizeTextInput)는 줄바꿈 외 연속 공백을 한 칸으로 접는다. 스킬 본문 저장
+ * (POST/PUT /api/agents/skills)이 이 경로를 타서 코드 블록 들여쓰기가 저장할 때마다 사라졌다 —
+ * 웹 편집·재작성 제안 적용 모두 해당. 실제 sanitizer 로 검증한다(목킹 없음).
+ */
+import type { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { validate, validateWithSecurity } from '../middlewares/validation';
+
+const schema = z.object({ name: z.string(), content: z.string() });
+const CODE = 'def f():\n    if x:\n\t\treturn 1\n';
+
+function run(mw: (req: Request, res: Response, next: NextFunction) => unknown, body: unknown) {
+    const req = { headers: { 'content-type': 'application/json' }, body } as unknown as Request;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn().mockReturnThis() } as unknown as Response;
+    const next = jest.fn();
+    mw(req, res, next);
+    expect(next).toHaveBeenCalled();
+    return req.body as { name: string; content: string };
+}
+
+describe('validate 정제 — 서식 보존 필드', () => {
+    it('기본 정제는 연속 공백을 접는다 (짧은 필드용 종전 동작)', () => {
+        const out = run(validate(schema), { name: '  a   b  ', content: CODE });
+        expect(out.name).toBe('a b');
+        expect(out.content).toBe('def f():\n if x:\n return 1');
+    });
+
+    it('preserveFormattingFields 필드는 들여쓰기·탭·끝 줄바꿈을 그대로 두고 제어문자만 뺀다', () => {
+        const out = run(validateWithSecurity(schema, { preserveFormattingFields: ['content'] }), { name: '  a   b  ', content: `${CODE}\u0000` });
+        expect(out.content).toBe(CODE);
+        expect(out.name).toBe('a b'); // 지정하지 않은 필드는 종전대로 정제
+    });
+});

--- a/apps/api/src/agents/__tests__/skill-inject-cap.test.ts
+++ b/apps/api/src/agents/__tests__/skill-inject-cap.test.ts
@@ -41,18 +41,25 @@ describe('buildManifestPrompt — 주입 합계 상한', () => {
         expect(out!.prompt).not.toContain('ECC-C:');
     });
 
-    it('큰 스킬은 개별 상한으로 절단돼 뒤의 system 스킬이 밀려나지 않는다', async () => {
-        rows = [row('huge', 5000), row('system-skill-backend', 100)];
+    it('큰 스킬은 개별 상한으로 절단돼 뒤의 페르소나가 밀려나지 않는다', async () => {
+        rows = [row('huge', 5000), row('system-skill-backend-developer', 100)];
         const out = await manager().buildManifestPrompt('backend-developer', undefined, 'technology');
-        expect(out!.skillNames).toEqual(['system-skill-backend', 'huge']);
+        expect(out!.skillNames).toEqual(['system-skill-backend-developer', 'huge']);
         expect(out!.prompt).toContain('... (truncated)');
-        expect(out!.prompt).toContain('SYSTEM-SKILL-BACKEND:');
+        expect(out!.prompt).toContain('SYSTEM-SKILL-BACKEND-DEVELOPER:');
     });
 
-    it('system 스킬은 priority 가 낮아도 먼저 담겨 상한에 밀려나지 않는다', async () => {
-        rows = [row('ecc-a', 600), row('ecc-b', 350), row('system-skill-backend', 100)];
+    it('페르소나는 priority 가 낮아도 먼저 담겨 상한에 밀려나지 않는다', async () => {
+        rows = [row('ecc-a', 600), row('ecc-b', 350), row('system-skill-backend-developer', 100)];
         const out = await manager().buildManifestPrompt('backend-developer', undefined, 'technology');
-        expect(out!.skillNames).toEqual(['system-skill-backend', 'ecc-a']);
+        expect(out!.skillNames).toEqual(['system-skill-backend-developer', 'ecc-a']);
+    });
+
+    it('전역 시스템 스킬(karpathy 등)은 페르소나처럼 앞세우지 않는다 — 관련 스킬이 밀려나지 않게 (2026-09-11)', async () => {
+        rows = [row('ecc-a', 650), row('system-skill-karpathy-guidelines', 300), row('system-skill-backend-developer', 100)];
+        const out = await manager().buildManifestPrompt('backend-developer', undefined, 'technology');
+        // 페르소나 → ecc-a 순으로 담고, karpathy 는 합계 상한을 넘어 건너뜀 (종전엔 karpathy 가 앞서 ecc-a 가 밀렸다)
+        expect(out!.skillNames).toEqual(['system-skill-backend-developer', 'ecc-a']);
     });
 
     it('합계가 상한 이내면 전부 주입한다', async () => {

--- a/apps/api/src/agents/skill-manager.ts
+++ b/apps/api/src/agents/skill-manager.ts
@@ -20,7 +20,7 @@
  */
 
 import { createLogger } from '../utils/logger';
-import { SkillRepository } from '../data/repositories/skill-repository';
+import { SkillRepository, AGENT_PERSONA_SKILL_ID_PREFIX } from '../data/repositories/skill-repository';
 import type { Pool } from 'pg';
 
 // Re-export 인터페이스 (기존 사용처 호환)
@@ -485,8 +485,9 @@ export class SkillManager {
         const injectedRows: typeof filtered = [];
         const skipped: string[] = [];
         let injectedChars = 0;
-        // system 스킬(페르소나 규칙, 작음)을 먼저 담아 상한에 밀려나지 않게 한다 — 나머지는 priority 순 유지.
-        const ordered = [...filtered].sort((a, b) => Number(b.id.startsWith('system-skill-')) - Number(a.id.startsWith('system-skill-')));
+        // 페르소나(작음)만 먼저 담아 상한에 밀리지 않게 — 전역 시스템 스킬(karpathy 등)까지 앞세우면 관련 스킬이 밀린다.
+        const isPersona = (r: { id: string; assigned_to: string }) => r.id === AGENT_PERSONA_SKILL_ID_PREFIX + r.assigned_to;
+        const ordered = [...filtered].sort((a, b) => Number(isPersona(b)) - Number(isPersona(a)));
         for (const r of ordered) {
             const body = r.prompt_md.length > SKILL_MANIFEST_PER_SKILL_MAX_CHARS
                 ? r.prompt_md.slice(0, SKILL_MANIFEST_PER_SKILL_MAX_CHARS) + '\n... (truncated)' : r.prompt_md;

--- a/apps/api/src/agents/skill-triggers.ts
+++ b/apps/api/src/agents/skill-triggers.ts
@@ -29,13 +29,15 @@ export function formatTriggerHint(manifestMeta?: Record<string, unknown>): strin
 
 /**
  * manifest yaml 의 `triggers:` 블록을 문자열 배열로 파싱.
- * 저장된 manifest_yaml 은 fence 없는 순수 yaml 이라 최상위 키를 multiline 으로 매칭한다.
+ * 최상위 키를 multiline 으로 매칭한다 (fence `---` 유무 무관).
  *
  * 지원 형태:
  *   triggers: [발표자료, 슬라이드]
  *   triggers:
  *     - 발표자료
  *     - "슬라이드"
+ *
+ * 목록 항목은 `-` 뒤 공백이 필수(YAML 규격) — 없으면 바로 뒤 닫는 fence `---` 가 항목 `--` 로 잡힌다.
  */
 export function parseManifestTriggers(manifestYaml: string): string[] {
     const inline = /^triggers:\s*\[([^\]]*)\]\s*$/m.exec(manifestYaml);
@@ -44,10 +46,10 @@ export function parseManifestTriggers(manifestYaml: string): string[] {
             .map(t => t.trim().replace(/^['"]|['"]$/g, ''))
             .filter(Boolean);
     }
-    const block = /^triggers:\s*\n((?:\s*-\s*[^\n]+\n?)+)/m.exec(manifestYaml);
+    const block = /^triggers:\s*\n((?:[ \t]*-[ \t]+[^\n]+\n?)+)/m.exec(manifestYaml);
     if (!block) return [];
     return block[1].split('\n')
-        .map(line => /^\s*-\s*(.+)$/.exec(line)?.[1]?.trim().replace(/^['"]|['"]$/g, '') ?? '')
+        .map(line => /^[ \t]*-[ \t]+(.+)$/.exec(line)?.[1]?.trim().replace(/^['"]|['"]$/g, '') ?? '')
         .filter(Boolean);
 }
 

--- a/apps/api/src/data/repositories/__tests__/skill-manifest-sync.test.ts
+++ b/apps/api/src/data/repositories/__tests__/skill-manifest-sync.test.ts
@@ -1,4 +1,5 @@
-import { buildManifestYaml, skillContentChecksum, upsertSkillManifest, DEFAULT_SKILL_MANIFEST_VERSION, SKILL_VERSION_LATEST_ORDER_SQL } from '../skill-manifest-sync';
+import { buildManifestYaml, extractPreservedManifestYaml, skillContentChecksum, upsertSkillManifest, DEFAULT_SKILL_MANIFEST_VERSION, SKILL_VERSION_LATEST_ORDER_SQL } from '../skill-manifest-sync';
+import { parseManifestTriggers } from '../../../agents/skill-triggers';
 
 // 2026-08-29: createSkill/upsertSystemSkill/skill-creator 가 manifest 를 안 만들어 배정돼도
 // 주입되지 않던 갭 — 모든 생성 경로가 이 헬퍼로 manifest 를 동반한다.
@@ -35,5 +36,30 @@ describe('skill-manifest-sync', () => {
         expect(query.mock.calls[0][1][1]).toBe('2.0.0');
         expect(query.mock.calls[0][1][5]).toBeNull();
         expect(query.mock.calls[0][1][6]).toBe(false);
+    });
+
+    // 2026-09-11: 본문 수정이 yaml 을 3키로 다시 써서 triggers 가 사라지던 잠복 결함
+    it('extractPreservedManifestYaml — 재생성 3키·fence 는 빼고 triggers·tool_bindings 등은 원문 그대로', () => {
+        const yaml = [
+            'name: presentation-designer', 'description: 발표자료 워크플로우', 'category: design', 'version: 1.0.3',
+            'triggers:', '  - "발표자료"', '  - "PPT"',
+            'tool_bindings:', '  - tool_name: "open-design::create_project"', '    mode: required',
+        ].join('\n');
+        expect(extractPreservedManifestYaml(yaml)).toBe([
+            'version: 1.0.3', 'triggers:', '  - "발표자료"', '  - "PPT"',
+            'tool_bindings:', '  - tool_name: "open-design::create_project"', '    mode: required',
+        ].join('\n'));
+    });
+
+    it('extractPreservedManifestYaml — 3키뿐인 fence yaml·빈 값은 빈 문자열, 접힌 description 연속 줄도 제외', () => {
+        expect(extractPreservedManifestYaml(buildManifestYaml({ name: 'n', description: 'd', category: 'ecc' }))).toBe('');
+        expect(extractPreservedManifestYaml(null)).toBe('');
+        expect(extractPreservedManifestYaml('description: >\n  긴 설명\n  둘째 줄\ntriggers: [a, b]')).toBe('triggers: [a, b]');
+    });
+
+    it('buildManifestYaml — preservedYaml 은 fence 안에 붙고, 닫는 fence 가 트리거로 잡히지 않는다', () => {
+        const y = buildManifestYaml({ name: 'n', description: 'd', category: 'design', preservedYaml: 'triggers:\n  - "PPT"\n  - 발표' });
+        expect(y).toBe('---\nname: n\ndescription: d\ncategory: design\ntriggers:\n  - "PPT"\n  - 발표\n---\n');
+        expect(parseManifestTriggers(y)).toEqual(['PPT', '발표']);
     });
 });

--- a/apps/api/src/data/repositories/__tests__/skill-repository-update-manifest.test.ts
+++ b/apps/api/src/data/repositories/__tests__/skill-repository-update-manifest.test.ts
@@ -1,0 +1,39 @@
+/**
+ * SkillRepository.updateSkill — 본문 수정 시 기존 manifest_yaml 의 triggers 등을 보존한다 (2026-09-11).
+ * 종전엔 yaml 을 name·description·category 3키로 다시 써서, 트리거로 게이트하던 스킬
+ * (presentation-designer)이 본문 한 번 수정에 모든 턴 주입으로 풀릴 참이었다.
+ */
+import { Pool } from 'pg';
+import { SkillRepository } from '../skill-repository';
+import { parseManifestTriggers } from '../../../agents/skill-triggers';
+
+jest.mock('../../retry-wrapper', () => ({
+    withRetry: (fn: () => unknown) => fn(),
+}));
+
+const skillRow = (content: string) => ({
+    id: 'skill-1', name: 'deck', description: 'd', content, category: 'design',
+    is_public: false, created_by: 'user-1', created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(), source_repo: null, source_path: null,
+    status: 'active', manifest_meta: null,
+});
+
+describe('SkillRepository.updateSkill — manifest yaml 보존', () => {
+    it('본문을 바꿔도 최신 manifest 의 triggers 가 유지된다', async () => {
+        const query = jest.fn()
+            .mockResolvedValueOnce({ rows: [skillRow('old')] }) // getSkillById
+            .mockResolvedValueOnce({ rows: [] }) // UPDATE agent_skills
+            .mockResolvedValueOnce({ rows: [{ version: '1.0.3', manifest_yaml: 'name: deck\ncategory: design\ntriggers:\n  - "PPT"' }] })
+            .mockResolvedValue({ rows: [skillRow('new')] }); // manifest upsert + getSkillById
+        const repo = new SkillRepository({ query } as unknown as Pool);
+
+        await repo.updateSkill('skill-1', { content: 'new' }, { userId: 'user-1', userRole: 'user' });
+
+        const upsert = query.mock.calls.find(([sql]) => String(sql).includes('INSERT INTO skill_manifests'));
+        expect(upsert).toBeDefined();
+        const params = upsert![1] as unknown[];
+        expect(params[1]).toBe('1.0.3');
+        expect(parseManifestTriggers(String(params[2]))).toEqual(['PPT']);
+        expect(params[3]).toBe('new');
+    });
+});

--- a/apps/api/src/data/repositories/skill-manifest-sync.ts
+++ b/apps/api/src/data/repositories/skill-manifest-sync.ts
@@ -35,14 +35,38 @@ export interface SkillManifestRow {
     version?: string;
     createdBy?: string | null;
     isPublic?: boolean;
+    /** 재생성 3키 밖의 기존 yaml 블록(triggers·tool_bindings 등) — extractPreservedManifestYaml 결과 */
+    preservedYaml?: string;
 }
 
 type QueryFn = (sql: string, params: unknown[]) => Promise<unknown>;
 
-/** 022/111 과 같은 fence 형식 — 소비처(buildManifestPrompt)는 `^name:`·`^category:` 멀티라인 정규식만 읽는다 */
-export function buildManifestYaml(row: Pick<SkillManifestRow, 'name' | 'description' | 'category'>): string {
+/** 재생성 시 행 값으로 다시 쓰는 키 — 나머지 최상위 블록은 보존한다 */
+const REGENERATED_MANIFEST_KEYS = new Set(['name', 'description', 'category']);
+
+/**
+ * 기존 manifest_yaml 에서 재생성 대상 키와 fence 를 뺀 최상위 블록만 추출한다.
+ * 종전엔 본문 수정이 yaml 을 3키로 다시 써서 triggers 가 사라졌다 — 트리거로 게이트하던 스킬이
+ * 그 순간부터 모든 턴에 주입되는 잠복 결함 (2026-09-11 발견, presentation-designer 가 해당).
+ */
+export function extractPreservedManifestYaml(yaml: string | null | undefined): string {
+    if (!yaml) return '';
+    const kept: string[] = [];
+    let keep = false;
+    for (const line of yaml.split(/\r?\n/)) {
+        if (/^---\s*$/.test(line)) { keep = false; continue; }
+        const top = /^([A-Za-z_][\w-]*):/.exec(line);
+        if (top) keep = !REGENERATED_MANIFEST_KEYS.has(top[1]);
+        if (keep && line.trim() !== '') kept.push(line);
+    }
+    return kept.join('\n');
+}
+
+/** 022/111 과 같은 fence 형식 — 소비처(buildManifestPrompt)는 `^name:`·`^category:`·`^triggers:` 멀티라인 정규식으로 읽는다 */
+export function buildManifestYaml(row: Pick<SkillManifestRow, 'name' | 'description' | 'category' | 'preservedYaml'>): string {
     const line = (v: string | null | undefined) => (v ?? '').replace(/\r?\n/g, ' ');
-    return `---\nname: ${line(row.name)}\ndescription: ${line(row.description)}\ncategory: ${row.category || 'general'}\n---\n`;
+    const preserved = row.preservedYaml ? `${row.preservedYaml}\n` : '';
+    return `---\nname: ${line(row.name)}\ndescription: ${line(row.description)}\ncategory: ${row.category || 'general'}\n${preserved}---\n`;
 }
 
 export function skillContentChecksum(content: string): string {

--- a/apps/api/src/data/repositories/skill-repository.ts
+++ b/apps/api/src/data/repositories/skill-repository.ts
@@ -10,7 +10,7 @@
  */
 
 import { createLogger } from '../../utils/logger';
-import { upsertSkillManifest, SKILL_VERSION_LATEST_ORDER_SQL, type SkillManifestRow } from './skill-manifest-sync';
+import { upsertSkillManifest, extractPreservedManifestYaml, SKILL_VERSION_LATEST_ORDER_SQL, type SkillManifestRow } from './skill-manifest-sync';
 import { BaseRepository, QueryParam } from './base-repository';
 import { assertResourceOwnerOrAdmin } from '../../auth/ownership';
 import { assertSkillMutationAllowed } from './skill-authz';
@@ -227,13 +227,15 @@ export class SkillRepository extends BaseRepository {
         // agent_skills.content 만 바꾸면 실제 주입은 옛 내용 그대로라 "수정했는데 그대로"가 된다.
         // 2026-08-29: UPDATE 가 아니라 upsert — manifest 가 없던 레거시 스킬도 갱신 시점에 생긴다.
         if (input.content !== undefined && input.content !== existing.content) {
-            const versions = await this.query<{ version: string }>(
-                `SELECT version FROM skill_manifests WHERE id = $1 ORDER BY ${SKILL_VERSION_LATEST_ORDER_SQL} LIMIT 1`, [id]
+            const latest = await this.query<{ version: string; manifest_yaml: string | null }>(
+                `SELECT version, manifest_yaml FROM skill_manifests WHERE id = $1 ORDER BY ${SKILL_VERSION_LATEST_ORDER_SQL} LIMIT 1`, [id]
             );
             await this.syncManifest({
                 id, name: params[0] as string, description: params[1] as string | null, category: params[3] as string,
                 content: input.content, createdBy: existing.createdBy ?? null, isPublic: params[4] as boolean,
-                version: versions.rows[0]?.version,
+                version: latest.rows[0]?.version,
+                // triggers·tool_bindings 등 3키 밖 블록은 유지 — 다시 쓰면 트리거 게이트가 조용히 풀린다
+                preservedYaml: extractPreservedManifestYaml(latest.rows[0]?.manifest_yaml),
             });
         }
 

--- a/apps/api/src/middlewares/validation.ts
+++ b/apps/api/src/middlewares/validation.ts
@@ -6,12 +6,17 @@ import { ZodSchema, ZodError, ZodIssue } from 'zod';
 import * as fs from 'fs';
 import * as path from 'path';
 import { badRequest } from '../utils/api-response';
-import { detectMaliciousPatterns, sanitizeTextInput, hasExcessiveSpecialCharacters } from '../schemas/security.schema';
+import { detectMaliciousPatterns, sanitizeTextInput, stripControlChars, hasExcessiveSpecialCharacters } from '../schemas/security.schema';
 
 interface SecurityValidationOptions {
     allowedContentTypes?: string[];
     maxBodySizeBytes?: number;
     sanitizeInput?: boolean;
+    /**
+     * 서식을 보존할 최상위 필드 — 제어문자만 제거하고 공백 접기·NFKC·trim 을 하지 않는다.
+     * 기본 정제는 줄바꿈 외 연속 공백을 한 칸으로 접어, 스킬 본문 코드 블록 들여쓰기가 저장 때마다 사라졌다 (2026-09-11).
+     */
+    preserveFormattingFields?: string[];
     detectMaliciousInput?: boolean;
     specialCharacterRatioLimit?: number;
 }
@@ -27,6 +32,7 @@ const DEFAULT_SECURITY_OPTIONS: Required<SecurityValidationOptions> = {
     allowedContentTypes: ['application/json'],
     maxBodySizeBytes: 1 * 1024 * 1024,
     sanitizeInput: true,
+    preserveFormattingFields: [],
     detectMaliciousInput: false,
     specialCharacterRatioLimit: 0.7,
 };
@@ -90,6 +96,18 @@ function sanitizeValue(value: unknown, depth: number = 0): unknown {
     return value;
 }
 
+/** 서식 보존 필드(최상위 문자열)는 제어문자만 제거하고, 나머지는 기본 정제 */
+function sanitizePayload(source: unknown, preserveFields: readonly string[]): unknown {
+    if (preserveFields.length === 0 || !source || typeof source !== 'object' || Array.isArray(source)) {
+        return sanitizeValue(source);
+    }
+    const output: Record<string, unknown> = {};
+    Object.entries(source as Record<string, unknown>).forEach(([key, item]) => {
+        output[key] = preserveFields.includes(key) && typeof item === 'string' ? stripControlChars(item) : sanitizeValue(item, 1);
+    });
+    return output;
+}
+
 function findSecurityViolations(payload: unknown, specialCharacterRatioLimit: number): string[] {
     const violations: string[] = [];
     const strings = extractStringValues(payload);
@@ -128,7 +146,7 @@ function createValidationMiddleware<T>(schema: ZodSchema<T>, options: SecurityVa
             }
 
             const source = mode === 'body' ? req.body : req.query;
-            const payload = merged.sanitizeInput ? sanitizeValue(source) : source;
+            const payload = merged.sanitizeInput ? sanitizePayload(source, merged.preserveFormattingFields) : source;
 
             if (merged.detectMaliciousInput) {
                 const violations = findSecurityViolations(payload, merged.specialCharacterRatioLimit);

--- a/apps/api/src/routes/skills.routes.ts
+++ b/apps/api/src/routes/skills.routes.ts
@@ -34,7 +34,7 @@ import { getUnifiedDatabase } from '../data/models/unified-database';
 import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { requireAuth } from '../auth';
 import { assertResourceOwnerOrAdmin } from '../auth/ownership';
-import { validate, validateQuery } from '../middlewares/validation';
+import { validate, validateQuery, validateWithSecurity } from '../middlewares/validation';
 import {
     createSkillSchema,
     updateSkillSchema,
@@ -166,7 +166,7 @@ router.get('/', requireAuth, validateQuery(searchSkillsQuerySchema), asyncHandle
  * POST /api/agents/skills
  * 스킬 생성
  */
-router.post('/', requireAuth, validate(createSkillSchema), asyncHandler(async (req: Request, res: Response) => {
+router.post('/', requireAuth, validateWithSecurity(createSkillSchema, { preserveFormattingFields: ['content'] }), asyncHandler(async (req: Request, res: Response) => {
     const userId = (req.user && 'userId' in req.user ? (req.user as { userId: string }).userId : req.user?.id?.toString());
     const { name, description, content, category, isPublic } = req.body;
 
@@ -498,7 +498,7 @@ router.post('/:skillId/rewrite-proposal', requireAuth, asyncHandler(async (req: 
  * PUT /api/agents/skills/:skillId
  * 스킬 수정 (소유권 검증 포함)
  */
-router.put('/:skillId', requireAuth, validate(updateSkillSchema), asyncHandler(async (req: Request, res: Response) => {
+router.put('/:skillId', requireAuth, validateWithSecurity(updateSkillSchema, { preserveFormattingFields: ['content'] }), asyncHandler(async (req: Request, res: Response) => {
     const { skillId } = req.params;
     const userId = (req.user && 'userId' in req.user ? (req.user as { userId: string }).userId : req.user?.id?.toString());
 

--- a/apps/api/src/schemas/security.schema.ts
+++ b/apps/api/src/schemas/security.schema.ts
@@ -53,7 +53,7 @@ const ENCODING_ATTACK_PATTERNS: readonly RegExp[] = [
     /&#x?[0-9a-f]+;/i,
 ];
 
-function stripControlChars(value: string): string {
+export function stripControlChars(value: string): string {
     return value.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
 }
 


### PR DESCRIPTION
## 요약
설치 스킬 컨텍스트 점검(2026-09-11) 후속입니다. 스킬 본문·manifest 가 저장 경로에서 조용히 훼손되던 결함 3건과 주입 순서 1건을 고칩니다.

1. **스킬 본문 저장 시 들여쓰기 소실 (현행 결함)** — `validate()` 기본 정제(`sanitizeTextInput`)가 줄바꿈 외 연속 공백을 한 칸으로 접고(`/[^\S\n]+/g → ' '`) NFKC·trim 을 합니다. `POST/PUT /api/agents/skills` 가 이 경로라 웹 스킬 편집·재작성 제안 적용(approvals) 모두 코드 블록 들여쓰기를 잃었습니다. ecc 스킬 9종(07-17 등록) 예제가 1칸 들여쓰기로 망가진 원인이고, 원본 재수입 PUT 도 같은 이유로 HTTP 200 인데 본문이 바뀌지 않았습니다. `validateWithSecurity(..., { preserveFormattingFields: ['content'] })` — 지정 필드는 제어문자만 제거하고 나머지 필드는 종전 정제를 유지합니다.
2. **본문 수정 시 manifest 트리거 소실 (잠복)** — `updateSkill` 이 manifest_yaml 을 name·description·category 3키로 재생성해 triggers·tool_bindings 가 사라졌습니다. presentation-designer(트리거 게이트)가 본문 한 번 수정에 모든 턴 주입으로 풀릴 수 있었습니다. 기존 yaml 의 3키 밖 최상위 블록을 보존합니다.
3. **트리거 파서가 닫는 fence 를 항목으로 잡음** — 목록 항목에 `-` 뒤 공백 필수(YAML 규격).
4. **주입 상한 순서** — `system-skill-*` 전체 우선 → 에이전트 페르소나(id = 접두사 + 배정 agent_id)만 우선. 전역 시스템 스킬(karpathy)을 기술 에이전트에 배정하면 관련 ecc 스킬이 상한에 밀리던 문제.

## 같은 부류로 남은 것 (범위 밖)
`validate()` 기본 정제는 검증을 쓰는 34개 라우트 파일 전부에 적용되고 opt-out 이 0건입니다. 긴 텍스트 필드 중 확인된 것: MCP 카탈로그 `command_template`(admin) · `external.schema` `cachedContent` · 시스템 설정 값. 여러 칸 공백이 의미를 갖는 값이면 같은 방식의 필드 지정이 필요합니다 — 별건.

## 테스트
- [x] 신규: `validation-preserve-formatting`(2, 실제 sanitizer) · `skill-repository-update-manifest`(1) · `skill-manifest-sync`(+3) · `skill-inject-cap`(+1, 픽스처 페르소나 id 정정)
- [x] 수정을 되돌리면 정제 · 트리거 보존 · fence 파싱 · 주입 순서 테스트가 각각 실패
- [x] 관련 8 suite 63 passed · `tsc --noEmit` 0 · eslint 0 (skills.routes max-lines 경고는 main 과 같은 기존 경고)
- [ ] 배포 후: ecc 원본 재수입 PUT 으로 들여쓰기 복원 실측 · 에이전트별 주입 재현

마이그레이션·env 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Kmw1CDfo4Eouse77o5PVh