### PR TITLE
feat(skills): 주입 합계 상한을 넘는 턴은 어떤 스킬을 불러올지 모델이 고른다

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1416,6 +1416,9 @@ SKILL_CATALOG_MAX_ITEMS=200
 SKILL_CATALOG_DESC_MAX=120
 # 에이전트 페르소나 스킬("○○ 전문 스킬")은 그 에이전트에 이미 자동 주입되므로 카탈로그에서 제외(기본 true).
 SKILL_CATALOG_EXCLUDE_PERSONAS=true
+# 에이전트 배정 스킬이 주입 합계 상한을 넘는 턴은 본문 대신 후보 목록을 싣고 모델이 load_skill 로
+# 고르게 한다(SKILL_AUTO_SELECT_ENABLED=true 일 때만). false 면 종전처럼 순서대로 담고 넘치면 건너뜀.
+SKILL_OVERFLOW_OFFER_ENABLED=true
 # 외부 MCP stdio 서버 OS 격리 (Docker) — 외부 MCP 서버를 `docker run` 컨테이너로 격리.
 # 호스트 FS·비밀·네트워크 접근 차단. macOS(Docker Desktop) 포함 docker 있는 모든 호스트에서 동작.
 # 기본 OFF. docker 부재 시 graceful no-op(비격리 실행 + 경고).

--- a/apps/api/src/agents/__tests__/manifest-injection-plan.test.ts
+++ b/apps/api/src/agents/__tests__/manifest-injection-plan.test.ts
@@ -1,0 +1,49 @@
+/**
+ * manifest 주입 계획 (2026-09-11) — 합계 상한을 넘는 턴의 선택을 id 순이 아니라 모델에게 맡긴다.
+ */
+import { planManifestInjection, manifestYamlField } from '../manifest-injection-plan';
+
+const row = (id: string, chars: number, assigned_to = 'backend-developer') => ({ id, assigned_to, prompt_md: 'x'.repeat(chars) });
+const isPersona = (r: { id: string; assigned_to: string }) => r.id === `system-skill-${r.assigned_to}`;
+const base = { maxChars: 1000, perSkillMaxChars: 700, isPersona };
+// 페르소나 100 + ecc-a(700 절단 → 716) + karpathy 300 = 1,116 > 1,000
+const overflowRows = () => [row('ecc-a', 800), row('system-skill-karpathy-guidelines', 300), row('system-skill-backend-developer', 100)];
+
+describe('planManifestInjection', () => {
+    it('합계가 상한 안이면 모두 싣는다 — 고를 필요가 없다', () => {
+        const p = planManifestInjection([row('a', 300), row('system-skill-backend-developer', 100)], { ...base, offerOnOverflow: true });
+        expect(p.injected.map((r) => r.id)).toEqual(['system-skill-backend-developer', 'a']);
+        expect(p.offered).toEqual([]);
+    });
+
+    it('넘치면(모델 선택) 페르소나만 싣고 나머지는 원본 그대로 후보로 넘긴다', () => {
+        const p = planManifestInjection(overflowRows(), { ...base, offerOnOverflow: true });
+        expect(p.injected.map((r) => r.id)).toEqual(['system-skill-backend-developer']);
+        expect(p.offered.map((r) => r.id)).toEqual(['ecc-a', 'system-skill-karpathy-guidelines']);
+        expect(p.offered[0].prompt_md).toHaveLength(800); // 절단 전 원본 — 목록의 크기 표시용
+        expect(p.skipped).toEqual([]);
+        expect(p.injectedChars).toBe(100);
+    });
+
+    it('모델 선택을 끄면 종전 결정적 규칙 — 페르소나 → 순서대로, 넘치는 뒤쪽은 건너뛰고 개별 절단', () => {
+        const p = planManifestInjection(overflowRows(), { ...base, offerOnOverflow: false });
+        expect(p.injected.map((r) => r.id)).toEqual(['system-skill-backend-developer', 'ecc-a']);
+        expect(p.injected[1].prompt_md).toContain('... (truncated)');
+        expect(p.skipped.map((r) => r.id)).toEqual(['system-skill-karpathy-guidelines']);
+        expect(p.offered).toEqual([]);
+    });
+
+    it('후보가 페르소나뿐이면 넘쳐도 목록 없이 싣는다 (첫 행은 항상)', () => {
+        const p = planManifestInjection([row('system-skill-backend-developer', 1500)], { ...base, offerOnOverflow: true });
+        expect(p.injected).toHaveLength(1);
+        expect(p.offered).toEqual([]);
+    });
+});
+
+describe('manifestYamlField', () => {
+    it('fence 유무와 무관하게 최상위 키 값을 읽는다', () => {
+        expect(manifestYamlField('---\nname: api-design\ndescription: "REST API"\n---\n', 'description')).toBe('REST API');
+        expect(manifestYamlField('name: deck\ncategory: design', 'name')).toBe('deck');
+        expect(manifestYamlField('name: deck', 'description')).toBeUndefined();
+    });
+});

--- a/apps/api/src/agents/__tests__/skill-inject-cap.test.ts
+++ b/apps/api/src/agents/__tests__/skill-inject-cap.test.ts
@@ -62,6 +62,18 @@ describe('buildManifestPrompt — 주입 합계 상한', () => {
         expect(out!.skillNames).toEqual(['system-skill-backend-developer', 'ecc-a']);
     });
 
+    it('모델 선택 모드: 넘치면 페르소나만 싣고 나머지는 load_skill 후보 목록으로 넘긴다 (2026-09-11)', async () => {
+        rows = [row('ecc-a', 650), row('system-skill-karpathy-guidelines', 300), row('system-skill-backend-developer', 100)];
+        const out = await manager().buildManifestPrompt('backend-developer', undefined, 'technology', undefined, { offerOnOverflow: true });
+        expect(out!.skillNames).toEqual(['system-skill-backend-developer']);
+        expect(out!.prompt).toContain('SYSTEM-SKILL-BACKEND-DEVELOPER:');
+        expect(out!.prompt).not.toContain('ECC-A:');
+        expect(out!.prompt).toContain('<skill_offer>');
+        expect(out!.prompt).toContain('- ecc-a (');
+        expect(out!.prompt).toContain('- system-skill-karpathy-guidelines (');
+        expect(out!.prompt).toContain('load_skill');
+    });
+
     it('합계가 상한 이내면 전부 주입한다', async () => {
         rows = [row('a', 100), row('b', 100), row('c', 100)];
         const out = await manager().buildManifestPrompt('backend-developer', undefined, 'technology');

--- a/apps/api/src/agents/manifest-injection-plan.ts
+++ b/apps/api/src/agents/manifest-injection-plan.ts
@@ -1,0 +1,80 @@
+/**
+ * manifest 스킬 주입 계획 (순수) — skill-manager.buildManifestPrompt 가 사용.
+ *
+ * 합계 상한(SKILL_MANIFEST_INJECT_MAX_CHARS)을 넘으면 종전엔 페르소나 → priority → id 순으로 담다가
+ * 나머지를 건너뛰었다. "관련도 높은 스킬 하나를 온전히" 가 의도였지만 실제 선택 기준은 id 순이었다
+ * (백엔드 질문에 트리거된 postgres-patterns·karpathy 가 id 순에 밀려 빠지는 식). offerOnOverflow 면
+ * 넘친 턴에는 페르소나만 싣고 나머지 후보를 목록으로 넘겨, 무엇을 불러올지 모델이 같은 턴에
+ * load_skill 로 판단한다 (판단 경계 B형 — 앞단 LLM 호출 없음, triggers 가 프리필터).
+ *
+ * @module agents/manifest-injection-plan
+ */
+import { buildSkillOfferBlock } from '../prompts/skill-offer';
+import { SKILL_CATALOG_DESC_MAX } from './skill-catalog';
+
+export interface PlanRow {
+    id: string;
+    assigned_to: string;
+    prompt_md: string;
+}
+
+export interface ManifestInjectionPlan<T extends PlanRow> {
+    /** 본문을 싣는 행 — prompt_md 는 개별 상한으로 잘린 값 */
+    injected: T[];
+    /** 결정적 규칙에서 합계 상한에 밀린 행 */
+    skipped: T[];
+    /** 모델 선택 모드에서 목록으로만 넘기는 행 — prompt_md 원본 유지 */
+    offered: T[];
+    injectedChars: number;
+}
+
+export interface PlanOptions<T extends PlanRow> {
+    maxChars: number;
+    perSkillMaxChars: number;
+    /** 모델이 load_skill 로 불러올 수 있을 때만 true — 아니면 종전 결정적 규칙 */
+    offerOnOverflow: boolean;
+    isPersona: (row: T) => boolean;
+}
+
+function clip<T extends PlanRow>(row: T, max: number): T {
+    return row.prompt_md.length > max ? { ...row, prompt_md: `${row.prompt_md.slice(0, max)}\n... (truncated)` } : row;
+}
+
+export function planManifestInjection<T extends PlanRow>(rows: readonly T[], opts: PlanOptions<T>): ManifestInjectionPlan<T> {
+    // 페르소나(작음)가 먼저 — 상한에 밀리지 않게. 나머지는 입력 순서(priority → id) 유지.
+    const personas = rows.filter((r) => opts.isPersona(r));
+    const others = rows.filter((r) => !opts.isPersona(r));
+    const ordered = [...personas, ...others].map((r) => clip(r, opts.perSkillMaxChars));
+    const total = ordered.reduce((sum, r) => sum + r.prompt_md.length, 0);
+
+    if (opts.offerOnOverflow && others.length > 0 && total > opts.maxChars) {
+        const injected = personas.map((r) => clip(r, opts.perSkillMaxChars));
+        return { injected, skipped: [], offered: others, injectedChars: injected.reduce((sum, r) => sum + r.prompt_md.length, 0) };
+    }
+
+    // 종전 결정적 규칙 — 첫 행은 상한과 무관하게 싣고, 넘치는 뒤쪽은 건너뛴다
+    const injected: T[] = [];
+    const skipped: T[] = [];
+    let injectedChars = 0;
+    for (const r of ordered) {
+        if (injected.length > 0 && injectedChars + r.prompt_md.length > opts.maxChars) { skipped.push(r); continue; }
+        injected.push(r);
+        injectedChars += r.prompt_md.length;
+    }
+    return { injected, skipped, offered: [], injectedChars };
+}
+
+/** manifest_yaml 최상위 스칼라 키 값(name·description 등) — fence 유무 무관 */
+export function manifestYamlField(yaml: string, key: string): string | undefined {
+    const m = new RegExp(`^${key}:\\s*([^\\n]+)`, 'm').exec(yaml);
+    return m?.[1]?.trim().replace(/^['"]|['"]$/g, '') || undefined;
+}
+
+/** 모델 선택 모드의 후보 목록 블록 — manifest 의 name·description(카탈로그와 같은 길이 상한)과 원본 크기 */
+export function buildManifestOfferBlock(offered: ReadonlyArray<PlanRow & { manifest_yaml: string }>): string {
+    return buildSkillOfferBlock(offered.map((r) => ({
+        name: manifestYamlField(r.manifest_yaml, 'name') || r.id,
+        description: (manifestYamlField(r.manifest_yaml, 'description') ?? '').slice(0, SKILL_CATALOG_DESC_MAX),
+        chars: r.prompt_md.length,
+    })));
+}

--- a/apps/api/src/agents/skill-catalog.ts
+++ b/apps/api/src/agents/skill-catalog.ts
@@ -9,9 +9,17 @@ const logger = createLogger('SkillCatalog');
 
 /** 카탈로그/선택 조회 상한 — env override (No-Hardcoding). searchSkills 가 200 으로 클램프한다. */
 export const SKILL_CATALOG_MAX_ITEMS = Number(process.env.SKILL_CATALOG_MAX_ITEMS) || 200;
-const SKILL_CATALOG_DESC_MAX = Number(process.env.SKILL_CATALOG_DESC_MAX) || 120;
+export const SKILL_CATALOG_DESC_MAX = Number(process.env.SKILL_CATALOG_DESC_MAX) || 120;
 /** 페르소나 스킬("○○ 전문 스킬")을 카탈로그·load_skill 대상에서 제외 — 기본 on, 'false' 면 종전 동작(롤백용). */
 export const SKILL_CATALOG_EXCLUDE_PERSONAS = process.env.SKILL_CATALOG_EXCLUDE_PERSONAS !== 'false';
+
+/**
+ * manifest 합계 상한을 넘은 턴에 후보를 목록으로 넘겨 모델이 load_skill 로 고르게 할지.
+ * load_skill 이 노출될 때(SKILL_AUTO_SELECT_ENABLED)만 의미가 있다. 'false' 면 종전 결정적 규칙(id 순).
+ */
+export function isSkillOfferEnabled(): boolean {
+    return process.env.SKILL_AUTO_SELECT_ENABLED === 'true' && process.env.SKILL_OVERFLOW_OFFER_ENABLED !== 'false';
+}
 
 /** 상한 초과 경고는 대상 수가 같으면 한 번만 (매 턴 반복 방지) */
 const truncationWarned = new Set<number>();

--- a/apps/api/src/agents/skill-manager.ts
+++ b/apps/api/src/agents/skill-manager.ts
@@ -49,6 +49,7 @@ import type {
 import { slugify } from '../chat/slash-command';
 import { recordSkillUsage } from './skill-usage-log';
 import { shouldInjectManifestSkill } from './manifest-injection-filter';
+import { planManifestInjection, buildManifestOfferBlock } from './manifest-injection-plan';
 import { SKILL_VERSION_LATEST_ORDER_SQL } from '../data/repositories/skill-manifest-sync';
 import { SKILL_MANIFEST_INJECT_MAX_CHARS, SKILL_MANIFEST_PER_SKILL_MAX_CHARS } from '../config/runtime-limits';
 import { SKILL_CATALOG_MAX_ITEMS, SKILL_CATALOG_EXCLUDE_PERSONAS, formatSkillCatalog, warnIfCatalogTruncated } from './skill-catalog';
@@ -415,6 +416,7 @@ export class SkillManager {
      */
     async buildManifestPrompt(
         agentId: string, userId?: string, agentCategory?: string, query?: string,
+        options: { offerOnOverflow?: boolean } = {},
     ): Promise<{ prompt: string; skillNames: string[] } | null> {
         let pool: Pool;
         try {
@@ -480,22 +482,15 @@ export class SkillManager {
         ));
         if (filtered.length === 0) return null;
 
-        // 주입 합계 상한 (프롬프트 다이어트 2026-09-05): priority 순으로 담다가 SKILL_MANIFEST_INJECT_MAX_CHARS
-        // 초과분은 건너뛴다(첫 스킬은 항상). 실측 backend-developer 4개 30.7K 자(≈9K 토큰)가 매 턴 실렸다.
-        const injectedRows: typeof filtered = [];
-        const skipped: string[] = [];
-        let injectedChars = 0;
-        // 페르소나(작음)만 먼저 담아 상한에 밀리지 않게 — 전역 시스템 스킬(karpathy 등)까지 앞세우면 관련 스킬이 밀린다.
-        const isPersona = (r: { id: string; assigned_to: string }) => r.id === AGENT_PERSONA_SKILL_ID_PREFIX + r.assigned_to;
-        const ordered = [...filtered].sort((a, b) => Number(isPersona(b)) - Number(isPersona(a)));
-        for (const r of ordered) {
-            const body = r.prompt_md.length > SKILL_MANIFEST_PER_SKILL_MAX_CHARS
-                ? r.prompt_md.slice(0, SKILL_MANIFEST_PER_SKILL_MAX_CHARS) + '\n... (truncated)' : r.prompt_md;
-            if (injectedRows.length > 0 && injectedChars + body.length > SKILL_MANIFEST_INJECT_MAX_CHARS) { skipped.push(r.id); continue; }
-            injectedRows.push({ ...r, prompt_md: body });
-            injectedChars += body.length;
-        }
-        if (skipped.length > 0) logger.info(`manifest 주입 상한(${SKILL_MANIFEST_INJECT_MAX_CHARS}자) — agent=${agentId} 주입 ${injectedRows.length}개(${injectedChars}자), 건너뜀: ${skipped.join(', ')}`);
+        // 주입 합계 상한 (프롬프트 다이어트 2026-09-05) — manifest-injection-plan.ts (순수): 페르소나 우선, 넘치면
+        // 모델 선택(후보 목록 → load_skill) 또는 종전 결정적 규칙(순서대로 담고 나머지 건너뜀).
+        const plan = planManifestInjection(filtered, {
+            maxChars: SKILL_MANIFEST_INJECT_MAX_CHARS, perSkillMaxChars: SKILL_MANIFEST_PER_SKILL_MAX_CHARS,
+            offerOnOverflow: options.offerOnOverflow === true,
+            isPersona: (r) => r.id === AGENT_PERSONA_SKILL_ID_PREFIX + r.assigned_to,
+        });
+        const injectedRows = plan.injected;
+        if (plan.skipped.length > 0) logger.info(`manifest 주입 상한(${SKILL_MANIFEST_INJECT_MAX_CHARS}자) — agent=${agentId} 주입 ${injectedRows.length}개(${plan.injectedChars}자), 건너뜀: ${plan.skipped.map(r => r.id).join(', ')}`);
         const blocks = injectedRows.map(r => {
             const safeId = r.id.replace(/[<>"&]/g, '');
             return `<skill_context name="${safeId}">\n${r.prompt_md}\n</skill_context>`;
@@ -534,6 +529,10 @@ export class SkillManager {
             } catch (e) {
                 logger.debug('개인 지정 스킬 union 실패 (manifest 분만 주입)', e);
             }
+        }
+        if (plan.offered.length > 0) {
+            blocks.push(buildManifestOfferBlock(plan.offered));
+            logger.info(`manifest 합계 상한 초과 — 모델 선택: agent=${agentId} 후보 ${plan.offered.length}개 (${plan.offered.map(r => r.id).join(', ')})`);
         }
         recordSkillUsage(injected.map(i => ({ ...i, kind: 'inject' as const, userId, args: { agentId } })));
         return { prompt: `\n\n## 적용된 스킬 (manifest)\n${blocks.join('\n\n')}`, skillNames };

--- a/apps/api/src/agents/system-prompt.ts
+++ b/apps/api/src/agents/system-prompt.ts
@@ -18,6 +18,7 @@ import { AgentSelection, AgentPhase } from './types';
 import { AGENTS } from './agent-data';
 import { createLogger } from '../utils/logger';
 import { getSkillManager } from './skill-manager';
+import { isSkillOfferEnabled } from './skill-catalog';
 import { getLanguageTemplate, type SupportedLanguageCode } from '../chat/language-policy';
 const logger = createLogger('AgentSystem');
 
@@ -252,7 +253,8 @@ ${applyPromptPlaceholders(promptTemplate.workingOn, { phase: getPhaseLabel(selec
     let hasDbSkills = false;
     const skillNames: string[] = [];
     try {
-        const manifest = await getSkillManager().buildManifestPrompt(agent.id, userId, agent.category, query);
+        // 상한을 넘는 턴은 후보 목록만 싣고 모델이 load_skill 로 고른다 (load_skill 노출 시)
+        const manifest = await getSkillManager().buildManifestPrompt(agent.id, userId, agent.category, query, { offerOnOverflow: isSkillOfferEnabled() });
         if (manifest) {
             result += manifest.prompt;
             hasDbSkills = true;

--- a/apps/api/src/prompts/skill-offer.ts
+++ b/apps/api/src/prompts/skill-offer.ts
@@ -1,0 +1,27 @@
+/**
+ * 스킬 후보 제시 블록 (2026-09-11) — manifest 합계 상한을 넘은 턴에 본문 대신 싣는다.
+ * 무엇을 불러올지는 모델이 같은 턴에 load_skill 로 판단한다 (agents/manifest-injection-plan 참고).
+ * @module prompts/skill-offer
+ */
+import { LOAD_SKILL_TOOL_NAME } from '../mcp/load-skill-tool';
+
+export interface SkillOfferItem {
+    name: string;
+    description: string;
+    chars: number;
+}
+
+export function buildSkillOfferBlock(items: readonly SkillOfferItem[]): string {
+    const lines = items.map((item) => {
+        const name = item.name.replace(/[<>"&]/g, '');
+        const size = `${(item.chars / 1000).toFixed(1)}K자`;
+        return item.description ? `- ${name} (${size}): ${item.description}` : `- ${name} (${size})`;
+    });
+    return [
+        '<skill_offer>',
+        `이 질문과 관련된 스킬이 여러 개라 본문을 미리 싣지 않았다. 답에 실제로 필요한 스킬만 \`${LOAD_SKILL_TOOL_NAME}\` 로 `
+            + '불러와 그 지침을 따르라(보통 1~2개). 필요 없으면 부르지 않는다.',
+        ...lines,
+        '</skill_offer>',
+    ].join('\n');
+}


### PR DESCRIPTION
## 요약
배정 스킬이 합계 상한(`SKILL_MANIFEST_INJECT_MAX_CHARS`, 12,000자)을 넘으면 종전엔 페르소나 → priority → id 순으로 담다가 나머지를 건너뛰었습니다. "관련도 높은 스킬 하나를 온전히" 가 의도였지만 실제 선택 기준은 **id 순**이라, 기술 에이전트 질문에서 트리거가 둘 이상 겹치면 두 번째 ecc 스킬과 karpathy 가 관련도와 무관하게 빠졌습니다(예: 백엔드 "API + postgres" 질문에서 postgres-patterns·karpathy 누락).

이제 **load_skill 이 노출되는 채팅 턴에서 넘치면** 페르소나만 싣고, 나머지 후보를 이름·설명·크기 목록(`<skill_offer>`)으로 넘겨 모델이 같은 턴에 `load_skill` 로 필요한 것만 불러옵니다.
- 앞단 LLM 호출 없는 인라인 도구형(CLAUDE.md 판단 경계 **B형**). triggers 가 프리필터라 목록은 넘치는 턴에만 뜹니다
- 합계가 상한 안이면 종전대로 모두 싣습니다 (추가 왕복 없음)
- 에이전트 작업·딥리서치 경로는 종전 결정적 규칙 유지

## 변경
- `agents/manifest-injection-plan.ts`(순수): `planManifestInjection` — 주입/건너뜀/후보 계획, `buildManifestOfferBlock`
- `prompts/skill-offer.ts`: 후보 목록 문구
- `buildManifestPrompt(…, { offerOnOverflow })` — 채팅(`system-prompt.ts`)만 `isSkillOfferEnabled()` 로 켬
- 게이트 `SKILL_OVERFLOW_OFFER_ENABLED`(기본 true, `SKILL_AUTO_SELECT_ENABLED=true` 필요) — `.env.example` 반영

## 트레이드오프
넘치는 턴은 모델이 `load_skill` 을 부르면 도구 왕복 1회가 늘어납니다. 배포 후 같은 질문으로 실측해 보고합니다.

## 테스트
- [x] 신규 `manifest-injection-plan.test.ts`(5) · `skill-inject-cap` +1(모델 선택 모드 프롬프트)
- [x] 모델 선택 분기를 되돌리면 2건 실패
- [x] 관련 8 suite 53 passed · `tsc --noEmit` 0 · eslint 0 · skill-manager.ts 598줄
- [ ] 배포 후 chat.openmake.cc: 트리거 겹치는 백엔드 질문에서 `<skill_offer>` → `load_skill` 호출·답변 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Kmw1CDfo4Eouse77o5PVh