### PR TITLE
feat(ios): web 기능 격차 5건 반영 — 오케스트레이터 진행·미디어 카드·서브에이전트·모델 비교·기능별 배정

### DIFF
--- a/apps/ios/OpenMakeApp/App/LumenComponents.swift
+++ b/apps/ios/OpenMakeApp/App/LumenComponents.swift
@@ -254,6 +254,7 @@ struct DesignSystemShowcase: View {
                     onDismiss: { showDrawer = false },
                     onNewChat: { showDrawer = false },
                     onAgentTasks: { showDrawer = false },
+                    onCompare: { showDrawer = false },
                     onDeepResearch: { showDrawer = false },
                     onConversation: { _ in showDrawer = false },
                     onSettings: { showDrawer = false })

--- a/apps/ios/OpenMakeApp/App/LumenDrawer.swift
+++ b/apps/ios/OpenMakeApp/App/LumenDrawer.swift
@@ -7,6 +7,7 @@ struct LumenDrawer: View {
     let onDismiss: () -> Void
     let onNewChat: () -> Void
     let onAgentTasks: () -> Void
+    let onCompare: () -> Void
     let onDeepResearch: () -> Void
     let onConversation: (OpenMakeClient.SessionSummary) -> Void
     let onSettings: () -> Void
@@ -44,6 +45,7 @@ struct LumenDrawer: View {
                     VStack(spacing: 4) {
                         DrawerRow(title: "새 대화", systemImage: "square.and.pencil", accent: true, action: onNewChat)
                         DrawerRow(title: "에이전트 작업", systemImage: "wand.and.stars", action: onAgentTasks)
+                        DrawerRow(title: "모델 비교", systemImage: "rectangle.split.2x1", action: onCompare)
                         DrawerRow(title: "딥리서치", systemImage: "magnifyingglass.circle", action: onDeepResearch)
                     }
                     .padding(.horizontal, 8)

--- a/apps/ios/OpenMakeApp/Features/AgentTasks/AgentTaskViews.swift
+++ b/apps/ios/OpenMakeApp/Features/AgentTasks/AgentTaskViews.swift
@@ -268,6 +268,8 @@ struct AgentTaskDetailView: View {
     @Environment(AppModel.self) private var model
     @State private var detail: AgentTaskDetail?
     @State private var approvals: [AgentTaskApproval] = []
+    /// 병렬 서브에이전트 진행 — 없으면 패널 숨김
+    @State private var subagents: [SubagentTrace] = []
     @State private var steering = ""
     @State private var errorMessage: String?
 
@@ -282,6 +284,8 @@ struct AgentTaskDetailView: View {
                             await load()
                         }
                     }
+
+                    SubagentPanel(traces: subagents)
 
                     if let result = detail.task.result, !result.isEmpty {
                         VStack(alignment: .leading, spacing: 8) {
@@ -380,8 +384,11 @@ struct AgentTaskDetailView: View {
         do {
             async let detailRequest = model.client.agentTask(id: taskId)
             async let approvalRequest = model.client.pendingAgentTaskApprovals()
+            async let subagentRequest = model.client.agentTaskSubagents(id: taskId)
             detail = try await detailRequest
             approvals = (try? await approvalRequest) ?? []
+            // 서브에이전트 조회 실패는 상세를 막지 않는다(fail-open — 패널만 비움)
+            subagents = (try? await subagentRequest) ?? []
             errorMessage = nil
         } catch {
             errorMessage = "작업 상태를 불러오지 못했습니다"

--- a/apps/ios/OpenMakeApp/Features/AgentTasks/SubagentPanel.swift
+++ b/apps/ios/OpenMakeApp/Features/AgentTasks/SubagentPanel.swift
@@ -1,0 +1,68 @@
+// 병렬 서브에이전트 진행 패널 — 웹 components/agent-tasks/subagent-panel.tsx 대응(#813).
+import SwiftUI
+import OpenMakeKit
+
+struct SubagentPanel: View {
+    let traces: [SubagentTrace]
+
+    var body: some View {
+        if !traces.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Text("병렬 에이전트 \(traces.count)개")
+                        .font(.headline)
+                        .foregroundStyle(Instrument.fg)
+                    Spacer()
+                    Text("\(traces.filter { $0.status == "completed" }.count)/\(traces.count) 완료")
+                        .font(Instrument.mono(size: 11.5))
+                        .foregroundStyle(Instrument.muted)
+                }
+                ForEach(traces) { trace in
+                    HStack(alignment: .top, spacing: 10) {
+                        LumenDot(color: color(for: trace.status), size: 7, pulsing: trace.status == "running")
+                            .padding(.top, 6)
+                        VStack(alignment: .leading, spacing: 3) {
+                            HStack(spacing: 6) {
+                                Text(trace.displayName)
+                                    .font(.system(size: 13.5, weight: .semibold))
+                                    .foregroundStyle(Instrument.fg)
+                                    .lineLimit(1)
+                                Text(trace.statusLabel)
+                                    .font(.system(size: 10.5, weight: .semibold))
+                                    .foregroundStyle(color(for: trace.status))
+                                    .padding(.horizontal, 6)
+                                    .padding(.vertical, 2)
+                                    .background(color(for: trace.status).opacity(0.12), in: Capsule())
+                            }
+                            HStack(spacing: 6) {
+                                Text("\(trace.steps.count)단계")
+                                if let lastTool = trace.steps.last(where: { $0.tool != nil })?.tool {
+                                    Text("· \(lastTool)")
+                                        .lineLimit(1)
+                                }
+                            }
+                            .font(.system(size: 11.5))
+                            .foregroundStyle(Instrument.muted)
+                        }
+                        Spacer(minLength: 0)
+                    }
+                    .padding(10)
+                    .background(Instrument.surface, in: RoundedRectangle(cornerRadius: 10))
+                    .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Instrument.border))
+                }
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("병렬 에이전트 \(traces.count)개")
+        }
+    }
+
+    private func color(for status: String) -> Color {
+        switch status {
+        case "completed": Instrument.success
+        case "failed": Instrument.danger
+        case "interrupted": Instrument.warn
+        case "running": Instrument.accent
+        default: Instrument.faint
+        }
+    }
+}

--- a/apps/ios/OpenMakeApp/Features/Compare/CompareLaneModel.swift
+++ b/apps/ios/OpenMakeApp/Features/Compare/CompareLaneModel.swift
@@ -1,0 +1,136 @@
+// 모델 비교 레인 — 레인마다 독립 소켓·세션·히스토리(웹 lib/use-compare-lane 과 같은 규약).
+// 서버는 `lane` 필드로 같은 사용자의 두 스트림을 구분하므로 반드시 실어 보낸다.
+import Foundation
+import Observation
+import OpenMakeKit
+
+@MainActor
+@Observable
+final class CompareLaneModel {
+    struct Message: Identifiable, Equatable {
+        let id = UUID()
+        let role: String
+        var content: String
+        var thinking: String = ""
+        var isStreaming = false
+        var error: String?
+        /// 서버가 실제로 응답한 모델(폴백 시 다름) — system_event model_fallback
+        var servedModel: String?
+    }
+
+    let lane: String
+    private let client: OpenMakeClient
+    private let socket: WsChatSocket
+    private var events: AsyncStream<WsServerEvent>?
+
+    private(set) var messages: [Message] = []
+    private(set) var isStreaming = false
+    private(set) var sessionId: String?
+
+    init(lane: String, client: OpenMakeClient, serverURL: URL) {
+        self.lane = lane
+        self.client = client
+        self.socket = WsChatSocket(serverURL: serverURL)
+    }
+
+    var lastServedModel: String? {
+        messages.last { $0.role == "assistant" && $0.servedModel != nil }?.servedModel
+    }
+
+    func send(_ prompt: String, model: String?, thinking: Bool) async {
+        // history 는 이번 사용자 메시지 직전까지 — 본문이 빈 assistant(첫 토큰 전 중단)는 제외
+        // (외부 provider 가 빈 assistant 로 400 을 낸다 — 웹과 동일)
+        let history = messages
+            .filter { $0.error == nil && !($0.role == "assistant" && $0.content.trimmingCharacters(in: .whitespaces).isEmpty) }
+            .map { History(content: $0.content, role: ChatRole(rawValue: $0.role) ?? .user) }
+        messages.append(Message(role: "user", content: prompt))
+        messages.append(Message(role: "assistant", content: "", isStreaming: true))
+        isStreaming = true
+        defer {
+            isStreaming = false
+            if let index = messages.indices.last { messages[index].isStreaming = false }
+        }
+
+        guard let bearer = await client.accessToken else {
+            setError("로그인이 필요합니다")
+            return
+        }
+        do {
+            var stream: AsyncStream<WsServerEvent>
+            if await socket.isConnected, let current = events {
+                stream = current
+            } else {
+                stream = try await socket.connect(bearer: bearer)
+                events = stream
+            }
+            try await socket.send(.chat(
+                message: prompt,
+                sessionId: sessionId,
+                model: model,
+                history: history,
+                thinkingMode: thinking ? true : nil,
+                lane: lane))
+
+            var finished = false
+            for await event in stream {
+                switch event.type {
+                case .token:
+                    patchLast { $0.content += event.token ?? "" }
+                case .thinking:
+                    patchLast { $0.thinking += event.token ?? event.thinking ?? "" }
+                case .sessionCreated:
+                    sessionId = event.sessionID
+                case .systemEvent:
+                    // 모델 폴백 고지 — 실제 응답 모델을 레인 헤더에 표시
+                    if event.payload?.type == "model_fallback",
+                       let to = event.payload?.metadata?["to"]?.value as? String {
+                        patchLast { $0.servedModel = to }
+                    }
+                case .done:
+                    if let cleaned = event.cleanedContent { patchLast { $0.content = cleaned } }
+                    finished = true
+                case .aborted:
+                    finished = true
+                case .error:
+                    setError(event.message ?? event.errorType ?? "오류가 발생했습니다")
+                    finished = true
+                case .tokenWarning:
+                    Task { try? await client.refresh() }
+                default:
+                    break
+                }
+                if finished { break }
+            }
+            if !finished {
+                setError("응답이 중간에 끊겼어요")
+            }
+        } catch {
+            setError("연결에 실패했습니다")
+        }
+    }
+
+    func stop() async {
+        guard isStreaming else { return }
+        await socket.abort()
+    }
+
+    func reset() {
+        messages = []
+        sessionId = nil
+        events = nil
+        Task { [socket] in await socket.disconnect() }
+    }
+
+    func teardown() {
+        Task { [socket] in await socket.disconnect() }
+    }
+
+    private func patchLast(_ change: (inout Message) -> Void) {
+        guard let index = messages.indices.last, messages[index].role == "assistant" else { return }
+        change(&messages[index])
+    }
+
+    private func setError(_ text: String) {
+        patchLast { $0.error = text }
+    }
+}

--- a/apps/ios/OpenMakeApp/Features/Compare/CompareView.swift
+++ b/apps/ios/OpenMakeApp/Features/Compare/CompareView.swift
@@ -1,0 +1,288 @@
+// 모델 비교 모드 — 두 모델이 같은 질문에 동시에 답한다(웹 /compare 대응, 2026-09-12 iOS 격차).
+// 입력창은 하나, 전송 한 번이 두 레인에 같은 프롬프트를 싣는다. 폰에서는 위·아래로 나눈다.
+import SwiftUI
+import OpenMakeKit
+
+struct CompareView: View {
+    @Environment(AppModel.self) private var model
+    @AppStorage("compare.modelA") private var modelA = ""
+    @AppStorage("compare.modelB") private var modelB = ""
+    @AppStorage("compare.thinking") private var thinking = false
+    @State private var laneA: CompareLaneModel?
+    @State private var laneB: CompareLaneModel?
+    @State private var draft = ""
+
+    private var isStreaming: Bool { (laneA?.isStreaming ?? false) || (laneB?.isStreaming ?? false) }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            pickers
+            Divider().overlay(Instrument.border)
+            if let laneA, let laneB {
+                GeometryReader { proxy in
+                    VStack(spacing: 0) {
+                        LanePane(lane: laneA, title: "A", modelId: modelA, fallback: model.modelCatalog?.defaultModel)
+                            .frame(height: proxy.size.height / 2)
+                        Divider().overlay(Instrument.borderStrong)
+                        LanePane(lane: laneB, title: "B", modelId: modelB, fallback: model.modelCatalog?.defaultModel)
+                            .frame(height: proxy.size.height / 2)
+                    }
+                }
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            composer
+        }
+        .background(Instrument.bg)
+        .navigationTitle("모델 비교")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("새 비교", systemImage: "arrow.counterclockwise") {
+                    laneA?.reset()
+                    laneB?.reset()
+                }
+                .disabled(isStreaming)
+            }
+        }
+        .task {
+            if laneA == nil {
+                laneA = CompareLaneModel(lane: "a", client: model.client, serverURL: AppConfig.serverURL)
+                laneB = CompareLaneModel(lane: "b", client: model.client, serverURL: AppConfig.serverURL)
+            }
+            if model.modelCatalog == nil { await model.loadCatalog() }
+        }
+        .onDisappear {
+            laneA?.teardown()
+            laneB?.teardown()
+        }
+    }
+
+    private var pickers: some View {
+        HStack(spacing: 8) {
+            ModelPickerMenu(label: "A", selection: $modelA, catalog: model.modelCatalog)
+            ModelPickerMenu(label: "B", selection: $modelB, catalog: model.modelCatalog)
+            Button {
+                thinking.toggle()
+            } label: {
+                Image(systemName: "brain")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(thinking ? Instrument.accent : Instrument.muted)
+                    .frame(width: 34, height: 34)
+                    .background(thinking ? Instrument.accentSoft : Instrument.surface2, in: RoundedRectangle(cornerRadius: 10))
+            }
+            .accessibilityLabel(thinking ? "추론 끄기" : "추론 켜기")
+            .accessibilityValue(thinking ? "켜짐" : "꺼짐")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private var composer: some View {
+        HStack(alignment: .bottom, spacing: 8) {
+            TextField("두 모델에게 같은 질문", text: $draft, axis: .vertical)
+                .font(.system(size: 15))
+                .lineLimit(1...4)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 9)
+                .background(Instrument.surface, in: RoundedRectangle(cornerRadius: 20))
+                .overlay(RoundedRectangle(cornerRadius: 20).strokeBorder(Instrument.border))
+            if isStreaming {
+                Button {
+                    Task {
+                        await laneA?.stop()
+                        await laneB?.stop()
+                    }
+                } label: {
+                    Image(systemName: "stop.fill")
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundStyle(Instrument.muted)
+                        .frame(width: 38, height: 38)
+                        .background(Instrument.surface2, in: Circle())
+                }
+                .accessibilityLabel("응답 중단")
+            } else {
+                Button(action: submit) {
+                    Image(systemName: "arrow.up")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(canSend ? Instrument.accentFg : Instrument.faint)
+                        .frame(width: 38, height: 38)
+                        .background(canSend ? Instrument.accent : Instrument.surface3, in: Circle())
+                }
+                .disabled(!canSend)
+                .accessibilityLabel("보내기")
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Instrument.bg)
+    }
+
+    private var canSend: Bool {
+        !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && laneA != nil
+    }
+
+    private func submit() {
+        let prompt = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty, let laneA, let laneB else { return }
+        draft = ""
+        let a = modelA.isEmpty ? nil : modelA
+        let b = modelB.isEmpty ? nil : modelB
+        let think = thinking
+        // 같은 틱에 두 레인 전송 — 서버는 lane 으로 스트림을 구분한다
+        Task { await laneA.send(prompt, model: a, thinking: think) }
+        Task { await laneB.send(prompt, model: b, thinking: think) }
+    }
+}
+
+private struct ModelPickerMenu: View {
+    let label: String
+    @Binding var selection: String
+    let catalog: ModelCatalog?
+
+    private var title: String {
+        if selection.isEmpty { return "기본" }
+        return catalog?.models.first { $0.modelId == selection }?.name ?? shortName(selection)
+    }
+
+    var body: some View {
+        Menu {
+            Button {
+                selection = ""
+            } label: {
+                if selection.isEmpty { Label("기본(서버 기본 모델)", systemImage: "checkmark") } else { Text("기본(서버 기본 모델)") }
+            }
+            if let catalog {
+                ForEach(catalog.models.filter { $0.available != false }, id: \.modelId) { entry in
+                    Button {
+                        selection = entry.modelId
+                    } label: {
+                        if selection == entry.modelId { Label(entry.name, systemImage: "checkmark") } else { Text(entry.name) }
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Text(label)
+                    .font(Instrument.mono(size: 11, weight: .semibold))
+                    .foregroundStyle(Instrument.accent)
+                Text(title)
+                    .font(.system(size: 12.5, weight: .medium))
+                    .foregroundStyle(Instrument.fg)
+                    .lineLimit(1)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(Instrument.faint)
+            }
+            .padding(.horizontal, 10)
+            .frame(height: 34)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Instrument.surface, in: RoundedRectangle(cornerRadius: 10))
+            .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Instrument.border))
+        }
+        .accessibilityLabel("모델 \(label) 선택")
+        .accessibilityValue(title)
+    }
+
+    private func shortName(_ id: String) -> String {
+        id.split(separator: ":").last.map(String.init) ?? id
+    }
+}
+
+private struct LanePane: View {
+    @Bindable var lane: CompareLaneModel
+    let title: String
+    let modelId: String
+    let fallback: String?
+
+    private var headerModel: String {
+        let served = lane.lastServedModel
+        let chosen = modelId.isEmpty ? (fallback ?? "기본") : modelId
+        let base = chosen.split(separator: ":").last.map(String.init) ?? chosen
+        if let served, served != chosen {
+            let servedShort = served.split(separator: ":").last.map(String.init) ?? served
+            return "\(base) → \(servedShort) 로 응답"
+        }
+        return base
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 6) {
+                Text(title)
+                    .font(Instrument.mono(size: 11, weight: .semibold))
+                    .foregroundStyle(Instrument.accent)
+                Text(headerModel)
+                    .font(.system(size: 11.5, weight: .medium))
+                    .foregroundStyle(Instrument.muted)
+                    .lineLimit(1)
+                Spacer()
+                if lane.isStreaming {
+                    LumenDot(color: Instrument.accent, size: 6, pulsing: true)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(Instrument.surface2)
+
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 12) {
+                        if lane.messages.isEmpty {
+                            Text("여기에 \(title) 모델의 답이 표시됩니다")
+                                .font(.system(size: 12.5))
+                                .foregroundStyle(Instrument.faint)
+                                .padding(.top, 20)
+                                .frame(maxWidth: .infinity)
+                        }
+                        ForEach(lane.messages) { message in
+                            if message.role == "user" {
+                                HStack {
+                                    Spacer(minLength: 40)
+                                    Text(message.content)
+                                        .font(.system(size: 13.5))
+                                        .foregroundStyle(Instrument.fg)
+                                        .padding(.horizontal, 12)
+                                        .padding(.vertical, 7)
+                                        .background(Instrument.surface2, in: RoundedRectangle(cornerRadius: 14))
+                                }
+                            } else {
+                                VStack(alignment: .leading, spacing: 6) {
+                                    if !message.thinking.isEmpty {
+                                        DisclosureGroup {
+                                            Text(message.thinking)
+                                                .font(.system(size: 12))
+                                                .foregroundStyle(Instrument.muted)
+                                                .textSelection(.enabled)
+                                        } label: {
+                                            Text("추론 과정")
+                                                .font(.system(size: 11.5, weight: .medium))
+                                                .foregroundStyle(Instrument.muted)
+                                        }
+                                        .tint(Instrument.muted)
+                                    }
+                                    if message.content.isEmpty && message.isStreaming {
+                                        ActivityStatusLine(text: message.thinking.isEmpty ? "응답을 기다리고 있어요" : "답변을 생각하고 있어요", kind: .thinking)
+                                    } else {
+                                        MarkdownText(content: message.content + (message.isStreaming ? " ▍" : ""))
+                                    }
+                                    if let error = message.error {
+                                        Text(error)
+                                            .font(.footnote)
+                                            .foregroundStyle(Instrument.danger)
+                                    }
+                                }
+                            }
+                        }
+                        Color.clear.frame(height: 1).id("bottom")
+                    }
+                    .padding(12)
+                }
+                .onChange(of: lane.messages.last?.content) {
+                    proxy.scrollTo("bottom", anchor: .bottom)
+                }
+            }
+        }
+    }
+}

--- a/apps/ios/OpenMakeApp/Features/Conversations/ChatSessionModel.swift
+++ b/apps/ios/OpenMakeApp/Features/Conversations/ChatSessionModel.swift
@@ -28,6 +28,8 @@ final class ChatSessionModel {
     private(set) var activityLog: [ChatActivityEntry] = []
     /// 스트리밍 시작 시각 — 경과 시간 표시(멈춤/진행 구분)의 기준
     private(set) var streamStartedAt: Date?
+    /// 멀티모달 오케스트레이터 진행(이미지·영상·음성 작업) — 있으면 진행 카드 위에 작업 목록을 보인다
+    private(set) var orchestrator: OrchestratorProgress?
 
     init(client: OpenMakeClient, serverURL: URL, sessionId: String?) {
         self.client = client
@@ -197,6 +199,7 @@ final class ChatSessionModel {
         activityKind = state.activityKind ?? .preparing
         activeSkills = state.activeSkillNames
         activityLog = state.activityLog
+        orchestrator = state.orchestrator
         for artifact in state.artifacts {
             let document = ArtifactDocument(streamed: artifact)
             if let index = artifacts.firstIndex(where: { $0.id == document.id }) {
@@ -297,5 +300,6 @@ final class ChatSessionModel {
         streamingText = ""
         isThinking = false
         statusText = nil
+        orchestrator = nil
     }
 }

--- a/apps/ios/OpenMakeApp/Features/Conversations/ConversationDetailView.swift
+++ b/apps/ios/OpenMakeApp/Features/Conversations/ConversationDetailView.swift
@@ -229,6 +229,10 @@ private struct ChatTranscriptView: View {
                             MarkdownText(content: chat.streamingText + " ▍")
                         }
                     }
+                    // 멀티모달 작업 목록 — 이미지·영상·음성 capability 작업의 상태(웹 진행 배너 대응)
+                    if chat.isStreaming, let progress = chat.orchestrator {
+                        OrchestratorProgressCard(progress: progress)
+                    }
                     // 진행 카드 — 스트리밍 중에는 본문 아래에도 계속 보여 "살아있음" 을 알린다
                     if chat.isStreaming {
                         ActivityProgressCard(

--- a/apps/ios/OpenMakeApp/Features/Conversations/ConversationListView.swift
+++ b/apps/ios/OpenMakeApp/Features/Conversations/ConversationListView.swift
@@ -12,6 +12,7 @@ struct ConversationListView: View {
     @State private var showSettings = false
     @State private var showDrawer = false
     @State private var showAgentTasks = false
+    @State private var showCompare = false
     @State private var selectedSession: OpenMakeClient.SessionSummary?
     @State private var searchText = ""
     @State private var autoChatFired = false
@@ -102,6 +103,9 @@ struct ConversationListView: View {
             .navigationDestination(isPresented: $showAgentTasks) {
                 AgentTaskListView()
             }
+            .navigationDestination(isPresented: $showCompare) {
+                CompareView()
+            }
             .navigationDestination(isPresented: Binding(
                 get: { selectedSession != nil },
                 set: { if !$0 { selectedSession = nil } }
@@ -151,6 +155,10 @@ struct ConversationListView: View {
                     onAgentTasks: {
                         showDrawer = false
                         showAgentTasks = true
+                    },
+                    onCompare: {
+                        showDrawer = false
+                        showCompare = true
                     },
                     onDeepResearch: {
                         model.modes.deepResearch = true

--- a/apps/ios/OpenMakeApp/Features/Conversations/GeneratedMediaViews.swift
+++ b/apps/ios/OpenMakeApp/Features/Conversations/GeneratedMediaViews.swift
@@ -1,0 +1,160 @@
+// 생성 영상·음성 카드 — 오케스트레이터가 결정적으로 붙이는 `[🎬 영상 보기](/generated/x.webm)`,
+// `[🔊 …](/generated/x.wav)` 링크의 렌더. 종전엔 raw 마크다운 링크로 노출됐다(2026-09-12).
+import SwiftUI
+import AVKit
+import OpenMakeKit
+
+/// AVPlayer 가 재생하는 컨테이너 — WebM(VP8/VP9)은 iOS 네이티브 재생이 불가하므로 Safari/공유로 넘긴다.
+private let nativePlayableVideo: Set<String> = ["mp4", "mov", "m4v"]
+
+struct GeneratedVideoCard: View {
+    let title: String
+    let source: String
+    @Environment(\.openURL) private var openURL
+
+    private var url: URL? { GeneratedMediaURLResolver.resolve(source: source, serverURL: AppConfig.serverURL) }
+    private var ext: String { (source.split(separator: "?").first.map(String.init) ?? source).components(separatedBy: ".").last?.lowercased() ?? "" }
+
+    var body: some View {
+        if let url {
+            VStack(alignment: .leading, spacing: 8) {
+                if nativePlayableVideo.contains(ext) {
+                    VideoPlayer(player: AVPlayer(url: url))
+                        .frame(height: 210)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                } else {
+                    // WebM — 앱 내 재생 불가. 열기(Safari)와 공유(저장·AirDrop)로 제공한다.
+                    HStack(spacing: 10) {
+                        Image(systemName: "film")
+                            .font(.system(size: 22))
+                            .foregroundStyle(Instrument.accent)
+                            .frame(width: 44, height: 44)
+                            .background(Instrument.accentSoft, in: RoundedRectangle(cornerRadius: 10))
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(cleanTitle)
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundStyle(Instrument.fg)
+                            Text("\(ext.uppercased()) · 앱 내 재생이 지원되지 않아 Safari 로 엽니다")
+                                .font(.system(size: 11.5))
+                                .foregroundStyle(Instrument.muted)
+                                .lineLimit(2)
+                        }
+                        Spacer(minLength: 0)
+                    }
+                }
+                HStack(spacing: 8) {
+                    Button {
+                        openURL(url)
+                    } label: {
+                        Label("Safari 에서 열기", systemImage: "safari")
+                    }
+                    ShareLink(item: url) {
+                        Label("공유", systemImage: "square.and.arrow.up")
+                    }
+                }
+                .font(.system(size: 12.5, weight: .medium))
+                .buttonStyle(.bordered)
+                .tint(Instrument.accent)
+            }
+            .padding(12)
+            .background(Instrument.surface, in: RoundedRectangle(cornerRadius: 14))
+            .overlay(RoundedRectangle(cornerRadius: 14).strokeBorder(Instrument.border))
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("생성된 영상 \(cleanTitle)")
+        } else {
+            // 서버 origin 밖 링크 — 자격증명 컨텍스트로 열지 않고 텍스트로만
+            Text("[\(title)](\(source))")
+                .font(.system(size: 15))
+                .foregroundStyle(Instrument.fg)
+        }
+    }
+
+    private var cleanTitle: String {
+        let stripped = title.unicodeScalars.filter { !$0.properties.isEmojiPresentation }.map(String.init).joined()
+        let trimmed = stripped.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? "영상" : trimmed
+    }
+}
+
+struct GeneratedAudioCard: View {
+    let title: String
+    let source: String
+    @State private var player: AVPlayer?
+    @State private var isPlaying = false
+
+    private var url: URL? { GeneratedMediaURLResolver.resolve(source: source, serverURL: AppConfig.serverURL) }
+
+    var body: some View {
+        if let url {
+            HStack(spacing: 12) {
+                Button {
+                    toggle(url: url)
+                } label: {
+                    Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundStyle(Instrument.accentFg)
+                        .frame(width: 40, height: 40)
+                        .background(Instrument.accent, in: Circle())
+                }
+                .accessibilityLabel(isPlaying ? "일시정지" : "재생")
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(cleanTitle)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(Instrument.fg)
+                    Text(url.lastPathComponent)
+                        .font(Instrument.mono(size: 11))
+                        .foregroundStyle(Instrument.muted)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 0)
+                ShareLink(item: url) {
+                    Image(systemName: "square.and.arrow.up")
+                        .font(.system(size: 14))
+                        .foregroundStyle(Instrument.muted)
+                        .frame(width: 36, height: 36)
+                }
+                .accessibilityLabel("음성 공유")
+            }
+            .padding(12)
+            .background(Instrument.surface, in: RoundedRectangle(cornerRadius: 14))
+            .overlay(RoundedRectangle(cornerRadius: 14).strokeBorder(Instrument.border))
+            .onDisappear {
+                player?.pause()
+                isPlaying = false
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("생성된 음성 \(cleanTitle)")
+        } else {
+            Text("[\(title)](\(source))")
+                .font(.system(size: 15))
+                .foregroundStyle(Instrument.fg)
+        }
+    }
+
+    private var cleanTitle: String {
+        let stripped = title.unicodeScalars.filter { !$0.properties.isEmojiPresentation }.map(String.init).joined()
+        let trimmed = stripped.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? "음성" : trimmed
+    }
+
+    private func toggle(url: URL) {
+        if player == nil {
+            let created = AVPlayer(url: url)
+            player = created
+            NotificationCenter.default.addObserver(
+                forName: .AVPlayerItemDidPlayToEndTime, object: created.currentItem, queue: .main
+            ) { _ in
+                created.seek(to: .zero)
+                isPlaying = false
+            }
+        }
+        guard let player else { return }
+        if isPlaying {
+            player.pause()
+        } else {
+            try? AVAudioSession.sharedInstance().setCategory(.playback)
+            player.play()
+        }
+        isPlaying.toggle()
+    }
+}

--- a/apps/ios/OpenMakeApp/Features/Conversations/MarkdownText.swift
+++ b/apps/ios/OpenMakeApp/Features/Conversations/MarkdownText.swift
@@ -21,6 +21,10 @@ struct MarkdownText: View {
                     textBlocks(text)
                 case .image(let alt, let source):
                     GeneratedImageView(alt: alt, source: source)
+                case .video(let title, let source):
+                    GeneratedVideoCard(title: title, source: source)
+                case .audio(let title, let source):
+                    GeneratedAudioCard(title: title, source: source)
                 }
             }
         }

--- a/apps/ios/OpenMakeApp/Features/Conversations/OrchestratorProgressCard.swift
+++ b/apps/ios/OpenMakeApp/Features/Conversations/OrchestratorProgressCard.swift
@@ -1,0 +1,95 @@
+// 멀티모달 오케스트레이터 진행 카드 — 계획/실행/종합 단계와 capability 작업별 상태.
+// 웹의 진행 배너(store.orchestratorProgress) 대응. 이미지 34s·영상 수 분 동안 "무엇을 하고
+// 있는지"를 보여야 멈춘 것처럼 보이지 않는다(2026-09-12 iOS 격차).
+import SwiftUI
+import OpenMakeKit
+
+struct OrchestratorProgressCard: View {
+    let progress: OrchestratorProgress
+
+    private var phaseTitle: String {
+        switch progress.phase {
+        case .planning: "질문을 분석하고 있어요"
+        case .executing: "작업을 실행하고 있어요"
+        case .synthesizing: "답변을 작성하고 있어요"
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Image(systemName: "sparkles")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(Instrument.second)
+                Text(phaseTitle)
+                    .font(.system(size: 12.5, weight: .semibold))
+                    .foregroundStyle(Instrument.fg2)
+                Spacer(minLength: 4)
+                if !progress.tasks.isEmpty {
+                    Text("\(progress.doneCount)/\(progress.tasks.count)")
+                        .font(Instrument.mono(size: 11.5))
+                        .foregroundStyle(Instrument.muted)
+                        .monospacedDigit()
+                }
+            }
+            ForEach(progress.tasks) { task in
+                HStack(alignment: .top, spacing: 8) {
+                    statusIcon(task.status)
+                        .frame(width: 14, height: 14)
+                        .padding(.top, 1)
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 6) {
+                            Text(task.label)
+                                .font(.system(size: 12.5, weight: .medium))
+                                .foregroundStyle(Instrument.fg)
+                            if let ms = task.ms, task.status == .ok || task.status == .failed {
+                                Text(durationText(ms))
+                                    .font(Instrument.mono(size: 11))
+                                    .foregroundStyle(Instrument.muted)
+                            }
+                        }
+                        if let detail = task.summary ?? task.instruction, !detail.isEmpty {
+                            Text(detail)
+                                .font(.system(size: 11.5))
+                                .foregroundStyle(task.status == .failed ? Instrument.danger : Instrument.muted)
+                                .lineLimit(2)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Instrument.secondSoft, in: RoundedRectangle(cornerRadius: 12))
+        .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(Instrument.border))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("멀티모달 작업 \(progress.doneCount)/\(progress.tasks.count) 완료, \(phaseTitle)")
+    }
+
+    @ViewBuilder
+    private func statusIcon(_ status: OrchestratorTask.Status) -> some View {
+        switch status {
+        case .pending:
+            Image(systemName: "circle.dotted")
+                .font(.system(size: 11))
+                .foregroundStyle(Instrument.faint)
+        case .running:
+            LumenDot(color: Instrument.accent, size: 7, pulsing: true)
+        case .ok:
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 12))
+                .foregroundStyle(Instrument.success)
+        case .failed:
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 12))
+                .foregroundStyle(Instrument.danger)
+        }
+    }
+
+    private func durationText(_ ms: Double) -> String {
+        let seconds = ms / 1000
+        if seconds < 60 { return String(format: "%.0f초", seconds) }
+        return "\(Int(seconds) / 60)분 \(Int(seconds) % 60)초"
+    }
+}

--- a/apps/ios/OpenMakeApp/Features/Settings/CapabilityModelsView.swift
+++ b/apps/ios/OpenMakeApp/Features/Settings/CapabilityModelsView.swift
@@ -1,0 +1,211 @@
+// 기능별 모델 배정 — 웹 settings/capability-groups.tsx 대응(6그룹 + 세부 설정).
+// 배정은 서버(capability_models)에 저장되므로 웹·iOS 어느 쪽에서 바꿔도 같은 채팅에 적용된다.
+import SwiftUI
+import OpenMakeKit
+
+struct CapabilityModelsView: View {
+    @Environment(AppModel.self) private var model
+    @State private var data: CapabilityModels?
+    @State private var loadError: String?
+    @State private var saveError: String?
+    @State private var busy: String?
+    @State private var expanded: Set<String> = []
+
+    /// 그룹 안 capability 의 배정이 서로 다를 때의 표시값
+    private static let mixed = "__mixed__"
+
+    private var isAdmin: Bool {
+        if case .loggedIn(let user) = model.authState { return user.role.rawValue == "admin" }
+        return false
+    }
+
+    private var models: [OpenMakeClient.ModelEntry] {
+        (model.modelCatalog?.models ?? []).filter { $0.available != false }
+    }
+
+    var body: some View {
+        List {
+            Section {
+                Text("질문을 분석한 Planner 가 계획한 기능(이미지·영상·음성 등)을 어느 모델이 처리할지 정합니다. 외부 모델은 게이트웨이에 편입된 provider 만 배정할 수 있고, 미배정 항목은 전역 설정 또는 기본값을 따릅니다.")
+                    .font(.footnote)
+                    .foregroundStyle(Instrument.muted)
+            }
+            if let data {
+                let resolved = CapabilityCatalog.resolveGroups(assignable: data.assignable, admin: isAdmin)
+                ForEach(resolved.groups) { group in
+                    groupSection(group, data: data)
+                }
+                if !resolved.hiddenUnsupported.isEmpty {
+                    Section {
+                        Text("아직 실행 경로가 없는 기능은 표시하지 않습니다: \(resolved.hiddenUnsupported.map(CapabilityCatalog.label).joined(separator: ", "))")
+                            .font(.footnote)
+                            .foregroundStyle(Instrument.faint)
+                    }
+                }
+            } else if let loadError {
+                Section { Text(loadError).foregroundStyle(Instrument.danger) }
+            } else {
+                Section { ProgressView("기능 배정 불러오는 중…") }
+            }
+            if let saveError {
+                Section { Text(saveError).foregroundStyle(Instrument.danger) }
+            }
+        }
+        .navigationTitle("기능별 모델 배정")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await load() }
+        .refreshable { await load() }
+    }
+
+    @ViewBuilder
+    private func groupSection(_ group: CapabilityCatalog.Group, data: CapabilityModels) -> some View {
+        let groupValue = groupSelection(group, data: data)
+        let isMixed = groupValue == Self.mixed
+        Section {
+            Picker(selection: Binding(
+                get: { groupValue },
+                set: { newValue in
+                    guard newValue != Self.mixed else { return }
+                    Task { await assign(group.members, fullId: newValue, key: group.id) }
+                }
+            )) {
+                Text("기본(자동)").tag("")
+                ForEach(models, id: \.modelId) { entry in
+                    Text(entry.name).tag(entry.modelId)
+                }
+                if isMixed { Text("(개별 설정)").tag(Self.mixed) }
+                if !groupValue.isEmpty, !isMixed, !models.contains(where: { $0.modelId == groupValue }) {
+                    Text("\(groupValue) (목록에 없음)").tag(groupValue)
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Text(group.title)
+                    if group.isUnsupported {
+                        badge("현재 미지원", color: Instrument.warn)
+                    } else if !groupValue.isEmpty {
+                        badge("배정됨", color: Instrument.accent)
+                    }
+                    if busy == group.id { ProgressView().controlSize(.small) }
+                }
+            }
+            .disabled(busy != nil)
+
+            if isMixed || expanded.contains(group.id) || group.members.count > 1 && expanded.contains(group.id) {
+                ForEach(group.members, id: \.self) { capability in
+                    capabilityRow(capability, data: data)
+                }
+            }
+            if group.members.count > 1 {
+                Button(expanded.contains(group.id) ? "세부 설정 닫기" : "세부 설정") {
+                    if expanded.contains(group.id) { expanded.remove(group.id) } else { expanded.insert(group.id) }
+                }
+                .font(.footnote)
+                .tint(Instrument.accent)
+            }
+        } header: {
+            Text(group.title)
+        } footer: {
+            Text(group.description)
+        }
+    }
+
+    @ViewBuilder
+    private func capabilityRow(_ capability: String, data: CapabilityModels) -> some View {
+        let current = data.override(for: capability)?.fullId ?? ""
+        VStack(alignment: .leading, spacing: 4) {
+            Picker(selection: Binding(
+                get: { current },
+                set: { newValue in Task { await assign([capability], fullId: newValue, key: capability) } }
+            )) {
+                Text("기본(자동)").tag("")
+                ForEach(models, id: \.modelId) { entry in
+                    Text(entry.name).tag(entry.modelId)
+                }
+                if !current.isEmpty, !models.contains(where: { $0.modelId == current }) {
+                    Text("\(current) (목록에 없음)").tag(current)
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Text(CapabilityCatalog.label(capability))
+                        .font(.system(size: 14))
+                    if CapabilityCatalog.unsupported.contains(capability) {
+                        badge("미지원", color: Instrument.warn)
+                    }
+                    if busy == capability { ProgressView().controlSize(.small) }
+                }
+            }
+            .disabled(busy != nil)
+            if let eff = data.effective(for: capability) {
+                Text(effectiveText(eff))
+                    .font(.system(size: 11.5))
+                    .foregroundStyle(eff.error == nil ? Instrument.muted : Instrument.warn)
+                    .lineLimit(2)
+            }
+        }
+        .padding(.leading, 8)
+    }
+
+    private func badge(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(color)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.12), in: Capsule())
+    }
+
+    private func groupSelection(_ group: CapabilityCatalog.Group, data: CapabilityModels) -> String {
+        let values = group.members.map { data.override(for: $0)?.fullId ?? "" }
+        guard let first = values.first else { return "" }
+        return values.allSatisfy { $0 == first } ? first : Self.mixed
+    }
+
+    private func effectiveText(_ eff: CapabilityEffective) -> String {
+        if let error = eff.error {
+            return "실효: 사용 불가 — \(error)"
+        }
+        let source: String = switch eff.source {
+        case "user": "내 배정"
+        case "global": "전역 설정"
+        case "default": "기본값"
+        default: eff.source ?? ""
+        }
+        let id = eff.fullId ?? "미배정"
+        return source.isEmpty ? "실효: \(id)" : "실효: \(id) (\(source))"
+    }
+
+    private func load() async {
+        loadError = nil
+        if model.modelCatalog == nil { await model.loadCatalog() }
+        do {
+            data = try await model.client.capabilityModels()
+        } catch {
+            loadError = "기능 배정을 불러오지 못했습니다."
+        }
+    }
+
+    /// 그룹 선택 → 멤버 전부 배정(빈 값이면 해제). 하나라도 실패하면 오류를 남기고 다시 읽는다.
+    private func assign(_ capabilities: [String], fullId: String, key: String) async {
+        busy = key
+        saveError = nil
+        defer { busy = nil }
+        for capability in capabilities {
+            do {
+                if fullId.isEmpty {
+                    try await model.client.clearCapabilityModel(capability)
+                } else {
+                    try await model.client.assignCapabilityModel(capability, fullId: fullId)
+                }
+            } catch let error as OpenMakeAPIError {
+                if case .server(_, _, let message) = error, let message, !message.isEmpty {
+                    saveError = "\(CapabilityCatalog.label(capability)): \(message)"
+                } else {
+                    saveError = "기능 배정 저장에 실패했습니다."
+                }
+            } catch {
+                saveError = "기능 배정 저장에 실패했습니다."
+            }
+        }
+        data = (try? await model.client.capabilityModels()) ?? data
+    }
+}

--- a/apps/ios/OpenMakeApp/Features/Settings/SettingsSheet.swift
+++ b/apps/ios/OpenMakeApp/Features/Settings/SettingsSheet.swift
@@ -27,6 +27,17 @@ struct SettingsSheet: View {
                     .pickerStyle(.segmented)
                 }
 
+                Section("기능") {
+                    NavigationLink {
+                        CapabilityModelsView()
+                    } label: {
+                        Label("기능별 모델 배정", systemImage: "square.grid.2x2")
+                    }
+                    Text("이미지·영상·음성 등 멀티모달 기능을 어느 모델이 처리할지 정합니다. 웹 설정과 같은 값입니다.")
+                        .font(.footnote)
+                        .foregroundStyle(Instrument.muted)
+                }
+
                 Section("서버") {
                     LabeledContent("주소", value: AppConfig.serverURL.host() ?? "-")
                     if let catalog = model.modelCatalog {

--- a/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/Capabilities.swift
+++ b/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/Capabilities.swift
@@ -1,0 +1,109 @@
+// OpenMakeKit — 멀티모달 capability 레지스트리(라벨·그룹). 서버 config/capabilities.ts 와
+// 웹 settings/capability-groups.tsx 의 결정적 사본 — 서버는 capability **이름**만 내려주므로
+// 사람이 읽는 라벨과 화면 그룹은 클라이언트가 가진다(웹과 같은 값을 유지할 것).
+import Foundation
+
+public enum CapabilityCatalog {
+    /// capability id → 한국어 라벨 (서버 CAPABILITY_LABELS_KO 와 동일)
+    public static let labels: [String: String] = [
+        "text.reason": "텍스트 추론·분석",
+        "text.code": "코드 작성·분석",
+        "text.synthesize": "최종 답변 종합(채팅 모델)",
+        "text.embed": "임베딩",
+        "vision.describe": "이미지 이해·설명",
+        "vision.ocr": "이미지 문자 인식(OCR)",
+        "image.generate": "이미지 생성",
+        "image.edit": "이미지 편집",
+        "audio.transcribe": "음성 인식(STT)",
+        "audio.speech": "음성 합성(TTS)",
+        "audio.analyze": "오디오 분석",
+        "music.analyze": "음악 분석",
+        "music.generate": "음악 생성",
+        "video.generate": "영상 생성",
+        "video.analyze": "영상 이해",
+        "web.search": "웹 검색",
+    ]
+
+    /// 검증된 provider 어댑터가 없는 capability — 배정과 무관하게 실행이 `unsupported` 로 끝난다
+    public static let unsupported: Set<String> = [
+        "audio.analyze", "music.analyze", "music.generate", "video.analyze",
+    ]
+
+    public static func label(_ capability: String) -> String {
+        labels[capability] ?? capability
+    }
+
+    /// 진행 카드용 짧은 동작 문구 — "이미지 생성" → "이미지를 생성하고 있어요"
+    public static func progressText(_ capability: String) -> String {
+        switch capability {
+        case "image.generate": return "이미지를 생성하고 있어요"
+        case "image.edit": return "이미지를 편집하고 있어요"
+        case "video.generate": return "영상을 생성하고 있어요 (몇 분 걸릴 수 있어요)"
+        case "audio.speech": return "음성을 합성하고 있어요"
+        case "audio.transcribe": return "음성을 텍스트로 옮기고 있어요"
+        case "vision.describe", "vision.ocr": return "이미지를 분석하고 있어요"
+        case "text.code": return "코드를 작성하고 있어요"
+        case "text.reason": return "내용을 분석하고 있어요"
+        default: return "\(label(capability)) 작업을 진행하고 있어요"
+        }
+    }
+
+    /// 설정 화면 그룹 — 웹 CAPABILITY_GROUPS 와 동일한 구성·순서
+    public struct Group: Identifiable, Equatable, Sendable {
+        public let id: String
+        public let title: String
+        public let description: String
+        public let members: [String]
+        public let adminOnly: Bool
+
+        /// 그룹 전원이 미지원이면 "현재 미지원" 배지 대상
+        public var isUnsupported: Bool { members.allSatisfy { CapabilityCatalog.unsupported.contains($0) } }
+    }
+
+    public static let groups: [Group] = [
+        Group(id: "text", title: "텍스트·비전", description: "추론·분석과 이미지 이해·OCR — 비전을 지원하는 텍스트 모델 하나가 맡습니다",
+              members: ["text.reason", "vision.describe", "vision.ocr"], adminOnly: false),
+        Group(id: "code", title: "코드", description: "코드 작성·수정 전용 모델(비우면 텍스트 모델이 처리)",
+              members: ["text.code"], adminOnly: false),
+        Group(id: "image", title: "이미지", description: "이미지 생성과 편집",
+              members: ["image.generate", "image.edit"], adminOnly: false),
+        Group(id: "audio", title: "음성", description: "음성 인식(STT)과 합성(TTS)",
+              members: ["audio.transcribe", "audio.speech"], adminOnly: false),
+        Group(id: "music", title: "음악", description: "음악 생성 — 아직 실행 경로가 없어 배정만 저장됩니다",
+              members: ["music.generate"], adminOnly: false),
+        Group(id: "video", title: "영상", description: "영상 생성(작업 제출 후 완료 시 결과 수령)",
+              members: ["video.generate"], adminOnly: false),
+        Group(id: "embed", title: "임베딩(인프라)", description: "검색·임베딩용 인프라 모델(관리자 전용)",
+              members: ["text.embed"], adminOnly: true),
+    ]
+
+    /// 그룹 안에 남겨 두는 미지원 capability(배지로 표시) — 나머지 미지원은 숨긴다
+    static let groupedUnsupported: Set<String> = ["music.generate"]
+
+    /// 서버가 준 배정 가능 목록을 화면 그룹으로 나눈다. 웹 resolveCapabilityGroups 와 같은 규칙:
+    /// 관리자 전용 그룹은 admin 이 아니면 제외, 미지원은 groupedUnsupported 만 남기고 숨김,
+    /// 어느 그룹에도 없는 항목은 "기타" 그룹으로.
+    public static func resolveGroups(assignable: [String], admin: Bool) -> (groups: [Group], hiddenUnsupported: [String]) {
+        let assignableSet = Set(assignable)
+        let visible: (String) -> Bool = { !unsupported.contains($0) || groupedUnsupported.contains($0) }
+        var placed = Set<String>()
+        var result: [Group] = []
+        for def in groups {
+            if def.adminOnly && !admin {
+                def.members.forEach { placed.insert($0) }
+                continue
+            }
+            let members = def.members.filter { assignableSet.contains($0) && visible($0) }
+            def.members.forEach { placed.insert($0) }
+            if !members.isEmpty {
+                result.append(Group(id: def.id, title: def.title, description: def.description, members: members, adminOnly: def.adminOnly))
+            }
+        }
+        let others = assignable.filter { !placed.contains($0) && visible($0) }
+        if !others.isEmpty {
+            result.append(Group(id: "other", title: "기타", description: "그룹에 속하지 않은 기능", members: others, adminOnly: false))
+        }
+        let hidden = assignable.filter { unsupported.contains($0) && !groupedUnsupported.contains($0) }
+        return (result, hidden)
+    }
+}

--- a/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/ChatStreamState.swift
+++ b/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/ChatStreamState.swift
@@ -58,6 +58,31 @@ public struct ChatActivityEntry: Identifiable, Equatable, Sendable {
     }
 }
 
+/// 멀티모달 오케스트레이터 작업 1건 (system_event orchestrator_plan/orchestrator_task 대응 — 웹 store 와 같은 형태)
+public struct OrchestratorTask: Identifiable, Equatable, Sendable {
+    public enum Status: String, Sendable { case pending, running, ok, failed }
+    public let id: String
+    public let capability: String
+    public var instruction: String?
+    public var status: Status
+    public var summary: String?
+    public var ms: Double?
+
+    public var label: String { CapabilityCatalog.label(capability) }
+}
+
+/// 오케스트레이터 진행 — 계획(planning) → 실행(executing, 작업별 상태) → 종합(synthesizing).
+/// `simple` 계획이거나 done/skipped 가 오면 nil 로 돌아간다(배너 소멸).
+public struct OrchestratorProgress: Equatable, Sendable {
+    public enum Phase: String, Sendable { case planning, executing, synthesizing }
+    public var phase: Phase
+    public var detail: String?
+    public var complexity: String?
+    public var tasks: [OrchestratorTask]
+
+    public var doneCount: Int { tasks.filter { $0.status == .ok || $0.status == .failed }.count }
+}
+
 public struct ChatStreamState: Sendable {
     public private(set) var streamingText = ""
     public private(set) var isThinking = false
@@ -78,6 +103,9 @@ public struct ChatStreamState: Sendable {
     public private(set) var artifacts: [ChatArtifact] = []
     /// 이번 응답에서 지나온 단계 이력 (최신이 마지막). 진행 카드에서 펼쳐 보여준다.
     public private(set) var activityLog: [ChatActivityEntry] = []
+    /// 멀티모달 오케스트레이터 진행 (이미지·영상·음성 등 capability 작업). 종전엔 system_event 를
+    /// 통째로 버려 이미지 34s·영상 수 분 동안 진행 표시가 0 이었다(2026-09-12).
+    public private(set) var orchestrator: OrchestratorProgress?
     /// 본문 토큰을 한 자라도 받았는지 — "응답 작성 중" 표시 판단용
     public var hasStartedAnswer: Bool { !streamingText.isEmpty }
 
@@ -89,6 +117,7 @@ public struct ChatStreamState: Sendable {
     public mutating func begin(hint: String? = nil) {
         activeSkillNames = []
         activityLog = []
+        orchestrator = nil
         setActivity(hint ?? "요청을 분석하고 있어요", kind: .preparing)
     }
 
@@ -164,6 +193,7 @@ public struct ChatStreamState: Sendable {
             isThinking = false
             statusText = nil
             activityKind = nil
+            orchestrator = nil
             if let raw = event.metrics {
                 metrics = ChatStreamMetrics(tokenCount: raw.tokenCount, tokensPerSec: raw.tokensPerSEC)
             }
@@ -188,12 +218,83 @@ public struct ChatStreamState: Sendable {
             isThinking = false
             isDone = false
             setActivity(streamingText.isEmpty ? "답변을 이어받고 있어요" : Self.writingText, kind: .finalizing)
+        case .systemEvent:
+            applySystemEvent(event.payload)
         case .resumeNone:
             resumeUnavailable = true
             isDone = true
             isThinking = false
             statusText = nil
             activityKind = nil
+        default:
+            break
+        }
+    }
+
+    /// system_event — 오케스트레이터 진행(orchestrator_status|plan|task)만 소비하고 나머지는 무시.
+    /// 알 수 없는 형태는 조용히 건너뛴다(fail-open, 웹 use-chat-socket applyOrchestratorEvent 와 같은 규칙).
+    private mutating func applySystemEvent(_ payload: Payload?) {
+        guard let payload else { return }
+        let md = SystemEventMetadata(payload.metadata)
+        switch payload.type {
+        case "orchestrator_status":
+            guard let phase = md.string("phase") else { return }
+            switch phase {
+            case "planning":
+                orchestrator = OrchestratorProgress(phase: .planning, detail: md.string("detail"), complexity: orchestrator?.complexity, tasks: orchestrator?.tasks ?? [])
+                setActivity("요청을 분석하고 있어요", kind: .preparing)
+            case "executing":
+                orchestrator = OrchestratorProgress(phase: .executing, detail: md.string("detail"), complexity: orchestrator?.complexity, tasks: orchestrator?.tasks ?? [])
+                if let running = orchestrator?.tasks.first(where: { $0.status == .running }) {
+                    setActivity(CapabilityCatalog.progressText(running.capability), kind: .tool)
+                } else {
+                    setActivity("작업을 실행하고 있어요", kind: .tool)
+                }
+            case "synthesizing":
+                orchestrator = OrchestratorProgress(phase: .synthesizing, detail: md.string("detail"), complexity: orchestrator?.complexity, tasks: orchestrator?.tasks ?? [])
+                setActivity("결과를 모아 답변을 정리하고 있어요", kind: .finalizing)
+            default:
+                // done | skipped | 기타 — 배너 숨김(상태 문구는 다음 이벤트가 갱신)
+                orchestrator = nil
+            }
+        case "orchestrator_plan":
+            let complexity = md.string("complexity")
+            if complexity == "simple" {
+                orchestrator = nil
+                return
+            }
+            let tasks: [OrchestratorTask] = md.objects("tasks").compactMap { t in
+                guard let id = t.string("id"), let capability = t.string("capability") else { return nil }
+                return OrchestratorTask(id: id, capability: capability, instruction: t.string("instruction"), status: .pending, summary: nil, ms: nil)
+            }
+            orchestrator = OrchestratorProgress(phase: orchestrator?.phase ?? .executing, detail: orchestrator?.detail, complexity: complexity, tasks: tasks)
+            if tasks.count == 1, let only = tasks.first {
+                setActivity(CapabilityCatalog.progressText(only.capability), kind: .tool)
+            } else if !tasks.isEmpty {
+                setActivity("\(tasks.count)개 작업을 실행하고 있어요", kind: .tool)
+            }
+        case "orchestrator_task":
+            guard let id = md.string("id"), let capability = md.string("capability"),
+                  let raw = md.string("status"), let status = OrchestratorTask.Status(rawValue: raw) else { return }
+            var progress = orchestrator ?? OrchestratorProgress(phase: .executing, detail: nil, complexity: nil, tasks: [])
+            if let index = progress.tasks.firstIndex(where: { $0.id == id }) {
+                progress.tasks[index].status = status
+                progress.tasks[index].summary = md.string("summary") ?? progress.tasks[index].summary
+                progress.tasks[index].ms = md.double("ms") ?? progress.tasks[index].ms
+            } else {
+                progress.tasks.append(OrchestratorTask(id: id, capability: capability, instruction: nil, status: status, summary: md.string("summary"), ms: md.double("ms")))
+            }
+            orchestrator = progress
+            switch status {
+            case .running:
+                setActivity(CapabilityCatalog.progressText(capability), kind: .tool)
+            case .ok:
+                setActivity("\(CapabilityCatalog.label(capability)) 완료", kind: .finalizing)
+            case .failed:
+                setActivity("\(CapabilityCatalog.label(capability)) 실패", kind: .finalizing)
+            case .pending:
+                break
+            }
         default:
             break
         }
@@ -236,6 +337,43 @@ public struct ChatStreamState: Sendable {
             let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty, seen.insert(trimmed).inserted else { return nil }
             return trimmed
+        }
+    }
+}
+
+
+/// system_event.payload.metadata 의 관대한 접근자 — 생성 모델의 JSONAny(value: Any) 위에서
+/// 문자열/숫자/객체 배열만 꺼낸다. 형식이 다르면 nil(무시).
+struct SystemEventMetadata {
+    private let raw: [String: Any]
+
+    init(_ metadata: [String: JSONAny]?) {
+        raw = (metadata ?? [:]).mapValues { $0.value }
+    }
+
+    init(any: [String: Any]) {
+        raw = any
+    }
+
+    func string(_ key: String) -> String? {
+        raw[key] as? String
+    }
+
+    func double(_ key: String) -> Double? {
+        switch raw[key] {
+        case let value as Double: return value
+        case let value as Int64: return Double(value)
+        case let value as Int: return Double(value)
+        default: return nil
+        }
+    }
+
+    func objects(_ key: String) -> [SystemEventMetadata] {
+        guard let array = raw[key] as? [Any] else { return [] }
+        return array.compactMap { item in
+            if let dict = item as? [String: Any] { return SystemEventMetadata(any: dict) }
+            if let dict = item as? [String: JSONAny] { return SystemEventMetadata(dict) }
+            return nil
         }
     }
 }

--- a/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/MarkdownContentParser.swift
+++ b/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/MarkdownContentParser.swift
@@ -3,6 +3,10 @@ import Foundation
 public enum MarkdownContentSegment: Equatable, Sendable {
     case text(String)
     case image(alt: String, source: String)
+    /// 생성 영상 링크 — `[🎬 영상 보기](/generated/x.webm)` (오케스트레이터 결정적 첨부)
+    case video(title: String, source: String)
+    /// 생성 음성 링크 — `[🔊 음성 듣기](/generated/x.wav)`
+    case audio(title: String, source: String)
 }
 
 public enum MarkdownContentParser {
@@ -10,6 +14,10 @@ public enum MarkdownContentParser {
     /// (llm/artifact-parser.ts 와 동일 grammar). 아티팩트는 별도 카드로 보여주므로
     /// 본문에서는 걷어낸다 — 남겨두면 raw 텍스트가 그대로 노출된다 (2026-08-18 실측).
     static let artifactPlaceholder = #"\[\[artifact:[^\]]+\]\]"#
+
+    /// 미디어로 취급하는 링크 확장자 — 서버 generated-media 가 저장하는 형식(webm·mp4·wav·mp3 …)
+    public static let videoExtensions: Set<String> = ["webm", "mp4", "mov", "m4v"]
+    public static let audioExtensions: Set<String> = ["mp3", "wav", "m4a", "ogg", "opus", "flac", "aac"]
 
     /// 아티팩트 placeholder 제거 + 그로 인해 남는 빈 줄 정리
     public static func strippingArtifactPlaceholders(_ content: String) -> String {
@@ -30,8 +38,11 @@ public enum MarkdownContentParser {
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// 본문을 텍스트/이미지/영상/음성 세그먼트로 나눈다.
+    /// 이미지는 `![alt](src)`, 영상·음성은 확장자가 미디어인 일반 링크 `[title](src)` 만 —
+    /// 그 밖의 링크는 텍스트에 그대로 남겨 인라인 마크다운이 처리한다.
     public static func segments(in content: String) -> [MarkdownContentSegment] {
-        let pattern = #"!\[([^\]]*)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)"#
+        let pattern = #"(!?)\[([^\]]*)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)"#
         guard let expression = try? NSRegularExpression(pattern: pattern) else {
             return [.text(content)]
         }
@@ -41,27 +52,64 @@ public enum MarkdownContentParser {
         guard !matches.isEmpty else { return [.text(content)] }
 
         var result: [MarkdownContentSegment] = []
+        var pendingText = ""
         var cursor = content.startIndex
+
+        func flushText() {
+            if !pendingText.isEmpty {
+                result.append(.text(pendingText))
+                pendingText = ""
+            }
+        }
+
         for match in matches {
             guard let whole = Range(match.range(at: 0), in: content),
-                  let alt = Range(match.range(at: 1), in: content),
-                  let source = Range(match.range(at: 2), in: content) else { continue }
+                  let bang = Range(match.range(at: 1), in: content),
+                  let label = Range(match.range(at: 2), in: content),
+                  let source = Range(match.range(at: 3), in: content) else { continue }
             if cursor < whole.lowerBound {
-                result.append(.text(String(content[cursor..<whole.lowerBound])))
+                pendingText += content[cursor..<whole.lowerBound]
             }
-            result.append(.image(
-                alt: String(content[alt]),
-                source: String(content[source])))
+            let src = String(content[source])
+            let title = String(content[label])
+            if !content[bang].isEmpty {
+                flushText()
+                result.append(.image(alt: title, source: src))
+            } else if let kind = mediaKind(of: src) {
+                flushText()
+                switch kind {
+                case .video: result.append(.video(title: title, source: src))
+                case .audio: result.append(.audio(title: title, source: src))
+                }
+            } else {
+                // 일반 링크 — 텍스트로 유지
+                pendingText += content[whole]
+            }
             cursor = whole.upperBound
         }
         if cursor < content.endIndex {
-            result.append(.text(String(content[cursor...])))
+            pendingText += content[cursor...]
         }
+        flushText()
         return result.isEmpty ? [.text(content)] : result
+    }
+
+    enum MediaKind { case video, audio }
+
+    static func mediaKind(of source: String) -> MediaKind? {
+        // 쿼리·프래그먼트 제거 후 확장자 판정
+        let path = source.split(separator: "?", maxSplits: 1).first.map(String.init) ?? source
+        let ext = (path as NSString).pathExtension.lowercased()
+        guard !ext.isEmpty else { return nil }
+        if videoExtensions.contains(ext) { return .video }
+        if audioExtensions.contains(ext) { return .audio }
+        return nil
     }
 }
 
-public enum GeneratedImageURLResolver {
+/// `/generated/*` 미디어 경로를 서버 절대 URL 로 — 같은 origin 의 /generated/ 만 허용
+/// (본문에 섞인 외부 URL 을 서버 자격증명 컨텍스트로 열지 않는다).
+public enum GeneratedMediaURLResolver {
     public static func resolve(source: String, serverURL: URL) -> URL? {
         guard let resolved = URL(string: source, relativeTo: serverURL)?.absoluteURL,
               resolved.scheme?.lowercased() == serverURL.scheme?.lowercased(),
@@ -69,5 +117,12 @@ public enum GeneratedImageURLResolver {
               resolved.port == serverURL.port,
               resolved.path.hasPrefix("/generated/") else { return nil }
         return resolved
+    }
+}
+
+/// 이전 이름 호환 — 이미지 전용으로 쓰이던 해석기
+public enum GeneratedImageURLResolver {
+    public static func resolve(source: String, serverURL: URL) -> URL? {
+        GeneratedMediaURLResolver.resolve(source: source, serverURL: serverURL)
     }
 }

--- a/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/OpenMakeClient+Capabilities.swift
+++ b/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/OpenMakeClient+Capabilities.swift
@@ -1,0 +1,71 @@
+// OpenMakeKit — 기능별 모델 배정(capability → 모델) API. 웹 settings/capability-models-section 대응.
+//   GET    /api/users/me/capability-models              → { overrides, effective, assignableCapabilities }
+//   PUT    /api/users/me/capability-models/:capability  body { model, params? }
+//   DELETE /api/users/me/capability-models/:capability
+import Foundation
+
+public struct CapabilityOverride: Decodable, Sendable, Equatable {
+    public let capability: String
+    public let fullId: String
+    public let params: [String: String]?
+}
+
+public struct CapabilityEffective: Decodable, Sendable, Equatable {
+    public let capability: String
+    public let fullId: String?
+    /// user | global | default
+    public let source: String?
+    public let error: String?
+    public let code: String?
+}
+
+public struct CapabilityModels: Sendable, Equatable {
+    public let overrides: [CapabilityOverride]
+    public let effective: [CapabilityEffective]
+    public let assignable: [String]
+
+    public init(overrides: [CapabilityOverride], effective: [CapabilityEffective], assignable: [String]) {
+        self.overrides = overrides
+        self.effective = effective
+        self.assignable = assignable
+    }
+
+    public func override(for capability: String) -> CapabilityOverride? {
+        overrides.first { $0.capability == capability }
+    }
+
+    public func effective(for capability: String) -> CapabilityEffective? {
+        effective.first { $0.capability == capability }
+    }
+}
+
+public extension OpenMakeClient {
+    func capabilityModels() async throws -> CapabilityModels {
+        struct Payload: Decodable {
+            let overrides: [CapabilityOverride]
+            let effective: [CapabilityEffective]
+            let assignableCapabilities: [String]
+        }
+        struct Envelope: Decodable { let data: Payload }
+        let (data, _) = try await authorizedSend(method: "GET", path: "/api/users/me/capability-models")
+        let payload = try decodeContract(Envelope.self, from: data).data
+        return CapabilityModels(
+            overrides: payload.overrides,
+            effective: payload.effective,
+            assignable: payload.assignableCapabilities)
+    }
+
+    /// 배정 — fullId 는 `<provider>:<model>` (카탈로그 modelId 그대로)
+    func assignCapabilityModel(_ capability: String, fullId: String) async throws {
+        struct Request: Encodable { let model: String }
+        _ = try await authorizedSend(
+            method: "PUT",
+            path: "/api/users/me/capability-models/\(capability)",
+            body: Request(model: fullId))
+    }
+
+    /// 배정 해제 — 전역/기본값으로 복귀
+    func clearCapabilityModel(_ capability: String) async throws {
+        _ = try await authorizedSend(method: "DELETE", path: "/api/users/me/capability-models/\(capability)")
+    }
+}

--- a/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/OpenMakeClient+Subagents.swift
+++ b/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/OpenMakeClient+Subagents.swift
@@ -1,0 +1,53 @@
+// OpenMakeKit — 에이전트 작업의 병렬 서브에이전트 진행 상태 (#813 웹 subagent-panel 대응).
+//   GET /api/agent-tasks/:id/subagents → { traces: [...] }
+import Foundation
+
+public struct SubagentStep: Decodable, Sendable, Equatable {
+    public let seq: Int
+    public let type: String
+    public let tool: String?
+    public let content: String?
+    public let at: String
+}
+
+public struct SubagentTrace: Decodable, Identifiable, Sendable, Equatable {
+    public var id: String { traceId }
+    public let traceId: String
+    public let origin: String
+    public let subIndex: Int
+    public let label: String?
+    /// queued | running | completed | failed | interrupted
+    public let status: String
+    public let startedAt: String
+    public let finishedAt: String?
+    public let steps: [SubagentStep]
+
+    /// 웹과 같은 이름 규칙 — 라벨이 없으면 출처로 "병렬 서브 #n" / "전문가 위임"
+    public var displayName: String {
+        if let label, !label.isEmpty { return label }
+        return origin == "spawn_agents" ? "병렬 서브 #\(subIndex + 1)" : "전문가 위임"
+    }
+
+    public var statusLabel: String {
+        switch status {
+        case "queued": "대기 중"
+        case "running": "실행 중"
+        case "completed": "완료"
+        case "failed": "실패"
+        case "interrupted": "중단됨"
+        default: status
+        }
+    }
+
+    public var isActive: Bool { status == "queued" || status == "running" }
+}
+
+public extension OpenMakeClient {
+    /// 서브에이전트가 없는 작업은 빈 배열 — 화면은 패널을 숨긴다(웹과 동일).
+    func agentTaskSubagents(id: String) async throws -> [SubagentTrace] {
+        struct Payload: Decodable { let traces: [SubagentTrace] }
+        struct Envelope: Decodable { let data: Payload }
+        let (data, _) = try await authorizedSend(method: "GET", path: "/api/agent-tasks/\(id)/subagents")
+        return try decodeContract(Envelope.self, from: data).data.traces
+    }
+}

--- a/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/WsChatSocket.swift
+++ b/apps/ios/Packages/OpenMakeKit/Sources/OpenMakeKit/WsChatSocket.swift
@@ -153,7 +153,9 @@ public extension WsChatRequest {
         saveHistory: Bool? = nil,
         memoryLearning: Bool? = nil,
         userAgentId: String? = nil,
-        userLocation: UserLocation? = nil
+        userLocation: UserLocation? = nil,
+        /// 모델 비교 모드 — 레인 식별(웹 use-compare-lane 과 동일 필드). 일반 채팅은 nil.
+        lane: String? = nil
     ) -> WsChatRequest {
         WsChatRequest(
             anonSessionID: nil,
@@ -167,7 +169,7 @@ public extension WsChatRequest {
             history: history.isEmpty ? nil : history,
             imageMode: imageMode,
             images: images,
-            lane: nil,
+            lane: lane,
             memoryLearning: memoryLearning,
             message: message,
             model: model,

--- a/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/CapabilityCatalogTests.swift
+++ b/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/CapabilityCatalogTests.swift
@@ -1,0 +1,43 @@
+// capability 그룹 해석 + 서브에이전트 응답 디코딩 테스트
+import XCTest
+@testable import OpenMakeKit
+
+final class CapabilityCatalogTests: XCTestCase {
+    private let assignable = [
+        "text.reason", "text.code", "text.embed", "vision.describe", "vision.ocr",
+        "image.generate", "image.edit", "audio.transcribe", "audio.speech", "audio.analyze",
+        "music.analyze", "music.generate", "video.generate", "video.analyze",
+    ]
+
+    func testGroupsForUserHideAdminAndUnsupported() {
+        let r = CapabilityCatalog.resolveGroups(assignable: assignable, admin: false)
+        XCTAssertEqual(r.groups.map(\.id), ["text", "code", "image", "audio", "music", "video"])
+        XCTAssertEqual(r.hiddenUnsupported, ["audio.analyze", "music.analyze", "video.analyze"])
+        XCTAssertTrue(r.groups.first { $0.id == "music" }!.isUnsupported)
+        XCTAssertFalse(r.groups.first { $0.id == "image" }!.isUnsupported)
+    }
+
+    func testAdminSeesEmbedGroup() {
+        let r = CapabilityCatalog.resolveGroups(assignable: assignable, admin: true)
+        XCTAssertTrue(r.groups.contains { $0.id == "embed" && $0.members == ["text.embed"] })
+    }
+
+    func testUnknownCapabilityFallsToOther() {
+        let r = CapabilityCatalog.resolveGroups(assignable: ["text.reason", "future.thing"], admin: false)
+        XCTAssertEqual(r.groups.last?.id, "other")
+        XCTAssertEqual(r.groups.last?.members, ["future.thing"])
+        XCTAssertEqual(CapabilityCatalog.label("future.thing"), "future.thing")
+    }
+
+    func testSubagentTraceDecodesAndNames() throws {
+        let json = #"{"traces":[{"traceId":"tr1","origin":"spawn_agents","subIndex":1,"label":null,"status":"running","startedAt":"2026-09-12T00:00:00Z","finishedAt":null,"steps":[{"seq":1,"type":"tool_call","tool":"web_search","content":null,"at":"2026-09-12T00:00:01Z"}]},{"traceId":"tr2","origin":"delegate","subIndex":0,"label":"법률 검토","status":"completed","startedAt":"2026-09-12T00:00:00Z","finishedAt":"2026-09-12T00:01:00Z","steps":[]}]}"#
+        struct Payload: Decodable { let traces: [SubagentTrace] }
+        let payload = try JSONDecoder().decode(Payload.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(payload.traces.count, 2)
+        XCTAssertEqual(payload.traces[0].displayName, "병렬 서브 #2")
+        XCTAssertTrue(payload.traces[0].isActive)
+        XCTAssertEqual(payload.traces[0].statusLabel, "실행 중")
+        XCTAssertEqual(payload.traces[1].displayName, "법률 검토")
+        XCTAssertFalse(payload.traces[1].isActive)
+    }
+}

--- a/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/MarkdownMediaTests.swift
+++ b/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/MarkdownMediaTests.swift
@@ -1,0 +1,41 @@
+// 생성 영상·음성 링크 세그먼트 테스트 — 종전 파서는 이미지만 알아 영상/음성 링크가 raw 로 노출됐다.
+import XCTest
+@testable import OpenMakeKit
+
+final class MarkdownMediaTests: XCTestCase {
+    func testVideoAndAudioLinksBecomeSegments() {
+        let segments = MarkdownContentParser.segments(
+            in: "영상을 완성했습니다.\n\n[🎬 영상 보기](/generated/video-1.webm)\n\n음성도 있어요 [🔊 듣기](/generated/tts-1.wav) 끝.")
+        XCTAssertEqual(segments, [
+            .text("영상을 완성했습니다.\n\n"),
+            .video(title: "🎬 영상 보기", source: "/generated/video-1.webm"),
+            .text("\n\n음성도 있어요 "),
+            .audio(title: "🔊 듣기", source: "/generated/tts-1.wav"),
+            .text(" 끝."),
+        ])
+    }
+
+    func testOrdinaryLinksStayInline() {
+        let segments = MarkdownContentParser.segments(in: "문서는 [여기](https://example.com/doc) 참고, 이미지 ![a](/generated/a.png)")
+        XCTAssertEqual(segments, [
+            .text("문서는 [여기](https://example.com/doc) 참고, 이미지 "),
+            .image(alt: "a", source: "/generated/a.png"),
+        ])
+    }
+
+    func testMediaKindIgnoresQueryAndCase() {
+        XCTAssertEqual(MarkdownContentParser.mediaKind(of: "/generated/x.MP4?v=1"), .video)
+        XCTAssertEqual(MarkdownContentParser.mediaKind(of: "/generated/x.mp3"), .audio)
+        XCTAssertNil(MarkdownContentParser.mediaKind(of: "/generated/x.pdf"))
+        XCTAssertNil(MarkdownContentParser.mediaKind(of: "https://example.com/"))
+    }
+
+    func testResolverAcceptsOnlySameOriginGenerated() {
+        let server = URL(string: "https://chat.openmake.cc")!
+        XCTAssertEqual(
+            GeneratedMediaURLResolver.resolve(source: "/generated/v.webm", serverURL: server)?.absoluteString,
+            "https://chat.openmake.cc/generated/v.webm")
+        XCTAssertNil(GeneratedMediaURLResolver.resolve(source: "https://evil.example/generated/v.webm", serverURL: server))
+        XCTAssertNil(GeneratedMediaURLResolver.resolve(source: "/uploads/v.webm", serverURL: server))
+    }
+}

--- a/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/OrchestratorProgressTests.swift
+++ b/apps/ios/Packages/OpenMakeKit/Tests/OpenMakeKitTests/OrchestratorProgressTests.swift
@@ -1,0 +1,71 @@
+// 멀티모달 오케스트레이터 진행(system_event orchestrator_*) 리듀서 테스트.
+// 종전엔 system_event 가 default 로 버려져 이미지·영상 턴에 진행 표시가 0 이었다.
+import XCTest
+@testable import OpenMakeKit
+
+final class OrchestratorProgressTests: XCTestCase {
+    private func event(_ json: String) -> WsServerEvent {
+        try! JSONDecoder().decode(WsServerEvent.self, from: json.data(using: .utf8)!)
+    }
+
+    private func systemEvent(_ type: String, _ metadata: String) -> WsServerEvent {
+        event(#"{"type":"system_event","payload":{"type":"\#(type)","message":"","metadata":\#(metadata)}}"#)
+    }
+
+    func testPlanningThenMultiPlanBuildsTaskList() {
+        var state = ChatStreamState()
+        state.begin()
+        state.apply(systemEvent("orchestrator_status", #"{"phase":"planning"}"#))
+        XCTAssertEqual(state.orchestrator?.phase, .planning)
+        state.apply(systemEvent("orchestrator_plan", #"{"complexity":"multi","tasks":[{"id":"t1","capability":"image.generate","instruction":"A lighthouse"}]}"#))
+        XCTAssertEqual(state.orchestrator?.complexity, "multi")
+        XCTAssertEqual(state.orchestrator?.tasks.count, 1)
+        XCTAssertEqual(state.orchestrator?.tasks.first?.status, .pending)
+        XCTAssertEqual(state.orchestrator?.tasks.first?.label, "이미지 생성")
+        XCTAssertEqual(state.statusText, "이미지를 생성하고 있어요")
+    }
+
+    func testTaskRunningThenOkUpdatesSameId() {
+        var state = ChatStreamState()
+        state.begin()
+        state.apply(systemEvent("orchestrator_plan", #"{"complexity":"multi","tasks":[{"id":"t1","capability":"video.generate"}]}"#))
+        state.apply(systemEvent("orchestrator_status", #"{"phase":"executing"}"#))
+        state.apply(systemEvent("orchestrator_task", #"{"id":"t1","capability":"video.generate","status":"running"}"#))
+        XCTAssertEqual(state.orchestrator?.tasks.first?.status, .running)
+        XCTAssertTrue(state.statusText?.contains("영상") == true)
+        state.apply(systemEvent("orchestrator_task", #"{"id":"t1","capability":"video.generate","status":"ok","summary":"영상 생성 완료","ms":18073}"#))
+        XCTAssertEqual(state.orchestrator?.tasks.count, 1, "같은 id 는 갱신, 추가 아님")
+        XCTAssertEqual(state.orchestrator?.tasks.first?.status, .ok)
+        XCTAssertEqual(state.orchestrator?.tasks.first?.ms, 18073)
+        XCTAssertEqual(state.orchestrator?.doneCount, 1)
+        state.apply(systemEvent("orchestrator_status", #"{"phase":"synthesizing","detail":"1/1"}"#))
+        XCTAssertEqual(state.orchestrator?.phase, .synthesizing)
+        XCTAssertEqual(state.orchestrator?.detail, "1/1")
+    }
+
+    func testSimplePlanAndDoneClearBanner() {
+        var state = ChatStreamState()
+        state.begin()
+        state.apply(systemEvent("orchestrator_status", #"{"phase":"planning"}"#))
+        state.apply(systemEvent("orchestrator_plan", #"{"complexity":"simple","tasks":[]}"#))
+        XCTAssertNil(state.orchestrator, "simple 은 종전 경로 — 배너 없음")
+        state.apply(systemEvent("orchestrator_status", #"{"phase":"planning"}"#))
+        state.apply(systemEvent("orchestrator_status", #"{"phase":"done","detail":"simple"}"#))
+        XCTAssertNil(state.orchestrator)
+        state.apply(systemEvent("orchestrator_status", #"{"phase":"executing"}"#))
+        state.apply(event(#"{"type":"done","messageId":"m1"}"#))
+        XCTAssertNil(state.orchestrator, "done 이면 배너 정리")
+    }
+
+    func testUnknownSystemEventIsIgnored() {
+        var state = ChatStreamState()
+        state.begin()
+        let before = state.statusText
+        state.apply(systemEvent("model_fallback", #"{"to":"local-llm:qwen"}"#))
+        XCTAssertNil(state.orchestrator)
+        XCTAssertEqual(state.statusText, before)
+        // metadata 형식이 깨져도 crash 없음
+        state.apply(systemEvent("orchestrator_task", #"{"id":42,"status":"running"}"#))
+        XCTAssertNil(state.orchestrator)
+    }
+}


### PR DESCRIPTION
9/9 이후 web 에 들어간 기능 중 iOS 에 빠진 5건을 반영합니다. **계약(shared-types·api-contracts) 변경 없음** → 코드젠 drift 0.

| # | 격차 | 반영 |
|---|---|---|
| 1 | 멀티모달 오케스트레이터 진행 배너(#837) — Kit 이 `system_event` 를 통째로 버려 이미지·영상 턴에 진행 표시 0 | `ChatStreamState.orchestrator` + `OrchestratorProgressCard`(단계·작업별 상태·소요) |
| 2 | 미디어 결과 렌더 — 영상 `[🎬 영상 보기](/generated/x.webm)`·TTS wav 링크가 raw 노출 | 파서 video/audio 세그먼트 + `GeneratedVideoCard`(mp4/mov VideoPlayer, WebM 은 Safari 열기·공유)·`GeneratedAudioCard` |
| 3 | 병렬 에이전트 실시간 상태(#813) | `agentTaskSubagents` API + `SubagentPanel`(작업 상세) |
| 4 | 모델 비교 모드(#807·#810) | `CompareView` — 레인마다 독립 소켓·세션(`lane`), 모델 2개·추론 토글 |
| 5 | 기능별 모델 배정(#832·#851) | `CapabilityModelsView` — 6그룹 + 세부 설정 + 실효 해석, 설정 진입 |

- Kit 테스트 +12 (84/84), 시뮬레이터 빌드 성공, 실기기(iPhone 17) 설치 완료
- 라벨·그룹은 서버 `config/capabilities.ts`·웹 `capability-groups.tsx` 의 결정적 사본 — 서버는 capability 이름만 내려준다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013st6eP2mLYDaHH4jEjP7Nf