### PR TITLE
fix(db): server-filesystem 미고정 시드를 2026.8.31 로 고정 (123, /code-review #854 지적)

### DIFF
--- a/db/migrations/123_mcp_filesystem_pin_unpinned_seed.sql
+++ b/db/migrations/123_mcp_filesystem_pin_unpinned_seed.sql
@@ -1,0 +1,17 @@
+-- 123: server-filesystem 미고정 시드도 2026.8.31 로 고정 (122 보완, /code-review #854 지적)
+--
+-- 122 는 '@2026.7.10' 고정 형태만 매치해 운영 DB(수동으로 고정돼 있던 행)는 갱신됐지만,
+-- 신규 설치는 023 시드가 **버전 미고정**('npx -y @modelcontextprotocol/server-filesystem')이라
+-- 122 의 WHERE 에 걸리지 않아 npx 가 매 spawn 마다 latest 로 해석된다(재현성 없음).
+-- 미고정 형태를 운영과 같은 2026.8.31 로 고정한다. 122 는 이미 적용된 마이그레이션이라
+-- (checksum 이력) 수정하지 않고 별도 파일로 둔다. 멱등.
+
+UPDATE mcp_server_catalog
+   SET command_template = 'npx -y @modelcontextprotocol/server-filesystem@2026.8.31'
+ WHERE command_template = 'npx -y @modelcontextprotocol/server-filesystem';
+
+UPDATE mcp_servers
+   SET args = '["-y","@modelcontextprotocol/server-filesystem@2026.8.31"]'::jsonb,
+       updated_at = NOW()
+ WHERE command = 'npx'
+   AND args = '["-y","@modelcontextprotocol/server-filesystem"]'::jsonb;


### PR DESCRIPTION
`/code-review 854` 지적 1건 반영.

122 의 filesystem 절은 `@2026.7.10` 고정 형태만 매치해 **운영 DB는 갱신됐지만**(수동 고정 행), 023 시드는 **버전 미고정**(`npx -y @modelcontextprotocol/server-filesystem`)이라 신규 설치에선 0행 갱신 → npx 가 매 spawn 마다 latest 로 해석(재현성 없음).

- 미고정 형태(카탈로그 템플릿 · 설치 인스턴스 args)를 운영과 같은 `2026.8.31` 로 고정하는 **별도 마이그레이션 123** (122 는 적용 이력·checksum 이 있어 수정하지 않음)
- 운영 DB 는 이미 고정 상태라 no-op, 멱등

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013st6eP2mLYDaHH4jEjP7Nf