### PR TITLE
perf(orchestrator): 영상 완료/실패 markDone 비차단(fire-and-forget)

### DIFF
--- a/apps/api/src/services/orchestrator/executors/video.ts
+++ b/apps/api/src/services/orchestrator/executors/video.ts
@@ -163,11 +163,12 @@ export const videoGenerateExecutor: CapabilityExecutor = async (task, ctx) => {
         const { bytes, contentType } = downloaded;
         const ext = contentType.includes('webm') || url.toLowerCase().endsWith('.webm') ? 'webm' : 'mp4';
         const media = saveVideo(bytes, ext, ctx.lang === 'ko' ? '영상 보기' : 'Watch');
-        if (repo && ctx.userId) await repo.markDone(ctx.userId, target.providerId, jobId, 'completed', media.urlPath).catch((err) => logger.warn(`[Video] 완료 저장 실패 ${jobId}(다음 요청은 재다운로드): ${err instanceof Error ? err.message : String(err)}`));
+        // 완료 표시는 응답을 막지 않는다(결과를 쓰지 않음 — 실패해도 다음 요청이 재다운로드로 자기 복구). 제출 시 upsertPending 만 await(persisted 판정).
+        if (repo && ctx.userId) void repo.markDone(ctx.userId, target.providerId, jobId, 'completed', media.urlPath).catch((err) => logger.warn(`[Video] 완료 저장 실패 ${jobId}(다음 요청은 재다운로드): ${err instanceof Error ? err.message : String(err)}`));
         return { ok: true, status: 'completed', text: ctx.lang === 'ko' ? `영상 생성 완료: ${media.urlPath}` : `Video generated: ${media.urlPath}`, media: [media], model: target.fullId, job, usage: { units: { kind: 'video_seconds', count: Number(view.raw.seconds ?? 0) || 0 } } } satisfies ExecutorOutput;
     }
     if (isTerminal(view, adapter)) {
-        if (repo && ctx.userId) await repo.markDone(ctx.userId, target.providerId, jobId, 'failed', null).catch(() => undefined);
+        if (repo && ctx.userId) void repo.markDone(ctx.userId, target.providerId, jobId, 'failed', null).catch(() => undefined);
         throw new Error(`영상 생성 실패 (status=${view.status}) ${JSON.stringify(view.raw).slice(0, 160)}`);
     }
     const pct = view.progress !== undefined ? ` (${view.progress}%)` : '';


### PR DESCRIPTION
## 요약
- `/code-review 847` 지적 반영: 완료·실패 경로의 `markDone` await 는 결과를 쓰지 않아(로그만) DB 지연이 이미 내려받은 영상 응답을 늦췄다 → 종전처럼 `void … .catch()`.
- 제출 경로 `upsertPending` await(`persisted` 판정 → 사용자 안내 분기)는 유지 — Codex 검토 3 의 취지(유료 job 재조회 연결 보장)는 이쪽이 담당.

## 검증
- tsc 0 · lint 0 · orchestrator 42 passed(저장 실패 안내 테스트 포함).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013st6eP2mLYDaHH4jEjP7Nf