### PR TITLE
feat(modality): 모달리티별 모델 배정 축(이미지·비전·영상·오디오) + IMAGE_GEN_MODEL 고정 호출 폐기

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1569,7 +1569,7 @@ APNS_PRIVATE_KEY=
 # MODALITY_VIDEO_WAIT_MS=300000          # generate_video 가 한 호출 안에서 완료를 기다리는 상한(초과 시 작업 id 반환 → get_video)
 # MODALITY_VIDEO_POLL_INTERVAL_MS=10000
 # MODALITY_VIDEO_DOWNLOAD_TIMEOUT_MS=120000
-# ※ hasa 영상(jobs-v1)은 LiteLLM pass-through 경유 — litellm.env 에 HASA_API_KEY 필요 (scripts/vllm/litellm.config.yaml)
+# ※ hasa 영상(jobs-v1 커스텀 API)만 게이트웨이가 프록시 못 해 사용자 BYOK 로 provider 직결(SSRF 고정 fetch) — 나머지는 전부 게이트웨이
 # 같은 턴 generate_image 다중 호출 병렬 실행 (기본 true — false 로 순차 복귀)
 # IMAGE_GEN_PARALLEL_ENABLED=true
 # 이미지 병렬 생성 동시 상한 (기본 3 — FLUX 서버 큐 과점유 방지)

--- a/.env.example
+++ b/.env.example
@@ -1547,10 +1547,15 @@ APNS_KEY_ID=
 APNS_TEAM_ID=
 APNS_PRIVATE_KEY=
 
-# 이미지 생성 — LiteLLM image_generation 모델명 (vLLM-Omni FLUX.2-klein). 미설정 시 generate_image 도구 비활성
-IMAGE_GEN_MODEL=flux2-klein
-# 이미지 생성 타임아웃 ms (기본 180000)
-IMAGE_GEN_TIMEOUT_MS=180000
+# ⚠️ 폐기 예정 (2026-09-12) — 이미지 생성 모델은 이제 모달리티 배정(DB modality_models, 설정 → 모델 & 응답 →
+# 모달리티 / 관리자 → 모델 역할)이 SoT 다. 이 값은 전역 image_gen 행이 없을 때 부팅 1회 시더로만 읽히고
+# 다음 배포에서 제거된다. 새 배포에선 비워 두고 관리자 UI 에서 배정할 것.
+# IMAGE_GEN_MODEL=flux2-klein
+# 모달리티 코드 기본값(전역 DB 행 없을 때) — 로컬 LiteLLM alias 만
+# MODALITY_DEFAULT_IMAGE_GEN=local-llm:flux2-klein
+# MODALITY_DEFAULT_EMBEDDING=local-llm:bge-m3
+# 이미지 생성 1건 타임아웃 ms (기본 180000, 구 IMAGE_GEN_TIMEOUT_MS 승계)
+# MODALITY_IMAGE_GEN_TIMEOUT_MS=180000
 # 같은 턴 generate_image 다중 호출 병렬 실행 (기본 true — false 로 순차 복귀)
 # IMAGE_GEN_PARALLEL_ENABLED=true
 # 이미지 병렬 생성 동시 상한 (기본 3 — FLUX 서버 큐 과점유 방지)

--- a/.env.example
+++ b/.env.example
@@ -1556,6 +1556,20 @@ APNS_PRIVATE_KEY=
 # MODALITY_DEFAULT_EMBEDDING=local-llm:bge-m3
 # 이미지 생성 1건 타임아웃 ms (기본 180000, 구 IMAGE_GEN_TIMEOUT_MS 승계)
 # MODALITY_IMAGE_GEN_TIMEOUT_MS=180000
+# vision 브리지(역할 모델이 비전 미지원일 때 첨부 이미지 → 텍스트) — 타임아웃·이미지 상한·응답 토큰
+# MODALITY_VISION_TIMEOUT_MS=90000
+# MODALITY_VISION_MAX_IMAGES=8
+# MODALITY_VISION_MAX_TOKENS=1500
+# TTS/STT/영상 — 타임아웃·상한 (도구는 의도 턴에만 노출: config/modality MODALITY_TOOL_INTENT_GATES)
+# MODALITY_TTS_TIMEOUT_MS=120000
+# MODALITY_TTS_MAX_CHARS=4000
+# MODALITY_STT_TIMEOUT_MS=180000
+# MODALITY_STT_MAX_BYTES=26214400
+# MODALITY_VIDEO_SUBMIT_TIMEOUT_MS=60000
+# MODALITY_VIDEO_WAIT_MS=300000          # generate_video 가 한 호출 안에서 완료를 기다리는 상한(초과 시 작업 id 반환 → get_video)
+# MODALITY_VIDEO_POLL_INTERVAL_MS=10000
+# MODALITY_VIDEO_DOWNLOAD_TIMEOUT_MS=120000
+# ※ hasa 영상(jobs-v1)은 LiteLLM pass-through 경유 — litellm.env 에 HASA_API_KEY 필요 (scripts/vllm/litellm.config.yaml)
 # 같은 턴 generate_image 다중 호출 병렬 실행 (기본 true — false 로 순차 복귀)
 # IMAGE_GEN_PARALLEL_ENABLED=true
 # 이미지 병렬 생성 동시 상한 (기본 3 — FLUX 서버 큐 과점유 방지)

--- a/apps/api/src/config/modality.ts
+++ b/apps/api/src/config/modality.ts
@@ -102,20 +102,18 @@ export const STT_ALLOWED_EXTS: ReadonlySet<string> = new Set(['mp3', 'wav', 'm4a
 export const VIDEO_GEN_DEFAULT_SECONDS = '4';
 export const VIDEO_GEN_DEFAULT_SIZE = '720x1280';
 /**
- * 영상 생성 provider 어댑터 — OpenAI `/v1/videos` 규격이 아닌 provider 는 LiteLLM **pass-through**
- * (`general_settings.pass_through_endpoints`, 정적 헤더로 upstream 키 주입 — scripts/vllm/litellm.config.yaml)
- * 경유로 부른다. LiteLLM 1.89.4 pass-through 는 클라이언트 헤더를 전달하지 못하므로(설정 모델에
- * forward_headers 없음, `extra: forbid`) 이 부류는 **서버 키(LiteLLM env) 전용 = 전역 배정만** 가능하다.
- * 호출은 여전히 게이트웨이 하나다.
+ * 영상 생성 provider 어댑터 — OpenAI `/v1/videos` 규격이 아닌 provider(hasa: `POST /videos/generations`
+ * → `GET /jobs/{id}` → `artifact_url`)는 LiteLLM 이 프록시하지 못한다(1.89.4 pass-through 는 클라이언트
+ * 헤더를 전달하지 못해 사용자 BYOK 를 실을 수 없고, hasa 는 `Authorization: Bearer` 만 받는다 — 2026-09-12 실측).
+ * 사용자별 키로 쓰기 위해 이 부류만 **앱이 직결**(SSRF 고정 fetch, 문서화된 예외 — chatgpt OAuth 와 같은 부류)한다.
+ * 이미지·오디오·비전·OpenAI 규격 영상은 그대로 게이트웨이 하나다.
  */
 export interface VideoProviderAdapter {
     kind: 'openai-videos' | 'jobs-v1';
-    /** jobs-v1: 게이트웨이 pass-through 접두 경로 (LiteLLM path) */
-    passThroughPrefix?: string;
-    /** jobs-v1: 제출·상태·산출물 경로 (접두 뒤) — `{id}` 치환 */
+    /** jobs-v1: 제출·상태 경로 (provider base 뒤) — `{id}` 치환 */
     submitPath?: string;
     statusPath?: string;
-    /** 상태 응답에서 산출물 URL 필드(접두 상대 경로면 pass-through 접두를 붙인다) */
+    /** 상태 응답에서 산출물 URL 필드(base 상대 경로면 base 를 붙인다) */
     artifactField?: string;
     doneStatuses?: readonly string[];
     failStatuses?: readonly string[];
@@ -123,7 +121,6 @@ export interface VideoProviderAdapter {
 export const VIDEO_PROVIDER_ADAPTERS: Record<string, VideoProviderAdapter> = {
     hasa: {
         kind: 'jobs-v1',
-        passThroughPrefix: '/passthrough/hasa',
         submitPath: '/videos/generations',
         statusPath: '/jobs/{id}',
         artifactField: 'artifact_url',

--- a/apps/api/src/config/modality.ts
+++ b/apps/api/src/config/modality.ts
@@ -96,6 +96,16 @@ export const IMAGE_GEN_DEFAULT_SIZE = '1024x1024';
 export const TTS_ALLOWED_FORMATS: ReadonlySet<string> = new Set(['mp3', 'wav', 'opus', 'aac', 'flac']);
 export const TTS_DEFAULT_FORMAT = 'mp3';
 export const TTS_DEFAULT_VOICE = 'alloy';
+/**
+ * provider 별 모달리티 기본 params — 배정 params(사용자 입력) 가 없을 때 적용. 실측 규격 차이를 흡수한다
+ * (hasa melotts-ko: voice 는 `KR` 만, 형식은 `wav` 만 — 2026-09-12). 우선순위: 도구 인자 > 배정 params > 이 표 > 전역 기본.
+ */
+export const PROVIDER_MODALITY_PARAM_DEFAULTS: Record<string, Partial<Record<Modality, Record<string, string>>>> = {
+    hasa: { tts: { voice: 'KR', format: 'wav' } },
+};
+export function providerParamDefaults(providerId: string, modality: Modality): Record<string, string> {
+    return PROVIDER_MODALITY_PARAM_DEFAULTS[providerId]?.[modality] ?? {};
+}
 /** STT 입력으로 허용하는 오디오 확장자 */
 export const STT_ALLOWED_EXTS: ReadonlySet<string> = new Set(['mp3', 'wav', 'm4a', 'ogg', 'opus', 'flac', 'webm', 'mp4']);
 /** 영상 생성 기본 인자 (OpenAI videos 규격 — provider 가 다르면 params 로 덮어쓴다) */

--- a/apps/api/src/config/modality.ts
+++ b/apps/api/src/config/modality.ts
@@ -1,0 +1,95 @@
+/**
+ * ============================================================
+ * Modality — 모달리티별 모델 배정 레지스트리 (L2 SoT)
+ * ============================================================
+ *
+ * "어떤 입출력을 어느 모델이 처리하는가"의 축. "역할&모델"(config/model-roles —
+ * 누가 텍스트 LLM 을 쓰는가)과 **별개**이며 텍스트 생성은 여기 넣지 않는다.
+ *
+ * 호출은 전부 LiteLLM 게이트웨이 하나로만 간다 — 로컬 모델은 게이트웨이 alias,
+ * 외부 provider 는 `LLM_GATEWAY_PROVIDERS` 에 편입된 것만 배정 가능(direct provider 거부).
+ *
+ * 저장은 L3 `modality_models`(scope='__global__' | user_id) — 해석 우선순위
+ * 사용자 오버라이드 → 전역 DB → 이 파일의 코드 기본값. env 계층은 두지 않는다
+ * (구 `IMAGE_GEN_MODEL` 은 부팅 1회 시더로만 읽고 다음 배포에서 제거).
+ *
+ * @module config/modality
+ */
+
+/** 모달리티 목록 — DB CHECK(117_modality_models.sql)와 정합 유지할 것 */
+export type Modality = 'image_gen' | 'image_edit' | 'vision' | 'video_gen' | 'stt' | 'tts' | 'embedding';
+
+export const MODALITIES: ReadonlyArray<Modality> = [
+    'image_gen', 'image_edit', 'vision', 'video_gen', 'stt', 'tts', 'embedding',
+];
+
+/** 사용자 오버라이드(BYOK)를 허용하는 모달리티 — 전부 허용. 제한이 필요해지면 여기서 뺀다. */
+export const USER_ASSIGNABLE_MODALITIES: ReadonlyArray<Modality> = MODALITIES;
+
+export const GLOBAL_MODALITY_SCOPE = '__global__';
+
+/** 모달리티가 쓰는 LiteLLM OpenAI 호환 엔드포인트 (게이트웨이 base 뒤에 붙는 경로) */
+export const MODALITY_ENDPOINT: Record<Modality, string> = {
+    image_gen: '/v1/images/generations',
+    image_edit: '/v1/images/edits',
+    vision: '/v1/chat/completions',
+    video_gen: '/v1/videos',
+    stt: '/v1/audio/transcriptions',
+    tts: '/v1/audio/speech',
+    embedding: '/v1/embeddings',
+};
+
+/**
+ * 코드 기본값 — 전역 DB 행이 없을 때. 로컬 alias 는 LiteLLM `litellm.config.yaml` 의
+ * model_name 과 일치해야 한다(scripts/vllm/litellm.config.yaml 참조본).
+ * 값이 없는 모달리티는 "미배정" — 도구가 안내 메시지로 거절한다(조용한 폴백 금지).
+ */
+export const MODALITY_DEFAULTS: Partial<Record<Modality, string>> = {
+    image_gen: process.env.MODALITY_DEFAULT_IMAGE_GEN || 'local-llm:flux2-klein',
+    embedding: process.env.MODALITY_DEFAULT_EMBEDDING || 'local-llm:bge-m3',
+};
+
+/** 모달리티별 호출 상한 — 호출부가 명명 상수로 읽는다(인라인 리터럴 금지) */
+export const MODALITY_LIMITS = {
+    /** 이미지 생성 1건 타임아웃 ms (디퓨전 1장 수십 초). 구 IMAGE_GEN_TIMEOUT_MS 승계. */
+    IMAGE_GEN_TIMEOUT_MS: parseInt(process.env.MODALITY_IMAGE_GEN_TIMEOUT_MS || process.env.IMAGE_GEN_TIMEOUT_MS || '180000', 10),
+    /** params JSONB 허용 키 — 모달리티별 화이트리스트(모르는 키는 저장 시 버린다) */
+    PARAM_KEYS: {
+        image_gen: ['size', 'quality', 'style'],
+        image_edit: ['size'],
+        vision: ['detail'],
+        video_gen: ['size', 'seconds'],
+        stt: ['language'],
+        tts: ['voice', 'format'],
+        embedding: ['dimensions'],
+    } as Record<Modality, readonly string[]>,
+    /** params 값 문자열 길이 상한 */
+    PARAM_VALUE_MAX_CHARS: 64,
+    /** fullId 길이 상한 (역할 배정과 동일) */
+    FULL_ID_MAX_CHARS: 200,
+    /** 전역 행 캐시 TTL ms (역할 해석기와 동일 60s, 같은 프로세스 변경은 즉시 무효화) */
+    GLOBAL_CACHE_TTL_MS: 60_000,
+} as const;
+
+/** 이미지 생성 허용 size 화이트리스트 (OpenAI images API 형식) */
+export const IMAGE_GEN_ALLOWED_SIZES: ReadonlySet<string> = new Set(['1024x1024', '768x1024', '1024x768', '512x512']);
+export const IMAGE_GEN_DEFAULT_SIZE = '1024x1024';
+
+export function isModality(value: string): value is Modality {
+    return (MODALITIES as readonly string[]).includes(value);
+}
+
+/** params 를 화이트리스트 키·문자열 값으로 정제 — 저장 직전 1곳에서만 호출 */
+export function sanitizeModalityParams(modality: Modality, input: unknown): Record<string, string> {
+    if (!input || typeof input !== 'object') return {};
+    const allowed = MODALITY_LIMITS.PARAM_KEYS[modality];
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
+        if (!allowed.includes(k)) continue;
+        if (typeof v !== 'string' && typeof v !== 'number') continue;
+        const s = String(v).trim();
+        if (!s || s.length > MODALITY_LIMITS.PARAM_VALUE_MAX_CHARS) continue;
+        out[k] = s;
+    }
+    return out;
+}

--- a/apps/api/src/config/modality.ts
+++ b/apps/api/src/config/modality.ts
@@ -53,6 +53,23 @@ export const MODALITY_DEFAULTS: Partial<Record<Modality, string>> = {
 export const MODALITY_LIMITS = {
     /** 이미지 생성 1건 타임아웃 ms (디퓨전 1장 수십 초). 구 IMAGE_GEN_TIMEOUT_MS 승계. */
     IMAGE_GEN_TIMEOUT_MS: parseInt(process.env.MODALITY_IMAGE_GEN_TIMEOUT_MS || process.env.IMAGE_GEN_TIMEOUT_MS || '180000', 10),
+    /** vision 브리지(첨부 이미지 → 텍스트) 1회 호출 타임아웃 ms */
+    VISION_BRIDGE_TIMEOUT_MS: parseInt(process.env.MODALITY_VISION_TIMEOUT_MS || '90000', 10),
+    /** vision 브리지에 넘길 이미지 상한(초과분은 건너뛰고 안내) — vLLM --limit-mm-per-prompt 와 같은 8 */
+    VISION_BRIDGE_MAX_IMAGES: parseInt(process.env.MODALITY_VISION_MAX_IMAGES || '8', 10),
+    /** vision 브리지 응답 max_tokens */
+    VISION_BRIDGE_MAX_TOKENS: parseInt(process.env.MODALITY_VISION_MAX_TOKENS || '1500', 10),
+    /** TTS 1회 타임아웃 ms · 입력 글자 상한 */
+    TTS_TIMEOUT_MS: parseInt(process.env.MODALITY_TTS_TIMEOUT_MS || '120000', 10),
+    TTS_MAX_CHARS: parseInt(process.env.MODALITY_TTS_MAX_CHARS || '4000', 10),
+    /** STT 1회 타임아웃 ms · 오디오 바이트 상한(OpenAI 규격 25MB) */
+    STT_TIMEOUT_MS: parseInt(process.env.MODALITY_STT_TIMEOUT_MS || '180000', 10),
+    STT_MAX_BYTES: parseInt(process.env.MODALITY_STT_MAX_BYTES || String(25 * 1024 * 1024), 10),
+    /** 영상 생성 — 제출 타임아웃 · 한 도구 호출 안에서 완료를 기다리는 상한 · 폴링 간격 */
+    VIDEO_SUBMIT_TIMEOUT_MS: parseInt(process.env.MODALITY_VIDEO_SUBMIT_TIMEOUT_MS || '60000', 10),
+    VIDEO_WAIT_MS: parseInt(process.env.MODALITY_VIDEO_WAIT_MS || '300000', 10),
+    VIDEO_POLL_INTERVAL_MS: parseInt(process.env.MODALITY_VIDEO_POLL_INTERVAL_MS || '10000', 10),
+    VIDEO_DOWNLOAD_TIMEOUT_MS: parseInt(process.env.MODALITY_VIDEO_DOWNLOAD_TIMEOUT_MS || '120000', 10),
     /** params JSONB 허용 키 — 모달리티별 화이트리스트(모르는 키는 저장 시 버린다) */
     PARAM_KEYS: {
         image_gen: ['size', 'quality', 'style'],
@@ -74,6 +91,63 @@ export const MODALITY_LIMITS = {
 /** 이미지 생성 허용 size 화이트리스트 (OpenAI images API 형식) */
 export const IMAGE_GEN_ALLOWED_SIZES: ReadonlySet<string> = new Set(['1024x1024', '768x1024', '1024x768', '512x512']);
 export const IMAGE_GEN_DEFAULT_SIZE = '1024x1024';
+
+/** TTS 응답 형식 화이트리스트 (OpenAI audio/speech 규격) */
+export const TTS_ALLOWED_FORMATS: ReadonlySet<string> = new Set(['mp3', 'wav', 'opus', 'aac', 'flac']);
+export const TTS_DEFAULT_FORMAT = 'mp3';
+export const TTS_DEFAULT_VOICE = 'alloy';
+/** STT 입력으로 허용하는 오디오 확장자 */
+export const STT_ALLOWED_EXTS: ReadonlySet<string> = new Set(['mp3', 'wav', 'm4a', 'ogg', 'opus', 'flac', 'webm', 'mp4']);
+/** 영상 생성 기본 인자 (OpenAI videos 규격 — provider 가 다르면 params 로 덮어쓴다) */
+export const VIDEO_GEN_DEFAULT_SECONDS = '4';
+export const VIDEO_GEN_DEFAULT_SIZE = '720x1280';
+/**
+ * 영상 생성 provider 어댑터 — OpenAI `/v1/videos` 규격이 아닌 provider 는 LiteLLM **pass-through**
+ * (`general_settings.pass_through_endpoints`, 정적 헤더로 upstream 키 주입 — scripts/vllm/litellm.config.yaml)
+ * 경유로 부른다. LiteLLM 1.89.4 pass-through 는 클라이언트 헤더를 전달하지 못하므로(설정 모델에
+ * forward_headers 없음, `extra: forbid`) 이 부류는 **서버 키(LiteLLM env) 전용 = 전역 배정만** 가능하다.
+ * 호출은 여전히 게이트웨이 하나다.
+ */
+export interface VideoProviderAdapter {
+    kind: 'openai-videos' | 'jobs-v1';
+    /** jobs-v1: 게이트웨이 pass-through 접두 경로 (LiteLLM path) */
+    passThroughPrefix?: string;
+    /** jobs-v1: 제출·상태·산출물 경로 (접두 뒤) — `{id}` 치환 */
+    submitPath?: string;
+    statusPath?: string;
+    /** 상태 응답에서 산출물 URL 필드(접두 상대 경로면 pass-through 접두를 붙인다) */
+    artifactField?: string;
+    doneStatuses?: readonly string[];
+    failStatuses?: readonly string[];
+}
+export const VIDEO_PROVIDER_ADAPTERS: Record<string, VideoProviderAdapter> = {
+    hasa: {
+        kind: 'jobs-v1',
+        passThroughPrefix: '/passthrough/hasa',
+        submitPath: '/videos/generations',
+        statusPath: '/jobs/{id}',
+        artifactField: 'artifact_url',
+        doneStatuses: ['COMPLETED', 'DONE', 'SUCCEEDED'],
+        failStatuses: ['FAILED', 'ERROR', 'CANCELLED', 'CANCELED'],
+    },
+};
+export function videoAdapterFor(providerId: string): VideoProviderAdapter {
+    return VIDEO_PROVIDER_ADAPTERS[providerId] ?? { kind: 'openai-videos' };
+}
+
+export const VIDEO_TERMINAL_STATUSES: ReadonlySet<string> = new Set(['completed', 'succeeded', 'failed', 'cancelled', 'canceled', 'error']);
+export const VIDEO_DONE_STATUSES: ReadonlySet<string> = new Set(['completed', 'succeeded']);
+
+/**
+ * 모달리티 도구의 채팅 노출 게이트 — 상시 노출 금지(도구폭주·prefix cache 원칙), 의도 턴에만.
+ * ChatService 가 메시지에 패턴이 맞으면 해당 도구를 강제 포함한다(카카오·web_search 강제 포함과 같은 선례).
+ */
+export const MODALITY_TOOL_INTENT_GATES: ReadonlyArray<{ tool: string; patterns: readonly RegExp[] }> = [
+    { tool: 'text_to_speech', patterns: [/(음성|목소리|오디오|소리)(으로|로)\s*(읽|만들|바꿔|변환|들려)/, /읽어\s*줘/, /낭독/, /\btts\b/i, /text[- ]to[- ]speech/i, /read (it|this|that) (aloud|out loud)/i, /\bvoice\s*(over|version)/i] },
+    { tool: 'transcribe_audio', patterns: [/(받아|옮겨)\s*(써|적)/, /전사/, /(음성|오디오|녹음)[^\n]{0,10}(텍스트|글|자막)/, /\bstt\b/i, /transcri(be|ption)/i, /speech[- ]to[- ]text/i] },
+    { tool: 'generate_video', patterns: [/(영상|비디오|동영상)[^\n]{0,12}(만들|생성|제작|그려)/, /\bvideo\b[^\n]{0,20}(generat|creat|make|render)/i, /(generat|creat|make)[^\n]{0,20}\bvideo\b/i] },
+    { tool: 'get_video', patterns: [/(영상|비디오|동영상)[^\n]{0,12}(상태|확인|됐|완료|다 됐|어디)/, /video[^\n]{0,20}(status|ready|done|finished)/i, /get_video/i] },
+];
 
 export function isModality(value: string): value is Modality {
     return (MODALITIES as readonly string[]).includes(value);

--- a/apps/api/src/controllers/modality-models.controller.ts
+++ b/apps/api/src/controllers/modality-models.controller.ts
@@ -1,0 +1,141 @@
+/**
+ * @module controllers/modality-models
+ * @description 사용자별 모달리티→모델 오버라이드 CRUD.
+ *
+ * "역할&모델"(user-model-roles.controller)과 별개 축 — 이미지·비전·영상·오디오·임베딩을
+ * 어느 모델이 처리하는지. 텍스트 생성은 여기 없다.
+ *
+ * Endpoints (모두 requireAuth):
+ *   GET    /api/users/me/modality-models             — 본인 오버라이드 + 실효(effective) 해석 결과
+ *   PUT    /api/users/me/modality-models/:modality   — 배정 (body: { model, params? })
+ *   DELETE /api/users/me/modality-models/:modality   — 해제 (전역/기본 폴백 복귀)
+ *
+ * PUT 검증(services/modality-resolver validateModalityAssignment):
+ *   외부 fullId → 카탈로그·openai-compatible·LLM_GATEWAY_PROVIDERS 편입·BYOK 키 등록/활성/비OAuth
+ */
+import { Router, Request } from 'express';
+import { z } from 'zod';
+import { requireAuth } from '../auth/middleware';
+import { validate } from '../middlewares/validation';
+import { getPool } from '../data/models/unified-database';
+import { ModalityModelsRepository } from '../data/repositories/modality-models-repo';
+import {
+    MODALITIES, MODALITY_LIMITS, USER_ASSIGNABLE_MODALITIES,
+    isModality, sanitizeModalityParams, type Modality,
+} from '../config/modality';
+import {
+    resolveModalityTarget, validateModalityAssignment, ModalityUnavailableError,
+} from '../services/modality-resolver';
+import { getAuditService } from '../services/AuditService';
+import { createLogger } from '../utils/logger';
+import { success, internalError, unauthorized, badRequest, notFound } from '../utils/api-response';
+
+const log = createLogger('ModalityModelsController');
+
+const putSchema = z.object({
+    model: z.string().min(1).max(MODALITY_LIMITS.FULL_ID_MAX_CHARS),
+    params: z.record(z.string(), z.union([z.string(), z.number()])).optional(),
+});
+
+function getUserId(req: Request): string | null {
+    if (!req.user) return null;
+    if ('userId' in req.user && typeof (req.user as { userId?: unknown }).userId === 'string') {
+        return (req.user as { userId: string }).userId;
+    }
+    if ('id' in req.user) return String(req.user.id);
+    return null;
+}
+
+function parseAssignable(value: string): Modality | null {
+    return isModality(value) && USER_ASSIGNABLE_MODALITIES.includes(value) ? value : null;
+}
+
+async function auditChange(userId: string, action: string, details: Record<string, unknown>): Promise<void> {
+    try {
+        await getAuditService().logAudit({ action, userId, resourceType: 'modality_model', details });
+    } catch (err) {
+        log.error('모달리티 배정 감사 기록 실패 (배정은 반영됨):', { action, details, err });
+    }
+}
+
+/** 실효 해석 — 각 모달리티가 지금 어느 모델로 가는지(키 노출 없음). 실패는 code 로 노출. */
+export async function describeEffectiveModalities(userId: string | undefined): Promise<Array<{
+    modality: Modality; fullId?: string; source?: string; error?: string; code?: string;
+}>> {
+    return Promise.all(MODALITIES.map(async (modality) => {
+        try {
+            const t = await resolveModalityTarget(modality, userId);
+            return { modality, fullId: t.fullId, source: t.source };
+        } catch (err) {
+            if (err instanceof ModalityUnavailableError) return { modality, error: err.message, code: err.code };
+            return { modality, error: err instanceof Error ? err.message : String(err) };
+        }
+    }));
+}
+
+export function createModalityModelsController(): Router {
+    const router = Router();
+
+    router.get('/', requireAuth, async (req, res) => {
+        const userId = getUserId(req);
+        if (!userId) { res.status(401).json(unauthorized()); return; }
+        try {
+            const repo = new ModalityModelsRepository(getPool());
+            const [overrides, effective] = await Promise.all([
+                repo.listByScope(userId),
+                describeEffectiveModalities(userId),
+            ]);
+            res.json(success({ overrides, effective, assignableModalities: USER_ASSIGNABLE_MODALITIES }));
+        } catch (err) {
+            log.error('list 실패:', err);
+            res.status(500).json(internalError('모달리티 배정 목록 조회 실패'));
+        }
+    });
+
+    router.put('/:modality', requireAuth, validate(putSchema), async (req, res) => {
+        const userId = getUserId(req);
+        if (!userId) { res.status(401).json(unauthorized()); return; }
+        const modality = parseAssignable(req.params.modality);
+        if (!modality) {
+            res.status(400).json(badRequest(`배정 불가 modality: '${req.params.modality}' (허용: ${USER_ASSIGNABLE_MODALITIES.join(', ')})`));
+            return;
+        }
+        try {
+            const body = req.body as z.infer<typeof putSchema>;
+            const fullId = body.model.trim();
+            const reason = await validateModalityAssignment(userId, fullId);
+            if (reason) { res.status(400).json(badRequest(reason)); return; }
+
+            const params = sanitizeModalityParams(modality, body.params);
+            const repo = new ModalityModelsRepository(getPool());
+            const { row, previous } = await repo.upsert(userId, modality, fullId, params);
+            log.info(`모달리티 배정 저장: userId=${userId} modality=${modality} model=${fullId}`);
+            await auditChange(userId, 'user_modality_model_set', { modality, model: fullId, previous });
+            res.json(success({ mapping: row }));
+        } catch (err) {
+            log.error('upsert 실패:', err);
+            res.status(500).json(internalError('모달리티 배정 저장 실패'));
+        }
+    });
+
+    router.delete('/:modality', requireAuth, async (req, res) => {
+        const userId = getUserId(req);
+        if (!userId) { res.status(401).json(unauthorized()); return; }
+        const modality = parseAssignable(req.params.modality);
+        if (!modality) { res.status(400).json(badRequest(`배정 불가 modality: '${req.params.modality}'`)); return; }
+        try {
+            const repo = new ModalityModelsRepository(getPool());
+            const previous = (await repo.get(userId, modality))?.fullId ?? null;
+            const deleted = await repo.delete(userId, modality);
+            if (!deleted) { res.status(404).json(notFound('배정 없음')); return; }
+            log.info(`모달리티 배정 해제: userId=${userId} modality=${modality}`);
+            await auditChange(userId, 'user_modality_model_unset', { modality, previous });
+            res.json(success({ deleted: true }));
+        } catch (err) {
+            log.error('delete 실패:', err);
+            res.status(500).json(internalError('모달리티 배정 해제 실패'));
+        }
+    });
+
+    return router;
+}

--- a/apps/api/src/controllers/modality-models.controller.ts
+++ b/apps/api/src/controllers/modality-models.controller.ts
@@ -103,7 +103,7 @@ export function createModalityModelsController(): Router {
         try {
             const body = req.body as z.infer<typeof putSchema>;
             const fullId = body.model.trim();
-            const reason = await validateModalityAssignment(userId, fullId);
+            const reason = await validateModalityAssignment(userId, fullId, {}, modality);
             if (reason) { res.status(400).json(badRequest(reason)); return; }
 
             const params = sanitizeModalityParams(modality, body.params);

--- a/apps/api/src/data/repositories/modality-models-repo.ts
+++ b/apps/api/src/data/repositories/modality-models-repo.ts
@@ -1,0 +1,113 @@
+/**
+ * @module data/repositories/modality-models-repo
+ * @description 모달리티→모델 배정(modality_models) 저장소 — 전역('__global__')·사용자 scope 공용.
+ *
+ * "역할&모델"(user_model_roles/global_model_roles)과 별개 축. 해석은 services/modality-resolver.
+ *
+ * @see db/migrations/117_modality_models.sql
+ */
+import { BaseRepository } from './base-repository';
+import { GLOBAL_MODALITY_SCOPE, type Modality } from '../../config/modality';
+
+export interface ModalityModelRow {
+    scope: string;
+    modality: Modality;
+    fullId: string;
+    params: Record<string, string>;
+    updatedAt: Date;
+}
+
+interface DbRow {
+    scope: string;
+    modality: Modality;
+    full_id: string;
+    params: Record<string, string> | null;
+    updated_at: Date;
+    [key: string]: unknown;
+}
+
+function toRow(row: DbRow): ModalityModelRow {
+    return {
+        scope: row.scope,
+        modality: row.modality,
+        fullId: row.full_id,
+        params: row.params ?? {},
+        updatedAt: row.updated_at,
+    };
+}
+
+export class ModalityModelsRepository extends BaseRepository {
+    async listByScope(scope: string): Promise<ModalityModelRow[]> {
+        const result = await this.query<DbRow>(
+            `SELECT * FROM modality_models WHERE scope = $1 ORDER BY modality`,
+            [scope],
+        );
+        return result.rows.map(toRow);
+    }
+
+    async listGlobal(): Promise<ModalityModelRow[]> {
+        return this.listByScope(GLOBAL_MODALITY_SCOPE);
+    }
+
+    async get(scope: string, modality: Modality): Promise<ModalityModelRow | null> {
+        const result = await this.query<DbRow>(
+            `SELECT * FROM modality_models WHERE scope = $1 AND modality = $2`,
+            [scope, modality],
+        );
+        return result.rows[0] ? toRow(result.rows[0]) : null;
+    }
+
+    /** 배정/변경 — 직전 fullId 를 같은 트랜잭션에서 캡처해 감사 로그용으로 함께 돌려준다 */
+    async upsert(
+        scope: string,
+        modality: Modality,
+        fullId: string,
+        params: Record<string, string>,
+    ): Promise<{ row: ModalityModelRow; previous: string | null }> {
+        const client = await this.pool.connect();
+        try {
+            await client.query('BEGIN');
+            await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`mm:${scope}:${modality}`]);
+            const prev = await client.query<DbRow>(
+                `SELECT full_id FROM modality_models WHERE scope = $1 AND modality = $2`,
+                [scope, modality],
+            );
+            const upserted = await client.query<DbRow>(
+                `INSERT INTO modality_models (scope, modality, full_id, params)
+                 VALUES ($1, $2, $3, $4::jsonb)
+                 ON CONFLICT (scope, modality) DO UPDATE SET
+                    full_id = EXCLUDED.full_id,
+                    params = EXCLUDED.params,
+                    updated_at = NOW()
+                 RETURNING *`,
+                [scope, modality, fullId, JSON.stringify(params)],
+            );
+            await client.query('COMMIT');
+            return { row: toRow(upserted.rows[0]), previous: prev.rows[0]?.full_id ?? null };
+        } catch (err) {
+            await client.query('ROLLBACK').catch(() => undefined);
+            throw err;
+        } finally {
+            client.release();
+        }
+    }
+
+    /** 미존재 시에만 삽입(시더용) — 이미 있으면 false */
+    async insertIfAbsent(scope: string, modality: Modality, fullId: string): Promise<boolean> {
+        const result = await this.query(
+            `INSERT INTO modality_models (scope, modality, full_id)
+             VALUES ($1, $2, $3)
+             ON CONFLICT (scope, modality) DO NOTHING`,
+            [scope, modality, fullId],
+        );
+        return (result.rowCount ?? 0) > 0;
+    }
+
+    async delete(scope: string, modality: Modality): Promise<boolean> {
+        const result = await this.query(
+            `DELETE FROM modality_models WHERE scope = $1 AND modality = $2`,
+            [scope, modality],
+        );
+        return (result.rowCount ?? 0) > 0;
+    }
+}

--- a/apps/api/src/data/user-manager.ts
+++ b/apps/api/src/data/user-manager.ts
@@ -467,6 +467,8 @@ class UserManagerImpl {
 
             // ── 2. 사용자 데이터 정리 ──
             await client.query('DELETE FROM user_memories WHERE user_id = $1', [userId]);
+            // 모달리티 모델 오버라이드 — scope 가 '__global__' 도 담아 FK 를 못 걸므로 여기서 정리
+            await client.query('DELETE FROM modality_models WHERE scope = $1', [userId]);
 
             await client.query('DELETE FROM external_connections WHERE user_id = $1', [userId]);
             await client.query('DELETE FROM user_api_keys WHERE user_id = $1', [userId]);

--- a/apps/api/src/llm/external-throttle.ts
+++ b/apps/api/src/llm/external-throttle.ts
@@ -63,6 +63,17 @@ function semaphoreFor(providerId: string): Semaphore {
     return s;
 }
 
+/**
+ * LLMClient 가 아닌 호출(모달리티 도구의 fetch 등)이 같은 provider 세마포어를 공유하기 위한 진입점.
+ * 로컬(local-llm)은 세마포어 없이 그대로 실행. 429 백오프는 하지 않는다 — 비스트림 단발 호출은
+ * 호출부가 결과 코드를 그대로 사용자에게 안내한다(조용한 재시도로 이미지 생성이 수 분 늦어지는 것 방지).
+ */
+export async function withProviderSlot<T>(providerId: string, fn: () => Promise<T>): Promise<T> {
+    if (providerId === 'local-llm') return fn();
+    const release = await semaphoreFor(providerId).acquire();
+    try { return await fn(); } finally { release(); }
+}
+
 /** 테스트용 — 세마포어 상태 초기화 */
 export function __resetExternalThrottleForTest(): void { semaphores.clear(); }
 

--- a/apps/api/src/mcp/__tests__/modality-media-tools.test.ts
+++ b/apps/api/src/mcp/__tests__/modality-media-tools.test.ts
@@ -13,6 +13,7 @@ jest.mock('../generated-media', () => ({
     },
     resolveGeneratedPath: () => null,
 }));
+jest.mock('../../security/ssrf-guard', () => ({ safeFetch: (url: string, init?: RequestInit) => (global.fetch as typeof fetch)(url, init) }));
 jest.mock('../../config/modality', () => {
     const actual = jest.requireActual('../../config/modality');
     return { ...actual, MODALITY_LIMITS: { ...actual.MODALITY_LIMITS, VIDEO_WAIT_MS: 50, VIDEO_POLL_INTERVAL_MS: 5 } };
@@ -25,7 +26,7 @@ import { MODALITY_TOOL_INTENT_GATES } from '../../config/modality';
 
 const gwTarget = (modality: string, extra: Partial<Record<string, unknown>> = {}) => ({
     modality, fullId: 'hasa/x', providerId: 'hasa', model: 'hasa/x', baseUrl: 'http://gw', endpoint: '/v1/audio/speech',
-    headers: { Authorization: 'Bearer m', 'x-api-key': 'k' }, params: {}, source: 'global', ...extra,
+    headers: { Authorization: 'Bearer m', 'x-api-key': 'k' }, params: {}, source: 'global', transport: 'gateway', ...extra,
 });
 const realFetch = global.fetch;
 afterEach(() => { global.fetch = realFetch; mockResolve.mockReset(); saved.length = 0; });
@@ -92,11 +93,11 @@ describe('transcribe_audio', () => {
 
 describe('generate_video / get_video', () => {
     const jobsTarget = () => gwTarget('video_gen', {
-        fullId: 'hasa:Wan2.2-T2V', model: 'Wan2.2-T2V', baseUrl: 'http://gw/passthrough/hasa',
-        endpoint: '/videos/generations', headers: { Authorization: 'Bearer m' },
+        fullId: 'hasa:Wan2.2-T2V', model: 'Wan2.2-T2V', baseUrl: 'https://open.hasa.re.kr/v1',
+        endpoint: '/videos/generations', headers: { Authorization: 'Bearer byok' }, transport: 'direct',
     });
 
-    it('jobs-v1(hasa): 제출 → 상태 폴링 → artifact_url(상대) 다운로드 → 링크', async () => {
+    it('jobs-v1(hasa): 직결(safeFetch) 제출 → 상태 폴링 → artifact_url(상대) 다운로드 → 링크', async () => {
         mockResolve.mockResolvedValue(jobsTarget());
         const calls: string[] = [];
         let polls = 0;
@@ -117,9 +118,9 @@ describe('generate_video / get_video', () => {
         const r = await generateVideoTool.handler({ prompt: 'a red circle' }, { userId: 'u1', role: 'user' });
         expect(r.isError).toBeFalsy();
         expect(r.content[0].text).toContain('/generated/video.webm');
-        expect(calls[0]).toBe('POST http://gw/passthrough/hasa/videos/generations');
-        expect(calls).toContain('GET http://gw/passthrough/hasa/jobs/vid_1');
-        expect(calls).toContain('GET http://gw/passthrough/hasa/files/v.webm');
+        expect(calls[0]).toBe('POST https://open.hasa.re.kr/v1/videos/generations');
+        expect(calls).toContain('GET https://open.hasa.re.kr/v1/jobs/vid_1');
+        expect(calls).toContain('GET https://open.hasa.re.kr/v1/files/v.webm');
         expect(saved[0]).toMatchObject({ prefix: 'video', ext: 'webm', size: 3 });
     });
 

--- a/apps/api/src/mcp/__tests__/modality-media-tools.test.ts
+++ b/apps/api/src/mcp/__tests__/modality-media-tools.test.ts
@@ -1,0 +1,172 @@
+/** 오디오·영상 도구 — 해석기·fetch mock 으로 wire(게이트웨이 1곳·헤더·본문)·형식 판별·비동기 작업 흐름 고정 */
+const mockResolve = jest.fn();
+jest.mock('../../services/modality-resolver', () => {
+    const actual = jest.requireActual('../../services/modality-resolver');
+    return { ...actual, resolveModalityTarget: (...a: unknown[]) => mockResolve(...a) };
+});
+jest.mock('../../data/models/unified-database', () => ({ getPool: () => ({}) }));
+const saved: Array<{ prefix: string; ext: string; size: number }> = [];
+jest.mock('../generated-media', () => ({
+    saveGeneratedFile: (prefix: string, ext: string, data: Buffer) => {
+        saved.push({ prefix, ext, size: data.length });
+        return { filename: `${prefix}.${ext}`, urlPath: `/generated/${prefix}.${ext}`, absPath: '/x' };
+    },
+    resolveGeneratedPath: () => null,
+}));
+jest.mock('../../config/modality', () => {
+    const actual = jest.requireActual('../../config/modality');
+    return { ...actual, MODALITY_LIMITS: { ...actual.MODALITY_LIMITS, VIDEO_WAIT_MS: 50, VIDEO_POLL_INTERVAL_MS: 5 } };
+});
+
+import { textToSpeechTool, transcribeAudioTool, sniffAudioExt } from '../audio-tools';
+import { generateVideoTool, getVideoTool } from '../video-tools';
+import { ModalityUnavailableError } from '../../services/modality-resolver';
+import { MODALITY_TOOL_INTENT_GATES } from '../../config/modality';
+
+const gwTarget = (modality: string, extra: Partial<Record<string, unknown>> = {}) => ({
+    modality, fullId: 'hasa/x', providerId: 'hasa', model: 'hasa/x', baseUrl: 'http://gw', endpoint: '/v1/audio/speech',
+    headers: { Authorization: 'Bearer m', 'x-api-key': 'k' }, params: {}, source: 'global', ...extra,
+});
+const realFetch = global.fetch;
+afterEach(() => { global.fetch = realFetch; mockResolve.mockReset(); saved.length = 0; });
+
+describe('text_to_speech', () => {
+    it('미배정이면 안내 오류', async () => {
+        mockResolve.mockRejectedValue(new ModalityUnavailableError('tts 미배정', 'MODALITY_UNASSIGNED'));
+        const r = await textToSpeechTool.handler({ text: 'hi' }, { userId: 'u1', role: 'user' });
+        expect(r.isError).toBe(true);
+        expect(r.content[0].text).toContain('tts 미배정');
+    });
+
+    it('게이트웨이 1곳으로 model·voice(params)·format 을 싣고, 바이트로 확장자를 확정한다', async () => {
+        mockResolve.mockResolvedValue(gwTarget('tts', { params: { voice: 'KR', format: 'wav' } }));
+        const wav = Buffer.concat([Buffer.from('RIFF....WAVE'), Buffer.alloc(8)]);
+        const f = jest.fn(async () => ({
+            ok: true, status: 200, text: async () => '',
+            arrayBuffer: async () => wav.buffer.slice(wav.byteOffset, wav.byteOffset + wav.length),
+        }));
+        global.fetch = f as unknown as typeof fetch;
+        const r = await textToSpeechTool.handler({ text: '안녕' }, { userId: 'u1', role: 'user' });
+        expect(r.isError).toBeFalsy();
+        expect(r.content[0].text).toContain('/generated/tts.wav');
+        const [url, init] = f.mock.calls[0] as unknown as [string, RequestInit];
+        expect(url).toBe('http://gw/v1/audio/speech');
+        expect(JSON.parse(init.body as string)).toEqual({ model: 'hasa/x', input: '안녕', voice: 'KR', response_format: 'wav' });
+        expect((init.headers as Record<string, string>)['x-api-key']).toBe('k');
+        expect(mockResolve).toHaveBeenCalledWith('tts', 'u1');
+    });
+
+    it('sniffAudioExt — RIFF/WAVE→wav, ID3→mp3, 모르면 요청 형식', () => {
+        expect(sniffAudioExt(Buffer.from('RIFFxxxxWAVEfmt '), 'mp3')).toBe('wav');
+        expect(sniffAudioExt(Buffer.from('ID3'), 'wav')).toBe('mp3');
+        expect(sniffAudioExt(Buffer.from('zzzz'), 'opus')).toBe('opus');
+    });
+});
+
+describe('transcribe_audio', () => {
+    it('base64 입력을 multipart(model·file·language) 로 보내고 text 를 돌려준다', async () => {
+        mockResolve.mockResolvedValue(gwTarget('stt', { endpoint: '/v1/audio/transcriptions', params: { language: 'ko' } }));
+        const f = jest.fn(async () => ({ ok: true, status: 200, json: async () => ({ text: ' 안녕하세요 ' }), text: async () => '' }));
+        global.fetch = f as unknown as typeof fetch;
+        const r = await transcribeAudioTool.handler(
+            { audio_base64: Buffer.from('abc').toString('base64'), filename: 'a.wav' },
+            { userId: 'u1', role: 'user' },
+        );
+        expect(r.isError).toBeFalsy();
+        expect(r.content[0].text).toContain('안녕하세요');
+        const [url, init] = f.mock.calls[0] as unknown as [string, RequestInit];
+        expect(url).toBe('http://gw/v1/audio/transcriptions');
+        const fd = init.body as FormData;
+        expect(fd.get('model')).toBe('hasa/x');
+        expect(fd.get('language')).toBe('ko');
+        expect((fd.get('file') as File).name).toBe('a.wav');
+        expect((init.headers as Record<string, string>)['Content-Type']).toBeUndefined();
+    });
+
+    it('허용되지 않는 확장자·입력 없음은 오류', async () => {
+        mockResolve.mockResolvedValue(gwTarget('stt'));
+        expect((await transcribeAudioTool.handler({ audio_base64: 'AA', filename: 'a.exe' }, undefined)).isError).toBe(true);
+        expect((await transcribeAudioTool.handler({}, undefined)).isError).toBe(true);
+    });
+});
+
+describe('generate_video / get_video', () => {
+    const jobsTarget = () => gwTarget('video_gen', {
+        fullId: 'hasa:Wan2.2-T2V', model: 'Wan2.2-T2V', baseUrl: 'http://gw/passthrough/hasa',
+        endpoint: '/videos/generations', headers: { Authorization: 'Bearer m' },
+    });
+
+    it('jobs-v1(hasa): 제출 → 상태 폴링 → artifact_url(상대) 다운로드 → 링크', async () => {
+        mockResolve.mockResolvedValue(jobsTarget());
+        const calls: string[] = [];
+        let polls = 0;
+        global.fetch = (async (url: string, init?: RequestInit) => {
+            calls.push(`${init?.method ?? 'GET'} ${url}`);
+            if (url.endsWith('/videos/generations')) return { ok: true, status: 200, json: async () => ({ job_id: 'vid_1', status: 'LOADING' }) };
+            if (url.endsWith('/jobs/vid_1')) {
+                polls++;
+                return { ok: true, status: 200, json: async () => (polls < 2
+                    ? { job_id: 'vid_1', status: 'GENERATING', progress: 50 }
+                    : { job_id: 'vid_1', status: 'COMPLETED', artifact_url: '/files/v.webm' }) };
+            }
+            if (url.endsWith('/files/v.webm')) {
+                return { ok: true, status: 200, headers: new Headers({ 'content-type': 'video/webm' }), arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer };
+            }
+            throw new Error('unexpected ' + url);
+        }) as unknown as typeof fetch;
+        const r = await generateVideoTool.handler({ prompt: 'a red circle' }, { userId: 'u1', role: 'user' });
+        expect(r.isError).toBeFalsy();
+        expect(r.content[0].text).toContain('/generated/video.webm');
+        expect(calls[0]).toBe('POST http://gw/passthrough/hasa/videos/generations');
+        expect(calls).toContain('GET http://gw/passthrough/hasa/jobs/vid_1');
+        expect(calls).toContain('GET http://gw/passthrough/hasa/files/v.webm');
+        expect(saved[0]).toMatchObject({ prefix: 'video', ext: 'webm', size: 3 });
+    });
+
+    it('상한 안에 안 끝나면 작업 id 를 돌려주고, get_video 가 이어받는다', async () => {
+        mockResolve.mockResolvedValue(jobsTarget());
+        global.fetch = (async (url: string) => {
+            if (url.endsWith('/videos/generations')) return { ok: true, status: 200, json: async () => ({ job_id: 'vid_2', status: 'LOADING' }) };
+            if (url.endsWith('/jobs/vid_2')) return { ok: true, status: 200, json: async () => ({ job_id: 'vid_2', status: 'GENERATING', progress: 10 }) };
+            throw new Error('unexpected ' + url);
+        }) as unknown as typeof fetch;
+        const r = await generateVideoTool.handler({ prompt: 'x' }, undefined);
+        expect(r.isError).toBeFalsy();
+        expect(r.content[0].text).toContain('vid_2');
+        expect(r.content[0].text).toContain('get_video');
+        const g = await getVideoTool.handler({ video_id: 'vid_2' }, undefined);
+        expect(g.content[0].text).toContain('진행 중');
+    });
+
+    it('OpenAI 규격: /v1/videos → /v1/videos/{id} → /content, 실패 status 는 오류', async () => {
+        mockResolve.mockResolvedValue(gwTarget('video_gen', { providerId: 'openrouter', model: 'openrouter/sora', baseUrl: 'http://gw', endpoint: '/v1/videos' }));
+        global.fetch = (async (url: string) => {
+            if (url === 'http://gw/v1/videos') return { ok: true, status: 200, json: async () => ({ id: 'v9', status: 'queued' }) };
+            if (url === 'http://gw/v1/videos/v9') return { ok: true, status: 200, json: async () => ({ id: 'v9', status: 'completed' }) };
+            if (url === 'http://gw/v1/videos/v9/content') {
+                return { ok: true, status: 200, headers: new Headers({ 'content-type': 'video/mp4' }), arrayBuffer: async () => new Uint8Array([9]).buffer };
+            }
+            throw new Error('unexpected ' + url);
+        }) as unknown as typeof fetch;
+        const r = await generateVideoTool.handler({ prompt: 'x' }, undefined);
+        expect(r.content[0].text).toContain('/generated/video.mp4');
+        global.fetch = (async () => ({ ok: true, status: 200, json: async () => ({ id: 'v9', status: 'failed', error: 'nsfw' }) })) as unknown as typeof fetch;
+        expect((await getVideoTool.handler({ video_id: 'v9' }, undefined)).isError).toBe(true);
+    });
+});
+
+describe('MODALITY_TOOL_INTENT_GATES', () => {
+    const hit = (tool: string, msg: string) =>
+        MODALITY_TOOL_INTENT_GATES.find((g) => g.tool === tool)!.patterns.some((re) => re.test(msg));
+    it('의도 문장에만 맞고 일반 질문엔 안 맞는다', () => {
+        expect(hit('text_to_speech', '이 문단 읽어줘')).toBe(true);
+        expect(hit('text_to_speech', '음성으로 만들어줘')).toBe(true);
+        expect(hit('transcribe_audio', '이 녹음 파일을 텍스트로 옮겨줘')).toBe(true);
+        expect(hit('generate_video', '바다 위 일출 영상 만들어줘')).toBe(true);
+        expect(hit('get_video', '아까 영상 다 됐어?')).toBe(true);
+        for (const t of ['text_to_speech', 'transcribe_audio', 'generate_video', 'get_video']) {
+            expect(hit(t, '오늘 서울 날씨 어때?')).toBe(false);
+            expect(hit(t, 'TypeScript 제네릭 설명해줘')).toBe(false);
+        }
+    });
+});

--- a/apps/api/src/mcp/audio-tools.ts
+++ b/apps/api/src/mcp/audio-tools.ts
@@ -1,0 +1,193 @@
+/**
+ * ============================================================
+ * Audio Tools — 음성 합성(TTS)·음성 인식(STT) 내장 도구
+ * ============================================================
+ *
+ * 모델은 모달리티 배정(`tts`/`stt`, services/modality-resolver)으로 정하고, 호출은 LiteLLM
+ * 게이트웨이의 OpenAI 호환 `/v1/audio/speech`·`/v1/audio/transcriptions` 하나로만 간다.
+ * 노출은 상시가 아니라 의도 턴에만(config/modality MODALITY_TOOL_INTENT_GATES).
+ *
+ * @module mcp/audio-tools
+ */
+import { MCPToolDefinition, MCPToolResult } from './types';
+import {
+    MODALITY_LIMITS, TTS_ALLOWED_FORMATS, TTS_DEFAULT_FORMAT, TTS_DEFAULT_VOICE, STT_ALLOWED_EXTS,
+} from '../config/modality';
+import { resolveModalityTarget, ModalityUnavailableError } from '../services/modality-resolver';
+import { withProviderSlot } from '../llm/external-throttle';
+import { saveGeneratedFile, resolveGeneratedPath } from './generated-media';
+import { safeFetch } from '../security/ssrf-guard';
+import { createLogger } from '../utils/logger';
+import * as fs from 'node:fs';
+
+const logger = createLogger('AudioTools');
+
+function textResult(text: string, isError = false): MCPToolResult {
+    return { content: [{ type: 'text', text }], isError };
+}
+
+function userIdOf(context?: { userId?: string | number }): string | undefined {
+    return context?.userId !== undefined ? String(context.userId) : undefined;
+}
+
+/** 매직 바이트로 오디오 확장자 판별 — 모르면 요청 형식 */
+export function sniffAudioExt(buf: Buffer, fallback: string): string {
+    if (buf.length >= 12 && buf.toString('ascii', 0, 4) === 'RIFF' && buf.toString('ascii', 8, 12) === 'WAVE') return 'wav';
+    if (buf.length >= 4 && buf.toString('ascii', 0, 4) === 'OggS') return 'opus';
+    if (buf.length >= 4 && buf.toString('ascii', 0, 4) === 'fLaC') return 'flac';
+    if (buf.length >= 3 && (buf.toString('ascii', 0, 3) === 'ID3' || (buf[0] === 0xff && (buf[1] & 0xe0) === 0xe0))) return 'mp3';
+    return fallback;
+}
+
+function friendlyError(prefix: string, e: unknown): MCPToolResult {
+    const msg = e instanceof Error ? e.message : String(e);
+    logger.warn(`${prefix}: ${msg}`);
+    const timeout = /timeout/i.test(msg);
+    return textResult(timeout ? `${prefix} 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.` : `${prefix} 중 오류: ${msg}`, true);
+}
+
+export const textToSpeechTool: MCPToolDefinition = {
+    tool: {
+        name: 'text_to_speech',
+        description:
+            '텍스트를 음성 오디오 파일로 합성합니다(TTS). 사용자가 "읽어줘", "음성으로 만들어줘", "낭독" 등을 요청하면 사용하세요. ' +
+            '결과로 받은 마크다운 링크를 답변에 그대로 포함하면 사용자가 재생할 수 있습니다.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                text: { type: 'string', description: `합성할 텍스트 (최대 ${MODALITY_LIMITS.TTS_MAX_CHARS}자)` },
+                voice: { type: 'string', description: '목소리 이름 (provider 규격, 예: alloy). 생략 시 배정 기본값' },
+                format: { type: 'string', description: '출력 형식 — mp3(기본) | wav | opus | aac | flac' },
+            },
+            required: ['text'],
+        },
+    },
+    handler: async (args, context): Promise<MCPToolResult> => {
+        const text = String(args.text || '').trim();
+        if (!text) return textResult('text 가 필요합니다.', true);
+        if (text.length > MODALITY_LIMITS.TTS_MAX_CHARS) {
+            return textResult(`텍스트가 너무 깁니다 (${text.length}자 > ${MODALITY_LIMITS.TTS_MAX_CHARS}자). 나눠서 요청하세요.`, true);
+        }
+        let target;
+        try {
+            target = await resolveModalityTarget('tts', userIdOf(context));
+        } catch (e) {
+            if (e instanceof ModalityUnavailableError) return textResult(`음성 합성 불가: ${e.message}`, true);
+            throw e;
+        }
+        const requestedFormat = String(args.format ?? target.params.format ?? '');
+        const format = TTS_ALLOWED_FORMATS.has(requestedFormat) ? requestedFormat : TTS_DEFAULT_FORMAT;
+        const voice = String(args.voice || target.params.voice || TTS_DEFAULT_VOICE);
+        try {
+            const res = await withProviderSlot(target.providerId, () => fetch(`${target.baseUrl}${target.endpoint}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', ...target.headers },
+                body: JSON.stringify({ model: target.model, input: text, voice, response_format: format }),
+                signal: AbortSignal.timeout(MODALITY_LIMITS.TTS_TIMEOUT_MS),
+            }));
+            if (!res.ok) {
+                const body = await res.text().catch(() => '');
+                logger.warn(`TTS 실패: HTTP ${res.status} ${body.slice(0, 200)}`);
+                return textResult(`음성 합성 실패 (HTTP ${res.status}). ${body.slice(0, 160)}`, true);
+            }
+            const buf = Buffer.from(await res.arrayBuffer());
+            if (buf.length === 0) return textResult('음성 합성 응답이 비어 있습니다.', true);
+            // 실제 바이트로 확장자 확정 — provider 가 요청 형식과 다른 바이트/Content-Type 을 주는 경우가 있다
+            const { filename, urlPath } = saveGeneratedFile('tts', sniffAudioExt(buf, format), buf);
+            logger.info(`TTS 완료: ${filename} (${target.fullId}/${target.source}, ${text.length}자, ${buf.length}B)`);
+            return textResult(`음성 파일이 생성되었습니다. 아래 링크를 답변에 그대로 포함하세요:\n\n[🔊 음성 듣기](${urlPath})`);
+        } catch (e) {
+            return friendlyError('음성 합성', e);
+        }
+    },
+};
+
+async function loadAudioInput(args: Record<string, unknown>): Promise<{ data: Buffer; filename: string } | string> {
+    const base64 = typeof args.audio_base64 === 'string' ? args.audio_base64 : '';
+    const url = typeof args.audio_url === 'string' ? args.audio_url.trim() : '';
+    const filenameArg = typeof args.filename === 'string' ? args.filename : '';
+    const extOf = (name: string) => (name.split('.').pop() || '').toLowerCase();
+
+    if (base64) {
+        const filename = filenameArg || 'audio.mp3';
+        if (!STT_ALLOWED_EXTS.has(extOf(filename))) return `허용되지 않는 오디오 형식: ${filename}`;
+        const data = Buffer.from(base64.replace(/^data:[^;]+;base64,/, ''), 'base64');
+        return { data, filename };
+    }
+    if (url.startsWith('/generated/')) {
+        const abs = resolveGeneratedPath(url);
+        if (!abs) return `찾을 수 없는 파일: ${url}`;
+        const filename = url.split('/').pop() || 'audio.mp3';
+        if (!STT_ALLOWED_EXTS.has(extOf(filename))) return `허용되지 않는 오디오 형식: ${filename}`;
+        return { data: fs.readFileSync(abs), filename };
+    }
+    if (/^https?:\/\//i.test(url)) {
+        const res = await safeFetch(url, { signal: AbortSignal.timeout(MODALITY_LIMITS.STT_TIMEOUT_MS) });
+        if (!res.ok) return `오디오 다운로드 실패 (HTTP ${res.status})`;
+        const filename = filenameArg || (new URL(url).pathname.split('/').pop() || 'audio.mp3');
+        if (!STT_ALLOWED_EXTS.has(extOf(filename))) return `허용되지 않는 오디오 형식: ${filename}`;
+        return { data: Buffer.from(await res.arrayBuffer()), filename };
+    }
+    return 'audio_url(https:// 또는 /generated/ 경로) 또는 audio_base64 가 필요합니다.';
+}
+
+export const transcribeAudioTool: MCPToolDefinition = {
+    tool: {
+        name: 'transcribe_audio',
+        description:
+            '오디오를 텍스트로 받아씁니다(STT). 사용자가 녹음·음성 파일의 전사/자막/텍스트 변환을 요청하면 사용하세요. ' +
+            'audio_url 은 https:// 주소 또는 이 서비스가 생성한 /generated/ 경로, 또는 audio_base64 로 데이터를 직접 전달합니다.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                audio_url: { type: 'string', description: '오디오 URL (https://…) 또는 /generated/<file>' },
+                audio_base64: { type: 'string', description: '오디오 파일 base64 (audio_url 대신)' },
+                filename: { type: 'string', description: '파일명(확장자로 형식 판별, base64/URL 확장자 없을 때)' },
+                language: { type: 'string', description: 'ISO-639-1 언어 힌트 (예: ko). 생략 시 자동' },
+            },
+            required: [],
+        },
+    },
+    handler: async (args, context): Promise<MCPToolResult> => {
+        let target;
+        try {
+            target = await resolveModalityTarget('stt', userIdOf(context));
+        } catch (e) {
+            if (e instanceof ModalityUnavailableError) return textResult(`음성 인식 불가: ${e.message}`, true);
+            throw e;
+        }
+        try {
+            const loaded = await loadAudioInput(args);
+            if (typeof loaded === 'string') return textResult(loaded, true);
+            if (loaded.data.length > MODALITY_LIMITS.STT_MAX_BYTES) {
+                return textResult(`오디오가 너무 큽니다 (${loaded.data.length}B > ${MODALITY_LIMITS.STT_MAX_BYTES}B).`, true);
+            }
+            const fd = new FormData();
+            fd.append('model', target.model);
+            fd.append('file', new Blob([new Uint8Array(loaded.data)]), loaded.filename);
+            const language = String(args.language || target.params.language || '');
+            if (language) fd.append('language', language);
+            // multipart 는 Content-Type 을 fetch 가 boundary 와 함께 붙인다 — 수동 지정 금지
+            const res = await withProviderSlot(target.providerId, () => fetch(`${target.baseUrl}${target.endpoint}`, {
+                method: 'POST',
+                headers: { ...target.headers },
+                body: fd,
+                signal: AbortSignal.timeout(MODALITY_LIMITS.STT_TIMEOUT_MS),
+            }));
+            if (!res.ok) {
+                const body = await res.text().catch(() => '');
+                logger.warn(`STT 실패: HTTP ${res.status} ${body.slice(0, 200)}`);
+                return textResult(`음성 인식 실패 (HTTP ${res.status}). ${body.slice(0, 160)}`, true);
+            }
+            const json = await res.json() as { text?: string };
+            const transcript = (json.text ?? '').trim();
+            if (!transcript) return textResult('음성 인식 결과가 비어 있습니다.', true);
+            logger.info(`STT 완료: ${loaded.filename} → ${transcript.length}자 (${target.fullId}/${target.source})`);
+            return textResult(`전사 결과:\n\n${transcript}`);
+        } catch (e) {
+            return friendlyError('음성 인식', e);
+        }
+    },
+};
+
+export const audioTools: MCPToolDefinition[] = [textToSpeechTool, transcribeAudioTool];

--- a/apps/api/src/mcp/generated-media.ts
+++ b/apps/api/src/mcp/generated-media.ts
@@ -1,0 +1,41 @@
+/**
+ * @module mcp/generated-media
+ * @description 모달리티 도구(이미지·오디오·영상)가 만든 파일을 백엔드 정적 경로(/generated/*)에 저장한다.
+ * apps/legacy-web/public/generated 을 express.static 이 항상 서빙한다(middlewares/setup.ts).
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+
+/** 생성 파일 저장 디렉토리 — 백엔드가 /generated/* 로 노출하는 정적 경로 */
+export function resolveGeneratedDir(): string {
+    return path.resolve(__dirname, '../../../../apps/legacy-web/public/generated');
+}
+
+/** 확장자 화이트리스트 — 경로 조작·임의 확장자 저장 차단 */
+const SAFE_EXT = /^[a-z0-9]{1,5}$/;
+
+export function saveGeneratedFile(prefix: string, ext: string, data: Buffer): { filename: string; urlPath: string; absPath: string } {
+    if (!SAFE_EXT.test(ext)) throw new Error(`허용되지 않는 확장자: ${ext}`);
+    const dir = resolveGeneratedDir();
+    fs.mkdirSync(dir, { recursive: true });
+    const filename = `${prefix}-${Date.now()}-${crypto.randomBytes(4).toString('hex')}.${ext}`;
+    const absPath = path.join(dir, filename);
+    fs.writeFileSync(absPath, data);
+    return { filename, urlPath: `/generated/${filename}`, absPath };
+}
+
+/** `/generated/<file>` 경로를 실파일로 해석 — 디렉토리 밖·심링크 탈출 차단. 없으면 null */
+export function resolveGeneratedPath(urlPath: string): string | null {
+    const m = /^\/generated\/([A-Za-z0-9._-]+)$/.exec(urlPath.trim());
+    if (!m) return null;
+    const dir = resolveGeneratedDir();
+    const abs = path.join(dir, m[1]);
+    try {
+        const real = fs.realpathSync(abs);
+        if (!real.startsWith(fs.realpathSync(dir) + path.sep)) return null;
+        return real;
+    } catch {
+        return null;
+    }
+}

--- a/apps/api/src/mcp/image-tools.ts
+++ b/apps/api/src/mcp/image-tools.ts
@@ -13,21 +13,14 @@
  *
  * @module mcp/image-tools
  */
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import * as crypto from 'node:crypto';
 import { MCPToolDefinition, MCPToolResult } from './types';
+import { saveGeneratedFile } from './generated-media';
 import { IMAGE_GEN_ALLOWED_SIZES, IMAGE_GEN_DEFAULT_SIZE, MODALITY_LIMITS } from '../config/modality';
 import { resolveModalityTarget, ModalityUnavailableError } from '../services/modality-resolver';
 import { withProviderSlot } from '../llm/external-throttle';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('ImageTools');
-
-/** 생성 이미지 저장 디렉토리 — 백엔드가 /generated/* 로 노출하는 정적 경로 (apps/legacy-web/public/generated) */
-function resolveGeneratedDir(): string {
-    return path.resolve(__dirname, '../../../../apps/legacy-web/public/generated');
-}
 
 function textResult(text: string, isError = false): MCPToolResult {
     return { content: [{ type: 'text', text }], isError };
@@ -89,15 +82,12 @@ export const generateImageTool: MCPToolDefinition = {
             }
             if (!b64) return textResult('이미지 생성 응답에 데이터가 없습니다.', true);
 
-            const dir = resolveGeneratedDir();
-            fs.mkdirSync(dir, { recursive: true });
-            const filename = `img-${Date.now()}-${crypto.randomBytes(4).toString('hex')}.png`;
-            fs.writeFileSync(path.join(dir, filename), Buffer.from(b64, 'base64'));
+            const { filename, urlPath } = saveGeneratedFile('img', 'png', Buffer.from(b64, 'base64'));
 
             const alt = prompt.slice(0, 80).replace(/[[\]]/g, '');
             logger.info(`이미지 생성 완료: ${filename} (${target.fullId}/${target.source}, ${size}, prompt ${prompt.length}자)`);
             return textResult(
-                `이미지가 생성되었습니다. 아래 마크다운을 답변에 그대로 포함하세요:\n\n![${alt}](/generated/${filename})`
+                `이미지가 생성되었습니다. 아래 마크다운을 답변에 그대로 포함하세요:\n\n![${alt}](${urlPath})`
             );
         } catch (e) {
             const msg = e instanceof Error ? e.message : String(e);

--- a/apps/api/src/mcp/image-tools.ts
+++ b/apps/api/src/mcp/image-tools.ts
@@ -1,14 +1,15 @@
 /**
  * ============================================================
- * Image Tools — 이미지 생성 내장 도구 (FLUX.2-klein via LiteLLM)
+ * Image Tools — 이미지 생성 내장 도구 (모달리티 배정 → LiteLLM)
  * ============================================================
  *
- * LiteLLM proxy 의 OpenAI 호환 `/v1/images/generations` 를 호출한다
- * (vLLM-Omni 가 FLUX.2-klein 을 서빙, LiteLLM model_list 의 flux2-klein 항목).
+ * 모델은 모달리티 배정(`image_gen`, services/modality-resolver — 사용자 오버라이드 →
+ * 전역 DB → 코드 기본값 flux2-klein)으로 정하고, 호출은 LiteLLM 게이트웨이의 OpenAI 호환
+ * `/v1/images/generations` 하나로만 간다(로컬 alias·외부 `<provider>/<model>` 공통).
+ * 구 `IMAGE_GEN_MODEL` env 고정 호출은 2026-09-12 폐기 — 부팅 시더로만 1회 읽는다.
+ *
  * 생성된 PNG 는 frontend 정적 경로(generated/)에 저장하고 마크다운 이미지
  * 링크를 반환 — 채팅 본문에 인라인 렌더된다 (CSP img-src 'self' 허용).
- *
- * 활성 조건: env IMAGE_GEN_MODEL 설정 시에만 동작 (미설정 시 안내 메시지).
  *
  * @module mcp/image-tools
  */
@@ -16,16 +17,12 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as crypto from 'node:crypto';
 import { MCPToolDefinition, MCPToolResult } from './types';
-import { getConfig } from '../config';
+import { IMAGE_GEN_ALLOWED_SIZES, IMAGE_GEN_DEFAULT_SIZE, MODALITY_LIMITS } from '../config/modality';
+import { resolveModalityTarget, ModalityUnavailableError } from '../services/modality-resolver';
+import { withProviderSlot } from '../llm/external-throttle';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('ImageTools');
-
-/** 이미지 생성 LLM 호출 타임아웃 — 디퓨전 1장 수십 초 가능 */
-const IMAGE_GEN_TIMEOUT_MS = parseInt(process.env.IMAGE_GEN_TIMEOUT_MS || '', 10) || 180_000;
-
-/** 허용 size 화이트리스트 (OpenAI images API 형식) */
-const ALLOWED_SIZES = new Set(['1024x1024', '768x1024', '1024x768', '512x512']);
 
 /** 생성 이미지 저장 디렉토리 — 백엔드가 /generated/* 로 노출하는 정적 경로 (apps/legacy-web/public/generated) */
 function resolveGeneratedDir(): string {
@@ -53,35 +50,43 @@ export const generateImageTool: MCPToolDefinition = {
             required: ['prompt'],
         },
     },
-    handler: async (args): Promise<MCPToolResult> => {
-        const model = process.env.IMAGE_GEN_MODEL;
-        if (!model) {
-            return textResult('이미지 생성 모델이 설정되어 있지 않습니다 (IMAGE_GEN_MODEL 미설정). 관리자에게 문의하세요.', true);
-        }
+    handler: async (args, context): Promise<MCPToolResult> => {
         const prompt = String(args.prompt || '').trim();
         if (!prompt) return textResult('prompt 가 필요합니다.', true);
-        const size = ALLOWED_SIZES.has(String(args.size)) ? String(args.size) : '1024x1024';
 
-        const config = getConfig();
+        const userId = context?.userId !== undefined ? String(context.userId) : undefined;
+        let target;
         try {
-            const res = await fetch(`${config.llmBaseUrl}/v1/images/generations`, {
+            target = await resolveModalityTarget('image_gen', userId);
+        } catch (e) {
+            if (e instanceof ModalityUnavailableError) return textResult(`이미지 생성 불가: ${e.message}`, true);
+            throw e;
+        }
+        // 인자 size > 배정 params.size > 기본. 화이트리스트 밖은 기본으로.
+        const requested = String(args.size ?? target.params.size ?? '');
+        const size = IMAGE_GEN_ALLOWED_SIZES.has(requested) ? requested : IMAGE_GEN_DEFAULT_SIZE;
+
+        try {
+            const res = await withProviderSlot(target.providerId, () => fetch(`${target.baseUrl}${target.endpoint}`, {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${config.llmApiKey}`,
-                },
+                headers: { 'Content-Type': 'application/json', ...target.headers },
                 // response_format 미전송 — LiteLLM 이 커스텀 openai image 모델에서 이 파라미터를
                 // 거부하며(UnsupportedParamsError), vLLM-Omni 기본 응답이 이미 b64_json 이다.
-                body: JSON.stringify({ model, prompt, n: 1, size }),
-                signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT_MS),
-            });
+                body: JSON.stringify({ model: target.model, prompt, n: 1, size }),
+                signal: AbortSignal.timeout(MODALITY_LIMITS.IMAGE_GEN_TIMEOUT_MS),
+            }));
             if (!res.ok) {
                 const body = await res.text().catch(() => '');
                 logger.warn(`이미지 생성 실패: HTTP ${res.status} ${body.slice(0, 200)}`);
                 return textResult(`이미지 생성 실패 (HTTP ${res.status}). 잠시 후 다시 시도해주세요.`, true);
             }
             const json = await res.json() as { data?: Array<{ b64_json?: string; url?: string }> };
-            const b64 = json.data?.[0]?.b64_json;
+            let b64 = json.data?.[0]?.b64_json;
+            // 외부 provider 는 url 만 주는 경우가 있다 — 게이트웨이 응답의 url 을 받아 저장 (같은 타임아웃)
+            if (!b64 && json.data?.[0]?.url) {
+                const img = await fetch(json.data[0].url, { signal: AbortSignal.timeout(MODALITY_LIMITS.IMAGE_GEN_TIMEOUT_MS) });
+                if (img.ok) b64 = Buffer.from(await img.arrayBuffer()).toString('base64');
+            }
             if (!b64) return textResult('이미지 생성 응답에 데이터가 없습니다.', true);
 
             const dir = resolveGeneratedDir();
@@ -90,7 +95,7 @@ export const generateImageTool: MCPToolDefinition = {
             fs.writeFileSync(path.join(dir, filename), Buffer.from(b64, 'base64'));
 
             const alt = prompt.slice(0, 80).replace(/[[\]]/g, '');
-            logger.info(`이미지 생성 완료: ${filename} (${size}, prompt ${prompt.length}자)`);
+            logger.info(`이미지 생성 완료: ${filename} (${target.fullId}/${target.source}, ${size}, prompt ${prompt.length}자)`);
             return textResult(
                 `이미지가 생성되었습니다. 아래 마크다운을 답변에 그대로 포함하세요:\n\n![${alt}](/generated/${filename})`
             );

--- a/apps/api/src/mcp/tools.ts
+++ b/apps/api/src/mcp/tools.ts
@@ -20,6 +20,8 @@
 import { MCPToolDefinition, MCPToolResult } from './types';
 import { agentTaskTools } from './agent-task-tools';
 import { imageTools } from './image-tools';
+import { audioTools } from './audio-tools';
+import { videoTools } from './video-tools';
 
 // ============================================
 // Vision Tools (OCR / Image Analysis)
@@ -163,6 +165,8 @@ export const builtInTools: MCPToolDefinition[] = [
     ...webScraperTools,
     ...agentTaskTools,
     ...imageTools,
+    ...audioTools,
+    ...videoTools,
     createSkillTool as MCPToolDefinition,
     importSkillFromGitTool as MCPToolDefinition,
     importAgentFromGitTool as MCPToolDefinition,

--- a/apps/api/src/mcp/video-tools.ts
+++ b/apps/api/src/mcp/video-tools.ts
@@ -1,0 +1,215 @@
+/**
+ * ============================================================
+ * Video Tools — 영상 생성 내장 도구 (비동기 작업)
+ * ============================================================
+ *
+ * 모델은 모달리티 배정(`video_gen`)으로 정하고, 호출은 LiteLLM 게이트웨이 하나로만 간다.
+ *  - OpenAI 규격 provider: `POST /v1/videos` → `GET /v1/videos/{id}` → `GET /v1/videos/{id}/content`
+ *  - jobs-v1 어댑터(hasa 등, config/modality VIDEO_PROVIDER_ADAPTERS): 게이트웨이 pass-through 경유
+ *    `POST <prefix>/videos/generations` → `GET <prefix>/jobs/{id}` → artifact_url 다운로드
+ *
+ * 생성은 수 분이 걸리므로 `generate_video` 는 상한(VIDEO_WAIT_MS)까지만 기다리고, 미완이면
+ * 작업 id 를 돌려준다 — `get_video` 로 이어서 확인한다. 노출은 의도 턴에만.
+ *
+ * @module mcp/video-tools
+ */
+import { MCPToolDefinition, MCPToolResult } from './types';
+import {
+    MODALITY_LIMITS, VIDEO_GEN_DEFAULT_SECONDS, VIDEO_GEN_DEFAULT_SIZE,
+    VIDEO_DONE_STATUSES, VIDEO_TERMINAL_STATUSES, videoAdapterFor, type VideoProviderAdapter,
+} from '../config/modality';
+import { resolveModalityTarget, ModalityUnavailableError, type ModalityTarget } from '../services/modality-resolver';
+import { withProviderSlot } from '../llm/external-throttle';
+import { saveGeneratedFile } from './generated-media';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('VideoTools');
+
+function textResult(text: string, isError = false): MCPToolResult {
+    return { content: [{ type: 'text', text }], isError };
+}
+function userIdOf(context?: { userId?: string | number }): string | undefined {
+    return context?.userId !== undefined ? String(context.userId) : undefined;
+}
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+interface JobView { id: string; status: string; progress?: number; artifactUrl?: string; raw: Record<string, unknown> }
+
+/** provider 응답 형태 차이를 한 형태로 — OpenAI(id/status) · jobs-v1(job_id/status/progress/artifact_url) */
+function toJobView(json: Record<string, unknown>, adapter: VideoProviderAdapter): JobView {
+    const id = String(json.id ?? json.job_id ?? '');
+    const status = String(json.status ?? '').toLowerCase();
+    const artifactField = adapter.artifactField ?? 'artifact_url';
+    const artifactUrl = typeof json[artifactField] === 'string' ? String(json[artifactField]) : undefined;
+    const progress = typeof json.progress === 'number' ? json.progress : undefined;
+    return { id, status, progress, artifactUrl, raw: json };
+}
+
+function isDone(view: JobView, adapter: VideoProviderAdapter): boolean {
+    const done = new Set([...(adapter.doneStatuses ?? []).map((s) => s.toLowerCase()), ...VIDEO_DONE_STATUSES]);
+    return done.has(view.status);
+}
+function isTerminal(view: JobView, adapter: VideoProviderAdapter): boolean {
+    const t = new Set([
+        ...(adapter.doneStatuses ?? []).map((s) => s.toLowerCase()),
+        ...(adapter.failStatuses ?? []).map((s) => s.toLowerCase()),
+        ...VIDEO_TERMINAL_STATUSES,
+    ]);
+    return t.has(view.status);
+}
+
+function statusUrl(target: ModalityTarget, adapter: VideoProviderAdapter, id: string): string {
+    const path = adapter.kind === 'jobs-v1' && adapter.statusPath
+        ? adapter.statusPath.replace('{id}', encodeURIComponent(id))
+        : `/v1/videos/${encodeURIComponent(id)}`;
+    return `${target.baseUrl}${path}`;
+}
+
+function contentUrl(target: ModalityTarget, adapter: VideoProviderAdapter, view: JobView): string | null {
+    if (adapter.kind === 'jobs-v1') {
+        if (!view.artifactUrl) return null;
+        // 절대 URL 이면 그대로, 접두 상대 경로(`/files/..`)면 pass-through 접두 뒤에 붙인다
+        return /^https?:\/\//i.test(view.artifactUrl) ? view.artifactUrl : `${target.baseUrl}${view.artifactUrl}`;
+    }
+    return `${target.baseUrl}/v1/videos/${encodeURIComponent(view.id)}/content`;
+}
+
+async function fetchJob(target: ModalityTarget, adapter: VideoProviderAdapter, id: string): Promise<JobView> {
+    const res = await fetch(statusUrl(target, adapter, id), {
+        headers: { ...target.headers },
+        signal: AbortSignal.timeout(MODALITY_LIMITS.VIDEO_SUBMIT_TIMEOUT_MS),
+    });
+    if (!res.ok) throw new Error(`작업 조회 실패 (HTTP ${res.status}) ${(await res.text().catch(() => '')).slice(0, 160)}`);
+    return toJobView(await res.json() as Record<string, unknown>, adapter);
+}
+
+async function downloadAndSave(target: ModalityTarget, adapter: VideoProviderAdapter, view: JobView): Promise<string> {
+    const url = contentUrl(target, adapter, view);
+    if (!url) throw new Error('완료됐지만 산출물 URL 이 없습니다');
+    const res = await fetch(url, { headers: { ...target.headers }, signal: AbortSignal.timeout(MODALITY_LIMITS.VIDEO_DOWNLOAD_TIMEOUT_MS) });
+    if (!res.ok) throw new Error(`영상 다운로드 실패 (HTTP ${res.status})`);
+    const buf = Buffer.from(await res.arrayBuffer());
+    if (buf.length === 0) throw new Error('영상 파일이 비어 있습니다');
+    const ct = (res.headers.get('content-type') ?? '').toLowerCase();
+    const extFromUrl = (new URL(url).pathname.split('.').pop() ?? '').toLowerCase();
+    const ext = ct.includes('webm') || extFromUrl === 'webm' ? 'webm' : 'mp4';
+    const { urlPath } = saveGeneratedFile('video', ext, buf);
+    logger.info(`영상 저장: ${urlPath} (${target.fullId}/${target.source}, ${buf.length}B)`);
+    return urlPath;
+}
+
+/** 완료까지 waitMs 안에서 폴링. 미완이면 마지막 상태 반환 */
+async function waitForJob(target: ModalityTarget, adapter: VideoProviderAdapter, id: string, waitMs: number): Promise<JobView> {
+    const deadline = Date.now() + waitMs;
+    let view = await fetchJob(target, adapter, id);
+    while (!isTerminal(view, adapter) && Date.now() < deadline) {
+        await sleep(Math.min(MODALITY_LIMITS.VIDEO_POLL_INTERVAL_MS, Math.max(1000, deadline - Date.now())));
+        view = await fetchJob(target, adapter, id);
+    }
+    return view;
+}
+
+function pendingText(view: JobView): string {
+    const pct = view.progress !== undefined ? ` (${view.progress}%)` : '';
+    return `영상 생성이 아직 진행 중입니다${pct}. 작업 id: \`${view.id}\` — 잠시 후 get_video 도구로 video_id 를 넘겨 확인하세요.`;
+}
+
+async function finishOrPending(target: ModalityTarget, adapter: VideoProviderAdapter, view: JobView): Promise<MCPToolResult> {
+    if (isDone(view, adapter)) {
+        const urlPath = await downloadAndSave(target, adapter, view);
+        return textResult(`영상이 생성되었습니다. 아래 링크를 답변에 그대로 포함하세요:\n\n[🎬 영상 보기](${urlPath})`);
+    }
+    if (isTerminal(view, adapter)) {
+        return textResult(`영상 생성 실패 (status=${view.status}). ${JSON.stringify(view.raw).slice(0, 200)}`, true);
+    }
+    return textResult(pendingText(view));
+}
+
+export const generateVideoTool: MCPToolDefinition = {
+    tool: {
+        name: 'generate_video',
+        description:
+            '텍스트 프롬프트로 짧은 영상을 생성합니다. 사용자가 "영상/비디오/동영상 만들어줘" 라고 하면 사용하세요. ' +
+            '생성은 수 분이 걸릴 수 있어 완료되지 않으면 작업 id 를 돌려주며, get_video 로 이어서 확인합니다. ' +
+            '결과 마크다운 링크는 답변에 그대로 포함하세요. 프롬프트는 영어로 구체적으로 쓸수록 좋습니다.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                prompt: { type: 'string', description: '영상 프롬프트 (영어 권장)' },
+                seconds: { type: 'string', description: `길이(초). 기본 ${VIDEO_GEN_DEFAULT_SECONDS}` },
+                size: { type: 'string', description: `해상도 WxH. 기본 ${VIDEO_GEN_DEFAULT_SIZE}` },
+            },
+            required: ['prompt'],
+        },
+    },
+    handler: async (args, context): Promise<MCPToolResult> => {
+        const prompt = String(args.prompt || '').trim();
+        if (!prompt) return textResult('prompt 가 필요합니다.', true);
+        let target: ModalityTarget;
+        try {
+            target = await resolveModalityTarget('video_gen', userIdOf(context));
+        } catch (e) {
+            if (e instanceof ModalityUnavailableError) return textResult(`영상 생성 불가: ${e.message}`, true);
+            throw e;
+        }
+        const adapter = videoAdapterFor(target.providerId);
+        const seconds = String(args.seconds || target.params.seconds || VIDEO_GEN_DEFAULT_SECONDS);
+        const size = String(args.size || target.params.size || VIDEO_GEN_DEFAULT_SIZE);
+        try {
+            const res = await withProviderSlot(target.providerId, () => fetch(`${target.baseUrl}${target.endpoint}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', ...target.headers },
+                body: JSON.stringify({ model: target.model, prompt, seconds, size }),
+                signal: AbortSignal.timeout(MODALITY_LIMITS.VIDEO_SUBMIT_TIMEOUT_MS),
+            }));
+            if (!res.ok) {
+                const body = await res.text().catch(() => '');
+                logger.warn(`영상 생성 제출 실패: HTTP ${res.status} ${body.slice(0, 200)}`);
+                return textResult(`영상 생성 실패 (HTTP ${res.status}). ${body.slice(0, 160)}`, true);
+            }
+            const view = toJobView(await res.json() as Record<string, unknown>, adapter);
+            if (!view.id) return textResult('영상 생성 응답에 작업 id 가 없습니다.', true);
+            logger.info(`영상 생성 제출: id=${view.id} status=${view.status} (${target.fullId}/${target.source})`);
+            const finalView = isTerminal(view, adapter) ? view : await waitForJob(target, adapter, view.id, MODALITY_LIMITS.VIDEO_WAIT_MS);
+            return await finishOrPending(target, adapter, finalView);
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            logger.warn(`영상 생성 오류: ${msg}`);
+            return textResult(/timeout/i.test(msg) ? '영상 생성 요청 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.' : `영상 생성 중 오류: ${msg}`, true);
+        }
+    },
+};
+
+export const getVideoTool: MCPToolDefinition = {
+    tool: {
+        name: 'get_video',
+        description: 'generate_video 가 돌려준 작업 id 로 영상 생성 상태를 확인하고, 완료됐으면 영상 링크를 가져옵니다.',
+        inputSchema: {
+            type: 'object',
+            properties: { video_id: { type: 'string', description: 'generate_video 가 돌려준 작업 id' } },
+            required: ['video_id'],
+        },
+    },
+    handler: async (args, context): Promise<MCPToolResult> => {
+        const id = String(args.video_id || '').trim();
+        if (!id) return textResult('video_id 가 필요합니다.', true);
+        let target: ModalityTarget;
+        try {
+            target = await resolveModalityTarget('video_gen', userIdOf(context));
+        } catch (e) {
+            if (e instanceof ModalityUnavailableError) return textResult(`영상 조회 불가: ${e.message}`, true);
+            throw e;
+        }
+        const adapter = videoAdapterFor(target.providerId);
+        try {
+            const view = await fetchJob(target, adapter, id);
+            return await finishOrPending(target, adapter, view);
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            logger.warn(`영상 조회 오류: ${msg}`);
+            return textResult(`영상 조회 중 오류: ${msg}`, true);
+        }
+    },
+};
+
+export const videoTools: MCPToolDefinition[] = [generateVideoTool, getVideoTool];

--- a/apps/api/src/mcp/video-tools.ts
+++ b/apps/api/src/mcp/video-tools.ts
@@ -5,8 +5,8 @@
  *
  * 모델은 모달리티 배정(`video_gen`)으로 정하고, 호출은 LiteLLM 게이트웨이 하나로만 간다.
  *  - OpenAI 규격 provider: `POST /v1/videos` → `GET /v1/videos/{id}` → `GET /v1/videos/{id}/content`
- *  - jobs-v1 어댑터(hasa 등, config/modality VIDEO_PROVIDER_ADAPTERS): 게이트웨이 pass-through 경유
- *    `POST <prefix>/videos/generations` → `GET <prefix>/jobs/{id}` → artifact_url 다운로드
+ *  - jobs-v1 어댑터(hasa 등, config/modality VIDEO_PROVIDER_ADAPTERS): 게이트웨이가 프록시 못 하는
+ *    커스텀 API 라 사용자 키로 provider 직결(SSRF 고정 fetch) `POST /videos/generations` → `GET /jobs/{id}` → artifact_url
  *
  * 생성은 수 분이 걸리므로 `generate_video` 는 상한(VIDEO_WAIT_MS)까지만 기다리고, 미완이면
  * 작업 id 를 돌려준다 — `get_video` 로 이어서 확인한다. 노출은 의도 턴에만.
@@ -21,6 +21,7 @@ import {
 import { resolveModalityTarget, ModalityUnavailableError, type ModalityTarget } from '../services/modality-resolver';
 import { withProviderSlot } from '../llm/external-throttle';
 import { saveGeneratedFile } from './generated-media';
+import { safeFetch } from '../security/ssrf-guard';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('VideoTools');
@@ -32,6 +33,11 @@ function userIdOf(context?: { userId?: string | number }): string | undefined {
     return context?.userId !== undefined ? String(context.userId) : undefined;
 }
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** 게이트웨이(loopback)는 fetch, provider 직결(jobs-v1)은 SSRF 고정 fetch */
+function fetchFor(target: ModalityTarget): (url: string, init?: RequestInit) => Promise<Response> {
+    return target.transport === 'direct' ? (url, init) => safeFetch(url, init) : (url, init) => fetch(url, init);
+}
 
 interface JobView { id: string; status: string; progress?: number; artifactUrl?: string; raw: Record<string, unknown> }
 
@@ -68,14 +74,14 @@ function statusUrl(target: ModalityTarget, adapter: VideoProviderAdapter, id: st
 function contentUrl(target: ModalityTarget, adapter: VideoProviderAdapter, view: JobView): string | null {
     if (adapter.kind === 'jobs-v1') {
         if (!view.artifactUrl) return null;
-        // 절대 URL 이면 그대로, 접두 상대 경로(`/files/..`)면 pass-through 접두 뒤에 붙인다
+        // 절대 URL 이면 그대로, 상대 경로(`/files/..`)면 provider base 뒤에 붙인다
         return /^https?:\/\//i.test(view.artifactUrl) ? view.artifactUrl : `${target.baseUrl}${view.artifactUrl}`;
     }
     return `${target.baseUrl}/v1/videos/${encodeURIComponent(view.id)}/content`;
 }
 
 async function fetchJob(target: ModalityTarget, adapter: VideoProviderAdapter, id: string): Promise<JobView> {
-    const res = await fetch(statusUrl(target, adapter, id), {
+    const res = await fetchFor(target)(statusUrl(target, adapter, id), {
         headers: { ...target.headers },
         signal: AbortSignal.timeout(MODALITY_LIMITS.VIDEO_SUBMIT_TIMEOUT_MS),
     });
@@ -86,7 +92,7 @@ async function fetchJob(target: ModalityTarget, adapter: VideoProviderAdapter, i
 async function downloadAndSave(target: ModalityTarget, adapter: VideoProviderAdapter, view: JobView): Promise<string> {
     const url = contentUrl(target, adapter, view);
     if (!url) throw new Error('완료됐지만 산출물 URL 이 없습니다');
-    const res = await fetch(url, { headers: { ...target.headers }, signal: AbortSignal.timeout(MODALITY_LIMITS.VIDEO_DOWNLOAD_TIMEOUT_MS) });
+    const res = await fetchFor(target)(url, { headers: { ...target.headers }, signal: AbortSignal.timeout(MODALITY_LIMITS.VIDEO_DOWNLOAD_TIMEOUT_MS) });
     if (!res.ok) throw new Error(`영상 다운로드 실패 (HTTP ${res.status})`);
     const buf = Buffer.from(await res.arrayBuffer());
     if (buf.length === 0) throw new Error('영상 파일이 비어 있습니다');
@@ -156,7 +162,7 @@ export const generateVideoTool: MCPToolDefinition = {
         const seconds = String(args.seconds || target.params.seconds || VIDEO_GEN_DEFAULT_SECONDS);
         const size = String(args.size || target.params.size || VIDEO_GEN_DEFAULT_SIZE);
         try {
-            const res = await withProviderSlot(target.providerId, () => fetch(`${target.baseUrl}${target.endpoint}`, {
+            const res = await withProviderSlot(target.providerId, () => fetchFor(target)(`${target.baseUrl}${target.endpoint}`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json', ...target.headers },
                 body: JSON.stringify({ model: target.model, prompt, seconds, size }),

--- a/apps/api/src/prompts/vision-bridge.ts
+++ b/apps/api/src/prompts/vision-bridge.ts
@@ -1,0 +1,36 @@
+/**
+ * ============================================================
+ * Vision Bridge Prompt — 첨부 이미지 → 텍스트 설명
+ * ============================================================
+ *
+ * 역할 모델(텍스트 전용)이 비전을 지원하지 않을 때, 모달리티 `vision` 모델이
+ * 첨부 이미지를 텍스트로 풀어 역할 모델에 넘기기 위한 system prompt.
+ * 역할 모델을 바꿔치기하지 않는 설계의 핵심 — 설명은 "답변" 이 아니라 "관찰 기록" 이어야 한다.
+ *
+ * @module prompts/vision-bridge
+ */
+
+const KO = `당신은 이미지 관찰 기록자입니다. 첨부된 이미지 각각을 다른 모델이 텍스트만으로 이해할 수 있게 사실대로 서술하세요.
+- 보이는 것만 기술: 대상·배치·텍스트(있으면 원문 그대로 전사)·수치·색상·상태. 추측은 "~로 보임"으로 표시
+- 사용자 질문에 답하지 마세요. 질문은 서술의 초점을 정하는 데만 참고합니다
+- 이미지가 여러 장이면 "이미지 1:", "이미지 2:" 로 번호를 붙여 순서대로
+- 표·코드·화면 캡처는 구조가 보이게(행/열, 메뉴 항목, 오류 문구) 옮기세요
+- 장당 300자 이내, 마크다운 제목 없이 평문`;
+
+const EN = `You are an image observation recorder. Describe each attached image factually so that a text-only model can understand it.
+- Describe only what is visible: objects, layout, any text (transcribe verbatim), numbers, colors, states. Mark guesses as "appears to be"
+- Do NOT answer the user's question; use it only to decide what to focus on
+- For multiple images, number them "Image 1:", "Image 2:" in order
+- For tables, code, or screenshots, preserve structure (rows/columns, menu items, error messages)
+- Under 300 words per image, plain text without markdown headings`;
+
+export function getVisionBridgeSystemPrompt(lang: string): string {
+    return lang === 'ko' ? KO : EN;
+}
+
+/** 역할 모델에 주입되는 설명 블록 헤더 — 사용자 발화가 아니라 보조 관찰 기록임을 명시 */
+export function getVisionBridgeNote(lang: string, fullId: string): string {
+    return lang === 'ko'
+        ? `[첨부 이미지 관찰 기록 — 현재 모델은 이미지를 직접 볼 수 없어 비전 모델(${fullId})이 텍스트로 옮겼습니다. 아래 기록을 근거로 답하세요.]`
+        : `[Attached image observations — the current model cannot see images, so a vision model (${fullId}) transcribed them. Answer based on the notes below.]`;
+}

--- a/apps/api/src/routes/admin-modality-models.routes.ts
+++ b/apps/api/src/routes/admin-modality-models.routes.ts
@@ -70,7 +70,7 @@ adminModalityModelsRouter.put('/modality-models/:modality', validate(putSchema),
     }
     const body = req.body as z.infer<typeof putSchema>;
     const fullId = body.model.trim();
-    const reason = await validateModalityAssignment(GLOBAL_MODALITY_SCOPE, fullId);
+    const reason = await validateModalityAssignment(GLOBAL_MODALITY_SCOPE, fullId, {}, modality);
     if (reason) { res.status(400).json(badRequest(reason)); return; }
 
     const repo = new ModalityModelsRepository(getPool());

--- a/apps/api/src/routes/admin-modality-models.routes.ts
+++ b/apps/api/src/routes/admin-modality-models.routes.ts
@@ -1,0 +1,95 @@
+/**
+ * @module routes/admin-modality-models
+ * @description 전역 모달리티→모델 배정(L3) — admin 전용.
+ *
+ * "역할&모델"(admin-model-roles.routes)과 별개 축. 외부 fullId 는 서버 공용 키 등록·활성 +
+ * LLM_GATEWAY_PROVIDERS 편입이 전제(400). 호출은 LiteLLM 게이트웨이 하나로만 간다.
+ *
+ * 엔드포인트 (모두 requireAuth + requireAdmin):
+ *   GET    /api/admin/modality-models            — 전역 배정 + 코드 기본값 + 실효 해석
+ *   PUT    /api/admin/modality-models/:modality  — 배정 (body: { model, params? })
+ *   DELETE /api/admin/modality-models/:modality  — 해제 (코드 기본값 복귀)
+ */
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+import { requireAuth, requireAdmin } from '../auth';
+import { validate } from '../middlewares/validation';
+import { asyncHandler } from '../utils/error-handler';
+import { success, badRequest, notFound } from '../utils/api-response';
+import { getPool } from '../data/models/unified-database';
+import { ModalityModelsRepository } from '../data/repositories/modality-models-repo';
+import {
+    GLOBAL_MODALITY_SCOPE, MODALITIES, MODALITY_DEFAULTS, MODALITY_LIMITS,
+    isModality, sanitizeModalityParams,
+} from '../config/modality';
+import { clearGlobalModalityCache, validateModalityAssignment } from '../services/modality-resolver';
+import { describeEffectiveModalities } from '../controllers/modality-models.controller';
+import { getConfig } from '../config';
+import { getAuditService } from '../services/AuditService';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('AdminModalityModelsRoutes');
+
+const putSchema = z.object({
+    model: z.string().min(1).max(MODALITY_LIMITS.FULL_ID_MAX_CHARS),
+    params: z.record(z.string(), z.union([z.string(), z.number()])).optional(),
+});
+
+function adminUserId(req: Request): string | undefined {
+    return req.user?.id !== undefined ? String(req.user.id) : undefined;
+}
+
+async function auditChange(req: Request, action: string, details: Record<string, unknown>): Promise<void> {
+    try {
+        await getAuditService().logAudit({ action, userId: adminUserId(req), resourceType: 'modality_model', details });
+    } catch (err) {
+        logger.error('모달리티 배정 감사 기록 실패 (변경은 반영됨):', { action, details, err });
+    }
+}
+
+export const adminModalityModelsRouter = Router();
+adminModalityModelsRouter.use(requireAuth, requireAdmin);
+
+adminModalityModelsRouter.get('/modality-models', asyncHandler(async (_req: Request, res: Response) => {
+    const repo = new ModalityModelsRepository(getPool());
+    const [mappings, effective] = await Promise.all([repo.listGlobal(), describeEffectiveModalities(undefined)]);
+    res.json(success({
+        mappings,
+        effective,
+        modalities: MODALITIES,
+        defaults: MODALITY_DEFAULTS,
+        gatewayProviders: getConfig().llmGatewayProviders,
+    }));
+}));
+
+adminModalityModelsRouter.put('/modality-models/:modality', validate(putSchema), asyncHandler(async (req: Request, res: Response) => {
+    const modality = req.params.modality;
+    if (!isModality(modality)) {
+        res.status(400).json(badRequest(`알 수 없는 modality: '${modality}' (허용: ${MODALITIES.join(', ')})`));
+        return;
+    }
+    const body = req.body as z.infer<typeof putSchema>;
+    const fullId = body.model.trim();
+    const reason = await validateModalityAssignment(GLOBAL_MODALITY_SCOPE, fullId);
+    if (reason) { res.status(400).json(badRequest(reason)); return; }
+
+    const repo = new ModalityModelsRepository(getPool());
+    const { row, previous } = await repo.upsert(GLOBAL_MODALITY_SCOPE, modality, fullId, sanitizeModalityParams(modality, body.params));
+    clearGlobalModalityCache();
+    await auditChange(req, 'admin_global_modality_model_set', { modality, model: fullId, previous });
+    logger.info(`전역 모달리티 배정 저장: modality=${modality} model=${fullId}`);
+    res.json(success({ mapping: row }));
+}));
+
+adminModalityModelsRouter.delete('/modality-models/:modality', asyncHandler(async (req: Request, res: Response) => {
+    const modality = req.params.modality;
+    if (!isModality(modality)) { res.status(400).json(badRequest(`알 수 없는 modality: '${modality}'`)); return; }
+    const repo = new ModalityModelsRepository(getPool());
+    const previous = (await repo.get(GLOBAL_MODALITY_SCOPE, modality))?.fullId ?? null;
+    const deleted = await repo.delete(GLOBAL_MODALITY_SCOPE, modality);
+    if (!deleted) { res.status(404).json(notFound('전역 배정 없음')); return; }
+    clearGlobalModalityCache();
+    await auditChange(req, 'admin_global_modality_model_unset', { modality, previous });
+    logger.info(`전역 모달리티 배정 해제: modality=${modality}`);
+    res.json(success({ deleted: true }));
+}));

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -22,6 +22,7 @@ export { mcpCatalogAdminRouter } from './mcp-catalog-admin.routes';
 export { mcpAdminMonitoringRouter } from './mcp-admin-monitoring.routes';
 export { toolHealthRouter } from './tool-health.routes';
 export { adminModelRolesRouter } from './admin-model-roles.routes';
+export { adminModalityModelsRouter } from './admin-modality-models.routes';
 export { adminSystemSettingsRouter } from './admin-system-settings.routes';
 export { firstRunSetupRouter } from './first-run-setup.routes';
 export { default as kakaoMapEmbedRouter } from './kakao-map-embed.routes';

--- a/apps/api/src/routes/model.routes.ts
+++ b/apps/api/src/routes/model.routes.ts
@@ -28,6 +28,7 @@ import { buildFullModelId } from '../providers/i-provider';
 import { getProviderCatalogEntry } from '../config/external-providers';
 import { isRoleAssignableModel, isChatCapableModel } from '../config/role-model-filter';
 import { resolveExternalModels } from '../services/external-models-catalog';
+import { resolveModalityTarget } from '../services/modality-resolver';
 
 const router = Router();
 const logger = createLogger('ModelRoutes');
@@ -171,9 +172,11 @@ router.get('/models', optionalAuth, asyncHandler(async (req: Request, res: Respo
         }
     }
 
-    // 이미지 생성 모델 — 채팅 모델이 아니라 generate_image 도구가 IMAGE_GEN_MODEL 로 호출.
-    // UI 는 이 값으로 "이미지 생성 가능" 표시만 한다 (채팅 셀렉터 옵션 아님). 미설정 시 null.
-    const imageModel = process.env.IMAGE_GEN_MODEL?.trim() || null;
+    // 이미지 생성 모델 — 채팅 모델이 아니라 generate_image 도구가 모달리티 배정(image_gen)으로 호출.
+    // UI 는 이 값으로 "이미지 생성 가능" 표시만 한다 (채팅 셀렉터 옵션 아님). 미배정 시 null.
+    const imageModel = await resolveModalityTarget('image_gen', userId ?? undefined)
+        .then((t) => t.fullId)
+        .catch(() => null);
 
     // 목록 필터 2종 —
     //   usableOnly=1 (역할 배정 드롭다운·커스텀 에이전트): 채팅 불가(임베딩/이미지) + 20B 이하 제외.

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -27,6 +27,7 @@ import { createUserAgentsController } from '../controllers/user-agents.controlle
 import { createUserExtensionsController } from '../controllers/user-extensions.controller';
 import { createUserMemoriesController } from '../controllers/user-memories.controller';
 import { createUserModelRolesController } from '../controllers/user-model-roles.controller';
+import { createModalityModelsController } from '../controllers/modality-models.controller';
 import debugQueueRouter from './debug-queue.routes';
 import { default as chatRouter, setClusterManager as setChatCluster } from './chat.routes';
 import { setClusterManager as setOpenAICompatCluster } from './openai-compat.routes';
@@ -45,6 +46,7 @@ import {
     mcpAdminMonitoringRouter,
     toolHealthRouter,
     adminModelRolesRouter,
+    adminModalityModelsRouter,
     adminSystemSettingsRouter,
     firstRunSetupRouter,
     kakaoMapEmbedRouter,
@@ -208,6 +210,7 @@ export function setupApiRoutes(
     }));
     app.use('/api/admin/mcp', mcpCatalogAdminRouter);
     app.use('/api/admin', adminModelRolesRouter);
+    app.use('/api/admin', adminModalityModelsRouter);
     app.use('/api/admin', adminSystemSettingsRouter);
     app.use('/api/admin/mcp', mcpAdminMonitoringRouter);
     app.use('/api/admin/agent-task-schedules', adminAgentTaskSchedulesRouter);
@@ -261,6 +264,8 @@ export function setupApiRoutes(
     // ⚠️ 채팅 `/remember` 슬래시는 미구현 — 저장은 이 엔드포인트(POST)로만.
     app.use('/api/users/me/memories', createUserMemoriesController());
     app.use('/api/users/me/model-roles', createUserModelRolesController());
+    // 모달리티(이미지·비전·영상·오디오·임베딩)→모델 오버라이드 — 역할 배정과 별개 축 (2026-09-12)
+    app.use('/api/users/me/modality-models', createModalityModelsController());
 
     // 클러스터 의존성 주입
     setChatCluster(cluster);

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -237,6 +237,14 @@ export class DashboardServer {
             console.error('[Server] 시스템 설정 로드 실패 (env 폴백으로 계속):', err);
         }
 
+        // 모달리티 모델 배정 시더 — 구 IMAGE_GEN_MODEL env 를 전역 image_gen 행으로 1회 이관 (fail-open)
+        try {
+            const { seedModalityDefaultsFromEnv } = await import('./services/modality-resolver');
+            await seedModalityDefaultsFromEnv();
+        } catch (err) {
+            console.error('[Server] 모달리티 시딩 실패 (계속):', err);
+        }
+
         // 외부 MCP 서버 초기화 (DB에서 설정 로드 → stdio 연결)
         try {
             const { getUnifiedMCPClient } = await import('./mcp');

--- a/apps/api/src/services/ChatService.ts
+++ b/apps/api/src/services/ChatService.ts
@@ -26,6 +26,7 @@ import type { ExecutionPlan } from '../chat/profile-resolver';
 import type { UserContext } from '../mcp/user-sandbox';
 import { getUnifiedMCPClient } from '../mcp/unified-client';
 import { CHAT_ALWAYS_ON_TOOL_NAMES } from '../mcp/agent-task-tools';
+import { MODALITY_TOOL_INTENT_GATES } from '../config/modality';
 import { OPS_METRICS_TOOL_ENABLED, OPS_METRICS_INTENT_PATTERNS } from '../config/ops-metrics';
 import { MCP_META_TOOL_NAMES } from '../mcp/mcp-meta-tools';
 import { CHAT_USER_MCP_TOOL_CAP, CHAT_USER_MCP_SCHEMA_BUDGET_BYTES, MCP_PROGRESSIVE_DISCLOSURE_ENABLED, MAP_INTENT_PATTERNS, ROUTE_INTENT_PATTERNS, WEB_SEARCH_INTENT_PATTERNS, PLAN_INTENT_PATTERNS, EXTENSION_IMPORT_INTENT_PATTERNS, CHAT_USER_MCP_BREADTH_SLOTS, CHAT_TOOL_INTENT_GATE_ENABLED, AGENT_TASK_INTENT_PATTERNS } from '../config/runtime-limits';
@@ -231,6 +232,15 @@ export class ChatService {
         }
         if (ROUTE_INTENT_PATTERNS.some((re) => re.test(reqCtx.message ?? ''))) {
             forceIncludeKakao('find-route', '길찾기 의도');
+        }
+        // 모달리티 도구(TTS·STT·영상)는 상시 노출 금지 — 의도 턴에만 강제 포함 (config/modality).
+        for (const gate of MODALITY_TOOL_INTENT_GATES) {
+            if (!gate.patterns.some((re) => re.test(reqCtx.message ?? ''))) continue;
+            const t = allTools.find((x) => x.function.name === gate.tool);
+            if (t && !finalCombined.some((x) => x.function.name === gate.tool)) {
+                finalCombined = [...finalCombined, t];
+                logger.info(`[Modality] ${gate.tool} 의도 감지 — 도구 포함`);
+            }
         }
         // 명시적 웹 검색 요청이면 web_search 를 강제 포함한다 — web_search 는 always-on 이
         // 아니라 에이전트 스킬 바인딩 경유로만 노출되므로, 에이전트 매칭이 안 되는 질문

--- a/apps/api/src/services/__tests__/modality-resolver.test.ts
+++ b/apps/api/src/services/__tests__/modality-resolver.test.ts
@@ -1,0 +1,165 @@
+/**
+ * modality-resolver 단위 테스트 — DB 없이 리포지토리 mock 으로 3단 폴백·게이트웨이 불변식·키 검증 고정.
+ */
+const mockConfig = {
+    llmBaseUrl: 'http://127.0.0.1:13401/',
+    llmApiKey: 'master-key',
+    llmGatewayProviders: ['openrouter', 'hasa'],
+};
+jest.mock('../../config', () => ({ getConfig: () => mockConfig }));
+jest.mock('../../data/models/unified-database', () => ({ getPool: () => ({}) }));
+
+import {
+    resolveModalityTarget, validateModalityAssignment, clearGlobalModalityCache,
+    seedModalityDefaultsFromEnv, ModalityUnavailableError,
+} from '../modality-resolver';
+import type { ModalityModelsRepository, ModalityModelRow } from '../../data/repositories/modality-models-repo';
+import type { ExternalKeysRepository } from '../../data/repositories/external-keys-repo';
+import type { ServerExternalKeysRepository } from '../../data/repositories/server-external-keys-repo';
+
+function row(scope: string, modality: ModalityModelRow['modality'], fullId: string, params: Record<string, string> = {}): ModalityModelRow {
+    return { scope, modality, fullId, params, updatedAt: new Date() };
+}
+
+function makeDeps(opts: {
+    user?: ModalityModelRow[];
+    global?: ModalityModelRow[];
+    userKey?: string | null;
+    serverKey?: string | null;
+} = {}) {
+    const models = {
+        get: jest.fn(async (scope: string, modality: string) =>
+            (opts.user ?? []).find((r) => r.scope === scope && r.modality === modality) ?? null),
+        listGlobal: jest.fn(async () => opts.global ?? []),
+        insertIfAbsent: jest.fn(async () => true),
+    } as unknown as ModalityModelsRepository;
+    const userKeys = {
+        decryptKey: jest.fn(async () => opts.userKey ?? null),
+        getByUserAndProvider: jest.fn(async () => opts.userKey ? { isActive: true, authMethod: 'api_key' } : null),
+    } as unknown as ExternalKeysRepository;
+    const serverKeys = {
+        decryptKey: jest.fn(async () => opts.serverKey ?? null),
+        get: jest.fn(async () => opts.serverKey ? { isActive: true } : null),
+    } as unknown as ServerExternalKeysRepository;
+    return { models, userKeys, serverKeys };
+}
+
+beforeEach(() => clearGlobalModalityCache());
+
+describe('resolveModalityTarget — 우선순위', () => {
+    it('사용자 오버라이드 > 전역 > 기본값', async () => {
+        const deps = makeDeps({
+            user: [row('u1', 'image_gen', 'local-llm:user-flux')],
+            global: [row('__global__', 'image_gen', 'local-llm:global-flux')],
+        });
+        const t = await resolveModalityTarget('image_gen', 'u1', deps);
+        expect(t).toMatchObject({ source: 'user', model: 'user-flux', providerId: 'local-llm' });
+        expect(t.baseUrl).toBe('http://127.0.0.1:13401');
+        expect(t.endpoint).toBe('/v1/images/generations');
+        expect(t.headers).toEqual({ Authorization: 'Bearer master-key' });
+    });
+
+    it('사용자 행 없으면 전역, 전역도 없으면 코드 기본값(flux2-klein)', async () => {
+        const g = await resolveModalityTarget('image_gen', 'u1', makeDeps({ global: [row('__global__', 'image_gen', 'flux-g')] }));
+        expect(g).toMatchObject({ source: 'global', model: 'flux-g' });
+        clearGlobalModalityCache(); // 전역 캐시(60s TTL)는 프로세스 전역 — 다음 해석이 새 리포를 보게 한다
+        const d = await resolveModalityTarget('image_gen', 'u1', makeDeps());
+        expect(d).toMatchObject({ source: 'default', model: 'flux2-klein' });
+    });
+
+    it('기본값 없는 모달리티(tts)는 MODALITY_UNASSIGNED 로 throw (조용한 폴백 금지)', async () => {
+        await expect(resolveModalityTarget('tts', 'u1', makeDeps())).rejects.toMatchObject({ code: 'MODALITY_UNASSIGNED' });
+    });
+
+    it('userId 없으면 사용자 조회를 건너뛴다', async () => {
+        const deps = makeDeps({ global: [row('__global__', 'embedding', 'local-llm:bge')] });
+        await resolveModalityTarget('embedding', undefined, deps);
+        expect(deps.models.get).not.toHaveBeenCalled();
+    });
+});
+
+describe('resolveModalityTarget — 외부 provider 는 게이트웨이 하나로', () => {
+    it('사용자 BYOK 외부 모델 → model=<provider>/<model>, x-api-key=BYOK, Authorization=master', async () => {
+        const deps = makeDeps({ user: [row('u1', 'image_gen', 'openrouter:sd-xl', { size: '512x512' })], userKey: 'byok' });
+        const t = await resolveModalityTarget('image_gen', 'u1', deps);
+        expect(t).toMatchObject({ source: 'user', providerId: 'openrouter', model: 'openrouter/sd-xl', params: { size: '512x512' } });
+        expect(t.headers).toEqual({ Authorization: 'Bearer master-key', 'x-api-key': 'byok' });
+        expect(t.baseUrl).toBe('http://127.0.0.1:13401');
+    });
+
+    it('전역 외부 모델은 서버 공용 키를 쓴다', async () => {
+        const deps = makeDeps({ global: [row('__global__', 'tts', 'hasa:tts-1')], serverKey: 'srv' });
+        const t = await resolveModalityTarget('tts', 'u1', deps);
+        expect(t.headers['x-api-key']).toBe('srv');
+        expect(t.endpoint).toBe('/v1/audio/speech');
+    });
+
+    it('게이트웨이 미편입 provider 는 MODALITY_PROVIDER_NOT_GATEWAY', async () => {
+        const deps = makeDeps({ user: [row('u1', 'image_gen', 'nvidia:flux')], userKey: 'k' });
+        await expect(resolveModalityTarget('image_gen', 'u1', deps)).rejects.toMatchObject({ code: 'MODALITY_PROVIDER_NOT_GATEWAY' });
+    });
+
+    it('키가 없으면 MODALITY_KEY_MISSING (사용자 행은 BYOK, 전역 행은 서버 키)', async () => {
+        const u = makeDeps({ user: [row('u1', 'image_gen', 'openrouter:x')], userKey: null, serverKey: 'srv' });
+        await expect(resolveModalityTarget('image_gen', 'u1', u)).rejects.toMatchObject({ code: 'MODALITY_KEY_MISSING' });
+        const g = makeDeps({ global: [row('__global__', 'image_gen', 'openrouter:x')], userKey: 'byok', serverKey: null });
+        await expect(resolveModalityTarget('image_gen', 'u1', g)).rejects.toMatchObject({ code: 'MODALITY_KEY_MISSING' });
+    });
+
+    it('ModalityUnavailableError 는 AppError(400) 계약을 따른다', async () => {
+        try {
+            await resolveModalityTarget('stt', 'u1', makeDeps());
+            throw new Error('unreachable');
+        } catch (e) {
+            expect(e).toBeInstanceOf(ModalityUnavailableError);
+            expect((e as ModalityUnavailableError).statusCode).toBe(400);
+        }
+    });
+});
+
+describe('validateModalityAssignment', () => {
+    it('로컬 태그는 통과, 빈 외부 모델 id 는 거절', async () => {
+        expect(await validateModalityAssignment('u1', 'local-llm:flux2-klein')).toBeNull();
+        expect(await validateModalityAssignment('u1', 'flux2-klein')).toBeNull();
+        expect(await validateModalityAssignment('u1', 'openrouter:')).toMatch(/비어/);
+    });
+
+    it('게이트웨이 미편입 provider 는 거절', async () => {
+        const r = await validateModalityAssignment('u1', 'nvidia:some-model', makeDeps({ userKey: 'k' }));
+        expect(r).toMatch(/LLM_GATEWAY_PROVIDERS/);
+    });
+
+    it('사용자 scope 는 BYOK 키, 전역 scope 는 서버 키를 요구한다', async () => {
+        expect(await validateModalityAssignment('u1', 'openrouter:m', makeDeps({ userKey: null }))).toMatch(/키를 먼저 등록/);
+        expect(await validateModalityAssignment('u1', 'openrouter:m', makeDeps({ userKey: 'k' }))).toBeNull();
+        expect(await validateModalityAssignment('__global__', 'hasa:m', makeDeps({ serverKey: null }))).toMatch(/서버 공용 키/);
+        expect(await validateModalityAssignment('__global__', 'hasa:m', makeDeps({ serverKey: 's' }))).toBeNull();
+    });
+
+    it('OAuth 연결(direct 전용)은 사용자 scope 에서 거절', async () => {
+        const deps = makeDeps({ userKey: 'k' });
+        (deps.userKeys.getByUserAndProvider as jest.Mock).mockResolvedValueOnce({ isActive: true, authMethod: 'oauth' });
+        expect(await validateModalityAssignment('u1', 'openrouter:m', deps)).toMatch(/OAuth/);
+    });
+});
+
+describe('seedModalityDefaultsFromEnv — 구 IMAGE_GEN_MODEL 1회 이관', () => {
+    const saved = process.env.IMAGE_GEN_MODEL;
+    afterEach(() => {
+        if (saved === undefined) delete process.env.IMAGE_GEN_MODEL; else process.env.IMAGE_GEN_MODEL = saved;
+    });
+
+    it('env 없으면 no-op', async () => {
+        delete process.env.IMAGE_GEN_MODEL;
+        const deps = makeDeps();
+        await seedModalityDefaultsFromEnv(deps.models);
+        expect(deps.models.insertIfAbsent).not.toHaveBeenCalled();
+    });
+
+    it('env 값은 local-llm: 접두를 붙여 전역 image_gen 에 insertIfAbsent', async () => {
+        process.env.IMAGE_GEN_MODEL = 'flux2-klein';
+        const deps = makeDeps();
+        await seedModalityDefaultsFromEnv(deps.models);
+        expect(deps.models.insertIfAbsent).toHaveBeenCalledWith('__global__', 'image_gen', 'local-llm:flux2-klein');
+    });
+});

--- a/apps/api/src/services/__tests__/modality-resolver.test.ts
+++ b/apps/api/src/services/__tests__/modality-resolver.test.ts
@@ -143,28 +143,32 @@ describe('validateModalityAssignment', () => {
     });
 });
 
-describe('영상 jobs-v1 어댑터(hasa) — pass-through·전역 전용', () => {
-    it('전역 배정은 통과, 사용자 scope 는 거절(BYOK 를 pass-through 에 실을 수 없음)', async () => {
-        expect(await validateModalityAssignment('__global__', 'hasa:Wan2.2-T2V', makeDeps(), 'video_gen')).toBeNull();
-        expect(await validateModalityAssignment('u1', 'hasa:Wan2.2-T2V', makeDeps({ userKey: 'k' }), 'video_gen')).toMatch(/전역 배정만/);
-        // 같은 provider 라도 다른 모달리티(tts)는 종전 규칙(사용자 BYOK 허용)
-        expect(await validateModalityAssignment('u1', 'hasa:melotts-ko', makeDeps({ userKey: 'k' }), 'tts')).toBeNull();
+describe('영상 jobs-v1 어댑터(hasa) — 게이트웨이가 프록시 못 하는 커스텀 API 는 사용자 키로 직결', () => {
+    it('사용자·전역 배정 모두 종전 키 규칙(BYOK / 서버 키)', async () => {
+        expect(await validateModalityAssignment('u1', 'hasa:Wan2.2-T2V', makeDeps({ userKey: 'k' }), 'video_gen')).toBeNull();
+        expect(await validateModalityAssignment('u1', 'hasa:Wan2.2-T2V', makeDeps({ userKey: null }), 'video_gen')).toMatch(/키를 먼저 등록/);
+        expect(await validateModalityAssignment('__global__', 'hasa:Wan2.2-T2V', makeDeps({ serverKey: 's' }), 'video_gen')).toBeNull();
     });
 
-    it('해석 결과는 pass-through 접두 + 제출 경로, 헤더는 master 만(upstream 키는 LiteLLM 정적 헤더)', async () => {
-        const deps = makeDeps({ global: [row('__global__', 'video_gen', 'hasa:Wan2.2-T2V')], serverKey: null });
+    it('사용자 행: provider base(등록 baseUrl 우선) + 제출 경로, Authorization=BYOK, transport=direct', async () => {
+        const deps = makeDeps({ user: [row('u1', 'video_gen', 'hasa:Wan2.2-T2V')], userKey: 'byok' });
+        (deps.userKeys.getByUserAndProvider as jest.Mock).mockResolvedValue({ isActive: true, authMethod: 'api_key', baseUrl: 'https://custom.hasa/v1/' });
         const t = await resolveModalityTarget('video_gen', 'u1', deps);
-        expect(t.baseUrl).toBe('http://127.0.0.1:13401/passthrough/hasa');
-        expect(t.endpoint).toBe('/videos/generations');
-        expect(t.model).toBe('Wan2.2-T2V');
-        expect(t.headers).toEqual({ Authorization: 'Bearer master-key' });
+        expect(t).toMatchObject({ transport: 'direct', baseUrl: 'https://custom.hasa/v1', endpoint: '/videos/generations', model: 'Wan2.2-T2V' });
+        expect(t.headers).toEqual({ Authorization: 'Bearer byok' });
     });
 
-    it('OpenAI 규격 provider 의 영상은 종전 경로(/v1/videos, x-api-key)', async () => {
+    it('전역 행: 카탈로그 기본 base + 서버 키', async () => {
+        const deps = makeDeps({ global: [row('__global__', 'video_gen', 'hasa:Wan2.2-T2V')], serverKey: 'srv' });
+        const t = await resolveModalityTarget('video_gen', undefined, deps);
+        expect(t).toMatchObject({ transport: 'direct', baseUrl: 'https://open.hasa.re.kr/v1' });
+        expect(t.headers).toEqual({ Authorization: 'Bearer srv' });
+    });
+
+    it('OpenAI 규격 provider 의 영상은 게이트웨이(/v1/videos, x-api-key)', async () => {
         const deps = makeDeps({ global: [row('__global__', 'video_gen', 'openrouter:sora')], serverKey: 'srv' });
         const t = await resolveModalityTarget('video_gen', undefined, deps);
-        expect(t.endpoint).toBe('/v1/videos');
-        expect(t.model).toBe('openrouter/sora');
+        expect(t).toMatchObject({ transport: 'gateway', endpoint: '/v1/videos', model: 'openrouter/sora' });
         expect(t.headers['x-api-key']).toBe('srv');
     });
 });

--- a/apps/api/src/services/__tests__/modality-resolver.test.ts
+++ b/apps/api/src/services/__tests__/modality-resolver.test.ts
@@ -143,6 +143,32 @@ describe('validateModalityAssignment', () => {
     });
 });
 
+describe('영상 jobs-v1 어댑터(hasa) — pass-through·전역 전용', () => {
+    it('전역 배정은 통과, 사용자 scope 는 거절(BYOK 를 pass-through 에 실을 수 없음)', async () => {
+        expect(await validateModalityAssignment('__global__', 'hasa:Wan2.2-T2V', makeDeps(), 'video_gen')).toBeNull();
+        expect(await validateModalityAssignment('u1', 'hasa:Wan2.2-T2V', makeDeps({ userKey: 'k' }), 'video_gen')).toMatch(/전역 배정만/);
+        // 같은 provider 라도 다른 모달리티(tts)는 종전 규칙(사용자 BYOK 허용)
+        expect(await validateModalityAssignment('u1', 'hasa:melotts-ko', makeDeps({ userKey: 'k' }), 'tts')).toBeNull();
+    });
+
+    it('해석 결과는 pass-through 접두 + 제출 경로, 헤더는 master 만(upstream 키는 LiteLLM 정적 헤더)', async () => {
+        const deps = makeDeps({ global: [row('__global__', 'video_gen', 'hasa:Wan2.2-T2V')], serverKey: null });
+        const t = await resolveModalityTarget('video_gen', 'u1', deps);
+        expect(t.baseUrl).toBe('http://127.0.0.1:13401/passthrough/hasa');
+        expect(t.endpoint).toBe('/videos/generations');
+        expect(t.model).toBe('Wan2.2-T2V');
+        expect(t.headers).toEqual({ Authorization: 'Bearer master-key' });
+    });
+
+    it('OpenAI 규격 provider 의 영상은 종전 경로(/v1/videos, x-api-key)', async () => {
+        const deps = makeDeps({ global: [row('__global__', 'video_gen', 'openrouter:sora')], serverKey: 'srv' });
+        const t = await resolveModalityTarget('video_gen', undefined, deps);
+        expect(t.endpoint).toBe('/v1/videos');
+        expect(t.model).toBe('openrouter/sora');
+        expect(t.headers['x-api-key']).toBe('srv');
+    });
+});
+
 describe('seedModalityDefaultsFromEnv — 구 IMAGE_GEN_MODEL 1회 이관', () => {
     const saved = process.env.IMAGE_GEN_MODEL;
     afterEach(() => {

--- a/apps/api/src/services/__tests__/modality-resolver.test.ts
+++ b/apps/api/src/services/__tests__/modality-resolver.test.ts
@@ -173,6 +173,16 @@ describe('영상 jobs-v1 어댑터(hasa) — 게이트웨이가 프록시 못 �
     });
 });
 
+describe('provider 별 params 기본값', () => {
+    it('hasa tts 는 voice=KR·format=wav 가 기본이고 배정 params 가 우선한다', async () => {
+        const a = await resolveModalityTarget('tts', undefined, makeDeps({ global: [row('__global__', 'tts', 'hasa:melotts-ko')], serverKey: 's' }));
+        expect(a.params).toEqual({ voice: 'KR', format: 'wav' });
+        clearGlobalModalityCache();
+        const b = await resolveModalityTarget('tts', undefined, makeDeps({ global: [row('__global__', 'tts', 'hasa:melotts-ko', { voice: 'EN' })], serverKey: 's' }));
+        expect(b.params).toEqual({ voice: 'EN', format: 'wav' });
+    });
+});
+
 describe('seedModalityDefaultsFromEnv — 구 IMAGE_GEN_MODEL 1회 이관', () => {
     const saved = process.env.IMAGE_GEN_MODEL;
     afterEach(() => {

--- a/apps/api/src/services/chat-service/__tests__/vision-bridge.test.ts
+++ b/apps/api/src/services/chat-service/__tests__/vision-bridge.test.ts
@@ -1,0 +1,69 @@
+/** vision-bridge — 미배정 null / 호출 wire(게이트웨이·헤더·image_url) / 상한 초과 생략 / 실패 throw */
+const mockResolve = jest.fn();
+jest.mock('../../modality-resolver', () => {
+    const actual = jest.requireActual('../../modality-resolver');
+    return { ...actual, resolveModalityTarget: (...a: unknown[]) => mockResolve(...a) };
+});
+jest.mock('../../../data/models/unified-database', () => ({ getPool: () => ({}) }));
+
+import { describeImagesForTextModel } from '../vision-bridge';
+import { ModalityUnavailableError } from '../../modality-resolver';
+import { MODALITY_LIMITS } from '../../../config/modality';
+
+const target = {
+    modality: 'vision', fullId: 'hasa:qwen-vl', providerId: 'hasa', model: 'hasa/qwen-vl',
+    baseUrl: 'http://gw', endpoint: '/v1/chat/completions',
+    headers: { Authorization: 'Bearer m', 'x-api-key': 'k' }, params: { detail: 'low' }, source: 'user',
+};
+const okFetch = (text = '이미지 1: 빨간 원') => jest.fn(async () => ({
+    ok: true, status: 200, json: async () => ({ choices: [{ message: { content: text } }] }), text: async () => '',
+})) as unknown as typeof fetch;
+
+beforeEach(() => mockResolve.mockReset());
+
+it('vision 미배정이면 null (호출부가 종전 400)', async () => {
+    mockResolve.mockRejectedValue(new ModalityUnavailableError('x', 'MODALITY_UNASSIGNED'));
+    const r = await describeImagesForTextModel({ images: ['AAAA'], userMessage: 'q', lang: 'ko', fetchImpl: okFetch() });
+    expect(r).toBeNull();
+});
+
+it('키 없음 등 다른 사유는 throw (조용한 폴백 금지)', async () => {
+    mockResolve.mockRejectedValue(new ModalityUnavailableError('no key', 'MODALITY_KEY_MISSING'));
+    await expect(describeImagesForTextModel({ images: ['AAAA'], userMessage: 'q', lang: 'ko', fetchImpl: okFetch() })).rejects.toMatchObject({ code: 'MODALITY_KEY_MISSING' });
+});
+
+it('게이트웨이 1곳으로 image_url 블록 + 헤더 계약 + params.detail 을 싣는다', async () => {
+    mockResolve.mockResolvedValue(target);
+    const f = okFetch();
+    const r = await describeImagesForTextModel({ images: ['data:image/png;base64,AAAA', 'BBBB'], userMessage: '이게 뭐야', userId: 'u1', lang: 'ko', fetchImpl: f });
+    expect(r).toMatchObject({ fullId: 'hasa:qwen-vl', imageCount: 2, skipped: 0 });
+    expect(r!.note).toContain('관찰 기록');
+    expect(r!.note).toContain('이미지 1: 빨간 원');
+    const [url, init] = (f as unknown as jest.Mock).mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://gw/v1/chat/completions');
+    expect((init.headers as Record<string, string>)['x-api-key']).toBe('k');
+    const body = JSON.parse(init.body as string);
+    expect(body.model).toBe('hasa/qwen-vl');
+    expect(body.stream).toBe(false);
+    const blocks = body.messages[1].content;
+    expect(blocks.filter((b: { type: string }) => b.type === 'image_url')).toHaveLength(2);
+    expect(blocks[1].image_url.url).toBe('data:image/png;base64,AAAA');
+    expect(blocks[2].image_url.url).toMatch(/^data:image\//);
+    expect(blocks[1].image_url.detail).toBe('low');
+    expect(mockResolve).toHaveBeenCalledWith('vision', 'u1');
+});
+
+it('상한 초과 이미지는 생략하고 안내를 붙인다', async () => {
+    mockResolve.mockResolvedValue(target);
+    const images = Array.from({ length: MODALITY_LIMITS.VISION_BRIDGE_MAX_IMAGES + 2 }, () => 'AAAA');
+    const r = await describeImagesForTextModel({ images, userMessage: '', lang: 'en', fetchImpl: okFetch('Image 1: x') });
+    expect(r).toMatchObject({ imageCount: MODALITY_LIMITS.VISION_BRIDGE_MAX_IMAGES, skipped: 2 });
+    expect(r!.note).toContain('2 skipped');
+});
+
+it('HTTP 오류·빈 응답은 throw', async () => {
+    mockResolve.mockResolvedValue(target);
+    const bad = jest.fn(async () => ({ ok: false, status: 502, text: async () => 'upstream', json: async () => ({}) })) as unknown as typeof fetch;
+    await expect(describeImagesForTextModel({ images: ['AAAA'], userMessage: '', lang: 'ko', fetchImpl: bad })).rejects.toThrow(/HTTP 502/);
+    await expect(describeImagesForTextModel({ images: ['AAAA'], userMessage: '', lang: 'ko', fetchImpl: okFetch('   ') })).rejects.toThrow(/비어/);
+});

--- a/apps/api/src/services/chat-service/external-provider.ts
+++ b/apps/api/src/services/chat-service/external-provider.ts
@@ -28,6 +28,7 @@ import type { ResolvedProvider } from '../../providers/provider-router';
 import { executeExternalTool, recordExternalUsageFireAndForget } from './external-tool-exec';
 
 import { resolveModelCapabilities } from './model-capabilities';
+import { describeImagesForTextModel } from './vision-bridge';
 import { markModelUnusableFireAndForget } from './external-model-availability';
 import { appendDeterministicBlocks } from './external-deterministic-append';
 
@@ -81,9 +82,6 @@ export async function runExternalStream(
     const wantsSpawn = AGENT_SPAWN.ENABLED
         && SPAWN_INTENT_PATTERNS.some((re) => re.test(req.message ?? ''));
 
-    // 메시지 배열 조립(시스템 프롬프트 + history + 현재 turn)은 external-messages 로 분리.
-    const messages = buildExternalMessages({ req, resolved, ctx, wantsMap, orchestration, wantsSpawn });
-
 
     // 토큰 쿼터 정책(2026-07-26 결정): 이 경로는 LLMClient 를 우회하므로 로컬 쿼터
     // (LLM_HOURLY/WEEKLY_TOKEN_LIMIT)를 타지 않는다. **의도된 면제**다 — 그 한도는 로컬
@@ -107,6 +105,9 @@ export async function runExternalStream(
         );
     }
 
+    // 역할 모델이 비전을 못 보면 모달리티 `vision` 모델이 첨부를 텍스트 관찰 기록으로 옮긴다
+    // (역할 모델 교체 없음 — 컨텍스트·prefix cache 유지). vision 미배정이면 종전 400.
+    let effectiveReq: ChatMessageRequest = req;
     if (hasImages && !caps.vision) {
         // 휴리스틱 기반 '부정' 은 신뢰하지 않는다 — 오차단(진짜 비전 모델 400)이 실제
         // 장애였다. 이 경우 그대로 진행하고, 정말 미지원이면 upstream 오류 →
@@ -115,15 +116,37 @@ export async function runExternalStream(
             logger.warn(
                 `[Vision] '${resolved.fullId}' vision 판정이 휴리스틱(부정) — 차단하지 않고 진행`,
             );
+        } else if (!req.images || req.images.length === 0) {
+            // 현재 턴엔 이미지가 없고 history 에만 남은 경우 — 기록 대상이 아니므로 제거만 한다.
+            logger.info(`[VisionBridge] '${resolved.fullId}' 는 비전 미지원 — history 이미지만 제거하고 진행`);
+            effectiveReq = { ...req, history: (req.history ?? []).map((h) => (h.images ? { ...h, images: undefined } : h)) };
         } else {
-            const err = new Error(
-                `Model '${resolved.fullId}' does not support vision input (capabilities.vision=false, source=${capsSource}). ` +
-                'Use a vision-capable model or remove images from the request.',
-            );
-            (err as Error & { statusCode?: number }).statusCode = 400;
-            throw err;
+            const bridged = await describeImagesForTextModel({
+                images: req.images ?? [],
+                userMessage: req.message ?? '',
+                userId: req.userId,
+                lang: ctx.resolvedLanguage || req.userLanguagePreference || 'en',
+            });
+            if (!bridged) {
+                const err = new Error(
+                    `Model '${resolved.fullId}' does not support vision input (capabilities.vision=false, source=${capsSource}). ` +
+                    'Use a vision-capable model, assign a vision modality model, or remove images from the request.',
+                );
+                (err as Error & { statusCode?: number }).statusCode = 400;
+                throw err;
+            }
+            // 현재 턴 이미지는 기록으로 대체, history 의 이미지는 제거(이번 턴 초점 밖 — 기록 대상 아님).
+            effectiveReq = {
+                ...req,
+                images: undefined,
+                message: `${req.message ?? ''}\n\n${bridged.note}`,
+                history: (req.history ?? []).map((h) => (h.images ? { ...h, images: undefined } : h)),
+            };
         }
     }
+
+    // 메시지 배열 조립(시스템 프롬프트 + history + 현재 turn)은 external-messages 로 분리.
+    const messages = buildExternalMessages({ req: effectiveReq, resolved, ctx, wantsMap, orchestration, wantsSpawn });
 
     // 도구 노출·억제·첫 턴 강제 결정은 external-tool-plan 으로 분리 (동작 동일).
     const { tools, forcedFirstTurnToolName } = buildExternalToolPlan({

--- a/apps/api/src/services/chat-service/vision-bridge.ts
+++ b/apps/api/src/services/chat-service/vision-bridge.ts
@@ -1,0 +1,99 @@
+/**
+ * @module services/chat-service/vision-bridge
+ * @description 역할(채팅) 모델이 비전을 지원하지 않을 때 모달리티 `vision` 모델이 첨부 이미지를
+ * 텍스트 관찰 기록으로 옮겨 넘긴다 — 역할 모델을 바꿔치기하지 않는다(컨텍스트·prefix cache 유지).
+ *
+ * 호출은 LiteLLM 게이트웨이 `/v1/chat/completions` 하나(로컬 alias·외부 `<provider>/<model>` 공통),
+ * provider 세마포어(withProviderSlot) 공유. `vision` 미배정이면 null 을 돌려 호출부가 종전 400 을 낸다
+ * (조용한 폴백 금지 — 배정하면 동작이 바뀐다는 것을 로그로 남긴다).
+ */
+import { MODALITY_LIMITS } from '../../config/modality';
+import { resolveModalityTarget, ModalityUnavailableError } from '../modality-resolver';
+import { withProviderSlot } from '../../llm/external-throttle';
+import { getVisionBridgeSystemPrompt, getVisionBridgeNote } from '../../prompts/vision-bridge';
+import { inferImageMime } from '../../utils/image-mime';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('VisionBridge');
+
+export interface VisionBridgeResult {
+    /** 역할 모델의 user 메시지 끝에 덧붙일 블록(헤더 + 관찰 기록) */
+    note: string;
+    fullId: string;
+    imageCount: number;
+    skipped: number;
+}
+
+export interface VisionBridgeInput {
+    images: string[];
+    userMessage: string;
+    userId?: string;
+    lang: string;
+    /** 테스트 주입용 */
+    fetchImpl?: typeof fetch;
+}
+
+function toDataUrl(img: string): string {
+    return img.startsWith('data:') ? img : `data:${inferImageMime(img)};base64,${img}`;
+}
+
+/**
+ * 첨부 이미지를 vision 모델로 설명한다. vision 미배정이면 null(호출부가 종전 동작).
+ * 호출 실패는 throw — 호출부가 사용자에게 사유를 보이게 한다(이미지를 조용히 버리지 않는다).
+ */
+export async function describeImagesForTextModel(input: VisionBridgeInput): Promise<VisionBridgeResult | null> {
+    let target;
+    try {
+        target = await resolveModalityTarget('vision', input.userId);
+    } catch (err) {
+        if (err instanceof ModalityUnavailableError && err.code === 'MODALITY_UNASSIGNED') {
+            logger.info('[VisionBridge] vision 모달리티 미배정 — 브리지 생략(종전 400 유지)');
+            return null;
+        }
+        throw err;
+    }
+
+    const max = MODALITY_LIMITS.VISION_BRIDGE_MAX_IMAGES;
+    const images = input.images.slice(0, max);
+    const skipped = input.images.length - images.length;
+    const content: Array<Record<string, unknown>> = [
+        { type: 'text', text: input.userMessage ? `사용자 질문(초점 참고용): ${input.userMessage.slice(0, 500)}` : '첨부 이미지를 서술하세요.' },
+        ...images.map((img) => ({ type: 'image_url', image_url: { url: toDataUrl(img), ...(target.params.detail ? { detail: target.params.detail } : {}) } })),
+    ];
+    const body = {
+        model: target.model,
+        messages: [
+            { role: 'system', content: getVisionBridgeSystemPrompt(input.lang) },
+            { role: 'user', content },
+        ],
+        max_tokens: MODALITY_LIMITS.VISION_BRIDGE_MAX_TOKENS,
+        stream: false,
+    };
+    const doFetch = input.fetchImpl ?? fetch;
+    const startedAt = Date.now();
+    const res = await withProviderSlot(target.providerId, () => doFetch(`${target.baseUrl}${target.endpoint}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...target.headers },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(MODALITY_LIMITS.VISION_BRIDGE_TIMEOUT_MS),
+    }));
+    if (!res.ok) {
+        const text = (await res.text().catch(() => '')).slice(0, 200);
+        throw new Error(`vision 모델(${target.fullId}) 호출 실패: HTTP ${res.status} ${text}`);
+    }
+    const json = await res.json() as { choices?: Array<{ message?: { content?: string | Array<{ text?: string }> } }> };
+    const raw = json.choices?.[0]?.message?.content;
+    const text = (typeof raw === 'string' ? raw : (raw ?? []).map((b) => b.text ?? '').join('')).trim();
+    if (!text) throw new Error(`vision 모델(${target.fullId}) 응답이 비어 있습니다`);
+
+    logger.info(`[VisionBridge] ${images.length}장 → ${text.length}자 (${target.fullId}/${target.source}, ${Date.now() - startedAt}ms${skipped ? `, 초과 ${skipped}장 생략` : ''})`);
+    const skippedNote = skipped > 0
+        ? (input.lang === 'ko' ? `\n(첨부 ${input.images.length}장 중 ${max}장만 기록 — 상한 초과 ${skipped}장 생략)` : `\n(${max} of ${input.images.length} images recorded — ${skipped} skipped over the limit)`)
+        : '';
+    return {
+        note: `${getVisionBridgeNote(input.lang, target.fullId)}\n${text}${skippedNote}`,
+        fullId: target.fullId,
+        imageCount: images.length,
+        skipped,
+    };
+}

--- a/apps/api/src/services/modality-resolver.ts
+++ b/apps/api/src/services/modality-resolver.ts
@@ -27,6 +27,7 @@ import {
     MODALITY_ENDPOINT,
     MODALITY_LIMITS,
     videoAdapterFor,
+    providerParamDefaults,
     type Modality,
 } from '../config/modality';
 import { EXTERNAL_PROVIDER_CATALOG } from '../config/external-providers';
@@ -152,6 +153,7 @@ async function externalTarget(
 ): Promise<ModalityTarget> {
     const cfg = getConfig();
     const { providerId, modelId } = splitFullId(fullId);
+    params = { ...providerParamDefaults(providerId, modality), ...params };
     const entry = EXTERNAL_PROVIDER_CATALOG.find((p) => p.id === providerId);
     if (!entry) throw new ModalityUnavailableError(`카탈로그에 없는 provider '${providerId}'`, 'MODALITY_PROVIDER_UNKNOWN');
     if (!cfg.llmGatewayProviders.includes(providerId)) {

--- a/apps/api/src/services/modality-resolver.ts
+++ b/apps/api/src/services/modality-resolver.ts
@@ -14,6 +14,8 @@
  *  - 외부: `LLM_GATEWAY_PROVIDERS` 편입 provider 만. model = `<provider>/<model>`,
  *    Authorization = master, `x-api-key` = 사용자/서버 키 (openai-compat-provider 의 헤더 계약과 동일)
  *  - direct 전용 provider(chatgpt OAuth 등)는 배정 자체를 거부한다.
+ *  - 예외: jobs-v1 영상(config/modality VIDEO_PROVIDER_ADAPTERS — hasa)은 게이트웨이가 프록시하지
+ *    못하는 커스텀 API 라 사용자 키로 provider 직결(`transport: 'direct'`, 도구가 SSRF 고정 fetch 사용).
  *
  * 실패는 조용히 폴백하지 않고 ModalityUnavailableError(code) 로 명시한다 — 도구가
  * 사용자에게 사유를 안내해야 "이미지가 안 나온다" 가 설정 문제임을 알 수 있다.
@@ -63,6 +65,8 @@ export interface ModalityTarget {
     headers: Record<string, string>;
     params: Record<string, string>;
     source: 'user' | 'global' | 'default';
+    /** 'gateway'(기본) | 'direct' — jobs-v1 영상처럼 게이트웨이가 프록시 못 하는 경우만 provider 직결 */
+    transport: 'gateway' | 'direct';
 }
 
 /** 배정 시점 검증 — 저장 전에 같은 규칙을 적용해 해석 시점 실패를 앞당긴다 */
@@ -70,7 +74,7 @@ export async function validateModalityAssignment(
     scope: string,
     fullId: string,
     deps: { userKeys?: ExternalKeysRepository; serverKeys?: ServerExternalKeysRepository } = {},
-    modality?: Modality,
+    _modality?: Modality,
 ): Promise<string | null> {
     if (!isExternalFullId(fullId)) {
         return toLocalModelTag(fullId) ? null : `해석 불가한 모델 id: '${fullId}'`;
@@ -82,12 +86,6 @@ export async function validateModalityAssignment(
     if (entry.sdkType !== 'openai-compatible') return `provider '${providerId}' 는 OpenAI 호환이 아니라 모달리티 배정을 지원하지 않습니다`;
     if (!getConfig().llmGatewayProviders.includes(providerId)) {
         return `provider '${providerId}' 는 LiteLLM 게이트웨이에 편입되지 않아 배정할 수 없습니다 (LLM_GATEWAY_PROVIDERS)`;
-    }
-    if (modality === 'video_gen' && videoAdapterFor(providerId).kind === 'jobs-v1') {
-        // pass-through 경유(서버 키 LiteLLM env 주입) — 사용자 BYOK 를 실을 수 없어 전역 배정만
-        return scope === GLOBAL_MODALITY_SCOPE
-            ? null
-            : `provider '${providerId}' 의 영상 생성은 게이트웨이 pass-through(서버 키) 전용이라 관리자 전역 배정만 가능합니다`;
     }
     if (scope === GLOBAL_MODALITY_SCOPE) {
         const repo = deps.serverKeys ?? new ServerExternalKeysRepository(getPool());
@@ -140,7 +138,7 @@ function localTarget(modality: Modality, fullId: string, params: Record<string, 
         modality, fullId, providerId: 'local-llm', model: tag,
         baseUrl: gatewayBase(), endpoint: MODALITY_ENDPOINT[modality],
         headers: { Authorization: `Bearer ${cfg.llmApiKey}` },
-        params, source,
+        params, source, transport: 'gateway',
     };
 }
 
@@ -160,22 +158,11 @@ async function externalTarget(
         throw new ModalityUnavailableError(`provider '${providerId}' 는 LiteLLM 게이트웨이 미편입 — 모달리티 호출 불가`, 'MODALITY_PROVIDER_NOT_GATEWAY');
     }
 
-    if (modality === 'video_gen') {
-        const adapter = videoAdapterFor(providerId);
-        if (adapter.kind === 'jobs-v1' && adapter.passThroughPrefix) {
-            // upstream 키는 LiteLLM pass-through 정적 헤더가 주입 — 앱은 master 로 게이트웨이만 인증
-            return {
-                modality, fullId, providerId, model: modelId,
-                baseUrl: `${gatewayBase()}${adapter.passThroughPrefix}`, endpoint: adapter.submitPath ?? MODALITY_ENDPOINT[modality],
-                headers: { Authorization: `Bearer ${cfg.llmApiKey}` },
-                params, source,
-            };
-        }
-    }
-
     let apiKey: string | null = null;
+    let userBaseUrl: string | null = null;
     if (source === 'user' && userId) {
         apiKey = await deps.userKeys.decryptKey(userId, providerId);
+        userBaseUrl = (await deps.userKeys.getByUserAndProvider(userId, providerId))?.baseUrl ?? null;
     } else {
         apiKey = await deps.serverKeys.decryptKey(providerId);
     }
@@ -185,11 +172,22 @@ async function externalTarget(
             'MODALITY_KEY_MISSING',
         );
     }
+    if (modality === 'video_gen' && videoAdapterFor(providerId).kind === 'jobs-v1') {
+        // 게이트웨이가 프록시 못 하는 커스텀 영상 API — 사용자 키로 provider 직결(도구는 SSRF 고정 fetch 사용)
+        const adapter = videoAdapterFor(providerId);
+        return {
+            modality, fullId, providerId, model: modelId,
+            baseUrl: (userBaseUrl || entry.defaultBaseUrl).replace(/\/+$/, ''),
+            endpoint: adapter.submitPath ?? MODALITY_ENDPOINT[modality],
+            headers: { Authorization: `Bearer ${apiKey}` },
+            params, source, transport: 'direct',
+        };
+    }
     return {
         modality, fullId, providerId, model: `${providerId}/${modelId}`,
         baseUrl: gatewayBase(), endpoint: MODALITY_ENDPOINT[modality],
         headers: { Authorization: `Bearer ${cfg.llmApiKey}`, 'x-api-key': apiKey },
-        params, source,
+        params, source, transport: 'gateway',
     };
 }
 

--- a/apps/api/src/services/modality-resolver.ts
+++ b/apps/api/src/services/modality-resolver.ts
@@ -1,0 +1,254 @@
+/**
+ * @module services/modality-resolver
+ * @description 모달리티(이미지·비전·영상·오디오·임베딩)→실행 대상 해석.
+ *
+ * "역할&모델"(model-role-resolver — 텍스트 LLM 을 누가 쓰는가)과 별개 축.
+ * 결정적 매핑이라 LLM 판단 경계(A형)와 무관.
+ *
+ * 우선순위: 사용자 오버라이드(modality_models scope=userId, BYOK 필요)
+ *         → 전역 DB(scope='__global__', 외부면 서버 공용 키 필요)
+ *         → 코드 기본값(config/modality MODALITY_DEFAULTS, 로컬만)
+ *
+ * 불변식 — **호출은 LiteLLM 게이트웨이 하나로만**:
+ *  - 로컬: `LLM_BASE_URL` + master key, model = alias 그대로
+ *  - 외부: `LLM_GATEWAY_PROVIDERS` 편입 provider 만. model = `<provider>/<model>`,
+ *    Authorization = master, `x-api-key` = 사용자/서버 키 (openai-compat-provider 의 헤더 계약과 동일)
+ *  - direct 전용 provider(chatgpt OAuth 등)는 배정 자체를 거부한다.
+ *
+ * 실패는 조용히 폴백하지 않고 ModalityUnavailableError(code) 로 명시한다 — 도구가
+ * 사용자에게 사유를 안내해야 "이미지가 안 나온다" 가 설정 문제임을 알 수 있다.
+ */
+import { getConfig } from '../config';
+import {
+    GLOBAL_MODALITY_SCOPE,
+    MODALITY_DEFAULTS,
+    MODALITY_ENDPOINT,
+    MODALITY_LIMITS,
+    type Modality,
+} from '../config/modality';
+import { EXTERNAL_PROVIDER_CATALOG } from '../config/external-providers';
+import { isExternalFullId, toLocalModelTag } from '../config/model-roles';
+import { getPool } from '../data/models/unified-database';
+import { ModalityModelsRepository, type ModalityModelRow } from '../data/repositories/modality-models-repo';
+import { ExternalKeysRepository } from '../data/repositories/external-keys-repo';
+import { ServerExternalKeysRepository } from '../data/repositories/server-external-keys-repo';
+import { AppError } from '../utils/error-handler';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('ModalityResolver');
+
+export type ModalityUnavailableCode =
+    | 'MODALITY_UNASSIGNED'
+    | 'MODALITY_PROVIDER_UNKNOWN'
+    | 'MODALITY_PROVIDER_NOT_GATEWAY'
+    | 'MODALITY_KEY_MISSING';
+
+export class ModalityUnavailableError extends AppError {
+    constructor(message: string, code: ModalityUnavailableCode) {
+        super(message, 400, true, code);
+    }
+}
+
+export interface ModalityTarget {
+    modality: Modality;
+    fullId: string;
+    providerId: string;
+    /** LiteLLM 에 보내는 model 값 (로컬 alias 또는 `<provider>/<model>`) */
+    model: string;
+    /** 게이트웨이 base URL (끝 슬래시 없음) */
+    baseUrl: string;
+    /** 엔드포인트 경로 — MODALITY_ENDPOINT */
+    endpoint: string;
+    headers: Record<string, string>;
+    params: Record<string, string>;
+    source: 'user' | 'global' | 'default';
+}
+
+/** 배정 시점 검증 — 저장 전에 같은 규칙을 적용해 해석 시점 실패를 앞당긴다 */
+export async function validateModalityAssignment(
+    scope: string,
+    fullId: string,
+    deps: { userKeys?: ExternalKeysRepository; serverKeys?: ServerExternalKeysRepository } = {},
+): Promise<string | null> {
+    if (!isExternalFullId(fullId)) {
+        return toLocalModelTag(fullId) ? null : `해석 불가한 모델 id: '${fullId}'`;
+    }
+    const { providerId, modelId } = splitFullId(fullId);
+    if (!modelId) return `모델 id 가 비어 있습니다: '${fullId}'`;
+    const entry = EXTERNAL_PROVIDER_CATALOG.find((p) => p.id === providerId);
+    if (!entry) return `카탈로그에 없는 provider: '${providerId}'`;
+    if (entry.sdkType !== 'openai-compatible') return `provider '${providerId}' 는 OpenAI 호환이 아니라 모달리티 배정을 지원하지 않습니다`;
+    if (!getConfig().llmGatewayProviders.includes(providerId)) {
+        return `provider '${providerId}' 는 LiteLLM 게이트웨이에 편입되지 않아 배정할 수 없습니다 (LLM_GATEWAY_PROVIDERS)`;
+    }
+    if (scope === GLOBAL_MODALITY_SCOPE) {
+        const repo = deps.serverKeys ?? new ServerExternalKeysRepository(getPool());
+        const row = await repo.get(providerId);
+        if (!row || !row.isActive) return `'${providerId}' 서버 공용 키가 등록·활성 상태여야 전역 배정할 수 있습니다`;
+    } else {
+        const repo = deps.userKeys ?? new ExternalKeysRepository(getPool());
+        const row = await repo.getByUserAndProvider(scope, providerId);
+        if (!row) return `'${providerId}' API 키를 먼저 등록하세요`;
+        if (!row.isActive) return `'${providerId}' API 키가 비활성 상태입니다`;
+        if (row.authMethod === 'oauth') return `'${providerId}' OAuth 연결은 게이트웨이를 거치지 않아 배정할 수 없습니다`;
+    }
+    return null;
+}
+
+/* ── 전역 캐시 (역할 해석기와 같은 TTL, 같은 프로세스 변경은 즉시 무효화) ── */
+let globalCache: { map: Map<Modality, ModalityModelRow>; fetchedAt: number } | null = null;
+
+export function clearGlobalModalityCache(): void {
+    globalCache = null;
+}
+
+async function getGlobalRow(repo: ModalityModelsRepository, modality: Modality): Promise<ModalityModelRow | null> {
+    const now = Date.now();
+    if (!globalCache || now - globalCache.fetchedAt > MODALITY_LIMITS.GLOBAL_CACHE_TTL_MS) {
+        try {
+            const rows = await repo.listGlobal();
+            globalCache = { map: new Map(rows.map((r) => [r.modality, r])), fetchedAt: now };
+        } catch (err) {
+            logger.warn(`전역 모달리티 조회 실패 (캐시/기본값 유지): ${err instanceof Error ? err.message : String(err)}`);
+            if (!globalCache) return null;
+        }
+    }
+    return globalCache.map.get(modality) ?? null;
+}
+
+function splitFullId(fullId: string): { providerId: string; modelId: string } {
+    const idx = fullId.indexOf(':');
+    return { providerId: fullId.slice(0, idx), modelId: fullId.slice(idx + 1) };
+}
+
+function gatewayBase(): string {
+    return getConfig().llmBaseUrl.replace(/\/+$/, '');
+}
+
+function localTarget(modality: Modality, fullId: string, params: Record<string, string>, source: ModalityTarget['source']): ModalityTarget {
+    const cfg = getConfig();
+    const tag = toLocalModelTag(fullId) ?? fullId;
+    return {
+        modality, fullId, providerId: 'local-llm', model: tag,
+        baseUrl: gatewayBase(), endpoint: MODALITY_ENDPOINT[modality],
+        headers: { Authorization: `Bearer ${cfg.llmApiKey}` },
+        params, source,
+    };
+}
+
+async function externalTarget(
+    modality: Modality,
+    fullId: string,
+    params: Record<string, string>,
+    source: ModalityTarget['source'],
+    userId: string | undefined,
+    deps: ResolveDeps,
+): Promise<ModalityTarget> {
+    const cfg = getConfig();
+    const { providerId, modelId } = splitFullId(fullId);
+    const entry = EXTERNAL_PROVIDER_CATALOG.find((p) => p.id === providerId);
+    if (!entry) throw new ModalityUnavailableError(`카탈로그에 없는 provider '${providerId}'`, 'MODALITY_PROVIDER_UNKNOWN');
+    if (!cfg.llmGatewayProviders.includes(providerId)) {
+        throw new ModalityUnavailableError(`provider '${providerId}' 는 LiteLLM 게이트웨이 미편입 — 모달리티 호출 불가`, 'MODALITY_PROVIDER_NOT_GATEWAY');
+    }
+
+    let apiKey: string | null = null;
+    if (source === 'user' && userId) {
+        apiKey = await deps.userKeys.decryptKey(userId, providerId);
+    } else {
+        apiKey = await deps.serverKeys.decryptKey(providerId);
+    }
+    if (!apiKey) {
+        throw new ModalityUnavailableError(
+            `'${providerId}' 키가 없어 ${modality} 모델 '${modelId}' 를 호출할 수 없습니다 (${source === 'user' ? 'BYOK 키' : '서버 공용 키'} 필요)`,
+            'MODALITY_KEY_MISSING',
+        );
+    }
+    return {
+        modality, fullId, providerId, model: `${providerId}/${modelId}`,
+        baseUrl: gatewayBase(), endpoint: MODALITY_ENDPOINT[modality],
+        headers: { Authorization: `Bearer ${cfg.llmApiKey}`, 'x-api-key': apiKey },
+        params, source,
+    };
+}
+
+interface ResolveDeps {
+    models: ModalityModelsRepository;
+    userKeys: ExternalKeysRepository;
+    serverKeys: ServerExternalKeysRepository;
+}
+
+function defaultDeps(): ResolveDeps {
+    const pool = getPool();
+    return {
+        models: new ModalityModelsRepository(pool),
+        userKeys: new ExternalKeysRepository(pool),
+        serverKeys: new ServerExternalKeysRepository(pool),
+    };
+}
+
+/**
+ * 모달리티의 실행 대상을 해석한다. 미배정·키 없음은 throw(ModalityUnavailableError) —
+ * 호출부는 message 를 그대로 사용자 안내로 쓴다.
+ */
+export async function resolveModalityTarget(
+    modality: Modality,
+    userId?: string,
+    deps: Partial<ResolveDeps> = {},
+): Promise<ModalityTarget> {
+    const d: ResolveDeps = { ...defaultDeps(), ...deps };
+
+    // ① 사용자 오버라이드
+    if (userId) {
+        let row: ModalityModelRow | null = null;
+        try {
+            row = await d.models.get(userId, modality);
+        } catch (err) {
+            logger.warn(`사용자 모달리티 조회 실패 (전역으로 계속): ${err instanceof Error ? err.message : String(err)}`);
+        }
+        if (row) {
+            return isExternalFullId(row.fullId)
+                ? externalTarget(modality, row.fullId, row.params, 'user', userId, d)
+                : localTarget(modality, row.fullId, row.params, 'user');
+        }
+    }
+
+    // ② 전역 DB
+    const global = await getGlobalRow(d.models, modality);
+    if (global) {
+        return isExternalFullId(global.fullId)
+            ? externalTarget(modality, global.fullId, global.params, 'global', userId, d)
+            : localTarget(modality, global.fullId, global.params, 'global');
+    }
+
+    // ③ 코드 기본값 (로컬만)
+    const fallback = MODALITY_DEFAULTS[modality];
+    if (fallback) return localTarget(modality, fallback, {}, 'default');
+
+    throw new ModalityUnavailableError(
+        `${modality} 모델이 배정되어 있지 않습니다. 설정 → 모델 & 응답 → 모달리티에서 배정하세요.`,
+        'MODALITY_UNASSIGNED',
+    );
+}
+
+/**
+ * 구 `IMAGE_GEN_MODEL` env → 전역 image_gen 행 1회 시딩 (부팅, 마이그레이션 직후).
+ * 전역 행이 이미 있으면 no-op. env 는 다음 배포에서 제거 대상 — 값이 남아 있으면 경고만.
+ * fail-open: 실패해도 부팅을 막지 않는다.
+ */
+export async function seedModalityDefaultsFromEnv(repo?: ModalityModelsRepository): Promise<void> {
+    const legacy = process.env.IMAGE_GEN_MODEL?.trim();
+    if (!legacy) return;
+    const fullId = legacy.includes(':') ? legacy : `local-llm:${legacy}`;
+    try {
+        const r = repo ?? new ModalityModelsRepository(getPool());
+        const inserted = await r.insertIfAbsent(GLOBAL_MODALITY_SCOPE, 'image_gen', fullId);
+        if (inserted) {
+            clearGlobalModalityCache();
+            logger.info(`전역 image_gen 을 구 IMAGE_GEN_MODEL 로 시딩: ${fullId}`);
+        }
+        logger.warn('IMAGE_GEN_MODEL env 는 폐기 예정 — 모달리티 설정(DB)이 SoT 입니다. .env 에서 제거하세요.');
+    } catch (err) {
+        logger.warn(`모달리티 시딩 실패 (계속): ${err instanceof Error ? err.message : String(err)}`);
+    }
+}

--- a/apps/api/src/services/modality-resolver.ts
+++ b/apps/api/src/services/modality-resolver.ts
@@ -24,6 +24,7 @@ import {
     MODALITY_DEFAULTS,
     MODALITY_ENDPOINT,
     MODALITY_LIMITS,
+    videoAdapterFor,
     type Modality,
 } from '../config/modality';
 import { EXTERNAL_PROVIDER_CATALOG } from '../config/external-providers';
@@ -69,6 +70,7 @@ export async function validateModalityAssignment(
     scope: string,
     fullId: string,
     deps: { userKeys?: ExternalKeysRepository; serverKeys?: ServerExternalKeysRepository } = {},
+    modality?: Modality,
 ): Promise<string | null> {
     if (!isExternalFullId(fullId)) {
         return toLocalModelTag(fullId) ? null : `해석 불가한 모델 id: '${fullId}'`;
@@ -80,6 +82,12 @@ export async function validateModalityAssignment(
     if (entry.sdkType !== 'openai-compatible') return `provider '${providerId}' 는 OpenAI 호환이 아니라 모달리티 배정을 지원하지 않습니다`;
     if (!getConfig().llmGatewayProviders.includes(providerId)) {
         return `provider '${providerId}' 는 LiteLLM 게이트웨이에 편입되지 않아 배정할 수 없습니다 (LLM_GATEWAY_PROVIDERS)`;
+    }
+    if (modality === 'video_gen' && videoAdapterFor(providerId).kind === 'jobs-v1') {
+        // pass-through 경유(서버 키 LiteLLM env 주입) — 사용자 BYOK 를 실을 수 없어 전역 배정만
+        return scope === GLOBAL_MODALITY_SCOPE
+            ? null
+            : `provider '${providerId}' 의 영상 생성은 게이트웨이 pass-through(서버 키) 전용이라 관리자 전역 배정만 가능합니다`;
     }
     if (scope === GLOBAL_MODALITY_SCOPE) {
         const repo = deps.serverKeys ?? new ServerExternalKeysRepository(getPool());
@@ -150,6 +158,19 @@ async function externalTarget(
     if (!entry) throw new ModalityUnavailableError(`카탈로그에 없는 provider '${providerId}'`, 'MODALITY_PROVIDER_UNKNOWN');
     if (!cfg.llmGatewayProviders.includes(providerId)) {
         throw new ModalityUnavailableError(`provider '${providerId}' 는 LiteLLM 게이트웨이 미편입 — 모달리티 호출 불가`, 'MODALITY_PROVIDER_NOT_GATEWAY');
+    }
+
+    if (modality === 'video_gen') {
+        const adapter = videoAdapterFor(providerId);
+        if (adapter.kind === 'jobs-v1' && adapter.passThroughPrefix) {
+            // upstream 키는 LiteLLM pass-through 정적 헤더가 주입 — 앱은 master 로 게이트웨이만 인증
+            return {
+                modality, fullId, providerId, model: modelId,
+                baseUrl: `${gatewayBase()}${adapter.passThroughPrefix}`, endpoint: adapter.submitPath ?? MODALITY_ENDPOINT[modality],
+                headers: { Authorization: `Bearer ${cfg.llmApiKey}` },
+                params, source,
+            };
+        }
     }
 
     let apiKey: string | null = null;

--- a/apps/web/app/(workspace)/admin/model-roles/page.tsx
+++ b/apps/web/app/(workspace)/admin/model-roles/page.tsx
@@ -21,6 +21,8 @@ import { ApiClient } from "@/lib/api-client";
 import { fetchModels, type ModelEntry } from "@/lib/models-api";
 import {
   ModalityEffectiveLine,
+  ModalityParamsInputs,
+  compactParams,
   type ModalityEffective,
   type ModalityOverride,
 } from "@/components/settings/modality-models-section";
@@ -135,6 +137,7 @@ function GlobalModalityModelsCard() {
   const [payload, setPayload] = useState<ModalityPayload | null>(null);
   const [models, setModels] = useState<ModelEntry[]>([]);
   const [busy, setBusy] = useState<string | null>(null);
+  const [paramDrafts, setParamDrafts] = useState<Record<string, Record<string, string>>>({});
   const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
@@ -146,6 +149,9 @@ function GlobalModalityModelsCard() {
         fetchModels(),
       ]);
       setPayload(r?.data ?? null);
+      const drafts: Record<string, Record<string, string>> = {};
+      for (const row of r?.data?.mappings ?? []) drafts[row.modality] = { ...(row.params ?? {}) };
+      setParamDrafts(drafts);
       setModels(m.models);
     } catch (e) {
       setError(e instanceof Error ? e.message : t("loadError"));
@@ -161,7 +167,11 @@ function GlobalModalityModelsCard() {
     setError(null);
     try {
       if (fullId) {
-        await ApiClient.put(`/api/admin/modality-models/${modality}`, { model: fullId });
+        const params = compactParams(paramDrafts[modality]);
+        await ApiClient.put(`/api/admin/modality-models/${modality}`, {
+          model: fullId,
+          ...(params ? { params } : {}),
+        });
       } else if (payload?.mappings.some((m) => m.modality === modality)) {
         await ApiClient.del(`/api/admin/modality-models/${modality}`);
       }
@@ -173,7 +183,12 @@ function GlobalModalityModelsCard() {
     }
   }
 
+  function setParam(modality: string, key: string, value: string) {
+    setParamDrafts((d) => ({ ...d, [modality]: { ...(d[modality] ?? {}), [key]: value } }));
+  }
+
   const mapped = new Map((payload?.mappings ?? []).map((m) => [m.modality, m.fullId]));
+  const savedParams = new Map((payload?.mappings ?? []).map((m) => [m.modality, m.params]));
   const effectiveMap = new Map((payload?.effective ?? []).map((e) => [e.modality, e]));
   const providers = payload?.gatewayProviders ?? [];
 
@@ -207,6 +222,16 @@ function GlobalModalityModelsCard() {
                 <p className="text-xs text-muted">
                   {t("codeDefault", { model: payload?.defaults[modality] || "—" })}
                 </p>
+                <ModalityParamsInputs
+                  modality={modality}
+                  draft={paramDrafts[modality] ?? {}}
+                  saved={savedParams.get(modality)}
+                  disabled={!current}
+                  busy={isBusy}
+                  onChange={(key, value) => setParam(modality, key, value)}
+                  onApply={() => void handleChange(modality, current)}
+                  t={t}
+                />
               </div>
               <div className="flex shrink-0 items-center gap-2">
                 {isBusy && <Loader2 className="h-4 w-4 animate-spin text-muted" aria-hidden />}

--- a/apps/web/app/(workspace)/admin/model-roles/page.tsx
+++ b/apps/web/app/(workspace)/admin/model-roles/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
-import { UsersRound, KeyRound, Trash2, Save, Loader2 } from "lucide-react";
+import { UsersRound, KeyRound, Trash2, Save, Loader2, Layers, RotateCcw } from "lucide-react";
 import {
   PageHeader,
   Card,
@@ -18,6 +18,12 @@ import {
 import { AdminTabs } from "@/components/hub-tabs";
 import type { ApiSuccess } from "@openmake/shared-types";
 import { ApiClient } from "@/lib/api-client";
+import { fetchModels, type ModelEntry } from "@/lib/models-api";
+import {
+  ModalityEffectiveLine,
+  type ModalityEffective,
+  type ModalityOverride,
+} from "@/components/settings/modality-models-section";
 
 /* ── 타입 (백엔드 /api/admin/model-roles, /api/admin/server-external-keys) ── */
 interface GlobalMapping {
@@ -41,6 +47,14 @@ interface ServerKeyRow {
 interface ServerKeysPayload {
   keys: ServerKeyRow[];
   providers: { id: string; displayName: string; defaultBaseUrl: string }[];
+}
+/* 백엔드 /api/admin/modality-models */
+interface ModalityPayload {
+  mappings: ModalityOverride[];
+  effective: ModalityEffective[];
+  modalities: string[];
+  defaults: Record<string, string>;
+  gatewayProviders: string[];
 }
 
 const inputCls =
@@ -108,6 +122,125 @@ function ServerKeyForm({ providers, onSaved }: {
       <p className="text-xs text-muted">{t("keyForm.dailyLimitHelp")}</p>
       {error && <p className="text-sm text-danger" role="alert">{error}</p>}
     </div>
+  );
+}
+
+/**
+ * 전역 모달리티→모델 배정 — "역할&모델"(텍스트 LLM 이 어떤 역할을 맡는가)과 별개 축.
+ * 이미지 생성·비전·영상·STT·TTS·임베딩을 처리할 모델을 전역 기본값으로 정한다.
+ * 외부 모델은 게이트웨이 편입 provider 만 허용(서버 400 사유를 그대로 표시).
+ */
+function GlobalModalityModelsCard() {
+  const t = useTranslations("adminModalityModels");
+  const [payload, setPayload] = useState<ModalityPayload | null>(null);
+  const [models, setModels] = useState<ModelEntry[]>([]);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const [r, m] = await Promise.all([
+        ApiClient.get<ApiSuccess<ModalityPayload>>("/api/admin/modality-models"),
+        // 채팅 불가 모델(임베딩·이미지)도 배정 대상 — 필터 없는 전체 목록.
+        fetchModels(),
+      ]);
+      setPayload(r?.data ?? null);
+      setModels(m.models);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("loadError"));
+    }
+  }, [t]);
+
+  useEffect(() => {
+    queueMicrotask(() => void load());
+  }, [load]);
+
+  async function handleChange(modality: string, fullId: string) {
+    setBusy(modality);
+    setError(null);
+    try {
+      if (fullId) {
+        await ApiClient.put(`/api/admin/modality-models/${modality}`, { model: fullId });
+      } else if (payload?.mappings.some((m) => m.modality === modality)) {
+        await ApiClient.del(`/api/admin/modality-models/${modality}`);
+      }
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("saveFailed"));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const mapped = new Map((payload?.mappings ?? []).map((m) => [m.modality, m.fullId]));
+  const effectiveMap = new Map((payload?.effective ?? []).map((e) => [e.modality, e]));
+  const providers = payload?.gatewayProviders ?? [];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Layers className="h-4 w-4" aria-hidden />
+          {t("title")}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted">{t("description")}</p>
+        <p className="text-xs text-muted">{t("axisNote")}</p>
+        <p className="text-xs text-muted">
+          {t("gatewayNote", { providers: providers.length > 0 ? providers.join(", ") : t("gatewayNone") })}
+        </p>
+        {error && <p className="text-sm text-danger" role="alert">{error}</p>}
+        {(payload?.modalities ?? []).map((modality) => {
+          const current = mapped.get(modality) ?? "";
+          const isBusy = busy === modality;
+          return (
+            <div key={modality} className="flex flex-col gap-2 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="min-w-0 space-y-1">
+                <div className="flex items-center gap-2">
+                  <span className="whitespace-nowrap text-sm font-medium">{t(`modalities.${modality}`)}</span>
+                  <span className="font-mono text-xs text-muted">{modality}</span>
+                  {current && <Badge tone="accent" className="shrink-0 whitespace-nowrap">{t("assigned")}</Badge>}
+                </div>
+                <ModalityEffectiveLine eff={effectiveMap.get(modality)} t={t} />
+                <p className="text-xs text-muted">
+                  {t("codeDefault", { model: payload?.defaults[modality] || "—" })}
+                </p>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                {isBusy && <Loader2 className="h-4 w-4 animate-spin text-muted" aria-hidden />}
+                <select
+                  className={`${selectCls} min-w-52`}
+                  value={current}
+                  disabled={isBusy}
+                  aria-label={t(`modalities.${modality}`)}
+                  onChange={(e) => void handleChange(modality, e.target.value)}
+                >
+                  <option value="">{t("defaultOption")}</option>
+                  {current && !models.some((m) => m.modelId === current) && (
+                    <option value={current}>{current} {t("notInList")}</option>
+                  )}
+                  {models.map((m) => (
+                    <option key={m.modelId} value={m.modelId}>
+                      {m.name}
+                      {m.provider !== "local-llm" ? ` (${m.provider})` : ""}
+                    </option>
+                  ))}
+                </select>
+                {current && !isBusy && (
+                  <Button variant="ghost" size="sm" aria-label={t("resetLabel")} title={t("resetLabel")}
+                    onClick={() => void handleChange(modality, "")}>
+                    <RotateCcw className="h-4 w-4" aria-hidden />
+                  </Button>
+                )}
+              </div>
+            </div>
+          );
+        })}
+        <p className="text-xs text-muted">{t("cacheNote")}</p>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -257,6 +390,8 @@ export default function AdminModelRolesPage() {
           <p className="text-xs text-muted">{t("globalRoles.cacheNote")}</p>
         </CardContent>
       </Card>
+
+      <GlobalModalityModelsCard />
     </div>
   );
 }

--- a/apps/web/app/(workspace)/settings/page.tsx
+++ b/apps/web/app/(workspace)/settings/page.tsx
@@ -38,6 +38,7 @@ import { MemorySection } from "@/components/settings/memory-section";
 import { ConnectorsSection } from "@/components/settings/connectors-section";
 import { ProviderKeysSection } from "@/components/settings/provider-keys-section";
 import { ModelRolesSection } from "@/components/settings/model-roles-section";
+import { ModalityModelsSection } from "@/components/settings/modality-models-section";
 import { ExtensionsSection } from "@/components/settings/extensions-section";
 
 /* ── 탭 정의 ────────────────────────────────────────────── */
@@ -688,6 +689,7 @@ export default function SettingsPage() {
               </Card>
               <ProviderKeysSection />
               <ModelRolesSection />
+              <ModalityModelsSection />
               </>
             )}
 

--- a/apps/web/components/settings/modality-models-section.tsx
+++ b/apps/web/components/settings/modality-models-section.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Layers, Loader2, RotateCcw } from "lucide-react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  Button,
+  Badge,
+} from "@/components/ui/primitives";
+import type { ApiSuccess } from "@openmake/shared-types";
+import { ApiClient } from "@/lib/api-client";
+import { fetchModels, type ModelEntry } from "@/lib/models-api";
+
+/* ── 타입 (백엔드 /api/users/me/modality-models 응답) ─────────── */
+export interface ModalityOverride {
+  scope: string;
+  modality: string;
+  fullId: string;
+  params: Record<string, string>;
+  updatedAt: string;
+}
+
+export type ModalitySource = "user" | "global" | "default";
+
+export interface ModalityEffective {
+  modality: string;
+  fullId?: string;
+  source?: ModalitySource;
+  error?: string;
+  code?: string;
+}
+
+interface ModalityModelsPayload {
+  overrides: ModalityOverride[];
+  effective: ModalityEffective[];
+  assignableModalities: string[];
+}
+
+/** 배정 미지정 select 값 — 전역/기본값으로 자동 해석됨 */
+const DEFAULT_VALUE = "";
+
+const SOURCE_TONE: Record<ModalitySource, "accent" | "success" | "neutral"> = {
+  user: "accent",
+  global: "success",
+  default: "neutral",
+};
+
+/** 사용자·관리자 섹션이 공유하는 실효 값 표시 (fullId + source 배지, 오류 시 경고 배지). */
+export function ModalityEffectiveLine({
+  eff,
+  t,
+}: {
+  eff: ModalityEffective | undefined;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  if (!eff) return null;
+  if (eff.error) {
+    return (
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        <Badge tone="warn" className="shrink-0 whitespace-nowrap">
+          {t("unavailableBadge")}
+        </Badge>
+        <span className="text-warn">{eff.error}</span>
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-wrap items-center gap-2 text-xs text-muted">
+      <span className="break-all font-mono">{eff.fullId ?? "—"}</span>
+      {eff.source && (
+        <Badge tone={SOURCE_TONE[eff.source]} className="shrink-0 whitespace-nowrap">
+          {t(`source.${eff.source}`)}
+        </Badge>
+      )}
+    </div>
+  );
+}
+
+/**
+ * 모달리티별 모델 배정 — 설정 '모델' 탭.
+ * "역할별 모델 배정"(어떤 텍스트 LLM 이 agent/judge 등을 맡는가)과 별개 축으로,
+ * 이미지 생성·비전·영상·STT·TTS·임베딩을 어느 모델이 처리하는지 정한다.
+ * 호출은 전부 LiteLLM 게이트웨이로 가므로 외부 모델은 게이트웨이 편입 provider 만 배정 가능
+ * (서버가 400 으로 거절 — 사유 문자열을 그대로 표시).
+ */
+export function ModalityModelsSection() {
+  const t = useTranslations("modalityModels");
+  const [overrides, setOverrides] = useState<ModalityOverride[]>([]);
+  const [effective, setEffective] = useState<ModalityEffective[]>([]);
+  const [modalities, setModalities] = useState<string[]>([]);
+  const [models, setModels] = useState<ModelEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [res, modelsRes] = await Promise.all([
+        ApiClient.get<ApiSuccess<ModalityModelsPayload>>("/api/users/me/modality-models"),
+        // 역할 배정과 달리 채팅 불가 모델(임베딩·이미지 등)이 배정 대상이므로 필터 없이 전체 목록.
+        fetchModels(),
+      ]);
+      setOverrides(res?.data?.overrides ?? []);
+      setEffective(res?.data?.effective ?? []);
+      setModalities(res?.data?.assignableModalities ?? []);
+      setModels(modelsRes.models);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("loadError"));
+      setOverrides([]);
+      setEffective([]);
+      setModalities([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    queueMicrotask(() => void load());
+  }, [load]);
+
+  async function handleChange(modality: string, fullId: string) {
+    setSaving(modality);
+    setError(null);
+    try {
+      if (fullId === DEFAULT_VALUE) {
+        // 오버라이드가 있을 때만 해제 (없으면 404 — 이미 기본 상태)
+        if (overrides.some((o) => o.modality === modality)) {
+          await ApiClient.del(`/api/users/me/modality-models/${modality}`);
+        }
+      } else {
+        // params 는 1차 UI 없음 — 보내지 않는다.
+        await ApiClient.put(`/api/users/me/modality-models/${modality}`, { model: fullId });
+      }
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("saveFailed"));
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  const mapped = new Map(overrides.map((o) => [o.modality, o.fullId]));
+  const effectiveMap = new Map(effective.map((e) => [e.modality, e]));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Layers className="h-4 w-4" aria-hidden />
+          {t("title")}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted">{t("description")}</p>
+        <p className="text-xs text-muted">{t("axisNote")}</p>
+        <p className="text-xs text-muted">{t("gatewayNote")}</p>
+
+        {error && (
+          <p className="text-sm text-danger" role="alert">
+            {error}
+          </p>
+        )}
+
+        {loading ? (
+          <div className="flex items-center gap-2 text-sm text-muted">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+            {t("loading")}
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {modalities.map((modality) => {
+              const current = mapped.get(modality) ?? DEFAULT_VALUE;
+              const isSaving = saving === modality;
+              return (
+                <div
+                  key={modality}
+                  className="flex flex-col gap-2 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="min-w-0 space-y-1">
+                    <div className="flex items-center gap-2">
+                      <span className="whitespace-nowrap text-sm font-medium">
+                        {t(`modalities.${modality}`)}
+                      </span>
+                      {current !== DEFAULT_VALUE && (
+                        <Badge tone="accent" className="shrink-0 whitespace-nowrap">
+                          {t("assignedBadge")}
+                        </Badge>
+                      )}
+                    </div>
+                    <ModalityEffectiveLine eff={effectiveMap.get(modality)} t={t} />
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2">
+                    {isSaving && (
+                      <Loader2 className="h-4 w-4 animate-spin text-muted" aria-hidden />
+                    )}
+                    <select
+                      className="h-9 min-w-52 rounded-md border border-border-strong bg-surface px-2 text-sm text-fg outline-none focus:border-accent"
+                      value={current}
+                      disabled={isSaving}
+                      aria-label={t(`modalities.${modality}`)}
+                      onChange={(e) => void handleChange(modality, e.target.value)}
+                    >
+                      <option value={DEFAULT_VALUE}>{t("defaultOption")}</option>
+                      {/* 저장값이 목록 밖이면 값을 보존하는 옵션을 덧붙여 실제 배정을 표시
+                          (model-roles-section 의 "(목록에 없음)" 규칙과 동일). */}
+                      {current !== DEFAULT_VALUE &&
+                        !models.some((m) => m.modelId === current) && (
+                          <option value={current}>
+                            {current} {t("notInList")}
+                          </option>
+                        )}
+                      {models.map((m) => (
+                        <option key={m.modelId} value={m.modelId}>
+                          {m.name}
+                          {m.provider !== "local-llm" ? ` (${m.provider})` : ""}
+                        </option>
+                      ))}
+                    </select>
+                    {current !== DEFAULT_VALUE && !isSaving && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        aria-label={t("resetLabel")}
+                        title={t("resetLabel")}
+                        onClick={() => void handleChange(modality, DEFAULT_VALUE)}
+                      >
+                        <RotateCcw className="h-4 w-4" aria-hidden />
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+            {modalities.length === 0 && !error && (
+              <p className="text-sm text-muted">{t("empty")}</p>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/settings/modality-models-section.tsx
+++ b/apps/web/components/settings/modality-models-section.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
-import { Layers, Loader2, RotateCcw } from "lucide-react";
+import { Layers, Loader2, RotateCcw, Save } from "lucide-react";
 import {
   Card,
   CardHeader,
@@ -42,6 +42,96 @@ interface ModalityModelsPayload {
 
 /** 배정 미지정 select 값 — 전역/기본값으로 자동 해석됨 */
 const DEFAULT_VALUE = "";
+
+/**
+ * 모달리티별 params 화이트리스트 — 백엔드 `config/modality.ts` `MODALITY_LIMITS.PARAM_KEYS` 와
+ * 동일하게 유지할 것(서버는 이 키 밖의 값을 조용히 버린다).
+ */
+export const MODALITY_PARAM_KEYS: Record<string, readonly string[]> = {
+  image_gen: ["size", "quality", "style"],
+  image_edit: ["size"],
+  vision: ["detail"],
+  video_gen: ["size", "seconds"],
+  stt: ["language"],
+  tts: ["voice", "format"],
+  embedding: ["dimensions"],
+};
+
+/** 백엔드 `PARAM_VALUE_MAX_CHARS` 와 동일 */
+export const MODALITY_PARAM_VALUE_MAX = 64;
+
+/** 비어 있지 않은(trim) 값만 남긴 params — PUT body 용. 없으면 undefined. */
+export function compactParams(draft: Record<string, string> | undefined): Record<string, string> | undefined {
+  if (!draft) return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(draft)) {
+    const s = v.trim();
+    if (s) out[k] = s;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/** 저장된 params 와 초안이 같은지 (빈 값은 없는 것으로 취급) */
+export function paramsEqual(saved: Record<string, string> | undefined, draft: Record<string, string> | undefined): boolean {
+  const a = compactParams(saved) ?? {};
+  const b = compactParams(draft) ?? {};
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const k of keys) if (a[k] !== b[k]) return false;
+  return true;
+}
+
+/**
+ * 모달리티 params 입력 행 (사용자·관리자 공용). 허용 키마다 작은 텍스트 입력 하나.
+ * 모델이 배정되지 않았으면 비활성, 저장값과 다를 때만 [적용] 버튼 노출.
+ */
+export function ModalityParamsInputs({
+  modality,
+  draft,
+  saved,
+  disabled,
+  busy,
+  onChange,
+  onApply,
+  t,
+}: {
+  modality: string;
+  draft: Record<string, string>;
+  saved: Record<string, string> | undefined;
+  disabled: boolean;
+  busy: boolean;
+  onChange: (key: string, value: string) => void;
+  onApply: () => void;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  const keys = MODALITY_PARAM_KEYS[modality] ?? [];
+  if (keys.length === 0) return null;
+  const dirty = !disabled && !paramsEqual(saved, draft);
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {keys.map((key) => (
+        <input
+          key={key}
+          type="text"
+          className="h-8 w-28 rounded-md border border-border bg-surface-2 px-2 font-mono text-xs text-fg placeholder:text-muted focus:border-accent focus:outline-none disabled:opacity-50"
+          placeholder={key}
+          title={key}
+          aria-label={`${t(`modalities.${modality}`)} ${key}`}
+          maxLength={MODALITY_PARAM_VALUE_MAX}
+          value={draft[key] ?? ""}
+          disabled={disabled || busy}
+          onChange={(e) => onChange(key, e.target.value)}
+        />
+      ))}
+      {dirty && (
+        <Button size="sm" variant="ghost" className="whitespace-nowrap" disabled={busy} onClick={onApply}>
+          <Save className="h-4 w-4" aria-hidden />
+          {t("paramsApply")}
+        </Button>
+      )}
+      <span className="text-xs text-muted">{t("paramsHint")}</span>
+    </div>
+  );
+}
 
 const SOURCE_TONE: Record<ModalitySource, "accent" | "success" | "neutral"> = {
   user: "accent",
@@ -95,6 +185,7 @@ export function ModalityModelsSection() {
   const [models, setModels] = useState<ModelEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState<string | null>(null);
+  const [paramDrafts, setParamDrafts] = useState<Record<string, Record<string, string>>>({});
   const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
@@ -106,7 +197,12 @@ export function ModalityModelsSection() {
         // 역할 배정과 달리 채팅 불가 모델(임베딩·이미지 등)이 배정 대상이므로 필터 없이 전체 목록.
         fetchModels(),
       ]);
-      setOverrides(res?.data?.overrides ?? []);
+      const nextOverrides = res?.data?.overrides ?? [];
+      setOverrides(nextOverrides);
+      // 저장된 params 를 초안으로 되돌린다(적용 뒤 dirty 표시가 사라지도록).
+      const drafts: Record<string, Record<string, string>> = {};
+      for (const o of nextOverrides) drafts[o.modality] = { ...(o.params ?? {}) };
+      setParamDrafts(drafts);
       setEffective(res?.data?.effective ?? []);
       setModalities(res?.data?.assignableModalities ?? []);
       setModels(modelsRes.models);
@@ -134,8 +230,11 @@ export function ModalityModelsSection() {
           await ApiClient.del(`/api/users/me/modality-models/${modality}`);
         }
       } else {
-        // params 는 1차 UI 없음 — 보내지 않는다.
-        await ApiClient.put(`/api/users/me/modality-models/${modality}`, { model: fullId });
+        const params = compactParams(paramDrafts[modality]);
+        await ApiClient.put(`/api/users/me/modality-models/${modality}`, {
+          model: fullId,
+          ...(params ? { params } : {}),
+        });
       }
       await load();
     } catch (e) {
@@ -145,7 +244,12 @@ export function ModalityModelsSection() {
     }
   }
 
+  function setParam(modality: string, key: string, value: string) {
+    setParamDrafts((d) => ({ ...d, [modality]: { ...(d[modality] ?? {}), [key]: value } }));
+  }
+
   const mapped = new Map(overrides.map((o) => [o.modality, o.fullId]));
+  const savedParams = new Map(overrides.map((o) => [o.modality, o.params]));
   const effectiveMap = new Map(effective.map((e) => [e.modality, e]));
 
   return (
@@ -194,6 +298,16 @@ export function ModalityModelsSection() {
                       )}
                     </div>
                     <ModalityEffectiveLine eff={effectiveMap.get(modality)} t={t} />
+                    <ModalityParamsInputs
+                      modality={modality}
+                      draft={paramDrafts[modality] ?? {}}
+                      saved={savedParams.get(modality)}
+                      disabled={current === DEFAULT_VALUE}
+                      busy={isSaving}
+                      onChange={(key, value) => setParam(modality, key, value)}
+                      onApply={() => void handleChange(modality, current)}
+                      t={t}
+                    />
                   </div>
                   <div className="flex shrink-0 items-center gap-2">
                     {isSaving && (

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1613,6 +1613,35 @@
     },
     "notInList": "(not in list)"
   },
+  "modalityModels": {
+    "title": "Model per Modality",
+    "description": "Choose which model handles image generation, vision, video, speech, and embeddings. Unassigned items follow the global setting or the default. This is a separate axis from the role assignments above (which text model each role uses).",
+    "axisNote": "This is a separate axis from \"Model Roles\" above (which text LLM handles agent, judge, etc.).",
+    "gatewayNote": "All calls go through the single LiteLLM gateway, so external models can only be assigned from providers enrolled in the gateway.",
+    "loading": "Loading modality mappings…",
+    "loadError": "Failed to load modality mappings.",
+    "saveFailed": "Failed to save modality mapping.",
+    "defaultOption": "Default (auto)",
+    "assignedBadge": "Assigned",
+    "unavailableBadge": "Unavailable",
+    "resetLabel": "Reset to default",
+    "empty": "No assignable modalities.",
+    "notInList": "(not in list)",
+    "source": {
+      "user": "My setting",
+      "global": "Global",
+      "default": "Default"
+    },
+    "modalities": {
+      "image_gen": "Image generation",
+      "image_edit": "Image editing",
+      "vision": "Vision (image understanding)",
+      "video_gen": "Video generation",
+      "stt": "Speech-to-text",
+      "tts": "Text-to-speech",
+      "embedding": "Embedding"
+    }
+  },
   "adminModelRoles": {
     "title": "Model Roles Admin",
     "description": "Manage global role→model mappings (defaults for all users) and server-shared external keys.",
@@ -1644,6 +1673,36 @@
       "save": "Save",
       "placeholder": "Empty = fallback ({fallback})",
       "cacheNote": "Changes take effect within 60 seconds without a restart."
+    }
+  },
+  "adminModalityModels": {
+    "title": "Global Modality Mappings",
+    "description": "Set the global default model for image generation, vision, video, speech, and embeddings. Per-user mappings take precedence; clearing falls back to the code default. This is a separate axis from the role assignments above (which text model each role uses).",
+    "axisNote": "This is a separate axis from \"Global Role Mappings\" above (which text LLM handles agent, judge, etc.).",
+    "gatewayNote": "All calls go through the single LiteLLM gateway, so external models can only be assigned from gateway-enrolled providers ({providers}).",
+    "gatewayNone": "none",
+    "loadError": "Failed to load modality mappings.",
+    "saveFailed": "Failed to save modality mapping.",
+    "defaultOption": "Default (code default)",
+    "assigned": "Assigned",
+    "unavailableBadge": "Unavailable",
+    "resetLabel": "Reset to default",
+    "codeDefault": "Code default: {model}",
+    "notInList": "(not in list)",
+    "cacheNote": "Changes take effect within 60 seconds without a restart.",
+    "source": {
+      "user": "My setting",
+      "global": "Global",
+      "default": "Default"
+    },
+    "modalities": {
+      "image_gen": "Image generation",
+      "image_edit": "Image editing",
+      "vision": "Vision (image understanding)",
+      "video_gen": "Video generation",
+      "stt": "Speech-to-text",
+      "tts": "Text-to-speech",
+      "embedding": "Embedding"
     }
   },
   "adminSystemSettings": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1627,6 +1627,8 @@
     "resetLabel": "Reset to default",
     "empty": "No assignable modalities.",
     "notInList": "(not in list)",
+    "paramsHint": "Provider-specific params — empty = default",
+    "paramsApply": "Apply params",
     "source": {
       "user": "My setting",
       "global": "Global",
@@ -1690,6 +1692,8 @@
     "codeDefault": "Code default: {model}",
     "notInList": "(not in list)",
     "cacheNote": "Changes take effect within 60 seconds without a restart.",
+    "paramsHint": "Provider-specific params — empty = default",
+    "paramsApply": "Apply params",
     "source": {
       "user": "My setting",
       "global": "Global",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1627,6 +1627,8 @@
     "resetLabel": "デフォルトに戻す",
     "empty": "割り当て可能なモダリティがありません。",
     "notInList": "(一覧にありません)",
+    "paramsHint": "provider 規格の引数 — 空欄ならデフォルト",
+    "paramsApply": "引数を適用",
     "source": {
       "user": "自分の設定",
       "global": "グローバル",
@@ -1690,6 +1692,8 @@
     "codeDefault": "コード既定値: {model}",
     "notInList": "(一覧にありません)",
     "cacheNote": "変更は再起動なしで最大60秒以内に反映されます。",
+    "paramsHint": "provider 規格の引数 — 空欄ならデフォルト",
+    "paramsApply": "引数を適用",
     "source": {
       "user": "自分の設定",
       "global": "グローバル",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1613,6 +1613,35 @@
     },
     "notInList": "（一覧にない）"
   },
+  "modalityModels": {
+    "title": "モダリティ別モデル割り当て",
+    "description": "画像生成・ビジョン・動画・音声・埋め込みをどのモデルが処理するかを決めます。未設定の項目はグローバル設定またはデフォルトに従います。 上のロール別モデル割り当て（どのロールがテキストモデルを使うか）とは別の軸です。",
+    "axisNote": "上の「役割別モデル割り当て」(どのテキストLLMがエージェント・判定などを担うか)とは別の軸です。",
+    "gatewayNote": "すべての呼び出しは単一の LiteLLM ゲートウェイを経由するため、外部モデルはゲートウェイに登録された provider のみ割り当てられます。",
+    "loading": "モダリティ設定を読み込み中…",
+    "loadError": "モダリティ設定を読み込めませんでした。",
+    "saveFailed": "モダリティ設定の保存に失敗しました。",
+    "defaultOption": "デフォルト(自動)",
+    "assignedBadge": "割り当て済み",
+    "unavailableBadge": "利用不可",
+    "resetLabel": "デフォルトに戻す",
+    "empty": "割り当て可能なモダリティがありません。",
+    "notInList": "(一覧にありません)",
+    "source": {
+      "user": "自分の設定",
+      "global": "グローバル",
+      "default": "デフォルト"
+    },
+    "modalities": {
+      "image_gen": "画像生成",
+      "image_edit": "画像編集",
+      "vision": "ビジョン(画像理解)",
+      "video_gen": "動画生成",
+      "stt": "音声認識",
+      "tts": "音声合成",
+      "embedding": "埋め込み"
+    }
+  },
   "adminModelRoles": {
     "title": "ロールモデル管理",
     "description": "グローバルなロール→モデル割り当て(全ユーザーの既定値)とサーバー共有外部キーを管理します。",
@@ -1644,6 +1673,36 @@
       "save": "保存",
       "placeholder": "空 = フォールバック ({fallback})",
       "cacheNote": "変更は再起動なしで最大60秒以内に反映されます。"
+    }
+  },
+  "adminModalityModels": {
+    "title": "グローバルモダリティ割り当て",
+    "description": "画像生成・ビジョン・動画・音声・埋め込みのグローバル既定モデルを設定します。ユーザー個別の割り当てが優先され、解除するとコードの既定値に戻ります。 上のロール別モデル割り当て（どのロールがテキストモデルを使うか）とは別の軸です。",
+    "axisNote": "上の「グローバル役割マッピング」(どのテキストLLMがエージェント・判定などを担うか)とは別の軸です。",
+    "gatewayNote": "すべての呼び出しは単一の LiteLLM ゲートウェイを経由するため、外部モデルはゲートウェイ登録済み provider({providers})のみ割り当てられます。",
+    "gatewayNone": "なし",
+    "loadError": "モダリティ設定を読み込めませんでした。",
+    "saveFailed": "モダリティ設定の保存に失敗しました。",
+    "defaultOption": "デフォルト(コード既定値)",
+    "assigned": "割り当て済み",
+    "unavailableBadge": "利用不可",
+    "resetLabel": "デフォルトに戻す",
+    "codeDefault": "コード既定値: {model}",
+    "notInList": "(一覧にありません)",
+    "cacheNote": "変更は再起動なしで最大60秒以内に反映されます。",
+    "source": {
+      "user": "自分の設定",
+      "global": "グローバル",
+      "default": "デフォルト"
+    },
+    "modalities": {
+      "image_gen": "画像生成",
+      "image_edit": "画像編集",
+      "vision": "ビジョン(画像理解)",
+      "video_gen": "動画生成",
+      "stt": "音声認識",
+      "tts": "音声合成",
+      "embedding": "埋め込み"
     }
   },
   "adminSystemSettings": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1613,6 +1613,35 @@
     },
     "notInList": "(목록에 없음)"
   },
+  "modalityModels": {
+    "title": "모달리티별 모델 배정",
+    "description": "이미지 생성·비전·영상·음성·임베딩을 어느 모델이 처리할지 정합니다. 미배정 항목은 전역 설정 또는 기본값을 따릅니다. 위의 역할별 모델 배정(누가 텍스트 모델을 쓰는가)과는 별개 축입니다.",
+    "axisNote": "위 \"역할별 모델 배정\"(어떤 텍스트 LLM 이 에이전트·판정 등을 맡는가)과는 별개의 축입니다.",
+    "gatewayNote": "모든 호출은 LiteLLM 게이트웨이 하나로 가므로 외부 모델은 게이트웨이에 편입된 provider 만 배정할 수 있습니다.",
+    "loading": "모달리티 배정 불러오는 중…",
+    "loadError": "모달리티 배정을 불러오지 못했습니다.",
+    "saveFailed": "모달리티 배정 저장에 실패했습니다.",
+    "defaultOption": "기본(자동)",
+    "assignedBadge": "배정됨",
+    "unavailableBadge": "사용 불가",
+    "resetLabel": "기본값으로 되돌리기",
+    "empty": "배정 가능한 모달리티가 없습니다.",
+    "notInList": "(목록에 없음)",
+    "source": {
+      "user": "내 설정",
+      "global": "전역",
+      "default": "기본값"
+    },
+    "modalities": {
+      "image_gen": "이미지 생성",
+      "image_edit": "이미지 편집",
+      "vision": "비전(이미지 이해)",
+      "video_gen": "영상 생성",
+      "stt": "음성 인식",
+      "tts": "음성 합성",
+      "embedding": "임베딩"
+    }
+  },
   "adminModelRoles": {
     "title": "역할 모델 관리",
     "description": "전역 역할→모델 매핑(모든 사용자 기본값)과 서버 공용 외부 키를 관리합니다.",
@@ -1644,6 +1673,36 @@
       "save": "저장",
       "placeholder": "비움 = 폴백 ({fallback})",
       "cacheNote": "변경은 재시작 없이 최대 60초 내에 반영됩니다."
+    }
+  },
+  "adminModalityModels": {
+    "title": "전역 모달리티 배정",
+    "description": "이미지 생성·비전·영상·음성·임베딩의 전역 기본 모델을 정합니다. 사용자 개인 배정이 우선하며, 해제하면 코드 기본값으로 돌아갑니다. 위의 역할별 모델 배정(누가 텍스트 모델을 쓰는가)과는 별개 축입니다.",
+    "axisNote": "위 \"전역 역할 매핑\"(어떤 텍스트 LLM 이 에이전트·판정 등을 맡는가)과는 별개의 축입니다.",
+    "gatewayNote": "모든 호출은 LiteLLM 게이트웨이 하나로 가므로 외부 모델은 게이트웨이 편입 provider({providers})만 배정할 수 있습니다.",
+    "gatewayNone": "없음",
+    "loadError": "모달리티 배정을 불러오지 못했습니다.",
+    "saveFailed": "모달리티 배정 저장에 실패했습니다.",
+    "defaultOption": "기본(코드 기본값)",
+    "assigned": "배정됨",
+    "unavailableBadge": "사용 불가",
+    "resetLabel": "기본값으로 되돌리기",
+    "codeDefault": "코드 기본값: {model}",
+    "notInList": "(목록에 없음)",
+    "cacheNote": "변경은 재시작 없이 최대 60초 내 반영됩니다.",
+    "source": {
+      "user": "내 설정",
+      "global": "전역",
+      "default": "기본값"
+    },
+    "modalities": {
+      "image_gen": "이미지 생성",
+      "image_edit": "이미지 편집",
+      "vision": "비전(이미지 이해)",
+      "video_gen": "영상 생성",
+      "stt": "음성 인식",
+      "tts": "음성 합성",
+      "embedding": "임베딩"
     }
   },
   "adminSystemSettings": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1627,6 +1627,8 @@
     "resetLabel": "기본값으로 되돌리기",
     "empty": "배정 가능한 모달리티가 없습니다.",
     "notInList": "(목록에 없음)",
+    "paramsHint": "provider 규격 인자 — 비우면 기본값",
+    "paramsApply": "인자 적용",
     "source": {
       "user": "내 설정",
       "global": "전역",
@@ -1690,6 +1692,8 @@
     "codeDefault": "코드 기본값: {model}",
     "notInList": "(목록에 없음)",
     "cacheNote": "변경은 재시작 없이 최대 60초 내 반영됩니다.",
+    "paramsHint": "provider 규격 인자 — 비우면 기본값",
+    "paramsApply": "인자 적용",
     "source": {
       "user": "내 설정",
       "global": "전역",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1627,6 +1627,8 @@
     "resetLabel": "恢复默认",
     "empty": "没有可分配的模态。",
     "notInList": "(不在列表中)",
+    "paramsHint": "provider 规格参数 — 留空则为默认值",
+    "paramsApply": "应用参数",
     "source": {
       "user": "我的设置",
       "global": "全局",
@@ -1690,6 +1692,8 @@
     "codeDefault": "代码默认值:{model}",
     "notInList": "(不在列表中)",
     "cacheNote": "更改无需重启,最多 60 秒内生效。",
+    "paramsHint": "provider 规格参数 — 留空则为默认值",
+    "paramsApply": "应用参数",
     "source": {
       "user": "我的设置",
       "global": "全局",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1613,6 +1613,35 @@
     },
     "notInList": "（不在列表中）"
   },
+  "modalityModels": {
+    "title": "按模态分配模型",
+    "description": "决定由哪个模型处理图像生成、视觉、视频、语音和嵌入。未分配的项目遵循全局设置或默认值。 这与上方的角色模型分配（哪个角色使用文本模型）是彼此独立的维度。",
+    "axisNote": "这与上方的“角色模型分配”(哪个文本 LLM 负责代理、判定等)是相互独立的维度。",
+    "gatewayNote": "所有调用都经由单一的 LiteLLM 网关,因此外部模型只能分配已接入网关的 provider。",
+    "loading": "正在加载模态分配…",
+    "loadError": "无法加载模态分配。",
+    "saveFailed": "保存模态分配失败。",
+    "defaultOption": "默认(自动)",
+    "assignedBadge": "已分配",
+    "unavailableBadge": "不可用",
+    "resetLabel": "恢复默认",
+    "empty": "没有可分配的模态。",
+    "notInList": "(不在列表中)",
+    "source": {
+      "user": "我的设置",
+      "global": "全局",
+      "default": "默认"
+    },
+    "modalities": {
+      "image_gen": "图像生成",
+      "image_edit": "图像编辑",
+      "vision": "视觉(图像理解)",
+      "video_gen": "视频生成",
+      "stt": "语音识别",
+      "tts": "语音合成",
+      "embedding": "嵌入"
+    }
+  },
   "adminModelRoles": {
     "title": "角色模型管理",
     "description": "管理全局角色→模型映射(所有用户的默认值)和服务器共享外部密钥。",
@@ -1644,6 +1673,36 @@
       "save": "保存",
       "placeholder": "留空 = 回退 ({fallback})",
       "cacheNote": "更改无需重启,最多60秒内生效。"
+    }
+  },
+  "adminModalityModels": {
+    "title": "全局模态分配",
+    "description": "设置图像生成、视觉、视频、语音和嵌入的全局默认模型。用户个人分配优先;清除后回退到代码默认值。 这与上方的角色模型分配（哪个角色使用文本模型）是彼此独立的维度。",
+    "axisNote": "这与上方的“全局角色映射”(哪个文本 LLM 负责代理、判定等)是相互独立的维度。",
+    "gatewayNote": "所有调用都经由单一的 LiteLLM 网关,因此外部模型只能分配已接入网关的 provider({providers})。",
+    "gatewayNone": "无",
+    "loadError": "无法加载模态分配。",
+    "saveFailed": "保存模态分配失败。",
+    "defaultOption": "默认(代码默认值)",
+    "assigned": "已分配",
+    "unavailableBadge": "不可用",
+    "resetLabel": "恢复默认",
+    "codeDefault": "代码默认值:{model}",
+    "notInList": "(不在列表中)",
+    "cacheNote": "更改无需重启,最多 60 秒内生效。",
+    "source": {
+      "user": "我的设置",
+      "global": "全局",
+      "default": "默认"
+    },
+    "modalities": {
+      "image_gen": "图像生成",
+      "image_edit": "图像编辑",
+      "vision": "视觉(图像理解)",
+      "video_gen": "视频生成",
+      "stt": "语音识别",
+      "tts": "语音合成",
+      "embedding": "嵌入"
     }
   },
   "adminSystemSettings": {

--- a/db/migrations/117_modality_models.sql
+++ b/db/migrations/117_modality_models.sql
@@ -1,0 +1,35 @@
+-- Migration 117 — modality_models 테이블
+--
+-- 모달리티(이미지 생성·비전·영상·STT·TTS·임베딩)별 모델 배정 (2026-09-12).
+-- "역할&모델"(user_model_roles / global_model_roles — 누가 텍스트 LLM 을 쓰는가)과
+-- 별개의 축: 어떤 입출력을 어느 모델이 처리하는가. 텍스트 생성은 이 테이블에 넣지 않는다.
+--
+-- scope: '__global__'(관리자 전역) 또는 users.id (사용자 오버라이드, BYOK 키 필요).
+-- full_id: 'local-llm:<tag>' | '<external_provider>:<model>' — 기존 fullId 규약.
+--          외부 provider 는 LLM_GATEWAY_PROVIDERS 에 편입된 것만 허용(호출은 LiteLLM 단일).
+-- params: 모달리티별 기본 인자(size·voice·duration 등) JSONB — 코드는 화이트리스트 키만 읽는다.
+--
+-- 해석 우선순위: 사용자 오버라이드 → 전역 DB → 코드 기본값(config/modality.ts).
+-- 구 IMAGE_GEN_MODEL env 는 부팅 시 전역 image_gen 행이 없을 때 1회 시더로만 읽는다
+-- (services/modality-resolver.ts seedModalityDefaultsFromEnv) — 다음 배포에서 env 삭제.
+--
+-- modality CHECK 는 코드 SoT(config/modality.ts MODALITIES)와 정합 유지할 것.
+
+CREATE TABLE IF NOT EXISTS modality_models (
+    scope       TEXT NOT NULL,
+    modality    TEXT NOT NULL CHECK (modality IN ('image_gen', 'image_edit', 'vision', 'video_gen', 'stt', 'tts', 'embedding')),
+    full_id     TEXT NOT NULL,
+    params      JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (scope, modality)
+);
+
+COMMENT ON TABLE modality_models IS
+    '모달리티별 모델 배정 — 역할 배정(user_model_roles)과 별개 축. scope=''__global__'' 또는 user_id. 해석은 services/modality-resolver.';
+COMMENT ON COLUMN modality_models.full_id IS
+    '''local-llm:<tag>'' | ''<provider>:<model>''. 외부는 LLM_GATEWAY_PROVIDERS 편입 provider 만(LiteLLM 단일 호출).';
+
+-- scope 가 '__global__' 도 담아 users FK 를 걸 수 없다 — 사용자 행은 UserManager.deleteUser 가
+-- 같은 트랜잭션에서 DELETE 한다.
+CREATE INDEX IF NOT EXISTS idx_modality_models_scope ON modality_models (scope);

--- a/scripts/vllm/litellm.config.yaml
+++ b/scripts/vllm/litellm.config.yaml
@@ -83,6 +83,18 @@ general_settings:
   # 사용자 BYOK 를 요청 헤더에서 upstream 인증으로 전달 (BYOK 를 config 에 저장 금지)
   # ⚠️ database_url 미주입 — 앱 DB 오상속 방지 (arch.md §7-3)
   forward_llm_provider_auth_headers: true
+  # 모달리티 pass-through (2026-09-12, apps/api config/modality.ts VIDEO_PROVIDER_ADAPTERS) —
+  # OpenAI `/v1/videos` 규격이 아닌 provider(hasa: POST /videos/generations → GET /jobs/{id} → artifact_url)
+  # 를 게이트웨이 하나로 부르기 위한 경로. LiteLLM 1.89.4 pass-through 는 클라이언트 헤더를 전달하지
+  # 못하므로(설정 모델에 forward_headers 없음) upstream 키는 여기 정적 헤더(litellm.env HASA_API_KEY)로
+  # 주입한다 → 앱에선 관리자 전역 배정만 허용(사용자 BYOK 불가). auth: true = master key 로 게이트웨이 인증.
+  pass_through_endpoints:
+    - path: "/passthrough/hasa"
+      target: "https://open.hasa.re.kr/v1"
+      include_subpath: true
+      auth: true
+      headers:
+        Authorization: "Bearer os.environ/HASA_API_KEY"
 
 litellm_settings:
   drop_params: false

--- a/scripts/vllm/litellm.config.yaml
+++ b/scripts/vllm/litellm.config.yaml
@@ -83,18 +83,6 @@ general_settings:
   # 사용자 BYOK 를 요청 헤더에서 upstream 인증으로 전달 (BYOK 를 config 에 저장 금지)
   # ⚠️ database_url 미주입 — 앱 DB 오상속 방지 (arch.md §7-3)
   forward_llm_provider_auth_headers: true
-  # 모달리티 pass-through (2026-09-12, apps/api config/modality.ts VIDEO_PROVIDER_ADAPTERS) —
-  # OpenAI `/v1/videos` 규격이 아닌 provider(hasa: POST /videos/generations → GET /jobs/{id} → artifact_url)
-  # 를 게이트웨이 하나로 부르기 위한 경로. LiteLLM 1.89.4 pass-through 는 클라이언트 헤더를 전달하지
-  # 못하므로(설정 모델에 forward_headers 없음) upstream 키는 여기 정적 헤더(litellm.env HASA_API_KEY)로
-  # 주입한다 → 앱에선 관리자 전역 배정만 허용(사용자 BYOK 불가). auth: true = master key 로 게이트웨이 인증.
-  pass_through_endpoints:
-    - path: "/passthrough/hasa"
-      target: "https://open.hasa.re.kr/v1"
-      include_subpath: true
-      auth: true
-      headers:
-        Authorization: "Bearer os.environ/HASA_API_KEY"
 
 litellm_settings:
   drop_params: false


### PR DESCRIPTION
## 요약
"역할&모델"(누가 텍스트 LLM 을 쓰는가)과 **별개 축**으로, 이미지 생성·이미지 편집·비전·영상 생성·STT·TTS·임베딩을 **어느 모델이 처리하는가**를 배정한다. 호출은 LiteLLM 게이트웨이 하나로만 간다. 판정서: private docs `proposals/2026-09-12-modality-routing-via-litellm-verdict.md`.

## 1차 — 레지스트리·이미지 이관·UI
- **DB** `117_modality_models.sql` — `(scope, modality) PK`, scope=`__global__`|user_id, fullId 규약 공용, params JSONB(화이트리스트 키만).
- **해석기** `services/modality-resolver.ts` — 사용자 오버라이드(BYOK) → 전역 DB(서버 공용 키) → 코드 기본값(로컬만). 외부는 `LLM_GATEWAY_PROVIDERS` 편입 provider 만(model=`<provider>/<model>`, `x-api-key`), direct 전용(OAuth)은 배정 시점 400. 미배정·키 없음은 `ModalityUnavailableError(code)`.
- **API** `GET/PUT/DELETE /api/users/me/modality-models[/:modality]`, `/api/admin/modality-models` — 감사 로그 동반.
- **`generate_image` 이관** — `IMAGE_GEN_MODEL` env 고정 호출 제거. 부팅 시더로만 1회 읽고 env 정의는 **다음 배포에서 삭제**(2단계).
- **web** — 설정 → 모델 & 응답 하단 사용자 섹션, 관리자 → 모델 역할 하단 전역 카드, i18n ko/en/ja/zh.

## 2·3차 — vision 브리지·TTS/STT/영상
- **vision 브리지** `services/chat-service/vision-bridge.ts` — 역할 모델이 비전 미지원이면 모달리티 `vision` 모델이 첨부를 관찰 기록 텍스트로 옮겨 넘긴다(역할 모델 교체 없음). 미배정이면 종전 400.
- **도구** `text_to_speech`·`transcribe_audio`(`mcp/audio-tools.ts`), `generate_video`·`get_video`(`mcp/video-tools.ts`, 비동기 폴링·상한 초과 시 작업 id). 노출은 `MODALITY_TOOL_INTENT_GATES` 의도 턴에만. 생성 파일은 `mcp/generated-media.ts` → `/generated/*`.
- **영상 어댑터** — OpenAI `/v1/videos` 규격은 게이트웨이. jobs-v1(hasa: `/videos/generations` → `/jobs/{id}` → `artifact_url`)은 LiteLLM 이 프록시하지 못하고(1.89.4 pass-through 는 클라이언트 헤더 전달 불가, hasa 는 Bearer 만 수용) **사용자 결정(전부 개인 키)** 에 따라 앱이 BYOK 로 provider 직결(`transport='direct'`, `safeFetch`). 문서화된 예외이며 LiteLLM 설정 변경 없음.
- `.env.example` `MODALITY_*`.

## 실측(user 3 키, 게이트웨이 경유)
| provider | 이미지 | STT | TTS | 영상 |
|---|---|---|---|---|
| hasa | Qwen-Image 200 | whisper-large-v3-turbo 200 | melotts-ko 200 (voice `KR`, `wav` 만) | Wan2.2-T2V 커스텀 경로(jobs-v1) — 작업 COMPLETED·artifact_url webm 확인 |
| openrouter | 모델 있음, 키 월 한도 403 | 없음 | 없음 | 미지원 |
| ollama-cloud / nvidia | 404 | 404 | 404 | 미지원 |
| bai | inference 경로만, 이미지 모델 없음 | 403 | 403 | 403 |

## 검증
- api tsc·eslint 0, jest 신규 32(해석기 18·vision 5·도구/게이트 9) + 전체 suite.
- web tsc 0, 워크스페이스 eslint 0, 4 로케일 키 diff 0.
- 마이그레이션 SQL 운영 DB 트랜잭션 롤백 검증.

## 배포 후 사용자 작업 (관리자 작업 없음)
- 설정 → 모델 & 응답 → 모달리티에서 본인 키로 배정: `tts`=`hasa:melotts-ko`(voice=KR, format=wav) · `stt`=`hasa:whisper-large-v3-turbo` · `video_gen`=`hasa:Wan2.2-T2V` · `image_gen` 기본 로컬 flux2-klein · `vision` 로컬 qwen3.8-27b 등.
- 다음 배포에서 `IMAGE_GEN_MODEL` env 정의 삭제(2단계).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4QsmcWF1Muw7gCwTYDZ7Q

