### PR TITLE
fix(orchestrator): 영상 내려받기 상한 600s + 내려받기 실패를 pending 으로 보존

### DIFF
--- a/apps/api/src/config/capabilities.ts
+++ b/apps/api/src/config/capabilities.ts
@@ -154,7 +154,8 @@ export const CAPABILITY_LIMITS = {
     VIDEO_SUBMIT_TIMEOUT_MS: parseInt(process.env.CAPABILITY_VIDEO_SUBMIT_TIMEOUT_MS || '60000', 10),
     VIDEO_WAIT_MS: parseInt(process.env.CAPABILITY_VIDEO_WAIT_MS || '300000', 10),
     VIDEO_POLL_INTERVAL_MS: parseInt(process.env.CAPABILITY_VIDEO_POLL_INTERVAL_MS || '10000', 10),
-    VIDEO_DOWNLOAD_TIMEOUT_MS: parseInt(process.env.CAPABILITY_VIDEO_DOWNLOAD_TIMEOUT_MS || '120000', 10),
+    /** 산출물 내려받기 상한 — hasa 파일 서버가 3.7MB 를 173s 에 준 실측(2026-09-12)이 있어 넉넉히 둔다(TASK_TIMEOUT 안). */
+    VIDEO_DOWNLOAD_TIMEOUT_MS: parseInt(process.env.CAPABILITY_VIDEO_DOWNLOAD_TIMEOUT_MS || '600000', 10),
     /** params JSONB 허용 키 — capability 별 화이트리스트 */
     PARAM_KEYS: {
         'text.reason': ['temperature'], 'text.code': ['temperature'], 'text.synthesize': [], 'text.embed': ['dimensions'],

--- a/apps/api/src/services/orchestrator/executors/video.ts
+++ b/apps/api/src/services/orchestrator/executors/video.ts
@@ -103,10 +103,26 @@ export const videoGenerateExecutor: CapabilityExecutor = async (task, ctx) => {
     if (isDone(view, adapter)) {
         const url = contentUrl(target, adapter, view);
         if (!url) throw new Error('완료됐지만 산출물 URL 이 없습니다');
-        const { bytes, contentType } = await downloadProviderUrl(url, {
-            timeoutMs: CAPABILITY_LIMITS.VIDEO_DOWNLOAD_TIMEOUT_MS, signal: ctx.signal, allowTypes: ['video/', 'application/octet-stream'],
-            headers: sameOrigin(url, target.baseUrl) ? target.headers : undefined,
-        });
+        let downloaded: Awaited<ReturnType<typeof downloadProviderUrl>>;
+        try {
+            downloaded = await downloadProviderUrl(url, {
+                timeoutMs: CAPABILITY_LIMITS.VIDEO_DOWNLOAD_TIMEOUT_MS, signal: ctx.signal, allowTypes: ['video/', 'application/octet-stream'],
+                headers: sameOrigin(url, target.baseUrl) ? target.headers : undefined,
+            });
+        } catch (err) {
+            // provider 는 완성했는데 내려받기만 실패(느린 파일 서버·타임아웃) — 실패로 닫지 않고 job 을 pending 으로 남겨
+            // 다음 요청에서 같은 job 을 다시 내려받게 한다(2026-09-12 실측: hasa 3.7MB 173s > 종전 120s 상한).
+            if (ctx.signal?.aborted) throw err; // 턴 자체 취소는 그대로 전파(다운로드 자체 타임아웃은 ctx.signal 이 살아 있다)
+            const reason = err instanceof Error ? err.message : String(err);
+            logger.warn(`[Video] 완성된 산출물 내려받기 실패 ${jobId}: ${reason}`);
+            return {
+                ok: false, status: 'pending', media: [], model: target.fullId, job,
+                text: ctx.lang === 'ko'
+                    ? `영상은 완성됐지만 파일 내려받기가 실패했습니다(${reason}). 작업 id ${jobId} 는 보존되어 있으니 잠시 후 다시 요청하면 같은 영상을 다시 내려받습니다(새로 만들지 않음).`
+                    : `The video is finished but downloading it failed (${reason}). Job ${jobId} is saved; ask again shortly and the same video will be fetched (no new generation).`,
+            } satisfies ExecutorOutput;
+        }
+        const { bytes, contentType } = downloaded;
         const ext = contentType.includes('webm') || url.toLowerCase().endsWith('.webm') ? 'webm' : 'mp4';
         const media = saveVideo(bytes, ext, ctx.lang === 'ko' ? '영상 보기' : 'Watch');
         if (repo && ctx.userId) void repo.markDone(ctx.userId, target.providerId, jobId, 'completed', media.urlPath).catch(() => undefined);


### PR DESCRIPTION
## 요약
- 라이브(user 3, 2026-09-12 09:00·09:04 KST): hasa 영상 job 은 COMPLETED 인데 3.7MB webm 내려받기가 173s 걸려(실측 curl) 종전 상한 120s 에 걸리고, 채팅은 "타임아웃으로 영상이 만들어지지 못했다" 고 안내했다.
- `VIDEO_DOWNLOAD_TIMEOUT_MS` 기본 120s → 600s(`CAPABILITY_VIDEO_DOWNLOAD_TIMEOUT_MS`, 운영 .env 도 600000).
- 완성된 job 의 내려받기 실패는 `failed` 대신 `pending`(사유 포함)으로 돌려 `orchestrator_jobs` 행이 남고 다음 요청에서 같은 job 을 다시 내려받는다. 턴 취소(ctx.signal)는 그대로 전파.

## 검증
- tsc 0 · lint 0 · orchestrator 테스트 30 passed. 배포 후 사용자 세션의 실제 job(`vid_fc86e11cef71`) 재조회로 라이브 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cxUriTMNf9Zen4aeHZS3j