### PR TITLE
chore(mcp,llm): MCP·도구 호출 계층 최신화 — openai SDK 7 · MCP 프로토콜 협상 · 구조화 출력 폴백 · 서버 핀 상향

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -56,7 +56,7 @@
         "multer": "^2.0.2",
         "nodemailer": "^9.0.0",
         "officeparser": "^7.2.1",
-        "openai": "^6.37.0",
+        "openai": "^7.15.0",
         "ora": "^9.2.0",
         "pg": "^8.18.0",
         "turndown": "^7.2.2",

--- a/apps/api/src/config/mcp-protocol.ts
+++ b/apps/api/src/config/mcp-protocol.ts
@@ -1,0 +1,40 @@
+/**
+ * MCP 프로토콜 리비전 — 우리가 **서버로서** 응답할 수 있는 버전 목록.
+ *
+ * 배경: `mcp/server.ts` 는 initialize 응답에 `2024-11-05` 를 고정 문자열로 실었다
+ * (2024년 리비전). 클라이언트가 요청한 버전을 보지 않으므로 최신 클라이언트가
+ * 붙어도 항상 2년 전 리비전으로 협상됐다.
+ *
+ * 여기 실린 리비전은 전부 **legacy era**(평범한 `initialize` 핸드셰이크)이며
+ * `tools/list`·`tools/call` 의 와이어 형태가 동일하다 — 우리 서버가 구현한 범위가
+ * 그 셋뿐이라 리비전 간 차이가 없다. 2026-07-28(modern era)은 `server/discover`·
+ * tasks·`_meta` 봉투를 요구하므로 **의도적으로 제외**한다(구현하지 않은 것을
+ * 광고하지 않는다).
+ *
+ * 목록·기본값은 `@modelcontextprotocol/client` 의 `SUPPORTED_PROTOCOL_VERSIONS` /
+ * `LATEST_PROTOCOL_VERSION`(2.0.0 기준) 과 같다.
+ *
+ * @module config/mcp-protocol
+ */
+
+/** 우리 서버가 수용하는 리비전 (최신 우선). */
+export const MCP_SUPPORTED_PROTOCOL_VERSIONS: readonly string[] = [
+    '2025-11-25',
+    '2025-06-18',
+    '2025-03-26',
+    '2024-11-05',
+    '2024-10-07',
+];
+
+/** 클라이언트가 버전을 안 보내거나 모르는 버전을 요청할 때 응답할 리비전. */
+export const MCP_DEFAULT_PROTOCOL_VERSION = MCP_SUPPORTED_PROTOCOL_VERSIONS[0];
+
+/**
+ * initialize 협상 — 클라이언트가 요청한 리비전을 수용 가능하면 그대로 돌려주고,
+ * 아니면 우리가 지원하는 최신 리비전을 돌려준다(MCP 규약).
+ */
+export function negotiateProtocolVersion(requested: unknown): string {
+    return typeof requested === 'string' && MCP_SUPPORTED_PROTOCOL_VERSIONS.includes(requested)
+        ? requested
+        : MCP_DEFAULT_PROTOCOL_VERSION;
+}

--- a/apps/api/src/mcp/__tests__/protocol-version.test.ts
+++ b/apps/api/src/mcp/__tests__/protocol-version.test.ts
@@ -1,0 +1,65 @@
+/**
+ * MCP initialize 프로토콜 리비전 협상 회귀 테스트.
+ *
+ * 종전 `mcp/server.ts` 는 `protocolVersion: '2024-11-05'` 고정 문자열을 돌려줬다 —
+ * 클라이언트가 요청한 리비전을 보지 않아 최신 클라이언트도 2024 리비전으로 협상됐다.
+ * 이 테스트는 그 회귀(고정 문자열 복귀)를 잡는다.
+ */
+import { MCPServer } from '../server';
+import {
+    MCP_DEFAULT_PROTOCOL_VERSION,
+    MCP_SUPPORTED_PROTOCOL_VERSIONS,
+    negotiateProtocolVersion,
+} from '../../config/mcp-protocol';
+
+describe('negotiateProtocolVersion', () => {
+    it('지원 리비전을 요청하면 그대로 돌려준다', () => {
+        MCP_SUPPORTED_PROTOCOL_VERSIONS.forEach((v) => {
+            expect(negotiateProtocolVersion(v)).toBe(v);
+        });
+    });
+
+    it('모르는 리비전·누락은 우리 최신으로 떨어진다', () => {
+        expect(negotiateProtocolVersion('1999-01-01')).toBe(MCP_DEFAULT_PROTOCOL_VERSION);
+        expect(negotiateProtocolVersion(undefined)).toBe(MCP_DEFAULT_PROTOCOL_VERSION);
+        expect(negotiateProtocolVersion(42)).toBe(MCP_DEFAULT_PROTOCOL_VERSION);
+    });
+
+    it('최신 기본값은 2024 리비전이 아니다', () => {
+        expect(MCP_DEFAULT_PROTOCOL_VERSION).toBe('2025-11-25');
+    });
+
+    it('구현하지 않은 modern era(2026-07-28)는 광고하지 않는다', () => {
+        expect(MCP_SUPPORTED_PROTOCOL_VERSIONS).not.toContain('2026-07-28');
+        expect(negotiateProtocolVersion('2026-07-28')).toBe(MCP_DEFAULT_PROTOCOL_VERSION);
+    });
+});
+
+describe('MCPServer initialize', () => {
+    const server = new MCPServer('openmake-test', '1.0.0');
+
+    it('클라이언트가 요청한 최신 리비전을 그대로 협상한다', async () => {
+        const res = await server.handleRequest({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: { protocolVersion: '2025-11-25' },
+        });
+        expect((res.result as { protocolVersion: string }).protocolVersion).toBe('2025-11-25');
+    });
+
+    it('구 클라이언트(2024-11-05)와도 그 리비전으로 협상한다', async () => {
+        const res = await server.handleRequest({
+            jsonrpc: '2.0',
+            id: 2,
+            method: 'initialize',
+            params: { protocolVersion: '2024-11-05' },
+        });
+        expect((res.result as { protocolVersion: string }).protocolVersion).toBe('2024-11-05');
+    });
+
+    it('버전 미지정이면 우리 최신 리비전을 돌려준다', async () => {
+        const res = await server.handleRequest({ jsonrpc: '2.0', id: 3, method: 'initialize' });
+        expect((res.result as { protocolVersion: string }).protocolVersion).toBe(MCP_DEFAULT_PROTOCOL_VERSION);
+    });
+});

--- a/apps/api/src/mcp/__tests__/structured-content.test.ts
+++ b/apps/api/src/mcp/__tests__/structured-content.test.ts
@@ -1,0 +1,35 @@
+/**
+ * MCP 2025-06-18 구조화 출력(structuredContent) 폴백 회귀 테스트.
+ *
+ * 종전엔 content 가 비면 무조건 '(empty result)' 를 넣어, 구조화 출력만 돌려주는
+ * 서버의 정상 결과가 모델에게 "빈 결과"로 보였다(조용한 실패).
+ */
+import { serializeStructuredContent } from '../external-client';
+
+describe('serializeStructuredContent', () => {
+    it('객체를 JSON 으로 직렬화한다', () => {
+        expect(serializeStructuredContent({ temp: 21, unit: 'C' })).toBe('{\n  "temp": 21,\n  "unit": "C"\n}');
+    });
+
+    it('배열도 직렬화한다', () => {
+        expect(serializeStructuredContent([1, 2])).toContain('1');
+    });
+
+    it('문자열은 그대로 쓴다', () => {
+        expect(serializeStructuredContent('맑음')).toBe('맑음');
+    });
+
+    it('값이 없거나 빈 구조면 null — 호출부가 종전 문구를 쓴다', () => {
+        expect(serializeStructuredContent(undefined)).toBeNull();
+        expect(serializeStructuredContent(null)).toBeNull();
+        expect(serializeStructuredContent('')).toBeNull();
+        expect(serializeStructuredContent({})).toBeNull();
+        expect(serializeStructuredContent([])).toBeNull();
+    });
+
+    it('순환 참조는 null (throw 하지 않는다)', () => {
+        const a: Record<string, unknown> = {};
+        a.self = a;
+        expect(serializeStructuredContent(a)).toBeNull();
+    });
+});

--- a/apps/api/src/mcp/external-client.ts
+++ b/apps/api/src/mcp/external-client.ts
@@ -78,6 +78,11 @@ interface SDKCallToolResult {
         /** MIME 타입 */
         mimeType?: string;
     }>;
+    /**
+     * 구조화 출력 (MCP 2025-06-18 리비전) — `outputSchema` 를 선언한 도구가 돌려주는 JSON.
+     * 규약상 서버는 같은 내용을 `content` 텍스트로도 실어야 하지만, 그러지 않는 서버가 있다.
+     */
+    structuredContent?: unknown;
     /** 에러 발생 여부 */
     isError?: boolean;
 }
@@ -425,14 +430,35 @@ export class ExternalMCPClient extends EventEmitter {
             return entry;
         });
 
-        // 빈 결과 방지
+        // 빈 결과 방지 — content 가 비었는데 구조화 출력(MCP 2025-06-18)이 있으면 그것을 싣는다.
+        // (규약은 텍스트 폴백 동반을 요구하지만 지키지 않는 서버가 있고, 그때 모델에게
+        //  '(empty result)' 만 가면 도구가 실패한 것처럼 보인다 — 조용한 실패)
         if (content.length === 0) {
-            content.push({ type: 'text', text: '(empty result)' });
+            const structured = serializeStructuredContent(result.structuredContent);
+            content.push({ type: 'text', text: structured ?? '(empty result)' });
         }
 
         return {
             content,
             isError: result.isError || false,
         };
+    }
+}
+
+/**
+ * 구조화 출력(structuredContent)을 도구 결과 텍스트로 직렬화한다.
+ *
+ * content 가 비었을 때의 폴백 전용 — 값이 없거나 직렬화할 수 없으면 null 을 돌려
+ * 호출부가 종전 '(empty result)' 를 쓰게 한다. 상한은 도구 결과 절단이 뒤에서
+ * 처리하므로 여기서 따로 자르지 않는다.
+ */
+export function serializeStructuredContent(value: unknown): string | null {
+    if (value === undefined || value === null) return null;
+    if (typeof value === 'string') return value.length > 0 ? value : null;
+    try {
+        const json = JSON.stringify(value, null, 2);
+        return json && json !== '{}' && json !== '[]' ? json : null;
+    } catch {
+        return null;
     }
 }

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -29,6 +29,7 @@ import {
     MCPTool
 } from './types';
 import { builtInTools } from './tools';
+import { negotiateProtocolVersion } from '../config/mcp-protocol';
 
 /**
  * MCP 서버 클래스
@@ -128,7 +129,11 @@ export class MCPServer {
                         jsonrpc: '2.0',
                         id,
                         result: {
-                            protocolVersion: '2024-11-05',
+                            // 클라이언트가 요청한 리비전을 수용 가능하면 그대로, 아니면 우리 최신으로
+                            // (종전엔 '2024-11-05' 고정이라 최신 클라이언트도 2024 리비전으로 협상됐다)
+                            protocolVersion: negotiateProtocolVersion(
+                                (params as { protocolVersion?: unknown } | undefined)?.protocolVersion
+                            ),
                             serverInfo: this.serverInfo,
                             capabilities: this.serverInfo.capabilities
                         }

--- a/db/migrations/122_mcp_server_version_bumps.sql
+++ b/db/migrations/122_mcp_server_version_bumps.sql
@@ -1,0 +1,37 @@
+-- 122: MCP stdio 서버 고정 버전 상향 (2026-09-12)
+--
+-- 카탈로그 템플릿과 이미 설치된 인스턴스의 npx 고정 버전을 최신으로 올린다.
+-- 대상은 **운영 샌드박스(읽기 전용 rootfs · cap-drop ALL · net)와 동일한 조건에서
+-- 실제 연결·도구 목록을 확인한 것만**이다:
+--   · @upstash/context7-mcp        4.0.5      → 4.1.0       (도구 2종 동일: resolve-library-id, query-docs)
+--   · @modelcontextprotocol/server-filesystem 2026.7.10 → 2026.8.31 (도구 14종 동일)
+--
+-- ⚠️ @playwright/mcp 0.0.79 → 0.0.80 은 **의도적으로 제외**한다. 0.0.80 은 번들 playwright 가
+--    1.63.0-alpha-2026-08-05 → -08-31 로 올라가며 chromium 리비전이 1237 → 1243 으로 바뀌는데,
+--    같은 샌드박스 조건에서 1243 은 브라우저 기동이 "Chromium sandboxing failed!" 로 실패했다
+--    (같은 하네스에서 0.0.79 는 example.com 탐색 성공 — 실측 대조). 캐시 볼륨에 1243 을 설치해도
+--    동일하게 실패하므로 상류가 고칠 때까지 0.0.79 를 유지한다.
+--
+-- 설치 인스턴스는 **옛 고정 버전과 정확히 일치하는 행만** 갱신한다(사용자가 손댄 args 보존).
+
+-- 1) 카탈로그 템플릿
+UPDATE mcp_server_catalog
+   SET command_template = 'npx -y @upstash/context7-mcp@4.1.0'
+ WHERE command_template = 'npx -y @upstash/context7-mcp@4.0.5';
+
+UPDATE mcp_server_catalog
+   SET command_template = 'npx -y @modelcontextprotocol/server-filesystem@2026.8.31'
+ WHERE command_template = 'npx -y @modelcontextprotocol/server-filesystem@2026.7.10';
+
+-- 2) 설치된 인스턴스 args
+UPDATE mcp_servers
+   SET args = '["-y","@upstash/context7-mcp@4.1.0"]'::jsonb,
+       updated_at = NOW()
+ WHERE command = 'npx'
+   AND args = '["-y","@upstash/context7-mcp@4.0.5"]'::jsonb;
+
+UPDATE mcp_servers
+   SET args = '["-y","@modelcontextprotocol/server-filesystem@2026.8.31"]'::jsonb,
+       updated_at = NOW()
+ WHERE command = 'npx'
+   AND args = '["-y","@modelcontextprotocol/server-filesystem@2026.7.10"]'::jsonb;

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         },
         "apps/api": {
             "name": "openmake-api",
-            "version": "1.52.1",
+            "version": "1.61.1",
             "dependencies": {
                 "@modelcontextprotocol/client": "^2.0.0",
                 "@mozilla/readability": "^0.6.0",
@@ -84,7 +84,7 @@
                 "multer": "^2.0.2",
                 "nodemailer": "^9.0.0",
                 "officeparser": "^7.2.1",
-                "openai": "^6.37.0",
+                "openai": "^7.15.0",
                 "ora": "^9.2.0",
                 "pg": "^8.18.0",
                 "turndown": "^7.2.2",
@@ -171,7 +171,7 @@
         },
         "apps/discord-bot": {
             "name": "openmake-discord-bot",
-            "version": "1.52.1",
+            "version": "1.61.1",
             "dependencies": {
                 "discord.js": "^14.16.3",
                 "dotenv": "^16.4.5"
@@ -198,7 +198,7 @@
         },
         "apps/web": {
             "name": "@openmake/web",
-            "version": "1.52.1",
+            "version": "1.61.1",
             "dependencies": {
                 "@openmake/api-client": "*",
                 "@openmake/config": "*",
@@ -16554,18 +16554,34 @@
             "optional": true
         },
         "node_modules/openai": {
-            "version": "6.37.0",
-            "resolved": "https://registry.npmjs.org/openai/-/openai-6.37.0.tgz",
-            "integrity": "sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==",
+            "version": "7.15.0",
+            "resolved": "https://registry.npmjs.org/openai/-/openai-7.15.0.tgz",
+            "integrity": "sha512-2DIwesnPSduw68MFx7nAdgvshrgvS8WOan5W8+tgUMlAy/tY+Q41g80Pa+w/v64rHA6rtn+dketa8QvMVxU96w==",
             "license": "Apache-2.0",
-            "bin": {
-                "openai": "bin/cli"
+            "engines": {
+                "node": ">=22.0.0"
             },
             "peerDependencies": {
-                "ws": "^8.18.0",
+                "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+                "@smithy/hash-node": ">=4.3.0 <5",
+                "@smithy/signature-v4": ">=5.4.0 <6",
+                "undici": ">=5 <9",
+                "ws": "^8.21.0",
                 "zod": "^3.25 || ^4.0"
             },
             "peerDependenciesMeta": {
+                "@aws-sdk/credential-provider-node": {
+                    "optional": true
+                },
+                "@smithy/hash-node": {
+                    "optional": true
+                },
+                "@smithy/signature-v4": {
+                    "optional": true
+                },
+                "undici": {
+                    "optional": true
+                },
                 "ws": {
                     "optional": true
                 },
@@ -20391,7 +20407,7 @@
         },
         "packages/api-client": {
             "name": "@openmake/api-client",
-            "version": "1.52.1",
+            "version": "1.61.1",
             "dependencies": {
                 "@openmake/config": "*",
                 "@openmake/shared-types": "*"
@@ -20403,7 +20419,7 @@
         },
         "packages/config": {
             "name": "@openmake/config",
-            "version": "1.52.1"
+            "version": "1.61.1"
         },
         "packages/local-bridge-core": {
             "name": "@openmake/local-bridge-core",
@@ -20418,7 +20434,7 @@
         },
         "packages/shared-types": {
             "name": "@openmake/shared-types",
-            "version": "1.52.1"
+            "version": "1.61.1"
         }
     }
 }


### PR DESCRIPTION
MCP · 스킬 · 도구 호출 3축의 버전을 실측 대조해 **문제 없는 것만** 올렸습니다.

## 도구 호출
| 대상 | 현재 → 최신 | 판정 |
|---|---|---|
| `openai` | 6.37.0 → **7.15.0** | ✅ 적용 — v7 의 유일한 breaking change 는 "Node 22+ 요구"이고 레포 engines `>=24 <25`·운영 pm2 3앱 모두 24.16.0. tsc 0, API 표면 변화 없음 |

도구 정의는 이미 현행 규격(`tools`/`tool_calls`·`strict`·`tool_choice`)이고 구 `functions` 잔재는 없습니다(Responses API 의 `function_call` 아이템은 그 API 규격).

## MCP
| 항목 | 내용 |
|---|---|
| `@modelcontextprotocol/client` | 이미 최신 2.0.0 — 변경 없음 |
| **initialize 프로토콜 협상** | `mcp/server.ts` 가 `protocolVersion: '2024-11-05'` **고정 문자열**을 돌려줘 최신 클라이언트도 2024 리비전으로 협상됐다 → `config/mcp-protocol.ts` 지원 목록으로 협상. 구현하지 않은 modern era(2026-07-28)는 광고하지 않음 |
| **구조화 출력 폴백** | 외부 도구 결과의 `structuredContent`(MCP 2025-06-18)를 전혀 읽지 않아, content 를 비우고 구조화 출력만 주는 서버의 정상 결과가 모델에게 `(empty result)` 로 갔다 → content 가 빌 때만 직렬화해 싣는다 |
| **서버 핀 상향(122)** | `@upstash/context7-mcp` 4.0.5→**4.1.0**, `@modelcontextprotocol/server-filesystem` 2026.7.10→**2026.8.31** — 둘 다 운영과 같은 샌드박스(readonly rootfs·cap-drop ALL)에서 연결·도구 목록 실측(2종/14종 동일) |

## 올리지 않은 것 (근거 실측)
- **`@playwright/mcp` 0.0.79 → 0.0.80**: 번들 chromium 1237 → 1243. 캐시 볼륨에 1243 을 설치하고 같은 샌드박스로 돌리니 `Chromium sandboxing failed!` 로 브라우저 기동 실패, 같은 하네스에서 0.0.79 는 example.com 탐색 성공. 상류 수정 전까지 0.0.79 유지(설치한 1243 은 볼륨에서 제거)
- **`versionNegotiation: 'auto'`**: fleet 에 v2 서버가 생겼지만(context7 4.1.0 = `@modelcontextprotocol/server@2.0.0`) 우리 사용 범위는 listTools/callTool 뿐이라 이득이 없고, stdio 에서 'auto' 는 연결마다 프로브용 컨테이너를 한 번 더 띄운다 → legacy 유지
- **확장(스킬) 일괄 업데이트**: 상류가 갱신된 설치 확장 7건을 확인했으나 재설치는 `archiveLinkedComponents` 로 **기존 구성요소를 먼저 archive** 하고 새 것을 draft 로 넣는다 — 승인 전까지 활성 스킬·MCP 가 비는 구간이 생겨 일괄 적용하지 않았다(본문 아래 목록)

## 함께 수행한 운영 작업(코드 변경 아님)
- 확장 카탈로그 **19개 소스 전체 재동기화** (2026-08-29 → 오늘, 총 886 → 894 엔트리). 무인증 GitHub 60/hr 한도에 큰 소스 7개가 막혀 요청 단위 accessToken 으로 재시도

## 검증
- `npm run lint` — 오류 0(경고 35, main 베이스라인과 동일)
- `npm test` — 3,735 passed / 1 실패(`rate-limiter-behavior`, 단독 실행 시 통과하는 기존 flaky, 이번 변경과 무관)
- 신규 회귀 테스트 2종 — 프로토콜 협상 7건(수정을 되돌리면 2건 실패 확인) · 구조화 출력 5건

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013st6eP2mLYDaHH4jEjP7Nf