### PR TITLE
fix(api): 코드·비밀값이 들어오는 긴 텍스트 필드의 공백 정제 해제

### DIFF
--- a/apps/api/src/__tests__/validation-preserve-formatting.test.ts
+++ b/apps/api/src/__tests__/validation-preserve-formatting.test.ts
@@ -33,4 +33,11 @@ describe('validate 정제 — 서식 보존 필드', () => {
         expect(out.content).toBe(CODE);
         expect(out.name).toBe('a b'); // 지정하지 않은 필드는 종전대로 정제
     });
+
+    it('지정한 키 안쪽의 배열·객체 문자열까지 보존한다 (히스토리·첨부·도구 인자·환경변수)', () => {
+        const nested = z.object({ history: z.array(z.object({ content: z.string() })), env: z.record(z.string(), z.string()) });
+        const out = run(validateWithSecurity(nested, { preserveFormattingFields: ['history', 'env'] }),
+            { history: [{ content: CODE }], env: { PASS: ' a  b ' } }) as unknown as z.infer<typeof nested>;
+        expect(out).toEqual({ history: [{ content: CODE }], env: { PASS: ' a  b ' } });
+    });
 });

--- a/apps/api/src/middlewares/validation.ts
+++ b/apps/api/src/middlewares/validation.ts
@@ -96,14 +96,25 @@ function sanitizeValue(value: unknown, depth: number = 0): unknown {
     return value;
 }
 
-/** 서식 보존 필드(최상위 문자열)는 제어문자만 제거하고, 나머지는 기본 정제 */
+/** 서식 보존 — 문자열은 제어문자만 제거하고, 배열·객체는 안쪽까지 같은 규칙 */
+function preserveValue(value: unknown, depth: number = 0): unknown {
+    if (depth > 8) return value;
+    if (typeof value === 'string') return stripControlChars(value);
+    if (Array.isArray(value)) return value.map((item) => preserveValue(item, depth + 1));
+    if (value && typeof value === 'object') {
+        return Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, preserveValue(v, depth + 1)]));
+    }
+    return value;
+}
+
+/** 서식 보존 필드(최상위 키 — 안쪽 배열·객체 포함)는 preserveValue, 나머지는 기본 정제 */
 function sanitizePayload(source: unknown, preserveFields: readonly string[]): unknown {
     if (preserveFields.length === 0 || !source || typeof source !== 'object' || Array.isArray(source)) {
         return sanitizeValue(source);
     }
     const output: Record<string, unknown> = {};
     Object.entries(source as Record<string, unknown>).forEach(([key, item]) => {
-        output[key] = preserveFields.includes(key) && typeof item === 'string' ? stripControlChars(item) : sanitizeValue(item, 1);
+        output[key] = preserveFields.includes(key) ? preserveValue(item, 1) : sanitizeValue(item, 1);
     });
     return output;
 }

--- a/apps/api/src/routes/agent-task-schedule.routes.ts
+++ b/apps/api/src/routes/agent-task-schedule.routes.ts
@@ -21,7 +21,7 @@ import { success, badRequest, notFound } from '../utils/api-response';
 import { asyncHandler } from '../utils/error-handler';
 import { requireAuth } from '../auth';
 import { assertResourceOwnerOrAdmin } from '../auth/ownership';
-import { validate } from '../middlewares/validation';
+import { validateWithSecurity } from '../middlewares/validation';
 import { getPool } from '../data/models/unified-database';
 import { v4 as uuidv4 } from 'uuid';
 import { AgentTaskScheduleRepository } from '../data/repositories/agent-task-schedule-repository';
@@ -46,7 +46,7 @@ async function loadOwned(req: Request, res: Response, id: string) {
 }
 
 /** POST / — 스케줄 생성. */
-router.post('/', validate(createAgentTaskScheduleSchema), asyncHandler(async (req: Request, res: Response) => {
+router.post('/', validateWithSecurity(createAgentTaskScheduleSchema, { preserveFormattingFields: ['goal'] }), asyncHandler(async (req: Request, res: Response) => {
     const { goal, cron, intervalSeconds, maxTurns } = req.body as CreateAgentTaskScheduleInput;
     const userId = String(req.user!.id);
 
@@ -78,7 +78,7 @@ router.get('/', asyncHandler(async (req: Request, res: Response) => {
 }));
 
 /** PATCH /:id — 스케줄 수정. timing 변경 시 next_run_at 재계산. */
-router.patch('/:id', validate(updateAgentTaskScheduleSchema), asyncHandler(async (req: Request, res: Response) => {
+router.patch('/:id', validateWithSecurity(updateAgentTaskScheduleSchema, { preserveFormattingFields: ['goal'] }), asyncHandler(async (req: Request, res: Response) => {
     const s = await loadOwned(req, res, req.params.id);
     if (!s) return;
     const body = req.body as UpdateAgentTaskScheduleInput;

--- a/apps/api/src/routes/agent-task-template.routes.ts
+++ b/apps/api/src/routes/agent-task-template.routes.ts
@@ -20,7 +20,7 @@ import { success, notFound } from '../utils/api-response';
 import { asyncHandler } from '../utils/error-handler';
 import { requireAuth } from '../auth';
 import { assertResourceOwnerOrAdmin } from '../auth/ownership';
-import { validate } from '../middlewares/validation';
+import { validateWithSecurity } from '../middlewares/validation';
 import { getPool, getUnifiedDatabase } from '../data/models/unified-database';
 import { v4 as uuidv4 } from 'uuid';
 import { AgentTaskTemplateRepository, instantiateGoal } from '../data/repositories/agent-task-template-repository';
@@ -46,7 +46,7 @@ async function loadOwned(req: Request, res: Response, id: string) {
 }
 
 /** POST / — 템플릿 생성. */
-router.post('/', validate(createAgentTaskTemplateSchema), asyncHandler(async (req: Request, res: Response) => {
+router.post('/', validateWithSecurity(createAgentTaskTemplateSchema, { preserveFormattingFields: ['goalTemplate'] }), asyncHandler(async (req: Request, res: Response) => {
     const { name, goalTemplate, params, maxTurns } = req.body as CreateAgentTaskTemplateInput;
     const id = uuidv4();
     await repo().create({
@@ -64,7 +64,7 @@ router.get('/', asyncHandler(async (req: Request, res: Response) => {
 }));
 
 /** PATCH /:id — 수정. */
-router.patch('/:id', validate(updateAgentTaskTemplateSchema), asyncHandler(async (req: Request, res: Response) => {
+router.patch('/:id', validateWithSecurity(updateAgentTaskTemplateSchema, { preserveFormattingFields: ['goalTemplate'] }), asyncHandler(async (req: Request, res: Response) => {
     const t = await loadOwned(req, res, req.params.id);
     if (!t) return;
     const b = req.body as UpdateAgentTaskTemplateInput;
@@ -83,7 +83,7 @@ router.delete('/:id', asyncHandler(async (req: Request, res: Response) => {
 /**
  * POST /:id/instantiate — 파라미터 치환으로 task 생성. execute!==false 면 즉시 실행(큐 3-B 경유).
  */
-router.post('/:id/instantiate', validate(instantiateTemplateSchema), asyncHandler(async (req: Request, res: Response) => {
+router.post('/:id/instantiate', validateWithSecurity(instantiateTemplateSchema, { preserveFormattingFields: ['values'] }), asyncHandler(async (req: Request, res: Response) => {
     const t = await loadOwned(req, res, req.params.id);
     if (!t) return;
     const { values, execute } = req.body as InstantiateTemplateInput;

--- a/apps/api/src/routes/agent-task.routes.ts
+++ b/apps/api/src/routes/agent-task.routes.ts
@@ -85,6 +85,7 @@ const uploadMw = multer({
 // 무력화해 대용량 첨부가 "요청 본문이 너무 큽니다" 로 거부되던 정합 버그 방지.
 const jsonValidateMw = validateWithSecurity(createAgentTaskSchema, {
     maxBodySizeBytes: AGENT_TASK_LIMITS.REQUEST_BODY_MAX_BYTES,
+    preserveFormattingFields: ['goal', 'files'], // 첨부 텍스트(코드·CSV) 들여쓰기 보존 — 기본 정제는 연속 공백을 접는다
 });
 
 router.post('/', (req: Request, res: Response, next) => {

--- a/apps/api/src/routes/chat.routes.ts
+++ b/apps/api/src/routes/chat.routes.ts
@@ -23,7 +23,7 @@ import { optionalAuth } from '../auth';
 import { isPersistableUserId } from '../utils/user-id-validation';
 import { optionalApiKey } from '../middlewares/api-key-auth';
 import { chatRateLimiter } from '../middlewares/chat-rate-limiter';
-import { validate } from '../middlewares/validation';
+import { validateWithSecurity } from '../middlewares/validation';
 import { chatRequestSchema } from '../schemas';
 import { ChatRequestHandler, ChatRequestError } from '../chat/request-handler';
 import { ensureSession, saveUserMessage, saveAssistantMessage } from '../chat/request-persistence';
@@ -65,7 +65,7 @@ export function setClusterManager(cluster: ClusterManager): void {
  * 일반 채팅 API (non-streaming)
  * 🔒 Phase 2 보안 패치: optionalAuth 미들웨어 적용
  */
-router.post('/', optionalApiKey, optionalAuth, chatRateLimiter, validate(chatRequestSchema), asyncHandler(async (req: Request, res: Response) => {
+router.post('/', optionalApiKey, optionalAuth, chatRateLimiter, validateWithSecurity(chatRequestSchema, { preserveFormattingFields: ['message', 'history'] }), asyncHandler(async (req: Request, res: Response) => {
     const { message, model, nodeId, history, sessionId, tools, tool_choice } = req.body;
 
     // 인증 확인 (ChatRequestHandler로 통합)
@@ -148,7 +148,7 @@ router.post('/', optionalApiKey, optionalAuth, chatRateLimiter, validate(chatReq
  * ✅ ChatService 경유: DB 로깅, Discussion, Deep Research, Agent Loop, Memory 지원
  * NOTE: SSE 엔드포인트는 asyncHandler로 감싸지 않음 (수동 에러 처리 필요)
  */
-router.post('/stream', optionalApiKey, optionalAuth, chatRateLimiter, validate(chatRequestSchema), async (req: Request, res: Response) => {
+router.post('/stream', optionalApiKey, optionalAuth, chatRateLimiter, validateWithSecurity(chatRequestSchema, { preserveFormattingFields: ['message', 'history'] }), async (req: Request, res: Response) => {
     const { message, model, nodeId, sessionId, tools, tool_choice } = req.body;
 
     // 인증 확인 (ChatRequestHandler로 통합)

--- a/apps/api/src/routes/mcp-catalog.routes.ts
+++ b/apps/api/src/routes/mcp-catalog.routes.ts
@@ -8,7 +8,7 @@
  */
 import { Router, Request, Response } from 'express';
 import { requireAuth } from '../auth';
-import { validate } from '../middlewares/validation';
+import { validateWithSecurity } from '../middlewares/validation';
 import { asyncHandler } from '../utils/error-handler';
 import { success, forbidden, notFound } from '../utils/api-response';
 import { McpCatalogRepository } from '../data/repositories/mcp-catalog-repository';
@@ -36,7 +36,7 @@ mcpCatalogRouter.get('/catalog', requireAuth, asyncHandler(async (_req: Request,
 mcpCatalogRouter.post(
     '/servers/from-catalog',
     requireAuth,
-    validate(McpFromCatalogPayloadSchema),
+    validateWithSecurity(McpFromCatalogPayloadSchema, { preserveFormattingFields: ['args', 'env'] }), // 비밀값·인자 원문 유지
     asyncHandler(async (req: Request, res: Response) => {
         const userId = String(req.user?.id ?? '');
         const role = req.user?.role ?? 'user';

--- a/apps/api/src/routes/mcp.routes.ts
+++ b/apps/api/src/routes/mcp.routes.ts
@@ -35,7 +35,7 @@ import type { MCPTransportType, MCPConnectionStatus } from '../mcp/types';
 import { getLifecycleSupervisor } from '../mcp/lifecycle-supervisor';
 import { createLogger } from '../utils/logger';
 import { classifyConnectError, parseConnectError } from '../mcp/connect-error';
-import { validate } from '../middlewares/validation';
+import { validate, validateWithSecurity } from '../middlewares/validation';
 import { mcpToolExecuteSchema, mcpServerCreateSchema, mcpServerEnvUpdateSchema,
     mcpServerEnabledUpdateSchema, mcpServerAutoSpawnUpdateSchema, mcpServerRenameSchema } from '../schemas/mcp.schema';
 import { McpCatalogRepository } from '../data/repositories/mcp-catalog-repository';
@@ -76,7 +76,7 @@ export const mcpRouter = Router();
  });
 
   // 도구 실행 (POST) - 사용자 컨텍스트 기반 권한 검증
-  mcpRouter.post('/tools/:name/execute', requireAuth, validate(mcpToolExecuteSchema), asyncHandler(async (req: Request, res: Response) => {
+  mcpRouter.post('/tools/:name/execute', requireAuth, validateWithSecurity(mcpToolExecuteSchema, { preserveFormattingFields: ['arguments'] }), asyncHandler(async (req: Request, res: Response) => {
       const { name } = req.params;
       const { arguments: args = {} } = req.body;
 
@@ -174,7 +174,7 @@ export const mcpRouter = Router();
 
   // 새 외부 서버 등록 (POST) — visibility 분기:
   //   global (admin) | user_private | user_shared (사용자는 카탈로그 템플릿만)
-  mcpRouter.post('/servers', requireAuth, validate(mcpServerCreateSchema), asyncHandler(async (req: Request, res: Response) => {
+  mcpRouter.post('/servers', requireAuth, validateWithSecurity(mcpServerCreateSchema, { preserveFormattingFields: ['env'] }), asyncHandler(async (req: Request, res: Response) => {
       const userId = String(req.user?.id ?? '');
       const role = req.user?.role ?? 'user';
       const actor = { id: userId, role };
@@ -370,7 +370,7 @@ export const mcpRouter = Router();
       res.json(success({ id, auto_spawn: autoSpawn, spawned }));
   }));
 
-  mcpRouter.patch('/servers/:id/env', requireAuth, validate(mcpServerEnvUpdateSchema), asyncHandler(async (req: Request, res: Response) => {
+  mcpRouter.patch('/servers/:id/env', requireAuth, validateWithSecurity(mcpServerEnvUpdateSchema, { preserveFormattingFields: ['env'] }), asyncHandler(async (req: Request, res: Response) => {
       const userId = String(req.user?.id ?? '');
       const role = req.user?.role ?? 'user';
       const actor = { id: userId, role };

--- a/apps/api/src/schemas/__tests__/preserve-whitespace.test.ts
+++ b/apps/api/src/schemas/__tests__/preserve-whitespace.test.ts
@@ -1,0 +1,48 @@
+/**
+ * 긴 텍스트 필드 서식 보존 (2026-09-11).
+ *
+ * secureTextSchema 의 기본 정제(sanitizeTextInput)는 줄바꿈 외 연속 공백을 한 칸으로 접고 NFKC·trim 을 한다.
+ * REST 채팅 메시지·에이전트 작업 목표처럼 사용자가 코드를 붙여 넣는 필드는 모델에 닿기 전에 들여쓰기가
+ * 사라졌다(웹 채팅 WS 경로는 이 스키마를 타지 않아 무관). 실제 sanitizer 로 검증한다.
+ */
+import { secureTextSchema } from '../security.schema';
+import { chatRequestSchema } from '../chat.schema';
+import { createAgentTaskSchema, createAgentTaskScheduleSchema, createAgentTaskTemplateSchema } from '../agent-task.schema';
+
+const CODE = 'def f():\n    if x:\n\t\treturn 1\n';
+
+describe('secureTextSchema preserveWhitespace', () => {
+    it('기본은 연속 공백을 접는다 (짧은 필드용 종전 동작)', () => {
+        expect(secureTextSchema({ detectMaliciousPatterns: false }).parse(CODE)).toBe('def f():\n if x:\n return 1');
+    });
+
+    it('preserveWhitespace 는 들여쓰기·탭·끝 줄바꿈을 두고 제어문자만 뺀다', () => {
+        expect(secureTextSchema({ detectMaliciousPatterns: false, preserveWhitespace: true }).parse(`${CODE}\u0000`)).toBe(CODE);
+    });
+});
+
+describe('코드가 들어오는 긴 텍스트 필드는 서식을 보존한다', () => {
+    it('REST 채팅 메시지·히스토리 본문·도구 호출 인자', () => {
+        const args = '{"code": "if x:\\n    y"}';
+        const out = chatRequestSchema.parse({
+            message: CODE,
+            history: [
+                { role: 'user', content: CODE },
+                { role: 'assistant', content: null, tool_calls: [{ id: 'c1', type: 'function', function: { name: 'run', arguments: `  ${args}` } }] },
+            ],
+        });
+        expect(out.message).toBe(CODE);
+        expect(out.history?.[0].content).toBe(CODE);
+        expect(out.history?.[1].tool_calls?.[0].function.arguments).toBe(`  ${args}`);
+    });
+
+    it('에이전트 작업·예약·템플릿 목표', () => {
+        expect(createAgentTaskSchema.parse({ goal: CODE }).goal).toBe(CODE);
+        expect(createAgentTaskScheduleSchema.parse({ goal: CODE, intervalSeconds: 86_400 }).goal).toBe(CODE);
+        expect(createAgentTaskTemplateSchema.parse({ name: 't', goalTemplate: CODE }).goalTemplate).toBe(CODE);
+    });
+
+    it('짧은 식별 필드는 종전대로 정제한다 (모델 id 등)', () => {
+        expect(chatRequestSchema.parse({ message: 'hi', model: '  qwen   x  ' }).model).toBe('qwen x');
+    });
+});

--- a/apps/api/src/schemas/agent-task.schema.ts
+++ b/apps/api/src/schemas/agent-task.schema.ts
@@ -55,7 +55,7 @@ export type ChunkedUploadInitInput = z.infer<typeof chunkedUploadInitSchema>;
  * @property {Array} [images] - 입력 첨부 이미지 dataURL (vision 채널 전달)
  */
 export const createAgentTaskSchema = z.strictObject({
-    goal: secureTextSchema({ minLength: 1, maxLength: AGENT_TASK_LIMITS.GOAL_MAX_CHARS, fieldName: 'goal', allowHtmlLikeContent: true, detectMaliciousPatterns: false }),
+    goal: secureTextSchema({ minLength: 1, maxLength: AGENT_TASK_LIMITS.GOAL_MAX_CHARS, fieldName: 'goal', allowHtmlLikeContent: true, detectMaliciousPatterns: false, preserveWhitespace: true }),
     maxTurns: z.number().int().min(1).max(AGENT_TASK_LIMITS.MAX_TURNS_CEILING).optional(),
     // Cowork D1a: 실행 백엔드 — 'local' 은 LOCAL_EXECUTOR_ENABLED + 디바이스 연결 필요(라우트가 검증).
     executor: z.enum(['sandbox', 'local']).optional(),
@@ -105,7 +105,7 @@ export type ExecuteAgentTaskInput = z.infer<typeof executeAgentTaskSchema>;
  * cron 표현식 유효성은 라우트에서 parseCron 으로 추가 검증.
  */
 export const createAgentTaskScheduleSchema = z.object({
-    goal: secureTextSchema({ minLength: 1, maxLength: AGENT_TASK_LIMITS.GOAL_MAX_CHARS, fieldName: 'goal', allowHtmlLikeContent: true, detectMaliciousPatterns: false }),
+    goal: secureTextSchema({ minLength: 1, maxLength: AGENT_TASK_LIMITS.GOAL_MAX_CHARS, fieldName: 'goal', allowHtmlLikeContent: true, detectMaliciousPatterns: false, preserveWhitespace: true }),
     cron: z.string().min(1).max(120).optional(),
     intervalSeconds: z.number().int().min(AGENT_TASK_LIMITS.SCHEDULE_MIN_INTERVAL_SEC).max(365 * 24 * 3600).optional(),
     maxTurns: z.number().int().min(1).max(AGENT_TASK_LIMITS.MAX_TURNS_CEILING).optional(),
@@ -115,7 +115,7 @@ export const createAgentTaskScheduleSchema = z.object({
 
 /** 스케줄 부분 수정 스키마 — 제공된 필드만 갱신. */
 export const updateAgentTaskScheduleSchema = z.object({
-    goal: secureTextSchema({ minLength: 1, maxLength: AGENT_TASK_LIMITS.GOAL_MAX_CHARS, fieldName: 'goal', allowHtmlLikeContent: true, detectMaliciousPatterns: false }).optional(),
+    goal: secureTextSchema({ minLength: 1, maxLength: AGENT_TASK_LIMITS.GOAL_MAX_CHARS, fieldName: 'goal', allowHtmlLikeContent: true, detectMaliciousPatterns: false, preserveWhitespace: true }).optional(),
     cron: z.string().min(1).max(120).nullable().optional(),
     intervalSeconds: z.number().int().min(AGENT_TASK_LIMITS.SCHEDULE_MIN_INTERVAL_SEC).max(365 * 24 * 3600).nullable().optional(),
     maxTurns: z.number().int().min(1).max(AGENT_TASK_LIMITS.MAX_TURNS_CEILING).optional(),
@@ -135,7 +135,7 @@ const templateParamSchema = z.object({
 /** 작업 템플릿 생성 스키마(6-1). goal_template 은 secureText(HTML 태그 금지 등) 적용. */
 export const createAgentTaskTemplateSchema = z.object({
     name: z.string().min(1).max(100),
-    goalTemplate: secureTextSchema({ minLength: 1, maxLength: AGENT_TASK_LIMITS.GOAL_MAX_CHARS, fieldName: 'goalTemplate', allowHtmlLikeContent: true, detectMaliciousPatterns: false }),
+    goalTemplate: secureTextSchema({ minLength: 1, maxLength: AGENT_TASK_LIMITS.GOAL_MAX_CHARS, fieldName: 'goalTemplate', allowHtmlLikeContent: true, detectMaliciousPatterns: false, preserveWhitespace: true }),
     params: z.array(templateParamSchema).max(10).optional(),
     maxTurns: z.number().int().min(1).max(AGENT_TASK_LIMITS.MAX_TURNS_CEILING).optional(),
 });

--- a/apps/api/src/schemas/chat.schema.ts
+++ b/apps/api/src/schemas/chat.schema.ts
@@ -23,7 +23,7 @@ const toolCallInMessageSchema = z.object({
     type: z.literal('function'),
     function: z.object({
         name: secureTextSchema({ minLength: 1, maxLength: 128, fieldName: 'tool_call.function.name', allowNewLines: false, detectMaliciousPatterns: false }),
-        arguments: secureTextSchema({ maxLength: 200000, fieldName: 'tool_call.function.arguments', allowHtmlLikeContent: true, detectMaliciousPatterns: false }),
+        arguments: secureTextSchema({ maxLength: 200000, fieldName: 'tool_call.function.arguments', allowHtmlLikeContent: true, detectMaliciousPatterns: false, preserveWhitespace: true }),
     }),
 });
 
@@ -36,7 +36,7 @@ const toolCallInMessageSchema = z.object({
  */
 const chatMessageSchema = z.object({
     role: z.enum(['user', 'assistant', 'system', 'tool']),
-    content: secureTextSchema({ maxLength: 100000, fieldName: 'content', allowHtmlLikeContent: true, detectMaliciousPatterns: false }).or(z.null()).optional().default(''),
+    content: secureTextSchema({ maxLength: 100000, fieldName: 'content', allowHtmlLikeContent: true, detectMaliciousPatterns: false, preserveWhitespace: true }).or(z.null()).optional().default(''),
     tool_calls: z.array(toolCallInMessageSchema).optional(),
     tool_call_id: secureOptionalTextSchema({ maxLength: 200, fieldName: 'tool_call_id', allowNewLines: false, detectMaliciousPatterns: false }),
     // 히스토리 vision 이미지 — zod 기본 strip 이라 키가 없으면 validate 가 조용히 지워 WS/openai-compat
@@ -64,7 +64,7 @@ const toolDefinitionSchema = z.object({
     type: z.literal('function'),
     function: z.object({
         name: secureTextSchema({ minLength: 1, maxLength: 64, fieldName: 'function.name', allowNewLines: false, detectMaliciousPatterns: false }),
-        description: secureOptionalTextSchema({ maxLength: 5000, fieldName: 'function.description', allowHtmlLikeContent: true, detectMaliciousPatterns: false }),
+        description: secureOptionalTextSchema({ maxLength: 5000, fieldName: 'function.description', allowHtmlLikeContent: true, detectMaliciousPatterns: false, preserveWhitespace: true }),
         parameters: functionParametersSchema.optional(),
         strict: z.boolean().optional(),
     }),
@@ -105,7 +105,7 @@ const toolChoiceSchema = z.union([
  * @property {string|object} [tool_choice] - 도구 호출 제어 ("auto"|"none"|"required"|{...})
  */
 export const chatRequestSchema = z.object({
-    message: secureTextSchema({ minLength: 1, maxLength: 100000, fieldName: 'message', allowHtmlLikeContent: true, detectMaliciousPatterns: false }),
+    message: secureTextSchema({ minLength: 1, maxLength: 100000, fieldName: 'message', allowHtmlLikeContent: true, detectMaliciousPatterns: false, preserveWhitespace: true }),
     history: z.array(chatMessageSchema).optional(),
     model: secureOptionalTextSchema({ maxLength: 200, fieldName: 'model', allowNewLines: false, detectMaliciousPatterns: false }),
     nodeId: secureOptionalTextSchema({ maxLength: 200, fieldName: 'nodeId', allowNewLines: false, detectMaliciousPatterns: false }),

--- a/apps/api/src/schemas/security.schema.ts
+++ b/apps/api/src/schemas/security.schema.ts
@@ -8,6 +8,11 @@ export interface SecureTextOptions {
     allowHtmlLikeContent?: boolean;
     specialCharacterRatioLimit?: number;
     detectMaliciousPatterns?: boolean;
+    /**
+     * 공백 접기·NFKC·trim 없이 제어문자만 제거 — 코드·들여쓰기가 의미를 갖는 긴 본문용 (2026-09-11).
+     * 기본 정제는 줄바꿈 외 연속 공백을 한 칸으로 접어 REST 채팅에 붙여 넣은 코드가 모델에 닿기 전에 망가졌다.
+     */
+    preserveWhitespace?: boolean;
 }
 
 export interface MaliciousDetectionResult {
@@ -114,11 +119,12 @@ export function secureTextSchema(options: SecureTextOptions = {}) {
     const allowHtmlLikeContent = options.allowHtmlLikeContent ?? false;
     const specialCharacterRatioLimit = options.specialCharacterRatioLimit ?? 0.65;
     const detectPatterns = options.detectMaliciousPatterns ?? true;
+    const preserveWhitespace = options.preserveWhitespace ?? false;
 
     return z.string()
         .min(minLength)
         .max(maxLength)
-        .transform((value) => sanitizeTextInput(value, allowNewLines))
+        .transform((value) => (preserveWhitespace ? stripControlChars(value) : sanitizeTextInput(value, allowNewLines)))
         .superRefine((value, ctx) => {
             if (detectPatterns) {
                 const detection = detectMaliciousPatterns(value);


### PR DESCRIPTION
## 요약
`validate()` 기본 정제와 `secureTextSchema` 는 줄바꿈 외 연속 공백을 한 칸으로 접고 NFKC·trim 을 합니다. #823 에서 스킬 본문만 풀었고, 같은 정제가 걸린 긴 텍스트 필드를 전수 점검했습니다(검증을 쓰는 스키마 60여 개).

### 해제한 필드
| 경로 | 필드 | 영향 |
|---|---|---|
| REST 채팅 `/api/chat`·`/stream` | `message` · `history`(content·tool_calls.arguments) | 붙여 넣은 코드가 모델에 닿기 전에 들여쓰기를 잃음. 스키마·미들웨어 두 겹 (웹 채팅 WS 는 무관) |
| 에이전트 작업 생성 | `goal` · `files`(텍스트 content) | 첨부 `.py`/CSV 가 깨진 채 workspace `uploads/` 에 기록 (base64 원본 `data` 는 무관) |
| 예약·템플릿 | `goal` · `goalTemplate` · `values` | 목표 안 코드·중첩 목록 들여쓰기 |
| MCP | 도구 실행 `arguments` · 서버 등록/환경변수/카탈로그 설치 `env`·`args` | 코드 인자·비밀값 원문 변형 |

미들웨어 `preserveFormattingFields` 는 지정 키 안쪽 배열·객체까지 적용되도록 넓혔고, `secureTextSchema` 에 `preserveWhitespace` 옵션을 추가했습니다. 두 곳 모두 제어문자는 계속 제거합니다.

### 의도적으로 두는 것
- **비밀번호**(가입·로그인·변경·첫 셋업): 가입과 로그인이 같은 정제를 거쳐 저장 해시와 맞물려 있어, 바꾸면 기존 사용자 로그인이 실패할 수 있습니다
- 시스템 설정 값: URL·키·숫자뿐이라 trim 이 이득
- 외부 파일 `cachedContent`: 운영 0건(미사용)
- MCP 서버 `command`·`args`(한 줄 셸 명령) 와 이름·제목 등 짧은 필드

## 테스트
- [x] 신규 `preserve-whitespace.test.ts`(5, 실제 sanitizer — 채팅·작업·예약·템플릿 파싱) · `validation-preserve-formatting` +1(중첩 보존)
- [x] 수정을 되돌리면 4건 실패
- [x] 관련 9 suite 69 passed · `tsc --noEmit` 0 · eslint 0 (agent-task.routes max-lines 경고는 main 과 같은 기존 경고)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Kmw1CDfo4Eouse77o5PVh