### PR TITLE
chore(db): modality_models DROP (120) — 오케스트레이터 교체 2단계 마무리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1547,10 +1547,6 @@ APNS_KEY_ID=
 APNS_TEAM_ID=
 APNS_PRIVATE_KEY=
 
-# ⚠️ 폐기 예정 (2026-09-12) — 이미지 생성 모델은 capability 배정(DB capability_models, 설정 → 모델 & 응답 → 기능별 모델 /
-# 관리자 → 모델 역할)이 SoT 다. 이 값은 전역 image.generate 행이 없을 때 부팅 1회 시더로만 읽히고 다음 배포에서 제거된다.
-# IMAGE_GEN_MODEL=flux2-klein
-#
 # ── 멀티모달 오케스트레이터 (2026-09-12) — 모든 채팅 턴: Planner(역할 planner) → capability 작업 병렬 실행 → 채팅 모델이 종합 ──
 # ORCHESTRATOR_ENABLED=true                 # false 면 Planner 를 돌리지 않고 종전 단일 경로
 # ORCHESTRATOR_PLANNER_TIMEOUT_MS=20000     # 시도당 · ORCHESTRATOR_PLANNER_TOTAL_DEADLINE_MS=30000 (재시도 포함 전체)

--- a/apps/api/src/data/user-manager.ts
+++ b/apps/api/src/data/user-manager.ts
@@ -467,8 +467,8 @@ class UserManagerImpl {
 
             // ── 2. 사용자 데이터 정리 ──
             await client.query('DELETE FROM user_memories WHERE user_id = $1', [userId]);
-            // 모달리티 모델 오버라이드 — scope 가 '__global__' 도 담아 FK 를 못 걸므로 여기서 정리
-            await client.query('DELETE FROM modality_models WHERE scope = $1', [userId]);
+            // capability 배정 — scope 가 '__global__' 도 담아 FK 를 못 걸므로 여기서 정리
+            // (구 modality_models 는 120 에서 DROP — 118 이 capability_models 로 이관했다)
             await client.query('DELETE FROM capability_models WHERE scope = $1', [userId]);
             // 오케스트레이터 셰도우(계획 원문·user_id) — 계정 삭제 시 함께 제거
             await client.query('DELETE FROM orchestrator_runs WHERE user_id = $1', [userId]);

--- a/db/migrations/120_drop_modality_models.sql
+++ b/db/migrations/120_drop_modality_models.sql
@@ -1,0 +1,6 @@
+-- Migration 120 — modality_models DROP (2단계 배포의 2단계)
+--
+-- 117 이 만든 모달리티 배정 테이블은 118 이 capability_models 로 행을 이관했고,
+-- v1.59.0(PR #837) 이 코드 참조를 전부 제거해 배포됐다(마지막 참조 UserManager.deleteUser 도 이 PR 에서 제거).
+-- 되돌리려면 rollbacks/120_drop_modality_models.sql (capability_models 에서 역이관).
+DROP TABLE IF EXISTS modality_models;

--- a/db/migrations/rollbacks/120_drop_modality_models.sql
+++ b/db/migrations/rollbacks/120_drop_modality_models.sql
@@ -1,0 +1,26 @@
+-- Rollback 120 — modality_models 재생성 + capability_models 에서 역이관 (117 스키마 그대로)
+CREATE TABLE IF NOT EXISTS modality_models (
+    scope       TEXT NOT NULL,
+    modality    TEXT NOT NULL CHECK (modality IN ('image_gen', 'image_edit', 'vision', 'video_gen', 'stt', 'tts', 'embedding')),
+    full_id     TEXT NOT NULL,
+    params      JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (scope, modality)
+);
+CREATE INDEX IF NOT EXISTS idx_modality_models_scope ON modality_models (scope);
+INSERT INTO modality_models (scope, modality, full_id, params, created_at, updated_at)
+SELECT scope,
+       CASE capability
+           WHEN 'image.generate'   THEN 'image_gen'
+           WHEN 'image.edit'       THEN 'image_edit'
+           WHEN 'vision.describe'  THEN 'vision'
+           WHEN 'video.generate'   THEN 'video_gen'
+           WHEN 'audio.transcribe' THEN 'stt'
+           WHEN 'audio.speech'     THEN 'tts'
+           WHEN 'text.embed'       THEN 'embedding'
+       END,
+       full_id, params, created_at, updated_at
+FROM capability_models
+WHERE capability IN ('image.generate','image.edit','vision.describe','video.generate','audio.transcribe','audio.speech','text.embed')
+ON CONFLICT (scope, modality) DO NOTHING;


### PR DESCRIPTION
## 요약
- \`db/migrations/120_drop_modality_models.sql\`: 117 테이블 DROP. 118 이 \`capability_models\` 로 이관했고 v1.59.0(#837) 이 코드 참조를 제거해 배포된 뒤의 2단계.
- \`UserManager.deleteUser\` 에 남아 있던 마지막 \`DELETE FROM modality_models\` 제거(DROP 뒤엔 계정 삭제 트랜잭션이 깨진다).
- 롤백 \`rollbacks/120\` — 117 스키마 재생성 + capability→modality 역이관.
- \`.env.example\` 의 폐기 예정 \`IMAGE_GEN_MODEL\` 블록 제거(코드가 부팅 경고 외엔 읽지 않음).

## 검증
- 운영 DB: modality_models 6행 = capability_models 6행(이관 완료 확인).
- tsc 0, `src/data` jest 106 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4QsmcWF1Muw7gCwTYDZ7Q