### PR TITLE
fix(orchestrator): 저장된 영상 job 즉시 반환 + 내려받기 재시도

### DIFF
--- a/apps/api/src/config/capabilities.ts
+++ b/apps/api/src/config/capabilities.ts
@@ -156,6 +156,8 @@ export const CAPABILITY_LIMITS = {
     VIDEO_POLL_INTERVAL_MS: parseInt(process.env.CAPABILITY_VIDEO_POLL_INTERVAL_MS || '10000', 10),
     /** 산출물 내려받기 상한 — hasa 파일 서버가 3.7MB 를 173s 에 준 실측(2026-09-12)이 있어 넉넉히 둔다(TASK_TIMEOUT 안). */
     VIDEO_DOWNLOAD_TIMEOUT_MS: parseInt(process.env.CAPABILITY_VIDEO_DOWNLOAD_TIMEOUT_MS || '600000', 10),
+    /** 완성 산출물 내려받기 시도 횟수 — hasa 가 전송 중 연결을 끊는 실측(`terminated`, 2026-09-12)에 대비 */
+    VIDEO_DOWNLOAD_ATTEMPTS: parseInt(process.env.CAPABILITY_VIDEO_DOWNLOAD_ATTEMPTS || '2', 10),
     /** params JSONB 허용 키 — capability 별 화이트리스트 */
     PARAM_KEYS: {
         'text.reason': ['temperature'], 'text.code': ['temperature'], 'text.synthesize': [], 'text.embed': ['dimensions'],

--- a/apps/api/src/data/repositories/orchestrator-jobs-repo.ts
+++ b/apps/api/src/data/repositories/orchestrator-jobs-repo.ts
@@ -33,11 +33,16 @@ export class OrchestratorJobsRepository extends BaseRepository {
         );
     }
 
-    /** 최근 pending job (Planner 첨부 목록용) */
-    async listPending(userId: string, withinHours: number, limit: number): Promise<OrchestratorJobRow[]> {
+    /**
+     * 최근 job (Planner 첨부 목록용) — pending 과 **이미 받아둔 completed(result_path 있음)** 둘 다.
+     * completed 를 함께 주는 이유: "아까 영상 보여줘" 를 provider 재조회·재다운로드 없이 저장된 파일로 답하기 위해
+     * (hasa 파일 서버가 3.7MB 를 3~10분에 주는 실측, 2026-09-12). failed 는 제외.
+     */
+    async listRecent(userId: string, withinHours: number, limit: number): Promise<OrchestratorJobRow[]> {
         const r = await this.query<{ user_id: string; capability: string; provider_id: string; job_id: string; status: 'pending' | 'completed' | 'failed'; result_path: string | null; created_at: Date }>(
             `SELECT * FROM orchestrator_jobs
-             WHERE user_id = $1 AND status = 'pending' AND created_at > NOW() - ($2 || ' hours')::interval
+             WHERE user_id = $1 AND created_at > NOW() - ($2 || ' hours')::interval
+               AND (status = 'pending' OR (status = 'completed' AND result_path IS NOT NULL))
              ORDER BY created_at DESC LIMIT $3`,
             [userId, String(withinHours), limit],
         );

--- a/apps/api/src/prompts/orchestrator-planner.ts
+++ b/apps/api/src/prompts/orchestrator-planner.ts
@@ -44,7 +44,7 @@ ${caps}
 - 기존 이미지를 고치는 요청은 image.edit 이고 원본(첨부 id 또는 직전 생성 미디어 id)을 attachments 에 넣습니다. 새로 그리는 요청만 image.generate 입니다.
 - input.instruction 은 그 작업이 할 일을 한두 문장으로, 생성·편집 프롬프트는 영어로 구체적으로 씁니다.
 - audio.speech(낭독)는 **instruction 을 읽지 않습니다**. 읽을 문장이 정해져 있으면 input.text 에 그대로 넣고, 앞 작업 결과(요약·번역 등)를 읽어야 하면 input.refs 에 그 작업 id 만 넣습니다. 문장을 고치거나 번역해야 하면 먼저 text.reason 작업으로 만들고 그 결과를 refs 로 넘기세요.
-- 첨부 목록에 "job" 종류(진행 중이던 영상 작업)가 있고 사용자가 그 결과를 묻는다면 video.generate 를 새로 만들지 말고 attachments 에 그 job id 를 넣어 같은 작업을 재조회하세요.
+- 첨부 목록에 "job" 종류(진행 중이거나 이미 완료·저장된 영상 작업)가 있고 사용자가 그 결과를 묻는다면 video.generate 를 새로 만들지 말고 attachments 에 그 job id 를 넣어 같은 작업을 재조회하세요(저장된 것은 즉시 반환됩니다).
 - 크기·음성·형식·길이 같은 인자는 문장에 섞지 말고 input 의 키로 적습니다(예: "size":"512x512", "voice":"KR", "seconds":"4").
 - 모델명·파일명을 지어내지 마세요. 기능 목록에 없는 capability 는 쓰지 마세요.
 - JSON 외 다른 텍스트를 출력하지 마세요.
@@ -65,7 +65,7 @@ ${caps}
 - Modifying an existing image is image.edit with the source (attachment id or previously generated media id) in attachments. Only brand-new drawings are image.generate.
 - input.instruction: one or two sentences of what the task must do; generation/edit prompts in specific English.
 - audio.speech never reads the instruction aloud. Put the exact sentences in input.text, or reference an earlier task's output via input.refs. If the text must be rewritten/translated first, do that in a text.reason task and reference it.
-- If the attachments list contains a "job" entry (a video job still in progress) and the user asks about it, do NOT create a new video.generate; reference that job id in attachments to re-check the same job.
+- If the attachments list contains a "job" entry (a video job in progress or already finished and saved) and the user asks about it, do NOT create a new video.generate; reference that job id in attachments to re-check the same job (a saved one is returned immediately).
 - Put parameters such as size/voice/format/duration as input keys (e.g. "size":"512x512", "voice":"KR", "seconds":"4"), not inside sentences.
 - Never invent model names or file names. Never use a capability not listed.
 - Output nothing but JSON.

--- a/apps/api/src/services/orchestrator/__tests__/video-executor.test.ts
+++ b/apps/api/src/services/orchestrator/__tests__/video-executor.test.ts
@@ -1,0 +1,45 @@
+/** video.generate 실행기 — 저장본 즉시 반환 · 내려받기 재시도 · 내려받기 실패는 pending (2026-09-12 hasa 실측 대응) */
+jest.mock('../../../data/models/unified-database', () => ({ getPool: () => { throw new Error('no db'); } }));
+const target = { capability: 'video.generate', fullId: 'hasa:Wan2.2-T2V', providerId: 'hasa', model: 'Wan2.2-T2V', baseUrl: 'https://open.hasa.re.kr/v1', endpoint: '/videos/generations', headers: { Authorization: 'Bearer k' }, params: {}, source: 'user', transport: 'direct' };
+jest.mock('../capability-resolver', () => ({ resolveCapabilityTarget: async () => target }));
+const download = jest.fn(); const callJson = jest.fn();
+jest.mock('../http-call', () => ({ callJson: (...a: unknown[]) => callJson(...a), downloadProviderUrl: (...a: unknown[]) => download(...a) }));
+const saveVideo = jest.fn(() => ({ kind: 'video', urlPath: '/generated/video-new.webm', markdown: '[🎬 영상 보기](/generated/video-new.webm)' }));
+jest.mock('../media-io', () => ({ saveVideo: () => saveVideo() }));
+const exists = jest.fn();
+jest.mock('../../../mcp/generated-media', () => ({ resolveGeneratedPath: (p: string) => exists(p) }));
+jest.mock('../../../config/capabilities', () => ({
+    ...jest.requireActual('../../../config/capabilities'),
+    CAPABILITY_LIMITS: { ...jest.requireActual('../../../config/capabilities').CAPABILITY_LIMITS, VIDEO_WAIT_MS: 0, VIDEO_POLL_INTERVAL_MS: 1, VIDEO_DOWNLOAD_ATTEMPTS: 2 },
+}));
+
+import { videoGenerateExecutor } from '../executors/video';
+import type { ExecContext } from '../types';
+import type { PlanTask } from '../plan-schema';
+
+const task = (atts: string[]): PlanTask => ({ id: 't1', capability: 'video.generate', instruction: 'x', attachments: atts, refs: [], dependsOn: [], extra: {} } as unknown as PlanTask);
+const ctx = (job: Record<string, unknown>): ExecContext => ({ lang: 'ko', userMessage: 'q', results: new Map(), userId: 'u1', attachments: new Map([['j1', { id: 'j1', kind: 'job', name: 'n', mime: '', job }]]) } as unknown as ExecContext);
+beforeEach(() => { download.mockReset(); callJson.mockReset(); exists.mockReset(); saveVideo.mockClear(); });
+
+test('저장본(resultPath)이 실재하면 provider 호출·다운로드 없이 완료로 반환', async () => {
+    exists.mockReturnValue('/abs/video-old.webm');
+    const r = await videoGenerateExecutor(task(['j1']), ctx({ capability: 'video.generate', providerId: 'hasa', jobId: 'vid_1', resultPath: '/generated/video-old.webm' }));
+    expect(r.status).toBe('completed'); expect(r.media[0].urlPath).toBe('/generated/video-old.webm');
+    expect(callJson).not.toHaveBeenCalled(); expect(download).not.toHaveBeenCalled();
+});
+
+test('저장본 파일이 사라졌으면 재조회 경로로 — 첫 내려받기 실패 후 재시도 성공', async () => {
+    exists.mockReturnValue(null);
+    callJson.mockResolvedValue({ job_id: 'vid_1', status: 'COMPLETED', artifact_url: '/files/v.webm' });
+    download.mockRejectedValueOnce(new Error('terminated')).mockResolvedValueOnce({ bytes: Buffer.from([1]), contentType: 'video/webm' });
+    const r = await videoGenerateExecutor(task(['j1']), ctx({ capability: 'video.generate', providerId: 'hasa', jobId: 'vid_1', resultPath: '/generated/gone.webm' }));
+    expect(r.status).toBe('completed'); expect(download).toHaveBeenCalledTimes(2); expect(saveVideo).toHaveBeenCalledTimes(1);
+});
+
+test('내려받기가 전부 실패하면 failed 가 아니라 pending(사유 포함)', async () => {
+    exists.mockReturnValue(null);
+    callJson.mockResolvedValue({ job_id: 'vid_1', status: 'COMPLETED', artifact_url: '/files/v.webm' });
+    download.mockRejectedValue(new Error('terminated'));
+    const r = await videoGenerateExecutor(task(['j1']), ctx({ capability: 'video.generate', providerId: 'hasa', jobId: 'vid_1', resultPath: null }));
+    expect(r.ok).toBe(false); expect(r.status).toBe('pending'); expect(r.text).toMatch(/terminated/); expect(download).toHaveBeenCalledTimes(2);
+});

--- a/apps/api/src/services/orchestrator/executors/video.ts
+++ b/apps/api/src/services/orchestrator/executors/video.ts
@@ -11,7 +11,8 @@ import { OrchestratorJobsRepository } from '../../../data/repositories/orchestra
 import { resolveCapabilityTarget, type CapabilityTarget } from '../capability-resolver';
 import { callJson, downloadProviderUrl } from '../http-call';
 import { saveVideo } from '../media-io';
-import { refsRawText, type CapabilityExecutor, type ExecutorOutput } from '../types';
+import { refsRawText, type CapabilityExecutor, type ExecutorOutput, type TaskMedia } from '../types';
+import { resolveGeneratedPath } from '../../../mcp/generated-media';
 import { createLogger } from '../../../utils/logger';
 
 const logger = createLogger('VideoExecutor');
@@ -62,6 +63,25 @@ function jobsRepo(): OrchestratorJobsRepository | null {
     try { return new OrchestratorJobsRepository(getPool()); } catch { return null; }
 }
 
+/** 내려받기를 VIDEO_DOWNLOAD_ATTEMPTS 회까지 시도 — 턴 취소(signal)면 즉시 중단 */
+async function downloadWithRetry(url: string, target: CapabilityTarget, signal: AbortSignal | undefined): Promise<Awaited<ReturnType<typeof downloadProviderUrl>>> {
+    const attempts = Math.max(1, CAPABILITY_LIMITS.VIDEO_DOWNLOAD_ATTEMPTS);
+    let lastErr: unknown;
+    for (let i = 1; i <= attempts; i++) {
+        try {
+            return await downloadProviderUrl(url, {
+                timeoutMs: CAPABILITY_LIMITS.VIDEO_DOWNLOAD_TIMEOUT_MS, signal, allowTypes: ['video/', 'application/octet-stream'],
+                headers: sameOrigin(url, target.baseUrl) ? target.headers : undefined,
+            });
+        } catch (err) {
+            lastErr = err;
+            if (signal?.aborted || i === attempts) break;
+            logger.warn(`[Video] 내려받기 ${i}/${attempts} 실패 — 재시도: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    throw lastErr;
+}
+
 export const videoGenerateExecutor: CapabilityExecutor = async (task, ctx) => {
     const target = await resolveCapabilityTarget('video.generate', ctx.userId);
     const adapter = videoAdapterFor(target.providerId);
@@ -76,6 +96,13 @@ export const videoGenerateExecutor: CapabilityExecutor = async (task, ctx) => {
             throw new Error(`이전 영상 작업(${jobAtt.job.providerId})과 현재 배정 provider(${target.providerId})가 달라 재조회할 수 없습니다`);
         }
         jobId = jobAtt.job.jobId;
+        // 이미 받아둔 산출물이 있으면 provider 재조회·재다운로드 없이 그대로 돌려준다(파일이 실제로 있을 때만)
+        const saved = jobAtt.job.resultPath && resolveGeneratedPath(jobAtt.job.resultPath) ? jobAtt.job.resultPath : null;
+        if (saved) {
+            logger.info(`[Video] 기존 job 저장본 반환 ${jobId} ${saved}`);
+            const media: TaskMedia = { kind: 'video', urlPath: saved, markdown: `[🎬 ${ctx.lang === 'ko' ? '영상 보기' : 'Watch'}](${saved})` };
+            return { ok: true, status: 'completed', text: ctx.lang === 'ko' ? `영상(이미 완성): ${saved}` : `Video (already generated): ${saved}`, media: [media], model: target.fullId, job: { providerId: target.providerId, jobId } } satisfies ExecutorOutput;
+        }
         view = await fetchJob(target, adapter, jobId, ctx.signal);
         logger.info(`[Video] 기존 job 재조회 ${jobId} status=${view.status}`);
     } else {
@@ -105,10 +132,7 @@ export const videoGenerateExecutor: CapabilityExecutor = async (task, ctx) => {
         if (!url) throw new Error('완료됐지만 산출물 URL 이 없습니다');
         let downloaded: Awaited<ReturnType<typeof downloadProviderUrl>>;
         try {
-            downloaded = await downloadProviderUrl(url, {
-                timeoutMs: CAPABILITY_LIMITS.VIDEO_DOWNLOAD_TIMEOUT_MS, signal: ctx.signal, allowTypes: ['video/', 'application/octet-stream'],
-                headers: sameOrigin(url, target.baseUrl) ? target.headers : undefined,
-            });
+            downloaded = await downloadWithRetry(url, target, ctx.signal);
         } catch (err) {
             // provider 는 완성했는데 내려받기만 실패(느린 파일 서버·타임아웃) — 실패로 닫지 않고 job 을 pending 으로 남겨
             // 다음 요청에서 같은 job 을 다시 내려받게 한다(2026-09-12 실측: hasa 3.7MB 173s > 종전 120s 상한).

--- a/apps/api/src/services/orchestrator/orchestrate.ts
+++ b/apps/api/src/services/orchestrator/orchestrate.ts
@@ -75,10 +75,17 @@ export function collectAttachments(req: ChatMessageRequest): Map<string, Orchest
 async function collectPendingJobs(userId: string | undefined, map: Map<string, OrchestratorAttachment>): Promise<void> {
     if (!userId) return;
     try {
-        const rows = await new OrchestratorJobsRepository(getPool()).listPending(userId, ORCHESTRATOR.JOB_LOOKBACK_HOURS, ORCHESTRATOR.JOB_MAX_LISTED);
+        const rows = await new OrchestratorJobsRepository(getPool()).listRecent(userId, ORCHESTRATOR.JOB_LOOKBACK_HOURS, ORCHESTRATOR.JOB_MAX_LISTED);
         rows.forEach((r, i) => {
             const id = `j${i + 1}`;
-            map.set(id, { id, kind: 'job', name: `${r.capability} 진행 중 (${r.providerId} ${r.jobId}, ${r.createdAt.toISOString().slice(11, 16)}Z)`, mime: '', job: { capability: r.capability as Capability, providerId: r.providerId, jobId: r.jobId } });
+            const done = r.status === 'completed' && !!r.resultPath;
+            const state = done ? '완료·저장됨' : '진행 중';
+            map.set(id, {
+                id, kind: 'job', mime: '',
+                name: `${r.capability} ${state} (${r.providerId} ${r.jobId}, ${r.createdAt.toISOString().slice(11, 16)}Z)`,
+                ...(done && r.resultPath ? { urlPath: r.resultPath } : {}),
+                job: { capability: r.capability as Capability, providerId: r.providerId, jobId: r.jobId, resultPath: done ? r.resultPath : null },
+            });
         });
     } catch (err) {
         logger.debug(`pending job 조회 실패(무시): ${err instanceof Error ? err.message : String(err)}`);

--- a/apps/api/src/services/orchestrator/types.ts
+++ b/apps/api/src/services/orchestrator/types.ts
@@ -20,7 +20,7 @@ export interface OrchestratorAttachment {
     /** 텍스트 문서면 추출 텍스트 */
     text?: string;
     /** kind=job: 진행 중이던 비동기 작업(영상) — 재조회용 */
-    job?: { capability: Capability; providerId: string; jobId: string };
+    job?: { capability: Capability; providerId: string; jobId: string; /** 이미 받아둔 산출물(/generated/..) — 있으면 재조회·재다운로드 없이 그대로 반환 */ resultPath?: string | null };
 }
 
 export interface TaskMedia {


### PR DESCRIPTION
## 요약
- `orchestrator_jobs` 의 completed(result_path 있음) 행도 Planner 첨부(kind=job)에 실어, 사용자가 다시 물으면 provider 재조회·재다운로드 없이 `/generated` 저장본을 즉시 반환(파일 실재 확인, 없으면 종전 재조회 경로).
- 완성 산출물 내려받기를 `CAPABILITY_VIDEO_DOWNLOAD_ATTEMPTS`(기본 2)회 시도 — hasa 가 전송 중 `terminated` 로 끊는 실측 대응. 턴 취소는 즉시 중단.
- Planner 프롬프트(ko/en)의 job 규칙에 "완료·저장된 작업도 새로 만들지 않음" 명시.

## 검증
- 단위 테스트 `video-executor.test.ts` 3건(저장본 즉시 반환 시 provider·다운로드 호출 0 / 첫 실패 후 재시도 성공 / 전부 실패 → pending) + orchestrator 30 passed, tsc 0, lint 0.
- 배포 후 사용자 실제 job(`vid_fc86e11cef71`)으로 라이브 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRSQ84AdgaKGPEczPx8U7f