### PR TITLE
feat(local-bridge): 승인 대기를 컴패니언 네이티브 알림으로 + 컴패니언 다국어·키 안내 정정

### DIFF
--- a/.github/workflows/desktop-native.yml
+++ b/.github/workflows/desktop-native.yml
@@ -51,6 +51,10 @@ jobs:
             --target=node20 --format=cjs --outfile=apps/desktop-native/helper/dist/helper.cjs
           node apps/desktop-native/helper/harness.cjs
 
+      # ─── Gate 1-B: 다국어 표 (ko·en·ja·zh-Hans 키 집합 + 소스가 쓰는 L("키")) ───
+      - name: "Gate 1-B: Localization tables"
+        run: bash apps/desktop-native/check-l10n.sh
+
       # ─── Gate 2: Swift 릴리스 빌드 (무서명) ───
       - name: "Gate 2: Swift build"
         run: swift build -c release --package-path apps/desktop-native/OpenMakeCompanion

--- a/apps/api/src/services/agent-task/turn-executor.ts
+++ b/apps/api/src/services/agent-task/turn-executor.ts
@@ -84,14 +84,17 @@ export async function executeTurnToolCalls(input: TurnToolExecInput): Promise<Tu
     // 도구 실행 + 체크포인트
     let terminated = false;
     let terminateSummary = '';
-    // 승인 대기 진입 콜백 — task 도구·extra 도구 공용(status='paused' + web-push).
+    // 승인 대기 진입 콜백 — task 도구·extra 도구 공용(status='paused' + 알림).
+    // 알림은 두 채널: 웹 푸시(설정에서 켠 사용자만 — 운영 구독 0건이던 opt-in) + 로컬 실행 작업이면
+    // 실행 디바이스(컴패니언 네이티브 알림, 2026-09-11). 링크는 작업 상세로 바로 연다.
     const onApprovalPending = (toolName: string) => {
         void update({ status: 'paused' }).catch(() => { /* noop */ });
         void getPushService().sendPush(userId, {
             title: 'OpenMake 에이전트 — 승인 필요',
             body: `도구 실행 승인을 기다립니다: ${toolName}`,
-            url: '/agent-tasks',
+            url: `/agent-tasks?task=${encodeURIComponent(taskId)}`,
         }).catch(() => { /* noop */ });
+        try { taskRuntime?.notifyApprovalPending(toolName); } catch { /* 알림 실패는 작업에 영향 없음 */ }
     };
     // 읽기 전용 extra 도구(web_search 등) 병렬 선실행. 승인이 필요한 호출은 **자동 승인 작업에서만**
     // 포함한다 — 아니면 승인 창이 동시에 N개 뜬다(HITL fan-in). 결과·스텝 영속은 아래 루프가

--- a/apps/api/src/services/local-bridge/bridge-notice.test.ts
+++ b/apps/api/src/services/local-bridge/bridge-notice.test.ts
@@ -1,0 +1,89 @@
+/**
+ * 서버→디바이스 단방향 알림(bridge_notice) — 로컬 실행 작업의 승인 대기를 디바이스(컴패니언)로 알린다.
+ * 고정 계약: ① 요청과 같은 라우팅(deviceId 지정 = 정확 일치, 미지정 = 최근 접속) ② 프레임은
+ * 화이트리스트 필드만(임의 RPC 금지) ③ 디바이스 없음·닫힌 소켓·전송 예외는 조용히 false
+ * ④ RemoteExecutor 는 자기 task·디바이스로 보낸다.
+ */
+import type { WebSocket } from 'ws';
+import { getLocalBridgeRegistry, type BridgeNoticePayload, type DeviceSession } from './registry';
+import { RemoteExecutor } from './remote-executor';
+
+type FakeWs = WebSocket & { send: jest.Mock };
+
+function fakeWs(open = true): FakeWs {
+    return { readyState: open ? 1 : 3, OPEN: 1, send: jest.fn(), close: jest.fn() } as unknown as FakeWs;
+}
+
+function session(userId: string, deviceId: string, connectedAt: number, ws: WebSocket): DeviceSession {
+    return { userId, deviceId, label: `dev-${deviceId}`, folderName: `f-${deviceId}`, ws, connectedAt };
+}
+
+const notice: BridgeNoticePayload = { notice: 'approval_pending', taskId: 'task-1234abcd', toolName: 'file_ops' };
+
+describe('LocalBridgeRegistry.notify (bridge_notice)', () => {
+    const reg = getLocalBridgeRegistry();
+    const opened: WebSocket[] = [];
+
+    afterEach(() => {
+        for (const ws of opened.splice(0)) reg.unregister(ws);
+    });
+
+    function add(userId: string, deviceId: string, connectedAt: number, open = true): FakeWs {
+        const ws = fakeWs(open);
+        opened.push(ws);
+        reg.register(session(userId, deviceId, connectedAt, ws));
+        return ws;
+    }
+
+    it('지정한 디바이스에만, 화이트리스트 필드만 보낸다', () => {
+        const a = add('u-n1', 'dev-a', 1);
+        const b = add('u-n1', 'dev-b', 2);
+        const withExtra = { ...notice, command: 'rm -rf /' } as unknown as BridgeNoticePayload;
+
+        expect(reg.notify('u-n1', withExtra, 'dev-a')).toBe(true);
+
+        expect(b.send).not.toHaveBeenCalled();
+        expect(JSON.parse(a.send.mock.calls[0][0])).toEqual({
+            type: 'bridge_notice', notice: 'approval_pending', taskId: 'task-1234abcd', toolName: 'file_ops',
+        });
+    });
+
+    it('deviceId 미지정은 최근 접속 디바이스로 보낸다 — request() 와 같은 라우팅', () => {
+        const a = add('u-n2', 'dev-a', 1);
+        const b = add('u-n2', 'dev-b', 5);
+
+        reg.notify('u-n2', { ...notice, toolName: 'ask_human' });
+
+        expect(a.send).not.toHaveBeenCalled();
+        expect(b.send).toHaveBeenCalledTimes(1);
+    });
+
+    it('디바이스 없음·닫힌 소켓·전송 예외는 false 이고 throw 하지 않는다', () => {
+        expect(reg.notify('u-none', notice)).toBe(false);
+
+        add('u-n3', 'dev-closed', 1, false);
+        expect(reg.notify('u-n3', notice)).toBe(false);
+
+        const c = add('u-n4', 'dev-throw', 1);
+        c.send.mockImplementation(() => { throw new Error('boom'); });
+        expect(reg.notify('u-n4', notice)).toBe(false);
+    });
+});
+
+describe('RemoteExecutor.notifyApprovalPending', () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    it('자기 task·디바이스로 approval_pending 알림을 보낸다', () => {
+        const spy = jest.spyOn(getLocalBridgeRegistry(), 'notify').mockReturnValue(true);
+
+        new RemoteExecutor('task-5678efgh', 'user-9', 'dev-z').notifyApprovalPending('file_ops');
+
+        expect(spy).toHaveBeenCalledWith('user-9', { notice: 'approval_pending', taskId: 'task-5678efgh', toolName: 'file_ops' }, 'dev-z');
+    });
+
+    it('디바이스가 없어도 throw 하지 않는다 — 알림 실패가 작업을 흔들지 않게', () => {
+        jest.spyOn(getLocalBridgeRegistry(), 'notify').mockReturnValue(false);
+
+        expect(() => new RemoteExecutor('task-5678efgh', 'user-9').notifyApprovalPending('ask_human')).not.toThrow();
+    });
+});

--- a/apps/api/src/services/local-bridge/registry.ts
+++ b/apps/api/src/services/local-bridge/registry.ts
@@ -10,7 +10,9 @@
  *
  * 보안:
  *   - 등록은 인증된 WS(_authenticatedUserId)에서만 (handler.ts 가 보장)
- *   - 서버→디바이스로 나가는 메시지는 bridge_exec 고정 형태만 — 임의 RPC 금지
+ *   - 서버→디바이스로 나가는 메시지는 두 가지 고정 형태뿐 — 임의 RPC 금지
+ *       bridge_exec   : 도구 요청(kind 화이트리스트, reqId 로 결과 왕복)
+ *       bridge_notice : 단방향 알림(notice 화이트리스트) — 디바이스는 표시만 하고 아무것도 실행하지 않는다
  *   - 비밀(토큰 등)은 프로토콜에 싣지 않는다
  *
  * @module services/local-bridge/registry
@@ -24,6 +26,19 @@ const logger = createLogger('LocalBridge');
 
 /** 서버→디바이스 도구 요청 종류 — 이 외의 kind 는 존재하지 않는다(임의 RPC 금지). */
 export type BridgeKind = 'exec' | 'read' | 'write' | 'list' | 'listAll' | 'delete' | 'task_end' | 'worktree' | 'folders' | 'lsp_diagnostics' | 'code_nav';
+
+/**
+ * 서버→디바이스 단방향 알림 종류 — 디바이스 코어 NOTICE_KINDS 와 1:1.
+ * approval_pending: 로컬 실행 작업이 도구 승인·ask_human 응답을 기다리며 멈췄다(컴패니언이 네이티브 알림).
+ */
+export type BridgeNoticeKind = 'approval_pending';
+
+export interface BridgeNoticePayload {
+    notice: BridgeNoticeKind;
+    taskId: string;
+    /** 표시 전용 — 디바이스가 제어문자·길이를 다시 정리한다. */
+    toolName: string;
+}
 
 /** worktree 연산 — 서버는 op 만 지정하고 git 명령은 디바이스가 고정 인자로 조립한다(명령 주입 차단). */
 export type WorktreeOp = 'add' | 'diff' | 'remove';
@@ -240,6 +255,23 @@ class LocalBridgeRegistry {
                 resolve({ ok: false, error: `브리지 전송 실패: ${e instanceof Error ? e.message : String(e)}` });
             }
         });
+    }
+
+    /**
+     * 단방향 알림 — 응답을 기다리지 않는다(fire-and-forget). 라우팅은 request() 와 같다(deviceId 지정 시
+     * 정확 일치, 미지정은 최근 접속 디바이스). 프레임엔 화이트리스트 필드만 싣는다. 보냈으면 true,
+     * 디바이스 없음·닫힌 소켓·전송 예외는 false(throw 하지 않음 — 알림 실패가 작업을 흔들지 않게).
+     */
+    notify(userId: string, payload: BridgeNoticePayload, deviceId?: string): boolean {
+        const dev = this.getDevice(userId, deviceId);
+        if (!dev || dev.ws.readyState !== dev.ws.OPEN) return false;
+        try {
+            dev.ws.send(JSON.stringify({ type: 'bridge_notice', notice: payload.notice, taskId: payload.taskId, toolName: payload.toolName }));
+            return true;
+        } catch (e) {
+            logger.warn(`[Bridge] 알림 전송 실패: user=${userId} device=${dev.deviceId} ${e instanceof Error ? e.message : String(e)}`);
+            return false;
+        }
     }
 
     /** ws 소켓에 해당하는 디바이스 id (없으면 null) — bridge_result 발신자 검증용. */

--- a/apps/api/src/services/local-bridge/remote-executor.ts
+++ b/apps/api/src/services/local-bridge/remote-executor.ts
@@ -158,6 +158,16 @@ export class RemoteExecutor implements TaskExecutor {
         };
     }
 
+    /**
+     * 승인 대기 알림 — 이 작업을 실행 중인 디바이스로 bridge_notice 를 보낸다(컴패니언이 네이티브
+     * 알림으로 띄움). 단방향이라 결과를 기다리지 않고, 미연결은 조용히 넘긴다. 구 디바이스는 모르는
+     * type 을 무시하므로 추가 전용으로 안전하다.
+     */
+    notifyApprovalPending(toolName: string): void {
+        const sent = getLocalBridgeRegistry().notify(this.userId, { notice: 'approval_pending', taskId: this.taskId, toolName }, this.deviceId);
+        logger.info(`[${this.taskId}] 승인 대기 알림 → 디바이스 ${sent ? '전송' : '미전송(연결 없음)'}: ${toolName}`);
+    }
+
     /** 파일 경로를 worktree 기준으로 변환. 격리가 없으면 원래 경로 그대로. */
     private scoped(relPath: string): string {
         if (!this.worktreeRel) return relPath;

--- a/apps/api/src/services/task-sandbox/executor.ts
+++ b/apps/api/src/services/task-sandbox/executor.ts
@@ -129,6 +129,13 @@ export interface TaskExecutor {
      */
     codeNav?(spec: CodeNavSpec): Promise<CodeNavData | null>;
 
+    /**
+     * 승인 대기 알림 — 실행기가 사용자 디바이스에 닿아 있으면 구현한다(로컬 브리지: 컴패니언이
+     * 네이티브 알림을 띄운다). 웹 푸시는 사용자가 설정에서 켜야 하는 opt-in 이라 운영 구독 0건이던
+     * 실측(2026-09-11)을 메우는 채널이다. 전송 실패는 조용히 넘긴다(fail-open, 작업 무영향).
+     */
+    notifyApprovalPending?(toolName: string): void;
+
     /** 실행 환경 정리. removeWorkspace=false 면 산출물 회수를 위해 workspace 보존. 멱등. */
     cleanup(removeWorkspace?: boolean): Promise<void>;
 }

--- a/apps/api/src/services/task-sandbox/runtime.ts
+++ b/apps/api/src/services/task-sandbox/runtime.ts
@@ -128,6 +128,9 @@ export class TaskRuntime {
         return this.executor.captureDiff ? this.executor.captureDiff() : null;
     }
 
+    /** 승인 대기 알림을 실행기 채널로(로컬 브리지 → 디바이스 네이티브 알림). 미지원 실행기(docker)는 no-op. */
+    notifyApprovalPending(toolName: string): void { this.executor.notifyApprovalPending?.(toolName); }
+
     /** 호스트 workspace 절대경로 — 호스트측 git 연산(code-diff·clone·PR)이 의존.
      *  원격 실행기(D1)는 호스트 workspace 가 없으므로 호출부가 사용 전 가드해야 한다. */
     get workspacePath(): string {

--- a/apps/desktop-native/Localization/en.lproj/Localizable.strings
+++ b/apps/desktop-native/Localization/en.lproj/Localizable.strings
@@ -1,0 +1,86 @@
+/* OpenMake Companion — English. Keys are identifiers; check-l10n.sh verifies all four tables share the same key set. */
+
+/* Menu */
+"menu.status" = "Status: %@";
+"menu.folder" = "Folder: %@";
+"menu.openInFinder" = "Open in Finder";
+"menu.disconnect" = "Disconnect";
+"menu.connectFolder" = "Connect Work Folder…";
+"menu.addFolder" = "Add Work Folder…";
+"menu.disconnectAll" = "Disconnect All";
+"menu.clearAutoApprove" = "Revoke Bulk Approval (%ld tasks)";
+"menu.openWeb" = "Open in Browser";
+"menu.checkUpdates" = "Check for Updates…";
+"menu.settings" = "Settings…";
+"menu.quit" = "Quit";
+
+/* Settings */
+"settings.auth" = "Authentication";
+"settings.apiKey.placeholder" = "API key (omk_live_…)";
+"settings.apiKey.help" = "Issue a key with the bridge scope on the API Access page of the web app and paste it here. It is stored in the Keychain.";
+"settings.apiKey.open" = "Open API Access Page";
+"settings.backend" = "Backend";
+"settings.server" = "Server";
+"settings.save" = "Save";
+"settings.saved" = "Saved";
+"backend.external" = "External (chat.openmake.cc)";
+"backend.local" = "Local (localhost:52416)";
+
+/* Connection status */
+"status.idle" = "Not connected";
+"status.connecting" = "Connecting…";
+"status.connected" = "Connected: %@";
+"status.serverError" = "Server error: %@";
+"status.reconnecting" = "Disconnected — waiting to reconnect";
+"status.closed" = "Closed";
+"status.apiKeyRequired" = "API key required — enter it in Settings";
+"status.folderOpenFailed" = "Could not open folder: %@";
+"status.helperMissing" = "Helper resources missing (reinstall required)";
+"status.helperExited" = "Helper stopped — connect again";
+"status.helperLaunchFailed" = "Could not start helper: %@";
+
+/* Folder picker */
+"panel.title" = "Choose a folder for agent tasks (you can add several folders one at a time)";
+"panel.message" = "Agent tasks read and write files within this folder and its subfolders. Shell commands ask for your confirmation every time, and even when approved, the OS sandbox blocks writes outside the folder and reads of secret files (such as .ssh).";
+
+/* Shell command approval */
+"confirm.title" = "The agent wants to run this shell command on your computer";
+"confirm.folder" = "Working folder: %@";
+"confirm.sandboxOn" = "OS sandbox on: writes outside the folder and reads of secret files (.ssh/.aws, etc.) are blocked. Other reads and network access are allowed.";
+"confirm.sandboxOff" = "⚠️ Sandbox off: this command can access files outside the folder and the network with your account’s permissions.";
+"confirm.allHint" = "Choosing “Run All for This Task” stops these prompts until this task ends (other tasks are not affected).";
+"confirm.run" = "Run";
+"confirm.runAll" = "Run All for This Task";
+"confirm.deny" = "Deny";
+
+/* Notifications */
+"notify.taskEnd.title" = "Agent task finished";
+"notify.taskEnd.body" = "Your local task has finished. Check the results on the web.";
+"notify.approval.title" = "Agent task — approval needed";
+"notify.approval.body" = "Waiting for approval to run a tool: %@. Click to approve on the web.";
+"notify.question.title" = "The agent asked a question";
+"notify.question.body" = "The task is paused waiting for your answer. Click to answer on the web.";
+
+/* Updates */
+"update.insecure" = "Updates are only allowed from an HTTPS (or localhost) backend";
+"update.badBackend" = "Invalid backend address";
+"update.none.title" = "No updates";
+"update.none.body" = "There is no release on the native channel yet, or the manifest is missing. (Current v%@)";
+"update.latest.title" = "Up to date";
+"update.latest.body" = "v%@ is the latest version.";
+"update.available.title" = "Version v%1$@ is available (current v%2$@)";
+"update.available.body" = "Download and install it now? The app will quit briefly during installation and then reopen.";
+"update.install" = "Update";
+"update.later" = "Later";
+"update.badDownload" = "Invalid download address";
+"update.checksum" = "Download integrity check failed (sha256 mismatch)";
+"update.noBundle" = "Could not find the app bundle path (updates are unavailable in development runs)";
+"update.failed.title" = "Update check failed";
+"update.script.failTitle" = "Update failed";
+"update.script.log" = "Log";
+"update.script.mount" = "Could not mount the disk image.";
+"update.script.noApp" = "Could not find the app inside the image.";
+"update.script.copy" = "Could not copy the new version (check the permissions of the install folder).";
+"update.script.replace" = "Could not replace the existing app.";
+"update.script.rollback" = "Installing the new version failed, so the previous version was restored.";
+"update.script.reopen" = "The update succeeded, but the app could not be reopened.";

--- a/apps/desktop-native/Localization/ja.lproj/Localizable.strings
+++ b/apps/desktop-native/Localization/ja.lproj/Localizable.strings
@@ -1,0 +1,86 @@
+/* OpenMake Companion — 日本語。キーは識別子で、4 言語の表のキー集合は check-l10n.sh が照合する。 */
+
+/* メニュー */
+"menu.status" = "状態: %@";
+"menu.folder" = "フォルダ: %@";
+"menu.openInFinder" = "Finder で開く";
+"menu.disconnect" = "接続を解除";
+"menu.connectFolder" = "作業フォルダを接続…";
+"menu.addFolder" = "作業フォルダを追加…";
+"menu.disconnectAll" = "すべての接続を解除";
+"menu.clearAutoApprove" = "一括承認を解除（%ld 件のタスク）";
+"menu.openWeb" = "Web で開く";
+"menu.checkUpdates" = "アップデートを確認…";
+"menu.settings" = "設定…";
+"menu.quit" = "終了";
+
+/* 設定 */
+"settings.auth" = "認証";
+"settings.apiKey.placeholder" = "API キー (omk_live_…)";
+"settings.apiKey.help" = "Web の API アクセスページで bridge スコープのキーを発行して貼り付けてください。キーチェーンに保存されます。";
+"settings.apiKey.open" = "API アクセスページを開く";
+"settings.backend" = "バックエンド";
+"settings.server" = "サーバー";
+"settings.save" = "保存";
+"settings.saved" = "保存しました";
+"backend.external" = "外部 (chat.openmake.cc)";
+"backend.local" = "ローカル (localhost:52416)";
+
+/* 接続状態 */
+"status.idle" = "未接続";
+"status.connecting" = "接続中…";
+"status.connected" = "接続済み: %@";
+"status.serverError" = "サーバーエラー: %@";
+"status.reconnecting" = "切断 — 再接続を待機中";
+"status.closed" = "終了";
+"status.apiKeyRequired" = "API キーが必要です — 設定で入力してください";
+"status.folderOpenFailed" = "フォルダを開けませんでした: %@";
+"status.helperMissing" = "ヘルパーのリソースがありません（再インストールが必要です）";
+"status.helperExited" = "ヘルパーが終了しました — もう一度接続してください";
+"status.helperLaunchFailed" = "ヘルパーを起動できませんでした: %@";
+
+/* フォルダ選択 */
+"panel.title" = "エージェントのタスクに接続するフォルダを選択（複数のフォルダを 1 つずつ追加できます）";
+"panel.message" = "このフォルダ（とサブフォルダ）を基準にファイルを読み書きします。シェルコマンドは実行前に毎回確認し、承認しても OS サンドボックスがフォルダ外への書き込みと秘密ファイル（.ssh など）の読み取りをブロックします。";
+
+/* シェルコマンドの実行承認 */
+"confirm.title" = "エージェントがこのシェルコマンドをあなたのコンピュータで実行しようとしています";
+"confirm.folder" = "実行フォルダ: %@";
+"confirm.sandboxOn" = "OS サンドボックス適用: フォルダ外への書き込みと秘密ファイル（.ssh/.aws など）の読み取りはブロックされます。それ以外の読み取りとネットワークは許可されます。";
+"confirm.sandboxOff" = "⚠️ サンドボックス未適用: このコマンドはあなたのアカウント権限でフォルダ外のファイルやネットワークにアクセスできます。";
+"confirm.allHint" = "「このタスク中はすべて実行」を選ぶと、このタスクが終わるまで再確認しません（ほかのタスクには適用されません）。";
+"confirm.run" = "実行";
+"confirm.runAll" = "このタスク中はすべて実行";
+"confirm.deny" = "拒否";
+
+/* 通知 */
+"notify.taskEnd.title" = "エージェントのタスクが終了しました";
+"notify.taskEnd.body" = "ローカルのタスクが終わりました。結果を Web で確認してください。";
+"notify.approval.title" = "エージェントのタスク — 承認が必要です";
+"notify.approval.body" = "ツール実行の承認を待っています: %@。クリックして Web で承認してください。";
+"notify.question.title" = "エージェントから質問があります";
+"notify.question.body" = "タスクが回答を待って停止しています。クリックして Web で回答してください。";
+
+/* アップデート */
+"update.insecure" = "アップデートは HTTPS（または localhost）のバックエンドからのみ許可されます";
+"update.badBackend" = "無効なバックエンドアドレス";
+"update.none.title" = "アップデートはありません";
+"update.none.body" = "native チャネルの配布がまだないか、マニフェストがありません。（現在 v%@）";
+"update.latest.title" = "最新バージョン";
+"update.latest.body" = "現在の v%@ が最新です。";
+"update.available.title" = "新しいバージョン v%1$@ があります（現在 v%2$@）";
+"update.available.body" = "今すぐダウンロードしてインストールしますか？インストール中、アプリは一時的に終了してから再度開きます。";
+"update.install" = "アップデート";
+"update.later" = "後で";
+"update.badDownload" = "無効なダウンロードアドレス";
+"update.checksum" = "ダウンロードの整合性検証に失敗しました（sha256 不一致）";
+"update.noBundle" = "アプリバンドルのパスが見つかりません（開発実行ではアップデートできません）";
+"update.failed.title" = "アップデートの確認に失敗しました";
+"update.script.failTitle" = "アップデートに失敗しました";
+"update.script.log" = "ログ";
+"update.script.mount" = "ディスクイメージをマウントできませんでした。";
+"update.script.noApp" = "イメージ内にアプリが見つかりませんでした。";
+"update.script.copy" = "新しいバージョンをコピーできませんでした（インストール先フォルダの権限を確認してください）。";
+"update.script.replace" = "既存のアプリを置き換えられません。";
+"update.script.rollback" = "新しいバージョンのインストールに失敗したため、以前のバージョンに戻しました。";
+"update.script.reopen" = "アップデートは完了しましたが、アプリを再度開けませんでした。";

--- a/apps/desktop-native/Localization/ko.lproj/Localizable.strings
+++ b/apps/desktop-native/Localization/ko.lproj/Localizable.strings
@@ -1,0 +1,86 @@
+/* OpenMake Companion — 한국어 (개발 언어). 키는 식별자이며 네 언어 표의 키 집합은 check-l10n.sh 가 대조한다. */
+
+/* 메뉴 */
+"menu.status" = "상태: %@";
+"menu.folder" = "폴더: %@";
+"menu.openInFinder" = "Finder 에서 열기";
+"menu.disconnect" = "연결 해제";
+"menu.connectFolder" = "작업 폴더 연결…";
+"menu.addFolder" = "작업 폴더 추가…";
+"menu.disconnectAll" = "전체 연결 해제";
+"menu.clearAutoApprove" = "일괄 승인 해제 (%ld개 작업)";
+"menu.openWeb" = "웹에서 열기";
+"menu.checkUpdates" = "업데이트 확인…";
+"menu.settings" = "설정…";
+"menu.quit" = "종료";
+
+/* 설정 */
+"settings.auth" = "인증";
+"settings.apiKey.placeholder" = "API key (omk_live_…)";
+"settings.apiKey.help" = "웹의 API 액세스 페이지에서 bridge 스코프 키를 발급해 붙여넣으세요. Keychain 에 저장됩니다.";
+"settings.apiKey.open" = "API 액세스 페이지 열기";
+"settings.backend" = "백엔드";
+"settings.server" = "서버";
+"settings.save" = "저장";
+"settings.saved" = "저장됨";
+"backend.external" = "외부 (chat.openmake.cc)";
+"backend.local" = "로컬 (localhost:52416)";
+
+/* 연결 상태 */
+"status.idle" = "미연결";
+"status.connecting" = "연결 중…";
+"status.connected" = "연결됨: %@";
+"status.serverError" = "서버 오류: %@";
+"status.reconnecting" = "끊김 — 재연결 대기";
+"status.closed" = "종료";
+"status.apiKeyRequired" = "API key 필요 — 설정에서 입력";
+"status.folderOpenFailed" = "폴더 열기 실패: %@";
+"status.helperMissing" = "헬퍼 리소스 없음 (재설치 필요)";
+"status.helperExited" = "헬퍼 종료됨 — 다시 연결하세요";
+"status.helperLaunchFailed" = "헬퍼 실행 실패: %@";
+
+/* 폴더 선택 */
+"panel.title" = "에이전트 작업에 연결할 폴더 선택 (여러 폴더를 각각 추가할 수 있습니다)";
+"panel.message" = "이 폴더(와 하위 폴더)를 작업 기준으로 파일을 읽고 씁니다. 셸 명령은 실행 전 매번 확인을 받고, 승인해도 OS 샌드박스가 폴더 밖 쓰기와 비밀 파일(.ssh 등) 읽기를 차단합니다.";
+
+/* 셸 명령 실행 승인 */
+"confirm.title" = "에이전트가 이 셸 명령을 당신의 컴퓨터에서 실행하려고 합니다";
+"confirm.folder" = "실행 폴더: %@";
+"confirm.sandboxOn" = "OS 샌드박스 적용: 폴더 밖 쓰기와 비밀 파일(.ssh/.aws 등) 읽기는 차단됩니다. 그 외 읽기·네트워크는 허용됩니다.";
+"confirm.sandboxOff" = "⚠️ 샌드박스 미적용: 이 명령은 당신 계정 권한으로 폴더 밖 파일·네트워크에 접근할 수 있습니다.";
+"confirm.allHint" = "“이 작업 동안 모두 실행”을 고르면 이 작업이 끝날 때까지 다시 묻지 않습니다(다른 작업에는 적용되지 않습니다).";
+"confirm.run" = "실행";
+"confirm.runAll" = "이 작업 동안 모두 실행";
+"confirm.deny" = "거부";
+
+/* 알림 */
+"notify.taskEnd.title" = "에이전트 작업 종료";
+"notify.taskEnd.body" = "로컬 작업이 끝났습니다. 결과를 웹에서 확인하세요.";
+"notify.approval.title" = "에이전트 작업 — 승인 필요";
+"notify.approval.body" = "도구 실행 승인을 기다립니다: %@. 눌러서 웹에서 승인하세요.";
+"notify.question.title" = "에이전트가 질문했습니다";
+"notify.question.body" = "작업이 답을 기다리며 멈췄습니다. 눌러서 웹에서 답하세요.";
+
+/* 업데이트 */
+"update.insecure" = "업데이트는 HTTPS(또는 로컬호스트) 백엔드에서만 허용됩니다";
+"update.badBackend" = "잘못된 백엔드 주소";
+"update.none.title" = "업데이트 없음";
+"update.none.body" = "native 채널 배포가 아직 없거나 매니페스트가 없습니다. (현재 v%@)";
+"update.latest.title" = "최신 버전";
+"update.latest.body" = "현재 v%@ 가 최신입니다.";
+"update.available.title" = "새 버전 v%1$@ 이 있습니다 (현재 v%2$@)";
+"update.available.body" = "지금 받아서 설치할까요? 설치 중 앱이 잠시 종료됐다가 다시 열립니다.";
+"update.install" = "업데이트";
+"update.later" = "나중에";
+"update.badDownload" = "잘못된 다운로드 주소";
+"update.checksum" = "다운로드 무결성 검증 실패(sha256 불일치)";
+"update.noBundle" = "앱 번들 경로를 찾지 못했습니다(개발 실행에서는 업데이트 불가)";
+"update.failed.title" = "업데이트 확인 실패";
+"update.script.failTitle" = "업데이트 실패";
+"update.script.log" = "로그";
+"update.script.mount" = "디스크 이미지를 마운트하지 못했습니다.";
+"update.script.noApp" = "이미지 안에서 앱을 찾지 못했습니다.";
+"update.script.copy" = "새 버전 복사에 실패했습니다(설치 폴더 권한을 확인하세요).";
+"update.script.replace" = "기존 앱을 교체할 수 없습니다.";
+"update.script.rollback" = "새 버전 설치에 실패해 이전 버전으로 되돌렸습니다.";
+"update.script.reopen" = "업데이트는 됐지만 앱을 다시 열지 못했습니다.";

--- a/apps/desktop-native/Localization/zh-Hans.lproj/Localizable.strings
+++ b/apps/desktop-native/Localization/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,86 @@
+/* OpenMake Companion — 简体中文。键为标识符，check-l10n.sh 会核对四种语言表的键集合。 */
+
+/* 菜单 */
+"menu.status" = "状态：%@";
+"menu.folder" = "文件夹：%@";
+"menu.openInFinder" = "在访达中打开";
+"menu.disconnect" = "断开连接";
+"menu.connectFolder" = "连接工作文件夹…";
+"menu.addFolder" = "添加工作文件夹…";
+"menu.disconnectAll" = "全部断开";
+"menu.clearAutoApprove" = "撤销批量批准（%ld 个任务）";
+"menu.openWeb" = "在浏览器中打开";
+"menu.checkUpdates" = "检查更新…";
+"menu.settings" = "设置…";
+"menu.quit" = "退出";
+
+/* 设置 */
+"settings.auth" = "认证";
+"settings.apiKey.placeholder" = "API 密钥 (omk_live_…)";
+"settings.apiKey.help" = "请在网页的 API 访问页面签发 bridge 范围的密钥并粘贴到这里。密钥将保存在钥匙串中。";
+"settings.apiKey.open" = "打开 API 访问页面";
+"settings.backend" = "后端";
+"settings.server" = "服务器";
+"settings.save" = "保存";
+"settings.saved" = "已保存";
+"backend.external" = "外部 (chat.openmake.cc)";
+"backend.local" = "本地 (localhost:52416)";
+
+/* 连接状态 */
+"status.idle" = "未连接";
+"status.connecting" = "正在连接…";
+"status.connected" = "已连接：%@";
+"status.serverError" = "服务器错误：%@";
+"status.reconnecting" = "已断开 — 等待重新连接";
+"status.closed" = "已关闭";
+"status.apiKeyRequired" = "需要 API 密钥 — 请在设置中输入";
+"status.folderOpenFailed" = "无法打开文件夹：%@";
+"status.helperMissing" = "缺少辅助程序资源（需要重新安装）";
+"status.helperExited" = "辅助程序已停止 — 请重新连接";
+"status.helperLaunchFailed" = "无法启动辅助程序：%@";
+
+/* 选择文件夹 */
+"panel.title" = "选择要连接到智能体任务的文件夹（可以逐个添加多个文件夹）";
+"panel.message" = "智能体任务会在此文件夹（及其子文件夹）内读写文件。每次执行 Shell 命令前都会请求你确认；即使批准，系统沙盒也会阻止在文件夹外写入以及读取机密文件（如 .ssh）。";
+
+/* Shell 命令执行批准 */
+"confirm.title" = "智能体想在你的电脑上运行此 Shell 命令";
+"confirm.folder" = "运行文件夹：%@";
+"confirm.sandboxOn" = "已启用系统沙盒：在文件夹外写入和读取机密文件（.ssh/.aws 等）将被阻止。其他读取和网络访问不受限制。";
+"confirm.sandboxOff" = "⚠️ 未启用沙盒：此命令可以用你的账户权限访问文件夹外的文件和网络。";
+"confirm.allHint" = "选择“本任务期间全部运行”后，在此任务结束前不会再次询问（不适用于其他任务）。";
+"confirm.run" = "运行";
+"confirm.runAll" = "本任务期间全部运行";
+"confirm.deny" = "拒绝";
+
+/* 通知 */
+"notify.taskEnd.title" = "智能体任务已结束";
+"notify.taskEnd.body" = "本地任务已完成。请在网页上查看结果。";
+"notify.approval.title" = "智能体任务 — 需要批准";
+"notify.approval.body" = "正在等待批准运行工具：%@。点击后在网页上批准。";
+"notify.question.title" = "智能体提出了问题";
+"notify.question.body" = "任务已暂停，正在等待你的回答。点击后在网页上回答。";
+
+/* 更新 */
+"update.insecure" = "仅允许从 HTTPS（或 localhost）后端更新";
+"update.badBackend" = "后端地址无效";
+"update.none.title" = "没有更新";
+"update.none.body" = "native 通道尚无发布，或缺少清单。（当前 v%@）";
+"update.latest.title" = "已是最新版本";
+"update.latest.body" = "当前 v%@ 已是最新版本。";
+"update.available.title" = "有新版本 v%1$@（当前 v%2$@）";
+"update.available.body" = "现在下载并安装吗？安装期间应用会短暂退出，然后重新打开。";
+"update.install" = "更新";
+"update.later" = "稍后";
+"update.badDownload" = "下载地址无效";
+"update.checksum" = "下载完整性校验失败（sha256 不匹配）";
+"update.noBundle" = "找不到应用包路径（开发运行时无法更新）";
+"update.failed.title" = "检查更新失败";
+"update.script.failTitle" = "更新失败";
+"update.script.log" = "日志";
+"update.script.mount" = "无法挂载磁盘映像。";
+"update.script.noApp" = "在映像中找不到应用。";
+"update.script.copy" = "无法复制新版本（请检查安装文件夹的权限）。";
+"update.script.replace" = "无法替换现有应用。";
+"update.script.rollback" = "新版本安装失败，已恢复为之前的版本。";
+"update.script.reopen" = "更新已完成，但无法重新打开应用。";

--- a/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/CompanionApp.swift
+++ b/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/CompanionApp.swift
@@ -1,5 +1,6 @@
 // OpenMake Companion — 메뉴바 상주 로컬 에이전트 컴패니언.
 // 역할 한정(plan §1 비목표): 채팅 UI 없음 — 깊은 작업은 웹으로 딥링크 핸드오프.
+// 사용자 문구는 전부 L(키) — Localization/<lang>.lproj (L10n.swift 참고).
 import AppKit
 import SwiftUI
 import UserNotifications
@@ -57,36 +58,36 @@ struct MenuContent: View {
 
     var body: some View {
         if helper.connectedFolders.isEmpty {
-            Text("상태: \(helper.statusText)")
+            Text(L("menu.status", helper.statusText))
         }
         // 다중 루트 — 루트별 서브메뉴 (전체 경로는 로컬 표시 전용, 서버엔 basename 만 감)
         ForEach(helper.connectedFolders, id: \.self) { f in
-            Menu("폴더: \(URL(fileURLWithPath: f).lastPathComponent)") {
+            Menu(L("menu.folder", URL(fileURLWithPath: f).lastPathComponent)) {
                 Text(f)
-                if let st = helper.rootStatus[f] { Text("상태: \(st)") }
-                Button("Finder 에서 열기") { NSWorkspace.shared.open(URL(fileURLWithPath: f)) }
-                Button("연결 해제") { helper.disconnect(folder: f) }
+                if let st = helper.rootStatus[f] { Text(L("menu.status", st)) }
+                Button(L("menu.openInFinder")) { NSWorkspace.shared.open(URL(fileURLWithPath: f)) }
+                Button(L("menu.disconnect")) { helper.disconnect(folder: f) }
             }
         }
         Divider()
-        Button(helper.connectedFolders.isEmpty ? "작업 폴더 연결…" : "작업 폴더 추가…") { helper.chooseFolderAndConnect() }
+        Button(helper.connectedFolders.isEmpty ? L("menu.connectFolder") : L("menu.addFolder")) { helper.chooseFolderAndConnect() }
         if helper.connectedFolders.count > 1 {
-            Button("전체 연결 해제") { helper.disconnectAll() }
+            Button(L("menu.disconnectAll")) { helper.disconnectAll() }
         }
         if helper.autoApproveCount > 0 {
-            Button("일괄 승인 해제 (\(helper.autoApproveCount)개 작업)") { helper.clearAutoApprove() }
+            Button(L("menu.clearAutoApprove", helper.autoApproveCount)) { helper.clearAutoApprove() }
         }
         Divider()
-        Button("웹에서 열기") { helper.openWeb() }
-        Button("업데이트 확인…") {
+        Button(L("menu.openWeb")) { helper.openWeb() }
+        Button(L("menu.checkUpdates")) {
             Task { await Updater.shared.check(backendUrl: helper.backend.url, interactive: true) }
         }
-        Button("설정…") {
+        Button(L("menu.settings")) {
             openSettings()
             NSApp.activate(ignoringOtherApps: true)
         }
         Divider()
-        Button("종료") {
+        Button(L("menu.quit")) {
             helper.stopHelper()
             NSApp.terminate(nil)
         }
@@ -101,26 +102,28 @@ struct SettingsView: View {
 
     var body: some View {
         Form {
-            Section("인증") {
-                SecureField("API key (omk_live_…)", text: $apiKey)
-                Text("웹 설정 → API 키에서 bridge 스코프 키를 발급해 붙여넣으세요. Keychain 에 저장됩니다.")
+            Section(L("settings.auth")) {
+                SecureField(L("settings.apiKey.placeholder"), text: $apiKey)
+                Text(L("settings.apiKey.help"))
                     .font(.caption).foregroundStyle(.secondary)
+                // 키 발급 위치는 웹의 API 액세스 페이지(/api-access) — 설정 탭이 아니다.
+                Button(L("settings.apiKey.open")) { helper.openApiAccess(backendId: backendId) }
             }
-            Section("백엔드") {
-                Picker("서버", selection: $backendId) {
+            Section(L("settings.backend")) {
+                Picker(L("settings.server"), selection: $backendId) {
                     ForEach(HelperManager.backends, id: \.id) { b in
-                        Text(b.label).tag(b.id)
+                        Text(L(b.label)).tag(b.id)
                     }
                 }
             }
             HStack {
-                Button("저장") {
+                Button(L("settings.save")) {
                     Keychain.save(apiKey.trimmingCharacters(in: .whitespacesAndNewlines))
                     if backendId != helper.backendId { helper.switchBackend(backendId) }
                     saved = true
                     DispatchQueue.main.asyncAfter(deadline: .now() + 2) { saved = false }
                 }
-                if saved { Text("저장됨").foregroundStyle(.green) }
+                if saved { Text(L("settings.saved")).foregroundStyle(.green) }
             }
         }
         .padding(20)

--- a/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/HelperManager.swift
+++ b/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/HelperManager.swift
@@ -16,7 +16,7 @@ import UserNotifications
 final class HelperManager: NSObject, ObservableObject {
     static let shared = HelperManager()
 
-    @Published var statusText = "미연결"
+    @Published var statusText = L("status.idle")
     /** 연결된 루트들(realpath) — 루트당 독립 브리지 연결(파생 deviceId), 서버엔 별개 디바이스. */
     @Published var connectedFolders: [String] = []
     /** 루트별 최근 상태 텍스트 (연결됨/재연결 중/서버 오류 등). */
@@ -28,10 +28,10 @@ final class HelperManager: NSObject, ObservableObject {
     private var stdoutBuf = Data()
 
     // 백엔드 선택 — Electron 셸과 동일 2종. 로컬은 Next(3000)가 WS 를 프록시하지 못하므로
-    // 백엔드(52416) 직결 (기존 bridgeBackendUrl 관행).
+    // 백엔드(52416) 직결 (기존 bridgeBackendUrl 관행). label 은 다국어 키.
     static let backends: [(id: String, label: String, url: String, webUrl: String)] = [
-        ("external", "외부 (chat.openmake.cc)", "https://chat.openmake.cc", "https://chat.openmake.cc"),
-        ("local", "로컬 (localhost:52416)", "http://localhost:52416", "http://localhost:3000"),
+        ("external", "backend.external", "https://chat.openmake.cc", "https://chat.openmake.cc"),
+        ("local", "backend.local", "http://localhost:52416", "http://localhost:3000"),
     ]
     var backendId: String {
         get { UserDefaults.standard.string(forKey: "backend") ?? "external" }
@@ -54,6 +54,18 @@ final class HelperManager: NSObject, ObservableObject {
         }
     }
 
+    /** 헬퍼·코어 상태 코드 → 다국어 키. 코드가 없거나 모르는 값(auth_error 등)이면 원문을 그대로 쓴다. */
+    private static let statusKeys: [String: String] = [
+        "connecting": "status.connecting",
+        "connected": "status.connected",
+        "server_error": "status.serverError",
+        "reconnecting": "status.reconnecting",
+        "closed": "status.closed",
+        "idle": "status.idle",
+        "api_key_required": "status.apiKeyRequired",
+        "folder_open_failed": "status.folderOpenFailed",
+    ]
+
     // ── 헬퍼 프로세스 lifecycle ──
 
     private func resourceURL(_ name: String) -> URL? {
@@ -70,12 +82,12 @@ final class HelperManager: NSObject, ObservableObject {
         // OMK_BRIDGE_TOKEN 관행과 동일 계열. 정식 실행 경로는 Keychain 만 쓴다.
         let envKey = ProcessInfo.processInfo.environment["OMK_COMPANION_API_KEY"]
         guard let apiKey = envKey ?? Keychain.load(), !apiKey.isEmpty else {
-            statusText = "API key 필요 — 설정에서 입력"
+            statusText = L("status.apiKeyRequired")
             return false
         }
         guard let nodeURL = resourceURL("node"), FileManager.default.isExecutableFile(atPath: nodeURL.path),
               let helperURL = resourceURL("helper.cjs"), FileManager.default.fileExists(atPath: helperURL.path) else {
-            statusText = "헬퍼 리소스 없음 (재설치 필요)"
+            statusText = L("status.helperMissing")
             return false
         }
         let p = Process()
@@ -97,13 +109,13 @@ final class HelperManager: NSObject, ObservableObject {
             Task { @MainActor in
                 self?.process = nil
                 self?.stdinPipe = nil
-                if !(self?.connectedFolders.isEmpty ?? true) { self?.statusText = "헬퍼 종료됨 — 다시 연결하세요" }
+                if !(self?.connectedFolders.isEmpty ?? true) { self?.statusText = L("status.helperExited") }
                 self?.connectedFolders = []
                 self?.rootStatus = [:]
             }
         }
         do { try p.run() } catch {
-            statusText = "헬퍼 실행 실패: \(error.localizedDescription)"
+            statusText = L("status.helperLaunchFailed", error.localizedDescription)
             return false
         }
         process = p
@@ -134,8 +146,8 @@ final class HelperManager: NSObject, ObservableObject {
     /** 폴더 연결 — 권한 부여의 유일한 발원: 사용자가 패널에서 직접 고른 폴더만 헬퍼로 전달된다. */
     func chooseFolderAndConnect() {
         let panel = NSOpenPanel()
-        panel.title = "에이전트 작업에 연결할 폴더 선택 (여러 폴더를 각각 추가할 수 있습니다)"
-        panel.message = "이 폴더(와 하위 폴더)를 작업 기준으로 파일을 읽고 씁니다. 셸 명령은 실행 전 매번 확인을 받고, 승인해도 OS 샌드박스가 폴더 밖 쓰기와 비밀 파일(.ssh 등) 읽기를 차단합니다."
+        panel.title = L("panel.title")
+        panel.message = L("panel.message")
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
         panel.canCreateDirectories = true
@@ -191,6 +203,12 @@ final class HelperManager: NSObject, ObservableObject {
         if let url = URL(string: backend.webUrl) { NSWorkspace.shared.open(url) }
     }
 
+    /** bridge 스코프 키 발급 페이지 — 설정 화면에서 아직 저장하지 않은 백엔드 선택도 따른다. */
+    func openApiAccess(backendId id: String) {
+        let web = Self.backends.first { $0.id == id }?.webUrl ?? backend.webUrl
+        if let url = URL(string: "\(web)/api-access") { NSWorkspace.shared.open(url) }
+    }
+
     // ── 헬퍼 이벤트 소비 ──
 
     private func consume(_ d: Data) {
@@ -207,12 +225,13 @@ final class HelperManager: NSObject, ObservableObject {
     private func handle(_ kind: String, _ ev: [String: Any]) {
         switch kind {
         case "status":
-            let text = ev["text"] as? String ?? ""
+            let code = ev["code"] as? String
+            let text = Self.statusText(code: code, arg: ev["arg"] as? String, fallback: ev["text"] as? String ?? "")
             if let f = ev["folder"] as? String {
                 rootStatus[f] = text // 루트별 상태 (연결됨/재연결 중/서버 오류)
             } else {
                 statusText = text
-                if text == "미연결" { connectedFolders = []; rootStatus = [:] }
+                if code == "idle" { connectedFolders = []; rootStatus = [:] }
             }
         case "connected":
             if let f = ev["folder"] as? String, !connectedFolders.contains(f) { connectedFolders.append(f) }
@@ -227,9 +246,18 @@ final class HelperManager: NSObject, ObservableObject {
             presentConfirm(ev)
         case "taskEnd":
             notifyTaskEnd(taskId: ev["taskId"] as? String)
+        case "approvalPending":
+            if let taskId = ev["taskId"] as? String {
+                notifyApprovalPending(taskId: taskId, toolName: ev["toolName"] as? String ?? "")
+            }
         default:
             break
         }
+    }
+
+    private static func statusText(code: String?, arg: String?, fallback: String) -> String {
+        guard let code, let key = statusKeys[code] else { return fallback }
+        return L(key, arg ?? "")
     }
 
     /** exec 승인 — 비우회 네이티브 다이얼로그. 실행될 명령 원문·실행 폴더를 그대로 보여준다. */
@@ -243,18 +271,16 @@ final class HelperManager: NSObject, ObservableObject {
 
         let alert = NSAlert()
         alert.alertStyle = .warning
-        alert.messageText = "에이전트가 이 셸 명령을 당신의 컴퓨터에서 실행하려고 합니다"
-        var detail = "\(preview)\n\n실행 폴더: \(base)\n"
-        detail += sandboxed
-            ? "OS 샌드박스 적용: 폴더 밖 쓰기와 비밀 파일(.ssh/.aws 등) 읽기는 차단됩니다. 그 외 읽기·네트워크는 허용됩니다."
-            : "⚠️ 샌드박스 미적용: 이 명령은 당신 계정 권한으로 폴더 밖 파일·네트워크에 접근할 수 있습니다."
+        alert.messageText = L("confirm.title")
+        var detail = "\(preview)\n\n\(L("confirm.folder", base))\n"
+        detail += sandboxed ? L("confirm.sandboxOn") : L("confirm.sandboxOff")
         if taskId != nil {
-            detail += "\n\n\"이 작업 동안 모두 실행\"을 고르면 이 작업이 끝날 때까지 다시 묻지 않습니다(다른 작업에는 적용되지 않습니다)."
+            detail += "\n\n" + L("confirm.allHint")
         }
         alert.informativeText = detail
-        alert.addButton(withTitle: "실행")
-        if taskId != nil { alert.addButton(withTitle: "이 작업 동안 모두 실행") }
-        alert.addButton(withTitle: "거부")
+        alert.addButton(withTitle: L("confirm.run"))
+        if taskId != nil { alert.addButton(withTitle: L("confirm.runAll")) }
+        alert.addButton(withTitle: L("confirm.deny"))
         NSApp.activate(ignoringOtherApps: true)
         let r = alert.runModal()
         let result: String
@@ -264,16 +290,37 @@ final class HelperManager: NSObject, ObservableObject {
         send(["cmd": "confirm", "id": id, "result": result])
     }
 
+    /** 웹 작업 상세 딥링크 계약: /agent-tasks?task=<id> (admin/conversations 와 동일 패턴). */
+    private func taskUrl(_ taskId: String?) -> String {
+        taskId.map { "\(backend.webUrl)/agent-tasks?task=\($0)" } ?? backend.webUrl
+    }
+
     /** 작업 종료 알림 — 클릭 시 웹 작업 상세로 핸드오프(상세 UI 는 웹 단일 구현 원칙).
-        ask_human/승인 대기 알림은 서버 web-push 가 담당(turn-executor onApprovalPending) — 중복 구현 안 함. */
+        남아 있던 그 작업의 승인 대기 알림은 거둔다(이미 끝난 작업의 승인을 누르러 가지 않게). */
     private func notifyTaskEnd(taskId: String?) {
         let content = UNMutableNotificationContent()
-        content.title = "에이전트 작업 종료"
-        content.body = "로컬 작업이 끝났습니다. 결과를 웹에서 확인하세요."
-        // 웹 작업 상세 딥링크 계약: /agent-tasks?task=<id> (admin/conversations 와 동일 패턴)
-        let url = taskId.map { "\(backend.webUrl)/agent-tasks?task=\($0)" } ?? backend.webUrl
-        content.userInfo = ["url": url]
+        content.title = L("notify.taskEnd.title")
+        content.body = L("notify.taskEnd.body")
+        content.userInfo = ["url": taskUrl(taskId)]
+        let center = UNUserNotificationCenter.current()
+        if let taskId { center.removeDeliveredNotifications(withIdentifiers: ["approval-\(taskId)"]) }
         let req = UNNotificationRequest(identifier: taskId ?? UUID().uuidString, content: content, trigger: nil)
+        center.add(req) { _ in /* 권한 거부 등은 무시(fail-open) */ }
+    }
+
+    /** 승인 대기·질문 알림 — 서버가 브리지 bridge_notice 로 알려 준다(2026-09-11 설계 변경).
+        종전엔 "웹 푸시가 담당 — 중복 구현 안 함" 이었으나, 웹 푸시는 설정에서 켜야 하는 opt-in 이라
+        운영 구독 0건 = 실제 도달 0 이었다. 로컬 작업을 돌리는 동안 이 앱은 항상 떠 있으므로 여기서
+        직접 띄운다. 웹 푸시도 켠 사용자는 두 번 받을 수 있으나 놓치는 것보다 낫다.
+        식별자를 작업 단위로 고정해 다중 루트·연속 승인에서도 쌓이지 않고 최신 1건으로 교체된다. */
+    private func notifyApprovalPending(taskId: String, toolName: String) {
+        let content = UNMutableNotificationContent()
+        let isQuestion = toolName == "ask_human"
+        content.title = isQuestion ? L("notify.question.title") : L("notify.approval.title")
+        content.body = isQuestion ? L("notify.question.body") : L("notify.approval.body", toolName)
+        content.sound = .default
+        content.userInfo = ["url": taskUrl(taskId)]
+        let req = UNNotificationRequest(identifier: "approval-\(taskId)", content: content, trigger: nil)
         UNUserNotificationCenter.current().add(req) { _ in /* 권한 거부 등은 무시(fail-open) */ }
     }
 }

--- a/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/L10n.swift
+++ b/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/L10n.swift
@@ -1,0 +1,10 @@
+// 다국어 문자열 — apps/desktop-native/Localization/<lang>.lproj/Localizable.strings
+// (ko·en·ja·zh-Hans, 웹 LOCALES 와 같은 4개 언어). build.sh 가 앱 Resources 로 복사한다.
+// 키는 식별자이고 ko 가 개발 언어(웹 DEFAULT_LOCALE 과 동일)다. 네 표의 키 집합과 소스가 쓰는
+// L("키") 는 check-l10n.sh 가 빌드 전에 대조한다 — 빠진 키는 그 언어 사용자에게 식별자로 보이기 때문.
+import Foundation
+
+func L(_ key: String, _ args: CVarArg...) -> String {
+    let format = NSLocalizedString(key, comment: "")
+    return args.isEmpty ? format : String(format: format, arguments: args)
+}

--- a/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/Updater.swift
+++ b/apps/desktop-native/OpenMakeCompanion/Sources/OpenMakeCompanion/Updater.swift
@@ -32,10 +32,10 @@ final class Updater: ObservableObject {
         defer { checking = false }
         do {
             guard isSecureOrigin(backendUrl) else {
-                throw UpdateError.message("업데이트는 HTTPS(또는 로컬호스트) 백엔드에서만 허용됩니다")
+                throw UpdateError.message(L("update.insecure"))
             }
             guard let url = URL(string: "\(backendUrl)/api/desktop/latest") else {
-                throw UpdateError.message("잘못된 백엔드 주소")
+                throw UpdateError.message(L("update.badBackend"))
             }
             let (data, _) = try await URLSession.shared.data(from: url)
             guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -45,27 +45,27 @@ final class Updater: ObservableObject {
                   let file = native["file"] as? String,
                   let sha256 = native["sha256"] as? String, sha256.count == 64
             else {
-                if interactive { info("업데이트 없음", "native 채널 배포가 아직 없거나 매니페스트가 없습니다. (현재 v\(currentVersion))") }
+                if interactive { info(L("update.none.title"), L("update.none.body", currentVersion)) }
                 return
             }
             guard isNewer(version, than: currentVersion) else {
-                if interactive { info("최신 버전", "현재 v\(currentVersion) 가 최신입니다.") }
+                if interactive { info(L("update.latest.title"), L("update.latest.body", currentVersion)) }
                 return
             }
             // 테스트 훅(개발/E2E 전용): 다이얼로그 없이 즉시 진행 — OMK_COMPANION_* env 훅 계열.
             if ProcessInfo.processInfo.environment["OMK_COMPANION_AUTO_UPDATE"] != "1" {
                 let alert = NSAlert()
-                alert.messageText = "새 버전 v\(version) 이 있습니다 (현재 v\(currentVersion))"
-                alert.informativeText = "지금 받아서 설치할까요? 설치 중 앱이 잠시 종료됐다가 다시 열립니다."
-                alert.addButton(withTitle: "업데이트")
-                alert.addButton(withTitle: "나중에")
+                alert.messageText = L("update.available.title", version, currentVersion)
+                alert.informativeText = L("update.available.body")
+                alert.addButton(withTitle: L("update.install"))
+                alert.addButton(withTitle: L("update.later"))
                 NSApp.activate(ignoringOtherApps: true)
                 guard alert.runModal() == .alertFirstButtonReturn else { return }
             }
 
             let dmgURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(file)
             guard let dl = URL(string: "\(backendUrl)/api/desktop/download/\(file)") else {
-                throw UpdateError.message("잘못된 다운로드 주소")
+                throw UpdateError.message(L("update.badDownload"))
             }
             let (tmp, _) = try await URLSession.shared.download(from: dl)
             try? FileManager.default.removeItem(at: dmgURL)
@@ -75,16 +75,16 @@ final class Updater: ObservableObject {
             let hex = digest.map { String(format: "%02x", $0) }.joined()
             guard hex == sha256.lowercased() else {
                 try? FileManager.default.removeItem(at: dmgURL)
-                throw UpdateError.message("다운로드 무결성 검증 실패(sha256 불일치)")
+                throw UpdateError.message(L("update.checksum"))
             }
 
             try spawnReplaceScript(dmgPath: dmgURL.path)
             HelperManager.shared.stopHelper()
             NSApp.terminate(nil)
         } catch let e as UpdateError {
-            if case let .message(m) = e, interactive { info("업데이트 확인 실패", m) }
+            if case let .message(m) = e, interactive { info(L("update.failed.title"), m) }
         } catch {
-            if interactive { info("업데이트 확인 실패", error.localizedDescription) }
+            if interactive { info(L("update.failed.title"), error.localizedDescription) }
         }
     }
 
@@ -104,10 +104,22 @@ final class Updater: ObservableObject {
         return false
     }
 
+    /** 교체 스크립트가 실패 시 띄울 문구 — 앱이 다국어로 만들어 env 로 넘긴다(스크립트에 문자열을 박지 않음). */
+    private static let scriptMessages: [String: String] = [
+        "OMK_UPD_FAIL_TITLE": "update.script.failTitle",
+        "OMK_UPD_LOG": "update.script.log",
+        "OMK_UPD_MOUNT": "update.script.mount",
+        "OMK_UPD_NO_APP": "update.script.noApp",
+        "OMK_UPD_COPY": "update.script.copy",
+        "OMK_UPD_REPLACE": "update.script.replace",
+        "OMK_UPD_ROLLBACK": "update.script.rollback",
+        "OMK_UPD_REOPEN": "update.script.reopen",
+    ]
+
     /** 교체 스크립트 — Electron updater.js 의 검증된 시퀀스 이식 (스테이징→스왑→롤백·오류 시 osascript 경고). */
     private func spawnReplaceScript(dmgPath: String) throws {
         guard let appPath = Bundle.main.bundlePath.hasSuffix(".app") ? Bundle.main.bundlePath : nil else {
-            throw UpdateError.message("앱 번들 경로를 찾지 못했습니다(개발 실행에서는 업데이트 불가)")
+            throw UpdateError.message(L("update.noBundle"))
         }
         let ts = Int(Date().timeIntervalSince1970)
         let logPath = NSTemporaryDirectory() + "openmake-companion-update-\(ts).log"
@@ -120,7 +132,7 @@ final class Updater: ObservableObject {
 
         fail() {
           echo "FAIL: $1"
-          /usr/bin/osascript -e "display alert \\"업데이트 실패\\" message \\"$1\\n\\n로그: \(logPath)\\" as critical" || true
+          /usr/bin/osascript -e "display alert \\"$OMK_UPD_FAIL_TITLE\\" message \\"$1\\n\\n$OMK_UPD_LOG: \(logPath)\\" as critical" || true
           [ -d "$APP" ] && open -a "$APP" || true
           rm -f "$DMG"
           exit 1
@@ -128,29 +140,29 @@ final class Updater: ObservableObject {
 
         sleep 2
         MNT=$(hdiutil attach -nobrowse "$DMG" | grep -o '/Volumes/.*' | tail -1)
-        [ -n "$MNT" ] || fail "디스크 이미지를 마운트하지 못했습니다."
-        [ -d "$MNT/OpenMake Companion.app" ] || { hdiutil detach "$MNT" -quiet; fail "이미지 안에서 앱을 찾지 못했습니다."; }
+        [ -n "$MNT" ] || fail "$OMK_UPD_MOUNT"
+        [ -d "$MNT/OpenMake Companion.app" ] || { hdiutil detach "$MNT" -quiet; fail "$OMK_UPD_NO_APP"; }
 
         STAGE="$APP.new"
         rm -rf "$STAGE"
         if ! ditto "$MNT/OpenMake Companion.app" "$STAGE"; then
           rm -rf "$STAGE"; hdiutil detach "$MNT" -quiet
-          fail "새 버전 복사에 실패했습니다(설치 폴더 권한을 확인하세요)."
+          fail "$OMK_UPD_COPY"
         fi
         hdiutil detach "$MNT" -quiet
 
         BACKUP="$APP.old"
         rm -rf "$BACKUP"
-        mv "$APP" "$BACKUP" || { rm -rf "$STAGE"; fail "기존 앱을 교체할 수 없습니다."; }
+        mv "$APP" "$BACKUP" || { rm -rf "$STAGE"; fail "$OMK_UPD_REPLACE"; }
         if ! mv "$STAGE" "$APP"; then
           mv "$BACKUP" "$APP" 2>/dev/null
-          fail "새 버전 설치에 실패해 이전 버전으로 되돌렸습니다."
+          fail "$OMK_UPD_ROLLBACK"
         fi
         rm -rf "$BACKUP"
 
         xattr -dr com.apple.quarantine "$APP" 2>/dev/null
         rm -f "$DMG"
-        open -a "$APP" || fail "업데이트는 됐지만 앱을 다시 열지 못했습니다."
+        open -a "$APP" || fail "$OMK_UPD_REOPEN"
         echo "OK: updated $APP"
         rm -f "$0"
         """
@@ -160,6 +172,9 @@ final class Updater: ObservableObject {
         let p = Process()
         p.executableURL = URL(fileURLWithPath: "/bin/bash")
         p.arguments = [shPath]
+        var env = ProcessInfo.processInfo.environment
+        for (name, key) in Self.scriptMessages { env[name] = L(key) }
+        p.environment = env
         p.standardOutput = FileHandle.nullDevice
         p.standardError = FileHandle.nullDevice
         try p.run() // detached 성격 — 부모 종료 후에도 계속 실행됨(스크립트가 sleep 후 교체)

--- a/apps/desktop-native/README.md
+++ b/apps/desktop-native/README.md
@@ -1,6 +1,6 @@
 # OpenMake Companion (SwiftUI 네이티브 데스크톱)
 
-메뉴바 상주 **로컬 에이전트 컴패니언** — 폴더 연결·디바이스 상태·exec 승인·작업 종료 알림·웹 딥링크만 담당한다.
+메뉴바 상주 **로컬 에이전트 컴패니언** — 폴더 연결·디바이스 상태·exec 승인·작업 알림(종료·승인 대기)·웹 딥링크만 담당한다.
 채팅 등 깊은 UI 는 웹(chat.openmake.cc)이 전담한다 (plan §1 비목표: 채팅 UI 재구현 금지).
 Plan: `docs/proposals/2026-08-22-desktop-native-companion-plan.md` (로컬 보관).
 
@@ -10,13 +10,17 @@ Plan: `docs/proposals/2026-08-22-desktop-native-companion-plan.md` (로컬 보�
 helper/src/helper.mjs    # Node 헬퍼 — @openmake/local-bridge-core 의 stdio JSON-lines 어댑터
 helper/harness.cjs       # 헬퍼 회귀 하네스 (build.sh 가 게이트로 실행)
 OpenMakeCompanion/       # SwiftPM 앱 (MenuBarExtra + 설정 + HelperManager + Updater)
-build.sh                 # helper 번들(esbuild) → 하네스 → swift build → .app 조립 → ad-hoc 서명 → dmg
+Localization/            # <lang>.lproj/Localizable.strings — ko(개발 언어)·en·ja·zh-Hans
+check-l10n.sh            # 다국어 표 게이트 (build.sh·CI 공용)
+build.sh                 # helper 번들(esbuild) → 하네스 → l10n 게이트 → swift build → .app 조립 → ad-hoc 서명 → dmg
 ```
 
 - 브리지 보안 코어(경로 스코프·exec 3단 방어·git 고정 조립·worktree)는 **`packages/local-bridge-core` 재사용** — Swift 재구현 금지(plan §6 게이트).
 - 앱↔헬퍼 stdio 계약은 `helper.mjs` 상단 주석 참고. confirm 응답은 항상 앱(사용자 다이얼로그)만 발원.
-- 인증: API key(`omk_live_*`, bridge 스코프) → Keychain 저장, 헬퍼엔 env(`OMK_COMPANION_API_KEY`)로 전달 (ps 노출 방지).
+- 인증: API key(`omk_live_*`, bridge 스코프) → Keychain 저장, 헬퍼엔 env(`OMK_COMPANION_API_KEY`)로 전달 (ps 노출 방지). 키 발급은 웹의 **API 액세스 페이지(`/api-access`)** — 설정 화면의 "API 액세스 페이지 열기" 버튼이 연다.
 - **다중 루트(0.2.0)**: 메뉴 "작업 폴더 추가…" 로 여러 루트를 각각 연결 — 루트당 독립 브리지 연결(파생 deviceId = base id + 경로 해시)이라 **서버·프로토콜 무변경**, 웹엔 루트마다 별개 디바이스로 표시(기존 디바이스 선택기 사용). 유저당 총 디바이스 수는 서버 `LOCAL_BRIDGE_MAX_DEVICES`(기본 3)가 강제 — 초과는 해당 루트 상태에 서버 오류로 표면화. 스코프·샌드박스·일괄승인 회수는 루트별 독립(코어 인스턴스 분리).
+- **승인 대기 알림(0.2.6)**: 로컬 실행 작업이 도구 승인·`ask_human` 응답을 기다리며 멈추면 서버가 그 디바이스로 `bridge_notice`(단방향, 필드 화이트리스트)를 보내고 앱이 네이티브 알림을 띄운다(클릭 → `/agent-tasks?task=<id>`). 종전 설계는 "승인 대기 알림은 웹 푸시 담당 — 중복 구현 금지" 였으나, 웹 푸시는 설정에서 켜야 하는 opt-in 이라 운영 구독 0건 = 실제 도달 0 이어서 바꿨다. 코어는 알림을 검증(종류·taskId 형식·도구명 제어문자·길이)해 넘길 뿐 아무것도 실행하지 않고, 구 디바이스는 모르는 type 을 무시한다(추가 전용).
+- **다국어(0.2.6)**: 웹과 같은 네 언어. 문자열은 `L("키")` → `Localization/<lang>.lproj`, 앱 번들 `Contents/Resources` 로 복사하고 `CFBundleDevelopmentRegion=ko`(웹 `DEFAULT_LOCALE`). 헬퍼·코어의 상태 문구는 한국어 원문 + 상태 코드(`code`·`arg`)로 오고 앱이 코드로 번역한다. 새 문구를 넣으면 네 표에 모두 추가 — `check-l10n.sh` 가 키 불일치·누락 키를 막는다.
 - 업데이트: `GET /api/desktop/latest` 의 `native` 채널(추가 전용 필드) — sha256 검증 후 분리 스크립트가 교체·재실행 (구 Electron updater.js 에서 이식).
 
 ## 빌드 / 게시

--- a/apps/desktop-native/build.sh
+++ b/apps/desktop-native/build.sh
@@ -19,6 +19,9 @@ test -f "$ROOT/packages/local-bridge-core/dist/index.js" || { echo "core dist �
 # 2) 헬퍼 하네스 (회귀 게이트 — 실패 시 빌드 중단)
 (cd "$ROOT" && node apps/desktop-native/helper/harness.cjs)
 
+# 2-B) 다국어 표 게이트 (네 언어 키 집합·소스 사용 키 — 실패 시 빌드 중단)
+bash check-l10n.sh
+
 # 3) Swift 릴리스 빌드
 (cd OpenMakeCompanion && swift build -c release)
 
@@ -34,6 +37,8 @@ cp "$NODE_BIN" "$APP/Contents/Resources/node"
 chmod +x "$APP/Contents/Resources/node"
 # 앱 아이콘 — 구 Electron 앱에서 이설한 자산 (2026-08-23, apps/desktop 제거)
 cp "$ROOT/apps/desktop-native/assets/icon.icns" "$APP/Contents/Resources/icon.icns"
+# 다국어 표 — ko(개발 언어)·en·ja·zh-Hans (웹 LOCALES 와 같은 네 언어)
+cp -R Localization/*.lproj "$APP/Contents/Resources/"
 
 cat > "$APP/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
@@ -46,6 +51,8 @@ cat > "$APP/Contents/Info.plist" <<PLIST
   <key>CFBundleShortVersionString</key><string>$VERSION</string>
   <key>CFBundleExecutable</key><string>OpenMakeCompanion</string>
   <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleDevelopmentRegion</key><string>ko</string>
+  <key>CFBundleLocalizations</key><array><string>ko</string><string>en</string><string>ja</string><string>zh-Hans</string></array>
   <key>LSMinimumSystemVersion</key><string>14.0</string>
   <key>LSUIElement</key><true/>
   <key>CFBundleIconFile</key><string>icon</string>

--- a/apps/desktop-native/check-l10n.sh
+++ b/apps/desktop-native/check-l10n.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# 컴패니언 다국어 표 게이트 (build.sh·CI 공용) — 실패 시 빌드 중단.
+#   ① 네 언어 .strings 문법  ② 키 집합 일치  ③ Swift 소스가 쓰는 L("키") 가 전부 표에 있음
+# 빠진 키는 그 언어 사용자에게 식별자(menu.quit 등)가 그대로 보이므로 빌드 전에 막는다.
+set -euo pipefail
+cd "$(dirname "$0")"
+L10N="Localization"
+
+keys() {
+  plutil -convert json -o - "$1" \
+    | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(Object.keys(JSON.parse(s)).sort().join("\n")))'
+}
+
+REF="$(keys "$L10N/ko.lproj/Localizable.strings")"
+COUNT=0
+for f in "$L10N"/*.lproj/Localizable.strings; do
+  plutil -lint -s "$f" || { echo "문법 오류: $f"; exit 1; }
+  if [ "$(keys "$f")" != "$REF" ]; then
+    echo "키 불일치 (ko 기준): $f"
+    diff <(echo "$REF") <(keys "$f") || true
+    exit 1
+  fi
+  COUNT=$((COUNT + 1))
+done
+
+USED="$(grep -rhoE '\bL\("[A-Za-z0-9._]+"' OpenMakeCompanion/Sources | sed -E 's/^L\("//; s/"$//' | sort -u)"
+MISSING="$(comm -23 <(echo "$USED") <(echo "$REF"))"
+if [ -n "$MISSING" ]; then
+  echo "소스가 쓰지만 표에 없는 키:"
+  echo "$MISSING"
+  exit 1
+fi
+echo "l10n OK — 키 $(echo "$REF" | wc -l | tr -d ' ')개 × 언어 ${COUNT}개"

--- a/apps/desktop-native/helper/harness.cjs
+++ b/apps/desktop-native/helper/harness.cjs
@@ -118,6 +118,20 @@ const { WebSocketServer } = require('ws');
     const all = await execVia(dev1, { kind: 'listAll' });
     assert.ok(all.entries.includes('seed.txt') && all.entries.includes('subdir/out.txt'), 'listAll');
 
+    // ②-B 서버 단방향 알림(bridge_notice) — 검증 통과분만 approvalPending 이벤트로, 응답 프레임 없음.
+    //      상태 이벤트엔 다국어 표시용 code·arg 가 실린다(앱이 코드로 번역).
+    assert.ok(events.some((e) => e.ev === 'status' && e.folder === realFolder && e.code === 'connected'
+        && e.arg === path.basename(realFolder)), 'status code=connected · arg=폴더명');
+    const framesBefore = received.length;
+    socks.get(dev1).send(JSON.stringify({ type: 'bridge_notice', notice: 'approval_pending', taskId: 'harness-task-notice-0001', toolName: 'file_ops' }));
+    const ap = await waitEv((e) => e.ev === 'approvalPending');
+    assert.deepEqual([ap.taskId, ap.toolName, ap.folder], ['harness-task-notice-0001', 'file_ops', realFolder], 'approvalPending 이벤트');
+    socks.get(dev1).send(JSON.stringify({ type: 'bridge_notice', notice: 'approval_pending', taskId: '../escape', toolName: 'x' }));
+    socks.get(dev1).send(JSON.stringify({ type: 'bridge_notice', notice: 'exec_now', taskId: 'harness-task-notice-0002', toolName: 'x' }));
+    await new Promise((r) => setTimeout(r, 200));
+    assert.equal(events.filter((e) => e.ev === 'approvalPending').length, 1, '부적합 알림은 버린다');
+    assert.equal(received.length, framesBefore, '알림은 단방향 — 헬퍼가 응답 프레임을 보내지 않는다');
+
     // ③ exec — denylist / stdio confirm 승인 / 거부
     assert.equal((await execVia(dev1, { kind: 'exec', command: 'sudo ls' })).exitCode, 126, 'denylist 126');
     const runP = execVia(dev1, { kind: 'exec', command: 'echo -n from-companion', taskId: 'harness-task-000000000001' });

--- a/apps/desktop-native/helper/src/helper.mjs
+++ b/apps/desktop-native/helper/src/helper.mjs
@@ -13,12 +13,19 @@
 // 루트 경로 해시 파생(재접속 안정) — 서버는 루트마다 별개 디바이스로 본다(프로토콜 무변경,
 // 유저당 LOCAL_BRIDGE_MAX_DEVICES 상한은 서버가 강제하고 초과는 status 로 표면화).
 //
+// 승인 대기 알림(0.2.6): 서버 bridge_notice 를 코어가 검증해 onNotice 로 넘기면 approvalPending
+// 이벤트로 앱에 전달한다(앱이 네이티브 알림). 상태 이벤트엔 다국어 표시용 code·arg 를 싣는다
+// (text 는 한국어 원문 — 코드를 모르는 소비자용 폴백).
+//
 // stdio 계약 (한 줄 = JSON 하나, folder = 루트 realpath):
-//   helper→app: {ev:'status',folder?,text} {ev:'confirm',id,command,taskId,base,folder,sandbox}
+//   helper→app: {ev:'status',folder?,text,code?,arg?} {ev:'confirm',id,command,taskId,base,folder,sandbox}
 //               {ev:'autoApprove',count}(전 루트 합계) {ev:'taskEnd',taskId,folder}
+//               {ev:'approvalPending',taskId,toolName,folder}
 //               {ev:'connected',folder} {ev:'disconnected',folder}
 //   app→helper: {cmd:'connect',folder} {cmd:'disconnect',folder?}(folder 없으면 전체)
 //               {cmd:'confirm',id,result:'yes'|'all'|'no'} {cmd:'clearAutoApprove'} {cmd:'quit'}
+//   status code: connecting·connected(arg=폴더명)·server_error(arg=메시지)·reconnecting·closed·idle·
+//                auth_error(arg=메시지)·api_key_required·folder_open_failed(arg=메시지)
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -64,9 +71,12 @@ function totalAutoApprove() {
 }
 
 function connectFolder(folder) {
-  if (!apiKey) { send({ ev: 'status', text: 'API key 필요 — 앱 설정에서 입력' }); return; }
+  if (!apiKey) { send({ ev: 'status', text: 'API key 필요 — 앱 설정에서 입력', code: 'api_key_required' }); return; }
   let real;
-  try { real = fs.realpathSync(folder); } catch (e) { send({ ev: 'status', text: `폴더 열기 실패: ${e.message}` }); return; }
+  try { real = fs.realpathSync(folder); } catch (e) {
+    send({ ev: 'status', text: `폴더 열기 실패: ${e.message}`, code: 'folder_open_failed', arg: e.message });
+    return;
+  }
   const prev = roots.get(real);
   if (prev) prev.connection.disconnect(); // 같은 루트 재연결 = 세션 갱신
   const core = new BridgeCore({
@@ -86,7 +96,8 @@ function connectFolder(folder) {
     deviceId: rootDeviceId(real),
     label: `${os.hostname()} · ${path.basename(real)}`,
     headers: () => ({ Authorization: `Bearer ${apiKey}` }),
-    onStatus: (s) => send({ ev: 'status', folder: real, text: s }),
+    onStatus: (s, code, arg) => send({ ev: 'status', folder: real, text: s, ...(code ? { code } : {}), ...(arg !== undefined ? { arg } : {}) }),
+    onNotice: (n) => send({ ev: 'approvalPending', taskId: n.taskId, toolName: n.toolName, folder: real }),
     shouldReconnect: () => roots.has(real),
   });
   roots.set(real, { core, connection });
@@ -108,7 +119,7 @@ function disconnectFolder(folder) {
   r.connection.disconnect();         // 일괄 승인 회수 포함
   send({ ev: 'disconnected', folder: key });
   send({ ev: 'autoApprove', count: totalAutoApprove() });
-  if (roots.size === 0) send({ ev: 'status', text: '미연결' });
+  if (roots.size === 0) send({ ev: 'status', text: '미연결', code: 'idle' });
 }
 
 const rl = readline.createInterface({ input: process.stdin });
@@ -147,4 +158,4 @@ rl.on('close', shutdown);
 process.on('SIGTERM', shutdown);
 process.on('SIGINT', shutdown);
 
-send({ ev: 'status', text: '미연결' });
+send({ ev: 'status', text: '미연결', code: 'idle' });

--- a/packages/local-bridge-core/src/__tests__/connection.test.ts
+++ b/packages/local-bridge-core/src/__tests__/connection.test.ts
@@ -6,8 +6,10 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { WebSocketServer, type WebSocket as ServerWs } from 'ws';
-import { BridgeConnection } from '../connection';
+import { BridgeConnection, parseNotice } from '../connection';
 import { BridgeCore } from '../core';
+import { NOTICE_TOOL_NAME_MAX } from '../constants';
+import type { BridgeNotice } from '../types';
 
 interface Frame { type?: string; reqId?: string; result?: Record<string, unknown>; deviceId?: string; label?: string; folderName?: string }
 
@@ -141,5 +143,63 @@ describe('BridgeConnection (가짜 WS 서버)', () => {
         await new Promise((r) => setTimeout(r, 300));
         expect(server.connections).toBe(0);
         expect(statuses).toContain('로그인 필요 — 앱에서 로그인 후 다시 연결');
+    });
+
+    /** 알림·상태 코드 검증용 연결 — onNotice·onStatus(code, arg) 를 기록한다. */
+    function noticeConn(notices: BridgeNotice[], codes: Array<[string, string | undefined]> = []): BridgeConnection {
+        const core = new BridgeCore({ folder: base, confirm: async () => 'no', sandboxProfileDir: os.tmpdir() });
+        conn = new BridgeConnection({
+            serverUrl: `http://127.0.0.1:${server.port}`, core, deviceId: 'test-device-n', label: 'unit · notice',
+            headers: () => ({ Authorization: 'Bearer omk_test' }),
+            onStatus: (s, code, arg) => { statuses.push(s); if (code) codes.push([code, arg]); },
+            onNotice: (n) => notices.push(n),
+            reconnectMs: 100,
+        });
+        return conn;
+    }
+
+    it('bridge_notice(approval_pending)는 검증 후 onNotice 로 넘기고 서버로 아무 프레임도 보내지 않는다', async () => {
+        const notices: BridgeNotice[] = [];
+        await noticeConn(notices).connect();
+        await server.waitFor((f) => f.type === 'bridge_hello');
+        await new Promise((r) => setTimeout(r, 50));
+        const before = server.received.length;
+        server.send({ type: 'bridge_notice', notice: 'approval_pending', taskId: 'task-aaaaaaaa-0001', toolName: 'file_ops' });
+        await new Promise((r) => setTimeout(r, 150));
+        expect(notices).toEqual([{ notice: 'approval_pending', taskId: 'task-aaaaaaaa-0001', toolName: 'file_ops' }]);
+        expect(server.received.length).toBe(before); // 단방향 — 응답·실행 없음
+    });
+
+    it('종류·taskId·toolName 이 부적합한 알림은 버린다', async () => {
+        const notices: BridgeNotice[] = [];
+        await noticeConn(notices).connect();
+        await server.waitFor((f) => f.type === 'bridge_hello');
+        server.send({ type: 'bridge_notice', notice: 'run_command', taskId: 'task-aaaaaaaa-0001', toolName: 'x' });
+        server.send({ type: 'bridge_notice', notice: 'approval_pending', taskId: '../../etc', toolName: 'x' });
+        server.send({ type: 'bridge_notice', notice: 'approval_pending', taskId: 'task-aaaaaaaa-0001' });
+        server.send({ type: 'bridge_notice', notice: 'approval_pending', taskId: 'task-aaaaaaaa-0001', toolName: '   ' });
+        await new Promise((r) => setTimeout(r, 150));
+        expect(notices).toEqual([]);
+    });
+
+    it('도구 이름은 제어문자를 걷어내고 길이를 자른다 (서버 발 텍스트는 표시 전용)', () => {
+        const nul = String.fromCharCode(0);
+        const lf = String.fromCharCode(10);
+        const n = parseNotice({ type: 'bridge_notice', notice: 'approval_pending', taskId: 'task-aaaaaaaa-0001', toolName: `ask${nul}_human${lf}` });
+        expect(n?.toolName).toBe('ask_human');
+        const long = 'a'.repeat(NOTICE_TOOL_NAME_MAX + 50);
+        expect(parseNotice({ type: 'bridge_notice', notice: 'approval_pending', taskId: 'task-aaaaaaaa-0001', toolName: long })?.toolName)
+            .toHaveLength(NOTICE_TOOL_NAME_MAX);
+    });
+
+    it('상태 알림에 코드와 치환값을 함께 준다 — 호스트 다국어 표시용', async () => {
+        const codes: Array<[string, string | undefined]> = [];
+        await noticeConn([], codes).connect();
+        await server.waitFor((f) => f.type === 'bridge_hello');
+        await new Promise((r) => setTimeout(r, 50));
+        expect(codes).toEqual(expect.arrayContaining([['connecting', undefined], ['connected', path.basename(fs.realpathSync(base))]]));
+        conn!.disconnect();
+        await new Promise((r) => setTimeout(r, 100));
+        expect(codes[codes.length - 1]).toEqual(['closed', undefined]);
     });
 });

--- a/packages/local-bridge-core/src/connection.ts
+++ b/packages/local-bridge-core/src/connection.ts
@@ -3,11 +3,14 @@
  *
  * 인증 방식은 호스트가 다르다(데스크톱=세션 쿠키+Origin+주기 refresh, CLI=API key 헤더) —
  * headers()/onOpen 훅으로 주입하고 프로토콜 골격만 공유한다.
+ *
+ * 서버→디바이스 프레임은 bridge_exec(요청)·bridge_notice(단방향 알림) 두 가지만 처리하고 나머지는
+ * 무시한다. 알림은 검증을 통과한 것만 호스트(onNotice)에 넘길 뿐 아무 동작도 일으키지 않는다.
  */
 import WebSocket from 'ws';
-import { RECONNECT_MS } from './constants';
+import { NOTICE_KINDS, NOTICE_TOOL_NAME_MAX, RECONNECT_MS, TASK_ID_RE } from './constants';
 import type { BridgeCore } from './core';
-import type { BridgeMsg, BridgeResult } from './types';
+import type { BridgeMsg, BridgeNotice, BridgeResult, BridgeStatusCode } from './types';
 
 export interface BridgeConnectionOptions {
     /** 서버 http(s) URL — ws(s) 로 변환해 접속한다 (서버 WSS 는 { server } 라 경로 무관). */
@@ -17,12 +20,35 @@ export interface BridgeConnectionOptions {
     label: string;
     /** 접속 헤더 — 호출 시점마다 재평가(데스크톱은 최신 세션 쿠키를 읽는다). */
     headers: () => Promise<Record<string, string>> | Record<string, string>;
-    onStatus?: (s: string) => void;
+    /** 상태 알림 — s 는 한국어 고정 문구, code·arg 는 호스트 다국어 표시용(CLI 는 s 만 쓴다). */
+    onStatus?: (s: string, code?: BridgeStatusCode, arg?: string) => void;
+    /** 서버 단방향 알림(검증 통과분만) — 컴패니언은 네이티브 알림으로 띄운다. 미지정이면 무시. */
+    onNotice?: (n: BridgeNotice) => void;
     /** open 직후 훅 — 데스크톱의 주기 refresh 타이머 등. 반환한 cleanup 은 close 시 호출. */
     onOpen?: (ws: WebSocket) => (() => void) | void;
     /** 재연결 여부 — 데스크톱은 폴더 연결 상태, CLI 는 disconnect() 호출 여부로 판단. */
     shouldReconnect?: () => boolean;
     reconnectMs?: number;
+}
+
+/** 제어문자(0x00~0x1f, 0x7f) 제거 — 서버 발 텍스트를 알림에 그대로 싣지 않는다. */
+function stripControl(s: string): string {
+    let out = '';
+    for (const ch of s) {
+        const c = ch.charCodeAt(0);
+        if (c >= 0x20 && c !== 0x7f) out += ch;
+    }
+    return out;
+}
+
+/** bridge_notice 검증 — 화이트리스트 종류·taskId 형식·표시 텍스트 정리. 부적합하면 null. */
+export function parseNotice(m: BridgeMsg): BridgeNotice | null {
+    if (!NOTICE_KINDS.includes(m.notice ?? '')) return null;
+    if (typeof m.taskId !== 'string' || !TASK_ID_RE.test(m.taskId)) return null;
+    if (typeof m.toolName !== 'string') return null;
+    const toolName = stripControl(m.toolName).trim().slice(0, NOTICE_TOOL_NAME_MAX);
+    if (!toolName) return null;
+    return { notice: 'approval_pending', taskId: m.taskId, toolName };
 }
 
 export class BridgeConnection {
@@ -33,7 +59,7 @@ export class BridgeConnection {
 
     constructor(private readonly opts: BridgeConnectionOptions) {}
 
-    private status(s: string): void { this.opts.onStatus?.(s); }
+    private status(s: string, code?: BridgeStatusCode, arg?: string): void { this.opts.onStatus?.(s, code, arg); }
 
     async connect(): Promise<void> {
         this.closed = false;
@@ -46,11 +72,12 @@ export class BridgeConnection {
         try {
             headers = await this.opts.headers();
         } catch (e) {
-            this.status(String((e as Error).message || e));
+            const msg = String((e as Error).message || e);
+            this.status(msg, 'auth_error', msg);
             return;
         }
         this.ws = new WebSocket(wsUrl, { headers });
-        this.status('연결 중…');
+        this.status('연결 중…', 'connecting');
         const folderName = this.opts.core.folderRoot.split('/').filter(Boolean).pop() || '/';
 
         this.ws.on('open', () => setTimeout(() => {
@@ -69,8 +96,13 @@ export class BridgeConnection {
         this.ws.on('message', (d: WebSocket.RawData) => {
             let m: BridgeMsg;
             try { m = JSON.parse(d.toString()) as BridgeMsg; } catch { return; }
-            if (m.type === 'bridge_ready') { this.status(`연결됨: ${folderName}`); return; }
-            if (m.type === 'error') { this.status(`서버 오류: ${m.message ?? ''}`); return; }
+            if (m.type === 'bridge_ready') { this.status(`연결됨: ${folderName}`, 'connected', folderName); return; }
+            if (m.type === 'error') { this.status(`서버 오류: ${m.message ?? ''}`, 'server_error', m.message ?? ''); return; }
+            if (m.type === 'bridge_notice') {
+                const n = parseNotice(m);
+                if (n) this.opts.onNotice?.(n);
+                return; // 단방향 — 응답 프레임을 보내지 않는다
+            }
             if (m.type !== 'bridge_exec') return;
             const t0 = Date.now();
             const done = (result: BridgeResult): void => {
@@ -89,8 +121,11 @@ export class BridgeConnection {
         this.ws.on('close', () => {
             this.openCleanup?.(); this.openCleanup = null;
             const reconnect = !this.closed && (this.opts.shouldReconnect?.() ?? true);
-            if (!reconnect) { this.status(this.closed ? '종료' : '미연결'); return; }
-            this.status('끊김 — 재연결 대기');
+            if (!reconnect) {
+                if (this.closed) this.status('종료', 'closed'); else this.status('미연결', 'idle');
+                return;
+            }
+            this.status('끊김 — 재연결 대기', 'reconnecting');
             if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
             this.reconnectTimer = setTimeout(() => { void this.connect(); }, this.opts.reconnectMs ?? RECONNECT_MS);
         });

--- a/packages/local-bridge-core/src/constants.ts
+++ b/packages/local-bridge-core/src/constants.ts
@@ -20,6 +20,14 @@ export const WORKTREE_BRANCH_PREFIX = 'omk-task/';
 /** taskId 재검증 — 경로·브랜치명에 들어가므로 UUID 문자만 허용(디렉토리 탈출·옵션 주입 차단). */
 export const TASK_ID_RE = /^[a-zA-Z0-9-]{8,64}$/;
 
+/**
+ * 서버→디바이스 단방향 알림(bridge_notice) — 종류 화이트리스트와 표시 텍스트 상한.
+ * 알림은 표시만 하고 아무것도 실행하지 않는다(임의 RPC 금지). 도구 이름은 서버 발 텍스트라
+ * 제어문자를 걷어내고 길이를 자른 뒤에만 호스트로 넘긴다.
+ */
+export const NOTICE_KINDS: readonly string[] = ['approval_pending'];
+export const NOTICE_TOOL_NAME_MAX = 100;
+
 /** folders(하위 폴더 열거) 1회 상한 — 서버 BRIDGE_FOLDERS_MAX_ENTRIES 와 같은 축(디바이스측 강제). */
 export const FOLDERS_MAX_ENTRIES = 200;
 

--- a/packages/local-bridge-core/src/types.ts
+++ b/packages/local-bridge-core/src/types.ts
@@ -25,6 +25,10 @@ export interface BridgeMsg {
     ignoreCase?: boolean;
     /** code_nav grep — 매치 상한(디바이스 캡으로 다시 잘린다). */
     maxResults?: number;
+    /** bridge_notice — 알림 종류(NOTICE_KINDS 화이트리스트). */
+    notice?: string;
+    /** bridge_notice approval_pending — 승인을 기다리는 도구 이름(표시 전용, 서버 발 텍스트). */
+    toolName?: string;
 }
 
 /** code_nav 결과 — 읽기 전용 코드 탐색(grep/files)의 공통 표현. */
@@ -73,6 +77,23 @@ export interface BridgeResult {
     /** code_nav 결과. */
     codeNav?: BridgeCodeNav;
 }
+
+/**
+ * 서버→디바이스 단방향 알림 — BridgeConnection 이 검증한 것만 호스트(onNotice)로 넘어간다.
+ * approval_pending: 로컬 실행 작업이 도구 승인·ask_human 응답을 기다리며 멈췄다.
+ * 디바이스는 표시만 한다(아무것도 실행하지 않는다 — 임의 RPC 금지).
+ */
+export interface BridgeNotice {
+    notice: 'approval_pending';
+    taskId: string;
+    toolName: string;
+}
+
+/**
+ * 연결 상태 코드 — onStatus 의 두 번째 인자. 상태 텍스트는 한국어 고정이라 호스트가 다국어로
+ * 보여 줄 때 이 코드를 쓴다(세 번째 인자 arg = 폴더명·서버 메시지 등 치환값).
+ */
+export type BridgeStatusCode = 'connecting' | 'connected' | 'server_error' | 'reconnecting' | 'closed' | 'idle' | 'auth_error';
 
 /**
  * confirmExec 어댑터 — 실행 전 사용자 확인(비우회 게이트)의 호스트 구현.


### PR DESCRIPTION
## 요약

웹(openmake_llm)과 네이티브 macOS 컴패니언의 대조 점검에서 나온 3건을 고칩니다.

1. **승인 대기 알림이 실제로는 아무에게도 가지 않았다** — 컴패니언은 작업 종료만 알리고 승인 대기·`ask_human` 은 "웹 푸시 담당 — 중복 구현 금지" 로 맡겼는데, 웹 푸시는 설정에서 켜야 하는 opt-in 이라 운영 `push_subscriptions` **0건**(VAPID 키는 설정됨). 로컬 작업이 승인을 기다리며 멈춰도 Mac 에서 알 수 없고 무응답이면 HITL 강등으로 넘어갔다.
2. **API 키 안내 문구 오류** — "웹 설정 → API 키" 라고 안내했으나 bridge 스코프 키 발급은 `/api-access` 페이지다(설정엔 API 키 탭이 없고 `/api-keys` 는 외부 LLM 키 화면으로 redirect).
3. **다국어 미적용** — 웹은 ko·en·ja·zh 4개 언어인데 컴패니언(메뉴·실행 승인 창·알림)은 한국어 고정.

## 변경

**서버 (`apps/api`)**
- `registry.notify(userId, payload, deviceId?)` — 단방향 `bridge_notice`(fire-and-forget). 라우팅은 `request()` 와 같고 프레임엔 화이트리스트 필드만(`notice`·`taskId`·`toolName`). 디바이스 없음·닫힌 소켓·전송 예외는 `false`(throw 없음). 머리 주석의 "서버→디바이스는 bridge_exec 고정 형태만" 을 두 형태로 갱신.
- `TaskExecutor.notifyApprovalPending?` 선택 메서드(`diagnostics?`·`codeNav?` 와 같은 계약) — `RemoteExecutor` 만 구현(docker 샌드박스는 no-op). `TaskRuntime.notifyApprovalPending` 위임.
- `turn-executor` `onApprovalPending`(도구 승인·`ask_human` 공용)이 웹 푸시와 함께 디바이스 알림을 보내고, 웹 푸시 링크를 `/agent-tasks?task=<id>` 로(종전 목록).

**브리지 코어 (`packages/local-bridge-core`)**
- `bridge_notice` → `parseNotice` 검증(종류 `NOTICE_KINDS` 화이트리스트 · `TASK_ID_RE` · 도구명 제어문자 제거·`NOTICE_TOOL_NAME_MAX` 절단) 통과분만 `onNotice`. 응답 프레임 없음, 아무것도 실행하지 않음. 구 디바이스는 모르는 type 을 무시하므로 **추가 전용**.
- `onStatus(s, code?, arg?)` — 상태 텍스트(한국어 고정)와 함께 다국어 표시용 코드. 기존 CLI 는 `s` 만 쓰므로 무영향.

**컴패니언 0.2.6 (`apps/desktop-native`)**
- 헬퍼가 `approvalPending` 이벤트 전달 → 앱이 네이티브 알림(`approval-<taskId>` 식별자로 다중 루트·연속 승인에서도 1건, `ask_human` 은 "질문" 문구, 클릭 → 작업 상세, 작업 종료 시 남은 승인 알림 제거).
- 설정 안내를 `/api-access` 로 정정 + "API 액세스 페이지 열기" 버튼.
- `Localization/{ko,en,ja,zh-Hans}.lproj/Localizable.strings`(71키) + `L("키")`. 상태는 코드로 번역, 업데이트 교체 스크립트의 실패 안내도 env 로 다국어 전달. `CFBundleDevelopmentRegion=ko`(웹 `DEFAULT_LOCALE`).
- `check-l10n.sh` — 4개 표의 키 집합 일치 + 소스가 쓰는 `L("키")` 누락 검사. `build.sh`·CI(`desktop-native.yml` Gate 1-B)에서 실행.

## 검증

- API `tsc --noEmit` 0 · 서버 관련 테스트 77건 + 신규 `bridge-notice.test.ts` 5건 · 코어 테스트 86건(신규 알림·상태 코드 4건) · CLI tsc 0 · lint 오류 0
- 소스를 되돌리면 새 테스트가 실패(코어는 새 export 부재로 컴파일 실패, 서버는 `notify`·`notifyApprovalPending` TS2339) 확인 후 복원
- `build.sh 0.2.6`: 헬퍼 하네스 전 케이스(신규 — 알림 전달·부적합 알림 폐기·단방향·상태 code) · l10n 게이트(71키 × 4언어) · Swift 빌드 · 번들에 4개 lproj·Info.plist 언어 키·codesign OK
- 머지·배포 후: 컴패니언 0.2.6 게시 → 이 Mac 설치본 갱신 → 로컬 실행 작업의 승인 대기에서 네이티브 알림 라이브 확인 예정

## 체크리스트

- [x] `npm run lint` 통과
- [x] 관련 유닛 테스트 통과
- [x] DB 스키마 변경 없음 · 환경변수 추가 없음
- [x] 보안: 서버→디바이스 메시지 형태가 하나 늘었으나 단방향·필드 화이트리스트·디바이스측 검증(표시 전용, 실행 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kbjb3AKkyM97V1poRqCfiQ
