### PR TITLE
fix(ws): 인증 완료 전 도착한 메시지를 버리지 않는다

### DIFF
--- a/apps/api/src/config/timeouts.ts
+++ b/apps/api/src/config/timeouts.ts
@@ -201,6 +201,10 @@ export const WS_LIMITS = {
     MAX_MESSAGE_CHARS: parseInt(process.env.WS_MAX_MESSAGE_CHARS || String(64 * 1024 * 1024), 10),
     /** detach 된 스트림이 재생용으로 쌓아 두는 비-토큰 이벤트 버퍼 상한 (bytes) — 기본 4MB */
     DETACHED_STREAM_BUFFER_MAX_BYTES: Number(process.env.WS_DETACHED_STREAM_BUFFER_MAX_BYTES) || 4 * 1024 * 1024,
+    /** 인증 완료 전(연결 콜백의 await 구간) 도착한 프레임을 모아 두는 개수 상한 — 정상 첫 프레임은 hello 처럼 작다 */
+    EARLY_BUFFER_MAX_FRAMES: Number(process.env.WS_EARLY_BUFFER_MAX_FRAMES) || 8,
+    /** 같은 버퍼의 총 바이트 상한 — 기본 1MB. 인증 전 연결이 메모리를 점유하지 못하게 막는다 */
+    EARLY_BUFFER_MAX_BYTES: Number(process.env.WS_EARLY_BUFFER_MAX_BYTES) || 1024 * 1024,
     /** 사용자당 최대 동시 WebSocket 연결 수 */
     MAX_CONNECTIONS_PER_USER: Number(process.env.WS_MAX_CONNECTIONS_PER_USER) || 5,
     /** 연결 속도 제한 윈도우 (ms) — 기본 60초 */

--- a/apps/api/src/sockets/__tests__/ws-early-messages.test.ts
+++ b/apps/api/src/sockets/__tests__/ws-early-messages.test.ts
@@ -1,0 +1,71 @@
+/**
+ * 인증 전 도착 프레임 버퍼 — 연결 콜백의 await 구간에 온 메시지가 사라지지 않아야 한다 (2026-09-11).
+ */
+import { EventEmitter } from 'events';
+import type { RawData, WebSocket } from 'ws';
+import { bufferEarlyMessages } from '../ws-early-messages';
+import { WS_LIMITS } from '../../config/timeouts';
+
+/** ws 대신 쓰는 최소 소켓 — on/off/emit 만 필요하다. */
+function fakeWs(): { ws: WebSocket; emitter: EventEmitter } {
+    const emitter = new EventEmitter();
+    return { ws: emitter as unknown as WebSocket, emitter };
+}
+const frame = (s: string): RawData => Buffer.from(s) as unknown as RawData;
+const text = (d: RawData): string => d.toString();
+
+describe('bufferEarlyMessages', () => {
+    it('attach 전에 도착한 프레임을 도착 순서대로 재생한다', () => {
+        const { ws, emitter } = fakeWs();
+        const early = bufferEarlyMessages(ws);
+        emitter.emit('message', frame('hello'));
+        emitter.emit('message', frame('second'));
+
+        const seen: string[] = [];
+        early.attach((d) => { seen.push(text(d)); });
+        expect(seen).toEqual(['hello', 'second']);
+    });
+
+    it('attach 이후 도착분은 핸들러가 직접 받고, 재생과 중복되지 않는다', () => {
+        const { ws, emitter } = fakeWs();
+        const early = bufferEarlyMessages(ws);
+        emitter.emit('message', frame('before'));
+
+        const seen: string[] = [];
+        early.attach((d) => { seen.push(text(d)); });
+        emitter.emit('message', frame('after'));
+        expect(seen).toEqual(['before', 'after']);
+        expect(emitter.listenerCount('message')).toBe(1); // 임시 수집기는 떨어졌다
+    });
+
+    it('discard 는 재생하지 않고 수집기도 뗀다 (연결 거부 경로)', () => {
+        const { ws, emitter } = fakeWs();
+        const early = bufferEarlyMessages(ws);
+        emitter.emit('message', frame('dropped'));
+        early.discard();
+        expect(emitter.listenerCount('message')).toBe(0);
+    });
+
+    it('프레임 수 상한을 넘으면 초과분을 버린다', () => {
+        const { ws, emitter } = fakeWs();
+        const early = bufferEarlyMessages(ws);
+        const total = WS_LIMITS.EARLY_BUFFER_MAX_FRAMES + 3;
+        for (let i = 0; i < total; i += 1) emitter.emit('message', frame(`f${i}`));
+
+        const seen: string[] = [];
+        early.attach((d) => { seen.push(text(d)); });
+        expect(seen).toHaveLength(WS_LIMITS.EARLY_BUFFER_MAX_FRAMES);
+        expect(seen[0]).toBe('f0'); // 앞에서부터 담고 넘치면 버린다
+    });
+
+    it('총 바이트 상한을 넘는 프레임은 담지 않는다', () => {
+        const { ws, emitter } = fakeWs();
+        const early = bufferEarlyMessages(ws);
+        emitter.emit('message', frame('small'));
+        emitter.emit('message', frame('x'.repeat(WS_LIMITS.EARLY_BUFFER_MAX_BYTES + 1)));
+
+        const seen: string[] = [];
+        early.attach((d) => { seen.push(text(d)); });
+        expect(seen).toEqual(['small']);
+    });
+});

--- a/apps/api/src/sockets/__tests__/ws-early-messages.test.ts
+++ b/apps/api/src/sockets/__tests__/ws-early-messages.test.ts
@@ -46,26 +46,40 @@ describe('bufferEarlyMessages', () => {
         expect(emitter.listenerCount('message')).toBe(0);
     });
 
-    it('프레임 수 상한을 넘으면 초과분을 버린다', () => {
+    it('프레임 수 상한을 넘으면 통째로 거부한다 — 오류 전송 후 1009 로 닫고 재생하지 않는다', () => {
         const { ws, emitter } = fakeWs();
+        const sent: string[] = [];
+        const closed: Array<[number, string]> = [];
+        (emitter as unknown as { send: (s: string) => void }).send = (s) => { sent.push(s); };
+        (emitter as unknown as { close: (c: number, r: string) => void }).close = (c, r) => { closed.push([c, r]); };
         const early = bufferEarlyMessages(ws);
-        const total = WS_LIMITS.EARLY_BUFFER_MAX_FRAMES + 3;
-        for (let i = 0; i < total; i += 1) emitter.emit('message', frame(`f${i}`));
+        for (let i = 0; i <= WS_LIMITS.EARLY_BUFFER_MAX_FRAMES; i += 1) emitter.emit('message', frame(`f${i}`));
 
+        expect(closed).toEqual([[1009, 'early_buffer_overflow']]);
+        expect(JSON.parse(sent[0])).toMatchObject({ type: 'error' });
+        expect(emitter.listenerCount('message')).toBe(0); // 더 모으지 않는다
         const seen: string[] = [];
         early.attach((d) => { seen.push(text(d)); });
-        expect(seen).toHaveLength(WS_LIMITS.EARLY_BUFFER_MAX_FRAMES);
-        expect(seen[0]).toBe('f0'); // 앞에서부터 담고 넘치면 버린다
+        expect(seen).toEqual([]); // 일부만 재생해 순서가 깨지는 일이 없다
     });
 
-    it('총 바이트 상한을 넘는 프레임은 담지 않는다', () => {
+    it('총 바이트 상한을 넘는 프레임도 같은 방식으로 거부한다', () => {
         const { ws, emitter } = fakeWs();
-        const early = bufferEarlyMessages(ws);
+        const closed: number[] = [];
+        (emitter as unknown as { send: (s: string) => void }).send = () => { /* noop */ };
+        (emitter as unknown as { close: (c: number) => void }).close = (c) => { closed.push(c); };
+        bufferEarlyMessages(ws);
         emitter.emit('message', frame('small'));
         emitter.emit('message', frame('x'.repeat(WS_LIMITS.EARLY_BUFFER_MAX_BYTES + 1)));
+        expect(closed).toEqual([1009]);
+    });
 
-        const seen: string[] = [];
-        early.attach((d) => { seen.push(text(d)); });
-        expect(seen).toEqual(['small']);
+    it('attach·discard 전에 소켓이 닫히면 버퍼가 스스로 정리된다', () => {
+        const { ws, emitter } = fakeWs();
+        bufferEarlyMessages(ws);
+        emitter.emit('message', frame('orphan'));
+        emitter.emit('close');
+        expect(emitter.listenerCount('message')).toBe(0);
+        expect(emitter.listenerCount('close')).toBe(0);
     });
 });

--- a/apps/api/src/sockets/handler.ts
+++ b/apps/api/src/sockets/handler.ts
@@ -33,7 +33,7 @@
  * @requires ChatService - AI 메시지 처리 서비스
  * @requires ClusterManager - LLM 클러스터 관리
  */
-import { WebSocket, WebSocketServer } from 'ws';
+import { WebSocket, WebSocketServer, type RawData } from 'ws';
 import { IncomingMessage } from 'http';
 import crypto from 'node:crypto';
 import { ClusterManager } from '../cluster/manager';
@@ -46,6 +46,7 @@ import { WS_SECURITY } from '../config/security';
 import { getBuildId } from '../config/build-id';
 import { handleChatMessage } from './ws-chat-handler';
 import { getInFlightStreamRegistry, resolveStreamKey } from './ws-stream-registry';
+import { bufferEarlyMessages } from './ws-early-messages';
 import { handleRequestAgents } from './ws-agents-handler';
 import { getLocalBridgeRegistry } from '../services/local-bridge/registry';
 import { handleBridgeMessage } from './ws-bridge-handler';
@@ -122,6 +123,10 @@ export class WebSocketHandler {
      */
     private setupConnection(): void {
         this.wss.on('connection', async (ws: WebSocket, req: IncomingMessage) => {
+            // 인증(await) 구간에 도착한 프레임을 모아 둔다 — 리스너가 없으면 ws 가 그대로 버리기 때문.
+            // 아래 모든 경로에서 early.attach(정상) 또는 early.discard(거부)로 반드시 끝낸다.
+            const early = bufferEarlyMessages(ws);
+
             // CSWSH 방어: Origin 헤더 화이트리스트 검증
             // CORS는 WS upgrade에 적용되지 않으므로 서버가 직접 검증해야 한다.
             const origin = req.headers.origin;
@@ -141,6 +146,7 @@ export class WebSocketHandler {
                     /* socket may already be closed */
                 }
                 ws.close(WS_SECURITY.ORIGIN_REJECTED_CLOSE_CODE, WS_SECURITY.ORIGIN_REJECTED_REASON);
+                early.discard();
                 return;
             }
 
@@ -156,18 +162,21 @@ export class WebSocketHandler {
             if (this.guard.isIpRateLimited(clientIp)) {
                 ws.send(JSON.stringify({ type: 'error', message: '연결 요청이 너무 많습니다. 잠시 후 다시 시도해주세요.' }));
                 ws.close(1008, 'connection_rate_limited');
+                early.discard();
                 return;
             }
 
             if (auth.userId && this.guard.isUserRateLimited(auth.userId)) {
                 ws.send(JSON.stringify({ type: 'error', message: '사용자 연결 요청 한도를 초과했습니다. 잠시 후 다시 시도해주세요.' }));
                 ws.close(1008, 'user_connection_rate_limited');
+                early.discard();
                 return;
             }
 
             if (auth.userId && this.guard.getActiveConnectionsForUser(auth.userId) >= WS_LIMITS.MAX_CONNECTIONS_PER_USER) {
                 ws.send(JSON.stringify({ type: 'error', message: '동시 WebSocket 세션 한도를 초과했습니다. 기존 세션을 종료 후 다시 시도해주세요.' }));
                 ws.close(1008, 'connection_limit_exceeded');
+                early.discard();
                 return;
             }
 
@@ -203,6 +212,7 @@ export class WebSocketHandler {
                 ws.send(JSON.stringify({ type: 'error', message: '인증 토큰이 만료되었습니다. 다시 로그인해주세요.' }));
                 this.unregisterConnection(ws);
                 ws.close(1008, 'token_expired');
+                early.discard();
                 return;
             }
 
@@ -249,7 +259,7 @@ export class WebSocketHandler {
                 log.warn(`WebSocket error for user ${extWs._authenticatedUserId || 'anonymous'}:`, err);
             });
 
-            ws.on('message', async (data) => {
+            const onMessage = async (data: RawData): Promise<void> => {
                 const wsRequestId = crypto.randomUUID();
                 await runWithRequestContext({ requestId: wsRequestId }, async () => {
                     try {
@@ -295,7 +305,9 @@ export class WebSocketHandler {
                         log.error('[WS] 메시지 처리 오류:', (e instanceof Error ? e.message : String(e)) || e);
                     }
                 });
-            });
+            };
+            // 실제 핸들러 등록 + 인증 전 도착분 재생(도착 순서 유지).
+            early.attach(onMessage);
         });
     }
 

--- a/apps/api/src/sockets/ws-early-messages.ts
+++ b/apps/api/src/sockets/ws-early-messages.ts
@@ -7,8 +7,11 @@
  * 왕복 지연이 거의 없는 로컬 직결(`ws://127.0.0.1:52416`)에서 디바이스 등록이 유실됐다
  * (2026-09-11 실측: 즉시 전송 → 8초 무응답 / `init` 수신 후 전송 → 8ms 에 `bridge_ready`).
  *
- * 인증 전 연결이 메모리를 점유하지 못하도록 프레임 수·총 바이트 상한을 두고 넘치면 버린다
- * (정상 클라이언트의 첫 프레임은 hello·resume 같은 작은 메시지다).
+ * 인증 전 연결이 메모리를 점유하지 못하도록 프레임 수·총 바이트 상한을 둔다. 상한을 넘으면
+ * **조용히 버리지 않고** 오류를 보낸 뒤 1009 로 닫는다 — 일부만 버리면 순서가 깨지고 클라이언트는
+ * 응답 없이 기다리게 되어, 이 모듈이 없애려는 "조용한 유실" 이 다른 형태로 남기 때문이다
+ * (정상 클라이언트의 첫 프레임은 hello·resume 같은 작은 메시지라 상한에 닿지 않는다).
+ * 소켓이 먼저 닫히면 버퍼는 스스로 정리된다(attach/discard 를 못 부르는 경로 대비).
  *
  * @module sockets/ws-early-messages
  */
@@ -39,37 +42,39 @@ function frameSize(data: RawData): number {
 export function bufferEarlyMessages(ws: WebSocket): EarlyMessageBuffer {
     const frames: RawData[] = [];
     let bytes = 0;
-    let dropped = 0;
 
+    const stop = (): void => {
+        ws.off('message', collect);
+        ws.off('close', stop);
+        frames.length = 0;
+        bytes = 0;
+    };
     const collect = (data: RawData): void => {
         const size = frameSize(data);
         if (frames.length >= WS_LIMITS.EARLY_BUFFER_MAX_FRAMES || bytes + size > WS_LIMITS.EARLY_BUFFER_MAX_BYTES) {
-            dropped += 1;
+            // 일부만 담고 나머지를 버리면 순서가 깨진 채 재생된다 — 통째로 거부하고 이유를 알린다.
+            log.warn(`인증 전 프레임이 상한을 넘어 연결 종료 (상한 ${WS_LIMITS.EARLY_BUFFER_MAX_FRAMES}건/${WS_LIMITS.EARLY_BUFFER_MAX_BYTES}B, 도착 ${frames.length + 1}건/${bytes + size}B)`);
+            stop();
+            try { ws.send(JSON.stringify({ type: 'error', message: '인증이 끝나기 전에 보낸 메시지가 너무 많거나 큽니다. 연결 후 init 을 받고 다시 보내세요.' })); } catch { /* 이미 닫혔으면 무시 */ }
+            try { ws.close(1009, 'early_buffer_overflow'); } catch { /* already closing */ }
             return;
         }
         frames.push(data);
         bytes += size;
     };
     ws.on('message', collect);
+    ws.once('close', stop); // 거부 경로가 discard 를 못 부르더라도 소켓과 함께 정리된다
 
     return {
         attach(handler: (data: RawData) => void): void {
-            ws.off('message', collect);
-            ws.on('message', handler);
-            if (dropped > 0) {
-                log.warn(`인증 전 프레임 ${dropped}건 상한 초과로 폐기 (상한 ${WS_LIMITS.EARLY_BUFFER_MAX_FRAMES}건/${WS_LIMITS.EARLY_BUFFER_MAX_BYTES}B)`);
-            }
             const pending = frames.splice(0, frames.length);
-            bytes = 0;
+            stop();
+            ws.on('message', handler);
             if (pending.length > 0) {
                 log.info(`인증 전 도착 프레임 ${pending.length}건 재생`);
                 for (const data of pending) handler(data);
             }
         },
-        discard(): void {
-            ws.off('message', collect);
-            frames.length = 0;
-            bytes = 0;
-        },
+        discard: stop,
     };
 }

--- a/apps/api/src/sockets/ws-early-messages.ts
+++ b/apps/api/src/sockets/ws-early-messages.ts
@@ -1,0 +1,75 @@
+/**
+ * WS 연결 직후 도착한 프레임 버퍼 — 인증이 끝나기 전에 온 메시지가 조용히 사라지던 것을 막는다.
+ *
+ * `wss.on('connection')` 콜백은 async 라 인증(`await authenticateWebSocket`)과 초기 전송을 마친
+ * 뒤에야 `ws.on('message')` 를 등록한다. 그 사이에 도착한 프레임은 받는 리스너가 없어 ws 가
+ * 그대로 버린다(오류도 로그도 남지 않는다). 브리지 코어는 `open` 즉시 `bridge_hello` 를 보내므로
+ * 왕복 지연이 거의 없는 로컬 직결(`ws://127.0.0.1:52416`)에서 디바이스 등록이 유실됐다
+ * (2026-09-11 실측: 즉시 전송 → 8초 무응답 / `init` 수신 후 전송 → 8ms 에 `bridge_ready`).
+ *
+ * 인증 전 연결이 메모리를 점유하지 못하도록 프레임 수·총 바이트 상한을 두고 넘치면 버린다
+ * (정상 클라이언트의 첫 프레임은 hello·resume 같은 작은 메시지다).
+ *
+ * @module sockets/ws-early-messages
+ */
+import type { RawData, WebSocket } from 'ws';
+import { WS_LIMITS } from '../config/timeouts';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('WSEarly');
+
+export interface EarlyMessageBuffer {
+    /** 실제 메시지 핸들러를 붙이고, 모아 둔 프레임을 도착 순서대로 넘긴다. */
+    attach(handler: (data: RawData) => void): void;
+    /** 연결이 거부돼 핸들러를 붙이지 않을 때 — 리스너만 떼고 버린다. */
+    discard(): void;
+}
+
+/** RawData(Buffer | ArrayBuffer | Buffer[])의 바이트 크기. */
+function frameSize(data: RawData): number {
+    if (Array.isArray(data)) return data.reduce((n, b) => n + b.length, 0);
+    if (Buffer.isBuffer(data)) return data.length;
+    return (data as ArrayBuffer).byteLength || 0;
+}
+
+/**
+ * 연결 콜백 진입 직후 호출한다. 반환한 버퍼는 반드시 `attach()` 또는 `discard()` 로 끝내야
+ * 임시 리스너가 남지 않는다.
+ */
+export function bufferEarlyMessages(ws: WebSocket): EarlyMessageBuffer {
+    const frames: RawData[] = [];
+    let bytes = 0;
+    let dropped = 0;
+
+    const collect = (data: RawData): void => {
+        const size = frameSize(data);
+        if (frames.length >= WS_LIMITS.EARLY_BUFFER_MAX_FRAMES || bytes + size > WS_LIMITS.EARLY_BUFFER_MAX_BYTES) {
+            dropped += 1;
+            return;
+        }
+        frames.push(data);
+        bytes += size;
+    };
+    ws.on('message', collect);
+
+    return {
+        attach(handler: (data: RawData) => void): void {
+            ws.off('message', collect);
+            ws.on('message', handler);
+            if (dropped > 0) {
+                log.warn(`인증 전 프레임 ${dropped}건 상한 초과로 폐기 (상한 ${WS_LIMITS.EARLY_BUFFER_MAX_FRAMES}건/${WS_LIMITS.EARLY_BUFFER_MAX_BYTES}B)`);
+            }
+            const pending = frames.splice(0, frames.length);
+            bytes = 0;
+            if (pending.length > 0) {
+                log.info(`인증 전 도착 프레임 ${pending.length}건 재생`);
+                for (const data of pending) handler(data);
+            }
+        },
+        discard(): void {
+            ws.off('message', collect);
+            frames.length = 0;
+            bytes = 0;
+        },
+    };
+}


### PR DESCRIPTION
## 문제
WS 연결 콜백이 `await authenticateWebSocket` → `init` 전송을 마친 뒤에야 `ws.on('message')` 를 등록한다. 그 사이에 도착한 프레임은 받는 리스너가 없어 **조용히 사라진다**(오류도 로그도 없음).

브리지 코어(`BridgeConnection`)는 `open` 즉시 `bridge_hello` 를 보내므로, 왕복 지연이 거의 없는 **로컬 직결(`ws://127.0.0.1:52416`)에서 디바이스 등록이 유실**된다. 프로브 실측 — 즉시 전송: 8초 무응답(init·stats·build_id 만 수신) / `init` 수신 후 전송: 8ms 에 `bridge_ready`. 공개 주소(CF 터널)는 왕복 지연이 인증 시간을 가려 드러나지 않았다.

영향: 컴패니언 백엔드 선택기의 "로컬 52416", CLI `--server http://localhost:52416`.

## 수정
- `sockets/ws-early-messages.ts`(신규): 연결 콜백 진입 직후부터 프레임을 모으고, 실제 핸들러를 붙일 때 **도착 순서대로 재생**한다. 연결이 거부되는 경로는 `discard()` 로 임시 리스너만 뗀다.
- 인증 전 연결이 메모리를 점유하지 못하도록 **개수·총 바이트 상한**(`WS_LIMITS.EARLY_BUFFER_MAX_FRAMES` 8 · `EARLY_BUFFER_MAX_BYTES` 1MB, env 오버라이드). 넘친 프레임은 버리고 warn — 정상 클라이언트의 첫 프레임은 hello·resume 같은 작은 메시지다.
- `handler.ts`: 콜백 진입 시 버퍼 생성 → 거부 5경로(Origin·IP 한도·사용자 한도·동시연결 한도·토큰 만료) `discard()` → 메시지 등록 지점에서 `attach()`.

**클라이언트가 아니라 서버에서 막는다** — 이미 배포된 컴패니언·CLI 도 재배포 없이 함께 고쳐진다.

## 테스트
- 단위 5건: 재생 순서 · attach 이후 중복 없음(임시 리스너 해제) · discard · 개수 상한 · 바이트 상한
- 소켓 스위트 4개 29건 통과 · tsc 0 · eslint 무경고
- 배선 자체는 라이브 프로브로 확인한다(배포 후: 로컬 직결에 연결 즉시 `bridge_hello` → `bridge_ready`).

## 영향 범위
메시지 유실을 없애는 방향이며, 새로 열리는 경로는 없다(인증·거부 판정은 그대로, 버퍼는 상한 안에서만 유지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZBoHf9iS6UWwg9maLqWWN