### PR TITLE
feat(desktop): macOS 는 네이티브 컴패니언만 — 업데이트 기본값·게시·브리지에서 Electron 제거

### DIFF
--- a/apps/api/src/config/desktop-update.ts
+++ b/apps/api/src/config/desktop-update.ts
@@ -13,6 +13,6 @@ import * as path from 'path';
 export const DESKTOP_UPDATE = {
     /** dmg + latest.json 보관 디렉토리 */
     DIR: process.env.DESKTOP_UPDATE_DIR || path.join(process.cwd(), 'data', 'desktop-updates'),
-    /** 다운로드 허용 파일명 패턴 — 경로 조작 차단 */
-    FILE_PATTERN: /^OpenMake-[A-Za-z0-9.-]+\.dmg$/,
+    /** 다운로드 허용 파일명 패턴 — 경로 조작 차단. macOS 는 네이티브 컴패니언 dmg 만 (구 Electron dmg 거부, 2026-09-11) */
+    FILE_PATTERN: /^OpenMake-Companion-[A-Za-z0-9.-]+\.dmg$/,
 } as const;

--- a/apps/api/src/routes/__tests__/desktop-update.routes.test.ts
+++ b/apps/api/src/routes/__tests__/desktop-update.routes.test.ts
@@ -1,0 +1,82 @@
+/**
+ * 데스크톱 업데이트 매니페스트 — macOS 는 네이티브 컴패니언만 (2026-09-11).
+ * 최상위(기본) 값은 native 블록을 따르고, 구 Electron 필드·dmg 는 응답·다운로드에서 빠진다.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import express from 'express';
+import request from 'supertest';
+
+const DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'omk-desktop-update-'));
+const NATIVE = { version: '0.2.6', file: 'OpenMake-Companion-0.2.6-arm64.dmg', sha256: 'a'.repeat(64) };
+const ELECTRON = { version: '1.10.0', file: 'OpenMake-1.10.0-arm64.dmg', sha256: 'b'.repeat(64) };
+
+function writeManifest(m: unknown): void {
+    fs.writeFileSync(path.join(DIR, 'latest.json'), JSON.stringify(m));
+}
+
+let app: express.Express;
+
+beforeAll(async () => {
+    process.env.DESKTOP_UPDATE_DIR = DIR; // DESKTOP_UPDATE.DIR 는 모듈 로드 시점에 읽힌다
+    const { default: router } = await import('../desktop-update.routes');
+    app = express();
+    app.use('/api/desktop', router);
+    fs.writeFileSync(path.join(DIR, NATIVE.file), 'companion');
+    fs.writeFileSync(path.join(DIR, ELECTRON.file), 'electron');
+});
+
+afterAll(() => {
+    fs.rmSync(DIR, { recursive: true, force: true });
+    delete process.env.DESKTOP_UPDATE_DIR;
+});
+
+beforeEach(() => fs.rmSync(path.join(DIR, 'latest.json'), { force: true }));
+
+describe('GET /api/desktop/latest', () => {
+    it('최상위(기본) 값은 컴패니언이고 native 블록도 같은 값으로 싣는다', async () => {
+        writeManifest({ native: NATIVE });
+        const res = await request(app).get('/api/desktop/latest');
+        expect(res.status).toBe(200);
+        const url = `/api/desktop/download/${NATIVE.file}`;
+        expect(res.body.data).toEqual({ ...NATIVE, url, native: { ...NATIVE, url } });
+    });
+
+    it('구 Electron 최상위 필드가 남아 있어도 무시하고 컴패니언을 기본으로 낸다', async () => {
+        writeManifest({ ...ELECTRON, native: NATIVE });
+        const res = await request(app).get('/api/desktop/latest');
+        expect(res.status).toBe(200);
+        expect(res.body.data).toMatchObject({ version: NATIVE.version, file: NATIVE.file, sha256: NATIVE.sha256 });
+    });
+
+    it('native 블록이 없으면(Electron 만) 404', async () => {
+        writeManifest(ELECTRON);
+        expect((await request(app).get('/api/desktop/latest')).status).toBe(404);
+    });
+
+    it('native 파일명이 컴패니언 형식이 아니면 404', async () => {
+        writeManifest({ native: { ...NATIVE, file: ELECTRON.file } });
+        expect((await request(app).get('/api/desktop/latest')).status).toBe(404);
+    });
+
+    it('매니페스트가 없으면 404', async () => {
+        expect((await request(app).get('/api/desktop/latest')).status).toBe(404);
+    });
+});
+
+describe('GET /api/desktop/download/:file', () => {
+    it('컴패니언 dmg 는 내려준다', async () => {
+        const res = await request(app).get(`/api/desktop/download/${NATIVE.file}`);
+        expect(res.status).toBe(200);
+        expect(res.headers['content-disposition']).toContain(NATIVE.file);
+    });
+
+    it('구 Electron dmg 는 파일이 남아 있어도 거부한다', async () => {
+        expect((await request(app).get(`/api/desktop/download/${ELECTRON.file}`)).status).toBe(400);
+    });
+
+    it('매니페스트 등 dmg 가 아닌 파일은 거부한다', async () => {
+        expect((await request(app).get('/api/desktop/download/latest.json')).status).toBe(400);
+    });
+});

--- a/apps/api/src/routes/desktop-update.routes.ts
+++ b/apps/api/src/routes/desktop-update.routes.ts
@@ -1,12 +1,18 @@
 /**
- * Desktop 앱 업데이트 배포 — 버전 매니페스트 + dmg 다운로드.
+ * Desktop(macOS) 컴패니언 업데이트 배포 — 버전 매니페스트 + dmg 다운로드.
  *
  * 미서명(ad-hoc) 배포라 Squirrel 자동업데이트를 못 쓰므로, 앱이 이 API 로
  * 최신 버전을 확인하고 dmg 를 받아 자체 교체한다(sha256 은 매니페스트로 검증).
  * 공개 라우트(앱 배포용) — 파일명 화이트리스트로 경로 조작을 차단한다.
  *
- * GET /api/desktop/latest          → { version, file, sha256, url }
- * GET /api/desktop/download/:file  → dmg 스트림
+ * macOS 는 네이티브 컴패니언만 배포한다(2026-09-11). 매니페스트는 `native` 블록 하나이고,
+ * 응답의 최상위(기본) 값도 그 블록을 따른다 — 채널을 모르는 소비자도 컴패니언을 본다.
+ * 구 Electron 앱의 업데이터는 최상위 값을 읽는데, 컴패니언 버전(0.x)이 자기 버전(1.10.0)보다
+ * 낮아 "최신" 으로만 판단한다. 설령 넘어서더라도 그 교체 스크립트는 dmg 안의 `OpenMake.app` 을
+ * 찾지 못해 원래 앱을 다시 연다 — 덮어쓰지 않는다.
+ *
+ * GET /api/desktop/latest          → { version, file, sha256, url, native: { 같은 값 } }
+ * GET /api/desktop/download/:file  → dmg 스트림 (컴패니언 dmg 만)
  *
  * @module routes/desktop-update
  */
@@ -24,25 +30,15 @@ router.get('/latest', (_req: Request, res: Response) => {
     const manifestPath = path.join(DESKTOP_UPDATE.DIR, 'latest.json');
     try {
         const m = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
-            version?: string; file?: string; sha256?: string;
             native?: { version?: string; file?: string; sha256?: string };
         };
-        if (!m.version || !m.file || !DESKTOP_UPDATE.FILE_PATTERN.test(m.file)) {
+        const n = m.native;
+        if (!n?.version || !n.file || !DESKTOP_UPDATE.FILE_PATTERN.test(n.file)) {
             res.status(404).json(notFound('업데이트 매니페스트가 올바르지 않습니다'));
             return;
         }
-        // native 채널(SwiftUI 컴패니언) — 추가 전용: 블록이 없거나 형식이 어긋나면 기존 응답 그대로
-        const n = m.native;
-        const native = n && n.version && n.file && DESKTOP_UPDATE.FILE_PATTERN.test(n.file)
-            ? { version: n.version, file: n.file, sha256: n.sha256 ?? null, url: `/api/desktop/download/${n.file}` }
-            : null;
-        res.json(success({
-            version: m.version,
-            file: m.file,
-            sha256: m.sha256 ?? null,
-            url: `/api/desktop/download/${m.file}`,
-            ...(native ? { native } : {}),
-        }));
+        const native = { version: n.version, file: n.file, sha256: n.sha256 ?? null, url: `/api/desktop/download/${n.file}` };
+        res.json(success({ ...native, native }));
     } catch {
         res.status(404).json(notFound('배포된 데스크톱 업데이트가 없습니다'));
     }

--- a/apps/api/src/sockets/__tests__/ws-bridge-handler.test.ts
+++ b/apps/api/src/sockets/__tests__/ws-bridge-handler.test.ts
@@ -1,0 +1,73 @@
+/**
+ * 로컬 브리지 등록 게이트 — API key(bridge 스코프) 연결만 받는다 (2026-09-11).
+ * JWT/쿠키 연결로 등록하던 것은 구 Electron 데스크톱 앱뿐이었고, macOS 는 네이티브 컴패니언만 지원한다.
+ */
+import type { WebSocket } from 'ws';
+import type { WSMessage } from '../ws-types';
+
+const mockRegister = jest.fn(() => true);
+const mockHandleResult = jest.fn();
+
+jest.mock('../../services/local-bridge/registry', () => ({
+    getLocalBridgeRegistry: () => ({
+        register: (...a: unknown[]) => mockRegister(...(a as [])),
+        handleResult: (...a: unknown[]) => mockHandleResult(...(a as [])),
+        getDeviceIdByWs: () => 'dev-1',
+    }),
+}));
+jest.mock('../../config/local-bridge', () => ({ LOCAL_BRIDGE: { ENABLED: true, MAX_DEVICES: 3 } }));
+
+import { handleBridgeMessage } from '../ws-bridge-handler';
+
+function fakeWs(scopes: string[] | undefined) {
+    const sent: Array<Record<string, unknown>> = [];
+    const raw = {
+        _authenticatedUserId: 'u3',
+        _apiKeyScopes: scopes,
+        send: jest.fn((s: string) => { sent.push(JSON.parse(s) as Record<string, unknown>); }),
+        close: jest.fn(),
+    };
+    return { ws: raw as unknown as WebSocket, raw, sent };
+}
+
+const hello = { type: 'bridge_hello', deviceId: 'dev-1', label: 'mac · work', folderName: 'work' } as unknown as WSMessage;
+const result = { type: 'bridge_result', reqId: 'r-1', result: { ok: true } } as unknown as WSMessage;
+
+beforeEach(() => { mockRegister.mockClear(); mockHandleResult.mockClear(); });
+
+describe('handleBridgeMessage — 연결 방식 게이트', () => {
+    it('JWT/쿠키 연결(스코프 없음)의 bridge_hello 는 등록하지 않고 1008 로 닫는다', async () => {
+        const { ws, raw, sent } = fakeWs(undefined);
+        await handleBridgeMessage(ws, hello);
+        expect(mockRegister).not.toHaveBeenCalled();
+        expect(sent[0]).toMatchObject({ type: 'error' });
+        expect(raw.close).toHaveBeenCalledWith(1008, 'bridge_api_key_required');
+    });
+
+    it('JWT/쿠키 연결의 bridge_result 도 받지 않는다', async () => {
+        const { ws } = fakeWs(undefined);
+        await handleBridgeMessage(ws, result);
+        expect(mockHandleResult).not.toHaveBeenCalled();
+    });
+
+    it('bridge 스코프 API key 는 등록하고 bridge_ready 를 보낸다', async () => {
+        const { ws, raw, sent } = fakeWs(['bridge']);
+        await handleBridgeMessage(ws, hello);
+        expect(mockRegister).toHaveBeenCalledTimes(1);
+        expect(sent).toContainEqual({ type: 'bridge_ready', deviceId: 'dev-1' });
+        expect(raw.close).not.toHaveBeenCalled();
+    });
+
+    it('전권(*) API key 도 등록한다', async () => {
+        const { ws } = fakeWs(['*']);
+        await handleBridgeMessage(ws, hello);
+        expect(mockRegister).toHaveBeenCalledTimes(1);
+    });
+
+    it('bridge 스코프가 없는 API key 는 bridge_scope_required 로 닫는다', async () => {
+        const { ws, raw } = fakeWs(['chat']);
+        await handleBridgeMessage(ws, hello);
+        expect(mockRegister).not.toHaveBeenCalled();
+        expect(raw.close).toHaveBeenCalledWith(1008, 'bridge_scope_required');
+    });
+});

--- a/apps/api/src/sockets/ws-bridge-handler.ts
+++ b/apps/api/src/sockets/ws-bridge-handler.ts
@@ -22,9 +22,16 @@ export async function handleBridgeMessage(ws: WebSocket, msg: WSMessage): Promis
         ws.send(JSON.stringify({ type: 'error', message: '로컬 실행 기능이 비활성화되어 있습니다 (LOCAL_EXECUTOR_ENABLED)' }));
         return;
     }
+    // 브리지는 API key 연결만 받는다 — Companion·CLI 가 이 경로다(ws-auth 는 API key 연결에 항상
+    // 스코프 배열을 싣는다: 미지정 키는 ['*']). JWT/쿠키 연결(_apiKeyScopes=undefined)로 등록하던 것은
+    // 구 Electron 데스크톱 앱뿐이었고, macOS 는 네이티브 컴패니언만 지원하므로(2026-09-11) 거부한다.
+    if (extWs._apiKeyScopes === undefined) {
+        ws.send(JSON.stringify({ type: 'error', message: '로컬 실행은 OpenMake Companion 또는 CLI 로만 연결할 수 있습니다 — bridge 스코프 API key 로 접속하세요' }));
+        try { ws.close(1008, 'bridge_api_key_required'); } catch { /* already closing */ }
+        return;
+    }
     // API key 연결이면 bridge 스코프 필수 — 스코프 없는(예: chat 전용) 키의 브리지 등록 차단.
-    // JWT/쿠키(데스크톱 앱) 연결은 _apiKeyScopes=undefined 라 apiKeyHasScope 가 통과시킨다.
-    if (extWs._apiKeyScopes !== undefined && !apiKeyHasScope(extWs._apiKeyScopes, API_KEY_SCOPES.BRIDGE)) {
+    if (!apiKeyHasScope(extWs._apiKeyScopes, API_KEY_SCOPES.BRIDGE)) {
         ws.send(JSON.stringify({ type: 'error', message: `이 API key 는 '${API_KEY_SCOPES.BRIDGE}' 스코프가 없습니다 — bridge 스코프 키를 발급하세요` }));
         try { ws.close(1008, 'bridge_scope_required'); } catch { /* already closing */ }
         return;

--- a/apps/desktop-native/README.md
+++ b/apps/desktop-native/README.md
@@ -21,7 +21,7 @@ build.sh                 # helper 번들(esbuild) → 하네스 → l10n 게이�
 - **다중 루트(0.2.0)**: 메뉴 "작업 폴더 추가…" 로 여러 루트를 각각 연결 — 루트당 독립 브리지 연결(파생 deviceId = base id + 경로 해시)이라 **서버·프로토콜 무변경**, 웹엔 루트마다 별개 디바이스로 표시(기존 디바이스 선택기 사용). 유저당 총 디바이스 수는 서버 `LOCAL_BRIDGE_MAX_DEVICES`(기본 3)가 강제 — 초과는 해당 루트 상태에 서버 오류로 표면화. 스코프·샌드박스·일괄승인 회수는 루트별 독립(코어 인스턴스 분리).
 - **승인 대기 알림(0.2.6)**: 로컬 실행 작업이 도구 승인·`ask_human` 응답을 기다리며 멈추면 서버가 그 디바이스로 `bridge_notice`(단방향, 필드 화이트리스트)를 보내고 앱이 네이티브 알림을 띄운다(클릭 → `/agent-tasks?task=<id>`). 종전 설계는 "승인 대기 알림은 웹 푸시 담당 — 중복 구현 금지" 였으나, 웹 푸시는 설정에서 켜야 하는 opt-in 이라 운영 구독 0건 = 실제 도달 0 이어서 바꿨다. 코어는 알림을 검증(종류·taskId 형식·도구명 제어문자·길이)해 넘길 뿐 아무것도 실행하지 않고, 구 디바이스는 모르는 type 을 무시한다(추가 전용).
 - **다국어(0.2.6)**: 웹과 같은 네 언어. 문자열은 `L("키")` → `Localization/<lang>.lproj`, 앱 번들 `Contents/Resources` 로 복사하고 `CFBundleDevelopmentRegion=ko`(웹 `DEFAULT_LOCALE`). 헬퍼·코어의 상태 문구는 한국어 원문 + 상태 코드(`code`·`arg`)로 오고 앱이 코드로 번역한다. 새 문구를 넣으면 네 표에 모두 추가 — `check-l10n.sh` 가 키 불일치·누락 키를 막는다.
-- 업데이트: `GET /api/desktop/latest` 의 `native` 채널(추가 전용 필드) — sha256 검증 후 분리 스크립트가 교체·재실행 (구 Electron updater.js 에서 이식).
+- 업데이트: `GET /api/desktop/latest` 의 `native` 블록 — sha256 검증 후 분리 스크립트가 교체·재실행 (구 Electron updater.js 에서 이식). **macOS 는 네이티브 컴패니언만 배포한다(2026-09-11)** — 매니페스트는 native 블록 하나이고 최상위(기본) 값도 그것을 따르며, 구 Electron dmg 는 게시·다운로드에서 제거됐다. 서버 브리지 등록도 API key(bridge 스코프) 연결만 받는다(쿠키 로그인 연결 = 구 Electron 앱 경로 차단).
 
 ## 빌드 / 게시
 
@@ -29,7 +29,7 @@ build.sh                 # helper 번들(esbuild) → 하네스 → l10n 게이�
 npm run build:packages                      # local-bridge-core dist 선행
 bash apps/desktop-native/build.sh 0.1.1     # dist/OpenMake-Companion-<v>-arm64.dmg
 bash scripts/publish-desktop.sh apps/desktop-native/dist/OpenMake-Companion-0.1.1-arm64.dmg
-# → latest.json 의 native 블록만 갱신 (기존 Electron 설치본용 필드는 보존)
+# → latest.json 을 { native } 로 다시 쓴다 (컴패니언 dmg 가 아니면 거부)
 ```
 
 ## 개발/E2E 전용 env 훅 (정식 경로는 Keychain·NSOpenPanel·다이얼로그만)

--- a/scripts/publish-desktop.sh
+++ b/scripts/publish-desktop.sh
@@ -1,41 +1,29 @@
 #!/bin/bash
-# 데스크톱 dmg 를 업데이트 배포 디렉토리에 게시한다 (자체 업데이터용).
+# macOS 컴패니언 dmg 를 업데이트 배포 디렉토리에 게시한다 (자체 업데이터용).
 #   사용법: bash scripts/publish-desktop.sh [dmg경로]
 #   기본:  apps/desktop-native/dist 의 최신 OpenMake-Companion-*.dmg
-# 산출: $DESKTOP_UPDATE_DIR(기본 data/desktop-updates)/ 에 dmg 복사 + latest.json 생성.
+# 산출: $DESKTOP_UPDATE_DIR(기본 data/desktop-updates)/ 에 dmg 복사 + latest.json({ native }) 갱신.
 #
-# native 채널(SwiftUI 컴패니언): 파일명이 OpenMake-Companion-* 이면 latest.json 의
-# `native` 블록만 갱신한다 — Electron 필드(version/file/sha256)는 보존 (추가 전용 계약).
-# Electron 채널은 앱 소스 제거(2026-08-23) 후 신규 게시가 없다 — 기존 설치본의 업데이트
-# 확인이 404 가 되지 않도록 매니페스트의 electron 필드와 배포본은 그대로 두며, 분기는
-# 과거 dmg 재게시가 필요할 때를 위해 남긴다(경로를 인자로 직접 지정).
+# macOS 는 네이티브 컴패니언만 배포한다(2026-09-11) — 구 Electron 채널은 게시·매니페스트·
+# 다운로드에서 모두 제거됐으므로 컴패니언이 아닌 dmg 는 거부한다. 매니페스트는 native 블록
+# 하나로 다시 쓴다(남아 있던 Electron 최상위 필드도 이때 사라진다). 파일명 규칙은 서버
+# config/desktop-update.ts 의 FILE_PATTERN 과 같다.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DIR="${DESKTOP_UPDATE_DIR:-$ROOT/data/desktop-updates}"
 DMG="${1:-$(ls -t "$ROOT"/apps/desktop-native/dist/OpenMake-Companion-*.dmg 2>/dev/null | head -1)}"
 [ -f "$DMG" ] || { echo "dmg 없음: $DMG"; exit 1; }
 FILE="$(basename "$DMG")"
+[[ "$FILE" =~ ^OpenMake-Companion-[A-Za-z0-9.-]+\.dmg$ ]] || { echo "컴패니언 dmg(OpenMake-Companion-*.dmg)만 게시할 수 있습니다: $FILE"; exit 1; }
+VERSION="$(echo "$FILE" | sed -E 's/OpenMake-Companion-([0-9.]+)-.*/\1/')"
 SHA=$(shasum -a 256 "$DMG" | awk '{print $1}')
 mkdir -p "$DIR"
 cp "$DMG" "$DIR/$FILE"
 
-if [[ "$FILE" == OpenMake-Companion-* ]]; then
-  VERSION="$(echo "$FILE" | sed -E 's/OpenMake-Companion-([0-9.]+)-.*/\1/')"
-  CHANNEL=native
-else
-  VERSION="$(echo "$FILE" | sed -E 's/OpenMake-([0-9.]+)-.*/\1/')"
-  CHANNEL=electron
-fi
-
-CHANNEL="$CHANNEL" VERSION="$VERSION" FILE="$FILE" SHA="$SHA" MANIFEST="$DIR/latest.json" node -e '
+VERSION="$VERSION" FILE="$FILE" SHA="$SHA" MANIFEST="$DIR/latest.json" node -e '
 const fs = require("fs");
-const { CHANNEL, VERSION, FILE, SHA, MANIFEST } = process.env;
-let m = {};
-try { m = JSON.parse(fs.readFileSync(MANIFEST, "utf8")); } catch { /* 최초 생성 */ }
-const entry = { version: VERSION, file: FILE, sha256: SHA };
-if (CHANNEL === "native") m.native = entry;
-else m = { ...entry, ...(m.native ? { native: m.native } : {}) };
-fs.writeFileSync(MANIFEST, JSON.stringify(m) + "\n");
+const { VERSION, FILE, SHA, MANIFEST } = process.env;
+fs.writeFileSync(MANIFEST, JSON.stringify({ native: { version: VERSION, file: FILE, sha256: SHA } }) + "\n");
 '
-echo "게시됨($CHANNEL): v$VERSION → $DIR/$FILE"
+echo "게시됨(native): v$VERSION → $DIR/$FILE"
 cat "$DIR/latest.json"


### PR DESCRIPTION
## 요약
macOS 데스크톱은 네이티브 컴패니언(OpenMake Companion)만 지원한다. 구 Electron 앱(Desktop 1.10.0, 2026-08-23 소스 제거)의 배포·업데이트·로컬 실행 경로를 닫는다.

## 변경
- **`GET /api/desktop/latest`**: 매니페스트의 `native` 블록만 읽고, 응답 최상위(기본) 값도 그 블록을 따른다. 구 Electron 최상위 필드는 무시하고, `native` 가 없으면 404.
  - 구 Electron 업데이터는 최상위 값을 읽는데 컴패니언 버전(0.x) ≤ 자기 버전(1.10.0)이라 "최신"으로만 판단한다. 버전이 넘어서도 그 교체 스크립트는 dmg 안의 `OpenMake.app` 을 못 찾아 원래 앱을 다시 연다(덮어쓰지 않음).
  - 컴패니언 업데이터는 종전처럼 `native` 블록을 읽으므로 무영향.
- **다운로드**: 파일명 규칙을 `OpenMake-Companion-*.dmg` 로 좁혀 구 Electron dmg 는 400.
- **`scripts/publish-desktop.sh`**: 컴패니언 dmg 만 받고 `latest.json` 을 `{ native }` 로 다시 쓴다.
- **브리지 등록**(`ws-bridge-handler.ts`): API key 연결만 받는다. JWT/쿠키 연결(`_apiKeyScopes=undefined`)로 등록하던 것은 구 Electron 앱뿐이라 `bridge_api_key_required`(1008)로 거부. Companion·CLI 는 API key 연결이라 무영향(`ws-auth` 는 API key 연결에 항상 스코프 배열을 싣는다 — 미지정 키는 `['*']`).

## 테스트
- 라우트 8건 + 브리지 게이트 5건 = 13건 통과. 소스 변경을 되돌리면 6건 실패(테스트가 수정을 가려냄).
- tsc 0 · eslint 무경고 · `bash -n` 통과.

## 배포 후 후속 (이 PR 밖, 운영 데이터)
1. 라이브에서 기본값·다운로드 거부·쿠키 브리지 거부·컴패니언 재연결 확인
2. `data/desktop-updates/latest.json` 을 `{ native }` 로 정리 + 구 Electron dmg 3개(1.8.1·1.9.0·1.10.0, 약 300MB) 삭제

## 영향 범위(보안)
브리지 등록 경로를 좁히는 변경이다(허용 → 거부). 새로 열리는 경로는 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kbjb3AKkyM97V1poRqCfiQ