### PR TITLE
fix(web): 워크스페이스 페이지 3곳에 스크롤 컨테이너 누락 — 내용이 잘려 접근 불가

### DIFF
--- a/apps/web/app/(workspace)/admin/model-roles/page.tsx
+++ b/apps/web/app/(workspace)/admin/model-roles/page.tsx
@@ -290,10 +290,15 @@ export default function AdminModelRolesPage() {
   const mappedRoles = new Set((roles?.mappings ?? []).map((m) => m.role));
 
   return (
-    <div className="space-y-6">
+    // 워크스페이스 레이아웃의 <main> 은 h-dvh + overflow-hidden 이라(채팅이 자체 스크롤 영역을
+    // 갖는 전제) 페이지가 스크롤 컨테이너를 직접 만들어야 한다 — 없으면 본문이 뷰포트 밖에서
+    // 통째로 잘린다(2026-09-13 신고: 1280×900 에서 1,314px 접근 불가). 헤더·탭은 고정.
+    <>
       <PageHeader title={t("title")} description={t("description")} />
 
       <AdminTabs />
+
+      <div className="min-h-0 flex-1 space-y-6 overflow-y-auto p-6">
       {error && <p className="text-sm text-danger" role="alert">{error}</p>}
 
       <Card>
@@ -374,6 +379,7 @@ export default function AdminModelRolesPage() {
       </Card>
 
       <GlobalCapabilityModelsCard />
-    </div>
+      </div>
+    </>
   );
 }

--- a/apps/web/app/(workspace)/admin/schedules/page.tsx
+++ b/apps/web/app/(workspace)/admin/schedules/page.tsx
@@ -82,10 +82,13 @@ export default function AdminSchedulesPage() {
   const schedules = payload?.schedules ?? [];
 
   return (
-    <div className="space-y-6">
+    // <main> 이 overflow-hidden 이라 스크롤 컨테이너는 페이지가 만든다(헤더·탭은 고정).
+    <>
       <PageHeader title={t("title")} description={t("description")} />
 
       <AdminTabs />
+
+      <div className="min-h-0 flex-1 space-y-6 overflow-y-auto p-6">
       {error && <p className="text-sm text-danger" role="alert">{error}</p>}
 
       <Card>
@@ -153,6 +156,7 @@ export default function AdminSchedulesPage() {
           )}
         </CardContent>
       </Card>
-    </div>
+      </div>
+    </>
   );
 }

--- a/apps/web/app/(workspace)/api-access/page.tsx
+++ b/apps/web/app/(workspace)/api-access/page.tsx
@@ -163,11 +163,13 @@ export default function ApiAccessPage() {
   };
 
   return (
-    <div>
+    // 루트를 fragment 로 둬야 헤더·탭·본문이 <main>(flex flex-col) 의 직접 자식이 되어
+    // 본문의 flex-1 이 먹는다 — <div> 로 감싸면 스크롤 영역이 생기지 않아 내용이 잘린다.
+    <>
       <PageHeader title={t("title")} description={t("subtitle")} />
       <DeveloperTabs />
 
-      <div className="mx-auto max-w-4xl space-y-5 px-6 py-6">
+      <div className="mx-auto min-h-0 w-full max-w-4xl flex-1 space-y-5 overflow-y-auto px-6 py-6">
         {error && (
           <div className="flex items-center gap-2 rounded-md bg-danger-soft px-3 py-2 text-sm text-danger">
             <AlertTriangle className="h-4 w-4 shrink-0" />
@@ -345,6 +347,6 @@ export default function ApiAccessPage() {
           </CardContent>
         </Card>
       </div>
-    </div>
+    </>
   );
 }

--- a/apps/web/app/(workspace)/layout.tsx
+++ b/apps/web/app/(workspace)/layout.tsx
@@ -12,6 +12,19 @@ export default function WorkspaceLayout({
         <Sidebar />
       </div>
       <MobileSidebar />
+      {/*
+        ⚠️ 레이아웃 계약 — 이 <main> 은 h-dvh + overflow-hidden 이다(채팅이 컴포저를 고정하고
+        메시지 목록만 스크롤하는 전제). 따라서 **각 페이지가 스크롤 컨테이너를 직접 만들어야 한다**:
+
+            <PageHeader … />            ← 고정
+            <AdminTabs />               ← 고정(있으면)
+            <div className="min-h-0 flex-1 overflow-y-auto p-6">…본문…</div>
+
+        빠뜨리면 내용이 뷰포트 밖에서 통째로 잘리고 스크롤도 안 된다 — 화면엔 렌더되므로
+        조용한 결함이다(2026-09-13 신고: /admin/model-roles 가 1,280×900 에서 1,314px 접근 불가.
+        같은 부류로 /admin/schedules·/api-access 도 작은 창에서 잘렸다).
+        페이지 루트를 <div> 로 감싸면 flex-1 이 <main> 에 닿지 않으므로 fragment(<>)를 쓴다.
+      */}
       <main className="flex min-w-0 flex-1 flex-col overflow-hidden pb-[calc(3.25rem+env(safe-area-inset-bottom))] lg:pb-0">
         {children}
       </main>


### PR DESCRIPTION
## 신고

> https://chat.openmake.cc/admin/model-roles 세로 스크롤이 없어서 전체내용을 확인하지 못하고 있어

## 원인

워크스페이스 레이아웃의 `<main>` 은 `h-dvh + overflow-hidden` 이다 — 채팅이 컴포저를 고정하고 메시지 목록만 스크롤하는 전제다. 따라서 **각 페이지가 스크롤 컨테이너를 직접 만들어야 하는데**, 이 페이지들은 전체를 `<div className="space-y-6">` 로 감싸기만 해 내용이 뷰포트 밖에서 통째로 잘렸다. 화면엔 렌더되고 에러도 없어 **조용한 결함**이다.

## 실측 (배포본, 1280×900)

| 경로 | 잘린 높이 | 스크롤 가능 요소 |
|---|---|---|
| `/admin/model-roles` | **1,314px** | 0 |
| `/admin/schedules` | 작은 창에서 40px | 0 |
| `/api-access` | 작은 창에서 169px | 0 |

`/admin/schedules`·`/api-access` 는 현재 내용이 짧아 큰 화면에선 안 드러나지만, 스케줄이 늘거나 창이 작으면 같은 증상이 난다(뷰포트 480px 로 줄여 재현).

## 수정

관용구를 그대로 적용했다:

```tsx
<>
  <PageHeader … />                                        {/* 고정 */}
  <AdminTabs />                                           {/* 고정 */}
  <div className="min-h-0 flex-1 overflow-y-auto p-6">    {/* 스크롤 */}
    …본문…
  </div>
</>
```

페이지 루트를 `<div>` 로 감싸면 `flex-1` 이 `<main>`(flex flex-col)에 닿지 않으므로 fragment 로 바꿨다.

## 전수 확인

워크스페이스 28개 페이지를 **실제 렌더로** 측정해 이 3곳만 결함임을 확인했다. `/compare` 는 레인별 독립 컬럼 레이아웃이라 페이지 전체 스크롤이 없는 것이 설계이고, 나머지(`/api-keys`·`/mcp-servers`·`/mcp-monitoring`·`/memory` 등)는 하위 컴포넌트가 스크롤 영역을 만든다.

## 재발 방지

`layout.tsx` 에 레이아웃 계약을 주석으로 명시했다.

정적 grep 가드(`scripts/check-workspace-scroll.sh`)도 만들어 봤으나 **하위 컴포넌트에서 스크롤을 만드는 정상 페이지 4곳을 위반으로 잡아(오탐 50%) 폐기**했다 — 실제 렌더를 봐야 판정할 수 있는 종류이고, 오탐이 절반인 가드는 예외 목록만 키우고 신뢰를 잃는다. e2e 는 CI 에서 돌지 않아 게이트가 되지 못한다.

## 검증

- `tsc --noEmit`(apps/web) 통과, ESLint 오류 0
- 배포 후 라이브로 스크롤 동작 재확인 예정