### PR TITLE
fix(orchestrator): 영상 job 후속 발화의 simple 오판을 재조회로 보정

### DIFF
--- a/apps/api/src/config/capabilities.ts
+++ b/apps/api/src/config/capabilities.ts
@@ -180,6 +180,11 @@ export const TTS_ALLOWED_FORMATS: ReadonlySet<string> = new Set(['mp3', 'wav', '
 export const TTS_DEFAULT_FORMAT = 'mp3';
 export const TTS_DEFAULT_VOICE = 'alloy';
 export const STT_ALLOWED_EXTS: ReadonlySet<string> = new Set(['mp3', 'wav', 'm4a', 'ogg', 'opus', 'flac', 'webm', 'mp4']);
+/**
+ * 영상 후속 발화 판정 — Planner 가 저장·진행 중인 영상 job 첨부를 두고도 `simple` 로 답하면(실측: bai qwen3.8-flash 가
+ * "완료·저장됨" 을 "할 일 없음" 으로 읽음, 2026-09-12) 결정적으로 job 재조회 1작업으로 보정한다. 사용자 발화에만 적용.
+ */
+export const VIDEO_JOB_FOLLOWUP_PATTERN = /영상|비디오|동영상|\bvideo\b|\bclip\b/i;
 export const VIDEO_GEN_DEFAULT_SECONDS = '4';
 export const VIDEO_GEN_DEFAULT_SIZE = '720x1280';
 export const VIDEO_TERMINAL_STATUSES: ReadonlySet<string> = new Set(['completed', 'succeeded', 'failed', 'cancelled', 'canceled', 'error']);

--- a/apps/api/src/prompts/orchestrator-planner.ts
+++ b/apps/api/src/prompts/orchestrator-planner.ts
@@ -44,7 +44,7 @@ ${caps}
 - 기존 이미지를 고치는 요청은 image.edit 이고 원본(첨부 id 또는 직전 생성 미디어 id)을 attachments 에 넣습니다. 새로 그리는 요청만 image.generate 입니다.
 - input.instruction 은 그 작업이 할 일을 한두 문장으로, 생성·편집 프롬프트는 영어로 구체적으로 씁니다.
 - audio.speech(낭독)는 **instruction 을 읽지 않습니다**. 읽을 문장이 정해져 있으면 input.text 에 그대로 넣고, 앞 작업 결과(요약·번역 등)를 읽어야 하면 input.refs 에 그 작업 id 만 넣습니다. 문장을 고치거나 번역해야 하면 먼저 text.reason 작업으로 만들고 그 결과를 refs 로 넘기세요.
-- 첨부 목록에 "job" 종류(진행 중이거나 이미 완료·저장된 영상 작업)가 있고 사용자가 그 결과를 묻는다면 video.generate 를 새로 만들지 말고 attachments 에 그 job id 를 넣어 같은 작업을 재조회하세요(저장된 것은 즉시 반환됩니다).
+- 첨부 목록에 "job" 종류(진행 중이거나 이미 완료·저장된 영상 작업)가 있고 사용자가 그 영상을 묻거나 보여달라고 하면 **반드시 complexity "multi" 로 video.generate 작업 하나를 만들고 input.attachments 에 그 job id 를 넣으세요**(새 프롬프트로 만들지 않음). 저장된 영상은 이 작업으로만 사용자에게 전달됩니다 — simple 로 답하면 영상을 보여줄 수 없습니다.
 - 크기·음성·형식·길이 같은 인자는 문장에 섞지 말고 input 의 키로 적습니다(예: "size":"512x512", "voice":"KR", "seconds":"4").
 - 모델명·파일명을 지어내지 마세요. 기능 목록에 없는 capability 는 쓰지 마세요.
 - JSON 외 다른 텍스트를 출력하지 마세요.
@@ -65,7 +65,7 @@ ${caps}
 - Modifying an existing image is image.edit with the source (attachment id or previously generated media id) in attachments. Only brand-new drawings are image.generate.
 - input.instruction: one or two sentences of what the task must do; generation/edit prompts in specific English.
 - audio.speech never reads the instruction aloud. Put the exact sentences in input.text, or reference an earlier task's output via input.refs. If the text must be rewritten/translated first, do that in a text.reason task and reference it.
-- If the attachments list contains a "job" entry (a video job in progress or already finished and saved) and the user asks about it, do NOT create a new video.generate; reference that job id in attachments to re-check the same job (a saved one is returned immediately).
+- If the attachments list contains a "job" entry (a video job in progress or already finished and saved) and the user asks about or wants to see that video, you MUST answer with complexity "multi" and exactly one video.generate task whose input.attachments holds that job id (never a new prompt). A saved video reaches the user only through this task — a "simple" plan cannot show it.
 - Put parameters such as size/voice/format/duration as input keys (e.g. "size":"512x512", "voice":"KR", "seconds":"4"), not inside sentences.
 - Never invent model names or file names. Never use a capability not listed.
 - Output nothing but JSON.

--- a/apps/api/src/services/orchestrator/__tests__/http-and-attachments.test.ts
+++ b/apps/api/src/services/orchestrator/__tests__/http-and-attachments.test.ts
@@ -108,3 +108,17 @@ describe('첨부 계약', () => {
         expect(map.get('m3')).toMatchObject({ urlPath: '/generated/img-1.png' });
     });
 });
+
+describe('coerceJobFollowup — Planner 가 simple 로 답해도 영상 job 첨부 + 영상 발화면 재조회 1작업으로 보정', () => {
+    const { coerceJobFollowup } = jest.requireActual('../orchestrate') as typeof import('../orchestrate');
+    const simple = { complexity: 'simple' as const, synthesis: false, tasks: [], levels: [] } as unknown as import('../plan-schema').ValidatedPlan;
+    const jobAtt = new Map([['j1', { id: 'j1', kind: 'job' as const, name: 'video.generate 완료·저장됨', mime: '', job: { capability: 'video.generate' as const, providerId: 'hasa', jobId: 'vid_1', resultPath: '/generated/v.webm' } }]]);
+    it('영상 발화 + job 첨부 → multi/video.generate(job id 첨부)', () => {
+        const p = coerceJobFollowup(simple, jobAtt, '아까 영상 다 됐어? 보여줘');
+        expect(p.complexity).toBe('multi'); expect(p.tasks[0].capability).toBe('video.generate'); expect(p.tasks[0].attachments).toEqual(['j1']);
+    });
+    it('영상 언급이 없거나 job 첨부가 없으면 계획 그대로', () => {
+        expect(coerceJobFollowup(simple, jobAtt, '한국의 수도는?')).toBe(simple);
+        expect(coerceJobFollowup(simple, new Map(), '영상 보여줘')).toBe(simple);
+    });
+});

--- a/apps/api/src/services/orchestrator/orchestrate.ts
+++ b/apps/api/src/services/orchestrator/orchestrate.ts
@@ -9,11 +9,12 @@
  *  - `cancelled`: 사용자 취소 → 호출부가 종전 경로도 시작하지 않는다
  * 셰도우(orchestrator_runs)는 fire-and-forget.
  */
-import { ORCHESTRATOR, CAPABILITY_LABELS_KO, type Capability } from '../../config/capabilities';
+import { ORCHESTRATOR, CAPABILITY_LABELS_KO, VIDEO_JOB_FOLLOWUP_PATTERN, type Capability } from '../../config/capabilities';
 import { getPool } from '../../data/models/unified-database';
 import { OrchestratorRunsRepository } from '../../data/repositories/orchestrator-runs-repo';
 import type { ChatMessageRequest } from '../chat-service-types';
 import { planRequest } from './planner';
+import { validatePlan, type ValidatedPlan } from './plan-schema';
 import { executePlan } from './executor';
 import { preflightPlan } from './preflight';
 import { OrchestratorJobsRepository } from '../../data/repositories/orchestrator-jobs-repo';
@@ -90,6 +91,20 @@ async function collectPendingJobs(userId: string | undefined, map: Map<string, O
     } catch (err) {
         logger.debug(`pending job 조회 실패(무시): ${err instanceof Error ? err.message : String(err)}`);
     }
+}
+
+/**
+ * Planner 가 `simple` 을 냈는데 영상 job 첨부가 있고 사용자가 영상을 묻는 발화면, 가장 최근 job 을 재조회하는 1작업 multi 로 보정한다.
+ * (저장본은 실행기가 즉시 반환하므로 provider 호출 없음.) 그 외엔 계획 그대로.
+ */
+export function coerceJobFollowup(plan: ValidatedPlan, attachments: Map<string, OrchestratorAttachment>, message: string): ValidatedPlan {
+    if (plan.complexity !== 'simple' || !VIDEO_JOB_FOLLOWUP_PATTERN.test(message)) return plan;
+    const job = [...attachments.values()].find((a) => a.kind === 'job' && a.job?.capability === 'video.generate');
+    if (!job) return plan;
+    const v = validatePlan({ complexity: 'multi', language: plan.language, synthesis: true, tasks: [{ id: 't1', capability: 'video.generate', input: { instruction: message.slice(0, 400), attachments: [job.id] } }] }, new Set(attachments.keys()));
+    if (!v.ok) return plan;
+    logger.info(`[Orchestrator] simple → 영상 job 재조회로 보정 (${job.job?.jobId})`);
+    return v.plan;
 }
 
 function toPlannerMeta(atts: Map<string, OrchestratorAttachment>): PlannerAttachmentMeta[] {
@@ -180,7 +195,7 @@ export async function runOrchestrator(input: RunOrchestratorInput): Promise<Orch
         record({ requestId: input.requestId, userId, plannerModel: planned.model, plannerMs: planned.ms, plannerOk: false, plannerError: planned.error, outcome: 'fallback' });
         return { mode: 'fallback', contextBlock: fallbackNote(lang, planned.error ?? 'unknown'), mediaMarkdowns: [], plannerMs: planned.ms };
     }
-    const plan = planned.plan;
+    const plan = coerceJobFollowup(planned.plan, attachments, req.message ?? '');
     onProgress?.({ type: 'orchestrator_plan', complexity: plan.complexity, tasks: plan.tasks.map((t) => ({ id: t.id, capability: t.capability, instruction: t.instruction.slice(0, 160) })) });
 
     if (plan.complexity === 'simple') {


### PR DESCRIPTION
## 요약
- v1.60.2 라이브: 저장된 영상 job 이 첨부(kind=job, 완료·저장됨)로 실렸는데 Planner 가 `simple` 을 내 채팅 모델이 "확인 도구가 없다" 고 답했다.
- `coerceJobFollowup`(orchestrate.ts): 계획이 simple + 영상 job 첨부 + 사용자 발화가 `VIDEO_JOB_FOLLOWUP_PATTERN`(영상·비디오·동영상·video·clip)이면 가장 최근 job 을 재조회하는 video.generate 1작업 multi 로 보정(저장본이면 실행기가 provider 호출 없이 즉시 반환).
- Planner 프롬프트(ko/en) 규칙을 "반드시 multi + job id 첨부" 로 강화.

## 검증
- 단위 테스트 2건 추가(보정 성립 / 영상 언급·job 부재 시 계획 그대로), orchestrator 35 passed, tsc 0, lint 0.
- 배포 후 사용자 실제 job 으로 라이브 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRSQ84AdgaKGPEczPx8U7f