### PR TITLE
fix(chat): 추론만 온 턴을 답변으로 승격하지 않음 + 한글 자모 입력을 한국어로 판정

### DIFF
--- a/apps/api/src/__tests__/external-provider-reasoning-only.test.ts
+++ b/apps/api/src/__tests__/external-provider-reasoning-only.test.ts
@@ -1,0 +1,118 @@
+/**
+ * ============================================================
+ * External Provider — 추론만 온 턴 복구 테스트
+ * ============================================================
+ *
+ * 회귀(2026-09-11): 로컬 thinking 턴이 본문 없이 깨진 추론만 내고 끝나자 스트림 파서가 그 추론을
+ * 답변으로 승격해 `The user is "The user1. <tool_result> …` 가 답변으로 저장됐다.
+ * 수정: 파서는 승격하지 않고 빈 본문을 돌려준다(llm/reasoning-only-recovery). 여기서는
+ *   ① 빈 응답 방어(B)의 도구를 끈 재요청 1회가 정상 답변을 받는지
+ *   ② 재요청도 추론만이면 빈 답변 대신 종전처럼 추론을 노출하는지(D, 최후 수단)
+ * 를 고정한다.
+ */
+
+jest.mock('../utils/logger', () => ({
+    createLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+}));
+jest.mock('../chat/prompt', () => ({
+    getExternalProviderSystemGuards: () => '[GUARD]',
+}));
+jest.mock('../mcp/unified-client', () => ({
+    getUnifiedMCPClient: () => ({
+        executeToolWithContext: jest.fn().mockResolvedValue({ content: '검색 결과 텍스트', isError: false }),
+    }),
+}));
+// env 파생 상수 고정 (jest .env 의존 테스트 방지): 턴 5, wall-clock 가드 off, 서브에이전트 도구 off
+jest.mock('../config/runtime-limits', () => {
+    const actual = jest.requireActual('../config/runtime-limits');
+    return {
+        ...actual,
+        AGENT_LOOP_LIMITS: { ...actual.AGENT_LOOP_LIMITS, MAX_TURNS: 5, MAX_WALL_CLOCK_MS: 0 },
+        CHAT_SUBAGENT: { ...actual.CHAT_SUBAGENT, ENABLED: false },
+        AGENT_SPAWN: { ...actual.AGENT_SPAWN, ENABLED: false },
+    };
+});
+
+import { streamFromExternalProvider } from '../services/chat-service/external-fallback';
+
+/** 2026-09-11 운영에서 답변으로 저장된 깨진 추론 원문 */
+const GARBAGE_REASONING = 'The user is "The user1.\n<tool_result> 这个 is the2026-09-11:00 (</thinking>\n</functions>';
+
+type Turn = { content: string; thinking?: string };
+
+/** 턴마다 정해진 응답(본문·추론)을 돌려주는 fake 로컬 provider. 도구 호출은 하지 않는다. */
+function makeResolved(turns: Turn[], calls: Array<{ hadTools: boolean }>) {
+    let n = 0;
+    return {
+        providerId: 'local-llm',
+        modelId: 'test-model',
+        fullId: 'local-llm:test-model',
+        provider: {
+            getCapabilities: () => ({ vision: false, toolCalling: true }),
+            streamChat: jest.fn().mockImplementation(async (opts: any, cbs: any) => {
+                const turn = turns[Math.min(n, turns.length - 1)];
+                n++;
+                calls.push({ hadTools: Array.isArray(opts.tools) && opts.tools.length > 0 });
+                if (turn.thinking) cbs?.onThinking?.(turn.thinking);
+                if (turn.content) cbs?.onToken?.(turn.content);
+                return {
+                    content: turn.content,
+                    ...(turn.thinking ? { thinking: turn.thinking } : {}),
+                    toolCalls: [],
+                    finishReason: 'stop',
+                };
+            }),
+        },
+    } as any;
+}
+
+const webSearchTool = {
+    type: 'function' as const,
+    function: { name: 'web_search', description: '웹 검색', parameters: { type: 'object', properties: {} } },
+};
+
+async function run(turns: Turn[]) {
+    const calls: Array<{ hadTools: boolean }> = [];
+    const streamed: string[] = [];
+    const result = await streamFromExternalProvider(
+        { currentUserContext: null, allowedTools: [webSearchTool] } as any,
+        makeResolved(turns, calls),
+        { message: 'ㅎㅇ', userId: 'guest', history: [] } as any,
+        (token) => { if (token) streamed.push(token); },
+        {},
+    );
+    return { result, calls, streamed: streamed.join('') };
+}
+
+describe('External Provider — 추론만 온 턴', () => {
+    it('첫 턴이 추론만이면 도구를 끈 재요청 1회로 정상 답변을 받는다 — 깨진 추론은 답변에 없다', async () => {
+        const answer = '안녕하세요! 무엇을 도와드릴까요?';
+        const { result, calls, streamed } = await run([
+            { content: '', thinking: GARBAGE_REASONING },
+            { content: answer },
+        ]);
+
+        expect(calls.length).toBe(2);
+        expect(calls[1].hadTools).toBe(false);
+        expect(result).toBe(answer);
+        expect(streamed).not.toContain('The user1');
+    });
+
+    it('재요청도 추론만이면 빈 답변 대신 추론을 답변으로 노출한다 (최후 수단 — 종전 동작)', async () => {
+        const { result, calls, streamed } = await run([
+            { content: '', thinking: '첫 번째 추론' },
+            { content: '', thinking: '두 번째 추론' },
+        ]);
+
+        expect(calls.length).toBe(2);
+        expect(result).toBe('두 번째 추론');
+        expect(streamed).toContain('두 번째 추론');
+    });
+
+    it('정상 답변 턴에는 개입하지 않는다', async () => {
+        const { result, calls } = await run([{ content: '바로 답합니다.', thinking: '짧은 추론' }]);
+
+        expect(calls.length).toBe(1);
+        expect(result).toBe('바로 답합니다.');
+    });
+});

--- a/apps/api/src/__tests__/language-policy.test.ts
+++ b/apps/api/src/__tests__/language-policy.test.ts
@@ -537,3 +537,21 @@ describe('detectLanguage — 코드 식별자가 섞인 한국어 질문 (2026-0
         expect(out).toMatch(/App Router/);
     });
 });
+describe('detectLanguage — 한글 자모만 있는 입력 (2026-09-11 "ㅎㅇ" 영어 판정 정정)', () => {
+    test('자모만 있는 인사·웃음·대답은 한국어로 판정한다', () => {
+        for (const q of ['ㅎㅇ', 'ㅋㅋㅋ', 'ㅇㅇ']) {
+            const result = detectLanguage(q);
+            expect(result.language).toBe('ko');
+            expect(result.method).toBe('regex');
+        }
+    });
+    test('NFKC 로 조합형 자모(U+1100)가 된 입력도 한국어 — 입력 정제(NFKC)를 거친 경로', () => {
+        expect(detectLanguage('ㅎㅇ'.normalize('NFKC')).language).toBe('ko');
+    });
+    test('preprocess: 자모만 있는 줄을 특수문자 줄로 지우지 않는다', () => {
+        expect(preprocessTextForLanguageDetection('ㅎㅇ')).toBe('ㅎㅇ');
+    });
+    test('자모가 없는 짧은 영어는 그대로 영어 폴백', () => {
+        expect(detectLanguage('hi').language).toBe('en');
+    });
+});

--- a/apps/api/src/__tests__/stream-parser-reasoning.test.ts
+++ b/apps/api/src/__tests__/stream-parser-reasoning.test.ts
@@ -9,25 +9,36 @@
  * (delta.content)이 pendingReasoning 으로 흡수→thinking 오분류→recovery 가
  * reasoning+답변 전체를 content 채널로 승격하여 본문에 누수된다.
  * 수정: reasoning 필드를 한 번이라도 받으면 content-splitter 를 비활성화.
+ *
+ * 추론만 온 턴(2026-09-11): thinking 을 명시 요청했고 서버가 추론을 분리해 보냈는데 본문 없이
+ * 정상 종료하면, 그 추론을 답변으로 승격하지 않는다(깨진 추론이 답변으로 저장된 사고).
+ * 오설정·태그 흡수·max_tokens 소진 경우의 승격은 유지한다 — llm/reasoning-only-recovery.
  */
 
 jest.mock('../utils/logger', () => ({
     createLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
 }));
 
-import { streamChat } from '../llm/stream-parser';
+import { streamChat, nonStreamChat } from '../llm/stream-parser';
+import { FALLBACK_REASONING_ONLY_NOTICE } from '../llm/reasoning-only-recovery';
 import type { ChatRequest } from '../llm/types';
 
 /** delta 청크 배열을 async-iterable stream 으로 반환하는 가짜 OpenAI 클라이언트 */
-function fakeOpenAI(chunks: Array<Record<string, unknown>>): any {
+function fakeOpenAI(chunks: Array<Record<string, unknown>>, finishReason = 'stop'): any {
     async function* gen() {
         for (const delta of chunks) {
             yield { choices: [{ delta, finish_reason: null }] } as unknown;
         }
         // 마지막에 finish_reason + usage
-        yield { choices: [{ delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 10, completion_tokens: 20 } } as unknown;
+        yield { choices: [{ delta: {}, finish_reason: finishReason }], usage: { prompt_tokens: 10, completion_tokens: 20 } } as unknown;
     }
     return { chat: { completions: { create: jest.fn().mockResolvedValue(gen()) } } };
+}
+
+/** 비스트림 응답 1건을 돌려주는 가짜 OpenAI 클라이언트 */
+function fakeNonStream(message: Record<string, unknown>, finishReason = 'stop'): any {
+    const response = { choices: [{ message, finish_reason: finishReason }], usage: { prompt_tokens: 10, completion_tokens: 20 } };
+    return { chat: { completions: { create: jest.fn().mockResolvedValue(response) } } };
 }
 
 function collect() {
@@ -41,6 +52,9 @@ function collect() {
 }
 
 const baseReq: ChatRequest = { model: 'qwen3.6-35b-a3b', messages: [{ role: 'user', content: 'q' }] };
+
+/** 2026-09-11 운영에서 답변으로 저장된 깨진 추론 원문 */
+const GARBAGE_REASONING = 'The user is "The user1.\n<tool_result> 这个 is the2026-09-11:00 (</thinking>\n</functions>';
 
 describe('stream-parser — reasoning 채널 분리', () => {
     it('reasoning_content 필드 분리 + enable_thinking=true: 답변은 content, 추론은 thinking (누수 없음)', async () => {
@@ -91,18 +105,75 @@ describe('stream-parser — reasoning 채널 분리', () => {
         expect(thinkingTokens.join('')).toContain('reasoning here');
         expect(contentTokens.join('')).not.toContain('reasoning here');
     });
+});
 
-    it('전부 reasoning_content + content 빈 경우: recovery 가 thinking 을 답변으로 승격 (Case B 유지)', async () => {
+describe('stream-parser — 추론만 온 턴 (reasoning-only recovery)', () => {
+    it('enable_thinking=true + 서버가 추론만 분리해 보내고 정상 종료: 답변으로 승격하지 않는다', async () => {
+        const openai = fakeOpenAI([{ reasoning_content: GARBAGE_REASONING }]);
+        const { onToken, contentTokens, thinkingTokens } = collect();
+
+        const result = await streamChat(openai, baseReq, onToken, { chat_template_kwargs: { enable_thinking: true } });
+
+        // 본문은 비고 답변 채널로 재방송하지 않는다 — 호출자의 빈 응답 방어가 재요청한다
+        expect(result.content).toBe('');
+        expect(contentTokens).toEqual([]);
+        // 추론은 thinking 으로 보존
+        expect(result.thinking).toContain('The user is');
+        expect(thinkingTokens.join('')).toContain('The user is');
+    });
+
+    it('enable_thinking=false 인데 서버가 reasoning 채널로만 보냄(오설정): 답변으로 승격 (종전 동작 유지)', async () => {
+        const openai = fakeOpenAI([{ reasoning_content: 'The capital is Paris.' }]);
+        const { onToken, contentTokens } = collect();
+
+        const result = await streamChat(openai, baseReq, onToken, { chat_template_kwargs: { enable_thinking: false } });
+
+        expect(result.content).toBe('The capital is Paris.');
+        expect(contentTokens.join('')).toBe('The capital is Paris.');
+    });
+
+    it('reasoning-parser 없는 서버에서 `</think>` 없이 끝남(분리기가 본문 흡수): 답변으로 승격 (종전 동작 유지)', async () => {
         const openai = fakeOpenAI([
-            { reasoning_content: 'def foo():\n' },
-            { reasoning_content: '    return 1' },
+            { content: 'def foo():\n' },
+            { content: '    return 1' },
         ]);
         const { onToken, contentTokens } = collect();
 
         const result = await streamChat(openai, baseReq, onToken, { chat_template_kwargs: { enable_thinking: true } });
 
-        // content 가 비어 thinking 이 본 답변으로 승격되어야 함
         expect(result.content).toContain('def foo()');
         expect(contentTokens.join('')).toContain('def foo()');
+    });
+
+    it('enable_thinking=true + 추론만으로 max_tokens 소진(length): 절단 안내와 함께 승격 (종전 동작 유지)', async () => {
+        const openai = fakeOpenAI([{ reasoning_content: 'long reasoning' }], 'length');
+        const { onToken, contentTokens } = collect();
+
+        const result = await streamChat(openai, baseReq, onToken, { chat_template_kwargs: { enable_thinking: true } });
+
+        expect(result.content).toContain('long reasoning');
+        expect(result.content).toContain(FALLBACK_REASONING_ONLY_NOTICE);
+        expect(contentTokens.join('')).toContain('long reasoning');
+    });
+
+    it('nonStreamChat: enable_thinking=true + reasoning_content 만이면 승격하지 않는다', async () => {
+        const result = await nonStreamChat(
+            fakeNonStream({ content: null, reasoning_content: '끝나지 않은 추론' }),
+            baseReq,
+            { chat_template_kwargs: { enable_thinking: true } },
+        );
+
+        expect(result.content).toBe('');
+        expect(result.thinking).toBe('끝나지 않은 추론');
+    });
+
+    it('nonStreamChat: enable_thinking=false + reasoning_content 만(오설정)이면 승격 (종전 동작 유지)', async () => {
+        const result = await nonStreamChat(
+            fakeNonStream({ content: null, reasoning_content: 'Paris' }),
+            baseReq,
+            { chat_template_kwargs: { enable_thinking: false } },
+        );
+
+        expect(result.content).toBe('Paris');
     });
 });

--- a/apps/api/src/chat/language-policy.ts
+++ b/apps/api/src/chat/language-policy.ts
@@ -303,8 +303,8 @@ export function preprocessTextForLanguageDetection(text: string): string {
         .replace(/\b[A-Za-z0-9]+(?:[-_][A-Za-z0-9]+)+\b/g, ' ')
         // 숫자만 있는 부분 제거
         .replace(/^\d+$/gm, '')
-        // 특수문자만 있는 라인 제거
-        .replace(/^[^\w\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]+$/gm, '')
+        // 특수문자만 있는 라인 제거 — 한글 자모(ㅎㅇ·ㅋㅋ)와 NFKC 로 바뀐 조합형 자모(U+1100)는 문자로 남긴다
+        .replace(/^[^\w\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\u1100-\u11ff\u3131-\u318e\uac00-\ud7af]+$/gm, '')
         // 여러 공백을 하나로
         .replace(/\s+/g, ' ')
         .trim();
@@ -314,7 +314,7 @@ export function preprocessTextForLanguageDetection(text: string): string {
  * 언어별 문자 패턴 정의
  */
 export const LANGUAGE_PATTERNS = {
-    ko: /[\uac00-\ud7af]/g,          // 한글
+    ko: /[\u1100-\u11ff\u3131-\u318e\uac00-\ud7af]/g, // 한글 (조합형 자모 · 호환 자모 · 음절)
     ja: /[\u3040-\u309f\u30a0-\u30ff]/g, // 히라가나, 가타카나
     zh: /[\u4e00-\u9fff]/g,         // 중국어 한자
     ar: /[\u0600-\u06ff]/g,         // 아랍어

--- a/apps/api/src/llm/reasoning-only-recovery.ts
+++ b/apps/api/src/llm/reasoning-only-recovery.ts
@@ -1,0 +1,48 @@
+/**
+ * 추론(reasoning)만 오고 본문이 빈 턴을 답변으로 승격할지 — streamChat·nonStreamChat 공용 규칙.
+ *
+ * 승격은 원래 "reasoning 으로 온 것이 실은 답변" 인 두 경우의 워크어라운드다:
+ *   ① vLLM 이 enable_thinking=false 요청의 출력까지 reasoning 채널로 보내는 오설정
+ *   ② reasoning-parser 없는 서버에서 클라이언트 `</think>` 분리기가, `<think>` 를 prepend 하지
+ *      않는 모델의 답변을 통째로 thinking 으로 흡수한 경우
+ *
+ * 그러나 thinking 을 명시 요청했고 서버 reasoning-parser 가 추론을 별도 필드로 분리해 보냈는데
+ * 본문 없이 정상 종료(stop)했다면, 그 텍스트는 답변이 아니라 끝나지 않은 추론이다. 승격하면 추론
+ * 원문이 답변으로 노출·저장된다(2026-09-11 실측: qwen3.8-27b 가 "ㅎㅇ" 에 깨진 추론 39토큰만 내고
+ * 종료 → `The user is "The user1. <tool_result> 这个 …` 가 답변으로 저장). 이때는 승격하지 않고
+ * 빈 본문을 돌려줘 호출자의 빈 응답 방어(채팅: 도구를 끈 재요청 1회)가 답변을 다시 받게 한다.
+ *
+ * finish_reason=length 는 기존대로 승격 + 절단 안내 — 한도 소진은 재요청해도 같다.
+ */
+
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('ReasoningOnly');
+
+/**
+ * reasoning 모델(Qwen3 등)이 reasoning 토큰만으로 max_tokens 를 소진해 `content` 가 `null|""`
+ * 로 반환된 경우(finish_reason="length") 승격한 답변 끝에 붙이는 안내.
+ * 해결책: max_tokens(num_predict) 증가 또는 `LLM_DISABLE_THINKING_BY_DEFAULT=true`.
+ */
+export const FALLBACK_REASONING_ONLY_NOTICE =
+    '(응답 한도(max_tokens) 내에서 reasoning 단계만 완료되어 본문이 생성되지 않았습니다. ' +
+    '재시도 시 더 짧게 질문하거나, 관리자에게 num_predict 증가 또는 reasoning 비활성화를 요청하세요.)';
+
+export interface ReasoningOnlyTurn {
+    /** 요청의 chat_template_kwargs.enable_thinking (미전송이면 undefined) */
+    enableThinking: boolean | undefined;
+    /** 서버 reasoning-parser 가 reasoning 을 별도 필드(delta.reasoning 등)로 보냈는지 */
+    serverReasoningField: boolean;
+    finishReason: string | null | undefined;
+    model: string;
+    thinkingChars: number;
+    completionTokens?: number;
+}
+
+/** true 면 reasoning 을 답변으로 승격한다. 승격하지 않을 때는 관측용 warn 을 남긴다. */
+export function shouldPromoteReasoningOnly(t: ReasoningOnlyTurn): boolean {
+    if (t.enableThinking !== true || !t.serverReasoningField || t.finishReason === 'length') return true;
+    log.warn('[ReasoningOnly] thinking 요청 턴이 본문 없이 종료 — 추론을 답변으로 승격하지 않음 '
+        + `(model=${t.model} finish=${t.finishReason ?? '?'} completion_tokens=${t.completionTokens ?? '?'} thinking=${t.thinkingChars}자)`);
+    return false;
+}

--- a/apps/api/src/llm/stream-parser.ts
+++ b/apps/api/src/llm/stream-parser.ts
@@ -30,20 +30,9 @@ import { createLogger } from '../utils/logger';
 import { capPromptImages } from './prompt-image-cap';
 import { LLM_PROMPT_IMAGE_LIMITS } from '../config/runtime-limits';
 import { LOCAL_PRESERVE_THINKING_ENABLED } from '../config/llm-parameters';
+import { FALLBACK_REASONING_ONLY_NOTICE, shouldPromoteReasoningOnly } from './reasoning-only-recovery';
 
 const log = createLogger('StreamParser');
-
-/**
- * Fallback 메시지: vLLM reasoning 모델(Qwen3 등) 이 reasoning 토큰만으로
- * max_tokens 를 소진하여 `content` 가 `null|""` 로 반환된 경우 사용자에게 노출.
- *
- * 발생 조건 (vLLM 0.21+ Qwen3 reasoning):
- *   finish_reason="length", message.content=null, message.reasoning_content="...".
- * 해결책: max_tokens(num_predict) 증가 또는 `LLM_DISABLE_THINKING_BY_DEFAULT=true`.
- */
-const FALLBACK_REASONING_ONLY_NOTICE =
-    '(응답 한도(max_tokens) 내에서 reasoning 단계만 완료되어 본문이 생성되지 않았습니다. ' +
-    '재시도 시 더 짧게 질문하거나, 관리자에게 num_predict 증가 또는 reasoning 비활성화를 요청하세요.)';
 
 type OpenAIChatChunk = {
     choices: Array<{
@@ -452,9 +441,13 @@ export async function streamChat(
     // 일부 vLLM 빌드는 enable_thinking=false 요청을 받고도 모델 출력 전체를 reasoning
     // 채널로 라우팅하여 content=null 을 반환. 이 경우 reasoning 을 본 답변으로 승격하여
     // 사용자에게 빈 화면이 보이지 않도록 한다. finish_reason="length" 면 절단 안내도 부착.
+    // 단 thinking 을 명시 요청했고 서버가 추론을 분리해 보낸 정상 종료 턴은 승격하지 않는다(reasoning-only-recovery).
     let finalContent = reasoningSplit.content;
     let finalThinking = thinking;
-    if (!finalContent && thinking && toolCalls.length === 0) {
+    if (!finalContent && thinking && toolCalls.length === 0 && shouldPromoteReasoningOnly({
+        enableThinking: kwargs.enable_thinking, serverReasoningField: usesReasoningField,
+        finishReason, model: request.model, thinkingChars: thinking.length, completionTokens,
+    })) {
         // 2026-05-26: recovery 분기의 CoT extract 비활성 — false-positive 위험.
         // Qwen3.6 thinking 모드에서 코드 응답이 reasoning_content 로 전체 도착 + content 빈 채로
         // 종료되면, recovery 가 thinking 전체를 사용자에게 노출해야 함 (그것이 실제 답변).
@@ -562,10 +555,14 @@ export async function nonStreamChat(
     }
 
     // Reasoning-channel recovery (non-stream 동일 — streamChat 의 동일 원칙 적용).
-    // content 비어있고 reasoning 만 채워진 경우 reasoning 을 본 답변으로 승격.
+    // content 비어있고 reasoning 만 채워진 경우 reasoning 을 본 답변으로 승격(예외 규칙도 streamChat 과 동일).
     let finalContent = reasoningSplit.content;
     let finalThinking = combinedThinking;
-    if (!finalContent && combinedThinking && toolCalls.length === 0) {
+    const nsEnableThinking = (extraBody?.chat_template_kwargs as { enable_thinking?: boolean } | undefined)?.enable_thinking;
+    if (!finalContent && combinedThinking && toolCalls.length === 0 && shouldPromoteReasoningOnly({
+        enableThinking: nsEnableThinking, serverReasoningField: Boolean(serverReasoning),
+        finishReason, model: request.model, thinkingChars: combinedThinking.length, completionTokens: r.usage?.completion_tokens,
+    })) {
         finalContent = combinedThinking;
         finalThinking = '';
         if (finishReason === 'length') {

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -335,6 +335,15 @@ export async function runExternalStream(
                 },
             );
         }
+
+        // D. 추론만 온 턴의 최후 수단: 로컬 thinking 턴이 본문 없이 추론만 내면 스트림 파서는 승격하지
+        // 않고 빈 본문을 돌려준다(llm/reasoning-only-recovery). 위 B 의 재요청도 같거나 이미 도구를 끈
+        // 턴이라 재요청할 수 없으면, 빈 답변 대신 종전처럼 추론을 답변으로 노출한다.
+        if (!result.content?.trim() && !result.toolCalls?.length && result.thinking?.trim()) {
+            logger.warn(`⚠️ 외부 LLM 본문 없이 추론만 남음 — 최후 수단으로 추론을 답변으로 노출 (${resolved.fullId})`);
+            onToken(result.thinking, undefined);
+            result = { ...result, content: result.thinking };
+        }
     } catch (err) {
         // 컨텍스트 초과는 **재시도해도 같다** — UPSTREAM_ERROR("잠시 후 다시 시도") 로 안내하면
         // 사용자가 같은 실패를 반복한다. upstream 이 code 를 주지 않으므로 메시지로 판정한다


### PR DESCRIPTION
## 요약

2026-09-11 10:31 user 11 이 "ㅎㅇ" 를 보냈을 때 `The user is "The user1. <tool_result> 这个 is the2026-09-11:00 (</thinking> </functions>` 가 답변으로 표시·저장된 건의 앱 쪽 원인 2가지를 고칩니다.

## 원인

1. **추론을 답변으로 승격** — 로컬 qwen3.8-27b(thinking ON, 웹 기본값)가 추론 채널에 깨진 텍스트 39토큰만 내고 본문 없이 `stop` 했습니다. `llm/stream-parser.ts` 의 recovery 가 "본문이 비면 thinking 을 답변으로 승격" 해 그 추론이 답변으로 노출·저장됐습니다(DB `content == thinking`). 30일간 같은 승격 2건(08-30 qwen3.6 은 정상 추론 문장이 답변으로 노출).
2. **자모 입력 영어 판정** — `preprocessTextForLanguageDetection` 의 "특수문자만 있는 줄 제거" 허용 범위에 한글 음절만 있고 자모가 없어 `ㅎㅇ` 가 통째로 지워졌습니다(`processedLength 0` → `en 0.5` 폴백). 같은 조건 재현 12회 전부 영어 답변.

모델이 깨진 출력을 낸 원인 자체는 재현 0/12·DGX 로그 미접근으로 확정하지 못했습니다(이 PR 범위 밖).

## 변경

- `llm/reasoning-only-recovery.ts`(신규): 승격 규칙 단일화. **thinking 명시 요청(`enable_thinking === true`) + 서버가 추론을 별도 필드로 분리 + `finish_reason ≠ length`** 인 턴만 승격하지 않고 `[ReasoningOnly]` warn 로그. 서버 오설정(enable_thinking=false 인데 reasoning 채널)·클라이언트 `</think>` 분리기가 본문을 흡수한 경우·max_tokens 소진(절단 안내) 승격은 유지. `FALLBACK_REASONING_ONLY_NOTICE` 도 이 모듈로 이동(stream-parser 600줄 게이트).
- `llm/stream-parser.ts`: streamChat·nonStreamChat 두 recovery 가 위 규칙 사용.
- `services/chat-service/external-provider.ts`: 빈 본문이면 기존 B(도구를 끈 재요청 1회)가 동작. 재요청도 추론만이거나 이미 도구를 끈 턴이면 **D(최후 수단)** 로 종전처럼 추론을 노출 — 최악의 경우도 수정 전과 같다.
- `chat/language-policy.ts`: 전처리 허용 범위와 `LANGUAGE_PATTERNS.ko` 에 호환 자모(U+3131–318E)·조합형 자모(U+1100–11FF — NFKC 입력 정제 경로) 추가.

영향 범위: thinking 을 켜는 호출은 채팅 경로(`local-llm-provider`)뿐 — 에이전트 작업·judge·delegate·subagent 는 `think: false` 라 무영향. `LANGUAGE_PATTERNS.ko` 를 쓰는 `tool-result-language` 는 자모도 한국어로 세게 됨(의도).

## 검증

- `tsc --noEmit` 0, 관련 9 스위트 109 tests 통과
- 소스 3개를 되돌리면 새 테스트 6건 실패(자모 3 · 비승격 스트림/비스트림 2 · 최후 수단 1) 확인
- `eval:routing` 120/120, `eval:response`(mock) 30/30
- `npm run lint` 오류 0, stream-parser 589줄

## 체크리스트

- [x] `npm run lint` 통과
- [x] 관련 유닛 테스트 통과
- [x] 라우팅/응답 변경 → `eval:routing` + `eval:response` 실행
- [x] DB 스키마 변경 없음 · 환경변수 추가 없음
- [x] 보안 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcRnC8Dowx9eF6YH8SSfjz
